### PR TITLE
🐛 create LR before CLI config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,11 +66,11 @@ define buildProvider
 	$(eval $@_DIST = "${$@_HOME}"/dist)
 	$(eval $@_DIST_BIN = "./dist/${$@_NAME}")
 	$(eval $@_BIN = "${$@_DIST}"/"${$@_NAME}")
-	echo "--> [${$@_NAME}] generate CLI json"
-	cd ${$@_HOME} && go run ./gen/main.go .
 	echo "--> [${$@_NAME}] process resources"
 	./lr go ${$@_HOME}/resources/${$@_NAME}.lr --dist ${$@_DIST}
 	./lr docs json ${$@_HOME}/resources/${$@_NAME}.lr.manifest.yaml
+	echo "--> [${$@_NAME}] generate CLI json"
+	cd ${$@_HOME} && go run ./gen/main.go .
 	echo "--> [${$@_NAME}] creating ${$@_BIN}"
 	cd ${$@_HOME} && go build -o ${$@_DIST_BIN} ./main.go
 endef


### PR DESCRIPTION
In the case of K8s, the config pulls in discovery options from the remaining provider, which ultimately pull a dependency to the k8s resources. These, however, do not exist on a clean build, because LR has not yet been executed. Swap the order so that LR runs first, creating the lr-generated files (like k8s.lr.go) which then make the dependency chain work for creating the config.