### PR TITLE
🐛 support bridge-resources

### DIFF
--- a/providers-sdk/v1/lr/lr_test.go
+++ b/providers-sdk/v1/lr/lr_test.go
@@ -8,234 +8,217 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func parse(t *testing.T, cmd string, f func(*LR)) {
+func parse(t *testing.T, cmd string) *LR {
 	res, err := Parse(cmd)
-	assert.Nil(t, err)
-	if err == nil {
-		f(res)
-	}
+	require.Nil(t, err)
+	return res
 }
 
 func TestParse(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		parse(t, "", func(res *LR) {
-			assert.Equal(t, &LR{}, res)
-		})
+		res := parse(t, "")
+		assert.Equal(t, &LR{}, res)
 	})
 
 	t.Run("empty resource", func(t *testing.T) {
-		parse(t, "name", func(res *LR) {
-			assert.Equal(t, []*Resource{{ID: "name"}}, res.Resources)
-		})
+		res := parse(t, "name")
+		assert.Equal(t, []*Resource{{ID: "name"}}, res.Resources)
 	})
 
 	t.Run("empty resources", func(t *testing.T) {
-		parse(t, "one tw2 thr33", func(res *LR) {
-			assert.Equal(t, []*Resource{
-				{ID: "one"},
-				{ID: "tw2"},
-				{ID: "thr33"},
-			}, res.Resources)
-		})
+		res := parse(t, "one tw2 thr33")
+		assert.Equal(t, []*Resource{
+			{ID: "one"},
+			{ID: "tw2"},
+			{ID: "thr33"},
+		}, res.Resources)
 	})
 
 	t.Run("defaults", func(t *testing.T) {
-		parse(t, "name @defaults(\"id group=group.name\")", func(res *LR) {
-			assert.Equal(t, []*Resource{
-				{
-					ID:       "name",
-					Defaults: "id group=group.name",
-				},
-			}, res.Resources)
-		})
+		res := parse(t, "name @defaults(\"id group=group.name\")")
+		assert.Equal(t, []*Resource{
+			{
+				ID:       "name",
+				Defaults: "id group=group.name",
+			},
+		}, res.Resources)
 	})
 
 	t.Run("resource with a static field", func(t *testing.T) {
-		parse(t, `
+		res := parse(t, `
 		// resource-docs
 		// with multiline
 		name {
 			// field docs...
 			field type
 		}
-		`, func(res *LR) {
-			assert.Equal(t, "name", res.Resources[0].ID)
-			// TODO: needs to be fixed
-			// assert.Equal(t, "resource-docs", res.Resources[0].title)
-			// assert.Equal(t, "with multiline", res.Resources[0].desc)
+		`)
+		assert.Equal(t, "name", res.Resources[0].ID)
+		// TODO: needs to be fixed
+		// assert.Equal(t, "resource-docs", res.Resources[0].title)
+		// assert.Equal(t, "with multiline", res.Resources[0].desc)
 
-			f := []*Field{
-				{
-					BasicField: &BasicField{
-						ID:   "field",
-						Args: nil,
-						Type: Type{SimpleType: &SimpleType{"type"}},
-					},
-					Comments: []string{"// field docs..."},
+		f := []*Field{
+			{
+				BasicField: &BasicField{
+					ID:   "field",
+					Args: nil,
+					Type: Type{SimpleType: &SimpleType{"type"}},
 				},
-			}
-			assert.Equal(t, f, res.Resources[0].Body.Fields)
-		})
+				Comments: []string{"// field docs..."},
+			},
+		}
+		assert.Equal(t, f, res.Resources[0].Body.Fields)
 	})
 
 	t.Run("resource with a list type", func(t *testing.T) {
-		parse(t, "name {\nfield []type\n}", func(res *LR) {
-			f := []*Field{
-				{
-					BasicField: &BasicField{
-						ID:   "field",
-						Args: nil,
-						Type: Type{ListType: &ListType{Type{SimpleType: &SimpleType{"type"}}}},
-					},
+		res := parse(t, "name {\nfield []type\n}")
+		f := []*Field{
+			{
+				BasicField: &BasicField{
+					ID:   "field",
+					Args: nil,
+					Type: Type{ListType: &ListType{Type{SimpleType: &SimpleType{"type"}}}},
 				},
-			}
-			assert.Equal(t, "name", res.Resources[0].ID)
-			assert.Equal(t, f, res.Resources[0].Body.Fields)
-		})
+			},
+		}
+		assert.Equal(t, "name", res.Resources[0].ID)
+		assert.Equal(t, f, res.Resources[0].Body.Fields)
 	})
 
 	t.Run("resource with a map type", func(t *testing.T) {
-		parse(t, "name {\nfield map[a]b\n}", func(res *LR) {
-			f := []*Field{
-				{
-					BasicField: &BasicField{ID: "field", Args: nil, Type: Type{
-						MapType: &MapType{SimpleType{"a"}, Type{SimpleType: &SimpleType{"b"}}},
-					}},
-				},
-			}
-			assert.Equal(t, "name", res.Resources[0].ID)
-			assert.Equal(t, f, res.Resources[0].Body.Fields)
-		})
+		res := parse(t, "name {\nfield map[a]b\n}")
+		f := []*Field{
+			{
+				BasicField: &BasicField{ID: "field", Args: nil, Type: Type{
+					MapType: &MapType{SimpleType{"a"}, Type{SimpleType: &SimpleType{"b"}}},
+				}},
+			},
+		}
+		assert.Equal(t, "name", res.Resources[0].ID)
+		assert.Equal(t, f, res.Resources[0].Body.Fields)
 	})
 
 	t.Run("resource with a dependent field, no args", func(t *testing.T) {
-		parse(t, "name {\nfield() type\n}", func(res *LR) {
-			f := []*Field{
-				{BasicField: &BasicField{ID: "field", Args: &FieldArgs{}, Type: Type{SimpleType: &SimpleType{"type"}}}},
-			}
-			assert.Equal(t, "name", res.Resources[0].ID)
-			assert.Equal(t, f, res.Resources[0].Body.Fields)
-		})
+		res := parse(t, "name {\nfield() type\n}")
+		f := []*Field{
+			{BasicField: &BasicField{ID: "field", Args: &FieldArgs{}, Type: Type{SimpleType: &SimpleType{"type"}}}},
+		}
+		assert.Equal(t, "name", res.Resources[0].ID)
+		assert.Equal(t, f, res.Resources[0].Body.Fields)
 	})
 
 	t.Run("resource with a dependent field, with args", func(t *testing.T) {
-		parse(t, "name {\nfield(one, two.three) type\n}", func(res *LR) {
-			f := []*Field{
-				{BasicField: &BasicField{ID: "field", Type: Type{SimpleType: &SimpleType{"type"}}, Args: &FieldArgs{
-					List: []SimpleType{{"one"}, {"two.three"}},
-				}}},
-			}
-			assert.Equal(t, "name", res.Resources[0].ID)
-			assert.Equal(t, f, res.Resources[0].Body.Fields)
-		})
+		res := parse(t, "name {\nfield(one, two.three) type\n}")
+		f := []*Field{
+			{BasicField: &BasicField{ID: "field", Type: Type{SimpleType: &SimpleType{"type"}}, Args: &FieldArgs{
+				List: []SimpleType{{"one"}, {"two.three"}},
+			}}},
+		}
+		assert.Equal(t, "name", res.Resources[0].ID)
+		assert.Equal(t, f, res.Resources[0].Body.Fields)
 	})
 
 	t.Run("resource with init, with args", func(t *testing.T) {
-		parse(t, "name {\ninit(one int, two? string)\n}", func(res *LR) {
-			f := []*Field{
-				{Init: &Init{
-					Args: []TypedArg{
-						{ID: "one", Type: Type{SimpleType: &SimpleType{"int"}}},
-						{ID: "two", Type: Type{SimpleType: &SimpleType{"string"}}, Optional: true},
-					},
-				}},
-			}
-			assert.Equal(t, "name", res.Resources[0].ID)
-			assert.Equal(t, f, res.Resources[0].Body.Fields)
-		})
+		res := parse(t, "name {\ninit(one int, two? string)\n}")
+		f := []*Field{
+			{Init: &Init{
+				Args: []TypedArg{
+					{ID: "one", Type: Type{SimpleType: &SimpleType{"int"}}},
+					{ID: "two", Type: Type{SimpleType: &SimpleType{"string"}}, Optional: true},
+				},
+			}},
+		}
+		assert.Equal(t, "name", res.Resources[0].ID)
+		assert.Equal(t, f, res.Resources[0].Body.Fields)
 	})
 
 	t.Run("resource which is a list type", func(t *testing.T) {
-		parse(t, "name {\n[]base\n}", func(res *LR) {
-			lt := &SimplListType{Type: SimpleType{"base"}}
-			assert.Equal(t, "name", res.Resources[0].ID)
-			assert.Equal(t, lt, res.Resources[0].ListType)
-		})
+		res := parse(t, "name {\n[]base\n}")
+		lt := &SimplListType{Type: SimpleType{"base"}}
+		assert.Equal(t, "name", res.Resources[0].ID)
+		assert.Equal(t, lt, res.Resources[0].ListType)
 	})
 
 	t.Run("resource which is a list type, with args", func(t *testing.T) {
-		parse(t, "name {\n[]base(content)\ncontent string\n}", func(res *LR) {
-			lt := &SimplListType{
-				Type: SimpleType{"base"},
-				Args: &FieldArgs{
-					List: []SimpleType{{Type: "content"}},
-				},
-			}
-			assert.Equal(t, "name", res.Resources[0].ID)
-			assert.Equal(t, lt, res.Resources[0].ListType)
-		})
+		res := parse(t, "name {\n[]base(content)\ncontent string\n}")
+		lt := &SimplListType{
+			Type: SimpleType{"base"},
+			Args: &FieldArgs{
+				List: []SimpleType{{Type: "content"}},
+			},
+		}
+		assert.Equal(t, "name", res.Resources[0].ID)
+		assert.Equal(t, lt, res.Resources[0].ListType)
 	})
 
 	t.Run("resource which is a list type based on resource chain", func(t *testing.T) {
-		parse(t, "name {\n[]base.type.name\n}", func(res *LR) {
-			lt := &SimplListType{Type: SimpleType{"base.type.name"}}
-			assert.Equal(t, "name", res.Resources[0].ID)
-			assert.Equal(t, lt, res.Resources[0].ListType)
-		})
+		res := parse(t, "name {\n[]base.type.name\n}")
+		lt := &SimplListType{Type: SimpleType{"base.type.name"}}
+		assert.Equal(t, "name", res.Resources[0].ID)
+		assert.Equal(t, lt, res.Resources[0].ListType)
 	})
 
 	t.Run("embedded resource", func(t *testing.T) {
-		parse(t, `
+		res := parse(t, `
 	private name.no {
 		embed os.any
-	}`, func(res *LR) {
-			fields := []*Field{
-				{BasicField: &BasicField{isEmbedded: true, ID: "os", Type: Type{SimpleType: &SimpleType{Type: "os.any"}}, Args: &FieldArgs{}}},
-			}
+	}`)
+		fields := []*Field{
+			{BasicField: &BasicField{isEmbedded: true, ID: "os", Type: Type{SimpleType: &SimpleType{Type: "os.any"}}, Args: &FieldArgs{}}},
+		}
 
-			assert.Equal(t, "name.no", res.Resources[0].ID)
-			assert.Equal(t, true, res.Resources[0].IsPrivate)
-			assert.Equal(t, fields, res.Resources[0].Body.Fields)
-		})
+		assert.Equal(t, "name.no", res.Resources[0].ID)
+		assert.Equal(t, true, res.Resources[0].IsPrivate)
+		assert.Equal(t, fields, res.Resources[0].Body.Fields)
 	})
 
 	t.Run("embedded resource with an alias", func(t *testing.T) {
-		parse(t, `
+		res := parse(t, `
 	private name.no {
 		embed os.any as testx
-	}`, func(res *LR) {
-			fields := []*Field{
-				{BasicField: &BasicField{isEmbedded: true, ID: "testx", Type: Type{SimpleType: &SimpleType{Type: "os.any"}}, Args: &FieldArgs{}}},
-			}
+	}`)
+		fields := []*Field{
+			{BasicField: &BasicField{isEmbedded: true, ID: "testx", Type: Type{SimpleType: &SimpleType{Type: "os.any"}}, Args: &FieldArgs{}}},
+		}
 
-			assert.Equal(t, "name.no", res.Resources[0].ID)
-			assert.Equal(t, true, res.Resources[0].IsPrivate)
-			assert.Equal(t, fields, res.Resources[0].Body.Fields)
-		})
+		assert.Equal(t, "name.no", res.Resources[0].ID)
+		assert.Equal(t, true, res.Resources[0].IsPrivate)
+		assert.Equal(t, fields, res.Resources[0].Body.Fields)
 	})
 
 	t.Run("complex resource", func(t *testing.T) {
-		parse(t, `
+		res := parse(t, `
 	private name.no {
 		init(i1 string, i2 map[int]int)
 		field map[string]int
 		call(resource.field) []int
 		embed os.any
-	}`, func(res *LR) {
-			fields := []*Field{
-				{Init: &Init{Args: []TypedArg{
-					{ID: "i1", Type: Type{SimpleType: &SimpleType{"string"}}},
-					{ID: "i2", Type: Type{MapType: &MapType{SimpleType{"int"}, Type{SimpleType: &SimpleType{"int"}}}}},
-				}}},
-				{BasicField: &BasicField{ID: "field", Type: Type{MapType: &MapType{Key: SimpleType{"string"}, Value: Type{SimpleType: &SimpleType{"int"}}}}}},
-				{
-					BasicField: &BasicField{
-						ID:   "call",
-						Type: Type{ListType: &ListType{Type: Type{SimpleType: &SimpleType{"int"}}}},
-						Args: &FieldArgs{
-							List: []SimpleType{{"resource.field"}},
-						},
+	}`)
+		fields := []*Field{
+			{Init: &Init{Args: []TypedArg{
+				{ID: "i1", Type: Type{SimpleType: &SimpleType{"string"}}},
+				{ID: "i2", Type: Type{MapType: &MapType{SimpleType{"int"}, Type{SimpleType: &SimpleType{"int"}}}}},
+			}}},
+			{BasicField: &BasicField{ID: "field", Type: Type{MapType: &MapType{Key: SimpleType{"string"}, Value: Type{SimpleType: &SimpleType{"int"}}}}}},
+			{
+				BasicField: &BasicField{
+					ID:   "call",
+					Type: Type{ListType: &ListType{Type: Type{SimpleType: &SimpleType{"int"}}}},
+					Args: &FieldArgs{
+						List: []SimpleType{{"resource.field"}},
 					},
 				},
-				{BasicField: &BasicField{isEmbedded: true, ID: "os", Type: Type{SimpleType: &SimpleType{Type: "os.any"}}, Args: &FieldArgs{}}},
-			}
+			},
+			{BasicField: &BasicField{isEmbedded: true, ID: "os", Type: Type{SimpleType: &SimpleType{Type: "os.any"}}, Args: &FieldArgs{}}},
+		}
 
-			assert.Equal(t, "name.no", res.Resources[0].ID)
-			assert.Equal(t, true, res.Resources[0].IsPrivate)
-			assert.Equal(t, fields, res.Resources[0].Body.Fields)
-		})
+		assert.Equal(t, "name.no", res.Resources[0].ID)
+		assert.Equal(t, true, res.Resources[0].IsPrivate)
+		assert.Equal(t, fields, res.Resources[0].Body.Fields)
 	})
 }
 

