### PR TITLE
🧹 Change GCP root asset when scanning projects to gcp-project

### DIFF
--- a/motor/discovery/gcp/resolver_project.go
+++ b/motor/discovery/gcp/resolver_project.go
@@ -73,6 +73,7 @@ func (r *GcpProjectResolver) Resolve(ctx context.Context, tc *providers.Config, 
 
 	var resolvedRoot *asset.Asset
 	if tc.IncludesOneOfDiscoveryTarget(common.DiscoveryAuto, common.DiscoveryAll, DiscoveryProjects) {
+		pf.Name = "gcp-project"
 		resolvedRoot = &asset.Asset{
 			PlatformIds: []string{identifier},
 			Name:        "GCP project " + project,

--- a/motor/providers/google/provider.go
+++ b/motor/providers/google/provider.go
@@ -204,6 +204,8 @@ func (p *Provider) PlatformInfo() (*platform.Platform, error) {
 
 func getTitleForPlatformName(name string) string {
 	switch name {
+	case "gcp-project":
+		return "GCP Project"
 	case "gcp-compute-image":
 		return "GCP Compute Image"
 	case "gcp-compute-network":


### PR DESCRIPTION
Make sure the root asset has platform kind `gcp-object` and platform name `gcp-project`. This should be merged only after we have updated the existing policies to match the new asset filter