### PR TITLE
🐛 fix piped kubernetes manifests

### DIFF
--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -1,7 +1,9 @@
 package builder
 
 import (
+	"encoding/base64"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"regexp"
@@ -270,8 +272,16 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 	case providers.ProviderType_K8S:
 		connection.Backend = providerType
 
-		if filepath != "" {
-			if _, err := os.Stat(filepath); filepath != "-" && os.IsNotExist(err) {
+		// do pre-processing of piped manifest file
+		// TODO: consider using an afero.NewMemMapFs() in-memory file system instead of base64 encoding
+		if filepath == "-" {
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				log.Fatal().Err(err).Msg("cannot read Kubernetes manifest from stdin")
+			}
+			connection.Options["manifest-content"] = base64.StdEncoding.EncodeToString(data)
+		} else if filepath != "" {
+			if _, err := os.Stat(filepath); os.IsNotExist(err) {
 				log.Fatal().Str("file", filepath).Msg("Could not find the Kubernetes manifest file. Please specify the correct path.")
 			}
 			connection.Options["path"] = filepath

--- a/motor/discovery/k8s/resolver_cluster.go
+++ b/motor/discovery/k8s/resolver_cluster.go
@@ -102,7 +102,7 @@ func (r *ClusterResolver) Resolve(ctx context.Context, root *asset.Asset, tc *pr
 		} else {
 			clusterName = ""
 
-			if tc.Options[k8s.OPTION_MANIFEST] != "" || tc.Options[k8s.OPTION_ADMISSION] != "" {
+			if tc.Options[k8s.OPTION_MANIFEST] != "" || tc.Options[k8s.OPTION_ADMISSION] != "" || tc.Options[k8s.OPTION_IMMEMORY_CONTENT] != "" {
 				clusterName, _ = p.Name()
 			} else {
 				// try to parse context from kubectl config

--- a/motor/providers/k8s/manifest_provider.go
+++ b/motor/providers/k8s/manifest_provider.go
@@ -27,67 +27,88 @@ import (
 type Option func(*manifestProvider)
 
 func WithNamespace(namespace string) Option {
-	return func(t *manifestProvider) {
-		t.namespace = namespace
+	return func(p *manifestProvider) {
+		p.namespace = namespace
 	}
 }
 
 func WithManifestFile(filename string) Option {
-	return func(t *manifestProvider) {
-		t.manifestFile = filename
+	return func(p *manifestProvider) {
+		p.manifestFile = filename
+	}
+}
+
+func WithManifestContent(data []byte) Option {
+	return func(p *manifestProvider) {
+		p.manifestContent = data
 	}
 }
 
 func newManifestProvider(selectedResourceID string, objectKind string, opts ...Option) (KubernetesProvider, error) {
-	t := &manifestProvider{
+	p := &manifestProvider{
 		objectKind: objectKind,
 	}
 
 	for _, option := range opts {
-		option(t)
+		option(p)
 	}
 
-	manifest, err := loadManifestFile(t.manifestFile)
+	manifest := []byte{}
+	var err error
+
+	if len(p.manifestContent) > 0 {
+		manifest = p.manifestContent
+		p.assetName = "K8s Manifest"
+	} else if p.manifestFile != "" {
+		manifest, err = loadManifestFile(p.manifestFile)
+		if err != nil {
+			return nil, err
+		}
+		// manifest parent directory name
+		clusterName := common.ProjectNameFromPath(p.manifestFile)
+		clusterName = "K8s Manifest " + clusterName
+		p.assetName = clusterName
+	}
+
+	p.manifestParser, err = newManifestParser(manifest, p.namespace, selectedResourceID)
 	if err != nil {
 		return nil, err
 	}
-	t.manifestParser, err = newManifestParser(manifest, t.namespace, selectedResourceID)
-	if err != nil {
-		return nil, err
-	}
 
-	t.selectedResourceID = selectedResourceID
-	return t, nil
+	p.selectedResourceID = selectedResourceID
+	return p, nil
 }
 
 type manifestProvider struct {
 	manifestParser
+	assetName          string
 	manifestFile       string
+	manifestContent    []byte
 	namespace          string
 	selectedResourceID string
 	objectKind         string
 }
 
-func (t *manifestProvider) RunCommand(command string) (*os_provider.Command, error) {
+func (p *manifestProvider) RunCommand(command string) (*os_provider.Command, error) {
 	return nil, errors.New("k8s does not implement RunCommand")
 }
 
-func (t *manifestProvider) FileInfo(path string) (os_provider.FileInfoDetails, error) {
+func (p *manifestProvider) FileInfo(path string) (os_provider.FileInfoDetails, error) {
 	return os_provider.FileInfoDetails{}, errors.New("k8s does not implement FileInfo")
 }
 
-func (t *manifestProvider) FS() afero.Fs {
+func (p *manifestProvider) FS() afero.Fs {
 	return &fsutil.NoFs{}
 }
 
-func (t *manifestProvider) Close() {}
+func (p *manifestProvider) Close() {}
 
-func (t *manifestProvider) Capabilities() providers.Capabilities {
+func (p *manifestProvider) Capabilities() providers.Capabilities {
 	return providers.Capabilities{}
 }
 
-func (t *manifestProvider) PlatformInfo() *platform.Platform {
-	platformData := getPlatformInfo(t.objectKind, t.Runtime())
+func (p *manifestProvider) PlatformInfo() *platform.Platform {
+	platformData := getPlatformInfo(p.objectKind, p.Runtime())
 	if platformData != nil {
 		return platformData
 	}
@@ -95,43 +116,43 @@ func (t *manifestProvider) PlatformInfo() *platform.Platform {
 	return &platform.Platform{
 		Name:    "k8s-manifest",
 		Title:   "Kubernetes Manifest",
-		Kind:    t.Kind(),
+		Kind:    p.Kind(),
 		Family:  []string{"k8s"},
-		Runtime: t.Runtime(),
+		Runtime: p.Runtime(),
 	}
 }
 
-func (t *manifestProvider) Kind() providers.Kind {
+func (p *manifestProvider) Kind() providers.Kind {
 	return providers.Kind_KIND_CODE
 }
 
-func (t *manifestProvider) Runtime() string {
+func (p *manifestProvider) Runtime() string {
 	return providers.RUNTIME_KUBERNETES_MANIFEST
 }
 
-func (t *manifestProvider) PlatformIdDetectors() []providers.PlatformIdDetector {
+func (p *manifestProvider) PlatformIdDetectors() []providers.PlatformIdDetector {
 	return []providers.PlatformIdDetector{
 		providers.TransportPlatformIdentifierDetector,
 	}
 }
 
-func (t *manifestProvider) ServerVersion() *version.Info {
+func (p *manifestProvider) ServerVersion() *version.Info {
 	return nil
 }
 
-func (t *manifestProvider) SupportedResourceTypes() (*resources.ApiResourceIndex, error) {
-	return t.manifestParser.SupportedResourceTypes()
+func (p *manifestProvider) SupportedResourceTypes() (*resources.ApiResourceIndex, error) {
+	return p.manifestParser.SupportedResourceTypes()
 }
 
-func (t *manifestProvider) ID() (string, error) {
+func (p *manifestProvider) ID() (string, error) {
 	// If we are doing an admission control scan, we have 1 resource in the manifest and it has a UID.
 	// Instead of using the file path to generate the ID, use the resource UID. We do this because for
 	// CI/CD scans, the manifest is stored in a random file. This means we can potentially be scanning
 	// the same resource multiple times but it will result in different assets because of the random
 	// file name.
 
-	if len(t.objects) == 1 {
-		o, err := meta.Accessor(t.objects[0])
+	if len(p.objects) == 1 {
+		o, err := meta.Accessor(p.objects[0])
 		if err == nil {
 			if o.GetUID() != "" {
 				return string(o.GetUID()), nil
@@ -140,31 +161,33 @@ func (t *manifestProvider) ID() (string, error) {
 	}
 
 	h := sha256.New()
-	if t.manifestFile == "-" {
+
+	// special handling for embedded content (e.g. piped in via stdin)
+	if len(p.manifestContent) > 0 {
 		h.Write([]byte("stdin"))
 		return hex.EncodeToString(h.Sum(nil)), nil
 	}
 
-	_, err := os.Stat(t.manifestFile)
+	_, err := os.Stat(p.manifestFile)
 	if err != nil {
-		return "", errors.Wrap(err, "could not determine platform identifier for "+t.manifestFile)
+		return "", errors.Wrap(err, "could not determine platform identifier for "+p.manifestFile)
 	}
 
-	absPath, err := filepath.Abs(t.manifestFile)
+	absPath, err := filepath.Abs(p.manifestFile)
 	if err != nil {
-		return "", errors.Wrap(err, "could not determine platform identifier for "+t.manifestFile)
+		return "", errors.Wrap(err, "could not determine platform identifier for "+p.manifestFile)
 	}
 
 	h.Write([]byte(absPath))
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
-func (t *manifestProvider) Identifier() (string, error) {
-	if t.selectedResourceID != "" {
-		return t.selectedResourceID, nil
+func (p *manifestProvider) Identifier() (string, error) {
+	if p.selectedResourceID != "" {
+		return p.selectedResourceID, nil
 	}
 
-	uid, err := t.ID()
+	uid, err := p.ID()
 	if err != nil {
 		return "", err
 	}
@@ -172,79 +195,72 @@ func (t *manifestProvider) Identifier() (string, error) {
 	return NewPlatformID(uid), nil
 }
 
-func (t *manifestProvider) Name() (string, error) {
-	// manifest parent directory name
-	clusterName := common.ProjectNameFromPath(t.manifestFile)
-	clusterName = "K8s Manifest " + clusterName
-	return clusterName, nil
+func (p *manifestProvider) Name() (string, error) {
+	return p.assetName, nil
 }
 
-func (t *manifestProvider) AdmissionReviews() ([]admissionv1.AdmissionReview, error) {
+func (p *manifestProvider) AdmissionReviews() ([]admissionv1.AdmissionReview, error) {
 	return []admissionv1.AdmissionReview{}, nil
 }
 
 func loadManifestFile(manifestFile string) ([]byte, error) {
+	log.Debug().Str("filename", manifestFile).Msg("loading manifest file")
 	var input io.Reader
 
-	// if content is piped
-	if manifestFile == "-" {
-		input = os.Stdin
-	} else {
-		// return all resources from manifest
-		filenames := []string{}
+	// return all resources from manifest
+	filenames := []string{}
 
-		fi, err := os.Stat(manifestFile)
-		if err != nil {
-			return nil, err
-		}
+	fi, err := os.Stat(manifestFile)
+	if err != nil {
+		return nil, err
+	}
 
-		if fi.IsDir() {
-			yamlDecoder := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
-			filepath.WalkDir(manifestFile, func(path string, d fs.DirEntry, err error) error {
+	if fi.IsDir() {
+		yamlDecoder := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+		filepath.WalkDir(manifestFile, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			// only load yaml files for now
+			if !d.IsDir() {
+				ext := filepath.Ext(path)
+				if ext != ".yaml" && ext != ".yml" {
+					log.Debug().Str("file", path).Msg("ignore file, no .yaml or .yml ending")
+					return nil
+				}
+				// check whether this is valid k8s yaml
+				content, err := os.ReadFile(path)
 				if err != nil {
-					return err
+					log.Debug().Str("file", path).Err(err).Msg("ignore file, could not read file")
+					return nil
 				}
-
-				// only load yaml files for now
-				if !d.IsDir() {
-					ext := filepath.Ext(path)
-					if ext != ".yaml" && ext != ".yml" {
-						log.Debug().Str("file", path).Msg("ignore file, no .yaml or .yml ending")
-						return nil
+				// At this point, we do not care about specific schemes, just whether the file is a valid k8s yaml
+				_, _, err = yamlDecoder.Decode(content, nil, nil)
+				if err != nil {
+					// the err contains the file content, which is not useful in the output
+					errorString := ""
+					if len(err.Error()) > 40 {
+						errorString = err.Error()[:40] + "..."
+					} else {
+						errorString = err.Error()
 					}
-					// check whether this is valid k8s yaml
-					content, err := os.ReadFile(path)
-					if err != nil {
-						log.Debug().Str("file", path).Err(err).Msg("ignore file, could not read file")
-						return nil
-					}
-					// At this point, we do not care about specific schemes, just whether the file is a valid k8s yaml
-					_, _, err = yamlDecoder.Decode(content, nil, nil)
-					if err != nil {
-						// the err contains the file content, which is not useful in the output
-						errorString := ""
-						if len(err.Error()) > 40 {
-							errorString = err.Error()[:40] + "..."
-						} else {
-							errorString = err.Error()
-						}
-						log.Debug().Str("file", path).Str("error", errorString).Msg("ignore file, no valid kubernetes yaml")
-						return nil
-					}
-					log.Debug().Str("file", path).Msg("add file to manifest loading")
-					filenames = append(filenames, path)
+					log.Debug().Str("file", path).Str("error", errorString).Msg("ignore file, no valid kubernetes yaml")
+					return nil
 				}
+				log.Debug().Str("file", path).Msg("add file to manifest loading")
+				filenames = append(filenames, path)
+			}
 
-				return nil
-			})
-		} else {
-			filenames = append(filenames, manifestFile)
-		}
+			return nil
+		})
+	} else {
+		filenames = append(filenames, manifestFile)
+	}
 
-		input, err = resources.MergeManifestFiles(filenames)
-		if err != nil {
-			return nil, err
-		}
+	input, err = resources.MergeManifestFiles(filenames)
+	if err != nil {
+		return nil, err
 	}
 
 	return io.ReadAll(input)

--- a/motor/providers/k8s/provider.go
+++ b/motor/providers/k8s/provider.go
@@ -99,7 +99,6 @@ func New(ctx context.Context, pc *providers.Config) (KubernetesProvider, error) 
 		if err != nil {
 			return nil, err
 		}
-		println(string(data))
 		return newManifestProvider(pc.PlatformId, pc.Options[OPTION_OBJECT_KIND], WithManifestContent(data), WithNamespace(pc.Options[OPTION_NAMESPACE]))
 	}
 


### PR DESCRIPTION
fixes https://github.com/mondoohq/cnspec/issues/622

The initial implementation https://github.com/mondoohq/cnquery/pull/1213 was reading data from stdin directly inside of the provider. This does not work well for manifest files with multiple entries since the discovery splits them up into multiple scans. You can read from stdin only once.

In general I think it is best practice do avoid doing cli / terminal handling inside of the provider. Therefore this PR moves this logic to the cli to read the file. The initial version used a temporary file on disk. Problem with temporary files is that someone has to clean up the file after everything is complete. In case of a manifest file, multiple provider instances are created and it would require additional logic to handle the close down. Instead I opted for the version that reads the file and attaches the data into the provider options. I think this is only a temporary solution. Similar to MQL resources, we should introduce a provider cache where arbitrary data can be stored. Once that exists, we could use an in-memory file system and share that. The current implementation is a step in between.