### PR TITLE
🐛 read auto update from config

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -36,7 +36,7 @@ const (
 
 // Init initializes and loads the mondoo config
 func Init(rootCmd *cobra.Command) {
-	cobra.OnInitialize(initConfig)
+	cobra.OnInitialize(InitViperConfig)
 	Features = getFeatures()
 	// persistent flags are global for the application
 	rootCmd.PersistentFlags().StringVar(&UserProvidedPath, "config", "", "Set config file path (default $HOME/.config/mondoo/mondoo.yml)")
@@ -69,7 +69,7 @@ func getFeatures() cnquery.Features {
 	return cnquery.Features(flags)
 }
 
-func initConfig() {
+func InitViperConfig() {
 	viper.SetConfigType("yaml")
 
 	Path = strings.TrimSpace(UserProvidedPath)

--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.mondoo.com/cnquery/cli/components"
+	"go.mondoo.com/cnquery/cli/config"
 	"go.mondoo.com/cnquery/llx"
 	"go.mondoo.com/cnquery/providers"
 	"go.mondoo.com/cnquery/providers-sdk/v1/plugin"
@@ -53,8 +54,13 @@ func AttachCLIs(rootCmd *cobra.Command, commands ...*Command) error {
 func detectConnectorName(args []string, commands []*Command) (string, bool) {
 	autoUpdate := true
 
+	config.InitViperConfig()
+	if viper.IsSet("auto_update") {
+		autoUpdate = viper.GetBool("auto_update")
+	}
+
 	flags := pflag.NewFlagSet("set", pflag.ContinueOnError)
-	flags.Bool("auto-update", true, "")
+	flags.Bool("auto-update", autoUpdate, "")
 	flags.BoolP("help", "h", false, "")
 
 	builtins := genBuiltinFlags()


### PR DESCRIPTION
We ignored the configured value by default and it only worked from CLI argument. Now it reads the config first and defers to the CLI for overrides.

Config used `.config/mondoo/mondoo.yml` contains:

```yaml
auto_update: false
```

Then without providers to start:

![image](https://github.com/mondoohq/cnquery/assets/1307529/373cec9a-cc93-4b37-b5cd-9645cc34b208)
