### PR TITLE
✨ Allow creating of a recording from just a single asset.

### DIFF
--- a/providers-sdk/v1/testutils/testutils.go
+++ b/providers-sdk/v1/testutils/testutils.go
@@ -267,7 +267,7 @@ func mockRuntimeAbs(testdata string) llx.Runtime {
 func RecordingFromAsset(a *inventory.Asset) providers.Recording {
 	recording, err := providers.FromAsset(a)
 	if err != nil {
-		panic("failed to load recording: " + err.Error())
+		panic("failed to create recording from an asset: " + err.Error())
 	}
 	roRecording := recording.ReadOnly()
 

--- a/providers-sdk/v1/testutils/testutils.go
+++ b/providers-sdk/v1/testutils/testutils.go
@@ -22,6 +22,7 @@ import (
 	"go.mondoo.com/cnquery/v9/mql"
 	"go.mondoo.com/cnquery/v9/mqlc"
 	"go.mondoo.com/cnquery/v9/providers"
+	"go.mondoo.com/cnquery/v9/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/lr"
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/lr/docs"
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/resources"
@@ -233,9 +234,26 @@ func mockRuntime(testdata string) llx.Runtime {
 	return mockRuntimeAbs(filepath.Join(TestutilsDir, testdata))
 }
 
-func mockRuntimeAbs(testdata string) llx.Runtime {
+func MockFromRecording(recording providers.Recording) llx.Runtime {
 	runtime := Local().(*providers.Runtime)
 
+	err := runtime.SetMockRecording(recording, runtime.Provider.Instance.ID, true)
+	if err != nil {
+		panic("failed to set recording: " + err.Error())
+	}
+	err = runtime.SetMockRecording(recording, networkconf.Config.ID, true)
+	if err != nil {
+		panic("failed to set recording: " + err.Error())
+	}
+	err = runtime.SetMockRecording(recording, mockprovider.Config.ID, true)
+	if err != nil {
+		panic("failed to set recording: " + err.Error())
+	}
+
+	return runtime
+}
+
+func mockRuntimeAbs(testdata string) llx.Runtime {
 	abs, _ := filepath.Abs(testdata)
 	recording, err := providers.LoadRecordingFile(abs)
 	if err != nil {
@@ -243,20 +261,17 @@ func mockRuntimeAbs(testdata string) llx.Runtime {
 	}
 	roRecording := recording.ReadOnly()
 
-	err = runtime.SetMockRecording(roRecording, runtime.Provider.Instance.ID, true)
-	if err != nil {
-		panic("failed to set recording: " + err.Error())
-	}
-	err = runtime.SetMockRecording(roRecording, networkconf.Config.ID, true)
-	if err != nil {
-		panic("failed to set recording: " + err.Error())
-	}
-	err = runtime.SetMockRecording(roRecording, mockprovider.Config.ID, true)
-	if err != nil {
-		panic("failed to set recording: " + err.Error())
-	}
+	return MockFromRecording(roRecording)
+}
 
-	return runtime
+func RecordingFromAsset(a *inventory.Asset) providers.Recording {
+	recording, err := providers.FromAsset(a)
+	if err != nil {
+		panic("failed to load recording: " + err.Error())
+	}
+	roRecording := recording.ReadOnly()
+
+	return roRecording
 }
 
 func LinuxMock() llx.Runtime {

--- a/providers-sdk/v1/testutils/testutils.go
+++ b/providers-sdk/v1/testutils/testutils.go
@@ -274,6 +274,16 @@ func RecordingFromAsset(a *inventory.Asset) providers.Recording {
 	return roRecording
 }
 
+func MockFromAsset(a *inventory.Asset) llx.Runtime {
+	recording, err := providers.FromAsset(a)
+	if err != nil {
+		panic("failed to create recording from an asset: " + err.Error())
+	}
+	roRecording := recording.ReadOnly()
+
+	return MockFromRecording(roRecording)
+}
+
 func LinuxMock() llx.Runtime {
 	return mockRuntime("testdata/arch.json")
 }

--- a/providers-sdk/v1/testutils/testutils.go
+++ b/providers-sdk/v1/testutils/testutils.go
@@ -275,13 +275,7 @@ func RecordingFromAsset(a *inventory.Asset) providers.Recording {
 }
 
 func MockFromAsset(a *inventory.Asset) llx.Runtime {
-	recording, err := providers.FromAsset(a)
-	if err != nil {
-		panic("failed to create recording from an asset: " + err.Error())
-	}
-	roRecording := recording.ReadOnly()
-
-	return MockFromRecording(roRecording)
+	return MockFromRecording(RecordingFromAsset(a))
 }
 
 func LinuxMock() llx.Runtime {


### PR DESCRIPTION
 A bit simpler approach, compared to #2312 

We already have predefined recordings, which are great, but they cannot be modified in any way. 

This PR lets us create a recording from a simple asset, containing just that asset. It holds no resources/connections on the side, although we can extend

```
myAsset := &inventory.Asset{Name: "my-test"}
recording := testutils.RecordingFromAsset(myAsset)
runtime := testutils.MockFromRecording(recording)
```

