### PR TITLE
reduce potential dependencies in the command builder

### DIFF
--- a/apps/cnquery/cmd/builder/builder.go
+++ b/apps/cnquery/cmd/builder/builder.go
@@ -7,7 +7,8 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"go.mondoo.com/cnquery/motor/discovery/common"
+	"go.mondoo.com/cnquery/apps/cnquery/cmd/builder/common"
+	discovery_common "go.mondoo.com/cnquery/motor/discovery/common"
 	"go.mondoo.com/cnquery/motor/providers"
 )
 
@@ -33,9 +34,7 @@ const (
 )
 
 type (
-	commonFlagsFn  func(cmd *cobra.Command)
-	commonPreRunFn func(cmd *cobra.Command, args []string)
-	runFn          func(cmd *cobra.Command, args []string, provider providers.ProviderType, assetType AssetType)
+	runFn func(cmd *cobra.Command, args []string, provider providers.ProviderType, assetType AssetType)
 )
 
 func NewProviderCommand(opts CommandOpts) *cobra.Command {
@@ -82,14 +81,14 @@ type CommandOpts struct {
 	Short             string
 	Long              string
 	Run               runFn
-	CommonFlags       commonFlagsFn
-	CommonPreRun      commonPreRunFn
-	Docs              CommandsDocs
+	CommonFlags       common.CommonFlagsFn
+	CommonPreRun      common.CommonPreRunFn
+	Docs              common.CommandsDocs
 	PreRun            func(cmd *cobra.Command, args []string)
 	ValidArgsFunction func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
 }
 
-func buildCmd(baseCmd *cobra.Command, commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) {
+func buildCmd(baseCmd *cobra.Command, commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) {
 	containerCmd := containerProviderCmd(commonCmdFlags, preRun, runFn, docs)
 	containerImageCmd := containerImageProviderCmd(commonCmdFlags, preRun, runFn, docs)
 	containerCmd.AddCommand(containerImageCmd)
@@ -174,32 +173,7 @@ func buildCmd(baseCmd *cobra.Command, commonCmdFlags commonFlagsFn, preRun commo
 	baseCmd.AddCommand(scanVcdCmd(commonCmdFlags, preRun, runFn, docs))
 }
 
-type CommandsDocs struct {
-	Entries map[string]CommandDocsEntry
-}
-
-type CommandDocsEntry struct {
-	Short string
-	Long  string
-}
-
-func (c CommandsDocs) GetShort(id string) string {
-	e, ok := c.Entries[id]
-	if ok {
-		return e.Short
-	}
-	return ""
-}
-
-func (c CommandsDocs) GetLong(id string) string {
-	e, ok := c.Entries[id]
-	if ok {
-		return e.Long
-	}
-	return ""
-}
-
-func localProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func localProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "local",
 		Short:  docs.GetShort("local"),
@@ -214,7 +188,7 @@ func localProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn
 	return cmd
 }
 
-func mockProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func mockProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "mock PATH",
 		Short:  docs.GetShort("mock"),
@@ -230,7 +204,7 @@ func mockProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn 
 	return cmd
 }
 
-func vagrantCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func vagrantCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "vagrant HOST",
 		Short:  docs.GetShort("vagrant"),
@@ -245,7 +219,7 @@ func vagrantCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn
 	return cmd
 }
 
-func terraformProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func terraformProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "terraform PATH",
 		Short:  docs.GetShort("terraform"),
@@ -261,7 +235,7 @@ func terraformProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, r
 	return cmd
 }
 
-func terraformProviderStateCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func terraformProviderStateCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "state PATH",
 		Short:  "Scan a Terraform state file (json)",
@@ -276,7 +250,7 @@ func terraformProviderStateCmd(commonCmdFlags commonFlagsFn, preRun commonPreRun
 	return cmd
 }
 
-func terraformProviderPlanCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func terraformProviderPlanCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "plan PATH",
 		Short:  "Scan a Terraform plan file (json)",
@@ -291,7 +265,7 @@ func terraformProviderPlanCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunF
 	return cmd
 }
 
-func sshProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func sshProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "ssh user@host",
 		Short:  docs.GetShort("ssh"),
@@ -306,7 +280,7 @@ func sshProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn r
 	return cmd
 }
 
-func winrmProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func winrmProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "winrm user@host",
 		Short:  docs.GetShort("winrm"),
@@ -321,7 +295,7 @@ func winrmProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn
 	return cmd
 }
 
-func containerProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func containerProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "container ID",
 		Short:  docs.GetShort("container"),
@@ -336,7 +310,7 @@ func containerProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, r
 	return cmd
 }
 
-func containerImageProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func containerImageProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "image ID",
 		Short:  docs.GetShort("container-image"),
@@ -351,7 +325,7 @@ func containerImageProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRun
 	return cmd
 }
 
-func containerRegistryProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func containerRegistryProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Aliases: []string{"cr"},
 		Use:     "registry TARGET",
@@ -367,7 +341,7 @@ func containerRegistryProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPre
 	return cmd
 }
 
-func dockerProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func dockerProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "docker ID",
 		Short:  docs.GetShort("docker"),
@@ -382,7 +356,7 @@ func dockerProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runF
 			}
 
 			// If no target is provided and the discovery flag is empty or auto, then error out since there is nothing to scan.
-			if len(args) == 0 && (len(discover) == 0 || strings.Contains(discover, common.DiscoveryAuto)) {
+			if len(args) == 0 && (len(discover) == 0 || strings.Contains(discover, discovery_common.DiscoveryAuto)) {
 				log.Error().Msg("either a target or a discovery flag different from \"auto\" must be provided for docker scans")
 				return
 			}
@@ -394,7 +368,7 @@ func dockerProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runF
 	return cmd
 }
 
-func dockerContainerProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func dockerContainerProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "container ID",
 		Short:  docs.GetShort("docker-container"),
@@ -409,7 +383,7 @@ func dockerContainerProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRu
 	return cmd
 }
 
-func dockerImageProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func dockerImageProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "image ID",
 		Short:  docs.GetShort("docker-image"),
@@ -424,7 +398,7 @@ func dockerImageProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn,
 	return cmd
 }
 
-func kubernetesProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func kubernetesProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "k8s (optional MANIFEST path)",
 		Aliases: []string{"kubernetes"},
@@ -459,7 +433,7 @@ func kubernetesProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, 
 	return cmd
 }
 
-func awsProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func awsProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "aws",
 		Short: docs.GetShort("aws"),
@@ -480,7 +454,7 @@ func awsProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn r
 	return cmd
 }
 
-func awsEc2ProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func awsEc2ProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ec2 SUBCOMMAND",
 		Short: docs.GetShort("aws-ec2"),
@@ -495,7 +469,7 @@ func awsEc2ProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runF
 	return cmd
 }
 
-func awsEc2ConnectProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func awsEc2ConnectProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "instance-connect user@host",
 		Short:  docs.GetShort("aws-ec2-connect"),
@@ -510,7 +484,7 @@ func awsEc2ConnectProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunF
 	return cmd
 }
 
-func awsEc2EbsProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func awsEc2EbsProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "ebs INSTANCEID",
 		Short:  docs.GetShort("aws-ec2-ebs-instance"),
@@ -525,7 +499,7 @@ func awsEc2EbsProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, r
 	return cmd
 }
 
-func awsEc2EbsVolumeProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func awsEc2EbsVolumeProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "volume VOLUMEID",
 		Short:  docs.GetShort("aws-ec2-ebs-volume"),
@@ -540,7 +514,7 @@ func awsEc2EbsVolumeProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRu
 	return cmd
 }
 
-func awsEc2EbsSnapshotProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func awsEc2EbsSnapshotProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "snapshot SNAPSHOTID",
 		Short:  docs.GetShort("aws-ec2-ebs-snapshot"),
@@ -555,7 +529,7 @@ func awsEc2EbsSnapshotProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPre
 	return cmd
 }
 
-func awsEc2SsmProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func awsEc2SsmProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "ssm user@host",
 		Short:  docs.GetShort("aws-ec2-ssm"),
@@ -570,34 +544,16 @@ func awsEc2SsmProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, r
 	return cmd
 }
 
-func azureProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "azure",
-		Short: docs.GetShort("azure"),
-		Long:  docs.GetLong("azure"),
-		Args:  cobra.ExactArgs(0),
-		PreRun: func(cmd *cobra.Command, args []string) {
-			preRun(cmd, args)
-			viper.BindPFlag("subscription", cmd.Flags().Lookup("subscription"))
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_AZURE, DefaultAssetType)
-		},
+func azureProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_AZURE, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
-	cmd.Flags().String("tenant-id", "", "Directory (tenant) ID of the service principal")
-	cmd.Flags().String("client-id", "", "Application (client) ID of the service principal")
-	cmd.Flags().String("client-secret", "", "Secret for application")
-	cmd.Flags().String("certificate-path", "", "Path (in PKCS #12/PFX or PEM format) to the authentication certificate")
-	cmd.Flags().String("certificate-secret", "", "Passphrase for the authentication certificate file")
-	cmd.Flags().String("subscription", "", "ID of the Azure subscription to scan")
-	cmd.Flags().String("subscriptions", "", "Comma-separated list of Azure subscriptions to include")
-	cmd.Flags().String("subscriptions-exclude", "", "Comma-separated list of Azure subscriptions to exclude")
+	cmd := common.AzureProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 
 	return cmd
 }
 
-func scanGcpCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func scanGcpCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "gcp",
 		Short: docs.GetShort("gcp"),
@@ -628,7 +584,7 @@ func scanGcpCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn
 	return cmd
 }
 
-func scanGcpOrgCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func scanGcpOrgCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "org ORGANIZATION-ID",
 		Aliases: []string{"organization"},
@@ -648,7 +604,7 @@ func scanGcpOrgCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn ru
 	return cmd
 }
 
-func scanGcpProjectCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func scanGcpProjectCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "project PROJECT-ID",
 		Short: docs.GetShort("gcp-project"),
@@ -667,7 +623,7 @@ func scanGcpProjectCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runF
 	return cmd
 }
 
-func scanGcpFolderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func scanGcpFolderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "folder FOLDER-ID",
 		Short: docs.GetShort("gcp-folder"),
@@ -686,7 +642,7 @@ func scanGcpFolderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn
 	return cmd
 }
 
-func scanGcpGcrCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func scanGcpGcrCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "gcr PROJECT",
 		Short: docs.GetShort("gcp-gcr"),
