### PR TITLE
🐛 fix missing metadata from autocomplete

### DIFF
--- a/mqlc/builtin.go
+++ b/mqlc/builtin.go
@@ -155,6 +155,15 @@ func publicFieldsInfo(c *compiler, resourceInfo *resources.ResourceInfo) map[str
 			if !child.HasEmptyInit() {
 				continue
 			}
+
+			// implicit resources don't have their own metadata, so we grab it from
+			// the resource itself
+			res[k] = llx.Documentation{
+				Field: k,
+				Title: child.Title,
+				Desc:  child.Desc,
+			}
+			continue
 		}
 
 		res[k] = llx.Documentation{

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -1526,6 +1526,13 @@ func TestSuggestions(t *testing.T) {
 	}
 }
 
+func TestImplicitSuggestion(t *testing.T) {
+	res, _ := Compile("sshd.", schema, features, nil)
+	require.NotEmpty(t, res.Suggestions)
+
+	assert.Equal(t, "SSH server configuration", res.Suggestions[0].Title)
+}
+
 func TestCompiler_Error(t *testing.T) {
 	t.Run("unknown term", func(t *testing.T) {
 		_, err := Compile("sshd.config.params == enabled", schema, features, nil)


### PR DESCRIPTION
Finally getting those descriptions for shadowed resources:

BEFORE

![image](https://user-images.githubusercontent.com/1307529/195821977-a1e3344d-15fc-4b03-b6ec-28dba5109742.png)

AFTER

![image](https://user-images.githubusercontent.com/1307529/195821149-f59a4ced-a6bb-4e36-80ea-49c0b05651af.png)

Fixes #215

Something is off with sorting on those child fields, i may have another PR coming

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>