### PR TITLE
⭐️ allow filtering of query packs by short mrns

### DIFF
--- a/explorer/query_hub.go
+++ b/explorer/query_hub.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path"
+
+	"go.mondoo.com/cnquery/mrn"
 
 	"go.mondoo.com/ranger-rpc"
 
@@ -13,9 +16,22 @@ import (
 	"go.opentelemetry.io/otel"
 )
 
-const defaultRegistryUrl = "https://registry.api.mondoo.com"
+const (
+	defaultRegistryUrl     = "https://registry.api.mondoo.com"
+	RegistryServiceName    = "registry.mondoo.com"
+	CollectionIDNamespace  = "namespace"
+	CollectionIDQueryPacks = "querypacks"
+)
 
 var tracer = otel.Tracer("go.mondoo.com/cnquery/explorer")
+
+func NewQueryPackMrn(namespace string, uid string) string {
+	m := &mrn.MRN{
+		ServiceName:          RegistryServiceName,
+		RelativeResourceName: path.Join(CollectionIDNamespace, namespace, CollectionIDQueryPacks, uid),
+	}
+	return m.String()
+}
 
 // ValidateBundle and check queries, relationships, MRNs, and versions
 func (s *LocalServices) ValidateBundle(ctx context.Context, bundle *Bundle) (*Empty, error) {

--- a/explorer/query_hub_test.go
+++ b/explorer/query_hub_test.go
@@ -1,0 +1,19 @@
+package explorer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueryPackMrn(t *testing.T) {
+	// given
+	namespace := "test-namespace"
+	uid := "test-uid"
+
+	// when
+	mrn := NewQueryPackMrn(namespace, uid)
+
+	// then
+	assert.Equal(t, "//registry.mondoo.com/namespace/test-namespace/querypacks/test-uid", mrn)
+}

--- a/explorer/scan/local_scanner_test.go
+++ b/explorer/scan/local_scanner_test.go
@@ -1,0 +1,26 @@
+package scan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterPreprocess(t *testing.T) {
+	// given
+	filters := []string{
+		"namespace1/pack1",
+		"namespace2/pack2",
+		"//registry.mondoo.com/namespace/namespace3/querypacks/pack3",
+	}
+
+	// when
+	preprocessed := preprocessQueryPackFilters(filters)
+
+	// then
+	assert.Equal(t, []string{
+		"//registry.mondoo.com/namespace/namespace1/querypacks/pack1",
+		"//registry.mondoo.com/namespace/namespace2/querypacks/pack2",
+		"//registry.mondoo.com/namespace/namespace3/querypacks/pack3",
+	}, preprocessed)
+}


### PR DESCRIPTION
This change adds support to filter the query packs available in https://mondoo.com/registry by short mrns:

```
cnquery scan okta --organization dev-12345.okta.com --token $OKTA_TOKEN --querypack mondoohq/mondoo-okta-incident-response
```