### PR TITLE
🧹 update aws debug tests and logging

### DIFF
--- a/apps/cnquery/cmd/builder/builder.go
+++ b/apps/cnquery/cmd/builder/builder.go
@@ -56,6 +56,12 @@ func NewProviderCommand(opts CommandOpts) *cobra.Command {
 				os.Exit(1)
 			}
 
+			if viper.GetString("inventory-file") != "" {
+				// when the user provided an inventory file, users do not need to provide a provider
+				opts.Run(cmd, args, providers.ProviderType_UNKNOWN, DefaultAssetType)
+				return
+			}
+
 			log.Info().Msg("no provider specified, defaulting to local.\n  Use --help for a list of available providers.")
 			opts.Run(cmd, args, providers.ProviderType_LOCAL_OS, DefaultAssetType)
 		},

--- a/motor/discovery/aws/resolver_debug_test.go
+++ b/motor/discovery/aws/resolver_debug_test.go
@@ -1,0 +1,56 @@
+//go:build debugtest
+// +build debugtest
+
+package aws_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/motor/inventory"
+	v1 "go.mondoo.com/cnquery/motor/inventory/v1"
+)
+
+func TestInventory(t *testing.T) {
+	inventoryContent := `
+apiVersion: v1
+kind: Inventory
+metadata:
+  name: aws-inventory
+spec:
+  assets:
+    - id: account-1
+      connections:
+        - backend: aws
+          options:
+            profile: mondoo-dev
+          discover:
+            targets:
+              - "accounts"
+      annotations:
+        owner: user@example.com
+    - id: account-2
+      connections:
+        - backend: aws
+          options:
+            profile: mondoo-demo
+          discover:
+            targets:
+              - "accounts"
+      annotations:
+        owner: user@example.com% 
+`
+	inv, err := v1.InventoryFromYAML([]byte(inventoryContent))
+	require.NoError(t, err)
+
+	im, err := inventory.New(inventory.WithInventory(inv))
+
+	ctx := context.Background()
+	assetErrors := im.Resolve(ctx)
+	assert.True(t, len(assetErrors) == 0)
+
+	assetList := im.GetAssets()
+	assert.True(t, len(assetList) == 2)
+}

--- a/motor/providers/aws/provider.go
+++ b/motor/providers/aws/provider.go
@@ -52,10 +52,12 @@ func TransportOptions(opts map[string]string) []ProviderOption {
 	}
 
 	if awsRegion, ok := opts["region"]; ok {
+		log.Debug().Str("region", awsRegion).Msg("using region")
 		transportOpts = append(transportOpts, WithRegion(awsRegion))
 	}
 
 	if awsProfile, ok := opts["profile"]; ok {
+		log.Debug().Str("profile", awsProfile).Msg("using aws profile")
 		transportOpts = append(transportOpts, WithProfile(awsProfile))
 	}
 	return transportOpts
@@ -79,7 +81,7 @@ func New(pCfg *providers.Config, opts ...ProviderOption) (*Provider, error) {
 		return nil, errors.Wrap(err, "could not load aws configuration")
 	}
 	if cfg.Region == "" {
-		log.Warn().Msg("no AWS region found, using us-east-1")
+		log.Info().Msg("no AWS region found, using us-east-1")
 		cfg.Region = "us-east-1" // in case the user has no region set, default to us-east-1
 	}
 

--- a/motor/providers/aws/provider_test.go
+++ b/motor/providers/aws/provider_test.go
@@ -1,26 +1,28 @@
+//go:build debugtest
+// +build debugtest
+
 package aws
 
-// import (
-// 	"testing"
+import (
+	"testing"
 
-// 	"github.com/aws/aws-sdk-go-v2/aws/endpoints"
-// 	"github.com/stretchr/testify/require"
-// 	"go.mondoo.com/cnquery/motor/transports"
-// )
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/motor/providers"
+)
 
-// func TestAwsTransport(t *testing.T) {
+func TestAwsTransport(t *testing.T) {
+	pCfg := &providers.Config{
+		Backend: providers.ProviderType_AWS,
+		Options: map[string]string{
+			"profile": "example-demo",
+		},
+	}
 
-// 	pCfg := &transports.TransportConfig{
-// 		Type: transports.TransportBackend_CONNECTION_AWS,
-// 		Options: map[string]string{
-// 			"profile": "mondoo-inc",
-// 			"region":  endpoints.UsEast1RegionID,
-// 		},
-// 	}
+	p, err := New(pCfg, TransportOptions(pCfg.Options)...)
+	require.NoError(t, err)
 
-// 	p, err := New(pCfg)
-// 	require.NoError(t, err)
-
-// 	info, err := p.Account()
-// 	require.NoError(t, err)
-// }
+	info, err := p.Account()
+	require.NoError(t, err)
+	assert.NotNil(t, info)
+}


### PR DESCRIPTION
improve the logging messages and updates the debug test to be able to test aws discovery and provider quicker