### PR TITLE
✨ indicate auto-expanded MQL fields in --info

### DIFF
--- a/cli/printer/mql.go
+++ b/cli/printer/mql.go
@@ -748,7 +748,7 @@ func (print *Printer) DataWithLabel(r *llx.RawData, codeID string, bundle *llx.C
 	return b.String()
 }
 
-func (print *Printer) CompilerStats(stats *mqlc.CompilerStats) string {
+func (print *Printer) CompilerStats(stats mqlc.CompilerStats) string {
 	var res strings.Builder
 	res.WriteString("Resources and Fields used:\n")
 
@@ -757,7 +757,13 @@ func (print *Printer) CompilerStats(stats *mqlc.CompilerStats) string {
 			res.WriteString("- " + print.Yellow(resource) + "\n")
 			return
 		}
-		res.WriteString("  - " + print.Primary(field) + "  type=" + info.Type.Label() + "\n")
+
+		autoexpand := ""
+		if info.AutoExpand {
+			autoexpand = print.Disabled(" [auto-expand]")
+		}
+
+		res.WriteString("  - " + print.Primary(field) + "  type=" + info.Type.Label() + autoexpand + "\n")
 	})
 
 	return res.String()


### PR DESCRIPTION
After https://github.com/mondoohq/cnquery/pull/2290

```bash
cnquery run aws -c 'aws.vpcs.all(flowLogs.any(status == "ACTIVE"))' --info
```

![image](https://github.com/mondoohq/cnquery/assets/1307529/5e4cb5cf-6709-4896-aa74-253f318534c0)

(sorry Tim i really wanted the colors here :grin: )