### PR TITLE
🐛  make aws discovery consistent with other providers

### DIFF
--- a/providers/aws/provider/provider.go
+++ b/providers/aws/provider/provider.go
@@ -262,8 +262,6 @@ func (s *Service) detect(asset *inventory.Asset, conn plugin.Connection) error {
 	if c, ok := conn.(*connection.AwsConnection); ok {
 		asset.Name = c.Conf.Host
 		asset.Platform = c.PlatformInfo()
-		// TODO: do not do this here but in discovery
-		asset.PlatformIds = []string{"//platformid.api.mondoo.app/runtime/aws/accounts/" + c.AccountId()}
 	}
 	if c, ok := conn.(*awsec2ebsconn.AwsEbsConnection); ok {
 		asset.Platform = c.PlatformInfo()


### PR DESCRIPTION
this is the only provider trying to assign a platform id to the root of the discovery. That breaks the new discovery code. I checked and this change is compatible with the new and the old discovery code. We should merge this and release the providers to make sure the provider works as expected with the new cnquery code as well