### PR TITLE
✨ terraform.settings.backend

### DIFF
--- a/providers/terraform/resources/terraform.lr
+++ b/providers/terraform/resources/terraform.lr
@@ -88,6 +88,8 @@ terraform.settings {
   block terraform.block
   // Provider Requirements
   requiredProviders dict
+  // Backend configuration
+  backend dict
 }
 
 // Terraform State

--- a/providers/terraform/resources/terraform.lr.go
+++ b/providers/terraform/resources/terraform.lr.go
@@ -234,6 +234,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"terraform.settings.requiredProviders": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTerraformSettings).GetRequiredProviders()).ToDataRes(types.Dict)
 	},
+	"terraform.settings.backend": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTerraformSettings).GetBackend()).ToDataRes(types.Dict)
+	},
 	"terraform.state.formatVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTerraformState).GetFormatVersion()).ToDataRes(types.String)
 	},
@@ -530,6 +533,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"terraform.settings.requiredProviders": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlTerraformSettings).RequiredProviders, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
+		return
+	},
+	"terraform.settings.backend": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTerraformSettings).Backend, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
 		return
 	},
 	"terraform.state.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1284,6 +1291,7 @@ type mqlTerraformSettings struct {
 	// optional: if you define mqlTerraformSettingsInternal it will be used here
 	Block plugin.TValue[*mqlTerraformBlock]
 	RequiredProviders plugin.TValue[interface{}]
+	Backend plugin.TValue[interface{}]
 }
 
 // createTerraformSettings creates a new instance of this resource
@@ -1324,6 +1332,10 @@ func (c *mqlTerraformSettings) GetBlock() *plugin.TValue[*mqlTerraformBlock] {
 
 func (c *mqlTerraformSettings) GetRequiredProviders() *plugin.TValue[interface{}] {
 	return &c.RequiredProviders
+}
+
+func (c *mqlTerraformSettings) GetBackend() *plugin.TValue[interface{}] {
+	return &c.Backend
 }
 
 // mqlTerraformState for the terraform.state resource

--- a/providers/terraform/resources/terraform.lr.manifest.yaml
+++ b/providers/terraform/resources/terraform.lr.manifest.yaml
@@ -70,7 +70,7 @@ resources:
   terraform.module:
     fields:
       block:
-        min_mondoo_version: latest
+        min_mondoo_version: 9.0.0
       dir: {}
       key: {}
       source: {}
@@ -132,6 +132,8 @@ resources:
       - terraform
   terraform.settings:
     fields:
+      backend:
+        min_mondoo_version: latest
       block: {}
       requiredProviders: {}
     min_mondoo_version: 5.31.0


### PR DESCRIPTION
Easy accessor for the terraform backend settings.

Note: The Terraform provider needs get its testing extended considerably, which is when we will expand testing for these fields as well.

Note2: The backend settings are pulled in, but backend settings blocks are a different story.