### PR TITLE
Implement msgraph.settings.

### DIFF
--- a/motor/providers/microsoft/msgraph/msgraphclient/client.go
+++ b/motor/providers/microsoft/msgraph/msgraphclient/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/devicemanagement"
 	"github.com/microsoftgraph/msgraph-sdk-go/domains"
 	"github.com/microsoftgraph/msgraph-sdk-go/groups"
+	"github.com/microsoftgraph/msgraph-sdk-go/groupsettings"
 	"github.com/microsoftgraph/msgraph-sdk-go/organization"
 	"github.com/microsoftgraph/msgraph-sdk-go/policies"
 	"github.com/microsoftgraph/msgraph-sdk-go/rolemanagement"
@@ -114,4 +115,8 @@ func (m *GraphServiceClient) RoleManagement() *rolemanagement.RoleManagementRequ
 
 func (m *GraphServiceClient) DeviceManagement() *devicemanagement.DeviceManagementRequestBuilder {
 	return devicemanagement.NewDeviceManagementRequestBuilderInternal(m.pathParameters, m.requestAdapter)
+}
+
+func (m *GraphServiceClient) GroupSettings() *groupsettings.GroupSettingsRequestBuilder {
+	return groupsettings.NewGroupSettingsRequestBuilderInternal(m.pathParameters, m.requestAdapter)
 }

--- a/motor/providers/microsoft/msgraph/msgraphconv/structs.go
+++ b/motor/providers/microsoft/msgraph/msgraphconv/structs.go
@@ -83,6 +83,42 @@ func NewUnifiedRolePermission(p models.UnifiedRolePermissionable) UnifiedRolePer
 	}
 }
 
+type GroupSetting struct {
+	DisplayName string         `json:"displayName"`
+	TemplateId  string         `json:"templateId"`
+	Values      []SettingValue `json:"values"`
+}
+
+type SettingValue struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+func NewSettings(p []models.GroupSettingable) []GroupSetting {
+	res := []GroupSetting{}
+	for i := range p {
+		res = append(res, NewSetting(p[i]))
+	}
+	return res
+}
+
+func NewSetting(p models.GroupSettingable) GroupSetting {
+	values := []SettingValue{}
+	entries := p.GetValues()
+	for i := range entries {
+		values = append(values, SettingValue{
+			Name:  core.ToString(entries[i].GetName()),
+			Value: core.ToString(entries[i].GetValue()),
+		})
+	}
+
+	return GroupSetting{
+		DisplayName: core.ToString(p.GetDisplayName()),
+		TemplateId:  core.ToString(p.GetTemplateId()),
+		Values:      values,
+	}
+}
+
 // structs for AuthorizationPolicy
 
 type Entity struct {

--- a/resources/packs/ms365/msgraph.go
+++ b/resources/packs/ms365/msgraph.go
@@ -11,6 +11,7 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/devicemanagement"
 	"github.com/microsoftgraph/msgraph-sdk-go/domains"
 	"github.com/microsoftgraph/msgraph-sdk-go/groups"
+	"github.com/microsoftgraph/msgraph-sdk-go/groupsettings"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/organization"
 	"github.com/microsoftgraph/msgraph-sdk-go/policies"
@@ -34,7 +35,22 @@ func (m *mqlMsgraphOrganization) id() (string, error) {
 }
 
 func (m *mqlMsgraph) GetSettings() ([]interface{}, error) {
-	return nil, errors.New("msgraph.beta.settings not supported")
+	provider, err := microsoftProvider(m.MotorRuntime.Motor.Provider)
+	if err != nil {
+		return nil, err
+	}
+
+	graphClient, err := graphClient(provider)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	settings, err := graphClient.GroupSettings().Get(ctx, &groupsettings.GroupSettingsRequestBuilderGetRequestConfiguration{})
+	if err != nil {
+		return nil, msgraphclient.TransformODataError(err)
+	}
+	return core.JsonToDictSlice(msgraphconv.NewSettings(settings.GetValue()))
 }
 
 func (m *mqlMsgraph) GetOrganizations() ([]interface{}, error) {


### PR DESCRIPTION
It's now under `/groupSettings`, rather than just `/settings` for the production API.