### PR TITLE
Improve the invalid GitHub message

### DIFF
--- a/motor/providers/github/provider.go
+++ b/motor/providers/github/provider.go
@@ -61,7 +61,7 @@ func New(tc *providers.Config) (*Provider, error) {
 	_, resp, err := client.Zen(context.Background())
 	if err != nil {
 		if resp.StatusCode == 401 {
-			return nil, errors.New("invalid github token provided")
+			return nil, errors.New("invalid GitHub token provided. check the value passed with the --token flag or the GITHUB_TOKEN environment variable")
 		}
 		return nil, err
 	}


### PR DESCRIPTION
If we're reading in the env var the user won't necessarily know that's where the value came from. Help them to understand where we're pulling this from.

Signed-off-by: Tim Smith <tsmith84@gmail.com>