### PR TITLE
🐛 Make sure GCP alert policies conditions are always parsed correctly

### DIFF
--- a/resources/packs/gcp/logging.go
+++ b/resources/packs/gcp/logging.go
@@ -214,9 +214,17 @@ func (g *mqlGcpProjectLoggingserviceMetric) GetAlertPolicies() ([]interface{}, e
 
 func parseAlertPolicyConditionFilterMetricName(condition map[string]interface{}) string {
 	filter := condition["filter"].(string)
-	// The filter looks like this: metric.type=\"logging.googleapis.com/user/log-metric-filter-and-alerts-exist-for-project-ownership-assignments-changes\"
-	// We are interested in the user part of that string
-	return strings.TrimSuffix(strings.TrimPrefix(filter, "metric.type=\"logging.googleapis.com/user/"), "\"")
+	// The filter is composed of multiple statements split by AND or OR and spaces in between
+	parts := strings.Split(filter, " ")
+	for _, p := range parts {
+		// If the statement starts with metric.type="logging.googleapis.com/user/ then we are interested in it
+		if strings.HasPrefix(p, "metric.type=\"logging.googleapis.com/user/") {
+			// The filter looks like this: metric.type=\"logging.googleapis.com/user/log-metric-filter-and-alerts-exist-for-project-ownership-assignments-changes\"
+			// We are interested in the user part of that string
+			return strings.TrimSuffix(strings.TrimPrefix(p, "metric.type=\"logging.googleapis.com/user/"), "\"")
+		}
+	}
+	return ""
 }
 
 func (g *mqlGcpProjectLoggingservice) GetSinks() ([]interface{}, error) {


### PR DESCRIPTION
GCP alert policies condition filters can be complex queries with more than 1 statement in them. The assumption before was that the condition filter looks like this:
```
filter: "metric.type=\"logging.googleapis.com/user/major-foo-1\""
```
However, we just learned that this is not the case and valid filters are also:
```
filter: "metric.type=\"logging.googleapis.com/user/pass-audit-config-changes-0br0\" AND resource.type=\"metric\""
```

This PR makes sure the filter is split on ` ` and then every segment is checked until we locate the one containing the `metric.type`. Then we extract the metric name.