### PR TITLE
⭐️ allow users to use latest GCP instance snapshots instead of creating new ones

### DIFF
--- a/apps/cnquery/cmd/builder/common/common.go
+++ b/apps/cnquery/cmd/builder/common/common.go
@@ -498,6 +498,7 @@ func ScanGcpComputeInstanceCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRun
 			viper.BindPFlag("project-id", cmd.Flags().Lookup("project-id"))
 			viper.BindPFlag("zone", cmd.Flags().Lookup("zone"))
 			viper.BindPFlag("credentials-path", cmd.Flags().Lookup("credentials-path"))
+			viper.BindPFlag("use-latest-snapshot", cmd.Flags().Lookup("use-latest-snapshot"))
 		},
 		Run: runFn,
 	}
@@ -505,6 +506,7 @@ func ScanGcpComputeInstanceCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRun
 	cmd.Flags().String("project-id", "", "specify the GCP project ID where the target instance is located")
 	cmd.Flags().String("zone", "", "specify the GCP zone where the target instance is located")
 	cmd.Flags().String("credentials-path", "", "The path to the service account credentials to access the APIs with")
+	cmd.Flags().Bool("use-latest-snapshot", false, "use the latest available snapshot instead of creating a new one")
 	return cmd
 }
 

--- a/apps/cnquery/cmd/builder/common/common.go
+++ b/apps/cnquery/cmd/builder/common/common.go
@@ -498,7 +498,7 @@ func ScanGcpComputeInstanceCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRun
 			viper.BindPFlag("project-id", cmd.Flags().Lookup("project-id"))
 			viper.BindPFlag("zone", cmd.Flags().Lookup("zone"))
 			viper.BindPFlag("credentials-path", cmd.Flags().Lookup("credentials-path"))
-			viper.BindPFlag("use-latest-snapshot", cmd.Flags().Lookup("use-latest-snapshot"))
+			viper.BindPFlag("create-snapshot", cmd.Flags().Lookup("create-snapshot"))
 		},
 		Run: runFn,
 	}
@@ -506,7 +506,7 @@ func ScanGcpComputeInstanceCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRun
 	cmd.Flags().String("project-id", "", "specify the GCP project ID where the target instance is located")
 	cmd.Flags().String("zone", "", "specify the GCP zone where the target instance is located")
 	cmd.Flags().String("credentials-path", "", "The path to the service account credentials to access the APIs with")
-	cmd.Flags().Bool("use-latest-snapshot", false, "use the latest available snapshot instead of creating a new one")
+	cmd.Flags().Bool("create-snapshot", false, "create a new snapshot instead of using the latest available snapshot")
 	return cmd
 }
 

--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -487,6 +487,12 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 		case GcpComputeInstanceAssetType:
 			connection.Options["type"] = "instance"
 			connection.Options["instance-name"] = args[0]
+
+			if useLatestSnapshot, err := cmd.Flags().GetBool("use-latest-snapshot"); err != nil {
+				log.Fatal().Err(err).Msg("cannot parse --use-latest-snapshot")
+			} else if useLatestSnapshot {
+				connection.Options["use-latest-snapshot"] = "true"
+			}
 		case GcpComputeInstanceSnapshotAssetType:
 			connection.Options["type"] = "snapshot"
 			connection.Options["snapshot-name"] = args[0]

--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -488,10 +488,10 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 			connection.Options["type"] = "instance"
 			connection.Options["instance-name"] = args[0]
 
