### PR TITLE
Adds additional AWS IAM policy elements

### DIFF
--- a/providers/aws/resources/awspolicy/iampolicy.go
+++ b/providers/aws/resources/awspolicy/iampolicy.go
@@ -10,15 +10,19 @@ import (
 
 type IamPolicyDocument struct {
 	Version   string           `json:"Version,omitempty"`
+	Id        string           `json:"Id,omitempty"`
 	Statement policyStatements `json:"Statement,omitempty"`
 }
 
 type IamPolicyStatement struct {
-	Sid       string           `json:"Sid,omitempty"`
-	Effect    string           `json:"Effect,omitempty"`
-	Action    statementSection `json:"Action,omitempty"`
-	NotAction statementSection `json:"NotAction,omitempty"`
-	Resource  statementSection `json:"Resource,omitempty"`
+	Sid          string             `json:"Sid,omitempty"`
+	Effect       string             `json:"Effect,omitempty"`
+	Action       statementSection   `json:"Action,omitempty"`
+	NotAction    statementSection   `json:"NotAction,omitempty"`
+	NotResource  statementSection   `json:"NotResource,omitempty"`
+	Principal    statementSection   `json:"Principal,omitempty"`
+	NotPrincipal statementSection   `json:"NotPrincipal,omitempty"`
+	Resource     statementSection   `json:"Resource,omitempty"`
 }
 
 type policyStatements []IamPolicyStatement

--- a/providers/aws/resources/awspolicy/iampolicy_test.go
+++ b/providers/aws/resources/awspolicy/iampolicy_test.go
@@ -16,6 +16,8 @@ func TestIamPolicies(t *testing.T) {
 		"./testdata/iam_policy1.json",
 		"./testdata/iam_policy2.json",
 		"./testdata/iam_policy3.json",
+		"./testdata/iam_policy4.json",
+		"./testdata/iam_policy5.json",
 	}
 
 	for _, f := range files {

--- a/providers/aws/resources/awspolicy/testdata/iam_policy3.json
+++ b/providers/aws/resources/awspolicy/testdata/iam_policy3.json
@@ -1,5 +1,6 @@
 {
   "Version": "2012-10-17",
+  "Id": "cd3ad3d9-2776-4ef1-a904-4c229d1642ee",
   "Statement": {
     "Effect": "Allow",
     "NotAction": "kms:CreateKey",

--- a/providers/aws/resources/awspolicy/testdata/iam_policy4.json
+++ b/providers/aws/resources/awspolicy/testdata/iam_policy4.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+      "Effect": "Allow",
+      "Principal" : { 
+        "AWS": [ 
+          "123456789012",
+          "555555555555" 
+          ]
+        },
+      "Action": "s3:*",
+      "Resource": [
+          "arn:aws:s3:::BUCKETNAME",
+          "arn:aws:s3:::BUCKETNAME/*"
+      ]
+  }]
+}

--- a/providers/aws/resources/awspolicy/testdata/iam_policy5.json
+++ b/providers/aws/resources/awspolicy/testdata/iam_policy5.json
@@ -1,0 +1,15 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+      "Effect": "Deny",
+      "NotPrincipal": {"AWS": [
+          "arn:aws:iam::444455556666:user/Bob",
+          "arn:aws:iam::444455556666:root"
+      ]},
+      "Action": "s3:*",
+      "Resource": [
+          "arn:aws:s3:::BUCKETNAME",
+          "arn:aws:s3:::BUCKETNAME/*"
+      ]
+  }]
+}


### PR DESCRIPTION
Adds additional AWS IAM policy elements:

`Principal`
`NotPrincipal`
`NotResource`
`Id`

@vjeffrey We will also need to add `Condition` but I could use your support on that. 

`Condition` - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html
