### PR TITLE
🐛 fix gcp init functions panic

### DIFF
--- a/providers/gcp/resources/bigquery.go
+++ b/providers/gcp/resources/bigquery.go
@@ -190,6 +190,8 @@ func initGcpProjectBigqueryServiceDataset(runtime *plugin.Runtime, args map[stri
 			args["id"] = llx.StringData(ids.name)
 			args["location"] = llx.StringData(ids.region)
 			args["projectId"] = llx.StringData(ids.project)
+		} else {
+			return nil, nil, errors.New("no asset identifier found")
 		}
 	}
 

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -807,6 +807,8 @@ func initGcpProjectComputeServiceFirewall(runtime *plugin.Runtime, args map[stri
 		if ids := getAssetIdentifier(runtime); ids != nil {
 			args["name"] = llx.StringData(ids.name)
 			args["projectId"] = llx.StringData(ids.project)
+		} else {
+			return nil, nil, errors.New("no asset identifier found")
 		}
 	}
 

--- a/providers/gcp/resources/dataproc.go
+++ b/providers/gcp/resources/dataproc.go
@@ -462,7 +462,6 @@ func (g *mqlGcpProjectDataprocService) clusters() ([]interface{}, error) {
 						}
 
 						mqlConfig, err = CreateResource(g.MqlRuntime, "gcp.project.dataprocService.cluster.config", map[string]*llx.RawData{
-							"projectId":             llx.StringData(c.ProjectId),
 							"parentResourcePath":    llx.StringData(fmt.Sprintf("%s/dataproc/%s", projectId, c.ClusterName)),
 							"autoscaling":           llx.DictData(mqlAutoscalingCfg),
 							"configBucket":          llx.StringData(c.Config.ConfigBucket),

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -62,6 +63,8 @@ func initGcpProjectGkeServiceCluster(runtime *plugin.Runtime, args map[string]*l
 			args["name"] = llx.StringData(ids.name)
 			args["location"] = llx.StringData(ids.region)
 			args["projectId"] = llx.StringData(ids.project)
+		} else {
+			return nil, nil, errors.New("no asset identifier found")
 		}
 	}
 

--- a/providers/gcp/resources/storage.go
+++ b/providers/gcp/resources/storage.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -143,6 +144,8 @@ func initGcpProjectStorageServiceBucket(runtime *plugin.Runtime, args map[string
 			args["name"] = llx.StringData(ids.name)
 			args["projectId"] = llx.StringData(ids.project)
 			args["location"] = llx.StringData(ids.region)
+		} else {
+			return nil, nil, errors.New("no asset identifier found")
 		}
 	}
 


### PR DESCRIPTION
some of the init functions in the GCP provider weren't properly checking for missing asset IDs, which could result in provider panics

also dataproc config was trying to set a non-existent field