### PR TITLE
🐛 prevent crash on tf plan

### DIFF
--- a/providers/terraform/resources/hcl.go
+++ b/providers/terraform/resources/hcl.go
@@ -84,8 +84,12 @@ func (t *mqlTerraform) modules() ([]interface{}, error) {
 
 func (t *mqlTerraform) blocks() ([]interface{}, error) {
 	conn := t.MqlRuntime.Connection.(*connection.Connection)
-	files := conn.Parser().Files()
+	parser := conn.Parser()
+	if parser == nil {
+		return []interface{}{}, nil
+	}
 
+	files := parser.Files()
 	var mqlHclBlocks []interface{}
 	for k := range files {
 		f := files[k]


### PR DESCRIPTION
When reading a plan file, we do not get all the HCL bits. However, users may still call some of the resources like they would in v8 terms:

```coffee
cnquery> terraform.files
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xc0f420]

goroutine 5 [running]:
github.com/hashicorp/hcl/v2/hclparse.(*Parser).Files(0xc000258718?)
	/home/runner/go/pkg/mod/github.com/hashicorp/hcl/v2@v2.18.1/hclparse/parser.go:137
go.mondoo.com/cnquery/v9/providers/terraform/resources.(*mqlTerraform).files(0xc0001b4600)
	/home/runner/_work/cnquery/cnquery/providers/terraform/resources/hcl.go:39 +0x45
go.mondoo.com/cnquery/v9/providers/terraform/resources.(*mqlTerraform).GetFiles.func1()
...
```

This crash can be prevented by recognizing that the parser is nil.