### PR TITLE
⭐ New defaults and fields for aws.ec2.volume

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1748,7 +1748,7 @@ private aws.ec2.snapshot @defaults("arn") {
 }
 
 // Amazon EC2 volume
-private aws.ec2.volume @defaults("arn encrypted state") {
+private aws.ec2.volume @defaults("id region volumeType size encrypted state") {
   // ARN for the EC2 volume
   arn string
   // ID of the EC2 volume
@@ -1769,6 +1769,14 @@ private aws.ec2.volume @defaults("arn encrypted state") {
   createTime time
   // Region where the EC2 volume is stored
   region string
+  // Whether Amazon EBS Multi-Attach is enabled.
+  multiAttachEnabled bool
+  // The throughput that the volume supports, in MiB/s.
+  throughput int
+  // The size of the volume, in GiBs.
+  size int
+  // The number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes, this represents the number of IOPS that are provisioned for the volume. For gp2 volumes, this represents the baseline performance of the volume and the rate at which the volume accumulates I/O credits for bursting.
+  iops int
 }
 
 // Amazon EC2 instance

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -2537,6 +2537,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.volume.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Volume).GetRegion()).ToDataRes(types.String)
 	},
+	"aws.ec2.volume.multiAttachEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Volume).GetMultiAttachEnabled()).ToDataRes(types.Bool)
+	},
+	"aws.ec2.volume.throughput": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Volume).GetThroughput()).ToDataRes(types.Int)
+	},
+	"aws.ec2.volume.size": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Volume).GetSize()).ToDataRes(types.Int)
+	},
+	"aws.ec2.volume.iops": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Volume).GetIops()).ToDataRes(types.Int)
+	},
 	"aws.ec2.instance.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetArn()).ToDataRes(types.String)
 	},
@@ -5887,6 +5899,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.ec2.volume.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Volume).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.volume.multiAttachEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Volume).MultiAttachEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.volume.throughput": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Volume).Throughput, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.volume.size": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Volume).Size, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.volume.iops": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Volume).Iops, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.instance.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15598,6 +15626,10 @@ type mqlAwsEc2Volume struct {
 	VolumeType plugin.TValue[string]
 	CreateTime plugin.TValue[*time.Time]
 	Region plugin.TValue[string]
+	MultiAttachEnabled plugin.TValue[bool]
+	Throughput plugin.TValue[int64]
+	Size plugin.TValue[int64]
+	Iops plugin.TValue[int64]
 }
 
 // createAwsEc2Volume creates a new instance of this resource
