### PR TITLE
🧹 decouple inventory manager from providers 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -140,36 +140,6 @@
         "--log-level",
         "debug"
       ],
-    },
-    {
-      "name": "z",
-      "type": "go",
-      "request": "launch",
-      "program": "${workspaceRoot}/apps/cnquery/cnquery.go",
-      "cwd": "${workspaceRoot}/",
-      "args": [
-        // "run", "ssh", "root@127.0.0.1:32771", "-p", "raoshie3quuY6ceeFaeliuvoNgae7w", "-c", "command('echo hello world'){ stdout stderr exitcode }",
-        // "--record", 
-        // "--recording", "recording.json",
-        // "-v", "--log-level", "warn",
-        // "run", "-c", "mondoo.version",
-        // "run", "-c", "asset{*}",
-        "run", "-c", "command('echo hello world') { stdout stderr exitcode }",
-        // "ports.all(ip6tables.input.any(options.contains(port)))",
-        // "sshd.config.params",
-        // "status",
-      ],
-    },
-    {
-      "name": "zlr",
-      "type": "go",
-      "request": "launch",
-      "program": "${workspaceRoot}/providers-sdk/v1/lr/cli/main.go",
-      "cwd": "${workspaceRoot}/",
-      "args": [
-        // "-v", "--log-level", "warn",
-        "go", "providers/os/resources/os.lr", "--dist", "providers/os/dist",
-      ],
     }
   ]
 }

