### PR TITLE
🐛 auto-detect the network provider pre-shell

### DIFF
--- a/providers/defaults.go
+++ b/providers/defaults.go
@@ -36,4 +36,15 @@ var DefaultProviders Providers = map[string]*Provider{
 			},
 		},
 	},
+	"network": {
+		Provider: &plugin.Provider{
+			Name: "network",
+			Connectors: []plugin.Connector{
+				{
+					Name:  "host",
+					Short: "your local system",
+				},
+			},
+		},
+	},
 }


### PR DESCRIPTION
When users use `host` we want to auto-detect the network provider by default.