### PR TITLE
🐛 fix detection of provider via connector

### DIFF
--- a/providers/providers.go
+++ b/providers/providers.go
@@ -147,13 +147,13 @@ func ListAll() ([]*Provider, error) {
 
 // EnsureProvider find the provider for a given connector either from the list
 // of existing proviers or by downloading and installing it.
-func EnsureProvider(existing Providers, connectorName string, autoUpdate bool) (*Provider, error) {
-	provider := existing.ForConnection(connectorName)
+func EnsureProvider(existing Providers, connectorName string, connectorType string, autoUpdate bool) (*Provider, error) {
+	provider := existing.ForConnection(connectorName, connectorType)
 	if provider != nil {
 		return provider, nil
 	}
 
-	upstream := DefaultProviders.ForConnection(connectorName)
+	upstream := DefaultProviders.ForConnection(connectorName, connectorType)
 	if upstream == nil {
 		// we can't find any provider for this connector in our default set
 		return nil, nil
@@ -530,10 +530,22 @@ func (p *Provider) binPath() string {
 	return filepath.Join(p.Path, p.Name)
 }
 
-func (p Providers) ForConnection(name string) *Provider {
-	for _, provider := range p {
-		if slices.Contains(provider.ConnectionTypes, name) {
-			return provider
+func (p Providers) ForConnection(name string, typ string) *Provider {
+	if name != "" {
+		for _, provider := range p {
+			for i := range provider.Connectors {
+				if provider.Connectors[i].Name == name {
+					return provider
+				}
+			}
+		}
+	}
+
+	if typ != "" {
+		for _, provider := range p {
+			if slices.Contains(provider.ConnectionTypes, typ) {
+				return provider
+			}
 		}
 	}
 

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -180,7 +180,7 @@ func (r *Runtime) DetectProvider(asset *inventory.Asset) error {
 			continue
 		}
 
-		provider, err := EnsureProvider(r.coordinator.Providers, conn.Type, true)
+		provider, err := EnsureProvider(r.coordinator.Providers, "", conn.Type, true)
 		if err != nil {
 			errs.Add(err)
 			continue


### PR DESCRIPTION
We have conflated connection types (which are coming from asset detection) and connection names (which are coming from CLI). One of the last changes has broken the support of CLI-based connector-detection (at least when the connection type and name differed, like in the case of OS).

This PR clarifies the difference between these types, by allowing the `EnsureProvider` call to either take the type or the name for the connection. In the CLI, we get names like `docker`, which then translate to the `os` provider. In contrast, the connection type is something like `docker-image` which translates to the `os` provider. We could have mixed them all together, but it may lead to confusing results (it should not, but it can and then it really falls apart).

This is also important because `DefaultProviders` uses connector names, fully aligned with the way the CLI config of providers works, which requires a search by name, not by type.

@imilchev fyi ^^ had to clarify the difference to fix regular execution of CLI commands like `run` and `shell`, which had broken 