### PR TITLE
Format all the default values in help the same

### DIFF
--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -256,7 +256,7 @@ This example connects to Microsoft 365 using the PKCS #12 formatted certificate:
 		cmd.Flags().StringP("output", "o", "compact", "Set output format: "+reporter.AllFormats())
 		cmd.Flags().BoolP("json", "j", false, "Set output to JSON (shorthand)")
 		cmd.Flags().Bool("no-pager", false, "Disable interactive scan output pagination")
-		cmd.Flags().String("pager", "", "Enable scan output pagination with custom pagination command. default is 'less -R'")
+		cmd.Flags().String("pager", "", "Enable scan output pagination with custom pagination command (default 'less -R')")
 	},
 	CommonPreRun: func(cmd *cobra.Command, args []string) {
 		// multiple assets mapping

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -40,7 +40,7 @@ func Init(rootCmd *cobra.Command) {
 	AppFs = afero.NewOsFs()
 	Features = getFeatures()
 	// persistent flags are global for the application
-	rootCmd.PersistentFlags().StringVar(&UserProvidedPath, "config", "", "Set config file path (default is $HOME/.config/mondoo/mondoo.yml)")
+	rootCmd.PersistentFlags().StringVar(&UserProvidedPath, "config", "", "Set config file path (default $HOME/.config/mondoo/mondoo.yml)")
 }
 
 func getFeatures() cnquery.Features {

--- a/resources/lr/cli/cmd/root.go
+++ b/resources/lr/cli/cmd/root.go
@@ -42,7 +42,7 @@ func init() {
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "Set config file path (default is $HOME/.lr.yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "Set config file path (default $HOME/.lr.yaml)")
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
Makes the docs consistent

Signed-off-by: Tim Smith <tsmith84@gmail.com>