### PR TITLE
Ignore assets with no platform. Ensure container registry assets have a platform

### DIFF
--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -267,17 +267,21 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 			}
 		}
 		runtime.SetRecording(candidate.runtime.Recording)
-
 		err = runtime.Connect(&plugin.ConnectReq{
 			Features: config.Features,
 			Asset:    candidate.asset,
 			Upstream: upstream,
 		})
+
 		if err != nil {
 			log.Error().Err(err).Str("asset", candidate.asset.Name).Msg("unable to connect to asset")
 			continue
 		}
 
+		if candidate.asset.GetPlatform() == nil {
+			log.Error().Msgf("unable to detect platform for asset " + candidate.asset.Name)
+			continue
+		}
 		assets = append(assets, &assetWithRuntime{
 			asset:   candidate.asset,
 			runtime: runtime,

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -558,6 +558,10 @@ func (s *Service) discoverRegistry(conn *connection.TarConnection) (*inventory.I
 	}
 
 	inventory := &inventory.Inventory{}
+	// we detect the platform for each asset we discover here
+	for _, a := range resolvedAssets {
+		_ = s.detect(a, conn)
+	}
 	inventory.AddAssets(resolvedAssets...)
 
 	return inventory, nil

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -560,6 +560,7 @@ func (s *Service) discoverRegistry(conn *connection.TarConnection) (*inventory.I
 	inventory := &inventory.Inventory{}
 	// we detect the platform for each asset we discover here
 	for _, a := range resolvedAssets {
+		// ignore the error. we will retry detection if we connect to the asset
 		_ = s.detect(a, conn)
 	}
 	inventory.AddAssets(resolvedAssets...)


### PR DESCRIPTION
Mimic cnspec and ensure we only scan assets with platforms. Use the OS provider's detect to make sure inventory assets have a platform.

This fixes #2390