### PR TITLE
🧹 refactor providers coordinator

### DIFF
--- a/apps/cnquery/cmd/login.go
+++ b/apps/cnquery/cmd/login.go
@@ -16,7 +16,6 @@ import (
 	"go.mondoo.com/cnquery/v10"
 	"go.mondoo.com/cnquery/v10/cli/config"
 	cli_errors "go.mondoo.com/cnquery/v10/cli/errors"
-	cnquery_providers "go.mondoo.com/cnquery/v10/providers"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/sysinfo"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/upstream"
 	"go.mondoo.com/ranger-rpc"
@@ -52,7 +51,6 @@ You remain logged in until you explicitly log out using the 'logout' subcommand.
 		viper.BindPFlag("name", cmd.Flags().Lookup("name"))
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		defer cnquery_providers.Coordinator.Shutdown()
 		token, _ := cmd.Flags().GetString("token")
 		annotations, _ := cmd.Flags().GetStringToString("annotation")
 		return register(token, annotations)

--- a/apps/cnquery/cmd/login.go
+++ b/apps/cnquery/cmd/login.go
@@ -16,6 +16,7 @@ import (
 	"go.mondoo.com/cnquery/v10"
 	"go.mondoo.com/cnquery/v10/cli/config"
 	cli_errors "go.mondoo.com/cnquery/v10/cli/errors"
+	cnquery_providers "go.mondoo.com/cnquery/v10/providers"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/sysinfo"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/upstream"
 	"go.mondoo.com/ranger-rpc"
@@ -51,6 +52,7 @@ You remain logged in until you explicitly log out using the 'logout' subcommand.
 		viper.BindPFlag("name", cmd.Flags().Lookup("name"))
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		defer cnquery_providers.GlobalCoordinator.Shutdown()
 		token, _ := cmd.Flags().GetString("token")
 		annotations, _ := cmd.Flags().GetStringToString("annotation")
 		return register(token, annotations)

--- a/apps/cnquery/cmd/logout.go
+++ b/apps/cnquery/cmd/logout.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/viper"
 	"go.mondoo.com/cnquery/v10/cli/config"
 	cli_errors "go.mondoo.com/cnquery/v10/cli/errors"
+	cnquery_providers "go.mondoo.com/cnquery/v10/providers"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/sysinfo"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/upstream"
 	"sigs.k8s.io/yaml"
@@ -35,6 +36,7 @@ ensure the credentials cannot be used in the future.
 		viper.BindPFlag("force", cmd.Flags().Lookup("force"))
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		defer cnquery_providers.GlobalCoordinator.Shutdown()
 		var err error
 
 		// its perfectly fine not to have a config here, therefore we ignore errors

--- a/apps/cnquery/cmd/logout.go
+++ b/apps/cnquery/cmd/logout.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/viper"
 	"go.mondoo.com/cnquery/v10/cli/config"
 	cli_errors "go.mondoo.com/cnquery/v10/cli/errors"
-	cnquery_providers "go.mondoo.com/cnquery/v10/providers"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/sysinfo"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/upstream"
 	"sigs.k8s.io/yaml"
@@ -36,7 +35,6 @@ ensure the credentials cannot be used in the future.
 		viper.BindPFlag("force", cmd.Flags().Lookup("force"))
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		defer cnquery_providers.Coordinator.Shutdown()
 		var err error
 
 		// its perfectly fine not to have a config here, therefore we ignore errors

--- a/apps/cnquery/cmd/plugin.go
+++ b/apps/cnquery/cmd/plugin.go
@@ -130,7 +130,7 @@ func (c *cnqueryPlugin) RunQuery(conf *run.RunQueryConfig, runtime *providers.Ru
 
 	for i := range assets {
 		connectAsset := assets[i]
-		connectAssetRuntime, err := providers.Coordinator.RuntimeFor(connectAsset, runtime)
+		connectAssetRuntime, err := runtime.Coordinator.RuntimeFor(connectAsset, runtime)
 		if err != nil {
 			return err
 		}

--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -157,6 +157,7 @@ type scanConfig struct {
 }
 
 func getCobraScanConfig(cmd *cobra.Command, runtime *providers.Runtime, cliRes *plugin.ParseCLIRes) (*scanConfig, error) {
+	runtime.Coordinator.Stop(runtime.Provider.Instance, false)
 	opts, err := config.Read()
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to load config")

--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -157,7 +157,10 @@ type scanConfig struct {
 }
 
 func getCobraScanConfig(cmd *cobra.Command, runtime *providers.Runtime, cliRes *plugin.ParseCLIRes) (*scanConfig, error) {
-	runtime.Coordinator.Stop(runtime.Provider.Instance, false)
+	// When starting a scan, we don't need the provider instance started by the root.
+	if err := runtime.Coordinator.Stop(runtime.Provider.Instance, false); err != nil {
+		return nil, err
+	}
 	opts, err := config.Read()
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to load config")

--- a/apps/cnquery/cmd/shell.go
+++ b/apps/cnquery/cmd/shell.go
@@ -149,7 +149,7 @@ func StartShell(runtime *providers.Runtime, conf *ShellConfig) error {
 	// when we close the shell, we need to close the backend and store the recording
 	onCloseHandler := func() {
 		runtime.Close()
-		providers.Coordinator.Shutdown()
+		runtime.Coordinator.Shutdown()
 	}
 
 	shellOptions := []shell.ShellOption{}

--- a/apps/cnquery/cmd/shell.go
+++ b/apps/cnquery/cmd/shell.go
@@ -149,7 +149,7 @@ func StartShell(runtime *providers.Runtime, conf *ShellConfig) error {
 	// when we close the shell, we need to close the backend and store the recording
 	onCloseHandler := func() {
 		runtime.Close()
-		runtime.Coordinator.Shutdown()
+		providers.GlobalCoordinator.Shutdown()
 	}
 
 	shellOptions := []shell.ShellOption{}

--- a/apps/cnquery/cmd/status.go
+++ b/apps/cnquery/cmd/status.go
@@ -43,7 +43,6 @@ Status sends a ping to Mondoo Platform to verify the credentials.
 		viper.BindPFlag("output", cmd.Flags().Lookup("output"))
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		defer providers.Coordinator.Shutdown()
 		opts, optsErr := config.Read()
 		if optsErr != nil {
 			return cli_errors.NewCommandError(errors.Wrap(optsErr, "could not load configuration"), 1)

--- a/apps/cnquery/cmd/status.go
+++ b/apps/cnquery/cmd/status.go
@@ -43,6 +43,7 @@ Status sends a ping to Mondoo Platform to verify the credentials.
 		viper.BindPFlag("output", cmd.Flags().Lookup("output"))
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		defer providers.GlobalCoordinator.Shutdown()
 		opts, optsErr := config.Read()
 		if optsErr != nil {
 			return cli_errors.NewCommandError(errors.Wrap(optsErr, "could not load configuration"), 1)

--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -423,11 +423,10 @@ func setConnector(provider *plugin.Provider, connector *plugin.Connector, run fu
 			}
 		}
 
-		coordinator := providers.NewCoordinator()
-		defer coordinator.Shutdown()
+		defer providers.GlobalCoordinator.Shutdown()
 
 		// TODO: add flag to set timeout and then use RuntimeWithShutdownTimeout
-		runtime := coordinator.NewRuntime()
+		runtime := providers.GlobalCoordinator.NewRuntime()
 		defer runtime.Close()
 		if err = providers.SetDefaultRuntime(runtime); err != nil {
 			log.Error().Msg(err.Error())
@@ -484,7 +483,7 @@ func setConnector(provider *plugin.Provider, connector *plugin.Connector, run fu
 		if cliRes.Asset == nil {
 			log.Warn().Err(err).Msg("failed to discover assets after processing CLI arguments")
 		} else {
-			assetRuntime, err := coordinator.RuntimeFor(cliRes.Asset, runtime)
+			assetRuntime, err := providers.GlobalCoordinator.RuntimeFor(cliRes.Asset, runtime)
 			if err != nil {
 				log.Warn().Err(err).Msg("failed to get runtime for an asset that was detected after parsing the CLI")
 			} else {

--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -254,7 +254,7 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 			continue
 		}
 		rootAsset := &rootAsset{
-			asset:       asset,
+			asset:       resolvedAsset,
 			coordinator: coordinator,
 			runtime:     runtime,
 		}

--- a/providers/builtin.go
+++ b/providers/builtin.go
@@ -35,7 +35,7 @@ var builtinProviders = map[string]*builtinProvider{
 		Runtime: &RunningProvider{
 			Name:     mockProvider.Name,
 			ID:       mockProvider.ID,
-			Plugin:   &mockProviderService{coordinator: NewCoordinator()},
+			Plugin:   &mockProviderService{coordinator: &GlobalCoordinator},
 			isClosed: false,
 		},
 		Config: mockProvider.Provider,

--- a/providers/builtin.go
+++ b/providers/builtin.go
@@ -35,7 +35,7 @@ var builtinProviders = map[string]*builtinProvider{
 		Runtime: &RunningProvider{
 			Name:     mockProvider.Name,
 			ID:       mockProvider.ID,
-			Plugin:   &mockProviderService{coordinator: &Coordinator},
+			Plugin:   &mockProviderService{coordinator: NewCoordinator()},
 			isClosed: false,
 		},
 		Config: mockProvider.Provider,

--- a/providers/defaults_shared.go
+++ b/providers/defaults_shared.go
@@ -21,7 +21,7 @@ var defaultRuntime *Runtime
 
 func DefaultRuntime() *Runtime {
 	if defaultRuntime == nil {
-		defaultRuntime = Coordinator.NewRuntime()
+		defaultRuntime = NewCoordinator().NewRuntime()
 	}
 	return defaultRuntime
 }

--- a/providers/defaults_shared.go
+++ b/providers/defaults_shared.go
@@ -21,7 +21,7 @@ var defaultRuntime *Runtime
 
 func DefaultRuntime() *Runtime {
 	if defaultRuntime == nil {
-		defaultRuntime = NewCoordinator().NewRuntime()
+		defaultRuntime = GlobalCoordinator.NewRuntime()
 	}
 	return defaultRuntime
 }

--- a/providers/extensible_schema.go
+++ b/providers/extensible_schema.go
@@ -4,6 +4,7 @@
 package providers
 
 import (
+	"runtime"
 	"sync"
 
 	"github.com/rs/zerolog/log"
@@ -74,6 +75,7 @@ func (x *extensibleSchema) Close() {
 		Resources: map[string]*resources.ResourceInfo{},
 	}
 	x.sync.Unlock()
+	runtime.GC()
 }
 
 func (x *extensibleSchema) Lookup(name string) *resources.ResourceInfo {
@@ -156,7 +158,7 @@ func (x *extensibleSchema) unsafeLoadAll() {
 	}
 
 	for name := range providers {
-		schema, err := x.runtime.coordinator.LoadSchema(name)
+		schema, err := x.runtime.Coordinator.LoadSchema(name)
 		if err != nil {
 			log.Error().Err(err).Msg("load schema failed")
 		} else {

--- a/providers/k8s/connection/manifest/connection_test.go
+++ b/providers/k8s/connection/manifest/connection_test.go
@@ -21,7 +21,7 @@ import (
 
 func K8s() *providers.Runtime {
 	k8sSchema := testutils.MustLoadSchema(testutils.SchemaProvider{Provider: "k8s"})
-	runtime := providers.Coordinator.NewRuntime()
+	runtime := providers.GlobalCoordinator.NewRuntime()
 	provider := &providers.RunningProvider{
 		Name:   k8s_conf.Config.Name,
 		ID:     k8s_conf.Config.ID,

--- a/providers/mock.go
+++ b/providers/mock.go
@@ -23,7 +23,7 @@ var mockProvider = Provider{
 }
 
 type mockProviderService struct {
-	coordinator *coordinator
+	coordinator *Coordinator
 	initialized bool
 	runtime     *Runtime
 }

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -206,7 +206,7 @@ func ListActive() (Providers, error) {
 	}
 
 	// useful for caching; even if the structure gets updated with new providers
-	Coordinator.Providers = res
+	AvailableProviders = res
 	return res, nil
 }
 


### PR DESCRIPTION
The goal of this change is to allow the creation of nested provider coordinators. The concept is similar to the Go `context`. We have a `GlobalCoordinator`, which can have children and they have children too. When a parent coordinator shuts down, all children shutdown too.

Benefits of this approach:
- we can have 1 coordinator per root asset in an inventory
- provider instances are isolated for each coordinator
  - this means parallel scans can now work as expected. 1 scan cannot kill the providers of another
- we still have a global coordinator that will shutdown all children and all started providers

On the side I tried to cleanup the `distributeJob` function a bit by making a more readable structure for all the asset objects we are tossing around