### PR TITLE
🎉 gcp-9.0.2, k8s-9.0.2, os-9.0.4, terraform-9.0.3

### DIFF
--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/providers/gcp",
-	Version: "9.0.1",
+	Version: "9.0.2",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),

--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "k8s",
 	ID:              "go.mondoo.com/cnquery/providers/k8s",
-	Version:         "9.0.1",
+	Version:         "9.0.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/providers/os",
-	Version: "9.0.3",
+	Version: "9.0.4",
 	ConnectionTypes: []string{
 		provider.LocalConnectionType,
 		provider.SshConnectionType,

--- a/providers/terraform/config/config.go
+++ b/providers/terraform/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "terraform",
 	ID:      "go.mondoo.com/cnquery/providers/terraform",
-	Version: "9.0.2",
+	Version: "9.0.3",
 	ConnectionTypes: []string{
 		provider.StateConnectionType,
 		provider.PlanConnectionType,


### PR DESCRIPTION
This release was created by cnquery's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.