### PR TITLE
🧹 new logic to customise inventory config clone

### DIFF
--- a/providers/gcp/resources/discovery.go
+++ b/providers/gcp/resources/discovery.go
@@ -77,7 +77,7 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 					Kind:    "gcp-object",
 				},
 				Labels:      map[string]string{},
-				Connections: []*inventory.Config{cloneConfig(conn.Conf)},
+				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery())},
 			})
 		}
 
@@ -195,7 +195,7 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject) 
 				},
 				Labels: labels,
 				// TODO: the current connection handling does not work well for instances
-				Connections: []*inventory.Config{cloneConfig(conn.Conf)}, // pass-in the parent connection config
+				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery())}, // pass-in the parent connection config
 			})
 		}
 	}
@@ -227,7 +227,7 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject) 
 					Kind:    "gcp-object",
 				},
 				Labels:      labels,
-				Connections: []*inventory.Config{cloneConfig(conn.Conf)}, // pass-in the parent connection config
+				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery())}, // pass-in the parent connection config
 			})
 		}
 	}
@@ -254,7 +254,7 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject) 
 					Kind:    "gcp-object",
 				},
 				Labels:      map[string]string{},
-				Connections: []*inventory.Config{cloneConfig(conn.Conf)}, // pass-in the parent connection config
+				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery())}, // pass-in the parent connection config
 			})
 		}
 	}
@@ -285,7 +285,7 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject) 
 					Kind:    "gcp-object",
 				},
 				Labels:      map[string]string{},
-				Connections: []*inventory.Config{cloneConfig(conn.Conf)}, // pass-in the parent connection config
+				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery())}, // pass-in the parent connection config
 			})
 		}
 	}
@@ -312,7 +312,7 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject) 
 					Kind:    "gcp-object",
 				},
 				Labels:      map[string]string{},
-				Connections: []*inventory.Config{cloneConfig(conn.Conf)}, // pass-in the parent connection config
+				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery())}, // pass-in the parent connection config
 			})
 		}
 	}
@@ -339,7 +339,7 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject) 
 					Kind:    "gcp-object",
 				},
 				Labels:      map[string]string{},
-				Connections: []*inventory.Config{cloneConfig(conn.Conf)}, // pass-in the parent connection config
+				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery())}, // pass-in the parent connection config
 			})
 		}
 	}
@@ -366,7 +366,7 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject) 
 					Kind:    "gcp-object",
 				},
 				Labels:      map[string]string{},
-				Connections: []*inventory.Config{cloneConfig(conn.Conf)}, // pass-in the parent connection config
+				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery())}, // pass-in the parent connection config
 			})
 		}
 	}
@@ -393,19 +393,12 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject) 
 					Kind:    "gcp-object",
 				},
 				Labels:      map[string]string{},
-				Connections: []*inventory.Config{cloneConfig(conn.Conf)}, // pass-in the parent connection config
+				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery())}, // pass-in the parent connection config
 			})
 		}
 	}
 
 	return assetList, nil
-}
-
-func cloneConfig(invConf *inventory.Config) *inventory.Config {
-	invConfClone := invConf.Clone()
-	// We do not want to run discovery again for the already discovered assets
-	invConfClone.Discover = &inventory.Discovery{}
-	return invConfClone
 }
 
 func resolveGcr(ctx context.Context, conf *inventory.Config) ([]*inventory.Asset, error) {

--- a/providers/k8s/resources/discovery.go
+++ b/providers/k8s/resources/discovery.go
@@ -123,7 +123,7 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 			PlatformIds: []string{assetId},
 			Name:        conn.Name(),
 			Platform:    conn.Platform(),
-			Connections: []*inventory.Config{cloneConfig(invConfig)}, // pass-in the parent connection config
+			Connections: []*inventory.Config{invConfig.Clone(inventory.WithoutDiscovery())}, // pass-in the parent connection config
 		}
 		if slices.Contains(invConfig.Discover.Targets, DiscoveryClusters) {
 			in.Spec.Assets = append(in.Spec.Assets, root)
@@ -296,7 +296,7 @@ func discoverPods(
 			Name:        pod.Namespace.Data + "/" + pod.Name.Data,
 			Platform:    platform,
 			Labels:      labels,
-			Connections: []*inventory.Config{cloneConfig(invConfig)}, // pass-in the parent connection config
+			Connections: []*inventory.Config{invConfig.Clone(inventory.WithoutDiscovery())}, // pass-in the parent connection config
 		})
 		od.Add(pod.obj)
 	}
