### PR TITLE
✨ Change ports proto to include tpc/udp + IPv4/6

### DIFF
--- a/resources/packs/core/port.go
+++ b/resources/packs/core/port.go
@@ -474,25 +474,25 @@ func (p *mqlPorts) listLinux() ([]interface{}, error) {
 	}
 
 	var ports []interface{}
-	tcpPorts, err := p.parseProcNet("/proc/net/tcp", "ipv4", users, getProcess)
+	tcpPorts, err := p.parseProcNet("/proc/net/tcp", "tcp4", users, getProcess)
 	if err != nil {
 		return nil, err
 	}
 	ports = append(ports, tcpPorts...)
 
-	udpPorts, err := p.parseProcNet("/proc/net/udp", "ipv4", users, getProcess)
+	udpPorts, err := p.parseProcNet("/proc/net/udp", "udp4", users, getProcess)
 	if err != nil {
 		return nil, err
 	}
 	ports = append(ports, udpPorts...)
 
-	tcpPortsV6, err := p.parseProcNet("/proc/net/tcp6", "ipv6", users, getProcess)
+	tcpPortsV6, err := p.parseProcNet("/proc/net/tcp6", "tcp6", users, getProcess)
 	if err != nil {
 		return nil, err
 	}
 	ports = append(ports, tcpPortsV6...)
 
-	udpPortsV6, err := p.parseProcNet("/proc/net/udp6", "ipv6", users, getProcess)
+	udpPortsV6, err := p.parseProcNet("/proc/net/udp6", "udp6", users, getProcess)
 	if err != nil {
 		return nil, err
 	}
@@ -590,9 +590,9 @@ func (p *mqlPorts) parseWindowsPorts(r io.Reader, processes map[int64]Process) (
 
 		process := processes[port.OwningProcess]
 
-		protocol := "ipv4"
+		protocol := "tcp4"
 		if strings.Contains(port.LocalAddress, ":") {
-			protocol = "ipv6"
+			protocol = "tcp6"
 		}
 
 		obj, err := p.MotorRuntime.CreateResource("port",
@@ -666,9 +666,11 @@ func (p *mqlPorts) listMacos() ([]interface{}, error) {
 			}
 			mqlProcess := processes[int64(pid)]
 
-			protocol := "ipv4"
+			protocol := strings.ToLower(fd.Protocol)
 			if fd.Type == lsof.FileTypeIPv6 {
-				protocol = "ipv6"
+				protocol = protocol + "6"
+			} else {
+				protocol = protocol + "4"
 			}
 
 			localAddress, localPort, remoteAddress, remotePort, err := fd.NetworkFile()

--- a/resources/packs/core/tls.go
+++ b/resources/packs/core/tls.go
@@ -178,11 +178,6 @@ func (s *mqlTls) GetParams(socket Socket, domainName string) (map[string]interfa
 		return nil, err
 	}
 
-	// a proto of ipv6 or ipv4 isn't usable by the golang net package
-	if proto == "ipv6" || proto == "ipv4" {
-		proto = "tcp"
-	}
-
 	tester := tlsshake.New(proto, domainName, host, int(port))
 	if err := tester.Test(tlsshake.DefaultScanConfig()); err != nil {
 		return nil, err


### PR DESCRIPTION
The new way the proto is saved, allows for new filtering, like:
```
cnquery run local -c "ports.listening.where(protocol == /6/)" 
...
ports.listening.where: [
  0: port port=111 protocol="tcp6" address="[::]" process.executable=no data available
  1: port port=443 protocol="tcp6" address="[::]" process.executable=no data available
  2: port port=631 protocol="tcp6" address="[::1]" process.executable=no data available
  3: port port=8989 protocol="tcp6" address="[::]" process.executable="nexus"
]
```
or
```
cnquery run local -c "ports.listening.where(protocol == /tcp/)" 
...
ports.listening.where: [
  0: port port=53 protocol="tcp4" address="127.0.0.53" process.executable=no data available
  1: port port=53 protocol="tcp4" address="192.168.122.1" process.executable=no data available
  2: port port=29578 protocol="tcp4" address="127.0.0.1" process.executable="postgres"
  3: port port=111 protocol="tcp4" address="0.0.0.0" process.executable=no data available
  4: port port=443 protocol="tcp4" address="0.0.0.0" process.executable=no data available
  5: port port=47475 protocol="tcp4" address="127.0.0.1" process.executable="postgres"
  6: port port=15205 protocol="tcp4" address="127.0.0.1" process.executable="postgres"
  7: port port=5433 protocol="tcp4" address="127.0.0.1" process.executable="postgres"
  8: port port=40685 protocol="tcp4" address="127.0.0.1" process.executable="postgres"
  9: port port=40463 protocol="tcp4" address="127.0.0.1" process.executable="exe"
  10: port port=6463 protocol="tcp4" address="127.0.0.1" process.executable="Discord"
  11: port port=631 protocol="tcp4" address="127.0.0.1" process.executable=no data available
  12: port port=19287 protocol="tcp4" address="127.0.0.1" process.executable="postgres"
  13: port port=111 protocol="tcp6" address="[::]" process.executable=no data available
  14: port port=443 protocol="tcp6" address="[::]" process.executable=no data available
  15: port port=631 protocol="tcp6" address="[::1]" process.executable=no data available
  16: port port=8989 protocol="tcp6" address="[::]" process.executable="nexus"
]
```

Before, depending on the version, we only had the IP protocol version or the transport protocol. Now we have both in the same field.

This is the list of the go supported protocols: https://cs.opensource.google/go/go/+/refs/tags/go1.20.1:src/net/dial.go;l=286

This is a follow-up to the discussion in https://github.com/mondoohq/cnquery/pull/878/files