### PR TITLE
🐛 only scan local queries that are supported

### DIFF
--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -253,7 +253,14 @@ func (c *scanConfig) loadBundles() error {
 			return err
 		}
 
-		_, err = bundle.Compile(context.Background(), c.runtime.Schema())
+		_, err = bundle.CompileExt(context.Background(), explorer.BundleCompileConf{
+			Schema: c.runtime.Schema(),
+			// We don't care about failing queries for local runs. We may only
+			// process a subset of all the queries in the bundle. When we receive
+			// things from the server, upstream can filter things for us. But running
+			// them locally requires us to do it in here.
+			RemoveFailing: true,
+		})
 		if err != nil {
 			return errors.Wrap(err, "failed to compile bundle")
 		}


### PR DESCRIPTION
We may not always have all providers installed. When we run against an upstream server we only deal with the resolved bundle, which usually is sufficient to filter out anything we cannot run. However, with local bundles this is different. Especially when we pull bundles and compile them locally, they may contain a lot of things that the system has no provider for.

This PR filters out anything from the local execution that is not covered by the currently supported providers. These are tied to the active connection.

Before:

![image](https://github.com/mondoohq/cnquery/assets/1307529/8c3ed386-6e18-44e3-bb10-7799e9e6f70f)

After:

![image](https://github.com/mondoohq/cnquery/assets/1307529/9abc1b48-37c1-44ba-80af-428ccecf2091)
