### PR TITLE
🐛 Fix error messages for `.none()` queries

### DIFF
--- a/cli/printer/printer_test.go
+++ b/cli/printer/printer_test.go
@@ -308,6 +308,25 @@ func TestPrinter_Assessment(t *testing.T) {
 			}, "\n"),
 		},
 		{
+			"users.list.duplicates(gid).none()\n",
+			strings.Join([]string{
+				"[failed] [].none()",
+				"  actual:   [",
+				"    0: user {",
+				"      name: \"christopher\"",
+				"      gid: 1001",
+				"      uid: 1000",
+				"    }",
+				"    1: user {",
+				"      name: \"chris\"",
+				"      gid: 1001",
+				"      uid: 1000",
+				"    }",
+				"  ]",
+				"",
+			}, "\n"),
+		},
+		{
 			"users.all( uid < 1000 )\n",
 			strings.Join([]string{
 				"[failed] users.all()",

--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -1713,8 +1713,10 @@ func (c *compiler) addValueFieldChunks(ref uint64) {
 	for {
 		chunk := c.Result.CodeV2.Chunk(ref)
 		if chunk.Function == nil {
-			// this is a safe guard and shouldn't happen
-			log.Error().Msg("failed to find where function for assessment")
+			// this is a safe guard for some cases
+			// e.g. queries with .none() are totally valid and will not have a where block,
+			// because they do not check a specific field
+			log.Debug().Msg("failed to find where function for assessment, this can happen with empty assessments")
 			return
 		}
 		if chunk.Id == "$whereNot" || chunk.Id == "where" {


### PR DESCRIPTION
Queries like `users.list.duplicates(uid).none()` produced the error message `failed to find where function for assessment`. These errors were wrong.

In cases where no field is checked for the assessment, there is no `where` function