### PR TITLE
🧹 add make command to check for license headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ prep/tools:
 	# additional helper
 	go install gotest.tools/gotestsum@latest
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-
+	go install github.com/hashicorp/copywrite@latest
 
 #   🌙 MQL/MOTOR   #
 
@@ -345,3 +345,11 @@ test/lint/govet:
 test/lint/golangci-lint/run: prep/tools
 	golangci-lint --version
 	golangci-lint run
+
+license: license/headers/check
+
+license/headers/check:
+	copywrite headers --plan
+
+license/headers/apply:
+	copywrite headers


### PR DESCRIPTION
To validate the license headers:

```bash
make license
copywrite headers --plan
Executing in dry-run mode. Rerun without the `--plan` flag to apply changes.

Using license identifier: BUSL-1.1
Using copyright holder: Mondoo, Inc.

Exempting the following search patterns:
**/*.tf
**/testdata/**
**/*.pb.go
**/*_string.go

The following files are missing headers:
```

To add license headers automatically:

```bash
make license/headers/apply
```