### PR TITLE
⭐ Add more aws.rds.dbcluster and aws.rds.snapshot fields

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -323,7 +323,7 @@ private aws.waf.rule.statement.orstatement {
 // Rule statement that matches at a certain rate of requests (rate limiting)
 private aws.waf.rule.statement.ratebasedstatement {}
 
-// Rule statement that checks for a regex pattern defined in a regex pattern set 
+// Rule statement that checks for a regex pattern defined in a regex pattern set
 private aws.waf.rule.statement.regexpatternsetreferencestatement {
   // Name of the rule this statement belongs to
   ruleName string
@@ -399,7 +399,7 @@ private aws.waf.rule.fieldtomatch @defaults("target") {
   // Whether to match the query string
 	queryString bool
   // Whether to match all query arguments
-	allQueryArguments bool 
+	allQueryArguments bool
   // Whether to match the body (match if not null)
   body aws.waf.rule.fieldtomatch.body
   // Whether to match the cookie (match if not null)
@@ -1714,7 +1714,6 @@ private aws.dynamodb.table @defaults("name region") {
   globalTableVersion string
   // The table ID
   id string
-
 }
 
 // Amazon Relational Database Service (RDS)
@@ -1739,6 +1738,34 @@ private aws.rds.dbcluster @defaults("id region") {
   snapshots() []aws.rds.snapshot
   // Tags for the database cluster
   tags map[string]string
+  // Whether the cluster is encrypted
+  storageEncrypted bool
+  // The amount of storage, in GiB, provisioned on the cluster
+  storageAllocated int
+  // The storage IOPS provisioned on the cluster
+  storageIops int
+  // The type of storage provisioned on the cluster
+  storageType string
+  // Current state of the cluster
+  status string
+  // The creation date of the RDS cluster
+  createdTime time
+  // Number of days for which automated snapshots are retained
+  backupRetentionPeriod int
+  // Whether minor version patches are applied automatically
+  autoMinorVersionUpgrade bool
+  // Name of the compute and memory capacity class of the Cluster DB instances
+  clusterDbInstanceClass string
+  // Name of the database engine for this DB cluster
+  engine string
+  // The version of the database engine for this DB cluster
+  engineVersion string
+  // Whether the cluster is publicly accessible
+  publiclyAccessible bool
+  // Whether the cluster is a Multi-AZ deployment
+  multiAZ bool
+  // Whether deletion protection is enabled
+  deletionProtection bool
 }
 
 // Amazon RDS snapshot
@@ -1759,6 +1786,12 @@ private aws.rds.snapshot @defaults("id region type encrypted") {
   isClusterSnapshot bool
   // Tags for the snapshot
   tags map[string]string
+  // The snapshot DB engine
+  engine string
+  // The snapshot status
+  status string
+  // The amount of storage allocated to the snapshot
+  allocatedStorage int
 }
 
 // Amazon RDS database instance

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -2583,6 +2583,48 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.dbcluster.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbcluster).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"aws.rds.dbcluster.storageEncrypted": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetStorageEncrypted()).ToDataRes(types.Bool)
+	},
+	"aws.rds.dbcluster.storageAllocated": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetStorageAllocated()).ToDataRes(types.Int)
+	},
+	"aws.rds.dbcluster.storageIops": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetStorageIops()).ToDataRes(types.Int)
+	},
+	"aws.rds.dbcluster.storageType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetStorageType()).ToDataRes(types.String)
+	},
+	"aws.rds.dbcluster.status": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetStatus()).ToDataRes(types.String)
+	},
+	"aws.rds.dbcluster.createdTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetCreatedTime()).ToDataRes(types.Time)
+	},
+	"aws.rds.dbcluster.backupRetentionPeriod": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetBackupRetentionPeriod()).ToDataRes(types.Int)
+	},
+	"aws.rds.dbcluster.autoMinorVersionUpgrade": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetAutoMinorVersionUpgrade()).ToDataRes(types.Bool)
+	},
+	"aws.rds.dbcluster.clusterDbInstanceClass": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetClusterDbInstanceClass()).ToDataRes(types.String)
+	},
+	"aws.rds.dbcluster.engine": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetEngine()).ToDataRes(types.String)
+	},
+	"aws.rds.dbcluster.engineVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetEngineVersion()).ToDataRes(types.String)
+	},
+	"aws.rds.dbcluster.publiclyAccessible": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetPubliclyAccessible()).ToDataRes(types.Bool)
+	},
+	"aws.rds.dbcluster.multiAZ": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetMultiAZ()).ToDataRes(types.Bool)
+	},
+	"aws.rds.dbcluster.deletionProtection": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetDeletionProtection()).ToDataRes(types.Bool)
+	},
 	"aws.rds.snapshot.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsSnapshot).GetArn()).ToDataRes(types.String)
 	},
