### PR TITLE
🧹 Check LR generated json files for resource packs.

### DIFF
--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -34,4 +34,5 @@ jobs:
           protoc --version
           make prep
           make cnquery/generate
-          git diff --exit-code *.go 
+          git diff --exit-code *.go
+          git diff --exit-code resources/packs/**/*.lr.json


### PR DESCRIPTION
Signed-off-by: Preslav <preslav@mondoo.com>

Seen in https://github.com/mondoohq/cnquery/pull/326, there is no check if we forget to regen the info json files for the resources.