### PR TITLE
🐛 where/contains/... + vars

### DIFF
--- a/mqlc/builtin_map.go
+++ b/mqlc/builtin_map.go
@@ -37,10 +37,22 @@ func compileDictWhere(c *compiler, typ types.Type, ref uint64, id string, call *
 	})
 
 	blockCompiler.addArgumentPlaceholder(keyType, bindingChecksum)
-	blockCompiler.vars.add("key", variable{ref: blockCompiler.tailRef(), typ: keyType})
+	blockCompiler.vars.add("key", variable{
+		ref: blockCompiler.tailRef(),
+		typ: keyType,
+		callback: func() {
+			blockCompiler.standalone = false
+		},
+	})
 
 	blockCompiler.addArgumentPlaceholder(valueType, bindingChecksum)
-	blockCompiler.vars.add("value", variable{ref: blockCompiler.tailRef(), typ: valueType})
+	blockCompiler.vars.add("value", variable{
+		ref: blockCompiler.tailRef(),
+		typ: valueType,
+		callback: func() {
+			blockCompiler.standalone = false
+		},
+	})
 
 	// we want to make sure the `_` points to the value, which is useful when dealing
 	// with arrays and the default in maps
@@ -397,10 +409,22 @@ func compileMapWhere(c *compiler, typ types.Type, ref uint64, id string, call *p
 	})
 
 	blockCompiler.addArgumentPlaceholder(keyType, bindingChecksum)
-	blockCompiler.vars.add("key", variable{ref: blockCompiler.tailRef(), typ: keyType})
+	blockCompiler.vars.add("key", variable{
+		ref: blockCompiler.tailRef(),
+		typ: keyType,
+		callback: func() {
+			blockCompiler.standalone = false
+		},
+	})
 
 	blockCompiler.addArgumentPlaceholder(valueType, bindingChecksum)
-	blockCompiler.vars.add("value", variable{ref: blockCompiler.tailRef(), typ: valueType})
+	blockCompiler.vars.add("value", variable{
+		ref: blockCompiler.tailRef(),
+		typ: valueType,
+		callback: func() {
+			blockCompiler.standalone = false
+		},
+	})
 
 	// we want to make sure the `_` points to the value, which is useful when dealing
 	// with arrays and the default in maps

--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -1239,7 +1239,6 @@ func (c *compiler) compileIdentifier(id string, callBinding *variable, calls []*
 			Call:      llx.Chunk_PRIMITIVE,
 			Primitive: llx.RefPrimitiveV2(variable.ref),
 		})
-		c.standalone = false
 		checksum := c.Result.CodeV2.Checksums[c.tailRef()]
 		c.Result.Labels.Labels[checksum] = variable.name
 		return restCalls, variable.typ, nil

--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -21,9 +21,14 @@ import (
 )
 
 type variable struct {
-	name     string
-	ref      uint64
-	typ      types.Type
+	name string
+	ref  uint64
+	typ  types.Type
+	// callback is run when the variable is used by the compiler.
+	// This is particularly useful when dealing with pre-defined
+	// variables which may or may not be used in the actual code
+	// (like `key` and `value`). One use-case is to tell the
+	// block compiler that its bound value has been used.
 	callback func()
 }
 

--- a/resources/packs/core/core_test.go
+++ b/resources/packs/core/core_test.go
@@ -871,6 +871,10 @@ func TestArray(t *testing.T) {
 			[]interface{}{"yo"},
 		},
 		{
+			"x = ['a','b']; y = 'c'; x.contains(y)",
+			1, false,
+		},
+		{
 			"[1,2,3].contains(_ >= 2)",
 			1, true,
 		},
@@ -1056,6 +1060,16 @@ func TestListResource(t *testing.T) {
 		{
 			"users.map(name)",
 			0, []interface{}([]interface{}{"root", "chris", "christopher", "chris", "bin"}),
+		},
+		{
+			// outside variables cause the block to be standalone
+			"n=false; users.contains(n)",
+			1, false,
+		},
+		{
+			// variables do not override local fields in blocks
+			"name=false; users.contains(name)",
+			1, true,
 		},
 	})
 }


### PR DESCRIPTION
... was incorrectly interpreted as a non-standalone block. That is wrong. The `standalone` attribute in compilers referes to the contents of the compiler not to reference its bindings, i.e. everything in the expressions to stand on their own (or said differently: the expressions to be standalone). We had a bug where standalone was set to `false` when variables were used. The use of vars does not make something non-standalone. Only the values inside of vars can do that, which are handled in their assignment.

Example:

```
allowed_roles = ["roles/owner", "roles/editor", "roles/viewer"]
role = "roles/owner2"
allowed_roles.contains(role)
```

Since `role` is not in allowed roles, this should fail. Before, this was interpreted incorrectly and returned true. This bug is now fixed.