### PR TITLE
🐛 fix github scans

### DIFF
--- a/providers/github/provider/provider.go
+++ b/providers/github/provider/provider.go
@@ -143,7 +143,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 			}
 		}
 
-		asset.Connections[0].Id = conn.ID()
+		asset.Connections[0].Id = connId
 		return plugin.NewRuntime(
 			conn,
 			callback,
@@ -181,12 +181,6 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.GithubConnecti
 	}
 
 	asset.Platform = platform
-
-	id, err := conn.Identifier()
-	if err != nil {
-		return err
-	}
-	asset.PlatformIds = []string{id}
 	return nil
 }
 

--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -81,13 +81,6 @@ func discover(runtime *plugin.Runtime, targets []string) ([]*inventory.Asset, er
 	return assetList, nil
 }
 
-func cloneInventoryConf(invConf *inventory.Config) *inventory.Config {
-	invConfClone := invConf.Clone()
-	// We do not want to run discovery again for the already discovered assets
-	invConfClone.Discover = &inventory.Discovery{}
-	return invConfClone
-}
-
 func org(runtime *plugin.Runtime, orgName string, conn *connection.GithubConnection, targets []string) ([]*inventory.Asset, error) {
 	assetList := []*inventory.Asset{}
 	org, err := getMqlGithubOrg(runtime, orgName)
@@ -99,7 +92,7 @@ func org(runtime *plugin.Runtime, orgName string, conn *connection.GithubConnect
 		Name:        org.Name.Data,
 		Platform:    connection.GithubOrgPlatform,
 		Labels:      map[string]string{},
-		Connections: []*inventory.Config{cloneInventoryConf(conn.Conf)},
+		Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.ID()))},
 	})
 	if stringx.Contains(targets, connection.DiscoveryRepos) || stringx.Contains(targets, connection.DiscoveryRepository) || stringx.Contains(targets, connection.DiscoveryAll) || stringx.Contains(targets, connection.DiscoveryAuto) {
 		if stringx.Contains(targets, connection.DiscoveryRepos) || stringx.Contains(targets, connection.DiscoveryRepository) {
@@ -112,7 +105,7 @@ func org(runtime *plugin.Runtime, orgName string, conn *connection.GithubConnect
 				Name:        org.Login.Data + "/" + repo.Name.Data,
 				Platform:    connection.GithubRepoPlatform,
 				Labels:      make(map[string]string),
-				Connections: []*inventory.Config{cloneInventoryConf(conn.Conf)},
+				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithParentConnectionId(conn.ID()))},
 			})
 		}
 	}
@@ -128,7 +121,7 @@ func org(runtime *plugin.Runtime, orgName string, conn *connection.GithubConnect
 				Name:        user.Name.Data,
 				Platform:    connection.GithubUserPlatform,
 				Labels:      make(map[string]string),
-				Connections: []*inventory.Config{cloneInventoryConf(conn.Conf)},
+				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithParentConnectionId(conn.ID()))},
 			})
 		}
 	}
@@ -156,7 +149,7 @@ func repo(runtime *plugin.Runtime, repoName string, owner string, conn *connecti
 		Name:        owner + "/" + repo.Name.Data,
 		Platform:    connection.GithubRepoPlatform,
 		Labels:      make(map[string]string),
-		Connections: []*inventory.Config{cloneInventoryConf(conn.Conf)},
+		Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithParentConnectionId(conn.ID()))},
 	})
 
 	return assetList, nil
@@ -183,7 +176,7 @@ func user(runtime *plugin.Runtime, userName string, conn *connection.GithubConne
 		Name:        user.Name.Data,
 		Platform:    connection.GithubUserPlatform,
 		Labels:      make(map[string]string),
-		Connections: []*inventory.Config{cloneInventoryConf(conn.Conf)},
+		Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithParentConnectionId(conn.ID()))},
 	})
 	return assetList, nil
 }


### PR DESCRIPTION
The root of the scan shouldn't have a platform ID. Also made sure the connections for child assets are re-used which should make scans faster