### PR TITLE
🧹 Set the title of AWS accounts to be AWS Account

### DIFF
--- a/motor/providers/aws/provider.go
+++ b/motor/providers/aws/provider.go
@@ -275,7 +275,7 @@ func getPlatformForObject(platformName string) *platform.Platform {
 	}
 	return &platform.Platform{
 		Name:    "aws",
-		Title:   "Amazon Web Services",
+		Title:   "AWS Account",
 		Kind:    providers.Kind_KIND_API,
 		Runtime: providers.RUNTIME_AWS,
 	}


### PR DESCRIPTION
Right now an AWS Account passes into this functionw with the name of "" and we set the name to "aws" and the title to "Amazon Web Services". The "aws" platform is actually the account so we should properly name it. This is important as time goes on with fine grained scanning where we need to distinguish between the resources and the main account.