### PR TITLE
🐛 load embedded recording resources inside of plugins

### DIFF
--- a/cli/printer/printer_test.go
+++ b/cli/printer/printer_test.go
@@ -185,7 +185,7 @@ func TestPrinter_Assessment(t *testing.T) {
 				"    expected: == 1",
 				"    actual:   \"development\"",
 				"  [failed] user.authorizedkeys.file",
-				"    error: failed to create resource 'user': user 'notthere' does not exist",
+				"    error: cannot find user with name 'notthere'",
 				"",
 			}, "\n"),
 		},
@@ -430,9 +430,9 @@ func TestPrinter_Assessment(t *testing.T) {
 		//   ]
 		// `,
 		// 		},
-		// 		{
-		// 			"users.all(groups.all(name == 'root'))\n",
-		// 			`[failed] users.all()
+		// {
+		// 	"users.all(groups.all(name == 'root'))\n",
+		// 	`[failed] users.all()
 		//   actual:   [
 		//     0: user {
 		//       uid: 0
@@ -480,7 +480,7 @@ func TestPrinter_Assessment(t *testing.T) {
 		//     }
 		//   ]
 		// `,
-		// 		},
+		// },
 		{
 			"users.all(sshkeys.length > 2)\n",
 			strings.Join([]string{

--- a/providers/core/resources/core.lr.go
+++ b/providers/core/resources/core.lr.go
@@ -14,11 +14,11 @@ var resourceFactories map[string]plugin.ResourceFactory
 func init() {
 	resourceFactories = map[string]plugin.ResourceFactory {
 		"mondoo": {
-			// to override args, implement: initMondoo(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]interface{}, plugin.Resource, error)
+			// to override args, implement: initMondoo(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMondoo,
 		},
 		"asset": {
-			// to override args, implement: initAsset(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]interface{}, plugin.Resource, error)
+			// to override args, implement: initAsset(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAsset,
 		},
 	}

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -128,8 +128,11 @@ func (s *Service) Connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 		return nil, err
 	}
 
-	if err := s.detect(req.Asset, conn); err != nil {
-		return nil, err
+	// We only need to run the detection step when we don't have any asset information yet.
+	if req.Asset.Platform == nil {
+		if err := s.detect(req.Asset, conn); err != nil {
+			return nil, err
+		}
 	}
 
 	// TODO: discovery of related assets and use them in the inventory below
@@ -174,10 +177,11 @@ func (s *Service) connect(asset *inventory.Asset, hasRecording bool, callback pl
 
 	asset.Connections[0].Id = conn.ID()
 	s.runtimes[conn.ID()] = &plugin.Runtime{
-		Connection:   conn,
-		Resources:    map[string]plugin.Resource{},
-		Callback:     callback,
-		HasRecording: hasRecording,
+		Connection:     conn,
+		Resources:      map[string]plugin.Resource{},
+		Callback:       callback,
+		HasRecording:   hasRecording,
+		CreateResource: resources.CreateResource,
 	}
 
 	return conn, err

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -14,23 +14,23 @@ var resourceFactories map[string]plugin.ResourceFactory
 func init() {
 	resourceFactories = map[string]plugin.ResourceFactory {
 		"command": {
-			// to override args, implement: initCommand(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]interface{}, plugin.Resource, error)
+			// to override args, implement: initCommand(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createCommand,
 		},
 		"file": {
-			// to override args, implement: initFile(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]interface{}, plugin.Resource, error)
+			// to override args, implement: initFile(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createFile,
 		},
 		"file.permissions": {
-			// to override args, implement: initFilePermissions(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]interface{}, plugin.Resource, error)
+			// to override args, implement: initFilePermissions(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createFilePermissions,
 		},
 		"user": {
-			// to override args, implement: initUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]interface{}, plugin.Resource, error)
+			Init: initUser,
 			Create: createUser,
 		},
 		"users": {
-			// to override args, implement: initUsers(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]interface{}, plugin.Resource, error)
+			// to override args, implement: initUsers(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createUsers,
 		},
 		"authorizedkeys": {
@@ -38,23 +38,23 @@ func init() {
 			Create: createAuthorizedkeys,
 		},
 		"authorizedkeys.entry": {
-			// to override args, implement: initAuthorizedkeysEntry(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]interface{}, plugin.Resource, error)
+			// to override args, implement: initAuthorizedkeysEntry(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAuthorizedkeysEntry,
 		},
 		"group": {
-			// to override args, implement: initGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]interface{}, plugin.Resource, error)
+			// to override args, implement: initGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createGroup,
 		},
 		"groups": {
-			// to override args, implement: initGroups(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]interface{}, plugin.Resource, error)
+			// to override args, implement: initGroups(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createGroups,
 		},
 		"package": {
-			// to override args, implement: initPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]interface{}, plugin.Resource, error)
+			// to override args, implement: initPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createPackage,
 		},
 		"packages": {
-			// to override args, implement: initPackages(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]interface{}, plugin.Resource, error)
+			// to override args, implement: initPackages(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createPackages,
 		},
 	}
@@ -866,8 +866,11 @@ func (c *mqlFile) GetPermissions() *plugin.TValue[*mqlFilePermissions] {
 	return plugin.GetOrCompute[*mqlFilePermissions](&c.Permissions, func() (*mqlFilePermissions, error) {
 		if c.MqlRuntime.HasRecording {
 			d, err := c.MqlRuntime.FieldResourceFromRecording("file", c.__id, "permissions")
-			if err != nil || d != nil {
-				return d.Value.(*mqlFilePermissions), err
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlFilePermissions), nil
 			}
 		}
 
@@ -895,8 +898,11 @@ func (c *mqlFile) GetUser() *plugin.TValue[*mqlUser] {
 	return plugin.GetOrCompute[*mqlUser](&c.User, func() (*mqlUser, error) {
 		if c.MqlRuntime.HasRecording {
 			d, err := c.MqlRuntime.FieldResourceFromRecording("file", c.__id, "user")
-			if err != nil || d != nil {
-				return d.Value.(*mqlUser), err
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlUser), nil
 			}
 		}
 
@@ -908,8 +914,11 @@ func (c *mqlFile) GetGroup() *plugin.TValue[*mqlGroup] {
 	return plugin.GetOrCompute[*mqlGroup](&c.Group, func() (*mqlGroup, error) {
 		if c.MqlRuntime.HasRecording {
 			d, err := c.MqlRuntime.FieldResourceFromRecording("file", c.__id, "group")
-			if err != nil || d != nil {
-				return d.Value.(*mqlGroup), err
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGroup), nil
 			}
 		}
 
@@ -1142,8 +1151,11 @@ func (c *mqlUser) GetAuthorizedkeys() *plugin.TValue[*mqlAuthorizedkeys] {
 	return plugin.GetOrCompute[*mqlAuthorizedkeys](&c.Authorizedkeys, func() (*mqlAuthorizedkeys, error) {
 		if c.MqlRuntime.HasRecording {
 			d, err := c.MqlRuntime.FieldResourceFromRecording("user", c.__id, "authorizedkeys")
-			if err != nil || d != nil {
-				return d.Value.(*mqlAuthorizedkeys), err
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAuthorizedkeys), nil
 			}
 		}
 
@@ -1160,8 +1172,11 @@ func (c *mqlUser) GetGroup() *plugin.TValue[*mqlGroup] {
 	return plugin.GetOrCompute[*mqlGroup](&c.Group, func() (*mqlGroup, error) {
 		if c.MqlRuntime.HasRecording {
 			d, err := c.MqlRuntime.FieldResourceFromRecording("user", c.__id, "group")
-			if err != nil || d != nil {
-				return d.Value.(*mqlGroup), err
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGroup), nil
 			}
 		}
 
@@ -1217,6 +1232,16 @@ func (c *mqlUsers) MqlID() string {
 
 func (c *mqlUsers) GetList() *plugin.TValue[[]interface{}] {
 	return plugin.GetOrCompute[[]interface{}](&c.List, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("users", c.__id, "list")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
 		return c.list()
 	})
 }
@@ -1289,6 +1314,16 @@ func (c *mqlAuthorizedkeys) GetContent() *plugin.TValue[string] {
 
 func (c *mqlAuthorizedkeys) GetList() *plugin.TValue[[]interface{}] {
 	return plugin.GetOrCompute[[]interface{}](&c.List, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("authorizedkeys", c.__id, "list")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
 		vargFile := c.GetFile()
 		if vargFile.Error != nil {
 			return nil, vargFile.Error
@@ -1437,6 +1472,16 @@ func (c *mqlGroup) GetName() *plugin.TValue[string] {
 
 func (c *mqlGroup) GetMembers() *plugin.TValue[[]interface{}] {
 	return plugin.GetOrCompute[[]interface{}](&c.Members, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("group", c.__id, "members")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
 		return c.members()
 	})
 }
@@ -1484,6 +1529,16 @@ func (c *mqlGroups) MqlID() string {
 
 func (c *mqlGroups) GetList() *plugin.TValue[[]interface{}] {
 	return plugin.GetOrCompute[[]interface{}](&c.List, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("groups", c.__id, "list")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
 		return c.list()
 	})
 }
@@ -1635,6 +1690,16 @@ func (c *mqlPackages) MqlID() string {
 
 func (c *mqlPackages) GetList() *plugin.TValue[[]interface{}] {
 	return plugin.GetOrCompute[[]interface{}](&c.List, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("packages", c.__id, "list")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
 		return c.list()
 	})
 }

--- a/providers/os/resources/user.go
+++ b/providers/os/resources/user.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"go.mondoo.com/cnquery/llx"
+	"go.mondoo.com/cnquery/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/providers/os/connection/shared"
 	"go.mondoo.com/cnquery/providers/os/resources/users"
 )
@@ -22,7 +23,7 @@ func (x *mqlUser) id() (string, error) {
 	return "user/" + id + "/" + x.Name.Data, nil
 }
 
-func (x *mqlUser) init(args map[string]*llx.RawData) (map[string]*llx.RawData, *mqlUser, error) {
+func initUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) != 1 {
 		return args, nil, nil
 	}
@@ -34,7 +35,7 @@ func (x *mqlUser) init(args map[string]*llx.RawData) (map[string]*llx.RawData, *
 		return args, nil, nil
 	}
 
-	raw, err := CreateResource(x.MqlRuntime, "users", nil)
+	raw, err := CreateResource(runtime, "users", nil)
 	if err != nil {
 		return nil, nil, errors.New("cannot get list of users: " + err.Error())
 	}


### PR DESCRIPTION
After https://github.com/mondoohq/cnquery/pull/1389
    
Sometimes a plugin provider will decide to load a resource that comes from a recording, which has embedded child resources. This does not pass the regular flow where the host (cnquery) would be able to detect that such a resource was requested and could intervene. Instead, all of this plays inside of the plugin. Thus, we need to know when embedde resources are requested and load them on the fly.

Note: we don't want to load it all in the beginning, because (1) it could mean a lot of data which is never used and (2) (more importantly) it can lead to a chain-reaction of resources that are all connected (which we love to do because it's awesome) and then lock the provider into a loading loop (which needs additional handling to be terminated). This mechanism just does it async when the field is requested at the cost of a bit of overhead when the request is done, but saving a lot of effort especially as resources are getting more and more connected.

A few more notes:
- 🐛 fix incorrect initResource override hint to developers
- 🐛 do a much better job at detecting embedded resources in LR
- ✨ tie CreateResource to the plugin Runtime
- 🐛 avoid broken casting when we can't load a resource field from records (it tried to cast nil to the result type)
- 🐛 fix the user init call (it still used the old syntax)
