### PR TITLE
🐛 fix listing of windows processes

### DIFF
--- a/providers/os/resources/processes/ps1getprocess.go
+++ b/providers/os/resources/processes/ps1getprocess.go
@@ -179,5 +179,7 @@ func (wpm *WindowsProcessManager) Process(pid int64) (*OSProcess, error) {
 }
 
 func (wpm *WindowsProcessManager) ListSocketInodesByProcess() (map[int64]plugin.TValue[[]int64], error) {
-	return nil, errors.New("not implemented")
+	// This function is always invoked when listing processes (for unix and windows). If we return an error
+	// here, we break process listing. Instead we return an empty map
+	return map[int64]plugin.TValue[[]int64]{}, nil
 }


### PR DESCRIPTION
I believe the Inode stuff should be implemented for unix but not for windows. However, returning a "not implemented" error is breaking windows resources. Looking at the code it seems that we just need to return an empty map

Fixes #2530 