### PR TITLE
Improve error when field not found in resource

### DIFF
--- a/mqlc/builtin_resource.go
+++ b/mqlc/builtin_resource.go
@@ -34,7 +34,7 @@ func compileResourceDefault(c *compiler, typ types.Type, ref uint64, id string, 
 	fieldPath, fieldinfos, ok := c.findField(resource, id)
 	if !ok {
 		addFieldSuggestions(publicFieldsInfo(c, resource), id, c.Result)
-		return "", errors.New("cannot find field '" + id + "' in resource " + resource.Name)
+		return "", errors.New("cannot find field '" + id + "' in resource " + resource.Name + "resource")
 	}
 
 	lastRef := ref

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -1757,7 +1757,7 @@ func TestSuggestions(t *testing.T) {
 			// resource with partial field call
 			"sshd.config.para",
 			[]string{"params"},
-			errors.New("cannot find field 'para' in sshd.config"),
+			errors.New("cannot find field 'para' in sshd.config resource"),
 			nil,
 		},
 		{
@@ -1785,14 +1785,14 @@ func TestSuggestions(t *testing.T) {
 			// embedded with asset context on
 			"docker.containers[0].hostnam",
 			[]string{"hostname"},
-			errors.New("cannot find field 'hostnam' in docker.container"),
+			errors.New("cannot find field 'hostnam' in docker.container resource"),
 			cnquery.Features{byte(cnquery.MQLAssetContext)},
 		},
 		{
 			// embedded with asset context off
 			"docker.containers[0].hostnam",
 			[]string{},
-			errors.New("cannot find field 'hostnam' in docker.container"),
+			errors.New("cannot find field 'hostnam' in docker.container resource"),
 			nil,
 		},
 	}


### PR DESCRIPTION
When you run something like `os.uptime` it says it can't find the field in os and it's not entirely clear that os is the resource and not shorthand for your operating system.