### PR TITLE
🧹 remove extra space after hbar to allow for more control over rendering

### DIFF
--- a/cli/components/hbar.go
+++ b/cli/components/hbar.go
@@ -19,5 +19,5 @@ func Hbar(len uint32, percent float32) string {
 	if segments == 0 {
 		return ""
 	}
-	return strings.Repeat("█", int(segments)) + " "
+	return strings.Repeat("█", int(segments))
 }


### PR DESCRIPTION
fyi hbar is only used in cnspec, which is quickly getting an update for this change

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>