### PR TITLE
🐛 parse time formats case-insensitive

### DIFF
--- a/llx/builtin_resource.go
+++ b/llx/builtin_resource.go
@@ -256,9 +256,17 @@ func resourceDateV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (
 		return nil, rref, err
 	}
 
+	timestamp, ok := args[0].(string)
+	if !ok {
+		return nil, 0, errors.New("failed to parse time, timestamp needs to be a string")
+	}
+
 	var format string
 	if len(args) >= 2 {
-		format = args[1].(string)
+		format, ok = args[1].(string)
+		if !ok {
+			return nil, 0, errors.New("provided time format is not provided as string")
+		}
 		format = strings.ToLower(format)
 		if f, ok := timeFormats[format]; ok {
 			format = f
@@ -266,7 +274,7 @@ func resourceDateV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (
 	}
 
 	if format != "" {
-		parsed, err := time.Parse(format, args[0].(string))
+		parsed, err := time.Parse(format, timestamp)
 		if err != nil {
 			return nil, 0, errors.New("failed to parse time: " + err.Error())
 		}
@@ -276,7 +284,7 @@ func resourceDateV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (
 	// Note: Yes, this approach is much slower than giving us a hint
 	// about which time format is used.
 	for _, format := range defaultTimeFormatsOrder {
-		parsed, err := time.Parse(format, args[0].(string))
+		parsed, err := time.Parse(format, timestamp)
 		if err != nil {
 			continue
 		}

--- a/llx/builtin_resource.go
+++ b/llx/builtin_resource.go
@@ -259,6 +259,7 @@ func resourceDateV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (
 	var format string
 	if len(args) >= 2 {
 		format = args[1].(string)
+		format = strings.ToLower(format)
 		if f, ok := timeFormats[format]; ok {
 			format = f
 		}

--- a/providers/core/resources/parse_test.go
+++ b/providers/core/resources/parse_test.go
@@ -33,6 +33,16 @@ func TestParse_Date(t *testing.T) {
 			ResultIndex: 0,
 			Expectation: &simpleDate,
 		},
+		{
+			Code:        "parse.date('2023-12-23T00:00:00Z', 'rfc3339')",
+			ResultIndex: 0,
+			Expectation: &simpleDate,
+		},
+		{
+			Code:        "parse.date('2023-12-23T00:00:00Z', 'RFC3339')", // ensure the format finding is case-insensitive
+			ResultIndex: 0,
+			Expectation: &simpleDate,
+		},
 	})
 }
 


### PR DESCRIPTION
fixes https://github.com/mondoohq/cnquery/issues/3207 by making the parsing of the time format case insensitive