### PR TITLE
🐛 support empty bundle execution

### DIFF
--- a/explorer/executor/executor.go
+++ b/explorer/executor/executor.go
@@ -90,6 +90,14 @@ func ExecuteFilterQueries(runtime llx.Runtime, queries []*explorer.Mquery, timeo
 }
 
 func (e *instance) runCode(queries map[string]*explorer.ExecutionQuery, timeout time.Duration) error {
+	if len(queries) == 0 {
+		e.progressReporter.Completed()
+		go func() {
+			e.done <- struct{}{}
+		}()
+		return nil
+	}
+
 	e.execs = make(map[string]*llx.MQLExecutorV2, len(queries))
 
 	for i := range queries {


### PR DESCRIPTION
It is possible for bundles to end up having no queries at all after filtering. I noticed that the execution would hang until timeout is reached in this case.

@jaym You know this code much better than I do, could you add a test for this use-case? Also feel free to fix this up if you prefer a different approach.