### PR TITLE
⭐ Add new fields/defaults to aws.rds.snapshot

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1823,7 +1823,7 @@ private aws.rds.dbcluster @defaults("id region") {
 }
 
 // Amazon RDS snapshot
-private aws.rds.snapshot @defaults("id region type encrypted") {
+private aws.rds.snapshot @defaults("id region type encrypted createdAt") {
   // ARN of the snapshot
   arn string
   // ID of the snapshot
@@ -1842,10 +1842,16 @@ private aws.rds.snapshot @defaults("id region type encrypted") {
   tags map[string]string
   // The snapshot DB engine
   engine string
+  // The snapshot DB engine version
+  engineVersion string
   // The snapshot status
   status string
   // The amount of storage allocated to the snapshot
   allocatedStorage int
+  // The port that the DB instance or cluster listens on
+  port int
+  // The creation date of the snapshot
+  createdAt time
 }
 
 // Amazon RDS database instance
@@ -2279,7 +2285,7 @@ private aws.ec2.internetgateway @defaults("arn") {
   attachments []dict
 }
 
-// Amazon EC2 snapshot
+// Amazon EC2 (EBS) snapshot
 private aws.ec2.snapshot @defaults("id region volumeSize state") {
   // ARN for the snapshot
   arn string
@@ -2305,7 +2311,7 @@ private aws.ec2.snapshot @defaults("id region volumeSize state") {
   encrypted bool
 }
 
-// Amazon EC2 volume
+// Amazon EC2 (EBS) volume
 private aws.ec2.volume @defaults("id region volumeType size encrypted state") {
   // ARN for the EC2 volume
   arn string

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -2731,11 +2731,20 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.snapshot.engine": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsSnapshot).GetEngine()).ToDataRes(types.String)
 	},
+	"aws.rds.snapshot.engineVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsSnapshot).GetEngineVersion()).ToDataRes(types.String)
+	},
 	"aws.rds.snapshot.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsSnapshot).GetStatus()).ToDataRes(types.String)
 	},
 	"aws.rds.snapshot.allocatedStorage": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsSnapshot).GetAllocatedStorage()).ToDataRes(types.Int)
+	},
+	"aws.rds.snapshot.port": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsSnapshot).GetPort()).ToDataRes(types.Int)
+	},
+	"aws.rds.snapshot.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsSnapshot).GetCreatedAt()).ToDataRes(types.Time)
 	},
 	"aws.rds.dbinstance.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbinstance).GetArn()).ToDataRes(types.String)
@@ -6801,12 +6810,24 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsRdsSnapshot).Engine, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.rds.snapshot.engineVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsSnapshot).EngineVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.rds.snapshot.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsSnapshot).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.rds.snapshot.allocatedStorage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsSnapshot).AllocatedStorage, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.rds.snapshot.port": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsSnapshot).Port, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.rds.snapshot.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsSnapshot).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.rds.dbinstance.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -17737,8 +17758,11 @@ type mqlAwsRdsSnapshot struct {
 	IsClusterSnapshot plugin.TValue[bool]
 	Tags plugin.TValue[map[string]interface{}]
 	Engine plugin.TValue[string]
+	EngineVersion plugin.TValue[string]
 	Status plugin.TValue[string]
 	AllocatedStorage plugin.TValue[int64]
+	Port plugin.TValue[int64]
+	CreatedAt plugin.TValue[*time.Time]
 }
 
 // createAwsRdsSnapshot creates a new instance of this resource
@@ -17816,12 +17840,24 @@ func (c *mqlAwsRdsSnapshot) GetEngine() *plugin.TValue[string] {
 	return &c.Engine
 }
 
+func (c *mqlAwsRdsSnapshot) GetEngineVersion() *plugin.TValue[string] {
+	return &c.EngineVersion
+}
+
 func (c *mqlAwsRdsSnapshot) GetStatus() *plugin.TValue[string] {
 	return &c.Status
 }
 
 func (c *mqlAwsRdsSnapshot) GetAllocatedStorage() *plugin.TValue[int64] {
 	return &c.AllocatedStorage
+}
+
+func (c *mqlAwsRdsSnapshot) GetPort() *plugin.TValue[int64] {
+	return &c.Port
+}
+
+func (c *mqlAwsRdsSnapshot) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
 }
 
 // mqlAwsRdsDbinstance for the aws.rds.dbinstance resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -92,9 +92,9 @@ resources:
       title: Return the account ID (number) and any configured account aliases
   aws.acm:
     docs:
