### PR TITLE
🐛 fix concurrent access to extensible schema

### DIFF
--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -336,11 +336,11 @@ func (c *coordinator) newRuntime(isEphemeral bool) *Runtime {
 	res.schema.runtime = res
 
 	// TODO: do this dynamically in the future
-	res.schema.loadAllSchemas()
+	res.schema.unsafeLoadAll()
 	// TODO: this step too shouild be optional only, even when loading all.
 	// It is executed when the we connect via a provider, so doing it here is
 	// overkill.
-	res.schema.refresh()
+	res.schema.unsafeRefresh()
 
 	if !isEphemeral {
 		c.mutex.Lock()

--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -336,6 +336,8 @@ func (c *coordinator) newRuntime(isEphemeral bool) *Runtime {
 	res.schema.runtime = res
 
 	// TODO: do this dynamically in the future
+	// Once these calls are removed, please remember to update mock.go to explicitly
+	// load all schemas on startup.
 	res.schema.unsafeLoadAll()
 	// TODO: this step too shouild be optional only, even when loading all.
 	// It is executed when the we connect via a provider, so doing it here is

--- a/providers/extensible_schema_test.go
+++ b/providers/extensible_schema_test.go
@@ -37,7 +37,7 @@ func TestExtensibleSchema(t *testing.T) {
 	})
 
 	s.prioritizeIDs("second")
-	s.refresh()
+	s.unsafeRefresh()
 
 	info := s.Lookup("eternity")
 	require.NotNil(t, info)
@@ -52,7 +52,7 @@ func TestExtensibleSchema(t *testing.T) {
 	require.Equal(t, "first", finfo.Provider)
 
 	s.prioritizeIDs("first")
-	s.refresh()
+	s.unsafeRefresh()
 
 	_, finfo = s.LookupField("eternity", "iii")
 	require.NotNil(t, info)

--- a/providers/extensible_schema_test.go
+++ b/providers/extensible_schema_test.go
@@ -37,7 +37,6 @@ func TestExtensibleSchema(t *testing.T) {
 	})
 
 	s.prioritizeIDs("second")
-	s.unsafeRefresh()
 
 	info := s.Lookup("eternity")
 	require.NotNil(t, info)
@@ -52,7 +51,6 @@ func TestExtensibleSchema(t *testing.T) {
 	require.Equal(t, "first", finfo.Provider)
 
 	s.prioritizeIDs("first")
-	s.unsafeRefresh()
 
 	_, finfo = s.LookupField("eternity", "iii")
 	require.NotNil(t, info)

--- a/providers/mock.go
+++ b/providers/mock.go
@@ -117,7 +117,7 @@ func (s *mockProviderService) Init(running *RunningProvider) {
 	s.initialized = true
 
 	rt := s.coordinator.NewRuntime()
-	rt.schema.loadAllSchemas()
-	rt.schema.refresh()
+	rt.schema.unsafeLoadAll()
+	rt.schema.unsafeRefresh()
 	running.Schema = rt.schema.Schema()
 }

--- a/providers/mock.go
+++ b/providers/mock.go
@@ -117,7 +117,11 @@ func (s *mockProviderService) Init(running *RunningProvider) {
 	s.initialized = true
 
 	rt := s.coordinator.NewRuntime()
-	rt.schema.unsafeLoadAll()
-	rt.schema.unsafeRefresh()
+
+	// TODO: Currently not needed, as the runtime loads all schemas right now.
+	// Once it doesn't do that anymore, remember to load all schemas here
+	// rt.schema.unsafeLoadAll()
+	// rt.schema.unsafeRefresh()
+
 	running.Schema = rt.schema.Schema()
 }

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -130,7 +130,7 @@ func (r *Runtime) UseProvider(id string) error {
 func (r *Runtime) AddConnectedProvider(c *ConnectedProvider) {
 	r.providers[c.Instance.ID] = c
 	r.schema.Add(c.Instance.Name, c.Instance.Schema)
-	r.schema.refresh()
+	r.schema.unsafeRefresh()
 }
 
 func (r *Runtime) addProvider(id string, isEphemeral bool) (*ConnectedProvider, error) {
@@ -253,7 +253,7 @@ func (r *Runtime) Connect(req *plugin.ConnectReq) error {
 
 	r.Recording.EnsureAsset(r.Provider.Connection.Asset, r.Provider.Instance.ID, r.Provider.Connection.Id, asset.Connections[0])
 	r.schema.prioritizeIDs(BuiltinCoreID, r.Provider.Instance.ID)
-	r.schema.refresh()
+	r.schema.unsafeRefresh()
 	return nil
 }
 

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -130,7 +130,6 @@ func (r *Runtime) UseProvider(id string) error {
 func (r *Runtime) AddConnectedProvider(c *ConnectedProvider) {
 	r.providers[c.Instance.ID] = c
 	r.schema.Add(c.Instance.Name, c.Instance.Schema)
-	r.schema.unsafeRefresh()
 }
 
 func (r *Runtime) addProvider(id string, isEphemeral bool) (*ConnectedProvider, error) {
@@ -253,7 +252,6 @@ func (r *Runtime) Connect(req *plugin.ConnectReq) error {
 
 	r.Recording.EnsureAsset(r.Provider.Connection.Asset, r.Provider.Instance.ID, r.Provider.Connection.Id, asset.Connections[0])
 	r.schema.prioritizeIDs(BuiltinCoreID, r.Provider.Instance.ID)
-	r.schema.unsafeRefresh()
 	return nil
 }
 
@@ -633,10 +631,6 @@ func (r *Runtime) lookupFieldProvider(resource string, field string) (*Connected
 
 func (r *Runtime) Schema() llx.Schema {
 	return &r.schema
-}
-
-func (r *Runtime) AddSchema(name string, schema *resources.Schema) {
-	r.schema.Add(name, schema)
 }
 
 func (r *Runtime) asset() *inventory.Asset {


### PR DESCRIPTION
1. Reduce the complexity of locks (kudos @jaym for pointing this out)
2. Split all methods into safe and unsafe calls (to reduce complexity)
3. Make sure the aggregate object is never modified, only re-created

... and add lots of instructions on how to use this.