### PR TITLE
🐛 load resource async from recording

### DIFF
--- a/providers-sdk/v1/lr/collector.go
+++ b/providers-sdk/v1/lr/collector.go
@@ -33,7 +33,7 @@ func NewCollector(lrFile string) *Collector {
 }
 
 var regexMaps = map[string]*regexp.Regexp{
-	"init":   regexp.MustCompile(`func init(\S+)\(\S+ [^)]+\) \([^,]+, \*\S+, error\) {`),
+	"init":   regexp.MustCompile(`func init(\S+)\([^)]+\) \([^,]+, \S+\.Resource, error\) {`),
 	"id":     regexp.MustCompile(`func \(\S+ \*(mql\S+)\) id\(\) \(string, error\)`),
 	"struct": regexp.MustCompile(`type (mql\S+Internal) struct `),
 }

--- a/providers-sdk/v1/testutils/testdata/arch.json
+++ b/providers-sdk/v1/testutils/testdata/arch.json
@@ -180,6 +180,10 @@
           "Resource": "package",
           "ID": "package/acl",
           "Fields": {
+            "installed": {
+              "type": "\u0004",
+              "value": true
+            },
             "name": {
               "type": "\u0007",
               "value": "acl"
@@ -187,10 +191,6 @@
             "version": {
               "type": "\u0007",
               "value": "1.2.3"
-            },
-            "installed": {
-              "type": "\u0004",
-              "value": true
             }
           }
         },
@@ -199,8 +199,7 @@
           "ID": "package/unknown",
           "Fields": {
             "installed": {
-              "type": "\u0004",
-              "error": "cannot find package unknown"
+              "type": "\u0004"
             }
           }
         },
@@ -223,9 +222,24 @@
           "Resource": "user",
           "ID": "user/0/root",
           "Fields": {
+            "enabled": {
+              "type": "\u0004",
+              "value": false
+            },
             "gid": {
               "type": "\u0005",
               "value": 0
+            },
+            "group": {
+              "type": "\u001bgroup",
+              "value": {
+                "Name": "group",
+                "ID": "group/0/root"
+              }
+            },
+            "home": {
+              "type": "\u0007",
+              "value": "/root"
             },
             "name": {
               "type": "\u0007",
@@ -234,21 +248,6 @@
             "uid": {
               "type": "\u0005",
               "value": 0
-            },
-            "enabled": {
-              "type": "\u0004",
-              "value": false
-            },
-            "home": {
-              "type": "\u0007",
-              "value": "/root"
-            },
-            "group": {
-              "type": "\u001bgroup",
-              "value": {
-                "Name": "group",
-                "ID": "group/0/root"
-              }
             }
           }
         },
@@ -256,9 +255,20 @@
           "Resource": "user",
           "ID": "user/1/bin",
           "Fields": {
+            "enabled": {
+              "type": "\u0004",
+              "value": false
+            },
             "gid": {
               "type": "\u0005",
               "value": 1
+            },
+            "group": {
+              "type": "\u001bgroup",
+              "value": {
+                "Name": "group",
+                "ID": "group/1/bin"
+              }
             },
             "name": {
               "type": "\u0007",
@@ -267,17 +277,6 @@
             "uid": {
               "type": "\u0005",
               "value": 1
-            },
-            "enabled": {
-              "type": "\u0004",
-              "value": false
-            },
-            "group": {
-              "type": "\u001bgroup",
-              "value": {
-                "Name": "group",
-                "ID": "group/1/bin"
-              }
             }
           }
         },
@@ -285,9 +284,20 @@
           "Resource": "user",
           "ID": "user/1000/chris",
           "Fields": {
+            "enabled": {
+              "type": "\u0004",
+              "value": false
+            },
             "gid": {
               "type": "\u0005",
               "value": 1000
+            },
+            "group": {
+              "type": "\u001bgroup",
+              "value": {
+                "Name": "group",
+                "ID": "group/1000/chris"
+              }
             },
             "name": {
               "type": "\u0007",
@@ -296,17 +306,6 @@
             "uid": {
               "type": "\u0005",
               "value": 1000
-            },
-            "enabled": {
-              "type": "\u0004",
-              "value": false
-            },
-            "group": {
-              "type": "\u001bgroup",
-              "value": {
-                "Name": "group",
-                "ID": "group/1000/chris"
-              }
             }
           }
         },
