### PR TITLE
⭐️ cnquery bundle subcommand to create a query pack and to validate a pack

### DIFF
--- a/apps/cnquery/cmd/bundle.go
+++ b/apps/cnquery/cmd/bundle.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"context"
+	_ "embed"
+	"os"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"go.mondoo.com/cnquery/explorer"
+)
+
+func init() {
+	// bundle init
+	packBundlesCmd.AddCommand(queryPackInitCmd)
+
+	// bundle validate
+	packBundlesCmd.AddCommand(queryPackValidateCmd)
+
+	rootCmd.AddCommand(packBundlesCmd)
+}
+
+var packBundlesCmd = &cobra.Command{
+	Use:   "bundle",
+	Short: "Manage query packs",
+}
+
+//go:embed bundle_querypack-example.mql.yaml
+var embedQueryPackTemplate []byte
+
+var queryPackInitCmd = &cobra.Command{
+	Use:   "init [path]",
+	Short: "Creates an example query pack that can be used as a starting point. If no filename is provided, `example-pack.mql.yaml` us used",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		name := "example-pack.mql.yaml"
+		if len(args) == 1 {
+			name = args[0]
+		}
+
+		_, err := os.Stat(name)
+		if err == nil {
+			log.Fatal().Msgf("Query Pack '%s' already exists", name)
+		}
+
+		err = os.WriteFile(name, embedQueryPackTemplate, 0o640)
+		if err != nil {
+			log.Fatal().Err(err).Msgf("Could not write '%s'", name)
+		}
+		log.Info().Msgf("Example query pack file written to %s", name)
+	},
+}
+
+var queryPackValidateCmd = &cobra.Command{
+	Use:   "validate [path]",
+	Short: "Validates a query pack",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		log.Info().Str("file", args[0]).Msg("validate query pack")
+		pack, err := explorer.BundleFromPaths(args[0])
+		if err != nil {
+			log.Fatal().Err(err).Msg("could not load query pack")
+		}
+
+		_, err = pack.Compile(context.Background())
+		if err != nil {
+			log.Fatal().Err(err).Msg("could not validate query pack")
+		}
+		log.Info().Msg("valid query pack")
+	},
+}

--- a/apps/cnquery/cmd/bundle_querypack-example.mql.yaml
+++ b/apps/cnquery/cmd/bundle_querypack-example.mql.yaml
@@ -1,0 +1,31 @@
+# Read more about the policy structure at https://mondoo.com/docs/platform/policies/overview
+policies:
+  - uid: sshd-server-policy
+    name: SSH Server Policy
+    version: "1.0.0"
+    authors:
+      - name: Jane Doe
+        email: jane@example.com
+    tags:
+      key: value
+      another-key: another-value
+    specs:
+      - asset_filter:
+          query: platform.family.contains(_ == 'unix')
+        scoring_queries:
+          sshd-score-01:
+queries:
+  - uid: sshd-score-01
+    title: Ensure SSH MaxAuthTries is set to 4 or less
+    query: sshd.config.params["MaxAuthTries"] <= 4
+    docs:
+      desc: |
+        The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection.
+        When the login failure count reaches half the number, error messages will be written to the syslog file
+        detailing the login failure.
+      audit: Run the `sshd -T | grep maxauthtries` command and verify that output MaxAuthTries is 4 or less
+      remediation: |
+        Open your `/etc/ssh/sshd_config` and set `MaxAuthTries` to `4`.
+    refs:
+      - title: CIS Distribution Independent Linux
+        url: https://www.cisecurity.org/benchmark/distribution_independent_linux/


### PR DESCRIPTION
```bash
cnquery bundle init 
→ Example query pack file written to example-pack.mql.yaml

cnquery bundle validate example-pack.mql.yaml
→ validate query pack file=example-pack.mql.yaml
→ valid query pack
```

Signed-off-by: Christoph Hartmann <chris@lollyrock.com>