### PR TITLE
🐛 fix shell completion

### DIFF
--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -35,12 +35,10 @@ func AttachCLIs(rootCmd *cobra.Command, commands ...*Command) error {
 	}
 
 	connectorName, autoUpdate := detectConnectorName(os.Args, commands)
-	if connectorName == "" {
-		return nil
-	}
-
-	if _, err := providers.EnsureProvider(existing, connectorName, "", autoUpdate); err != nil {
-		return err
+	if connectorName != "" {
+		if _, err := providers.EnsureProvider(existing, connectorName, "", autoUpdate); err != nil {
+			return err
+		}
 	}
 
 	// Now that we know we have all providers, it's time to load them to build


### PR DESCRIPTION
The way it was written before, the 3 commands run/shell/scan were missing their providers when they are not in active use. The problem: shell-completion relies on them to exist.