### PR TITLE
🐛 add missing containsNone([/regex/]) support

### DIFF
--- a/llx/builtin.go
+++ b/llx/builtin.go
@@ -453,6 +453,8 @@ func init() {
 			string("!=" + types.ArrayLike):           {f: dictNotArrayV2, Label: "!="},
 			string("==" + types.Array(types.String)): {f: dictCmpStringarrayV2, Label: "=="},
 			string("!=" + types.Array(types.String)): {f: dictNotStringarrayV2, Label: "!="},
+			string("==" + types.Array(types.Regex)):  {f: dictCmpRegexarrayV2, Label: "=="},
+			string("!=" + types.Array(types.Regex)):  {f: dictNotRegexarrayV2, Label: "!="},
 			string("==" + types.Array(types.Bool)):   {f: dictCmpBoolarrayV2, Label: "=="},
 			string("!=" + types.Array(types.Bool)):   {f: dictNotBoolarrayV2, Label: "!="},
 			string("==" + types.Array(types.Int)):    {f: dictCmpIntarrayV2, Label: "=="},

--- a/llx/builtin_map.go
+++ b/llx/builtin_map.go
@@ -1561,6 +1561,25 @@ func dictNotStringarrayV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uin
 	return rawboolNotOpV2(e, bind, chunk, ref, opDictCmpStringarray)
 }
 
+func opDictCmpRegexarray(left *RawData, right *RawData) bool {
+	switch left.Value.(type) {
+	case string:
+		return cmpArrayOne(right, left, opStringCmpRegex)
+	case []interface{}:
+		return cmpArrays(left, right, opDictCmpRegex)
+	default:
+		return false
+	}
+}
+
+func dictCmpRegexarrayV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
+	return rawboolOpV2(e, bind, chunk, ref, opDictCmpRegexarray)
+}
+
+func dictNotRegexarrayV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
+	return rawboolNotOpV2(e, bind, chunk, ref, opDictCmpRegexarray)
+}
+
 func opDictCmpBoolarray(left *RawData, right *RawData) bool {
 	switch left.Value.(type) {
 	case string:

--- a/providers/os/resources/mql_test.go
+++ b/providers/os/resources/mql_test.go
@@ -309,6 +309,16 @@ func TestDict_Methods_Contains(t *testing.T) {
 			Expectation: false,
 		},
 		{
+			Code:        p + "params['string-array'].containsNone([/z/, /ひ/])",
+			ResultIndex: 2,
+			Expectation: true,
+		},
+		{
+			Code:        p + "params['string-array'].containsNone([/a/, /z/])",
+			ResultIndex: 2,
+			Expectation: false,
+		},
+		{
 			Code:        p + "params['string-array'].none('a')",
 			ResultIndex: 2,
 			Expectation: false,


### PR DESCRIPTION
```
field.containsNone( [ /a/, /.*b/ ] )
```