### PR TITLE
🧹 aws ec2 & ssm discovery: add running instance state filter by default

### DIFF
--- a/motor/discovery/aws/resolver.go
+++ b/motor/discovery/aws/resolver.go
@@ -203,12 +203,6 @@ func AssembleEc2InstancesFilters(opts map[string]string) Ec2InstancesFilters {
 	return ec2InstancesFilters
 }
 
-type Ec2InstancesFilters struct {
-	InstanceIds []string
-	Tags        map[string]string
-	Regions     []string
-}
-
 func AssembleIntegrationName(alias string, id string) string {
 	if alias == "" {
 		return fmt.Sprintf("AWS Account %s", id)

--- a/motor/discovery/aws/ssm_instances.go
+++ b/motor/discovery/aws/ssm_instances.go
@@ -109,6 +109,10 @@ func (ssmi *SSMManagedInstances) getInstances(account string, ec2InstancesFilter
 				input.Filters = append(input.Filters, types.InstanceInformationStringFilter{Key: aws.String("InstanceIds"), Values: ec2InstancesFilters.InstanceIds})
 				log.Debug().Interface("instance ids", ec2InstancesFilters.InstanceIds).Msgf("filtering")
 			}
+			if ec2InstancesFilters.InstanceState == 0 {
+				input.Filters = append(input.Filters, types.InstanceInformationStringFilter{Key: aws.String("PingStatus"), Values: []string{"Online"}})
+				log.Debug().Msg("filtering aws ssm instances by online ping status")
+			}
 			// NOTE: AWS does not support filtering by tags for this api call
 			nextToken := aws.String("no_token_to_start_with")
 			ssminstances := make([]types.InstanceInformation, 0)


### PR DESCRIPTION
⚠️ this changes the default behavior of the ec2 discovery to only return running/online instances (we'll need to update the lambda behavior as a follow up)

before:
<img width="925" alt="Screenshot 2022-12-23 at 15 09 45" src="https://user-images.githubusercontent.com/10341541/209409580-85490667-baa1-4df9-9d8f-63b61182d3df.png">

after:
<img width="1050" alt="Screenshot 2022-12-23 at 15 04 13" src="https://user-images.githubusercontent.com/10341541/209409577-0d8addbb-663a-4cbf-a11b-2d8851d623a9.png">
