### PR TITLE
🐛 prevent grpc nil errors

### DIFF
--- a/providers/core/provider/provider.go
+++ b/providers/core/provider/provider.go
@@ -131,5 +131,5 @@ func (s *Service) StoreData(req *plugin.StoreReq) (*plugin.StoreRes, error) {
 	if len(errs) != 0 {
 		return nil, errors.New(strings.Join(errs, ", "))
 	}
-	return nil, nil
+	return &plugin.StoreRes{}, nil
 }

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -288,5 +288,5 @@ func (s *Service) StoreData(req *plugin.StoreReq) (*plugin.StoreRes, error) {
 	if len(errs) != 0 {
 		return nil, errors.New(strings.Join(errs, ", "))
 	}
-	return nil, nil
+	return &plugin.StoreRes{}, nil
 }


### PR DESCRIPTION
After https://github.com/mondoohq/cnquery/pull/1431

We have to return non-nil on success or grpc will fail to encode