### PR TITLE
🐛 Fix subscription platform id. Do not link assets to empty root.

### DIFF
--- a/motor/discovery/azure/resolver.go
+++ b/motor/discovery/azure/resolver.go
@@ -127,7 +127,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 			if err != nil {
 				return nil, err
 			}
-			id, _ := provider.Identifier()
+			id, _ := p.Identifier()
 			subAsset := &asset.Asset{
 				PlatformIds: []string{id},
 				Name:        name,
@@ -163,10 +163,6 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 					a.RelatedAssets = append(a.RelatedAssets, sub)
 				}
 
-				// if there's a root available, link the asset to it
-				if root != nil {
-					a.RelatedAssets = append(a.RelatedAssets, root)
-				}
 				resolved = append(resolved, a)
 			}
 		}
@@ -197,11 +193,6 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 				// if there's a sub available, link the asset to it
 				if sub := subsAssets[*s.SubscriptionID]; sub != nil {
 					a.RelatedAssets = append(a.RelatedAssets, sub)
-				}
-
-				// if there's a root available, link the asset to it
-				if root != nil {
-					a.RelatedAssets = append(a.RelatedAssets, root)
 				}
 
 				resolved = append(resolved, a)

--- a/resources/packs/k8s/k8s.lr.go
+++ b/resources/packs/k8s/k8s.lr.go
@@ -8,8 +8,8 @@ import (
 
 	"go.mondoo.com/cnquery/resources"
 	"github.com/rs/zerolog/log"
-	"go.mondoo.com/cnquery/resources/packs/core"
 	"go.mondoo.com/cnquery/resources/packs/os"
+	"go.mondoo.com/cnquery/resources/packs/core"
 )
 
 // Init all resources into the registry


### PR DESCRIPTION
Assign the right platform id to subscriptions, until now it was using the wrong provider.

Removed links from root to assets. It seems that the root right now is a completely blank asset so that's of no use. The assets already have to links to the subscriptions assets so that does not change