### PR TITLE
🧹 safe guard connections that should implement the Closer interface

### DIFF
--- a/providers/aws/connection/awsec2ebsconn/provider.go
+++ b/providers/aws/connection/awsec2ebsconn/provider.go
@@ -32,6 +32,8 @@ const (
 	EBSConnectionType shared.ConnectionType = "ebs"
 )
 
+var _ plugin.Closer = (*AwsEbsConnection)(nil)
+
 type AwsEbsConnection struct {
 	plugin.Connection
 	asset               *inventory.Asset

--- a/providers/azure/connection/azureinstancesnapshot/provider.go
+++ b/providers/azure/connection/azureinstancesnapshot/provider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v10/mrn"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/inventory"
+	"go.mondoo.com/cnquery/v10/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/vault"
 	"go.mondoo.com/cnquery/v10/providers/azure/connection/auth"
 	"go.mondoo.com/cnquery/v10/providers/azure/connection/shared"
@@ -279,6 +280,8 @@ func NewAzureSnapshotConnection(id uint32, conf *inventory.Config, asset *invent
 	asset.Platform.Runtime = c.Runtime()
 	return c, nil
 }
+
+var _ plugin.Closer = (*AzureSnapshotConnection)(nil)
 
 type AzureSnapshotConnection struct {
 	*fs.FileSystemConnection

--- a/providers/gcp/connection/gcpinstancesnapshot/provider.go
+++ b/providers/gcp/connection/gcpinstancesnapshot/provider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v10/mrn"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/inventory"
+	"go.mondoo.com/cnquery/v10/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v10/providers/gcp/connection/shared"
 	"go.mondoo.com/cnquery/v10/providers/os/connection/fs"
 	"go.mondoo.com/cnquery/v10/providers/os/connection/local"
@@ -251,6 +252,8 @@ func NewGcpSnapshotConnection(id uint32, conf *inventory.Config, asset *inventor
 
 	return c, nil
 }
+
+var _ plugin.Closer = (*GcpSnapshotConnection)(nil)
 
 type GcpSnapshotConnection struct {
 	*fs.FileSystemConnection

--- a/providers/os/connection/fs/filesystem.go
+++ b/providers/os/connection/fs/filesystem.go
@@ -14,7 +14,10 @@ import (
 	"go.mondoo.com/cnquery/v10/providers/os/fs"
 )
 
-var _ shared.Connection = &FileSystemConnection{}
+var (
+	_ shared.Connection = (*FileSystemConnection)(nil)
+	_ plugin.Closer     = (*FileSystemConnection)(nil)
+)
 
 func NewFileSystemConnectionWithClose(id uint32, conf *inventory.Config, asset *inventory.Asset, closeFN func()) (*FileSystemConnection, error) {
 	path, ok := conf.Options["path"]

--- a/providers/os/connection/local/local.go
+++ b/providers/os/connection/local/local.go
@@ -109,10 +109,6 @@ func (p *LocalConnection) FileInfo(path string) (shared.FileInfoDetails, error) 
 	}, nil
 }
 
-func (p *LocalConnection) Close() {
-	// TODO: we need to close all commands and file handles
-}
-
 type CommandRunner struct {
 	shared.Command
 	cmdExecutor *exec.Cmd

--- a/providers/os/connection/ssh.go
+++ b/providers/os/connection/ssh.go
@@ -37,7 +37,10 @@ import (
 	"golang.org/x/crypto/ssh/knownhosts"
 )
 
-var _ shared.Connection = (*SshConnection)(nil)
+var (
+	_ shared.Connection = (*SshConnection)(nil)
+	_ plugin.Closer     = (*SshConnection)(nil)
+)
 
 type SshConnection struct {
 	plugin.Connection

--- a/providers/os/connection/tar.go
+++ b/providers/os/connection/tar.go
@@ -30,7 +30,10 @@ const (
 	FLATTENED_IMAGE = "flattened_path"
 )
 
-var _ shared.Connection = (*TarConnection)(nil)
+var (
+	_ shared.Connection = (*TarConnection)(nil)
+	_ plugin.Closer     = (*TarConnection)(nil)
+)
 
 type TarConnection struct {
 	plugin.Connection

--- a/providers/os/connection/winrm.go
+++ b/providers/os/connection/winrm.go
@@ -169,7 +169,3 @@ func (p *WinrmConnection) FileSystem() afero.Fs {
 	}
 	return p.fs
 }
-
-func (p *WinrmConnection) Close() {
-	// nothing to do yet
-}

--- a/providers/terraform/connection/connection.go
+++ b/providers/terraform/connection/connection.go
@@ -12,6 +12,8 @@ import (
 
 type ConnectionType string
 
+var _ plugin.Closer = (*Connection)(nil)
+
 // References:
 // - https://www.terraform.io/docs/language/syntax/configuration.html
 // - https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md


### PR DESCRIPTION
Just make sure that we explicitly state that these connections implement the `plugin.Closer` interface. This will make sure that if in the future the interface changes, we will get compiler errors

I removed the `Close` functions from connections that didn't really implement any logic in them to avoid confusion. If we need those in the future we can re-add and implement the `Close` functions.