### PR TITLE
Specify PEM format is supported for ms365 connections, extend example cmds

### DIFF
--- a/apps/cnquery/cmd/builder/common/common.go
+++ b/apps/cnquery/cmd/builder/common/common.go
@@ -638,7 +638,7 @@ func Ms365ProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn
 	cmd.Flags().String("tenant-id", "", "directory (tenant) ID of the service principal")
 	cmd.Flags().String("client-id", "", "application (client) ID of the service principal")
 	cmd.Flags().String("client-secret", "", "secret for application")
-	cmd.Flags().String("certificate-path", "", "path to certificate that's used for certificate-based authentication in PKCS 12 format (pfx)")
+	cmd.Flags().String("certificate-path", "", "Path (in PKCS #12/PFX or PEM format) to the authentication certificate")
 	cmd.Flags().String("certificate-secret", "", "passphrase for certificate file")
 	cmd.Flags().String("datareport", "", "set the MS365 datareport for the scan")
 	return cmd

--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -231,6 +231,11 @@ This example connects to Microsoft 365 using the PKCS #12 formatted certificate:
 
     $ cnquery scan ms365 --tenant-id {tenant id} --client-id {client id} --certificate-path {certificate.pfx} --certificate-secret {certificate secret}
     $ cnquery scan ms365 --tenant-id {tenant id} --client-id {client id} --certificate-path {certificate.pfx} --ask-pass
+
+This example connects to Microsoft 365 using the PEM formatted certificate:
+
+    $ cnquery scan ms365 --tenant-id {tenant id} --client-id {client id} --certificate-path {certificate.pem} --certificate-secret {certificate secret}
+    $ cnquery scan ms365 --tenant-id {tenant id} --client-id {client id} --certificate-path {certificate.pem} --ask-pass
 `,
 			},
 			"host": {


### PR DESCRIPTION
Fixes #1111