### PR TITLE
🛑⭐ restructure JSON output

### DIFF
--- a/llx/rawdata_json.go
+++ b/llx/rawdata_json.go
@@ -402,8 +402,22 @@ func rawDataJSON(typ types.Type, data interface{}, codeID string, bundle *CodeBu
 	}
 }
 
+func JSONerror(err error) []byte {
+	return []byte("{\"error\":" + string2json(err.Error()) + "}")
+}
+
 func (r *RawData) JSON(codeID string, bundle *CodeBundle) []byte {
+	if r.Value == nil && r.Error != nil {
+		return JSONerror(r.Error)
+	}
+
 	var res bytes.Buffer
 	rawDataJSON(r.Type, r.Value, codeID, bundle, &res)
 	return res.Bytes()
+}
+
+func (r *RawData) JSONfield(codeID string, bundle *CodeBundle) []byte {
+	label := label(codeID, bundle, true)
+	value := r.JSON(codeID, bundle)
+	return []byte(string2json(label) + ":" + string(value))
 }


### PR DESCRIPTION
1. We used to conditionally create a list of entries for every entrypoint in a query. But this only happened when there were more than 1 entry. This conditional handling creates inconsistencies for the output. It also looses all information about the query that produced it (eg users.list in the example) and it prevents us from attaching more meta-information (since it's just a list item and not structured). So, go for structured info. This is a breaking change.

2. Errors tend to eat up all available JSON output. Try to provide as much output as possible and give access to errors inside of it. There are multiple follow-ups here like aggregating errors (see the point above) and giving structured errors instead of strings in the appropriate fields (which allows for way easier checking ie type == object and field == error)

Given

```
cnquery run local -c "users.list{*}" -j | jq .
```

OLD output

![image](https://user-images.githubusercontent.com/1307529/195475137-9188f1e4-006d-4940-a132-fc9095f2fd39.png)

NEW output

![image](https://user-images.githubusercontent.com/1307529/195475226-93de140b-4f0b-40c5-a1a6-1aeefe30496e.png)


Signed-off-by: Dominik Richter <dominik.richter@gmail.com>