### PR TITLE
🧹 refactor os connection types

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -5,7 +5,7 @@ package config
 
 import (
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/plugin"
-	"go.mondoo.com/cnquery/v10/providers/os/provider"
+	"go.mondoo.com/cnquery/v10/providers/os/connection/shared"
 	"go.mondoo.com/cnquery/v10/providers/os/resources/discovery/docker_engine"
 )
 
@@ -14,17 +14,17 @@ var Config = plugin.Provider{
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
 	Version: "10.0.1",
 	ConnectionTypes: []string{
-		provider.LocalConnectionType,
-		provider.SshConnectionType,
-		provider.TarConnectionType,
-		provider.DockerSnapshotConnectionType,
-		provider.VagrantConnectionType,
-		provider.DockerImageConnectionType,
-		provider.DockerContainerConnectionType,
-		provider.DockerRegistryConnectionType,
-		provider.ContainerRegistryConnectionType,
-		provider.RegistryImageConnectionType,
-		provider.FilesystemConnectionType,
+		shared.Type_Local.String(),
+		shared.Type_SSH.String(),
+		shared.Type_Tar.String(),
+		shared.Type_DockerSnapshot.String(),
+		shared.Type_Vagrant.String(),
+		shared.Type_DockerImage.String(),
+		shared.Type_DockerContainer.String(),
+		shared.Type_DockerRegistry.String(),
+		shared.Type_ContainerRegistry.String(),
+		shared.Type_RegistryImage.String(),
+		shared.Type_FileSystem.String(),
 	},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/os/connection/shared/shared.go
+++ b/providers/os/connection/shared/shared.go
@@ -18,17 +18,28 @@ import (
 
 type ConnectionType string
 
+func (ct ConnectionType) String() string {
+	return string(ct)
+}
+
 // Note: We generally prefer to have the types close with their connections,
 // however the detectors would then have to pull in every connection as a
 // dependency with all their code, just to check if the type is e.g. local
 // or ssh. Keeping them in shared is more annoying (coding-wise), but
 // keeps the dependency-graph very small.
 const (
-	Type_Local          ConnectionType = "local"
-	Type_SSH            ConnectionType = "ssh"
-	Type_Tar            ConnectionType = "tar"
-	Type_FileSystem     ConnectionType = "filesystem"
-	Type_DockerSnapshot ConnectionType = "docker-snapshot"
+	Type_Local             ConnectionType = "local"
+	Type_SSH               ConnectionType = "ssh"
+	Type_Tar               ConnectionType = "tar"
+	Type_FileSystem        ConnectionType = "filesystem"
+	Type_DockerSnapshot    ConnectionType = "docker-snapshot"
+	Type_Winrm             ConnectionType = "winrm"
+	Type_Vagrant           ConnectionType = "vagrant"
+	Type_DockerImage       ConnectionType = "docker-image"
+	Type_DockerContainer   ConnectionType = "docker-container"
+	Type_DockerRegistry    ConnectionType = "docker-registry"
+	Type_ContainerRegistry ConnectionType = "container-registry"
+	Type_RegistryImage     ConnectionType = "registry-image"
 )
 
 type Connection interface {

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -28,20 +28,6 @@ import (
 	"go.mondoo.com/cnquery/v10/utils/stringx"
 )
 
-const (
-	LocalConnectionType             = "local"
-	SshConnectionType               = "ssh"
-	TarConnectionType               = "tar"
-	DockerSnapshotConnectionType    = "docker-snapshot"
-	VagrantConnectionType           = "vagrant"
-	DockerImageConnectionType       = "docker-image"
-	DockerContainerConnectionType   = "docker-container"
-	DockerRegistryConnectionType    = "docker-registry"
-	ContainerRegistryConnectionType = "container-registry"
-	RegistryImageConnectionType     = "registry-image"
-	FilesystemConnectionType        = "filesystem"
-)
-
 type Service struct {
 	plugin.Service
 	runtimes         map[uint32]*plugin.Runtime
@@ -320,7 +306,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	var err error
 
 	switch conf.Type {
-	case LocalConnectionType:
+	case shared.Type_Local.String():
 		s.lastConnectionID++
 		conn = local.NewConnection(s.lastConnectionID, conf, asset)
 
@@ -331,7 +317,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 			asset.IdDetector = fingerprint.ActiveIdDetectors
 		}
 
-	case SshConnectionType:
+	case shared.Type_SSH.String():
 		s.lastConnectionID++
 		conn, err = connection.NewSshConnection(s.lastConnectionID, conf, asset)
 		if err != nil {
@@ -347,7 +333,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 			asset.IdDetector = fingerprint.ActiveIdDetectors
 		}
 
-	case TarConnectionType:
+	case shared.Type_Tar.String():
 		s.lastConnectionID++
 		conn, err = connection.NewTarConnection(s.lastConnectionID, conf, asset)
 		if err != nil {
@@ -361,7 +347,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 			asset.IdDetector = fingerprint.ActiveIdDetectors
 		}
 
-	case DockerSnapshotConnectionType:
+	case shared.Type_DockerSnapshot.String():
 		s.lastConnectionID++
 		conn, err = connection.NewDockerSnapshotConnection(s.lastConnectionID, conf, asset)
 		if err != nil {
@@ -375,7 +361,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 			asset.IdDetector = fingerprint.ActiveIdDetectors
 		}
 
-	case VagrantConnectionType:
+	case shared.Type_Vagrant.String():
 		s.lastConnectionID++
 		conn, err = connection.NewVagrantConnection(s.lastConnectionID, conf, asset)
 		if err != nil {
@@ -388,23 +374,23 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 			return nil, err
 		}
 
-	case DockerImageConnectionType:
+	case shared.Type_DockerImage.String():
 		s.lastConnectionID++
 		conn, err = connection.NewDockerContainerImageConnection(s.lastConnectionID, conf, asset)
 
-	case DockerContainerConnectionType:
+	case shared.Type_DockerContainer.String():
 		s.lastConnectionID++
 		conn, err = connection.NewDockerEngineContainer(s.lastConnectionID, conf, asset)
 
-	case DockerRegistryConnectionType, ContainerRegistryConnectionType:
+	case shared.Type_DockerRegistry.String(), shared.Type_ContainerRegistry.String():
 		s.lastConnectionID++
 		conn, err = connection.NewContainerRegistryImage(s.lastConnectionID, conf, asset)
 
-	case RegistryImageConnectionType:
+	case shared.Type_RegistryImage.String():
 		s.lastConnectionID++
 		conn, err = connection.NewContainerRegistryImage(s.lastConnectionID, conf, asset)
 
-	case FilesystemConnectionType:
+	case shared.Type_FileSystem.String():
 		s.lastConnectionID++
 		conn, err = fs.NewConnection(s.lastConnectionID, conf, asset)
 		if err != nil {


### PR DESCRIPTION
The os provider had two places where connection types where defined. This was confusing. The values where the same though. This cleans up the different parts to just use one definition.