### PR TITLE
🧹 Improve debug logging for AWS calls, do not fetch ec2's instance VPC if not needed

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1766,6 +1766,8 @@ private aws.ec2.instance @defaults("arn state") {
   keypair() aws.ec2.keypair
   // Time when the last state transition occurred
   stateTransitionTime time
+  // The ARN of the VPC, associated with the instance
+  vpcArn string
 }
 
 // Amazon EC2 Key Pair

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1766,7 +1766,7 @@ private aws.ec2.instance @defaults("arn state") {
   keypair() aws.ec2.keypair
   // Time when the last state transition occurred
   stateTransitionTime time
-  // The ARN of the VPC, associated with the instance
+  // The ARN of the VPC associated with the instance
   vpcArn string
 }
 

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -2531,6 +2531,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.instance.stateTransitionTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetStateTransitionTime()).ToDataRes(types.Time)
 	},
+	"aws.ec2.instance.vpcArn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Instance).GetVpcArn()).ToDataRes(types.String)
+	},
 	"aws.ec2.keypair.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Keypair).GetArn()).ToDataRes(types.String)
 	},
@@ -5775,6 +5778,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.ec2.instance.stateTransitionTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Instance).StateTransitionTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instance.vpcArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Instance).VpcArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.keypair.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15312,6 +15319,7 @@ type mqlAwsEc2Instance struct {
 	PrivateDnsName plugin.TValue[string]
 	Keypair plugin.TValue[*mqlAwsEc2Keypair]
 	StateTransitionTime plugin.TValue[*time.Time]
+	VpcArn plugin.TValue[string]
 }
 
 // createAwsEc2Instance creates a new instance of this resource
