### PR TITLE
🧹 Resolve secret for each provider config in GCP

### DIFF
--- a/motor/discovery/gcp/resolver_project.go
+++ b/motor/discovery/gcp/resolver_project.go
@@ -51,11 +51,6 @@ func (r *GcpProjectResolver) Resolve(ctx context.Context, tc *providers.Config, 
 		return nil, errors.New("could not create gcp provider")
 	}
 
-	// If there is a service account provided in the inventory, resolve it and then copy it to the provider config we use
-	if len(tc.Credentials) != 0 {
-		tc.Credentials[0] = provider.GetCredential()
-	}
-
 	identifier, err := provider.Identifier()
 	if err != nil {
 		return nil, err
@@ -95,7 +90,7 @@ func (r *GcpProjectResolver) Resolve(ctx context.Context, tc *providers.Config, 
 		DiscoveryGkeClusters,
 		DiscoveryStorageBuckets,
 		DiscoveryBigQueryDatasets) {
-		assetList, err := GatherAssets(tc, project)
+		assetList, err := GatherAssets(ctx, tc, project, cfn)
 		if err != nil {
 			return nil, err
 		}

--- a/motor/providers/google/provider.go
+++ b/motor/providers/google/provider.go
@@ -10,7 +10,6 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/os/fsutil"
 	"go.mondoo.com/cnquery/motor/vault"
-	"google.golang.org/protobuf/proto"
 )
 
 var (
@@ -142,10 +141,6 @@ type Provider struct {
 	serviceAccountSubject string
 	cred                  *vault.Credential
 	platformOverride      string
-}
-
-func (p *Provider) GetCredential() *vault.Credential {
-	return proto.Clone(p.cred).(*vault.Credential)
 }
 
 func (p *Provider) FS() afero.Fs {


### PR DESCRIPTION
Initially, the idea was to copy the resolved secret over to the cloned provider configs. That is not ideal since it requires other changes as well. After a discussion with @chris-rock we concluded that resolving secrets multiple times is a vault problem, not a provider problem. This PR makes sure that scanning GCP assets work. In a follow up PR I will address the issue with the retrieval of the same secret multiple times.