### PR TITLE
🧹 separate mquery RefreshChecksum from Compile

### DIFF
--- a/explorer/mquery.go
+++ b/explorer/mquery.go
@@ -263,7 +263,11 @@ func (m *Mquery) Merge(base *Mquery) *Mquery {
 // in the query, is pulled from the base.
 func (m *Mquery) AddBase(base *Mquery) {
 	if m.Mql == "" {
+		// MQL, type and codeID go hand in hand, so make sure to always pull them
+		// fully when doing this.
 		m.Mql = base.Mql
+		m.CodeId = base.CodeId
+		m.Type = base.Type
 	}
 	if m.Type == "" {
 		m.Type = base.Type


### PR DESCRIPTION
after #887 
    
There are two ways in which checksums can be refreshed: One does the compile step and the other doesn't. The latter is used whenever we use Merge or AddBase. At the same time we didn't want to overload those two methods and add too much functionality into them.