### PR TITLE
Add new fields + better defaults in aws.acm.certificate

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -417,9 +417,9 @@ private aws.waf.rule.fieldtomatch @defaults("target") {
   // Whether to match the URI path
   uriPath bool
   // Whether to match the query string
-	queryString bool
+  queryString bool
   // Whether to match all query arguments
-	allQueryArguments bool
+  allQueryArguments bool
   // Whether to match the body (match if not null)
   body aws.waf.rule.fieldtomatch.body
   // Whether to match the cookie (match if not null)
@@ -427,15 +427,15 @@ private aws.waf.rule.fieldtomatch @defaults("target") {
   // Whether to match the single header (match if not null)
   singleHeader aws.waf.rule.fieldtomatch.singleheader
   // Whether to match the header order (match if not null)
-	headerOrder aws.waf.rule.fieldtomatch.headerorder
+  headerOrder aws.waf.rule.fieldtomatch.headerorder
   // Whether to match the header (match if not null)
-	headers aws.waf.rule.fieldtomatch.headers
+  headers aws.waf.rule.fieldtomatch.headers
   // Whether to match the JA3 fingerprint (match if not null)
-	ja3Fingerprint aws.waf.rule.fieldtomatch.ja3fingerprint
+  ja3Fingerprint aws.waf.rule.fieldtomatch.ja3fingerprint
   // Whether to match the JSON body (match if not null)
-	jsonBody aws.waf.rule.fieldtomatch.jsonbody
+  jsonBody aws.waf.rule.fieldtomatch.jsonbody
   // Whether to match the single query argument of the field (match if not null)
-	singleQueryArgument aws.waf.rule.fieldtomatch.singlequeryargument
+  singleQueryArgument aws.waf.rule.fieldtomatch.singlequeryargument
 }
 
 // Body of the field to match
@@ -977,7 +977,7 @@ aws.acm @defaults("certificates") {
 }
 
 // AWS Certificate Manager Certificate resource (provides an object representing an individual ACM certificate)
-private aws.acm.certificate @defaults("arn domainName") {
+private aws.acm.certificate @defaults("domainName issuer createdAt notAfter") {
   // ARN for the certificate
   arn string
   // Time before which the certificate is not valid
@@ -996,6 +996,18 @@ private aws.acm.certificate @defaults("arn domainName") {
   certificate() network.certificate
   // Tags associated with the certificate
   tags map[string]string
+  // The algorithm that was used to generate the public-private key pair
+  keyAlgorithm string
+  // The serial number of the certificate
+  serial string
+  // The source of the certificate. AMAZON_ISSUED or IMPORTED
+  source string
+  // The name of the certificate authority that issued and signed the certificate
+  issuer string
+  // The time at which the certificate was issued. This value exists only when the certificate source is AMAZON_ISSUED
+  issuedAt time
+  // The date and time when the certificate was imported. This value exists only when the certificate source is IMPORTED.
+  importedAt time
 }
 
 // AWS Auto Scaling

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -1776,6 +1776,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.acm.certificate.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsAcmCertificate).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"aws.acm.certificate.keyAlgorithm": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsAcmCertificate).GetKeyAlgorithm()).ToDataRes(types.String)
+	},
+	"aws.acm.certificate.serial": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsAcmCertificate).GetSerial()).ToDataRes(types.String)
+	},
+	"aws.acm.certificate.source": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsAcmCertificate).GetSource()).ToDataRes(types.String)
+	},
+	"aws.acm.certificate.issuer": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsAcmCertificate).GetIssuer()).ToDataRes(types.String)
+	},
+	"aws.acm.certificate.issuedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsAcmCertificate).GetIssuedAt()).ToDataRes(types.Time)
+	},
+	"aws.acm.certificate.importedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsAcmCertificate).GetImportedAt()).ToDataRes(types.Time)
+	},
 	"aws.autoscaling.groups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsAutoscaling).GetGroups()).ToDataRes(types.Array(types.Resource("aws.autoscaling.group")))
 	},
@@ -5271,6 +5289,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.acm.certificate.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsAcmCertificate).Tags, ok = plugin.RawToTValue[map[string]interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.acm.certificate.keyAlgorithm": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsAcmCertificate).KeyAlgorithm, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.acm.certificate.serial": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsAcmCertificate).Serial, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.acm.certificate.source": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsAcmCertificate).Source, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.acm.certificate.issuer": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsAcmCertificate).Issuer, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.acm.certificate.issuedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsAcmCertificate).IssuedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.acm.certificate.importedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsAcmCertificate).ImportedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.autoscaling.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -13183,6 +13225,12 @@ type mqlAwsAcmCertificate struct {
 	Subject plugin.TValue[string]
 	Certificate plugin.TValue[plugin.Resource]
 	Tags plugin.TValue[map[string]interface{}]
+	KeyAlgorithm plugin.TValue[string]
+	Serial plugin.TValue[string]
+	Source plugin.TValue[string]
+	Issuer plugin.TValue[string]
+	IssuedAt plugin.TValue[*time.Time]
+	ImportedAt plugin.TValue[*time.Time]
 }
 
 // createAwsAcmCertificate creates a new instance of this resource
