### PR TITLE
🐛 prevent a crash on assertion creation

### DIFF
--- a/cli/printer/printer_test.go
+++ b/cli/printer/printer_test.go
@@ -182,6 +182,26 @@ func TestPrinter(t *testing.T) {
 func TestPrinter_Assessment(t *testing.T) {
 	runAssessmentTests(t, []assessmentTest{
 		{
+			// [dom] This query caused a crash in the assessment generation
+			"parse.json(\"/dummy.json\").params.f.where(ff == 3) != empty\nparse.json(\"/dummy.json\").params.f.where(ff == 3).all(ff < 0)",
+			strings.Join([]string{
+				"[failed] parse.json(\"/dummy.json\").params.f.where(ff == 3) != empty",
+				"parse.json(\"/dummy.json\").params.f.where(ff == 3).all(ff < 0)",
+				"  [ok] value: [",
+				"    0: {",
+				"      ff: 3.000000",
+				"    }",
+				"  ]",
+				"  [failed] [].all()",
+				"    actual:   [",
+				"      0: {",
+				"        ff: 3.000000",
+				"      }",
+				"    ]",
+				"",
+			}, "\n"),
+		},
+		{
 			// mixed use: assertion and erroneous data field
 			"mondoo.build == 1; user(name: 'notthere').authorizedkeys.file",
 			strings.Join([]string{

--- a/llx/code.go
+++ b/llx/code.go
@@ -439,9 +439,9 @@ func (l *CodeV2) entrypoint2assessment(bundle *CodeBundle, ref uint64, lookup fu
 					if code.Blocks[i].Datapoints[j] == listRef {
 						continue
 					}
-					chunk := code.Chunk(code.Blocks[i].Datapoints[j])
+					cc := code.Chunk(code.Blocks[i].Datapoints[j])
 					// this contains the default values
-					if chunk.Function.Binding == listRef {
+					if cc.Function != nil && cc.Function.Binding == listRef {
 						listRef = code.Blocks[i].Datapoints[j]
 						break OUTER
 					}


### PR DESCRIPTION
We currently have a crash that happens on the assertion creation:

```
go.mondoo.com/cnquery/v10/llx.(*CodeV2).entrypoint2assessment(0xc00070f020, 0xc000ca8b40, 0x10000000d, 0xc001254ce0)
	/pub/go/src/go.mondoo.com/cnquery/llx/code.go:444 +0x1303
go.mondoo.com/cnquery/v10/llx.Results2AssessmentLookupV2(0xc000ca8b40, 0xc0010898f0?)
	/pub/go/src/go.mondoo.com/cnquery/llx/code_bundle.go:57 +0x11a
go.mondoo.com/cnspec/v10/policy.Query2Assessment(0xc000ca8b40, 0xc0009cc3c0?)
	/pub/go/src/go.mondoo.com/cnspec/policy/assessment.go:40 +0x25e
go.mondoo.com/cnspec/v10/cli/reporter.(*defaultReporter).printCheck(0xc001225890, 0xc00065df80, 0xc0000e5400, 0xc000f8e200, 0xc0000061a0?, 0xc00006a500?)
	/pub/go/src/go.mondoo.com/cnspec/cli/reporter/print_compact.go:560 +0x279
```

The original MS365 check boiled down to its essentials was reproducible and has been added as a test.

This happens when we create an assertion on top of a dict-based data structure, that cycles through individual elements (eg via `where`). It reaches a point where it compares the elements to `empty`, which then causes a crash because it doesn't have a function defined in the chunk (to be expected).

The additional guard we insert checks if the function is defined and otherwise moves on.

Closes https://github.com/mondoohq/server/issues/7339