### PR TITLE
✨ release to ghcr

### DIFF
--- a/.github/.goreleaser-edge.yml
+++ b/.github/.goreleaser-edge.yml
@@ -39,7 +39,7 @@ dockers: # https://goreleaser.com/customization/docker/
     dockerfile: Dockerfile-ubi
     image_templates:
       - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-ubi-amd64"
-      - "mondoo/{{ .ProjectName }}:edge-latest-ubi-amd64"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-ubi-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"

--- a/.github/.goreleaser-edge.yml
+++ b/.github/.goreleaser-edge.yml
@@ -38,7 +38,7 @@ dockers: # https://goreleaser.com/customization/docker/
     goarch: amd64
     dockerfile: Dockerfile-ubi
     image_templates:
-      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-ubi-amd64"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-ubi-amd64"
       - "mondoo/{{ .ProjectName }}:edge-latest-ubi-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
@@ -52,8 +52,8 @@ dockers: # https://goreleaser.com/customization/docker/
     goarch: arm64
     dockerfile: Dockerfile-ubi
     image_templates:
-      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-ubi-arm64"
-      - "mondoo/{{ .ProjectName }}:edge-latest-ubi-arm64"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-ubi-arm64"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-ubi-arm64"
     build_flag_templates:
       - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -66,8 +66,8 @@ dockers: # https://goreleaser.com/customization/docker/
     goos: linux
     goarch: amd64
     image_templates:
-      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-amd64"
-      - "mondoo/{{ .ProjectName }}:edge-latest-amd64"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-amd64"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -79,8 +79,8 @@ dockers: # https://goreleaser.com/customization/docker/
     goos: linux
     goarch: arm64
     image_templates:
-      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-arm64v8"
-      - "mondoo/{{ .ProjectName }}:edge-latest-arm64v8"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-arm64v8"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-arm64v8"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -93,8 +93,8 @@ dockers: # https://goreleaser.com/customization/docker/
     goarch: arm
     goarm: 6
     image_templates:
-      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv6"
-      - "mondoo/{{ .ProjectName }}:edge-latest-armv6"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-armv6"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-armv6"
     build_flag_templates:
       - "--platform=linux/arm/v6"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -107,8 +107,8 @@ dockers: # https://goreleaser.com/customization/docker/
     goarch: arm
     goarm: 7
     image_templates:
-      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv7"
-      - "mondoo/{{ .ProjectName }}:edge-latest-armv7"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-armv7"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-armv7"
     build_flag_templates:
       - "--platform=linux/arm/v7"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -123,8 +123,8 @@ dockers: # https://goreleaser.com/customization/docker/
     goarch: amd64
     dockerfile: Dockerfile-ubi
     image_templates:
-      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-ubi-amd64-rootless"
-      - "mondoo/{{ .ProjectName }}:edge-latest-ubi-amd64-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-ubi-amd64-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-ubi-amd64-rootless"
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -137,8 +137,8 @@ dockers: # https://goreleaser.com/customization/docker/
     goarch: arm64
     dockerfile: Dockerfile-ubi
     image_templates:
-      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-ubi-arm64-rootless"
-      - "mondoo/{{ .ProjectName }}:edge-latest-ubi-arm64-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-ubi-arm64-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-ubi-arm64-rootless"
     build_flag_templates:
       - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -150,8 +150,8 @@ dockers: # https://goreleaser.com/customization/docker/
     goos: linux
     goarch: amd64
     image_templates:
-      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-amd64-rootless"
-      - "mondoo/{{ .ProjectName }}:edge-latest-amd64-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-amd64-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-amd64-rootless"
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -163,8 +163,8 @@ dockers: # https://goreleaser.com/customization/docker/
     goos: linux
     goarch: arm64
     image_templates:
-      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-arm64v8-rootless"
-      - "mondoo/{{ .ProjectName }}:edge-latest-arm64v8-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-arm64v8-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-arm64v8-rootless"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -177,8 +177,8 @@ dockers: # https://goreleaser.com/customization/docker/
     goarch: arm
     goarm: 6
     image_templates:
