### PR TITLE
✨ more HTTP security headers

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -34,6 +34,7 @@ mfs
 mgroup
 Mpim
 nodepool
+nosniff
 nullgroup
 opcplc
 Pids
@@ -42,6 +43,7 @@ pushconfig
 querypack
 resourcegroup
 Sas
+SAMEORIGIN
 serviceprincipals
 Snat
 spdx

--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -37,6 +37,14 @@ private http.header @defaults("length=params.length") {
   params map[string][]string
   // Strict-Transport-Security header
   sts() http.header.sts
+  // X-Frame-Options header: DENY, SAMEORIGIN, or ALLOW-FROM origin (obsolete)
+  xFrameOptions() string
+  // X-XSS-Protection header
+  xXssProtection() http.header.xssProtection
+  // X-Content-Type-Options header: nosniff
+  xContentTypeOptions() string
+  // Referrer-Policy header
+  referrerPolicy() string
 }
 
 // HTTP Header for Strict-Transport-Security
@@ -47,6 +55,17 @@ private http.header.sts @defaults("maxAge includeSubDomains preload") {
   includeSubDomains bool
   // Non-standard directive for preloading STS
   preload bool
+}
+
+// HTTP Header for X-XSS-Protection, which is now outdated (replaced by CSP)
+// and may even cause security vulnerabilities
+private http.header.xssProtection @defaults("enabled mode report") {
+  // Enabled when the header value is set to 1. Disabled if set to 0
+  enabled bool
+  // Mode for XSS filtering.
+  mode string
+  // Report endpoint for violations (Chromium only).
+  report string
 }
 
 // URL resource, generally represented as:

--- a/providers/network/resources/network.lr.manifest.yaml
+++ b/providers/network/resources/network.lr.manifest.yaml
@@ -95,7 +95,15 @@ resources:
   http.header:
     fields:
       params: {}
+      referrerPolicy:
+        min_mondoo_version: 9.1.0
       sts: {}
+      xContentTypeOptions:
+        min_mondoo_version: 9.1.0
+      xFrameOptions:
+        min_mondoo_version: 9.1.0
+      xXssProtection:
+        min_mondoo_version: 9.1.0
     is_private: true
     min_mondoo_version: 9.1.0
   http.header.sts:
@@ -103,6 +111,15 @@ resources:
       includeSubDomains: {}
       maxAge: {}
       preload: {}
+    is_private: true
+    min_mondoo_version: 9.1.0
+  http.header.xssProtection:
+    fields:
+      enabled: {}
+      includeSubDomains: {}
+      mode: {}
+      preload: {}
+      report: {}
     is_private: true
     min_mondoo_version: 9.1.0
   openpgp.entities:


### PR DESCRIPTION
After: https://github.com/mondoohq/cnquery/pull/2211

adds:
- X-Frame-Options
- X-XSS-Protection
- X-Content-Type-Options
- Referrer-Policy

```coffee
http.get('https://console.mondoo.com') { version header{ xFrameOptions xXssProtection xContentTypeOptions referrerPolicy }}
```

```coffee
http.get: {
  header: {
    xContentTypeOptions: "nosniff"
    referrerPolicy: "same-origin"
    xFrameOptions: "SAMEORIGIN"
    xXssProtection: http.header.xssProtection enabled=true mode="block" report=null
  }
  version: "2.0"
}
```

... getting closer to CSP

kudos @benr 