### PR TITLE
⭐️ detect Rocky Linux 9 as RHEL clone

### DIFF
--- a/motor/platform/detector/detector_test.go
+++ b/motor/platform/detector/detector_test.go
@@ -227,8 +227,8 @@ func TestAlmaLinux9OSDetector(t *testing.T) {
 	assert.Equal(t, []string{"redhat", "linux", "unix", "os"}, di.Family)
 }
 
-func TestRocky8OSDetector(t *testing.T) {
-	detector, err := newDetector("./testdata/detect-rocky-8.toml")
+func TestRockyLinux8OSDetector(t *testing.T) {
+	detector, err := newDetector("./testdata/detect-rocky-linux-8.toml")
 	assert.Nil(t, err, "was able to create the transport")
 	di, err := detector.Platform()
 	require.NoError(t, err)
@@ -236,6 +236,19 @@ func TestRocky8OSDetector(t *testing.T) {
 	assert.Equal(t, "rockylinux", di.Name, "os name should be identified")
 	assert.Equal(t, "Rocky Linux 8.5 (Green Obsidian)", di.Title, "os title should be identified")
 	assert.Equal(t, "8.5", di.Version, "os version should be identified")
+	assert.Equal(t, "aarch64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"redhat", "linux", "unix", "os"}, di.Family)
+}
+
+func TestRockyLinux9OSDetector(t *testing.T) {
+	detector, err := newDetector("./testdata/detect-rocky-linux-9.toml")
+	assert.Nil(t, err, "was able to create the transport")
+	di, err := detector.Platform()
+	require.NoError(t, err)
+
+	assert.Equal(t, "rockylinux", di.Name, "os name should be identified")
+	assert.Equal(t, "Rocky Linux 9.0 (Blue Onyx)", di.Title, "os title should be identified")
+	assert.Equal(t, "9.0", di.Version, "os version should be identified")
 	assert.Equal(t, "aarch64", di.Arch, "os arch should be identified")
 	assert.Equal(t, []string{"redhat", "linux", "unix", "os"}, di.Family)
 }

--- a/motor/platform/detector/platform_specs.go
+++ b/motor/platform/detector/platform_specs.go
@@ -269,6 +269,13 @@ var centos = &PlatformResolver{
 			}
 		}
 
+		// newer rockylinux do not have /etc/centos-release
+		if pf.Name == "rockylinux" {
+			if ok, err := afs.Exists("/etc/rocky-release"); err == nil && ok {
+				return true, nil
+			}
+		}
+
 		// NOTE: CentOS 5 does not have /etc/centos-release
 		// fallback to /etc/centos-release file
 		if ok, err := afs.Exists("/etc/centos-release"); err != nil || !ok {

--- a/motor/platform/detector/testdata/detect-rocky-linux-8.toml
+++ b/motor/platform/detector/testdata/detect-rocky-linux-8.toml
@@ -14,7 +14,7 @@ content = "Rocky Linux release 8.5 (Green Obsidian)"
 content = "Rocky Linux release 8.5 (Green Obsidian)"
 
 [files."/etc/rocky-release"]
-content = "AlmaLinux release 8.3 Beta (Purple Manul)"
+content = "Rocky Linux release 8.5 (Green Obsidian)"
 
 [files."/etc/os-release"]
 content = """

--- a/motor/platform/detector/testdata/detect-rocky-linux-9.toml
+++ b/motor/platform/detector/testdata/detect-rocky-linux-9.toml
@@ -1,0 +1,34 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "aarch64"
+
+[commands."uname -r"]
+stdout = "5.10.104-linuxkit"
+
+[files."/etc/redhat-release"]
+content = "Rocky Linux release 9.0 (Blue Onyx)"
+
+[files."/etc/rocky-release"]
+content = "Rocky Linux release 9.0 (Blue Onyx)"
+
+[files."/etc/os-release"]
+content = """
+NAME="Rocky Linux"
+VERSION="9.0 (Blue Onyx)"
+ID="rocky"
+ID_LIKE="rhel centos fedora"
+VERSION_ID="9.0"
+PLATFORM_ID="platform:el9"
+PRETTY_NAME="Rocky Linux 9.0 (Blue Onyx)"
+ANSI_COLOR="0;32"
+LOGO="fedora-logo-icon"
+CPE_NAME="cpe:/o:rocky:rocky:9::baseos"
+HOME_URL="https://rockylinux.org/"
+BUG_REPORT_URL="https://bugs.rockylinux.org/"
+ROCKY_SUPPORT_PRODUCT="Rocky-Linux-9"
+ROCKY_SUPPORT_PRODUCT_VERSION="9.0"
+REDHAT_SUPPORT_PRODUCT="Rocky Linux"
+REDHAT_SUPPORT_PRODUCT_VERSION="9.0"
+"""


### PR DESCRIPTION
Withing the proper detection of the family, `package` and `service` resources do not work properly. This change detects Rocky Linux 9 as proper RHEL clone.