### PR TITLE
🐛 make sure gitlab discovers only unique assets

### DIFF
--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -70,7 +70,7 @@ func (r *Runtime) tryShutdown() shutdownResult {
 					continue
 				}
 			}
-			log.Error().Msg("failed to disconnect from provider " + provider.Instance.Name)
+			log.Error().Err(err).Msg("failed to disconnect from provider " + provider.Instance.Name)
 		}
 	}
 	return shutdownResult{}


### PR DESCRIPTION
It is possible to setup gitlab in such a way that 1 project appears in multiple groups. The gitlab provider discovers assets starting from the root and traversing down finding everything along the way. It is possible that the same thing is found in 2 different places. In the end the provider should return a unique list of assets with no duplicates to make sure everything works as expected