### PR TITLE
⭐️  Added destinationType (aws)

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -135,6 +135,8 @@ private aws.vpc.flowlog @defaults("id region status") {
   createdAt time
   // The destination for the flow log data
   destination string
+  // The destination type for the flow log data
+  destinationType string
   // The maximum interval of time during which a flow of packets is captured and aggregated into a flow log record. The possible values are 60 seconds (1 minute) or 600 seconds (10 minutes).
   maxAggregationInterval int
   // The type of traffic to monitor. ACCEPT, ALL, and REJECT

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -853,6 +853,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.vpc.flowlog.destination": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcFlowlog).GetDestination()).ToDataRes(types.String)
 	},
+	"aws.vpc.flowlog.destinationType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcFlowlog).GetDestinationType()).ToDataRes(types.String)
+	},
 	"aws.vpc.flowlog.maxAggregationInterval": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcFlowlog).GetMaxAggregationInterval()).ToDataRes(types.Int)
 	},
@@ -3863,6 +3866,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.vpc.flowlog.destination": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcFlowlog).Destination, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.flowlog.destinationType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcFlowlog).DestinationType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.flowlog.maxAggregationInterval": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8769,6 +8776,7 @@ type mqlAwsVpcFlowlog struct {
 	Tags plugin.TValue[map[string]interface{}]
 	CreatedAt plugin.TValue[*time.Time]
 	Destination plugin.TValue[string]
+	DestinationType plugin.TValue[string]
 	MaxAggregationInterval plugin.TValue[int64]
 	TrafficType plugin.TValue[string]
 }
@@ -8831,6 +8839,10 @@ func (c *mqlAwsVpcFlowlog) GetCreatedAt() *plugin.TValue[*time.Time] {
 
 func (c *mqlAwsVpcFlowlog) GetDestination() *plugin.TValue[string] {
 	return &c.Destination
+}
+
+func (c *mqlAwsVpcFlowlog) GetDestinationType() *plugin.TValue[string] {
+	return &c.DestinationType
 }
 
 func (c *mqlAwsVpcFlowlog) GetMaxAggregationInterval() *plugin.TValue[int64] {

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2471,6 +2471,8 @@ resources:
         min_mondoo_version: 9.0.0
       destination:
         min_mondoo_version: 9.0.0
+      destinationType:
+        min_mondoo_version: 9.0.0
       id: {}
       maxAggregationInterval:
         min_mondoo_version: 9.0.0

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -179,6 +179,7 @@ func (a *mqlAwsVpc) flowLogs() ([]interface{}, error) {
 				map[string]*llx.RawData{
 					"createdAt":              llx.TimeDataPtr(flowLog.CreationTime),
 					"destination":            llx.StringDataPtr(flowLog.LogDestination),
+					"destinationType":        llx.StringData(string(flowLog.LogDestinationType)),
 					"id":                     llx.StringDataPtr(flowLog.FlowLogId),
 					"maxAggregationInterval": llx.IntData(convert.ToInt64From32(flowLog.MaxAggregationInterval)),
 					"region":                 llx.StringData(a.Region.Data),


### PR DESCRIPTION
AWS VPC Flow Logs supports three types of destinations for flow log data:

1. cloud-watch-logs: Specifies that the flow log data will be published to Amazon CloudWatch Logs.

3. s3

5. kinesis-data-firehose

![Screenshot from 2024-02-20 18-50-41](https://github.com/mondoohq/cnquery/assets/56231339/06f87f2b-3d33-43e5-98c9-d19fabf111b4)