--- a/providers-sdk/v1/lr/schema.go
+++ b/providers-sdk/v1/lr/schema.go
@@ -14,7 +14,7 @@ import (
 func Schema(ast *LR) (*resources.Schema, error) {
 	provider, ok := ast.Options["provider"]
 	if !ok {
-		return nil, errors.New("Missing provider name for resources to generate schema")
+		return nil, errors.New("missing provider name for resources to generate schema")
 	}
 
 	res := &resources.Schema{
@@ -77,6 +77,9 @@ func Schema(ast *LR) (*resources.Schema, error) {
 					Id:          rem,
 					Fields:      map[string]*resources.Field{},
 					IsExtension: true,
+					// Resource extensions do not set the provider. They are here to
+					// indicate that it bridges the resource chain, but it cannot
+					// initialize this resource! This is why no provider is set.
 				}
 				res.Resources[rem] = child
 			}

--- a/providers-sdk/v1/lr/schema_test.go
+++ b/providers-sdk/v1/lr/schema_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package lr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/providers-sdk/v1/resources"
+	"go.mondoo.com/cnquery/types"
+)
+
+const provider = "🐱"
+
+func schemaFor(t *testing.T, s string) *resources.Schema {
+	ast := parse(t, s)
+	ast.Options = map[string]string{"provider": provider}
+	res, err := Schema(ast)
+	require.NoError(t, err)
+	return res
+}
+
+func TestSchema(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		res := schemaFor(t, "")
+		assert.Empty(t, res.Resources)
+	})
+
+	t.Run("chain resource creation", func(t *testing.T) {
+		res := schemaFor(t, `
+			platform.has.name {}
+		`)
+		require.NotEmpty(t, res.Resources)
+		require.Equal(t, &resources.ResourceInfo{
+			Id:          "platform",
+			IsExtension: true,
+			Fields: map[string]*resources.Field{
+				"has": {
+					Name:     "has",
+					Type:     string(types.Resource("platform.has")),
+					Provider: provider,
+				},
+			},
+		}, res.Resources["platform"])
+	})
+}


### PR DESCRIPTION
These are resources without providers, e.g. `my.name.is.bob` as a resource creates the bridge resources `my`, `my.name` and `my.name.is`. These cannot be created in the provider that created `my.name.is.bob` because they are only bridging in nature. That said, users should still be able to type `my.name` and not be greeted by crimson letters desperately proclaiming an error. Not helpful.

This PR not only adds support for this mechanism but also adds more testing to LR generation.