### PR TITLE
🐛 fix error on aws iam attachedPolicies attachedGroups

### DIFF
--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -1069,7 +1069,7 @@ func (a *mqlAwsIamPolicy) attachedGroups() ([]interface{}, error) {
 	for i := range entities.PolicyGroups {
 		group := entities.PolicyGroups[i]
 
-		mqlUser, err := CreateResource(a.MqlRuntime, "aws.iam.group",
+		mqlUser, err := NewResource(a.MqlRuntime, "aws.iam.group",
 			map[string]*llx.RawData{
 				"name": llx.StringDataPtr(group.GroupName),
 			})


### PR DESCRIPTION
fixes https://github.com/mondoohq/cnquery/issues/2677

```

cnquery> aws.iam.policies.where( attachedGroups.length > 0 ) { attachedGroups }
aws.iam.policies.where: [
  0: {
    attachedGroups: [
      0: aws.iam.group arn="arn:aws:iam::..:group/ec2-instance-connect-" name="ec2-instance-connect-"
    ]
  }
```