### PR TITLE
🐛 Fix AWS VPC routetable id

### DIFF
--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -6030,7 +6030,12 @@ func createAwsVpcRoutetable(runtime *plugin.Runtime, args map[string]*llx.RawDat
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+	res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("aws.vpc.routetable", res.__id)

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -140,6 +140,10 @@ func (a *mqlAwsVpc) flowLogs() ([]interface{}, error) {
 	return flowLogs, nil
 }
 
+func (a *mqlAwsVpcRoutetable) id() (string, error) {
+  return a.Id.Data, nil
+}
+
 func (a *mqlAwsVpc) routeTables() ([]interface{}, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	vpcVal := a.Id.Data


### PR DESCRIPTION
Found this bug during #1827 

Before 

```
aws.vpcs.where[0].routeTables: [
  0: aws.vpc.routetable id="rtb-0d28b6f55dfe767c2"
  1: aws.vpc.routetable id="rtb-0d28b6f55dfe767c2"
]
```

Shows the same id twice

After

```
aws.vpcs.where[0].routeTables: [
  0: aws.vpc.routetable id="rtb-0d28b6f55dfe767c2"
  1: aws.vpc.routetable id="rtb-0952ff3c9d1568369"
]
```