### PR TITLE
🐛 Fix conversion of primitives with NO type (#1456)

### DIFF
--- a/llx/data_conversions.go
+++ b/llx/data_conversions.go
@@ -441,7 +441,8 @@ func (r *Result) RawResultV2() *RawResult {
 
 	data := &RawData{}
 	if r.Data != nil {
-		if r.Data.IsNil() {
+		// The type can be empty, when we do not have data
+		if r.Data.IsNil() || types.Type(r.Data.Type).IsEmpty() {
 			data.Type = types.Nil
 		} else {
 			data = r.Data.RawData()


### PR DESCRIPTION
In case we have a resource without data, it also does not have a type. We need to catch this to prevent the error: `cannot convert primitive with NO type information`

This happens, e.g., when we test for the exists of a file before doing anything else with the resource.

Backport from main.

Partially-Fixes #957