### PR TITLE
🐛 Fix image names for k8s container discovery

### DIFF
--- a/providers/k8s/resources/discovery.go
+++ b/providers/k8s/resources/discovery.go
@@ -9,12 +9,14 @@ import (
 	"strings"
 
 	"github.com/gobwas/glob"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v9/providers/k8s/connection/shared"
 	"go.mondoo.com/cnquery/v9/providers/k8s/connection/shared/resources"
+	"go.mondoo.com/cnquery/v9/providers/os/resources/discovery/container_registry"
 	"go.mondoo.com/cnquery/v9/types"
 	"go.mondoo.com/cnquery/v9/utils/stringx"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -811,17 +813,29 @@ func discoverContainerImages(conn shared.Connection, runtime *plugin.Runtime, in
 		runningImages = types.MergeMaps(runningImages, podImages)
 	}
 
-	assetList := make([]*inventory.Asset, 0, len(runningImages))
-	for _, i := range runningImages {
-		assetList = append(assetList, &inventory.Asset{
-			Connections: []*inventory.Config{
-				{
-					Type: "registry-image",
-					Host: i.resolvedImage,
-				},
-			},
-			Category: conn.Asset().Category,
-		})
+	assetList, err := convertImagesToAssets(runningImages)
+	if err != nil {
+		return nil, err
+	}
+
+	return assetList, nil
+}
+
+func convertImagesToAssets(images map[string]ContainerImage) ([]*inventory.Asset, error) {
+	assetList := make([]*inventory.Asset, 0, len(images))
+	for _, i := range images {
+		ccresolver := container_registry.NewContainerRegistryResolver()
+
+		ref, err := name.ParseReference(i.resolvedImage, name.WeakValidation)
+		if err != nil {
+			return nil, err
+		}
+
+		a, err := ccresolver.GetImage(ref, nil)
+		if err != nil {
+			return nil, err
+		}
+		assetList = append(assetList, a)
 	}
 
 	return assetList, nil

--- a/providers/k8s/resources/discovery_test.go
+++ b/providers/k8s/resources/discovery_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/v9/providers-sdk/v1/inventory"
+)
+
+func TestConvertImagesToAssets(t *testing.T) {
+	images := map[string]ContainerImage{
+		"nginx:1.25.3": {
+			resolvedImage: "nginx@sha256:10d1f5b58f74683ad34eb29287e07dab1e90f10af243f151bb50aa5dbb4d62ee",
+		},
+	}
+	expectedAssets := []inventory.Asset{
+		{
+			Name: "index.docker.io/library/nginx@10d1f5b58f74",
+		},
+	}
+
+	assets, err := convertImagesToAssets(images)
+	require.NoError(t, err)
+	require.Len(t, assets, len(images))
+
+	for i := range assets {
+		require.NotNil(t, assets[i])
+		require.Equal(t, expectedAssets[i].Name, assets[i].Name)
+	}
+}


### PR DESCRIPTION
This fixes the asset name when images are discovered inside a kubernetes cluster.

Now the name is the same as with v8