### PR TITLE
🧹 improve python author

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -1077,6 +1077,8 @@ python.package @defaults("name version") {
   license() string
   // Author of the package
   author() string
+  // Author email of the package
+  authorEmail() string
   // Short package description
   summary() string
   // Package URL

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -1568,6 +1568,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"python.package.author": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPythonPackage).GetAuthor()).ToDataRes(types.String)
 	},
+	"python.package.authorEmail": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPythonPackage).GetAuthorEmail()).ToDataRes(types.String)
+	},
 	"python.package.summary": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPythonPackage).GetSummary()).ToDataRes(types.String)
 	},
@@ -3708,6 +3711,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"python.package.author": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlPythonPackage).Author, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"python.package.authorEmail": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPythonPackage).AuthorEmail, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"python.package.summary": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10621,6 +10628,7 @@ type mqlPythonPackage struct {
 	Version plugin.TValue[string]
 	License plugin.TValue[string]
 	Author plugin.TValue[string]
+	AuthorEmail plugin.TValue[string]
 	Summary plugin.TValue[string]
 	Purl plugin.TValue[string]
 	Cpes plugin.TValue[[]interface{}]
@@ -10693,6 +10701,12 @@ func (c *mqlPythonPackage) GetLicense() *plugin.TValue[string] {
 func (c *mqlPythonPackage) GetAuthor() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Author, func() (string, error) {
 		return c.author()
+	})
+}
+
+func (c *mqlPythonPackage) GetAuthorEmail() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.AuthorEmail, func() (string, error) {
+		return c.authorEmail()
 	})
 }
 

--- a/providers/os/resources/os.lr.manifest.yaml
+++ b/providers/os/resources/os.lr.manifest.yaml
@@ -736,6 +736,7 @@ resources:
   python.package:
     fields:
       author: {}
+      authorEmail: {}
       cpe: {}
       cpes: {}
       dependencies: {}

--- a/providers/os/resources/python/mime.go
+++ b/providers/os/resources/python/mime.go
@@ -62,10 +62,16 @@ func ParseMIME(r io.Reader, pythonMIMEFilepath string) (*PackageDetails, error) 
 		cpes = append(cpes, cpeEntry)
 	}
 
