### PR TITLE
✨ Extend Berglas vault provider with opts.

### DIFF
--- a/motor/vault/config/vaultconfigstore.go
+++ b/motor/vault/config/vaultconfigstore.go
@@ -66,11 +66,16 @@ func New(vCfg *vault.VaultConfiguration) (vault.Vault, error) {
 	case vault.VaultType_GCPBerglas:
 		projectID := vCfg.Options["project-id"]
 		kmsKeyID := vCfg.Options["kms-key-id"]
+		bucketName := vCfg.Options["bucket-name"]
+		opts := []gcpberglas.Option{}
 		if kmsKeyID != "" {
-			v = gcpberglas.NewWithKey(projectID, &kmsKeyID)
-		} else {
-			v = gcpberglas.New(projectID)
+			opts = append(opts, gcpberglas.WithKmsKey(kmsKeyID))
 		}
+		if bucketName != "" {
+			opts = append(opts, gcpberglas.WithBucket(bucketName))
+		}
+		v = gcpberglas.New(projectID, opts...)
+
 	default:
 		return nil, errors.Errorf("could not connect to vault: %s (%s)", vCfg.Name, vCfg.Type.String())
 	}


### PR DESCRIPTION
 Add `WithBucket` and `WithKmsKeyId` opts to set the bucket and kms key to be used when using berglas for storing secrets. The vault now also returns the berglas key by using the passed in value and returning it in a formatted manner. This lets us inject the bucket to which we want data to be stored in an easier way, rather than relying on a passed in string.