### PR TITLE
🐛 Fix failures in GitHub pagination when fetching org repos

### DIFF
--- a/motor/discovery/github/github.go
+++ b/motor/discovery/github/github.go
@@ -119,13 +119,13 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *provide
 				return nil, err
 			}
 
-			listOpts := &github.RepositoryListByOrgOptions{
+			listOpts := &github.RepositoryListOptions{
 				ListOptions: github.ListOptions{PerPage: 100},
 				Type:        "all",
 			}
 			allRepos := []*github.Repository{}
 			for {
-				repos, resp, err := p.Client().Repositories.List(context.Background(), org.GetLogin(), &github.RepositoryListOptions{})
+				repos, resp, err := p.Client().Repositories.List(context.Background(), org.GetLogin(), listOpts)
 				if err != nil {
 					if strings.Contains(err.Error(), "404") {
 						return nil, nil


### PR DESCRIPTION
We were passing in a new repo options data structure each time that set the pagination back to the initial value.