### PR TITLE
🐛 fix gitlab project detection

### DIFF
--- a/providers/gitlab/resources/gitlab.go
+++ b/providers/gitlab/resources/gitlab.go
@@ -54,7 +54,7 @@ func (g *mqlGitlabGroup) projects() ([]interface{}, error) {
 	}
 	gid := g.Id.Data
 
-	grp, _, err := conn.Client().Groups.GetGroup(gid, nil)
+	grp, _, err := conn.Client().Groups.GetGroup(int(gid), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fixes the issue in the gitlab api that it cannot work with int64 but only int project ids:

```
cnquery> gitlab.group { * }
1 error occurred:
	* invalid ID type 123456, the ID must be an int or a string
```