### PR TITLE
✨ prioritize connected provider schema

### DIFF
--- a/providers-sdk/v1/resources/schema.go
+++ b/providers-sdk/v1/resources/schema.go
@@ -3,6 +3,9 @@
 
 package resources
 
+// Add another schema and return yourself. other may be nil.
+// The other schema overrides specifications in this schema, unless
+// a resource is flagged as an extension.
 func (s *Schema) Add(other *Schema) *Schema {
 	if other == nil {
 		return s

--- a/providers-sdk/v1/resources/schema.go
+++ b/providers-sdk/v1/resources/schema.go
@@ -3,9 +3,11 @@
 
 package resources
 
+import "google.golang.org/protobuf/proto"
+
 // Add another schema and return yourself. other may be nil.
 // The other schema overrides specifications in this schema, unless
-// a resource is flagged as an extension.
+// it is trying to extend a resource whose base is already defined.
 func (s *Schema) Add(other *Schema) *Schema {
 	if other == nil {
 		return s
@@ -15,8 +17,9 @@ func (s *Schema) Add(other *Schema) *Schema {
 		if existing, ok := s.Resources[k]; ok {
 			// We will merge resources into it until we find one that is not extending.
 			// Technically, this should only happen with one resource and one only,
-			// i.e. the root resource. This is more of a protection.
-			if existing.IsExtension {
+			// i.e. the root resource. In case they are incorrectly specified, the
+			// last added resource wins (as is the case with all other fields below).
+			if !v.IsExtension || existing.IsExtension {
 				existing.IsExtension = v.IsExtension
 				existing.Provider = v.Provider
 				existing.Init = v.Init
@@ -46,14 +49,13 @@ func (s *Schema) Add(other *Schema) *Schema {
 			}
 
 			if existing.Fields == nil {
-				existing.Fields = v.Fields
-			} else {
-				for fk, fv := range v.Fields {
-					existing.Fields[fk] = fv
-				}
+				existing.Fields = map[string]*Field{}
+			}
+			for fk, fv := range v.Fields {
+				existing.Fields[fk] = fv
 			}
 		} else {
-			s.Resources[k] = v
+			s.Resources[k] = proto.Clone(v).(*ResourceInfo)
 		}
 	}
 

--- a/providers/extensible_schema_test.go
+++ b/providers/extensible_schema_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/v9/providers-sdk/v1/resources"
+)
+
+func TestExtensibleSchema(t *testing.T) {
+	s := newExtensibleSchema()
+
+	s.Add("first", &resources.Schema{
+		Resources: map[string]*resources.ResourceInfo{
+			"eternity": {
+				Fields: map[string]*resources.Field{
+					"iii": {Provider: "first"},
+					"v":   {Provider: "first"},
+				},
+				Provider: "first",
+			},
+		},
+	})
+
+	s.Add("second", &resources.Schema{
+		Resources: map[string]*resources.ResourceInfo{
+			"eternity": {
+				Fields: map[string]*resources.Field{
+					"iii": {Provider: "second"},
+				},
+				Provider: "second",
+			},
+		},
+	})
+
+	s.prioritizeIDs("second")
+	s.refresh()
+
+	info := s.Lookup("eternity")
+	require.NotNil(t, info)
+	require.Equal(t, "second", info.Provider)
+
+	_, finfo := s.LookupField("eternity", "iii")
+	require.NotNil(t, info)
+	require.Equal(t, "second", finfo.Provider)
+
+	_, finfo = s.LookupField("eternity", "v")
+	require.NotNil(t, info)
+	require.Equal(t, "first", finfo.Provider)
+
+	s.prioritizeIDs("first")
+	s.refresh()
+
+	_, finfo = s.LookupField("eternity", "iii")
+	require.NotNil(t, info)
+	require.Equal(t, "first", finfo.Provider)
+}

--- a/providers/mock.go
+++ b/providers/mock.go
@@ -114,5 +114,6 @@ func (s *mockProviderService) Init(running *RunningProvider) {
 
 	rt := s.coordinator.NewRuntime()
 	rt.schema.loadAllSchemas()
-	running.Schema = &rt.schema.Schema
+	rt.schema.refresh()
+	running.Schema = rt.schema.Schema()
 }

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -130,6 +130,7 @@ func (r *Runtime) UseProvider(id string) error {
 func (r *Runtime) AddConnectedProvider(c *ConnectedProvider) {
 	r.providers[c.Instance.ID] = c
 	r.schema.Add(c.Instance.Name, c.Instance.Schema)
+	r.schema.refresh()
 }
 
 func (r *Runtime) addProvider(id string, isEphemeral bool) (*ConnectedProvider, error) {
@@ -251,6 +252,8 @@ func (r *Runtime) Connect(req *plugin.ConnectReq) error {
 	}
 
 	r.Recording.EnsureAsset(r.Provider.Connection.Asset, r.Provider.Instance.ID, r.Provider.Connection.Id, asset.Connections[0])
+	r.schema.prioritizeIDs(BuiltinCoreID, r.Provider.Instance.ID)
+	r.schema.refresh()
 	return nil
 }
 


### PR DESCRIPTION
Currently schemas are loaded in almost random order (except for the core provider). This is problematic if 2 providers provide the same resource, like `asset.eol` which is provided by both `os` and `vsphere`. Since we now have this use-case, it became more important to control the load-order of schemas.

Notes:
1. At the very start we still `loadAllSchemas`. This will be removed in the future because we really don't need all schemas at all times. We also initialize early runtimes that we tend to throw away - so all this work is wasted.
   - In this early stage we only prioritize the core provider
2. Once users connect to a provider via `runtime.Connect(..)` it sets the default provider for the runtime. It is also the signal for us to set a priority schema, based on whatever the users connected to. For example: If we connect to e.g. `vsphere` this provider gets prioritized.
   - Once prioritized, the schema is refreshed
   - During the refresh the core provider comes first, then the connecting provider.
3. Extending the schema behaved incorrectly when two non-extended resources were added. In this case the base resource survived, even though the new resource should have overwritten it (to be consistent with the remaining code).
4. We were passing pointers around for schemas, which is nice and fast, but also led to object changes that were unintended. Most notably: When re-prioritizing schemas it became evident that the original resource had changed (and adopted all the fields of merged resources). This approach is slower but safer from side-effects.