### PR TITLE
🧹 Remove --iam-actions proto plugin gen.

### DIFF
--- a/motor/asset/asset.go
+++ b/motor/asset/asset.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-//go:generate protoc --proto_path=../../:. --go_out=. --go_opt=paths=source_relative --rangerrpc_out=. --iam-actions_out=. asset.proto
+//go:generate protoc --proto_path=../../:. --go_out=. --go_opt=paths=source_relative --rangerrpc_out=. asset.proto
 
 func (a *Asset) HumanName() string {
 	if a == nil {

--- a/motor/inventory/v1/inventory.go
+++ b/motor/inventory/v1/inventory.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-//go:generate protoc --proto_path=../../../:. --go_out=. --go_opt=paths=source_relative --rangerrpc_out=. --iam-actions_out=. inventory.proto
+//go:generate protoc --proto_path=../../../:. --go_out=. --go_opt=paths=source_relative --rangerrpc_out=. inventory.proto
 
 const (
 	InventoryFilePath = "mondoo.app/source-file"

--- a/motor/platform/platform.go
+++ b/motor/platform/platform.go
@@ -6,7 +6,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 )
 
-//go:generate protoc --proto_path=../../:. --go_out=. --go_opt=paths=source_relative --rangerrpc_out=. --iam-actions_out=. platform.proto
+//go:generate protoc --proto_path=../../:. --go_out=. --go_opt=paths=source_relative --rangerrpc_out=. platform.proto
 
 func (p *Platform) IsFamily(family string) bool {
 	for i := range p.Family {

--- a/motor/providers/provider.go
+++ b/motor/providers/provider.go
@@ -1,6 +1,6 @@
 package providers
 
-//go:generate protoc --proto_path=../..:. --go_out=. --go_opt=paths=source_relative --rangerrpc_out=. --iam-actions_out=. provider.proto
+//go:generate protoc --proto_path=../..:. --go_out=. --go_opt=paths=source_relative --rangerrpc_out=. provider.proto
 
 type PlatformIdDetector string
 


### PR DESCRIPTION
I believe we do not need those anymore? They cause troubles when running cnquery in a container (so no iam plugin)

Signed-off-by: Preslav <preslav@mondoo.com>