### PR TITLE
⭐️ add filesystem provider to command builder

### DIFF
--- a/apps/cnquery/cmd/builder/builder.go
+++ b/apps/cnquery/cmd/builder/builder.go
@@ -178,6 +178,7 @@ func buildCmd(baseCmd *cobra.Command, commonCmdFlags common.CommonFlagsFn, preRu
 	baseCmd.AddCommand(scanGoogleWorkspaceCmd(commonCmdFlags, preRun, runFn, docs))
 	baseCmd.AddCommand(scanSlackCmd(commonCmdFlags, preRun, runFn, docs))
 	baseCmd.AddCommand(scanVcdCmd(commonCmdFlags, preRun, runFn, docs))
+	baseCmd.AddCommand(scanFilesystemCmd(commonCmdFlags, preRun, runFn, docs))
 }
 
 func localProviderCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
@@ -536,5 +537,13 @@ func scanVcdCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunF
 		runFn(cmd, args, providers.ProviderType_VCD, DefaultAssetType)
 	}
 	cmd := common.ScanVcdCmd(commonCmdFlags, preRun, wrapRunFn, docs)
+	return cmd
+}
+
+func scanFilesystemCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_FS, DefaultAssetType)
+	}
+	cmd := common.ScanFilesystemCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }

--- a/apps/cnquery/cmd/builder/common/common.go
+++ b/apps/cnquery/cmd/builder/common/common.go
@@ -771,3 +771,20 @@ func ScanVcdCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn
 	cmd.Flags().String("organization", "", "vCloud Director Organization (optional)")
 	return cmd
 }
+
+func ScanFilesystemCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "filesystem",
+		Aliases: []string{"fs"},
+		Short:   docs.GetShort("filesystem"),
+		Long:    docs.GetLong("filesystem"),
+		Args:    cobra.ExactArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			cmd.Flags().Set("path", args[0])
+			preRun(cmd, args)
+		},
+		Run: runFn,
+	}
+	commonCmdFlags(cmd)
+	return cmd
+}

--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -742,6 +742,9 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 		}
 
 		connection.Credentials = append(connection.Credentials, cred)
+	case providers.ProviderType_FS:
+		connection.Backend = providerType
+		connection.Options["path"] = filepath
 	}
 
 	parsedAsset.Connections = []*providers.Config{connection}

--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -247,6 +247,9 @@ This example connects to Microsoft 365 using the PEM formatted certificate:
 			"arista": {
 				Short: "Scan an Arista endpoint.",
 			},
+			"filesystem": {
+				Short: "Scan a mounted file system target.",
+			},
 		},
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/apps/cnquery/cmd/shell.go
+++ b/apps/cnquery/cmd/shell.go
@@ -239,6 +239,9 @@ This example connects to Microsoft 365 using the PKCS #12 formatted certificate:
 			"oci": {
 				Short: "Connect to Oracle Cloud Infrastructure (OCI) tenancy.",
 			},
+			"filesystem": {
+				Short: "Connect to a mounted file system target.",
+			},
 		},
 	},
 	Run: func(cmd *cobra.Command, args []string, provider providers.ProviderType, assetType builder.AssetType) {


### PR DESCRIPTION
This allows you to test mounted firmware files:

```
cnquery shell fs /mnt/firmware/
→ discover related assets for 1 asset(s)
→ resolved assets resolved-assets=1
  ___ _ __   __ _ _   _  ___ _ __ _   _ 
 / __| '_ \ / _` | | | |/ _ \ '__| | | |
| (__| | | | (_| | |_| |  __/ |  | |_| |
 \___|_| |_|\__, |\__,_|\___|_|   \__, |
  mondoo™      |_|                |___/  interactive shell

cnquery> asset {name version platform }
asset: {
  version: "v3.1.17"
  platform: "poky-iot2000"
  name: "iot2000"
}
```

You can easily test this locally via:

```
cnquery shell fs motor/providers/fs/testdata/centos8 
```