### PR TITLE
🐛 gcp compute instances should be labelled as platform instance not image

### DIFF
--- a/motor/discovery/gcp/mql_asset_objects.go
+++ b/motor/discovery/gcp/mql_asset_objects.go
@@ -106,7 +106,7 @@ func computeInstances(m *MqlDiscovery, project string, tc *providers.Config, sfn
 					name:       i.Name,
 					id:         i.Id,
 					service:    "compute",
-					objectType: "image",
+					objectType: "instance",
 				},
 			}, tc)
 		a.State = mapInstanceStatus(i.Status)


### PR DESCRIPTION
also, i didn't touch the logic for this part right now, but why are we entirely skipping windows instances, like not discovering them at all? @preslavgerchev @imilchev does one of you know?
```
		if disksContainWindows(i.Disks) {
			log.Debug().Msgf("skipping windows instance %s", i.Name)
			continue
		}
```