### PR TITLE
🐛 jobpool and aws creds error handling

### DIFF
--- a/motor/providers/aws/provider.go
+++ b/motor/providers/aws/provider.go
@@ -94,14 +94,18 @@ func New(pCfg *providers.Config, opts ...ProviderOption) (*Provider, error) {
 	// gather information about the aws account
 	identity, err := CheckIam(t.config)
 	if err != nil {
+		log.Debug().Err(err).Msg("could not gather details of AWS account")
 		// try with govcloud region
 		t.config.Region = "us-gov-west-1"
 		identity, err = CheckIam(t.config)
 		if err != nil {
-			log.Warn().Err(err).Msg("could not gather details of AWS account")
-			// do not error since this break with localstack
+			log.Debug().Err(err).Msg("could not gather details of AWS account")
+			return nil, err
 		}
-	} else {
+	}
+
+	// either the regular check or the gov-check worked
+	if err == nil {
 		t.info = Info{
 			Account:          toString(identity.Account),
 			Arn:              toString(identity.Arn),

--- a/resources/library/jobpool/jobpool.go
+++ b/resources/library/jobpool/jobpool.go
@@ -1,6 +1,7 @@
 package jobpool
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -72,7 +73,11 @@ func NewJob(f func() (JobResult, error)) *Job {
 
 // Run runs a job and does appropriate accounting via a given sync.WorkGroup
 func (t *Job) Run(wg *sync.WaitGroup) {
-	t.Result, t.Err = t.f()
+	if t.f == nil {
+		t.Err = fmt.Errorf("no funtion to run in jobpool: %s", t.Err)
+	} else {
+		t.Result, t.Err = t.f()
+	}
 	wg.Done()
 }
 


### PR DESCRIPTION
First commit tries to handle the case where the jobpool wasn't completely set up b/c of a permissions/credentials error (for example when building the job pool and hitting https://github.com/mondoohq/cnquery/blob/main/resources/packs/aws/aws_vpcs.go#L58 ). Just check the job function for nil before calling it.

Second commit doesn't try to bury the initial credentials errors, and just errors early before we get further down the discovery codepaths.