### PR TITLE
⭐️ simplify provider dep update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -351,7 +351,7 @@ require (
 	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/exp/typeparams v0.0.0-20230905200255-921286631fa9 // indirect
-	golang.org/x/mod v0.12.0 // indirect
+	golang.org/x/mod v0.12.0
 	golang.org/x/oauth2 v0.12.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect

--- a/providers-sdk/v1/util/version/version.go
+++ b/providers-sdk/v1/util/version/version.go
@@ -94,6 +94,11 @@ func checkGoModUpdate(providerPath string) {
 
 	// Iterate through the require statements and update dependencies
 	for _, require := range modFile.Require {
+		// Skip indirect dependencies
+		if require.Indirect {
+			continue
+		}
+
 		cmd := exec.Command("go", "get", "-u", require.Mod.Path+"@"+require.Mod.Version)
 
 		// Redirect standard output and standard error to the console


### PR DESCRIPTION
after #2001

Ensure all providers have an up-to-date go mod:

```
version mod-tidy providers/*/
→ Running 'go mod tidy' for providers/arista/...
→ Running 'go mod tidy' for providers/aws/...
→ Running 'go mod tidy' for providers/azure/...
→ Running 'go mod tidy' for providers/core/...
→ Running 'go mod tidy' for providers/equinix/...
→ Running 'go mod tidy' for providers/gcp/...
→ Running 'go mod tidy' for providers/github/...
→ Running 'go mod tidy' for providers/gitlab/...
→ Running 'go mod tidy' for providers/google-workspace/...
→ Running 'go mod tidy' for providers/ipmi/...
→ Running 'go mod tidy' for providers/k8s/...
→ Running 'go mod tidy' for providers/ms365/...
→ Running 'go mod tidy' for providers/network/...
→ Running 'go mod tidy' for providers/oci/...
→ Running 'go mod tidy' for providers/okta/...
→ Running 'go mod tidy' for providers/opcua/...
→ Running 'go mod tidy' for providers/os/...
→ Running 'go mod tidy' for providers/slack/...
→ Running 'go mod tidy' for providers/terraform/...
→ Running 'go mod tidy' for providers/vcd/...
→ Running 'go mod tidy' for providers/vsphere/...
```

Want to update all dependencies, just run:

```
version mod-update providers/*/
```