### PR TITLE
🧹 split CLI tests into a separate job

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -91,6 +91,39 @@ jobs:
           name: test-results
           path: report.xml
 
+  go-test-cli:
+    runs-on: self-hosted
+    timeout-minutes: 120
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Import environment variables from file
+        run: cat ".github/env" >> $GITHUB_ENV
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ">=${{ env.golang-version }}"
+          cache: false
+
+      - name: 'Set up gcloud CLI'
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      - name: Set provider env
+        run: echo "PROVIDERS_PATH=${PWD}/.providers" >> $GITHUB_ENV
+      - name: Display Provider PAth
+        run: echo $PROVIDERS_PATH
+
+      - name: Test cnquery CLI
+        run: make test/go-cli/plain-ci
+
+      - uses: actions/upload-artifact@v4  # upload test results
+        if: success() || failure()        # run this step even if previous step failed
+        with:
+          name: test-results-cli
+          path: report.xml
+
   go-bench:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main'

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -7,6 +7,7 @@ on:
       - '**.go'
       - '**.mod'
       - 'go.sum'
+      - 'Makefile'
 
 jobs:
   # Check if there is any dirty change for go mod tidy

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -8,6 +8,7 @@ on:
       - '**.mod'
       - 'go.sum'
       - 'Makefile'
+      - '.github/workflows/pr-test-lint.yml'
 
 jobs:
   # Check if there is any dirty change for go mod tidy

--- a/Makefile
+++ b/Makefile
@@ -600,10 +600,10 @@ benchmark/go:
 test/go: cnquery/generate test/go/plain
 
 test/go/plain:
-	go test -cover $(shell go list ./... | grep -v '/providers/' | grep -v '/test/cli/')
+	go test -cover $(shell go list ./... | grep -v '/providers/' | grep -v '/test/cli')
 
 test/go/plain-ci: prep/tools providers/build providers/test
-	gotestsum --junitfile report.xml --format pkgname -- -cover $(shell go list ./... | grep -v '/vendor/' | grep -v '/providers/')
+	gotestsum --junitfile report.xml --format pkgname -- -cover $(shell go list ./... | grep -v '/vendor/' | grep -v '/providers/' | grep -v '/test/cli')
 
 test/go-cli/plain:
 	go test -cover $(shell go list ./... | grep 'test/cli')

--- a/Makefile
+++ b/Makefile
@@ -602,13 +602,13 @@ test/go: cnquery/generate test/go/plain
 test/go/plain:
 	go test -cover $(shell go list ./... | grep -v '/providers/' | grep -v '/test/cli')
 
-test/go/plain-ci: prep/tools providers/build providers/test
+test/go/plain-ci: prep/tools providers/build
 	gotestsum --junitfile report.xml --format pkgname -- -cover $(shell go list ./... | grep -v '/vendor/' | grep -v '/providers/' | grep -v '/test/cli')
 
 test/go-cli/plain:
 	go test -cover $(shell go list ./... | grep 'test/cli')
 
-test/go-cli/plain-ci: prep/tools providers/build providers/test
+test/go-cli/plain-ci: prep/tools providers/build
 	gotestsum --junitfile report.xml --format pkgname -- -cover $(shell go list ./... | grep 'test/cli')
 
 .PHONY: test/lint/staticcheck

--- a/Makefile
+++ b/Makefile
@@ -600,10 +600,16 @@ benchmark/go:
 test/go: cnquery/generate test/go/plain
 
 test/go/plain:
-	go test -cover $(shell go list ./... | grep -v '/providers/')
+	go test -cover $(shell go list ./... | grep -v '/providers/' | grep -v '/test/cli/')
 
 test/go/plain-ci: prep/tools providers/build providers/test
 	gotestsum --junitfile report.xml --format pkgname -- -cover $(shell go list ./... | grep -v '/vendor/' | grep -v '/providers/')
+
+test/go-cli/plain:
+	go test -cover $(shell go list ./... | grep 'test/cli')
+
+test/go-cli/plain-ci: prep/tools providers/build providers/test
+	gotestsum --junitfile report.xml --format pkgname -- -cover $(shell go list ./... | grep 'test/cli')
 
 .PHONY: test/lint/staticcheck
 test/lint/staticcheck:


### PR DESCRIPTION
Split the CLI tests into a separate job because they rely on the fact that no providers have been installed. When other unit tests are pulling providers, they make the CLI tests fail. With this change that should no longer be an issue, because CLI and non-CLI tests will be executed independently