### PR TITLE
🧹 Attach zerolog logger to plugin clients.

### DIFF
--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -209,7 +209,7 @@ func (c *coordinator) Start(id string, isEphemeral bool, update UpdateProvidersC
 		AllowedProtocols: []plugin.Protocol{
 			plugin.ProtocolNetRPC, plugin.ProtocolGRPC,
 		},
-		Logger: &hclogger{},
+		Logger: &hclogger{Logger: log.Logger},
 		Stderr: os.Stderr,
 	})
 


### PR DESCRIPTION
Attach the zerolog logger to the plugin. This way we gain extra logging around the plugins' lifecycle:

```
cnquery> exit
x plugin process exited error="exit status 1" id=8679 plugin=/opt/mondoo/providers/azure/azure
! failed to shut down provider error="rpc error: code = Unavailable desc = error reading from server: EOF" provider=azure
→ plugin process exited id=9127 plugin=/opt/mondoo/providers/os/os
```