### PR TITLE
🐛 empty arrays are falsy

### DIFF
--- a/llx/rawdata.go
+++ b/llx/rawdata.go
@@ -229,8 +229,20 @@ func isTruthy(data interface{}, typ types.Type) (bool, bool) {
 
 	case types.ArrayLike:
 		arr := data.([]interface{})
-		res := true
 
+		// Empty arrays count as false here, this is because users
+		// frequently write statements like:
+		//     list.where(a == 1) && list.where(b == 2)
+		// which technically should be:
+		//     list.contains(a == 1) && list.contains(b == 2)
+		// However, it's so frequent with our users and we can't see
+		// a reasonable upside to keeping empty array as truthy, since
+		// null checks are far less likely.
+		if len(arr) == 0 {
+			return false, true
+		}
+
+		res := true
 		for i := range arr {
 			t1, f1 := isTruthy(arr[i], typ.Child())
 			if f1 {

--- a/llx/rawdata_test.go
+++ b/llx/rawdata_test.go
@@ -57,7 +57,7 @@ func TestTruthy(t *testing.T) {
 		{RegexData("r"), true},
 		{TimeData(time.Time{}), false},
 		{TimeData(now), true},
-		{ArrayData([]interface{}{}, types.Any), true},
+		{ArrayData([]interface{}{}, types.Any), false},
 		{ArrayData([]interface{}{false}, types.Bool), false},
 		{ArrayData([]interface{}{true}, types.Bool), true},
 		{MapData(map[string]interface{}{}, types.Any), true},


### PR DESCRIPTION
This is had been burried for a bit: Empty arrays should count as falsy. They are often used in statements where people use the `where` clause instead of `contains` and have a hard time figuring out why the query is not behaving right. This is because "where" semantically in a boolean statement often tends to be thought of as "where xyz contains". Users should still use `contains` in these cases, but this change makes it easier to work around it for a moment. Also linting... tba

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>