### PR TITLE
🧹 socketstats resource was returning an empty error 

### DIFF
--- a/resources/packs/azure/azure.go
+++ b/resources/packs/azure/azure.go
@@ -19,7 +19,7 @@ func init() {
 func azureTransport(t providers.Instance) (*microsoft_transport.Provider, error) {
 	at, ok := t.(*microsoft_transport.Provider)
 	if !ok {
-		return nil, errors.New("azure resource is not supported on this transport")
+		return nil, errors.New("azure resource is not supported on this provider")
 	}
 	if len(at.SubscriptionID()) == 0 {
 		return nil, errors.New("azure resource requires a subscription id")

--- a/resources/packs/gcp/gcp.go
+++ b/resources/packs/gcp/gcp.go
@@ -18,7 +18,7 @@ func init() {
 func gcpProvider(t providers.Instance) (*gcp_provider.Provider, error) {
 	provider, ok := t.(*gcp_provider.Provider)
 	if !ok {
-		return nil, errors.New("gcp resource is not supported on this transport")
+		return nil, errors.New("gcp resource is not supported on this provider")
 	}
 	return provider, nil
 }

--- a/resources/packs/ms365/ms365.go
+++ b/resources/packs/ms365/ms365.go
@@ -17,7 +17,7 @@ func init() {
 func microsoftProvider(t providers.Instance) (*microsoft.Provider, error) {
 	at, ok := t.(*microsoft.Provider)
 	if !ok {
-		return nil, errors.New("microsoft resource is not supported on this transport")
+		return nil, errors.New("microsoft resource is not supported on this provider")
 	}
 	return at, nil
 }

--- a/resources/packs/os/command.go
+++ b/resources/packs/os/command.go
@@ -16,7 +16,7 @@ func (c *mqlCommand) id() (string, error) {
 
 func (c *mqlCommand) execute() (*os.Command, error) {
 	if !c.MotorRuntime.Motor.Provider.Capabilities().HasCapability(providers.Capability_RunCommand) {
-		return nil, errors.New("run command not supported on this transport")
+		return nil, errors.New("run command not supported on this provider")
 	}
 
 	osProvider, err := osProvider(c.MotorRuntime.Motor)


### PR DESCRIPTION
when used on a povider that does not allow to run commands, it returned an empty error:

```
cnspec> socketstats.openPorts
Query encountered errors:

socketstats.openPorts: []
```

Not it returns:

```
cnspec> socketstats.openPorts
Query encountered errors:
socketStats not supported on this provider
socketstats.openPorts: []
```