### PR TITLE
✨ auto-expand results in assessments

### DIFF
--- a/cli/printer/mql.go
+++ b/cli/printer/mql.go
@@ -146,7 +146,13 @@ func (print *Printer) assessment(bundle *llx.CodeBundle, assessment *llx.Assessm
 	if assessment.Actual != nil {
 		res.WriteString(nextIndent)
 		res.WriteString("actual:   ")
-		res.WriteString(print.Primitive(assessment.Actual, codeID, bundle, nextIndent))
+
+		checksum := bundle.CodeV2.Checksums[assessment.Ref]
+		if _, ok := bundle.AutoExpand[checksum]; ok {
+			res.WriteString(print.Primitive(assessment.Actual, checksum, bundle, nextIndent))
+		} else {
+			res.WriteString(print.Primitive(assessment.Actual, codeID, bundle, nextIndent))
+		}
 	}
 
 	return res.String()
@@ -448,7 +454,7 @@ func (print *Printer) autoExpand(blockRef uint64, data interface{}, bundle *llx.
 			return "[]"
 		}
 
-		prefix := "  "
+		prefix := indent + "  "
 		res.WriteString("[\n")
 		for i := range arr {
 			c := print.autoExpand(blockRef, arr[i], bundle, prefix)

--- a/cli/printer/printer_test.go
+++ b/cli/printer/printer_test.go
@@ -263,14 +263,6 @@ func TestPrinter_Assessment(t *testing.T) {
 			}, "\n"),
 		},
 		{
-			"# @msg Expected ${$expected.length} users but got ${length}\n" +
-				"users.none( uid == 0 )",
-			strings.Join([]string{
-				"[failed] Expected 5 users but got 1",
-				"",
-			}, "\n"),
-		},
-		{
 			"mondoo.build == 1",
 			strings.Join([]string{
 				"[failed] mondoo.build == 1",
@@ -299,6 +291,16 @@ func TestPrinter_Assessment(t *testing.T) {
 			}, "\n"),
 		},
 		{
+			"# @msg Expected ${$expected.length} users but got ${length}\n" +
+				"users.none( uid == 0 )",
+			strings.Join([]string{
+				"[failed] Expected 5 users but got 1",
+				"",
+			}, "\n"),
+		},
+		{
+			// FIXME: This case is currently printing too much. Remove the auto-generated
+			// expansion if the annotation is present.
 			"if(true) {\n" +
 				"  # @msg Expected ${$expected.length} users but got ${length}\n" +
 				"  users.none( uid == 0 )\n" +
@@ -306,7 +308,20 @@ func TestPrinter_Assessment(t *testing.T) {
 			strings.Join([]string{
 				"if: {",
 				"  [failed] Expected 5 users but got 1",
+				"  users.where.list: [",
+				"    user name=\"root\" uid=0 gid=0",
+				"  ]",
 				"}",
+			}, "\n"),
+		},
+		{
+			"users.all(uid > 0)",
+			strings.Join([]string{
+				"[failed] users.all()",
+				"  actual:   [",
+				"    user name=\"root\" uid=0 gid=0",
+				"  ]",
+				"",
 			}, "\n"),
 		},
 	})

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -1051,6 +1051,27 @@ func TestCompiler_ResourceExpansion(t *testing.T) {
 			}, res.CodeV2.Blocks[1].Chunks[1])
 		})
 	})
+
+	cmd = "users.all( uid > 0 )"
+	t.Run(cmd, func(t *testing.T) {
+		compileT(t, cmd, func(res *llx.CodeBundle) {
+			assertFunction(t, "users", nil, res.CodeV2.Blocks[0].Chunks[0])
+			assertFunction(t, "{}", &llx.Function{
+				Binding: (1 << 32) | 4,
+				Type:    string(types.Array(types.Block)),
+				Args:    []*llx.Primitive{llx.FunctionPrimitive(3 << 32)},
+			}, res.CodeV2.Blocks[0].Chunks[5])
+
+			assertFunction(t, "name", &llx.Function{
+				Binding: (3 << 32) | 1,
+				Type:    string(types.String),
+			}, res.CodeV2.Blocks[2].Chunks[1])
+
+			assert.Equal(t, map[string]uint64{res.CodeV2.Checksums[1<<32|6]: 3 << 32}, res.AutoExpand)
+			assert.Equal(t, []uint64{1<<32 | 5}, res.CodeV2.Blocks[0].Entrypoints)
+			assert.Equal(t, []uint64{1<<32 | 6}, res.CodeV2.Blocks[0].Datapoints)
+		})
+	})
 }
 
 func TestCompiler_ArrayResource(t *testing.T) {


### PR DESCRIPTION
These were still using their old IDs and not as easy to fix. There is a follow-up with @msg assertions and this, which currently double-print inside of blocks. Worth getting this update in and follow up on the bug.

![image](https://user-images.githubusercontent.com/1307529/196385836-5f481d05-fbde-4f53-abf8-91ed93efb2fa.png)


Signed-off-by: Dominik Richter <dominik.richter@gmail.com>