### PR TITLE
🐛 add all default providers

### DIFF
--- a/providers/defaults.go
+++ b/providers/defaults.go
@@ -20,6 +20,50 @@ func DefaultRuntime() *Runtime {
 // to tell users what providers are used for common connections, when there
 // is no other way to find out.
 var DefaultProviders Providers = map[string]*Provider{
+	"gcp": {
+		Provider: &plugin.Provider{
+			Name: "gcp",
+			Connectors: []plugin.Connector{
+				{
+					Name:  "gcp",
+					Short: "GCP Cloud",
+				},
+			},
+		},
+	},
+	"ipmi": {
+		Provider: &plugin.Provider{
+			Name: "ipmi",
+			Connectors: []plugin.Connector{
+				{
+					Name:  "ipmi",
+					Short: "Ipmi",
+				},
+			},
+		},
+	},
+	"arista": {
+		Provider: &plugin.Provider{
+			Name: "arista",
+			Connectors: []plugin.Connector{
+				{
+					Name:  "arista",
+					Short: "Arista EOS",
+				},
+			},
+		},
+	},
+	"terraform": {
+		Provider: &plugin.Provider{
+			Name: "terraform",
+			Connectors: []plugin.Connector{
+				{
+					Name:  "terraform",
+					Short: "a terraform hcl file or directory.",
+				},
+			},
+		},
+	},
 	"os": {
 		Provider: &plugin.Provider{
 			Name: "os",
@@ -38,7 +82,147 @@ var DefaultProviders Providers = map[string]*Provider{
 				},
 				{
 					Name:  "vagrant",
-					Short: "a Vagrant virtual machine",
+					Short: "a Vagrant host",
+				},
+				{
+					Name:  "container",
+					Short: "a running container or container image",
+				},
+				{
+					Name:  "filesystem",
+					Short: "a mounted file system target.",
+				},
+			},
+		},
+	},
+	"vsphere": {
+		Provider: &plugin.Provider{
+			Name: "vsphere",
+			Connectors: []plugin.Connector{
+				{
+					Name:  "vsphere",
+					Short: "VMware vSphere",
+				},
+			},
+		},
+	},
+	"google-workspace": {
+		Provider: &plugin.Provider{
+			Name: "google-workspace",
+			Connectors: []plugin.Connector{
+				{
+					Name:  "google-workspace",
+					Short: "Google Workspace",
+				},
+			},
+		},
+	},
+	"opcua": {
+		Provider: &plugin.Provider{
+			Name: "opcua",
+			Connectors: []plugin.Connector{
+				{
+					Name:  "opcua",
+					Short: "OPC UA",
+				},
+			},
+		},
+	},
+	"okta": {
+		Provider: &plugin.Provider{
+			Name: "okta",
+			Connectors: []plugin.Connector{
+				{
+					Name:  "okta",
+					Short: "Okta",
+				},
+			},
+		},
+	},
+	"slack": {
+		Provider: &plugin.Provider{
+			Name: "slack",
+			Connectors: []plugin.Connector{
+				{
+					Name:  "slack",
+					Short: "slack team",
+				},
+			},
+		},
+	},
+	"github": {
+		Provider: &plugin.Provider{
+			Name: "github",
+			Connectors: []plugin.Connector{
+				{
+					Name:  "github",
+					Short: "GitHub",
+				},
+			},
+		},
+	},
+	"equinix": {
+		Provider: &plugin.Provider{
+			Name: "equinix",
+			Connectors: []plugin.Connector{
+				{
+					Name:  "equinix",
+					Short: "Equinix Metal",
+				},
+			},
+		},
+	},
+	"k8s": {
+		Provider: &plugin.Provider{
+			Name: "k8s",
+			Connectors: []plugin.Connector{
+				{
+					Name:  "k8s",
+					Short: "a Kubernetes cluster or local manifest file(s).",
+				},
+			},
+		},
+	},
+	"vcd": {
+		Provider: &plugin.Provider{
+			Name: "vcd",
+			Connectors: []plugin.Connector{
+				{
+					Name:  "vcd",
+					Short: "VMware Cloud Director",
+				},
+			},
+		},
+	},
+	"aws": {
+		Provider: &plugin.Provider{
+			Name: "aws",
+			Connectors: []plugin.Connector{
+				{
+					Name:  "aws",
+					Short: "aws account",
+				},
+			},
+		},
+	},
+	"gitlab": {
+		Provider: &plugin.Provider{
+			Name: "gitlab",
+			Connectors: []plugin.Connector{
+				{
+					Name:  "gitlab",
+					Short: "GitLab",
+				},
+			},
+		},
+	},
+	"oci": {
+		Provider: &plugin.Provider{
+			Name: "oci",
+			Connectors: []plugin.Connector{
+				{
+					Name:  "oci",
+					Short: "Oracle Cloud Infrastructure",
 				},
 			},
 		},
@@ -49,7 +233,29 @@ var DefaultProviders Providers = map[string]*Provider{
 			Connectors: []plugin.Connector{
 				{
 					Name:  "host",
-					Short: "your local system",
+					Short: "a remote host",
+				},
+			},
+		},
+	},
+	"ms365": {
+		Provider: &plugin.Provider{
+			Name: "ms365",
+			Connectors: []plugin.Connector{
+				{
+					Name:  "ms365",
+					Short: "ms365",
+				},
+			},
+		},
+	},
+	"azure": {
+		Provider: &plugin.Provider{
+			Name: "azure",
+			Connectors: []plugin.Connector{
+				{
+					Name:  "azure",
+					Short: "azure",
 				},
 			},
 		},


### PR DESCRIPTION
Without these, an installation without providers in the very early stage does not know what to install. With this, they know what to install. Example: remove all provider plugins and try `cnquery shell aws`.