### PR TITLE
🐛 fixes for suse linux

### DIFF
--- a/resources/packs/core/packages/rpm_packages.go
+++ b/resources/packs/core/packages/rpm_packages.go
@@ -257,7 +257,7 @@ func (spm *SusePkgManager) Available() (map[string]PackageUpdate, error) {
 	if spm.isStaticAnalysis() {
 		return spm.staticAvailable()
 	}
-	cmd, err := spm.provider.RunCommand("zypper --xmlout list-updates")
+	cmd, err := spm.provider.RunCommand("zypper -n --xmlout list-updates")
 	if err != nil {
 		log.Debug().Err(err).Msg("mql[packages]> could not read package updates")
 		return nil, fmt.Errorf("could not read package update list")

--- a/resources/packs/core/packages/rpm_updates.go
+++ b/resources/packs/core/packages/rpm_updates.go
@@ -49,7 +49,7 @@ type zypper struct {
 }
 
 // for Suse, updates are package updates
-// parses the output of `zypper --xmlout list-updates`
+// parses the output of `zypper -n --xmlout list-updates`
 func ParseZypperUpdates(input io.Reader) (map[string]PackageUpdate, error) {
 	pkgs := map[string]PackageUpdate{}
 	zypper, err := ParseZypper(input)

--- a/resources/packs/core/packages/rpm_updates_test.go
+++ b/resources/packs/core/packages/rpm_updates_test.go
@@ -38,7 +38,7 @@ func TestZypperUpdateParser(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c, err := mock.RunCommand("zypper --xmlout list-updates")
+	c, err := mock.RunCommand("zypper -n --xmlout list-updates")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/resources/packs/core/packages/testdata/updates_zypper.toml
+++ b/resources/packs/core/packages/testdata/updates_zypper.toml
@@ -1,4 +1,4 @@
-[commands."zypper --xmlout list-updates"]
+[commands."zypper -n --xmlout list-updates"]
 stdout = """<?xml version='1.0'?>
 <stream>
 <message type="info">Loading repository data...</message>
@@ -246,7 +246,7 @@ drop-in replacement for sysvinit.</description>
 </stream>
 """
 
-[commands."zypper --xmlout list-updates -t patch"]
+[commands."zypper -n --xmlout list-updates -t patch"]
 stdout = """<?xml version='1.0'?>
 <stream>
 <progress id="raw-refresh" name="Retrieving repository &apos;NON OSS&apos; metadata" value="0"/>

--- a/resources/packs/os/services/sysv.go
+++ b/resources/packs/os/services/sysv.go
@@ -45,7 +45,7 @@ func (s *SysVServiceManager) List() ([]*Service, error) {
 	}
 
 	// 3. mimic `service --status-all` by running `service x status` for each detected service
-	running, err := s.running(services)
+	running, err := s.running(statusServices)
 	if err != nil {
 		return nil, err
 	}
@@ -53,12 +53,8 @@ func (s *SysVServiceManager) List() ([]*Service, error) {
 	// aggregate data into service struct
 	res := []*Service{}
 
-	for i := range services {
+	for i := range statusServices {
 		service := services[i]
-
-		if stringx.Contains(ignored, service) {
-			continue
-		}
 
 		srv := &Service{
 			Name:      service,


### PR DESCRIPTION
This fixes the following reported issues:

- cnspec scan unresponsive - "zypper --xmlout list-updates" missing -n flag
- handles suse system services specially

Followup on https://github.com/mondoohq/cnquery/pull/1424 