### PR TITLE
🐛 do not error out on failing to discover a k8s container

### DIFF
--- a/providers/k8s/resources/discovery.go
+++ b/providers/k8s/resources/discovery.go
@@ -822,12 +822,14 @@ func convertImagesToAssets(images map[string]ContainerImage) ([]*inventory.Asset
 
 		ref, err := name.ParseReference(i.resolvedImage, name.WeakValidation)
 		if err != nil {
-			return nil, err
+			log.Error().Err(err).Msg("failed to parse image reference")
+			continue
 		}
 
 		a, err := ccresolver.GetImage(ref, nil)
 		if err != nil {
-			return nil, err
+			log.Error().Err(err).Msg("failed to get image")
+			continue
 		}
 		assetList = append(assetList, a)
 	}


### PR DESCRIPTION
instead of erroring out, we should continue with the next container