### PR TITLE
🐛 allow make providers/config to run with failing providers

### DIFF
--- a/providers-sdk/v1/util/configure/configure.go
+++ b/providers-sdk/v1/util/configure/configure.go
@@ -135,7 +135,7 @@ func buildProviders(providers []string) {
 		cmd := exec.Command("make", "providers/build/"+provider)
 		log.Debug().Str("provider", provider).Msg("build provider " + strconv.Itoa(i+1) + "/" + strconv.Itoa(len(providers)))
 		if err := cmd.Run(); err != nil {
-			log.Fatal().Err(err).Str("provider", provider).Msg("failed to build provider")
+			log.Error().Err(err).Str("provider", provider).Msg("failed to build provider")
 		}
 
 		// inefficient copy...


### PR DESCRIPTION
makes development easier, since the rest of the wiring can still happen, even if the provider is faulty