### PR TITLE
⭐ support loading fields across multiple providers

### DIFF
--- a/llx/runtime.go
+++ b/llx/runtime.go
@@ -14,5 +14,6 @@ type Runtime interface {
 
 type Schema interface {
 	Lookup(resource string) *resources.ResourceInfo
+	LookupField(resource string, field string) (*resources.ResourceInfo, *resources.Field)
 	AllResources() map[string]*resources.ResourceInfo
 }

--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -897,6 +897,7 @@ func filterEmptyExpressions(expressions []*parser.Expression) []*parser.Expressi
 
 type fieldPath []string
 
+// TODO: embed this into the Schema LookupField call!
 func (c *compiler) findField(resource *resources.ResourceInfo, fieldName string) (fieldPath, []*resources.Field, bool) {
 	fieldInfo, ok := resource.Fields[fieldName]
 	if ok {
@@ -944,7 +945,7 @@ func (c *compiler) compileBoundIdentifierWithMqlCtx(id string, binding *variable
 	typ := binding.typ
 
 	if typ.IsResource() {
-		resource := c.Schema.Lookup(typ.ResourceName())
+		resource, _ := c.Schema.LookupField(typ.ResourceName(), id)
 		if resource == nil {
 			return true, types.Nil, errors.New("cannot find resource that is called by '" + id + "' of type " + typ.Label())
 		}
@@ -1039,13 +1040,12 @@ func (c *compiler) compileBoundIdentifierWithoutMqlCtx(id string, binding *varia
 	typ := binding.typ
 
 	if typ.IsResource() {
-		resource := c.Schema.Lookup(typ.ResourceName())
+		resource, fieldinfo := c.Schema.LookupField(typ.ResourceName(), id)
 		if resource == nil {
 			return true, types.Nil, errors.New("cannot find resource that is called by '" + id + "' of type " + typ.Label())
 		}
 
-		fieldinfo, ok := resource.Fields[id]
-		if ok {
+		if fieldinfo != nil {
 			if call != nil && len(call.Function) > 0 {
 				return true, types.Nil, errors.New("cannot call resource field with arguments yet")
 			}

--- a/providers-sdk/v1/resources/schema.go
+++ b/providers-sdk/v1/resources/schema.go
@@ -43,6 +43,14 @@ func (s *Schema) Lookup(name string) *ResourceInfo {
 	return s.Resources[name]
 }
 
+func (s *Schema) LookupField(resource string, field string) (*ResourceInfo, *Field) {
+	res := s.Lookup(resource)
+	if res == nil || res.Fields == nil {
+		return res, nil
+	}
+	return res, res.Fields[field]
+}
+
 func (s *Schema) AllResources() map[string]*ResourceInfo {
 	return s.Resources
 }

--- a/providers/mock/mock.go
+++ b/providers/mock/mock.go
@@ -263,6 +263,10 @@ func (e emptySchema) Lookup(resource string) *resources.ResourceInfo {
 	return nil
 }
 
+func (e emptySchema) LookupField(resource string, field string) (*resources.ResourceInfo, *resources.Field) {
+	return nil, nil
+}
+
 func (e emptySchema) AllResources() map[string]*resources.ResourceInfo {
 	return nil
 }


### PR DESCRIPTION
This way calls like `asset{*}` will fundamentally work. Parts of the resource resides with the original provider for it, parts reside with the override.

On the example we still have to fix the `eol` call within the asset resource, since it is forwarded...