### PR TITLE
🐛 fix provider scaffolding

### DIFF
--- a/apps/provider-scaffold/template/provider/provider.go.template
+++ b/apps/provider-scaffold/template/provider/provider.go.template
@@ -107,7 +107,6 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	asset.Connections[0].Id = conn.ID()
 	s.runtimes[conn.ID()] = &plugin.Runtime{
 		Connection:     conn,
-		Resources:      map[string]plugin.Resource{},
 		Callback:       callback,
 		HasRecording:   req.HasRecording,
 		CreateResource: resources.CreateResource,
@@ -154,7 +153,7 @@ func (s *Service) GetData(req *plugin.DataReq) (*plugin.DataRes, error) {
 		}, nil
 	}
 
-	resource, ok := runtime.Resources[req.Resource+"\x00"+req.ResourceId]
+	resource, ok := runtime.Resources.Get(req.Resource + "\x00" + req.ResourceId)
 	if !ok {
 		// Note: Since resources are internally always created, there are only very
 		// few cases where we arrive here:
@@ -183,4 +182,8 @@ func (s *Service) GetData(req *plugin.DataReq) (*plugin.DataRes, error) {
 
 func (s *Service) StoreData(req *plugin.StoreReq) (*plugin.StoreRes, error) {
 	return nil, errors.New("not yet implemented")
+}
+
+func (s *Service) MockConnect(req *plugin.ConnectReq, callback plugin.ProviderCallback) (*plugin.ConnectRes, error) {
+	return nil, errors.New("mock connect not yet implemented")
 }


### PR DESCRIPTION
These changes where necessary to make `make provider/build` go through.