### PR TITLE
🐛 package init does not get list from recording

### DIFF
--- a/providers/os/resources/packages.go
+++ b/providers/os/resources/packages.go
@@ -42,9 +42,8 @@ func initPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 	}
 	packages := pkgs.(*mqlPackages)
 
-	list := packages.GetList()
-	if list.Error != nil {
-		return nil, nil, list.Error
+	if err = packages.refreshCache(nil); err != nil {
+		return nil, nil, err
 	}
 
 	x, found := packages.packagesByName[name]


### PR DESCRIPTION
it uses the wrong method, which causes the internal list of packages by name to not get refreshed