### PR TITLE
🐛 fix aws es domains resource

### DIFF
--- a/providers/aws/resources/aws_es.go
+++ b/providers/aws/resources/aws_es.go
@@ -67,7 +67,7 @@ func (a *mqlAwsEs) getDomains(conn *connection.AwsConnection) []*jobpool.Job {
 			for _, domain := range domains.DomainNames {
 				// note: the api returns name and region here, so we just use that.
 				// the arn is not returned until we get to the describe call
-				mqlDomain, err := CreateResource(a.MqlRuntime, "aws.es.domain",
+				mqlDomain, err := NewResource(a.MqlRuntime, "aws.es.domain",
 					map[string]*llx.RawData{
 						"name":   llx.StringData(convert.ToString(domain.DomainName)),
 						"region": llx.StringData(regionVal),
@@ -88,18 +88,6 @@ func initAwsEsDomain(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-
-	// if len(args) == 0 {
-	// 	if ids := aruntime); ids != nil {
-	// 		args["name"] = ids.name
-	// 		args["arn"] = ids.arn
-	// 		if arn.IsARN(ids.arn) {
-	// 			if p, err := arn.Parse(ids.arn); err == nil {
-	// 				args["region"] = p.Region
-	// 			}
-	// 		}
-	// 	}
-	// }
 
 	if args["name"] == nil || args["region"] == nil {
 		return nil, nil, errors.New("name and region required to fetch es domain")


### PR DESCRIPTION
Closes #2114 

Before
```
cnquery> aws.es.domains{*}
1 error occurred:
	* cannot convert primitive with NO type information
aws.es.domains: [
  0: {
    nodeToNodeEncryptionEnabled: cannot convert primitive with NO type information
    tags: cannot convert primitive with NO type information
    arn: cannot convert primitive with NO type information
    encryptionAtRestEnabled: cannot convert primitive with NO type information
    endpoint: cannot convert primitive with NO type information
    region: "eu-central-1"
    name: "test"
  }
]
```

After
```
cnquery> aws.es.domains{*}
aws.es.domains: [
  0: {
    nodeToNodeEncryptionEnabled: true
    tags: {}
    arn: "arn:aws:es:eu-central-1:345411212130:domain/test"
    encryptionAtRestEnabled: true
    endpoint: ""
    region: "eu-central-1"
    name: "test"
  }
]
```


Problem was that `initAwsEsDomains` was not being called. 
I looked for another resource that required an init and found `ecs.clusters` - I found that the difference lies in `ecs.clusters` using `NewResource` instead of `CreateResource`. 

I also removed a comment that seemed unnecessary.