@@ -705,7 +661,7 @@ func scanGcpGcrCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn ru
 	return cmd
 }
 
-func vsphereProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func vsphereProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "vsphere user@host",
 		Short:  docs.GetShort("vsphere"),
@@ -720,7 +676,7 @@ func vsphereProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, run
 	return cmd
 }
 
-func vsphereVmProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func vsphereVmProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "vm user@host",
 		Short:  docs.GetShort("vsphere-vm"),
@@ -735,7 +691,7 @@ func vsphereVmProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, r
 	return cmd
 }
 
-func scanGithubCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func scanGithubCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "github SUBCOMMAND",
 		Short: docs.GetShort("github"),
@@ -749,7 +705,7 @@ func scanGithubCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn ru
 	return cmd
 }
 
-func githubProviderOrganizationCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func githubProviderOrganizationCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "org",
 		Short: docs.GetShort("github-org"),
@@ -768,7 +724,7 @@ func githubProviderOrganizationCmd(commonCmdFlags commonFlagsFn, preRun commonPr
 	return cmd
 }
 
-func githubProviderRepositoryCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func githubProviderRepositoryCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "repo",
 		Short: docs.GetShort("github-repo"),
@@ -787,7 +743,7 @@ func githubProviderRepositoryCmd(commonCmdFlags commonFlagsFn, preRun commonPreR
 	return cmd
 }
 
-func githubProviderUserCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func githubProviderUserCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "user",
 		Short: docs.GetShort("github-user"),
@@ -806,7 +762,7 @@ func githubProviderUserCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, 
 	return cmd
 }
 
-func gitlabProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func gitlabProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "gitlab",
 		Short: docs.GetShort("gitlab"),
@@ -828,7 +784,7 @@ func gitlabProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runF
 	return cmd
 }
 
-func ms365ProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func ms365ProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "ms365",
 		Aliases: []string{"microsoft365"},
@@ -850,7 +806,7 @@ func ms365ProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn
 	return cmd
 }
 
-func hostProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func hostProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "host HOST",
 		Short:  docs.GetShort("host"),
@@ -865,7 +821,7 @@ func hostProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn 
 	return cmd
 }
 
-func aristaProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func aristaProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "arista user@host",
 		Short:  docs.GetShort("arista"),
@@ -880,7 +836,7 @@ func aristaProviderCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runF
 	return cmd
 }
 
-func scanOktaCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func scanOktaCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "okta",
 		Short: docs.GetShort("okta"),
@@ -901,7 +857,7 @@ func scanOktaCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runF
 	return cmd
 }
 
-func scanGoogleWorkspaceCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func scanGoogleWorkspaceCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "google-workspace",
 		Aliases: []string{"googleworkspace"},
@@ -927,7 +883,7 @@ func scanGoogleWorkspaceCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn,
 	return cmd
 }
 
-func scanSlackCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func scanSlackCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "slack",
 		Short: docs.GetShort("slack"),
@@ -946,7 +902,7 @@ func scanSlackCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn run
 	return cmd
 }
 
-func scanVcdCmd(commonCmdFlags commonFlagsFn, preRun commonPreRunFn, runFn runFn, docs CommandsDocs) *cobra.Command {
+func scanVcdCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "vcd",
 		Short: docs.GetShort("vcd"),

--- a/apps/cnquery/cmd/builder/builder.go
+++ b/apps/cnquery/cmd/builder/builder.go
@@ -448,164 +448,66 @@ func githubProviderUserCmd(commonCmdFlags common.CommonFlagsFn, preRun common.Co
 }
 
 func gitlabProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "gitlab",
-		Short: docs.GetShort("gitlab"),
-		Long:  docs.GetLong("gitlab"),
-		Args:  cobra.ExactArgs(0),
-		PreRun: func(cmd *cobra.Command, args []string) {
-			viper.BindPFlag("token", cmd.Flags().Lookup("token"))
-			viper.BindPFlag("group", cmd.Flags().Lookup("group"))
-			preRun(cmd, args)
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_GITLAB, DefaultAssetType) // TODO: does not indicate individual assets
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_GITLAB, DefaultAssetType) // TODO: does not indicate individual assets
 	}
-	commonCmdFlags(cmd)
-	cmd.Flags().String("group", "", "a GitLab group to scan")
-	cmd.MarkFlagRequired("group")
-	cmd.Flags().String("token", "", "GitLab personal access token")
+	cmd := common.GitlabProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func ms365ProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "ms365",
-		Aliases: []string{"microsoft365"},
-		Short:   docs.GetShort("ms365"),
-		Long:    docs.GetLong("ms365"),
-		Args:    cobra.ExactArgs(0),
-		PreRun:  preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_MS365, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_MS365, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
-	cmd.Flags().String("tenant-id", "", "directory (tenant) ID of the service principal")
-	cmd.Flags().String("client-id", "", "application (client) ID of the service principal")
-	cmd.Flags().String("client-secret", "", "secret for application")
-	cmd.Flags().String("certificate-path", "", "path to certificate that's used for certificate-based authentication in PKCS 12 format (pfx)")
-	cmd.Flags().String("certificate-secret", "", "passphrase for certificate file")
-	cmd.Flags().String("datareport", "", "set the MS365 datareport for the scan")
+	cmd := common.Ms365ProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func hostProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "host HOST",
-		Short:  docs.GetShort("host"),
-		Long:   docs.GetLong("host"),
-		Args:   cobra.ExactArgs(1),
-		PreRun: preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_HOST, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_HOST, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
+	cmd := common.HostProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func aristaProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "arista user@host",
-		Short:  docs.GetShort("arista"),
-		Long:   docs.GetLong("arista"),
-		Args:   cobra.ExactArgs(1),
-		PreRun: preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_ARISTAEOS, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_ARISTAEOS, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
+	cmd := common.AristaProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func scanOktaCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "okta",
-		Short: docs.GetShort("okta"),
-		Long:  docs.GetLong("okta"),
-		Args:  cobra.ExactArgs(0),
-		PreRun: func(cmd *cobra.Command, args []string) {
-			viper.BindPFlag("organization", cmd.Flags().Lookup("organization"))
-			viper.BindPFlag("token", cmd.Flags().Lookup("token"))
-			preRun(cmd, args)
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_OKTA, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_OKTA, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
-	cmd.Flags().String("organization", "", "specify the Okta organization to scan")
-	cmd.Flags().String("token", "", "Okta access token")
+	cmd := common.ScanOktaCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func scanGoogleWorkspaceCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "google-workspace",
-		Aliases: []string{"googleworkspace"},
-		Short:   docs.GetShort("googleworkspace"),
-		Long:    docs.GetLong("googleworkspace"),
-		Args:    cobra.ExactArgs(0),
-		PreRun: func(cmd *cobra.Command, args []string) {
-			viper.BindPFlag("customer-id", cmd.Flags().Lookup("customer-id"))
-			viper.BindPFlag("impersonated-user-email", cmd.Flags().Lookup("impersonated-user-email"))
-			viper.BindPFlag("credentials-path", cmd.Flags().Lookup("credentials-path"))
-
-			preRun(cmd, args)
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_GOOGLE_WORKSPACE, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_GOOGLE_WORKSPACE, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
-	cmd.Flags().String("customer-id", "", "Specify the Google Workspace customer id to scan")
-	cmd.Flags().String("impersonated-user-email", "", "The impersonated user's email with access to the Admin APIs")
-	cmd.Flags().String("credentials-path", "", "The path to the service account credentials to access the APIs with")
+	cmd := common.ScanGoogleWorkspaceCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 
 	return cmd
 }
 
 func scanSlackCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "slack",
-		Short: docs.GetShort("slack"),
-		Long:  docs.GetLong("slack"),
-		Args:  cobra.ExactArgs(0),
-		PreRun: func(cmd *cobra.Command, args []string) {
-			viper.BindPFlag("token", cmd.Flags().Lookup("token"))
-			preRun(cmd, args)
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_SLACK, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_SLACK, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
-	cmd.Flags().String("token", "", "Slack API token")
+	cmd := common.ScanSlackCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func scanVcdCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "vcd",
-		Short: docs.GetShort("vcd"),
-		Long:  docs.GetLong("vcd"),
-		Args:  cobra.ExactArgs(0),
-		PreRun: func(cmd *cobra.Command, args []string) {
-			viper.BindPFlag("user", cmd.Flags().Lookup("user"))
-			viper.BindPFlag("host", cmd.Flags().Lookup("host"))
-			viper.BindPFlag("organization", cmd.Flags().Lookup("organization"))
-			preRun(cmd, args)
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_VCD, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_VCD, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
-	cmd.Flags().String("user", "", "vCloud Director user")
-	cmd.Flags().String("host", "", "vCloud Director Host")
-	cmd.Flags().String("organization", "", "vCloud Director Organization (optional)")
+	cmd := common.ScanVcdCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }

--- a/apps/cnquery/cmd/builder/builder.go
+++ b/apps/cnquery/cmd/builder/builder.go
@@ -2,13 +2,11 @@ package builder
 
 import (
 	"os"
-	"strings"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.mondoo.com/cnquery/apps/cnquery/cmd/builder/common"
-	discovery_common "go.mondoo.com/cnquery/motor/discovery/common"
 	"go.mondoo.com/cnquery/motor/providers"
 )
 
@@ -296,251 +294,119 @@ func winrmProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonP
 }
 
 func containerProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "container ID",
-		Short:  docs.GetShort("container"),
-		Long:   docs.GetLong("container"),
-		Args:   cobra.ExactArgs(1),
-		PreRun: preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_DOCKER, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_DOCKER, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
+	cmd := common.ContainerProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func containerImageProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "image ID",
-		Short:  docs.GetShort("container-image"),
-		Long:   docs.GetLong("container-image"),
-		Args:   cobra.ExactArgs(1),
-		PreRun: preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_DOCKER_ENGINE_IMAGE, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_DOCKER_ENGINE_IMAGE, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
+
+	cmd := common.ContainerImageProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func containerRegistryProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Aliases: []string{"cr"},
-		Use:     "registry TARGET",
-		Short:   docs.GetShort("container-registry"),
-		Long:    docs.GetLong("container-registry"),
-		Args:    cobra.ExactArgs(1),
-		PreRun:  preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_CONTAINER_REGISTRY, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_CONTAINER_REGISTRY, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
+	cmd := common.ContainerRegistryProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func dockerProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "docker ID",
-		Short:  docs.GetShort("docker"),
-		Long:   docs.GetLong("docker"),
-		Args:   cobra.MaximumNArgs(1),
-		PreRun: preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			discover, err := cmd.Flags().GetString("discover")
-			if err != nil {
-				log.Error().Err(err).Msg("failed to retrieve discover flag")
-				return
-			}
-
-			// If no target is provided and the discovery flag is empty or auto, then error out since there is nothing to scan.
-			if len(args) == 0 && (len(discover) == 0 || strings.Contains(discover, discovery_common.DiscoveryAuto)) {
-				log.Error().Msg("either a target or a discovery flag different from \"auto\" must be provided for docker scans")
-				return
-			}
-
-			runFn(cmd, args, providers.ProviderType_DOCKER, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_DOCKER, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
+
+	cmd := common.DockerProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func dockerContainerProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "container ID",
-		Short:  docs.GetShort("docker-container"),
-		Long:   docs.GetLong("docker-container"),
-		Args:   cobra.ExactArgs(1),
-		PreRun: preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_DOCKER_ENGINE_CONTAINER, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_DOCKER_ENGINE_CONTAINER, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
+
+	cmd := common.DockerContainerProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func dockerImageProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "image ID",
-		Short:  docs.GetShort("docker-image"),
-		Long:   docs.GetLong("docker-image"),
-		Args:   cobra.ExactArgs(1),
-		PreRun: preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_DOCKER_ENGINE_IMAGE, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_DOCKER_ENGINE_IMAGE, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
+
+	cmd := common.DockerImageProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func kubernetesProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "k8s (optional MANIFEST path)",
-		Aliases: []string{"kubernetes"},
-		Short:   docs.GetShort("kubernetes"),
-		Long:    docs.GetLong("kubernetes"),
-		Args:    cobra.MaximumNArgs(1),
-		PreRun: func(cmd *cobra.Command, args []string) {
-			preRun(cmd, args)
-			// FIXME: DEPRECATED, remove in v8.0 vv
-			viper.BindPFlag("namespace", cmd.Flags().Lookup("namespace"))
-			// ^^
-			viper.BindPFlag("namespaces-exclude", cmd.Flags().Lookup("namespaces-exclude"))
-			viper.BindPFlag("namespaces", cmd.Flags().Lookup("namespaces"))
-			viper.BindPFlag("context", cmd.Flags().Lookup("context"))
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) > 0 {
-				cmd.Flags().Set("path", args[0])
-			}
-			runFn(cmd, args, providers.ProviderType_K8S, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_K8S, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
-	// FIXME: DEPRECATED, remove in v8.0
-	cmd.Flags().String("namespace", "", "filter kubernetes objects by namespace")
-	cmd.Flags().MarkHidden("namespace")
-	// ^^
 
-	cmd.Flags().String("context", "", "target a Kubernetes context")
-	cmd.Flags().String("namespaces-exclude", "", "filter out Kubernetes objects in the matching namespaces")
-	cmd.Flags().String("namespaces", "", "only include Kubernetes object in the matching namespaces")
+	cmd := common.KubernetesProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func awsProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "aws",
-		Short: docs.GetShort("aws"),
-		Long:  docs.GetLong("aws"),
-		Args:  cobra.ExactArgs(0),
-		PreRun: func(cmd *cobra.Command, args []string) {
-			preRun(cmd, args)
-			viper.BindPFlag("project", cmd.Flags().Lookup("project"))
-			viper.BindPFlag("region", cmd.Flags().Lookup("region"))
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_AWS, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_AWS, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
-	cmd.Flags().String("profile", "", "pick a named AWS profile to use")
-	cmd.Flags().String("region", "", "the AWS region to scan")
+
+	cmd := common.AwsProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func awsEc2ProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "ec2 SUBCOMMAND",
-		Short: docs.GetShort("aws-ec2"),
-		Long:  docs.GetLong("aws-ec2"),
-		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help()
-			os.Exit(0)
-		},
-	}
-	commonCmdFlags(cmd)
+	cmd := common.AwsEc2ProviderCmd(commonCmdFlags, preRun, nil, docs)
 	return cmd
 }
 
 func awsEc2ConnectProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "instance-connect user@host",
-		Short:  docs.GetShort("aws-ec2-connect"),
-		Long:   docs.GetLong("aws-ec2-connect"),
-		Args:   cobra.ExactArgs(1),
-		PreRun: preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_SSH, Ec2InstanceConnectAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_SSH, Ec2InstanceConnectAssetType)
 	}
