### PR TITLE
🧹 remove mqlc.MustCompile

### DIFF
--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -2206,12 +2206,3 @@ func Compile(input string, props map[string]*llx.Primitive, conf compilerConfig)
 
 	return res, nil
 }
-
-// MustCompile a code piece that should not fail (otherwise panic)
-func MustCompile(input string, conf compilerConfig, props map[string]*llx.Primitive) *llx.CodeBundle {
-	res, err := Compile(input, props, conf)
-	if err != nil {
-		log.Fatal().Err(err).Msg("Failed to compile")
-	}
-	return res
-}


### PR DESCRIPTION
This method also exists in explorer/executor, but with a few differences:
1. it has tests
2. it is actually in use (in any of our projects)
3. it provides useful functionality like using the default runtime

Deduplicate it between mqlc and the explorer/executor.

To understand why we remove this but keep the other method: This method is used as an analogy to regexp.MustCompile and thus you'd want it to be self-contained without having to do additional steps.

However, this needs a bit more follow-up work, because the runtime may not contain the providers necessary for the piece of code to run. This is surfacing right now in cnspec, where MQL code is requested by the reporter which is provided by the `os` plugin (which may not be installed!). Thus, these methods will likely need a bit more work...