### PR TITLE
🏃Speed up azure provider by caching the azure subscription.

### DIFF
--- a/providers/azure/resources/azure.go
+++ b/providers/azure/resources/azure.go
@@ -1,0 +1,17 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+// TODO: we should look into restructuring resources for v11.
+// we should be able to define the subscription as a property on the azure one, i.e.
+//
+//	azure {
+//	  subscription() azure.subscription
+//	}
+//
+// right now this isn't possible as the resource lookup gets confused between trying to directly create azure.subscription
+// or create azure and then do azure.subscription()
+type mqlAzureInternal struct {
+	sub *mqlAzureSubscription
+}

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -6054,7 +6054,7 @@ func SetAllData(resource plugin.Resource, args map[string]*llx.RawData) error {
 type mqlAzure struct {
 	MqlRuntime *plugin.Runtime
 	__id string
-	// optional: if you define mqlAzureInternal it will be used here
+	mqlAzureInternal
 }
 
 // createAzure creates a new instance of this resource


### PR DESCRIPTION
By caching the azure subscription we avoid that it's being called every single time a query asks for it.

I ran some manual scans and the scan time goes from 55-60s to 18-20s for me

