### PR TITLE
🐛 cache mql field errors

### DIFF
--- a/providers-sdk/v1/plugin/runtime.go
+++ b/providers-sdk/v1/plugin/runtime.go
@@ -242,6 +242,7 @@ func GetOrCompute[T any](cached *TValue[T], compute func() (T, error)) *TValue[T
 		res := &TValue[T]{Data: x, Error: err}
 		if err != NotReady {
 			res.State = StateIsSet | StateIsNull
+			(*cached) = TValue[T]{Data: x, State: StateIsSet, Error: err}
 		}
 		return res
 	}

--- a/providers-sdk/v1/plugin/runtime.go
+++ b/providers-sdk/v1/plugin/runtime.go
@@ -242,7 +242,7 @@ func GetOrCompute[T any](cached *TValue[T], compute func() (T, error)) *TValue[T
 		res := &TValue[T]{Data: x, Error: err}
 		if err != NotReady {
 			res.State = StateIsSet | StateIsNull
-			(*cached) = TValue[T]{Data: x, State: StateIsSet, Error: err}
+			(*cached) = *res
 		}
 		return res
 	}


### PR DESCRIPTION
Errors where not cached and slowed down the execution.