### PR TITLE
🐛 provider installation should refresh schema

### DIFF
--- a/providers/providers.go
+++ b/providers/providers.go
@@ -34,6 +34,11 @@ var (
 	// CachedProviders contains all providers that have been loaded the last time
 	// ListActive or ListAll have been called
 	CachedProviders []*Provider
+	// LastProviderInstall keeps track of when the last provider installation
+	// took place relative to this runtime. This means:
+	// - 0 = no provider was installed during this run
+	// - unix time seconds = time of last install during this run
+	LastProviderInstall int64
 )
 
 func init() {
@@ -277,6 +282,7 @@ func installVersion(name string, version string) (*Provider, error) {
 	// we need to clear out the cache now, because we installed something new,
 	// otherwise it will load old data
 	CachedProviders = nil
+	LastProviderInstall = time.Now().Unix()
 
 	return installed[0], nil
 }

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -35,9 +35,8 @@ var (
 	// ListActive or ListAll have been called
 	CachedProviders []*Provider
 	// LastProviderInstall keeps track of when the last provider installation
-	// took place relative to this runtime. This means:
-	// - 0 = no provider was installed during this run
-	// - unix time seconds = time of last install during this run
+	// took place relative to this runtime. It is initialized to a non-zero
+	// timestamp during this file's init() method. Timestamps are unix seconds.
 	LastProviderInstall int64
 )
 
@@ -48,6 +47,8 @@ func init() {
 		HomePath, _ = config.HomePath("providers")
 		DefaultPath = HomePath
 	}
+
+	LastProviderInstall = time.Now().Unix()
 }
 
 type Providers map[string]*Provider

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -279,11 +279,6 @@ func installVersion(name string, version string) (*Provider, error) {
 		return nil, errors.New("version for provider didn't match expected install version: expected " + version + ", installed: " + installed[0].Version)
 	}
 
-	// we need to clear out the cache now, because we installed something new,
-	// otherwise it will load old data
-	CachedProviders = nil
-	LastProviderInstall = time.Now().Unix()
-
 	return installed[0], nil
 }
 
@@ -473,6 +468,11 @@ func InstallIO(reader io.ReadCloser, conf InstallConf) ([]*Provider, error) {
 
 		res = append(res, provider)
 	}
+
+	// we need to clear out the cache now, because we installed something new,
+	// otherwise it will load old data
+	CachedProviders = nil
+	LastProviderInstall = time.Now().Unix()
 
 	return res, nil
 }

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -5,6 +5,7 @@ package providers
 
 import (
 	"errors"
+	"math"
 	"sync"
 	"time"
 
@@ -96,7 +97,9 @@ func (r *Runtime) Close() {
 }
 
 func (r *Runtime) DeactivateProviderDiscovery() {
-	r.schema.allLoaded = true
+	// Setting this to the max int means this value will always be larger than
+	// any real timestamp for the last installation time of a provider.
+	r.schema.lastRefreshed = math.MaxInt64
 }
 
 func (r *Runtime) AssetMRN() string {


### PR DESCRIPTION
Extensible schemas are used to go across multiple providers and aggregate a schema. We use them extensively, in order to load all available resources and fields. However, if a new provider is installed after a schema has been fully loaded, it won't show up, because the schema doesn't know it has to refresh.

This is now fixed. We keep track of the last time a provider was installed to the system. Whenever that happens, a timestamp is updated. Each extensible schema keeps track of this timestamp. If it changes, the schema gets refreshed.