### PR TITLE
🧹 log the error that caused a provider to be unavailable

### DIFF
--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -421,7 +421,7 @@ func (r *Runtime) handlePluginError(err error, provider *ConnectedProvider) (boo
 		// Error: Unavailable. Happens when the plugin crashes.
 		// TODO: try to restart the plugin and reset its connections
 		provider.Instance.isClosed = true
-		provider.Instance.err = errors.New("the '" + provider.Instance.Name + "' provider crashed")
+		provider.Instance.err = errors.New("the '" + provider.Instance.Name + "' provider crashed: " + err.Error())
 		return false, provider.Instance.err
 	}
 	return false, err


### PR DESCRIPTION
sometimes we have seen this error in the logs while scanning. However, the actual error message causing the provider to shutdown isn't printed. This should help investigate the issue further