### PR TITLE
🐛 Fix cpes resource definition in vSphere

### DIFF
--- a/providers/vsphere/resources/vsphere.lr
+++ b/providers/vsphere/resources/vsphere.lr
@@ -1,6 +1,8 @@
 // Copyright (c) Mondoo, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
+import "../../core/resources/core.lr"
+
 option provider = "go.mondoo.com/cnquery/v9/providers/vsphere"
 option go_package = "go.mondoo.com/cnquery/v10/providers/vsphere/resources"
 

--- a/providers/vsphere/resources/vsphere.lr.go
+++ b/providers/vsphere/resources/vsphere.lr.go
@@ -183,7 +183,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"asset.cpes": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAsset).GetCpes()).ToDataRes(types.Array(types.Resource("core.cpe")))
+		return (r.(*mqlAsset).GetCpes()).ToDataRes(types.Array(types.Resource("cpe")))
 	},
 	"asset.vulnerabilityReport": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAsset).GetVulnerabilityReport()).ToDataRes(types.Dict)


### PR DESCRIPTION
Without the import, the resources.json file was created with `core.cpe` as the resource for `cpes`. This failed on lookup when compiling a query.

Adding the import creates the resources.json file `cpe` as the resource for `cpes`. Then the lookup works again.