### PR TITLE
🐛 fix panic in osRetry logic

### DIFF
--- a/providers/providers.go
+++ b/providers/providers.go
@@ -520,7 +520,7 @@ func osRetry(f func() error, maxRetry int) error {
 			return nil
 		}
 
-		if errors.As(err, syscall.EBUSY) || errors.As(err, syscall.EAGAIN) {
+		if errno, ok := err.(syscall.Errno); ok && errno.Temporary() {
 			time.Sleep(osRetryDuration)
 		} else {
 			return err

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -4,9 +4,11 @@
 package providers
 
 import (
+	"syscall"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/plugin"
 )
@@ -56,4 +58,14 @@ func TestProviderShutdown(t *testing.T) {
 	err = s.Shutdown()
 	require.NoError(t, err)
 	require.True(t, s.isCloseOrShutdown())
+}
+
+func TestOsRetry_RetryableError(t *testing.T) {
+	funcCounter := 0
+	testFunc := func() error {
+		funcCounter++
+		return syscall.EAGAIN
+	}
+	assert.NoError(t, osRetry(testFunc, 2))
+	assert.Equal(t, 2, funcCounter)
 }


### PR DESCRIPTION
The implementation of `errors.As` is using pointers and reflection to do some black magic when checking for error types. This way of comparison isn't compatible with the `syscall.Errno` errors and results in a panic (see the attached issue). This answer gives an example of how to compare the error properly: https://stackoverflow.com/a/64067281

Fixes #3173 