### PR TITLE
🐛 Fix resource lookup for `cpe`

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -18,7 +18,7 @@ alias os.unix.sshd = sshd
 
 extend asset {
   // Common Platform Enumeration (CPE) for the asset
-  cpes() []core.cpe
+  cpes() []cpe
   // Advisory & vulnerability report
   // Deprecated; will be removed in version 10.0
   // use vulnmgmt instead
@@ -612,7 +612,7 @@ package @defaults("name version") {
   purl string
 
   // Common Platform Enumeration (CPE) for the package
-  cpes []core.cpe
+  cpes []cpe
 
   // Package origin (optional)
   origin() string
@@ -1157,7 +1157,7 @@ python.package @defaults("name version") {
   // Package URL
   purl() string
   // Common Platform Enumeration (CPE) for the package
-  cpes() []core.cpe
+  cpes() []cpe
   // List of packages depended on
   dependencies() []python.package
 }

--- a/providers/vsphere/resources/vsphere.lr
+++ b/providers/vsphere/resources/vsphere.lr
@@ -7,7 +7,7 @@ option go_package = "go.mondoo.com/cnquery/v10/providers/vsphere/resources"
 // vSphere asset resource
 extend asset {
   // Common Platform Enumeration (CPE) for the asset
-  cpes() []core.cpe
+  cpes() []cpe
   // Advisory & vulnerability report
   // Will be deprecated in version 10.0; Full advisory & vulnerability report  
   // use vulnmgmt instead

--- a/providers/vsphere/resources/vsphere.lr.go
+++ b/providers/vsphere/resources/vsphere.lr.go
@@ -183,7 +183,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"asset.cpes": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAsset).GetCpes()).ToDataRes(types.Array(types.Resource("core.cpe")))
+		return (r.(*mqlAsset).GetCpes()).ToDataRes(types.Array(types.Resource("cpe")))
 	},
 	"asset.vulnerabilityReport": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAsset).GetVulnerabilityReport()).ToDataRes(types.Dict)


### PR DESCRIPTION
This fixes the error:
```
failed to compile query 'asset { name platform version arch ids labels cpes.map(uri) }': cannot find resource that is called by 'uri' of type core.cpe"
```