### PR TITLE
🐛 raw data json err (#1387)

### DIFF
--- a/llx/rawdata_json.go
+++ b/llx/rawdata_json.go
@@ -400,7 +400,9 @@ func (r *RawData) JSON(codeID string, bundle *CodeBundle) []byte {
 	}
 
 	var res bytes.Buffer
-	rawDataJSON(r.Type, r.Value, codeID, bundle, &res)
+	if err := rawDataJSON(r.Type, r.Value, codeID, bundle, &res); err != nil {
+		return JSONerror(err)
+	}
 	return res.Bytes()
 }
 


### PR DESCRIPTION
Properly handle cases where the value of `RawData` cannot be parsed

This was present in v8 but wasn't ported to v9