### PR TITLE
🧹 rewrite ipv6 addresses before connecting over ssh

### DIFF
--- a/apps/cnquery/cmd/builder/parse_test.go
+++ b/apps/cnquery/cmd/builder/parse_test.go
@@ -36,3 +36,52 @@ func TestTargetParser(t *testing.T) {
 		assert.Equal(t, tests[i].target, res, tests[i].value)
 	}
 }
+
+func TestParseIPv6(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "//192.168.123.22",
+			expected: "//192.168.123.22",
+		},
+		{
+			input:    "ssh://user@192.168.123.22:22",
+			expected: "ssh://user@192.168.123.22:22",
+		},
+		{
+			input:    "//user@192.168.123.22:22",
+			expected: "//user@192.168.123.22:22",
+		},
+		{
+			input:    "ssh://user@[fe80::a3c4:928f:d918:22]:22",
+			expected: "ssh://user@[fe80::a3c4:928f:d918:22]:22",
+		},
+		{
+			input:    "//user@[fe80::a3c4:928f:d918:22]:22",
+			expected: "//user@[fe80::a3c4:928f:d918:22]:22",
+		},
+		{
+			input:    "//user@fe80::a3c4:d918:22",
+			expected: "//user@[fe80::a3c4:d918:22]",
+		},
+		{
+			input:    "//user@fe80::a3c4:d918:22:22", // no abiliy to understand user might have meant port 22!
+			expected: "//user@[fe80::a3c4:d918:22:22]",
+		},
+		{
+			input:    "//fe80::a3c4:d918:22",
+			expected: "//[fe80::a3c4:d918:22]",
+		},
+		{
+			input:    "//[fe80::a3c4:d918:22]:22",
+			expected: "//[fe80::a3c4:d918:22]:22",
+		},
+	}
+
+	for _, test := range tests {
+		res := addIPv6Brackets(test.input)
+		assert.Equal(t, test.expected, res, "unexpected parsing result during ipv6 handling")
+	}
+}

--- a/motor/providers/ssh/provider.go
+++ b/motor/providers/ssh/provider.go
@@ -153,6 +153,10 @@ func (p *Provider) Connect() error {
 	conn, _, err := establishClientConnection(cc, hostkeyCallback)
 	if err != nil {
 		log.Debug().Err(err).Str("provider", "ssh").Str("host", cc.Host).Int32("port", cc.Port).Bool("insecure", cc.Insecure).Msg("could not establish ssh session")
+		fmt.Printf("HOST: %+v\n", cc.Host)
+		if strings.ContainsAny(cc.Host, "[]") {
+			log.Info().Str("host", cc.Host).Int32("port", cc.Port).Msg("ensure proper []s when combining IPv6 with port numbers")
+		}
 		return err
 	}
 	p.SSHClient = conn

--- a/motor/providers/ssh/provider.go
+++ b/motor/providers/ssh/provider.go
@@ -1,6 +1,7 @@
 package ssh
 
 import (
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -26,6 +27,16 @@ var (
 )
 
 func New(pCfg *providers.Config) (*Provider, error) {
+	host := pCfg.GetHost()
+	// ipv6 addresses w/o the surrounding [] will eventually error
+	// so check whether we have an ipv6 address by parsing it (the
+	// parsing will fail if the string DOES have the []s) and adding
+	// the []s
+	ip := net.ParseIP(host)
+	if ip != nil && ip.To16() != nil {
+		pCfg.Host = fmt.Sprintf("[%s]", host)
+	}
+
 	pCfg = ReadSSHConfig(pCfg)
 
 	// ensure all required configs are set


### PR DESCRIPTION
trying to connect to an ipv6 address w/o the surrounding []s around the ipv6 address will error.

detect when we're dealing with an ipv6 address and add the []s as needed.

This will solve it for cases like when dealing with ansible inventory files with ipv6 addresses for some of the target hosts.

Specifying an ipv6 host via the CLI still would require the []s be added for example `cnquery shell ssh user@[fe80::0010]`

Fixes: https://github.com/mondoohq/cnspec/issues/403