### PR TITLE
🐛 fix incorrect (and recursive) filter+docs unmarshal

### DIFF
--- a/explorer/filters.go
+++ b/explorer/filters.go
@@ -101,7 +101,9 @@ func (s *Filters) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	return json.Unmarshal(data, &s.Items)
+	// prevent recursive calls into UnmarshalJSON with a placeholder type
+	type tmp Filters
+	return json.Unmarshal(data, (*tmp)(s))
 }
 
 func (s *Filters) Compile(ownerMRN string) error {

--- a/explorer/mquery.go
+++ b/explorer/mquery.go
@@ -366,7 +366,9 @@ func (r *Remediation) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	return json.Unmarshal(data, r.Items)
+	// prevent recursive calls into UnmarshalJSON with a placeholder type
+	type tmp Remediation
+	return json.Unmarshal(data, (*tmp)(r))
 }
 
 func ChecksumFilters(queries []*Mquery) (string, error) {


### PR DESCRIPTION
1. unmarshaling into `filter.Items` doesn't make any sense, since we don't want users to set their own keys; they are computed and only used for deduplication/lookup
2. if we don't do the temporary type the `UnmarshalJSON` will be called recursively without end. This is true for both Filter and Remediation 