### PR TITLE
🧹 providers coordinator v2

### DIFF
--- a/apps/cnquery/cmd/login.go
+++ b/apps/cnquery/cmd/login.go
@@ -52,7 +52,7 @@ You remain logged in until you explicitly log out using the 'logout' subcommand.
 		viper.BindPFlag("name", cmd.Flags().Lookup("name"))
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		defer cnquery_providers.Coordinator.Shutdown()
+		defer cnquery_providers.GlobalCoordinator.Shutdown()
 		token, _ := cmd.Flags().GetString("token")
 		annotations, _ := cmd.Flags().GetStringToString("annotation")
 		return register(token, annotations)

--- a/apps/cnquery/cmd/logout.go
+++ b/apps/cnquery/cmd/logout.go
@@ -36,7 +36,7 @@ ensure the credentials cannot be used in the future.
 		viper.BindPFlag("force", cmd.Flags().Lookup("force"))
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		defer cnquery_providers.Coordinator.Shutdown()
+		defer cnquery_providers.GlobalCoordinator.Shutdown()
 		var err error
 
 		// its perfectly fine not to have a config here, therefore we ignore errors

--- a/apps/cnquery/cmd/plugin.go
+++ b/apps/cnquery/cmd/plugin.go
@@ -129,7 +129,7 @@ func (c *cnqueryPlugin) RunQuery(conf *run.RunQueryConfig, runtime *providers.Ru
 			return err
 		}
 
-		connectAssetRuntime, err := providers.Coordinator.RuntimeFor(asset, runtime)
+		connectAssetRuntime, err := providers.GlobalCoordinator.RuntimeFor(asset, runtime)
 		if err != nil {
 			return err
 		}

--- a/apps/cnquery/cmd/shell.go
+++ b/apps/cnquery/cmd/shell.go
@@ -153,7 +153,7 @@ func StartShell(runtime *providers.Runtime, conf *ShellConfig) error {
 	// when we close the shell, we need to close the backend and store the recording
 	onCloseHandler := func() {
 		runtime.Close()
-		providers.Coordinator.Shutdown()
+		providers.GlobalCoordinator.Shutdown()
 	}
 
 	shellOptions := []shell.ShellOption{}

--- a/apps/cnquery/cmd/status.go
+++ b/apps/cnquery/cmd/status.go
@@ -43,7 +43,7 @@ Status sends a ping to Mondoo Platform to verify the credentials.
 		viper.BindPFlag("output", cmd.Flags().Lookup("output"))
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		defer providers.Coordinator.Shutdown()
+		defer providers.GlobalCoordinator.Shutdown()
 		opts, optsErr := config.Read()
 		if optsErr != nil {
 			return cli_errors.NewCommandError(errors.Wrap(optsErr, "could not load configuration"), 1)

--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -424,7 +424,7 @@ func setConnector(provider *plugin.Provider, connector *plugin.Connector, run fu
 		}
 
 		// TODO: add flag to set timeout and then use RuntimeWithShutdownTimeout
-		runtime := providers.Coordinator.NewRuntime()
+		runtime := providers.GlobalCoordinator.NewRuntime()
 		if err = providers.SetDefaultRuntime(runtime); err != nil {
 			log.Error().Msg(err.Error())
 		}
@@ -440,12 +440,12 @@ func setConnector(provider *plugin.Provider, connector *plugin.Connector, run fu
 		}
 
 		if err := runtime.UseProvider(provider.ID); err != nil {
-			providers.Coordinator.Shutdown()
+			providers.GlobalCoordinator.Shutdown()
 			log.Fatal().Err(err).Msg("failed to start provider " + provider.Name)
 		}
 
 		if record != "" && useRecording != "" {
-			providers.Coordinator.Shutdown()
+			providers.GlobalCoordinator.Shutdown()
 			log.Fatal().Msg("please only use --record or --use-recording, but not both at the same time")
 		}
 		recordingPath := record
@@ -459,7 +459,7 @@ func setConnector(provider *plugin.Provider, connector *plugin.Connector, run fu
 			PrettyPrintJSON: pretty,
 		})
 		if err != nil {
-			providers.Coordinator.Shutdown()
+			providers.GlobalCoordinator.Shutdown()
 			log.Fatal().Msg(err.Error())
 		}
 		runtime.SetRecording(recording)
@@ -471,13 +471,13 @@ func setConnector(provider *plugin.Provider, connector *plugin.Connector, run fu
 		})
 		if err != nil {
 			runtime.Close()
-			providers.Coordinator.Shutdown()
+			providers.GlobalCoordinator.Shutdown()
 			log.Fatal().Err(err).Msg("failed to parse cli arguments")
 		}
 
 		if cliRes == nil {
 			runtime.Close()
-			providers.Coordinator.Shutdown()
+			providers.GlobalCoordinator.Shutdown()
 			log.Fatal().Msg("failed to process CLI arguments, nothing was returned")
 			return // adding this here as a compiler hint to stop warning about nil-dereferences
 		}
