### PR TITLE
🥳 support quit as keyword in the shell

### DIFF
--- a/cli/shell/shell.go
+++ b/cli/shell/shell.go
@@ -217,6 +217,8 @@ func (s *Shell) ExecCmd(cmd string) {
 		s.execQuery(cmd)
 	case cmd == "":
 		return
+	case cmd == "quit":
+		fallthrough
 	case cmd == "exit":
 		s.handleExit()
 		return


### PR DESCRIPTION
Similar to python shell we want to make sure that we support both `exit` and `quit`. This allows users to quickly navigate between different shell tools without thinking too much about the specifics for each shell.

```coffeescript
±> cnquery shell                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
→ connected to macOS
  ___ _ __   __ _ _   _  ___ _ __ _   _ 
 / __| '_ \ / _` | | | |/ _ \ '__| | | |
| (__| | | | (_| | |_| |  __/ |  | |_| |
 \___|_| |_|\__, |\__,_|\___|_|   \__, |
  mondoo™      |_|                |___/  interactive shell

cnquery> quit
±>
```