### PR TITLE
Debugging improvements for goreleaser failures

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Install Quill for Mac Signing and Notarization
         run: |
-            curl -sSfL https://raw.githubusercontent.com/anchore/quill/main/install.sh | sh -s -- -b /tmp v0.4.0
+            curl -sSfL https://raw.githubusercontent.com/anchore/quill/main/install.sh | sh -s -- -b /tmp
             /tmp/quill help
 
       - name: Log in to the Container registry

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Install Quill for Mac Signing and Notarization
         run: |
-            curl -sSfL https://raw.githubusercontent.com/anchore/quill/main/install.sh | sh -s -- -b /tmp v0.2.0
+            curl -sSfL https://raw.githubusercontent.com/anchore/quill/main/install.sh | sh -s -- -b /tmp v0.4.0
             /tmp/quill help
 
       - name: Log in to the Container registry
@@ -111,6 +111,14 @@ jobs:
       - name: Check RPMs
         run: |
           rpm -qpi dist/*.rpm
+      - name: Output Quill Logs
+        if: ${{ failure() }}
+        run: |
+          for f in $(find /tmp -name 'quill-*.log' 2>/dev/null); do
+            echo "=== $f ==="
+            ls -l $f
+            cat $f
+          done
 
       - name: Publish Release to releases.mondoo.com
         uses: peter-evans/repository-dispatch@v2

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -7,9 +7,11 @@ on:
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: 'Skip publishing to releases.mondoo.com'
+        description: 'Skip publishing to releases.mondoo.com?'
+        type: boolean
         required: false
         default: false
+
 
 env:
   REGISTRY: docker.io

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - '*'
   workflow_dispatch:
+    inputs:
+      skip-publish:
+        description: 'Skip publishing to releases.mondoo.com'
+        required: false
+        default: false
 
 env:
   REGISTRY: docker.io
@@ -121,6 +126,7 @@ jobs:
           done
 
       - name: Publish Release to releases.mondoo.com
+        if: ${{ ! inputs.skip-publish }}
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.RELEASR_ACTION_TOKEN }}
@@ -132,5 +138,6 @@ jobs:
           }'
 
       - name: Cleanup
+        if: always()
         run:
           rm -f ${CERT_PATH}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,7 +66,7 @@ builds:
           output: true
           env:
           - TARGET={{ .Target }}
-        - cmd: jsign --storetype DIGICERTONE --alias "${SM_CERT_ALIAS}" --storepass "${SM_API_KEY}|${SM_CLIENT_CERT_FILE}|${SM_CLIENT_CERT_PASSWORD}" --tsaurl "http://timestamp.digicert.com" '{{ .Path }}'
+        - cmd: jsign --storetype DIGICERTONE --alias "{{ .Env.SM_CERT_ALIAS }}" --storepass "{{ .Env.SM_API_KEY }}|{{ .Env.SM_CLIENT_CERT_FILE}}|{{ .Env.SM_CLIENT_CERT_PASSWORD }}" --tsaurl "http://timestamp.digicert.com" '{{ .Path }}'
 nfpms:
   -
     maintainer: Mondoo <hello@mondoo.com>

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,7 +66,7 @@ builds:
           output: true
           env:
           - TARGET={{ .Target }}
-        - jsign --storetype DIGICERTONE --alias "${SM_CERT_ALIAS}" --storepass "${SM_API_KEY}|${SM_CLIENT_CERT_FILE}|${SM_CLIENT_CERT_PASSWORD}" --tsaurl "http://timestamp.digicert.com" '{{ .Path }}'
+        - cmd: jsign --storetype DIGICERTONE --alias "${SM_CERT_ALIAS}" --storepass "${SM_API_KEY}|${SM_CLIENT_CERT_FILE}|${SM_CLIENT_CERT_PASSWORD}" --tsaurl "http://timestamp.digicert.com" '{{ .Path }}'
 nfpms:
   -
     maintainer: Mondoo <hello@mondoo.com>

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,7 +66,7 @@ builds:
           output: true
           env:
           - TARGET={{ .Target }}
-        - cmd: jsign --storetype DIGICERTONE --alias "${SM_CERT_ALIAS}" --storepass "${SM_API_KEY}|${SM_CLIENT_CERT_FILE}|${SM_CLIENT_CERT_PASSWORD}" --tsaurl "http://timestamp.digicert.com" '{{ .Path }}'
+        - jsign --storetype DIGICERTONE --alias "${SM_CERT_ALIAS}" --storepass "${SM_API_KEY}|${SM_CLIENT_CERT_FILE}|${SM_CLIENT_CERT_PASSWORD}" --tsaurl "http://timestamp.digicert.com" '{{ .Path }}'
 nfpms:
   -
     maintainer: Mondoo <hello@mondoo.com>

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,7 +44,7 @@ builds:
       - -s -w -X go.mondoo.com/cnquery.Version={{.Version}} -X go.mondoo.com/cnquery.Build={{.ShortCommit}} -X go.mondoo.com/cnquery.Date={{.Date}}
     hooks:
       post:
-        - cmd: /tmp/quill sign-and-notarize "{{ .Path }}" -vv
+        - cmd: /tmp/quill sign-and-notarize "{{ .Path }}" -vv || true
           env:
             - QUILL_LOG_FILE=/tmp/quill-{{ .Target }}.log
   - id: windows


### PR DESCRIPTION
This morning a change to Apple's Notorization service suddenly caused https://github.com/anchore/quill/issues/118 in the excellent Quill tool.  This change update quill to the new fixed version, also allow releaser to continue in the event of a notorization failure (to avoid holding up all platforms) and dumps the logs for quill to allow for easier debugging.  