### PR TITLE
🐛 Fix microsoft resource identifier.

### DIFF
--- a/resources/packs/ms365/msgraph.go
+++ b/resources/packs/ms365/msgraph.go
@@ -27,7 +27,7 @@ import (
 )
 
 func (m *mqlMicrosoft) id() (string, error) {
-	return "msgraph", nil
+	return "microsoft", nil
 }
 
 func (m *mqlMicrosoftOrganization) id() (string, error) {


### PR DESCRIPTION
Missed during the renaming