### PR TITLE
🧹 testutils: load schema from LR

### DIFF
--- a/providers-sdk/v1/testutils/testutils.go
+++ b/providers-sdk/v1/testutils/testutils.go
@@ -22,6 +22,8 @@ import (
 	"go.mondoo.com/cnquery/mql"
 	"go.mondoo.com/cnquery/mqlc"
 	"go.mondoo.com/cnquery/providers"
+	"go.mondoo.com/cnquery/providers-sdk/v1/lr"
+	"go.mondoo.com/cnquery/providers-sdk/v1/resources"
 	"go.mondoo.com/cnquery/providers/mock"
 	networkconf "go.mondoo.com/cnquery/providers/network/config"
 	networkprovider "go.mondoo.com/cnquery/providers/network/provider"
@@ -147,24 +149,25 @@ func (ctx *tester) TestMqlc(t *testing.T, bundle *llx.CodeBundle, props map[stri
 	return results
 }
 
+func mustLoadSchema(provider string) *resources.Schema {
+	path := filepath.Join(TestutilsDir, "../../../providers/"+provider+"/resources/"+provider+".lr")
+	res, err := lr.Resolve(path, func(path string) ([]byte, error) { return os.ReadFile(path) })
+	if err != nil {
+		panic(err.Error())
+	}
+
+	schema, err := lr.Schema(res)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	return schema
+}
+
 func Local() llx.Runtime {
-	raw, err := os.ReadFile(filepath.Join(TestutilsDir, "../../../providers/os/resources/os.resources.json"))
-	if err != nil {
-		panic("failed to load os resources for testing: " + err.Error())
-	}
-	osSchema := providers.MustLoadSchema("os", raw)
-
-	raw, err = os.ReadFile(filepath.Join(TestutilsDir, "../../../providers/core/resources/core.resources.json"))
-	if err != nil {
-		panic("failed to load core resources for testing: " + err.Error())
-	}
-	coreSchema := providers.MustLoadSchema("core", raw)
-
-	raw, err = os.ReadFile(filepath.Join(TestutilsDir, "../../../providers/network/resources/network.resources.json"))
-	if err != nil {
-		panic("failed to load network resources for testing: " + err.Error())
-	}
-	networkSchema := providers.MustLoadSchema("network", raw)
+	osSchema := mustLoadSchema("os")
+	coreSchema := mustLoadSchema("core")
+	networkSchema := mustLoadSchema("network")
 
 	runtime := providers.Coordinator.NewRuntime()
 


### PR DESCRIPTION
We don't have all the resources json schemas in this repo. That's because they get generated together with the build process of each provider. Because we don't all the schemas in the repo, testutils cannot just be included in other projects, because they don't go through the json resources schema generation.

We now have 2 options: (1) check in all the schemas into the repo or (2) generate the schema from LR files.

This PR takes the second option. It treats these LR files in the same way the schema loader treats JSON files: they contain all the metadata, we don't need to generate any Go-files for tests, we don't need to generate manifests, we only need the schema which is fully self-contained in LR files. Thus, instead of parsing JSONs step by step, it parses LR files step by step (but natively) and get the schema from them. This reduces the amount of files that will make it into regular PR reviews by default (because the auto-generated schema doesn't require reviews).

This may change in the future and we are very open to discussions on this decisions.

Required for cnspec v9.