### PR TITLE
⭐ add simple accessors for dicts

### DIFF
--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -1096,6 +1096,21 @@ func (c *compiler) compileBoundIdentifierWithoutMqlCtx(id string, binding *varia
 		return true, typ, err
 	}
 
+	// Support easy accessors for dicts and maps, e.g:
+	// json.params.A.B.C => json.params["A"]["B"]["C"]
+	if typ == types.Dict {
+		c.addChunk(&llx.Chunk{
+			Call: llx.Chunk_FUNCTION,
+			Id:   "[]",
+			Function: &llx.Function{
+				Type:    string(typ),
+				Binding: binding.ref,
+				Args:    []*llx.Primitive{llx.StringPrimitive(id)},
+			},
+		})
+		return true, typ, nil
+	}
+
 	return false, types.Nil, nil
 }
 

--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -1096,21 +1096,6 @@ func (c *compiler) compileBoundIdentifierWithoutMqlCtx(id string, binding *varia
 		return true, typ, err
 	}
 
-	// Support easy accessors for dicts and maps, e.g:
-	// json.params.A.B.C => json.params["A"]["B"]["C"]
-	if typ == types.Dict {
-		c.addChunk(&llx.Chunk{
-			Call: llx.Chunk_FUNCTION,
-			Id:   "[]",
-			Function: &llx.Function{
-				Type:    string(typ),
-				Binding: binding.ref,
-				Args:    []*llx.Primitive{llx.StringPrimitive(id)},
-			},
-		})
-		return true, typ, nil
-	}
-
 	return false, types.Nil, nil
 }
 
@@ -1279,6 +1264,22 @@ func (c *compiler) compileIdentifier(id string, callBinding *variable, calls []*
 	found, restCalls, typ, err = c.compileResource(id, calls)
 	if found {
 		return restCalls, typ, err
+	}
+
+	// Support easy accessors for dicts and maps, e.g:
+	// json.params { A.B.C } => json.params { _["A"]["B"]["C"] }
+	if callBinding != nil && callBinding.typ == types.Dict {
+		c.addChunk(&llx.Chunk{
+			Call: llx.Chunk_FUNCTION,
+			Id:   "[]",
+			Function: &llx.Function{
+				Type:    string(callBinding.typ),
+				Binding: callBinding.ref,
+				Args:    []*llx.Primitive{llx.StringPrimitive(id)},
+			},
+		})
+		c.standalone = false
+		return restCalls, callBinding.typ, err
 	}
 
 	// suggestions
@@ -1525,11 +1526,26 @@ func (c *compiler) compileOperand(operand *parser.Operand) (*llx.Primitive, erro
 				return nil, err
 			}
 			if !found {
-				addFieldSuggestions(availableFields(c, typ), id, c.Result)
-				return nil, errors.New("cannot find field '" + id + "' in " + typ.Label())
+				if typ != types.Dict || !reAccessor.MatchString(id) {
+					addFieldSuggestions(availableFields(c, typ), id, c.Result)
+					return nil, errors.New("cannot find field '" + id + "' in " + typ.Label())
+				}
+
+				// Support easy accessors for dicts and maps, e.g:
+				// json.params.A.B.C => json.params["A"]["B"]["C"]
+				c.addChunk(&llx.Chunk{
+					Call: llx.Chunk_FUNCTION,
+					Id:   "[]",
+					Function: &llx.Function{
+						Type:    string(typ),
+						Binding: ref,
+						Args:    []*llx.Primitive{llx.StringPrimitive(id)},
+					},
+				})
+			} else {
+				typ = resType
 			}
 
-			typ = resType
 			if call != nil && len(calls) > 0 {
 				calls = calls[1:]
 			}

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -466,6 +466,40 @@ func TestCompiler_Props(t *testing.T) {
 	})
 }
 
+func TestCompiler_Dict(t *testing.T) {
+	compileProps(t, "props.d.A.B", map[string]*llx.Primitive{
+		"d": {Type: string(types.Dict)},
+	}, func(res *llx.CodeBundle) {
+		assertProperty(t, "d", types.Dict, res.CodeV2.Blocks[0].Chunks[0])
+		assert.Equal(t, []uint64{(1 << 32) | 3}, res.CodeV2.Entrypoints())
+		assertFunction(t, "[]", &llx.Function{
+			Type:    string(types.Dict),
+			Binding: (1 << 32) | 1,
+			Args:    []*llx.Primitive{llx.StringPrimitive("A")},
+		}, res.CodeV2.Blocks[0].Chunks[1])
+		assertFunction(t, "[]", &llx.Function{
+			Type:    string(types.Dict),
+			Binding: (1 << 32) | 2,
+			Args:    []*llx.Primitive{llx.StringPrimitive("B")},
+		}, res.CodeV2.Blocks[0].Chunks[2])
+		assert.Equal(t, map[string]string{"d": string(types.Dict)}, res.Props)
+	})
+
+	compileProps(t, "props.d.A-1", map[string]*llx.Primitive{
+		"d": {Type: string(types.Dict)},
+	}, func(res *llx.CodeBundle) {
+		assertProperty(t, "d", types.Dict, res.CodeV2.Blocks[0].Chunks[0])
+		assert.Equal(t, []uint64{(1 << 32) | 2, (1 << 32) | 3}, res.CodeV2.Entrypoints())
+		assertFunction(t, "[]", &llx.Function{
+			Type:    string(types.Dict),
+			Binding: (1 << 32) | 1,
+			Args:    []*llx.Primitive{llx.StringPrimitive("A")},
+		}, res.CodeV2.Blocks[0].Chunks[1])
+		assertPrimitive(t, llx.IntPrimitive(-1), res.CodeV2.Blocks[0].Chunks[2])
+		assert.Equal(t, map[string]string{"d": string(types.Dict)}, res.Props)
+	})
+}
+
 func TestCompiler_If(t *testing.T) {
 	compileT(t, "if ( true ) { return 1 } else if ( false ) { return 2 } else { return 3 }", func(res *llx.CodeBundle) {
 		assertFunction(t, "if", &llx.Function{

--- a/providers/os/resources/parse.go
+++ b/providers/os/resources/parse.go
@@ -114,7 +114,7 @@ func (s *mqlParseJson) id() (string, error) {
 }
 
 func (s *mqlParseJson) content(file *mqlFile) (string, error) {
-	c := file.Content
+	c := file.GetContent()
 	return c.Data, c.Error
 }
 


### PR DESCRIPTION
Accessing dict structures sometimes feels a bit painful:

```coffee
dict["one"]["more"]["field"]
```

Luckily for us, this pattern is well-known in the framework that birthed the scripting part of MQL: JS.

With that in mind:

```coffee
dict.one.more.field
```

is a much better way of expressing this use-case.

Now: combine this with the power of GraphQL, and all of a sudden you get something like this:

```coffee
dict {
  one {
    more.field
  }
  another
}
```

Here is an example of using it in this repo:

```graphql
{
  Name 
  Version 
  Connectors {
    Name 
    Short
  }
}
```

If we run it like this:

```bash
cnquery run -c "parse.json('providers/os/dist/os.json').params{Name Version Connectors {Name Short}} --json"
```

and prettify the output:

![image](https://github.com/mondoohq/cnquery/assets/1307529/195090b7-4c4e-40aa-83a7-f1744252032e)
