### PR TITLE
🐛 fix missing slack team name

### DIFF
--- a/providers/slack/connection/connection.go
+++ b/providers/slack/connection/connection.go
@@ -53,6 +53,7 @@ func NewSlackConnection(id uint32, asset *inventory.Asset, conf *inventory.Confi
 
 	sc.client = client
 	sc.teamInfo = teamInfo
+	sc.asset.Name = teamInfo.Name
 	return sc, nil
 }
 


### PR DESCRIPTION
local and ssh are also missing asset name --- i think it's because we didn't port over all the id detection stuff we had in v8...looking into it