### PR TITLE
🐛 Fix port resource panic

### DIFF
--- a/providers/os/resources/port.go
+++ b/providers/os/resources/port.go
@@ -508,6 +508,11 @@ func (p *mqlPorts) parseWindowsPorts(r io.Reader, processes map[int64]*mqlProces
 			return nil, err
 		}
 
+		portObj := obj.(*mqlPort)
+		if process == nil {
+			portObj.Process.State = plugin.StateIsSet | plugin.StateIsNull
+		}
+
 		res = append(res, obj)
 	}
 	return res, nil
@@ -595,6 +600,10 @@ func (p *mqlPorts) listMacos() ([]interface{}, error) {
 			if err != nil {
 				log.Error().Err(err).Send()
 				return nil, err
+			}
+			portObj := obj.(*mqlPort)
+			if mqlProcess == nil {
+				portObj.Process.State = plugin.StateIsSet | plugin.StateIsNull
 			}
 
 			res = append(res, obj)


### PR DESCRIPTION
It is possible for the port resource to panic on mac and windows if the process is requested. This can happen because we query for all the processes first, then we query for ports which gets us process ids. A new process showing up between the first and second queries can cause the panic to happen.

Linux has a similar check