### PR TITLE
🐛 Fix images being wrongly classified as registries.

### DIFF
--- a/motor/discovery/container_registry/registry.go
+++ b/motor/discovery/container_registry/registry.go
@@ -187,7 +187,7 @@ func (a *DockerRegistryImages) toAsset(ref name.Reference, creds []*vault.Creden
 		Name:        imageUrl,
 		Platform: &platform.Platform{
 			Kind:    providers.Kind_KIND_CONTAINER_IMAGE,
-			Runtime: providers.RUNTIME_DOCKER_REGISTRY,
+			Runtime: providers.RUNTIME_DOCKER_IMAGE,
 		},
 		Connections: []*providers.Config{
 			{

--- a/motor/discovery/k8s/resolver_test.go
+++ b/motor/discovery/k8s/resolver_test.go
@@ -35,7 +35,7 @@ func TestManifestResolver(t *testing.T) {
 	assert.Equal(t, assetList[1].Platform.Name, "k8s-pod")
 	assert.Contains(t, assetList[1].Platform.Family, "k8s-workload")
 	assert.Contains(t, assetList[1].Platform.Family, "k8s")
-	assert.Equal(t, assetList[3].Platform.Runtime, "docker-registry")
+	assert.Equal(t, assetList[3].Platform.Runtime, "docker-image")
 }
 
 func TestAdmissionReviewResolver(t *testing.T) {
@@ -60,7 +60,7 @@ func TestAdmissionReviewResolver(t *testing.T) {
 	assert.Equal(t, assetList[1].Platform.Name, "k8s-pod")
 	assert.Contains(t, assetList[1].Platform.Family, "k8s-workload")
 	assert.Contains(t, assetList[1].Platform.Family, "k8s")
-	assert.Equal(t, assetList[2].Platform.Runtime, "docker-registry")
+	assert.Equal(t, assetList[2].Platform.Runtime, "docker-image")
 	assert.Equal(t, assetList[3].Platform.Runtime, "k8s-admission")
 }
 


### PR DESCRIPTION
Fixes https://gitlab.com/mondoolabs/mondoo/-/issues/1428