### PR TITLE
🐛 ensure aws ebs scan cleans up after itself

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -87,6 +87,8 @@ jobs:
 
       - name: Setup Copywrite
         uses: hashicorp/setup-copywrite@v1.1.2
+        with:
+          version: v0.16.4
 
       - name: Check Header Compliance
         run: copywrite headers --plan

--- a/providers/aws/connection/awsec2ebsconn/destroy.go
+++ b/providers/aws/connection/awsec2ebsconn/destroy.go
@@ -16,8 +16,12 @@ import (
 
 func (c *AwsEbsConnection) DetachVolumeFromInstance(ctx context.Context, volume *awsec2ebstypes.VolumeInfo) error {
 	log.Info().Msg("detach volume")
+	var deviceName string
+	if c.volumeMounter != nil {
+		deviceName = c.volumeMounter.VolumeAttachmentLoc
+	}
 	res, err := c.scannerRegionEc2svc.DetachVolume(ctx, &ec2.DetachVolumeInput{
-		Device: aws.String(c.volumeMounter.VolumeAttachmentLoc), VolumeId: &volume.Id,
+		Device: aws.String(deviceName), VolumeId: &volume.Id,
 		InstanceId: &c.scannerInstance.Id,
 	})
 	if err != nil {

--- a/providers/aws/provider/provider.go
+++ b/providers/aws/provider/provider.go
@@ -97,8 +97,11 @@ func parseFlagsToOptions(m map[string]*llx.Primitive) map[string]string {
 func (s *Service) Shutdown(req *plugin.ShutdownReq) (*plugin.ShutdownRes, error) {
 	for i := range s.runtimes {
 		runtime := s.runtimes[i]
-		if conn, ok := runtime.Connection.(awsec2ebsconn.AwsEbsConnection); ok {
-			conn.Close()
+		if conn, ok := runtime.Connection.(shared.Connection); ok {
+			if conn.Type() == awsec2ebsconn.EBSConnectionType {
+				conn := runtime.Connection.(*awsec2ebsconn.AwsEbsConnection)
+				conn.Close()
+			}
 		}
 	}
 	return &plugin.ShutdownRes{}, nil


### PR DESCRIPTION
fixes https://github.com/mondoohq/cnquery/issues/1847

i don't love what i had to do to actually have all the info i needed to complete the shutdown - i had to copy a bunch of information that is usually on the provider to the asset connection options bc i was losing all the info on the provider by the time i get here...

```
cnquery> asset { platform version ids }
DBG starting query execution qrid=EmKggjLCPHY=
DBG finished query execution qrid=EmKggjLCPHY=
DBG bQqpVQgYCCh7C/Xkwh4dH/57nw0MiMSTXN4GoxUJz4PeyJsL2T2yg81qBXbpX9TR+kRYRrEBOCJfeiDkxt4LRg== finished
DBG graph has received all datapoints
asset: {
  version: "22.04"
  platform: "ubuntu"
  ids: [
    0: "//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/367400545713/regions/us-east-1/instances/i-09739098c40b6df84"
  ]
}
cnquery> exit
DBG close aws ebs connection
DBG unmount volume dir=/tmp/cnspec-scan2100575520
→ detach volume
→ waiting for volume detachment completion state=available
DBG remove created dir dir=/tmp/cnspec-scan2100575520
→ delete created volume
→ deleted temporary volume created by Mondoo vol-id=vol-0b5ab2f2f22a3e4fb
[root@ip-172-31-38-240 ec2-user]#
```