### PR TITLE
✨ string.contains(regex)

### DIFF
--- a/llx/builtin.go
+++ b/llx/builtin.go
@@ -303,6 +303,8 @@ func init() {
 			string("contains" + types.Array(types.String)): {f: stringContainsArrayStringV2, Label: "contains"},
 			string("contains" + types.Int):                 {f: stringContainsIntV2, Label: "contains"},
 			string("contains" + types.Array(types.Int)):    {f: stringContainsArrayIntV2, Label: "contains"},
+			string("contains" + types.Regex):               {f: stringContainsRegex, Label: "contains"},
+			string("contains" + types.Array(types.Regex)):  {f: stringContainsArrayRegex, Label: "contains"},
 			string("find"):      {f: stringFindV2, Label: "find"},
 			string("camelcase"): {f: stringCamelcaseV2, Label: "camelcase"},
 			string("downcase"):  {f: stringDowncaseV2, Label: "downcase"},
@@ -510,6 +512,8 @@ func init() {
 			string("contains" + types.Array(types.String)): {f: dictContainsArrayStringV2, Label: "contains"},
 			string("contains" + types.Int):                 {f: dictContainsIntV2, Label: "contains"},
 			string("contains" + types.Array(types.Int)):    {f: dictContainsArrayIntV2, Label: "contains"},
+			string("contains" + types.Regex):               {f: dictContainsRegex, Label: "contains"},
+			string("contains" + types.Array(types.Regex)):  {f: dictContainsArrayRegex, Label: "contains"},
 			string("find"): {f: dictFindV2, Label: "find"},
 			// NOTE: the following functions are internal ONLY!
 			// We have not yet decided if and how these may be exposed to users

--- a/mqlc/builtin_simple.go
+++ b/mqlc/builtin_simple.go
@@ -51,6 +51,17 @@ func compileStringContains(c *compiler, typ types.Type, ref uint64, id string, c
 			},
 		})
 		return types.Bool, nil
+	case types.Regex:
+		c.addChunk(&llx.Chunk{
+			Call: llx.Chunk_FUNCTION,
+			Id:   "contains" + string(types.Regex),
+			Function: &llx.Function{
+				Type:    string(types.Bool),
+				Binding: ref,
+				Args:    []*llx.Primitive{val},
+			},
+		})
+		return types.Bool, nil
 	case types.Array(types.String):
 		c.addChunk(&llx.Chunk{
 			Call: llx.Chunk_FUNCTION,
@@ -66,6 +77,17 @@ func compileStringContains(c *compiler, typ types.Type, ref uint64, id string, c
 		c.addChunk(&llx.Chunk{
 			Call: llx.Chunk_FUNCTION,
 			Id:   "contains" + string(types.Array(types.Int)),
+			Function: &llx.Function{
+				Type:    string(types.Bool),
+				Binding: ref,
+				Args:    []*llx.Primitive{val},
+			},
+		})
+		return types.Bool, nil
+	case types.Array(types.Regex):
+		c.addChunk(&llx.Chunk{
+			Call: llx.Chunk_FUNCTION,
+			Id:   "contains" + string(types.Array(types.Regex)),
 			Function: &llx.Function{
 				Type:    string(types.Bool),
 				Binding: ref,

--- a/resources/packs/core/core_test.go
+++ b/resources/packs/core/core_test.go
@@ -502,6 +502,22 @@ func TestString_Methods(t *testing.T) {
 			0, true,
 		},
 		{
+			"'hello'.contains(/l+/)",
+			0, true,
+		},
+		{
+			"'hello'.contains(/l$/)",
+			0, false,
+		},
+		{
+			"'hello'.contains([/^l/, /l$/])",
+			0, false,
+		},
+		{
+			"'hello'.contains([/z/, /ll/])",
+			0, true,
+		},
+		{
 			"'oh-hello-world!'.camelcase",
 			0, "ohHelloWorld!",
 		},


### PR DESCRIPTION
**AFTER https://github.com/mondoohq/cnquery/pull/1279**
Feel free to remove the `DRAFT` from the title once the above PR is merged!

... and a handful of derivates like string.contains([]regex), dict.contains(regex) and dict.contains([]regex).
    
Now you 

```
"hello world".contains(/wor.d/)
```
    
Please note: if the regex has beginning or end conditions (i.e. `^` or `$`) these will be respected by `contains`, i.e. it will not magically remove these.
    
We are introducing this operation to deprecated the old approach of `x == regex` with v9. It currently leads to very misleading results with e.g. `1.2.3.4abc == regex.ipv4` returning `true`.
    
Signed-off-by: Dominik Richter <dominik.richter@gmail.com>
