### PR TITLE
🐛 fix incorrect os-connection + 🧹 add os builtin

### DIFF
--- a/providers-sdk/v1/util/configure/configure.go
+++ b/providers-sdk/v1/util/configure/configure.go
@@ -107,10 +107,15 @@ import (
 
 	coreconf "go.mondoo.com/cnquery/providers/core/config"
 	core "go.mondoo.com/cnquery/providers/core/provider"
+	// osconf "go.mondoo.com/cnquery/providers/os/config"
+	// os "go.mondoo.com/cnquery/providers/os/provider"
 %s)
 
 //go:embed core/resources/core.resources.json
 var coreInfo []byte
+
+// //go:embed os/resources/os.resources.json
+// var osInfo []byte
 
 %s
 var builtinProviders = map[string]*builtinProvider{
@@ -124,6 +129,16 @@ var builtinProviders = map[string]*builtinProvider{
 		},
 		Config: &coreconf.Config,
 	},
+	// osconf.Config.ID: {
+	// 	Runtime: &RunningProvider{
+	// 		Name:     osconf.Config.Name,
+	// 		ID:       osconf.Config.ID,
+	// 		Plugin:   os.Init(),
+	// 		Schema:   MustLoadSchema("os", osInfo),
+	// 		isClosed: false,
+	// 	},
+	// 	Config: &osconf.Config,
+	// },
 %s
 }
 `

--- a/providers/builtin.go
+++ b/providers/builtin.go
@@ -15,10 +15,15 @@ import (
 
 	coreconf "go.mondoo.com/cnquery/providers/core/config"
 	core "go.mondoo.com/cnquery/providers/core/provider"
+	// osconf "go.mondoo.com/cnquery/providers/os/config"
+	// os "go.mondoo.com/cnquery/providers/os/provider"
 )
 
 //go:embed core/resources/core.resources.json
 var coreInfo []byte
+
+// //go:embed os/resources/os.resources.json
+// var osInfo []byte
 
 var builtinProviders = map[string]*builtinProvider{
 	coreconf.Config.ID: {
@@ -31,4 +36,14 @@ var builtinProviders = map[string]*builtinProvider{
 		},
 		Config: &coreconf.Config,
 	},
+	// osconf.Config.ID: {
+	// 	Runtime: &RunningProvider{
+	// 		Name:     osconf.Config.Name,
+	// 		ID:       osconf.Config.ID,
+	// 		Plugin:   os.Init(),
+	// 		Schema:   MustLoadSchema("os", osInfo),
+	// 		isClosed: false,
+	// 	},
+	// 	Config: &osconf.Config,
+	// },
 }

--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -15,7 +15,6 @@ var Config = plugin.Provider{
 	ConnectionTypes: []string{
 		provider.LocalConnectionType,
 		provider.SshConnectionType,
-		provider.MockConnectionType,
 		provider.TarConnectionType,
 		provider.DockerSnapshotConnectionType,
 		provider.VagrantConnectionType,


### PR DESCRIPTION
- the os provider does not support the mock connection
- add back the builtin comments for the os provider, since we still use it (until it gets wired into its own go.mod)