### PR TITLE
🐛 Fix GKE node scanning

### DIFF
--- a/providers/os/connection/filesystem.go
+++ b/providers/os/connection/filesystem.go
@@ -34,12 +34,13 @@ func NewFileSystemConnectionWithClose(id uint32, conf *inventory.Config, asset *
 	log.Debug().Str("path", path).Msg("load filesystem")
 
 	return &FileSystemConnection{
-		id:         id,
-		Conf:       conf,
-		asset:      asset,
-		MountedDir: path,
-		closeFN:    closeFN,
-		fs:         fs.NewMountedFs(path),
+		id:           id,
+		Conf:         conf,
+		asset:        asset,
+		MountedDir:   path,
+		closeFN:      closeFN,
+		tcPlatformId: conf.PlatformId,
+		fs:           fs.NewMountedFs(path),
 	}, nil
 }
 
@@ -100,7 +101,7 @@ func (c *FileSystemConnection) Capabilities() shared.Capabilities {
 
 func (c *FileSystemConnection) Identifier() (string, error) {
 	if c.tcPlatformId == "" {
-		return "", errors.New("not platform id provided")
+		return "", errors.New("no platform id provided")
 	}
 	return c.tcPlatformId, nil
 }

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -419,10 +419,17 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 		if err != nil {
 			return nil, err
 		}
-		fingerprint, err := IdentifyPlatform(conn, asset.Platform, []string{ids.IdDetector_Hostname})
-		if err == nil {
-			asset.Name = fingerprint.Name
-			asset.PlatformIds = fingerprint.PlatformIDs
+		// This is a workaournd to set Google COS platfomr IDs when scanned from inside k8s
+		pID, err := conn.(*connection.FileSystemConnection).Identifier()
+		if err != nil {
+			fingerprint, err := IdentifyPlatform(conn, asset.Platform, []string{ids.IdDetector_Hostname})
+			if err == nil {
+				asset.Name = fingerprint.Name
+				asset.PlatformIds = fingerprint.PlatformIDs
+			}
+		} else {
+			// In this case asset.Name should already be set via the inventory
+			asset.PlatformIds = []string{pID}
 		}
 
 	// Do not expose mock connection as a supported type


### PR DESCRIPTION
We are missing some data from COS, that's why we supply some infomration via an inventory file. This infomration needs to be preserved, so we can sync the asset.