### PR TITLE
🦘 bump to go v1.20

### DIFF
--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: "1.20"
           cache: false
           
       - name: Log in to the Container registry

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: ">=1.20.4"
           cache: false
           
       - name: Log in to the Container registry

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.20
           cache: false
           
       - name: Log in to the Container registry

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: ">=1.20.4"
           cache: false
 
       - name: 'Authenticate to Google Cloud'

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: "1.20"
           cache: false
 
       - name: 'Authenticate to Google Cloud'

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.20
           cache: false
 
       - name: 'Authenticate to Google Cloud'

--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -9,7 +9,7 @@ on:
       - '**.go'
 
 env:
-  GO_VERSION: 1.19
+  GO_VERSION: 1.20
   PROTO_VERSION: 21.7
 
 jobs:

--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -9,8 +9,8 @@ on:
       - '**.go'
 
 env:
-  GO_VERSION: 1.20
-  PROTO_VERSION: 21.7
+  GO_VERSION: "1.20"
+  PROTO_VERSION: "21.7"
 
 jobs:
   # Check if there is any dirty change for generated files

--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -9,7 +9,7 @@ on:
       - '**.go'
 
 env:
-  GO_VERSION: "1.20"
+  GO_VERSION: ">=1.20.4"
   PROTO_VERSION: "21.7"
 
 jobs:

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -9,7 +9,7 @@ on:
       - 'go.sum'
 
 env:
-  GO_VERSION: "1.20"
+  GO_VERSION: ">=1.20.4"
 
 jobs:
   # Check if there is any dirty change for go mod tidy

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -9,7 +9,7 @@ on:
       - 'go.sum'
 
 env:
-  GO_VERSION: 1.20
+  GO_VERSION: "1.20"
 
 jobs:
   # Check if there is any dirty change for go mod tidy

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -9,7 +9,7 @@ on:
       - 'go.sum'
 
 env:
-  GO_VERSION: 1.19
+  GO_VERSION: 1.20
 
 jobs:
   # Check if there is any dirty change for go mod tidy

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,7 +6,7 @@
 
 Before building from source, be sure to install:
 
-- [Go 1.19.0+](https://golang.org/dl/)
+- [Go 1.20.0+](https://golang.org/dl/)
 - [Protocol Buffers v21+](https://github.com/protocolbuffers/protobuf/releases)
 
 On macOS systems with Homebrew, run: `brew install go@1.19 protobuf`

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.mondoo.com/cnquery
 
-go 1.19
+go 1.20
 
 require (
 	cloud.google.com/go/accessapproval v1.5.0


### PR DESCRIPTION
Check if we can have all the blockers removed for letting this run on OSX, which seems to have been the blocker the last time we tried to bump it.

Also: YAML is hard :grin:  I replaced every version that was set as a number with an explicit string, otherwise it tries to pull go v1.2 (instead of v1.20)