### PR TITLE
🐛 fix ms365 pkcs12 authentication and update options for azure

### DIFF
--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -304,7 +304,7 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 		if subscription, err := cmd.Flags().GetString("subscription"); err != nil {
 			log.Fatal().Err(err).Msg("cannot parse --subscription value")
 		} else if subscription != "" {
-			connection.Options["subscriptionID"] = subscription
+			connection.Options["subscription-id"] = subscription
 		}
 	case providers.ProviderType_GCP:
 		connection.Backend = providerType
@@ -418,10 +418,10 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 		}
 
 		if tenantId, err := cmd.Flags().GetString("tenant-id"); err == nil {
-			connection.Options["tenantId"] = tenantId
+			connection.Options["tenant-id"] = tenantId
 		}
 		if clientID, err := cmd.Flags().GetString("client-id"); err == nil {
-			connection.Options["clientId"] = clientID
+			connection.Options["client-id"] = clientID
 		}
 
 		if clientSecret, err := cmd.Flags().GetString("client-secret"); err != nil {
@@ -437,20 +437,19 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 		if certificatepPath, err := cmd.Flags().GetString("certificate-path"); err != nil {
 			log.Fatal().Err(err).Msg("cannot parse --certificate-path value")
 		} else if certificatepPath != "" {
+			if password == "" {
+				certificateSecret, err := cmd.Flags().GetString("certificate-secret")
+				if err != nil {
+					log.Fatal().Err(err).Msg("cannot parse --certificate-secret value")
+				} else {
+					password = certificateSecret
+				}
+			}
 			connection.Credentials = append(connection.Credentials, &vault.Credential{
-				Type:           vault.CredentialType_private_key,
+				Type:           vault.CredentialType_pkcs12,
 				User:           username,
 				PrivateKeyPath: certificatepPath,
-			})
-		}
-
-		if certificateSecret, err := cmd.Flags().GetString("certificate-secret"); err != nil {
-			log.Fatal().Err(err).Msg("cannot parse --certificate-secret value")
-		} else if certificateSecret != "" {
-			connection.Credentials = append(connection.Credentials, &vault.Credential{
-				Type:     vault.CredentialType_password,
-				User:     username,
-				Password: password,
+				Password:       password,
 			})
 		}
 	case providers.ProviderType_HOST:

--- a/motor/discovery/azure/resolver.go
+++ b/motor/discovery/azure/resolver.go
@@ -30,7 +30,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
-	subscriptionID := tc.Options["subscriptionID"]
+	subscriptionID := tc.Options["subscription-id"]
 
 	// TODO: for now we only support the azure cli authentication
 	err := azure_provider.IsAzInstalled()
@@ -57,7 +57,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 	}
 
 	// attach tenant to config
-	tc.Options["tenantID"] = *subscription.TenantID
+	tc.Options["tenant-id"] = *subscription.TenantID
 
 	provider, err := azure_provider.New(tc)
 	if err != nil {

--- a/motor/inventory/v1/inventory.go
+++ b/motor/inventory/v1/inventory.go
@@ -90,6 +90,10 @@ func (p *Inventory) ToYAML() ([]byte, error) {
 // Re-generating yaml, results into a different yaml output. While the results are identical,
 // the yaml file is not.
 func (p *Inventory) PreProcess() error {
+	if p.Spec == nil {
+		p.Spec = &InventorySpec{}
+	}
+
 	if p.Spec.Credentials == nil {
 		p.Spec.Credentials = map[string]*vault.Credential{}
 	}
@@ -159,7 +163,11 @@ func (p *Inventory) PreProcess() error {
 				return errors.New("cannot read credential: " + path)
 			}
 			cred.Secret = data
-			cred.Type = vault.CredentialType_private_key
+
+			// only set the credential type if it is not set, pkcs12 also uses the private key path
+			if cred.Type == vault.CredentialType_undefined {
+				cred.Type = vault.CredentialType_private_key
+			}
 		}
 	}
 	return nil

--- a/motor/vault/credential.go
+++ b/motor/vault/credential.go
@@ -14,7 +14,9 @@ func (cred *Credential) PreProcess() {
 	if cred.PrivateKey != "" {
 		cred.Secret = []byte(cred.PrivateKey)
 		cred.PrivateKey = ""
-		cred.Type = CredentialType_private_key
+		if cred.Type == CredentialType_undefined {
+			cred.Type = CredentialType_private_key
+		}
 	}
 
 	// NOTE: it is possible that private keys hold an additional password, therefore we only


### PR DESCRIPTION
@atomic111 reported an issue with certificate authentication for Microsoft 365. This fixes the case credentials have been not handled correctly internally. Tests have been added to ensure this does not happen again.

In addition I used this opportunity to clean up a few bits:

- update ms365 dependency
- harmonize azure and ms365 options for inventory (with fallback for old properties)