### PR TITLE
🐛 prevent cnquery from panicking if there are no querybundles

### DIFF
--- a/explorer/bundle.go
+++ b/explorer/bundle.go
@@ -281,6 +281,10 @@ func (p *Bundle) FilterQueryPacks(IDs []string) bool {
 		return false
 	}
 
+	if p == nil {
+		return true
+	}
+
 	valid := make(map[string]struct{}, len(IDs))
 	for i := range IDs {
 		valid[IDs[i]] = struct{}{}


### PR DESCRIPTION
When in incognito mode and no querypack-bundle specified, this was panicking during scan.