### PR TITLE
🧹 Improve GCP connection error message

### DIFF
--- a/motor/providers/google/provider.go
+++ b/motor/providers/google/provider.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"go.mondoo.com/cnquery/motor/platform"
 	"go.mondoo.com/cnquery/motor/providers"
@@ -104,17 +105,20 @@ func New(pCfg *providers.Config) (*Provider, error) {
 	case Organization:
 		_, err := t.GetOrganization(id)
 		if err != nil {
-			return nil, errors.New("could not find or have no access to organization " + id)
+			log.Error().Err(err).Msgf("could not find or have no access to organization %s", id)
+			return nil, err
 		}
 	case Project:
 		_, err := t.GetProject(id)
 		if err != nil {
-			return nil, errors.New("could not find or have no access to project " + id)
+			log.Error().Err(err).Msgf("could not find or have no access to project %s", id)
+			return nil, err
 		}
 	case Workspace:
 		_, err := t.GetWorkspaceCustomer(id)
 		if err != nil {
-			return nil, errors.New("could not find or have no access to workspace " + id)
+			log.Error().Err(err).Msgf("could not find or have no access to workspace %s", id)
+			return nil, err
 		}
 		t.serviceAccountSubject = pCfg.Options["impersonated-user-email"]
 


### PR DESCRIPTION
We do not really show what the actual error is that prevented us from connecting to GCP. This PR makes sure that we bubble up the real error next to our own message

Old output:
```
./cnquery scan --inventory-file vault-inv.yml         
→ loaded configuration from /Users/ivanmilchev/.config/mondoo/mondoo.yml using source default
→ load inventory inventory-file=vault-inv.yml
→ using service account credentials
→ discover related assets for 1 asset(s)
→ resolved assets resolved-assets=0
x could not resolve asset error="could not find or have no access to project mondoo-dev-262313" asset=cool-stuff
FTL failed to run scan error="failed to resolve multiple assets"
```

New output:
```
./cnquery scan --inventory-file vault-inv.yml   
→ loaded configuration from /Users/ivanmilchev/.config/mondoo/mondoo.yml using source default
→ load inventory inventory-file=vault-inv.yml
→ using service account credentials
→ discover related assets for 1 asset(s)
x could not find or have no access to project mondoo-dev-262313 error="unsupported credential type: password"
→ resolved assets resolved-assets=0
x could not resolve asset error="unsupported credential type: password" asset=cool-stuff
FTL failed to run scan error="failed to resolve multiple assets"
```