### PR TITLE
✨Add support for passing in OCI provider params via the CLI.

### DIFF
--- a/apps/cnquery/cmd/builder/common/common.go
+++ b/apps/cnquery/cmd/builder/common/common.go
@@ -529,14 +529,18 @@ func OciProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn R
 		Args:  cobra.ExactArgs(0),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			preRun(cmd, args)
-			// viper.BindPFlag("project", cmd.Flags().Lookup("project"))
-			// viper.BindPFlag("region", cmd.Flags().Lookup("region"))
 		},
 		Run: runFn,
 	}
 	commonCmdFlags(cmd)
-	// cmd.Flags().String("profile", "", "pick a named AWS profile to use")
-	// cmd.Flags().String("region", "", "the AWS region to scan")
+	cmd.Flags().String("tenancy", "", "The tenancy's OCID")
+	cmd.Flags().String("user", "", "The user's OCID")
+	cmd.Flags().String("region", "", "The selected region")
+	cmd.Flags().String("key-path", "", "The path to the private key, that will be used for authentication")
+	cmd.Flags().String("fingerprint", "", "The fingerprint of the private key")
+	cmd.Flags().String("key-secret", "", "The passphrase for private key, that will be used for authentication")
+	// either we require all of the params, needed to build an OCI connection or we default to using the default provider there
+	cmd.MarkFlagsRequiredTogether("tenancy", "user", "region", "key-path", "fingerprint")
 	return cmd
 }
 

--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -480,17 +480,34 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 		}
 	case providers.ProviderType_OCI:
 		connection.Backend = providerType
-		//if profile, err := cmd.Flags().GetString("profile"); err != nil {
-		//	log.Fatal().Err(err).Msg("cannot parse --profile value")
-		//} else if profile != "" {
-		//	connection.Options["profile"] = profile
-		//}
-		//
-		//if region, err := cmd.Flags().GetString("region"); err != nil {
-		//	log.Fatal().Err(err).Msg("cannot parse --region values")
-		//} else if region != "" {
-		//	connection.Options["region"] = region
-		//}
+		tenancy, _ := cmd.Flags().GetString("tenancy")
+		fingerprint, _ := cmd.Flags().GetString("fingerprint")
+		user, _ := cmd.Flags().GetString("user")
+		keyPath, _ := cmd.Flags().GetString("key-path")
+		keyPassphrase, _ := cmd.Flags().GetString("key-passphrase")
+		region, _ := cmd.Flags().GetString("region")
+
+		if tenancy != "" {
+			connection.Options["tenancy"] = tenancy
+		}
+		if fingerprint != "" {
+			connection.Options["fingerprint"] = fingerprint
+		}
+		if region != "" {
+			connection.Options["region"] = region
+		}
+		if user != "" {
+			connection.Options["user"] = user
+		}
+
+		if keyPath != "" {
+			connection.Credentials = append(connection.Credentials, &vault.Credential{
+				Type:           vault.CredentialType_private_key,
+				PrivateKeyPath: keyPath,
+				Password:       keyPassphrase,
+			})
+		}
+
 	case providers.ProviderType_VSPHERE:
 		connection.Backend = providerType
 		target, err := parseTarget(args[0])

--- a/motor/providers/oci/provider.go
+++ b/motor/providers/oci/provider.go
@@ -1,8 +1,11 @@
 package oci
 
 import (
+	"errors"
+
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"go.mondoo.com/cnquery/motor/providers"
+	"go.mondoo.com/cnquery/motor/vault"
 )
 
 var (
@@ -11,8 +14,33 @@ var (
 )
 
 func New(pCfg *providers.Config) (*Provider, error) {
-	configProvider := common.DefaultConfigProvider()
-
+	var configProvider common.ConfigurationProvider
+	// if we have passed in credentials, assume we want to pass in all values explicitly.
+	if len(pCfg.Credentials) > 0 {
+		fingerprint := pCfg.Options["fingerprint"]
+		if fingerprint == "" {
+			return nil, errors.New("OCI provider fingerprint value cannot be empty")
+		}
+		tenancyOcid := pCfg.Options["tenancy"]
+		if tenancyOcid == "" {
+			return nil, errors.New("OCI provider tenancy value cannot be empty")
+		}
+		userOcid := pCfg.Options["user"]
+		if userOcid == "" {
+			return nil, errors.New("OCI provider user value cannot be empty")
+		}
+		region := pCfg.Options["region"]
+		if region == "" {
+			return nil, errors.New("OCI provider region value cannot be empty")
+		}
+		pkey := pCfg.Credentials[0]
+		if pkey.Type != vault.CredentialType_private_key {
+			return nil, errors.New("OCI provider does not support credential type: " + pkey.Type.String())
+		}
+		configProvider = common.NewRawConfigurationProvider(tenancyOcid, userOcid, region, fingerprint, string(pkey.Secret), nil)
+	} else {
+		configProvider = common.DefaultConfigProvider()
+	}
 	tenancyOcid, err := configProvider.TenancyOCID()
 	if err != nil {
 		return nil, err
@@ -20,8 +48,7 @@ func New(pCfg *providers.Config) (*Provider, error) {
 
 	t := &Provider{
 		// opts:   pCfg.Options,
-		config: configProvider,
-
+		config:      configProvider,
 		tenancyOcid: tenancyOcid,
 	}
 


### PR DESCRIPTION
Extends support for opening a shell to an OCI instance by letting the user specify all the required params via the CLI. Also makes it possible that we use an inventory file to perform OCI scanning.

```
cnquery shell oci
```
will use the default provider, reading default config files and env vars

```
cnquery shell oci --tenancy ocid1.tenancy..--user ocid1.. --region "us-ashburn-1" --fingerprint aa:aa:aa:aa...--key-path ~/.oci/private.pem
```

All of `tenancy`, `user`, `region`, `fingerprint` and `key-path` values are required if trying to establish a connection via the CLI params.
