### PR TITLE
🐛 consistent group(gid:0) / group(name:"root") init

### DIFF
--- a/providers/os/resources/group.go
+++ b/providers/os/resources/group.go
@@ -9,12 +9,62 @@ import (
 	"sync"
 
 	"go.mondoo.com/cnquery/v9/llx"
+	"go.mondoo.com/cnquery/v9/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v9/providers/os/connection/shared"
 	"go.mondoo.com/cnquery/v9/providers/os/resources/groups"
 )
 
 type mqlGroupInternal struct {
 	membersArr []string
+}
+
+func initGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) != 1 {
+		return args, nil, nil
+	}
+
+	// if user is only initialized with a name or uid, we will try to look it up
+	rawName, nameOk := args["name"]
+	rawGID, idOk := args["gid"]
+	if !nameOk && !idOk {
+		return args, nil, nil
+	}
+
+	raw, err := CreateResource(runtime, "groups", nil)
+	if err != nil {
+		return nil, nil, errors.New("cannot get list of groups: " + err.Error())
+	}
+	groups := raw.(*mqlGroups)
+
+	if err := groups.refreshCache(nil); err != nil {
+		return nil, nil, err
+	}
+
+	if nameOk {
+		name, ok := rawName.Value.(string)
+		if !ok {
+			return nil, nil, errors.New("cannot detect group, invalid type for name (expected string)")
+		}
+		group, ok := groups.groupsByName[name]
+		if !ok {
+			return nil, nil, errors.New("cannot find group with name '" + name + "'")
+		}
+		return nil, group, nil
+	}
+
+	if idOk {
+		id, ok := rawGID.Value.(int64)
+		if !ok {
+			return nil, nil, errors.New("cannot detect group, invalid type for name (expected int)")
+		}
+		group, ok := groups.groupsByID[id]
+		if !ok {
+			return nil, nil, errors.New("cannot find group with UID '" + strconv.Itoa(int(id)) + "'")
+		}
+		return nil, group, nil
+	}
+
+	return nil, nil, errors.New("cannot find group, no search criteria provided")
 }
 
 func (x *mqlGroup) id() (string, error) {
@@ -48,8 +98,9 @@ func (x *mqlGroup) members() ([]interface{}, error) {
 }
 
 type mqlGroupsInternal struct {
-	lock       sync.Mutex
-	groupsByID map[int64]*mqlGroup
+	lock         sync.Mutex
+	groupsByID   map[int64]*mqlGroup
+	groupsByName map[string]*mqlGroup
 }
 
 func (x *mqlGroups) list() ([]interface{}, error) {
@@ -91,10 +142,30 @@ func (x *mqlGroups) list() ([]interface{}, error) {
 
 		g := nu.(*mqlGroup)
 		g.membersArr = group.Members
-		x.groupsByID[g.Gid.Data] = g
 	}
 
-	return res, nil
+	return res, x.refreshCache(res)
+}
+
+func (x *mqlGroups) refreshCache(all []interface{}) error {
+	if all == nil {
+		raw := x.GetList()
+		if raw.Error != nil {
+			return raw.Error
+		}
+		all = raw.Data
+	}
+
+	x.groupsByID = map[int64]*mqlGroup{}
+	x.groupsByName = map[string]*mqlGroup{}
+
+	for i := range all {
+		g := all[i].(*mqlGroup)
+		x.groupsByID[g.Gid.Data] = g
+		x.groupsByName[g.Name.Data] = g
+	}
+
+	return nil
 }
 
 func (x *mqlGroups) findID(id int64) (*mqlGroup, error) {

--- a/providers/os/resources/group_test.go
+++ b/providers/os/resources/group_test.go
@@ -21,4 +21,18 @@ func TestResource_Groups(t *testing.T) {
 		assert.Empty(t, res[0].Result().Error)
 		assert.Equal(t, "root", res[0].Data.Value)
 	})
+
+	t.Run("test group init (gid)", func(t *testing.T) {
+		res := x.TestQuery(t, "group(gid: 1000).name")
+		assert.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, "chris", res[0].Data.Value)
+	})
+
+	t.Run("test group init (name)", func(t *testing.T) {
+		res := x.TestQuery(t, "group(name: 'chris').gid")
+		assert.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, int64(1000), res[0].Data.Value)
+	})
 }

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -187,7 +187,7 @@ func init() {
 			Create: createAuthorizedkeysEntry,
 		},
 		"group": {
-			// to override args, implement: initGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init: initGroup,
 			Create: createGroup,
 		},
 		"groups": {

--- a/providers/os/resources/user_test.go
+++ b/providers/os/resources/user_test.go
@@ -35,4 +35,18 @@ func TestResource_Users(t *testing.T) {
 		assert.Empty(t, res[0].Result().Error)
 		assert.Equal(t, true, res[1].Data.Value)
 	})
+
+	t.Run("test user init (uid)", func(t *testing.T) {
+		res := x.TestQuery(t, "user(uid: 1000).name")
+		assert.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, "chris", res[0].Data.Value)
+	})
+
+	t.Run("test user init (name)", func(t *testing.T) {
+		res := x.TestQuery(t, "user(name: 'chris').uid")
+		assert.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, int64(1000), res[0].Data.Value)
+	})
 }


### PR DESCRIPTION
We had inconsistent behavior between the `user` init (which supported being called with `uid` and `name`) and `group` (which didn't have an init call at all).

Both have now been aligned, so you can call:

```coffee
> user(uid: 0)
user: user name="root" uid=0 gid=0

> user(name: "root")
user: user name="root" uid=0 gid=0
```

as well as

```coffee
> group(gid: 0)
group: group name="root" gid=0

> group(name: "root")
group: group name="root" gid=0
```

Fixes #2937 

Expands testing.