### PR TITLE
expose a variety of shared CLI commands

### DIFF
--- a/apps/cnquery/cmd/login.go
+++ b/apps/cnquery/cmd/login.go
@@ -20,13 +20,13 @@ import (
 )
 
 func init() {
-	rootCmd.AddCommand(loginCmd)
-	loginCmd.Flags().StringP("token", "t", "", "Set a client registration token.")
-	loginCmd.Flags().String("name", "", "Set asset name.")
-	loginCmd.Flags().String("api-endpoint", "", "Set the Mondoo API endpoint.")
+	rootCmd.AddCommand(LoginCmd)
+	LoginCmd.Flags().StringP("token", "t", "", "Set a client registration token.")
+	LoginCmd.Flags().String("name", "", "Set asset name.")
+	LoginCmd.Flags().String("api-endpoint", "", "Set the Mondoo API endpoint.")
 }
 
-var loginCmd = &cobra.Command{
+var LoginCmd = &cobra.Command{
 	Use:     "login",
 	Aliases: []string{"register"},
 	Short:   "Register with Mondoo Platform.",

--- a/apps/cnquery/cmd/logout.go
+++ b/apps/cnquery/cmd/logout.go
@@ -17,11 +17,11 @@ import (
 )
 
 func init() {
-	rootCmd.AddCommand(logoutCmd)
-	logoutCmd.Flags().Bool("force", false, "Force re-authentication")
+	rootCmd.AddCommand(LogoutCmd)
+	LogoutCmd.Flags().Bool("force", false, "Force re-authentication")
 }
 
-var logoutCmd = &cobra.Command{
+var LogoutCmd = &cobra.Command{
 	Use:     "logout",
 	Aliases: []string{"unregister"},
 	Short:   "Log out from Mondoo Platform.",

--- a/apps/cnquery/cmd/root.go
+++ b/apps/cnquery/cmd/root.go
@@ -55,8 +55,8 @@ func Execute() {
 			Action:  "Interactive shell with ",
 		},
 		&providers.Command{
-			Command: runCmd,
-			Run:     runcmdRun,
+			Command: RunCmd,
+			Run:     RunCmdRun,
 			Action:  "Run a query with ",
 		},
 		&providers.Command{

--- a/apps/cnquery/cmd/run.go
+++ b/apps/cnquery/cmd/run.go
@@ -17,16 +17,16 @@ import (
 )
 
 func init() {
-	rootCmd.AddCommand(runCmd)
+	rootCmd.AddCommand(RunCmd)
 
-	runCmd.Flags().StringP("command", "c", "", "MQL query to executed in the shell.")
-	runCmd.Flags().Bool("parse", false, "Parse the query and return the logical structure.")
-	runCmd.Flags().Bool("ast", false, "Parse the query and return the abstract syntax tree (AST).")
-	runCmd.Flags().BoolP("json", "j", false, "Run the query and return the object in a JSON structure.")
-	runCmd.Flags().String("platform-id", "", "Select a specific target asset by providing its platform ID.")
+	RunCmd.Flags().StringP("command", "c", "", "MQL query to executed in the shell.")
+	RunCmd.Flags().Bool("parse", false, "Parse the query and return the logical structure.")
+	RunCmd.Flags().Bool("ast", false, "Parse the query and return the abstract syntax tree (AST).")
+	RunCmd.Flags().BoolP("json", "j", false, "Run the query and return the object in a JSON structure.")
+	RunCmd.Flags().String("platform-id", "", "Select a specific target asset by providing its platform ID.")
 }
 
-var runCmd = &cobra.Command{
+var RunCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run an MQL query.",
 	Long:  `Run an MQL query on the CLI and displays its results.`,
@@ -35,7 +35,7 @@ var runCmd = &cobra.Command{
 	},
 }
 
-var runcmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *plugin.ParseCLIRes) {
+var RunCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *plugin.ParseCLIRes) {
 	conf := proto.RunQueryConfig{}
 
 	conf.Command, _ = cmd.Flags().GetString("command")

--- a/apps/cnquery/cmd/shell.go
+++ b/apps/cnquery/cmd/shell.go
@@ -40,6 +40,25 @@ var shellCmd = &cobra.Command{
 }
 
 var shellRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *plugin.ParseCLIRes) {
+	shellConf := ParseShellConfig(cmd, cliRes)
+	if err := StartShell(runtime, shellConf); err != nil {
+		log.Fatal().Err(err).Msg("failed to run query")
+	}
+}
+
+// ShellConfig is the shared configuration for running a shell given all
+// commandline and config inputs.
+// TODO: the config is a shared structure, which should be moved to proto
+type ShellConfig struct {
+	Command        string
+	Asset          *inventory.Asset
+	Features       cnquery.Features
+	PlatformID     string
+	WelcomeMessage string
+	UpstreamConfig *upstream.UpstreamConfig
+}
+
+func ParseShellConfig(cmd *cobra.Command, cliRes *plugin.ParseCLIRes) *ShellConfig {
 	conf, err := config.Read()
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to load config")
@@ -67,22 +86,7 @@ var shellRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *plug
 	}
 
 	shellConf.Command, _ = cmd.Flags().GetString("command")
-	err = StartShell(runtime, &shellConf)
-	if err != nil {
-		log.Fatal().Err(err).Msg("failed to run query")
-	}
-}
-
-// ShellConfig is the shared configuration for running a shell given all
-// commandline and config inputs.
-// TODO: the config is a shared structure, which should be moved to proto
-type ShellConfig struct {
-	Command        string
-	Asset          *inventory.Asset
-	Features       cnquery.Features
-	PlatformID     string
-	WelcomeMessage string
-	UpstreamConfig *upstream.UpstreamConfig
+	return &shellConf
 }
 
 // StartShell will start an interactive CLI shell

--- a/apps/cnquery/cmd/status.go
+++ b/apps/cnquery/cmd/status.go
@@ -25,12 +25,12 @@ import (
 )
 
 func init() {
-	statusCmd.Flags().StringP("output", "o", "", "Set output format. Accepts json or yaml.")
-	rootCmd.AddCommand(statusCmd)
+	StatusCmd.Flags().StringP("output", "o", "", "Set output format. Accepts json or yaml.")
+	rootCmd.AddCommand(StatusCmd)
 }
 
-// statusCmd represents the version command
-var statusCmd = &cobra.Command{
+// StatusCmd represents the version command
+var StatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Verify access to Mondoo Platform.",
 	Long: `

--- a/apps/cnquery/cmd/vault.go
+++ b/apps/cnquery/cmd/vault.go
@@ -17,18 +17,18 @@ import (
 
 func init() {
 	vaultListCmd.Flags().Bool("show-options", false, "displays configured options")
-	vaultCmd.AddCommand(vaultListCmd)
+	VaultCmd.AddCommand(vaultListCmd)
 
 	vaultConfigureCmd.Flags().String("type", "", "possible values: "+strings.Join(vault.TypeIds(), " | "))
 	vaultConfigureCmd.Flags().StringToString("option", nil, "addition vault connection options, multiple options via --option key=value")
-	vaultCmd.AddCommand(vaultConfigureCmd)
+	VaultCmd.AddCommand(vaultConfigureCmd)
 
-	vaultCmd.AddCommand(vaultRemoveCmd)
-	vaultCmd.AddCommand(vaultResetCmd)
+	VaultCmd.AddCommand(vaultRemoveCmd)
+	VaultCmd.AddCommand(vaultResetCmd)
 
-	vaultCmd.AddCommand(vaultAddSecretCmd)
+	VaultCmd.AddCommand(vaultAddSecretCmd)
 
-	rootCmd.AddCommand(vaultCmd)
+	rootCmd.AddCommand(VaultCmd)
 }
 
 func emptyVaultConfigSecret() *vault.Secret {
@@ -39,8 +39,8 @@ func emptyVaultConfigSecret() *vault.Secret {
 	}
 }
 
-// vaultCmd represents the vault command
-var vaultCmd = &cobra.Command{
+// VaultCmd represents the vault command
+var VaultCmd = &cobra.Command{
 	Use:   "vault",
 	Short: "Manage vault environments.",
 	Long:  ``,


### PR DESCRIPTION
We are exposing:
- vault
- status
- run
- login
- logout

Additionally, the shell command can largely be re-used with a few config changes in cnspec. We still expose it, but we expect the runner to be overwritten to make adjustments to the config. 

This will help finalize cnspec for v9.