### PR TITLE
🐛 Trigger job step on push event

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -81,14 +81,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+      # TODO: remove once the dependabot PRs for cnquery go.mod work
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
       - name: Updates to cnquery core go.mod?
         id: cnquerygomod
-        if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
+        if: ((github.event_name == 'push' && github.ref_name != 'main') || github.event_name == 'pull_request') && github.actor == 'dependabot[bot]'
         run: |
           echo "COUNT_GOMOD=$(git diff-tree --name-only -r HEAD~1..HEAD | grep -c -E "^go.mod$")" >> $GITHUB_OUTPUT
 
       - name: Fix providers go.mod for dependabot PRs
-        if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' && steps.cnquerygomod.outputs.COUNT_GOMOD == '1'
+        if: github.actor == 'dependabot[bot]' && steps.cnquerygomod.outputs.COUNT_GOMOD == '1'
         run: |
           go run providers-sdk/v1/util/version/version.go mod-tidy providers/*/
           COUNT=$(git status --short | wc -l)


### PR DESCRIPTION
According to the debug logs, this workflow is triggered on push, not pull_request.
Change the check to push, but make sure the commit does not happen on merge to main again.
The debug step is only temporary to get more insight and will be removed later.