### PR TITLE
🐛 properly sort suggestions with matching prefix or empty

### DIFF
--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -133,7 +133,8 @@ func findFuzzy(name string, names []string) fuzzy.Ranks {
 		ha := strings.HasPrefix(a.Target, name)
 		hb := strings.HasPrefix(b.Target, name)
 		if ha && hb {
-			return a.Distance < b.Distance
+			// here it's just going by order, because it has the prefix
+			return a.Target < b.Target
 		}
 		if ha {
 			return true
@@ -141,6 +142,7 @@ func findFuzzy(name string, names []string) fuzzy.Ranks {
 		if hb {
 			return false
 		}
+		// unlike here where we sort by fuzzy distance
 		return a.Distance < b.Distance
 	})
 


### PR DESCRIPTION
It was off when we have the same prefix as seen:

![image](https://user-images.githubusercontent.com/1307529/195822445-38dca3a3-16da-44a1-b90d-e465e9520628.png)

Here we want to sort alphabetically, since fuzzy isn't needed for this:

![image](https://user-images.githubusercontent.com/1307529/195822588-71467112-1b71-4462-94d3-e6c779fa8247.png)

This has the beautiful side-effect that it also fixes the edge-case where we don't type anything in, since everything is prefixed by empty string ;)

![image](https://user-images.githubusercontent.com/1307529/195822713-238913df-4c46-4b16-9ad6-1ed5419bdeaf.png)
