### PR TITLE
🐛 prevent hard crashes on missing asset metadata in run command

### DIFF
--- a/apps/cnquery/cmd/plugin.go
+++ b/apps/cnquery/cmd/plugin.go
@@ -122,6 +122,18 @@ func (c *cnqueryPlugin) RunQuery(conf *run.RunQueryConfig, runtime *providers.Ru
 	for i := range discoveredAssets.Assets {
 		asset := discoveredAssets.Assets[i]
 
+		// sanity checks to prevent panics
+		if asset.Runtime == nil {
+			log.Error().Msg("asset is missing a runtime")
+			continue
+		} else if asset.Runtime.Provider.Connection.Asset == nil {
+			log.Error().Msg("asset is missing metadata")
+			continue
+		} else if asset.Runtime.Provider.Connection.Asset.Platform == nil {
+			log.Error().Msg("asset is missing platform metadata")
+			continue
+		}
+
 		// when we close the shell, we need to close the backend and store the recording
 		onCloseHandler := func() {
 			// FIXME: store recording

--- a/apps/cnquery/cmd/shell.go
+++ b/apps/cnquery/cmd/shell.go
@@ -132,7 +132,15 @@ func StartShell(runtime *providers.Runtime, conf *ShellConfig) error {
 		os.Exit(1)
 	}
 
-	log.Info().Msgf("connected to %s", connectAsset.Runtime.Provider.Connection.Asset.Platform.Title)
+	if connectAsset.Runtime.Provider.Connection.Asset == nil {
+		log.Error().Msg("asset failed to return metadata")
+		os.Exit(1)
+	} else if connectAsset.Runtime.Provider.Connection.Asset.Platform == nil {
+		log.Error().Msg("asset failed to return platform metadata")
+		os.Exit(1)
+	} else {
+		log.Info().Msgf("connected to %s", connectAsset.Runtime.Provider.Connection.Asset.Platform.Title)
+	}
 
 	// when we close the shell, we need to close the backend and store the recording
 	onCloseHandler := func() {


### PR DESCRIPTION
After https://github.com/mondoohq/cnquery/pull/3538

Similar to https://github.com/mondoohq/cnquery/pull/3538 but for the `run` command.

```bash
cnspec run docker image ubuntu:latest -c "asset.name"
```

on my local machine, due to something else being wrong, the provider failed to return a platform. The issue is, that this quickly leads to:

```
go.mondoo.com/cnquery/v10/providers/core/provider.(*Service).Connect(0xc000831900?, 0xc000836600, {0x0?, 0x0?})
        /pub/go/src/go.mondoo.com/cnquery/providers/core/provider/provider.go:67 +0x320
go.mondoo.com/cnquery/v10/providers.(*Runtime).lookupResourceProvider(0xc000831900, {0xc00081b751, 0x5})
        /pub/go/src/go.mondoo.com/cnquery/providers/runtime.go:585 +0x453
go.mondoo.com/cnquery/v10/providers.(*Runtime).CreateResource(0xc000831900, {0xc00081b751, 0x5}, 0x0)
        /pub/go/src/go.mondoo.com/cnquery/providers/runtime.go:242 +0x3f
```

Instead, this PR implements nice errors messages like this:

```
x asset is missing platform metadata
```
