### PR TITLE
✨ use variable names in labels

### DIFF
--- a/cli/printer/printer_test.go
+++ b/cli/printer/printer_test.go
@@ -200,7 +200,7 @@ func TestPrinter(t *testing.T) {
 		},
 		{
 			"a = 3\n if(true) {\n a == 3 \n}",
-			"-> block 1\n   entrypoints: [<1,2>]\n   1: 3\n   2: if bind: <0,0> type:block (true, => <2,0>, [\n     0: ref<1,1>\n   ])\n-> block 2\n   entrypoints: [<2,2>]\n   1: ref<1,1>\n   2: ==\x05 bind: <1,1> type:bool (3)\n",
+			"-> block 1\n   entrypoints: [<1,2>]\n   1: 3\n   2: if bind: <0,0> type:block (true, => <2,0>, [\n     0: ref<1,1>\n   ])\n-> block 2\n   entrypoints: [<2,2>]\n   1: ref<1,1>\n   2: ==\x05 bind: <2,1> type:bool (3)\n",
 			[]string{"if: {\n  a == 3: true\n}"},
 		},
 		{

--- a/llx/code.go
+++ b/llx/code.go
@@ -1,6 +1,7 @@
 package llx
 
 import (
+	"bytes"
 	"sort"
 
 	"go.mondoo.com/cnquery/checksums"
@@ -499,7 +500,15 @@ func ComparableLabel(label string) (string, bool) {
 		return "", false
 	}
 
-	x := label[0:1]
+	start := 0
+	for bytes.IndexByte(comparableIndicators, label[start]) == -1 {
+		start++
+		if start >= len(label) {
+			return "", false
+		}
+	}
+
+	x := label[start : start+1]
 	if _, ok := comparableOperations[x]; ok {
 		return x, true
 	}
@@ -507,13 +516,15 @@ func ComparableLabel(label string) (string, bool) {
 		return "", false
 	}
 
-	x = label[0:2]
+	x = label[start : start+2]
 	if _, ok := comparableOperations[x]; ok {
 		return x, true
 	}
 
 	return "", false
 }
+
+var comparableIndicators = []byte{'=', '!', '>', '<', '&', '|'}
 
 var comparableOperations = map[string]struct{}{
 	"==": {},

--- a/mqlc/labels_test.go
+++ b/mqlc/labels_test.go
@@ -165,6 +165,11 @@ func TestLabels(t *testing.T) {
 			&llx.Labels{
 				Labels: map[string]string{
 					"FU1/hdJ5vadWluEfeQHhklVNU86zhW3zNwxraoHDXJYJj7X2AsjJkhuQjaCfx607pvV/Yjez346tOwzg7i9inQ==": "c",
+					// TODO: optimize the code so we don't generate these 2 labels vv
+					// they are not needed
+					"M3Zw1U5oVhZQeXdyvlpQc6tJz7LG6NiZ7oGQCr1eDSloV75R7lRObrv53UuaHvBOuZG3zBt5BDx9MRoRJwIlfA==": "a",
+					"lUa7PEZHR8EfRzYDn+Q38ZZTckepgNlv1sFhRL6l+v7gmV+v/7IxTAoJ2VlAHkCpNU5p5KFLPzPwn6K1Eq27XQ==": "b",
+					// ^^
 				},
 			},
 		},

--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -1232,6 +1232,8 @@ func (c *compiler) compileIdentifier(id string, callBinding *variable, calls []*
 			Primitive: llx.RefPrimitiveV2(variable.ref),
 		})
 		c.standalone = false
+		checksum := c.Result.CodeV2.Checksums[c.tailRef()]
+		c.Result.Labels.Labels[checksum] = variable.name
 		return restCalls, variable.typ, nil
 	}
 

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -1867,7 +1867,7 @@ func TestCompiler_Entrypoints(t *testing.T) {
 				c = "c"
 				c == "c"
 			`,
-			nil,
+			[]uint64{(1 << 32) | 3, (1 << 32) | 5, (1 << 32) | 8},
 			[]uint64{(1 << 32) | 4, (1 << 32) | 6, (1 << 32) | 9},
 		},
 		{
@@ -1879,7 +1879,7 @@ func TestCompiler_Entrypoints(t *testing.T) {
 				c = a == b
 				c == false
 			`,
-			[]uint64{(1 << 32) | 9},
+			[]uint64{(1 << 32) | 3, (1 << 32) | 5, (1 << 32) | 10},
 			[]uint64{(1 << 32) | 4, (1 << 32) | 6, (1 << 32) | 11},
 		},
 	}
