### PR TITLE
🐛 find.files with no results fixed

### DIFF
--- a/providers/builtin_dev.go
+++ b/providers/builtin_dev.go
@@ -6,25 +6,25 @@
 
 package providers
 
-import (
-	_ "embed"
-	// osconf "go.mondoo.com/cnquery/providers/os/config"
-	// os "go.mondoo.com/cnquery/providers/os/provider"
-)
+// import (
+// 	_ "embed"
+
+// 	osconf "go.mondoo.com/cnquery/providers/os/config"
+// 	os "go.mondoo.com/cnquery/providers/os/provider"
+// )
 
 // //go:embed os/resources/os.resources.json
 // var osInfo []byte
 
-func init() {
-	// builtinProviders[osconf.Config.ID] = &builtinProvider{
-	// 	Runtime: &RunningProvider{
-	// 		Name:     osconf.Config.Name,
-	// 		ID:       osconf.Config.ID,
-	// 		Plugin:   os.Init(),
-	// 		Schema:   MustLoadSchema("os", osInfo),
-	// 		isClosed: false,
-	// 	},
-	// 	Config: &osconf.Config,
-	// }
-
-}
+// func init() {
+// 	builtinProviders[osconf.Config.ID] = &builtinProvider{
+// 		Runtime: &RunningProvider{
+// 			Name:     osconf.Config.Name,
+// 			ID:       osconf.Config.ID,
+// 			Plugin:   os.Init(),
+// 			Schema:   MustLoadSchema("os", osInfo),
+// 			isClosed: false,
+// 		},
+// 		Config: &osconf.Config,
+// 	}
+// }

--- a/providers/os/resources/files.go
+++ b/providers/os/resources/files.go
@@ -131,7 +131,12 @@ func (l *mqlFilesFind) list() ([]interface{}, error) {
 			return nil, out.Error
 		}
 
-		foundFiles = strings.Split(strings.Trim(out.Data, " \t\n"), "\n")
+		lines := strings.TrimSpace(out.Data)
+		if lines == "" {
+			foundFiles = []string{}
+		} else {
+			foundFiles = strings.Split(lines, "\n")
+		}
 	} else {
 		return nil, errors.New("find is not supported for your platform")
 	}


### PR DESCRIPTION
This caused the error:

```coffee
cnspec> files.find(from: "/", type: "file", regex: ".*keychains.*")
Query encountered errors:
1 error occurred:
	* file does not exist
files.find.list: [
  0: file path="" size=0 permissions.string=no data available
]
```

With this update it behaves correctly:

```coffee
cnspec> files.find(from: "/", type: "file", regex: ".*keychains.*")
files.find.list: []
```

Additionally I commented out the builtin os provider for much easier use (avoid uncommenting 3 sections, just uncomment it all).