### PR TITLE
🐛 Parse k8s namespace filters from inventory file

### DIFF
--- a/providers/k8s/connection/shared/connection.go
+++ b/providers/k8s/connection/shared/connection.go
@@ -18,8 +18,8 @@ import (
 const (
 	OPTION_MANIFEST          = "path"
 	OPTION_IMMEMORY_CONTENT  = "manifest-content"
-	OPTION_NAMESPACE         = "namespace"
-	OPTION_NAMESPACE_EXCLUDE = "namespace-exclude"
+	OPTION_NAMESPACE         = "namespaces"
+	OPTION_NAMESPACE_EXCLUDE = "namespaces-exclude"
 	OPTION_ADMISSION         = "k8s-admission-review"
 	OPTION_OBJECT_KIND       = "object-kind"
 	OPTION_CONTEXT           = "context"

--- a/providers/k8s/provider/provider.go
+++ b/providers/k8s/provider/provider.go
@@ -71,11 +71,11 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		conf.Options[shared.OPTION_CONTEXT] = string(context.Value)
 	}
 
-	if ns, ok := req.Flags["namespaces"]; ok {
+	if ns, ok := req.Flags[shared.OPTION_NAMESPACE]; ok {
 		conf.Options[shared.OPTION_NAMESPACE] = string(ns.Value)
 	}
 
-	if ns, ok := req.Flags["namespaces-exclude"]; ok {
+	if ns, ok := req.Flags[shared.OPTION_NAMESPACE_EXCLUDE]; ok {
 		conf.Options[shared.OPTION_NAMESPACE_EXCLUDE] = string(ns.Value)
 	}
 

--- a/providers/k8s/resources/discovery.go
+++ b/providers/k8s/resources/discovery.go
@@ -103,14 +103,7 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 	}
 	k8s := res.(*mqlK8s)
 
-	nsFilter := NamespaceFilterOpts{}
-	if include, ok := invConfig.Options[shared.OPTION_NAMESPACE]; ok && len(include) > 0 {
-		nsFilter.include = strings.Split(include, ",")
-	}
-
-	if exclude, ok := invConfig.Options[shared.OPTION_NAMESPACE_EXCLUDE]; ok && len(exclude) > 0 {
-		nsFilter.exclude = strings.Split(exclude, ",")
-	}
+	nsFilter := setNamespaceFilters(invConfig)
 
 	resFilters, err := resourceFilters(invConfig)
 	if err != nil {
@@ -1081,4 +1074,16 @@ func resourceFilters(cfg *inventory.Config) (*ResourceFilters, error) {
 		}
 	}
 	return resourcesFilter, nil
+}
+
+func setNamespaceFilters(cfg *inventory.Config) NamespaceFilterOpts {
+	nsFilter := NamespaceFilterOpts{}
+	if include, ok := cfg.Options[shared.OPTION_NAMESPACE]; ok && len(include) > 0 {
+		nsFilter.include = strings.Split(include, ",")
+	}
+
+	if exclude, ok := cfg.Options[shared.OPTION_NAMESPACE_EXCLUDE]; ok && len(exclude) > 0 {
+		nsFilter.exclude = strings.Split(exclude, ",")
+	}
+	return nsFilter
 }

--- a/providers/k8s/resources/discovery_test.go
+++ b/providers/k8s/resources/discovery_test.go
@@ -31,3 +31,33 @@ func TestConvertImagesToAssets(t *testing.T) {
 		require.Equal(t, expectedAssets[i].Name, assets[i].Name)
 	}
 }
+
+func TestSetNamespaceFilters(t *testing.T) {
+	cfg := &inventory.Config{
+		Options: map[string]string{
+			"namespaces":         "namespace1,namespace2",
+			"namespaces-exclude": "namespace3,namespace4",
+		},
+	}
+
+	nsFilter := setNamespaceFilters(cfg)
+
+	expectedInclude := []string{"namespace1", "namespace2"}
+	expectedExclude := []string{"namespace3", "namespace4"}
+
+	require.Equal(t, expectedInclude, nsFilter.include)
+	require.Equal(t, expectedExclude, nsFilter.exclude)
+
+	// missing "s" in namespaces
+	cfg = &inventory.Config{
+		Options: map[string]string{
+			"namespace":         "namespace1,namespace2",
+			"namespace-exclude": "namespace3,namespace4",
+		},
+	}
+
+	nsFilter = setNamespaceFilters(cfg)
+
+	require.Nil(t, nsFilter.include)
+	require.Nil(t, nsFilter.exclude)
+}


### PR DESCRIPTION
The CLI parser was already using the correct names. Now also the inventory parser is looking the correct options.

Fixes #2805