### PR TITLE
Add properties for device configurations, domain dns records, compliance policies

### DIFF
--- a/resources/packs/ms365/msgraph.go
+++ b/resources/packs/ms365/msgraph.go
@@ -818,7 +818,7 @@ func (m *mqlMsgraphDevicemanagement) GetDeviceConfigurations() ([]interface{}, e
 	configurations := resp.GetValue()
 	for i := range configurations {
 		configuration := configurations[i]
-		properties, _ := core.JsonToDict(configuration.GetAdditionalData())
+		properties := getConfigurationProperties(configuration)
 		mqlResource, err := m.MotorRuntime.CreateResource("msgraph.devicemanagement.deviceconfiguration",
 			"id", core.ToString(configuration.GetId()),
 			"lastModifiedDateTime", configuration.GetLastModifiedDateTime(),
@@ -835,6 +835,138 @@ func (m *mqlMsgraphDevicemanagement) GetDeviceConfigurations() ([]interface{}, e
 	}
 
 	return res, nil
+}
+
+// TODO: androidDeviceOwnerGeneralDeviceConfiguration missing
+func getConfigurationProperties(config models.DeviceConfigurationable) map[string]interface{} {
+	props := map[string]interface{}{}
+	if config.GetOdataType() != nil {
+		props["@odata.type"] = *config.GetOdataType()
+	}
+
+	agdc, ok := config.(*models.AndroidGeneralDeviceConfiguration)
+	if ok {
+		if agdc.GetPasswordRequired() != nil {
+			props["passwordRequired"] = *agdc.GetPasswordRequired()
+		}
+		if agdc.GetPasswordSignInFailureCountBeforeFactoryReset() != nil {
+			props["passwordSignInFailureCountBeforeFactoryReset"] = *agdc.GetPasswordSignInFailureCountBeforeFactoryReset()
+		}
+		if agdc.GetPasswordMinimumLength() != nil {
+			props["passwordMinimumLength"] = *agdc.GetPasswordMinimumLength()
+		}
+		if agdc.GetStorageRequireDeviceEncryption() != nil {
+			props["storageRequireDeviceEncryption"] = *agdc.GetStorageRequireDeviceEncryption()
+		}
+		if agdc.GetPasswordRequiredType() != nil {
+			props["passwordRequiredType"] = *agdc.GetPasswordRequiredType()
+		}
+		if agdc.GetPasswordExpirationDays() != nil {
+			props["passwordExpirationDays"] = *agdc.GetPasswordExpirationDays()
+		}
+	}
+	w10gc, ok := config.(*models.Windows10GeneralConfiguration)
+	if ok {
+		if w10gc.GetPasswordRequired() != nil {
+			props["passwordRequired"] = *w10gc.GetPasswordRequired()
+		}
+		if w10gc.GetPasswordMinutesOfInactivityBeforeScreenTimeout() != nil {
+			props["passwordMinutesOfInactivityBeforeScreenTimeout"] = *w10gc.GetPasswordMinutesOfInactivityBeforeScreenTimeout()
+		}
+		if w10gc.GetPasswordSignInFailureCountBeforeFactoryReset() != nil {
+			props["passwordSignInFailureCountBeforeFactoryReset"] = *w10gc.GetPasswordSignInFailureCountBeforeFactoryReset()
+		}
+		if w10gc.GetPasswordMinimumLength() != nil {
+			props["passwordMinimumLength"] = *w10gc.GetPasswordMinimumLength()
+		}
+		if w10gc.GetPasswordRequiredType() != nil {
+			props["passwordRequiredType"] = *w10gc.GetPasswordRequiredType()
+		}
+		if w10gc.GetPasswordExpirationDays() != nil {
+			props["passwordExpirationDays"] = *w10gc.GetPasswordExpirationDays()
+		}
+		if w10gc.GetPasswordExpirationDays() != nil {
+			props["passwordExpirationDays"] = *w10gc.GetPasswordExpirationDays()
+		}
+	}
+	macdc, ok := config.(*models.MacOSGeneralDeviceConfiguration)
+	if ok {
+		if macdc.GetPasswordMinutesOfInactivityBeforeScreenTimeout() != nil {
+			props["passwordMinutesOfInactivityBeforeScreenTimeout"] = *macdc.GetPasswordMinutesOfInactivityBeforeScreenTimeout()
+		}
+		if macdc.GetPasswordMinimumLength() != nil {
+			props["passwordMinimumLength"] = *macdc.GetPasswordMinimumLength()
+		}
+		if macdc.GetPasswordMinutesOfInactivityBeforeLock() != nil {
+			props["passwordMinutesOfInactivityBeforeLock"] = *macdc.GetPasswordMinutesOfInactivityBeforeLock()
+		}
+		if macdc.GetPasswordRequiredType() != nil {
+			props["passwordRequiredType"] = *macdc.GetPasswordRequiredType()
+		}
+		if macdc.GetPasswordBlockSimple() != nil {
+			props["passwordBlockSimple"] = *macdc.GetPasswordBlockSimple()
+		}
+		if macdc.GetPasswordRequired() != nil {
+			props["passwordRequired"] = *macdc.GetPasswordRequired()
+		}
+		if macdc.GetPasswordExpirationDays() != nil {
+			props["passwordExpirationDays"] = *macdc.GetPasswordExpirationDays()
+		}
+	}
+
+	iosdc, ok := config.(*models.IosGeneralDeviceConfiguration)
+	if ok {
+		if iosdc.GetPasscodeSignInFailureCountBeforeWipe() != nil {
+			props["passcodeSignInFailureCountBeforeWipe"] = *iosdc.GetPasscodeSignInFailureCountBeforeWipe()
+		}
+		if iosdc.GetPasscodeMinimumLength() != nil {
+			props["passcodeMinimumLength"] = *iosdc.GetPasscodeMinimumLength()
+		}
+		if iosdc.GetPasscodeMinutesOfInactivityBeforeLock() != nil {
+			props["passcodeMinutesOfInactivityBeforeLock"] = *iosdc.GetPasscodeMinutesOfInactivityBeforeLock()
+		}
+		if iosdc.GetPasscodeMinutesOfInactivityBeforeScreenTimeout() != nil {
+			props["passcodeMinutesOfInactivityBeforeScreenTimeout"] = *iosdc.GetPasscodeMinutesOfInactivityBeforeScreenTimeout()
+		}
+		if iosdc.GetPasscodeRequiredType() != nil {
+			props["passcodeRequiredType"] = *iosdc.GetPasscodeRequiredType()
+		}
+		if iosdc.GetPasscodeBlockSimple() != nil {
+			props["passcodeBlockSimple"] = *iosdc.GetPasscodeBlockSimple()
+		}
+		if iosdc.GetPasscodeRequired() != nil {
+			props["passcodeRequired"] = *iosdc.GetPasscodeRequired()
+		}
+		if iosdc.GetPasscodeExpirationDays() != nil {
+			props["passcodeExpirationDays"] = *iosdc.GetPasscodeExpirationDays()
+		}
+	}
+	awpgdc, ok := config.(*models.AndroidWorkProfileGeneralDeviceConfiguration)
+	if ok {
+		if awpgdc.GetPasswordSignInFailureCountBeforeFactoryReset() != nil {
+			props["passwordSignInFailureCountBeforeFactoryReset"] = *awpgdc.GetPasswordSignInFailureCountBeforeFactoryReset()
+		}
+		if awpgdc.GetPasswordMinimumLength() != nil {
+			props["passwordMinimumLength"] = *awpgdc.GetPasswordMinimumLength()
+		}
+		if awpgdc.GetPasswordMinutesOfInactivityBeforeScreenTimeout() != nil {
+			props["passwordMinutesOfInactivityBeforeScreenTimeout"] = *awpgdc.GetPasswordMinutesOfInactivityBeforeScreenTimeout()
+		}
+		if awpgdc.GetWorkProfilePasswordMinutesOfInactivityBeforeScreenTimeout() != nil {
+			props["workProfilePasswordMinutesOfInactivityBeforeScreenTimeout"] = *awpgdc.GetWorkProfilePasswordMinutesOfInactivityBeforeScreenTimeout()
+		}
+		if awpgdc.GetPasswordRequiredType() != nil {
+			props["passwordRequiredType"] = *awpgdc.GetPasswordRequiredType()
+		}
+		if awpgdc.GetWorkProfilePasswordRequiredType() != nil {
+			props["workProfilePasswordRequiredType"] = *awpgdc.GetWorkProfilePasswordRequiredType()
+		}
+		if awpgdc.GetPasswordExpirationDays() != nil {
+			props["passwordExpirationDays"] = *awpgdc.GetPasswordExpirationDays()
+		}
+
+	}
+	return props
 }
 
 func (m *mqlMsgraphDevicemanagement) GetDeviceCompliancePolicies() ([]interface{}, error) {
@@ -870,7 +1002,7 @@ func (m *mqlMsgraphDevicemanagement) GetDeviceCompliancePolicies() ([]interface{
 		compliancePolicy := compliancePolicies[i]
 
 		assignments, _ := core.JsonToDictSlice(msgraphconv.NewDeviceCompliancePolicyAssignments(compliancePolicy.GetAssignments()))
-		properties, _ := core.JsonToDict(compliancePolicy.GetAdditionalData())
+		properties := getComplianceProperties(compliancePolicy)
 
 		mqlResource, err := m.MotorRuntime.CreateResource("msgraph.devicemanagement.devicecompliancepolicy",
 			"id", core.ToString(compliancePolicy.GetId()),
@@ -889,6 +1021,37 @@ func (m *mqlMsgraphDevicemanagement) GetDeviceCompliancePolicies() ([]interface{
 	}
 
 	return res, nil
+}
+
+// TODO: windows 10 props missing.
+func getComplianceProperties(compliance models.DeviceCompliancePolicyable) map[string]interface{} {
+	props := map[string]interface{}{}
+	if compliance.GetOdataType() != nil {
+		props["@odata.type"] = *compliance.GetOdataType()
+	}
+
+	ioscp, ok := compliance.(*models.IosCompliancePolicy)
+	if ok {
+		if ioscp.GetSecurityBlockJailbrokenDevices() != nil {
+			props["securityBlockJailbrokenDevices"] = *ioscp.GetSecurityBlockJailbrokenDevices()
+		}
+		if ioscp.GetManagedEmailProfileRequired() != nil {
+			props["managedEmailProfileRequired"] = *ioscp.GetManagedEmailProfileRequired()
+		}
+	}
+	androidcp, ok := compliance.(*models.AndroidCompliancePolicy)
+	if ok {
+		if androidcp.GetSecurityBlockJailbrokenDevices() != nil {
+			props["securityBlockJailbrokenDevices"] = *androidcp.GetSecurityBlockJailbrokenDevices()
+		}
+	}
+	androidworkcp, ok := compliance.(*models.AndroidWorkProfileCompliancePolicy)
+	if ok {
+		if androidworkcp.GetSecurityBlockJailbrokenDevices() != nil {
+			props["securityBlockJailbrokenDevices"] = *androidworkcp.GetSecurityBlockJailbrokenDevices()
+		}
+	}
+	return props
 }
 
 func (m *mqlMsgraphDevicemanagementDeviceconfiguration) id() (string, error) {

--- a/resources/packs/ms365/msgraph.go
+++ b/resources/packs/ms365/msgraph.go
@@ -909,16 +909,22 @@ func getConfigurationProperties(config models.DeviceConfigurationable) map[strin
 			props["storageRequireDeviceEncryption"] = *agdc.GetStorageRequireDeviceEncryption()
 		}
 		if agdc.GetPasswordRequiredType() != nil {
-			props["passwordRequiredType"] = *agdc.GetPasswordRequiredType()
+			props["passwordRequiredType"] = agdc.GetPasswordRequiredType().String()
 		}
 		if agdc.GetPasswordExpirationDays() != nil {
 			props["passwordExpirationDays"] = *agdc.GetPasswordExpirationDays()
+		}
+		if agdc.GetPasswordMinutesOfInactivityBeforeScreenTimeout() != nil {
+			props["passwordMinutesOfInactivityBeforeScreenTimeout"] = *agdc.GetPasswordMinutesOfInactivityBeforeScreenTimeout()
 		}
 	}
 	w10gc, ok := config.(*models.Windows10GeneralConfiguration)
 	if ok {
 		if w10gc.GetPasswordRequired() != nil {
 			props["passwordRequired"] = *w10gc.GetPasswordRequired()
+		}
+		if w10gc.GetPasswordBlockSimple() != nil {
+			props["passwordBlockSimple"] = *w10gc.GetPasswordBlockSimple()
 		}
 		if w10gc.GetPasswordMinutesOfInactivityBeforeScreenTimeout() != nil {
 			props["passwordMinutesOfInactivityBeforeScreenTimeout"] = *w10gc.GetPasswordMinutesOfInactivityBeforeScreenTimeout()
@@ -930,7 +936,7 @@ func getConfigurationProperties(config models.DeviceConfigurationable) map[strin
 			props["passwordMinimumLength"] = *w10gc.GetPasswordMinimumLength()
 		}
 		if w10gc.GetPasswordRequiredType() != nil {
-			props["passwordRequiredType"] = *w10gc.GetPasswordRequiredType()
+			props["passwordRequiredType"] = w10gc.GetPasswordRequiredType().String()
 		}
 		if w10gc.GetPasswordExpirationDays() != nil {
 			props["passwordExpirationDays"] = *w10gc.GetPasswordExpirationDays()
@@ -951,7 +957,7 @@ func getConfigurationProperties(config models.DeviceConfigurationable) map[strin
 			props["passwordMinutesOfInactivityBeforeLock"] = *macdc.GetPasswordMinutesOfInactivityBeforeLock()
 		}
 		if macdc.GetPasswordRequiredType() != nil {
-			props["passwordRequiredType"] = *macdc.GetPasswordRequiredType()
+			props["passwordRequiredType"] = macdc.GetPasswordRequiredType().String()
 		}
 		if macdc.GetPasswordBlockSimple() != nil {
 			props["passwordBlockSimple"] = *macdc.GetPasswordBlockSimple()
@@ -979,7 +985,7 @@ func getConfigurationProperties(config models.DeviceConfigurationable) map[strin
 			props["passcodeMinutesOfInactivityBeforeScreenTimeout"] = *iosdc.GetPasscodeMinutesOfInactivityBeforeScreenTimeout()
 		}
 		if iosdc.GetPasscodeRequiredType() != nil {
-			props["passcodeRequiredType"] = *iosdc.GetPasscodeRequiredType()
+			props["passcodeRequiredType"] = iosdc.GetPasscodeRequiredType().String()
 		}
 		if iosdc.GetPasscodeBlockSimple() != nil {
 			props["passcodeBlockSimple"] = *iosdc.GetPasscodeBlockSimple()
@@ -1006,15 +1012,14 @@ func getConfigurationProperties(config models.DeviceConfigurationable) map[strin
 			props["workProfilePasswordMinutesOfInactivityBeforeScreenTimeout"] = *awpgdc.GetWorkProfilePasswordMinutesOfInactivityBeforeScreenTimeout()
 		}
 		if awpgdc.GetPasswordRequiredType() != nil {
-			props["passwordRequiredType"] = *awpgdc.GetPasswordRequiredType()
+			props["passwordRequiredType"] = awpgdc.GetPasswordRequiredType().String()
 		}
 		if awpgdc.GetWorkProfilePasswordRequiredType() != nil {
-			props["workProfilePasswordRequiredType"] = *awpgdc.GetWorkProfilePasswordRequiredType()
+			props["workProfilePasswordRequiredType"] = awpgdc.GetWorkProfilePasswordRequiredType().String()
 		}
 		if awpgdc.GetPasswordExpirationDays() != nil {
 			props["passwordExpirationDays"] = *awpgdc.GetPasswordExpirationDays()
 		}
-
 	}
 	return props
 }

--- a/resources/packs/ms365/msgraph.go
+++ b/resources/packs/ms365/msgraph.go
@@ -341,7 +341,7 @@ func (m *mqlMsgraphDomain) GetServiceConfigurationRecords() ([]interface{}, erro
 	records := resp.GetValue()
 	for i := range records {
 		record := records[i]
-		properties, _ := core.JsonToDict(record.GetAdditionalData())
+		properties := getDomainsDnsRecordProperties(record)
 
 		mqlResource, err := m.MotorRuntime.CreateResource("msgraph.domaindnsrecord",
 			"id", core.ToString(record.GetId()),
@@ -359,6 +359,56 @@ func (m *mqlMsgraphDomain) GetServiceConfigurationRecords() ([]interface{}, erro
 	}
 
 	return res, nil
+}
+
+func getDomainsDnsRecordProperties(record models.DomainDnsRecordable) map[string]interface{} {
+	props := map[string]interface{}{}
+	if record.GetOdataType() != nil {
+		props["@odata.type"] = *record.GetOdataType()
+	}
+	txtRecord, ok := record.(*models.DomainDnsTxtRecord)
+	if ok {
+		if txtRecord.GetText() != nil {
+			props["text"] = *txtRecord.GetText()
+		}
+	}
+	mxRecord, ok := record.(*models.DomainDnsMxRecord)
+	if ok {
+		if mxRecord.GetMailExchange() != nil {
+			props["mailExchange"] = *mxRecord.GetMailExchange()
+		}
+		if mxRecord.GetPreference() != nil {
+			props["preference"] = *mxRecord.GetPreference()
+		}
+	}
+	cNameRecord, ok := record.(*models.DomainDnsCnameRecord)
+	if ok {
+		if cNameRecord.GetCanonicalName() != nil {
+			props["canonicalName"] = *cNameRecord.GetCanonicalName()
+		}
+	}
+	srvRecord, ok := record.(*models.DomainDnsSrvRecord)
+	if ok {
+		if srvRecord.GetNameTarget() != nil {
+			props["nameTarget"] = *srvRecord.GetNameTarget()
+		}
+		if srvRecord.GetPort() != nil {
+			props["port"] = *srvRecord.GetPort()
+		}
+		if srvRecord.GetPriority() != nil {
+			props["priority"] = *srvRecord.GetPriority()
+		}
+		if srvRecord.GetProtocol() != nil {
+			props["protocol"] = *srvRecord.GetProtocol()
+		}
+		if srvRecord.GetService() != nil {
+			props["service"] = *srvRecord.GetService()
+		}
+		if srvRecord.GetWeight() != nil {
+			props["weight"] = *srvRecord.GetWeight()
+		}
+	}
+	return props
 }
 
 func (m *mqlMsgraphApplication) id() (string, error) {


### PR DESCRIPTION
To keep the current policies intact, add the properties manually. Previously those came directly from the API, now we need to see what kind of object is being returned and fill those in by hand.

There are 2 things that are missing, marked with TODOs.


