### PR TITLE
🐛 avoid logging before logger is initialized

### DIFF
--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -433,7 +433,16 @@ func (s *localAssetScanner) prepareAsset() error {
 	return nil
 }
 
-var assetDetectBundle = executor.MustCompile("asset { kind platform runtime version family }")
+var _assetDetectBundle *llx.CodeBundle
+
+func assetDetectBundle() *llx.CodeBundle {
+	if _assetDetectBundle == nil {
+		// NOTE: we need to make sure this is loaded after the logger has been
+		// initialized, otherwise the provider detection will print annoying logs
+		_assetDetectBundle = executor.MustCompile("asset { kind platform runtime version family }")
+	}
+	return _assetDetectBundle
+}
 
 func (s *localAssetScanner) ensureBundle() error {
 	if s.job.Bundle != nil {
@@ -441,7 +450,7 @@ func (s *localAssetScanner) ensureBundle() error {
 	}
 
 	features := cnquery.GetFeatures(s.job.Ctx)
-	res, err := mql.ExecuteCode(s.Runtime, assetDetectBundle, nil, features)
+	res, err := mql.ExecuteCode(s.Runtime, assetDetectBundle(), nil, features)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
After https://github.com/mondoohq/cnquery/pull/1448

This caused very very early logs to be printed, because even with an `init()` call this runs before the CLI `root.go` is able to call its `init()`. So, we have to work around these limitations...

Before:

![image](https://github.com/mondoohq/cnquery/assets/1307529/770e7008-3417-42b3-9198-d0cee944be28)

After:

![image](https://github.com/mondoohq/cnquery/assets/1307529/c5a34c47-bb75-431c-9fff-2b4c98ce739b)
