### PR TITLE
🐛 Do not use embedded fields when expanding {*} for resources.

### DIFF
--- a/mqlc/builtin.go
+++ b/mqlc/builtin.go
@@ -184,6 +184,10 @@ func publicFieldsInfo(c *compiler, resourceInfo *resources.ResourceInfo) map[str
 		if v.IsPrivate {
 			continue
 		}
+		if v.IsEmbedded && !c.UseAssetContext {
+			continue
+		}
+
 		if v.IsEmbedded && c.UseAssetContext {
 			name := types.Type(v.Type).ResourceName()
 			child, ok := c.Schema.Resources[name]

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -1782,11 +1782,18 @@ func TestSuggestions(t *testing.T) {
 			nil,
 		},
 		{
-			// embedded
+			// embedded with asset context on
 			"docker.containers[0].hostnam",
 			[]string{"hostname"},
 			errors.New("cannot find field 'hostnam' in docker.container"),
 			cnquery.Features{byte(cnquery.MQLAssetContext)},
+		},
+		{
+			// embedded with asset context off
+			"docker.containers[0].hostnam",
+			[]string{},
+			errors.New("cannot find field 'hostnam' in docker.container"),
+			nil,
 		},
 	}
 


### PR DESCRIPTION
Fixes #440 

Allows us to use resources where there are embedded fields:
![image](https://user-images.githubusercontent.com/11717082/200845665-f49764d3-e907-4103-8c4b-d3531d5fadda.png)

This would fail previously as `{*}` also included embeddded resources, which requires the `MQLAssetContext` flag on.