### PR TITLE
⭐️ detect PLCnext as platform and read its version and build

### DIFF
--- a/motor/platform/detector/detector_test.go
+++ b/motor/platform/detector/detector_test.go
@@ -731,6 +731,20 @@ func TestBusyboxLinuxDetector(t *testing.T) {
 	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
 }
 
+func TestPlcNextLinuxDetector(t *testing.T) {
+	detector, err := newDetector("./testdata/detect-plcnext.toml")
+	assert.Nil(t, err, "was able to create the transport")
+	di, err := detector.Platform()
+	require.NoError(t, err)
+
+	assert.Equal(t, "plcnext", di.Name, "os name should be identified")
+	assert.Equal(t, "PLCnext", di.Title, "os title should be identified")
+	assert.Equal(t, "23.0.0.65", di.Version, "os version should be identified")
+	assert.Equal(t, "d755854b5b21ecb8dca26b0a560e6842a0c638d7", di.Build, "os build version should be identified")
+	assert.Equal(t, "armv7l", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
+}
+
 func TestWindows2016Detector(t *testing.T) {
 	detector, err := newDetector("./testdata/detect-windows2016.toml")
 	assert.Nil(t, err, "was able to create the transport")

--- a/motor/platform/detector/testdata/detect-plcnext.toml
+++ b/motor/platform/detector/testdata/detect-plcnext.toml
@@ -1,0 +1,15 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "armv7l"
+
+[commands."uname -r"]
+stdout = "5.4.193-rt74-pxc"
+
+[files."/etc/plcnext/arpversion"]
+content = """
+Arpversion: 23.0.0.65
+GIT Commit Hash: d755854b5b21ecb8dca26b0a560e6842a0c638d7
+Build Job: "jenkins-PLCnext-Yocto_Targets-Yocto_AXCF2152-release%2F23.0.x-65"
+"""


### PR DESCRIPTION
Detects https://www.plcnext-community.net / https://github.com/plcnext as valid operating system.

```
platform: {
  name: "plcnext"
  build: "d755854b5b21ecb8dca26b0a560e6842a0c638d7"
  title: "PLCnext"
  version: "23.0.0.65"
}
```