### PR TITLE
🐛 attach cli PreRun on command-generation

### DIFF
--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -141,9 +141,10 @@ func setDefaultConnector(provider *plugin.Provider, connector *plugin.Connector,
 
 func attachConnectorCmd(provider *plugin.Provider, connector *plugin.Connector, cmd *Command) {
 	res := &cobra.Command{
-		Use:   connector.Use,
-		Short: cmd.Action + connector.Short,
-		Long:  connector.Long,
+		Use:    connector.Use,
+		Short:  cmd.Action + connector.Short,
+		Long:   connector.Long,
+		PreRun: cmd.Command.PreRun,
 	}
 
 	cmd.Command.Flags().VisitAll(func(flag *pflag.Flag) {


### PR DESCRIPTION
Without this, PreRun for these new commands is not called. This means that things like `viper.BindPFlag` is not executed, which in term breaks later execution.