### PR TITLE
🐛 Add fallback unmarshalling for azure security contacts.

### DIFF
--- a/resources/packs/azure/azure_cloud_defender.go
+++ b/resources/packs/azure/azure_cloud_defender.go
@@ -291,10 +291,6 @@ func getSecurityContacts(ctx context.Context, subscriptionId, host, token string
 	return result, err
 }
 
-type SecurityContactsValue struct {
-	Contacts []security.Contact
-}
-
 func getPolicyAssignments(ctx context.Context, subscriptionId, host, token string) (PolicyAssignments, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policyAssignments"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))

--- a/resources/packs/azure/azure_cloud_defender.go
+++ b/resources/packs/azure/azure_cloud_defender.go
@@ -274,7 +274,25 @@ func getSecurityContacts(ctx context.Context, subscriptionId, host, token string
 	}
 	result := []security.Contact{}
 	err = json.Unmarshal(raw, &result)
+	if err != nil {
+		// fallback, try to unmarshal to ContactList
+		contactList := &security.ContactList{}
+		err = json.Unmarshal(raw, contactList)
+		if err != nil {
+			return nil, err
+		}
+		for _, c := range contactList.Value {
+			if c != nil {
+				result = append(result, *c)
+			}
+		}
+	}
+
 	return result, err
+}
+
+type SecurityContactsValue struct {
+	Contacts []security.Contact
 }
 
 func getPolicyAssignments(ctx context.Context, subscriptionId, host, token string) (PolicyAssignments, error) {


### PR DESCRIPTION
If there are no security contacts, the Microsoft API brings back the response as `ContactList` instead of `[]Contact` so unmarshalling fails. Fallback to attempt both before returning an error.