-	commonCmdFlags(cmd)
+
+	cmd := common.AwsEc2ConnectProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func awsEc2EbsProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "ebs INSTANCEID",
-		Short:  docs.GetShort("aws-ec2-ebs-instance"),
-		Long:   docs.GetLong("aws-ec2-ebs-instance"),
-		Args:   cobra.ExactArgs(1),
-		PreRun: preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_AWS_EC2_EBS, Ec2ebsInstanceAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_AWS_EC2_EBS, Ec2ebsInstanceAssetType)
 	}
-	commonCmdFlags(cmd)
+	cmd := common.AwsEc2EbsProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func awsEc2EbsVolumeProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "volume VOLUMEID",
-		Short:  docs.GetShort("aws-ec2-ebs-volume"),
-		Long:   docs.GetLong("aws-ec2-ebs-volume"),
-		Args:   cobra.ExactArgs(1),
-		PreRun: preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_AWS_EC2_EBS, Ec2ebsVolumeAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_AWS_EC2_EBS, Ec2ebsVolumeAssetType)
 	}
-	commonCmdFlags(cmd)
+
+	cmd := common.AwsEc2EbsVolumeProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func awsEc2EbsSnapshotProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "snapshot SNAPSHOTID",
-		Short:  docs.GetShort("aws-ec2-ebs-snapshot"),
-		Long:   docs.GetLong("aws-ec2-ebs-snapshot"),
-		Args:   cobra.ExactArgs(1),
-		PreRun: preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_AWS_EC2_EBS, Ec2ebsSnapshotAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_AWS_EC2_EBS, Ec2ebsSnapshotAssetType)
 	}
-	commonCmdFlags(cmd)
+	cmd := common.AwsEc2EbsSnapshotProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func awsEc2SsmProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "ssm user@host",
-		Short:  docs.GetShort("aws-ec2-ssm"),
-		Long:   docs.GetLong("aws-ec2-ssm"),
-		Args:   cobra.ExactArgs(1),
-		PreRun: preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_AWS_SSM_RUN_COMMAND, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_AWS_SSM_RUN_COMMAND, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
+	cmd := common.AwsEc2SsmProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 

--- a/apps/cnquery/cmd/builder/builder.go
+++ b/apps/cnquery/cmd/builder/builder.go
@@ -172,124 +172,66 @@ func buildCmd(baseCmd *cobra.Command, commonCmdFlags common.CommonFlagsFn, preRu
 }
 
 func localProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "local",
-		Short:  docs.GetShort("local"),
-		Long:   docs.GetLong("local"),
-		Args:   cobra.ExactArgs(0),
-		PreRun: preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_LOCAL_OS, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_LOCAL_OS, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
+	cmd := common.LocalProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func mockProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "mock PATH",
-		Short:  docs.GetShort("mock"),
-		Long:   docs.GetLong("mock"),
-		Args:   cobra.ExactArgs(1),
-		PreRun: preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Flags().Set("path", args[0])
-			runFn(cmd, args, providers.ProviderType_MOCK, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_MOCK, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
+	cmd := common.MockProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func vagrantCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "vagrant HOST",
-		Short:  docs.GetShort("vagrant"),
-		Long:   docs.GetLong("vagrant"),
-		Args:   cobra.ExactArgs(1),
-		PreRun: preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_VAGRANT, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_VAGRANT, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
+	cmd := common.VagrantCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func terraformProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "terraform PATH",
-		Short:  docs.GetShort("terraform"),
-		Long:   docs.GetLong("terraform"),
-		Args:   cobra.ExactArgs(1),
-		PreRun: preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Flags().Set("path", args[0])
-			runFn(cmd, args, providers.ProviderType_TERRAFORM, TerraformHclAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_TERRAFORM, TerraformHclAssetType)
 	}
-	commonCmdFlags(cmd)
+	cmd := common.TerraformProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func terraformProviderStateCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "state PATH",
-		Short:  "Scan a Terraform state file (json)",
-		Args:   cobra.ExactArgs(1),
-		PreRun: preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Flags().Set("path", args[0])
-			runFn(cmd, args, providers.ProviderType_TERRAFORM, TerraformStateAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_TERRAFORM, TerraformStateAssetType)
 	}
-	commonCmdFlags(cmd)
+	cmd := common.TerraformProviderStateCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func terraformProviderPlanCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "plan PATH",
-		Short:  "Scan a Terraform plan file (json)",
-		Args:   cobra.ExactArgs(1),
-		PreRun: preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Flags().Set("path", args[0])
-			runFn(cmd, args, providers.ProviderType_TERRAFORM, TerraformPlanAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_TERRAFORM, TerraformPlanAssetType)
 	}
-	commonCmdFlags(cmd)
+	cmd := common.TerraformProviderPlanCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func sshProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "ssh user@host",
-		Short:  docs.GetShort("ssh"),
-		Long:   docs.GetLong("ssh"),
-		Args:   cobra.ExactArgs(1),
-		PreRun: preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_SSH, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_SSH, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
+	cmd := common.SshProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func winrmProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "winrm user@host",
-		Short:  docs.GetShort("winrm"),
-		Long:   docs.GetLong("winrm"),
-		Args:   cobra.ExactArgs(1),
-		PreRun: preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_WINRM, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_WINRM, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
+	cmd := common.WinrmProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
@@ -420,211 +362,88 @@ func azureProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonP
 }
 
 func scanGcpCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "gcp",