@@ -485,7 +485,7 @@ func setConnector(provider *plugin.Provider, connector *plugin.Connector, run fu
 		if cliRes.Asset == nil {
 			log.Warn().Err(err).Msg("failed to discover assets after processing CLI arguments")
 		} else {
-			assetRuntime, err := providers.Coordinator.RuntimeFor(cliRes.Asset, runtime)
+			assetRuntime, err := providers.GlobalCoordinator.RuntimeFor(cliRes.Asset, runtime)
 			if err != nil {
 				log.Warn().Err(err).Msg("failed to get runtime for an asset that was detected after parsing the CLI")
 			} else {
@@ -495,7 +495,7 @@ func setConnector(provider *plugin.Provider, connector *plugin.Connector, run fu
 
 		run(cc, runtime, cliRes)
 		runtime.Close()
-		providers.Coordinator.Shutdown()
+		providers.GlobalCoordinator.Shutdown()
 	}
 
 	attachFlags(cmd.Flags(), allFlags)

--- a/explorer/scan/discovery.go
+++ b/explorer/scan/discovery.go
@@ -90,7 +90,7 @@ func (d *DiscoveredAssets) GetAssetsByPlatformID(platformID string) []*inventory
 		for _, c := range a.Children {
 			for _, p := range c.Asset.PlatformIds {
 				if platformID == "" || p == platformID {
-					assets = append(assets, a.Asset)
+					assets = append(assets, c.Asset)
 					break
 				}
 			}

--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -351,6 +351,9 @@ func (s *LocalScanner) distributeJob(job *Job, ctx context.Context, upstream *up
 			}
 		}()
 		wg.Wait()
+
+		// Shutdown the coordinator for the current root asset
+		root.Coordinator.Shutdown()
 	}
 	scanGroups.Wait()
 	return reporter.Reports(), nil

--- a/providers-sdk/v1/testutils/testutils.go
+++ b/providers-sdk/v1/testutils/testutils.go
@@ -200,7 +200,7 @@ func Local() llx.Runtime {
 	networkSchema := MustLoadSchema(SchemaProvider{Provider: "network"})
 	mockSchema := MustLoadSchema(SchemaProvider{Provider: "mockprovider"})
 
-	runtime := providers.Coordinator.NewRuntime()
+	runtime := providers.GlobalCoordinator.NewRuntime()
 
 	provider := &providers.RunningProvider{
 		Name:   osconf.Config.Name,

--- a/providers/builtin.go
+++ b/providers/builtin.go
@@ -35,7 +35,7 @@ var builtinProviders = map[string]*builtinProvider{
 		Runtime: &RunningProvider{
 			Name:     mockProvider.Name,
 			ID:       mockProvider.ID,
-			Plugin:   &mockProviderService{coordinator: &Coordinator},
+			Plugin:   &mockProviderService{coordinator: GlobalCoordinator},
 			isClosed: false,
 		},
 		Config: mockProvider.Provider,

--- a/providers/defaults_shared.go
+++ b/providers/defaults_shared.go
@@ -21,7 +21,7 @@ var defaultRuntime *Runtime
 
 func DefaultRuntime() *Runtime {
 	if defaultRuntime == nil {
-		defaultRuntime = Coordinator.NewRuntime()
+		defaultRuntime = GlobalCoordinator.NewRuntime()
 	}
 	return defaultRuntime
 }

--- a/providers/global_coordinator.go
+++ b/providers/global_coordinator.go
@@ -28,6 +28,7 @@ type Coordinator interface {
 	Start(id string, isEphemeral bool, update UpdateProvidersConfig) (*RunningProvider, error)
 	Stop(provider *RunningProvider, isEphemeral bool) error
 	NewRuntime() *Runtime
+	NewRuntimeFrom(parent *Runtime) *Runtime
 	RuntimeFor(asset *inventory.Asset, parent *Runtime) (*Runtime, error)
 	GetRunningProviderById(id string) *RunningProvider
 	GetProviders() Providers

--- a/providers/local_coordinator.go
+++ b/providers/local_coordinator.go
@@ -113,14 +113,18 @@ func (lc *localCoordinator) Shutdown() {
 	defer lc.mutex.Unlock()
 
 	for provider := range lc.runningEphemeral {
-		log.Debug().Str("provider", provider.Name).Msg("Shutting down ephemeral provider")
-		lc.parent.Stop(provider, true)
+		log.Debug().Str("provider", provider.Name).Msg("shutting down ephemeral provider")
+		if err := lc.parent.Stop(provider, true); err != nil {
+			log.Error().Err(err).Str("provider", provider.Name).Msg("error stopping ephemeral provider")
+		}
 	}
 	lc.runningEphemeral = map[*RunningProvider]struct{}{}
 
 	for _, provider := range lc.runningByID {
-		log.Debug().Str("provider", provider.Name).Msg("Shutting down provider")
-		lc.parent.Stop(provider, true)
+		log.Debug().Str("provider", provider.Name).Msg("shutting down provider")
+		if err := lc.parent.Stop(provider, true); err != nil {
+			log.Error().Err(err).Str("provider", provider.Name).Msg("error stopping provider")
+		}
 	}
 	lc.runningByID = map[string]*RunningProvider{}
 }

--- a/providers/local_coordinator.go
+++ b/providers/local_coordinator.go
@@ -1,0 +1,104 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"sync"
+
+	"go.mondoo.com/cnquery/v10/providers-sdk/v1/inventory"
+	"go.mondoo.com/cnquery/v10/providers-sdk/v1/resources"
+)
+
+type localCoordinator struct {
+	parent Coordinator
+
+	runningByID      map[string]*RunningProvider
+	runningEphemeral map[*RunningProvider]struct{}
+	mutex            sync.Mutex
+}
+
+func NewLocalCoordinator(parent Coordinator) Coordinator {
+	return &localCoordinator{
+		parent:           parent,
+		runningByID:      map[string]*RunningProvider{},
+		runningEphemeral: map[*RunningProvider]struct{}{},
+	}
+}
+
+func (lc *localCoordinator) Start(id string, isEphemeral bool, update UpdateProvidersConfig) (*RunningProvider, error) {
+	// From the parent's perspective, all providers from its children are ephemeral
+	provider, err := lc.parent.Start(id, true, update)
+	if err != nil {
+		return nil, err
+	}
+
+	lc.mutex.Lock()
+	if isEphemeral {
+		lc.runningEphemeral[provider] = struct{}{}
+	} else {
+		lc.runningByID[provider.ID] = provider
+	}
+	lc.mutex.Unlock()
+	return provider, nil
+}
+
+func (lc *localCoordinator) Stop(provider *RunningProvider, isEphemeral bool) error {
+	if provider == nil {
+		return nil
+	}
+
+	lc.mutex.Lock()
+	defer lc.mutex.Unlock()
+
+	if isEphemeral {
+		delete(lc.runningEphemeral, provider)
+	} else {
+		found := lc.runningByID[provider.ID]
+		if found != nil {
+			delete(lc.runningByID, provider.ID)
+		}
+	}
+	return lc.parent.Stop(provider, true)
+}
+
+func (lc *localCoordinator) NewRuntime() *Runtime {
+	return lc.parent.NewRuntime()
+}
+
+func (lc *localCoordinator) RuntimeFor(asset *inventory.Asset, parent *Runtime) (*Runtime, error) {
+	return lc.parent.RuntimeFor(asset, parent)
+}
+
+func (lc *localCoordinator) GetRunningProviderById(id string) *RunningProvider {
+	lc.mutex.Lock()
+	defer lc.mutex.Unlock()
+	return lc.runningByID[id]
+}
+
+func (lc *localCoordinator) GetProviders() Providers {
+	return lc.parent.GetProviders()
+}
+
+func (lc *localCoordinator) SetProviders(providers Providers) {
+	lc.parent.SetProviders(providers)
+}
+
+func (lc *localCoordinator) LoadSchema(name string) (*resources.Schema, error) {
+	return lc.parent.LoadSchema(name)
+}
+
+func (lc *localCoordinator) Shutdown() {
+	lc.mutex.Lock()
+	defer lc.mutex.Unlock()
+
+	for cur := range lc.runningEphemeral {
+		lc.parent.Stop(cur, true)
+	}
+	lc.runningEphemeral = map[*RunningProvider]struct{}{}
+
+	for _, runtime := range lc.runningByID {
+		lc.parent.Stop(runtime, true)
+	}
+	lc.runningByID = map[string]*RunningProvider{}
+}

--- a/providers/mock.go
+++ b/providers/mock.go
@@ -23,7 +23,7 @@ var mockProvider = Provider{
 }
 
 type mockProviderService struct {
-	coordinator *coordinator
+	coordinator Coordinator
 	initialized bool
 	runtime     *Runtime
 }

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -206,7 +206,7 @@ func ListActive() (Providers, error) {
 	}
 
 	// useful for caching; even if the structure gets updated with new providers
-	Coordinator.Providers = res
+	GlobalCoordinator.SetProviders(res)
 	return res, nil
 }
 

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -33,7 +33,7 @@ type Runtime struct {
 	recording llx.Recording
 	features  []byte
 	// coordinator is used to grab providers
-	coordinator *coordinator
+	coordinator Coordinator
 	// providers for with open connections
 	providers map[string]*ConnectedProvider
 	// schema aggregates all resources executable on this asset
@@ -149,7 +149,7 @@ func (r *Runtime) addProvider(id string, isEphemeral bool) (*ConnectedProvider, 
 
 	} else {
 		// TODO: we need to detect only the shared running providers
-		running = r.coordinator.RunningByID[id]
+		running = r.coordinator.GetRunningProviderById(id)
 		if running == nil {
 			var err error
 			running, err = r.coordinator.Start(id, false, r.AutoUpdate)
@@ -193,7 +193,7 @@ func (r *Runtime) providerForAsset(asset *inventory.Asset) (*Provider, error) {
 			conn.Type = inventory.ConnBackendToType(conn.Backend)
 		}
 
-		provider, err := EnsureProvider(ProviderLookup{ConnType: conn.Type}, true, r.coordinator.Providers)
+		provider, err := EnsureProvider(ProviderLookup{ConnType: conn.Type}, true, r.coordinator.GetProviders())
 		if err != nil {
 			errs.Add(err)
 			continue


### PR DESCRIPTION
The goal is to allow creating local coordinators with a parent coordinator. The way the code is setup is:
- providers are always managed by the parent coordinator. This means eventually all providers should end up in the global coordinator
- the local coordinator only keeps a reference to the started providers but are not managing them
- from the perspective of the global coordinator any provider started by a local coordinator is ephemeral. This means the local coordinators have dedicated providers for them. This allows scans to run independently of each other
- there is no direct dependency from the global coordinator to its children