### PR TITLE
🧹 Do not query the sources for scans

### DIFF
--- a/providers-sdk/v1/upstream/gql/vulnmgmt_gql.go
+++ b/providers-sdk/v1/upstream/gql/vulnmgmt_gql.go
@@ -74,12 +74,7 @@ type ReportStats struct {
 }
 
 type Cve struct {
-	Id     string
-	Source struct {
-		Id   string
-		Name string
-		Url  string
-	}
+	Id          string
 	Title       string
 	Description string
 	Summary     string
@@ -105,12 +100,7 @@ type Cve struct {
 }
 
 type Advisory struct {
-	Id     string
-	Source struct {
-		Id   string
-		Name string
-		Url  string
-	}
+	Id          string
 	Title       string
 	Description string
 


### PR DESCRIPTION
We do not need to query the sources for advisories and CVEs as we do not use the data.