### PR TITLE
🐛 set default sudo executable

### DIFF
--- a/providers/os/connection/ssh_test.go
+++ b/providers/os/connection/ssh_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/cnquery/v9/providers-sdk/v1/inventory"
+)
+
+func TestSSHDefaultSettings(t *testing.T) {
+	conn := &SshConnection{
+		conf: &inventory.Config{
+			Sudo: &inventory.Sudo{
+				Active: true,
+			},
+		},
+	}
+	conn.setDefaultSettings()
+	assert.Equal(t, int32(22), conn.conf.Port)
+	assert.Equal(t, "sudo", conn.conf.Sudo.Executable)
+}


### PR DESCRIPTION
This fixes an issue reported by @username-is-already-taken2. Packer plugin properly enables the sudo config via the inventory https://github.com/mondoohq/packer-plugin-cnspec/blob/a4c6be26de7ac51f49259fd9ea4501663d43ea87/provisioner/provisioner.go#L335-L340. 

Problem was that no sudo executable was set. The cli flag always set the executable as well https://github.com/mondoohq/cnquery/blob/main/providers/os/connection/shared/shared.go#L197-L212. Therefore the inventory for the packer scan used the following sudo setting:

```json
"sudo": {
  "active": true
}
```

This PR changes the default and always falls back to `sudo` cli if no alternative executable was set.
