### PR TITLE
⭐ Improvments for related assets for K8s

### DIFF
--- a/motor/discovery/k8s/list_nodes.go
+++ b/motor/discovery/k8s/list_nodes.go
@@ -1,0 +1,149 @@
+package k8s
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	"go.mondoo.com/cnquery/motor/asset"
+	"go.mondoo.com/cnquery/motor/motorid/gce"
+	"go.mondoo.com/cnquery/motor/platform"
+	"go.mondoo.com/cnquery/motor/providers"
+	"go.mondoo.com/cnquery/motor/providers/k8s"
+	v1 "k8s.io/api/core/v1"
+)
+
+// ListNodes lits all nodes in the cluster.
+func ListNodes(p k8s.KubernetesProvider, connection *providers.Config, clusterIdentifier string, namespaceFilter []string) ([]*asset.Asset, []nodeRelationshipInfo, error) {
+	nodes, err := p.Nodes()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	assets := []*asset.Asset{}
+	nodeRelationshipInfos := []nodeRelationshipInfo{}
+	for i := range nodes {
+		node := nodes[i]
+		asset, err := createAssetFromObject(&node, p.Runtime(), connection, clusterIdentifier)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "failed to create asset from node")
+		}
+
+		assets = append(assets, asset)
+		nInfo, _ := detectNodeRelationshipInfo(node)
+		if nInfo.hostInstanceAsset != nil {
+			asset.RelatedAssets = append(asset.RelatedAssets, nInfo.hostInstanceAsset)
+		}
+		nodeRelationshipInfos = append(nodeRelationshipInfos, nInfo)
+	}
+
+	return assets, nodeRelationshipInfos, nil
+}
+
+type nodeRelationshipInfo struct {
+	cloudAccountAsset *asset.Asset
+	hostInstanceAsset *asset.Asset
+}
+
+var (
+	gkeProviderIDInfoRegexp     = regexp.MustCompile("^gce://([\\-0-9a-zA-Z]+)/([\\-0-9a-zA-Z]+)/.*")
+	aksProviderIDInstanceRegexp = regexp.MustCompile("^azure:///(.+)$")
+)
+
+func detectNodeRelationshipInfo(node v1.Node) (nodeRelationshipInfo, bool) {
+	for k := range node.Labels {
+		if strings.HasPrefix(k, "eks.amazonaws.com") {
+			// The node info doesn't seem to have the AWS Account id
+			return nodeRelationshipInfo{}, false
+		} else if strings.HasPrefix(k, "cloud.google.com/gke") {
+			return gkeRelationshipInfo(node)
+		} else if strings.HasPrefix(k, "kubernetes.azure.com") {
+			return aksRelationshipInfo(node)
+		}
+	}
+	hostname := node.Labels["kubernetes.io/hostname"]
+	if hostname == "" {
+		return nodeRelationshipInfo{}, false
+	}
+	return nodeRelationshipInfo{
+		hostInstanceAsset: &asset.Asset{
+			Name:        hostname,
+			PlatformIds: []string{"//platformid.api.mondoo.app/hostname/" + hostname},
+		},
+	}, true
+}
+
+func gkeRelationshipInfo(node v1.Node) (nodeRelationshipInfo, bool) {
+	matches := gkeProviderIDInfoRegexp.FindStringSubmatch(node.Spec.ProviderID)
+	if len(matches) != 3 {
+		return nodeRelationshipInfo{}, false
+	}
+	project := matches[1]
+	zone := matches[2]
+	instanceID := node.Annotations["container.googleapis.com/instance_id"]
+	instanceIDInt, err := strconv.ParseUint(instanceID, 10, 64)
+	if err != nil {
+		return nodeRelationshipInfo{}, false
+	}
+	if project != "" && zone != "" && instanceID != "" {
+		cloudAccountAsset := &asset.Asset{
+			Name: "GCP project " + project,
+			Platform: &platform.Platform{
+				Kind:    providers.Kind_KIND_API,
+				Runtime: providers.RUNTIME_GCP,
+				Title:   "Google Cloud Platform",
+			},
+			PlatformIds: []string{"//platformid.api.mondoo.app/runtime/gcp/projects/" + project},
+		}
+		hostInstanceAsset := &asset.Asset{
+			Name: node.Labels["kubernetes.io/hostname"],
+			Platform: &platform.Platform{
+				Kind:    providers.Kind_KIND_VIRTUAL_MACHINE,
+				Runtime: providers.RUNTIME_GCP_COMPUTE,
+				Arch:    node.Labels["kubernetes.io/arch"],
+			},
+			PlatformIds:   []string{gce.MondooGcpInstanceID(project, zone, instanceIDInt)},
+			RelatedAssets: []*asset.Asset{cloudAccountAsset},
+		}
+		return nodeRelationshipInfo{
+			cloudAccountAsset: cloudAccountAsset,
+			hostInstanceAsset: hostInstanceAsset,
+		}, true
+	}
+	return nodeRelationshipInfo{}, false
+}
+
+func aksRelationshipInfo(node v1.Node) (nodeRelationshipInfo, bool) {
+	matches := aksProviderIDInstanceRegexp.FindStringSubmatch(node.Spec.ProviderID)
+	if len(matches) != 2 {
+		return nodeRelationshipInfo{}, false
+	}
+	parts := strings.Split(matches[1], "/")
+	if len(parts) < 2 || parts[0] != "subscriptions" {
+		return nodeRelationshipInfo{}, false
+	}
+	sub := parts[1]
+	cloudAccountAsset := &asset.Asset{
+		Name: "Azure subscription " + sub,
+		Platform: &platform.Platform{
+			Kind:    providers.Kind_KIND_API,
+			Runtime: providers.RUNTIME_AZ,
+		},
+		PlatformIds: []string{"//platformid.api.mondoo.app/runtime/azure/subscriptions/" + sub},
+	}
+	hostInstanceAsset := &asset.Asset{
+		Name: node.Labels["kubernetes.io/hostname"],
+		Platform: &platform.Platform{
+			Kind:    providers.Kind_KIND_VIRTUAL_MACHINE,
+			Runtime: providers.RUNTIME_AZ_COMPUTE,
+			Arch:    node.Labels["kubernetes.io/arch"],
+		},
+		PlatformIds:   []string{"//platformid.api.mondoo.app/runtime/azure/" + matches[1]},
+		RelatedAssets: []*asset.Asset{cloudAccountAsset},
+	}
+	return nodeRelationshipInfo{
+		cloudAccountAsset: cloudAccountAsset,
+		hostInstanceAsset: hostInstanceAsset,
+	}, true
+}

