### PR TITLE
✨ Make querypack + query UIDs mandatory

### DIFF
--- a/examples/os.mql.yaml
+++ b/examples/os.mql.yaml
@@ -8,13 +8,16 @@ packs:
 
   queries:
   - title: Find all SSH packages that are installed
+    uid: ssh-packages
     mql: |
       packages.
         where(name == /ssh/)
   - title: Get SSH services
+    uid: ssh-services
     mql: |
       services.
         where(name == /ssh/)
   - title: All the SSH config
+    uid: ssh-config
     mql: |
       sshd.config.params


### PR DESCRIPTION
During the initial release of cnquery we made it easy for users to write bundles. One of our decisions was to make `uid` fields optional for both querypacks and queries at that time.

However, in the meantime we have learned how important these fields are for exception-handling. Adding them on the fly will lead to changing UIDs. Even if we relied on MQL or metadata contents, it would easily cause auto-generated UIDs to change if these contents change.

We plan to add functionality to the linter and/or initial loading steps to auto-fill UIDs on the fly - but at the same time modify the bundle and write them back to disk. This helps new users while keeping the field stable.