### PR TITLE
Move env var check for slack to the cmd parser.

### DIFF
--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -626,12 +626,17 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 	case providers.ProviderType_SLACK:
 		connection.Backend = providerType
 
-		if x, err := cmd.Flags().GetString("token"); err != nil {
-			log.Fatal().Err(err).Msg("cannot parse --token value")
-		} else if x != "" {
+		// the env var has precedence over --token
+		token := os.Getenv("SLACK_TOKEN")
+		if token == "" {
+			if token, err = cmd.Flags().GetString("token"); err != nil {
+				log.Fatal().Err(err).Msg("cannot parse --token value")
+			}
+		}
+		if token != "" {
 			connection.Credentials = append(connection.Credentials, &vault.Credential{
 				Type:     vault.CredentialType_password,
-				Password: x,
+				Password: token,
 			})
 		}
 	case providers.ProviderType_VCD:

--- a/motor/providers/slack/provider.go
+++ b/motor/providers/slack/provider.go
@@ -2,7 +2,6 @@ package slack
 
 import (
 	"errors"
-	"os"
 
 	"github.com/rs/zerolog/log"
 	"github.com/slack-go/slack"
@@ -17,12 +16,8 @@ var (
 
 func New(pCfg *providers.Config) (*Provider, error) {
 	// check if the token was provided by the option. This way is deprecated since it does not pass the token as secret
+	// FIXME: remove me in v8.0
 	token := pCfg.Options["token"]
-
-	// if no token was provided, lets read the env variable
-	if token == "" {
-		token = os.Getenv("SLACK_TOKEN")
-	}
 
 	// if a secret was provided, it always overrides the env variable since it has precedence
 	if len(pCfg.Credentials) > 0 {


### PR DESCRIPTION
Similar to #943, move the env var check to the command parser for Slack. Add a FIXME to remove a deprecated inventory file option.