### PR TITLE
🐛 fix the recording

### DIFF
--- a/apps/cnquery/cmd/plugin.go
+++ b/apps/cnquery/cmd/plugin.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"github.com/spf13/viper"
 	"os"
 
 	"github.com/cockroachdb/errors"
@@ -150,7 +151,7 @@ func (c *cnqueryPlugin) RunQuery(conf *proto.RunQueryConfig, out shared.OutputHe
 
 		// when we close the shell, we need to close the backend and store the recording
 		onCloseHandler := func() {
-			storeRecording(m)
+			m.StoreRecording(viper.GetString("record-file"))
 		}
 
 		shellOptions := []shell.ShellOption{}

--- a/apps/cnquery/cmd/root.go
+++ b/apps/cnquery/cmd/root.go
@@ -2,15 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"net/http"
-	"os"
-	"regexp"
-	"strings"
-	"time"
-
 	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 	"github.com/spf13/viper"
@@ -19,10 +12,13 @@ import (
 	"go.mondoo.com/cnquery/cli/sysinfo"
 	"go.mondoo.com/cnquery/cli/theme"
 	"go.mondoo.com/cnquery/logger"
-	"go.mondoo.com/cnquery/motor"
 	"go.mondoo.com/cnquery/motor/asset"
 	"go.mondoo.com/ranger-rpc"
 	"go.mondoo.com/ranger-rpc/plugins/scope"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
 )
 
 const (
@@ -87,19 +83,6 @@ func initLogger(cmd *cobra.Command) {
 		level = "debug"
 	}
 	logger.Set(level)
-}
-
-// storeRecording stores tracked commands and files into the recording file
-func storeRecording(m *motor.Motor) {
-	if m.IsRecording() {
-		filename := viper.GetString("record-file")
-		if filename == "" {
-			filename = "recording-" + time.Now().Format("20060102150405") + ".toml"
-		}
-		log.Info().Str("filename", filename).Msg("store recordings")
-		data := m.Recording()
-		os.WriteFile(filename, data, 0o700)
-	}
 }
 
 func filterAssetByPlatformID(assetList []*asset.Asset, selectionID string) (*asset.Asset, error) {

--- a/apps/cnquery/cmd/shell.go
+++ b/apps/cnquery/cmd/shell.go
@@ -43,7 +43,6 @@ var shellCmd = builder.NewProviderCommand(builder.CommandOpts{
 		cmd.Flags().Bool("host-machines", false, "Also scan host machines like ESXi server.")
 		cmd.Flags().Bool("record", false, "Record all backend calls.")
 		cmd.Flags().MarkHidden("record")
-
 		cmd.Flags().String("record-file", "", "File path for the recorded provider calls. This only works for operating system providers.)")
 		cmd.Flags().MarkHidden("record-file")
 
@@ -60,8 +59,6 @@ var shellCmd = builder.NewProviderCommand(builder.CommandOpts{
 		viper.BindPFlag("sudo.active", cmd.Flags().Lookup("sudo"))
 
 		viper.BindPFlag("output", cmd.Flags().Lookup("output"))
-		viper.BindPFlag("record", cmd.Flags().Lookup("record"))
-
 		viper.BindPFlag("vault.name", cmd.Flags().Lookup("vault"))
 		viper.BindPFlag("platform-id", cmd.Flags().Lookup("platform-id"))
 

--- a/apps/cnquery/cmd/shell_run.go
+++ b/apps/cnquery/cmd/shell_run.go
@@ -6,8 +6,8 @@ import (
 	"os"
 
 	"github.com/mattn/go-isatty"
-
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
 	"go.mondoo.com/cnquery"
 	"go.mondoo.com/cnquery/cli/components"
 	"go.mondoo.com/cnquery/cli/shell"
@@ -89,7 +89,7 @@ func StartShell(conf *ShellConfig) error {
 	// when we close the shell, we need to close the backend and store the recording
 	onCloseHandler := func() {
 		// store tracked commands and files
-		storeRecording(m)
+		m.StoreRecording(viper.GetString("record-file"))
 	}
 
 	shellOptions := []shell.ShellOption{}

--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -351,6 +351,10 @@ func (s *LocalScanner) RunAssetJob(job *AssetJob) {
 			}
 
 			job.Reporter.AddReport(job.Asset, results)
+
+			if m.IsRecording() {
+				m.StoreRecording("") // if no filename is provided it generates one
+			}
 		}(connections[c])
 	}
 }


### PR DESCRIPTION
This issue was reported by @mm-weber. The recordings where working for `cnquery shell` but not for `cnquery scan`. This brings back the ability to record the data (os provider only) for a query pack. 