### PR TITLE
🐛 support http.get on host connection

### DIFF
--- a/providers/network/resources/http.go
+++ b/providers/network/resources/http.go
@@ -16,6 +16,7 @@ import (
 	"go.mondoo.com/cnquery/v9/checksums"
 	"go.mondoo.com/cnquery/v9/llx"
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/plugin"
+	"go.mondoo.com/cnquery/v9/providers/network/connection"
 	"go.mondoo.com/cnquery/v9/types"
 	"go.mondoo.com/cnquery/v9/utils/sortx"
 )
@@ -47,6 +48,30 @@ func initHttpGet(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 		delete(args, "rawUrl")
 		args["url"] = llx.ResourceData(url, "url")
 	}
+
+	if _, ok := args["url"]; !ok {
+		conn := runtime.Connection.(*connection.HostConnection)
+		if conn.Conf == nil {
+			return nil, nil, errors.New("missing ")
+		}
+
+		// FIXME: pure workaround to get this working, but we need to retain the scheme on parsing!
+		scheme := "http"
+		if conn.Conf.Port == 443 {
+			scheme = "https"
+		}
+
+		url, err := NewResource(runtime, "url", map[string]*llx.RawData{
+			"host":   llx.StringData(conn.Conf.Host),
+			"port":   llx.IntData(int64(conn.Conf.Port)),
+			"scheme": llx.StringData(scheme),
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		args["url"] = llx.ResourceData(url, "url")
+	}
+
 	return args, nil, nil
 }
 
@@ -60,6 +85,10 @@ func (x *mqlHttpGet) do() error {
 
 	if x.resp.State&plugin.StateIsSet != 0 {
 		return x.resp.Error
+	}
+
+	if x.Url.Data == nil {
+		return errors.New("missing URL for http.get")
 	}
 
 	resp, err := http.Get(x.Url.Data.String.Data)

--- a/providers/network/resources/http.go
+++ b/providers/network/resources/http.go
@@ -52,7 +52,7 @@ func initHttpGet(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 	if _, ok := args["url"]; !ok {
 		conn := runtime.Connection.(*connection.HostConnection)
 		if conn.Conf == nil {
-			return nil, nil, errors.New("missing ")
+			return nil, nil, errors.New("missing URL for http.get")
 		}
 
 		// FIXME: pure workaround to get this working, but we need to retain the scheme on parsing!

--- a/providers/network/resources/network.lr.manifest.yaml
+++ b/providers/network/resources/network.lr.manifest.yaml
@@ -95,8 +95,7 @@ resources:
   http.header:
     fields:
       contentType: {}
-      csp:
-        min_mondoo_version: 9.1.0
+      csp: {}
       params: {}
       referrerPolicy: {}
       setCookie: {}
@@ -104,31 +103,31 @@ resources:
       xContentTypeOptions: {}
       xFrameOptions: {}
       xXssProtection: {}
-    maturity: experimental
     is_private: true
+    maturity: experimental
     min_mondoo_version: 9.1.0
   http.header.contentType:
     fields:
       params: {}
       type: {}
-    maturity: experimental
     is_private: true
+    maturity: experimental
     min_mondoo_version: 9.1.0
   http.header.setCookie:
     fields:
       name: {}
       params: {}
       value: {}
-    maturity: experimental
     is_private: true
+    maturity: experimental
     min_mondoo_version: 9.1.0
   http.header.sts:
     fields:
       includeSubDomains: {}
       maxAge: {}
       preload: {}
-    maturity: experimental
     is_private: true
+    maturity: experimental
     min_mondoo_version: 9.1.0
   http.header.xssProtection:
     fields:
@@ -137,8 +136,8 @@ resources:
       mode: {}
       preload: {}
       report: {}
-    maturity: experimental
     is_private: true
+    maturity: experimental
     min_mondoo_version: 9.1.0
   openpgp.entities:
     fields:


### PR DESCRIPTION
After https://github.com/mondoohq/cnquery/pull/2213
yeah i'm chaining a few...

i.e.:

```bash
> cnquery shell host console.mondoo.com
```

Then:

```coffee
http.get { version header url }
```

```coffee
http.get: {
  header: http.header
  url: url string="http://console.mondoo.com:80"
  version: "2.0"
}
```

@scottford-io this fixes one of the problems you raised in https://github.com/mondoohq/cnquery/pull/2213#issuecomment-1763188304
