### PR TITLE
🧹 be more specific for gcp flags and use `--project-id` and `organization-id`

### DIFF
--- a/apps/cnquery/cmd/builder/builder.go
+++ b/apps/cnquery/cmd/builder/builder.go
@@ -582,9 +582,11 @@ func scanGcpCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn
 	commonCmdFlags(cmd)
 	cmd.Flags().String("project", "", "specify the GCP project to scan")
 	cmd.Flags().MarkHidden("project")
+	cmd.Flags().MarkDeprecated("project", "--project is deprecated in favor of --project-id")
 	cmd.Flags().String("project-id", "", "specify the GCP project ID to scan")
 	cmd.Flags().String("organization", "", "specify the GCP organization to scan")
 	cmd.Flags().MarkHidden("organization")
+	cmd.Flags().MarkDeprecated("organization", "--organization is deprecated in favor of --organization-id")
 	cmd.Flags().String("organization-id", "", "specify the GCP organization ID to scan")
 	return cmd
 }

--- a/apps/cnquery/cmd/builder/builder.go
+++ b/apps/cnquery/cmd/builder/builder.go
@@ -572,6 +572,8 @@ func scanGcpCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn
 			preRun(cmd, args)
 			viper.BindPFlag("project", cmd.Flags().Lookup("project"))
 			viper.BindPFlag("organization", cmd.Flags().Lookup("organization"))
+			viper.BindPFlag("project-id", cmd.Flags().Lookup("project-id"))
+			viper.BindPFlag("organization-id", cmd.Flags().Lookup("organization-id"))
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			runFn(cmd, args, providers.ProviderType_GCP, DefaultAssetType)
@@ -579,7 +581,11 @@ func scanGcpCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn
 	}
 	commonCmdFlags(cmd)
 	cmd.Flags().String("project", "", "specify the GCP project to scan")
+	cmd.Flags().MarkHidden("project")
+	cmd.Flags().String("project-id", "", "specify the GCP project ID to scan")
 	cmd.Flags().String("organization", "", "specify the GCP organization to scan")
+	cmd.Flags().MarkHidden("organization")
+	cmd.Flags().String("organization-id", "", "specify the GCP organization ID to scan")
 	return cmd
 }
 

--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -367,17 +367,32 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 	case providers.ProviderType_GCP:
 		connection.Backend = providerType
 
+		// deprecated, remove in v8
 		if project, err := cmd.Flags().GetString("project"); err != nil {
 			log.Fatal().Err(err).Msg("cannot parse --project value")
 		} else if project != "" {
-			connection.Options["project"] = project
+			connection.Options["project-id"] = project
 		}
 
+		// deprecated, remove in v8
 		if organization, err := cmd.Flags().GetString("organization"); err != nil {
 			log.Fatal().Err(err).Msg("cannot parse --organization value")
 		} else if organization != "" {
-			connection.Options["organization"] = organization
+			connection.Options["organization-id"] = organization
 		}
+
+		if project, err := cmd.Flags().GetString("project-id"); err != nil {
+			log.Fatal().Err(err).Msg("cannot parse --project value")
+		} else if project != "" {
+			connection.Options["project-id"] = project
+		}
+
+		if organization, err := cmd.Flags().GetString("organization-id"); err != nil {
+			log.Fatal().Err(err).Msg("cannot parse --organization value")
+		} else if organization != "" {
+			connection.Options["organization-id"] = organization
+		}
+
 	case providers.ProviderType_VSPHERE:
 		connection.Backend = providerType
 		target, err := parseTarget(args[0])

