### PR TITLE
🐛 properly wait until progress bar is closed

### DIFF
--- a/cli/progress/progress.go
+++ b/cli/progress/progress.go
@@ -94,7 +94,10 @@ func (p *progressbar) Open() error {
 				time.Sleep(time.Second / progressPipedFps)
 				o.ClearLines(2)
 				o.WriteString(p.View())
-				if p.Data.complete {
+				p.lock.Lock()
+				complete := p.Data.complete
+				p.lock.Unlock()
+				if complete {
 					break
 				}
 			}
@@ -149,7 +152,10 @@ func (p *progressbar) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return p, nil
 
 	case tickMsg:
-		if p.Data.complete {
+		p.lock.Lock()
+		complete := p.Data.complete
+		p.lock.Unlock()
+		if complete {
 			return p, tea.Quit
 		}
 		return p, tickCmd()

--- a/cli/progress/progress.go
+++ b/cli/progress/progress.go
@@ -9,6 +9,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/mattn/go-isatty"
+	"github.com/muesli/termenv"
 	"github.com/pkg/errors"
 	"go.mondoo.com/cnquery/logger"
 )
@@ -33,6 +34,7 @@ type progressbar struct {
 	lock         sync.Mutex
 	bar          *renderer
 	isTTY        bool
+	wg           sync.WaitGroup
 }
 
 type progressData struct {
@@ -62,7 +64,7 @@ func NewMultiBar(id string, data progressData) *progressbar {
 		id:           id,
 		maxNameWidth: maxNameWidth,
 		Data:         data,
-		isTTY:        isatty.IsTerminal(os.Stdout.Fd()) && false, // FIXME: re-enable the detection
+		isTTY:        isatty.IsTerminal(os.Stdout.Fd()),
 	}
 }
 
@@ -73,26 +75,29 @@ func (p *progressbar) Open() error {
 		return errors.Wrap(err, "failed to initialize progressbar renderer")
 	}
 
+	p.wg.Add(1)
 	if p.isTTY {
 		go func() {
+			defer p.wg.Done()
 			(logger.LogOutputWriter.(*logger.BufferedWriter)).Pause()
 			defer (logger.LogOutputWriter.(*logger.BufferedWriter)).Resume()
-
 			if _, err := tea.NewProgram(p).Run(); err != nil {
+				fmt.Println(err.Error())
 				panic(err)
 			}
 		}()
 	} else {
 		go func() {
+			defer p.wg.Done()
+			o := termenv.NewOutput(os.Stdout)
 			for {
 				time.Sleep(time.Second / progressPipedFps)
+				o.ClearLines(2)
+				o.WriteString(p.View())
 				if p.Data.complete {
 					break
 				}
-				fmt.Print(p.View() + "\r\033[2A")
 			}
-
-			fmt.Print(p.View())
 		}()
 	}
 
@@ -106,7 +111,10 @@ func (p *progressbar) OnProgress(current int, total int) {
 }
 
 func (p *progressbar) Close() {
+	p.lock.Lock()
 	p.Data.complete = true
+	p.lock.Unlock()
+	p.wg.Wait()
 }
 
 const (
@@ -124,10 +132,6 @@ func (p *progressbar) Init() tea.Cmd {
 
 // Update is a required interface method for the underlying renderer
 func (p *progressbar) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	if p.Data.complete {
-		return p, tea.Quit
-	}
-
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
@@ -145,6 +149,9 @@ func (p *progressbar) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return p, nil
 
 	case tickMsg:
+		if p.Data.complete {
+			return p, tea.Quit
+		}
 		return p, tickCmd()
 
 	default:
@@ -155,15 +162,12 @@ func (p *progressbar) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // View is a required interface method for the underlying renderer
 func (p *progressbar) View() string {
 	pad := strings.Repeat(" ", p.padding)
-
 	out := ""
-	p.lock.Lock()
 	for i := range p.Data.Names {
 		name := p.Data.Names[i]
 		value := p.Data.Completion[i]
 		out += "\n" + pad + p.bar.View(value) + " " + name
 	}
-	p.lock.Unlock()
 
 	out += "\n"
 	return out


### PR DESCRIPTION
The terminal cursor was not properly recovered because we have not waited until the go routine is properly completed