### PR TITLE
🧹 allow configuration of scp via asset opts

### DIFF
--- a/motor/providers/ssh/provider.go
+++ b/motor/providers/ssh/provider.go
@@ -35,7 +35,7 @@ func New(pCfg *providers.Config) (*Provider, error) {
 	}
 
 	activateScp := false
-	if os.Getenv("MONDOO_SSH_SCP") == "on" {
+	if os.Getenv("MONDOO_SSH_SCP") == "on" || pCfg.Options["ssh_scp"] == "on" {
 		activateScp = true
 	}
 


### PR DESCRIPTION
This is required for the packer integration since the integration cannot change the env variable from their own process.