### PR TITLE
🐛 ensure a missing keypair does not block the ec2 instances results

### DIFF
--- a/resources/packs/aws/aws_ec2.go
+++ b/resources/packs/aws/aws_ec2.go
@@ -732,10 +732,11 @@ func (s *mqlAwsEc2) gatherInstanceInfo(instances []types.Reservation, imdsvVersi
 					"name", core.ToString(instance.KeyName),
 				)
 				if err != nil {
-					return nil, err
+					log.Error().Err(err).Msg(fmt.Sprintf("unable to retrieve ec2 instance keypair with name %s in region %s", core.ToString(instance.KeyName), regionVal))
+				} else {
+					mqlKp := mqlKeyPair.(AwsEc2Keypair)
+					args = append(args, "keypair", mqlKp)
 				}
-				mqlKp := mqlKeyPair.(AwsEc2Keypair)
-				args = append(args, "keypair", mqlKp)
 			}
 
 			mqlEc2Instance, err := s.MotorRuntime.CreateResource("aws.ec2.instance", args...)


### PR DESCRIPTION
fixes https://github.com/mondoohq/client/issues/195

with released mondoo vs on this branch
```
[failed] aws.ec2.instances
  error: job err: : failed to create resource 'aws.ec2.keypair': operation error EC2: DescribeKeyPairs, https response error StatusCode: 400, RequestID: 4157ef6a-8964-4be1-8a0b-a5b5c86c2a47, api error InvalidKeyPair.NotFound: The key pair 'badone' does not exist

mondoo> exit

~/go/src/go.mondoo.io/mondoo vj/fixes* 23s
[10/10/22 16:44:21] ❯ AWS_PROFILE="vvdefault" DEBUG=1 m shell aws -c aws.ec2.instances
→ loaded configuration from /Users/vj/.config/mondoo/mondoo.yml using source default
→ discover related assets for 1 asset(s)
→ resolved assets resolved-assets=1
                        .-.
                        : :
,-.,-.,-. .--. ,-.,-. .-' : .--.  .--. ™
: ,. ,. :' .; :: ,. :' .; :' .; :' .; :
:_;:_;:_;`.__.':_;:_;`.__.'`.__.'`.__.'  interactive shell

aws.ec2.instances: [
  0: aws.ec2.instance id = arn:aws:ec2:us-east-1:921877552404:instance/i-06e2...
  1: aws.ec2.instance id = arn:aws:ec2:us-east-1:921877552404:instance/i-07ea...
  2: aws.ec2.instance id = arn:aws:ec2:us-east-1:921877552404:instance/i-0387...
  3: aws.ec2.instance id = arn:aws:ec2:us-east-1:921877552404:instance/i-0facc...
  4: aws.ec2.instance id = arn:aws:ec2:us-east-1:921877552404:instance/i-0b244...
  5: aws.ec2.instance id = arn:aws:ec2:us-east-2:921877552404:instance/i-056da31e...
  6: aws.ec2.instance id = arn:aws:ec2:us-east-2:921877552404:instance/i-0ce00f...
  7: aws.ec2.instance id = arn:aws:ec2:us-east-2:921877552404:instance/i-0e5a7...
  8: aws.ec2.instance id = arn:aws:ec2:us-east-2:921877552404:instance/i-0f761e...
  9: aws.ec2.instance id = arn:aws:ec2:us-west-1:921877552404:instance/i-020ee...
]
mondoo> exit
```