### PR TITLE
🌈 replace provider update error with warning

### DIFF
--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -170,7 +170,10 @@ func (c *coordinator) tryProviderUpdate(provider *Provider, update UpdateProvide
 
 	latest, err := LatestVersion(provider.Name)
 	if err != nil {
-		return nil, err
+		log.Warn().Msg(err.Error())
+		// we can just continue with the existing provider, no need to error up,
+		// the warning is enough since we are still functional
+		return provider, nil
 	}
 
 	semver := semver.Parser{}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -252,7 +252,7 @@ func LatestVersion(name string) (string, error) {
 	}
 
 	if latestVersion == "" {
-		return "", errors.New("cannot find '" + name + "' in available upstream providers")
+		return "", errors.New("cannot determine latest version of provider '" + name + "'")
 	}
 	return latestVersion, nil
 }


### PR DESCRIPTION
Updates are mostly optional. The system may be working fine and displaying it as an error at this stage may lead to unnecessary fear.