### PR TITLE
bubble up errors while processing TLS

### DIFF
--- a/resources/packs/core/tlsshake/tlsshake.go
+++ b/resources/packs/core/tlsshake/tlsshake.go
@@ -171,7 +171,7 @@ func (s *Tester) Test(conf ScanConfig) error {
 
 	workers.Wait()
 
-	return nil
+	return errs
 }
 
 // Attempts to connect to an endpoint with a given version and records


### PR DESCRIPTION
w/o this, you get silent failures when we run into failures while testing out TLS

For example, when connecting to an IPv6 port (w/o the fix in #875 ):
```
[jdiaz@fedora cnquery (joel/tls-errors *+$%)]$ cnquery run local -c "ports.listening.where(port == 443) { tls { * }}"                                            
→ discover related assets for 1 asset(s)                                                                                                                         
→ resolved assets resolved-assets=1                                                                                                                              
ports.listening.where: [                                                                                                                                         
  0: {                                                                                                                                                           
    tls: {                                                                                                                                                       
      domainName: ""                                                                                                                                             
      extensions: []                                                                                                                                             
      certificates: []                                                                                                                                           
      socket: socket protocol="tcp" port=443 address="::"                                                                                                        
      ciphers: []                                                                                                                                                
      nonSniCertificates: []                                                                                                                                     
      params: {                                                                                                                                                  
        certificates: []                                                                                                                                         
        ciphers: {}                                                                                                                                              
        errors: []                                                                                                                                               
        extensions: {}                                                                                                                                           
        non-sni-certificates: []                                                                                                                                 
        versions: {}                                                                                                                                             
      }                                                                                                                                                          
      versions: []                                                                                                                                               
    }                                                                                                                                                            
  }                                                                             
]
```

With this change, you get a clearer idea of what might be going on:
```
[jdiaz@fedora cnquery (joel/tls-errors *+$%)]$ ./cnquery run local -c "ports.listening.where(port == 443) { tls { * }}"
→ discover related assets for 1 asset(s)                                                                                                                         
→ resolved assets resolved-assets=1                                                                                                                              
Query encountered errors:                                                                                                                                        
85 errors occurred:                                                                                                                                              
        * failed to connect to target: dial tcp: address :::443: too many colons in address
        * failed to connect to target: dial tcp: address :::443: too many colons in address
        * failed to connect to target: dial tcp: address :::443: too many colons in address
        * failed to connect to target: dial tcp: address :::443: too many colons in address
        * failed to connect to target: dial tcp: address :::443: too many colons in address
        * failed to connect to target: dial tcp: address :::443: too many colons in address
... many, many lines of this output
```
Signed-off-by: Joel Diaz <joel@mondoo.com>