### PR TITLE
🐛 use all resource packs on cnquery run

### DIFF
--- a/apps/cnquery/cmd/plugin.go
+++ b/apps/cnquery/cmd/plugin.go
@@ -17,7 +17,7 @@ import (
 	provider_resolver "go.mondoo.com/cnquery/motor/providers/resolver"
 	"go.mondoo.com/cnquery/mqlc"
 	"go.mondoo.com/cnquery/mqlc/parser"
-	"go.mondoo.com/cnquery/resources/packs/os/info"
+	"go.mondoo.com/cnquery/resources/packs/all/info"
 	"go.mondoo.com/cnquery/shared"
 	"go.mondoo.com/cnquery/shared/proto"
 )

--- a/resources/packs/all/info/all.go
+++ b/resources/packs/all/info/all.go
@@ -18,7 +18,7 @@ import (
 	coreInfo "go.mondoo.com/cnquery/resources/packs/core/info"
 	gcpInfo "go.mondoo.com/cnquery/resources/packs/gcp/info"
 	githubInfo "go.mondoo.com/cnquery/resources/packs/github/info"
-	gitlabInfo "go.mondoo.com/cnquery/resources/packs/github/info"
+	gitlabInfo "go.mondoo.com/cnquery/resources/packs/gitlab/info"
 	k8sInfo "go.mondoo.com/cnquery/resources/packs/k8s/info"
 	ms365Info "go.mondoo.com/cnquery/resources/packs/ms365/info"
 	osInfo "go.mondoo.com/cnquery/resources/packs/os/info"


### PR DESCRIPTION
It was only using the OS pack, which is insufficient to run `cnquery run aws -c ...`. Also fixes a problem where we didnt pull the gitlab resource pack correctly into all.

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>