### PR TITLE
✨ Add support for scanning azure disks.

### DIFF
--- a/providers/azure/connection/azureinstancesnapshot/platform.go
+++ b/providers/azure/connection/azureinstancesnapshot/platform.go
@@ -6,3 +6,7 @@ package azureinstancesnapshot
 func SnapshotPlatformMrn(snapshotId string) string {
 	return "//platformid.api.mondoo.app/runtime/azure" + snapshotId
 }
+
+func DiskPlatformMrn(diskId string) string {
+	return "//platformid.api.mondoo.app/runtime/azure" + diskId
+}

--- a/providers/azure/connection/azureinstancesnapshot/provider_test.go
+++ b/providers/azure/connection/azureinstancesnapshot/provider_test.go
@@ -14,8 +14,8 @@ func TestParseTarget(t *testing.T) {
 	t.Run("parse snapshot target with just a resource name", func(t *testing.T) {
 		scanner := &azureScannerInstance{
 			instanceInfo: instanceInfo{
-				ResourceGroup: "my-rg",
-				InstanceName:  "my-instance",
+				resourceGroup: "my-rg",
+				instanceName:  "my-instance",
 			},
 		}
 		target := "my-other-snapshot"
@@ -30,13 +30,13 @@ func TestParseTarget(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "my-rg", scanTarget.ResourceGroup)
 		assert.Equal(t, target, scanTarget.Target)
-		assert.Equal(t, "snapshot", scanTarget.TargetType)
+		assert.Equal(t, SnapshotTargetType, scanTarget.TargetType)
 	})
 	t.Run("parse instance target with just a resource name", func(t *testing.T) {
 		scanner := &azureScannerInstance{
 			instanceInfo: instanceInfo{
-				ResourceGroup: "my-rg",
-				InstanceName:  "my-instance",
+				resourceGroup: "my-rg",
+				instanceName:  "my-instance",
 			},
 		}
 		target := "my-other-instance"
@@ -51,13 +51,34 @@ func TestParseTarget(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "my-rg", scanTarget.ResourceGroup)
 		assert.Equal(t, target, scanTarget.Target)
-		assert.Equal(t, "instance", scanTarget.TargetType)
+		assert.Equal(t, InstanceTargetType, scanTarget.TargetType)
+	})
+	t.Run("parse disk target with just a resource name", func(t *testing.T) {
+		scanner := &azureScannerInstance{
+			instanceInfo: instanceInfo{
+				resourceGroup: "my-rg",
+				instanceName:  "my-instance",
+			},
+		}
+		target := "my-disk"
+
+		conf := &inventory.Config{
+			Options: map[string]string{
+				"target": target,
+				"type":   "disk",
+			},
+		}
+		scanTarget, err := ParseTarget(conf, scanner)
+		assert.NoError(t, err)
+		assert.Equal(t, "my-rg", scanTarget.ResourceGroup)
+		assert.Equal(t, target, scanTarget.Target)
+		assert.Equal(t, DiskTargetType, scanTarget.TargetType)
 	})
 	t.Run("parse snapshot target with a fully qualifed Azure resource id", func(t *testing.T) {
 		scanner := &azureScannerInstance{
 			instanceInfo: instanceInfo{
-				ResourceGroup: "my-rg",
-				InstanceName:  "my-instance",
+				resourceGroup: "my-rg",
+				instanceName:  "my-instance",
 			},
 		}
 		target := "/subscriptions/f1a2873a-6c27-4097-aa7c-3df51f103e91/resourceGroups/my-other-rg/providers/Microsoft.Compute/snapshots/test-snp"
@@ -72,13 +93,13 @@ func TestParseTarget(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "my-other-rg", scanTarget.ResourceGroup)
 		assert.Equal(t, "test-snp", scanTarget.Target)
-		assert.Equal(t, "snapshot", scanTarget.TargetType)
+		assert.Equal(t, SnapshotTargetType, scanTarget.TargetType)
 	})
 	t.Run("parse instance target with a fully qualifed Azure resource id", func(t *testing.T) {
 		scanner := &azureScannerInstance{
 			instanceInfo: instanceInfo{
-				ResourceGroup: "my-rg",
-				InstanceName:  "my-instance",
+				resourceGroup: "my-rg",
+				instanceName:  "my-instance",
 			},
 		}
 		target := "/subscriptions/f1a2873a-6b27-4097-aa7c-3df51f103e96/resourceGroups/debian_group/providers/Microsoft.Compute/virtualMachines/debian"
@@ -93,6 +114,27 @@ func TestParseTarget(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "debian_group", scanTarget.ResourceGroup)
 		assert.Equal(t, "debian", scanTarget.Target)
-		assert.Equal(t, "instance", scanTarget.TargetType)
+		assert.Equal(t, InstanceTargetType, scanTarget.TargetType)
+	})
+	t.Run("parse disk target with a fully qualifed Azure resource id", func(t *testing.T) {
+		scanner := &azureScannerInstance{
+			instanceInfo: instanceInfo{
+				resourceGroup: "my-rg",
+				instanceName:  "my-instance",
+			},
+		}
+		target := "/subscriptions/f1a2873a-6b27-4097-aa7c-3df51f103e96/resourceGroups/debian_group/providers/Microsoft.Compute/disks/disk-1"
+
+		conf := &inventory.Config{
+			Options: map[string]string{
+				"target": target,
+				"type":   "disk",
+			},
+		}
+		scanTarget, err := ParseTarget(conf, scanner)
+		assert.NoError(t, err)
+		assert.Equal(t, "debian_group", scanTarget.ResourceGroup)
+		assert.Equal(t, "disk-1", scanTarget.Target)
+		assert.Equal(t, DiskTargetType, scanTarget.TargetType)
 	})
 }

