### PR TITLE
Removes experimental status from GitHub resource

### DIFF
--- a/motor/providers/resolver/resolver.go
+++ b/motor/providers/resolver/resolver.go
@@ -34,7 +34,6 @@ import (
 )
 
 var providerDevelopmentStatus = map[providers.ProviderType]string{
-	providers.ProviderType_GITHUB:      "experimental",
 	providers.ProviderType_AWS_EC2_EBS: "experimental",
 }
 

--- a/resources/packs/github/github.lr.manifest.yaml
+++ b/resources/packs/github/github.lr.manifest.yaml
@@ -210,7 +210,6 @@ resources:
         min_mondoo_version: 6.11.0
       webhooks:
         min_mondoo_version: 6.11.0
-    maturity: experimental
     min_mondoo_version: 5.15.0
   github.package:
     fields:


### PR DESCRIPTION
This PR removes the "experimental" status from GITHUB....

<img width="1111" alt="image" src="https://user-images.githubusercontent.com/49754039/198738444-abcb02ca-4034-445c-82b2-b330e4b2b7c6.png">


Signed-off-by: Scott Ford <scott@scottford.io>