### PR TITLE
🧹 fix warning in gql client

### DIFF
--- a/providers-sdk/v1/upstream/gql/client.go
+++ b/providers-sdk/v1/upstream/gql/client.go
@@ -18,7 +18,7 @@ type MondooClient struct {
 
 // NewClient creates a new GraphQL client for the Mondoo API
 // provide the http client used for rpc, to also pass in the proxy settings
-func NewClient(upstream upstream.UpstreamConfig, httpClient *http.Client) (*MondooClient, error) {
+func NewClient(upstream *upstream.UpstreamConfig, httpClient *http.Client) (*MondooClient, error) {
 	gqlEndpoint := upstream.ApiEndpoint + "/query"
 	creds, err := json.Marshal(upstream.Creds)
 	if err != nil {

--- a/providers/os/resources/asset_vuln.go
+++ b/providers/os/resources/asset_vuln.go
@@ -122,7 +122,7 @@ func getAdvisoryReport(runtime *plugin.Runtime) (*mvd.VulnReport, error) {
 	}
 
 	// get new gql client
-	mondooClient, err := gql.NewClient(mcc.UpstreamConfig, mcc.HttpClient)
+	mondooClient, err := gql.NewClient(&mcc.UpstreamConfig, mcc.HttpClient)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/os/resources/vulnmgmt.go
+++ b/providers/os/resources/vulnmgmt.go
@@ -32,7 +32,7 @@ func (v *mqlVulnmgmt) lastAssessment() (*time.Time, error) {
 		mondooClient = v.gqlClient
 	} else {
 		// get new gql client
-		mondooClient, err = gql.NewClient(mcc.UpstreamConfig, mcc.HttpClient)
+		mondooClient, err = gql.NewClient(&mcc.UpstreamConfig, mcc.HttpClient)
 		if err != nil {
 			return nil, err
 		}
@@ -203,7 +203,7 @@ func (v *mqlVulnmgmt) getReport() (*gql.VulnReport, error) {
 		mondooClient = v.gqlClient
 	} else {
 		// get new gql client
-		mondooClient, err = gql.NewClient(mcc.UpstreamConfig, mcc.HttpClient)
+		mondooClient, err = gql.NewClient(&mcc.UpstreamConfig, mcc.HttpClient)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/vsphere/resources/vulnmgmt.go
+++ b/providers/vsphere/resources/vulnmgmt.go
@@ -32,7 +32,7 @@ func (v *mqlVulnmgmt) lastAssessment() (*time.Time, error) {
 		mondooClient = v.gqlClient
 	} else {
 		// get new gql client
-		mondooClient, err = gql.NewClient(mcc.UpstreamConfig, mcc.HttpClient)
+		mondooClient, err = gql.NewClient(&mcc.UpstreamConfig, mcc.HttpClient)
 		if err != nil {
 			return nil, err
 		}
@@ -176,7 +176,7 @@ func (v *mqlVulnmgmt) getReport() (*gql.VulnReport, error) {
 		mondooClient = v.gqlClient
 	} else {
 		// get new gql client
-		mondooClient, err = gql.NewClient(mcc.UpstreamConfig, mcc.HttpClient)
+		mondooClient, err = gql.NewClient(&mcc.UpstreamConfig, mcc.HttpClient)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
the fact that this is not a pointer causes annoying linter warnings because we are copying some lock by reference instead of a pointer. This fixes the issue