### PR TITLE
🐛 aws: use default region if none is specified

### DIFF
--- a/motor/providers/aws/provider.go
+++ b/motor/providers/aws/provider.go
@@ -78,6 +78,10 @@ func New(pCfg *providers.Config, opts ...ProviderOption) (*Provider, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not load aws configuration")
 	}
+	if cfg.Region == "" {
+		log.Warn().Msg("no AWS region found, using us-east-1")
+		cfg.Region = "us-east-1" // in case the user has no region set, default to us-east-1
+	}
 
 	t.config = cfg
 


### PR DESCRIPTION
fixes https://github.com/mondoohq/cnquery/issues/539#issuecomment-1335645776