### PR TITLE
✨ Rename recording to AssetRecording, allow overwriting of asset.

### DIFF
--- a/providers/os/resources/python_test.go
+++ b/providers/os/resources/python_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestResource_Python(t *testing.T) {
-	x := testutils.InitTester(testutils.RecordingMock("./python/testdata/linux.json"))
+	x := testutils.InitTester(testutils.MockFromPath("./python/testdata/linux.json"))
 
 	t.Run("parse all packages", func(t *testing.T) {
 		res := x.TestQuery(t, "python.packages")
@@ -34,7 +34,7 @@ func TestResource_Python(t *testing.T) {
 }
 
 func TestResource_PythonPackage(t *testing.T) {
-	x := testutils.InitTester(testutils.RecordingMock("./python/testdata/python-package.json"))
+	x := testutils.InitTester(testutils.MockFromPath("./python/testdata/python-package.json"))
 
 	t.Run("parse single package", func(t *testing.T) {
 		res := x.TestQuery(t, "python.package(\"/usr/lib/python3/dist-packages/python_ftp_server-1.3.17.dist-info/METADATA\").name")

--- a/providers/recording.go
+++ b/providers/recording.go
@@ -56,16 +56,15 @@ func (r *AssetRecording) SetAsset(asset *inventory.Asset) error {
 		ai.Runtime = asset.Platform.Runtime
 		ai.Labels = asset.Platform.Labels
 	}
-	if r.Assets == nil {
-		r.Assets = []assetRecording{}
-	}
 	if len(r.Assets) == 0 {
-		r.Assets[0] = assetRecording{
-			Asset:       ai,
-			connections: map[string]*connectionRecording{},
-			resources:   map[string]*resourceRecording{},
-			Connections: []connectionRecording{},
-			Resources:   []resourceRecording{},
+		r.Assets = []assetRecording{
+			{
+				Asset:       ai,
+				connections: map[string]*connectionRecording{},
+				resources:   map[string]*resourceRecording{},
+				Connections: []connectionRecording{},
+				Resources:   []resourceRecording{},
+			},
 		}
 	} else {
 		// we want to only overwrite the asset info. some tests use mock policies/queries where there are filters

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -459,13 +459,13 @@ func (r *Runtime) SetRecording(recording Recording) error {
 	return nil
 }
 
-func baseRecording(anyRecording Recording) *recording {
-	var baseRecording *recording
+func baseRecording(anyRecording Recording) *AssetRecording {
+	var baseRecording *AssetRecording
 	switch x := anyRecording.(type) {
-	case *recording:
+	case *AssetRecording:
 		baseRecording = x
 	case *readOnlyRecording:
-		baseRecording = x.recording
+		baseRecording = x.AssetRecording
 	}
 	return baseRecording
 }


### PR DESCRIPTION
We already have predefined recordings, which are great, but they cannot be modified in any way. 

For example, assume there's a test that has a policy with a filter that looks like `asset.name == 'my-test'`. We could load a recording and all we'd need to do is change the asset's name to match that policy and start asserting against it.

This PR exposes the internal `recording` by renaming it to `AssetRecording`. It also exposes a few more functions in the test utils to return just the recording, not the runtime. This allows for something like
```
myAsset := &inventory.Asset{Name: "my-test"}
recording := testutils.LinuxAssetRecording()
recording.SetAsset(myAsset)
runtime := testutils.MockFromRecording(recording)
```

