### PR TITLE
🐛Only request project-id from gcloud cli if its not in the options.

### DIFF
--- a/motor/discovery/gcp/resolver_gcp.go
+++ b/motor/discovery/gcp/resolver_gcp.go
@@ -37,7 +37,7 @@ func (r *GcpResolver) Resolve(ctx context.Context, root *asset.Asset, tc *provid
 		// when the user has not provided a project, check if we got a project or try to determine it
 		// FIXME: DEPRECATED, update in v8.0 vv
 		// The option "project" has been deprecated in favor of project-id
-		if tc.Options == nil || (tc.Options["project"] == "" || tc.Options["project-id"] != "") {
+		if tc.Options == nil || (tc.Options["project"] == "" && tc.Options["project-id"] == "") {
 			// ^^
 			// try to determine current project
 			projectid, err := gcp_provider.GetCurrentProject()


### PR DESCRIPTION
Only call the gcloud cli if both `project` and `project-id` are empty.