### PR TITLE
🧹 use self-hosted runner for code generation test

### DIFF
--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
   # Check if there is any dirty change for generated files
   generated-files:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Install Go
         uses: actions/setup-go@v3
@@ -23,12 +23,15 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: "Install required tooling"
+        run: |
+          sudo apt install -y gcc
       - name: Check generated files
         # Note we do not use apt install -y protobuf-compiler` since it is too old
         run: |
           PB_REL="https://github.com/protocolbuffers/protobuf/releases"
           curl -LO $PB_REL/download/v${PROTO_VERSION}/protoc-${PROTO_VERSION}-linux-x86_64.zip
-          unzip protoc-${PROTO_VERSION}-linux-x86_64.zip -d $HOME/.local
+          unzip -o protoc-${PROTO_VERSION}-linux-x86_64.zip -d $HOME/.local
           rm protoc-${PROTO_VERSION}-linux-x86_64.zip
           export PATH="$PATH:$HOME/.local/bin"
           protoc --version


### PR DESCRIPTION
after #559 

This change reduced the code-generation time from more than 30 min to 3 min