--- a/motor/discovery/gcp/resolver_gcp.go
+++ b/motor/discovery/gcp/resolver_gcp.go
@@ -21,12 +21,12 @@ func (r *GcpResolver) AvailableDiscoveryTargets() []string {
 }
 
 func (r *GcpResolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
-	if tc.Options != nil && tc.Options["organization"] != "" {
+	if tc.Options != nil && (tc.Options["organization"] != "" || tc.Options["organization-id"] != "") {
 		// discover the full organization
 		return (&GcpOrgResolver{}).Resolve(tc, cfn, sfn, userIdDetectors...)
 	} else {
 		// when the user has not provided a project, check if we got a project or try to determine it
-		if tc.Options == nil || tc.Options["project"] == "" {
+		if tc.Options == nil || (tc.Options["project"] == "" || tc.Options["project-id"] != "") {
 			// try to determine current project
 			projectid, err := gcp_provider.GetCurrentProject()
 			if err != nil || len(projectid) == 0 {

--- a/motor/discovery/gcp/resolver_org.go
+++ b/motor/discovery/gcp/resolver_org.go
@@ -20,7 +20,7 @@ func (r *GcpOrgResolver) AvailableDiscoveryTargets() []string {
 func (r *GcpOrgResolver) Resolve(tc *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
-	if tc == nil || tc.Options["organization"] == "" {
+	if tc == nil || (tc.Options["organization"] == "" && tc.Options["organization-id"] == "") {
 		return resolved, nil
 	}
 
@@ -70,7 +70,7 @@ func (r *GcpOrgResolver) Resolve(tc *providers.Config, cfn common.CredentialFn, 
 			project := projects[i]
 			projectConfig := tc.Clone()
 			projectConfig.Options = map[string]string{
-				"project": project.ProjectId,
+				"project-id": project.ProjectId,
 			}
 
 			assets, err := (&GcpProjectResolver{}).Resolve(projectConfig, cfn, sfn, userIdDetectors...)

--- a/motor/discovery/gcp/resolver_project.go
+++ b/motor/discovery/gcp/resolver_project.go
@@ -24,7 +24,8 @@ func (r *GcpProjectResolver) AvailableDiscoveryTargets() []string {
 func (r *GcpProjectResolver) Resolve(tc *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
-	if tc == nil || tc.Options["project"] == "" {
+	// NOTE: project is deprecated in favor of project-id and will be removed in v8
+	if tc == nil || (tc.Options["project"] == "" && tc.Options["project-id"] == "") {
 		return resolved, nil
 	}
 
@@ -45,7 +46,10 @@ func (r *GcpProjectResolver) Resolve(tc *providers.Config, cfn common.Credential
 		return nil, err
 	}
 
-	project := tc.Options["project"]
+	project := tc.Options["project-id"]
+	if project == "" {
+		project = tc.Options["project"]
+	}
 
 	if tc.IncludesOneOfDiscoveryTarget(common.DiscoveryAuto, common.DiscoveryAll, DiscoveryProjects) {
 		resolved = append(resolved, &asset.Asset{

--- a/motor/providers/gcp/provider.go
+++ b/motor/providers/gcp/provider.go
@@ -28,15 +28,22 @@ func New(pCfg *providers.Config) (*Provider, error) {
 		return nil, providers.ErrProviderTypeDoesNotMatch
 	}
 
-	if pCfg.Options == nil || (pCfg.Options["project"] == "" && pCfg.Options["organization"] == "") {
+	if pCfg.Options == nil || (pCfg.Options["project-id"] == "" && pCfg.Options["project"] == "" && pCfg.Options["organization-id"] == "" && pCfg.Options["organization"] == "") {
 		return nil, errors.New("gcp provider requires a project id or organization id. please set option `project` or `organization`")
 	}
 
 	var resourceType ResourceType
 	var id string
-	if pCfg.Options["project"] != "" {
+	if pCfg.Options["project-id"] != "" {
+		resourceType = Project
+		id = pCfg.Options["project-id"]
+	} else if pCfg.Options["project"] != "" {
+		// deprecated, use project-id
 		resourceType = Project
 		id = pCfg.Options["project"]
+	} else if pCfg.Options["organization-id"] != "" {
+		resourceType = Organization
+		id = pCfg.Options["organization-id"]
 	} else if pCfg.Options["organization"] != "" {
 		resourceType = Organization
 		id = pCfg.Options["organization"]
@@ -100,7 +107,7 @@ func (p *Provider) Kind() providers.Kind {
 }
 
 func (p *Provider) Runtime() string {
-	return providers.RUNTIME_AWS
+	return providers.RUNTIME_GCP
 }
 
 func (p *Provider) PlatformIdDetectors() []providers.PlatformIdDetector {


### PR DESCRIPTION
Before it was a bit unclear which arguments should be used. `project` can also be the name of the project but we only supported the project-id. This is a non-breaking change because the old flags stay available but are hidden now. If the inventory is used, the old properties are being supported as well.

```
cnquery shell gcp --organization-id 12345678
```