### PR TITLE
🐛 Check if /proc/sys/ files can be read before retrieving kernel parameters

### DIFF
--- a/resources/packs/testdata/arch.toml
+++ b/resources/packs/testdata/arch.toml
@@ -461,6 +461,8 @@ stat.isdir = true
 stat.isdir = true
 
 [files."/proc/sys/net/ipv4/ip_forward"]
+stat.isdir=false
+stat.mode=420
 content = "1"
 
 [commands."mount"]


### PR DESCRIPTION
While going through `/proc/sys/` files to get kernel params on a linux machine, check if the file can be read before trying to fetch it.