### PR TITLE
🐛 make sure providers are not killed after an asset is scanned

### DIFF
--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -312,6 +312,7 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 		multiprogress.Open()
 	}()
 	scanGroup.Wait()
+	providers.Coordinator.Shutdown()
 	return reporter.Reports(), finished, nil
 }
 

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -69,7 +69,8 @@ func (r *Runtime) Close() {
 		log.Error().Err(err).Msg("failed to save recording")
 	}
 
-	r.coordinator.Close(r.Provider.Instance)
+	// TODO: ideally, we try to close the provider here but only if there are no more assets that need it
+	// r.coordinator.Close(r.Provider.Instance)
 	r.schema.Close()
 }
 


### PR DESCRIPTION
This makes sure that scans for a list of assets work. The current implementation would kill the provider after the first asset is scanned. We do a simple fix here that will only kill open providers after the whole scan is complete. As a long term fix we should probably look into keeping track of assets that need a specific provider. Only when all assets for the provider have been scanned, it can be killed.