### PR TITLE
🐛 fix atlassian scim

### DIFF
--- a/providers/atlassian/connection/scim/connection.go
+++ b/providers/atlassian/connection/scim/connection.go
@@ -32,7 +32,7 @@ func NewConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*
 		token = os.Getenv("ATLASSIAN_SCIM_TOKEN")
 	}
 	if token == "" {
-		return nil, errors.New("you need to provide atlassian scim token via ATLASSIAN_SCIM_TOKEN env or via --admin-token flag")
+		return nil, errors.New("you need to provide atlassian scim token via ATLASSIAN_SCIM_TOKEN env or via --scim-token flag")
 	}
 
 	if conf.Options["directory-id"] == "" {

--- a/providers/atlassian/resources/atlassian.lr
+++ b/providers/atlassian/resources/atlassian.lr
@@ -4,9 +4,9 @@ option go_package = "go.mondoo.com/cnquery/providers/atlassian/resources"
 // Cross-domain Identity Management (SCIM)
 atlassian.scim {
   // SCIM users
-  users() []atlassian.scim.organization.scim.user
+  users() []atlassian.scim.user
   // SCIM groups
-  groups() []atlassian.scim.organization.scim.group
+  groups() []atlassian.scim.group
 }
 
 // SCIM user

--- a/providers/atlassian/resources/atlassian.lr.go
+++ b/providers/atlassian/resources/atlassian.lr.go
@@ -154,10 +154,10 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"atlassian.scim.users": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAtlassianScim).GetUsers()).ToDataRes(types.Array(types.Resource("atlassian.scim.organization.scim.user")))
+		return (r.(*mqlAtlassianScim).GetUsers()).ToDataRes(types.Array(types.Resource("atlassian.scim.user")))
 	},
 	"atlassian.scim.groups": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAtlassianScim).GetGroups()).ToDataRes(types.Array(types.Resource("atlassian.scim.organization.scim.group")))
+		return (r.(*mqlAtlassianScim).GetGroups()).ToDataRes(types.Array(types.Resource("atlassian.scim.group")))
 	},
 	"atlassian.scim.user.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAtlassianScimUser).GetId()).ToDataRes(types.String)

--- a/providers/atlassian/resources/atlassian_scim.go
+++ b/providers/atlassian/resources/atlassian_scim.go
@@ -28,7 +28,7 @@ func (a *mqlAtlassianScim) users() ([]interface{}, error) {
 	}
 	res := []interface{}{}
 	for _, scimUser := range scimUsers.Resources {
-		mqlAtlassianAdminSCIMuser, err := CreateResource(a.MqlRuntime, "atlassian.scim.organization.scim.user",
+		mqlAtlassianAdminSCIMuser, err := CreateResource(a.MqlRuntime, "atlassian.scim.user",
 			map[string]*llx.RawData{
 				"id":           llx.StringData(scimUser.ID),
 				"name":         llx.StringData(scimUser.Name.Formatted),
@@ -57,7 +57,7 @@ func (a *mqlAtlassianScim) groups() ([]interface{}, error) {
 	}
 	res := []interface{}{}
 	for _, scimGroup := range scimGroup.Resources {
-		mqlAtlassianAdminSCIMgroup, err := CreateResource(a.MqlRuntime, "atlassian.scim.organization.scim.group",
+		mqlAtlassianAdminSCIMgroup, err := CreateResource(a.MqlRuntime, "atlassian.scim.group",
 			map[string]*llx.RawData{
 				"id":   llx.StringData(scimGroup.ID),
 				"name": llx.StringData(scimGroup.DisplayName),


### PR DESCRIPTION
Before
```
cnquery> atlassian.scim.users
cannot find resource atlassian.scim.organization.scim.user in this provider
atlassian.scim.users: null
```

After
```
cnquery> atlassian.scim.users
atlassian.scim.users: [
  0: atlassian.scim.user displayName="Test User"
  1: atlassian.scim.user displayName="Usr Two"
  2: atlassian.scim.user displayName="Marius K"
  3: atlassian.scim.user displayName="Ben R"
]
```