### PR TITLE
✨Add subscriptions and subscriptions-exclude arguments for azure scanning

### DIFF
--- a/apps/cnquery/cmd/builder/builder.go
+++ b/apps/cnquery/cmd/builder/builder.go
@@ -576,6 +576,9 @@ func azureProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn
 	cmd.Flags().String("certificate-path", "", "path to certificate that's used for certificate-based authentication in PKCS 12 format (pfx)")
 	cmd.Flags().String("certificate-secret", "", "passphrase for certificate file")
 	cmd.Flags().String("subscription", "", "the Azure subscription ID to scan")
+	cmd.Flags().String("subscriptions", "", "the Azure subscriptions to include")
+	cmd.Flags().String("subscriptions-exclude", "", "the Azure subscriptions to exclude")
+
 	return cmd
 }
 

--- a/apps/cnquery/cmd/builder/builder.go
+++ b/apps/cnquery/cmd/builder/builder.go
@@ -576,8 +576,8 @@ func azureProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn
 	cmd.Flags().String("certificate-path", "", "path to certificate that's used for certificate-based authentication in PKCS 12 format (pfx)")
 	cmd.Flags().String("certificate-secret", "", "passphrase for certificate file")
 	cmd.Flags().String("subscription", "", "the Azure subscription ID to scan")
-	cmd.Flags().String("subscriptions", "", "the Azure subscriptions to include")
-	cmd.Flags().String("subscriptions-exclude", "", "the Azure subscriptions to exclude")
+	cmd.Flags().String("subscriptions", "", "a comma-separated list of Azure subscriptions to include")
+	cmd.Flags().String("subscriptions-exclude", "", "a comma-separated list of Azure subscriptions to exclude")
 
 	return cmd
 }

--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -341,6 +341,9 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 		clientSecret, _ := cmd.Flags().GetString("client-secret")
 		certificatePath, _ := cmd.Flags().GetString("certificate-path")
 		certificateSecret, _ := cmd.Flags().GetString("certificate-secret")
+		subsToInclude, _ := cmd.Flags().GetString("subscriptions")
+		subsToExclude, _ := cmd.Flags().GetString("subscriptions-exclude")
+
 		if clientid == "" && (clientSecret == "" || certificatePath == "") {
 			if err != nil {
 				log.Fatal().Err(err).Msg("cannot parse --subscription value")
@@ -355,6 +358,13 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 		if clientid != "" {
 			connection.Options["client-id"] = clientid
 		}
+		if subsToExclude != "" {
+			connection.Options["subscriptions-exclude"] = subsToExclude
+		}
+		if subsToInclude != "" {
+			connection.Options["subscriptions"] = subsToInclude
+		}
+
 		if clientSecret != "" {
 			connection.Credentials = append(connection.Credentials, &vault.Credential{
 				Type:     vault.CredentialType_password,

--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -358,6 +358,9 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 		if clientid != "" {
 			connection.Options["client-id"] = clientid
 		}
+		if subsToExclude != "" && subsToInclude != "" {
+			log.Fatal().Msg("cannot provide both --subscriptions and --subscriptions-exclude, provide only one of them")
+		}
 		if subsToExclude != "" {
 			connection.Options["subscriptions-exclude"] = subsToExclude
 		}


### PR DESCRIPTION
Lets us include or exclude specific subscriptions when running an azure discovery. Very similar to the k8s namespaces filtering in terms of behaviour.

`~/go/bin/cnquery shell azure  --subscriptions-exclude=984df67f-fc2e-4ebf-80a2-98380182f060,1e829eb0-e6a3-4c7b-8212-5868aaebd318`

