### PR TITLE
Add createdAt to aws.ec2.keypair + cleanup ptrs

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2388,7 +2388,7 @@ private aws.ec2.instance @defaults("instanceId region state instanceType archite
 }
 
 // Amazon EC2 key pair
-private aws.ec2.keypair @defaults("arn name") {
+private aws.ec2.keypair @defaults("name type region") {
   // ARN of the key pair
   arn string
   // Fingerprint for the key pair
@@ -2401,6 +2401,8 @@ private aws.ec2.keypair @defaults("arn name") {
   tags map[string]string
   // Region where the key pair exists
   region string
+  // Date the keypair was created
+  createdAt time
 }
 
 // Amazon EC2 image (AMI)

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -3411,6 +3411,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.keypair.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Keypair).GetRegion()).ToDataRes(types.String)
 	},
+	"aws.ec2.keypair.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Keypair).GetCreatedAt()).ToDataRes(types.Time)
+	},
 	"aws.ec2.image.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Image).GetArn()).ToDataRes(types.String)
 	},
@@ -7781,6 +7784,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.ec2.keypair.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Keypair).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.keypair.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Keypair).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.image.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20250,6 +20257,7 @@ type mqlAwsEc2Keypair struct {
 	Type plugin.TValue[string]
 	Tags plugin.TValue[map[string]interface{}]
 	Region plugin.TValue[string]
+	CreatedAt plugin.TValue[*time.Time]
 }
 
 // createAwsEc2Keypair creates a new instance of this resource
@@ -20311,6 +20319,10 @@ func (c *mqlAwsEc2Keypair) GetTags() *plugin.TValue[map[string]interface{}] {
 
 func (c *mqlAwsEc2Keypair) GetRegion() *plugin.TValue[string] {
 	return &c.Region
+}
+
+func (c *mqlAwsEc2Keypair) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
 }
 
 // mqlAwsEc2Image for the aws.ec2.image resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -976,6 +976,7 @@ resources:
   aws.ec2.keypair:
     fields:
       arn: {}
+      createdAt: {}
       fingerprint: {}
       name: {}
       region: {}
@@ -2386,16 +2387,13 @@ resources:
       - aws
   aws.vpc.endpoint:
     fields:
-      createdAt:
-        min_mondoo_version: 9.0.0
+      createdAt: {}
       id: {}
       policyDocument: {}
-      privateDnsEnabled:
-        min_mondoo_version: 9.0.0
+      privateDnsEnabled: {}
       region: {}
       serviceName: {}
-      state:
-        min_mondoo_version: 9.0.0
+      state: {}
       subnets: {}
       type: {}
       vpc: {}
@@ -2438,17 +2436,13 @@ resources:
   aws.vpc.subnet:
     fields:
       arn: {}
-      assignIpv6AddressOnCreation:
-        min_mondoo_version: 9.0.0
-      availabilityZone:
-        min_mondoo_version: latest
+      assignIpv6AddressOnCreation: {}
+      availabilityZone: {}
       cidrs: {}
-      defaultForAvailabilityZone:
-        min_mondoo_version: latest
+      defaultForAvailabilityZone: {}
       id: {}
       mapPublicIpOnLaunch: {}
-      state:
-        min_mondoo_version: 9.0.0
+      state: {}
     is_private: true
     min_mondoo_version: 9.0.0
     platform:

--- a/providers/aws/resources/aws_acm.go
+++ b/providers/aws/resources/aws_acm.go
@@ -13,7 +13,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v9/llx"
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/plugin"
-	"go.mondoo.com/cnquery/v9/providers-sdk/v1/util/convert"
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/cnquery/v9/providers/aws/connection"
 
