### PR TITLE
🧹 Attach data disks with a delete opt. Add an option to skip detach/delete steps

### DIFF
--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -97,6 +97,13 @@ var Config = plugin.Provider{
 					Desc:    "Comma-separated list of Azure subscriptions to exclude.",
 					Option:  plugin.FlagOption_Hidden,
 				},
+				{
+					Long:    "skip-snapshot-cleanup",
+					Type:    plugin.FlagType_Bool,
+					Default: "",
+					Desc:    "If set, no cleanup will be performed for the snapshot connection.",
+					Option:  plugin.FlagOption_Hidden,
+				},
 			},
 		},
 	},

--- a/providers/azure/connection/azureinstancesnapshot/provider.go
+++ b/providers/azure/connection/azureinstancesnapshot/provider.go
@@ -29,6 +29,7 @@ const (
 	DiskTargetType         string                = "disk"
 	SnapshotTargetType     string                = "snapshot"
 	InstanceTargetType     string                = "instance"
+	SkipCleanup            string                = "skip-cleanup"
 )
 
 // the instance from which we're performing the scan
@@ -308,7 +309,7 @@ func (c *AzureSnapshotConnection) Close() {
 		}
 	}
 
-	if c.snapshotCreator != nil {
+	if c.snapshotCreator != nil && !c.skipCleanup() {
 		if c.mountInfo.diskName != "" {
 			err := c.snapshotCreator.detachDisk(c.mountInfo.diskName, c.scanner.instanceInfo)
 			if err != nil {
@@ -330,6 +331,10 @@ func (c *AzureSnapshotConnection) Close() {
 			log.Error().Err(err).Msg("unable to remove dir")
 		}
 	}
+}
+
+func (c *AzureSnapshotConnection) skipCleanup() bool {
+	return c.opts[SkipCleanup] == "true"
 }
 
 func (c *AzureSnapshotConnection) Kind() string {

--- a/providers/azure/connection/azureinstancesnapshot/provider.go
+++ b/providers/azure/connection/azureinstancesnapshot/provider.go
@@ -29,7 +29,7 @@ const (
 	DiskTargetType         string                = "disk"
 	SnapshotTargetType     string                = "snapshot"
 	InstanceTargetType     string                = "instance"
-	SkipCleanup            string                = "skip-cleanup"
+	SkipCleanup            string                = "skip-snapshot-cleanup"
 )
 
 // the instance from which we're performing the scan
@@ -308,8 +308,9 @@ func (c *AzureSnapshotConnection) Close() {
 			log.Error().Err(err).Msg("unable to unmount volume")
 		}
 	}
-
-	if c.snapshotCreator != nil && !c.skipCleanup() {
+	if c.skipCleanup() {
+		log.Debug().Msgf("skipping azure snapshot cleanup, %s flag is set to true", SkipCleanup)
+	} else if c.snapshotCreator != nil {
 		if c.mountInfo.diskName != "" {
 			err := c.snapshotCreator.detachDisk(c.mountInfo.diskName, c.scanner.instanceInfo)
 			if err != nil {

--- a/providers/azure/connection/azureinstancesnapshot/snapshot.go
+++ b/providers/azure/connection/azureinstancesnapshot/snapshot.go
@@ -214,12 +214,14 @@ func (sc *snapshotCreator) attachDisk(targetInstance instanceInfo, diskName, dis
 		return err
 	}
 	attachOpt := compute.DiskCreateOptionTypesAttach
+	deleteOpt := compute.DiskDeleteOptionTypesDelete
 	// the Azure API requires all disks to be specified, even the already attached ones.
 	// we simply attach the new disk to the end of the already present list of data disks
 	disks := targetInstance.vm.Properties.StorageProfile.DataDisks
 	disks = append(disks, &compute.DataDisk{
 		Name:         &diskName,
 		CreateOption: &attachOpt,
+		DeleteOption: &deleteOpt,
 		Lun:          &lun,
 		ManagedDisk: &compute.ManagedDiskParameters{
 			ID: &diskId,

--- a/providers/azure/provider/provider.go
+++ b/providers/azure/provider/provider.go
@@ -42,7 +42,7 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	subscriptionsToExclude := flags["subscriptions-exclude"]
 	certificatePath := flags["certificate-path"]
 	certificateSecret := flags["certificate-secret"]
-
+	skipSnapshotCleanup := flags["skip-snapshot-cleanup"]
 	opts := map[string]string{}
 	creds := []*vault.Credential{}
 
@@ -57,7 +57,10 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	if len(subscriptionsToExclude.Value) > 0 {
 		opts["subscriptions-exclude"] = string(subscriptionsToExclude.Value)
 	}
-
+	// the presence of the flag indicates that we should skip cleanup
+	if len(skipSnapshotCleanup.Value) > 0 {
+		opts[azureinstancesnapshot.SkipCleanup] = "true"
+	}
 	if len(clientSecret.Value) > 0 {
 		creds = append(creds, &vault.Credential{
 			Type:   vault.CredentialType_password,

--- a/providers/azure/provider/provider.go
+++ b/providers/azure/provider/provider.go
@@ -58,7 +58,7 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		opts["subscriptions-exclude"] = string(subscriptionsToExclude.Value)
 	}
 	// the presence of the flag indicates that we should skip cleanup
-	if len(skipSnapshotCleanup.Value) > 0 {
+	if present := skipSnapshotCleanup.RawData().Value.(bool); present {
 		opts[azureinstancesnapshot.SkipCleanup] = "true"
 	}
 	if len(clientSecret.Value) > 0 {


### PR DESCRIPTION
Attach the Azure data disks with a delete option. That means that if the VM gets deleted, the data disks get delete alongside.

Also add an option to skip detach/delete steps. This may be useful when we're performing a scan on a VM we know will get deleted soon after. In that case, manually detaching/deleting the data disk is redundant as we know this will happen when the VM itself gets deleted. To trigger this, add the `--skip-snapshot-cleanup` flag.