### PR TITLE
🐛 expose Shell Close function to store recordings when used with cnquery run

### DIFF
--- a/apps/cnquery/cmd/run.go
+++ b/apps/cnquery/cmd/run.go
@@ -199,6 +199,7 @@ var execCmd = builder.NewProviderCommand(builder.CommandOpts{
 		if err != nil {
 			log.Error().Err(err).Msg("failed to initialize Mondoo Shell")
 		}
+		defer sh.Close()
 
 		code, results, err := sh.RunOnce(command)
 		if err != nil {


### PR DESCRIPTION
fixes an issue with `cnquery run --record` where the toml file is not stored when the command completed

superseeds  #58