### PR TITLE
🐛 prevent hard crashes on missing asset metadata

### DIFF
--- a/apps/cnquery/cmd/shell.go
+++ b/apps/cnquery/cmd/shell.go
@@ -132,7 +132,15 @@ func StartShell(runtime *providers.Runtime, conf *ShellConfig) error {
 		os.Exit(1)
 	}
 
-	log.Info().Msgf("connected to %s", connectAsset.Runtime.Provider.Connection.Asset.Platform.Title)
+	if connectAsset.Runtime.Provider.Connection.Asset == nil {
+		log.Error().Msg("asset failed to return metadata")
+		os.Exit(1)
+	} else if connectAsset.Runtime.Provider.Connection.Asset.Platform == nil {
+		log.Error().Msg("asset failed to return platform metadata")
+		os.Exit(1)
+	} else {
+		log.Info().Msgf("connected to %s", connectAsset.Runtime.Provider.Connection.Asset.Platform.Title)
+	}
 
 	// when we close the shell, we need to close the backend and store the recording
 	onCloseHandler := func() {


### PR DESCRIPTION
I still have to track down the cause of this, but when I ran:

```bash
cnspec shell docker image ubuntu:latest
```

on my local machine, due to something else being wrong, the provider failed to return a platform. The issue is, that this quickly leads to:

```
panic({0x1bb91e0?, 0x347feb0?})
	/usr/lib/go/src/runtime/panic.go:770 +0x132
go.mondoo.com/cnquery/v10/apps/cnquery/cmd.StartShell(0xc000d53c80, 0xc000d50de0)
	/pub/go/pkg/mod/go.mondoo.com/cnquery/v10@v10.6.2-0.20240311174838-3eb7077113c2/apps/cnquery/cmd/shell.go:135 +0x3f1
go.mondoo.com/cnspec/v10/apps/cnspec/cmd.init.func30(0xc0001489c0?, 0xc000d53c80, 0xc00023b500?)
	/pub/go/src/go.mondoo.com/cnspec/apps/cnspec/cmd/shell.go:34 +0x54

```

Instead, this PR implements nice errors messages like this:

```
x asset failed to return platform metadata
```

It still exits, because we have no good way of recovering from this errors at the moment.