### PR TITLE
🐛 use upstream config from parent

### DIFF
--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -257,6 +257,7 @@ func getCobraScanConfig(cmd *cobra.Command, runtime *providers.Runtime, cliRes *
 				Incognito:   conf.IsIncognito,
 				Creds:       serviceAccount,
 			}
+			providers.DefaultRuntime().UpstreamConfig = conf.runtime.UpstreamConfig
 		} else {
 			log.Warn().Msg("No credentials provided. Switching to --incognito mode.")
 			conf.IsIncognito = true

--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -360,6 +360,7 @@ func (c *coordinator) newRuntime() *Runtime {
 
 func (c *coordinator) NewRuntimeFrom(parent *Runtime) *Runtime {
 	res := c.NewRuntime()
+	res.UpstreamConfig = parent.UpstreamConfig
 	res.recording = parent.Recording()
 	for k, v := range parent.providers {
 		res.providers[k] = v


### PR DESCRIPTION
Re-use the upstream config from the parent runtime