### PR TITLE
🎉 arista-9.1.19, atlassian-9.1.19, aws-10.0.2, azure-10.0.4, equinix-…

### DIFF
--- a/providers/arista/config/config.go
+++ b/providers/arista/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "arista",
 	ID:              "go.mondoo.com/cnquery/v9/providers/arista",
-	Version:         "9.1.18",
+	Version:         "9.1.19",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/atlassian/config/config.go
+++ b/providers/atlassian/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "atlassian",
 	ID:      "go.mondoo.com/cnquery/v9/providers/atlassian",
-	Version: "9.1.18",
+	Version: "9.1.19",
 	ConnectionTypes: []string{
 		provider.DefaultConnectionType,
 		"jira",

--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "10.0.1",
+	Version:         "10.0.2",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "azure",
 	ID:      "go.mondoo.com/cnquery/v9/providers/azure",
-	Version: "10.0.3",
+	Version: "10.0.4",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(azureinstancesnapshot.SnapshotConnectionType),

--- a/providers/equinix/config/config.go
+++ b/providers/equinix/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "equinix",
 	ID:              "go.mondoo.com/cnquery/v9/providers/equinix",
-	Version:         "10.0.1",
+	Version:         "10.0.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "10.0.1",
+	Version: "10.0.2",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),

--- a/providers/github/config/config.go
+++ b/providers/github/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "github",
 	ID:              "go.mondoo.com/cnquery/v9/providers/github",
-	Version:         "10.0.1",
+	Version:         "10.0.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/gitlab/config/config.go
+++ b/providers/gitlab/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gitlab",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gitlab",
-	Version: "10.0.1",
+	Version: "10.0.2",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		provider.GitlabGroupConnection,

--- a/providers/google-workspace/config/config.go
+++ b/providers/google-workspace/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "google-workspace",
 	ID:              "go.mondoo.com/cnquery/v9/providers/google-workspace",
-	Version:         "10.0.1",
+	Version:         "10.0.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/ipmi/config/config.go
+++ b/providers/ipmi/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ipmi",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ipmi",
-	Version:         "10.0.1",
+	Version:         "10.0.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "k8s",
 	ID:              "go.mondoo.com/cnquery/v9/providers/k8s",
-	Version:         "10.0.1",
+	Version:         "10.0.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ms365",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ms365",
-	Version:         "10.0.1",
+	Version:         "10.0.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/oci/config/config.go
+++ b/providers/oci/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "oci",
 	ID:              "go.mondoo.com/cnquery/v9/providers/oci",
-	Version:         "10.0.1",
+	Version:         "10.0.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/okta/config/config.go
+++ b/providers/okta/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "okta",
 	ID:              "go.mondoo.com/cnquery/v9/providers/okta",
-	Version:         "10.0.1",
+	Version:         "10.0.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/opcua/config/config.go
+++ b/providers/opcua/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "opcua",
 	ID:              "go.mondoo.com/cnquery/v9/providers/opcua",
-	Version:         "10.0.1",
+	Version:         "10.0.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "10.0.1",
+	Version: "10.0.2",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),

--- a/providers/slack/config/config.go
+++ b/providers/slack/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "slack",
 	ID:              "go.mondoo.com/cnquery/v9/providers/slack",
-	Version:         "10.0.2",
+	Version:         "10.0.3",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/terraform/config/config.go
+++ b/providers/terraform/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "terraform",
 	ID:      "go.mondoo.com/cnquery/v9/providers/terraform",
-	Version: "10.0.1",
+	Version: "10.0.2",
 	ConnectionTypes: []string{
 		provider.StateConnectionType,
 		provider.PlanConnectionType,

--- a/providers/vcd/config/config.go
+++ b/providers/vcd/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vcd",
 	ID:              "go.mondoo.com/cnquery/v9/providers/vcd",
-	Version:         "10.0.1",
+	Version:         "10.0.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/vsphere/config/config.go
+++ b/providers/vsphere/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vsphere",
 	ID:              "go.mondoo.com/cnquery/v9/providers/vsphere",
-	Version:         "10.0.1",
+	Version:         "10.0.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
…10.0.2, gcp-10.0.2, github-10.0.2, gitlab-10.0.2, google-workspace-10.0.2, ipmi-10.0.2, k8s-10.0.2, ms365-10.0.2, oci-10.0.2, okta-10.0.2, opcua-10.0.2, os-10.0.2, slack-10.0.3, terraform-10.0.2, vcd-10.0.2, vsphere-10.0.2

This release was created by cnquery's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.