### PR TITLE
🐛 Only delete volumes we created

### DIFF
--- a/motor/providers/awsec2ebs/destroy.go
+++ b/motor/providers/awsec2ebs/destroy.go
@@ -21,7 +21,7 @@ func (p *Provider) UnmountVolumeFromInstance() error {
 	return nil
 }
 
-func (p *Provider) DetachVolumeFromInstance(ctx context.Context, volume *VolumeId) error {
+func (p *Provider) DetachVolumeFromInstance(ctx context.Context, volume *VolumeInfo) error {
 	log.Info().Msg("detach volume")
 	res, err := p.scannerRegionEc2svc.DetachVolume(ctx, &ec2.DetachVolumeInput{
 		Device: aws.String(p.tmpInfo.volumeAttachmentLoc), VolumeId: &volume.Id,
@@ -47,7 +47,7 @@ func (p *Provider) DetachVolumeFromInstance(ctx context.Context, volume *VolumeI
 	return nil
 }
 
-func (p *Provider) DeleteCreatedVolume(ctx context.Context, volume *VolumeId) error {
+func (p *Provider) DeleteCreatedVolume(ctx context.Context, volume *VolumeInfo) error {
 	log.Info().Msg("delete created volume")
 	_, err := p.scannerRegionEc2svc.DeleteVolume(ctx, &ec2.DeleteVolumeInput{VolumeId: &volume.Id})
 	return err

--- a/motor/providers/awsec2ebs/provider.go
+++ b/motor/providers/awsec2ebs/provider.go
@@ -155,11 +155,9 @@ type TargetInfo struct {
 }
 
 type tmpInfo struct {
-	// these fields are referenced during setup/mount and close
-	createdExtraVolume  bool      // true if we created an extra volume to attach to the scanner instance
-	scanVolumeId        *VolumeId // the volume id of the volume we attached to the instance
-	scanDir             string    // the tmp dir we create; serves as the directory we mount the volume to
-	volumeAttachmentLoc string    // where we tell AWS to attach the volume; it doesn't necessarily get attached there, but we have to reference this same location when detaching
+	scanVolumeInfo      *VolumeInfo // the info of the volume we attached to the instance
+	scanDir             string      // the tmp dir we create; serves as the directory we mount the volume to
+	volumeAttachmentLoc string      // where we tell AWS to attach the volume; it doesn't necessarily get attached there, but we have to reference this same location when detaching
 }
 
 func (p *Provider) RunCommand(command string) (*os.Command, error) {
@@ -180,7 +178,7 @@ func (p *Provider) FS() afero.Fs {
 
 func (p *Provider) Close() {
 	if p.opts != nil {
-		if p.opts[NoSetup] == "true" || p.targetType == EBSTargetSnapshot {
+		if p.opts[NoSetup] == "true" {
 			return
 		}
 	}
@@ -189,15 +187,17 @@ func (p *Provider) Close() {
 	if err != nil {
 		log.Error().Err(err).Msg("unable to unmount volume")
 	}
-	err = p.DetachVolumeFromInstance(ctx, p.tmpInfo.scanVolumeId)
+	err = p.DetachVolumeFromInstance(ctx, p.tmpInfo.scanVolumeInfo)
 	if err != nil {
 		log.Error().Err(err).Msg("unable to detach volume")
 	}
 	// only delete the volume if we created it, e.g., if we're scanning a snapshot
-	if p.tmpInfo.createdExtraVolume {
-		err = p.DeleteCreatedVolume(ctx, p.tmpInfo.scanVolumeId)
-		if err != nil {
-			log.Error().Err(err).Msg("unable to delete volume")
+	if val, ok := p.tmpInfo.scanVolumeInfo.Tags["Created By"]; ok {
+		if val == "Mondoo" {
+			err = p.DeleteCreatedVolume(ctx, p.tmpInfo.scanVolumeInfo)
+			if err != nil {
+				log.Error().Err(err).Msg("unable to delete volume")
+			}
 		}
 	}
 	err = p.RemoveCreatedDir()

--- a/motor/providers/awsec2ebs/provider.go
+++ b/motor/providers/awsec2ebs/provider.go
@@ -192,12 +192,13 @@ func (p *Provider) Close() {
 		log.Error().Err(err).Msg("unable to detach volume")
 	}
 	// only delete the volume if we created it, e.g., if we're scanning a snapshot
-	if val, ok := p.tmpInfo.scanVolumeInfo.Tags["Created By"]; ok {
+	if val, ok := p.tmpInfo.scanVolumeInfo.Tags["createdBy"]; ok {
 		if val == "Mondoo" {
 			err = p.DeleteCreatedVolume(ctx, p.tmpInfo.scanVolumeInfo)
 			if err != nil {
 				log.Error().Err(err).Msg("unable to delete volume")
 			}
+			log.Info().Str("vol-id", p.tmpInfo.scanVolumeInfo.Id).Msg("deleted temporary volume created by Mondoo")
 		}
 	} else {
 		log.Debug().Str("vol-id", p.tmpInfo.scanVolumeInfo.Id).Msg("skipping volume deletion, not created by Mondoo")

--- a/motor/providers/awsec2ebs/provider.go
+++ b/motor/providers/awsec2ebs/provider.go
@@ -199,6 +199,8 @@ func (p *Provider) Close() {
 				log.Error().Err(err).Msg("unable to delete volume")
 			}
 		}
+	} else {
+		log.Debug().Str("vol-id", p.tmpInfo.scanVolumeInfo.Id).Msg("skipping volume deletion, not created by Mondoo")
 	}
 	err = p.RemoveCreatedDir()
 	if err != nil {

--- a/motor/providers/awsec2ebs/setup.go
+++ b/motor/providers/awsec2ebs/setup.go
@@ -15,7 +15,7 @@ import (
 	motoraws "go.mondoo.com/cnquery/motor/discovery/aws"
 )
 
-func (t *Provider) Validate(ctx context.Context) (*types.Instance, *VolumeId, *SnapshotId, error) {
+func (t *Provider) Validate(ctx context.Context) (*types.Instance, *VolumeInfo, *SnapshotId, error) {
 	target := t.target
 	switch t.targetType {
 	case EBSTargetInstance:
@@ -39,9 +39,9 @@ func (t *Provider) Validate(ctx context.Context) (*types.Instance, *VolumeId, *S
 			if vol.State != types.VolumeStateAvailable {
 				// we can still scan it, it just means we have to do the whole snapshot/create volume dance
 				log.Warn().Msg("volume specified is not in available state")
-				return nil, &VolumeId{Id: t.target.Id, Account: t.target.AccountId, Region: t.target.Region, IsAvailable: false}, nil, nil
+				return nil, &VolumeInfo{Id: t.target.Id, Account: t.target.AccountId, Region: t.target.Region, IsAvailable: false, Tags: awsTagsToMap(vol.Tags)}, nil, nil
 			}
-			return nil, &VolumeId{Id: t.target.Id, Account: t.target.AccountId, Region: t.target.Region, IsAvailable: true}, nil, nil
+			return nil, &VolumeInfo{Id: t.target.Id, Account: t.target.AccountId, Region: t.target.Region, IsAvailable: true, Tags: awsTagsToMap(vol.Tags)}, nil, nil
 		}
 	case EBSTargetSnapshot:
 		log.Info().Interface("snapshot", target).Msg("validate exists")
@@ -58,16 +58,16 @@ func (t *Provider) Validate(ctx context.Context) (*types.Instance, *VolumeId, *S
 	return nil, nil, nil, errors.New("cannot validate; unrecognized ebs target")
 }
 
-func (t *Provider) SetupForTargetVolume(ctx context.Context, volume VolumeId) (bool, error) {
+func (t *Provider) SetupForTargetVolume(ctx context.Context, volume VolumeInfo) (bool, error) {
 	log.Debug().Interface("volume", volume).Msg("setup for target volume")
 	if !volume.IsAvailable {
 		return t.SetupForTargetVolumeUnavailable(ctx, volume)
 	}
-	t.tmpInfo.scanVolumeId = &volume
+	t.tmpInfo.scanVolumeInfo = &volume
 	return t.AttachVolumeToInstance(ctx, volume)
 }
 
-func (t *Provider) SetupForTargetVolumeUnavailable(ctx context.Context, volume VolumeId) (bool, error) {
+func (t *Provider) SetupForTargetVolumeUnavailable(ctx context.Context, volume VolumeInfo) (bool, error) {
 	found, snapId, err := t.FindRecentSnapshotForVolume(ctx, volume)
 	if err != nil {
 		// only log the error here, this is not a blocker
@@ -87,8 +87,7 @@ func (t *Provider) SetupForTargetVolumeUnavailable(ctx context.Context, volume V
 	if err != nil {
 		return false, err
 	}
-	t.tmpInfo.createdExtraVolume = true
-	t.tmpInfo.scanVolumeId = &volId
+	t.tmpInfo.scanVolumeInfo = &volId
 	return t.AttachVolumeToInstance(ctx, volId)
 }
 
@@ -102,15 +101,14 @@ func (t *Provider) SetupForTargetSnapshot(ctx context.Context, snapshot Snapshot
 	if err != nil {
 		return false, err
 	}
-	t.tmpInfo.createdExtraVolume = true
-	t.tmpInfo.scanVolumeId = &volId
+	t.tmpInfo.scanVolumeInfo = &volId
 	return t.AttachVolumeToInstance(ctx, volId)
 }
 
 func (t *Provider) SetupForTargetInstance(ctx context.Context, instanceinfo *types.Instance) (bool, error) {
 	log.Debug().Str("instance id", *instanceinfo.InstanceId).Msg("setup for target instance")
 	var err error
-	v, err := t.GetVolumeIdForInstance(ctx, instanceinfo)
+	v, err := t.GetVolumeInfoForInstance(ctx, instanceinfo)
 	if err != nil {
 		return false, err
 	}
@@ -133,22 +131,21 @@ func (t *Provider) SetupForTargetInstance(ctx context.Context, instanceinfo *typ
 	if err != nil {
 		return false, err
 	}
-	t.tmpInfo.createdExtraVolume = true
-	t.tmpInfo.scanVolumeId = &volId
+	t.tmpInfo.scanVolumeInfo = &volId
 	return t.AttachVolumeToInstance(ctx, volId)
 }
 
-func (t *Provider) GetVolumeIdForInstance(ctx context.Context, instanceinfo *types.Instance) (VolumeId, error) {
+func (t *Provider) GetVolumeInfoForInstance(ctx context.Context, instanceinfo *types.Instance) (VolumeInfo, error) {
 	i := t.target
 	log.Info().Interface("instance", i).Msg("find volume id")
 
-	if volID := GetVolumeIdForInstance(instanceinfo); volID != nil {
-		return VolumeId{Id: *volID, Region: i.Region, Account: i.AccountId}, nil
+	if volID := GetVolumeInfoForInstance(instanceinfo); volID != nil {
+		return VolumeInfo{Id: *volID, Region: i.Region, Account: i.AccountId, Tags: map[string]string{}}, nil
 	}
-	return VolumeId{}, errors.New("no volume id found for instance")
+	return VolumeInfo{}, errors.New("no volume id found for instance")
 }
 
-func GetVolumeIdForInstance(instanceinfo *types.Instance) *string {
+func GetVolumeInfoForInstance(instanceinfo *types.Instance) *string {
 	if len(instanceinfo.BlockDeviceMappings) == 1 {
 		return instanceinfo.BlockDeviceMappings[0].Ebs.VolumeId
 	}
@@ -167,11 +164,11 @@ func GetVolumeIdForInstance(instanceinfo *types.Instance) *string {
 	return nil
 }
 
-func (t *Provider) FindRecentSnapshotForVolume(ctx context.Context, v VolumeId) (bool, SnapshotId, error) {
+func (t *Provider) FindRecentSnapshotForVolume(ctx context.Context, v VolumeInfo) (bool, SnapshotId, error) {
 	return FindRecentSnapshotForVolume(ctx, v, t.scannerRegionEc2svc)
 }
 
-func FindRecentSnapshotForVolume(ctx context.Context, v VolumeId, svc *ec2.Client) (bool, SnapshotId, error) {
+func FindRecentSnapshotForVolume(ctx context.Context, v VolumeInfo, svc *ec2.Client) (bool, SnapshotId, error) {
 	log.Info().Msg("find recent snapshot")
 	res, err := svc.DescribeSnapshots(ctx,
 		&ec2.DescribeSnapshotsInput{Filters: []types.Filter{
@@ -215,7 +212,7 @@ func FindRecentSnapshotForVolume(ctx context.Context, v VolumeId, svc *ec2.Clien
 	return false, SnapshotId{}, nil
 }
 
-func (t *Provider) CreateSnapshotFromVolume(ctx context.Context, v VolumeId) (SnapshotId, error) {
+func (t *Provider) CreateSnapshotFromVolume(ctx context.Context, v VolumeInfo) (SnapshotId, error) {
 	log.Info().Msg("create snapshot")
 	// snapshot the volume
 	// use region from volume for aws config
@@ -313,9 +310,9 @@ func (t *Provider) CopySnapshotToRegion(ctx context.Context, snapshot SnapshotId
 	return SnapshotId{Id: *res.SnapshotId, Region: t.config.Region, Account: t.scannerInstance.Account}, nil
 }
 
-func (t *Provider) CreateVolumeFromSnapshot(ctx context.Context, snapshot SnapshotId) (VolumeId, error) {
+func (t *Provider) CreateVolumeFromSnapshot(ctx context.Context, snapshot SnapshotId) (VolumeInfo, error) {
 	log.Info().Msg("create volume")
-	var vol VolumeId
+	var vol VolumeInfo
 
 	out, err := t.scannerRegionEc2svc.CreateVolume(ctx, &ec2.CreateVolumeInput{
 		SnapshotId:        &snapshot.Id,
@@ -343,7 +340,7 @@ func (t *Provider) CreateVolumeFromSnapshot(ctx context.Context, snapshot Snapsh
 		}
 		state = vols.Volumes[0].State
 	}
-	return VolumeId{Id: *out.VolumeId, Region: t.config.Region, Account: t.scannerInstance.Account}, nil
+	return VolumeInfo{Id: *out.VolumeId, Region: t.config.Region, Account: t.scannerInstance.Account, Tags: awsTagsToMap(out.Tags)}, nil
 }
 
 func newVolumeAttachmentLoc() string {
@@ -391,7 +388,7 @@ func AttachVolume(ctx context.Context, ec2svc *ec2.Client, location string, volI
 	return location, res.State, nil
 }
 
-func (t *Provider) AttachVolumeToInstance(ctx context.Context, volume VolumeId) (bool, error) {
+func (t *Provider) AttachVolumeToInstance(ctx context.Context, volume VolumeInfo) (bool, error) {
 	log.Info().Str("volume id", volume.Id).Msg("attach volume")
 	t.tmpInfo.volumeAttachmentLoc = newVolumeAttachmentLoc()
 	ready := false
@@ -424,4 +421,14 @@ func (t *Provider) AttachVolumeToInstance(ctx context.Context, volume VolumeId) 
 		}
 	}
 	return true, nil
+}
+
+func awsTagsToMap(tags []types.Tag) map[string]string {
+	m := make(map[string]string)
+	for _, t := range tags {
+		if t.Key != nil && t.Value != nil {
+			m[*t.Key] = *t.Value
+		}
+	}
+	return m
 }

--- a/motor/providers/awsec2ebs/setup.go
+++ b/motor/providers/awsec2ebs/setup.go
@@ -87,6 +87,7 @@ func (t *Provider) SetupForTargetVolumeUnavailable(ctx context.Context, volume V
 	if err != nil {
 		return false, err
 	}
+	t.tmpInfo.createdExtraVolume = true
 	t.tmpInfo.scanVolumeId = &volId
 	return t.AttachVolumeToInstance(ctx, volId)
 }
@@ -101,6 +102,7 @@ func (t *Provider) SetupForTargetSnapshot(ctx context.Context, snapshot Snapshot
 	if err != nil {
 		return false, err
 	}
+	t.tmpInfo.createdExtraVolume = true
 	t.tmpInfo.scanVolumeId = &volId
 	return t.AttachVolumeToInstance(ctx, volId)
 }
@@ -131,6 +133,7 @@ func (t *Provider) SetupForTargetInstance(ctx context.Context, instanceinfo *typ
 	if err != nil {
 		return false, err
 	}
+	t.tmpInfo.createdExtraVolume = true
 	t.tmpInfo.scanVolumeId = &volId
 	return t.AttachVolumeToInstance(ctx, volId)
 }

--- a/motor/providers/awsec2ebs/types.go
+++ b/motor/providers/awsec2ebs/types.go
@@ -53,16 +53,18 @@ type SnapshotId struct {
 	Account string
 }
 
-type VolumeId struct {
+type VolumeInfo struct {
 	Id          string
 	Region      string
 	Account     string
 	IsAvailable bool
+	Tags        map[string]string
 }
 
 func resourceTags(resourceType types.ResourceType, instanceId string) []types.TagSpecification {
 	return []types.TagSpecification{
-		{ResourceType: resourceType,
+		{
+			ResourceType: resourceType,
 			Tags: []types.Tag{
 				{Key: aws.String("Created By"), Value: aws.String("Mondoo")},
 				{Key: aws.String("Created From Instance"), Value: aws.String(instanceId)},

--- a/motor/providers/awsec2ebs/types.go
+++ b/motor/providers/awsec2ebs/types.go
@@ -66,7 +66,7 @@ func resourceTags(resourceType types.ResourceType, instanceId string) []types.Ta
 		{
 			ResourceType: resourceType,
 			Tags: []types.Tag{
-				{Key: aws.String("Created By"), Value: aws.String("Mondoo")},
+				{Key: aws.String("createdBy"), Value: aws.String("Mondoo")},
 				{Key: aws.String("Created From Instance"), Value: aws.String(instanceId)},
 			},
 		},

--- a/motor/providers/awsec2ebs/types.go
+++ b/motor/providers/awsec2ebs/types.go
@@ -67,6 +67,7 @@ func resourceTags(resourceType types.ResourceType, instanceId string) []types.Ta
 			ResourceType: resourceType,
 			Tags: []types.Tag{
 				{Key: aws.String("createdBy"), Value: aws.String("Mondoo")},
+				{Key: aws.String("Created By"), Value: aws.String("Mondoo")},
 				{Key: aws.String("Created From Instance"), Value: aws.String(instanceId)},
 			},
 		},


### PR DESCRIPTION
In some cases, e.g., snapshot scans we create volumes which we have to delete afterwards. But when scanning an available volume, we shouldn't delete it afterwards.

Fixes #500

Signed-off-by: Christian Zunker <christian@mondoo.com>