### PR TITLE
✨ structure provider plugins into folders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ define installProvider
 	$(eval $@_DST = "$(HOME)/.config/mondoo/providers/${$@_NAME}")
 	echo "--> install ${$@_NAME}"
 	install -d "${$@_DST}"
-	install -m 644 ./${$@_DIST}/${$@_NAME} ${$@_DST}/
+	install -m 755 ./${$@_DIST}/${$@_NAME} ${$@_DST}/
 	install -m 644 ./${$@_DIST}/${$@_NAME}.json ${$@_DST}/
 	install -m 644 ./${$@_DIST}/${$@_NAME}.resources.json ${$@_DST}/
 endef

--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -62,7 +62,7 @@ func (c *coordinator) Start(id string) (*RunningProvider, error) {
 		}
 	}
 
-	pluginCmd := exec.Command(provider.Path, "run_as_plugin")
+	pluginCmd := exec.Command(provider.binPath(), "run_as_plugin")
 	log.Debug().Str("path", pluginCmd.Path).Msg("running provider plugin")
 
 	addColorConfig(pluginCmd)


### PR DESCRIPTION
In the old model, all plugin files were flat in a plugins folder. That can get out of hand because a ton of files will be all over the place. 

Instead, put all plugin files into a folder with the plugin name, e.g.:

```
.config/mondoo/providers
└── os
    ├── os
    ├── os.json
    └── os.resources.json
```