### PR TITLE
🐛 make sure network provider asset has platform id

### DIFF
--- a/providers/network/provider/provider.go
+++ b/providers/network/provider/provider.go
@@ -180,6 +180,8 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.HostConnection
 		Title:  "Network API",
 	}
 
+	asset.PlatformIds = []string{"//platformid.api.mondoo.app/runtime/network/host/" + conn.Conf.Host}
+
 	return nil
 }
 


### PR DESCRIPTION
noticed this while testing out another pr