--- a/motor/discovery/k8s/list_nodes_test.go
+++ b/motor/discovery/k8s/list_nodes_test.go
@@ -1,0 +1,318 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/motor/providers"
+	"go.mondoo.com/cnquery/motor/providers/k8s"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestListNodesAKS(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	p := k8s.NewMockKubernetesProvider(mockCtrl)
+
+	nodes := []corev1.Node{
+		{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Node",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "aks-default-36939070-vmss000000",
+				UID:  "acc8d118-f62a-4743-a55c-71dd19201c6c",
+				Annotations: map[string]string{
+					"csi.volume.kubernetes.io/nodeid":                        `{"disk.csi.azure.com":"aks-default-36939070-vmss000000","file.csi.azure.com":"aks-default-36939070-vmss000000"}`,
+					"node.alpha.kubernetes.io/ttl":                           "0",
+					"volumes.kubernetes.io/controller-managed-attach-detach": "true",
+				},
+				Labels: map[string]string{
+					"agentpool":                                       "default",
+					"beta.kubernetes.io/arch":                         "amd64",
+					"beta.kubernetes.io/instance-type":                "standard_d2_v2",
+					"beta.kubernetes.io/os":                           "linux",
+					"failure-domain.beta.kubernetes.io/region":        "eastus",
+					"failure-domain.beta.kubernetes.io/zone":          "0",
+					"kubernetes.azure.com/agentpool":                  "default",
+					"kubernetes.azure.com/cluster":                    "MC_mondoo-operator-tests-wcou_mondoo-operator-tests-wcou_eastus",
+					"kubernetes.azure.com/kubelet-identity-client-id": "c032ffd9-e9c3-4c4b-bece-1cee42d3da09",
+					"kubernetes.azure.com/mode":                       "system",
+					"kubernetes.azure.com/node-image-version":         "AKSUbuntu-1804containerd-2022.08.15",
+					"kubernetes.azure.com/os-sku":                     "Ubuntu",
+					"kubernetes.azure.com/role":                       "agent",
+					"kubernetes.azure.com/storageprofile":             "managed",
+					"kubernetes.azure.com/storagetier":                "Standard_LRS",
+					"kubernetes.io/arch":                              "amd64",
+					"kubernetes.io/hostname":                          "aks-default-36939070-vmss000000",
+					"kubernetes.io/os":                                "linux",
+					"kubernetes.io/role":                              "agent",
+					"node-role.kubernetes.io/agent":                   "",
+					"node.kubernetes.io/instance-type":                "standard_d2_v2",
+					"storageprofile":                                  "managed",
+					"storagetier":                                     "Standard_LRS",
+					"topology.disk.csi.azure.com/zone":                "",
+					"topology.kubernetes.io/region":                   "eastus",
+					"topology.kubernetes.io/zone":                     "0",
+				},
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: "azure:///subscriptions/f1a2873a-6b27-4097-aa7c-3df51f103e96/resourceGroups/mc_mondoo-operator-tests-wcou_mondoo-operator-tests-wcou_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-36939070-vmss/virtualMachines/0",
+				PodCIDR:    "10.244.0.0/24",
+				PodCIDRs:   []string{"10.244.0.0/24"},
+			},
+		},
+	}
+
+	p.EXPECT().Runtime().Return("k8s-cluster")
+	p.EXPECT().Nodes().Return(nodes, nil)
+
+	clusterIdentifier := "//platformid.api.mondoo.app/runtime/k8s/uid/e26043bb-8669-48a2-b684-b1e132198cdc"
+
+	pCfg := &providers.Config{}
+	assets, relInfo, err := ListNodes(p, pCfg, clusterIdentifier, nil)
+	require.NoError(t, err)
+	require.Len(t, assets, 1)
+	require.Equal(t, "Kubernetes Node", assets[0].Platform.Title)
+	require.Equal(t, "k8s-node", assets[0].Platform.Name)
+	require.Equal(t, providers.Kind_KIND_K8S_OBJECT, assets[0].Platform.Kind)
+	require.ElementsMatch(t, []string{"k8s-workload", "k8s"}, assets[0].Platform.Family)
+	require.Equal(t, []string{"//platformid.api.mondoo.app/runtime/k8s/uid/e26043bb-8669-48a2-b684-b1e132198cdc/nodes/name/aks-default-36939070-vmss000000"}, assets[0].PlatformIds)
+
+	// Adds relatonship to host
+	require.Len(t, assets[0].RelatedAssets, 1)
+	require.Equal(t, "aks-default-36939070-vmss000000", assets[0].RelatedAssets[0].Name)
+	require.Equal(t, providers.Kind_KIND_VIRTUAL_MACHINE, assets[0].RelatedAssets[0].Platform.Kind)
+	require.Equal(t, providers.RUNTIME_AZ_COMPUTE, assets[0].RelatedAssets[0].Platform.Runtime)
+	require.Equal(t, "amd64", assets[0].RelatedAssets[0].Platform.Arch)
+	require.Equal(t, []string{"//platformid.api.mondoo.app/runtime/azure/subscriptions/f1a2873a-6b27-4097-aa7c-3df51f103e96/resourceGroups/mc_mondoo-operator-tests-wcou_mondoo-operator-tests-wcou_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-36939070-vmss/virtualMachines/0"}, assets[0].RelatedAssets[0].PlatformIds)
+
+	require.NotNil(t, relInfo[0].hostInstanceAsset)
+	require.Equal(t, assets[0].RelatedAssets[0], relInfo[0].hostInstanceAsset)
+	require.NotNil(t, relInfo[0].cloudAccountAsset)
+	require.Equal(t, []string{"//platformid.api.mondoo.app/runtime/azure/subscriptions/f1a2873a-6b27-4097-aa7c-3df51f103e96"}, relInfo[0].cloudAccountAsset.PlatformIds)
+	require.Equal(t, providers.Kind_KIND_API, relInfo[0].cloudAccountAsset.Platform.Kind)
+	require.Equal(t, providers.RUNTIME_AZ, relInfo[0].cloudAccountAsset.Platform.Runtime)
+}
+
+func TestListNodesGKE(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	p := k8s.NewMockKubernetesProvider(mockCtrl)
+
+	nodes := []corev1.Node{
+		{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Node",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gke-gke-cluster-generic-pool-4dfcd37f-s3d6",
+				UID:  "f2cd325c-23eb-465d-8843-9e53665779f0",
+				Annotations: map[string]string{
+					"container.googleapis.com/instance_id": "8976889368772093420",
+				},
+				Labels: map[string]string{
+					"beta.kubernetes.io/arch":                  "amd64",
+					"beta.kubernetes.io/instance-type":         "n1-standard-2",
+					"beta.kubernetes.io/os":                    "linux",
+					"cloud.google.com/gke-boot-disk":           "pd-standard",
+					"cloud.google.com/gke-container-runtime":   "docker",
+					"cloud.google.com/gke-netd-ready":          "true",
+					"cloud.google.com/gke-nodepool":            "generic-pool",
+					"cloud.google.com/gke-os-distribution":     "cos",
+					"cloud.google.com/machine-family":          "n1",
+					"cluster_name":                             "gke-cluster",
+					"failure-domain.beta.kubernetes.io/region": "us-central1",
+					"failure-domain.beta.kubernetes.io/zone":   "us-central1-b",
+					"iam.gke.io/gke-metadata-server-enabled":   "true",
+					"kubernetes.io/arch":                       "amd64",
+					"kubernetes.io/hostname":                   "gke-gke-cluster-generic-pool-4dfcd37f-s3d6",
+					"kubernetes.io/os":                         "linux",
+					"node.kubernetes.io/instance-type":         "n1-standard-2",
+					"node.kubernetes.io/masq-agent-ds-ready":   "true",
+					"node_pool":                                "generic-pool",
+					"topology.gke.io/zone":                     "us-central1-b",
+					"topology.kubernetes.io/region":            "us-central1",
+					"topology.kubernetes.io/zone":              "us-central1-b",
+				},
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: "gce://mondoo-test/us-central1-b/gke-gke-cluster-generic-pool-4dfcd37f-s3d6",
+				PodCIDR:    "192.168.1.0/24",
+				PodCIDRs:   []string{"192.168.1.0/24"},
+			},
+		},
+	}
+
+	p.EXPECT().Runtime().Return("k8s-cluster")
+	p.EXPECT().Nodes().Return(nodes, nil)
+
+	clusterIdentifier := "//platformid.api.mondoo.app/runtime/k8s/uid/e26043bb-8669-48a2-b684-b1e132198cdc"
+
+	pCfg := &providers.Config{}
+	assets, relInfo, err := ListNodes(p, pCfg, clusterIdentifier, nil)
+	require.NoError(t, err)
+	require.Len(t, assets, 1)
+	require.Equal(t, "Kubernetes Node", assets[0].Platform.Title)
+	require.Equal(t, "k8s-node", assets[0].Platform.Name)
+	require.Equal(t, providers.Kind_KIND_K8S_OBJECT, assets[0].Platform.Kind)
+	require.ElementsMatch(t, []string{"k8s-workload", "k8s"}, assets[0].Platform.Family)
+	require.Equal(t, []string{"//platformid.api.mondoo.app/runtime/k8s/uid/e26043bb-8669-48a2-b684-b1e132198cdc/nodes/name/gke-gke-cluster-generic-pool-4dfcd37f-s3d6"}, assets[0].PlatformIds)
+
+	// Adds relatonship to host
+	require.Len(t, assets[0].RelatedAssets, 1)
+	require.Equal(t, "gke-gke-cluster-generic-pool-4dfcd37f-s3d6", assets[0].RelatedAssets[0].Name)
+	require.Equal(t, providers.Kind_KIND_VIRTUAL_MACHINE, assets[0].RelatedAssets[0].Platform.Kind)
+	require.Equal(t, providers.RUNTIME_GCP_COMPUTE, assets[0].RelatedAssets[0].Platform.Runtime)
+	require.Equal(t, "amd64", assets[0].RelatedAssets[0].Platform.Arch)
+	require.Equal(t, []string{"//platformid.api.mondoo.app/runtime/gcp/compute/v1/projects/mondoo-test/zones/us-central1-b/instances/8976889368772093420"}, assets[0].RelatedAssets[0].PlatformIds)
+
+	require.NotNil(t, relInfo[0].hostInstanceAsset)
+	require.Equal(t, assets[0].RelatedAssets[0], relInfo[0].hostInstanceAsset)
+	require.NotNil(t, relInfo[0].cloudAccountAsset)
+	require.Equal(t, []string{"//platformid.api.mondoo.app/runtime/gcp/projects/mondoo-test"}, relInfo[0].cloudAccountAsset.PlatformIds)
+	require.Equal(t, providers.Kind_KIND_API, relInfo[0].cloudAccountAsset.Platform.Kind)
+	require.Equal(t, providers.RUNTIME_GCP, relInfo[0].cloudAccountAsset.Platform.Runtime)
+}
+
+func TestListNodesEKS(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	p := k8s.NewMockKubernetesProvider(mockCtrl)
+
+	nodes := []corev1.Node{
+		{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Node",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ip-10-0-5-36.eu-central-1.compute.internal",
+				UID:  "c9a5bb24-e77b-46fd-be55-8a247faee098",
+				Annotations: map[string]string{
+					"alpha.kubernetes.io/provided-node-ip": "10.0.5.36",
+				},
+				Labels: map[string]string{
+					"beta.kubernetes.io/arch":                       "amd64",
+					"beta.kubernetes.io/instance-type":              "m5zn.large",
+					"beta.kubernetes.io/os":                         "linux",
+					"eks.amazonaws.com/capacityType":                "SPOT",
+					"eks.amazonaws.com/nodegroup":                   "eks-managed-nodes-l3il-20220901164719853800000006",
+					"eks.amazonaws.com/nodegroup-image":             "ami-01c52a64630ff492f",
+					"eks.amazonaws.com/sourceLaunchTemplateId":      "lt-0b3c2c84c209ec814",
+					"eks.amazonaws.com/sourceLaunchTemplateVersion": "1",
+					"failure-domain.beta.kubernetes.io/region":      "eu-central-1",
+					"failure-domain.beta.kubernetes.io/zone":        "eu-central-1b",
+					"k8s.io/cloud-provider-aws":                     "10f49535c88faa0a8024328860a01464",
+					"kubernetes.io/arch":                            "amd64",
+					"kubernetes.io/hostname":                        "ip-10-0-5-36.eu-central-1.compute.internal",
+					"kubernetes.io/os":                              "linux",
+					"node.kubernetes.io/instance-type":              "m5zn.large",
+					"topology.kubernetes.io/region":                 "eu-central-1",
+					"topology.kubernetes.io/zone":                   "eu-central-1b",
+				},
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: "aws:///eu-central-1b/i-0178150be4c94393d",
+			},
+		},
+	}
+
+	p.EXPECT().Runtime().Return("k8s-cluster")
+	p.EXPECT().Nodes().Return(nodes, nil)
+
+	clusterIdentifier := "//platformid.api.mondoo.app/runtime/k8s/uid/e26043bb-8669-48a2-b684-b1e132198cdc"
+
+	pCfg := &providers.Config{}
+	assets, relInfo, err := ListNodes(p, pCfg, clusterIdentifier, nil)
+	require.NoError(t, err)
+	require.Len(t, assets, 1)
+	require.Equal(t, "Kubernetes Node", assets[0].Platform.Title)
+	require.Equal(t, "k8s-node", assets[0].Platform.Name)
+	require.Equal(t, providers.Kind_KIND_K8S_OBJECT, assets[0].Platform.Kind)
+	require.ElementsMatch(t, []string{"k8s-workload", "k8s"}, assets[0].Platform.Family)
+	require.Equal(t, []string{"//platformid.api.mondoo.app/runtime/k8s/uid/e26043bb-8669-48a2-b684-b1e132198cdc/nodes/name/ip-10-0-5-36.eu-central-1.compute.internal"}, assets[0].PlatformIds)
+
+	require.Len(t, assets[0].RelatedAssets, 0)
+
+	require.Nil(t, relInfo[0].hostInstanceAsset)
+	require.Nil(t, relInfo[0].cloudAccountAsset)
+}
+
+func TestListNodesK3S(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	p := k8s.NewMockKubernetesProvider(mockCtrl)
+
+	nodes := []corev1.Node{
+		{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Node",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "x1",
+				UID:  "08677417-062a-4521-af10-901913b575cf",
+				Annotations: map[string]string{
+					"k3s.io/hostname":              "x1",
+					"k3s.io/internal-ip":           "192.168.1.87",
+					"k3s.io/node-args":             `'["server","--write-kubeconfig-mode","0644"]'`,
+					"k3s.io/node-config-hash":      "LUZJBAJBVUEWLANIK5CQFBP3IKZUSSX643EDQVRRLL4O4D6AVNLQ====",
+					"k3s.io/node-env":              `'{"K3S_DATA_DIR":"/var/lib/rancher/k3s/data/577968fa3d58539cc4265245941b7be688833e6bf5ad7869fa2afe02f15f1cd2"}'`,
+					"node.alpha.kubernetes.io/ttl": "0",
+					"volumes.kubernetes.io/controller-managed-attach-detach": "true"},
+				Labels: map[string]string{
+					"beta.kubernetes.io/arch":               "amd64",
+					"beta.kubernetes.io/instance-type":      "k3s",
+					"beta.kubernetes.io/os":                 "linux",
+					"egress.k3s.io/cluster":                 "true",
+					"kubernetes.io/arch":                    "amd64",
+					"kubernetes.io/hostname":                "x1",
+					"kubernetes.io/os":                      "linux",
+					"node-role.kubernetes.io/control-plane": "true",
+					"node-role.kubernetes.io/master":        "true",
+					"node.kubernetes.io/instance-type":      "k3s",
+				},
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: "k3s://x1",
+				PodCIDR:    "10.42.0.0/24",
+				PodCIDRs:   []string{"10.42.0.0/24"},
+			},
+		},
+	}
+
+	p.EXPECT().Runtime().Return("k8s-cluster")
+	p.EXPECT().Nodes().Return(nodes, nil)
+
+	clusterIdentifier := "//platformid.api.mondoo.app/runtime/k8s/uid/e26043bb-8669-48a2-b684-b1e132198cdc"
+
+	pCfg := &providers.Config{}
+	assets, relInfo, err := ListNodes(p, pCfg, clusterIdentifier, nil)
+	require.NoError(t, err)
+	require.Len(t, assets, 1)
+	require.Equal(t, "Kubernetes Node", assets[0].Platform.Title)
+	require.Equal(t, "k8s-node", assets[0].Platform.Name)
+	require.Equal(t, providers.Kind_KIND_K8S_OBJECT, assets[0].Platform.Kind)
+	require.ElementsMatch(t, []string{"k8s-workload", "k8s"}, assets[0].Platform.Family)
+	require.Equal(t, []string{"//platformid.api.mondoo.app/runtime/k8s/uid/e26043bb-8669-48a2-b684-b1e132198cdc/nodes/name/x1"}, assets[0].PlatformIds)
+
+	// Adds relatonship to host
+	require.Len(t, assets[0].RelatedAssets, 1)
+	require.Equal(t, "x1", assets[0].RelatedAssets[0].Name)
+	require.Equal(t, providers.Kind_KIND_UNKNOWN, assets[0].RelatedAssets[0].GetPlatform().GetKind())
+	require.Equal(t, "", assets[0].RelatedAssets[0].GetPlatform().GetRuntime())
+	require.Equal(t, []string{"//platformid.api.mondoo.app/hostname/x1"}, assets[0].RelatedAssets[0].PlatformIds)
+
+	require.NotNil(t, relInfo[0].hostInstanceAsset)
+	require.Equal(t, assets[0].RelatedAssets[0], relInfo[0].hostInstanceAsset)
+	require.Nil(t, relInfo[0].cloudAccountAsset)
+}

