### PR TITLE
🐛 show scan+run+shell as regular commands in --help

### DIFF
--- a/apps/cnquery/cmd/run.go
+++ b/apps/cnquery/cmd/run.go
@@ -33,6 +33,8 @@ var RunCmd = &cobra.Command{
 	PreRun: func(cmd *cobra.Command, args []string) {
 		viper.BindPFlag("platform-id", cmd.Flags().Lookup("platform-id"))
 	},
+	// we have to initialize an empty run so it shows up as a runnable command in --help
+	Run: func(cmd *cobra.Command, args []string) {},
 }
 
 var RunCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *plugin.ParseCLIRes) {

--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -103,6 +103,8 @@ To manually configure a query pack, use this:
 		}
 		return []string{}, cobra.ShellCompDirectiveNoFileComp
 	},
+	// we have to initialize an empty run so it shows up as a runnable command in --help
+	Run: func(cmd *cobra.Command, args []string) {},
 }
 
 var scanCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *plugin.ParseCLIRes) {

--- a/apps/cnquery/cmd/shell.go
+++ b/apps/cnquery/cmd/shell.go
@@ -36,6 +36,8 @@ var shellCmd = &cobra.Command{
 	PreRun: func(cmd *cobra.Command, args []string) {
 		viper.BindPFlag("platform-id", cmd.Flags().Lookup("platform-id"))
 	},
+	// we have to initialize an empty run so it shows up as a runnable command in --help
+	Run: func(cmd *cobra.Command, args []string) {},
 }
 
 var shellRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *plugin.ParseCLIRes) {


### PR DESCRIPTION
Before:

![image](https://github.com/mondoohq/cnquery/assets/1307529/71f2264f-cea6-40c6-bf7b-99de5e9c49ea)


After:

![image](https://github.com/mondoohq/cnquery/assets/1307529/1a609580-dc2b-47f4-8c68-71498d76fb2e)
