### PR TITLE
✨ list providers: builtin vs other

### DIFF
--- a/apps/cnquery/cmd/providers.go
+++ b/apps/cnquery/cmd/providers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.mondoo.com/cnquery/cli/theme"
 	"go.mondoo.com/cnquery/providers"
+	"go.mondoo.com/cnquery/sortx"
 )
 
 func init() {
@@ -28,15 +29,27 @@ var providersCmd = &cobra.Command{
 }
 
 func list() {
-	list, err := providers.List()
+	list, err := providers.ListAll()
 	if err != nil {
 		log.Error().Err(err).Msg("failed to list providers")
+	}
+
+	for _, v := range list {
+		if v.Path == "" {
+			continue
+		}
+		if err := v.LoadJSON(); err != nil {
+			log.Error().Err(err).
+				Str("provider", v.Name).
+				Str("path", v.Path).
+				Msg("failed to load provider")
+		}
 	}
 
 	printProviders(list)
 }
 
-func printProviders(p providers.Providers) {
+func printProviders(p []*providers.Provider) {
 	if len(p) == 0 {
 		log.Info().Msg("No providers found.")
 		fmt.Println("No providers found.")
@@ -48,35 +61,51 @@ func printProviders(p providers.Providers) {
 	}
 
 	paths := map[string][]*providers.Provider{}
-	for _, provider := range p {
+	for i := range p {
+		provider := p[i]
+		if provider.Path == "" {
+			paths["builtin"] = append(paths["builtin"], provider)
+			continue
+		}
 		dir := filepath.Dir(provider.Path)
 		paths[dir] = append(paths[dir], provider)
 	}
 
-	for path, list := range paths {
-		fmt.Println()
-		log.Info().Msg(path + " (found " + strconv.Itoa(len(list)) + " providers)")
-		fmt.Println()
+	printProviderPath("builtin", paths["builtin"], false)
+	printProviderPath(providers.HomePath, paths[providers.HomePath], true)
+	printProviderPath(providers.SystemPath, paths[providers.SystemPath], true)
+	delete(paths, "builtin")
+	delete(paths, providers.HomePath)
+	delete(paths, providers.SystemPath)
 
-		sort.Slice(list, func(i, j int) bool {
-			return list[i].Name < list[j].Name
-		})
-
-		for i := range list {
-			printProvider(list[i])
-		}
-	}
-
-	if _, ok := paths[providers.SystemPath]; !ok {
-		fmt.Println("")
-		log.Info().Msg(providers.SystemPath + " has no providers")
-	}
-	if _, ok := paths[providers.HomePath]; !ok {
-		fmt.Println("")
-		log.Info().Msg(providers.HomePath + " has no providers")
+	keys := sortx.Keys(paths)
+	for _, path := range keys {
+		printProviderPath(path, paths[path], true)
 	}
 
 	fmt.Println()
+}
+
+func printProviderPath(path string, list []*providers.Provider, printEmpty bool) {
+	if list == nil {
+		if printEmpty {
+			fmt.Println("")
+			log.Info().Msg(path + " has no providers")
+		}
+		return
+	}
+
+	fmt.Println()
+	log.Info().Msg(path + " (found " + strconv.Itoa(len(list)) + " providers)")
+	fmt.Println()
+
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].Name < list[j].Name
+	})
+
+	for i := range list {
+		printProvider(list[i])
+	}
 }
 
 func printProvider(p *providers.Provider) {

--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -25,7 +25,7 @@ type Command struct {
 // AttachCLIs will attempt to parse the current commandline and look for providers.
 // This step is done before cobra ever takes effect
 func AttachCLIs(rootCmd *cobra.Command, commands ...*Command) error {
-	existing, err := providers.List()
+	existing, err := providers.ListActive()
 	if err != nil {
 		return err
 	}

--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -45,7 +45,7 @@ func (c *coordinator) Start(id string) (*RunningProvider, error) {
 
 	if c.Providers == nil {
 		var err error
-		c.Providers, err = List()
+		c.Providers, err = ListActive()
 		if err != nil {
 			return nil, err
 		}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -33,20 +33,28 @@ type Provider struct {
 	Path   string
 }
 
-func List() (Providers, error) {
-	local := listPaths()
-	var res Providers = make(map[string]*Provider, len(local))
-	for _, v := range local {
-		if err := v.LoadJSON(); err != nil {
-			return nil, err
-		}
+// List providers that are going to be used in their default order:
+// builtin > user > system. The providers are also loaded and provider their
+// metadata/configuration.
+func ListActive() (Providers, error) {
+	all, err := ListAll()
+	if err != nil {
+		return nil, err
+	}
+
+	var res Providers = make(map[string]*Provider, len(all))
+	for _, v := range all {
 		res[v.ID] = v
 	}
 
-	// we add builtin ones here, possibly overriding providers in paths
-	for name, x := range builtinProviders {
-		res[name] = &Provider{
-			Provider: x.Config,
+	for _, v := range res {
+		// only happens for builtin providers
+		if v.Path == "" {
+			continue
+		}
+
+		if err := v.LoadJSON(); err != nil {
+			return nil, err
 		}
 	}
 
@@ -55,11 +63,14 @@ func List() (Providers, error) {
 	return res, nil
 }
 
-func listPaths() Providers {
+// ListAll available providers, including duplicates between builtin, user,
+// and system providers. We only return errors when the things we are trying
+// to load don't work. Note that the providers are not loaded yet.
+func ListAll() ([]*Provider, error) {
 	// This really shouldn't happen, but just in case it does...
 	if SystemPath == "" && HomePath == "" {
-		log.Error().Msg("can't find any paths for providers, none are configured")
-		return nil
+		log.Warn().Msg("can't find any paths for providers, none are configured")
+		return nil, nil
 	}
 
 	sysOk := config.ProbeDir(SystemPath)
@@ -73,26 +84,33 @@ func listPaths() Providers {
 			msg = msg.Str("home-path", HomePath)
 		}
 		msg.Msg("no provider paths exist")
-		return nil
+		return nil, nil
 	}
 
-	providers := map[string]*Provider{}
-
+	var res []*Provider
 	if sysOk {
-		err := findProviders(SystemPath, providers)
+		cur, err := findProviders(SystemPath)
 		if err != nil {
 			log.Warn().Str("path", SystemPath).Msg("failed to get providers from system path")
 		}
+		res = append(res, cur...)
 	}
 
 	if homeOk {
-		err := findProviders(HomePath, providers)
+		cur, err := findProviders(HomePath)
 		if err != nil {
 			log.Warn().Str("path", HomePath).Msg("failed to get providers from home path")
 		}
+		res = append(res, cur...)
 	}
 
-	return providers
+	for _, x := range builtinProviders {
+		res = append(res, &Provider{
+			Provider: x.Config,
+		})
+	}
+
+	return res, nil
 }
 
 func isOverlyPermissive(path string) (bool, error) {
@@ -109,19 +127,19 @@ func isOverlyPermissive(path string) (bool, error) {
 	return false, nil
 }
 
-func findProviders(path string, res map[string]*Provider) error {
+func findProviders(path string) ([]*Provider, error) {
 	overlyPermissive, err := isOverlyPermissive(path)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if overlyPermissive {
-		return errors.New("path is overly permissive, make sure it is not writable to others or the group: " + path)
+		return nil, errors.New("path is overly permissive, make sure it is not writable to others or the group: " + path)
 	}
 
 	log.Debug().Str("path", path).Msg("searching providers in path")
 	files, err := afero.ReadDir(config.AppFs, path)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	candidates := map[string]struct{}{}
@@ -132,6 +150,7 @@ func findProviders(path string, res map[string]*Provider) error {
 		}
 	}
 
+	var res []*Provider
 	for name := range candidates {
 		pdir := filepath.Join(path, name)
 
@@ -152,15 +171,15 @@ func findProviders(path string, res map[string]*Provider) error {
 			continue
 		}
 
-		res[name] = &Provider{
+		res = append(res, &Provider{
 			Provider: &plugin.Provider{
 				Name: name,
 			},
 			Path: filepath.Join(path, name),
-		}
+		})
 	}
 
-	return nil
+	return res, nil
 }
 
 // This is the default installation source for core providers.

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -416,7 +416,7 @@ func (x *extensibleSchema) loadAllSchemas() {
 	}
 	x.allLoaded = true
 
-	providers, err := List()
+	providers, err := ListActive()
 	if err != nil {
 		log.Error().Err(err).Msg("failed to list all providers, can't load additional schemas")
 		return


### PR DESCRIPTION
- instead of printing '.' for builtin, it now says 'builtin'
- print providers in the order: builtin, home, and then system
- list out all providers in all locations, not just whatever is active

example (on my dev setup):

```
> cnquery providers                                                                                                                                   x130 

→ builtin (found 2 providers)

  core 9.0.0
  os 9.0.1 with connectors: local, ssh, winrm

→ /home/zero/.config/mondoo/providers (found 1 providers)

  os 9.0.0 with connectors: local, ssh, winrm

→ /opt/mondoo/providers has no providers

```

^^  also if i have a builtin `os` now i also see the local plugin in the folder and the builtin one separate