### PR TITLE
🧹 Assign a type to switch statements similar to if statements

### DIFF
--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -465,6 +465,7 @@ func (c *compiler) compileSwitchBlock(expressions []*parser.Expression, chunk *l
 		}
 	}
 
+	var lastType types.Type = types.Unset
 	for i := 0; i < len(expressions); i += 2 {
 		err := c.compileSwitchCase(expressions[i], bind, chunk)
 		if err != nil {
@@ -497,6 +498,19 @@ func (c *compiler) compileSwitchBlock(expressions []*parser.Expression, chunk *l
 		// TODO(jaym): Discuss with dom: v1 seems to hardcore this as
 		// single valued
 		blockCompiler.block.SingleValue = true
+
+		// Check the types
+		lastChunk := blockCompiler.block.LastChunk()
+		if lastType == types.Unset {
+			lastType = lastChunk.Type()
+		} else {
+			// If the last type is not the same as the current type, then
+			// we set the type to any
+			if lastChunk.Type() != lastType {
+				lastType = types.Any
+			}
+			chunk.Function.Type = string(lastType)
+		}
 
 		depArgs := []*llx.Primitive{}
 		for _, v := range blockCompiler.blockDeps {

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -711,7 +711,7 @@ func TestCompiler_If(t *testing.T) {
 func TestCompiler_Switch(t *testing.T) {
 	compileT(t, "switch ( 1 ) { case _ > 0: true; default: false }", func(res *llx.CodeBundle) {
 		assertFunction(t, "switch", &llx.Function{
-			Type:    string(types.Unset),
+			Type:    string(types.Bool),
 			Binding: 0,
 			Args: []*llx.Primitive{
 				llx.IntPrimitive(1),
@@ -734,6 +734,15 @@ func TestCompiler_Switch(t *testing.T) {
 		assert.Equal(t, []uint64{(1 << 32) | 3}, res.CodeV2.Entrypoints())
 		assert.Empty(t, res.CodeV2.Datapoints())
 	})
+	t.Run("test types fall back to any", func(t *testing.T) {
+		compileT(t, "switch ( 1 ) { case _ > 0: true; case _ < 0: 'test'; default: false }", func(res *llx.CodeBundle) {
+			assert.Equal(t, types.Any, res.CodeV2.Blocks[0].Chunks[3].Type())
+		})
+		compileT(t, "switch ( 1 ) { case _ > 0: true; default: 'test' }", func(res *llx.CodeBundle) {
+			assert.Equal(t, types.Any, res.CodeV2.Blocks[0].Chunks[2].Type())
+		})
+	})
+
 }
 
 // //    =======================


### PR DESCRIPTION
We have difficulty storing the unset type. It doesn't seem unreasonable to me that switch should behave similar to if and have a type set.

The following query wasn't properly typed before:
```
switch {
  case tls.versions.containsOnly(["tls1.2", "tls1.3"]):
    score(100);
  case tls.ciphers.all( /rc4/i ):
    score(100);
  case tls.ciphers.none( /null|dh_anon|export|des|rc2|idea/ ):
    score(80);
  default:
    score(0);
}
```

Now, it gets compiled as:
```
-> block 1
   entrypoints: [<1,13>]
   1: tls
   2: versions bind: <1,1> type:[]string
   3: difference bind: <1,2> type:[]string ([
     0: "tls1.2"
     1: "tls1.3"
   ])
   4: == bind: <1,3> type:bool ([])
   5: tls
   6: ciphers bind: <1,5> type:[]string
   7: $whereNot bind: <1,6> type:[]string (ref<1,6>, => <3,0>)
   8: $all bind: <1,7> type:bool
   9: tls
   10: ciphers bind: <1,9> type:[]string
   11: where bind: <1,10> type:[]string (ref<1,10>, => <5,0>)
   12: $none bind: <1,11> type:bool
   13: switch bind: <0,0> type:score (_, ref<1,4>, => <2,0>, [], ref<1,8>, => <4,0>, [], ref<1,12>, => <6,0>, [], true, => <7,0>, [])
-> block 2
   entrypoints: [<2,1>]
   1: score bind: <0,0> type:score (100)
-> block 3
   entrypoints: [<3,3>]
   1: _
   2: /(?i)rc4/
   3: = bind: <3,1> type:bool (ref<3,2>)
-> block 4
   entrypoints: [<4,1>]
   1: score bind: <0,0> type:score (100)
-> block 5
   entrypoints: [<5,3>]
   1: _
   2: /null|dh_anon|export|des|rc2|idea/
   3: = bind: <5,1> type:bool (ref<5,2>)
-> block 6
   entrypoints: [<6,1>]
   1: score bind: <0,0> type:score (80)
-> block 7
   entrypoints: [<7,1>]
   1: score bind: <0,0> type:score (0)
```