### PR TITLE
🐛 Assign default MRN to incognito assets.

### DIFF
--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -207,7 +207,7 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 		// ensure we have non-empty asset MRNs
 		for i := range assets {
 			cur := assets[i]
-			if cur.Mrn == "" && cur.Id == "" {
+			if cur.Mrn == "" {
 				randID := "//" + explorer.SERVICE_NAME + "/" + explorer.MRN_RESOURCE_ASSET + "/" + ksuid.New().String()
 				x, err := mrn.NewMRN(randID)
 				if err != nil {


### PR DESCRIPTION
We now assign the asset id during the connection to the provider so we don't have to check that anymore