### PR TITLE
Updates AWS ipPermissions defaults to include more fields

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1765,7 +1765,7 @@ private aws.ec2.securitygroup @defaults("arn") {
 }
 
 // Amazon EC2 Security Group IP Permission
-private aws.ec2.securitygroup.ippermission @defaults("id") {
+private aws.ec2.securitygroup.ippermission @defaults("id toPort fromPort ipProtocol ipRanges ipv6Ranges") {
   // Unique ID for the IP permission
   id string
   // Start of port range for TCP/UDP protocols


### PR DESCRIPTION
This PR updates the default fields for AWS Security Group IP permissions to make the findings more actionable.

## Current:

```
  21: {
    ipPermissionsEgress: [
  0: aws.ec2.securitygroup.ippermission id="sg-6b43f159-0-egress"
    ]
    vpc: aws.vpc arn="arn:aws:vpc:us-west-2:177043752222:id/vpc-ffa52222" isDefault=true
    tags: {}
    name: "default"
    description: "default VPC security group"
    id: "sg-6b432222"
    region: "us-west-2"
    ipPermissions: [
  0: aws.ec2.securitygroup.ippermission id="sg-6b432222-0"
    ]
    arn: "arn:aws:ec2:us-west-2:177043759222:security-group/sg-6b432222"
    isAttachedToNetworkInterface: false
  }
```

## Updated 

```
  21: {
    tags: {}
    name: "default"
    ipPermissionsEgress: [
      0: aws.ec2.securitygroup.ippermission id="sg-6b43f159-0-egress" toPort=0 fromPort=0 ipProtocol="-1" ipRanges=[
        0: "0.0.0.0/0"
      ] ipv6Ranges=[]
    ]
    description: "default VPC security group"
    id: "sg-6b432222"
    ipPermissions: [
      0: aws.ec2.securitygroup.ippermission id="sg-6b42222-0" toPort=0 fromPort=0 ipProtocol="-1" ipRanges=[] ipv6Ranges=[]
    ]
    vpc: aws.vpc arn="arn:aws:vpc:us-west-2:177043752222:id/vpc-ffa59787" isDefault=true cidrBlock="172.31.0.0/16"
    region: "us-west-2"
    arn: "arn:aws:ec2:us-west-2:177043752222:security-group/sg-6b432222"
    isAttachedToNetworkInterface: false
  }
```