### PR TITLE
⭐️  add package url to os and python packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -602,6 +602,9 @@ test/lint/golangci-lint/run: prep/tools
 	golangci-lint --version
 	golangci-lint run
 
+test/lint/extended: prep/tools
+	golangci-lint run --config=.github/.golangci.yml --timeout=30m
+
 license: license/headers/check
 
 license/headers/check:

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/muesli/termenv v0.15.2
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opencontainers/image-spec v1.1.0-rc5
+	github.com/package-url/packageurl-go v0.1.2
 	github.com/pierrec/lz4/v4 v4.1.18
 	github.com/pkg/sftp v1.13.6
 	github.com/pkg/term v1.2.0-beta.2

--- a/go.sum
+++ b/go.sum
@@ -747,6 +747,8 @@ github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJ
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
+github.com/package-url/packageurl-go v0.1.2 h1:0H2DQt6DHd/NeRlVwW4EZ4oEI6Bn40XlNPRqegcxuo4=
+github.com/package-url/packageurl-go v0.1.2/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/pierrec/lz4/v4 v4.1.18 h1:xaKrnTkyoqfh1YItXl56+6KJNVYWlEEPuAQW9xsplYQ=

--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -17,6 +17,10 @@ import (
 	win "go.mondoo.com/cnquery/v9/providers/os/detector/windows"
 )
 
+const (
+	LabelDistroID = "distro-id"
+)
+
 // Operating Systems
 var macOS = &PlatformResolver{
 	Name:     "macos",
@@ -905,6 +909,9 @@ var linuxFamily = &PlatformResolver{
 
 		pf.Name = ""
 		pf.Title = ""
+		if pf.Labels == nil {
+			pf.Labels = map[string]string{}
+		}
 
 		lsb, err := osrd.lsbconfig()
 		// ignore lsb config if we got an error
@@ -933,6 +940,7 @@ var linuxFamily = &PlatformResolver{
 		} else {
 			if len(osr["ID"]) > 0 {
 				pf.Name = osr["ID"]
+				pf.Labels[LabelDistroID] = osr["ID"]
 			}
 			if len(osr["PRETTY_NAME"]) > 0 {
 				pf.Title = osr["PRETTY_NAME"]

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -529,6 +529,8 @@ package @defaults("name version") {
 
   // Name of the package
   name string
+  // Package description
+  description string
   // Current version of the package
   version string
   // Architecture of this package
@@ -540,8 +542,9 @@ package @defaults("name version") {
   format string
   // Status of this package (e.g., if it is needed)
   status() string
-  // Package description
-  description string
+
+  // Package URL
+  purl string
 
   // Package origin (optional)
   origin() string
@@ -552,6 +555,8 @@ package @defaults("name version") {
   installed bool
   // Whether the package is outdated
   outdated() bool
+
+
 }
 
 // List of packages on this system

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -555,8 +555,6 @@ package @defaults("name version") {
   installed bool
   // Whether the package is outdated
   outdated() bool
-
-
 }
 
 // List of packages on this system
@@ -1061,28 +1059,22 @@ python {
 // Python package information
 python.package @defaults("name version") {
   init(path? string)
-
   // ID is the python.package unique identifier
   id string
-
   // Name of the package
   name() string
-
   // File containing the package metadata
   file file
-
   // Version of the package
   version() string
-
   // License of the package
   license() string
-
   // Author of the package
   author() string
-
   // Short package description
   summary() string
-
+  // Package URL
+  purl() string
   // List of packages depended on
   dependencies() []python.package
 }

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -1004,6 +1004,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"package.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPackage).GetName()).ToDataRes(types.String)
 	},
+	"package.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPackage).GetDescription()).ToDataRes(types.String)
+	},
 	"package.version": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPackage).GetVersion()).ToDataRes(types.String)
 	},
@@ -1019,8 +1022,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"package.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPackage).GetStatus()).ToDataRes(types.String)
 	},
-	"package.description": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlPackage).GetDescription()).ToDataRes(types.String)
+	"package.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPackage).GetPurl()).ToDataRes(types.String)
 	},
 	"package.origin": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPackage).GetOrigin()).ToDataRes(types.String)
@@ -2783,6 +2786,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlPackage).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"package.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPackage).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"package.version": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlPackage).Version, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -2803,8 +2810,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlPackage).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"package.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlPackage).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+	"package.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPackage).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"package.origin": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7385,12 +7392,13 @@ type mqlPackage struct {
 	__id string
 	// optional: if you define mqlPackageInternal it will be used here
 	Name plugin.TValue[string]
+	Description plugin.TValue[string]
 	Version plugin.TValue[string]
 	Arch plugin.TValue[string]
 	Epoch plugin.TValue[string]
 	Format plugin.TValue[string]
 	Status plugin.TValue[string]
-	Description plugin.TValue[string]
+	Purl plugin.TValue[string]
 	Origin plugin.TValue[string]
 	Available plugin.TValue[string]
 	Installed plugin.TValue[bool]
@@ -7438,6 +7446,10 @@ func (c *mqlPackage) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
 
+func (c *mqlPackage) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
 func (c *mqlPackage) GetVersion() *plugin.TValue[string] {
 	return &c.Version
 }
@@ -7460,8 +7472,8 @@ func (c *mqlPackage) GetStatus() *plugin.TValue[string] {
 	})
 }
 
