### PR TITLE
🐛 do not throw error for missing terraform configuration in hcl

### DIFF
--- a/resources/packs/terraform/hcl.go
+++ b/resources/packs/terraform/hcl.go
@@ -562,7 +562,10 @@ func (s *mqlTerraformSettings) init(args *resources.Args) (*resources.Args, Terr
 	}
 
 	if len(blocks) != 1 {
-		return nil, nil, errors.New("no `terraform` settings block found")
+		// no terraform settings block found, this is ok for terraform and not an error
+		(*args)["block"] = nil
+		(*args)["requiredProviders"] = map[string]interface{}{}
+		return args, nil, nil
 	}
 
 	settingsBlock := blocks[0].(TerraformBlock)

--- a/resources/packs/terraform/hcl_test.go
+++ b/resources/packs/terraform/hcl_test.go
@@ -7,46 +7,66 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	terraformHclPath       = "./testdata/terraform"
+	terraformHclModulePath = "./testdata/terraform-module"
+)
+
 func TestResource_Terraform(t *testing.T) {
 	t.Run("terraform providers", func(t *testing.T) {
-		res := testTerraformHclQuery(t, "terraform.providers[0].type")
+		res := testTerraformHclQuery(t, terraformHclPath, "terraform.providers[0].type")
 		require.NotEmpty(t, res)
 		assert.Empty(t, res[0].Result().Error)
 		assert.Equal(t, string("provider"), res[0].Data.Value)
 	})
 
 	t.Run("terraform ignore commented out resources", func(t *testing.T) {
-		res := testTerraformHclQuery(t, "terraform.providers.length")
+		res := testTerraformHclQuery(t, terraformHclPath, "terraform.providers.length")
 		require.NotEmpty(t, res)
 		assert.Empty(t, res[0].Result().Error)
 		assert.Equal(t, int64(3), res[0].Data.Value)
 	})
 
 	t.Run("terraform nested blocks", func(t *testing.T) {
-		res := testTerraformHclQuery(t, "terraform.blocks.where( type == \"resource\" && labels.contains(\"aws_instance\"))[0].type")
+		res := testTerraformHclQuery(t, terraformHclPath, "terraform.blocks.where( type == \"resource\" && labels.contains(\"aws_instance\"))[0].type")
 		require.NotEmpty(t, res)
 		assert.Empty(t, res[0].Result().Error)
 		assert.Equal(t, string("resource"), res[0].Data.Value)
 	})
 
 	t.Run("terraform jsonencode blocks", func(t *testing.T) {
-		res := testTerraformHclQuery(t, "terraform.resources.where( nameLabel == 'aws_iam_policy' && labels[1] == 'policy' )[0].arguments['policy'][0]['Version']")
+		res := testTerraformHclQuery(t, terraformHclPath, "terraform.resources.where( nameLabel == 'aws_iam_policy' && labels[1] == 'policy' )[0].arguments['policy'][0]['Version']")
 		require.NotEmpty(t, res)
 		assert.Empty(t, res[0].Result().Error)
 		assert.Equal(t, string("2012-10-17"), res[0].Data.Value)
 	})
 
 	t.Run("terraform providers", func(t *testing.T) {
-		res := testTerraformHclQuery(t, "terraform.resources.where( nameLabel  == 'google_compute_instance')[0].arguments['metadata']")
+		res := testTerraformHclQuery(t, terraformHclPath, "terraform.resources.where( nameLabel  == 'google_compute_instance')[0].arguments['metadata']")
 		require.NotEmpty(t, res)
 		assert.Empty(t, res[0].Result().Error)
 		assert.Equal(t, map[string]interface{}{"enable-oslogin": true}, res[0].Data.Value)
 	})
 
 	t.Run("terraform settings", func(t *testing.T) {
-		res := testTerraformHclQuery(t, "terraform.settings.requiredProviders['aws']['version']")
+		res := testTerraformHclQuery(t, terraformHclPath, "terraform.settings.requiredProviders['aws']['version']")
 		require.NotEmpty(t, res)
 		assert.Empty(t, res[0].Result().Error)
 		assert.Equal(t, "~> 3.74", res[0].Data.Value)
+	})
+}
+
+func TestModuleWithoutResources_Terraform(t *testing.T) {
+	t.Run("terraform settings", func(t *testing.T) {
+		res := testTerraformHclQuery(t, terraformHclModulePath, "terraform.settings") // should not thorw error
+		require.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+	})
+
+	t.Run("terraform settings", func(t *testing.T) {
+		res := testTerraformHclQuery(t, terraformHclModulePath, "terraform.settings.block") // should not thorw error
+		require.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, nil, res[0].Data.Value)
 	})
 }

--- a/resources/packs/terraform/terraform_test.go
+++ b/resources/packs/terraform/terraform_test.go
@@ -15,11 +15,11 @@ import (
 
 var x = testutils.InitTester(testutils.LinuxMock(), os.Registry)
 
-func testTerraformHclQuery(t *testing.T, query string) []*llx.RawResult {
+func testTerraformHclQuery(t *testing.T, path string, query string) []*llx.RawResult {
 	p, err := provider.New(&providers.Config{
 		Backend: providers.ProviderType_TERRAFORM,
 		Options: map[string]string{
-			"path": "./testdata/terraform",
+			"path": path,
 		},
 	})
 	require.NoError(t, err)

--- a/resources/packs/terraform/testdata/terraform-module/aws.tf
+++ b/resources/packs/terraform/testdata/terraform-module/aws.tf
@@ -1,0 +1,32 @@
+## dummy. we do not use bucket replication at all
+provider "aws" {
+  alias  = "replica"
+  region = "eu-west-1"
+}
+
+module "remote-state-s3-backend" {
+  providers = {
+    aws         = aws
+    aws.replica = aws.replica
+  }
+
+  source  = "nozaq/remote-state-s3-backend/aws"
+  version = "1.4.0"
+
+  enable_replication = false
+
+  noncurrent_version_transitions = [
+    {
+      days          = 5
+      storage_class = "GLACIER"
+    }
+  ]
+
+  noncurrent_version_expiration = {
+    days = 30
+  }
+
+  tags = {
+    Module = "0-bootstrap-terraform"
+  }
+}


### PR DESCRIPTION
When the provider setting was missing:

```
terraform {
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "~> 3.74"
    }
  }
}
```

we threw an error in during execution.

```
cnquery> terraform.settings
Query encountered errors:
failed to create resource 'terraform.settings': no `terraform` settings block found
terraform.settings: no data available
```

Since this is valid terraform configuration, we treat empty values as ok too