### PR TITLE
🧹 do not error on filepath.SkipDir when reading linux bios

### DIFF
--- a/resources/packs/os/smbios/linux.go
+++ b/resources/packs/os/smbios/linux.go
@@ -95,5 +95,10 @@ func (s *LinuxSmbiosManager) Info() (*SmBiosInfo, error) {
 		return nil
 	})
 
-	return &smInfo, wErr
+	// If the error is SkipDir we can safely ignore it
+	if wErr != nil && wErr != filepath.SkipDir {
+		return nil, wErr
+	}
+
+	return &smInfo, nil
 }


### PR DESCRIPTION
When running a snapshot scan we can run into the issue that we log a `SkipDir` error when reading bios. That error is irrelevant and we should just return empty data