### PR TITLE
🐛 pass down a golang-recognized protocol for TLS discovery (v7 backport)

### DIFF
--- a/resources/packs/core/port.go
+++ b/resources/packs/core/port.go
@@ -427,25 +427,25 @@ func (p *mqlPorts) listLinux() ([]interface{}, error) {
 	}
 
 	var ports []interface{}
-	tcpPorts, err := p.parseProcNet("/proc/net/tcp", "tcp", users, getProcess)
+	tcpPorts, err := p.parseProcNet("/proc/net/tcp", "ipv4", users, getProcess)
 	if err != nil {
 		return nil, err
 	}
 	ports = append(ports, tcpPorts...)
 
-	udpPorts, err := p.parseProcNet("/proc/net/udp", "udp", users, getProcess)
+	udpPorts, err := p.parseProcNet("/proc/net/udp", "ipv4", users, getProcess)
 	if err != nil {
 		return nil, err
 	}
 	ports = append(ports, udpPorts...)
 
-	tcpPortsV6, err := p.parseProcNet("/proc/net/tcp6", "tcp", users, getProcess)
+	tcpPortsV6, err := p.parseProcNet("/proc/net/tcp6", "ipv6", users, getProcess)
 	if err != nil {
 		return nil, err
 	}
 	ports = append(ports, tcpPortsV6...)
 
-	udpPortsV6, err := p.parseProcNet("/proc/net/udp6", "udp", users, getProcess)
+	udpPortsV6, err := p.parseProcNet("/proc/net/udp6", "ipv6", users, getProcess)
 	if err != nil {
 		return nil, err
 	}

--- a/resources/packs/core/tls.go
+++ b/resources/packs/core/tls.go
@@ -178,6 +178,11 @@ func (s *mqlTls) GetParams(socket Socket, domainName string) (map[string]interfa
 		return nil, err
 	}
 
+	// a proto of ipv6 or ipv4 isn't usable by the golang net package
+	if proto == "ipv6" || proto == "ipv4" {
+		proto = "tcp"
+	}
+
 	tester := tlsshake.New(proto, domainName, host, int(port))
 	if err := tester.Test(tlsshake.DefaultScanConfig()); err != nil {
 		return nil, err


### PR DESCRIPTION
ipv4 and ipv6 are not recognized as protocols when being parsed through golang's net package. While something like 'ip6:tcp' is accepted, it then causes further problems when opening the socket connection.

Just set the protocol to tcp as what was happening on Linux.

But!, change the linux protocol field when parting /proc/net to match what we do in other OSes (namely setting ipv4 and ipv6 as the protocol when appropriate).

Before this PR's changes, you can see no TLS certificate date fetched from an ipv4 endpoint (a non-Windows/Darwin-specific fix - that also affects
Windows/Darwin - on ipv6 is fixed in #875).
```
>c:\Users\canef\cnquery.exe run local -c "ports.listening.where(port == 11443)[1]{ tls.certificates.length }"
→ discover related assets for 1 asset(s)
→ resolved assets resolved-assets=1
ports.listening.where[1]: {
  tls.certificates.length: 0
}
```

Now we can fetch TLS cert data:
```
>cnquery-fixed.exe run local -c "ports.listening.where(port == 11443)[1]{ tls.certificates.length }"
→ discover related assets for 1 asset(s)
→ resolved assets resolved-assets=1
ports.listening.where[1]: {
  tls.certificates.length: 2
}
```

---------

Signed-off-by: Joel Diaz <joel@mondoo.com>