### PR TITLE
🐛 maintain correct binding chain when adding assessment fields to defaults

### DIFF
--- a/llx/code.go
+++ b/llx/code.go
@@ -12,6 +12,10 @@ func (b *Block) ChunkIndex() uint32 {
 	return uint32(len(b.Chunks))
 }
 
+func ChunkIndex(ref uint64) uint32 {
+	return uint32(ref & 0xFFFFFFFF)
+}
+
 func absRef(blockRef uint64, relRef uint32) uint64 {
 	return (blockRef & 0xFFFFFFFF00000000) | uint64(relRef)
 }

--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -1738,10 +1738,104 @@ func (c *compiler) addValueFieldChunks(ref uint64) {
 		ref = chunk.Function.Binding
 	}
 
+	type fieldTreeNode struct {
+		id       string
+		chunk    *llx.Chunk
+		chunkIdx int
+		children map[string]*fieldTreeNode
+	}
+
+	type fieldTree struct {
+		nodes []*fieldTreeNode
+	}
+
+	blockToFieldTree := func(block *llx.Block, filter func(chunkIdx int, chunk *llx.Chunk) bool) fieldTree {
+		// This function assumes the chunks are topologically sorted such
+		// that any dependency is always before the chunk that depends on it
+		nodes := make([]*fieldTreeNode, len(block.Chunks))
+		for i := range block.Chunks {
+			chunk := block.Chunks[i]
+			if !filter(i, chunk) {
+				continue
+			}
+			nodes[i] = &fieldTreeNode{
+				id:       chunk.Id,
+				chunk:    chunk,
+				chunkIdx: i + 1,
+				children: map[string]*fieldTreeNode{},
+			}
+
+			if chunk.Function != nil && chunk.Function.Binding != 0 {
+				chunkIdx := llx.ChunkIndex(chunk.Function.Binding)
+				parent := nodes[chunkIdx-1]
+				if parent != nil {
+					nodes[chunkIdx-1].children[chunk.Id] = nodes[i]
+				}
+			}
+		}
+
+		return fieldTree{
+			nodes: nodes,
+		}
+	}
+
+	addToTree := func(tree *fieldTree, parentPath []string, blockRef uint64, block *llx.Block, chunk *llx.Chunk) bool {
+		// add a chunk to the tree. If the path already exists, do nothing
+		// return true if the chunk was added, false if it already existed
+		if len(tree.nodes) != len(block.Chunks) {
+			panic("tree and block chunks do not match")
+		}
+
+		parent := tree.nodes[0]
+		for _, id := range parentPath[1:] {
+			child := parent.children[id]
+			parent = child
+		}
+
+		if parent.children[chunk.Id] != nil {
+			return false
+		}
+
+		newChunk := chunk
+		if chunk.Function != nil {
+			newChunk = &llx.Chunk{
+				Call: chunk.Call,
+				Id:   chunk.Id,
+				Function: &llx.Function{
+					Binding: (blockRef & 0xFFFFFFFF00000000) | uint64(parent.chunkIdx),
+					Type:    chunk.Function.Type,
+					Args:    chunk.Function.Args,
+				},
+			}
+		}
+
+		parent.children[chunk.Id] = &fieldTreeNode{
+			id:       chunk.Id,
+			chunk:    newChunk,
+			chunkIdx: len(tree.nodes) + 1,
+			children: map[string]*fieldTreeNode{},
+		}
+		tree.nodes = append(tree.nodes, parent.children[chunk.Id])
+		block.AddChunk(c.Result.CodeV2, blockRef, newChunk)
+
+		return true
+	}
+
+	var visitTreeNodes func(tree *fieldTree, node *fieldTreeNode, path []string, visit func(tree *fieldTree, node *fieldTreeNode, path []string))
+	visitTreeNodes = func(tree *fieldTree, node *fieldTreeNode, path []string, visit func(tree *fieldTree, node *fieldTreeNode, path []string)) {
+		if node == nil {
+			return
+		}
+		path = append(path, node.id)
+		for _, child := range node.children {
+			visit(tree, child, path)
+			visitTreeNodes(tree, child, path, visit)
+		}
+	}
+
 	// This block holds all the data and function chunks used
 	// for the predicate(s) of the .all()/.none()/... fucntion
 	var assessmentBlock *llx.Block
