### PR TITLE
🧹 Мake GCP scanning consistent with other scan commands

### DIFF
--- a/apps/cnquery/cmd/builder/builder.go
+++ b/apps/cnquery/cmd/builder/builder.go
@@ -23,6 +23,9 @@ const (
 	Ec2ebsInstanceAssetType
 	Ec2ebsVolumeAssetType
 	Ec2ebsSnapshotAssetType
+	GcpOrganizationAssetType
+	GcpProjectAssetType
+	GcpFolderAssetType
 	GcrContainerRegistryAssetType
 	GithubOrganizationAssetType
 	GithubRepositoryAssetType
@@ -121,6 +124,9 @@ func buildCmd(baseCmd *cobra.Command, commonCmdFlags commonFlagsFn, preRun commo
 	gcpCmd := scanGcpCmd(commonCmdFlags, preRun, runFn, docs)
 	gcpGcrCmd := scanGcpGcrCmd(commonCmdFlags, preRun, runFn, docs)
 	gcpCmd.AddCommand(gcpGcrCmd)
+	gcpCmd.AddCommand(scanGcpOrgCmd(commonCmdFlags, preRun, runFn, docs))
+	gcpCmd.AddCommand(scanGcpProjectCmd(commonCmdFlags, preRun, runFn, docs))
+	gcpCmd.AddCommand(scanGcpFolderCmd(commonCmdFlags, preRun, runFn, docs))
 
 	// vsphere subcommand
 	vsphereCmd := vsphereProviderCmd(commonCmdFlags, preRun, runFn, docs)
@@ -617,6 +623,58 @@ func scanGcpCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn
 	cmd.Flags().MarkHidden("organization")
 	cmd.Flags().MarkDeprecated("organization", "--organization is deprecated in favor of --organization-id")
 	cmd.Flags().String("organization-id", "", "specify the GCP organization ID to scan")
+	return cmd
+}
+
+func scanGcpOrgCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "org ORGANIZATION-ID",
+		Aliases: []string{"organization"},
+		Short:   docs.GetShort("gcp-org"),
+		Long:    docs.GetLong("gcp-org"),
+		Args:    cobra.ExactArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			preRun(cmd, args)
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			runFn(cmd, args, providers.ProviderType_GCP, GcpOrganizationAssetType)
+		},
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func scanGcpProjectCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "project PROJECT-ID",
+		Short: docs.GetShort("gcp-project"),
+		Long:  docs.GetLong("gcp-project"),
+		Args:  cobra.ExactArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			preRun(cmd, args)
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			runFn(cmd, args, providers.ProviderType_GCP, GcpProjectAssetType)
+		},
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func scanGcpFolderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "folder FOLDER-ID",
+		Short: docs.GetShort("gcp-folder"),
+		Long:  docs.GetLong("gcp-folder"),
+		Args:  cobra.ExactArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			preRun(cmd, args)
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			runFn(cmd, args, providers.ProviderType_GCP, GcpFolderAssetType)
+		},
+	}
+	commonCmdFlags(cmd)
 	return cmd
 }
 

--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -389,30 +389,45 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 	case providers.ProviderType_GCP:
 		connection.Backend = providerType
 
-		// deprecated, remove in v8
-		if project, err := cmd.Flags().GetString("project"); err != nil {
-			log.Fatal().Err(err).Msg("cannot parse --project value")
-		} else if project != "" {
-			connection.Options["project-id"] = project
-		}
+		switch assetType {
+		case DefaultAssetType:
+			// deprecated, remove in v8
+			if project, err := cmd.Flags().GetString("project"); err != nil {
+				log.Fatal().Err(err).Msg("cannot parse --project value")
+			} else if project != "" {
+				log.Warn().Msg("--project flag is deprecated, use `scan gcp project` instead")
+				connection.Options["project-id"] = project
+			}
 
-		// deprecated, remove in v8
-		if organization, err := cmd.Flags().GetString("organization"); err != nil {
-			log.Fatal().Err(err).Msg("cannot parse --organization value")
-		} else if organization != "" {
-			connection.Options["organization-id"] = organization
-		}
+			// deprecated, remove in v8
+			if organization, err := cmd.Flags().GetString("organization"); err != nil {
+				log.Fatal().Err(err).Msg("cannot parse --organization value")
+			} else if organization != "" {
+				log.Warn().Msg("--organization flag is deprecated, use `scan gcp org` instead")
+				connection.Options["organization-id"] = organization
+			}
 
-		if project, err := cmd.Flags().GetString("project-id"); err != nil {
-			log.Fatal().Err(err).Msg("cannot parse --project value")
-		} else if project != "" {
-			connection.Options["project-id"] = project
-		}
+			// deprecated, remove in v9
+			if project, err := cmd.Flags().GetString("project-id"); err != nil {
+				log.Fatal().Err(err).Msg("cannot parse --project value")
+			} else if project != "" {
+				log.Warn().Msg("--organization-id flag is deprecated, use `scan gcp project` instead")
+				connection.Options["project-id"] = project
+			}
 
-		if organization, err := cmd.Flags().GetString("organization-id"); err != nil {
-			log.Fatal().Err(err).Msg("cannot parse --organization value")
-		} else if organization != "" {
-			connection.Options["organization-id"] = organization
+			// deprecated, remove in v9
+			if organization, err := cmd.Flags().GetString("organization-id"); err != nil {
+				log.Fatal().Err(err).Msg("cannot parse --organization value")
+			} else if organization != "" {
+				log.Warn().Msg("--organization-id flag is deprecated, use `scan gcp org` instead")
+				connection.Options["organization-id"] = organization
+			}
+		case GcpOrganizationAssetType:
+			connection.Options["organization-id"] = args[0]
+		case GcpProjectAssetType:
+			connection.Options["project-id"] = args[0]
+		case GcpFolderAssetType:
+			connection.Options["folder-id"] = args[0]
 		}
 
 	case providers.ProviderType_VSPHERE:

--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -165,7 +165,16 @@ configuration for the account scan. To scan Azure virtual machines, you must
 configure your Azure credentials and have SSH access to the virtual machines.`,
 			},
 			"gcp": {
-				Short: "Scan a Google Cloud Platform (GCP) organization or project.",
+				Short: "Scan a Google Cloud Platform (GCP) organization, project or folder.",
+			},
+			"gcp-org": {
+				Short: "Scan a Google Cloud Platform (GCP) organization.",
+			},
+			"gcp-project": {
+				Short: "Scan a Google Cloud Platform (GCP) project.",
+			},
+			"gcp-folder": {
+				Short: "Scan a Google Cloud Platform (GCP) folder.",
 			},
 			"gcp-gcr": {
 				Short: "Scan a Google Container Registry (GCR).",


### PR DESCRIPTION
This PR sets up new commands for scanning GCP:
```bash
cnquery scan gcp org 342423 # <-- scan GCP organization; `org` and `organization` both work
cnquery scan gcp project mondoo-dev # <-- scan GCP project
cnquery scan gcp folder 3421423 # <-- scan GCP folder
```

The current commands still work but they show a deprecation warning message.

_Note that folder scanning doesn't work yet because it is still not merged into `main`. This should start working once #892 is merged._