### PR TITLE
🐛 fix error when cloning resources

### DIFF
--- a/llx/runtime.go
+++ b/llx/runtime.go
@@ -9,7 +9,7 @@ type Runtime interface {
 	AssetMRN() string
 	Unregister(watcherUID string) error
 	CreateResource(name string, args map[string]*Primitive) (Resource, error)
-	CreateResourceWithID(name string, id string, args map[string]*Primitive) (Resource, error)
+	CloneResource(src Resource, id string, fields []string, args map[string]*Primitive) (Resource, error)
 	WatchAndUpdate(resource Resource, field string, watcherUID string, callback func(res interface{}, err error)) error
 	Schema() Schema
 	Close()


### PR DESCRIPTION
Mandatory arguments were never submitted, because the new provider concept meant that we had to request all the fields individually. We were missing a good pattern to execute this.

Turns out the CreateResourceWithID was only used in one place and its primary purpose was to clone the resource. This method has now been adjusted to better reflect its purpose and its arguments can now do the heavy lifting or getting all the necessary fields for cloning the resource. This method can be further refined to grab mandatory fields automatically.

Before:

![image](https://github.com/mondoohq/cnquery/assets/1307529/8725d87e-a8ac-49bd-a1cb-042c6bd008c7)

After:

![image](https://github.com/mondoohq/cnquery/assets/1307529/3bc73ce6-2262-4d29-a7b6-825bfb0da449)
