### PR TITLE
🐛 allow bi-directional loading of recordings

### DIFF
--- a/providers-sdk/v1/lr/go.go
+++ b/providers-sdk/v1/lr/go.go
@@ -243,7 +243,7 @@ func SetData(resource plugin.Resource, field string, val *llx.RawData) error {
 	return nil
 }
 
-func setAllData(resource plugin.Resource, args map[string]*llx.RawData) error {
+func SetAllData(resource plugin.Resource, args map[string]*llx.RawData) error {
 	var err error
 	for k, v := range args {
 		if err = SetData(resource, k, v); err != nil {
@@ -314,7 +314,7 @@ func %s(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource,
 		MqlRuntime: runtime,
 	}
 
-	err := setAllData(res, args)
+	err := SetAllData(res, args)
 	if err != nil {
 		return res, err
 	}
@@ -323,10 +323,10 @@ func %s(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource,
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording(%s, res.__id)
-		if err != nil || arsg == nil {
+		if err != nil || args == nil {
 			return res, err
 		}
-		return res, setAllData(res, args)
+		return res, SetAllData(res, args)
 	}
 
 	return res, nil
@@ -393,6 +393,7 @@ func (b *goBuilder) goField(r *Resource, field *Field) {
 		if varg%s.Error != nil {
 			return %s, varg%s.Error
 		}
+
 		`, name, name, name, goZero, name))
 			argCall = append(argCall, "varg"+name+".Data")
 		}
@@ -423,7 +424,7 @@ func (c *%s) Get%s() *plugin.TValue[%s] {
 `,
 		r.structName(b), goName, goType,
 		goType, goName, goType,
-		fromRecording, strings.Join(argDefs, "\n\t\t"),
+		fromRecording, strings.Join(argDefs, ""),
 		field.BasicField.ID, strings.Join(argCall, ", "),
 	)
 }

--- a/providers-sdk/v1/plugin/runtime.go
+++ b/providers-sdk/v1/plugin/runtime.go
@@ -35,7 +35,7 @@ func (r *Runtime) ResourceFromRecording(name string, id string) (map[string]*llx
 	// recording and initialize them.
 	// TODO: we could use the provided information for a later request.
 	for k, v := range data.Fields {
-		if types.Type(v.Data.Type).IsResource() {
+		if types.Type(v.Data.Type).ContainsResource() {
 			delete(data.Fields, k)
 		}
 	}
@@ -43,6 +43,10 @@ func (r *Runtime) ResourceFromRecording(name string, id string) (map[string]*llx
 	return ProtoArgsToRawDataArgs(data.Fields)
 }
 
+// FieldResourceFromRecording loads a field which is a resource from a recording.
+// These are not immediately initialized when the recording is loaded, to avoid
+// having to recursively initialize too many things that won't be used. Once
+// it's time, this function is called to initialize the resource.
 func (r *Runtime) FieldResourceFromRecording(resource string, id string, field string) (*llx.RawData, error) {
 	data, err := r.Callback.GetRecording(&DataReq{
 		Resource:   resource,

--- a/providers-sdk/v1/testutils/testdata/arch.json
+++ b/providers-sdk/v1/testutils/testdata/arch.json
@@ -299,6 +299,10 @@
                 "ID": "group/1000/chris"
               }
             },
+            "home": {
+              "type": "\u0007",
+              "value": "/home/chris"
+            },
             "name": {
               "type": "\u0007",
               "value": "chris"

--- a/providers/core/resources/core.lr.go
+++ b/providers/core/resources/core.lr.go
@@ -226,7 +226,7 @@ func SetData(resource plugin.Resource, field string, val *llx.RawData) error {
 	return nil
 }
 
-func setAllData(resource plugin.Resource, args map[string]*llx.RawData) error {
+func SetAllData(resource plugin.Resource, args map[string]*llx.RawData) error {
 	var err error
 	for k, v := range args {
 		if err = SetData(resource, k, v); err != nil {
@@ -254,7 +254,7 @@ func createMondoo(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin
 		MqlRuntime: runtime,
 	}
 
-	err := setAllData(res, args)
+	err := SetAllData(res, args)
 	if err != nil {
 		return res, err
 	}
@@ -263,10 +263,10 @@ func createMondoo(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("mondoo", res.__id)
-		if err != nil {
+		if err != nil || args == nil {
 			return res, err
 		}
-		return res, setAllData(res, args)
+		return res, SetAllData(res, args)
 	}
 
 	return res, nil
@@ -330,7 +330,7 @@ func createAsset(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.
 		MqlRuntime: runtime,
 	}
 
-	err := setAllData(res, args)
+	err := SetAllData(res, args)
 	if err != nil {
 		return res, err
 	}
@@ -339,10 +339,10 @@ func createAsset(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("asset", res.__id)
-		if err != nil {
+		if err != nil || args == nil {
 			return res, err
 		}
-		return res, setAllData(res, args)
+		return res, SetAllData(res, args)
 	}
 
 	return res, nil

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -662,7 +662,7 @@ func SetData(resource plugin.Resource, field string, val *llx.RawData) error {
 	return nil
 }
 
-func setAllData(resource plugin.Resource, args map[string]*llx.RawData) error {
+func SetAllData(resource plugin.Resource, args map[string]*llx.RawData) error {
 	var err error
 	for k, v := range args {
 		if err = SetData(resource, k, v); err != nil {
@@ -690,7 +690,7 @@ func createCommand(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugi
 		MqlRuntime: runtime,
 	}
 
-	err := setAllData(res, args)
+	err := SetAllData(res, args)
 	if err != nil {
 		return res, err
 	}
@@ -702,10 +702,10 @@ func createCommand(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugi
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("command", res.__id)
-		if err != nil {
+		if err != nil || args == nil {
 			return res, err
 		}
-		return res, setAllData(res, args)
+		return res, SetAllData(res, args)
 	}
 
 	return res, nil
@@ -729,6 +729,7 @@ func (c *mqlCommand) GetStdout() *plugin.TValue[string] {
 		if vargCommand.Error != nil {
 			return "", vargCommand.Error
 		}
+
 		return c.stdout(vargCommand.Data)
 	})
 }
@@ -739,6 +740,7 @@ func (c *mqlCommand) GetStderr() *plugin.TValue[string] {
 		if vargCommand.Error != nil {
 			return "", vargCommand.Error
 		}
+
 		return c.stderr(vargCommand.Data)
 	})
 }
@@ -749,6 +751,7 @@ func (c *mqlCommand) GetExitcode() *plugin.TValue[int64] {
 		if vargCommand.Error != nil {
 			return 0, vargCommand.Error
 		}
+
 		return c.exitcode(vargCommand.Data)
 	})
 }
@@ -777,7 +780,7 @@ func createFile(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.R
 		MqlRuntime: runtime,
 	}
 
-	err := setAllData(res, args)
+	err := SetAllData(res, args)
 	if err != nil {
 		return res, err
 	}
@@ -789,10 +792,10 @@ func createFile(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.R
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("file", res.__id)
-		if err != nil {
+		if err != nil || args == nil {
 			return res, err
 		}
-		return res, setAllData(res, args)
+		return res, SetAllData(res, args)
 	}
 
 	return res, nil
@@ -816,6 +819,7 @@ func (c *mqlFile) GetBasename() *plugin.TValue[string] {
 		if vargPath.Error != nil {
 			return "", vargPath.Error
 		}
+
 		return c.basename(vargPath.Data)
 	})
 }
@@ -826,6 +830,7 @@ func (c *mqlFile) GetDirname() *plugin.TValue[string] {
 		if vargPath.Error != nil {
 			return "", vargPath.Error
 		}
+
 		return c.dirname(vargPath.Data)
 	})
 }
@@ -841,6 +846,7 @@ func (c *mqlFile) GetContent() *plugin.TValue[string] {
 		if vargExists.Error != nil {
 			return "", vargExists.Error
 		}
+
 		return c.content(vargPath.Data, vargExists.Data)
 	})
 }
@@ -851,6 +857,7 @@ func (c *mqlFile) GetExists() *plugin.TValue[bool] {
 		if vargPath.Error != nil {
 			return false, vargPath.Error
 		}
+
 		return c.exists(vargPath.Data)
 	})
 }
@@ -868,6 +875,7 @@ func (c *mqlFile) GetPermissions() *plugin.TValue[*mqlFilePermissions] {
 		if vargPath.Error != nil {
 			return nil, vargPath.Error
 		}
+
 		return c.permissions(vargPath.Data)
 	})
 }
@@ -878,6 +886,7 @@ func (c *mqlFile) GetSize() *plugin.TValue[int64] {
 		if vargPath.Error != nil {
 			return 0, vargPath.Error
 		}
+
 		return c.size(vargPath.Data)
 	})
 }
@@ -914,6 +923,7 @@ func (c *mqlFile) GetEmpty() *plugin.TValue[bool] {
 		if vargPath.Error != nil {
 			return false, vargPath.Error
 		}
+
 		return c.empty(vargPath.Data)
 	})
 }
