### PR TITLE
⭐ New defaults and fields for aws.ec2.snapshot

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1728,7 +1728,7 @@ private aws.ec2.internetgateway @defaults("arn") {
 }
 
 // Amazon EC2 snapshot
-private aws.ec2.snapshot @defaults("arn") {
+private aws.ec2.snapshot @defaults("id region volumeSize state") {
   // ARN for the snapshot
   arn string
   // ID for the snapshot
@@ -1745,6 +1745,12 @@ private aws.ec2.snapshot @defaults("arn") {
   tags map[string]string
   // State of the snapshot (pending, completed, error, recoverable, or recovering)
   state string
+  // The size of the volume, in GiB.
+  volumeSize int
+  // The description of the snapshot
+  description string
+  // Whether the snapshot is encrypted
+  encrypted bool
 }
 
 // Amazon EC2 volume

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -2507,6 +2507,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.snapshot.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Snapshot).GetState()).ToDataRes(types.String)
 	},
+	"aws.ec2.snapshot.volumeSize": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Snapshot).GetVolumeSize()).ToDataRes(types.Int)
+	},
+	"aws.ec2.snapshot.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Snapshot).GetDescription()).ToDataRes(types.String)
+	},
+	"aws.ec2.snapshot.encrypted": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Snapshot).GetEncrypted()).ToDataRes(types.Bool)
+	},
 	"aws.ec2.volume.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Volume).GetArn()).ToDataRes(types.String)
 	},
@@ -5843,6 +5852,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.ec2.snapshot.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Snapshot).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.snapshot.volumeSize": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Snapshot).VolumeSize, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.snapshot.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Snapshot).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.snapshot.encrypted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Snapshot).Encrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.volume.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15510,6 +15531,9 @@ type mqlAwsEc2Snapshot struct {
 	StartTime plugin.TValue[*time.Time]
 	Tags plugin.TValue[map[string]interface{}]
 	State plugin.TValue[string]
+	VolumeSize plugin.TValue[int64]
+	Description plugin.TValue[string]
+	Encrypted plugin.TValue[bool]
 }
 
 // createAwsEc2Snapshot creates a new instance of this resource
@@ -15581,6 +15605,18 @@ func (c *mqlAwsEc2Snapshot) GetTags() *plugin.TValue[map[string]interface{}] {
 
 func (c *mqlAwsEc2Snapshot) GetState() *plugin.TValue[string] {
 	return &c.State
+}
+
+func (c *mqlAwsEc2Snapshot) GetVolumeSize() *plugin.TValue[int64] {
+	return &c.VolumeSize
+}
+
+func (c *mqlAwsEc2Snapshot) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlAwsEc2Snapshot) GetEncrypted() *plugin.TValue[bool] {
+	return &c.Encrypted
 }
 
 // mqlAwsEc2Volume for the aws.ec2.volume resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -1051,12 +1051,18 @@ resources:
     fields:
       arn: {}
       createVolumePermission: {}
+      description:
+        min_mondoo_version: 9.11.0
+      encrypted:
+        min_mondoo_version: 9.11.0
       id: {}
       region: {}
       startTime: {}
       state: {}
       tags: {}
       volumeId: {}
+      volumeSize:
+        min_mondoo_version: 9.11.0
     is_private: true
     min_mondoo_version: 5.15.0
     platform:

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -1338,13 +1338,16 @@ func (a *mqlAwsEc2) getSnapshots(conn *connection.AwsConnection) []*jobpool.Job 
 				for _, snapshot := range snapshots.Snapshots {
 					mqlSnap, err := CreateResource(a.MqlRuntime, "aws.ec2.snapshot",
 						map[string]*llx.RawData{
-							"arn":       llx.StringData(fmt.Sprintf(snapshotArnPattern, regionVal, conn.AccountId(), convert.ToString(snapshot.SnapshotId))),
-							"id":        llx.StringData(convert.ToString(snapshot.SnapshotId)),
-							"region":    llx.StringData(regionVal),
-							"volumeId":  llx.StringData(convert.ToString(snapshot.VolumeId)),
-							"startTime": llx.TimeDataPtr(snapshot.StartTime),
-							"tags":      llx.MapData(Ec2TagsToMap(snapshot.Tags), types.String),
-							"state":     llx.StringData(string(snapshot.State)),
+							"arn":         llx.StringData(fmt.Sprintf(snapshotArnPattern, regionVal, conn.AccountId(), convert.ToString(snapshot.SnapshotId))),
+							"description": llx.StringDataPtr(snapshot.Description),
+							"encrypted":   llx.BoolDataPtr(snapshot.Encrypted),
+							"id":          llx.StringDataPtr(snapshot.SnapshotId),
+							"region":      llx.StringData(regionVal),
+							"startTime":   llx.TimeDataPtr(snapshot.StartTime),
+							"state":       llx.StringData(string(snapshot.State)),
+							"tags":        llx.MapData(Ec2TagsToMap(snapshot.Tags), types.String),
+							"volumeId":    llx.StringDataPtr(snapshot.VolumeId),
+							"volumeSize":  llx.IntData(convert.ToInt64From32(snapshot.VolumeSize)),
 						})
 					if err != nil {
 						return nil, err


### PR DESCRIPTION
Add new fields and improve the defaults

```
cnquery> aws.ec2.snapshots
aws.ec2.snapshots: [
  0: aws.ec2.snapshot id="snap-xxxxxxxxx" region="us-east-1" volumeSize=8 state="completed"
  1: aws.ec2.snapshot id="snap-xxxxxxxxx" region="us-east-1" volumeSize=8 state="completed"
  2: aws.ec2.snapshot id="snap-xxxxxxxxx" region="us-east-1" volumeSize=30 state="completed"
  3: aws.ec2.snapshot id="snap-xxxxxxxxx" region="us-east-1" volumeSize=30 state="completed"
````

```
cnquery> aws.ec2.snapshots.first{*}
aws.ec2.snapshots.first: {
  id: "snap-xxxxxxxxx"
  startTime: 2022-11-30 15:31:03.985 -0800 PST
  encrypted: true
  tags: {
    Base_AMI_Name: "amzn2-ami-kernel-5.10-hvm-2.0.20221103.3-x86_64-gp2"
    Creation_Date: "2022-11-14T23:11:49.000Z"
    Name: "mondoo-aws-amazon-linux-2-secure-base-20221130232803"
    Source_AMI: "ami-xxxxxxxxx"
  }
  arn: "arn:aws:ec2:us-east-1:xxxxxxxxx:snapshot/snap-xxxxxxxxx"
  volumeSize: 8
  state: "completed"
  description: "Created by CreateImage(i-xxxxxxxxx) for ami-xxxxxxxxx"
  createVolumePermission: []
  volumeId: "vol-xxxxxxxxx"
  region: "us-east-1"
}
```