### PR TITLE
🐛 Support protobuf string values for VaultType.

### DIFF
--- a/providers-sdk/v1/vault/config_test.go
+++ b/providers-sdk/v1/vault/config_test.go
@@ -22,12 +22,15 @@ func TestVaultTypeParser(t *testing.T) {
 - gcp-secret-manager
 - aws-secrets-manager
 - aws-parameter-store
+- GCPBerglas
+- AWSParameterStore
+- Memory
 `
 
 	v := []VaultType{}
 	yaml.Unmarshal([]byte(content), &v)
 
-	assert.Equal(t, 8, len(v))
+	assert.Equal(t, 11, len(v))
 	assert.Equal(t, VaultType_None, v[0])
 	assert.Equal(t, VaultType_KeyRing, v[1])
 	assert.Equal(t, VaultType_LinuxKernelKeyring, v[2])
@@ -36,6 +39,9 @@ func TestVaultTypeParser(t *testing.T) {
 	assert.Equal(t, VaultType_GCPSecretsManager, v[5])
 	assert.Equal(t, VaultType_AWSSecretsManager, v[6])
 	assert.Equal(t, VaultType_AWSParameterStore, v[7])
+	assert.Equal(t, VaultType_GCPBerglas, v[8])
+	assert.Equal(t, VaultType_AWSParameterStore, v[9])
+	assert.Equal(t, VaultType_Memory, v[10])
 }
 
 func TestVaultTypeMarshal(t *testing.T) {


### PR DESCRIPTION
In v8, the inventory proto had its own `VaultConfiguration`
```
message VaultConfiguration {
  string name = 1;
  string type = 2;
  map<string, string> options = 3;
}
```

Note the type here is a string. This meant that we'd usually pass in the string representation of the enum, which is using the auto-generated map, e.g.
```
VaultType_name = map[int32]string{
		0: "None",
		1: "KeyRing",
		2: "LinuxKernelKeyring",
		3: "EncryptedFile",
		4: "HashiCorp",
		5: "GCPSecretsManager",
		6: "AWSSecretsManager",
		7: "AWSParameterStore",
		8: "GCPBerglas",
		9: "Memory",
	}
```

In v9, we've gotten rid of the the duplicate `VaultConfiguration` in the inventory.proto and it now directly uses the proper config, which is defined (in `vault.proto`) as:
```

message VaultConfiguration {
  string name = 1;
  VaultType type = 2;
  map <string, string> options = 3;
}
```

Note the type here is correct, it references to the enum type instead of a string. To support conversion from v8, extend the 
`NewVaultType` func to also consider the auto-generated protobuf string map
