### PR TITLE
🐛 propagate errors about port-process-relationships

### DIFF
--- a/resources/packs/core/processes/linuxproc.go
+++ b/resources/packs/core/processes/linuxproc.go
@@ -92,14 +92,15 @@ func (lpm *LinuxProcManager) Process(pid int64) (*OSProcess, error) {
 		return nil, err
 	}
 
-	socketInodes := lpm.procSocketInods(pid, pidPath)
+	socketInodes, socketInodesErr := lpm.procSocketInods(pid, pidPath)
 
 	process := &OSProcess{
-		Pid:          pid,
-		Executable:   status.Executable,
-		State:        status.State,
-		Command:      cmdline,
-		SocketInodes: socketInodes,
+		Pid:               pid,
+		Executable:        status.Executable,
+		State:             status.State,
+		Command:           cmdline,
+		SocketInodes:      socketInodes,
+		SocketInodesError: socketInodesErr,
 	}
 
 	return process, nil

--- a/resources/packs/core/processes/linuxproc_windows.go
+++ b/resources/packs/core/processes/linuxproc_windows.go
@@ -4,6 +4,6 @@ package processes
 
 // Read out all connected sockets. This is not yet implemented on non-Unix
 // systems and needs some work to function via remote connections
-func (lpm *LinuxProcManager) procSocketInods(pid int64, procPidPath string) []int64 {
-	return []int64{}
+func (lpm *LinuxProcManager) procSocketInods(pid int64, procPidPath string) ([]int64, error) {
+	return []int64{}, errors.New("reading socket inodes is not implemented for Windows")
 }

--- a/resources/packs/core/processes/manager.go
+++ b/resources/packs/core/processes/manager.go
@@ -10,12 +10,13 @@ import (
 )
 
 type OSProcess struct {
-	Pid          int64
-	Command      string
-	Executable   string
-	State        string
-	Uid          int64
-	SocketInodes []int64
+	Pid               int64
+	Command           string
+	Executable        string
+	State             string
+	Uid               int64
+	SocketInodes      []int64
+	SocketInodesError error
 }
 
 type OSProcessManager interface {


### PR DESCRIPTION
Previously when reading out the file descriptors, we would silently ignore errors that happened there. However, it is quite common for someone without sufficient permissions to read this list, e.g. when we ask which port is opened by which process. When this happens, now we propagate the errors and wrap it nicely so that users know it is a permissions issue and can sudo their way out of it.

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>