### PR TITLE
✨ retain host scheme in network provider

### DIFF
--- a/providers/network/provider/provider.go
+++ b/providers/network/provider/provider.go
@@ -76,6 +76,7 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 			Port:     int32(port),
 			Host:     host,
 			Path:     url.Path,
+			Runtime:  url.Scheme,
 			Insecure: insecure,
 		}},
 	}

--- a/providers/network/resources/http.go
+++ b/providers/network/resources/http.go
@@ -55,10 +55,16 @@ func initHttpGet(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 			return nil, nil, errors.New("missing URL for http.get")
 		}
 
-		// FIXME: pure workaround to get this working, but we need to retain the scheme on parsing!
-		scheme := "http"
-		if conn.Conf.Port == 443 {
-			scheme = "https"
+		scheme := conn.Conf.Runtime
+		if scheme == "" {
+			// At this point we are in best effort territory. Which means we will
+			// go HTTP unless port 443 is specified. Users can always provide a
+			// scheme to be prescriptive.
+			if conn.Conf.Port == 443 {
+				scheme = "https"
+			} else {
+				scheme = "http"
+			}
 		}
 
 		url, err := NewResource(runtime, "url", map[string]*llx.RawData{


### PR DESCRIPTION
After https://github.com/mondoohq/cnquery/pull/2220

The network provider had a small workaround for schemes to guess if we
were dealing with HTTP or HTTPS. However, this is not safe to use
outside of the two standard ports (80=http, 443=https).

I noticed that the `Runtime` field was unused for network connections.
This change uses this field to retain the "runtime of the network
connection". Users can choose to specify or not specify it. The host
provider works perfectly well without specifying it of course.

Examples:

```coffee
> cnquery run host mondoo.com -c "http.get { statusCode version url }"
http.get: {
  statusCode: 200
  url: url string="http://mondoo.com:80"
  version: "2.0"
}
```

With scheme, default ports are guessed:

```coffee
> cnquery run host https://mondoo.com -c "http.get { statusCode version url }"
http.get: {
  statusCode: 200
  url: url string="https://mondoo.com:443"
  version: "2.0"
}
```

And the effect of using a scheme with the wrong port:

```coffee
> cnquery run host https://mondoo.com:80 -c "http.get { statusCode version url }"
1 error occurred:
        * Get "https://mondoo.com:80": http: server gave HTTP response to HTTPS client
```
