### PR TITLE
🐛 fix mock provider panic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ providers/*/resources/*.resources.json
 providers/*/resources/*.manifest.json
 providers/mock_coordinator.go
 providers/mock_plugin_interface.go
+providers/mock_schema.go
 providers-sdk/*/testutils/mockprovider/resources/*.resources.json
 !providers/core/resources/*.resources.json

--- a/providers/builtin.go
+++ b/providers/builtin.go
@@ -35,7 +35,7 @@ var builtinProviders = map[string]*builtinProvider{
 		Runtime: &RunningProvider{
 			Name:     mockProvider.Name,
 			ID:       mockProvider.ID,
-			Plugin:   &mockProviderService{coordinator: Coordinator},
+			Plugin:   &mockProviderService{},
 			isClosed: false,
 		},
 		Config: mockProvider.Provider,

--- a/providers/mock.go
+++ b/providers/mock.go
@@ -23,7 +23,6 @@ var mockProvider = Provider{
 }
 
 type mockProviderService struct {
-	coordinator ProvidersCoordinator
 	initialized bool
 	runtime     *Runtime
 }
@@ -121,9 +120,8 @@ func (s *mockProviderService) Init(running *RunningProvider) {
 	}
 	s.initialized = true
 
-	// TODO: Currently not needed, as the runtime loads all schemas right now.
+	// TODO: Currently not needed, as the coordinator loads all schemas right now.
 	// Once it doesn't do that anymore, remember to load all schemas here
 	// rt.schema.unsafeLoadAll()
 	// rt.schema.unsafeRefresh()
-	running.Schema = s.coordinator.Schema()
 }


### PR DESCRIPTION
The schema is loaded by the coordinator. The mock provider doesn't need to do anything for that

fixes #3364 