### PR TITLE
🐛 fix aliased resources

### DIFF
--- a/mql/mql_test.go
+++ b/mql/mql_test.go
@@ -133,3 +133,24 @@ func TestMqlIfAndProps(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, nil, value.Value)
 }
+
+func TestResourceAliases(t *testing.T) {
+	x := testutils.InitTester(testutils.LinuxMock())
+	x.TestSimple(t, []testutils.SimpleTest{
+		{
+			Code:        "os.unix.sshd.config.file.path",
+			ResultIndex: 0,
+			Expectation: "/etc/ssh/sshd_config",
+		},
+		{
+			Code:        "os.unix.sshd { config.file.path }",
+			ResultIndex: 0,
+			Expectation: map[string]interface{}{
+				"_":   llx.ResourceData(&llx.MockResource{Name: "sshd"}, "os.unix.sshd"),
+				"__s": llx.NilData,
+				"__t": llx.BoolData(true),
+				"k6rlXoYpV48Qd19gKeNl+/IiPnkI5VNQBiqZBca3gDKsIRiLcpXQUlDv52x9sscIWiqOMpC7+x/aBpY0IUq0ww==": llx.StringData("/etc/ssh/sshd_config"),
+			},
+		},
+	})
+}

--- a/providers-sdk/v1/lr/schema.go
+++ b/providers-sdk/v1/lr/schema.go
@@ -86,13 +86,14 @@ func Schema(ast *LR) (*resources.Schema, error) {
 
 			if _, ok := child.Fields[basename]; !ok {
 				child.Fields[basename] = &resources.Field{
-					Name:        basename,
-					Type:        string(types.Resource(resource)),
-					IsMandatory: false, // it cannot be mandatory if we create it here
-					IsPrivate:   isPrivate,
-					Title:       fieldInfo.Title,
-					Desc:        fieldInfo.Desc,
-					Provider:    provider,
+					Name:               basename,
+					Type:               string(types.Resource(resource)),
+					IsMandatory:        false, // it cannot be mandatory if we create it here
+					IsImplicitResource: true,
+					IsPrivate:          isPrivate,
+					Title:              fieldInfo.Title,
+					Desc:               fieldInfo.Desc,
+					Provider:           provider,
 				}
 			}
 

--- a/providers-sdk/v1/lr/schema_test.go
+++ b/providers-sdk/v1/lr/schema_test.go
@@ -38,9 +38,10 @@ func TestSchema(t *testing.T) {
 			IsExtension: true,
 			Fields: map[string]*resources.Field{
 				"has": {
-					Name:     "has",
-					Type:     string(types.Resource("platform.has")),
-					Provider: provider,
+					Name:               "has",
+					Type:               string(types.Resource("platform.has")),
+					Provider:           provider,
+					IsImplicitResource: true,
 				},
 			},
 		}, res.Resources["platform"])

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -222,10 +222,14 @@ func (r *Runtime) Connect(req *plugin.ConnectReq) error {
 }
 
 func (r *Runtime) CreateResource(name string, args map[string]*llx.Primitive) (llx.Resource, error) {
-	provider, _, err := r.lookupResourceProvider(name)
+	provider, info, err := r.lookupResourceProvider(name)
 	if err != nil {
 		return nil, err
 	}
+	if info == nil {
+		return nil, errors.New("cannot create '" + name + "', no resource info found")
+	}
+	name = info.Id
 
 	// Resources without providers are bridging resources only. They are static in nature.
 	if provider == nil {


### PR DESCRIPTION
We could no longer call aliased resource properly. This was partly because the way the schema generation had changed (where I missed to migrate the `IsImplicitResource` field) and partly because the resource lookup had also changed (since we want to call the base resource now with the provider, not the alias).