### PR TITLE
🐛 resource == null fixed

### DIFF
--- a/llx/builtin_simple.go
+++ b/llx/builtin_simple.go
@@ -200,11 +200,11 @@ func chunkNeqTrueV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (
 }
 
 func bindingEqNil(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
-	return BoolData(bind == nil), 0, nil
+	return BoolData(bind.Value == nil), 0, nil
 }
 
 func bindingNeqNil(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
-	return BoolData(bind != nil), 0, nil
+	return BoolData(bind.Value != nil), 0, nil
 }
 
 // raw operator handling

--- a/mql/mql_test.go
+++ b/mql/mql_test.go
@@ -170,6 +170,26 @@ func TestNullResources(t *testing.T) {
 			Expectation: nil,
 		},
 		{
+			Code:        "muser.nullgroup == null",
+			ResultIndex: 1,
+			Expectation: true,
+		},
+		{
+			Code:        "muser.nullgroup == empty",
+			ResultIndex: 2,
+			Expectation: true,
+		},
+		{
+			Code:        "muser.groups.where(null) == empty",
+			ResultIndex: 2,
+			Expectation: false,
+		},
+		{
+			Code:        "muser.groups.where(name == '') == empty",
+			ResultIndex: 2,
+			Expectation: true,
+		},
+		{
 			Code:        "muser.groups",
 			ResultIndex: 0,
 			Expectation: []interface{}{


### PR DESCRIPTION
The binding is non-null, we need to compare the value, not the binding struct.