### PR TITLE
🎉 update providers

### DIFF
--- a/providers/arista/config/config.go
+++ b/providers/arista/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "arista",
 	ID:              "go.mondoo.com/cnquery/providers/arista",
-	Version:         "9.0.2",
+	Version:         "9.0.3",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/providers/aws",
-	Version:         "9.0.3",
+	Version:         "9.0.4",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "azure",
 	ID:              "go.mondoo.com/cnquery/providers/azure",
-	Version:         "9.0.2",
+	Version:         "9.0.3",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/equinix/config/config.go
+++ b/providers/equinix/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "equinix",
 	ID:              "go.mondoo.com/cnquery/providers/equinix",
-	Version:         "9.0.1",
+	Version:         "9.0.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/providers/gcp",
-	Version: "9.0.2",
+	Version: "9.0.3",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),

--- a/providers/github/config/config.go
+++ b/providers/github/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "github",
 	ID:              "go.mondoo.com/cnquery/providers/github",
-	Version:         "9.0.2",
+	Version:         "9.0.3",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/gitlab/config/config.go
+++ b/providers/gitlab/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gitlab",
 	ID:      "go.mondoo.com/cnquery/providers/gitlab",
-	Version: "9.0.2",
+	Version: "9.0.3",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		provider.GitlabGroupConnection,

--- a/providers/google-workspace/config/config.go
+++ b/providers/google-workspace/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "google-workspace",
 	ID:              "go.mondoo.com/cnquery/providers/google-workspace",
-	Version:         "9.0.1",
+	Version:         "9.0.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/ipmi/config/config.go
+++ b/providers/ipmi/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ipmi",
 	ID:              "go.mondoo.com/cnquery/providers/ipmi",
-	Version:         "9.0.1",
+	Version:         "9.0.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "k8s",
 	ID:              "go.mondoo.com/cnquery/providers/k8s",
-	Version:         "9.0.4",
+	Version:         "9.0.5",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ms365",
 	ID:              "go.mondoo.com/cnquery/providers/ms365",
-	Version:         "9.0.1",
+	Version:         "9.0.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/oci/config/config.go
+++ b/providers/oci/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "oci",
 	ID:              "go.mondoo.com/cnquery/providers/oci",
-	Version:         "9.0.2",
+	Version:         "9.0.3",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/okta/config/config.go
+++ b/providers/okta/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "okta",
 	ID:              "go.mondoo.com/cnquery/providers/okta",
-	Version:         "9.0.3",
+	Version:         "9.0.4",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/opcua/config/config.go
+++ b/providers/opcua/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "opcua",
 	ID:              "go.mondoo.com/cnquery/providers/opcua",
-	Version:         "9.0.2",
+	Version:         "9.0.3",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/providers/os",
-	Version: "9.0.5",
+	Version: "9.0.6",
 	ConnectionTypes: []string{
 		provider.LocalConnectionType,
 		provider.SshConnectionType,

--- a/providers/slack/config/config.go
+++ b/providers/slack/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "slack",
 	ID:              "go.mondoo.com/cnquery/providers/slack",
-	Version:         "9.0.2",
+	Version:         "9.0.3",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/terraform/config/config.go
+++ b/providers/terraform/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "terraform",
 	ID:      "go.mondoo.com/cnquery/providers/terraform",
-	Version: "9.0.4",
+	Version: "9.0.5",
 	ConnectionTypes: []string{
 		provider.StateConnectionType,
 		provider.PlanConnectionType,

--- a/providers/vcd/config/config.go
+++ b/providers/vcd/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vcd",
 	ID:              "go.mondoo.com/cnquery/providers/vcd",
-	Version:         "9.0.2",
+	Version:         "9.0.3",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/vsphere/config/config.go
+++ b/providers/vsphere/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vsphere",
 	ID:              "go.mondoo.com/cnquery/providers/vsphere",
-	Version:         "9.0.2",
+	Version:         "9.0.3",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
arista-9.0.3, aws-9.0.4, azure-9.0.3, equinix-9.0.2, gcp-9.0.3, github-9.0.3, gitlab-9.0.3, google-workspace-9.0.2, ipmi-9.0.2, k8s-9.0.5, ms365-9.0.2, oci-9.0.3, okta-9.0.4, opcua-9.0.3, os-9.0.6, slack-9.0.3, terraform-9.0.5, vcd-9.0.3, vsphere-9.0.3

This release was created by cnquery's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.