### PR TITLE
🐛 be more defensive with assertion creation

### DIFF
--- a/cli/printer/printer_test.go
+++ b/cli/printer/printer_test.go
@@ -209,6 +209,31 @@ func TestPrinter(t *testing.T) {
 func TestPrinter_Assessment(t *testing.T) {
 	runAssessmentTests(t, []assessmentTest{
 		{
+			// mixed use: assertion and erroneous data field
+			"mondoo.build == 1; user(name: 'notthere').authorizedkeys.file",
+			strings.Join([]string{
+				"[failed] mondoo.build == 1; user(name: 'notthere').authorizedkeys.file",
+				"  [failed] mondoo.build == 1",
+				"    expected: == 1",
+				"    actual:   \"development\"",
+				"  [failed] user.authorizedkeys.file",
+				"    error: failed to create resource 'user': user 'notthere' does not exist",
+				"",
+			}, "\n"),
+		},
+		{
+			// mixed use: assertion and working data field
+			"mondoo.build == 1; user(name: 'root').authorizedkeys.file",
+			strings.Join([]string{
+				"[failed] mondoo.build == 1; user(name: 'root').authorizedkeys.file",
+				"  [failed] mondoo.build == 1",
+				"    expected: == 1",
+				"    actual:   \"development\"",
+				"  [ok] value: file id = /root/.ssh/authorized_keys",
+				"",
+			}, "\n"),
+		},
+		{
 			"[1,2,3].\n" +
 				"# @msg Found ${length} numbers\n" +
 				"none( _ > 1 )",
@@ -253,20 +278,6 @@ func TestPrinter_Assessment(t *testing.T) {
 				"",
 			}, "\n"),
 		},
-		// // TODO: this test needs fixing for the mixed output use-case,
-		// // where we have both an assertion and datapoints, with either having an error
-		// {
-		// 	"mondoo.build == 1;user(name: 'notthere').authorizedkeys.file",
-		// 	strings.Join([]string{
-		// 		"[failed] mondoo.build == 1;user(name: 'notthere').authorizedkeys.file",
-		// 		"  [failed] mondoo.build == 1",
-		// 		"    expected: == 1",
-		// 		"    actual:   \"development\"",
-		// 		"  [failed] user.authorizedkeys.file",
-		// 		"    error: failed to create resource 'user': user 'notthere' does not exist",
-		// 		"",
-		// 	}, "\n"),
-		// },
 		{
 			"if(true) {\n" +
 				"  # @msg Expected ${$expected.length} users but got ${length}\n" +

--- a/llx/code_bundle.go
+++ b/llx/code_bundle.go
@@ -61,7 +61,7 @@ func Results2AssessmentLookupV2(bundle *CodeBundle, f func(s string) (*RawResult
 			res.Success = false
 		}
 
-		res.IsAssertion = cur.IsAssertion
+		res.IsAssertion = res.IsAssertion || cur.IsAssertion
 	}
 
 	if !res.IsAssertion {


### PR DESCRIPTION
we want to use the assertion approach whenever we see an assessment, not just if the last expression was an assertion

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>