### PR TITLE
⭐ explore report --json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -58,7 +58,7 @@
         "explore",
         "local",
         "-f",
-        "./examples/example.mql.yaml"
+        "./examples/example.unix.mql.yaml"
       ],
     }
   ]

--- a/apps/cnquery/cmd/explore.go
+++ b/apps/cnquery/cmd/explore.go
@@ -253,6 +253,7 @@ This example connects to Microsoft 365 using the PKCS #12 formatted certificate:
 
 		// output rendering
 		cmd.Flags().StringP("output", "o", "compact", "set output format: "+reporter.AllFormats())
+		cmd.Flags().BoolP("json", "j", false, "set output to JSON (shorthand)")
 		cmd.Flags().Bool("no-pager", false, "disable interactive scan output pagination")
 		cmd.Flags().String("pager", "", "enable scan output pagination with custom pagination command. default is 'less -R'")
 	},
@@ -356,6 +357,12 @@ func getCobraScanConfig(cmd *cobra.Command, args []string, provider providers.Pr
 		fmt.Println("Available output formats: " + reporter.AllFormats())
 		os.Exit(0)
 	}
+
+	// --json takes precedence
+	if ok, _ := cmd.Flags().GetBool("json"); ok {
+		output = "json"
+	}
+	conf.Output = output
 
 	// check if the user used --password without a value
 	askPass, err := cmd.Flags().GetBool("ask-pass")

--- a/cli/reporter/json.go
+++ b/cli/reporter/json.go
@@ -1,0 +1,110 @@
+package reporter
+
+import (
+	"encoding/json"
+	"errors"
+
+	"go.mondoo.com/cnquery/explorer"
+	"go.mondoo.com/cnquery/llx"
+	"go.mondoo.com/cnquery/shared"
+)
+
+func BundleResultsToJSON(code *llx.CodeBundle, results map[string]*llx.RawResult, out shared.OutputHelper) error {
+	var checksums []string
+	eps := code.CodeV2.Entrypoints()
+	checksums = make([]string, len(eps))
+	for i, ref := range eps {
+		checksums[i] = code.CodeV2.Checksums[ref]
+	}
+
+	// since we iterate over checksums, we run into the situation that this could be a slice
+	// eg. cnquery run k8s --query "platform { name } k8s.pod.name" --json
+
+	out.WriteString("{")
+
+	for j, checksum := range checksums {
+		result := results[checksum]
+		if result == nil {
+			llx.JSONerror(errors.New("cannot find result for this query"))
+		} else {
+			jsonData := result.Data.JSONfield(checksum, code)
+			out.Write(jsonData)
+		}
+
+		if len(checksums) != j+1 {
+			out.WriteString(",")
+		}
+	}
+
+	out.WriteString("}")
+
+	return nil
+}
+
+func ReportCollectionToJSON(data *explorer.ReportCollection, out shared.OutputHelper) error {
+	if data == nil {
+		return nil
+	}
+
+	queryMrnIdx := map[string]string{}
+	for i := range data.Bundle.Packs {
+		pack := data.Bundle.Packs[i]
+		for j := range pack.Queries {
+			query := pack.Queries[j]
+			queryMrnIdx[query.CodeId] = query.Mrn
+		}
+	}
+
+	out.WriteString(
+		"{" +
+			"\"assets\":")
+	assets, err := json.Marshal(data.Assets)
+	if err != nil {
+		return err
+	}
+	out.WriteString(string(assets))
+
+	out.WriteString("," +
+		"\"data\":" +
+		"{")
+	pre := ""
+	for id, report := range data.Reports {
+		out.WriteString(pre + llx.PrettyPrintString(id) + ":{")
+		pre = ","
+
+		resolved, ok := data.Resolved[id]
+		if !ok {
+			return errors.New("cannot find resolved pack for " + id + " in report")
+		}
+
+		results := report.RawResults()
+		pre2 := ""
+		for qid, query := range resolved.ExecutionJob.Queries {
+			printID := queryMrnIdx[qid]
+			if printID == "" {
+				printID = qid
+			}
+
+			out.WriteString(pre2 + llx.PrettyPrintString(printID) + ":")
+			pre2 = ","
+
+			err := BundleResultsToJSON(query.Code, results, out)
+			if err != nil {
+				return err
+			}
+		}
+		out.WriteString("}")
+	}
+
+	out.WriteString("}," +
+		"\"errors\":" +
+		"{")
+	pre = ""
+	for id, err := range data.Errors {
+		out.WriteString(pre + llx.PrettyPrintString(id) + ":" + llx.PrettyPrintString(err))
+		pre = ","
+	}
+	out.WriteString("}}")
+
+	return nil
+}

--- a/cli/reporter/reporter.go
+++ b/cli/reporter/reporter.go
@@ -8,6 +8,7 @@ import (
 	"go.mondoo.com/cnquery/cli/printer"
 	"go.mondoo.com/cnquery/cli/theme/colors"
 	"go.mondoo.com/cnquery/explorer"
+	"go.mondoo.com/cnquery/shared"
 )
 
 type Reporter struct {
@@ -62,8 +63,9 @@ func (r *Reporter) Print(data *explorer.ReportCollection, out io.Writer) error {
 			data:      data,
 		}
 		return rr.print()
-	// case JSON:
-	// 	res, err = data.ToJSON()
+	case JSON:
+		w := shared.IOWriter{Writer: out}
+		return ReportCollectionToJSON(data, &w)
 	// case CSV:
 	// 	res, err = data.ToCsv()
 	default:


### PR DESCRIPTION
Introduces a custom printer to create reports. It doesn't just take the raw data and dump it all to CLI, but instead carefully constructs a JSON representation of the report that is useful for further processing. It contains MRNs for queries, eliminates pesky lookups, and nicely aggregates data.

![image](https://user-images.githubusercontent.com/1307529/195787255-3c581e58-d878-47b5-8e59-c12ebb9ba04e.png)


Features 3 fields on the top level: assets (for quick lookup and aggregation), reports (for all the data) and errors (for error aggregation).

Unlike `json.Marshal` it doesn't dump any compiled code, doesn't dump the resolved pack, and doesn't force lookups of all data fields.


Signed-off-by: Dominik Richter <dominik.richter@gmail.com>