### PR TITLE
🐛 fix cnquery shell default provider

### DIFF
--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -135,7 +135,11 @@ func attachProviders(existing providers.Providers, commands []*Command) {
 }
 
 func attachProvidersToCmd(existing providers.Providers, cmd *Command) {
+	var osProvider *providers.Provider
 	for _, provider := range existing {
+		if provider.Name == "os" {
+			osProvider = provider
+		}
 		for j := range provider.Connectors {
 			conn := provider.Connectors[j]
 			attachConnectorCmd(provider.Provider, &conn, cmd)
@@ -148,11 +152,11 @@ func attachProvidersToCmd(existing providers.Providers, cmd *Command) {
 	}
 
 	// the default is always os.local if it exists
-	if p, ok := existing[providers.DefaultOsID]; ok {
-		for i := range p.Connectors {
-			c := p.Connectors[i]
+	if osProvider != nil {
+		for i := range osProvider.Connectors {
+			c := osProvider.Connectors[i]
 			if c.Name == "local" {
-				setDefaultConnector(p.Provider, &c, cmd)
+				setDefaultConnector(osProvider.Provider, &c, cmd)
 				break
 			}
 		}


### PR DESCRIPTION
#2103 

Looking for a provider with the name "os" instead of looking for the id "go.mondoo.com/cnquery/v9/providers/os" would work in that it accepts both `9.0.7` (which has the id "go.mondoo.com/cnquery/providers/os") and `9.0.11`. 
Overall not sure how much I like this fix, it feels like it might cause problems in the future, especially if we actually get multiple providers called "os" with different ids

It seems to work for all cases I tested
* not having any os provider installed
* 9.0.0 installed
* 9.0.11 installed