### PR TITLE
✨ get closed or all PRs from github

### DIFF
--- a/providers/github/resources/github.lr
+++ b/providers/github/resources/github.lr
@@ -289,8 +289,12 @@ private github.repository @defaults("fullName") {
   hasDiscussions bool
   // Whether the repository is an organization repository template
   isTemplate bool
-  // Whether the repository has open merge requests
+  // List of open merge requests for the repository
   openMergeRequests() []github.mergeRequest
+  // List of closed merge requests for the repository
+  closedMergeRequests() []github.mergeRequest
+  // List of all merge requests for the repository
+  allMergeRequests() []github.mergeRequest
   // List of branches for the repository
   branches() []github.branch
   // Default branch name for the repository

--- a/providers/github/resources/github.lr.go
+++ b/providers/github/resources/github.lr.go
@@ -556,6 +556,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"github.repository.openMergeRequests": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubRepository).GetOpenMergeRequests()).ToDataRes(types.Array(types.Resource("github.mergeRequest")))
 	},
+	"github.repository.closedMergeRequests": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubRepository).GetClosedMergeRequests()).ToDataRes(types.Array(types.Resource("github.mergeRequest")))
+	},
+	"github.repository.allMergeRequests": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubRepository).GetAllMergeRequests()).ToDataRes(types.Array(types.Resource("github.mergeRequest")))
+	},
 	"github.repository.branches": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubRepository).GetBranches()).ToDataRes(types.Array(types.Resource("github.branch")))
 	},
@@ -1457,6 +1463,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"github.repository.openMergeRequests": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGithubRepository).OpenMergeRequests, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"github.repository.closedMergeRequests": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubRepository).ClosedMergeRequests, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"github.repository.allMergeRequests": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubRepository).AllMergeRequests, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
 	"github.repository.branches": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3002,6 +3016,8 @@ type mqlGithubRepository struct {
 	HasDiscussions plugin.TValue[bool]
 	IsTemplate plugin.TValue[bool]
 	OpenMergeRequests plugin.TValue[[]interface{}]
+	ClosedMergeRequests plugin.TValue[[]interface{}]
+	AllMergeRequests plugin.TValue[[]interface{}]
 	Branches plugin.TValue[[]interface{}]
 	DefaultBranchName plugin.TValue[string]
 	Commits plugin.TValue[[]interface{}]
@@ -3201,6 +3217,38 @@ func (c *mqlGithubRepository) GetOpenMergeRequests() *plugin.TValue[[]interface{
 		}
 
 		return c.openMergeRequests()
+	})
+}
+
+func (c *mqlGithubRepository) GetClosedMergeRequests() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.ClosedMergeRequests, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("github.repository", c.__id, "closedMergeRequests")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.closedMergeRequests()
+	})
+}
+
+func (c *mqlGithubRepository) GetAllMergeRequests() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.AllMergeRequests, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("github.repository", c.__id, "allMergeRequests")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.allMergeRequests()
 	})
 }
 

--- a/providers/github/resources/github.lr.manifest.yaml
+++ b/providers/github/resources/github.lr.manifest.yaml
@@ -294,6 +294,8 @@ resources:
     fields:
       MergeRequests:
         min_mondoo_version: latest
+      allMergeRequests:
+        min_mondoo_version: latest
       allowAutoMerge:
         min_mondoo_version: 6.4.0
       allowForking:
@@ -311,6 +313,8 @@ resources:
         min_mondoo_version: 7.14.0
       closedIssues:
         min_mondoo_version: 7.14.0
+      closedMergeRequests:
+        min_mondoo_version: latest
       collaborators:
         min_mondoo_version: 6.11.0
       commits:

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -125,7 +125,7 @@ func (g *mqlGithubRepository) id() (string, error) {
 }
 
 func initGithubMergeRequest(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	if len(args) > 1 {
+	if len(args) > 2 {
 		return args, nil, nil
 	}
 
@@ -164,7 +164,7 @@ func initGithubMergeRequest(runtime *plugin.Runtime, args map[string]*llx.RawDat
 		owner = user.GetLogin()
 	}
 	reponame := ""
-	if x, ok := args["name"]; ok {
+	if x, ok := args["repoName"]; ok {
 		reponame = x.Value.(string)
 	} else {
 		repo, err := conn.Repository()
@@ -354,7 +354,7 @@ func (g *mqlGithubRepository) license() (*mqlGithubLicense, error) {
 	return res.(*mqlGithubLicense), nil
 }
 
-func (g *mqlGithubRepository) openMergeRequests() ([]interface{}, error) {
+func (g *mqlGithubRepository) getMergeRequests(state string) ([]interface{}, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 	if g.Name.Error != nil {
 		return nil, g.Name.Error
@@ -371,7 +371,7 @@ func (g *mqlGithubRepository) openMergeRequests() ([]interface{}, error) {
 
 	listOpts := &github.PullRequestListOptions{
 		ListOptions: github.ListOptions{PerPage: paginationPerPage},
-		State:       "open",
+		State:       state,
 	}
 	var allPulls []*github.PullRequest
 	for {
@@ -435,6 +435,30 @@ func (g *mqlGithubRepository) openMergeRequests() ([]interface{}, error) {
 	}
 
 	return res, nil
+}
+
+func (g *mqlGithubRepository) allMergeRequests() ([]interface{}, error) {
+	res, err := g.getMergeRequests("all")
+	if err != nil {
+		return nil, err
+	}
+	return res, err
+}
+
+func (g *mqlGithubRepository) closedMergeRequests() ([]interface{}, error) {
+	res, err := g.getMergeRequests("closed")
+	if err != nil {
+		return nil, err
+	}
+	return res, err
+}
+
+func (g *mqlGithubRepository) openMergeRequests() ([]interface{}, error) {
+	res, err := g.getMergeRequests("open")
+	if err != nil {
+		return nil, err
+	}
+	return res, err
 }
 
 func (g *mqlGithubMergeRequest) id() (string, error) {


### PR DESCRIPTION
Fixes: https://github.com/mondoohq/cnquery/issues/2764
Fixes: https://github.com/mondoohq/cnquery/issues/2739

Add `closedMergeRequests` and `allMergeRequests` to allow users more control over how much data they want to fetch from github.

A mini addition for github.mergeRequest also got in here that allows specifing the repo

```
github.mergeRequest(number: 2201 repoName: cnspec)
```