### PR TITLE
🧹 add CompilerConfig on all compile-related calls

### DIFF
--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -21,6 +21,7 @@ import (
 	"go.mondoo.com/cnquery/v9/cli/theme"
 	"go.mondoo.com/cnquery/v9/explorer"
 	"go.mondoo.com/cnquery/v9/explorer/scan"
+	"go.mondoo.com/cnquery/v9/mqlc"
 	"go.mondoo.com/cnquery/v9/providers"
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/plugin"
@@ -282,8 +283,9 @@ func (c *scanConfig) loadBundles() error {
 			return err
 		}
 
+		conf := mqlc.NewConfig(c.runtime.Schema(), cnquery.DefaultFeatures)
 		_, err = bundle.CompileExt(context.Background(), explorer.BundleCompileConf{
-			Schema: c.runtime.Schema(),
+			CompilerConfig: conf,
 			// We don't care about failing queries for local runs. We may only
 			// process a subset of all the queries in the bundle. When we receive
 			// things from the server, upstream can filter things for us. But running

--- a/explorer/bundle_test.go
+++ b/explorer/bundle_test.go
@@ -10,10 +10,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/v9"
+	"go.mondoo.com/cnquery/v9/mqlc"
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/testutils"
 )
 
-var mock = testutils.LinuxMock()
+var (
+	mock = testutils.LinuxMock()
+	conf = mqlc.NewConfig(mock.Schema(), cnquery.DefaultFeatures)
+)
 
 func TestBundleLoad(t *testing.T) {
 	t.Run("load bundle from file", func(t *testing.T) {
@@ -56,8 +61,8 @@ func TestFilterQueriesWontCompile(t *testing.T) {
 	b2, err := BundleFromYAML([]byte(failingVariant))
 	require.NoError(t, err)
 	_, err2 := b2.CompileExt(context.Background(), BundleCompileConf{
-		Schema:        mock.Schema(),
-		RemoveFailing: false,
+		CompilerConfig: conf,
+		RemoveFailing:  false,
 	})
 	require.Error(t, err2)
 }
@@ -66,8 +71,8 @@ func TestFilterQueriesIgnoreError(t *testing.T) {
 	b, err := BundleFromYAML([]byte(failingVariant))
 	require.NoError(t, err)
 	bmap, err := b.CompileExt(context.Background(), BundleCompileConf{
-		Schema:        mock.Schema(),
-		RemoveFailing: true,
+		CompilerConfig: conf,
+		RemoveFailing:  true,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, bmap)

--- a/explorer/executor/executor.go
+++ b/explorer/executor/executor.go
@@ -14,6 +14,7 @@ import (
 	"go.mondoo.com/cnquery/v9/cli/progress"
 	"go.mondoo.com/cnquery/v9/explorer"
 	"go.mondoo.com/cnquery/v9/llx"
+	"go.mondoo.com/cnquery/v9/mqlc"
 	"go.mondoo.com/cnquery/v9/utils/multierr"
 )
 
@@ -36,9 +37,10 @@ func RunExecutionJob(
 func ExecuteFilterQueries(runtime llx.Runtime, queries []*explorer.Mquery, timeout time.Duration) ([]*explorer.Mquery, []error) {
 	equeries := map[string]*explorer.ExecutionQuery{}
 	mqueries := map[string]*explorer.Mquery{}
+	conf := mqlc.NewConfig(runtime.Schema(), cnquery.DefaultFeatures)
 	for i := range queries {
 		query := queries[i]
-		code, err := query.Compile(nil, runtime.Schema())
+		code, err := query.Compile(nil, conf)
 		// Errors for filter queries are common when they reference resources for
 		// providers that are not found on the system.
 		if err != nil {

--- a/explorer/filters.go
+++ b/explorer/filters.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"go.mondoo.com/cnquery/v9/checksums"
-	llx "go.mondoo.com/cnquery/v9/llx"
+	"go.mondoo.com/cnquery/v9/mqlc"
 	"go.mondoo.com/cnquery/v9/utils/multierr"
 )
 
@@ -114,14 +114,17 @@ func (s *Filters) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, (*tmp)(s))
 }
 
-func (s *Filters) Compile(ownerMRN string, schema llx.Schema) error {
+func (s *Filters) Compile(ownerMRN string, conf mqlc.CompilerConfig) error {
 	if s == nil || len(s.Items) == 0 {
 		return nil
 	}
 
 	res := make(map[string]*Mquery, len(s.Items))
 	for _, query := range s.Items {
-		query.RefreshAsFilter(ownerMRN, schema)
+		_, err := query.RefreshAsFilter(ownerMRN, conf)
+		if err != nil {
+			return err
+		}
 
 		if _, ok := res[query.CodeId]; ok {
 			continue

--- a/explorer/impact.go
+++ b/explorer/impact.go
@@ -11,6 +11,24 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func (v *Impact) HumanReadable() string {
+	if v.Value == nil {
+		return "unknown"
+	}
+	switch {
+	case v.Value.Value >= 90:
+		return "critical"
+	case v.Value.Value >= 70:
+		return "high"
+	case v.Value.Value >= 40:
+		return "medium"
+	case v.Value.Value > 0:
+		return "low"
+	default:
+		return "info"
+	}
+}
+
 func (v *Impact) AddBase(base *Impact) {
 	if base == nil {
 		return

--- a/explorer/mquery_test.go
+++ b/explorer/mquery_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/v9"
+	"go.mondoo.com/cnquery/v9/mqlc"
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/testutils"
 )
 
@@ -20,13 +22,14 @@ func TestMquery_RefreshAsAssetFilterStableChecksum(t *testing.T) {
 	}
 
 	x := testutils.LinuxMock()
+	conf := mqlc.NewConfig(x.Schema(), cnquery.DefaultFeatures)
 
-	_, err := m.RefreshAsFilter("//owner/me", x.Schema())
+	_, err := m.RefreshAsFilter("//owner/me", conf)
 	require.NoError(t, err)
 	assert.Equal(t, "//owner/me/filter/"+m.CodeId, m.Mrn)
 
 	cs := m.Checksum
-	_, err = m.RefreshAsFilter("//owner/me", x.Schema())
+	_, err = m.RefreshAsFilter("//owner/me", conf)
 	require.NoError(t, err)
 	assert.Equal(t, cs, m.Checksum)
 }
@@ -46,9 +49,10 @@ func TestMquery_Refresh(t *testing.T) {
 	assert.Empty(t, a.Props[0].Uid)
 
 	x := testutils.LinuxMock()
+	conf := mqlc.NewConfig(x.Schema(), cnquery.DefaultFeatures)
 	err = a.RefreshChecksum(
 		context.Background(),
-		x.Schema(),
+		conf,
 		func(ctx context.Context, mrn string) (*Mquery, error) {
 			return nil, nil
 		},

--- a/explorer/property.go
+++ b/explorer/property.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 
 	"github.com/rs/zerolog/log"
-	"go.mondoo.com/cnquery/v9"
 	"go.mondoo.com/cnquery/v9/checksums"
 	llx "go.mondoo.com/cnquery/v9/llx"
 	"go.mondoo.com/cnquery/v9/mqlc"
@@ -43,17 +42,17 @@ func (p *Property) RefreshMRN(ownerMRN string) error {
 }
 
 // Compile a given property and return the bundle.
-func (p *Property) Compile(props map[string]*llx.Primitive, schema llx.Schema) (*llx.CodeBundle, error) {
-	return mqlc.Compile(p.Mql, props, mqlc.NewConfig(schema, cnquery.DefaultFeatures))
+func (p *Property) Compile(props map[string]*llx.Primitive, conf mqlc.CompilerConfig) (*llx.CodeBundle, error) {
+	return mqlc.Compile(p.Mql, props, conf)
 }
 
 // RefreshChecksumAndType by compiling the query and updating the Checksum field
-func (p *Property) RefreshChecksumAndType(schema llx.Schema) (*llx.CodeBundle, error) {
-	return p.refreshChecksumAndType(schema)
+func (p *Property) RefreshChecksumAndType(conf mqlc.CompilerConfig) (*llx.CodeBundle, error) {
+	return p.refreshChecksumAndType(conf)
 }
 
-func (p *Property) refreshChecksumAndType(schema llx.Schema) (*llx.CodeBundle, error) {
-	bundle, err := p.Compile(nil, schema)
+func (p *Property) refreshChecksumAndType(conf mqlc.CompilerConfig) (*llx.CodeBundle, error) {
+	bundle, err := p.Compile(nil, conf)
 	if err != nil {
 		return bundle, multierr.Wrap(err, "failed to compile property '"+p.Mql+"'")
 	}


### PR DESCRIPTION
Remaining todos to move this out of draft:
- [ ] update cnspec: https://github.com/mondoohq/cnspec/pull/937
- [ ] update other components

-----

Until now, the only thing developers can configure when it comes to compile-related calls is the schema.

However, there are use-cases where we may want to configure other things in the compiler, like:
- which feature-flags are enabled/disabled
- use of stats

I ran into the last use-case myself, which would have caused large copy-paste rewrites of the Bundle-compiler, just in order to get access to all the stats.

At this point it is a more comprehensive experience to not move the schema around, but instead wire the compiler config directly through all these calls. This means that more future-facing features will be configurable and that a chain of calls (like `Bundle.Compile`) uses a consistent set of compiler configs.

@ Reviewers: I recommend merging this post-release, since it will require changes in all upstream projects that depend on it. I have already updated cnspec, but there are more.