### PR TITLE
🧹 Revert default k8s auto discovery from resolver

### DIFF
--- a/motor/discovery/k8s/resolver.go
+++ b/motor/discovery/k8s/resolver.go
@@ -204,13 +204,6 @@ func addSeparateAssets(
 	clusterIdentifier string,
 	od *k8s.PlatformIdOwnershipDirectory,
 ) ([]*asset.Asset, error) {
-	// If there is no discovery or there are no targets set the targets to DiscoveryAuto
-	if tc.Discover == nil {
-		tc.Discover = &providers.Discovery{}
-	}
-	if len(tc.Discover.Targets) == 0 {
-		tc.Discover.Targets = []string{DiscoveryAuto}
-	}
 	resolved := []*asset.Asset{}
 
 	// discover deployments


### PR DESCRIPTION
It seems like setting the default behaviour in the resolver causes issues with `cnquery shell` and `cnquery run`. That is because >1 asset is discovered and the user is required to select to which one to connect. This makes the user experience pretty annoying. I will revert the change from the resolver and will set the default options only for `mondoo scan` explicitly since it only makes sense for that case.