### PR TITLE
🐛 fix crash on empty array.flat with missing type info

### DIFF
--- a/llx/builtin_array.go
+++ b/llx/builtin_array.go
@@ -462,6 +462,10 @@ func arrayFlat(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawD
 	typ := bind.Type
 	for typ.IsArray() {
 		typ = typ.Child()
+		if typ.NotSet() {
+			typ = types.Any
+			break
+		}
 	}
 
 	return &RawData{Type: types.Array(typ), Value: res}, 0, nil

--- a/llx/builtin_array_test.go
+++ b/llx/builtin_array_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package llx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/v10/types"
+)
+
+func TestArrayFlat(t *testing.T) {
+	t.Run("empty array with missing type info", func(t *testing.T) {
+		res, ref, err := arrayFlat(nil, &RawData{
+			Type:  types.ArrayLike,
+			Value: []any{},
+		}, nil, 0)
+		require.NoError(t, err)
+		require.Equal(t, uint64(0), ref)
+		require.Equal(t, ArrayData(nil, types.Any), res)
+	})
+}


### PR DESCRIPTION
This can unfortunately still happen, where the type info is missing and we essentially get the array indication in the type field, but nothing else. The subsequent for loop then crashes it.

Add testing for this use-case and fix the crash by forcing the any-type into it.