### PR TITLE
🧹 enable linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 # See https://golangci-lint.run/usage/configuration/ for configuration options
 run:
-  timeout: 5m
+  timeout: 15m
   skip-dirs:
   skip-files:
     - ".*\\.pb\\.go$"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,10 @@ linters:
   disable-all: true
   enable:
     - gofmt
+    - staticcheck
+    - errcheck
+    - gosimple
+    - ineffassign
 # deactivated for now since its slow in github actions
 #    - govet
 

--- a/llx/rawdata_json.go
+++ b/llx/rawdata_json.go
@@ -399,7 +399,9 @@ func (r *RawData) JSON(codeID string, bundle *CodeBundle) []byte {
 	}
 
 	var res bytes.Buffer
-	rawDataJSON(r.Type, r.Value, codeID, bundle, &res)
+	if err := rawDataJSON(r.Type, r.Value, codeID, bundle, &res); err != nil {
+		return JSONerror(err)
+	}
 	return res.Bytes()
 }
 


### PR DESCRIPTION
I was just working on a bug and I discovered that all linters were disabled. We are barely checking for any issues at the moment. If those were enabled, we wouldn't have had the bug I was working on, since it was related to an error that was never checked