### PR TITLE
✨Add docker tag when scanning a container registry image.

### DIFF
--- a/motor/discovery/container_registry/registry.go
+++ b/motor/discovery/container_registry/registry.go
@@ -180,6 +180,7 @@ func (a *DockerRegistryImages) toAsset(ref name.Reference, creds []*vault.Creden
 	}
 	imgDigest := desc.Digest.String()
 	repoName := ref.Context().Name()
+	imgTag := ref.Context().Tag(ref.Identifier()).Name()
 	imageUrl := repoName + "@" + imgDigest
 	asset := &asset.Asset{
 		PlatformIds: []string{containerid.MondooContainerImageID(imgDigest)},
@@ -199,8 +200,9 @@ func (a *DockerRegistryImages) toAsset(ref name.Reference, creds []*vault.Creden
 		Labels: make(map[string]string),
 	}
 
-	// store digest
+	// store digest and tag
 	asset.Labels["docker.io/digest"] = imgDigest
+	asset.Labels["docker.io/tags"] = imgTag
 	log.Debug().Strs("platform-ids", asset.PlatformIds).Msg("asset platform ids")
 	return asset, nil
 }

--- a/motor/discovery/k8s/list_images.go
+++ b/motor/discovery/k8s/list_images.go
@@ -181,7 +181,7 @@ func newPodImageAsset(i containerImage) (*asset.Asset, error) {
 	if len(i.image) > 0 {
 		tag, err := name.NewTag(i.image, name.WeakValidation)
 		if err == nil {
-			tagName = tag.TagStr()
+			tagName = tag.Name()
 		}
 	}
 	if a.Labels == nil {


### PR DESCRIPTION
When scanning an image from a container registry, also append the image name:tag combo as a label:
![image](https://user-images.githubusercontent.com/11717082/188463625-f889e46a-9e15-43ea-9b0c-9db1c152d7e2.png)

We have this behaviour for running `scan container image`:
![image](https://user-images.githubusercontent.com/11717082/188463899-6d716871-738b-43a6-b14e-4a6355af48b5.png)
