### PR TITLE
🐞 add non-interactive flag to the zypper command

### DIFF
--- a/providers/os/resources/updates/suse_updates.go
+++ b/providers/os/resources/updates/suse_updates.go
@@ -25,7 +25,7 @@ func (sum *SuseUpdateManager) Format() string {
 }
 
 func (sum *SuseUpdateManager) List() ([]OperatingSystemUpdate, error) {
-	cmd, err := sum.conn.RunCommand("zypper --xmlout list-updates -t patch")
+	cmd, err := sum.conn.RunCommand("zypper -n --xmlout list-updates -t patch")
 	if err != nil {
 		return nil, fmt.Errorf("could not read package list")
 	}


### PR DESCRIPTION
During a cnspec scan on a system without access to the suse repositories, zypper waits for user input. This results in an unresponsive cnspec scan.