### PR TITLE
🐛 fix mql hangs with aliased and direct resource in the same policy

### DIFF
--- a/resources/runtime.go
+++ b/resources/runtime.go
@@ -148,26 +148,26 @@ func (ctx *Runtime) createMockResource(name string, cls *ResourceCls) (ResourceT
 	return res, nil
 }
 
-func (ctx *Runtime) lookupResource(name string) (*ResourceCls, error) {
+func (ctx *Runtime) lookupResource(name string) (*ResourceCls, string, error) {
 	for {
 		r := ctx.Registry.Resources[name]
 		if r == nil {
-			return nil, errors.New("cannot find resource '" + name + "'")
+			return nil, name, errors.New("cannot find resource '" + name + "'")
 		} else if r.Factory != nil {
-			return r, nil
+			return r, name, nil
 		} else if r.Name != name {
 			// A resource was given an alias. Look up through aliases
 			name = r.Name
 		} else {
 			// We found a resource with a factory
-			return nil, errors.New("cannot find resource factory for '" + name + "'")
+			return nil, name, errors.New("cannot find resource factory for '" + name + "'")
 		}
 	}
 }
 
 // CreateResourceWithID creates a new resource instance and force it to have a certain ID
 func (ctx *Runtime) CreateResourceWithID(name string, id string, args ...interface{}) (ResourceType, error) {
-	r, err := ctx.lookupResource(name)
+	r, name, err := ctx.lookupResource(name)
 	if err != nil {
 		return nil, err
 	}

--- a/resources/runtime.go
+++ b/resources/runtime.go
@@ -171,6 +171,9 @@ func (ctx *Runtime) CreateResourceWithID(name string, id string, args ...interfa
 	if err != nil {
 		return nil, err
 	}
+	// We could have looked up an aliased resource. We need to correct the name
+	// for caching
+	name = r.Name
 
 	argsMap, err := args2map(args)
 	if err != nil {


### PR DESCRIPTION
Example policy that causes things to hang
```
policies:
  - uid: testpolicy3
    name: Test Policy 3
    version: 0.10.1
    is_public: false
    scoring_system: 2
    tags:
      stability: "testing"
    specs:
      - asset_filter:
          query: |
            true == true
        scoring_queries:
          jay-scoring-query-2:
          jay-scoring-query-3:
queries:
  - uid: jay-scoring-query-2
    title: test it 1
    severity: 10
    query: |
      file("foo").content
  - uid: jay-scoring-query-3
    title: test it 2
    severity: 10
    query: |
      os.base.file("foo").content
```

The issue lies in the fact that the cache key used by some of the observer code differs from the runtime code that caches the resources. The observer thinks its already seen a resource, so it must already be computed (or will be computed). However, the runtime code cached it using the aliased name. It then tries to ask the resources cache to look up a field, which is empty because its basically treated as a different resource that needs to be computed.