### PR TITLE
✨ Improve default host handling for no scheme/port

### DIFF
--- a/providers/network/resources/network.go
+++ b/providers/network/resources/network.go
@@ -1,0 +1,19 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+// This is a small selection of common ports that are supported.
+// Outside of this range, users will have to specify ports explicitly.
+// We could expand this to cover more of IANA.
+var CommonPorts = map[string]int{
+	"https":  443,
+	"http":   80,
+	"ssh":    22,
+	"ftp":    21,
+	"telnet": 23,
+	"smtp":   25,
+	"dns":    53,
+	"pop3":   110,
+	"imap4":  143,
+}


### PR DESCRIPTION
After https://github.com/mondoohq/cnquery/pull/2357

Users sometimes target a system like this:

```
cnquery shell host mondoo.com
```

Question is: What is this? If we connect to it, what do we connect to?

Until now, we'd opt to HTTP, which was of course nice for `http.get`. But it was horrible for `tls`, because it tried to connect on the default HTTP port - definitely not what the user intended.

This new mechanism allows users to skip the scheme and the port and ask the resources to figure out what they want to do with it. For `http` this is something different than for `tls`.

Example:

```
cnquery shell host mondoo.com
```

with the queries:

```coffee
> http.get { version url.string }
http.get: {
  url.string: "http://mondoo.com"
  version: "2.0"
}

> tls { socket versions }
tls: {
  versions: [
    0: "tls1.2"
    1: "tls1.3"
  ]
  socket: socket protocol="tcp" port=443 address="mondoo.com"
}
```

As you can see, both resources change the port, based on what users intended. Users can still override this by providing a proper URL or specifying the port.
