### PR TITLE
Fix spelling in AWS resource

### DIFF
--- a/resources/packs/aws/aws.lr
+++ b/resources/packs/aws/aws.lr
@@ -358,7 +358,7 @@ private aws.es.domain {
   nodeToNodeEncryptionEnabled bool
   // name of the es domain
   name string
-  // endpoint used to submit index and search reqs
+  // endpoint used to submit index and search requests
   endpoint string
   // region where the domain exists
   region string
@@ -1215,7 +1215,7 @@ private aws.ec2.snapshot {
   id string
   // region where the snapshot exists
   region string
-  // users/groups that have the permsfor creating volumes from the snapshot
+  // users/groups that have the permissions for creating volumes from the snapshot
   createVolumePermission() []dict
   // id of the volume used to create the snapshot
   volumeId string


### PR DESCRIPTION
Avoid a spell check warning in docs

Signed-off-by: Tim Smith <tsmith84@gmail.com>