### PR TITLE
fix aws waf cannot convert primitive with NO type information

### DIFF
--- a/providers/aws/resources/aws_waf.go
+++ b/providers/aws/resources/aws_waf.go
@@ -71,7 +71,8 @@ func (a *mqlAwsWaf) acls() ([]interface{}, error) {
 	ctx := context.Background()
 	acls := []interface{}{}
 	nextMarker := aws.String("No-Marker-to-begin-with")
-	scope := waftypes.Scope(a.Scope.Data)
+	scopeString := a.Scope.Data
+	scope := waftypes.Scope(scopeString)
 	params := &wafv2.ListWebACLsInput{Scope: scope}
 	for nextMarker != nil {
 		aclsRes, err := svc.ListWebACLs(ctx, params)
@@ -96,6 +97,7 @@ func (a *mqlAwsWaf) acls() ([]interface{}, error) {
 			mqlAcl, err := CreateResource(a.MqlRuntime, "aws.waf.acl",
 				map[string]*llx.RawData{
 					"id":                       llx.StringDataPtr(acl.Id),
+					"scope":                    llx.StringData(scopeString),
 					"arn":                      llx.StringDataPtr(acl.ARN),
 					"name":                     llx.StringDataPtr(acl.Name),
 					"description":              llx.StringDataPtr(acl.Description),


### PR DESCRIPTION
Fixes 

```
cnquery> aws.waf(scope: "REGIONAL").acls{ * }
2 errors occurred:
        * operation error WAFV2: GetWebACL, 1 validation error(s) found.
- missing required field, GetWebACLInput.Scope.

        * cannot convert primitive with NO type information
aws.waf.acls: [
  0: {
    description: ""
    scope: cannot convert primitive with NO type information
    rules: operation error WAFV2: GetWebACL, 1 validation error(s) found.
- missing required field, GetWebACLInput.Scope.

    id: "d1ae782d-700b-4112-99ab-d9df8d0d0e24"
    arn: "arn:aws:wafv2:us-east-1:921877552404:regional/webacl/marius-test/d1ae782d-700b-4112-99ab-d9df8d0d0e24"
    name: "marius-test"
    managedByFirewallManager: false
  }
]
```