### PR TITLE
🧹 ensure we do not fail the whole resource when there are region perm restrictions

### DIFF
--- a/resources/packs/aws/aws.go
+++ b/resources/packs/aws/aws.go
@@ -2,8 +2,10 @@ package aws
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/smithy-go/transport/http"
 	"go.mondoo.com/cnquery/motor/providers"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources/packs/aws/info"
@@ -51,4 +53,14 @@ func GetRegionFromArn(arnVal string) (string, error) {
 		return "", err
 	}
 	return parsedArn.Region, nil
+}
+
+func Is400AccessDeniedError(err error) bool {
+	var respErr *http.ResponseError
+	if errors.As(err, &respErr) {
+		if respErr.HTTPStatusCode() == 400 && strings.Contains(respErr.Error(), "AccessDeniedException") {
+			return true
+		}
+	}
+	return false
 }

--- a/resources/packs/aws/aws_access_analyzer.go
+++ b/resources/packs/aws/aws_access_analyzer.go
@@ -59,6 +59,10 @@ func (a *mqlAwsAccessAnalyzer) getAnalyzers(provider *aws_provider.Provider) []*
 			for nextToken != nil {
 				analyzers, err := svc.ListAnalyzers(ctx, params)
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					log.Error().Err(err).Str("region", regionVal).Msg("error listing analyzers")
 					return nil, err
 				}

--- a/resources/packs/aws/aws_acm.go
+++ b/resources/packs/aws/aws_acm.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/acm"
 	"github.com/aws/aws-sdk-go-v2/service/acm/types"
+	"github.com/rs/zerolog/log"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources"
 	"go.mondoo.com/cnquery/resources/library/jobpool"
