### PR TITLE
🧹 fallback to noop progress bar if fail to create progress bar

### DIFF
--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -201,7 +201,8 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstreamConf
 	if isatty.IsTerminal(os.Stdout.Fd()) && !strings.EqualFold(logger.GetLevel(), "debug") && !strings.EqualFold(logger.GetLevel(), "trace") {
 		multiprogress, err = progress.NewMultiProgressBars(progressBarElements, orderedKeys)
 		if err != nil {
-			return nil, false, errors.Wrap(err, "failed to create progress bars")
+			log.Error().Err(err).Msg("failed to create progress bars; using noop progress bar")
+			multiprogress = progress.NoopMultiProgressBars{}
 		}
 	} else {
 		// TODO: adjust naming

--- a/motor/discovery/aws/resolver.go
+++ b/motor/discovery/aws/resolver.go
@@ -107,7 +107,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 		log.Debug().Int("instances", len(assetList)).Msg("completed ssm instance search")
 		for i := range assetList {
 			a := assetList[i]
-			if resolvedRoot != nil {
+			if resolvedRoot != nil && a != nil {
 				a.RelatedAssets = append(a.RelatedAssets, resolvedRoot)
 			}
 			log.Debug().Str("name", a.Name).Str("region", a.Labels[RegionLabel]).Str("state", strings.ToLower(a.State.String())).Msg("resolved ssm instance")
@@ -131,7 +131,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 		log.Debug().Int("instances", len(assetList)).Bool("insecure", r.Insecure).Msg("completed instance search")
 		for i := range assetList {
 			a := assetList[i]
-			if resolvedRoot != nil {
+			if resolvedRoot != nil && a != nil {
 				a.RelatedAssets = append(a.RelatedAssets, resolvedRoot)
 			}
 			log.Debug().Str("name", a.Name).Str("region", a.Labels[RegionLabel]).Str("state", strings.ToLower(a.State.String())).Msg("resolved ec2 instance")
@@ -168,7 +168,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 		log.Debug().Int("images", len(assetList)).Msg("completed ecr search")
 		for i := range assetList {
 			a := assetList[i]
-			if resolvedRoot != nil {
+			if resolvedRoot != nil && a != nil {
 				a.RelatedAssets = append(a.RelatedAssets, resolvedRoot)
 			}
 			resolved = append(resolved, a)
@@ -188,7 +188,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 		log.Debug().Int("assets", len(assetList)).Msg("completed ecs search")
 		for i := range assetList {
 			a := assetList[i]
-			if resolvedRoot != nil {
+			if resolvedRoot != nil && a != nil {
 				a.RelatedAssets = append(a.RelatedAssets, resolvedRoot)
 			}
 			resolved = append(resolved, a)


### PR DESCRIPTION
i ran into an issue where i got

`FTL failed to run scan error="failed to create progress bars: number of elements and orderedKeys must be equal"` (i think an asset wasn't being initialised correctly). 

seems like we can just log and use the noop progress bar if something fails
