### PR TITLE
🐛 fix ipv6 address test

### DIFF
--- a/motor/providers/ssh/provider.go
+++ b/motor/providers/ssh/provider.go
@@ -33,7 +33,7 @@ func New(pCfg *providers.Config) (*Provider, error) {
 	// parsing will fail if the string DOES have the []s) and adding
 	// the []s
 	ip := net.ParseIP(host)
-	if ip != nil && ip.To16() != nil {
+	if ip != nil && ip.To4() == nil {
 		pCfg.Host = fmt.Sprintf("[%s]", host)
 	}
 
@@ -153,7 +153,6 @@ func (p *Provider) Connect() error {
 	conn, _, err := establishClientConnection(cc, hostkeyCallback)
 	if err != nil {
 		log.Debug().Err(err).Str("provider", "ssh").Str("host", cc.Host).Int32("port", cc.Port).Bool("insecure", cc.Insecure).Msg("could not establish ssh session")
-		fmt.Printf("HOST: %+v\n", cc.Host)
 		if strings.ContainsAny(cc.Host, "[]") {
 			log.Info().Str("host", cc.Host).Int32("port", cc.Port).Msg("ensure proper []s when combining IPv6 with port numbers")
 		}


### PR DESCRIPTION
the golang To16() function call will succeed against an ipv4 address.

what we need to test is whether we can succeed with a To4() call as that will return nil when given an ipv6 address.

w/o this, we get []s around the ipv4 addresses (which doesn't cause an error, but it still seems wrong)

```
DBG could not establish ssh session error="dial tcp 192.168.86.4:22: connect: operation timed out" host=[192.168.86.4] insecure=false port=22 provider=ssh
```

w/this PR the host we try to connect to no longer gets the unecessary []s:
```
DBG could not establish ssh session error="dial tcp 192.168.86.4:22: connect: operation timed out" host=192.168.86.4 insecure=false port=22 provider=ssh
```