### PR TITLE
Fix google workspace and tf mql docs generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -395,7 +395,7 @@ lr/docs/markdown: providers/lr
 		--description "The GitLab resource pack lets you use MQL to query and assess the security of your GitLab organization and repositories." \
 		--docs-file providers/gitlab/resources/gitlab.lr.manifest.yaml \
 		--output ../docs/docs/mql/resources/gitlab-pack
-	./lr markdown providers/googleworkspace/resources/googleworkspace.lr \
+	./lr markdown providers/google-workspace/resources/google-workspace.lr \
 		--pack-name "Google Workspace" \
 		--description "The Google Workspace resource pack lets you use MQL to query and assess the security of your Google Workspace identities and configuration." \
 		--docs-file providers/google-workspace/resources/google-workspace.lr.manifest.yaml \

--- a/providers/terraform/resources/terraform.lr.manifest.yaml
+++ b/providers/terraform/resources/terraform.lr.manifest.yaml
@@ -113,7 +113,7 @@ resources:
     min_mondoo_version: latest
     platform:
       name:
-      - terraform-hcl
+      - terraform-plan
   terraform.plan.resourceChange:
     fields:
       actionReason: {}
@@ -152,7 +152,7 @@ resources:
     min_mondoo_version: 6.11.0
     platform:
       name:
-      - terraform-state
+      - terraform-hcl
   terraform.state.module:
     fields:
       address: {}
@@ -171,7 +171,7 @@ resources:
     min_mondoo_version: 6.11.0
     platform:
       name:
-      - terraform-hcl
+      - terraform-state
   terraform.state.resource:
     fields:
       address: {}
@@ -187,4 +187,4 @@ resources:
     min_mondoo_version: 6.11.0
     platform:
       name:
-      - terraform-state
+      - terraform-hcl


### PR DESCRIPTION
Fix the path to the LR docs for Google Workspace and regenerate the LR file for TF with the latest platform mapping