### PR TITLE
🐛 support --record on scan command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -110,8 +110,9 @@
         "scan",
         // "local",
         "-f",
-        "./examples/os.mql.yaml"
-      ],
+        "examples/os.mql.yaml",
+        // "--record", "a.json"
+      ]
     },
     // gcp.project.kms.keyrings
     {

--- a/apps/cnquery/cmd/run.go
+++ b/apps/cnquery/cmd/run.go
@@ -41,7 +41,6 @@ var RunCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *plu
 	conf.Command, _ = cmd.Flags().GetString("command")
 	conf.DoAst, _ = cmd.Flags().GetBool("ast")
 	conf.DoParse, _ = cmd.Flags().GetBool("parse")
-	conf.DoRecord, _ = cmd.Flags().GetBool("record")
 	if doJSON, _ := cmd.Flags().GetBool("json"); doJSON {
 		conf.Format = "json"
 	}


### PR DESCRIPTION
Note: there is a bug where it does not associate the correct asset, because we reconnect and the ID of the asset is wrong. Will be fixed...