### PR TITLE
🎉 k8s-10.2.2

### DIFF
--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "k8s",
 	ID:              "go.mondoo.com/cnquery/v9/providers/k8s",
-	Version:         "10.2.1",
+	Version:         "10.2.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by cnquery's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.