@@ -340,7 +340,7 @@ func discoverJobs(
 			Name:        job.Namespace.Data + "/" + job.Name.Data,
 			Platform:    platform,
 			Labels:      labels,
-			Connections: []*inventory.Config{cloneConfig(invConfig)}, // pass-in the parent connection config
+			Connections: []*inventory.Config{invConfig.Clone(inventory.WithoutDiscovery())}, // pass-in the parent connection config
 		})
 		od.Add(job.obj)
 	}
@@ -384,7 +384,7 @@ func discoverCronJobs(
 			Name:        cjob.Namespace.Data + "/" + cjob.Name.Data,
 			Platform:    platform,
 			Labels:      labels,
-			Connections: []*inventory.Config{cloneConfig(invConfig)}, // pass-in the parent connection config
+			Connections: []*inventory.Config{invConfig.Clone(inventory.WithoutDiscovery())}, // pass-in the parent connection config
 		})
 		od.Add(cjob.obj)
 	}
@@ -428,7 +428,7 @@ func discoverStatefulSets(
 			Name:        statefulset.Namespace.Data + "/" + statefulset.Name.Data,
 			Platform:    platform,
 			Labels:      labels,
-			Connections: []*inventory.Config{cloneConfig(invConfig)}, // pass-in the parent connection config
+			Connections: []*inventory.Config{invConfig.Clone(inventory.WithoutDiscovery())}, // pass-in the parent connection config
 		})
 		od.Add(statefulset.obj)
 	}
@@ -472,7 +472,7 @@ func discoverDeployments(
 			Name:        deployment.Namespace.Data + "/" + deployment.Name.Data,
 			Platform:    platform,
 			Labels:      labels,
-			Connections: []*inventory.Config{cloneConfig(invConfig)}, // pass-in the parent connection config
+			Connections: []*inventory.Config{invConfig.Clone(inventory.WithoutDiscovery())}, // pass-in the parent connection config
 		})
 		od.Add(deployment.obj)
 	}
@@ -516,7 +516,7 @@ func discoverReplicaSets(
 			Name:        replicaset.Namespace.Data + "/" + replicaset.Name.Data,
 			Platform:    platform,
 			Labels:      labels,
-			Connections: []*inventory.Config{cloneConfig(invConfig)}, // pass-in the parent connection config
+			Connections: []*inventory.Config{invConfig.Clone(inventory.WithoutDiscovery())}, // pass-in the parent connection config
 		})
 		od.Add(replicaset.obj)
 	}
@@ -560,7 +560,7 @@ func discoverDaemonSets(
 			Name:        daemonset.Namespace.Data + "/" + daemonset.Name.Data,
 			Platform:    platform,
 			Labels:      labels,
-			Connections: []*inventory.Config{cloneConfig(invConfig)}, // pass-in the parent connection config
+			Connections: []*inventory.Config{invConfig.Clone(inventory.WithoutDiscovery())}, // pass-in the parent connection config
 		})
 		od.Add(daemonset.obj)
 	}
@@ -634,7 +634,7 @@ func discoverIngresses(
 			Name:        ingress.Namespace.Data + "/" + ingress.Name.Data,
 			Platform:    platform,
 			Labels:      labels,
-			Connections: []*inventory.Config{cloneConfig(invConfig)}, // pass-in the parent connection config
+			Connections: []*inventory.Config{invConfig.Clone(inventory.WithoutDiscovery())}, // pass-in the parent connection config
 		})
 		od.Add(ingress.obj)
 	}
@@ -686,7 +686,7 @@ func discoverNamespaces(
 			Name:        ns.Name,
 			Platform:    platform,
 			Labels:      labels,
-			Connections: []*inventory.Config{cloneConfig(invConfig)}, // pass-in the parent connection config
+			Connections: []*inventory.Config{invConfig.Clone(inventory.WithoutDiscovery())}, // pass-in the parent connection config
 		})
 		if od != nil {
 			od.Add(&ns)
@@ -869,13 +869,6 @@ func createPlatformData(objectKind, runtime string) (*inventory.Platform, error)
 		return nil, fmt.Errorf("could not determine object kind %s", objectKind)
 	}
 	return platformData, nil
-}
-
-func cloneConfig(invConf *inventory.Config) *inventory.Config {
-	invConfClone := invConf.Clone()
-	// We do not want to run discovery again for the already discovered assets
-	invConfClone.Discover = &inventory.Discovery{}
-	return invConfClone
 }
 
 func setRelatedAssets(conn shared.Connection, root *inventory.Asset, assets []*inventory.Asset, od *PlatformIdOwnershipIndex) {


### PR DESCRIPTION
We use a similar logic in multiple providers to clone a config but remove the discovery options. This is useful since we most likely do not want the discovery options when we clone. This change makes the the `config.Clone()` more smart by providing more options that can be provided. It makes the code of the providers more readable.