### PR TITLE
🐛 add builtin flags for cli pre-processing

### DIFF
--- a/providers-sdk/v1/plugin/flag.go
+++ b/providers-sdk/v1/plugin/flag.go
@@ -1,0 +1,38 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package plugin
+
+type FlagType byte
+
+const (
+	FlagType_Bool FlagType = 1 + iota
+	FlagType_Int
+	FlagType_String
+	FlagType_List
+	FlagType_KeyValue
+)
+
+type FlagOption byte
+
+const (
+	FlagOption_Hidden FlagOption = 0x1 << iota
+	FlagOption_Deprecated
+	FlagOption_Required
+	FlagOption_Password
+	// max: 8 options!
+)
+
+type Flag struct {
+	Long    string     `json:",omitempty"`
+	Short   string     `json:",omitempty"`
+	Default string     `json:",omitempty"`
+	Desc    string     `json:",omitempty"`
+	Type    FlagType   `json:",omitempty"`
+	Option  FlagOption `json:",omitempty"`
+	// ConfigEntry that is used for this flag:
+	// "" = use the same as Long
+	// "some.other" = map to some.other field
+	// "-" = do not read this from config
+	ConfigEntry string `json:",omitempty"`
+}

--- a/providers-sdk/v1/plugin/start.go
+++ b/providers-sdk/v1/plugin/start.go
@@ -32,40 +32,6 @@ type Connector struct {
 	Discovery []string `json:",omitempty"`
 }
 
-type FlagType byte
-
-const (
-	FlagType_Bool FlagType = 1 + iota
-	FlagType_Int
-	FlagType_String
-	FlagType_List
-	FlagType_KeyValue
-)
-
-type FlagOption byte
-
-const (
-	FlagOption_Hidden FlagOption = 0x1 << iota
-	FlagOption_Deprecated
-	FlagOption_Required
-	FlagOption_Password
-	// max: 8 options!
-)
-
-type Flag struct {
-	Long    string     `json:",omitempty"`
-	Short   string     `json:",omitempty"`
-	Default string     `json:",omitempty"`
-	Desc    string     `json:",omitempty"`
-	Type    FlagType   `json:",omitempty"`
-	Option  FlagOption `json:",omitempty"`
-	// ConfigEntry that is used for this flag:
-	// "" = use the same as Long
-	// "some.other" = map to some.other field
-	// "-" = do not read this from config
-	ConfigEntry string `json:",omitempty"`
-}
-
 func Start(args []string, impl ProviderPlugin) {
 	logger.CliCompactLogger(logger.LogOutputWriter)
 	zerolog.SetGlobalLevel(zerolog.WarnLevel)

--- a/providers/mock.go
+++ b/providers/mock.go
@@ -11,8 +11,9 @@ import (
 
 var mockProvider = Provider{
 	Provider: &plugin.Provider{
-		Name: "mock",
-		ID:   "go.mondoo.com/cnquery/providers/mock",
+		Name:    "mock",
+		ID:      "go.mondoo.com/cnquery/providers/mock",
+		Version: "9.0.0",
 		Connectors: []plugin.Connector{{
 			Name:  "mock",
 			Use:   "mock",


### PR DESCRIPTION
This avoids an error-message which makes users think that recordings were not loaded.

Before 

```bash
..go/src/go.mondoo.com/cnquery ±> go run apps/cnquery/cnquery.go run -c sshd.config.params --use-recording a.json
! pre-processing of cli had an error error="unknown flag: --use-recording"
→ no provider specified, defaulting to local. Use --help to see all providers.
→ loaded configuration from /home/zero/.config/mondoo/mondoo.yml using source default
```

After:

```bash
..go/src/go.mondoo.com/cnquery ±> go run apps/cnquery/cnquery.go run -c sshd.config.params --use-recording a.json
→ no provider specified, defaulting to local. Use --help to see all providers.
→ loaded configuration from /home/zero/.config/mondoo/mondoo.yml using source default
```