### PR TITLE
🧹 use shorter name for container images

### DIFF
--- a/motor/discovery/container_registry/registry.go
+++ b/motor/discovery/container_registry/registry.go
@@ -181,10 +181,11 @@ func (a *DockerRegistryImages) toAsset(ref name.Reference, creds []*vault.Creden
 	imgDigest := desc.Digest.String()
 	repoName := ref.Context().Name()
 	imgTag := ref.Context().Tag(ref.Identifier()).Name()
+	name := repoName + "@" + containerid.ShortContainerImageID(imgDigest)
 	imageUrl := repoName + "@" + imgDigest
 	asset := &asset.Asset{
 		PlatformIds: []string{containerid.MondooContainerImageID(imgDigest)},
-		Name:        imageUrl,
+		Name:        name,
 		Platform: &platform.Platform{
 			Kind:    providers.Kind_KIND_CONTAINER_IMAGE,
 			Runtime: providers.RUNTIME_DOCKER_REGISTRY,

--- a/motor/discovery/k8s/list_images_test.go
+++ b/motor/discovery/k8s/list_images_test.go
@@ -3,6 +3,8 @@ package k8s
 import (
 	"testing"
 
+	"go.mondoo.com/cnquery/motor/motorid/containerid"
+
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -69,12 +71,12 @@ func TestListPodImage(t *testing.T) {
 
 	imgDigest := desc.Digest.String()
 	repoName := ref.Context().Name()
-	imageUrl := repoName + "@" + imgDigest
+	imageUrl := repoName + "@" + containerid.ShortContainerImageID(imgDigest)
 
 	expectedAssetNames := []string{
 		imageUrl,
-		"k8s.gcr.io/kube-scheduler@sha256:32308abe86f7415611ca86ee79dd0a73e74ebecb2f9e3eb85fc3a8e62f03d0e7",
-		"k8s.gcr.io/kube-proxy@sha256:def87f007b49d50693aed83d4703d0e56c69ae286154b1c7a20cd1b3a320cf7c",
+		"k8s.gcr.io/kube-scheduler@32308abe86f7",
+		"k8s.gcr.io/kube-proxy@def87f007b49",
 	}
 
 	clusterIdentifier := "//platformid.api.mondoo.app/runtime/k8s/uid/e26043bb-8669-48a2-b684-b1e132198cdc"
@@ -176,9 +178,9 @@ func TestListPodImage_FromStatus(t *testing.T) {
 	p.EXPECT().Pods(nss[1]).Return(pods2, nil)
 
 	expectedAssetNames := []string{
-		"index.docker.io/library/nginx@sha256:f335d7436887b39393409261603fb248e0c385ec18997d866dd44f7e9b621096",
-		"k8s.gcr.io/kube-scheduler@sha256:32308abe86f7415611ca86ee79dd0a73e74ebecb2f9e3eb85fc3a8e62f03d0e7",
-		"k8s.gcr.io/kube-proxy@sha256:def87f007b49d50693aed83d4703d0e56c69ae286154b1c7a20cd1b3a320cf7c",
+		"index.docker.io/library/nginx@f335d7436887",
+		"k8s.gcr.io/kube-scheduler@32308abe86f7",
+		"k8s.gcr.io/kube-proxy@def87f007b49",
 	}
 
 	clusterIdentifier := "//platformid.api.mondoo.app/runtime/k8s/uid/e26043bb-8669-48a2-b684-b1e132198cdc"


### PR DESCRIPTION
This change simplifies the container image names from:

```
index.docker.io/library/debian@sha256:604db908f7ce93379b1289c0c7ba73b252002087a3fa64fe904b430083ba5f69
```

to

```
index.docker.io/library/debian@604db908f7ce
```

The long sha is not helpful and the first 12 characters are usually enough to identify the image. This has no effect on the identification of the image, that logic will continue to use the full hash.

```
Asset: index.docker.io/library/debian@sha256:604db908f7ce93379b1289c0c7ba73b252002087a3fa64fe904b430083ba5f69
=============================================================================================================
Data queries:
platform.eol.date: 2022-07-01 02:00:00 +0200 CEST
platform.vulnerabilityReport: {
  platform: {
    arch: "amd64"
    name: "debian"
    release: "10.13"
    title: "Debian GNU/Linux 10 (buster), Docker Image"
  }
  published: "2022-10-21T15:43:43+02:00"
  stats: {
    advisories: {}
... 7 more lines ...

Controls:
✕ Fail:  Ensure the platform is not End-of-Life
✓ Pass:  Ensure no known platform CVEs exist
✕ Fail:  Platform is not end-of-life
✓ Pass:  Ensure no known platform advisories exist
```

```
Asset: index.docker.io/library/debian@604db908f7ce
==================================================
Data queries:
platform.eol.date: 2022-07-01 02:00:00 +0200 CEST
platform.vulnerabilityReport: {
  platform: {
    arch: "amd64"
    name: "debian"
    release: "10.13"
    title: "Debian GNU/Linux 10 (buster), Docker Image"
  }
  published: "2022-10-21T15:49:33+02:00"
  stats: {
    advisories: {}
... 7 more lines ...

Controls:
✕ Fail:  Platform is not end-of-life
✓ Pass:  Ensure no known platform advisories exist
✕ Fail:  Ensure the platform is not End-of-Life
✓ Pass:  Ensure no known platform CVEs exist
```
