### PR TITLE
make sshd_config include case insensitive

### DIFF
--- a/resources/packs/os/sshd/include.go
+++ b/resources/packs/os/sshd/include.go
@@ -17,7 +17,7 @@ import (
 var (
 	// includeStatement is a regexp for checking whether a given sshd configuration line
 	// is an 'Include' statement
-	includeStatement = regexp.MustCompile(`^Include\s+(.*)$`)
+	includeStatement = regexp.MustCompile(`^[I|i]nclude\s+(.*)$`)
 	// includeStatementHasGlob is a regext for checking whether the contents of an 'Include'
 	// statement have a wildcard/glob (ie. a literal '*')
 	includeStatementHasGlob = regexp.MustCompile(`.*\*.*`)


### PR DESCRIPTION
the include statement in sshd_config can be:

```
Include /etc/ssh/sshd_config.d/*.conf
```
or

```
include /etc/ssh/sshd_config.d/*.conf
```

Signed-off-by: Patrick Münch <patrick.muench1111@gmail.com>