### PR TITLE
✨ array.flat

### DIFF
--- a/llx/builtin.go
+++ b/llx/builtin.go
@@ -533,6 +533,7 @@ func init() {
 			"$any":                   {f: arrayAnyV2},
 			"$one":                   {f: arrayOneV2},
 			"map":                    {f: arrayMapV2},
+			"flat":                   {f: arrayFlat},
 			"duplicates":             {f: arrayDuplicatesV2},
 			"fieldDuplicates":        {f: arrayFieldDuplicatesV2},
 			"unique":                 {f: arrayUniqueV2},

--- a/mqlc/builtin.go
+++ b/mqlc/builtin.go
@@ -94,6 +94,7 @@ func init() {
 			"one":          {compile: compileArrayOne, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
 			"none":         {compile: compileArrayNone, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
 			"map":          {compile: compileArrayMap, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
+			"flat":         {typ: childType, signature: FunctionSignature{}},
 		},
 		types.MapLike: {
 			"[]":     {typ: childType, signature: FunctionSignature{Required: 1, Args: []types.Type{types.String}}},

--- a/resources/packs/core/core_test.go
+++ b/resources/packs/core/core_test.go
@@ -916,6 +916,11 @@ func TestArray(t *testing.T) {
 			[]interface{}{int64(1), int64(2)},
 		},
 		{
+			"[[0],[[1, 2]], 3].flat",
+			0,
+			[]interface{}{int64(0), int64(1), int64(2), int64(3)},
+		},
+		{
 			"[0].where(_ > 0).where(_ > 0)",
 			0,
 			[]interface{}{},


### PR DESCRIPTION
for flat mapping arrays:

```
> [[0],[[1, 2]], 3].flat
[0,1,2,3]
```

Type detection still needs some work.