### PR TITLE
✨ make providers/bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,12 @@ id_rsa.pub
 mondoo-test-secret-key
 gha-creds-*.json
 /tools
+# primarily used to ignore all dist files built for providers
 /dist
+# we want to track core + os, despite being generate JSON files
+# because we use them for testing in a lot of places.
+# TODO: solve this for other provider types on the fly
+!providers/core/dist/core.resources.json
+!providers/os/dist/os.resources.json
 providers/*/resources/*.resources.json
+providers/*/resources/*.manifest.json

--- a/providers-sdk/v1/lr/cli/cmd/docs.go
+++ b/providers-sdk/v1/lr/cli/cmd/docs.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -222,15 +223,21 @@ var docsJSONCmd = &cobra.Command{
 	Long:  `convert a yaml-based docs manifest into its json description, ready for loading`,
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		file := args[0]
+
 		dist, err := cmd.Flags().GetString("dist")
 		if err != nil {
 			log.Fatal().Err(err).Msg("failed to get dist flag")
 		}
-		if dist == "" {
-			log.Fatal().Err(err).Msg("please provide a dist folder where generated json will go")
-		}
 
-		file := args[0]
+		// without dist we want the file to be put alongside the original
+		if dist == "" {
+			src, err := filepath.Abs(file)
+			if err != nil {
+				log.Fatal().Err(err).Msg("cannot figure out the absolute path for the source file")
+			}
+			dist = filepath.Dir(src)
+		}
 
 		raw, err := os.ReadFile(file)
 		if err != nil {


### PR DESCRIPTION
to generate tar.xz files for every bundle locally. Great for testing, not meant for distirbution (since you want to do this for every architecture)
    
Also: remove some older resource generation code, which we no longer use. Do not install the core provider by install (it is meant to be builtin by default). And finally: do not build the lr.manifest.json into the dist folder, since we don't distribute it. Instead it will be kept alongside the manifest.yaml for further processing.