### PR TITLE
🐛 print proper errors for early provider checks

### DIFF
--- a/apps/cnquery/cmd/root.go
+++ b/apps/cnquery/cmd/root.go
@@ -4,13 +4,13 @@
 package cmd
 
 import (
-	"fmt"
 	"net/http"
 	"os"
 	"regexp"
 	"strings"
 
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 	"github.com/spf13/viper"
@@ -64,12 +64,12 @@ func Execute() {
 		},
 	)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		log.Error().Msg(err.Error())
 		os.Exit(1)
 	}
 
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		log.Error().Msg(err.Error())
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
We printed to stderr, but no visual indication which sucked. Streamline error handling in this phase with the remaineder of the application (which uses `log.Error`).