### PR TITLE
🐛 ignore empty namespaces for k8s manifests

### DIFF
--- a/motor/providers/k8s/manifest_parser.go
+++ b/motor/providers/k8s/manifest_parser.go
@@ -68,9 +68,13 @@ func (t *manifestParser) Namespaces() ([]v1.Namespace, error) {
 		res := t.objects[i]
 		o, err := meta.Accessor(res)
 		if err == nil {
+			ns := o.GetNamespace()
+			if ns == "" {
+				continue
+			}
 			// There are types of resources that do not have meta data. Instead of erroring
 			// skip them.
-			namespaceMap[o.GetNamespace()] = struct{}{}
+			namespaceMap[ns] = struct{}{}
 		}
 	}
 


### PR DESCRIPTION
With the changes related to namespace scanning, we now use  listing namespaces in more places. That uncovered a bug in the code that lists namespaces for a manifest. If a resource in a manifest has an unspecified namespace, cnquery will return a namespace with no name. That has a different meaning if k8s. Namespace with no name means "all namespaces".

This behaviour triggers [this bug](https://github.com/mondoohq/mondoo-operator/actions/runs/4492994964/jobs/7903820410?pr=727).