### PR TITLE
🧹 replace ioutil.ReadFile with os.ReadFile

### DIFF
--- a/cli/shell/shell.go
+++ b/cli/shell/shell.go
@@ -3,7 +3,6 @@ package shell
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path"
@@ -13,8 +12,6 @@ import (
 	"strings"
 	"sync"
 
-	"go.mondoo.com/cnquery/mql"
-
 	prompt "github.com/c-bata/go-prompt"
 	"github.com/mitchellh/go-homedir"
 	"github.com/rs/zerolog/log"
@@ -22,6 +19,7 @@ import (
 	"go.mondoo.com/cnquery/cli/theme"
 	"go.mondoo.com/cnquery/llx"
 	"go.mondoo.com/cnquery/motor"
+	"go.mondoo.com/cnquery/mql"
 	"go.mondoo.com/cnquery/mqlc"
 	"go.mondoo.com/cnquery/mqlc/parser"
 	"go.mondoo.com/cnquery/resources"
@@ -129,7 +127,7 @@ func (s *Shell) RunInteractive(cmd string) {
 	s.History = []string{}
 	homeDir, _ := homedir.Dir()
 	s.HistoryPath = path.Join(homeDir, ".mondoo_history")
-	if rawHistory, err := ioutil.ReadFile(s.HistoryPath); err == nil {
+	if rawHistory, err := os.ReadFile(s.HistoryPath); err == nil {
 		s.History = strings.Split(string(rawHistory), "\n")
 	}
 

--- a/motor/inventory/ansibleinventory/inventory_test.go
+++ b/motor/inventory/ansibleinventory/inventory_test.go
@@ -1,7 +1,7 @@
 package ansibleinventory_test
 
 import (
-	"io/ioutil"
+	"os"
 	"sort"
 	"testing"
 
@@ -45,7 +45,7 @@ func TestValidInventory(t *testing.T) {
 }
 
 func TestParseInventory(t *testing.T) {
-	input, err := ioutil.ReadFile("./testdata/empty.json")
+	input, err := os.ReadFile("./testdata/empty.json")
 	assert.Nil(t, err)
 	assert.True(t, ansibleinventory.IsInventory(input))
 
@@ -56,7 +56,7 @@ func TestParseInventory(t *testing.T) {
 }
 
 func TestParseInventoryUngrouped(t *testing.T) {
-	input, err := ioutil.ReadFile("./testdata/ungrouped.json")
+	input, err := os.ReadFile("./testdata/ungrouped.json")
 	assert.Nil(t, err)
 	assert.True(t, ansibleinventory.IsInventory(input))
 
@@ -69,7 +69,7 @@ func TestParseInventoryUngrouped(t *testing.T) {
 }
 
 func TestFullInventory(t *testing.T) {
-	input, err := ioutil.ReadFile("./testdata/inventory.json")
+	input, err := os.ReadFile("./testdata/inventory.json")
 	assert.Nil(t, err)
 	assert.True(t, ansibleinventory.IsInventory(input))
 
@@ -97,7 +97,7 @@ func sortHosts(hosts []*ansibleinventory.Host) {
 }
 
 func TestHostExtraction(t *testing.T) {
-	input, err := ioutil.ReadFile("./testdata/ungrouped.json")
+	input, err := os.ReadFile("./testdata/ungrouped.json")
 	assert.Nil(t, err)
 	assert.True(t, ansibleinventory.IsInventory(input))
 
@@ -142,7 +142,7 @@ func TestHostExtraction(t *testing.T) {
 // convert the ini via
 // ansible-inventory -i integrations/ansibleinventory/testdata/local.ini --list > integrations/ansibleinventory/testdata/local.json
 func TestHostConnectionLocal(t *testing.T) {
-	input, err := ioutil.ReadFile("./testdata/local.json")
+	input, err := os.ReadFile("./testdata/local.json")
 	assert.Nil(t, err)
 	assert.True(t, ansibleinventory.IsInventory(input))
 
@@ -165,7 +165,7 @@ func TestHostConnectionLocal(t *testing.T) {
 
 // yq -y . integrations/ansibleinventory/testdata/local.json
 func TestHostConnectionLocalYaml(t *testing.T) {
-	input, err := ioutil.ReadFile("./testdata/local.yaml")
+	input, err := os.ReadFile("./testdata/local.yaml")
 	assert.Nil(t, err)
 	assert.True(t, ansibleinventory.IsInventory(input))
 
@@ -189,7 +189,7 @@ func TestHostConnectionLocalYaml(t *testing.T) {
 // convert winrm.ini via
 // ansible-inventory -i integrations/ansibleinventory/testdata/windows.ini --list > integrations/ansibleinventory/testdata/windows.json
 func TestHostConnectionWinrm(t *testing.T) {
-	input, err := ioutil.ReadFile("./testdata/winrm.json")
+	input, err := os.ReadFile("./testdata/winrm.json")
 	assert.Nil(t, err)
 	assert.True(t, ansibleinventory.IsInventory(input))
 
@@ -222,7 +222,7 @@ func TestHostConnectionWinrm(t *testing.T) {
 }
 
 func TestHostSSHPrivateKey(t *testing.T) {
-	input, err := ioutil.ReadFile("./testdata/ssh_private_key.json")
+	input, err := os.ReadFile("./testdata/ssh_private_key.json")
 	assert.Nil(t, err)
 	assert.True(t, ansibleinventory.IsInventory(input))
 
@@ -243,7 +243,7 @@ func TestHostSSHPrivateKey(t *testing.T) {
 }
 
 func TestInventoryConversion(t *testing.T) {
-	input, err := ioutil.ReadFile("./testdata/inventory.json")
+	input, err := os.ReadFile("./testdata/inventory.json")
 	assert.Nil(t, err)
 	assert.True(t, ansibleinventory.IsInventory(input))
 
@@ -257,7 +257,7 @@ func TestInventoryConversion(t *testing.T) {
 }
 
 func TestInventoryWithUsernameConversion(t *testing.T) {
-	input, err := ioutil.ReadFile("./testdata/hosts.json")
+	input, err := os.ReadFile("./testdata/hosts.json")
 	assert.Nil(t, err)
 	assert.True(t, ansibleinventory.IsInventory(input))
 
@@ -286,7 +286,7 @@ func TestInventoryWithUsernameConversion(t *testing.T) {
 }
 
 func TestTagsAndGroups(t *testing.T) {
-	input, err := ioutil.ReadFile("./testdata/tags_groups.json")
+	input, err := os.ReadFile("./testdata/tags_groups.json")
 	assert.Nil(t, err)
 	assert.True(t, ansibleinventory.IsInventory(input))
 

--- a/motor/inventory/v1/inventory.go
+++ b/motor/inventory/v1/inventory.go
@@ -1,7 +1,7 @@
 package v1
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/cockroachdb/errors"
@@ -54,7 +54,7 @@ func InventoryFromFile(path string) (*Inventory, error) {
 		return nil, err
 	}
 
-	inventoryData, err := ioutil.ReadFile(absPath)
+	inventoryData, err := os.ReadFile(absPath)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +154,7 @@ func (p *Inventory) PreProcess() error {
 				}
 			}
 
-			data, err := ioutil.ReadFile(path)
+			data, err := os.ReadFile(path)
 			if err != nil {
 				return errors.New("cannot read credential: " + path)
 			}

--- a/motor/motorid/awsec2/metadata_local_test.go
+++ b/motor/motorid/awsec2/metadata_local_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -32,7 +33,7 @@ func fakeConfig() aws.Config {
 }
 
 func TestEC2RoleProviderInstanceIdentityLocal(t *testing.T) {
-	instanceIdentityDocument, err := ioutil.ReadFile("./testdata/instance-identity-document.json")
+	instanceIdentityDocument, err := os.ReadFile("./testdata/instance-identity-document.json")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/motor/providers/gcp/gcloud_config_test.go
+++ b/motor/providers/gcp/gcloud_config_test.go
@@ -2,7 +2,7 @@ package gcp_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,7 +11,7 @@ import (
 )
 
 func TestParseGcloudConfig(t *testing.T) {
-	data, err := ioutil.ReadFile("./testdata/gcloud_config.json")
+	data, err := os.ReadFile("./testdata/gcloud_config.json")
 	require.NoError(t, err)
 
 	config, err := gcp.ParseGcloudConfig(bytes.NewReader(data))

--- a/motor/providers/mock/toml.go
+++ b/motor/providers/mock/toml.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"os"
 
 	"github.com/BurntSushi/toml"
 	"github.com/rs/zerolog/log"
@@ -45,7 +45,7 @@ func Parse(data string) (*TomlData, error) {
 func LoadFile(mock *Provider, path string) error {
 	log.Debug().Str("path", path).Msg("mock> load toml into mock backend")
 
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return errors.New("could not open: " + path)
 	}

--- a/motor/providers/ssh/sftp/sftp_test.go
+++ b/motor/providers/ssh/sftp/sftp_test.go
@@ -41,7 +41,7 @@ type SftpFsContext struct {
 // it should be possible to use $HOME/.ssh/id_rsa to login into the stub sftp server
 func SftpConnect(user, password, host string) (*SftpFsContext, error) {
 	/*
-		pemBytes, err := ioutil.ReadFile(os.Getenv("HOME") + "/.ssh/id_rsa")
+		pemBytes, err := os.ReadFile(os.Getenv("HOME") + "/.ssh/id_rsa")
 		if err != nil {
 			return nil,err
 		}

--- a/motor/vault/credential.go
+++ b/motor/vault/credential.go
@@ -3,7 +3,6 @@ package vault
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -73,7 +72,7 @@ func NewPrivateKeyCredentialFromPath(user string, path string, password string) 
 		return nil, errors.New("private key does not exist " + path)
 	}
 
-	pemBytes, err := ioutil.ReadFile(path)
+	pemBytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/resources/lr/cli/cmd/docs.go
+++ b/resources/lr/cli/cmd/docs.go
@@ -36,7 +36,7 @@ var docsYamlCmd = &cobra.Command{
 	Long:  `parse an LR file and generates a yaml file structure for additional documentation.`,
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		raw, err := ioutil.ReadFile(args[0])
+		raw, err := os.ReadFile(args[0])
 		if err != nil {
 			log.Error().Msg(err.Error())
 			return
@@ -95,7 +95,7 @@ var docsYamlCmd = &cobra.Command{
 		_, err = os.Stat(filepath)
 		if err == nil {
 			log.Info().Msg("load existing data")
-			content, err := ioutil.ReadFile(filepath)
+			content, err := os.ReadFile(filepath)
 			if err != nil {
 				log.Fatal().Err(err).Msg("could not read file " + filepath)
 			}
@@ -217,7 +217,7 @@ var docsJSONCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		file := args[0]
 
-		raw, err := ioutil.ReadFile(file)
+		raw, err := os.ReadFile(file)
 		if err != nil {
 			log.Fatal().Err(err)
 		}

--- a/resources/lr/cli/cmd/parse.go
+++ b/resources/lr/cli/cmd/parse.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -16,7 +16,7 @@ var parseCmd = &cobra.Command{
 	Long:  `parse an LR file and print the AST`,
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		raw, err := ioutil.ReadFile(args[0])
+		raw, err := os.ReadFile(args[0])
 		if err != nil {
 			log.Error().Msg(err.Error())
 			return

--- a/resources/lr/collector.go
+++ b/resources/lr/collector.go
@@ -2,6 +2,7 @@ package lr
 
 import (
 	"io/ioutil"
+	"os"
 	"path"
 	"regexp"
 	"strings"
@@ -51,7 +52,7 @@ func (c *Collector) collect() error {
 		}
 
 		f := path.Join(c.path, file.Name())
-		res, err := ioutil.ReadFile(f)
+		res, err := os.ReadFile(f)
 		if err != nil {
 			return err
 		}

--- a/resources/lr/lr_test.go
+++ b/resources/lr/lr_test.go
@@ -4,7 +4,7 @@
 package lr
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -195,7 +195,7 @@ func TestParseLR(t *testing.T) {
 
 		t.Run(lrPath, func(t *testing.T) {
 			res, err := Resolve(absPath, func(path string) ([]byte, error) {
-				raw, err := ioutil.ReadFile(path)
+				raw, err := os.ReadFile(path)
 				if err != nil {
 					t.Fatal("failed to load " + path + ":" + err.Error())
 				}

--- a/resources/packs/aws/awspolicy/iampolicy_test.go
+++ b/resources/packs/aws/awspolicy/iampolicy_test.go
@@ -2,21 +2,20 @@ package awspolicy
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestIamPolicies(t *testing.T) {
-
 	files := []string{
 		"./testdata/iam_policy1.json",
 		"./testdata/iam_policy2.json",
 	}
 
 	for _, f := range files {
-		data, err := ioutil.ReadFile(f)
+		data, err := os.ReadFile(f)
 		require.NoError(t, err, f)
 
 		var policy IamPolicyDocument

--- a/resources/packs/aws/awspolicy/s3bucketpolicy_test.go
+++ b/resources/packs/aws/awspolicy/s3bucketpolicy_test.go
@@ -2,7 +2,7 @@ package awspolicy
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +10,6 @@ import (
 )
 
 func TestS3BucketPolicies(t *testing.T) {
-
 	files := []string{
 		"./testdata/s3bucket_policy1.json",
 		"./testdata/s3bucket_policy2.json",
@@ -27,7 +26,7 @@ func TestS3BucketPolicies(t *testing.T) {
 	}
 
 	for _, f := range files {
-		data, err := ioutil.ReadFile(f)
+		data, err := os.ReadFile(f)
 		require.NoError(t, err, f)
 
 		var policy S3BucketPolicy
@@ -38,7 +37,7 @@ func TestS3BucketPolicies(t *testing.T) {
 
 func TestPolicyPrincipal(t *testing.T) {
 	f := "./testdata/s3bucket_principal.json"
-	data, err := ioutil.ReadFile(f)
+	data, err := os.ReadFile(f)
 	require.NoError(t, err, f)
 
 	var policy S3BucketPolicy
@@ -46,6 +45,6 @@ func TestPolicyPrincipal(t *testing.T) {
 	require.NoError(t, err, f)
 
 	assert.Equal(t, map[string][]string{
-		"AWS": []string{"*"},
+		"AWS": {"*"},
 	}, policy.Statements[0].Principal.Data())
 }

--- a/resources/packs/os/sshd/params_test.go
+++ b/resources/packs/os/sshd/params_test.go
@@ -1,16 +1,15 @@
 package sshd
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSSHParser(t *testing.T) {
-	raw, err := ioutil.ReadFile("./testdata/sshd_config")
+	raw, err := os.ReadFile("./testdata/sshd_config")
 	require.NoError(t, err)
 
 	sshParams, err := Params(string(raw))
@@ -27,7 +26,7 @@ func TestSSHParser(t *testing.T) {
 }
 
 func TestSSHParseCaseInsensitive(t *testing.T) {
-	raw, err := ioutil.ReadFile("./testdata/case_insensitive")
+	raw, err := os.ReadFile("./testdata/case_insensitive")
 	require.NoError(t, err)
 
 	sshParams, err := Params(string(raw))


### PR DESCRIPTION
replaces the deprecated ioutil.ReadFile method with os.ReadFile

Signed-off-by: Christoph Hartmann <chris@lollyrock.com>