### PR TITLE
🧹 add cnquery version and build to client headers on upstream scan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,9 @@ cnquery/build/linux:
 cnquery/build/windows:
 	GOOS=windows go build ${LDFLAGSDIST} apps/cnquery/cnquery.go
 
+cnquery/build/darwin:
+	GOOS=darwin go build ${LDFLAGSDIST} apps/cnquery/cnquery.go
+
 .PHONY: cnquery/install
 cnquery/install:
 	GOBIN=${GOPATH}/bin go install ${LDFLAGSDIST} apps/cnquery/cnquery.go

--- a/apps/cnquery/cmd/root.go
+++ b/apps/cnquery/cmd/root.go
@@ -132,17 +132,20 @@ func sysInfoHeader(sysInfo *sysinfo.SystemInfo, features cnquery.Features) range
 	)
 
 	h := http.Header{}
-	h.Set(HttpHeaderUserAgent, scope.XInfoHeader(map[string]string{
+	info := map[string]string{
 		"cnquery": cnquery.Version,
 		"build":   cnquery.Build,
-		"PN":      sysInfo.Platform.Name,
-		"PR":      sysInfo.Platform.Version,
-		"PA":      sysInfo.Platform.Arch,
-		"IP":      sysInfo.IP,
-		"HN":      sysInfo.Hostname,
-	}))
+	}
+	if sysInfo != nil {
+		info["PN"] = sysInfo.Platform.Name
+		info["PR"] = sysInfo.Platform.Version
+		info["PA"] = sysInfo.Platform.Arch
+		info["IP"] = sysInfo.IP
+		info["HN"] = sysInfo.Hostname
+		h.Set(HttpHeaderPlatformID, sysInfo.PlatformId)
+	}
+	h.Set(HttpHeaderUserAgent, scope.XInfoHeader(info))
 	h.Set(HttpHeaderClientFeatures, features.Encode())
-	h.Set(HttpHeaderPlatformID, sysInfo.PlatformId)
 	return scope.NewCustomHeaderRangerPlugin(h)
 }
 


### PR DESCRIPTION
 add cnquery version and build to client headers on upstream scan so that we can read in the client version and build info server-side on upstream scan