@@ -2606,6 +2648,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.rds.snapshot.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsSnapshot).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.rds.snapshot.engine": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsSnapshot).GetEngine()).ToDataRes(types.String)
+	},
+	"aws.rds.snapshot.status": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsSnapshot).GetStatus()).ToDataRes(types.String)
+	},
+	"aws.rds.snapshot.allocatedStorage": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsSnapshot).GetAllocatedStorage()).ToDataRes(types.Int)
 	},
 	"aws.rds.dbinstance.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbinstance).GetArn()).ToDataRes(types.String)
@@ -6462,6 +6513,62 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsRdsDbcluster).Tags, ok = plugin.RawToTValue[map[string]interface{}](v.Value, v.Error)
 		return
 	},
+	"aws.rds.dbcluster.storageEncrypted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).StorageEncrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.storageAllocated": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).StorageAllocated, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.storageIops": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).StorageIops, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.storageType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).StorageType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.createdTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).CreatedTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.backupRetentionPeriod": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).BackupRetentionPeriod, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.autoMinorVersionUpgrade": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).AutoMinorVersionUpgrade, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.clusterDbInstanceClass": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).ClusterDbInstanceClass, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.engine": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).Engine, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.engineVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).EngineVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.publiclyAccessible": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).PubliclyAccessible, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.multiAZ": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).MultiAZ, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.deletionProtection": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).DeletionProtection, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"aws.rds.snapshot.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 			r.(*mqlAwsRdsSnapshot).__id, ok = v.Value.(string)
 			return
