### PR TITLE
🌈 add query title or UID to output

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -49,16 +49,16 @@
       ],
     },
     {
-      "name": "cnquery-explore-file",
+      "name": "cnquery-scan-file",
       "type": "go",
       "request": "launch",
       "program": "${workspaceRoot}/apps/cnquery/cnquery.go",
       "cwd": "${workspaceRoot}/",
       "args": [
-        "explore",
+        "scan",
         "local",
         "-f",
-        "./examples/example.unix.mql.yaml"
+        "./examples/example-os.mql.yaml"
       ],
     }
   ]

--- a/cli/reporter/print_compact.go
+++ b/cli/reporter/print_compact.go
@@ -9,6 +9,7 @@ import (
 	"github.com/muesli/termenv"
 	"go.mondoo.com/cnquery/explorer"
 	"go.mondoo.com/cnquery/llx"
+	"go.mondoo.com/cnquery/mrn"
 	"go.mondoo.com/cnquery/stringx"
 )
 
@@ -154,12 +155,17 @@ func (r *defaultReporter) printAssetQueries(assetMrn string, queries []*explorer
 			result = stringx.MaxLines(10, result)
 		}
 
-		// TODO: only in long version + needs styling
-		// r.out.Write([]byte(query.Query))
-		// r.out.Write([]byte{'\n'})
+		title := query.Title
+		if title == "" {
+			title, _ = mrn.GetResource(query.Mrn, "queries")
+		}
+		if title != "" {
+			title += ":\n"
+		}
 
+		r.out.Write([]byte(title))
 		r.out.Write([]byte(result))
-		r.out.Write([]byte{'\n'})
+		r.out.Write([]byte("\n\n"))
 	}
 	r.out.Write([]byte("\n"))
 }


### PR DESCRIPTION
It will try to grab either to print it. If neither is available, we will just stick to printing the output of the query itself. It will improve over time, so that it becomes clearer where it originated. At least for the short version, we want to avoid printing the full query.

![image](https://user-images.githubusercontent.com/1307529/196852604-cc972660-cc9b-4d5f-abd1-0fe624f4ffb2.png)


Signed-off-by: Dominik Richter <dominik.richter@gmail.com>