### PR TITLE
🐛 inject runtime into services

### DIFF
--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -314,7 +314,7 @@ func (s *LocalScanner) runMotorizedAsset(job *AssetJob) (*AssetReport, error) {
 	var res *AssetReport
 	var scanErr error
 
-	runtimeErr := inmemory.WithDb(func(db *inmemory.Db, services *explorer.LocalServices) error {
+	runtimeErr := inmemory.WithDb(job.runtime, func(db *inmemory.Db, services *explorer.LocalServices) error {
 		if job.UpstreamConfig.ApiEndpoint != "" && !job.UpstreamConfig.Incognito {
 			log.Debug().Msg("using API endpoint " + s.upstream.ApiEndpoint)
 			client, err := s.upstream.InitClient()

--- a/explorer/services.go
+++ b/explorer/services.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	llx "go.mondoo.com/cnquery/llx"
-	"go.mondoo.com/cnquery/providers"
 	"go.mondoo.com/ranger-rpc"
 	"golang.org/x/sync/semaphore"
 )
@@ -34,12 +33,12 @@ type LocalServices struct {
 }
 
 // NewLocalServices initializes a reasonably configured local services struct
-func NewLocalServices(datalake DataLake, uuid string) *LocalServices {
+func NewLocalServices(datalake DataLake, uuid string, runtime llx.Runtime) *LocalServices {
 	return &LocalServices{
 		DataLake:  datalake,
 		Upstream:  nil,
 		Incognito: false,
-		runtime:   providers.DefaultRuntime(),
+		runtime:   runtime,
 	}
 }
 

--- a/internal/datalakes/inmemory/inmemory.go
+++ b/internal/datalakes/inmemory/inmemory.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/uuid"
 	"go.mondoo.com/cnquery/explorer"
+	"go.mondoo.com/cnquery/llx"
 )
 
 // Db is the database backend, it allows the interaction with the underlying data.
@@ -16,7 +17,7 @@ type Db struct {
 }
 
 // NewServices creates a new set of backend services
-func NewServices() (*Db, *explorer.LocalServices, error) {
+func NewServices(runtime llx.Runtime) (*Db, *explorer.LocalServices, error) {
 	var cache kvStore = newKissDb()
 
 	db := &Db{
@@ -25,15 +26,15 @@ func NewServices() (*Db, *explorer.LocalServices, error) {
 		nowProvider: time.Now,
 	}
 
-	services := explorer.NewLocalServices(db, db.uuid)
+	services := explorer.NewLocalServices(db, db.uuid, runtime)
 	db.services = services // close the connection between db and services
 
 	return db, services, nil
 }
 
 // WithDb creates a new set of backend services and closes everything out once the function is done
-func WithDb(f func(*Db, *explorer.LocalServices) error) error {
-	db, ls, err := NewServices()
+func WithDb(runtime llx.Runtime, f func(*Db, *explorer.LocalServices) error) error {
+	db, ls, err := NewServices(runtime)
 	if err != nil {
 		return err
 	}

--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -94,7 +94,7 @@ func (c *coordinator) Start(id string) (*RunningProvider, error) {
 	}
 
 	res := &RunningProvider{
-		Name:   id,
+		Name:   provider.Name,
 		ID:     provider.ID,
 		Plugin: raw.(pp.ProviderPlugin),
 		Client: client,


### PR DESCRIPTION
After https://github.com/mondoohq/cnquery/pull/1430

Currently, when creating a new set of local services, we are actually creating a new runtime. So far that never caused problems, because cnquery was monolithic. Now that is changing, and we want the correct runtime to be injected and used (ie not created anew) into services. This popped up as a bug when running scans, where part of the queries were not executable because providers were missing.

This is also bad behavior in the previous iteration, since we never used the correct runtime.