### PR TITLE
🧹 no more duplicating resource pack info json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,29 +61,18 @@ lr/build:
 	go generate .
 	go build -o lr resources/lr/cli/main.go
 	./lr go resources/packs/core/core.lr
-	go generate ./resources/packs/core/info
 	./lr docs go resources/packs/core/core.lr.manifest.yaml
 	go fmt resources/packs/core/core.lr.manifest.go
 	./lr go resources/packs/os/os.lr
-	go generate ./resources/packs/os/info
 	./lr go resources/packs/aws/aws.lr
-	go generate ./resources/packs/aws/info
 	./lr go resources/packs/azure/azure.lr
-	go generate ./resources/packs/azure/info
 	./lr go resources/packs/gcp/gcp.lr
-	go generate ./resources/packs/gcp/info
 	./lr go resources/packs/ms365/ms365.lr
-	go generate ./resources/packs/ms365/info
 	./lr go resources/packs/github/github.lr
-	go generate ./resources/packs/github/info
 	./lr go resources/packs/gitlab/gitlab.lr
-	go generate ./resources/packs/gitlab/info
 	./lr go resources/packs/terraform/terraform.lr
-	go generate ./resources/packs/terraform/info
 	./lr go resources/packs/k8s/k8s.lr
-	go generate ./resources/packs/k8s/info
 	./lr go resources/packs/vsphere/vsphere.lr
-	go generate ./resources/packs/vsphere/info
 	./lr go resources/mock/mochi.lr
 
 lr/release:

--- a/resources/lr/cli/cmd/go.go
+++ b/resources/lr/cli/cmd/go.go
@@ -19,7 +19,8 @@ var goCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		file := args[0]
-		packageName := path.Base(path.Dir(file))
+		folder := path.Dir(file)
+		packageName := path.Base(folder)
 
 		res, err := lr.Resolve(file, func(path string) ([]byte, error) {
 			return os.ReadFile(path)
@@ -50,7 +51,13 @@ var goCmd = &cobra.Command{
 			log.Error().Err(err).Msg("failed to generate schema json")
 		}
 
-		err = os.WriteFile(args[0]+".json", []byte(schemaData), 0o644)
+		infoFolder := path.Join(folder, "info")
+		if err = os.MkdirAll(infoFolder, 0o755); err != nil {
+			log.Fatal().Err(err).Str("folder", infoFolder).Msg("failed to ensure info folder")
+		}
+
+		infoFile := path.Join(infoFolder, args[0]+".json")
+		err = os.WriteFile(infoFile, []byte(schemaData), 0o644)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to write schema json")
 		}

--- a/resources/packs/aws/info/info.go
+++ b/resources/packs/aws/info/info.go
@@ -10,7 +10,6 @@ import (
 
 // fyi this is a workaround for paths: https://github.com/golang/go/issues/46056
 //
-//go:generate cp ../aws.lr.json ./aws.lr.json
 //go:embed aws.lr.json
 var info []byte
 

--- a/resources/packs/azure/info/info.go
+++ b/resources/packs/azure/info/info.go
@@ -10,7 +10,6 @@ import (
 
 // fyi this is a workaround for paths: https://github.com/golang/go/issues/46056
 //
-//go:generate cp ../azure.lr.json ./azure.lr.json
 //go:embed azure.lr.json
 var info []byte
 

--- a/resources/packs/core/info/info.go
+++ b/resources/packs/core/info/info.go
@@ -10,7 +10,6 @@ import (
 
 // fyi this is a workaround for paths: https://github.com/golang/go/issues/46056
 //
-//go:generate cp ../core.lr.json ./core.lr.json
 //go:embed core.lr.json
 var info []byte
 

--- a/resources/packs/gcp/info/info.go
+++ b/resources/packs/gcp/info/info.go
@@ -10,7 +10,6 @@ import (
 
 // fyi this is a workaround for paths: https://github.com/golang/go/issues/46056
 //
-//go:generate cp ../gcp.lr.json ./gcp.lr.json
 //go:embed gcp.lr.json
 var info []byte
 

--- a/resources/packs/github/info/info.go
+++ b/resources/packs/github/info/info.go
@@ -10,7 +10,6 @@ import (
 
 // fyi this is a workaround for paths: https://github.com/golang/go/issues/46056
 //
-//go:generate cp ../github.lr.json ./github.lr.json
 //go:embed github.lr.json
 var info []byte
 

--- a/resources/packs/gitlab/info/info.go
+++ b/resources/packs/gitlab/info/info.go
@@ -10,7 +10,6 @@ import (
 
 // fyi this is a workaround for paths: https://github.com/golang/go/issues/46056
 //
-//go:generate cp ../gitlab.lr.json ./gitlab.lr.json
 //go:embed gitlab.lr.json
 var info []byte
 

--- a/resources/packs/k8s/info/info.go
+++ b/resources/packs/k8s/info/info.go
@@ -10,7 +10,6 @@ import (
 
 // fyi this is a workaround for paths: https://github.com/golang/go/issues/46056
 //
-//go:generate cp ../k8s.lr.json ./k8s.lr.json
 //go:embed k8s.lr.json
 var info []byte
 

--- a/resources/packs/ms365/info/info.go
+++ b/resources/packs/ms365/info/info.go
@@ -10,7 +10,6 @@ import (
 
 // fyi this is a workaround for paths: https://github.com/golang/go/issues/46056
 //
-//go:generate cp ../ms365.lr.json ./ms365.lr.json
 //go:embed ms365.lr.json
 var info []byte
 

--- a/resources/packs/os/info/info.go
+++ b/resources/packs/os/info/info.go
@@ -10,7 +10,6 @@ import (
 
 // fyi this is a workaround for paths: https://github.com/golang/go/issues/46056
 //
-//go:generate cp ../os.lr.json ./os.lr.json
 //go:embed os.lr.json
 var info []byte
 

--- a/resources/packs/terraform/info/info.go
+++ b/resources/packs/terraform/info/info.go
@@ -10,7 +10,6 @@ import (
 
 // fyi this is a workaround for paths: https://github.com/golang/go/issues/46056
 //
-//go:generate cp ../terraform.lr.json ./terraform.lr.json
 //go:embed terraform.lr.json
 var info []byte
 

--- a/resources/packs/vsphere/info/info.go
+++ b/resources/packs/vsphere/info/info.go
@@ -10,7 +10,6 @@ import (
 
 // fyi this is a workaround for paths: https://github.com/golang/go/issues/46056
 //
-//go:generate cp ../vsphere.lr.json ./vsphere.lr.json
 //go:embed vsphere.lr.json
 var info []byte
 


### PR DESCRIPTION
just generate the file in the info folder. We want it to be loadable separately anyway. Next step will be to generate the rest of the info files as well, but there is no rush...

requires #8 to land first