### PR TITLE
🐛 fix os services working with .service ending

### DIFF
--- a/providers/os/resources/services.go
+++ b/providers/os/resources/services.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"errors"
+	"strings"
 	"sync"
 
 	"github.com/rs/zerolog/log"
@@ -39,7 +40,9 @@ func initService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 		return nil, nil, err
 	}
 
-	if srv, ok := services.namedServices[name]; ok {
+	cleanServiceName := strings.TrimSuffix(name, ".service")
+
+	if srv, ok := services.namedServices[cleanServiceName]; ok {
 		return nil, srv, nil
 	}
 
@@ -48,7 +51,6 @@ func initService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 	res.Description.State = plugin.StateIsSet | plugin.StateIsNull
 	res.Installed = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
 	res.Running = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
-	res.Enabled = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
 	res.Type.State = plugin.StateIsSet | plugin.StateIsNull
 	res.Enabled = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
 	res.Masked = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}


### PR DESCRIPTION
#2432 
The culprit here was that if the user provided the `.service` ending we wouldn't match the service

So 

```
cnquery run -c 'service("avahi-daemon.service") {*}'
```

Would not be matched to `avahi-daemon` and returns default values.
This PR let's us ignore the `.service` suffix, so that both `avahi-daemon.service` and `avahi-deamon` will be properly recognized

Edit: This does not complete fix the issue #2432 but that said the change should still make sense.
To close the issue #2442 is also required but currently work in progress