### PR TITLE
🐛 Use bool value and not pointer for `aws.ec2.networkacl.entry.egress`

### DIFF
--- a/resources/packs/aws/aws_ec2.go
+++ b/resources/packs/aws/aws_ec2.go
@@ -168,7 +168,7 @@ func (s *mqlAwsEc2Networkacl) GetEntries() ([]interface{}, error) {
 	res := []interface{}{}
 	for _, entry := range networkacls.NetworkAcls[0].Entries {
 		args := []interface{}{
-			"egress", entry.Egress,
+			"egress", *entry.Egress,
 			"ruleAction", string(entry.RuleAction),
 			"id", id + "-" + strconv.Itoa(core.ToIntFrom32(entry.RuleNumber)),
 		}


### PR DESCRIPTION
Fixes #1463