### PR TITLE
✨ add CSP header support

### DIFF
--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -50,6 +50,8 @@ private http.header @defaults("length=params.length") {
   contentType() http.header.contentType
   // Set-Cookie header
   setCookie() http.header.setCookie
+  // Content-Security-Policy header
+  csp() map[string]string
 }
 
 // HTTP header for Strict-Transport-Security

--- a/providers/network/resources/network.lr.go
+++ b/providers/network/resources/network.lr.go
@@ -230,6 +230,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"http.header.setCookie": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHttpHeader).GetSetCookie()).ToDataRes(types.Resource("http.header.setCookie"))
 	},
+	"http.header.csp": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHttpHeader).GetCsp()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"http.header.sts.maxAge": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHttpHeaderSts).GetMaxAge()).ToDataRes(types.Time)
 	},
@@ -698,6 +701,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"http.header.setCookie": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHttpHeader).SetCookie, ok = plugin.RawToTValue[*mqlHttpHeaderSetCookie](v.Value, v.Error)
+		return
+	},
+	"http.header.csp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHttpHeader).Csp, ok = plugin.RawToTValue[map[string]interface{}](v.Value, v.Error)
 		return
 	},
 	"http.header.sts.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1506,6 +1513,7 @@ type mqlHttpHeader struct {
 	ReferrerPolicy plugin.TValue[string]
 	ContentType plugin.TValue[*mqlHttpHeaderContentType]
 	SetCookie plugin.TValue[*mqlHttpHeaderSetCookie]
+	Csp plugin.TValue[map[string]interface{}]
 }
 
 // createHttpHeader creates a new instance of this resource
@@ -1628,6 +1636,12 @@ func (c *mqlHttpHeader) GetSetCookie() *plugin.TValue[*mqlHttpHeaderSetCookie] {
 		}
 
 		return c.setCookie()
+	})
+}
+
+func (c *mqlHttpHeader) GetCsp() *plugin.TValue[map[string]interface{}] {
+	return plugin.GetOrCompute[map[string]interface{}](&c.Csp, func() (map[string]interface{}, error) {
+		return c.csp()
 	})
 }
 

--- a/providers/network/resources/network.lr.manifest.yaml
+++ b/providers/network/resources/network.lr.manifest.yaml
@@ -95,20 +95,23 @@ resources:
   http.header:
     fields:
       contentType: {}
+      csp:
+        min_mondoo_version: 9.1.0
       params: {}
       referrerPolicy: {}
-      setCookie:
-        min_mondoo_version: 9.1.0
+      setCookie: {}
       sts: {}
       xContentTypeOptions: {}
       xFrameOptions: {}
       xXssProtection: {}
+    maturity: experimental
     is_private: true
     min_mondoo_version: 9.1.0
   http.header.contentType:
     fields:
       params: {}
       type: {}
+    maturity: experimental
     is_private: true
     min_mondoo_version: 9.1.0
   http.header.setCookie:
@@ -116,6 +119,7 @@ resources:
       name: {}
       params: {}
       value: {}
+    maturity: experimental
     is_private: true
     min_mondoo_version: 9.1.0
   http.header.sts:
@@ -123,6 +127,7 @@ resources:
       includeSubDomains: {}
       maxAge: {}
       preload: {}
+    maturity: experimental
     is_private: true
     min_mondoo_version: 9.1.0
   http.header.xssProtection:
@@ -132,6 +137,7 @@ resources:
       mode: {}
       preload: {}
       report: {}
+    maturity: experimental
     is_private: true
     min_mondoo_version: 9.1.0
   openpgp.entities:


### PR DESCRIPTION
After https://github.com/mondoohq/cnquery/pull/2215

Note: all of these HTTP headers are still experimental for the time being.

I'll likely replace a few types with simpler map implementations. CSP was a good example for this.

```coffee
http.get("https://console.mondoo.com").header.csp
```

```coffee
http.get.header.csp: {
  base-uri: "'self'"
  block-all-mixed-content: ""
  connect-src: "'self' mondoo.com *.mondoo.com *.google-analytics.com *.googleapis.com sentry.io *.doubleclick.net https://heapanalytics.com https://hubspot-forms-static-embed-eu1.s3.amazonaws.com https://forms-eu1.hsforms.com https://mondoo.statuspage.io https://status.mondoo.com https://us.api.mondoo.com"
  font-src: "'self' data: fonts.gstatic.com https://heapanalytics.com"
  form-action: "'self' https://forms-eu1.hsforms.com"
  img-src: "'self' data: www.google-analytics.com www.gstatic.com https://heapanalytics.com *.githubusercontent.com *.googleusercontent.com https://www.googletagmanager.com https://track-eu1.hubspot.com https://forms-eu1.hsforms.com https://translate.google.com"
  media-src: "'self'"
  object-src: "'none'"
  sandbox: "allow-forms allow-downloads allow-scripts allow-popups allow-same-origin"
  script-src: "'self' apis.google.com https://www.google-analytics.com ssl.google-analytics.com https://www.googletagmanager.com https://cdn.heapanalytics.com https://heapanalytics.com https://js-eu1.hsforms.net https://api-eu1.hubspot.com https://forms-eu1.hubspot.com 'unsafe-inline' 'unsafe-eval'"
  style-src: "'self' 'unsafe-inline' fonts.googleapis.com https://heapanalytics.com https://translate.googleapis.com"
}
```

What's a bit annoying with this version, is accessing child elements:

```coffee
csp["base-uri"]
```

instead of something simpler like:

```coffee
csp.baseUri
```