### PR TITLE
🧹 shutdown coordinator after a scan

### DIFF
--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -402,6 +402,7 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 	}()
 
 	scanGroup.Wait()
+	providers.Coordinator.Shutdown()
 	return reporter.Reports(), finished, nil
 }
 


### PR DESCRIPTION
Make sure we clean the running providers after a scan. This change is already present in cnspec but was forgotten here