### PR TITLE
⚡ speed up ports under linux

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -763,7 +763,7 @@ port @defaults("port protocol address process.executable") {
   // User configured for this port
   user user
   // Process that is connected to this port
-  process process
+  process() process
   // State of this open port
   state string
   // Remote address connected to this port


### PR DESCRIPTION
This is a preliminary step: One of the main resources ports is slow is because it is trying to find the process that is connected to each port. This can take a while.

This change is only an initial step, but it makes the process part async and optional. If all you need is a list of open ports, the request is now very fast on linux. It only slows down when you request the process.

We still use the process in the defaults. Additionally the process detection can be massively improved on linux...