### PR TITLE
✨ add retry to providers install

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -265,7 +265,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.5 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.5
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.8 // indirect
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -377,7 +377,7 @@ func LatestVersion(name string) (string, error) {
 	}
 	client.Timeout = time.Duration(5 * time.Second)
 
-	res, err := client.Get("https://releases.mondoo.com/providers/latest.json")
+	res, err := client.Get("https://releases.mondoo.zom/providers/latest.json")
 	if err != nil {
 		return "", err
 	}
@@ -731,27 +731,25 @@ func MustLoadSchemaFromFile(name string, path string) *resources.Schema {
 }
 
 // ZerologAdapter adapts the zerolog logger to the LeveledLogger interface.
+// Converts all retry logs to debug logs
 type ZerologAdapter struct {
 	logger zerolog.Logger
 }
 
 func (z *ZerologAdapter) Error(msg string, keysAndValues ...interface{}) {
-	// The error from retryable http tells us that the request failed
-	// Ignore, just log the fact that we are retrying - which is a debug msg
+	z.logger.Debug().Fields(convertToFields(keysAndValues...)).Msg(msg)
 }
 
 func (z *ZerologAdapter) Info(msg string, keysAndValues ...interface{}) {
-	z.logger.Info().Fields(convertToFields(keysAndValues...)).Msg(msg)
+	z.logger.Debug().Fields(convertToFields(keysAndValues...)).Msg(msg)
 }
 
 func (z *ZerologAdapter) Debug(msg string, keysAndValues ...interface{}) {
-	if strings.Contains(msg, "retrying") {
-		z.logger.Warn().Fields(convertToFields(keysAndValues...)).Msg(msg)
-	}
+	z.logger.Debug().Fields(convertToFields(keysAndValues...)).Msg(msg)
 }
 
 func (z *ZerologAdapter) Warn(msg string, keysAndValues ...interface{}) {
-	z.logger.Warn().Fields(convertToFields(keysAndValues...)).Msg(msg)
+	z.logger.Debug().Fields(convertToFields(keysAndValues...)).Msg(msg)
 }
 
 func convertToFields(keysAndValues ...interface{}) map[string]interface{} {

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -377,7 +377,7 @@ func LatestVersion(name string) (string, error) {
 	}
 	client.Timeout = time.Duration(5 * time.Second)
 
-	res, err := client.Get("https://releases.mondoo.zom/providers/latest.json")
+	res, err := client.Get("https://releases.mondoo.com/providers/latest.json")
 	if err != nil {
 		return "", err
 	}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -359,7 +359,6 @@ func LatestVersion(name string) (string, error) {
 	}
 	client.Timeout = time.Duration(5 * time.Second)
 
-	// Define the maximum number of retries
 	maxRetries := 3
 	var res *http.Response
 
@@ -371,6 +370,7 @@ func LatestVersion(name string) (string, error) {
 		if attempt == maxRetries {
 			return "", err
 		}
+		log.Debug().Msgf("Failed to get https://releases.mondoo.com/providers/latest.json, trying again in %d seconds", attempt)
 		time.Sleep(time.Second * time.Duration(attempt))
 	}
 

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -359,10 +359,21 @@ func LatestVersion(name string) (string, error) {
 	}
 	client.Timeout = time.Duration(5 * time.Second)
 
-	res, err := client.Get("https://releases.mondoo.com/providers/latest.json")
-	if err != nil {
-		return "", err
+	// Define the maximum number of retries
+	maxRetries := 3
+	var res *http.Response
+
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		res, err = client.Get("https://releases.mondoo.com/providers/latest.json")
+		if err == nil {
+			break
+		}
+		if attempt == maxRetries {
+			return "", err
+		}
+		time.Sleep(time.Second * time.Duration(attempt))
 	}
+
 	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		log.Debug().Err(err).Msg("reading latest.json failed")


### PR DESCRIPTION
Fixes #2490

When we fail to get `https://releases.mondoo.com/providers/latest.json` this will wait 1 second, try again, wait 2 seconds, try again. Should hopefully make `prep/providers` stage a bit more reliable.