### PR TITLE
🐛 Re-add all-namespaces flag so we do not create a breaking change

### DIFF
--- a/apps/cnquery/cmd/builder/builder.go
+++ b/apps/cnquery/cmd/builder/builder.go
@@ -408,6 +408,7 @@ func kubernetesProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, 
 		},
 	}
 	commonCmdFlags(cmd)
+	cmd.Flags().Bool("all-namespaces", false, "DEPRECATED: list the resources across all namespaces.")
 	cmd.Flags().String("namespace", "", "target a kubernetes namespace")
 	cmd.Flags().String("context", "", "target a kubernetes context")
 	return cmd

--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -223,6 +223,10 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 		} else if namespace != "" {
 			connection.Options["namespace"] = namespace
 		}
+
+		if allNs, _ := cmd.Flags().GetBool("all-namespaces"); allNs {
+			log.Warn().Msg("the --all-namespaces flag is deprecated and will be removed")
+		}
 	case providers.ProviderType_AWS:
 		connection.Backend = providerType
 		if profile, err := cmd.Flags().GetString("profile"); err != nil {


### PR DESCRIPTION
I re-added the `all-namespaces` flag so it doesn't create a breaking change for Mondoo client. I also added a warning when the flag is set so we can notify users that this thing is being deprecated