### PR TITLE
🧹 introduce structured mqlc errors

### DIFF
--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -212,6 +212,33 @@ func TestCompiler_Buggy(t *testing.T) {
 	}
 }
 
+func TestCompiler_StructuredErrors(t *testing.T) {
+	data := []struct {
+		code string
+		errT any
+	}{
+		{
+			code: `does_not_exist`,
+			errT: mqlc.ErrIdentifierNotFound{},
+		},
+		{
+			code: `mondoo.does_not_exist`,
+			errT: mqlc.ErrIdentifierNotFound{},
+		},
+		{
+			code: `props.does_not_exist`,
+			errT: mqlc.ErrIdentifierNotFound{},
+		},
+	}
+
+	for _, v := range data {
+		t.Run(v.code, func(t *testing.T) {
+			_, err := mqlc.Compile(v.code, nil, conf)
+			assert.ErrorAs(t, err, &v.errT)
+		})
+	}
+}
+
 func TestCompiler_Semicolon(t *testing.T) {
 	compileT(t, "mondoo.version;mondoo.build", func(res *llx.CodeBundle) {
 		require.Len(t, res.CodeV2.Blocks, 1)

--- a/utils/multierr/errors.go
+++ b/utils/multierr/errors.go
@@ -18,6 +18,7 @@ type withMessage struct {
 
 func (w withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
 func (w withMessage) Cause() error  { return w.cause }
+func (w withMessage) Unwrap() error { return w.cause }
 
 func Wrap(err error, message string) error {
 	if err == nil {


### PR DESCRIPTION
These help us communicate when resources or fields have not been found. They are indications that can be used to infer that providers may be missing on the system.