@@ -6496,6 +6603,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.rds.snapshot.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsSnapshot).Tags, ok = plugin.RawToTValue[map[string]interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.rds.snapshot.engine": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsSnapshot).Engine, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.snapshot.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsSnapshot).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.snapshot.allocatedStorage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsSnapshot).AllocatedStorage, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"aws.rds.dbinstance.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -17079,6 +17198,20 @@ type mqlAwsRdsDbcluster struct {
 	Members plugin.TValue[[]interface{}]
 	Snapshots plugin.TValue[[]interface{}]
 	Tags plugin.TValue[map[string]interface{}]
+	StorageEncrypted plugin.TValue[bool]
+	StorageAllocated plugin.TValue[int64]
+	StorageIops plugin.TValue[int64]
+	StorageType plugin.TValue[string]
+	Status plugin.TValue[string]
+	CreatedTime plugin.TValue[*time.Time]
+	BackupRetentionPeriod plugin.TValue[int64]
+	AutoMinorVersionUpgrade plugin.TValue[bool]
+	ClusterDbInstanceClass plugin.TValue[string]
+	Engine plugin.TValue[string]
+	EngineVersion plugin.TValue[string]
+	PubliclyAccessible plugin.TValue[bool]
+	MultiAZ plugin.TValue[bool]
+	DeletionProtection plugin.TValue[bool]
 }
 
 // createAwsRdsDbcluster creates a new instance of this resource
@@ -17154,6 +17287,62 @@ func (c *mqlAwsRdsDbcluster) GetTags() *plugin.TValue[map[string]interface{}] {
 	return &c.Tags
 }
 
+func (c *mqlAwsRdsDbcluster) GetStorageEncrypted() *plugin.TValue[bool] {
+	return &c.StorageEncrypted
+}
+
+func (c *mqlAwsRdsDbcluster) GetStorageAllocated() *plugin.TValue[int64] {
+	return &c.StorageAllocated
+}
+
+func (c *mqlAwsRdsDbcluster) GetStorageIops() *plugin.TValue[int64] {
+	return &c.StorageIops
+}
+
+func (c *mqlAwsRdsDbcluster) GetStorageType() *plugin.TValue[string] {
+	return &c.StorageType
+}
+
+func (c *mqlAwsRdsDbcluster) GetStatus() *plugin.TValue[string] {
+	return &c.Status
+}
+
+func (c *mqlAwsRdsDbcluster) GetCreatedTime() *plugin.TValue[*time.Time] {
+	return &c.CreatedTime
+}
+
+func (c *mqlAwsRdsDbcluster) GetBackupRetentionPeriod() *plugin.TValue[int64] {
+	return &c.BackupRetentionPeriod
+}
+
+func (c *mqlAwsRdsDbcluster) GetAutoMinorVersionUpgrade() *plugin.TValue[bool] {
+	return &c.AutoMinorVersionUpgrade
+}
+
+func (c *mqlAwsRdsDbcluster) GetClusterDbInstanceClass() *plugin.TValue[string] {
+	return &c.ClusterDbInstanceClass
+}
+
+func (c *mqlAwsRdsDbcluster) GetEngine() *plugin.TValue[string] {
+	return &c.Engine
+}
+
+func (c *mqlAwsRdsDbcluster) GetEngineVersion() *plugin.TValue[string] {
+	return &c.EngineVersion
+}
+
+func (c *mqlAwsRdsDbcluster) GetPubliclyAccessible() *plugin.TValue[bool] {
+	return &c.PubliclyAccessible
+}
+
+func (c *mqlAwsRdsDbcluster) GetMultiAZ() *plugin.TValue[bool] {
+	return &c.MultiAZ
+}
+
+func (c *mqlAwsRdsDbcluster) GetDeletionProtection() *plugin.TValue[bool] {
+	return &c.DeletionProtection
+}
+
 // mqlAwsRdsSnapshot for the aws.rds.snapshot resource
 type mqlAwsRdsSnapshot struct {
 	MqlRuntime *plugin.Runtime
@@ -17167,6 +17356,9 @@ type mqlAwsRdsSnapshot struct {
 	Region plugin.TValue[string]
 	IsClusterSnapshot plugin.TValue[bool]
 	Tags plugin.TValue[map[string]interface{}]
+	Engine plugin.TValue[string]
+	Status plugin.TValue[string]
+	AllocatedStorage plugin.TValue[int64]
 }
 
 // createAwsRdsSnapshot creates a new instance of this resource
@@ -17238,6 +17430,18 @@ func (c *mqlAwsRdsSnapshot) GetIsClusterSnapshot() *plugin.TValue[bool] {
 
 func (c *mqlAwsRdsSnapshot) GetTags() *plugin.TValue[map[string]interface{}] {
 	return &c.Tags
+}
+
+func (c *mqlAwsRdsSnapshot) GetEngine() *plugin.TValue[string] {
+	return &c.Engine
+}
+
+func (c *mqlAwsRdsSnapshot) GetStatus() *plugin.TValue[string] {
+	return &c.Status
+}
+
+func (c *mqlAwsRdsSnapshot) GetAllocatedStorage() *plugin.TValue[int64] {
+	return &c.AllocatedStorage
 }
 
 // mqlAwsRdsDbinstance for the aws.rds.dbinstance resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -1883,10 +1883,38 @@ resources:
         The `aws.rds.dbcluster` provides fields for assessing the configuration of AWS RDS Clusters.
     fields:
       arn: {}
+      autoMinorVersionUpgrade:
+        min_mondoo_version: 9.0.0
+      backupRetentionPeriod:
+        min_mondoo_version: 9.0.0
+      clusterDbInstanceClass:
+        min_mondoo_version: 9.0.0
+      createdTime:
+        min_mondoo_version: 9.0.0
+      deletionProtection:
+        min_mondoo_version: 9.0.0
+      engine:
+        min_mondoo_version: 9.0.0
+      engineVersion:
+        min_mondoo_version: 9.0.0
       id: {}
       members: {}
+      multiAZ:
+        min_mondoo_version: 9.0.0
+      publiclyAccessible:
+        min_mondoo_version: 9.0.0
       region: {}
       snapshots: {}
+      status:
+        min_mondoo_version: 9.0.0
+      storageAllocated:
+        min_mondoo_version: 9.0.0
+      storageEncrypted:
+        min_mondoo_version: 9.0.0
+      storageIops:
+        min_mondoo_version: 9.0.0
+      storageType:
+        min_mondoo_version: 9.0.0
       tags: {}
     is_private: true
     min_mondoo_version: 5.15.0
@@ -1945,12 +1973,18 @@ resources:
       desc: |
         The `aws.rds.snapshot` fields for assessing the configuration of RDS snapshots. For usage see the `aws.rds` resource documentation.
     fields:
+      allocatedStorage:
+        min_mondoo_version: 9.0.0
       arn: {}
       attributes: {}
       encrypted: {}
+      engine:
+        min_mondoo_version: 9.0.0
       id: {}
       isClusterSnapshot: {}
       region: {}
+      status:
+        min_mondoo_version: 9.0.0
       tags: {}
       type: {}
     is_private: true

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -93,6 +93,7 @@ func (a *mqlAwsRds) getDbInstances(conn *connection.AwsConnection) []*jobpool.Jo
 							"autoMinorVersionUpgrade":       llx.BoolDataPtr(dbInstance.AutoMinorVersionUpgrade),
 							"availabilityZone":              llx.StringDataPtr(dbInstance.AvailabilityZone),
 							"backupRetentionPeriod":         llx.IntData(convert.ToInt64From32(dbInstance.BackupRetentionPeriod)),
+							"createdTime":                   llx.TimeDataPtr(dbInstance.InstanceCreateTime),
 							"dbInstanceClass":               llx.StringDataPtr(dbInstance.DBInstanceClass),
 							"dbInstanceIdentifier":          llx.StringDataPtr(dbInstance.DBInstanceIdentifier),
 							"deletionProtection":            llx.BoolDataPtr(dbInstance.DeletionProtection),
@@ -109,10 +110,9 @@ func (a *mqlAwsRds) getDbInstances(conn *connection.AwsConnection) []*jobpool.Jo
 							"status":                        llx.StringDataPtr(dbInstance.DBInstanceStatus),
 							"storageAllocated":              llx.IntData(convert.ToInt64From32(dbInstance.AllocatedStorage)),
 							"storageEncrypted":              llx.BoolDataPtr(dbInstance.StorageEncrypted),
-							"storageType":                   llx.StringDataPtr(dbInstance.StorageType),
 							"storageIops":                   llx.IntData(convert.ToInt64From32(dbInstance.Iops)),
+							"storageType":                   llx.StringDataPtr(dbInstance.StorageType),
 							"tags":                          llx.MapData(rdsTagsToMap(dbInstance.TagList), types.String),
-							"createdTime":                   llx.TimeDataPtr(dbInstance.InstanceCreateTime),
 						})
 					if err != nil {
 						return nil, err
@@ -240,11 +240,25 @@ func (a *mqlAwsRds) getDbClusters(conn *connection.AwsConnection) []*jobpool.Job
 					// }
 					mqlDbCluster, err := CreateResource(a.MqlRuntime, "aws.rds.dbcluster",
 						map[string]*llx.RawData{
-							"arn":    llx.StringDataPtr(cluster.DBClusterArn),
-							"region": llx.StringData(regionVal),
-							"id":     llx.StringDataPtr(cluster.DBClusterIdentifier),
+							"arn":                     llx.StringDataPtr(cluster.DBClusterArn),
+							"autoMinorVersionUpgrade": llx.BoolDataPtr(cluster.AutoMinorVersionUpgrade),
+							"backupRetentionPeriod":   llx.IntData(convert.ToInt64From32(cluster.BackupRetentionPeriod)),
+							"clusterDbInstanceClass":  llx.StringDataPtr(cluster.DBClusterInstanceClass),
+							"createdTime":             llx.TimeDataPtr(cluster.ClusterCreateTime),
+							"deletionProtection":      llx.BoolDataPtr(cluster.DeletionProtection),
+							"engine":                  llx.StringDataPtr(cluster.Engine),
+							"engineVersion":           llx.StringDataPtr(cluster.EngineVersion),
+							"id":                      llx.StringDataPtr(cluster.DBClusterIdentifier),
+							"multiAZ":                 llx.BoolDataPtr(cluster.MultiAZ),
+							"publiclyAccessible":      llx.BoolDataPtr(cluster.PubliclyAccessible),
+							"region":                  llx.StringData(regionVal),
+							"status":                  llx.StringDataPtr(cluster.Status),
+							"storageAllocated":        llx.IntData(convert.ToInt64From32(cluster.AllocatedStorage)),
+							"storageEncrypted":        llx.BoolDataPtr(cluster.StorageEncrypted),
+							"storageIops":             llx.IntData(convert.ToInt64From32(cluster.Iops)),
+							"storageType":             llx.StringDataPtr(cluster.StorageType),
+							"tags":                    llx.MapData(rdsTagsToMap(cluster.TagList), types.String),
 							// "members": mqlRdsDbInstances,
-							"tags": llx.MapData(rdsTagsToMap(cluster.TagList), types.String),
 						})
 					if err != nil {
 						return nil, err
@@ -289,6 +303,9 @@ func (a *mqlAwsRdsDbcluster) snapshots() ([]interface{}, error) {
 					"encrypted":         llx.BoolDataPtr(snapshot.StorageEncrypted),
 					"isClusterSnapshot": llx.BoolData(true),
 					"tags":              llx.MapData(rdsTagsToMap(snapshot.TagList), types.String),
+					"engine":            llx.StringDataPtr(snapshot.Engine),
+					"status":            llx.StringDataPtr(snapshot.Status),
+					"allocatedStorage":  llx.IntData(convert.ToInt64From32(snapshot.AllocatedStorage)),
 				})
 			if err != nil {
 				return nil, err
@@ -328,6 +345,9 @@ func (a *mqlAwsRdsDbinstance) snapshots() ([]interface{}, error) {
 					"encrypted":         llx.BoolDataPtr(snapshot.Encrypted),
 					"isClusterSnapshot": llx.BoolData(false),
 					"tags":              llx.MapData(rdsTagsToMap(snapshot.TagList), types.String),
+					"engine":            llx.StringDataPtr(snapshot.Engine),
+					"status":            llx.StringDataPtr(snapshot.Status),
+					"allocatedStorage":  llx.IntData(convert.ToInt64From32(snapshot.AllocatedStorage)),
 				})
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Add useful data to these resources.

```coffee
aws.rds.dbClusters.first: {
  storageIops: 1000
  members: cannot convert primitive with NO type information
  id: "timtest"
  storageEncrypted: true
  clusterDbInstanceClass: "db.m5d.large"
  backupRetentionPeriod: 7
  engine: "postgres"
  multiAZ: true
  storageType: "io1"
  storageAllocated: 100
  createdTime: 2023-12-13 17:22:30.666 -0800 PST
  status: "available"
  snapshots: [
    0: aws.rds.snapshot id="rds:timtest-2023-12-14-01-25" region="us-west-2" type="automated" encrypted=true
  ]
  publiclyAccessible: false
  deletionProtection: true
  region: "us-west-2"
  autoMinorVersionUpgrade: true
  arn: "arn:aws:rds:us-west-2:XXXXXXX:cluster:timtest"
  engineVersion: "15.4"
  tags: {}
}
```

```coffee
cnquery> aws.rds.dbClusters.first{snapshots{*}}
aws.rds.dbClusters.first: {
  snapshots: [
    0: {
      arn: "arn:aws:rds:us-west-2:XXXXXXXXX:cluster-snapshot:rds:timtest-2023-12-14-01-25"
      isClusterSnapshot: true
      type: "automated"
      status: "available"
      encrypted: true
      engine: "postgres"
      id: "rds:timtest-2023-12-14-01-25"
      allocatedStorage: 100
      tags: {}
      region: "us-west-2"
      attributes: [
        0: {
          AttributeName: "restore"
          AttributeValues: []
        }
      ]
    }
  ]
}
```