### PR TITLE
🐛 compute checksum for properties of queries

### DIFF
--- a/examples/complex.mql.yaml
+++ b/examples/complex.mql.yaml
@@ -52,7 +52,7 @@ packs:
           # This MQL uses the property defined above. You can override it via
           # e.g. --props "home='/home/user'"
           mql: |
-            file( props.home ) { * }
+            file( props.home ) { basename user group }
 
 # These are shared queries that can be used in any querypack
 queries:

--- a/explorer/mquery.go
+++ b/explorer/mquery.go
@@ -118,6 +118,9 @@ func (m *Mquery) RefreshChecksum(
 
 	for i := range m.Props {
 		prop := m.Props[i]
+		if _, err := prop.RefreshChecksumAndType(schema); err != nil {
+			return err
+		}
 		if prop.Checksum == "" {
 			return errors.New("referenced property '" + prop.Mrn + "' checksum is empty")
 		}

--- a/explorer/mquery.go
+++ b/explorer/mquery.go
@@ -77,6 +77,13 @@ func (m *Mquery) RefreshMRN(ownerMRN string) error {
 
 	m.Mrn = nu
 	m.Uid = ""
+
+	for i := range m.Props {
+		if err := m.Props[i].RefreshMRN(ownerMRN); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/explorer/mquery_test.go
+++ b/explorer/mquery_test.go
@@ -13,13 +13,22 @@ import (
 	"go.mondoo.com/cnquery/providers-sdk/v1/testutils"
 )
 
-func TestMquery_RefreshChecksum(t *testing.T) {
+func TestMquery_Refresh(t *testing.T) {
 	a := &Mquery{
 		Mql:   "mondoo.version != props.world",
+		Uid:   "my-id0",
 		Props: []*Property{{Mql: "'hi'", Uid: "world"}},
 	}
+
+	err := a.RefreshMRN("//owner")
+	require.NoError(t, err)
+	assert.Equal(t, "//owner/queries/my-id0", a.Mrn)
+	assert.Empty(t, a.Uid)
+	assert.Equal(t, "//owner/queries/world", a.Props[0].Mrn)
+	assert.Empty(t, a.Props[0].Uid)
+
 	x := testutils.LinuxMock()
-	err := a.RefreshChecksum(
+	err = a.RefreshChecksum(
 		context.Background(),
 		x.Schema(),
 		func(ctx context.Context, mrn string) (*Mquery, error) {
@@ -27,8 +36,8 @@ func TestMquery_RefreshChecksum(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	assert.Equal(t, "t2slvX2k58s=", a.Checksum)
-	assert.Equal(t, "0xgs2tmERsM=", a.Props[0].Checksum)
+	assert.Equal(t, "5KkJ/lLHnBM=", a.Checksum)
+	assert.Equal(t, "9NhbOk30tEg=", a.Props[0].Checksum)
 }
 
 func TestMqueryMerge(t *testing.T) {

--- a/explorer/mquery_test.go
+++ b/explorer/mquery_test.go
@@ -4,12 +4,32 @@
 package explorer
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/providers-sdk/v1/testutils"
 )
+
+func TestMquery_RefreshChecksum(t *testing.T) {
+	a := &Mquery{
+		Mql:   "mondoo.version != props.world",
+		Props: []*Property{{Mql: "'hi'", Uid: "world"}},
+	}
+	x := testutils.LinuxMock()
+	err := a.RefreshChecksum(
+		context.Background(),
+		x.Schema(),
+		func(ctx context.Context, mrn string) (*Mquery, error) {
+			return nil, nil
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "t2slvX2k58s=", a.Checksum)
+	assert.Equal(t, "0xgs2tmERsM=", a.Props[0].Checksum)
+}
 
 func TestMqueryMerge(t *testing.T) {
 	a := &Mquery{


### PR DESCRIPTION
We had missed to process checksums and MRNs for properties of queries with this call. Since semantically it is supposed to refresh the entire checksum of the Mquery object, it needs to cover properties as well.