### PR TITLE
🧹 fix slack asset name and discovery/req args

### DIFF
--- a/providers/slack/config/config.go
+++ b/providers/slack/config/config.go
@@ -18,8 +18,8 @@ var Config = plugin.Provider{
 			Name:      "slack",
 			Use:       "slack",
 			Short:     "slack team",
-			MinArgs:   1,
-			MaxArgs:   1,
+			MinArgs:   0,
+			MaxArgs:   0,
 			Discovery: []string{},
 			Flags: []plugin.Flag{
 				{

--- a/providers/slack/connection/connection.go
+++ b/providers/slack/connection/connection.go
@@ -53,7 +53,7 @@ func NewSlackConnection(id uint32, asset *inventory.Asset, conf *inventory.Confi
 
 	sc.client = client
 	sc.teamInfo = teamInfo
-	sc.asset.Name = teamInfo.Name
+	sc.asset.Name = "Slack team " + teamInfo.Name
 	return sc, nil
 }
 


### PR DESCRIPTION
no args needed, its just `shell/scan slack` with a token, just like v8