### PR TITLE
🐛 Fix the property merging in props cache

### DIFF
--- a/explorer/property.go
+++ b/explorer/property.go
@@ -119,18 +119,20 @@ func NewPropsCache() PropsCache {
 // Add properties, NOT overwriting existing ones (instead we add them as base)
 func (c PropsCache) Add(props ...*Property) {
 	for i := range props {
-		prop := props[i]
-		if prop.Uid != "" {
-			if base, ok := c.cache[prop.Uid]; ok {
-				prop.Merge(base)
+		base := props[i]
+		if base.Uid != "" {
+			if existingProp, ok := c.cache[base.Uid]; ok {
+				existingProp.Merge(base)
+			} else {
+				c.cache[base.Uid] = base
 			}
-			c.cache[prop.Uid] = prop
 		}
-		if prop.Mrn != "" {
-			if base, ok := c.cache[prop.Mrn]; ok {
-				prop.Merge(base)
+		if base.Mrn != "" {
+			if existingProp, ok := c.cache[base.Mrn]; ok {
+				existingProp.Merge(base)
+			} else {
+				c.cache[base.Mrn] = base
 			}
-			c.cache[prop.Mrn] = prop
 		}
 	}
 }


### PR DESCRIPTION
PropsCache seems to get filled top down. So asset policy, space policy, actual policies. This means that the bases go in last. If something is in the cache, then the thing thats being merged into it is more base than what was there