--- a/apps/cnquery/cmd/shell.go
+++ b/apps/cnquery/cmd/shell.go
@@ -102,7 +102,7 @@ type ShellConfig struct {
 
 // StartShell will start an interactive CLI shell
 func StartShell(runtime *providers.Runtime, conf *ShellConfig) error {
-	im, err := manager.NewManager(manager.WithInventory(conf.Inventory))
+	im, err := manager.NewManager(manager.WithInventory(conf.Inventory, runtime))
 	if err != nil {
 		log.Fatal().Err(err).Msg("could not load asset information")
 	}

--- a/llx/data_conversions.go
+++ b/llx/data_conversions.go
@@ -567,7 +567,7 @@ func pmap2raw(p *Primitive) *RawData {
 func presource2raw(p *Primitive) *RawData {
 	id := string(p.Value)
 	typ := types.Type(p.Type)
-	return &RawData{Value: MockResource{
+	return &RawData{Value: &MockResource{
 		Name: typ.ResourceName(),
 		ID:   id,
 	}, Type: typ}
@@ -600,14 +600,19 @@ func primitive2array(b *blockExecutor, ref uint64, args []*Primitive) ([]interfa
 		return []interface{}{}, 0, nil
 	}
 
-	var cur *RawData
-	var rref uint64
-	var err error
 	res := make([]interface{}, len(args))
 	for i := range args {
-		cur, rref, err = b.resolveValue(args[i], ref)
-		if rref > 0 || err != nil {
-			return nil, rref, err
+		var cur *RawData
+
+		if b != nil && types.Type(args[i].Type) == types.Ref {
+			var rref uint64
+			var err error
+			cur, rref, err = b.resolveValue(args[i], ref)
+			if rref > 0 || err != nil {
+				return nil, rref, err
+			}
+		} else {
+			cur = args[i].RawData()
 		}
 
 		if cur != nil {

--- a/providers-sdk/v1/inventory/manager/credentials_query.go
+++ b/providers-sdk/v1/inventory/manager/credentials_query.go
@@ -11,7 +11,6 @@ import (
 	"go.mondoo.com/cnquery/mql"
 	"go.mondoo.com/cnquery/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/providers-sdk/v1/vault"
-	"go.mondoo.com/cnquery/providers/mock"
 	"go.mondoo.com/cnquery/types"
 )
 
@@ -22,9 +21,8 @@ type CredentialQueryResponse struct {
 	SecretId string `json:"secret_id,omitempty"` // id to use to fetch the secret from the source vault
 }
 
-func NewCredentialQueryRunner(credentialQuery string) (*CredentialQueryRunner, error) {
-	rt := mock.New()
-	mqlExecutor := mql.New(rt, cnquery.DefaultFeatures)
+func NewCredentialQueryRunner(credentialQuery string, runtime llx.Runtime) (*CredentialQueryRunner, error) {
+	mqlExecutor := mql.New(runtime, cnquery.DefaultFeatures)
 
 	// just empty props to ensure we can compile
 	props := map[string]*llx.Primitive{
@@ -35,7 +33,7 @@ func NewCredentialQueryRunner(credentialQuery string) (*CredentialQueryRunner, e
 	}
 
 	// test query to see if it compiles well
-	_, err := mql.Exec(credentialQuery, rt, nil, props)
+	_, err := mql.Exec(credentialQuery, runtime, nil, props)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not compile the secret metadata function")
 	}

--- a/providers-sdk/v1/inventory/manager/credentials_query_test.go
+++ b/providers-sdk/v1/inventory/manager/credentials_query_test.go
@@ -1,4 +1,4 @@
-package manager
+package manager_test
 
 import (
 	"testing"
@@ -6,13 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/cnquery/providers-sdk/v1/inventory"
+	"go.mondoo.com/cnquery/providers-sdk/v1/inventory/manager"
 	"go.mondoo.com/cnquery/providers-sdk/v1/vault"
+	"go.mondoo.com/cnquery/providers/mock"
 )
 
 func TestSecretKeySimple(t *testing.T) {
 	query := `{ type: 'ssh_agent' }`
-
-	runner, err := NewCredentialQueryRunner(query)
+	runner, err := manager.NewCredentialQueryRunner(query, mock.New())
 	require.NoError(t, err)
 	cred, err := runner.Run(&inventory.Asset{})
 	require.NoError(t, err)
@@ -27,7 +28,7 @@ func TestSecretKeyIfReturn(t *testing.T) {
 		return {type: 'private_key', secret_id: 'otherkey'}
 	`
 
-	runner, err := NewCredentialQueryRunner(query)
+	runner, err := manager.NewCredentialQueryRunner(query, mock.New())
 	require.NoError(t, err)
 
 	cred, err := runner.Run(&inventory.Asset{
@@ -49,7 +50,7 @@ func TestSecretKeyIfConditionalReturn(t *testing.T) {
         return { secret_id: '' }"
 	`
 
-	runner, err := NewCredentialQueryRunner(query)
+	runner, err := manager.NewCredentialQueryRunner(query, mock.New())
 	require.NoError(t, err)
 
 	// check with provided label

--- a/providers/mock/mock.go
+++ b/providers/mock/mock.go
@@ -85,6 +85,7 @@ func New() *Mock {
 	return &Mock{
 		Inventory: map[string]Resources{},
 		Providers: []string{},
+		schema:    emptySchema{},
 	}
 }
 
@@ -232,6 +233,14 @@ func (m *Mock) Schema() llx.Schema {
 	return m.schema
 }
 
-func (m *Mock) Close() {
-	// nothing to do yet...
+func (m *Mock) Close() {}
+
+type emptySchema struct{}
+
+func (e emptySchema) Lookup(resource string) *resources.ResourceInfo {
+	return nil
+}
+
+func (e emptySchema) AllResources() map[string]*resources.ResourceInfo {
+	return nil
 }

--- a/providers/os/connection/ssh.go
+++ b/providers/os/connection/ssh.go
@@ -19,7 +19,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"go.mondoo.com/cnquery/providers-sdk/v1/inventory"
-	"go.mondoo.com/cnquery/providers-sdk/v1/inventory/manager"
 	"go.mondoo.com/cnquery/providers-sdk/v1/vault"
 	"go.mondoo.com/cnquery/providers/os/connection/shared"
 	"go.mondoo.com/cnquery/providers/os/connection/ssh/awsinstanceconnect"
@@ -36,11 +35,10 @@ const (
 )
 
 type SshConnection struct {
-	fs        afero.Fs
-	Sudo      *shared.Sudo
-	id        uint32
-	conf      *inventory.Config
-	inventory manager.InventoryManager
+	fs   afero.Fs
+	Sudo *shared.Sudo
+	id   uint32
+	conf *inventory.Config
 
 	serverVersion    string
 	UseScpFilesystem bool
@@ -48,11 +46,10 @@ type SshConnection struct {
 	SSHClient        *ssh.Client
 }
 
-func NewSshConnection(id uint32, conf *inventory.Config, im manager.InventoryManager) (*SshConnection, error) {
+func NewSshConnection(id uint32, conf *inventory.Config) (*SshConnection, error) {
 	res := SshConnection{
-		id:        id,
-		conf:      conf,
-		inventory: im,
+		id:   id,
+		conf: conf,
 	}
 
 	host := conf.GetHost()

--- a/providers/os/provider/detector.go
+++ b/providers/os/provider/detector.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/providers-sdk/v1/inventory"
-	"go.mondoo.com/cnquery/providers-sdk/v1/inventory/manager"
 	"go.mondoo.com/cnquery/providers/os/detector"
 	"go.mondoo.com/cnquery/providers/os/id/aws"
 	"go.mondoo.com/cnquery/providers/os/id/azure"
@@ -56,8 +55,8 @@ func mapDetectors(raw []string) map[string]struct{} {
 	return res
 }
 
-func (s *Service) detect(asset *inventory.Asset, manager manager.InventoryManager) error {
-	conn, err := s.connect(asset, manager)
+func (s *Service) detect(asset *inventory.Asset) error {
+	conn, err := s.connect(asset)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Shoving the entire MQL runtime into providers is not very helpful, we should keep them slim. This change moves the asset resolution with credentials to the calling runtime (cnquery/cnspec) instead of the plugin. This keeps plugins more focused and slim, fewer things for developers to know.

get closer to turning the tests green