### PR TITLE
Avoid sudo on self-hosted runners

### DIFF
--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -23,9 +23,14 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: "Install required tooling"
+      # We do not permit sudo on self-hosted runners
+      - name: "Ensure GCC is installed"
         run: |
-          sudo apt install -y gcc
+          if gcc --version; then 
+            echo "Good to go"; 
+          else 
+            echo "Install GCC on the runner."; 
+          fi
       - name: Check generated files
         # Note we do not use apt install -y protobuf-compiler` since it is too old
         run: |


### PR DESCRIPTION
Jobs on self hosted runners do not run in containers, they run on the host.  Allowing a workflow to install software or otherwise manipulate the system as root is a major security risk.  Instead lets just check that it's installed.  (Sadly, there isn't an 'if' expression to determine if we're on a shared or self-hosted runner, which would be ideal.)