### PR TITLE
Updates defaults for Terraform resources

### DIFF
--- a/providers/terraform/resources/terraform.lr
+++ b/providers/terraform/resources/terraform.lr
@@ -27,7 +27,7 @@ terraform {
 }
 
 // Terraform configuration file (.tf or .tf.json file)
-terraform.file {
+terraform.file @defaults("path") {
   // Terraform (.tf or tf.json file)
   path string
   // All blocks within the file
@@ -71,7 +71,7 @@ terraform.block @defaults("type labels") {
 }
 
 // Terraform module block
-terraform.module @defaults("key") {
+terraform.module @defaults("key source") {
   // Unique identifier for the module
   key string
   // Source from which the module was loaded
@@ -112,7 +112,7 @@ terraform.state {
 }
 
 // Terraform state output values
-terraform.state.output {
+terraform.state.output @defaults("identifier") {
   init(identifier string)
   // Output identifier
   identifier string
@@ -136,7 +136,7 @@ terraform.state.module @defaults("address") {
 }
 
 // Terraform state resource
-terraform.state.resource @defaults("name") {
+terraform.state.resource @defaults("type name") {
   // Address is the absolute resource address
   address string
   // Mode: managed or data


### PR DESCRIPTION
This PR updates some defaults for Terraform resources. 

### Terraform State Resources

**Before**
```
cnquery> terraform.state.resources
terraform.state.resources: [
  0: terraform.state.resource name="random"
  1: terraform.state.resource name="this"
  2: terraform.state.resource name="current"
  3: terraform.state.resource name="this"
  4: terraform.state.resource name="this"
  5: terraform.state.resource name="this"
  6: terraform.state.resource name="this"
  7: terraform.state.resource name="this"
  8: terraform.state.resource name="this"
```

**AFTER**
```
cnquery> terraform.state.resources
terraform.state.resources: [
  0: terraform.state.resource type="random_string" name="random"
  1: terraform.state.resource type="aws_instance" name="this"
  2: terraform.state.resource type="aws_partition" name="current"
  3: terraform.state.resource type="aws_ssm_parameter" name="this"
  4: terraform.state.resource type="aws_s3_bucket" name="this"
  5: terraform.state.resource type="aws_s3_bucket_acl" name="this"
  6: terraform.state.resource type="aws_s3_bucket_ownership_controls" name="this"
  7: terraform.state.resource type="aws_s3_bucket_public_access_block" name="this"
  8: terraform.state.resource type="aws_s3_bucket_versioning" name="this"
```

### Terraform Files
Now includes paths

```
cnquery> terraform.files
terraform.files: [
  0: terraform.file path="../tf-state/main.tf"
  1: terraform.file path="../tf-state/variables.tf"
]
```
