### PR TITLE
🐛 prevent testutils from loading local providers

### DIFF
--- a/providers-sdk/v1/testutils/testutils.go
+++ b/providers-sdk/v1/testutils/testutils.go
@@ -227,6 +227,13 @@ func Local() llx.Runtime {
 	}
 	runtime.AddConnectedProvider(&providers.ConnectedProvider{Instance: provider})
 
+	// Since the testutils runtime is meant to be used with in-memory
+	// providers only, we deactivate any type of discovery on the system.
+	// This prevents us from accidentally pulling locally installed providers
+	// which may not work with the current dependencies. The task of testing
+	// those falls to an integration environment, not to unit tests.
+	runtime.DeactivateProviderDiscovery()
+
 	return runtime
 }
 


### PR DESCRIPTION
Testutils are meant as an in-memory testing utility for unit tests. However, in their default configuration they pull providers from the local system, which can have unforseen consequences.

Most of the code in `testutils.go` already sets up the runtime to use in-memory providers with linked dependencies.

This changes ensures that we don't accidentally load installed providers on the system - or try to install online providers. For unit tests, we rely on providers that are fast to grab and execute, thus executable from memory. Other types of testing (particularly smoke/integration) are a different matter and not in scope of these utilities at the time of writing. (Which doesn't mean that they can't become that, but I think we want to be more explicit about when that happens, to avoid accidental side-effects where unit tests start to install providers)

Counter-points to this are very welcome!