### PR TITLE
🧹 Retry login command when concurrent IAM updates are detected

### DIFF
--- a/apps/cnquery/cmd/logout.go
+++ b/apps/cnquery/cmd/logout.go
@@ -80,7 +80,7 @@ ensure the credentials cannot be used in the future.
 
 		if !viper.GetBool("force") {
 			log.Info().Msg("are you sure you want to revoke client access to Mondoo Platform? Use --force if you are sure")
-			return cli_errors.ExitCode1WithoutError
+			return cli_errors.NewCommandError(errors.New("--force is required to logout"), ConfigurationErrorCode)
 		}
 
 		// try to load config into credentials struct


### PR DESCRIPTION
If the server returns aborted for RegisterAgent, that means it aborted the change because of concurrent writes to the IAM policy, likely meaning concurrent registrations. Clients are safe to backoff and retry in this case.