### PR TITLE
🧹 initialize gitlab project

### DIFF
--- a/providers/gitlab/resources/gitlab.lr.go
+++ b/providers/gitlab/resources/gitlab.lr.go
@@ -23,7 +23,7 @@ func init() {
 			Create: createGitlabGroup,
 		},
 		"gitlab.project": {
-			// to override args, implement: initGitlabProject(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init: initGitlabProject,
 			Create: createGitlabProject,
 		},
 	}


### PR DESCRIPTION

```
cnquery shell gitlab --group example --discover projects
→ selected asset asset="GitLab Project test-public" selection=0
→ connected to GitLab Project
  ___ _ __   __ _ _   _  ___ _ __ _   _ 
 / __| '_ \ / _` | | | |/ _ \ '__| | | |
| (__| | | | (_| | |_| |  __/ |  | |_| |
 \___|_| |_|\__, |\__,_|\___|_|   \__, |
  mondoo™      |_|                |___/  interactive shell

cnquery> gitlab.project
gitlab.project: gitlab.project fullName="example / test-public" webURL="https://gitlab.com/example/test-public"
```