### PR TITLE
🧹 do not error on filepath.SkipDir when reading linux bios

### DIFF
--- a/providers/os/resources/smbios/linux.go
+++ b/providers/os/resources/smbios/linux.go
@@ -98,5 +98,10 @@ func (s *LinuxSmbiosManager) Info() (*SmBiosInfo, error) {
 		return nil
 	})
 
-	return &smInfo, wErr
+	// If the error is SkipDir we can safely ignore it
+	if wErr != nil && wErr != filepath.SkipDir {
+		return nil, wErr
+	}
+
+	return &smInfo, nil
 }


### PR DESCRIPTION
Migrate https://github.com/mondoohq/cnquery/pull/1461

Fixes https://github.com/mondoohq/cnquery/issues/1474