### PR TITLE
🐛 Use filters from groups

### DIFF
--- a/explorer/bundle.go
+++ b/explorer/bundle.go
@@ -496,11 +496,14 @@ func (p *Bundle) Filters() []*Mquery {
 	uniq := map[string]*Mquery{}
 	for i := range p.Packs {
 		pack := p.Packs[i]
-		if pack.Filters == nil {
-			continue
-		}
-		for k, v := range pack.Filters.Items {
-			uniq[k] = v
+		for j := range pack.Groups {
+			group := pack.Groups[j]
+			if group.Filters == nil {
+				continue
+			}
+			for k, v := range group.Filters.Items {
+				uniq[k] = v
+			}
 		}
 	}
 

--- a/explorer/bundle.go
+++ b/explorer/bundle.go
@@ -492,10 +492,21 @@ func (p *Bundle) EnsureUIDs() {
 	}
 }
 
+// Filters retrieves the aggregated filters for all querypacks in this bundle.
 func (p *Bundle) Filters() []*Mquery {
 	uniq := map[string]*Mquery{}
 	for i := range p.Packs {
 		pack := p.Packs[i]
+
+		// TODO: Currently we don't process the difference between local pack filters
+		// and their group filters correctly. These need aggregation.
+
+		if pack.Filters != nil {
+			for k, v := range pack.Filters.Items {
+				uniq[k] = v
+			}
+		}
+
 		for j := range pack.Groups {
 			group := pack.Groups[j]
 			if group.Filters == nil {

--- a/explorer/querypack.go
+++ b/explorer/querypack.go
@@ -132,15 +132,21 @@ func ChecksumQueries(queries []*Mquery) (checksums.Fast, checksums.Fast) {
 
 // ComputeFilters into mql
 func (p *QueryPack) ComputeFilters(ctx context.Context, ownerMRN string) ([]*Mquery, error) {
-	if p.Filters == nil {
-		return nil, errors.New("cannot compute filters for a querypack, unless it was compiled first")
+	numFilters := 0
+	for i := range p.Groups {
+		if p.Groups[i].Filters == nil {
+			return nil, errors.New("cannot compute filters for a querypack, unless it was compiled first")
+		}
+		numFilters += len(p.Groups[i].Filters.Items)
 	}
 
-	res := make([]*Mquery, len(p.Filters.Items))
+	res := make([]*Mquery, numFilters)
 	idx := 0
-	for _, v := range p.Filters.Items {
-		res[idx] = v
-		idx++
+	for i := range p.Groups {
+		for _, v := range p.Groups[i].Filters.Items {
+			res[idx] = v
+			idx++
+		}
 	}
 
 	sort.Slice(res, func(i, j int) bool {

--- a/explorer/querypack.go
+++ b/explorer/querypack.go
@@ -133,6 +133,9 @@ func ChecksumQueries(queries []*Mquery) (checksums.Fast, checksums.Fast) {
 // ComputeFilters into mql
 func (p *QueryPack) ComputeFilters(ctx context.Context, ownerMRN string) ([]*Mquery, error) {
 	numFilters := 0
+	if p.Filters != nil {
+		numFilters += len(p.Filters.Items)
+	}
 	for i := range p.Groups {
 		if p.Groups[i].Filters == nil {
 			return nil, errors.New("cannot compute filters for a querypack, unless it was compiled first")
@@ -142,6 +145,12 @@ func (p *QueryPack) ComputeFilters(ctx context.Context, ownerMRN string) ([]*Mqu
 
 	res := make([]*Mquery, numFilters)
 	idx := 0
+	if p.Filters != nil {
+		for _, v := range p.Filters.Items {
+			res[idx] = v
+			idx++
+		}
+	}
 	for i := range p.Groups {
 		for _, v := range p.Groups[i].Filters.Items {
 			res[idx] = v


### PR DESCRIPTION
Filters from querypacks are converted to filters inside a group when saved as a policy. when we get the policy back as a querypack, we need to query the group for filters.