-      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv6-rootless"
-      - "mondoo/{{ .ProjectName }}:edge-latest-armv6-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-armv6-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-armv6-rootless"
     build_flag_templates:
       - "--platform=linux/arm/v6"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -191,8 +191,8 @@ dockers: # https://goreleaser.com/customization/docker/
     goarch: arm
     goarm: 7
     image_templates:
-      - "mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv7-rootless"
-      - "mondoo/{{ .ProjectName }}:edge-latest-armv7-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-armv7-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-armv7-rootless"
     build_flag_templates:
       - "--platform=linux/arm/v7"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -202,47 +202,47 @@ dockers: # https://goreleaser.com/customization/docker/
       - "--target=rootless"
 docker_manifests:  # https://goreleaser.com/customization/docker_manifest/
     # UBI containers
-  - name_template: mondoo/{{ .ProjectName }}:edge-{{ .Version }}-ubi
+  - name_template: ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-ubi
     image_templates:
-      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-ubi-amd64
-      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-ubi-arm64
-  - name_template: mondoo/{{ .ProjectName }}:edge-latest-ubi
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-ubi-amd64
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-ubi-arm64
+  - name_template: ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-ubi
     image_templates:
-      - mondoo/{{ .ProjectName }}:edge-latest-ubi-amd64
-      - mondoo/{{ .ProjectName }}:edge-latest-ubi-arm64
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-ubi-amd64
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-ubi-arm64
     # Standard containers
-  - name_template: mondoo/{{ .ProjectName }}:edge-{{ .Version }}
+  - name_template: ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}
     image_templates:
-      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-amd64
-      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-arm64v8
-      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv6
-      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv7
-  - name_template: mondoo/{{ .ProjectName }}:edge-latest
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-amd64
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-arm64v8
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-armv6
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-armv7
+  - name_template: ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest
     image_templates:
-      - mondoo/{{ .ProjectName }}:edge-latest-amd64
-      - mondoo/{{ .ProjectName }}:edge-latest-arm64v8
-      - mondoo/{{ .ProjectName }}:edge-latest-armv6
-      - mondoo/{{ .ProjectName }}:edge-latest-armv7
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-amd64
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-arm64v8
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-armv6
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-armv7
   # Rootless
     # UBI containers
-  - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-rootless
+  - name_template: ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-ubi-rootless
     image_templates:
-      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-ubi-amd64-rootless
-      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-ubi-arm64-rootless
-  - name_template: mondoo/{{ .ProjectName }}:edge-latest-ubi-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-ubi-amd64-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-ubi-arm64-rootless
+  - name_template: ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-ubi-rootless
     image_templates:
-      - mondoo/{{ .ProjectName }}:edge-latest-ubi-amd64-rootless
-      - mondoo/{{ .ProjectName }}:edge-latest-ubi-arm64-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-ubi-amd64-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-ubi-arm64-rootless
     # Standard containers
-  - name_template: mondoo/{{ .ProjectName }}:edge-{{ .Version }}-rootless
+  - name_template: ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-rootless
     image_templates:
-      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-amd64-rootless
-      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-arm64v8-rootless
-      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv6-rootless
-      - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-armv7-rootless
-  - name_template: mondoo/{{ .ProjectName }}:edge-latest-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-amd64-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-arm64v8-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-armv6-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-{{ .Version }}-armv7-rootless
+  - name_template: ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-rootless
     image_templates:
-      - mondoo/{{ .ProjectName }}:edge-latest-amd64-rootless
-      - mondoo/{{ .ProjectName }}:edge-latest-arm64v8-rootless
-      - mondoo/{{ .ProjectName }}:edge-latest-armv6-rootless
-      - mondoo/{{ .ProjectName }}:edge-latest-armv7-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-amd64-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-arm64v8-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-armv6-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:edge-latest-armv7-rootless

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -6,9 +6,6 @@ on:
       - 'main'
   workflow_dispatch:
 
-env:
-  REGISTRY: docker.io
-
 jobs:
   goreleaser:
     permissions:
@@ -30,13 +27,6 @@ jobs:
         with:
           go-version: ">=1.20.4"
           cache: false
-          
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Locally tag the current commit
         run: |

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -126,4 +126,7 @@ jobs:
         run: |
           for tag in ${DOCKER_METADATA_OUTPUT_TAGS}; do
             skopeo copy docker://$tag docker://mondoo/cnquery:${tag#"$GHCR_REGISTRY"} --multi-arch all
