### PR TITLE
⭐️ support uid / gid for files on running docker containers

### DIFF
--- a/motor/providers/container/docker_engine/fs.go
+++ b/motor/providers/container/docker_engine/fs.go
@@ -50,7 +50,7 @@ func isDockerClientSupported(path string) bool {
 
 func (fs *FS) Open(name string) (afero.File, error) {
 	if isDockerClientSupported(name) {
-		return FileOpen(fs.dockerClient, name, fs.Container, fs.Provider)
+		return FileOpen(fs.dockerClient, name, fs.Container, fs.Provider, fs.catFS)
 	} else {
 		return fs.catFS.Open(name)
 	}
@@ -73,11 +73,7 @@ func (fs *FS) Rename(oldname, newname string) error {
 }
 
 func (fs *FS) Stat(name string) (os.FileInfo, error) {
-	f, err := fs.Open(name)
-	if err != nil {
-		return nil, err
-	}
-	return f.Stat()
+	return fs.catFS.Stat(name)
 }
 
 func (fs *FS) Chmod(name string, mode os.FileMode) error {

--- a/motor/providers/os/statutil/stat.go
+++ b/motor/providers/os/statutil/stat.go
@@ -1,8 +1,8 @@
 package statutil
 
 import (
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -46,7 +46,7 @@ func New(cmdRunner CommandRunner) *statHelper {
 type statHelper struct {
 	commandRunner CommandRunner
 	detected      bool
-	isunix        bool
+	isUnix        bool
 }
 
 var bsdunix = map[string]bool{
@@ -66,7 +66,7 @@ func (s *statHelper) Stat(name string) (os.FileInfo, error) {
 			return nil, err
 		}
 
-		data, err := ioutil.ReadAll(cmd.Stdout)
+		data, err := io.ReadAll(cmd.Stdout)
 		if err != nil {
 			return nil, err
 		}
@@ -74,14 +74,14 @@ func (s *statHelper) Stat(name string) (os.FileInfo, error) {
 		// only switch to unix if we properly detected it, otherwise fallback to linux
 		val := strings.ToLower(strings.TrimSpace(string(data)))
 
-		isunix, ok := bsdunix[val]
-		if ok && isunix {
-			s.isunix = true
+		isUnix, ok := bsdunix[val]
+		if ok && isUnix {
+			s.isUnix = true
 		}
 		s.detected = true
 	}
 
-	if s.isunix {
+	if s.isUnix {
 		return s.unix(name)
 	}
 	return s.linux(name)
@@ -126,7 +126,7 @@ func (s *statHelper) linux(name string) (os.FileInfo, error) {
 		return nil, errors.New("could not parse file stat: " + path)
 	}
 
-	data, err := ioutil.ReadAll(cmd.Stdout)
+	data, err := io.ReadAll(cmd.Stdout)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +198,7 @@ func (s *statHelper) unix(name string) (os.FileInfo, error) {
 		log.Debug().Err(err).Send()
 	}
 
-	data, err := ioutil.ReadAll(cmd.Stdout)
+	data, err := io.ReadAll(cmd.Stdout)
 	if err != nil {
 		return nil, err
 	}

--- a/motor/providers/ssh/cat/cat_file.go
+++ b/motor/providers/ssh/cat/cat_file.go
@@ -3,7 +3,7 @@ package cat
 import (
 	"bytes"
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -34,7 +34,7 @@ func (f *File) readContent() (*bytes.Buffer, error) {
 		return nil, err
 	}
 
-	data, err := ioutil.ReadAll(cmd.Stdout)
+	data, err := io.ReadAll(cmd.Stdout)
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +96,7 @@ func (f *File) Readdirnames(n int) (names []string, err error) {
 		return nil, err
 	}
 
-	data, err := ioutil.ReadAll(cmd.Stdout)
+	data, err := io.ReadAll(cmd.Stdout)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Before this PR we have not supported UID/GID parsing for running docker containers. This PR changes this and adds support.

*before*

```coffeescript
cnquery> file("/tmp").user.name
Query encountered errors:
cannot cast resource to resource type: <nil>
file.user.name: no data available
```

*after*

```coffeescript
cnquery> file("/tmp").user.name
file.user.name: "root"
```