### PR TITLE
🐛 pre-load all providers

### DIFF
--- a/apps/cnquery/cmd/providers.go
+++ b/apps/cnquery/cmd/providers.go
@@ -116,18 +116,6 @@ func list() {
 		log.Error().Err(err).Msg("failed to list providers")
 	}
 
-	for _, v := range list {
-		if v.Path == "" {
-			continue
-		}
-		if err := v.LoadJSON(); err != nil {
-			log.Error().Err(err).
-				Str("provider", v.Name).
-				Str("path", v.Path).
-				Msg("failed to load provider")
-		}
-	}
-
 	printProviders(list)
 }
 


### PR DESCRIPTION
After https://github.com/mondoohq/cnquery/pull/1413

The mechanisms where it was only loaded from disk when necessary breaks because we need the CLI options to be loaded before we de-dupe any providers. This is done via name, so we have to have their metadata loaded. This makes the code simpler and removes any surprises with having a provider that has no metadata.