### PR TITLE
🐛 print labels for variables inside of blocks

### DIFF
--- a/cli/printer/printer_test.go
+++ b/cli/printer/printer_test.go
@@ -312,6 +312,27 @@ func TestPrinter_Assessment(t *testing.T) {
 	})
 }
 
+func TestPrinter_Blocks(t *testing.T) {
+	runSimpleTests(t, []simpleTest{
+		{
+			"['a', 'b'] { x=_ \n x }",
+			"", // ignore
+			[]string{
+				strings.Join([]string{
+					"[",
+					"  0: {",
+					"    x: \"a\"",
+					"  }",
+					"  1: {",
+					"    x: \"b\"",
+					"  }",
+					"]",
+				}, "\n"),
+			},
+		},
+	})
+}
+
 func TestPrinter_Buggy(t *testing.T) {
 	runSimpleTests(t, []simpleTest{
 		{

--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -619,7 +619,9 @@ func (c *compiler) blockOnResource(expressions []*parser.Expression, typ types.T
 			return blockRefs{}, err
 		}
 	}
+
 	blockCompiler.updateEntrypoints(false)
+	blockCompiler.updateLabels()
 
 	return blockRefs{
 		block:        blockCompiler.blockRef,


### PR DESCRIPTION
**Problem**

I want to be able to assign variables in block to store specific values and then print them out accordingly with the proper label.

```javascript
cnquery> ['a', 'b'] { x = _ x }
[
  0: {
    x: "a"
  }
  1: {
    x: "b"
  }
]
```

**Solution**

We updated the output to generate labels for variables. It fixes https://github.com/mondoohq/cnquery/issues/574 updates reported by @chris-rock.

![image](https://user-images.githubusercontent.com/1307529/212834668-19efaeae-b0e1-480b-84b1-faa3f419a4a8.png)

![image](https://user-images.githubusercontent.com/1307529/212834741-99001d3c-a914-45b0-b797-1198d1667e8d.png)


Signed-off-by: Dominik Richter <dominik.richter@gmail.com>