### PR TITLE
Mark client-id and tenant-id as required flags when scanning ms365.

### DIFF
--- a/apps/cnquery/cmd/builder/common/common.go
+++ b/apps/cnquery/cmd/builder/common/common.go
@@ -636,7 +636,9 @@ func Ms365ProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn
 	}
 	commonCmdFlags(cmd)
 	cmd.Flags().String("tenant-id", "", "directory (tenant) ID of the service principal")
+	cmd.MarkFlagRequired("tenant-id")
 	cmd.Flags().String("client-id", "", "application (client) ID of the service principal")
+	cmd.MarkFlagRequired("client-id")
 	cmd.Flags().String("client-secret", "", "secret for application")
 	cmd.Flags().String("certificate-path", "", "path to certificate that's used for certificate-based authentication in PKCS 12 format (pfx)")
 	cmd.Flags().String("certificate-secret", "", "passphrase for certificate file")

--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -566,12 +566,16 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 		}
 		// ^^
 
-		if tenantId, err := cmd.Flags().GetString("tenant-id"); err == nil {
-			connection.Options["tenant-id"] = tenantId
+		tenantId, err := cmd.Flags().GetString("tenant-id")
+		if err != nil {
+			log.Fatal().Err(err).Msg("cannot parse --tenant-id value")
 		}
-		if clientID, err := cmd.Flags().GetString("client-id"); err == nil {
-			connection.Options["client-id"] = clientID
+		clientId, err := cmd.Flags().GetString("client-id")
+		if err != nil {
+			log.Fatal().Err(err).Msg("cannot parse --client-id value")
 		}
+		connection.Options["client-id"] = clientId
+		connection.Options["tenant-id"] = tenantId
 
 		if clientSecret, err := cmd.Flags().GetString("client-secret"); err != nil {
 			log.Fatal().Err(err).Msg("cannot parse --client-secret value")


### PR DESCRIPTION
Fixes #1112 

![image](https://user-images.githubusercontent.com/11717082/233033253-3dd3fb1d-8afb-4187-9241-e30250ebf8b7.png)