-		Short: docs.GetShort("gcp"),
-		Long:  docs.GetLong("gcp"),
-		Args:  cobra.ExactArgs(0),
-		PreRun: func(cmd *cobra.Command, args []string) {
-			preRun(cmd, args)
-			viper.BindPFlag("project", cmd.Flags().Lookup("project"))
-			viper.BindPFlag("organization", cmd.Flags().Lookup("organization"))
-			viper.BindPFlag("project-id", cmd.Flags().Lookup("project-id"))
-			viper.BindPFlag("organization-id", cmd.Flags().Lookup("organization-id"))
-			viper.BindPFlag("credentials-path", cmd.Flags().Lookup("credentials-path"))
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_GCP, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_GCP, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
-	cmd.Flags().String("project", "", "specify the GCP project to scan")
-	cmd.Flags().MarkHidden("project")
-	cmd.Flags().MarkDeprecated("project", "--project is deprecated in favor of --project-id")
-	cmd.Flags().String("project-id", "", "specify the GCP project ID to scan")
-	cmd.Flags().String("organization", "", "specify the GCP organization to scan")
-	cmd.Flags().MarkHidden("organization")
-	cmd.Flags().MarkDeprecated("organization", "--organization is deprecated in favor of --organization-id")
-	cmd.Flags().String("organization-id", "", "specify the GCP organization ID to scan")
-	cmd.Flags().String("credentials-path", "", "The path to the service account credentials to access the APIs with")
+	cmd := common.ScanGcpCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func scanGcpOrgCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "org ORGANIZATION-ID",
-		Aliases: []string{"organization"},
-		Short:   docs.GetShort("gcp-org"),
-		Long:    docs.GetLong("gcp-org"),
-		Args:    cobra.ExactArgs(1),
-		PreRun: func(cmd *cobra.Command, args []string) {
-			preRun(cmd, args)
-			viper.BindPFlag("credentials-path", cmd.Flags().Lookup("credentials-path"))
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_GCP, GcpOrganizationAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_GCP, GcpOrganizationAssetType)
 	}
-	commonCmdFlags(cmd)
-	cmd.Flags().String("credentials-path", "", "The path to the service account credentials to access the APIs with")
+	cmd := common.ScanGcpOrgCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func scanGcpProjectCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "project PROJECT-ID",
-		Short: docs.GetShort("gcp-project"),
-		Long:  docs.GetLong("gcp-project"),
-		Args:  cobra.ExactArgs(1),
-		PreRun: func(cmd *cobra.Command, args []string) {
-			preRun(cmd, args)
-			viper.BindPFlag("credentials-path", cmd.Flags().Lookup("credentials-path"))
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_GCP, GcpProjectAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_GCP, GcpProjectAssetType)
 	}
-	commonCmdFlags(cmd)
-	cmd.Flags().String("credentials-path", "", "The path to the service account credentials to access the APIs with")
+
+	cmd := common.ScanGcpProjectCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func scanGcpFolderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "folder FOLDER-ID",
-		Short: docs.GetShort("gcp-folder"),
-		Long:  docs.GetLong("gcp-folder"),
-		Args:  cobra.ExactArgs(1),
-		PreRun: func(cmd *cobra.Command, args []string) {
-			preRun(cmd, args)
-			viper.BindPFlag("credentials-path", cmd.Flags().Lookup("credentials-path"))
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_GCP, GcpFolderAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_GCP, GcpFolderAssetType)
 	}
-	commonCmdFlags(cmd)
-	cmd.Flags().String("credentials-path", "", "The path to the service account credentials to access the APIs with")
+	cmd := common.ScanGcpFolderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func scanGcpGcrCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "gcr PROJECT",
-		Short: docs.GetShort("gcp-gcr"),
-		Long:  docs.GetLong("gcp-gcr"),
-		Args:  cobra.ExactArgs(1),
-		PreRun: func(cmd *cobra.Command, args []string) {
-			viper.BindPFlag("repository", cmd.Flags().Lookup("repository"))
-			preRun(cmd, args)
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_CONTAINER_REGISTRY, GcrContainerRegistryAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_CONTAINER_REGISTRY, GcrContainerRegistryAssetType)
 	}
-	commonCmdFlags(cmd)
-	cmd.Flags().String("repository", "", "specify the GCR repository to scan")
+	cmd := common.ScanGcpGcrCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func vsphereProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "vsphere user@host",
-		Short:  docs.GetShort("vsphere"),
-		Long:   docs.GetLong("vsphere"),
-		Args:   cobra.ExactArgs(1),
-		PreRun: preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_VSPHERE, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_VSPHERE, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
+	cmd := common.VsphereProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func vsphereVmProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "vm user@host",
-		Short:  docs.GetShort("vsphere-vm"),
-		Long:   docs.GetLong("vsphere-vm"),
-		Args:   cobra.ExactArgs(1),
-		PreRun: preRun,
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_VSPHERE_VM, DefaultAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_VSPHERE_VM, DefaultAssetType)
 	}
-	commonCmdFlags(cmd)
+	cmd := common.VsphereVmProviderCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func scanGithubCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "github SUBCOMMAND",
-		Short: docs.GetShort("github"),
-		Long:  docs.GetLong("github"),
-		Args:  cobra.ExactArgs(0),
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help()
-			os.Exit(0)
-		},
-	}
+	cmd := common.ScanGithubCmd(commonCmdFlags, preRun, nil, docs)
 	return cmd
 }
 
 func githubProviderOrganizationCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "org",
-		Short: docs.GetShort("github-org"),
-		Long:  docs.GetLong("github-org"),
-		Args:  cobra.ExactArgs(1),
-		PreRun: func(cmd *cobra.Command, args []string) {
-			viper.BindPFlag("token", cmd.Flags().Lookup("token"))
-			preRun(cmd, args)
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_GITHUB, GithubOrganizationAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_GITHUB, GithubOrganizationAssetType)
 	}
-	commonCmdFlags(cmd)
-	cmd.Flags().String("token", "", "GitHub personal access tokens")
+	cmd := common.GithubProviderOrganizationCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func githubProviderRepositoryCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "repo",
-		Short: docs.GetShort("github-repo"),
-		Long:  docs.GetLong("github-repo"),
-		Args:  cobra.ExactArgs(1),
-		PreRun: func(cmd *cobra.Command, args []string) {
-			viper.BindPFlag("token", cmd.Flags().Lookup("token"))
-			preRun(cmd, args)
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_GITHUB, GithubRepositoryAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_GITHUB, GithubRepositoryAssetType)
 	}
-	commonCmdFlags(cmd)
-	cmd.Flags().String("token", "", "GitHub personal access token")
+	cmd := common.GithubProviderRepositoryCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 
 func githubProviderUserCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "user",
-		Short: docs.GetShort("github-user"),
-		Long:  docs.GetLong("github-user"),
-		Args:  cobra.ExactArgs(1),
-		PreRun: func(cmd *cobra.Command, args []string) {
-			viper.BindPFlag("token", cmd.Flags().Lookup("token"))
-			preRun(cmd, args)
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			runFn(cmd, args, providers.ProviderType_GITHUB, GithubUserAssetType)
-		},
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_GITHUB, GithubUserAssetType)
 	}
-	commonCmdFlags(cmd)
-	cmd.Flags().String("token", "", "GitHub personal access token")
+	cmd := common.GithubProviderUserCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 

--- a/apps/cnquery/cmd/builder/builder.go
+++ b/apps/cnquery/cmd/builder/builder.go
@@ -100,9 +100,9 @@ func buildCmd(baseCmd *cobra.Command, commonCmdFlags common.CommonFlagsFn, preRu
 	dockerCmd.AddCommand(dockerContainerCmd)
 
 	// aws subcommand
-	amsCmd := awsProviderCmd(commonCmdFlags, preRun, runFn, docs)
+	awsCmd := awsProviderCmd(commonCmdFlags, preRun, runFn, docs)
 	awsEc2 := awsEc2ProviderCmd(commonCmdFlags, preRun, runFn, docs)
-	amsCmd.AddCommand(awsEc2)
+	awsCmd.AddCommand(awsEc2)
 
 	awsEc2Connect := awsEc2ConnectProviderCmd(commonCmdFlags, preRun, runFn, docs)
 	awsEc2.AddCommand(awsEc2Connect)
@@ -156,7 +156,7 @@ func buildCmd(baseCmd *cobra.Command, commonCmdFlags common.CommonFlagsFn, preRu
 	baseCmd.AddCommand(containerCmd)
 	baseCmd.AddCommand(dockerCmd)
 	baseCmd.AddCommand(kubernetesProviderCmd(commonCmdFlags, preRun, runFn, docs))
-	baseCmd.AddCommand(amsCmd)
+	baseCmd.AddCommand(awsCmd)
 	baseCmd.AddCommand(azureProviderCmd(commonCmdFlags, preRun, runFn, docs))
 	baseCmd.AddCommand(gcpCmd)
 	baseCmd.AddCommand(vsphereCmd)

--- a/apps/cnquery/cmd/builder/builder.go
+++ b/apps/cnquery/cmd/builder/builder.go
@@ -87,6 +87,9 @@ type CommandOpts struct {
 }
 
 func buildCmd(baseCmd *cobra.Command, commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) {
+	// REMEMBER: when adding new commands, to also add entries in the slimbuilder package so that
+	// the mondoo wrapper can also pick up the new subcommands
+
 	containerCmd := containerProviderCmd(commonCmdFlags, preRun, runFn, docs)
 	containerImageCmd := containerImageProviderCmd(commonCmdFlags, preRun, runFn, docs)
 	containerCmd.AddCommand(containerImageCmd)

--- a/apps/cnquery/cmd/builder/common/common.go
+++ b/apps/cnquery/cmd/builder/common/common.go
@@ -1,0 +1,62 @@
+package common
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type CommandsDocs struct {
+	Entries map[string]CommandDocsEntry
+}
+
+type CommandDocsEntry struct {
+	Short string
+	Long  string
+}
+
+func (c CommandsDocs) GetShort(id string) string {
+	e, ok := c.Entries[id]
+	if ok {
+		return e.Short
+	}
+	return ""
+}
+
+func (c CommandsDocs) GetLong(id string) string {
+	e, ok := c.Entries[id]
+	if ok {
+		return e.Long
+	}
+	return ""
+}
+
+type (
+	CommonFlagsFn  func(cmd *cobra.Command)
+	CommonPreRunFn func(cmd *cobra.Command, args []string)
+	RunFn          func(cmd *cobra.Command, args []string)
+)
+
+func AzureProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "azure",
+		Short: docs.GetShort("azure"),
+		Long:  docs.GetLong("azure"),
+		Args:  cobra.ExactArgs(0),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			preRun(cmd, args)
+			viper.BindPFlag("subscription", cmd.Flags().Lookup("subscription"))
+		},
+		Run: runFn,
+	}
+	commonCmdFlags(cmd)
+	cmd.Flags().String("tenant-id", "", "Directory (tenant) ID of the service principal")
+	cmd.Flags().String("client-id", "", "Application (client) ID of the service principal")
+	cmd.Flags().String("client-secret", "", "Secret for application")
+	cmd.Flags().String("certificate-path", "", "Path (in PKCS #12/PFX or PEM format) to the authentication certificate")
+	cmd.Flags().String("certificate-secret", "", "Passphrase for the authentication certificate file")
+	cmd.Flags().String("subscription", "", "ID of the Azure subscription to scan")
+	cmd.Flags().String("subscriptions", "", "Comma-separated list of Azure subscriptions to include")
+	cmd.Flags().String("subscriptions-exclude", "", "Comma-separated list of Azure subscriptions to exclude")
+
+	return cmd
+}

