### PR TITLE
🧹 Automatically create PR to update all deps

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -81,34 +81,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      # TODO: remove once the dependabot PRs for cnquery go.mod work
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
-
-      - name: Updates to cnquery core go.mod?
-        id: cnquerygomod
-        if: ((github.event_name == 'push' && github.ref_name != 'main') || github.event_name == 'pull_request') && github.actor == 'dependabot[bot]'
-        run: |
-          echo "COUNT_GOMOD=$(git diff-tree --name-only -r origin/${{github.ref_name}} origin/main | grep -c -E "^go.mod$")" >> $GITHUB_OUTPUT
-
-      - name: Fix providers go.mod for dependabot PRs
-        if: github.actor == 'dependabot[bot]' && steps.cnquerygomod.outputs.COUNT_GOMOD == '1'
-        run: |
-          go run providers-sdk/v1/util/version/version.go mod-tidy providers/*/
-          COUNT=$(git status --short | wc -l)
-          if [ "$COUNT" -eq "0" ]; then
-            echo "No changes to providers go.mod"
-            exit 0
-          fi
-          git config --global user.email "tools@mondoo.com"
-          git config --global user.name "Mondoo Tools"
-          git add providers/
-          git commit -m "🧹 Update providers go.mod for dependabot PR ${{ github.event.number }}"
-          git push
-        shell: bash
-
       - name: 'Set up gcloud CLI'
         uses: 'google-github-actions/setup-gcloud@v1'
 

--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -1,0 +1,54 @@
+name: Update cnuery and provider dependencies
+
+on:
+  schedule:
+    - cron: "11 8 * * 1" # every monday
+  workflow_dispatch:
+
+jobs:
+  update-deps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Import environment variables from file
+        run: cat ".github/env" >> $GITHUB_ENV
+
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ">=${{ env.golang-version }}"
+          cache: false
+
+      - name: Update deps
+        id: update-deps
+        run: |
+          alias version="go run providers-sdk/v1/util/version/version.go"
+          version mod-update . --latest
+          version mod-update providers/*/ --latest
+          version mod-tidy providers/*/
+          version mod-tidy .
+          echo "COUNT_GOMOD=$(git status --short --untracked-files=no | wc -l)" >> $GITHUB_OUTPUT
+
+      - name: Commit changes upstream
+        id: branch
+        if: ${{ steps.update-deps.outputs.COUNT_GOMOD != '0' }}
+        run: |
+          git config --global user.email "tools@mondoo.com"
+          git config --global user.name "Mondoo Tools"
+          BRANCH_NAME="version/deps_update_$(date +%Y%m%d)"
+          git checkout -b ${BRANCH_NAME}
+          git add go.mod go.sum || true
+          git add providers/ || true
+          git commit -m "🧹 Update deps for cnquery and providers $(date +%Y%m%d)"
+          git push --set-upstream origin ${BRANCH_NAME}
+        shell: bash
+
+      - name: Create pull request
+        run: gh pr create -B main --fill --body 'Created by Mondoo Tools via Github actions'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This creates a PR to update cnquery and provider deps. Dpendabot PRs on the cnquery go.mod do not work, because they mostly also require updates on the provider go.mods.