### PR TITLE
🐛 parse manifests from stdin

### DIFF
--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -271,7 +271,7 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 		connection.Backend = providerType
 
 		if filepath != "" {
-			if _, err := os.Stat(filepath); os.IsNotExist(err) {
+			if _, err := os.Stat(filepath); filepath != "-" && os.IsNotExist(err) {
 				log.Fatal().Str("file", filepath).Msg("Could not find the Kubernetes manifest file. Please specify the correct path.")
 			}
 			connection.Options["path"] = filepath


### PR DESCRIPTION
We had support for this but we broke it when we added some validation whether the file exists or not

Fixes mondoohq/cnspec#402

`cat p.yaml | ./cnquery scan k8s -  `:
```                                                                                                                                                                                                              
→ loaded configuration from /Users/ivanmilchev/.config/mondoo/mondoo.yml using source default
→ using service account credentials
→ discover related assets for 1 asset(s)
→ discovery option auto is used. This will detect the assets: cluster, cronjobs, daemonsets, deployments, ingresses, jobs, pods, replicasets, statefulsets
→ resolved assets resolved-assets=2
→ synchronize assets

 K8s Manifest -                  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────   0%
... 1 more asset ...

 0/2 scanned                     ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────   0%
```