### PR TITLE
Add new properties to gitlab.project

### DIFF
--- a/providers/gitlab/go.mod
+++ b/providers/gitlab/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/rs/zerolog v1.30.0
 	github.com/stretchr/testify v1.8.4
 	github.com/xanzy/go-gitlab v0.91.1
-	go.mondoo.com/cnquery v0.0.0-20230915180754-c5f61bc705cf
+	go.mondoo.com/cnquery v0.0.0-20230920205842-55a158611de3
 )
 
 require (
@@ -59,7 +59,7 @@ require (
 	golang.org/x/text v0.13.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20230913181813-007df8e322eb // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230920204549-e6e6cdab5c13 // indirect
 	google.golang.org/grpc v1.58.1 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect

--- a/providers/gitlab/go.sum
+++ b/providers/gitlab/go.sum
@@ -551,8 +551,8 @@ google.golang.org/genproto v0.0.0-20201210142538-e3217bee35cc/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210108203827-ffc7fda8c3d7/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210226172003-ab064af71705/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20230913181813-007df8e322eb h1:Isk1sSH7bovx8Rti2wZK0UZF6oraBDK74uoyLEEVFN0=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20230913181813-007df8e322eb/go.mod h1:+Bk1OCOj40wS2hwAMA+aCW9ypzm63QTBBHp6lQ3p+9M=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20230920204549-e6e6cdab5c13 h1:N3bU/SQDCDyD6R528GJ/PwW9KjYcJA3dgyH+MovAkIM=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20230920204549-e6e6cdab5c13/go.mod h1:KSqppvjFjtoCI+KGd4PELB0qLNxdJHRGqRI09mB6pQA=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/providers/gitlab/resources/gitlab.go
+++ b/providers/gitlab/resources/gitlab.go
@@ -62,11 +62,30 @@ func (g *mqlGitlabGroup) projects() ([]interface{}, error) {
 		prj := grp.Projects[i]
 
 		mqlProject, err := CreateResource(g.MqlRuntime, "gitlab.project", map[string]*llx.RawData{
-			"id":          llx.IntData(int64(prj.ID)),
-			"name":        llx.StringData(prj.Name),
-			"path":        llx.StringData(prj.Path),
-			"description": llx.StringData(prj.Description),
-			"visibility":  llx.StringData(string(prj.Visibility)),
+			"allowMergeOnSkippedPipeline": llx.BoolData(prj.AllowMergeOnSkippedPipeline),
+			"archived":                    llx.BoolData(prj.Archived),
+			"autoDevopsEnabled":           llx.BoolData(prj.AutoDevopsEnabled),
+			"containerRegistryEnabled":    llx.BoolData(prj.ContainerRegistryEnabled),
+			"createdAt":                   llx.TimeDataPtr(prj.CreatedAt),
+			"defaultBranch":               llx.StringData(prj.DefaultBranch),
+			"description":                 llx.StringData(prj.Description),
+			"emailsDisabled":              llx.BoolData(!prj.EmailsEnabled),
+			"fullName":                    llx.StringData(prj.NameWithNamespace),
+			"id":                          llx.IntData(int64(prj.ID)),
+			"issuesEnabled":               llx.BoolData(prj.IssuesEnabled),
+			"mergeRequestsEnabled":        llx.BoolData(prj.MergeRequestsEnabled),
+			"mirror":                      llx.BoolData(prj.Mirror),
+			"name":                        llx.StringData(prj.Name),
+			"onlyAllowMergeIfAllDiscussionsAreResolved": llx.BoolData(prj.OnlyAllowMergeIfAllDiscussionsAreResolved),
+			"onlyAllowMergeIfPipelineSucceeds":          llx.BoolData(prj.OnlyAllowMergeIfPipelineSucceeds),
+			"packagesEnabled":                           llx.BoolData(prj.PackagesEnabled),
+			"path":                                      llx.StringData(prj.Path),
+			"requirementsEnabled":                       llx.BoolData(prj.RequirementsEnabled),
+			"serviceDeskEnabled":                        llx.BoolData(prj.ServiceDeskEnabled),
+			"snippetsEnabled":                           llx.BoolData(prj.SnippetsEnabled),
+			"visibility":                                llx.StringData(string(prj.Visibility)),
+			"webURL":                                    llx.StringData(prj.WebURL),
+			"wikiEnabled":                               llx.BoolData(prj.WikiEnabled),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -76,7 +76,7 @@ gitlab.project @defaults("fullName visibility webURL") {
   serviceDeskEnabled bool
 	// Is the packages feature enabled?
   packagesEnabled bool
-	// Is the Auto DevOps feature enabled
+	// Is the Auto DevOps feature enabled?
   autoDevopsEnabled bool
 	// Is the requirements feature enabled
   requirementsEnabled bool

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -66,7 +66,7 @@ gitlab.project @defaults("fullName visibility webURL") {
   issuesEnabled bool
 	// Is the merge request feature enabled?
   mergeRequestsEnabled bool
-	// Is the wiki feature enabled
+	// Is the wiki feature enabled?
   wikiEnabled bool
 	// Is the snippets feature enabled
   snippetsEnabled bool

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -64,7 +64,7 @@ gitlab.project @defaults("fullName visibility webURL") {
   onlyAllowMergeIfAllDiscussionsAreResolved bool
   // Is the issues feature enabled?
   issuesEnabled bool
-	// Is the merge request feature enabled
+	// Is the merge request feature enabled?
   mergeRequestsEnabled bool
 	// Is the wiki feature enabled
   wikiEnabled bool

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -74,7 +74,7 @@ gitlab.project @defaults("fullName visibility webURL") {
   containerRegistryEnabled bool
 	// Is the Service Desk feature enabled?
   serviceDeskEnabled bool
-	// Is the packages feature enabled
+	// Is the packages feature enabled?
   packagesEnabled bool
 	// Is the Auto DevOps feature enabled
   autoDevopsEnabled bool

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -62,7 +62,7 @@ gitlab.project @defaults("fullName visibility webURL") {
   onlyAllowMergeIfPipelineSucceeds bool
   // Allow merging merge requests if all discussions are resolved
   onlyAllowMergeIfAllDiscussionsAreResolved bool
-  // Is the issues feature enabled
+  // Is the issues feature enabled?
   issuesEnabled bool
 	// Is the merge request feature enabled
   mergeRequestsEnabled bool

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -50,7 +50,7 @@ gitlab.project @defaults("fullName visibility webURL") {
   visibility string
   // Is the project archived?
   archived bool
-  // Is the project a mirror
+  // Is the project a mirror?
   mirror bool
   // URL of the project
   webURL string

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -14,9 +14,9 @@ gitlab.group @defaults("name") {
   path string
   // Group description
   description string
-  // URL of the project
+  // URL of the group
   webURL string
-  // Group visibility. Can be private, internal, or public.
+  // The group's visibility level. Can be private, internal, or public.
   visibility string
   // Require all users in this group to setup Two-factor authentication.
   requireTwoFactorAuthentication bool
@@ -31,15 +31,53 @@ gitlab.group @defaults("name") {
 }
 
 // GitLab Project
-gitlab.project @defaults("name visibility") {
+gitlab.project @defaults("fullName visibility webURL") {
   // Project ID
   id int
   // Project name
   name string
+  // The full name of the project including the namespace
+  fullName string
   // Project path
   path string
+  // Create date of the project
+  createdAt time  
   // Project description
   description string
+  // default git branch
+  defaultBranch string
   // The project's visibility level. Can be private, internal, or public.
   visibility string
+  // Is the project archived
+  archived bool
+  // Is the project a mirror
+  mirror bool
+  // URL of the project
+  webURL string
+  // Disable project email notifications
+  emailsDisabled bool
+  // Allow merging merge requests when a pipeline is skipped
+  allowMergeOnSkippedPipeline bool
+  // Only allow merging merge requests if the pipelines succeed
+  onlyAllowMergeIfPipelineSucceeds bool
+  // Allow merging merge requests if all discussions are resolved
+  onlyAllowMergeIfAllDiscussionsAreResolved bool
+  // Is the issues feature enabled
+  issuesEnabled bool
+	// Is the merge request feature enabled
+  mergeRequestsEnabled bool
+	// Is the wiki feature enabled
+  wikiEnabled bool
+	// Is the snippets feature enabled
+  snippetsEnabled bool
+	// Is the container registry feature enabled
+  containerRegistryEnabled bool
+	// Is the Service Desk feature enabled
+  serviceDeskEnabled bool
+	// Is the packages feature enabled
+  packagesEnabled bool
+	// Is the Auto DevOps feature enabled
+  autoDevopsEnabled bool
+	// Is the requirements feature enabled
+  requirementsEnabled bool
 }

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -72,7 +72,7 @@ gitlab.project @defaults("fullName visibility webURL") {
   snippetsEnabled bool
 	// Is the container registry feature enabled
   containerRegistryEnabled bool
-	// Is the Service Desk feature enabled
+	// Is the Service Desk feature enabled?
   serviceDeskEnabled bool
 	// Is the packages feature enabled
   packagesEnabled bool

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -68,7 +68,7 @@ gitlab.project @defaults("fullName visibility webURL") {
   mergeRequestsEnabled bool
 	// Is the wiki feature enabled?
   wikiEnabled bool
-	// Is the snippets feature enabled
+	// Is the snippets feature enabled?
   snippetsEnabled bool
 	// Is the container registry feature enabled
   containerRegistryEnabled bool

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -36,7 +36,7 @@ gitlab.project @defaults("fullName visibility webURL") {
   id int
   // Project name
   name string
-  // The full name of the project including the namespace
+  // The full name of the project, including the namespace
   fullName string
   // Project path
   path string

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -78,6 +78,6 @@ gitlab.project @defaults("fullName visibility webURL") {
   packagesEnabled bool
 	// Is the Auto DevOps feature enabled?
   autoDevopsEnabled bool
-	// Is the requirements feature enabled
+	// Is the requirements feature enabled?
   requirementsEnabled bool
 }

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -70,7 +70,7 @@ gitlab.project @defaults("fullName visibility webURL") {
   wikiEnabled bool
 	// Is the snippets feature enabled?
   snippetsEnabled bool
-	// Is the container registry feature enabled
+	// Is the container registry feature enabled?
   containerRegistryEnabled bool
 	// Is the Service Desk feature enabled?
   serviceDeskEnabled bool

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -48,7 +48,7 @@ gitlab.project @defaults("fullName visibility webURL") {
   defaultBranch string
   // The project's visibility level. Can be private, internal, or public.
   visibility string
-  // Is the project archived
+  // Is the project archived?
   archived bool
   // Is the project a mirror
   mirror bool

--- a/providers/gitlab/resources/gitlab.lr.go
+++ b/providers/gitlab/resources/gitlab.lr.go
@@ -7,6 +7,7 @@ package resources
 
 import (
 	"errors"
+	"time"
 
 	"go.mondoo.com/cnquery/llx"
 	"go.mondoo.com/cnquery/providers-sdk/v1/plugin"
@@ -132,14 +133,71 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gitlab.project.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetName()).ToDataRes(types.String)
 	},
+	"gitlab.project.fullName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetFullName()).ToDataRes(types.String)
+	},
 	"gitlab.project.path": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetPath()).ToDataRes(types.String)
+	},
+	"gitlab.project.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetCreatedAt()).ToDataRes(types.Time)
 	},
 	"gitlab.project.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetDescription()).ToDataRes(types.String)
 	},
+	"gitlab.project.defaultBranch": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetDefaultBranch()).ToDataRes(types.String)
+	},
 	"gitlab.project.visibility": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetVisibility()).ToDataRes(types.String)
+	},
+	"gitlab.project.archived": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetArchived()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.mirror": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetMirror()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.webURL": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetWebURL()).ToDataRes(types.String)
+	},
+	"gitlab.project.emailsDisabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetEmailsDisabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.allowMergeOnSkippedPipeline": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetAllowMergeOnSkippedPipeline()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.onlyAllowMergeIfPipelineSucceeds": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetOnlyAllowMergeIfPipelineSucceeds()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.onlyAllowMergeIfAllDiscussionsAreResolved": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetOnlyAllowMergeIfAllDiscussionsAreResolved()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.issuesEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetIssuesEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.mergeRequestsEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetMergeRequestsEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.wikiEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetWikiEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.snippetsEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetSnippetsEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.containerRegistryEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetContainerRegistryEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.serviceDeskEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetServiceDeskEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.packagesEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetPackagesEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.autoDevopsEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetAutoDevopsEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.requirementsEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetRequirementsEnabled()).ToDataRes(types.Bool)
 	},
 }
 
@@ -213,16 +271,92 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlGitlabProject).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gitlab.project.fullName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).FullName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gitlab.project.path": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabProject).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"gitlab.project.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabProject).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gitlab.project.defaultBranch": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).DefaultBranch, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gitlab.project.visibility": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabProject).Visibility, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.archived": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).Archived, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.mirror": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).Mirror, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.webURL": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).WebURL, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.emailsDisabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).EmailsDisabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.allowMergeOnSkippedPipeline": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).AllowMergeOnSkippedPipeline, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.onlyAllowMergeIfPipelineSucceeds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).OnlyAllowMergeIfPipelineSucceeds, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.onlyAllowMergeIfAllDiscussionsAreResolved": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).OnlyAllowMergeIfAllDiscussionsAreResolved, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.issuesEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).IssuesEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.mergeRequestsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).MergeRequestsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.wikiEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).WikiEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.snippetsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).SnippetsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.containerRegistryEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).ContainerRegistryEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.serviceDeskEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).ServiceDeskEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.packagesEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).PackagesEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.autoDevopsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).AutoDevopsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.requirementsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).RequirementsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 }
@@ -367,9 +501,28 @@ type mqlGitlabProject struct {
 	// optional: if you define mqlGitlabProjectInternal it will be used here
 	Id plugin.TValue[int64]
 	Name plugin.TValue[string]
+	FullName plugin.TValue[string]
 	Path plugin.TValue[string]
+	CreatedAt plugin.TValue[*time.Time]
 	Description plugin.TValue[string]
+	DefaultBranch plugin.TValue[string]
 	Visibility plugin.TValue[string]
+	Archived plugin.TValue[bool]
+	Mirror plugin.TValue[bool]
+	WebURL plugin.TValue[string]
+	EmailsDisabled plugin.TValue[bool]
+	AllowMergeOnSkippedPipeline plugin.TValue[bool]
+	OnlyAllowMergeIfPipelineSucceeds plugin.TValue[bool]
+	OnlyAllowMergeIfAllDiscussionsAreResolved plugin.TValue[bool]
+	IssuesEnabled plugin.TValue[bool]
+	MergeRequestsEnabled plugin.TValue[bool]
+	WikiEnabled plugin.TValue[bool]
+	SnippetsEnabled plugin.TValue[bool]
+	ContainerRegistryEnabled plugin.TValue[bool]
+	ServiceDeskEnabled plugin.TValue[bool]
+	PackagesEnabled plugin.TValue[bool]
+	AutoDevopsEnabled plugin.TValue[bool]
+	RequirementsEnabled plugin.TValue[bool]
 }
 
 // createGitlabProject creates a new instance of this resource
