### PR TITLE
🐛 Allow mondoo-tools to push

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -58,6 +58,8 @@ jobs:
   go-test:
     runs-on: self-hosted
     timeout-minutes: 120
+    permissions:
+      contents: write
     steps:         
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
We can only assign permissions on a job level.

But a dependabot PR runs on the workflow files from main. It should not include updated workflows