### PR TITLE
🐛 Use default path when installing a provider.

### DIFF
--- a/providers/providers.go
+++ b/providers/providers.go
@@ -315,7 +315,7 @@ func InstallFile(path string, conf InstallConf) ([]*Provider, error) {
 
 func InstallIO(reader io.ReadCloser, conf InstallConf) ([]*Provider, error) {
 	if conf.Dst == "" {
-		conf.Dst = HomePath
+		conf.Dst = DefaultPath
 	}
 
 	if !config.ProbeDir(conf.Dst) {


### PR DESCRIPTION
The `init` function in the providers sets the default path to either the system path or the home path, depending on whether we're running as root. If trying to install a provider, we previously defaulted to the home path, which was only set when running as non-root.

Fix this to always use default path so that the install works for both root and non-root users.