### PR TITLE
✨ support gitlab conn with no group or project defined

### DIFF
--- a/providers/gitlab/resources/gitlab.go
+++ b/providers/gitlab/resources/gitlab.go
@@ -52,9 +52,9 @@ func (g *mqlGitlabGroup) projects() ([]interface{}, error) {
 	if g.Path.Error != nil {
 		return nil, g.Path.Error
 	}
-	path := g.Path.Data
+	gid := g.Id.Data
 
-	grp, _, err := conn.Client().Groups.GetGroup(path, nil)
+	grp, _, err := conn.Client().Groups.GetGroup(gid, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- i wanted to also update the tf platform ids for v8 compatibility, but it's not working well - something in the reconnect is returning the incorrect id when i try that, so left that out for now
- there's an error when scanning against the server. this exists on main, i couldn't track it down quite yet, but will look later today:
```
 Terraform Static Analysis mondoolabs/example-gitlab          ────────────────────────────────────────────────────────────────────────────────────────────────────────   0%
... 4 more assets ...

 0/5 scanned                                                  ────────────────────────────────────────────────────────────────────────────────────────────────────────   0%

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x10342340c]

goroutine 219 [running]:
go.mondoo.com/cnquery/providers/terraform/resources.initTerraformState(0x103c4abc0?, 0x14000672630?)
	/Users/vj/go/src/go.mondoo.io/cnquery/providers/terraform/resources/tfstate.go:28 +0x3c
go.mondoo.com/cnquery/providers/terraform/resources.NewResource(0x14001c8b020, {0x14000500d50, 0xf}, 0x1400a1022d0)
	/Users/vj/go/src/go.mondoo.io/cnquery/providers/terraform/resources/terraform.lr.go:89 +0x84
```

this pr enables connecting to gitlab without group or project defined:
```
cnspec scan gitlab --token TOKEN <- returns all groups the user has access to
cnspec scan gitlab --token TOKEN --discover groups <- same as above
cnspec scan gitlab --token TOKEN --discover projects <- returns all the projects discovered in all the groups the user has access to
cnspec scan gitlab --token TOKEN --discover terraform  <- returns all the terraform in all the projects discovered in all the groups the user has access to
```