### PR TITLE
🐛 return proper error when no provider could be detected

### DIFF
--- a/providers/providers.go
+++ b/providers/providers.go
@@ -285,6 +285,14 @@ func ListAll() ([]*Provider, error) {
 	return res, nil
 }
 
+type ProviderNotFoundError struct {
+	lookup ProviderLookup
+}
+
+func (e *ProviderNotFoundError) Error() string {
+	return "cannot find provider for " + e.lookup.String()
+}
+
 // EnsureProvider makes sure that a given provider exists and returns it.
 // You can supply providers either via:
 //  1. providerID, which universally identifies it, e.g. "go.mondoo.com/cnquery/v10/providers/os"
@@ -319,7 +327,7 @@ func EnsureProvider(search ProviderLookup, autoUpdate bool, existing Providers) 
 	if upstream == nil {
 		// we can't find any provider for this connector in our default set
 		// FIXME: This causes a panic in the CLI, we should handle this better
-		return nil, nil
+		return nil, &ProviderNotFoundError{lookup: search}
 	}
 
 	if !autoUpdate {


### PR DESCRIPTION
The `DetectProvider` https://github.com/mondoohq/cnquery/blob/main/providers/runtime.go#L168C1-L178C2 relies on the fact that we either have an error or a proper provider object. 

```go
// DetectProvider will try to detect and start the right provider for this
// runtime. Generally recommended when you receive an asset to be scanned,
// but haven't initialized any provider. It will also try to install providers
// if necessary (and enabled)
func (r *Runtime) DetectProvider(asset *inventory.Asset) error {
	provider, err := r.providerForAsset(asset)
	if err != nil {
		return err
	}
	return r.UseProvider(provider.ID)
}
```

Turns out this was not always the case. `EnsureProvider` has a case where it returns `nil, nil`. This changes the logic to make the error explicit https://github.com/mondoohq/cnquery/blob/main/providers/providers.go#L318-L323.