@@ -1944,7 +1944,7 @@ func TestCompiler_NestedEntrypoints(t *testing.T) {
 					j == k
 				}
 			`,
-			[]uint64{},
+			[]uint64{(1 << 32) | 2},
 			[]uint64{(1 << 32) | 6, (2 << 32) | 5, (3 << 32) | 5, (4 << 32) | 5},
 		},
 		{

--- a/mqlc/operators.go
+++ b/mqlc/operators.go
@@ -168,12 +168,11 @@ func compileComparable(c *compiler, id string, call *parser.Call) (types.Type, e
 	}
 
 	for left.Type() == types.Ref {
-		var ok bool
-		leftRef, ok = left.Primitive.RefV2()
+		ref, ok := left.Primitive.RefV2()
 		if !ok {
 			return types.Nil, errors.New("failed to get reference entry of left operand to " + id + ", this should not happen")
 		}
-		left = c.Result.CodeV2.Chunk(leftRef)
+		left = c.Result.CodeV2.Chunk(ref)
 	}
 
 	// find specialized or generalized builtin function

--- a/resources/packs/core/core_test.go
+++ b/resources/packs/core/core_test.go
@@ -344,12 +344,12 @@ func TestOperations_Equality(t *testing.T) {
 			simpleTests = append(simpleTests, []testutils.SimpleTest{
 				{a + " == " + b, 0, res},
 				{a + " != " + b, 0, !res},
-				{"a = " + a + "  a == " + b, 0, res},
-				{"a = " + a + "  a != " + b, 0, !res},
+				{"a = " + a + "  a == " + b, 1, res},
+				{"a = " + a + "  a != " + b, 1, !res},
 				{"b = " + b + "; " + a + " == b", 1, res},
 				{"b = " + b + "; " + a + " != b", 1, !res},
-				{"a = " + a + "; b = " + b + "; a == b", 1, res},
-				{"a = " + a + "; b = " + b + "; a != b", 1, !res},
+				{"a = " + a + "; b = " + b + "; a == b", 2, res},
+				{"a = " + a + "; b = " + b + "; a != b", 2, !res},
 			}...)
 		}
 	}

--- a/resources/packs/os/secpol_test.go
+++ b/resources/packs/os/secpol_test.go
@@ -34,7 +34,7 @@ func TestResource_Secpol(t *testing.T) {
 	t.Run("test a specific secpol systemaccess entry", func(t *testing.T) {
 		res := testWindowsQuery(t, "secpol.privilegerights['SeNetworkLogonRight'] == ['S-1-1-0', 'S-1-5-32-544', 'S-1-5-32-545', 'S-1-5-32-551']")
 		assert.NotEmpty(t, res)
-		assert.Empty(t, res[0].Result().Error)
-		assert.Equal(t, true, res[0].Data.Value)
+		assert.Empty(t, res[1].Result().Error)
+		assert.Equal(t, true, res[1].Data.Value)
 	})
 }


### PR DESCRIPTION
Some queries can get very hard to read and understand, if there is a long preamble before the actual assertion. For example:

```
sshd.config('/etc/ssh/my_sshd_config').params["Protocol"] == 2
```

A way to simplify this is to use named variables. This allows users to write:

```
sshProto = sshd.config('/etc/ssh/my_sshd_config').params["Protocol"]
sshProto == 2
```

This is done with the intention to have the named variable show up in the result like this:

```
[failed] sshProto == 21
  expected: == 21
  actual:   "22"
```

However, up until this PR we would always bind the source of the reference, which lost track of the variable's name, and led to this:

```
[failed] sshd.config.params[Protocol] == 21
  expected: == 21
  actual:   "22"
```

This PR remedies it by retaining the original reference.

FYI @scottford-io @atomic111 