### PR TITLE
✨ compiler multi-stat WalkSorted + bugfix

### DIFF
--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -2243,11 +2243,11 @@ func CompileAST(ast *parser.AST, props map[string]*llx.Primitive, conf CompilerC
 // Compile a code piece against a schema into chunky code
 func compile(input string, props map[string]*llx.Primitive, compilerConf CompilerConfig) (*llx.CodeBundle, error) {
 
-	conf := compilerConf
-	conf.Stats = compilerConf.Stats.CompileQuery(input)
-
 	// remove leading whitespace; we are re-using this later on
 	input = Dedent(input)
+
+	conf := compilerConf
+	conf.Stats = compilerConf.Stats.CompileQuery(input)
 
 	ast, err := parser.Parse(input)
 	if ast == nil {

--- a/mqlc/mqlc_stats.go
+++ b/mqlc/mqlc_stats.go
@@ -141,7 +141,18 @@ func newCompilerMultiStats() *compilerMultiStats {
 }
 
 func (c *compilerMultiStats) WalkSorted(f func(resource string, field string, info FieldStat)) {
-	panic("walking code on multi-stats not yet supported")
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	aggregate := newCompilerStats()
+	for _, v := range c.stats {
+		v.WalkSorted(func(resource, field string, info FieldStat) {
+			aggregate.CallResource(resource)
+			aggregate.ResourceFields[resource][field] = info
+		})
+	}
+
+	aggregate.WalkSorted(f)
 }
 
 func (c *compilerMultiStats) WalkCode(f func(code string, stats CompilerStats)) {


### PR DESCRIPTION
Support WalkSorted on multi-stat compiler configs.

Bugfix that compiler stats are done after the query is cleaned, otherwise it leads to bad anchors for internal IDs