### PR TITLE
🐛 fix temp v9 os provider upgrade

### DIFF
--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -157,6 +157,18 @@ func attachProvidersToCmd(existing providers.Providers, cmd *Command) {
 			}
 		}
 	}
+
+	// temp for migrating v9 beta users
+	if p, ok := existing[providers.DeprecatedDefaultOsID]; ok {
+		for i := range p.Connectors {
+			c := p.Connectors[i]
+			if c.Name == "local" {
+				setDefaultConnector(p.Provider, &c, cmd)
+				break
+			}
+		}
+	}
+
 }
 
 func setDefaultConnector(provider *plugin.Provider, connector *plugin.Connector, cmd *Command) {

--- a/providers/defaults.go
+++ b/providers/defaults.go
@@ -8,7 +8,10 @@ import (
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/plugin"
 )
 
-const DefaultOsID = "go.mondoo.com/cnquery/v9/providers/os"
+const (
+	DefaultOsID           = "go.mondoo.com/cnquery/v9/providers/os"
+	DeprecatedDefaultOsID = "go.mondoo.com/cnquery/providers/os" // temp to migrate v9 beta users
+)
 
 var defaultRuntime *Runtime
 


### PR DESCRIPTION
Closes #2103 

We could also temporarily allow the old id as well to make upgrade smoother for beta users