### PR TITLE
🧹 Support int32 in llx dict primitives.

### DIFF
--- a/llx/data_conversions.go
+++ b/llx/data_conversions.go
@@ -74,6 +74,8 @@ func dict2primitive(value interface{}) (*Primitive, error) {
 	switch x := value.(type) {
 	case bool:
 		return BoolPrimitive(x), nil
+	case int32:
+		return IntPrimitive(int64(x)), nil
 	case int64:
 		return IntPrimitive(x), nil
 	case float64:


### PR DESCRIPTION
Fixes #2046 