### PR TITLE
🐛 compile variant queries in bundles earlier

### DIFF
--- a/explorer/bundle.go
+++ b/explorer/bundle.go
@@ -445,14 +445,6 @@ func (c *bundleCache) precompileQuery(query *Mquery, pack *QueryPack) {
 		return
 	}
 
-	// filters will need to be aggregated into the pack's filters
-	if pack != nil {
-		if err := pack.ComputedFilters.AddQueryFilters(query, c.lookupQuery); err != nil {
-			c.errors = append(c.errors, errors.New("failed to register filters for query "+query.Mrn))
-			return
-		}
-	}
-
 	// ensure MRNs for variants
 	for i := range query.Variants {
 		variant := query.Variants[i]
@@ -463,6 +455,14 @@ func (c *bundleCache) precompileQuery(query *Mquery, pack *QueryPack) {
 		}
 		if uid != "" {
 			c.uid2mrn[uid] = variant.Mrn
+		}
+	}
+
+	// filters will need to be aggregated into the pack's filters
+	if pack != nil {
+		if err := pack.ComputedFilters.AddQueryFilters(query, c.lookupQuery); err != nil {
+			c.errors = append(c.errors, errors.New("failed to register filters for query "+query.Mrn))
+			return
 		}
 	}
 }

--- a/explorer/bundle_test.go
+++ b/explorer/bundle_test.go
@@ -4,11 +4,13 @@
 package explorer
 
 import (
+	"context"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/v9/providers-sdk/v1/testutils"
 )
 
 func TestBundleLoad(t *testing.T) {
@@ -20,6 +22,19 @@ func TestBundleLoad(t *testing.T) {
 
 		// ensure that the uid is generated
 		assert.True(t, len(bundle.Packs[0].Queries[0].Uid) > 0)
+	})
+
+	t.Run("compile complex bundle", func(t *testing.T) {
+		bundle, err := BundleFromPaths("../examples/complex.mql.yaml")
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(bundle.Packs))
+		assert.Equal(t, 4, len(bundle.Queries))
+
+		mock := testutils.LinuxMock()
+		m, err := bundle.Compile(context.Background(), mock.Schema())
+		require.NoError(t, err)
+		require.NotNil(t, m)
+		assert.Len(t, m.Queries, 6)
 	})
 
 	t.Run("load bundle from memory", func(t *testing.T) {


### PR DESCRIPTION
Technically adding the filters should happen after the variant queries have been compiled, not before. This aligns with cnspec.

Partly related to the issue below vv
Fixes https://github.com/mondoohq/cnquery/issues/2279