### PR TITLE
🛑 change the behavior of first/last to support empty lists

### DIFF
--- a/llx/builtin_array.go
+++ b/llx/builtin_array.go
@@ -24,7 +24,7 @@ func arrayGetFirstIndexV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uin
 	}
 
 	if len(arr) == 0 {
-		return nil, 0, errors.New("array index out of bound (trying to access first element on an empty array)")
+		return &RawData{Type: bind.Type[1:]}, 0, nil
 	}
 
 	return &RawData{
@@ -44,7 +44,7 @@ func arrayGetLastIndexV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint
 	}
 
 	if len(arr) == 0 {
-		return nil, 0, errors.New("array index out of bound (trying to access last element on an empty array)")
+		return &RawData{Type: bind.Type[1:]}, 0, nil
 	}
 
 	return &RawData{

--- a/resources/packs/core/core_test.go
+++ b/resources/packs/core/core_test.go
@@ -732,6 +732,14 @@ func TestArray_Access(t *testing.T) {
 			"[1,2,3].last",
 			0, int64(3),
 		},
+		{
+			"[].first",
+			0, nil,
+		},
+		{
+			"[].last",
+			0, nil,
+		},
 	})
 }
 


### PR DESCRIPTION
`first` and `last` both were introduced as helper methods to easily access the first and last element of an array. As such, having to deal with empty lists and the consequences of `null` is really annoying.

To better fit their behavior, these methods will now return `null` if you access elements from an empty or null array. For the latter case we already had this behavior, so now it better fits together.

Users can still use `[0]` to access the first and `[-1]` for the last element and have it throw an error if those elements could not be found.

```
> [1,2,3].where(_>4).first
where.first: null
```