### PR TITLE
✨ Automatically create cnquery update PR

### DIFF
--- a/.github/workflows/bump-cnspec.yml
+++ b/.github/workflows/bump-cnspec.yml
@@ -1,0 +1,19 @@
+name: Trigger cnquery bump in cnspec
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  trigger-cnspec:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger cnquery bump in cnspec
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.RELEASR_ACTION_TOKEN }}
+          repository: "mondoohq/cnspec"
+          event-type: update-cnquery
+          client-payload: '{
+              "version": "${{  github.ref_name }}"
+            }'


### PR DESCRIPTION
A new cnquery release will trigger a workflow in the cnspec repo to create a PR which updates the dep.