### PR TITLE
⭐️ support multiple versions of package lock file

### DIFF
--- a/providers/os/resources/npm/package_lock.go
+++ b/providers/os/resources/npm/package_lock.go
@@ -10,22 +10,64 @@ import (
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/upstream/mvd"
 )
 
-type PackageJsonLockEntry struct {
-	Version string `json:"version"`
-	Dev     bool   `json:"dev"`
+// packageLock is the struct to represent the package.lock file
+// see https://docs.npmjs.com/cli/v10/configuring-npm/package-lock-json
+type packageLock struct {
+	Name            string `json:"name"`
+	Version         string `json:"version"`
+	LockfileVersion int    `json:"lockfileVersion"`
+	Requires        bool   `json:"requires"`
+	// Packages maps package locations to an object containing the information about that package,
+	// root project is typically listed with a key of ""
+	Packages map[string]packageLockPackage `json:"packages"`
+	// Dependencies contains legacy data for supporting versions of npm that use lockfileVersion: 1 or lower.
+	// We can ignore that for lockfileVersion: 2+
+	Dependencies map[string]packageLockDependency `jsonn:"dependencies"`
 }
 
-// PackageJsonLock is the struct to represent the package.lock file
-type PackageJsonLock struct {
-	Name         string                          `json:"name"`
-	Version      string                          `json:"version"`
-	Dependencies map[string]PackageJsonLockEntry `jsonn:"dependencies"`
+type packageLockDependency struct {
+	Version   string `json:"version"`
+	Resolved  string `json:"resolved"`
+	Integrity string `json:"integrity"`
+	Dev       bool   `json:"dev"`
 }
 
+type packageLockPackage struct {
+	Name      string             `json:"name"`
+	Version   string             `json:"version"`
+	Resolved  string             `json:"resolved"`
+	Integrity string             `json:"integrity"`
+	License   packageLockLicense `json:"license"`
+}
+
+type packageLockLicense []string
+
+// UnmarshalJSON is a custom unmarshaler for the packageLockLicense type. It allows to handle the license field
+// which could be either a string or an array.
+func (l *packageLockLicense) UnmarshalJSON(data []byte) (err error) {
+
+	var slice []string
+	if err := json.Unmarshal(data, &slice); err == nil {
+		*l = slice
+		return nil
+	}
+
+	var single string
+	if err = json.Unmarshal(data, &single); err == nil {
+		*l = []string{single}
+		return nil
+	}
+
+	// if it's neither a string nor an array, ignore it
+	return nil
+}
+
+// PackageLockParser is the parser for the package.lock file npm format.
+// see https://docs.npmjs.com/cli/v10/configuring-npm/package-lock-json
 type PackageLockParser struct{}
 
 func (p *PackageLockParser) Parse(r io.Reader) ([]*mvd.Package, error) {
-	var packageJsonLock PackageJsonLock
+	var packageJsonLock packageLock
 	err := json.NewDecoder(r).Decode(&packageJsonLock)
 	if err != nil {
 		return nil, err

--- a/providers/os/resources/npm/package_lock_test.go
+++ b/providers/os/resources/npm/package_lock_test.go
@@ -4,6 +4,7 @@
 package npm
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
 
@@ -11,6 +12,126 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/upstream/mvd"
 )
+
+func TestPackageLock(t *testing.T) {
+	tests := []struct {
+		Fixture  string
+		Expected packageLock
+	}{
+		{
+			Fixture: "testdata/package-lock/lockfile-v0.json",
+			Expected: packageLock{
+				Name:            "react-build",
+				Version:         "15.1.0",
+				LockfileVersion: 0,
+				Requires:        false,
+				Packages:        nil,
+				Dependencies: map[string]packageLockDependency{
+					"art": {
+						Version:  "0.10.1",
+						Resolved: "https://registry.npmjs.org/art/-/art-0.10.1.tgz",
+					},
+					"babel-cli": {
+						Version:  "6.10.1",
+						Resolved: "https://registry.npmjs.org/babel-cli/-/babel-cli-6.10.1.tgz",
+					},
+				},
+			},
+		},
+		{
+			Fixture: "testdata/package-lock/lockfile-v1.json",
+			Expected: packageLock{
+				Name:            "npm",
+				Version:         "6.0.0",
+				LockfileVersion: 1,
+				Requires:        true,
+				Dependencies: map[string]packageLockDependency{
+					"JSONStream": {
+						Version:   "1.3.2",
+						Resolved:  "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+						Integrity: "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+					},
+				},
+			},
+		},
+		{
+			Fixture: "testdata/package-lock/lockfile-v2.json",
+			Expected: packageLock{
+				Name:            "npm",
+				Version:         "7.0.0",
+				LockfileVersion: 2,
+				Requires:        true,
+				Packages: map[string]packageLockPackage{
+					"": {
+						Name:    "npm",
+						Version: "7.0.0",
+						License: packageLockLicense(
+							[]string{"Artistic-2.0"},
+						),
+					},
+					"node_modules/@babel/code-frame": {
+						Version:   "7.10.4",
+						Resolved:  "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+						Integrity: "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					},
+				},
+				Dependencies: map[string]packageLockDependency{
+					"@babel/code-frame": {
+						Version:   "7.10.4",
+						Resolved:  "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+						Integrity: "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+						Dev:       true,
+					},
+				},
+			},
+		},
+		{
+			Fixture: "testdata/package-lock/lockfile-v3.json",
+			Expected: packageLock{
+				Name:            "npm",
+				Version:         "10.4.0",
+				LockfileVersion: 3,
+				Requires:        true,
+				Packages: map[string]packageLockPackage{
+					"": {
+						Name:    "npm",
+						Version: "10.4.0",
+						License: packageLockLicense(
+							[]string{"Artistic-2.0"},
+						),
+					},
+					"node_modules/@isaacs/string-locale-compare": {
+						Version:   "1.1.0",
+						Resolved:  "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz",
+						Integrity: "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==",
+					},
+				},
+			},
+		},
+		{
+			Fixture: "testdata/package-lock/simple-lock.json",
+			Expected: packageLock{
+				Name:            "simple",
+				Version:         "1.0.0",
+				LockfileVersion: 1,
+				Requires:        true,
+			},
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.Fixture, func(t *testing.T) {
+			f, err := os.Open(tests[i].Fixture)
+			require.NoError(t, err)
+
+			pkg := packageLock{}
+			err = json.NewDecoder(f).Decode(&pkg)
+			require.NoError(t, err)
+			assert.Equal(t, tests[i].Expected, pkg)
+		})
+	}
+}
 
 func TestPackageJsonLockParser(t *testing.T) {
 	f, err := os.Open("./testdata/package-lock/workbox-package-lock.json")

--- a/providers/os/resources/npm/package_lock_test.go
+++ b/providers/os/resources/npm/package_lock_test.go
@@ -86,6 +86,24 @@ func TestPackageLock(t *testing.T) {
 			},
 		},
 		{
+			Fixture: "testdata/package-lock/lockfile-v2-licenses.json",
+			Expected: packageLock{
+				Name:            "my-package",
+				Version:         "1.0.0",
+				LockfileVersion: 2,
+				Requires:        true,
+				Packages: map[string]packageLockPackage{
+					"": {
+						Name:    "my-package",
+						Version: "1.0.0",
+						License: packageLockLicense(
+							[]string{"MIT", "Apache2"},
+						),
+					},
+				},
+			},
+		},
+		{
 			Fixture: "testdata/package-lock/lockfile-v3.json",
 			Expected: packageLock{
 				Name:            "npm",

--- a/providers/os/resources/npm/testdata/package-lock/lockfile-v0.json
+++ b/providers/os/resources/npm/testdata/package-lock/lockfile-v0.json
@@ -1,0 +1,23 @@
+{
+  "name": "react-build",
+  "version": "15.1.0",
+  "dependencies": {
+    "art": {
+      "version": "0.10.1",
+      "from": "art@>=0.10.1 <0.11.0",
+      "resolved": "https://registry.npmjs.org/art/-/art-0.10.1.tgz"
+    },
+    "babel-cli": {
+      "version": "6.10.1",
+      "from": "babel-cli@>=6.6.5 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.10.1.tgz",
+      "dependencies": {
+        "babel-register": {
+          "version": "6.9.0",
+          "from": "babel-register@>=6.9.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.9.0.tgz"
+        }
+      }
+    }
+  }
+}

--- a/providers/os/resources/npm/testdata/package-lock/lockfile-v1.json
+++ b/providers/os/resources/npm/testdata/package-lock/lockfile-v1.json
@@ -1,0 +1,29 @@
+{
+  "name": "npm",
+  "version": "6.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "JSONStream": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      },
+      "dependencies": {
+        "jsonparse": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+          "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+        },
+        "through": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+        }
+      }
+    }
+  }
+}

--- a/providers/os/resources/npm/testdata/package-lock/lockfile-v2-licenses.json
+++ b/providers/os/resources/npm/testdata/package-lock/lockfile-v2-licenses.json
@@ -1,0 +1,16 @@
+{
+  "name": "my-package",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "my-package",
+      "version": "1.0.0",
+      "license": [
+        "MIT",
+        "Apache2"
+      ]
+    }
+  }
+}

