### PR TITLE
🐛 Use consistent k8s resource version label

### DIFF
--- a/motor/discovery/k8s/asset_data.go
+++ b/motor/discovery/k8s/asset_data.go
@@ -140,7 +140,7 @@ func addMondooAssetLabels(assetLabels map[string]string, objMeta v1.Object, objT
 	assetLabels["k8s.mondoo.com/apiVersion"] = objType.GetAPIVersion()
 	if objMeta.GetResourceVersion() != "" {
 		// objects discovered from manifest do not necessarily have a resource version
-		assetLabels["k8s.mondoo.com/resourceVersion"] = objMeta.GetResourceVersion()
+		assetLabels["k8s.mondoo.com/resource-version"] = objMeta.GetResourceVersion()
 	}
 	assetLabels["k8s.mondoo.com/cluster-id"] = clusterIdentifier
 


### PR DESCRIPTION
Fixes #647

The double labeling described in #647 is present only for k8s admission controller scans. That is because the admission controller labels objects with `k8s.mondoo.com/resource-version` and cnquery does that with `k8s.mondoo.com/resourceVersion`. Since we parse `k8s.mondoo.com/resource-version` to `Resource Version` in the UI I picked that one to be the label for resource version. Making it consistent between cnquery and the operator means that there will be just 1 label on the scanned assets