### PR TITLE
DRAFT: 🐛 Fail k8s discovery for non-existing namespaces

### DIFF
--- a/motor/discovery/k8s/resolver.go
+++ b/motor/discovery/k8s/resolver.go
@@ -94,7 +94,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 			}
 
 			if !exists {
-				return nil, fmt.Errorf("namespace %s does not exist", namespace)
+				return nil, fmt.Errorf("namespace %s does not exist in cluster", namespace)
 			}
 			namespacesFilter = append(namespacesFilter, namespace)
 		} else {

--- a/motor/discovery/k8s/resolver_test.go
+++ b/motor/discovery/k8s/resolver_test.go
@@ -64,6 +64,26 @@ func TestAdmissionReviewResolver(t *testing.T) {
 	assert.Equal(t, assetList[3].Platform.Runtime, "k8s-admission")
 }
 
+func TestManifestResolverDiscovery_NamespaceDoesNotExist(t *testing.T) {
+	resolver := &Resolver{}
+	manifestFile := "../../providers/k8s/resources/testdata/pod.yaml"
+
+	ctx := resources.SetDiscoveryCache(context.Background(), resources.NewDiscoveryCache())
+
+	_, err := resolver.Resolve(ctx, &asset.Asset{}, &providers.Config{
+		PlatformId: "//platform/k8s/uid/123/namespace/default/pod/name/mondoo",
+		Backend:    providers.ProviderType_K8S,
+		Options: map[string]string{
+			"path":      manifestFile,
+			"namespace": "bogus",
+		},
+		Discover: &providers.Discovery{
+			Targets: []string{"pod"},
+		},
+	}, nil, nil)
+	require.Error(t, err)
+}
+
 func TestManifestResolverDiscoveries(t *testing.T) {
 	testCases := []struct {
 		kind            string


### PR DESCRIPTION
Fail if the namespace filter specifies a namespace that doesn't exist. You can try it with: `cnquery shell k8s --option namespace=bogus`

```
cnquery shell k8s --option namespace=bogus                                          
→ loaded configuration from /Users/ivanmilchev/.config/mondoo/mondoo.yml using source default
→ discover related assets for 1 asset(s)
→ resolved assets resolved-assets=0
x could not connect to asset error="namespace bogus does not exist" asset=
FTL could not resolve assets
```