@@ -417,14 +570,90 @@ func (c *mqlGitlabProject) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
 
+func (c *mqlGitlabProject) GetFullName() *plugin.TValue[string] {
+	return &c.FullName
+}
+
 func (c *mqlGitlabProject) GetPath() *plugin.TValue[string] {
 	return &c.Path
+}
+
+func (c *mqlGitlabProject) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
 }
 
 func (c *mqlGitlabProject) GetDescription() *plugin.TValue[string] {
 	return &c.Description
 }
 
+func (c *mqlGitlabProject) GetDefaultBranch() *plugin.TValue[string] {
+	return &c.DefaultBranch
+}
+
 func (c *mqlGitlabProject) GetVisibility() *plugin.TValue[string] {
 	return &c.Visibility
+}
+
+func (c *mqlGitlabProject) GetArchived() *plugin.TValue[bool] {
+	return &c.Archived
+}
+
+func (c *mqlGitlabProject) GetMirror() *plugin.TValue[bool] {
+	return &c.Mirror
+}
+
+func (c *mqlGitlabProject) GetWebURL() *plugin.TValue[string] {
+	return &c.WebURL
+}
+
+func (c *mqlGitlabProject) GetEmailsDisabled() *plugin.TValue[bool] {
+	return &c.EmailsDisabled
+}
+
+func (c *mqlGitlabProject) GetAllowMergeOnSkippedPipeline() *plugin.TValue[bool] {
+	return &c.AllowMergeOnSkippedPipeline
+}
+
+func (c *mqlGitlabProject) GetOnlyAllowMergeIfPipelineSucceeds() *plugin.TValue[bool] {
+	return &c.OnlyAllowMergeIfPipelineSucceeds
+}
+
+func (c *mqlGitlabProject) GetOnlyAllowMergeIfAllDiscussionsAreResolved() *plugin.TValue[bool] {
+	return &c.OnlyAllowMergeIfAllDiscussionsAreResolved
+}
+
+func (c *mqlGitlabProject) GetIssuesEnabled() *plugin.TValue[bool] {
+	return &c.IssuesEnabled
+}
+
+func (c *mqlGitlabProject) GetMergeRequestsEnabled() *plugin.TValue[bool] {
+	return &c.MergeRequestsEnabled
+}
+
+func (c *mqlGitlabProject) GetWikiEnabled() *plugin.TValue[bool] {
+	return &c.WikiEnabled
+}
+
+func (c *mqlGitlabProject) GetSnippetsEnabled() *plugin.TValue[bool] {
+	return &c.SnippetsEnabled
+}
+
+func (c *mqlGitlabProject) GetContainerRegistryEnabled() *plugin.TValue[bool] {
+	return &c.ContainerRegistryEnabled
+}
+
+func (c *mqlGitlabProject) GetServiceDeskEnabled() *plugin.TValue[bool] {
+	return &c.ServiceDeskEnabled
+}
+
+func (c *mqlGitlabProject) GetPackagesEnabled() *plugin.TValue[bool] {
+	return &c.PackagesEnabled
+}
+
+func (c *mqlGitlabProject) GetAutoDevopsEnabled() *plugin.TValue[bool] {
+	return &c.AutoDevopsEnabled
+}
+
+func (c *mqlGitlabProject) GetRequirementsEnabled() *plugin.TValue[bool] {
+	return &c.RequirementsEnabled
 }

