### PR TITLE
🐛 Fix errors when scanning container images

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -168,7 +168,7 @@ var Config = plugin.Provider{
 			Use:     "container",
 			Short:   "a running container or container image",
 			MinArgs: 1,
-			MaxArgs: 1,
+			MaxArgs: 2,
 			Discovery: []string{
 				"containers",
 				"container-images",

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -143,7 +143,9 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		conf.Path = string(x.Value)
 	}
 
-	conf.Credentials = append(conf.Credentials, &vault.Credential{Type: vault.CredentialType_ssh_agent, User: user})
+	if user != "" {
+		conf.Credentials = append(conf.Credentials, &vault.Credential{Type: vault.CredentialType_ssh_agent, User: user})
+	}
 
 	asset := &inventory.Asset{
 		Connections: []*inventory.Config{conf},


### PR DESCRIPTION
This fixes two errors:
```
cnquery run container registry gcr.io/mondoo-base-infra/mvd:latest -c "asset{ name platform ids kind runtime title }" --verbose     
Error: accepts 1 arg(s), received 2
...
x accepts 1 arg(s), received 2
```

This check was introduced with https://github.com/mondoohq/cnquery/pull/1503

And
```
cnquery run container registry gcr.io/mondoo-base-infra/mvd:latest -c "asset{ name platform ids kind runtime title }" --verbose 
DBG using provider os with connector container
! using builtin provider for os
→ loaded configuration from /etc/opt/mondoo/mondoo.yml using source default
DBG found valid container registry reference ref=gcr.io/mondoo-base-infra/mvd:latest
! unknown credentials for container image
[
  {
    "type": "ssh_agent"
  }
]
...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x138f0a4]

goroutine 1 [running]:
go.mondoo.com/cnquery/providers/os/resources/discovery/container_registry.AuthOption({0xc00053f698?, 0x1, 0x1}, {0x0, 0x0})
	/home/christian/workspace/mondoo/github.com/cnquery/providers/os/resources/discovery/container_registry/resolver.go:113 +0xc4
go.mondoo.com/cnquery/providers/os/resources/discovery/container_registry.(*Resolver).Resolve(0xc000312fc0?, {0x10a000007?, 0x7?}, 0x0?, 0xc0003101e0, {0x0, 0x0})
	/home/christian/workspace/mondoo/github.com/cnquery/providers/os/resources/discovery/container_registry/resolver.go:54 +0x23a
go.mondoo.com/cnquery/providers/os/provider.(*Service).discover(0xc000610590?, 0xc0000fe900?)
	/home/christian/workspace/mondoo/github.com/cnquery/providers/os/provider/provider.go:446 +0x65
```

The ssh agent was introduced with https://github.com/mondoohq/cnquery/pull/1735