### PR TITLE
🐛Fix tags filtering for AWS instances.

### DIFF
--- a/motor/discovery/aws/resolver_test.go
+++ b/motor/discovery/aws/resolver_test.go
@@ -30,5 +30,5 @@ func TestAssembleEc2InstancesFilters(t *testing.T) {
 	opts["tags"] = "env=test"
 	f = AssembleEc2InstancesFilters(opts)
 	assert.NotNil(t, f)
-	assert.Equal(t, map[string]string{"tag:env": "test"}, f.Tags)
+	assert.Equal(t, map[string]string{"env": "test"}, f.Tags)
 }


### PR DESCRIPTION
Signed-off-by: Preslav <preslav@mondoo.com>
We already prepend the tags with `tag` here:https://github.com/mondoohq/cnquery/blob/main/motor/discovery/aws/ec2_instances.go#L92

Therefore, until now `dev:dev` would equal to `tag:tag:dev:dev`, this removes the redundant 2nd tag prepending