### PR TITLE
🐛Fix incorrect assignment of uid over gid for file info stat data.

### DIFF
--- a/motor/providers/mock/file.go
+++ b/motor/providers/mock/file.go
@@ -70,7 +70,7 @@ func (mf *MockFile) Stat() (os.FileInfo, error) {
 		FMode:    mf.data.StatData.Mode,
 		FIsDir:   mf.data.StatData.IsDir,
 		Uid:      mf.data.StatData.Uid,
-		Gid:      mf.data.StatData.Uid,
+		Gid:      mf.data.StatData.Gid,
 	}, nil
 }
 


### PR DESCRIPTION
A simple fix to get the mocked gid file related commands to work.