### PR TITLE
:star: Add new properties to the aws.vpc resource

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -35,15 +35,19 @@ aws.organization @defaults("arn masterAccountEmail") {
 }
 
 // Amazon Virtual Private Cloud (VPC)
-private aws.vpc @defaults("arn isDefault") {
+private aws.vpc @defaults("arn isDefault cidrBlock") {
   // ARN of the VPC
   arn string
   // ID of the VPC
   id string
+  // IPv4 CIDR block of the VPC
+  cidrBlock string
   // State of the VPC (pending or available)
   state string
   // Whether the VPC is the default one
   isDefault bool
+  // How instance hardware tenancy settings are enforced on instances launched in this VPC
+  instanceTenancy string
   // Region the VPC exists in
   region string
   // A list of flowlogs for the VPC

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -595,11 +595,17 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.vpc.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpc).GetId()).ToDataRes(types.String)
 	},
+	"aws.vpc.cidrBlock": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpc).GetCidrBlock()).ToDataRes(types.String)
+	},
 	"aws.vpc.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpc).GetState()).ToDataRes(types.String)
 	},
 	"aws.vpc.isDefault": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpc).GetIsDefault()).ToDataRes(types.Bool)
+	},
+	"aws.vpc.instanceTenancy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpc).GetInstanceTenancy()).ToDataRes(types.String)
 	},
 	"aws.vpc.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpc).GetRegion()).ToDataRes(types.String)
@@ -2665,12 +2671,20 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsVpc).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.vpc.cidrBlock": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpc).CidrBlock, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.vpc.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpc).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.isDefault": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpc).IsDefault, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.instanceTenancy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpc).InstanceTenancy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6015,8 +6029,10 @@ type mqlAwsVpc struct {
 	// optional: if you define mqlAwsVpcInternal it will be used here
 	Arn plugin.TValue[string]
 	Id plugin.TValue[string]
+	CidrBlock plugin.TValue[string]
 	State plugin.TValue[string]
 	IsDefault plugin.TValue[bool]
+	InstanceTenancy plugin.TValue[string]
 	Region plugin.TValue[string]
 	FlowLogs plugin.TValue[[]interface{}]
 	RouteTables plugin.TValue[[]interface{}]
@@ -6069,12 +6085,20 @@ func (c *mqlAwsVpc) GetId() *plugin.TValue[string] {
 	return &c.Id
 }
 
+func (c *mqlAwsVpc) GetCidrBlock() *plugin.TValue[string] {
+	return &c.CidrBlock
+}
+
 func (c *mqlAwsVpc) GetState() *plugin.TValue[string] {
 	return &c.State
 }
 
 func (c *mqlAwsVpc) GetIsDefault() *plugin.TValue[bool] {
 	return &c.IsDefault
+}
+
+func (c *mqlAwsVpc) GetInstanceTenancy() *plugin.TValue[string] {
+	return &c.InstanceTenancy
 }
 
 func (c *mqlAwsVpc) GetRegion() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2177,8 +2177,12 @@ resources:
   aws.vpc:
     fields:
       arn: {}
+      cidrBlock:
+        min_mondoo_version: 9.0.0
       flowLogs: {}
       id: {}
+      instanceTenancy:
+        min_mondoo_version: 9.0.0
       isDefault: {}
       region: {}
       routeTables: {}

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -80,12 +80,14 @@ func (a *mqlAws) getVpcs(conn *connection.AwsConnection) []*jobpool.Job {
 
 					mqlVpc, err := CreateResource(a.MqlRuntime, "aws.vpc",
 						map[string]*llx.RawData{
-							"arn":       llx.StringData(fmt.Sprintf(vpcArnPattern, regionVal, conn.AccountId(), convert.ToString(v.VpcId))),
-							"id":        llx.StringData(convert.ToString(v.VpcId)),
-							"state":     llx.StringData(string(v.State)),
-							"isDefault": llx.BoolData(convert.ToBool(v.IsDefault)),
-							"region":    llx.StringData(regionVal),
-							"tags":      llx.MapData(Ec2TagsToMap(v.Tags), types.String),
+							"arn":             llx.StringData(fmt.Sprintf(vpcArnPattern, regionVal, conn.AccountId(), convert.ToString(v.VpcId))),
+							"id":              llx.StringData(convert.ToString(v.VpcId)),
+							"state":           llx.StringData(string(v.State)),
+							"isDefault":       llx.BoolData(convert.ToBool(v.IsDefault)),
+							"instanceTenancy": llx.StringData(string(v.InstanceTenancy)),
+							"cidrBlock":       llx.StringData(convert.ToString(v.CidrBlock)),
+							"region":          llx.StringData(regionVal),
+							"tags":            llx.MapData(Ec2TagsToMap(v.Tags), types.String),
 						})
 					if err != nil {
 						log.Error().Msg(err.Error())

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -81,11 +81,11 @@ func (a *mqlAws) getVpcs(conn *connection.AwsConnection) []*jobpool.Job {
 					mqlVpc, err := CreateResource(a.MqlRuntime, "aws.vpc",
 						map[string]*llx.RawData{
 							"arn":             llx.StringData(fmt.Sprintf(vpcArnPattern, regionVal, conn.AccountId(), convert.ToString(v.VpcId))),
-							"id":              llx.StringData(convert.ToString(v.VpcId)),
+							"id":              llx.StringDataPtr(v.VpcId),
 							"state":           llx.StringData(string(v.State)),
 							"isDefault":       llx.BoolData(convert.ToBool(v.IsDefault)),
 							"instanceTenancy": llx.StringData(string(v.InstanceTenancy)),
-							"cidrBlock":       llx.StringData(convert.ToString(v.CidrBlock)),
+							"cidrBlock":       llx.StringDataPtr(v.CidrBlock),
 							"region":          llx.StringData(regionVal),
 							"tags":            llx.MapData(Ec2TagsToMap(v.Tags), types.String),
 						})
@@ -143,7 +143,7 @@ func (a *mqlAwsVpc) flowLogs() ([]interface{}, error) {
 }
 
 func (a *mqlAwsVpcRoutetable) id() (string, error) {
-  return a.Id.Data, nil
+	return a.Id.Data, nil
 }
 
 func (a *mqlAwsVpc) routeTables() ([]interface{}, error) {


### PR DESCRIPTION
Add a few new things for asset inventory:

- CIDR Block
- Instance tenancy settings

```
cnquery> aws.vpcs.first{*}
aws.vpcs.first: {
  instanceTenancy: "default"
  region: "ap-south-1"
  cidrBlock: "172.31.0.0/16"
  isDefault: true
  state: "available"
  arn: "FOO"
  id: "vpc-0c67aa67"
  flowLogs: []
  tags: {}
  routeTables: [
    0: aws.vpc.routetable id="FOO"
  ]
}
```
Signed-off-by: Tim Smith <tsmith84@gmail.com>