### PR TITLE
⭐️ add support for GCP snapshot scanning

### DIFF
--- a/apps/cnquery/cmd/builder/builder.go
+++ b/apps/cnquery/cmd/builder/builder.go
@@ -25,6 +25,7 @@ const (
 	GcpOrganizationAssetType
 	GcpProjectAssetType
 	GcpFolderAssetType
+	GcpComputeInstanceAssetType
 	GcpComputeInstanceSnapshotAssetType
 	GcrContainerRegistryAssetType
 	GithubOrganizationAssetType
@@ -131,6 +132,7 @@ func buildCmd(baseCmd *cobra.Command, commonCmdFlags common.CommonFlagsFn, preRu
 	gcpCmd.AddCommand(scanGcpProjectCmd(commonCmdFlags, preRun, runFn, docs))
 	gcpCmd.AddCommand(scanGcpFolderCmd(commonCmdFlags, preRun, runFn, docs))
 	gcpCmd.AddCommand(scanGcpComputeInstanceCmd(commonCmdFlags, preRun, runFn, docs))
+	gcpCmd.AddCommand(scanGcpComputeSnapshotCmd(commonCmdFlags, preRun, runFn, docs))
 
 	// oci subcommand
 	ociCmd := ociProviderCmd(commonCmdFlags, preRun, runFn, docs)
@@ -426,10 +428,19 @@ func scanGcpGcrCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreR
 
 func scanGcpComputeInstanceCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
 	wrapRunFn := func(cmd *cobra.Command, args []string) {
-		runFn(cmd, args, providers.ProviderType_GCP_COMPUTE_INSTANCE_SNAPSHOT, GcpComputeInstanceSnapshotAssetType)
+		runFn(cmd, args, providers.ProviderType_GCP_COMPUTE_INSTANCE_SNAPSHOT, GcpComputeInstanceAssetType)
 	}
 
 	cmd := common.ScanGcpComputeInstanceCmd(commonCmdFlags, preRun, wrapRunFn, docs)
+	return cmd
+}
+
+func scanGcpComputeSnapshotCmd(commonCmdFlags common.CommonFlagsFn, preRun common.CommonPreRunFn, runFn runFn, docs common.CommandsDocs) *cobra.Command {
+	wrapRunFn := func(cmd *cobra.Command, args []string) {
+		runFn(cmd, args, providers.ProviderType_GCP_COMPUTE_INSTANCE_SNAPSHOT, GcpComputeInstanceSnapshotAssetType)
+	}
+
+	cmd := common.ScanGcpComputeSnapshotCmd(commonCmdFlags, preRun, wrapRunFn, docs)
 	return cmd
 }
 

--- a/apps/cnquery/cmd/builder/common/common.go
+++ b/apps/cnquery/cmd/builder/common/common.go
@@ -508,6 +508,27 @@ func ScanGcpComputeInstanceCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRun
 	return cmd
 }
 
+func ScanGcpComputeSnapshotCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "snapshot INSTANCE-NAME",
+		Short: docs.GetShort("gcp-compute-instance"),
+		Long:  docs.GetLong("gcp-compute-instance"),
+		Args:  cobra.ExactArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			preRun(cmd, args)
+			viper.BindPFlag("project-id", cmd.Flags().Lookup("project-id"))
+			viper.BindPFlag("zone", cmd.Flags().Lookup("zone"))
+			viper.BindPFlag("credentials-path", cmd.Flags().Lookup("credentials-path"))
+		},
+		Run: runFn,
+	}
+	commonCmdFlags(cmd)
+	cmd.Flags().String("project-id", "", "specify the GCP project ID where the target instance is located")
+	cmd.Flags().String("zone", "", "specify the GCP zone where the target instance is located")
+	cmd.Flags().String("credentials-path", "", "The path to the service account credentials to access the APIs with")
+	return cmd
+}
+
 func ScanGcpFolderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "folder FOLDER-ID",

--- a/apps/cnquery/cmd/builder/common/common.go
+++ b/apps/cnquery/cmd/builder/common/common.go
@@ -510,9 +510,9 @@ func ScanGcpComputeInstanceCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRun
 
 func ScanGcpComputeSnapshotCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn RunFn, docs CommandsDocs) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "snapshot INSTANCE-NAME",
-		Short: docs.GetShort("gcp-compute-instance"),
-		Long:  docs.GetLong("gcp-compute-instance"),
+		Use:   "snapshot SNAPSHOT-NAME",
+		Short: docs.GetShort("gcp-compute-snapshot"),
+		Long:  docs.GetLong("gcp-compute-snapshot"),
 		Args:  cobra.ExactArgs(1),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			preRun(cmd, args)

