### PR TITLE
🐛 Scan images only once per digest

### DIFF
--- a/motor/discovery/container_registry/registry.go
+++ b/motor/discovery/container_registry/registry.go
@@ -136,6 +136,7 @@ func (a *DockerRegistryImages) ListRepository(repoName string) ([]*asset.Asset, 
 		return nil, handleUnauthorizedError(err, repo.Name())
 	}
 
+	foundDigests := map[string]struct{}{}
 	for i := range tags {
 		repoWithTag := repo.Name() + ":" + tags[i]
 
@@ -148,6 +149,11 @@ func (a *DockerRegistryImages) ListRepository(repoName string) ([]*asset.Asset, 
 		if err != nil {
 			return nil, err
 		}
+		if _, ok := foundDigests[a.PlatformIds[0]]; ok {
+			// skip duplicate digests
+			continue
+		}
+		foundDigests[a.PlatformIds[0]] = struct{}{}
 		assets = append(assets, a)
 	}
 	return assets, nil


### PR DESCRIPTION
This deduplicates images in a registry by their digest. Images with multiple tags, but the same digest will only be scanned once.

It stores all tags found for the image with the same digest.
In the UI, it looks like this:
![image](https://user-images.githubusercontent.com/827818/222880409-a85f09ce-5085-48da-87cc-63e3a5a4bdae.png)


Fixes https://github.com/mondoohq/cnspec/issues/399