### PR TITLE
⭐️ ability to fetch group roles and members

### DIFF
--- a/providers/okta/resources/customRoles.go
+++ b/providers/okta/resources/customRoles.go
@@ -1,0 +1,91 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"go.mondoo.com/cnquery/v9/llx"
+	"go.mondoo.com/cnquery/v9/providers-sdk/v1/plugin"
+	"go.mondoo.com/cnquery/v9/providers-sdk/v1/util/convert"
+	"go.mondoo.com/cnquery/v9/providers/okta/connection"
+	"go.mondoo.com/cnquery/v9/providers/okta/resources/sdk"
+	"go.mondoo.com/cnquery/v9/types"
+	"net/http"
+	"strings"
+)
+
+func (o *mqlOkta) customRoles() ([]interface{}, error) {
+	runtime := o.MqlRuntime
+
+	conn := runtime.Connection.(*connection.OktaConnection)
+	client := conn.Client()
+
+	ctx := context.Background()
+	apiSupplement := &sdk.ApiExtension{
+		RequestExecutor: client.CloneRequestExecutor(),
+	}
+
+	respList, resp, err := apiSupplement.ListCustomRoles(
+		ctx,
+		nil,
+	)
+
+	// handle case where no policy exists
+	if err != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	// handle special case where the policy type does not exist
+	if err != nil && resp.StatusCode == http.StatusBadRequest && strings.Contains(strings.ToLower(err.Error()), "invalid policy type") {
+		return nil, nil
+	}
+
+	if len(respList.Roles) == 0 {
+		return nil, nil
+	}
+
+	list := []interface{}{}
+	appendEntry := func(datalist []*sdk.CustomRole) error {
+		for i := range datalist {
+			r, err := newMqlOktaCustomRole(o.MqlRuntime, datalist[i])
+			if err != nil {
+				return err
+			}
+			list = append(list, r)
+		}
+		return nil
+	}
+
+	err = appendEntry(respList.Roles)
+	if err != nil {
+		return nil, err
+	}
+
+	for resp.HasNextPage() {
+		var roles []*sdk.CustomRole
+		resp, err = resp.Next(ctx, &roles)
+		if err != nil {
+			return nil, err
+		}
+		err = appendEntry(roles)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return list, nil
+
+}
+
+func newMqlOktaCustomRole(runtime *plugin.Runtime, entry *sdk.CustomRole) (interface{}, error) {
+	return CreateResource(runtime, "okta.customRole", map[string]*llx.RawData{
+		"id":          llx.StringData(entry.Id),
+		"label":       llx.StringData(entry.Label),
+		"description": llx.StringData(entry.Description),
+		"permissions": llx.ArrayData(convert.SliceAnyToInterface(entry.Permissions), types.String),
+	})
+}
+
+func (o *mqlOktaRole) id() (string, error) {
+	return "okta.role/" + o.Id.Data, o.Id.Error
+}

--- a/providers/okta/resources/groups.go
+++ b/providers/okta/resources/groups.go
@@ -74,6 +74,8 @@ func newMqlOktaGroup(runtime *plugin.Runtime, entry *okta.Group) (interface{}, e
 
 	return CreateResource(runtime, "okta.group", map[string]*llx.RawData{
 		"id":                    llx.StringData(entry.Id),
+		"name":                  llx.StringData(entry.Profile.Name),
+		"description":           llx.StringData(entry.Profile.Description),
 		"type":                  llx.StringData(entry.Type),
 		"created":               llx.TimeDataPtr(entry.Created),
 		"lastMembershipUpdated": llx.TimeDataPtr(entry.LastMembershipUpdated),
@@ -84,4 +86,157 @@ func newMqlOktaGroup(runtime *plugin.Runtime, entry *okta.Group) (interface{}, e
 
 func (o *mqlOktaGroup) id() (string, error) {
 	return "okta.group/" + o.Id.Data, o.Id.Error
+}
+
+func (o *mqlOktaGroup) members() ([]interface{}, error) {
+	conn := o.MqlRuntime.Connection.(*connection.OktaConnection)
+	client := conn.Client()
+
+	ctx := context.Background()
+	groupID := o.Id.Data
+	slice, resp, err := client.Group.ListGroupUsers(ctx, groupID, query.NewQueryParams(query.WithLimit(queryLimit)))
+
+	if len(slice) == 0 {
+		return nil, nil
+	}
+
+	list := []interface{}{}
+	appendEntry := func(datalist []*okta.User) error {
+		for i := range datalist {
+			entry := datalist[i]
+			r, err := newMqlOktaUser(o.MqlRuntime, entry)
+			if err != nil {
+				return err
+			}
+			list = append(list, r)
+		}
+
+		return nil
+	}
+
+	err = appendEntry(slice)
+	if err != nil {
+		return nil, err
+	}
+
+	for resp != nil && resp.HasNextPage() {
+		var slice []*okta.User
+		resp, err = resp.Next(ctx, &slice)
+		if err != nil {
+			return nil, err
+		}
+		err = appendEntry(slice)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return list, nil
+
+}
+
+func (o *mqlOktaGroup) roles() ([]interface{}, error) {
+	conn := o.MqlRuntime.Connection.(*connection.OktaConnection)
+	client := conn.Client()
+
+	ctx := context.Background()
+	groupID := o.Id.Data
+	slice, resp, err := client.Group.ListGroupAssignedRoles(ctx, groupID, query.NewQueryParams(query.WithLimit(queryLimit)))
+
+	if len(slice) == 0 {
+		return nil, nil
+	}
+
+	list := []interface{}{}
+	appendEntry := func(datalist []*okta.Role) error {
+		for i := range datalist {
+			entry := datalist[i]
+			r, err := newMqlOktaRole(o.MqlRuntime, entry)
+			if err != nil {
+				return err
+			}
+			list = append(list, r)
+		}
+
+		return nil
+	}
+
+	err = appendEntry(slice)
+	if err != nil {
+		return nil, err
+	}
+
+	for resp != nil && resp.HasNextPage() {
+		var slice []*okta.Role
+		resp, err = resp.Next(ctx, &slice)
+		if err != nil {
+			return nil, err
+		}
+		err = appendEntry(slice)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return list, nil
+}
+
+func (o *mqlOkta) groupRules() ([]interface{}, error) {
+	conn := o.MqlRuntime.Connection.(*connection.OktaConnection)
+	client := conn.Client()
+
+	ctx := context.Background()
+	slice, resp, err := client.Group.ListGroupRules(
+		ctx,
+		query.NewQueryParams(
+			query.WithLimit(queryLimit),
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(slice) == 0 {
+		return nil, nil
+	}
+
+	list := []interface{}{}
+	appendEntry := func(datalist []*okta.GroupRule) error {
+		for i := range datalist {
+			entry := datalist[i]
+			r, err := newMqlOktaGroupRule(o.MqlRuntime, entry)
+			if err != nil {
+				return err
+			}
+			list = append(list, r)
+		}
+
+		return nil
+	}
+
+	err = appendEntry(slice)
+	if err != nil {
+		return nil, err
+	}
+
+	for resp != nil && resp.HasNextPage() {
+		var slice []*okta.GroupRule
+		resp, err = resp.Next(ctx, &slice)
+		if err != nil {
+			return nil, err
+		}
+		err = appendEntry(slice)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return list, nil
+}
+
+func newMqlOktaGroupRule(runtime *plugin.Runtime, entry *okta.GroupRule) (interface{}, error) {
+
+	return CreateResource(runtime, "okta.groupRule", map[string]*llx.RawData{
+		"id":     llx.StringData(entry.Id),
+		"name":   llx.StringData(entry.Name),
+		"status": llx.StringData(entry.Status),
+		"type":   llx.StringData(entry.Type),
+	})
 }

--- a/providers/okta/resources/okta.lr
+++ b/providers/okta/resources/okta.lr
@@ -144,7 +144,7 @@ private okta.role @defaults("label status") {
 private okta.group @defaults("name") {
   // Unique key for Group
   id string
-	// Group Name
+	// Group name
   name string
 	// Group description
 	description string
@@ -158,9 +158,9 @@ private okta.group @defaults("name") {
   lastUpdated time
   // The Group's Profile properties
   profile dict
-  // Group Members
+  // Group members
   members() []okta.user
-  // Group Roles
+  // Group roles
   roles() []okta.role
 }
 
@@ -338,7 +338,7 @@ private okta.threatsConfiguration @defaults("action") {
 
 // Okta Custom Role
 private okta.customRole @defaults("label") {
-  // Identifier of the Policy
+  // Identifier for the policy
   id string
   // Name of the Custom Role
   label string

--- a/providers/okta/resources/okta.lr
+++ b/providers/okta/resources/okta.lr
@@ -10,6 +10,8 @@ okta {
   users() []okta.user
   // Okta groups
   groups() []okta.group
+  // Okta group rules
+  groupRules() []okta.groupRule
   // Okta domains
   domains() []okta.domain
   // Okta applications
@@ -18,6 +20,8 @@ okta {
   trustedOrigins() []okta.trustedOrigin
   // Okta networks
   networks() []okta.network
+	// Okta custom roles
+  customRoles() []okta.customRole
 }
 
 // Okta Organization
@@ -87,7 +91,7 @@ okta.policies {
 }
 
 // Okta User
-private okta.user @defaults("id profile['email']" ){
+private okta.user @defaults("profile['email']" ){
   // Unique key for user
   id string
   // The user's type identifier
@@ -119,7 +123,7 @@ private okta.user @defaults("id profile['email']" ){
 }
 
 // Okta Role
-private okta.role @defaults("id status") {
+private okta.role @defaults("label status") {
   // The identifier of the role
   id string
   // The assignment type of the role
@@ -137,9 +141,13 @@ private okta.role @defaults("id status") {
 }
 
 // Okta Group
-private okta.group @defaults("id") {
+private okta.group @defaults("name") {
   // Unique key for Group
   id string
+	// Group Name
+  name string
+	// Group description
+	description string
   // Determines how a Group's Profile and memberships are managed
   type dict
   // Timestamp when Group was created
@@ -150,6 +158,21 @@ private okta.group @defaults("id") {
   lastUpdated time
   // The Group's Profile properties
   profile dict
+  // Group Members
+  members() []okta.user
+  // Group Roles
+  roles() []okta.role
+}
+
+private okta.groupRule @defaults("name") {
+  // Unique key for Group Rule
+  id string
+	// Group Rule Name
+  name string
+	// Group Rule Status
+	status string
+	// Group Rule Type
+	type string
 }
 
 // Okta Application
@@ -310,4 +333,17 @@ private okta.threatsConfiguration @defaults("action") {
   created time
   // Timestamp when the Network Zone was last updated
   lastUpdated time
+
+}
+
+// Okta Custom Role
+private okta.customRole @defaults("label") {
+  // Identifier of the Policy
+  id string
+  // Name of the Custom Role
+  label string
+  // Description of the Custom Role
+  description string
+  // Role Permissions
+  permissions []string
 }

--- a/providers/okta/resources/okta.lr.manifest.yaml
+++ b/providers/okta/resources/okta.lr.manifest.yaml
@@ -5,10 +5,13 @@ resources:
   okta:
     fields:
       applications: {}
+      customRoles: {}
       domains: {}
+      groupRules: {}
       groups: {}
       networks:
         min_mondoo_version: 8.4.0
+      roles: {}
       trustedOrigins: {}
       users: {}
     min_mondoo_version: latest
@@ -29,6 +32,14 @@ resources:
       visibility: {}
     is_private: true
     min_mondoo_version: latest
+  okta.customRole:
+    fields:
+      description: {}
+      id: {}
+      label: {}
+      permissions: {}
+    is_private: true
+    min_mondoo_version: latest
   okta.domain:
     fields:
       dnsRecords: {}
@@ -41,10 +52,22 @@ resources:
   okta.group:
     fields:
       created: {}
+      description: {}
       id: {}
       lastMembershipUpdated: {}
       lastUpdated: {}
+      members: {}
+      name: {}
       profile: {}
+      roles: {}
+      type: {}
+    is_private: true
+    min_mondoo_version: latest
+  okta.groupRule:
+    fields:
+      id: {}
+      name: {}
+      status: {}
       type: {}
     is_private: true
     min_mondoo_version: latest

--- a/providers/okta/resources/sdk/roles.go
+++ b/providers/okta/resources/sdk/roles.go
@@ -1,0 +1,42 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package sdk
+
+import (
+	"context"
+	"github.com/okta/okta-sdk-golang/v2/okta"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
+	"net/http"
+)
+
+type ListCustomRolesResponse struct {
+	Roles []*CustomRole `json:"roles,omitempty"`
+}
+
+type CustomRole struct {
+	Id          string      `json:"id,omitempty"`
+	Label       string      `json:"label,omitempty"`
+	Description string      `json:"description,omitempty"`
+	Permissions []string    `json:"permissions,omitempty"`
+	Links       interface{} `json:"_links,omitempty"`
+}
+
+// ListCustomRoles Gets all customRoles based on the query params
+func (m *ApiExtension) ListCustomRoles(ctx context.Context, qp *query.Params) (*ListCustomRolesResponse, *okta.Response, error) {
+	url := "/api/v1/iam/roles"
+	if qp != nil {
+		url += qp.String()
+	}
+	rq := m.RequestExecutor
+	req, err := rq.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	var response *ListCustomRolesResponse
+	resp, err := rq.Do(ctx, req, &response)
+	if err != nil {
+		return nil, resp, err
+	}
+	return response, resp, nil
+}

--- a/providers/okta/resources/users.go
+++ b/providers/okta/resources/users.go
@@ -111,10 +111,6 @@ func (o *mqlOktaUser) id() (string, error) {
 	return "okta.user/" + o.Id.Data, o.Id.Error
 }
 
-func (o *mqlOktaRole) id() (string, error) {
-	return "okta.role/" + o.Id.Data, o.Id.Error
-}
-
 func (o *mqlOktaUser) roles() ([]interface{}, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OktaConnection)
 	client := conn.Client()
@@ -131,15 +127,7 @@ func (o *mqlOktaUser) roles() ([]interface{}, error) {
 
 	appendEntry := func(datalist []*okta.Role) error {
 		for _, r := range datalist {
-			mqlOktaRole, err := CreateResource(o.MqlRuntime, "okta.role", map[string]*llx.RawData{
-				"id":             llx.StringData(r.Id),
-				"assignmentType": llx.StringData(r.AssignmentType),
-				"created":        llx.TimeDataPtr(r.Created),
-				"lastUpdated":    llx.TimeDataPtr(r.LastUpdated),
-				"label":          llx.StringData(r.Label),
-				"status":         llx.StringData(r.Status),
-				"type":           llx.StringData(r.Type),
-			})
+			mqlOktaRole, err := newMqlOktaRole(o.MqlRuntime, r)
 			if err != nil {
 				return err
 			}
@@ -163,4 +151,20 @@ func (o *mqlOktaUser) roles() ([]interface{}, error) {
 		}
 	}
 	return res, nil
+}
+
+func newMqlOktaRole(runtime *plugin.Runtime, role *okta.Role) (*mqlOktaRole, error) {
+	r, err := CreateResource(runtime, "okta.role", map[string]*llx.RawData{
+		"id":             llx.StringData(role.Id),
+		"assignmentType": llx.StringData(role.AssignmentType),
+		"created":        llx.TimeDataPtr(role.Created),
+		"lastUpdated":    llx.TimeDataPtr(role.LastUpdated),
+		"label":          llx.StringData(role.Label),
+		"status":         llx.StringData(role.Status),
+		"type":           llx.StringData(role.Type),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.(*mqlOktaRole), nil
 }


### PR DESCRIPTION
This change allows users to fetch the okta groups with its roles and members:

```
cnspec> okta.groups.where(roles.one(type =="SUPER_ADMIN")) { name roles { * } members members.length < 2 }
okta.groups.where: [
  0: {
    roles: [
      0: {
        created: 2023-04-08 22:11:00 +0200 CEST
        lastUpdated: 2023-04-08 22:11:00 +0200 CEST
        assignmentType: "GROUP"
        id: "gra91lrbpr7vabz4l5d7"
        type: "SUPER_ADMIN"
        status: "ACTIVE"
        label: "Super Administrator"
      }
    ]
    name: "Super Admins"
    members.length < 2: true
    members: [
      0: okta.user profile.email="ben@example.com"
    ]
  }
]
```

You can also check which permissions custom roles have:

```
cnspec> okta.customRoles { * }
okta.customRoles: [
  0: {
    label: "Custom Role"
    id: "cr0cyddwhxapVOPrB5d7"
    description: "Custom Role"
    permissions: []
  }
]
```

This allows us to make dramatic performance improvement for the okta health sight policy https://github.com/mondoohq/cnspec-policies/blob/main/core/mondoo-okta-security.mql.yaml#L183. 

```
okta.users.where( roles.map(type).contains("SUPER_ADMIN") ).length < props.maxOktaSuperAdmins
```

Instead of iterating over all users (which is slow for large accounts), we just have to look for the group and the role.

```
okta.groups.where(roles.one(type =="SUPER_ADMIN")).all(members.length < 2 )
```

