### PR TITLE
🐛 move default provider path on macos to /Library/Mondoo

### DIFF
--- a/cli/config/path.go
+++ b/cli/config/path.go
@@ -83,10 +83,18 @@ func systemPath(isConfig bool, childPath ...string) string {
 	var parts []string
 	if runtime.GOOS == "windows" {
 		parts = append([]string{`C:\ProgramData\Mondoo\`}, childPath...)
-	} else if isConfig {
-		parts = append([]string{"/etc", "opt", "mondoo"}, childPath...)
+	} else if runtime.GOOS == "darwin" {
+		if isConfig {
+			parts = append([]string{"/Library", "Mondoo", "etc"}, childPath...)
+		} else {
+			parts = append([]string{"/Library", "Mondoo"}, childPath...)
+		}
 	} else {
-		parts = append([]string{"/opt", "mondoo"}, childPath...)
+		if isConfig {
+			parts = append([]string{"/etc", "opt", "mondoo"}, childPath...)
+		} else {
+			parts = append([]string{"/opt", "mondoo"}, childPath...)
+		}
 	}
 
 	systemConfig := filepath.Join(parts...)


### PR DESCRIPTION
Add special handling for MacOS / Darwin and make sure all configs + providers are in the same shared directory `/Library/Mondoo`

Fixes https://github.com/mondoohq/cnquery/issues/1832