### PR TITLE
Add kind to default fields in azure cosmodb

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -1421,7 +1421,7 @@ private azure.subscription.cosmosDbService {
 }
 
 // Azure Cosmos DB Account
-private azure.subscription.cosmosDbService.account @defaults("name location") {
+private azure.subscription.cosmosDbService.account @defaults("name kind location") {
   // Cosmos DB account ID
   id string
   // Cosmos DB account name


### PR DESCRIPTION
This gets us the DB type which was MongoDB in my testing