@@ -13268,6 +13316,30 @@ func (c *mqlAwsAcmCertificate) GetCertificate() *plugin.TValue[plugin.Resource] 
 
 func (c *mqlAwsAcmCertificate) GetTags() *plugin.TValue[map[string]interface{}] {
 	return &c.Tags
+}
+
+func (c *mqlAwsAcmCertificate) GetKeyAlgorithm() *plugin.TValue[string] {
+	return &c.KeyAlgorithm
+}
+
+func (c *mqlAwsAcmCertificate) GetSerial() *plugin.TValue[string] {
+	return &c.Serial
+}
+
+func (c *mqlAwsAcmCertificate) GetSource() *plugin.TValue[string] {
+	return &c.Source
+}
+
+func (c *mqlAwsAcmCertificate) GetIssuer() *plugin.TValue[string] {
+	return &c.Issuer
+}
+
+func (c *mqlAwsAcmCertificate) GetIssuedAt() *plugin.TValue[*time.Time] {
+	return &c.IssuedAt
+}
+
+func (c *mqlAwsAcmCertificate) GetImportedAt() *plugin.TValue[*time.Time] {
+	return &c.ImportedAt
 }
 
 // mqlAwsAutoscaling for the aws.autoscaling resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -130,8 +130,20 @@ resources:
       certificate: {}
       createdAt: {}
       domainName: {}
+      importedAt:
+        min_mondoo_version: 9.0.0
+      issuedAt:
+        min_mondoo_version: 9.0.0
+      issuer:
+        min_mondoo_version: 9.0.0
+      keyAlgorithm:
+        min_mondoo_version: 9.0.0
       notAfter: {}
       notBefore: {}
+      serial:
+        min_mondoo_version: 9.0.0
+      source:
+        min_mondoo_version: 9.0.0
       status: {}
       subject: {}
       tags:

--- a/providers/aws/resources/aws_acm.go
+++ b/providers/aws/resources/aws_acm.go
@@ -122,12 +122,18 @@ func initAwsAcmCertificate(runtime *plugin.Runtime, args map[string]*llx.RawData
 	}
 
 	args["arn"] = llx.StringData(arnVal)
-	args["notBefore"] = llx.TimeDataPtr(certDetails.Certificate.NotBefore)
-	args["notAfter"] = llx.TimeDataPtr(certDetails.Certificate.NotAfter)
 	args["createdAt"] = llx.TimeDataPtr(certDetails.Certificate.CreatedAt)
-	args["domainName"] = llx.StringData(convert.ToString(certDetails.Certificate.DomainName))
+	args["domainName"] = llx.StringDataPtr(certDetails.Certificate.DomainName)
+	args["importedAt"] = llx.TimeDataPtr(certDetails.Certificate.ImportedAt)
+	args["issuedAt"] = llx.TimeDataPtr(certDetails.Certificate.IssuedAt)
+	args["issuer"] = llx.StringDataPtr(certDetails.Certificate.Issuer)
+	args["keyAlgorithm"] = llx.StringData(string(certDetails.Certificate.KeyAlgorithm))
+	args["notAfter"] = llx.TimeDataPtr(certDetails.Certificate.NotAfter)
+	args["notBefore"] = llx.TimeDataPtr(certDetails.Certificate.NotBefore)
+	args["serial"] = llx.StringDataPtr(certDetails.Certificate.Serial)
+	args["source"] = llx.StringData(string(certDetails.Certificate.Type))
 	args["status"] = llx.StringData(string(certDetails.Certificate.Status))
-	args["subject"] = llx.StringData(convert.ToString(certDetails.Certificate.Subject))
+	args["subject"] = llx.StringDataPtr(certDetails.Certificate.Subject)
 	args["tags"] = llx.MapData(CertTagsToMapTags(certTags.Tags), types.String)
 	return args, nil, nil
 }


### PR DESCRIPTION
Improve the defaults and add these new fields:

- keyAlgorithm
- serial
- source
- issuer
- issuedAt
- importedAt

```coffee
aws.acm.certificates: [
  0: aws.acm.certificate domainName="example.com" issuer="Amazon" createdAt=2023-07-26 08:28:34.859 -0700 PDT notAfter=2024-08-23 16:59:59 -0700 PDT
]
```

```coffee
aws.acm.certificates.first: {
  status: "ISSUED"
  tags: {}
  certificate: certificate serial="1234" subject.commonName="example.com" subject.dn="CN=example.com"
  notBefore: 2023-07-25 17:00:00 -0700 PDT
  issuer: "Amazon"
  domainName: "example.com"
  serial: "123"
  subject: "CN=example.com"
  issuedAt: 2023-07-26 08:29:03.022 -0700 PDT
  importedAt: null
  source: "AMAZON_ISSUED"
  keyAlgorithm: "RSA-2048"
  notAfter: 2024-08-23 16:59:59 -0700 PDT
  createdAt: 2023-07-26 08:28:34.859 -0700 PDT
  arn: "1234"
}
```