### PR TITLE
✨ auto-install missing providers

### DIFF
--- a/apps/cnquery/cmd/root.go
+++ b/apps/cnquery/cmd/root.go
@@ -78,7 +78,7 @@ func init() {
 	// since the log instance is already initialized, replace default zerolog color output with our own
 	// use color logger by default
 	logger.CliCompactLogger(logger.LogOutputWriter)
-	zerolog.SetGlobalLevel(zerolog.WarnLevel)
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 
 	config.DefaultConfigFile = "mondoo.yml"
 

--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -183,7 +183,7 @@ func (c *coordinator) tryProviderUpdate(provider *Provider, update UpdateProvide
 		Str("installed", provider.Version).
 		Str("latest", latest).
 		Msg("found a new version for '" + provider.Name + "' provider")
-	provider, err = InstallVersion(provider.Name, latest)
+	provider, err = installVersion(provider.Name, latest)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
After https://github.com/mondoohq/cnquery/pull/1447

- 🐛 clear out the cache of providers during the installation
- inject the installation as early as possible, because we need to reload CLI options

![image](https://github.com/mondoohq/cnquery/assets/1307529/a3b84bcc-e23c-48a7-a84c-ff4bcb6c0a3b)
