### PR TITLE
Add instances-api azure discovery target

### DIFF
--- a/motor/discovery/azure/consts.go
+++ b/motor/discovery/azure/consts.go
@@ -2,8 +2,10 @@ package azure
 
 const (
 	// Discovery flags
-	DiscoverySubscriptions     = "subscriptions"
-	DiscoveryInstances         = "instances"
+	DiscoverySubscriptions = "subscriptions"
+	DiscoveryInstances     = "instances"
+	// TODO: this probably needs some more work on the linking to its OS counterpart side
+	DiscoveryInstancesApi      = "instances-api"
 	DiscoverySqlServers        = "sql-servers"
 	DiscoveryPostgresServers   = "postgres-servers"
 	DiscoveryMySqlServers      = "mysql-servers"

--- a/motor/discovery/azure/mql_asset_objects.go
+++ b/motor/discovery/azure/mql_asset_objects.go
@@ -26,9 +26,8 @@ func getTitleFamily(azureObject azureObject) (azureObjectPlatformInfo, error) {
 			return azureObjectPlatformInfo{title: "Azure Compute VM", platform: "azure-compute-vm"}, nil
 		}
 		if azureObject.objectType == "vm-api" {
-			return azureObjectPlatformInfo{title: "Azure Compute VM API ", platform: "azure-compute-vm-api"}, nil
+			return azureObjectPlatformInfo{title: "Azure Compute VM", platform: "azure-compute-vm-api"}, nil
 		}
-
 	case "sql":
 		if azureObject.objectType == "server" {
 			return azureObjectPlatformInfo{title: "Azure SQL Server", platform: "azure-sql-server"}, nil

--- a/motor/discovery/azure/mql_assets.go
+++ b/motor/discovery/azure/mql_assets.go
@@ -81,6 +81,13 @@ func GatherAssets(ctx context.Context, tc *providers.Config, credsResolver vault
 		}
 		assets = append(assets, instances...)
 	}
+	if tc.IncludesOneOfDiscoveryTarget(common.DiscoveryAll, DiscoveryInstancesApi) {
+		instancesApi, err := computeInstancesApi(m, provider.SubscriptionID(), pCfg)
+		if err != nil {
+			return nil, err
+		}
+		assets = append(assets, instancesApi...)
+	}
 	if tc.IncludesOneOfDiscoveryTarget(common.DiscoveryAll, DiscoverySqlServers) {
 		servers, err := computeSqlServers(m, provider.SubscriptionID(), pCfg)
 		if err != nil {

--- a/motor/discovery/azure/resolver.go
+++ b/motor/discovery/azure/resolver.go
@@ -15,6 +15,12 @@ import (
 	"go.mondoo.com/cnquery/motor/vault"
 )
 
+var ResourceDiscoveryTargets = []string{
+	DiscoveryInstances, DiscoverySqlServers, DiscoveryPostgresServers,
+	DiscoveryMySqlServers, DiscoveryMariaDbServers, DiscoveryStorageAccounts,
+	DiscoveryStorageContainers, DiscoveryKeyVaults, DiscoverySecurityGroups, DiscoveryInstancesApi,
+}
+
 type Resolver struct{}
 
 func (r *Resolver) Name() string {
@@ -23,9 +29,10 @@ func (r *Resolver) Name() string {
 
 func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{
-		common.DiscoveryAuto, common.DiscoveryAll, DiscoverySubscriptions, DiscoveryInstances,
-		DiscoverySqlServers, DiscoveryPostgresServers, DiscoveryMySqlServers, DiscoveryMariaDbServers,
-		DiscoveryStorageAccounts, DiscoveryStorageContainers, DiscoveryKeyVaults, DiscoverySecurityGroups,
+		common.DiscoveryAuto, common.DiscoveryAll, DiscoverySubscriptions,
+		DiscoveryInstances, DiscoverySqlServers, DiscoveryPostgresServers,
+		DiscoveryMySqlServers, DiscoveryMariaDbServers, DiscoveryStorageAccounts,
+		DiscoveryStorageContainers, DiscoveryKeyVaults, DiscoverySecurityGroups, DiscoveryInstancesApi,
 	}
 }
 
@@ -148,10 +155,9 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 	}
 
 	// resources as assets
-	if tc.IncludesOneOfDiscoveryTarget(common.DiscoveryAll, common.DiscoveryAuto,
-		DiscoveryInstances, DiscoverySqlServers, DiscoveryPostgresServers, DiscoveryMySqlServers,
-		DiscoveryMariaDbServers, DiscoveryStorageAccounts, DiscoveryStorageContainers,
-		DiscoveryKeyVaults, DiscoverySecurityGroups) {
+	if tc.IncludesOneOfDiscoveryTarget(common.DiscoveryAll, DiscoveryInstances, DiscoveryInstancesApi,
+		DiscoverySqlServers, DiscoveryPostgresServers, DiscoveryMySqlServers, DiscoveryMariaDbServers,
+		DiscoveryStorageAccounts, DiscoveryStorageContainers, DiscoveryKeyVaults, DiscoverySecurityGroups) {
 		for id, tc := range subsConfig {
 			assetList, err := GatherAssets(ctx, tc.Cfg, credsResolver, sfn)
 			if err != nil {

--- a/motor/discovery/azure/resolver.go
+++ b/motor/discovery/azure/resolver.go
@@ -28,12 +28,9 @@ func (r *Resolver) Name() string {
 }
 
 func (r *Resolver) AvailableDiscoveryTargets() []string {
-	return []string{
-		common.DiscoveryAuto, common.DiscoveryAll, DiscoverySubscriptions,
-		DiscoveryInstances, DiscoverySqlServers, DiscoveryPostgresServers,
-		DiscoveryMySqlServers, DiscoveryMariaDbServers, DiscoveryStorageAccounts,
-		DiscoveryStorageContainers, DiscoveryKeyVaults, DiscoverySecurityGroups, DiscoveryInstancesApi,
-	}
+	targets := []string{common.DiscoveryAll, common.DiscoveryAuto, DiscoverySubscriptions}
+	targets = append(targets, ResourceDiscoveryTargets...)
+	return targets
 }
 
 func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*asset.Asset, error) {
@@ -154,10 +151,10 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 		}
 	}
 
+	resourceTargets := []string{common.DiscoveryAll}
+	resourceTargets = append(resourceTargets, ResourceDiscoveryTargets...)
 	// resources as assets
-	if tc.IncludesOneOfDiscoveryTarget(common.DiscoveryAll, DiscoveryInstances, DiscoveryInstancesApi,
-		DiscoverySqlServers, DiscoveryPostgresServers, DiscoveryMySqlServers, DiscoveryMariaDbServers,
-		DiscoveryStorageAccounts, DiscoveryStorageContainers, DiscoveryKeyVaults, DiscoverySecurityGroups) {
+	if tc.IncludesOneOfDiscoveryTarget(resourceTargets...) {
 		for id, tc := range subsConfig {
 			assetList, err := GatherAssets(ctx, tc.Cfg, credsResolver, sfn)
 			if err != nil {


### PR DESCRIPTION
Problem: Trying to scan an instance right now with an azure policy does not work since the instances have an attached SSH connection. This means that a query like `azure.compute.subscription.vm{...}` will not work on the ssh provider.

To fix this, this PR introduces a new target `instances-api`.
  - `instances` is meant to instantiate the instances as proper VMs with attached SSH connection to them.
  - `instances-api` is meant to instantiate the instances as API objects, solely looking at what the azure API returns on them

Discovering both will produce 2 assets for 1 VM, one on the 'API' (external) side and one for the 'OS' (inside) side
```
➜ ~/go/bin/cnquery shell azure --discover instances-api,instances
→ loaded configuration from /Users/preslavgerchev/.config/mondoo/mondoo.yml using source default
→ discover related assets for 1 asset(s)
! could not determine credentials for asset name=ms365-windows
→ resolved assets resolved-assets=2

    Available assets                       
                                           
  > 1. ms365-windows (azure-compute-vm)    
    2. ms365-windows (azure-compute-vm-api)
```

This will allow us to rewrite policies by using the new platform name for a target so that azure policies only target API instance assets.

