### PR TITLE
add --namespaces-exclude --namespaces parameters

### DIFF
--- a/apps/cnquery/cmd/builder/builder.go
+++ b/apps/cnquery/cmd/builder/builder.go
@@ -394,9 +394,11 @@ func kubernetesProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, 
 		Args:    cobra.MaximumNArgs(1),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			preRun(cmd, args)
+			// FIXME: DEPRECATED, remove in v8.0 vv
 			viper.BindPFlag("namespace", cmd.Flags().Lookup("namespace"))
+			// ^^
 			viper.BindPFlag("namespaces-exclude", cmd.Flags().Lookup("namespaces-exclude"))
-			viper.BindPFlag("namespaces-include", cmd.Flags().Lookup("namespaces-include"))
+			viper.BindPFlag("namespaces", cmd.Flags().Lookup("namespaces"))
 			viper.BindPFlag("context", cmd.Flags().Lookup("context"))
 		},
 		Run: func(cmd *cobra.Command, args []string) {
@@ -407,10 +409,14 @@ func kubernetesProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, 
 		},
 	}
 	commonCmdFlags(cmd)
+	// FIXME: DEPRECATED, remove in v8.0
 	cmd.Flags().String("namespace", "", "filter kubernetes objects by namespace")
+	cmd.Flags().MarkHidden("namespace")
+	// ^^
+
 	cmd.Flags().String("context", "", "target a kubernetes context")
 	cmd.Flags().String("namespaces-exclude", "", "filter out kubernetes objects in the matching namespaces")
-	cmd.Flags().String("namespaces-include", "", "only include kubernetes object in the matching namespaces")
+	cmd.Flags().String("namespaces", "", "only include kubernetes object in the matching namespaces")
 	return cmd
 }
 

--- a/apps/cnquery/cmd/builder/builder.go
+++ b/apps/cnquery/cmd/builder/builder.go
@@ -395,7 +395,8 @@ func kubernetesProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, 
 		PreRun: func(cmd *cobra.Command, args []string) {
 			preRun(cmd, args)
 			viper.BindPFlag("namespace", cmd.Flags().Lookup("namespace"))
-			viper.BindPFlag("skip-namespaces", cmd.Flags().Lookup("skip-namespaces"))
+			viper.BindPFlag("namespaces-exclude", cmd.Flags().Lookup("namespaces-exclude"))
+			viper.BindPFlag("namespaces-include", cmd.Flags().Lookup("namespaces-include"))
 			viper.BindPFlag("context", cmd.Flags().Lookup("context"))
 		},
 		Run: func(cmd *cobra.Command, args []string) {
@@ -408,7 +409,8 @@ func kubernetesProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, 
 	commonCmdFlags(cmd)
 	cmd.Flags().String("namespace", "", "filter kubernetes objects by namespace")
 	cmd.Flags().String("context", "", "target a kubernetes context")
-	cmd.Flags().String("skip-namespaces", "", "filter out kubernetes objects in the matching namespaces")
+	cmd.Flags().String("namespaces-exclude", "", "filter out kubernetes objects in the matching namespaces")
+	cmd.Flags().String("namespaces-include", "", "only include kubernetes object in the matching namespaces")
 	return cmd
 }
 

--- a/apps/cnquery/cmd/builder/builder.go
+++ b/apps/cnquery/cmd/builder/builder.go
@@ -395,6 +395,7 @@ func kubernetesProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, 
 		PreRun: func(cmd *cobra.Command, args []string) {
 			preRun(cmd, args)
 			viper.BindPFlag("namespace", cmd.Flags().Lookup("namespace"))
+			viper.BindPFlag("skip-namespaces", cmd.Flags().Lookup("skip-namespaces"))
 			viper.BindPFlag("context", cmd.Flags().Lookup("context"))
 		},
 		Run: func(cmd *cobra.Command, args []string) {
@@ -407,6 +408,7 @@ func kubernetesProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, 
 	commonCmdFlags(cmd)
 	cmd.Flags().String("namespace", "", "filter kubernetes objects by namespace")
 	cmd.Flags().String("context", "", "target a kubernetes context")
+	cmd.Flags().String("skip-namespaces", "", "filter out kubernetes objects in the matching namespaces")
 	return cmd
 }
 

