### PR TITLE
🐛 make filter queries optional

### DIFF
--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -672,7 +672,7 @@ func (s *localAssetScanner) runQueryPack() (*AssetReport, error) {
 
 // FilterQueries returns all queries whose result is truthy
 func (s *localAssetScanner) FilterQueries(queries []*explorer.Mquery, timeout time.Duration) ([]*explorer.Mquery, []error) {
-	return executor.RunFilterQueries(s.Runtime, queries, timeout)
+	return executor.ExecuteFilterQueries(s.Runtime, queries, timeout)
 }
 
 // UpdateFilters takes a list of test filters and runs them against the backend


### PR DESCRIPTION
Analogous to https://github.com/mondoohq/cnspec/pull/741

Also adjust naming of the filter function in the executor. This needs more deduplication of course, but a small step ... 🤏