### PR TITLE
🐛 properly discover scannable root assets

### DIFF
--- a/explorer/scan/discovery.go
+++ b/explorer/scan/discovery.go
@@ -110,6 +110,18 @@ func DiscoverAssets(ctx context.Context, inv *inventory.Inventory, upstream *ups
 
 		resolvedRootAsset = rootAssetWithRuntime.Asset // to ensure we get all the information the connect call gave us
 
+		// If the root asset has platform IDs, then it is a scannable asset, so we need to add it
+		if len(resolvedRootAsset.PlatformIds) > 0 {
+			if !discoveredAssets.Add(rootAssetWithRuntime.Asset, rootAssetWithRuntime.Runtime) {
+				rootAssetWithRuntime.Runtime.Close()
+			}
+		}
+
+		// If there is no inventory, no assets have been discovered under the root asset
+		if rootAssetWithRuntime.Runtime.Provider.Connection.Inventory == nil {
+			continue
+		}
+
 		// for all discovered assets, we apply mondoo-specific labels and annotations that come from the root asset
 		for _, a := range rootAssetWithRuntime.Runtime.Provider.Connection.Inventory.Spec.Assets {
 			// create runtime for root asset

--- a/explorer/scan/discovery_test.go
+++ b/explorer/scan/discovery_test.go
@@ -221,4 +221,13 @@ func TestDiscoverAssets(t *testing.T) {
 			assert.Equal(t, "actions.github.com", asset.Asset.Labels["mondoo.com/exec-environment"])
 		}
 	})
+
+	t.Run("scannable root asset", func(t *testing.T) {
+		inv := getInventory()
+		inv.Spec.Assets[0].Connections[0].Type = "local"
+
+		discoveredAssets, err := DiscoverAssets(context.Background(), inv, nil, providers.NullRecording{})
+		require.NoError(t, err)
+		assert.Len(t, discoveredAssets.Assets, 1)
+	})
 }


### PR DESCRIPTION
sometimes the root assets are scannable, sometimes they are not. For example, when running a `cnquery scan local`, the root asset is the local machine and it should be scanned. However, when running `cnquery scan k8s`, the root asset is just the unresolved inventory.

This change makes sure both cases work as expected. A test is added to cover the missing case