### PR TITLE
🧹 make status err reporting clearer

### DIFF
--- a/apps/cnquery/cmd/status.go
+++ b/apps/cnquery/cmd/status.go
@@ -190,7 +190,9 @@ func (s Status) RenderCliStatus() {
 	if s.Client.Registered && s.Client.PingPongError == nil {
 		log.Info().Msg(theme.DefaultTheme.Success("client authenticated successfully"))
 	} else {
-		log.Error().Err(s.Client.PingPongError).Msg("could not connect to Mondoo Platform")
+		log.Error().Err(s.Client.PingPongError).
+			Msgf("The Mondoo Platform credentials provided at %s didn't successfully authenticate with Mondoo Platform. Please re-authenticate with Mondoo Platform. To learn how, read https://mondoo.com/docs/cnspec/cnspec-adv-install/registration.",
+				viper.ConfigFileUsed())
 	}
 
 	for i := range s.Upstream.Warnings {

--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/segmentio/ksuid"
+	"github.com/spf13/viper"
 	"go.mondoo.com/cnquery"
 	"go.mondoo.com/cnquery/cli/progress"
 	"go.mondoo.com/cnquery/explorer"
@@ -94,6 +95,11 @@ func (s *LocalScanner) Run(ctx context.Context, job *Job) (*explorer.ReportColle
 
 	reports, _, err := s.distributeJob(job, dctx, upstreamConfig)
 	if err != nil {
+		if code := status.Code(err); code == codes.Unauthenticated {
+			return nil, errors.Wrapf(err,
+				"The Mondoo Platform credentials provided at %s didn't successfully authenticate with Mondoo Platform. Please re-authenticate with Mondoo Platform. To learn how, read https://mondoo.com/docs/cnspec/cnspec-adv-install/registration.",
+				viper.ConfigFileUsed())
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Related to mondoohq/cnspec#365

```
→ loaded configuration from /Users/ivanmilchev/Downloads/temp.json using source --config
→ Platform:     macos
→ Version:      13.3.1
→ Hostname:     Ivan-Milchev.local
→ IP:           192.168.2.4
→ Time:         2023-04-24T12:44:02+02:00
→ Version:      v8.6.0 (API Version: unstable)
→ API ConnectionConfig: https://us.api.mondoo.com
→ API Status:   SERVING
→ API Time:     2023-04-24T10:44:02Z
→ API Version:  8
! API versions do not match, please update the client
→ Owner:        //captain.api.mondoo.app/spaces/keen-banzai-154123
→ Client:       no managed client
→ Service Account:      //agents.api.mondoo.app/spaces/keen-banzai-154123/serviceaccounts/2OrwvXItmEV0Aue93mep5oPIiS4
→ client is registered
x The Mondoo Platform credentials provided at /Users/ivanmilchev/Downloads/temp.json didn't successfully authenticate with Mondoo Platform. Please re-authenticate e.g. via `cnspec login` with Mondoo Platform. For instructions, read https://mondoo.com/docs/install/registration. error="rpc error: code = Unauthenticated desc = request permission unauthenticated"
```