### PR TITLE
✨ Allow caching credentials in memory 

### DIFF
--- a/apps/cnquery/cmd/shell_run.go
+++ b/apps/cnquery/cmd/shell_run.go
@@ -17,6 +17,7 @@ import (
 	"go.mondoo.com/cnquery/motor/inventory"
 	v1 "go.mondoo.com/cnquery/motor/inventory/v1"
 	provider_resolver "go.mondoo.com/cnquery/motor/providers/resolver"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 	"go.mondoo.com/cnquery/resources"
 )
 
@@ -44,7 +45,8 @@ func StartShell(conf *ShellConfig) error {
 	if err != nil {
 		log.Fatal().Err(err).Msg("could not load asset information")
 	}
-	assetErrors := im.Resolve(ctx)
+	credsResolver := credentials_resolver.New(im.GetVault(), true)
+	assetErrors := im.Resolve(ctx, credsResolver)
 	if len(assetErrors) > 0 {
 		for a := range assetErrors {
 			log.Error().Err(assetErrors[a]).Str("asset", a.Name).Msg("could not connect to asset")
@@ -81,7 +83,7 @@ func StartShell(conf *ShellConfig) error {
 		log.Fatal().Msg("no asset selected")
 	}
 
-	m, err := provider_resolver.OpenAssetConnection(ctx, connectAsset, im.GetCredential, conf.DoRecord)
+	m, err := provider_resolver.OpenAssetConnection(ctx, connectAsset, credsResolver, conf.DoRecord)
 	if err != nil {
 		log.Fatal().Err(err).Msg("could not connect to asset")
 	}

--- a/explorer/scan/scan.go
+++ b/explorer/scan/scan.go
@@ -9,7 +9,7 @@ import (
 	"go.mondoo.com/cnquery/explorer"
 	"go.mondoo.com/cnquery/motor"
 	"go.mondoo.com/cnquery/motor/asset"
-	"go.mondoo.com/cnquery/motor/vault"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 	"go.mondoo.com/cnquery/resources"
 )
 
@@ -27,7 +27,7 @@ type AssetJob struct {
 	QueryPackFilters []string
 	Props            map[string]string
 	Ctx              context.Context
-	GetCredential    func(cred *vault.Credential) (*vault.Credential, error)
+	CredsResolver    credentials_resolver.Resolver
 	Reporter         Reporter
 	connection       *motor.Motor
 	ProgressReporter progress.Progress

--- a/explorer/scan/scan.go
+++ b/explorer/scan/scan.go
@@ -9,7 +9,7 @@ import (
 	"go.mondoo.com/cnquery/explorer"
 	"go.mondoo.com/cnquery/motor"
 	"go.mondoo.com/cnquery/motor/asset"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 	"go.mondoo.com/cnquery/resources"
 )
 
@@ -27,7 +27,7 @@ type AssetJob struct {
 	QueryPackFilters []string
 	Props            map[string]string
 	Ctx              context.Context
-	CredsResolver    credentials_resolver.Resolver
+	CredsResolver    vault.Resolver
 	Reporter         Reporter
 	connection       *motor.Motor
 	ProgressReporter progress.Progress

--- a/motor/discovery/aws/ebs/resolver.go
+++ b/motor/discovery/aws/ebs/resolver.go
@@ -7,7 +7,7 @@ import (
 	"go.mondoo.com/cnquery/motor/discovery/aws"
 	"go.mondoo.com/cnquery/motor/discovery/common"
 	"go.mondoo.com/cnquery/motor/providers"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 type Resolver struct{}
@@ -20,7 +20,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	pCfg.Backend = providers.ProviderType_AWS_EC2_EBS
 	assetInfo := &asset.Asset{
 		Name:        pCfg.Options["id"],

--- a/motor/discovery/aws/ebs/resolver.go
+++ b/motor/discovery/aws/ebs/resolver.go
@@ -7,6 +7,7 @@ import (
 	"go.mondoo.com/cnquery/motor/discovery/aws"
 	"go.mondoo.com/cnquery/motor/discovery/common"
 	"go.mondoo.com/cnquery/motor/providers"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 type Resolver struct{}
@@ -19,7 +20,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	pCfg.Backend = providers.ProviderType_AWS_EC2_EBS
 	assetInfo := &asset.Asset{
 		Name:        pCfg.Options["id"],

--- a/motor/discovery/aws/resolver.go
+++ b/motor/discovery/aws/resolver.go
@@ -12,6 +12,7 @@ import (
 	"go.mondoo.com/cnquery/motor/platform/detector"
 	"go.mondoo.com/cnquery/motor/providers"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 const (
@@ -71,7 +72,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return discovery
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	// add aws api as asset

--- a/motor/discovery/aws/resolver.go
+++ b/motor/discovery/aws/resolver.go
@@ -12,7 +12,7 @@ import (
 	"go.mondoo.com/cnquery/motor/platform/detector"
 	"go.mondoo.com/cnquery/motor/providers"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 const (
@@ -72,7 +72,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return discovery
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	// add aws api as asset

--- a/motor/discovery/azure/resolver.go
+++ b/motor/discovery/azure/resolver.go
@@ -12,6 +12,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	microsoft "go.mondoo.com/cnquery/motor/providers/microsoft"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 const (
@@ -29,7 +30,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll, DiscoverySubscriptions, DiscoveryInstances}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 	subscriptionID := tc.Options["subscription-id"]
 	clientId := tc.Options["client-id"]
@@ -48,7 +49,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 		subsToExclude = append(subsToExclude, strings.Split(subscriptionsExclude, ",")...)
 	}
 	// Note: we use the resolver instead of the direct azure_provider.New to resolve credentials properly
-	m, err := resolver.NewMotorConnection(ctx, tc, cfn)
+	m, err := resolver.NewMotorConnection(ctx, tc, credsResolver)
 	if err != nil {
 		return nil, err
 	}

--- a/motor/discovery/azure/resolver.go
+++ b/motor/discovery/azure/resolver.go
@@ -12,7 +12,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	microsoft "go.mondoo.com/cnquery/motor/providers/microsoft"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 const (
@@ -30,7 +30,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll, DiscoverySubscriptions, DiscoveryInstances}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 	subscriptionID := tc.Options["subscription-id"]
 	clientId := tc.Options["client-id"]

--- a/motor/discovery/common/credentials.go
+++ b/motor/discovery/common/credentials.go
@@ -9,7 +9,7 @@ import (
 
 type (
 	// CredentialFn retrieves the credentials to connect to the platform
-	CredentialFn func(cred *vault.Credential) (*vault.Credential, error)
+	// CredentialFn func(cred *vault.Credential) (*vault.Credential, error)
 	// QuerySecretFn is used during discovery phase to identify a secret for an asset
 	QuerySecretFn func(a *asset.Asset) (*vault.Credential, error)
 )

--- a/motor/discovery/common/credentials.go
+++ b/motor/discovery/common/credentials.go
@@ -8,8 +8,6 @@ import (
 )
 
 type (
-	// CredentialFn retrieves the credentials to connect to the platform
-	// CredentialFn func(cred *vault.Credential) (*vault.Credential, error)
 	// QuerySecretFn is used during discovery phase to identify a secret for an asset
 	QuerySecretFn func(a *asset.Asset) (*vault.Credential, error)
 )

--- a/motor/discovery/container_registry/resolver.go
+++ b/motor/discovery/container_registry/resolver.go
@@ -13,6 +13,7 @@ import (
 	"go.mondoo.com/cnquery/motor/discovery/common"
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/vault"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 type Resolver struct {
@@ -30,7 +31,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	imageFetcher := NewContainerRegistryResolver()
@@ -49,7 +50,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *provide
 	if err == nil {
 		log.Debug().Str("image", pCfg.Host).Msg("detected container image in container registry")
 
-		remoteOpts := AuthOption(pCfg.Credentials, cfn)
+		remoteOpts := AuthOption(pCfg.Credentials, credsResolver)
 		// we need to disable default keychain auth if an auth method was found
 		if len(remoteOpts) > 0 {
 			imageFetcher.DisableKeychainAuth = true
@@ -101,14 +102,14 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *provide
 	return resolved, nil
 }
 
-func AuthOption(credentials []*vault.Credential, cfn common.CredentialFn) []remote.Option {
+func AuthOption(credentials []*vault.Credential, credsResolver credentials_resolver.Resolver) []remote.Option {
 	remoteOpts := []remote.Option{}
 	for i := range credentials {
 		cred := credentials[i]
 
 		// NOTE: normally the motor connection is resolving the credentials but here we need the credential earlier
 		// we probably want to write some mql resources to support the query of registries itself
-		resolvedCredential, err := cfn(cred)
+		resolvedCredential, err := credsResolver.GetCredential(cred)
 		if err != nil {
 			log.Warn().Err(err).Msg("could not resolve credential")
 		}

--- a/motor/discovery/container_registry/resolver.go
+++ b/motor/discovery/container_registry/resolver.go
@@ -13,7 +13,6 @@ import (
 	"go.mondoo.com/cnquery/motor/discovery/common"
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/vault"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 type Resolver struct {
@@ -31,7 +30,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	imageFetcher := NewContainerRegistryResolver()
@@ -102,7 +101,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *provide
 	return resolved, nil
 }
 
-func AuthOption(credentials []*vault.Credential, credsResolver credentials_resolver.Resolver) []remote.Option {
+func AuthOption(credentials []*vault.Credential, credsResolver vault.Resolver) []remote.Option {
 	remoteOpts := []remote.Option{}
 	for i := range credentials {
 		cred := credentials[i]

--- a/motor/discovery/docker_engine/resolver.go
+++ b/motor/discovery/docker_engine/resolver.go
@@ -13,7 +13,7 @@ import (
 	"go.mondoo.com/cnquery/motor/platform"
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/tar"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 const (
@@ -31,7 +31,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll, DiscoveryContainerRunning, DiscoveryContainerImages}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	if pCfg == nil {
 		return nil, errors.New("no transport configuration found")
 	}
@@ -163,7 +163,7 @@ func (k *Resolver) container(ctx context.Context, root *asset.Asset, pCfg *provi
 	}, nil
 }
 
-func (k *Resolver) images(ctx context.Context, root *asset.Asset, pCfg *providers.Config, ded *dockerEngineDiscovery, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn) ([]*asset.Asset, error) {
+func (k *Resolver) images(ctx context.Context, root *asset.Asset, pCfg *providers.Config, ded *dockerEngineDiscovery, credsResolver vault.Resolver, sfn common.QuerySecretFn) ([]*asset.Asset, error) {
 	// if we have a docker engine available, try to fetch it from there
 	if ded != nil {
 		ii, err := ded.ImageInfo(pCfg.Host)

--- a/motor/discovery/docker_engine/resolver.go
+++ b/motor/discovery/docker_engine/resolver.go
@@ -13,6 +13,7 @@ import (
 	"go.mondoo.com/cnquery/motor/platform"
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/tar"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 const (
@@ -30,7 +31,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll, DiscoveryContainerRunning, DiscoveryContainerImages}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	if pCfg == nil {
 		return nil, errors.New("no transport configuration found")
 	}
@@ -91,7 +92,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *provide
 
 	if pCfg.Backend == providers.ProviderType_DOCKER_ENGINE_IMAGE {
 		// NOTE, we ignore dockerEngErr here since we fallback to pulling the images directly
-		resolvedAssets, err := r.images(ctx, root, pCfg, ded, cfn, sfn)
+		resolvedAssets, err := r.images(ctx, root, pCfg, ded, credsResolver, sfn)
 		if err != nil {
 			return nil, err
 		}
@@ -119,7 +120,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *provide
 		}
 	}
 
-	containerImageAssets, err := r.images(ctx, root, pCfg, ded, cfn, sfn)
+	containerImageAssets, err := r.images(ctx, root, pCfg, ded, credsResolver, sfn)
 	if err == nil {
 		return containerImageAssets, nil
 	}
@@ -162,7 +163,7 @@ func (k *Resolver) container(ctx context.Context, root *asset.Asset, pCfg *provi
 	}, nil
 }
 
-func (k *Resolver) images(ctx context.Context, root *asset.Asset, pCfg *providers.Config, ded *dockerEngineDiscovery, cfn common.CredentialFn, sfn common.QuerySecretFn) ([]*asset.Asset, error) {
+func (k *Resolver) images(ctx context.Context, root *asset.Asset, pCfg *providers.Config, ded *dockerEngineDiscovery, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn) ([]*asset.Asset, error) {
 	// if we have a docker engine available, try to fetch it from there
 	if ded != nil {
 		ii, err := ded.ImageInfo(pCfg.Host)
@@ -194,7 +195,7 @@ func (k *Resolver) images(ctx context.Context, root *asset.Asset, pCfg *provider
 	rr := container_registry.Resolver{
 		NoStrictValidation: true,
 	}
-	return rr.Resolve(ctx, root, pCfg, cfn, sfn)
+	return rr.Resolve(ctx, root, pCfg, credsResolver, sfn)
 }
 
 func DiscoverDockerEngineAssets(pCfg *providers.Config) ([]*asset.Asset, error) {

--- a/motor/discovery/equinix/resolver.go
+++ b/motor/discovery/equinix/resolver.go
@@ -8,6 +8,7 @@ import (
 	"go.mondoo.com/cnquery/motor/platform/detector"
 	"go.mondoo.com/cnquery/motor/providers"
 	equinix_provider "go.mondoo.com/cnquery/motor/providers/equinix"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 type Resolver struct{}
@@ -20,7 +21,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, t *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, t *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	// add aws api as asset

--- a/motor/discovery/equinix/resolver.go
+++ b/motor/discovery/equinix/resolver.go
@@ -8,7 +8,7 @@ import (
 	"go.mondoo.com/cnquery/motor/platform/detector"
 	"go.mondoo.com/cnquery/motor/providers"
 	equinix_provider "go.mondoo.com/cnquery/motor/providers/equinix"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 type Resolver struct{}
@@ -21,7 +21,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, t *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, t *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	// add aws api as asset

--- a/motor/discovery/gcp/mql_assets.go
+++ b/motor/discovery/gcp/mql_assets.go
@@ -15,6 +15,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	gcpprovider "go.mondoo.com/cnquery/motor/providers/google"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 	"go.mondoo.com/cnquery/mql"
 	"go.mondoo.com/cnquery/resources"
 	resource_pack "go.mondoo.com/cnquery/resources/packs/gcp"
@@ -56,11 +57,11 @@ func (md *MqlDiscovery) GetList(query string) []interface{} {
 	return a
 }
 
-func GatherAssets(ctx context.Context, tc *providers.Config, project string, cfn common.CredentialFn) ([]*asset.Asset, error) {
+func GatherAssets(ctx context.Context, tc *providers.Config, project string, credsResolver credentials_resolver.Resolver) ([]*asset.Asset, error) {
 	assets := []*asset.Asset{}
 	// Note: we use the resolver instead of the direct gcp_provider.New to resolve credentials properly
 	pCfg := tc.Clone()
-	motor, err := resolver.NewMotorConnection(ctx, pCfg, cfn)
+	motor, err := resolver.NewMotorConnection(ctx, pCfg, credsResolver)
 	if err != nil {
 		return nil, err
 	}

--- a/motor/discovery/gcp/mql_assets.go
+++ b/motor/discovery/gcp/mql_assets.go
@@ -15,7 +15,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	gcpprovider "go.mondoo.com/cnquery/motor/providers/google"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 	"go.mondoo.com/cnquery/mql"
 	"go.mondoo.com/cnquery/resources"
 	resource_pack "go.mondoo.com/cnquery/resources/packs/gcp"
@@ -57,7 +57,7 @@ func (md *MqlDiscovery) GetList(query string) []interface{} {
 	return a
 }
 
-func GatherAssets(ctx context.Context, tc *providers.Config, project string, credsResolver credentials_resolver.Resolver) ([]*asset.Asset, error) {
+func GatherAssets(ctx context.Context, tc *providers.Config, project string, credsResolver vault.Resolver) ([]*asset.Asset, error) {
 	assets := []*asset.Asset{}
 	// Note: we use the resolver instead of the direct gcp_provider.New to resolve credentials properly
 	pCfg := tc.Clone()

--- a/motor/discovery/gcp/resolver_gcp.go
+++ b/motor/discovery/gcp/resolver_gcp.go
@@ -8,6 +8,7 @@ import (
 	"go.mondoo.com/cnquery/motor/discovery/common"
 	"go.mondoo.com/cnquery/motor/providers"
 	gcp_provider "go.mondoo.com/cnquery/motor/providers/google"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 type GcpResolver struct{}
@@ -26,13 +27,13 @@ func (r *GcpResolver) AvailableDiscoveryTargets() []string {
 	}
 }
 
-func (r *GcpResolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *GcpResolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	// FIXME: DEPRECATED, update in v8.0 vv
 	// The option "organization" has been deprecated in favor of organization-id
 	if tc.Options != nil && (tc.Options["organization"] != "" || tc.Options["organization-id"] != "") {
 		// ^^
 		// discover the full organization
-		return (&GcpOrgResolver{}).Resolve(ctx, tc, cfn, sfn, userIdDetectors...)
+		return (&GcpOrgResolver{}).Resolve(ctx, tc, credsResolver, sfn, userIdDetectors...)
 	} else {
 		// when the user has not provided a project, check if we got a project or try to determine it
 		// FIXME: DEPRECATED, update in v8.0 vv
@@ -51,6 +52,6 @@ func (r *GcpResolver) Resolve(ctx context.Context, root *asset.Asset, tc *provid
 		}
 
 		// assume it is the local project
-		return (&GcpProjectResolver{}).Resolve(ctx, tc, cfn, sfn, userIdDetectors...)
+		return (&GcpProjectResolver{}).Resolve(ctx, tc, credsResolver, sfn, userIdDetectors...)
 	}
 }

--- a/motor/discovery/gcp/resolver_gcp.go
+++ b/motor/discovery/gcp/resolver_gcp.go
@@ -8,7 +8,7 @@ import (
 	"go.mondoo.com/cnquery/motor/discovery/common"
 	"go.mondoo.com/cnquery/motor/providers"
 	gcp_provider "go.mondoo.com/cnquery/motor/providers/google"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 type GcpResolver struct{}
@@ -27,7 +27,7 @@ func (r *GcpResolver) AvailableDiscoveryTargets() []string {
 	}
 }
 
-func (r *GcpResolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *GcpResolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	// FIXME: DEPRECATED, update in v8.0 vv
 	// The option "organization" has been deprecated in favor of organization-id
 	if tc.Options != nil && (tc.Options["organization"] != "" || tc.Options["organization-id"] != "") {

--- a/motor/discovery/gcp/resolver_gcr.go
+++ b/motor/discovery/gcp/resolver_gcr.go
@@ -7,6 +7,7 @@ import (
 	"go.mondoo.com/cnquery/motor/asset"
 	"go.mondoo.com/cnquery/motor/discovery/common"
 	"go.mondoo.com/cnquery/motor/providers"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 type GcrResolver struct{}
@@ -19,7 +20,7 @@ func (r *GcrResolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *GcrResolver) Resolve(ctx context.Context, root *asset.Asset, t *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *GcrResolver) Resolve(ctx context.Context, root *asset.Asset, t *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 	repository := t.Host
 

--- a/motor/discovery/gcp/resolver_gcr.go
+++ b/motor/discovery/gcp/resolver_gcr.go
@@ -7,7 +7,7 @@ import (
 	"go.mondoo.com/cnquery/motor/asset"
 	"go.mondoo.com/cnquery/motor/discovery/common"
 	"go.mondoo.com/cnquery/motor/providers"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 type GcrResolver struct{}
@@ -20,7 +20,7 @@ func (r *GcrResolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *GcrResolver) Resolve(ctx context.Context, root *asset.Asset, t *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *GcrResolver) Resolve(ctx context.Context, root *asset.Asset, t *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 	repository := t.Host
 

--- a/motor/discovery/gcp/resolver_org.go
+++ b/motor/discovery/gcp/resolver_org.go
@@ -7,7 +7,7 @@ import (
 	"go.mondoo.com/cnquery/motor/discovery/common"
 	"go.mondoo.com/cnquery/motor/providers"
 	gcp_provider "go.mondoo.com/cnquery/motor/providers/google"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 type GcpOrgResolver struct{}
@@ -20,7 +20,7 @@ func (r *GcpOrgResolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll, DiscoveryProjects}
 }
 
-func (r *GcpOrgResolver) Resolve(ctx context.Context, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *GcpOrgResolver) Resolve(ctx context.Context, tc *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	// FIXME: DEPRECATED, update in v8.0 vv

--- a/motor/discovery/gcp/resolver_org.go
+++ b/motor/discovery/gcp/resolver_org.go
@@ -7,6 +7,7 @@ import (
 	"go.mondoo.com/cnquery/motor/discovery/common"
 	"go.mondoo.com/cnquery/motor/providers"
 	gcp_provider "go.mondoo.com/cnquery/motor/providers/google"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 type GcpOrgResolver struct{}
@@ -19,7 +20,7 @@ func (r *GcpOrgResolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll, DiscoveryProjects}
 }
 
-func (r *GcpOrgResolver) Resolve(ctx context.Context, tc *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *GcpOrgResolver) Resolve(ctx context.Context, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	// FIXME: DEPRECATED, update in v8.0 vv
@@ -78,7 +79,7 @@ func (r *GcpOrgResolver) Resolve(ctx context.Context, tc *providers.Config, cfn 
 				"project-id": project.ProjectId,
 			}
 
-			assets, err := (&GcpProjectResolver{}).Resolve(ctx, projectConfig, cfn, sfn, userIdDetectors...)
+			assets, err := (&GcpProjectResolver{}).Resolve(ctx, projectConfig, credsResolver, sfn, userIdDetectors...)
 			if err != nil {
 				return nil, err
 			}

--- a/motor/discovery/gcp/resolver_project.go
+++ b/motor/discovery/gcp/resolver_project.go
@@ -11,6 +11,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	gcp_provider "go.mondoo.com/cnquery/motor/providers/google"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 	"google.golang.org/api/compute/v1"
 )
 
@@ -30,7 +31,7 @@ func (r *GcpProjectResolver) AvailableDiscoveryTargets() []string {
 	}
 }
 
-func (r *GcpProjectResolver) Resolve(ctx context.Context, tc *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *GcpProjectResolver) Resolve(ctx context.Context, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	// FIXME: DEPRECATED, update in v8.0 vv
@@ -41,7 +42,7 @@ func (r *GcpProjectResolver) Resolve(ctx context.Context, tc *providers.Config, 
 	}
 
 	// Note: we use the resolver instead of the direct gcp_provider.New to resolve credentials properly
-	m, err := resolver.NewMotorConnection(ctx, tc, cfn)
+	m, err := resolver.NewMotorConnection(ctx, tc, credsResolver)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +91,7 @@ func (r *GcpProjectResolver) Resolve(ctx context.Context, tc *providers.Config, 
 		DiscoveryGkeClusters,
 		DiscoveryStorageBuckets,
 		DiscoveryBigQueryDatasets) {
-		assetList, err := GatherAssets(ctx, tc, project, cfn)
+		assetList, err := GatherAssets(ctx, tc, project, credsResolver)
 		if err != nil {
 			return nil, err
 		}

--- a/motor/discovery/gcp/resolver_project.go
+++ b/motor/discovery/gcp/resolver_project.go
@@ -11,7 +11,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	gcp_provider "go.mondoo.com/cnquery/motor/providers/google"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 	"google.golang.org/api/compute/v1"
 )
 
@@ -31,7 +31,7 @@ func (r *GcpProjectResolver) AvailableDiscoveryTargets() []string {
 	}
 }
 
-func (r *GcpProjectResolver) Resolve(ctx context.Context, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *GcpProjectResolver) Resolve(ctx context.Context, tc *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	// FIXME: DEPRECATED, update in v8.0 vv

--- a/motor/discovery/github/github.go
+++ b/motor/discovery/github/github.go
@@ -12,7 +12,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	github_provider "go.mondoo.com/cnquery/motor/providers/github"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 const (
@@ -31,7 +31,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll, DiscoveryRepository, DiscoveryUser}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	// establish connection to GitHub
 	m, err := resolver.NewMotorConnection(ctx, pCfg, credsResolver)
 	if err != nil {

--- a/motor/discovery/github/github.go
+++ b/motor/discovery/github/github.go
@@ -12,6 +12,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	github_provider "go.mondoo.com/cnquery/motor/providers/github"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 const (
@@ -30,9 +31,9 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll, DiscoveryRepository, DiscoveryUser}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	// establish connection to GitHub
-	m, err := resolver.NewMotorConnection(ctx, pCfg, cfn)
+	m, err := resolver.NewMotorConnection(ctx, pCfg, credsResolver)
 	if err != nil {
 		return nil, err
 	}

--- a/motor/discovery/gitlab/gitlab.go
+++ b/motor/discovery/gitlab/gitlab.go
@@ -9,6 +9,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	gitlab_transport "go.mondoo.com/cnquery/motor/providers/gitlab"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 const DiscoveryGroup = "group"
@@ -23,9 +24,9 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll, DiscoveryGroup}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	// establish connection to GitLab
-	m, err := resolver.NewMotorConnection(ctx, tc, cfn)
+	m, err := resolver.NewMotorConnection(ctx, tc, credsResolver)
 	if err != nil {
 		return nil, err
 	}

--- a/motor/discovery/gitlab/gitlab.go
+++ b/motor/discovery/gitlab/gitlab.go
@@ -9,7 +9,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	gitlab_transport "go.mondoo.com/cnquery/motor/providers/gitlab"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 const DiscoveryGroup = "group"
@@ -24,7 +24,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll, DiscoveryGroup}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	// establish connection to GitLab
 	m, err := resolver.NewMotorConnection(ctx, tc, credsResolver)
 	if err != nil {

--- a/motor/discovery/googleworkspace/googleworkspace.go
+++ b/motor/discovery/googleworkspace/googleworkspace.go
@@ -9,6 +9,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	google_provider "go.mondoo.com/cnquery/motor/providers/google"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 type Resolver struct{}
@@ -21,11 +22,11 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, cc *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, cc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	// Note: we use the resolver instead of the direct ms365_provider.New to resolve credentials properly
-	m, err := resolver.NewMotorConnection(ctx, cc, cfn)
+	m, err := resolver.NewMotorConnection(ctx, cc, credsResolver)
 	if err != nil {
 		return nil, err
 	}

--- a/motor/discovery/googleworkspace/googleworkspace.go
+++ b/motor/discovery/googleworkspace/googleworkspace.go
@@ -9,7 +9,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	google_provider "go.mondoo.com/cnquery/motor/providers/google"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 type Resolver struct{}
@@ -22,7 +22,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, cc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, cc *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	// Note: we use the resolver instead of the direct ms365_provider.New to resolve credentials properly

--- a/motor/discovery/ipmi/resolver.go
+++ b/motor/discovery/ipmi/resolver.go
@@ -8,7 +8,7 @@ import (
 	"go.mondoo.com/cnquery/motor/platform/detector"
 	"go.mondoo.com/cnquery/motor/providers"
 	ipmi_provider "go.mondoo.com/cnquery/motor/providers/ipmi"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 const DiscoveryDevice = "device"
@@ -23,7 +23,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll, DiscoveryDevice}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, t *providers.Config, credsResover credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, t *providers.Config, credsResover vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	provider, err := ipmi_provider.New(t)
 	if err != nil {
 		return nil, err

--- a/motor/discovery/ipmi/resolver.go
+++ b/motor/discovery/ipmi/resolver.go
@@ -8,6 +8,7 @@ import (
 	"go.mondoo.com/cnquery/motor/platform/detector"
 	"go.mondoo.com/cnquery/motor/providers"
 	ipmi_provider "go.mondoo.com/cnquery/motor/providers/ipmi"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 const DiscoveryDevice = "device"
@@ -22,7 +23,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll, DiscoveryDevice}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, t *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, t *providers.Config, credsResover credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	provider, err := ipmi_provider.New(t)
 	if err != nil {
 		return nil, err

--- a/motor/discovery/k8s/resolver.go
+++ b/motor/discovery/k8s/resolver.go
@@ -15,6 +15,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers/k8s"
 	"go.mondoo.com/cnquery/motor/providers/k8s/resources"
 	"go.mondoo.com/cnquery/motor/providers/local"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 	"go.mondoo.com/cnquery/resources/packs/os/kubectl"
 )
 
@@ -64,7 +65,7 @@ type K8sResourceIdentifier struct {
 	Name      string
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	features := cnquery.GetFeatures(ctx)
 	resolved := []*asset.Asset{}
 	nsFilter := NamespaceFilterOpts{

--- a/motor/discovery/k8s/resolver.go
+++ b/motor/discovery/k8s/resolver.go
@@ -15,7 +15,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers/k8s"
 	"go.mondoo.com/cnquery/motor/providers/k8s/resources"
 	"go.mondoo.com/cnquery/motor/providers/local"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 	"go.mondoo.com/cnquery/resources/packs/os/kubectl"
 )
 
@@ -65,7 +65,7 @@ type K8sResourceIdentifier struct {
 	Name      string
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	features := cnquery.GetFeatures(ctx)
 	resolved := []*asset.Asset{}
 	nsFilter := NamespaceFilterOpts{

--- a/motor/discovery/local/local.go
+++ b/motor/discovery/local/local.go
@@ -12,6 +12,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/os"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 type Resolver struct{}
@@ -29,7 +30,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	assetObj := &asset.Asset{
 		Name:        root.Name,
 		State:       asset.State_STATE_ONLINE,
@@ -41,7 +42,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 		assetObj.Name = tc.Host
 	}
 
-	m, err := resolver.NewMotorConnection(ctx, tc, cfn)
+	m, err := resolver.NewMotorConnection(ctx, tc, credsResolver)
 	if err != nil {
 		return nil, err
 	}

--- a/motor/discovery/local/local.go
+++ b/motor/discovery/local/local.go
@@ -12,7 +12,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/os"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 type Resolver struct{}
@@ -30,7 +30,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	assetObj := &asset.Asset{
 		Name:        root.Name,
 		State:       asset.State_STATE_ONLINE,

--- a/motor/discovery/mock/mock.go
+++ b/motor/discovery/mock/mock.go
@@ -11,7 +11,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/os"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 type Resolver struct{}
@@ -24,7 +24,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	assetObj := &asset.Asset{
 		State:       asset.State_STATE_ONLINE,
 		Connections: []*providers.Config{tc},

--- a/motor/discovery/mock/mock.go
+++ b/motor/discovery/mock/mock.go
@@ -11,6 +11,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/os"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 type Resolver struct{}
@@ -23,7 +24,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	assetObj := &asset.Asset{
 		State:       asset.State_STATE_ONLINE,
 		Connections: []*providers.Config{tc},
@@ -38,7 +39,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 		Kind: providers.Kind_KIND_BARE_METAL,
 	}
 
-	m, err := resolver.NewMotorConnection(ctx, tc, cfn)
+	m, err := resolver.NewMotorConnection(ctx, tc, credsResolver)
 	if err != nil {
 		return nil, err
 	}

--- a/motor/discovery/ms365/resolver.go
+++ b/motor/discovery/ms365/resolver.go
@@ -9,6 +9,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	microsoft "go.mondoo.com/cnquery/motor/providers/microsoft"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 const DiscoveryTenant = "tenants"
@@ -23,11 +24,11 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll, DiscoveryTenant}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, cc *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, cc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	// Note: we use the resolver instead of the direct ms365_provider.New to resolve credentials properly
-	m, err := resolver.NewMotorConnection(ctx, cc, cfn)
+	m, err := resolver.NewMotorConnection(ctx, cc, credsResolver)
 	if err != nil {
 		return nil, err
 	}

--- a/motor/discovery/ms365/resolver.go
+++ b/motor/discovery/ms365/resolver.go
@@ -9,7 +9,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	microsoft "go.mondoo.com/cnquery/motor/providers/microsoft"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 const DiscoveryTenant = "tenants"
@@ -24,7 +24,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll, DiscoveryTenant}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, cc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, cc *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	// Note: we use the resolver instead of the direct ms365_provider.New to resolve credentials properly

--- a/motor/discovery/network/resolver.go
+++ b/motor/discovery/network/resolver.go
@@ -8,7 +8,7 @@ import (
 	"go.mondoo.com/cnquery/motor/platform/detector"
 	"go.mondoo.com/cnquery/motor/providers"
 	network_transport "go.mondoo.com/cnquery/motor/providers/network"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 type Resolver struct{}
@@ -21,7 +21,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, conf *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, conf *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	transport, err := network_transport.New(conf)
 	if err != nil {
 		return nil, err

--- a/motor/discovery/network/resolver.go
+++ b/motor/discovery/network/resolver.go
@@ -8,6 +8,7 @@ import (
 	"go.mondoo.com/cnquery/motor/platform/detector"
 	"go.mondoo.com/cnquery/motor/providers"
 	network_transport "go.mondoo.com/cnquery/motor/providers/network"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 type Resolver struct{}
@@ -20,7 +21,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, conf *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, conf *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	transport, err := network_transport.New(conf)
 	if err != nil {
 		return nil, err

--- a/motor/discovery/okta/resolver.go
+++ b/motor/discovery/okta/resolver.go
@@ -9,6 +9,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	okta_provider "go.mondoo.com/cnquery/motor/providers/okta"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 type Resolver struct{}
@@ -21,11 +22,11 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, cc *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, cc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	// Note: we use the resolver instead of the direct ms365_provider.New to resolve credentials properly
-	m, err := resolver.NewMotorConnection(ctx, cc, cfn)
+	m, err := resolver.NewMotorConnection(ctx, cc, credsResolver)
 	if err != nil {
 		return nil, err
 	}

--- a/motor/discovery/okta/resolver.go
+++ b/motor/discovery/okta/resolver.go
@@ -9,7 +9,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	okta_provider "go.mondoo.com/cnquery/motor/providers/okta"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 type Resolver struct{}
@@ -22,7 +22,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, cc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, cc *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	// Note: we use the resolver instead of the direct ms365_provider.New to resolve credentials properly

--- a/motor/discovery/os/os.go
+++ b/motor/discovery/os/os.go
@@ -11,6 +11,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/os"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 type Resolver struct{}
@@ -23,7 +24,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	assetObj := &asset.Asset{
 		Name:        root.Name,
 		Connections: []*providers.Config{tc},
@@ -41,7 +42,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 		}
 	}
 
-	m, err := resolver.NewMotorConnection(ctx, tc, cfn)
+	m, err := resolver.NewMotorConnection(ctx, tc, credsResolver)
 	if err != nil {
 		return nil, err
 	}

--- a/motor/discovery/os/os.go
+++ b/motor/discovery/os/os.go
@@ -11,7 +11,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/os"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 type Resolver struct{}
@@ -24,7 +24,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	assetObj := &asset.Asset{
 		Name:        root.Name,
 		Connections: []*providers.Config{tc},

--- a/motor/discovery/resolve.go
+++ b/motor/discovery/resolve.go
@@ -45,13 +45,13 @@ import (
 	"go.mondoo.com/cnquery/motor/motorid"
 	"go.mondoo.com/cnquery/motor/providers"
 	pr "go.mondoo.com/cnquery/motor/providers/resolver"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 	"go.mondoo.com/cnquery/stringx"
 )
 
 type Resolver interface {
 	Name() string
-	Resolve(ctx context.Context, root *asset.Asset, t *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn,
+	Resolve(ctx context.Context, root *asset.Asset, t *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn,
 		userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error)
 	AvailableDiscoveryTargets() []string
 }
@@ -106,7 +106,7 @@ func InitCtx(ctx context.Context) context.Context {
 	return initCtx
 }
 
-func ResolveAsset(ctx context.Context, root *asset.Asset, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn) ([]*asset.Asset, error) {
+func ResolveAsset(ctx context.Context, root *asset.Asset, credsResolver vault.Resolver, sfn common.QuerySecretFn) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	// if the asset is missing a secret, we try to add this for the asset
@@ -191,7 +191,7 @@ type ResolvedAssets struct {
 	Errors        map[*asset.Asset]error
 }
 
-func ResolveAssets(ctx context.Context, rootAssets []*asset.Asset, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn) ResolvedAssets {
+func ResolveAssets(ctx context.Context, rootAssets []*asset.Asset, credsResolver vault.Resolver, sfn common.QuerySecretFn) ResolvedAssets {
 	resolved := []*asset.Asset{}
 	resolvedMap := map[string]struct{}{}
 	errors := map[*asset.Asset]error{}
@@ -247,7 +247,7 @@ func ResolveAssets(ctx context.Context, rootAssets []*asset.Asset, credsResolver
 	}
 }
 
-func resolveRelatedAssets(ctx context.Context, relatedAssets []*asset.Asset, platformIdToAssetMap map[string]*asset.Asset, credsResolver credentials_resolver.Resolver) {
+func resolveRelatedAssets(ctx context.Context, relatedAssets []*asset.Asset, platformIdToAssetMap map[string]*asset.Asset, credsResolver vault.Resolver) {
 	for _, assetObj := range relatedAssets {
 		if len(assetObj.PlatformIds) > 0 {
 			for _, platformId := range assetObj.PlatformIds {

--- a/motor/discovery/resolve.go
+++ b/motor/discovery/resolve.go
@@ -45,12 +45,13 @@ import (
 	"go.mondoo.com/cnquery/motor/motorid"
 	"go.mondoo.com/cnquery/motor/providers"
 	pr "go.mondoo.com/cnquery/motor/providers/resolver"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 	"go.mondoo.com/cnquery/stringx"
 )
 
 type Resolver interface {
 	Name() string
-	Resolve(ctx context.Context, root *asset.Asset, t *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn,
+	Resolve(ctx context.Context, root *asset.Asset, t *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn,
 		userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error)
 	AvailableDiscoveryTargets() []string
 }
@@ -105,7 +106,7 @@ func InitCtx(ctx context.Context) context.Context {
 	return initCtx
 }
 
-func ResolveAsset(ctx context.Context, root *asset.Asset, cfn common.CredentialFn, sfn common.QuerySecretFn) ([]*asset.Asset, error) {
+func ResolveAsset(ctx context.Context, root *asset.Asset, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	// if the asset is missing a secret, we try to add this for the asset
@@ -144,7 +145,7 @@ func ResolveAsset(ctx context.Context, root *asset.Asset, cfn common.CredentialF
 		userIdDetectors := providers.ToPlatformIdDetectors(root.IdDetector)
 
 		// resolve assets
-		resolvedAssets, err := r.Resolve(ctx, root, pCfg, cfn, sfn, userIdDetectors...)
+		resolvedAssets, err := r.Resolve(ctx, root, pCfg, credsResolver, sfn, userIdDetectors...)
 		if err != nil {
 			assetFallbackName(root, pCfg)
 			return nil, err
@@ -190,7 +191,7 @@ type ResolvedAssets struct {
 	Errors        map[*asset.Asset]error
 }
 
-func ResolveAssets(ctx context.Context, rootAssets []*asset.Asset, cfn common.CredentialFn, sfn common.QuerySecretFn) ResolvedAssets {
+func ResolveAssets(ctx context.Context, rootAssets []*asset.Asset, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn) ResolvedAssets {
 	resolved := []*asset.Asset{}
 	resolvedMap := map[string]struct{}{}
 	errors := map[*asset.Asset]error{}
@@ -200,7 +201,7 @@ func ResolveAssets(ctx context.Context, rootAssets []*asset.Asset, cfn common.Cr
 	for i := range rootAssets {
 		asset := rootAssets[i]
 
-		resolverAssets, err := ResolveAsset(ctx, asset, cfn, sfn)
+		resolverAssets, err := ResolveAsset(ctx, asset, credsResolver, sfn)
 		if err != nil {
 			errors[asset] = err
 			continue
@@ -222,7 +223,7 @@ func ResolveAssets(ctx context.Context, rootAssets []*asset.Asset, cfn common.Cr
 		resolved = append(resolved, resolverAssets...)
 	}
 
-	resolveRelatedAssets(ctx, relatedAssets, platformIdToAssetMap, cfn)
+	resolveRelatedAssets(ctx, relatedAssets, platformIdToAssetMap, credsResolver)
 
 	neededRelatedAssets := []*asset.Asset{}
 	for _, a := range relatedAssets {
@@ -246,7 +247,7 @@ func ResolveAssets(ctx context.Context, rootAssets []*asset.Asset, cfn common.Cr
 	}
 }
 
-func resolveRelatedAssets(ctx context.Context, relatedAssets []*asset.Asset, platformIdToAssetMap map[string]*asset.Asset, cfn common.CredentialFn) {
+func resolveRelatedAssets(ctx context.Context, relatedAssets []*asset.Asset, platformIdToAssetMap map[string]*asset.Asset, credsResolver credentials_resolver.Resolver) {
 	for _, assetObj := range relatedAssets {
 		if len(assetObj.PlatformIds) > 0 {
 			for _, platformId := range assetObj.PlatformIds {
@@ -263,7 +264,7 @@ func resolveRelatedAssets(ctx context.Context, relatedAssets []*asset.Asset, pla
 			}
 
 			func() {
-				m, err := pr.NewMotorConnection(ctx, tc, cfn)
+				m, err := pr.NewMotorConnection(ctx, tc, credsResolver)
 				if err != nil {
 					log.Warn().Err(err).Msg("could not connect to related asset")
 					return

--- a/motor/discovery/slack/resolver.go
+++ b/motor/discovery/slack/resolver.go
@@ -9,6 +9,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
 	slack_provider "go.mondoo.com/cnquery/motor/providers/slack"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 type Resolver struct{}
@@ -21,10 +22,10 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, cc *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, cc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
-	m, err := resolver.NewMotorConnection(ctx, cc, cfn)
+	m, err := resolver.NewMotorConnection(ctx, cc, credsResolver)
 	if err != nil {
 		return nil, err
 	}

--- a/motor/discovery/slack/resolver.go
+++ b/motor/discovery/slack/resolver.go
@@ -9,7 +9,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
 	slack_provider "go.mondoo.com/cnquery/motor/providers/slack"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 type Resolver struct{}
@@ -22,7 +22,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, cc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, cc *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	m, err := resolver.NewMotorConnection(ctx, cc, credsResolver)

--- a/motor/discovery/tar/tar.go
+++ b/motor/discovery/tar/tar.go
@@ -9,6 +9,7 @@ import (
 	"go.mondoo.com/cnquery/motor/motorid"
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 type Resolver struct{}
@@ -21,14 +22,14 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	assetObj := &asset.Asset{
 		Name:        root.Name,
 		Connections: []*providers.Config{tc},
 		State:       asset.State_STATE_ONLINE,
 	}
 
-	m, err := resolver.NewMotorConnection(ctx, tc, cfn)
+	m, err := resolver.NewMotorConnection(ctx, tc, credsResolver)
 	if err != nil {
 		return nil, err
 	}

--- a/motor/discovery/tar/tar.go
+++ b/motor/discovery/tar/tar.go
@@ -9,7 +9,7 @@ import (
 	"go.mondoo.com/cnquery/motor/motorid"
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 type Resolver struct{}
@@ -22,7 +22,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	assetObj := &asset.Asset{
 		Name:        root.Name,
 		Connections: []*providers.Config{tc},

--- a/motor/discovery/terraform/terraform.go
+++ b/motor/discovery/terraform/terraform.go
@@ -9,6 +9,7 @@ import (
 	"go.mondoo.com/cnquery/motor/motorid"
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 type Resolver struct{}
@@ -21,7 +22,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	name := ""
 	if tc.Options["path"] != "" {
 		// manifest parent directory name
@@ -49,7 +50,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 		assetObj.Labels["path"] = absPath
 	}
 
-	m, err := resolver.NewMotorConnection(ctx, tc, cfn)
+	m, err := resolver.NewMotorConnection(ctx, tc, credsResolver)
 	if err != nil {
 		return nil, err
 	}

--- a/motor/discovery/terraform/terraform.go
+++ b/motor/discovery/terraform/terraform.go
@@ -9,7 +9,7 @@ import (
 	"go.mondoo.com/cnquery/motor/motorid"
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 type Resolver struct{}
@@ -22,7 +22,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	name := ""
 	if tc.Options["path"] != "" {
 		// manifest parent directory name

--- a/motor/discovery/vagrant/vagrant.go
+++ b/motor/discovery/vagrant/vagrant.go
@@ -14,6 +14,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers/local"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
 	"go.mondoo.com/cnquery/motor/vault"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 type Resolver struct{}
@@ -26,7 +27,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (v *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (v *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	localProvider, err := local.New()

--- a/motor/discovery/vagrant/vagrant.go
+++ b/motor/discovery/vagrant/vagrant.go
@@ -14,7 +14,6 @@ import (
 	"go.mondoo.com/cnquery/motor/providers/local"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
 	"go.mondoo.com/cnquery/motor/vault"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 type Resolver struct{}
@@ -27,7 +26,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (v *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (v *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	localProvider, err := local.New()

--- a/motor/discovery/vcd/resolver.go
+++ b/motor/discovery/vcd/resolver.go
@@ -9,6 +9,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
 	vcd_provider "go.mondoo.com/cnquery/motor/providers/vcd"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 type Resolver struct{}
@@ -21,10 +22,10 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, cc *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, cc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
-	m, err := resolver.NewMotorConnection(ctx, cc, cfn)
+	m, err := resolver.NewMotorConnection(ctx, cc, credsResolver)
 	if err != nil {
 		return nil, err
 	}

--- a/motor/discovery/vcd/resolver.go
+++ b/motor/discovery/vcd/resolver.go
@@ -9,7 +9,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
 	vcd_provider "go.mondoo.com/cnquery/motor/providers/vcd"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 type Resolver struct{}
@@ -22,7 +22,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, cc *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, cc *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	m, err := resolver.NewMotorConnection(ctx, cc, credsResolver)

--- a/motor/discovery/vsphere/vm_guest_resolver.go
+++ b/motor/discovery/vsphere/vm_guest_resolver.go
@@ -11,7 +11,6 @@ import (
 	"go.mondoo.com/cnquery/motor/providers/resolver"
 	"go.mondoo.com/cnquery/motor/providers/vmwareguestapi"
 	"go.mondoo.com/cnquery/motor/vault"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 type VMGuestResolver struct{}
@@ -24,7 +23,7 @@ func (r *VMGuestResolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto}
 }
 
-func (k *VMGuestResolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (k *VMGuestResolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	// we leverage the vpshere transport to establish a connection
@@ -80,7 +79,7 @@ func (k *VMGuestResolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *
 	}
 }
 
-func EnrichVsphereToolsConnWithSecrets(a *asset.Asset, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn) {
+func EnrichVsphereToolsConnWithSecrets(a *asset.Asset, credsResolver vault.Resolver, sfn common.QuerySecretFn) {
 	// search secret for vm
 	// NOTE: we do not use `common.EnrichAssetWithSecrets(a, sfn)` here since vmware requires two secrets at the same time
 	for j := range a.Connections {

--- a/motor/discovery/vsphere/vsphere_resolver.go
+++ b/motor/discovery/vsphere/vsphere_resolver.go
@@ -14,7 +14,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
 	"go.mondoo.com/cnquery/motor/providers/vsphere"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 const (
@@ -33,7 +33,7 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll, DiscoveryInstances, DiscoveryHostMachines}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	// we leverage the vpshere transport to establish a connection

--- a/motor/discovery/vsphere/vsphere_resolver.go
+++ b/motor/discovery/vsphere/vsphere_resolver.go
@@ -14,6 +14,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
 	"go.mondoo.com/cnquery/motor/providers/vsphere"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 const (
@@ -32,11 +33,11 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{common.DiscoveryAuto, common.DiscoveryAll, DiscoveryInstances, DiscoveryHostMachines}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, cfn common.CredentialFn, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
+func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *providers.Config, credsResolver credentials_resolver.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
 	resolved := []*asset.Asset{}
 
 	// we leverage the vpshere transport to establish a connection
-	m, err := resolver.NewMotorConnection(ctx, pCfg, cfn)
+	m, err := resolver.NewMotorConnection(ctx, pCfg, credsResolver)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +128,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *provide
 			}
 
 			// find the secret reference for the asset
-			EnrichVsphereToolsConnWithSecrets(vm, cfn, sfn)
+			EnrichVsphereToolsConnWithSecrets(vm, credsResolver, sfn)
 
 			resolved = append(resolved, vm)
 		}

--- a/motor/inventory/manager.go
+++ b/motor/inventory/manager.go
@@ -2,7 +2,6 @@ package inventory
 
 import (
 	"context"
-	"errors"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/logger"
@@ -12,6 +11,7 @@ import (
 	v1 "go.mondoo.com/cnquery/motor/inventory/v1"
 	"go.mondoo.com/cnquery/motor/vault"
 	"go.mondoo.com/cnquery/motor/vault/config"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 	"go.mondoo.com/cnquery/motor/vault/inmemory"
 	"go.mondoo.com/cnquery/motor/vault/multivault"
 )
@@ -172,48 +172,6 @@ func (im *inventoryManager) GetRelatedAssets() []*asset.Asset {
 	return im.relatedAssets
 }
 
-// GetCredential retrieves the credential from vault via the secret id
-func (im *inventoryManager) GetCredential(cred *vault.Credential) (*vault.Credential, error) {
-	if cred == nil {
-		return nil, errors.New("cannot find credential with empty input")
-	}
-
-	v := im.GetVault()
-	if v == nil {
-		return nil, vault.NotFoundError
-	}
-
-	info, _ := v.About(context.Background(), &vault.Empty{})
-	var name string
-	if info != nil {
-		name = info.Name
-	}
-	log.Debug().Str("secret-id", cred.SecretId).Str("vault", name).Msg("fetch secret from vault")
-	// TODO: do we need to provide the encoding from outside or inside?
-	secret, err := v.Get(context.Background(), &vault.SecretID{
-		Key: cred.SecretId,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	retrievedCred, err := secret.Credential()
-	if err != nil {
-		return nil, err
-	}
-
-	// merge creds since user can provide additional credential_type, user
-	if cred.User != "" {
-		retrievedCred.User = cred.User
-	}
-
-	if cred.Type != vault.CredentialType_undefined {
-		retrievedCred.Type = cred.Type
-	}
-
-	return retrievedCred, nil
-}
-
 // QuerySecretId provides an input and determines the credential information for an asset
 // The credential will only include the reference to the secret and not include the actual secret
 func (im *inventoryManager) QuerySecretId(a *asset.Asset) (*vault.Credential, error) {
@@ -227,8 +185,8 @@ func (im *inventoryManager) QuerySecretId(a *asset.Asset) (*vault.Credential, er
 	return im.credentialQueryRunner.Run(a)
 }
 
-func (im *inventoryManager) Resolve(ctx context.Context) map[*asset.Asset]error {
-	resolvedAssets := discovery.ResolveAssets(ctx, im.assetList, im.GetCredential, im.QuerySecretId)
+func (im *inventoryManager) Resolve(ctx context.Context, credsResolver credentials_resolver.Resolver) map[*asset.Asset]error {
+	resolvedAssets := discovery.ResolveAssets(ctx, im.assetList, credsResolver, im.QuerySecretId)
 
 	// TODO: iterate over all resolved assets and match them with the original list and try to find credentials for each asset
 	im.assetList = resolvedAssets.Assets

--- a/motor/inventory/manager.go
+++ b/motor/inventory/manager.go
@@ -86,7 +86,7 @@ func New(opts ...Option) (*inventoryManager, error) {
 }
 
 type inventoryManager struct {
-	CredsResolver credentials_resolver.Resolver
+	CredsResolver vault.Resolver
 	assetList     []*asset.Asset
 	relatedAssets []*asset.Asset
 	// optional vault set by user

--- a/motor/inventory/manager_load_test.go
+++ b/motor/inventory/manager_load_test.go
@@ -7,7 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/cnquery/motor/asset"
-	"go.mondoo.com/cnquery/motor/inventory/v1"
+	v1 "go.mondoo.com/cnquery/motor/inventory/v1"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 func TestInventoryLoader(t *testing.T) {
@@ -16,6 +17,8 @@ func TestInventoryLoader(t *testing.T) {
 
 	im, err := New(WithInventory(inventory))
 	require.NoError(t, err)
+
+	credsResolver := credentials_resolver.New(im.GetVault(), false)
 
 	// gather all assets and check their secrets
 	assetList := im.GetAssets()
@@ -27,7 +30,7 @@ func TestInventoryLoader(t *testing.T) {
 			conn := a.Connections[j]
 			for k := range conn.Credentials {
 				cred := conn.Credentials[k]
-				_, err := im.GetCredential(cred)
+				_, err := credsResolver.GetCredential(cred)
 				assert.NoError(t, err, cred.SecretId)
 			}
 		}
@@ -53,6 +56,8 @@ func TestAwsInventoryLoader(t *testing.T) {
 	im, err := New(WithInventory(inventory))
 	require.NoError(t, err)
 
+	credsResolver := credentials_resolver.New(im.GetVault(), false)
+
 	// gather all assets and check their secrets
 	assetList := im.GetAssets()
 	require.NoError(t, err)
@@ -63,7 +68,7 @@ func TestAwsInventoryLoader(t *testing.T) {
 			conn := a.Connections[j]
 			for k := range conn.Credentials {
 				cred := conn.Credentials[k]
-				resolvedCred, err := im.GetCredential(cred)
+				resolvedCred, err := credsResolver.GetCredential(cred)
 				assert.NoError(t, err, cred.SecretId)
 				assert.NotNil(t, resolvedCred)
 			}

--- a/motor/inventory/manager_query_test.go
+++ b/motor/inventory/manager_query_test.go
@@ -11,6 +11,7 @@ import (
 	v1 "go.mondoo.com/cnquery/motor/inventory/v1"
 	"go.mondoo.com/cnquery/motor/platform"
 	"go.mondoo.com/cnquery/motor/providers"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 	mockvault "go.mondoo.com/cnquery/motor/vault/mock"
 )
 
@@ -41,7 +42,8 @@ func TestSecretManagerPassword(t *testing.T) {
 	assert.Equal(t, "mockPassword", credential.SecretId)
 
 	// now we try to get the full credential with the secret
-	_, err = im.GetCredential(credential)
+	credsResolver := credentials_resolver.New(im.GetVault(), false)
+	_, err = credsResolver.GetCredential(credential)
 	assert.NoError(t, err)
 }
 
@@ -72,7 +74,8 @@ func TestSecretManagerPrivateKey(t *testing.T) {
 	assert.Equal(t, "mockPKey", credential.SecretId)
 
 	// now we try to get the full credential with the secret
-	_, err = im.GetCredential(credential)
+	credsResolver := credentials_resolver.New(im.GetVault(), false)
+	_, err = credsResolver.GetCredential(credential)
 	assert.NoError(t, err)
 }
 
@@ -103,6 +106,7 @@ func TestSecretManagerBadKey(t *testing.T) {
 	assert.Equal(t, "bad-id", credential.SecretId)
 
 	// now we try to get the full credential with the secret
-	_, err = im.GetCredential(credential)
+	credsResolver := credentials_resolver.New(im.GetVault(), false)
+	_, err = credsResolver.GetCredential(credential)
 	assert.Error(t, err)
 }

--- a/motor/inventory/manager_test.go
+++ b/motor/inventory/manager_test.go
@@ -7,6 +7,7 @@ import (
 	v1 "go.mondoo.com/cnquery/motor/inventory/v1"
 
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 func TestInventoryIdempotent(t *testing.T) {
@@ -17,11 +18,15 @@ func TestInventoryIdempotent(t *testing.T) {
 
 	im, err := New(WithInventory(v1inventory))
 	require.NoError(t, err)
+
+	credsResolver := credentials_resolver.New(im.GetVault(), false)
 	// runs resolve step, especially the creds resolution
-	im.Resolve(ctx)
+	im.Resolve(ctx, credsResolver)
 
 	im, err = New(WithInventory(v1inventory))
 	require.NoError(t, err)
+
+	credsResolver = credentials_resolver.New(im.GetVault(), false)
 	// runs resolve step, especially the creds resolution
-	im.Resolve(ctx)
+	im.Resolve(ctx, credsResolver)
 }

--- a/motor/inventory/manager_test.go
+++ b/motor/inventory/manager_test.go
@@ -7,7 +7,6 @@ import (
 	v1 "go.mondoo.com/cnquery/motor/inventory/v1"
 
 	"github.com/stretchr/testify/require"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
 func TestInventoryIdempotent(t *testing.T) {
@@ -19,14 +18,12 @@ func TestInventoryIdempotent(t *testing.T) {
 	im, err := New(WithInventory(v1inventory))
 	require.NoError(t, err)
 
-	credsResolver := credentials_resolver.New(im.GetVault(), false)
 	// runs resolve step, especially the creds resolution
-	im.Resolve(ctx, credsResolver)
+	im.Resolve(ctx)
 
 	im, err = New(WithInventory(v1inventory))
 	require.NoError(t, err)
 
-	credsResolver = credentials_resolver.New(im.GetVault(), false)
 	// runs resolve step, especially the creds resolution
-	im.Resolve(ctx, credsResolver)
+	im.Resolve(ctx)
 }

--- a/motor/providers/resolver/connect.go
+++ b/motor/providers/resolver/connect.go
@@ -8,10 +8,10 @@ import (
 	"go.mondoo.com/cnquery/motor"
 	"go.mondoo.com/cnquery/motor/asset"
 	"go.mondoo.com/cnquery/motor/providers"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
-func EstablishConnection(ctx context.Context, tc *providers.Config, credsResolver credentials_resolver.Resolver, insecure bool, record bool) (*motor.Motor, error) {
+func EstablishConnection(ctx context.Context, tc *providers.Config, credsResolver vault.Resolver, insecure bool, record bool) (*motor.Motor, error) {
 	log.Debug().Str("connection", tc.ToUrl()).Bool("insecure", insecure).Msg("establish connection to asset")
 	// overwrite connection specific insecure with global insecure
 	if insecure {
@@ -25,7 +25,7 @@ func EstablishConnection(ctx context.Context, tc *providers.Config, credsResolve
 	return NewMotorConnection(ctx, tc, credsResolver)
 }
 
-func OpenAssetConnection(ctx context.Context, assetInfo *asset.Asset, credsResolver credentials_resolver.Resolver, record bool) (*motor.Motor, error) {
+func OpenAssetConnection(ctx context.Context, assetInfo *asset.Asset, credsResolver vault.Resolver, record bool) (*motor.Motor, error) {
 	if assetInfo == nil {
 		return nil, errors.New("asset is not defined")
 	}
@@ -70,7 +70,7 @@ func OpenAssetConnection(ctx context.Context, assetInfo *asset.Asset, credsResol
 	return m, nil
 }
 
-func OpenAssetConnections(ctx context.Context, assetInfo *asset.Asset, credsResolver credentials_resolver.Resolver, record bool) ([]*motor.Motor, error) {
+func OpenAssetConnections(ctx context.Context, assetInfo *asset.Asset, credsResolver vault.Resolver, record bool) ([]*motor.Motor, error) {
 	if assetInfo == nil {
 		return nil, errors.New("asset is not defined")
 	}

--- a/motor/providers/resolver/connect.go
+++ b/motor/providers/resolver/connect.go
@@ -8,10 +8,10 @@ import (
 	"go.mondoo.com/cnquery/motor"
 	"go.mondoo.com/cnquery/motor/asset"
 	"go.mondoo.com/cnquery/motor/providers"
-	"go.mondoo.com/cnquery/motor/vault"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 )
 
-func EstablishConnection(ctx context.Context, tc *providers.Config, credentialFn func(cred *vault.Credential) (*vault.Credential, error), insecure bool, record bool) (*motor.Motor, error) {
+func EstablishConnection(ctx context.Context, tc *providers.Config, credsResolver credentials_resolver.Resolver, insecure bool, record bool) (*motor.Motor, error) {
 	log.Debug().Str("connection", tc.ToUrl()).Bool("insecure", insecure).Msg("establish connection to asset")
 	// overwrite connection specific insecure with global insecure
 	if insecure {
@@ -22,10 +22,10 @@ func EstablishConnection(ctx context.Context, tc *providers.Config, credentialFn
 		tc.Record = true
 	}
 
-	return NewMotorConnection(ctx, tc, credentialFn)
+	return NewMotorConnection(ctx, tc, credsResolver)
 }
 
-func OpenAssetConnection(ctx context.Context, assetInfo *asset.Asset, credentialFn func(cred *vault.Credential) (*vault.Credential, error), record bool) (*motor.Motor, error) {
+func OpenAssetConnection(ctx context.Context, assetInfo *asset.Asset, credsResolver credentials_resolver.Resolver, record bool) (*motor.Motor, error) {
 	if assetInfo == nil {
 		return nil, errors.New("asset is not defined")
 	}
@@ -60,7 +60,7 @@ func OpenAssetConnection(ctx context.Context, assetInfo *asset.Asset, credential
 		pCfg.PlatformId = assetInfo.PlatformIds[0]
 	}
 
-	m, err := EstablishConnection(ctx, pCfg, credentialFn, pCfg.Insecure, record)
+	m, err := EstablishConnection(ctx, pCfg, credsResolver, pCfg.Insecure, record)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func OpenAssetConnection(ctx context.Context, assetInfo *asset.Asset, credential
 	return m, nil
 }
 
-func OpenAssetConnections(ctx context.Context, assetInfo *asset.Asset, credentialFn func(cred *vault.Credential) (*vault.Credential, error), record bool) ([]*motor.Motor, error) {
+func OpenAssetConnections(ctx context.Context, assetInfo *asset.Asset, credsResolver credentials_resolver.Resolver, record bool) ([]*motor.Motor, error) {
 	if assetInfo == nil {
 		return nil, errors.New("asset is not defined")
 	}
@@ -107,7 +107,7 @@ func OpenAssetConnections(ctx context.Context, assetInfo *asset.Asset, credentia
 			pCfg.PlatformId = assetInfo.PlatformIds[0]
 		}
 
-		m, err := EstablishConnection(ctx, pCfg, credentialFn, pCfg.Insecure, record)
+		m, err := EstablishConnection(ctx, pCfg, credsResolver, pCfg.Insecure, record)
 		if err != nil {
 			return nil, err
 		}

--- a/motor/providers/resolver/resolver.go
+++ b/motor/providers/resolver/resolver.go
@@ -32,7 +32,6 @@ import (
 	"go.mondoo.com/cnquery/motor/providers/vsphere"
 	"go.mondoo.com/cnquery/motor/providers/winrm"
 	"go.mondoo.com/cnquery/motor/vault"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -49,7 +48,7 @@ func warnIncompleteFeature(backend providers.ProviderType) {
 // NewMotorConnection establishes a motor connection by using the provided provider configuration
 // By default, it uses the id detector mechanisms provided by the provider. User can overwrite that
 // behaviour by optionally passing id detector identifier
-func NewMotorConnection(ctx context.Context, tc *providers.Config, credsResolver credentials_resolver.Resolver) (*motor.Motor, error) {
+func NewMotorConnection(ctx context.Context, tc *providers.Config, credsResolver vault.Resolver) (*motor.Motor, error) {
 	log.Debug().Msg("establish motor connection")
 	var m *motor.Motor
 

--- a/motor/vault/cache/cached_vault.go
+++ b/motor/vault/cache/cached_vault.go
@@ -1,4 +1,4 @@
-package credentials_resolver
+package cache
 
 import (
 	"context"
@@ -11,7 +11,7 @@ type cachedVault struct {
 	vault   vault.Vault
 }
 
-func newCachedVault(v vault.Vault) vault.Vault {
+func New(v vault.Vault) vault.Vault {
 	return &cachedVault{
 		secrets: map[string]*vault.Secret{},
 		vault:   v,

--- a/motor/vault/credentials_resolver/cached_vault.go
+++ b/motor/vault/credentials_resolver/cached_vault.go
@@ -1,0 +1,41 @@
+package credentials_resolver
+
+import (
+	"context"
+
+	"go.mondoo.com/cnquery/motor/vault"
+)
+
+type cachedVault struct {
+	secrets map[string]*vault.Secret
+	vault   vault.Vault
+}
+
+func newCachedVault(v vault.Vault) vault.Vault {
+	return &cachedVault{
+		secrets: map[string]*vault.Secret{},
+		vault:   v,
+	}
+}
+
+func (c *cachedVault) About(ctx context.Context, e *vault.Empty) (*vault.VaultInfo, error) {
+	// return the info about the underlying vault. The cached vault is only an abstraction
+	return c.vault.About(ctx, e)
+}
+
+func (c *cachedVault) Get(ctx context.Context, id *vault.SecretID) (*vault.Secret, error) {
+	if s, ok := c.secrets[id.Key]; ok {
+		return s, nil
+	}
+	s, err := c.vault.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	c.secrets[id.Key] = s
+	return s, nil
+}
+
+func (c *cachedVault) Set(ctx context.Context, s *vault.Secret) (*vault.SecretID, error) {
+	return c.vault.Set(ctx, s)
+}

--- a/motor/vault/credentials_resolver/credentials_resolver.go
+++ b/motor/vault/credentials_resolver/credentials_resolver.go
@@ -1,0 +1,66 @@
+package credentials_resolver
+
+import (
+	"context"
+	"errors"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/motor/vault"
+)
+
+type Resolver interface {
+	GetCredential(cred *vault.Credential) (*vault.Credential, error)
+}
+
+type resolver struct {
+	vault vault.Vault
+}
+
+func New(v vault.Vault, enableCaching bool) Resolver {
+	if enableCaching {
+		return &resolver{vault: newCachedVault(v)}
+	}
+	return &resolver{vault: v}
+}
+
+// GetCredential retrieves the credential from vault via the secret id
+func (c *resolver) GetCredential(cred *vault.Credential) (*vault.Credential, error) {
+	if cred == nil {
+		return nil, errors.New("cannot find credential with empty input")
+	}
+
+	info, _ := c.vault.About(context.Background(), &vault.Empty{})
+	var name string
+	if info != nil {
+		name = info.Name
+	}
+	log.Debug().Str("secret-id", cred.SecretId).Str("vault", name).Msg("fetch secret from vault")
+	// TODO: do we need to provide the encoding from outside or inside?
+	secret, err := c.vault.Get(context.Background(), &vault.SecretID{
+		Key: cred.SecretId,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// user can overwrite the encoding
+	if cred.SecretEncoding != vault.SecretEncoding_encoding_undefined {
+		secret.Encoding = cred.SecretEncoding
+	}
+
+	retrievedCred, err := secret.Credential()
+	if err != nil {
+		return nil, err
+	}
+
+	// merge creds since user can provide additional credential_type, user
+	if cred.User != "" {
+		retrievedCred.User = cred.User
+	}
+
+	if cred.Type != vault.CredentialType_undefined {
+		retrievedCred.Type = cred.Type
+	}
+
+	return retrievedCred, nil
+}

--- a/motor/vault/credentials_resolver/credentials_resolver.go
+++ b/motor/vault/credentials_resolver/credentials_resolver.go
@@ -6,11 +6,8 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/motor/vault"
+	"go.mondoo.com/cnquery/motor/vault/cache"
 )
-
-type Resolver interface {
-	GetCredential(cred *vault.Credential) (*vault.Credential, error)
-}
 
 type resolver struct {
 	vault vault.Vault
@@ -18,9 +15,9 @@ type resolver struct {
 
 // New creates a new credentials resolver. The resolver allows for caching already resolved credentials
 // in memory such that they are not retrieved from vault again.
-func New(v vault.Vault, enableCaching bool) Resolver {
+func New(v vault.Vault, enableCaching bool) vault.Resolver {
 	if enableCaching {
-		return &resolver{vault: newCachedVault(v)}
+		return &resolver{vault: cache.New(v)}
 	}
 	return &resolver{vault: v}
 }
@@ -43,11 +40,6 @@ func (c *resolver) GetCredential(cred *vault.Credential) (*vault.Credential, err
 	})
 	if err != nil {
 		return nil, err
-	}
-
-	// user can overwrite the encoding
-	if cred.SecretEncoding != vault.SecretEncoding_encoding_undefined {
-		secret.Encoding = cred.SecretEncoding
 	}
 
 	retrievedCred, err := secret.Credential()

--- a/motor/vault/credentials_resolver/credentials_resolver.go
+++ b/motor/vault/credentials_resolver/credentials_resolver.go
@@ -16,6 +16,8 @@ type resolver struct {
 	vault vault.Vault
 }
 
+// New creates a new credentials resolver. The resolver allows for caching already resolved credentials
+// in memory such that they are not retrieved from vault again.
 func New(v vault.Vault, enableCaching bool) Resolver {
 	if enableCaching {
 		return &resolver{vault: newCachedVault(v)}

--- a/motor/vault/vault.go
+++ b/motor/vault/vault.go
@@ -10,6 +10,10 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+type Resolver interface {
+	GetCredential(cred *Credential) (*Credential, error)
+}
+
 //go:generate protoc --proto_path=../../:. --go_out=. --go_opt=paths=source_relative --rangerrpc_out=. vault.proto
 
 func EscapeSecretID(key string) string {

--- a/resources/packs/core/platform_test.go
+++ b/resources/packs/core/platform_test.go
@@ -17,6 +17,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/container/docker_engine"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
+	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 	"go.mondoo.com/cnquery/resources/packs/core"
 	"go.mondoo.com/cnquery/resources/packs/testutils"
 
@@ -96,7 +97,8 @@ func TestDockerContainer_Platform(t *testing.T) {
 	im, err := inventory.New(inventory.WithAssets([]*asset.Asset{connAsset}))
 	require.NoError(t, err)
 
-	assetErrors := im.Resolve(ctx)
+	credsResolver := credentials_resolver.New(im.GetVault(), false)
+	assetErrors := im.Resolve(ctx, credsResolver)
 	require.Empty(t, assetErrors)
 	assetList := im.GetAssets()
 	container := assetList[0]

--- a/resources/packs/core/platform_test.go
+++ b/resources/packs/core/platform_test.go
@@ -17,7 +17,6 @@ import (
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/container/docker_engine"
 	"go.mondoo.com/cnquery/motor/providers/resolver"
-	"go.mondoo.com/cnquery/motor/vault/credentials_resolver"
 	"go.mondoo.com/cnquery/resources/packs/core"
 	"go.mondoo.com/cnquery/resources/packs/testutils"
 
@@ -97,8 +96,7 @@ func TestDockerContainer_Platform(t *testing.T) {
 	im, err := inventory.New(inventory.WithAssets([]*asset.Asset{connAsset}))
 	require.NoError(t, err)
 
-	credsResolver := credentials_resolver.New(im.GetVault(), false)
-	assetErrors := im.Resolve(ctx, credsResolver)
+	assetErrors := im.Resolve(ctx)
 	require.Empty(t, assetErrors)
 	assetList := im.GetAssets()
 	container := assetList[0]


### PR DESCRIPTION
Implemented a credentials resolver to replace the `GetCredentials` function that is being passed around. The resolver allows for caching credentials such that they don't need to be retrieved multiple times