### PR TITLE
🧹 Catch asset problems before they reach the progressbar

### DIFF
--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -2,6 +2,7 @@ package scan
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	sync "sync"
@@ -194,6 +195,11 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstreamConf
 	progressBarElements := map[string]string{}
 	orderedKeys := []string{}
 	for i := range assetList {
+		// this shouldn't happen, but might
+		// it normally indicates a bug in the provider
+		if presentAsset, present := progressBarElements[assetList[i].PlatformIds[0]]; present {
+			return nil, false, fmt.Errorf("asset %s and %s have the same platform id %s", presentAsset, assetList[i].Name, assetList[i].PlatformIds[0])
+		}
 		progressBarElements[assetList[i].PlatformIds[0]] = assetList[i].Name
 		orderedKeys = append(orderedKeys, assetList[i].PlatformIds[0])
 	}


### PR DESCRIPTION
This checks whether we have duplicate platformID across the assets.

When not checked here, we would see this:
FTL failed to run scan error='could not create progress bar: number of elements and orderedKeys must be equal'