@@ -59,6 +60,10 @@ func (a *mqlAwsAcm) getCertificates(provider *aws_provider.Provider) []*jobpool.
 			for nextToken != nil {
 				certs, err := svc.ListCertificates(ctx, params)
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 				for _, cert := range certs.CertificateSummaryList {

--- a/resources/packs/aws/aws_apigateway.go
+++ b/resources/packs/aws/aws_apigateway.go
@@ -67,6 +67,10 @@ func (a *mqlAwsApigateway) getRestApis(provider *aws_provider.Provider) []*jobpo
 			for {
 				restApisResp, err := svc.GetRestApis(ctx, &apigateway.GetRestApisInput{Position: position})
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, errors.Wrap(err, "could not gather AWS API Gateway REST APIs")
 				}
 

--- a/resources/packs/aws/aws_applicationautoscaling.go
+++ b/resources/packs/aws/aws_applicationautoscaling.go
@@ -78,6 +78,10 @@ func (a *mqlAwsApplicationAutoscaling) getTargets(provider *aws_provider.Provide
 			for nextToken != nil {
 				resp, err := svc.DescribeScalableTargets(ctx, params)
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, errors.Wrap(err, "could not gather application autoscaling scalable targets")
 				}
 

--- a/resources/packs/aws/aws_autoscaling.go
+++ b/resources/packs/aws/aws_autoscaling.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+	"github.com/rs/zerolog/log"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources/library/jobpool"
 	"go.mondoo.com/cnquery/resources/packs/core"
@@ -59,6 +60,10 @@ func (a *mqlAwsAutoscaling) getGroups(provider *aws_provider.Provider) []*jobpoo
 			for nextToken != nil {
 				groups, err := svc.DescribeAutoScalingGroups(ctx, params)
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 				for _, group := range groups.AutoScalingGroups {

--- a/resources/packs/aws/aws_backup.go
+++ b/resources/packs/aws/aws_backup.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/backup"
 	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/rs/zerolog/log"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources/library/jobpool"
 	"go.mondoo.com/cnquery/resources/packs/core"
@@ -61,6 +62,10 @@ func (a *mqlAwsBackup) getVaults(provider *aws_provider.Provider) []*jobpool.Job
 
 			vaults, err := svc.ListBackupVaults(ctx, &backup.ListBackupVaultsInput{})
 			if err != nil {
+				if Is400AccessDeniedError(err) {
+					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+					return res, nil
+				}
 				return nil, err
 			}
 			for _, v := range vaults.BackupVaultList {

--- a/resources/packs/aws/aws_cloudtrail.go
+++ b/resources/packs/aws/aws_cloudtrail.go
@@ -99,14 +99,18 @@ func (t *mqlAwsCloudtrail) getTrails(provider *aws_provider.Provider) []*jobpool
 
 			svc := provider.Cloudtrail(regionVal)
 			ctx := context.Background()
+			res := []interface{}{}
 
 			// no pagination required
 			trailsResp, err := svc.DescribeTrails(ctx, &cloudtrail.DescribeTrailsInput{})
 			if err != nil {
+				if Is400AccessDeniedError(err) {
+					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+					return res, nil
+				}
 				return nil, errors.Wrap(err, "could not gather aws cloudtrail trails")
 			}
 
-			res := []interface{}{}
 			for i := range trailsResp.TrailList {
 				trail := trailsResp.TrailList[i]
 

--- a/resources/packs/aws/aws_cloudwatch.go
+++ b/resources/packs/aws/aws_cloudwatch.go
@@ -68,6 +68,10 @@ func (t *mqlAwsCloudwatch) getMetrics(provider *aws_provider.Provider) []*jobpoo
 			for nextToken != nil {
 				metrics, err := svc.ListMetrics(ctx, params)
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 				for _, metric := range metrics.Metrics {
@@ -535,6 +539,10 @@ func (t *mqlAwsCloudwatch) getAlarms(provider *aws_provider.Provider) []*jobpool
 
 				alarms, err := svc.DescribeAlarms(ctx, params)
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 
@@ -685,6 +693,10 @@ func (t *mqlAwsCloudwatch) getLogGroups(provider *aws_provider.Provider) []*jobp
 			for nextToken != nil {
 				logGroups, err := svc.DescribeLogGroups(ctx, params)
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, errors.Wrap(err, "could not gather aws cloudwatch log groups")
 				}
 				nextToken = logGroups.NextToken

--- a/resources/packs/aws/aws_codebuild.go
+++ b/resources/packs/aws/aws_codebuild.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/codebuild"
 	"github.com/aws/aws-sdk-go-v2/service/codebuild/types"
+	"github.com/rs/zerolog/log"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources"
 	"go.mondoo.com/cnquery/resources/library/jobpool"
@@ -56,6 +57,10 @@ func (t *mqlAwsCodebuild) getProjects(provider *aws_provider.Provider) []*jobpoo
 			for nextToken != nil {
 				projects, err := svc.ListProjects(ctx, params)
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 

--- a/resources/packs/aws/aws_config.go
+++ b/resources/packs/aws/aws_config.go
@@ -53,6 +53,10 @@ func (c *mqlAwsConfig) getRecorders(provider *aws_provider.Provider) []*jobpool.
 			params := &configservice.DescribeConfigurationRecordersInput{}
 			configRecorders, err := svc.DescribeConfigurationRecorders(ctx, params)
 			if err != nil {
+				if Is400AccessDeniedError(err) {
+					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+					return res, nil
+				}
 				return nil, err
 			}
 			recorderStatusMap, err := c.describeConfigRecorderStatus(svc, regionVal)

--- a/resources/packs/aws/aws_dms.go
+++ b/resources/packs/aws/aws_dms.go
@@ -55,6 +55,10 @@ func (d *mqlAwsDms) getReplicationInstances(provider *aws_provider.Provider) []*
 			for {
 				replicationInstances, err := svc.DescribeReplicationInstances(ctx, &databasemigrationservice.DescribeReplicationInstancesInput{Marker: marker})
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return tasks, nil
+					}
 					return nil, err
 				}
 				replicationInstancesAggregated = append(replicationInstancesAggregated, replicationInstances.ReplicationInstances...)

--- a/resources/packs/aws/aws_dynamodb.go
+++ b/resources/packs/aws/aws_dynamodb.go
@@ -59,10 +59,15 @@ func (d *mqlAwsDynamodb) getBackups(provider *aws_provider.Provider) []*jobpool.
 
 			svc := provider.Dynamodb(regionVal)
 			ctx := context.Background()
+			res := []interface{}{}
 
 			// no pagination required
 			listBackupsResp, err := svc.ListBackups(ctx, &dynamodb.ListBackupsInput{})
 			if err != nil {
+				if Is400AccessDeniedError(err) {
+					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+					return res, nil
+				}
 				return nil, errors.Wrap(err, "could not gather aws dynamodb backups")
 			}
 			backupSummary, err := core.JsonToDictSlice(listBackupsResp.BackupSummaries)
@@ -181,10 +186,15 @@ func (d *mqlAwsDynamodb) getLimits(provider *aws_provider.Provider) []*jobpool.J
 
 			svc := provider.Dynamodb(regionVal)
 			ctx := context.Background()
+			res := []interface{}{}
 
 			// no pagination required
 			limitsResp, err := svc.DescribeLimits(ctx, &dynamodb.DescribeLimitsInput{})
 			if err != nil {
+				if Is400AccessDeniedError(err) {
+					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+					return res, nil
+				}
 				return nil, errors.Wrap(err, "could not gather aws dynamodb backups")
 			}
 
@@ -276,13 +286,17 @@ func (d *mqlAwsDynamodb) getTables(provider *aws_provider.Provider) []*jobpool.J
 
 			svc := provider.Dynamodb(regionVal)
 			ctx := context.Background()
+			res := []interface{}{}
 
 			// no pagination required
 			listTablesResp, err := svc.ListTables(ctx, &dynamodb.ListTablesInput{})
 			if err != nil {
+				if Is400AccessDeniedError(err) {
+					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+					return res, nil
+				}
 				return nil, errors.Wrap(err, "could not gather aws dynamodb tables")
 			}
-			res := []interface{}{}
 			for _, tableName := range listTablesResp.TableNames {
 				// call describe table to get real info/details about the table
 				table, err := svc.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: &tableName})

--- a/resources/packs/aws/aws_ec2.go
+++ b/resources/packs/aws/aws_ec2.go
@@ -100,6 +100,10 @@ func (s *mqlAwsEc2) getNetworkACLs(provider *aws_provider.Provider) []*jobpool.J
 			for nextToken != nil {
 				networkAcls, err := svc.DescribeNetworkAcls(ctx, params)
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 				nextToken = networkAcls.NextToken
@@ -247,6 +251,10 @@ func (s *mqlAwsEc2) getSecurityGroups(provider *aws_provider.Provider) []*jobpoo
 			for nextToken != nil {
 				securityGroups, err := svc.DescribeSecurityGroups(ctx, params)
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 				nextToken = securityGroups.NextToken
@@ -371,6 +379,10 @@ func (s *mqlAwsEc2) getKeypairs(provider *aws_provider.Provider) []*jobpool.Job 
 			params := &ec2.DescribeKeyPairsInput{}
 			keyPairs, err := svc.DescribeKeyPairs(ctx, params)
 			if err != nil {
+				if Is400AccessDeniedError(err) {
+					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+					return res, nil
+				}
 				return nil, err
 			}
 
@@ -509,9 +521,14 @@ func (s *mqlAwsEc2) getEbsEncryptionPerRegion(provider *aws_provider.Provider) [
 
 			svc := provider.Ec2(regionVal)
 			ctx := context.Background()
+			res := []interface{}{}
 
 			ebsEncryptionRes, err := svc.GetEbsEncryptionByDefault(ctx, &ec2.GetEbsEncryptionByDefaultInput{})
 			if err != nil {
+				if Is400AccessDeniedError(err) {
+					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+					return res, nil
+				}
 				return nil, err
 			}
 			structVal := ebsEncryption{
@@ -610,6 +627,10 @@ func (s *mqlAwsEc2) getInstances(provider *aws_provider.Provider) []*jobpool.Job
 			filterName := "metadata-options.http-tokens"
 			imdsv2Instances, err := s.getImdsv2Instances(ctx, svc, filterName)
 			if err != nil {
+				if Is400AccessDeniedError(err) {
+					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+					return res, nil
+				}
 				return nil, err
 			}
 			res, err = s.gatherInstanceInfo(imdsv2Instances, 2, regionVal)
@@ -619,6 +640,10 @@ func (s *mqlAwsEc2) getInstances(provider *aws_provider.Provider) []*jobpool.Job
 
 			imdsv1Instances, err := s.getImdsv1Instances(ctx, svc, filterName)
 			if err != nil {
+				if Is400AccessDeniedError(err) {
+					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+					return res, nil
+				}
 				return nil, err
 			}
 			imdsv1Res, err := s.gatherInstanceInfo(imdsv1Instances, 1, regionVal)
@@ -1039,6 +1064,10 @@ func (s *mqlAwsEc2) getVolumes(provider *aws_provider.Provider) []*jobpool.Job {
 			for nextToken != nil {
 				volumes, err := svc.DescribeVolumes(ctx, params)
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 				for _, vol := range volumes.Volumes {
@@ -1278,6 +1307,10 @@ func (s *mqlAwsEc2) getVpnConnections(provider *aws_provider.Provider) []*jobpoo
 
 			vpnConnections, err := svc.DescribeVpnConnections(ctx, &ec2.DescribeVpnConnectionsInput{})
 			if err != nil {
+				if Is400AccessDeniedError(err) {
+					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+					return res, nil
+				}
 				return nil, err
 			}
 			for _, vpnConn := range vpnConnections.VpnConnections {
@@ -1352,6 +1385,10 @@ func (s *mqlAwsEc2) getSnapshots(provider *aws_provider.Provider) []*jobpool.Job
 			for nextToken != nil {
 				snapshots, err := svc.DescribeSnapshots(ctx, params)
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 				for _, snapshot := range snapshots.Snapshots {
@@ -1447,6 +1484,10 @@ func (s *mqlAwsEc2) getInternetGateways(provider *aws_provider.Provider) []*jobp
 			for nextToken != nil {
 				internetGws, err := svc.DescribeInternetGateways(ctx, params)
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 				for _, gateway := range internetGws.InternetGateways {

--- a/resources/packs/aws/aws_ecr.go
+++ b/resources/packs/aws/aws_ecr.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/aws/aws-sdk-go-v2/service/ecrpublic"
 	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources"
 	"go.mondoo.com/cnquery/resources/library/jobpool"
@@ -107,6 +108,10 @@ func (e *mqlAwsEcr) getPrivateRepositories(provider *aws.Provider) []*jobpool.Jo
 
 			repoResp, err := svc.DescribeRepositories(ctx, &ecr.DescribeRepositoriesInput{})
 			if err != nil {
+				if Is400AccessDeniedError(err) {
+					log.Warn().Str("region", region).Msg("error accessing region for AWS API")
+					return res, nil
+				}
 				return nil, err
 			}
 			for i := range repoResp.Repositories {
@@ -159,6 +164,10 @@ func (e *mqlAwsEcrRepository) GetImages() ([]interface{}, error) {
 		svc := at.EcrPublic(region)
 		res, err := svc.DescribeImages(ctx, &ecrpublic.DescribeImagesInput{RepositoryName: &name})
 		if err != nil {
+			if Is400AccessDeniedError(err) {
+				log.Warn().Str("region", region).Msg("error accessing region for AWS API")
+				return nil, nil
+			}
 			return nil, err
 		}
 
@@ -187,6 +196,10 @@ func (e *mqlAwsEcrRepository) GetImages() ([]interface{}, error) {
 		svc := at.Ecr(region)
 		res, err := svc.DescribeImages(ctx, &ecr.DescribeImagesInput{RepositoryName: &name})
 		if err != nil {
+			if Is400AccessDeniedError(err) {
+				log.Warn().Str("region", region).Msg("error accessing region for AWS API")
+				return nil, nil
+			}
 			return nil, err
 		}
 		for i := range res.ImageDetails {

--- a/resources/packs/aws/aws_ecs.go
+++ b/resources/packs/aws/aws_ecs.go
@@ -123,6 +123,10 @@ func (ecs *mqlAwsEcs) getECSClusters(provider *aws_provider.Provider) []*jobpool
 			for nextToken != nil {
 				resp, err := svc.ListClusters(ctx, params)
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, errors.Wrap(err, "could not gather ecs cluster information")
 				}
 				nextToken = resp.NextToken

--- a/resources/packs/aws/aws_efs.go
+++ b/resources/packs/aws/aws_efs.go
@@ -62,6 +62,10 @@ func (e *mqlAwsEfs) getFilesystems(provider *aws_provider.Provider) []*jobpool.J
 			for {
 				describeFileSystemsRes, err := svc.DescribeFileSystems(ctx, &efs.DescribeFileSystemsInput{Marker: marker})
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 

--- a/resources/packs/aws/aws_eks.go
+++ b/resources/packs/aws/aws_eks.go
@@ -53,6 +53,10 @@ func (e *mqlAwsEks) getClusters(provider *aws_provider.Provider) []*jobpool.Job 
 
 			describeClusterRes, err := svc.ListClusters(ctx, &eks.ListClustersInput{})
 			if err != nil {
+				if Is400AccessDeniedError(err) {
+					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+					return res, nil
+				}
 				return nil, err
 			}
 

--- a/resources/packs/aws/aws_elasticache.go
+++ b/resources/packs/aws/aws_elasticache.go
@@ -58,6 +58,10 @@ func (e *mqlAwsElasticache) getClusters(provider *aws_provider.Provider) []*jobp
 			for {
 				clusters, err := svc.DescribeCacheClusters(ctx, &elasticache.DescribeCacheClustersInput{Marker: marker})
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 				if len(clusters.CacheClusters) == 0 {

--- a/resources/packs/aws/aws_elb.go
+++ b/resources/packs/aws/aws_elb.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing"
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	"github.com/rs/zerolog/log"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources"
 	"go.mondoo.com/cnquery/resources/library/jobpool"
@@ -64,6 +65,10 @@ func (e *mqlAwsElb) getClassicLoadBalancers(provider *aws_provider.Provider) []*
 			for {
 				lbs, err := svc.DescribeLoadBalancers(ctx, &elasticloadbalancing.DescribeLoadBalancersInput{Marker: marker})
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 				for _, lb := range lbs.LoadBalancerDescriptions {
@@ -138,6 +143,10 @@ func (e *mqlAwsElb) getLoadBalancers(provider *aws_provider.Provider) []*jobpool
 			for {
 				lbs, err := svc.DescribeLoadBalancers(ctx, &elasticloadbalancingv2.DescribeLoadBalancersInput{Marker: marker})
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 				for _, lb := range lbs.LoadBalancers {

--- a/resources/packs/aws/aws_emr.go
+++ b/resources/packs/aws/aws_emr.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/emr"
 	"github.com/aws/aws-sdk-go-v2/service/emr/types"
+	"github.com/rs/zerolog/log"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources/library/jobpool"
 	"go.mondoo.com/cnquery/resources/packs/core"
@@ -57,6 +58,10 @@ func (e *mqlAwsEmr) getClusters(provider *aws_provider.Provider) []*jobpool.Job 
 			for {
 				clusters, err := svc.ListClusters(ctx, &emr.ListClustersInput{Marker: marker})
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 				for _, cluster := range clusters.Clusters {

--- a/resources/packs/aws/aws_es.go
+++ b/resources/packs/aws/aws_es.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/elasticsearchservice"
 	"github.com/aws/smithy-go/transport/http"
+	"github.com/rs/zerolog/log"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources"
 	"go.mondoo.com/cnquery/resources/library/jobpool"
@@ -54,6 +55,10 @@ func (e *mqlAwsEs) getDomains(provider *aws_provider.Provider) []*jobpool.Job {
 
 			domains, err := svc.ListDomainNames(ctx, &elasticsearchservice.ListDomainNamesInput{})
 			if err != nil {
+				if Is400AccessDeniedError(err) {
+					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+					return res, nil
+				}
 				return nil, err
 			}
 

--- a/resources/packs/aws/aws_guardduty.go
+++ b/resources/packs/aws/aws_guardduty.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/guardduty"
 	"github.com/aws/aws-sdk-go-v2/service/guardduty/types"
+	"github.com/rs/zerolog/log"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources"
 	"go.mondoo.com/cnquery/resources/library/jobpool"
@@ -61,6 +62,10 @@ func (g *mqlAwsGuardduty) getDetectors(provider *aws_provider.Provider) []*jobpo
 			for nextToken != nil {
 				detectors, err := svc.ListDetectors(ctx, params)
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 

--- a/resources/packs/aws/aws_kms.go
+++ b/resources/packs/aws/aws_kms.go
@@ -55,6 +55,10 @@ func (k *mqlAwsKms) getKeys(provider *aws_provider.Provider) []*jobpool.Job {
 			for {
 				keyList, err := svc.ListKeys(ctx, &kms.ListKeysInput{Marker: marker})
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 

--- a/resources/packs/aws/aws_lambda.go
+++ b/resources/packs/aws/aws_lambda.go
@@ -60,6 +60,10 @@ func (l *mqlAwsLambda) getFunctions(provider *aws_provider.Provider) []*jobpool.
 			for {
 				functionsResp, err := svc.ListFunctions(ctx, &lambda.ListFunctionsInput{Marker: marker})
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, errors.Wrap(err, "could not gather aws lambda functions")
 				}
 				for _, function := range functionsResp.Functions {

--- a/resources/packs/aws/aws_rds.go
+++ b/resources/packs/aws/aws_rds.go
@@ -67,6 +67,10 @@ func (d *mqlAwsRds) getDbInstances(provider *aws_provider.Provider) []*jobpool.J
 			for {
 				dbInstances, err := svc.DescribeDBInstances(ctx, &rds.DescribeDBInstancesInput{Marker: marker})
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 				for _, dbInstance := range dbInstances.DBInstances {
@@ -221,6 +225,10 @@ func (d *mqlAwsRds) getDbClusters(provider *aws_provider.Provider) []*jobpool.Jo
 			for {
 				dbClusters, err := svc.DescribeDBClusters(ctx, &rds.DescribeDBClustersInput{Marker: marker})
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 

--- a/resources/packs/aws/aws_redshift.go
+++ b/resources/packs/aws/aws_redshift.go
@@ -68,6 +68,10 @@ func (r *mqlAwsRedshift) getClusters(provider *aws_provider.Provider) []*jobpool
 			for {
 				clusters, err := svc.DescribeClusters(ctx, &redshift.DescribeClustersInput{Marker: marker})
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 				for _, cluster := range clusters.Clusters {

--- a/resources/packs/aws/aws_sagemaker.go
+++ b/resources/packs/aws/aws_sagemaker.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
 	"github.com/aws/smithy-go/transport/http"
+	"github.com/rs/zerolog/log"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources"
 	"go.mondoo.com/cnquery/resources/library/jobpool"
@@ -57,6 +58,10 @@ func (s *mqlAwsSagemaker) getEndpoints(provider *aws_provider.Provider) []*jobpo
 			for nextToken != nil {
 				endpoints, err := svc.ListEndpoints(ctx, params)
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 
@@ -154,6 +159,10 @@ func (s *mqlAwsSagemaker) getNotebookInstances(provider *aws_provider.Provider) 
 			for nextToken != nil {
 				notebookInstances, err := svc.ListNotebookInstances(ctx, &sagemaker.ListNotebookInstancesInput{})
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 				for _, instance := range notebookInstances.NotebookInstances {

--- a/resources/packs/aws/aws_secretsmanager.go
+++ b/resources/packs/aws/aws_secretsmanager.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+	"github.com/rs/zerolog/log"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources/library/jobpool"
 	"go.mondoo.com/cnquery/resources/packs/core"
@@ -59,6 +60,10 @@ func (e *mqlAwsSecretsmanager) getSecrets(provider *aws_provider.Provider) []*jo
 			for nextToken != nil {
 				secrets, err := svc.ListSecrets(ctx, params)
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 				for _, secret := range secrets.SecretList {

--- a/resources/packs/aws/aws_securityhub.go
+++ b/resources/packs/aws/aws_securityhub.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/securityhub"
 	"github.com/aws/aws-sdk-go-v2/service/securityhub/types"
+	"github.com/rs/zerolog/log"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources/library/jobpool"
 	"go.mondoo.com/cnquery/resources/packs/core"
@@ -52,6 +53,10 @@ func (s *mqlAwsSecurityhub) getHubs(provider *aws_provider.Provider) []*jobpool.
 			res := []interface{}{}
 			secHub, err := svc.DescribeHub(ctx, &securityhub.DescribeHubInput{})
 			if err != nil {
+				if Is400AccessDeniedError(err) {
+					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+					return res, nil
+				}
 				var notFoundErr *types.InvalidAccessException
 				if errors.As(err, &notFoundErr) {
 					return nil, nil

--- a/resources/packs/aws/aws_sns.go
+++ b/resources/packs/aws/aws_sns.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 	"github.com/aws/smithy-go/transport/http"
+	"github.com/rs/zerolog/log"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources"
 	"go.mondoo.com/cnquery/resources/library/jobpool"
@@ -96,6 +97,10 @@ func (s *mqlAwsSns) getTopics(provider *aws_provider.Provider) []*jobpool.Job {
 			for nextToken != nil {
 				topics, err := svc.ListTopics(ctx, params)
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 				for _, topic := range topics.Topics {

--- a/resources/packs/aws/aws_ssm.go
+++ b/resources/packs/aws/aws_ssm.go
@@ -69,6 +69,10 @@ func (s *mqlAwsSsm) getInstances(provider *aws_provider.Provider) []*jobpool.Job
 			for nextToken != nil {
 				isssmresp, err := ssmsvc.DescribeInstanceInformation(ctx, input)
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, errors.Wrap(err, "could not gather ssm information")
 				}
 				nextToken = isssmresp.NextToken

--- a/resources/packs/aws/aws_vpcs.go
+++ b/resources/packs/aws/aws_vpcs.go
@@ -75,6 +75,10 @@ func (s *mqlAws) getVpcs(provider *aws_provider.Provider) []*jobpool.Job {
 			for nextToken != nil {
 				vpcs, err := svc.DescribeVpcs(ctx, params)
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 				nextToken = vpcs.NextToken


### PR DESCRIPTION
some users have region restrictions on different services, so that they can access us-east-1 for a specific service, but not, for example, us-west-1

a user reported running into this behavior when attempting to query their aws resources

before:
```
 [9/03/23 22:10:14] ❯ AWS_PROFILE="restricted" cnquery shell aws
→ no Mondoo configuration file provided. using defaults
→ discover related assets for 1 asset(s)
→ resolved assets resolved-assets=1
  ___ _ __   __ _ _   _  ___ _ __ _   _
 / __| '_ \ / _` | | | |/ _ \ '__| | | |
| (__| | | | (_| | |_| |  __/ |  | |_| |
 \___|_| |_|\__, |\__,_|\___|_|   \__, |
  mondoo™      |_|                |___/  interactive shell

cnquery> aws.cloudwatch.logGroups { * }
Query encountered errors:
job err: : could not gather aws cloudwatch log groups: operation error CloudWatch Logs: DescribeLogGroups, https response error StatusCode: 400, RequestID: 87000c84-59e8-4aae-bec2-b1caba97254d, api error AccessDeniedException: User: arn:aws:iam::172746783610:user/restricted-test is not authorized to perform: logs:DescribeLogGroups on resource: arn:aws:logs:us-east-2:172746783610:log-group::log-stream: with an explicit deny in an identity-based policy
aws.cloudwatch.logGroups: no data available
cnquery> exit
```

AFTER:
```
cnquery> aws.cloudwatch.logGroups { * }
! error accessing region for AWS API region=us-east-2
aws.cloudwatch.logGroups: [
  0: {
    kmsKey: data is not a map to auto-expand
    arn: "arn:aws:logs:eu-west-1:172746783610:log-group:/aws/lambda/MondooLambda:*"
    region: "eu-west-1"
    metricsFilters: []
    name: "/aws/lambda/MondooLambda"
  }
  1: {
    kmsKey: data is not a map to auto-expand
    arn: "arn:aws:logs:eu-central-1:172746783610:log-group:/aws/lambda/MondooLambda:*"
    region: "eu-central-1"
    metricsFilters: []
    name: "/aws/lambda/MondooLambda"
  }
...
```