### PR TITLE
🐛 Fix ExitCode1WithoutError panic

### DIFF
--- a/cli/errors/command_error.go
+++ b/cli/errors/command_error.go
@@ -26,5 +26,8 @@ func (e *CommandError) HasError() bool {
 }
 
 func (e *CommandError) Error() string {
+	if e.err == nil {
+		return ""
+	}
 	return e.err.Error()
 }


### PR DESCRIPTION
A panic is possible because `ExitCode1WithoutError` sets err to nil.

```
goroutine 1 [running]:
go.mondoo.com/cnquery/v9/cli/errors.(*CommandError).Error(0xc000012060)
    /home/jaym/workspace/mondoo/cnquery/cli/errors/command_error.go:29 +0x24
github.com/spf13/cobra.(*Command).ExecuteC(0x2a0c260)
    /home/jaym/workspace/godev/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1080 +0xac7
github.com/spf13/cobra.(*Command).Execute(0x2a0c260)
    /home/jaym/workspace/godev/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992 +0x32
go.mondoo.com/cnspec/v9/apps/cnspec/cmd.Execute()
    /home/jaym/workspace/mondoo/cnspec/apps/cnspec/cmd/root.go:114 +0x325
main.main()
    /home/jaym/workspace/mondoo/cnspec/apps/cnspec/cnspec.go:9 +0xf
```