### PR TITLE
🐛 fix certificate extensions ids

### DIFF
--- a/providers/network/resources/certificates.go
+++ b/providers/network/resources/certificates.go
@@ -56,9 +56,10 @@ func pkixnameToMql(runtime *plugin.Runtime, name pkix.Name, id string) (*mqlPkix
 	return r.(*mqlPkixName), nil
 }
 
-func pkixextensionToMql(runtime *plugin.Runtime, ext pkix.Extension, id string) (*mqlPkixExtension, error) {
+func pkixextensionToMql(runtime *plugin.Runtime, ext pkix.Extension, fingerprint string, id string) (*mqlPkixExtension, error) {
 	r, err := CreateResource(runtime, "pkix.extension", map[string]*llx.RawData{
-		"identifier": llx.StringData(id),
+		"id":         llx.StringData(id),
+		"identifier": llx.StringData(fingerprint + ":" + id),
 		"critical":   llx.BoolData(ext.Critical),
 		"value":      llx.StringData(string(ext.Value)),
 	})
@@ -332,7 +333,7 @@ func (s *mqlCertificate) extensions() ([]interface{}, error) {
 	fingerprint := hex.EncodeToString(certificates.Sha256Hash(cert))
 	for i := range cert.Extensions {
 		extension := cert.Extensions[i]
-		ext, err := pkixextensionToMql(s.MqlRuntime, extension, fingerprint+":"+extension.Id.String())
+		ext, err := pkixextensionToMql(s.MqlRuntime, extension, fingerprint, extension.Id.String())
 		if err != nil {
 			return nil, err
 		}
@@ -354,7 +355,7 @@ func (s *mqlCertificate) sanExtension() (*mqlPkixSanExtension, error) {
 		return nil, nil
 	}
 
-	ext, err := pkixextensionToMql(s.MqlRuntime, *extension, fingerprint+":"+extension.Id.String())
+	ext, err := pkixextensionToMql(s.MqlRuntime, *extension, fingerprint, extension.Id.String())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -229,7 +229,9 @@ pkix.name @defaults("id dn commonName") {
 }
 
 // x509 certificate PKIX extension
-pkix.extension {
+pkix.extension @defaults("id") {
+  // ID
+  id string
   // Extension identifier
   identifier string
   // Flag for critical extension

--- a/providers/network/resources/network.lr.go
+++ b/providers/network/resources/network.lr.go
@@ -444,6 +444,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"pkix.name.extraNames": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPkixName).GetExtraNames()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"pkix.extension.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPkixExtension).GetId()).ToDataRes(types.String)
+	},
 	"pkix.extension.identifier": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPkixExtension).GetIdentifier()).ToDataRes(types.String)
 	},
@@ -1045,6 +1048,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 			r.(*mqlPkixExtension).__id, ok = v.Value.(string)
 			return
 		},
+	"pkix.extension.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPkixExtension).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"pkix.extension.identifier": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlPkixExtension).Identifier, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -2610,6 +2617,7 @@ type mqlPkixExtension struct {
 	MqlRuntime *plugin.Runtime
 	__id string
 	// optional: if you define mqlPkixExtensionInternal it will be used here
+	Id plugin.TValue[string]
 	Identifier plugin.TValue[string]
 	Critical plugin.TValue[bool]
 	Value plugin.TValue[string]
@@ -2650,6 +2658,10 @@ func (c *mqlPkixExtension) MqlName() string {
 
 func (c *mqlPkixExtension) MqlID() string {
 	return c.__id
+}
+
+func (c *mqlPkixExtension) GetId() *plugin.TValue[string] {
+	return &c.Id
 }
 
 func (c *mqlPkixExtension) GetIdentifier() *plugin.TValue[string] {

--- a/providers/network/resources/network.lr.manifest.yaml
+++ b/providers/network/resources/network.lr.manifest.yaml
@@ -193,6 +193,8 @@ resources:
   pkix.extension:
     fields:
       critical: {}
+      id:
+        min_mondoo_version: latest
       identifier: {}
       value: {}
     min_mondoo_version: 5.15.0


### PR DESCRIPTION
https://github.com/mondoohq/cnquery/issues/2445

```
./cnquery shell host mondoo.com
! using builtin provider for network
! using builtin provider for network
→ no Mondoo configuration file provided, using defaults
→ connected to Network API
  ___ _ __   __ _ _   _  ___ _ __ _   _
 / __| '_ \ / _` | | | |/ _ \ '__| | | |
| (__| | | | (_| | |_| |  __/ |  | |_| |
 \___|_| |_|\__, |\__,_|\___|_|   \__, |
  mondoo™      |_|                |___/  interactive shell

cnquery> tls.certificates.first.extensions
tls.certificates.first.extensions: [
  0: pkix.extension id="2.5.29.15"
  1: pkix.extension id="2.5.29.37"
  2: pkix.extension id="2.5.29.19"
  3: pkix.extension id="2.5.29.14"
  4: pkix.extension id="2.5.29.35"
  5: pkix.extension id="1.3.6.1.5.5.7.1.1"
  6: pkix.extension id="2.5.29.17"
  7: pkix.extension id="2.5.29.32"
  8: pkix.extension id="2.5.29.31"
  9: pkix.extension id="1.3.6.1.4.1.11129.2.4.2"
]
cnquery> tls.certificates.first.extensions.first.identifier
tls.certificates.first.extensions.first.identifier: "3d4d8713c7748d3e5b44d3d5f0f500ba4bf78cc860d54206a9499488680de5b1:2.5.29.15"
```