### PR TITLE
Add support for Eurolinux 7/8/9

### DIFF
--- a/motor/platform/detector/detector_test.go
+++ b/motor/platform/detector/detector_test.go
@@ -253,6 +253,45 @@ func TestRockyLinux9OSDetector(t *testing.T) {
 	assert.Equal(t, []string{"redhat", "linux", "unix", "os"}, di.Family)
 }
 
+func TestEuroLinux7OSDetector(t *testing.T) {
+	detector, err := newDetector("./testdata/detect-eurolinux-7.toml")
+	assert.Nil(t, err, "was able to create the transport")
+	di, err := detector.Platform()
+	require.NoError(t, err)
+
+	assert.Equal(t, "eurolinux", di.Name, "os name should be identified")
+	assert.Equal(t, "EuroLinux 7.9 (Minsk)", di.Title, "os title should be identified")
+	assert.Equal(t, "7.9", di.Version, "os version should be identified")
+	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"redhat", "linux", "unix", "os"}, di.Family)
+}
+
+func TestEuroLinux8OSDetector(t *testing.T) {
+	detector, err := newDetector("./testdata/detect-eurolinux-8.toml")
+	assert.Nil(t, err, "was able to create the transport")
+	di, err := detector.Platform()
+	require.NoError(t, err)
+
+	assert.Equal(t, "eurolinux", di.Name, "os name should be identified")
+	assert.Equal(t, "EuroLinux 8.7 (Brussels)", di.Title, "os title should be identified")
+	assert.Equal(t, "8.7", di.Version, "os version should be identified")
+	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"redhat", "linux", "unix", "os"}, di.Family)
+}
+
+func TestEuroLinux9OSDetector(t *testing.T) {
+	detector, err := newDetector("./testdata/detect-eurolinux-9.toml")
+	assert.Nil(t, err, "was able to create the transport")
+	di, err := detector.Platform()
+	require.NoError(t, err)
+
+	assert.Equal(t, "eurolinux", di.Name, "os name should be identified")
+	assert.Equal(t, "EuroLinux 9.1 (Stockholm)", di.Title, "os title should be identified")
+	assert.Equal(t, "9.1", di.Version, "os version should be identified")
+	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"redhat", "linux", "unix", "os"}, di.Family)
+}
+
 func TestUbuntu1204Detector(t *testing.T) {
 	detector, err := newDetector("./testdata/detect-ubuntu1204.toml")
 	assert.Nil(t, err, "was able to create the transport")

--- a/motor/platform/detector/platform_specs.go
+++ b/motor/platform/detector/platform_specs.go
@@ -243,7 +243,18 @@ var rhel = &PlatformResolver{
 	},
 }
 
-// The centos platform resolver finds CentOS and CentOS-like platforms alike alma and rocky
+var eurolinux = &PlatformResolver{
+	Name:     "eurolinux",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
+		if pf.Name == "eurolinux" {
+			return true, nil
+		}
+		return false, nil
+	},
+}
+
+// The centos platform resolver finds CentOS and CentOS-like platforms like alma and rocky
 var centos = &PlatformResolver{
 	Name:     "centos",
 	IsFamily: false,
@@ -787,7 +798,7 @@ var redhatFamily = &PlatformResolver{
 	IsFamily: true,
 	// NOTE: oracle pretends to be redhat with /etc/redhat-release and Red Hat Linux, therefore we
 	// want to check that platform before redhat
-	Children: []*PlatformResolver{oracle, rhel, centos, fedora, scientific},
+	Children: []*PlatformResolver{oracle, rhel, centos, fedora, scientific, eurolinux},
 	Detect: func(r *PlatformResolver, pf *platform.Platform, p os.OperatingSystemProvider) (bool, error) {
 		f, err := p.FS().Open("/etc/redhat-release")
 		if err != nil {

--- a/motor/platform/detector/testdata/detect-eurolinux-7.toml
+++ b/motor/platform/detector/testdata/detect-eurolinux-7.toml
@@ -1,0 +1,27 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[files."/etc/redhat-release"]
+content = "EuroLinux release 7.9 (Minsk)"
+
+[files."/etc/os-release"]
+content = """
+NAME="EuroLinux"
+VERSION="7.9 (Minsk)"
+ID="eurolinux"
+ID_LIKE="rhel scientific centos fedora"
+VERSION_ID="7.9"
+PRETTY_NAME="EuroLinux 7.9 (Minsk)"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:eurolinux:eurolinux:7.9:GA"
+HOME_URL="http://www.euro-linux.com/"
+BUG_REPORT_URL="mailto:euro@euro-linux.com"
+
+REDHAT_BUGZILLA_PRODUCT="EuroLinux 7"
+REDHAT_BUGZILLA_PRODUCT_VERSION=7.9
+REDHAT_SUPPORT_PRODUCT="EuroLinux"
+REDHAT_SUPPORT_PRODUCT_VERSION="7.9"
+"""

--- a/motor/platform/detector/testdata/detect-eurolinux-8.toml
+++ b/motor/platform/detector/testdata/detect-eurolinux-8.toml
@@ -1,0 +1,26 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[files."/etc/redhat-release"]
+content = "EuroLinux release 8.7 (Brussels)"
+
+[files."/etc/os-release"]
+content = """
+NAME="EuroLinux"
+VERSION="8.7 (Brussels)"
+ID="eurolinux"
+ID_LIKE="rhel fedora centos"
+VERSION_ID="8.7"
+PLATFORM_ID="platform:el8"
+PRETTY_NAME="EuroLinux 8.7 (Brussels)"
+ANSI_COLOR="0;34"
+CPE_NAME="cpe:/o:eurolinux:eurolinux:8"
+HOME_URL="https://www.euro-linux.com/"
+DOCUMENTATION_URL="https://docs.euro-linux.com/"
+BUG_REPORT_URL="https://github.com/EuroLinux/eurolinux-distro-bugs-and-rfc/"
+REDHAT_SUPPORT_PRODUCT="EuroLinux"
+REDHAT_SUPPORT_PRODUCT_VERSION="8"
+"""

--- a/motor/platform/detector/testdata/detect-eurolinux-9.toml
+++ b/motor/platform/detector/testdata/detect-eurolinux-9.toml
@@ -1,0 +1,27 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[files."/etc/redhat-release"]
+content = "EuroLinux release 9.1 (Stockholm)"
+
+[files."/etc/os-release"]
+content = """
+NAME="EuroLinux"
+VERSION="9.1 (Stockholm)"
+ID="eurolinux"
+ID_LIKE="rhel fedora centos"
+VERSION_ID="9.1"
+PLATFORM_ID="platform:el9"
+PRETTY_NAME="EuroLinux 9.1 (Stockholm)"
+ANSI_COLOR="0;34"
+LOGO="fedora-logo-icon"
+CPE_NAME="cpe:/o:eurolinux:eurolinux:9"
+HOME_URL="https://www.euro-linux.com/"
+DOCUMENTATION_URL="https://docs.euro-linux.com"
+BUG_REPORT_URL="https://github.com/EuroLinux/eurolinux-distro-bugs-and-rfc/"
+REDHAT_SUPPORT_PRODUCT="EuroLinux"
+REDHAT_SUPPORT_PRODUCT_VERSION="9"
+"""


### PR DESCRIPTION
This is another RHEL-deriv

cnquery> platform { name version family }
platform: {
  name: "eurolinux"
  family: [
    0: "redhat"
    1: "linux"
    2: "unix"
    3: "os"
  ]
  version: "9.1"
}