### PR TITLE
:bug: fix fail if config file not found

### DIFF
--- a/apps/cnquery/cmd/bundle.go
+++ b/apps/cnquery/cmd/bundle.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -143,7 +144,14 @@ var queryPackUploadCmd = &cobra.Command{
 		}
 		err := config.ValidateUserProvidedConfigPath()
 		if err != nil {
-			log.Fatal().Err(err).Msg("Could not load user provided config")
+			fileNotFoundError := new(config.FileNotFoundError)
+			if errors.As(err, &fileNotFoundError) {
+				log.Fatal().Msgf(
+					"Couldn't find user provided config file \n\nEnsure that %s provided through %s is a valid file path", fileNotFoundError.Path(), fileNotFoundError.Source(),
+				)
+			} else {
+				log.Fatal().Err(err).Msg("Could not load user provided config")
+			}
 		}
 		config.DisplayUsedConfig()
 

--- a/apps/cnquery/cmd/bundle.go
+++ b/apps/cnquery/cmd/bundle.go
@@ -141,7 +141,7 @@ var queryPackUploadCmd = &cobra.Command{
 		if optsErr != nil {
 			log.Fatal().Err(optsErr).Msg("could not load configuration")
 		}
-		err := config.ValidateConfigPath()
+		err := config.ValidateUserProvidedConfigPath()
 		if err != nil {
 			log.Fatal().Err(err).Msg("Could not load user provided config")
 		}

--- a/apps/cnquery/cmd/bundle.go
+++ b/apps/cnquery/cmd/bundle.go
@@ -141,6 +141,10 @@ var queryPackUploadCmd = &cobra.Command{
 		if optsErr != nil {
 			log.Fatal().Err(optsErr).Msg("could not load configuration")
 		}
+		err := config.ValidateConfigPath()
+		if err != nil {
+			log.Fatal().Err(err).Msg("Could not load user provided config")
+		}
 		config.DisplayUsedConfig()
 
 		filename := args[0]

--- a/apps/cnquery/cmd/login.go
+++ b/apps/cnquery/cmd/login.go
@@ -147,7 +147,7 @@ func register(token string) {
 		if optsErr != nil {
 			log.Fatal().Msg("could not load configuration, please use --token or --config with the appropriate values")
 		}
-		err = config.ValidateConfigPath()
+		err = config.ValidateUserProvidedConfigPath()
 		if err != nil {
 			log.Fatal().Err(err).Msg("Could not load user provided config")
 		}

--- a/apps/cnquery/cmd/login.go
+++ b/apps/cnquery/cmd/login.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -149,7 +150,14 @@ func register(token string) {
 		}
 		err = config.ValidateUserProvidedConfigPath()
 		if err != nil {
-			log.Fatal().Err(err).Msg("Could not load user provided config")
+			fileNotFoundError := new(config.FileNotFoundError)
+			if errors.As(err, &fileNotFoundError) {
+				log.Fatal().Msgf(
+					"Couldn't find user provided config file \n\nEnsure that %s provided through %s is a valid file path", fileNotFoundError.Path(), fileNotFoundError.Source(),
+				)
+			} else {
+				log.Fatal().Err(err).Msg("Could not load user provided config")
+			}
 		}
 		config.DisplayUsedConfig()
 

--- a/apps/cnquery/cmd/login.go
+++ b/apps/cnquery/cmd/login.go
@@ -147,7 +147,10 @@ func register(token string) {
 		if optsErr != nil {
 			log.Fatal().Msg("could not load configuration, please use --token or --config with the appropriate values")
 		}
-		// print the used config to the user
+		err = config.ValidateConfigPath()
+		if err != nil {
+			log.Fatal().Err(err).Msg("Could not load user provided config")
+		}
 		config.DisplayUsedConfig()
 
 		httpClient, err = opts.GetHttpClient()

--- a/apps/cnquery/cmd/logout.go
+++ b/apps/cnquery/cmd/logout.go
@@ -39,7 +39,10 @@ the credentials cannot be used in the future.
 			log.Fatal().Msg("could not load configuration")
 		}
 
-		// print the used config to the user
+		err = config.ValidateConfigPath()
+		if err != nil {
+			log.Fatal().Err(err).Msg("Could not load user provided config")
+		}
 		config.DisplayUsedConfig()
 
 		// determine information about the client

--- a/apps/cnquery/cmd/logout.go
+++ b/apps/cnquery/cmd/logout.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"os"
 
 	"github.com/rs/zerolog/log"
@@ -41,7 +42,14 @@ the credentials cannot be used in the future.
 
 		err = config.ValidateUserProvidedConfigPath()
 		if err != nil {
-			log.Fatal().Err(err).Msg("Could not load user provided config")
+			fileNotFoundError := new(config.FileNotFoundError)
+			if errors.As(err, &fileNotFoundError) {
+				log.Fatal().Msgf(
+					"Couldn't find user provided config file \n\nEnsure that %s provided through %s is a valid file path", fileNotFoundError.Path(), fileNotFoundError.Source(),
+				)
+			} else {
+				log.Fatal().Err(err).Msg("Could not load user provided config")
+			}
 		}
 		config.DisplayUsedConfig()
 

--- a/apps/cnquery/cmd/logout.go
+++ b/apps/cnquery/cmd/logout.go
@@ -39,7 +39,7 @@ the credentials cannot be used in the future.
 			log.Fatal().Msg("could not load configuration")
 		}
 
-		err = config.ValidateConfigPath()
+		err = config.ValidateUserProvidedConfigPath()
 		if err != nil {
 			log.Fatal().Err(err).Msg("Could not load user provided config")
 		}

--- a/apps/cnquery/cmd/plugin.go
+++ b/apps/cnquery/cmd/plugin.go
@@ -63,7 +63,7 @@ func (c *cnqueryPlugin) RunQuery(conf *proto.RunQueryConfig, out shared.OutputHe
 		log.Fatal().Err(optsErr).Msg("could not load configuration")
 	}
 
-	err := config.ValidateConfigPath()
+	err := config.ValidateUserProvidedConfigPath()
 	if err != nil {
 		log.Fatal().Err(err).Msg("Could not load user provided config")
 	}

--- a/apps/cnquery/cmd/plugin.go
+++ b/apps/cnquery/cmd/plugin.go
@@ -65,7 +65,14 @@ func (c *cnqueryPlugin) RunQuery(conf *proto.RunQueryConfig, out shared.OutputHe
 
 	err := config.ValidateUserProvidedConfigPath()
 	if err != nil {
-		log.Fatal().Err(err).Msg("Could not load user provided config")
+		fileNotFoundError := new(config.FileNotFoundError)
+		if errors.As(err, &fileNotFoundError) {
+			log.Fatal().Msgf(
+				"Couldn't find user provided config file \n\nEnsure that %s provided through %s is a valid file path", fileNotFoundError.Path(), fileNotFoundError.Source(),
+			)
+		} else {
+			log.Fatal().Err(err).Msg("Could not load user provided config")
+		}
 	}
 	config.DisplayUsedConfig()
 

--- a/apps/cnquery/cmd/plugin.go
+++ b/apps/cnquery/cmd/plugin.go
@@ -63,6 +63,10 @@ func (c *cnqueryPlugin) RunQuery(conf *proto.RunQueryConfig, out shared.OutputHe
 		log.Fatal().Err(optsErr).Msg("could not load configuration")
 	}
 
+	err := config.ValidateConfigPath()
+	if err != nil {
+		log.Fatal().Err(err).Msg("Could not load user provided config")
+	}
 	config.DisplayUsedConfig()
 
 	ctx := discovery.InitCtx(context.Background())

--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -389,12 +389,14 @@ func getCobraScanConfig(cmd *cobra.Command, args []string, provider providers.Pr
 	}
 	err := config.ValidateUserProvidedConfigPath()
 	if err != nil {
-		if serr, ok := err.(*config.FileNotFoundError); ok {
-			log.Error().Err(serr).Msg("Couldn't find user provided config file")
-			log.Info().Msgf("Ensure that %s provided through %s is a valid file path", serr.Path(), serr.Source())
-			os.Exit(1)
+		fileNotFoundError := new(config.FileNotFoundError)
+		if errors.As(err, &fileNotFoundError) {
+			log.Fatal().Err(fileNotFoundError).Msgf(
+				"Couldn't find user provided config file \n\nEnsure that %s provided through %s is a valid file path", fileNotFoundError.Path(), fileNotFoundError.Source(),
+			)
+		} else {
+			log.Fatal().Err(err).Msg("Failed to load user provided config")
 		}
-		log.Fatal().Err(err).Msg("Failed to load user provided config")
 	}
 	config.DisplayUsedConfig()
 

--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -389,7 +389,12 @@ func getCobraScanConfig(cmd *cobra.Command, args []string, provider providers.Pr
 	}
 	err := config.ValidateUserProvidedConfigPath()
 	if err != nil {
-		log.Fatal().Msg(err.Error())
+		if serr, ok := err.(*config.FileNotFoundError); ok {
+			log.Error().Err(serr).Msg("Couldn't find user provided config file")
+			log.Info().Msgf("Ensure that %s provided through %s is a valid file path", serr.Path(), serr.Source())
+			os.Exit(1)
+		}
+		log.Fatal().Err(err).Msg("Failed to load user provided config")
 	}
 	config.DisplayUsedConfig()
 

--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -391,7 +391,7 @@ func getCobraScanConfig(cmd *cobra.Command, args []string, provider providers.Pr
 	if err != nil {
 		fileNotFoundError := new(config.FileNotFoundError)
 		if errors.As(err, &fileNotFoundError) {
-			log.Fatal().Err(fileNotFoundError).Msgf(
+			log.Fatal().Msgf(
 				"Couldn't find user provided config file \n\nEnsure that %s provided through %s is a valid file path", fileNotFoundError.Path(), fileNotFoundError.Source(),
 			)
 		} else {

--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -387,6 +387,10 @@ func getCobraScanConfig(cmd *cobra.Command, args []string, provider providers.Pr
 	if optsErr != nil {
 		log.Fatal().Err(optsErr).Msg("could not load configuration")
 	}
+	err := config.ValidateConfigPath()
+	if err != nil {
+		log.Fatal().Msg(err.Error())
+	}
 	config.DisplayUsedConfig()
 
 	// display activated features

--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -387,7 +387,7 @@ func getCobraScanConfig(cmd *cobra.Command, args []string, provider providers.Pr
 	if optsErr != nil {
 		log.Fatal().Err(optsErr).Msg("could not load configuration")
 	}
-	err := config.ValidateConfigPath()
+	err := config.ValidateUserProvidedConfigPath()
 	if err != nil {
 		log.Fatal().Msg(err.Error())
 	}

--- a/apps/cnquery/cmd/shell.go
+++ b/apps/cnquery/cmd/shell.go
@@ -263,7 +263,7 @@ func GetCobraShellConfig(cmd *cobra.Command, args []string, provider providers.P
 		log.Fatal().Err(optsErr).Msg("could not load configuration")
 	}
 
-	err := config.ValidateConfigPath()
+	err := config.ValidateUserProvidedConfigPath()
 	if err != nil {
 		log.Fatal().Err(err).Msg("Could not load user provided config")
 	}

--- a/apps/cnquery/cmd/shell.go
+++ b/apps/cnquery/cmd/shell.go
@@ -265,7 +265,14 @@ func GetCobraShellConfig(cmd *cobra.Command, args []string, provider providers.P
 
 	err := config.ValidateUserProvidedConfigPath()
 	if err != nil {
-		log.Fatal().Err(err).Msg("Could not load user provided config")
+		fileNotFoundError := new(config.FileNotFoundError)
+		if errors.As(err, &fileNotFoundError) {
+			log.Fatal().Msgf(
+				"Couldn't find user provided config file \n\nEnsure that %s provided through %s is a valid file path", fileNotFoundError.Path(), fileNotFoundError.Source(),
+			)
+		} else {
+			log.Fatal().Err(err).Msg("Could not load user provided config")
+		}
 	}
 	config.DisplayUsedConfig()
 

--- a/apps/cnquery/cmd/shell.go
+++ b/apps/cnquery/cmd/shell.go
@@ -263,6 +263,10 @@ func GetCobraShellConfig(cmd *cobra.Command, args []string, provider providers.P
 		log.Fatal().Err(optsErr).Msg("could not load configuration")
 	}
 
+	err := config.ValidateConfigPath()
+	if err != nil {
+		log.Fatal().Err(err).Msg("Could not load user provided config")
+	}
 	config.DisplayUsedConfig()
 
 	conf := ShellConfig{

--- a/apps/cnquery/cmd/status.go
+++ b/apps/cnquery/cmd/status.go
@@ -45,7 +45,7 @@ Status sends a ping to Mondoo Platform to verify the credentials.
 			log.Fatal().Err(optsErr).Msg("could not load configuration")
 		}
 
-		err := config.ValidateConfigPath()
+		err := config.ValidateUserProvidedConfigPath()
 		if err != nil {
 			log.Fatal().Err(err).Msg("Could not load user provided config")
 		}

--- a/apps/cnquery/cmd/status.go
+++ b/apps/cnquery/cmd/status.go
@@ -45,6 +45,10 @@ Status sends a ping to Mondoo Platform to verify the credentials.
 			log.Fatal().Err(optsErr).Msg("could not load configuration")
 		}
 
+		err := config.ValidateConfigPath()
+		if err != nil {
+			log.Fatal().Err(err).Msg("Could not load user provided config")
+		}
 		config.DisplayUsedConfig()
 
 		s := Status{

--- a/apps/cnquery/cmd/status.go
+++ b/apps/cnquery/cmd/status.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"strings"
 	"time"
@@ -47,7 +48,14 @@ Status sends a ping to Mondoo Platform to verify the credentials.
 
 		err := config.ValidateUserProvidedConfigPath()
 		if err != nil {
-			log.Fatal().Err(err).Msg("Could not load user provided config")
+			fileNotFoundError := new(config.FileNotFoundError)
+			if errors.As(err, &fileNotFoundError) {
+				log.Fatal().Msgf(
+					"Couldn't find user provided config file \n\nEnsure that %s provided through %s is a valid file path", fileNotFoundError.Path(), fileNotFoundError.Source(),
+				)
+			} else {
+				log.Fatal().Err(err).Msg("Could not load user provided config")
+			}
 		}
 		config.DisplayUsedConfig()
 

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -241,7 +241,7 @@ func DisplayUsedConfig() {
 	}
 }
 
-func ValidateConfigPath() error {
+func ValidateUserProvidedConfigPath() error {
 	configPath := os.Getenv(configSourcePath)
 	if !LoadedConfig && len(UserProvidedPath) > 0 {
 		_, err := os.Stat(UserProvidedPath)

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -97,7 +97,7 @@ func Test_inventoryPath(t *testing.T) {
 	assert.True(t, ok)
 }
 
-func Test_ValidateConfigPath(t *testing.T) {
+func Test_ValidateUserProvidedConfigPath(t *testing.T) {
 	type test struct {
 		testUserProvidedPath string
 		testMondooConfigPath string
@@ -141,7 +141,7 @@ func Test_ValidateConfigPath(t *testing.T) {
 		LoadedConfig = tc.loadedConfig
 		UserProvidedPath = tc.testUserProvidedPath
 		t.Setenv("MONDOO_CONFIG_PATH", tc.testMondooConfigPath)
-		err := ValidateConfigPath()
+		err := ValidateUserProvidedConfigPath()
 		if tc.shouldFail {
 			assert.Error(t, err)
 		} else {

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -96,3 +96,56 @@ func Test_inventoryPath(t *testing.T) {
 	assert.Equal(t, systemInventory, path)
 	assert.True(t, ok)
 }
+
+func Test_ValidateConfigPath(t *testing.T) {
+	type test struct {
+		testUserProvidedPath string
+		testMondooConfigPath string
+		loadedConfig         bool
+		shouldFail           bool
+	}
+	tests := []test{
+		{
+			testUserProvidedPath: "/does/not/exist",
+			testMondooConfigPath: "",
+			loadedConfig:         false,
+			shouldFail:           true,
+		},
+		{
+			testUserProvidedPath: "",
+			testMondooConfigPath: "/does/not/exist",
+			loadedConfig:         false,
+			shouldFail:           true,
+		},
+		{
+			testUserProvidedPath: "/does/not/exist",
+			testMondooConfigPath: "/does/not/exist",
+			loadedConfig:         false,
+			shouldFail:           true,
+		},
+		{
+			testUserProvidedPath: "",
+			testMondooConfigPath: "",
+			loadedConfig:         false,
+			shouldFail:           false,
+		},
+		{
+			testUserProvidedPath: "",
+			testMondooConfigPath: "",
+			loadedConfig:         true,
+			shouldFail:           false,
+		},
+	}
+
+	for _, tc := range tests {
+		LoadedConfig = tc.loadedConfig
+		UserProvidedPath = tc.testUserProvidedPath
+		t.Setenv("MONDOO_CONFIG_PATH", tc.testMondooConfigPath)
+		err := ValidateConfigPath()
+		if tc.shouldFail {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}


### PR DESCRIPTION
closes #1056

New behavior: 
![image](https://github.com/mondoohq/cnquery/assets/38843153/53361c06-9ca6-4de4-83b2-b5d1f9245053)

I believe that if the user provides the `--config` flag he does not want us to run the scan without his config if we can't find the file, so it makes sense to just fail here and let the user fix his command.