### PR TITLE
🐛 Fix docker connection to support specifying either an image or a container.

### DIFF
--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -88,7 +88,31 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		port = 5985
 	case "vagrant":
 		conf.Type = "vagrant"
-	case "container", "docker":
+	case "docker":
+		if len(req.Args) > 1 {
+			switch req.Args[0] {
+			case "image":
+				conf.Type = "docker-image"
+				conf.Host = req.Args[1]
+			case "registry":
+				conf.Type = "docker-registry"
+				conf.Host = req.Args[1]
+			case "tar":
+				conf.Type = "docker-snapshot"
+				conf.Path = req.Args[1]
+			case "container":
+				conf.Type = "docker-container"
+				conf.Host = req.Args[1]
+			}
+		} else {
+			connType, err := connection.FetchConnectionType(req.Args[0])
+			if err != nil {
+				return nil, err
+			}
+			conf.Type = connType
+			containerID = req.Args[0]
+		}
+	case "container":
 		if len(req.Args) > 1 {
 			switch req.Args[0] {
 			case "image":


### PR DESCRIPTION
Fixes #2040 

The following are now supported:
```
~/go/bin/cnquery shell docker pensive_boyd // by container name
~/go/bin/cnquery shell docker 7b486842ac61 // by container id
~/go/bin/cnquery shell docker debian:11 // by image tag
~/go/bin/cnquery shell docker 3a30687df9b732bb88601b6c6c7866d632d5c9d4260cc7ec0fd575abffbbee32 // by image digest

~/go/bin/cnquery shell docker container pensive_boyd // by container name
~/go/bin/cnquery shell docker container 7b486842ac61 // by container id
```

I split off the `ParseCLI` logic for `container` and `docker` as having `docker container` makes sense whereas `container container` is not logical, `cnquery shell container <id>` should work just like `cnquery shell docker container <id>`