--- a/motor/discovery/k8s/resolver.go
+++ b/motor/discovery/k8s/resolver.go
@@ -132,6 +132,17 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 	resolved = append(resolved, clusterAsset)
 
 	ownershipDir := k8s.NewEmptyPlatformIdOwnershipDirectory(clusterIdentifier)
+
+	// nodes are only added as related assets because we have no policies to scan them
+	nodes, nodeRelationshipInfos, err := ListNodes(p, tc, clusterIdentifier, namespacesFilter)
+	if err == nil && len(nodes) > 0 {
+		ri := nodeRelationshipInfos[0]
+		if ri.cloudAccountAsset != nil {
+			clusterAsset.RelatedAssets = append(clusterAsset.RelatedAssets, ri.cloudAccountAsset)
+		}
+		clusterAsset.RelatedAssets = append(clusterAsset.RelatedAssets, nodes...)
+	}
+
 	additionalAssets, err := addSeparateAssets(tc, p, namespacesFilter, clusterIdentifier, ownershipDir)
 	if err != nil {
 		return nil, err

--- a/motor/providers/k8s/api_provider.go
+++ b/motor/providers/k8s/api_provider.go
@@ -252,6 +252,19 @@ func (t *apiProvider) PlatformInfo() *platform.Platform {
 	}
 }
 
