### PR TITLE
🧹 Use proper tag naming for edge releases

### DIFF
--- a/.github/.goreleaser-edge.yml
+++ b/.github/.goreleaser-edge.yml
@@ -1,0 +1,169 @@
+---
+project_name: cnquery
+env:
+  - CGO_ENABLED=0
+builds:
+  - id: linux
+    main: ../apps/cnquery/cnquery.go
+    binary: cnquery
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - 386
+      - arm64
+      - arm
+      - ppc64le
+    # ARM 6= Raspberry Pi A, A+, B, B+, Zero
+    # ARM 7= Raspberry Pi 2, 3, 4
+    goarm:
+      - 6
+      - 7
+    flags:
+      - -tags="production netgo"
+    ldflags:
+      - "-extldflags=-static"
+      - -s -w -X go.mondoo.com/cnquery.Version={{.Version}} -X go.mondoo.com/cnquery.Build={{.ShortCommit}} -X go.mondoo.com/cnquery.Date={{.Date}}
+checksum:
+  name_template: '{{ .ProjectName }}_v{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+release:
+  disable: true
+changelog:
+  skip: true
+dockers: # https://goreleaser.com/customization/docker/
+  - use: buildx
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-amd64"
+      - "mondoo/{{ .ProjectName }}:edge-latest-amd64"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--target=root"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-arm64v8"
+      - "mondoo/{{ .ProjectName }}:edge-latest-arm64v8"
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--target=root"
+  - use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 6
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv6"
+      - "mondoo/{{ .ProjectName }}:edge-latest-armv6"
+    build_flag_templates:
+      - "--platform=linux/arm/v6"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--target=root"
+  - use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 7
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv7"
+      - "mondoo/{{ .ProjectName }}:edge-latest-armv7"
+    build_flag_templates:
+      - "--platform=linux/arm/v7"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--target=root"
+  # Rootless
+  - use: buildx
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-amd64-rootless"
+      - "mondoo/{{ .ProjectName }}:edge-latest-amd64-rootless"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--target=rootless"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-arm64v8-rootless"
+      - "mondoo/{{ .ProjectName }}:edge-latest-arm64v8-rootless"
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--target=rootless"
+  - use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 6
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv6-rootless"
+      - "mondoo/{{ .ProjectName }}:edge-latest-armv6-rootless"
+    build_flag_templates:
+      - "--platform=linux/arm/v6"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--target=rootless"
+  - use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 7
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv7-rootless"
+      - "mondoo/{{ .ProjectName }}:edge-latest-armv7-rootless"
+    build_flag_templates:
+      - "--platform=linux/arm/v7"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--target=rootless"
+docker_manifests:  # https://goreleaser.com/customization/docker_manifest/
+  - name_template: mondoo/{{ .ProjectName }}:edge-{{ .Version }}
+    image_templates:
+      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-amd64
+      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-arm64v8
+      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv6
+      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv7
+  - name_template: mondoo/{{ .ProjectName }}:edge-latest
+    image_templates:
+      - mondoo/{{ .ProjectName }}:edge-latest-amd64
+      - mondoo/{{ .ProjectName }}:edge-latest-arm64v8
+      - mondoo/{{ .ProjectName }}:edge-latest-armv6
+      - mondoo/{{ .ProjectName }}:edge-latest-armv7
+  # Rootless
+  - name_template: mondoo/{{ .ProjectName }}:edge-{{ .Version }}-rootless
+    image_templates:
+      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-amd64-rootless
+      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-arm64v8-rootless
+      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv6-rootless
+      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv7-rootless
+  - name_template: mondoo/{{ .ProjectName }}:edge-latest-rootless
+    image_templates:
+      - mondoo/{{ .ProjectName }}:edge-latest-amd64-rootless
+      - mondoo/{{ .ProjectName }}:edge-latest-arm64v8-rootless
+      - mondoo/{{ .ProjectName }}:edge-latest-armv6-rootless
+      - mondoo/{{ .ProjectName }}:edge-latest-armv7-rootless

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -34,22 +34,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      # Make sure no releases are created in Github
-      # Make sure only linux binaries and docker files are built
-      # Do not build and push images for 'latest' and major version tags
-      - name: Prepare .goreleaser-edge.yml
-        run: |
-          cp .goreleaser.yml .goreleaser-edge.yml
-          yq -i ".release.disable = true" .goreleaser-edge.yml
-          yq -i ".changelog.skip = true" .goreleaser-edge.yml
-          yq -i "del(.nfpms)" .goreleaser-edge.yml
-          yq -i 'del(.builds[] | select(.id == "macos"))' .goreleaser-edge.yml
-          yq -i 'del(.builds[] | select(.id == "windows"))' .goreleaser-edge.yml
-          yq -i "del(.archives)" .goreleaser-edge.yml
-          yq -i 'del(.dockers[].image_templates[] | select(. == "*latest*"))' .goreleaser-edge.yml
-          yq -i 'del(.dockers[].image_templates[] | select(. == "*{{ .Major }}*"))' .goreleaser-edge.yml
-          yq -i 'del(.docker_manifests[] | select(.name_template == "*latest*"))' .goreleaser-edge.yml
-          yq -i 'del(.docker_manifests[] | select(.name_template == "*{{ .Major }}*"))' .goreleaser-edge.yml
       - name: Locally tag the current commit
         run: |
           VERSION=$(make version)
@@ -59,7 +43,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release -f .goreleaser-edge.yml --rm-dist --timeout 120m
+          args: release -f .github/.goreleaser-edge.yml --rm-dist --timeout 120m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NFPM_DEFAULT_RPM_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ id_rsa.pub
 mondoo-test-secret-key
 gha-creds-*.json
 /tools
-.goreleaser-edge.yml


### PR DESCRIPTION
The goal here is to have the following tags for edge releases:
- edge-latest
- edge-latest-rootless
- edge-VERSION
- edge-VERSION-rootless

I spent quite some time trying to make the magic happen with `yq` but it seems too much effort. 80% of the goreleaser config for edge releases is the docker configuration. In this case it has to be quite different from the one for the normal release procedure. This is the reason why I decided to just manually configure the file and use that