### PR TITLE
🐛 Fix arch detection of scratch containers

### DIFF
--- a/motor/platform/detector/platform_resolver.go
+++ b/motor/platform/detector/platform_resolver.go
@@ -41,9 +41,11 @@ func (r *PlatformResolver) Resolve(p os.OperatingSystemProvider) (*platform.Plat
 
 	_, ok = p.(*docker_engine.Provider)
 	if resolved && ok {
+		pi.Arch = p.(*docker_engine.Provider).PlatformArchitecture
 		// if the platform name is not set, we should fallback to the scratch operating system
 		if len(pi.Name) == 0 {
 			di.Name = "scratch"
+			di.Arch = pi.Arch
 			return di, true
 		}
 	}

--- a/motor/providers/container/docker_engine/docker_engine.go
+++ b/motor/providers/container/docker_engine/docker_engine.go
@@ -41,6 +41,16 @@ func New(container string) (*Provider, error) {
 		kind:         providers.Kind_KIND_CONTAINER,
 		runtime:      providers.RUNTIME_DOCKER_CONTAINER,
 	}
+
+	// this can later be used for containers build from scratch
+	serverVersion, err := dockerClient.ServerVersion(context.Background())
+	if err != nil {
+		log.Debug().Err(err).Msg("docker> cannot get server version")
+	} else {
+		log.Debug().Interface("serverVersion", serverVersion).Msg("docker> server version")
+		t.PlatformArchitecture = serverVersion.Arch
+	}
+
 	t.Fs = &FS{
 		dockerClient: t.dockerClient,
 		Container:    t.container,
@@ -55,7 +65,8 @@ type Provider struct {
 	container    string
 	Fs           *FS
 
-	PlatformIdentifier string
+	PlatformIdentifier   string
+	PlatformArchitecture string
 	// optional metadata to store additional information
 	Metadata struct {
 		Name   string


### PR DESCRIPTION
Before this change, we couldn't show an architecture for running containers build from scratch images:
```
cnquery run container 1ff13294e780 -c 'platform{ name arch }'
→ discover related assets for 1 asset(s)
→ resolved assets resolved-assets=1
platform: {
  arch: ""
  name: "scratch"
}
```
The reason was, we couldn't execute any command or read any file inside the container.

But we can query the docker daemon for the architecture:
```
cnquery run container 1ff13294e780 -c 'platform{ name arch }'
→ discover related assets for 1 asset(s)
→ resolved assets resolved-assets=1
platform: {
  arch: "amd64"
  name: "scratch"
}
```

Signed-off-by: Christian Zunker <christian@mondoo.com>