### PR TITLE
🐛 Set asset name in ebs scanning if it is provided.

### DIFF
--- a/motor/discovery/aws/ebs/resolver.go
+++ b/motor/discovery/aws/ebs/resolver.go
@@ -28,6 +28,10 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *provide
 		PlatformIds: []string{pCfg.PlatformId},
 		Labels:      map[string]string{aws.EBSScanLabel: "true", aws.RegionLabel: pCfg.Options["region"], "mondoo.com/item-type": pCfg.Options["type"]},
 	}
+	// If there's a root-provided name, use that to overwrite
+	if root.Name != "" {
+		assetInfo.Name = root.Name
+	}
 
 	return []*asset.Asset{assetInfo}, nil
 }

--- a/motor/providers/awsec2ebs/types.go
+++ b/motor/providers/awsec2ebs/types.go
@@ -13,6 +13,7 @@ import (
 type InstanceId struct {
 	Id             string
 	Region         string
+	Name           string
 	Account        string
 	Zone           string
 	MarketplaceImg bool


### PR DESCRIPTION
If `asset-name` flag is set, use it in the EBS provider.