--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -231,6 +231,12 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 		} else if namespace != "" {
 			connection.Options["namespace"] = namespace
 		}
+
+		if skipNamespaces, err := cmd.Flags().GetString("skip-namespaces"); err != nil {
+			log.Fatal().Err(err).Msg("cannot parse --skip-namespaces values")
+		} else if skipNamespaces != "" {
+			connection.Options["skip-namespaces"] = skipNamespaces
+		}
 	case providers.ProviderType_AWS:
 		connection.Backend = providerType
 		if profile, err := cmd.Flags().GetString("profile"); err != nil {

--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -232,10 +232,16 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 			connection.Options["namespace"] = namespace
 		}
 
-		if skipNamespaces, err := cmd.Flags().GetString("skip-namespaces"); err != nil {
-			log.Fatal().Err(err).Msg("cannot parse --skip-namespaces values")
-		} else if skipNamespaces != "" {
-			connection.Options["skip-namespaces"] = skipNamespaces
+		if excludeNamespaces, err := cmd.Flags().GetString("namespaces-exclude"); err != nil {
+			log.Fatal().Err(err).Msg("cannot parse --namespaces-exclude values")
+		} else if excludeNamespaces != "" {
+			connection.Options["namespaces-exclude"] = excludeNamespaces
+		}
+
+		if includeNamespaces, err := cmd.Flags().GetString("namespaces-include"); err != nil {
+			log.Fatal().Err(err).Msg("cannot parse --namespaces-include values")
+		} else if includeNamespaces != "" {
+			connection.Options["namespaces-include"] = includeNamespaces
 		}
 	case providers.ProviderType_AWS:
 		connection.Backend = providerType

--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -226,11 +226,13 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 			connection.Options["path"] = filepath
 		}
 
+		// FIXME: DEPRECATED, remove in v8.0 vv
 		if namespace, err := cmd.Flags().GetString("namespace"); err != nil {
 			log.Fatal().Err(err).Msg("cannot parse --namespace values")
 		} else if namespace != "" {
 			connection.Options["namespace"] = namespace
 		}
+		// ^^
 
 		if excludeNamespaces, err := cmd.Flags().GetString("namespaces-exclude"); err != nil {
 			log.Fatal().Err(err).Msg("cannot parse --namespaces-exclude values")
@@ -238,10 +240,10 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 			connection.Options["namespaces-exclude"] = excludeNamespaces
 		}
 
