### PR TITLE
🐛 tls extension value parsing

### DIFF
--- a/providers/network/resources/certificates.go
+++ b/providers/network/resources/certificates.go
@@ -96,6 +96,9 @@ func ExtensionValueToReadableFormat(ext pkix.Extension) (string, error) {
 
 func pkixextensionToMql(runtime *plugin.Runtime, ext pkix.Extension, fingerprint string, id string) (*mqlPkixExtension, error) {
 	value, err := ExtensionValueToReadableFormat(ext)
+	if err != nil {
+		value = string(ext.Value)
+	}
 	r, err := CreateResource(runtime, "pkix.extension", map[string]*llx.RawData{
 		"id":         llx.StringData(id),
 		"identifier": llx.StringData(fingerprint + ":" + id),

--- a/providers/network/resources/certificates.go
+++ b/providers/network/resources/certificates.go
@@ -10,7 +10,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -76,6 +75,18 @@ func ExtensionValueToReadableFormat(ext pkix.Extension) (string, error) {
 			}
 
 			readableValue = strings.Join(pairs, ":")
+		}
+	case ext.Id.Equal(asn1.ObjectIdentifier{2, 5, 29, 17}): // Subject Alternative Name
+		var rawValues []asn1.RawValue
+		if _, err := asn1.Unmarshal(ext.Value, &rawValues); err != nil {
+			log.Error().Err(err).Msg("Error unmarshalling Subject Alternative Name")
+		} else {
+			log.Debug().Msg("Extension Identified as Subject Alternative Name")
+			var sans []string
+			for _, raw := range rawValues {
+				sans = append(sans, string(raw.Bytes))
+			}
+			readableValue = strings.Join(sans, " | ")
 		}
 	default:
 		log.Debug().Msg("Unknown or unhandled extension")

--- a/providers/network/resources/certificates.go
+++ b/providers/network/resources/certificates.go
@@ -64,7 +64,7 @@ func ExtensionValueToReadableFormat(ext pkix.Extension) (string, error) {
 	case ext.Id.Equal(asn1.ObjectIdentifier{2, 5, 29, 14}): // Subject Key Identifier
 		var subjectKeyID []byte
 		if _, err := asn1.Unmarshal(ext.Value, &subjectKeyID); err != nil {
-			log.Error().Err(err).Msg("Error unmarshalling Subject Key ID")
+			log.Warn().Err(err).Msg("Error unmarshalling Subject Key ID")
 		} else {
 			log.Debug().Msg("Extension Identified as Subject Key ID")
 			hexString := strings.ToUpper(hex.EncodeToString(subjectKeyID))
@@ -79,7 +79,7 @@ func ExtensionValueToReadableFormat(ext pkix.Extension) (string, error) {
 	case ext.Id.Equal(asn1.ObjectIdentifier{2, 5, 29, 17}): // Subject Alternative Name
 		var rawValues []asn1.RawValue
 		if _, err := asn1.Unmarshal(ext.Value, &rawValues); err != nil {
-			log.Error().Err(err).Msg("Error unmarshalling Subject Alternative Name")
+			log.Warn().Err(err).Msg("Error unmarshalling Subject Alternative Name")
 		} else {
 			log.Debug().Msg("Extension Identified as Subject Alternative Name")
 			var sans []string

--- a/providers/network/resources/certificates_test.go
+++ b/providers/network/resources/certificates_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package resources
 
 import (

--- a/providers/network/resources/certificates_test.go
+++ b/providers/network/resources/certificates_test.go
@@ -1,0 +1,59 @@
+package resources
+
+import (
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"testing"
+)
+
+func TestExtensionValueToReadableFormat(t *testing.T) {
+	// ASN.1-encoded DNS name "example.com" for the SAN extension.
+	sanValue, err := asn1.Marshal([]asn1.RawValue{
+		{
+			Tag:   asn1.TagIA5String, // TagIA5String is commonly used for DNS names
+			Bytes: []byte("example.com"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Error marshaling test SAN value: %v", err)
+	}
+
+	testCases := []struct {
+		name        string
+		extension   pkix.Extension
+		want        string
+		expectError bool
+	}{
+		{
+			name: "SubjectKeyIdentifier",
+			extension: pkix.Extension{
+				Id:    asn1.ObjectIdentifier{2, 5, 29, 14},
+				Value: []byte{0x04, 0x04, 0xDE, 0xAD, 0xBE, 0xEF},
+			},
+			want:        "DE:AD:BE:EF",
+			expectError: false,
+		},
+		{
+			name: "SubjectAlternativeName",
+			extension: pkix.Extension{
+				Id:    asn1.ObjectIdentifier{2, 5, 29, 17},
+				Value: sanValue,
+			},
+			want:        "example.com",
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ExtensionValueToReadableFormat(tc.extension)
+			if (err != nil) != tc.expectError {
+				t.Errorf("ExtensionValueToReadableFormat() for test '%v' unexpected error = %v", tc.name, err)
+				return
+			}
+			if got != tc.want {
+				t.Errorf("ExtensionValueToReadableFormat() for test '%v' = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/mondoohq/cnquery/issues/2445

The problem is that there are many potential extensions, some which are quite niche. 
We should at least implement parsing for the most common ones.

This PR covers:

- [x] Subject Key Identifier (SKID)
- [x] Subject Alternative Names (SAN)