### PR TITLE
Use MQL functions to retrieve aws resources, making use of the cache.

### DIFF
--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -614,7 +614,7 @@ func (a *mqlAwsEc2) getInstances(conn *connection.AwsConnection) []*jobpool.Job 
 	for _, region := range regions {
 		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling aws with region %s", regionVal)
+			log.Debug().Msgf("calling aws func with region %s", regionVal)
 
 			svc := conn.Ec2(regionVal)
 			ctx := context.Background()
@@ -854,8 +854,8 @@ func initAwsEc2Securitygroup(runtime *plugin.Runtime, args map[string]*llx.RawDa
 	}
 	awsEc2 := obj.(*mqlAwsEc2)
 
-	rawResources, err := awsEc2.securityGroups()
-	if err != nil {
+	rawResources := awsEc2.GetSecurityGroups()
+	if rawResources.Error != nil {
 		return nil, nil, err
 	}
 
@@ -875,8 +875,8 @@ func initAwsEc2Securitygroup(runtime *plugin.Runtime, args map[string]*llx.RawDa
 		}
 	}
 
-	for i := range rawResources {
-		securityGroup := rawResources[i].(*mqlAwsEc2Securitygroup)
+	for i := range rawResources.Data {
+		securityGroup := rawResources.Data[i].(*mqlAwsEc2Securitygroup)
 		if match(securityGroup) {
 			return args, securityGroup, nil
 		}
@@ -1111,6 +1111,7 @@ func initAwsEc2Instance(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		return args, nil, nil
 	}
 
+	log.Debug().Msg("init an ec2 instance")
 	if len(args) == 0 {
 		if ids := getAssetIdentifier(runtime); ids != nil {
 			args["arn"] = llx.StringData(ids.arn)
@@ -1127,14 +1128,14 @@ func initAwsEc2Instance(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 	}
 	ec2 := obj.(*mqlAwsEc2)
 
-	rawResources, err := ec2.instances()
-	if err != nil {
+	rawResources := ec2.GetInstances()
+	if rawResources.Error != nil {
 		return nil, nil, err
 	}
 
 	arnVal := args["arn"].Value.(string)
-	for i := range rawResources {
-		instance := rawResources[i].(*mqlAwsEc2Instance)
+	for i := range rawResources.Data {
+		instance := rawResources.Data[i].(*mqlAwsEc2Instance)
 		if instance.Arn.Data == arnVal {
 			return args, instance, nil
 		}

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -299,8 +299,8 @@ func initAwsVpc(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[stri
 	}
 	a := obj.(*mqlAws)
 
-	rawResources, err := a.vpcs()
-	if err != nil {
+	rawResources := a.GetVpcs()
+	if rawResources.Error != nil {
 		return nil, nil, err
 	}
 
@@ -313,8 +313,8 @@ func initAwsVpc(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[stri
 		}
 	}
 
-	for i := range rawResources {
-		volume := rawResources[i].(*mqlAwsVpc)
+	for i := range rawResources.Data {
+		volume := rawResources.Data[i].(*mqlAwsVpc)
 		if match(volume) {
 			return args, volume, nil
 		}


### PR DESCRIPTION
By using the MQL implementation of `Get`, we hit the cache once it's computed, this saves a lot of time when iterating over resources

There are probably other places where we need to change this, I only made sure that `aws.ec2.instances` queries are fixed. Will follow through with others later

Before:
```
➜ ~/go/bin/cnquery run aws -c 'aws.ec2.instances.length'
→ loaded configuration from /Users/preslavgerchev/.config/mondoo/mondoo.yml using source default
aws.ec2.instances.length: 10

cnquery on  preslav/aws-fix [$!?] via 🐹 v1.21.1 on 🐳 v20.10.16 using ☁️  default/mondoo-prod-243414 took 3m 7s
```

After:
``` 
➜ ~/go/bin/cnquery run aws -c 'aws.ec2.instances.length'
! using builtin provider for aws
! using builtin provider for aws
→ loaded configuration from /Users/preslavgerchev/.config/mondoo/mondoo.yml using source default
! using builtin provider for aws
aws.ec2.instances.length: 10

cnquery on  preslav/aws-fix [$!?] via 🐹 v1.21.1 on 🐳 v20.10.16 using ☁️  default/mondoo-prod-243414 took 12s 
```