### PR TITLE
✨ parse.time auto-detect multiple formats

### DIFF
--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: "1.20"
           cache: false
           
       - name: Log in to the Container registry

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.20
           cache: false
           
       - name: Log in to the Container registry

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: "1.20"
           cache: false
 
       - name: 'Authenticate to Google Cloud'

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.20
           cache: false
 
       - name: 'Authenticate to Google Cloud'

--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -9,7 +9,7 @@ on:
       - '**.go'
 
 env:
-  GO_VERSION: 1.19
+  GO_VERSION: 1.20
   PROTO_VERSION: 21.7
 
 jobs:

--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -9,8 +9,8 @@ on:
       - '**.go'
 
 env:
-  GO_VERSION: 1.20
-  PROTO_VERSION: 21.7
+  GO_VERSION: "1.20"
+  PROTO_VERSION: "21.7"
 
 jobs:
   # Check if there is any dirty change for generated files

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -9,7 +9,7 @@ on:
       - 'go.sum'
 
 env:
-  GO_VERSION: 1.20
+  GO_VERSION: "1.20"
 
 jobs:
   # Check if there is any dirty change for go mod tidy

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -9,7 +9,7 @@ on:
       - 'go.sum'
 
 env:
-  GO_VERSION: 1.19
+  GO_VERSION: 1.20
 
 jobs:
   # Check if there is any dirty change for go mod tidy

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,7 +6,7 @@
 
 Before building from source, be sure to install:
 
-- [Go 1.19.0+](https://golang.org/dl/)
+- [Go 1.20.0+](https://golang.org/dl/)
 - [Protocol Buffers v21+](https://github.com/protocolbuffers/protobuf/releases)
 
 On macOS systems with Homebrew, run: `brew install go@1.19 protobuf`

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.mondoo.com/cnquery
 
-go 1.19
+go 1.20
 
 require (
 	cloud.google.com/go/accessapproval v1.5.0

--- a/mqlc/builtin_resource.go
+++ b/mqlc/builtin_resource.go
@@ -3,7 +3,7 @@ package mqlc
 import (
 	"strconv"
 
-	"github.com/cockroachdb/errors"
+	"github.com/pkg/errors"
 	"go.mondoo.com/cnquery/llx"
 	"go.mondoo.com/cnquery/mqlc/parser"
 	"go.mondoo.com/cnquery/resources"

--- a/resources/packs/core/core.lr
+++ b/resources/packs/core/core.lr
@@ -196,7 +196,7 @@ groups {
 // Parse provides common parsers (json, ini, certs, etc)
 parse {
   // Builtin functions:
-  // Date(value, format) time
+  // date(value, format) time
 }
 
 // Date and time functions


### PR DESCRIPTION
After: https://github.com/mondoohq/cnquery/pull/1255

It is now possible to call `parse.time` with many different formats (other than the default RFC3339). cnquery will try to auto-detect what it is.

Here are a few examples using the new calls:

```coffee
# RFC 3339
parse.date("2006-01-02T15:04:05Z")

# Simple Date + Time
parse.date("2006-01-02 15:04:05")

# Date only
parse.date("2006-01-02")

# Time only, parses as a duration
parse.date("15:04:05")

# RFC 1123
parse.date("Mon, 02 Jan 2006 15:04:05 MST")

# ANSIC
parse.date("Mon Jan 2 15:04:05 2006")

# RFC 822
parse.date("02 Jan 06 15:04 MST")

# RFC 850
parse.date("Monday, 02-Jan-06 15:04:05 MST")

# Kitchen time
parse.date("3:04PM")

# Handy timestamp
parse.date("Jan 2 15:04:05")
```

Additionally, timezones can be specified with numeric values for RFC1123
and RFC822:

```coffee
# RFC 1123 with numeric timezone
parse.date('Mon, 02 Jan 2006 15:04:05 -0700')

# RFC 822 with numeric timezone
parse.date('02 Jan 06 15:04 -0700')
```