-      desc: Use the `aws.acm` resource to assess the configuration of the
-        AWS Certificates Manager service in the account. This resource returns
-        a list of ACM certificates found in the account.
+      desc: Use the `aws.acm` resource to assess the configuration of the AWS Certificates
+        Manager service in the account. This resource returns a list of ACM certificates
+        found in the account.
     fields:
       certificates: {}
     min_mondoo_version: 5.15.0
@@ -153,8 +153,8 @@ resources:
       - aws
   aws.apigateway:
     docs:
-      desc: Use the `aws.apigateway` resource to assess the configuration
-        of the AWS API Gateway service.
+      desc: Use the `aws.apigateway` resource to assess the configuration of the AWS
+        API Gateway service.
     fields:
       restApis: {}
     min_mondoo_version: 5.15.0
@@ -291,13 +291,12 @@ resources:
     snippets:
     - query: "aws.autoscaling.groups { \n  arn \n  healthCheckType \n  loadBalancerNames
         \n  name \n}\n"
-      title: Return a list of all auto-scaling groups configured across all 
-        enabled regions across the account and
-        the values for specified fields
+      title: Return a list of all auto-scaling groups configured across all enabled
+        regions across the account and the values for specified fields
     - query: "aws.autoscaling.groups.where(loadBalancerNames.length > 0) { \n  healthCheckType
         == \"ELB\" \n}\n"
-      title: Check that all autoscaling groups associated with a load balancer use health
-        checks
+      title: Check that all autoscaling groups associated with a load balancer use
+        health checks
   aws.autoscaling.group:
     docs:
       desc: |
@@ -342,12 +341,11 @@ resources:
     - title: What is AWS Backup?
       url: https://docs.aws.amazon.com/aws-backup/latest/devguide/whatisbackup.html
     - title: Compliance validation for AWS Backup
-      url: https://docs.aws.amazon.com/aws-backup/latest/devguide/backup-compliance.html  
+      url: https://docs.aws.amazon.com/aws-backup/latest/devguide/backup-compliance.html
     snippets:
-    - query: "aws.backup.vaults { \n  arn \n  region \n  recoveryPoints
-        \n  name \n}\n"
-      title: Return a list of all AWS Backup vaults configured across all 
-        enabled regions across the account and all their recovery points
+    - query: "aws.backup.vaults { \n  arn \n  region \n  recoveryPoints \n  name \n}\n"
+      title: Return a list of all AWS Backup vaults configured across all enabled
+        regions across the account and all their recovery points
   aws.backup.vault:
     docs:
       desc: |
@@ -624,8 +622,8 @@ resources:
       - aws
   aws.codebuild:
     docs:
-      desc: "Use the `aws.codebuild` resource to assess the configuration of the
-        AWS CodeBuild service and the projects within. \n"
+      desc: "Use the `aws.codebuild` resource to assess the configuration of the AWS
+        CodeBuild service and the projects within. \n"
     fields:
       projects: {}
     min_mondoo_version: 5.15.0
@@ -655,8 +653,7 @@ resources:
         AWS_SECRET_ACCESS_KEY are not in plaintext
     - query: "aws.codebuild.projects.where( source['Type'] == \"BITBUCKET\" || source['Type']
         == \"GITHUB\" ) { \n  source['Auth']['Type'] == \"OAUTH\"\n}\n"
-      title: Check that all projects using GitHub or Bitbucket as the source use
-        oauth
+      title: Check that all projects using GitHub or Bitbucket as the source use oauth
   aws.codebuild.project:
     docs:
       desc: |
@@ -1411,8 +1408,8 @@ resources:
       - aws
   aws.elasticache:
     docs:
-      desc: "Use the `aws.elasticache` resource to assess the configuration
-        of Amazon ElastiCache. \n"
+      desc: "Use the `aws.elasticache` resource to assess the configuration of Amazon
+        ElastiCache. \n"
     fields:
       cacheClusters: {}
       clusters: {}
