### PR TITLE
🧹 check that generate tasks do not change the code

### DIFF
--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -1,0 +1,37 @@
+name: Generated Code Test
+
+## Only trigger tests if source is changing
+on:
+  push:
+    paths:
+      - '**.proto'
+      - '**.lr'
+      - '**.go'
+
+env:
+  GO_VERSION: 1.19
+  PROTO_VERSION: 21.7
+
+jobs:
+  # Check if there is any dirty change for generated files
+  generated-files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Check generated files
+        # Note we do not use apt install -y protobuf-compiler` since it is too old
+        run: |
+          PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+          curl -LO $PB_REL/download/v${PROTO_VERSION}/protoc-${PROTO_VERSION}-linux-x86_64.zip
+          unzip protoc-${PROTO_VERSION}-linux-x86_64.zip -d $HOME/.local
+          rm protoc-${PROTO_VERSION}-linux-x86_64.zip
+          export PATH="$PATH:$HOME/.local/bin"
+          protoc --version
+          make prep
+          make cnquery/generate
+          git diff --exit-code *.go 


### PR DESCRIPTION
This test was added to prevent missing generated code as happened with #189 

Signed-off-by: Christoph Hartmann <chris@lollyrock.com>