### PR TITLE
🐛Fix flaky aws where filters test.

### DIFF
--- a/motor/discovery/aws/ec2_instances_test.go
+++ b/motor/discovery/aws/ec2_instances_test.go
@@ -50,15 +50,17 @@ func TestWhereFilter(t *testing.T) {
 		Tags: map[string]string{"Name": "test"},
 	}
 	require.Equal(t, `tags["Name"] == "test"`, whereFilter(filters))
+
 	filters = Ec2InstancesFilters{
 		Tags: map[string]string{"Name": "test", "another": "test2"},
 	}
-	require.Equal(t, `tags["Name"] == "test" || tags["another"] == "test2"`, whereFilter(filters))
+	// go access map keys randomly so both are possible outputs here when building the filters
+	expected := []string{`tags["Name"] == "test" || tags["another"] == "test2"`, `tags["another"] == "test2" || tags["Name"] == "test"`}
+	require.Contains(t, expected, whereFilter(filters))
 
 	filters = Ec2InstancesFilters{
 		Regions: []string{"us-east-2"},
 		Tags:    map[string]string{"Name": "test"},
 	}
-
 	require.Equal(t, `region == "us-east-2" && tags["Name"] == "test"`, whereFilter(filters))
 }


### PR DESCRIPTION
Observed in https://github.com/mondoohq/cnquery/actions/runs/4342703577/jobs/7583851503

Map keys are access randomly so building the where filter on multiple key-value pairs can produce different output.
This PR makes sure that all possibilities are accounted for and the output is equal to at least one of then.