### PR TITLE
🐛 fix crash on user.members without init

### DIFF
--- a/providers/os/resources/group.go
+++ b/providers/os/resources/group.go
@@ -35,6 +35,10 @@ func (x *mqlGroup) members() ([]interface{}, error) {
 	}
 	users := raw.(*mqlUsers)
 
+	if err := users.refreshCache(nil); err != nil {
+		return nil, err
+	}
+
 	res := make([]interface{}, len(x.membersArr))
 	for i, name := range x.membersArr {
 		res[i] = users.usersByName[name]


### PR DESCRIPTION
Cannot request values from the list if we fail to initialize it in the firt place.