### PR TITLE
⭐️ support PKIX certificate Subject Alternative Name extension

### DIFF
--- a/providers/network/resources/certificates/extensions.go
+++ b/providers/network/resources/certificates/extensions.go
@@ -1,0 +1,149 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BSD-3-Clause
+package certificates
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+	"golang.org/x/crypto/cryptobyte"
+	cryptobyte_asn1 "golang.org/x/crypto/cryptobyte/asn1"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// This code is based on the x509 parser from the Go standard library:
+// https://github.com/golang/go/blob/master/src/crypto/x509/parser.go
+// License of the Go standard library: BSD 3-Clause "New" or "Revised" License
+var OIDExtensionSubjectAltName = asn1.ObjectIdentifier{2, 5, 29, 17}
+
+const (
+	nameTypeEmail = 1
+	nameTypeDNS   = 2
+	nameTypeURI   = 6
+	nameTypeIP    = 7
+)
+
+func isIA5String(s string) error {
+	for _, r := range s {
+		// Per RFC5280 "IA5String is limited to the set of ASCII characters"
+		if r > unicode.MaxASCII {
+			return fmt.Errorf("x509: %q cannot be encoded as an IA5String", s)
+		}
+	}
+
+	return nil
+}
+
+func GetSanExtension(cert *x509.Certificate) *pkix.Extension {
+	for _, ext := range cert.Extensions {
+		if ext.Id.Equal(OIDExtensionSubjectAltName) {
+			return &ext
+		}
+	}
+
+	return nil
+}
+
+func forEachSAN(der cryptobyte.String, callback func(tag int, data []byte) error) error {
+	if !der.ReadASN1(&der, cryptobyte_asn1.SEQUENCE) {
+		return errors.New("x509: invalid subject alternative names")
+	}
+	for !der.Empty() {
+		var san cryptobyte.String
+		var tag cryptobyte_asn1.Tag
+		if !der.ReadAnyASN1(&san, &tag) {
+			return errors.New("x509: invalid subject alternative name")
+		}
+		if err := callback(int(tag^0x80), san); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ParseSANExtension(der cryptobyte.String) (dnsNames, emailAddresses []string, ipAddresses []net.IP, uris []*url.URL, err error) {
+	err = forEachSAN(der, func(tag int, data []byte) error {
+		switch tag {
+		case nameTypeEmail:
+			email := string(data)
+			if err := isIA5String(email); err != nil {
+				return errors.New("x509: SAN rfc822Name is malformed")
+			}
+			emailAddresses = append(emailAddresses, email)
+		case nameTypeDNS:
+			name := string(data)
+			if err := isIA5String(name); err != nil {
+				return errors.New("x509: SAN dNSName is malformed")
+			}
+			dnsNames = append(dnsNames, string(name))
+		case nameTypeURI:
+			uriStr := string(data)
+			if err := isIA5String(uriStr); err != nil {
+				return errors.New("x509: SAN uniformResourceIdentifier is malformed")
+			}
+			uri, err := url.Parse(uriStr)
+			if err != nil {
+				return fmt.Errorf("x509: cannot parse URI %q: %s", uriStr, err)
+			}
+			if len(uri.Host) > 0 {
+				if _, ok := domainToReverseLabels(uri.Host); !ok {
+					return fmt.Errorf("x509: cannot parse URI %q: invalid domain", uriStr)
+				}
+			}
+			uris = append(uris, uri)
+		case nameTypeIP:
+			switch len(data) {
+			case net.IPv4len, net.IPv6len:
+				ipAddresses = append(ipAddresses, data)
+			default:
+				return errors.New("x509: cannot parse IP address of length " + strconv.Itoa(len(data)))
+			}
+		}
+
+		return nil
+	})
+
+	return
+}
+
+// domainToReverseLabels converts a textual domain name like foo.example.com to
+// the list of labels in reverse order, e.g. ["com", "example", "foo"].
+func domainToReverseLabels(domain string) (reverseLabels []string, ok bool) {
+	for len(domain) > 0 {
+		if i := strings.LastIndexByte(domain, '.'); i == -1 {
+			reverseLabels = append(reverseLabels, domain)
+			domain = ""
+		} else {
+			reverseLabels = append(reverseLabels, domain[i+1:])
+			domain = domain[:i]
+		}
+	}
+
+	if len(reverseLabels) > 0 && len(reverseLabels[0]) == 0 {
+		// An empty label at the end indicates an absolute value.
+		return nil, false
+	}
+
+	for _, label := range reverseLabels {
+		if len(label) == 0 {
+			// Empty labels are otherwise invalid.
+			return nil, false
+		}
+
+		for _, c := range label {
+			if c < 33 || c > 126 {
+				// Invalid character.
+				return nil, false
+			}
+		}
+	}
+
+	return reverseLabels, true
+}

--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -197,6 +197,8 @@ certificate @defaults("serial subject.commonName subject.dn") {
   revokedAt() time
   // Indicates if the certificate is valid by checking its chain
   isVerified() bool
+  // SAN extension value params
+  sanExtension() pkix.sanExtension
 }
 
 // x509 certificate PKIX name
@@ -234,6 +236,20 @@ pkix.extension {
   critical bool
   // Extension value
   value string
+}
+
+// x509 certificate PKIX Subject Alternative Name extension
+private pkix.sanExtension @defaults("dnsNames") {
+	// x509 certificate PKIX extension
+	extension pkix.extension
+	// DNS names
+	dnsNames []string
+	// IP addresses
+	ipAddresses []string
+	// Email addresses
+	emailAddresses []string
+	// URIs
+	uris []string
 }
 
 private openpgp.entities {

--- a/providers/network/resources/network.lr.manifest.yaml
+++ b/providers/network/resources/network.lr.manifest.yaml
@@ -23,6 +23,10 @@ resources:
       pem: {}
       policyIdentifier: {}
       revokedAt: {}
+      san:
+        min_mondoo_version: latest
+      sanExtension:
+        min_mondoo_version: latest
       serial: {}
       signature: {}
       signingAlgorithm: {}
@@ -208,6 +212,22 @@ resources:
       serialNumber: {}
       streetAddress: {}
     min_mondoo_version: 5.15.0
+  pkix.sanExtension:
+    fields:
+      dnsNames: {}
+      emailAddresses: {}
+      extension: {}
+      ipAddresses: {}
+      uris: {}
+    is_private: true
+    min_mondoo_version: latest
+  sanExtensionParams:
+    fields:
+      dnsNames: {}
+      emailAddresses: {}
+      extension: {}
+      ipAddresses: {}
+    min_mondoo_version: latest
   socket:
     fields:
       address: {}


### PR DESCRIPTION
```
cnspec shell host google.com    
cnspec> tls.certificates { sanExtension { * }}
cnspec> tls.certificates { sanExtension { * }}
tls.certificates: [
  0: {
    sanExtension: {
      uris: []
      extension: pkix.extension id = 5842ac625349147af543f8049f60497ca270c0412667bbeb1042482e805069f9:2.5.29.17
      emailAddresses: []
      dnsNames: [
        0: "*.google.com"
        1: "*.appengine.google.com"
        2: "*.bdn.dev"
        3: "*.origin-test.bdn.dev"
        4: "*.cloud.google.com"
        5: "*.crowdsource.google.com"
        6: "*.datacompute.google.com"
        7: "*.google.ca"
        8: "*.google.cl"
        9: "*.google.co.in"
        10: "*.google.co.jp"
        11: "*.google.co.uk"
        12: "*.google.com.ar"
        13: "*.google.com.au"
        14: "*.google.com.br"
        15: "*.google.com.co"
        16: "*.google.com.mx"
        17: "*.google.com.tr"
        18: "*.google.com.vn"
...
      ]
    }
  }
  1: {
    sanExtension: null
  }
  2: {
    sanExtension: null
  }
]
```