@@ -314,9 +313,20 @@
           "Resource": "user",
           "ID": "user/1001/christopher",
           "Fields": {
+            "enabled": {
+              "type": "\u0004",
+              "value": false
+            },
             "gid": {
               "type": "\u0005",
               "value": 1000
+            },
+            "group": {
+              "type": "\u001bgroup",
+              "value": {
+                "Name": "group",
+                "ID": "group/1000/chris"
+              }
             },
             "name": {
               "type": "\u0007",
@@ -325,17 +335,6 @@
             "uid": {
               "type": "\u0005",
               "value": 1001
-            },
-            "enabled": {
-              "type": "\u0004",
-              "value": false
-            },
-            "group": {
-              "type": "\u001bgroup",
-              "value": {
-                "Name": "group",
-                "ID": "group/1000/chris"
-              }
             }
           }
         },

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -192,7 +192,7 @@ func (s *Service) GetData(req *plugin.DataReq) (*plugin.DataRes, error) {
 	args := plugin.PrimitiveArgsToRawDataArgs(req.Args)
 
 	if req.ResourceId == "" && req.Field == "" {
-		res, err := resources.CreateResource(runtime, req.Resource, args)
+		res, err := resources.NewResource(runtime, req.Resource, args)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/os/resources/authorizedkeys.go
+++ b/providers/os/resources/authorizedkeys.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"go.mondoo.com/cnquery/llx"
+	"go.mondoo.com/cnquery/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/providers/os/resources/authorizedkeys"
 )
 
@@ -23,21 +24,21 @@ func (x *mqlAuthorizedkeysEntry) id() (string, error) {
 	return path + ":" + strconv.FormatInt(x.Line.Data, 10), nil
 }
 
-func (x *mqlAuthorizedkeys) init(args map[string]*llx.RawData) (map[string]*llx.RawData, *mqlAuthorizedkeys, error) {
+func initAuthorizedkeys(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	// users may supply only the file or the path. Until we deprecate path in this
 	// resource, we have to make sure it gets filled; if we receive a file,
 	// set it from the file (for consistency)
 	if v, ok := args["file"]; ok {
 		file, ok := v.Value.(*mqlFile)
 		if !ok {
-			return nil, nil, errors.New("Wrong type for 'file' in authorizedkeys initialization, it must be a file")
+			return nil, nil, errors.New("wrong type for 'file' in authorizedkeys initialization, it must be a file")
 		}
 
 		args["path"] = llx.StringData(file.Path.Data)
 	}
 
 	if path, ok := args["path"]; ok {
-		f, err := CreateResource(x.MqlRuntime, "file", map[string]*llx.RawData{
+		f, err := CreateResource(runtime, "file", map[string]*llx.RawData{
 			"path": path,
 		})
 		if err != nil {

--- a/providers/os/resources/authorizedkeys_test.go
+++ b/providers/os/resources/authorizedkeys_test.go
@@ -10,7 +10,7 @@ func TestResource_AuthorizedKeys(t *testing.T) {
 	t.Run("view authorized keys file", func(t *testing.T) {
 		res := x.TestQuery(t, "authorizedkeys('/home/chris/.ssh/authorized_keys').content")
 		assert.NotEmpty(t, res)
-		assert.Equal(t, 755, len(res[0].Data.Value.(string)))
+		assert.Equal(t, 745, len(res[0].Data.Value.(string)))
 	})
 
 	t.Run("test authorized keys type", func(t *testing.T) {

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -338,7 +338,8 @@ func (r *Runtime) SetRecording(recording *recording, providerID string, readOnly
 		}
 
 		res, err := provider.Instance.Plugin.Connect(&plugin.ConnectReq{
-			Asset: asset,
+			Asset:        asset,
+			HasRecording: true,
 		}, &callbacks)
 		if err != nil {
 			return errors.New("failed to set mock connection for recording: " + err.Error())


### PR DESCRIPTION
- 🐛 fix the detection of new init-style argument parsers for resources
- ✨ add the provider that generated an error message to a few of the auto-generated messages (more to come)
- 🐛 handle errors from resource ID-generation
- 🧹 stop exposing data setters for call-arguments in resources
- 🐛 avoid loading resource fields from within providers when calling recordings (needs recursive loading in a follow-up, for now it prevents a crash)
- and most importantly: 🟢 fix 3/4 authorized keys tests (without actually storing the authorized keys resource or fields!) (which caused this giant rewrite)