-	var assessmentBlockRef uint64
 	// find the referenced block for the where function
 	for i := len(whereChunk.Function.Args) - 1; i >= 0; i-- {
 		arg := whereChunk.Function.Args[i]
@@ -1749,80 +1843,41 @@ func (c *compiler) addValueFieldChunks(ref uint64) {
 			raw := arg.RawData()
 			blockRef := raw.Value.(uint64)
 			assessmentBlock = c.Result.CodeV2.Block(blockRef)
-			assessmentBlockRef = blockRef
 			break
 		}
 	}
+	assessmentBlockTree := blockToFieldTree(assessmentBlock, func(chunkIdx int, chunk *llx.Chunk) bool {
+		if chunk.Id == "$whereNot" || chunk.Id == "where" {
+			return false
+		} else if _, compareable := llx.ComparableLabel(chunk.Id); compareable {
+			return false
+		} else if chunk.Function != nil && len(chunk.Function.Args) > 0 {
+			// filter out nested function block that require other blocks
+			// This at least makes https://github.com/mondoohq/cnquery/issues/1339
+			// not panic
+			for _, arg := range chunk.Function.Args {
+				if types.Type(arg.Type).Underlying() == types.Ref {
+					return false
+				}
+			}
+
+		}
+		return true
+	})
 
 	defaultFieldsBlock := c.Result.CodeV2.Blocks[len(c.Result.CodeV2.Blocks)-1]
 	defaultFieldsRef := defaultFieldsBlock.HeadRef(c.Result.CodeV2.LastBlockRef())
-	var resourceFieldsRef uint64
-	if assessmentBlock.Chunks[1].Function != nil {
-		resourceFieldsRef = assessmentBlock.HeadRef(assessmentBlockRef)
-	}
+	defaultFieldsBlockTree := blockToFieldTree(defaultFieldsBlock, func(chunkIdx int, chunk *llx.Chunk) bool {
+		return true
+	})
 
-	chunksToAdd := []*llx.Chunk{}
-	// Check whether the chunk is already present in the default fields block
-	// This can happen, when the assessment checks one of the default fields
-	// We can skip the first Chunk, as it is the resource binding
-	for i := 1; i < len(assessmentBlock.Chunks); i++ {
-		chunk := assessmentBlock.Chunks[i]
-		// filter out nested function block and only add fields for outer most resource
-		if chunk.Id == "$whereNot" || chunk.Id == "where" {
-			break
+	visitTreeNodes(&assessmentBlockTree, assessmentBlockTree.nodes[0], make([]string, 0, 16), func(tree *fieldTree, node *fieldTreeNode, path []string) {
+		// add the node to the assessment block tree
+		chunkAdded := addToTree(&defaultFieldsBlockTree, path, defaultFieldsRef, defaultFieldsBlock, node.chunk)
+		if chunkAdded && node.chunk.Function != nil {
+			defaultFieldsBlock.Entrypoints = append(defaultFieldsBlock.Entrypoints, (defaultFieldsRef&0xFFFFFFFF00000000)|uint64(len(defaultFieldsBlock.Chunks)))
 		}
-		chunkAlreadyPresent := false
-		for j := range defaultFieldsBlock.Chunks {
-			if chunk.Id == defaultFieldsBlock.Chunks[j].Id {
-				chunkAlreadyPresent = true
-				break
-			}
-		}
-		if chunkAlreadyPresent {
-			continue
-		}
-		// We do not need the comparison chunks
-		if _, compareable := llx.ComparableLabel(chunk.Id); compareable {
-			continue
-		}
-		newChunk := &llx.Chunk{
-			Call: chunk.Call,
-			Id:   chunk.Id,
-		}
-		if chunk.Function != nil {
-			newChunk.Function = &llx.Function{
-				Binding: chunk.Function.Binding,
-				Type:    chunk.Function.Type,
-				Args:    chunk.Function.Args,
-			}
-		}
-		chunksToAdd = append(chunksToAdd, newChunk)
-	}
-	if len(chunksToAdd) == 0 {
-		// looks like all fields are already present, nothing to do
-		// this can happen, when the assessment checks one of the default fields
-		return
-	}
-	chunkRef := defaultFieldsRef
-	for i := range chunksToAdd {
-		newChunk := chunksToAdd[i]
-		if newChunk.Function != nil {
-			// check whether the chunk originially bound to the resource, then bind it again to the resource and not the previous chunk
-			if newChunk.Function.Binding == resourceFieldsRef {
-				newChunk.Function.Binding = defaultFieldsRef
-			} else {
-				newChunk.Function.Binding = chunkRef
-			}
-		}
-
-		defaultFieldsBlock.AddChunk(c.Result.CodeV2, chunkRef, newChunk)
-		chunkRef = defaultFieldsBlock.TailRef(chunkRef)
-
-		// FIXME: it would be nice to only have the "leaf" chunks as entrypoints
-		// Now we get a lot of data that we don't necessarily need
-		// e.g. for dict["key"] we get the entry and the whole dict
-		defaultFieldsBlock.Entrypoints = append(defaultFieldsBlock.Entrypoints, chunkRef)
-	}
+	})
 }
 
 func (c *compiler) expandListResource(chunk *llx.Chunk, ref uint64) (*llx.Chunk, types.Type, uint64) {

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -888,6 +888,37 @@ func TestCompiler_ArrayAll(t *testing.T) {
 	})
 }
 
