### PR TITLE
🐛 Fix bug where concurrent chain executions would not complete

### DIFF
--- a/llx/llx.go
+++ b/llx/llx.go
@@ -838,9 +838,11 @@ func (e *blockExecutor) runChain(start uint64) {
 			res, nextRef, err = e.runRef(curRef)
 		}
 
-		// stop this chain of execution, if it didn't return anything
+		// stop this chain of execution, if it didn't return anything and
+		// there is nothing else left to process
 		// we need more data ie an event to provide info
-		if res == nil && nextRef == 0 && err == nil {
+		if res == nil && nextRef == 0 && err == nil && len(remaining) == 0 {
+			log.Trace().Uint64("ref", curRef).Msg("exec> stop chain")
 			return
 		}
 

--- a/resources/packs/core/core_test.go
+++ b/resources/packs/core/core_test.go
@@ -1263,3 +1263,17 @@ func TestBrokenQueryExecution(t *testing.T) {
 	require.Error(t, results[1].Data.Error)
 	require.Error(t, results[2].Data.Error)
 }
+
+func TestBrokenQueryExecutionGH674(t *testing.T) {
+	// See https://github.com/mondoohq/cnquery/issues/674
+	x := testutils.InitTester(testutils.LinuxMock(), core.Registry)
+	bundle, err := x.Compile(`
+a = file("/tmp/ref1").content.trim
+file(a).path == "/tmp/ref2"
+file(a).content.trim == "asdf"
+	`)
+	require.NoError(t, err)
+
+	results := x.TestMqlc(t, bundle, nil)
+	require.Len(t, results, 5)
+}

--- a/resources/packs/testdata/arch.toml
+++ b/resources/packs/testdata/arch.toml
@@ -660,3 +660,9 @@ content="""
 </dict>
 </plist>
 """
+
+[files."/tmp/ref1"]
+content="""/tmp/ref2"""
+
+[files."/tmp/ref2"]
+content="""asdf"""


### PR DESCRIPTION
Setup:
```sh
mkdir tmp
echo "tmp/a" > tmp/ref1
echo "asdf" > tmp/a
```

A sample query that failed:
```
a = file("tmp/ref1").content.trim
file(a).path == "tmp/a"
file(a).content.trim == "asdf"
```

Fixes #674