### PR TITLE
⭐ schema-only provider support

### DIFF
--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -215,8 +215,8 @@ func (c *coordinator) tryProviderUpdate(provider *Provider, update UpdateProvide
 		return nil, errors.New("cannot determine installation path for provider")
 	}
 
-	binPath := provider.binPath()
-	stat, err := os.Stat(binPath)
+	statPath := provider.confJSONPath()
+	stat, err := os.Stat(statPath)
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +261,7 @@ func (c *coordinator) tryProviderUpdate(provider *Provider, update UpdateProvide
 	}
 	PrintInstallResults([]*Provider{provider})
 	now := time.Now()
-	if err := os.Chtimes(binPath, now, now); err != nil {
+	if err := os.Chtimes(statPath, now, now); err != nil {
 		log.Warn().
 			Str("provider", provider.Name).
 			Msg("failed to update refresh time on provider")


### PR DESCRIPTION
Support loading providers without the binary. This is useful in some isolated environments and embedded scenarios, where users may want to use MQL capabilities like compiling/linting, without having or executing the plugin binaries.

This is not something users of cnquery/cnspec will generally use, but it is super useful for embedded and very specialized use-cases. Example:

![image](https://github.com/mondoohq/cnquery/assets/1307529/bd79f64c-4bff-471b-8575-d7d83d5b6507)
