### PR TITLE
✨ add state transition time to aws ec2 instance

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1659,6 +1659,8 @@ private aws.ec2.instance @defaults("arn state") {
   privateDnsName string
   // Keypair associated with the instance
   keypair() aws.ec2.keypair
+  // Time when the last state transition occurred
+  stateTransitionTime time
 }
 
 // Amazon EC2 Key Pair

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -2373,6 +2373,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.instance.keypair": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetKeypair()).ToDataRes(types.Resource("aws.ec2.keypair"))
 	},
+	"aws.ec2.instance.stateTransitionTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Instance).GetStateTransitionTime()).ToDataRes(types.Time)
+	},
 	"aws.ec2.keypair.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Keypair).GetArn()).ToDataRes(types.String)
 	},
@@ -5409,6 +5412,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.ec2.instance.keypair": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Instance).Keypair, ok = plugin.RawToTValue[*mqlAwsEc2Keypair](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instance.stateTransitionTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Instance).StateTransitionTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.keypair.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -14587,6 +14594,7 @@ type mqlAwsEc2Instance struct {
 	PrivateIp plugin.TValue[string]
 	PrivateDnsName plugin.TValue[string]
 	Keypair plugin.TValue[*mqlAwsEc2Keypair]
+	StateTransitionTime plugin.TValue[*time.Time]
 }
 
 // createAwsEc2Instance creates a new instance of this resource
@@ -14754,6 +14762,10 @@ func (c *mqlAwsEc2Instance) GetKeypair() *plugin.TValue[*mqlAwsEc2Keypair] {
 
 		return c.keypair()
 	})
+}
+
+func (c *mqlAwsEc2Instance) GetStateTransitionTime() *plugin.TValue[*time.Time] {
+	return &c.StateTransitionTime
 }
 
 // mqlAwsEc2Keypair for the aws.ec2.keypair resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -502,6 +502,8 @@ resources:
       state: {}
       stateReason: {}
       stateTransitionReason: {}
+      stateTransitionTime:
+        min_mondoo_version: 9.0.0
       tags: {}
       vpc: {}
     is_private: true


### PR DESCRIPTION
fixes https://github.com/mondoohq/cnquery/issues/1643

```
cnquery> aws.ec2.instances.where( state == "stopped" && stateTransitionTime < time.now - 30*time.day ) { stateTransitionTime state }
DBG starting query execution qrid=GVd0vsyNOBE=
DBG daWNxyu0vy7M7lY62/znQoeC7D1caKIBbTICbdCMxXLPeSZenpEA2Hv493wQCmUoGwR9Pwvs/UqXYtNXYMHJvg== finished
DBG graph has received all datapoints
DBG finished query execution qrid=GVd0vsyNOBE=
aws.ec2.instances.where: [
  0: {
    state: "stopped"
    stateTransitionTime: 2023-08-11 16:30:16 -0600 MDT
  }
  1: {
    state: "stopped"
    stateTransitionTime: 2022-09-30 09:16:03 -0600 MDT
  }
  2: {
    state: "stopped"
    stateTransitionTime: 2022-09-30 09:15:58 -0600 MDT
  }
  3: {
    state: "stopped"
    stateTransitionTime: 2022-05-11 03:23:47 -0600 MDT
  }
  4: {
    state: "stopped"
    stateTransitionTime: 2023-08-11 16:30:22 -0600 MDT
  }
]
```