### PR TITLE
Revert "✨ Add container discovery to v9 os provider"

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -33,7 +33,7 @@ var Config = plugin.Provider{
 			MinArgs: 0,
 			MaxArgs: 0,
 			Discovery: []string{
-				"container",
+				"containers",
 				"container-images",
 			},
 			Flags: []plugin.Flag{
@@ -170,7 +170,7 @@ var Config = plugin.Provider{
 			MinArgs: 1,
 			MaxArgs: 1,
 			Discovery: []string{
-				"container",
+				"containers",
 				"container-images",
 			},
 			Flags: []plugin.Flag{

--- a/providers/os/connection/docker_container.go
+++ b/providers/os/connection/docker_container.go
@@ -58,9 +58,9 @@ func NewDockerContainerConnection(id uint32, conf *inventory.Config, asset *inve
 	}
 
 	// check if we are having a container
-	data, err := dockerClient.ContainerInspect(context.Background(), conf.Host)
+	data, err := dockerClient.ContainerInspect(context.Background(), asset.Name)
 	if err != nil {
-		return nil, errors.New("cannot find container " + conf.Host)
+		return nil, errors.New("cannot find container " + asset.Name)
 	}
 
 	if !data.State.Running {
@@ -70,7 +70,7 @@ func NewDockerContainerConnection(id uint32, conf *inventory.Config, asset *inve
 	conn := &DockerContainerConnection{
 		asset:     asset,
 		Client:    dockerClient,
-		container: conf.Host,
+		container: asset.Name,
 		kind:      "container",
 		runtime:   "docker",
 	}

--- a/providers/os/resources/discovery/docker_engine/container.go
+++ b/providers/os/resources/discovery/docker_engine/container.go
@@ -132,15 +132,34 @@ func (e *dockerEngineDiscovery) ListContainer() ([]*inventory.Asset, error) {
 
 	container := make([]*inventory.Asset, len(dContainers))
 	for i, dContainer := range dContainers {
+		name := strings.Join(DockerDisplayNames(dContainer.Names), ",")
 		asset := &inventory.Asset{
+			Name:        name,
+			PlatformIds: []string{containerid.MondooContainerID(dContainer.ID)},
+			Platform: &inventory.Platform{
+				Kind:    "container",
+				Runtime: "docker-container",
+			},
 			Connections: []*inventory.Config{
 				{
 					Backend: "docker-engine",
-					Type:    "docker-container",
 					Host:    dContainer.ID,
 				},
 			},
+			State:  mapContainerState(dContainer.State),
+			Labels: make(map[string]string),
 		}
+
+		for key := range dContainer.Labels {
+			asset.Labels[key] = dContainer.Labels[key]
+		}
+
+		// fetch docker specific metadata
+		labels := map[string]string{}
+		labels["mondoo.com/image-id"] = dContainer.ImageID
+		labels["docker.io/image-name"] = dContainer.Image
+		labels["docker.io/names"] = name
+		asset.Labels = labels
 
 		container[i] = asset
 	}

--- a/providers/os/resources/discovery/docker_engine/images.go
+++ b/providers/os/resources/discovery/docker_engine/images.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"go.mondoo.com/cnquery/providers-sdk/v1/inventory"
+	"go.mondoo.com/cnquery/providers/os/id/containerid"
 )
 
 // be aware that images are prefixed with sha256:, while containers are not
@@ -52,13 +53,33 @@ func (e *dockerEngineDiscovery) ListImages() ([]*inventory.Asset, error) {
 		}
 
 		asset := &inventory.Asset{
+			Name:        strings.Join(dImg.RepoTags, ","),
+			PlatformIds: []string{containerid.MondooContainerImageID(digest)},
+			Platform: &inventory.Platform{
+				Kind:    "container-image",
+				Runtime: "docker-image",
+			},
 			Connections: []*inventory.Config{
 				{
-					Type: "docker-image",
-					Host: dImg.ID,
+					Backend: "docker-image",
+					Host:    dImg.ID,
 				},
 			},
+			State: inventory.State_STATE_ONLINE,
 		}
+
+		// update labels
+		labels := map[string]string{}
+		for key := range dImg.Labels {
+			labels[key] = dImg.Labels[key]
+		}
+
+		labels["mondoo.com/image-id"] = dImg.ID
+		// project/repo:5e664d0e,gcr.io/project/repo:5e664d0e
+		labels["docker.io/tags"] = strings.Join(dImg.RepoTags, ",")
+		// gcr.io/project/repo@sha256:5248...2bee
+		labels["docker.io/digests"] = strings.Join(dImg.RepoDigests, ",")
+		asset.Labels = labels
 
 		imgs[i] = asset
 	}

--- a/providers/os/resources/discovery/docker_engine/resolver.go
+++ b/providers/os/resources/discovery/docker_engine/resolver.go
@@ -209,10 +209,6 @@ func DiscoverDockerEngineAssets(conf *inventory.Config) ([]*inventory.Asset, err
 	// the system is using docker or podman locally
 	assetList := []*inventory.Asset{}
 
-	if conf.Discover == nil {
-		return assetList, nil
-	}
-
 	// discover running container: container
 	if stringx.Contains(conf.Discover.Targets, "all") || stringx.Contains(conf.Discover.Targets, DiscoveryContainerRunning) {
 		ded, err := NewDockerEngineDiscovery()


### PR DESCRIPTION
The PR breaks the normal local run right now:

```bash
..go/src/go.mondoo.com/cnquery ±> go run apps/cnquery/cnquery.go shell local                                                                 8m main[0e7b2f9b]
! using builtin provider for os
→ loaded configuration from /home/zero/.config/mondoo/mondoo.yml using source default
FTL could not find an asset that we can connect to
exit status 1

```

Reverts mondoohq/cnquery#1701