### PR TITLE
Put Devuan into Debian family

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -214,6 +214,17 @@ var popos = &PlatformResolver{
 	},
 }
 
+var devuan = &PlatformResolver{
+	Name:     "devuan",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		if pf.Name == "devuan" {
+			return true, nil
+		}
+		return false, nil
+	},
+}
+
 // rhel PlatformResolver only detects redhat and no derivatives
 var rhel = &PlatformResolver{
 	Name:     "redhat",
@@ -851,7 +862,7 @@ var redhatFamily = &PlatformResolver{
 var debianFamily = &PlatformResolver{
 	Name:     "debian",
 	IsFamily: true,
-	Children: []*PlatformResolver{debian, ubuntu, raspbian, kali, linuxmint, popos},
+	Children: []*PlatformResolver{debian, ubuntu, raspbian, kali, linuxmint, popos, devuan},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		return true, nil
 	},


### PR DESCRIPTION
It's a non-systemd forked of Debian. With this change the package resource works.

```
cnquery> asset.family
asset.family: [
  0: "debian"
  1: "linux"
  2: "unix"
  3: "os"
]
cnquery> packages.list.first
packages.list.first: package name="libpam-runtime" version="1.1.8-3.6"
```