### PR TITLE
🐛 fix running on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,15 @@ ifndef VERSION
 VERSION=${LATEST_VERSION_TAG}+$(shell git rev-list --count HEAD)
 endif
 
+ifndef TARGETOS
+	TARGETOS = $(shell go env GOOS)
+endif
+
+BIN_SUFFIX = ""
+ifeq ($(TARGETOS),windows)
+	BIN_SUFFIX=".exe"
+endif
+
 LDFLAGS=-ldflags "-s -w -X go.mondoo.com/cnquery.Version=${VERSION} -X go.mondoo.com/cnquery.Build=${TAG}" # -linkmode external -extldflags=-static
 LDFLAGSDIST=-tags production -ldflags "-s -w -X go.mondoo.com/cnquery.Version=${LATEST_VERSION_TAG} -X go.mondoo.com/cnquery.Build=${TAG} -s -w"
 
@@ -59,15 +68,6 @@ prep/tools:
 #   🌙 MQL/MOTOR   #
 
 cnquery/generate: clean/proto llx/generate shared/generate providers explorer/generate
-
-ifndef TARGETOS
-	TARGETOS = $(shell go env GOOS)
-endif
-
-BIN_SUFFIX = ""
-ifeq ($(TARGETOS),windows)
-	BIN_SUFFIX=".exe"
-endif
 
 define buildProvider
 	$(eval $@_HOME = $(1))

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,15 @@ prep/tools:
 
 cnquery/generate: clean/proto llx/generate shared/generate providers explorer/generate
 
+ifndef TARGETOS
+	TARGETOS = $(shell go env GOOS)
+endif
+
+BIN_SUFFIX = ""
+ifeq ($(TARGETOS),windows)
+	BIN_SUFFIX=".exe"
+endif
+
 define buildProvider
 	$(eval $@_HOME = $(1))
 	$(eval $@_NAME = $(shell basename ${$@_HOME}))
@@ -73,7 +82,7 @@ define buildProvider
 	echo "--> [${$@_NAME}] generate CLI json"
 	cd ${$@_HOME} && go run ./gen/main.go .
 	echo "--> [${$@_NAME}] creating ${$@_BIN}"
-	cd ${$@_HOME} && go build -o ${$@_DIST_BIN} ./main.go
+	cd ${$@_HOME} && GOOS=${TARGETOS} go build -o ${$@_DIST_BIN}${BIN_SUFFIX} ./main.go
 endef
 
 define installProvider
@@ -461,7 +470,7 @@ cnquery/build/linux:
 
 .PHONY: cnquery/build/windows
 cnquery/build/windows:
-	GOOS=windows go build ${LDFLAGSDIST} apps/cnquery/cnquery.go
+	GOOS=windows GOARCH=amd64 go build ${LDFLAGSDIST} apps/cnquery/cnquery.go
 
 cnquery/build/darwin:
 	GOOS=darwin go build ${LDFLAGSDIST} apps/cnquery/cnquery.go

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -95,12 +95,13 @@ func ListAll() ([]*Provider, error) {
 		if HomePath != "" {
 			msg = msg.Str("home-path", HomePath)
 		}
+		msg.Msg("can't find any paths for providers, none are configured")
 	}
 
 	if sysOk {
 		cur, err := findProviders(SystemPath)
 		if err != nil {
-			log.Warn().Str("path", SystemPath).Msg("failed to get providers from system path")
+			log.Warn().Str("path", SystemPath).Err(err).Msg("failed to get providers from system path")
 		}
 		all = append(all, cur...)
 	}
@@ -108,7 +109,7 @@ func ListAll() ([]*Provider, error) {
 	if homeOk {
 		cur, err := findProviders(HomePath)
 		if err != nil {
-			log.Warn().Str("path", HomePath).Msg("failed to get providers from home path")
+			log.Warn().Str("path", HomePath).Err(err).Msg("failed to get providers from home path")
 		}
 		all = append(all, cur...)
 	}
@@ -428,7 +429,8 @@ func isOverlyPermissive(path string) (bool, error) {
 	}
 
 	mode := stat.Mode()
-	if mode&0o022 != 0 {
+	// We don't check the permissions for windows
+	if runtime.GOOS != "windows" && mode&0o022 != 0 {
 		return true, nil
 	}
 
@@ -476,6 +478,9 @@ func findProviders(path string) ([]*Provider, error) {
 func readProviderDir(pdir string) (*Provider, error) {
 	name := filepath.Base(pdir)
 	bin := filepath.Join(pdir, name)
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
 	conf := filepath.Join(pdir, name+".json")
 	resources := filepath.Join(pdir, name+".resources.json")
 
@@ -484,11 +489,11 @@ func readProviderDir(pdir string) (*Provider, error) {
 		return nil, nil
 	}
 	if !config.ProbeFile(conf) {
-		log.Debug().Str("path", bin).Msg("ignoring provider, can't access the plugin config")
+		log.Debug().Str("path", conf).Msg("ignoring provider, can't access the plugin config")
 		return nil, nil
 	}
 	if !config.ProbeFile(resources) {
-		log.Debug().Str("path", bin).Msg("ignoring provider, can't access the plugin schema")
+		log.Debug().Str("path", resources).Msg("ignoring provider, can't access the plugin schema")
 		return nil, nil
 	}
 
@@ -527,7 +532,11 @@ func (p *Provider) LoadResources() error {
 }
 
 func (p *Provider) binPath() string {
-	return filepath.Join(p.Path, p.Name)
+	name := p.Name
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	return filepath.Join(p.Path, name)
 }
 
 func (p Providers) ForConnection(name string) *Provider {


### PR DESCRIPTION
- [x] skip permissions checks for cnquery config on windows
- [x] allow building providers for windows on non-Windows machine
- [x] make sure provider binaries end up on `.exe` for Windows
- [x] if the runtime is Windows look for `.exe` binaries of providers

```
PS C:\Users\ivan\Desktop> .\cnquery.exe run local -c os.name
→ no Mondoo configuration file provided, using defaults
os.name: "IVAN-WIN"
```