+	author := mimeData.Get("Author")
+	authorEmail := mimeData.Get("Author-email")
+	if authorEmail != "" {
+		author = fmt.Sprintf("%s <%s>", author, authorEmail)
+	}
+
 	return &PackageDetails{
 		Name:         mimeData.Get("Name"),
 		Summary:      mimeData.Get("Summary"),
-		Author:       mimeData.Get("Author"),
+		Author:       author,
 		License:      mimeData.Get("License"),
 		Version:      mimeData.Get("Version"),
 		Dependencies: deps,

--- a/providers/os/resources/python/mime.go
+++ b/providers/os/resources/python/mime.go
@@ -18,6 +18,7 @@ type PackageDetails struct {
 	File         string
 	License      string
 	Author       string
+	AuthorEmail  string
 	Summary      string
 	Version      string
 	Dependencies []string
@@ -62,16 +63,11 @@ func ParseMIME(r io.Reader, pythonMIMEFilepath string) (*PackageDetails, error) 
 		cpes = append(cpes, cpeEntry)
 	}
 
-	author := mimeData.Get("Author")
-	authorEmail := mimeData.Get("Author-email")
-	if authorEmail != "" {
-		author = fmt.Sprintf("%s <%s>", author, authorEmail)
-	}
-
 	return &PackageDetails{
 		Name:         mimeData.Get("Name"),
 		Summary:      mimeData.Get("Summary"),
-		Author:       author,
+		Author:       mimeData.Get("Author"),
+		AuthorEmail:  mimeData.Get("Author-email"),
 		License:      mimeData.Get("License"),
 		Version:      mimeData.Get("Version"),
 		Dependencies: deps,

--- a/providers/os/resources/python/mine_test.go
+++ b/providers/os/resources/python/mine_test.go
@@ -41,7 +41,8 @@ License-File: LICENSE
 	pkg, err := ParseMIME(strings.NewReader(content), "/usr/lib/python3.11/site-packages/pyftpdlib-1.5.7-py3.11.egg-info/PKG-INFO")
 	require.NoError(t, err)
 
-	assert.Equal(t, "Giampaolo Rodola' <g.rodola@gmail.com>", pkg.Author)
+	assert.Equal(t, "Giampaolo Rodola'", pkg.Author)
+	assert.Equal(t, "g.rodola@gmail.com", pkg.AuthorEmail)
 	assert.Equal(t, "pyftpdlib", pkg.Name)
 	assert.Equal(t, "1.5.7", pkg.Version)
 	assert.Equal(t, "MIT", pkg.License)

--- a/providers/os/resources/python/mine_test.go
+++ b/providers/os/resources/python/mine_test.go
@@ -41,6 +41,7 @@ License-File: LICENSE
 	pkg, err := ParseMIME(strings.NewReader(content), "/usr/lib/python3.11/site-packages/pyftpdlib-1.5.7-py3.11.egg-info/PKG-INFO")
 	require.NoError(t, err)
 
+	assert.Equal(t, "Giampaolo Rodola' <g.rodola@gmail.com>", pkg.Author)
 	assert.Equal(t, "pyftpdlib", pkg.Name)
 	assert.Equal(t, "1.5.7", pkg.Version)
 	assert.Equal(t, "MIT", pkg.License)

--- a/providers/os/resources/python_package.go
+++ b/providers/os/resources/python_package.go
@@ -76,6 +76,14 @@ func (k *mqlPythonPackage) author() (string, error) {
 	return k.Author.Data, nil
 }
 
+func (k *mqlPythonPackage) authorEmail() (string, error) {
+	err := k.populateData()
+	if err != nil {
+		return "", err
+	}
+	return k.AuthorEmail.Data, nil
+}
+
 func (k *mqlPythonPackage) summary() (string, error) {
 	err := k.populateData()
 	if err != nil {
@@ -126,6 +134,7 @@ func (k *mqlPythonPackage) populateData() error {
 	k.Name = plugin.TValue[string]{Data: ppd.Name, State: plugin.StateIsSet}
 	k.Version = plugin.TValue[string]{Data: ppd.Version, State: plugin.StateIsSet}
 	k.Author = plugin.TValue[string]{Data: ppd.Author, State: plugin.StateIsSet}
+	k.AuthorEmail = plugin.TValue[string]{Data: ppd.AuthorEmail, State: plugin.StateIsSet}
 	k.Summary = plugin.TValue[string]{Data: ppd.Summary, State: plugin.StateIsSet}
 	k.License = plugin.TValue[string]{Data: ppd.License, State: plugin.StateIsSet}
 	k.Dependencies = plugin.TValue[[]interface{}]{Data: convert.SliceAnyToInterface(ppd.Dependencies), State: plugin.StateIsSet}
@@ -171,6 +180,7 @@ func newMqlPythonPackage(runtime *plugin.Runtime, ppd python.PackageDetails, dep
 		"name":         llx.StringData(ppd.Name),
 		"version":      llx.StringData(ppd.Version),
 		"author":       llx.StringData(ppd.Author),
+		"authorEmail":  llx.StringData(ppd.AuthorEmail),
 		"summary":      llx.StringData(ppd.Summary),
 		"license":      llx.StringData(ppd.License),
 		"file":         llx.ResourceData(f, f.MqlName()),


### PR DESCRIPTION
after #2634 

This improves the author name output to include the email

**before**

```coffeescript
cnquery> python.packages { name author }
python.packages: [
  0: {
    name: "Jinja2"
    author: "Armin Ronacher"
  }
  ...
]
```

**after**

```coffeescript
cnquery> python.packages { name author authorEmail }
python.packages: [
  0: {
    name: "Jinja2"
    author: "Armin Ronacher"
    authorEmail: "armin.ronacher@active-4.com"
  }
  ...
]
```