### PR TITLE
🐛 change viper binding from api-proxy to api_proxy

### DIFF
--- a/apps/cnquery/cmd/root.go
+++ b/apps/cnquery/cmd/root.go
@@ -67,7 +67,7 @@ func init() {
 	rootCmd.PersistentFlags().String("api-proxy", "", "Set proxy for communications with Mondoo API")
 	viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
 	viper.BindPFlag("log-level", rootCmd.PersistentFlags().Lookup("log-level"))
-	viper.BindPFlag("api-proxy", rootCmd.PersistentFlags().Lookup("api-proxy"))
+	viper.BindPFlag("api_proxy", rootCmd.PersistentFlags().Lookup("api-proxy"))
 	viper.BindEnv("features")
 
 	config.Init(rootCmd)


### PR DESCRIPTION
this way, when the 'login' subcommand goes to save the config file, the --api-proxy that was set via CLI param just goes along for the ride and ends up in the config file.

presently it ends up in the config file as 'api-proxy' which wouldn't be picked up when reading the config file.