### PR TITLE
🐛 fix mvd go package name

### DIFF
--- a/providers-sdk/v1/upstream/mvd/mvd.proto
+++ b/providers-sdk/v1/upstream/mvd/mvd.proto
@@ -8,7 +8,7 @@ package mondoo.mvd.v1;
 import "providers-sdk/v1/upstream/mvd/cvss/cvss.proto";
 
 option go_package = 
-  "go.mondoo.com/cnquery/v9/providers-sdk/v1/upstream/mvd/mvd";
+  "go.mondoo.com/cnquery/v9/providers-sdk/v1/upstream/mvd";
 
 message Platform {
   string name = 1;


### PR DESCRIPTION
there seems to be a typo here which breaks the generation for cnspec