### PR TITLE
⭐️ implement vuln report for vsphere

### DIFF
--- a/providers/vsphere/resources/asset_advisories.go
+++ b/providers/vsphere/resources/asset_advisories.go
@@ -1,0 +1,43 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"go.mondoo.com/cnquery/v9/providers-sdk/v1/resources"
+	"go.mondoo.com/cnquery/v9/providers-sdk/v1/upstream/mvd"
+	"go.mondoo.com/cnquery/v9/providers-sdk/v1/util/convert"
+	"go.mondoo.com/cnquery/v9/providers/vsphere/connection"
+)
+
+// fetches the vulnerability report and returns the full report
+func (p *mqlAsset) vulnerabilityReport() (interface{}, error) {
+	runtime := p.MqlRuntime
+
+	mcc := runtime.Upstream
+	if mcc == nil || mcc.ApiEndpoint == "" {
+		return nil, resources.MissingUpstreamError{}
+	}
+
+	// get new mvd client
+	scannerClient, err := mvd.NewAdvisoryScannerClient(mcc.ApiEndpoint, mcc.HttpClient, mcc.Plugins...)
+	if err != nil {
+		return nil, err
+	}
+
+	conn := runtime.Connection.(*connection.VsphereConnection)
+	apiPackages := []*mvd.Package{}
+
+	scanjob := &mvd.AnalyseAssetRequest{
+		Platform: mvd.NewMvdPlatform(conn.Asset().Platform),
+		Packages: apiPackages,
+	}
+
+	report, err := scannerClient.AnalyseAsset(context.Background(), scanjob)
+	if err != nil {
+		return nil, err
+	}
+
+	return convert.JsonToDict(report)
+}

--- a/providers/vsphere/resources/vsphere.lr
+++ b/providers/vsphere/resources/vsphere.lr
@@ -4,6 +4,10 @@
 option provider = "go.mondoo.com/cnquery/v9/providers/vsphere"
 option go_package = "go.mondoo.com/cnquery/v9/providers/vsphere/resources"
 
+extend asset {
+  vulnerabilityReport() dict
+}
+
 // VMware vSphere resource
 vsphere {
   // System information including the name, type, version, and build number

--- a/providers/vsphere/resources/vsphere.lr.manifest.yaml
+++ b/providers/vsphere/resources/vsphere.lr.manifest.yaml
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 resources:
+  asset:
+    fields:
+      vulnerabilityReport: {}
+    min_mondoo_version: latest
   esxi:
     docs:
       desc: |


### PR DESCRIPTION
This is an extraction from https://github.com/mondoohq/cnquery/pull/2301. For vulnerability scanning we need return the list of packages. For ESXi we do not use the os connection therefore we need to implement the same resource in the vsphere provider. This PR adds the implementation to fetch and build the report here.

TODO:

- [x] It looks like `extend asset` is not reliably picking up the implementation from the current provider, fixed by https://github.com/mondoohq/cnquery/pull/2370