### PR TITLE
🐛 restructure platform specs into detector package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,14 @@ explorer/generate:
 
 #   🏗 Binary / Build   #
 
+.PHONY: cnquery/build/linux
+cnquery/build/linux:
+	GOOS=linux go build ${LDFLAGSDIST} apps/cnquery/cnquery.go
+
+.PHONY: cnquery/build/windows
+cnquery/build/windows:
+	GOOS=windows go build ${LDFLAGSDIST} apps/cnquery/cnquery.go
+
 .PHONY: cnquery/install
 cnquery/install:
 	GOBIN=${GOPATH}/bin go install ${LDFLAGSDIST} apps/cnquery/cnquery.go

--- a/motor/discovery/vsphere/vsphere_resolver.go
+++ b/motor/discovery/vsphere/vsphere_resolver.go
@@ -10,7 +10,7 @@ import (
 	"go.mondoo.com/cnquery/motor/asset"
 	"go.mondoo.com/cnquery/motor/discovery/common"
 	"go.mondoo.com/cnquery/motor/motorid"
-	"go.mondoo.com/cnquery/motor/platform"
+	"go.mondoo.com/cnquery/motor/platform/detector"
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
 	"go.mondoo.com/cnquery/motor/providers/vsphere"
@@ -97,7 +97,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *provide
 			ht.Options = host.Annotations
 			host.Connections = append(host.Connections, ht)
 
-			pf, err := platform.VspherePlatform(trans, host.PlatformIds[0])
+			pf, err := detector.VspherePlatform(trans, host.PlatformIds[0])
 			if err == nil {
 				host.Platform = pf
 			} else {
@@ -119,7 +119,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *provide
 		for i := range vms {
 			vm := vms[i]
 
-			pf, err := platform.VspherePlatform(trans, vm.PlatformIds[0])
+			pf, err := detector.VspherePlatform(trans, vm.PlatformIds[0])
 			if err == nil {
 				vm.Platform = pf
 			} else {

--- a/motor/platform/detector/detector.go
+++ b/motor/platform/detector/detector.go
@@ -39,9 +39,9 @@ func (d *Detector) resolveOS(p os.OperatingSystemProvider) (*platform.Platform, 
 	// NOTE: on windows, powershell calls are expensive therefore we want to shortcut the detection mechanism
 	local, ok := p.(*local.Provider)
 	if ok && runtime.GOOS == "windows" {
-		return platform.WindowsFamily.Resolve(local)
+		return WindowsFamily.Resolve(local)
 	} else {
-		return platform.OperatingSystems.Resolve(p)
+		return OperatingSystems.Resolve(p)
 	}
 }
 
@@ -62,7 +62,7 @@ func (d *Detector) Platform() (*platform.Platform, error) {
 		if err != nil {
 			return nil, err
 		}
-		return platform.VspherePlatform(pt, identifier)
+		return VspherePlatform(pt, identifier)
 	case *arista.Provider:
 		v, err := pt.GetVersion()
 		if err != nil {

--- a/motor/platform/detector/os_release.go
+++ b/motor/platform/detector/os_release.go
@@ -1,4 +1,4 @@
-package platform
+package detector
 
 import (
 	"io/ioutil"

--- a/motor/platform/detector/os_release_test.go
+++ b/motor/platform/detector/os_release_test.go
@@ -1,4 +1,4 @@
-package platform
+package detector
 
 import (
 	"testing"
@@ -7,7 +7,6 @@ import (
 )
 
 func TestMajorMinorParser(t *testing.T) {
-
 	data := []struct {
 		release string
 		major   string

--- a/motor/platform/detector/parser_esxi_version.go
+++ b/motor/platform/detector/parser_esxi_version.go
@@ -1,13 +1,11 @@
-package platform
+package detector
 
 import (
 	"fmt"
 	"regexp"
 )
 
-var (
-	EsxiReleaseRegex = regexp.MustCompile(`^VMware ESXi\s(.*)\s*$`)
-)
+var EsxiReleaseRegex = regexp.MustCompile(`^VMware ESXi\s(.*)\s*$`)
 
 func ParseEsxiRelease(content string) (string, error) {
 	m := EsxiReleaseRegex.FindStringSubmatch(content)

--- a/motor/platform/detector/parser_esxi_version_test.go
+++ b/motor/platform/detector/parser_esxi_version_test.go
@@ -1,19 +1,19 @@
-package platform_test
+package detector_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mondoo.com/cnquery/motor/platform"
+	"go.mondoo.com/cnquery/motor/platform/detector"
 )
 
 func TestEsxiVersionParser(t *testing.T) {
-	m, err := platform.ParseEsxiRelease("VMware ESXi 6.7.0 build-13006603")
+	m, err := detector.ParseEsxiRelease("VMware ESXi 6.7.0 build-13006603")
 	require.NoError(t, err)
 	assert.Equal(t, "6.7.0 build-13006603", m)
 
-	m, err = platform.ParseEsxiRelease("VMware ESXi 6.7.0 build-13006603\n")
+	m, err = detector.ParseEsxiRelease("VMware ESXi 6.7.0 build-13006603\n")
 	require.NoError(t, err)
 	assert.Equal(t, "6.7.0 build-13006603", m)
 }

--- a/motor/platform/detector/parser_linux_version.go
+++ b/motor/platform/detector/parser_linux_version.go
@@ -1,4 +1,4 @@
-package platform
+package detector
 
 import (
 	"errors"

--- a/motor/platform/detector/parser_linux_version_test.go
+++ b/motor/platform/detector/parser_linux_version_test.go
@@ -1,15 +1,14 @@
-package platform_test
+package detector_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mondoo.com/cnquery/motor/platform"
+	"go.mondoo.com/cnquery/motor/platform/detector"
 )
 
 func TestOSReleaseParser(t *testing.T) {
-
 	osRelease := `NAME="Ubuntu"
 VERSION="16.04.3 LTS (Xenial Xerus)"
 ID=ubuntu
@@ -22,7 +21,7 @@ BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
 VERSION_CODENAME=xenial
 UBUNTU_CODENAME=xenial`
 
-	m, err := platform.ParseOsRelease(osRelease)
+	m, err := detector.ParseOsRelease(osRelease)
 	assert.Nil(t, err)
 
 	assert.Equal(t, "Ubuntu", m["NAME"], "NAME should be parsed properly")
@@ -52,7 +51,7 @@ ORACLE_BUGZILLA_PRODUCT_VERSION=6.9
 ORACLE_SUPPORT_PRODUCT="Oracle Linux"
 ORACLE_SUPPORT_PRODUCT_VERSION=6.9`
 
-	m, err = platform.ParseOsRelease(osRelease)
+	m, err = detector.ParseOsRelease(osRelease)
 	require.NoError(t, err)
 	assert.Equal(t, "Oracle Linux Server", m["NAME"], "NAME should be parsed properly")
 	assert.Equal(t, "ol", m["ID"], "ID should be parsed properly")
@@ -60,13 +59,12 @@ ORACLE_SUPPORT_PRODUCT_VERSION=6.9`
 }
 
 func TestEtcLsbReleaseParser(t *testing.T) {
-
 	lsbRelease := `DISTRIB_ID=Ubuntu
 DISTRIB_RELEASE=16.04
 DISTRIB_CODENAME=xenial
 DISTRIB_DESCRIPTION="Ubuntu 16.04.3 LTS"`
 
-	m, err := platform.ParseLsbRelease(lsbRelease)
+	m, err := detector.ParseLsbRelease(lsbRelease)
 	require.NoError(t, err)
 
 	assert.Equal(t, "Ubuntu", m["DISTRIB_ID"], "DISTRIB_ID should be parsed properly")
@@ -77,25 +75,25 @@ DISTRIB_DESCRIPTION="Ubuntu 16.04.3 LTS"`
 
 func TestRedhatRelease(t *testing.T) {
 	rhRelease := "CentOS Linux release 7.4.1708 (Core)"
-	name, release, err := platform.ParseRhelVersion(rhRelease)
+	name, release, err := detector.ParseRhelVersion(rhRelease)
 	require.NoError(t, err)
 	assert.Equal(t, "CentOS Linux", name, "parse os name")
 	assert.Equal(t, "7.4.1708", release, "parse release version")
 
 	rhRelease = "CentOS release 6.9 (Final)"
-	name, release, err = platform.ParseRhelVersion(rhRelease)
+	name, release, err = detector.ParseRhelVersion(rhRelease)
 	require.NoError(t, err)
 	assert.Equal(t, "CentOS", name, "parse os name")
 	assert.Equal(t, "6.9", release, "parse release version")
 
 	rhRelease = "Red Hat Enterprise Linux Server release 7.4 (Maipo)"
-	name, release, err = platform.ParseRhelVersion(rhRelease)
+	name, release, err = detector.ParseRhelVersion(rhRelease)
 	assert.Nil(t, err)
 	assert.Equal(t, "Red Hat Enterprise Linux Server", name, "parse os name")
 	assert.Equal(t, "7.4", release, "parse release version")
 
 	rhRelease = "Oracle Linux Server release 7.4 (Maipo)"
-	name, release, err = platform.ParseRhelVersion(rhRelease)
+	name, release, err = detector.ParseRhelVersion(rhRelease)
 	require.NoError(t, err)
 	assert.Equal(t, "Oracle Linux Server", name, "parse os name")
 	assert.Equal(t, "7.4", release, "parse release version")

--- a/motor/platform/detector/parser_macos_version.go
+++ b/motor/platform/detector/parser_macos_version.go
@@ -1,4 +1,4 @@
-package platform
+package detector
 
 import (
 	"encoding/xml"
@@ -30,13 +30,12 @@ type PropertyList struct {
 func ParseMacOSSystemVersion(content string) (map[string]string, error) {
 	v := PropertyList{}
 	err := xml.Unmarshal([]byte(content), &v)
-
 	if err != nil {
 		return nil, err
 	}
 
 	m := make(map[string]string)
-	for i, _ := range v.Dict.Keys {
+	for i := range v.Dict.Keys {
 		m[v.Dict.Keys[i]] = v.Dict.Values[i]
 	}
 	return m, nil

--- a/motor/platform/detector/parser_macos_version_test.go
+++ b/motor/platform/detector/parser_macos_version_test.go
@@ -1,11 +1,11 @@
-package platform_test
+package detector_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mondoo.com/cnquery/motor/platform"
+	"go.mondoo.com/cnquery/motor/platform/detector"
 )
 
 func TestDarwinRelease(t *testing.T) {
@@ -14,7 +14,7 @@ ProductVersion:	10.13.2
 BuildVersion:	17C88
 	`
 
-	m, err := platform.ParseDarwinRelease(swVers)
+	m, err := detector.ParseDarwinRelease(swVers)
 	require.NoError(t, err)
 
 	assert.Equal(t, "Mac OS X", m["ProductName"], "ProductName should be parsed properly")
@@ -23,7 +23,6 @@ BuildVersion:	17C88
 }
 
 func TestMacOsSystemVersion(t *testing.T) {
-
 	systemVersion := `
 	<?xml version="1.0" encoding="UTF-8"?>
 	<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -43,7 +42,7 @@ func TestMacOsSystemVersion(t *testing.T) {
 	</plist>
 	`
 
-	m, err := platform.ParseMacOSSystemVersion(systemVersion)
+	m, err := detector.ParseMacOSSystemVersion(systemVersion)
 	assert.Nil(t, err)
 
 	assert.Equal(t, "17C88", m["ProductBuildVersion"], "ProductBuildVersion should be parsed properly")

--- a/motor/platform/detector/parser_sol.go
+++ b/motor/platform/detector/parser_sol.go
@@ -1,4 +1,4 @@
-package platform
+package detector
 
 import (
 	"fmt"
@@ -15,7 +15,6 @@ type SolarisRelease struct {
 var solarisVersionRegex = regexp.MustCompile(`^\s+((?:[\w]\s*)*Solaris)\s([\w\d.]+)`)
 
 func ParseSolarisRelease(content string) (*SolarisRelease, error) {
-
 	m := solarisVersionRegex.FindStringSubmatch(content)
 	if len(m) < 2 {
 		return nil, fmt.Errorf("could not parse solaris version: %s", content)

--- a/motor/platform/detector/parser_sol_test.go
+++ b/motor/platform/detector/parser_sol_test.go
@@ -1,11 +1,12 @@
-package platform_test
+package detector_test
 
 import (
 	"testing"
 
+	"go.mondoo.com/cnquery/motor/platform/detector"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mondoo.com/cnquery/motor/platform"
 )
 
 func TestOpenSolaris2009Release(t *testing.T) {
@@ -16,7 +17,7 @@ func TestOpenSolaris2009Release(t *testing.T) {
                           Assembled 07 May 2009
 `
 
-	r, err := platform.ParseSolarisRelease(input)
+	r, err := detector.ParseSolarisRelease(input)
 	require.NoError(t, err)
 
 	assert.Equal(t, "opensolaris", r.ID)
@@ -31,7 +32,7 @@ func TestSolaris11Release(t *testing.T) {
 					   Assembled 04 November 2010
 `
 
-	r, err := platform.ParseSolarisRelease(input)
+	r, err := detector.ParseSolarisRelease(input)
 	require.NoError(t, err)
 
 	assert.Equal(t, "solaris", r.ID)
@@ -49,7 +50,7 @@ func TestSolaris10Release(t *testing.T) {
                 Solaris 10 10/09 (Update 8) Patch Bundle applied.
 `
 
-	r, err := platform.ParseSolarisRelease(input)
+	r, err := detector.ParseSolarisRelease(input)
 	require.NoError(t, err)
 
 	assert.Equal(t, "solaris", r.ID)

--- a/motor/platform/detector/platform_resolver.go
+++ b/motor/platform/detector/platform_resolver.go
@@ -1,12 +1,13 @@
-package platform
+package detector
 
 import (
 	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/motor/platform"
 	"go.mondoo.com/cnquery/motor/providers/os"
 	"go.mondoo.com/cnquery/motor/providers/tar"
 )
 
-type detect func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error)
+type detect func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error)
 
 type PlatformResolver struct {
 	Name     string
@@ -15,9 +16,9 @@ type PlatformResolver struct {
 	Detect   detect
 }
 
-func (r *PlatformResolver) Resolve(p os.OperatingSystemProvider) (*Platform, bool) {
+func (r *PlatformResolver) Resolve(p os.OperatingSystemProvider) (*platform.Platform, bool) {
 	// prepare detect info object
-	di := &Platform{}
+	di := &platform.Platform{}
 	di.Family = make([]string, 0)
 
 	// start recursive platform resolution
@@ -44,7 +45,7 @@ func (r *PlatformResolver) Resolve(p os.OperatingSystemProvider) (*Platform, boo
 // Resolve tries to find recursively all
 // platforms until a leaf (operating systems) detect
 // mechanism is returning true
-func (r *PlatformResolver) resolvePlatform(pf *Platform, p os.OperatingSystemProvider) (*Platform, bool) {
+func (r *PlatformResolver) resolvePlatform(pf *platform.Platform, p os.OperatingSystemProvider) (*platform.Platform, bool) {
 	detected, err := r.Detect(r, pf, p)
 	if err != nil {
 		return pf, false

--- a/motor/platform/detector/platform_specs.go
+++ b/motor/platform/detector/platform_specs.go
@@ -1,4 +1,4 @@
-package platform
+package detector
 
 import (
 	"bytes"
@@ -7,28 +7,19 @@ import (
 	"strconv"
 	"strings"
 
-	"go.mondoo.com/cnquery/motor/providers/os"
-
 	"github.com/gosimple/slug"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
+	"go.mondoo.com/cnquery/motor/platform"
 	win "go.mondoo.com/cnquery/motor/platform/windows"
-)
-
-// often used family names
-var (
-	FAMILY_UNIX    = "unix"
-	FAMILY_DARWIN  = "darwin"
-	FAMILY_LINUX   = "linux"
-	FAMILY_BSD     = "bsd"
-	FAMILY_WINDOWS = "windows"
+	"go.mondoo.com/cnquery/motor/providers/os"
 )
 
 // Operating Systems
 var macOS = &PlatformResolver{
 	Name:     "macos",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		// when we reach here, we know it is darwin
 		// check xml /System/Library/CoreServices/SystemVersion.plist
 		f, err := p.FS().Open("/System/Library/CoreServices/SystemVersion.plist")
@@ -61,7 +52,7 @@ var macOS = &PlatformResolver{
 var otherDarwin = &PlatformResolver{
 	Name:     "darwin",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		return true, nil
 	},
 }
@@ -69,7 +60,7 @@ var otherDarwin = &PlatformResolver{
 var alpine = &PlatformResolver{
 	Name:     "alpine",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		// check if we are on edge
 		osrd := NewOSReleaseDetector(p)
 		osr, err := osrd.osrelease()
@@ -108,7 +99,7 @@ var alpine = &PlatformResolver{
 var arch = &PlatformResolver{
 	Name:     "arch",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		if pf.Name == "arch" {
 			return true, nil
 		}
@@ -119,7 +110,7 @@ var arch = &PlatformResolver{
 var manjaro = &PlatformResolver{
 	Name:     "manjaro",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		if pf.Name == "manjaro" {
 			return true, nil
 		}
@@ -130,7 +121,7 @@ var manjaro = &PlatformResolver{
 var debian = &PlatformResolver{
 	Name:     "debian",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		osrd := NewOSReleaseDetector(p)
 
 		f, err := p.FS().Open("/etc/debian_version")
@@ -168,7 +159,7 @@ var debian = &PlatformResolver{
 var ubuntu = &PlatformResolver{
 	Name:     "ubuntu",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		if pf.Name == "ubuntu" {
 			return true, nil
 		}
@@ -179,7 +170,7 @@ var ubuntu = &PlatformResolver{
 var raspbian = &PlatformResolver{
 	Name:     "raspbian",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		if pf.Name == "raspbian" {
 			return true, nil
 		}
@@ -190,7 +181,7 @@ var raspbian = &PlatformResolver{
 var kali = &PlatformResolver{
 	Name:     "kali",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		if pf.Name == "kali" {
 			return true, nil
 		}
@@ -201,7 +192,7 @@ var kali = &PlatformResolver{
 var linuxmint = &PlatformResolver{
 	Name:     "linuxmint",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		if pf.Name == "linuxmint" {
 			return true, nil
 		}
@@ -212,7 +203,7 @@ var linuxmint = &PlatformResolver{
 var popos = &PlatformResolver{
 	Name:     "pop",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		if pf.Name == "pop" {
 			return true, nil
 		}
@@ -224,7 +215,7 @@ var popos = &PlatformResolver{
 var rhel = &PlatformResolver{
 	Name:     "redhat",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		// etc redhat release was parsed by the family already,
 		// we reuse that information here
 		// e.g. Red Hat Linux, Red Hat Enterprise Linux Server
@@ -258,7 +249,7 @@ var rhel = &PlatformResolver{
 var centos = &PlatformResolver{
 	Name:     "centos",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		// works for centos 5+
 		if strings.Contains(pf.Title, "CentOS") || pf.Name == "centos" {
 			pf.Name = "centos"
@@ -295,7 +286,7 @@ var centos = &PlatformResolver{
 var fedora = &PlatformResolver{
 	Name:     "fedora",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		if strings.Contains(pf.Title, "Fedora") || pf.Name == "fedora" {
 			pf.Name = "fedora"
 			return true, nil
@@ -324,7 +315,7 @@ var fedora = &PlatformResolver{
 var oracle = &PlatformResolver{
 	Name:     "oracle",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		// works for oracle 7+
 		if pf.Name == "ol" {
 			pf.Name = "oraclelinux"
@@ -354,7 +345,7 @@ var oracle = &PlatformResolver{
 var scientific = &PlatformResolver{
 	Name:     "scientific",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		// works for oracle 7+
 		if pf.Name == "scientific" {
 			return true, nil
@@ -373,7 +364,7 @@ var scientific = &PlatformResolver{
 var amazonlinux = &PlatformResolver{
 	Name:     "amazonlinux",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		if pf.Name == "amzn" {
 			pf.Name = "amazonlinux"
 			return true, nil
@@ -385,7 +376,7 @@ var amazonlinux = &PlatformResolver{
 var windriver = &PlatformResolver{
 	Name:     "wrlinux",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		if pf.Name == "wrlinux" {
 			return true, nil
 		}
@@ -396,7 +387,7 @@ var windriver = &PlatformResolver{
 var opensuse = &PlatformResolver{
 	Name:     "opensuse",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		if pf.Name == "opensuse" || pf.Name == "opensuse-leap" || pf.Name == "opensuse-tumbleweed" {
 			return true, nil
 		}
@@ -408,7 +399,7 @@ var opensuse = &PlatformResolver{
 var sles = &PlatformResolver{
 	Name:     "sles",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		if pf.Name == "sles" {
 			return true, nil
 		}
@@ -419,7 +410,7 @@ var sles = &PlatformResolver{
 var suseMicroOs = &PlatformResolver{
 	Name:     "suse-microos",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		if pf.Name == "suse-microos" {
 			return true, nil
 		}
@@ -430,7 +421,7 @@ var suseMicroOs = &PlatformResolver{
 var gentoo = &PlatformResolver{
 	Name:     "gentoo",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		f, err := p.FS().Open("/etc/gentoo-release")
 		if err != nil {
 			return false, nil
@@ -463,7 +454,7 @@ var gentoo = &PlatformResolver{
 var ubios = &PlatformResolver{
 	Name:     "ubios",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		if pf.Name == "ubios" {
 			return true, nil
 		}
@@ -474,7 +465,7 @@ var ubios = &PlatformResolver{
 var busybox = &PlatformResolver{
 	Name:     "busybox",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		busyboxExists, err := afero.Exists(p.FS(), "/bin/busybox")
 		if !busyboxExists || err != nil {
 			return false, nil
@@ -525,7 +516,7 @@ var busybox = &PlatformResolver{
 var photon = &PlatformResolver{
 	Name:     "photon",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		if pf.Name == "photon" {
 			return true, nil
 		}
@@ -536,7 +527,7 @@ var photon = &PlatformResolver{
 var openwrt = &PlatformResolver{
 	Name:     "openwrt",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		// No clue why they are not using either lsb-release or os-release
 		f, err := p.FS().Open("/etc/openwrt_release")
 		if err != nil {
@@ -571,7 +562,7 @@ var openwrt = &PlatformResolver{
 var defaultLinux = &PlatformResolver{
 	Name:     "generic-linux",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		// if we reach here, we know that we detected linux already
 		log.Debug().Msg("platform> we do not know the linux system, but we do our best in guessing")
 		return true, nil
@@ -581,7 +572,7 @@ var defaultLinux = &PlatformResolver{
 var netbsd = &PlatformResolver{
 	Name:     "netbsd",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		if strings.Contains(strings.ToLower(pf.Name), "netbsd") == false {
 			return false, nil
 		}
@@ -600,7 +591,7 @@ var netbsd = &PlatformResolver{
 var freebsd = &PlatformResolver{
 	Name:     "freebsd",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		if strings.Contains(strings.ToLower(pf.Name), "freebsd") == false {
 			return false, nil
 		}
@@ -619,7 +610,7 @@ var freebsd = &PlatformResolver{
 var openbsd = &PlatformResolver{
 	Name:     "openbsd",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		if strings.Contains(strings.ToLower(pf.Name), "openbsd") == false {
 			return false, nil
 		}
@@ -638,7 +629,7 @@ var openbsd = &PlatformResolver{
 var dragonflybsd = &PlatformResolver{
 	Name:     "dragonflybsd",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		if strings.Contains(strings.ToLower(pf.Name), "dragonfly") == false {
 			return false, nil
 		}
@@ -658,7 +649,7 @@ var dragonflybsd = &PlatformResolver{
 var windows = &PlatformResolver{
 	Name:     "windows",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		data, err := win.GetWmiInformation(p)
 		if err != nil {
 			log.Debug().Err(err).Msg("could not gather wmi information")
@@ -695,10 +686,10 @@ var windows = &PlatformResolver{
 
 // Families
 var darwinFamily = &PlatformResolver{
-	Name:     FAMILY_DARWIN,
+	Name:     platform.FAMILY_DARWIN,
 	IsFamily: true,
 	Children: []*PlatformResolver{macOS, otherDarwin},
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		if strings.Contains(strings.ToLower(pf.Name), "darwin") == false {
 			return false, nil
 		}
@@ -732,10 +723,10 @@ var darwinFamily = &PlatformResolver{
 }
 
 var bsdFamily = &PlatformResolver{
-	Name:     FAMILY_BSD,
+	Name:     platform.FAMILY_BSD,
 	IsFamily: true,
 	Children: []*PlatformResolver{darwinFamily, netbsd, freebsd, openbsd, dragonflybsd},
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		osrd := NewOSReleaseDetector(p)
 		unames, err := osrd.unames()
 		if err != nil {
@@ -762,7 +753,7 @@ var redhatFamily = &PlatformResolver{
 	// NOTE: oracle pretends to be redhat with /etc/redhat-release and Red Hat Linux, therefore we
 	// want to check that platform before redhat
 	Children: []*PlatformResolver{oracle, rhel, centos, fedora, scientific},
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		f, err := p.FS().Open("/etc/redhat-release")
 		if err != nil {
 			log.Debug().Err(err)
@@ -804,7 +795,7 @@ var debianFamily = &PlatformResolver{
 	Name:     "debian",
 	IsFamily: true,
 	Children: []*PlatformResolver{debian, ubuntu, raspbian, kali, linuxmint, popos},
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		return true, nil
 	},
 }
@@ -813,7 +804,7 @@ var suseFamily = &PlatformResolver{
 	Name:     "suse",
 	IsFamily: true,
 	Children: []*PlatformResolver{opensuse, sles, suseMicroOs},
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		return true, nil
 	},
 }
@@ -822,7 +813,7 @@ var archFamily = &PlatformResolver{
 	Name:     "arch",
 	IsFamily: true,
 	Children: []*PlatformResolver{arch, manjaro},
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		// if the file exists, we are on arch or one of its derivatives
 		f, err := p.FS().Open("/etc/arch-release")
 		if err != nil {
@@ -852,10 +843,10 @@ var archFamily = &PlatformResolver{
 }
 
 var linuxFamily = &PlatformResolver{
-	Name:     FAMILY_LINUX,
+	Name:     platform.FAMILY_LINUX,
 	IsFamily: true,
 	Children: []*PlatformResolver{archFamily, redhatFamily, debianFamily, suseFamily, amazonlinux, alpine, gentoo, busybox, photon, windriver, openwrt, ubios, defaultLinux},
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		detected := false
 		osrd := NewOSReleaseDetector(p)
 
@@ -961,10 +952,10 @@ var linuxFamily = &PlatformResolver{
 }
 
 var unixFamily = &PlatformResolver{
-	Name:     FAMILY_UNIX,
+	Name:     platform.FAMILY_UNIX,
 	IsFamily: true,
 	Children: []*PlatformResolver{bsdFamily, linuxFamily, solaris},
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		// in order to support linux container image detection, we cannot run
 		// processes here, lets just read files to detect a system
 		return true, nil
@@ -974,7 +965,7 @@ var unixFamily = &PlatformResolver{
 var solaris = &PlatformResolver{
 	Name:     "solaris",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		osrd := NewOSReleaseDetector(p)
 
 		// check if we got vmkernel
@@ -1024,7 +1015,7 @@ var solaris = &PlatformResolver{
 var esxi = &PlatformResolver{
 	Name:     "esxi",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		log.Debug().Msg("check for esxi system")
 		// at this point, we are already 99% its esxi
 		cmd, err := p.RunCommand("vmware -v")
@@ -1054,7 +1045,7 @@ var esxFamily = &PlatformResolver{
 	Name:     "esx",
 	IsFamily: true,
 	Children: []*PlatformResolver{esxi},
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		osrd := NewOSReleaseDetector(p)
 
 		// check if we got vmkernel
@@ -1080,10 +1071,10 @@ var esxFamily = &PlatformResolver{
 }
 
 var WindowsFamily = &PlatformResolver{
-	Name:     FAMILY_WINDOWS,
+	Name:     platform.FAMILY_WINDOWS,
 	IsFamily: true,
 	Children: []*PlatformResolver{windows},
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		return true, nil
 	},
 }
@@ -1091,7 +1082,7 @@ var WindowsFamily = &PlatformResolver{
 var unknownOperatingSystem = &PlatformResolver{
 	Name:     "unknown-os",
 	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		// if we reach here, we really do not know the system
 		log.Debug().Msg("platform> we do not know the operating system, please contact support")
 		return true, nil
@@ -1102,7 +1093,7 @@ var OperatingSystems = &PlatformResolver{
 	Name:     "os",
 	IsFamily: true,
 	Children: []*PlatformResolver{unixFamily, WindowsFamily, esxFamily, unknownOperatingSystem},
-	Detect: func(r *PlatformResolver, pf *Platform, p os.OperatingSystemProvider) (bool, error) {
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		return true, nil
 	},
 }

--- a/motor/platform/detector/platform_test.go
+++ b/motor/platform/detector/platform_test.go
@@ -1,7 +1,9 @@
-package platform
+package detector
 
 import (
 	"testing"
+
+	"go.mondoo.com/cnquery/motor/platform"
 
 	"github.com/stretchr/testify/assert"
 	"go.mondoo.com/cnquery/motor/providers"
@@ -41,11 +43,11 @@ func TestIsFamily(t *testing.T) {
 		Expected bool
 	}{
 		{
-			Val:      IsFamily("redhat", FAMILY_LINUX),
+			Val:      IsFamily("redhat", platform.FAMILY_LINUX),
 			Expected: true,
 		},
 		{
-			Val:      IsFamily("redhat", FAMILY_UNIX),
+			Val:      IsFamily("redhat", platform.FAMILY_UNIX),
 			Expected: true,
 		},
 		{
@@ -53,7 +55,7 @@ func TestIsFamily(t *testing.T) {
 			Expected: true,
 		},
 		{
-			Val:      IsFamily("centos", FAMILY_LINUX),
+			Val:      IsFamily("centos", platform.FAMILY_LINUX),
 			Expected: true,
 		},
 		{
@@ -69,11 +71,11 @@ func TestIsFamily(t *testing.T) {
 
 func TestPrettyTitle(t *testing.T) {
 	test := []struct {
-		Platform *Platform
+		Platform *platform.Platform
 		Expected string
 	}{
 		{
-			Platform: &Platform{
+			Platform: &platform.Platform{
 				Title:   "Kali GNU/Linux Rolling",
 				Version: "2019.4",
 				Family:  []string{"linux", "unix", "os"},
@@ -81,7 +83,7 @@ func TestPrettyTitle(t *testing.T) {
 			Expected: "Kali GNU/Linux Rolling",
 		},
 		{
-			Platform: &Platform{
+			Platform: &platform.Platform{
 				Title:   "Red Hat Enterprise Linux",
 				Runtime: providers.RUNTIME_AWS_EC2,
 				Version: "7",
@@ -90,7 +92,7 @@ func TestPrettyTitle(t *testing.T) {
 			Expected: "Red Hat Enterprise Linux, AWS EC2 Instance",
 		},
 		{
-			Platform: &Platform{
+			Platform: &platform.Platform{
 				Title:   "Red Hat Enterprise Linux",
 				Kind:    providers.Kind_KIND_API,
 				Version: "7",
@@ -99,7 +101,7 @@ func TestPrettyTitle(t *testing.T) {
 			Expected: "Red Hat Enterprise Linux",
 		},
 		{
-			Platform: &Platform{
+			Platform: &platform.Platform{
 				Title:   "Red Hat Enterprise Linux",
 				Kind:    providers.Kind_KIND_BARE_METAL,
 				Version: "7",
@@ -108,7 +110,7 @@ func TestPrettyTitle(t *testing.T) {
 			Expected: "Red Hat Enterprise Linux, bare metal",
 		},
 		{
-			Platform: &Platform{
+			Platform: &platform.Platform{
 				Title:   "Red Hat Enterprise Linux 8",
 				Kind:    providers.Kind_KIND_CONTAINER_IMAGE,
 				Version: "8",
@@ -117,7 +119,7 @@ func TestPrettyTitle(t *testing.T) {
 			Expected: "Red Hat Enterprise Linux 8, Container Image",
 		},
 		{
-			Platform: &Platform{
+			Platform: &platform.Platform{
 				Title:   "Amazon Web Services 8",
 				Runtime: providers.RUNTIME_AWS,
 				Kind:    providers.Kind_KIND_API,
@@ -126,7 +128,7 @@ func TestPrettyTitle(t *testing.T) {
 			Expected: "Amazon Web Services 8",
 		},
 		{
-			Platform: &Platform{
+			Platform: &platform.Platform{
 				Title:   "Test Deployment",
 				Runtime: providers.RUNTIME_KUBERNETES_CLUSTER,
 				Family:  []string{"k8s-workload", "k8s"},
@@ -134,7 +136,7 @@ func TestPrettyTitle(t *testing.T) {
 			Expected: "Test Deployment, Kubernetes Cluster",
 		},
 		{
-			Platform: &Platform{
+			Platform: &platform.Platform{
 				Title:   "Test Deployment",
 				Runtime: providers.RUNTIME_KUBERNETES_MANIFEST,
 				Family:  []string{"k8s-workload", "k8s"},
@@ -142,7 +144,7 @@ func TestPrettyTitle(t *testing.T) {
 			Expected: "Test Deployment, Kubernetes Manifest File",
 		},
 		{
-			Platform: &Platform{
+			Platform: &platform.Platform{
 				Title:   "k8s test cluster",
 				Runtime: providers.RUNTIME_KUBERNETES,
 				Family:  []string{"k8s"},

--- a/motor/platform/detector/tree.go
+++ b/motor/platform/detector/tree.go
@@ -1,0 +1,61 @@
+package detector
+
+// map that is organized by platform name, to quickly determine its families
+var osTree = platfromPartens(OperatingSystems)
+
+func platfromPartens(r *PlatformResolver) map[string][]string {
+	return traverseFamily(r, []string{})
+}
+
+func traverseFamily(r *PlatformResolver, parents []string) map[string][]string {
+	if r.IsFamily {
+		// make sure we completely copy the values, otherwise they are going to overwrite themselves
+		p := make([]string, len(parents))
+		copy(p, parents)
+		// add the current family
+		p = append(p, r.Name)
+		res := map[string][]string{}
+
+		// iterate over children
+		for i := range r.Children {
+			child := r.Children[i]
+			// recursively walk through the tree
+			collect := traverseFamily(child, p)
+			for k := range collect {
+				res[k] = collect[k]
+			}
+		}
+		return res
+	}
+
+	// return child (no family)
+	return map[string][]string{
+		r.Name: parents,
+	}
+}
+
+func Family(platform string) []string {
+	parents, ok := osTree[platform]
+	if !ok {
+		return []string{}
+	}
+	return parents
+}
+
+// gathers the family for the provided platform
+// NOTE: at this point only operating systems have families
+func IsFamily(platform string, family string) bool {
+	// 1. determine the families of the platform
+	parents, ok := osTree[platform]
+	if !ok {
+		return false
+	}
+
+	// 2. check that the platform is part of the family
+	for i := range parents {
+		if parents[i] == family {
+			return true
+		}
+	}
+	return false
+}

--- a/motor/platform/detector/vsphere.go
+++ b/motor/platform/detector/vsphere.go
@@ -1,16 +1,17 @@
-package platform
+package detector
 
 import (
 	"errors"
 
+	"go.mondoo.com/cnquery/motor/platform"
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/vsphere"
-	vsphere_transport "go.mondoo.com/cnquery/motor/providers/vsphere"
+	vsphere_provider "go.mondoo.com/cnquery/motor/providers/vsphere"
 )
 
-func VspherePlatform(t *vsphere.Provider, identifier string) (*Platform, error) {
-	if vsphere_transport.IsVsphereResourceID(identifier) {
-		moid, err := vsphere_transport.ParseVsphereResourceID(identifier)
+func VspherePlatform(t *vsphere.Provider, identifier string) (*platform.Platform, error) {
+	if vsphere_provider.IsVsphereResourceID(identifier) {
+		moid, err := vsphere_provider.ParseVsphereResourceID(identifier)
 		if err != nil {
 			return nil, err
 		}
@@ -27,14 +28,14 @@ func VspherePlatform(t *vsphere.Provider, identifier string) (*Platform, error) 
 			esxi_version := ""
 			esxi_build := ""
 			// we do not abort in case of error because the simulator does not support esxi interface for the host
-			ver, err := vsphere_transport.EsxiVersion(host)
+			ver, err := vsphere_provider.EsxiVersion(host)
 			if err == nil {
 				esxi_version = ver.Version
 				esxi_build = ver.Build
 			}
 
 			// host
-			return &Platform{
+			return &platform.Platform{
 				Name:    "vmware-esxi",
 				Title:   "VMware ESXi",
 				Release: esxi_version,
@@ -47,7 +48,7 @@ func VspherePlatform(t *vsphere.Provider, identifier string) (*Platform, error) 
 		case "VirtualMachine":
 			// TODO: we should detect more details here
 			// vm
-			return &Platform{
+			return &platform.Platform{
 				Runtime: providers.RUNTIME_VSPHERE_VM,
 				Kind:    providers.Kind_KIND_VIRTUAL_MACHINE,
 			}, nil
@@ -57,7 +58,7 @@ func VspherePlatform(t *vsphere.Provider, identifier string) (*Platform, error) 
 	}
 
 	info := t.Info()
-	return &Platform{
+	return &platform.Platform{
 		Name:    "vmware-vsphere",
 		Title:   info.FullName,
 		Release: info.Version,

--- a/motor/platform/platform.go
+++ b/motor/platform/platform.go
@@ -8,6 +8,15 @@ import (
 
 //go:generate protoc --proto_path=../../:. --go_out=. --go_opt=paths=source_relative --rangerrpc_out=. platform.proto
 
+// often used family names
+var (
+	FAMILY_UNIX    = "unix"
+	FAMILY_DARWIN  = "darwin"
+	FAMILY_LINUX   = "linux"
+	FAMILY_BSD     = "bsd"
+	FAMILY_WINDOWS = "windows"
+)
+
 func (p *Platform) IsFamily(family string) bool {
 	for i := range p.Family {
 		if p.Family[i] == family {
@@ -74,64 +83,4 @@ func (p *Platform) PrettyTitle() string {
 	}
 
 	return prettyTitle
-}
-
-// map that is organized by platform name, to quickly determine its families
-var osTree = platfromPartens(OperatingSystems)
-
-func platfromPartens(r *PlatformResolver) map[string][]string {
-	return traverseFamily(r, []string{})
-}
-
-func traverseFamily(r *PlatformResolver, parents []string) map[string][]string {
-	if r.IsFamily {
-		// make sure we completely copy the values, otherwise they are going to overwrite themselves
-		p := make([]string, len(parents))
-		copy(p, parents)
-		// add the current family
-		p = append(p, r.Name)
-		res := map[string][]string{}
-
-		// iterate over children
-		for i := range r.Children {
-			child := r.Children[i]
-			// recursively walk through the tree
-			collect := traverseFamily(child, p)
-			for k := range collect {
-				res[k] = collect[k]
-			}
-		}
-		return res
-	}
-
-	// return child (no family)
-	return map[string][]string{
-		r.Name: parents,
-	}
-}
-
-func Family(platform string) []string {
-	parents, ok := osTree[platform]
-	if !ok {
-		return []string{}
-	}
-	return parents
-}
-
-// gathers the family for the provided platform
-// NOTE: at this point only operating systems have families
-func IsFamily(platform string, family string) bool {
-	// 1. determine the families of the platform
-	parents, ok := osTree[platform]
-	if !ok {
-		return false
-	}
-
-	// 2. check that the platform is part of the family
-	for i := range parents {
-		if parents[i] == family {
-			return true
-		}
-	}
-	return false
 }

--- a/resources/packs/os/services/manager.go
+++ b/resources/packs/os/services/manager.go
@@ -4,10 +4,9 @@ import (
 	"errors"
 	"regexp"
 
-	"go.mondoo.com/cnquery/motor/providers/os"
-
 	"go.mondoo.com/cnquery/motor"
-	"go.mondoo.com/cnquery/motor/platform"
+	"go.mondoo.com/cnquery/motor/platform/detector"
+	"go.mondoo.com/cnquery/motor/providers/os"
 )
 
 type Service struct {
@@ -67,7 +66,7 @@ func ResolveManager(motor *motor.Motor) (OSServiceManager, error) {
 		osm = ResolveSystemdServiceManager(osProvider)
 	// NOTE: we need to check fedora before rhel family, since its also rhel family
 	case pf.Name == "fedora":
-		rv := platform.ParseOsVersion(pf.Version)
+		rv := detector.ParseOsVersion(pf.Version)
 		v, err := rv.MajorAtoi()
 		if err != nil {
 			return nil, errors.New("unknown fedora version: " + pf.Version)
@@ -80,7 +79,7 @@ func ResolveManager(motor *motor.Motor) (OSServiceManager, error) {
 			osm = ResolveSystemdServiceManager(osProvider)
 		}
 	case pf.IsFamily("redhat"):
-		rv := platform.ParseOsVersion(pf.Version)
+		rv := detector.ParseOsVersion(pf.Version)
 		v, err := rv.MajorAtoi()
 		if err != nil {
 			return nil, errors.New("unknown redhat version: " + pf.Version)
@@ -91,7 +90,7 @@ func ResolveManager(motor *motor.Motor) (OSServiceManager, error) {
 			osm = ResolveSystemdServiceManager(osProvider)
 		}
 	case pf.Name == "ubuntu" || pf.Name == "linuxmint" || pf.Name == "pop":
-		rv := platform.ParseOsVersion(pf.Version)
+		rv := detector.ParseOsVersion(pf.Version)
 		v, err := rv.MajorAtoi()
 		if err != nil {
 			return nil, errors.New("unknown ubuntu version: " + pf.Version)
@@ -103,7 +102,7 @@ func ResolveManager(motor *motor.Motor) (OSServiceManager, error) {
 			osm = ResolveSystemdServiceManager(osProvider)
 		}
 	case pf.Name == "debian":
-		rv := platform.ParseOsVersion(pf.Version)
+		rv := detector.ParseOsVersion(pf.Version)
 		v, err := rv.MajorAtoi()
 		if err != nil {
 			return nil, errors.New("unknown debian version: " + pf.Version)
@@ -117,7 +116,7 @@ func ResolveManager(motor *motor.Motor) (OSServiceManager, error) {
 	case pf.Name == "suse-microos": // it is suse family but uses a different version scheme
 		osm = ResolveSystemdServiceManager(osProvider)
 	case pf.IsFamily("suse"):
-		rv := platform.ParseOsVersion(pf.Version)
+		rv := detector.ParseOsVersion(pf.Version)
 		v, err := rv.MajorAtoi()
 		if err != nil {
 			return nil, errors.New("unknown suse version: " + pf.Version)


### PR DESCRIPTION
We introduced a circular dependency that only happened on Windows:

```
package command-line-arguments
	imports go.mondoo.com/cnquery/apps/cnquery/cmd
	imports go.mondoo.com/cnquery/apps/cnquery/cmd/builder
	imports go.mondoo.com/cnquery/motor/asset
	imports go.mondoo.com/cnquery/motor/platform
	imports go.mondoo.com/cnquery/motor/platform/windows
	imports go.mondoo.com/cnquery/motor/providers/local
	imports go.mondoo.com/cnquery/motor/asset: import cycle not allowed
```

We imported the windows provider in the the platform package. To avoid that I moved the platform specs into the detector package (where they are used anyway).