### PR TITLE
✨ cnquery status show latest version available

### DIFF
--- a/apps/cnquery/cmd/status.go
+++ b/apps/cnquery/cmd/status.go
@@ -186,7 +186,7 @@ func (s Status) RenderCliStatus() {
 		log.Info().Msg("Features:\t\t" + strings.Join(s.Upstream.Features, ","))
 	}
 
-	if s.Client.ParentMrn == "" {
+	if s.Client.ParentMrn != "" {
 		log.Info().Msg("Owner:\t\t" + s.Client.ParentMrn)
 	}
 

--- a/apps/cnquery/cmd/status.go
+++ b/apps/cnquery/cmd/status.go
@@ -159,7 +159,7 @@ func (s Status) RenderCliStatus() {
 
 	latestVersion, err := cnquery.GetLatestVersion()
 	if err != nil {
-		log.Warn().Msg("failed to get latest version")
+		log.Warn().Err(err).Msg("failed to get latest version")
 	}
 
 	log.Info().Msg("Time:\t\t\t" + s.Client.Timestamp)

--- a/apps/cnquery/cmd/status.go
+++ b/apps/cnquery/cmd/status.go
@@ -149,37 +149,42 @@ type ClientStatus struct {
 func (s Status) RenderCliStatus() {
 	if s.Client.Platform != nil {
 		agent := s.Client
-		log.Info().Msg("Platform:\t" + agent.Platform.Name)
-		log.Info().Msg("Version:\t" + agent.Platform.Version)
-		log.Info().Msg("Hostname:\t" + agent.Hostname)
-		log.Info().Msg("IP:\t\t" + agent.IP)
+		log.Info().Msg("Platform:\t\t" + agent.Platform.Name)
+		log.Info().Msg("Version:\t\t" + agent.Platform.Version)
+		log.Info().Msg("Hostname:\t\t" + agent.Hostname)
+		log.Info().Msg("IP:\t\t\t" + agent.IP)
 	} else {
 		log.Warn().Msg("could not determine client platform information")
 	}
 
-	log.Info().Msg("Time:\t\t" + s.Client.Timestamp)
-	log.Info().Msg("Version:\t" + cnquery.GetVersion() + " (API Version: " + cnquery.APIVersion() + ")")
+	log.Info().Msg("Time:\t\t\t" + s.Client.Timestamp)
+	log.Info().Msg("Version:\t\t" + cnquery.GetVersion() + " (API Version: " + cnquery.APIVersion() + ")")
+	log.Info().Msg("Latest Version:\t" + cnquery.GetLatestVersion())
+
+	if cnquery.GetVersion() != cnquery.GetLatestVersion() {
+		log.Warn().Msg("A newer version is available")
+	}
 
 	log.Info().Msg("API ConnectionConfig:\t" + s.Upstream.API.Endpoint)
-	log.Info().Msg("API Status:\t" + s.Upstream.API.Status)
-	log.Info().Msg("API Time:\t" + s.Upstream.API.Timestamp)
-	log.Info().Msg("API Version:\t" + s.Upstream.API.Version)
+	log.Info().Msg("API Status:\t\t" + s.Upstream.API.Status)
+	log.Info().Msg("API Time:\t\t" + s.Upstream.API.Timestamp)
+	log.Info().Msg("API Version:\t\t" + s.Upstream.API.Version)
 
 	if s.Upstream.API.Version != cnquery.APIVersion() {
 		log.Warn().Msg("API versions do not match, please update the client")
 	}
 
 	if len(s.Upstream.Features) > 0 {
-		log.Info().Msg("Features:\t" + strings.Join(s.Upstream.Features, ","))
+		log.Info().Msg("Features:\t\t" + strings.Join(s.Upstream.Features, ","))
 	}
 
 	if s.Client.ParentMrn == "" {
-		log.Info().Msg("Owner:\t" + s.Client.ParentMrn)
+		log.Info().Msg("Owner:\t\t" + s.Client.ParentMrn)
 	}
 
 	if s.Client.Registered {
-		log.Info().Msg("Client:\t" + s.Client.Mrn)
-		log.Info().Msg("Service Account:\t" + s.Client.ServiceAccount)
+		log.Info().Msg("Client:\t\t" + s.Client.Mrn)
+		log.Info().Msg("Service Account:\t\t" + s.Client.ServiceAccount)
 		log.Info().Msg(theme.DefaultTheme.Success("client is registered"))
 	} else {
 		log.Error().Msg("client is not registered")

--- a/apps/cnquery/cmd/status.go
+++ b/apps/cnquery/cmd/status.go
@@ -157,13 +157,14 @@ func (s Status) RenderCliStatus() {
 		log.Warn().Msg("could not determine client platform information")
 	}
 
+	log.Info().Msg("Time:\t\t\t" + s.Client.Timestamp)
+	log.Info().Msg("Version:\t\t" + cnquery.GetVersion() + " (API Version: " + cnquery.APIVersion() + ")")
+
 	latestVersion, err := cnquery.GetLatestVersion()
 	if err != nil {
 		log.Warn().Err(err).Msg("failed to get latest version")
 	}
 
-	log.Info().Msg("Time:\t\t\t" + s.Client.Timestamp)
-	log.Info().Msg("Version:\t\t" + cnquery.GetVersion() + " (API Version: " + cnquery.APIVersion() + ")")
 	if latestVersion != "" {
 		log.Info().Msg("Latest Version:\t" + latestVersion)
 

--- a/apps/cnquery/cmd/status.go
+++ b/apps/cnquery/cmd/status.go
@@ -157,12 +157,19 @@ func (s Status) RenderCliStatus() {
 		log.Warn().Msg("could not determine client platform information")
 	}
 
+	latestVersion, err := cnquery.GetLatestVersion()
+	if err != nil {
+		log.Warn().Msg("failed to get latest version")
+	}
+
 	log.Info().Msg("Time:\t\t\t" + s.Client.Timestamp)
 	log.Info().Msg("Version:\t\t" + cnquery.GetVersion() + " (API Version: " + cnquery.APIVersion() + ")")
-	log.Info().Msg("Latest Version:\t" + cnquery.GetLatestVersion())
+	if latestVersion != "" {
+		log.Info().Msg("Latest Version:\t" + latestVersion)
 
-	if cnquery.GetVersion() != cnquery.GetLatestVersion() {
-		log.Warn().Msg("A newer version is available")
+		if cnquery.GetVersion() != latestVersion && cnquery.GetVersion() != "unstable" {
+			log.Warn().Msg("A newer version is available")
+		}
 	}
 
 	log.Info().Msg("API ConnectionConfig:\t" + s.Upstream.API.Endpoint)

--- a/cnquery.go
+++ b/cnquery.go
@@ -52,9 +52,10 @@ type Release struct {
 	Name string `json:"name"`
 }
 
+var cnqueryGithubReleaseUrl = "https://api.github.com/repos/mondoohq/cnquery/releases/latest"
+
 // GetLatestReleaseName fetches the name of the latest release from the specified GitHub repository
-func GetLatestReleaseName() (string, error) {
-	url := "https://api.github.com/repos/mondoohq/cnquery/releases/latest"
+func GetLatestReleaseName(url string) (string, error) {
 	resp, err := http.Get(url)
 	if err != nil {
 		return "", fmt.Errorf("error fetching latest release: %v", err)
@@ -79,13 +80,13 @@ func GetLatestReleaseName() (string, error) {
 }
 
 // GetLatestVersion returns the latest version available on Github
-func GetLatestVersion() string {
-	releaseName, err := GetLatestReleaseName()
+func GetLatestVersion() (string, error) {
+	releaseName, err := GetLatestReleaseName(cnqueryGithubReleaseUrl)
 	if err != nil {
-		panic(err)
+		return "", err
 	}
 	cleanVersion := strings.TrimPrefix(releaseName, "v")
-	return cleanVersion
+	return cleanVersion, nil
 }
 
 var coreSemverRegex = regexp.MustCompile(`^(\d+.\d+.\d+)`)

--- a/cnquery.go
+++ b/cnquery.go
@@ -4,7 +4,12 @@
 package cnquery
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
 	"regexp"
+	"strings"
 )
 
 // Version is set via ldflags
@@ -40,6 +45,47 @@ func GetVersion() string {
 		return "unstable"
 	}
 	return Version
+}
+
+// Release represents a GitHub release
+type Release struct {
+	Name string `json:"name"`
+}
+
+// GetLatestReleaseName fetches the name of the latest release from the specified GitHub repository
+func GetLatestReleaseName() (string, error) {
+	url := "https://api.github.com/repos/mondoohq/cnquery/releases/latest"
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("error fetching latest release: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("received non-OK response status: %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading response body: %v", err)
+	}
+
+	var release Release
+	if err := json.Unmarshal(body, &release); err != nil {
+		return "", fmt.Errorf("error unmarshalling response: %v", err)
+	}
+
+	return release.Name, nil
+}
+
+// GetLatestVersion returns the latest version available on Github
+func GetLatestVersion() string {
+	releaseName, err := GetLatestReleaseName()
+	if err != nil {
+		panic(err)
+	}
+	cleanVersion := strings.TrimPrefix(releaseName, "v")
+	return cleanVersion
 }
 
 var coreSemverRegex = regexp.MustCompile(`^(\d+.\d+.\d+)`)


### PR DESCRIPTION
This adds a new output to `cnquery status` which shows the version number of the latest release available on github and shows a hint that a newer version is available if it the currently installed version and the latest version don't match.

```
./cnquery status
→ no Mondoo configuration file provided, using defaults
→ Platform:             ubuntu
→ Version:              22.04
→ Hostname:             mondoopad
→ IP:                   192.168.178.32
→ Time:                 2023-11-01T13:36:01+01:00
→ Version:              unstable (API Version: unstable)
→ Latest Version:       9.4.0
! A newer version is available
→ API ConnectionConfig: https://us.api.mondoo.com
→ API Status:           SERVING
→ API Time:             2023-11-01T12:36:02Z
→ API Version:          9
```

Related to: https://github.com/mondoohq/cnspec/issues/887