@@ -15487,6 +15495,10 @@ func (c *mqlAwsEc2Instance) GetKeypair() *plugin.TValue[*mqlAwsEc2Keypair] {
 
 func (c *mqlAwsEc2Instance) GetStateTransitionTime() *plugin.TValue[*time.Time] {
 	return &c.StateTransitionTime
+}
+
+func (c *mqlAwsEc2Instance) GetVpcArn() *plugin.TValue[string] {
+	return &c.VpcArn
 }
 
 // mqlAwsEc2Keypair for the aws.ec2.keypair resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -866,6 +866,8 @@ resources:
         min_mondoo_version: 9.0.0
       tags: {}
       vpc: {}
+      vpcArn:
+        min_mondoo_version: latest
     is_private: true
     min_mondoo_version: 5.15.0
     platform:

--- a/providers/aws/resources/aws_apigateway.go
+++ b/providers/aws/resources/aws_apigateway.go
@@ -52,7 +52,7 @@ func (a *mqlAwsApigateway) getRestApis(conn *connection.AwsConnection) []*jobpoo
 	for _, region := range regions {
 		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling AWS with region %s", regionVal)
+			log.Debug().Msgf("gateway>getRestApis>calling AWS with region %s", regionVal)
 
 			svc := conn.Apigateway(regionVal)
 			ctx := context.Background()

--- a/providers/aws/resources/aws_applicationautoscaling.go
+++ b/providers/aws/resources/aws_applicationautoscaling.go
@@ -58,7 +58,7 @@ func (a *mqlAwsApplicationAutoscaling) getTargets(conn *connection.AwsConnection
 	for _, region := range regions {
 		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling aws with region %s", regionVal)
+			log.Debug().Msgf("appautoscaling>getTargets>calling aws with region %s", regionVal)
 
 			svc := conn.ApplicationAutoscaling(regionVal)
 			ctx := context.Background()

--- a/providers/aws/resources/aws_cloudtrail.go
+++ b/providers/aws/resources/aws_cloudtrail.go
@@ -90,7 +90,7 @@ func (a *mqlAwsCloudtrail) getTrails(conn *connection.AwsConnection) []*jobpool.
 	for _, region := range regions {
 		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling aws with region %s", regionVal)
+			log.Debug().Msgf("cloudtrail>getTrails>calling aws with region %s", regionVal)
 
 			svc := conn.Cloudtrail(regionVal)
 			ctx := context.Background()

--- a/providers/aws/resources/aws_cloudwatch.go
+++ b/providers/aws/resources/aws_cloudwatch.go
@@ -582,7 +582,7 @@ func (a *mqlAwsCloudwatch) getLogGroups(conn *connection.AwsConnection) []*jobpo
 	for _, region := range regions {
 		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling aws with region %s", regionVal)
+			log.Debug().Msgf("cloudwatch>getLogGroups>calling aws with region %s", regionVal)
 
 			svc := conn.CloudwatchLogs(regionVal)
 			ctx := context.Background()

--- a/providers/aws/resources/aws_config.go
+++ b/providers/aws/resources/aws_config.go
@@ -46,7 +46,7 @@ func (a *mqlAwsConfig) getRecorders(conn *connection.AwsConnection) []*jobpool.J
 	for _, region := range regions {
 		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling aws with region %s", regionVal)
+			log.Debug().Msgf("config>getRecorders>calling aws with region %s", regionVal)
 
 			svc := conn.ConfigService(regionVal)
 			ctx := context.Background()
@@ -153,7 +153,7 @@ func (a *mqlAwsConfig) getRules(conn *connection.AwsConnection) []*jobpool.Job {
 	for _, region := range regions {
 		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling aws with region %s", regionVal)
+			log.Debug().Msgf("config>getRules>calling aws with region %s", regionVal)
 
 			svc := conn.ConfigService(regionVal)
 			ctx := context.Background()

--- a/providers/aws/resources/aws_dms.go
+++ b/providers/aws/resources/aws_dms.go
@@ -46,7 +46,7 @@ func (a *mqlAwsDms) getReplicationInstances(conn *connection.AwsConnection) []*j
 	for _, region := range regions {
 		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling aws with region %s", regionVal)
+			log.Debug().Msgf("dms>getReplicationInstances>calling aws with region %s", regionVal)
 
 			svc := conn.Dms(regionVal)
 			ctx := context.Background()

--- a/providers/aws/resources/aws_dynamodb.go
+++ b/providers/aws/resources/aws_dynamodb.go
@@ -53,7 +53,7 @@ func (a *mqlAwsDynamodb) getBackups(conn *connection.AwsConnection) []*jobpool.J
 	for _, region := range regions {
 		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling aws with region %s", regionVal)
+			log.Debug().Msgf("dynamodb>getBackups>calling aws with region %s", regionVal)
 
 			svc := conn.Dynamodb(regionVal)
 			ctx := context.Background()
@@ -173,7 +173,7 @@ func (a *mqlAwsDynamodb) getLimits(conn *connection.AwsConnection) []*jobpool.Jo
 	for _, region := range regions {
 		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling aws with region %s", regionVal)
+			log.Debug().Msgf("dynamodb>getLimits>calling aws with region %s", regionVal)
 
 			svc := conn.Dynamodb(regionVal)
 			ctx := context.Background()
@@ -261,7 +261,7 @@ func (a *mqlAwsDynamodb) getTables(conn *connection.AwsConnection) []*jobpool.Jo
 	for _, region := range regions {
 		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling aws with region %s", regionVal)
+			log.Debug().Msgf("dynamodb>getTables>calling aws with region %s", regionVal)
 
 			svc := conn.Dynamodb(regionVal)
 			ctx := context.Background()

--- a/providers/aws/resources/aws_efs.go
+++ b/providers/aws/resources/aws_efs.go
@@ -52,7 +52,7 @@ func (a *mqlAwsEfs) getFilesystems(conn *connection.AwsConnection) []*jobpool.Jo
 	for i := range regions {
 		regionVal := regions[i]
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling aws with region %s", regionVal)
+			log.Debug().Msgf("efs>getFilesystems>calling aws with region %s", regionVal)
 
 			svc := conn.Efs(regionVal)
 			ctx := context.Background()

--- a/providers/aws/resources/aws_eks.go
+++ b/providers/aws/resources/aws_eks.go
@@ -49,7 +49,7 @@ func (a *mqlAwsEks) getClusters(conn *connection.AwsConnection) []*jobpool.Job {
 	for _, region := range regions {
 		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling aws with region %s", regionVal)
+			log.Debug().Msgf("eks>getClusters>calling aws with region %s", regionVal)
 
 			svc := conn.Eks(regionVal)
 			ctx := context.Background()

--- a/providers/aws/resources/aws_elasticache.go
+++ b/providers/aws/resources/aws_elasticache.go
@@ -53,7 +53,7 @@ func (a *mqlAwsElasticache) getClusters(conn *connection.AwsConnection) []*jobpo
 	for _, region := range regions {
 		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling aws with region %s", regionVal)
+			log.Debug().Msgf("elasticache>getClusters>calling aws with region %s", regionVal)
 
 			svc := conn.Elasticache(regionVal)
 			ctx := context.Background()
@@ -123,7 +123,7 @@ func (a *mqlAwsElasticache) getCacheClusters(conn *connection.AwsConnection) []*
 	for _, region := range regions {
 		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling aws with region %s", regionVal)
+			log.Debug().Msgf("elasticache>getCacheClusters>calling aws with region %s", regionVal)
 
 			svc := conn.Elasticache(regionVal)
 			ctx := context.Background()

--- a/providers/aws/resources/aws_kms.go
+++ b/providers/aws/resources/aws_kms.go
@@ -49,7 +49,7 @@ func (a *mqlAwsKms) getKeys(conn *connection.AwsConnection) []*jobpool.Job {
 	for _, region := range regions {
 		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling aws with region %s", regionVal)
+			log.Debug().Msgf("kms>getKeys>calling aws with region %s", regionVal)
 
 			svc := conn.Kms(regionVal)
 			ctx := context.Background()

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -54,7 +54,7 @@ func (a *mqlAwsLambda) getFunctions(conn *connection.AwsConnection) []*jobpool.J
 	for _, region := range regions {
 		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling aws with region %s", regionVal)
+			log.Debug().Msgf("lambda>getFunctions>calling aws with region %s", regionVal)
 
 			svc := conn.Lambda(regionVal)
 			ctx := context.Background()

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -53,7 +53,7 @@ func (a *mqlAwsRds) getDbInstances(conn *connection.AwsConnection) []*jobpool.Jo
 	for _, region := range regions {
 		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling aws with region %s", regionVal)
+			log.Debug().Msgf("rds>getDbInstances>calling aws with region %s", regionVal)
 
 			res := []interface{}{}
 			svc := conn.Rds(regionVal)
@@ -209,7 +209,7 @@ func (a *mqlAwsRds) getDbClusters(conn *connection.AwsConnection) []*jobpool.Job
 	for _, region := range regions {
 		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling aws with region %s", regionVal)
+			log.Debug().Msgf("rds>getDbClusters>calling aws with region %s", regionVal)
 
 			res := []interface{}{}
 			svc := conn.Rds(regionVal)

--- a/providers/aws/resources/aws_redshift.go
+++ b/providers/aws/resources/aws_redshift.go
@@ -58,7 +58,7 @@ func (a *mqlAwsRedshift) getClusters(conn *connection.AwsConnection) []*jobpool.
 	for _, region := range regions {
 		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling aws with region %s", regionVal)
+			log.Debug().Msgf("redshift>getClusters>calling aws with region %s", regionVal)
 
 			svc := conn.Redshift(regionVal)
 			ctx := context.Background()

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -52,7 +52,7 @@ func (a *mqlAws) getVpcs(conn *connection.AwsConnection) []*jobpool.Job {
 	for i := range regions {
 		regionVal := regions[i]
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling aws with region %s", regionVal)
+			log.Debug().Msgf("vpc>getVpcs>calling aws with region %s", regionVal)
 
 			svc := conn.Ec2(regionVal)
 			ctx := context.Background()


### PR DESCRIPTION
 * Improve logging for all AWS client calls. This is useful when debugging to see what API calls are going out to see where the problem might be
 * Make sure we only load an instance's VPC if actually requested, i.e. compute it once needed. To do so, I've added a `vpcArn` field that holds the vpc's ARN and can be used to request it