### PR TITLE
🧹 ensure example query packs pass our own lint requirements

### DIFF
--- a/apps/cnquery/cmd/bundle.go
+++ b/apps/cnquery/cmd/bundle.go
@@ -8,7 +8,6 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
-	"strconv"
 
 	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
@@ -17,6 +16,7 @@ import (
 	"go.mondoo.com/cnquery/v10/cli/config"
 	cli_errors "go.mondoo.com/cnquery/v10/cli/errors"
 	"go.mondoo.com/cnquery/v10/explorer"
+	"go.mondoo.com/cnquery/v10/internal/bundle"
 	"go.mondoo.com/cnquery/v10/providers"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/upstream"
 	"go.mondoo.com/cnquery/v10/utils/stringx"
@@ -69,49 +69,6 @@ var queryPackInitCmd = &cobra.Command{
 	},
 }
 
-func validate(queryPackBundle *explorer.Bundle) []string {
-	errors := []string{}
-
-	// check that we have uids for packs and queries
-	for i := range queryPackBundle.Packs {
-		pack := queryPackBundle.Packs[i]
-		packId := strconv.Itoa(i)
-
-		if pack.Uid == "" {
-			errors = append(errors, fmt.Sprintf("pack %s does not define a uid", packId))
-		} else {
-			packId = pack.Uid
-		}
-
-		if pack.Name == "" {
-			errors = append(errors, fmt.Sprintf("pack %s does not define a name", packId))
-		}
-
-		for j := range pack.Queries {
-			query := pack.Queries[j]
-			queryId := strconv.Itoa(j)
-			if query.Uid == "" {
-				errors = append(errors, fmt.Sprintf("query %s/%s does not define a uid", packId, queryId))
-			} else {
-				queryId = query.Uid
-			}
-
-			if query.Title == "" {
-				errors = append(errors, fmt.Sprintf("query %s/%s does not define a name", packId, queryId))
-			}
-		}
-	}
-
-	// we compile after the checks because it removes the uids and replaces it with mrns
-	schema := providers.DefaultRuntime().Schema()
-	_, err := queryPackBundle.Compile(context.Background(), schema)
-	if err != nil {
-		errors = append(errors, "could not compile the query pack bundle", err.Error())
-	}
-
-	return errors
-}
-
 // ensureProviders ensures that all providers are locally installed
 func ensureProviders() error {
 	for _, v := range providers.DefaultProviders {
@@ -139,7 +96,7 @@ var queryPackLintCmd = &cobra.Command{
 			return cli_errors.NewCommandError(errors.Wrap(err, "could not load query pack"), 1)
 		}
 
-		errors := validate(queryPackBundle)
+		errors := bundle.Lint(queryPackBundle)
 		if len(errors) > 0 {
 			log.Error().Msg("could not validate query pack")
 			for i := range errors {
@@ -177,7 +134,7 @@ var queryPackPublishCmd = &cobra.Command{
 			return cli_errors.NewCommandError(errors.Wrap(err, "could not load query pack bundle"), 1)
 		}
 
-		bundleErrors := validate(queryPackBundle)
+		bundleErrors := bundle.Lint(queryPackBundle)
 		if len(bundleErrors) > 0 {
 			log.Error().Msg("could not validate query pack")
 			for i := range bundleErrors {

--- a/examples/complex.mql.yaml
+++ b/examples/complex.mql.yaml
@@ -5,6 +5,7 @@
 # show off some of the more advanced features. It is meant as a demo only.
 packs:
 - uid: mixed-os
+  name: Sample OS Query Pack for Linux and macOS
   filters:
   - asset.family.contains("unix")
 

--- a/examples/k8s.mql.yaml
+++ b/examples/k8s.mql.yaml
@@ -3,6 +3,7 @@
 
 packs:
   - uid: kubernetes-pod-security-info
+    name: Kubernetes Pod Security Info
     filters:
       - asset.platform == "k8s-pod"
     queries:

--- a/examples/lint_test.go
+++ b/examples/lint_test.go
@@ -1,0 +1,20 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package examples
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/v10/explorer"
+	"go.mondoo.com/cnquery/v10/internal/bundle"
+	"testing"
+)
+
+func TestExampleLint(t *testing.T) {
+	queryPackBundle, err := explorer.BundleFromPaths(".")
+	require.NoError(t, err)
+
+	lintErr := bundle.Lint(queryPackBundle)
+	assert.Equal(t, []string{}, lintErr)
+}

--- a/examples/lint_test.go
+++ b/examples/lint_test.go
@@ -8,10 +8,47 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/cnquery/v10/explorer"
 	"go.mondoo.com/cnquery/v10/internal/bundle"
+	"go.mondoo.com/cnquery/v10/providers"
+	"os"
 	"testing"
 )
 
+func ensureProviders(ids []string) error {
+	for _, id := range ids {
+		_, err := providers.EnsureProvider(providers.ProviderLookup{ID: id}, true, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestMain(m *testing.M) {
+	dir := ".lint-providers"
+	providers.CustomProviderPath = dir
+	providers.DefaultPath = dir
+
+	err := ensureProviders([]string{
+		"go.mondoo.com/cnquery/providers/os",
+		"go.mondoo.com/cnquery/providers/k8s",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	exitVal := m.Run()
+
+	// cleanup custom provider path to ensure no leftovers and other tests are not affected
+	err = os.RemoveAll(dir)
+	if err != nil {
+		panic(err)
+	}
+
+	os.Exit(exitVal)
+}
+
 func TestExampleLint(t *testing.T) {
+
 	queryPackBundle, err := explorer.BundleFromPaths(".")
 	require.NoError(t, err)
 

--- a/examples/os.mql.yaml
+++ b/examples/os.mql.yaml
@@ -3,6 +3,7 @@
 
 packs:
 - uid: linux-mixed-queries
+  name: Linux Mixed Queries
   filters:
   - asset.family.contains("unix")
 

--- a/internal/bundle/lint.go
+++ b/internal/bundle/lint.go
@@ -1,0 +1,55 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package bundle
+
+import (
+	"context"
+	"fmt"
+	"go.mondoo.com/cnquery/v10/explorer"
+	"go.mondoo.com/cnquery/v10/providers"
+	"strconv"
+)
+
+func Lint(queryPackBundle *explorer.Bundle) []string {
+	errors := []string{}
+
+	// check that we have uids for packs and queries
+	for i := range queryPackBundle.Packs {
+		pack := queryPackBundle.Packs[i]
+		packId := strconv.Itoa(i)
+
+		if pack.Uid == "" {
+			errors = append(errors, fmt.Sprintf("pack %s does not define a uid", packId))
+		} else {
+			packId = pack.Uid
+		}
+
+		if pack.Name == "" {
+			errors = append(errors, fmt.Sprintf("pack %s does not define a name", packId))
+		}
+
+		for j := range pack.Queries {
+			query := pack.Queries[j]
+			queryId := strconv.Itoa(j)
+			if query.Uid == "" {
+				errors = append(errors, fmt.Sprintf("query %s/%s does not define a uid", packId, queryId))
+			} else {
+				queryId = query.Uid
+			}
+
+			if query.Title == "" {
+				errors = append(errors, fmt.Sprintf("query %s/%s does not define a name", packId, queryId))
+			}
+		}
+	}
+
+	// we compile after the checks because it removes the uids and replaces it with mrns
+	schema := providers.DefaultRuntime().Schema()
+	_, err := queryPackBundle.Compile(context.Background(), schema)
+	if err != nil {
+		errors = append(errors, "could not compile the query pack bundle", err.Error())
+	}
+
+	return errors
+}


### PR DESCRIPTION
Use our lint requirements to validate our examples. To make this work, we temporarily install the required providers and remove them afterwards. This ensures that other tests like cli tests are not affected by the providers we need here.