### PR TITLE
🐛 fix provider shutdown

### DIFF
--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -313,16 +313,19 @@ func setConnector(provider *plugin.Provider, connector *plugin.Connector, run fu
 		})
 		if err != nil {
 			runtime.Close()
+			providers.Coordinator.Shutdown()
 			log.Fatal().Err(err).Msg("failed to parse cli arguments")
 		}
 
 		if cliRes == nil {
 			runtime.Close()
+			providers.Coordinator.Shutdown()
 			log.Fatal().Msg("failed to process CLI arguments, nothing was returned")
 		}
 
 		run(cc, runtime, cliRes)
 		runtime.Close()
+		providers.Coordinator.Shutdown()
 	}
 
 	for i := range allFlags {

--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -350,7 +350,6 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 		multiprogress.Open()
 	}()
 	scanGroup.Wait()
-	providers.Coordinator.Shutdown()
 	return reporter.Reports(), finished, nil
 }
 

--- a/providers-sdk/v1/plugin/grpc.go
+++ b/providers-sdk/v1/plugin/grpc.go
@@ -87,6 +87,10 @@ func (m *GRPCServer) Connect(ctx context.Context, req *ConnectReq) (*ConnectRes,
 	return m.Impl.Connect(req, a)
 }
 
+func (m *GRPCServer) Shutdown(ctx context.Context, req *ShutdownReq) (*ShutdownRes, error) {
+	return m.Impl.Shutdown(req)
+}
+
 func (m *GRPCServer) GetData(ctx context.Context, req *DataReq) (*DataRes, error) {
 	return m.Impl.GetData(req)
 }

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -106,7 +106,8 @@ func (r *Runtime) Close() {
 		}
 	}
 
-	r.coordinator.Close(r.Provider.Instance)
+	// TODO: ideally, we try to close the provider here but only if there are no more assets that need it
+	// r.coordinator.Close(r.Provider.Instance)
 	r.schema.Close()
 }
 


### PR DESCRIPTION
- [x] implement `Shutdown` for the provider server
- [x] Do not kill the provider after an asset is scanned
- [x] do we need to call shutdown when the runtime is closed or when the provider is closed?