### PR TITLE
✨Add asset-name flag, allowing overwriting of asset names.

### DIFF
--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -54,7 +54,7 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 	password, _ := cmd.Flags().GetString("password")
 	identityFile, _ := cmd.Flags().GetString("identity-file")
 	sudo, _ := cmd.Flags().GetBool("sudo")
-
+	assetName, _ := cmd.Flags().GetString("asset-name")
 	// parse options
 	optionData, err := cmd.Flags().GetStringToString("option")
 	if err != nil {
@@ -88,6 +88,7 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 	annotations, err := cmd.Flags().GetStringToString("annotation")
 
 	parsedAsset := &asset.Asset{
+		Name:        assetName,
 		Options:     map[string]string{},
 		Labels:      labels,
 		Annotations: annotations,

--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -235,6 +235,7 @@ This example connects to Microsoft 365 using the PKCS #12 formatted certificate:
 		cmd.Flags().Bool("ask-pass", false, "Ask for connection password")
 		cmd.Flags().StringP("identity-file", "i", "", "Select a file from which the identity (private key) for public key authentication is read")
 		cmd.Flags().String("id-detector", "", "User-override for platform id detection mechanism, supported are "+strings.Join(providers.AvailablePlatformIdDetector(), ", "))
+		cmd.Flags().String("asset-name", "", "User-override for the asset name")
 
 		cmd.Flags().String("path", "", "Path to a local file or directory that the connection should use")
 		cmd.Flags().StringToString("option", nil, "Additional connection options, multiple options can be passed in via --option key=value")

--- a/motor/discovery/local/local.go
+++ b/motor/discovery/local/local.go
@@ -62,7 +62,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 	}
 
 	assetObj.PlatformIds = fingerprint.PlatformIDs
-	if fingerprint.Name != "" {
+	if fingerprint.Name != "" && assetObj.Name == "" {
 		assetObj.Name = fingerprint.Name
 	}
 

--- a/motor/discovery/resolve.go
+++ b/motor/discovery/resolve.go
@@ -114,8 +114,8 @@ func ResolveAsset(ctx context.Context, root *asset.Asset, cfn common.CredentialF
 	assetFallbackName := func(a *asset.Asset, c *providers.Config) {
 		// set the asset name to the config name. This is only required for error cases where the discovery
 		// is not successful
-		if root.Name == "" {
-			root.Name = c.Host
+		if a.Name == "" {
+			a.Name = c.Host
 		}
 	}
 


### PR DESCRIPTION
A new `asset-name` flag that allows for overwriting the root asset name. Essentially equal to passing an inventory file with the name of the asset being set.