### PR TITLE
🛑⭐ access resource lists without calling `list`

### DIFF
--- a/llx/code.go
+++ b/llx/code.go
@@ -19,6 +19,15 @@ func (b *Block) TailRef(blockRef uint64) uint64 {
 	return absRef(blockRef, b.ChunkIndex())
 }
 
+func (b *Block) ReplaceEntrypoint(old uint64, nu uint64) {
+	for i := range b.Entrypoints {
+		if b.Entrypoints[i] == old {
+			b.Entrypoints[i] = nu
+			return
+		}
+	}
+}
+
 // LastChunk is the last chunk in the list or nil
 func (b *Block) LastChunk() *Chunk {
 	max := len(b.Chunks)

--- a/llx/types.go
+++ b/llx/types.go
@@ -22,6 +22,14 @@ func (c *Chunk) Type() types.Type {
 		return types.Type(c.Primitive.Type)
 	}
 
+	// Chunks that don't have a function call but do have an ID are resources.
+	// They are bound globally (because otherwise they'd have a function) and
+	// they are not primitive (we eliminate those above). They could still be
+	// global non-functions, but we need to investigate that case.
+	if c.Id != "" {
+		return types.Resource(c.Id)
+	}
+
 	return types.Any
 }
 

--- a/mqlc/builtin.go
+++ b/mqlc/builtin.go
@@ -142,6 +142,11 @@ func builtinFunction(typ types.Type, id string) (*compileHandler, error) {
 	return nil, errors.New("cannot find function '" + id + "' for type '" + typ.Label() + "' during compile")
 }
 
