### PR TITLE
🐛 detect providers connectors via aliases

### DIFF
--- a/providers/providers.go
+++ b/providers/providers.go
@@ -575,6 +575,9 @@ func (p Providers) ForConnection(name string, typ string) *Provider {
 				if provider.Connectors[i].Name == name {
 					return provider
 				}
+				if slices.Contains(provider.Connectors[i].Aliases, name) {
+					return provider
+				}
 			}
 		}
 	}
@@ -583,6 +586,11 @@ func (p Providers) ForConnection(name string, typ string) *Provider {
 		for _, provider := range p {
 			if slices.Contains(provider.ConnectionTypes, typ) {
 				return provider
+			}
+			for i := range provider.Connectors {
+				if slices.Contains(provider.Connectors[i].Aliases, typ) {
+					return provider
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Allow detecting connectors via their aliases. Example inventory that doesn't work with `main` but works with this PR:
```yaml
metadata:
  labels:
    environment: production
  name: mondoo-node-inventory
spec:
  assets:
  - connections:
    - backend: fs
      host: /mnt/host
      platform_id: //platformid.api.mondoo.app/runtime/k8s/uid/d8e7c886-5b35-4437-a94d-1b63a18ee2c7/node/77e9837b-03ab-4ece-be17-0fbd4407886f
    id: host
    labels:
      k8s.mondoo.com/kind: node
      mondoo.com/integration-mrn: //integration.api.mondoo.app/spaces/nostalgic-vaughan-429863/integrations/2VzF3FBgWk4NzKNchhIhEFyBgV9
    managed_by: mondoo-operator-d8e7c886-5b35-4437-a94d-1b63a18ee2c7
    name: minikube

```