--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -481,9 +481,15 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 		}
 	case providers.ProviderType_GCP_COMPUTE_INSTANCE_SNAPSHOT:
 		connection.Backend = providerType
-		connection.Options = map[string]string{
-			"type":          "instance",
-			"instance-name": args[0],
+		connection.Options = map[string]string{}
+
+		switch assetType {
+		case GcpComputeInstanceAssetType:
+			connection.Options["type"] = "instance"
+			connection.Options["instance-name"] = args[0]
+		case GcpComputeInstanceSnapshotAssetType:
+			connection.Options["type"] = "snapshot"
+			connection.Options["snapshot-name"] = args[0]
 		}
 
 		if projectId, err := cmd.Flags().GetString("project-id"); err != nil {

--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -190,6 +190,9 @@ configure your Azure credentials and have SSH access to the virtual machines.`,
 			"gcp-compute-instance": {
 				Short: "Scan a Google Cloud Platform (GCP) VM instance.",
 			},
+			"gcp-compute-snapshot": {
+				Short: "Scan a Google Cloud Platform (GCP) VM snapshot.",
+			},
 			"oci": {
 				Short: "Scan a Oracle Cloud Infrastructure (OCI) tenancy.",
 			},

--- a/apps/cnquery/cmd/shell.go
+++ b/apps/cnquery/cmd/shell.go
@@ -196,6 +196,9 @@ configure your Azure credentials and have SSH access to the virtual machines.`,
 			"gcp-compute-instance": {
 				Short: "Connect to a Google Cloud Platform (GCP) VM instance.",
 			},
+			"gcp-compute-snapshot": {
+				Short: "Connect to a Google Cloud Platform (GCP) VM snapshot.",
+			},
 			"vsphere": {
 				Short: "Connect to a VMware vSphere API endpoint.",
 			},

--- a/motor/providers/gcpinstancesnapshot/platform.go
+++ b/motor/providers/gcpinstancesnapshot/platform.go
@@ -1,0 +1,5 @@
+package gcpinstancesnapshot
+
+func SnapshotPlatformMrn(project string, snapshotName string) string {
+	return "//platformid.api.mondoo.app/runtime/gcp/compute/v1/projects/" + project + "/snapshots/" + snapshotName
+}

--- a/motor/providers/gcpinstancesnapshot/snapshot.go
+++ b/motor/providers/gcpinstancesnapshot/snapshot.go
@@ -165,7 +165,7 @@ func (sc *SnapshotCreator) createDisk(disk *compute.Disk, projectID, zone, diskN
 	return clonedDiskUrl, nil
 }
 
-// snapshotDisk creates a new disk from a snapshot
+// createSnapshotDisk creates a new disk from a snapshot
 func (sc *SnapshotCreator) createSnapshotDisk(snapshotUrl, projectID, zone, diskName string) (string, error) {
 	// create a new disk from snapshot
 	disk := &compute.Disk{


### PR DESCRIPTION
follow up on https://github.com/mondoohq/cnquery/pull/1311

This change allows users to scan GCP compute snapshots directly:

```bash
cnquery shell gcp snapshot suse12 --project-id my-project-id
→ discover related assets for 1 asset(s)
→ resolved assets resolved-assets=1
→ found target volume device name=/dev/sdb3
  ___ _ __  ___ _ __   ___  ___ 
 / __| '_ \/ __| '_ \ / _ \/ __|
| (__| | | \__ \ |_) |  __/ (__ 
 \___|_| |_|___/ .__/ \___|\___|
   mondoo™     |_|              
cnspec> asset.platform
asset.platform: "sles"
cnspec> asset.version
asset.version: "12.5"
cnspec> packages
packages.list: [
  0: package name="release-notes-sles" version="12.5.20200504-3.11.1"
  1: package name="libqrencode3" version="3.4.3-1.31"
  2: package name="lifecycle-data-sle-module-toolchain" version="1-3.15.1"
  3: package name="yast2-firewall" version="3.4.0-6.3.2"
  4: package name="recode" version="3.6-663.62"
  5: package name="sle-module-legacy-release-POOL" version="12-10.10.1"
  6: package name="SuSEfirewall2" version="3.6.312.333-3.13.1"
  7: package name="gamin-server" version="0.1.10-11.19"
...
```