### PR TITLE
🐛 support variants for querypacks

### DIFF
--- a/explorer/querypack.go
+++ b/explorer/querypack.go
@@ -116,7 +116,7 @@ func ChecksumQueries(queries []*Mquery) (checksums.Fast, checksums.Fast) {
 
 		// we add this sanity check since we expose the method, but can't ensure
 		// that users have compiled everything beforehand
-		if query.Checksum == "" || query.CodeId == "" {
+		if query.Checksum == "" || (query.CodeId == "" && len(query.Variants) == 0) {
 			panic("internal error processing filter checksums: query is compiled")
 		}
 


### PR DESCRIPTION
I ran the experiment with https://github.com/mondoohq/cnquery-packs on the `scottford/terraform-asset-inventory-variants` branch. In this example, we have a querypack with queries in a group that use variants. The way the syntax is set up was not originally support. This PR enables it.

