### PR TITLE
Fixes capitalization of resources for docs

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -4,7 +4,7 @@ import "../../network/resources/network.lr"
 option provider = "go.mondoo.com/cnquery/v9/providers/aws"
 option go_package = "go.mondoo.com/cnquery/v9/providers/aws/resources"
 
-// AWS Resource
+// AWS resource
 aws @defaults("account.id") {
   // List of `aws.vpc` objects representing all VPCs in the account across all enabled regions
   vpcs() []aws.vpc
@@ -62,7 +62,7 @@ private aws.vpc @defaults("id isDefault cidrBlock region") {
   tags map[string]string
 }
 
-// Amazon Virtual Private Cloud (VPC) Route Table
+// Amazon Virtual Private Cloud (VPC) route table
 private aws.vpc.routetable @defaults("id routes.length") {
   // Unique ID of the route table
   id string
@@ -70,7 +70,7 @@ private aws.vpc.routetable @defaults("id routes.length") {
   routes []dict
 }
 
-// Amazon Virtual Private Cloud (VPC) Subnet
+// Amazon Virtual Private Cloud (VPC) subnet
 private aws.vpc.subnet @defaults("id cidrs availabilityZone defaultForAvailabilityZone") {
   // ARN of the subnet
   arn string
@@ -86,7 +86,7 @@ private aws.vpc.subnet @defaults("id cidrs availabilityZone defaultForAvailabili
   defaultForAvailabilityZone bool
 }
 
-// Amazon Virtual Private Cloud (VPC) Endpoint
+// Amazon Virtual Private Cloud (VPC) endpoint
 private aws.vpc.endpoint @defaults("id type region") {
   // Unique ID of the endpoint
   id string
@@ -104,7 +104,7 @@ private aws.vpc.endpoint @defaults("id type region") {
   subnets []string
 }
 
-// Amazon Virtual Private Cloud (VPC) Flow Log
+// Amazon Virtual Private Cloud (VPC) flow log
 private aws.vpc.flowlog @defaults("id region status") {
   // Unique ID of the flow log
   id string
@@ -118,13 +118,13 @@ private aws.vpc.flowlog @defaults("id region status") {
   tags map[string]string
 }
 
-// AWS IAM Access Analyzer resource for assessing the configuration of AWS IAM Access Analyzer
+// AWS IAM Access Analyzer resource (for assessing the configuration of AWS IAM Access Analyzer)
 aws.accessAnalyzer @defaults("analyzers") {
   // List of `aws.accessanalyzer.analyzer` objects for all AWS IAM Access Analyzers configured within the account 
   analyzers() []aws.accessanalyzer.analyzer
 }
 
-// AWS IAM Access Analyzer resource provides an object representing an individual AWS IAM Access Analyzer configuration
+// AWS IAM Access Analyzer resource (provides an object representing an individual AWS IAM Access Analyzer configuration)
 private aws.accessanalyzer.analyzer @defaults("name type status") {
   // ARN for the analyzer
   arn string
@@ -138,13 +138,13 @@ private aws.accessanalyzer.analyzer @defaults("name type status") {
   tags map[string]string
 }
 
-// AWS Elastic File System (EFS) Service
+// AWS Elastic File System (EFS) service
 aws.efs @defaults("filesystems") {
   // A list of file systems managed by the service
   filesystems() []aws.efs.filesystem
 }
 
-// AWS Elastic File System (EFS) Filesystem
+// AWS Elastic File System (EFS) filesystem
 private aws.efs.filesystem @defaults("name id region") {
   // Name of the file system
   name string
@@ -174,7 +174,7 @@ aws.kms @defaults("keys") {
   keys() []aws.kms.key
 }
 
-// AWS Key Management Service (KMS) Key
+// AWS Key Management Service (KMS) key
 private aws.kms.key @defaults("id region metadata.Description") {
   // Unique identifier for the key
   id string
@@ -271,7 +271,7 @@ private aws.iam.usercredentialreportentry @defaults("arn") {
   userCreationTime() time
 }
 
-// AWS IAM User
+// AWS IAM user
 private aws.iam.user @defaults("arn name") {
   // ARN of the IAM user 
   arn string
@@ -295,7 +295,7 @@ private aws.iam.user @defaults("arn name") {
   accessKeys() []dict
 }
 
-// AWS IAM Policy
+// AWS IAM policy
 private aws.iam.policy @defaults("arn name") {
   // ARN of the policy
   arn string
@@ -328,7 +328,7 @@ private aws.iam.policy @defaults("arn name") {
   attachedGroups() []aws.iam.group
 }
 
-// AWS IAM Policy Version
+// AWS IAM policy version
 private aws.iam.policyversion @defaults("arn isDefaultVersion") {
   // ARN of the policy version
   arn string
@@ -342,7 +342,7 @@ private aws.iam.policyversion @defaults("arn isDefaultVersion") {
   createDate time
 }
 
-// AWS IAM Role
+// AWS IAM role
 private aws.iam.role @defaults("arn name") {
   // ARN of the role
   arn string
@@ -358,7 +358,7 @@ private aws.iam.role @defaults("arn name") {
   createDate time
 }
 
-// AWS IAM Group
+// AWS IAM group
 private aws.iam.group @defaults("arn name") {
   // ARN of the group
   arn string
@@ -372,7 +372,7 @@ private aws.iam.group @defaults("arn name") {
   usernames []string
 }
 
-// AWS IAM Virtual MFA Device
+// AWS IAM virtual MFA device
 private aws.iam.virtualmfadevice @defaults("serialNumber") {
   // Serial number for the MFA device
   serialNumber string
@@ -390,7 +390,7 @@ aws.sagemaker {
   notebookInstances() []aws.sagemaker.notebookinstance
 }
 
-// AWS SageMaker Notebook Instance
+// AWS SageMaker notebook instance
 private aws.sagemaker.notebookinstance @defaults("arn name") {
   // ARN for the notebook instance
   arn string
@@ -404,7 +404,7 @@ private aws.sagemaker.notebookinstance @defaults("arn name") {
   tags map[string]string
 }
 
-// AWS SageMaker Notebook Instance Details
+// AWS SageMaker notebook instance details
 private aws.sagemaker.notebookinstance.details @defaults("arn") {
   // ARN for the notebook instance
   arn string
@@ -414,7 +414,7 @@ private aws.sagemaker.notebookinstance.details @defaults("arn") {
   directInternetAccess string
 }
 
-// AWS SageMaker Endpoint
+// AWS SageMaker endpoint
 private aws.sagemaker.endpoint @defaults("arn name") {
   // ARN for the endpoint
   arn string
@@ -434,7 +434,7 @@ aws.sns {
   topics() []aws.sns.topic
 }
 
-// AWS Simple Notification Service (SNS) Topic
+// AWS Simple Notification Service (SNS) topic
 private aws.sns.topic @defaults("arn") {
   // SNS topic ARN
   arn string
@@ -448,7 +448,7 @@ private aws.sns.topic @defaults("arn") {
   tags() map[string]string
 }
 
-// AWS Simple Notification Service (SNS) Subscription
+// AWS Simple Notification Service (SNS) subscription
 private aws.sns.subscription @defaults("arn") {
   // ARN of the subscription
   arn string
@@ -456,13 +456,13 @@ private aws.sns.subscription @defaults("arn") {
   protocol string
 }
 
-// AWS Elasticsearch Service
+// AWS Elasticsearch service
 aws.es {
   // List of Elasticsearch domains
   domains() []aws.es.domain
 }
 
-// Amazon Elasticsearch Service Domain
+// Amazon Elasticsearch service domain
 private aws.es.domain @defaults("arn name") {
   // ARN for the Elasticsearch domain
   arn string
@@ -486,13 +486,13 @@ private aws.es.domain @defaults("arn name") {
   domainName string
 }
 
-// AWS Certificate Manager resource for assessing the configuration of AWS Certificate Manager
+// AWS Certificate Manager resource (for assessing the configuration of AWS Certificate Manager)
 aws.acm {
   // List of `aws.acm.certificate` objects representing ACM certificates configured within the account
   certificates() []aws.acm.certificate
 }
 
-// AWS Certificate Manager Certificate resource provides an object representing an individual ACM certificate
+// AWS Certificate Manager Certificate resource (provides an object representing an individual ACM certificate)
 private aws.acm.certificate @defaults("arn domainName") {
   // ARN for the certificate
   arn string
@@ -520,7 +520,7 @@ aws.autoscaling {
   groups() []aws.autoscaling.group
 }
 
-// AWS Auto Scaling Group
+// AWS Auto Scaling group
 private aws.autoscaling.group @defaults("arn name") {
   // ARN for the autoscaling group
   arn string
@@ -542,7 +542,7 @@ aws.elb {
   loadBalancers() []aws.elb.loadbalancer
 }
 
-// AWS Elastic Load Balancing Load Balancer
+// AWS Elastic Load Balancing load balancer
 private aws.elb.loadbalancer @defaults("arn name") {
   // ARN for the load balancer
   arn string
@@ -568,7 +568,7 @@ aws.codebuild {
   projects() []aws.codebuild.project
 }
 
-// AWS CodeBuild Project
+// AWS CodeBuild project
 private aws.codebuild.project @defaults("arn name") {
   // ARN for the project
   arn string
@@ -592,7 +592,7 @@ aws.guardduty {
   detectors() []aws.guardduty.detector
 }
 
-// Amazon GuardDuty Detector
+// Amazon GuardDuty detector
 private aws.guardduty.detector @defaults("id region") {
   // Unique ID for the detector
   id string
@@ -612,7 +612,7 @@ aws.securityhub {
   hubs() []aws.securityhub.hub
 }
 
-// AWS Security Hub
+// AWS Security Hub hub
 private aws.securityhub.hub @defaults("arn") {
   // ARN for the Security Hub
   arn string
@@ -626,7 +626,7 @@ aws.secretsmanager {
   secrets() []aws.secretsmanager.secret
 }
 
-// AWS Secrets Manager Secret
+// AWS Secrets Manager secret
 private aws.secretsmanager.secret @defaults("arn name") {
   // ARN for the secret
   arn string
@@ -661,7 +661,7 @@ aws.ecs {
   containerInstances() []aws.ecs.instance
 }
 
-// Amazon ECS Cluster
+// Amazon ECS cluster
 private aws.ecs.cluster {
   // ARN of the ECS cluster
   arn string
@@ -685,7 +685,7 @@ private aws.ecs.cluster {
   containerInstances() []aws.ecs.instance
 }
 
-// AWS ECS Container Instance
+// AWS ECS container instance
 private aws.ecs.instance {
   // True if agent is connected to ECS
   agentConnected bool
@@ -701,7 +701,7 @@ private aws.ecs.instance {
   region string
 }
 
-// Amazon ECS Task
+// Amazon ECS task
 private aws.ecs.task {
   // ARN of the ECS task
   arn string
@@ -721,7 +721,7 @@ private aws.ecs.task {
   containers []aws.ecs.container
 }
 
-// Amazon ECS Container 
+// Amazon ECS container 
 private aws.ecs.container {
   // Name of the ECS container + IP for unique identification
   name string
@@ -761,7 +761,7 @@ aws.emr {
   clusters() []aws.emr.cluster
 }
 
-// Amazon EMR Cluster
+// Amazon EMR cluster
 private aws.emr.cluster @defaults("arn") {
   // ARN for the cluster
   arn string
@@ -791,7 +791,7 @@ aws.cloudwatch {
   metrics() []aws.cloudwatch.metric
 }
 
-// Amazon CloudWatch Metrics Alarm
+// Amazon CloudWatch metrics alarm
 private aws.cloudwatch.metricsalarm @defaults("arn") {
   // ARN for the metric alarm
   arn string
@@ -815,7 +815,7 @@ private aws.cloudwatch.metricsalarm @defaults("arn") {
   name string
 }
 
-// Amazon CloudWatch Metric
+// Amazon CloudWatch metric
 private aws.cloudwatch.metric @defaults("name region") {
   // Name of the metric
   name string
@@ -831,7 +831,7 @@ private aws.cloudwatch.metric @defaults("name region") {
   statistics() aws.cloudwatch.metricstatistics 
 }
 
-// Amazon CloudWatch Metric Dimension
+// Amazon CloudWatch metric dimension
 aws.cloudwatch.metricdimension @defaults("name value") {
   // Name of the dimension
   name string
@@ -839,7 +839,7 @@ aws.cloudwatch.metricdimension @defaults("name value") {
   value string
 }
 
-// Amazon CloudWatch Metric Statistics
+// Amazon CloudWatch metric statistics
 aws.cloudwatch.metricstatistics @defaults("name region") {
   init(namespace string, region string, name string)
   // Namespace for the metric
@@ -854,7 +854,7 @@ aws.cloudwatch.metricstatistics @defaults("name region") {
   datapoints []aws.cloudwatch.metric.datapoint
 }
 
-// Amazon CloudWatch Metric Datapoint
+// Amazon CloudWatch metric datapoint
 private aws.cloudwatch.metric.datapoint @defaults("id") {
   // Unique identifier for the datapoint
   id string
@@ -872,7 +872,7 @@ private aws.cloudwatch.metric.datapoint @defaults("id") {
   unit string
 }
 
-// Amazon CloudWatch Log Group
+// Amazon CloudWatch log group
 private aws.cloudwatch.loggroup @defaults("arn") {
   // ARN of the log group
   arn string
@@ -886,7 +886,7 @@ private aws.cloudwatch.loggroup @defaults("arn") {
   region string
 }
 
-// Amazon CloudWatch Log Group Metrics Filter
+// Amazon CloudWatch log group metrics filter
 private aws.cloudwatch.loggroup.metricsfilter @defaults("id") {
   // Unique ID for the metric
   id string
@@ -906,7 +906,7 @@ aws.cloudfront {
   functions() []aws.cloudfront.function
 }
 
-// Amazon CloudFront Distribution
+// Amazon CloudFront distribution
 private aws.cloudfront.distribution {
   // ARN of the CloudFront distribution
   arn string
@@ -922,7 +922,7 @@ private aws.cloudfront.distribution {
   cacheBehaviors []dict
 }
 
-// Amazon CloudFront Distribution Origin
+// Amazon CloudFront distribution origin
 private aws.cloudfront.distribution.origin {
   // Domain name for the origin
   domainName string
@@ -938,7 +938,7 @@ private aws.cloudfront.distribution.origin {
   account string
 }
 
-// Amazon CloudFront Function
+// Amazon CloudFront function
 private aws.cloudfront.function {
   // Name of the CloudFront function
   name string
@@ -964,7 +964,7 @@ aws.cloudtrail {
   trails() []aws.cloudtrail.trail
 }
 
-// AWS CloudTrail Trail
+// AWS CloudTrail trail
 private aws.cloudtrail.trail @defaults("arn") {
   // ARN of the trail
   arn string
@@ -996,19 +996,19 @@ private aws.cloudtrail.trail @defaults("arn") {
   region string
 }
 
-// Amazon S3 Bucket Control
+// Amazon S3 bucket control
 aws.s3control {
   // Account level public access configuration for S3
   accountPublicAccessBlock() dict
 }
 
-// Amazon S3 Cloud Object Storage
+// Amazon S3 cloud object storage
 aws.s3 {
   // List of S3 buckets across the account
   buckets() []aws.s3.bucket
 }
 
-// Amazon S3 Bucket
+// Amazon S3 bucket
 private aws.s3.bucket @defaults("arn") {
   // ARN of the bucket
   arn string
@@ -1048,7 +1048,7 @@ private aws.s3.bucket @defaults("arn") {
   createdTime time
 }
 
-// Amazon S3 Bucket Grant
+// Amazon S3 bucket grant
 private aws.s3.bucket.grant @defaults("name permission") {
   // ID of the bucket grant
   id string
@@ -1060,7 +1060,7 @@ private aws.s3.bucket.grant @defaults("name permission") {
   grantee map[string]string
 }
 
-// Amazon S3 Bucket CORS Rule
+// Amazon S3 bucket CORS rule
 private aws.s3.bucket.corsrule @defaults("name") {
   // Name of the rule
   name string
@@ -1076,7 +1076,7 @@ private aws.s3.bucket.corsrule @defaults("name") {
   maxAgeSeconds int
 }
 
-// Amazon S3 Bucket Policy
+// Amazon S3 bucket policy
 private aws.s3.bucket.policy @defaults("name version") {
   // Unique ID for the policy
   id string
@@ -1091,28 +1091,28 @@ private aws.s3.bucket.policy @defaults("name version") {
 }
 
 
-// AWS Application Autoscaling
+// AWS Application Auto Scaling
 aws.applicationAutoscaling @defaults("namespace") {
   init(namespace string)
-  // Service namespace to query for application autoscaling
+  // Service namespace to query for application auto scaling
   namespace string
   // List of scalable targets belonging to the service namespace
   scalableTargets() []aws.applicationautoscaling.target
 }
 
-// AWS Application Autoscaling Target
+// AWS Application Auto Scaling target
 private aws.applicationautoscaling.target @defaults("arn") {
   // Namespace for the target
   namespace string
-  // ARN of the autoscaling target
+  // ARN of the auto scaling target
   arn string
   // Scalable dimension for the target
   scalableDimension string
-  // Minimum capacity set for the autoscaling target
+  // Minimum capacity set for the auto scaling target
   minCapacity int
-  // Maximum capacity set for the autoscaling target
+  // Maximum capacity set for the auto scaling target
   maxCapacity int 
-  // suspendedState for the autoscaling target
+  // suspendedState for the auto scaling target
   suspendedState dict
 }
 
@@ -1122,7 +1122,7 @@ aws.backup {
   vaults() []aws.backup.vault
 }
 
-// AWS Backup Vault
+// AWS Backup vault
 private aws.backup.vault @defaults("arn") {
   // ARN of the vault
   arn string
@@ -1132,7 +1132,7 @@ private aws.backup.vault @defaults("arn") {
   recoveryPoints() []aws.backup.vaultRecoveryPoint
 }
 
-// AWS Backup Vault Recovery Point
+// AWS Backup vault recovery point
 private aws.backup.vaultRecoveryPoint @defaults("arn") {
   // ARN of the recovery point
   arn string
@@ -1166,7 +1166,7 @@ aws.dynamodb {
   limits() []aws.dynamodb.limit
 }
 
-// Amazon DynamoDB Limits
+// Amazon DynamoDB limits
 private aws.dynamodb.limit @defaults("arn") {
   // ARN representing the account + region where the limit applies 
   arn string
@@ -1182,7 +1182,7 @@ private aws.dynamodb.limit @defaults("arn") {
   tableMaxWrite int
 }
 
-// Amazon DynamoDB Global Table
+// Amazon DynamoDB global table
 private aws.dynamodb.globaltable @defaults("arn") {
   // ARN for the global table
   arn string
@@ -1192,7 +1192,7 @@ private aws.dynamodb.globaltable @defaults("arn") {
   replicaSettings() []dict
 }
 
-// Amazon DynamoDB Table
+// Amazon DynamoDB table
 private aws.dynamodb.table @defaults("arn") {
   // ARN for the table
   arn string
@@ -1220,7 +1220,7 @@ aws.rds {
   dbClusters() []aws.rds.dbcluster
 }
 
-// Amazon RDS Database Cluster
+// Amazon RDS database cluster
 private aws.rds.dbcluster @defaults("arn") {
   // ARN for the database cluster
   arn string
@@ -1236,7 +1236,7 @@ private aws.rds.dbcluster @defaults("arn") {
   tags map[string]string
 }
 
-// Amazon RDS Snapshot
+// Amazon RDS snapshot
 private aws.rds.snapshot @defaults("arn") {
   // ARN of the snapshot
   arn string
@@ -1256,7 +1256,7 @@ private aws.rds.snapshot @defaults("arn") {
   tags map[string]string
 }
 
-// Amazon RDS Database Instance
+// Amazon RDS database instance
 private aws.rds.dbinstance @defaults("id region engine engineVersion") {
   // ARN for the database instance
   arn string
@@ -1318,7 +1318,7 @@ aws.elasticache {
   cacheClusters() []aws.elasticache.cluster
 }
 
-// Amazon ElastiCache Cluster
+// Amazon ElastiCache cluster
 private aws.elasticache.cluster @defaults("arn") {
   // ARN for the cluster
   arn string
@@ -1382,7 +1382,7 @@ aws.redshift {
   clusters() []aws.redshift.cluster
 }
 
-// Amazon Redshift Cluster
+// Amazon Redshift cluster
 private aws.redshift.cluster @defaults("arn") {
   // Whether major upgrades are applied automatically
   allowVersionUpgrade bool
@@ -1436,7 +1436,7 @@ private aws.redshift.cluster @defaults("arn") {
   vpcId string
 }
 
-// AWS Elastic Container Registry
+// AWS Elastic Container Registry (ECR)
 aws.ecr {
   // List of private repositories
   privateRepositories() []aws.ecr.repository
@@ -1446,7 +1446,7 @@ aws.ecr {
   images() []aws.ecr.image
 }
 
-// AWS Elastic Container Registry Repository
+// AWS Elastic Container Registry repository
 private aws.ecr.repository {
   // ARN of the repository
   arn string
@@ -1466,7 +1466,7 @@ private aws.ecr.repository {
   imageScanOnPush bool
 }
 
-// AWS Elastic Container Registry Image
+// AWS Elastic Container Registry image
 private aws.ecr.image {
   // SHA256 of the image manifest
   digest string
@@ -1492,7 +1492,7 @@ aws.dms {
   replicationInstances() []dict
 }
 
-// AWS API Gateway
+// Amazon API Gateway
 aws.apigateway {
   // List of `aws.apigateway.restapi` objects representing all rest APIs across all enabled regions in the account
   restApis() []aws.apigateway.restapi
@@ -1518,7 +1518,7 @@ private aws.apigateway.restapi @defaults("arn") {
   tags map[string]string
 }
 
-// Amazon API Gateway REST API Stages
+// Amazon API Gateway REST API stages
 private aws.apigateway.stage @defaults("arn") {
   // ARN for the REST API stage
   arn string
@@ -1540,7 +1540,7 @@ aws.lambda {
   functions() []aws.lambda.function
 }
 
-// AWS Lambda Function
+// AWS Lambda function
 private aws.lambda.function @defaults("arn") {
   // ARN of the function
   arn string
@@ -1567,7 +1567,7 @@ aws.ssm {
   instances() []aws.ssm.instance
 }
 
-// Amazon SSM Instance
+// Amazon SSM instance
 private aws.ssm.instance {
   // Instance ID for the SSM Instance
   instanceId string
@@ -1607,7 +1607,7 @@ aws.ec2 {
   keypairs() []aws.ec2.keypair
 }
 
-// Amazon EC2 Network ACL
+// Amazon EC2 network ACL
 private aws.ec2.networkacl @defaults("arn") {
   // ARN for the network ACL
   arn string
@@ -1619,7 +1619,7 @@ private aws.ec2.networkacl @defaults("arn") {
   entries() []aws.ec2.networkacl.entry
 }
 
-// Amazon EC2 Network ACL Entry
+// Amazon EC2 network ACL entry
 private aws.ec2.networkacl.entry {
   // Whether this is an entry for egress rules
   egress bool
@@ -1631,7 +1631,7 @@ private aws.ec2.networkacl.entry {
   id string
 }
 
-// Amazon EC2 Network ACL Entry Port Range
+// Amazon EC2 network ACL entry port range
 private aws.ec2.networkacl.entry.portrange {
   // Starting port for port range
   from int
@@ -1641,7 +1641,7 @@ private aws.ec2.networkacl.entry.portrange {
   id string
 }
 
-// Amazon EC2 VPN Connection
+// Amazon EC2 VPN connection
 private aws.ec2.vpnconnection @defaults("arn") {
   // ARN for the VPN connection
   arn string
@@ -1649,7 +1649,7 @@ private aws.ec2.vpnconnection @defaults("arn") {
   vgwTelemetry []aws.ec2.vgwtelemetry
 }
 
-// Amazon EC2 VPN Tunnel Telemetry
+// Amazon EC2 VPN tunnel telemetry
 private aws.ec2.vgwtelemetry {
   // Outside IP address
   outsideIpAddress string
@@ -1659,7 +1659,7 @@ private aws.ec2.vgwtelemetry {
   statusMessage string
 }
 
-// Amazon EC2 Internet Gateway
+// Amazon EC2 internet gateway
 private aws.ec2.internetgateway @defaults("arn") {
   // ARN for the gateway
   arn string
@@ -1669,7 +1669,7 @@ private aws.ec2.internetgateway @defaults("arn") {
   attachments []dict
 }
 
-// Amazon EC2 Snapshot
+// Amazon EC2 snapshot
 private aws.ec2.snapshot @defaults("arn") {
   // ARN for the snapshot
   arn string
@@ -1689,7 +1689,7 @@ private aws.ec2.snapshot @defaults("arn") {
   state string
 } 
 
-// Amazon EC2 Volume
+// Amazon EC2 volume
 private aws.ec2.volume @defaults("arn encrypted state") {
   // ARN for the EC2 volume
   arn string
@@ -1713,7 +1713,7 @@ private aws.ec2.volume @defaults("arn encrypted state") {
   region string
 }
 
-// Amazon EC2 Instance
+// Amazon EC2 instance
 private aws.ec2.instance @defaults("arn state") {
   // ARN for the instance
   arn string
@@ -1773,7 +1773,7 @@ private aws.ec2.instance @defaults("arn state") {
   vpcArn string
 }
 
-// Amazon EC2 Key Pair
+// Amazon EC2 key pair
 private aws.ec2.keypair @defaults("arn name") {
   // ARN of the key pair
   arn string
@@ -1789,7 +1789,7 @@ private aws.ec2.keypair @defaults("arn name") {
   region string
 }
 
-// Amazon EC2 Image (AMI)
+// Amazon EC2 image (AMI)
 private aws.ec2.image @defaults("arn") {
   // ARN for the AMI
   arn string
@@ -1805,7 +1805,7 @@ private aws.ec2.image @defaults("arn") {
   ownerAlias string
 }
 
-// Amazon EC2 Instance Device
+// Amazon EC2 instance device
 private aws.ec2.instance.device {
   // Boolean to denote whether volume should be deleted on instance termination
   deleteOnTermination bool
@@ -1817,7 +1817,7 @@ private aws.ec2.instance.device {
   deviceName string
 }
 
-// Amazon EC2 Security Group
+// Amazon EC2 security group
 private aws.ec2.securitygroup @defaults("arn") {
   // Security group ARN
   arn string
@@ -1841,7 +1841,7 @@ private aws.ec2.securitygroup @defaults("arn") {
   isAttachedToNetworkInterface() bool
 }
 
-// Amazon EC2 Security Group IP Permission
+// Amazon EC2 security group IP permission
 private aws.ec2.securitygroup.ippermission @defaults("id toPort fromPort ipProtocol ipRanges ipv6Ranges") {
   // Unique ID for the IP permission
   id string
@@ -1858,7 +1858,7 @@ private aws.ec2.securitygroup.ippermission @defaults("id toPort fromPort ipProto
 }
 
 
-// AWS Config
+// AWS config
 aws.config {
   // List of configuration recorders for each region in the account
   recorders() []aws.config.recorder
@@ -1866,7 +1866,7 @@ aws.config {
   rules() []aws.config.rule
 }
 
-// AWS Config Rule
+// AWS config rule
 private aws.config.rule @defaults("arn state") {
   // ARN for the config rule
   arn string
@@ -1876,7 +1876,7 @@ private aws.config.rule @defaults("arn state") {
   source dict
 }
 
-// AWS Config Recorder
+// AWS config recorder
 private aws.config.recorder @defaults("name region") {
   // Name of the recorder
   name string
@@ -1900,7 +1900,7 @@ aws.eks {
   clusters() []aws.eks.cluster
 }
 
-// Amazon EKS Cluster
+// Amazon EKS cluster
 private aws.eks.cluster @defaults("arn version status") {
   // Name of the cluster
   name string

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -5,7 +5,7 @@ option go_package = "go.mondoo.com/cnquery/v9/providers/azure/resources"
 azure {
 }
 
-// Azure Subscription
+// Azure subscription
 azure.subscription @defaults ("name") {
   // Full resource identifier of the subscription
   id string
@@ -62,7 +62,7 @@ azure.subscription @defaults ("name") {
   advisor() azure.subscription.advisorService
 }
 
-// Azure Resource Group
+// Azure resource group
 private azure.subscription.resourcegroup @defaults("name location") {
   // Resource group ID
   id string
@@ -80,7 +80,7 @@ private azure.subscription.resourcegroup @defaults("name location") {
   provisioningState string
 }
 
-// Azure Resource
+// Azure resource
 private azure.subscription.resource @defaults("id name location") {
   // Resource ID
   id string
@@ -110,7 +110,7 @@ private azure.subscription.resource @defaults("id name location") {
   changedTime time
 }
 
-// Azure Compute
+// Azure compute
 private azure.subscription.computeService {
   // Subscription identifier
   subscriptionId string
@@ -120,7 +120,7 @@ private azure.subscription.computeService {
   disks() []azure.subscription.computeService.disk
 }
 
-// Azure Compute Virtual Machine
+// Azure compute virtual machine
 azure.subscription.computeService.vm @defaults("name location properties.hardwareProfile.vmSize properties.storageProfile.osDisk.osType") {
   // VM ID
   id string
@@ -144,7 +144,7 @@ azure.subscription.computeService.vm @defaults("name location properties.hardwar
   publicIpAddresses() []azure.subscription.networkService.ipAddress
 }
 
-// Azure Disk Resource
+// Azure disk resource
 azure.subscription.computeService.disk @defaults("name location properties.osType properties.diskSizeGB properties.diskState") {
   // Disk resource ID
   id string
@@ -168,7 +168,7 @@ azure.subscription.computeService.disk @defaults("name location properties.osTyp
   properties dict
 }
 
-// Azure Network
+// Azure network
 private azure.subscription.networkService {
   // Subscription identifier
   subscriptionId string
@@ -202,7 +202,7 @@ private azure.subscription.networkService {
   applicationFirewallPolicies() []azure.subscription.networkService.applicationFirewallPolicy
 }
 
-// Azure Virtual Network (VNet) Gateway
+// Azure virtual network (VNet) gateway
 azure.subscription.networkService.virtualNetworkGateway @defaults("id name location") {
   // VNet gateway ID
   id string
@@ -258,7 +258,7 @@ azure.subscription.networkService.virtualNetworkGateway @defaults("id name locat
   vpnClientConfiguration dict
 }
 
-// Azure Network Application Security Group
+// Azure network application security group
 azure.subscription.networkService.appSecurityGroup @defaults("id name location") {
   // Application security group ID
   id string
@@ -276,7 +276,7 @@ azure.subscription.networkService.appSecurityGroup @defaults("id name location")
   properties dict
 }
 
-// Azure Network Firewall
+// Azure network firewall
 azure.subscription.networkService.firewall @defaults("id name location") {
   // Firewall ID
   id string
@@ -314,7 +314,7 @@ azure.subscription.networkService.firewall @defaults("id name location") {
   applicationRules []azure.subscription.networkService.firewall.applicationRule
 }
 
-// Azure Network Firewall IP Configuration
+// Azure network firewall IP configuration
 private azure.subscription.networkService.firewall.ipConfig @defaults("id name") {
   // Firewall IP configuration ID 
   id string
@@ -332,7 +332,7 @@ private azure.subscription.networkService.firewall.ipConfig @defaults("id name")
   subnet() azure.subscription.networkService.subnet  
 }
 
-// Azure Network Firewall Network Rule
+// Azure network firewall network rule
 private azure.subscription.networkService.firewall.networkRule @defaults("id name") {
   // Firewall network rule ID 
   id string
@@ -344,7 +344,7 @@ private azure.subscription.networkService.firewall.networkRule @defaults("id nam
   properties dict
 }
 
-// Azure Network Firewall Application Rule
+// Azure network firewall application rule
 private azure.subscription.networkService.firewall.applicationRule @defaults("id name") {
   // Firewall application rule ID 
   id string
@@ -356,7 +356,7 @@ private azure.subscription.networkService.firewall.applicationRule @defaults("id
   properties dict
 }
 
-// Azure Network Firewall NAT Rule
+// Azure network firewall NAT rule
 private azure.subscription.networkService.firewall.natRule @defaults("id name") {
   // Firewall NAT rule ID 
   id string
@@ -368,7 +368,7 @@ private azure.subscription.networkService.firewall.natRule @defaults("id name") 
   properties dict
 }
 
-// Azure Network Firewall Policy
+// Azure network firewall policy
 azure.subscription.networkService.firewallPolicy @defaults("id name location") {
   // Firewall policy ID
   id string
@@ -394,7 +394,7 @@ azure.subscription.networkService.firewallPolicy @defaults("id name location") {
   firewalls() []azure.subscription.networkService.firewall
 }
 
-// Azure Virtual Network (VNet) Gateway IP Configuration
+// Azure Virtual Network (VNet) gateway IP configuration
 private azure.subscription.networkService.virtualNetworkGateway.ipConfig @defaults("id name") {
   // VNet gateway IP Configuration ID 
   id string
@@ -410,7 +410,7 @@ private azure.subscription.networkService.virtualNetworkGateway.ipConfig @defaul
   publicIpAddress() azure.subscription.networkService.ipAddress
 }
 
-// Azure Virtual Network (VNet) Gateway Connection
+// Azure Virtual Network (VNet) gateway connection
 private azure.subscription.networkService.virtualNetworkGateway.connection @defaults("id name") {
   // VNet gateway connection ID 
   id string
@@ -424,7 +424,7 @@ private azure.subscription.networkService.virtualNetworkGateway.connection @defa
   properties dict
 }
   
-// Azure Network BGP Settings
+// Azure network BGP settings
 private azure.subscription.networkService.bgpSettings @defaults("asn bgpPeeringAddress") {
   // BGP Settings ID
   id string
@@ -438,7 +438,7 @@ private azure.subscription.networkService.bgpSettings @defaults("asn bgpPeeringA
   bgpPeeringAddressesConfig []azure.subscription.networkService.bgpSettings.ipConfigurationBgpPeeringAddress
 }
 
-// Azure BGP Settings IP Configuration
+// Azure BGP settings IP configuration
 private azure.subscription.networkService.bgpSettings.ipConfigurationBgpPeeringAddress @defaults("defaultBgpIpAddresses") {
   // BGP Settings IP Configuration ID
   id string
@@ -452,7 +452,7 @@ private azure.subscription.networkService.bgpSettings.ipConfigurationBgpPeeringA
   tunnelIpAddresses []string
 }
 
-// Azure Network NAT Gateway
+// Azure network NAT gateway
 azure.subscription.networkService.natGateway @defaults("id name location") {
   // NAT Gateway ID
   id string
@@ -476,7 +476,7 @@ azure.subscription.networkService.natGateway @defaults("id name location") {
   subnets() []azure.subscription.networkService.subnet
 }
 
-// Azure Network Subnet
+// Azure network subnet
 azure.subscription.networkService.subnet @defaults("id name addressPrefix") {
   // Subnet ID
   id string
@@ -496,7 +496,7 @@ azure.subscription.networkService.subnet @defaults("id name addressPrefix") {
   ipConfigurations() []azure.subscription.networkService.virtualNetworkGateway.ipConfig
 }
 
-// Azure Virtual Network
+// Azure Virtual network (VNet)
 azure.subscription.networkService.virtualNetwork @defaults("id name location") {
   // Virtual Network ID
   id string
@@ -522,7 +522,7 @@ azure.subscription.networkService.virtualNetwork @defaults("id name location") {
   enableVmProtection bool
 }
 
-// Azure Virtual Network DHCP Options
+// Azure Virtual Network DHCP options
 private azure.subscription.networkService.virtualNetwork.dhcpOptions {
   // DHCP options ID
   id string
@@ -530,7 +530,7 @@ private azure.subscription.networkService.virtualNetwork.dhcpOptions {
   dnsServers []string
 }
 
-// Azure Network Load Balancer
+// Azure Load Balancer
 azure.subscription.networkService.loadBalancer @defaults("id name location") {
   // Load Balancer ID
   id string
@@ -564,7 +564,7 @@ azure.subscription.networkService.loadBalancer @defaults("id name location") {
   loadBalancerRules []azure.subscription.networkService.loadBalancerRule
 }
 
-// Azure Network Probe
+// Azure network probe
 private azure.subscription.networkService.probe @defaults("id name"){
   // Probe ID
   id string
@@ -578,7 +578,7 @@ private azure.subscription.networkService.probe @defaults("id name"){
   properties dict
 }
 
-// Azure Network Backend Address Pool
+// Azure network backend address pool
 private azure.subscription.networkService.backendAddressPool @defaults("id name") {
   // Backend Address Pool ID
   id string
@@ -592,7 +592,7 @@ private azure.subscription.networkService.backendAddressPool @defaults("id name"
   properties dict
 }
 
-// Azure Network Inbound NAT Pool
+// Azure network inbound NAT pool
 private azure.subscription.networkService.inboundNatPool @defaults("id name") {
   // Inbound NAT Pool ID
   id string
@@ -606,7 +606,7 @@ private azure.subscription.networkService.inboundNatPool @defaults("id name") {
   properties dict
 }
 
-// Azure Network Inbound NAT Rule
+// Azure network inbound NAT rule
 private azure.subscription.networkService.inboundNatRule @defaults("id name") {
   // Inbound NAT Rule ID
   id string
@@ -620,7 +620,7 @@ private azure.subscription.networkService.inboundNatRule @defaults("id name") {
   properties dict
 }
 
-// Azure Network Frontend IP Configuration
+// Azure network frontend IP configuration
 private azure.subscription.networkService.frontendIpConfig @defaults("id name") {
   // Frontend IP Configuration ID
   id string
@@ -636,35 +636,35 @@ private azure.subscription.networkService.frontendIpConfig @defaults("id name") 
   zones []string
 }
 
-// Azure Network Load Balancer Rule
+// Azure Load Balancer rule
 private azure.subscription.networkService.loadBalancerRule @defaults("id name") {
-  // Load Balancer Rule ID
+  // Load Balancer rule ID
   id string
-  // Load Balancer Rule name
+  // Load Balancer rule name
   name string
-  // Load Balancer Rule type
+  // Load Balancer rule type
   type string
-  // Load Balancer Rule etag
+  // Load Balancer rule etag
   etag string
-  // Load Balancer Rule properties
+  // Load Balancer rule properties
   properties dict
 }
 
-// Azure Network Outbound Rule
+// Azure network outbound rule
 private azure.subscription.networkService.outboundRule @defaults("id name") {
-  // Outbound Rule ID
+  // Outbound rule ID
   id string
-  // Outbound Rule name
+  // Outbound rule name
   name string
-  // Outbound Rule type
+  // Outbound rule type
   type string
-  // Outbound Rule etag
+  // Outbound rule etag
   etag string
-  // Outbound Rule properties
+  // Outbound rule properties
   properties dict
 }
 
-// Azure Network Interface
+// Azure network interface
 azure.subscription.networkService.interface @defaults("name location properties.macAddress properties.nicType") {
   // Network interface ID
   id string
@@ -684,7 +684,7 @@ azure.subscription.networkService.interface @defaults("name location properties.
   vm() azure.subscription.computeService.vm
 }
 
-// Azure Network IP address
+// Azure network IP address
 private azure.subscription.networkService.ipAddress @defaults("id name location") {
   // IP address ID
   id string
@@ -718,7 +718,7 @@ private azure.subscription.networkService.bastionHost @defaults("id name locatio
   sku dict
 }
 
-// Azure Network Security Group
+// Azure network security group
 private azure.subscription.networkService.securityGroup @defaults("id name location") {
   // Security group ID
   id string
@@ -742,7 +742,7 @@ private azure.subscription.networkService.securityGroup @defaults("id name locat
   defaultSecurityRules []azure.subscription.networkService.securityrule
 }
 
-// Azure Network Security Rule
+// Azure network security rule
 private azure.subscription.networkService.securityrule @defaults("id name") {
   // Security rule ID
   id string
@@ -778,7 +778,7 @@ private azure.subscription.networkService.watcher @defaults("name location") {
   provisioningState string
 }
 
-// Azure Network Watcher Flow Log
+// Azure Network Watcher flow log
 private azure.subscription.networkService.watcher.flowlog @defaults("name location") {
   // Network watcher flow log ID
   id string
@@ -860,7 +860,7 @@ private azure.subscription.storageService {
   accounts() []azure.subscription.storageService.account
 }
 
-// Azure Storage Account
+// Azure Storage account
 private azure.subscription.storageService.account @defaults("id name location") {
   // Storage account ID
   id string
@@ -892,7 +892,7 @@ private azure.subscription.storageService.account @defaults("id name location") 
   dataProtection() azure.subscription.storageService.account.dataProtection
 }
 
-// Azure Storage Account Data Protection
+// Azure Storage account data protection
 private azure.subscription.storageService.account.dataProtection @defaults("blobSoftDeletionEnabled blobRetentionDays") {
   // ID of the storage account
   storageAccountId string
@@ -906,7 +906,7 @@ private azure.subscription.storageService.account.dataProtection @defaults("blob
   containerRetentionDays int
 }
 
-// Azure Storage Account Service Properties
+// Azure Storage account service properties
 private azure.subscription.storageService.account.service.properties @defaults("id") {
   // ID of the service
   id string
@@ -918,7 +918,7 @@ private azure.subscription.storageService.account.service.properties @defaults("
   logging azure.subscription.storageService.account.service.properties.logging
 }
 
-// Azure Storage Account Service Properties Metrics 
+// Azure Storage account service properties metrics 
 private azure.subscription.storageService.account.service.properties.metrics @defaults("id includeAPIs enabled") {
   // ID of the metrics
   id string
@@ -932,7 +932,7 @@ private azure.subscription.storageService.account.service.properties.metrics @de
   version string
 }
 
-// Azure Storage Account Service Properties Retention Policy
+// Azure Storage account service properties retention policy
 private azure.subscription.storageService.account.service.properties.retentionPolicy @defaults("id") {
   // ID of the retention policy
   id string
@@ -942,7 +942,7 @@ private azure.subscription.storageService.account.service.properties.retentionPo
   enabled bool 
 }
 
-// Azure Storage Account Service Properties Logging
+// Azure Storage account service properties logging
 private azure.subscription.storageService.account.service.properties.logging @defaults("id") {
   // ID of the logging configuration
   id string
@@ -958,7 +958,7 @@ private azure.subscription.storageService.account.service.properties.logging @de
   retentionPolicy azure.subscription.storageService.account.service.properties.retentionPolicy
 }
 
-// Azure Storage Container
+// Azure Storage container
 private azure.subscription.storageService.account.container @defaults("id name") {
   // Storage container ID
   id string
@@ -983,7 +983,7 @@ private azure.subscription.webService {
   availableRuntimes() []dict
 }
 
-// Azure Web App Site
+// Azure Web app site
 private azure.subscription.webService.appsite @defaults("id name location") {
   // App site ID
   id string
@@ -1015,7 +1015,7 @@ private azure.subscription.webService.appsite @defaults("id name location") {
   stack() dict
 }
 
-// Azure AppSite Authentication Settings
+// Azure AppSite authentication settings
 private azure.subscription.webService.appsiteauthsettings @defaults("id name") {
   // Auth settings ID
   id string
@@ -1029,7 +1029,7 @@ private azure.subscription.webService.appsiteauthsettings @defaults("id name") {
   properties dict
 }
 
-// Azure AppSite Config
+// Azure AppSite config
 private azure.subscription.webService.appsiteconfig @defaults("id name") {
   // Appsite config ID
   id string
@@ -1051,7 +1051,7 @@ private azure.subscription.sqlService {
   servers() []azure.subscription.sqlService.server
 }
 
-// Azure SQL Server
+// Azure SQL server
 private azure.subscription.sqlService.server @defaults("name location") {
   // SQL server ID
   id string
@@ -1086,7 +1086,7 @@ private azure.subscription.sqlService.server @defaults("name location") {
   virtualNetworkRules() []azure.subscription.sqlService.virtualNetworkRule
 }
 
-// Azure SQL Server Vulnerability Assessment Settings
+// Azure SQL server vulnerability assessment settings
 private azure.subscription.sqlService.server.vulnerabilityassessmentsettings {
   // ID of the vulnerability assessment
   id string
@@ -1108,7 +1108,7 @@ private azure.subscription.sqlService.server.vulnerabilityassessmentsettings {
   mailSubscriptionAdmins bool
 }
 
-// Azure SQL Server Administrator
+// Azure SQL server administrator
 private azure.subscription.sqlService.server.administrator @defaults("id name") {
   // SQL administrator ID
   id string
@@ -1126,7 +1126,7 @@ private azure.subscription.sqlService.server.administrator @defaults("id name") 
   tenantId string
 }
 
-// Azure SQL Server Database
+// Azure SQL server database
 private azure.subscription.sqlService.database @defaults("id name") {
   // SQL database ID
   id string
@@ -1188,7 +1188,7 @@ private azure.subscription.sqlService.database @defaults("id name") {
   usage() []azure.subscription.sqlService.databaseusage
 }
 
-// Azure SQL Database Usage
+// Azure SQL database usage
 private azure.subscription.sqlService.databaseusage @defaults("id name") {
   // Database usage ID
   id string
@@ -1214,7 +1214,7 @@ private azure.subscription.postgreSqlService {
   servers() []azure.subscription.postgreSqlService.server
 }
 
-// Azure Database for PostgreSQL Server
+// Azure Database for PostgreSQL server
 private azure.subscription.postgreSqlService.server @defaults("id name location") {
   // PostgreSQL server ID
   id string
@@ -1236,7 +1236,7 @@ private azure.subscription.postgreSqlService.server @defaults("id name location"
   firewallRules() []azure.subscription.sqlService.firewallrule
 }
 
-// Azure Database for PostgreSQL Database
+// Azure Database for PostgreSQL database
 private azure.subscription.postgreSqlService.database  @defaults("id name") {
   // PostgreSQL database ID
   id string
@@ -1250,7 +1250,7 @@ private azure.subscription.postgreSqlService.database  @defaults("id name") {
   collation string
 }
 
-// Azure SQL Configuration
+// Azure SQL configuration
 private azure.subscription.sqlService.configuration  @defaults("id name") {
   // SQL configuration ID
   id string
@@ -1272,7 +1272,7 @@ private azure.subscription.sqlService.configuration  @defaults("id name") {
   source string
 }
 
-// Azure SQL Firewall Rule
+// Azure SQL firewall rule
 private azure.subscription.sqlService.firewallrule  @defaults("id name") {
   // SQL firewall rule ID
   id string
@@ -1286,7 +1286,7 @@ private azure.subscription.sqlService.firewallrule  @defaults("id name") {
   endIpAddress string
 }
 
-// Azure SQL Virtual Network Rule
+// Azure SQL virtual network rule
 private azure.subscription.sqlService.virtualNetworkRule  @defaults("id name") {
   // Virtual network rule ID
   id string
@@ -1310,7 +1310,7 @@ private azure.subscription.mySqlService {
   flexibleServers() []azure.subscription.mySqlService.flexibleServer
 }
 
-// Azure Database for MySQL Server
+// Azure Database for MySQL server
 private azure.subscription.mySqlService.server @defaults("id name location") {
   // MySQL server ID
   id string
@@ -1332,7 +1332,7 @@ private azure.subscription.mySqlService.server @defaults("id name location") {
   firewallRules() []azure.subscription.sqlService.firewallrule
 }
 
-// Azure Database for MySQL Database
+// Azure Database for MySQL database
 private azure.subscription.mySqlService.database @defaults("id name") {
   // MySQL database ID
   id string
@@ -1346,7 +1346,7 @@ private azure.subscription.mySqlService.database @defaults("id name") {
   collation string
 }
 
-// Azure Database for MySQL Flexible Server
+// Azure Database for MySQL flexible server
 private azure.subscription.mySqlService.flexibleServer @defaults("id name location") {
   // MySQL flexible server ID
   id string
@@ -1376,7 +1376,7 @@ private azure.subscription.mariaDbService {
   servers() []azure.subscription.mariaDbService.server
 }
 
-// Azure Database for MariaDB Server
+// Azure Database for MariaDB server
 private azure.subscription.mariaDbService.server  @defaults("id name location") {
   // MariaDB server ID
   id string
@@ -1398,7 +1398,7 @@ private azure.subscription.mariaDbService.server  @defaults("id name location") 
   firewallRules() []azure.subscription.sqlService.firewallrule
 }
 
-// Azure Database for MariaDB Database
+// Azure Database for MariaDB database
 private azure.subscription.mariaDbService.database @defaults("id name") {
   // MariaDB database ID
   id string
@@ -1420,7 +1420,7 @@ private azure.subscription.cosmosDbService {
   accounts() []azure.subscription.cosmosDbService.account
 }
 
-// Azure Cosmos DB Account
+// Azure Cosmos DB account
 private azure.subscription.cosmosDbService.account @defaults("name kind location") {
   // Cosmos DB account ID
   id string
@@ -1446,7 +1446,7 @@ private azure.subscription.keyVaultService {
   vaults() []azure.subscription.keyVaultService.vault
 }
 
-// Azure Key Vault Vault
+// Azure Key Vault vault
 private azure.subscription.keyVaultService.vault  @defaults("vaultName type vaultUri location") {
   // Vault ID
   id string
@@ -1474,7 +1474,7 @@ private azure.subscription.keyVaultService.vault  @defaults("vaultName type vaul
   diagnosticSettings() []azure.subscription.monitorService.diagnosticsetting
 }
 
-// Azure Key Vault Key
+// Azure Key Vault key
 private azure.subscription.keyVaultService.key  @defaults("kid keyName") {
   // Key ID
   kid string
@@ -1502,7 +1502,7 @@ private azure.subscription.keyVaultService.key  @defaults("kid keyName") {
   versions() []azure.subscription.keyVaultService.key
 }
 
-// Azure Key Vault Certificate
+// Azure Key Vault certificate
 private azure.subscription.keyVaultService.certificate  @defaults("id certName") {
   // Certificate ID
   id string
@@ -1530,7 +1530,7 @@ private azure.subscription.keyVaultService.certificate  @defaults("id certName")
   versions() []azure.subscription.keyVaultService.certificate
 }
 
-// Azure Key Vault Secret
+// Azure Key Vault secret
 private azure.subscription.keyVaultService.secret  @defaults("id secretName") {
   // Secret ID
   id string
@@ -1572,7 +1572,7 @@ private azure.subscription.monitorService {
   activityLog() azure.subscription.monitorService.activityLog 
 }
 
-// Azure Monitor Activity Log
+// Azure Monitor activity log
 private azure.subscription.monitorService.activityLog @defaults("alerts") {
   // Subscription identifier
   subscriptionId string
@@ -1580,7 +1580,7 @@ private azure.subscription.monitorService.activityLog @defaults("alerts") {
   alerts() []azure.subscription.monitorService.activityLog.alert
 }
 
-// Azure Monitor Application Insights
+// Azure Monitor application insights
 private azure.subscription.monitorService.applicationInsight @defaults("name location type")  {
   // Application insight ID
   id string
@@ -1598,7 +1598,7 @@ private azure.subscription.monitorService.applicationInsight @defaults("name loc
   type string
 }
 
-// Azure Monitor Activity Log Alert
+// Azure Monitor activity log alert
 private azure.subscription.monitorService.activityLog.alert @defaults("name type") {
   // ID of the activity log alert
   id string
@@ -1620,7 +1620,7 @@ private azure.subscription.monitorService.activityLog.alert @defaults("name type
   scopes []string
 }
 
-// Azure Monitor Log Profile
+// Azure Monitor log profile
 private azure.subscription.monitorService.logprofile  @defaults("id name location") {
   // Log profile ID
   id string
@@ -1640,7 +1640,7 @@ private azure.subscription.monitorService.logprofile  @defaults("id name locatio
   storageAccount() azure.subscription.storageService.account
 }
 
-// Azure Monitor Diagnostic Setting
+// Azure Monitor diagnostic setting
 private azure.subscription.monitorService.diagnosticsetting @defaults("id name") {
   // Diagnostic setting ID
   id string
@@ -1656,7 +1656,7 @@ private azure.subscription.monitorService.diagnosticsetting @defaults("id name")
   storageAccount() azure.subscription.storageService.account
 }
 
-// Azure Microsoft Cloud Defender
+// Microsoft Defender for Cloud
 private azure.subscription.cloudDefenderService @defaults("defenderForServers defenderForContainers"){
   // Subscription identifier
   subscriptionId string
@@ -1670,7 +1670,7 @@ private azure.subscription.cloudDefenderService @defaults("defenderForServers de
   securityContacts() []azure.subscription.cloudDefenderService.securityContact
 }
 
-// Azure Microsoft Cloud Defender Security Contact 
+// Microsoft Defender for Cloud security contact 
 private azure.subscription.cloudDefenderService.securityContact @defaults("name alertNotifications.state"){
   // ID of the security contact
   id string
@@ -1684,7 +1684,7 @@ private azure.subscription.cloudDefenderService.securityContact @defaults("name 
   notificationsByRole dict
 }
 
-// Azure Authorization
+// Azure authorization
 private azure.subscription.authorizationService {
   // Subscription identifier
   subscriptionId string
@@ -1692,7 +1692,7 @@ private azure.subscription.authorizationService {
   roleDefinitions() []azure.subscription.authorizationService.roleDefinition
 }
 
-// Azure Role Definition
+// Azure role definition
 private azure.subscription.authorizationService.roleDefinition @defaults ("id name scopes") {
   // ID of the role definition
   id string
@@ -1708,7 +1708,7 @@ private azure.subscription.authorizationService.roleDefinition @defaults ("id na
   permissions []azure.subscription.authorizationService.roleDefinition.permission
 }
 
-// Azure Role Definition Permission
+// Azure role definition permission
 private azure.subscription.authorizationService.roleDefinition.permission @defaults ("allowedActions deniedActions") {
   // ID of the permission
   id string
@@ -1786,7 +1786,7 @@ private azure.subscription.advisorService @defaults("averageScore recommendation
   averageScore() float
 }
 
-// Azure Advisor Recommendation
+// Azure Advisor recommendation
 private azure.subscription.advisorService.recommendation @defaults("name category impact description impactedResource") {
   // Recommendation ID
   id string
@@ -1812,7 +1812,7 @@ private azure.subscription.advisorService.recommendation @defaults("name categor
   properties dict
 }
 
-// Azure Advisor Score
+// Azure Advisor score
 private azure.subscription.advisorService.score @defaults("name") {
   // Score identifier
   id string
@@ -1826,7 +1826,7 @@ private azure.subscription.advisorService.score @defaults("name") {
   timeSeries []azure.subscription.advisorService.timeSeries 
 }
 
-// Azure Advisor Time Series
+// Azure Advisor time series
 private azure.subscription.advisorService.timeSeries {
   // Advisor time series identifier
   id string
@@ -1836,7 +1836,7 @@ private azure.subscription.advisorService.timeSeries {
   scores []azure.subscription.advisorService.securityScore
 }
 
-// Azure Advisor Security Score
+// Azure Advisor security score
 private azure.subscription.advisorService.securityScore {
   // Security score identifier
   id string

--- a/providers/core/resources/core.lr
+++ b/providers/core/resources/core.lr
@@ -4,7 +4,7 @@
 option provider = "go.mondoo.com/cnquery/v9/providers/core"
 option go_package = "go.mondoo.com/cnquery/v9/providers/core/resources"
 
-// Provide contextual information about MQL runtime and environment
+// Contextual information about MQL runtime and environment
 mondoo @defaults("version") {
   // Version of the client running on the asset
   version() string
@@ -98,7 +98,7 @@ regex {
   creditCard() regex
 }
 
-// Parse provides common parsers (json, ini, certs, etc)
+// Provides common parsers (json, ini, certs, etc)
 parse {
   // Built-in functions:
   // date(value, format) time

--- a/providers/equinix/resources/equinix.lr
+++ b/providers/equinix/resources/equinix.lr
@@ -4,7 +4,7 @@
 option provider = "go.mondoo.com/cnquery/v9/providers/equinix"
 option go_package = "go.mondoo.com/cnquery/v9/providers/equinix/resources"
 
-// Equinix Metal Project
+// Equinix Metal project
 equinix.metal.project @defaults("name") {
   // Project ID
   id string
@@ -24,7 +24,7 @@ equinix.metal.project @defaults("name") {
   devices() []equinix.metal.device
 }
 
-// Equinix Metal Organization
+// Equinix Metal organization
 equinix.metal.organization @defaults("name") {
   // Organization ID
   id string
@@ -56,7 +56,7 @@ equinix.metal.organization @defaults("name") {
  	users() []equinix.metal.user
 }
 
-// Equinix Metal User
+// Equinix Metal user
 private equinix.metal.user @defaults("email") {
   // User ID
   id string
@@ -90,7 +90,7 @@ private equinix.metal.user @defaults("email") {
   url string
 }
 
-// Equinix Metal SSH Key
+// Equinix Metal SSH key
 equinix.metal.sshkey @defaults("label") {
   // ID of the SSH key
   id string
@@ -108,7 +108,7 @@ equinix.metal.sshkey @defaults("label") {
   url string
 }
 
-// Equinix Metal Device
+// Equinix Metal device
 equinix.metal.device {
   // Device ID
   id string

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -20,7 +20,7 @@ alias gcp.dns = gcp.project.dnsService
 alias gcp.bigquery = gcp.project.bigqueryService
 alias gcp.storage = gcp.project.storageService
 
-// GCP Cloud Organization
+// GCP cloud organization
 gcp.organization @defaults("name") {
   // Organization ID
   id string
@@ -40,7 +40,7 @@ gcp.organization @defaults("name") {
   projects() gcp.projects
 }
 
-// GCP Folders
+// GCP folders
 private gcp.folders {
   []gcp.folder
   // Parent ID
@@ -49,7 +49,7 @@ private gcp.folders {
   children() []gcp.folder
 }
 
-// GCP Folder
+// GCP folder
 private gcp.folder @defaults("name") {
   // Folder ID
   id string
@@ -69,7 +69,7 @@ private gcp.folder @defaults("name") {
   projects() gcp.projects
 }
 
-// GCP Projects
+// GCP projects
 private gcp.projects {
   []gcp.project
   // Parent ID
@@ -78,7 +78,7 @@ private gcp.projects {
   children() []gcp.project
 }
 
-// Google Cloud Platform Project
+// Google Cloud Platform project
 gcp.project @defaults("name") {
   // Unique, user-assigned ID of the project
   id string
@@ -140,7 +140,7 @@ gcp.project @defaults("name") {
   monitoring() gcp.project.monitoringService
 }
 
-// GCP Service
+// GCP service
 gcp.service @defaults("name") {
   // Project ID
   projectId string
@@ -156,7 +156,7 @@ gcp.service @defaults("name") {
   enabled() bool
 }
 
-// GCP Recommendation and Suggested Action
+// GCP recommendation and suggested action
 gcp.recommendation {
   // ID of recommendation
   id string
@@ -184,7 +184,7 @@ gcp.recommendation {
   state dict
 }
 
-// GCP Resource Manager Binding
+// GCP Resource Manager binding
 private gcp.resourcemanager.binding {
   // Internal ID
   id string
@@ -228,7 +228,7 @@ private gcp.project.computeService {
   forwardingRules() []gcp.project.computeService.forwardingRule
 }
 
-// GCP Compute Address
+// GCP Compute address
 private gcp.project.computeService.address @defaults("name address addressType") {
   // Unique identifier
   id string
@@ -268,7 +268,7 @@ private gcp.project.computeService.address @defaults("name address addressType")
   resourceUrls []string
 }
 
-// GCP Compute Forwarding Rules
+// GCP Compute forwarding rules
 private gcp.project.computeService.forwardingRule {
   // Unique identifier
   id string
@@ -326,7 +326,7 @@ private gcp.project.computeService.forwardingRule {
   targetUrl string
 }
 
-// GCP Compute Region
+// GCP Compute region
 private gcp.project.computeService.region @defaults("name") {
   // Unique identifier
   id string
@@ -344,7 +344,7 @@ private gcp.project.computeService.region @defaults("name") {
   deprecated dict
 }
 
-// GCP Compute Zone
+// GCP Compute zone
 private gcp.project.computeService.zone @defaults("name") {
   // Unique identifier
   id string
@@ -358,7 +358,7 @@ private gcp.project.computeService.zone @defaults("name") {
   created time
 }
 
-// GCP Machine Type
+// GCP machine type
 private gcp.project.computeService.machineType @defaults("name") {
   // Unique identifier
   id string
@@ -384,7 +384,7 @@ private gcp.project.computeService.machineType @defaults("name") {
   zone gcp.project.computeService.zone
 }
 
-// GCP Compute Instances
+// GCP Compute instances
 private gcp.project.computeService.instance @defaults("name") {
   // Unique identifier for the instance
   id string
@@ -466,7 +466,7 @@ private gcp.project.computeService.instance @defaults("name") {
   zone gcp.project.computeService.zone
 }
 
-// GCP Compute Service Account
+// GCP Compute service account
 private gcp.project.computeService.serviceaccount @defaults("email") {
   // Service account email address
   email string
@@ -474,7 +474,7 @@ private gcp.project.computeService.serviceaccount @defaults("email") {
   scopes []string
 }
 
-// GCP Compute Persistent Disk
+// GCP Compute persistent disk
 private gcp.project.computeService.disk @defaults("name") {
   // Unique identifier for the resource
   id string
@@ -512,7 +512,7 @@ private gcp.project.computeService.disk @defaults("name") {
   diskEncryptionKey dict
 }
 
-// GCP Compute Attached Disk
+// GCP Compute attached disk
 private gcp.project.computeService.attachedDisk {
   // Attached Disk ID
   id string
@@ -546,7 +546,7 @@ private gcp.project.computeService.attachedDisk {
   type string
 }
 
-// GCP Compute Persistent Disk Snapshot
+// GCP Compute persistent disk snapshot
 private gcp.project.computeService.snapshot @defaults("name") {
   // Unique identifier
   id string
@@ -610,7 +610,7 @@ private gcp.project.computeService.image @defaults("id name") {
   status string
 }
 
-// GCP Compute Firewall
+// GCP Compute firewall
 private gcp.project.computeService.firewall @defaults("name") {
   // Unique identifier
   id string
@@ -644,7 +644,7 @@ private gcp.project.computeService.firewall @defaults("name") {
   denied []dict
 }
 
-// GCP Compute VPC Network resource
+// GCP Compute VPC network resource
 private gcp.project.computeService.network @defaults("name") {
   // Unique identifier
   id string
@@ -678,7 +678,7 @@ private gcp.project.computeService.network @defaults("name") {
   subnetworks() []gcp.project.computeService.subnetwork
 }
 
-// GCP Compute VPC Network Partitioning
+// GCP Compute VPC network partitioning
 private gcp.project.computeService.subnetwork @defaults("name") {
   // Unique identifier
   id string
@@ -726,7 +726,7 @@ private gcp.project.computeService.subnetwork @defaults("name") {
   created time
 }
 
-// GCP Compute VPC Network Partitioning Log Configuration
+// GCP Compute VPC network partitioning log configuration
 private gcp.project.computeService.subnetwork.logConfig @defaults("enable") {
   // Internal ID
   id string
@@ -744,7 +744,7 @@ private gcp.project.computeService.subnetwork.logConfig @defaults("enable") {
   metadataFields []string
 }
 
-// GCP Compute Cloud Router
+// GCP Compute cloud router
 private gcp.project.computeService.router @defaults("name")  {
   // Unique identifier
   id string
@@ -764,7 +764,7 @@ private gcp.project.computeService.router @defaults("name")  {
   created time
 }
 
-// GCP Compute Backend Service
+// GCP Compute backend service
 private gcp.project.computeService.backendService @defaults("name") {
   // Unique identifier
   id string
@@ -834,7 +834,7 @@ private gcp.project.computeService.backendService @defaults("name") {
   timeoutSec int
 }
 
-// GCP Compute Backend Service Backend
+// GCP Compute backend service backend
 private gcp.project.computeService.backendService.backend @defaults("description") {
   // Internal ID
   id string
@@ -864,7 +864,7 @@ private gcp.project.computeService.backendService.backend @defaults("description
   maxUtilization float
 }
 
-// GCP Compute Backend Service CDN Policy
+// GCP Compute backend service CDN policy
 private gcp.project.computeService.backendService.cdnPolicy {
   // Internal ID
   id string
@@ -902,7 +902,7 @@ private gcp.project.storageService {
   buckets() []gcp.project.storageService.bucket
 }
 
-// GCP Cloud Storage Bucket
+// GCP Cloud Storage bucket
 private gcp.project.storageService.bucket @defaults("id") {
   // Bucket ID
   id string
@@ -932,7 +932,7 @@ private gcp.project.storageService.bucket @defaults("id") {
   retentionPolicy dict
 }
 
-// GCP Cloud SQL Resources
+// GCP Cloud SQL resources
 private gcp.project.sqlService {
   // Project ID
   projectId string
@@ -940,7 +940,7 @@ private gcp.project.sqlService {
   instances() []gcp.project.sqlService.instance
 }
 
-// GCP Cloud SQL Instance
+// GCP Cloud SQL instance
 private gcp.project.sqlService.instance @defaults("name") {
   // Project ID
   projectId string
@@ -994,7 +994,7 @@ private gcp.project.sqlService.instance @defaults("name") {
   databases() []gcp.project.sqlService.instance.database
 }
 
-// GCP Cloud SQL Instance Database
+// GCP Cloud SQL instance database
 private gcp.project.sqlService.instance.database @defaults("name") {
   // Project ID
   projectId string
@@ -1010,7 +1010,7 @@ private gcp.project.sqlService.instance.database @defaults("name") {
   sqlserverDatabaseDetails dict
 }
 
-// GCP Cloud SQL Instance IP Mapping
+// GCP Cloud SQL instance IP mapping
 private gcp.project.sqlService.instance.ipMapping @defaults("ipAddress") {
   // Internal ID
   id string
@@ -1022,7 +1022,7 @@ private gcp.project.sqlService.instance.ipMapping @defaults("ipAddress") {
   type string
 }
 
-// GCP Cloud SQL Instance Settings
+// GCP Cloud SQL instance settings
 private gcp.project.sqlService.instance.settings {
   // Project ID
   projectId string
@@ -1084,7 +1084,7 @@ private gcp.project.sqlService.instance.settings {
   userLabels map[string]string
 }
 
-// GCP Cloud SQL Instance Settings Backup Configuration
+// GCP Cloud SQL instance settings backup configuration
 private gcp.project.sqlService.instance.settings.backupconfiguration {
   // Internal ID
   id string
@@ -1104,7 +1104,7 @@ private gcp.project.sqlService.instance.settings.backupconfiguration {
   transactionLogRetentionDays int
 }
 
-// GCP Cloud SQL Instance Settings Deny Maintenance Period
+// GCP Cloud SQL instance settings deny maintenance period
 private gcp.project.sqlService.instance.settings.denyMaintenancePeriod @defaults("startDate endDate") {
   // Internal ID
   id string
@@ -1116,7 +1116,7 @@ private gcp.project.sqlService.instance.settings.denyMaintenancePeriod @defaults
   time string
 }
 
-// GCP Cloud SQL Instance Settings IP Configuration
+// GCP Cloud SQL instance settings IP configuration
 private gcp.project.sqlService.instance.settings.ipConfiguration {
   // Internal ID
   id string
@@ -1132,7 +1132,7 @@ private gcp.project.sqlService.instance.settings.ipConfiguration {
   requireSsl bool
 }
 
-// GCP Cloud SQL Instance Settings Maintenance Window
+// GCP Cloud SQL instance settings maintenance window
 private gcp.project.sqlService.instance.settings.maintenanceWindow @defaults("day hour") {
   // Internal ID
   id string
@@ -1144,7 +1144,7 @@ private gcp.project.sqlService.instance.settings.maintenanceWindow @defaults("da
   updateTrack string
 }
 
-// GCP Cloud SQL Instance Settings Password Validation Policy
+// GCP Cloud SQL instance settings password validation policy
 private gcp.project.sqlService.instance.settings.passwordValidationPolicy @defaults("enabledPasswordPolicy") {
   // Internal ID
   id string
@@ -1162,7 +1162,7 @@ private gcp.project.sqlService.instance.settings.passwordValidationPolicy @defau
   reuseInterval int
 }
 
-// GCP BigQuery Resources
+// GCP BigQuery resources
 private gcp.project.bigqueryService @defaults("projectId") {
   // Project ID
   projectId string
@@ -1170,7 +1170,7 @@ private gcp.project.bigqueryService @defaults("projectId") {
   datasets() []gcp.project.bigqueryService.dataset
 }
 
-// GCP BigQuery Dataset
+// GCP BigQuery dataset
 private gcp.project.bigqueryService.dataset @defaults("id name") {
   // Dataset ID
   id string
@@ -1202,7 +1202,7 @@ private gcp.project.bigqueryService.dataset @defaults("id name") {
   routines() []gcp.project.bigqueryService.routine
 }
 
-// GCP BigQuery Dataset Access Entry
+// GCP BigQuery dataset access entry
 private gcp.project.bigqueryService.dataset.accessEntry @defaults("role entity entityType") {
   // Internal ID
   id string
@@ -1222,7 +1222,7 @@ private gcp.project.bigqueryService.dataset.accessEntry @defaults("role entity e
   datasetRef dict
 }
 
-// GCP BigQuery Table
+// GCP BigQuery table
 private gcp.project.bigqueryService.table @defaults("id") {
   // Table ID
   id string
@@ -1304,7 +1304,7 @@ private gcp.project.bigqueryService.model @defaults("id") {
   kmsName string
 }
 
-// GCP BigQuery Routine
+// GCP BigQuery routine
 private gcp.project.bigqueryService.routine @defaults("id") {
   // Routine ID
   id string
@@ -1334,7 +1334,7 @@ private gcp.project.dnsService {
   policies() []gcp.project.dnsService.policy
 }
 
-// Cloud DNS Managed Zone (a resource that represents a DNS zone hosted by the Cloud DNS service)
+// Cloud DNS managed zone (a resource that represents a DNS zone hosted by the Cloud DNS service)
 private gcp.project.dnsService.managedzone @defaults("name") {
   // Managed zone ID
   id string
@@ -1360,7 +1360,7 @@ private gcp.project.dnsService.managedzone @defaults("name") {
   recordSets() []gcp.project.dnsService.recordset
 }
 
-// Cloud DNS Record Set
+// Cloud DNS record set
 private gcp.project.dnsService.recordset @defaults("name") {
   // Project ID
   projectId string
@@ -1404,7 +1404,7 @@ private gcp.project.gkeService {
   clusters() []gcp.project.gkeService.cluster
 }
 
-// GCP GKE Cluster
+// GCP GKE cluster
 private gcp.project.gkeService.cluster @defaults("name") {
   // Project ID
   projectId string
@@ -1472,7 +1472,7 @@ private gcp.project.gkeService.cluster @defaults("name") {
   databaseEncryption dict
 }
 
-// GKE Cluster Addons Config
+// GKE cluster addons config
 private gcp.project.gkeService.cluster.addonsConfig {
   // Internal ID
   id string
@@ -1498,7 +1498,7 @@ private gcp.project.gkeService.cluster.addonsConfig {
   gkeBackupAgentConfig dict
 }
 
-// GKE Cluster IP Allocation Policy
+// GKE cluster IP allocation policy
 private gcp.project.gkeService.cluster.ipAllocationPolicy {
   // Internal ID
   id string
@@ -1528,7 +1528,7 @@ private gcp.project.gkeService.cluster.ipAllocationPolicy {
   ipv6AccessType string
 }
 
-// GKE Cluster Network Config
+// GKE cluster network config
 private gcp.project.gkeService.cluster.networkConfig @defaults("networkPath") {
   // Internal ID
   id string
@@ -1556,7 +1556,7 @@ private gcp.project.gkeService.cluster.networkConfig @defaults("networkPath") {
   serviceExternalIpsConfig dict
 }
 
-// GKE Cluster Node Pool
+// GKE cluster node pool
 private gcp.project.gkeService.cluster.nodepool @defaults("name") {
   // Internal ID
   id string
@@ -1580,7 +1580,7 @@ private gcp.project.gkeService.cluster.nodepool @defaults("name") {
   management dict
 }
 
-// GCP GKE Node Pool-Level Network Configuration
+// GCP GKE node pool-Level network configuration
 private gcp.project.gkeService.cluster.nodepool.networkConfig @defaults("podRange podIpv4CidrBlock") {
   // Internal ID
   id string
@@ -1592,7 +1592,7 @@ private gcp.project.gkeService.cluster.nodepool.networkConfig @defaults("podRang
   performanceConfig gcp.project.gkeService.cluster.nodepool.networkConfig.performanceConfig
 }
 
-// GCP GKE Node Pool Network Performance Configuration
+// GCP GKE node pool network performance configuration
 private gcp.project.gkeService.cluster.nodepool.networkConfig.performanceConfig @defaults("totalEgressBandwidthTier") {
   // Internal ID
   id string
@@ -1600,7 +1600,7 @@ private gcp.project.gkeService.cluster.nodepool.networkConfig.performanceConfig 
   totalEgressBandwidthTier string
 }
 
-// GCP GKE Node Pool Configuration
+// GCP GKE node pool configuration
 private gcp.project.gkeService.cluster.nodepool.config @defaults("machineType diskSizeGb") {
   // Internal ID
   id string
@@ -1660,7 +1660,7 @@ private gcp.project.gkeService.cluster.nodepool.config @defaults("machineType di
   confidentialNodes gcp.project.gkeService.cluster.nodepool.config.confidentialNodes
 }
 
-// GCP GKE Node Pool Hardware Accelerators Configuration
+// GCP GKE node pool hardware accelerators configuration
 private gcp.project.gkeService.cluster.nodepool.config.accelerator @defaults("type count") {
   // Internal ID
   id string
@@ -1684,7 +1684,7 @@ private gcp.project.gkeService.cluster.nodepool.config.accelerator.gpuSharingCon
   strategy string
 }
 
-// GCP GKE Kubernetes Node Taint
+// GCP GKE Kubernetes node taint
 private gcp.project.gkeService.cluster.nodepool.config.nodeTaint @defaults("key value effect") {
   // Internal ID
   id string
@@ -1696,7 +1696,7 @@ private gcp.project.gkeService.cluster.nodepool.config.nodeTaint @defaults("key 
   effect string
 }
 
-// GCP GKE Node Pool Sandbox Configuration
+// GCP GKE node pool sandbox configuration
 private gcp.project.gkeService.cluster.nodepool.config.sandboxConfig @defaults("type") {
   // Internal ID
   id string
@@ -1704,7 +1704,7 @@ private gcp.project.gkeService.cluster.nodepool.config.sandboxConfig @defaults("
   type string
 }
 
-// GCP GKE Node Pool Shielded Instance Configuration
+// GCP GKE node pool shielded instance configuration
 private gcp.project.gkeService.cluster.nodepool.config.shieldedInstanceConfig @defaults("enableSecureBoot enableIntegrityMonitoring") {
   // Internal ID
   id string
@@ -1714,7 +1714,7 @@ private gcp.project.gkeService.cluster.nodepool.config.shieldedInstanceConfig @d
   enableIntegrityMonitoring bool
 }
 
-// GCP GKE Node Pool Parameters That Can Be Configured on Linux Nodes
+// GCP GKE node pool parameters that can be configured on Linux nodes
 private gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig @defaults("sysctls") {
   // Internal ID
   id string
@@ -1722,7 +1722,7 @@ private gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig @defaults
   sysctls map[string]string
 }
 
-// GCP GKE Node Pool Kubelet Configuration
+// GCP GKE Node Pool kubelet configuration
 private gcp.project.gkeService.cluster.nodepool.config.kubeletConfig @defaults("cpuManagerPolicy podPidsLimit") {
   // Internal ID
   id string
@@ -1734,7 +1734,7 @@ private gcp.project.gkeService.cluster.nodepool.config.kubeletConfig @defaults("
   podPidsLimit int
 }
 
-// GCP GKE Node Pool GCFS Configuration
+// GCP GKE node pool GCFS configuration
 private gcp.project.gkeService.cluster.nodepool.config.gcfsConfig @defaults("enabled") {
   // Internal ID
   id string
@@ -1742,7 +1742,7 @@ private gcp.project.gkeService.cluster.nodepool.config.gcfsConfig @defaults("ena
   enabled bool
 }
 
-// GCP GKE Node Pool Advanced Machine Features Configuration
+// GCP GKE node pool advanced machine features configuration
 private gcp.project.gkeService.cluster.nodepool.config.advancedMachineFeatures @defaults("threadsPerCore") {
   // Internal ID
   id string
@@ -1750,7 +1750,7 @@ private gcp.project.gkeService.cluster.nodepool.config.advancedMachineFeatures @
   threadsPerCore int
 }
 
-// GCP GKE Node Pool GVNIC Configuration
+// GCP GKE node pool GVNIC configuration
 private gcp.project.gkeService.cluster.nodepool.config.gvnicConfig @defaults("enabled") {
   // Internal ID
   id string
@@ -1758,7 +1758,7 @@ private gcp.project.gkeService.cluster.nodepool.config.gvnicConfig @defaults("en
   enabled bool
 }
 
-// GCP GKE Node Pool Confidential Nodes Configuration
+// GCP GKE node pool confidential nodes configuration
 private gcp.project.gkeService.cluster.nodepool.config.confidentialNodes @defaults("enabled") {
   // Internal ID
   id string
@@ -1766,7 +1766,7 @@ private gcp.project.gkeService.cluster.nodepool.config.confidentialNodes @defaul
   enabled bool
 }
 
-// GCP Pub/Sub Resources
+// GCP Pub/Sub resources
 private gcp.project.pubsubService {
   // Project ID
   projectId string
@@ -1778,7 +1778,7 @@ private gcp.project.pubsubService {
   snapshots() []gcp.project.pubsubService.snapshot
 }
 
-// GCP Pub/Sub Topic
+// GCP Pub/Sub topic
 private gcp.project.pubsubService.topic @defaults("name") {
   // Project ID
   projectId string
@@ -1788,7 +1788,7 @@ private gcp.project.pubsubService.topic @defaults("name") {
   config() gcp.project.pubsubService.topic.config
 }
 
-// GCP Pub/Sub Topic Configuration
+// GCP Pub/Sub topic configuration
 private gcp.project.pubsubService.topic.config @defaults("kmsKeyName messageStoragePolicy") {
   // Project ID
   projectId string
@@ -1802,7 +1802,7 @@ private gcp.project.pubsubService.topic.config @defaults("kmsKeyName messageStor
   messageStoragePolicy gcp.project.pubsubService.topic.config.messagestoragepolicy
 }
 
-// GCP Pub/Sub Topic Message Storage Policy
+// GCP Pub/Sub topic message storage policy
 private gcp.project.pubsubService.topic.config.messagestoragepolicy @defaults("allowedPersistenceRegions"){
   // Parent configuration ID
   configId string
@@ -1810,7 +1810,7 @@ private gcp.project.pubsubService.topic.config.messagestoragepolicy @defaults("a
   allowedPersistenceRegions []string
 }
 
-// GCP Pub/Sub Subscription
+// GCP Pub/Sub subscription
 private gcp.project.pubsubService.subscription @defaults("name") {
   // Project ID
   projectId string
@@ -1820,7 +1820,7 @@ private gcp.project.pubsubService.subscription @defaults("name") {
   config() gcp.project.pubsubService.subscription.config
 }
 
-// GCP Pub/Sub Subscription Configuration
+// GCP Pub/Sub subscription configuration
 private gcp.project.pubsubService.subscription.config @defaults("topic.name ackDeadline expirationPolicy") {
   // Project ID
   projectId string
@@ -1842,7 +1842,7 @@ private gcp.project.pubsubService.subscription.config @defaults("topic.name ackD
   labels map[string]string
 }
 
-// GCP Pub/Sub Configuration for Subscriptions That Operate in Push Mode
+// GCP Pub/Sub configuration for subscriptions that operate in push mode
 private gcp.project.pubsubService.subscription.config.pushconfig @defaults("attributes") {
   // Parent configuration ID
   configId string
@@ -1852,7 +1852,7 @@ private gcp.project.pubsubService.subscription.config.pushconfig @defaults("attr
   attributes map[string]string
 }
 
-// GCP Pub/Sub Snapshot
+// GCP Pub/Sub snapshot
 private gcp.project.pubsubService.snapshot @defaults("name") {
   // Project ID
   projectId string
@@ -1863,7 +1863,7 @@ private gcp.project.pubsubService.snapshot @defaults("name") {
   // When the snapshot expires
   expiration time
 }
-// GCP KMS Resources
+// GCP KMS resources
 private gcp.project.kmsService {
   // Project ID
   projectId string
@@ -1873,7 +1873,7 @@ private gcp.project.kmsService {
   keyrings() []gcp.project.kmsService.keyring
 }
 
-// GCP KMS Keyring
+// GCP KMS keyring
 private gcp.project.kmsService.keyring @defaults("name") {
   // Project ID
   projectId string
@@ -1889,7 +1889,7 @@ private gcp.project.kmsService.keyring @defaults("name") {
   cryptokeys() []gcp.project.kmsService.keyring.cryptokey
 }
 
-// GCP KMS Crypto Key
+// GCP KMS crypto key
 private gcp.project.kmsService.keyring.cryptokey @defaults("name purpose") {
   // Full resource path
   resourcePath string
@@ -1921,7 +1921,7 @@ private gcp.project.kmsService.keyring.cryptokey @defaults("name purpose") {
   iamPolicy() []gcp.resourcemanager.binding
 }
 
-// GCP KMS Crypto Key Version
+// GCP KMS crypto key version
 private gcp.project.kmsService.keyring.cryptokey.version @defaults("name state") {
   // Full resource path
   resourcePath string
@@ -1955,7 +1955,7 @@ private gcp.project.kmsService.keyring.cryptokey.version @defaults("name state")
   reimportEligible bool
 }
 
-// GCP KMS Crypto Key Version Attestation
+// GCP KMS crypto key version attestation
 private gcp.project.kmsService.keyring.cryptokey.version.attestation {
   // Crypto key version name
   cryptoKeyVersionName string
@@ -1965,7 +1965,7 @@ private gcp.project.kmsService.keyring.cryptokey.version.attestation {
   certificateChains gcp.project.kmsService.keyring.cryptokey.version.attestation.certificatechains
 }
 
-// GCP KMS Crypto Key Version Attestation Certificate Chains
+// GCP KMS crypto key version attestation certificate chains
 private gcp.project.kmsService.keyring.cryptokey.version.attestation.certificatechains {
   // Crypto key version name
   cryptoKeyVersionName string
@@ -1987,7 +1987,7 @@ private gcp.project.kmsService.keyring.cryptokey.version.externalProtectionLevel
   ekmConnectionKeyPath string
 }
 
-// GCP Contact
+// GCP contact
 private gcp.essentialContact @defaults("email notificationCategories") {
   // Full resource path
   resourcePath string
@@ -2003,7 +2003,7 @@ private gcp.essentialContact @defaults("email notificationCategories") {
   validationState string
 }
 
-// GCP Project API Key
+// GCP project API key
 private gcp.project.apiKey @defaults("name") {
   // The ID of the key
   id string
@@ -2027,7 +2027,7 @@ private gcp.project.apiKey @defaults("name") {
   updated time
 }
 
-// GCP Project API key restrictions
+// GCP project API key restrictions
 private gcp.project.apiKey.restrictions {
   // Parent resource path
   parentResourcePath string
@@ -2043,7 +2043,7 @@ private gcp.project.apiKey.restrictions {
   serverKeyRestrictions dict
 }
 
-// GCP Logging Resources
+// GCP Logging resources
 private gcp.project.loggingservice {
   // Project ID
   projectId string
@@ -2055,7 +2055,7 @@ private gcp.project.loggingservice {
   sinks() []gcp.project.loggingservice.sink
 }
 
-// GCP Logging Bucket
+// GCP Logging bucket
 private gcp.project.loggingservice.bucket @defaults("name") {
   // Project ID
   projectId string
@@ -2081,7 +2081,7 @@ private gcp.project.loggingservice.bucket @defaults("name") {
   updated time
 }
 
-// GCP Logging Bucket Index Config
+// GCP Logging bucket index config
 private gcp.project.loggingservice.bucket.indexConfig @defaults("id") {
   // Internal ID
   id string
@@ -2093,7 +2093,7 @@ private gcp.project.loggingservice.bucket.indexConfig @defaults("id") {
   type string
 }
 
-// GCP Logging Metric
+// GCP Logging metric
 private gcp.project.loggingservice.metric @defaults("description filter") {
   // Metric ID
   id string
@@ -2107,7 +2107,7 @@ private gcp.project.loggingservice.metric @defaults("description filter") {
   alertPolicies() []gcp.project.monitoringService.alertPolicy
 }
 
-// GCP Logging Sink
+// GCP Logging sink
 private gcp.project.loggingservice.sink @defaults("destination") {
   // Sink ID
   id string
@@ -2125,7 +2125,7 @@ private gcp.project.loggingservice.sink @defaults("destination") {
   includeChildren bool
 }
 
-// GCP IAM Resources
+// GCP IAM resources
 private gcp.project.iamService {
   // Project ID
   projectId string
@@ -2133,7 +2133,7 @@ private gcp.project.iamService {
   serviceAccounts() []gcp.project.iamService.serviceAccount
 }
 
-// GCP Service Account
+// GCP service account
 private gcp.project.iamService.serviceAccount @defaults("displayName name") {
   // Project ID
   projectId string
@@ -2155,7 +2155,7 @@ private gcp.project.iamService.serviceAccount @defaults("displayName name") {
   keys() []gcp.project.iamService.serviceAccount.key
 }
 
-// GCP Service Account Keys
+// GCP service sccount keys
 private gcp.project.iamService.serviceAccount.key @defaults("name") {
   // Service account key name
   name string
@@ -2172,7 +2172,7 @@ private gcp.project.iamService.serviceAccount.key @defaults("name") {
   // Whether the key is disabled
   disabled bool
 }
-// GCP Cloud Function
+// GCP cloud function
 private gcp.project.cloudFunction @defaults("name") {
   // Project ID
   projectId string
@@ -2241,7 +2241,7 @@ private gcp.project.cloudFunction @defaults("name") {
   // Docker registry to use for this deployment
   dockerRegistry string
 }
-// GCP Dataproc Resources
+// GCP Dataproc resources
 private gcp.project.dataprocService {
   // Project ID
   projectId string
@@ -2253,7 +2253,7 @@ private gcp.project.dataprocService {
   clusters() []gcp.project.dataprocService.cluster
 }
 
-// GCP Dataproc Cluster
+// GCP Dataproc cluster
 private gcp.project.dataprocService.cluster @defaults("name") {
   // Project ID
   projectId string
@@ -2275,7 +2275,7 @@ private gcp.project.dataprocService.cluster @defaults("name") {
   virtualClusterConfig gcp.project.dataprocService.cluster.virtualClusterConfig
 }
 
-// GCP Dataproc Cluster Config
+// GCP Dataproc cluster config
 private gcp.project.dataprocService.cluster.config {
   // Parent resource path
   parentResourcePath string
@@ -2313,7 +2313,7 @@ private gcp.project.dataprocService.cluster.config {
   worker gcp.project.dataprocService.cluster.config.instance
 }
 
-// GCP Dataproc Cluster Endpoint Config
+// GCP Dataproc cluster endpoint config
 private gcp.project.dataprocService.cluster.config.gceCluster {
   // Internal ID
   id string
@@ -2349,7 +2349,7 @@ private gcp.project.dataprocService.cluster.config.gceCluster {
   zoneUri string
 }
 
-// GCP Dataproc Cluster GCE Cluster Reservation Affinity Config
+// GCP Dataproc cluster GCE cluster reservation affinity config
 private gcp.project.dataprocService.cluster.config.gceCluster.reservationAffinity {
   // Internal ID
   id string
@@ -2361,7 +2361,7 @@ private gcp.project.dataprocService.cluster.config.gceCluster.reservationAffinit
   values []string
 }
 
-// GCP Dataproc Cluster GCE Cluster Shielded Instance Config
+// GCP Dataproc cluster GCE cluster shielded instance config
 private gcp.project.dataprocService.cluster.config.gceCluster.shieldedInstanceConfig {
   // Internal ID
   id string
@@ -2373,7 +2373,7 @@ private gcp.project.dataprocService.cluster.config.gceCluster.shieldedInstanceCo
   enableVtpm bool
 }
 
-// GCP Dataproc cluster GKE Cluster config
+// GCP Dataproc cluster GKE cluster config
 private gcp.project.dataprocService.cluster.config.gkeCluster {
   // Internal ID
   id string
@@ -2383,7 +2383,7 @@ private gcp.project.dataprocService.cluster.config.gkeCluster {
   nodePoolTarget []dict
 }
 
-// GCP Dataproc Cluster Lifecycle Config
+// GCP Dataproc cluster lifecycle config
 private gcp.project.dataprocService.cluster.config.lifecycle {
   // Internal ID
   id string
@@ -2425,7 +2425,7 @@ private gcp.project.dataprocService.cluster.config.instance {
   preemptibility string
 }
 
-// GCP Dataproc Cluster Instance Disk Config
+// GCP Dataproc cluster instance disk config
 private gcp.project.dataprocService.cluster.config.instance.diskConfig {
   // Internal ID
   id string
@@ -2439,7 +2439,7 @@ private gcp.project.dataprocService.cluster.config.instance.diskConfig {
   numLocalSsds int
 }
 
-// GCP Dataproc Cluster Status
+// GCP Dataproc cluster status
 private gcp.project.dataprocService.cluster.status @defaults("state") {
   // Internal ID
   id string
@@ -2453,7 +2453,7 @@ private gcp.project.dataprocService.cluster.status @defaults("state") {
   substate string
 }
 
-// GCP Dataproc Cluster Virtual Cluster Config
+// GCP Dataproc cluster virtual cluster config
 private gcp.project.dataprocService.cluster.virtualClusterConfig {
   // Parent resource path
   parentResourcePath string
@@ -2464,7 +2464,7 @@ private gcp.project.dataprocService.cluster.virtualClusterConfig {
   // Cloud Storage bucket used to stage job dependencies, config files, and job driver console output
   stagingBucket string
 }
-// GCP Cloud Run Resources
+// GCP Cloud Run resources
 private gcp.project.cloudRunService {
   // Project ID
   projectId string
@@ -2478,7 +2478,7 @@ private gcp.project.cloudRunService {
   jobs() []gcp.project.cloudRunService.job
 }
 
-// GCP Cloud Run Operation
+// GCP Cloud Run operation
 private gcp.project.cloudRunService.operation @defaults("name") {
   // Project ID
   projectId string
@@ -2488,7 +2488,7 @@ private gcp.project.cloudRunService.operation @defaults("name") {
   done bool
 }
 
-// GCP Cloud Run Service
+// GCP Cloud Run service
 private gcp.project.cloudRunService.service @defaults("name") {
   // Service identifier
   id string
@@ -2544,7 +2544,7 @@ private gcp.project.cloudRunService.service @defaults("name") {
   reconciling bool
 }
 
-// GCP Cloud Run Service Revision Template
+// GCP Cloud Run service revision template
 private gcp.project.cloudRunService.service.revisionTemplate @defaults("name") {
   // Internal ID
   id string
@@ -2578,7 +2578,7 @@ private gcp.project.cloudRunService.service.revisionTemplate @defaults("name") {
   maxInstanceRequestConcurrency int
 }
 
-// GCP Cloud Run Service Revision Template Container
+// GCP Cloud Run service revision template container
 private gcp.project.cloudRunService.container @defaults("name image") {
   // Internal ID
   id string
@@ -2606,7 +2606,7 @@ private gcp.project.cloudRunService.container @defaults("name image") {
   startupProbe gcp.project.cloudRunService.container.probe
 }
 
-// GCP Cloud Run Service Revision Template Container Probe
+// GCP Cloud Run service revision template container probe
 private gcp.project.cloudRunService.container.probe {
   // Internal ID
   id string
@@ -2624,7 +2624,7 @@ private gcp.project.cloudRunService.container.probe {
   tcpSocket dict
 }
 
-// GCP Cloud Run Condition
+// GCP Cloud Run condition
 private gcp.project.cloudRunService.condition @defaults("type state message") {
   // Internal ID
   id string
@@ -2640,7 +2640,7 @@ private gcp.project.cloudRunService.condition @defaults("type state message") {
   severity string
 }
 
-// GCP Cloud Run Job
+// GCP Cloud Run job
 private gcp.project.cloudRunService.job {
   // Job identifier
   id string
@@ -2688,7 +2688,7 @@ private gcp.project.cloudRunService.job {
   reconciling bool
 }
 
-// GCP Cloud Run Job Execution Template
+// GCP Cloud Run job execution template
 private gcp.project.cloudRunService.job.executionTemplate {
   // Internal ID
   id string
@@ -2704,7 +2704,7 @@ private gcp.project.cloudRunService.job.executionTemplate {
   template gcp.project.cloudRunService.job.executionTemplate.taskTemplate
 }
 
-// GCP Cloud Run Job Execution Template Task Template
+// GCP Cloud Run job execution template task template
 private gcp.project.cloudRunService.job.executionTemplate.taskTemplate {
   // Internal ID
   id string
@@ -2730,7 +2730,7 @@ private gcp.project.cloudRunService.job.executionTemplate.taskTemplate {
   maxRetries int
 }
 
-// GCP Access Approval Settings
+// GCP access approval settings
 private gcp.accessApprovalSettings {
   // Resource path
   resourcePath string
@@ -2748,7 +2748,7 @@ private gcp.accessApprovalSettings {
   invalidKeyVersion bool
 }
 
-// GCP Monitoring Resources
+// GCP monitoring resources
 private gcp.project.monitoringService {
   // Project ID
   projectId string
@@ -2756,7 +2756,7 @@ private gcp.project.monitoringService {
   alertPolicies() []gcp.project.monitoringService.alertPolicy
 }
 
-// GCP Monitoring Alert Policy
+// GCP monitoring alert policy
 private gcp.project.monitoringService.alertPolicy {
   // Project ID
   projectId string

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -2155,7 +2155,7 @@ private gcp.project.iamService.serviceAccount @defaults("displayName name") {
   keys() []gcp.project.iamService.serviceAccount.key
 }
 
-// GCP service sccount keys
+// GCP service account keys
 private gcp.project.iamService.serviceAccount.key @defaults("name") {
   // Service account key name
   name string

--- a/providers/github/resources/github.lr
+++ b/providers/github/resources/github.lr
@@ -44,7 +44,7 @@ private git.gpgSignature @defaults("sha") {
   signature string
 }
 
-// GitHub Organization
+// GitHub organization
 github.organization @defaults("login name") {
   // Organization login
   login string
@@ -128,7 +128,7 @@ github.organization @defaults("login name") {
   packages() []github.package
 }
 
-// GitHub User
+// GitHub user
 private github.user @defaults("id name") {
   // User ID
   id int
@@ -166,7 +166,7 @@ private github.user @defaults("id name") {
   gists() []github.gist
 }
 
-// GitHub Team
+// GitHub team
 private github.team @defaults("id name") {
   // Team ID
   id int
@@ -188,7 +188,7 @@ private github.team @defaults("id name") {
   organization github.organization
 }
 
-// GitHub Collaborator
+// GitHub collaborator
 private github.collaborator @defaults("user") {
   // Collaborator ID
   id int
@@ -198,7 +198,7 @@ private github.collaborator @defaults("user") {
   permissions []string
 }
 
-// GitHub Package
+// GitHub package
 private github.package @defaults("id name") {
   // Package ID
   id int
@@ -220,7 +220,7 @@ private github.package @defaults("id name") {
   repository() github.repository
 }
 
-// GitHub Repository
+// GitHub repository
 private github.repository @defaults("fullName") {
   init(name string) // can only be used when logged in to github as a user
   // Repository ID
@@ -323,7 +323,7 @@ private github.repository @defaults("fullName") {
   license() github.license
 }
 
-// GitHub License
+// GitHub license
 private github.license @defaults("spdxId") {
   // License key
   key string
@@ -335,7 +335,7 @@ private github.license @defaults("spdxId") {
   spdxId string
 }
 
-// GitHub Repository File
+// GitHub repository file
 private github.file @defaults("name type") {
   // File path
   path string
@@ -357,7 +357,7 @@ private github.file @defaults("name type") {
   content() string
 }
 
-// GitHub Release
+// GitHub release
 private github.release @defaults("name tagName") {
   // Release url
   url string
@@ -369,7 +369,7 @@ private github.release @defaults("name tagName") {
   preRelease bool
 }
 
-// GitHub Webhook
+// GitHub webhook
 private github.webhook @defaults("id name") {
   // Webhook ID
   id int
@@ -385,7 +385,7 @@ private github.webhook @defaults("id name") {
   active bool
 }
 
-// GitHub Workflow
+// GitHub workflow
 private github.workflow @defaults("id name") {
   // Workflow ID
   id int
@@ -405,7 +405,7 @@ private github.workflow @defaults("id name") {
   configuration() dict
 }
 
-// GitHub Repository Branch
+// GitHub repository branch
 private github.branch @defaults("name") {
   // Repository branch name
   name string
@@ -425,7 +425,7 @@ private github.branch @defaults("name") {
   isDefault bool
 }
 
-// GitHub Repository Branch Protection
+// GitHub repository branch protection
 private github.branchprotection @defaults("id") {
   // Repository branch protection ID
   id string
@@ -449,7 +449,7 @@ private github.branchprotection @defaults("id") {
   allowDeletions dict
 }
 
-// GitHub Repository Commit
+// GitHub repository commit
 private github.commit @defaults("sha") {
   // Commit owner
   owner string
@@ -469,7 +469,7 @@ private github.commit @defaults("sha") {
   stats dict
 }
 
-// GitHub Repository Pull Request 
+// GitHub repository pull request 
 private github.mergeRequest @defaults("id state") {
   // Pull request ID
   id int
@@ -495,7 +495,7 @@ private github.mergeRequest @defaults("id state") {
   repoName string
 }
 
-// GitHub Repository Review
+// GitHub repository review
 private github.review @defaults("url state") {
   // Review url
   url string
@@ -507,7 +507,7 @@ private github.review @defaults("url state") {
   user github.user
 }
 
-// GitHub App Installation
+// GitHub application installation
 private github.installation @defaults("id appId") {
   // Application installation ID
   id int
@@ -521,7 +521,7 @@ private github.installation @defaults("id appId") {
   updatedAt time
 }
 
-// GitHub Gist
+// GitHub gist
 private github.gist @defaults("description") {
   // Gist ID
   id string
@@ -539,7 +539,7 @@ private github.gist @defaults("description") {
   files []github.gistfile
 }
 
-// GitHub Gist File
+// GitHub gist file
 private github.gistfile @defaults("filename") {
   // Gist ID
   gistId string
@@ -557,7 +557,7 @@ private github.gistfile @defaults("filename") {
   content() string
 }
 
-// GitHub Issue
+// GitHub issue
 private github.issue @defaults("title") {
   // Issue ID
   id int

--- a/providers/github/resources/github.lr
+++ b/providers/github/resources/github.lr
@@ -62,13 +62,13 @@ github.organization @defaults("login name") {
   location string
   // Organization email
   email string
-  // Organization twitter name
+  // Organization Twitter handle
   twitterUsername string
-  // Profile picture URL
+  // Organization profile picture URL
   avatarUrl string
-  // Organization followers
+  // Organization's number of followers
   followers int
-  // Organization following
+  // Number of organizations the organization is following
   following int
   // Organization description
   description string
@@ -76,7 +76,7 @@ github.organization @defaults("login name") {
   createdAt time
   // Update time for the organization
   updatedAt time
-  // Number of private repos
+  // Number of private repositories
   totalPrivateRepos int
   // Number of owned private repositories for the organization
   ownedPrivateRepos int
@@ -90,9 +90,9 @@ github.organization @defaults("login name") {
   billingEmail string
   // GitHub plan the organization is subscribed to
   plan dict
-  // Two-factor authentication required for all members
+  // Whether two-factor authentication is required for all members
   twoFactorRequirementEnabled bool
-  // Verified organization by GitHub
+  // Whether the organization is verified by GitHub
   isVerified bool
   // The default repository permission
   defaultRepositoryPermission string
@@ -150,17 +150,17 @@ private github.user @defaults("id name") {
   followers int
   // User following
   following int
-  // User twitter name
+  // User Twitter handle
   twitterUsername string
   // User create time in UTC
   createdAt time
   // Last user update time in UTC
   updatedAt time
-  // User suspended time
+  // When the user was suspended
   suspendedAt time
-  // User company
+  // User's company
   company string
-  // User repositories
+  // User's repositories
   repositories() []github.repository
   // User gists
   gists() []github.gist
@@ -192,9 +192,9 @@ private github.team @defaults("id name") {
 private github.collaborator @defaults("user") {
   // Collaborator ID
   id int
-  // Collaborator user information
+  // Collaborator's user information
   user github.user
-  // Collaborator permissions
+  // Collaborator's permissions
   permissions []string
 }
 
@@ -241,13 +241,13 @@ private github.repository @defaults("fullName") {
   topics []string
   // Repository language
   language string
-  // Count of repository watchers
+  // Number of users watching the repository
   watchersCount int
-  // Count of repository forks
+  // Number of repository forks
   forksCount int
-  // Count of repository stargazers
+  // Number of repository stargazers
   stargazersCount int
-  // Count of open issues in repository
+  // Number of open issues in repository
   openIssuesCount int
   // Repository create time
   createdAt time
@@ -279,7 +279,7 @@ private github.repository @defaults("fullName") {
   hasIssues bool
   // Whether the repository has projects
   hasProjects bool
-  // Whether the repository has wiki
+  // Whether the repository has a wiki
   hasWiki bool
   // Whether the repository has pages
   hasPages bool
@@ -345,9 +345,9 @@ private github.file @defaults("name type") {
   type string
   // File shasum
   sha string
-  // Whether file is a binary
+  // Whether the file is a binary
   isBinary bool
-  // List of files in directory
+  // List of files in the directory
   files() []github.file
   // File owner
   ownerName string
@@ -375,9 +375,9 @@ private github.webhook @defaults("id name") {
   id int
   // Webhook name
   name string
-  // Webhook url
+  // Webhook URL
   url string
-  // List of events for webhook
+  // List of events for the webhook
   events []string
   // Webhook config
   config dict
@@ -409,7 +409,7 @@ private github.workflow @defaults("id name") {
 private github.branch @defaults("name") {
   // Repository branch name
   name string
-  // Deprecated. Use isProtected instead
+  // Deprecated; use isProtected instead
   protected bool
   // Whether branch protection is enabled
   isProtected bool
@@ -421,7 +421,7 @@ private github.branch @defaults("name") {
   repoName string
   // Repository branch owner
   owner github.user
-  // Whether branch is the default branch
+  // Whether the branch is the default branch
   isDefault bool
 }
 
@@ -477,7 +477,7 @@ private github.mergeRequest @defaults("id state") {
   number int
   // Pull request state
   state string
-  // Pull request created at time (in UTC)
+  // Pull request creation time (in UTC)
   createdAt time
   // Pull request labels
   labels []dict
@@ -497,7 +497,7 @@ private github.mergeRequest @defaults("id state") {
 
 // GitHub repository review
 private github.review @defaults("url state") {
-  // Review url
+  // Review URL
   url string
   // Review state
   state string
@@ -511,7 +511,7 @@ private github.review @defaults("url state") {
 private github.installation @defaults("id appId") {
   // Application installation ID
   id int
-  // Application configured id
+  // Application configured ID
   appId int
   // Application configured slug
   appSlug string
@@ -533,7 +533,7 @@ private github.gist @defaults("description") {
   updatedAt time
   // Gist owner
   owner github.user
-  // Indicates whether the gist is public
+  // Whether the gist is public
   public bool
   // Gist files
   files []github.gistfile
@@ -549,7 +549,7 @@ private github.gistfile @defaults("filename") {
   type string
   // Gist file language
   language string
-  // Gist file raw url
+  // Gist file raw URL
   rawUrl string
   // Gist file size
   size int
@@ -569,7 +569,7 @@ private github.issue @defaults("title") {
   state string
   // Issue body
   body string
-  // Issue url
+  // Issue URL
   url string
   // Issue create time
   createdAt time
@@ -577,8 +577,8 @@ private github.issue @defaults("title") {
   updatedAt time
   // Issue closed time
   closedAt time
-  // Issue assignees
+  // Users to whom the issue is assigned
   assignees []github.user
-  // Issue closed by
+  // User who closed the issue
   closedBy github.user
 }

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -4,7 +4,7 @@
 option provider = "go.mondoo.com/cnquery/v9/providers/gitlab"
 option go_package = "go.mondoo.com/cnquery/v9/providers/gitlab/resources"
 
-// GitLab Group
+// GitLab group
 gitlab.group @defaults("name visibility webURL") {
   // Group ID
   id int
@@ -32,7 +32,7 @@ gitlab.group @defaults("name visibility webURL") {
   projects() []gitlab.project
 }
 
-// GitLab Project
+// GitLab project
 gitlab.project @defaults("fullName visibility webURL") {
   // Project ID
   id int

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -18,17 +18,17 @@ gitlab.group @defaults("name visibility webURL") {
   description string
   // URL of the group
   webURL string
-  // The group's visibility level. Can be private, internal, or public.
+  // The group's visibility level: private, internal, or public
   visibility string
-  // Require all users in this group to setup Two-factor authentication.
+  // Whether all users in this group are required to set up two-factor authentication
   requireTwoFactorAuthentication bool
-  // Don't allow forking projects outside this group
+  // Whether forking projects outside this group is forbidden
   preventForkingOutsideGroup bool
-  // Disable group email notifications
+  // Whether group email notifications are disabled
   emailsDisabled bool
-  // Disable group mentions within issues and merge requests
+  // Whether group mentions within issues and merge requests are disabled
   mentionsDisabled bool
-  // List all projects that belong to the group
+  // List of all projects that belong to the group
   projects() []gitlab.project
 }
 
@@ -46,40 +46,40 @@ gitlab.project @defaults("fullName visibility webURL") {
   createdAt time  
   // Project description
   description string
-  // Default git branch
+  // Default Git branch
   defaultBranch string
-  // The project's visibility level. Can be private, internal, or public.
+  // The project's visibility level: private, internal, or public
   visibility string
-  // Is the project archived?
+  // Whether the project is archived
   archived bool
-  // Is the project a mirror?
+  // Whether the project is a mirror
   mirror bool
   // URL of the project
   webURL string
-  // Disable project email notifications
+  // Whether project email notifications are disabled
   emailsDisabled bool
-  // Allow merging merge requests when a pipeline is skipped
+  // Whether merging merge requests is allowed when a pipeline is skipped
   allowMergeOnSkippedPipeline bool
-  // Only allow merging merge requests if the pipelines succeed
+  // Whether merging merge requests is allowed only if the pipelines succeed
   onlyAllowMergeIfPipelineSucceeds bool
-  // Allow merging merge requests if all discussions are resolved
+  // Whether merging merge requests is allowed only if all discussions are resolved
   onlyAllowMergeIfAllDiscussionsAreResolved bool
-  // Is the issues feature enabled?
+  // Whether the issues feature is enabled
   issuesEnabled bool
-	// Is the merge request feature enabled?
+	// Whether the merge request feature is enabled
   mergeRequestsEnabled bool
-	// Is the wiki feature enabled?
+	// Whether the wiki feature is enabled
   wikiEnabled bool
-	// Is the snippets feature enabled?
+	// Whether the snippets feature is enabled
   snippetsEnabled bool
-	// Is the container registry feature enabled?
+	// Whether the container registry feature is enabled
   containerRegistryEnabled bool
-	// Is the Service Desk feature enabled?
+	// Whether the Service Desk feature is enabled
   serviceDeskEnabled bool
-	// Is the packages feature enabled?
+	// Whether the packages feature is enabled
   packagesEnabled bool
-	// Is the Auto DevOps feature enabled?
+	// Whether the Auto DevOps feature is enabled
   autoDevopsEnabled bool
-	// Is the requirements feature enabled?
+	// Whether the requirements feature is enabled
   requirementsEnabled bool
 }

--- a/providers/google-workspace/resources/google-workspace.lr
+++ b/providers/google-workspace/resources/google-workspace.lr
@@ -42,7 +42,7 @@ private googleworkspace.domain @defaults("domainName") {
   creationTime time
 }
 
-// Google Workspace User Accounts
+// Google Workspace user accounts
 private googleworkspace.user @defaults("primaryEmail") {
   // The unique ID for the user
   id string
@@ -86,7 +86,7 @@ private googleworkspace.user @defaults("primaryEmail") {
   tokens() []googleworkspace.token
 }
 
-// Google Workspace Token
+// Google Workspace token
 private googleworkspace.token @defaults("displayText") {
   // Indicates if the application is registered with Google
   anonymous bool
@@ -102,7 +102,7 @@ private googleworkspace.token @defaults("displayText") {
   userKey string
 }
 
-// Google Workspace Third-party Connected Apps
+// Google Workspace third-party connected apps
 private googleworkspace.connectedApp @defaults("name clientId") {
   // The unique ID of the application
   clientId string
@@ -116,7 +116,7 @@ private googleworkspace.connectedApp @defaults("name clientId") {
   tokens []googleworkspace.token
 }
 
-// Google Workspace Group
+// Google Workspace group
 private googleworkspace.group @defaults("email") {
   // The unique ID of a group
   id string
@@ -140,7 +140,7 @@ private googleworkspace.group @defaults("email") {
   securitySettings() dict
 }
 
-// Google Workspace Group Member
+// Google Workspace group member
 private googleworkspace.member @defaults("email") {
   // The unique ID of the group member
   id string
@@ -154,7 +154,7 @@ private googleworkspace.member @defaults("email") {
   user() googleworkspace.user
 }
 
-// Google Workspace Role
+// Google Workspace role
 private googleworkspace.role @defaults("name") {
   // ID of the role
   id int
@@ -170,12 +170,12 @@ private googleworkspace.role @defaults("name") {
   privileges []dict
 }
 
-// Google Workspace Apps Reports
+// Google Workspace apps reports
 private googleworkspace.report.apps {
   drive() []googleworkspace.report.activity
 }
 
-// Google Workspace App Reports Activity
+// Google Workspace app reports activity
 private googleworkspace.report.activity {
   id int
   ipAddress string
@@ -184,12 +184,12 @@ private googleworkspace.report.activity {
   events []dict
 }
 
-// Google Workspace User Usage Reports
+// Google Workspace user usage reports
 private googleworkspace.report.users {
   []googleworkspace.report.usage
 }
 
-// Google Workspace Usage Report
+// Google workspace usage report
 private googleworkspace.report.usage {
   // The unique identifier of the customer's account
   customerId string


### PR DESCRIPTION
I changed some resource descriptions to heading-style caps in some earlier commits. This returns them to sentence-style caps.
I also tacked on some other edits.