### PR TITLE
🐛 os.Connect should not return the asset in the inventory

### DIFF
--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -206,14 +206,6 @@ func (s *Service) Connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 		}
 	}
 
-	if inv == nil {
-		inv = &inventory.Inventory{
-			Spec: &inventory.InventorySpec{
-				Assets: []*inventory.Asset{req.Asset},
-			},
-		}
-	}
-
 	return &plugin.ConnectRes{
 		Id:        uint32(conn.ID()),
 		Name:      conn.Name(),


### PR DESCRIPTION
The behavior of the connect call is defined in the proto here: https://github.com/mondoohq/cnquery/blob/main/providers-sdk/v1/plugin/plugin.proto\#L35-L38 It clarifies that the inventory only returns other discovered assets, while the asset field contains the one asset that the connection call was requesting.

Remove the code that added the connection asset to the inventory, since it does not count as a discovered asset.