### PR TITLE
🐛 mquery AddBase/Merge transfer MQL CodeID

### DIFF
--- a/explorer/mquery.go
+++ b/explorer/mquery.go
@@ -263,7 +263,11 @@ func (m *Mquery) Merge(base *Mquery) *Mquery {
 // in the query, is pulled from the base.
 func (m *Mquery) AddBase(base *Mquery) {
 	if m.Mql == "" {
+		// MQL, type and codeID go hand in hand, so make sure to always pull them
+		// fully when doing this.
 		m.Mql = base.Mql
+		m.CodeId = base.CodeId
+		m.Type = base.Type
 	}
 	if m.Type == "" {
 		m.Type = base.Type


### PR DESCRIPTION
When we take the base MQL, we should also retain the CodeID and type, which is always connected to the MQL code. This makes merging queries easier and doesn't require them to get re-compiled.

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>