### PR TITLE
⭐ Add discovery for aws-rds-dbcluster

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -38,6 +38,7 @@ var Config = plugin.Provider{
 				resources.DiscoveryS3Buckets,
 				resources.DiscoveryCloudtrailTrails,
 				resources.DiscoveryRdsDbInstances,
+				resources.DiscoveryRdsDbClusters,
 				resources.DiscoveryVPCs,
 				resources.DiscoverySecurityGroups,
 				resources.DiscoveryIAMUsers,

--- a/providers/aws/connection/platform.go
+++ b/providers/aws/connection/platform.go
@@ -34,6 +34,8 @@ func getTitleForPlatformName(name string) string {
 		return "AWS CloudTrail Trail"
 	case "aws-rds-dbinstance":
 		return "AWS RDS DB Instance"
+	case "aws-rds-dbcluster":
+		return "AWS RDS DB Cluster"
 	case "aws-dynamodb-table":
 		return "AWS DynamoDB Table"
 	case "aws-redshift-cluster":

--- a/providers/aws/resources/discovery.go
+++ b/providers/aws/resources/discovery.go
@@ -33,6 +33,7 @@ const (
 	DiscoveryS3Buckets                  = "s3-buckets"
 	DiscoveryCloudtrailTrails           = "cloudtrail-trails"
 	DiscoveryRdsDbInstances             = "rds-dbinstances"
+	DiscoveryRdsDbClusters              = "rds-dbclusters"
 	DiscoveryVPCs                       = "vpcs"
 	DiscoverySecurityGroups             = "security-groups"
 	DiscoveryIAMUsers                   = "iam-users"
@@ -71,6 +72,7 @@ var AllAPIResources = []string{
 	DiscoveryS3Buckets,
 	DiscoveryCloudtrailTrails,
 	DiscoveryRdsDbInstances,
+	DiscoveryRdsDbClusters,
 	DiscoveryVPCs,
 	DiscoverySecurityGroups,
 	DiscoveryIAMUsers,
@@ -521,6 +523,32 @@ func discover(runtime *plugin.Runtime, awsAccount *mqlAwsAccount, target string,
 				awsObject: awsObject{
 					account: accountId, region: f.Region.Data, arn: f.Arn.Data,
 					id: f.Id.Data, service: "rds", objectType: "dbinstance",
+				},
+			}
+			assetList = append(assetList, MqlObjectToAsset(accountId, m, conn))
+		}
+	case DiscoveryRdsDbClusters:
+		res, err := NewResource(runtime, "aws.rds", map[string]*llx.RawData{})
+		if err != nil {
+			return nil, err
+		}
+
+		r := res.(*mqlAwsRds)
+
+		clusters := r.GetDbClusters()
+		if clusters == nil {
+			return assetList, nil
+		}
+
+		for i := range clusters.Data {
+			f := clusters.Data[i].(*mqlAwsRdsDbcluster)
+
+			tags := mapStringInterfaceToStringString(f.Tags.Data)
+			m := mqlObject{
+				name: f.Id.Data, labels: tags,
+				awsObject: awsObject{
+					account: accountId, region: f.Region.Data, arn: f.Arn.Data,
+					id: f.Id.Data, service: "rds", objectType: "dbcluster",
 				},
 			}
 			assetList = append(assetList, MqlObjectToAsset(accountId, m, conn))

--- a/providers/aws/resources/discovery_conversion.go
+++ b/providers/aws/resources/discovery_conversion.go
@@ -111,6 +111,9 @@ func getPlatformName(awsObject awsObject) string {
 		if awsObject.objectType == "dbinstance" {
 			return "aws-rds-dbinstance"
 		}
+		if awsObject.objectType == "dbcluster" {
+			return "aws-rds-dbcluster"
+		}
 	case "dynamodb":
 		if awsObject.objectType == "table" {
 			return "aws-dynamodb-table"


### PR DESCRIPTION
RDS clusters are very important and should be scanned as their own assets with checks applied to those assets. This starts that process.

```
cnquery shell aws --discover rds-dbclusters
→ loaded configuration from /Users/tsmith/.config/mondoo/mondoo.yml using source default

    Available assets

  > 1. othercluster (aws-rds-dbcluster)
    2. timcluster (aws-rds-dbcluster)








    ↑/k up • ↓/j down • q quit • ? more

```