### PR TITLE
🐛 prevent crash on dict[string].contains

### DIFF
--- a/llx/builtin.go
+++ b/llx/builtin.go
@@ -312,6 +312,23 @@ func init() {
 			string("split"):     {f: stringSplitV2, Label: "split"},
 			string("trim"):      {f: stringTrimV2, Label: "trim"},
 		},
+		types.StringSlice: {
+			// TODO: implement the remaining calls for this type
+			// string("==" + types.Nil):                 {f: chunkEqFalseV2, Label: "=="},
+			// string("!=" + types.Nil):                 {f: chunkNeqFalseV2, Label: "!="},
+			string("==" + types.String): {f: stringsliceEqString, Label: "=="},
+			// string("!=" + types.String):              {f: stringNotStringV2, Label: "!="},
+			// string("==" + types.Regex):               {f: stringCmpRegexV2, Label: "=="},
+			// string("!=" + types.Regex):               {f: stringNotRegexV2, Label: "!="},
+			// string("==" + types.Bool):                {f: stringCmpBoolV2, Label: "=="},
+			// string("!=" + types.Bool):                {f: stringNotBoolV2, Label: "!="},
+			// string("==" + types.Int):                 {f: stringCmpIntV2, Label: "=="},
+			// string("!=" + types.Int):                 {f: stringNotIntV2, Label: "!="},
+			// string("==" + types.Float):               {f: stringCmpFloatV2, Label: "=="},
+			// string("!=" + types.Float):               {f: stringNotFloatV2, Label: "!="},
+			// string("==" + types.Dict):                {f: stringCmpDictV2, Label: "=="},
+			// string("!=" + types.Dict):                {f: stringNotDictV2, Label: "!="},
+		},
 		types.Regex: {
 			// == / !=
 			string("==" + types.Nil):                 {f: stringCmpNilV2, Label: "=="},

--- a/llx/builtin_simple.go
+++ b/llx/builtin_simple.go
@@ -2313,3 +2313,17 @@ func timeUnixV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*Raw
 	raw := t.Unix()
 	return IntData(int64(raw)), 0, nil
 }
+
+// stringslice methods
+
+func stringsliceEqString(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
+	return dataOpV2(e, bind, chunk, ref, types.Int, func(left interface{}, right interface{}) *RawData {
+		l := left.(string)
+		r := right.(string)
+		idx := strings.Index(l, r)
+		if idx == -1 {
+			return StringData("")
+		}
+		return StringData(r)
+	})
+}

--- a/mqlc/builtin.go
+++ b/mqlc/builtin.go
@@ -50,10 +50,10 @@ func init() {
 			"unix":    {typ: intType, signature: FunctionSignature{}},
 		},
 		types.Dict: {
-			"[]": {typ: dictType, signature: FunctionSignature{Required: 1, Args: []types.Type{types.Any}}},
-			"{}": {typ: blockType, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
+			"[]":       {typ: dictType, signature: FunctionSignature{Required: 1, Args: []types.Type{types.Any}}},
+			"{}":       {typ: blockType, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
+			"contains": {compile: compileArrayContains, typ: boolType, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
 			// string-ish
-			"contains":  {compile: compileStringContains, typ: boolType, signature: FunctionSignature{Required: 1, Args: []types.Type{types.String}}},
 			"find":      {typ: stringArrayType, signature: FunctionSignature{Required: 1, Args: []types.Type{types.Regex}}},
 			"length":    {typ: intType, signature: FunctionSignature{}},
 			"camelcase": {typ: stringType, signature: FunctionSignature{}},

--- a/resources/packs/core/core_test.go
+++ b/resources/packs/core/core_test.go
@@ -1076,6 +1076,30 @@ func TestResource_duplicateFields(t *testing.T) {
 	})
 }
 
+func TestDict_Methods_Contains(t *testing.T) {
+	p := "parse.json('/dummy.json')."
+
+	x := testutils.InitTester(testutils.LinuxMock(), core.Registry)
+	x.TestSimple(t, []testutils.SimpleTest{
+		{
+			p + "params['hello'].contains('ll')",
+			1, true,
+		},
+		{
+			p + "params['hello'].contains('lloo')",
+			1, false,
+		},
+		{
+			p + "params['string-array'].contains('a')",
+			1, true,
+		},
+		{
+			p + "params['string-array'].contains(_ == 'a')",
+			1, true,
+		},
+	})
+}
+
 func TestDict_Methods_Map(t *testing.T) {
 	p := "parse.json('/dummy.json')."
 
@@ -1132,10 +1156,6 @@ func TestDict_Methods_Map(t *testing.T) {
 		{
 			p + "params['hello'].trim('ho')",
 			0, "ell",
-		},
-		{
-			p + "params['hello'].contains('llo')",
-			0, true,
 		},
 		{
 			p + "params['dict'].length",


### PR DESCRIPTION
Originally contains was only created for simple strings. However, we have since started to support the keyword for arrays and maps. The problem is: dicts can be either and the behavior betweenboth is very different.

This PR adds the first level of support for contains on dicts, that works on both arrays and strings. The printing is still shot, but this is the first step to add proper support.

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>