### PR TITLE
🐛 update `for` field in props

### DIFF
--- a/explorer/property_test.go
+++ b/explorer/property_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package explorer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProperty_RefreshMrn(t *testing.T) {
+	in := &Property{
+		Uid: "uid1",
+		For: []*ObjectRef{{
+			Uid: "uid2",
+		}},
+	}
+
+	err := in.RefreshMRN("//my.owner")
+	require.NoError(t, err)
+
+	assert.Equal(t, "", in.Uid)
+	assert.Equal(t, "//my.owner/queries/uid1", in.Mrn)
+	assert.Equal(t, "", in.For[0].Uid)
+	assert.Equal(t, "//my.owner/queries/uid2", in.For[0].Mrn)
+}

--- a/explorer/query_conductor.go
+++ b/explorer/query_conductor.go
@@ -201,7 +201,7 @@ func (s *LocalServices) addQueryToJob(ctx context.Context, query *Mquery, job *E
 		for i := range query.Props {
 			prop := query.Props[i]
 
-			override, name, _ := propsCache.Get(ctx, prop.Mrn)
+			override, name, _ := propsCache.Get(prop.Mrn)
 			if override != nil {
 				prop = override
 			}


### PR DESCRIPTION
We were never fully implementing referential properties until now. This PR fixes the fact that the `for` field is referencing other properties in the same bundle using their `uid`. It now correctly generates their `mrn` and sets the `uid` to empty string like in the property itself.