--- a/providers/gitlab/resources/gitlab.lr.manifest.yaml
+++ b/providers/gitlab/resources/gitlab.lr.manifest.yaml
@@ -23,10 +23,48 @@ resources:
     min_mondoo_version: 5.15.0
   gitlab.project:
     fields:
+      allowMergeOnSkippedPipeline:
+        min_mondoo_version: 9.0.0
+      archived:
+        min_mondoo_version: 9.0.0
+      autoDevopsEnabled:
+        min_mondoo_version: 9.0.0
+      containerRegistryEnabled:
+        min_mondoo_version: 9.0.0
+      createdAt:
+        min_mondoo_version: 9.0.0
+      defaultBranch:
+        min_mondoo_version: 9.0.0
       description: {}
+      emailsDisabled:
+        min_mondoo_version: 9.0.0
+      fullName:
+        min_mondoo_version: 9.0.0
       id: {}
+      issuesEnabled:
+        min_mondoo_version: 9.0.0
+      mergeRequestsEnabled:
+        min_mondoo_version: 9.0.0
+      mirror:
+        min_mondoo_version: 9.0.0
       name: {}
+      onlyAllowMergeIfAllDiscussionsAreResolved:
+        min_mondoo_version: 9.0.0
+      onlyAllowMergeIfPipelineSucceeds:
+        min_mondoo_version: 9.0.0
+      packagesEnabled:
+        min_mondoo_version: 9.0.0
       path: {}
