### PR TITLE
🐛 support chaining of null resources

### DIFF
--- a/llx/builtin.go
+++ b/llx/builtin.go
@@ -724,6 +724,13 @@ func validateBuiltinFunctionsV2() {
 }
 
 func runResourceFunction(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
+	if bind.Value == nil {
+		e.cache.Store(ref, &stepCache{
+			Result: NilData,
+		})
+		return NilData, 0, nil
+	}
+
 	rr, ok := bind.Value.(Resource)
 	if !ok {
 		// TODO: can we get rid of this fmt call

--- a/mql/mql_test.go
+++ b/mql/mql_test.go
@@ -170,6 +170,11 @@ func TestNullResources(t *testing.T) {
 			Expectation: nil,
 		},
 		{
+			Code:        "muser.nullgroup.name",
+			ResultIndex: 0,
+			Expectation: nil,
+		},
+		{
 			Code:        "muser.nullgroup == null",
 			ResultIndex: 1,
 			Expectation: true,


### PR DESCRIPTION
We have fairly consisten null-chaining already:

```coffee
cnquery> parse.json("dummy.json").params.nothere
parse.json.params.nothere: null

cnquery> parse.json("dummy.json").params.nothere + 1
parse.json.params.nothere.+: null

cnquery> parse.json("dummy.json").params.nothere.field == empty
[ok] value: _
```

However, it turns out we didn't correctly chain resources:

```coffee
cnquery> http.get.header.setCookie
http.get.header.setCookie: null

cnquery> http.get.header.setCookie.name
cannot cast resource to resource type: <nil>
```

This PR fixes the behavior to be more in line with null-chaining:

```coffee
cnquery> http.get.header.setCookie
http.get.header.setCookie: null

cnquery> http.get.header.setCookie.name
http.get.header.setCookie.name: null

cnquery> http.get.header.setCookie { name }
http.get.header.setCookie: null
```