### PR TITLE
⭐️ pack upload to query hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can then pipe the output to [jq](https://stedolan.github.io/jq/) or other ap
 
 ## Query packs
 
-You can combine multiple queries into query packs, which can run together. `cnquery` comes with query packs out of the box for most systems. You can simply run:
+You can combine multiple queries into query packs, which can run together. `cnquery` comes with default [query packs](https://github.com/mondoohq/cnquery-packs) out of the box for most systems. You can simply run:
 
 ```bash
 cnquery scan
@@ -106,11 +106,11 @@ Like all other commands, you can specify different providers like `k8s`, `aws`, 
 
 These files can also contain multiple query packs for many different target systems. For an example, see `examples/multi-target.mql.yaml`.
 
-## Distributing cnqueries across your fleet
+## Private Query Packs 
 
-You can share query packs across your fleet using the Query Hub.
+Distributing cnqueries across your fleet
 
-The Query Hub creates a secure, private environment in your account that stores data about your assets. It makes it very easy for all assets to report on query packs and define custom rules for your fleet.
+You can share query packs across your fleet using the Mondoo's Query Hub. The Query Hub creates a secure, private environment in your account that stores data about your assets. It makes it very easy for all assets to report on query packs and define custom rules for your fleet.
 
 To use the Query Hub:
 
@@ -118,7 +118,7 @@ To use the Query Hub:
 cnquery auth login
 ```
 
-Once set up, you can collect your asset's data (for example `aws`):
+Once set up, activate the Pack's and you can collect your asset's data (for example `aws`):
 
 ```bash
 cnquery scan aws
@@ -127,7 +127,7 @@ cnquery scan aws
 To add custom query packs, you can upload them:
 
 ```bash
-cnquery pack upload mypack.mql.yaml
+cnquery bundle upload mypack.mql.yaml
 ```
 
 ## Supported Targets

--- a/apps/cnquery/cmd/bundle.go
+++ b/apps/cnquery/cmd/bundle.go
@@ -3,11 +3,19 @@ package cmd
 import (
 	"context"
 	_ "embed"
+	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	cnquery_config "go.mondoo.com/cnquery/apps/cnquery/cmd/config"
+	"go.mondoo.com/cnquery/cli/config"
 	"go.mondoo.com/cnquery/explorer"
+	"go.mondoo.com/cnquery/stringx"
+	"go.mondoo.com/cnquery/upstream"
+	"go.mondoo.com/ranger-rpc"
 )
 
 func init() {
@@ -17,12 +25,16 @@ func init() {
 	// bundle validate
 	packBundlesCmd.AddCommand(queryPackValidateCmd)
 
+	// bundle add
+	packBundlesCmd.AddCommand(queryPackUploadCmd)
+
 	rootCmd.AddCommand(packBundlesCmd)
 }
 
 var packBundlesCmd = &cobra.Command{
-	Use:   "bundle",
-	Short: "Manage query packs",
+	Use:     "bundle",
+	Aliases: []string{"pack"},
+	Short:   "Manage query packs",
 }
 
 //go:embed bundle_querypack-example.mql.yaml
@@ -51,21 +63,148 @@ var queryPackInitCmd = &cobra.Command{
 	},
 }
 
+func validate(queryPackBundle *explorer.Bundle) []string {
+	errors := []string{}
+
+	// check that we have uids for packs and queries
+	for i := range queryPackBundle.Packs {
+		pack := queryPackBundle.Packs[i]
+		packId := strconv.Itoa(i)
+
+		if pack.Uid == "" {
+			errors = append(errors, fmt.Sprintf("pack %s does not define a uid", packId))
+		} else {
+			packId = pack.Uid
+		}
+
+		if pack.Name == "" {
+			errors = append(errors, fmt.Sprintf("pack %s does not define a name", packId))
+		}
+
+		for j := range pack.Queries {
+			query := pack.Queries[j]
+			queryId := strconv.Itoa(j)
+			if query.Uid == "" {
+				errors = append(errors, fmt.Sprintf("query %s/%s does not define a uid", packId, queryId))
+			} else {
+				queryId = query.Uid
+			}
+
+			if query.Title == "" {
+				errors = append(errors, fmt.Sprintf("query %s/%s does not define a name", packId, queryId))
+			}
+		}
+	}
+
+	// we compile after the checks because it removes the uids and replaces it with mrns
+	_, err := queryPackBundle.Compile(context.Background())
+	if err != nil {
+		errors = append(errors, "could not compile the query pack bundle", err.Error())
+	}
+
+	return errors
+}
+
 var queryPackValidateCmd = &cobra.Command{
 	Use:   "validate [path]",
 	Short: "Validates a query pack",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Info().Str("file", args[0]).Msg("validate query pack")
-		pack, err := explorer.BundleFromPaths(args[0])
+		queryPackBundle, err := explorer.BundleFromPaths(args[0])
 		if err != nil {
 			log.Fatal().Err(err).Msg("could not load query pack")
 		}
 
-		_, err = pack.Compile(context.Background())
+		errors := validate(queryPackBundle)
+		if len(errors) > 0 {
+			log.Error().Msg("could not validate query pack")
+			for i := range errors {
+				fmt.Fprintf(os.Stderr, stringx.Indent(2, errors[i]))
+			}
+			os.Exit(1)
+		}
+
+		log.Info().Msg("valid query pack")
+	},
+}
+
+var queryPackUploadCmd = &cobra.Command{
+	Use:   "upload [path]",
+	Short: "Adds a user-owned pack to Mondoo's Query Hub",
+	Args:  cobra.ExactArgs(1),
+	PreRun: func(cmd *cobra.Command, args []string) {
+		viper.BindPFlag("pack-version", cmd.Flags().Lookup("pack-version"))
+		viper.BindPFlag("output", cmd.Flags().Lookup("output"))
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		opts, optsErr := cnquery_config.ReadConfig()
+		if optsErr != nil {
+			log.Fatal().Err(optsErr).Msg("could not load configuration")
+		}
+		config.DisplayUsedConfig()
+
+		filename := args[0]
+		log.Info().Str("file", filename).Msg("load query pack bundle")
+		queryPackBundle, err := explorer.BundleFromPaths(filename)
 		if err != nil {
-			log.Fatal().Err(err).Msg("could not validate query pack")
+			log.Fatal().Err(err).Msg("could not load query pack bundle")
+		}
+
+		errors := validate(queryPackBundle)
+		if len(errors) > 0 {
+			log.Error().Msg("could not validate query pack")
+			for i := range errors {
+				fmt.Fprintf(os.Stderr, stringx.Indent(2, errors[i]))
+			}
+			os.Exit(1)
 		}
 		log.Info().Msg("valid query pack")
+
+		// compile manipulates the bundle, therefore we read it again
+		queryPackBundle, err = explorer.BundleFromPaths(filename)
+		if err != nil {
+			log.Fatal().Err(err).Msg("could not load query pack bundle")
+		}
+
+		log.Info().Str("space", opts.SpaceMrn).Msg("add query pack bundle to space")
+		overrideVersionFlag := false
+		overrideVersion := viper.GetString("pack-version")
+		if len(overrideVersion) > 0 {
+			overrideVersionFlag = true
+		}
+
+		serviceAccount := opts.GetServiceCredential()
+		if serviceAccount == nil {
+			log.Fatal().Msg("cnquery has no credentials. Log in with `cnquery login`")
+		}
+
+		certAuth, _ := upstream.NewServiceAccountRangerPlugin(serviceAccount)
+		queryHubServices, err := explorer.NewQueryHubClient(opts.UpstreamApiEndpoint(), ranger.DefaultHttpClient(), certAuth)
+		if err != nil {
+			log.Fatal().Err(err).Msg("could not connect to query hub")
+		}
+
+		// set the owner mrn for spaces
+		queryPackBundle.OwnerMrn = opts.SpaceMrn
+		ctx := context.Background()
+
+		// override version and/or labels
+		for i := range queryPackBundle.Packs {
+			p := queryPackBundle.Packs[i]
+
+			// override query pack version
+			if overrideVersionFlag {
+				p.Version = overrideVersion
+			}
+		}
+
+		// send data upstream
+		_, err = queryHubServices.SetBundle(ctx, queryPackBundle)
+		if err != nil {
+			log.Fatal().Err(err).Msg("could not add query packs")
+		}
+
+		log.Info().Msg("successfully added query packs")
 	},
 }

--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -402,7 +402,6 @@ func getCobraScanConfig(cmd *cobra.Command, args []string, provider providers.Pr
 	if serviceAccount != nil {
 		log.Info().Msg("using service account credentials")
 		certAuth, _ := upstream.NewServiceAccountRangerPlugin(serviceAccount)
-
 		conf.UpstreamConfig = &resources.UpstreamConfig{
 			SpaceMrn:    opts.GetParentMrn(),
 			ApiEndpoint: opts.UpstreamApiEndpoint(),

--- a/explorer/querypack.go
+++ b/explorer/querypack.go
@@ -17,7 +17,7 @@ func (p *QueryPack) InvalidateAllChecksums() {
 // RefreshMRN computes a MRN from the UID or validates the existing MRN.
 // Both of these need to fit the ownerMRN. It also removes the UID.
 func (p *QueryPack) RefreshMRN(ownerMRN string) error {
-	nu, err := RefreshMRN(ownerMRN, p.Mrn, "query pack", p.Uid)
+	nu, err := RefreshMRN(ownerMRN, p.Mrn, "querypack", p.Uid)
 	if err != nil {
 		log.Error().Err(err).Str("owner", ownerMRN).Str("uid", p.Uid).Msg("failed to refresh mrn")
 		return errors.Wrap(err, "failed to refresh mrn for query "+p.Name)


### PR DESCRIPTION
This change allows users to upload from cnquery to Mondoo Platform

```
$ cnquery bundle validate example-pack.mql.yaml
→ validate query pack file=example-pack.mql.yaml
x could not validate query pack
  pack example-pack does not define a name

$ cnquery bundle validate example-pack.mql.yaml
→ validate query pack file=example-pack.mql.yaml
→ valid query pack

$ cnquery bundle upload example-pack.mql.yaml
→ load query pack bundle file=example-pack.mql.yaml
→ valid query pack
→ add query pack bundle to space space=//captain.api.mondoo.app/spaces/test-infallible-taussig-796596
→ successfully added query packs
```

- improves the validate function
- compiles the bundle before upload

Once the file is uploaded you see it in Mondoo's Query Hub

<img width="1443" alt="Screenshot 2022-10-20 at 21 27 55" src="https://user-images.githubusercontent.com/1178413/197041592-1b0f5c9e-298a-43a5-a7ff-b754a54dd72c.png">