+            skopeo copy docker://$tag docker://mondoo/cnquery:${tag#"$GHCR_REGISTRY"}-rootless --multi-arch all
+            skopeo copy docker://$tag docker://mondoo/cnquery:${tag#"$GHCR_REGISTRY"}-ubi --multi-arch all
+            skopeo copy docker://$tag docker://mondoo/cnquery:${tag#"$GHCR_REGISTRY"}-ubi-rootless --multi-arch all
           done

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 env:
+  GHCR_PREFIX: "ghcr.io/mondoohq/cnquery:"
   REGISTRY: docker.io
 
 jobs:
@@ -65,13 +66,6 @@ jobs:
             curl -sSfL https://raw.githubusercontent.com/anchore/quill/main/install.sh | sh -s -- -b /tmp v0.2.0
             /tmp/quill help
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
@@ -102,3 +96,34 @@ jobs:
             "repository": "${{ github.event.repository.name }}",
             "version":  "${{  github.ref_name }}"
           }'
+  sync-docker:
+    runs-on: self-hosted
+    timeout-minutes: 5
+    needs: 
+      - goreleaser
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/mondoohq/cnquery
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}
+      - name: Log in to dockerhub
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Copy to dockerhub
+        run: |
+          for tag in ${DOCKER_METADATA_OUTPUT_TAGS}; do
+            skopeo copy docker://$tag docker://mondoo/cnquery:${tag#"$GHCR_REGISTRY"} --multi-arch all
+          done

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -95,9 +95,9 @@ dockers: # https://goreleaser.com/customization/docker/
     goarch: amd64
     dockerfile: Dockerfile-ubi
     image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64"
-      - "mondoo/{{ .ProjectName }}:{{ .Major }}-ubi-amd64"
-      - "mondoo/{{ .ProjectName }}:latest-ubi-amd64"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-ubi-amd64"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-ubi-amd64"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:latest-ubi-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -110,9 +110,9 @@ dockers: # https://goreleaser.com/customization/docker/
     goarch: arm64
     dockerfile: Dockerfile-ubi
     image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64"
-      - "mondoo/{{ .ProjectName }}:{{ .Major }}-ubi-arm64"
-      - "mondoo/{{ .ProjectName }}:latest-ubi-arm64"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-ubi-arm64"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-ubi-arm64"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:latest-ubi-arm64"
     build_flag_templates:
       - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -125,9 +125,9 @@ dockers: # https://goreleaser.com/customization/docker/
     goos: linux
     goarch: amd64
     image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-amd64"
-      - "mondoo/{{ .ProjectName }}:{{ .Major }}-amd64"
-      - "mondoo/{{ .ProjectName }}:latest-amd64"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-amd64"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:latest-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -139,9 +139,9 @@ dockers: # https://goreleaser.com/customization/docker/
     goos: linux
     goarch: arm64
     image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8"
-      - "mondoo/{{ .ProjectName }}:{{ .Major }}-arm64v8"
-      - "mondoo/{{ .ProjectName }}:latest-arm64v8"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-arm64v8"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-arm64v8"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:latest-arm64v8"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -154,9 +154,9 @@ dockers: # https://goreleaser.com/customization/docker/
     goarch: arm
     goarm: 6
     image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv6"
-      - "mondoo/{{ .ProjectName }}:{{ .Major }}-armv6"
-      - "mondoo/{{ .ProjectName }}:latest-armv6"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-armv6"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-armv6"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:latest-armv6"
     build_flag_templates:
       - "--platform=linux/arm/v6"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -169,9 +169,9 @@ dockers: # https://goreleaser.com/customization/docker/
     goarch: arm
     goarm: 7
     image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv7"
-      - "mondoo/{{ .ProjectName }}:{{ .Major }}-armv7"
-      - "mondoo/{{ .ProjectName }}:latest-armv7"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-armv7"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-armv7"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:latest-armv7"
     build_flag_templates:
       - "--platform=linux/arm/v7"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -186,9 +186,9 @@ dockers: # https://goreleaser.com/customization/docker/
     goarch: amd64
     dockerfile: Dockerfile-ubi
     image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64-rootless"
