### PR TITLE
🧹 use the aws ec2 instance name as asset name (instead of instance id) when it exists

### DIFF
--- a/motor/discovery/aws/ec2_instances.go
+++ b/motor/discovery/aws/ec2_instances.go
@@ -188,9 +188,13 @@ func instanceToAsset(account string, region string, instance types.Instance, ins
 	}
 	// add AWS metadata labels
 	asset.Labels = addAWSMetadataLabels(asset.Labels, ec2InstanceToBasicInstanceInfo(instance, region, account))
-
+	if label, ok := asset.Labels[ImportedFromAWSTagKeyPrefix+AWSNameLabel]; ok {
+		asset.Name = label
+	}
 	return asset
 }
+
+const AWSNameLabel = "Name"
 
 type awsec2id struct {
 	Account  string

--- a/motor/discovery/aws/ssm_instances.go
+++ b/motor/discovery/aws/ssm_instances.go
@@ -203,5 +203,8 @@ func ssmInstanceToAsset(account string, region string, instance types.InstanceIn
 	}
 	// add AWS metadata labels
 	asset.Labels = addAWSMetadataLabels(asset.Labels, ssmInstanceToBasicInstanceInfo(instance, region, account))
+	if label, ok := asset.Labels[ImportedFromAWSTagKeyPrefix+AWSNameLabel]; ok {
+		asset.Name = label
+	}
 	return asset
 }


### PR DESCRIPTION
```
DBG completed instance search insecure=false instances=6
DBG resolved ec2 instance name=k8s-operator01
DBG resolved ec2 instance name=k8s-operator02
DBG resolved ec2 instance name=k8s-operator03
DBG resolved ec2 instance name=vm-with-ebs-iam-role
DBG resolved ec2 instance name=amazonlinux2-for-ebs-volume-scan
DBG resolved ec2 instance name=i-020eed3b1e4965d8d
```

Signed-off-by: Victoria Jeffrey <vj@mondoo.com>