### PR TITLE
✨ parse.duration

### DIFF
--- a/llx/builtin.go
+++ b/llx/builtin.go
@@ -694,7 +694,8 @@ func init() {
 				return e.runBlock(bind, chunk.Function.Args[0], chunk.Function.Args[1:], ref)
 			}},
 			// TODO: [#32] unique builtin fields that need a long-term support in LR
-			string(types.Resource("parse") + ".date"): {f: resourceDateV2},
+			string(types.Resource("parse") + ".date"):     {f: resourceDateV2},
+			string(types.Resource("parse") + ".duration"): {f: resourceDuration},
 		},
 	}
 

--- a/mqlc/builtin.go
+++ b/mqlc/builtin.go
@@ -135,7 +135,8 @@ func init() {
 		},
 		// TODO: [#32] unique builtin fields that need a long-term support in LR
 		types.Resource("parse"): {
-			"date": {compile: compileResourceParseDate, signature: FunctionSignature{Required: 1, Args: []types.Type{types.String, types.String}}},
+			"date":     {compile: compileResourceParseDate, signature: FunctionSignature{Required: 1, Args: []types.Type{types.String, types.String}}},
+			"duration": {compile: compileResourceParseDuration, signature: FunctionSignature{Required: 1, Args: []types.Type{types.String}}},
 		},
 	}
 }

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -1954,7 +1954,7 @@ func TestSuggestions(t *testing.T) {
 		{
 			// builtin calls
 			"parse.d",
-			[]string{"date"},
+			[]string{"date", "duration"},
 			errors.New("cannot find field 'd' in parse"),
 			nil,
 		},

--- a/providers/core/resources/core.lr
+++ b/providers/core/resources/core.lr
@@ -102,6 +102,7 @@ regex {
 parse {
   // Built-in functions:
   // date(value, format) time
+  // duration(value) time
 }
 
 // UUIDs based on RFC 4122 and DCE 1.1

--- a/providers/core/resources/parse_test.go
+++ b/providers/core/resources/parse_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"go.mondoo.com/cnquery/v9/llx"
 	"go.mondoo.com/cnquery/v9/providers-sdk/v1/testutils"
 )
 
@@ -31,6 +32,46 @@ func TestParse_Date(t *testing.T) {
 			Code:        "parse.date('Mon Dec 23 00:00:00 2023', 'ansic')",
 			ResultIndex: 0,
 			Expectation: &simpleDate,
+		},
+	})
+}
+
+func TestParse_Duration(t *testing.T) {
+	twoSecs := llx.DurationToTime(2)
+	tenMin := llx.DurationToTime(10 * 60)
+	threeHours := llx.DurationToTime(3 * 60 * 60)
+	thirtyDays := llx.DurationToTime(30 * 60 * 60 * 24)
+	sevenYears := llx.DurationToTime(7 * 60 * 60 * 24 * 365)
+	x.TestSimple(t, []testutils.SimpleTest{
+		{
+			Code:        "parse.duration('2')",
+			ResultIndex: 0,
+			Expectation: &twoSecs,
+		},
+		{
+			Code:        "parse.duration('2seconds')",
+			ResultIndex: 0,
+			Expectation: &twoSecs,
+		},
+		{
+			Code:        "parse.duration('10min')",
+			ResultIndex: 0,
+			Expectation: &tenMin,
+		},
+		{
+			Code:        "parse.duration('3h')",
+			ResultIndex: 0,
+			Expectation: &threeHours,
+		},
+		{
+			Code:        "parse.duration('30day')",
+			ResultIndex: 0,
+			Expectation: &thirtyDays,
+		},
+		{
+			Code:        "parse.duration('7y')",
+			ResultIndex: 0,
+			Expectation: &sevenYears,
 		},
 	})
 }


### PR DESCRIPTION
This now supports parsing durations in seconds (s), minutes (m), hours (m), days (d), and years (y). This works with both the shorthand scalar as well as the long version, e.g.:

```coffee
parse.duration("3d")
parse.duration("3days")
```

The parser is very lenient, but we recommend using the above scalars as so:

```
1s = 1 second
2m = 2 minutes
3h = 3 hours
4d = 4 days
5y = 5 years
```