### PR TITLE
⚡ reduce # of lines printed in shell

### DIFF
--- a/cli/shell/shell.go
+++ b/cli/shell/shell.go
@@ -25,6 +25,7 @@ import (
 	"go.mondoo.com/cnquery/resources"
 	"go.mondoo.com/cnquery/resources/packs/all"
 	"go.mondoo.com/cnquery/sortx"
+	"go.mondoo.com/cnquery/stringx"
 	"go.mondoo.com/cnquery/types"
 )
 
@@ -68,6 +69,7 @@ type Shell struct {
 	Theme       *theme.Theme
 	History     []string
 	HistoryPath string
+	MaxLines    int
 
 	completer       *Completer
 	alreadyPrinted  *sync.Map
@@ -85,6 +87,7 @@ func New(backend *motor.Motor, opts ...ShellOption) (*Shell, error) {
 		alreadyPrinted: &sync.Map{},
 		out:            os.Stdout,
 		features:       cnquery.DefaultFeatures,
+		MaxLines:       1024,
 	}
 
 	res.Registry = all.Registry
@@ -327,6 +330,11 @@ func (s *Shell) RunOnce(cmd string) (*llx.CodeBundle, map[string]*llx.RawResult,
 
 func (s *Shell) PrintResults(code *llx.CodeBundle, results map[string]*llx.RawResult) {
 	printedResult := s.Theme.PolicyPrinter.Results(code, results)
+
+	if s.MaxLines > 0 {
+		printedResult = stringx.MaxLines(s.MaxLines, printedResult)
+	}
+
 	fmt.Fprint(s.out, "\r")
 	fmt.Fprintln(s.out, printedResult)
 }


### PR DESCRIPTION
When running soemthing in shell that generates thousands of lines of output, the shell will block and take a long time to process (and pipe) all the output to STDOUT. We can't speed up STDOUT a lot, but we can make sure we don't push an insane amount of data to it, that would slow it down.

With this change we are introducing a maximum number of lines. The 1k lines is the default that many CLI shells come with. This is a ton of entries, even if we block-extract 8 fields, accounting for 2 extra lines per block, we would be able to display 100 items. This is a very sane amount for a regular REPL environment.

We will make this configurable again down the line. Feedback is very welcome!

For now, it will stop the shell from almost locking up when a ton of lines/items are extracted.