### PR TITLE
🐛 also support the docker conn for cnquery shell docker <id>

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -198,6 +198,39 @@ var Config = plugin.Provider{
 			},
 		},
 		{
+			Name:    "docker",
+			Use:     "docker",
+			Short:   "a running docker or docker image",
+			MinArgs: 1,
+			MaxArgs: 2,
+			Discovery: []string{
+				docker_engine.DiscoveryContainerRunning,
+				docker_engine.DiscoveryContainerImages,
+			},
+			Flags: []plugin.Flag{
+				{
+					Long:        "sudo",
+					Type:        plugin.FlagType_Bool,
+					Default:     "false",
+					Desc:        "Elevate privileges with sudo.",
+					ConfigEntry: "sudo.active",
+				},
+				{
+					Long:    "id-detector",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "User override for platform ID detection mechanism",
+					Option:  plugin.FlagOption_Hidden,
+				},
+				{
+					Long:    "disable-cache",
+					Type:    plugin.FlagType_Bool,
+					Default: "false",
+					Desc:    "Disable the in-memory cache for images. WARNING: This will slow down scans significantly.",
+				},
+			},
+		},
+		{
 			Name:    "filesystem",
 			Aliases: []string{"fs"},
 			Use:     "filesystem [flags]",


### PR DESCRIPTION
```
[22/09/23 10:15:36] ❯ go run apps/cnquery/cnquery.go shell docker d0e78872d058
! using builtin provider for os
→ no Mondoo configuration file provided, using defaults
→ connected to Ubuntu 22.04.1 LTS
  ___ _ __   __ _ _   _  ___ _ __ _   _
 / __| '_ \ / _` | | | |/ _ \ '__| | | |
| (__| | | | (_| | |_| |  __/ |  | |_| |
 \___|_| |_|\__, |\__,_|\___|_|   \__, |
  mondoo™      |_|                |___/  interactive shell

cnquery> exit
```
```
[22/09/23 10:15:13] ❯ go run apps/cnquery/cnquery.go shell container d0e78872d058
! using builtin provider for os
→ no Mondoo configuration file provided, using defaults
→ connected to Ubuntu 22.04.1 LTS
  ___ _ __   __ _ _   _  ___ _ __ _   _
 / __| '_ \ / _` | | | |/ _ \ '__| | | |
| (__| | | | (_| | |_| |  __/ |  | |_| |
 \___|_| |_|\__, |\__,_|\___|_|   \__, |
  mondoo™      |_|                |___/  interactive shell

cnquery> exit
```

the argument for docker was also required in v8,
```
[22/09/23 10:13:15] ❯ cnquery shell docker
x either a target or a discovery flag different from "auto" must be provided for docker scans

~/go/src/go.mondoo.io/cnquery main*
[22/09/23 10:14:16] ❯ cnquery version
cnquery 8.28.4 (f7739318, 2023-09-20T10:09:07Z)

~/go/src/go.mondoo.io/cnquery main*
[22/09/23 10:14:31] ❯ cnquery shell docker d0e78872d058
→ no Mondoo configuration file provided. using defaults
→ discover related assets for 1 asset(s)
→ resolved assets resolved-assets=1
```