### PR TITLE
🐛 Add id function for sql service firewall rules.

### DIFF
--- a/providers/azure/resources/sql.go
+++ b/providers/azure/resources/sql.go
@@ -56,6 +56,10 @@ func (a *mqlAzureSubscriptionSqlServiceServerVulnerabilityassessmentsettings) id
 	return a.Id.Data, nil
 }
 
+func (a *mqlAzureSubscriptionSqlServiceFirewallrule) id() (string, error) {
+	return a.Id.Data, nil
+}
+
 func (a *mqlAzureSubscriptionSqlService) servers() ([]interface{}, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	ctx := context.Background()


### PR DESCRIPTION
Fixes #3088

```
cnquery> azure.subscription.sql.servers[0].firewallRules
azure.subscription.sql.servers[0].firewallRules: [
  0: azure.subscription.sqlService.firewallrule id="/subscriptions/e9ee8090-9784-42d6-9534-bc1d881eeff6/resourceGroups/Security-Team-resources-aqla/providers/Microsoft.Sql/servers/security-team-sql-server1-90sq/firewallRules/ClientIPAddress1" name="ClientIPAddress1"
  1: azure.subscription.sqlService.firewallrule id="/subscriptions/e9ee8090-9784-42d6-9534-bc1d881eeff6/resourceGroups/Security-Team-resources-aqla/providers/Microsoft.Sql/servers/security-team-sql-server1-90sq/firewallRules/range2" name="range2"
  2: azure.subscription.sqlService.firewallrule id="/subscriptions/e9ee8090-9784-42d6-9534-bc1d881eeff6/resourceGroups/Security-Team-resources-aqla/providers/Microsoft.Sql/servers/security-team-sql-server1-90sq/firewallRules/test-qlserver-rule-1" name="test-qlserver-rule-1"
]
```