### PR TITLE
⭐️ support go mod version pinning in version command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c
 	github.com/StackExchange/wmi v1.2.1
+	// pin v0.3.0
 	github.com/alecthomas/participle v0.3.0
 	github.com/alecthomas/participle/v2 v2.1.0
 	github.com/aws/aws-sdk-go v1.48.7
@@ -67,6 +68,7 @@ require (
 	github.com/muesli/reflow v0.3.0
 	github.com/muesli/termenv v0.15.2
 	github.com/olekukonko/tablewriter v0.0.5
+	// pin v1.1.0-rc5
 	github.com/opencontainers/image-spec v1.1.0-rc5
 	github.com/package-url/packageurl-go v0.1.2
 	github.com/pierrec/lz4/v4 v4.1.18

--- a/providers-sdk/v1/util/version/version.go
+++ b/providers-sdk/v1/util/version/version.go
@@ -155,6 +155,17 @@ func checkGoModUpdate(providerPath string, updateStrategy UpdateStrategy) {
 			modPath = require.Mod.Path + "@" + require.Mod.Version
 		}
 
+		if require.Syntax.Comments.Before != nil {
+			for i := range require.Syntax.Comments.Before {
+				comment := require.Syntax.Comments.Before[i].Token
+				if strings.HasPrefix(comment, "// pin") {
+					version := strings.TrimSpace(strings.TrimPrefix(comment, "// pin"))
+					log.Info().Msgf("Found pin comment for %s: %s", require.Mod.Path, version)
+					modPath = require.Mod.Path + "@" + version
+				}
+			}
+		}
+
 		cmd := exec.Command("go", "get", "-u", modPath)
 
 		// Redirect standard output and standard error to the console


### PR DESCRIPTION
To pin a version just add a simple comment in front of the dependency in go.mod:

```
	// pin v1.1.0-rc5
	github.com/opencontainers/image-spec v1.1.0-rc5
```

The `version` cmd is respecting the pinning during go mod version bumps.