### PR TITLE
✨ ensure that the core provider overrides

### DIFF
--- a/providers/extensible_schema.go
+++ b/providers/extensible_schema.go
@@ -40,11 +40,25 @@ func (x *extensibleSchema) loadAllSchemas() {
 	}
 
 	for name := range providers {
+		if name == BuiltinCoreID {
+			continue
+		}
 		schema, err := x.runtime.coordinator.LoadSchema(name)
 		if err != nil {
 			log.Error().Err(err).Msg("load schema failed")
 		} else {
 			x.Add(name, schema)
+		}
+	}
+
+	// We are loading the core provider last, so it overrides all other schemas.
+	// It will ensure that core fields are preferred.
+	if _, ok := providers[BuiltinCoreID]; ok {
+		schema, err := x.runtime.coordinator.LoadSchema(BuiltinCoreID)
+		if err != nil {
+			log.Error().Err(err).Msg("load schema failed")
+		} else {
+			x.Add(BuiltinCoreID, schema)
 		}
 	}
 }


### PR DESCRIPTION
The core provider is the only special provider in our current list, treated with higher priority.

We are looking to be more explicit about the order in which providers are added and how things are getting merged together. Until we get there, we can force core to at least not be overwritten by another provider.