### PR TITLE
🐛 fix empty iddetector

### DIFF
--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -405,8 +405,9 @@ func getCobraScanConfig(cmd *cobra.Command, args []string, provider providers.Pr
 
 	// determine the scan config from pipe or args
 	flagAsset := builder.ParseTargetAsset(cmd, args, provider, assetType)
-	iddetector, _ := cmd.Flags().GetString("id-detector")
-	flagAsset.IdDetector = []string{iddetector}
+	if iddetector, _ := cmd.Flags().GetString("id-detector"); iddetector != "" {
+		flagAsset.IdDetector = []string{iddetector}
+	}
 	conf.Inventory, err = inventoryloader.ParseOrUse(flagAsset, viper.GetBool("insecure"))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not load configuration")


### PR DESCRIPTION
Without this change, the default value for `iddetector` can be `""` empty string, which is then handed down all the way to `motor/motorid`, where it then fails, because it falls through the empty check and then tries to run with an empty string ID-detector, not finding anything.

Fixes the issue introduced in e806cb11033f058b7c584bea8389fafd07bbc28c.

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>