### PR TITLE
🐛 fix panic for cnquery json reporter when asset could not be scanned

### DIFF
--- a/cli/reporter/json.go
+++ b/cli/reporter/json.go
@@ -47,11 +47,15 @@ func ReportCollectionToJSON(data *explorer.ReportCollection, out shared.OutputHe
 	}
 
 	queryMrnIdx := map[string]string{}
-	for i := range data.Bundle.Packs {
-		pack := data.Bundle.Packs[i]
-		for j := range pack.Queries {
-			query := pack.Queries[j]
-			queryMrnIdx[query.CodeId] = query.Mrn
+
+	// this case can happen when all assets error out, eg. no query pack is available that matches
+	if data.Bundle != nil {
+		for i := range data.Bundle.Packs {
+			pack := data.Bundle.Packs[i]
+			for j := range pack.Queries {
+				query := pack.Queries[j]
+				queryMrnIdx[query.CodeId] = query.Mrn
+			}
 		}
 	}
 


### PR DESCRIPTION
In cases where cnquery could not find a suitable query pack and the json exporter was used eg. via `cnquery scan local --output json`, cnquery created a panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x40 pc=0x10b0c01e0]

goroutine 1 [running]:
go.mondoo.com/cnquery/cli/reporter.ReportCollectionToJSON(0x14002b1a190, {0x10e2b2c30, 0x14000b3a0c0})
        /Users/chris/go/src/go.mondoo.com/workspace/cnquery/cli/reporter/json.go:50 +0x70
go.mondoo.com/cnquery/cli/reporter.(*Reporter).Print(0x14002b2c000, 0x14002b1a190, {0x10e223280?, 0x140001aa008})
        /Users/chris/go/src/go.mondoo.com/workspace/cnquery/cli/reporter/reporter.go:110 +0x1f8
go.mondoo.com/cnquery/apps/cnquery/cmd.printReports(0x140028cd980?, 0x140028cd980, 0x0?)
        /Users/chris/go/src/go.mondoo.com/workspace/cnquery/apps/cnquery/cmd/scan.go:568 +0x124
go.mondoo.com/cnquery/apps/cnquery/cmd.glob..func21(0x0?, {0x14000f63b40?, 0x0?, 0x0?}, 0x0?, 0x0?)
        /Users/chris/go/src/go.mondoo.com/workspace/cnquery/apps/cnquery/cmd/scan.go:348 +0xf4
go.mondoo.com/cnquery/apps/cnquery/cmd/builder.localProviderCmd.func1(0x14002834c00?, {0x14000f63b40?, 0x2?, 0x2?})
        /Users/chris/go/src/go.mondoo.com/workspace/cnquery/apps/cnquery/cmd/builder/builder.go:181 +0x30
github.com/spf13/cobra.(*Command).execute(0x14002834c00, {0x14000f63b20, 0x2, 0x2})
        /Users/chris/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:920 +0x5b0
github.com/spf13/cobra.(*Command).ExecuteC(0x112a70720)
        /Users/chris/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x35c
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/chris/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
go.mondoo.com/cnquery/apps/cnquery/cmd.Execute()
        /Users/chris/go/src/go.mondoo.com/workspace/cnquery/apps/cnquery/cmd/root.go:50 +0x28
main.main()
        /Users/chris/go/src/go.mondoo.com/workspace/cnquery/apps/cnquery/cnquery.go:6 +0x1c


Mimic Kubescape for cnspec readme
[Repository scanning](https://hub.armosec.io/docs/repository-scanning)
[kubescape/getting-started.md at master · kubescape/kubescape · GitHub](https://github.com/kubescape/kubescape/blob/master/docs/getting-started.md#examples)
```

This fix addresses that issue and renders the error as it should be:

```
cnquery scan local --output json | jq .
{
  "assets": {
    "//assets.api.mondoo.app/spaces/cranky-kirch-566148/assets/2PCGFThVe7WyfS9PbUdEqMLc5hw": {
      "mrn": "//assets.api.mondoo.app/spaces/cranky-kirch-566148/assets/2PCGFThVe7WyfS9PbUdEqMLc5hw",
      "name": "ChristoHartmann.fritz.box"
    }
  },
  "data": {},
  "errors": {
    "//assets.api.mondoo.app/spaces/cranky-kirch-566148/assets/2PCGFThVe7WyfS9PbUdEqMLc5hw": "asset doesn't support any policies"
  }
}
```
