### PR TITLE
🐛 Fix networkAcl portRange and egress

### DIFF
--- a/resources/packs/aws/aws_ec2.go
+++ b/resources/packs/aws/aws_ec2.go
@@ -167,27 +167,35 @@ func (s *mqlAwsEc2Networkacl) GetEntries() ([]interface{}, error) {
 
 	res := []interface{}{}
 	for _, entry := range networkacls.NetworkAcls[0].Entries {
+		egress := core.ToBool(entry.Egress)
+		entryId := id + "-" + strconv.Itoa(core.ToIntFrom32(entry.RuleNumber))
+		if egress {
+			entryId += "-egress"
+		} else {
+			entryId += "-ingress"
+		}
 		args := []interface{}{
-			"egress", core.ToBool(entry.Egress),
+			"egress", egress,
 			"ruleAction", string(entry.RuleAction),
-			"id", id + "-" + strconv.Itoa(core.ToIntFrom32(entry.RuleNumber)),
+			"id", entryId,
 		}
 		if entry.PortRange != nil {
-			mqlPortEntry, err := s.MotorRuntime.CreateResource("aws.ec2.networkacl.entry.portrange",
-				"from", entry.PortRange.From,
-				"to", entry.PortRange.To,
-				"id", id+"-"+strconv.Itoa(core.ToIntFrom32(entry.RuleNumber))+"-"+strconv.Itoa(core.ToIntFrom32(entry.PortRange.From)),
+			mqlPortRange, err := s.MotorRuntime.CreateResource("aws.ec2.networkacl.entry.portrange",
+				"from", core.ToInt64From32(entry.PortRange.From),
+				"to", core.ToInt64From32(entry.PortRange.To),
+				"id", entryId+"-"+strconv.Itoa(core.ToIntFrom32(entry.PortRange.From)),
 			)
 			if err != nil {
 				return nil, err
 			}
-			args = append(args, mqlPortEntry)
+			args = append(args, "portRange", mqlPortRange)
 		}
 
 		mqlAclEntry, err := s.MotorRuntime.CreateResource("aws.ec2.networkacl.entry", args...)
 		if err != nil {
 			return nil, err
 		}
+
 		res = append(res, mqlAclEntry)
 	}
 


### PR DESCRIPTION
For `egress` ids weren't unique across egress and ingress rules. That resulted in strange outputs not matching AWS.

For `portRange` we had a type mismatch and the resource wasn't created as expected

Fixes #1463