### PR TITLE
🐛 Only override platform if it's an azure asset. (#1001)

### DIFF
--- a/motor/providers/microsoft/platform.go
+++ b/motor/providers/microsoft/platform.go
@@ -59,17 +59,17 @@ func getTitleForPlatformName(name string) string {
 }
 
 func (p *Provider) PlatformInfo() (*platform.Platform, error) {
-	// TODO: that's a hack, figure out a better way
-	if p.platformOverride != "" && p.platformOverride != "azure" {
-		return &platform.Platform{
-			Name:    p.platformOverride,
-			Title:   getTitleForPlatformName(p.platformOverride),
-			Kind:    providers.Kind_KIND_AZURE_OBJECT,
-			Runtime: providers.RUNTIME_AZ,
-		}, nil
-	}
 	switch p.assetType {
 	case azure:
+		// TODO: that's a hack, figure out a better way
+		if p.platformOverride != "" && p.platformOverride != "azure" {
+			return &platform.Platform{
+				Name:    p.platformOverride,
+				Title:   getTitleForPlatformName(p.platformOverride),
+				Kind:    providers.Kind_KIND_AZURE_OBJECT,
+				Runtime: providers.RUNTIME_AZ,
+			}, nil
+		}
 		return &platform.Platform{
 			Name:    "azure",
 			Title:   "Microsoft Azure",


### PR DESCRIPTION
Fixes the platform for ms365 which was accidentally broken with the release of #963

Before:
```
cnquery> platform{title kind runtime name}
platform: {
  kind: "azure-object"
  name: "microsoft365"
  runtime: "azure"
  title: "Microsoft Azure"
}
```

After:
```
cnquery> platform {name title kind runtime}
platform: {
  kind: "api"
  name: "microsoft365"
  runtime: "ms-graph"
  title: "Microsoft 365"
}
```