### PR TITLE
🧹 improve slack conversations handling

### DIFF
--- a/providers/slack/resources/conversations.go
+++ b/providers/slack/resources/conversations.go
@@ -19,7 +19,7 @@ func (o *mqlSlackConversations) id() (string, error) {
 	return "slack.conversations", nil
 }
 
-func (s *mqlSlackConversations) listChannels(types []string) ([]interface{}, error) {
+func (s *mqlSlackConversations) listChannels(types ...string) ([]interface{}, error) {
 	conn := s.MqlRuntime.Connection.(*connection.SlackConnection)
 	client := conn.Client()
 	if client == nil {
@@ -63,19 +63,19 @@ func (s *mqlSlackConversations) listChannels(types []string) ([]interface{}, err
 }
 
 func (s *mqlSlackConversations) list() ([]interface{}, error) {
-	return s.listChannels([]string{"public_channel", "private_channel", "mpim", "im"})
+	return s.listChannels("public_channel", "private_channel", "mpim", "im")
 }
 
 func (s *mqlSlackConversations) privateChannels() ([]interface{}, error) {
-	return s.listChannels([]string{"private_channel"})
+	return s.listChannels("private_channel")
 }
 
 func (s *mqlSlackConversations) publicChannels() ([]interface{}, error) {
-	return s.listChannels([]string{"public_channel"})
+	return s.listChannels("public_channel")
 }
 
 func (s *mqlSlackConversations) directMessages() ([]interface{}, error) {
-	return s.listChannels([]string{"mpim", "im"})
+	return s.listChannels("mpim", "im")
 }
 
 type topic struct {

--- a/providers/slack/resources/conversations.go
+++ b/providers/slack/resources/conversations.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"github.com/slack-go/slack"
 	"go.mondoo.com/cnquery/v9/llx"
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/plugin"
@@ -14,7 +15,11 @@ import (
 	"go.mondoo.com/cnquery/v9/providers/slack/connection"
 )
 
-func (s *mqlSlack) conversations() ([]interface{}, error) {
+func (o *mqlSlackConversations) id() (string, error) {
+	return "slack.conversations", nil
+}
+
+func (s *mqlSlackConversations) listChannels(types []string) ([]interface{}, error) {
 	conn := s.MqlRuntime.Connection.(*connection.SlackConnection)
 	client := conn.Client()
 	if client == nil {
@@ -27,12 +32,17 @@ func (s *mqlSlack) conversations() ([]interface{}, error) {
 	// scopes: channels:read, groups:read, im:read, mpim:read
 	opts := &slack.GetConversationsParameters{
 		Limit: 1000, // use maximum
-		Types: []string{"public_channel", "private_channel", "mpim", "im"},
+		Types: types,
 	}
 
 	for {
 		conversations, cursor, err := client.GetConversations(opts)
-		if err != nil {
+		var rateLimitedError *slack.RateLimitedError
+		if errors.As(err, &rateLimitedError) {
+			// wait for the rate limit to expire
+			log.Info().Msgf("Rate limited, waiting %s", rateLimitedError.RetryAfter)
+			time.Sleep(rateLimitedError.RetryAfter * time.Second)
+		} else if err != nil {
 			return nil, err
 		}
 		for i := range conversations {
@@ -52,7 +62,22 @@ func (s *mqlSlack) conversations() ([]interface{}, error) {
 	return list, nil
 }
 
-// custom object to make sure the json values match and the time is properly parsed
+func (s *mqlSlackConversations) list() ([]interface{}, error) {
+	return s.listChannels([]string{"public_channel", "private_channel", "mpim", "im"})
+}
+
+func (s *mqlSlackConversations) privateChannels() ([]interface{}, error) {
+	return s.listChannels([]string{"private_channel"})
+}
+
+func (s *mqlSlackConversations) publicChannels() ([]interface{}, error) {
+	return s.listChannels([]string{"public_channel"})
+}
+
+func (s *mqlSlackConversations) directMessages() ([]interface{}, error) {
+	return s.listChannels([]string{"mpim", "im"})
+}
+
 type topic struct {
 	Value   string     `json:"value"`
 	Creator string     `json:"creator"`

--- a/providers/slack/resources/slack.lr
+++ b/providers/slack/resources/slack.lr
@@ -10,8 +10,17 @@ slack {
   accessLogs() []slack.login
   // List of Slack user groups
   userGroups() []slack.userGroup
-  // List of channels in a Slack team
-  conversations() []slack.conversation
+}
+
+// Slack conversations (channels, direct messages, and group messages)
+slack.conversations {
+  []slack.conversation
+  // List of private channels in a Slack team
+  privateChannels() []slack.conversation
+  // List of public channels in a Slack team
+  publicChannels() []slack.conversation
+  // List of direct messages in a Slack team
+  directMessages() []slack.conversation
 }
 
 // Slack team
@@ -26,7 +35,7 @@ slack.team @defaults("id domain") {
   emailDomain string
 }
 
- // Slack users
+// Slack users
 slack.users {
   []slack.user
   // Bot users in the workspace

--- a/providers/slack/resources/slack.lr.manifest.yaml
+++ b/providers/slack/resources/slack.lr.manifest.yaml
@@ -5,7 +5,6 @@ resources:
   slack:
     fields:
       accessLogs: {}
-      conversations: {}
       userGroups: {}
     min_mondoo_version: latest
   slack.conversation:
@@ -30,6 +29,14 @@ resources:
       priority: {}
       purpose: {}
       topic: {}
+    min_mondoo_version: latest
+  slack.conversations:
+    fields:
+      "": {}
+      directMessages: {}
+      list: {}
+      privateChannels: {}
+      publicChannels: {}
     min_mondoo_version: latest
   slack.enterpriseUser:
     fields:


### PR DESCRIPTION
- allows users to filter by top level categories without where queries which leads to performance improvements since we only fetch the relevant data
- implement handling for rate-limiting since slack go sdk is not doing that for the conversations api