### PR TITLE
🐛 adjust type of empty+errored array maps

### DIFF
--- a/llx/builtin_array.go
+++ b/llx/builtin_array.go
@@ -362,12 +362,16 @@ func arrayMapV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*Raw
 	}
 
 	if items.Value == nil {
-		return &RawData{Type: items.Type}, 0, nil
+		return &RawData{Type: types.Type(chunk.Function.Type)}, 0, nil
 	}
 
 	list := items.Value.([]interface{})
 	if len(list) == 0 {
-		return items, 0, nil
+		// Note: We have to set the type to be the child taype here. The array is
+		// now technically an any-typed, i.e. it cannot just be cast into a
+		// []T if that is requested down the line. Without carrying types around,
+		// we won't be able to do that easily.
+		return &RawData{Type: types.Type(chunk.Function.Type), Value: []interface{}{}}, 0, nil
 	}
 
 	arg1 := chunk.Function.Args[1]

--- a/llx/llx.go
+++ b/llx/llx.go
@@ -789,7 +789,21 @@ func (e *blockExecutor) runFunction(chunk *Chunk, ref uint64) (*RawData, uint64,
 	}
 
 	if res.Error != nil {
-		e.cache.Store(ref, &stepCache{Result: res})
+		// The data type that this chunk requests needs to be matched. If the
+		// chunk was supposed to transform e.g. a []T into a T, then we need to
+		// make sure that the result type - even if it's an error - is set to T.
+		typ := f.Type
+		if typ == "" {
+			typ = string(res.Type)
+		}
+
+		e.cache.Store(ref, &stepCache{
+			Result: &RawData{
+				Type:  types.Type(typ),
+				Value: res.Value,
+				Error: res.Error,
+			},
+		})
 		return nil, 0, res.Error
 	}
 

--- a/mql/mql_test.go
+++ b/mql/mql_test.go
@@ -190,6 +190,11 @@ func TestNullResources(t *testing.T) {
 			Expectation: false,
 		},
 		{
+			Code:        "muser.groups.where(name == '').map(name) + ['one']",
+			ResultIndex: 0,
+			Expectation: []interface{}{"one"},
+		},
+		{
 			Code:        "muser.groups.where(name == '') == empty",
 			ResultIndex: 2,
 			Expectation: true,


### PR DESCRIPTION
Couple of problems we saw:
1. Reported in https://github.com/mondoohq/cnquery/issues/2604 we see that the child type of the list is never set correctly, if the list is empty. A bit lazy on the return, glad to have this fixed
2. I also noticed that on errors the type is retained. Technically, this shouldn't matter (because it's an error), but just to be sure, we should set it correctly when we return the results.

Fixes https://github.com/mondoohq/cnquery/issues/2604