### PR TITLE
🐛 ensure we use the credential token for gitlab scan

### DIFF
--- a/motor/discovery/gitlab/gitlab.go
+++ b/motor/discovery/gitlab/gitlab.go
@@ -52,9 +52,11 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *provide
 	if err != nil {
 		return nil, err
 	}
-	rootToken, err := credsResolver.GetCredential(root.Connections[0].Credentials[0])
-	if err == nil && rootToken != nil {
-		pCfg.Credentials = []*vault.Credential{rootToken}
+	if len(root.Connections) > 0 && root.Connections[0].Credentials != nil && len(root.Connections[0].Credentials) > 0 {
+		gitlabToken, err := credsResolver.GetCredential(root.Connections[0].Credentials[0])
+		if err == nil && gitlabToken != nil {
+			pCfg.Credentials = []*vault.Credential{gitlabToken}
+		}
 	}
 
 	defaultName := root.Name

--- a/motor/discovery/gitlab/gitlab.go
+++ b/motor/discovery/gitlab/gitlab.go
@@ -52,6 +52,10 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *provide
 	if err != nil {
 		return nil, err
 	}
+	rootToken, err := credsResolver.GetCredential(root.Connections[0].Credentials[0])
+	if err == nil && rootToken != nil {
+		pCfg.Credentials = []*vault.Credential{rootToken}
+	}
 
 	defaultName := root.Name
 	list := []*asset.Asset{}


### PR DESCRIPTION
the error i encountered is reproducible by running `unset SSH_AUTH_SOCK` and then running `DEBUG=1 cnquery shell gitlab --group mondoolabs --token TOKEN`

you should see it fail out when cloning the repos 

(with this change it should just work. in my test i have one repo i can't clone due to perms, so it get 36 assets discovered)

------
i'm a little uncertain about this change, i would have expected some process before resolve, like the enrich assets one,  to take care of doing this

but i did test this on two diff machines and got the same result on both