### PR TITLE
🐛 support null resources

### DIFF
--- a/cli/printer/mql.go
+++ b/cli/printer/mql.go
@@ -449,6 +449,10 @@ func (print *Printer) autoExpand(blockRef uint64, data interface{}, bundle *llx.
 		return res.String()
 	}
 
+	if data == nil {
+		return print.Secondary("null")
+	}
+
 	m, ok := data.(map[string]interface{})
 	if !ok {
 		return "data is not a map to auto-expand"

--- a/providers-sdk/v1/plugin/runtime.go
+++ b/providers-sdk/v1/plugin/runtime.go
@@ -170,13 +170,16 @@ func (x *TValue[T]) ToDataRes(typ types.Type) *DataRes {
 		return &DataRes{}
 	}
 	if x.State&StateIsNull != 0 {
-		res := &DataRes{
-			Data: &llx.Primitive{Type: string(typ)},
-		}
 		if x.Error != nil {
-			res.Error = x.Error.Error()
+			return &DataRes{
+				Error: x.Error.Error(),
+				Data:  &llx.Primitive{Type: string(typ)},
+			}
 		}
-		return res
+
+		return &DataRes{
+			Data: &llx.Primitive{Type: string(types.Nil)},
+		}
 	}
 	raw := llx.RawData{Type: typ, Value: x.Data, Error: x.Error}
 	res := raw.Result()


### PR DESCRIPTION
An example for how this works using the `user` resource and setting its `group` field to null:

```go
func (x *mqlUser) group(gid int64) (*mqlGroup, error) {
  x.Group.State = plugin.StateIsSet|plugin.StateIsNull
  return nil, nil
}
```

Once you set the field internally (`StateIsSet`), it will ignore the return values and instead read it from the field that you set. Then it will see `StateIsNull` and use it on the return data