### PR TITLE
🧹 Use main branch instead of master for test workflow

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -2,7 +2,7 @@ name: Code Test
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 env:


### PR DESCRIPTION
The workflow was specifying `master` instead of `main` so it was never running for pushes to `main`