### PR TITLE
🧹 Allow running microsoft queries from an azure asset

### DIFF
--- a/providers/ms365/connection/auth.go
+++ b/providers/ms365/connection/auth.go
@@ -18,7 +18,10 @@ func getTokenCredential(credential *vault.Credential, tenantId, clientId string)
 	var azCred azcore.TokenCredential
 	var err error
 	if credential == nil {
-		return nil, errors.New("no credentials provided")
+		azCred, err = azidentity.NewAzureCLICredential(&azidentity.AzureCLICredentialOptions{})
+		if err != nil {
+			return nil, errors.Wrap(err, "error creating CLI credentials")
+		}
 	} else {
 		// we only support private key authentication for ms 365
 		switch credential.Type {


### PR DESCRIPTION
Assume we can get no credentials if running just `shell azure`. This also enables `shell ms365 --tenant-id <value>` which makes querying a bit easier