### PR TITLE
🧹 Rename the ec2-volume and ec2-snapshot platforms to be EBS

### DIFF
--- a/providers/aws/connection/platform.go
+++ b/providers/aws/connection/platform.go
@@ -42,10 +42,10 @@ func getTitleForPlatformName(name string) string {
 		return "AWS VPC"
 	case "aws-security-group":
 		return "AWS Security Group"
-	case "aws-ec2-volume":
-		return "AWS EC2 Volume"
-	case "aws-ec2-snapshot":
-		return "AWS EC2 Snapshot"
+	case "aws-ebs-volume":
+		return "AWS EBS Volume"
+	case "aws-ebs-snapshot":
+		return "AWS EBS Snapshot"
 	case "aws-iam-user":
 		return "AWS IAM User"
 	case "aws-iam-group":

--- a/providers/aws/resources/discovery_conversion.go
+++ b/providers/aws/resources/discovery_conversion.go
@@ -128,9 +128,9 @@ func getPlatformName(awsObject awsObject) string {
 		case "securitygroup":
 			return "aws-security-group"
 		case "volume":
-			return "aws-ec2-volume"
+			return "aws-ebs-volume"
 		case "snapshot":
-			return "aws-ec2-snapshot"
+			return "aws-ebs-snapshot"
 		case "instance":
 			return "aws-ec2-instance"
 		}


### PR DESCRIPTION
The API calls these EC2, which makes sense from an SDK organization standpoint, but doesn't reflect what these platforms are call. The console and documentation calls these EBS volumes/snapshots. This is a breaking change, but the blast radius is very small at this point since discover is not enabled by default. V10 is the perfect time to make this before we enable fine grained scanning by default.