### PR TITLE
🐛 Always use ownership directory for k8s discovery

### DIFF
--- a/motor/discovery/k8s/list_cronjobs.go
+++ b/motor/discovery/k8s/list_cronjobs.go
@@ -60,9 +60,8 @@ func ListCronJobs(
 	assets := []*asset.Asset{}
 	for i := range cronJobs {
 		cronJob := cronJobs[i]
-		if od != nil {
-			od.Add(&cronJob)
-		}
+		od.Add(&cronJob)
+
 		asset, err := createAssetFromObject(&cronJob, p.Runtime(), connection, clusterIdentifier)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create asset from cronjob")

--- a/motor/discovery/k8s/list_daemonsets.go
+++ b/motor/discovery/k8s/list_daemonsets.go
@@ -60,9 +60,8 @@ func ListDaemonSets(
 	assets := []*asset.Asset{}
 	for i := range daemonSets {
 		daemonSet := daemonSets[i]
-		if od != nil {
-			od.Add(&daemonSet)
-		}
+		od.Add(&daemonSet)
+
 		asset, err := createAssetFromObject(&daemonSet, p.Runtime(), connection, clusterIdentifier)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create asset from daemonset")

--- a/motor/discovery/k8s/list_deployments.go
+++ b/motor/discovery/k8s/list_deployments.go
@@ -60,9 +60,8 @@ func ListDeployments(
 	assets := []*asset.Asset{}
 	for i := range deployments {
 		deployment := deployments[i]
-		if od != nil {
-			od.Add(&deployment)
-		}
+		od.Add(&deployment)
+
 		asset, err := createAssetFromObject(&deployment, p.Runtime(), connection, clusterIdentifier)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create asset from deployment")

--- a/motor/discovery/k8s/list_jobs.go
+++ b/motor/discovery/k8s/list_jobs.go
@@ -60,9 +60,8 @@ func ListJobs(
 	assets := []*asset.Asset{}
 	for i := range jobs {
 		job := jobs[i]
-		if od != nil {
-			od.Add(&job)
-		}
+		od.Add(&job)
+
 		asset, err := createAssetFromObject(&job, p.Runtime(), connection, clusterIdentifier)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create asset from job")

--- a/motor/discovery/k8s/list_pods.go
+++ b/motor/discovery/k8s/list_pods.go
@@ -59,9 +59,8 @@ func ListPods(
 	assets := []*asset.Asset{}
 	for i := range pods {
 		pod := pods[i]
-		if od != nil {
-			od.Add(&pod)
-		}
+		od.Add(&pod)
+
 		asset, err := createAssetFromObject(&pod, p.Runtime(), connection, clusterIdentifier)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create asset from pod")

--- a/motor/discovery/k8s/list_replicasets.go
+++ b/motor/discovery/k8s/list_replicasets.go
@@ -59,9 +59,8 @@ func ListReplicaSets(
 	assets := []*asset.Asset{}
 	for i := range replicaSets {
 		replicaSet := replicaSets[i]
-		if od != nil {
-			od.Add(&replicaSet)
-		}
+		od.Add(&replicaSet)
+
 		asset, err := createAssetFromObject(&replicaSet, p.Runtime(), connection, clusterIdentifier)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create asset from repicaset")

--- a/motor/discovery/k8s/list_statefulsets.go
+++ b/motor/discovery/k8s/list_statefulsets.go
@@ -60,9 +60,8 @@ func ListStatefulSets(
 	assets := []*asset.Asset{}
 	for i := range statefulSets {
 		statefulSet := statefulSets[i]
-		if od != nil {
-			od.Add(&statefulSet)
-		}
+		od.Add(&statefulSet)
+
 		asset, err := createAssetFromObject(&statefulSet, p.Runtime(), connection, clusterIdentifier)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create asset from statefulset")

--- a/motor/discovery/k8s/resolver.go
+++ b/motor/discovery/k8s/resolver.go
@@ -137,7 +137,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 
 	// Only discover cluster and nodes if there are no resource filters.
 	var clusterAsset *asset.Asset
-	var ownershipDir *k8s.PlatformIdOwnershipDirectory
+	ownershipDir := k8s.NewEmptyPlatformIdOwnershipDirectory(clusterIdentifier)
 	if len(resourcesFilter) == 0 {
 		clusterAsset = &asset.Asset{
 			PlatformIds: []string{clusterIdentifier},
@@ -147,8 +147,6 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 			State:       asset.State_STATE_RUNNING,
 		}
 		resolved = append(resolved, clusterAsset)
-
-		ownershipDir = k8s.NewEmptyPlatformIdOwnershipDirectory(clusterIdentifier)
 
 		// nodes are only added as related assets because we have no policies to scan them
 		nodes, nodeRelationshipInfos, err := ListNodes(p, tc, clusterIdentifier, namespacesFilter)
@@ -295,34 +293,32 @@ func addSeparateAssets(
 		resolved = append(resolved, replicasets...)
 	}
 
-	if od != nil {
-		// build a lookup on the k8s uid to look up individual assets to link
-		platformIdToAssetMap := map[string]*asset.Asset{}
-		for _, assetObj := range resolved {
-			for _, platformId := range assetObj.PlatformIds {
-				platformIdToAssetMap[platformId] = assetObj
-			}
+	// build a lookup on the k8s uid to look up individual assets to link
+	platformIdToAssetMap := map[string]*asset.Asset{}
+	for _, assetObj := range resolved {
+		for _, platformId := range assetObj.PlatformIds {
+			platformIdToAssetMap[platformId] = assetObj
 		}
+	}
 
-		for id, a := range platformIdToAssetMap {
-			ownedBy := od.OwnedBy(id)
-			for _, ownerPlatformId := range ownedBy {
-				if aa, ok := platformIdToAssetMap[ownerPlatformId]; ok {
-					a.RelatedAssets = append(a.RelatedAssets, aa)
-				} else {
-					// If the owner object is not scanned we can still add an asset as we know most of the information
-					// from the ownerReference field
-					if platformEntry, ok := od.GetKubernetesObjectData(ownerPlatformId); ok {
-						platformData, err := createPlatformData(platformEntry.Kind, providers.RUNTIME_KUBERNETES_CLUSTER)
-						if err != nil {
-							continue
-						}
-						a.RelatedAssets = append(a.RelatedAssets, &asset.Asset{
-							PlatformIds: []string{ownerPlatformId},
-							Platform:    platformData,
-							Name:        platformEntry.Namespace + "/" + platformEntry.Name,
-						})
+	for id, a := range platformIdToAssetMap {
+		ownedBy := od.OwnedBy(id)
+		for _, ownerPlatformId := range ownedBy {
+			if aa, ok := platformIdToAssetMap[ownerPlatformId]; ok {
+				a.RelatedAssets = append(a.RelatedAssets, aa)
+			} else {
+				// If the owner object is not scanned we can still add an asset as we know most of the information
+				// from the ownerReference field
+				if platformEntry, ok := od.GetKubernetesObjectData(ownerPlatformId); ok {
+					platformData, err := createPlatformData(platformEntry.Kind, providers.RUNTIME_KUBERNETES_CLUSTER)
+					if err != nil {
+						continue
 					}
+					a.RelatedAssets = append(a.RelatedAssets, &asset.Asset{
+						PlatformIds: []string{ownerPlatformId},
+						Platform:    platformData,
+						Name:        platformEntry.Namespace + "/" + platformEntry.Name,
+					})
 				}
 			}
 		}


### PR DESCRIPTION
This fixes the issue with asset relationships whenever `k8s-resources` option is specified in the inventory