### PR TITLE
⭐ support auto-update for installed providers

### DIFF
--- a/apps/cnquery/cmd/providers.go
+++ b/apps/cnquery/cmd/providers.go
@@ -83,31 +83,23 @@ func installProviderUrl(u string) {
 		log.Fatal().Err(err).Msg("failed to install")
 	}
 
-	providers, err := providers.InstallIO(res.Body, providers.InstallConf{
+	installed, err := providers.InstallIO(res.Body, providers.InstallConf{
 		Dst: providers.HomePath,
 	})
-	finalizeProviderInstall(providers, err)
-}
-
-func installProviderFile(path string) {
-	providers, err := providers.InstallFile(path, providers.InstallConf{
-		Dst: providers.HomePath,
-	})
-	finalizeProviderInstall(providers, err)
-}
-
-func finalizeProviderInstall(providers []*providers.Provider, err error) {
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to install")
 	}
+	providers.PrintInstallResults(installed)
+}
 
-	for i := range providers {
-		provider := providers[i]
-		log.Info().
-			Str("version", provider.Version).
-			Str("path", provider.Path).
-			Msg("successfully installed " + provider.Name + " provider")
+func installProviderFile(path string) {
+	installed, err := providers.InstallFile(path, providers.InstallConf{
+		Dst: providers.HomePath,
+	})
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to install")
 	}
+	providers.PrintInstallResults(installed)
 }
 
 func list() {

--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -285,6 +285,13 @@ func setConnector(provider *plugin.Provider, connector *plugin.Connector, run fu
 		}
 
 		runtime := providers.Coordinator.NewRuntime()
+
+		// TODO: read from config
+		runtime.AutoUpdate = providers.UpdateProvidersConfig{
+			Enabled:         true,
+			RefreshInterval: 60 * 60,
+		}
+
 		if err := runtime.UseProvider(provider.ID); err != nil {
 			providers.Coordinator.Shutdown()
 			log.Fatal().Err(err).Msg("failed to start provider " + provider.Name)

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -22,6 +22,7 @@ type Runtime struct {
 	Provider       *ConnectedProvider
 	UpstreamConfig *upstream.UpstreamConfig
 	Recording      Recording
+	AutoUpdate     UpdateProvidersConfig
 
 	features []byte
 	// coordinator is used to grab providers
@@ -109,7 +110,7 @@ func (r *Runtime) addProvider(id string) (*ConnectedProvider, error) {
 
 	if running == nil {
 		var err error
-		running, err = r.coordinator.Start(id)
+		running, err = r.coordinator.Start(id, r.AutoUpdate)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
![image](https://github.com/mondoohq/cnquery/assets/1307529/56593c67-b426-45ad-920f-68f3a5995ff4)

A great starting point!

**How does it work?**

1. This only operates on whatever provider the user wants to use. It doesn't consider other providers. This keeps updates focused on things that are in use only. This is done when a provider is started by the coordinator. I.e. it does not happen when we attach to shell, only when we actually make use of a provider.
2. Updates will only be checked for non-builtin providers. We ignore builtin providers, since we never load them from disk (no matter the version). Builtin is builtin after all ;)
3. It looks at the binary for the installed provider. If the last change time is too recent (1h by default) it will not try to check for new versions. If we check for new versions, the change time will be updated, no matter if something was installed or not, so that we don't have to do these calls too often.
4. It will then get the latest versions for all providers that are available. For now we have a simple entrypoint, which will later move to the registry and support more specialized requests. But for now, we have this amazing JSON that tells us what the latest provider versions are.
5. If it finds the provider in the list and if the version (via semver) is more recent, then it will try to install it.
6. The installation detects the architecture and OS automatically. It downloads and unpacks the tar.xz and installs it.
7. After everything is done, it will let you know about the installation and then proceed to use this latest version of the provider.

More to come, progress bar etc etc, but a great start!