### PR TITLE
🐛 fix platform bits for GCP that were missing

### DIFF
--- a/providers/gcp/connection/platform.go
+++ b/providers/gcp/connection/platform.go
@@ -51,38 +51,38 @@ func (c *GcpConnection) PlatformInfo() (*inventory.Platform, error) {
 	// TODO: this is a hack and we need to find a better way to do this
 	if c.platformOverride != "" && c.platformOverride != "gcp" {
 		return &inventory.Platform{
-			Name:   c.platformOverride,
-			Title:  getTitleForPlatformName(c.platformOverride),
-			Family: []string{"google"},
-			// Kind:    providers.Kind_KIND_GCP_OBJECT,
-			// Runtime: providers.RUNTIME_GCP,
+			Name:    c.platformOverride,
+			Title:   getTitleForPlatformName(c.platformOverride),
+			Family:  []string{"google"},
+			Kind:    "gcp-object",
+			Runtime: "gcp",
 		}, nil
 	}
 
 	switch c.resourceType {
 	case Organization:
 		return &inventory.Platform{
-			Name:   "gcp-org",
-			Title:  "GCP Organization",
-			Family: []string{"google"},
-			// Kind:    providers.Kind_KIND_GCP_OBJECT,
-			// Runtime: p.Runtime(),
+			Name:    "gcp-org",
+			Title:   "GCP Organization",
+			Family:  []string{"google"},
+			Kind:    "gcp-object",
+			Runtime: "gcp",
 		}, nil
 	case Project:
 		return &inventory.Platform{
-			Name:   "gcp-project",
-			Title:  "GCP Project",
-			Family: []string{"google"},
-			// Kind:    providers.Kind_KIND_GCP_OBJECT,
-			// Runtime: p.Runtime(),
+			Name:    "gcp-project",
+			Title:   "GCP Project",
+			Family:  []string{"google"},
+			Kind:    "gcp-object",
+			Runtime: "gcp",
 		}, nil
 	case Folder:
 		return &inventory.Platform{
-			Name:   "gcp-folder",
-			Title:  "GCP Folder",
-			Family: []string{"google"},
-			// Kind:    providers.Kind_KIND_GCP_OBJECT,
-			// Runtime: p.Runtime(),
+			Name:    "gcp-folder",
+			Title:   "GCP Folder",
+			Family:  []string{"google"},
+			Kind:    "gcp-object",
+			Runtime: "gcp",
 		}, nil
 	}
 

--- a/providers/gcp/provider/provider.go
+++ b/providers/gcp/provider/provider.go
@@ -203,16 +203,10 @@ func (s *Service) Connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 		return nil, err
 	}
 
-	// We only need to run the detection step when we don't have any asset information yet.
-	if req.Asset.Platform == nil {
-		if err := s.detect(req.Asset, conn); err != nil {
-			return nil, err
-		}
-	}
-
 	var inventory *inventory.Inventory
 	// discovery assets for further scanning
 	if conn.Config().Discover != nil {
+		// detection of the platform is done in the discovery phase
 		inventory, err = s.discover(conn)
 		if err != nil {
 			return nil, err
@@ -271,25 +265,6 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	}
 
 	return conn, err
-}
-
-func (s *Service) detect(asset *inventory.Asset, conn shared.GcpConnection) error {
-	asset.Name = conn.Config().Host
-
-	// TODO: integrate the PlatformInfo() of the GCP connection or merge it with this!
-
-	switch conn.Config().Type {
-	default:
-		asset.Platform = &inventory.Platform{
-			Name:   "gcp",
-			Family: []string{"gcp"},
-			Kind:   "api",
-			Title:  "GCP Cloud",
-		}
-		asset.PlatformIds = []string{"//platformid.api.mondoo.app/runtime/gcp/"}
-	}
-
-	return nil
 }
 
 func (s *Service) discover(conn shared.GcpConnection) (*inventory.Inventory, error) {

--- a/providers/gcp/provider/provider.go
+++ b/providers/gcp/provider/provider.go
@@ -276,6 +276,8 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 func (s *Service) detect(asset *inventory.Asset, conn shared.GcpConnection) error {
 	asset.Name = conn.Config().Host
 
+	// TODO: integrate the PlatformInfo() of the GCP connection or merge it with this!
+
 	switch conn.Config().Type {
 	default:
 		asset.Platform = &inventory.Platform{


### PR DESCRIPTION
2 important notes:

1. PlatformInfo is currently not used. Give the it the aws provider treatment and
2. Are we setting good platform IDs?

I only see this in provider.go:

```go
asset.PlatformIds = []string{"//platformid.api.mondoo.app/runtime/gcp/"}
```