### PR TITLE
⭐ Update aws.ec2.networkacl with new fields

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1669,6 +1669,10 @@ private aws.ec2.networkacl @defaults("id region") {
   region string
   // Entries for the network ACL
   entries() []aws.ec2.networkacl.entry
+  // Whether the ACL is the default network ACL for the VPC
+  isDefault bool
+  // Tags for the ACL
+  tags map[string]string
 }
 
 // Amazon EC2 network ACL entry

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -2429,6 +2429,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.networkacl.entries": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Networkacl).GetEntries()).ToDataRes(types.Array(types.Resource("aws.ec2.networkacl.entry")))
 	},
+	"aws.ec2.networkacl.isDefault": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Networkacl).GetIsDefault()).ToDataRes(types.Bool)
+	},
+	"aws.ec2.networkacl.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Networkacl).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"aws.ec2.networkacl.entry.egress": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2NetworkaclEntry).GetEgress()).ToDataRes(types.Bool)
 	},
@@ -5715,6 +5721,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.ec2.networkacl.entries": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Networkacl).Entries, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.networkacl.isDefault": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Networkacl).IsDefault, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.networkacl.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Networkacl).Tags, ok = plugin.RawToTValue[map[string]interface{}](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.networkacl.entry.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15108,6 +15122,8 @@ type mqlAwsEc2Networkacl struct {
 	Id plugin.TValue[string]
 	Region plugin.TValue[string]
 	Entries plugin.TValue[[]interface{}]
+	IsDefault plugin.TValue[bool]
+	Tags plugin.TValue[map[string]interface{}]
 }
 
 // createAwsEc2Networkacl creates a new instance of this resource
@@ -15173,6 +15189,14 @@ func (c *mqlAwsEc2Networkacl) GetEntries() *plugin.TValue[[]interface{}] {
 
 		return c.entries()
 	})
+}
+
+func (c *mqlAwsEc2Networkacl) GetIsDefault() *plugin.TValue[bool] {
+	return &c.IsDefault
+}
+
+func (c *mqlAwsEc2Networkacl) GetTags() *plugin.TValue[map[string]interface{}] {
+	return &c.Tags
 }
 
 // mqlAwsEc2NetworkaclEntry for the aws.ec2.networkacl.entry resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -969,7 +969,11 @@ resources:
       arn: {}
       entries: {}
       id: {}
+      isDefault:
+        min_mondoo_version: 9.11.0
       region: {}
+      tags:
+        min_mondoo_version: 9.11.0
     is_private: true
     min_mondoo_version: 5.15.0
     platform:

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -103,9 +103,11 @@ func (a *mqlAwsEc2) getNetworkACLs(conn *connection.AwsConnection) []*jobpool.Jo
 					acl := networkAcls.NetworkAcls[i]
 					mqlNetworkAcl, err := CreateResource(a.MqlRuntime, "aws.ec2.networkacl",
 						map[string]*llx.RawData{
-							"arn":    llx.StringData(fmt.Sprintf(networkAclArnPattern, regionVal, conn.AccountId(), convert.ToString(acl.NetworkAclId))),
-							"id":     llx.StringDataPtr(acl.NetworkAclId),
-							"region": llx.StringData(regionVal),
+							"arn":       llx.StringData(fmt.Sprintf(networkAclArnPattern, regionVal, conn.AccountId(), convert.ToString(acl.NetworkAclId))),
+							"id":        llx.StringDataPtr(acl.NetworkAclId),
+							"region":    llx.StringData(regionVal),
+							"isDefault": llx.BoolDataPtr(acl.IsDefault),
+							"tags":      llx.MapData(Ec2TagsToMap(acl.Tags), types.String),
 						})
 					if err != nil {
 						return nil, err


### PR DESCRIPTION
isDefault and tags

```
 19: {
    isDefault: false
    arn: "arn:aws:ec2:us-east-1:xxxxxxxxx:network-acl/acl-xxxxxxxxx"
    tags: {
      Attributes: "public"
      Name: "eg-prod-app-public"
      Namespace: "eg"
      Stage: "prod"
    }
    region: "us-east-1"
    id: "acl-xxxxxxxxx"
    entries: [
      0: aws.ec2.networkacl.entry id="acl-xxxxxxxxx-100-egress" egress=true ruleAction="allow" cidrBlock="0.0.0.0/0" portRange=null
      1: aws.ec2.networkacl.entry id="acl-xxxxxxxxx-32767-egress" egress=true ruleAction="deny" cidrBlock="0.0.0.0/0" portRange=null
      2: aws.ec2.networkacl.entry id="acl-xxxxxxxxx-100-ingress" egress=false ruleAction="allow" cidrBlock="0.0.0.0/0" portRange=null
      3: aws.ec2.networkacl.entry id="acl-xxxxxxxxx-32767-ingress" egress=false ruleAction="deny" cidrBlock="0.0.0.0/0" portRange=null
    ]
  }
```