### PR TITLE
🧹 add make task to compile lr into go bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,9 @@ providers/defaults:
 providers/lr:
 	go build -o lr ./providers-sdk/v1/lr/cli/main.go
 
+providers/lr/install: providers/lr
+	cp ./lr ${GOPATH}/bin
+
 .PHONY: providers/build
 # Note we need \ to escape the target line into multiple lines
 providers/build: \


### PR DESCRIPTION
This allows users to easily install the lr command into go bin