### PR TITLE
✨ Add page iterator for fetching users and service principals in MS365.

### DIFF
--- a/providers/ms365/resources/iterator.go
+++ b/providers/ms365/resources/iterator.go
@@ -1,0 +1,28 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+
+	abstractions "github.com/microsoft/kiota-abstractions-go"
+	"github.com/microsoft/kiota-abstractions-go/serialization"
+	msgraphgocore "github.com/microsoftgraph/msgraph-sdk-go-core"
+)
+
+func iterate[T interface{}](ctx context.Context, res interface{}, adapter abstractions.RequestAdapter, constructorFunc serialization.ParsableFactory) ([]T, error) {
+	resp := []T{}
+	iterator, err := msgraphgocore.NewPageIterator[T](res, adapter, constructorFunc)
+	if err != nil {
+		return nil, transformError(err)
+	}
+	err = iterator.Iterate(ctx, func(u T) bool {
+		resp = append(resp, u)
+		return true
+	})
+	if err != nil {
+		return nil, transformError(err)
+	}
+	return resp, nil
+}


### PR DESCRIPTION
Use msgraph page iterator to get the next page (via odata's next link) if there's more elements than what `top` indicates.
Set the top to 999 to reduce the amount of API calls we'd require.