### PR TITLE
🐛 fix scan --help duplicates scan targets

### DIFF
--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -139,11 +139,6 @@ func attachProvidersToCmd(existing providers.Providers, cmd *Command) {
 		for j := range provider.Connectors {
 			conn := provider.Connectors[j]
 			attachConnectorCmd(provider.Provider, &conn, cmd)
-			for k := range conn.Aliases {
-				copyConn := conn
-				copyConn.Name = conn.Aliases[k]
-				attachConnectorCmd(provider.Provider, &copyConn, cmd)
-			}
 		}
 	}
 


### PR DESCRIPTION
Closes #2118 

Each target that had an Alias, such as k8s and kubernetes, would show up once for each alias in `cnquery scan --help`.

Before:
```
Available Commands:
  container   Scan a running container or container image
  docker      Scan a running docker or docker image
  filesystem  Scan a mounted file system target test.
  filesystem  Scan a mounted file system target test.
  k8s         Scan a Kubernetes cluster or local manifest file(s).
  k8s         Scan a Kubernetes cluster or local manifest file(s).
  local       Scan your local system
  mock        Scan use a recording without an active connection
  ssh         Scan a remote system via SSH
  vagrant     Scan a Vagrant host
  winrm       Scan a remote system via WinRM
```

After:
```
Available Commands:
  container   Scan a running container or container image
  docker      Scan a running docker or docker image
  filesystem  Scan a mounted file system target test.
  k8s         Scan a Kubernetes cluster or local manifest file(s).
  local       Scan your local system
  mock        Scan use a recording without an active connection
  ssh         Scan a remote system via SSH
  vagrant     Scan a Vagrant host
  winrm       Scan a remote system via WinRM
```

I verified that using the aliases also still works as expected.
I am unsure if there was another reason for us to add these connector copies, so far I haven't found any side effects.