### PR TITLE
🧹 mark azure and gcp related assets

### DIFF
--- a/motor/discovery/azure/resolver.go
+++ b/motor/discovery/azure/resolver.go
@@ -127,7 +127,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 			if err != nil {
 				return nil, err
 			}
-			id, _ := p.Identifier()
+			id, _ := provider.Identifier()
 			subAsset := &asset.Asset{
 				PlatformIds: []string{id},
 				Name:        name,
@@ -140,6 +140,9 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 				},
 			}
 			subsAssets[*sub.Sub.SubscriptionID] = subAsset
+			if root != nil {
+				subAsset.RelatedAssets = append(subAsset.RelatedAssets, root)
+			}
 			resolved = append(resolved, subAsset)
 		}
 	}
@@ -154,8 +157,12 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 				return nil, err
 			}
 			for _, a := range assetList {
-				if rootSub := subsAssets[id]; rootSub != nil {
-					a.RelatedAssets = append(a.RelatedAssets, rootSub)
+				if sub := subsAssets[id]; sub != nil {
+					a.RelatedAssets = append(a.RelatedAssets, sub)
+				}
+
+				if root != nil {
+					a.RelatedAssets = append(a.RelatedAssets, root)
 				}
 				resolved = append(resolved, a)
 			}
@@ -184,9 +191,13 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 					a.Connections[i].Insecure = tc.Insecure
 				}
 
-				if rootSub := subsAssets[*s.SubscriptionID]; rootSub != nil {
-					a.RelatedAssets = append(a.RelatedAssets, rootSub)
+				if sub := subsAssets[*s.SubscriptionID]; sub != nil {
+					a.RelatedAssets = append(a.RelatedAssets, sub)
 				}
+				if root != nil {
+					a.RelatedAssets = append(a.RelatedAssets, root)
+				}
+
 				resolved = append(resolved, a)
 			}
 		}

--- a/motor/discovery/azure/resolver.go
+++ b/motor/discovery/azure/resolver.go
@@ -140,6 +140,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 				},
 			}
 			subsAssets[*sub.Sub.SubscriptionID] = subAsset
+			// if there's a root, link the sub to it
 			if root != nil {
 				subAsset.RelatedAssets = append(subAsset.RelatedAssets, root)
 			}
@@ -157,10 +158,12 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 				return nil, err
 			}
 			for _, a := range assetList {
+				// if there's a sub available, link the asset to it
 				if sub := subsAssets[id]; sub != nil {
 					a.RelatedAssets = append(a.RelatedAssets, sub)
 				}
 
+				// if there's a root available, link the asset to it
 				if root != nil {
 					a.RelatedAssets = append(a.RelatedAssets, root)
 				}
@@ -191,9 +194,12 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 					a.Connections[i].Insecure = tc.Insecure
 				}
 
+				// if there's a sub available, link the asset to it
 				if sub := subsAssets[*s.SubscriptionID]; sub != nil {
 					a.RelatedAssets = append(a.RelatedAssets, sub)
 				}
+
+				// if there's a root available, link the asset to it
 				if root != nil {
 					a.RelatedAssets = append(a.RelatedAssets, root)
 				}

--- a/motor/discovery/gcp/resolver_folder.go
+++ b/motor/discovery/gcp/resolver_folder.go
@@ -101,7 +101,13 @@ func (r *GcpFolderResolver) Resolve(ctx context.Context, tc *providers.Config, c
 			if err != nil {
 				return nil, err
 			}
-			resolved = append(resolved, assets...)
+			for i := range assets {
+				a := assets[i]
+				if resolvedRoot != nil && a.Platform.Name == "gcp-project" {
+					a.RelatedAssets = append(a.RelatedAssets, resolvedRoot)
+				}
+				resolved = append(resolved, a)
+			}
 		}
 	}
 	return resolved, nil

--- a/motor/discovery/gcp/resolver_org.go
+++ b/motor/discovery/gcp/resolver_org.go
@@ -134,7 +134,7 @@ func (r *GcpOrgResolver) Resolve(ctx context.Context, tc *providers.Config, cred
 			}
 			for i := range assets {
 				a := assets[i]
-				if rootAsset != nil {
+				if rootAsset != nil && a.Platform.Name == "gcp-project" {
 					a.RelatedAssets = append(a.RelatedAssets, rootAsset)
 				}
 				resolved = append(resolved, a)

--- a/motor/discovery/gcp/resolver_org.go
+++ b/motor/discovery/gcp/resolver_org.go
@@ -139,7 +139,6 @@ func (r *GcpOrgResolver) Resolve(ctx context.Context, tc *providers.Config, cred
 				}
 				resolved = append(resolved, a)
 			}
-			resolved = append(resolved, assets...)
 		}
 	}
 

--- a/motor/discovery/gcp/resolver_org.go
+++ b/motor/discovery/gcp/resolver_org.go
@@ -96,6 +96,13 @@ func (r *GcpOrgResolver) Resolve(ctx context.Context, tc *providers.Config, cred
 			if err != nil {
 				return nil, err
 			}
+			for i := range assets {
+				a := assets[i]
+				if rootAsset != nil {
+					a.RelatedAssets = append(a.RelatedAssets, rootAsset)
+				}
+				resolved = append(resolved, a)
+			}
 			resolved = append(resolved, assets...)
 		}
 	}
@@ -124,6 +131,13 @@ func (r *GcpOrgResolver) Resolve(ctx context.Context, tc *providers.Config, cred
 			assets, err := (&GcpProjectResolver{}).Resolve(ctx, projectConfig, credsResolver, sfn, userIdDetectors...)
 			if err != nil {
 				return nil, err
+			}
+			for i := range assets {
+				a := assets[i]
+				if rootAsset != nil {
+					a.RelatedAssets = append(a.RelatedAssets, rootAsset)
+				}
+				resolved = append(resolved, a)
 			}
 			resolved = append(resolved, assets...)
 		}


### PR DESCRIPTION
ensure that gcp and azure assets are correctly assigned as related in the console ui