### PR TITLE
⭐️ extract files that are used by a package

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -623,6 +623,14 @@ package @defaults("name version") {
   installed bool
   // Whether the package is outdated
   outdated() bool
+
+  // Package files
+  files() []pkgFileInfo
+}
+
+private pkgFileInfo @defaults("path") {
+  // Path to the file
+  path string
 }
 
 // List of packages on this system

--- a/providers/os/resources/os.lr.manifest.yaml
+++ b/providers/os/resources/os.lr.manifest.yaml
@@ -561,6 +561,8 @@ resources:
         min_mondoo_version: latest
       description: {}
       epoch: {}
+      files:
+        min_mondoo_version: latest
       format: {}
       installed: {}
       name: {}
@@ -647,6 +649,11 @@ resources:
       file: {}
       params: {}
     min_mondoo_version: 5.15.0
+  pkgFileInfo:
+    fields:
+      path: {}
+    is_private: true
+    min_mondoo_version: latest
   platform:
     fields:
       vulnerabilityReport: {}

--- a/providers/os/resources/packages/aix_packages.go
+++ b/providers/os/resources/packages/aix_packages.go
@@ -55,23 +55,28 @@ type AixPkgManager struct {
 	platform *inventory.Platform
 }
 
-func (f *AixPkgManager) Name() string {
+func (a *AixPkgManager) Name() string {
 	return "AIX Package Manager"
 }
 
-func (f *AixPkgManager) Format() string {
+func (a *AixPkgManager) Format() string {
 	return AixPkgFormat
 }
 
-func (f *AixPkgManager) List() ([]Package, error) {
-	cmd, err := f.conn.RunCommand("lslpp -cl ")
+func (a *AixPkgManager) List() ([]Package, error) {
+	cmd, err := a.conn.RunCommand("lslpp -cl ")
 	if err != nil {
 		return nil, fmt.Errorf("could not read freebsd package list")
 	}
 
-	return parseAixPackages(f.platform, cmd.Stdout)
+	return parseAixPackages(a.platform, cmd.Stdout)
 }
 
-func (f *AixPkgManager) Available() (map[string]PackageUpdate, error) {
+func (a *AixPkgManager) Available() (map[string]PackageUpdate, error) {
 	return map[string]PackageUpdate{}, nil
+}
+
+func (a *AixPkgManager) Files(name string, version string, arch string) ([]FileRecord, error) {
+	// not yet implemented
+	return nil, nil
 }

--- a/providers/os/resources/packages/aix_packages_test.go
+++ b/providers/os/resources/packages/aix_packages_test.go
@@ -26,8 +26,7 @@ func TestParseAixPackages(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, 16, len(m), "detected the right amount of packages")
 
-	var p Package
-	p = Package{
+	p := Package{
 		Name:        "X11.apps.msmit",
 		Version:     "7.3.0.0",
 		Description: "AIXwindows msmit Application",

--- a/providers/os/resources/packages/apk_packages.go
+++ b/providers/os/resources/packages/apk_packages.go
@@ -11,6 +11,7 @@ import (
 	cpe2 "go.mondoo.com/cnquery/v10/providers/os/resources/cpe"
 	"go.mondoo.com/cnquery/v10/providers/os/resources/purl"
 	"io"
+	"path/filepath"
 	"regexp"
 
 	"github.com/rs/zerolog/log"
@@ -58,6 +59,7 @@ func ParseApkDbPackages(pf *inventory.Platform, input io.Reader) []Package {
 	scanner := bufio.NewScanner(input)
 	pkg := Package{}
 	var key string
+	var dir string
 	for scanner.Scan() {
 		line := scanner.Text()
 
@@ -95,6 +97,14 @@ func ParseApkDbPackages(pf *inventory.Platform, input io.Reader) []Package {
 			pkg.Origin = m[2] // origin
 		case "T":
 			pkg.Description = m[2] // description
+		case "F":
+			dir = m[2]
+		case "R":
+			// files
+			pkg.FilesAvailable = PkgFilesIncluded
+			pkg.Files = append(pkg.Files, FileRecord{
+				Path: filepath.Join(dir, m[2]),
+			})
 		}
 	}
 
@@ -157,4 +167,9 @@ func (apm *AlpinePkgManager) Available() (map[string]PackageUpdate, error) {
 		return nil, fmt.Errorf("could not read package update list")
 	}
 	return ParseApkUpdates(cmd.Stdout)
+}
+
+func (apm *AlpinePkgManager) Files(name string, version string, arch string) ([]FileRecord, error) {
+	// not yet implemented
+	return nil, nil
 }

--- a/providers/os/resources/packages/apk_packages_test.go
+++ b/providers/os/resources/packages/apk_packages_test.go
@@ -1,16 +1,14 @@
 // Copyright (c) Mondoo, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package packages_test
+package packages
 
 import (
 	"testing"
 
-	"go.mondoo.com/cnquery/v10/providers-sdk/v1/inventory"
-
 	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/cnquery/v10/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v10/providers/os/connection/mock"
-	"go.mondoo.com/cnquery/v10/providers/os/resources/packages"
 )
 
 func TestAlpineApkdbParser(t *testing.T) {
@@ -34,87 +32,190 @@ func TestAlpineApkdbParser(t *testing.T) {
 	}
 	defer f.Close()
 
-	m := packages.ParseApkDbPackages(pf, f)
+	m := ParseApkDbPackages(pf, f)
 	assert.Equal(t, 7, len(m), "detected the right amount of packages")
 
-	var p packages.Package
-	p = packages.Package{
-		Name:        "musl",
-		Version:     "1510953106:1.1.18-r2",
-		Epoch:       "1510953106",
-		Arch:        "x86_64",
-		Description: "the musl c library (libc) implementation",
-		Origin:      "musl",
-		PUrl:        "pkg:apk/alpine/musl@1510953106%3A1.1.18-r2?arch=x86_64&distro=alpine-3.7.0&epoch=1510953106",
-		CPE:         "cpe:2.3:a:musl:musl:1510953106:x86_64:*:*:*:*:x86_64:*",
-		Format:      packages.AlpinePkgFormat,
+	p := Package{
+		Name:           "musl",
+		Version:        "1510953106:1.1.18-r2",
+		Epoch:          "1510953106",
+		Arch:           "x86_64",
+		Description:    "the musl c library (libc) implementation",
+		Origin:         "musl",
+		PUrl:           "pkg:apk/alpine/musl@1510953106%3A1.1.18-r2?arch=x86_64&distro=alpine-3.7.0&epoch=1510953106",
+		CPE:            "cpe:2.3:a:musl:musl:1510953106:x86_64:*:*:*:*:x86_64:*",
+		Format:         AlpinePkgFormat,
+		FilesAvailable: PkgFilesIncluded,
+		Files: []FileRecord{
+			{
+				Path: "lib/libc.musl-x86_64.so.1",
+			},
+			{
+				Path: "lib/ld-musl-x86_64.so.1",
+			},
+		},
 	}
-	assert.Contains(t, m, p, "musl detected")
+	assert.Equal(t, findPkg(m, p.Name), p, p.Name)
 
-	p = packages.Package{
-		Name:        "libressl2.6-libcrypto",
-		Version:     "1510257703:2.6.3-r0",
-		Epoch:       "1510257703",
-		Arch:        "x86_64",
-		Description: "libressl libcrypto library",
-		Origin:      "libressl",
-		PUrl:        "pkg:apk/alpine/libressl2.6-libcrypto@1510257703%3A2.6.3-r0?arch=x86_64&distro=alpine-3.7.0&epoch=1510257703",
-		CPE:         "cpe:2.3:a:libressl2.6-libcrypto:libressl2.6-libcrypto:1510257703:x86_64:*:*:*:*:x86_64:*",
-		Format:      packages.AlpinePkgFormat,
+	p = Package{
+		Name:           "libressl2.6-libcrypto",
+		Version:        "1510257703:2.6.3-r0",
+		Epoch:          "1510257703",
+		Arch:           "x86_64",
+		Description:    "libressl libcrypto library",
+		Origin:         "libressl",
+		PUrl:           "pkg:apk/alpine/libressl2.6-libcrypto@1510257703%3A2.6.3-r0?arch=x86_64&distro=alpine-3.7.0&epoch=1510257703",
+		CPE:            "cpe:2.3:a:libressl2.6-libcrypto:libressl2.6-libcrypto:1510257703:x86_64:*:*:*:*:x86_64:*",
+		Format:         AlpinePkgFormat,
+		FilesAvailable: PkgFilesIncluded,
+		Files: []FileRecord{
+			{
+				Path: "etc/ssl/cert.pem",
+			},
+			{
+				Path: "etc/ssl/x509v3.cnf",
+			},
+			{
+				Path: "etc/ssl/openssl.cnf",
+			},
+			{
+				Path: "lib/libcrypto.so.42",
+			},
+			{
+				Path: "lib/libcrypto.so.42.0.0",
+			},
+			{
+				Path: "usr/lib/libcrypto.so.42",
+			},
+			{
+				Path: "usr/lib/libcrypto.so.42.0.0",
+			},
+		},
 	}
-	assert.Contains(t, m, p, "libcrypto detected")
+	assert.Equal(t, findPkg(m, p.Name), p, p.Name)
 
-	p = packages.Package{
-		Name:        "libressl2.6-libssl",
-		Version:     "1510257703:2.6.3-r0",
-		Epoch:       "1510257703",
-		Arch:        "x86_64",
-		Description: "libressl libssl library",
-		Origin:      "libressl",
-		PUrl:        "pkg:apk/alpine/libressl2.6-libssl@1510257703%3A2.6.3-r0?arch=x86_64&distro=alpine-3.7.0&epoch=1510257703",
-		CPE:         "cpe:2.3:a:libressl2.6-libssl:libressl2.6-libssl:1510257703:x86_64:*:*:*:*:x86_64:*",
-		Format:      packages.AlpinePkgFormat,
+	p = Package{
+		Name:           "libressl2.6-libssl",
+		Version:        "1510257703:2.6.3-r0",
+		Epoch:          "1510257703",
+		Arch:           "x86_64",
+		Description:    "libressl libssl library",
+		Origin:         "libressl",
+		PUrl:           "pkg:apk/alpine/libressl2.6-libssl@1510257703%3A2.6.3-r0?arch=x86_64&distro=alpine-3.7.0&epoch=1510257703",
+		CPE:            "cpe:2.3:a:libressl2.6-libssl:libressl2.6-libssl:1510257703:x86_64:*:*:*:*:x86_64:*",
+		Format:         AlpinePkgFormat,
+		FilesAvailable: PkgFilesIncluded,
+		Files: []FileRecord{
+			{
+				Path: "lib/libssl.so.44.0.1",
+			},
+			{
+				Path: "lib/libssl.so.44",
+			},
+			{
+				Path: "usr/lib/libssl.so.44.0.1",
+			},
+			{
+				Path: "usr/lib/libssl.so.44",
+			},
+		},
 	}
-	assert.Contains(t, m, p, "libssl detected")
+	assert.Equal(t, findPkg(m, p.Name), p, p.Name)
 
-	p = packages.Package{
-		Name:        "apk-tools",
-		Version:     "1515485577:2.8.2-r0",
-		Epoch:       "1515485577",
-		Arch:        "x86_64",
-		Description: "Alpine Package Keeper - package manager for alpine",
-		Origin:      "apk-tools",
-		PUrl:        "pkg:apk/alpine/apk-tools@1515485577%3A2.8.2-r0?arch=x86_64&distro=alpine-3.7.0&epoch=1515485577",
-		CPE:         "cpe:2.3:a:apk-tools:apk-tools:1515485577:x86_64:*:*:*:*:x86_64:*",
-		Format:      packages.AlpinePkgFormat,
+	p = Package{
+		Name:           "apk-tools",
+		Version:        "1515485577:2.8.2-r0",
+		Epoch:          "1515485577",
+		Arch:           "x86_64",
+		Description:    "Alpine Package Keeper - package manager for alpine",
+		Origin:         "apk-tools",
+		PUrl:           "pkg:apk/alpine/apk-tools@1515485577%3A2.8.2-r0?arch=x86_64&distro=alpine-3.7.0&epoch=1515485577",
+		CPE:            "cpe:2.3:a:apk-tools:apk-tools:1515485577:x86_64:*:*:*:*:x86_64:*",
+		Format:         AlpinePkgFormat,
+		FilesAvailable: PkgFilesIncluded,
+		Files: []FileRecord{
+			{
+				Path: "sbin/apk",
+			},
+		},
 	}
-	assert.Contains(t, m, p, "apk-tools detected")
+	assert.Equal(t, findPkg(m, p.Name), p, p.Name)
 
-	p = packages.Package{
-		Name:        "busybox",
-		Version:     "1513075346:1.27.2-r7",
-		Epoch:       "1513075346",
-		Arch:        "x86_64",
-		Description: "Size optimized toolbox of many common UNIX utilities",
-		Origin:      "busybox",
-		PUrl:        "pkg:apk/alpine/busybox@1513075346%3A1.27.2-r7?arch=x86_64&distro=alpine-3.7.0&epoch=1513075346",
-		CPE:         "cpe:2.3:a:busybox:busybox:1513075346:x86_64:*:*:*:*:x86_64:*",
-		Format:      packages.AlpinePkgFormat,
+	p = Package{
+		Name:           "busybox",
+		Version:        "1513075346:1.27.2-r7",
+		Epoch:          "1513075346",
+		Arch:           "x86_64",
+		Description:    "Size optimized toolbox of many common UNIX utilities",
+		Origin:         "busybox",
+		PUrl:           "pkg:apk/alpine/busybox@1513075346%3A1.27.2-r7?arch=x86_64&distro=alpine-3.7.0&epoch=1513075346",
+		CPE:            "cpe:2.3:a:busybox:busybox:1513075346:x86_64:*:*:*:*:x86_64:*",
+		Format:         AlpinePkgFormat,
+		FilesAvailable: PkgFilesIncluded,
+		Files: []FileRecord{
+			{
+				Path: "bin/busybox",
+			},
+			{
+				Path: "bin/sh",
+			},
+			{
+				Path: "etc/securetty",
+			},
+			{
+				Path: "etc/udhcpd.conf",
+			},
+			{
+				Path: "etc/logrotate.d/acpid",
+			},
+			{
+				Path: "etc/network/if-up.d/dad",
+			},
+		},
 	}
-	assert.Contains(t, m, p, "busybox detected")
+	assert.Equal(t, findPkg(m, p.Name), p, p.Name)
 
-	p = packages.Package{
-		Name:        "alpine-baselayout",
-		Version:     "1510075862:3.0.5-r2",
-		Epoch:       "1510075862",
-		Arch:        "x86_64",
-		Description: "Alpine base dir structure and init scripts",
-		Origin:      "alpine-baselayout",
-		PUrl:        "pkg:apk/alpine/alpine-baselayout@1510075862%3A3.0.5-r2?arch=x86_64&distro=alpine-3.7.0&epoch=1510075862",
-		CPE:         "cpe:2.3:a:alpine-baselayout:alpine-baselayout:1510075862:x86_64:*:*:*:*:x86_64:*",
-		Format:      packages.AlpinePkgFormat,
+	p = Package{
+		Name:           "alpine-baselayout",
+		Version:        "1510075862:3.0.5-r2",
+		Epoch:          "1510075862",
+		Arch:           "x86_64",
+		Description:    "Alpine base dir structure and init scripts",
+		Origin:         "alpine-baselayout",
+		PUrl:           "pkg:apk/alpine/alpine-baselayout@1510075862%3A3.0.5-r2?arch=x86_64&distro=alpine-3.7.0&epoch=1510075862",
+		CPE:            "cpe:2.3:a:alpine-baselayout:alpine-baselayout:1510075862:x86_64:*:*:*:*:x86_64:*",
+		Format:         AlpinePkgFormat,
+		FilesAvailable: PkgFilesIncluded,
+		Files: []FileRecord{
+			{Path: "etc/hosts"},
+			{Path: "etc/sysctl.conf"},
+			{Path: "etc/group"},
+			{Path: "etc/protocols"},
+			{Path: "etc/fstab"},
+			{Path: "etc/mtab"},
+			{Path: "etc/profile"},
+			{Path: "etc/TZ"},
+			{Path: "etc/shells"},
+			{Path: "etc/motd"},
+			{Path: "etc/inittab"},
+			{Path: "etc/hostname"},
+			{Path: "etc/modules"},
+			{Path: "etc/services"},
+			{Path: "etc/shadow"},
+			{Path: "etc/passwd"},
+			{Path: "etc/profile.d/color_prompt"},
+			{Path: "etc/sysctl.d/00-alpine.conf"},
+			{Path: "etc/modprobe.d/i386.conf"},
+			{Path: "etc/modprobe.d/blacklist.conf"},
+			{Path: "etc/modprobe.d/aliases.conf"},
+			{Path: "etc/modprobe.d/kms.conf"},
+			{Path: "etc/crontabs/root"},
+			{Path: "sbin/mkmntdirs"},
+			{Path: "var/run"},
+			{Path: "var/spool/cron/crontabs"},
+		},
 	}
-	assert.Contains(t, m, p, "alpine-baselayout detected")
+	assert.Equal(t, findPkg(m, p.Name), p, p.Name)
 }
 
 func TestApkUpdateParser(t *testing.T) {
@@ -128,7 +229,7 @@ func TestApkUpdateParser(t *testing.T) {
 	}
 	assert.Nil(t, err)
 
-	m, err := packages.ParseApkUpdates(c.Stdout)
+	m, err := ParseApkUpdates(c.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(m), "detected the right amount of package updates")
 

--- a/providers/os/resources/packages/cos_packages.go
+++ b/providers/os/resources/packages/cos_packages.go
@@ -51,7 +51,7 @@ func (cpm *CosPkgManager) List() ([]Package, error) {
 	return ParseCosPackages(fr)
 }
 
-func (mpm *CosPkgManager) Available() (map[string]PackageUpdate, error) {
+func (cpm *CosPkgManager) Available() (map[string]PackageUpdate, error) {
 	return nil, errors.New("cannot determine available packages for cos")
 }
 
@@ -80,4 +80,9 @@ func ParseCosPackages(input io.Reader) ([]Package, error) {
 	}
 
 	return pkgs, nil
+}
+
+func (cpm *CosPkgManager) Files(name string, version string, arch string) ([]FileRecord, error) {
+	// not yet implemented
+	return nil, nil
 }

--- a/providers/os/resources/packages/cos_packages_test.go
+++ b/providers/os/resources/packages/cos_packages_test.go
@@ -19,8 +19,7 @@ func TestParseCosPackages(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(m), "detected the right amount of packages")
 
-	var p Package
-	p = Package{
+	p := Package{
 		Name:    "zlib",
 		Version: "1.2.11-r4",
 		Arch:    "",

--- a/providers/os/resources/packages/freebsd_packages.go
+++ b/providers/os/resources/packages/freebsd_packages.go
@@ -84,3 +84,8 @@ func (f *FreeBSDPkgManager) List() ([]Package, error) {
 func (f *FreeBSDPkgManager) Available() (map[string]PackageUpdate, error) {
 	return map[string]PackageUpdate{}, nil
 }
+
+func (mpm *FreeBSDPkgManager) Files(name string, version string, arch string) ([]FileRecord, error) {
+	// not yet implemented
+	return nil, nil
+}

--- a/providers/os/resources/packages/macos_packages.go
+++ b/providers/os/resources/packages/macos_packages.go
@@ -34,6 +34,7 @@ func ParseMacOSPackages(input io.Reader) ([]Package, error) {
 	type sysProfilerItems struct {
 		Name    string `plist:"_name"`
 		Version string `plist:"version"`
+		Path    string `plist:"path"`
 	}
 
 	type sysProfiler struct {
@@ -56,6 +57,14 @@ func ParseMacOSPackages(input io.Reader) ([]Package, error) {
 		pkgs[i].Name = entry.Name
 		pkgs[i].Version = entry.Version
 		pkgs[i].Format = MacosPkgFormat
+		pkgs[i].FilesAvailable = PkgFilesIncluded
+		if entry.Path != "" {
+			pkgs[i].Files = []FileRecord{
+				{
+					Path: entry.Path,
+				},
+			}
+		}
 	}
 
 	return pkgs, nil
@@ -85,4 +94,9 @@ func (mpm *MacOSPkgManager) List() ([]Package, error) {
 
 func (mpm *MacOSPkgManager) Available() (map[string]PackageUpdate, error) {
 	return nil, errors.New("cannot determine available packages for macOS")
+}
+
+func (mpm *MacOSPkgManager) Files(name string, version string, arch string) ([]FileRecord, error) {
+	// nothing extra to be done here since the list is already included in the package list
+	return nil, nil
 }

--- a/providers/os/resources/packages/macos_packages_test.go
+++ b/providers/os/resources/packages/macos_packages_test.go
@@ -30,8 +30,12 @@ func TestMacOsXPackageParser(t *testing.T) {
 	assert.Equal(t, "Preview", m[0].Name, "pkg name detected")
 	assert.Equal(t, "10.0", m[0].Version, "pkg version detected")
 	assert.Equal(t, packages.MacosPkgFormat, m[0].Format, "pkg format detected")
+	assert.Equal(t, packages.PkgFilesIncluded, m[0].FilesAvailable)
+	assert.Equal(t, []packages.FileRecord{{Path: "/Applications/Preview.app"}}, m[0].Files)
 
 	assert.Equal(t, "Contacts", m[1].Name, "pkg name detected")
 	assert.Equal(t, "11.0", m[1].Version, "pkg version detected")
-	assert.Equal(t, packages.MacosPkgFormat, m[0].Format, "pkg format detected")
+	assert.Equal(t, packages.MacosPkgFormat, m[1].Format, "pkg format detected")
+	assert.Equal(t, packages.PkgFilesIncluded, m[1].FilesAvailable)
+	assert.Equal(t, []packages.FileRecord{{Path: "/Applications/Contacts.app"}}, m[1].Files)
 }

--- a/providers/os/resources/packages/opkg_packages.go
+++ b/providers/os/resources/packages/opkg_packages.go
@@ -172,3 +172,8 @@ func (opkg *OpkgPkgManager) ListFromFile() ([]Package, error) {
 func (opkg *OpkgPkgManager) Available() (map[string]PackageUpdate, error) {
 	return map[string]PackageUpdate{}, nil
 }
+
+func (opkg *OpkgPkgManager) Files(name string, version string, arch string) ([]FileRecord, error) {
+	// not yet implemented
+	return nil, nil
+}

--- a/providers/os/resources/packages/opkg_packages_test.go
+++ b/providers/os/resources/packages/opkg_packages_test.go
@@ -25,8 +25,7 @@ firewall - 2016-11-29-1`
 	m := packages.ParseOpkgListPackagesCommand(strings.NewReader(pkgList))
 
 	assert.Equal(t, 5, len(m), "detected the right amount of packages")
-	var p packages.Package
-	p = packages.Package{
+	p := packages.Package{
 		Name:    "busybox",
 		Version: "1.24.2-1",
 		Format:  packages.OpkgPkgFormat,

--- a/providers/os/resources/packages/packages_test.go
+++ b/providers/os/resources/packages/packages_test.go
@@ -1,0 +1,13 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package packages
+
+func findPkg(pkgs []Package, name string) Package {
+	for _, p := range pkgs {
+		if p.Name == name {
+			return p
+		}
+	}
+	panic("package not found: " + name)
+}

--- a/providers/os/resources/packages/pacman_packages.go
+++ b/providers/os/resources/packages/pacman_packages.go
@@ -68,3 +68,8 @@ func (ppm *PacmanPkgManager) List() ([]Package, error) {
 func (ppm *PacmanPkgManager) Available() (map[string]PackageUpdate, error) {
 	return nil, errors.New("Available() not implemented for pacman")
 }
+
+func (ppm *PacmanPkgManager) Files(name string, version string, arch string) ([]FileRecord, error) {
+	// not yet implemented
+	return nil, nil
+}

--- a/providers/os/resources/packages/pacman_packages_test.go
+++ b/providers/os/resources/packages/pacman_packages_test.go
@@ -35,8 +35,7 @@ zziplib 0.13.67-1`
 	m := packages.ParsePacmanPackages(pf, strings.NewReader(pkgList))
 
 	assert.Equal(t, 8, len(m), "detected the right amount of packages")
-	var p packages.Package
-	p = packages.Package{
+	p := packages.Package{
 		Name:    "qpdfview",
 		Version: "0.4.17beta1-4.1",
 		PUrl:    "pkg:alpm/arch/qpdfview@0.4.17beta1-4.1?distro=arch",

--- a/providers/os/resources/packages/rpm_packages_test.go
+++ b/providers/os/resources/packages/rpm_packages_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Mondoo, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package packages_test
+package packages
 
 import (
 	"bytes"
@@ -11,13 +11,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"go.mondoo.com/cnquery/v10/providers-sdk/v1/inventory"
-
 	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/v10/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v10/providers/os/connection/mock"
-	"go.mondoo.com/cnquery/v10/providers/os/resources/packages"
 )
 
 func TestRedhat7Parser(t *testing.T) {
@@ -41,66 +39,94 @@ func TestRedhat7Parser(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m := packages.ParseRpmPackages(pf, c.Stdout)
+	m := ParseRpmPackages(pf, c.Stdout)
 	assert.Equal(t, 144, len(m), "detected the right amount of packages")
 
-	var p packages.Package
-	p = packages.Package{
-		Name:        "ncurses-base",
-		Version:     "5.9-14.20130511.el7_4",
-		Arch:        "noarch",
-		Description: "Descriptions of common terminals",
-		PUrl:        "pkg:rpm/rhel/ncurses-base@5.9-14.20130511.el7_4?arch=noarch&distro=rhel-7.4",
-		CPE:         "cpe:2.3:a:ncurses-base:ncurses-base:5.9-14.20130511.el7_4:noarch:*:*:*:*:*:*",
-		Format:      packages.RpmPkgFormat,
+	p := Package{
+		Name:           "ncurses-base",
+		Version:        "5.9-14.20130511.el7_4",
+		Arch:           "noarch",
+		Description:    "Descriptions of common terminals",
+		PUrl:           "pkg:rpm/rhel/ncurses-base@5.9-14.20130511.el7_4?arch=noarch&distro=rhel-7.4",
+		CPE:            "cpe:2.3:a:ncurses-base:ncurses-base:5.9-14.20130511.el7_4:noarch:*:*:*:*:*:*",
+		Format:         RpmPkgFormat,
+		FilesAvailable: PkgFilesAsync,
 	}
-	assert.Contains(t, m, p, "ncurses-base")
+	assert.Equal(t, findPkg(m, p.Name), p, p.Name)
 
-	p = packages.Package{
-		Name:        "libstdc++",
-		Version:     "4.8.5-28.el7_5.1",
-		Arch:        "x86_64",
-		Description: "GNU Standard C++ Library",
-		PUrl:        "pkg:rpm/rhel/libstdc%2B%2B@4.8.5-28.el7_5.1?arch=x86_64&distro=rhel-7.4",
-		CPE:         "cpe:2.3:a:libstdc++:libstdc\\+\\+:4.8.5-28.el7_5.1:x86_64:*:*:*:*:*:*",
-		Format:      packages.RpmPkgFormat,
+	p = Package{
+		Name:           "libstdc++",
+		Version:        "4.8.5-28.el7_5.1",
+		Arch:           "x86_64",
+		Description:    "GNU Standard C++ Library",
+		PUrl:           "pkg:rpm/rhel/libstdc%2B%2B@4.8.5-28.el7_5.1?arch=x86_64&distro=rhel-7.4",
+		CPE:            "cpe:2.3:a:libstdc++:libstdc\\+\\+:4.8.5-28.el7_5.1:x86_64:*:*:*:*:*:*",
+		Format:         RpmPkgFormat,
+		FilesAvailable: PkgFilesAsync,
 	}
-	assert.Contains(t, m, p, "libstdc detected")
+	assert.Equal(t, findPkg(m, p.Name), p, p.Name)
 
-	p = packages.Package{
-		Name:        "iputils",
-		Version:     "20160308-10.el7",
-		Arch:        "x86_64",
-		Description: "Network monitoring tools including ping",
-		PUrl:        "pkg:rpm/rhel/iputils@20160308-10.el7?arch=x86_64&distro=rhel-7.4",
-		CPE:         "cpe:2.3:a:iputils:iputils:20160308-10.el7:x86_64:*:*:*:*:*:*",
-		Format:      packages.RpmPkgFormat,
+	p = Package{
+		Name:           "iputils",
+		Version:        "20160308-10.el7",
+		Arch:           "x86_64",
+		Description:    "Network monitoring tools including ping",
+		PUrl:           "pkg:rpm/rhel/iputils@20160308-10.el7?arch=x86_64&distro=rhel-7.4",
+		CPE:            "cpe:2.3:a:iputils:iputils:20160308-10.el7:x86_64:*:*:*:*:*:*",
+		Format:         RpmPkgFormat,
+		FilesAvailable: PkgFilesAsync,
 	}
-	assert.Contains(t, m, p, "gpg-pubkey detected")
+	assert.Equal(t, findPkg(m, p.Name), p, p.Name)
 
-	p = packages.Package{
-		Name:        "openssl-libs",
-		Version:     "1:1.0.2k-12.el7",
-		Epoch:       "1",
-		Arch:        "x86_64",
-		Description: "A general purpose cryptography library with TLS implementation",
-		PUrl:        "pkg:rpm/rhel/openssl-libs@1%3A1.0.2k-12.el7?arch=x86_64&distro=rhel-7.4&epoch=1",
-		CPE:         "cpe:2.3:a:openssl-libs:openssl-libs:1:x86_64:*:*:*:*:1:*",
-		Format:      packages.RpmPkgFormat,
+	p = Package{
+		Name:           "openssl-libs",
+		Version:        "1:1.0.2k-12.el7",
+		Epoch:          "1",
+		Arch:           "x86_64",
+		Description:    "A general purpose cryptography library with TLS implementation",
+		PUrl:           "pkg:rpm/rhel/openssl-libs@1%3A1.0.2k-12.el7?arch=x86_64&distro=rhel-7.4&epoch=1",
+		CPE:            "cpe:2.3:a:openssl-libs:openssl-libs:1:x86_64:*:*:*:*:1:*",
+		Format:         RpmPkgFormat,
+		FilesAvailable: PkgFilesAsync,
 	}
-	assert.Contains(t, m, p, "gpg-pubkey detected")
+	assert.Equal(t, findPkg(m, p.Name), p, p.Name)
 
-	p = packages.Package{
-		Name:        "dbus-libs",
-		Version:     "1:1.10.24-7.el7",
-		Epoch:       "1",
-		Arch:        "x86_64",
-		Description: "Libraries for accessing D-BUS",
-		PUrl:        "pkg:rpm/rhel/dbus-libs@1%3A1.10.24-7.el7?arch=x86_64&distro=rhel-7.4&epoch=1",
-		CPE:         "cpe:2.3:a:dbus-libs:dbus-libs:1:x86_64:*:*:*:*:1:*",
-		Format:      packages.RpmPkgFormat,
+	p = Package{
+		Name:           "dbus-libs",
+		Version:        "1:1.10.24-7.el7",
+		Epoch:          "1",
+		Arch:           "x86_64",
+		Description:    "Libraries for accessing D-BUS",
+		PUrl:           "pkg:rpm/rhel/dbus-libs@1%3A1.10.24-7.el7?arch=x86_64&distro=rhel-7.4&epoch=1",
+		CPE:            "cpe:2.3:a:dbus-libs:dbus-libs:1:x86_64:*:*:*:*:1:*",
+		Format:         RpmPkgFormat,
+		FilesAvailable: PkgFilesAsync,
 	}
-	assert.Contains(t, m, p, "gpg-pubkey detected")
+	assert.Equal(t, findPkg(m, p.Name), p, p.Name)
+
+	// fetch package files
+	p = Package{
+		Name:           "hostname",
+		Version:        "3.13-3.el7",
+		Epoch:          "",
+		Arch:           "x86_64",
+		Description:    "Utility to set/show the host name or domain name",
+		PUrl:           "pkg:rpm/rhel/hostname@3.13-3.el7?arch=x86_64&distro=rhel-7.4",
+		CPE:            "cpe:2.3:a:hostname:hostname:3.13-3.el7:x86_64:*:*:*:*:*:*",
+		Format:         RpmPkgFormat,
+		FilesAvailable: PkgFilesAsync,
+	}
+	assert.Equal(t, findPkg(m, p.Name), p, p.Name)
+
+	mgr := &RpmPkgManager{
+		conn:     mock,
+		platform: pf,
+	}
+	pkgFiles, err := mgr.Files(p.Name, p.Version, p.Arch)
+	require.NoError(t, err)
+	assert.Equal(t, 4, len(pkgFiles), "detected the right amount of package files")
+	assert.Contains(t, pkgFiles, FileRecord{Path: "/usr/bin/dnsdomainname"})
+	assert.Contains(t, pkgFiles, FileRecord{Path: "/usr/share/man/man1/ypdomainname.1.gz"})
 }
 
 func TestRedhat6Parser(t *testing.T) {
@@ -124,53 +150,56 @@ func TestRedhat6Parser(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m := packages.ParseRpmPackages(pf, c.Stdout)
+	m := ParseRpmPackages(pf, c.Stdout)
 	assert.Equal(t, 8, len(m), "detected the right amount of packages")
 
-	var p packages.Package
-	p = packages.Package{
-		Name:        "ElectricFence",
-		Version:     "2.1-3",
-		Arch:        "i386",
-		Description: "A debugger which detects memory allocation violations.",
-		PUrl:        "pkg:rpm/rhel/ElectricFence@2.1-3?arch=i386&distro=rhel-6.2",
-		CPE:         "cpe:2.3:a:electricfence:electricfence:2.1-3:i386:*:*:*:*:*:*",
-		Format:      packages.RpmPkgFormat,
+	p := Package{
+		Name:           "ElectricFence",
+		Version:        "2.1-3",
+		Arch:           "i386",
+		Description:    "A debugger which detects memory allocation violations.",
+		PUrl:           "pkg:rpm/rhel/ElectricFence@2.1-3?arch=i386&distro=rhel-6.2",
+		CPE:            "cpe:2.3:a:electricfence:electricfence:2.1-3:i386:*:*:*:*:*:*",
+		Format:         RpmPkgFormat,
+		FilesAvailable: PkgFilesAsync,
 	}
 	assert.Contains(t, m, p, "ElectricFence")
 
-	p = packages.Package{
-		Name:        "shadow-utils",
-		Version:     "1:19990827-10",
-		Epoch:       "1",
-		Arch:        "i386",
-		Description: "Utilities for managing shadow password files and user/group accounts.",
-		PUrl:        "pkg:rpm/rhel/shadow-utils@1%3A19990827-10?arch=i386&distro=rhel-6.2&epoch=1",
-		CPE:         "cpe:2.3:a:shadow-utils:shadow-utils:1:i386:*:*:*:*:1:*",
-		Format:      packages.RpmPkgFormat,
+	p = Package{
+		Name:           "shadow-utils",
+		Version:        "1:19990827-10",
+		Epoch:          "1",
+		Arch:           "i386",
+		Description:    "Utilities for managing shadow password files and user/group accounts.",
+		PUrl:           "pkg:rpm/rhel/shadow-utils@1%3A19990827-10?arch=i386&distro=rhel-6.2&epoch=1",
+		CPE:            "cpe:2.3:a:shadow-utils:shadow-utils:1:i386:*:*:*:*:1:*",
+		Format:         RpmPkgFormat,
+		FilesAvailable: PkgFilesAsync,
 	}
 	assert.Contains(t, m, p, "shadow-utils")
 
-	p = packages.Package{
-		Name:        "arpwatch",
-		Version:     "1:2.1a4-19",
-		Epoch:       "1",
-		Arch:        "i386",
-		Description: "Network monitoring tools for tracking IP addresses on a network.",
-		PUrl:        "pkg:rpm/rhel/arpwatch@1%3A2.1a4-19?arch=i386&distro=rhel-6.2&epoch=1",
-		CPE:         "cpe:2.3:a:arpwatch:arpwatch:1:i386:*:*:*:*:1:*",
-		Format:      packages.RpmPkgFormat,
+	p = Package{
+		Name:           "arpwatch",
+		Version:        "1:2.1a4-19",
+		Epoch:          "1",
+		Arch:           "i386",
+		Description:    "Network monitoring tools for tracking IP addresses on a network.",
+		PUrl:           "pkg:rpm/rhel/arpwatch@1%3A2.1a4-19?arch=i386&distro=rhel-6.2&epoch=1",
+		CPE:            "cpe:2.3:a:arpwatch:arpwatch:1:i386:*:*:*:*:1:*",
+		Format:         RpmPkgFormat,
+		FilesAvailable: PkgFilesAsync,
 	}
 	assert.Contains(t, m, p, "arpwatch")
 
-	p = packages.Package{
-		Name:        "bash",
-		Version:     "1.14.7-22",
-		Arch:        "i386",
-		Description: "The GNU Bourne Again shell (bash) version 1.14.",
-		PUrl:        "pkg:rpm/rhel/bash@1.14.7-22?arch=i386&distro=rhel-6.2",
-		CPE:         "cpe:2.3:a:bash:bash:1.14.7-22:i386:*:*:*:*:*:*",
-		Format:      packages.RpmPkgFormat,
+	p = Package{
+		Name:           "bash",
+		Version:        "1.14.7-22",
+		Arch:           "i386",
+		Description:    "The GNU Bourne Again shell (bash) version 1.14.",
+		PUrl:           "pkg:rpm/rhel/bash@1.14.7-22?arch=i386&distro=rhel-6.2",
+		CPE:            "cpe:2.3:a:bash:bash:1.14.7-22:i386:*:*:*:*:*:*",
+		Format:         RpmPkgFormat,
+		FilesAvailable: PkgFilesAsync,
 	}
 	assert.Contains(t, m, p, "bash")
 }
@@ -219,40 +248,42 @@ func TestPhoton4ImageParser(t *testing.T) {
 		},
 	}
 
-	m := packages.ParseRpmPackages(pf, &packageList)
+	m := ParseRpmPackages(pf, &packageList)
 	assert.Equal(t, 36, len(m), "detected the right amount of packages")
 
-	var p packages.Package
-	p = packages.Package{
-		Name:        "ncurses-libs",
-		Version:     "6.2-6.ph4",
-		Arch:        "x86_64",
-		Description: "Ncurses Libraries",
-		PUrl:        "pkg:rpm/photon/ncurses-libs@6.2-6.ph4?arch=x86_64&distro=photon-3.0",
-		CPE:         "cpe:2.3:a:ncurses-libs:ncurses-libs:6.2-6.ph4:x86_64:*:*:*:*:*:*",
-		Format:      packages.RpmPkgFormat,
+	p := Package{
+		Name:           "ncurses-libs",
+		Version:        "6.2-6.ph4",
+		Arch:           "x86_64",
+		Description:    "Ncurses Libraries",
+		PUrl:           "pkg:rpm/photon/ncurses-libs@6.2-6.ph4?arch=x86_64&distro=photon-3.0",
+		CPE:            "cpe:2.3:a:ncurses-libs:ncurses-libs:6.2-6.ph4:x86_64:*:*:*:*:*:*",
+		Format:         RpmPkgFormat,
+		FilesAvailable: PkgFilesAsync,
 	}
 	assert.Contains(t, m, p, "ncurses-libs")
 
-	p = packages.Package{
-		Name:        "bash",
-		Version:     "5.0-2.ph4",
-		Arch:        "x86_64",
-		Description: "Bourne-Again SHell",
-		PUrl:        "pkg:rpm/photon/bash@5.0-2.ph4?arch=x86_64&distro=photon-3.0",
-		CPE:         "cpe:2.3:a:bash:bash:5.0-2.ph4:x86_64:*:*:*:*:*:*",
-		Format:      packages.RpmPkgFormat,
+	p = Package{
+		Name:           "bash",
+		Version:        "5.0-2.ph4",
+		Arch:           "x86_64",
+		Description:    "Bourne-Again SHell",
+		PUrl:           "pkg:rpm/photon/bash@5.0-2.ph4?arch=x86_64&distro=photon-3.0",
+		CPE:            "cpe:2.3:a:bash:bash:5.0-2.ph4:x86_64:*:*:*:*:*:*",
+		Format:         RpmPkgFormat,
+		FilesAvailable: PkgFilesAsync,
 	}
 	assert.Contains(t, m, p, "bash")
 
-	p = packages.Package{
-		Name:        "sqlite-libs",
-		Version:     "3.38.5-1.ph4",
-		Arch:        "x86_64",
-		Description: "sqlite3 library",
-		PUrl:        "pkg:rpm/photon/sqlite-libs@3.38.5-1.ph4?arch=x86_64&distro=photon-3.0",
-		CPE:         "cpe:2.3:a:sqlite-libs:sqlite-libs:3.38.5-1.ph4:x86_64:*:*:*:*:*:*",
-		Format:      packages.RpmPkgFormat,
+	p = Package{
+		Name:           "sqlite-libs",
+		Version:        "3.38.5-1.ph4",
+		Arch:           "x86_64",
+		Description:    "sqlite3 library",
+		PUrl:           "pkg:rpm/photon/sqlite-libs@3.38.5-1.ph4?arch=x86_64&distro=photon-3.0",
+		CPE:            "cpe:2.3:a:sqlite-libs:sqlite-libs:3.38.5-1.ph4:x86_64:*:*:*:*:*:*",
+		Format:         RpmPkgFormat,
+		FilesAvailable: PkgFilesAsync,
 	}
 	assert.Contains(t, m, p, "sqlite-libs")
 }

--- a/providers/os/resources/packages/scratch.go
+++ b/providers/os/resources/packages/scratch.go
@@ -24,3 +24,8 @@ func (dpm *ScratchPkgManager) List() ([]Package, error) {
 func (dpm *ScratchPkgManager) Available() (map[string]PackageUpdate, error) {
 	return map[string]PackageUpdate{}, nil
 }
+
+func (dpm *ScratchPkgManager) Files(nname string, version string, arch string) ([]FileRecord, error) {
+	// not yet implemented
+	return nil, nil
+}

--- a/providers/os/resources/packages/solaris_packages.go
+++ b/providers/os/resources/packages/solaris_packages.go
@@ -100,3 +100,8 @@ func (s *SolarisPkgManager) List() ([]Package, error) {
 func (s *SolarisPkgManager) Available() (map[string]PackageUpdate, error) {
 	return map[string]PackageUpdate{}, nil
 }
+
+func (s *SolarisPkgManager) Files(name string, version string, arch string) ([]FileRecord, error) {
+	// not yet implemented
+	return nil, nil
+}

--- a/providers/os/resources/packages/solaris_packages_test.go
+++ b/providers/os/resources/packages/solaris_packages_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Mondoo, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package packages_test
+package packages
 
 import (
 	"path/filepath"
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v10/providers/os/connection/mock"
-	"go.mondoo.com/cnquery/v10/providers/os/resources/packages"
 )
 
 func TestFmriParser(t *testing.T) {
@@ -22,7 +21,7 @@ func TestFmriParser(t *testing.T) {
 	// Version: 0.5.11
 	// Branch: 0.175.2.0.0.34.0
 
-	sp, err := packages.ParseSolarisFmri("pkg://solaris/entire@0.5.11,5.11-0.175.1.0.0.24.2:20120919T190135Z")
+	sp, err := ParseSolarisFmri("pkg://solaris/entire@0.5.11,5.11-0.175.1.0.0.24.2:20120919T190135Z")
 	require.NoError(t, err)
 	assert.Equal(t, "entire", sp.Name)
 	assert.Equal(t, "solaris", sp.Publisher)
@@ -45,7 +44,7 @@ func TestFmriParser(t *testing.T) {
 	//           Size: 101.36 kB
 	//           FMRI: pkg://solaris/x11/library/libxscrnsaver@1.2.2,5.11-0.175.1.0.0.24.1317:20120904T180021Z
 
-	sp, err = packages.ParseSolarisFmri("pkg://solaris/x11/library/libxscrnsaver@1.2.2,5.11-0.175.1.0.0.24.1317:20120904T180021Z")
+	sp, err = ParseSolarisFmri("pkg://solaris/x11/library/libxscrnsaver@1.2.2,5.11-0.175.1.0.0.24.1317:20120904T180021Z")
 	require.NoError(t, err)
 	assert.Equal(t, "x11/library/libxscrnsaver", sp.Name)
 	assert.Equal(t, "solaris", sp.Publisher)
@@ -60,28 +59,27 @@ pkg://solaris/compress/bzip2@1.0.6,5.11-0.175.1.0.0.24.0:20120904T170602Z    i--
 pkg://solaris/compress/gzip@1.4,5.11-0.175.1.0.0.24.0:20120904T170603Z       i--
 pkg://solaris/compress/p7zip@9.20.1,5.11-0.175.1.0.0.24.0:20120904T170605Z   i--`
 
-	m := packages.ParseSolarisPackages(strings.NewReader(pkgList))
+	m := ParseSolarisPackages(strings.NewReader(pkgList))
 
 	assert.Equal(t, 4, len(m), "detected the right amount of packages")
-	var p packages.Package
-	p = packages.Package{
+	p := Package{
 		Name:    "archiver/gnu-tar",
 		Version: "1.26",
-		Format:  packages.SolarisPkgFormat,
+		Format:  SolarisPkgFormat,
 	}
 	assert.Contains(t, m, p, "pkg detected")
 
-	p = packages.Package{
+	p = Package{
 		Name:    "compress/bzip2",
 		Version: "1.0.6",
-		Format:  packages.SolarisPkgFormat,
+		Format:  SolarisPkgFormat,
 	}
 	assert.Contains(t, m, p, "pkg detected")
 
-	p = packages.Package{
+	p = Package{
 		Name:    "compress/p7zip",
 		Version: "9.20.1",
-		Format:  packages.SolarisPkgFormat,
+		Format:  SolarisPkgFormat,
 	}
 	assert.Contains(t, m, p, "pkg detected")
 }
@@ -95,17 +93,17 @@ func TestSolarisManager(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	pkgManager, err := packages.ResolveSystemPkgManager(conn)
+	pkgManager, err := ResolveSystemPkgManager(conn)
 	require.NoError(t, err)
 
 	pkgList, err := pkgManager.List()
 	require.NoError(t, err)
 
 	assert.Equal(t, 146, len(pkgList))
-	p := packages.Package{
+	p := Package{
 		Name:    "compress/p7zip",
 		Version: "9.20.1",
-		Format:  packages.SolarisPkgFormat,
+		Format:  SolarisPkgFormat,
 	}
 	assert.Contains(t, pkgList, p, "pkg detected")
 }

--- a/providers/os/resources/packages/testdata/packages_dpkg.toml
+++ b/providers/os/resources/packages/testdata/packages_dpkg.toml
@@ -228,3 +228,18 @@ Description: Dynamic library for security auditing
  security related events.
 Homepage: http://people.redhat.com/sgrubb/audit/
 """
+
+[files."/var/lib/dpkg/info/libss2:amd64.list"]
+content="""
+/.
+/lib
+/lib/aarch64-linux-gnu
+/lib/aarch64-linux-gnu/libss.so.2.0
+/usr
+/usr/share
+/usr/share/doc
+/usr/share/doc/libss2
+/usr/share/doc/libss2/copyright
+/lib/aarch64-linux-gnu/libss.so.2
+/usr/share/doc/libss2/changelog.Debian.gz
+"""

--- a/providers/os/resources/packages/testdata/packages_redhat7.toml
+++ b/providers/os/resources/packages/testdata/packages_redhat7.toml
@@ -1,3 +1,6 @@
+[commands."command -v rpm"]
+stdout="/usr/bin/rpm"
+
 [commands."rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH} %{SUMMARY}\\n'"]
 stdout="""
 tzdata 0:2018e-3.el7 noarch Timezone data
@@ -144,4 +147,12 @@ yum 0:3.4.3-158.el7.centos noarch RPM package installer/updater/manager
 yum-utils 0:1.1.31-46.el7_5 noarch Utilities based around the yum package manager
 passwd 0:0.79-4.el7 x86_64 An utility for setting or changing passwords using PAM
 rootfiles 0:8.1-11.el7 noarch The basic required files for the root user's directory
+"""
+
+[commands."rpm -ql hostname"]
+stdout="""
+/usr/bin/dnsdomainname
+/usr/bin/domainname
+/usr/share/man/man1/nisdomainname.1.gz
+/usr/share/man/man1/ypdomainname.1.gz
 """

--- a/providers/os/resources/packages/windows_packages.go
+++ b/providers/os/resources/packages/windows_packages.go
@@ -316,3 +316,8 @@ func ParseWindowsAppPackages(input io.Reader) ([]Package, error) {
 func (win *WinPkgManager) Available() (map[string]PackageUpdate, error) {
 	return map[string]PackageUpdate{}, nil
 }
+
+func (win *WinPkgManager) Files(name string, version string, arch string) ([]FileRecord, error) {
+	// not yet implemented
+	return nil, nil
+}


### PR DESCRIPTION
When you want to find outdated packages, it is important to know where the files are located. This change adds a new `files` field to the packages resources that allows users to see where the package is located on disk:

```coffee
packages { name version files }
```

Not all operating system package manager have a list of the files associated with the package. At this point we added support for:

- alpine
- deb based systems (Debian, Ubuntu)
- macOS
- rpm based systems (Red Hat, Rocky, Alma)

**alpine**

```coffee
cnquery> packages.list[3] { name version files }
packages.list[3]: {
  name: "alpine-keys"
  version: "1634579657:2.4-r1"
  files: [
    0: pkgFileInfo path="etc/apk/keys/alpine-devel@lists.alpinelinux.org-524d27bb.rsa.pub"
    1: pkgFileInfo path="etc/apk/keys/alpine-devel@lists.alpinelinux.org-58199dcc.rsa.pub"
    2: pkgFileInfo path="etc/apk/keys/alpine-devel@lists.alpinelinux.org-616a9724.rsa.pub"
    ...
    35: pkgFileInfo path="usr/share/apk/keys/x86/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub"
    36: pkgFileInfo path="usr/share/apk/keys/x86/alpine-devel@lists.alpinelinux.org-5243ef4b.rsa.pub"
    37: pkgFileInfo path="usr/share/apk/keys/x86/alpine-devel@lists.alpinelinux.org-61666e3f.rsa.pub"
    38: pkgFileInfo path="usr/share/apk/keys/x86_64/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub"
    39: pkgFileInfo path="usr/share/apk/keys/x86_64/alpine-devel@lists.alpinelinux.org-5261cecb.rsa.pub"
    40: pkgFileInfo path="usr/share/apk/keys/x86_64/alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub"
  ]
}

```

**deb-based ubuntu**

```coffee
packages.list[3]: {
  name: "base-passwd"
  version: "3.5.51"
  files: [
    0: pkgFileInfo path="/."
    1: pkgFileInfo path="/usr"
    2: pkgFileInfo path="/usr/sbin"
   ...
    38: pkgFileInfo path="/usr/share/man/ru"
    39: pkgFileInfo path="/usr/share/man/ru/man8"
    40: pkgFileInfo path="/usr/share/man/ru/man8/update-passwd.8.gz"
  ]
}

```

**macOS**

```coffee
packages.list[3]: {
  name: "Calculator"
  version: "10.16"
  files: [
    0: pkgFileInfo path="/System/Applications/Calculator.app"
  ]
}
```

**rpm-based Rocky Linux**

```coffee
packages.list[3]: {
  name: "rocky-gpg-keys"
  version: "9.3"
  files: [
    0: pkgFileInfo path="/etc/pki/rpm-gpg"
    1: pkgFileInfo path="/etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9"
    2: pkgFileInfo path="/etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9-Testing"
  ]
}
```