### PR TITLE
🧹 fall back to resource title for field comments

### DIFF
--- a/cli/shell/shell.go
+++ b/cli/shell/shell.go
@@ -422,6 +422,13 @@ func (s *Shell) renderResources(schema *resources.Schema, keys []string) {
 			fieldName := "  " + field.Name
 			fieldType := types.Type(field.Type).Label()
 			displayType := ""
+			fieldComment := field.Title
+			if fieldComment == "" && types.Type(field.Type).IsResource() {
+				r, ok := schema.Resources[fieldType]
+				if ok {
+					fieldComment = r.Title
+				}
+			}
 			if len(fieldType) > 0 {
 				fieldType = " " + fieldType
 				displayType = s.Theme.PolicyPrinter.Disabled(fieldType)
@@ -431,7 +438,7 @@ func (s *Shell) renderResources(schema *resources.Schema, keys []string) {
 			rows = append(rows, rowEntry{
 				s.Theme.PolicyPrinter.Secondary(fieldName) + displayType + seperator,
 				keyLength,
-				field.Title,
+				fieldComment,
 			})
 			if maxk < keyLength {
 				maxk = keyLength


### PR DESCRIPTION
Before:
```
cnquery> help aws
aws:                                                 AWS Resource
  accessAnalyzer aws.accessAnalyzer:
  account aws.account:
  acm aws.acm:
  apigateway aws.apigateway:
  applicationAutoscaling aws.applicationAutoscaling:
  autoscaling aws.autoscaling:
  backup aws.backup:
  cloudtrail aws.cloudtrail:
...
```

After:
```
cnquery> help aws
aws:                                                 AWS Resource
  accessAnalyzer aws.accessAnalyzer:                 AWS Access Analyzer resource for assessing the configuration of AWS IAM Access Analyzer
  account aws.account:                               AWS Account
  acm aws.acm:                                       AWS Certificate Manager resource for assessing the configuration of AWS Certificate Manager
  apigateway aws.apigateway:                         AWS API Gateway
  applicationAutoscaling aws.applicationAutoscaling: AWS Application Autoscaling
  autoscaling aws.autoscaling:                       AWS Auto Scaling
  backup aws.backup:                                 AWS Backup
  cloudtrail aws.cloudtrail:                         AWS CloudTrail
...
```