### PR TITLE
🐛 remove os.exit and log.fatal calls

### DIFF
--- a/apps/cnquery/cmd/root.go
+++ b/apps/cnquery/cmd/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/viper"
 	"go.mondoo.com/cnquery/v9"
 	"go.mondoo.com/cnquery/v9/cli/config"
+	cli_errors "go.mondoo.com/cnquery/v9/cli/errors"
 	"go.mondoo.com/cnquery/v9/cli/providers"
 	"go.mondoo.com/cnquery/v9/cli/sysinfo"
 	"go.mondoo.com/cnquery/v9/cli/theme"
@@ -74,6 +75,13 @@ func Execute() {
 	}
 
 	if err := rootCmd.Execute(); err != nil {
+		if cErr, ok := err.(*cli_errors.CommandError); ok {
+			if cErr.HasError() {
+				log.Error().Msg(err.Error())
+			}
+			os.Exit(cErr.ExitCode())
+		}
+
 		log.Error().Msg(err.Error())
 		os.Exit(1)
 	}

--- a/cli/errors/command_error.go
+++ b/cli/errors/command_error.go
@@ -1,0 +1,30 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package errors
+
+var ExitCode1WithoutError = NewCommandError(nil, 1)
+
+type CommandError struct {
+	exitCode int
+	err      error
+}
+
+func NewCommandError(err error, exitCode int) *CommandError {
+	return &CommandError{
+		exitCode: exitCode,
+		err:      err,
+	}
+}
+
+func (e *CommandError) ExitCode() int {
+	return e.exitCode
+}
+
+func (e *CommandError) HasError() bool {
+	return e.err != nil
+}
+
+func (e *CommandError) Error() string {
+	return e.err.Error()
+}


### PR DESCRIPTION
fixes #2377

remove the `os.Exit` and `log.Fatal` calls from commands and return errors instead

I haven't touched the `scan` command since that one handles the coordinator shutdown inside the scanner itself