### PR TITLE
🐛 do not jump into the shell for the first asset if the user quits the asset selection

### DIFF
--- a/apps/cnquery/cmd/shell_run.go
+++ b/apps/cnquery/cmd/shell_run.go
@@ -77,6 +77,10 @@ func StartShell(conf *ShellConfig) error {
 		}
 	}
 
+	if connectAsset == nil {
+		log.Fatal().Msg("no asset selected")
+	}
+
 	m, err := provider_resolver.OpenAssetConnection(ctx, connectAsset, im.GetCredential, conf.DoRecord)
 	if err != nil {
 		log.Fatal().Err(err).Msg("could not connect to asset")

--- a/cli/components/assetselect.go
+++ b/cli/components/assetselect.go
@@ -22,7 +22,7 @@ func AssetSelect(assetList []*asset.Asset) *asset.Asset {
 		list[i] = name
 	}
 
-	var selection int
+	selection := -1 // make sure we have an invalid index
 	err := tea.NewProgram(NewListModel("Available assets", list, func(s int) {
 		selection = s
 	})).Start()
@@ -31,6 +31,9 @@ func AssetSelect(assetList []*asset.Asset) *asset.Asset {
 		os.Exit(1)
 	}
 
+	if selection == -1 {
+		return nil
+	}
 	selected := assetList[selection]
 	log.Info().Int("selection", selection).Str("asset", selected.Name).Msg("selected asset")
 	return selected

--- a/cli/components/list.go
+++ b/cli/components/list.go
@@ -69,6 +69,7 @@ func (m listModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch keypress := msg.String(); keypress {
 		case "ctrl+c":
 			m.quitting = true
+			m.selectedHandler(-1)
 			return m, tea.Quit
 
 		case "enter":


### PR DESCRIPTION
With #178 we introduced the ability to allow users to select the asset they want to connect to. While works great, it has handled the case well when the user quits the selection. This change covers this case.

Signed-off-by: Christoph Hartmann <chris@lollyrock.com>