### PR TITLE
🐛 Fix unmarshal for terraform plan `replace_paths`

### DIFF
--- a/providers/terraform/provider/testdata/tfplan-replace-paths/tfplan.json
+++ b/providers/terraform/provider/testdata/tfplan-replace-paths/tfplan.json
@@ -1,0 +1,36 @@
+{
+  "format_version": "1.5",
+  "terraform_version": "1.5.0",
+  "resource_changes": [
+    {
+      "address": "",
+      "module_address": "",
+      "mode": "managed",
+      "type": "google_service_account_iam_member",
+      "name": "cloud_deploy_service_account",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": ["delete", "create"],
+        "before": {
+          "condition": [],
+          "etag": "BwYCXPmcVSE=",
+          "id": "",
+          "member": "",
+          "role": "",
+          "service_account_id": ""
+        },
+        "after": {
+          "condition": [],
+          "member": "",
+          "role": "",
+          "service_account_id": ""
+        },
+        "after_unknown": { "condition": [], "etag": true, "id": true },
+        "before_sensitive": { "condition": [] },
+        "after_sensitive": { "condition": [] },
+        "replace_paths": [["member"]]
+      },
+      "action_reason": "replace_because_cannot_update"
+    }
+  ]
+}

--- a/providers/terraform/provider/tfplan_test.go
+++ b/providers/terraform/provider/tfplan_test.go
@@ -96,3 +96,21 @@ func TestTerraformPlanParsing(t *testing.T) {
 
 	assert.Equal(t, 1, len(pc.RootModule.Resources))
 }
+
+// // FIXME: This test needs migration
+// func TestTerraformPlanParsingReplacePaths(t *testing.T) {
+// 	path := "./testdata/tfplan-replace-paths/tfplan.json"
+// 	query := "terraform.plan.resourceChanges"
+// 	res := testTerraformPlanQueryWithPath(t, query, path)
+// 	require.NotEmpty(t, res)
+// 	assert.Empty(t, res[0].Result().Error)
+
+// 	query = "terraform.plan.resourceChanges[0].change.replacePaths"
+// 	res = testTerraformPlanQueryWithPath(t, query, path)
+// 	require.NotEmpty(t, res)
+// 	resArrayInterface, ok := res[0].Data.Value.([]interface{})
+// 	require.True(t, ok)
+// 	resArrayStrings, ok := resArrayInterface[0].([]interface{})
+// 	require.True(t, ok)
+// 	assert.Equal(t, "member", resArrayStrings[0].(string))
+// }

--- a/providers/terraform/resources/tfplan.go
+++ b/providers/terraform/resources/tfplan.go
@@ -84,7 +84,7 @@ func (t *mqlTerraformPlan) resourceChanges() ([]interface{}, error) {
 			}
 		}
 
-		var replacePaths map[string]interface{}
+		var replacePaths []interface{}
 		if rc.Change.ReplacePaths != nil {
 			if err := json.Unmarshal(rc.Change.ReplacePaths, &replacePaths); err != nil {
 				return nil, err
@@ -99,7 +99,7 @@ func (t *mqlTerraformPlan) resourceChanges() ([]interface{}, error) {
 			"afterUnknown":    llx.MapData(afterUnknown, types.Any),
 			"beforeSensitive": llx.MapData(beforeSensitive, types.Any),
 			"afterSensitive":  llx.MapData(afterSensitive, types.Any),
-			"replacePaths":    llx.MapData(replacePaths, types.Any),
+			"replacePaths":    llx.ArrayData(replacePaths, types.Any),
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Migrate https://github.com/mondoohq/cnquery/pull/1511

Fixes https://github.com/mondoohq/cnquery/issues/1512

Note: These Terraform tests need a proper migration of their test as described in https://github.com/mondoohq/cnquery/issues/1787