### PR TITLE
🐛 fix ipmi cli

### DIFF
--- a/providers/ipmi/config/config.go
+++ b/providers/ipmi/config/config.go
@@ -15,9 +15,15 @@ var Config = plugin.Provider{
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{
-			Name:      "ipmi",
-			Use:       "ipmi",
-			Short:     "Ipmi",
+			Name:  "ipmi",
+			Use:   "ipmi user@host",
+			Short: "Intelligent Platform Management Interface (IPMI)",
+			Long: `ipmi is designed for querying resources via the Intelligent Platform Management Interface (IPMI).
+IPMI provides management and monitoring capabilities  independently of the host system's CPU,
+firmware (BIOS or UEFI), and operating system.
+`,
+			MinArgs:   1,
+			MaxArgs:   1,
 			Discovery: []string{provider.ConnectionType},
 			Flags: []plugin.Flag{
 				{
@@ -32,7 +38,7 @@ var Config = plugin.Provider{
 					Short:       "p",
 					Type:        plugin.FlagType_String,
 					Default:     "",
-					Desc:        "Set the connection password for SSH.",
+					Desc:        "Set the connection password for IPMI connection.",
 					Option:      plugin.FlagOption_Password,
 					ConfigEntry: "-",
 				},

--- a/providers/ipmi/main.go
+++ b/providers/ipmi/main.go
@@ -10,6 +10,13 @@ import (
 	"go.mondoo.com/cnquery/providers/ipmi/provider"
 )
 
+// This is the entry point for the IPMI provider.
+//
+// To test the provider, start the simulator:
+// docker run -d -p 623:623/udp vaporio/ipmi-simulator
+//
+// Once the simulator is running, you can query it:
+// cnquery shell ipmi ADMIN@0.0.0.0 --password 'ADMIN'
 func main() {
 	plugin.Start(os.Args, provider.Init())
 }

--- a/providers/ipmi/provider/provider.go
+++ b/providers/ipmi/provider/provider.go
@@ -44,7 +44,6 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	}
 
 	// custom flag parsing
-
 	user := ""
 	port := 623
 	if len(req.Args) != 0 {


### PR DESCRIPTION
```
cnquery shell ipmi ADMIN@0.0.0.0 --password 'ADMIN'
→ connected to IPMI
  ___ _ __   __ _ _   _  ___ _ __ _   _ 
 / __| '_ \ / _` | | | |/ _ \ '__| | | |
| (__| | | | (_| | |_| |  __/ |  | |_| |
 \___|_| |_|\__, |\__,_|\___|_|   \__, |
  mondoo™      |_|                |___/  interactive shell

cnquery> ipmi.guid
ipmi.guid: "A123456789AB"
cnquery> ipmi.deviceID
ipmi.deviceID: {
  additionalDeviceSupport: {
    bridge: false
    chassisDevice: true
    fruInventoryDevice: true
    ipmbEventGenerator: false
    ipmbEventReciever: true
    sdrRepositoryDevice: true
    selDevice: true
    sensorDevice: true
  }
  deviceAvailable: true
  deviceID: 0.000000
  deviceRevision: 3.000000
  firmwareRevision: "9.08"
  ipmiVersion: 2.000000
  manufacturerID: 4753.000000
  manufacturerName: "Unknown"
  productID: 3842.000000
  productName: "Unknown"
  providesDeviceSDRs: false
}
cnquery> ipmi.chassis.status
ipmi.chassis.status: {
  chassisIntrusion: false
  coolingFanFault: false
  driveFault: false
  frontPanelLockout: false
  lastPowerEvent: {
    ac-failed: false
    command: false
    fault: false
    interlock: false
    overload: false
  }
  mainPowerFault: false
  powerControlFault: false
  powerInterlock: false
  powerOverload: false
  powerRestorePolicy: "always-off"
  systemPower: true
}
cnquery> 
```