### PR TITLE
🧹 Add --credentials-path param for gcp/googleworkspace commands.

### DIFF
--- a/apps/cnquery/cmd/builder/builder.go
+++ b/apps/cnquery/cmd/builder/builder.go
@@ -609,6 +609,7 @@ func scanGcpCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn
 			viper.BindPFlag("organization", cmd.Flags().Lookup("organization"))
 			viper.BindPFlag("project-id", cmd.Flags().Lookup("project-id"))
 			viper.BindPFlag("organization-id", cmd.Flags().Lookup("organization-id"))
+			viper.BindPFlag("credentials-path", cmd.Flags().Lookup("credentials-path"))
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			runFn(cmd, args, providers.ProviderType_GCP, DefaultAssetType)
@@ -623,6 +624,7 @@ func scanGcpCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn
 	cmd.Flags().MarkHidden("organization")
 	cmd.Flags().MarkDeprecated("organization", "--organization is deprecated in favor of --organization-id")
 	cmd.Flags().String("organization-id", "", "specify the GCP organization ID to scan")
+	cmd.Flags().String("credentials-path", "", "The path to the service account credentials to access the APIs with")
 	return cmd
 }
 
@@ -635,12 +637,14 @@ func scanGcpOrgCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn ru
 		Args:    cobra.ExactArgs(1),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			preRun(cmd, args)
+			viper.BindPFlag("credentials-path", cmd.Flags().Lookup("credentials-path"))
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			runFn(cmd, args, providers.ProviderType_GCP, GcpOrganizationAssetType)
 		},
 	}
 	commonCmdFlags(cmd)
+	cmd.Flags().String("credentials-path", "", "The path to the service account credentials to access the APIs with")
 	return cmd
 }
 
@@ -652,12 +656,14 @@ func scanGcpProjectCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runF
 		Args:  cobra.ExactArgs(1),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			preRun(cmd, args)
+			viper.BindPFlag("credentials-path", cmd.Flags().Lookup("credentials-path"))
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			runFn(cmd, args, providers.ProviderType_GCP, GcpProjectAssetType)
 		},
 	}
 	commonCmdFlags(cmd)
+	cmd.Flags().String("credentials-path", "", "The path to the service account credentials to access the APIs with")
 	return cmd
 }
 
@@ -669,12 +675,14 @@ func scanGcpFolderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn
 		Args:  cobra.ExactArgs(1),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			preRun(cmd, args)
+			viper.BindPFlag("credentials-path", cmd.Flags().Lookup("credentials-path"))
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			runFn(cmd, args, providers.ProviderType_GCP, GcpFolderAssetType)
 		},
 	}
 	commonCmdFlags(cmd)
+	cmd.Flags().String("credentials-path", "", "The path to the service account credentials to access the APIs with")
 	return cmd
 }
 
@@ -903,6 +911,7 @@ func scanGoogleWorkspaceCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlag("customer-id", cmd.Flags().Lookup("customer-id"))
 			viper.BindPFlag("impersonated-user-email", cmd.Flags().Lookup("impersonated-user-email"))
+			viper.BindPFlag("credentials-path", cmd.Flags().Lookup("credentials-path"))
 
 			preRun(cmd, args)
 		},
@@ -913,6 +922,8 @@ func scanGoogleWorkspaceCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn,
 	commonCmdFlags(cmd)
 	cmd.Flags().String("customer-id", "", "Specify the Google Workspace customer id to scan")
 	cmd.Flags().String("impersonated-user-email", "", "The impersonated user's email with access to the Admin APIs")
+	cmd.Flags().String("credentials-path", "", "The path to the service account credentials to access the APIs with")
+
 	return cmd
 }
 

--- a/motor/providers/google/clients.go
+++ b/motor/providers/google/clients.go
@@ -29,11 +29,6 @@ func (t *Provider) Credentials(scopes ...string) (*googleoauth.Credentials, erro
 		return googleoauth.CredentialsFromJSONWithParams(ctx, data, credParams)
 	}
 
-	if t.serviceAccountSubject != "" {
-		// use custom service account provided by user
-		return googleoauth.CredentialsFromJSONWithParams(ctx, t.serviceAccount, credParams)
-	}
-
 	// otherwise fallback to default google sdk authentication
 	log.Debug().Msg("fallback to default google sdk authentication")
 	return googleoauth.FindDefaultCredentials(ctx, scopes...)
@@ -49,11 +44,6 @@ func (t *Provider) Client(scope ...string) (*http.Client, error) {
 			return nil, err
 		}
 		return serviceAccountAuth(ctx, t.serviceAccountSubject, data, scope...)
-	}
-
-	// use service account authentication if we loaded a service account
-	if t.serviceAccount != nil {
-		return serviceAccountAuth(ctx, t.serviceAccountSubject, t.serviceAccount, scope...)
 	}
 
 	// otherwise fallback to default google sdk authentication

--- a/motor/providers/google/provider.go
+++ b/motor/providers/google/provider.go
@@ -2,7 +2,6 @@ package google
 
 import (
 	"errors"
-	"os"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/motor/providers"
@@ -162,15 +161,4 @@ func (p *Provider) PlatformIdDetectors() []providers.PlatformIdDetector {
 	return []providers.PlatformIdDetector{
 		providers.TransportPlatformIdentifierDetector,
 	}
-}
-
-func loadCredentialsFromEnv(envs ...string) ([]byte, error) {
-	for i := range envs {
-		val := os.Getenv(envs[i])
-		if val != "" {
-			return os.ReadFile(val)
-		}
-	}
-
-	return nil, nil
 }


### PR DESCRIPTION
This PR adds `--credentials-path` arg to both `gcp` and `googleworkspace` shell/scan commands.

Furthermore it moves out the env var reading to the commands, the provider now only works with credentials, making it easy to do a inventory-file scan.

Environment variables will have precedence over the new `--credentials-path` arg

Examples:

With env var:
```
GOOGLE_APPLICATION_CREDENTIALS=~/mondoo-dev-1111111.json cnquery shell gcp
```

With `--credentials-path`:
```
cnquery shell gcp --credentials-path ~/mondoo-dev-1111111.json
```



