### PR TITLE
🧹 dump ms365 output in debug files, stop scripts on error.

### DIFF
--- a/providers/ms365/connection/exchange_report.go
+++ b/providers/ms365/connection/exchange_report.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/pkg/errors"
+	"go.mondoo.com/cnquery/v9/logger"
 )
 
 var exchangeReport = `
@@ -102,6 +103,9 @@ func (c *Ms365Connection) getReport(outlookToken, organization string) (*Exchang
 		if err != nil {
 			return nil, err
 		}
+
+		logger.DebugDumpJSON("exchange-online-report", data)
+
 		err = json.Unmarshal(data, report)
 		if err != nil {
 			return nil, err
@@ -112,6 +116,7 @@ func (c *Ms365Connection) getReport(outlookToken, organization string) (*Exchang
 			return nil, err
 		}
 
+		logger.DebugDumpJSON("exchange-online-report", data)
 		return nil, fmt.Errorf("failed to generate exchange online report (exit code %d): %s", res.ExitStatus, string(data))
 	}
 	return report, nil

--- a/providers/ms365/connection/sharepoint_report.go
+++ b/providers/ms365/connection/sharepoint_report.go
@@ -10,9 +10,11 @@ import (
 	"io"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"go.mondoo.com/cnquery/v9/logger"
 )
 
 var sharepointReport = `
+$ErrorActionPreference = "Stop"
 $token = '%s'
 $url = "%s"
 Install-Module PnP.PowerShell -Force -Scope CurrentUser -RequiredVersion 1.12.0
@@ -75,6 +77,9 @@ func (c *Ms365Connection) getSharepointReport(spToken, url string) (*SharepointO
 		if err != nil {
 			return nil, err
 		}
+
+		logger.DebugDumpJSON("sharepoint-online-report", string(data))
+
 		err = json.Unmarshal(data, report)
 		if err != nil {
 			return nil, err
@@ -85,6 +90,7 @@ func (c *Ms365Connection) getSharepointReport(spToken, url string) (*SharepointO
 			return nil, err
 		}
 
+		logger.DebugDumpJSON("sharepoint-online-report", string(data))
 		return nil, fmt.Errorf("failed to generate sharepoint online report (exit code %d): %s", res.ExitStatus, string(data))
 	}
 	return report, nil

--- a/providers/ms365/connection/teams_report.go
+++ b/providers/ms365/connection/teams_report.go
@@ -11,9 +11,11 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"go.mondoo.com/cnquery/v9/logger"
 )
 
 var teamsReport = `
+$ErrorActionPreference = "Stop"
 $graphToken= '%s'
 $teamsToken = '%s'
 
@@ -77,6 +79,8 @@ func (c *Ms365Connection) getTeamsReport(accessToken, teamsToken string) (*MsTea
 		idx := strings.IndexByte(str, '{')
 		after := str[idx:]
 		newData := []byte(after)
+
+		logger.DebugDumpJSON("ms-teams-report", string(newData))
 		err = json.Unmarshal(newData, report)
 		if err != nil {
 			return nil, err
@@ -87,6 +91,7 @@ func (c *Ms365Connection) getTeamsReport(accessToken, teamsToken string) (*MsTea
 			return nil, err
 		}
 
+		logger.DebugDumpJSON("ms-teams-report", string(data))
 		return nil, fmt.Errorf("failed to generate ms teams report (exit code %d): %s", res.ExitStatus, string(data))
 	}
 	return report, nil


### PR DESCRIPTION
Use `logger.DebugDump` to get the script output out for an improved debugging experience. Also stop the scripts if there's an error, avoiding issues where we get back an empty JSON object since one of the cmdlets has failed