### PR TITLE
🐛 runtime starts should be debug messages

### DIFF
--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -288,7 +288,7 @@ func (c *coordinator) NewRuntime() *Runtime {
 	cnt := c.runtimeCnt
 	c.mutex.Unlock()
 
-	log.Warn().Msg("Started a new runtime (" + strconv.Itoa(cnt) + " total)")
+	log.Debug().Msg("Started a new runtime (" + strconv.Itoa(cnt) + " total)")
 
 	return res
 }


### PR DESCRIPTION
I messed this up in a previous PR, time to fix it!