### PR TITLE
🧹 update opcua subcommand help

### DIFF
--- a/providers/opcua/config/config.go
+++ b/providers/opcua/config/config.go
@@ -15,16 +15,22 @@ var Config = plugin.Provider{
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{
-			Name:      "opcua",
-			Use:       "opcua",
-			Short:     "OPC UA",
+			Name:  "opcua",
+			Use:   "opcua [--endpoint <endpoint>]",
+			Short: "OPC UA",
+			Long: `opcua is designed for querying resources on an OPC UA (Open Platform 
+Communications Unified Architecture) server, a protocol facilitating machine-to-machine communications within 
+the realm of industrial automation.
+`,
+
 			Discovery: []string{},
 			Flags: []plugin.Flag{
 				{
 					Long:    "endpoint",
 					Type:    plugin.FlagType_String,
 					Default: "",
-					Desc:    "OPC UA service endpoint",
+					Desc:    "OPC UA endpoint URL of the OPC UA server in the format opc.tcp://<host>:<port>",
+					Option:  plugin.FlagOption_Required,
 				},
 			},
 		},

--- a/providers/opcua/main.go
+++ b/providers/opcua/main.go
@@ -10,6 +10,13 @@ import (
 	"go.mondoo.com/cnquery/providers/opcua/provider"
 )
 
+// This is the entry point for the OPCUA provider.
+//
+// To test the provider, start the simulator:
+// docker run --rm -it -p 50000:50000 -p 8080:8080 --name opcplc mcr.microsoft.com/iotedge/opc-plc:latest --pn=50000 --autoaccept --sph --sn=5 --sr=10 --st=uint --fn=5 --fr=1 --ft=uint --gn=5 --ut --dca
+//
+// Once the simulator is running, you can query it:
+// cnquery shell opcua --endpoint opc.tcp://localhost:50000
 func main() {
 	plugin.Start(os.Args, provider.Init())
 }


### PR DESCRIPTION
```
cnquery shell opcua --endpoint opc.tcp://localhost:50000
→ loaded configuration from /Users/chris/.config/mondoo/mondoo.yml using source default
→ connected to OPC UA
  ___ _ __   __ _ _   _  ___ _ __ _   _ 
 / __| '_ \ / _` | | | |/ _ \ '__| | | |
| (__| | | | (_| | |_| |  __/ |  | |_| |
 \___|_| |_|\__, |\__,_|\___|_|   \__, |
  mondoo™      |_|                |___/  interactive shell

cnquery> googleworkspace.user
cnquery> opcua.root
opcua.root: opcua.node id="i=84" name="Root"
cnquery> opcua.root { * }
opcua.root: {
  id: "i=84"
  dataType: ""
  description: ""
  max: ""
  properties: []
  namespace: opcua.namespace id = opcua.namespace/0
  min: ""
  components: []
  writeable: false
  name: "Root"
  organizes: [
    0: opcua.node id="i=85" name="Objects"
    1: opcua.node id="i=86" name="Types"
    2: opcua.node id="i=87" name="Views"
  ]
  class: "NodeClassObject"
  unit: ""
  accessLevel: "AccessLevelTypeNone"
}
```