### PR TITLE
🐛 raw data json err

### DIFF
--- a/llx/rawdata_json.go
+++ b/llx/rawdata_json.go
@@ -399,7 +399,9 @@ func (r *RawData) JSON(codeID string, bundle *CodeBundle) []byte {
 	}
 
 	var res bytes.Buffer
-	rawDataJSON(r.Type, r.Value, codeID, bundle, &res)
+	if err := rawDataJSON(r.Type, r.Value, codeID, bundle, &res); err != nil {
+		return JSONerror(err)
+	}
 	return res.Bytes()
 }
 


### PR DESCRIPTION
Properly handle cases where the value of `RawData` cannot be parsed