@@ -1508,8 +1505,8 @@ resources:
         load balancer http listeners
     - query: "aws.elb.classicLoadBalancers.all( listenerDescriptions.any ( \n  _['Listener']['Protocol']
         == \"HTTPS\" || _['Listener']['Protocol'] == \"SSL\" ) \n)\n"
-      title: Check that all Classic Load Balancers use SSL certificates provided
-        by AWS Cert Mgr
+      title: Check that all Classic Load Balancers use SSL certificates provided by
+        AWS Cert Mgr
   aws.elb.loadbalancer:
     docs:
       desc: |
@@ -1850,8 +1847,8 @@ resources:
       - aws
   aws.kms:
     docs:
-      desc: "Use the `aws.kms` resource to assess the configuration of AWS
-        KMS keys. \n"
+      desc: "Use the `aws.kms` resource to assess the configuration of AWS KMS keys.
+        \n"
     fields:
       keys: {}
     min_mondoo_version: 5.15.0
@@ -1879,8 +1876,8 @@ resources:
       - aws
   aws.lambda:
     docs:
-      desc: "Use the `aws.lambda` resource to assess the configuration of
-        AWS Lambda. \n"
+      desc: "Use the `aws.lambda` resource to assess the configuration of AWS Lambda.
+        \n"
     fields:
       functions: {}
     min_mondoo_version: 5.15.0
@@ -2052,11 +2049,17 @@ resources:
         min_mondoo_version: 9.0.0
       arn: {}
       attributes: {}
+      createdAt:
+        min_mondoo_version: 10.0.0
       encrypted: {}
       engine:
         min_mondoo_version: 9.0.0
+      engineVersion:
+        min_mondoo_version: 10.0.0
       id: {}
       isClusterSnapshot: {}