+      requirementsEnabled:
+        min_mondoo_version: 9.0.0
+      serviceDeskEnabled:
+        min_mondoo_version: 9.0.0
+      snippetsEnabled:
+        min_mondoo_version: 9.0.0
       visibility: {}
+      webURL:
+        min_mondoo_version: 9.0.0
+      wikiEnabled:
+        min_mondoo_version: 9.0.0
     maturity: experimental
     min_mondoo_version: 5.15.0


### PR DESCRIPTION
Add a pile of new properties we need to improve the security policy + asset overview data.

```
gitlab.group.projects.first: {
  webURL: "https://gitlab.com/lunaelectric/rover"
  issuesEnabled: true
  wikiEnabled: true
  requirementsEnabled: false
  path: "rover"
  createdAt: 2023-09-20 15:56:18.042 -0700 PDT
  containerRegistryEnabled: true
  name: "Rover"
  visibility: "private"
  id: 50575105
  defaultBranch: "main"
  description: ""
  archived: false
  serviceDeskEnabled: true
  emailsDisabled: false
  mirror: false
  allowMergeOnSkippedPipeline: false
  autoDevopsEnabled: false
  onlyAllowMergeIfAllDiscussionsAreResolved: false
  onlyAllowMergeIfPipelineSucceeds: false
  fullName: "Lunalectric / Rover"
  packagesEnabled: true
  mergeRequestsEnabled: true
  snippetsEnabled: true
}
```

Highlights:

- Update the defaults to use the new fullName property which includes the namespace (group in our context)
- Include super handy things for asset inventory like the URL, create date, and status of features, if its a mirror/archived, and the default branch name.
- Include some rules for merges