### PR TITLE
🐛 fix multiple parameters in AssetURL

### DIFF
--- a/providers-sdk/v1/inventory/asset_url.go
+++ b/providers-sdk/v1/inventory/asset_url.go
@@ -326,7 +326,7 @@ func (a *AssetUrlSchema) BuildQueries(kvs []KV) []AssetUrlChain {
 		kv := kvs[i]
 		nuNodes := a.keys[kv.Key]
 		nodes = append(nodes, nuNodes...)
-		for i := 0; i < len(nuNodes); i++ {
+		for j := 0; j < len(nuNodes); j++ {
 			values = append(values, kv.Value)
 		}
 	}
@@ -339,16 +339,56 @@ func (a *AssetUrlSchema) BuildQueries(kvs []KV) []AssetUrlChain {
 	for len(nodes) != 0 {
 		lastIdx := len(nodes) - 1
 		cur := nodes[lastIdx]
-		curKey := values[lastIdx]
+		curValue := values[lastIdx]
 		nodes = nodes[:lastIdx]
 		values = values[:lastIdx]
 
-		res = append(res, buildParentQuery(cur, curKey))
+		query := buildParentQuery(cur, curValue, kvs)
+		if len(query) == 0 {
+			continue
+		}
+
+		res = append(res, query)
+		// since this is a valid chain, let's check the list of remaining nodes
+		// if anything can get eliminated
+		for cur != nil {
+			nodes = filterArr(nodes, cur)
+			cur = cur.Parent
+		}
 	}
 	return res
 }
 
-func buildParentQuery(leaf *AssetUrlBranch, value string) AssetUrlChain {
+func filterArr[T comparable](arr []T, entry T) []T {
+	for i := range arr {
+		if arr[i] == entry {
+			arr[i] = arr[len(arr)-1]
+			return arr[:len(arr)-1]
+		}
+	}
+	return arr
+}
+
+func filterKV(kvs []KV, key string, value string) []KV {
+	found := -1
+	for i := range kvs {
+		if kvs[i].Key == key && (value == "*" || kvs[i].Value == value) {
+			found = i
+			break
+		}
+	}
+	if found == -1 {
+		return kvs
+	}
+	kvs[found] = kvs[len(kvs)-1]
+	return kvs[:len(kvs)-1]
+}
+
+// Build a parent query from a leaf in an asset url schema and a given value
+// in the parent branch under which this leaf was located. The required KVs
+// are a list of identifiers that should be contained (or supported) by the
+// resulting asset URL chain.
+func buildParentQuery(leaf *AssetUrlBranch, value string, requiredKVs []KV) AssetUrlChain {
 	res := make([]KV, leaf.Depth)
 
 	cur := leaf
@@ -359,8 +399,15 @@ func buildParentQuery(leaf *AssetUrlBranch, value string) AssetUrlChain {
 			Value: curValue,
 		}
 
+		requiredKVs = filterKV(requiredKVs, cur.Key, curValue)
 		curValue = cur.ParentValue
 		cur = cur.Parent
+	}
+
+	// if we have any KVs that remain on this chain, that means we haven't found
+	// a valid query
+	if len(requiredKVs) != 0 {
+		return nil
 	}
 
 	return res

--- a/providers-sdk/v1/inventory/asset_url_test.go
+++ b/providers-sdk/v1/inventory/asset_url_test.go
@@ -105,7 +105,7 @@ func TestAddSubtree(t *testing.T) {
 		assert.Equal(t, []AssetUrlChain{
 			{
 				KV{"technology", "aws"},
-				KV{"account", "*"},
+				KV{"account", "123"},
 				KV{"service", "ec2"},
 				KV{"family", "windows"},
 				KV{"platform", "windows server"},

--- a/providers-sdk/v1/inventory/asset_url_test.go
+++ b/providers-sdk/v1/inventory/asset_url_test.go
@@ -71,7 +71,7 @@ func TestAddSubtree(t *testing.T) {
 		}, keys)
 	})
 
-	t.Run("build a query with referenced tree positions", func(t *testing.T) {
+	t.Run("build query with 1 params and 2 results", func(t *testing.T) {
 		err := root.RefreshCache()
 		require.NoError(t, err)
 
@@ -86,6 +86,42 @@ func TestAddSubtree(t *testing.T) {
 				KV{"family", "windows"},
 				KV{"platform", "windows server"},
 			},
+			{
+				KV{"technology", "os"},
+				KV{"family", "windows"},
+				KV{"platform", "windows server"},
+			},
+		}, queries)
+	})
+
+	t.Run("build query with 2 params and 1 result", func(t *testing.T) {
+		err := root.RefreshCache()
+		require.NoError(t, err)
+
+		queries := root.BuildQueries([]KV{
+			{Key: "account", Value: "123"},
+			{Key: "platform", Value: "windows server"},
+		})
+		assert.Equal(t, []AssetUrlChain{
+			{
+				KV{"technology", "aws"},
+				KV{"account", "*"},
+				KV{"service", "ec2"},
+				KV{"family", "windows"},
+				KV{"platform", "windows server"},
+			},
+		}, queries)
+	})
+
+	t.Run("build query with 2 params (incl root) and 1 result", func(t *testing.T) {
+		err := root.RefreshCache()
+		require.NoError(t, err)
+
+		queries := root.BuildQueries([]KV{
+			{Key: "technology", Value: "os"},
+			{Key: "platform", Value: "windows server"},
+		})
+		assert.Equal(t, []AssetUrlChain{
 			{
 				KV{"technology", "os"},
 				KV{"family", "windows"},


### PR DESCRIPTION
We returned too many queries from the list. This approach fixes the underlying bug by:
1. making sure all requested parameters are in the query and
2. removing nodes from the search tree once a descendent is found