### PR TITLE
🧹 Test provided cert/pass when creating an ms365 connection.

### DIFF
--- a/motor/discovery/ms365/resolver.go
+++ b/motor/discovery/ms365/resolver.go
@@ -43,6 +43,12 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, cc *providers
 		return nil, err
 	}
 
+	// try getting a token, this wil err out if the pem/pfx file are wrong or if the password
+	// is wrong. allows for returning an err early
+	_, err = provider.GetTokenCredential()
+	if err != nil {
+		return nil, err
+	}
 	// detect platform info for the asset
 	pf, err := m.Platform()
 	if err != nil {

--- a/motor/providers/microsoft/auth.go
+++ b/motor/providers/microsoft/auth.go
@@ -1,6 +1,8 @@
 package microsoft
 
 import (
+	"fmt"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/cockroachdb/errors"
@@ -25,17 +27,16 @@ func (p *Provider) GetTokenCredential() (azcore.TokenCredential, error) {
 		case vault.CredentialType_pkcs12:
 			certs, privateKey, err := azidentity.ParseCertificates(p.cred.Secret, []byte(p.cred.Password))
 			if err != nil {
-				return nil, errors.Wrap(err, "could not parse provided certificate")
+				return nil, errors.Wrap(err, fmt.Sprintf("could not parse provided certificate at %s", p.cred.PrivateKeyPath))
 			}
-
 			credential, err = azidentity.NewClientCertificateCredential(p.tenantID, p.clientID, certs, privateKey, &azidentity.ClientCertificateCredentialOptions{})
 			if err != nil {
-				return nil, errors.Wrap(err, "error creating credentials")
+				return nil, errors.Wrap(err, "error creating credentials from a certificate")
 			}
 		case vault.CredentialType_password:
 			credential, err = azidentity.NewClientSecretCredential(p.tenantID, p.clientID, string(p.cred.Secret), &azidentity.ClientSecretCredentialOptions{})
 			if err != nil {
-				return nil, errors.Wrap(err, "error creating credentials")
+				return nil, errors.Wrap(err, "error creating credentials from a secret")
 			}
 		default:
 			return nil, errors.New("invalid secret configuration for microsoft transport: " + p.cred.Type.String())

--- a/motor/providers/microsoft/auth.go
+++ b/motor/providers/microsoft/auth.go
@@ -25,7 +25,7 @@ func (p *Provider) GetTokenCredential() (azcore.TokenCredential, error) {
 		case vault.CredentialType_pkcs12:
 			certs, privateKey, err := azidentity.ParseCertificates(p.cred.Secret, []byte(p.cred.Password))
 			if err != nil {
-				return nil, errors.Wrap(err, "could not parse certificate")
+				return nil, errors.Wrap(err, "could not parse provided certificate")
 			}
 
 			credential, err = azidentity.NewClientCertificateCredential(p.tenantID, p.clientID, certs, privateKey, &azidentity.ClientCertificateCredentialOptions{})


### PR DESCRIPTION
Fixes #1113 

![image](https://user-images.githubusercontent.com/11717082/235607919-6df19c56-fd39-4224-88a6-d537d731b4b1.png)

```
~/go/bin/cnquery shell ms365 --certificate-path ~/cert-no-pk.pem --client-id xxxxxxx --tenant-id xxxxxxxx
→ loaded configuration from /Users/preslavgerchev/.config/mondoo/mondoo.yml using source default
→ discover related assets for 1 asset(s)
→ resolved assets resolved-assets=0
x could not connect to asset error="could not parse provided certificate at /Users/preslavgerchev/azure-cert.pem: found no private key" asset=
FTL could not resolve assets
```
