### PR TITLE
🐛 hot fix for too long upstream scan time

### DIFF
--- a/providers-sdk/v1/plugin/start.go
+++ b/providers-sdk/v1/plugin/start.go
@@ -17,7 +17,18 @@ type Provider struct {
 	ID              string
 	Version         string
 	ConnectionTypes []string
-	Connectors      []Connector
+	// CrossProviderTypes are asset providers that already
+	// have a primary provider set, but which may need to use
+	// resources from a different provider. For example:
+	// The primary provider of an asset may be the "os" provider.
+	// However, it now wants to use resources from the "network" provider.
+	// The "network" provider can indicate that it also supports
+	// assets from the "os" provider.
+	// TODO: This is only a hotfix and will be solved by
+	// each provider creating an asset object when it tries to
+	// call out.
+	CrossProviderTypes []string
+	Connectors         []Connector
 }
 
 type Connector struct {

--- a/providers/network/config/config.go
+++ b/providers/network/config/config.go
@@ -13,6 +13,11 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/cnquery/v9/providers/network",
 	Version:         "9.0.4",
 	ConnectionTypes: []string{provider.ConnectionType},
+	CrossProviderTypes: []string{
+		"go.mondoo.com/cnquery/v9/providers/os",
+		"go.mondoo.com/cnquery/v9/providers/k8s",
+		"go.mondoo.com/cnquery/v9/providers/aws",
+	},
 	Connectors: []plugin.Connector{
 		{
 			Name:      "host",

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -537,6 +537,10 @@ func (r *Runtime) lookupResourceProvider(resource string) (*ConnectedProvider, *
 		return provider, info, nil
 	}
 
+	if info.Provider == "core???"
+	r.coordinator.Providers[info.Provider].Provider.CrossProviderType
+	  does it include r.Provider.Instance.ID
+
 	res, err := r.addProvider(info.Provider, false)
 	if err != nil {
 		return nil, nil, multierr.Wrap(err, "failed to start provider '"+info.Provider+"'")

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -537,9 +537,10 @@ func (r *Runtime) lookupResourceProvider(resource string) (*ConnectedProvider, *
 		return provider, info, nil
 	}
 
-	if info.Provider == "core???"
-	r.coordinator.Providers[info.Provider].Provider.CrossProviderType
-	  does it include r.Provider.Instance.ID
+	providerConn := r.Provider.Instance.ID
+	if info.Provider != providerConn && info.Provider != "go.mondoo.com/cnquery/v9/providers/core" && info.Provider != "go.mondoo.com/cnquery/v9/providers/network" {
+		return nil, nil, errors.New("incorrect provider for asset, not adding")
+	}
 
 	res, err := r.addProvider(info.Provider, false)
 	if err != nil {


### PR DESCRIPTION
i haven't been able to find a good policy with examples of the os + network resources so i didn't do the cross provider types thing yet, im just skipping over the check if its network or core. gonna go find a test example for the network stuff now

```
with this branch, reporting upstream, and all providers installed:
`DEBUG=1 go run apps/cnquery/cnquery.go scan local  2.71s user 1.89s system 39% cpu 11.757 total`
`DEBUG=1 go run apps/cnspec/cnspec.go scan local  4.12s user 3.00s system 42% cpu 16.767 total`
```

im not patient enough to time out the version of this scan on main. i can say its more than 5 minutes for sure.