--- a/apps/cnquery/cmd/builder/common/common.go
+++ b/apps/cnquery/cmd/builder/common/common.go
@@ -1,8 +1,14 @@
 package common
 
 import (
+	"os"
+	"strings"
+
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	discovery_common "go.mondoo.com/cnquery/motor/discovery/common"
 )
 
 type CommandsDocs struct {
@@ -35,6 +41,251 @@ type (
 	CommonPreRunFn func(cmd *cobra.Command, args []string)
 	RunFn          func(cmd *cobra.Command, args []string)
 )
+
+var AllSubcommandFuncs = []func(CommonFlagsFn, CommonPreRunFn, RunFn, CommandsDocs) *cobra.Command{
+	ContainerProviderCmd,
+	ContainerImageProviderCmd,
+	ContainerRegistryProviderCmd,
+	DockerProviderCmd,
+	DockerContainerProviderCmd,
+	DockerImageProviderCmd,
+	KubernetesProviderCmd,
+	AwsProviderCmd,
+	AwsEc2ProviderCmd,
+	AwsEc2ConnectProviderCmd,
+	AwsEc2EbsProviderCmd,
+	AwsEc2EbsVolumeProviderCmd,
+	AwsEc2EbsSnapshotProviderCmd,
+	AwsEc2SsmProviderCmd,
+	AzureProviderCmd,
+}
+
+func ContainerProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "container ID",
+		Short:  docs.GetShort("container"),
+		Long:   docs.GetLong("container"),
+		Args:   cobra.ExactArgs(1),
+		PreRun: preRun,
+		Run:    runFn,
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func ContainerImageProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "image ID",
+		Short:  docs.GetShort("container-image"),
+		Long:   docs.GetLong("container-image"),
+		Args:   cobra.ExactArgs(1),
+		PreRun: preRun,
+		Run:    runFn,
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func ContainerRegistryProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Aliases: []string{"cr"},
+		Use:     "registry TARGET",
+		Short:   docs.GetShort("container-registry"),
+		Long:    docs.GetLong("container-registry"),
+		Args:    cobra.ExactArgs(1),
+		PreRun:  preRun,
+		Run:     runFn,
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func DockerProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "docker ID",
+		Short:  docs.GetShort("docker"),
+		Long:   docs.GetLong("docker"),
+		Args:   cobra.MaximumNArgs(1),
+		PreRun: preRun,
+		Run: func(cmd *cobra.Command, args []string) {
+			discover, err := cmd.Flags().GetString("discover")
+			if err != nil {
+				log.Error().Err(err).Msg("failed to retrieve discover flag")
+				return
+			}
+
+			// If no target is provided and the discovery flag is empty or auto, then error out since there is nothing to scan.
+			if len(args) == 0 && (len(discover) == 0 || strings.Contains(discover, discovery_common.DiscoveryAuto)) {
+				log.Error().Msg("either a target or a discovery flag different from \"auto\" must be provided for docker scans")
+				return
+			}
+
+			runFn(cmd, args)
+		},
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func DockerContainerProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "container ID",
+		Short:  docs.GetShort("docker-container"),
+		Long:   docs.GetLong("docker-container"),
+		Args:   cobra.ExactArgs(1),
+		PreRun: preRun,
+		Run:    runFn,
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func DockerImageProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "image ID",
+		Short:  docs.GetShort("docker-image"),
+		Long:   docs.GetLong("docker-image"),
+		Args:   cobra.ExactArgs(1),
+		PreRun: preRun,
+		Run:    runFn,
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func KubernetesProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "k8s (optional MANIFEST path)",
+		Aliases: []string{"kubernetes"},
+		Short:   docs.GetShort("kubernetes"),
+		Long:    docs.GetLong("kubernetes"),
+		Args:    cobra.MaximumNArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			preRun(cmd, args)
+			// FIXME: DEPRECATED, remove in v8.0 vv
+			viper.BindPFlag("namespace", cmd.Flags().Lookup("namespace"))
+			// ^^
+			viper.BindPFlag("namespaces-exclude", cmd.Flags().Lookup("namespaces-exclude"))
+			viper.BindPFlag("namespaces", cmd.Flags().Lookup("namespaces"))
+			viper.BindPFlag("context", cmd.Flags().Lookup("context"))
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) > 0 {
+				cmd.Flags().Set("path", args[0])
+			}
+			runFn(cmd, args)
+		},
+	}
+	commonCmdFlags(cmd)
+	// FIXME: DEPRECATED, remove in v8.0
+	cmd.Flags().String("namespace", "", "filter kubernetes objects by namespace")
+	cmd.Flags().MarkHidden("namespace")
+	// ^^
+
+	cmd.Flags().String("context", "", "target a Kubernetes context")
+	cmd.Flags().String("namespaces-exclude", "", "filter out Kubernetes objects in the matching namespaces")
+	cmd.Flags().String("namespaces", "", "only include Kubernetes object in the matching namespaces")
+	return cmd
+}
+
+func AwsProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "aws",
+		Short: docs.GetShort("aws"),
+		Long:  docs.GetLong("aws"),
+		Args:  cobra.ExactArgs(0),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			preRun(cmd, args)
+			viper.BindPFlag("project", cmd.Flags().Lookup("project"))
+			viper.BindPFlag("region", cmd.Flags().Lookup("region"))
+		},
+		Run: runFn,
+	}
+	commonCmdFlags(cmd)
+	cmd.Flags().String("profile", "", "pick a named AWS profile to use")
+	cmd.Flags().String("region", "", "the AWS region to scan")
+	return cmd
+}
+
+func AwsEc2ProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ec2 SUBCOMMAND",
+		Short: docs.GetShort("aws-ec2"),
+		Long:  docs.GetLong("aws-ec2"),
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+			os.Exit(0)
+		},
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func AwsEc2ConnectProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "instance-connect user@host",
+		Short:  docs.GetShort("aws-ec2-connect"),
+		Long:   docs.GetLong("aws-ec2-connect"),
+		Args:   cobra.ExactArgs(1),
+		PreRun: preRun,
+		Run:    runFn,
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func AwsEc2EbsProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "ebs INSTANCEID",
+		Short:  docs.GetShort("aws-ec2-ebs-instance"),
+		Long:   docs.GetLong("aws-ec2-ebs-instance"),
+		Args:   cobra.ExactArgs(1),
+		PreRun: preRun,
+		Run:    runFn,
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func AwsEc2EbsVolumeProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "volume VOLUMEID",
+		Short:  docs.GetShort("aws-ec2-ebs-volume"),
+		Long:   docs.GetLong("aws-ec2-ebs-volume"),
+		Args:   cobra.ExactArgs(1),
+		PreRun: preRun,
+		Run:    runFn,
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func AwsEc2EbsSnapshotProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "snapshot SNAPSHOTID",
+		Short:  docs.GetShort("aws-ec2-ebs-snapshot"),
+		Long:   docs.GetLong("aws-ec2-ebs-snapshot"),
+		Args:   cobra.ExactArgs(1),
+		PreRun: preRun,
+		Run:    runFn,
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func AwsEc2SsmProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "ssm user@host",
+		Short:  docs.GetShort("aws-ec2-ssm"),
+		Long:   docs.GetLong("aws-ec2-ssm"),
+		Args:   cobra.ExactArgs(1),
+		PreRun: preRun,
+		Run:    runFn,
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
 
 func AzureProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{

--- a/apps/cnquery/cmd/builder/common/common.go
+++ b/apps/cnquery/cmd/builder/common/common.go
@@ -596,3 +596,150 @@ func GithubProviderUserCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, 
 	cmd.Flags().String("token", "", "GitHub personal access token")
 	return cmd
 }
+
+func GitlabProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "gitlab",
+		Short: docs.GetShort("gitlab"),
+		Long:  docs.GetLong("gitlab"),
+		Args:  cobra.ExactArgs(0),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlag("token", cmd.Flags().Lookup("token"))
+			viper.BindPFlag("group", cmd.Flags().Lookup("group"))
+			preRun(cmd, args)
+		},
+		Run: runFn,
+	}
+	commonCmdFlags(cmd)
+	cmd.Flags().String("group", "", "a GitLab group to scan")
+	cmd.MarkFlagRequired("group")
+	cmd.Flags().String("token", "", "GitLab personal access token")
+	return cmd
+}
+
+func Ms365ProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "ms365",
+		Aliases: []string{"microsoft365"},
+		Short:   docs.GetShort("ms365"),
+		Long:    docs.GetLong("ms365"),
+		Args:    cobra.ExactArgs(0),
+		PreRun:  preRun,
+		Run:     runFn,
+	}
+	commonCmdFlags(cmd)
+	cmd.Flags().String("tenant-id", "", "directory (tenant) ID of the service principal")
+	cmd.Flags().String("client-id", "", "application (client) ID of the service principal")
+	cmd.Flags().String("client-secret", "", "secret for application")
+	cmd.Flags().String("certificate-path", "", "path to certificate that's used for certificate-based authentication in PKCS 12 format (pfx)")
+	cmd.Flags().String("certificate-secret", "", "passphrase for certificate file")
+	cmd.Flags().String("datareport", "", "set the MS365 datareport for the scan")
+	return cmd
+}
+
+func HostProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "host HOST",
+		Short:  docs.GetShort("host"),
+		Long:   docs.GetLong("host"),
+		Args:   cobra.ExactArgs(1),
+		PreRun: preRun,
+		Run:    runFn,
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func AristaProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "arista user@host",
+		Short:  docs.GetShort("arista"),
+		Long:   docs.GetLong("arista"),
+		Args:   cobra.ExactArgs(1),
+		PreRun: preRun,
+		Run:    runFn,
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func ScanOktaCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "okta",
+		Short: docs.GetShort("okta"),
+		Long:  docs.GetLong("okta"),
+		Args:  cobra.ExactArgs(0),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlag("organization", cmd.Flags().Lookup("organization"))
+			viper.BindPFlag("token", cmd.Flags().Lookup("token"))
+			preRun(cmd, args)
+		},
+		Run: runFn,
+	}
+	commonCmdFlags(cmd)
+	cmd.Flags().String("organization", "", "specify the Okta organization to scan")
+	cmd.Flags().String("token", "", "Okta access token")
+	return cmd
+}
+
+func ScanGoogleWorkspaceCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "google-workspace",
+		Aliases: []string{"googleworkspace"},
+		Short:   docs.GetShort("googleworkspace"),
+		Long:    docs.GetLong("googleworkspace"),
+		Args:    cobra.ExactArgs(0),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlag("customer-id", cmd.Flags().Lookup("customer-id"))
+			viper.BindPFlag("impersonated-user-email", cmd.Flags().Lookup("impersonated-user-email"))
+			viper.BindPFlag("credentials-path", cmd.Flags().Lookup("credentials-path"))
+
+			preRun(cmd, args)
+		},
+		Run: runFn,
+	}
+	commonCmdFlags(cmd)
+	cmd.Flags().String("customer-id", "", "Specify the Google Workspace customer id to scan")
+	cmd.Flags().String("impersonated-user-email", "", "The impersonated user's email with access to the Admin APIs")
+	cmd.Flags().String("credentials-path", "", "The path to the service account credentials to access the APIs with")
+
+	return cmd
+}
+
+func ScanSlackCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "slack",
+		Short: docs.GetShort("slack"),
+		Long:  docs.GetLong("slack"),
+		Args:  cobra.ExactArgs(0),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlag("token", cmd.Flags().Lookup("token"))
+			preRun(cmd, args)
+		},
+		Run: runFn,
+	}
+	commonCmdFlags(cmd)
+	cmd.Flags().String("token", "", "Slack API token")
+	return cmd
+}
+
+func ScanVcdCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "vcd",
+		Short: docs.GetShort("vcd"),
+		Long:  docs.GetLong("vcd"),
+		Args:  cobra.ExactArgs(0),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlag("user", cmd.Flags().Lookup("user"))
+			viper.BindPFlag("host", cmd.Flags().Lookup("host"))
+			viper.BindPFlag("organization", cmd.Flags().Lookup("organization"))
+			preRun(cmd, args)
+		},
+		Run: runFn,
+	}
+	commonCmdFlags(cmd)
+	cmd.Flags().String("user", "", "vCloud Director user")
+	cmd.Flags().String("host", "", "vCloud Director Host")
+	cmd.Flags().String("organization", "", "vCloud Director Organization (optional)")
+	return cmd
+}

