### PR TITLE
🧹 improve name of docker image

### DIFF
--- a/motor/discovery/docker_engine/container.go
+++ b/motor/discovery/docker_engine/container.go
@@ -111,7 +111,10 @@ func (e *dockerEngineDiscovery) ImageInfo(name string) (ImageInfo, error) {
 	labels["docker.io/tags"] = strings.Join(res.RepoTags, ",")
 	labels["docker.io/digests"] = strings.Join(res.RepoDigests, ",")
 
-	ii.Name = containerid.ShortContainerImageID(res.ID)
+	if len(res.RepoTags) > 0 {
+		ii.Name = res.RepoTags[0] + "@"
+	}
+	ii.Name = ii.Name + containerid.ShortContainerImageID(res.ID)
 	ii.ID = res.ID
 	ii.Labels = labels
 	ii.PlatformID = containerid.MondooContainerImageID(res.ID)


### PR DESCRIPTION
For container images stored in the docker engine, we use the short sha. It was difficult for users to know which image it was. Now we use Docker's repo tags, to improve the user experience.

The output of the asset name switches from:

```
Asset: edcf96f9d9d9
===================
Data queries:
platform.eol.date: 2022-07-01 02:00:00 +0200 CEST
... 382 more lines ...
```
to:

```
Asset: debian:10@edcf96f9d9d9
=============================
Data queries:
platform.eol.date: 2022-07-01 02:00:00 +0200 CEST
... 382 more lines ...
```
