### PR TITLE
⭐ Improve aws.config.rules resource

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1966,9 +1966,9 @@ private aws.config.rule @defaults("name id region state") {
   // The ID of the Config rule
   id string
   // The name that you assigned to the Config rule
-	name string
+  name string
   // The description that provided for the Config rule
-	description string
+  description string
   // Region for the Config rule
   region string
 }

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1751,7 +1751,7 @@ private aws.ec2.snapshot @defaults("id region volumeSize state") {
   tags map[string]string
   // State of the snapshot (pending, completed, error, recoverable, or recovering)
   state string
-  // The size of the volume, in GiB.
+  // The size of the volume, in GiB
   volumeSize int
   // The description of the snapshot
   description string

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1947,7 +1947,6 @@ private aws.ec2.securitygroup.ippermission @defaults("id toPort fromPort ipProto
   ipv6Ranges []string
 }
 
-
 // AWS config
 aws.config {
   // List of configuration recorders for each region in the account
@@ -1957,13 +1956,21 @@ aws.config {
 }
 
 // AWS config rule
-private aws.config.rule @defaults("arn state") {
+private aws.config.rule @defaults("name id region state") {
   // ARN for the config rule
   arn string
   // State of the rule
   state string
   // Rule identifier that causes the function to evaluate resources
   source dict
+  // The ID of the Config rule
+  id string
+  // The name that you assigned to the Config rule
+	name string
+  // The description that provided for the Config rule
+	description string
+  // Region for the Config rule
+  region string
 }
 
 // AWS config recorder

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1673,7 +1673,7 @@ private aws.ec2.networkacl @defaults("id region") {
   entries() []aws.ec2.networkacl.entry
   // Whether the ACL is the default network ACL for the VPC
   isDefault bool
-  // Tags for the ACL
+  // Tags for the network ACL
   tags map[string]string
 }
 

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -2780,6 +2780,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.config.rule.source": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsConfigRule).GetSource()).ToDataRes(types.Dict)
 	},
+	"aws.config.rule.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsConfigRule).GetId()).ToDataRes(types.String)
+	},
+	"aws.config.rule.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsConfigRule).GetName()).ToDataRes(types.String)
+	},
+	"aws.config.rule.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsConfigRule).GetDescription()).ToDataRes(types.String)
+	},
+	"aws.config.rule.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsConfigRule).GetRegion()).ToDataRes(types.String)
+	},
 	"aws.config.recorder.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsConfigRecorder).GetName()).ToDataRes(types.String)
 	},
@@ -6273,6 +6285,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.config.rule.source": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsConfigRule).Source, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.config.rule.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsConfigRule).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.config.rule.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsConfigRule).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.config.rule.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsConfigRule).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.config.rule.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsConfigRule).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.config.recorder.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16509,6 +16537,10 @@ type mqlAwsConfigRule struct {
 	Arn plugin.TValue[string]
 	State plugin.TValue[string]
 	Source plugin.TValue[interface{}]
+	Id plugin.TValue[string]
+	Name plugin.TValue[string]
+	Description plugin.TValue[string]
+	Region plugin.TValue[string]
 }
 
 // createAwsConfigRule creates a new instance of this resource
@@ -16558,6 +16590,22 @@ func (c *mqlAwsConfigRule) GetState() *plugin.TValue[string] {
 
 func (c *mqlAwsConfigRule) GetSource() *plugin.TValue[interface{}] {
 	return &c.Source
+}
+
+func (c *mqlAwsConfigRule) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAwsConfigRule) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAwsConfigRule) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlAwsConfigRule) GetRegion() *plugin.TValue[string] {
+	return &c.Region
 }
 
 // mqlAwsConfigRecorder for the aws.config.recorder resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -678,11 +678,18 @@ resources:
       - aws
   aws.config.rule:
     docs:
-      desc: "The `aws.config.rule` resource provides fields representing an individual
-        AWS Config rule configured within an account. For usage see the `aws.config`
-        resource documentation. \n"
+      desc: |
+        The `aws.config.rule` resource provides fields representing an individual AWS Config rule configured within an account. For usage see the `aws.config` resource documentation.
     fields:
       arn: {}
+      description:
+        min_mondoo_version: 9.11.0
+      id:
+        min_mondoo_version: 9.11.0
+      name:
+        min_mondoo_version: 9.11.0
+      region:
+        min_mondoo_version: 9.11.0
       source: {}
       state: {}
     is_private: true

--- a/providers/aws/resources/aws_config.go
+++ b/providers/aws/resources/aws_config.go
@@ -75,8 +75,8 @@ func (a *mqlAwsConfig) getRecorders(conn *connection.AwsConnection) []*jobpool.J
 				}
 				mqlRecorder, err := CreateResource(a.MqlRuntime, "aws.config.recorder",
 					map[string]*llx.RawData{
-						"name":                       llx.StringData(convert.ToString(r.Name)),
-						"roleArn":                    llx.StringData(convert.ToString(r.RoleARN)),
+						"name":                       llx.StringDataPtr(r.Name),
+						"roleArn":                    llx.StringDataPtr(r.RoleARN),
 						"allSupported":               llx.BoolData(r.RecordingGroup.AllSupported),
 						"includeGlobalResourceTypes": llx.BoolData(r.RecordingGroup.IncludeGlobalResourceTypes),
 						"recording":                  llx.BoolData(recording),
@@ -171,9 +171,13 @@ func (a *mqlAwsConfig) getRules(conn *connection.AwsConnection) []*jobpool.Job {
 				}
 				mqlRule, err := CreateResource(a.MqlRuntime, "aws.config.rule",
 					map[string]*llx.RawData{
-						"arn":    llx.StringData(convert.ToString(r.ConfigRuleArn)),
-						"state":  llx.StringData(string(r.ConfigRuleState)),
-						"source": llx.MapData(jsonSource, types.Any),
+						"arn":         llx.StringDataPtr(r.ConfigRuleArn),
+						"name":        llx.StringDataPtr(r.ConfigRuleName),
+						"description": llx.StringDataPtr(r.Description),
+						"id":          llx.StringDataPtr(r.ConfigRuleId),
+						"source":      llx.MapData(jsonSource, types.Any),
+						"state":       llx.StringData(string(r.ConfigRuleState)),
+						"region":      llx.StringData(regionVal),
 					})
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
Add new fields and defaults plus cleanup some ptrs

```
cnquery> aws.config.rules
aws.config.rules: [
  0: aws.config.rule name="ec2-ebs-encryption-by-default" id="config-rule-2tre0q" region="us-east-1" state="ACTIVE"
  1: aws.config.rule name="ec2-imdsv2-check" id="config-rule-antu1f" region="us-east-1" state="ACTIVE"
  2: aws.config.rule name="ec2-instance-detailed-monitoring-enabled" id="config-rule-lilt2r" region="us-east-1" state="ACTIVE"
```

```
cnquery> aws.config.rules.first{*}
aws.config.rules.first: {
  source: {
    CustomPolicyDetails: null
    Owner: "AWS"
    SourceDetails: null
    SourceIdentifier: "EC2_EBS_ENCRYPTION_BY_DEFAULT"
  }
  id: "config-rule-2tre0q"
  arn: "arn:aws:config:us-east-1:xxxxxxxx:config-rule/config-rule-2tre0q"
  region: "us-east-1"
  description: "Check that Amazon Elastic Block Store (EBS) encryption is enabled by default. The rule is NON_COMPLIANT if the encryption is not enabled."
  state: "ACTIVE"
  name: "ec2-ebs-encryption-by-default"
}
```

