### PR TITLE
🐛 fix var labels in comparable assertions in blocks

### DIFF
--- a/cli/printer/printer_test.go
+++ b/cli/printer/printer_test.go
@@ -201,7 +201,7 @@ func TestPrinter(t *testing.T) {
 		{
 			"a = 3\n if(true) {\n a == 3 \n}",
 			"-> block 1\n   entrypoints: [<1,2>]\n   1: 3\n   2: if bind: <0,0> type:block (true, => <2,0>, [\n     0: ref<1,1>\n   ])\n-> block 2\n   entrypoints: [<2,2>]\n   1: ref<1,1>\n   2: ==\x05 bind: <1,1> type:bool (3)\n",
-			[]string{"if: {\n   == 3: true\n}"},
+			[]string{"if: {\n  a == 3: true\n}"},
 		},
 		{
 			"mondoo",
@@ -325,6 +325,22 @@ func TestPrinter_Blocks(t *testing.T) {
 					"  }",
 					"  1: {",
 					"    x: \"b\"",
+					"  }",
+					"]",
+				}, "\n"),
+			},
+		},
+		{
+			"['a', 'b'] { x=_ \n x == 'a' }",
+			"", // ignore
+			[]string{
+				strings.Join([]string{
+					"[",
+					"  0: {",
+					"    x == \"a\": true",
+					"  }",
+					"  1: {",
+					"    x == \"a\": false",
 					"  }",
 					"]",
 				}, "\n"),

--- a/mqlc/labels.go
+++ b/mqlc/labels.go
@@ -17,18 +17,17 @@ func createLabel(res *llx.CodeBundle, ref uint64, schema *resources.Schema) (str
 	chunk := code.Chunk(ref)
 
 	if chunk.Call == llx.Chunk_PRIMITIVE {
-		if chunk.Primitive.Type != string(types.Ref) {
-			return "", nil
-		}
-
 		// In the case of refs, we want to check for the name of the variable,
 		// which is what every final ref should lead to
-		ref, ok := chunk.Primitive.RefV2()
-		if !ok {
-			return "", nil
+		if chunk.Primitive.Type == string(types.Ref) {
+			if deref, ok := chunk.Primitive.RefV2(); ok {
+				ref = deref
+			}
 		}
 
+		// TODO: better labels if we don't have it as a var
 		label := res.Vars[ref]
+
 		return label, nil
 	}
 


### PR DESCRIPTION
One more special case I had overlooked, kudos @chris-rock for the reminder.

Finalizes https://github.com/mondoohq/cnquery/issues/574

**Problem**

I have a query where I assign a value to a variable and then compare the variable e.g. `["a", "b"] { a=_ a=="a" }` The output is sub-optimal since I do not see anymore in the results which value it was compared to.

```javascript
cnquery> ["a", "b"] { a=_ a=="a" }
[
  0: {
     == "a": true
  }
  1: {
     == "a": false
  }
]
```

**Solution**

The new output includes the proper label of the variable:

```javascript
cnquery> ["a", "b"] { a=_ a=="a" }
[
  0: {
    a == "a": true
  }
  1: {
    a == "a": false
  }
]
```

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>