### PR TITLE
🐛 update provider defaults + missing connection types + v8 compat

### DIFF
--- a/providers-sdk/v1/inventory/inventory.go
+++ b/providers-sdk/v1/inventory/inventory.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
 	"github.com/segmentio/ksuid"
 	"go.mondoo.com/cnquery/providers-sdk/v1/vault"
 	"google.golang.org/protobuf/proto"
@@ -56,7 +57,8 @@ func InventoryFromYAML(data []byte) (*Inventory, error) {
 		for _, asset := range res.Spec.Assets {
 			for _, conn := range asset.Connections {
 				if conn.Type == "" {
-					conn.Type = connBackendToType(conn.Backend)
+					log.Warn().Msg("no connection `type` provided in inventory, falling back to deprecated `backend` field")
+					conn.Type = ConnBackendToType(conn.Backend)
 				}
 			}
 		}

--- a/providers-sdk/v1/inventory/v8_inventory.go
+++ b/providers-sdk/v1/inventory/v8_inventory.go
@@ -114,7 +114,7 @@ func (s *ProviderType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func connBackendToType(backend ProviderType) string {
+func ConnBackendToType(backend ProviderType) string {
 	switch backend {
 	case ProviderType_LOCAL_OS:
 		return "os"

--- a/providers/defaults.go
+++ b/providers/defaults.go
@@ -31,31 +31,10 @@ func SetDefaultRuntime(rt *Runtime) error {
 // to tell users what providers are used for common connections, when there
 // is no other way to find out.
 var DefaultProviders Providers = map[string]*Provider{
-	"gcp": {
-		Provider: &plugin.Provider{
-			Name: "gcp",
-			Connectors: []plugin.Connector{
-				{
-					Name:  "gcp",
-					Short: "GCP Cloud",
-				},
-			},
-		},
-	},
-	"ipmi": {
-		Provider: &plugin.Provider{
-			Name: "ipmi",
-			Connectors: []plugin.Connector{
-				{
-					Name:  "ipmi",
-					Short: "IPMI",
-				},
-			},
-		},
-	},
 	"arista": {
 		Provider: &plugin.Provider{
-			Name: "arista",
+			Name:            "arista",
+			ConnectionTypes: []string{"arista"},
 			Connectors: []plugin.Connector{
 				{
 					Name:  "arista",
@@ -64,20 +43,185 @@ var DefaultProviders Providers = map[string]*Provider{
 			},
 		},
 	},
-	"terraform": {
+	"aws": {
 		Provider: &plugin.Provider{
-			Name: "terraform",
+			Name:            "aws",
+			ConnectionTypes: []string{"aws", "ebs"},
 			Connectors: []plugin.Connector{
 				{
-					Name:  "terraform",
-					Short: "a terraform hcl file or directory.",
+					Name:  "aws",
+					Short: "aws account",
+				},
+			},
+		},
+	},
+	"azure": {
+		Provider: &plugin.Provider{
+			Name:            "azure",
+			ConnectionTypes: []string{"azure"},
+			Connectors: []plugin.Connector{
+				{
+					Name:  "azure",
+					Short: "azure",
+				},
+			},
+		},
+	},
+	"core": {
+		Provider: &plugin.Provider{
+			Name:            "core",
+			ConnectionTypes: []string(nil),
+			Connectors:      []plugin.Connector{},
+		},
+	},
+	"equinix": {
+		Provider: &plugin.Provider{
+			Name:            "equinix",
+			ConnectionTypes: []string{"equinix"},
+			Connectors: []plugin.Connector{
+				{
+					Name:  "equinix",
+					Short: "Equinix Metal",
+				},
+			},
+		},
+	},
+	"gcp": {
+		Provider: &plugin.Provider{
+			Name:            "gcp",
+			ConnectionTypes: []string{"gcp", "gcp-snapshot"},
+			Connectors: []plugin.Connector{
+				{
+					Name:  "gcp",
+					Short: "GCP Cloud",
+				},
+			},
+		},
+	},
+	"github": {
+		Provider: &plugin.Provider{
+			Name:            "github",
+			ConnectionTypes: []string{"github"},
+			Connectors: []plugin.Connector{
+				{
+					Name:  "github",
+					Short: "GitHub",
+				},
+			},
+		},
+	},
+	"gitlab": {
+		Provider: &plugin.Provider{
+			Name:            "gitlab",
+			ConnectionTypes: []string{"gitlab", "gitlab-group", "gitlab-project"},
+			Connectors: []plugin.Connector{
+				{
+					Name:  "gitlab",
+					Short: "GitLab",
+				},
+			},
+		},
+	},
+	"google-workspace": {
+		Provider: &plugin.Provider{
+			Name:            "google-workspace",
+			ConnectionTypes: []string{"google-workspace"},
+			Connectors: []plugin.Connector{
+				{
+					Name:  "google-workspace",
+					Short: "Google Workspace",
+				},
+			},
+		},
+	},
+	"ipmi": {
+		Provider: &plugin.Provider{
+			Name:            "ipmi",
+			ConnectionTypes: []string{"ipmi"},
+			Connectors: []plugin.Connector{
+				{
+					Name:  "ipmi",
+					Short: "Ipmi",
+				},
+			},
+		},
+	},
+	"k8s": {
+		Provider: &plugin.Provider{
+			Name:            "k8s",
+			ConnectionTypes: []string{"k8s"},
+			Connectors: []plugin.Connector{
+				{
+					Name:  "k8s",
+					Short: "a Kubernetes cluster or local manifest file(s).",
+				},
+			},
+		},
+	},
+	"ms365": {
+		Provider: &plugin.Provider{
+			Name:            "ms365",
+			ConnectionTypes: []string{"ms365"},
+			Connectors: []plugin.Connector{
+				{
+					Name:  "ms365",
+					Short: "ms365",
+				},
+			},
+		},
+	},
+	"network": {
+		Provider: &plugin.Provider{
+			Name:            "network",
+			ConnectionTypes: []string{"host"},
+			Connectors: []plugin.Connector{
+				{
+					Name:  "host",
+					Short: "a remote host",
+				},
+			},
+		},
+	},
+	"oci": {
+		Provider: &plugin.Provider{
+			Name:            "oci",
+			ConnectionTypes: []string{"oci"},
+			Connectors: []plugin.Connector{
+				{
+					Name:  "oci",
+					Short: "Oracle Cloud Infrastructure",
+				},
+			},
+		},
+	},
+	"okta": {
+		Provider: &plugin.Provider{
+			Name:            "okta",
+			ConnectionTypes: []string{"okta"},
+			Connectors: []plugin.Connector{
+				{
+					Name:  "okta",
+					Short: "Okta",
+				},
+			},
+		},
+	},
+	"opcua": {
+		Provider: &plugin.Provider{
+			Name:            "opcua",
+			ConnectionTypes: []string{"opcua"},
+			Connectors: []plugin.Connector{
+				{
+					Name:  "opcua",
+					Short: "OPC UA",
 				},
 			},
 		},
 	},
 	"os": {
 		Provider: &plugin.Provider{
-			Name: "os",
+			Name:            "os",
+			ConnectionTypes: []string{"local", "ssh", "tar", "docker-snapshot", "vagrant", "docker-image", "docker-container", "docker-registry", "container-registry", "registry-image", "filesystem"},
 			Connectors: []plugin.Connector{
 				{
 					Name:  "local",
@@ -100,103 +244,44 @@ var DefaultProviders Providers = map[string]*Provider{
 					Short: "a running container or container image",
 				},
 				{
+					Name:  "docker",
+					Short: "a running docker or docker image",
+				},
+				{
 					Name:  "filesystem",
 					Short: "a mounted file system target.",
 				},
 			},
 		},
 	},
-	"vsphere": {
-		Provider: &plugin.Provider{
-			Name: "vsphere",
-			Connectors: []plugin.Connector{
-				{
-					Name:  "vsphere",
-					Short: "VMware vSphere",
-				},
-			},
-		},
-	},
-	"google-workspace": {
-		Provider: &plugin.Provider{
-			Name: "google-workspace",
-			Connectors: []plugin.Connector{
-				{
-					Name:  "google-workspace",
-					Short: "Google Workspace",
-				},
-			},
-		},
-	},
-	"opcua": {
-		Provider: &plugin.Provider{
-			Name: "opcua",
-			Connectors: []plugin.Connector{
-				{
-					Name:  "opcua",
-					Short: "OPC UA",
-				},
-			},
-		},
-	},
-	"okta": {
-		Provider: &plugin.Provider{
-			Name: "okta",
-			Connectors: []plugin.Connector{
-				{
-					Name:  "okta",
-					Short: "Okta",
-				},
-			},
-		},
-	},
 	"slack": {
 		Provider: &plugin.Provider{
-			Name: "slack",
+			Name:            "slack",
+			ConnectionTypes: []string{"slack"},
 			Connectors: []plugin.Connector{
 				{
 					Name:  "slack",
-					Short: "Slack Team",
+					Short: "slack team",
 				},
 			},
 		},
 	},
-	"github": {
+	"terraform": {
 		Provider: &plugin.Provider{
-			Name: "github",
+			Name:            "terraform",
+			ConnectionTypes: []string{"terraform-state", "terraform-plan", "terraform-hcl", "terraform-hcl-git"},
 			Connectors: []plugin.Connector{
 				{
-					Name:  "github",
-					Short: "GitHub",
-				},
-			},
-		},
-	},
-	"equinix": {
-		Provider: &plugin.Provider{
-			Name: "equinix",
-			Connectors: []plugin.Connector{
-				{
-					Name:  "equinix",
-					Short: "Equinix Metal",
-				},
-			},
-		},
-	},
-	"k8s": {
-		Provider: &plugin.Provider{
-			Name: "k8s",
-			Connectors: []plugin.Connector{
-				{
-					Name:  "k8s",
-					Short: "Kubernetes cluster or local manifest file(s)",
+					Name:  "terraform",
+					Short: "a terraform hcl file or directory.",
 				},
 			},
 		},
 	},
 	"vcd": {
 		Provider: &plugin.Provider{
-			Name: "vcd",
+			Name:            "vcd",
+			ConnectionTypes: []string{"vcd"},
 			Connectors: []plugin.Connector{
 				{
 					Name:  "vcd",
@@ -205,68 +290,14 @@ var DefaultProviders Providers = map[string]*Provider{
 			},
 		},
 	},
-	"aws": {
+	"vsphere": {
 		Provider: &plugin.Provider{
-			Name: "aws",
+			Name:            "vsphere",
+			ConnectionTypes: []string{"vsphere"},
 			Connectors: []plugin.Connector{
 				{
-					Name:  "aws",
-					Short: "AWS account",
-				},
-			},
-		},
-	},
-	"gitlab": {
-		Provider: &plugin.Provider{
-			Name: "gitlab",
-			Connectors: []plugin.Connector{
-				{
-					Name:  "gitlab",
-					Short: "GitLab",
-				},
-			},
-		},
-	},
-	"oci": {
-		Provider: &plugin.Provider{
-			Name: "oci",
-			Connectors: []plugin.Connector{
-				{
-					Name:  "oci",
-					Short: "Oracle Cloud Infrastructure",
-				},
-			},
-		},
-	},
-	"network": {
-		Provider: &plugin.Provider{
-			Name: "network",
-			Connectors: []plugin.Connector{
-				{
-					Name:  "host",
-					Short: "Remote host",
-				},
-			},
-		},
-	},
-	"ms365": {
-		Provider: &plugin.Provider{
-			Name: "ms365",
-			Connectors: []plugin.Connector{
-				{
-					Name:  "ms365",
-					Short: "Microsoft 365",
-				},
-			},
-		},
-	},
-	"azure": {
-		Provider: &plugin.Provider{
-			Name: "azure",
-			Connectors: []plugin.Connector{
-				{
-					Name:  "azure",
-					Short: "Azure",
+					Name:  "vsphere",
+					Short: "VMware vSphere",
 				},
 			},
 		},

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -160,11 +160,8 @@ func (r *Runtime) DetectProvider(asset *inventory.Asset) error {
 	for i := range asset.Connections {
 		conn := asset.Connections[i]
 		if conn.Type == "" {
-			if conn.Backend != "" {
-				conn.Type = conn.Backend
-			} else {
-				continue
-			}
+			log.Warn().Msg("no connection `type` provided in inventory, falling back to deprecated `backend` field")
+			conn.Type = inventory.ConnBackendToType(conn.Backend)
 		}
 
 		provider, err := EnsureProvider("", conn.Type, true, r.coordinator.Providers)

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -160,7 +160,11 @@ func (r *Runtime) DetectProvider(asset *inventory.Asset) error {
 	for i := range asset.Connections {
 		conn := asset.Connections[i]
 		if conn.Type == "" {
-			continue
+			if conn.Backend != "" {
+				conn.Type = conn.Backend
+			} else {
+				continue
+			}
 		}
 
 		provider, err := EnsureProvider("", conn.Type, true, r.coordinator.Providers)


### PR DESCRIPTION
Connection types were missing and thus caused any request that would look for them to fail. In most cases this is not noticable at all (because you eg connect to github to continue to do things with github as you discover more stuff).

But there is a very nasty case where this hurt: When we are in serve mode and don't have a primary connection that triggers provider installations. In this case we receive asset types (or rather v8 Backend fields!), which then didn't find any way to look up their provider.

So:
1. Add a script to help with defaults generation (it does 80% of the work, you only have to copy it over): ```bash version defaults providers/*/ ```
2. Update all providers with it
3. Support v8 `Backend` field (needs in-depth testing since both fields are not fully compatible; add translations where necessary)