### PR TITLE
⭐️ GitHub action to release the cnquery binary

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,27 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,74 @@
+---
+project_name: cnquery
+env:
+  - CGO_ENABLED=0
+builds:
+  - id: linux
+    main: ./apps/cnquery/cnquery.go
+    binary: cnquery
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - 386
+      - arm64
+      - arm
+    # ARM 6= Raspberry Pi A, A+, B, B+, Zero
+    # ARM 7= Raspberry Pi 2, 3, 4
+    goarm:
+      - 6
+      - 7
+    flags:
+      - -tags="production netgo"
+    ldflags:
+      - "-extldflags=-static"
+      - -s -w -X go.mondoo.com/mondoo.Version={{.Version}} -X go.mondoo.com/cnquery.Build={{.ShortCommit}} -X go.mondoo.com/cnquery.Date={{.Date}}
+  - id: macos
+    main: ./apps/cnquery/cnquery.go
+    binary: cnquery
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    flags: -tags production
+    ldflags:
+      # clang + macos does not support static: - -extldflags "-static"
+      - -s -w -X go.mondoo.com/cnquery.Version={{.Version}} -X go.mondoo.com/cnquery.Build={{.ShortCommit}} -X go.mondoo.com/cnquery.Date={{.Date}}
+  - id: windows
+    main: ./apps/cnquery/cnquery.go
+    binary: cnquery
+    goos:
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    # -buildmode exe is required since go 1.15.0 https://github.com/golang/go/issues/40795
+    flags: -tags production -buildmode exe
+    ldflags:
+      - "-extldflags -static"
+      - -s -w -X go.mondoo.com/mondoo.Version={{.Version}} -X go.mondoo.com/mondoo.Build={{.ShortCommit}} -X go.mondoo.com/mondoo.Date={{.Date}}
+nfpms:
+  -
+    maintainer: Mondoo <hello@mondoo.com>
+    description: Cloud-Native Asset Inventory Framework
+    homepage: https://mondoo.com/
+    vendor: Mondoo, Inc
+    license: MPL-2.0
+    formats:
+      - deb
+      - rpm
+archives:
+  - id: releases
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - none*
+checksum:
+  name_template: '{{ .ProjectName }}_v{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+snapshot:
+  name_template: "{{ .Tag }}-snapshot"
+changelog:
+  use: github-native

--- a/Makefile
+++ b/Makefile
@@ -199,11 +199,17 @@ mqlc: | llx mqlc/test
 mqlc/test:
 	go test -timeout 5s $(shell go list ./mqlc/... | grep -v '/vendor/')
 
-#   🏗 Binary   #
+#   🏗 Binary / Build   #
 
 .PHONY: cnquery/install
 cnquery/install:
 	GOBIN=${GOPATH}/bin go install ${LDFLAGSDIST} apps/cnquery/cnquery.go
+
+cnquery/dist/goreleaser/stable:
+	goreleaser release --rm-dist --skip-publish --skip-validate	-f .goreleaser.yml --timeout 120m
+
+cnquery/dist/goreleaser/edge:
+	goreleaser release --rm-dist --skip-publish --skip-validate	-f .goreleaser.yml --timeout 120m --snapshot
 
 #   ⛹🏽‍ Testing   #
 


### PR DESCRIPTION
after #49 

adds the goreleaser workflow to release the binary for tagged releases