### PR TITLE
🐛 load core schema last

### DIFF
--- a/providers/extensible_schema.go
+++ b/providers/extensible_schema.go
@@ -172,8 +172,16 @@ func (x *extensibleSchema) unsafeRefresh() {
 	res := resources.Schema{
 		Resources: map[string]*resources.ResourceInfo{},
 	}
-	for _, schema := range x.loaded {
-		res.Add(schema)
+
+	for id, schema := range x.loaded {
+		if id != BuiltinCoreID {
+			res.Add(schema)
+		}
+	}
+
+	// Add the core schema last, so that it cannot be overridden by any other schema
+	if x.loaded[BuiltinCoreID] != nil {
+		res.Add(x.loaded[BuiltinCoreID])
 	}
 
 	// Note: This object is read-only and thus must be re-created to


### PR DESCRIPTION
makes sure resources from the core provider cannot be overridden