### PR TITLE
🧹 Do not fetch azure instance info if not required.

### DIFF
--- a/providers/azure/connection/azureinstancesnapshot/setup.go
+++ b/providers/azure/connection/azureinstancesnapshot/setup.go
@@ -55,6 +55,9 @@ func (c *AzureSnapshotConnection) setupDiskAndMount(target scanTarget, lun int32
 }
 
 func (c *AzureSnapshotConnection) setupDisk(target scanTarget) (mountedDiskInfo, assetInfo, error) {
+	if c.scanner.instanceInfo == nil {
+		return mountedDiskInfo{}, assetInfo{}, errors.New("cannot setup disk, instance info not found")
+	}
 	mi := mountedDiskInfo{}
 	ai := assetInfo{}
 	h := sha256.New()
@@ -79,7 +82,7 @@ func (c *AzureSnapshotConnection) setupDisk(target scanTarget) (mountedDiskInfo,
 		}
 
 		log.Debug().Str("boot disk", instanceInfo.bootDiskId).Msg("found boot disk for instance, cloning")
-		disk, err := c.snapshotCreator.cloneDisk(instanceInfo.bootDiskId, c.scanner.resourceGroup, diskName, c.scanner.location, c.scanner.vm.Zones)
+		disk, err := c.snapshotCreator.cloneDisk(instanceInfo.bootDiskId, c.scanner.resourceGroup, diskName, c.scanner.instanceInfo.location, c.scanner.instanceInfo.vm.Zones)
 		if err != nil {
 			log.Error().Err(err).Msg("could not complete disk cloning")
 			return mountedDiskInfo{}, assetInfo{}, errors.Wrap(err, "could not complete disk cloning")
@@ -95,7 +98,7 @@ func (c *AzureSnapshotConnection) setupDisk(target scanTarget) (mountedDiskInfo,
 			return mountedDiskInfo{}, assetInfo{}, err
 		}
 
-		disk, err := c.snapshotCreator.createSnapshotDisk(snapshotInfo.snapshotId, c.scanner.resourceGroup, diskName, c.scanner.location, c.scanner.vm.Zones)
+		disk, err := c.snapshotCreator.createSnapshotDisk(snapshotInfo.snapshotId, c.scanner.resourceGroup, diskName, c.scanner.instanceInfo.location, c.scanner.instanceInfo.vm.Zones)
 		if err != nil {
 			log.Error().Err(err).Msg("could not complete snapshot disk creation")
 			return mountedDiskInfo{}, assetInfo{}, errors.Wrap(err, "could not create disk from snapshot")
@@ -111,7 +114,7 @@ func (c *AzureSnapshotConnection) setupDisk(target scanTarget) (mountedDiskInfo,
 			return mountedDiskInfo{}, assetInfo{}, err
 		}
 
-		disk, err := c.snapshotCreator.cloneDisk(diskInfo.diskId, c.scanner.resourceGroup, diskName, c.scanner.location, c.scanner.vm.Zones)
+		disk, err := c.snapshotCreator.cloneDisk(diskInfo.diskId, c.scanner.resourceGroup, diskName, c.scanner.instanceInfo.location, c.scanner.instanceInfo.vm.Zones)
 		if err != nil {
 			log.Error().Err(err).Msg("could not complete disk cloning")
 			return mountedDiskInfo{}, assetInfo{}, errors.Wrap(err, "could not complete disk cloning")

--- a/providers/azure/connection/azureinstancesnapshot/snapshot.go
+++ b/providers/azure/connection/azureinstancesnapshot/snapshot.go
@@ -5,6 +5,7 @@ package azureinstancesnapshot
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -207,7 +208,10 @@ func (sc *snapshotCreator) cloneDisk(sourceDiskId, resourceGroupName, diskName s
 }
 
 // attachDisk attaches a disk to an instance
-func (sc *snapshotCreator) attachDisk(targetInstance instanceInfo, diskName, diskId string, lun int32) error {
+func (sc *snapshotCreator) attachDisk(targetInstance *instanceInfo, diskName, diskId string, lun int32) error {
+	if targetInstance == nil {
+		return errors.New("targetInstance is nil, cannot attach disk")
+	}
 	ctx := context.Background()
 	log.Debug().Str("disk-name", diskName).Int32("LUN", lun).Msg("attach disk")
 	computeSvc, err := sc.computeClient()
@@ -257,7 +261,10 @@ func (sc *snapshotCreator) attachDisk(targetInstance instanceInfo, diskName, dis
 	return err
 }
 
-func (sc *snapshotCreator) detachDisk(diskName string, targetInstance instanceInfo) error {
+func (sc *snapshotCreator) detachDisk(diskName string, targetInstance *instanceInfo) error {
+	if targetInstance == nil {
+		return errors.New("targetInstance is nil, cannot detach disk")
+	}
 	ctx := context.Background()
 	log.Debug().Str("instance-name", targetInstance.instanceName).Msg("detach disk from instance")
 	computeSvc, err := sc.computeClient()


### PR DESCRIPTION
We do not require scanner instance info if we're not attaching anything. Make the `instanceInfo` optional and only retrieve if required.

This means that we can perform a scan on an already mounted disk without ever communicating with the Azure API.