-      - "mondoo/{{ .ProjectName }}:{{ .Major }}-ubi-amd64-rootless"
-      - "mondoo/{{ .ProjectName }}:latest-ubi-amd64-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-ubi-amd64-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-ubi-amd64-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:latest-ubi-amd64-rootless"
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -201,9 +201,9 @@ dockers: # https://goreleaser.com/customization/docker/
     goarch: arm64
     dockerfile: Dockerfile-ubi
     image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64-rootless"
-      - "mondoo/{{ .ProjectName }}:{{ .Major }}-ubi-arm64-rootless"
-      - "mondoo/{{ .ProjectName }}:latest-ubi-arm64-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-ubi-arm64-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-ubi-arm64-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:latest-ubi-arm64-rootless"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -216,9 +216,9 @@ dockers: # https://goreleaser.com/customization/docker/
     goos: linux
     goarch: amd64
     image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-amd64-rootless"
-      - "mondoo/{{ .ProjectName }}:{{ .Major }}-amd64-rootless"
-      - "mondoo/{{ .ProjectName }}:latest-amd64-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-amd64-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-amd64-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:latest-amd64-rootless"
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -230,9 +230,9 @@ dockers: # https://goreleaser.com/customization/docker/
     goos: linux
     goarch: arm64
     image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8-rootless"
-      - "mondoo/{{ .ProjectName }}:{{ .Major }}-arm64v8-rootless"
-      - "mondoo/{{ .ProjectName }}:latest-arm64v8-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-arm64v8-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-arm64v8-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:latest-arm64v8-rootless"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -245,9 +245,9 @@ dockers: # https://goreleaser.com/customization/docker/
     goarch: arm
     goarm: 6
     image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv6-rootless"
-      - "mondoo/{{ .ProjectName }}:{{ .Major }}-armv6-rootless"
-      - "mondoo/{{ .ProjectName }}:latest-armv6-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-armv6-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-armv6-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:latest-armv6-rootless"
     build_flag_templates:
       - "--platform=linux/arm/v6"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -260,9 +260,9 @@ dockers: # https://goreleaser.com/customization/docker/
     goarch: arm
     goarm: 7
     image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv7-rootless"
-      - "mondoo/{{ .ProjectName }}:{{ .Major }}-armv7-rootless"
-      - "mondoo/{{ .ProjectName }}:latest-armv7-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-armv7-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-armv7-rootless"
+      - "ghcr.io/mondoohq/{{ .ProjectName }}:latest-armv7-rootless"
     build_flag_templates:
       - "--platform=linux/arm/v7"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -272,69 +272,69 @@ dockers: # https://goreleaser.com/customization/docker/
       - "--target=rootless"
 docker_manifests:  # https://goreleaser.com/customization/docker_manifest/
     # UBI containers
-  - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}-ubi
+  - name_template: ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-ubi
     image_templates:
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-ubi-amd64
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-ubi-arm64
   - name_template: mondoo/{{ .ProjectName }}:{{ .Major }}-ubi
     image_templates:
-      - mondoo/{{ .ProjectName }}:{{ .Major }}-ubi-amd64
-      - mondoo/{{ .ProjectName }}:{{ .Major }}-ubi-arm64
-  - name_template: mondoo/{{ .ProjectName }}:latest
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-ubi-amd64
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-ubi-arm64
+  - name_template: ghcr.io/mondoohq/{{ .ProjectName }}:latest
     image_templates:
-      - mondoo/{{ .ProjectName }}:latest-amd64
-      - mondoo/{{ .ProjectName }}:latest-arm64v8
-      - mondoo/{{ .ProjectName }}:latest-armv6
-      - mondoo/{{ .ProjectName }}:latest-armv7
+      - ghcr.io/mondoohq/{{ .ProjectName }}:latest-amd64
+      - ghcr.io/mondoohq/{{ .ProjectName }}:latest-arm64v8
+      - ghcr.io/mondoohq/{{ .ProjectName }}:latest-armv6
+      - ghcr.io/mondoohq/{{ .ProjectName }}:latest-armv7
     # Standard containers
