### PR TITLE
⭐️ IBM AIX support

### DIFF
--- a/providers/os/resources/packages/aix_packages.go
+++ b/providers/os/resources/packages/aix_packages.go
@@ -1,0 +1,68 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package packages
+
+import (
+	"bufio"
+	"fmt"
+	"go.mondoo.com/cnquery/providers/os/connection/shared"
+	"io"
+	"strings"
+)
+
+const (
+	AixPkgFormat = "bff"
+)
+
+func parseAixPackages(r io.Reader) ([]Package, error) {
+	pkgs := []Package{}
+
+	scanner := bufio.NewScanner(r)
+	i := 0
+	for scanner.Scan() {
+		line := scanner.Text()
+		i++
+
+		if i == 1 {
+			continue
+		}
+
+		record := strings.Split(line, ":")
+
+		// Fileset, Level, PtfID, State, Type, Description, EFIXLocked
+		pkgs = append(pkgs, Package{
+			Name:        record[1],
+			Version:     record[2],
+			Description: strings.TrimSpace(record[6]),
+			Format:      AixPkgFormat,
+		})
+
+	}
+	return pkgs, nil
+}
+
+type AixPkgManager struct {
+	conn shared.Connection
+}
+
+func (f *AixPkgManager) Name() string {
+	return "AIX Package Manager"
+}
+
+func (f *AixPkgManager) Format() string {
+	return AixPkgFormat
+}
+
+func (f *AixPkgManager) List() ([]Package, error) {
+	cmd, err := f.conn.RunCommand("lslpp -cl ")
+	if err != nil {
+		return nil, fmt.Errorf("could not read freebsd package list")
+	}
+
+	return parseAixPackages(cmd.Stdout)
+}
+
+func (f *AixPkgManager) Available() (map[string]PackageUpdate, error) {
+	return map[string]PackageUpdate{}, nil
+}

--- a/providers/os/resources/packages/aix_packages_test.go
+++ b/providers/os/resources/packages/aix_packages_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package packages
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAixPackages(t *testing.T) {
+	f, err := os.Open("testdata/packages_aix.txt")
+	require.NoError(t, err)
+
+	m, err := parseAixPackages(f)
+	require.Nil(t, err)
+	assert.Equal(t, 16, len(m), "detected the right amount of packages")
+
+	var p Package
+	p = Package{
+		Name:        "X11.apps.msmit",
+		Version:     "7.3.0.0",
+		Description: "AIXwindows msmit Application",
+		Format:      "bff",
+	}
+	assert.Contains(t, m, p)
+}