--- a/providers/azure/connection/azureinstancesnapshot/snapshot.go
+++ b/providers/azure/connection/azureinstancesnapshot/snapshot.go
@@ -20,9 +20,39 @@ const (
 	createdValue   = "cnspec"
 )
 
-func NewSnapshotCreator(token azcore.TokenCredential, subscriptionId string) (*SnapshotCreator, error) {
+type snapshotCreator struct {
+	subscriptionId string
+	token          azcore.TokenCredential
+	opts           *policy.ClientOptions
+	labels         map[string]*string
+}
+
+type instanceInfo struct {
+	subscriptionId string
+	resourceGroup  string
+	instanceName   string
+	location       string
+	bootDiskId     string
+	zones          []*string
+	// Attach the entire VM response as well
+	vm compute.VirtualMachine
+}
+
+type snapshotInfo struct {
+	snapshotName string
+	snapshotId   string
+	location     string
+}
+
+type diskInfo struct {
+	diskName string
+	diskId   string
+	location string
+}
+
+func NewSnapshotCreator(token azcore.TokenCredential, subscriptionId string) (*snapshotCreator, error) {
 	createdByVal := createdValue
-	sc := &SnapshotCreator{
+	sc := &snapshotCreator{
 		labels: map[string]*string{
 			createdByLabel: &createdByVal,
 		},
@@ -32,22 +62,15 @@ func NewSnapshotCreator(token azcore.TokenCredential, subscriptionId string) (*S
 	return sc, nil
 }
 
-type SnapshotCreator struct {
-	subscriptionId string
-	token          azcore.TokenCredential
-	opts           *policy.ClientOptions
-	labels         map[string]*string
-}
-
-func (sc *SnapshotCreator) snapshotClient() (*compute.SnapshotsClient, error) {
+func (sc *snapshotCreator) snapshotClient() (*compute.SnapshotsClient, error) {
 	return compute.NewSnapshotsClient(sc.subscriptionId, sc.token, sc.opts)
 }
 
-func (sc *SnapshotCreator) diskClient() (*compute.DisksClient, error) {
+func (sc *snapshotCreator) diskClient() (*compute.DisksClient, error) {
 	return compute.NewDisksClient(sc.subscriptionId, sc.token, sc.opts)
 }
 
-func (sc *SnapshotCreator) computeClient() (*compute.VirtualMachinesClient, error) {
+func (sc *snapshotCreator) computeClient() (*compute.VirtualMachinesClient, error) {
 	return computeClient(sc.token, sc.subscriptionId, sc.opts)
 }
 
@@ -55,18 +78,7 @@ func computeClient(token azcore.TokenCredential, subId string, opts *policy.Clie
 	return compute.NewVirtualMachinesClient(subId, token, opts)
 }
 
-type instanceInfo struct {
-	SubscriptionId string
-	ResourceGroup  string
-	InstanceName   string
-	Location       string
-	BootDiskId     string
-	Zones          []*string
-	// Attach the entire VM response as well
-	Vm compute.VirtualMachine
-}
-
-func (sc *SnapshotCreator) InstanceInfo(resourceGroup, instanceName string) (instanceInfo, error) {
+func (sc *snapshotCreator) instanceInfo(resourceGroup, instanceName string) (instanceInfo, error) {
 	return InstanceInfo(resourceGroup, instanceName, sc.subscriptionId, sc.token)
 }
 
@@ -83,25 +95,17 @@ func InstanceInfo(resourceGroup, instanceName, subId string, token azcore.TokenC
 	if err != nil {
 		return ii, err
 	}
-	ii.ResourceGroup = resourceGroup
-	ii.InstanceName = *instance.Name
-	ii.BootDiskId = *instance.Properties.StorageProfile.OSDisk.ManagedDisk.ID
-	ii.Location = *instance.Location
-	ii.SubscriptionId = subId
-	ii.Zones = instance.Zones
-	ii.Vm = instance.VirtualMachine
+	ii.resourceGroup = resourceGroup
+	ii.instanceName = *instance.Name
+	ii.bootDiskId = *instance.Properties.StorageProfile.OSDisk.ManagedDisk.ID
+	ii.location = *instance.Location
+	ii.subscriptionId = subId
+	ii.zones = instance.Zones
+	ii.vm = instance.VirtualMachine
 	return ii, nil
 }
 
-type snapshotInfo struct {
-	PlatformMrn   string
-	ResourceGroup string
-	SnapshotName  string
-	SnapshotId    string
-	Location      string
-}
-
-func (sc *SnapshotCreator) SnapshotInfo(resourceGroup, snapshotName string) (snapshotInfo, error) {
+func (sc *snapshotCreator) snapshotInfo(resourceGroup, snapshotName string) (snapshotInfo, error) {
 	ctx := context.Background()
 	si := snapshotInfo{}
 
@@ -115,14 +119,34 @@ func (sc *SnapshotCreator) SnapshotInfo(resourceGroup, snapshotName string) (sna
 		return si, err
 	}
 
-	si.SnapshotName = *snapshot.Name
-	si.SnapshotId = *snapshot.ID
-	si.Location = *snapshot.Location
+	si.snapshotName = *snapshot.Name
+	si.snapshotId = *snapshot.ID
+	si.location = *snapshot.Location
 	return si, nil
 }
 
+func (sc *snapshotCreator) diskInfo(resourceGroup, snapshotName string) (diskInfo, error) {
+	ctx := context.Background()
+	di := diskInfo{}
+
+	snapshotSvc, err := sc.diskClient()
+	if err != nil {
+		return di, err
+	}
+
+	disk, err := snapshotSvc.Get(ctx, resourceGroup, snapshotName, &compute.DisksClientGetOptions{})
+	if err != nil {
+		return di, err
+	}
+
+	di.diskId = *disk.ID
+	di.diskName = *disk.Name
+	di.location = *disk.Location
+	return di, nil
+}
+
 // createDisk creates a new disk
-func (sc *SnapshotCreator) createDisk(disk compute.Disk, resourceGroupName, diskName string) (compute.Disk, error) {
+func (sc *snapshotCreator) createDisk(disk compute.Disk, resourceGroupName, diskName string) (compute.Disk, error) {
 	ctx := context.Background()
 
 	diskSvc, err := sc.diskClient()
@@ -144,7 +168,7 @@ func (sc *SnapshotCreator) createDisk(disk compute.Disk, resourceGroupName, disk
 }
 
 // createSnapshotDisk creates a new disk from a snapshot
-func (sc *SnapshotCreator) createSnapshotDisk(sourceSnaphotId, resourceGroupName, diskName, location string, zones []*string) (compute.Disk, error) {
+func (sc *snapshotCreator) createSnapshotDisk(sourceSnaphotId, resourceGroupName, diskName, location string, zones []*string) (compute.Disk, error) {
 	// create a new disk from snapshot
 	createOpt := compute.DiskCreateOptionCopy
 	disk := compute.Disk{
@@ -163,7 +187,7 @@ func (sc *SnapshotCreator) createSnapshotDisk(sourceSnaphotId, resourceGroupName
 }
 
 // cloneDisk clones a provided disk
-func (sc *SnapshotCreator) cloneDisk(sourceDiskId, resourceGroupName, diskName string, location string, zones []*string) (compute.Disk, error) {
+func (sc *snapshotCreator) cloneDisk(sourceDiskId, resourceGroupName, diskName string, location string, zones []*string) (compute.Disk, error) {
 	// create a new disk by copying another disk
 	createOpt := compute.DiskCreateOptionCopy
 	disk := compute.Disk{
@@ -182,7 +206,7 @@ func (sc *SnapshotCreator) cloneDisk(sourceDiskId, resourceGroupName, diskName s
 }
 
 // attachDisk attaches a disk to an instance
-func (sc *SnapshotCreator) attachDisk(targetInstance instanceInfo, diskName, diskId string, lun int32) error {
+func (sc *snapshotCreator) attachDisk(targetInstance instanceInfo, diskName, diskId string, lun int32) error {
 	ctx := context.Background()
 	log.Debug().Str("disk-name", diskName).Int32("LUN", lun).Msg("attach disk")
 	computeSvc, err := sc.computeClient()
@@ -192,7 +216,7 @@ func (sc *SnapshotCreator) attachDisk(targetInstance instanceInfo, diskName, dis
 	attachOpt := compute.DiskCreateOptionTypesAttach
 	// the Azure API requires all disks to be specified, even the already attached ones.
 	// we simply attach the new disk to the end of the already present list of data disks
-	disks := targetInstance.Vm.Properties.StorageProfile.DataDisks
+	disks := targetInstance.vm.Properties.StorageProfile.DataDisks
 	disks = append(disks, &compute.DataDisk{
 		Name:         &diskName,
 		CreateOption: &attachOpt,
@@ -202,7 +226,7 @@ func (sc *SnapshotCreator) attachDisk(targetInstance instanceInfo, diskName, dis
 		},
 	})
 	vm := compute.VirtualMachine{
-		Location: &targetInstance.Location,
+		Location: &targetInstance.location,
 		Properties: &compute.VirtualMachineProperties{
 			StorageProfile: &compute.StorageProfile{
 				DataDisks: disks,
@@ -210,7 +234,7 @@ func (sc *SnapshotCreator) attachDisk(targetInstance instanceInfo, diskName, dis
 		},
 	}
 
-	poller, err := computeSvc.BeginCreateOrUpdate(ctx, targetInstance.ResourceGroup, targetInstance.InstanceName, vm, &compute.VirtualMachinesClientBeginCreateOrUpdateOptions{})
+	poller, err := computeSvc.BeginCreateOrUpdate(ctx, targetInstance.resourceGroup, targetInstance.instanceName, vm, &compute.VirtualMachinesClientBeginCreateOrUpdateOptions{})
 	if err != nil {
 		return err
 	}
@@ -232,9 +256,9 @@ func (sc *SnapshotCreator) attachDisk(targetInstance instanceInfo, diskName, dis
 	return err
 }
 
-func (sc *SnapshotCreator) detachDisk(diskName string, targetInstance instanceInfo) error {
+func (sc *snapshotCreator) detachDisk(diskName string, targetInstance instanceInfo) error {
 	ctx := context.Background()
-	log.Debug().Str("instance-name", targetInstance.InstanceName).Msg("detach disk from instance")
+	log.Debug().Str("instance-name", targetInstance.instanceName).Msg("detach disk from instance")
 	computeSvc, err := sc.computeClient()
 	if err != nil {
 		return err
@@ -243,15 +267,15 @@ func (sc *SnapshotCreator) detachDisk(diskName string, targetInstance instanceIn
 	// we stored the disks as they were before attaching the new one in the targetInstance.
 	// we simply use that list which will result in the new disk being detached
 	vm := compute.VirtualMachine{
-		Location: &targetInstance.Location,
+		Location: &targetInstance.location,
 		Properties: &compute.VirtualMachineProperties{
 			StorageProfile: &compute.StorageProfile{
-				DataDisks: targetInstance.Vm.Properties.StorageProfile.DataDisks,
+				DataDisks: targetInstance.vm.Properties.StorageProfile.DataDisks,
 			},
 		},
 	}
 
-	poller, err := computeSvc.BeginCreateOrUpdate(ctx, targetInstance.ResourceGroup, targetInstance.InstanceName, vm, &compute.VirtualMachinesClientBeginCreateOrUpdateOptions{})
+	poller, err := computeSvc.BeginCreateOrUpdate(ctx, targetInstance.resourceGroup, targetInstance.instanceName, vm, &compute.VirtualMachinesClientBeginCreateOrUpdateOptions{})
 	if err != nil {
 		return err
 	}
@@ -274,7 +298,7 @@ func (sc *SnapshotCreator) detachDisk(diskName string, targetInstance instanceIn
 }
 
 // deleteCreatedDisk deletes the given disk if it matches the created label
-func (sc *SnapshotCreator) deleteCreatedDisk(resourceGroup, diskName string) error {
+func (sc *snapshotCreator) deleteCreatedDisk(resourceGroup, diskName string) error {
 	ctx := context.Background()
 
 	diskSvc, err := sc.diskClient()

--- a/providers/azure/provider/provider.go
+++ b/providers/azure/provider/provider.go
@@ -116,12 +116,18 @@ func handleAzureComputeSubcommands(args []string, config *inventory.Config) erro
 	case "instance":
 		config.Type = string(azureinstancesnapshot.SnapshotConnectionType)
 		config.Discover = nil
-		config.Options["type"] = "instance"
+		config.Options["type"] = azureinstancesnapshot.InstanceTargetType
 		config.Options["target"] = args[2]
 		return nil
 	case "snapshot":
 		config.Type = string(azureinstancesnapshot.SnapshotConnectionType)
-		config.Options["type"] = "snapshot"
+		config.Options["type"] = azureinstancesnapshot.SnapshotTargetType
+		config.Options["target"] = args[2]
+		config.Discover = nil
+		return nil
+	case "disk":
+		config.Type = string(azureinstancesnapshot.SnapshotConnectionType)
+		config.Options["type"] = azureinstancesnapshot.DiskTargetType
 		config.Options["target"] = args[2]
 		config.Discover = nil
 		return nil


### PR DESCRIPTION
Adds support for scanning azure disks: `cnquery scan azure compute disk <id> ....`.

This means that the azure snapshot scanner now supports disks, instances and snapshot targets. This PR also adds some cleanup by removing unused properties and making things private where possible.