### PR TITLE
🐛 support legacy+modern provider ID lookups

### DIFF
--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -158,18 +158,7 @@ func attachProvidersToCmd(existing providers.Providers, cmd *Command) {
 	}
 
 	// the default is always os.local if it exists
-	if p, ok := existing[providers.DefaultOsID]; ok {
-		for i := range p.Connectors {
-			c := p.Connectors[i]
-			if c.Name == "local" {
-				setDefaultConnector(p.Provider, &c, cmd)
-				break
-			}
-		}
-	}
-
-	// temp for migrating v9 beta users
-	if p, ok := existing[providers.DeprecatedDefaultOsID]; ok {
+	if p, ok := existing.GetFirstID(providers.DefaultOsIDs...); ok {
 		for i := range p.Connectors {
 			c := p.Connectors[i]
 			if c.Name == "local" {

--- a/providers/defaults_shared.go
+++ b/providers/defaults_shared.go
@@ -7,10 +7,15 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-const (
-	DefaultOsID           = "go.mondoo.com/cnquery/v10/providers/os"
-	DeprecatedDefaultOsID = "go.mondoo.com/cnquery/providers/os" // temp to migrate v9 beta users
-)
+var DefaultOsIDs = []string{
+	"go.mondoo.com/cnquery/providers/os",
+	// FIXME: DEPRECATED, remove in v12.0 vv
+	// We specify providers without versions now. Also remove the providers
+	// GetFirstID function, since it only exists for this use-case
+	"go.mondoo.com/cnquery/v9/providers/os",
+	"go.mondoo.com/cnquery/v10/providers/os",
+	// ^^
+}
 
 var defaultRuntime *Runtime
 

--- a/providers/network/config/config.go
+++ b/providers/network/config/config.go
@@ -17,9 +17,14 @@ var Config = plugin.Provider{
 		"go.mondoo.com/cnquery/providers/os",
 		"go.mondoo.com/cnquery/providers/k8s",
 		"go.mondoo.com/cnquery/providers/aws",
+		// FIXME: DEPRECATED, remove in v12.0 vv
+		// Until v10 providers had a version indication in their ID. With v10
+		// this is no longer the case. Once we get far enough away from legacy
+		// version support, we can safely remove this.
 		"go.mondoo.com/cnquery/v9/providers/os",
 		"go.mondoo.com/cnquery/v9/providers/k8s",
 		"go.mondoo.com/cnquery/v9/providers/aws",
+		// ^^
 	},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -80,6 +80,23 @@ func (s ProviderLookup) String() string {
 
 type Providers map[string]*Provider
 
+// FIXME: DEPRECATED, remove in v12.0 vv
+// Unlike lookup, which searches through providers by ID, connection type and
+// connection names, this function only cycles through the index of providers
+// (which is based on IDs) in order and returns the first found provider.
+// We introduced this function to help transition from versioned IDs in
+// providers to unversioned IDs in providers.
+func (p Providers) GetFirstID(ids ...string) (*Provider, bool) {
+	for _, id := range ids {
+		if found, ok := p[id]; ok {
+			return found, true
+		}
+	}
+	return nil, false
+}
+
+// ^^
+
 // Lookup a provider in this list. If you search via ProviderID we will
 // try to find the exact provider. Otherwise we will try to find a matching
 // connector type first and name second.

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -579,9 +579,14 @@ func (r *Runtime) lookupResourceProvider(resource string) (*ConnectedProvider, *
 	providerConn := r.Provider.Instance.ID
 	crossProviderList := []string{
 		"go.mondoo.com/cnquery/providers/core",
-		"go.mondoo.com/cnquery/v9/providers/core", // for backwards compatibility
 		"go.mondoo.com/cnquery/providers/network",
+		// FIXME: DEPRECATED, remove in v12.0 vv
+		// Until v10 providers had a version indication in their ID. With v10
+		// this is no longer the case. Once we get far enough away from legacy
+		// version support, we can safely remove this.
+		"go.mondoo.com/cnquery/v9/providers/core",    // for backwards compatibility
 		"go.mondoo.com/cnquery/v9/providers/network", // for backwards compatibility
+		// ^^
 	}
 
 	if info.Provider != providerConn && !stringx.Contains(crossProviderList, info.Provider) {


### PR DESCRIPTION
Legacy providers contain the version in their ID. Modern providers after v10 do not do this anymore.

Support both forms of lookup in this transition time.