--- a/providers/os/resources/packages/packages.go
+++ b/providers/os/resources/packages/packages.go
@@ -73,6 +73,8 @@ func ResolveSystemPkgManager(conn shared.Connection) (OperatingSystemPkgManager,
 		pm = &CosPkgManager{conn: conn}
 	case asset.Platform.Name == "freebsd":
 		pm = &FreeBSDPkgManager{conn: conn}
+	case asset.Platform.Name == "aix":
+		pm = &AixPkgManager{conn: conn}
 	case asset.Platform.IsFamily("linux"):
 		// no clear package manager for linux platform found
 		// most likely we land here if we have a yocto-based system

--- a/providers/os/resources/packages/testdata/packages_aix.txt
+++ b/providers/os/resources/packages/testdata/packages_aix.txt
@@ -1,0 +1,17 @@
+#Fileset:Level:PTF Id:State:Type:Description:EFIX Locked
+/usr/lib/objrepos:ICU4C.rte:7.3.0.0::COMMITTED:I:International Components for Unicode :
+/usr/lib/objrepos:Java8_64.jre:8.0.0.636::COMMITTED:I:Java SDK 64-bit Java Runtime Environment :
+/usr/lib/objrepos:Java8_64.sdk:8.0.0.636::COMMITTED:I:Java SDK 64-bit Development Kit :
+/usr/lib/objrepos:X11.adt.bitmaps:7.3.0.0::COMMITTED:I:AIXwindows Application Development Toolkit Bitmap Files :
+/usr/lib/objrepos:X11.adt.imake:7.3.0.0::COMMITTED:I:AIXwindows Application Development Toolkit imake :
+/usr/lib/objrepos:X11.adt.include:7.3.0.0::COMMITTED:I:AIXwindows Application Development Toolkit Include Files :
+/usr/lib/objrepos:X11.adt.lib:7.3.0.0::COMMITTED:I:AIXwindows Application Development Toolkit Libraries :
+/usr/lib/objrepos:X11.apps.aixterm:7.3.0.0::COMMITTED:I:AIXwindows aixterm Application :
+/usr/lib/objrepos:X11.apps.clients:7.3.0.0::COMMITTED:I:AIXwindows Client Applications :
+/usr/lib/objrepos:X11.apps.config:7.3.0.0::COMMITTED:I:AIXwindows Configuration Applications :
+/usr/lib/objrepos:X11.apps.custom:7.3.0.0::COMMITTED:I:AIXwindows Customizing Tool :
+/usr/lib/objrepos:X11.apps.msmit:7.3.0.0::COMMITTED:I:AIXwindows msmit Application :
+/usr/lib/objrepos:X11.apps.rte:7.3.0.0::COMMITTED:I:AIXwindows Runtime Configuration Applications :
+/usr/lib/objrepos:X11.apps.util:7.3.0.0::COMMITTED:I:AIXwindows Utility Applications :
+/usr/lib/objrepos:X11.apps.xdm:7.3.0.0::COMMITTED:I:AIXwindows xdm Application :
+/usr/lib/objrepos:X11.apps.xterm:7.3.0.0::COMMITTED:I:AIXwindows xterm Application :

--- a/providers/os/resources/services/aixlssrc.go
+++ b/providers/os/resources/services/aixlssrc.go
@@ -1,0 +1,66 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package services
+
+import (
+	"bufio"
+	"go.mondoo.com/cnquery/providers/os/connection/shared"
+	"io"
+	"regexp"
+)
+
+type AixServiceManager struct {
+	conn shared.Connection
+}
+
+func (s *AixServiceManager) Name() string {
+	return "System Resource Controller"
+}
+
+func (s *AixServiceManager) List() ([]*Service, error) {
+	cmd, err := s.conn.RunCommand("lssrc -a")
+	if err != nil {
+		return nil, err
+	}
+
+	entries := parseLssrc(cmd.Stdout)
+	services := make([]*Service, len(entries))
+	for i, entry := range entries {
+		services[i] = &Service{
+			Name:      entry.Subsystem,
+			Enabled:   entry.Status == "active",
+			Installed: true,
+			Running:   entry.Status == "active",
+			Type:      "aix",
+		}
+	}
+	return services, nil
+}
+
+type lssrcEntry struct {
+	Subsystem string
+	Group     string
+	PID       string
+	Status    string
+}
+
+var lssrcRegex = regexp.MustCompile(`^\s([\w.-]+)(\s+[\w]+\s+){0,1}([\d]+){0,1}\s+([\w]+)$`)
+
+func parseLssrc(input io.Reader) []lssrcEntry {
+	entries := []lssrcEntry{}
+	scanner := bufio.NewScanner(input)
+	for scanner.Scan() {
+		line := scanner.Text()
+		m := lssrcRegex.FindStringSubmatch(line)
+		if len(m) == 5 {
+			entries = append(entries, lssrcEntry{
+				Subsystem: m[1],
+				Group:     m[2],
+				PID:       m[3],
+				Status:    m[4],
+			})
+		}
+	}
+	return entries
+}

--- a/providers/os/resources/services/aixlssrc_test.go
+++ b/providers/os/resources/services/aixlssrc_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package services
+
+import (
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func TestLssrcParse(t *testing.T) {
+	testOutput := `
+Subsystem         Group            PID          Status 
+ syslogd          ras              3932558      active
+ aso                               4653462      active
+ biod             nfs              5046692      active
+ rpc.lockd        nfs              5636560      active
+ qdaemon          spooler          5767630      active
+ ctrmc            rsct             5439966      active
+ pmperfrec                         6881768      active
+ IBM.HostRM       rsct_rm          5898530      active
+ automountd       autofs           7340402      active
+ lpd              spooler                       inoperative
+ nimsh            nimclient                     inoperative
+ nimhttp                                        inoperative
+ timed            tcpip                         inoperative
+`
+	entries := parseLssrc(strings.NewReader(testOutput))
+	assert.Equal(t, 13, len(entries), "detected the right amount of services")
+	assert.Equal(t, "syslogd", entries[0].Subsystem, "service name detected")
+	assert.Equal(t, "active", entries[0].Status, "service status detected")
+	assert.Equal(t, "timed", entries[12].Subsystem, "service name detected")
+	assert.Equal(t, "inoperative", entries[12].Status, "service status detected")
+}

--- a/providers/os/resources/services/manager.go
+++ b/providers/os/resources/services/manager.go
@@ -139,6 +139,8 @@ func ResolveManager(conn shared.Connection) (OSServiceManager, error) {
 		osm = &AlpineOpenrcServiceManager{conn: conn}
 	case asset.Platform.Name == "cos":
 		osm = ResolveSystemdServiceManager(conn)
+	case asset.Platform.Name == "aix":
+		osm = &AixServiceManager{conn: conn}
 	case asset.Platform.Name == "kali": // debian based with versions from 2015 onwards being systemd based
 		osm = ResolveSystemdServiceManager(conn)
 	}


### PR DESCRIPTION
Display asset information:

```
cnquery> asset { name platform version arch }
asset: {
  version: "7.2"
  arch: "powerpc"
  platform: "aix"
  name: "p1280-pvm1"
}
```

List packages:

```
cnquery> packages
packages.list: [
  0: package name="GSKit8.gskcrypt32.ppc.rte" version="8.0.50.88"
  1: package name="GSKit8.gskcrypt64.ppc.rte" version="8.0.50.88"
  2: package name="GSKit8.gskssl32.ppc.rte" version="8.0.50.88"
  3: package name="GSKit8.gskssl64.ppc.rte" version="8.0.50.88"
  4: package name="ICU4C.rte" version="7.2.5.0"
  5: package name="adde.v2.common.rte" version="7.2.0.0"
  6: package name="adde.v2.ethernet.rte" version="7.2.5.200"
  7: package name="adde.v2.rdma.rte" version="7.2.2.0"
  8: package name="bos.64bit" version="7.2.5.201"
  9: package name="bos.acct" version="7.2.5.200"
  10: package name="bos.adt.base" version="7.2.5.200"
  11: package name="bos.adt.debug" version="7.2.5.201"
  12: package name="bos.adt.include" version="7.2.5.201"
  13: package name="bos.adt.lib" version="7.2.5.200"
  ...
```

List services:

```
services.list: [
  0: service name="syslogd" running=true enabled=true type="aix"
  1: service name="sendmail" running=true enabled=true type="aix"
  2: service name="portmap" running=true enabled=true type="aix"
  3: service name="inetd" running=true enabled=true type="aix"
  4: service name="snmpd" running=true enabled=true type="aix"
  5: service name="hostmibd" running=true enabled=true type="aix"
  6: service name="snmpmibd" running=true enabled=true type="aix"
  7: service name="aixmibd" running=true enabled=true type="aix"
  8: service name="aso" running=true enabled=true type="aix"
  ...
```