### PR TITLE
🧹 Set the title of AWS accounts to be AWS Account

### DIFF
--- a/providers/aws/connection/platform.go
+++ b/providers/aws/connection/platform.go
@@ -20,7 +20,7 @@ func GetPlatformForObject(platformName string) *inventory.Platform {
 	}
 	return &inventory.Platform{
 		Name:    "aws",
-		Title:   "Amazon Web Services",
+		Title:   "AWS Account",
 		Kind:    "api",
 		Runtime: "aws",
 	}


### PR DESCRIPTION
Migrate https://github.com/mondoohq/cnquery/pull/1443

Fixes https://github.com/mondoohq/cnquery/issues/1477