### PR TITLE
🐛 pass in type for azure.subscription.network.ipAddress resource.

### DIFF
--- a/resources/packs/azure/azure_rm_compute.go
+++ b/resources/packs/azure/azure_rm_compute.go
@@ -196,6 +196,7 @@ func (a *mqlAzureSubscriptionComputeServiceVm) GetPublicIpAddresses() ([]interfa
 					"location", core.ToString(ipAddress.Location),
 					"tags", azureTagsToInterface(ipAddress.Tags),
 					"ipAddress", core.ToString(ipAddress.Properties.IPAddress),
+					"type", core.ToString(ipAddress.Type),
 				)
 				if err != nil {
 					return nil, err

--- a/resources/packs/azure/azure_rm_network.go
+++ b/resources/packs/azure/azure_rm_network.go
@@ -106,6 +106,7 @@ func (a *mqlAzureSubscriptionNetworkService) GetPublicIpAddresses() ([]interface
 					"location", core.ToString(ip.Location),
 					"tags", azureTagsToInterface(ip.Tags),
 					"ipAddress", core.ToString(ip.Properties.IPAddress),
+					"type", core.ToString(ip.Type),
 				)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
Somehow this was never being set. Not sure how it ever (if) worked.