### PR TITLE
🐛 interpret nil bytes as empty string

### DIFF
--- a/llx/data_conversions_v1_test.go
+++ b/llx/data_conversions_v1_test.go
@@ -200,9 +200,6 @@ func TestCastResult(t *testing.T) {
 			Type types.Type
 		}{
 			{
-				Type: types.String,
-			},
-			{
 				Type: types.Int,
 			},
 			{
@@ -249,9 +246,6 @@ func TestResultFromNilConversion(t *testing.T) {
 			{
 				Type: string(types.Float),
 			},
-			{
-				Type: string(types.String),
-			},
 			NilPrimitive,
 			{
 				Type: string(types.Time),
@@ -264,6 +258,17 @@ func TestResultFromNilConversion(t *testing.T) {
 
 			assert.Equal(t, tests[i].Type, result.GetData().GetType())
 			assert.Nil(t, result.GetData().GetValue())
+		}
+
+		{
+			p := &Primitive{
+				Type: string(types.String),
+			}
+			assert.False(t, p.IsNil())
+			rawData := p.RawData()
+			result := rawData.Result()
+
+			assert.Equal(t, []byte{}, result.GetData().GetValue())
 		}
 	})
 

--- a/llx/primitives.go
+++ b/llx/primitives.go
@@ -400,7 +400,10 @@ func (p *Primitive) Size() int {
 }
 
 // IsNil returns true if a primitive is nil. A primitive is nil if it's type is nil,
-// or if it has no associated value
+// or if it has no associated value. The exception is the string type. If an empty
+// bytes field is serialized (for example for an empty string), that field is nil.
 func (p *Primitive) IsNil() bool {
-	return p == nil || p.Type == string(types.Nil) || (p.Value == nil && p.Map == nil && p.Array == nil)
+	return p == nil ||
+		p.Type == string(types.Nil) ||
+		(p.Value == nil && p.Map == nil && p.Array == nil && p.Type != string(types.String))
 }

--- a/llx/primitives_test.go
+++ b/llx/primitives_test.go
@@ -79,11 +79,11 @@ func TestPrimitiveNil(t *testing.T) {
 		assert.True(t, p.IsNil())
 	})
 
-	t.Run("string without value is nil", func(t *testing.T) {
+	t.Run("string without value is an empty string (not nil)", func(t *testing.T) {
 		p := &Primitive{
 			Type: string(types.String),
 		}
-		assert.True(t, p.IsNil())
+		assert.False(t, p.IsNil())
 	})
 
 	t.Run("string with value is not nil", func(t *testing.T) {


### PR DESCRIPTION
if we cast an empty string to `[]byte`, and put it in a protobuf
`bytes`, that doesn't get serialized/serialized as an empty array.
It comes back as null. Which means we cannot distinguish between an
empty string and a nil string

We ran into this case with this query:
```
  registrykey.property(path: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters', name: 'NullSessionPipes') {
    value == ""
  }
```

It worked fine when we ran it locally with `mondoo exec`. It worked fine
when we ran in in a policy in incognito mode. It failed when running
from a policy against nexus. The resolved policy that came back had a
nil Value for the primitive instead of an empty `[]byte`