### PR TITLE
🐛 use gitlab mql group projects for project init

### DIFF
--- a/motor/discovery/gitlab/gitlab.go
+++ b/motor/discovery/gitlab/gitlab.go
@@ -131,8 +131,6 @@ func (r *Resolver) Resolve(ctx context.Context, root *asset.Asset, pCfg *provide
 			})
 
 			if pCfg.IncludesOneOfDiscoveryTarget(common.DiscoveryAuto, common.DiscoveryAll, DiscoveryProject) {
-				p.Client().Projects.ListProjects(&gitlab.ListProjectsOptions{})
-
 				for _, project := range grp.Projects {
 					clonedConfig := pCfg.Clone()
 					if clonedConfig.Options == nil {


### PR DESCRIPTION
...i was able to reproduce the error that led to creating this pr earlier, and now i cannot. i do not understand why. 

in any case, this is the error that was reported:
```
failed to create resource 'gitlab.project': GET https://gitlab.com/api/v4...
404 {message: 404 Project Not Found}
```

we were previously hitting the api every time we init-ed a project..this changes it to use the group projects. i kept on convincing myself this wasn't correct, but since we always require a group along with a project, it does still work. and it means we don't hit the api every time 