+func (t *apiProvider) Nodes() ([]v1.Node, error) {
+	ctx := context.Background()
+	list, err := t.clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	// needed because of https://github.com/kubernetes/client-go/issues/861
+	for i := range list.Items {
+		list.Items[i].SetGroupVersionKind(v1.SchemeGroupVersion.WithKind("Node"))
+	}
+	return list.Items, err
+}
+
 func (t *apiProvider) Namespaces() ([]v1.Namespace, error) {
 	ctx := context.Background()
 	list, err := t.clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})

--- a/motor/providers/k8s/manifest_provider.go
+++ b/motor/providers/k8s/manifest_provider.go
@@ -178,6 +178,10 @@ func (t *manifestProvider) Name() (string, error) {
 	return clusterName, nil
 }
 
+func (t *manifestProvider) Nodes() ([]v1.Node, error) {
+	return []v1.Node{}, nil
+}
+
 // Namespaces iterates over all file-based manifests and extracts all namespaces used
 func (t *manifestProvider) Namespaces() ([]v1.Namespace, error) {
 	// iterate over all resources and extract all the namespaces

--- a/motor/providers/k8s/mock_provider.go
+++ b/motor/providers/k8s/mock_provider.go
@@ -260,6 +260,21 @@ func (mr *MockKubernetesProviderMockRecorder) Namespaces() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Namespaces", reflect.TypeOf((*MockKubernetesProvider)(nil).Namespaces))
 }
 
