### PR TITLE
🐛 fix kubelet resource panic

### DIFF
--- a/resources/packs/k8s/kubelet_flags.go
+++ b/resources/packs/k8s/kubelet_flags.go
@@ -49,7 +49,11 @@ func mergeFlagsIntoConfig(kubeletConfig map[string]interface{}, flags map[string
 		nodeLabels := map[string]string{}
 		for _, label := range strings.Split(flags["node-labels"].(string), ",") {
 			labelSplit := strings.Split(label, "=")
-			nodeLabels[labelSplit[0]] = labelSplit[1]
+			labelVal := ""
+			if len(labelSplit) > 1 {
+				labelVal = labelSplit[1]
+			}
+			nodeLabels[labelSplit[0]] = labelVal
 		}
 		data, err := core.JsonToDict(nodeLabels)
 		if err != nil {


### PR DESCRIPTION
Scanning a RHCOS node, results in a panic:
```
panic: runtime error: index out of range [1] with length 1

goroutine 71 [running]:
go.mondoo.com/cnquery/resources/packs/k8s.mergeFlagsIntoConfig(0x96eb580?, 0xc0010d7600?)
	/home/runner/go/pkg/mod/go.mondoo.com/cnquery@v0.0.0-20230412152832-be51e3344dfa/resources/packs/k8s/kubelet_flags.go:52 +0x33b
go.mondoo.com/cnquery/resources/packs/k8s.(*mqlK8sKubelet).createConfiguration(0x8955080?, 0xc0028b4600?, {0xc002892189, 0x1c}, {0x7f1a356421d0, 0xc0016c40a0}, 0x1)
	/home/runner/go/pkg/mod/go.mondoo.com/cnquery@v0.0.0-20230412152832-be51e3344dfa/resources/packs/k8s/kubelet.go:112 +0x205
go.mondoo.com/cnquery/resources/packs/k8s.(*mqlK8sKubelet).init(0xc00014c130, 0xc00014c120)
	/home/runner/go/pkg/mod/go.mondoo.com/cnquery@v0.0.0-20230412152832-be51e3344dfa/resources/packs/k8s/kubelet.go:75 +0x43f
go.mondoo.com/cnquery/resources/packs/k8s.newK8sKubelet(0xc00175fa80, 0x0?)
	/home/runner/go/pkg/mod/go.mondoo.com/cnquery@v0.0.0-20230412152832-be51e3344dfa/resources/packs/k8s/k8s.lr.go:1953 +0xcf
go.mondoo.com/cnquery/resources.(*Runtime).CreateResourceWithID(0xc00175fa80, {0xc00245f980?, 0x0?}, {0x0, 0x0}, {0xf2dfdc8, 0x0, 0x0})
	/home/runner/go/pkg/mod/go.mondoo.com/cnquery@v0.0.0-20230412152832-be51e3344dfa/resources/runtime.go:194 +0x34c
go.mondoo.com/cnquery/resources.(*Runtime).CreateResource(...)
	/home/runner/go/pkg/mod/go.mondoo.com/cnquery@v0.0.0-20230412152832-be51e3344dfa/resources/runtime.go:225
go.mondoo.com/cnquery/llx.(*blockExecutor).createResource(0xc0007ed5e0, {0xc00245f980, 0xb}, 0xb?, 0xc00288e0c8?, 0x5fd1f20?)
	/home/runner/go/pkg/mod/go.mondoo.com/cnquery@v0.0.0-20230412152832-be51e3344dfa/llx/llx.go:679 +0x12c
go.mondoo.com/cnquery/llx.(*blockExecutor).runGlobalFunction(0xc0007ed5e0, 0xc00290eb40, 0xf122a00, 0xa?)
	/home/runner/go/pkg/mod/go.mondoo.com/cnquery@v0.0.0-20230412152832-be51e3344dfa/llx/llx.go:724 +0x2af
go.mondoo.com/cnquery/llx.(*blockExecutor).runFunction(0xc0007ed5e0?, 0xc00290eb90?, 0x0?)
	/home/runner/go/pkg/mod/go.mondoo.com/cnquery@v0.0.0-20230412152832-be51e3344dfa/llx/llx.go:750 +0xfd
go.mondoo.com/cnquery/llx.(*blockExecutor).runChunk(0xc0007ed5e0, 0x5fd20ee?, 0x100000001?)
	/home/runner/go/pkg/mod/go.mondoo.com/cnquery@v0.0.0-20230412152832-be51e3344dfa/llx/llx.go:781 +0x25e
go.mondoo.com/cnquery/llx.(*blockExecutor).runRef(0xc0028b60e0?, 0x8aab460?)
	/home/runner/go/pkg/mod/go.mondoo.com/cnquery@v0.0.0-20230412152832-be51e3344dfa/llx/llx.go:806 +0xef
go.mondoo.com/cnquery/llx.(*blockExecutor).runChain(0xc0007ed5e0, 0x971ce94?)
	/home/runner/go/pkg/mod/go.mondoo.com/cnquery@v0.0.0-20230412152832-be51e3344dfa/llx/llx.go:838 +0xa6
go.mondoo.com/cnquery/llx.(*blockExecutor).run(0xc0007ed5e0)
	/home/runner/go/pkg/mod/go.mondoo.com/cnquery@v0.0.0-20230412152832-be51e3344dfa/llx/llx.go:351 +0x2d7
go.mondoo.com/cnquery/llx.(*MQLExecutorV2).Run(0xc0029108a0?)
	/home/runner/go/pkg/mod/go.mondoo.com/cnquery@v0.0.0-20230412152832-be51e3344dfa/llx/llx.go:283 +0x59
go.mondoo.com/cnspec/policy/executor/internal.(*executionManager).executeCodeBundle(0xc002962230, 0xc00290c280, 0x0?, {0x0, 0x0})
	/home/runner/_work/cnspec/cnspec/policy/executor/internal/execution_manager.go:164 +0x357
go.mondoo.com/cnspec/policy/executor/internal.(*executionManager).Start.func1()
	/home/runner/_work/cnspec/cnspec/policy/executor/internal/execution_manager.go:85 +0x1cb
created by go.mondoo.com/cnspec/policy/executor/internal.(*executionManager).Start
	/home/runner/_work/cnspec/cnspec/policy/executor/internal/execution_manager.go:54 +0x6a
```

It seems like there is some label in the form of `labelName=`, which causes the code to panic. I added a check to make sure we don't try to access the value of the label if such isn't set