### PR TITLE
🐛 Fix memory usage when scanning large images

### DIFF
--- a/apps/cnquery/cmd/builder/common/common.go
+++ b/apps/cnquery/cmd/builder/common/common.go
@@ -171,14 +171,18 @@ func ContainerProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, r
 
 func ContainerImageProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "image ID",
-		Short:  docs.GetShort("container-image"),
-		Long:   docs.GetLong("container-image"),
-		Args:   cobra.ExactArgs(1),
-		PreRun: preRun,
-		Run:    runFn,
+		Use:   "image ID",
+		Short: docs.GetShort("container-image"),
+		Long:  docs.GetLong("container-image"),
+		Args:  cobra.ExactArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			preRun(cmd, args)
+			viper.BindPFlag("disable-cache", cmd.Flags().Lookup("disable-cache"))
+		},
+		Run: runFn,
 	}
 	commonCmdFlags(cmd)
+	cmd.Flags().Bool("disable-cache", false, "Disable the in-memory cache for images. WARNING: This will slow down scans significantly.")
 	return cmd
 }
 
@@ -256,14 +260,18 @@ func DockerContainerProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRu
 
 func DockerImageProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "image ID",
-		Short:  docs.GetShort("docker-image"),
-		Long:   docs.GetLong("docker-image"),
-		Args:   cobra.ExactArgs(1),
-		PreRun: preRun,
-		Run:    runFn,
+		Use:   "image ID",
+		Short: docs.GetShort("docker-image"),
+		Long:  docs.GetLong("docker-image"),
+		Args:  cobra.ExactArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			preRun(cmd, args)
+			viper.BindPFlag("disable-cache", cmd.Flags().Lookup("disable-cache"))
+		},
+		Run: runFn,
 	}
 	commonCmdFlags(cmd)
+	cmd.Flags().Bool("disable-cache", false, "Disable the in-memory cache for images. WARNING: This will slow down scans significantly.")
 	return cmd
 }
 

--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -230,6 +230,12 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 		connection.Backend = providerType
 		connection.Host = args[0]
 	case providers.ProviderType_DOCKER_ENGINE_IMAGE:
+		disableInMemoryCache := false
+		disableInMemoryCache, err := cmd.Flags().GetBool("disable-cache")
+		if err != nil {
+			log.Error().Err(err).Msg("cannot parse --disable-cache value")
+		}
+		connection.Options["disable-cache"] = strconv.FormatBool(disableInMemoryCache)
 		connection.Backend = providerType
 		connection.Host = args[0]
 	case providers.ProviderType_TAR:

--- a/apps/cnquery/cmd/run.go
+++ b/apps/cnquery/cmd/run.go
@@ -11,6 +11,7 @@ import (
 	"go.mondoo.com/cnquery/cli/components"
 	"go.mondoo.com/cnquery/cli/config"
 	"go.mondoo.com/cnquery/cli/inventoryloader"
+	"go.mondoo.com/cnquery/cli/prof"
 	"go.mondoo.com/cnquery/motor/discovery/common"
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/shared"
@@ -69,6 +70,7 @@ var execCmd = builder.NewProviderCommand(builder.CommandOpts{
 		viper.BindPFlag("record-file", cmd.Flags().Lookup("record-file"))
 	},
 	Run: func(cmd *cobra.Command, args []string, provider providers.ProviderType, assetType builder.AssetType) {
+		prof.InitProfiler()
 		conf, err := GetCobraRunConfig(cmd, args, provider, assetType)
 		if err != nil {
 			log.Fatal().Err(err).Msg("failed to prepare config")

--- a/motor/discovery/docker_engine/container.go
+++ b/motor/discovery/docker_engine/container.go
@@ -85,6 +85,8 @@ type ImageInfo struct {
 	PlatformID string
 	Labels     map[string]string
 	Arch       string
+	// Size in megabytes
+	Size int64
 }
 
 func (e *dockerEngineDiscovery) ImageInfo(name string) (ImageInfo, error) {
@@ -103,6 +105,8 @@ func (e *dockerEngineDiscovery) ImageInfo(name string) (ImageInfo, error) {
 	case "amd64":
 		ii.Arch = "x86_64"
 	}
+
+	ii.Size = res.Size / 1024 / 1024
 
 	labels := map[string]string{}
 	labels["mondoo.com/image-id"] = res.ID

--- a/motor/providers/container/container.go
+++ b/motor/providers/container/container.go
@@ -134,7 +134,7 @@ func NewDockerEngineImage(endpoint *providers.Config) (ContainerProvider, error)
 	// This is the image id that is used to pull the image from the registry.
 	log.Debug().Msg("found docker engine image " + labelImageId)
 	if ii.Size > 1024 && !disableInmemoryCache { // > 1GB
-		log.Warn().Int64("size", ii.Size).Msg("The image is bigger than 1GB, this will require a lot of memory. Consider disabling the in-memory cache with `--disable-cache=true`.")
+		log.Warn().Int64("size", ii.Size).Msg("Because the image is larger than 1 GB, this task will require a lot of memory. Consider disabling the in-memory cache by adding this flag to the command: `--disable-cache=true`")
 	}
 	_, rc, err := image.LoadImageFromDockerEngine(ii.ID, disableInmemoryCache)
 	if err != nil {

--- a/motor/providers/container/image/docker.go
+++ b/motor/providers/container/image/docker.go
@@ -34,8 +34,12 @@ func (r ShaReference) Scope(scope string) string {
 	return ""
 }
 
-func LoadImageFromDockerEngine(sha string) (v1.Image, io.ReadCloser, error) {
-	img, err := daemon.Image(&ShaReference{SHA: strings.Replace(sha, "sha256:", "", -1)})
+func LoadImageFromDockerEngine(sha string, disableBuffer bool) (v1.Image, io.ReadCloser, error) {
+	opts := []daemon.Option{}
+	if disableBuffer {
+		opts = append(opts, daemon.WithUnbufferedOpener())
+	}
+	img, err := daemon.Image(&ShaReference{SHA: strings.Replace(sha, "sha256:", "", -1)}, opts...)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
This fix prevents a copy of the image in memory. But that has a performance impact.