### PR TITLE
🐛 fix map values correct type

### DIFF
--- a/llx/builtin_map.go
+++ b/llx/builtin_map.go
@@ -177,9 +177,11 @@ func mapKeysV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawD
 }
 
 func mapValuesV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
+	typ := bind.Type.Child()
+
 	if bind.Value == nil {
 		return &RawData{
-			Type:  types.Array(types.Dict),
+			Type:  types.Array(typ),
 			Error: errors.New("Failed to get values of `null`"),
 		}, 0, nil
 	}
@@ -196,7 +198,7 @@ func mapValuesV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*Ra
 		i++
 	}
 
-	return ArrayData(res, types.Dict), 0, nil
+	return ArrayData(res, typ), 0, nil
 }
 
 func dictGetIndexV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {

--- a/mqlc/builtin.go
+++ b/mqlc/builtin.go
@@ -94,7 +94,7 @@ func init() {
 			"one":          {compile: compileArrayOne, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
 			"none":         {compile: compileArrayNone, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
 			"map":          {compile: compileArrayMap, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
-			"flat":         {typ: childType, signature: FunctionSignature{}},
+			"flat":         {compile: compileArrayFlat, signature: FunctionSignature{}},
 		},
 		types.MapLike: {
 			"[]":     {typ: childType, signature: FunctionSignature{Required: 1, Args: []types.Type{types.String}}},
@@ -102,7 +102,7 @@ func init() {
 			"length": {typ: intType, signature: FunctionSignature{}},
 			"where":  {compile: compileMapWhere, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
 			"keys":   {typ: stringArrayType, signature: FunctionSignature{}},
-			"values": {typ: dictArrayType, signature: FunctionSignature{}},
+			"values": {compile: compileMapValues, signature: FunctionSignature{}},
 		},
 		types.ResourceLike: {
 			// "":       compileHandler{compile: compileResourceDefault},

--- a/mqlc/builtin_array.go
+++ b/mqlc/builtin_array.go
@@ -488,3 +488,24 @@ func compileArrayMap(c *compiler, typ types.Type, ref uint64, id string, call *p
 	})
 	return types.Array(mappedType), nil
 }
+
+func compileArrayFlat(c *compiler, typ types.Type, ref uint64, id string, call *parser.Call) (types.Type, error) {
+	if call != nil && len(call.Function) > 0 {
+		return types.Nil, errors.New("no arguments supported for '" + id + "'")
+	}
+
+	for typ.IsArray() {
+		typ = typ.Child()
+	}
+	typ = types.Array(typ)
+
+	c.addChunk(&llx.Chunk{
+		Call: llx.Chunk_FUNCTION,
+		Id:   id,
+		Function: &llx.Function{
+			Type:    string(typ),
+			Binding: ref,
+		},
+	})
+	return typ, nil
+}

--- a/mqlc/builtin_map.go
+++ b/mqlc/builtin_map.go
@@ -460,3 +460,16 @@ func compileMapWhere(c *compiler, typ types.Type, ref uint64, id string, call *p
 	})
 	return typ, nil
 }
+
+func compileMapValues(c *compiler, typ types.Type, ref uint64, id string, call *parser.Call) (types.Type, error) {
+	typ = types.Array(typ.Child())
+	c.addChunk(&llx.Chunk{
+		Call: llx.Chunk_FUNCTION,
+		Id:   id,
+		Function: &llx.Function{
+			Type:    string(typ),
+			Binding: ref,
+		},
+	})
+	return typ, nil
+}


### PR DESCRIPTION
Now you can call this and get the right results:

```coffee
> pam.conf.entries.values.flat{*}
pam.conf.entries.values.flat: [
  0: {
    options: []
    control: "sufficient"
    module: "pam_rootok.so"
    pamType: "auth"
    lineNumber: 1
    service: "/etc/pam.d/chsh"
  },
  ...
]
```