### PR TITLE
🧹 rename transport to provider

### DIFF
--- a/motor/providers/resolver/resolver.go
+++ b/motor/providers/resolver/resolver.go
@@ -33,19 +33,19 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var transportDevelopmentStatus = map[providers.ProviderType]string{
+var providerDevelopmentStatus = map[providers.ProviderType]string{
 	providers.ProviderType_GITHUB:      "experimental",
 	providers.ProviderType_AWS_EC2_EBS: "experimental",
 }
 
 func warnIncompleteFeature(backend providers.ProviderType) {
-	if transportDevelopmentStatus[backend] != "" {
-		log.Warn().Str("feature", backend.String()).Str("status", transportDevelopmentStatus[backend]).Msg("WARNING: you are using an early access feature")
+	if providerDevelopmentStatus[backend] != "" {
+		log.Warn().Str("feature", backend.String()).Str("status", providerDevelopmentStatus[backend]).Msg("WARNING: you are using an early access feature")
 	}
 }
 
-// NewMotorConnection establishes a motor connection by using the provided transport configuration
-// By default, it uses the id detector mechanisms provided by the transport. User can overwrite that
+// NewMotorConnection establishes a motor connection by using the provided provider configuration
+// By default, it uses the id detector mechanisms provided by the provider. User can overwrite that
 // behaviour by optionally passing id detector identifier
 func NewMotorConnection(ctx context.Context, tc *providers.Config, credentialFn func(cred *vault.Credential) (*vault.Credential, error)) (*motor.Motor, error) {
 	log.Debug().Msg("establish motor connection")
@@ -74,7 +74,7 @@ func NewMotorConnection(ctx context.Context, tc *providers.Config, credentialFn 
 	// establish connection
 	switch resolvedConfig.Backend {
 	case providers.ProviderType_MOCK:
-		log.Debug().Msg("connection> load mock transport")
+		log.Debug().Msg("connection> load mock provider")
 		p, err := mock.NewFromToml(resolvedConfig)
 		if err != nil {
 			return nil, err
@@ -85,7 +85,7 @@ func NewMotorConnection(ctx context.Context, tc *providers.Config, credentialFn 
 			return nil, err
 		}
 	case providers.ProviderType_LOCAL_OS:
-		log.Debug().Msg("connection> load local transport")
+		log.Debug().Msg("connection> load local provider")
 		p, err := local.NewWithConfig(resolvedConfig)
 		if err != nil {
 			return nil, err
@@ -96,7 +96,7 @@ func NewMotorConnection(ctx context.Context, tc *providers.Config, credentialFn 
 			return nil, err
 		}
 	case providers.ProviderType_TAR:
-		log.Debug().Msg("connection> load tar transport")
+		log.Debug().Msg("connection> load tar provider")
 		p, err := tar.New(resolvedConfig)
 		if err != nil {
 			return nil, err
@@ -107,7 +107,7 @@ func NewMotorConnection(ctx context.Context, tc *providers.Config, credentialFn 
 			return nil, err
 		}
 	case providers.ProviderType_CONTAINER_REGISTRY:
-		log.Debug().Msg("connection> load container registry transport")
+		log.Debug().Msg("connection> load container registry provider")
 		p, err := container.NewContainerRegistryImage(resolvedConfig)
 		if err != nil {
 			return nil, err
@@ -117,7 +117,7 @@ func NewMotorConnection(ctx context.Context, tc *providers.Config, credentialFn 
 			return nil, err
 		}
 	case providers.ProviderType_DOCKER_ENGINE_CONTAINER:
-		log.Debug().Msg("connection> load docker engine container transport")
+		log.Debug().Msg("connection> load docker engine container provider")
 		p, err := container.NewDockerEngineContainer(resolvedConfig)
 		if err != nil {
 			return nil, err
@@ -127,7 +127,7 @@ func NewMotorConnection(ctx context.Context, tc *providers.Config, credentialFn 
 			return nil, err
 		}
 	case providers.ProviderType_DOCKER_ENGINE_IMAGE:
-		log.Debug().Msg("connection> load docker engine image transport")
+		log.Debug().Msg("connection> load docker engine image provider")
 		p, err := container.NewDockerEngineImage(resolvedConfig)
 		if err != nil {
 			return nil, err
@@ -137,7 +137,7 @@ func NewMotorConnection(ctx context.Context, tc *providers.Config, credentialFn 
 			return nil, err
 		}
 	case providers.ProviderType_SSH:
-		log.Debug().Msg("connection> load ssh transport")
+		log.Debug().Msg("connection> load ssh provider")
 		p, err := ssh.New(resolvedConfig)
 		if err != nil {
 			return nil, err
@@ -148,7 +148,7 @@ func NewMotorConnection(ctx context.Context, tc *providers.Config, credentialFn 
 			return nil, err
 		}
 	case providers.ProviderType_WINRM:
-		log.Debug().Msg("connection> load winrm transport")
+		log.Debug().Msg("connection> load winrm provider")
 		p, err := winrm.New(resolvedConfig)
 		if err != nil {
 			return nil, err
@@ -159,7 +159,7 @@ func NewMotorConnection(ctx context.Context, tc *providers.Config, credentialFn 
 			return nil, err
 		}
 	case providers.ProviderType_VSPHERE:
-		log.Debug().Msg("connection> load vsphere transport")
+		log.Debug().Msg("connection> load vsphere provider")
 		p, err := vsphere.New(resolvedConfig)
 		if err != nil {
 			return nil, err
@@ -170,7 +170,7 @@ func NewMotorConnection(ctx context.Context, tc *providers.Config, credentialFn 
 			return nil, err
 		}
 	case providers.ProviderType_ARISTAEOS:
-		log.Debug().Msg("connection> load arista eos transport")
+		log.Debug().Msg("connection> load arista eos provider")
 		p, err := arista.New(resolvedConfig)
 		if err != nil {
 			return nil, err
@@ -180,7 +180,7 @@ func NewMotorConnection(ctx context.Context, tc *providers.Config, credentialFn 
 			return nil, err
 		}
 	case providers.ProviderType_AWS:
-		log.Debug().Msg("connection> load aws transport")
+		log.Debug().Msg("connection> load aws provider")
 		p, err := aws_provider.New(resolvedConfig, aws_provider.TransportOptions(resolvedConfig.Options)...)
 		if err != nil {
 			return nil, err
@@ -190,7 +190,7 @@ func NewMotorConnection(ctx context.Context, tc *providers.Config, credentialFn 
 			return nil, err
 		}
 	case providers.ProviderType_GCP:
-		log.Debug().Msg("connection> load gcp transport")
+		log.Debug().Msg("connection> load gcp provider")
 		p, err := gcp.New(resolvedConfig)
 		if err != nil {
 			return nil, err
@@ -200,7 +200,7 @@ func NewMotorConnection(ctx context.Context, tc *providers.Config, credentialFn 
 			return nil, err
 		}
 	case providers.ProviderType_AZURE:
-		log.Debug().Msg("connection> load azure transport")
+		log.Debug().Msg("connection> load azure provider")
 		p, err := azure.New(resolvedConfig)
 		if err != nil {
 			return nil, err
@@ -210,7 +210,7 @@ func NewMotorConnection(ctx context.Context, tc *providers.Config, credentialFn 
 			return nil, err
 		}
 	case providers.ProviderType_MS365:
-		log.Debug().Msg("connection> load microsoft 365 transport")
+		log.Debug().Msg("connection> load microsoft 365 provider")
 		p, err := ms365.New(resolvedConfig)
 		if err != nil {
 			return nil, err
@@ -220,7 +220,7 @@ func NewMotorConnection(ctx context.Context, tc *providers.Config, credentialFn 
 			return nil, err
 		}
 	case providers.ProviderType_IPMI:
-		log.Debug().Msg("connection> load ipmi transport")
+		log.Debug().Msg("connection> load ipmi provider")
 		p, err := ipmi.New(resolvedConfig)
 		if err != nil {
 			return nil, err
@@ -288,7 +288,7 @@ func NewMotorConnection(ctx context.Context, tc *providers.Config, credentialFn 
 		if err != nil {
 			return nil, err
 		}
-		// TODO (jaym) before merge: The ebs transport is being lost. This
+		// TODO (jaym) before merge: The ebs provider is being lost. This
 		// is problematic. It will break the platform id detection being added
 		m, err = motor.New(p.FsProvider)
 		if err != nil {


### PR DESCRIPTION
This change covers a few more renames that we forgot.