-			if useLatestSnapshot, err := cmd.Flags().GetBool("use-latest-snapshot"); err != nil {
-				log.Fatal().Err(err).Msg("cannot parse --use-latest-snapshot")
-			} else if useLatestSnapshot {
-				connection.Options["use-latest-snapshot"] = "true"
+			if createNewSnapshot, err := cmd.Flags().GetBool("create-snapshot"); err != nil {
+				log.Fatal().Err(err).Msg("cannot parse --create-snapshot")
+			} else if createNewSnapshot {
+				connection.Options["create-snapshot"] = "true"
 			}
 		case GcpComputeInstanceSnapshotAssetType:
 			connection.Options["type"] = "snapshot"

--- a/motor/providers/gcpinstancesnapshot/snapshot_debug_test.go
+++ b/motor/providers/gcpinstancesnapshot/snapshot_debug_test.go
@@ -1,0 +1,26 @@
+//go:build debugtest
+// +build debugtest
+
+package gcpinstancesnapshot
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLatestInstanceSnapshot(t *testing.T) {
+	sc, err := NewSnapshotCreator()
+	require.NoError(t, err)
+
+	projectId := "my-project-1234"
+	zone := "us-central1-a"
+	instanceName := "super-dupa-instance"
+
+	ii, err := sc.InstanceInfo(projectId, zone, instanceName)
+	require.NoError(t, err)
+	assert.Equal(t, "super-dupa-instance", ii.InstanceName)
+
+	snap, err := sc.searchLatestSnapshot(projectId, ii.BootDiskSourceURL)
+	require.NoError(t, err)
+	assert.NotNil(t, snap)
+}

--- a/motor/providers/os/snapshot/volumemounter.go
+++ b/motor/providers/os/snapshot/volumemounter.go
@@ -42,23 +42,23 @@ func (m *VolumeMounter) Mount() error {
 	if fsInfo == nil {
 		return errors.New("unable to find target volume on instance")
 	}
-	log.Info().Str("device name", fsInfo.name).Msg("found target volume")
+	log.Debug().Str("device name", fsInfo.name).Msg("found target volume")
 	return m.mountVolume(fsInfo)
 }
 
 func (m *VolumeMounter) createScanDir() error {
-	log.Info().Msg("create tmp scan dir")
 	dir, err := os.MkdirTemp("", "cnspec-scan")
 	if err != nil {
 		log.Error().Err(err).Msg("error creating directory")
 		return err
 	}
 	m.ScanDir = dir
+	log.Debug().Str("dir", dir).Msg("created tmp scan dir")
 	return nil
 }
 
 func (m *VolumeMounter) getFsInfo() (*fsInfo, error) {
-	log.Info().Msg("search for target volume")
+	log.Debug().Msg("search for target volume")
 
 	// TODO: replace with mql query once version with lsblk resource is released
 	// TODO: only use sudo if we are not root
@@ -96,7 +96,6 @@ func (m *VolumeMounter) getFsInfo() (*fsInfo, error) {
 }
 
 func (m *VolumeMounter) mountVolume(fsInfo *fsInfo) error {
-	log.Info().Msg("mount volume")
 	opts := []string{}
 	if fsInfo.fstype == "xfs" {
 		opts = append(opts, "nouuid")
@@ -107,7 +106,7 @@ func (m *VolumeMounter) mountVolume(fsInfo *fsInfo) error {
 }
 
 func (m *VolumeMounter) UnmountVolumeFromInstance() error {
-	log.Info().Msg("unmount volume")
+	log.Debug().Str("dir", m.ScanDir).Msg("unmount volume")
 	if err := Unmount(m.ScanDir); err != nil {
 		log.Error().Err(err).Msg("failed to unmount dir")
 		return err
@@ -116,6 +115,6 @@ func (m *VolumeMounter) UnmountVolumeFromInstance() error {
 }
 
 func (m *VolumeMounter) RemoveTempScanDir() error {
-	log.Info().Msg("remove created dir")
+	log.Debug().Str("dir", m.ScanDir).Msg("remove created dir")
 	return os.RemoveAll(m.ScanDir)
 }


### PR DESCRIPTION
after #1314

With this change we introduce a new flag `--use-latest-snapshot` and allow users o use existing snapshots of instances if they exist. If no snapshot exists we still fallback to create a instance disk clone.

```bash
cnspec scan gcp instance sles12 --project-id my-project-id --zone us-central1-a --use-latest-snapshot
→ no Mondoo configuration file provided. using defaults
→ discover related assets for 1 asset(s)
→ resolved assets resolved-assets=1

 sles12 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% score: C


Asset: sles12
-------------

Checks:
✕ Fail:  D  20  Ensure auditing for processes that start prior to auditd is enabled
✕ Fail:  D  20  Ensure successful file system mounts are collected
✕ Fail:  C  40  Ensure Advanced Intrusion Detection Environment (AIDE) is installed
✓ Pass:  A 100  Ensure rsh server is stopped and not enabled
✕ Fail:  F   0  Ensure secure permissions on /etc/group- are set
✓ Pass:  A 100  Ensure Avahi server is stopped and not enabled
✕ Fail:  D  20  Ensure system accounts are non-login
✓ Pass:  A 100  Ensure secure permissions on /etc/group are set
! Error:        Ensure rsyslog default file permissions configured
✓ Pass:  A 100  Ensure prelink is disabled
✓ Pass:  A 100  Ensure auditd is installed
✓ Pass:  A 100  Ensure X Window System is not installed
! Error:        Ensure access to the su command is restricted
✕ Fail:  D  20  Ensure session initiation information is collected
✕ Fail:  F   0  Ensure broadcast ICMP requests are ignored
✕ Fail:  D  20  Ensure login and logout events are collected
...
```