### PR TITLE
✨ re-use provider instance for all assets when scanning k8s

### DIFF
--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -233,9 +233,17 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 	for i := range assetCandidates {
 		candidate := assetCandidates[i]
 
-		runtime, err := providers.Coordinator.EphemeralRuntimeFor(candidate.asset)
-		if err != nil {
-			return nil, false, err
+		var runtime *providers.Runtime
+		if candidate.asset.Connections[0].Type == "k8s" {
+			runtime, err = providers.Coordinator.RuntimeFor(candidate.asset, providers.DefaultRuntime())
+			if err != nil {
+				return nil, false, err
+			}
+		} else {
+			runtime, err = providers.Coordinator.EphemeralRuntimeFor(candidate.asset)
+			if err != nil {
+				return nil, false, err
+			}
 		}
 		runtime.SetRecording(candidate.runtime.Recording)
 


### PR DESCRIPTION
Same as mondoohq/cnspec#802