### PR TITLE
🐛 support sudo over ssh on alpine

### DIFF
--- a/providers/os/connection/local/statutil/testdata/linux.toml
+++ b/providers/os/connection/local/statutil/testdata/linux.toml
@@ -4,22 +4,12 @@ stdout = "x86_64"
 [commands."uname -s"]
 stdout = "Linux"
 
-[commands."stat -L /etc/ssh/sshd_config --printf '%s\n%f\n%u\n%g\n%X\n%Y\n%C'"]
-stdout = """4317
-8180
-0
-0
-1590420240
-1590418792
+[commands."stat -L /etc/ssh/sshd_config -c '%s.%f.%u.%g.%X.%Y.%C'"]
+stdout = """4317.8180.0.0.1590420240.1590418792.?
 """
 
-[commands."stat -L /usr/bin/su --printf '%s\n%f\n%u\n%g\n%X\n%Y\n%C'"]
-stdout = """71728
-89ed
-0
-0
-1634057181
-1629123001
+[commands."stat -L /usr/bin/su -c '%s.%f.%u.%g.%X.%Y.%C'"]
+stdout = """71728.89ed.0.0.1634057181.1629123001.?
 """
 
 

--- a/providers/os/connection/ssh/cat/testdata/cat.toml
+++ b/providers/os/connection/ssh/cat/testdata/cat.toml
@@ -39,25 +39,15 @@ UsePAM yes
 """
 
 
-[commands."sudo stat -L /etc/ssh/sshd_config --printf '%s\n%f\n%u\n%g\n%X\n%Y\n%C'"]
-stdout = """4317
-8180
-0
-0
-1590420240
-1590418792
+[commands."sudo stat -L /etc/ssh/sshd_config -c '%s.%f.%u.%g.%X.%Y.%C'"]
+stdout = """4317.8180.0.0.1590420240.1590418792.?
 """
 
 [commands."sudo test -e /etc/ssh"]
 stdout = ""
 
-[commands."sudo stat -L /etc/ssh --printf '%s\n%f\n%u\n%g\n%X\n%Y\n%C'"]
-stdout = """271
-41ed
-0
-0
-1635245760
-1635147499
+[commands."sudo stat -L /etc/ssh -c '%s.%f.%u.%g.%X.%Y.%C'"]
+stdout = """271.41ed.0.0.1635245760.1635147499.?
 """
 
 [commands."sudo ls -1 '/etc/ssh'"]


### PR DESCRIPTION
stat does not support all the flags on Alpine, particularly printf. We can skip newline escapes, since we only grab simple fields. The only limitation here is the SElinux context, which we do not return yet (so we can revisit that then). Even so, it is the last value returned, so we can stick with `-c`