-		if includeNamespaces, err := cmd.Flags().GetString("namespaces-include"); err != nil {
-			log.Fatal().Err(err).Msg("cannot parse --namespaces-include values")
+		if includeNamespaces, err := cmd.Flags().GetString("namespaces"); err != nil {
+			log.Fatal().Err(err).Msg("cannot parse --namespaces values")
 		} else if includeNamespaces != "" {
-			connection.Options["namespaces-include"] = includeNamespaces
+			connection.Options["namespaces"] = includeNamespaces
 		}
 	case providers.ProviderType_AWS:
 		connection.Backend = providerType

--- a/motor/discovery/k8s/list_images.go
+++ b/motor/discovery/k8s/list_images.go
@@ -22,7 +22,7 @@ const dockerPullablePrefix = "docker-pullable://"
 
 // ListPodImages lits all container images for the pods in the cluster. Only unique container images are returned.
 // Uniqueness is determined based on the container digests.
-func ListPodImages(p k8s.KubernetesProvider, namespaceFilter string, od *k8s.PlatformIdOwnershipDirectory) ([]*asset.Asset, error) {
+func ListPodImages(p k8s.KubernetesProvider, nsFilter NamespaceFilterOpts, od *k8s.PlatformIdOwnershipDirectory) ([]*asset.Asset, error) {
 	namespaces, err := p.Namespaces()
 	if err != nil {
 		return nil, errors.Wrap(err, "could not list kubernetes namespaces")
@@ -33,8 +33,8 @@ func ListPodImages(p k8s.KubernetesProvider, namespaceFilter string, od *k8s.Pla
 	credsStore := NewCredsStore(p)
 	for i := range namespaces {
 		namespace := namespaces[i]
-		if namespaceFilter != "" && namespace.Name != namespaceFilter {
-			log.Debug().Str("namespace", namespace.Name).Str("filter", namespaceFilter).Msg("namespace not included")
+		if skipNamespace(namespace, nsFilter) {
+			log.Debug().Str("namespace", namespace.Name).Msg("namespace not included")
 			continue
 		}
 

--- a/motor/discovery/k8s/list_images_test.go
+++ b/motor/discovery/k8s/list_images_test.go
@@ -79,7 +79,7 @@ func TestListPodImage(t *testing.T) {
 
 	clusterIdentifier := "//platformid.api.mondoo.app/runtime/k8s/uid/e26043bb-8669-48a2-b684-b1e132198cdc"
 	ownershipDir := k8s.NewEmptyPlatformIdOwnershipDirectory(clusterIdentifier)
-	assets, err := ListPodImages(p, "", ownershipDir)
+	assets, err := ListPodImages(p, NamespaceFilterOpts{}, ownershipDir)
 	assert.NoError(t, err)
 
 	var assetNames []string
@@ -183,7 +183,7 @@ func TestListPodImage_FromStatus(t *testing.T) {
 
 	clusterIdentifier := "//platformid.api.mondoo.app/runtime/k8s/uid/e26043bb-8669-48a2-b684-b1e132198cdc"
 	ownershipDir := k8s.NewEmptyPlatformIdOwnershipDirectory(clusterIdentifier)
-	assets, err := ListPodImages(p, "", ownershipDir)
+	assets, err := ListPodImages(p, NamespaceFilterOpts{}, ownershipDir)
 	assert.NoError(t, err)
 
 	var assetNames []string

--- a/motor/discovery/k8s/list_workloads.go
+++ b/motor/discovery/k8s/list_workloads.go
@@ -15,7 +15,7 @@ import (
 
 type NamespaceFilterOpts struct {
 	include []string
-	ignore  []string
+	exclude []string
 }
 
 // ListCronJobs list all cronjobs in the cluster.
@@ -184,7 +184,7 @@ func skipNamespace(namespace v1.Namespace, filter NamespaceFilterOpts) bool {
 
 	// if nothing explictly meant to be included, then check whether
 	// it should be excluded
-	for _, ns := range filter.ignore {
+	for _, ns := range filter.exclude {
 		if namespace.Name == ns {
 			return true
 		}

--- a/motor/discovery/k8s/list_workloads_test.go
+++ b/motor/discovery/k8s/list_workloads_test.go
@@ -134,7 +134,7 @@ func TestListCronJobs(t *testing.T) {
 
 	pCfg := &providers.Config{}
 	ownershipDir := k8s.NewEmptyPlatformIdOwnershipDirectory(clusterIdentifier)
-	assets, err := ListCronJobs(p, pCfg, clusterIdentifier, "", make(map[string][]K8sResourceIdentifier), ownershipDir)
+	assets, err := ListCronJobs(p, pCfg, clusterIdentifier, NamespaceFilterOpts{}, make(map[string][]K8sResourceIdentifier), ownershipDir)
 	require.NoError(t, err)
 	require.Equal(t, []string{k8s.NewPlatformWorkloadId(clusterIdentifier,
 		strings.ToLower(parent.Kind),
@@ -248,7 +248,7 @@ func TestListCronJobs_Filter(t *testing.T) {
 			{Type: "cronjob", Name: cronjobs[0].Name, Namespace: cronjobs[0].Namespace},
 		},
 	}
-	assets, err := ListCronJobs(p, pCfg, clusterIdentifier, "", resFilter, ownershipDir)
+	assets, err := ListCronJobs(p, pCfg, clusterIdentifier, NamespaceFilterOpts{}, resFilter, ownershipDir)
 	require.NoError(t, err)
 
 	var assetNames []string
@@ -368,7 +368,7 @@ func TestListDaemonsets(t *testing.T) {
 
 	pCfg := &providers.Config{}
 	ownershipDir := k8s.NewEmptyPlatformIdOwnershipDirectory(clusterIdentifier)
-	assets, err := ListDaemonSets(p, pCfg, clusterIdentifier, "", make(map[string][]K8sResourceIdentifier), ownershipDir)
+	assets, err := ListDaemonSets(p, pCfg, clusterIdentifier, NamespaceFilterOpts{}, make(map[string][]K8sResourceIdentifier), ownershipDir)
 	require.NoError(t, err)
 	require.Equal(t, []string{k8s.NewPlatformWorkloadId(clusterIdentifier,
 		strings.ToLower(parent.Kind),
@@ -462,7 +462,7 @@ func TestListDaemonsets_Filter(t *testing.T) {
 			{Type: "daemonset", Name: daemonsets[0].Name, Namespace: daemonsets[0].Namespace},
 		},
 	}
-	assets, err := ListDaemonSets(p, pCfg, clusterIdentifier, "", resFilter, ownershipDir)
+	assets, err := ListDaemonSets(p, pCfg, clusterIdentifier, NamespaceFilterOpts{}, resFilter, ownershipDir)
 	require.NoError(t, err)
 
 	var assetNames []string
@@ -575,7 +575,7 @@ func TestListDeployments(t *testing.T) {
 
 	pCfg := &providers.Config{}
 	ownershipDir := k8s.NewEmptyPlatformIdOwnershipDirectory(clusterIdentifier)
-	assets, err := ListDeployments(p, pCfg, clusterIdentifier, "", make(map[string][]K8sResourceIdentifier), ownershipDir)
+	assets, err := ListDeployments(p, pCfg, clusterIdentifier, NamespaceFilterOpts{}, make(map[string][]K8sResourceIdentifier), ownershipDir)
 	require.NoError(t, err)
 	require.Equal(t, []string{k8s.NewPlatformWorkloadId(clusterIdentifier,
 		strings.ToLower(parent.Kind),
@@ -669,7 +669,7 @@ func TestListDeployments_Filter(t *testing.T) {
 			{Type: "deployment", Name: deployments[0].Name, Namespace: deployments[0].Namespace},
 		},
 	}
-	assets, err := ListDeployments(p, pCfg, clusterIdentifier, "", resFilter, ownershipDir)
+	assets, err := ListDeployments(p, pCfg, clusterIdentifier, NamespaceFilterOpts{}, resFilter, ownershipDir)
 	require.NoError(t, err)
 
 	var assetNames []string
@@ -793,7 +793,7 @@ func TestListJobs(t *testing.T) {
 	pCfg := &providers.Config{}
 	ownershipDir := k8s.NewEmptyPlatformIdOwnershipDirectory(clusterIdentifier)
 	ownershipDir.Add(&parent)
-	assets, err := ListJobs(p, pCfg, clusterIdentifier, "", make(map[string][]K8sResourceIdentifier), ownershipDir)
+	assets, err := ListJobs(p, pCfg, clusterIdentifier, NamespaceFilterOpts{}, make(map[string][]K8sResourceIdentifier), ownershipDir)
 	require.NoError(t, err)
 	require.Equal(t, []string{k8s.NewPlatformWorkloadId(clusterIdentifier,
 		strings.ToLower(parent.Kind),
@@ -897,7 +897,7 @@ func TestListJobs_Filter(t *testing.T) {
 			{Type: "job", Name: jobs[0].Name, Namespace: jobs[0].Namespace},
 		},
 	}
-	assets, err := ListJobs(p, pCfg, clusterIdentifier, "", resFilter, ownershipDir)
+	assets, err := ListJobs(p, pCfg, clusterIdentifier, NamespaceFilterOpts{}, resFilter, ownershipDir)
 	require.NoError(t, err)
 
 	var assetNames []string
@@ -1001,7 +1001,7 @@ func TestListPods(t *testing.T) {
 
 	pCfg := &providers.Config{}
 	ownershipDir := k8s.NewEmptyPlatformIdOwnershipDirectory(clusterIdentifier)
-	assets, err := ListPods(p, pCfg, clusterIdentifier, "", make(map[string][]K8sResourceIdentifier), ownershipDir)
+	assets, err := ListPods(p, pCfg, clusterIdentifier, NamespaceFilterOpts{}, make(map[string][]K8sResourceIdentifier), ownershipDir)
 	require.NoError(t, err)
 	require.Equal(t, []string{k8s.NewPlatformWorkloadId(clusterIdentifier,
 		strings.ToLower(parent.Kind),
@@ -1086,7 +1086,7 @@ func TestListPods_Filter(t *testing.T) {
 			{Type: "pod", Name: pods[0].Name, Namespace: pods[0].Namespace},
 		},
 	}
-	assets, err := ListPods(p, pCfg, clusterIdentifier, "", resFilter, ownershipDir)
+	assets, err := ListPods(p, pCfg, clusterIdentifier, NamespaceFilterOpts{}, resFilter, ownershipDir)
 	require.NoError(t, err)
 	var assetNames []string
 	for _, a := range assets {
@@ -1202,7 +1202,7 @@ func TestListReplicaSets(t *testing.T) {
 
 	pCfg := &providers.Config{}
 	ownershipDir := k8s.NewEmptyPlatformIdOwnershipDirectory(clusterIdentifier)
-	assets, err := ListReplicaSets(p, pCfg, clusterIdentifier, "", make(map[string][]K8sResourceIdentifier), ownershipDir)
+	assets, err := ListReplicaSets(p, pCfg, clusterIdentifier, NamespaceFilterOpts{}, make(map[string][]K8sResourceIdentifier), ownershipDir)
 	require.NoError(t, err)
 	require.Equal(t, []string{k8s.NewPlatformWorkloadId(clusterIdentifier,
 		strings.ToLower(parent.Kind),
@@ -1296,7 +1296,7 @@ func TestListReplicaSets_Filter(t *testing.T) {
 			{Type: "replicaset", Name: replicaSets[0].Name, Namespace: replicaSets[0].Namespace},
 		},
 	}
-	assets, err := ListReplicaSets(p, pCfg, clusterIdentifier, "", resFilter, ownershipDir)
+	assets, err := ListReplicaSets(p, pCfg, clusterIdentifier, NamespaceFilterOpts{}, resFilter, ownershipDir)
 	require.NoError(t, err)
 
 	var assetNames []string
@@ -1426,7 +1426,7 @@ func TestListStatefulSets(t *testing.T) {
 
 	pCfg := &providers.Config{}
 	ownershipDir := k8s.NewEmptyPlatformIdOwnershipDirectory(clusterIdentifier)
-	assets, err := ListStatefulSets(p, pCfg, clusterIdentifier, "", make(map[string][]K8sResourceIdentifier), ownershipDir)
+	assets, err := ListStatefulSets(p, pCfg, clusterIdentifier, NamespaceFilterOpts{}, make(map[string][]K8sResourceIdentifier), ownershipDir)
 	require.NoError(t, err)
 	require.Equal(t, []string{k8s.NewPlatformWorkloadId(clusterIdentifier,
 		strings.ToLower(parent.Kind),
@@ -1530,7 +1530,7 @@ func TestListStatefulSets_Filter(t *testing.T) {
 			{Type: "statefulset", Name: statefulsets[0].Name, Namespace: statefulsets[0].Namespace},
 		},
 	}
-	assets, err := ListStatefulSets(p, pCfg, clusterIdentifier, "", resFilter, ownershipDir)
+	assets, err := ListStatefulSets(p, pCfg, clusterIdentifier, NamespaceFilterOpts{}, resFilter, ownershipDir)
 	require.NoError(t, err)
 
 	var assetNames []string

--- a/motor/discovery/k8s/list_workloads_test.go
+++ b/motor/discovery/k8s/list_workloads_test.go
@@ -1623,12 +1623,12 @@ func TestListFiltering(t *testing.T) {
 	assert.Equal(t, 4, len(assets), "expected only 1 Pod to be returned")
 
 	// Exclude kube-system
-	assets, err = ListPods(p, pCfg, clusterIdentifier, NamespaceFilterOpts{ignore: []string{nss[1].Name}}, make(map[string][]K8sResourceIdentifier), ownershipDir)
+	assets, err = ListPods(p, pCfg, clusterIdentifier, NamespaceFilterOpts{exclude: []string{nss[1].Name}}, make(map[string][]K8sResourceIdentifier), ownershipDir)
 	require.NoError(t, err)
 	assert.Equal(t, 5, len(assets), "expected only 1 Pod to be returned")
 
 	// Include and exclude list should behave like only include list
-	assets, err = ListPods(p, pCfg, clusterIdentifier, NamespaceFilterOpts{include: []string{nss[1].Name}, ignore: []string{nss[1].Name}}, make(map[string][]K8sResourceIdentifier), ownershipDir)
+	assets, err = ListPods(p, pCfg, clusterIdentifier, NamespaceFilterOpts{include: []string{nss[1].Name}, exclude: []string{nss[1].Name}}, make(map[string][]K8sResourceIdentifier), ownershipDir)
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(assets), "expected only 1 Pod to be returned")
 }

--- a/motor/discovery/k8s/list_workloads_test.go
+++ b/motor/discovery/k8s/list_workloads_test.go
@@ -1620,12 +1620,12 @@ func TestListFiltering(t *testing.T) {
 	// List 'kube-system' and 'other-namespace'
 	assets, err = ListPods(p, pCfg, clusterIdentifier, NamespaceFilterOpts{include: []string{nss[1].Name, nss[2].Name}}, make(map[string][]K8sResourceIdentifier), ownershipDir)
 	require.NoError(t, err)
-	assert.Equal(t, 4, len(assets), "expected only 1 Pod to be returned")
+	assert.Equal(t, 4, len(assets), "expected only 4 Pods to be returned")
 
 	// Exclude kube-system
 	assets, err = ListPods(p, pCfg, clusterIdentifier, NamespaceFilterOpts{exclude: []string{nss[1].Name}}, make(map[string][]K8sResourceIdentifier), ownershipDir)
 	require.NoError(t, err)
-	assert.Equal(t, 5, len(assets), "expected only 1 Pod to be returned")
+	assert.Equal(t, 5, len(assets), "expected only 5 Pods to be returned")
 
 	// Include and exclude list should behave like only include list
 	assets, err = ListPods(p, pCfg, clusterIdentifier, NamespaceFilterOpts{include: []string{nss[1].Name}, exclude: []string{nss[1].Name}}, make(map[string][]K8sResourceIdentifier), ownershipDir)

--- a/motor/discovery/k8s/resolver.go
+++ b/motor/discovery/k8s/resolver.go
@@ -82,16 +82,19 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 		return nil, err
 	}
 
-	// if --namespace and --namespaces-include were both specified, just combine them into a single
+	// if --namespace and --namespaces were both specified, just combine them into a single
 	// list of Namespaces to allow resources from
+
+	// FIXME: DEPRECATED, remove in v8.0 vv
 	namespaceOpt := tc.Options["namespace"]
 	if len(namespaceOpt) > 0 {
 		log.Info().Msgf("namespace filter has been set to %q", namespaceOpt)
 		nsFilter.include = append(nsFilter.include, namespaceOpt)
 
 	}
+	// ^^
 
-	includeNamespaces := tc.Options["namespaces-include"]
+	includeNamespaces := tc.Options["namespaces"]
 	if len(includeNamespaces) > 0 {
 		nsFilter.include = append(nsFilter.include, strings.Split(includeNamespaces, ",")...)
 	}

--- a/motor/discovery/k8s/resolver.go
+++ b/motor/discovery/k8s/resolver.go
@@ -120,10 +120,10 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 
 	excludeNamespaces := tc.Options["namespaces-exclude"]
 	if len(excludeNamespaces) > 0 {
-		nsFilter.ignore = strings.Split(excludeNamespaces, ",")
+		nsFilter.exclude = strings.Split(excludeNamespaces, ",")
 	}
 
-	log.Debug().Strs("namespacesIncludeFilter", nsFilter.include).Strs("namespacesExcludeFilter", nsFilter.ignore).Msg("resolve k8s assets")
+	log.Debug().Strs("namespacesIncludeFilter", nsFilter.include).Strs("namespacesExcludeFilter", nsFilter.exclude).Msg("resolve k8s assets")
 
 	clusterIdentifier, err := p.Identifier()
 	if err != nil {


### PR DESCRIPTION
--namespaces-exclude allows cnquery to ignore a comma-separated list of Namespaces whose resources should be skipped when performing discovery.

On the other hand, specifying --namespaces will only allow resources matching the list of Namespaces provided.

Combining the previously-existing --namespace param (singular) with --namespaces (plural) will just be joined into one big allow-list. So --namespaces=default,kube-system is the same as saying --namespace=kube-system --namespaces=default.

Signed-off-by: Joel Diaz <joel@mondoo.com>