### PR TITLE
⭐️ Container edge releases

### DIFF
--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -68,5 +68,4 @@ jobs:
           args: release -f .goreleaser-edge.yml --rm-dist --timeout 120m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CERT_PASSWORD: ${{ steps.gcp_secrets.outputs.code_sign_cert_challenge }}
           NFPM_DEFAULT_RPM_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -22,7 +22,7 @@ jobs:
         os: [linux]
         arch: ['amd64', '386', 'arm64', 'arm', 'ppc64le']
 
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 120
     steps:
       - name: Checkout
@@ -72,40 +72,21 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      # Make sure no releases are created in Github
+      - name: Prepare .goreleaser-edge.yml
+        run: |
+          cp .goreleaser.yml .goreleaser-edge.yml
+          yq -i ".release.disable = true" .goreleaser-edge.yml
+          yq -i ".changelog.skip = true" .goreleaser-edge.yml
+      - name: Locally tag the current commit
+        run: git tag $(make version)
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist --snapshot --id=linux --timeout 5m
+          args: release -f .goreleaser-edge.yml --rm-dist --timeout 120m
         env:
-          GOARCH: ${{ matrix.arch}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CERT_PASSWORD: ${{ steps.gcp_secrets.outputs.code_sign_cert_challenge }}
           NFPM_DEFAULT_RPM_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      - name: Copy Dockerfile
-        run: |
-          cp Dockerfile dist/linux_linux_${{ matrix.arch }}
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=schedule,pattern=main
-            type=ref,event=branch
-            type=ref,event=tag
-            type=ref,event=pr
-          flavor: |
-            suffix=-${{ matrix.arch }},onlatest=true
-      - name: Build and push operator image
-        id: build-and-push-operator
-        uses: docker/build-push-action@v3
-        with:
-          context: ./dist/linux_linux_${{ matrix.arch }}
-          platforms: ${{ matrix.os }}/${{ matrix.arch }}
-          push: true
-          labels: ${{ steps.meta.outputs.labels }}
-          tags: ${{ steps.meta.outputs.tags }}
-        
-

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -17,11 +17,6 @@ jobs:
       # Add "id-token" for google-github-actions/auth
       id-token: 'write'
 
-    strategy:
-      matrix:
-        os: [linux]
-        arch: ['amd64', '386', 'arm64', 'arm', 'ppc64le']
-
     runs-on: self-hosted
     timeout-minutes: 120
     steps:

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -1,0 +1,111 @@
+name: goreleaser edge containers
+
+on:
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch:
+
+env:
+  REGISTRY: docker.io
+
+jobs:
+  goreleaser:
+    permissions:
+      # Add "contents" to write release
+      contents: 'write'
+      # Add "id-token" for google-github-actions/auth
+      id-token: 'write'
+
+    strategy:
+      matrix:
+        os: [linux]
+        arch: ['amd64', '386', 'arm64', 'arm', 'ppc64le']
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIP }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      - id: 'gcp_secrets'
+        uses: 'google-github-actions/get-secretmanager-secrets@v0'
+        with:
+          secrets: |-
+            code_sign_cert_b64:mondoo-base-infra/mondoo_code_sign_certificate_pfx_b64
+            code_sign_cert_challenge:mondoo-base-infra/mondoo_code_sign_challenge
+      - name: "Write RPM Signing Cert"
+        run: |
+          gpgkey="$(mktemp -t gpgkey.XXX)"
+          base64 -d <<<"$GPG_KEY" > "$gpgkey"
+          echo "GPG_KEY_PATH=$gpgkey" >> $GITHUB_ENV
+        env:
+          GPG_KEY: '${{ secrets.GPG_KEY}}'
+      - name: "Write Windows Signing Cert"
+        run: |
+          cert="$(mktemp -t cert.XXX)"
+          base64 -d <<<"$CERT_CONTENTS" > "$cert"
+          echo "CERT_FILE=$cert" >> $GITHUB_ENV
+        env:
+          CERT_CONTENTS: '${{ steps.gcp_secrets.outputs.code_sign_cert_b64 }}'
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist --snapshot --id=linux --timeout 5m
+        env:
+          GOARCH: ${{ matrix.arch}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CERT_PASSWORD: ${{ steps.gcp_secrets.outputs.code_sign_cert_challenge }}
+          NFPM_DEFAULT_RPM_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Copy Dockerfile
+        run: |
+          cp Dockerfile dist/linux_linux_${{ matrix.arch }}
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule,pattern=main
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+          flavor: |
+            suffix=-${{ matrix.arch }},onlatest=true
+      - name: Build and push operator image
+        id: build-and-push-operator
+        uses: docker/build-push-action@v3
+        with:
+          context: ./dist/linux_linux_${{ matrix.arch }}
+          platforms: ${{ matrix.os }}/${{ matrix.arch }}
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+        
+

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -41,31 +41,6 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v0'
-        with:
-          workload_identity_provider: ${{ secrets.GCP_WIP }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - id: 'gcp_secrets'
-        uses: 'google-github-actions/get-secretmanager-secrets@v0'
-        with:
-          secrets: |-
-            code_sign_cert_b64:mondoo-base-infra/mondoo_code_sign_certificate_pfx_b64
-            code_sign_cert_challenge:mondoo-base-infra/mondoo_code_sign_challenge
-      - name: "Write RPM Signing Cert"
-        run: |
-          gpgkey="$(mktemp -t gpgkey.XXX)"
-          base64 -d <<<"$GPG_KEY" > "$gpgkey"
-          echo "GPG_KEY_PATH=$gpgkey" >> $GITHUB_ENV
-        env:
-          GPG_KEY: '${{ secrets.GPG_KEY}}'
-      - name: "Write Windows Signing Cert"
-        run: |
-          cert="$(mktemp -t cert.XXX)"
-          base64 -d <<<"$CERT_CONTENTS" > "$cert"
-          echo "CERT_FILE=$cert" >> $GITHUB_ENV
-        env:
-          CERT_CONTENTS: '${{ steps.gcp_secrets.outputs.code_sign_cert_b64 }}'
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
@@ -73,11 +48,16 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       # Make sure no releases are created in Github
+      # Make sure only linux binaries and docker files are built
       - name: Prepare .goreleaser-edge.yml
         run: |
           cp .goreleaser.yml .goreleaser-edge.yml
           yq -i ".release.disable = true" .goreleaser-edge.yml
           yq -i ".changelog.skip = true" .goreleaser-edge.yml
+          yq -i "del(.nfpms)" .goreleaser.yml
+          yq -i 'del(.builds[] | select(.id == "macos"))' .goreleaser.yml
+          yq -i 'del(.builds[] | select(.id == "windows"))' .goreleaser.yml
+          yq -i "del(.archives)" .goreleaser.yml
       - name: Locally tag the current commit
         run: git tag $(make version)
       - name: Run GoReleaser

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ id_rsa.pub
 mondoo-test-secret-key
 gha-creds-*.json
 /tools
+.goreleaser-edge.yml


### PR DESCRIPTION
Since we cannot use goreleaser directly to do our edge releases I created a separate workflow for that. The workflow is triggered for every commit to `main`. It will do a snapshot release of the binary and then create a container with that binary. The container is then pushed to our registry. This PR will create a container for every architecture. If we agree to the approach I will create a follow-up PR to do the virtual tag that combines all architectures.