### PR TITLE
🐛 do not add root asset to discovered inventory

### DIFF
--- a/providers/vsphere/resources/discovery.go
+++ b/providers/vsphere/resources/discovery.go
@@ -58,10 +58,6 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 
 	targets := handleTargets(conn.Conf.Discover.Targets)
 
-	if stringx.Contains(targets, DiscoveryApi) {
-		in.Spec.Assets = append(in.Spec.Assets, conn.Asset())
-	}
-
 	res, err := NewResource(runtime, "vsphere", map[string]*llx.RawData{})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
We added the root asset to the inventory which caused the shell/scan to pick the wrong connection.