### PR TITLE
🐛 support semicolons in blocks

### DIFF
--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -763,6 +763,11 @@ func TestCompiler_Switch(t *testing.T) {
 		assert.Equal(t, []uint64{(1 << 32) | 3}, res.CodeV2.Entrypoints())
 		assert.Empty(t, res.CodeV2.Datapoints())
 	})
+
+	compileT(t, "switch { case 3 > 2: 123; default: 321 }", func(res *llx.CodeBundle) {
+		assert.Equal(t, []uint64{(1 << 32) | 3}, res.CodeV2.Entrypoints())
+	})
+
 	t.Run("test types fall back to any", func(t *testing.T) {
 		compileT(t, "switch ( 1 ) { case _ > 0: true; case _ < 0: 'test'; default: false }", func(res *llx.CodeBundle) {
 			assert.Equal(t, types.Any, res.CodeV2.Blocks[0].Chunks[3].Type())

--- a/mqlc/parser/parser.go
+++ b/mqlc/parser/parser.go
@@ -652,6 +652,7 @@ func (p *parser) parseOperand() (*Operand, bool, error) {
 							},
 						},
 					}
+
 					for {
 						exp, err := p.parseExpression()
 						if err != nil {
@@ -661,16 +662,15 @@ func (p *parser) parseOperand() (*Operand, bool, error) {
 							break
 						}
 						block.Operand.Block = append(block.Operand.Block, exp)
+						if p.token.Value == "case" || p.token.Value == "default" {
+							break
+						}
 					}
 
 					if len(block.Operand.Block) == 0 {
 						return nil, false, errors.New("expected block following `" + ident + "` statement")
 					}
 					res.Block = append(res.Block, &block)
-
-					for p.token.Value == ";" {
-						p.nextToken()
-					}
 				}
 
 				p.nextToken()

--- a/mqlc/parser/parser.go
+++ b/mqlc/parser/parser.go
@@ -852,6 +852,10 @@ func (p *parser) parseExpression() (*Expression, error) {
 		return p.flushExpression(), err
 	}
 
+	for p.token.Value == ";" {
+		p.nextToken()
+	}
+
 	return &res, err
 }
 


### PR DESCRIPTION
We were not able to call things like `mondoo { version ; build }` cleanly. Fix it.