### PR TITLE
🧹 add user-friendly err when using unauthenticated cnquery

### DIFF
--- a/resources/packs/core/asset_advisories.go
+++ b/resources/packs/core/asset_advisories.go
@@ -14,8 +14,8 @@ import (
 func (a *mqlAsset) GetVulnerabilityReport() (interface{}, error) {
 	r := a.MotorRuntime
 	mcc := r.UpstreamConfig
-	if mcc == nil {
-		return nil, errors.New("mondoo upstream configuration is missing")
+	if mcc == nil || mcc.ApiEndpoint == "" {
+		return nil, errors.New(MissingUpstreamErr)
 	}
 
 	// get asset information

--- a/resources/packs/core/core.go
+++ b/resources/packs/core/core.go
@@ -2,6 +2,10 @@ package core
 
 import "go.mondoo.com/cnquery/resources/packs/core/info"
 
+const MissingUpstreamErr = `To use this resource, you must authenticate with the Mondoo Platform.
+To learn how, read: 
+https://mondoo.com/docs/cnspec/cnspec-adv-install/registration/`
+
 var Registry = info.Registry
 
 func init() {

--- a/resources/packs/core/mondoo_eol.go
+++ b/resources/packs/core/mondoo_eol.go
@@ -22,8 +22,8 @@ func (p *mqlMondooEol) GetDate() (*time.Time, error) {
 
 	r := p.MotorRuntime
 	mcc := r.UpstreamConfig
-	if mcc == nil {
-		return nil, errors.New("mondoo upstream configuration is missing")
+	if mcc == nil || mcc.ApiEndpoint == "" {
+		return nil, errors.New(MissingUpstreamErr)
 	}
 
 	// get new advisory report

--- a/resources/packs/core/platform_advisories.go
+++ b/resources/packs/core/platform_advisories.go
@@ -52,8 +52,8 @@ func newAdvisoryScannerHttpClient(mondooapi string, plugins []ranger.ClientPlugi
 func (p *mqlPlatform) GetVulnerabilityReport() (interface{}, error) {
 	r := p.MotorRuntime
 	mcc := r.UpstreamConfig
-	if mcc == nil {
-		return nil, errors.New("mondoo upstream configuration is missing")
+	if mcc == nil || mcc.ApiEndpoint == "" {
+		return nil, errors.New(MissingUpstreamErr)
 	}
 
 	// get platform information

--- a/resources/packs/core/platform_eol.go
+++ b/resources/packs/core/platform_eol.go
@@ -78,8 +78,8 @@ func (p *mqlPlatformEol) init(args *resources.Args) (*resources.Args, PlatformEo
 
 	r := p.MotorRuntime
 	mcc := r.UpstreamConfig
-	if mcc == nil {
-		return nil, nil, errors.New("mondoo upstream configuration is missing")
+	if mcc == nil || mcc.ApiEndpoint == "" {
+		return nil, nil, errors.New(MissingUpstreamErr)
 	}
 
 	// get new advisory report


### PR DESCRIPTION
For the cases when authentication is actually needed but not provided:
```
cnquery> platform.cves
Query encountered errors:
This resource requires data from the Mondoo Platform.
For instructions on using cnspec with the Mondoo platform, see:
https://mondoo.com/docs/cnspec/cnspec-adv-install/registration/
platform.cves.list: []
```

Fixes mondoohq/cnspec#364