### PR TITLE
🐛 report asset errors

### DIFF
--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -127,6 +127,10 @@ var scanCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 	}
 
 	printReports(report, conf, cmd)
+
+	if report != nil && len(report.Errors) > 0 {
+		os.Exit(1)
+	}
 }
 
 // helper method to retrieve the list of query packs for autocomplete

--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -43,6 +43,11 @@ type assetWithRuntime struct {
 	runtime *providers.Runtime
 }
 
+type assetWithError struct {
+	asset *inventory.Asset
+	err   error
+}
+
 type LocalScanner struct {
 	ctx       context.Context
 	fetcher   *fetcher
@@ -188,6 +193,7 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 	var assets []*assetWithRuntime
 	// note: asset candidate runtimes are the runtime that discovered them
 	var assetCandidates []*assetWithRuntime
+	var assetErrors []*assetWithError
 
 	// we connect and perform discovery for each asset in the job inventory
 	for i := range assetList {
@@ -200,6 +206,10 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 		runtime, err := providers.Coordinator.RuntimeFor(asset, providers.DefaultRuntime())
 		if err != nil {
 			log.Error().Err(err).Str("asset", asset.Name).Msg("unable to create runtime for asset")
+			assetErrors = append(assetErrors, &assetWithError{
+				asset: resolvedAsset,
+				err:   err,
+			})
 			continue
 		}
 		runtime.SetRecording(s.recording)
@@ -210,6 +220,10 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 			Upstream: upstream,
 		}); err != nil {
 			log.Error().Err(err).Msg("unable to connect to asset")
+			assetErrors = append(assetErrors, &assetWithError{
+				asset: resolvedAsset,
+				err:   err,
+			})
 			continue
 		}
 		asset = runtime.Provider.Connection.Asset // to ensure we get all the information the connect call gave us
@@ -221,7 +235,11 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 		}
 		processedAssets, err := providers.ProcessAssetCandidates(runtime, runtime.Provider.Connection, upstream, "")
 		if err != nil {
-			return nil, false, err
+			assetErrors = append(assetErrors, &assetWithError{
+				asset: resolvedAsset,
+				err:   err,
+			})
+			continue
 		}
 		for i := range processedAssets {
 			assetCandidates = append(assetCandidates, &assetWithRuntime{
@@ -294,10 +312,6 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 		})
 	}
 
-	if len(assets) == 0 {
-		return nil, false, nil
-	}
-
 	// if there is exactly one asset, assure that the --asset-name is used
 	// TODO: make it so that the --asset-name is set for the root asset only even if multiple assets are there
 	// This is a temporary fix that only works if there is only one asset
@@ -310,6 +324,20 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 	for _, asset := range assets {
 		asset.asset.KindString = asset.asset.GetPlatform().Kind
 		justAssets = append(justAssets, asset.asset)
+	}
+	for _, asset := range assetErrors {
+		justAssets = append(justAssets, asset.asset)
+	}
+
+	// plan scan jobs
+	reporter := NewAggregateReporter(justAssets)
+	// if we had asset errors we want to place them into the reporter
+	for i := range assetErrors {
+		reporter.AddScanError(assetErrors[i].asset, assetErrors[i].err)
+	}
+
+	if len(assets) == 0 {
+		return reporter.Reports(), false, nil
 	}
 
 	// sync assets
@@ -362,8 +390,6 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 		}
 	}
 
-	// plan scan jobs
-	reporter := NewAggregateReporter(justAssets)
 	// if a bundle was provided check that it matches the filter, bundles can also be downloaded
 	// later therefore we do not want to stop execution here
 	if job.Bundle != nil && job.Bundle.FilterQueryPacks(job.QueryPackFilters) {
@@ -376,7 +402,7 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 		// this shouldn't happen, but might
 		// it normally indicates a bug in the provider
 		if presentAsset, present := progressBarElements[assets[i].asset.PlatformIds[0]]; present {
-			return nil, false, fmt.Errorf("asset %s and %s have the same platform id %s", presentAsset, assets[i].asset.Name, assets[i].asset.PlatformIds[0])
+			return reporter.Reports(), false, fmt.Errorf("asset %s and %s have the same platform id %s", presentAsset, assets[i].asset.Name, assets[i].asset.PlatformIds[0])
 		}
 		progressBarElements[assets[i].asset.PlatformIds[0]] = assets[i].asset.Name
 		orderedKeys = append(orderedKeys, assets[i].asset.PlatformIds[0])


### PR DESCRIPTION
This bug was originally reported by @username-is-already-taken2

When cnquery was executed in a pipeline and a connect error happened, we never collected that error and returned a non-zero exit code. That can lead to silent errors.

We always prepared the report structure to collect the errors. This change handles asset errors now.

**before**

```shell
> cnquery scan ssh user@host
x unable to connect to asset error="rpc error: code = Unknown desc = dial tcp: lookup host: no such host"

> echo $?
0

```

**after**

```shell
> cnquery scan ssh user@host

Summary (1 assets)
==================

Target:     
error: rpc error: code = Unknown desc = dial tcp: lookup host: no such host

> echo $?
1

```