### PR TITLE
:bug: Fix display config when using MONDOO_CONFIG_PATH

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -37,6 +37,7 @@ var (
 )
 
 const configSourceBase64 = "$MONDOO_CONFIG_BASE64"
+const configSourcePath = "$MONDOO_CONFIG_PATH"
 
 // Init initializes and loads the mondoo config
 func Init(rootCmd *cobra.Command) {
@@ -166,7 +167,7 @@ func initConfig() {
 		viper.ReadConfig(bytes.NewBuffer(decodedData))
 	} else if len(Path) == 0 && len(os.Getenv("MONDOO_CONFIG_PATH")) > 0 {
 		// fallback to env variable if provided, but only if --config is not used
-		Source = "$MONDOO_CONFIG_PATH"
+		Source = configSourcePath
 		Path = os.Getenv("MONDOO_CONFIG_PATH")
 	} else if len(Path) != 0 {
 		Source = "--config"
@@ -232,6 +233,8 @@ func DisplayUsedConfig() {
 		log.Warn().Msg("could not load configuration file " + UserProvidedPath)
 	} else if LoadedConfig {
 		log.Info().Msg("loaded configuration from " + viper.ConfigFileUsed() + " using source " + Source)
+	} else if Source == configSourcePath {
+		log.Info().Msg("loaded configuration from environment using source " + Source)
 	} else if Source == configSourceBase64 {
 		log.Info().Msg("loaded configuration from environment using source " + Source)
 	} else {


### PR DESCRIPTION
While working on #1246   I noticed that `DisplayUsedConfig` would not work with `$MONDOO_CONFIG_PATH` - this PR fixes that.

Previous behavior:
![image](https://github.com/mondoohq/cnquery/assets/38843153/ce8ba973-dafb-4f2a-b783-8bf9f6581e87)


New behavior:
![image](https://github.com/mondoohq/cnquery/assets/38843153/bd66c55f-e8be-421e-80e1-9ce02a44436f)


Note that this shows as successful no matter if the path for `MONDOO_CONFIG_PATH` is a valid one. The same is already true for `MONDOO_CONFIG_BASE64` can also be set to e.g. "bogus" and it will say it loaded it just fine.
So I think it's fine to for now and I'll continue working on validation improvements in #1246 