### PR TITLE
🐛 Set recorder file enoent property correctly when file does not exist.

### DIFF
--- a/motor/providers/mock/record.go
+++ b/motor/providers/mock/record.go
@@ -278,7 +278,7 @@ func (fs recordFS) Stat(name string) (os.FileInfo, error) {
 
 	enonet := false
 	stat, err := fs.observe.Stat(name)
-	if err == os.ErrNotExist {
+	if errors.Is(err, os.ErrNotExist) {
 		enonet = true
 	}
 


### PR DESCRIPTION
makes sure the `enoent` property is correctly set so it can be used:
```
[files]
  [files.blabla]
    path = "blabla"
    enoent = true
    content = ""
    [files.blabla.stat]
      mode = 0
      time = 0001-01-01T00:00:00Z
      isdir = false
      uid = 0
      gid = 0
      size = 0
```
