### PR TITLE
⭐ number.inRange support

### DIFF
--- a/llx/builtin.go
+++ b/llx/builtin.go
@@ -176,6 +176,7 @@ func init() {
 			string("||" + types.ArrayLike):           {f: intOrArrayV2, Label: "||"},
 			string("&&" + types.MapLike):             {f: intAndMapV2, Label: "&&"},
 			string("||" + types.MapLike):             {f: intOrMapV2, Label: "||"},
+			string("inRange"):                        {f: intInRange, Label: "inRange"},
 		},
 		types.Float: {
 			// == / !=
@@ -246,6 +247,7 @@ func init() {
 			string("||" + types.ArrayLike):           {f: floatOrArrayV2, Label: "||"},
 			string("&&" + types.MapLike):             {f: floatAndMapV2, Label: "&&"},
 			string("||" + types.MapLike):             {f: floatOrMapV2, Label: "&&"},
+			string("inRange"):                        {f: floatInRange, Label: "inRange"},
 		},
 		types.String: {
 			// == / !=

--- a/llx/builtin_simple.go
+++ b/llx/builtin_simple.go
@@ -1568,6 +1568,92 @@ func mapOrIntV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*Raw
 	return boolOpV2(e, bind, chunk, ref, opMapOrInt)
 }
 
+func int64InRange(e *blockExecutor, val int64, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
+	minRef := chunk.Function.Args[0]
+	min, rref, err := e.resolveValue(minRef, ref)
+	if err != nil || rref > 0 {
+		return nil, rref, err
+	}
+
+	switch minval := min.Value.(type) {
+	case int64:
+		if val < minval {
+			return BoolFalse, 0, nil
+		}
+	case float64:
+		if float64(val) < minval {
+			return BoolFalse, 0, nil
+		}
+	}
+
+	maxRef := chunk.Function.Args[1]
+	max, rref, err := e.resolveValue(maxRef, ref)
+	if err != nil || rref > 0 {
+		return nil, rref, err
+	}
+
+	switch maxval := max.Value.(type) {
+	case int64:
+		if val > maxval {
+			return BoolFalse, 0, nil
+		}
+	case float64:
+		if float64(val) > maxval {
+			return BoolFalse, 0, nil
+		}
+	}
+
+	return BoolTrue, 0, nil
+}
+
+func float64InRange(e *blockExecutor, val float64, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
+	minRef := chunk.Function.Args[0]
+	min, rref, err := e.resolveValue(minRef, ref)
+	if err != nil || rref > 0 {
+		return nil, rref, err
+	}
+
+	switch minval := min.Value.(type) {
+	case int64:
+		if val < float64(minval) {
+			return BoolFalse, 0, nil
+		}
+	case float64:
+		if val < minval {
+			return BoolFalse, 0, nil
+		}
+	}
+
+	maxRef := chunk.Function.Args[1]
+	max, rref, err := e.resolveValue(maxRef, ref)
+	if err != nil || rref > 0 {
+		return nil, rref, err
+	}
+
+	switch maxval := max.Value.(type) {
+	case int64:
+		if val > float64(maxval) {
+			return BoolFalse, 0, nil
+		}
+	case float64:
+		if val > maxval {
+			return BoolFalse, 0, nil
+		}
+	}
+
+	return BoolTrue, 0, nil
+}
+
+func intInRange(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
+	val := bind.Value.(int64)
+	return int64InRange(e, val, chunk, ref)
+}
+
+func floatInRange(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
+	val := bind.Value.(float64)
+	return float64InRange(e, val, chunk, ref)
+}
+
 // float &&/|| T
 
 func opFloatAndString(left interface{}, right interface{}) bool {

--- a/mqlc/builtin.go
+++ b/mqlc/builtin.go
@@ -34,6 +34,12 @@ var builtinFunctions map[types.Type]map[string]compileHandler
 
 func init() {
 	builtinFunctions = map[types.Type]map[string]compileHandler{
+		types.Int: {
+			"inRange": {typ: boolType, compile: compileInRange},
+		},
+		types.Float: {
+			"inRange": {typ: boolType, compile: compileInRange},
+		},
 		types.String: {
 			"contains":  {compile: compileStringContains, typ: boolType, signature: FunctionSignature{Required: 1, Args: []types.Type{types.String}}},
 			"find":      {typ: stringArrayType, signature: FunctionSignature{Required: 1, Args: []types.Type{types.Regex}}},

--- a/providers/core/resources/mql_test.go
+++ b/providers/core/resources/mql_test.go
@@ -364,6 +364,12 @@ func TestNumber_Methods(t *testing.T) {
 		{
 			Code: "1 == NaN", Expectation: false,
 		},
+		{
+			Code: "2.inRange(1,2.0)", Expectation: true,
+		},
+		{
+			Code: "3.0.inRange(1.0,2)", Expectation: false,
+		},
 	})
 }
 


### PR DESCRIPTION
Support a simpler methods to see if a number is in range.

So far users have to:

```coffee
num >= 3 && num <= 5
```

Now you can:

```coffee
num.inRange(min,  max)
```

Example:

```coffee
3.inRange(3, 5)
```

This supports both integers and floats. Dict support is coming next.