### PR TITLE
🧹 smaller fixes for Google Workspace

### DIFF
--- a/motor/providers/config.go
+++ b/motor/providers/config.go
@@ -81,6 +81,8 @@ func (cfg *Config) ToUrl() string {
 		return ProviderID_OKTA
 	case ProviderType_SLACK:
 		return ProviderID_SLACK
+	case ProviderType_GOOGLE_WORKSPACE:
+		return ProviderID_GOOGLE_WORKSPACE
 	case ProviderType_HOST:
 		if _, ok := cfg.Options["tls"]; ok {
 			return ProviderID_TLS + "://" + cfg.Host

--- a/resources/packs/googleworkspace/domain.go
+++ b/resources/packs/googleworkspace/domain.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (g *mqlGoogleworkspace) GetDomains() ([]interface{}, error) {
-	provider, directoryService, err := directoryService(g.MotorRuntime.Motor.Provider)
+	provider, directoryService, err := directoryService(g.MotorRuntime.Motor.Provider, directory.AdminDirectoryDomainReadonlyScope)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- uses the correct scope for domains call
- removes warning about unknown provider