### PR TITLE
🧹 semantically split up mquery Merge and AddBase

### DIFF
--- a/explorer/bundle.go
+++ b/explorer/bundle.go
@@ -393,7 +393,7 @@ func (p *Bundle) compileQueries(queries []*Mquery, ownerMrn string, pack *QueryP
 
 		existing, ok := lookupQuery[query.Mrn]
 		if ok {
-			query.Merge(existing)
+			query.AddBase(existing)
 			query.Filters.Compile(ownerMrn)
 			pack.Filters.RegisterChild(query.Filters)
 			query.RefreshChecksumAndType(lookupProp)

--- a/explorer/mquery.go
+++ b/explorer/mquery.go
@@ -14,6 +14,7 @@ import (
 	"go.mondoo.com/cnquery/mrn"
 	"go.mondoo.com/cnquery/resources/packs/all/info"
 	"go.mondoo.com/cnquery/types"
+	"google.golang.org/protobuf/proto"
 )
 
 // Compile a given query and return the bundle. Both v1 and v2 versions are compiled.
@@ -249,7 +250,18 @@ func (m *Mquery) Sanitize() {
 	}
 }
 
-func (m *Mquery) Merge(base *Mquery) {
+// Merge a given query with a base query and create a new query object as a
+// result of it. Anything that is not set in the query, is pulled from the base.
+func (m *Mquery) Merge(base *Mquery) *Mquery {
+	// TODO: lots of potential to speed things up here
+	res := proto.Clone(m).(*Mquery)
+	res.AddBase(base)
+	return res
+}
+
+// AddBase adds a base query into the query object. Anything that is not set
+// in the query, is pulled from the base.
+func (m *Mquery) AddBase(base *Mquery) {
 	if m.Mql == "" {
 		m.Mql = base.Mql
 	}

--- a/explorer/mquery_test.go
+++ b/explorer/mquery_test.go
@@ -1,0 +1,60 @@
+package explorer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMqueryMerge(t *testing.T) {
+	a := &Mquery{
+		Mql:   "base",
+		Title: "base title",
+		Docs: &MqueryDocs{
+			Desc:  "base desc",
+			Audit: "base audit",
+			Remediation: &Remediation{
+				Items: []*TypedDoc{{
+					Id:   "default",
+					Desc: "a desciption",
+				}},
+			},
+		},
+	}
+	b := &Mquery{
+		Mql: "override",
+		Docs: &MqueryDocs{
+			Desc: "override desc",
+			Remediation: &Remediation{
+				Items: []*TypedDoc{{
+					Id:   "default",
+					Desc: "b desciption",
+				}},
+			},
+		},
+	}
+
+	c := b.Merge(a)
+
+	assert.NotEqual(t, a.Mql, c.Mql)
+	assert.Equal(t, b.Mql, c.Mql)
+
+	assert.Equal(t, a.Title, c.Title)
+	assert.NotEqual(t, b.Title, c.Title)
+
+	assert.NotEqual(t, a.Docs.Desc, c.Docs.Desc)
+	assert.Equal(t, b.Docs.Desc, c.Docs.Desc)
+
+	assert.Equal(t, a.Docs.Audit, c.Docs.Audit)
+	assert.NotEqual(t, b.Docs.Audit, c.Docs.Audit)
+
+	a.CodeId = "not this"
+	b.CodeId = "not this either"
+	assert.Equal(t, "", c.CodeId)
+
+	// we want to make sure there are no residual shallow-copies
+	cD := c.Docs.Remediation.Items[0].Desc
+	a.Docs.Remediation.Items[0].Desc = "not this"
+	a.Docs.Remediation.Items[0].Desc = "not this either"
+	assert.Equal(t, cD, c.Docs.Remediation.Items[0].Desc)
+}


### PR DESCRIPTION
The current call only allowed the overwriting of the query that was trying to merge with a base. This is problematic in places where we do not want to alter the original query. This is not the case in cnquery, but it is the case in cnspec (which will be updated shortly after this merged to accomodate the change for v8).

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>