### PR TITLE
⭐️ gitlab terraform discovery

### DIFF
--- a/apps/cnquery/cmd/builder/common/common.go
+++ b/apps/cnquery/cmd/builder/common/common.go
@@ -690,13 +690,15 @@ func GitlabProviderCmd(commonCmdFlags CommonFlagsFn, preRun CommonPreRunFn, runF
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlag("token", cmd.Flags().Lookup("token"))
 			viper.BindPFlag("group", cmd.Flags().Lookup("group"))
+			viper.BindPFlag("project", cmd.Flags().Lookup("project"))
 			preRun(cmd, args)
 		},
 		Run: runFn,
 	}
 	commonCmdFlags(cmd)
-	cmd.Flags().String("group", "", "a GitLab group to scan")
+	cmd.Flags().String("group", "", "a GitLab group")
 	cmd.MarkFlagRequired("group")
+	cmd.Flags().String("project", "", "a GitLab project")
 	cmd.Flags().String("token", "", "GitLab personal access token")
 	return cmd
 }

--- a/apps/cnquery/cmd/builder/parse.go
+++ b/apps/cnquery/cmd/builder/parse.go
@@ -640,6 +640,12 @@ func ParseTargetAsset(cmd *cobra.Command, args []string, providerType providers.
 			connection.Options["group"] = x
 		}
 
+		if x, err := cmd.Flags().GetString("project"); err != nil {
+			log.Fatal().Err(err).Msg("cannot parse --project value")
+		} else if x != "" {
+			connection.Options["project"] = x
+		}
+
 		if x, err := cmd.Flags().GetString("token"); err != nil {
 			log.Fatal().Err(err).Msg("cannot parse --token value")
 		} else if x != "" {

--- a/motor/providers/terraform/provider_test.go
+++ b/motor/providers/terraform/provider_test.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"go.mondoo.com/cnquery/motor/vault"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,4 +32,18 @@ func TestModuleManifestIssue676(t *testing.T) {
 
 	require.NotNil(t, p.modulesManifest)
 	require.Len(t, p.modulesManifest.Records, 3)
+}
+
+func TestGitCloneUrl(t *testing.T) {
+	cloneUrl, err := gitCloneUrl("git+https://somegitlab.com/vendor/package.git", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "git@somegitlab.com:vendor/package.git", cloneUrl)
+
+	cloneUrl, err = gitCloneUrl("git+https://somegitlab.com/vendor/package.git", []*vault.Credential{{
+		Type:     vault.CredentialType_password,
+		User:     "oauth2",
+		Password: "ACCESS_TOKEN",
+	}})
+	require.NoError(t, err)
+	assert.Equal(t, "https://oauth2:ACCESS_TOKEN@somegitlab.com/vendor/package.git", cloneUrl)
 }


### PR DESCRIPTION
This PR adds the ability to the gitlab provider to detect terraform inside of the git repo.

```bash
cnquery shell gitlab --group example --project example-gitlab
→ loaded configuration from /Users/chris/.config/mondoo/mondoo.yml using source default
→ discover related assets for 1 asset(s)
→ resolved assets resolved-assets=2

    Available assets                               
                                                   
  > 1. example / Example Gitlab (gitlab-project)
    2. example / Example Gitlab (terraform-hcl) 
 ```