### PR TITLE
🧹 improve asset platform information for slack

### DIFF
--- a/motor/discovery/slack/resolver.go
+++ b/motor/discovery/slack/resolver.go
@@ -54,7 +54,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, cc *providers
 		}
 		resolved = append(resolved, &asset.Asset{
 			PlatformIds: []string{identifier},
-			Name:        "Slack organization " + teamName,
+			Name:        "Slack team " + teamName,
 			Platform:    pf,
 			Connections: []*providers.Config{cc}, // pass-in the current config
 			Labels:      map[string]string{},

--- a/motor/providers/runtime.go
+++ b/motor/providers/runtime.go
@@ -29,4 +29,5 @@ const (
 	RUNTIME_GITLAB               = "gitlab" // api
 	RUNTIME_TERRAFORM            = "terraform"
 	RUNTIME_OKTA                 = "okta"
+	RUNTIME_SLACK                = "slack"
 )

--- a/motor/providers/slack/platform.go
+++ b/motor/providers/slack/platform.go
@@ -4,10 +4,11 @@ import "go.mondoo.com/cnquery/motor/platform"
 
 func (p *Provider) PlatformInfo() (*platform.Platform, error) {
 	return &platform.Platform{
-		Name:    "slack",
-		Title:   "Slack",
+		Name:    "slack-team",
+		Title:   "Slack Team",
 		Runtime: p.Runtime(),
 		Kind:    p.Kind(),
+		Family:  []string{"slack"},
 	}, nil
 }
 

--- a/motor/providers/slack/provider.go
+++ b/motor/providers/slack/provider.go
@@ -71,7 +71,7 @@ func (p *Provider) Kind() providers.Kind {
 }
 
 func (p *Provider) Runtime() string {
-	return ""
+	return providers.RUNTIME_SLACK
 }
 
 func (p *Provider) PlatformIdDetectors() []providers.PlatformIdDetector {


### PR DESCRIPTION
switches the asset platform name for slack from "slack" to "slack-team"

```graphql
cnquery> asset { * }
asset: {
  kind: "api"
  build: ""
  version: ""
  title: "Slack Team"
  arch: ""
  labels: {}
  platform: "slack-team"
  vulnerabilityReport: nil
  platform
  runtime: "slack"
  ids: [
    0: "//platformid.api.mondoo.app/runtime/slack/team/ABCDEFG"
  ]
  name: "Slack team superstar labs"
  fqdn: ""
  family: [
    0: "slack"
  ]
}
```