### PR TITLE
🐛 Check args before calling a plugin

### DIFF
--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -147,6 +147,21 @@ func attachConnectorCmd(provider *plugin.Provider, connector *plugin.Connector, 
 		PreRun: cmd.Command.PreRun,
 	}
 
+	if connector.MinArgs == connector.MaxArgs {
+		if connector.MinArgs == 0 {
+			res.Args = cobra.NoArgs
+		} else {
+			res.Args = cobra.ExactArgs(int(connector.MinArgs))
+		}
+	} else {
+		if connector.MaxArgs > 0 && connector.MinArgs == 0 {
+			res.Args = cobra.MaximumNArgs(int(connector.MaxArgs))
+		} else if connector.MaxArgs == 0 && connector.MinArgs > 0 {
+			res.Args = cobra.MinimumNArgs(int(connector.MinArgs))
+		} else {
+			res.Args = cobra.RangeArgs(int(connector.MinArgs), int(connector.MaxArgs))
+		}
+	}
 	cmd.Command.Flags().VisitAll(func(flag *pflag.Flag) {
 		res.Flags().AddFlag(flag)
 	})


### PR DESCRIPTION
Thsi prevents panics wherre a arg is missing:
```
cnquery run vagrant -c "asset" 
! using builtin provider for os
→ loaded configuration from /etc/opt/mondoo/mondoo.yml using source default
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x112b609]

goroutine 1 [running]:
go.mondoo.com/cnquery/providers/os/connection.(*VagrantConnection).Asset(0x40c72d?)
	<autogenerated>:1 +0x9
go.mondoo.com/cnquery/providers/os/provider.(*Service).connect(0xc000308910, 0xc0006e3aa0, {0x1e546c0?, 0xc00009f600})
	/home/christian/workspace/mondoo/github.com/cnquery/providers/os/provider/provider.go:187 +0x2b0
go.mondoo.com/cnquery/providers/os/provider.(*Service).Connect(0x1e3faa0?, 0xc0006e3aa0, {0x1e546c0?, 0xc00009f600?})
	/home/christian/workspace/mondoo/github.com/cnquery/providers/os/provider/provider.go:129 +0x45
...
```

With this PR, it looks like this:
```
cnquery run vagrant -c "asset" 
Error: accepts 1 arg(s), received 0
Usage:
  cnquery run vagrant host [flags]

Flags:
      --ast                    Parse the query and return the abstract syntax tree (AST).
  -c, --command string         MQL query to executed in the shell.
      --discover strings       Enable the discovery of nested assets. Supports: all,auto
  -h, --help                   help for vagrant
  -j, --json                   Run the query and return the object in a JSON structure.
      --parse                  Parse the query and return the logical structure.
      --platform-id string     Select a specific target asset by providing its platform ID.
      --record string          Record all resouce calls and use resouces in the recording
      --use-recording string   Use a recording to inject resouces data (read-only)

Global Flags:
      --api-proxy string   Set proxy for communications with Mondoo API
      --config string      Set config file path (default $HOME/.config/mondoo/mondoo.yml)
      --log-level string   Set log level: error, warn, info, debug, trace (default "info")
  -v, --verbose            Enable verbose output

accepts 1 arg(s), received 0
```