### PR TITLE
🐛 Try to make mquery checksums stable

### DIFF
--- a/explorer/mquery_test.go
+++ b/explorer/mquery_test.go
@@ -13,6 +13,24 @@ import (
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/testutils"
 )
 
+func TestMquery_RefreshAsAssetFilterStableChecksum(t *testing.T) {
+	m := &Mquery{
+		Mql: "true",
+		Uid: "my-id0",
+	}
+
+	x := testutils.LinuxMock()
+
+	_, err := m.RefreshAsFilter("//owner/me", x.Schema())
+	require.NoError(t, err)
+	assert.Equal(t, "//owner/me/filter/"+m.CodeId, m.Mrn)
+
+	cs := m.Checksum
+	_, err = m.RefreshAsFilter("//owner/me", x.Schema())
+	require.NoError(t, err)
+	assert.Equal(t, cs, m.Checksum)
+}
+
 func TestMquery_Refresh(t *testing.T) {
 	a := &Mquery{
 		Mql:   "mondoo.version != props.world",


### PR DESCRIPTION
If we change a value inside the query, we need to recalculate the checksum. If checksums aren't stable, this ends up breaking parts of the resolver code in cnspec