### PR TITLE
⭐️ use upstream configuration if credentials are provided

### DIFF
--- a/explorer/scan/scan.go
+++ b/explorer/scan/scan.go
@@ -9,6 +9,7 @@ import (
 	"go.mondoo.com/cnquery/motor"
 	"go.mondoo.com/cnquery/motor/asset"
 	"go.mondoo.com/cnquery/motor/vault"
+	"go.mondoo.com/cnquery/resources"
 )
 
 //go:generate protoc --proto_path=../../:. --go_out=. --go_opt=paths=source_relative --rangerrpc_out=. cnquery_explorer_scan.proto
@@ -19,7 +20,7 @@ func init() {
 
 type AssetJob struct {
 	DoRecord         bool
-	Incognito        bool
+	UpstremConfig    resources.UpstreamConfig
 	Asset            *asset.Asset
 	Bundle           *explorer.Bundle
 	QueryPackFilters []string

--- a/resources/runtime.go
+++ b/resources/runtime.go
@@ -66,7 +66,6 @@ func (c *Cache) Delete(key string) { c.Map.Delete(key) }
 type UpstreamConfig struct {
 	AssetMrn    string
 	SpaceMrn    string
-	Collector   string
 	ApiEndpoint string
 	Plugins     []ranger.ClientPlugin
 	Incognito   bool


### PR DESCRIPTION
This change allows authenticated users to use eol and vulnerability data from mql resources. This is the first step. In a second iteration we connect cnquery to the public Mondoo Vulnerability Database (MVD) so that users do not need to be authenticated.