### PR TITLE
🐛 fix remediation parsing

### DIFF
--- a/explorer/filters.go
+++ b/explorer/filters.go
@@ -139,6 +139,9 @@ func (s *Filters) RegisterChild(child *Filters) {
 	}
 }
 
+// RegisterQuery attempt to take a query (or nil) and register all its filters.
+// This includes any variants that the query might have as well. It will also
+// try to look up the base query, if requested.
 func (s *Filters) RegisterQuery(query *Mquery, lookupQueries map[string]*Mquery) error {
 	if query == nil {
 		return nil

--- a/explorer/mquery.go
+++ b/explorer/mquery.go
@@ -395,9 +395,20 @@ func (r *Remediation) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
+	if err := json.Unmarshal(data, &r.Items); err == nil {
+		return nil
+	}
+
 	// prevent recursive calls into UnmarshalJSON with a placeholder type
 	type tmp Remediation
 	return json.Unmarshal(data, (*tmp)(r))
+}
+
+func (r *Remediation) MarshalJSON() ([]byte, error) {
+	if r == nil {
+		return []byte{}, nil
+	}
+	return json.Marshal(r.Items)
 }
 
 func ChecksumFilters(queries []*Mquery) (string, error) {


### PR DESCRIPTION
it expected the `items` structure to be created in non-simple remediations, which is annoying. We intended for remediations to either be simple string or to be an array of remediation items (but without the need for an addition `items` field).