### PR TITLE
Make letha the codeowner on the LR files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
 ### mondoohq/cnquery CODEOWNERS
 
-# All resource updates require editorial review by Docs Editor Letha with backup of Tim
-*.lr @misterpantz @tas50
+# Markdown and resource updates should be reviewed by an editor
+*.lr @mondoohq/mondoo-editors
+*.md @mondoohq/mondoo-editors
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+### mondoohq/cnquery CODEOWNERS
+
+# All resource updates require editorial review by Docs Editor Letha with backup of Tim
+*.lr @misterpantz @tas50


### PR DESCRIPTION
This way we get reviews on potential docs changes before they make it into the docs. This reduces followup PRs and wasted effort.

Signed-off-by: Tim Smith <tsmith84@gmail.com>