### PR TITLE
🛑 Change k8s cluster platform name from "kubernetes" to "k8s-cluster"

### DIFF
--- a/motor/providers/k8s/api_provider.go
+++ b/motor/providers/k8s/api_provider.go
@@ -243,13 +243,13 @@ func (t *apiProvider) PlatformInfo() *platform.Platform {
 	}
 
 	return &platform.Platform{
-		Name:    "kubernetes",
-		Title:   "Kubernetes",
+		Name:    "k8s-cluster",
+		Title:   "Kubernetes Cluster",
 		Release: release,
 		Version: release,
 		Build:   build,
 		Arch:    arch,
-		Family:  []string{"kubernetes"},
+		Family:  []string{"k8s"},
 		Kind:    providers.Kind_KIND_API,
 		Runtime: providers.RUNTIME_KUBERNETES_CLUSTER,
 	}

--- a/motor/providers/k8s/manifest_provider.go
+++ b/motor/providers/k8s/manifest_provider.go
@@ -92,10 +92,10 @@ func (t *manifestProvider) PlatformInfo() *platform.Platform {
 	}
 
 	return &platform.Platform{
-		Name:    "kubernetes",
+		Name:    "k8s-cluster",
 		Title:   "Kubernetes Manifest",
 		Kind:    t.Kind(),
-		Family:  []string{"kubernetes"},
+		Family:  []string{"k8s"},
 		Runtime: t.Runtime(),
 	}
 }

--- a/motor/providers/k8s/manifest_provider_test.go
+++ b/motor/providers/k8s/manifest_provider_test.go
@@ -54,9 +54,9 @@ func TestManifestFileProvider(t *testing.T) {
 		transport, err := newManifestProvider("", "", WithManifestFile(manifestFile))
 		require.NoError(t, err)
 		require.NotNil(t, transport)
-		assert.Equal(t, "kubernetes", transport.PlatformInfo().Name)
+		assert.Equal(t, "k8s-cluster", transport.PlatformInfo().Name)
 		assert.Equal(t, "k8s-manifest", transport.PlatformInfo().Runtime)
 		assert.Equal(t, providers.Kind_KIND_CODE, transport.PlatformInfo().Kind)
-		assert.Contains(t, transport.PlatformInfo().Family, "kubernetes")
+		assert.Contains(t, transport.PlatformInfo().Family, "k8s")
 	})
 }


### PR DESCRIPTION
Fixes #214

Signed-off-by: Christian Zunker <christian@mondoo.com>