--- a/providers/os/resources/npm/testdata/package-lock/lockfile-v2.json
+++ b/providers/os/resources/npm/testdata/package-lock/lockfile-v2.json
@@ -1,0 +1,37 @@
+{
+  "name": "npm",
+  "version": "7.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "npm",
+      "version": "7.0.0",
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "@npmcli/arborist": "^1.0.0",
+        "@npmcli/ci-detect": "^1.2.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    }
+  },
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.10.4"
+      }
+    }
+  }
+}

--- a/providers/os/resources/npm/testdata/package-lock/lockfile-v3.json
+++ b/providers/os/resources/npm/testdata/package-lock/lockfile-v3.json
@@ -1,0 +1,29 @@
+{
+  "name": "npm",
+  "version": "10.4.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "npm",
+      "version": "10.4.0",
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "@isaacs/string-locale-compare": "^1.1.0"
+      },
+      "bin": {
+        "npm": "bin/npm-cli.js",
+        "npx": "bin/npx-cli.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@isaacs/string-locale-compare": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz",
+      "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==",
+      "inBundle": true
+    }
+  }
+}

--- a/providers/os/resources/npm/testdata/package-lock/simple-lock.json
+++ b/providers/os/resources/npm/testdata/package-lock/simple-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "simple",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true
+}


### PR DESCRIPTION
This PR extends the current package-lock parsing capability and adds more tests to validate that we are able to load its multiple versions.