### PR TITLE
✨ Recursively search directory for k8s manifests

### DIFF
--- a/cli/reporter/print_compact.go
+++ b/cli/reporter/print_compact.go
@@ -69,6 +69,7 @@ func (r *defaultReporter) printAssetSummary(assetMrn string, asset *explorer.Ass
 				target,
 			)))
 		}
+		r.out.Write([]byte("\n"))
 		return
 	}
 

--- a/motor/providers/k8s/manifest_provider.go
+++ b/motor/providers/k8s/manifest_provider.go
@@ -4,9 +4,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
+	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -20,6 +19,8 @@ import (
 	"go.mondoo.com/cnquery/motor/providers/os/fsutil"
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 	"k8s.io/apimachinery/pkg/version"
 )
 
@@ -197,29 +198,50 @@ func loadManifestFile(manifestFile string) ([]byte, error) {
 		}
 
 		if fi.IsDir() {
-			// NOTE: we are not using filepath.WalkDir since we do not net recursive walking
-			files, err := ioutil.ReadDir(manifestFile)
-			if err != nil {
-				return nil, err
-			}
-			for i := range files {
-				f := files[i]
-				if f.IsDir() {
-					continue
+			filepath.WalkDir(manifestFile, func(path string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return err
 				}
-				filename := path.Join(manifestFile, f.Name())
 
 				// only load yaml files for now
-				ext := filepath.Ext(filename)
-				if ext == ".yaml" || ext == ".yml" {
-					log.Debug().Str("file", filename).Msg("add file to manifest loading")
-					filenames = append(filenames, filename)
-				} else {
-					log.Debug().Str("file", filename).Msg("ignore file")
+				if !d.IsDir() {
+					ext := filepath.Ext(path)
+					if ext != ".yaml" && ext != ".yml" {
+						log.Debug().Str("file", path).Msg("ignore file, no .yaml or .yml ending")
+						return nil
+					}
+					// check whether this is valid k8s yaml
+					f, err := os.Open(path)
+					if err != nil {
+						log.Debug().Str("file", path).Err(err).Msg("ignore file, could not open file")
+						return nil
+					}
+					defer f.Close()
+
+					content, err := io.ReadAll(f)
+					if err != nil {
+						log.Debug().Str("file", path).Err(err).Msg("ignore file, could not read file")
+						return nil
+					}
+					// At this point, we do not care about specific schemes, just whether the file is a valid k8s yaml
+					_, _, err = yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme).Decode(content, nil, nil)
+					if err != nil {
+						// the err contains the file content, which is not useful in the output
+						errorString := ""
+						if len(err.Error()) > 40 {
+							errorString = err.Error()[:40] + "..."
+						} else {
+							errorString = err.Error()
+						}
+						log.Debug().Str("file", path).Str("error", errorString).Msg("ignore file, no valid kubernetes yaml")
+						return nil
+					}
+					log.Debug().Str("file", path).Msg("add file to manifest loading")
+					filenames = append(filenames, path)
 				}
 
-			}
-
+				return nil
+			})
 		} else {
 			filenames = append(filenames, manifestFile)
 		}
@@ -230,5 +252,5 @@ func loadManifestFile(manifestFile string) ([]byte, error) {
 		}
 	}
 
-	return ioutil.ReadAll(input)
+	return io.ReadAll(input)
 }

