### PR TITLE
⭐️  Added the status of the Log delivery VPC  (aws)

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -137,6 +137,8 @@ private aws.vpc.flowlog @defaults("id region status") {
   destination string
   // The destination type for the flow log data
   destinationType string
+   // The delivery log status for the flow log data
+  deliverLogsStatus string
   // The maximum interval of time during which a flow of packets is captured and aggregated into a flow log record. The possible values are 60 seconds (1 minute) or 600 seconds (10 minutes).
   maxAggregationInterval int
   // The type of traffic to monitor. ACCEPT, ALL, and REJECT

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -856,6 +856,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.vpc.flowlog.destinationType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcFlowlog).GetDestinationType()).ToDataRes(types.String)
 	},
+	"aws.vpc.flowlog.deliverLogsStatus": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcFlowlog).GetDeliverLogsStatus()).ToDataRes(types.String)
+	},
 	"aws.vpc.flowlog.maxAggregationInterval": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcFlowlog).GetMaxAggregationInterval()).ToDataRes(types.Int)
 	},
@@ -3870,6 +3873,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.vpc.flowlog.destinationType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcFlowlog).DestinationType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.flowlog.deliverLogsStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcFlowlog).DeliverLogsStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.flowlog.maxAggregationInterval": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8777,6 +8784,7 @@ type mqlAwsVpcFlowlog struct {
 	CreatedAt plugin.TValue[*time.Time]
 	Destination plugin.TValue[string]
 	DestinationType plugin.TValue[string]
+	DeliverLogsStatus plugin.TValue[string]
 	MaxAggregationInterval plugin.TValue[int64]
 	TrafficType plugin.TValue[string]
 }
@@ -8843,6 +8851,10 @@ func (c *mqlAwsVpcFlowlog) GetDestination() *plugin.TValue[string] {
 
 func (c *mqlAwsVpcFlowlog) GetDestinationType() *plugin.TValue[string] {
 	return &c.DestinationType
+}
+
+func (c *mqlAwsVpcFlowlog) GetDeliverLogsStatus() *plugin.TValue[string] {
+	return &c.DeliverLogsStatus
 }
 
 func (c *mqlAwsVpcFlowlog) GetMaxAggregationInterval() *plugin.TValue[int64] {

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2469,6 +2469,8 @@ resources:
     fields:
       createdAt:
         min_mondoo_version: 9.0.0
+      deliverLogsStatus:
+        min_mondoo_version: 9.0.0
       destination:
         min_mondoo_version: 9.0.0
       destinationType:

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -180,6 +180,7 @@ func (a *mqlAwsVpc) flowLogs() ([]interface{}, error) {
 					"createdAt":              llx.TimeDataPtr(flowLog.CreationTime),
 					"destination":            llx.StringDataPtr(flowLog.LogDestination),
 					"destinationType":        llx.StringData(string(flowLog.LogDestinationType)),
+					"deliverLogsStatus":      llx.StringDataPtr(flowLog.DeliverLogsStatus),
 					"id":                     llx.StringDataPtr(flowLog.FlowLogId),
 					"maxAggregationInterval": llx.IntData(convert.ToInt64From32(flowLog.MaxAggregationInterval)),
 					"region":                 llx.StringData(a.Region.Data),


### PR DESCRIPTION
Situations Where DeliverLogsStatus May Not Be "SUCCESS":

"FAILED": This status indicates that the flow log failed to deliver logs to the specified log destination. This could be due to several reasons such as:

1. Incorrect permissions: The IAM role specified in DeliverLogsPermissionArn lacks the necessary permissions to publish logs to the destination.
2. Non-existent log group/log stream: The specified CloudWatch Logs log group or log stream does not exist.
3. Incorrect log destination configuration: There may be a misconfiguration with the log destination settings.
4. "ACCESSERROR": This status means that AWS was unable to deliver logs to the specified destination due to an access error. This is typically related to permission issues or the log destination being deleted or modified.


![Screenshot from 2024-02-21 08-49-58](https://github.com/mondoohq/cnquery/assets/56231339/2065c572-0e1d-4e54-a584-7eab22f6c233)

