### PR TITLE
🧹 remove trailing dot for short cmd description

### DIFF
--- a/apps/cnquery/cmd/bundle.go
+++ b/apps/cnquery/cmd/bundle.go
@@ -39,7 +39,7 @@ func init() {
 var packBundlesCmd = &cobra.Command{
 	Use:     "bundle",
 	Aliases: []string{"pack"},
-	Short:   "Create, upload, and validate query packs.",
+	Short:   "Create, upload, and validate query packs",
 }
 
 //go:embed bundle_querypack-example.mql.yaml
@@ -47,7 +47,8 @@ var embedQueryPackTemplate []byte
 
 var queryPackInitCmd = &cobra.Command{
 	Use:   "init [path]",
-	Short: "Create an example query pack that you can use as a starting point. If you don't provide a filename, cnquery uses `example-pack.mql.yaml`.",
+	Short: "Create an example query pack",
+	Long:  "Create an example query pack that you can use as a starting point. If you don't provide a filename, cnquery uses `example-pack.mql.yaml`.",
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		name := "example-pack.mql.yaml"
@@ -124,7 +125,7 @@ func ensureProviders() error {
 var queryPackLintCmd = &cobra.Command{
 	Use:     "lint [path]",
 	Aliases: []string{"validate"},
-	Short:   "Apply style formatting to a query pack.",
+	Short:   "Apply style formatting to a query pack",
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Info().Str("file", args[0]).Msg("lint query pack")
@@ -157,7 +158,7 @@ var queryPackLintCmd = &cobra.Command{
 var queryPackPublishCmd = &cobra.Command{
 	Use:     "publish [path]",
 	Aliases: []string{"upload"},
-	Short:   "Add a user-owned query pack to the Mondoo Security Registry.",
+	Short:   "Add a user-owned query pack to the Mondoo Security Registry",
 	Args:    cobra.ExactArgs(1),
 	PreRun: func(cmd *cobra.Command, args []string) {
 		viper.BindPFlag("pack-version", cmd.Flags().Lookup("pack-version"))

--- a/apps/cnquery/cmd/login.go
+++ b/apps/cnquery/cmd/login.go
@@ -33,7 +33,7 @@ func init() {
 var LoginCmd = &cobra.Command{
 	Use:     "login",
 	Aliases: []string{"register"},
-	Short:   "Register with Mondoo Platform.",
+	Short:   "Register with Mondoo Platform",
 	Long: `
 Log in to Mondoo Platform using a registration token. To pass in the token, use 
 the '--token' flag.

--- a/apps/cnquery/cmd/logout.go
+++ b/apps/cnquery/cmd/logout.go
@@ -27,7 +27,7 @@ func init() {
 var LogoutCmd = &cobra.Command{
 	Use:     "logout",
 	Aliases: []string{"unregister"},
-	Short:   "Log out from Mondoo Platform.",
+	Short:   "Log out from Mondoo Platform",
 	Long: `
 This process also revokes the Mondoo Platform service account to 
 ensure the credentials cannot be used in the future.

--- a/apps/cnquery/cmd/plugin.go
+++ b/apps/cnquery/cmd/plugin.go
@@ -30,7 +30,7 @@ import (
 var pluginCmd = &cobra.Command{
 	Use:    "run_as_plugin",
 	Hidden: true,
-	Short:  "Run as a plugin.",
+	Short:  "Run as a plugin",
 	Run: func(cmd *cobra.Command, args []string) {
 		plugin.Serve(&plugin.ServeConfig{
 			HandshakeConfig: shared.Handshake,

--- a/apps/cnquery/cmd/providers.go
+++ b/apps/cnquery/cmd/providers.go
@@ -30,7 +30,7 @@ func init() {
 
 var ProvidersCmd = &cobra.Command{
 	Use:    "providers",
-	Short:  "Providers add connectivity to all assets.",
+	Short:  "Providers add connectivity to all assets",
 	Long:   `Manage your providers. List and install new ones or update existing ones.`,
 	PreRun: func(cmd *cobra.Command, args []string) {},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/apps/cnquery/cmd/run.go
+++ b/apps/cnquery/cmd/run.go
@@ -34,7 +34,7 @@ func init() {
 
 var RunCmd = &cobra.Command{
 	Use:   "run",
-	Short: "Run an MQL query.",
+	Short: "Run an MQL query",
 	Long:  `Run an MQL query on the CLI and displays its results.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		viper.BindPFlag("platform-id", cmd.Flags().Lookup("platform-id"))

--- a/apps/cnquery/cmd/sbom.go
+++ b/apps/cnquery/cmd/sbom.go
@@ -31,7 +31,7 @@ func init() {
 
 var sbomCmd = &cobra.Command{
 	Use:   "sbom",
-	Short: "Experimental: Generate a software bill of materials (SBOM) for a given asset.",
+	Short: "Experimental: Generate a software bill of materials (SBOM) for a given asset",
 	Long: `Generate a software bill of materials (SBOM) for a given asset. The SBOM
 is a representation of the asset's software components and their dependencies.
 

--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -59,7 +59,7 @@ func init() {
 
 var scanCmd = &cobra.Command{
 	Use:   "scan",
-	Short: "Scan assets with one or more query packs.",
+	Short: "Scan assets with one or more query packs",
 	Long: `
 This command scans an asset using a query pack. For example, you can scan
 the local system with its pre-configured query pack:

--- a/apps/cnquery/cmd/shell.go
+++ b/apps/cnquery/cmd/shell.go
@@ -33,8 +33,8 @@ func init() {
 
 var shellCmd = &cobra.Command{
 	Use:   "shell",
-	Short: "Interactive query shell for MQL.",
-	Long:  `Allows the interactive exploration of MQL queries.`,
+	Short: "Interactive query shell for MQL",
+	Long:  `Allows the interactive exploration of MQL queries`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		viper.BindPFlag("platform-id", cmd.Flags().Lookup("platform-id"))
 	},

--- a/apps/cnquery/cmd/status.go
+++ b/apps/cnquery/cmd/status.go
@@ -35,7 +35,7 @@ func init() {
 // StatusCmd represents the version command
 var StatusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Verify access to Mondoo Platform.",
+	Short: "Verify access to Mondoo Platform",
 	Long: `
 Status sends a ping to Mondoo Platform to verify the credentials.
 	`,

--- a/apps/cnquery/cmd/vault.go
+++ b/apps/cnquery/cmd/vault.go
@@ -38,13 +38,13 @@ func init() {
 // VaultCmd represents the vault command
 var VaultCmd = &cobra.Command{
 	Use:   "vault",
-	Short: "Manage vault environments.",
+	Short: "Manage vault environments",
 	Long:  ``,
 }
 
 var vaultListCmd = &cobra.Command{
 	Use:    "list",
-	Short:  "List vault environments.",
+	Short:  "List vault environments",
 	Long:   ``,
 	Hidden: true,
 	PreRun: func(cmd *cobra.Command, args []string) {
@@ -58,7 +58,7 @@ var vaultListCmd = &cobra.Command{
 var vaultConfigureCmd = &cobra.Command{
 	Use:     "configure VAULTNAME",
 	Aliases: []string{"set"},
-	Short:   "Configure a vault environment.",
+	Short:   "Configure a vault environment",
 	Long: `
 
 cnquery vault configure mondoo-client-vault --type linux-kernel-keyring
@@ -122,7 +122,7 @@ cnquery vault configure mondoo-client-vault --type linux-kernel-keyring
 
 var vaultRemoveCmd = &cobra.Command{
 	Use:    "remove VAULTNAME",
-	Short:  "Remove a configured vault environment.",
+	Short:  "Remove a configured vault environment",
 	Long:   ``,
 	Args:   cobra.ExactArgs(1),
 	Hidden: true,
@@ -133,7 +133,7 @@ var vaultRemoveCmd = &cobra.Command{
 
 var vaultResetCmd = &cobra.Command{
 	Use:    "reset",
-	Short:  "Reset the vault configuration to defaults.",
+	Short:  "Reset the vault configuration to defaults",
 	Long:   ``,
 	Args:   cobra.ExactArgs(0),
 	Hidden: true,
@@ -144,7 +144,7 @@ var vaultResetCmd = &cobra.Command{
 
 var vaultAddSecretCmd = &cobra.Command{
 	Use:   "add-secret SECRETID SECRETVALUE",
-	Short: "Store a secret in a vault.",
+	Short: "Store a secret in a vault",
 	Args:  cobra.ExactArgs(2),
 	PreRun: func(cmd *cobra.Command, args []string) {
 		viper.BindPFlag("inventory-file", cmd.Flags().Lookup("inventory-file"))

--- a/apps/cnquery/cmd/version.go
+++ b/apps/cnquery/cmd/version.go
@@ -13,7 +13,7 @@ import (
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Display the cnquery version.",
+	Short: "Display the cnquery version",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(cnquery.Info())
 	},

--- a/test/cli/testdata/cnquery.ct
+++ b/test/cli/testdata/cnquery.ct
@@ -11,19 +11,19 @@ Usage:
   cnquery [command]
 
 Available Commands:
-  bundle        Create, upload, and validate query packs.
+  bundle        Create, upload, and validate query packs
   completion    Generate the autocompletion script for the specified shell
   help          Help about any command
-  login         Register with Mondoo Platform.
-  logout        Log out from Mondoo Platform.
-  providers     Providers add connectivity to all assets.
-  run           Run an MQL query.
-  sbom          Experimental: Generate a software bill of materials (SBOM) for a given asset.
-  scan          Scan assets with one or more query packs.
-  shell         Interactive query shell for MQL.
-  status        Verify access to Mondoo Platform.
-  vault         Manage vault environments.
-  version       Display the cnquery version.
+  login         Register with Mondoo Platform
+  logout        Log out from Mondoo Platform
+  providers     Providers add connectivity to all assets
+  run           Run an MQL query
+  sbom          Experimental: Generate a software bill of materials (SBOM) for a given asset
+  scan          Scan assets with one or more query packs
+  shell         Interactive query shell for MQL
+  status        Verify access to Mondoo Platform
+  vault         Manage vault environments
+  version       Display the cnquery version
 
 Flags:
       --api-proxy string   Set proxy for communications with Mondoo API

--- a/test/cli/testdata/cnquery_vault.ct
+++ b/test/cli/testdata/cnquery_vault.ct
@@ -1,12 +1,12 @@
 $ cnquery vault
-Manage vault environments.
+Manage vault environments
 
 Usage:
   cnquery vault [command]
 
 Available Commands:
-  add-secret  Store a secret in a vault.
-  configure   Configure a vault environment.
+  add-secret  Store a secret in a vault
+  configure   Configure a vault environment
 
 Flags:
   -h, --help   help for vault


### PR DESCRIPTION
after #3031 

simplifies the short description of commands since it is unusual to use trailing dots for short descriptions.