### PR TITLE
:broom: remove unused pager and no-pager arguments

### DIFF
--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -301,8 +301,8 @@ This example connects to Microsoft 365 using the PEM formatted certificate:
 		// output rendering
 		cmd.Flags().StringP("output", "o", "compact", "Set output format: "+reporter.AllFormats())
 		cmd.Flags().BoolP("json", "j", false, "Set output to JSON (shorthand).")
-		cmd.Flags().Bool("no-pager", false, "Disable interactive scan output pagination.")
-		cmd.Flags().String("pager", "", "Enable scan output pagination with custom pagination command (default 'less -R').")
+		//cmd.Flags().Bool("no-pager", false, "Disable interactive scan output pagination.")
+		//cmd.Flags().String("pager", "", "Enable scan output pagination with custom pagination command (default 'less -R').")
 	},
 	CommonPreRun: func(cmd *cobra.Command, args []string) {
 		// multiple assets mapping
@@ -323,8 +323,8 @@ This example connects to Microsoft 365 using the PEM formatted certificate:
 
 		viper.BindPFlag("output", cmd.Flags().Lookup("output"))
 		// the logic is that noPager takes precedence over pager if both are sent
-		viper.BindPFlag("no_pager", cmd.Flags().Lookup("no-pager"))
-		viper.BindPFlag("pager", cmd.Flags().Lookup("pager"))
+		//viper.BindPFlag("no_pager", cmd.Flags().Lookup("no-pager"))
+		//viper.BindPFlag("pager", cmd.Flags().Lookup("pager"))
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
 		// Special handling for users that want to see what output options are


### PR DESCRIPTION
I belive that `--pager` and `--no-pager` arguments are currently not having any effect, I was not able to make them work, neither on cnquery nor on cnspec.

I found that there was some effort to introduce paging in https://github.com/mondoohq/cnquery/pull/279 but that code is still not used anywhere. So I think we should remove these flags until we have a proper implementation. 

I left these commented out since I belive this feature is still planned.

See also: https://github.com/mondoohq/cnspec/issues/602

If these flags are indeed used somewhere please let me know