### PR TITLE
🐛 ensure we use the connection asset so we do not lose info from connect call

### DIFF
--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -212,6 +212,7 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 			log.Error().Err(err).Msg("unable to connect to asset")
 			continue
 		}
+		asset = runtime.Provider.Connection.Asset // to ensure we get all the information the connect call gave us
 
 		// for all discovered assets, we apply mondoo-specific labels and annotations that come from the root asset
 		for _, a := range runtime.Provider.Connection.GetInventory().GetSpec().GetAssets() {
@@ -272,6 +273,7 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 			Asset:    candidate.asset,
 			Upstream: upstream,
 		})
+		candidate.asset = runtime.Provider.Connection.Asset // to ensure we get all the information the connect call gave us
 
 		if err != nil {
 			log.Error().Err(err).Str("asset", candidate.asset.Name).Msg("unable to connect to asset")


### PR DESCRIPTION
i found that we had the name in the provider runtime code, but when we popped back out to the local scanner code the asset did not have a name. this sets the asset to the one set by the connection, which should have the info we want

DO NOT use builtin provider to test this - things work without this change with the builtin provider. 

easiest way to test is ssh scan to linux machine - you should see a valid instance id, e.g. `i-9038439043`