### PR TITLE
🐛 terraform: avoid nil crash on non-existent block in module

### DIFF
--- a/providers/terraform/resources/hcl.go
+++ b/providers/terraform/resources/hcl.go
@@ -691,6 +691,11 @@ func (t *mqlTerraformModule) block() (*mqlTerraformBlock, error) {
 		}
 	}
 
+	if mqlHclBlock == nil {
+		t.Block.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+
 	return mqlHclBlock, nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/mondoohq/cnquery/issues/3377