### PR TITLE
🐛 use system path on default when root user is used

### DIFF
--- a/apps/cnquery/cmd/root.go
+++ b/apps/cnquery/cmd/root.go
@@ -81,6 +81,13 @@ func init() {
 	logger.CliCompactLogger(logger.LogOutputWriter)
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 
+	// TODO harmonize with initLogger, which is called later and attached to the command
+	// here we set the log level only by environment variable
+	envLevel, ok := logger.GetEnvLogLevel()
+	if ok {
+		logger.Set(envLevel)
+	}
+
 	config.DefaultConfigFile = "mondoo.yml"
 
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")


### PR DESCRIPTION
This change handle the special case where we run cnquery inside of a container. When root (uid-0) is used we want to use the system path as default. While we handled the case for home path detection we have not incorporated that when we install a plugin. Now we determine the default path, this allows us to run well in container land:

```
docker run -it cnspec-alpine /bin/sh
/ # cnquery shell local
! can't find any paths for providers, none are configured system-path=/opt/mondoo/providers
→ installing provider 'os' version=9.0.0
→ successfully installed os provider path=/opt/mondoo/providers/os version=9.0.0
→ no Mondoo configuration file provided, using defaults
→ connected to Alpine Linux v3.15
  ___ _ __   __ _ _   _  ___ _ __ _   _ 
 / __| '_ \ / _` | | | |/ _ \ '__| | | |
| (__| | | | (_| | |_| |  __/ |  | |_| |
 \___|_| |_|\__, |\__,_|\___|_|   \__, |
  mondoo™      |_|                |___/  interactive shell

cnquery> 
```

In addition, I added code that DEBUG=1 is also respected for global logging before the commands are injected