### PR TITLE
Update cnquery description from fleet -> infra

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Open source, cloud-native asset inventory and discovery**
 
-cnquery is a cloud-native tool for querying your entire fleet. It answers thousands of questions about your infrastructure and integrates with over 300 resources across cloud accounts, Kubernetes, containers, services, VMs, APIs, and more.
+cnquery is a cloud-native tool for querying your entire infrastructure. It answers thousands of questions about your infrastructure and integrates with over 300 resources across cloud accounts, Kubernetes, containers, services, VMs, APIs, and more.
 
 ![cnquery run example](docs/images/cnquery-run.gif)
 
@@ -130,7 +130,7 @@ Go to [console.mondoo.com](http://console.mondoo.com) to sign up.
 
 To learn about Mondoo Platform, read the [Mondoo Platform docs](https://mondoo.com/docs/platform/home/) or visit [mondoo.com](https://www.mondoo.com).
 
-## Distribute queries across your fleet with private query packs
+## Distribute queries across your infrastructure with private query packs
 
 You can create and share query packs using the Registry in the Mondoo Console. The Registry is a secure, private environment in your account where you store both Mondoo query packs and custom query packs. This lets you use the same query packs for all assets.
 
@@ -194,7 +194,7 @@ cnquery bundle upload mypack.mql.yaml
 
 ## What's next?
 
-There are so many things cnquery can do! Gather information about your fleet, find tool-sprawl across systems, run incident response, and share data with auditors… cnquery is nearly limitless in capabilities.
+There are so many things cnquery can do! Gather information about your infrastructure, find tool-sprawl across systems, run incident response, and share data with auditors… cnquery is nearly limitless in capabilities.
 
 Explore:
 

--- a/apps/cnquery/cmd/root.go
+++ b/apps/cnquery/cmd/root.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	askForPasswordValue = ">passwordisnotset<"
-	rootCmdDesc         = "cnquery is a cloud-native tool for querying your entire fleet.\n"
+	rootCmdDesc         = "cnquery is a cloud-native tool for querying your entire infrastructure.\n"
 
 	// we send a 78 exit code to prevent systemd service from restart
 	ConfigurationErrorCode = 78


### PR DESCRIPTION
We're not using the fleet word anymore. Update to infrastructure to match the same change we made in v8