### PR TITLE
🔧 expand EnsureProvider to cover IDs

### DIFF
--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -36,7 +36,7 @@ func AttachCLIs(rootCmd *cobra.Command, commands ...*Command) error {
 
 	connectorName, autoUpdate := detectConnectorName(os.Args, rootCmd, commands, existing)
 	if connectorName != "" {
-		if _, err := providers.EnsureProvider(connectorName, "", autoUpdate, existing); err != nil {
+		if _, err := providers.EnsureProvider(providers.ProviderLookup{ConnName: connectorName}, autoUpdate, existing); err != nil {
 			return err
 		}
 	}

--- a/cli/sysinfo/sysinfo.go
+++ b/cli/sysinfo/sysinfo.go
@@ -52,7 +52,7 @@ func GatherSystemInfo(opts ...SystemInfoOption) (*SystemInfo, error) {
 		cfg.runtime = providers.Coordinator.NewRuntime()
 
 		// init runtime
-		if _, err := providers.EnsureProvider("local", "", true, nil); err != nil {
+		if _, err := providers.EnsureProvider(providers.ProviderLookup{ConnName: "local"}, true, nil); err != nil {
 			return nil, err
 		}
 		if err := cfg.runtime.UseProvider(providers.DefaultOsID); err != nil {

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -179,7 +179,7 @@ func (r *Runtime) DetectProvider(asset *inventory.Asset) error {
 			conn.Type = inventory.ConnBackendToType(conn.Backend)
 		}
 
-		provider, err := EnsureProvider("", conn.Type, true, r.coordinator.Providers)
+		provider, err := EnsureProvider(ProviderLookup{ConnType: conn.Type}, true, r.coordinator.Providers)
 		if err != nil {
 			errs.Add(err)
 			continue


### PR DESCRIPTION
After: https://github.com/mondoohq/cnquery/pull/2305

Refactor the whole EnsureProvider flow so users can specify providers
via ID, connector name and connector type. All of them are useful:

1. Install provider from Defaults => just specify the ID
2. Install provider from CLI args (like "local") => just specify name
3. Install provider from connection type => doh
