### PR TITLE
🐛 fix ssh authentication

### DIFF
--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -141,9 +141,6 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 		if err != nil {
 			log.Error().Err(err).Msg("cannot parse target")
 		}
-		if identityFile == "" && password == "" {
-			log.Warn().Msg("No identity file or password are provided for ssh authentication, use either --identity-file, --ask-pass or --password. Falling back to ssh agent authentication.")
-		}
 		connection.Host = target.Hostname
 		connection.Port = target.Port
 		connection.Path = target.Path
@@ -174,6 +171,10 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 					PrivateKeyPath: identityFile,
 				})
 			}
+		}
+
+		if len(connection.Credentials) == 0 {
+			log.Warn().Msg("no identity file or password are provided for ssh authentication, use either --identity-file, --ask-pass or --password, fall back to ssh agent")
 		}
 	case providers.ProviderType_WINRM:
 		connection.Backend = providerType

--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -153,7 +153,7 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstreamConf
 		if err != nil {
 			return nil, false, err
 		}
-		log.Info().Int("assets", len(resp.Details)).Msg("got assets details")
+		log.Debug().Int("assets", len(resp.Details)).Msg("got assets details")
 		platformAssetMapping := make(map[string]*explorer.SynchronizeAssetsRespAssetDetail)
 		for i := range resp.Details {
 			log.Debug().Str("platform-mrn", resp.Details[i].PlatformMrn).Str("asset", resp.Details[i].AssetMrn).Msg("asset mapping")

--- a/motor/providers/ssh/config.go
+++ b/motor/providers/ssh/config.go
@@ -42,8 +42,7 @@ func ReadSSHConfig(cc *providers.Config) *providers.Config {
 		cc.Host = hostname
 	}
 
-	if len(cc.Credentials) == 0 {
-
+	if len(cc.Credentials) == 0 || (len(cc.Credentials) == 1 && cc.Credentials[0].Type == vault.CredentialType_password && len(cc.Credentials[0].Secret) == 0) {
 		user, _ := cfg.Get(host, "User")
 		port, err := cfg.Get(host, "Port")
 		if err == nil {

--- a/motor/providers/ssh/session.go
+++ b/motor/providers/ssh/session.go
@@ -129,9 +129,11 @@ func prepareConnection(pCfg *providers.Config) ([]ssh.AuthMethod, []io.Closer, e
 				signers = append(signers, priv)
 			}
 		case vault.CredentialType_password:
-			// use password auth
-			log.Debug().Msg("enabled ssh password authentication")
-			auths = append(auths, ssh.Password(string(credential.Secret)))
+			// use password auth if the password was set, this is also used when only the username is set
+			if len(credential.Secret) > 0 {
+				log.Debug().Msg("enabled ssh password authentication")
+				auths = append(auths, ssh.Password(string(credential.Secret)))
+			}
 		case vault.CredentialType_ssh_agent:
 			log.Debug().Msg("enabled ssh agent authentication")
 			useAgentAuth()
@@ -229,7 +231,8 @@ func prepareConnection(pCfg *providers.Config) ([]ssh.AuthMethod, []io.Closer, e
 	}
 
 	// if no credential was provided, fallback to ssh-agent and ssh-config
-	if len(pCfg.Credentials) == 0 {
+	if len(auths) == 0 {
+		log.Debug().Msg("enabled ssh agent authentication")
 		useAgentAuth()
 	}
 


### PR DESCRIPTION
When the cli was refactored, the cli always added a credential with password authentication as soon as a username was set. The ssh provider check to enable ssh config reading and ssh agent fallback only triggered when no credential was provided. This change adapts the checks so that the fallbacks to ssh config and ssh agent start working again.

fixes #291