### PR TITLE
🧹 Get windows code signing working

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -9,9 +9,10 @@ on:
 
 jobs:
   goreleaser:
-    # Add "id-token" for google-github-actions/auth
     permissions:
-      contents: 'read'
+      # Add "contents" to write release
+      contents: 'write'
+      # Add "id-token" for google-github-actions/auth
       id-token: 'write'
 
     runs-on: self-hosted
@@ -30,24 +31,19 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.GCP_WIP }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v0'
-      - name: "Fetch Windows Signing Cert"
-        run: |
-          cert="$(mktemp -t cert.XXX)"
-          # We need to transform the secret which is in base64url encoding to base64 encoding
-          content=$(gcloud secrets versions access latest --secret=mondoo_code_sign_certificate_pfx --format='get(payload.data)' | sed 's|_|/|g; s|-|+|g')
-          base64 -d <<<"$content" > "$cert"
-          echo "CERT_FILE=$cert" >> $GITHUB_ENV
-      - name: "Fetch Windows Signing Cert Challenge"
-        run: |
-          pass=$(gcloud secrets versions access latest --secret=mondoo_code_sign_challenge)
-          echo "CERT_PASS=$pass >> $GITHUB_ENV"
-      - name: Obtain signing cert
+      - id: 'gcp_secrets'
+        uses: 'google-github-actions/get-secretmanager-secrets@v0'
+        with:
+          secrets: |-
+            code_sign_cert_b64:mondoo-base-infra/mondoo_code_sign_certificate_pfx_b64
+            code_sign_cert_challenge:mondoo-base-infra/mondoo_code_sign_challenge
+      - name: "Write Windows Signing Cert"
         run: |
           cert="$(mktemp -t cert.XXX)"
           base64 -d <<<"$CERT_CONTENTS" > "$cert"
           echo "CERT_FILE=$cert" >> $GITHUB_ENV
+        env:
+          CERT_CONTENTS: '${{ steps.gcp_secrets.outputs.code_sign_cert_b64 }}'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
@@ -56,3 +52,4 @@ jobs:
           args: release --rm-dist --timeout 120m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CERT_PASSWORD: ${{ steps.gcp_secrets.outputs.code_sign_cert_challenge }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ file1
 id_rsa
 id_rsa.pub
 mondoo-test-secret-key
+gha-creds-*.json

--- a/scripts/sign-windows-executable.sh
+++ b/scripts/sign-windows-executable.sh
@@ -41,7 +41,7 @@ if [ -z "$CERT_PASSWORD" ]; then
   exit 1
 fi
 
-osslsigncode sign -n "GitHub CLI" -t http://timestamp.digicert.com \
+osslsigncode sign -n "Mondoo cnquery" -t http://timestamp.digicert.com \
   -pkcs12 "$CERT_FILE" -readpass <(printf "%s" "$CERT_PASSWORD") -h sha256 \
   -in "$EXE" -out "$EXE"~
 


### PR DESCRIPTION
- use google-github-actions/get-secretmanager-secrets to help keep secrets masked
- fix up gitignore
- other minor problems like file permissions