### PR TITLE
🐛 Pass k8s object kind in provider options

### DIFF
--- a/motor/discovery/k8s/asset_data_test.go
+++ b/motor/discovery/k8s/asset_data_test.go
@@ -54,6 +54,7 @@ func TestAssetData(t *testing.T) {
 	assert.Equal(t, "k8s-cronjob", asset.Platform.Name)
 	assert.ElementsMatch(t, []string{"k8s", "k8s-workload"}, asset.Platform.Family)
 	assert.Equal(t, "test123", asset.Labels["k8s.mondoo.com/namespace"])
+	assert.Equal(t, "cronjob", asset.Connections[0].Options["object-kind"])
 }
 
 func TestAssetNodeData(t *testing.T) {
@@ -80,4 +81,5 @@ func TestAssetNodeData(t *testing.T) {
 	assert.Equal(t, "v1", asset.Platform.Version)
 	assert.Equal(t, "k8s-node", asset.Platform.Name)
 	assert.ElementsMatch(t, []string{"k8s"}, asset.Platform.Family)
+	assert.Equal(t, "node", asset.Connections[0].Options["object-kind"])
 }

--- a/motor/providers/k8s/admission_provider.go
+++ b/motor/providers/k8s/admission_provider.go
@@ -17,8 +17,10 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 )
 
-func newAdmissionProvider(data string, selectedResourceID string) (KubernetesProvider, error) {
-	t := &admissionProvider{}
+func newAdmissionProvider(data string, selectedResourceID string, objectKind string) (KubernetesProvider, error) {
+	t := &admissionProvider{
+		objectKind: objectKind,
+	}
 	admission, err := base64.StdEncoding.DecodeString(data)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to decode admission review")
@@ -49,6 +51,7 @@ func newAdmissionProvider(data string, selectedResourceID string) (KubernetesPro
 type admissionProvider struct {
 	manifestParser
 	selectedResourceID string
+	objectKind         string
 }
 
 func (t *admissionProvider) RunCommand(command string) (*os_provider.Command, error) {
@@ -70,7 +73,7 @@ func (t *admissionProvider) Capabilities() providers.Capabilities {
 }
 
 func (t *admissionProvider) PlatformInfo() *platform.Platform {
-	platformData := getPlatformInfo(t.selectedResourceID, t.Runtime())
+	platformData := getPlatformInfo(t.objectKind, t.Runtime())
 	if platformData != nil {
 		return platformData
 	}

--- a/motor/providers/k8s/admission_provider_test.go
+++ b/motor/providers/k8s/admission_provider_test.go
@@ -14,7 +14,7 @@ func TestAdmissionProvider(t *testing.T) {
 	data, err := os.ReadFile(manifestFile)
 	require.NoError(t, err)
 
-	transport, err := newAdmissionProvider(base64.StdEncoding.EncodeToString(data), "")
+	transport, err := newAdmissionProvider(base64.StdEncoding.EncodeToString(data), "", "")
 	require.NoError(t, err)
 	require.NotNil(t, transport)
 	res, err := transport.AdmissionReviews()

--- a/motor/providers/k8s/api_provider.go
+++ b/motor/providers/k8s/api_provider.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/client-go/util/homedir"
 )
 
-func newApiProvider(namespace string, selectedResourceID string, dCache *resources.DiscoveryCache) (KubernetesProvider, error) {
+func newApiProvider(namespace string, objectKind string, selectedResourceID string, dCache *resources.DiscoveryCache) (KubernetesProvider, error) {
 	// check if the user .kube/config file exists
 	// NOTE: BuildConfigFromFlags falls back to cluster loading when .kube/config string is empty
 	// therefore we want to only change the kubeconfig string when the file really exists
@@ -72,6 +72,7 @@ func newApiProvider(namespace string, selectedResourceID string, dCache *resourc
 		d:                  d,
 		clientset:          clientset,
 		selectedResourceID: selectedResourceID,
+		objectKind:         objectKind,
 	}, nil
 }
 
@@ -81,6 +82,7 @@ type apiProvider struct {
 	namespace          string
 	clientset          *kubernetes.Clientset
 	selectedResourceID string
+	objectKind         string
 }
 
 func (t *apiProvider) Close() {}
@@ -227,7 +229,7 @@ func (t *apiProvider) PlatformInfo() *platform.Platform {
 	build := ""
 	arch := ""
 
-	platformData := getPlatformInfo(t.selectedResourceID, t.Runtime())
+	platformData := getPlatformInfo(t.objectKind, t.Runtime())
 	if platformData != nil {
 		return platformData
 	}

--- a/motor/providers/k8s/manifest_provider.go
+++ b/motor/providers/k8s/manifest_provider.go
@@ -37,8 +37,10 @@ func WithManifestFile(filename string) Option {
 	}
 }
 
-func newManifestProvider(selectedResourceID string, opts ...Option) (KubernetesProvider, error) {
-	t := &manifestProvider{}
+func newManifestProvider(selectedResourceID string, objectKind string, opts ...Option) (KubernetesProvider, error) {
+	t := &manifestProvider{
+		objectKind: objectKind,
+	}
 
 	for _, option := range opts {
 		option(t)
@@ -62,6 +64,7 @@ type manifestProvider struct {
 	manifestFile       string
 	namespace          string
 	selectedResourceID string
+	objectKind         string
 }
 
 func (t *manifestProvider) RunCommand(command string) (*os_provider.Command, error) {
@@ -83,7 +86,7 @@ func (t *manifestProvider) Capabilities() providers.Capabilities {
 }
 
 func (t *manifestProvider) PlatformInfo() *platform.Platform {
-	platformData := getPlatformInfo(t.selectedResourceID, t.Runtime())
+	platformData := getPlatformInfo(t.objectKind, t.Runtime())
 	if platformData != nil {
 		return platformData
 	}

--- a/motor/providers/k8s/manifest_provider_test.go
+++ b/motor/providers/k8s/manifest_provider_test.go
@@ -25,7 +25,7 @@ func TestManifestFiles(t *testing.T) {
 	for _, testCase := range tests {
 		t.Run("k8s "+testCase.kind, func(t *testing.T) {
 			manifestFile := "./resources/testdata/" + testCase.kind + ".yaml"
-			transport, err := newManifestProvider("", WithManifestFile(manifestFile))
+			transport, err := newManifestProvider("", testCase.kind, WithManifestFile(manifestFile))
 			require.NoError(t, err)
 			require.NotNil(t, transport)
 			res, err := transport.Resources(testCase.kind, "mondoo", "default")


### PR DESCRIPTION
Parsing this from the platform identifier is problematic because the server can change the platform identifier, as is the case for cicd assets.