+// Compile calls to builtin type handlers, that aren't mapped via builtin
+// functions above. Typically only used if we need to go deeper into the given
+// type to figure out what to do. For example: list resources are just
+// resource types, so we can't tell if there are builtin functions without
+// detecting that we are looking at a list resource.
 func (c *compiler) compileImplicitBuiltin(typ types.Type, id string) (*compileHandler, *variable, error) {
 	if !typ.IsResource() {
 		return nil, nil, nil

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -1017,7 +1017,7 @@ func TestCompiler_ArrayResourceFieldGlob(t *testing.T) {
 		assertFunction(t, "groups", nil, res.CodeV2.Blocks[0].Chunks[0])
 		assertFunction(t, "list", &llx.Function{
 			Binding: (1 << 32) | 1,
-			Type:    string(types.Resource("group")),
+			Type:    string(types.Array(types.Resource("group"))),
 		}, res.CodeV2.Blocks[0].Chunks[1])
 		assertFunction(t, "{}", &llx.Function{
 			Type:    string(types.Block),
@@ -1298,7 +1298,7 @@ func TestCompiler_CallWithResource(t *testing.T) {
 		assertFunction(t, "users", nil, res.CodeV2.Blocks[0].Chunks[0])
 		assertFunction(t, "list", &llx.Function{
 			Binding: (1 << 32) | 1,
-			Type:    string(types.Resource("user")),
+			Type:    string(types.Array(types.Resource("user"))),
 		}, res.CodeV2.Blocks[0].Chunks[1])
 		assertFunction(t, "{}", &llx.Function{
 			Type:    string(types.Block),
@@ -1331,7 +1331,7 @@ func TestCompiler_List(t *testing.T) {
 		assertFunction(t, "packages", nil, res.CodeV2.Blocks[0].Chunks[0])
 		assertFunction(t, "list", &llx.Function{
 			Binding: (1 << 32) | 1,
-			Type:    string(types.Resource("package")),
+			Type:    string(types.Array(types.Resource("package"))),
 		}, res.CodeV2.Blocks[0].Chunks[1])
 		assertFunction(t, "{}", &llx.Function{
 			Type:    string(types.Block),
@@ -1354,7 +1354,12 @@ func TestCompiler_List(t *testing.T) {
 func TestCompiler_ResourceEmptyWhere(t *testing.T) {
 	compileT(t, "packages.where()", func(res *llx.CodeBundle) {
 		assertFunction(t, "packages", nil, res.CodeV2.Blocks[0].Chunks[0])
-		assert.Equal(t, 1, len(res.CodeV2.Blocks[0].Chunks))
+		assert.Len(t, res.CodeV2.Blocks[0].Chunks, 2)
+		assertFunction(t, "packages", nil, res.CodeV2.Blocks[0].Chunks[0])
+		assertFunction(t, "list", &llx.Function{
+			Binding: (1 << 32) | 1,
+			Type:    string(types.Array(types.Resource("package"))),
+		}, res.CodeV2.Blocks[0].Chunks[1])
 	})
 }
 

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -916,7 +916,42 @@ func TestCompiler_ResourceMapLength(t *testing.T) {
 	})
 }
 
-func TestCompiler_ResourceArrayAccessor(t *testing.T) {
+func TestCompiler_ArrayResource(t *testing.T) {
+	var cmd string
+
+	cmd = "packages[123]"
+	t.Run(cmd, func(t *testing.T) {
+		compileT(t, cmd, func(res *llx.CodeBundle) {
+			assertFunction(t, "list", &llx.Function{
+				Binding: (1 << 32) | 1,
+				Args:    nil,
+				Type:    string(types.Array(types.Resource("package"))),
+			}, res.CodeV2.Blocks[0].Chunks[1])
+			assertFunction(t, "[]", &llx.Function{
+				Binding: (1 << 32) | 2,
+				Args:    []*llx.Primitive{llx.IntPrimitive(123)},
+				Type:    string(types.Resource("package")),
+			}, res.CodeV2.Blocks[0].Chunks[2])
+		})
+	})
+
+	cmd = "packages.length"
+	t.Run(cmd, func(t *testing.T) {
+		compileT(t, cmd, func(res *llx.CodeBundle) {
+			assertFunction(t, "list", &llx.Function{
+				Binding: (1 << 32) | 1,
+				Args:    nil,
+				Type:    string(types.Array(types.Resource("package"))),
+			}, res.CodeV2.Blocks[0].Chunks[1])
+			assertFunction(t, "length", &llx.Function{
+				Binding: (1 << 32) | 1,
+				Args:    []*llx.Primitive{llx.RefPrimitiveV2((1 << 32) | 2)},
+				Type:    string(types.Int),
+			}, res.CodeV2.Blocks[0].Chunks[2])
+		})
+	})
+
+	// FIXME: DEPRECATED, remove in v8.0 vv
 	compileT(t, "packages.list[123]", func(res *llx.CodeBundle) {
 		assertFunction(t, "[]", &llx.Function{
 			Binding: (1 << 32) | 2,
@@ -924,29 +959,18 @@ func TestCompiler_ResourceArrayAccessor(t *testing.T) {
 			Type:    string(types.Resource("package")),
 		}, res.CodeV2.Blocks[0].Chunks[2])
 	})
-}
 
-func TestCompiler_ResourceArrayLength(t *testing.T) {
 	compileT(t, "packages.list.length", func(res *llx.CodeBundle) {
-		assertFunction(t, "length", &llx.Function{
-			Binding: (1 << 32) | 2,
-			Type:    string(types.Int),
-		}, res.CodeV2.Blocks[0].Chunks[2])
-	})
-}
-
-func TestCompiler_ResourceArrayImplicitLength(t *testing.T) {
-	compileT(t, "packages.length", func(res *llx.CodeBundle) {
 		assertFunction(t, "list", &llx.Function{
 			Binding: (1 << 32) | 1,
 			Type:    string(types.Array(types.Resource("package"))),
 		}, res.CodeV2.Blocks[0].Chunks[1])
 		assertFunction(t, "length", &llx.Function{
-			Binding: (1 << 32) | 1,
-			Args:    []*llx.Primitive{llx.RefPrimitiveV2((1 << 32) | 2)},
+			Binding: (1 << 32) | 2,
 			Type:    string(types.Int),
 		}, res.CodeV2.Blocks[0].Chunks[2])
 	})
+	// ^^
 }
 
 func TestCompiler_ResourceFieldGlob(t *testing.T) {
@@ -989,14 +1013,14 @@ func TestCompiler_ResourceFieldGlob(t *testing.T) {
 }
 
 func TestCompiler_ArrayResourceFieldGlob(t *testing.T) {
-	compileT(t, "groups.list { * }", func(res *llx.CodeBundle) {
+	compileT(t, "groups { * }", func(res *llx.CodeBundle) {
 		assertFunction(t, "groups", nil, res.CodeV2.Blocks[0].Chunks[0])
 		assertFunction(t, "list", &llx.Function{
-			Type:    string(types.Array(types.Resource("group"))),
 			Binding: (1 << 32) | 1,
+			Type:    string(types.Resource("group")),
 		}, res.CodeV2.Blocks[0].Chunks[1])
 		assertFunction(t, "{}", &llx.Function{
-			Type:    string(types.Array(types.Block)),
+			Type:    string(types.Block),
 			Binding: (1 << 32) | 2,
 			Args:    []*llx.Primitive{llx.FunctionPrimitive(2 << 32)},
 		}, res.CodeV2.Blocks[0].Chunks[2])
@@ -1270,14 +1294,14 @@ func TestCompiler_StringContainsWithInt(t *testing.T) {
 }
 
 func TestCompiler_CallWithResource(t *testing.T) {
-	compileT(t, "users.list { file(home) }", func(res *llx.CodeBundle) {
+	compileT(t, "users { file(home) }", func(res *llx.CodeBundle) {
 		assertFunction(t, "users", nil, res.CodeV2.Blocks[0].Chunks[0])
 		assertFunction(t, "list", &llx.Function{
-			Type:    string(types.Array(types.Resource("user"))),
 			Binding: (1 << 32) | 1,
+			Type:    string(types.Resource("user")),
 		}, res.CodeV2.Blocks[0].Chunks[1])
 		assertFunction(t, "{}", &llx.Function{
-			Type:    string(types.Array(types.Block)),
+			Type:    string(types.Block),
 			Binding: (1 << 32) | 2,
 			Args:    []*llx.Primitive{llx.FunctionPrimitive(2 << 32)},
 		}, res.CodeV2.Blocks[0].Chunks[2])
@@ -1303,14 +1327,14 @@ func TestCompiler_CallWithResource(t *testing.T) {
 }
 
 func TestCompiler_List(t *testing.T) {
-	compileT(t, "packages.list { name }", func(res *llx.CodeBundle) {
+	compileT(t, "packages { name }", func(res *llx.CodeBundle) {
 		assertFunction(t, "packages", nil, res.CodeV2.Blocks[0].Chunks[0])
 		assertFunction(t, "list", &llx.Function{
-			Type:    string(types.Array(types.Resource("package"))),
 			Binding: (1 << 32) | 1,
+			Type:    string(types.Resource("package")),
 		}, res.CodeV2.Blocks[0].Chunks[1])
 		assertFunction(t, "{}", &llx.Function{
-			Type:    string(types.Array(types.Block)),
+			Type:    string(types.Block),
 			Binding: (1 << 32) | 2,
 			Args:    []*llx.Primitive{llx.FunctionPrimitive(2 << 32)},
 		}, res.CodeV2.Blocks[0].Chunks[2])

--- a/resources/lr/go.go
+++ b/resources/lr/go.go
@@ -78,11 +78,13 @@ func (b *goBuilder) goResource(r *Resource) error {
 			args = &FieldArgs{}
 		}
 
+		// FIXME: DEPRECATED, remove in v8.0 vv
 		field := &BasicField{
 			ID:   "list",
 			Args: args,
 			Type: Type{ListType: &ListType{Type: Type{SimpleType: &SimpleType{t}}}},
 		}
+		// ^^
 
 		r.Body.Fields = append(r.Body.Fields, &Field{BasicField: field})
 	}

--- a/resources/lr/go.go
+++ b/resources/lr/go.go
@@ -78,13 +78,11 @@ func (b *goBuilder) goResource(r *Resource) error {
 			args = &FieldArgs{}
 		}
 
-		// FIXME: DEPRECATED, remove in v8.0 vv
 		field := &BasicField{
 			ID:   "list",
 			Args: args,
 			Type: Type{ListType: &ListType{Type: Type{SimpleType: &SimpleType{t}}}},
 		}
-		// ^^
 
 		r.Body.Fields = append(r.Body.Fields, &Field{BasicField: field})
 	}

--- a/resources/packs/core/core_test.go
+++ b/resources/packs/core/core_test.go
@@ -925,6 +925,14 @@ func TestListResource(t *testing.T) {
 		assert.Len(t, res[0].Data.Value, 5)
 	})
 
+	// FIXME: DEPRECATED, remove in v8.0 vv
+	t.Run("support deprecated block call with list and other fields", func(t *testing.T) {
+		res := x.TestQuery(t, "ports { listening list }")
+		assert.NotEmpty(t, res)
+		assert.NotEmpty(t, res[0].Data.Value)
+	})
+	// ^^
+
 	x.TestSimple(t, []testutils.SimpleTest{
 		{
 			"users.where(name == 'root').length",
@@ -1016,7 +1024,7 @@ func TestResource_duplicateFields(t *testing.T) {
 	x := testutils.InitTester(testutils.LinuxMock(), core.Registry)
 	x.TestSimple(t, []testutils.SimpleTest{
 		{
-			"users.duplicates(uid) { uid }",
+			"users.list.duplicates(uid) { uid }",
 			0,
 			[]interface{}{
 				map[string]interface{}{

--- a/resources/packs/core/core_test.go
+++ b/resources/packs/core/core_test.go
@@ -916,8 +916,15 @@ func TestMap(t *testing.T) {
 	})
 }
 
-func TestResource_Filters(t *testing.T) {
+func TestListResource(t *testing.T) {
 	x := testutils.InitTester(testutils.LinuxMock(), core.Registry)
+
+	t.Run("list resource by default returns the list", func(t *testing.T) {
+		res := x.TestQuery(t, "users")
+		assert.NotEmpty(t, res)
+		assert.Len(t, res[0].Data.Value, 5)
+	})
+
 	x.TestSimple(t, []testutils.SimpleTest{
 		{
 			"users.where(name == 'root').length",
@@ -952,10 +959,14 @@ func TestResource_Filters(t *testing.T) {
 				},
 			},
 		},
+		{
+			"users.map(name)",
+			0, []interface{}([]interface{}{"root", "chris", "christopher", "chris", "bin"}),
+		},
 	})
 }
 
-func TestResource_Contains(t *testing.T) {
+func TestListResource_Assertions(t *testing.T) {
 	x := testutils.InitTester(testutils.LinuxMock(), core.Registry)
 	x.TestSimple(t, []testutils.SimpleTest{
 		{
@@ -966,12 +977,6 @@ func TestResource_Contains(t *testing.T) {
 			"users.where(uid < 100).contains(name == 'root')",
 			1, true,
 		},
-	})
-}
-
-func TestResource_All(t *testing.T) {
-	x := testutils.InitTester(testutils.LinuxMock(), core.Registry)
-	x.TestSimple(t, []testutils.SimpleTest{
 		{
 			"users.all(uid >= 0)",
 			1, true,
@@ -980,12 +985,6 @@ func TestResource_All(t *testing.T) {
 			"users.where(uid < 100).all(uid >= 0)",
 			1, true,
 		},
-	})
-}
-
-func TestResource_Any(t *testing.T) {
-	x := testutils.InitTester(testutils.LinuxMock(), core.Registry)
-	x.TestSimple(t, []testutils.SimpleTest{
 		{
 			"users.any(uid < 100)",
 			1, true,
@@ -994,12 +993,6 @@ func TestResource_Any(t *testing.T) {
 			"users.where(uid < 100).any(uid < 50)",
 			1, true,
 		},
-	})
-}
-
-func TestResource_One(t *testing.T) {
-	x := testutils.InitTester(testutils.LinuxMock(), core.Registry)
-	x.TestSimple(t, []testutils.SimpleTest{
 		{
 			"users.one(uid == 0)",
 			1, true,
@@ -1008,12 +1001,6 @@ func TestResource_One(t *testing.T) {
 			"users.where(uid < 100).one(uid == 0)",
 			1, true,
 		},
-	})
-}
-
-func TestResource_None(t *testing.T) {
-	x := testutils.InitTester(testutils.LinuxMock(), core.Registry)
-	x.TestSimple(t, []testutils.SimpleTest{
 		{
 			"users.none(uid == 99999)",
 			1, true,
@@ -1025,21 +1012,11 @@ func TestResource_None(t *testing.T) {
 	})
 }
 
-func TestResource_Map(t *testing.T) {
-	x := testutils.InitTester(testutils.LinuxMock(), core.Registry)
-	x.TestSimple(t, []testutils.SimpleTest{
-		{
-			"users.map(name)",
-			0, []interface{}([]interface{}{"root", "chris", "christopher", "chris", "bin"}),
-		},
-	})
-}
-
 func TestResource_duplicateFields(t *testing.T) {
 	x := testutils.InitTester(testutils.LinuxMock(), core.Registry)
 	x.TestSimple(t, []testutils.SimpleTest{
 		{
-			"users.list.duplicates(uid) { uid }",
+			"users.duplicates(uid) { uid }",
 			0,
 			[]interface{}{
 				map[string]interface{}{


### PR DESCRIPTION
Signed-off-by: Dominik Richter <dominik.richter@gmail.com>

## Easier list access

Instead of `users.list` just run `users`:

![image](https://user-images.githubusercontent.com/1307529/196016519-9a759236-bc94-4ebf-996f-e80bc073c329.png)

Access to individual elements can now be written simply as `users[0]` instead of `users.list[0]`

![image](https://user-images.githubusercontent.com/1307529/196016548-fe02b752-c729-4fc6-a08d-5761fd0afe36.png)

Block operations don't require `list` anymore and always apply to child elements:

![image](https://user-images.githubusercontent.com/1307529/196016559-1f4dbc7c-9b4f-41f8-bf57-f112bc52d5b1.png)

## Soft deprecations

For V6 compatibility (which we maintain throughout V7 lifetime) you can still write things the old way, but should switch to the new way soon:

```
old> users { list }
new> users

old> ports { listening list }
new> ports
new> ports.listening
```

Additionally we show nice deprecation warnings (e.g. for `ports { listening list }`):

![image](https://user-images.githubusercontent.com/1307529/196018198-63dffe0b-d289-44f6-83a1-7b26653a3e9e.png)


