### PR TITLE
🐛 use correct schema + conditional upstream config

### DIFF
--- a/explorer/scan/fetcher.go
+++ b/explorer/scan/fetcher.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"go.mondoo.com/cnquery"
 	"go.mondoo.com/cnquery/explorer"
-	"go.mondoo.com/cnquery/providers"
+	"go.mondoo.com/cnquery/llx"
 )
 
 type fetcher struct {
@@ -21,7 +21,7 @@ func newFetcher() *fetcher {
 	}
 }
 
-func (f *fetcher) fetchBundles(ctx context.Context, urls ...string) (*explorer.Bundle, error) {
+func (f *fetcher) fetchBundles(ctx context.Context, schema llx.Schema, urls ...string) (*explorer.Bundle, error) {
 	var res *explorer.Bundle = &explorer.Bundle{}
 
 	for i := range urls {
@@ -37,7 +37,7 @@ func (f *fetcher) fetchBundles(ctx context.Context, urls ...string) (*explorer.B
 		}
 
 		// need to generate MRNs for everything
-		if _, err := cur.Compile(ctx, providers.DefaultRuntime().Schema()); err != nil {
+		if _, err := cur.Compile(ctx, schema); err != nil {
 			return nil, errors.Wrap(err, "failed to compile fetched bundle")
 		}
 


### PR DESCRIPTION
After https://github.com/mondoohq/cnquery/pull/1432

1. Like previously stated, in the past we were taking a lot of shortcuts by instantiating schemas multiple times. Now that we have runtime-bound schemas (with specificly loaded plugin providers) we have to do this properly, i.e. schemas are handed over.
2. We do not always have an upstream config, so for the cases where we don't, we have to work around it. We don't want to set an upstream config when we didn't load one, so it needs a check now.