### PR TITLE
🏃🏻‍♂️ faster aws connect and discovery

### DIFF
--- a/providers/aws/resources/discovery.go
+++ b/providers/aws/resources/discovery.go
@@ -186,6 +186,11 @@ func Discover(runtime *plugin.Runtime, filters connection.DiscoveryFilters) (*in
 		Assets: []*inventory.Asset{},
 	}}
 
+	if (conn.Conf == nil || len(conn.Conf.Discover.Targets) == 0) && conn.Asset() != nil {
+		in.Spec.Assets = append(in.Spec.Assets, conn.Asset())
+		return in, nil
+	}
+
 	res, err := NewResource(runtime, "aws.account", map[string]*llx.RawData{"id": llx.StringData("aws.account/" + conn.AccountId())})
 	if err != nil {
 		return nil, err
@@ -468,11 +473,13 @@ func discover(runtime *plugin.Runtime, awsAccount *mqlAwsAccount, target string,
 		for i := range bs.Data {
 			f := bs.Data[i].(*mqlAwsS3Bucket)
 
+			location := f.GetLocation()
+
 			tags := mapStringInterfaceToStringString(f.Tags.Data)
 			m := mqlObject{
 				name: f.Name.Data, labels: tags,
 				awsObject: awsObject{
-					account: accountId, region: f.Location.Data, arn: f.Arn.Data,
+					account: accountId, region: location.Data, arn: f.Arn.Data,
 					id: f.Name.Data, service: "s3", objectType: "bucket",
 				},
 			}

--- a/providers/aws/resources/discovery.go
+++ b/providers/aws/resources/discovery.go
@@ -473,13 +473,11 @@ func discover(runtime *plugin.Runtime, awsAccount *mqlAwsAccount, target string,
 		for i := range bs.Data {
 			f := bs.Data[i].(*mqlAwsS3Bucket)
 
-			location := f.GetLocation()
-
 			tags := mapStringInterfaceToStringString(f.Tags.Data)
 			m := mqlObject{
 				name: f.Name.Data, labels: tags,
 				awsObject: awsObject{
-					account: accountId, region: location.Data, arn: f.Arn.Data,
+					account: accountId, region: f.Location.Data, arn: f.Arn.Data,
 					id: f.Name.Data, service: "s3", objectType: "bucket",
 				},
 			}


### PR DESCRIPTION
we have a similar flow for k8s. We don't need to do discovery every time we connect to an asset. This is currently happening for aws. With the current code a `Connect` call for an AWS asset takes about 1s. With this change the `Connect` call takes about 500ms

Please verify this works for all discoveries. I only tested this with s3 buckets and kms keys