### PR TITLE
🐛 select querypacks on cli

### DIFF
--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -222,7 +222,7 @@ This example connects to Microsoft 365 using the PKCS #12 formatted certificate:
 
 		// bundles, packs & incognito mode
 		cmd.Flags().Bool("incognito", false, "Run in incognito mode. Do not report scan results to the Mondoo platform.")
-		cmd.Flags().StringSlice("querypack", nil, "Set the query packs to be executed (requires incognito mode), multiple query packs can be specified")
+		cmd.Flags().StringSlice("querypack", nil, "Set the query packs to be executed (requires querypack-bundle). Multiple UIDs can be specified")
 		cmd.Flags().StringSliceP("querypack-bundle", "f", nil, "Path to local query pack file")
 		// flag completion command
 		cmd.RegisterFlagCompletionFunc("querypack", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -351,7 +351,7 @@ func getCobraScanConfig(cmd *cobra.Command, args []string, provider providers.Pr
 		IsIncognito:    viper.GetBool("incognito"),
 		DoRecord:       viper.GetBool("record"),
 		QueryPackPaths: viper.GetStringSlice("querypack-bundle"),
-		QueryPackNames: viper.GetStringSlice("querypack"),
+		QueryPackNames: viper.GetStringSlice("querypacks"),
 	}
 
 	// if users want to get more information on available output options,

--- a/explorer/bundle.go
+++ b/explorer/bundle.go
@@ -275,9 +275,10 @@ func (p *Bundle) Compile(ctx context.Context) (*BundleMap, error) {
 // If a given query pack has a MRN set (but no UID) it will try to get the UID from the MRN
 // and also filter by that criteria.
 // If the list of IDs is empty this function doesn't do anything.
-func (p *Bundle) FilterQueryPacks(IDs []string) {
+// If all packs in the bundles were filtered out, return true.
+func (p *Bundle) FilterQueryPacks(IDs []string) bool {
 	if len(IDs) == 0 {
-		return
+		return false
 	}
 
 	valid := make(map[string]struct{}, len(IDs))
@@ -310,6 +311,11 @@ func (p *Bundle) FilterQueryPacks(IDs []string) {
 	}
 
 	p.Packs = res
+
+	if len(res) == 0 {
+		return true
+	}
+	return false
 }
 
 // Makes sure every query in the bundle and every query pack has a UID set,

--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -184,7 +184,9 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstreamConf
 
 	// plan scan jobs
 	reporter := NewAggregateReporter(assetList)
-	job.Bundle.FilterQueryPacks(job.QueryPackFilters)
+	if job.Bundle.FilterQueryPacks(job.QueryPackFilters) {
+		return nil, false, errors.New("All available packs filtered out. Nothing to do.")
+	}
 
 	for i := range assetList {
 		asset := assetList[i]


### PR DESCRIPTION
This behavior was buggy for querypack. Note, it only works in incognito right now

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>