### PR TITLE
Remove double resoure in error message

### DIFF
--- a/resources/runtime.go
+++ b/resources/runtime.go
@@ -160,7 +160,7 @@ func (ctx *Runtime) lookupResource(name string) (*ResourceCls, error) {
 			name = r.Name
 		} else {
 			// We found a resource with a factory
-			return nil, errors.New("cannot find resource resource factory for '" + name + "'")
+			return nil, errors.New("cannot find resource factory for '" + name + "'")
 		}
 	}
 }


### PR DESCRIPTION
This error message still doesn't make a ton of sense, but now the double word is gone

Signed-off-by: Tim Smith <tsmith84@gmail.com>