@@ -949,7 +959,7 @@ func createFilePermissions(runtime *plugin.Runtime, args map[string]*llx.RawData
 		MqlRuntime: runtime,
 	}
 
-	err := setAllData(res, args)
+	err := SetAllData(res, args)
 	if err != nil {
 		return res, err
 	}
@@ -961,10 +971,10 @@ func createFilePermissions(runtime *plugin.Runtime, args map[string]*llx.RawData
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("file.permissions", res.__id)
-		if err != nil {
+		if err != nil || args == nil {
 			return res, err
 		}
-		return res, setAllData(res, args)
+		return res, SetAllData(res, args)
 	}
 
 	return res, nil
@@ -1071,7 +1081,7 @@ func createUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.R
 		MqlRuntime: runtime,
 	}
 
-	err := setAllData(res, args)
+	err := SetAllData(res, args)
 	if err != nil {
 		return res, err
 	}
@@ -1083,10 +1093,10 @@ func createUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.R
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("user", res.__id)
-		if err != nil {
+		if err != nil || args == nil {
 			return res, err
 		}
-		return res, setAllData(res, args)
+		return res, SetAllData(res, args)
 	}
 
 	return res, nil
@@ -1141,6 +1151,7 @@ func (c *mqlUser) GetAuthorizedkeys() *plugin.TValue[*mqlAuthorizedkeys] {
 		if vargHome.Error != nil {
 			return nil, vargHome.Error
 		}
+
 		return c.authorizedkeys(vargHome.Data)
 	})
 }
