### PR TITLE
✨ add first/last to dict, including support for empty lists

### DIFF
--- a/llx/builtin.go
+++ b/llx/builtin.go
@@ -485,8 +485,10 @@ func init() {
 			string("*" + types.Time):                 {f: dictTimesTimeV2, Label: "*"},
 			// fields
 			"[]":                              {f: dictGetIndexV2},
-			"length":                          {f: dictLengthV2},
+			"first":                           {f: dictGetFirstIndexV2},
+			"last":                            {f: dictGetLastIndexV2},
 			"{}":                              {f: dictBlockCallV2},
+			"length":                          {f: dictLengthV2},
 			"camelcase":                       {f: dictCamelcaseV2, Label: "camelcase"},
 			"downcase":                        {f: dictDowncaseV2, Label: "downcase"},
 			"upcase":                          {f: dictUpcaseV2, Label: "upcase"},

--- a/llx/builtin_array.go
+++ b/llx/builtin_array.go
@@ -24,7 +24,7 @@ func arrayGetFirstIndexV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uin
 	}
 
 	if len(arr) == 0 {
-		return nil, 0, errors.New("array index out of bound (trying to access first element on an empty array)")
+		return &RawData{Type: bind.Type[1:]}, 0, nil
 	}
 
 	return &RawData{
@@ -44,7 +44,7 @@ func arrayGetLastIndexV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint
 	}
 
 	if len(arr) == 0 {
-		return nil, 0, errors.New("array index out of bound (trying to access last element on an empty array)")
+		return &RawData{Type: bind.Type[1:]}, 0, nil
 	}
 
 	return &RawData{

--- a/llx/builtin_map.go
+++ b/llx/builtin_map.go
@@ -252,6 +252,88 @@ func dictGetIndexV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (
 	}
 }
 
