### PR TITLE
Add security group to aws.rds.dbcluster

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1766,6 +1766,8 @@ private aws.rds.dbcluster @defaults("id region") {
   multiAZ bool
   // Whether deletion protection is enabled
   deletionProtection bool
+  // List of VPC security group elements that the DB cluster belongs to
+  securityGroups []aws.ec2.securitygroup
 }
 
 // Amazon RDS snapshot

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -2625,6 +2625,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.dbcluster.deletionProtection": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbcluster).GetDeletionProtection()).ToDataRes(types.Bool)
 	},
+	"aws.rds.dbcluster.securityGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
+	},
 	"aws.rds.snapshot.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsSnapshot).GetArn()).ToDataRes(types.String)
 	},
@@ -6567,6 +6570,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.rds.dbcluster.deletionProtection": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsDbcluster).DeletionProtection, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).SecurityGroups, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
 	"aws.rds.snapshot.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -17212,6 +17219,7 @@ type mqlAwsRdsDbcluster struct {
 	PubliclyAccessible plugin.TValue[bool]
 	MultiAZ plugin.TValue[bool]
 	DeletionProtection plugin.TValue[bool]
+	SecurityGroups plugin.TValue[[]interface{}]
 }
 
 // createAwsRdsDbcluster creates a new instance of this resource
@@ -17341,6 +17349,10 @@ func (c *mqlAwsRdsDbcluster) GetMultiAZ() *plugin.TValue[bool] {
 
 func (c *mqlAwsRdsDbcluster) GetDeletionProtection() *plugin.TValue[bool] {
 	return &c.DeletionProtection
+}
+
+func (c *mqlAwsRdsDbcluster) GetSecurityGroups() *plugin.TValue[[]interface{}] {
+	return &c.SecurityGroups
 }
 
 // mqlAwsRdsSnapshot for the aws.rds.snapshot resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -1904,6 +1904,8 @@ resources:
       publiclyAccessible:
         min_mondoo_version: 9.0.0
       region: {}
+      securityGroups:
+        min_mondoo_version: 9.0.0
       snapshots: {}
       status:
         min_mondoo_version: 9.0.0

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -238,6 +238,18 @@ func (a *mqlAwsRds) getDbClusters(conn *connection.AwsConnection) []*jobpool.Job
 					// 	}
 					// 	mqlRdsDbInstances = append(mqlRdsDbInstances, mqlInstance)
 					// }
+					sgs := []interface{}{}
+					for i := range cluster.VpcSecurityGroups {
+						// NOTE: this will create the resource and determine the data in its init method
+						mqlSg, err := NewResource(a.MqlRuntime, "aws.ec2.securitygroup",
+							map[string]*llx.RawData{
+								"arn": llx.StringData(fmt.Sprintf(securityGroupArnPattern, regionVal, conn.AccountId(), convert.ToString(cluster.VpcSecurityGroups[i].VpcSecurityGroupId))),
+							})
+						if err != nil {
+							return nil, err
+						}
+						sgs = append(sgs, mqlSg.(*mqlAwsEc2Securitygroup))
+					}
 					mqlDbCluster, err := CreateResource(a.MqlRuntime, "aws.rds.dbcluster",
 						map[string]*llx.RawData{
 							"arn":                     llx.StringDataPtr(cluster.DBClusterArn),
@@ -258,6 +270,7 @@ func (a *mqlAwsRds) getDbClusters(conn *connection.AwsConnection) []*jobpool.Job
 							"storageIops":             llx.IntData(convert.ToInt64From32(cluster.Iops)),
 							"storageType":             llx.StringDataPtr(cluster.StorageType),
 							"tags":                    llx.MapData(rdsTagsToMap(cluster.TagList), types.String),
+							"securityGroups":          llx.ArrayData(sgs, types.Resource("aws.ec2.securitygroup")),
 							// "members": mqlRdsDbInstances,
 						})
 					if err != nil {


### PR DESCRIPTION
This is a copy/modification of the same logic we use for the dbinstance resource