### PR TITLE
⭐ support ephemeral vs normal runtimes

### DIFF
--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -235,10 +235,11 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 	for i := range assetCandidates {
 		candidate := assetCandidates[i]
 
-		runtime, err := providers.Coordinator.RuntimeFor(candidate.asset, candidate.runtime)
+		runtime, err := providers.Coordinator.EphemeralRuntimeFor(candidate.asset)
 		if err != nil {
 			return nil, false, err
 		}
+		runtime.SetRecording(candidate.runtime.Recording)
 
 		err = runtime.Connect(&plugin.ConnectReq{
 			Features: config.Features,

--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -24,13 +24,15 @@ import (
 var BuiltinCoreID = coreconf.Config.ID
 
 var Coordinator = coordinator{
-	Running:  []*RunningProvider{},
-	runtimes: map[string]*Runtime{},
+	RunningByID:      map[string]*RunningProvider{},
+	RunningEphemeral: map[*RunningProvider]struct{}{},
+	runtimes:         map[string]*Runtime{},
 }
 
 type coordinator struct {
-	Providers Providers
-	Running   []*RunningProvider
+	Providers        Providers
+	RunningByID      map[string]*RunningProvider
+	RunningEphemeral map[*RunningProvider]struct{}
 
 	unprocessedRuntimes []*Runtime
 	runtimes            map[string]*Runtime
@@ -101,7 +103,7 @@ type UpdateProvidersConfig struct {
 	RefreshInterval int
 }
 
-func (c *coordinator) Start(id string, update UpdateProvidersConfig) (*RunningProvider, error) {
+func (c *coordinator) Start(id string, isEphemeral bool, update UpdateProvidersConfig) (*RunningProvider, error) {
 	if x, ok := builtinProviders[id]; ok {
 		// We don't warn for core providers, which are the only providers
 		// built into the binary (for now).
@@ -189,7 +191,11 @@ func (c *coordinator) Start(id string, update UpdateProvidersConfig) (*RunningPr
 	}
 
 	c.mutex.Lock()
-	c.Running = append(c.Running, res)
+	if isEphemeral {
+		c.RunningEphemeral[res] = struct{}{}
+	} else {
+		c.RunningByID[res.ID] = res
+	}
 	c.mutex.Unlock()
 
 	return res, nil
@@ -265,6 +271,10 @@ func (c *coordinator) tryProviderUpdate(provider *Provider, update UpdateProvide
 }
 
 func (c *coordinator) NewRuntime() *Runtime {
+	return c.newRuntime(false)
+}
+
+func (c *coordinator) newRuntime(isEphemeral bool) *Runtime {
 	res := &Runtime{
 		coordinator: c,
 		providers:   map[string]*ConnectedProvider{},
@@ -276,19 +286,21 @@ func (c *coordinator) NewRuntime() *Runtime {
 		},
 		Recording:       NullRecording{},
 		shutdownTimeout: defaultShutdownTimeout,
+		isEphemeral:     isEphemeral,
 	}
 	res.schema.runtime = res
 
 	// TODO: do this dynamically in the future
 	res.schema.loadAllSchemas()
 
-	c.mutex.Lock()
-	c.unprocessedRuntimes = append(c.unprocessedRuntimes, res)
-	c.runtimeCnt++
-	cnt := c.runtimeCnt
-	c.mutex.Unlock()
-
-	log.Debug().Msg("Started a new runtime (" + strconv.Itoa(cnt) + " total)")
+	if !isEphemeral {
+		c.mutex.Lock()
+		c.unprocessedRuntimes = append(c.unprocessedRuntimes, res)
+		c.runtimeCnt++
+		cnt := c.runtimeCnt
+		c.mutex.Unlock()
+		log.Debug().Msg("Started a new runtime (" + strconv.Itoa(cnt) + " total)")
+	}
 
 	return res
 }
@@ -317,6 +329,18 @@ func (c *coordinator) RuntimeFor(asset *inventory.Asset, parent *Runtime) (*Runt
 	}
 
 	res = c.NewRuntimeFrom(parent)
+	return res, res.DetectProvider(asset)
+}
+
+// EphemeralRuntimeFor an asset, creates a new ephemeral runtime and connectors.
+// These are designed to be thrown away at the end of their use.
+// Note: at the time of writing they may still share auxiliary providers with
+// other runtimes, e.g. if provider X spawns another provider Y, the latter
+// may be a shared provider. The majority of memory load should be on the
+// primary provider (eg X in this case) so that it can effectively clear
+// its memory at the end of its use.
+func (c *coordinator) EphemeralRuntimeFor(asset *inventory.Asset) (*Runtime, error) {
+	res := c.newRuntime(true)
 	return res, res.DetectProvider(asset)
 }
 
@@ -361,31 +385,46 @@ func (c *coordinator) unsafeSetAssetRuntime(asset *inventory.Asset, runtime *Run
 	return found
 }
 
-func (c *coordinator) Close(p *RunningProvider) {
-	if !p.isClosed {
-		p.isClosed = true
-		if p.Client != nil {
-			p.Client.Kill()
+func (c *coordinator) Stop(provider *RunningProvider, isEphemeral bool) error {
+	if provider == nil {
+		return nil
+	}
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if isEphemeral {
+		delete(c.RunningEphemeral, provider)
+	} else {
+		found := c.RunningByID[provider.ID]
+		if found != nil {
+			delete(c.RunningByID, provider.ID)
 		}
 	}
 
-	c.mutex.Lock()
-	for i := range c.Running {
-		if c.Running[i] == p {
-			c.Running = append(c.Running[0:i], c.Running[i+1:]...)
-			break
-		}
-	}
-	c.mutex.Unlock()
+	return provider.Shutdown()
 }
 
 func (c *coordinator) Shutdown() {
 	c.mutex.Lock()
-	for i := range c.Running {
-		cur := c.Running[i]
+
+	for cur := range c.RunningEphemeral {
+		if err := cur.Shutdown(); err != nil {
+			log.Warn().Err(err).Str("provider", cur.Name).Msg("failed to shut down provider")
+		}
 		cur.isClosed = true
 		cur.Client.Kill()
 	}
+	c.RunningEphemeral = map[*RunningProvider]struct{}{}
+
+	for _, runtime := range c.RunningByID {
+		if err := runtime.Shutdown(); err != nil {
+			log.Warn().Err(err).Str("provider", runtime.Name).Msg("failed to shut down provider")
+		}
+		runtime.isClosed = true
+		runtime.Client.Kill()
+	}
+	c.RunningByID = map[string]*RunningProvider{}
+
 	c.mutex.Unlock()
 }
 

--- a/providers/mock.go
+++ b/providers/mock.go
@@ -63,7 +63,7 @@ func (s *mockProviderService) Connect(req *plugin.ConnectReq, callback plugin.Pr
 	for i := range asset.Connections {
 		conf := asset.Connections[i]
 
-		provider, err := s.runtime.addProvider(conf.ProviderID)
+		provider, err := s.runtime.addProvider(conf.ProviderID, false)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to init provider for connection in recording")
 		}


### PR DESCRIPTION
Ephemeral runtimes are used as throw-away runtimes, that come with their own plugin runner (and execution space). These runtimes can be thrown away after they are used, while other runtimes and plugins remain shared.

This is particularly useful when scanning targets with the discover mode, where potentially many runtimes/plugins need to be instantiated on the fly and are only required for the lifetime of the scan.

![image](https://github.com/mondoohq/cnquery/assets/1307529/ef7e4170-83d1-4123-9ba9-726b16b1f39b)

Ephemeral providers:

1. Have their own plug instance that is not share with any other provider.
2. They can be safely shut down, without impacting other providers.
3. Ephemeral runtimes may spawn additional providers, which are shared in nature. On shutdown of ephemeral providers these shared providers are not closed.
4. Non-ephemeral plugin instances are now only destroyed when the coordinator shuts down.

Fixes https://github.com/mondoohq/cnquery/issues/2049