@@ -70,7 +69,7 @@ func (a *mqlAwsAcm) getCertificates(conn *connection.AwsConnection) []*jobpool.J
 				}
 				for _, cert := range certs.CertificateSummaryList {
 					mqlCert, err := NewResource(a.MqlRuntime, "aws.acm.certificate", map[string]*llx.RawData{
-						"arn": llx.StringData(convert.ToString(cert.CertificateArn)),
+						"arn": llx.StringDataPtr(cert.CertificateArn),
 					})
 					if err != nil {
 						return nil, err

--- a/providers/aws/resources/aws_dynamodb.go
+++ b/providers/aws/resources/aws_dynamodb.go
@@ -223,7 +223,7 @@ func (a *mqlAwsDynamodb) globalTables() ([]interface{}, error) {
 		mqlTable, err := CreateResource(a.MqlRuntime, "aws.dynamodb.globaltable",
 			map[string]*llx.RawData{
 				"arn":  llx.StringData(fmt.Sprintf(dynamoGlobalTableArnPattern, conn.AccountId(), convert.ToString(table.GlobalTableName))),
-				"name": llx.StringData(convert.ToString(table.GlobalTableName)),
+				"name": llx.StringDataPtr(table.GlobalTableName),
 			})
 		if err != nil {
 			return nil, err

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -407,11 +407,12 @@ func (a *mqlAwsEc2) getKeypairs(conn *connection.AwsConnection) []*jobpool.Job {
 				mqlKeypair, err := CreateResource(a.MqlRuntime, "aws.ec2.keypair",
 					map[string]*llx.RawData{
 						"arn":         llx.StringData(fmt.Sprintf(keypairArnPattern, conn.AccountId(), regionVal, convert.ToString(kp.KeyPairId))),
-						"fingerprint": llx.StringData(convert.ToString(kp.KeyFingerprint)),
-						"name":        llx.StringData(convert.ToString(kp.KeyName)),
+						"fingerprint": llx.StringDataPtr(kp.KeyFingerprint),
+						"name":        llx.StringDataPtr(kp.KeyName),
 						"type":        llx.StringData(string(kp.KeyType)),
 						"tags":        llx.MapData(Ec2TagsToMap(kp.Tags), types.String),
 						"region":      llx.StringData(regionVal),
+						"createdAt":   llx.TimeDataPtr(kp.CreateTime),
 					})
 				if err != nil {
 					return nil, err

--- a/providers/aws/resources/aws_ecr.go
+++ b/providers/aws/resources/aws_ecr.go
@@ -118,10 +118,10 @@ func (a *mqlAwsEcr) getPrivateRepositories(conn *connection.AwsConnection) []*jo
 				}
 				mqlRepoResource, err := CreateResource(a.MqlRuntime, "aws.ecr.repository",
 					map[string]*llx.RawData{
-						"arn":             llx.StringData(convert.ToString(r.RepositoryArn)),
-						"name":            llx.StringData(convert.ToString(r.RepositoryName)),
-						"uri":             llx.StringData(convert.ToString(r.RepositoryUri)),
-						"registryId":      llx.StringData(convert.ToString(r.RegistryId)),
+						"arn":             llx.StringDataPtr(r.RepositoryArn),
+						"name":            llx.StringDataPtr(r.RepositoryName),
+						"uri":             llx.StringDataPtr(r.RepositoryUri),
+						"registryId":      llx.StringDataPtr(r.RegistryId),
 						"public":          llx.BoolData(false),
 						"region":          llx.StringData(region),
 						"imageScanOnPush": llx.BoolData(imageScanOnPush),
@@ -167,10 +167,10 @@ func (a *mqlAwsEcrRepository) images() ([]interface{}, error) {
 			}
 			mqlImage, err := CreateResource(a.MqlRuntime, "aws.ecr.image",
 				map[string]*llx.RawData{
-					"digest":     llx.StringData(convert.ToString(image.ImageDigest)),
-					"mediaType":  llx.StringData(convert.ToString(image.ImageManifestMediaType)),
+					"digest":     llx.StringDataPtr(image.ImageDigest),
+					"mediaType":  llx.StringDataPtr(image.ImageManifestMediaType),
 					"tags":       llx.ArrayData(tags, types.String),
-					"registryId": llx.StringData(convert.ToString(image.RegistryId)),
+					"registryId": llx.StringDataPtr(image.RegistryId),
 					"repoName":   llx.StringData(name),
 					"region":     llx.StringData(region),
 					"arn":        llx.StringData(ecrImageArn(ImageInfo{Region: region, RegistryId: convert.ToString(image.RegistryId), RepoName: name, Digest: convert.ToString(image.ImageDigest)})),
@@ -199,10 +199,10 @@ func (a *mqlAwsEcrRepository) images() ([]interface{}, error) {
 			}
 			mqlImage, err := CreateResource(a.MqlRuntime, "aws.ecr.image",
 				map[string]*llx.RawData{
-					"digest":     llx.StringData(convert.ToString(image.ImageDigest)),
-					"mediaType":  llx.StringData(convert.ToString(image.ImageManifestMediaType)),
+					"digest":     llx.StringDataPtr(image.ImageDigest),
+					"mediaType":  llx.StringDataPtr(image.ImageManifestMediaType),
 					"tags":       llx.ArrayData(tags, types.String),
-					"registryId": llx.StringData(convert.ToString(image.RegistryId)),
+					"registryId": llx.StringDataPtr(image.RegistryId),
 					"repoName":   llx.StringData(name),
 					"region":     llx.StringData(region),
 					"arn":        llx.StringData(ecrImageArn(ImageInfo{Region: region, RegistryId: convert.ToString(image.RegistryId), RepoName: name, Digest: convert.ToString(image.ImageDigest)})),
@@ -283,10 +283,10 @@ func (a *mqlAwsEcr) publicRepositories() ([]interface{}, error) {
 
 		mqlRepoResource, err := CreateResource(a.MqlRuntime, "aws.ecr.repository",
 			map[string]*llx.RawData{
-				"arn":             llx.StringData(convert.ToString(r.RepositoryArn)),
-				"name":            llx.StringData(convert.ToString(r.RepositoryName)),
-				"uri":             llx.StringData(convert.ToString(r.RepositoryUri)),
-				"registryId":      llx.StringData(convert.ToString(r.RegistryId)),
+				"arn":             llx.StringDataPtr(r.RepositoryArn),
+				"name":            llx.StringDataPtr(r.RepositoryName),
+				"uri":             llx.StringDataPtr(r.RepositoryUri),
+				"registryId":      llx.StringDataPtr(r.RegistryId),
 				"public":          llx.BoolData(true),
 				"region":          llx.StringData("us-east-1"),
 				"imageScanOnPush": llx.BoolData(false),

--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -83,7 +83,7 @@ func (a *mqlAwsS3) buckets() ([]interface{}, error) {
 		}
 		mqlS3Bucket, err := CreateResource(a.MqlRuntime, "aws.s3.bucket",
 			map[string]*llx.RawData{
-				"name":        llx.StringData(convert.ToString(bucket.Name)),
+				"name":        llx.StringDataPtr(bucket.Name),
 				"arn":         llx.StringData(fmt.Sprintf(s3ArnPattern, convert.ToString(bucket.Name))),
 				"exists":      llx.BoolData(true),
 				"location":    llx.StringData(region),


### PR DESCRIPTION
- Add createdAt to aws.ec2.keypair
- Improve defaults in aws.ec2.keypair
- Cleanup some incorrect min mondoo version fields
- Use StringDataPtr where we can