### PR TITLE
🎉 aws-9.0.13, azure-9.0.8, gcp-9.0.9, github-9.0.8, gitlab-9.0.8, google-workspace-9.0.6, k8s-9.0.12, ms365-9.0.8, oci-9.0.8, os-9.0.12, terraform-9.0.12

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "9.0.12",
+	Version:         "9.0.13",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "azure",
 	ID:              "go.mondoo.com/cnquery/v9/providers/azure",
-	Version:         "9.0.7",
+	Version:         "9.0.8",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "9.0.8",
+	Version: "9.0.9",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),

--- a/providers/github/config/config.go
+++ b/providers/github/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "github",
 	ID:              "go.mondoo.com/cnquery/v9/providers/github",
-	Version:         "9.0.7",
+	Version:         "9.0.8",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/gitlab/config/config.go
+++ b/providers/gitlab/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gitlab",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gitlab",
-	Version: "9.0.7",
+	Version: "9.0.8",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		provider.GitlabGroupConnection,

--- a/providers/google-workspace/config/config.go
+++ b/providers/google-workspace/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "google-workspace",
 	ID:              "go.mondoo.com/cnquery/v9/providers/google-workspace",
-	Version:         "9.0.5",
+	Version:         "9.0.6",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "k8s",
 	ID:              "go.mondoo.com/cnquery/v9/providers/k8s",
-	Version:         "9.0.11",
+	Version:         "9.0.12",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ms365",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ms365",
-	Version:         "9.0.7",
+	Version:         "9.0.8",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/oci/config/config.go
+++ b/providers/oci/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "oci",
 	ID:              "go.mondoo.com/cnquery/v9/providers/oci",
-	Version:         "9.0.7",
+	Version:         "9.0.8",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "9.0.11",
+	Version: "9.0.12",
 	ConnectionTypes: []string{
 		provider.LocalConnectionType,
 		provider.SshConnectionType,

--- a/providers/terraform/config/config.go
+++ b/providers/terraform/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "terraform",
 	ID:      "go.mondoo.com/cnquery/v9/providers/terraform",
-	Version: "9.0.11",
+	Version: "9.0.12",
 	ConnectionTypes: []string{
 		provider.StateConnectionType,
 		provider.PlanConnectionType,


### PR DESCRIPTION
…gle-workspace-9.0.6, k8s-9.0.12, ms365-9.0.8, oci-9.0.8, os-9.0.12, terraform-9.0.12

This release was created by cnquery's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.