### PR TITLE
🧹 aws ebs scan: reassign to fs conn once mounted

### DIFF
--- a/providers/aws/provider/provider.go
+++ b/providers/aws/provider/provider.go
@@ -217,7 +217,15 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	case string(awsec2ebsconn.EBSConnectionType):
 		s.lastConnectionID++
 		conn, err = awsec2ebsconn.NewAwsEbsConnection(s.lastConnectionID, conf, asset)
-
+		if conn.Asset() != nil && len(conn.Asset().Connections) > 0 && conn.Asset().Connections[0].Options["mounted"] != "" {
+			// if we've already done all the mounting work, then reassign the connection
+			// to be the filesystem connection so we use the right connection down the line
+			fsconn := conn.(*awsec2ebsconn.AwsEbsConnection).FsProvider
+			conn = fsconn
+			req.Asset = fsconn.Asset()
+			req.Asset.Connections[0] = fsconn.Conf
+			asset = req.Asset
+		}
 	default:
 		s.lastConnectionID++
 		conn, err = connection.NewAwsConnection(s.lastConnectionID, asset, conf)


### PR DESCRIPTION
fixes https://github.com/mondoohq/server/issues/6770 for ebs scanning, we should look at other places where this happens

with this pr i get a score on my asset instead of X/error: https://edge.console.mondoo.com/space/inventory/2XojNy4h1BPQyzpQWOHXuqQSbNQ/overview?spaceId=funny-poitras-168395