### PR TITLE
Extend aws fingerprint detection

### DIFF
--- a/cli/sysinfo/sysinfo.go
+++ b/cli/sysinfo/sysinfo.go
@@ -70,9 +70,9 @@ func GatherSystemInfo(opts ...SystemInfoOption) (*SystemInfo, error) {
 			idDetector = providers.MachineIdDetector
 		}
 
-		platformIDs, _, err := motorid.GatherPlatformIDs(cfg.m.Provider, pi, idDetector)
-		if err == nil && len(platformIDs) > 0 {
-			sysInfo.PlatformId = platformIDs[0]
+		info, err := motorid.GatherPlatformInfo(cfg.m.Provider, pi, idDetector)
+		if err == nil && len(info.IDs) > 0 {
+			sysInfo.PlatformId = info.IDs[0]
 		}
 	}
 

--- a/motor/motorid/awsec2/metadata_cmd.go
+++ b/motor/motorid/awsec2/metadata_cmd.go
@@ -1,11 +1,16 @@
 package awsec2
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cockroachdb/errors"
 	"go.mondoo.com/cnquery/motor/platform"
 	"go.mondoo.com/cnquery/motor/providers/os"
@@ -13,20 +18,22 @@ import (
 )
 
 const (
-	identityUrl                   = "http://169.254.169.254/latest/dynamic/instance-identity/document"
-	metadataIdentityScriptWindows = "Invoke-RestMethod -TimeoutSec 1 -URI http://169.254.169.254/latest/dynamic/instance-identity/document -UseBasicParsing | ConvertTo-Json"
+	identityUrl = "http://169.254.169.254/latest/dynamic/instance-identity/document"
+	tagNameUrl  = "http://169.254.169.254/latest/meta-data/tags/instance/Name"
 )
 