--- a/motor/providers/k8s/manifest_provider.go
+++ b/motor/providers/k8s/manifest_provider.go
@@ -198,6 +198,7 @@ func loadManifestFile(manifestFile string) ([]byte, error) {
 		}
 
 		if fi.IsDir() {
+			yamlDecoder := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
 			filepath.WalkDir(manifestFile, func(path string, d fs.DirEntry, err error) error {
 				if err != nil {
 					return err
@@ -211,20 +212,13 @@ func loadManifestFile(manifestFile string) ([]byte, error) {
 						return nil
 					}
 					// check whether this is valid k8s yaml
-					f, err := os.Open(path)
-					if err != nil {
-						log.Debug().Str("file", path).Err(err).Msg("ignore file, could not open file")
-						return nil
-					}
-					defer f.Close()
-
-					content, err := io.ReadAll(f)
+					content, err := os.ReadFile(path)
 					if err != nil {
 						log.Debug().Str("file", path).Err(err).Msg("ignore file, could not read file")
 						return nil
 					}
 					// At this point, we do not care about specific schemes, just whether the file is a valid k8s yaml
-					_, _, err = yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme).Decode(content, nil, nil)
+					_, _, err = yamlDecoder.Decode(content, nil, nil)
 					if err != nil {
 						// the err contains the file content, which is not useful in the output
 						errorString := ""

--- a/motor/providers/k8s/manifest_provider_test.go
+++ b/motor/providers/k8s/manifest_provider_test.go
@@ -60,3 +60,23 @@ func TestManifestFileProvider(t *testing.T) {
 		assert.Contains(t, transport.PlatformInfo().Family, "k8s")
 	})
 }
+
+func TestLoadManifestDirRecursively(t *testing.T) {
+	manifests, err := loadManifestFile("./resources/testdata/")
+	require.NoError(t, err)
+
+	manifestsAsString := string(manifests[:])
+	// This is content from files of the root dir
+	assert.Contains(t, manifestsAsString, "mondoo")
+	assert.Contains(t, manifestsAsString, "RollingUpdate")
+
+	// Files containing this should be skipped
+	assert.NotContains(t, manifestsAsString, "AdmissionReview")
+	assert.NotContains(t, manifestsAsString, "README")
+	assert.NotContains(t, manifestsAsString, "operators.coreos.com")
+
+	// This is from files in subdirs whicch should be included
+	assert.Contains(t, manifestsAsString, "hello-1")
+	assert.Contains(t, manifestsAsString, "hello-2")
+	assert.Contains(t, manifestsAsString, "MondooAuditConfig")
+}

--- a/motor/providers/k8s/resources/testdata/subdir/README.md
+++ b/motor/providers/k8s/resources/testdata/subdir/README.md
@@ -1,0 +1,2 @@
+These files are here, to test the recursive loading of manifests.
+They are part of the negative test, the files that should be skipped.

--- a/motor/providers/k8s/resources/testdata/subdir/kustomization.yaml
+++ b/motor/providers/k8s/resources/testdata/subdir/kustomization.yaml
@@ -1,0 +1,35 @@
+# These resources constitute the fully configured set of manifests
+# used to generate the 'manifests/' directory in a bundle.
+resources:
+- bases/mondoo-operator.clusterserviceversion.yaml
+- ../default
+- ../samples
+- ../scorecard
+
+# [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
+# Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.
+# These patches remove the unnecessary "cert" volume and its manager container volumeMount.
+#patchesJson6902:
+#- target:
+#    group: apps
+#    version: v1
+#    kind: Deployment
+#    name: controller-manager
+#    namespace: system
+#  patch: |-
+#    # Remove the manager container's "cert" volumeMount, since OLM will create and mount a set of certs.
+#    # Update the indices in this path if adding or removing containers/volumeMounts in the manager's Deployment.
+#    - op: remove
+#      path: /spec/template/spec/containers/0/volumeMounts/0
+#    # Remove the "cert" volume, since OLM will create and mount a set of certs.
+#    # Update the indices in this path if adding or removing volumes in the manager's Deployment.
+#    - op: remove
+#      path: /spec/template/spec/volumes/0
+
+patches:
+  - target:
+      group: operators.coreos.com
+      version: v1alpha1
+      kind: ClusterServiceVersion
+      name: mondoo-operator\.v.*
+    path: patches/description.yaml

--- a/motor/providers/k8s/resources/testdata/subdir2/2cronjobs.yaml
+++ b/motor/providers/k8s/resources/testdata/subdir2/2cronjobs.yaml
@@ -1,0 +1,45 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: hello-1
+  namespace: default
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hello
+            image: busybox:1.28
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+            securityContext:
+              allowPrivilegeEscalation: true
+          restartPolicy: OnFailure
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: hello-2
+  namespace: default
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hello
+            image: busybox:1.28
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+            securityContext:
+              allowPrivilegeEscalation: true
+          restartPolicy: OnFailure

--- a/motor/providers/k8s/resources/testdata/subdir2/README.md
+++ b/motor/providers/k8s/resources/testdata/subdir2/README.md
@@ -1,0 +1,2 @@
+These files are here, to test the recursive loading of manifests.
+The README should be skipped and the yaml should be included.

--- a/motor/providers/k8s/resources/testdata/subdir2/mondooauditconfig.yaml
+++ b/motor/providers/k8s/resources/testdata/subdir2/mondooauditconfig.yaml
@@ -1,0 +1,19 @@
+apiVersion: k8s.mondoo.com/v1alpha2
+kind: MondooAuditConfig
+metadata:
+  name: mondoo-client
+  namespace: mondoo-operator
+spec:
+  mondooCredsSecretRef:
+    name: mondoo-client
+  kubernetesResources:
+    enable: true
+  nodes:
+    enable: true
+  admission:
+    enable: true
+    mode: permissive
+    certificateProvisioning:
+      # Could be "cert-manager", "openshift" or "manual"
+      mode: cert-manager
+  


### PR DESCRIPTION
When a directory is provided as an argument, we will recursively read it and add the k8s manifest files. Currently, only yaml and yml files will be read. Non-manifest yaml files will be skipped.

Signed-off-by: Christian Zunker <christian@mondoo.com>