-func (c *mqlPackage) GetDescription() *plugin.TValue[string] {
-	return &c.Description
+func (c *mqlPackage) GetPurl() *plugin.TValue[string] {
+	return &c.Purl
 }
 
 func (c *mqlPackage) GetOrigin() *plugin.TValue[string] {

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -1565,6 +1565,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"python.package.summary": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPythonPackage).GetSummary()).ToDataRes(types.String)
 	},
+	"python.package.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPythonPackage).GetPurl()).ToDataRes(types.String)
+	},
 	"python.package.dependencies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPythonPackage).GetDependencies()).ToDataRes(types.Array(types.Resource("python.package")))
 	},
@@ -3692,6 +3695,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"python.package.summary": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlPythonPackage).Summary, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"python.package.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPythonPackage).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"python.package.dependencies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10572,6 +10579,7 @@ type mqlPythonPackage struct {
 	License plugin.TValue[string]
 	Author plugin.TValue[string]
 	Summary plugin.TValue[string]
+	Purl plugin.TValue[string]
 	Dependencies plugin.TValue[[]interface{}]
 }
 
@@ -10647,6 +10655,12 @@ func (c *mqlPythonPackage) GetAuthor() *plugin.TValue[string] {
 func (c *mqlPythonPackage) GetSummary() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Summary, func() (string, error) {
 		return c.summary()
+	})
+}
+
+func (c *mqlPythonPackage) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 

--- a/providers/os/resources/os.lr.manifest.yaml
+++ b/providers/os/resources/os.lr.manifest.yaml
@@ -738,6 +738,7 @@ resources:
       licenses: {}
       name: {}
       path: {}
+      purl: {}
       summary: {}
       version: {}
     min_mondoo_version: latest

--- a/providers/os/resources/os.lr.manifest.yaml
+++ b/providers/os/resources/os.lr.manifest.yaml
@@ -560,6 +560,8 @@ resources:
       name: {}
       origin: {}
       outdated: {}
+      purl:
+        min_mondoo_version: latest
       status: {}
       version: {}
     min_mondoo_version: 5.15.0

--- a/providers/os/resources/packages.go
+++ b/providers/os/resources/packages.go
@@ -58,6 +58,7 @@ func initPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 	res.Epoch.State = plugin.StateIsSet | plugin.StateIsNull
 	res.Available.State = plugin.StateIsSet | plugin.StateIsNull
 	res.Description.State = plugin.StateIsSet | plugin.StateIsNull
+	res.Purl.State = plugin.StateIsSet | plugin.StateIsNull
 	res.Arch.State = plugin.StateIsSet | plugin.StateIsNull
 	res.Format.State = plugin.StateIsSet | plugin.StateIsNull
 	res.Origin.State = plugin.StateIsSet | plugin.StateIsNull
