### PR TITLE
🐛Fix passing of client secret for ms365.

### DIFF
--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -490,7 +490,7 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 			connection.Credentials = append(connection.Credentials, &vault.Credential{
 				Type:     vault.CredentialType_password,
 				User:     username,
-				Password: password,
+				Password: clientSecret,
 			})
 		}
 


### PR DESCRIPTION
We were using the wrong arg here, the client secret was being ignored