@@ -15675,6 +15707,22 @@ func (c *mqlAwsEc2Volume) GetCreateTime() *plugin.TValue[*time.Time] {
 
 func (c *mqlAwsEc2Volume) GetRegion() *plugin.TValue[string] {
 	return &c.Region
+}
+
+func (c *mqlAwsEc2Volume) GetMultiAttachEnabled() *plugin.TValue[bool] {
+	return &c.MultiAttachEnabled
+}
+
+func (c *mqlAwsEc2Volume) GetThroughput() *plugin.TValue[int64] {
+	return &c.Throughput
+}
+
+func (c *mqlAwsEc2Volume) GetSize() *plugin.TValue[int64] {
+	return &c.Size
+}
+
+func (c *mqlAwsEc2Volume) GetIops() *plugin.TValue[int64] {
+	return &c.Iops
 }
 
 // mqlAwsEc2Instance for the aws.ec2.instance resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -1087,9 +1087,17 @@ resources:
         min_mondoo_version: 5.25.0
       encrypted: {}
       id: {}
+      iops:
+        min_mondoo_version: 9.11.0
+      multiAttachEnabled:
+        min_mondoo_version: 9.11.0
       region: {}
+      size:
+        min_mondoo_version: 9.11.0
       state: {}
       tags: {}
+      throughput:
+        min_mondoo_version: 9.11.0
       volumeType: {}
     is_private: true
     min_mondoo_version: 5.15.0

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -1049,16 +1049,20 @@ func (a *mqlAwsEc2) getVolumes(conn *connection.AwsConnection) []*jobpool.Job {
 					}
 					mqlVol, err := CreateResource(a.MqlRuntime, "aws.ec2.volume",
 						map[string]*llx.RawData{
-							"arn":              llx.StringData(fmt.Sprintf(volumeArnPattern, region, conn.AccountId(), convert.ToString(vol.VolumeId))),
-							"id":               llx.StringData(convert.ToString(vol.VolumeId)),
-							"attachments":      llx.ArrayData(jsonAttachments, types.Any),
-							"encrypted":        llx.BoolData(convert.ToBool(vol.Encrypted)),
-							"state":            llx.StringData(string(vol.State)),
-							"tags":             llx.MapData(Ec2TagsToMap(vol.Tags), types.String),
-							"availabilityZone": llx.StringData(convert.ToString(vol.AvailabilityZone)),
-							"volumeType":       llx.StringData(string(vol.VolumeType)),
-							"createTime":       llx.TimeDataPtr(vol.CreateTime),
-							"region":           llx.StringData(regionVal),
+							"arn":                llx.StringData(fmt.Sprintf(volumeArnPattern, region, conn.AccountId(), convert.ToString(vol.VolumeId))),
+							"attachments":        llx.ArrayData(jsonAttachments, types.Any),
+							"availabilityZone":   llx.StringDataPtr(vol.AvailabilityZone),
+							"createTime":         llx.TimeDataPtr(vol.CreateTime),
+							"encrypted":          llx.BoolDataPtr(vol.Encrypted),
+							"id":                 llx.StringDataPtr(vol.VolumeId),
+							"iops":               llx.IntData(convert.ToInt64From32(vol.Iops)),
+							"multiAttachEnabled": llx.BoolDataPtr(vol.MultiAttachEnabled),
+							"region":             llx.StringData(regionVal),
+							"size":               llx.IntData(convert.ToInt64From32(vol.Size)),
+							"state":              llx.StringData(string(vol.State)),
+							"tags":               llx.MapData(Ec2TagsToMap(vol.Tags), types.String),
+							"throughput":         llx.IntData(convert.ToInt64From32(vol.Throughput)),
+							"volumeType":         llx.StringData(string(vol.VolumeType)),
 						})
 					if err != nil {
 						return nil, err


### PR DESCRIPTION
```
aws.ec2.volumes: [
  0: aws.ec2.volume id="vol-xxxxxxx" region="us-east-1" volumeType="gp3" size=80 encrypted=true state="in-use"
  1: aws.ec2.volume id="vol-xxxxxxx" region="us-east-1" volumeType="gp3" size=16 encrypted=false state="in-use"
  2: aws.ec2.volume id="vol-xxxxxxx" region="us-east-1" volumeType="gp2" size=50 encrypted=true state="in-use"
```

```
cnquery> aws.ec2.volumes.first{*}
aws.ec2.volumes.first: {
  region: "us-east-1"
  id: "vol-xxxxxxx"
  arn: "arn:aws:ec2:us-west-2:xxxxxxx:volume/vol-xxxxxxx"
  multiAttachEnabled: false
  tags: {
    ExtraTag: "EKS managed node group complete example"
    Name: "eks-managed-nodes-sg40"
    eks:cluster-name: "eks-cluster-container-escape-demo-sg40-cluster"
    eks:nodegroup-name: "eks-managed-nodes-sg40-xxxxxxx"
  }
  throughput: 150
  iops: 3000
  availabilityZone: "us-east-1c"
  attachments: [
    0: {
      AttachTime: "2023-12-08T03:37:23Z"
      DeleteOnTermination: true
      Device: "/dev/xvda"
      InstanceId: "i-xxxxxxx"
      State: "attached"
      VolumeId: "vol-xxxxxxx"
    }
  ]
  encrypted: true
  volumeType: "gp3"
  createTime: 2023-12-07 19:37:23.341 -0800 PST
  size: 80
  state: "in-use"
}
```