### PR TITLE
🐛 Allow for provider shutdown to take longer than a heartbeat.

### DIFF
--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -50,8 +50,10 @@ func TestProviderShutdown(t *testing.T) {
 	}
 	err := s.heartbeat()
 	require.NoError(t, err)
+	require.False(t, s.isCloseOrShutdown())
 	// the shutdown here takes 10 seconds, whereas the heartbeat interval is every second.
 	// this means that this provider gets multiple heartbeats while shutting down
 	err = s.Shutdown()
 	require.NoError(t, err)
+	require.True(t, s.isCloseOrShutdown())
 }

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/v9/providers-sdk/v1/plugin"
+)
+
+type testPlugin struct {
+	plugin.Service
+}
+
+func (t *testPlugin) Connect(req *plugin.ConnectReq, callback plugin.ProviderCallback) (*plugin.ConnectRes, error) {
+	return nil, nil
+}
+
+func (t *testPlugin) MockConnect(req *plugin.ConnectReq, callback plugin.ProviderCallback) (*plugin.ConnectRes, error) {
+	return nil, nil
+}
+
+func (t *testPlugin) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error) {
+	return nil, nil
+}
+
+func (t *testPlugin) Shutdown(req *plugin.ShutdownReq) (*plugin.ShutdownRes, error) {
+	// sleep more than the heartbeat interval to ensure that even if shutting down
+	// the provider can still respond to heartbeats
+	time.Sleep(10 * time.Second)
+	return &plugin.ShutdownRes{}, nil
+}
+
+func (t *testPlugin) GetData(req *plugin.DataReq) (*plugin.DataRes, error) {
+	return nil, nil
+}
+
+func (t *testPlugin) StoreData(req *plugin.StoreReq) (*plugin.StoreRes, error) {
+	return nil, nil
+}
+
+func TestProviderShutdown(t *testing.T) {
+	s := &RunningProvider{
+		Plugin: &testPlugin{},
+	}
+	err := s.heartbeat()
+	require.NoError(t, err)
+	err = s.Shutdown()
+	require.NoError(t, err)
+}

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -44,10 +44,14 @@ func (t *testPlugin) StoreData(req *plugin.StoreReq) (*plugin.StoreRes, error) {
 
 func TestProviderShutdown(t *testing.T) {
 	s := &RunningProvider{
-		Plugin: &testPlugin{},
+		Plugin:      &testPlugin{},
+		interval:    500 * time.Millisecond,
+		gracePeriod: 500 * time.Millisecond,
 	}
 	err := s.heartbeat()
 	require.NoError(t, err)
+	// the shutdown here takes 10 seconds, whereas the heartbeat interval is every second.
+	// this means that this provider gets multiple heartbeats while shutting down
 	err = s.Shutdown()
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Until now, both `Shutdown` and `Heartbeat` shared a lock. This means that if shutting down ever takes more then the heartbeat interval, the provider plugin gets killed as it cannot keep doing heartbeats since the lock is occupied.

This PR introduces a second lock to only be used for the heartbeat-related stuff: Setting `isClosed` and `isShutdown` on the provider and then using this in the heartbeat logic. The shutdown logic uses a separate lock to ensure that both can run in parallel. 