### PR TITLE
🐛 Make sure GCP kind remains api instead of gcp-object

### DIFF
--- a/motor/providers/google/provider.go
+++ b/motor/providers/google/provider.go
@@ -182,7 +182,7 @@ func (p *Provider) PlatformIdDetectors() []providers.PlatformIdDetector {
 }
 
 func (p *Provider) PlatformInfo() (*platform.Platform, error) {
-	if p.platformOverride != "" {
+	if p.platformOverride != "" && p.platformOverride != "gcp" {
 		return &platform.Platform{
 			Name:    p.platformOverride,
 			Title:   getTitleForPlatformName(p.platformOverride),


### PR DESCRIPTION
The root `gcp` asset got kind `api`. That was not intentional as it should still remain `api`