### PR TITLE
✨ array delete: [1,2,3,3,4] - [3,4,5] = [1,2]

### DIFF
--- a/llx/builtin.go
+++ b/llx/builtin.go
@@ -519,6 +519,7 @@ func init() {
 			"&&":                     {Compiler: compileLogicalArrayOp(types.ArrayLike, "&&")},
 			"||":                     {Compiler: compileLogicalArrayOp(types.ArrayLike, "||")},
 			"+":                      {Compiler: compileArrayOpArray("+"), f: tarrayConcatTarrayV2, Label: "+"},
+			"-":                      {Compiler: compileArrayOpArray("-"), f: tarrayDeleteTarrayV2, Label: "-"},
 			// logical operations []<T> -- K
 			string(types.Any + "&&" + types.Bool):      {f: arrayAndBoolV2, Label: "&&"},
 			string(types.Any + "||" + types.Bool):      {f: arrayOrBoolV2, Label: "||"},

--- a/resources/packs/core/core_test.go
+++ b/resources/packs/core/core_test.go
@@ -878,6 +878,11 @@ func TestArray(t *testing.T) {
 			0,
 			[]interface{}{int64(1), int64(2), int64(3)},
 		},
+		{
+			"[3,1,3,4,2] - [3,4,5]",
+			0,
+			[]interface{}{int64(1), int64(2)},
+		},
 	})
 }
 


### PR DESCRIPTION
Pretty straightforward, after implementing ways to concat arrays, add the ability to quickly remove elements. This is going to be the most commonly used intuitive shorthand for this type of operation. We already have ways to filter content (`where`) and will likely use similar approaches to remove elements via index. That however is a different use-case.

```
> [1,2,3,3,4] - [3,4,5]
[1,2]
```

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>