### PR TITLE
🐛 ensure the subnetwork asset name, not mql object name, is the one with the region suffix

### DIFF
--- a/motor/discovery/gcp/mql_asset_objects.go
+++ b/motor/discovery/gcp/mql_asset_objects.go
@@ -195,7 +195,7 @@ func computeSubnetworks(m *MqlDiscovery, project string, tc *providers.Config) (
 				gcpObject: gcpObject{
 					project:    project,
 					region:     region,
-					name:       subnetName,
+					name:       s.Name,
 					id:         s.Id,
 					service:    "compute",
 					objectType: "subnetwork",


### PR DESCRIPTION
fixes https://github.com/mondoohq/cnquery/issues/1578