### PR TITLE
🐛 aws ssm discovery and connect: use instance id for search when available

### DIFF
--- a/motor/discovery/aws/ec2_instances.go
+++ b/motor/discovery/aws/ec2_instances.go
@@ -224,8 +224,9 @@ func instanceToAsset(instanceInfo instanceInfo) *asset.Asset {
 				},
 			},
 			Options: map[string]string{
-				"region":  instanceInfo.region,
-				"profile": instanceInfo.profile,
+				"region":   instanceInfo.region,
+				"profile":  instanceInfo.profile,
+				"instance": *instanceInfo.instance.InstanceId,
 			},
 		})
 	}

--- a/motor/discovery/aws/ssm_instances.go
+++ b/motor/discovery/aws/ssm_instances.go
@@ -217,8 +217,9 @@ func ssmInstanceToAsset(instanceInfo ssmInstanceInfo, cfg aws.Config) *asset.Ass
 			Runtime:     providers.RUNTIME_AWS_EC2,
 			Credentials: creds,
 			Options: map[string]string{
-				"region":  instanceInfo.region,
-				"profile": instanceInfo.profile,
+				"region":   instanceInfo.region,
+				"profile":  instanceInfo.profile,
+				"instance": *instanceInfo.instance.InstanceId,
 			},
 		}},
 		State:  mapSmmManagedPingStateCode(instanceInfo.instance.PingStatus),

--- a/motor/providers/ssh/session.go
+++ b/motor/providers/ssh/session.go
@@ -164,7 +164,11 @@ func prepareConnection(pCfg *providers.Config) ([]ssh.AuthMethod, []io.Closer, e
 
 			// we use ec2 instance connect api to create credentials for an aws instance
 			eic := awsinstanceconnect.New(cfg)
-			creds, err := eic.GenerateCredentials(pCfg.Host, credential.User)
+			host := pCfg.Host
+			if id, ok := pCfg.Options["instance"]; ok {
+				host = id
+			}
+			creds, err := eic.GenerateCredentials(host, credential.User)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -222,7 +226,11 @@ func prepareConnection(pCfg *providers.Config) ([]ssh.AuthMethod, []io.Closer, e
 			}
 			log.Debug().Msg("generating instance connect credentials")
 			eic := awsinstanceconnect.New(cfg)
-			creds, err := eic.GenerateCredentials(pCfg.Host, credential.User)
+			host := pCfg.Host
+			if id, ok := pCfg.Options["instance"]; ok {
+				host = id
+			}
+			creds, err := eic.GenerateCredentials(host, credential.User)
 			if err != nil {
 				return nil, nil, err
 			}


### PR DESCRIPTION
with command:
`DEBUG=1 go run apps/cnquery/cnquery.go shell aws --discover ssm --profile AWSPROFILE`

after selecting an asset - 

before & after:
```
[3/01/23 22:00:00] ❯ cnquery shell aws --discover ssm --profile vvdefault
→ loaded configuration from /Users/vj/.config/mondoo/mondoo.yml using source default
→ discover related assets for 1 asset(s)
→ resolved assets resolved-assets=3
→ selected asset asset=test.smm-5.25 selection=2
FTL could not connect to asset error="could not find the instance"

~/go/src/go.mondoo.io/cnquery vj/ssm-discover-connect* 10s

[3/01/23 22:00:59] ❯ go run apps/cnquery/cnquery.go shell aws --discover ssm --profile vvdefault
→ loaded configuration from /Users/vj/.config/mondoo/mondoo.yml using source default
→ discover related assets for 1 asset(s)
→ resolved assets resolved-assets=3
→ selected asset asset=test.smm-5.25 selection=2
  ___ _ __   __ _ _   _  ___ _ __ _   _
 / __| '_ \ / _` | | | |/ _ \ '__| | | |
| (__| | | | (_| | |_| |  __/ |  | |_| |
 \___|_| |_|\__, |\__,_|\___|_|   \__, |
  mondoo™      |_|                |___/  interactive shell

cnquery>
```