### PR TITLE
🐛 Do not close runtime for root asset if no inventory.

### DIFF
--- a/explorer/scan/discovery.go
+++ b/explorer/scan/discovery.go
@@ -132,7 +132,6 @@ func DiscoverAssets(ctx context.Context, inv *inventory.Inventory, upstream *ups
 
 		// If there is no inventory, no assets have been discovered under the root asset
 		if rootAssetWithRuntime.Runtime.Provider.Connection.Inventory == nil {
-			closeRootRuntime = true
 			continue
 		}
 


### PR DESCRIPTION
If we are only scanning the root asset we shouldn't close its runtime if no inventory is specified