### PR TITLE
Update no config file error message

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -226,6 +226,6 @@ func DisplayUsedConfig() {
 	} else if Source == configSourceBase64 {
 		log.Info().Msg("loaded configuration from environment using source " + Source)
 	} else {
-		log.Info().Msg("no configuration file provided")
+		log.Info().Msg("no Mondoo configuration file provided. using defaults")
 	}
 }


### PR DESCRIPTION
This is a super confusing error message that makes it unclear what config file is not being found. Is it K8s? Is it AWS? Is it Mondoo? Who knows.

Current message:

![image](https://user-images.githubusercontent.com/1015200/206802229-ebda5f1a-7450-4f8d-9f60-a2882bdcb056.png)


Signed-off-by: Tim Smith <tsmith84@gmail.com>