### PR TITLE
🧹 disable os detection for registry images

### DIFF
--- a/providers/os/connection/tar.go
+++ b/providers/os/connection/tar.go
@@ -185,6 +185,7 @@ func NewTarConnectionForContainer(id uint32, conf *inventory.Config, asset *inve
 		asset: asset,
 		Fs:    provider_tar.NewFs(f.Name()),
 		fetchFn: func() (string, error) {
+			log.Warn().Msg("loading container image into tar connection")
 			err = cache.StreamToTmpFile(mutate.Extract(img), f)
 			if err != nil {
 				os.Remove(f.Name())

--- a/providers/os/detector/platform_resolver.go
+++ b/providers/os/detector/platform_resolver.go
@@ -25,14 +25,19 @@ func (r *PlatformResolver) Resolve(conn shared.Connection) (*inventory.Platform,
 	di.Family = make([]string, 0)
 
 	// start recursive platform resolution
-	pi, resolved := r.resolvePlatform(di, conn)
+	pi := &inventory.Platform{}
+	resolved := conn.Type() == shared.Type_RegistryImage
+	if conn.Type() != shared.Type_RegistryImage {
+		pi, resolved = r.resolvePlatform(di, conn)
+	}
 
 	// if we have a container image use the architecture specified in the transport as it is resolved
 	// using the container image properties
-	tarConn, ok := conn.(*connection.TarConnection)
+	tarConn, ok := conn.(*connection.DockerRegistryImageConnection)
 	if resolved && ok {
 		pi.Arch = tarConn.PlatformArchitecture
 		di.Runtime = "docker-image"
+		di.Title = "Docker Image"
 		di.Kind = "container-image"
 
 		// if the platform name is not set, we should fallback to the scratch operating system


### PR DESCRIPTION
this makes sure we aren't pulling the container unless we are running a scan