### PR TITLE
🐛 avoid accidental empty properties

### DIFF
--- a/explorer/property_test.go
+++ b/explorer/property_test.go
@@ -8,6 +8,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/v10"
+	"go.mondoo.com/cnquery/v10/mqlc"
+	"go.mondoo.com/cnquery/v10/providers"
 )
 
 func TestProperty_RefreshMrn(t *testing.T) {
@@ -25,4 +28,42 @@ func TestProperty_RefreshMrn(t *testing.T) {
 	assert.Equal(t, "//my.owner/queries/uid1", in.Mrn)
 	assert.Equal(t, "", in.For[0].Uid)
 	assert.Equal(t, "//my.owner/queries/uid2", in.For[0].Mrn)
+}
+
+func TestProperty_MustNotBeEmpty(t *testing.T) {
+	in := &Property{
+		Uid: "uid1",
+		Mql: "",
+	}
+
+	schema := providers.DefaultRuntime().Schema()
+	conf := mqlc.NewConfig(schema, cnquery.DefaultFeatures)
+	_, err := in.RefreshChecksumAndType(conf)
+
+	assert.Error(t, err)
+}
+
+func TestProperty_MustCompile(t *testing.T) {
+	schema := providers.DefaultRuntime().Schema()
+	conf := mqlc.NewConfig(schema, cnquery.DefaultFeatures)
+
+	t.Run("fails on invalid MQL", func(t *testing.T) {
+		in := &Property{
+			Uid: "uid1",
+			Mql: "ruri.ryu",
+		}
+
+		_, err := in.RefreshChecksumAndType(conf)
+		assert.Error(t, err)
+	})
+
+	t.Run("works with a valid query", func(t *testing.T) {
+		in := &Property{
+			Uid: "uid1",
+			Mql: "mondoo.version",
+		}
+
+		_, err := in.RefreshChecksumAndType(conf)
+		assert.NoError(t, err)
+	})
 }


### PR DESCRIPTION
A friend accidentally the `query` (which we used pre v9) attribute for the property, instead of the `mql` field. This led to an empty property, which in this case is never valid. Properties must be non-empty.

Guarantee non-empty props + add more testing.