### PR TITLE
🧹 assign the ecs runtime and container kind when ecs motor id used

### DIFF
--- a/motor/motorid/awsecs/awsecs_test.go
+++ b/motor/motorid/awsecs/awsecs_test.go
@@ -1,0 +1,16 @@
+package awsecsid
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestParseECSContainerId(t *testing.T) {
+	path := "//platformid.api.mondoo.app/runtime/aws/ecs/v1/accounts/185972265011/regions/us-east-1/container/vjtest/f088b38d61ac45d6a946b5aebbe7197a/314e35e0-2d0a-4408-b37e-16063461d73a"
+	id, err := ParseMondooECSContainerId(path)
+	assert.NilError(t, err)
+	assert.Equal(t, id.Account, "185972265011")
+	assert.Equal(t, id.Region, "us-east-1")
+	assert.Equal(t, id.Id, "vjtest/f088b38d61ac45d6a946b5aebbe7197a/314e35e0-2d0a-4408-b37e-16063461d73a")
+}

--- a/motor/motorid/motorid.go
+++ b/motor/motorid/motorid.go
@@ -111,6 +111,8 @@ func extractPlatformAndKindFromPlatformId(id string) (string, providers.Kind) {
 		return providers.RUNTIME_AWS_EC2, providers.Kind_KIND_VIRTUAL_MACHINE
 	} else if awsec2.IsValidMondooAccountId(id) {
 		return providers.RUNTIME_AWS, providers.Kind_KIND_API
+	} else if awsecsid.IsValidMondooECSContainerId(id) {
+		return providers.RUNTIME_AWS_ECS, providers.Kind_KIND_CONTAINER
 	}
 	return "", providers.Kind_KIND_UNKNOWN
 }


### PR DESCRIPTION

to ensure that we categorize the ecs container correctly