-  - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}
+  - name_template: ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}
     image_templates:
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-amd64
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-armv6
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-armv7
-  - name_template: mondoo/{{ .ProjectName }}:{{ .Major }}
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-amd64
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-arm64v8
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-armv6
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-armv7
+  - name_template: ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}
     image_templates:
-      - mondoo/{{ .ProjectName }}:{{ .Major }}-amd64
-      - mondoo/{{ .ProjectName }}:{{ .Major }}-arm64v8
-      - mondoo/{{ .ProjectName }}:{{ .Major }}-armv6
-      - mondoo/{{ .ProjectName }}:{{ .Major }}-armv7
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-amd64
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-arm64v8
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-armv6
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-armv7
   - name_template: mondoo/{{ .ProjectName }}:latest
     image_templates:
-      - mondoo/{{ .ProjectName }}:latest-amd64
-      - mondoo/{{ .ProjectName }}:latest-arm64v8
-      - mondoo/{{ .ProjectName }}:latest-armv6
-      - mondoo/{{ .ProjectName }}:latest-armv7
+      - ghcr.io/mondoohq/{{ .ProjectName }}:latest-amd64
+      - ghcr.io/mondoohq/{{ .ProjectName }}:latest-arm64v8
+      - ghcr.io/mondoohq/{{ .ProjectName }}:latest-armv6
+      - ghcr.io/mondoohq/{{ .ProjectName }}:latest-armv7
   # Rootless
     # UBI containers
-  - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-rootless
+  - name_template: ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-ubi-rootless
     image_templates:
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64-rootless
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64-rootless
-  - name_template: mondoo/{{ .ProjectName }}:{{ .Major }}-ubi-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-ubi-amd64-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-ubi-arm64-rootless
+  - name_template: ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-ubi-rootless
     image_templates:
-      - mondoo/{{ .ProjectName }}:{{ .Major }}-ubi-amd64-rootless
-      - mondoo/{{ .ProjectName }}:{{ .Major }}-ubi-arm64-rootless
-  - name_template: mondoo/{{ .ProjectName }}:latest-ubi-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-ubi-amd64-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-ubi-arm64-rootless
+  - name_template: ghcr.io/mondoohq/{{ .ProjectName }}:latest-ubi-rootless
     image_templates:
-      - mondoo/{{ .ProjectName }}:latest-ubi-amd64-rootless
-      - mondoo/{{ .ProjectName }}:latest-ubi-arm64-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:latest-ubi-amd64-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:latest-ubi-arm64-rootless
     # Standard containers
-  - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}-rootless
+  - name_template: ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-rootless
     image_templates:
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-amd64-rootless
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8-rootless
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-armv6-rootless
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-armv7-rootless
-  - name_template: mondoo/{{ .ProjectName }}:{{ .Major }}-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-amd64-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-arm64v8-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-armv6-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Version }}-armv7-rootless
+  - name_template: ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-rootless
     image_templates:
-      - mondoo/{{ .ProjectName }}:{{ .Major }}-amd64-rootless
-      - mondoo/{{ .ProjectName }}:{{ .Major }}-arm64v8-rootless
-      - mondoo/{{ .ProjectName }}:{{ .Major }}-armv6-rootless
-      - mondoo/{{ .ProjectName }}:{{ .Major }}-armv7-rootless
-  - name_template: mondoo/{{ .ProjectName }}:latest-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-amd64-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-arm64v8-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-armv6-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:{{ .Major }}-armv7-rootless
+  - name_template: ghcr.io/mondoohq/{{ .ProjectName }}:latest-rootless
     image_templates:
-      - mondoo/{{ .ProjectName }}:latest-amd64-rootless
-      - mondoo/{{ .ProjectName }}:latest-arm64v8-rootless
-      - mondoo/{{ .ProjectName }}:latest-armv6-rootless
-      - mondoo/{{ .ProjectName }}:latest-armv7-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:latest-amd64-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:latest-arm64v8-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:latest-armv6-rootless
+      - ghcr.io/mondoohq/{{ .ProjectName }}:latest-armv7-rootless


### PR DESCRIPTION
We always release to ghcr. For prod releases we add an extra job that copies the images from ghcr to dockerhub