### PR TITLE
🐛 fix uptime parser for some new cases

### DIFF
--- a/resources/packs/os/uptime/unix.go
+++ b/resources/packs/os/uptime/unix.go
@@ -13,7 +13,7 @@ import (
 	"go.mondoo.com/cnquery/motor/providers/os"
 )
 
-var UnixUptimeRegex = regexp.MustCompile(`^.*up[\s]*(?:(\d+)\s(day[s]*|min[s]*),)*(?:\s+([\d:]+),\s)*\s*(?:(\d+)\suser[s]*,\s)*\s*load\s+average[s]*:\s+(\d+[\.,]\d+)[,\s]+(\d+[\.,]\d+)[,\s]+(\d+[\.,]\d+)\s*$`)
+var UnixUptimeRegex = regexp.MustCompile(`^.*up[\s]*(?:\s*(\d+)\s(day[s]*),)*(?:\s*(\d+)\s(min[s]*),)*(?:\s+([\d:]+),\s)*\s*(?:(\d+)\suser[s]*,\s)*\s*load\s+average[s]*:\s+(\d+[\.,]\d+)[,\s]+(\d+[\.,]\d+)[,\s]+(\d+[\.,]\d+)\s*$`)
 
 type UnixUptimeResult struct {
 	Duration           int64
@@ -23,39 +23,58 @@ type UnixUptimeResult struct {
 	LoadFifteenMinutes float64
 }
 
+func unixDuration(date, measure string) (int64, error) {
+	// calculate the time x * days / minutes + hours ( m[1]*m[2] + m[3])
+	duration, err := strconv.ParseInt(date, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	switch measure {
+	case "day":
+		fallthrough
+	case "days":
+		duration = duration * 24 * int64(time.Hour)
+	case "min":
+		fallthrough
+	case "mins":
+		duration = duration * int64(time.Minute)
+	}
+	return duration, nil
+}
+
 func ParseUnixUptime(uptime string) (*UnixUptimeResult, error) {
 	log.Debug().Str("uptime", uptime).Msg("parse")
 	m := UnixUptimeRegex.FindStringSubmatch(uptime)
 
-	if len(m) != 8 {
+	if len(m) != 10 {
 		return nil, fmt.Errorf("could not parse uptime: %s", uptime)
 	}
 
 	var duration int64
 	var err error
 
+	// parse days
 	if len(m[2]) > 0 {
-		// calculate the time x * days / minutes + hours ( m[1]*m[2] + m[3])
-		duration, err = strconv.ParseInt(m[1], 10, 64)
+		unixDuration, err := unixDuration(m[1], m[2])
 		if err != nil {
 			return nil, err
 		}
+		duration = duration + unixDuration
+	}
 
-		switch m[2] {
-		case "day":
-			fallthrough
-		case "days":
-			duration = duration * 24 * int64(time.Hour)
-		case "min":
-			fallthrough
-		case "mins":
-			duration = duration * int64(time.Minute)
+	// parse mins
+	if len(m[4]) > 0 {
+		unixDuration, err := unixDuration(m[3], m[4])
+		if err != nil {
+			return nil, err
 		}
+		duration = duration + unixDuration
 	}
 
 	// add optional hours
-	if len(m[3]) > 0 {
-		hours := strings.Split(m[3], ":")
+	if len(m[5]) > 0 {
+		hours := strings.Split(m[5], ":")
 		if len(hours) == 2 {
 			// log.Debug().Msg("parse hour")
 			hh, err := strconv.ParseInt(hours[0], 10, 64)
@@ -77,24 +96,24 @@ func ParseUnixUptime(uptime string) (*UnixUptimeResult, error) {
 
 	// users is optional and is not returned on alpine
 	users := 0
-	if len(m[4]) > 0 {
-		users, err = strconv.Atoi(m[4])
+	if len(m[6]) > 0 {
+		users, err = strconv.Atoi(m[6])
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	loadOneMinute, err := strconv.ParseFloat(strings.Replace(m[5], ",", ".", 1), 64)
+	loadOneMinute, err := strconv.ParseFloat(strings.Replace(m[7], ",", ".", 1), 64)
 	if err != nil {
 		return nil, err
 	}
 
-	loadFiveMinutes, err := strconv.ParseFloat(strings.Replace(m[6], ",", ".", 1), 64)
+	loadFiveMinutes, err := strconv.ParseFloat(strings.Replace(m[8], ",", ".", 1), 64)
 	if err != nil {
 		return nil, err
 	}
 
-	loadFifteenMinutes, err := strconv.ParseFloat(strings.Replace(m[7], ",", ".", 1), 64)
+	loadFifteenMinutes, err := strconv.ParseFloat(strings.Replace(m[9], ",", ".", 1), 64)
 	if err != nil {
 		return nil, err
 	}

--- a/resources/packs/os/uptime/unix_test.go
+++ b/resources/packs/os/uptime/unix_test.go
@@ -147,6 +147,18 @@ func TestMacOSUptime(t *testing.T) {
 		LoadFifteenMinutes: float64(3.72),
 	}, duration)
 	assert.Equal(t, "38m0s", time.Duration(duration.Duration).String())
+
+	data = "13:16  up 8 days, 13 mins, 6 users, load averages: 2.56 2.68 2.91"
+	duration, err = uptime.ParseUnixUptime(data)
+	assert.Nil(t, err)
+	assert.Equal(t, &uptime.UnixUptimeResult{
+		Duration:           691980000000000,
+		Users:              6,
+		LoadOneMinute:      float64(2.56),
+		LoadFiveMinutes:    float64(2.68),
+		LoadFifteenMinutes: float64(2.91),
+	}, duration)
+	assert.Equal(t, "192h13m0s", time.Duration(duration.Duration).String())
 }
 
 func TestFreebsdUptime(t *testing.T) {


### PR DESCRIPTION
During testing I discovered case with update that has not happened before. I added a new test case and adjusted the parser to handle the case where both days and mins are included in the output.