### PR TITLE
:bug:  fix panic on domainName

### DIFF
--- a/resources/packs/core/dns.go
+++ b/resources/packs/core/dns.go
@@ -29,15 +29,17 @@ func (d *mqlDomainName) init(args *resources.Args) (*resources.Args, DomainName,
 		(*args)["fqdn"] = fqdn
 	}
 
-	dn, err := domain.Parse(fqdn.(string))
-	if err != nil {
-		return nil, nil, err
-	}
+	if fqdn != nil {
+		dn, err := domain.Parse(fqdn.(string))
+		if err != nil {
+			return nil, nil, err
+		}
 
-	(*args)["effectiveTLDPlusOne"] = dn.EffectiveTLDPlusOne
-	(*args)["tld"] = dn.TLD
-	(*args)["tldIcannManaged"] = dn.IcannManagedTLD
-	(*args)["labels"] = StrSliceToInterface(dn.Labels)
+		(*args)["effectiveTLDPlusOne"] = dn.EffectiveTLDPlusOne
+		(*args)["tld"] = dn.TLD
+		(*args)["tldIcannManaged"] = dn.IcannManagedTLD
+		(*args)["labels"] = StrSliceToInterface(dn.Labels)
+	}
 
 	return args, nil, nil
 }

--- a/resources/packs/core/dns.go
+++ b/resources/packs/core/dns.go
@@ -29,17 +29,19 @@ func (d *mqlDomainName) init(args *resources.Args) (*resources.Args, DomainName,
 		(*args)["fqdn"] = fqdn
 	}
 
-	if fqdn != nil {
-		dn, err := domain.Parse(fqdn.(string))
-		if err != nil {
-			return nil, nil, err
-		}
-
-		(*args)["effectiveTLDPlusOne"] = dn.EffectiveTLDPlusOne
-		(*args)["tld"] = dn.TLD
-		(*args)["tldIcannManaged"] = dn.IcannManagedTLD
-		(*args)["labels"] = StrSliceToInterface(dn.Labels)
+	if fqdn == nil {
+		return nil, nil, errors.New("domainName resource requires fqdn argument")
 	}
+
+	dn, err := domain.Parse(fqdn.(string))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	(*args)["effectiveTLDPlusOne"] = dn.EffectiveTLDPlusOne
+	(*args)["tld"] = dn.TLD
+	(*args)["tldIcannManaged"] = dn.IcannManagedTLD
+	(*args)["labels"] = StrSliceToInterface(dn.Labels)
 
 	return args, nil, nil
 }

--- a/resources/packs/core/dns_test.go
+++ b/resources/packs/core/dns_test.go
@@ -10,3 +10,10 @@ func TestResource_DNS(t *testing.T) {
 	res := x.TestQuery(t, "dns(\"mondoo.com\").mx")
 	assert.NotEmpty(t, res)
 }
+
+func TestResource_DomainName(t *testing.T) {
+	res := x.TestQuery(t, "domainName")
+	assert.NotEmpty(t, res)
+	res = x.TestQuery(t, "domainName(\"mondoo.com\").tld")
+	assert.Equal(t, "com", string(res[0].Result().Data.Value))
+}


### PR DESCRIPTION
closes #993 

Instead of a panic the output would now be 

```
cnquery> domainName
Query encountered errors:
failed to validate resource 'domainName': Initialized "domainName" resource without a "effectiveTLDPlusOne". This field is required.
domainName: no data available
```

I also thought about returning an error here when `if fqdn == nil` 

```
if fqdn == nil {
    return nil, nil, errors.New("some error")
}
```

Which would then be 

```
cnquery> domainName
Query encountered errors:
failed to create resource 'domainName': some error
domainName: no data available
```

Of course using something more descriptive then "some error". Which way do you guys prefer? 