### PR TITLE
Update scan help

### DIFF
--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -127,7 +127,7 @@ or container name (e.g. elated_poincare).`,
 or the image name (e.g. ubuntu:latest).`,
 			},
 			"kubernetes": {
-				Short: "Scan a Kubernetes cluster",
+				Short: "Scan a Kubernetes cluster or local manifest file(s)",
 			},
 			"aws": {
 				Short: "Scan an AWS account or instance",
@@ -176,8 +176,20 @@ configure your Azure credentials and have SSH access to your instances.`,
 			"vsphere-vm": {
 				Short: "Scan a VMware vSphere VM",
 			},
+			"vcd": {
+				Short: "Scan a VMware Virtual Cloud Director organization",
+			},
 			"github": {
 				Short: "Scan a GitHub organization or repository",
+			},
+			"okta": {
+				Short: "Scan an Okta organization",
+			},
+			"googleworkspace": {
+				Short: "Scan a Google Workspace organization",
+			},
+			"slack": {
+				Short: "Scan a Slack team",
 			},
 			"github-org": {
 				Short: "Scan a GitHub organization",
@@ -202,7 +214,7 @@ This example connects to Microsoft 365 using the PKCS #12 formatted certificate:
 `,
 			},
 			"host": {
-				Short: "Scan a host endpoint",
+				Short: "Scan a host endpoint (domain name)",
 			},
 			"arista": {
 				Short: "Scan an Arista endpoint",


### PR DESCRIPTION
We were missing a few, our k8s description skipped over manifest scans, and host scanning could use some clarification.

Previous output:

```
Available Commands:
  arista          Scan an Arista endpoint
  aws             Scan an AWS account or instance
  azure           Scan a Microsoft Azure account or instance
  container       Scan a container, an image, or a registry
  docker          Scan a Docker container or image
  gcp             Scan a Google Cloud Platform (GCP) account
  github          Scan a GitHub organization or repository
  gitlab          Scan a GitLab group
  googleworkspace
  host            Scan a host endpoint
  k8s             Scan a Kubernetes cluster
  local           Scan a local target
  mock            Scan a mock target (a simulated asset)
  ms365           Scan a Microsoft 365 endpoint
  okta
  slack
  ssh             Scan a SSH target
  terraform       Scan all Terraform files in a path (.tf files)
  vagrant         Scan a Vagrant host
  vcd
  vsphere         Scan a VMware vSphere API endpoint
  winrm           Scan a WinRM target
```

cc: @chris-rock for guidance on Okta. What is the unit of Okta? Is it an account?

Signed-off-by: Tim Smith <tsmith84@gmail.com>