### PR TITLE
⭐️ support cnquery run for multiple assets

### DIFF
--- a/cli/printer/mql.go
+++ b/cli/printer/mql.go
@@ -23,8 +23,13 @@ func (print *Printer) Results(bundle *llx.CodeBundle, results map[string]*llx.Ra
 	}
 
 	var res strings.Builder
+	i := 0
 	for _, v := range results {
 		res.WriteString(print.Result(v, bundle, useV2Code))
+		if len(results) > 1 && len(results) != i+1 {
+			res.WriteString("\n")
+		}
+		i++
 	}
 	return res.String()
 }


### PR DESCRIPTION
after #178 

This change brings multi-asset support to `cnquery run` command. Queries are executed for all discovered results.

<img width="1120" alt="Screenshot 2022-10-05 at 16 01 30" src="https://user-images.githubusercontent.com/1178413/194080630-d28cb2f1-2054-4b2a-8b4c-85f1256b1881.png">

<img width="1120" alt="Screenshot 2022-10-05 at 16 13 36" src="https://user-images.githubusercontent.com/1178413/194082508-e1bb2651-a2f6-4c95-9f4d-cc2cfaa00311.png">
