### PR TITLE
🐛 do not fail out on incomplete epoch field on packages

### DIFF
--- a/providers/os/resources/packages.go
+++ b/providers/os/resources/packages.go
@@ -137,7 +137,7 @@ func (x *mqlPackages) list() ([]interface{}, error) {
 			"format":      llx.StringData(osPkg.Format),
 			"installed":   llx.BoolData(true),
 			"origin":      llx.StringData(osPkg.Origin),
-			// "epoch": "", // TODO: support Epoch
+			"epoch":       llx.NilData, // TODO: support Epoch
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
fixes https://github.com/mondoohq/cnquery/issues/1719

epoch was also not filled in on v8. same todo is on the resource there. we should followup and address that!