@@ -1158,6 +1169,7 @@ func (c *mqlUser) GetGroup() *plugin.TValue[*mqlGroup] {
 		if vargGid.Error != nil {
 			return nil, vargGid.Error
 		}
+
 		return c.group(vargGid.Data)
 	})
 }
@@ -1177,7 +1189,7 @@ func createUsers(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.
 		MqlRuntime: runtime,
 	}
 
-	err := setAllData(res, args)
+	err := SetAllData(res, args)
 	if err != nil {
 		return res, err
 	}
@@ -1186,10 +1198,10 @@ func createUsers(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("users", res.__id)
-		if err != nil {
+		if err != nil || args == nil {
 			return res, err
 		}
-		return res, setAllData(res, args)
+		return res, SetAllData(res, args)
 	}
 
 	return res, nil
@@ -1227,7 +1239,7 @@ func createAuthorizedkeys(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		MqlRuntime: runtime,
 	}
 
-	err := setAllData(res, args)
+	err := SetAllData(res, args)
 	if err != nil {
 		return res, err
 	}
@@ -1239,10 +1251,10 @@ func createAuthorizedkeys(runtime *plugin.Runtime, args map[string]*llx.RawData)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("authorizedkeys", res.__id)
-		if err != nil {
+		if err != nil || args == nil {
 			return res, err
 		}
-		return res, setAllData(res, args)
+		return res, SetAllData(res, args)
 	}
 
 	return res, nil
@@ -1270,6 +1282,7 @@ func (c *mqlAuthorizedkeys) GetContent() *plugin.TValue[string] {
 		if vargFile.Error != nil {
 			return "", vargFile.Error
 		}
+
 		return c.content(vargFile.Data)
 	})
 }
@@ -1285,6 +1298,7 @@ func (c *mqlAuthorizedkeys) GetList() *plugin.TValue[[]interface{}] {
 		if vargContent.Error != nil {
 			return nil, vargContent.Error
 		}
+
 		return c.list(vargFile.Data, vargContent.Data)
 	})
 }
@@ -1309,7 +1323,7 @@ func createAuthorizedkeysEntry(runtime *plugin.Runtime, args map[string]*llx.Raw
 		MqlRuntime: runtime,
 	}
 
-	err := setAllData(res, args)
+	err := SetAllData(res, args)
 	if err != nil {
 		return res, err
 	}
