### PR TITLE
✨ handle auto update configuration for providers

### DIFF
--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -397,9 +397,13 @@ func setConnector(provider *plugin.Provider, connector *plugin.Connector, run fu
 		// TODO: add flag to set timeout and then use RuntimeWithShutdownTimeout
 		runtime := providers.Coordinator.NewRuntime()
 
-		// TODO: read from config
+		autoUpdate := true
+		if viper.IsSet("auto_update") {
+			autoUpdate = viper.GetBool("auto_update")
+		}
+
 		runtime.AutoUpdate = providers.UpdateProvidersConfig{
-			Enabled:         true,
+			Enabled:         autoUpdate,
 			RefreshInterval: 60 * 60,
 		}
 


### PR DESCRIPTION
Allows disabling the update for providers by setting the env var `MONDOO_AUTO_UPDATE=false`