### PR TITLE
🐛 SUSE11 ignore all *boot* services

### DIFF
--- a/resources/packs/os/services/sysv.go
+++ b/resources/packs/os/services/sysv.go
@@ -34,7 +34,7 @@ func (s *SysVServiceManager) List() ([]*Service, error) {
 	}
 
 	// eg. we ignore the following run levels since `service halt status` may shutdown the system
-	ignored := []string{"functions", "killall", "halt", "reboot", "shutdown"}
+	ignored := []string{"functions", "killall", "halt", "boot", "shutdown"}
 	statusServices := []string{}
 	for i := range services {
 		service := services[i]

--- a/resources/packs/os/services/sysv.go
+++ b/resources/packs/os/services/sysv.go
@@ -34,7 +34,7 @@ func (s *SysVServiceManager) List() ([]*Service, error) {
 	}
 
 	// eg. we ignore the following run levels since `service halt status` may shutdown the system
-	ignored := []string{"functions", "killall", "halt", "boot", "shutdown"}
+	ignored := []string{"boot", "boot.local", "functions", "halt", "halt.local", "killall", "rc", "reboot", "shutdown", "single", "skeleton", ".depend.boot", ".depend.start", ".depend.stop" }
 	statusServices := []string{}
 	for i := range services {
 		service := services[i]


### PR DESCRIPTION
... as it hangs on at "boot" during any service check. Applies to #1469 