### PR TITLE
🐛 ensure uids are also generated when BundleFromYaml is used

### DIFF
--- a/explorer/bundle.go
+++ b/explorer/bundle.go
@@ -109,9 +109,6 @@ func aggregateFilesToBundle(paths []string) (*Bundle, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "could not load file: "+path)
 		}
-
-		bundle.EnsureUIDs()
-
 		combineBundles(mergedBundle, bundle)
 	}
 
@@ -143,6 +140,7 @@ func bundleFromSingleFile(path string) (*Bundle, error) {
 func BundleFromYAML(data []byte) (*Bundle, error) {
 	var res Bundle
 	err := yaml.Unmarshal(data, &res)
+	res.EnsureUIDs()
 	return &res, err
 }
 

--- a/explorer/bundle_test.go
+++ b/explorer/bundle_test.go
@@ -1,0 +1,33 @@
+package explorer
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBundleLoad(t *testing.T) {
+	t.Run("load bundle from file", func(t *testing.T) {
+		bundle, err := BundleFromPaths("../examples/os.mql.yaml")
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(bundle.Packs))
+		assert.Equal(t, 3, len(bundle.Packs[0].Queries))
+
+		// ensure that the uid is generated
+		assert.True(t, len(bundle.Packs[0].Queries[0].Uid) > 0)
+	})
+
+	t.Run("load bundle from memory", func(t *testing.T) {
+		data, err := os.ReadFile("../examples/os.mql.yaml")
+		require.NoError(t, err)
+		bundle, err := BundleFromYAML(data)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(bundle.Packs))
+		assert.Equal(t, 3, len(bundle.Packs[0].Queries))
+
+		// ensure that the uid is generated
+		assert.True(t, len(bundle.Packs[0].Queries[0].Uid) > 0)
+	})
+}


### PR DESCRIPTION
we forgot to ensure that we need to create uids for embedded queries when bundles are loaded from memory