### PR TITLE
🐛 handle empty COMMAND ps column

### DIFF
--- a/resources/packs/core/processes/manager_test.go
+++ b/resources/packs/core/processes/manager_test.go
@@ -21,7 +21,7 @@ func TestManagerDebian(t *testing.T) {
 	mounts, err := mm.List()
 	require.NoError(t, err)
 
-	assert.Equal(t, 2, len(mounts))
+	assert.Equal(t, 3, len(mounts))
 }
 
 func TestManagerMacos(t *testing.T) {

--- a/resources/packs/core/processes/testdata/debian.toml
+++ b/resources/packs/core/processes/testdata/debian.toml
@@ -26,10 +26,12 @@ mode = 555
 [files."/proc/1"]
 mode = 555
 
+# PID 3987 is really a ps output where the COMMAND column is blank
 [commands."ps axo pid,pcpu,pmem,vsz,rss,tty,stat,stime,time,uid,command"]
 stdout = """  PID %CPU %MEM    VSZ   RSS TT       STAT STIME     TIME   UID COMMAND
-1  0.0  0.1  12124  3232 pts/0    Ss   07:48 00:00:00     0 /bin/bash
-46  0.0  0.0  41836  1900 pts/0    R+   10:02 00:00:00     0 ps axo pid,pcpu,pmem,vsz,rss,tty,stat,stime,time,uid,command
+    1 0.0  0.1  12124  3232  pts/0    Ss   07:48   00:00:00     0 /bin/bash
+   46 0.0  0.0  41836  1900  pts/0    R+   10:02   00:00:00     0 ps axo pid,pcpu,pmem,vsz,rss,tty,stat,stime,time,uid,command
+ 3987 0.0  0.0 147712  6080  ?        Sl   Mar10   00:00:00     0 
 """
 
 [files."/proc/1/cmdline"]

--- a/resources/packs/core/processes/unixps.go
+++ b/resources/packs/core/processes/unixps.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	LINUX_PS_REGEX = regexp.MustCompile(`^\s*([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ].*)$`)
+	LINUX_PS_REGEX = regexp.MustCompile(`^\s*([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ].*)?$`)
 	UNIX_PS_REGEX  = regexp.MustCompile(`^\s*([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ].*)$`)
 )
 
@@ -55,8 +55,7 @@ func ParseLinuxPsResult(input io.Reader) ([]*ProcessEntry, error) {
 
 		m := LINUX_PS_REGEX.FindStringSubmatch(line)
 		if len(m) != 12 {
-			log.Warn().Str("psoutput", line).Msg("unexpected result while trying to parse process output")
-			continue
+			log.Fatal().Str("psoutput", line).Msg("unexpected result while trying to parse process output")
 		}
 		if m[1] == "PID" {
 			// header
@@ -101,8 +100,7 @@ func ParseUnixPsResult(input io.Reader) ([]*ProcessEntry, error) {
 		line := scanner.Text()
 		m := UNIX_PS_REGEX.FindStringSubmatch(line)
 		if len(m) != 11 {
-			log.Warn().Str("psoutput", line).Msg("unexpected result while trying to parse process output")
-			continue
+			log.Fatal().Str("psoutput", line).Msg("unexpected result while trying to parse process output")
 		}
 		if m[1] == "PID" {
 			// header
@@ -120,7 +118,7 @@ func ParseUnixPsResult(input io.Reader) ([]*ProcessEntry, error) {
 			continue
 		}
 
-		// PID %CPU %MEM    VSZ   RSS TT       STAT  STARTED     TIME   UID COMMAND
+		// PID %CPU %MEM    VSZ   RSS TTY       STAT  TIME   UID COMMAND
 		p := &ProcessEntry{
 			Pid:     pid,
 			CPU:     m[2],

--- a/resources/packs/core/processes/unixps_test.go
+++ b/resources/packs/core/processes/unixps_test.go
@@ -21,7 +21,7 @@ func TestLinuxPSProcessParser(t *testing.T) {
 
 	m, err := processes.ParseLinuxPsResult(c.Stdout)
 	assert.Nil(t, err)
-	assert.Equal(t, 2, len(m), "detected the right amount of processes")
+	assert.Equal(t, 3, len(m), "detected the right amount of processes")
 
 	assert.Equal(t, "/bin/bash", m[0].Command, "process command detected")
 	assert.Equal(t, int64(1), m[0].Pid, "process pid detected")
@@ -30,6 +30,10 @@ func TestLinuxPSProcessParser(t *testing.T) {
 	assert.Equal(t, "ps axo pid,pcpu,pmem,vsz,rss,tty,stat,stime,time,uid,command", m[1].Command, "process command detected")
 	assert.Equal(t, int64(46), m[1].Pid, "process pid detected")
 	assert.Equal(t, int64(0), m[1].Uid, "process uid detected")
+
+	assert.Equal(t, "", m[2].Command, "process command matched against empty COMMAND column")
+	assert.Equal(t, int64(3987), m[2].Pid, "process pid detected")
+	assert.Equal(t, int64(0), m[2].Uid, "process uid detected")
 }
 
 func TestOSxPSProcessParser(t *testing.T) {


### PR DESCRIPTION
We have seen that the 'ps' output returned can have an empty field for the COMMAND column. Update the regexp to allow for the possibility of it being empty.

Extend the test case to explicitly cover this scenario.

Upgrade the checking for unexpected regexp results to a Fatal().