### PR TITLE
🧹 fix docker proc test

### DIFF
--- a/motor/providers/container/docker_engine/docker_engine.go
+++ b/motor/providers/container/docker_engine/docker_engine.go
@@ -43,7 +43,7 @@ func New(container string) (*Provider, error) {
 	t.Fs = &FS{
 		dockerClient: t.dockerClient,
 		Container:    t.container,
-		Transport:    t,
+		Provider:     t,
 		catFS:        cat.New(t),
 	}
 	return t, nil

--- a/motor/providers/container/docker_engine/fs.go
+++ b/motor/providers/container/docker_engine/fs.go
@@ -14,7 +14,7 @@ import (
 type FS struct {
 	Container    string
 	dockerClient *client.Client
-	Transport    *Provider
+	Provider     *Provider
 	catFS        *cat.Fs
 }
 
@@ -50,7 +50,7 @@ func isDockerClientSupported(path string) bool {
 
 func (fs *FS) Open(name string) (afero.File, error) {
 	if isDockerClientSupported(name) {
-		return FileOpen(fs.dockerClient, name, fs.Container, fs.Transport)
+		return FileOpen(fs.dockerClient, name, fs.Container, fs.Provider)
 	} else {
 		return fs.catFS.Open(name)
 	}

--- a/resources/packs/core/processes/docker_test.go
+++ b/resources/packs/core/processes/docker_test.go
@@ -1,3 +1,6 @@
+//go:build debugtest
+// +build debugtest
+
 package processes
 
 import (
@@ -18,7 +21,7 @@ import (
 )
 
 func TestDockerProcsList(t *testing.T) {
-	image := "docker.io/nginx:stable-alpine"
+	image := "docker.io/nginx:stable"
 	ctx := context.Background()
 	dClient, err := docker_engine.GetDockerClient()
 	assert.NoError(t, err)
@@ -62,10 +65,10 @@ func TestDockerProcsList(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	transport, err := docker_engine.New(created.ID)
+	provider, err := docker_engine.New(created.ID)
 	assert.NoError(t, err)
 
-	motor, err := motor.New(transport)
+	motor, err := motor.New(provider)
 	assert.NoError(t, err)
 
 	pMan, err := ResolveManager(motor)

--- a/resources/packs/core/processes/linuxproc.go
+++ b/resources/packs/core/processes/linuxproc.go
@@ -20,7 +20,7 @@ func (lpm *LinuxProcManager) Name() string {
 }
 
 func (lpm *LinuxProcManager) List() ([]*OSProcess, error) {
-	// get all subdirectories of /proc, filter by nunbers
+	// get all subdirectories of /proc, filter by numbers
 	f, err := lpm.provider.FS().Open("/proc")
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to access /proc")


### PR DESCRIPTION
- switch from alpine to base container since stat handling for container is not optimised for this alpine version
- also switch the docker based test to debug since it not doing additional testing, but slowing down the go test. It is still helpful for manual debugging running containers