### PR TITLE
🧹Parse okta profile correctly. Use OKTA_CLIENT_TOKEN env var over --token if set

### DIFF
--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -602,12 +602,18 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 			connection.Options["organization"] = organization
 		}
 
-		if x, err := cmd.Flags().GetString("token"); err != nil {
-			log.Fatal().Err(err).Msg("cannot parse --token value")
-		} else if x != "" {
+		// the env var has precedence over --token
+		token := os.Getenv("OKTA_CLIENT_TOKEN")
+		if token == "" {
+			if token, err = cmd.Flags().GetString("token"); err != nil {
+				log.Fatal().Err(err).Msg("cannot parse --token value")
+			}
+		}
+
+		if token != "" {
 			connection.Credentials = append(connection.Credentials, &vault.Credential{
 				Type:     vault.CredentialType_password,
-				Password: x,
+				Password: token,
 			})
 		}
 	case providers.ProviderType_GOOGLE_WORKSPACE:

--- a/motor/providers/okta/okta.go
+++ b/motor/providers/okta/okta.go
@@ -41,7 +41,7 @@ func New(pCfg *providers.Config) (*Provider, error) {
 	}
 
 	if token == "" {
-		return nil, errors.New("a valid Okta token is required, pass --token '<yourtoken>'")
+		return nil, errors.New("a valid Okta token is required, pass --token '<yourtoken>' or set OKTA_CLIENT_TOKEN environment variable")
 	}
 
 	_, client, err := okta.NewClient(

--- a/resources/packs/okta/users.go
+++ b/resources/packs/okta/users.go
@@ -72,6 +72,12 @@ func newMqlOktaUser(runtime *resources.Runtime, user *okta.User) (interface{}, e
 		return nil, err
 	}
 
+	profileDict := map[string]interface{}{}
+	if user.Profile != nil {
+		for k, v := range *user.Profile {
+			profileDict[k] = v
+		}
+	}
 	return runtime.CreateResource("okta.user",
 		"id", user.Id,
 		"type", userType,
@@ -81,7 +87,7 @@ func newMqlOktaUser(runtime *resources.Runtime, user *okta.User) (interface{}, e
 		"lastLogin", user.LastLogin,
 		"lastUpdated", user.LastUpdated,
 		"passwordChanged", user.PasswordChanged,
-		"profile", user.Profile,
+		"profile", profileDict,
 		"status", user.Status,
 		"statusChanged", user.StatusChanged,
 		"transitioningToStatus", user.TransitioningToStatus,


### PR DESCRIPTION
The okta provider now supports using the `OKTA_CLIENT_TOKEN` env var to get a token. This makes the --token arg optional.

Using an env var, token is optional
```
OKTA_CLIENT_TOKEN=<token> cnquery shell okta --organization <org>
```
Using a token
```
cnquery shell okta --organization <org> --token <token>
```

Using both, the env var will have precedence
```
OKTA_CLIENT_TOKEN=<token> cnquery shell okta --organization <org> --token <token>
```

Furthermore, this PR also fixes retrieving an okta user profile by making sure it's a correct dictionary, allowing queries on it.
Before:
```
cnquery> okta.users{profile}
okta.users: [
  0: {
    profile: &map[email:preslav@mondoo.com firstName:Preslav lastName:Gerchev login:preslav@mondoo.com mobilePhone:<nil> secondEmail:<nil>]
  }
]
```

After:
```
cnquery> okta.users{profile}
okta.users: [
  0: {
    profile: {
      email: "preslav@mondoo.com"
      firstName: "Preslav"
      lastName: "Gerchev"
      login: "preslav@mondoo.com"
      mobilePhone: null
      secondEmail: null
    }
  }
]
```



