### PR TITLE
✨Cast 32-bit ints to 64-bit ints when comparing dict values

### DIFF
--- a/llx/builtin_map.go
+++ b/llx/builtin_map.go
@@ -877,6 +877,9 @@ func boolNotDictV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*
 // dict ==/!= int   (embedded: string + float)
 
 func opDictCmpInt(left interface{}, right interface{}) bool {
+	if _, ok := left.(int32); ok {
+		left = int64(left.(int32))
+	}
 	switch x := left.(type) {
 	case int64:
 		return x == right.(int64)
@@ -890,6 +893,9 @@ func opDictCmpInt(left interface{}, right interface{}) bool {
 }
 
 func opIntCmpDict(left interface{}, right interface{}) bool {
+	if _, ok := right.(int32); ok {
+		right = int64(right.(int32))
+	}
 	switch x := right.(type) {
 	case int64:
 		return left.(int64) == x


### PR DESCRIPTION
~~Sometimes, the data in the LR resources is an int32 int. Comparing such a field against an input, say~~
```
// resource.id is 5 (32-bit int)
resource.id == 5  // false
```
~~would be faulty since the input is always assumed to be a 64-int bit.~~

~~There are 2 scenarios I see to fix this:~~
 ~~1. What this PR does: when comparing 2 ints, up-cast to 64-int bit always to make sure we can properly compare~~
~~2. Make sure no resource has a 32int bit on it. This might be a bit harder to maintain as we cannot really impose this during compile time (or can we?), so it might be hard to spot~~

Edit:
This cannot happen for resources as there's a built-in check. I only extended the functions that are called when doing comparisong against a dict. Both
```
5 == dict['val']
```
and
```
dict['val'] == 5
```
work
@jaym  @arlimus 