### PR TITLE
🐛 fix tf resource panic (check type of hcl key)

### DIFF
--- a/resources/packs/terraform/hcl.go
+++ b/resources/packs/terraform/hcl.go
@@ -391,7 +391,7 @@ func getCtyValue(expr hcl.Expression, ctx *hcl.EvalContext) interface{} {
 		for _, o := range t.Items {
 			key := getCtyValue(o.KeyExpr, ctx)
 			value := getCtyValue(o.ValueExpr, ctx)
-			keyString := key.(string)
+			keyString := GetKeyString(key)
 			result[keyString] = value
 		}
 		return result
@@ -404,6 +404,21 @@ func getCtyValue(expr hcl.Expression, ctx *hcl.EvalContext) interface{} {
 	default:
 		log.Warn().Msgf("unknown type %T", t)
 		return nil
+	}
+}
+
+func GetKeyString(key interface{}) string {
+	switch v := key.(type) {
+	case []string:
+		return strings.Join(v, ",")
+	case []interface{}:
+		s := ""
+		for i := range v {
+			s = s + v[i].(string)
+		}
+		return s
+	default:
+		return key.(string)
 	}
 }
 

--- a/resources/packs/terraform/hcl_test.go
+++ b/resources/packs/terraform/hcl_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/resources/packs/terraform"
 )
 
 const (
@@ -69,4 +70,10 @@ func TestModuleWithoutResources_Terraform(t *testing.T) {
 		assert.Empty(t, res[0].Result().Error)
 		assert.Equal(t, nil, res[0].Data.Value)
 	})
+}
+
+func TestKeyString(t *testing.T) {
+	require.Equal(t, "keytest", terraform.GetKeyString("keytest"))
+	require.Equal(t, "key,thing", terraform.GetKeyString([]string{"key", "thing"}))
+	require.Equal(t, "keything", terraform.GetKeyString([]interface{}{"key", "thing"}))
 }


### PR DESCRIPTION
fixes https://github.com/mondoohq/cnspec/issues/599

```
cnquery> terraform.blocks { * }
terraform.blocks: [
  0: {
    end: terraform.fileposition id = file.position//Users/vj/test.tf/1/1
    labels: []
    arguments: {
      blah: {
        test-random_string.rando.id: {
          type: "something"
        }
      }
    }
    snippet: "     1 | locals {
     2 |   blah = {
     3 |     \"test-${random_string.rando.id}\" = {
     4 |       type = \"something\"
"
    type: "locals"
    blocks: []
    attributes: {
      blah: {
        type: "any"
        value: {
          test-random_string.rando.id: {
            type: "something"
          }
        }
      }
    }


```