### PR TITLE
🐛 Fix FS walkthrough when using cat to read file contents.

### DIFF
--- a/motor/providers/ssh/cat/cat_file.go
+++ b/motor/providers/ssh/cat/cat_file.go
@@ -106,7 +106,7 @@ func (f *File) Readdirnames(n int) (names []string, err error) {
 	if list != nil {
 		// filter . and ..
 		keep := func(x string) bool {
-			if x == "." || x == ".." {
+			if x == "." || x == ".." || x == "" {
 				return false
 			}
 			return true


### PR DESCRIPTION
`ls -1 /proc/sys/fs/binfmt_misc` would return `[]string{ ""}` array as a result. the logic afterwards would append the filename to the dir and do a walkthrough of the files inside. problem is that apending "" `to /proc/sys/fs/binfmt_misc` would still result in `/proc/sys/fs/binfmt_misc`, leading to a never-ending loop.