### PR TITLE
⭐️ expose macOS updates as `os.updates`

### DIFF
--- a/resources/packs/os/updates/mac_updates.go
+++ b/resources/packs/os/updates/mac_updates.go
@@ -1,0 +1,82 @@
+package updates
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"howett.net/plist"
+
+	"go.mondoo.com/cnquery/motor/providers/os"
+)
+
+const (
+	MacosUpdateFormat = "macos"
+)
+
+type MacosUpdateManager struct {
+	provider os.OperatingSystemProvider
+}
+
+func (um *MacosUpdateManager) Name() string {
+	return "macOS Update Manager"
+}
+
+func (um *MacosUpdateManager) Format() string {
+	return MacosUpdateFormat
+}
+
+func (um *MacosUpdateManager) List() ([]OperatingSystemUpdate, error) {
+	f, err := um.provider.FS().Open("/Library/Preferences/com.apple.SoftwareUpdate.plist")
+	defer f.Close()
+	if err != nil {
+		return nil, fmt.Errorf("could not read package list")
+	}
+	return ParseSoftwarePlistUpdates(f)
+}
+
+// parse macos system version property list
+func ParseSoftwarePlistUpdates(input io.Reader) ([]OperatingSystemUpdate, error) {
+	var r io.ReadSeeker
+	r, ok := input.(io.ReadSeeker)
+
+	// if the read seaker is not implemented lets cache stdout in-memory
+	if !ok {
+		packageList, err := io.ReadAll(input)
+		if err != nil {
+			return nil, err
+		}
+		r = strings.NewReader(string(packageList))
+	}
+
+	type recommendedUpdate struct {
+		Identifier           string `plist:"Identifier"`
+		DisplayName          string `plist:"Display Name"`
+		Version              string `plist:"Display Version"`
+		MobileSoftwareUpdate bool   `plist:"MobileSoftwareUpdate"`
+		ProductKey           string `plist:"Product Key"`
+	}
+
+	type softwareUpdate struct {
+		RecommendedUpdates []recommendedUpdate `plist:"RecommendedUpdates"`
+	}
+
+	var data softwareUpdate
+	decoder := plist.NewDecoder(r)
+	err := decoder.Decode(&data)
+	if err != nil {
+		return nil, err
+	}
+
+	updates := make([]OperatingSystemUpdate, len(data.RecommendedUpdates))
+	for i, entry := range data.RecommendedUpdates {
+		updates[i].ID = entry.ProductKey
+		updates[i].Name = entry.Identifier
+		updates[i].Description = entry.DisplayName
+		updates[i].Version = entry.Version
+
+		updates[i].Format = MacosUpdateFormat
+	}
+
+	return updates, nil
+}

--- a/resources/packs/os/updates/mac_updates_test.go
+++ b/resources/packs/os/updates/mac_updates_test.go
@@ -1,0 +1,26 @@
+package updates
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMacUpdatesParser(t *testing.T) {
+	f, err := os.Open("./testdata/com.apple.SoftwareUpdate.plist")
+	defer f.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := ParseSoftwarePlistUpdates(f)
+	assert.Nil(t, err)
+	assert.Equal(t, 4, len(m), "detected the right amount of updates")
+
+	pkg, err := findKb(m, "MSU_UPDATE_21G217_patch_12.6.1")
+	require.NoError(t, err)
+	assert.Equal(t, "MSU_UPDATE_21G217_patch_12.6.1", pkg.Name, "update detected")
+	assert.Equal(t, "macOS Monterey 12.6.1", pkg.Description, "update title detected")
+}

--- a/resources/packs/os/updates/testdata/com.apple.SoftwareUpdate.plist
+++ b/resources/packs/os/updates/testdata/com.apple.SoftwareUpdate.plist
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DoItLaterTonightAttemptsCount</key>
+	<dict>
+		<key>002-83793</key>
+		<integer>1</integer>
+		<key>012-70652</key>
+		<integer>1</integer>
+		<key>071-82714</key>
+		<integer>1</integer>
+		<key>21E258</key>
+		<integer>1</integer>
+		<key>21G72</key>
+		<integer>1</integer>
+	</dict>
+	<key>LastAttemptBuildVersion</key>
+	<string>12.6 (21G115)</string>
+	<key>LastAttemptSystemVersion</key>
+	<string>12.6 (21G115)</string>
+	<key>LastBackgroundSuccessfulDate</key>
+	<date>2022-12-09T14:28:24Z</date>
+	<key>LastFullSuccessfulDate</key>
+	<date>2022-12-09T14:28:24Z</date>
+	<key>LastRecommendedMajorOSBundleIdentifier</key>
+	<string></string>
+	<key>LastRecommendedUpdatesAvailable</key>
+	<integer>4</integer>
+	<key>LastResultCode</key>
+	<integer>0</integer>
+	<key>LastSessionSuccessful</key>
+	<true/>
+	<key>LastSuccessfulDate</key>
+	<date>2022-12-09T14:28:52Z</date>
+	<key>LastUpdatesAvailable</key>
+	<integer>4</integer>
+	<key>PrimaryLanguages</key>
+	<array>
+		<string>en-DE</string>
+		<string>en-GB</string>
+	</array>
+	<key>RecommendedUpdates</key>
+	<array>
+		<dict>
+			<key>Display Name</key>
+			<string>macOS Monterey 12.6.1</string>
+			<key>Display Version</key>
+			<string>12.6.1</string>
+			<key>Identifier</key>
+			<string>MSU_UPDATE_21G217_patch_12.6.1</string>
+			<key>MobileSoftwareUpdate</key>
+			<true/>
+			<key>Product Key</key>
+			<string>MSU_UPDATE_21G217_patch_12.6.1</string>
+		</dict>
+		<dict>
+			<key>Display Name</key>
+			<string>Command Line Tools beta 3 for Xcode</string>
+			<key>Display Version</key>
+			<string>14.1</string>
+			<key>Identifier</key>
+			<string>Command Line Tools beta 3 for Xcode</string>
+			<key>Product Key</key>
+			<string>012-70652</string>
+		</dict>
+		<dict>
+			<key>Display Name</key>
+			<string>Command Line Tools for Xcode</string>
+			<key>Display Version</key>
+			<string>14.1</string>
+			<key>Identifier</key>
+			<string>Command Line Tools for Xcode</string>
+			<key>Product Key</key>
+			<string>012-91817</string>
+		</dict>
+		<dict>
+			<key>Display Name</key>
+			<string>Safari</string>
+			<key>Display Version</key>
+			<string>16.1</string>
+			<key>Identifier</key>
+			<string>Safari16.1MontereyAuto</string>
+			<key>Product Key</key>
+			<string>012-89022</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/resources/packs/os/updates/updates.go
+++ b/resources/packs/os/updates/updates.go
@@ -43,6 +43,8 @@ func ResolveSystemUpdateManager(motor *motor.Motor) (OperatingSystemUpdateManage
 		um = &SuseUpdateManager{provider: osProvider}
 	case "windows":
 		um = &WindowsUpdateManager{provider: osProvider}
+	case "macos":
+		um = &MacosUpdateManager{provider: osProvider}
 	default:
 		return nil, errors.New("your platform is not supported by os updates resource")
 	}


### PR DESCRIPTION
addresses #588
after #586 

brings the handling for os updates to macOS

```
cnquery> os.updates
os.updates: [
  0: os.update name="MSU_UPDATE_21G217_patch_12.6.1"
  1: os.update name="Command Line Tools beta 3 for Xcode"
  2: os.update name="Command Line Tools for Xcode"
  3: os.update name="Safari16.1MontereyAuto"
]
```