### PR TITLE
🧹 align discovery options between k8s + azure + gcp

### DIFF
--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -3,24 +3,9 @@
 
 package config
 
-import "go.mondoo.com/cnquery/providers-sdk/v1/plugin"
-
-// Discovery flags
-const (
-	DiscoveryAuto          = "auto"
-	DiscoveryAll           = "all"
-	DiscoverySubscriptions = "subscriptions"
-	DiscoveryInstances     = "instances"
-	// TODO: this probably needs some more work on the linking to its OS counterpart side
-	DiscoveryInstancesApi      = "instances-api"
-	DiscoverySqlServers        = "sql-servers"
-	DiscoveryPostgresServers   = "postgres-servers"
-	DiscoveryMySqlServers      = "mysql-servers"
-	DiscoveryMariaDbServers    = "mariadb-servers"
-	DiscoveryStorageAccounts   = "storage-accounts"
-	DiscoveryStorageContainers = "storage-containers"
-	DiscoveryKeyVaults         = "keyvaults-vaults"
-	DiscoverySecurityGroups    = "security-groups"
+import (
+	"go.mondoo.com/cnquery/providers-sdk/v1/plugin"
+	"go.mondoo.com/cnquery/providers/azure/resources"
 )
 
 var Config = plugin.Provider{
@@ -35,19 +20,19 @@ var Config = plugin.Provider{
 			MinArgs: 0,
 			MaxArgs: 8,
 			Discovery: []string{
-				DiscoveryAuto,
-				DiscoveryAll,
-				DiscoverySubscriptions,
-				DiscoveryInstances,
-				DiscoveryInstancesApi,
-				DiscoverySqlServers,
-				DiscoveryPostgresServers,
-				DiscoveryMySqlServers,
-				DiscoveryMariaDbServers,
-				DiscoveryStorageAccounts,
-				DiscoveryStorageContainers,
-				DiscoveryKeyVaults,
-				DiscoverySecurityGroups,
+				resources.DiscoveryAuto,
+				resources.DiscoveryAll,
+				resources.DiscoverySubscriptions,
+				resources.DiscoveryInstances,
+				resources.DiscoveryInstancesApi,
+				resources.DiscoverySqlServers,
+				resources.DiscoveryPostgresServers,
+				resources.DiscoveryMySqlServers,
+				resources.DiscoveryMariaDbServers,
+				resources.DiscoveryStorageAccounts,
+				resources.DiscoveryStorageContainers,
+				resources.DiscoveryKeyVaults,
+				resources.DiscoverySecurityGroups,
 			},
 			Flags: []plugin.Flag{
 				{

--- a/providers/azure/provider/provider.go
+++ b/providers/azure/provider/provider.go
@@ -13,7 +13,6 @@ import (
 	"go.mondoo.com/cnquery/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/providers-sdk/v1/upstream"
 	"go.mondoo.com/cnquery/providers-sdk/v1/vault"
-	"go.mondoo.com/cnquery/providers/azure/config"
 	"go.mondoo.com/cnquery/providers/azure/connection"
 	"go.mondoo.com/cnquery/providers/azure/resources"
 )
@@ -93,7 +92,7 @@ func parseDiscover(flags map[string]*llx.Primitive) *inventory.Discovery {
 			targets = append(targets, entry)
 		}
 	} else {
-		targets = []string{config.DiscoveryAuto}
+		targets = []string{resources.DiscoveryAuto}
 	}
 	return &inventory.Discovery{Targets: targets}
 }

--- a/providers/azure/resources/discovery.go
+++ b/providers/azure/resources/discovery.go
@@ -11,7 +11,6 @@ import (
 	"go.mondoo.com/cnquery/llx"
 	"go.mondoo.com/cnquery/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/providers-sdk/v1/plugin"
-	"go.mondoo.com/cnquery/providers/azure/config"
 	"go.mondoo.com/cnquery/providers/azure/connection"
 	"go.mondoo.com/cnquery/utils/stringx"
 
@@ -22,6 +21,21 @@ const (
 	SubscriptionLabel = "azure.mondoo.com/subscription"
 	RegionLabel       = "mondoo.com/region"
 	InstanceLabel     = "mondoo.com/instance"
+
+	DiscoveryAuto          = "auto"
+	DiscoveryAll           = "all"
+	DiscoverySubscriptions = "subscriptions"
+	DiscoveryInstances     = "instances"
+	// TODO: this probably needs some more work on the linking to its OS counterpart side
+	DiscoveryInstancesApi      = "instances-api"
+	DiscoverySqlServers        = "sql-servers"
+	DiscoveryPostgresServers   = "postgres-servers"
+	DiscoveryMySqlServers      = "mysql-servers"
+	DiscoveryMariaDbServers    = "mariadb-servers"
+	DiscoveryStorageAccounts   = "storage-accounts"
+	DiscoveryStorageContainers = "storage-containers"
+	DiscoveryKeyVaults         = "keyvaults-vaults"
+	DiscoverySecurityGroups    = "security-groups"
 )
 
 type azureObject struct {
@@ -73,76 +87,76 @@ func Discover(runtime *plugin.Runtime, rootConf *inventory.Config) (*inventory.I
 		subsWithConfigs[i] = subWithConfig{sub: sub, conf: getSubConfig(conn.Conf, sub)}
 	}
 
-	if stringx.ContainsAnyOf(targets, config.DiscoverySubscriptions, config.DiscoveryAll, config.DiscoveryAuto) {
+	if stringx.ContainsAnyOf(targets, DiscoverySubscriptions, DiscoveryAll, DiscoveryAuto) {
 		// we've already discovered those, simply add them as assets
 		for _, s := range subsWithConfigs {
 			assets = append(assets, subToAsset(s.sub, s.conf))
 		}
 	}
-	if stringx.ContainsAnyOf(targets, config.DiscoveryInstances, config.DiscoveryAll) {
+	if stringx.ContainsAnyOf(targets, DiscoveryInstances, DiscoveryAll) {
 		vms, err := discoverInstances(runtime, subsWithConfigs)
 		if err != nil {
 			return nil, err
 		}
 		assets = append(assets, vms...)
 	}
-	if stringx.ContainsAnyOf(targets, config.DiscoveryInstancesApi, config.DiscoveryAll) {
+	if stringx.ContainsAnyOf(targets, DiscoveryInstancesApi, DiscoveryAll) {
 		vms, err := discoverInstancesApi(runtime, subsWithConfigs)
 		if err != nil {
 			return nil, err
 		}
 		assets = append(assets, vms...)
 	}
-	if stringx.ContainsAnyOf(targets, config.DiscoverySqlServers, config.DiscoveryAll) {
+	if stringx.ContainsAnyOf(targets, DiscoverySqlServers, DiscoveryAll) {
 		sqlServers, err := discoverSqlServers(runtime, subsWithConfigs)
 		if err != nil {
 			return nil, err
 		}
 		assets = append(assets, sqlServers...)
 	}
-	if stringx.ContainsAnyOf(targets, config.DiscoveryMySqlServers, config.DiscoveryAll) {
+	if stringx.ContainsAnyOf(targets, DiscoveryMySqlServers, DiscoveryAll) {
 		mySqlServers, err := discoverMySqlServers(runtime, subsWithConfigs)
 		if err != nil {
 			return nil, err
 		}
 		assets = append(assets, mySqlServers...)
 	}
-	if stringx.ContainsAnyOf(targets, config.DiscoveryPostgresServers, config.DiscoveryAll) {
+	if stringx.ContainsAnyOf(targets, DiscoveryPostgresServers, DiscoveryAll) {
 		postgresServers, err := discoverPostgresqlServers(runtime, subsWithConfigs)
 		if err != nil {
 			return nil, err
 		}
 		assets = append(assets, postgresServers...)
 	}
-	if stringx.ContainsAnyOf(targets, config.DiscoveryMariaDbServers, config.DiscoveryAll) {
+	if stringx.ContainsAnyOf(targets, DiscoveryMariaDbServers, DiscoveryAll) {
 		mariaDbServers, err := discoverMariadbServers(runtime, subsWithConfigs)
 		if err != nil {
 			return nil, err
 		}
 		assets = append(assets, mariaDbServers...)
 	}
-	if stringx.ContainsAnyOf(targets, config.DiscoveryStorageAccounts, config.DiscoveryAll) {
+	if stringx.ContainsAnyOf(targets, DiscoveryStorageAccounts, DiscoveryAll) {
 		accs, err := discoverStorageAccounts(runtime, subsWithConfigs)
 		if err != nil {
 			return nil, err
 		}
 		assets = append(assets, accs...)
 	}
-	if stringx.ContainsAnyOf(targets, config.DiscoveryStorageContainers, config.DiscoveryAll) {
+	if stringx.ContainsAnyOf(targets, DiscoveryStorageContainers, DiscoveryAll) {
 		containers, err := discoverStorageAccountsContainers(runtime, subsWithConfigs)
 		if err != nil {
 			return nil, err
 		}
 		assets = append(assets, containers...)
 	}
-	if stringx.ContainsAnyOf(targets, config.DiscoverySecurityGroups, config.DiscoveryAll) {
+	if stringx.ContainsAnyOf(targets, DiscoverySecurityGroups, DiscoveryAll) {
 		secGrps, err := discoverSecurityGroups(runtime, subsWithConfigs)
 		if err != nil {
 			return nil, err
 		}
 		assets = append(assets, secGrps...)
 	}
-	if stringx.ContainsAnyOf(targets, config.DiscoveryKeyVaults, config.DiscoveryAll) {
+	if stringx.ContainsAnyOf(targets, DiscoveryKeyVaults, DiscoveryAll) {
 		kvs, err := discoverVaults(runtime, subsWithConfigs)
 		if err != nil {
 			return nil, err

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -3,21 +3,9 @@
 
 package config
 
-import "go.mondoo.com/cnquery/providers-sdk/v1/plugin"
-
-const (
-	// Discovery flags
-	DiscoveryOrganization       = "organization"
-	DiscoveryFolders            = "folders"
-	DiscoveryInstances          = "instances"
-	DiscoveryProjects           = "projects"
-	DiscoveryComputeImages      = "compute-images"
-	DiscoveryComputeNetworks    = "compute-networks"
-	DiscoveryComputeSubnetworks = "compute-subnetworks"
-	DiscoveryComputeFirewalls   = "compute-firewalls"
-	DiscoveryGkeClusters        = "gke-clusters"
-	DiscoveryStorageBuckets     = "storage-buckets"
-	DiscoveryBigQueryDatasets   = "bigquery-datasets"
+import (
+	"go.mondoo.com/cnquery/providers-sdk/v1/plugin"
+	"go.mondoo.com/cnquery/providers/gcp/resources"
 )
 
 var Config = plugin.Provider{
@@ -30,17 +18,17 @@ var Config = plugin.Provider{
 			Use:   "gcp",
 			Short: "GCP Cloud",
 			Discovery: []string{
-				DiscoveryOrganization,
-				DiscoveryFolders,
-				DiscoveryInstances,
-				DiscoveryProjects,
-				DiscoveryComputeImages,
-				DiscoveryComputeNetworks,
-				DiscoveryComputeSubnetworks,
-				DiscoveryComputeFirewalls,
-				DiscoveryGkeClusters,
-				DiscoveryStorageBuckets,
-				DiscoveryBigQueryDatasets,
+				resources.DiscoveryOrganization,
+				resources.DiscoveryFolders,
+				resources.DiscoveryInstances,
+				resources.DiscoveryProjects,
+				resources.DiscoveryComputeImages,
+				resources.DiscoveryComputeNetworks,
+				resources.DiscoveryComputeSubnetworks,
+				resources.DiscoveryComputeFirewalls,
+				resources.DiscoveryGkeClusters,
+				resources.DiscoveryStorageBuckets,
+				resources.DiscoveryBigQueryDatasets,
 			},
 			Flags: []plugin.Flag{
 				{

--- a/providers/gcp/resources/discovery.go
+++ b/providers/gcp/resources/discovery.go
@@ -6,9 +6,23 @@ package resources
 import (
 	"go.mondoo.com/cnquery/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/providers-sdk/v1/plugin"
-	"go.mondoo.com/cnquery/providers/gcp/config"
 	"go.mondoo.com/cnquery/providers/gcp/connection"
 	"golang.org/x/exp/slices"
+)
+
+const (
+	// Discovery flags
+	DiscoveryOrganization       = "organization"
+	DiscoveryFolders            = "folders"
+	DiscoveryInstances          = "instances"
+	DiscoveryProjects           = "projects"
+	DiscoveryComputeImages      = "compute-images"
+	DiscoveryComputeNetworks    = "compute-networks"
+	DiscoveryComputeSubnetworks = "compute-subnetworks"
+	DiscoveryComputeFirewalls   = "compute-firewalls"
+	DiscoveryGkeClusters        = "gke-clusters"
+	DiscoveryStorageBuckets     = "storage-buckets"
+	DiscoveryBigQueryDatasets   = "bigquery-datasets"
 )
 
 func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
@@ -51,7 +65,7 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 			in.Spec.Assets = append(in.Spec.Assets, list...)
 		}
 
-		if slices.Contains(conn.Conf.Discover.Targets, config.DiscoveryProjects) {
+		if slices.Contains(conn.Conf.Discover.Targets, DiscoveryProjects) {
 			in.Spec.Assets = append(in.Spec.Assets, &inventory.Asset{
 				PlatformIds: []string{
 					connection.NewProjectPlatformID(gcpProject.Id.Data),
@@ -73,7 +87,7 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 func discoverOrganization(conn *connection.GcpConnection, gcpOrg *mqlGcpOrganization, target string) ([]*inventory.Asset, error) {
 	assetList := []*inventory.Asset{}
 	switch target {
-	case config.DiscoveryProjects:
+	case DiscoveryProjects:
 		projects := gcpOrg.GetProjects()
 		if projects.Error != nil {
 			return nil, projects.Error
@@ -114,7 +128,7 @@ func discoverOrganization(conn *connection.GcpConnection, gcpOrg *mqlGcpOrganiza
 func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, target string) ([]*inventory.Asset, error) {
 	assetList := []*inventory.Asset{}
 	switch target {
-	case config.DiscoveryInstances:
+	case DiscoveryInstances:
 		compute := gcpProject.GetCompute()
 		if compute.Error != nil {
 			return nil, compute.Error
@@ -158,7 +172,7 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, 
 			})
 		}
 
-	case config.DiscoveryComputeImages:
+	case DiscoveryComputeImages:
 		compute := gcpProject.GetCompute()
 		if compute.Error != nil {
 			return nil, compute.Error
@@ -187,7 +201,7 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, 
 				Connections: []*inventory.Config{conn.Conf.Clone()}, // pass-in the parent connection config
 			})
 		}
-	case config.DiscoveryComputeNetworks:
+	case DiscoveryComputeNetworks:
 		compute := gcpProject.GetCompute()
 		if compute.Error != nil {
 			return nil, compute.Error
@@ -211,7 +225,7 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, 
 				Connections: []*inventory.Config{conn.Conf.Clone()}, // pass-in the parent connection config
 			})
 		}
-	case config.DiscoveryComputeSubnetworks:
+	case DiscoveryComputeSubnetworks:
 		compute := gcpProject.GetCompute()
 		if compute.Error != nil {
 			return nil, compute.Error
@@ -239,7 +253,7 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, 
 				Connections: []*inventory.Config{conn.Conf.Clone()}, // pass-in the parent connection config
 			})
 		}
-	case config.DiscoveryComputeFirewalls:
+	case DiscoveryComputeFirewalls:
 		compute := gcpProject.GetCompute()
 		if compute.Error != nil {
 			return nil, compute.Error
@@ -263,7 +277,7 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, 
 				Connections: []*inventory.Config{conn.Conf.Clone()}, // pass-in the parent connection config
 			})
 		}
-	case config.DiscoveryGkeClusters:
+	case DiscoveryGkeClusters:
 		gke := gcpProject.GetGke()
 		if gke.Error != nil {
 			return nil, gke.Error
@@ -287,7 +301,7 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, 
 				Connections: []*inventory.Config{conn.Conf.Clone()}, // pass-in the parent connection config
 			})
 		}
-	case config.DiscoveryStorageBuckets:
+	case DiscoveryStorageBuckets:
 		storage := gcpProject.GetStorage()
 		if storage.Error != nil {
 			return nil, storage.Error
@@ -311,7 +325,7 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, 
 				Connections: []*inventory.Config{conn.Conf.Clone()}, // pass-in the parent connection config
 			})
 		}
-	case config.DiscoveryBigQueryDatasets:
+	case DiscoveryBigQueryDatasets:
 		bq := gcpProject.GetBigquery()
 		if bq.Error != nil {
 			return nil, bq.Error


### PR DESCRIPTION
After https://github.com/mondoohq/cnquery/pull/1625

Taking the k8s pattern. The config should not have to be imported by other modules (at the time of writing).