@@ -1321,10 +1335,10 @@ func createAuthorizedkeysEntry(runtime *plugin.Runtime, args map[string]*llx.Raw
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("authorizedkeys.entry", res.__id)
-		if err != nil {
+		if err != nil || args == nil {
 			return res, err
 		}
-		return res, setAllData(res, args)
+		return res, SetAllData(res, args)
 	}
 
 	return res, nil
@@ -1380,7 +1394,7 @@ func createGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.
 		MqlRuntime: runtime,
 	}
 
-	err := setAllData(res, args)
+	err := SetAllData(res, args)
 	if err != nil {
 		return res, err
 	}
@@ -1392,10 +1406,10 @@ func createGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("group", res.__id)
-		if err != nil {
+		if err != nil || args == nil {
 			return res, err
 		}
-		return res, setAllData(res, args)
+		return res, SetAllData(res, args)
 	}
 
 	return res, nil
@@ -1442,7 +1456,7 @@ func createGroups(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin
 		MqlRuntime: runtime,
 	}
 
-	err := setAllData(res, args)
+	err := SetAllData(res, args)
 	if err != nil {
 		return res, err
 	}
@@ -1451,10 +1465,10 @@ func createGroups(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("groups", res.__id)
-		if err != nil {
+		if err != nil || args == nil {
 			return res, err
 		}
-		return res, setAllData(res, args)
+		return res, SetAllData(res, args)
 	}
 
 	return res, nil
@@ -1499,7 +1513,7 @@ func createPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugi
 		MqlRuntime: runtime,
 	}
 
-	err := setAllData(res, args)
+	err := SetAllData(res, args)
 	if err != nil {
 		return res, err
 	}
@@ -1511,10 +1525,10 @@ func createPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugi
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("package", res.__id)
-		if err != nil {
+		if err != nil || args == nil {
 			return res, err
 		}
-		return res, setAllData(res, args)
+		return res, SetAllData(res, args)
 	}
 
 	return res, nil
@@ -1593,7 +1607,7 @@ func createPackages(runtime *plugin.Runtime, args map[string]*llx.RawData) (plug
 		MqlRuntime: runtime,
 	}
 
-	err := setAllData(res, args)
+	err := SetAllData(res, args)
 	if err != nil {
 		return res, err
 	}
@@ -1602,10 +1616,10 @@ func createPackages(runtime *plugin.Runtime, args map[string]*llx.RawData) (plug
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("packages", res.__id)
-		if err != nil {
+		if err != nil || args == nil {
 			return res, err
 		}
-		return res, setAllData(res, args)
+		return res, SetAllData(res, args)
 	}
 
 	return res, nil

--- a/providers/os/resources/user.go
+++ b/providers/os/resources/user.go
@@ -89,7 +89,7 @@ func (x *mqlUser) group(gid int64) (*mqlGroup, error) {
 func (u *mqlUser) authorizedkeys(home string) (*mqlAuthorizedkeys, error) {
 	// TODO: we may need to handle ".ssh/authorized_keys2" too
 	authorizedKeysPath := path.Join(home, ".ssh", "authorized_keys")
-	ak, err := CreateResource(u.MqlRuntime, "authorizedkeys", map[string]*llx.RawData{
+	ak, err := NewResource(u.MqlRuntime, "authorizedkeys", map[string]*llx.RawData{
 		"path": llx.StringData(authorizedKeysPath),
 	})
 	if err != nil {

--- a/types/types.go
+++ b/types/types.go
@@ -147,6 +147,21 @@ func (typ Type) IsResource() bool {
 	return typ[0] == byteResource
 }
 
+// ContainsResource checks if this or any child type has a resource
+func (typ Type) ContainsResource() bool {
+	for {
+		if typ.IsResource() {
+			return true
+		}
+
+		if !typ.IsArray() && !typ.IsMap() {
+			return false
+		}
+
+		typ = typ.Child()
+	}
+}
+
 // Function for creating a function type signature
 func Function(required rune, args []Type) Type {
 	var sig string


### PR DESCRIPTION
- re-expose SetAllData because we need it in calling providers to set resources from recordings
- types can now check if they contain a resource; this is important because loading resources from recordings requires proper initialization
- 🐛 a resource that cannot be found in a provider may have not been initialized from the caller; this happens when we load data from a recording, but are missing a number of fields in the recording. This is actually a great case where the recording only needs the data it cannot compute on the fly

This makes it 4/4 for authorized keys tests