### PR TITLE
✨ Install a specific provider version

### DIFF
--- a/apps/cnquery/cmd/providers.go
+++ b/apps/cnquery/cmd/providers.go
@@ -82,10 +82,11 @@ var installProviderCmd = &cobra.Command{
 }
 
 func installProviderByVersion(name string, version string) {
-	_, err := providers.Install(name, version)
+	installed, err := providers.Install(name, version)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to install")
 	}
+	providers.PrintInstallResults([]*providers.Provider{installed})
 }
 
 func installProviderUrl(u string) {

--- a/apps/cnquery/cmd/providers.go
+++ b/apps/cnquery/cmd/providers.go
@@ -52,7 +52,7 @@ var listProvidersCmd = &cobra.Command{
 var installProviderCmd = &cobra.Command{
 	Use:    "install <NAME>",
 	Short:  "Install or update a provider.",
-	Args:   cobra.MinimumNArgs(1),
+	Args:   cobra.ExactArgs(1),
 	Long:   "",
 	PreRun: func(cmd *cobra.Command, args []string) {},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/apps/cnquery/cmd/providers.go
+++ b/apps/cnquery/cmd/providers.go
@@ -26,6 +26,7 @@ func init() {
 
 	installProviderCmd.Flags().StringP("file", "f", "", "install a provider via a file")
 	installProviderCmd.Flags().String("url", "", "install a provider via URL")
+	installProviderCmd.Flags().String("version", "", "install a specific version of a provider")
 }
 
 var ProvidersCmd = &cobra.Command{
@@ -51,9 +52,17 @@ var listProvidersCmd = &cobra.Command{
 var installProviderCmd = &cobra.Command{
 	Use:    "install <NAME>",
 	Short:  "Install or update a provider.",
+	Args:   cobra.MinimumNArgs(1),
 	Long:   "",
 	PreRun: func(cmd *cobra.Command, args []string) {},
 	Run: func(cmd *cobra.Command, args []string) {
+		// If there's a version and a name, we can install the version, using the default home url for
+		// providers
+		version, _ := cmd.Flags().GetString("version")
+		if version != "" {
+			installProviderByVersion(args[0], version)
+			return
+		}
 		// Explicit installs of files will ignore version recommendations.
 		// So we just take them and roll with it.
 		path, _ := cmd.Flags().GetString("file")
@@ -70,6 +79,13 @@ var installProviderCmd = &cobra.Command{
 
 		log.Fatal().Msg("cannot install providers by name yet")
 	},
+}
+
+func installProviderByVersion(name string, version string) {
+	_, err := providers.Install(name, version)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to install")
+	}
 }
 
 func installProviderUrl(u string) {

--- a/apps/cnquery/cmd/providers.go
+++ b/apps/cnquery/cmd/providers.go
@@ -49,9 +49,8 @@ var listProvidersCmd = &cobra.Command{
 }
 
 var installProviderCmd = &cobra.Command{
-	Use:    "install <NAME@[VERSION]>",
+	Use:    "install <NAME[@VERSION]>",
 	Short:  "Install or update a provider.",
-	Args:   cobra.ExactArgs(1),
 	Long:   "",
 	PreRun: func(cmd *cobra.Command, args []string) {},
 	Run: func(cmd *cobra.Command, args []string) {
@@ -67,6 +66,10 @@ var installProviderCmd = &cobra.Command{
 		if url != "" {
 			installProviderUrl(url)
 			return
+		}
+
+		if len(args) == 0 {
+			log.Fatal().Msg("no provider specified, use the NAME[@VERSION] format to pass in a provider name")
 		}
 
 		// if no url or file is specified, we default to installing by name from the default upstream

--- a/apps/cnquery/cmd/providers.go
+++ b/apps/cnquery/cmd/providers.go
@@ -26,7 +26,6 @@ func init() {
 
 	installProviderCmd.Flags().StringP("file", "f", "", "install a provider via a file")
 	installProviderCmd.Flags().String("url", "", "install a provider via URL")
-	installProviderCmd.Flags().String("version", "", "install a specific version of a provider")
 }
 
 var ProvidersCmd = &cobra.Command{
@@ -50,7 +49,7 @@ var listProvidersCmd = &cobra.Command{
 }
 
 var installProviderCmd = &cobra.Command{
-	Use:    "install <NAME>",
+	Use:    "install <NAME@[VERSION]>",
 	Short:  "Install or update a provider.",
 	Args:   cobra.ExactArgs(1),
 	Long:   "",

--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -235,7 +235,7 @@ func (c *coordinator) tryProviderUpdate(provider *Provider, update UpdateProvide
 	if err != nil {
 		return nil, err
 	}
-
+	PrintInstallResults([]*Provider{provider})
 	now := time.Now()
 	if err := os.Chtimes(binPath, now, now); err != nil {
 		log.Warn().

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -176,8 +176,12 @@ func EnsureProvider(existing Providers, connectorName string, connectorType stri
 	}
 
 	nu, err := Install(upstream.Name, "")
+	if err != nil {
+		return nil, err
+	}
 	existing.Add(nu)
-	return nu, err
+	PrintInstallResults([]*Provider{nu})
+	return nu, nil
 }
 
 func Install(name string, version string) (*Provider, error) {
@@ -245,7 +249,6 @@ func installVersion(name string, version string) (*Provider, error) {
 	// otherwise it will load old data
 	CachedProviders = nil
 
-	PrintInstallResults(installed)
 	return installed[0], nil
 }
 

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -185,11 +185,8 @@ func EnsureProvider(existing Providers, connectorName string, connectorType stri
 }
 
 func Install(name string, version string) (*Provider, error) {
-	if version != "" {
-		// we remove the v prefix if passing in a version that looks like 'v9.0.0'
-		version = strings.TrimPrefix(version, "v")
-	} else {
-		// else, if no version is specified, we default to installing the latest one
+	if version == "" {
+		// if no version is specified, we default to installing the latest one
 		latestVersion, err := LatestVersion(name)
 		if err != nil {
 			return nil, err

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -181,7 +181,11 @@ func EnsureProvider(existing Providers, connectorName string, connectorType stri
 }
 
 func Install(name string, version string) (*Provider, error) {
-	if version == "" {
+	if version != "" {
+		// we remove the v prefix if passing in a version that looks like 'v9.0.0'
+		version = strings.TrimPrefix(version, "v")
+	} else {
+		// else, if no version is specified, we default to installing the latest one
 		latestVersion, err := LatestVersion(name)
 		if err != nil {
 			return nil, err

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -175,15 +175,18 @@ func EnsureProvider(existing Providers, connectorName string, connectorType stri
 		return nil, errors.New("cannot find installed provider for connection " + connectorName)
 	}
 
-	nu, err := Install(upstream.Name)
+	nu, err := Install(upstream.Name, "")
 	existing.Add(nu)
 	return nu, err
 }
 
-func Install(name string) (*Provider, error) {
-	version, err := LatestVersion(name)
-	if err != nil {
-		return nil, err
+func Install(name string, version string) (*Provider, error) {
+	if version == "" {
+		latestVersion, err := LatestVersion(name)
+		if err != nil {
+			return nil, err
+		}
+		version = latestVersion
 	}
 
 	log.Info().


### PR DESCRIPTION
Allows users to install providers by just name or ver
```
➜ ~/go/bin/cnquery providers  install okta@9.0.0                             
→ installing provider 'okta' version=9.0.0
→ successfully installed okta provider path=/Users/preslavgerchev/.config/mondoo/providers/okta version=9.0.0
```

```
➜ ~/go/bin/cnquery providers  install okta@9.0.1
→ installing provider 'okta' version=9.0.1
FTL failed to install error="cannot find provider okta-9.0.1 under url https://releases.mondoo.com/providers/okta/9.0.1/okta_9.0.1_darwin_arm64.tar.xz"
```
There's an issue with the CLI pre-processing, I will look into it, seems unrelated to the changes in this PR