### PR TITLE
✨ use globally unique connection IDs for providers

### DIFF
--- a/providers-sdk/v1/inventory/inventory.go
+++ b/providers-sdk/v1/inventory/inventory.go
@@ -417,7 +417,7 @@ func (cfg *Config) Clone(opts ...CloneOption) *Config {
 	}
 
 	clonedObject := proto.Clone(cfg).(*Config)
-
+	clonedObject.Id = 0
 	if cloneSettings.noDiscovery {
 		clonedObject.Discover = &Discovery{}
 	}

--- a/providers-sdk/v1/plugin/service_test.go
+++ b/providers-sdk/v1/plugin/service_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/v10/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v10/utils/syncx"
 )
 
@@ -59,7 +60,7 @@ func TestAddRuntime(t *testing.T) {
 	addRuntimes := func() {
 		defer wg.Done()
 		for i := 0; i < 50; i++ {
-			_, err := s.AddRuntime(func(connId uint32) (*Runtime, error) {
+			_, err := s.AddRuntime(&inventory.Config{}, func(connId uint32) (*Runtime, error) {
 				return &Runtime{}, nil
 			})
 			require.NoError(t, err)
@@ -82,7 +83,7 @@ func TestAddRuntime(t *testing.T) {
 func TestAddRuntime_ParentNotExist(t *testing.T) {
 	s := NewService()
 	parentId := uint32(10)
-	_, err := s.AddRuntime(func(connId uint32) (*Runtime, error) {
+	_, err := s.AddRuntime(&inventory.Config{}, func(connId uint32) (*Runtime, error) {
 		c := newTestConnection(connId)
 		c.parentId = parentId
 		return &Runtime{
@@ -96,7 +97,7 @@ func TestAddRuntime_ParentNotExist(t *testing.T) {
 func TestAddRuntime_Parent(t *testing.T) {
 	s := NewService()
 
-	parent, err := s.AddRuntime(func(connId uint32) (*Runtime, error) {
+	parent, err := s.AddRuntime(&inventory.Config{}, func(connId uint32) (*Runtime, error) {
 		resMap := &syncx.Map[Resource]{}
 		resMap.Set("test.resource", &TestResource{})
 
@@ -108,7 +109,7 @@ func TestAddRuntime_Parent(t *testing.T) {
 	require.NoError(t, err)
 
 	parentId := parent.Connection.ID()
-	child, err := s.AddRuntime(func(connId uint32) (*Runtime, error) {
+	child, err := s.AddRuntime(&inventory.Config{}, func(connId uint32) (*Runtime, error) {
 		c := newTestConnection(connId)
 		c.parentId = parentId
 		return &Runtime{
@@ -128,7 +129,7 @@ func TestAddRuntime_Parent(t *testing.T) {
 func TestGetRuntime(t *testing.T) {
 	s := NewService()
 
-	runtime, err := s.AddRuntime(func(connId uint32) (*Runtime, error) {
+	runtime, err := s.AddRuntime(&inventory.Config{}, func(connId uint32) (*Runtime, error) {
 		return &Runtime{
 			Connection: newTestConnection(connId),
 		}, nil
@@ -137,7 +138,7 @@ func TestGetRuntime(t *testing.T) {
 
 	// Add some more runtimes
 	for i := 0; i < 5; i++ {
-		_, err := s.AddRuntime(func(connId uint32) (*Runtime, error) {
+		_, err := s.AddRuntime(&inventory.Config{}, func(connId uint32) (*Runtime, error) {
 			return &Runtime{
 				Connection: newTestConnection(connId),
 			}, nil
@@ -154,7 +155,7 @@ func TestGetRuntime(t *testing.T) {
 func TestGetRuntime_DoesNotExist(t *testing.T) {
 	s := NewService()
 
-	_, err := s.AddRuntime(func(connId uint32) (*Runtime, error) {
+	_, err := s.AddRuntime(&inventory.Config{}, func(connId uint32) (*Runtime, error) {
 		return &Runtime{
 			Connection: newTestConnection(connId),
 		}, nil
@@ -169,7 +170,7 @@ func TestGetRuntime_DoesNotExist(t *testing.T) {
 func TestDisconnect(t *testing.T) {
 	s := NewService()
 
-	runtime, err := s.AddRuntime(func(connId uint32) (*Runtime, error) {
+	runtime, err := s.AddRuntime(&inventory.Config{}, func(connId uint32) (*Runtime, error) {
 		return &Runtime{
 			Connection: newTestConnection(connId),
 		}, nil
@@ -186,7 +187,7 @@ func TestDisconnect(t *testing.T) {
 func TestDisconnect_Closer(t *testing.T) {
 	s := NewService()
 
-	runtime, err := s.AddRuntime(func(connId uint32) (*Runtime, error) {
+	runtime, err := s.AddRuntime(&inventory.Config{}, func(connId uint32) (*Runtime, error) {
 		return &Runtime{
 			Connection: newTestConnectionWithClose(connId),
 		}, nil
@@ -208,7 +209,7 @@ func TestShutdown(t *testing.T) {
 
 	// Add some more runtimes
 	for i := 0; i < 50; i++ {
-		_, err := s.AddRuntime(func(connId uint32) (*Runtime, error) {
+		_, err := s.AddRuntime(&inventory.Config{}, func(connId uint32) (*Runtime, error) {
 			return &Runtime{
 				Connection: newTestConnection(connId),
 			}, nil
@@ -228,7 +229,7 @@ func TestShutdown_Closer(t *testing.T) {
 	// Add some more runtimes
 	runtimes := []*Runtime{}
 	for i := 0; i < 50; i++ {
-		runtime, err := s.AddRuntime(func(connId uint32) (*Runtime, error) {
+		runtime, err := s.AddRuntime(&inventory.Config{}, func(connId uint32) (*Runtime, error) {
 			return &Runtime{
 				Connection: newTestConnectionWithClose(connId),
 			}, nil

--- a/providers/arista/provider/provider.go
+++ b/providers/arista/provider/provider.go
@@ -124,7 +124,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	asset := req.Asset
 	conf := asset.Connections[0]
 
-	runtime, err := s.AddRuntime(func(connId uint32) (*plugin.Runtime, error) {
+	runtime, err := s.AddRuntime(conf, func(connId uint32) (*plugin.Runtime, error) {
 		conn, err := connection.NewAristaConnection(connId, asset, conf)
 		if err != nil {
 			return nil, err

--- a/providers/atlassian/provider/provider.go
+++ b/providers/atlassian/provider/provider.go
@@ -137,7 +137,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 
 	asset := req.Asset
 	conf := asset.Connections[0]
-	runtime, err := s.AddRuntime(func(connId uint32) (*plugin.Runtime, error) {
+	runtime, err := s.AddRuntime(conf, func(connId uint32) (*plugin.Runtime, error) {
 		conn, err := connection.NewConnection(connId, asset, conf)
 		if err != nil {
 			return nil, err

--- a/providers/aws/provider/provider.go
+++ b/providers/aws/provider/provider.go
@@ -186,7 +186,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	asset := req.Asset
 	conf := asset.Connections[0]
 
-	runtime, err := s.AddRuntime(func(connId uint32) (*plugin.Runtime, error) {
+	runtime, err := s.AddRuntime(conf, func(connId uint32) (*plugin.Runtime, error) {
 		var conn shared.Connection
 		var err error
 

--- a/providers/azure/provider/provider.go
+++ b/providers/azure/provider/provider.go
@@ -192,7 +192,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	asset := req.Asset
 	conf := asset.Connections[0]
 
-	runtime, err := s.AddRuntime(func(connId uint32) (*plugin.Runtime, error) {
+	runtime, err := s.AddRuntime(conf, func(connId uint32) (*plugin.Runtime, error) {
 		var conn shared.AzureConnection
 		var err error
 

--- a/providers/core/provider/provider.go
+++ b/providers/core/provider/provider.go
@@ -35,7 +35,7 @@ func (s *Service) Connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	}
 
 	connectionId := defaultConnection
-	runtime, err := s.AddRuntime(func(connId uint32) (*plugin.Runtime, error) {
+	runtime, err := s.AddRuntime(req.Asset.Connections[0], func(connId uint32) (*plugin.Runtime, error) {
 		connectionId = connId
 		var upstream *upstream.UpstreamClient
 		var err error

--- a/providers/equinix/provider/provider.go
+++ b/providers/equinix/provider/provider.go
@@ -108,7 +108,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 
 	asset := req.Asset
 	conf := asset.Connections[0]
-	runtime, err := s.AddRuntime(func(connId uint32) (*plugin.Runtime, error) {
+	runtime, err := s.AddRuntime(conf, func(connId uint32) (*plugin.Runtime, error) {
 		conn, err := connection.NewEquinixConnection(connId, asset, conf)
 		if err != nil {
 			return nil, err

--- a/providers/gcp/provider/provider.go
+++ b/providers/gcp/provider/provider.go
@@ -209,7 +209,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	asset := req.Asset
 	conf := asset.Connections[0]
 
-	runtime, err := s.AddRuntime(func(connId uint32) (*plugin.Runtime, error) {
+	runtime, err := s.AddRuntime(conf, func(connId uint32) (*plugin.Runtime, error) {
 		var conn shared.GcpConnection
 		var err error
 

--- a/providers/github/provider/provider.go
+++ b/providers/github/provider/provider.go
@@ -127,7 +127,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	}
 
 	asset := req.Asset
-	runtime, err := s.AddRuntime(func(connId uint32) (*plugin.Runtime, error) {
+	runtime, err := s.AddRuntime(asset.Connections[0], func(connId uint32) (*plugin.Runtime, error) {
 		conn, err := connection.NewGithubConnection(connId, asset)
 		if err != nil {
 			return nil, err

--- a/providers/gitlab/provider/provider.go
+++ b/providers/gitlab/provider/provider.go
@@ -141,7 +141,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 
 	asset := req.Asset
 	conf := asset.Connections[0]
-	runtime, err := s.AddRuntime(func(connId uint32) (*plugin.Runtime, error) {
+	runtime, err := s.AddRuntime(conf, func(connId uint32) (*plugin.Runtime, error) {
 		conn, err := connection.NewGitLabConnection(connId, asset, conf)
 		if err != nil {
 			return nil, err

--- a/providers/google-workspace/provider/provider.go
+++ b/providers/google-workspace/provider/provider.go
@@ -159,7 +159,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 
 	asset := req.Asset
 	conf := asset.Connections[0]
-	runtime, err := s.AddRuntime(func(connId uint32) (*plugin.Runtime, error) {
+	runtime, err := s.AddRuntime(conf, func(connId uint32) (*plugin.Runtime, error) {
 		conn, err := connection.NewGoogleWorkspaceConnection(connId, asset, conf)
 		if err != nil {
 			return nil, err

--- a/providers/ipmi/provider/provider.go
+++ b/providers/ipmi/provider/provider.go
@@ -118,7 +118,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 
 	asset := req.Asset
 	conf := asset.Connections[0]
-	runtime, err := s.AddRuntime(func(connId uint32) (*plugin.Runtime, error) {
+	runtime, err := s.AddRuntime(conf, func(connId uint32) (*plugin.Runtime, error) {
 		conn, err := connection.NewIpmiConnection(connId, asset, conf)
 		if err != nil {
 			return nil, err

--- a/providers/k8s/provider/provider.go
+++ b/providers/k8s/provider/provider.go
@@ -137,7 +137,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	asset := req.Asset
 	conf := asset.Connections[0]
 
-	runtime, err := s.AddRuntime(func(connId uint32) (*plugin.Runtime, error) {
+	runtime, err := s.AddRuntime(conf, func(connId uint32) (*plugin.Runtime, error) {
 		var conn shared.Connection
 		var err error
 		if manifestContent, ok := conf.Options[shared.OPTION_IMMEMORY_CONTENT]; ok {

--- a/providers/ms365/provider/provider.go
+++ b/providers/ms365/provider/provider.go
@@ -115,7 +115,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 
 	asset := req.Asset
 	conf := asset.Connections[0]
-	runtime, err := s.AddRuntime(func(connId uint32) (*plugin.Runtime, error) {
+	runtime, err := s.AddRuntime(conf, func(connId uint32) (*plugin.Runtime, error) {
 		conn, err := connection.NewMs365Connection(connId, asset, conf)
 		if err != nil {
 			return nil, err

--- a/providers/network/provider/provider.go
+++ b/providers/network/provider/provider.go
@@ -137,7 +137,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	asset := req.Asset
 	conf := asset.Connections[0]
 
-	runtime, err := s.AddRuntime(func(connId uint32) (*plugin.Runtime, error) {
+	runtime, err := s.AddRuntime(conf, func(connId uint32) (*plugin.Runtime, error) {
 		var conn *connection.HostConnection
 
 		switch conf.Type {

--- a/providers/oci/provider/provider.go
+++ b/providers/oci/provider/provider.go
@@ -137,7 +137,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	asset := req.Asset
 	conf := asset.Connections[0]
 
-	runtime, err := s.AddRuntime(func(connId uint32) (*plugin.Runtime, error) {
+	runtime, err := s.AddRuntime(conf, func(connId uint32) (*plugin.Runtime, error) {
 		conn, err := connection.NewOciConnection(connId, asset, conf)
 		if err != nil {
 			return nil, err

--- a/providers/okta/provider/provider.go
+++ b/providers/okta/provider/provider.go
@@ -117,7 +117,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 
 	asset := req.Asset
 	conf := asset.Connections[0]
-	runtime, err := s.AddRuntime(func(connId uint32) (*plugin.Runtime, error) {
+	runtime, err := s.AddRuntime(conf, func(connId uint32) (*plugin.Runtime, error) {
 		conn, err := connection.NewOktaConnection(connId, asset, conf)
 		if err != nil {
 			return nil, err

--- a/providers/opcua/provider/provider.go
+++ b/providers/opcua/provider/provider.go
@@ -91,7 +91,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 
 	asset := req.Asset
 	conf := asset.Connections[0]
-	runtime, err := s.AddRuntime(func(connId uint32) (*plugin.Runtime, error) {
+	runtime, err := s.AddRuntime(conf, func(connId uint32) (*plugin.Runtime, error) {
 		conn, err := connection.NewOpcuaConnection(connId, asset, conf)
 		if err != nil {
 			return nil, err

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -292,7 +292,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	asset := req.Asset
 	conf := asset.Connections[0]
 
-	runtime, err := s.AddRuntime(func(connId uint32) (*plugin.Runtime, error) {
+	runtime, err := s.AddRuntime(conf, func(connId uint32) (*plugin.Runtime, error) {
 		var conn shared.Connection
 		var err error
 

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -193,6 +193,11 @@ func (r *Runtime) Connect(req *plugin.ConnectReq) error {
 		return errors.New("cannot connect to asset, no connection info provided")
 	}
 
+	// If there is no connection ID set, we need to assign one from the coordinator
+	if asset.Connections[0].Id == 0 {
+		asset.Connections[0].Id = Coordinator.NextConnectionId()
+	}
+
 	r.features = req.Features
 	callbacks := providerCallbacks{
 		runtime: r,

--- a/providers/slack/provider/provider.go
+++ b/providers/slack/provider/provider.go
@@ -119,7 +119,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 
 	asset := req.Asset
 	conf := asset.Connections[0]
-	runtime, err := s.AddRuntime(func(connId uint32) (*plugin.Runtime, error) {
+	runtime, err := s.AddRuntime(conf, func(connId uint32) (*plugin.Runtime, error) {
 		var conn *connection.SlackConnection
 		var err error
 

--- a/providers/terraform/provider/provider.go
+++ b/providers/terraform/provider/provider.go
@@ -135,7 +135,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	asset := req.Asset
 	conf := asset.Connections[0]
 
-	runtime, err := s.AddRuntime(func(connId uint32) (*plugin.Runtime, error) {
+	runtime, err := s.AddRuntime(conf, func(connId uint32) (*plugin.Runtime, error) {
 		var conn *connection.Connection
 		var err error
 

--- a/providers/vcd/provider/provider.go
+++ b/providers/vcd/provider/provider.go
@@ -109,7 +109,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	asset := req.Asset
 	conf := asset.Connections[0]
 
-	runtime, err := s.AddRuntime(func(connId uint32) (*plugin.Runtime, error) {
+	runtime, err := s.AddRuntime(conf, func(connId uint32) (*plugin.Runtime, error) {
 		conn, err := connection.NewVcdConnection(connId, asset, conf)
 		if err != nil {
 			return nil, err

--- a/providers/vsphere/provider/provider.go
+++ b/providers/vsphere/provider/provider.go
@@ -139,7 +139,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	asset := req.Asset
 	conf := asset.Connections[0]
 
-	runtime, err := s.AddRuntime(func(connId uint32) (*plugin.Runtime, error) {
+	runtime, err := s.AddRuntime(conf, func(connId uint32) (*plugin.Runtime, error) {
 		conn, err := connection.NewVsphereConnection(connId, asset, conf)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Use globally unique connection IDs for providers. This allows us to call `Connect` multiple times for providers without having to create new connections in the process. It also helps us to do cross-provider connections in the future since 1 asset will always have 1 connection ID for all providers it talks to.

**New flow**
Connection IDs are assigned by the coordinator. If a connection has no ID yet, it gets one from the coordinator which makes sure it is globally unique.
- Made sure cloned inventories are cloned without the connection ID. This makes sure discovered assets get their own connection ID
- Made sure that we first check if a connection with this ID exists for the current provider. If there is one, we return that and we do not create a new connection
- This flow is only used for cnquery/cnspec clients that support it. Old clients will use the old way

**Old flow**
The old flow is maximally contained in the base `Service` struct that is reused by all providers. When we clean that up in v12, most of the changes will be in that struct. The old flow is triggered only when we attempt to create a runtime with connection ID 0. This indicates cnquery/cnspec is an old version and doesn't set IDs externally. The old flow will also create a new runtime for an asset that calls `Connect` for a second time