### PR TITLE
🧹 improve err msg for missing/incorrect github repo

### DIFF
--- a/motor/providers/github/platform.go
+++ b/motor/providers/github/platform.go
@@ -2,8 +2,8 @@ package github
 
 import (
 	"context"
-	"errors"
 
+	"github.com/cockroachdb/errors"
 	"github.com/google/go-github/v49/github"
 	"go.mondoo.com/cnquery/motor/platform"
 	"go.mondoo.com/cnquery/motor/providers"
@@ -47,7 +47,7 @@ func (p *Provider) PlatformInfo() (*platform.Platform, error) {
 		return GithubRepoPlatform, nil
 	}
 
-	return nil, errors.New("could not detect GitHub asset type")
+	return nil, errors.Wrap(err, "could not detect GitHub asset type")
 }
 
 func NewGithubOrgIdentifier(orgId string) string {


### PR DESCRIPTION
fixes https://github.com/mondoohq/cnspec/issues/226

```
[24/01/23 14:53:58] ❯ go run apps/cnspec/cnspec.go scan github repo Lunalectric/does-not-exist
zsh: correct 'github' to '.github' [nyae]? n
→ no Mondoo configuration file provided. using defaults
→ discover related assets for 1 asset(s)
→ resolved assets resolved-assets=0
x could not resolve asset error="could not detect GitHub asset type: GET https://api.github.com/repos/Lunalectric/does-not-exist: 404 Not Found []" asset=
FTL failed to run scan error="failed to resolve multiple assets"
exit status 1
```