### PR TITLE
🐛 fix sample pack

### DIFF
--- a/apps/cnquery/cmd/bundle_querypack-example.mql.yaml
+++ b/apps/cnquery/cmd/bundle_querypack-example.mql.yaml
@@ -1,31 +1,20 @@
-# Read more about the policy structure at https://mondoo.com/docs/platform/policies/overview
-policies:
-  - uid: sshd-server-policy
-    name: SSH Server Policy
-    version: "1.0.0"
-    authors:
-      - name: Jane Doe
-        email: jane@example.com
-    tags:
-      key: value
-      another-key: another-value
-    specs:
-      - asset_filter:
-          query: platform.family.contains(_ == 'unix')
-        scoring_queries:
-          sshd-score-01:
-queries:
-  - uid: sshd-score-01
-    title: Ensure SSH MaxAuthTries is set to 4 or less
-    query: sshd.config.params["MaxAuthTries"] <= 4
-    docs:
-      desc: |
-        The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection.
-        When the login failure count reaches half the number, error messages will be written to the syslog file
-        detailing the login failure.
-      audit: Run the `sshd -T | grep maxauthtries` command and verify that output MaxAuthTries is 4 or less
-      remediation: |
-        Open your `/etc/ssh/sshd_config` and set `MaxAuthTries` to `4`.
-    refs:
-      - title: CIS Distribution Independent Linux
-        url: https://www.cisecurity.org/benchmark/distribution_independent_linux/
+packs:
+  - uid: sshd-config-collector
+    name: SSH Server Configuration
+    filters:
+      - asset.family.contains("unix")
+    queries:
+      - uid: mondoo-openssh-platform
+        title: Retrieve information about the Platform
+        query: |
+          asset {
+            platform
+            version
+            arch
+          }
+      - uid: mondoo-openssh-installed-version
+        title: Retrieve list about installed ssh packages
+        query: packages.where(name == /ssh/)
+      - uid: mondoo-openssh-config
+        title: Retrieve parsed sshd configuration
+        query: sshd.config.params


### PR DESCRIPTION
the previous implementation generated a policy which was a copy and paste error from cnspec