### PR TITLE
🧹 make testutils easier to use

### DIFF
--- a/cli/printer/printer_test.go
+++ b/cli/printer/printer_test.go
@@ -15,7 +15,7 @@ import (
 	"go.mondoo.com/cnquery/utils/sortx"
 )
 
-var x = testutils.InitTester(testutils.LinuxMock("../../providers-sdk/v1/testutils"))
+var x = testutils.InitTester(testutils.LinuxMock())
 
 func init() {
 	logger.InitTestEnv()

--- a/cli/reporter/json_test.go
+++ b/cli/reporter/json_test.go
@@ -14,7 +14,7 @@ import (
 	"gotest.tools/assert"
 )
 
-var x = testutils.InitTester(testutils.LinuxMock("../../providers-sdk/v1/testutils"))
+var x = testutils.InitTester(testutils.LinuxMock())
 
 func testQuery(t *testing.T, query string) (*llx.CodeBundle, map[string]*llx.RawResult) {
 	codeBundle, err := x.Compile(query)

--- a/cli/shell/shell_test.go
+++ b/cli/shell/shell_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func localShell() *shell.Shell {
-	runtime := testutils.LinuxMock("../../providers-sdk/v1/testutils")
+	runtime := testutils.LinuxMock()
 	res, err := shell.New(runtime)
 	if err != nil {
 		panic(err.Error())

--- a/explorer/filters_test.go
+++ b/explorer/filters_test.go
@@ -50,7 +50,7 @@ func TestSummarize(t *testing.T) {
 
 func TestBundleAssetFilter(t *testing.T) {
 	// load the raw bundle
-	tester := testutils.InitTester(testutils.LinuxMock("../providers-sdk/v1/testutils"))
+	tester := testutils.InitTester(testutils.LinuxMock())
 	bundle, err := explorer.BundleFromPaths("../examples/os.mql.yaml")
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(bundle.Packs))

--- a/mql/mql_test.go
+++ b/mql/mql_test.go
@@ -24,7 +24,7 @@ func init() {
 }
 
 func runtime() llx.Runtime {
-	return testutils.LinuxMock("../providers-sdk/v1/testutils")
+	return testutils.LinuxMock()
 }
 
 func getEnvFeatures() cnquery.Features {

--- a/providers/core/resources/core_test.go
+++ b/providers/core/resources/core_test.go
@@ -5,4 +5,4 @@ package resources_test
 
 import "go.mondoo.com/cnquery/providers-sdk/v1/testutils"
 
-var x = testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+var x = testutils.InitTester(testutils.LinuxMock())

--- a/providers/core/resources/mql_test.go
+++ b/providers/core/resources/mql_test.go
@@ -38,7 +38,7 @@ func TestCore_Props(t *testing.T) {
 		},
 	}
 
-	x := testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+	x := testutils.InitTester(testutils.LinuxMock())
 
 	for i := range tests {
 		cur := tests[i]
@@ -332,7 +332,7 @@ func TestNumber_Methods(t *testing.T) {
 }
 
 func TestString_Methods(t *testing.T) {
-	x := testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+	x := testutils.InitTester(testutils.LinuxMock())
 	x.TestSimple(t, []testutils.SimpleTest{
 		{
 			Code:        "'hello'.contains('ll')",
@@ -418,7 +418,7 @@ func TestString_Methods(t *testing.T) {
 }
 
 func TestScore_Methods(t *testing.T) {
-	x := testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+	x := testutils.InitTester(testutils.LinuxMock())
 	x.TestSimple(t, []testutils.SimpleTest{
 		{
 			Code:        "score(100)",
@@ -432,7 +432,7 @@ func TestScore_Methods(t *testing.T) {
 }
 
 func TestTypeof_Methods(t *testing.T) {
-	x := testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+	x := testutils.InitTester(testutils.LinuxMock())
 	x.TestSimple(t, []testutils.SimpleTest{
 		{
 			Code:        "typeof(null)",
@@ -454,7 +454,7 @@ func TestTypeof_Methods(t *testing.T) {
 }
 
 func TestArray_Access(t *testing.T) {
-	x := testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+	x := testutils.InitTester(testutils.LinuxMock())
 	x.TestSimpleErrors(t, []testutils.SimpleTest{
 		{
 			Code:        "[0,1,2][100000]",
@@ -491,7 +491,7 @@ func TestArray_Access(t *testing.T) {
 }
 
 func TestArray(t *testing.T) {
-	x := testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+	x := testutils.InitTester(testutils.LinuxMock())
 	x.TestSimple(t, []testutils.SimpleTest{
 		{
 			Code:        "[1,2,3]",
@@ -635,7 +635,7 @@ func TestArray(t *testing.T) {
 }
 
 func TestResource_Default(t *testing.T) {
-	x := testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+	x := testutils.InitTester(testutils.LinuxMock())
 	res := x.TestQuery(t, "mondoo")
 	require.NotEmpty(t, res)
 	vals := res[0].Data.Value.(map[string]interface{})
@@ -644,7 +644,7 @@ func TestResource_Default(t *testing.T) {
 }
 
 func TestBrokenQueryExecution(t *testing.T) {
-	x := testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+	x := testutils.InitTester(testutils.LinuxMock())
 	bundle, err := x.Compile("'asdf'.contains('asdf') == true")
 	require.NoError(t, err)
 	bundle.CodeV2.Blocks[0].Chunks[1].Id = "fakecontains"

--- a/providers/core/resources/time_test.go
+++ b/providers/core/resources/time_test.go
@@ -19,7 +19,7 @@ func duration(i int64) *time.Time {
 }
 
 func TestFuzzyTime(t *testing.T) {
-	x := testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+	x := testutils.InitTester(testutils.LinuxMock())
 	code := "time.now.unix"
 	t.Run(code, func(t *testing.T) {
 		res := x.TestQuery(t, code)
@@ -40,7 +40,7 @@ func TestFuzzyTime(t *testing.T) {
 func TestTimeParsing(t *testing.T) {
 	parserTimestamp := int64(1136214245)
 
-	x := testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+	x := testutils.InitTester(testutils.LinuxMock())
 	x.TestSimple(t, []testutils.SimpleTest{
 		{
 			Code:        "parse.date('0000-01-01T02:03:04Z').seconds",
@@ -131,7 +131,7 @@ func TestTime_Methods(t *testing.T) {
 	today, _ := time.ParseInLocation("2006-01-02", now.Format("2006-01-02"), now.Location())
 	tomorrow := today.Add(24 * time.Hour)
 
-	x := testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+	x := testutils.InitTester(testutils.LinuxMock())
 	x.TestSimple(t, []testutils.SimpleTest{
 		{
 			Code:        "time.now > time.today",

--- a/providers/network/resources/network_test.go
+++ b/providers/network/resources/network_test.go
@@ -5,4 +5,4 @@ package resources_test
 
 import "go.mondoo.com/cnquery/providers-sdk/v1/testutils"
 
-var x = testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+var x = testutils.InitTester(testutils.LinuxMock())

--- a/providers/os/resources/mql_test.go
+++ b/providers/os/resources/mql_test.go
@@ -22,7 +22,7 @@ import (
 // core provider counterpart to this test file.
 
 func testChain(t *testing.T, codes ...string) {
-	tr := testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+	tr := testutils.InitTester(testutils.LinuxMock())
 	for i := range codes {
 		code := codes[i]
 		t.Run(code, func(t *testing.T) {
@@ -77,7 +77,7 @@ func TestOS_Vars(t *testing.T) {
 }
 
 func TestMap(t *testing.T) {
-	x := testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+	x := testutils.InitTester(testutils.LinuxMock())
 	x.TestSimple(t, []testutils.SimpleTest{
 		{
 			Code:        "{a: 123}",
@@ -119,7 +119,7 @@ func TestMap(t *testing.T) {
 }
 
 func TestListResource(t *testing.T) {
-	x := testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+	x := testutils.InitTester(testutils.LinuxMock())
 
 	t.Run("list resource by default returns the list", func(t *testing.T) {
 		res := x.TestQuery(t, "users")
@@ -178,7 +178,7 @@ func TestListResource(t *testing.T) {
 }
 
 func TestListResource_Assertions(t *testing.T) {
-	x := testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+	x := testutils.InitTester(testutils.LinuxMock())
 	x.TestSimple(t, []testutils.SimpleTest{
 		{
 			Code:        "users.contains(name == 'root')",
@@ -226,7 +226,7 @@ func TestListResource_Assertions(t *testing.T) {
 }
 
 func TestResource_duplicateFields(t *testing.T) {
-	x := testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+	x := testutils.InitTester(testutils.LinuxMock())
 	x.TestSimple(t, []testutils.SimpleTest{
 		{
 			Code: "users.list.duplicates(gid) { gid }",
@@ -257,7 +257,7 @@ func TestResource_duplicateFields(t *testing.T) {
 func TestDict_Methods_Contains(t *testing.T) {
 	p := "parse.json('/dummy.json')."
 
-	x := testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+	x := testutils.InitTester(testutils.LinuxMock())
 	x.TestSimple(t, []testutils.SimpleTest{
 		{
 			Code:        p + "params['hello'].contains('ll')",
@@ -344,7 +344,7 @@ func TestDict_Methods_Map(t *testing.T) {
 		panic(err.Error())
 	}
 
-	x := testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+	x := testutils.InitTester(testutils.LinuxMock())
 	x.TestSimple(t, []testutils.SimpleTest{
 		{
 			Code:        p + "params['string-array'].where(_ == 'a')",
@@ -440,7 +440,7 @@ func TestDict_Methods_Map(t *testing.T) {
 func TestDict_Methods_Array(t *testing.T) {
 	p := "parse.json('/dummy.array.json')."
 
-	x := testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+	x := testutils.InitTester(testutils.LinuxMock())
 	x.TestSimple(t, []testutils.SimpleTest{
 		{
 			Code:        p + "params[0]",
@@ -474,7 +474,7 @@ func TestDict_Methods_Array(t *testing.T) {
 }
 
 func TestDict_Methods_OtherJson(t *testing.T) {
-	x := testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+	x := testutils.InitTester(testutils.LinuxMock())
 	x.TestSimple(t, []testutils.SimpleTest{
 		{
 			Code:        "parse.json('/dummy.number.json').params",
@@ -500,7 +500,7 @@ func TestDict_Methods_OtherJson(t *testing.T) {
 }
 
 func TestArrayBlockError(t *testing.T) {
-	x := testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+	x := testutils.InitTester(testutils.LinuxMock())
 	res := x.TestQuery(t, "users.list { file(_.name + 'doesnotexist').content }")
 	assert.NotEmpty(t, res)
 	queryResult := res[len(res)-1]
@@ -510,7 +510,7 @@ func TestArrayBlockError(t *testing.T) {
 
 func TestBrokenQueryExecutionGH674(t *testing.T) {
 	// See https://github.com/mondoohq/cnquery/issues/674
-	x := testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+	x := testutils.InitTester(testutils.LinuxMock())
 	bundle, err := x.Compile(`
 a = file("/tmp/ref1").content.trim
 file(a).path == "/tmp/ref2"

--- a/providers/os/resources/os_test.go
+++ b/providers/os/resources/os_test.go
@@ -10,9 +10,9 @@ import (
 	"go.mondoo.com/cnquery/providers-sdk/v1/testutils"
 )
 
-var x = testutils.InitTester(testutils.LinuxMock("../../../providers-sdk/v1/testutils"))
+var x = testutils.InitTester(testutils.LinuxMock())
 
 func testWindowsQuery(t *testing.T, query string) []*llx.RawResult {
-	win := testutils.InitTester(testutils.WindowsMock("../../../providers-sdk/v1/testutils"))
+	win := testutils.InitTester(testutils.WindowsMock())
 	return win.TestQuery(t, query)
 }

--- a/providers/os/resources/python_test.go
+++ b/providers/os/resources/python_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestResource_Python(t *testing.T) {
-	x := testutils.InitTester(testutils.RecordingMock("../../../providers-sdk/v1/testutils", "./python/testdata/linux.json"))
+	x := testutils.InitTester(testutils.RecordingMock("./python/testdata/linux.json"))
 
 	t.Run("parse all packages", func(t *testing.T) {
 		res := x.TestQuery(t, "python.packages")
@@ -34,7 +34,7 @@ func TestResource_Python(t *testing.T) {
 }
 
 func TestResource_PythonPackage(t *testing.T) {
-	x := testutils.InitTester(testutils.RecordingMock("../../../providers-sdk/v1/testutils", "./python/testdata/python-package.json"))
+	x := testutils.InitTester(testutils.RecordingMock("./python/testdata/python-package.json"))
 
 	t.Run("parse single package", func(t *testing.T) {
 		res := x.TestQuery(t, "python.package(\"/usr/lib/python3/dist-packages/python_ftp_server-1.3.17.dist-info/METADATA\").name")


### PR DESCRIPTION
No more specifying the path. Especially when you import these testutils it is hard to figure out the path.