### PR TITLE
🐛 report on crashed provider + dedupe shutdown + fix multierr nil

### DIFF
--- a/utils/multierr/errors.go
+++ b/utils/multierr/errors.go
@@ -34,10 +34,11 @@ type Errors struct {
 }
 
 func (m *Errors) Add(err ...error) {
-	if err == nil {
-		return
+	for i := range err {
+		if err[i] != nil {
+			m.errors = append(m.errors, err[i])
+		}
 	}
-	m.errors = append(m.errors, err...)
 }
 
 func (m *Errors) Error() string {

--- a/utils/multierr/errors_test.go
+++ b/utils/multierr/errors_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package multierr_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/cnquery/utils/multierr"
+)
+
+func TestMultiErr(t *testing.T) {
+	t.Run("add nil errors", func(t *testing.T) {
+		var e multierr.Errors
+		e.Add(nil)
+		e.Add(nil, nil, nil)
+		assert.Nil(t, e.Deduplicate())
+	})
+
+	t.Run("add mixed errors", func(t *testing.T) {
+		var e multierr.Errors
+		e.Add(errors.New("1"), nil, errors.New("1"))
+		var b multierr.Errors
+		b.Add(errors.New("1"))
+		assert.Equal(t, b.Deduplicate(), e.Deduplicate())
+	})
+}


### PR DESCRIPTION
1. Crashed providers print their plugin panic and then an error message about being unable to shutdown the provider. This is wrong and misleading.
2. Since we have potentialy multiple runtimes, the shutdown call can come down multiple paths to the same provider, leading to duplication of errors and reporting. Fix it by giving providers one clear shutdown.
3. Multierr did not handle nil errors correctly and would then end up in panic-land. Fixed.

With these updates we get:

![image](https://github.com/mondoohq/cnquery/assets/1307529/d5f22d36-fe77-42ca-96f6-a5e4007aefbd)

Future ideas: hide away the panic behind a DEBUG flag