### PR TITLE
🧹 Apply root-level asset labels to inventory assets.

### DIFF
--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -207,6 +207,11 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 			log.Error().Err(err).Msg("unable to connect to asset")
 			continue
 		}
+
+		// for all discovered assets, we apply mondoo-specific labels that come from the root asset
+		for _, a := range runtime.Provider.Connection.GetInventory().GetSpec().GetAssets() {
+			a.AddMondooLabels(asset)
+		}
 		processedAssets, err := providers.ProcessAssetCandidates(runtime, runtime.Provider.Connection, upstream, "")
 		if err != nil {
 			return nil, false, err

--- a/providers-sdk/v1/inventory/asset.go
+++ b/providers-sdk/v1/inventory/asset.go
@@ -138,3 +138,15 @@ func (s *AssetCategory) UnmarshalJSON(data []byte) error {
 	}
 	return nil
 }
+
+// Merges the mondoo-specific labels from the provided root into the provided asset
+func (a *Asset) AddMondooLabels(root *Asset) {
+	if a.Labels == nil {
+		a.Labels = map[string]string{}
+	}
+	for k, v := range root.Labels {
+		if strings.HasPrefix(k, "mondoo.com/") {
+			a.Labels[k] = v
+		}
+	}
+}


### PR DESCRIPTION
I am not sure if this is the place to fix this. Maybe indeed it's to have each provider decide that for themselves (whether they want to apply root-level asset labels to discovered assets)