### PR TITLE
🐛 allow args for gcp connection

### DIFF
--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -20,9 +20,10 @@ var Config = plugin.Provider{
 	},
 	Connectors: []plugin.Connector{
 		{
-			Name:  "gcp",
-			Use:   "gcp",
-			Short: "GCP Cloud",
+			Name:    "gcp",
+			Use:     "gcp",
+			Short:   "GCP Cloud",
+			MaxArgs: 2,
 			Discovery: []string{
 				resources.DiscoveryAll,
 				resources.DiscoveryAuto,


### PR DESCRIPTION
```
[22/09/23 10:29:07] ❯ go run apps/cnquery/cnquery.go shell gcp project mondoo-dev-262313
! using builtin provider for gcp
→ no Mondoo configuration file provided, using defaults
→ connected to GCP Project mondoo-dev
  ___ _ __   __ _ _   _  ___ _ __ _   _
 / __| '_ \ / _` | | | |/ _ \ '__| | | |
| (__| | | | (_| | |_| |  __/ |  | |_| |
 \___|_| |_|\__, |\__,_|\___|_|   \__, |
  mondoo™      |_|                |___/  interactive shell

cnquery> asset { platform ids version kind }
asset: {
  kind: "gcp-object"
  version: ""
  platform: "gcp-project"
  ids: [
    0: "//platformid.api.mondoo.app/runtime/gcp/projects/mondoo-dev-262313"
  ]
}
cnquery> exit
```