### PR TITLE
🧹 fix error reporting for os.exit

### DIFF
--- a/apps/cnquery/cmd/bundle.go
+++ b/apps/cnquery/cmd/bundle.go
@@ -129,6 +129,8 @@ var queryPackLintCmd = &cobra.Command{
 			for i := range errors {
 				fmt.Fprintf(os.Stderr, stringx.Indent(2, errors[i]))
 			}
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
 			return cli_errors.ExitCode1WithoutError
 		}
 
@@ -165,6 +167,8 @@ var queryPackPublishCmd = &cobra.Command{
 			for i := range bundleErrors {
 				fmt.Fprintf(os.Stderr, stringx.Indent(2, bundleErrors[i]))
 			}
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
 			return cli_errors.ExitCode1WithoutError
 		}
 		log.Info().Msg("valid query pack")

--- a/apps/cnquery/cmd/status.go
+++ b/apps/cnquery/cmd/status.go
@@ -120,6 +120,8 @@ Status sends a ping to Mondoo Platform to verify the credentials.
 		}
 
 		if !s.Client.Registered || s.Client.PingPongError != nil {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
 			return cli_errors.ExitCode1WithoutError
 		}
 		return nil


### PR DESCRIPTION
we need to suppress the errors and usage if we want to keep the behaviour the same as pre-#2379

Fixes #2440