+// Nodes mocks base method.
+func (m *MockKubernetesProvider) Nodes() ([]v11.Node, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Nodes")
+	ret0, _ := ret[0].([]v11.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Nodes indicates an expected call of Nodes.
+func (mr *MockKubernetesProviderMockRecorder) Nodes() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nodes", reflect.TypeOf((*MockKubernetesProvider)(nil).Nodes))
+}
+
 // PlatformIdDetectors mocks base method.
 func (m *MockKubernetesProvider) PlatformIdDetectors() []providers.PlatformIdDetector {
 	m.ctrl.T.Helper()

--- a/motor/providers/k8s/platform.go
+++ b/motor/providers/k8s/platform.go
@@ -10,7 +10,7 @@ func NewPlatformWorkloadId(clusterIdentifier, workloadType, namespace, name stri
 	platformIdentifier := clusterIdentifier
 	// when mondoo is called with "--namespace xyz" the cluster identifier already contains the namespace
 	// when called with --all-namespaces, it is missing, but we need it to identify workloads
-	if !strings.Contains(clusterIdentifier, "namespace") {
+	if !strings.Contains(clusterIdentifier, "namespace") && namespace != "" {
 		platformIdentifier += "/namespace/" + namespace
 	}
 	// add plural "s"

--- a/motor/providers/k8s/provider.go
+++ b/motor/providers/k8s/provider.go
@@ -43,6 +43,7 @@ type KubernetesProvider interface {
 	ID() (string, error)
 	// MRN style platform identifier
 	PlatformIdentifier() (string, error)
+	Nodes() ([]v1.Node, error)
 	Namespaces() ([]v1.Namespace, error)
 	Pod(namespace, name string) (*v1.Pod, error)
 	Pods(namespace v1.Namespace) ([]v1.Pod, error)


### PR DESCRIPTION
- I've introduced an asset type for K8s nodes. It currently only shows up as a related asset, not a scanned asset
- From the K8s nodes, we can try to detect the cloud account. This works for AKS and GKE, as the node info has the subscription/project identifiers. This information is not available in the EKS node metadata. If this is detectable, we can link the cluster to the cloud account.
- The K8s node is linked to the underlying host node. If its a google cloud compute node or azure cloud compute node, we create the platform identifier from the project/subscription identifier + instance identifier. For EKS, this is skipped because we do not have the AWS account id.