### PR TITLE
🌈 add index to auto-expanded list items

### DIFF
--- a/cli/printer/mql.go
+++ b/cli/printer/mql.go
@@ -453,6 +453,8 @@ func (print *Printer) autoExpand(blockRef uint64, data interface{}, bundle *llx.
 		for i := range arr {
 			c := print.autoExpand(blockRef, arr[i], bundle, prefix)
 			res.WriteString(prefix)
+			res.WriteString(strconv.Itoa(i))
+			res.WriteString(": ")
 			res.WriteString(c)
 			res.WriteByte('\n')
 		}

--- a/cli/printer/printer_test.go
+++ b/cli/printer/printer_test.go
@@ -215,11 +215,11 @@ func TestPrinter(t *testing.T) {
 			"", // ignore
 			[]string{
 				"users.list: [\n" +
-					"  user name=\"root\" uid=0 gid=0\n" +
-					"  user name=\"chris\" uid=1000 gid=1001\n" +
-					"  user name=\"christopher\" uid=1000 gid=1001\n" +
-					"  user name=\"chris\" uid=1002 gid=1003\n" +
-					"  user name=\"bin\" uid=1 gid=1\n" +
+					"  0: user name=\"root\" uid=0 gid=0\n" +
+					"  1: user name=\"chris\" uid=1000 gid=1001\n" +
+					"  2: user name=\"christopher\" uid=1000 gid=1001\n" +
+					"  3: user name=\"chris\" uid=1002 gid=1003\n" +
+					"  4: user name=\"bin\" uid=1 gid=1\n" +
 					"]",
 			},
 		},


### PR DESCRIPTION
It's much easier to address individual entries if you have the index as a prefix:

![image](https://user-images.githubusercontent.com/1307529/205182325-58e73787-e06d-460f-8b65-f14bde313ded.png)


Signed-off-by: Dominik Richter <dominik.richter@gmail.com>