### PR TITLE
Add username to the slack.user resource defaults

### DIFF
--- a/providers/slack/resources/slack.lr
+++ b/providers/slack/resources/slack.lr
@@ -40,7 +40,7 @@ slack.users {
 }
 
 // Slack User
-slack.user @defaults("id") {
+slack.user @defaults("id name") {
   // Identifier for workspace user
   id string
   // User name


### PR DESCRIPTION
This will make the results of user queries actionable by giving an actual username instead of just an ID