### PR TITLE
🐛 Change data conversion to allow for nil resources. Fix azure monitor as an example

### DIFF
--- a/providers-sdk/v1/plugin/runtime.go
+++ b/providers-sdk/v1/plugin/runtime.go
@@ -239,13 +239,12 @@ func GetOrCompute[T any](cached *TValue[T], compute func() (T, error)) *TValue[T
 
 	x, err := compute()
 	if err != nil {
-		res := &TValue[T]{State: StateIsSet}
+		// why do we always set to IsNull here?
+		res := &TValue[T]{State: StateIsSet | StateIsNull}
 		// Note: if we're getting back a NotReady error, it means the computed
 		// resource is not present and we should return nil.
 		// To avoid panics down the stack, we only set the data and err if it's anything other than a NotReady error
-		if err == NotReady {
-			res.State |= StateIsNull
-		} else {
+		if err != NotReady {
 			res.Data = x
 			res.Error = err
 		}

--- a/providers/azure/resources/monitor.go
+++ b/providers/azure/resources/monitor.go
@@ -5,7 +5,6 @@ package resources
 
 import (
 	"context"
-	"errors"
 
 	"go.mondoo.com/cnquery/v9/llx"
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/plugin"
@@ -268,28 +267,28 @@ func (a *mqlAzureSubscriptionMonitorServiceActivityLog) alerts() ([]interface{},
 
 func (a *mqlAzureSubscriptionMonitorServiceLogprofile) storageAccount() (*mqlAzureSubscriptionStorageServiceAccount, error) {
 	if a.StorageAccountId.IsNull() {
-		return nil, errors.New("diagnostic settings has no storage account")
+		return nil, plugin.NotReady
 	}
 	if a.StorageAccountId.Error != nil {
 		return nil, a.StorageAccountId.Error
 	}
 	storageAccId := a.StorageAccountId.Data
 	if storageAccId == "" {
-		return nil, errors.New("diagnostic settings has no storage account")
+		return nil, plugin.NotReady
 	}
 	return getStorageAccount(storageAccId, a.MqlRuntime, a.MqlRuntime.Connection.(*connection.AzureConnection))
 }
 
 func (a *mqlAzureSubscriptionMonitorServiceDiagnosticsetting) storageAccount() (*mqlAzureSubscriptionStorageServiceAccount, error) {
 	if a.StorageAccountId.IsNull() {
-		return nil, errors.New("diagnostic settings has no storage account")
+		return nil, plugin.NotReady
 	}
 	if a.StorageAccountId.Error != nil {
 		return nil, a.StorageAccountId.Error
 	}
 	storageAccId := a.StorageAccountId.Data
 	if storageAccId == "" {
-		return nil, errors.New("diagnostic settings has no storage account")
+		return nil, plugin.NotReady
 	}
 	return getStorageAccount(storageAccId, a.MqlRuntime, a.MqlRuntime.Connection.(*connection.AzureConnection))
 }


### PR DESCRIPTION
Some of the resources we try to fetch may not be present, consider this as an example:
```

// Azure Monitor Diagnostic Setting
private azure.subscription.monitorService.diagnosticsetting @defaults("id name") {
  .....
  // Diagnostic setting storage account
  storageAccount() azure.subscription.storageService.account
}
```

When computing the storage account it is totally possible that this resource is not present. Until now, trying to return a nil resource resulted in a panic which was fixed by returning an error, something like
```
return nil, errors.New("storage account not present for the diagnostic setting resource")
```
which led to
```
cnquery> azure.subscription.monitor.diagnosticSettings{storageAccount}
1 error occurred:
        * diagnostic settings has no storage account
azure.subscription.monitor.diagnosticSettings: [
  0: {
    storageAccount: diagnostic settings has no storage account
  }
]
```

The problem with this is that there's not really an error, it's just that the storage account isn't present.

To fix this, I saw that we have a `plugin.NotReady` error which seemed like a good indicator of this use case. This now results in
```
cnquery> azure.subscription.monitor.diagnosticSettings{storageAccount}
azure.subscription.monitor.diagnosticSettings: [
  0: {
    storageAccount: null
  }
]
```

which will allow for better assertions

Chaining on null resources remains functional:
```
cnquery> azure.subscription.monitor.diagnosticSettings{storageAccount.id}
azure.subscription.monitor.diagnosticSettings: [
  0: {
    storageAccount.id: null
  }
]
```