### PR TITLE
Avoid mdx compilation errors in docs markdown

### DIFF
--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -287,7 +287,7 @@ private openpgp.publicKey {
 private openpgp.identity {
   // Primary key fingerprint
   fingerprint string
-  // Full name in form of "Full Name (comment) <email@example.com>"
+  // Full name in form of `Full Name (comment) <email@example.com>`
   id string
   // Name
   name string


### PR DESCRIPTION
Bare values like <> are no longer allowed in markdown so this causes errors when the parser is trying to parse it. This avoids the parsing.