### PR TITLE
🐛 fix TLS on open endpoint without TLS

### DIFF
--- a/providers/network/resources/tls.go
+++ b/providers/network/resources/tls.go
@@ -190,7 +190,7 @@ func (s *mqlTls) params(socket *mqlSocket, domainName string) (map[string]interf
 
 	tester := tlsshake.New(proto, domainName, host, int(port))
 	if err := tester.Test(tlsshake.DefaultScanConfig()); err != nil {
-		if errors.Is(err, tlsshake.ErrFailedToConnect) {
+		if errors.Is(err, tlsshake.ErrFailedToConnect) || errors.Is(err, tlsshake.ErrFailedToTlsResponse) {
 			s.Params.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil
 		}

--- a/utils/multierr/errors.go
+++ b/utils/multierr/errors.go
@@ -30,13 +30,13 @@ func Wrap(err error, message string) error {
 }
 
 type Errors struct {
-	errors []error
+	Errors []error
 }
 
 func (m *Errors) Add(err ...error) {
 	for i := range err {
 		if err[i] != nil {
-			m.errors = append(m.errors, err[i])
+			m.Errors = append(m.Errors, err[i])
 		}
 	}
 }
@@ -44,29 +44,29 @@ func (m *Errors) Add(err ...error) {
 func (m *Errors) Error() string {
 	var res strings.Builder
 
-	n := strconv.Itoa(len(m.errors))
+	n := strconv.Itoa(len(m.Errors))
 	if n == "1" {
 		res.WriteString("1 error occurred:\n")
 	} else {
 		res.WriteString(n + " errors occurred:\n")
 	}
 
-	for i := range m.errors {
+	for i := range m.Errors {
 		res.WriteString("\t* ")
-		res.WriteString(m.errors[i].Error())
+		res.WriteString(m.Errors[i].Error())
 		res.WriteByte('\n')
 	}
 	return res.String()
 }
 
 func (m Errors) Deduplicate() error {
-	if len(m.errors) == 0 {
+	if len(m.Errors) == 0 {
 		return nil
 	}
 
 	track := map[string]error{}
-	for i := range m.errors {
-		e := m.errors[i]
+	for i := range m.Errors {
+		e := m.Errors[i]
 		track[e.Error()] = e
 	}
 
@@ -76,9 +76,9 @@ func (m Errors) Deduplicate() error {
 		res[i] = v
 		i++
 	}
-	return &Errors{errors: res}
+	return &Errors{Errors: res}
 }
 
 func (m Errors) IsEmpty() bool {
-	return len(m.errors) == 0
+	return len(m.Errors) == 0
 }


### PR DESCRIPTION
After https://github.com/mondoohq/cnquery/pull/2358

A valid endpoint with TLS returns very cryptic error messages.

We already handled the case of having no open endpoint in https://github.com/mondoohq/cnquery/pull/2357 . This extends the approach to also work for open endpoints that are not TLS.

OLD:

```coffee
> tls { socket versions }
1 error occurred:
        * 1 error occurred:
        * failed to get a TLS response
tls: {
  versions: 1 error occurred:
        * failed to get a TLS response

  socket: socket protocol="tcp" port=80 address="mondoo.com"
}
```

NEW

```coffee
> tls { socket versions }
tls: {
  versions: null
  socket: socket protocol="tcp" port=80 address="mondoo.com"
}
```
