### PR TITLE
Small text improvements to azure provider cmd.

### DIFF
--- a/apps/cnquery/cmd/builder/builder.go
+++ b/apps/cnquery/cmd/builder/builder.go
@@ -582,7 +582,7 @@ func azureProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn
 	cmd.Flags().String("tenant-id", "", "Directory (tenant) ID of the service principal")
 	cmd.Flags().String("client-id", "", "Application (client) ID of the service principal")
 	cmd.Flags().String("client-secret", "", "Secret for application")
-	cmd.Flags().String("certificate-path", "", "Path (in PKCS #12/PFX format) to the authentication certificate")
+	cmd.Flags().String("certificate-path", "", "Path (in PKCS #12/PFX or PEM format) to the authentication certificate")
 	cmd.Flags().String("certificate-secret", "", "Passphrase for the authentication certificate file")
 	cmd.Flags().String("subscription", "", "ID of the Azure subscription to scan")
 	cmd.Flags().String("subscriptions", "", "Comma-separated list of Azure subscriptions to include")

--- a/motor/providers/microsoft/auth.go
+++ b/motor/providers/microsoft/auth.go
@@ -25,7 +25,7 @@ func (p *Provider) GetTokenCredential() (azcore.TokenCredential, error) {
 		case vault.CredentialType_pkcs12:
 			certs, privateKey, err := azidentity.ParseCertificates(p.cred.Secret, []byte(p.cred.Password))
 			if err != nil {
-				return nil, errors.Wrap(err, "could not parse pfx file")
+				return nil, errors.Wrap(err, "could not parse certificate")
 			}
 
 			credential, err = azidentity.NewClientCertificateCredential(p.tenantID, p.clientID, certs, privateKey, &azidentity.ClientCertificateCredentialOptions{})


### PR DESCRIPTION
 - Remove the `pfx` word from the error we return if the certificate cannot be parsed, we do not know what's the format of the file from where the data came in
 - Add .pem as a supported format for the `--certificate-path` arg of `azure shell`