### PR TITLE
🐛 Set secret encoding in berglas vault.

### DIFF
--- a/motor/vault/gcpberglas/berglas.go
+++ b/motor/vault/gcpberglas/berglas.go
@@ -105,6 +105,8 @@ func (v *Vault) Get(ctx context.Context, id *vault.SecretID) (*vault.Secret, err
 	return &vault.Secret{
 		Key:  id.Key,
 		Data: result.Plaintext,
+		// we do not know the encoding here, but the default is binary
+		Encoding: vault.SecretEncoding_encoding_binary,
 	}, nil
 }
 


### PR DESCRIPTION
With the removal of secret encoding from credentials in #840 we need to be explicit about the encoding of the secret that gets returned from the vault so that we can convert it correctly to a credential

This fixes only the berglas vault, I have not looked at the rest of our vault implementations