+func TestCompiler_All_Issue1316(t *testing.T) {
+	// https://github.com/mondoohq/cnquery/issues/1316
+	compileT(t, `files.find(from: ".", type: "file").all( permissions.other_readable == false )`, func(res *llx.CodeBundle) {
+		require.Equal(t, 3, len(res.CodeV2.Blocks))
+		require.Equal(t, 6, len(res.CodeV2.Blocks[2].Chunks))
+		assertPrimitive(t, &llx.Primitive{
+			Type: string(types.Resource("file")),
+		}, res.CodeV2.Blocks[2].Chunks[0])
+		assertFunction(t, "path", &llx.Function{
+			Type:    string(types.String),
+			Binding: (3 << 32) | 1,
+		}, res.CodeV2.Blocks[2].Chunks[1])
+		assertFunction(t, "size", &llx.Function{
+			Type:    string(types.Int),
+			Binding: (3 << 32) | 1,
+		}, res.CodeV2.Blocks[2].Chunks[2])
+		assertFunction(t, "permissions", &llx.Function{
+			Type:    string(types.Resource("file.permissions")),
+			Binding: (3 << 32) | 1,
+		}, res.CodeV2.Blocks[2].Chunks[3])
+		assertFunction(t, "string", &llx.Function{
+			Type:    string(types.String),
+			Binding: (3 << 32) | 4,
+		}, res.CodeV2.Blocks[2].Chunks[4])
+		assertFunction(t, "other_readable", &llx.Function{
+			Type:    string(types.Bool),
+			Binding: (3 << 32) | 4,
+		}, res.CodeV2.Blocks[2].Chunks[5])
+	})
+}
+
 //    =================
 //   👋   RESOURCES   🍹
 //    =================


### PR DESCRIPTION
This fixes an issue where the call binding chain was not being maintained when adding fields from the assessment block to the default fields block

For example:
```
go run apps/cnquery/cnquery.go run --ast -c '
entires = ["/etc/hosts"]
entires {
    files.find(from: _, type: "file").all( permissions.other_readable == false )
}
'
```
was producing:
```
-> block 1
   entrypoints: [<1,3>]
   1: [
     0: "/etc/hosts"
   ]
   2: ref<1,1>
   3: {} bind: <1,2> type:[]block (=> <2,0>)
-> block 2
   entrypoints: [<2,6>]
   1: _
   2: files.find bind: <0,0> type:files.find ("from", ref<2,1>, "type", "file")
   3: list bind: <2,2> type:[]file
   4: $whereNot bind: <2,2> type:files.find (ref<2,3>, => <3,0>)
   5: list bind: <2,4> type:[]file
   6: $all bind: <2,5> type:bool
   7: {} bind: <2,5> type:[]block (=> <4,0>)
-> block 3
   entrypoints: [<3,4>]
   1: file id = context
   2: permissions bind: <3,1> type:file.permissions
   3: other_readable bind: <3,2> type:bool
   4: == bind: <3,3> type:bool (false)
-> block 4
   entrypoints: [<4,2> <4,3> <4,5> <4,6>]
   1: file id = context
   2: path bind: <4,1> type:string
   3: size bind: <4,1> type:int
   4: permissions bind: <4,1> type:file.permissions
   5: string bind: <4,4> type:string
   6: other_readable bind: <4,1> type:bool
```

In this example, `<4,6>` shohuld bind to `<4,4>` but incorrectly assumed it should bind to `<4,1>`.

As part of this, I've filtered out any function calls that have references. This should keep https://github.com/mondoohq/cnquery/issues/1339 from panicking

Fixes https://github.com/mondoohq/cnquery/issues/1316