+func dictGetFirstIndexV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
+	if bind.Value == nil {
+		return &RawData{Type: bind.Type}, 0, nil
+	}
+
+	switch x := bind.Value.(type) {
+	case []interface{}:
+		if len(x) == 0 {
+			return &RawData{Type: bind.Type}, 0, nil
+		}
+
+		return &RawData{
+			Value: x[0],
+			Type:  bind.Type,
+		}, 0, nil
+
+	case map[string]interface{}:
+		if len(x) == 0 {
+			return &RawData{Type: bind.Type}, 0, nil
+		}
+
+		var firstKey string
+		for k := range x {
+			firstKey = k
+			break
+		}
+		for k := range x {
+			if k < firstKey {
+				firstKey = k
+			}
+		}
+
+		return &RawData{
+			Value: x[firstKey],
+			Type:  bind.Type,
+		}, 0, nil
+	default:
+		return &RawData{Type: bind.Type}, 0, nil
+	}
+}
+
+func dictGetLastIndexV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
+	if bind.Value == nil {
+		return &RawData{Type: bind.Type}, 0, nil
+	}
+
+	switch x := bind.Value.(type) {
+	case []interface{}:
+		if len(x) == 0 {
+			return &RawData{Type: bind.Type}, 0, nil
+		}
+
+		return &RawData{
+			Value: x[len(x)-1],
+			Type:  bind.Type,
+		}, 0, nil
+
+	case map[string]interface{}:
+		if len(x) == 0 {
+			return &RawData{Type: bind.Type}, 0, nil
+		}
+
+		var lastKey string
+		for k := range x {
+			lastKey = k
+			break
+		}
+		for k := range x {
+			if lastKey < k {
+				lastKey = k
+			}
+		}
+
+		return &RawData{
+			Value: x[lastKey],
+			Type:  bind.Type,
+		}, 0, nil
+	default:
+		return &RawData{Type: bind.Type}, 0, nil
+	}
+}
+
 func dictLengthV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
 	if bind.Value == nil {
 		return &RawData{Type: bind.Type}, 0, nil

--- a/mql/testdata/arch.toml
+++ b/mql/testdata/arch.toml
@@ -586,7 +586,7 @@ content="""
 
 [files."/dummy.array.json"]
 content="""
-[1,"hi",{"ll": 0}]
+[1,"hi",{"ll": 0},"z"]
 """
 
 [files."/dummy.true.json"]

--- a/mqlc/builtin.go
+++ b/mqlc/builtin.go
@@ -62,6 +62,8 @@ func init() {
 			"split":     {typ: stringArrayType, signature: FunctionSignature{Required: 1, Args: []types.Type{types.String}}},
 			"trim":      {typ: stringType, signature: FunctionSignature{Required: 0, Args: []types.Type{types.String}}},
 			// array- or map-ish
+			"first":        {typ: dictType, signature: FunctionSignature{}},
+			"last":         {typ: dictType, signature: FunctionSignature{}},
 			"where":        {compile: compileDictWhere, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
 			"contains":     {compile: compileDictContains, typ: boolType, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
 			"containsOnly": {compile: compileDictContainsOnly, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},

--- a/resources/packs/core/core_test.go
+++ b/resources/packs/core/core_test.go
@@ -1225,6 +1225,14 @@ func TestDict_Methods_Map(t *testing.T) {
 			"parse.date(" + p + "params['date'])",
 			0, &expectedTime,
 		},
+		{
+			p + "params.first",
+			0, float64(1),
+		},
+		{
+			p + "params.last",
+			0, true,
+		},
 	})
 
 	x.TestSimpleErrors(t, []testutils.SimpleTest{
@@ -1256,6 +1264,22 @@ func TestDict_Methods_Array(t *testing.T) {
 			p + "params[2]",
 			0,
 			map[string]interface{}{"ll": float64(0)},
+		},
+		{
+			p + "params.first",
+			0, float64(1),
+		},
+		{
+			p + "params.last",
+			0, "z",
+		},
+		{
+			p + "params.where(-1).first",
+			0, nil,
+		},
+		{
+			p + "params.where(-1).last",
+			0, nil,
 		},
 	})
 }

--- a/resources/packs/core/core_test.go
+++ b/resources/packs/core/core_test.go
@@ -732,6 +732,14 @@ func TestArray_Access(t *testing.T) {
 			"[1,2,3].last",
 			0, int64(3),
 		},
+		{
+			"[].first",
+			0, nil,
+		},
+		{
+			"[].last",
+			0, nil,
+		},
 	})
 }
 

--- a/resources/packs/testdata/arch.toml
+++ b/resources/packs/testdata/arch.toml
@@ -585,7 +585,7 @@ content="""
 
 [files."/dummy.array.json"]
 content="""
-[1,"hi",{"ll": 0}]
+[1,"hi",{"ll": 0},"z"]
 """
 
 [files."/dummy.true.json"]


### PR DESCRIPTION
After https://github.com/mondoohq/cnquery/pull/1236 !

We have supported `first` and `last` for arrays already, now we are adding it to dicts, i.e. parsed JSON, to also access these first and last elements.

```
cnquery> parse.json("dummy.json").params["string-array"].first
parse.json.params[string-array].first: "a"
cnquery> parse.json("dummy.json").params["string-array"].last
parse.json.params[string-array].last: "c"
cnquery> parse.json("dummy.json").params["string-array"].where("non-exist").first
parse.json.params[string-array].where.first: null
cnquery> parse.json("dummy.json").params["string-array"].where("non-exist").last
parse.json.params[string-array].where.last: null

cnquery> parse.json("dummy.json").params.first
parse.json.params.first: 1.000000
cnquery> parse.json("dummy.json").params.last
parse.json.params.last: true
cnquery> parse.json("dummy.json").params.where("non-exist").first
parse.json.params.where.first: null
cnquery> parse.json("dummy.json").params.where("non-exist").last
parse.json.params.where.last: null
```