### PR TITLE
⭐️ unique platform id for terraform when used with git

### DIFF
--- a/providers/terraform/provider/detector_test.go
+++ b/providers/terraform/provider/detector_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectNameFromFile(t *testing.T) {
+	name := parseNameFromPath("/test/path/nested/terraform.tfstate")
+	assert.Equal(t, "nested", name)
+}
+
+func TestDetectNameFromSsh(t *testing.T) {
+	url := "git@gitlab.com:exampleorg/example-gitlab.git"
+	domain, org, repo, err := parseSSHURL(url)
+	require.NoError(t, err)
+	assert.Equal(t, "gitlab.com", domain)
+	assert.Equal(t, "exampleorg", org)
+	assert.Equal(t, "example-gitlab", repo)
+}


### PR DESCRIPTION
This is a followup to https://github.com/mondoohq/cnquery/pull/1975

```
cnquery shell gitlab --group example --discover terraform 
→ loaded configuration from /Users/chris/.config/mondoo/mondoo.yml using source default

    Available assets                                                               
                                                                                   
  > 1. Terraform Static Analysis example/example-gitlab (terraform-hcl)         
    2. Terraform Static Analysis example/example-playground (terraform-hcl)     
    3. Terraform Static Analysis example/example-code (terraform-hcl) 
    4. Terraform Static Analysis example/example-demo-environment (terraform-hcl)            
```