--- a/apps/cnquery/cmd/builder/common/common.go
+++ b/apps/cnquery/cmd/builder/common/common.go
@@ -42,22 +42,118 @@ type (
 	RunFn          func(cmd *cobra.Command, args []string)
 )
 
-var AllSubcommandFuncs = []func(CommonFlagsFn, CommonPreRunFn, RunFn, CommandsDocs) *cobra.Command{
-	ContainerProviderCmd,
-	ContainerImageProviderCmd,
-	ContainerRegistryProviderCmd,
-	DockerProviderCmd,
-	DockerContainerProviderCmd,
-	DockerImageProviderCmd,
-	KubernetesProviderCmd,
-	AwsProviderCmd,
-	AwsEc2ProviderCmd,
-	AwsEc2ConnectProviderCmd,
-	AwsEc2EbsProviderCmd,
-	AwsEc2EbsVolumeProviderCmd,
-	AwsEc2EbsSnapshotProviderCmd,
-	AwsEc2SsmProviderCmd,
-	AzureProviderCmd,
+func LocalProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "local",
+		Short:  docs.GetShort("local"),
+		Long:   docs.GetLong("local"),
+		Args:   cobra.ExactArgs(0),
+		PreRun: preRun,
+		Run:    runFn,
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func MockProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "mock PATH",
+		Short:  docs.GetShort("mock"),
+		Long:   docs.GetLong("mock"),
+		Args:   cobra.ExactArgs(1),
+		PreRun: preRun,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Flags().Set("path", args[0])
+			runFn(cmd, args)
+		},
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func VagrantCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "vagrant HOST",
+		Short:  docs.GetShort("vagrant"),
+		Long:   docs.GetLong("vagrant"),
+		Args:   cobra.ExactArgs(1),
+		PreRun: preRun,
+		Run:    runFn,
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func TerraformProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "terraform PATH",
+		Short:  docs.GetShort("terraform"),
+		Long:   docs.GetLong("terraform"),
+		Args:   cobra.ExactArgs(1),
+		PreRun: preRun,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Flags().Set("path", args[0])
+			runFn(cmd, args)
+		},
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func TerraformProviderStateCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "state PATH",
+		Short:  "Scan a Terraform state file (json)",
+		Args:   cobra.ExactArgs(1),
+		PreRun: preRun,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Flags().Set("path", args[0])
+			runFn(cmd, args)
+		},
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func TerraformProviderPlanCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "plan PATH",
+		Short:  "Scan a Terraform plan file (json)",
+		Args:   cobra.ExactArgs(1),
+		PreRun: preRun,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Flags().Set("path", args[0])
+			runFn(cmd, args)
+		},
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func SshProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "ssh user@host",
+		Short:  docs.GetShort("ssh"),
+		Long:   docs.GetLong("ssh"),
+		Args:   cobra.ExactArgs(1),
+		PreRun: preRun,
+		Run:    runFn,
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func WinrmProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "winrm user@host",
+		Short:  docs.GetShort("winrm"),
+		Long:   docs.GetLong("winrm"),
+		Args:   cobra.ExactArgs(1),
+		PreRun: preRun,
+		Run:    runFn,
+	}
+	commonCmdFlags(cmd)
+	return cmd
 }
 
 func ContainerProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
@@ -309,5 +405,194 @@ func AzureProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn
 	cmd.Flags().String("subscriptions", "", "Comma-separated list of Azure subscriptions to include")
 	cmd.Flags().String("subscriptions-exclude", "", "Comma-separated list of Azure subscriptions to exclude")
 
+	return cmd
+}
+
+func ScanGcpCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "gcp",
+		Short: docs.GetShort("gcp"),
+		Long:  docs.GetLong("gcp"),
+		Args:  cobra.ExactArgs(0),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			preRun(cmd, args)
+			viper.BindPFlag("project", cmd.Flags().Lookup("project"))
+			viper.BindPFlag("organization", cmd.Flags().Lookup("organization"))
+			viper.BindPFlag("project-id", cmd.Flags().Lookup("project-id"))
+			viper.BindPFlag("organization-id", cmd.Flags().Lookup("organization-id"))
+			viper.BindPFlag("credentials-path", cmd.Flags().Lookup("credentials-path"))
+		},
+		Run: runFn,
+	}
+	commonCmdFlags(cmd)
+	cmd.Flags().String("project", "", "specify the GCP project to scan")
+	cmd.Flags().MarkHidden("project")
+	cmd.Flags().MarkDeprecated("project", "--project is deprecated in favor of --project-id")
+	cmd.Flags().String("project-id", "", "specify the GCP project ID to scan")
+	cmd.Flags().String("organization", "", "specify the GCP organization to scan")
+	cmd.Flags().MarkHidden("organization")
+	cmd.Flags().MarkDeprecated("organization", "--organization is deprecated in favor of --organization-id")
+	cmd.Flags().String("organization-id", "", "specify the GCP organization ID to scan")
+	cmd.Flags().String("credentials-path", "", "The path to the service account credentials to access the APIs with")
+	return cmd
+}
+
+func ScanGcpOrgCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "org ORGANIZATION-ID",
+		Aliases: []string{"organization"},
+		Short:   docs.GetShort("gcp-org"),
+		Long:    docs.GetLong("gcp-org"),
+		Args:    cobra.ExactArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			preRun(cmd, args)
+			viper.BindPFlag("credentials-path", cmd.Flags().Lookup("credentials-path"))
+		},
+		Run: runFn,
+	}
+	commonCmdFlags(cmd)
+	cmd.Flags().String("credentials-path", "", "The path to the service account credentials to access the APIs with")
+	return cmd
+}
+
+func ScanGcpProjectCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "project PROJECT-ID",
+		Short: docs.GetShort("gcp-project"),
+		Long:  docs.GetLong("gcp-project"),
+		Args:  cobra.ExactArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			preRun(cmd, args)
+			viper.BindPFlag("credentials-path", cmd.Flags().Lookup("credentials-path"))
+		},
+		Run: runFn,
+	}
+	commonCmdFlags(cmd)
+	cmd.Flags().String("credentials-path", "", "The path to the service account credentials to access the APIs with")
+	return cmd
+}
+
+func ScanGcpFolderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "folder FOLDER-ID",
+		Short: docs.GetShort("gcp-folder"),
+		Long:  docs.GetLong("gcp-folder"),
+		Args:  cobra.ExactArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			preRun(cmd, args)
+			viper.BindPFlag("credentials-path", cmd.Flags().Lookup("credentials-path"))
+		},
+		Run: runFn,
+	}
+	commonCmdFlags(cmd)
+	cmd.Flags().String("credentials-path", "", "The path to the service account credentials to access the APIs with")
+	return cmd
+}
+
+func ScanGcpGcrCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "gcr PROJECT",
+		Short: docs.GetShort("gcp-gcr"),
+		Long:  docs.GetLong("gcp-gcr"),
+		Args:  cobra.ExactArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlag("repository", cmd.Flags().Lookup("repository"))
+			preRun(cmd, args)
+		},
+		Run: runFn,
+	}
+	commonCmdFlags(cmd)
+	cmd.Flags().String("repository", "", "specify the GCR repository to scan")
+	return cmd
+}
+
+func VsphereProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "vsphere user@host",
+		Short:  docs.GetShort("vsphere"),
+		Long:   docs.GetLong("vsphere"),
+		Args:   cobra.ExactArgs(1),
+		PreRun: preRun,
+		Run:    runFn,
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func VsphereVmProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "vm user@host",
+		Short:  docs.GetShort("vsphere-vm"),
+		Long:   docs.GetLong("vsphere-vm"),
+		Args:   cobra.ExactArgs(1),
+		PreRun: preRun,
+		Run:    runFn,
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}
+
+func ScanGithubCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "github SUBCOMMAND",
+		Short: docs.GetShort("github"),
+		Long:  docs.GetLong("github"),
+		Args:  cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+			os.Exit(0)
+		},
+	}
+	return cmd
+}
+
+func GithubProviderOrganizationCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "org",
+		Short: docs.GetShort("github-org"),
+		Long:  docs.GetLong("github-org"),
+		Args:  cobra.ExactArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlag("token", cmd.Flags().Lookup("token"))
+			preRun(cmd, args)
+		},
+		Run: runFn,
+	}
+	commonCmdFlags(cmd)
+	cmd.Flags().String("token", "", "GitHub personal access tokens")
+	return cmd
+}
+
+func GithubProviderRepositoryCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "repo",
+		Short: docs.GetShort("github-repo"),
+		Long:  docs.GetLong("github-repo"),
+		Args:  cobra.ExactArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlag("token", cmd.Flags().Lookup("token"))
+			preRun(cmd, args)
+		},
+		Run: runFn,
+	}
+	commonCmdFlags(cmd)
+	cmd.Flags().String("token", "", "GitHub personal access token")
+	return cmd
+}
+
+func GithubProviderUserCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "user",
+		Short: docs.GetShort("github-user"),
+		Long:  docs.GetLong("github-user"),
+		Args:  cobra.ExactArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlag("token", cmd.Flags().Lookup("token"))
+			preRun(cmd, args)
+		},
+		Run: runFn,
+	}
+	commonCmdFlags(cmd)
+	cmd.Flags().String("token", "", "GitHub personal access token")
 	return cmd
 }

