### PR TITLE
:broom: replace cockroachdb/errors with standard library errors

### DIFF
--- a/apps/cnquery/cmd/config/config.go
+++ b/apps/cnquery/cmd/config/config.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 	"go.mondoo.com/cnquery"
@@ -15,7 +15,7 @@ func ReadConfig() (*CliConfig, error) {
 	var opts CliConfig
 	err := viper.Unmarshal(&opts)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to decode into config struct")
+		return nil, errors.Join(err, errors.New("unable to decode into config struct"))
 	}
 
 	return &opts, nil

--- a/apps/cnquery/cmd/root.go
+++ b/apps/cnquery/cmd/root.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"

--- a/apps/cnquery/cmd/run.go
+++ b/apps/cnquery/cmd/run.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"os"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -278,7 +278,7 @@ func GetCobraRunConfig(cmd *cobra.Command, args []string, provider providers.Pro
 	flagAsset := builder.ParseTargetAsset(cmd, args, provider, assetType)
 	conf.Inventory, err = inventoryloader.ParseOrUse(flagAsset, viper.GetBool("insecure"))
 	if err != nil {
-		return nil, errors.Wrap(err, "could not load configuration")
+		return nil, errors.Join(err, errors.New("could not load configuration"))
 	}
 
 	conf.PlatformId = viper.GetString("platform-id")

--- a/apps/cnquery/cmd/shell.go
+++ b/apps/cnquery/cmd/shell.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"os"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -309,7 +309,7 @@ func GetCobraShellConfig(cmd *cobra.Command, args []string, provider providers.P
 	flagAsset := builder.ParseTargetAsset(cmd, args, provider, assetType)
 	conf.Inventory, err = inventoryloader.ParseOrUse(flagAsset, viper.GetBool("insecure"))
 	if err != nil {
-		return nil, errors.Wrap(err, "could not load configuration")
+		return nil, errors.Join(err, errors.New("could not load configuration"))
 	}
 
 	conf.PlatformID = viper.GetString("platform-id")

--- a/cli/config/aws-ssm-ps.go
+++ b/cli/config/aws-ssm-ps.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"path"
 	"regexp"
@@ -9,9 +10,10 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 
+	"errors"
+
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
-	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 )
@@ -26,12 +28,12 @@ func loadAwsSSMParameterStore(key string) error {
 	log.Info().Str("key", ssmKey).Msg("look for configuration stored in aws ssm parameter store")
 	err := viper.AddRemoteProvider("aws-ssm-ps", "localhost", ssmKey)
 	if err != nil {
-		return errors.Wrap(err, "could not initialize gs provider")
+		return errors.Join(err, errors.New("could not initialize gs provider"))
 	}
 	viper.SetConfigType("yaml")
 	err = viper.ReadRemoteConfig()
 	if err != nil {
-		return errors.Wrapf(err, "could not read aws ssm parameter config from %s", ssmKey)
+		return errors.Join(err, errors.New(fmt.Sprintf("could not read aws ssm parameter config from %s", ssmKey)))
 	}
 
 	return nil

--- a/cli/config/store.go
+++ b/cli/config/store.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
@@ -24,10 +24,10 @@ func StoreConfig() error {
 		// write file
 		err = os.WriteFile(path, []byte{}, 0o644)
 		if err != nil {
-			return errors.Wrap(err, "failed to save mondoo config")
+			return errors.Join(err, errors.New("failed to save mondoo config"))
 		}
 	} else if err != nil {
-		return errors.Wrap(err, "failed to check stats for mondoo config")
+		return errors.Join(err, errors.New("failed to check stats for mondoo config"))
 	}
 
 	return viper.WriteConfig()

--- a/cli/inventoryloader/inventory.go
+++ b/cli/inventoryloader/inventory.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 	"go.mondoo.com/cnquery/motor/asset"
@@ -141,7 +141,7 @@ func ParseOrUse(cliAsset *asset.Asset, insecure bool) (*v1.Inventory, error) {
 	// parses optional inventory file if inventory was not piped already
 	v1inventory, err = Parse()
 	if err != nil {
-		return nil, errors.Wrap(err, "could not parse inventory")
+		return nil, errors.Join(err, errors.New("could not parse inventory"))
 	}
 
 	// add asset from cli to inventory

--- a/cli/prof/prof.go
+++ b/cli/prof/prof.go
@@ -2,6 +2,7 @@
 package prof
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/pprof"
 	"os"
@@ -9,7 +10,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cockroachdb/errors"
+	"errors"
+
 	"github.com/rs/zerolog/log"
 )
 
@@ -82,7 +84,7 @@ func parseProf(profVal string) (profilerOpts, error) {
 			if val != "" {
 				i, err := strconv.Atoi(val)
 				if err != nil {
-					return opts, errors.Wrapf(err, "invalid value %q for memprofilerate", val)
+					return opts, errors.Join(err, errors.New(fmt.Sprintf("invalid value %q for memprofilerate", val)))
 				}
 				opts.MemProfileRate = &i
 			}

--- a/explorer/filters.go
+++ b/explorer/filters.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"go.mondoo.com/cnquery/checksums"
 )
 
@@ -172,7 +172,7 @@ func (s *Filters) AddQueryFiltersFn(ctx context.Context, query *Mquery, lookupQu
 		mrn := query.Variants[i].Mrn
 		variant, err := lookupQuery(ctx, mrn)
 		if err != nil {
-			return errors.Wrap(err, "cannot find query variant "+mrn)
+			return errors.Join(err, errors.New("cannot find query variant "+mrn))
 		}
 		s.AddQueryFiltersFn(ctx, variant, lookupQuery)
 	}

--- a/motor/discovery/aws/mql_asset_objects.go
+++ b/motor/discovery/aws/mql_asset_objects.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"go.mondoo.com/cnquery/motor/asset"
 	"go.mondoo.com/cnquery/motor/discovery/common"
 	"go.mondoo.com/cnquery/motor/providers"
@@ -107,7 +107,7 @@ func getTitleFamily(awsObject awsObject) (awsObjectPlatformInfo, error) {
 			return awsObjectPlatformInfo{title: "AWS ECR Image", platform: "aws-ecr-image"}, nil
 		}
 	}
-	return awsObjectPlatformInfo{}, errors.Newf("missing runtime info for aws object service %s type %s", awsObject.service, awsObject.objectType)
+	return awsObjectPlatformInfo{}, errors.New(fmt.Sprintf("missing runtime info for aws object service %s type %s", awsObject.service, awsObject.objectType))
 }
 
 func s3Buckets(m *MqlDiscovery, account string, tc *providers.Config) ([]*asset.Asset, error) {

--- a/motor/discovery/aws/resolver.go
+++ b/motor/discovery/aws/resolver.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/motor/asset"
 	"go.mondoo.com/cnquery/motor/discovery/common"
@@ -156,14 +156,14 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 		// create a map to track the platform ids of the ssm instances, to avoid duplication of assets
 		s, err := NewSSMManagedInstancesDiscovery(mqldiscovery, tc.Clone(), info.ID)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not initialize aws ec2 ssm discovery")
+			return nil, errors.Join(err, errors.New("could not initialize aws ec2 ssm discovery"))
 		}
 		s.FilterOptions = AssembleEc2InstancesFilters(discoverFilter)
 		s.profile = tc.Options["profile"]
 		s.PassInLabels = root.Labels
 		assetList, err := s.List()
 		if err != nil {
-			return nil, errors.Wrap(err, "could not fetch ec2 ssm instances")
+			return nil, errors.Join(err, errors.New("could not fetch ec2 ssm instances"))
 		}
 		log.Debug().Int("instances", len(assetList)).Msg("completed ssm instance search")
 		for i := range assetList {
@@ -179,7 +179,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 	if tc.IncludesOneOfDiscoveryTarget(common.DiscoveryAll, DiscoveryInstances) {
 		e, err := NewEc2Discovery(mqldiscovery, tc.Clone(), info.ID)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not initialize aws ec2 discovery")
+			return nil, errors.Join(err, errors.New("could not initialize aws ec2 discovery"))
 		}
 
 		e.Insecure = tc.Insecure
@@ -188,7 +188,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 		e.PassInLabels = root.Labels
 		assetList, err := e.List()
 		if err != nil {
-			return nil, errors.Wrap(err, "could not fetch ec2 instances")
+			return nil, errors.Join(err, errors.New("could not fetch ec2 instances"))
 		}
 		log.Debug().Int("instances", len(assetList)).Bool("insecure", e.Insecure).Msg("completed instance search")
 		for i := range assetList {
@@ -219,14 +219,14 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 	if tc.IncludesOneOfDiscoveryTarget(common.DiscoveryAll, DiscoveryECR) {
 		i, err := NewEcrDiscovery(mqldiscovery, tc.Clone(), info.ID)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not initialize aws ecr discovery")
+			return nil, errors.Join(err, errors.New("could not initialize aws ecr discovery"))
 		}
 
 		i.profile = tc.Options["profile"]
 		i.PassInLabels = root.Labels
 		assetList, err := i.List()
 		if err != nil {
-			return nil, errors.Wrap(err, "could not fetch ecr repositories information")
+			return nil, errors.Join(err, errors.New("could not fetch ecr repositories information"))
 		}
 		log.Debug().Int("images", len(assetList)).Msg("completed ecr search")
 		for i := range assetList {
@@ -241,12 +241,12 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, tc *providers
 	if tc.IncludesOneOfDiscoveryTarget(common.DiscoveryAll, DiscoveryECS) {
 		c, err := NewECSContainersDiscovery(mqldiscovery, tc.Clone(), info.ID)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not initialize aws ecs discovery")
+			return nil, errors.Join(err, errors.New("could not initialize aws ecs discovery"))
 		}
 		c.PassInLabels = root.Labels
 		assetList, err := c.List()
 		if err != nil {
-			return nil, errors.Wrap(err, "could not fetch ecs clusters information")
+			return nil, errors.Join(err, errors.New("could not fetch ecs clusters information"))
 		}
 		log.Debug().Int("assets", len(assetList)).Msg("completed ecs search")
 		for i := range assetList {

--- a/motor/discovery/azure/mql_asset_objects.go
+++ b/motor/discovery/azure/mql_asset_objects.go
@@ -1,7 +1,9 @@
 package azure
 
 import (
-	"github.com/cockroachdb/errors"
+	"errors"
+	"fmt"
+
 	"go.mondoo.com/cnquery/motor/asset"
 	"go.mondoo.com/cnquery/motor/discovery/common"
 	"go.mondoo.com/cnquery/motor/providers"
@@ -60,7 +62,7 @@ func getTitleFamily(azureObject azureObject) (azureObjectPlatformInfo, error) {
 			return azureObjectPlatformInfo{title: "Azure Key Vault", platform: "azure-keyvault-vault"}, nil
 		}
 	}
-	return azureObjectPlatformInfo{}, errors.Newf("missing runtime info for azure object service %s type %s", azureObject.service, azureObject.objectType)
+	return azureObjectPlatformInfo{}, errors.New(fmt.Sprintf("missing runtime info for azure object service %s type %s", azureObject.service, azureObject.objectType))
 }
 
 func fetchInstances(m *MqlDiscovery) ([]instance, error) {

--- a/motor/discovery/azure/resolver.go
+++ b/motor/discovery/azure/resolver.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
-	"github.com/cockroachdb/errors"
+	"errors"
 	"go.mondoo.com/cnquery/motor/asset"
 	"go.mondoo.com/cnquery/motor/discovery/common"
 	"go.mondoo.com/cnquery/motor/platform/detector"

--- a/motor/discovery/container_registry/registry.go
+++ b/motor/discovery/container_registry/registry.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/rs/zerolog/log"
@@ -93,7 +93,7 @@ func (a *DockerRegistryImages) Repositories(reg name.Registry) ([]string, error)
 func (a *DockerRegistryImages) ListRegistry(registry string) ([]*asset.Asset, error) {
 	reg, err := name.NewRegistry(registry)
 	if err != nil {
-		return nil, errors.Wrap(err, "resolve registry")
+		return nil, errors.Join(err, errors.New("resolve registry"))
 	}
 
 	repos, err := a.Repositories(reg)

--- a/motor/discovery/docker_engine/client.go
+++ b/motor/discovery/docker_engine/client.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	dopts "github.com/docker/cli/opts"
 	"github.com/docker/docker/client"
 )

--- a/motor/discovery/docker_engine/resolver.go
+++ b/motor/discovery/docker_engine/resolver.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/motor/asset"
@@ -80,7 +80,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *provide
 
 	if pCfg.Backend == providers.ProviderType_DOCKER_ENGINE_CONTAINER {
 		if dockerEngErr != nil {
-			return nil, errors.Wrap(dockerEngErr, "cannot connect to docker engine to fetch the container")
+			return nil, errors.Join(dockerEngErr, errors.New("cannot connect to docker engine to fetch the container"))
 		}
 		resolvedAsset, err := r.container(ctx, root, pCfg, ded)
 		if err != nil {
@@ -126,7 +126,7 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *provide
 	}
 
 	// if we reached here, we assume we have a name of an image or container from a registry
-	return nil, errors.Wrap(err, "could not find the container reference")
+	return nil, errors.Join(err, errors.New("could not find the container reference"))
 }
 
 func (k *Resolver) container(ctx context.Context, root *asset.Asset, pCfg *providers.Config, ded *dockerEngineDiscovery) (*asset.Asset, error) {

--- a/motor/discovery/gcp/mql_asset_objects.go
+++ b/motor/discovery/gcp/mql_asset_objects.go
@@ -1,7 +1,9 @@
 package gcp
 
 import (
-	"github.com/cockroachdb/errors"
+	"errors"
+	"fmt"
+
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/motor/asset"
 	"go.mondoo.com/cnquery/motor/discovery/common"
@@ -25,7 +27,7 @@ func getTitleFamily(o gcpObject) (gcpObjectPlatformInfo, error) {
 		case "firewall":
 			return gcpObjectPlatformInfo{title: "GCP Compute Firewall", platform: "gcp-compute-firewall"}, nil
 		default:
-			return gcpObjectPlatformInfo{}, errors.Newf("unknown gcp compute object type", o.objectType)
+			return gcpObjectPlatformInfo{}, errors.New(fmt.Sprintf("unknown gcp compute object type", o.objectType))
 		}
 	case "gke":
 		if o.objectType == "cluster" {
@@ -40,7 +42,7 @@ func getTitleFamily(o gcpObject) (gcpObjectPlatformInfo, error) {
 			return gcpObjectPlatformInfo{title: "GCP BigQuery Dataset", platform: "gcp-bigquery-dataset"}, nil
 		}
 	}
-	return gcpObjectPlatformInfo{}, errors.Newf("missing runtime info for gcp object service %s type %s", o.service, o.objectType)
+	return gcpObjectPlatformInfo{}, errors.New(fmt.Sprintf("missing runtime info for gcp object service %s type %s", o.service, o.objectType))
 }
 
 func computeInstances(m *MqlDiscovery, project string, tc *providers.Config, sfn common.QuerySecretFn) ([]*asset.Asset, error) {

--- a/motor/discovery/gcp/mql_asset_objects.go
+++ b/motor/discovery/gcp/mql_asset_objects.go
@@ -27,7 +27,7 @@ func getTitleFamily(o gcpObject) (gcpObjectPlatformInfo, error) {
 		case "firewall":
 			return gcpObjectPlatformInfo{title: "GCP Compute Firewall", platform: "gcp-compute-firewall"}, nil
 		default:
-			return gcpObjectPlatformInfo{}, errors.New(fmt.Sprintf("unknown gcp compute object type", o.objectType))
+			return gcpObjectPlatformInfo{}, errors.New(fmt.Sprintf("unknown gcp compute object type %s", o.objectType))
 		}
 	case "gke":
 		if o.objectType == "cluster" {

--- a/motor/discovery/gcp/resolver_folder.go
+++ b/motor/discovery/gcp/resolver_folder.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"go.mondoo.com/cnquery/motor/asset"
 	"go.mondoo.com/cnquery/motor/discovery/common"
 	"go.mondoo.com/cnquery/motor/platform/detector"

--- a/motor/discovery/gcp/resolver_project.go
+++ b/motor/discovery/gcp/resolver_project.go
@@ -3,7 +3,7 @@ package gcp
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"go.mondoo.com/cnquery/motor/asset"
 	"go.mondoo.com/cnquery/motor/discovery/common"
 	"go.mondoo.com/cnquery/motor/platform/detector"

--- a/motor/discovery/resolve.go
+++ b/motor/discovery/resolve.go
@@ -12,9 +12,9 @@ package discovery
 
 import (
 	"context"
+	"errors"
 	"strings"
 
-	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/motor/asset"
 	"go.mondoo.com/cnquery/motor/discovery/aws"

--- a/motor/discovery/vagrant/vagrant.go
+++ b/motor/discovery/vagrant/vagrant.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/motor/asset"
 	"go.mondoo.com/cnquery/motor/discovery/common"

--- a/motor/inventory/credentialquery/credentials_query.go
+++ b/motor/inventory/credentialquery/credentials_query.go
@@ -3,7 +3,7 @@ package credentialquery
 import (
 	"strings"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/mitchellh/mapstructure"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery"
@@ -40,7 +40,7 @@ func NewCredentialQueryRunner(credentialQuery string) (*CredentialQueryRunner, e
 	// test query to see if it compiles well
 	_, err = mql.Exec(credentialQuery, rt, nil, props)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not compile the secret metadata function")
+		return nil, errors.Join(err, errors.New("could not compile the secret metadata function"))
 	}
 	return &CredentialQueryRunner{
 		mqlExecutor:         mqlExecutor,

--- a/motor/inventory/domainlist/domainlist.go
+++ b/motor/inventory/domainlist/domainlist.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/motor/asset"
 	v1 "go.mondoo.com/cnquery/motor/inventory/v1"
@@ -73,7 +73,7 @@ type networkResolver struct{}
 func (r *networkResolver) ParseConnectionURL(fullUrl string, identityFile string, password string) (*providers.Config, error) {
 	url, err := url.Parse(fullUrl)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse target URL")
+		return nil, errors.Join(err, errors.New("failed to parse target URL"))
 	}
 
 	// TODO: Processing the family here needs a bit more work. It is unclear
@@ -104,7 +104,7 @@ func (r *networkResolver) ParseConnectionURL(fullUrl string, identityFile string
 		res.Host = hostBits[0]
 		port, err := strconv.Atoi(hostBits[1])
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to parse port in target URL")
+			return nil, errors.Join(err, errors.New("failed to parse port in target URL"))
 		}
 		res.Port = int32(port)
 	default:

--- a/motor/inventory/v1/inventory.go
+++ b/motor/inventory/v1/inventory.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/segmentio/ksuid"
 	asset "go.mondoo.com/cnquery/motor/asset"
 	"go.mondoo.com/cnquery/motor/vault"

--- a/motor/motorid/awsec2/awsec2.go
+++ b/motor/motorid/awsec2/awsec2.go
@@ -6,8 +6,8 @@ import (
 
 	"go.mondoo.com/cnquery/motor/providers/os"
 
+	"errors"
 	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/cockroachdb/errors"
 	"go.mondoo.com/cnquery/motor/platform"
 	"go.mondoo.com/cnquery/motor/providers/local"
 )
@@ -26,7 +26,7 @@ func Resolve(provider os.OperatingSystemProvider, pf *platform.Platform) (Instan
 	if ok {
 		cfg, err := config.LoadDefaultConfig(context.Background())
 		if err != nil {
-			return nil, errors.Wrap(err, "cannot not determine aws environment")
+			return nil, errors.Join(err, errors.New("cannot not determine aws environment"))
 		}
 		return NewLocal(cfg), nil
 	} else {

--- a/motor/motorid/awsec2/id.go
+++ b/motor/motorid/awsec2/id.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 )
 
 // aws://ec2/v1/accounts/{account}/regions/{region}/instances/{instanceid}

--- a/motor/motorid/awsec2/metadata_cmd.go
+++ b/motor/motorid/awsec2/metadata_cmd.go
@@ -7,11 +7,11 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"errors"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/cockroachdb/errors"
 	"go.mondoo.com/cnquery/motor/platform"
 	"go.mondoo.com/cnquery/motor/providers/os"
 	"go.mondoo.com/cnquery/motor/providers/os/powershell"
@@ -44,7 +44,7 @@ func (m *CommandInstanceMetadata) Identify() (Identity, error) {
 	// parse into struct
 	doc := imds.InstanceIdentityDocument{}
 	if err := json.NewDecoder(strings.NewReader(instanceDocument)).Decode(&doc); err != nil {
-		return Identity{}, errors.Wrap(err, "failed to decode EC2 instance identity document")
+		return Identity{}, errors.Join(err, errors.New("failed to decode EC2 instance identity document"))
 	}
 
 	name := ""

--- a/motor/motorid/awsecs/awsecs.go
+++ b/motor/motorid/awsecs/awsecs.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/cockroachdb/errors"
+	"errors"
 	"go.mondoo.com/cnquery/motor/platform"
 	"go.mondoo.com/cnquery/motor/providers/local"
 	"go.mondoo.com/cnquery/motor/providers/mock"

--- a/motor/motorid/awsecs/metadata_cmd.go
+++ b/motor/motorid/awsecs/metadata_cmd.go
@@ -5,8 +5,8 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"errors"
 	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/motor/motorid/containerid"
 	"go.mondoo.com/cnquery/motor/platform"
@@ -39,7 +39,7 @@ func (m *ContainerMetadata) Identify() (Identity, error) {
 	// parse into struct
 	doc := EcrContainerIdentityDoc{}
 	if err := json.NewDecoder(strings.NewReader(containerDocument)).Decode(&doc); err != nil {
-		return Identity{}, errors.Wrap(err, "failed to decode ECS container identity document")
+		return Identity{}, errors.Join(err, errors.New("failed to decode ECS container identity document"))
 	}
 	var accountID string
 	if arn.IsARN(doc.ContainerArn) {

--- a/motor/motorid/machineid/guid.go
+++ b/motor/motorid/machineid/guid.go
@@ -1,7 +1,7 @@
 package machineid
 
 import (
-	"github.com/cockroachdb/errors"
+	"errors"
 	"go.mondoo.com/cnquery/motor/platform"
 	"go.mondoo.com/cnquery/motor/providers/os"
 	"go.mondoo.com/cnquery/resources/packs/core/platformid"
@@ -10,7 +10,7 @@ import (
 func MachineId(provider os.OperatingSystemProvider, pf *platform.Platform) (string, error) {
 	uuidProvider, err := platformid.MachineIDProvider(provider, pf)
 	if err != nil {
-		return "", errors.Wrap(err, "cannot determine platform uuid")
+		return "", errors.Join(err, errors.New("cannot determine platform uuid"))
 	}
 
 	if uuidProvider == nil {
@@ -19,7 +19,7 @@ func MachineId(provider os.OperatingSystemProvider, pf *platform.Platform) (stri
 
 	id, err := uuidProvider.ID()
 	if err != nil {
-		return "", errors.Wrap(err, "cannot determine platform uuid")
+		return "", errors.Join(err, errors.New("cannot determine platform uuid"))
 	}
 
 	return id, nil

--- a/motor/motorid/motorid.go
+++ b/motor/motorid/motorid.go
@@ -3,7 +3,7 @@ package motorid
 import (
 	"fmt"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/motor/discovery/aws"
 	"go.mondoo.com/cnquery/motor/motorid/awsec2"

--- a/motor/motorid/sshhostkey/sshhostkey.go
+++ b/motor/motorid/sshhostkey/sshhostkey.go
@@ -3,7 +3,7 @@ package sshhostkey
 import (
 	"os"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/motor/platform"
 	"go.mondoo.com/cnquery/motor/providers"
@@ -35,11 +35,11 @@ func Detect(t providers.Instance, p *platform.Platform) ([]string, error) {
 		} else if os.IsNotExist(err) {
 			continue
 		} else if err != nil {
-			return nil, errors.Wrap(err, "could not read file:"+hostKeyFilePath)
+			return nil, errors.Join(err, errors.New("could not read file:"+hostKeyFilePath))
 		}
 		publicKey, _, _, _, err := ssh.ParseAuthorizedKey(data)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not parse public key file:"+hostKeyFilePath)
+			return nil, errors.Join(err, errors.New("could not parse public key file:"+hostKeyFilePath))
 		}
 
 		identifiers = append(identifiers, ssh_transport.PlatformIdentifier(publicKey))

--- a/motor/providers/arista/provider.go
+++ b/motor/providers/arista/provider.go
@@ -2,7 +2,7 @@ package arista
 
 import (
 	"github.com/aristanetworks/goeapi"
-	"github.com/cockroachdb/errors"
+	"errors"
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/vault"
 )

--- a/motor/providers/aws/provider.go
+++ b/motor/providers/aws/provider.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"sync"
 
+	"errors"
 	aws_sdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
-	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/motor/platform"
 	"go.mondoo.com/cnquery/motor/providers"
@@ -79,7 +79,7 @@ func New(pCfg *providers.Config, opts ...ProviderOption) (*Provider, error) {
 
 	cfg, err := config.LoadDefaultConfig(context.Background(), t.awsConfigOptions...)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not load aws configuration")
+		return nil, errors.Join(err, errors.New("could not load aws configuration"))
 	}
 	if cfg.Region == "" {
 		log.Info().Msg("no AWS region found, using us-east-1")

--- a/motor/providers/awsec2ebs/provider.go
+++ b/motor/providers/awsec2ebs/provider.go
@@ -2,11 +2,9 @@ package awsec2ebs
 
 import (
 	"context"
+	"errors"
 	"math/rand"
 	"time"
-	"errors"
-
-	"go.mondoo.com/cnquery/motor/providers/os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -84,11 +82,7 @@ func New(pCfg *providers.Config) (*Provider, error) {
 	// 3. validate
 	instanceinfo, volumeid, snapshotid, err := p.Validate(ctx)
 	if err != nil {
-<<<<<<< HEAD
-		return p, errors.Wrap(err, "unable to validate")
-=======
-		return t, errors.Join(err, errors.New("unable to validate"))
->>>>>>> 53cdaacd (:broom: replace cockroachdb/errors with standard library errors)
+		return p, errors.Join(err, errors.New("unable to validate"))
 	}
 
 	// 4. setup the volume for scanning

--- a/motor/providers/awsec2ebs/provider.go
+++ b/motor/providers/awsec2ebs/provider.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"math/rand"
 	"time"
+	"errors"
+
+	"go.mondoo.com/cnquery/motor/providers/os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
-	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"go.mondoo.com/cnquery/motor/providers"
@@ -35,11 +37,11 @@ func New(pCfg *providers.Config) (*Provider, error) {
 	// TODO allow custom aws config
 	cfg, err := config.LoadDefaultConfig(context.Background())
 	if err != nil {
-		return nil, errors.Wrap(err, "could not load aws configuration")
+		return nil, errors.Join(err, errors.New("could not load aws configuration"))
 	}
 	i, err := RawInstanceInfo(cfg)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not load instance info: aws-ec2-ebs provider only valid on ec2 instances")
+		return nil, errors.Join(err, errors.New("could not load instance info: aws-ec2-ebs provider only valid on ec2 instances"))
 	}
 
 	// ec2 client for the scanner region
@@ -82,7 +84,11 @@ func New(pCfg *providers.Config) (*Provider, error) {
 	// 3. validate
 	instanceinfo, volumeid, snapshotid, err := p.Validate(ctx)
 	if err != nil {
+<<<<<<< HEAD
 		return p, errors.Wrap(err, "unable to validate")
+=======
+		return t, errors.Join(err, errors.New("unable to validate"))
+>>>>>>> 53cdaacd (:broom: replace cockroachdb/errors with standard library errors)
 	}
 
 	// 4. setup the volume for scanning
@@ -245,11 +251,11 @@ func GetRawInstanceInfo(profile string) (*imds.InstanceIdentityDocument, error) 
 		cfg, err = config.LoadDefaultConfig(ctx, config.WithSharedConfigProfile(profile))
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "could not load aws configuration")
+		return nil, errors.Join(err, errors.New("could not load aws configuration"))
 	}
 	i, err := RawInstanceInfo(cfg)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not load instance info: aws-ec2-ebs provider is only valid on ec2 instances")
+		return nil, errors.Join(err, errors.New("could not load instance info: aws-ec2-ebs provider is only valid on ec2 instances"))
 	}
 	return i, nil
 }

--- a/motor/providers/awsec2ebs/setup.go
+++ b/motor/providers/awsec2ebs/setup.go
@@ -2,15 +2,17 @@ package awsec2ebs
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"strings"
 	"time"
+
+	"errors"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/smithy-go"
-	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	motoraws "go.mondoo.com/cnquery/motor/discovery/aws"
 )
@@ -265,7 +267,7 @@ func CreateSnapshotFromVolume(ctx context.Context, cfg aws.Config, volID string,
 			return nil, err
 		}
 		if len(snaps.Snapshots) != 1 {
-			return nil, errors.Newf("expected one snapshot, got %d", len(snaps.Snapshots))
+			return nil, errors.New(fmt.Sprintf("expected one snapshot, got %d", len(snaps.Snapshots)))
 		}
 		snapProgress = *snaps.Snapshots[0].Progress
 		snapState = snaps.Snapshots[0].State

--- a/motor/providers/awsec2ebs/types.go
+++ b/motor/providers/awsec2ebs/types.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/cockroachdb/errors"
+	"errors"
 )
 
 type InstanceId struct {

--- a/motor/providers/equinix/provider.go
+++ b/motor/providers/equinix/provider.go
@@ -1,7 +1,7 @@
 package equinix
 
 import (
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/packethost/packngo"
 	"go.mondoo.com/cnquery/motor/providers"
 )
@@ -31,12 +31,12 @@ func New(cfg *providers.Config) (*Provider, error) {
 	// https://github.com/packethost/packngo/issues/245
 	//project, _, err := c.Projects.Get(projectId, nil)
 	//if err != nil {
-	//	return nil, errors.Wrap(err, "could not find the requested equinix project: "+projectId)
+	//	return nil, errors.Join(err, errors.New("could not find the requested equinix project: "+projectId))
 	//}
 
 	ps, _, err := c.Projects.List(nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot retrieve equinix projects")
+		return nil, errors.Join(err, errors.New("cannot retrieve equinix projects"))
 	}
 
 	var project *packngo.Project
@@ -46,7 +46,7 @@ func New(cfg *providers.Config) (*Provider, error) {
 		}
 	}
 	if project == nil {
-		return nil, errors.Wrap(err, "could not find the requested equinix project: "+projectId)
+		return nil, errors.Join(err, errors.New("could not find the requested equinix project: "+projectId))
 	}
 
 	return &Provider{

--- a/motor/providers/github/platform.go
+++ b/motor/providers/github/platform.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/google/go-github/v49/github"
 	"go.mondoo.com/cnquery/motor/platform"
 	"go.mondoo.com/cnquery/motor/providers"
@@ -47,7 +47,7 @@ func (p *Provider) PlatformInfo() (*platform.Platform, error) {
 		return GithubRepoPlatform, nil
 	}
 
-	return nil, errors.Wrap(err, "could not detect GitHub asset type")
+	return nil, errors.Join(err, errors.New("could not detect GitHub asset type"))
 }
 
 func NewGithubOrgIdentifier(orgId string) string {

--- a/motor/providers/google/gcloud_config.go
+++ b/motor/providers/google/gcloud_config.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"go.mondoo.com/cnquery/motor/providers/local"
 )
 
@@ -23,7 +23,7 @@ func GetCurrentProject() (string, error) {
 
 	gcloudconfig, err := ParseGcloudConfig(cmd.Stdout)
 	if err != nil {
-		return "", errors.Wrap(err, "could not read gcloud config")
+		return "", errors.Join(err, errors.New("could not read gcloud config"))
 	}
 
 	return gcloudconfig.Configuration.Properties.Core.Project, nil

--- a/motor/providers/k8s/resources/resource_index.go
+++ b/motor/providers/k8s/resources/resource_index.go
@@ -1,7 +1,9 @@
 package resources
 
 import (
-	"github.com/cockroachdb/errors"
+	"errors"
+	"fmt"
+
 	"github.com/rs/zerolog/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -13,7 +15,7 @@ func ResourceIndex(resList []*metav1.APIResourceList) (*ApiResourceIndex, error)
 		log.Debug().Msgf("iterating over group %s/%s (%d api resources types)", group.GroupVersion, group.APIVersion, len(group.APIResources))
 		gv, err := schema.ParseGroupVersion(group.GroupVersion)
 		if err != nil {
-			return nil, errors.Wrapf(err, "%q cannot be parsed into groupversion", group.GroupVersion)
+			return nil, errors.Join(err, errors.New(fmt.Sprintf("%q cannot be parsed into groupversion", group.GroupVersion)))
 		}
 
 		for _, apiRes := range group.APIResources {

--- a/motor/providers/microsoft/msgraph/msgraphclient/adapter.go
+++ b/motor/providers/microsoft/msgraph/msgraphclient/adapter.go
@@ -1,7 +1,7 @@
 package msgraphclient
 
 import (
-	"github.com/cockroachdb/errors"
+	"errors"
 	absauth "github.com/microsoft/kiota-abstractions-go/authentication"
 	msgraphsdkgo "github.com/microsoftgraph/msgraph-sdk-go"
 )
@@ -13,7 +13,7 @@ var DefaultMSGraphScopes = []string{DefaultMSGraphScope}
 func NewGraphRequestAdapterWithFn(providerFn func() (absauth.AuthenticationProvider, error)) (*msgraphsdkgo.GraphRequestAdapter, error) {
 	auth, err := providerFn()
 	if err != nil {
-		return nil, errors.Wrap(err, "authentication provider error")
+		return nil, errors.Join(err, errors.New("authentication provider error"))
 	}
 
 	return msgraphsdkgo.NewGraphRequestAdapter(auth)

--- a/motor/providers/microsoft/msgraph/msgraphconv/errors.go
+++ b/motor/providers/microsoft/msgraph/msgraphconv/errors.go
@@ -1,7 +1,9 @@
 package msgraphconv
 
 import (
-	"github.com/cockroachdb/errors"
+	"errors"
+	"fmt"
+
 	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 )
 
@@ -9,7 +11,7 @@ func TransformError(err error) error {
 	oDataErr, ok := err.(*odataerrors.ODataError)
 	if ok && oDataErr != nil {
 		if err := oDataErr.GetError(); err != nil {
-			return errors.Newf("error while performing request. Code: %s, Message: %s", *err.GetCode(), *err.GetMessage())
+			return errors.New(fmt.Sprintf("error while performing request. Code: %s, Message: %s", *err.GetCode(), *err.GetMessage()))
 		}
 	}
 	return err

--- a/motor/providers/microsoft/platform.go
+++ b/motor/providers/microsoft/platform.go
@@ -1,7 +1,7 @@
 package microsoft
 
 import (
-	"github.com/cockroachdb/errors"
+	"errors"
 	"go.mondoo.com/cnquery/motor/platform"
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/vault"

--- a/motor/providers/microsoft/provider.go
+++ b/motor/providers/microsoft/provider.go
@@ -3,7 +3,7 @@ package microsoft
 import (
 	"sync"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/microsoft/ms365/ms365report"
 	"go.mondoo.com/cnquery/motor/vault"

--- a/motor/providers/oci/clients.go
+++ b/motor/providers/oci/clients.go
@@ -3,7 +3,7 @@ package oci
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/oracle/oci-go-sdk/v65/audit"
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/core"
@@ -63,7 +63,7 @@ func (p *Provider) GetCompartments(ctx context.Context) ([]identity.Compartment,
 
 		response, err := oClient.ListCompartments(ctx, request)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to list compartments in tenancy: "+p.tenancyOcid)
+			return nil, errors.Join(err, errors.New("failed to list compartments in tenancy: "+p.tenancyOcid))
 		}
 
 		for i := range response.Items {

--- a/motor/providers/os/statutil/stat.go
+++ b/motor/providers/os/statutil/stat.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	os_provider "go.mondoo.com/cnquery/motor/providers/os"
 )
@@ -142,27 +142,27 @@ func (s *statHelper) linux(name string) (os.FileInfo, error) {
 
 	size, err := strconv.Atoi(statsData[0])
 	if err != nil {
-		return nil, errors.Wrap(err, "could not stat "+name)
+		return nil, errors.Join(err, errors.New("could not stat "+name))
 	}
 
 	uid, err := strconv.ParseInt(statsData[2], 10, 64)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not stat "+name)
+		return nil, errors.Join(err, errors.New("could not stat "+name))
 	}
 
 	gid, err := strconv.ParseInt(statsData[3], 10, 64)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not stat "+name)
+		return nil, errors.Join(err, errors.New("could not stat "+name))
 	}
 
 	mask, err := strconv.ParseUint(statsData[1], 16, 32)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not stat "+name)
+		return nil, errors.Join(err, errors.New("could not stat "+name))
 	}
 
 	mtime, err := strconv.ParseInt(statsData[4], 10, 64)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not stat "+name)
+		return nil, errors.Join(err, errors.New("could not stat "+name))
 	}
 
 	// extract file modes
@@ -212,30 +212,30 @@ func (s *statHelper) unix(name string) (os.FileInfo, error) {
 
 	size, err := strconv.Atoi(statsData[0])
 	if err != nil {
-		return nil, errors.Wrap(err, "could not stat "+name)
+		return nil, errors.Join(err, errors.New("could not stat "+name))
 	}
 
 	uid, err := strconv.ParseInt(statsData[2], 10, 64)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not stat "+name)
+		return nil, errors.Join(err, errors.New("could not stat "+name))
 	}
 
 	gid, err := strconv.ParseInt(statsData[3], 10, 64)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not stat "+name)
+		return nil, errors.Join(err, errors.New("could not stat "+name))
 	}
 
 	// NOTE: the base is 8 instead of 16 on linux systems
 	mask, err := strconv.ParseUint(statsData[1], 8, 32)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not stat "+name)
+		return nil, errors.Join(err, errors.New("could not stat "+name))
 	}
 
 	mode := toFileMode(mask)
 
 	mtime, err := strconv.ParseInt(statsData[4], 10, 64)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not stat "+name)
+		return nil, errors.Join(err, errors.New("could not stat "+name))
 	}
 
 	return &os_provider.FileInfo{

--- a/motor/providers/resolver/connect.go
+++ b/motor/providers/resolver/connect.go
@@ -3,7 +3,7 @@ package resolver
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/motor"
 	"go.mondoo.com/cnquery/motor/asset"

--- a/motor/providers/ssh/awsinstanceconnect/ec2instanceconnect.go
+++ b/motor/providers/ssh/awsinstanceconnect/ec2instanceconnect.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/sethvargo/go-password/password"
 
 	"github.com/aws/aws-sdk-go-v2/aws"

--- a/motor/providers/ssh/cat/cat.go
+++ b/motor/providers/ssh/cat/cat.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	os_provider "go.mondoo.com/cnquery/motor/providers/os"

--- a/motor/providers/ssh/cat/cat_file.go
+++ b/motor/providers/ssh/cat/cat_file.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/kballard/go-shellquote"
 )
 
@@ -42,7 +42,7 @@ func (f *File) readContent() (*bytes.Buffer, error) {
 	if f.useBase64encoding {
 		data, err = base64.StdEncoding.DecodeString(string(data))
 		if err != nil {
-			return nil, errors.Wrap(err, "could not decode base64 data stream")
+			return nil, errors.Join(err, errors.New("could not decode base64 data stream"))
 		}
 	}
 

--- a/motor/providers/ssh/provider.go
+++ b/motor/providers/ssh/provider.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	rawsftp "github.com/pkg/sftp"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
@@ -115,7 +115,7 @@ func (p *Provider) Connect() error {
 	// load known hosts and track the fingerprint of the ssh server for later identification
 	knownHostsCallback, err := KnownHostsCallback()
 	if err != nil {
-		return errors.Wrap(err, "could not read hostkey file")
+		return errors.Join(err, errors.New("could not read hostkey file"))
 	}
 
 	var hostkey ssh.PublicKey

--- a/motor/providers/ssh/session.go
+++ b/motor/providers/ssh/session.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"strconv"
 
+	"errors"
 	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/ssh/awsinstanceconnect"
@@ -159,7 +159,7 @@ func prepareConnection(pCfg *providers.Config) ([]ssh.AuthMethod, []io.Closer, e
 			// use the generated ssh credentials for authentication
 			priv, err := signers.GetSignerFromPrivateKeyWithPassphrase(creds.KeyPair.PrivateKey, creds.KeyPair.Passphrase)
 			if err != nil {
-				return nil, nil, errors.Wrap(err, "could not read generated private key")
+				return nil, nil, errors.Join(err, errors.New("could not read generated private key"))
 			}
 			sshSigners = append(sshSigners, priv)
 			closer = append(closer, ssmConn)
@@ -190,7 +190,7 @@ func prepareConnection(pCfg *providers.Config) ([]ssh.AuthMethod, []io.Closer, e
 
 			priv, err := signers.GetSignerFromPrivateKeyWithPassphrase(creds.KeyPair.PrivateKey, creds.KeyPair.Passphrase)
 			if err != nil {
-				return nil, nil, errors.Wrap(err, "could not read generated private key")
+				return nil, nil, errors.Join(err, errors.New("could not read generated private key"))
 			}
 			sshSigners = append(sshSigners, priv)
 

--- a/motor/providers/ssh/sftp/sftp.go
+++ b/motor/providers/ssh/sftp/sftp.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/pkg/sftp"
 	"github.com/spf13/afero"
 	"go.mondoo.com/cnquery/motor/providers/ssh/cat"
@@ -37,7 +37,7 @@ type Fs struct {
 func New(commandRunner cat.CommandRunner, client *ssh.Client) (afero.Fs, error) {
 	ftpClient, err := sftpClient(client)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not initialize sftp backend")
+		return nil, errors.Join(err, errors.New("could not initialize sftp backend"))
 	}
 
 	return &Fs{

--- a/motor/providers/terraform/provider.go
+++ b/motor/providers/terraform/provider.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"go.mondoo.com/cnquery/motor/providers"
@@ -104,7 +104,7 @@ func New(tc *providers.Config) (*Provider, error) {
 						if errors.Is(err, os.ErrNotExist) {
 							log.Debug().Str("path", path).Msg("no terraform module manifest found")
 						} else {
-							return errors.Wrap(err, fmt.Sprintf("could not parse terraform module manifest %s", path))
+							return errors.Join(err, errors.New(fmt.Sprintf("could not parse terraform module manifest %s", path)))
 						}
 					}
 
@@ -116,12 +116,12 @@ func New(tc *providers.Config) (*Provider, error) {
 					log.Debug().Str("path", path).Msg("parsing hcl file")
 					err = loader.ParseHclFile(path)
 					if err != nil {
-						return errors.Wrap(err, "could not parse hcl file")
+						return errors.Join(err, errors.New("could not parse hcl file"))
 					}
 
 					err = ReadTfVarsFromFile(path, tfVars)
 					if err != nil {
-						return errors.Wrap(err, "could not parse tfvars file")
+						return errors.Join(err, errors.New("could not parse tfvars file"))
 					}
 				}
 				return nil
@@ -129,12 +129,12 @@ func New(tc *providers.Config) (*Provider, error) {
 		} else {
 			err = loader.ParseHclFile(path)
 			if err != nil {
-				return nil, errors.Wrap(err, "could not parse hcl file")
+				return nil, errors.Join(err, errors.New("could not parse hcl file"))
 			}
 
 			err = ReadTfVarsFromFile(path, tfVars)
 			if err != nil {
-				return nil, errors.Wrap(err, "could not parse tfvars file")
+				return nil, errors.Join(err, errors.New("could not parse tfvars file"))
 			}
 		}
 	}

--- a/motor/providers/terraform/provider.go
+++ b/motor/providers/terraform/provider.go
@@ -119,14 +119,12 @@ func New(tc *providers.Config) (*Provider, error) {
 					log.Debug().Str("path", path).Msg("parsing hcl file")
 					err = loader.ParseHclFile(path)
 					if err != nil {
-						//return errors.Wrap(err, "could not parse hcl file")
-						return gerrors.Join(err, errors.New("could not parse hcl file"))
+						return errors.Join(err, errors.New("could not parse hcl file"))
 					}
 
 					err = ReadTfVarsFromFile(path, tfVars)
 					if err != nil {
-						//return errors.Wrap(err, "could not parse tfvars file")
-						return gerrors.Join(err, errors.New("could not parse tfvars file"))
+						return errors.Join(err, errors.New("could not parse tfvars file"))
 					}
 				}
 				return nil
@@ -134,14 +132,12 @@ func New(tc *providers.Config) (*Provider, error) {
 		} else {
 			err = loader.ParseHclFile(path)
 			if err != nil {
-				return nil, gerrors.Join(err, errors.New("could not parse hcl file"))
-				//return nil, errors.Wrap(err, "could not parse hcl file")
+				return nil, errors.Join(err, errors.New("could not parse hcl file"))
 			}
 
 			err = ReadTfVarsFromFile(path, tfVars)
 			if err != nil {
-				return nil, gerrors.Join(err, errors.New("could not parse tfvars file"))
-				//return nil, errors.Wrap(err, "could not parse tfvars file")
+				return nil, errors.Join(err, errors.New("could not parse tfvars file"))
 			}
 		}
 	}

--- a/motor/providers/terraform/provider.go
+++ b/motor/providers/terraform/provider.go
@@ -13,9 +13,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	gerrors "errors"
-
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"go.mondoo.com/cnquery/motor/providers"
@@ -106,10 +104,10 @@ func New(tc *providers.Config) (*Provider, error) {
 						if errors.Is(err, os.ErrNotExist) {
 							log.Debug().Str("path", path).Msg("no terraform module manifest found")
 						} else {
-							//return gerrors.Join(err, fmt.Errorf("could not parse terraform module manifest %s", path)) --> test fails
-							//return gerrors.New(fmt.Sprintf("could not parse terraform module manifest %s", path))  --> test fails
-							//return fmt.Errorf("could not parse terraform module manifest %s: %w", path, err) --> test fails
-							return errors.Wrap(err, fmt.Sprintf("could not parse terraform module manifest %s", path)) // --> test passes
+							return errors.Join(err, fmt.Errorf("could not parse terraform module manifest %s", path)) // -> test fails
+							//return gerrors.New(fmt.Sprintf("could not parse terraform module manifest %s", path))  -> test fails
+							//return fmt.Errorf("could not parse terraform module manifest %s: %w", path, err) -> test fails
+							// return errors.Wrap(err, fmt.Sprintf("could not parse terraform module manifest %s", path)) -> test passes using cockroachdb/errors
 						}
 					}
 

--- a/motor/providers/vcd/provider.go
+++ b/motor/providers/vcd/provider.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
 	"go.mondoo.com/cnquery/motor/providers"

--- a/motor/providers/winrm/cat/cat.go
+++ b/motor/providers/winrm/cat/cat.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/spf13/afero"
 	os_provider "go.mondoo.com/cnquery/motor/providers/os"
 	"go.mondoo.com/cnquery/motor/providers/os/powershell"

--- a/motor/vault/awsparameterstore/parameterstore.go
+++ b/motor/vault/awsparameterstore/parameterstore.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/cockroachdb/errors"
+	"errors"
 	"go.mondoo.com/cnquery/motor/vault"
 )
 

--- a/motor/vault/awssecretsmanager/secretsmanager.go
+++ b/motor/vault/awssecretsmanager/secretsmanager.go
@@ -3,7 +3,6 @@ package awssecretsmanager
 import (
 	"context"
 
-	"errors"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/aws/arn"

--- a/motor/vault/awssecretsmanager/secretsmanager.go
+++ b/motor/vault/awssecretsmanager/secretsmanager.go
@@ -3,6 +3,7 @@ package awssecretsmanager
 import (
 	"context"
 
+	"errors"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/aws/arn"

--- a/motor/vault/mock/mock_vault.go
+++ b/motor/vault/mock/mock_vault.go
@@ -3,7 +3,7 @@ package mockvault
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/motor/vault"
 )

--- a/motor/vault/vault.go
+++ b/motor/vault/vault.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"go.mondoo.com/ranger-rpc/codes"
 	"go.mondoo.com/ranger-rpc/status"
 	"google.golang.org/protobuf/proto"
@@ -42,7 +42,7 @@ func (x *Secret) Credential() (*Credential, error) {
 	}
 
 	if err != nil {
-		return nil, errors.Wrap(err, "unknown secret format")
+		return nil, errors.Join(err, errors.New("unknown secret format"))
 	}
 
 	cred.SecretId = x.Key

--- a/mqlc/builtin_resource.go
+++ b/mqlc/builtin_resource.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"strconv"
 
-	"github.com/pkg/errors"
 	"go.mondoo.com/cnquery/llx"
 	"go.mondoo.com/cnquery/mqlc/parser"
 	"go.mondoo.com/cnquery/resources"

--- a/mqlc/builtin_resource.go
+++ b/mqlc/builtin_resource.go
@@ -1,6 +1,7 @@
 package mqlc
 
 import (
+	"errors"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -95,7 +96,7 @@ func (f *FunctionSignature) Validate(args []*llx.Primitive, c *compiler) error {
 		if argT == types.Ref {
 			argT, err = c.dereferenceType(args[i])
 			if err != nil {
-				return errors.Wrap(err, "failed to dereference argument in validating function signature")
+				return errors.Join(err, errors.New("failed to dereference argument in validating function signature"))
 			}
 		}
 

--- a/resources/packs/aws/aws_apigateway.go
+++ b/resources/packs/aws/aws_apigateway.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"errors"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
-	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources"
@@ -71,7 +71,7 @@ func (a *mqlAwsApigateway) getRestApis(provider *aws_provider.Provider) []*jobpo
 						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
 						return res, nil
 					}
-					return nil, errors.Wrap(err, "could not gather AWS API Gateway REST APIs")
+					return nil, errors.Join(err, errors.New("could not gather AWS API Gateway REST APIs"))
 				}
 
 				for _, restApi := range restApisResp.Items {
@@ -165,7 +165,7 @@ func (a *mqlAwsApigatewayRestapi) GetStages() ([]interface{}, error) {
 	// no pagination required
 	stagesResp, err := svc.GetStages(ctx, &apigateway.GetStagesInput{RestApiId: &restApiId})
 	if err != nil {
-		return nil, errors.Wrap(err, "could not gather AWS API Gateway stages")
+		return nil, errors.Join(err, errors.New("could not gather AWS API Gateway stages"))
 	}
 	res := []interface{}{}
 	for _, stage := range stagesResp.Item {

--- a/resources/packs/aws/aws_applicationautoscaling.go
+++ b/resources/packs/aws/aws_applicationautoscaling.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"errors"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/applicationautoscaling"
 	"github.com/aws/aws-sdk-go-v2/service/applicationautoscaling/types"
-	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources/library/jobpool"
@@ -17,7 +17,7 @@ import (
 func (a *mqlAwsApplicationAutoscaling) id() (string, error) {
 	n, err := a.Namespace()
 	if err != nil {
-		return "", errors.Wrap(err, "namespace required. please provide an aws service as argument. valid values: [comprehend, rds, sagemaker, appstream, elasticmapreduce, dynamodb, lambda, ecs, cassandra, ec2, neptune, kafka, custom-resource, elasticache]")
+		return "", errors.Join(err, errors.New("namespace required. please provide an aws service as argument. valid values: [comprehend, rds, sagemaker, appstream, elasticmapreduce, dynamodb, lambda, ecs, cassandra, ec2, neptune, kafka, custom-resource, elasticache]"))
 	}
 	return "aws.applicationAutoscaling." + n, nil
 }
@@ -82,7 +82,7 @@ func (a *mqlAwsApplicationAutoscaling) getTargets(provider *aws_provider.Provide
 						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
 						return res, nil
 					}
-					return nil, errors.Wrap(err, "could not gather application autoscaling scalable targets")
+					return nil, errors.Join(err, errors.New("could not gather application autoscaling scalable targets"))
 				}
 
 				for _, target := range resp.ScalableTargets {

--- a/resources/packs/aws/aws_cloudfront.go
+++ b/resources/packs/aws/aws_cloudfront.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"errors"
 	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
-	"github.com/cockroachdb/errors"
 	"go.mondoo.com/cnquery/resources/packs/core"
 )
 
@@ -47,7 +47,7 @@ func (f *mqlAwsCloudfront) GetDistributions() ([]interface{}, error) {
 	for {
 		distributions, err := svc.ListDistributions(ctx, &cloudfront.ListDistributionsInput{Marker: marker})
 		if err != nil {
-			return nil, errors.Wrap(err, "could not gather aws cloudfront distributions")
+			return nil, errors.Join(err, errors.New("could not gather aws cloudfront distributions"))
 		}
 
 		for i := range distributions.DistributionList.Items {
@@ -126,7 +126,7 @@ func (f *mqlAwsCloudfront) GetFunctions() ([]interface{}, error) {
 	for {
 		functions, err := svc.ListFunctions(ctx, &cloudfront.ListFunctionsInput{Marker: marker})
 		if err != nil {
-			return nil, errors.Wrap(err, "could not gather aws cloudfront functions")
+			return nil, errors.Join(err, errors.New("could not gather aws cloudfront functions"))
 		}
 
 		for i := range functions.FunctionList.Items {

--- a/resources/packs/aws/aws_cloudtrail.go
+++ b/resources/packs/aws/aws_cloudtrail.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"errors"
 	"github.com/aws/aws-sdk-go-v2/service/cloudtrail"
-	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources"
@@ -108,7 +108,7 @@ func (t *mqlAwsCloudtrail) getTrails(provider *aws_provider.Provider) []*jobpool
 					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
 					return res, nil
 				}
-				return nil, errors.Wrap(err, "could not gather aws cloudtrail trails")
+				return nil, errors.Join(err, errors.New("could not gather aws cloudtrail trails"))
 			}
 
 			for i := range trailsResp.TrailList {

--- a/resources/packs/aws/aws_dynamodb.go
+++ b/resources/packs/aws/aws_dynamodb.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"errors"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
-	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources"
@@ -68,7 +68,7 @@ func (d *mqlAwsDynamodb) getBackups(provider *aws_provider.Provider) []*jobpool.
 					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
 					return res, nil
 				}
-				return nil, errors.Wrap(err, "could not gather aws dynamodb backups")
+				return nil, errors.Join(err, errors.New("could not gather aws dynamodb backups"))
 			}
 			backupSummary, err := core.JsonToDictSlice(listBackupsResp.BackupSummaries)
 			if err != nil {
@@ -141,7 +141,7 @@ func (d *mqlAwsDynamodbTable) GetBackups() ([]interface{}, error) {
 
 	listBackupsResp, err := svc.ListBackups(ctx, &dynamodb.ListBackupsInput{TableName: &tableName})
 	if err != nil {
-		return nil, errors.Wrap(err, "could not gather aws dynamodb backups")
+		return nil, errors.Join(err, errors.New("could not gather aws dynamodb backups"))
 	}
 	return core.JsonToDictSlice(listBackupsResp.BackupSummaries)
 }
@@ -217,7 +217,7 @@ func (d *mqlAwsDynamodb) getLimits(provider *aws_provider.Provider) []*jobpool.J
 					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
 					return res, nil
 				}
-				return nil, errors.Wrap(err, "could not gather aws dynamodb backups")
+				return nil, errors.Join(err, errors.New("could not gather aws dynamodb backups"))
 			}
 
 			mqlLimits, err := d.MotorRuntime.CreateResource("aws.dynamodb.limit",
@@ -253,7 +253,7 @@ func (d *mqlAwsDynamodb) GetGlobalTables() ([]interface{}, error) {
 	// no pagination required
 	listGlobalTablesResp, err := svc.ListGlobalTables(ctx, &dynamodb.ListGlobalTablesInput{})
 	if err != nil {
-		return nil, errors.Wrap(err, "could not gather aws dynamodb global tables")
+		return nil, errors.Join(err, errors.New("could not gather aws dynamodb global tables"))
 	}
 	res := []interface{}{}
 	for _, table := range listGlobalTablesResp.GlobalTables {
@@ -317,13 +317,13 @@ func (d *mqlAwsDynamodb) getTables(provider *aws_provider.Provider) []*jobpool.J
 					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
 					return res, nil
 				}
-				return nil, errors.Wrap(err, "could not gather aws dynamodb tables")
+				return nil, errors.Join(err, errors.New("could not gather aws dynamodb tables"))
 			}
 			for _, tableName := range listTablesResp.TableNames {
 				// call describe table to get real info/details about the table
 				table, err := svc.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: &tableName})
 				if err != nil {
-					return nil, errors.Wrap(err, "could not get aws dynamodb table")
+					return nil, errors.Join(err, errors.New("could not get aws dynamodb table"))
 				}
 				sseDict, err := core.JsonToDict(table.Table.SSEDescription)
 				if err != nil {
@@ -381,7 +381,7 @@ func (d *mqlAwsDynamodbGlobaltable) GetReplicaSettings() ([]interface{}, error) 
 	// no pagination required
 	tableSettingsResp, err := svc.DescribeGlobalTableSettings(ctx, &dynamodb.DescribeGlobalTableSettingsInput{GlobalTableName: &tableName})
 	if err != nil {
-		return nil, errors.Wrap(err, "could not gather aws dynamodb table settings")
+		return nil, errors.Join(err, errors.New("could not gather aws dynamodb table settings"))
 	}
 	return core.JsonToDictSlice(tableSettingsResp.ReplicaSettings)
 }
@@ -446,7 +446,7 @@ func (d *mqlAwsDynamodbTable) GetContinuousBackups() (interface{}, error) {
 	// no pagination required
 	continuousBackupsResp, err := svc.DescribeContinuousBackups(ctx, &dynamodb.DescribeContinuousBackupsInput{TableName: &tableName})
 	if err != nil {
-		return nil, errors.Wrap(err, "could not gather aws dynamodb continuous backups")
+		return nil, errors.Join(err, errors.New("could not gather aws dynamodb continuous backups"))
 	}
 	return core.JsonToDict(continuousBackupsResp.ContinuousBackupsDescription)
 }

--- a/resources/packs/aws/aws_ec2.go
+++ b/resources/packs/aws/aws_ec2.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"errors"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -13,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/aws/smithy-go"
-	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources"
@@ -144,11 +144,11 @@ func (s *mqlAwsEc2NetworkaclEntryPortrange) id() (string, error) {
 func (s *mqlAwsEc2Networkacl) GetEntries() ([]interface{}, error) {
 	id, err := s.Id()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse id")
+		return nil, errors.Join(err, errors.New("unable to parse id"))
 	}
 	region, err := s.Region()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to region")
+		return nil, errors.Join(err, errors.New("unable to region"))
 	}
 	at, err := awsProvider(s.MotorRuntime.Motor.Provider)
 	if err != nil {
@@ -201,11 +201,11 @@ func (s *mqlAwsEc2NetworkaclEntry) GetPortRange() (interface{}, error) {
 func (s *mqlAwsEc2Securitygroup) GetIsAttachedToNetworkInterface() (bool, error) {
 	sgId, err := s.Id()
 	if err != nil {
-		return false, errors.Wrap(err, "unable to parse instance id")
+		return false, errors.Join(err, errors.New("unable to parse instance id"))
 	}
 	region, err := s.Region()
 	if err != nil {
-		return false, errors.Wrap(err, "unable to parse instance id")
+		return false, errors.Join(err, errors.New("unable to parse instance id"))
 	}
 	provider, err := awsProvider(s.MotorRuntime.Motor.Provider)
 	if err != nil {
@@ -930,11 +930,11 @@ func (s *mqlAwsEc2Instance) GetKeypair() (interface{}, error) {
 func (s *mqlAwsEc2Instance) GetSsm() (interface{}, error) {
 	instanceId, err := s.InstanceId()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse instance id")
+		return nil, errors.Join(err, errors.New("unable to parse instance id"))
 	}
 	region, err := s.Region()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse instance region")
+		return nil, errors.Join(err, errors.New("unable to parse instance region"))
 	}
 	provider, err := awsProvider(s.MotorRuntime.Motor.Provider)
 	if err != nil {
@@ -963,11 +963,11 @@ func (s *mqlAwsEc2Instance) GetPatchState() (interface{}, error) {
 	var res interface{}
 	instanceId, err := s.InstanceId()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse instance id")
+		return nil, errors.Join(err, errors.New("unable to parse instance id"))
 	}
 	region, err := s.Region()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse instance region")
+		return nil, errors.Join(err, errors.New("unable to parse instance region"))
 	}
 	provider, err := awsProvider(s.MotorRuntime.Motor.Provider)
 	if err != nil {
@@ -995,11 +995,11 @@ func (s *mqlAwsEc2Instance) GetInstanceStatus() (interface{}, error) {
 	var res interface{}
 	instanceId, err := s.InstanceId()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse instance id")
+		return nil, errors.Join(err, errors.New("unable to parse instance id"))
 	}
 	region, err := s.Region()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse instance region")
+		return nil, errors.Join(err, errors.New("unable to parse instance region"))
 	}
 	provider, err := awsProvider(s.MotorRuntime.Motor.Provider)
 	if err != nil {
@@ -1430,11 +1430,11 @@ func (s *mqlAwsEc2) getSnapshots(provider *aws_provider.Provider) []*jobpool.Job
 func (s *mqlAwsEc2Snapshot) GetCreateVolumePermission() ([]interface{}, error) {
 	id, err := s.Id()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse instance id")
+		return nil, errors.Join(err, errors.New("unable to parse instance id"))
 	}
 	region, err := s.Region()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse instance region")
+		return nil, errors.Join(err, errors.New("unable to parse instance region"))
 	}
 	provider, err := awsProvider(s.MotorRuntime.Motor.Provider)
 	if err != nil {

--- a/resources/packs/aws/aws_ecr.go
+++ b/resources/packs/aws/aws_ecr.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"errors"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/aws/aws-sdk-go-v2/service/ecrpublic"
-	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources"
@@ -140,19 +140,19 @@ func (e *mqlAwsEcr) getPrivateRepositories(provider *aws.Provider) []*jobpool.Jo
 func (e *mqlAwsEcrRepository) GetImages() ([]interface{}, error) {
 	name, err := e.Name()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse name")
+		return nil, errors.Join(err, errors.New("unable to parse name"))
 	}
 	region, err := e.Region()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse region")
+		return nil, errors.Join(err, errors.New("unable to parse region"))
 	}
 	public, err := e.Public()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse public val")
+		return nil, errors.Join(err, errors.New("unable to parse public val"))
 	}
 	uri, err := e.Uri()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse uri val")
+		return nil, errors.Join(err, errors.New("unable to parse uri val"))
 	}
 	at, err := awsProvider(e.MotorRuntime.Motor.Provider)
 	if err != nil {

--- a/resources/packs/aws/aws_ecs.go
+++ b/resources/packs/aws/aws_ecs.go
@@ -11,8 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 
+	"errors"
 	ecsservice "github.com/aws/aws-sdk-go-v2/service/ecs"
-	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources"
@@ -127,7 +127,7 @@ func (ecs *mqlAwsEcs) getECSClusters(provider *aws_provider.Provider) []*jobpool
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
-					return nil, errors.Wrap(err, "could not gather ecs cluster information")
+					return nil, errors.Join(err, errors.New("could not gather ecs cluster information"))
 				}
 				nextToken = resp.NextToken
 				if resp.NextToken != nil {
@@ -182,7 +182,7 @@ func (e *mqlAwsEcsCluster) init(args *resources.Args) (*resources.Args, AwsEcsCl
 		return nil, nil, err
 	}
 	if len(clusterDetails.Clusters) != 1 {
-		return nil, nil, errors.Newf("only expected one cluster, got %d", len(clusterDetails.Clusters))
+		return nil, nil, errors.New(fmt.Sprintf("only expected one cluster, got %d", len(clusterDetails.Clusters)))
 	}
 	c := clusterDetails.Clusters[0]
 	configuration, err := core.JsonToDict(c.Configuration)
@@ -306,7 +306,7 @@ func (ecs *mqlAwsEcsCluster) GetTasks() ([]interface{}, error) {
 	for nextToken != nil {
 		resp, err := svc.ListTasks(ctx, params)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not gather ecs tasks information")
+			return nil, errors.Join(err, errors.New("could not gather ecs tasks information"))
 		}
 		nextToken = resp.NextToken
 		if resp.NextToken != nil {
@@ -369,7 +369,7 @@ func (e *mqlAwsEcsTask) init(args *resources.Args) (*resources.Args, AwsEcsTask,
 		return nil, nil, err
 	}
 	if len(taskDetails.Tasks) != 1 {
-		return nil, nil, errors.Newf("only expected one task, got %d", len(taskDetails.Tasks))
+		return nil, nil, errors.New(fmt.Sprintf("only expected one task, got %d", len(taskDetails.Tasks)))
 	}
 	t := taskDetails.Tasks[0]
 	taskDefinitionArn := t.TaskDefinitionArn

--- a/resources/packs/aws/aws_efs.go
+++ b/resources/packs/aws/aws_efs.go
@@ -3,10 +3,10 @@ package aws
 import (
 	"context"
 
+	"errors"
 	"github.com/aws/aws-sdk-go-v2/service/efs"
 	"github.com/aws/aws-sdk-go-v2/service/efs/types"
 	"github.com/aws/smithy-go/transport/http"
-	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources"
@@ -170,11 +170,11 @@ func (e *mqlAwsEfsFilesystem) GetKmsKey() (interface{}, error) {
 func (e *mqlAwsEfsFilesystem) GetBackupPolicy() (interface{}, error) {
 	id, err := e.Id()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse id")
+		return nil, errors.Join(err, errors.New("unable to parse id"))
 	}
 	region, err := e.Region()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse instance region")
+		return nil, errors.Join(err, errors.New("unable to parse instance region"))
 	}
 	provider, err := awsProvider(e.MotorRuntime.Motor.Provider)
 	if err != nil {

--- a/resources/packs/aws/aws_lambda.go
+++ b/resources/packs/aws/aws_lambda.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"encoding/json"
 
+	"errors"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	"github.com/aws/smithy-go/transport/http"
-	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources"
@@ -64,7 +64,7 @@ func (l *mqlAwsLambda) getFunctions(provider *aws_provider.Provider) []*jobpool.
 						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
 						return res, nil
 					}
-					return nil, errors.Wrap(err, "could not gather aws lambda functions")
+					return nil, errors.Join(err, errors.New("could not gather aws lambda functions"))
 				}
 				for _, function := range functionsResp.Functions {
 					vpcConfigJson, err := core.JsonToDict(function.VpcConfig)
@@ -168,7 +168,7 @@ func (l *mqlAwsLambdaFunction) GetConcurrency() (int64, error) {
 	// no pagination required
 	functionConcurrency, err := svc.GetFunctionConcurrency(ctx, &lambda.GetFunctionConcurrencyInput{FunctionName: &funcName})
 	if err != nil {
-		return 0, errors.Wrap(err, "could not gather aws lambda function concurrency")
+		return 0, errors.Join(err, errors.New("could not gather aws lambda function concurrency"))
 	}
 	if functionConcurrency.ReservedConcurrentExecutions != nil {
 		return core.ToInt64From32(functionConcurrency.ReservedConcurrentExecutions), nil

--- a/resources/packs/aws/aws_ssm.go
+++ b/resources/packs/aws/aws_ssm.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"errors"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
-	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	aws_provider "go.mondoo.com/cnquery/motor/providers/aws"
 	"go.mondoo.com/cnquery/resources"
@@ -73,7 +73,7 @@ func (s *mqlAwsSsm) getInstances(provider *aws_provider.Provider) []*jobpool.Job
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
-					return nil, errors.Wrap(err, "could not gather ssm information")
+					return nil, errors.Join(err, errors.New("could not gather ssm information"))
 				}
 				nextToken = isssmresp.NextToken
 				if isssmresp.NextToken != nil {

--- a/resources/packs/azure/azure_ad.go
+++ b/resources/packs/azure/azure_ad.go
@@ -3,7 +3,7 @@ package azure
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/microsoft/kiota-abstractions-go/authentication"
 	a "github.com/microsoft/kiota-authentication-azure-go"
 	msgraphclient "github.com/microsoftgraph/msgraph-sdk-go"

--- a/resources/packs/core/dnsshake/dnsshake.go
+++ b/resources/packs/core/dnsshake/dnsshake.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/hashicorp/go-multierror"
 	"github.com/miekg/dns"
 )

--- a/resources/packs/core/kernel.go
+++ b/resources/packs/core/kernel.go
@@ -3,7 +3,7 @@ package core
 import (
 	"strings"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/motor/platform"
 	"go.mondoo.com/cnquery/resources"
@@ -208,7 +208,7 @@ func (k *mqlKernel) GetInfo() (interface{}, error) {
 	// find suitable kernel module manager
 	mm, err := kernel.ResolveManager(k.MotorRuntime.Motor)
 	if mm == nil || err != nil {
-		return nil, errors.Wrap(err, "could not detect suitable kernel module manager for platform")
+		return nil, errors.Join(err, errors.New("could not detect suitable kernel module manager for platform"))
 	}
 
 	// retrieve all kernel modules
@@ -224,7 +224,7 @@ func (k *mqlKernel) GetParameters() (map[string]interface{}, error) {
 	// find suitable kernel module manager
 	mm, err := kernel.ResolveManager(k.MotorRuntime.Motor)
 	if mm == nil || err != nil {
-		return nil, errors.Wrap(err, "could not detect suitable kernel module manager for platform")
+		return nil, errors.Join(err, errors.New("could not detect suitable kernel module manager for platform"))
 	}
 
 	// retrieve all kernel modules
@@ -246,13 +246,13 @@ func (k *mqlKernel) GetModules() ([]interface{}, error) {
 	// find suitable kernel module manager
 	mm, err := kernel.ResolveManager(k.MotorRuntime.Motor)
 	if mm == nil || err != nil {
-		return nil, errors.Wrap(err, "could not detect suitable kernel module manager for platform")
+		return nil, errors.Join(err, errors.New("could not detect suitable kernel module manager for platform"))
 	}
 
 	// retrieve all kernel modules
 	kernelModules, err := mm.Modules()
 	if err != nil {
-		return nil, errors.Wrap(err, "could not retrieve kernel module list for platform")
+		return nil, errors.Join(err, errors.New("could not retrieve kernel module list for platform"))
 	}
 	log.Debug().Int("modules", len(kernelModules)).Msg("[kernel.modules]> modules")
 

--- a/resources/packs/core/kernel/info.go
+++ b/resources/packs/core/kernel/info.go
@@ -1,7 +1,7 @@
 package kernel
 
 import (
-	"github.com/cockroachdb/errors"
+	"errors"
 	"io"
 	"io/ioutil"
 	"regexp"

--- a/resources/packs/core/kernel/manager.go
+++ b/resources/packs/core/kernel/manager.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"go.mondoo.com/cnquery/motor/providers"
@@ -159,7 +159,7 @@ func (s *LinuxKernelManager) Modules() ([]*KernelModule, error) {
 	// TODO: use proc in future
 	cmd, err := s.provider.RunCommand("/sbin/lsmod")
 	if err != nil {
-		return nil, errors.Wrap(err, "could not read kernel modules")
+		return nil, errors.Join(err, errors.New("could not read kernel modules"))
 	}
 
 	return ParseLsmod(cmd.Stdout), nil
@@ -176,12 +176,12 @@ func (s *OSXKernelManager) Name() string {
 func (s *OSXKernelManager) Info() (KernelInfo, error) {
 	cmd, err := s.provider.RunCommand("uname -r")
 	if err != nil {
-		return KernelInfo{}, errors.Wrap(err, "could not read kernel parameters")
+		return KernelInfo{}, errors.Join(err, errors.New("could not read kernel parameters"))
 	}
 
 	data, err := ioutil.ReadAll(cmd.Stdout)
 	if err != nil {
-		return KernelInfo{}, errors.Wrap(err, "could not read kernel parameters")
+		return KernelInfo{}, errors.Join(err, errors.New("could not read kernel parameters"))
 	}
 
 	return KernelInfo{
@@ -192,7 +192,7 @@ func (s *OSXKernelManager) Info() (KernelInfo, error) {
 func (s *OSXKernelManager) Parameters() (map[string]string, error) {
 	cmd, err := s.provider.RunCommand("sysctl -a")
 	if err != nil {
-		return nil, errors.Wrap(err, "could not read kernel parameters")
+		return nil, errors.Join(err, errors.New("could not read kernel parameters"))
 	}
 
 	return ParseSysctl(cmd.Stdout, ":")
@@ -201,7 +201,7 @@ func (s *OSXKernelManager) Parameters() (map[string]string, error) {
 func (s *OSXKernelManager) Modules() ([]*KernelModule, error) {
 	cmd, err := s.provider.RunCommand("kextstat")
 	if err != nil {
-		return nil, errors.Wrap(err, "could not read kernel modules")
+		return nil, errors.Join(err, errors.New("could not read kernel modules"))
 	}
 
 	return ParseKextstat(cmd.Stdout), nil
@@ -222,7 +222,7 @@ func (s *FreebsdKernelManager) Info() (KernelInfo, error) {
 func (s *FreebsdKernelManager) Parameters() (map[string]string, error) {
 	cmd, err := s.provider.RunCommand("sysctl -a")
 	if err != nil {
-		return nil, errors.Wrap(err, "could not read kernel parameters")
+		return nil, errors.Join(err, errors.New("could not read kernel parameters"))
 	}
 
 	return ParseSysctl(cmd.Stdout, ":")
@@ -231,7 +231,7 @@ func (s *FreebsdKernelManager) Parameters() (map[string]string, error) {
 func (s *FreebsdKernelManager) Modules() ([]*KernelModule, error) {
 	cmd, err := s.provider.RunCommand("kldstat")
 	if err != nil {
-		return nil, errors.Wrap(err, "could not read kernel modules")
+		return nil, errors.Join(err, errors.New("could not read kernel modules"))
 	}
 
 	return ParseKldstat(cmd.Stdout), nil

--- a/resources/packs/core/networkinterface/hostip.go
+++ b/resources/packs/core/networkinterface/hostip.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"sort"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 )
 
@@ -92,7 +92,7 @@ func HostIP(interfaces []Interface) (ip string, err error) {
 func GetOutboundIP() (net.IP, error) {
 	conn, err := net.Dial("udp", "1.1.1.1:80")
 	if err != nil {
-		return nil, errors.Wrap(err, "could not determine outbound ip")
+		return nil, errors.Join(err, errors.New("could not determine outbound ip"))
 	}
 	defer conn.Close()
 

--- a/resources/packs/core/networkinterface/interface.go
+++ b/resources/packs/core/networkinterface/interface.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/motor"
 	"go.mondoo.com/cnquery/motor/platform"
@@ -95,7 +95,7 @@ func (i *GoNativeInterfaceHandler) Interfaces() ([]Interface, error) {
 	var goInterfaces []net.Interface
 	var err error
 	if goInterfaces, err = net.Interfaces(); err != nil {
-		return nil, errors.Wrap(err, "failed to load network interfaces")
+		return nil, errors.Join(err, errors.New("failed to load network interfaces"))
 	}
 
 	ifaces := make([]Interface, len(goInterfaces))
@@ -133,7 +133,7 @@ func (i *LinuxInterfaceHandler) Interfaces() ([]Interface, error) {
 	// fetch all network adapter via ip addr show
 	cmd, err := i.provider.RunCommand("ip -o addr show")
 	if err != nil {
-		return nil, errors.Wrap(err, "could not fetch macos network adapter")
+		return nil, errors.Join(err, errors.New("could not fetch macos network adapter"))
 	}
 
 	return i.ParseIpAddr(cmd.Stdout)
@@ -219,7 +219,7 @@ func (i *MacOSInterfaceHandler) Interfaces() ([]Interface, error) {
 	// fetch all network adapter
 	cmd, err := i.provider.RunCommand("ifconfig")
 	if err != nil {
-		return nil, errors.Wrap(err, "could not fetch macos network adapter")
+		return nil, errors.Join(err, errors.New("could not fetch macos network adapter"))
 	}
 
 	return i.ParseMacOS(cmd.Stdout)
@@ -245,7 +245,7 @@ func (i *MacOSInterfaceHandler) ParseMacOS(r io.Reader) ([]Interface, error) {
 			var err error
 			mtu, err = strconv.Atoi(strings.TrimSpace(m[4]))
 			if err != nil {
-				return nil, errors.Wrap(err, "cannot parse macos ifconfig mtu")
+				return nil, errors.Join(err, errors.New("cannot parse macos ifconfig mtu"))
 			}
 
 			var flags net.Flags
@@ -400,21 +400,21 @@ func (i *WindowsInterfaceHandler) Interfaces() ([]Interface, error) {
 	// fetch all network adapter
 	cmd, err := i.provider.RunCommand(powershell.Wrap(WinGetNetAdapter))
 	if err != nil {
-		return nil, errors.Wrap(err, "could not fetch windows network adapter")
+		return nil, errors.Join(err, errors.New("could not fetch windows network adapter"))
 	}
 	winAdapter, err := i.ParseNetAdapter(cmd.Stdout)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not parse windows network adapter list")
+		return nil, errors.Join(err, errors.New("could not parse windows network adapter list"))
 	}
 
 	// fetch all ip addresses
 	cmd, err = i.provider.RunCommand(powershell.Wrap(WinGetNetIPAddress))
 	if err != nil {
-		return nil, errors.Wrap(err, "could not fetch windows ip addresses")
+		return nil, errors.Join(err, errors.New("could not fetch windows ip addresses"))
 	}
 	winIpAddresses, err := i.ParseNetIpAdresses(cmd.Stdout)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not parse windows ip addresses")
+		return nil, errors.Join(err, errors.New("could not parse windows ip addresses"))
 	}
 
 	// map information together

--- a/resources/packs/core/packages.go
+++ b/resources/packs/core/packages.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/resources"
@@ -106,7 +106,7 @@ func (p *mqlPackages) GetList() ([]interface{}, error) {
 	// retrieve all system packages
 	osPkgs, err := pm.List()
 	if err != nil {
-		return nil, errors.Wrap(err, "could not retrieve package list for platform")
+		return nil, errors.Join(err, errors.New("could not retrieve package list for platform"))
 	}
 	log.Debug().Int("packages", len(osPkgs)).Msg("mql[packages]> installed packages")
 

--- a/resources/packs/core/packages/macos_packages.go
+++ b/resources/packs/core/packages/macos_packages.go
@@ -8,7 +8,7 @@ import (
 
 	"go.mondoo.com/cnquery/motor/providers/os"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	plist "howett.net/plist"
 )
 

--- a/resources/packs/core/packages/packages.go
+++ b/resources/packs/core/packages/packages.go
@@ -1,7 +1,7 @@
 package packages
 
 import (
-	"github.com/cockroachdb/errors"
+	"errors"
 	"go.mondoo.com/cnquery/motor"
 	"go.mondoo.com/cnquery/motor/providers/os"
 )

--- a/resources/packs/core/packages/pacman_packages.go
+++ b/resources/packs/core/packages/pacman_packages.go
@@ -8,7 +8,7 @@ import (
 
 	"go.mondoo.com/cnquery/motor/providers/os"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 )
 
 const (

--- a/resources/packs/core/packages/windows_packages.go
+++ b/resources/packs/core/packages/windows_packages.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/motor/platform"
 	"go.mondoo.com/cnquery/motor/platform/windows"
@@ -232,11 +232,11 @@ func (w *WinPkgManager) List() ([]Package, error) {
 	// hotfixes
 	cmd, err = w.provider.RunCommand(powershell.Wrap(WINDOWS_QUERY_HOTFIXES))
 	if err != nil {
-		return nil, errors.Wrap(err, "could not fetch hotfixes")
+		return nil, errors.Join(err, errors.New("could not fetch hotfixes"))
 	}
 	hotfixes, err := ParseWindowsHotfixes(cmd.Stdout)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not parse hotfix results")
+		return nil, errors.Join(err, errors.New("could not parse hotfix results"))
 	}
 	hotfixAsPkgs := HotFixesToPackages(hotfixes)
 

--- a/resources/packs/core/processes/linuxproc.go
+++ b/resources/packs/core/processes/linuxproc.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"go.mondoo.com/cnquery/motor/providers/os"
@@ -23,7 +23,7 @@ func (lpm *LinuxProcManager) List() ([]*OSProcess, error) {
 	// get all subdirectories of /proc, filter by numbers
 	f, err := lpm.provider.FS().Open("/proc")
 	if err != nil {
-		return nil, errors.WithMessage(err, "failed to access /proc")
+		return nil, errors.Join(err, errors.New("failed to access /proc"))
 	}
 
 	dirs, err := f.Readdirnames(-1)

--- a/resources/packs/core/tls.go
+++ b/resources/packs/core/tls.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"go.mondoo.com/cnquery/llx"
 	"go.mondoo.com/cnquery/motor/providers/network"
 	"go.mondoo.com/cnquery/resources"

--- a/resources/packs/github/github.go
+++ b/resources/packs/github/github.go
@@ -3,7 +3,7 @@ package github
 import (
 	"time"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/google/go-github/v49/github"
 	"go.mondoo.com/cnquery/motor/providers"
 	provider "go.mondoo.com/cnquery/motor/providers/github"

--- a/resources/packs/github/github_user.go
+++ b/resources/packs/github/github_user.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/google/go-github/v49/github"
 	"go.mondoo.com/cnquery/resources"
 	"go.mondoo.com/cnquery/resources/packs/core"

--- a/resources/packs/ms365/msgraph.go
+++ b/resources/packs/ms365/msgraph.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/microsoft/kiota-abstractions-go/authentication"
 	a "github.com/microsoft/kiota-authentication-azure-go"
 	msgraphclient "github.com/microsoftgraph/msgraph-sdk-go"

--- a/resources/packs/os/equinix.go
+++ b/resources/packs/os/equinix.go
@@ -3,7 +3,7 @@ package os
 import (
 	"time"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/packethost/packngo"
 	"go.mondoo.com/cnquery/motor/providers"
 	equinix_provider "go.mondoo.com/cnquery/motor/providers/equinix"

--- a/resources/packs/os/machine.go
+++ b/resources/packs/os/machine.go
@@ -3,7 +3,7 @@ package os
 import (
 	"fmt"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"go.mondoo.com/cnquery/resources"
 	"go.mondoo.com/cnquery/resources/packs/os/smbios"
 )
@@ -29,7 +29,7 @@ func getbiosinfo(runtime *resources.Runtime) (*smbios.SmBiosInfo, error) {
 		// find suitable package manager
 		pf, err := runtime.Motor.Platform()
 		if err != nil {
-			return nil, errors.Wrap(err, "could not detect suitable smbios manager for platform")
+			return nil, errors.Join(err, errors.New("could not detect suitable smbios manager for platform"))
 		}
 
 		osProvider, err := osProvider(runtime.Motor)
@@ -45,7 +45,7 @@ func getbiosinfo(runtime *resources.Runtime) (*smbios.SmBiosInfo, error) {
 		// retrieve smbios info
 		biosInfo, err = pm.Info()
 		if err != nil {
-			return nil, errors.Wrap(err, "could not retrieve smbios info for platform")
+			return nil, errors.Join(err, errors.New("could not retrieve smbios info for platform"))
 		}
 
 		machine.MqlResource().Cache.Store("_biosInfo", &resources.CacheEntry{Data: biosInfo})

--- a/resources/packs/os/mount/manager.go
+++ b/resources/packs/os/mount/manager.go
@@ -1,7 +1,7 @@
 package mount
 
 import (
-	"github.com/cockroachdb/errors"
+	"errors"
 	"go.mondoo.com/cnquery/motor"
 	"go.mondoo.com/cnquery/motor/providers"
 	"go.mondoo.com/cnquery/motor/providers/os"
@@ -69,7 +69,7 @@ func (s *LinuxMountManager) List() ([]MountPoint, error) {
 	if s.provider.Capabilities().HasCapability(providers.Capability_RunCommand) {
 		cmd, err := s.provider.RunCommand("mount")
 		if err != nil {
-			return nil, errors.Wrap(err, "could not read mounts")
+			return nil, errors.Join(err, errors.New("could not read mounts"))
 		}
 		return ParseLinuxMountCmd(cmd.Stdout), nil
 	} else if s.provider.Capabilities().HasCapability(providers.Capability_File) {
@@ -90,7 +90,7 @@ func (s *UnixMountManager) Name() string {
 func (s *UnixMountManager) List() ([]MountPoint, error) {
 	cmd, err := s.provider.RunCommand("mount")
 	if err != nil {
-		return nil, errors.Wrap(err, "could not read package list")
+		return nil, errors.Join(err, errors.New("could not read package list"))
 	}
 
 	return ParseUnixMountCmd(cmd.Stdout), nil

--- a/resources/packs/os/mount/mount.go
+++ b/resources/packs/os/mount/mount.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/spf13/afero"
 )
 

--- a/resources/packs/os/os.go
+++ b/resources/packs/os/os.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/llx"
 	"go.mondoo.com/cnquery/motor"
@@ -337,7 +337,7 @@ func (s *mqlOs) GetMachineid() (string, error) {
 
 	uuidProvider, err := platformid.MachineIDProvider(osProvider, platform)
 	if err != nil {
-		return "", errors.Wrap(err, "cannot determine platform uuid")
+		return "", errors.Join(err, errors.New("cannot determine platform uuid"))
 	}
 
 	if uuidProvider == nil {
@@ -346,7 +346,7 @@ func (s *mqlOs) GetMachineid() (string, error) {
 
 	id, err := uuidProvider.ID()
 	if err != nil {
-		return "", errors.Wrap(err, "cannot determine platform uuid")
+		return "", errors.Join(err, errors.New("cannot determine platform uuid"))
 	}
 
 	return id, nil
@@ -647,7 +647,7 @@ func (s *mqlOsBase) GetMachineid() (string, error) {
 
 	uuidProvider, err := platformid.MachineIDProvider(osProvider, platform)
 	if err != nil {
-		return "", errors.Wrap(err, "cannot determine platform uuid")
+		return "", errors.Join(err, errors.New("cannot determine platform uuid"))
 	}
 
 	if uuidProvider == nil {
@@ -656,7 +656,7 @@ func (s *mqlOsBase) GetMachineid() (string, error) {
 
 	id, err := uuidProvider.ID()
 	if err != nil {
-		return "", errors.Wrap(err, "cannot determine platform uuid")
+		return "", errors.Join(err, errors.New("cannot determine platform uuid"))
 	}
 
 	return id, nil

--- a/resources/packs/os/secpol.go
+++ b/resources/packs/os/secpol.go
@@ -1,7 +1,7 @@
 package os
 
 import (
-	"github.com/cockroachdb/errors"
+	"errors"
 	"go.mondoo.com/cnquery/motor/providers/os/powershell"
 	"go.mondoo.com/cnquery/resources"
 	"go.mondoo.com/cnquery/resources/packs/os/windows"
@@ -30,7 +30,7 @@ func (s *mqlSecpol) policy() (*windows.Secpol, error) {
 
 	cmd, err := osProvider.RunCommand(encoded)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not run secpol script")
+		return nil, errors.Join(err, errors.New("could not run secpol script"))
 	}
 
 	policy, err = windows.ParseSecpol(cmd.Stdout)

--- a/resources/packs/os/windows/secpol.go
+++ b/resources/packs/os/windows/secpol.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"gopkg.in/ini.v1"
 )
 
@@ -26,7 +26,7 @@ func ParseSecpol(r io.Reader) (*Secpol, error) {
 
 	cfg, err := ini.Load(r)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not parse secpol")
+		return nil, errors.Join(err, errors.New("could not parse secpol"))
 	}
 
 	sysAccess, err := cfg.GetSection("System Access")

--- a/resources/packs/os/yum.go
+++ b/resources/packs/os/yum.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"go.mondoo.com/cnquery/resources"
 	"go.mondoo.com/cnquery/resources/packs/core"
 	"go.mondoo.com/cnquery/resources/packs/os/yum"
@@ -35,7 +35,7 @@ func (y *mqlYum) GetRepos() ([]interface{}, error) {
 
 	cmd, err := osProvider.RunCommand("yum -v repolist all")
 	if err != nil {
-		return nil, errors.Wrap(err, "could not retrieve yum repo list")
+		return nil, errors.Join(err, errors.New("could not retrieve yum repo list"))
 	}
 
 	if cmd.ExitStatus != 0 {

--- a/resources/packs/terraform/hcl.go
+++ b/resources/packs/terraform/hcl.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cockroachdb/errors"
+	"errors"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/typeexpr"
 	"github.com/hashicorp/hcl/v2/hclsyntax"


### PR DESCRIPTION
Replacing the cockroachdb `errors.Wrap` with `errors.Join` which is available since go 1.20.

Related discussion: https://github.com/orgs/mondoohq/discussions/1328#discussioncomment-6335615