### PR TITLE
✨Support IP addresses and instance ids for ic and ssm connectivity.

### DIFF
--- a/motor/providers/ssh/session.go
+++ b/motor/providers/ssh/session.go
@@ -175,7 +175,8 @@ func prepareConnection(pCfg *providers.Config) ([]ssh.AuthMethod, []io.Closer, e
 			// prepare websocket connection and bind it to a free local port
 			localIp := "localhost"
 			remotePort := "22"
-
+			// NOTE: for SSM we always target the instance id
+			pCfg.Host = creds.InstanceId
 			localPort, err := awsssmsession.GetAvailablePort()
 			if err != nil {
 				return nil, nil, errors.New("could not find an available port to start the ssm proxy")


### PR DESCRIPTION
Supports both:
```
cnquery shell aws ec2 ssm ubuntu@255.255.255.255
cnquery shell aws ec2 instance-connect ubuntu@255.255.255.255
```
and
```
cnquery shell aws ec2 ssm ubuntu@i-03a9f7b6c706f43d5
cnquery shell aws ec2 instance-connect ubuntu@i-03a9f7b6c706f43d5
```