### PR TITLE
🐛 prevent crashes on calling dict.containsOnly without array

### DIFF
--- a/llx/builtin_map.go
+++ b/llx/builtin_map.go
@@ -786,7 +786,6 @@ func dictDifferenceV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64)
 	filters, ok := arg.Value.([]interface{})
 	if !ok {
 		return &RawData{Type: bind.Type, Error: errors.New("tried to call function with a non-array, please make sure the argument is an array")}, 0, nil
-		// filters = []interface{}{arg.Value}
 	}
 
 	var res []interface{}

--- a/llx/builtin_map.go
+++ b/llx/builtin_map.go
@@ -783,7 +783,11 @@ func dictDifferenceV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64)
 		return &RawData{Type: bind.Type, Error: errors.New("cannot compute difference of lists, argument is not a list")}, 0, nil
 	}
 
-	filters := arg.Value.([]interface{})
+	filters, ok := arg.Value.([]interface{})
+	if !ok {
+		return &RawData{Type: bind.Type, Error: errors.New("tried to call function with a non-array, please make sure the argument is an array")}, 0, nil
+		// filters = []interface{}{arg.Value}
+	}
 
 	var res []interface{}
 	var skip bool

--- a/resources/packs/core/core_test.go
+++ b/resources/packs/core/core_test.go
@@ -1102,6 +1102,18 @@ func TestDict_Methods_Contains(t *testing.T) {
 			1, true,
 		},
 		{
+			p + "params['string-array'].containsOnly(['c', 'a', 'b'])",
+			1, true,
+		},
+		{
+			p + "params['string-array'].containsOnly(['a', 'b'])",
+			1, false,
+		},
+		// {
+		// 	p + "params['string-array'].containsOnly('a')",
+		// 	1, false,
+		// },
+		{
 			p + "params['string-array'].none('a')",
 			1, false,
 		},


### PR DESCRIPTION
This technically doesnt work and is in line with the way it works for arrays. However, I think we should change this because more users are runingn into this...