### PR TITLE
🐛 fix hashi vault

### DIFF
--- a/motor/vault/hashivault/hashivault.go
+++ b/motor/vault/hashivault/hashivault.go
@@ -8,12 +8,14 @@ import (
 	"strings"
 
 	"github.com/hashicorp/vault/api"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/motor/vault"
 )
 
 var notImplemented = errors.New("not implemented")
 
 func New(serverURL string, token string) *Vault {
+	log.Debug().Bool("token-sec", len(token) > 0).Msgf("Using HashiCorp Vault at %s", serverURL)
 	return &Vault{
 		Token: token,
 		APIConfig: api.Config{
@@ -62,6 +64,7 @@ func validKey(key string) error {
 
 // https://learn.hashicorp.com/tutorials/vault/versioned-kv?in=vault/secrets-management#step-2-write-secrets
 func (v *Vault) Get(ctx context.Context, id *vault.SecretID) (*vault.Secret, error) {
+	log.Debug().Str("secret", id.Key).Msg("gather secret from hashicorp-vault")
 	c, err := v.client()
 	if err != nil {
 		return nil, err
@@ -83,8 +86,9 @@ func (v *Vault) Get(ctx context.Context, id *vault.SecretID) (*vault.Secret, err
 	}
 
 	return &vault.Secret{
-		Key:  id.Key,
-		Data: secretBytes,
+		Key:      id.Key,
+		Data:     secretBytes,
+		Encoding: vault.SecretEncoding_encoding_json,
 	}, nil
 }
 

--- a/motor/vault/hashivault/hashivault_test.go
+++ b/motor/vault/hashivault/hashivault_test.go
@@ -37,7 +37,7 @@ func TestHashiVault(t *testing.T) {
 	require.NoError(t, err)
 
 	jsonSecret := make(map[string]string)
-	err = json.Unmarshal([]byte(newCred.Secret), &jsonSecret)
+	err = json.Unmarshal(newCred.Data, &jsonSecret)
 	require.NoError(t, err)
 
 	assert.Equal(t, jsonSecret, fields)


### PR DESCRIPTION
To use hashi-vault, use the following config:

```yaml
apiVersion: v1
kind: Inventory
metadata:
  name: mondoo-inventory
  labels:
    environment: production
spec:
  assets:
    - name: vsphere
      connections:
        - backend: vsphere
          host: 192.168.1.24
          credentials:
            - secret_id: test-key # uses the secret kv backend automatically
          discover:
            targets:
              - host-machines
  vault:
    name: local
    type: hashicorp-vault
    options:
      url: http://127.0.0.1:8200 # dev-server url
      token: <token>
```