### PR TITLE
🧹 Improve error message if no identity file or password are provided for ssh auth

### DIFF
--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -141,6 +141,9 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 		if err != nil {
 			log.Error().Err(err).Msg("cannot parse target")
 		}
+		if identityFile == "" && password == "" {
+			log.Warn().Msg("No identity file or password are provided for ssh authentication, use either --identity-file, --ask-pass or --password. Falling back to ssh agent authentication.")
+		}
 		connection.Host = target.Hostname
 		connection.Port = target.Port
 		connection.Path = target.Path


### PR DESCRIPTION
Fixes https://github.com/mondoohq/cnquery/issues/291

```
➜ go run apps/cnquery/cnquery.go shell ssh ubuntu@255.255.255.255
→ loaded configuration from /Users/preslavgerchev/.config/mondoo/mondoo.yml using source default
! No identity file or password are provided for ssh authentication, use either --identity-file, --ask-pass or --password. Falling back to ssh agent authentication.
→ discover related assets for 1 asset(s)
→ resolved assets resolved-assets=0
x could not connect to asset error="ssh: handshake failed: ssh: unable to authenticate, attempted methods [none], no supported methods remain" asset=255.255.255.255
FTL could not resolve assets
exit status 1
```

Please feel free to improve the error message if you want to!