### PR TITLE
🧹 Prevent nil panic when recording is not set

### DIFF
--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -73,6 +73,10 @@ func NewLocalScanner(opts ...ScannerOption) *LocalScanner {
 		opts[i](ls)
 	}
 
+	if ls.recording == nil {
+		ls.recording = providers.NullRecording{}
+	}
+
 	return ls
 }
 


### PR DESCRIPTION
In case recording isn't specififed during scanner initialisation, set the NullRecording