### PR TITLE
🧹 Add annotations to all assets in the inventory.

### DIFF
--- a/apps/cnquery/cmd/sbom.go
+++ b/apps/cnquery/cmd/sbom.go
@@ -136,7 +136,7 @@ var sbomCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 			if len(boms) > 1 {
 				filename = fmt.Sprintf("%s-%d.%s", path.Base(outputTarget), i, path.Ext(outputTarget))
 			}
-			err := os.WriteFile(filename, output.Bytes(), 0600)
+			err := os.WriteFile(filename, output.Bytes(), 0o600)
 			if err != nil {
 				log.Fatal().Err(err).Msg("failed to write SBOM to file")
 			}
@@ -177,7 +177,7 @@ func getSbomScanConfig(cmd *cobra.Command, runtime *providers.Runtime, cliRes *p
 		cliRes.Asset.Name = assetName
 	}
 
-	inv, err := inventoryloader.ParseOrUse(cliRes.Asset, viper.GetBool("insecure"), optAnnotations)
+	inv, err := inventoryloader.ParseOrUse(func() *inventory.Asset { return cliRes.Asset }, viper.GetBool("insecure"), optAnnotations)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to parse inventory")
 	}

--- a/apps/cnquery/cmd/sbom.go
+++ b/apps/cnquery/cmd/sbom.go
@@ -177,7 +177,7 @@ func getSbomScanConfig(cmd *cobra.Command, runtime *providers.Runtime, cliRes *p
 		cliRes.Asset.Name = assetName
 	}
 
-	inv, err := inventoryloader.ParseOrUse(func() *inventory.Asset { return cliRes.Asset }, viper.GetBool("insecure"), optAnnotations)
+	inv, err := inventoryloader.ParseOrUse(cliRes.Asset, viper.GetBool("insecure"), optAnnotations)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to parse inventory")
 	}

--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -191,7 +191,7 @@ func getCobraScanConfig(cmd *cobra.Command, runtime *providers.Runtime, cliRes *
 		cliRes.Asset.Name = assetName
 	}
 
-	inv, err := inventoryloader.ParseOrUse(func() *inventory.Asset { return cliRes.Asset }, viper.GetBool("insecure"), optAnnotations)
+	inv, err := inventoryloader.ParseOrUse(cliRes.Asset, viper.GetBool("insecure"), optAnnotations)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to parse inventory")
 	}

--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -191,7 +191,7 @@ func getCobraScanConfig(cmd *cobra.Command, runtime *providers.Runtime, cliRes *
 		cliRes.Asset.Name = assetName
 	}
 
-	inv, err := inventoryloader.ParseOrUse(cliRes.Asset, viper.GetBool("insecure"), optAnnotations)
+	inv, err := inventoryloader.ParseOrUse(func() *inventory.Asset { return cliRes.Asset }, viper.GetBool("insecure"), optAnnotations)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to parse inventory")
 	}

--- a/cli/inventoryloader/inventory.go
+++ b/cli/inventoryloader/inventory.go
@@ -136,7 +136,7 @@ func parseDomainListInventory(data []byte) (*inventory.Inventory, error) {
 
 // ParseOrUse tries to load the inventory and if nothing exists it
 // will instead use the provided asset.
-func ParseOrUse(assetFn func() *inventory.Asset, insecure bool, annotations map[string]string) (*inventory.Inventory, error) {
+func ParseOrUse(asset *inventory.Asset, insecure bool, annotations map[string]string) (*inventory.Inventory, error) {
 	var v1inventory *inventory.Inventory
 	var err error
 
@@ -147,11 +147,8 @@ func ParseOrUse(assetFn func() *inventory.Asset, insecure bool, annotations map[
 	}
 
 	// add asset from cli to inventory
-	if len(v1inventory.Spec.GetAssets()) == 0 {
-		asset := assetFn()
-		if asset != nil {
-			v1inventory.AddAssets(asset)
-		}
+	if len(v1inventory.Spec.GetAssets()) == 0 && asset != nil {
+		v1inventory.AddAssets(asset)
 	}
 
 	for _, asset := range v1inventory.Spec.GetAssets() {

--- a/cli/inventoryloader/inventory.go
+++ b/cli/inventoryloader/inventory.go
@@ -136,7 +136,7 @@ func parseDomainListInventory(data []byte) (*inventory.Inventory, error) {
 
 // ParseOrUse tries to load the inventory and if nothing exists it
 // will instead use the provided asset.
-func ParseOrUse(cliAsset *inventory.Asset, insecure bool, annotations map[string]string) (*inventory.Inventory, error) {
+func ParseOrUse(assetFn func() *inventory.Asset, insecure bool, annotations map[string]string) (*inventory.Inventory, error) {
 	var v1inventory *inventory.Inventory
 	var err error
 
@@ -147,13 +147,19 @@ func ParseOrUse(cliAsset *inventory.Asset, insecure bool, annotations map[string
 	}
 
 	// add asset from cli to inventory
-	if (len(v1inventory.Spec.GetAssets()) == 0) && cliAsset != nil {
-		cliAsset.AddAnnotations(annotations)
-		v1inventory.AddAssets(cliAsset)
+	if len(v1inventory.Spec.GetAssets()) == 0 {
+		asset := assetFn()
+		if asset != nil {
+			v1inventory.AddAssets(asset)
+		}
+	}
+
+	for _, asset := range v1inventory.Spec.GetAssets() {
+		asset.AddAnnotations(annotations)
 	}
 
 	// if the --insecure flag is set, we overwrite the individual setting for the asset
-	if insecure == true {
+	if insecure {
 		v1inventory.MarkConnectionsInsecure()
 	}
 


### PR DESCRIPTION
Ensure all assets in the inventory (whether discovered from the inventory or passed in as fallbacks) get annotated correctly.
