### PR TITLE
🐛 avoid printing home-path for root

### DIFF
--- a/apps/cnquery/cmd/providers.go
+++ b/apps/cnquery/cmd/providers.go
@@ -153,7 +153,7 @@ func printProviders(p []*providers.Provider) {
 
 func printProviderPath(path string, list []*providers.Provider, printEmpty bool) {
 	if list == nil {
-		if printEmpty {
+		if printEmpty && path != "" {
 			fmt.Println("")
 			log.Info().Msg(path + " has no providers")
 		}


### PR DESCRIPTION
Root just uses the system path, so trying to print a home path that is an empty string is confusing and wrong.

Before:

![image](https://github.com/mondoohq/cnquery/assets/1307529/1e4333be-cc6e-43fb-9608-ea458bb85f6a)


After:

![image](https://github.com/mondoohq/cnquery/assets/1307529/9247a2a0-bd8b-48a1-a368-2ed1d82b77c7)
