### PR TITLE
🐛 Fix memory usage when scanning large images

### DIFF
--- a/motor/discovery/docker_engine/container.go
+++ b/motor/discovery/docker_engine/container.go
@@ -85,6 +85,8 @@ type ImageInfo struct {
 	PlatformID string
 	Labels     map[string]string
 	Arch       string
+	// Size in megabytes
+	Size int64
 }
 
 func (e *dockerEngineDiscovery) ImageInfo(name string) (ImageInfo, error) {
@@ -103,6 +105,8 @@ func (e *dockerEngineDiscovery) ImageInfo(name string) (ImageInfo, error) {
 	case "amd64":
 		ii.Arch = "x86_64"
 	}
+
+	ii.Size = res.Size / 1024 / 1024
 
 	labels := map[string]string{}
 	labels["mondoo.com/image-id"] = res.ID

--- a/motor/providers/container/image/docker.go
+++ b/motor/providers/container/image/docker.go
@@ -35,7 +35,8 @@ func (r ShaReference) Scope(scope string) string {
 }
 
 func LoadImageFromDockerEngine(sha string) (v1.Image, io.ReadCloser, error) {
-	img, err := daemon.Image(&ShaReference{SHA: strings.Replace(sha, "sha256:", "", -1)})
+	opts := []daemon.Option{daemon.WithUnbufferedOpener()}
+	img, err := daemon.Image(&ShaReference{SHA: strings.Replace(sha, "sha256:", "", -1)}, opts...)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
This fix prevents a copy of the image in memory. But that has a performance impact.