### PR TITLE
Add port and endpoint to aws.rds.dbinstance

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1892,6 +1892,10 @@ private aws.rds.dbinstance @defaults("id region engine engineVersion") {
   autoMinorVersionUpgrade bool
   // The creation date of the RDS instance
   createdTime time
+  // The port that the DB instance listens on. If the DB instance is part of a DB cluster, this can be a different port than the DB cluster port.
+  port int
+  // The connection endpoint for the DB instance
+  endpoint string
 }
 
 // Amazon ElastiCache

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -2802,6 +2802,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.dbinstance.createdTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbinstance).GetCreatedTime()).ToDataRes(types.Time)
 	},
+	"aws.rds.dbinstance.port": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetPort()).ToDataRes(types.Int)
+	},
+	"aws.rds.dbinstance.endpoint": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetEndpoint()).ToDataRes(types.String)
+	},
 	"aws.elasticache.clusters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticache).GetClusters()).ToDataRes(types.Array(types.Dict))
 	},
@@ -6883,6 +6889,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.rds.dbinstance.createdTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsDbinstance).CreatedTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.port": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).Port, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.endpoint": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).Endpoint, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.elasticache.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -17757,6 +17771,8 @@ type mqlAwsRdsDbinstance struct {
 	Status plugin.TValue[string]
 	AutoMinorVersionUpgrade plugin.TValue[bool]
 	CreatedTime plugin.TValue[*time.Time]
+	Port plugin.TValue[int64]
+	Endpoint plugin.TValue[string]
 }
 
 // createAwsRdsDbinstance creates a new instance of this resource
@@ -17906,6 +17922,14 @@ func (c *mqlAwsRdsDbinstance) GetAutoMinorVersionUpgrade() *plugin.TValue[bool] 
 
 func (c *mqlAwsRdsDbinstance) GetCreatedTime() *plugin.TValue[*time.Time] {
 	return &c.CreatedTime
+}
+
+func (c *mqlAwsRdsDbinstance) GetPort() *plugin.TValue[int64] {
+	return &c.Port
+}
+
+func (c *mqlAwsRdsDbinstance) GetEndpoint() *plugin.TValue[string] {
+	return &c.Endpoint
 }
 
 // mqlAwsElasticache for the aws.elasticache resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -1987,6 +1987,8 @@ resources:
         min_mondoo_version: 5.19.1
       deletionProtection: {}
       enabledCloudwatchLogsExports: {}
+      endpoint:
+        min_mondoo_version: 9.0.0
       engine:
         min_mondoo_version: 5.19.1
       engineVersion:
@@ -1995,6 +1997,8 @@ resources:
       id: {}
       multiAZ: {}
       name: {}
+      port:
+        min_mondoo_version: 9.0.0
       publiclyAccessible: {}
       region: {}
       securityGroups:

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -104,6 +104,7 @@ func (a *mqlAwsRds) getDbInstances(conn *connection.AwsConnection) []*jobpool.Jo
 							"id":                            llx.StringDataPtr(dbInstance.DBInstanceIdentifier),
 							"multiAZ":                       llx.BoolDataPtr(dbInstance.MultiAZ),
 							"name":                          llx.StringDataPtr(dbInstance.DBName),
+							"port":                          llx.IntData(convert.ToInt64From32(dbInstance.DbInstancePort)),
 							"publiclyAccessible":            llx.BoolDataPtr(dbInstance.PubliclyAccessible),
 							"region":                        llx.StringData(regionVal),
 							"securityGroups":                llx.ArrayData(sgs, types.Resource("aws.ec2.securitygroup")),
@@ -113,6 +114,7 @@ func (a *mqlAwsRds) getDbInstances(conn *connection.AwsConnection) []*jobpool.Jo
 							"storageIops":                   llx.IntData(convert.ToInt64From32(dbInstance.Iops)),
 							"storageType":                   llx.StringDataPtr(dbInstance.StorageType),
 							"tags":                          llx.MapData(rdsTagsToMap(dbInstance.TagList), types.String),
+							"endpoint":                      llx.StringDataPtr(dbInstance.Endpoint.Address),
 						})
 					if err != nil {
 						return nil, err


### PR DESCRIPTION
A few more useful items to align with the dbcluster resource