### PR TITLE
:bug: fix --context option ignored in cnspec

### DIFF
--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -288,6 +288,13 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 		} else if includeNamespaces != "" {
 			connection.Options["namespaces"] = includeNamespaces
 		}
+
+		if targetContext, err := cmd.Flags().GetString("context"); err != nil {
+			log.Fatal().Err(err).Msg("cannot parse --context values")
+		} else if targetContext != "" {
+			connection.Options["context"] = targetContext
+		}
+
 	case providers.ProviderType_AWS:
 		connection.Backend = providerType
 		if profile, err := cmd.Flags().GetString("profile"); err != nil {
@@ -301,6 +308,7 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 		} else if region != "" {
 			connection.Options["region"] = region
 		}
+
 	case providers.ProviderType_AWS_EC2_EBS:
 		noSetup := "false"
 		if connection.Options[awsec2ebs.NoSetup] != "" {

--- a/motor/providers/k8s/api_provider.go
+++ b/motor/providers/k8s/api_provider.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/util/homedir"
 )
 
-func newApiProvider(namespace string, objectKind string, selectedResourceID string, dCache *resources.DiscoveryCache) (KubernetesProvider, error) {
+func newApiProvider(context string, namespace string, objectKind string, selectedResourceID string, dCache *resources.DiscoveryCache) (KubernetesProvider, error) {
 	// check if the user .kube/config file exists
 	// NOTE: BuildConfigFromFlags falls back to cluster loading when .kube/config string is empty
 	// therefore we want to only change the kubeconfig string when the file really exists
@@ -47,7 +47,7 @@ func newApiProvider(namespace string, objectKind string, selectedResourceID stri
 		}
 	}
 
-	config, err := buildConfigFromFlags("", kubeconfig)
+	config, err := buildConfigFromFlags("", kubeconfig, context)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func newApiProvider(namespace string, objectKind string, selectedResourceID stri
 
 // buildConfigFromFlags we rebuild clientcmd.BuildConfigFromFlags to make sure we do not log warnings for every
 // scan.
-func buildConfigFromFlags(masterUrl, kubeconfigPath string) (*restclient.Config, error) {
+func buildConfigFromFlags(masterUrl, kubeconfigPath string, context string) (*restclient.Config, error) {
 	if kubeconfigPath == "" && masterUrl == "" {
 		kubeconfig, err := restclient.InClusterConfig()
 		if err == nil {
@@ -90,7 +90,7 @@ func buildConfigFromFlags(masterUrl, kubeconfigPath string) (*restclient.Config,
 	}
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath},
-		&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: masterUrl}}).ClientConfig()
+		&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: masterUrl}, CurrentContext: context}).ClientConfig()
 }
 
 type apiProvider struct {

--- a/motor/providers/k8s/provider.go
+++ b/motor/providers/k8s/provider.go
@@ -23,6 +23,7 @@ const (
 	OPTION_NAMESPACE   = "namespace"
 	OPTION_ADMISSION   = "k8s-admission-review"
 	OPTION_OBJECT_KIND = "object-kind"
+	OPTION_CONTEXT     = "context"
 )
 
 var (
@@ -103,7 +104,7 @@ func New(ctx context.Context, tc *providers.Config) (KubernetesProvider, error) 
 		return nil, fmt.Errorf("context does not have an initialized discovery cache")
 	}
 
-	return newApiProvider(tc.Options[OPTION_NAMESPACE], tc.Options[OPTION_OBJECT_KIND], tc.PlatformId, dCache)
+	return newApiProvider(tc.Options[OPTION_CONTEXT], tc.Options[OPTION_NAMESPACE], tc.Options[OPTION_OBJECT_KIND], tc.PlatformId, dCache)
 }
 
 func getPlatformInfo(objectKind string, runtime string) *platform.Platform {


### PR DESCRIPTION
Closes https://github.com/mondoohq/cnspec/issues/593

Working example of the `--context` flag
![image](https://github.com/mondoohq/cnquery/assets/38843153/1dc5ed25-2d0a-43ad-a487-95c07d06a75b)


If the flag is not provided it still falls back to the default cluster
![image](https://github.com/mondoohq/cnquery/assets/38843153/97b6beb6-7d34-4f50-8c2a-f24df7dc5d50)