+      port:
+        min_mondoo_version: 10.0.0
       region: {}
       status:
         min_mondoo_version: 9.0.0

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -318,16 +318,19 @@ func (a *mqlAwsRdsDbcluster) snapshots() ([]interface{}, error) {
 		for _, snapshot := range snapshots.DBClusterSnapshots {
 			mqlDbSnapshot, err := CreateResource(a.MqlRuntime, "aws.rds.snapshot",
 				map[string]*llx.RawData{
-					"arn":               llx.StringDataPtr(snapshot.DBClusterSnapshotArn),
-					"id":                llx.StringDataPtr(snapshot.DBClusterSnapshotIdentifier),
-					"type":              llx.StringDataPtr(snapshot.SnapshotType),
-					"region":            llx.StringData(region),
-					"encrypted":         llx.BoolDataPtr(snapshot.StorageEncrypted),
-					"isClusterSnapshot": llx.BoolData(true),
-					"tags":              llx.MapData(rdsTagsToMap(snapshot.TagList), types.String),
-					"engine":            llx.StringDataPtr(snapshot.Engine),
-					"status":            llx.StringDataPtr(snapshot.Status),
 					"allocatedStorage":  llx.IntData(convert.ToInt64From32(snapshot.AllocatedStorage)),
+					"arn":               llx.StringDataPtr(snapshot.DBClusterSnapshotArn),
+					"createdAt":         llx.TimeDataPtr(snapshot.SnapshotCreateTime),
+					"encrypted":         llx.BoolDataPtr(snapshot.StorageEncrypted),
+					"engine":            llx.StringDataPtr(snapshot.Engine),
+					"engineVersion":     llx.StringDataPtr(snapshot.EngineVersion),
+					"id":                llx.StringDataPtr(snapshot.DBClusterSnapshotIdentifier),
+					"port":              llx.IntData(convert.ToInt64From32(snapshot.Port)),
+					"isClusterSnapshot": llx.BoolData(true),
+					"region":            llx.StringData(region),
+					"status":            llx.StringDataPtr(snapshot.Status),
+					"tags":              llx.MapData(rdsTagsToMap(snapshot.TagList), types.String),
+					"type":              llx.StringDataPtr(snapshot.SnapshotType),
 				})
 			if err != nil {
 				return nil, err
@@ -360,16 +363,19 @@ func (a *mqlAwsRdsDbinstance) snapshots() ([]interface{}, error) {
 		for _, snapshot := range snapshots.DBSnapshots {
 			mqlDbSnapshot, err := CreateResource(a.MqlRuntime, "aws.rds.snapshot",
 				map[string]*llx.RawData{
-					"arn":               llx.StringDataPtr(snapshot.DBSnapshotArn),
-					"id":                llx.StringDataPtr(snapshot.DBSnapshotIdentifier),
-					"type":              llx.StringDataPtr(snapshot.SnapshotType),
-					"region":            llx.StringData(region),
-					"encrypted":         llx.BoolDataPtr(snapshot.Encrypted),
-					"isClusterSnapshot": llx.BoolData(false),
-					"tags":              llx.MapData(rdsTagsToMap(snapshot.TagList), types.String),
-					"engine":            llx.StringDataPtr(snapshot.Engine),
-					"status":            llx.StringDataPtr(snapshot.Status),
 					"allocatedStorage":  llx.IntData(convert.ToInt64From32(snapshot.AllocatedStorage)),
+					"arn":               llx.StringDataPtr(snapshot.DBSnapshotArn),
+					"createdAt":         llx.TimeDataPtr(snapshot.SnapshotCreateTime),
+					"encrypted":         llx.BoolDataPtr(snapshot.Encrypted),
+					"engine":            llx.StringDataPtr(snapshot.Engine),
+					"engineVersion":     llx.StringDataPtr(snapshot.EngineVersion),
+					"id":                llx.StringDataPtr(snapshot.DBSnapshotIdentifier),
+					"port":              llx.IntData(convert.ToInt64From32(snapshot.Port)),
+					"isClusterSnapshot": llx.BoolData(false),
+					"region":            llx.StringData(region),
+					"status":            llx.StringDataPtr(snapshot.Status),
+					"tags":              llx.MapData(rdsTagsToMap(snapshot.TagList), types.String),
+					"type":              llx.StringDataPtr(snapshot.SnapshotType),
 				})
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
The most useful is the create date of the snapshot, but this also adds useful things like the version of the engine and the port the DB was running on.

Improved output of default within a RDS DB instance:

```coffee
aws.rds.dbInstances.first: {
  enhancedMonitoringResourceArn: "arn:aws:logs:us-west-2:1234:log-group:RDSOSMetrics:log-stream:db-3WQORXB4LEOQXVQAEI2LUWTPHQ"
  backupRetentionPeriod: 7
  engineVersion: "15.4"
  createdTime: 2024-01-20 19:05:45.311 -0800 PST
  port: 0
  name: null
  status: "available"
  storageAllocated: 100
  storageType: "io1"
  tags: {}
  publiclyAccessible: false
  availabilityZone: "us-west-2c"
  region: "us-west-2"
  securityGroups: [
    0: aws.ec2.securitygroup id="sg-6b43f159" name="default" region="us-west-2" vpc.id="vpc-ffa59787"
  ]
  storageIops: 1000
  engine: "postgres"
  endpoint: "database-1.cvpi3ygjru5b.us-west-2.rds.amazonaws.com"
  enabledCloudwatchLogsExports: []
  snapshots: [
    0: aws.rds.snapshot id="rds:database-1-2024-01-21-03-07" region="us-west-2" type="automated" encrypted=true createdAt=2024-01-20 19:07:09.281 -0800 PST
    1: aws.rds.snapshot id="timsnapshot" region="us-west-2" type="manual" encrypted=true createdAt=2024-01-20 19:18:03.897 -0800 PST
  ]
  multiAZ: false
  arn: "arn:aws:rds:us-west-2:1234:db:database-1"
  storageEncrypted: true
  dbInstanceIdentifier: "database-1"
  deletionProtection: false
  dbInstanceClass: "db.t3.micro"
  id: "database-1"
  autoMinorVersionUpgrade: true
}
```


Complete output of the snapshot:

```coffee
aws.rds.dbInstances.first.snapshots.first: {
  type: "automated"
  encrypted: true
  attributes: [
    0: {
      AttributeName: "restore"
      AttributeValues: []
    }
  ]
  engineVersion: "15.4"
  createdAt: 2024-01-20 19:07:09.281 -0800 PST
  port: 5432
  engine: "postgres"
  allocatedStorage: 100
  id: "rds:database-1-2024-01-21-03-07"
  tags: {}
  arn: "arn:aws:rds:us-west-2:1234:snapshot:rds:database-1-2024-01-21-03-07"
  region: "us-west-2"
  isClusterSnapshot: false
  status: "available"
}
```