### PR TITLE
⭐️ Provider Builder v2

### DIFF
--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -21,6 +21,7 @@ env:
 
 jobs:
   scoping:
+    name: "Scoping"
     runs-on: self-hosted
     timeout-minutes: 10
     outputs:

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -33,7 +33,6 @@ jobs:
       - name: Detect providers
         id: providers
         run: |
-          SKIP_PROVIDERS="core xx"
           providers=$(find providers -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
           build=""
           root=$PWD

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -122,9 +122,9 @@ jobs:
             VERSION=$(echo $pkg | cut -f2 -d_)
             echo "Publishing $pkg: $PROVIDER $VERSION"
 
-            echo "Publishing $pkg to gs://${BUCKET}/providers/${PROVIDER}/${PROVIDER}_${VERSION}/"
-            gsutil -m cp -c dist/${pkg}*.xz gs://${BUCKET}/providers/${PROVIDER}/${PROVIDER}_${VERSION}/
-            gsutil -m cp -c dist/${pkg}_SHA256SUMS gs://${BUCKET}/providers/${PROVIDER}/${PROVIDER}_${VERSION}/
+            echo "Publishing $pkg to gs://${BUCKET}/providers/${PROVIDER}/${VERSION}/"
+            gsutil -m cp -c dist/${pkg}*.xz gs://${BUCKET}/providers/${PROVIDER}/${VERSION}/
+            gsutil -m cp -c dist/${pkg}_SHA256SUMS gs://${BUCKET}/providers/${PROVIDER}/${VERSION}/
           done
 
       - name: 'Save Artifacts'

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -22,6 +22,8 @@ jobs:
   scoping:
     runs-on: self-hosted
     timeout-minutes: 10
+    outputs:
+      providers: ${{ steps.providers.outputs.providers }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,10 +32,10 @@ jobs:
       - name: Detect providers
         id: providers
         run: |
-          p=$(find providers -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
-          providers=$p # This removes the trailing newlines
-          echo "providers=\"$providers\"" >> $GITHUB_OUTPUT
-          echo "PROVIDERS=\"$providers\"" >> $GITHUB_ENV
+          { echo "providers="<<EOF
+            $(find providers -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+            echo EOF
+          } >> $GITHUB_OUTPUT
 
   provider-build:
     name: "${{ matrix.provider }}"

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -30,10 +30,10 @@ jobs:
       - name: Detect providers
         id: providers
         run: |
-          providers=$(find providers -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
-          echo "::set-output name=providers::$providers"
+          p=$(find providers -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+          providers=$p # This removes the trailing newlines
+          echo "providers=$providers" >> $GITHUB_OUTPUT
           echo "PROVIDERS=$providers" >> $GITHUB_ENV
-          echo "Detected providers: $providers"
 
   provider-build:
     name: "${{ matrix.provider }}"

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -53,7 +53,7 @@ jobs:
             printf "PROVIDER $p:\n  Local version: $REPO_VERSION\n  Remote version: $DIST_VERSION\n"
             if [[ $REPO_VERSION != $DIST_VERSION ]]; then
               echo "  Adding $p to build list"
-              build="$build $p"
+              build="$build\n$p"
             else
               echo "  Skipping: Provider version unchanged."
             fi

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -54,15 +54,14 @@ jobs:
             printf "PROVIDER $p:\n  Local version: $REPO_VERSION\n  Remote version: $DIST_VERSION\n"
             if [[ $REPO_VERSION != $DIST_VERSION ]]; then
               echo "  Adding $p to build list"
-              build="$build\n$p"
+              build="$build $p"
             else
               echo "  Skipping: Provider version unchanged."
             fi
             cd $root
           done
 
-          printf '%s\n' "${build[@]}" | jq -R . | jq -sc . > providers.json
-          echo "providers=$(cat providers.json)" >> $GITHUB_OUTPUT
+          echo -n $build | jq -Rsc 'split(" ")' >> $GITHUB_OUTPUT
 
           if [[ ${{ github.event.inputs.build_all }} == 'true' ]]; then
             echo "Forced build of all providers"

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -64,6 +64,12 @@ jobs:
           printf '%s\n' "${build[@]}" | jq -R . | jq -sc . > providers.json
           echo "providers=$(cat providers.json)" >> $GITHUB_OUTPUT
 
+          if [[ ${{ github.event.inputs.build_all }} == 'true' ]]; then
+            echo "Forced build of all providers"
+            printf '%s\n' "${providers[@]}" | jq -R . | jq -sc . > providers.json
+            echo "providers=$(cat providers.json)" >> $GITHUB_OUTPUT
+          fi
+
           echo "Providers detected:"
           echo $providers
 
@@ -123,7 +129,7 @@ jobs:
           done
 
       - name: 'Save Artifacts'
-        if: ${{ github.event.inputs.skip_publish == 'false' }}
+        if: ${{ github.event.inputs.skip_publish == 'true' }}
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.provider }}

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -17,6 +17,7 @@ on:
 
 env:
   BUCKET: releases-us.mondoo.io
+  SKIP_PROVIDERS: "core"
 
 jobs:
   scoping:
@@ -32,12 +33,42 @@ jobs:
       - name: Detect providers
         id: providers
         run: |
+          SKIP_PROVIDERS="core xx"
           providers=$(find providers -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
-          printf '%s\n' "${providers[@]}" | jq -R . | jq -sc . > providers.json
+          build=""
+          root=$PWD
+          for p in $providers; do
+            skip=0
+            for s in $SKIP_PROVIDERS; do
+              if [[ $p == $s ]]; then
+                skip=1
+              fi
+            done
+            if [[ $skip == 1 ]]; then
+              echo "$p is on the skip list. Skipping."
+              continue
+            fi
+            cd providers/$p
+            REPO_VERSION=$(grep Version config/config.go | cut -f2 -d\")
+            DIST_VERSION=$(curl -s https://releases.mondoo.com/providers/${p}/latest.json | jq -r .version)
+            printf "PROVIDER $p:\n  Local version: $REPO_VERSION\n  Remote version: $DIST_VERSION\n"
+            if [[ $REPO_VERSION != $DIST_VERSION ]]; then
+              echo "  Adding $p to build list"
+              build="$build $p"
+            else
+              echo "  Skipping: Provider version unchanged."
+            fi
+            cd $root
+          done
+
+          printf '%s\n' "${build[@]}" | jq -R . | jq -sc . > providers.json
           echo "providers=$(cat providers.json)" >> $GITHUB_OUTPUT
 
           echo "Providers detected:"
           echo $providers
+
+          echo "Providers to build:"
+          echo $build
 
   provider-build:
     name: "${{ matrix.provider }}"
@@ -53,24 +84,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Check for changes
-        id: version
-        run: |
-          echo "Checking for changes in ${{ matrix.provider }}"
-          cd providers/${{ matrix.provider }}
-          REPO_VERSION=$(grep Version config/config.go | cut -f2 -d\")
-          echo "REPO_VERSION=$REPO_VERSION" >> $GITHUB_ENV
-          DIST_VERSION=$(curl -s https://releases-us.mondoo.io/providers/${{ matrix.provider }}/latest.json | jq -r .version)
-          echo "DIST_VERSION=$DIST_VERSION" >> $GITHUB_ENV
-          echo "Version in this repo:           $REPO_VERSION"
-          echo "Version on releases.mondoo.com: $DIST_VERSION"
-
-      - name: Abort if no change
-        if: ${{ github.event.inputs.build_all == 'false' && steps.version.outputs.REPO_VERSION == steps.version.outputs.DIST_VERSION }}
-        run: |
-          echo "No changes to version detected for ${{ matrix.provider }}. Skipping build."
-          exit 78
 
       - name: Set up Go
         uses: actions/setup-go@v4

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -33,7 +33,9 @@ jobs:
         id: providers
         run: |
           find providers -mindepth 1 -maxdepth 1 -type d -exec basename {} \; > providers.list
-          echo "providers=$(cat providers.list | tr '\n' ' ')" >> $GITHUB_OUTPUT
+          echo "providers=$(cat providers.list | tr '\n' ',')" >> $GITHUB_OUTPUT
+          echo "Providers detected:"
+          cat providers.list
 
   provider-build:
     name: "${{ matrix.provider }}"
@@ -43,7 +45,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        provider: ${{ needs.scoping.outputs.providers }}
+        provider: [ ${{ needs.scoping.outputs.providers }} ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -113,7 +115,7 @@ jobs:
           path: dist
 
   provider-index:
-    needs: provider-build
+    needs: [provider-build, scoping]
     runs-on: self-hosted
     steps:
       - name: Trigger Reindex of releases.mondoo.com

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -1,6 +1,9 @@
 name: 'Build & Release Providers'
 
 on:
+  push:
+    branches: ['main']
+    paths: ['providers/**']
   workflow_dispatch:
     inputs:
       build_all:

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -2,23 +2,69 @@ name: 'Build & Release Providers'
 
 on:
   workflow_dispatch:
+    inputs:
+      build_all:
+        description: 'Force build all providers'
+        required: false
+        default: 'false'
+      skip_publish:
+        description: 'Skip publishing'
+        required: false
+        default: 'false'
+
 
 env:
   BUCKET: releases-us.mondoo.io
 
 jobs:
-  provider-build:
+  scoping:
     runs-on: self-hosted
-    timeout-minutes: 120
-    strategy:
-      max-parallel: 2
-      matrix:
-        provider: [arista, aws, azure, equinix, gcp, github, gitlab, google-workspace, ipmi, k8s, ms365, network, oci, okta, opcua, os, slack, terraform, vcd, vsphere ]
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Detect providers
+        id: providers
+        run: |
+          providers=$(find providers -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+          echo "::set-output name=providers::$providers")"
+          echo "PROVIDERS=$providers" >> $GITHUB_ENV
+          echo "Detecting providers: $providers"
+
+  provider-build:
+    name: "${{ matrix.provider }}"
+    runs-on: self-hosted
+    timeout-minutes: 120
+    needs: scoping
+    strategy:
+      max-parallel: 2
+      matrix:
+        provider: ${{ needs.scoping.outputs.providers }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes
+        id: version
+        run: |
+          echo "Checking for changes in ${{ matrix.provider }}"
+          cd providers/${{ matrix.provider }}
+          REPO_VERSION=$(grep Version config/config.go | cut -f2 -d\")
+          echo "REPO_VERSION=$REPO_VERSION" >> $GITHUB_ENV
+          DIST_VERSION=$(curl -s https://releases-us.mondoo.io/providers/${{ matrix.provider }}/latest.json | jq -r .version)
+          echo "DIST_VERSION=$DIST_VERSION" >> $GITHUB_ENV
+
+      - name: Skip if no changes
+        if: ${{ github.event.inputs.build_all == 'false' }}
+        run: |
+          if [ "$REPO_VERSION" == "$DIST_VERSION" ]; then
+            echo "No change to version detected for ${{ matrix.provider }}. Skipping build."
+            exit 78
+          fi
 
       - name: Set up Go
         uses: actions/setup-go@v4
@@ -45,16 +91,24 @@ jobs:
           scripts/provider_bundler.sh ${{ matrix.provider }}
 
       - name: 'Publish Provider'
+        if: ${{ github.event.inputs.skip_publish == 'false' }}
         run: |
           for pkg in $(ls dist | cut -f1,2 -d_ | uniq); do
             echo "Publishing $pkg"
             PROVIDER=$(echo $pkg | cut -f1 -d_)
-            VERSION=$(echo $pkg | cut -f2 -d_)
+            VERSION=$REPO_VERSION
 
             echo "Publishing $pkg to gs://${BUCKET}/providers/${PROVIDER}/${VERSION}/"
             gsutil -m cp -c dist/${pkg}*.xz gs://${BUCKET}/providers/${PROVIDER}/${VERSION}/
             gsutil -m cp -c dist/${pkg}_SHA256SUMS gs://${BUCKET}/providers/${PROVIDER}/${VERSION}/
           done
+
+      - name: 'Save Artifacts'
+        if: ${{ github.event.inputs.skip_publish == 'false' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.provider }}
+          path: dist
 
   provider-index:
     needs: provider-build

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -63,14 +63,14 @@ jobs:
           echo "REPO_VERSION=$REPO_VERSION" >> $GITHUB_ENV
           DIST_VERSION=$(curl -s https://releases-us.mondoo.io/providers/${{ matrix.provider }}/latest.json | jq -r .version)
           echo "DIST_VERSION=$DIST_VERSION" >> $GITHUB_ENV
+          echo "Version in this repo:           $REPO_VERSION"
+          echo "Version on releases.mondoo.com: $DIST_VERSION"
 
-      - name: Skip if no changes
-        if: ${{ github.event.inputs.build_all == 'false' }}
+      - name: Abort if no change
+        if: ${{ github.event.inputs.build_all == 'false' && steps.version.outputs.REPO_VERSION == steps.version.outputs.DIST_VERSION }}
         run: |
-          if [ "$REPO_VERSION" == "$DIST_VERSION" ]; then
-            echo "No change to version detected for ${{ matrix.provider }}. Skipping build."
-            exit 78
-          fi
+          echo "No changes to version detected for ${{ matrix.provider }}. Skipping build."
+          exit 78
 
       - name: Set up Go
         uses: actions/setup-go@v4

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -32,10 +32,12 @@ jobs:
       - name: Detect providers
         id: providers
         run: |
-          find providers -mindepth 1 -maxdepth 1 -type d -exec basename {} \; > providers.list
-          echo "providers=$(cat providers.list | tr '\n' ',')" >> $GITHUB_OUTPUT
+          providers=$(find providers -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+          printf '%s\n' "${providers[@]}" | jq -R . | jq -sc . > providers.json
+          echo "providers=$(cat providers.json)" >> $GITHUB_OUTPUT
+
           echo "Providers detected:"
-          cat providers.list
+          echo $providers
 
   provider-build:
     name: "${{ matrix.provider }}"
@@ -45,7 +47,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        provider: [ ${{ needs.scoping.outputs.providers }} ]
+        provider: ${{ fromJSON(needs.scoping.outputs.providers) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -32,10 +32,8 @@ jobs:
       - name: Detect providers
         id: providers
         run: |
-          { echo "providers="<<EOF
-            $(find providers -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
-            echo EOF
-          } >> $GITHUB_OUTPUT
+          find providers -mindepth 1 -maxdepth 1 -type d -exec basename {} \;) > providers.list
+          echo "providers=$(cat providers.list)" >> $GITHUB_OUTPUT
 
   provider-build:
     name: "${{ matrix.provider }}"

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -118,13 +118,13 @@ jobs:
         if: ${{ github.event.inputs.skip_publish == 'false' }}
         run: |
           for pkg in $(ls dist | cut -f1,2 -d_ | uniq); do
-            echo "Publishing $pkg"
             PROVIDER=$(echo $pkg | cut -f1 -d_)
-            VERSION=$REPO_VERSION
+            VERSION=$(echo $pkg | cut -f2 -d_)
+            echo "Publishing $pkg: $PROVIDER $VERSION"
 
-            echo "Publishing $pkg to gs://${BUCKET}/providers/${PROVIDER}/${VERSION}/"
-            gsutil -m cp -c dist/${pkg}*.xz gs://${BUCKET}/providers/${PROVIDER}/${VERSION}/
-            gsutil -m cp -c dist/${pkg}_SHA256SUMS gs://${BUCKET}/providers/${PROVIDER}/${VERSION}/
+            echo "Publishing $pkg to gs://${BUCKET}/providers/${PROVIDER}/${PROVIDER}_${VERSION}/"
+            gsutil -m cp -c dist/${pkg}*.xz gs://${BUCKET}/providers/${PROVIDER}/${PROVIDER}_${VERSION}/
+            gsutil -m cp -c dist/${pkg}_SHA256SUMS gs://${BUCKET}/providers/${PROVIDER}/${PROVIDER}_${VERSION}/
           done
 
       - name: 'Save Artifacts'

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Detect providers
         id: providers
         run: |
-          find providers -mindepth 1 -maxdepth 1 -type d -exec basename {} \;) > providers.list
+          find providers -mindepth 1 -maxdepth 1 -type d -exec basename {} \; > providers.list
           echo "providers=$(cat providers.list)" >> $GITHUB_OUTPUT
 
   provider-build:

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -33,7 +33,7 @@ jobs:
         id: providers
         run: |
           find providers -mindepth 1 -maxdepth 1 -type d -exec basename {} \; > providers.list
-          echo "providers=$(cat providers.list)" >> $GITHUB_OUTPUT
+          echo "providers=$(cat providers.list | tr '\n' ' ')" >> $GITHUB_OUTPUT
 
   provider-build:
     name: "${{ matrix.provider }}"

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -32,8 +32,8 @@ jobs:
         run: |
           p=$(find providers -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
           providers=$p # This removes the trailing newlines
-          echo "providers=$providers" >> $GITHUB_OUTPUT
-          echo "PROVIDERS=$providers" >> $GITHUB_ENV
+          echo "providers=\"$providers\"" >> $GITHUB_OUTPUT
+          echo "PROVIDERS=\"$providers\"" >> $GITHUB_ENV
 
   provider-build:
     name: "${{ matrix.provider }}"

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -5,10 +5,12 @@ on:
     inputs:
       build_all:
         description: 'Force build all providers'
+        type: boolean
         required: false
         default: 'false'
       skip_publish:
         description: 'Skip publishing'
+        type: boolean
         required: false
         default: 'false'
 

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -31,9 +31,9 @@ jobs:
         id: providers
         run: |
           providers=$(find providers -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
-          echo "::set-output name=providers::$providers")"
+          echo "::set-output name=providers::$providers"
           echo "PROVIDERS=$providers" >> $GITHUB_ENV
-          echo "Detecting providers: $providers"
+          echo "Detected providers: $providers"
 
   provider-build:
     name: "${{ matrix.provider }}"

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -61,7 +61,7 @@ jobs:
             cd $root
           done
 
-          echo -n $build | jq -Rsc 'split(" ")' >> $GITHUB_OUTPUT
+          echo "providers=$(echo -n $build | jq -Rsc 'split(" ")')" >> $GITHUB_OUTPUT
 
           if [[ ${{ github.event.inputs.build_all }} == 'true' ]]; then
             echo "Forced build of all providers"

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -193,7 +193,7 @@ func Install(name string) (*Provider, error) {
 }
 
 // This is the default installation source for core providers.
-const upstreamURL = "https://releases.mondoo.com/providers/{NAME}/{VERSION}/{NAME}_{VERSION}_{OS}_{ARCH}.tar.xz"
+const upstreamURL = "https://releases.mondoo.com/providers/{NAME}/{NAME}_{VERSION}/{NAME}_{VERSION}_{OS}_{ARCH}.tar.xz"
 
 func installVersion(name string, version string) (*Provider, error) {
 	url := upstreamURL

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -193,7 +193,7 @@ func Install(name string) (*Provider, error) {
 }
 
 // This is the default installation source for core providers.
-const upstreamURL = "https://releases.mondoo.com/providers/{NAME}/{NAME}_{VERSION}/{NAME}_{VERSION}_{OS}_{ARCH}.tar.xz"
+const upstreamURL = "https://releases.mondoo.com/providers/{NAME}/{VERSION}/{NAME}_{VERSION}_{OS}_{ARCH}.tar.xz"
 
 func installVersion(name string, version string) (*Provider, error) {
 	url := upstreamURL


### PR DESCRIPTION
This change introduces several improvements to building of providers:

- Only providers which are changed are built.  This is determined by examining the version of each provider in the repo and comparing that version number against that of the latest.json on releases.mondoo.com.  If the number is the same the provider is skipped in the build process.  If it is different the provider is build and deployed.
- Providers are built any time a push to main includes a change in the providers/ directory
- The manual invocation of the workflow includes the ability to forcably build and deploy all providers and also the ability to skip publishing
- Providers that are built but not deployed (such as by forcing a skip such as above) will retain the built artifacts with the job for inspection or testing purposes
- Providers are automatically discovered.  A list (env var) is provided to explicitly exclude providers, such as 'core'
