### PR TITLE
⭐ Add new fields to aws.vpc.subnet

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -80,6 +80,10 @@ private aws.vpc.subnet @defaults("arn") {
   cidrs string
   // Indicates whether instances launched in this subnet receive a public IPv4 address
   mapPublicIpOnLaunch bool
+  // The availability zone where this subnet is located
+  availabilityZone string
+  // Indicates whether this is the default subnet for the availability zone
+  defaultForAvailabilityZone bool
 }
 
 // Amazon Virtual Private Cloud (VPC) Endpoint

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -647,6 +647,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.vpc.subnet.mapPublicIpOnLaunch": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcSubnet).GetMapPublicIpOnLaunch()).ToDataRes(types.Bool)
 	},
+	"aws.vpc.subnet.availabilityZone": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcSubnet).GetAvailabilityZone()).ToDataRes(types.String)
+	},
+	"aws.vpc.subnet.defaultForAvailabilityZone": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcSubnet).GetDefaultForAvailabilityZone()).ToDataRes(types.Bool)
+	},
 	"aws.vpc.endpoint.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcEndpoint).GetId()).ToDataRes(types.String)
 	},
@@ -2850,6 +2856,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.vpc.subnet.mapPublicIpOnLaunch": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcSubnet).MapPublicIpOnLaunch, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.subnet.availabilityZone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcSubnet).AvailabilityZone, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.subnet.defaultForAvailabilityZone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcSubnet).DefaultForAvailabilityZone, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.endpoint.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6490,6 +6504,8 @@ type mqlAwsVpcSubnet struct {
 	Id plugin.TValue[string]
 	Cidrs plugin.TValue[string]
 	MapPublicIpOnLaunch plugin.TValue[bool]
+	AvailabilityZone plugin.TValue[string]
+	DefaultForAvailabilityZone plugin.TValue[bool]
 }
 
 // createAwsVpcSubnet creates a new instance of this resource
@@ -6543,6 +6559,14 @@ func (c *mqlAwsVpcSubnet) GetCidrs() *plugin.TValue[string] {
 
 func (c *mqlAwsVpcSubnet) GetMapPublicIpOnLaunch() *plugin.TValue[bool] {
 	return &c.MapPublicIpOnLaunch
+}
+
+func (c *mqlAwsVpcSubnet) GetAvailabilityZone() *plugin.TValue[string] {
+	return &c.AvailabilityZone
+}
+
+func (c *mqlAwsVpcSubnet) GetDefaultForAvailabilityZone() *plugin.TValue[bool] {
+	return &c.DefaultForAvailabilityZone
 }
 
 // mqlAwsVpcEndpoint for the aws.vpc.endpoint resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2289,7 +2289,11 @@ resources:
   aws.vpc.subnet:
     fields:
       arn: {}
+      availabilityZone:
+        min_mondoo_version: latest
       cidrs: {}
+      defaultForAvailabilityZone:
+        min_mondoo_version: latest
       id: {}
       mapPublicIpOnLaunch: {}
     is_private: true

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -262,10 +262,12 @@ func (a *mqlAwsVpc) subnets() ([]interface{}, error) {
 		for _, subnet := range subnets.Subnets {
 			subnetResource, err := CreateResource(a.MqlRuntime, "aws.vpc.subnet",
 				map[string]*llx.RawData{
-					"arn":                 llx.StringData(fmt.Sprintf(subnetArnPattern, a.Region.Data, conn.AccountId(), convert.ToString(subnet.SubnetId))),
-					"id":                  llx.StringData(convert.ToString(subnet.SubnetId)),
-					"cidrs":               llx.StringData(*subnet.CidrBlock),
-					"mapPublicIpOnLaunch": llx.BoolData(*subnet.MapPublicIpOnLaunch),
+					"arn":                        llx.StringData(fmt.Sprintf(subnetArnPattern, a.Region.Data, conn.AccountId(), convert.ToString(subnet.SubnetId))),
+					"id":                         llx.StringDataPtr(subnet.SubnetId),
+					"cidrs":                      llx.StringDataPtr(subnet.CidrBlock),
+					"mapPublicIpOnLaunch":        llx.BoolDataPtr(subnet.MapPublicIpOnLaunch),
+					"availabilityZone":           llx.StringDataPtr(subnet.AvailabilityZone),
+					"defaultForAvailabilityZone": llx.BoolDataPtr(subnet.DefaultForAz),
 				})
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Add AZ fields to the subnet, which is critical information when digging into VPC subnets.

```
cnquery> aws.vpcs.first.subnets{*}
aws.vpcs.first.subnets: [
  0: {
    arn: "arn:aws:ec2:ap-south-1:177043123456:subnet/subnet-b231234"
    id: "subnet-b231234"
    cidrs: "172.31.16.0/20"
    mapPublicIpOnLaunch: true
    defaultForAvailabilityZone: true
    availabilityZone: "ap-south-1c"
  }
...
````