### PR TITLE
Update host asset title from Network API to Network Host

### DIFF
--- a/providers/network/provider/provider.go
+++ b/providers/network/provider/provider.go
@@ -188,7 +188,7 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.HostConnection
 		Name:   "host",
 		Family: []string{"network"},
 		Kind:   "network",
-		Title:  "Network API",
+		Title:  "Network Host",
 	}
 
 	asset.Fqdn = conn.FQDN()


### PR DESCRIPTION
Network API is very confusing when we're scanning domains and IPs.