### PR TITLE
🐛 abort scans if there are no assets

### DIFF
--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -222,10 +222,15 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 		})
 	}
 
+	if len(assets) == 0 {
+		return nil, false, nil
+	}
+
 	justAssets := []*inventory.Asset{}
 	for _, asset := range assets {
 		justAssets = append(justAssets, asset.asset)
 	}
+
 	// sync assets
 	if upstream != nil && upstream.ApiEndpoint != "" && !upstream.Incognito {
 		log.Info().Msg("synchronize assets")


### PR DESCRIPTION
All the remaining code that deals with synchronization and test execution is unnecessary if there are no assets.