### PR TITLE
🐛 store+load recordings with errors

### DIFF
--- a/llx/rawdata_test.go
+++ b/llx/rawdata_test.go
@@ -4,10 +4,13 @@
 package llx
 
 import (
+	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mondoo.com/cnquery/types"
 )
 
@@ -169,6 +172,40 @@ func TestSuccess(t *testing.T) {
 			success, valid := o.data.IsSuccess()
 			assert.Equal(t, o.success, success)
 			assert.Equal(t, o.valid, valid)
+		})
+	}
+}
+
+func TestRawData_JSON(t *testing.T) {
+	tests := []*RawData{
+		NilData,
+		BoolTrue,
+		BoolFalse,
+		IntData(0),
+		IntData(123),
+		FloatData(0),
+		FloatData(1.23),
+		StringData(""),
+		StringData("b"),
+		RegexData(""),
+		RegexData("r"),
+		TimeData(time.Time{}),
+		// TODO: the raw comparison here does not come out right, because of nano time
+		// TimeData(now),
+		ArrayData([]interface{}{"a", "b"}, types.String),
+		MapData(map[string]interface{}{"a": "b"}, types.String),
+		{Error: errors.New("test")},
+	}
+
+	for i := range tests {
+		o := tests[i]
+		t.Run(o.String(), func(t *testing.T) {
+			out, err := json.Marshal(o)
+			require.NoError(t, err)
+			var res RawData
+			err = json.Unmarshal(out, &res)
+			require.NoError(t, err)
+			assert.Equal(t, o, &res)
 		})
 	}
 }

--- a/providers/recording.go
+++ b/providers/recording.go
@@ -174,7 +174,6 @@ func LoadRecordingFile(path string) (*recording, error) {
 
 	pres := &res
 	pres.refreshCache()
-	pres.fixTypes()
 
 	if err = pres.reconnectResources(); err != nil {
 		return nil, err
@@ -227,26 +226,6 @@ func (r *recording) refreshCache() {
 			if conn.id != 0 {
 				r.assets[conn.id] = asset
 			}
-		}
-	}
-}
-
-// json during the unmarshal step will load some things in a way that we
-// can't process. For example: numbers are loaded as float64, but can also
-// be int64's in MQL. This fixes the loaded types.
-func (r *recording) fixTypes() {
-	for i := range r.Assets {
-		asset := r.Assets[i]
-		for j := range asset.Resources {
-			fixResourceTypes(&asset.Resources[j])
-		}
-	}
-}
-
-func fixResourceTypes(r *resourceRecording) {
-	for _, v := range r.Fields {
-		if v.Type == types.Int {
-			v.Value = int64(v.Value.(float64))
 		}
 	}
 }

--- a/providers/recording.go
+++ b/providers/recording.go
@@ -267,6 +267,12 @@ func (r *recording) reconnectResources() error {
 func (r *recording) reconnectResource(asset *assetRecording, resource *resourceRecording) error {
 	var err error
 	for k, v := range resource.Fields {
+		if v.Error != nil {
+			// in this case we have neither type information nor a value
+			resource.Fields[k].Error = v.Error
+			continue
+		}
+
 		typ := types.Type(v.Type)
 		resource.Fields[k].Value, err = tryReconnect(typ, v.Value, resource)
 		if err != nil {


### PR DESCRIPTION
Up until this point, errors were marshalled into `error:{}` into JSON files. This caused problems when trying to load the structure (because the error type is not familiar with empty object).

This fixes the issue in the RawData to JSON marshal/unmarshal calls and additionally handles type problems for int (which is by default read as a float) and time (which is read as a string). It also fixes a problem with reconnecting resources when the field in question is an error.