### PR TITLE
⭐ Improve aws.ec2.securityGroups defaults + ptr cleanup

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1888,7 +1888,7 @@ private aws.ec2.instance.device {
 }
 
 // Amazon EC2 security group
-private aws.ec2.securitygroup @defaults("arn") {
+private aws.ec2.securitygroup @defaults("id name region vpc.id") {
   // Security group ARN
   arn string
   // Security group ID

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -269,7 +269,7 @@ func (a *mqlAwsEc2) getSecurityGroups(conn *connection.AwsConnection) []*jobpool
 								"id":         llx.StringData(convert.ToString(group.GroupId) + "-" + strconv.Itoa(p)),
 								"fromPort":   llx.IntData(convert.ToInt64From32(permission.FromPort)),
 								"toPort":     llx.IntData(convert.ToInt64From32(permission.ToPort)),
-								"ipProtocol": llx.StringData(convert.ToString(permission.IpProtocol)),
+								"ipProtocol": llx.StringDataPtr(permission.IpProtocol),
 								"ipRanges":   llx.ArrayData(ipRanges, types.Any),
 								"ipv6Ranges": llx.ArrayData(ipv6Ranges, types.Any),
 							})
@@ -304,7 +304,7 @@ func (a *mqlAwsEc2) getSecurityGroups(conn *connection.AwsConnection) []*jobpool
 								"id":         llx.StringData(convert.ToString(group.GroupId) + "-" + strconv.Itoa(p) + "-egress"),
 								"fromPort":   llx.IntData(convert.ToInt64From32(permission.FromPort)),
 								"toPort":     llx.IntData(convert.ToInt64From32(permission.ToPort)),
-								"ipProtocol": llx.StringData(convert.ToString(permission.IpProtocol)),
+								"ipProtocol": llx.StringDataPtr(permission.IpProtocol),
 								"ipRanges":   llx.ArrayData(ipRanges, types.Any),
 								"ipv6Ranges": llx.ArrayData(ipv6Ranges, types.Any),
 							})
@@ -317,9 +317,9 @@ func (a *mqlAwsEc2) getSecurityGroups(conn *connection.AwsConnection) []*jobpool
 
 					args := map[string]*llx.RawData{
 						"arn":                 llx.StringData(fmt.Sprintf(securityGroupArnPattern, regionVal, conn.AccountId(), convert.ToString(group.GroupId))),
-						"id":                  llx.StringData(convert.ToString(group.GroupId)),
-						"name":                llx.StringData(convert.ToString(group.GroupName)),
-						"description":         llx.StringData(convert.ToString(group.Description)),
+						"id":                  llx.StringDataPtr(group.GroupId),
+						"name":                llx.StringDataPtr(group.GroupName),
+						"description":         llx.StringDataPtr(group.Description),
 						"tags":                llx.MapData(Ec2TagsToMap(group.Tags), types.String),
 						"ipPermissions":       llx.ArrayData(mqlIpPermissions, types.Resource("aws.ec2.securitygroup.ippermission")),
 						"ipPermissionsEgress": llx.ArrayData(mqlIpPermissionsEgress, types.Resource("aws.ec2.securitygroup.ippermission")),


### PR DESCRIPTION
Improve the defaults and cleanup some string conversions.

```
aws.ec2.securityGroups: [
  0: aws.ec2.securitygroup id="sg-xxxxx" name="mondoo-scanning-securitygroup" region="ap-south-1" vpc.id="vpc-xxxxx"
  1: aws.ec2.securitygroup id="sg-xxxxx" name="default" region="ap-south-1" vpc.id="vpc-xxxxx"
  2: aws.ec2.securitygroup id="sg-xxxxx" name="default" region="eu-north-1" vpc.id="vpc-xxxxx"
  3: aws.ec2.securitygroup id="sg-xxxxx" name="mondoo-scanning-securitygroup" region="eu-north-1" vpc.id="vpc-xxxxx"
  4: aws.ec2.securitygroup id="sg-xxxxx" name="default" region="eu-west-3" vpc.id="vpc-xxxxx"
```