### PR TITLE
🧹 fix panic during login with wrong token

### DIFF
--- a/apps/cnquery/cmd/status.go
+++ b/apps/cnquery/cmd/status.go
@@ -179,7 +179,7 @@ func (s Status) RenderCliStatus() {
 
 	if s.Client.Registered && s.Client.PingPongError == nil {
 		log.Info().Msg(theme.DefaultTheme.Success("client authenticated successfully"))
-	} else {
+	} else if s.Client.PingPongError == nil {
 		log.Error().Err(s.Client.PingPongError).
 			Msgf("The Mondoo Platform credentials provided at %s didn't successfully authenticate with Mondoo Platform. Please re-authenticate with Mondoo Platform. To learn how, read https://mondoo.com/docs/cnspec/cnspec-adv-install/registration.",
 				viper.ConfigFileUsed())


### PR DESCRIPTION
This change fixes a panic during login when the token is invalid. It also changes the fatal logging to pure warn with os exit.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x104c16f70]

goroutine 1 [running]:
go.mondoo.com/ranger-rpc.(*Client).DoClientRequest(0x140002e8b80, {0x1056222a0?, 0x105fdeae0}, {0x10560f8f8, 0x14000732ff0}, {0x14000734220, 0x1e}, {0x105610598, 0x14000733230}, {0x1056105b8, ...})
	/Users/chris/go/pkg/mod/go.mondoo.com/ranger-rpc@v0.5.1/client.go:65 +0x2a0
go.mondoo.com/cnquery/providers-sdk/v1/upstream.(*AgentManagerClient).PingPong(0x140002e8b80, {0x1056222a0, 0x105fdeae0}, 0x14000732ff0?)
	/Users/chris/go/src/go.mondoo.com/cnquery/providers-sdk/v1/upstream/upstream.ranger.go:65 +0xc0
go.mondoo.com/cnquery/apps/cnquery/cmd.register({0x0, 0x0})
	/Users/chris/go/src/go.mondoo.com/cnquery/apps/cnquery/cmd/login.go:230 +0xfcc
go.mondoo.com/cnquery/apps/cnquery/cmd.glob..func6(0x140006d4300?, {0x1050ce013?, 0x4?, 0x1050cdfaf?})
	/Users/chris/go/src/go.mondoo.com/cnquery/apps/cnquery/cmd/login.go:49 +0x74
github.com/spf13/cobra.(*Command).execute(0x105ebaac0, {0x140004aecc0, 0x2, 0x2})
	/Users/chris/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944 +0x640
github.com/spf13/cobra.(*Command).ExecuteC(0x105ebbc00)
	/Users/chris/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x320
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/chris/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
go.mondoo.com/cnquery/apps/cnquery/cmd.Execute()
	/Users/chris/go/src/go.mondoo.com/cnquery/apps/cnquery/cmd/root.go:71 +0x15c
main.main()
	/Users/chris/go/src/go.mondoo.com/cnquery/apps/cnquery/cnquery.go:9 +0x1c
```