-func NewCommandInstanceMetadata(provider os.OperatingSystemProvider, pf *platform.Platform) *CommandInstanceMetadata {
+func NewCommandInstanceMetadata(provider os.OperatingSystemProvider, pf *platform.Platform, config *aws.Config) *CommandInstanceMetadata {
 	return &CommandInstanceMetadata{
 		provider: provider,
 		platform: pf,
+		config:   config,
 	}
 }
 
 type CommandInstanceMetadata struct {
 	provider os.OperatingSystemProvider
 	platform *platform.Platform
+	config   *aws.Config
 }
 
 func (m *CommandInstanceMetadata) Identify() (Identity, error) {
@@ -34,22 +41,51 @@ func (m *CommandInstanceMetadata) Identify() (Identity, error) {
 	if err != nil {
 		return Identity{}, err
 	}
-
 	// parse into struct
 	doc := imds.InstanceIdentityDocument{}
 	if err := json.NewDecoder(strings.NewReader(instanceDocument)).Decode(&doc); err != nil {
 		return Identity{}, errors.Wrap(err, "failed to decode EC2 instance identity document")
 	}
+
+	name := ""
+	// Note that the tags metadata service has to be enabled for this to work. If not, we fallback to trying to get the name
+	// via the aws API (if there's a config provided).
+	taggedName, err := m.instanceNameTag()
+	if err == nil {
+		name = taggedName
+	} else if m.config != nil {
+		ec2svc := ec2.NewFromConfig(*m.config)
+		ctx := context.Background()
+		filters := []ec2types.Filter{
+			{
+				Name:   aws.String("resource-id"),
+				Values: []string{doc.InstanceID},
+			},
+		}
+		tags, err := ec2svc.DescribeTags(ctx, &ec2.DescribeTagsInput{Filters: filters})
+		if err == nil {
+			for _, t := range tags.Tags {
+				if t.Key != nil && *t.Key == "Name" && t.Value != nil {
+					name = *t.Value
+				}
+			}
+		}
+	}
 	return Identity{
-		InstanceID: MondooInstanceID(doc.AccountID, doc.Region, doc.InstanceID),
-		AccountID:  "//platformid.api.mondoo.app/runtime/aws/accounts/" + doc.AccountID,
+		InstanceName: name,
+		InstanceID:   MondooInstanceID(doc.AccountID, doc.Region, doc.InstanceID),
+		AccountID:    "//platformid.api.mondoo.app/runtime/aws/accounts/" + doc.AccountID,
 	}, nil
 }
 
-func (m *CommandInstanceMetadata) instanceIdentityDocument() (string, error) {
+func curlWindows(url string) string {
+	return fmt.Sprintf("Invoke-RestMethod -TimeoutSec 1 -URI %s -UseBasicParsing | ConvertTo-Json", url)
+}
+
+func (m *CommandInstanceMetadata) curlDocument(url string) (string, error) {
 	switch {
 	case m.platform.IsFamily(platform.FAMILY_UNIX):
-		cmd, err := m.provider.RunCommand("curl " + identityUrl)
+		cmd, err := m.provider.RunCommand("curl " + url)
 		if err != nil {
 			return "", err
 		}
@@ -60,7 +96,9 @@ func (m *CommandInstanceMetadata) instanceIdentityDocument() (string, error) {
 
 		return strings.TrimSpace(string(data)), nil
 	case m.platform.IsFamily(platform.FAMILY_WINDOWS):
-		cmd, err := m.provider.RunCommand(powershell.Encode(metadataIdentityScriptWindows))
+		curlCmd := curlWindows(url)
+		encoded := powershell.Encode(curlCmd)
+		cmd, err := m.provider.RunCommand(encoded)
 		if err != nil {
 			return "", err
 		}
@@ -73,4 +111,19 @@ func (m *CommandInstanceMetadata) instanceIdentityDocument() (string, error) {
 	default:
 		return "", errors.New("your platform is not supported by aws metadata identifier resource")
 	}
+}
+
+func (m *CommandInstanceMetadata) instanceNameTag() (string, error) {
+	res, err := m.curlDocument(tagNameUrl)
+	if err != nil {
+		return "", err
+	}
+	if strings.Contains(res, "Not Found") {
+		return "", errors.New("metadata tags not enabled")
+	}
+	return res, nil
+}
+
+func (m *CommandInstanceMetadata) instanceIdentityDocument() (string, error) {
+	return m.curlDocument(identityUrl)
 }

--- a/motor/motorid/awsec2/metadata_cmd_test.go
+++ b/motor/motorid/awsec2/metadata_cmd_test.go
@@ -21,10 +21,30 @@ func TestEC2RoleProviderInstanceIdentityUnix(t *testing.T) {
 	p, err := m.Platform()
 	require.NoError(t, err)
 
-	metadata := awsec2.NewCommandInstanceMetadata(provider, p)
+	metadata := awsec2.NewCommandInstanceMetadata(provider, p, nil)
 	ident, err := metadata.Identify()
 
 	assert.Nil(t, err)
+	assert.Equal(t, "ec2-name", ident.InstanceName)
+	assert.Equal(t, "//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/123456789012/regions/us-west-2/instances/i-1234567890abcdef0", ident.InstanceID)
+	assert.Equal(t, "//platformid.api.mondoo.app/runtime/aws/accounts/123456789012", ident.AccountID)
+}
+
+func TestEC2RoleProviderInstanceIdentityUnixNoName(t *testing.T) {
+	provider, err := mock.NewFromTomlFile("./testdata/instance-identity_document_linux_no_tags.toml")
+	require.NoError(t, err)
+
+	m, err := motor.New(provider)
+	require.NoError(t, err)
+
+	p, err := m.Platform()
+	require.NoError(t, err)
+
+	metadata := awsec2.NewCommandInstanceMetadata(provider, p, nil)
+	ident, err := metadata.Identify()
+
+	assert.Nil(t, err)
+	assert.Equal(t, "", ident.InstanceName)
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/123456789012/regions/us-west-2/instances/i-1234567890abcdef0", ident.InstanceID)
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/aws/accounts/123456789012", ident.AccountID)
 }
@@ -39,10 +59,30 @@ func TestEC2RoleProviderInstanceIdentityWindows(t *testing.T) {
 	p, err := m.Platform()
 	require.NoError(t, err)
 
-	metadata := awsec2.NewCommandInstanceMetadata(provider, p)
+	metadata := awsec2.NewCommandInstanceMetadata(provider, p, nil)
 	ident, err := metadata.Identify()
 
 	assert.Nil(t, err)
+	assert.Equal(t, "ec2-name-windows", ident.InstanceName)
+	assert.Equal(t, "//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/123456789012/regions/us-east-1/instances/i-1234567890abcdef0", ident.InstanceID)
+	assert.Equal(t, "//platformid.api.mondoo.app/runtime/aws/accounts/123456789012", ident.AccountID)
+}
+
+func TestEC2RoleProviderInstanceIdentityWindowsNoName(t *testing.T) {
+	provider, err := mock.NewFromTomlFile("./testdata/instance-identity_document_windows_no_tags.toml")
+	require.NoError(t, err)
+
+	m, err := motor.New(provider)
+	require.NoError(t, err)
+
+	p, err := m.Platform()
+	require.NoError(t, err)
+
+	metadata := awsec2.NewCommandInstanceMetadata(provider, p, nil)
+	ident, err := metadata.Identify()
+
+	assert.Nil(t, err)
+	assert.Equal(t, "", ident.InstanceName)
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/123456789012/regions/us-east-1/instances/i-1234567890abcdef0", ident.InstanceID)
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/aws/accounts/123456789012", ident.AccountID)
 }

--- a/motor/motorid/awsec2/metadata_local_test.go
+++ b/motor/motorid/awsec2/metadata_local_test.go
@@ -50,6 +50,7 @@ func TestEC2RoleProviderInstanceIdentityLocal(t *testing.T) {
 	metadata := awsec2.NewLocal(cfg)
 	ident, err := metadata.Identify()
 	assert.Nil(t, err)
+	assert.Equal(t, "", ident.InstanceName)
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/123456789012/regions/us-west-2/instances/i-1234567890abcdef0", ident.InstanceID)
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/aws/accounts/123456789012", ident.AccountID)
 }

--- a/motor/motorid/awsec2/testdata/instance-identity_document_linux.toml
+++ b/motor/motorid/awsec2/testdata/instance-identity_document_linux.toml
@@ -31,3 +31,5 @@ stdout = """
 }
 """
 
+[commands."curl http://169.254.169.254/latest/meta-data/tags/instance/Name"]
+stdout = "ec2-name"

--- a/motor/motorid/awsec2/testdata/instance-identity_document_linux_no_tags.toml
+++ b/motor/motorid/awsec2/testdata/instance-identity_document_linux_no_tags.toml
@@ -10,30 +10,6 @@ stdout = "4.9.125-linuxkit"
 [files."/etc/redhat-release"]
 content = "Red Hat Enterprise Linux Server release 7.2 (Maipo)"
 
-[files."/sys/class/dmi/id/product_version"]
-  path = "/sys/class/dmi/id/product_version"
-  enoent = false
-  content = " "
-  [files."/sys/class/dmi/id/product_version".stat]
-    mode = 292
-    time = 2021-11-15T13:16:57Z
-    isdir = false
-    uid = 0
-    gid = 0
-    size = 0
-
-[files."/sys/class/dmi/id/bios_vendor"]
-  path = "/sys/class/dmi/id/bios_vendor"
-  enoent = false
-  content = "Amazon EC2"
-  [files."/sys/class/dmi/id/bios_vendor".stat]
-    mode = 292
-    time = 2021-11-15T13:16:57Z
-    isdir = false
-    uid = 0
-    gid = 0
-    size = 0
-
 [commands."curl http://169.254.169.254/latest/dynamic/instance-identity/document"]
 stdout = """
 {
@@ -56,4 +32,16 @@ stdout = """
 """
 
 [commands."curl http://169.254.169.254/latest/meta-data/tags/instance/Name"]
-stdout = "ec2-name"
+stdout = """
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+ <head>
+  <title>404 - Not Found</title>
+ </head>
+ <body>
+  <h1>404 - Not Found</h1>
+ </body>
+</html>
+"""

--- a/motor/motorid/awsec2/testdata/instance-identity_document_windows_no_tags.toml
+++ b/motor/motorid/awsec2/testdata/instance-identity_document_windows_no_tags.toml
@@ -6,7 +6,19 @@
     exit_status = 0
   [commands.fb0f5ced4f556de99f237ea35a78ba4ddd5fc4e149589805d95cbf44f5ccc7aa]
     command = "powershell.exe -NoProfile -EncodedCommand JABQAHIAbwBnAHIAZQBzAHMAUAByAGUAZgBlAHIAZQBuAGMAZQA9ACcAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQAnADsASQBuAHYAbwBrAGUALQBSAGUAcwB0AE0AZQB0AGgAbwBkACAALQBUAGkAbQBlAG8AdQB0AFMAZQBjACAAMQAgAC0AVQBSAEkAIABoAHQAdABwADoALwAvADEANgA5AC4AMgA1ADQALgAxADYAOQAuADIANQA0AC8AbABhAHQAZQBzAHQALwBtAGUAdABhAC0AZABhAHQAYQAvAHQAYQBnAHMALwBpAG4AcwB0AGEAbgBjAGUALwBOAGEAbQBlACAALQBVAHMAZQBCAGEAcwBpAGMAUABhAHIAcwBpAG4AZwAgAHwAIABDAG8AbgB2AGUAcgB0AFQAbwAtAEoAcwBvAG4A"
-    stdout = "ec2-name-windows"
+    stdout = """
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+ <head>
+  <title>404 - Not Found</title>
+ </head>
+ <body>
+  <h1>404 - Not Found</h1>
+ </body>
+</html>
+"""
     stderr = ""
     exit_status = 0
   [commands.7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682]

--- a/motor/motorid/clouddetect/providers/aws/aws_test.go
+++ b/motor/motorid/clouddetect/providers/aws/aws_test.go
@@ -20,9 +20,10 @@ func TestDetectInstance(t *testing.T) {
 	p, err := m.Platform()
 	require.NoError(t, err)
 
-	identifier, related := Detect(provider, p)
+	identifier, name, related := Detect(provider, p)
 
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/123456789012/regions/us-west-2/instances/i-1234567890abcdef0", identifier)
+	assert.Equal(t, "ec2-name", name)
 	require.Len(t, related, 1)
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/aws/accounts/123456789012", related[0])
 }
@@ -37,9 +38,10 @@ func TestDetectInstanceArm(t *testing.T) {
 	p, err := m.Platform()
 	require.NoError(t, err)
 
-	identifier, related := Detect(provider, p)
+	identifier, name, related := Detect(provider, p)
 
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/123456789012/regions/us-west-2/instances/i-1234567890abcdef0", identifier)
+	assert.Equal(t, "ec2-name", name)
 	require.Len(t, related, 1)
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/aws/accounts/123456789012", related[0])
 }
@@ -54,8 +56,10 @@ func TestDetectNotInstance(t *testing.T) {
 	p, err := m.Platform()
 	require.NoError(t, err)
 
-	identifier, related := Detect(provider, p)
+	identifier, name, related := Detect(provider, p)
 
 	assert.Equal(t, "", identifier)
+	assert.Equal(t, "", name)
+
 	require.Len(t, related, 0)
 }

--- a/motor/motorid/clouddetect/providers/aws/testdata/instance.toml
+++ b/motor/motorid/clouddetect/providers/aws/testdata/instance.toml
@@ -43,3 +43,6 @@ stdout = """
 }
 """
 
+
+[commands."curl http://169.254.169.254/latest/meta-data/tags/instance/Name"]
+stdout = "ec2-name"

--- a/motor/motorid/clouddetect/providers/gce/gce_test.go
+++ b/motor/motorid/clouddetect/providers/gce/gce_test.go
@@ -19,9 +19,10 @@ func TestDetectLinuxInstance(t *testing.T) {
 	p, err := m.Platform()
 	require.NoError(t, err)
 
-	identifier, relatedIdentifiers := Detect(provider, p)
+	identifier, name, relatedIdentifiers := Detect(provider, p)
 
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/gcp/compute/v1/projects/mondoo-dev-262313/zones/us-central1-a/instances/6001244637815193808", identifier)
+	assert.Equal(t, "", name)
 	require.Len(t, relatedIdentifiers, 1)
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/gcp/projects/mondoo-dev-262313", relatedIdentifiers[0])
 }
@@ -36,9 +37,10 @@ func TestDetectWindowsInstance(t *testing.T) {
 	p, err := m.Platform()
 	require.NoError(t, err)
 
-	identifier, relatedIdentifiers := Detect(provider, p)
+	identifier, name, relatedIdentifiers := Detect(provider, p)
 
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/gcp/compute/v1/projects/mondoo-dev-262313/zones/us-central1-a/instances/5275377306317132843", identifier)
+	assert.Equal(t, "", name)
 	require.Len(t, relatedIdentifiers, 1)
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/gcp/projects/mondoo-dev-262313", relatedIdentifiers[0])
 }
@@ -53,8 +55,9 @@ func TestNoMatch(t *testing.T) {
 	p, err := m.Platform()
 	require.NoError(t, err)
 
-	identifier, relatedIdentifiers := Detect(provider, p)
+	identifier, name, relatedIdentifiers := Detect(provider, p)
 
 	assert.Empty(t, identifier)
+	assert.Empty(t, name)
 	assert.Empty(t, relatedIdentifiers)
 }

--- a/motor/providers/ssh/session.go
+++ b/motor/providers/ssh/session.go
@@ -210,7 +210,7 @@ func prepareConnection(pCfg *providers.Config) ([]ssh.AuthMethod, []io.Closer, e
 			if err != nil {
 				return nil, nil, err
 			}
-
+			log.Debug().Msg("generating instance connect credentials")
 			eic := awsinstanceconnect.New(cfg)
 			creds, err := eic.GenerateCredentials(pCfg.Host, credential.User)
 			if err != nil {


### PR DESCRIPTION
 - Extend the `PlatformFingerprint` to also be able to return an asset name, next to the platform ids
 - Update the `aws` detectors to be able to fetch a name for an instance. This can either happen via using the tags local endpoint (if enabled) or using the AWS API if there's a config. If neither's present we fallback to using the instance id as the name.
 - Tests

This will help with properly naming EC2 assets when scanning those via ssh (instance-connect,ssm)