### PR TITLE
⭐️ markdown cli docs generator

### DIFF
--- a/apps/cnquery/cmd/root.go
+++ b/apps/cnquery/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
 	"github.com/spf13/viper"
 	"go.mondoo.com/cnquery"
 	"go.mondoo.com/cnquery/cli/config"
@@ -141,4 +142,13 @@ func sysInfoHeader(sysInfo *sysinfo.SystemInfo, features cnquery.Features) range
 	h.Set(HttpHeaderClientFeatures, features.Encode())
 	h.Set(HttpHeaderPlatformID, sysInfo.PlatformId)
 	return scope.NewCustomHeaderRangerPlugin(h)
+}
+
+func GenerateMarkdown(dir string) error {
+	rootCmd.DisableAutoGenTag = true
+
+	// We need to remove our fancy logo from the markdown output,
+	// since it messes with the formatting.
+	rootCmd.Long = rootCmdDesc
+	return doc.GenMarkdownTree(rootCmd, dir)
 }

--- a/apps/gen-docs/main.go
+++ b/apps/gen-docs/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"os"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/pflag"
+	"go.mondoo.com/cnquery/apps/cnquery/cmd"
+)
+
+func main() {
+	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+	dir := flags.String("docs-path", "", "Path directory where you want to generate doc files")
+
+	if err := flags.Parse(os.Args); err != nil {
+		log.Fatal().Err(err).Msg("error: could not parse flags")
+	}
+
+	if *dir == "" {
+		log.Fatal().Msg("--docs-path is required")
+	}
+
+	err := cmd.GenerateMarkdown(*dir)
+	if err != nil {
+		log.Fatal().Err(err).Msg("could not generate markdown")
+	}
+}

--- a/cli/reporter/print.go
+++ b/cli/reporter/print.go
@@ -1,6 +1,7 @@
 package reporter
 
 import (
+	"sort"
 	"strings"
 )
 
@@ -36,5 +37,8 @@ func AllFormats() string {
 			res = append(res, k)
 		}
 	}
+
+	// ensure the order is always the same
+	sort.Strings(res)
 	return strings.Join(res, ", ")
 }

--- a/go.mod
+++ b/go.mod
@@ -122,6 +122,7 @@ require (
 	github.com/sethvargo/go-password v0.2.0
 	github.com/spf13/afero v1.9.2
 	github.com/spf13/cobra v1.5.0
+	github.com/spf13/pflag v1.0.6-0.20201009195203-85dd5c8bc61c
 	github.com/spf13/viper v1.13.0
 	github.com/stretchr/testify v1.8.0
 	github.com/toravir/csd v0.0.0-20200911003203-13ae77ad849c
@@ -217,6 +218,7 @@ require (
 	github.com/cockroachdb/redact v1.1.3 // indirect
 	github.com/containerd/console v1.0.3 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.12.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/creack/pty v1.1.11 // indirect
 	github.com/curioswitch/go-reassign v0.1.2 // indirect
 	github.com/daixiang0/gci v0.7.0 // indirect
@@ -387,6 +389,7 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/rivo/uniseg v0.3.4 // indirect
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ryancurrah/gomodguard v1.2.4 // indirect
 	github.com/ryanrolds/sqlclosecheck v0.3.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
@@ -406,7 +409,6 @@ require (
 	github.com/sourcegraph/go-diff v0.6.1 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.6-0.20201009195203-85dd5c8bc61c // indirect
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.1.1 // indirect
 	github.com/stretchr/objx v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -413,6 +413,7 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -1373,6 +1374,7 @@ github.com/rs/zerolog v1.28.0/go.mod h1:NILgTygv/Uej1ra5XxGf82ZFSLk58MFGAUS2o6us
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryancurrah/gomodguard v1.2.3/go.mod h1:rYbA/4Tg5c54mV1sv4sQTP5WOPBcoLtnBZ7/TEhXAbg=
 github.com/ryancurrah/gomodguard v1.2.4 h1:CpMSDKan0LtNGGhPrvupAoLeObRFjND8/tU1rEOtBp4=


### PR DESCRIPTION
allows you to generate the cli docs:

```
go run apps/gen-docs/main.go --docs-path path/docs/cli
```

Signed-off-by: Christoph Hartmann <chris@lollyrock.com>