### PR TITLE
🧹 remove debug messages

### DIFF
--- a/apps/cnquery/cmd/plugin.go
+++ b/apps/cnquery/cmd/plugin.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/errors"
 	"github.com/hashicorp/go-plugin"
@@ -134,9 +133,7 @@ func (c *cnqueryPlugin) RunQuery(conf *proto.RunQueryConfig, out shared.OutputHe
 	}
 	defer sh.Close()
 
-	fmt.Printf("%#v\n", conf.Command)
 	code, results, err := sh.RunOnce(conf.Command)
-	fmt.Printf("%#v\n", code)
 	if err != nil {
 		return errors.Wrap(err, "failed to run")
 	}


### PR DESCRIPTION
This ensures we can pipe the json output to tools like jq:

```
cnquery run local -c "sshd.config.params" --json | jq . 
→ discover related assets for 1 asset(s)
→ resolved assets resolved-assets=1
{
  "AcceptEnv": "LANG LC_*",
  "AuthorizedKeysFile": ".ssh/authorized_keys",
  "Subsystem": "sftp /usr/libexec/sftp-server",
  "UsePAM": "yes"
}
```