@@ -138,6 +139,7 @@ func (x *mqlPackages) list() ([]interface{}, error) {
 			"installed":   llx.BoolData(true),
 			"origin":      llx.StringData(osPkg.Origin),
 			"epoch":       llx.NilData, // TODO: support Epoch
+			"purl":        llx.StringData(osPkg.PUrl),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/os/resources/packages/apk_packages_test.go
+++ b/providers/os/resources/packages/apk_packages_test.go
@@ -4,6 +4,7 @@
 package packages_test
 
 import (
+	"go.mondoo.com/cnquery/v9/providers-sdk/v1/inventory"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,16 @@ import (
 )
 
 func TestAlpineApkdbParser(t *testing.T) {
+	pf := &inventory.Platform{
+		Name:    "alpine",
+		Version: "3.7.0",
+		Arch:    "x86_64",
+		Family:  []string{"linux", "unix", "os"},
+		Labels: map[string]string{
+			"distro-id": "alpine",
+		},
+	}
+
 	mock, err := mock.New("./testdata/packages_apk.toml", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -22,16 +33,18 @@ func TestAlpineApkdbParser(t *testing.T) {
 	}
 	defer f.Close()
 
-	m := packages.ParseApkDbPackages(f)
+	m := packages.ParseApkDbPackages(pf, f)
 	assert.Equal(t, 7, len(m), "detected the right amount of packages")
 
 	var p packages.Package
 	p = packages.Package{
 		Name:        "musl",
 		Version:     "1510953106:1.1.18-r2",
+		Epoch:       "1510953106",
 		Arch:        "x86_64",
 		Description: "the musl c library (libc) implementation",
 		Origin:      "musl",
+		PUrl:        "pkg:apk/alpine/musl@1510953106%3A1.1.18-r2?arch=x86_64&distro=alpine-3.7.0&epoch=1510953106",
 		Format:      packages.AlpinePkgFormat,
 	}
 	assert.Contains(t, m, p, "musl detected")
@@ -39,9 +52,11 @@ func TestAlpineApkdbParser(t *testing.T) {
 	p = packages.Package{
 		Name:        "libressl2.6-libcrypto",
 		Version:     "1510257703:2.6.3-r0",
+		Epoch:       "1510257703",
 		Arch:        "x86_64",
 		Description: "libressl libcrypto library",
 		Origin:      "libressl",
+		PUrl:        "pkg:apk/alpine/libressl2.6-libcrypto@1510257703%3A2.6.3-r0?arch=x86_64&distro=alpine-3.7.0&epoch=1510257703",
 		Format:      packages.AlpinePkgFormat,
 	}
 	assert.Contains(t, m, p, "libcrypto detected")
@@ -49,9 +64,11 @@ func TestAlpineApkdbParser(t *testing.T) {
 	p = packages.Package{
 		Name:        "libressl2.6-libssl",
 		Version:     "1510257703:2.6.3-r0",
+		Epoch:       "1510257703",
 		Arch:        "x86_64",
 		Description: "libressl libssl library",
 		Origin:      "libressl",
+		PUrl:        "pkg:apk/alpine/libressl2.6-libssl@1510257703%3A2.6.3-r0?arch=x86_64&distro=alpine-3.7.0&epoch=1510257703",
 		Format:      packages.AlpinePkgFormat,
 	}
 	assert.Contains(t, m, p, "libssl detected")
@@ -59,9 +76,11 @@ func TestAlpineApkdbParser(t *testing.T) {
 	p = packages.Package{
 		Name:        "apk-tools",
 		Version:     "1515485577:2.8.2-r0",
+		Epoch:       "1515485577",
 		Arch:        "x86_64",
 		Description: "Alpine Package Keeper - package manager for alpine",
 		Origin:      "apk-tools",
+		PUrl:        "pkg:apk/alpine/apk-tools@1515485577%3A2.8.2-r0?arch=x86_64&distro=alpine-3.7.0&epoch=1515485577",
 		Format:      packages.AlpinePkgFormat,
 	}
 	assert.Contains(t, m, p, "apk-tools detected")
@@ -69,9 +88,11 @@ func TestAlpineApkdbParser(t *testing.T) {
 	p = packages.Package{
 		Name:        "busybox",
 		Version:     "1513075346:1.27.2-r7",
+		Epoch:       "1513075346",
 		Arch:        "x86_64",
 		Description: "Size optimized toolbox of many common UNIX utilities",
 		Origin:      "busybox",
+		PUrl:        "pkg:apk/alpine/busybox@1513075346%3A1.27.2-r7?arch=x86_64&distro=alpine-3.7.0&epoch=1513075346",
 		Format:      packages.AlpinePkgFormat,
 	}
 	assert.Contains(t, m, p, "apk-tools detected")
@@ -79,9 +100,11 @@ func TestAlpineApkdbParser(t *testing.T) {
 	p = packages.Package{
 		Name:        "alpine-baselayout",
 		Version:     "1510075862:3.0.5-r2",
+		Epoch:       "1510075862",
 		Arch:        "x86_64",
 		Description: "Alpine base dir structure and init scripts",
 		Origin:      "alpine-baselayout",
+		PUrl:        "pkg:apk/alpine/alpine-baselayout@1510075862%3A3.0.5-r2?arch=x86_64&distro=alpine-3.7.0&epoch=1510075862",
 		Format:      packages.AlpinePkgFormat,
 	}
 	assert.Contains(t, m, p, "apk-tools detected")

--- a/providers/os/resources/packages/dpkg_packages_test.go
+++ b/providers/os/resources/packages/dpkg_packages_test.go
@@ -4,6 +4,7 @@
 package packages_test
 
 import (
+	"go.mondoo.com/cnquery/v9/providers-sdk/v1/inventory"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,13 +14,23 @@ import (
 )
 
 func TestDpkgParser(t *testing.T) {
+	pf := &inventory.Platform{
+		Name:    "ubuntu",
+		Version: "18.04",
+		Arch:    "x86_64",
+		Family:  []string{"debian", "linux", "unix", "os"},
+		Labels: map[string]string{
+			"distro-id": "ubuntu",
+		},
+	}
+
 	mock, err := mock.New("./testdata/packages_dpkg.toml", nil)
 	require.NoError(t, err)
 	f, err := mock.FileSystem().Open("/var/lib/dpkg/status")
 	require.NoError(t, err)
 	defer f.Close()
 
-	m, err := packages.ParseDpkgPackages(f)
+	m, err := packages.ParseDpkgPackages(pf, f)
 	require.NoError(t, err)
 	assert.Equal(t, 10, len(m), "detected the right amount of packages")
 
@@ -41,6 +52,7 @@ partition tables (eg. GPT, MBR, etc).
 The fdisk utility is the classical text-mode utility.
 The cfdisk utilitity gives a more userfriendly curses based interface.
 The sfdisk utility is mostly for automation and scripting uses.`,
+		PUrl:   "pkg:deb/ubuntu/fdisk@2.31.1-0.4ubuntu3.1?arch=amd64&distro=ubuntu-18.04",
 		Format: "deb",
 	}
 	assert.Contains(t, m, p, "fdisk detected")
@@ -55,19 +67,30 @@ The sfdisk utility is mostly for automation and scripting uses.`,
 The audit-libs package contains the dynamic libraries needed for
 applications to use the audit framework. It is used to monitor systems for
 security related events.`,
+		PUrl:   "pkg:deb/ubuntu/libaudit1@1%3A2.4-1%2Bb1?arch=amd64&distro=ubuntu-18.04",
 		Format: "deb",
 	}
 	assert.Contains(t, m, p, "libaudit1 detected")
 }
 
 func TestDpkgParserStatusD(t *testing.T) {
+	pf := &inventory.Platform{
+		Name:    "ubuntu",
+		Version: "18.04",
+		Arch:    "x86_64",
+		Family:  []string{"debian", "linux", "unix", "os"},
+		Labels: map[string]string{
+			"distro-id": "ubuntu",
+		},
+	}
+
 	mock, err := mock.New("./testdata/packages_dpkg_statusd.toml", nil)
 	require.NoError(t, err)
 	f, err := mock.FileSystem().Open("/var/lib/dpkg/status.d/base")
 	require.NoError(t, err)
 	defer f.Close()
 
-	m, err := packages.ParseDpkgPackages(f)
+	m, err := packages.ParseDpkgPackages(pf, f)
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(m), "detected the right amount of packages")
 
@@ -81,6 +104,7 @@ This package contains the basic filesystem hierarchy of a Debian system, and
 several important miscellaneous files, such as /etc/debian_version,
 /etc/host.conf, /etc/issue, /etc/motd, /etc/profile, and others,
 and the text of several common licenses in use on Debian systems.`,
+		PUrl:   "pkg:deb/ubuntu/base-files@9.9%2Bdeb9u11?arch=amd64&distro=ubuntu-18.04",
 		Format: "deb",
 	}
 	assert.Contains(t, m, p, "fdisk detected")

--- a/providers/os/resources/packages/packages.go
+++ b/providers/os/resources/packages/packages.go
@@ -11,6 +11,7 @@ import (
 type Package struct {
 	Name        string `json:"name"`
 	Version     string `json:"version"`
+	Epoch       string `json:"epoch,omitempty"`
 	Arch        string `json:"arch"`
 	Status      string `json:"status,omitempty"`
 	Description string `json:"description"`
@@ -20,6 +21,9 @@ type Package struct {
 	// o 	Package Origin - https://wiki.alpinelinux.org/wiki/Apk_spec
 	Origin string `json:"origin"`
 	Format string `json:"format"`
+
+	// Package Url follows https://github.com/package-url/purl-spec
+	PUrl string `json:"purl,omitempty"`
 }
 
 // extends Package to store available version
@@ -48,9 +52,9 @@ func ResolveSystemPkgManager(conn shared.Connection) (OperatingSystemPkgManager,
 
 	switch {
 	case asset.Platform.IsFamily("arch"): // arch family
-		pm = &PacmanPkgManager{conn: conn}
+		pm = &PacmanPkgManager{conn: conn, platform: asset.Platform}
 	case asset.Platform.IsFamily("debian"): // debian family
-		pm = &DebPkgManager{conn: conn}
+		pm = &DebPkgManager{conn: conn, platform: asset.Platform}
 	case asset.Platform.Name == "amazonlinux" || asset.Platform.Name == "photon" || asset.Platform.Name == "wrlinux":
 		fallthrough
 	case asset.Platform.IsFamily("redhat"): // rhel family
@@ -58,7 +62,7 @@ func ResolveSystemPkgManager(conn shared.Connection) (OperatingSystemPkgManager,
 	case asset.Platform.IsFamily("suse"): // suse handling
 		pm = &SusePkgManager{RpmPkgManager{conn: conn, platform: asset.Platform}}
 	case asset.Platform.Name == "alpine": // alpine
-		pm = &AlpinePkgManager{conn: conn}
+		pm = &AlpinePkgManager{conn: conn, platform: asset.Platform}
 	case asset.Platform.Name == "macos": // mac os family
 		pm = &MacOSPkgManager{conn: conn}
 	case asset.Platform.Name == "windows":

--- a/providers/os/resources/packages/pacman_packages_test.go
+++ b/providers/os/resources/packages/pacman_packages_test.go
@@ -4,6 +4,7 @@
 package packages_test
 
 import (
+	"go.mondoo.com/cnquery/v9/providers-sdk/v1/inventory"
 	"strings"
 	"testing"
 
@@ -12,6 +13,16 @@ import (
 )
 
 func TestPacmanParser(t *testing.T) {
+	pf := &inventory.Platform{
+		Name:    "arch",
+		Version: "",
+		Arch:    "x86_64",
+		Family:  []string{"arch", "linux", "unix", "os"},
+		Labels: map[string]string{
+			"distro-id": "arch",
+		},
+	}
+
 	pkgList := `qpdfview 0.4.17beta1-4.1
 usbmuxd 1.1.0+28+g46bdf3e-1
 vertex-maia-themes 20171114-1
@@ -21,13 +32,14 @@ zita-alsa-pcmi 0.2.0-3
 zlib 1:1.2.11-2
 zziplib 0.13.67-1`
 
-	m := packages.ParsePacmanPackages(strings.NewReader(pkgList))
+	m := packages.ParsePacmanPackages(pf, strings.NewReader(pkgList))
 
 	assert.Equal(t, 8, len(m), "detected the right amount of packages")
 	var p packages.Package
 	p = packages.Package{
 		Name:    "qpdfview",
 		Version: "0.4.17beta1-4.1",
+		PUrl:    "pkg:alpm/arch/qpdfview@0.4.17beta1-4.1?distro=arch",
 		Format:  packages.PacmanPkgFormat,
 	}
 	assert.Contains(t, m, p, "pkg detected")
@@ -35,6 +47,7 @@ zziplib 0.13.67-1`
 	p = packages.Package{
 		Name:    "vertex-maia-themes",
 		Version: "20171114-1",
+		PUrl:    "pkg:alpm/arch/vertex-maia-themes@20171114-1?distro=arch",
 		Format:  packages.PacmanPkgFormat,
 	}
 	assert.Contains(t, m, p, "pkg detected")
@@ -42,12 +55,23 @@ zziplib 0.13.67-1`
 	p = packages.Package{
 		Name:    "xfce4-pulseaudio-plugin",
 		Version: "0.3.2.r13.g553691a-1",
+		PUrl:    "pkg:alpm/arch/xfce4-pulseaudio-plugin@0.3.2.r13.g553691a-1?distro=arch",
 		Format:  packages.PacmanPkgFormat,
 	}
 	assert.Contains(t, m, p, "pkg detected")
 }
 
 func TestPacmanWithWarningsParser(t *testing.T) {
+	pf := &inventory.Platform{
+		Name:    "arch",
+		Version: "",
+		Arch:    "x86_64",
+		Family:  []string{"arch", "linux", "unix", "os"},
+		Labels: map[string]string{
+			"distro-id": "arch",
+		},
+	}
+
 	pkgList := `warning: database file for 'core' does not exist (use '-Sy' to download)
 warning: database file for 'extra' does not exist (use '-Sy' to download)
 warning: database file for 'community' does not exist (use '-Sy' to download)
@@ -55,12 +79,13 @@ acl 2.2.53-2
 archlinux-keyring 20200108-1
 argon2 20190702-2`
 
-	m := packages.ParsePacmanPackages(strings.NewReader(pkgList))
+	m := packages.ParsePacmanPackages(pf, strings.NewReader(pkgList))
 
 	assert.Equal(t, 3, len(m), "detected the right amount of packages")
 	p := packages.Package{
 		Name:    "acl",
 		Version: "2.2.53-2",
+		PUrl:    "pkg:alpm/arch/acl@2.2.53-2?distro=arch",
 		Format:  packages.PacmanPkgFormat,
 	}
 	assert.Contains(t, m, p, "pkg detected")

--- a/providers/os/resources/packages/rpm_packages_test.go
+++ b/providers/os/resources/packages/rpm_packages_test.go
@@ -6,6 +6,7 @@ package packages_test
 import (
 	"bytes"
 	"fmt"
+	"go.mondoo.com/cnquery/v9/providers-sdk/v1/inventory"
 	"io"
 	"os"
 	"path/filepath"
@@ -24,12 +25,22 @@ func TestRedhat7Parser(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	pf := &inventory.Platform{
+		Name:    "redhat",
+		Version: "7.4",
+		Arch:    "x86_64",
+		Family:  []string{"redhat", "linux", "unix", "os"},
+		Labels: map[string]string{
+			"distro-id": "rhel",
+		},
+	}
+
 	c, err := mock.RunCommand("rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH} %{SUMMARY}\\n'")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	m := packages.ParseRpmPackages(c.Stdout)
+	m := packages.ParseRpmPackages(pf, c.Stdout)
 	assert.Equal(t, 144, len(m), "detected the right amount of packages")
 
 	var p packages.Package
@@ -38,6 +49,7 @@ func TestRedhat7Parser(t *testing.T) {
 		Version:     "5.9-14.20130511.el7_4",
 		Arch:        "noarch",
 		Description: "Descriptions of common terminals",
+		PUrl:        "pkg:rpm/rhel/ncurses-base@5.9-14.20130511.el7_4?arch=noarch&distro=rhel-7.4",
 		Format:      packages.RpmPkgFormat,
 	}
 	assert.Contains(t, m, p, "ncurses-base")
@@ -47,6 +59,7 @@ func TestRedhat7Parser(t *testing.T) {
 		Version:     "4.8.5-28.el7_5.1",
 		Arch:        "x86_64",
 		Description: "GNU Standard C++ Library",
+		PUrl:        "pkg:rpm/rhel/libstdc%2B%2B@4.8.5-28.el7_5.1?arch=x86_64&distro=rhel-7.4",
 		Format:      packages.RpmPkgFormat,
 	}
 	assert.Contains(t, m, p, "libstdc detected")
@@ -56,6 +69,7 @@ func TestRedhat7Parser(t *testing.T) {
 		Version:     "20160308-10.el7",
 		Arch:        "x86_64",
 		Description: "Network monitoring tools including ping",
+		PUrl:        "pkg:rpm/rhel/iputils@20160308-10.el7?arch=x86_64&distro=rhel-7.4",
 		Format:      packages.RpmPkgFormat,
 	}
 	assert.Contains(t, m, p, "gpg-pubkey detected")
@@ -63,8 +77,10 @@ func TestRedhat7Parser(t *testing.T) {
 	p = packages.Package{
 		Name:        "openssl-libs",
 		Version:     "1:1.0.2k-12.el7",
+		Epoch:       "1",
 		Arch:        "x86_64",
 		Description: "A general purpose cryptography library with TLS implementation",
+		PUrl:        "pkg:rpm/rhel/openssl-libs@1%3A1.0.2k-12.el7?arch=x86_64&distro=rhel-7.4&epoch=1",
 		Format:      packages.RpmPkgFormat,
 	}
 	assert.Contains(t, m, p, "gpg-pubkey detected")
@@ -72,8 +88,10 @@ func TestRedhat7Parser(t *testing.T) {
 	p = packages.Package{
 		Name:        "dbus-libs",
 		Version:     "1:1.10.24-7.el7",
+		Epoch:       "1",
 		Arch:        "x86_64",
 		Description: "Libraries for accessing D-BUS",
+		PUrl:        "pkg:rpm/rhel/dbus-libs@1%3A1.10.24-7.el7?arch=x86_64&distro=rhel-7.4&epoch=1",
 		Format:      packages.RpmPkgFormat,
 	}
 	assert.Contains(t, m, p, "gpg-pubkey detected")
@@ -85,12 +103,22 @@ func TestRedhat6Parser(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	pf := &inventory.Platform{
+		Name:    "redhat",
+		Version: "6.2",
+		Arch:    "x86_64",
+		Family:  []string{"redhat", "linux", "unix", "os"},
+		Labels: map[string]string{
+			"distro-id": "rhel",
+		},
+	}
+
 	c, err := mock.RunCommand("rpm -qa --queryformat '%{NAME} %{EPOCH}:%{VERSION}-%{RELEASE} %{ARCH} %{SUMMARY}\\n'")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	m := packages.ParseRpmPackages(c.Stdout)
+	m := packages.ParseRpmPackages(pf, c.Stdout)
 	assert.Equal(t, 8, len(m), "detected the right amount of packages")
 
 	var p packages.Package
@@ -99,6 +127,7 @@ func TestRedhat6Parser(t *testing.T) {
 		Version:     "2.1-3",
 		Arch:        "i386",
 		Description: "A debugger which detects memory allocation violations.",
+		PUrl:        "pkg:rpm/rhel/ElectricFence@2.1-3?arch=i386&distro=rhel-6.2",
 		Format:      packages.RpmPkgFormat,
 	}
 	assert.Contains(t, m, p, "ElectricFence")
@@ -106,8 +135,10 @@ func TestRedhat6Parser(t *testing.T) {
 	p = packages.Package{
 		Name:        "shadow-utils",
 		Version:     "1:19990827-10",
+		Epoch:       "1",
 		Arch:        "i386",
 		Description: "Utilities for managing shadow password files and user/group accounts.",
+		PUrl:        "pkg:rpm/rhel/shadow-utils@1%3A19990827-10?arch=i386&distro=rhel-6.2&epoch=1",
 		Format:      packages.RpmPkgFormat,
 	}
 	assert.Contains(t, m, p, "shadow-utils")
@@ -115,8 +146,10 @@ func TestRedhat6Parser(t *testing.T) {
 	p = packages.Package{
 		Name:        "arpwatch",
 		Version:     "1:2.1a4-19",
+		Epoch:       "1",
 		Arch:        "i386",
 		Description: "Network monitoring tools for tracking IP addresses on a network.",
+		PUrl:        "pkg:rpm/rhel/arpwatch@1%3A2.1a4-19?arch=i386&distro=rhel-6.2&epoch=1",
 		Format:      packages.RpmPkgFormat,
 	}
 	assert.Contains(t, m, p, "arpwatch")
@@ -126,6 +159,7 @@ func TestRedhat6Parser(t *testing.T) {
 		Version:     "1.14.7-22",
 		Arch:        "i386",
 		Description: "The GNU Bourne Again shell (bash) version 1.14.",
+		PUrl:        "pkg:rpm/rhel/bash@1.14.7-22?arch=i386&distro=rhel-6.2",
 		Format:      packages.RpmPkgFormat,
 	}
 	assert.Contains(t, m, p, "bash")
@@ -165,7 +199,17 @@ func TestPhoton4ImageParser(t *testing.T) {
 		packageList.WriteString(fmt.Sprintf("%s %d:%s-%s %s %s\n", pkg.Name, pkg.EpochNum(), pkg.Version, pkg.Release, pkg.Arch, pkg.Summary))
 	}
 
-	m := packages.ParseRpmPackages(&packageList)
+	pf := &inventory.Platform{
+		Name:    "photon",
+		Version: "3.0",
+		Arch:    "x86_64",
+		Family:  []string{"linux", "unix", "os"},
+		Labels: map[string]string{
+			"distro-id": "photon",
+		},
+	}
+
+	m := packages.ParseRpmPackages(pf, &packageList)
 	assert.Equal(t, 36, len(m), "detected the right amount of packages")
 
 	var p packages.Package
@@ -174,6 +218,7 @@ func TestPhoton4ImageParser(t *testing.T) {
 		Version:     "6.2-6.ph4",
 		Arch:        "x86_64",
 		Description: "Ncurses Libraries",
+		PUrl:        "pkg:rpm/photon/ncurses-libs@6.2-6.ph4?arch=x86_64&distro=photon-3.0",
 		Format:      packages.RpmPkgFormat,
 	}
 	assert.Contains(t, m, p, "ncurses-libs")
@@ -183,6 +228,7 @@ func TestPhoton4ImageParser(t *testing.T) {
 		Version:     "5.0-2.ph4",
 		Arch:        "x86_64",
 		Description: "Bourne-Again SHell",
+		PUrl:        "pkg:rpm/photon/bash@5.0-2.ph4?arch=x86_64&distro=photon-3.0",
 		Format:      packages.RpmPkgFormat,
 	}
 	assert.Contains(t, m, p, "bash")
@@ -192,6 +238,7 @@ func TestPhoton4ImageParser(t *testing.T) {
 		Version:     "3.38.5-1.ph4",
 		Arch:        "x86_64",
 		Description: "sqlite3 library",
+		PUrl:        "pkg:rpm/photon/sqlite-libs@3.38.5-1.ph4?arch=x86_64&distro=photon-3.0",
 		Format:      packages.RpmPkgFormat,
 	}
 	assert.Contains(t, m, p, "sqlite-libs")

--- a/providers/os/resources/purl/purl.go
+++ b/providers/os/resources/purl/purl.go
@@ -1,0 +1,80 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package purl
+
+import (
+	"github.com/package-url/packageurl-go"
+	"go.mondoo.com/cnquery/v9/providers-sdk/v1/inventory"
+	"go.mondoo.com/cnquery/v9/providers/os/detector"
+	"sort"
+	"strings"
+)
+
+const (
+	QualifierArch   = "arch"
+	QualifierDistro = "distro"
+	QualifierEpoch  = "epoch"
+)
+
+// NewQualifiers creates a new Qualifiers slice from a map of key/value pairs.
+// see https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst for more information
+func NewQualifiers(qualifier map[string]string) packageurl.Qualifiers {
+	// Create a slice for the keys to sort them
+	keys := make([]string, 0, len(qualifier))
+	for k := range qualifier {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// Create the list of Qualifiers
+	list := make(packageurl.Qualifiers, 0, len(keys))
+	for _, k := range keys {
+		val := qualifier[k]
+		if val != "" {
+			list = append(list, packageurl.Qualifier{
+				Key:   k,
+				Value: val,
+			})
+		}
+	}
+
+	return list
+}
+
+// NewPackageUrl creates a new package url for a given platform, name, version, arch, epoch and purlType
+// see https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst for more information
+func NewPackageUrl(pf *inventory.Platform, name string, version string, arch string, epoch string, purlType string) string {
+	qualifiers := map[string]string{}
+	if arch != "" {
+		qualifiers[QualifierArch] = arch
+	}
+
+	if epoch != "" && epoch != "0" {
+		qualifiers[QualifierEpoch] = epoch
+	}
+
+	namespace := pf.Name
+	if pf.Labels != nil && pf.Labels[detector.LabelDistroID] != "" {
+		namespace = pf.Labels[detector.LabelDistroID]
+	}
+
+	// generate distro qualifier
+	distroQualifiers := []string{}
+	distroQualifiers = append(distroQualifiers, namespace)
+	if pf.Version != "" {
+		distroQualifiers = append(distroQualifiers, pf.Version)
+	} else if pf.Build != "" {
+		distroQualifiers = append(distroQualifiers, pf.Build)
+	}
+	qualifiers[QualifierDistro] = strings.Join(distroQualifiers, "-")
+
+	return packageurl.NewPackageURL(
+		purlType,
+		namespace,
+		name,
+		version,
+		NewQualifiers(qualifiers),
+		"",
+	).ToString()
+}

--- a/providers/os/resources/python_package.go
+++ b/providers/os/resources/python_package.go
@@ -72,6 +72,11 @@ func (k *mqlPythonPackage) summary() (string, error) {
 	return k.Summary.Data, nil
 }
 
+func (k *mqlPythonPackage) purl() (string, error) {
+	k.populateData()
+	return k.Purl.Data, nil
+}
+
 func (k *mqlPythonPackage) dependencies() ([]interface{}, error) {
 	k.populateData()
 	return k.Dependencies.Data, nil
@@ -102,6 +107,7 @@ func (k *mqlPythonPackage) populateData() error {
 	k.Summary = plugin.TValue[string]{Data: ppd.summary, State: plugin.StateIsSet}
 	k.License = plugin.TValue[string]{Data: ppd.license, State: plugin.StateIsSet}
 	k.Dependencies = plugin.TValue[[]interface{}]{Data: deps, State: plugin.StateIsSet}
+	k.Purl = plugin.TValue[string]{Data: ppd.purl, State: plugin.StateIsSet}
 
 	return nil
 }

--- a/providers/os/resources/python_package.go
+++ b/providers/os/resources/python_package.go
@@ -48,37 +48,58 @@ func initPythonPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 }
 
 func (k *mqlPythonPackage) name() (string, error) {
-	k.populateData()
+	err := k.populateData()
+	if err != nil {
+		return "", err
+	}
 	return k.Name.Data, nil
 }
 
 func (k *mqlPythonPackage) version() (string, error) {
-	k.populateData()
+	err := k.populateData()
+	if err != nil {
+		return "", err
+	}
 	return k.Version.Data, nil
 }
 
 func (k *mqlPythonPackage) license() (string, error) {
-	k.populateData()
+	err := k.populateData()
+	if err != nil {
+		return "", err
+	}
 	return k.License.Data, nil
 }
 
 func (k *mqlPythonPackage) author() (string, error) {
-	k.populateData()
+	err := k.populateData()
+	if err != nil {
+		return "", err
+	}
 	return k.Author.Data, nil
 }
 
 func (k *mqlPythonPackage) summary() (string, error) {
-	k.populateData()
+	err := k.populateData()
+	if err != nil {
+		return "", err
+	}
 	return k.Summary.Data, nil
 }
 
 func (k *mqlPythonPackage) purl() (string, error) {
-	k.populateData()
+	err := k.populateData()
+	if err != nil {
+		return "", err
+	}
 	return k.Purl.Data, nil
 }
 
 func (k *mqlPythonPackage) dependencies() ([]interface{}, error) {
-	k.populateData()
+	err := k.populateData()
+	if err != nil {
+		return nil, err
+	}
 	return k.Dependencies.Data, nil
 }
 

--- a/providers/os/resources/reboot/rhel.go
+++ b/providers/os/resources/reboot/rhel.go
@@ -4,6 +4,7 @@
 package reboot
 
 import (
+	"go.mondoo.com/cnquery/v9/providers-sdk/v1/inventory"
 	"io"
 	"strings"
 
@@ -33,7 +34,12 @@ func (s *RpmNewestKernel) RebootPending() (bool, error) {
 		return false, err
 	}
 
-	pkgs := packages.ParseRpmPackages(installedKernelCmd.Stdout)
+	var pf *inventory.Platform
+	if s.conn.Asset() != nil {
+		pf = s.conn.Asset().Platform
+	}
+
+	pkgs := packages.ParseRpmPackages(pf, installedKernelCmd.Stdout)
 	// this case is valid in container
 	if len(pkgs) == 0 {
 		return false, nil


### PR DESCRIPTION
To identify packages it is useful to have the purl when available. This change adds purl for all major linux platforms and pythong packages. See https://github.com/package-url/purl-spec

To query all the package purls for ``:

```javascript
cnquery shell docker registry.access.redhat.com/ubi8/ubi 
→ connected to Red Hat Enterprise Linux 8.8 (Ootpa)
  ___ _ __   __ _ _   _  ___ _ __ _   _ 
 / __| '_ \ / _` | | | |/ _ \ '__| | | |
| (__| | | | (_| | |_| |  __/ |  | |_| |
 \___|_| |_|\__, |\__,_|\___|_|   \__, |
  mondoo™      |_|                |___/  interactive shell

cnquery> packages.map(purl) + python.packages.map(purl)
packages.map.+: [
  0: "pkg:rpm/rhel/tzdata@2023c-1.el8?arch=noarch&distro=rhel-8.8"
  1: "pkg:rpm/rhel/python3-pip-wheel@9.0.3-22.el8?arch=noarch&distro=rhel-8.8"
  2: "pkg:rpm/rhel/ncurses-base@6.1-9.20180224.el8_8.1?arch=noarch&distro=rhel-8.8"
  3: "pkg:rpm/rhel/redhat-release@8.8-0.8.el8?arch=aarch64&distro=rhel-8.8"
  4: "pkg:rpm/rhel/filesystem@3.8-6.el8?arch=aarch64&distro=rhel-8.8"
  5: "pkg:rpm/rhel/pcre2@10.32-3.el8_6?arch=aarch64&distro=rhel-8.8"
  6: "pkg:rpm/rhel/ncurses-libs@6.1-9.20180224.el8_8.1?arch=aarch64&distro=rhel-8.8"
  7: "pkg:rpm/rhel/glibc-minimal-langpack@2.28-225.el8_8.6?arch=aarch64&distro=rhel-8.8"
  8: "pkg:rpm/rhel/bash@4.4.20-4.el8_6?arch=aarch64&distro=rhel-8.8"
  9: "pkg:rpm/rhel/zlib@1.2.11-21.el8_7?arch=aarch64&distro=rhel-8.8"
  10: "pkg:rpm/rhel/bzip2-libs@1.0.6-26.el8?arch=aarch64&distro=rhel-8.8"
  ...
  176: "pkg:rpm/rhel/python3-subscription-manager-rhsm@1.28.36-3.el8_8?arch=aarch64&distro=rhel-8.8"
  177: "pkg:rpm/rhel/dnf-data@4.7.0-16.el8_8?arch=noarch&distro=rhel-8.8"
  178: "pkg:rpm/rhel/dnf@4.7.0-16.el8_8?arch=noarch&distro=rhel-8.8"
  179: "pkg:rpm/rhel/dnf-plugin-subscription-manager@1.28.36-3.el8_8?arch=aarch64&distro=rhel-8.8"
  180: "pkg:rpm/rhel/yum@4.7.0-16.el8_8?arch=noarch&distro=rhel-8.8"
  181: "pkg:rpm/rhel/tar@2%3A1.30-9.el8?arch=aarch64&distro=rhel-8.8&epoch=2"
  182: "pkg:rpm/rhel/findutils@1%3A4.6.0-20.el8_8.1?arch=aarch64&distro=rhel-8.8&epoch=1"
  183: "pkg:rpm/rhel/rootfiles@8.1-22.el8?arch=noarch&distro=rhel-8.8"
  184: "pkg:rpm/rhel/gpg-pubkey@d4082792-5b32db75?distro=rhel-8.8"
  185: "pkg:pypi/PySocks@1.6.8"
  186: "pkg:pypi/chardet@3.0.4"
  187: "pkg:pypi/decorator@4.2.1"
  188: "pkg:pypi/idna@2.5"
  189: "pkg:pypi/iniparse@0.4"
  190: "pkg:pypi/pyinotify@0.9.6"
  191: "pkg:pypi/python-dateutil@2.6.1"
  213: "pkg:pypi/PyGObject@3.28.3"
  214: "pkg:pypi/rpm@4.14.3"
  215: "pkg:pypi/subscription-manager@1.28.36"
  216: "pkg:pypi/systemd-python@234"
]
```
