### PR TITLE
🧹 improve the err msg on the aws application autoscaling resource

### DIFF
--- a/resources/packs/aws/aws_applicationautoscaling.go
+++ b/resources/packs/aws/aws_applicationautoscaling.go
@@ -17,7 +17,7 @@ import (
 func (a *mqlAwsApplicationAutoscaling) id() (string, error) {
 	n, err := a.Namespace()
 	if err != nil {
-		return "", errors.Wrap(err, "namespace required")
+		return "", errors.Wrap(err, "namespace required. please provide an aws service as argument. valid values: [comprehend, rds, sagemaker, appstream, elasticmapreduce, dynamodb, lambda, ecs, cassandra, ec2, neptune, kafka, custom-resource, elasticache]")
 	}
 	return "aws.applicationAutoscaling." + n, nil
 }


### PR DESCRIPTION
https://github.com/mondoohq/cnquery/issues/333#issuecomment-1283644060
```
cnquery> aws.applicationAutoscaling { * }
Query encountered errors:
failed to create resource 'aws.applicationAutoscaling': namespace required. please provide an aws service as argument. valid values: [comprehend, rds, sagemaker, appstream, elasticmapreduce, dynamodb, lambda, ecs, cassandra, ec2, neptune, kafka, custom-resource, elasticache]: "aws.applicationAutoscaling" failed: no value provided for static field "namespace"
aws.applicationAutoscaling: no data available
cnquery> exit
```