### PR TITLE
⭐ add assume role support for aws

### DIFF
--- a/apps/cnquery/cmd/builder/common/common.go
+++ b/apps/cnquery/cmd/builder/common/common.go
@@ -319,6 +319,8 @@ func AwsProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runFn R
 	commonCmdFlags(cmd)
 	cmd.Flags().String("profile", "", "pick a named AWS profile to use")
 	cmd.Flags().String("region", "", "the AWS region to scan")
+	cmd.Flags().String("role-arn", "", "the role ARN to use for assume-role")
+	cmd.Flags().String("external-id", "", "the external id to use for assume-role")
 	return cmd
 }
 

--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -326,6 +326,16 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 			connection.Options["region"] = region
 		}
 
+		if role, err := cmd.Flags().GetString("role-arn"); err != nil {
+			log.Fatal().Err(err).Msg("cannot parse --role-arn values")
+		} else if role != "" {
+			connection.Options["role-arn"] = role
+		}
+		if ext, err := cmd.Flags().GetString("external-id"); err != nil {
+			log.Fatal().Err(err).Msg("cannot parse --external-id values")
+		} else if ext != "" {
+			connection.Options["external-id"] = ext
+		}
 	case providers.ProviderType_AWS_EC2_EBS:
 		noSetup := "false"
 		if connection.Options[snapshot.NoSetup] != "" {


### PR DESCRIPTION
add assume role support for aws


`go run apps/cnquery/cnquery.go shell aws --option role-arn=ROLEARN `
`go run apps/cnquery/cnquery.go shell aws --option role-arn=ROLEARN --option external-id=EXTERNALID`