### PR TITLE
⚡ re-use runtimes across providers

### DIFF
--- a/apps/cnquery/cmd/plugin.go
+++ b/apps/cnquery/cmd/plugin.go
@@ -117,12 +117,12 @@ func (c *cnqueryPlugin) RunQuery(conf *run.RunQueryConfig, runtime *providers.Ru
 
 	for i := range assets {
 		connectAsset := assets[i]
-		connectAssetRuntime := providers.Coordinator.NewRuntimeFrom(runtime)
-
-		if err := connectAssetRuntime.DetectProvider(connectAsset); err != nil {
+		connectAssetRuntime, err := providers.Coordinator.RuntimeFor(connectAsset, runtime)
+		if err != nil {
 			return err
 		}
-		err := connectAssetRuntime.Connect(&pp.ConnectReq{
+
+		err = connectAssetRuntime.Connect(&pp.ConnectReq{
 			Features: config.Features,
 			Asset:    connectAsset,
 			Upstream: upstreamConfig,

--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -408,6 +408,9 @@ func setConnector(provider *plugin.Provider, connector *plugin.Connector, run fu
 
 		// TODO: add flag to set timeout and then use RuntimeWithShutdownTimeout
 		runtime := providers.Coordinator.NewRuntime()
+		if err = providers.SetDefaultRuntime(runtime); err != nil {
+			log.Error().Msg(err.Error())
+		}
 
 		autoUpdate := true
 		if viper.IsSet("auto_update") {

--- a/providers/defaults.go
+++ b/providers/defaults.go
@@ -3,7 +3,10 @@
 
 package providers
 
-import "go.mondoo.com/cnquery/providers-sdk/v1/plugin"
+import (
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/cnquery/providers-sdk/v1/plugin"
+)
 
 const DefaultOsID = "go.mondoo.com/cnquery/providers/os"
 
@@ -14,6 +17,14 @@ func DefaultRuntime() *Runtime {
 		defaultRuntime = Coordinator.NewRuntime()
 	}
 	return defaultRuntime
+}
+
+func SetDefaultRuntime(rt *Runtime) error {
+	if rt == nil {
+		return errors.New("attempted to set default runtime to null")
+	}
+	defaultRuntime = rt
+	return nil
 }
 
 // DefaultProviders are useful when working in air-gapped environments

--- a/providers/extensible_schema.go
+++ b/providers/extensible_schema.go
@@ -1,0 +1,123 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"sync"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/providers-sdk/v1/resources"
+)
+
+type extensibleSchema struct {
+	resources.Schema
+
+	loaded    map[string]struct{}
+	runtime   *Runtime
+	allLoaded bool
+	lockAll   sync.Mutex // only used in getting all schemas
+	lockAdd   sync.Mutex // only used when adding a schema
+}
+
+func (x *extensibleSchema) loadAllSchemas() {
+	x.lockAll.Lock()
+	defer x.lockAll.Unlock()
+
+	// If another goroutine started to load this before us, it will be locked until
+	// we complete to load everything and then it will be dumped into this
+	// position. At this point, if it has been loaded we can return safely, since
+	// we don't unlock until we are finished loading.
+	if x.allLoaded {
+		return
+	}
+	x.allLoaded = true
+
+	providers, err := ListActive()
+	if err != nil {
+		log.Error().Err(err).Msg("failed to list all providers, can't load additional schemas")
+		return
+	}
+
+	for name := range providers {
+		schema, err := x.runtime.coordinator.LoadSchema(name)
+		if err != nil {
+			log.Error().Err(err).Msg("load schema failed")
+		} else {
+			x.Add(name, schema)
+		}
+	}
+}
+
+func (x *extensibleSchema) Close() {
+	x.loaded = map[string]struct{}{}
+	x.Schema.Resources = nil
+}
+
+func (x *extensibleSchema) Lookup(name string) *resources.ResourceInfo {
+	if found, ok := x.Resources[name]; ok {
+		return found
+	}
+	if x.allLoaded {
+		return nil
+	}
+
+	x.loadAllSchemas()
+	return x.Resources[name]
+}
+
+func (x *extensibleSchema) LookupField(resource string, field string) (*resources.ResourceInfo, *resources.Field) {
+	found, ok := x.Resources[resource]
+	if !ok {
+		if x.allLoaded {
+			return nil, nil
+		}
+
+		x.loadAllSchemas()
+
+		found, ok = x.Resources[resource]
+		if !ok {
+			return nil, nil
+		}
+		return found, found.Fields[field]
+	}
+
+	fieldObj, ok := found.Fields[field]
+	if ok {
+		return found, fieldObj
+	}
+	if x.allLoaded {
+		return found, nil
+	}
+
+	x.loadAllSchemas()
+	return found, found.Fields[field]
+}
+
+func (x *extensibleSchema) Add(name string, schema *resources.Schema) {
+	if schema == nil {
+		return
+	}
+	if name == "" {
+		log.Error().Msg("tried to add a schema with no name")
+		return
+	}
+
+	x.lockAdd.Lock()
+	defer x.lockAdd.Unlock()
+
+	if _, ok := x.loaded[name]; ok {
+		return
+	}
+
+	x.loaded[name] = struct{}{}
+	x.Schema.Add(schema)
+}
+
+func (x *extensibleSchema) AllResources() map[string]*resources.ResourceInfo {
+	if !x.allLoaded {
+		x.loadAllSchemas()
+	}
+
+	return x.Resources
+}


### PR DESCRIPTION
We minimize runtime creation as much as we can in this iteration.

1. Whenever an existing runtime connects to an asset (and collects identifying information about the asset like platform identifiers or MRN), it can be re-used in subsequent runs with the same asset. Discovery runs provide assets with discovery information, so they can be re-used. 
2. Runtimes that never connect to assets (like the initial runtime on a scan) will be discarded. There are very few of these.
3. On re-use, the provider-discovery is not necessary anymore, saving more calls.