### PR TITLE
✨ cnquery status show installed providers

### DIFF
--- a/apps/cnquery/cmd/status.go
+++ b/apps/cnquery/cmd/status.go
@@ -160,11 +160,12 @@ func (s Status) RenderCliStatus() {
 	log.Info().Msg("Time:\t\t" + s.Client.Timestamp)
 	log.Info().Msg("Version:\t" + cnquery.GetVersion() + " (API Version: " + cnquery.APIVersion() + ")")
 
-	providers, err := getProviders()
+	installed, outdated, err := getProviders()
 	if err != nil {
-		log.Warn().Msg("failed to get provider info")
+		log.Warn().Err(err).Msg("failed to get provider info")
 	}
-	log.Info().Msg("Providers:\t" + strings.Join(providers, " | "))
+	log.Info().Msg("Installed Providers:\t" + strings.Join(installed, " | "))
+	log.Info().Msg("Outdated Providers:\t" + strings.Join(outdated, " | "))
 
 	log.Info().Msg("API ConnectionConfig:\t" + s.Upstream.API.Endpoint)
 	log.Info().Msg("API Status:\t" + s.Upstream.API.Status)
@@ -220,16 +221,24 @@ func (s Status) RenderYaml() {
 	os.Stdout.Write(output)
 }
 
-func getProviders() ([]string, error) {
-	var res []string
+func getProviders() ([]string, []string, error) {
+	var installed []string
+	var outdated []string
 
 	allProviders, err := providers.ListActive()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	for _, provider := range allProviders {
-		res = append(res, provider.Name)
+		installed = append(installed, provider.Name)
+		latestVersion, err := providers.LatestVersion(provider.Name)
+		if err != nil {
+			continue
+		}
+		if latestVersion != provider.Version {
+			outdated = append(outdated, provider.Name)
+		}
 	}
 
-	return res, nil
+	return installed, outdated, nil
 }

--- a/apps/cnquery/cmd/status.go
+++ b/apps/cnquery/cmd/status.go
@@ -160,6 +160,12 @@ func (s Status) RenderCliStatus() {
 	log.Info().Msg("Time:\t\t" + s.Client.Timestamp)
 	log.Info().Msg("Version:\t" + cnquery.GetVersion() + " (API Version: " + cnquery.APIVersion() + ")")
 
+	providers, err := getProviders()
+	if err != nil {
+		log.Warn().Msg("failed to get provider info")
+	}
+	log.Info().Msg("Providers:\t" + strings.Join(providers, " | "))
+
 	log.Info().Msg("API ConnectionConfig:\t" + s.Upstream.API.Endpoint)
 	log.Info().Msg("API Status:\t" + s.Upstream.API.Status)
 	log.Info().Msg("API Time:\t" + s.Upstream.API.Timestamp)
@@ -212,4 +218,18 @@ func (s Status) RenderYaml() {
 		log.Error().Err(err).Msg("could not generate yaml")
 	}
 	os.Stdout.Write(output)
+}
+
+func getProviders() ([]string, error) {
+	var res []string
+
+	allProviders, err := providers.ListActive()
+	if err != nil {
+		return nil, err
+	}
+	for _, provider := range allProviders {
+		res = append(res, provider.Name)
+	}
+
+	return res, nil
 }


### PR DESCRIPTION
https://github.com/mondoohq/cnspec/issues/887

Related to: #2439 

Example:
```
./cnquery status
→ no Mondoo configuration file provided, using defaults
→ Platform:     ubuntu
→ Version:      22.04
→ Hostname:     mondoopad
→ IP:           192.168.178.32
→ Time:         2023-11-02T09:13:47+01:00
→ Version:      unstable (API Version: unstable)
→ Providers:    azure | core | os | gcp | network | vsphere | github | okta | gitlab | google-workspace | opcua | ipmi | slack | arista | equinix | k8s | oci | mock | ms365 | terraform | aws
→ API ConnectionConfig: https://us.api.mondoo.com
→ API Status:   SERVING
→ API Time:     2023-11-02T08:13:47Z
→ API Version:  9
! API versions do not match, please update the client
```