### PR TITLE
🐛 retain reverse connection to provider

### DIFF
--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -535,8 +535,12 @@ func (x *extensibleSchema) loadAllSchemas() {
 	}
 
 	for name := range providers {
-		schema := x.runtime.coordinator.LoadSchema(name)
-		x.Add(name, schema)
+		schema, err := x.runtime.coordinator.LoadSchema(name)
+		if err != nil {
+			log.Error().Err(err).Msg("load schema failed")
+		} else {
+			x.Add(name, schema)
+		}
 	}
 }
 


### PR DESCRIPTION
After https://github.com/mondoohq/cnquery/pull/1450

If we close it too early, then the plugin cannot call back to another plugin to create resources or get data.