### PR TITLE
🐛 avoid building dynamic `id` fields in resources

### DIFF
--- a/providers-sdk/v1/lr/go.go
+++ b/providers-sdk/v1/lr/go.go
@@ -442,6 +442,11 @@ func (b *goBuilder) goField(r *Resource, field *Field) {
 		return
 	}
 
+	if field.BasicField.ID == "id" {
+		b.errors.Add(errors.New("cannot create a dynamically computed `id` field, please turn it into a static field (ie: `id(..)` => `id`)"))
+		return
+	}
+
 	goName := field.BasicField.goName()
 	goType := field.BasicField.Type.goType(b)
 	goZero := field.BasicField.Type.goZeroValue()

--- a/providers/vcd/resources/externalnetworks.go
+++ b/providers/vcd/resources/externalnetworks.go
@@ -43,6 +43,13 @@ type mqlVcdExternalNetworkInternal struct {
 	externalNetwork *govcd.ExternalNetwork
 }
 
+func (v *mqlVcdExternalNetwork) id() (string, error) {
+	if v.Name.Error != nil {
+		return "", v.Name.Error
+	}
+	return "vcd.externalNetwork/" + v.Name.Data, nil
+}
+
 func (v *mqlVcdExternalNetwork) getData() (*types.ExternalNetwork, error) {
 	// check if the data is cached
 	// TODO: probably we need locking here to make sure concurrent access is covered
@@ -67,7 +74,7 @@ func (v *mqlVcdExternalNetwork) getData() (*types.ExternalNetwork, error) {
 	return externalNetwork.ExternalNetwork, nil
 }
 
-func (v *mqlVcdExternalNetwork) id() (string, error) {
+func (v *mqlVcdExternalNetwork) urn() (string, error) {
 	externalNetwork, err := v.getData()
 	if err != nil {
 		return "", err

--- a/providers/vcd/resources/vcd.lr
+++ b/providers/vcd/resources/vcd.lr
@@ -120,10 +120,10 @@ vcd.networkPool {
 
 // VMware Cloud Director External Network
 private vcd.externalNetwork @defaults("name") {
-  // URN of the network
-  id() string
   // Unique name for the network
   name string
+	// URN of the network
+	urn() string
   // Network description
   description() string
   // External network configuration

--- a/providers/vcd/resources/vcd.lr.go
+++ b/providers/vcd/resources/vcd.lr.go
@@ -274,11 +274,11 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"vcd.networkPool.networkPoolType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVcdNetworkPool).GetNetworkPoolType()).ToDataRes(types.Int)
 	},
-	"vcd.externalNetwork.id": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlVcdExternalNetwork).GetId()).ToDataRes(types.String)
-	},
 	"vcd.externalNetwork.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVcdExternalNetwork).GetName()).ToDataRes(types.String)
+	},
+	"vcd.externalNetwork.urn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVcdExternalNetwork).GetUrn()).ToDataRes(types.String)
 	},
 	"vcd.externalNetwork.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVcdExternalNetwork).GetDescription()).ToDataRes(types.String)
@@ -705,12 +705,12 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 			r.(*mqlVcdExternalNetwork).__id, ok = v.Value.(string)
 			return
 		},
-	"vcd.externalNetwork.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlVcdExternalNetwork).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"vcd.externalNetwork.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlVcdExternalNetwork).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"vcd.externalNetwork.urn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVcdExternalNetwork).Urn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"vcd.externalNetwork.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1625,8 +1625,8 @@ type mqlVcdExternalNetwork struct {
 	MqlRuntime *plugin.Runtime
 	__id string
 	mqlVcdExternalNetworkInternal
-	Id plugin.TValue[string]
 	Name plugin.TValue[string]
+	Urn plugin.TValue[string]
 	Description plugin.TValue[string]
 	Configuration plugin.TValue[interface{}]
 }
@@ -1668,14 +1668,14 @@ func (c *mqlVcdExternalNetwork) MqlID() string {
 	return c.__id
 }
 
-func (c *mqlVcdExternalNetwork) GetId() *plugin.TValue[string] {
-	return plugin.GetOrCompute[string](&c.Id, func() (string, error) {
-		return c.id()
-	})
-}
-
 func (c *mqlVcdExternalNetwork) GetName() *plugin.TValue[string] {
 	return &c.Name
+}
+
+func (c *mqlVcdExternalNetwork) GetUrn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Urn, func() (string, error) {
+		return c.urn()
+	})
 }
 
 func (c *mqlVcdExternalNetwork) GetDescription() *plugin.TValue[string] {


### PR DESCRIPTION
After https://github.com/mondoohq/cnquery/pull/1572

tldr: use static `id` fields in resources, dynamic fields would need the same `id()` method we use for internal IDs

Long explanation: It is possible for a resource to define itself an `id` field. We have done this before (eg in yum repos) where the field returns a custom ID that users can access.

All MQL resources have their own internal ID. The confusion happens, when we have a semantic `id` field we expose to users and an internal `id` field that we do not expose. At the time of writing, we have no scenario where we would ever need an ID field that is different from the internal ID of the resource. Ideally we can have both use the same ID, i.e. if users ever expose an `id` field it should semantically provide everything we would expect from the ID of a resource.

For the time being, we only need to solve one problem: Dynamic `id()` fields would force users to implement an `func id()` call, that conflicts with the call to create internal IDs. This PR will not deduplicate this concept (we can do this in a follow-up), but it at least needs to prevent the scenario from happening and give users some guidance.

For all users that expose an `id` field, we solution is to create it as a static field, so that at the time of resource creation it is set. This will also allow us to deduplicate this field if we choose to down the line. Semantically too, this makes sense, since the ID of the object should be known at creation time, whether internal or user-facing.
