### PR TITLE
🐛 do not include architecture as default field for aws ec2 instance yet

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2247,7 +2247,7 @@ private aws.ec2.volume @defaults("id region volumeType size encrypted state") {
 }
 
 // Amazon EC2 instance
-private aws.ec2.instance @defaults("instanceId region state instanceType architecture platformDetails") {
+private aws.ec2.instance @defaults("instanceId region state instanceType platformDetails") {
   // ARN for the instance
   arn string
   // Instance ID for the instance


### PR DESCRIPTION
its only supported on 9.11+, so putting it in defaults breaks things