### PR TITLE
✨ disable provider auto-update

### DIFF
--- a/apps/cnquery/cmd/root.go
+++ b/apps/cnquery/cmd/root.go
@@ -85,9 +85,11 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
 	rootCmd.PersistentFlags().String("log-level", "info", "Set log level: error, warn, info, debug, trace")
 	rootCmd.PersistentFlags().String("api-proxy", "", "Set proxy for communications with Mondoo API")
+	rootCmd.PersistentFlags().Bool("auto-update", true, "Enable automatic provider installation and update")
 	viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
 	viper.BindPFlag("log-level", rootCmd.PersistentFlags().Lookup("log-level"))
 	viper.BindPFlag("api_proxy", rootCmd.PersistentFlags().Lookup("api-proxy"))
+	viper.BindPFlag("auto_update", rootCmd.PersistentFlags().Lookup("auto-update"))
 	viper.BindEnv("features")
 
 	config.Init(rootCmd)

--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.mondoo.com/cnquery/cli/components"
+	"go.mondoo.com/cnquery/cli/config"
 	"go.mondoo.com/cnquery/llx"
 	"go.mondoo.com/cnquery/providers"
 	"go.mondoo.com/cnquery/providers-sdk/v1/plugin"
@@ -30,12 +31,12 @@ func AttachCLIs(rootCmd *cobra.Command, commands ...*Command) error {
 		return err
 	}
 
-	connectorName := detectConnector(os.Args, rootCmd, commands)
+	connectorName, autoUpdate := detectConnector(os.Args, rootCmd, commands)
 	if connectorName == "" {
 		return nil
 	}
 
-	if _, err := providers.EnsureProvider(existing, connectorName); err != nil {
+	if _, err := providers.EnsureProvider(existing, connectorName, autoUpdate); err != nil {
 		return err
 	}
 
@@ -54,48 +55,43 @@ func flagHasArgs(flag *pflag.Flag) bool {
 	return flag.NoOptDefVal == ""
 }
 
-func detectConnector(args []string, rootCmd *cobra.Command, commands []*Command) string {
-	// We cannot fully parse the cli, yet. So we have to deal with what we have.
-	// We can safely ignore all options up to a point. We are looking for one of
-	// the supported commands, which can be followed by a provider.
+func detectConnector(args []string, rootCmd *cobra.Command, commands []*Command) (string, bool) {
+	autoUpdate := true
+	action := ""
 
-	// because the default first arg is the calling program, we are ignoring it
-	// and instead starting at arg position 2 (idx=1)
-	cmd, arg2, err := rootCmd.Find(args[1:])
-	if cmd == nil || err != nil {
-		return ""
+	preRunRoot := &cobra.Command{
+		Use: "root",
+		Run: func(cmd *cobra.Command, args []string) {
+			autoUpdate, _ = cmd.Flags().GetBool("auto-update")
+			for _, arg := range args {
+				for j := range commands {
+					if arg == commands[j].Command.Use {
+						action = arg
+						break
+					}
+				}
+				if action != "" {
+					break
+				}
+			}
+		},
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			UnknownFlags: true,
+		},
 	}
 
-	found := false
-	for j := range commands {
-		if cmd == commands[j].Command {
-			found = true
-			continue
-		}
-	}
-	if !found {
-		return ""
+	preRunRoot.PersistentFlags().Bool("auto-update", true, "Enable automatic provider installation and update")
+	viper.BindPFlag("auto_update", rootCmd.PersistentFlags().Lookup("auto-update"))
+	config.Init(preRunRoot)
+
+	err := preRunRoot.Execute()
+	if err != nil {
+		log.Debug().Err(err).Msg("early detection error")
+		log.Error().Msg("failed to run early comman detection")
+		return "", false
 	}
 
-	argIsValue := false
-	for _, arg := range arg2 {
-		switch {
-		case strings.Contains(arg, "="):
-			continue // assigned flags don't get additional arg
-		case strings.HasPrefix(arg, "--"):
-			argIsValue = flagHasArgs(cmd.Flags().Lookup(arg[2:]))
-		case strings.HasPrefix(arg, "-"):
-			argIsValue = flagHasArgs(cmd.Flags().ShorthandLookup(arg[1:]))
-		case argIsValue:
-			argIsValue = false
-		default:
-			return arg
-		}
-	}
-
-	// If we arrive here, we can safely assume that the command was called
-	// with no provider at all. This means that we default to local.
-	return "local"
+	return action, autoUpdate
 }
 
 func attacheProviders(existing providers.Providers, commands []*Command) {

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -143,7 +143,7 @@ func ListAll() ([]*Provider, error) {
 
 // EnsureProvider find the provider for a given connector either from the list
 // of existing proviers or by downloading and installing it.
-func EnsureProvider(existing Providers, connectorName string) (*Provider, error) {
+func EnsureProvider(existing Providers, connectorName string, autoUpdate bool) (*Provider, error) {
 	provider := existing.ForConnection(connectorName)
 	if provider != nil {
 		return provider, nil
@@ -153,6 +153,10 @@ func EnsureProvider(existing Providers, connectorName string) (*Provider, error)
 	if upstream == nil {
 		// we can't find any provider for this connector in our default set
 		return nil, nil
+	}
+
+	if !autoUpdate {
+		return nil, errors.New("cannot find installed provider for connection " + connectorName)
 	}
 
 	nu, err := Install(upstream.Name)

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -141,7 +141,7 @@ func (r *Runtime) DetectProvider(asset *inventory.Asset) error {
 			continue
 		}
 
-		provider, err := EnsureProvider(r.coordinator.Providers, conn.Type)
+		provider, err := EnsureProvider(r.coordinator.Providers, conn.Type, true)
 		if err != nil {
 			errs.Add(err)
 			continue


### PR DESCRIPTION
- Add an optional flag `--auto-update=false` to disable provider install or updates
- Move the pre-loader to a new model where a dummy command is being used instead of manual parsing. This is done so that we can inject all the crazy config handling we have to do, because the option could be set in the config.

Follow-ups:
1. There is still a bug in loading this from config...
2. It currently hard-codes the provider updates on indirect calls from the runtime. This needs to respect config/CLI options. (even global is fine...)