### PR TITLE
⭐ Add new properties to `gitlab.group` resource

### DIFF
--- a/providers/gitlab/resources/gitlab.go
+++ b/providers/gitlab/resources/gitlab.go
@@ -32,8 +32,12 @@ func initGitlabGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 	args["name"] = llx.StringData(grp.Name)
 	args["path"] = llx.StringData(grp.Path)
 	args["description"] = llx.StringData(grp.Description)
+	args["webURL"] = llx.StringData(string(grp.WebURL))
 	args["visibility"] = llx.StringData(string(grp.Visibility))
 	args["requireTwoFactorAuthentication"] = llx.BoolData(grp.RequireTwoFactorAuth)
+	args["preventForkingOutsideGroup"] = llx.BoolData(grp.PreventForkingOutsideGroup)
+	args["mentionsDisabled"] = llx.BoolData(grp.MentionsDisabled)
+	args["emailsDisabled"] = llx.BoolData(grp.EmailsDisabled)
 
 	return args, nil, nil
 }

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -14,10 +14,18 @@ gitlab.group @defaults("name") {
   path string
   // Group description
   description string
+  // URL of the project
+  webURL string
   // Group visibility. Can be private, internal, or public.
   visibility string
   // Require all users in this group to setup Two-factor authentication.
   requireTwoFactorAuthentication bool
+  // Don't allow forking projects outside this group
+  preventForkingOutsideGroup bool
+  // Disable group email notifications
+  emailsDisabled bool
+  // Disable group mentions within issues and merge requests
+  mentionsDisabled bool
   // List all projects that belong to the group
   projects() []gitlab.project
 }

--- a/providers/gitlab/resources/gitlab.lr.go
+++ b/providers/gitlab/resources/gitlab.lr.go
@@ -105,11 +105,23 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gitlab.group.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabGroup).GetDescription()).ToDataRes(types.String)
 	},
+	"gitlab.group.webURL": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabGroup).GetWebURL()).ToDataRes(types.String)
+	},
 	"gitlab.group.visibility": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabGroup).GetVisibility()).ToDataRes(types.String)
 	},
 	"gitlab.group.requireTwoFactorAuthentication": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabGroup).GetRequireTwoFactorAuthentication()).ToDataRes(types.Bool)
+	},
+	"gitlab.group.preventForkingOutsideGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabGroup).GetPreventForkingOutsideGroup()).ToDataRes(types.Bool)
+	},
+	"gitlab.group.emailsDisabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabGroup).GetEmailsDisabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.group.mentionsDisabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabGroup).GetMentionsDisabled()).ToDataRes(types.Bool)
 	},
 	"gitlab.group.projects": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabGroup).GetProjects()).ToDataRes(types.Array(types.Resource("gitlab.project")))
@@ -161,12 +173,28 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlGitlabGroup).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gitlab.group.webURL": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabGroup).WebURL, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gitlab.group.visibility": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabGroup).Visibility, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gitlab.group.requireTwoFactorAuthentication": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabGroup).RequireTwoFactorAuthentication, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.group.preventForkingOutsideGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabGroup).PreventForkingOutsideGroup, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.group.emailsDisabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabGroup).EmailsDisabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.group.mentionsDisabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabGroup).MentionsDisabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gitlab.group.projects": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -230,8 +258,12 @@ type mqlGitlabGroup struct {
 	Name plugin.TValue[string]
 	Path plugin.TValue[string]
 	Description plugin.TValue[string]
+	WebURL plugin.TValue[string]
 	Visibility plugin.TValue[string]
 	RequireTwoFactorAuthentication plugin.TValue[bool]
+	PreventForkingOutsideGroup plugin.TValue[bool]
+	EmailsDisabled plugin.TValue[bool]
+	MentionsDisabled plugin.TValue[bool]
 	Projects plugin.TValue[[]interface{}]
 }
 
@@ -288,12 +320,28 @@ func (c *mqlGitlabGroup) GetDescription() *plugin.TValue[string] {
 	return &c.Description
 }
 
+func (c *mqlGitlabGroup) GetWebURL() *plugin.TValue[string] {
+	return &c.WebURL
+}
+
 func (c *mqlGitlabGroup) GetVisibility() *plugin.TValue[string] {
 	return &c.Visibility
 }
 
 func (c *mqlGitlabGroup) GetRequireTwoFactorAuthentication() *plugin.TValue[bool] {
 	return &c.RequireTwoFactorAuthentication
+}
+
+func (c *mqlGitlabGroup) GetPreventForkingOutsideGroup() *plugin.TValue[bool] {
+	return &c.PreventForkingOutsideGroup
+}
+
+func (c *mqlGitlabGroup) GetEmailsDisabled() *plugin.TValue[bool] {
+	return &c.EmailsDisabled
+}
+
+func (c *mqlGitlabGroup) GetMentionsDisabled() *plugin.TValue[bool] {
+	return &c.MentionsDisabled
 }
 
 func (c *mqlGitlabGroup) GetProjects() *plugin.TValue[[]interface{}] {

--- a/providers/gitlab/resources/gitlab.lr.manifest.yaml
+++ b/providers/gitlab/resources/gitlab.lr.manifest.yaml
@@ -5,12 +5,20 @@ resources:
   gitlab.group:
     fields:
       description: {}
+      emailsDisabled:
+        min_mondoo_version: 9.0.0
       id: {}
+      mentionsDisabled:
+        min_mondoo_version: 9.0.0
       name: {}
       path: {}
+      preventForkingOutsideGroup:
+        min_mondoo_version: 9.0.0
       projects: {}
       requireTwoFactorAuthentication: {}
       visibility: {}
+      webURL:
+        min_mondoo_version: 9.0.0
     maturity: experimental
     min_mondoo_version: 5.15.0
   gitlab.project:


### PR DESCRIPTION
Add new properties to gitlab.group

- emailsDisabled
- preventForkingOutsideGroup
- mentionsDisabled
- webURL

These are helpful for expanding the gitlab security policy + asset overview data for the console

```
gitlab.group: {
  name: "mondoolabs"
  webURL: "https://gitlab.com/groups/mondoolabs"
  path: "mondoolabs"
  mentionsDisabled: false
  description: ""
  projects: [
  0: gitlab.project name="Example Gitlab" visibility="private"
  ]
  id: 5409231
  requireTwoFactorAuthentication: true
  visibility: "private"
  emailsDisabled: false
  preventForkingOutsideGroup: false
}
```