### PR TITLE
🧹 allow filtering of query packs

### DIFF
--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -398,14 +398,17 @@ func getCobraScanConfig(cmd *cobra.Command, args []string, provider providers.Pr
 		conf.Inventory.ApplyCategory(asset.AssetCategory_CATEGORY_CICD)
 	}
 
-	serviceAccount := opts.GetServiceCredential()
-	if serviceAccount != nil {
-		log.Info().Msg("using service account credentials")
-		certAuth, _ := upstream.NewServiceAccountRangerPlugin(serviceAccount)
-		conf.UpstreamConfig = &resources.UpstreamConfig{
-			SpaceMrn:    opts.GetParentMrn(),
-			ApiEndpoint: opts.UpstreamApiEndpoint(),
-			Plugins:     []ranger.ClientPlugin{certAuth},
+	var serviceAccount *upstream.ServiceAccountCredentials
+	if !conf.IsIncognito {
+		serviceAccount = opts.GetServiceCredential()
+		if serviceAccount != nil {
+			log.Info().Msg("using service account credentials")
+			certAuth, _ := upstream.NewServiceAccountRangerPlugin(serviceAccount)
+			conf.UpstreamConfig = &resources.UpstreamConfig{
+				SpaceMrn:    opts.GetParentMrn(),
+				ApiEndpoint: opts.UpstreamApiEndpoint(),
+				Plugins:     []ranger.ClientPlugin{certAuth},
+			}
 		}
 	}
 


### PR DESCRIPTION
Before this change querypack filtering only worked for local bundles but not for bundles fetched from public query hub. This adds this ability. It also prints `-o full` info at the end of the scan.

<img width="927" alt="Screenshot 2022-11-01 at 14 38 43" src="https://user-images.githubusercontent.com/1178413/199246787-23798a6e-570a-4d45-8bfb-5512500a5fe0.png">
