### PR TITLE
⭐ terraform.resources { related } support

### DIFF
--- a/providers/terraform/resources/terraform.lr
+++ b/providers/terraform/resources/terraform.lr
@@ -63,6 +63,8 @@ terraform.block @defaults("type labels") {
   attributes() dict
   // Child Blocks
   blocks() []terraform.block
+  // Related blocks
+  related() []terraform.block
   // Block Snippet
   snippet string
 }

--- a/providers/terraform/resources/terraform.lr.manifest.yaml
+++ b/providers/terraform/resources/terraform.lr.manifest.yaml
@@ -33,6 +33,8 @@ resources:
       end: {}
       labels: {}
       nameLabel: {}
+      related:
+        min_mondoo_version: 9.0.12
       snippet: {}
       start: {}
       type: {}


### PR DESCRIPTION
Discover all related resources of a given terraform resource. Additionally overhaul the internal discovery of all terraform blocks and reduce the amount of repetition drastically.

For example, given the following Terraform snippet:

```hcl
resource "aws_iam_role" "dev-resources-iam-role" {
  name        = "SSM-role-${local.name}-${random_string.suffix.result}"
  # ...
}

resource "aws_iam_instance_profile" "dev-resources-iam-profile" {
  name = "ec2_ssm_profile-${local.name}-${random_string.suffix.result}"
  role = aws_iam_role.dev-resources-iam-role.name
  # ...
}
```

Using this MQL:

```coffee
terraform.resources { 
  nameLabel 
  related { 
    nameLabel
  } 
}
```

We get:

```coffee
terraform.resources: [
  0: {
    nameLabel: "aws_iam_instance_profile"
    related: [
      0: {
        nameLabel: "aws_iam_role"
      }
    ]
  }
  1: {
    nameLabel: "aws_iam_role"
    related: [
      0: {
        nameLabel: "aws_iam_instance_profile"
      }
    ]
  }
]
```