### PR TITLE
🐛 revert error on non-existent package, service, and kernel.module

### DIFF
--- a/providers/os/resources/kernel.go
+++ b/providers/os/resources/kernel.go
@@ -322,7 +322,12 @@ func initKernelModule(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 	if res, ok := kernel.moduleByName[name]; ok {
 		return nil, res, nil
 	}
-	return args, nil, nil
+
+	res := &mqlKernelModule{}
+	res.Name = plugin.TValue[string]{Data: name, State: plugin.StateIsSet}
+	res.Size.State = plugin.StateIsSet | plugin.StateIsNull
+	res.Loaded = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	return nil, res, nil
 }
 
 func (k *mqlKernelModule) id() (string, error) {

--- a/providers/os/resources/packages.go
+++ b/providers/os/resources/packages.go
@@ -46,12 +46,23 @@ func initPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 		return nil, nil, err
 	}
 
-	x, found := packages.packagesByName[name]
-	if !found {
-		return nil, nil, errors.New("cannot find package " + name)
+	if res, ok := packages.packagesByName[name]; ok {
+		return nil, res, nil
 	}
 
-	return nil, x, nil
+	res := &mqlPackage{}
+	res.Name = plugin.TValue[string]{Data: name, State: plugin.StateIsSet}
+	res.Installed = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	res.Outdated = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	res.Version.State = plugin.StateIsSet | plugin.StateIsNull
+	res.Epoch.State = plugin.StateIsSet | plugin.StateIsNull
+	res.Available.State = plugin.StateIsSet | plugin.StateIsNull
+	res.Description.State = plugin.StateIsSet | plugin.StateIsNull
+	res.Arch.State = plugin.StateIsSet | plugin.StateIsNull
+	res.Format.State = plugin.StateIsSet | plugin.StateIsNull
+	res.Origin.State = plugin.StateIsSet | plugin.StateIsNull
+	res.Status.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, res, nil
 }
 
 func (p *mqlPackage) status() (string, error) {

--- a/providers/os/resources/services.go
+++ b/providers/os/resources/services.go
@@ -39,12 +39,20 @@ func initService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 		return nil, nil, err
 	}
 
-	srv := services.namedServices[name]
-	if srv == nil {
-		return nil, nil, errors.New("service '" + name + "' does not exist")
+	if srv, ok := services.namedServices[name]; ok {
+		return nil, srv, nil
 	}
 
-	return nil, srv, nil
+	res := &mqlService{}
+	res.Name = plugin.TValue[string]{Data: name, State: plugin.StateIsSet}
+	res.Description.State = plugin.StateIsSet | plugin.StateIsNull
+	res.Installed = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	res.Running = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	res.Enabled = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	res.Type.State = plugin.StateIsSet | plugin.StateIsNull
+	res.Enabled = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	res.Masked = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	return nil, res, nil
 }
 
 func (x *mqlService) id() (string, error) {


### PR DESCRIPTION
This is in line with v8 and would otherwise break a number of existing queries. It is inconsistent with a few other resources (like `user`) and needs further alignment (as descriped in https://github.com/mondoohq/cnquery/issues/1622).

That said, some fields are now null instead of empty strings:

```coffee
cnquery> package("blah"){*}
package: {
  name: "blah"
  version: null
  epoch: null
  available: null
  description: null
  status: null
  outdated: false
  arch: null
  origin: null
  installed: false
  format: null
}

cnquery> service("blah"){*}
service: {
  name: "blah"
  installed: false
  description: null
  type: null
  enabled: false
  running: false
  masked: false
}

cnquery> kernel.module("blah"){*}
kernel.module: {
  size: null
  name: "blah"
  loaded: false
}
```

