### PR TITLE
⭐️  new login and logout subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The Query Hub creates a secure, private environment in your account that stores 
 To use the Query Hub:
 
 ```bash
-cnquery auth login
+cnquery login --token TOKEN
 ```
 
 Once set up, you can collect your asset's data (for example `aws`):

--- a/apps/cnquery/cmd/logout.go
+++ b/apps/cnquery/cmd/logout.go
@@ -16,13 +16,14 @@ import (
 )
 
 func init() {
-	rootCmd.AddCommand(unregisterCmd)
-	unregisterCmd.Flags().Bool("force", false, "Force registration")
+	rootCmd.AddCommand(logoutCmd)
+	logoutCmd.Flags().Bool("force", false, "Force re-authentication")
 }
 
-var unregisterCmd = &cobra.Command{
-	Use:   "unregister",
-	Short: "Unregister from Mondoo Platform",
+var logoutCmd = &cobra.Command{
+	Use:     "logout",
+	Aliases: []string{"unregister"},
+	Short:   "Log out from Mondoo Platform",
 	Long: `
 This process also initiates a revocation of the client's service account to ensure
 the credentials cannot be used in future anymore.


### PR DESCRIPTION
This change allows cnquery to login to Mondoo Platform

```
cnquery login --token $MONDOO_TOKEN --config cnquery-test.yml
→ token will expire at Thu, 20 Oct 2022 21:34:22 CEST
→ saving config path=cnquery-test.yml
→ config file does not exist, create a new one path=cnquery-test.yml
→ client //agents.api.mondoo.app/spaces/test-infallible-taussig-796596/agents/2G89H49tT6yJyR37vaGRONzFWuP has logged in successfully
```

- renamed old `registration` subcommand to new `login`subcommand
- renamed old `unregistration` subcommand to new `logout`subcommand