### PR TITLE
🐛 download os provider for login+status

### DIFF
--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -36,7 +36,7 @@ func AttachCLIs(rootCmd *cobra.Command, commands ...*Command) error {
 
 	connectorName, autoUpdate := detectConnectorName(os.Args, rootCmd, commands, existing)
 	if connectorName != "" {
-		if _, err := providers.EnsureProvider(existing, connectorName, "", autoUpdate); err != nil {
+		if _, err := providers.EnsureProvider(connectorName, "", autoUpdate, existing); err != nil {
 			return err
 		}
 	}

--- a/cli/sysinfo/sysinfo.go
+++ b/cli/sysinfo/sysinfo.go
@@ -49,12 +49,12 @@ func GatherSystemInfo(opts ...SystemInfoOption) (*SystemInfo, error) {
 
 	log.Debug().Msg("Gathering system information")
 	if cfg.runtime == nil {
-
 		cfg.runtime = providers.Coordinator.NewRuntime()
 
-		// TODO: we need to ensure that the os provider is available here
-
 		// init runtime
+		if _, err := providers.EnsureProvider("local", "", true, nil); err != nil {
+			return nil, err
+		}
 		if err := cfg.runtime.UseProvider(providers.DefaultOsID); err != nil {
 			return nil, err
 		}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -151,9 +151,25 @@ func ListAll() ([]*Provider, error) {
 	return res, nil
 }
 
-// EnsureProvider find the provider for a given connector either from the list
-// of existing proviers or by downloading and installing it.
-func EnsureProvider(existing Providers, connectorName string, connectorType string, autoUpdate bool) (*Provider, error) {
+// EnsureProvider makes sure that a given provider exists and returns it.
+// You can supply providers either via:
+//  1. connectorName, which is what you see in the CLI e.g. "local", "ssh", ...
+//  2. connectorType, which is how assets define the connector type when
+//     they are moved between discovery and execution, e.g. "registry-image".
+//
+// If you disable autoUpdate, it will neither update NOR install missing providers.
+//
+// If you don't supply existing providers, it will look for alist of all
+// active providers first.
+func EnsureProvider(connectorName string, connectorType string, autoUpdate bool, existing Providers) (*Provider, error) {
+	if existing == nil {
+		var err error
+		existing, err = ListActive()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	provider := existing.ForConnection(connectorName, connectorType)
 	if provider != nil {
 		return provider, nil

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -192,7 +192,7 @@ func (r *Runtime) DetectProvider(asset *inventory.Asset) error {
 			continue
 		}
 
-		provider, err := EnsureProvider(r.coordinator.Providers, "", conn.Type, true)
+		provider, err := EnsureProvider("", conn.Type, true, r.coordinator.Providers)
 		if err != nil {
 			errs.Add(err)
 			continue


### PR DESCRIPTION
Both commands need to get system infos at the start. Without the os provider this is not possible (at the time of writing).

This PR also clarifies how the method `EnsureProviders` works and makes the list of existing providers optional.