### PR TITLE
🐛 establish cache refresh from recording pattern

### DIFF
--- a/providers/os/resources/packages.go
+++ b/providers/os/resources/packages.go
@@ -103,7 +103,6 @@ func (x *mqlPackages) list() ([]interface{}, error) {
 
 	// create MQL package os for each package
 	pkgs := make([]interface{}, len(osPkgs))
-	namedMap := map[string]*mqlPackage{}
 	for i, osPkg := range osPkgs {
 		// check if we found a newer version
 		available := ""
@@ -130,10 +129,26 @@ func (x *mqlPackages) list() ([]interface{}, error) {
 		}
 
 		pkgs[i] = pkg
-		namedMap[osPkg.Name] = pkg.(*mqlPackage)
 	}
 
-	x.packagesByName = namedMap
+	return pkgs, x.refreshCache(pkgs)
+}
 
-	return pkgs, nil
+func (x *mqlPackages) refreshCache(all []interface{}) error {
+	if all == nil {
+		raw := x.GetList()
+		if raw.Error != nil {
+			return raw.Error
+		}
+		all = raw.Data
+	}
+
+	x.packagesByName = map[string]*mqlPackage{}
+
+	for i := range all {
+		u := all[i].(*mqlPackage)
+		x.packagesByName[u.Name.Data] = u
+	}
+
+	return nil
 }

--- a/providers/os/resources/services.go
+++ b/providers/os/resources/services.go
@@ -44,8 +44,8 @@ func initService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 	return nil, srv, nil
 }
 
-func (p *mqlService) id() (string, error) {
-	return p.Name.Data, nil
+func (x *mqlService) id() (string, error) {
+	return x.Name.Data, nil
 }
 
 type mqlServicesInternal struct {
@@ -53,12 +53,12 @@ type mqlServicesInternal struct {
 	namedServices map[string]*mqlService
 }
 
-func (p *mqlServices) list() ([]interface{}, error) {
-	p.lock.Lock()
-	defer p.lock.Unlock()
+func (x *mqlServices) list() ([]interface{}, error) {
+	x.lock.Lock()
+	defer x.lock.Unlock()
 
 	// find suitable service manager
-	conn := p.MqlRuntime.Connection.(shared.Connection)
+	conn := x.MqlRuntime.Connection.(shared.Connection)
 	osm, err := services.ResolveManager(conn)
 	if osm == nil || err != nil {
 		// there are valid cases where this error is happening, eg. you run a service query in
@@ -81,7 +81,7 @@ func (p *mqlServices) list() ([]interface{}, error) {
 	for i := range services {
 		srv := services[i]
 
-		mqlSrv, err := CreateResource(p.MqlRuntime, "service", map[string]*llx.RawData{
+		mqlSrv, err := CreateResource(x.MqlRuntime, "service", map[string]*llx.RawData{
 			"name":        llx.StringData(srv.Name),
 			"description": llx.StringData(srv.Description),
 			"installed":   llx.BoolData(srv.Installed),
@@ -97,23 +97,23 @@ func (p *mqlServices) list() ([]interface{}, error) {
 		mqlSrvs = append(mqlSrvs, mqlSrv.(*mqlService))
 	}
 
-	return mqlSrvs, p.refreshCache(mqlSrvs)
+	return mqlSrvs, x.refreshCache(mqlSrvs)
 }
 
-func (p *mqlServices) refreshCache(all []interface{}) error {
+func (x *mqlServices) refreshCache(all []interface{}) error {
 	if all == nil {
-		raw := p.GetList()
+		raw := x.GetList()
 		if raw.Error != nil {
 			return raw.Error
 		}
 		all = raw.Data
 	}
 
-	namedMap := map[string]*mqlService{}
+	x.namedServices = map[string]*mqlService{}
 	for i := range all {
 		service := all[i].(*mqlService)
-		namedMap[service.Name.Data] = service
+		x.namedServices[service.Name.Data] = service
 	}
-	p.namedServices = namedMap
+
 	return nil
 }


### PR DESCRIPTION
recently introduced for services, this pattern is excellent to keep the cache separate from the initial load (even if we have to cycle things again) AND it makes it so that we can load these things safely from recordings.

Up until this point there was the edge-case where we loaded a cached list of resources from a recording during a call for eg `resource(name)`. Since it is loaded from a recording, it did not create the mqlResourceInternal structures. A nasty workaround to this problem has now been removed as well. This model is much cleaner and safe to use across recordings