### PR TITLE
🐛 Keep idDetectors across connects

### DIFF
--- a/providers/os/provider/platform.go
+++ b/providers/os/provider/platform.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/inventory"
+	"go.mondoo.com/cnquery/v9/providers/os/connection"
 	"go.mondoo.com/cnquery/v9/providers/os/connection/shared"
 	"go.mondoo.com/cnquery/v9/providers/os/detector"
 	"go.mondoo.com/cnquery/v9/providers/os/id/awsec2"
@@ -26,6 +27,7 @@ type PlatformFingerprint struct {
 	Runtime       string
 	Kind          string
 	RelatedAssets []PlatformFingerprint
+	idDetectors   []string
 }
 
 type PlatformInfo struct {
@@ -44,8 +46,21 @@ func IdentifyPlatform(conn shared.Connection, p *inventory.Platform, idDetectors
 	}
 
 	var fingerprint PlatformFingerprint
-	var ids []string
+	var platformIds []string
 	var relatedIds []string
+
+	if len(idDetectors) == 0 {
+		// fallback to default id detectors
+		switch conn.Type() {
+		case connection.Local:
+			idDetectors = []string{ids.IdDetector_Hostname, ids.IdDetector_CloudDetect}
+		case connection.SSH:
+			idDetectors = []string{ids.IdDetector_Hostname, ids.IdDetector_CloudDetect, ids.IdDetector_SshHostkey}
+		case connection.Tar, connection.FileSystem, connection.DockerSnapshot:
+			idDetectors = []string{ids.IdDetector_Hostname}
+		}
+	}
+	fingerprint.idDetectors = idDetectors
 
 	for i := range idDetectors {
 		idDetector := idDetectors[i]
@@ -56,7 +71,7 @@ func IdentifyPlatform(conn shared.Connection, p *inventory.Platform, idDetectors
 			continue
 		}
 		if len(platformInfo.IDs) > 0 {
-			ids = append(ids, platformInfo.IDs...)
+			platformIds = append(platformIds, platformInfo.IDs...)
 		}
 		if len(platformInfo.RelatedPlatformIDs) > 0 {
 			relatedIds = append(relatedIds, platformInfo.RelatedPlatformIDs...)
@@ -84,11 +99,11 @@ func IdentifyPlatform(conn shared.Connection, p *inventory.Platform, idDetectors
 	}
 
 	// if we found zero platform ids something went wrong
-	if len(ids) == 0 {
+	if len(platformIds) == 0 {
 		return nil, errors.New("could not determine a platform identifier")
 	}
 
-	fingerprint.PlatformIDs = ids
+	fingerprint.PlatformIDs = platformIds
 	for _, v := range relatedIds {
 		fingerprint.RelatedAssets = append(fingerprint.RelatedAssets, PlatformFingerprint{
 			PlatformIDs: []string{v},
@@ -96,7 +111,7 @@ func IdentifyPlatform(conn shared.Connection, p *inventory.Platform, idDetectors
 		})
 	}
 
-	log.Debug().Interface("id-detector", idDetectors).Strs("platform-ids", ids).Msg("detected platform ids")
+	log.Debug().Interface("id-detector", idDetectors).Strs("platform-ids", platformIds).Msg("detected platform ids")
 	return &fingerprint, nil
 }
 

--- a/providers/os/provider/platform.go
+++ b/providers/os/provider/platform.go
@@ -22,12 +22,12 @@ import (
 )
 
 type PlatformFingerprint struct {
-	PlatformIDs   []string
-	Name          string
-	Runtime       string
-	Kind          string
-	RelatedAssets []PlatformFingerprint
-	idDetectors   []string
+	PlatformIDs       []string
+	Name              string
+	Runtime           string
+	Kind              string
+	RelatedAssets     []PlatformFingerprint
+	activeIdDetectors []string
 }
 
 type PlatformInfo struct {
@@ -60,7 +60,7 @@ func IdentifyPlatform(conn shared.Connection, p *inventory.Platform, idDetectors
 			idDetectors = []string{ids.IdDetector_Hostname}
 		}
 	}
-	fingerprint.idDetectors = idDetectors
+	fingerprint.activeIdDetectors = idDetectors
 
 	for i := range idDetectors {
 		idDetector := idDetectors[i]

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -319,7 +319,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 		if err == nil {
 			asset.Name = fingerprint.Name
 			asset.PlatformIds = fingerprint.PlatformIDs
-			asset.IdDetector = fingerprint.idDetectors
+			asset.IdDetector = fingerprint.activeIdDetectors
 		}
 
 	case SshConnectionType:
@@ -335,7 +335,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 				asset.Name = fingerprint.Name
 			}
 			asset.PlatformIds = fingerprint.PlatformIDs
-			asset.IdDetector = fingerprint.idDetectors
+			asset.IdDetector = fingerprint.activeIdDetectors
 		}
 
 	case TarConnectionType:
@@ -349,7 +349,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 		if err == nil {
 			asset.Name = fingerprint.Name
 			asset.PlatformIds = fingerprint.PlatformIDs
-			asset.IdDetector = fingerprint.idDetectors
+			asset.IdDetector = fingerprint.activeIdDetectors
 		}
 
 	case DockerSnapshotConnectionType:
@@ -363,7 +363,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 		if err == nil {
 			asset.Name = fingerprint.Name
 			asset.PlatformIds = fingerprint.PlatformIDs
-			asset.IdDetector = fingerprint.idDetectors
+			asset.IdDetector = fingerprint.activeIdDetectors
 		}
 
 	case VagrantConnectionType:
@@ -408,7 +408,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 			if err == nil {
 				asset.Name = fingerprint.Name
 				asset.PlatformIds = fingerprint.PlatformIDs
-				asset.IdDetector = fingerprint.idDetectors
+				asset.IdDetector = fingerprint.activeIdDetectors
 			}
 		} else {
 			// In this case asset.Name should already be set via the inventory

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -319,6 +319,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 		if len(idDetectors) == 0 {
 			// fallback to default id detectors
 			idDetectors = []string{ids.IdDetector_Hostname, ids.IdDetector_CloudDetect}
+			asset.IdDetector = idDetectors
 		}
 
 		fingerprint, err := IdentifyPlatform(conn, asset.Platform, idDetectors)
@@ -337,6 +338,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 		if len(idDetectors) == 0 {
 			// fallback to default id detectors
 			idDetectors = []string{ids.IdDetector_Hostname, ids.IdDetector_CloudDetect, ids.IdDetector_SshHostkey}
+			asset.IdDetector = idDetectors
 		}
 
 		fingerprint, err := IdentifyPlatform(conn, asset.Platform, idDetectors)
@@ -358,6 +360,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 		if len(idDetectors) == 0 {
 			// fallback to default id detectors
 			idDetectors = []string{ids.IdDetector_Hostname}
+			asset.IdDetector = idDetectors
 		}
 		fingerprint, err := IdentifyPlatform(conn, asset.Platform, idDetectors)
 		if err == nil {
@@ -376,6 +379,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 		if len(idDetectors) == 0 {
 			// fallback to default id detectors
 			idDetectors = []string{ids.IdDetector_Hostname}
+			asset.IdDetector = idDetectors
 		}
 
 		fingerprint, err := IdentifyPlatform(conn, asset.Platform, idDetectors)

--- a/providers/os/provider/provider_test.go
+++ b/providers/os/provider/provider_test.go
@@ -36,6 +36,7 @@ func TestLocalConnectionIdDetectors(t *testing.T) {
 	require.NotContains(t, connectResp.Asset.IdDetector, ids.IdDetector_SshHostkey)
 	// here we have the hostname twice, as platformid and stand alone
 	// This get's cleaned up later in the code
+	// FIXME: this should only be 1
 	require.Len(t, connectResp.Asset.PlatformIds, 2)
 
 	shutdownconnectResp, err := srv.Shutdown(&plugin.ShutdownReq{})

--- a/providers/os/provider/provider_test.go
+++ b/providers/os/provider/provider_test.go
@@ -1,0 +1,64 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/v9/providers-sdk/v1/inventory"
+	"go.mondoo.com/cnquery/v9/providers-sdk/v1/plugin"
+	"go.mondoo.com/cnquery/v9/providers/os/id/ids"
+)
+
+func TestLocalConnectionIdDetectors(t *testing.T) {
+	// check that we get the data via the resources
+
+	srv := &Service{
+		runtimes:         map[uint32]*plugin.Runtime{},
+		lastConnectionID: 0,
+	}
+
+	resp, err := srv.Connect(&plugin.ConnectReq{
+		Asset: &inventory.Asset{
+			Connections: []*inventory.Config{
+				{
+					Type: "local",
+				},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	require.Len(t, resp.Asset.IdDetector, 2)
+	require.Contains(t, resp.Asset.IdDetector, ids.IdDetector_Hostname)
+	require.Contains(t, resp.Asset.IdDetector, ids.IdDetector_CloudDetect)
+	require.NotContains(t, resp.Asset.IdDetector, ids.IdDetector_SshHostkey)
+	// here we have the hostname twice, as platformid and stand alone
+	// This get's cleaned up later in the code
+	require.Len(t, resp.Asset.PlatformIds, 2)
+
+	shutdownResp, err := srv.Shutdown(&plugin.ShutdownReq{})
+	require.NoError(t, err)
+	require.NotNil(t, shutdownResp)
+
+	srv = &Service{
+		runtimes:         map[uint32]*plugin.Runtime{},
+		lastConnectionID: 0,
+	}
+	resp, err = srv.Connect(&plugin.ConnectReq{
+		Asset: resp.Asset,
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	require.Len(t, resp.Asset.IdDetector, 2)
+	require.Contains(t, resp.Asset.IdDetector, ids.IdDetector_Hostname)
+	require.Contains(t, resp.Asset.IdDetector, ids.IdDetector_CloudDetect)
+	require.NotContains(t, resp.Asset.IdDetector, ids.IdDetector_SshHostkey)
+	// Now the platformIDs are cleaned up
+	require.Len(t, resp.Asset.PlatformIds, 1)
+
+	shutdownResp, err = srv.Shutdown(&plugin.ShutdownReq{})
+	require.NoError(t, err)
+	require.NotNil(t, shutdownResp)
+}

--- a/providers/os/provider/provider_test.go
+++ b/providers/os/provider/provider_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package provider
 
 import (
@@ -10,14 +13,12 @@ import (
 )
 
 func TestLocalConnectionIdDetectors(t *testing.T) {
-	// check that we get the data via the resources
-
 	srv := &Service{
 		runtimes:         map[uint32]*plugin.Runtime{},
 		lastConnectionID: 0,
 	}
 
-	resp, err := srv.Connect(&plugin.ConnectReq{
+	connectResp, err := srv.Connect(&plugin.ConnectReq{
 		Asset: &inventory.Asset{
 			Connections: []*inventory.Config{
 				{
@@ -27,38 +28,38 @@ func TestLocalConnectionIdDetectors(t *testing.T) {
 		},
 	}, nil)
 	require.NoError(t, err)
-	require.NotNil(t, resp)
+	require.NotNil(t, connectResp)
 
-	require.Len(t, resp.Asset.IdDetector, 2)
-	require.Contains(t, resp.Asset.IdDetector, ids.IdDetector_Hostname)
-	require.Contains(t, resp.Asset.IdDetector, ids.IdDetector_CloudDetect)
-	require.NotContains(t, resp.Asset.IdDetector, ids.IdDetector_SshHostkey)
+	require.Len(t, connectResp.Asset.IdDetector, 2)
+	require.Contains(t, connectResp.Asset.IdDetector, ids.IdDetector_Hostname)
+	require.Contains(t, connectResp.Asset.IdDetector, ids.IdDetector_CloudDetect)
+	require.NotContains(t, connectResp.Asset.IdDetector, ids.IdDetector_SshHostkey)
 	// here we have the hostname twice, as platformid and stand alone
 	// This get's cleaned up later in the code
-	require.Len(t, resp.Asset.PlatformIds, 2)
+	require.Len(t, connectResp.Asset.PlatformIds, 2)
 
-	shutdownResp, err := srv.Shutdown(&plugin.ShutdownReq{})
+	shutdownconnectResp, err := srv.Shutdown(&plugin.ShutdownReq{})
 	require.NoError(t, err)
-	require.NotNil(t, shutdownResp)
+	require.NotNil(t, shutdownconnectResp)
 
 	srv = &Service{
 		runtimes:         map[uint32]*plugin.Runtime{},
 		lastConnectionID: 0,
 	}
-	resp, err = srv.Connect(&plugin.ConnectReq{
-		Asset: resp.Asset,
+	connectResp, err = srv.Connect(&plugin.ConnectReq{
+		Asset: connectResp.Asset,
 	}, nil)
 	require.NoError(t, err)
-	require.NotNil(t, resp)
+	require.NotNil(t, connectResp)
 
-	require.Len(t, resp.Asset.IdDetector, 2)
-	require.Contains(t, resp.Asset.IdDetector, ids.IdDetector_Hostname)
-	require.Contains(t, resp.Asset.IdDetector, ids.IdDetector_CloudDetect)
-	require.NotContains(t, resp.Asset.IdDetector, ids.IdDetector_SshHostkey)
+	require.Len(t, connectResp.Asset.IdDetector, 2)
+	require.Contains(t, connectResp.Asset.IdDetector, ids.IdDetector_Hostname)
+	require.Contains(t, connectResp.Asset.IdDetector, ids.IdDetector_CloudDetect)
+	require.NotContains(t, connectResp.Asset.IdDetector, ids.IdDetector_SshHostkey)
 	// Now the platformIDs are cleaned up
-	require.Len(t, resp.Asset.PlatformIds, 1)
+	require.Len(t, connectResp.Asset.PlatformIds, 1)
 
-	shutdownResp, err = srv.Shutdown(&plugin.ShutdownReq{})
+	shutdownconnectResp, err = srv.Shutdown(&plugin.ShutdownReq{})
 	require.NoError(t, err)
-	require.NotNil(t, shutdownResp)
+	require.NotNil(t, shutdownconnectResp)
 }


### PR DESCRIPTION
With local connections, we saw the case in cnspec, that on first connect, assets had platformIDs as expected. With local connections this should only be the hostname and perhaps cloud data.

But on later connects, the set id detectors were emtpy and another default kicked in: https://github.com/mondoohq/cnquery/blob/main/providers/os/provider/detector.go\#L39-L41

This added the ssh hostkey detector to the asset which is not expected.