### PR TITLE
🟢 add missing tests for typecasts

### DIFF
--- a/mql/mql_test.go
+++ b/mql/mql_test.go
@@ -156,6 +156,67 @@ func TestResourceAliases(t *testing.T) {
 	})
 }
 
+func TestTypeCasts(t *testing.T) {
+	x := testutils.InitTester(testutils.LinuxMock())
+	x.TestSimple(t, []testutils.SimpleTest{
+		{
+			Code:        "/regex2string/",
+			ResultIndex: 0,
+			Expectation: "regex2string",
+		},
+		{
+			Code:        "regex('s.*g') == 'string'",
+			ResultIndex: 1,
+			Expectation: true,
+		},
+		{
+			Code:        "int(1.23)",
+			ResultIndex: 0,
+			Expectation: int64(1),
+		},
+		{
+			Code:        "int('12')",
+			ResultIndex: 0,
+			Expectation: int64(12),
+		},
+		{
+			Code:        "float(123)",
+			ResultIndex: 0,
+			Expectation: float64(123),
+		},
+		{
+			Code:        "float('123')",
+			ResultIndex: 0,
+			Expectation: float64(123),
+		},
+		{
+			Code:        "int(float('1.23'))",
+			ResultIndex: 0,
+			Expectation: int64(1),
+		},
+		{
+			Code:        "bool(1.23)",
+			ResultIndex: 0,
+			Expectation: true,
+		},
+		{
+			Code:        "bool(0)",
+			ResultIndex: 0,
+			Expectation: false,
+		},
+		{
+			Code:        "bool('true')",
+			ResultIndex: 0,
+			Expectation: true,
+		},
+		{
+			Code:        "bool('false')",
+			ResultIndex: 0,
+			Expectation: false,
+		},
+	})
+}
+
 func TestNullResources(t *testing.T) {
 	x := testutils.InitTester(testutils.LinuxMock())
 	x.TestSimple(t, []testutils.SimpleTest{


### PR DESCRIPTION
It was late when I pushed this, but I promised to add the missing tests, so here we are. Related to https://github.com/mondoohq/cnquery/pull/3463

I ran into an issue last night where `regex` would only either work as the type-cast or as the keyword we use for eg `regex.ipv4`. It popped up during the previous PR for the latter case, now we are also adding tests for the former.