### PR TITLE
🧹 use coffee for highlighting of md files

### DIFF
--- a/resources/lr/cli/cmd/markdown.go
+++ b/resources/lr/cli/cmd/markdown.go
@@ -287,7 +287,7 @@ func (l *lrSchemaRenderer) renderResourcePage(resource *lr.Resource, schema *res
 			snippet := docs.Snippets[si]
 			builder.WriteString(snippet.Title)
 			builder.WriteString("\n\n")
-			builder.WriteString("```javascript\n")
+			builder.WriteString("```coffee\n")
 			builder.WriteString(strings.TrimSpace(snippet.Query))
 			builder.WriteString("\n```\n\n")
 		}


### PR DESCRIPTION
it doesnt force the prettifier for markdown to add semicolons and also it does a really good job at highlighting mql code (better than graphql imo)

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>