### PR TITLE
🐛 Do not return the type of the predicate for if blocks

### DIFF
--- a/llx/builtin_global.go
+++ b/llx/builtin_global.go
@@ -67,8 +67,11 @@ func ifCallV2(e *blockExecutor, f *Function, ref uint64) (*RawData, uint64, erro
 	max := len(f.Args)
 	for idx+2 < max {
 		res, dref, err := e.resolveValue(f.Args[idx], ref)
-		if err != nil || dref != 0 || res == nil {
+		if dref != 0 || (err != nil && res == nil) {
 			return res, dref, err
+		}
+		if res.Error != nil {
+			return NilData, 0, res.Error
 		}
 
 		if truthy, _ := res.IsTruthy(); truthy {


### PR DESCRIPTION
When there were errors, `ifCallV2` would return the type of the predicate for the result of the if block.

That becomes problematic for a query like the following:
```
if (file('/etc/amazon/').exists) {
  return "AWS"
} else if ( users.any( name == 'ec2-user' || name == 'ec2-instance-connect' ) ) {
  return "AWS"
} else if ( machine.baseboard.manufacturer == 'Amazon EC2') {
  return "AWS"
} else if ( asset.platform == "cos" ) {
  return "GCP"
} else if ( file('/etc/google_instance_id').exists ) {
  return "GCP"
} else if ( file('/var/lib/waagent/').exists ) {
  return "Azure"
} else if ( file('/var/lib/dhcp/dhclient.enp1s0.leases').exists && file('/var/lib/dhcp/dhclient.enp1s0.leases').content.lines.contains( /unknown-245/ ) ) {
  return "Azure"
} else {
  return "Unknown"
}
```

If you cannot run `machine.baseboard.manufacturer`, for example if you're not root, an error is returned. The type of the result is boolean, when it should be string. You then get a message like the following:

```
failed to send datapoints error="1 error occurred:\n\t* failed to store data for \"HTCzrF9d2vMJ1iUZsoMcMwaC8XQ7bvQE5nLxC0I5cSBlLXawpmn74WyIEaTgXuUmz/C5iRSeedT3eBg9h6xx8A==\", types don't match: expected string, got bool\n\n"
```