--- a/apps/cnquery/cmd/builder/common/common.go
+++ b/apps/cnquery/cmd/builder/common/common.go
@@ -258,9 +258,6 @@ func KubernetesProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, 
 		Args:    cobra.MaximumNArgs(1),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			preRun(cmd, args)
-			// FIXME: DEPRECATED, remove in v8.0 vv
-			viper.BindPFlag("namespace", cmd.Flags().Lookup("namespace"))
-			// ^^
 			viper.BindPFlag("namespaces-exclude", cmd.Flags().Lookup("namespaces-exclude"))
 			viper.BindPFlag("namespaces", cmd.Flags().Lookup("namespaces"))
 			viper.BindPFlag("context", cmd.Flags().Lookup("context"))
@@ -273,10 +270,6 @@ func KubernetesProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, 
 		},
 	}
 	commonCmdFlags(cmd)
-	// FIXME: DEPRECATED, remove in v8.0
-	cmd.Flags().String("namespace", "", "filter kubernetes objects by namespace")
-	cmd.Flags().MarkHidden("namespace")
-	// ^^
 
 	cmd.Flags().String("context", "", "target a Kubernetes context")
 	cmd.Flags().String("namespaces-exclude", "", "filter out Kubernetes objects in the matching namespaces")

--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/viper"
 	"go.mondoo.com/cnquery"
 	"go.mondoo.com/cnquery/apps/cnquery/cmd/builder"
+	"go.mondoo.com/cnquery/apps/cnquery/cmd/builder/common"
 	cnquery_config "go.mondoo.com/cnquery/apps/cnquery/cmd/config"
 	"go.mondoo.com/cnquery/cli/components"
 	"go.mondoo.com/cnquery/cli/config"
