### PR TITLE
🐛 fix findfile capability for providers

### DIFF
--- a/providers/os/connection/fs/filesystem.go
+++ b/providers/os/connection/fs/filesystem.go
@@ -92,7 +92,7 @@ func (c *FileSystemConnection) Close() {
 }
 
 func (c *FileSystemConnection) Capabilities() shared.Capabilities {
-	return shared.Capability_FileSearch | shared.Capability_File
+	return shared.Capability_FileSearch | shared.Capability_File | shared.Capability_FindFile
 }
 
 func (c *FileSystemConnection) Identifier() (string, error) {

--- a/providers/os/connection/tar.go
+++ b/providers/os/connection/tar.go
@@ -73,7 +73,7 @@ func (c *TarConnection) Identifier() (string, error) {
 }
 
 func (c *TarConnection) Capabilities() shared.Capabilities {
-	return shared.Capability_File | shared.Capability_FileSearch
+	return shared.Capability_File | shared.Capability_FileSearch | shared.Capability_FindFile
 }
 
 func (p *TarConnection) RunCommand(command string) (*shared.Command, error) {


### PR DESCRIPTION
The capability wasn't added to the 2 connections that actually implement this.

fixes #3101 

```
cnspec shell container image ubuntu:latest
→ loaded configuration from /Users/ivanmilchev/.config/mondoo/mondoo.yml using source default
→ connected to Ubuntu 22.04.3 LTS
  ___ _ __  ___ _ __   ___  ___ 
 / __| '_ \/ __| '_ \ / _ \/ __|
| (__| | | \__ \ |_) |  __/ (__ 
 \___|_| |_|___/ .__/ \___|\___|
   mondoo™     |_|              
cnspec> files.find()
files.find.list: []
```