### PR TITLE
🧹 Use DefaultAzureCredential for token resolving in the Azure provider

### DIFF
--- a/providers/azure/connection/auth/auth.go
+++ b/providers/azure/connection/auth/auth.go
@@ -16,10 +16,10 @@ import (
 func GetTokenCredential(credential *vault.Credential, tenantId, clientId string) (azcore.TokenCredential, error) {
 	var azCred azcore.TokenCredential
 	var err error
-	// fallback to CLI authorizer if no credentials are specified
+	// fallback to default authorizer if no credentials are specified
 	if credential == nil {
-		log.Debug().Msg("using azure cli to get a token")
-		azCred, err = azidentity.NewAzureCLICredential(&azidentity.AzureCLICredentialOptions{})
+		log.Debug().Msg("using default azure token resolver")
+		azCred, err = azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{})
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating CLI credentials")
 		}


### PR DESCRIPTION
This extends the connection capabilities of the azure provider from just CLI creds to env var, workload identity, managed identity and CLI creds.