### PR TITLE
🧹 share k8s discovery cache within a provider instance

### DIFF
--- a/providers/k8s/connection/api/connection.go
+++ b/providers/k8s/connection/api/connection.go
@@ -36,7 +36,7 @@ type Connection struct {
 	currentClusterName string
 }
 
-func NewConnection(id uint32, asset *inventory.Asset) (shared.Connection, error) {
+func NewConnection(id uint32, asset *inventory.Asset, discoveryCache *resources.DiscoveryCache) (shared.Connection, error) {
 	// check if the user .kube/config file exists
 	// NOTE: BuildConfigFromFlags falls back to cluster loading when .kube/config string is empty
 	// therefore we want to only change the kubeconfig string when the file really exists
@@ -72,7 +72,7 @@ func NewConnection(id uint32, asset *inventory.Asset) (shared.Connection, error)
 	config.Burst = 1000
 
 	// initialize api
-	d, err := resources.NewDiscoveryCache().Get(config)
+	d, err := discoveryCache.Get(config)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/k8s/provider/provider.go
+++ b/providers/k8s/provider/provider.go
@@ -16,6 +16,7 @@ import (
 	"go.mondoo.com/cnquery/providers/k8s/connection/api"
 	"go.mondoo.com/cnquery/providers/k8s/connection/manifest"
 	"go.mondoo.com/cnquery/providers/k8s/connection/shared"
+	connectionResources "go.mondoo.com/cnquery/providers/k8s/connection/shared/resources"
 	"go.mondoo.com/cnquery/providers/k8s/resources"
 )
 
@@ -24,12 +25,14 @@ const ConnectionType = "k8s"
 type Service struct {
 	runtimes         map[uint32]*plugin.Runtime
 	lastConnectionID uint32
+	discoveryCache   *connectionResources.DiscoveryCache
 }
 
 func Init() *Service {
 	return &Service{
 		runtimes:         map[uint32]*plugin.Runtime{},
 		lastConnectionID: 0,
+		discoveryCache:   connectionResources.NewDiscoveryCache(),
 	}
 }
 
@@ -165,7 +168,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 		}
 	} else {
 		s.lastConnectionID++
-		conn, err = api.NewConnection(s.lastConnectionID, asset)
+		conn, err = api.NewConnection(s.lastConnectionID, asset, s.discoveryCache)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
makes sure the discovery cache is shared for a provider instance. Right now, we don't re-use the provider instance yet, but we should adjust it for the future