@@ -24,7 +25,7 @@ import (
 	"go.mondoo.com/cnquery/explorer"
 	"go.mondoo.com/cnquery/explorer/scan"
 	"go.mondoo.com/cnquery/motor/asset"
-	"go.mondoo.com/cnquery/motor/discovery/common"
+	discovery_common "go.mondoo.com/cnquery/motor/discovery/common"
 	v1 "go.mondoo.com/cnquery/motor/inventory/v1"
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/resources"
@@ -51,8 +52,8 @@ To manually configure a query pack, use this:
     $ cnquery scan local -f bundle.mql.yaml --incognito
 
 	`,
-	Docs: builder.CommandsDocs{
-		Entries: map[string]builder.CommandDocsEntry{
+	Docs: common.CommandsDocs{
+		Entries: map[string]common.CommandDocsEntry{
 			"local": {
 				Short: "Scan your local system.",
 			},
@@ -264,7 +265,7 @@ This example connects to Microsoft 365 using the PKCS #12 formatted certificate:
 
 		cmd.Flags().String("path", "", "Path to a local file or directory for the connection to use.")
 		cmd.Flags().StringToString("option", nil, "Additional connection options. You can pass multiple options using `--option key=value`.")
-		cmd.Flags().String("discover", common.DiscoveryAuto, "Enable the discovery of nested assets. Supported: 'all|auto|instances|host-instances|host-machines|container|container-images|pods|cronjobs|statefulsets|deployments|jobs|replicasets|daemonsets'")
+		cmd.Flags().String("discover", discovery_common.DiscoveryAuto, "Enable the discovery of nested assets. Supported: 'all|auto|instances|host-instances|host-machines|container|container-images|pods|cronjobs|statefulsets|deployments|jobs|replicasets|daemonsets'")
 		cmd.Flags().StringToString("discover-filter", nil, "Additional filter for asset discovery.")
 		cmd.Flags().StringToString("annotation", nil, "Add an annotation to the asset.") // user-added, editable
 

--- a/apps/cnquery/cmd/shell.go
+++ b/apps/cnquery/cmd/shell.go
@@ -8,11 +8,12 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.mondoo.com/cnquery/apps/cnquery/cmd/builder"
+	"go.mondoo.com/cnquery/apps/cnquery/cmd/builder/common"
 	cnquery_config "go.mondoo.com/cnquery/apps/cnquery/cmd/config"
 	"go.mondoo.com/cnquery/cli/components"
 	"go.mondoo.com/cnquery/cli/config"
 	"go.mondoo.com/cnquery/cli/inventoryloader"
-	"go.mondoo.com/cnquery/motor/discovery/common"
+	discovery_common "go.mondoo.com/cnquery/motor/discovery/common"
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/resources"
 	"go.mondoo.com/cnquery/upstream"
@@ -48,7 +49,7 @@ var shellCmd = builder.NewProviderCommand(builder.CommandOpts{
 
 		cmd.Flags().String("path", "", "Path to a local file or directory for the connection to use.")
 		cmd.Flags().StringToString("option", nil, "Additional connection options. You can pass multiple options using `--option key=value`.")
-		cmd.Flags().String("discover", common.DiscoveryAuto, "Enable the discovery of nested assets. Supported: 'all|auto|instances|host-instances|host-machines|container|container-images|pods|cronjobs|statefulsets|deployments|jobs|replicasets|daemonsets'")
+		cmd.Flags().String("discover", discovery_common.DiscoveryAuto, "Enable the discovery of nested assets. Supported: 'all|auto|instances|host-instances|host-machines|container|container-images|pods|cronjobs|statefulsets|deployments|jobs|replicasets|daemonsets'")
 		cmd.Flags().StringToString("discover-filter", nil, "Additional filter for asset discovery.")
 	},
 	CommonPreRun: func(cmd *cobra.Command, args []string) {
@@ -66,8 +67,8 @@ var shellCmd = builder.NewProviderCommand(builder.CommandOpts{
 		viper.BindPFlag("record", cmd.Flags().Lookup("record"))
 		viper.BindPFlag("record-file", cmd.Flags().Lookup("record-file"))
 	},
-	Docs: builder.CommandsDocs{
-		Entries: map[string]builder.CommandDocsEntry{
+	Docs: common.CommandsDocs{
+		Entries: map[string]common.CommandDocsEntry{
 			"local": {
 				Short: "Connect to your local system.",
 			},

--- a/apps/cnquery/cmd/slimbuilder/builder.go
+++ b/apps/cnquery/cmd/slimbuilder/builder.go
@@ -1,5 +1,7 @@
 package builder
 
+// FIXME: DEPRECATED, remove in v9.0 vv
+// Yes...the entire file
 import (
 	"os"
 
@@ -144,3 +146,5 @@ func buildCmd(baseCmd *cobra.Command, commonCmdFlags common.CommonFlagsFn, preRu
 	baseCmd.AddCommand(common.ScanSlackCmd(commonCmdFlags, preRun, runFn, docs))
 	baseCmd.AddCommand(common.ScanVcdCmd(commonCmdFlags, preRun, runFn, docs))
 }
+
+// ^^

--- a/apps/cnquery/cmd/slimbuilder/builder.go
+++ b/apps/cnquery/cmd/slimbuilder/builder.go
@@ -9,27 +9,6 @@ import (
 	"go.mondoo.com/cnquery/apps/cnquery/cmd/builder/common"
 )
 
-type AssetType int64
-
-const (
-	UnknownAssetType AssetType = iota
-	DefaultAssetType
-	TerraformHclAssetType
-	TerraformStateAssetType
-	TerraformPlanAssetType
-	Ec2InstanceConnectAssetType
-	Ec2ebsInstanceAssetType
-	Ec2ebsVolumeAssetType
-	Ec2ebsSnapshotAssetType
-	GcpOrganizationAssetType
-	GcpProjectAssetType
-	GcpFolderAssetType
-	GcrContainerRegistryAssetType
-	GithubOrganizationAssetType
-	GithubRepositoryAssetType
-	GithubUserAssetType
-)
-
 func NewSlimProviderCommand(opts CommandOpts) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     opts.Use,

--- a/apps/cnquery/cmd/slimbuilder/builder.go
+++ b/apps/cnquery/cmd/slimbuilder/builder.go
@@ -61,12 +61,40 @@ type CommandOpts struct {
 }
 
 func buildCmd(baseCmd *cobra.Command, commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn common.RunFn, docs common.CommandsDocs) {
+	containerCmd := common.ContainerProviderCmd(commonCmdFlags, preRun, runFn, docs)
+	containerImageCmd := common.ContainerImageProviderCmd(commonCmdFlags, preRun, runFn, docs)
+	containerCmd.AddCommand(containerImageCmd)
+	containerRegistryCmd := common.ContainerRegistryProviderCmd(commonCmdFlags, preRun, runFn, docs)
+	containerCmd.AddCommand(containerRegistryCmd)
+
+	dockerCmd := common.DockerProviderCmd(commonCmdFlags, preRun, runFn, docs)
+	dockerImageCmd := common.DockerImageProviderCmd(commonCmdFlags, preRun, runFn, docs)
+	dockerCmd.AddCommand(dockerImageCmd)
+	dockerContainerCmd := common.DockerContainerProviderCmd(commonCmdFlags, preRun, runFn, docs)
+	dockerCmd.AddCommand(dockerContainerCmd)
+
+	// aws subcommand
+	awsCmd := common.AwsProviderCmd(commonCmdFlags, preRun, runFn, docs)
+	awsEc2 := common.AwsEc2ProviderCmd(commonCmdFlags, preRun, runFn, docs)
+	awsCmd.AddCommand(awsEc2)
+
+	awsEc2Connect := common.AwsEc2ConnectProviderCmd(commonCmdFlags, preRun, runFn, docs)
+	awsEc2.AddCommand(awsEc2Connect)
+
+	awsEc2EbsCmd := common.AwsEc2EbsProviderCmd(commonCmdFlags, preRun, runFn, docs)
+	awsEc2EbsVolumeCmd := common.AwsEc2EbsVolumeProviderCmd(commonCmdFlags, preRun, runFn, docs)
+	awsEc2EbsCmd.AddCommand(awsEc2EbsVolumeCmd)
+	awsEc2EbsSnapshotCmd := common.AwsEc2EbsSnapshotProviderCmd(commonCmdFlags, preRun, runFn, docs)
+	awsEc2EbsCmd.AddCommand(awsEc2EbsSnapshotCmd)
+	awsEc2.AddCommand(awsEc2EbsCmd)
+
+	awsEc2Ssm := common.AwsEc2SsmProviderCmd(commonCmdFlags, preRun, runFn, docs)
+	awsEc2.AddCommand(awsEc2Ssm)
+
 	// subcommands
-	baseCmd.AddCommand(azureProviderCmd(commonCmdFlags, preRun, runFn, docs))
-}
-
-func azureProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn common.RunFn, docs common.CommandsDocs) *cobra.Command {
-	cmd := common.AzureProviderCmd(commonCmdFlags, preRun, runFn, docs)
-
-	return cmd
+	baseCmd.AddCommand(containerCmd)
+	baseCmd.AddCommand(dockerCmd)
+	baseCmd.AddCommand(common.KubernetesProviderCmd(commonCmdFlags, preRun, runFn, docs))
+	baseCmd.AddCommand(awsCmd)
+	baseCmd.AddCommand(common.AzureProviderCmd(commonCmdFlags, preRun, runFn, docs))
 }

--- a/apps/cnquery/cmd/slimbuilder/builder.go
+++ b/apps/cnquery/cmd/slimbuilder/builder.go
@@ -135,4 +135,12 @@ func buildCmd(baseCmd *cobra.Command, commonCmdFlags common.CommonFlagsFn, preRu
 	baseCmd.AddCommand(gcpCmd)
 	baseCmd.AddCommand(vsphereCmd)
 	baseCmd.AddCommand(githubCmd)
+	baseCmd.AddCommand(common.GitlabProviderCmd(commonCmdFlags, preRun, runFn, docs))
+	baseCmd.AddCommand(common.Ms365ProviderCmd(commonCmdFlags, preRun, runFn, docs))
+	baseCmd.AddCommand(common.HostProviderCmd(commonCmdFlags, preRun, runFn, docs))
+	baseCmd.AddCommand(common.AristaProviderCmd(commonCmdFlags, preRun, runFn, docs))
+	baseCmd.AddCommand(common.ScanOktaCmd(commonCmdFlags, preRun, runFn, docs))
+	baseCmd.AddCommand(common.ScanGoogleWorkspaceCmd(commonCmdFlags, preRun, runFn, docs))
+	baseCmd.AddCommand(common.ScanSlackCmd(commonCmdFlags, preRun, runFn, docs))
+	baseCmd.AddCommand(common.ScanVcdCmd(commonCmdFlags, preRun, runFn, docs))
 }

--- a/apps/cnquery/cmd/slimbuilder/builder.go
+++ b/apps/cnquery/cmd/slimbuilder/builder.go
@@ -91,10 +91,48 @@ func buildCmd(baseCmd *cobra.Command, commonCmdFlags common.CommonFlagsFn, preRu
 	awsEc2Ssm := common.AwsEc2SsmProviderCmd(commonCmdFlags, preRun, runFn, docs)
 	awsEc2.AddCommand(awsEc2Ssm)
 
+	// gcp subcommand
+	gcpCmd := common.ScanGcpCmd(commonCmdFlags, preRun, runFn, docs)
+	gcpGcrCmd := common.ScanGcpGcrCmd(commonCmdFlags, preRun, runFn, docs)
+	gcpCmd.AddCommand(gcpGcrCmd)
+	gcpCmd.AddCommand(common.ScanGcpOrgCmd(commonCmdFlags, preRun, runFn, docs))
+	gcpCmd.AddCommand(common.ScanGcpProjectCmd(commonCmdFlags, preRun, runFn, docs))
+	gcpCmd.AddCommand(common.ScanGcpFolderCmd(commonCmdFlags, preRun, runFn, docs))
+
+	// vsphere subcommand
+	vsphereCmd := common.VsphereProviderCmd(commonCmdFlags, preRun, runFn, docs)
+	vsphereVmCmd := common.VsphereVmProviderCmd(commonCmdFlags, preRun, runFn, docs)
+	vsphereCmd.AddCommand(vsphereVmCmd)
+
+	// github subcommand
+	githubCmd := common.ScanGithubCmd(commonCmdFlags, preRun, runFn, docs)
+	githubOrgCmd := common.GithubProviderOrganizationCmd(commonCmdFlags, preRun, runFn, docs)
+	githubCmd.AddCommand(githubOrgCmd)
+	githubRepositoryCmd := common.GithubProviderRepositoryCmd(commonCmdFlags, preRun, runFn, docs)
+	githubCmd.AddCommand(githubRepositoryCmd)
+	githubUserCmd := common.GithubProviderUserCmd(commonCmdFlags, preRun, runFn, docs)
+	githubCmd.AddCommand(githubUserCmd)
+
+	// terraform subcommand
+	terraformCmd := common.TerraformProviderCmd(commonCmdFlags, preRun, runFn, docs)
+	terraformPlanCmd := common.TerraformProviderPlanCmd(commonCmdFlags, preRun, runFn, docs)
+	terraformCmd.AddCommand(terraformPlanCmd)
+	terraformStateCmd := common.TerraformProviderStateCmd(commonCmdFlags, preRun, runFn, docs)
+	terraformCmd.AddCommand(terraformStateCmd)
+
 	// subcommands
+	baseCmd.AddCommand(common.LocalProviderCmd(commonCmdFlags, preRun, runFn, docs))
+	baseCmd.AddCommand(common.MockProviderCmd(commonCmdFlags, preRun, runFn, docs))
+	baseCmd.AddCommand(common.VagrantCmd(commonCmdFlags, preRun, runFn, docs))
+	baseCmd.AddCommand(terraformCmd)
+	baseCmd.AddCommand(common.SshProviderCmd(commonCmdFlags, preRun, runFn, docs))
+	baseCmd.AddCommand(common.WinrmProviderCmd(commonCmdFlags, preRun, runFn, docs))
 	baseCmd.AddCommand(containerCmd)
 	baseCmd.AddCommand(dockerCmd)
 	baseCmd.AddCommand(common.KubernetesProviderCmd(commonCmdFlags, preRun, runFn, docs))
 	baseCmd.AddCommand(awsCmd)
 	baseCmd.AddCommand(common.AzureProviderCmd(commonCmdFlags, preRun, runFn, docs))
+	baseCmd.AddCommand(gcpCmd)
+	baseCmd.AddCommand(vsphereCmd)
+	baseCmd.AddCommand(githubCmd)
 }

--- a/apps/cnquery/cmd/slimbuilder/builder.go
+++ b/apps/cnquery/cmd/slimbuilder/builder.go
@@ -1,0 +1,93 @@
+package builder
+
+import (
+	"os"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.mondoo.com/cnquery/apps/cnquery/cmd/builder/common"
+)
+
+type AssetType int64
+
+const (
+	UnknownAssetType AssetType = iota
+	DefaultAssetType
+	TerraformHclAssetType
+	TerraformStateAssetType
+	TerraformPlanAssetType
+	Ec2InstanceConnectAssetType
+	Ec2ebsInstanceAssetType
+	Ec2ebsVolumeAssetType
+	Ec2ebsSnapshotAssetType
+	GcpOrganizationAssetType
+	GcpProjectAssetType
+	GcpFolderAssetType
+	GcrContainerRegistryAssetType
+	GithubOrganizationAssetType
+	GithubRepositoryAssetType
+	GithubUserAssetType
+)
+
+func NewSlimProviderCommand(opts CommandOpts) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     opts.Use,
+		Aliases: opts.Aliases,
+		Short:   opts.Short,
+		Long:    opts.Long,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if opts.PreRun != nil {
+				opts.PreRun(cmd, args)
+			}
+			if opts.CommonPreRun != nil {
+				opts.CommonPreRun(cmd, args)
+			}
+		},
+		ValidArgsFunction: opts.ValidArgsFunction,
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) > 0 {
+				log.Error().Msg("provider " + args[0] + " does not exist")
+				cmd.Help()
+				os.Exit(1)
+			}
+
+			if viper.GetString("inventory-file") != "" {
+				// when the user provided an inventory file, users do not need to provide a provider
+				opts.Run(cmd, args)
+				return
+			}
+
+			log.Info().Msg("no provider specified, defaulting to local.\n  Use --help for a list of available providers.")
+			opts.Run(cmd, args)
+		},
+	}
+	opts.CommonFlags(cmd)
+	buildCmd(cmd, opts.CommonFlags, opts.CommonPreRun, opts.Run, opts.Docs)
+	return cmd
+}
+
+// CommandOpts is a helper command to create a cobra.Command
+type CommandOpts struct {
+	Use               string
+	Aliases           []string
+	Short             string
+	Long              string
+	Run               common.RunFn
+	CommonFlags       common.CommonFlagsFn
+	CommonPreRun      common.CommonPreRunFn
+	Docs              common.CommandsDocs
+	PreRun            func(cmd *cobra.Command, args []string)
+	ValidArgsFunction func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
+}
+
+func buildCmd(baseCmd *cobra.Command, commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn common.RunFn, docs common.CommandsDocs) {
+	// subcommands
+	baseCmd.AddCommand(azureProviderCmd(commonCmdFlags, preRun, runFn, docs))
+}
+
+func azureProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn common.RunFn, docs common.CommandsDocs) *cobra.Command {
+	cmd := common.AzureProviderCmd(commonCmdFlags, preRun, runFn, docs)
+
+	return cmd
+}


### PR DESCRIPTION
This should allow building a wrapper tool w/o pulling in all the real dependencies, so that the wrapper can mimmick the CLI subcommands and parameters of cnquery.

Essentially we move the functions for building the subcommands out into a separate package to allow the current cmd/builder to wrap the function that receives the ProvidersType and AssetType info around a standard cobra.Command function signature. For example:

```
func(cmd *cobra.Command, args []string) {
   callCmdBuilderFunction(cmd, args, providers/ProviderType_AZURE, defaultAssetType)
}
```

The new "slim builder" will allow building the subcommands w/o needing to pull in the `cnquery/motors/providers` package as a dependency (and avoiding all the sub-dependencies that come along with it (like azure, aws, gcp, etc...)).