### PR TITLE
🐛 switch providers after CLI parsing

### DIFF
--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -163,7 +163,6 @@ func attachProvidersToCmd(existing providers.Providers, cmd *Command) {
 			}
 		}
 	}
-
 }
 
 func setDefaultConnector(provider *plugin.Provider, connector *plugin.Connector, cmd *Command) {
@@ -474,6 +473,18 @@ func setConnector(provider *plugin.Provider, connector *plugin.Connector, run fu
 			runtime.Close()
 			providers.Coordinator.Shutdown()
 			log.Fatal().Msg("failed to process CLI arguments, nothing was returned")
+			return // adding this here as a compiler hint to stop warning about nil-dereferences
+		}
+
+		if cliRes.Asset == nil {
+			log.Warn().Err(err).Msg("failed to discover assets after processing CLI arguments")
+		} else {
+			assetRuntime, err := providers.Coordinator.RuntimeFor(cliRes.Asset, runtime)
+			if err != nil {
+				log.Warn().Err(err).Msg("failed to get runtime for an asset that was detected after parsing the CLI")
+			} else {
+				runtime = assetRuntime
+			}
 		}
 
 		run(cc, runtime, cliRes)


### PR DESCRIPTION
Early runtime checks can cause providers to switch. For example: A user may start with the `aws` provider, but really want to user the `os` provider to scan an instance in AWS:

```bash
cnquery shell aws ec2 instance-connect ec2-user@i-1234abc --region us-east-1 --profile home
```

In the above example, we use the `aws` provider to parse the CLI. However, after that it's all about handing off the actual asset to the `os` provider to execute the scan.

Related to https://github.com/mondoohq/cnquery/issues/2166