### PR TITLE
🧹 detect the aws ec2 instance name

### DIFF
--- a/motor/motorid/awsec2/awsec2.go
+++ b/motor/motorid/awsec2/awsec2.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"go.mondoo.com/cnquery/motor/providers/local"
 	"go.mondoo.com/cnquery/motor/providers/os"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/cockroachdb/errors"
 	"go.mondoo.com/cnquery/motor/platform"
-	"go.mondoo.com/cnquery/motor/providers/local"
 )
 
 type Identity struct {
@@ -22,6 +22,14 @@ type InstanceIdentifier interface {
 }
 
 func Resolve(provider os.OperatingSystemProvider, pf *platform.Platform) (InstanceIdentifier, error) {
+	if pf.IsFamily(platform.FAMILY_UNIX) || pf.IsFamily(platform.FAMILY_WINDOWS) {
+		// try to fetch a config, even if this is not being ran on the ec2 instance itself.
+		cfg, err := config.LoadDefaultConfig(context.Background())
+		if err != nil {
+			return NewCommandInstanceMetadata(provider, pf, nil), nil
+		}
+		return NewCommandInstanceMetadata(provider, pf, &cfg), nil
+	}
 	_, ok := provider.(*local.Provider)
 	if ok {
 		cfg, err := config.LoadDefaultConfig(context.Background())
@@ -29,15 +37,6 @@ func Resolve(provider os.OperatingSystemProvider, pf *platform.Platform) (Instan
 			return nil, errors.Wrap(err, "cannot not determine aws environment")
 		}
 		return NewLocal(cfg), nil
-	} else {
-		if pf.IsFamily(platform.FAMILY_UNIX) || pf.IsFamily(platform.FAMILY_WINDOWS) {
-			// try to fetch a config, even if this is not being ran on the ec2 instance itself.
-			cfg, err := config.LoadDefaultConfig(context.Background())
-			if err != nil {
-				return NewCommandInstanceMetadata(provider, pf, nil), nil
-			}
-			return NewCommandInstanceMetadata(provider, pf, &cfg), nil
-		}
 	}
 	return nil, errors.New(fmt.Sprintf("awsec2 id detector is not supported for your asset: %s %s", pf.Name, pf.Version))
 }


### PR DESCRIPTION
before & after:

<img width="1197" alt="Screenshot 2023-01-04 at 15 07 05" src="https://user-images.githubusercontent.com/10341541/210659385-6382b3a6-de8f-4941-a54c-5143a6275fc8.png">


notice the "connecting to asset" line. with the installed cnquery, it's the instance id. with the local copy of cnquery, it's the name of the instance from the name tag