### PR TITLE
🧹 use new `inventory-format-ansible` and `inventory-format-domainlist` names for flags

### DIFF
--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -31,8 +31,18 @@ func init() {
 	scanCmd.Flags().String("platform-id", "", "Select a specific target asset by providing its platform ID.")
 
 	scanCmd.Flags().String("inventory-file", "", "Set the path to the inventory file.")
+
+	scanCmd.Flags().Bool("inventory-format-ansible", false, "Set the inventory format to Ansible.")
+	// "inventory-ansible" is deprecated, use "inventory-format-ansible" instead
 	scanCmd.Flags().Bool("inventory-ansible", false, "Set the inventory format to Ansible.")
+	scanCmd.Flags().MarkDeprecated("inventory-ansible", "use --inventory-format-ansible")
+	scanCmd.Flags().MarkHidden("inventory-ansible")
+
+	scanCmd.Flags().Bool("inventory-format-domainlist", false, "Set the inventory format to domain list.")
+	// "inventory-domainlist" is deprecated, use "inventory-format-domainlist" instead
 	scanCmd.Flags().Bool("inventory-domainlist", false, "Set the inventory format to domain list.")
+	scanCmd.Flags().MarkDeprecated("inventory-domainlist", "use --inventory-format-domainlist")
+	scanCmd.Flags().MarkHidden("inventory-domainlist")
 
 	// bundles, packs & incognito mode
 	scanCmd.Flags().Bool("incognito", false, "Run in incognito mode. Do not report scan results to  Mondoo Platform.")

--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -32,17 +32,17 @@ func init() {
 
 	scanCmd.Flags().String("inventory-file", "", "Set the path to the inventory file.")
 
-	scanCmd.Flags().Bool("inventory-format-ansible", false, "Set the inventory format to Ansible.")
+	_ = scanCmd.Flags().Bool("inventory-format-ansible", false, "Set the inventory format to Ansible.")
 	// "inventory-ansible" is deprecated, use "inventory-format-ansible" instead
-	scanCmd.Flags().Bool("inventory-ansible", false, "Set the inventory format to Ansible.")
-	scanCmd.Flags().MarkDeprecated("inventory-ansible", "use --inventory-format-ansible")
-	scanCmd.Flags().MarkHidden("inventory-ansible")
+	_ = scanCmd.Flags().Bool("inventory-ansible", false, "Set the inventory format to Ansible.")
+	_ = scanCmd.Flags().MarkDeprecated("inventory-ansible", "use --inventory-format-ansible")
+	_ = scanCmd.Flags().MarkHidden("inventory-ansible")
 
-	scanCmd.Flags().Bool("inventory-format-domainlist", false, "Set the inventory format to domain list.")
+	_ = scanCmd.Flags().Bool("inventory-format-domainlist", false, "Set the inventory format to domain list.")
 	// "inventory-domainlist" is deprecated, use "inventory-format-domainlist" instead
-	scanCmd.Flags().Bool("inventory-domainlist", false, "Set the inventory format to domain list.")
-	scanCmd.Flags().MarkDeprecated("inventory-domainlist", "use --inventory-format-domainlist")
-	scanCmd.Flags().MarkHidden("inventory-domainlist")
+	_ = scanCmd.Flags().Bool("inventory-domainlist", false, "Set the inventory format to domain list.")
+	_ = scanCmd.Flags().MarkDeprecated("inventory-domainlist", "use --inventory-format-domainlist")
+	_ = scanCmd.Flags().MarkHidden("inventory-domainlist")
 
 	// bundles, packs & incognito mode
 	scanCmd.Flags().Bool("incognito", false, "Run in incognito mode. Do not report scan results to  Mondoo Platform.")

--- a/cli/inventoryloader/inventory.go
+++ b/cli/inventoryloader/inventory.go
@@ -81,7 +81,7 @@ func Parse() (*inventory.Inventory, error) {
 	}
 
 	// force detection
-	if viper.GetBool("inventory-ansible") {
+	if viper.GetBool("inventory-format-ansible") || viper.GetBool("inventory-ansible") {
 		log.Debug().Msg("parse ansible inventory")
 		inventory, err := parseAnsibleInventory(data)
 		if err != nil {
@@ -90,7 +90,7 @@ func Parse() (*inventory.Inventory, error) {
 		return inventory, nil
 	}
 
-	if viper.GetBool("inventory-domainlist") {
+	if viper.GetBool("inventory-format-domainlist") || viper.GetBool("inventory-domainlist") {
 		log.Debug().Msg("parse domainlist inventory")
 		inventory, err := parseDomainListInventory(data)
 		if err != nil {
@@ -119,6 +119,7 @@ func Parse() (*inventory.Inventory, error) {
 }
 
 func parseAnsibleInventory(data []byte) (*inventory.Inventory, error) {
+	log.Info().Msg("use ansible inventory")
 	inventory, err := ansibleinventory.Parse(data)
 	if err != nil {
 		return nil, err
@@ -127,6 +128,7 @@ func parseAnsibleInventory(data []byte) (*inventory.Inventory, error) {
 }
 
 func parseDomainListInventory(data []byte) (*inventory.Inventory, error) {
+	log.Info().Msg("use domainlist inventory")
 	inventory, err := domainlist.Parse(bytes.NewReader(data))
 	if err != nil {
 		return nil, err

--- a/test/cli/testdata/cnquery_scan.ct
+++ b/test/cli/testdata/cnquery_scan.ct
@@ -17,20 +17,20 @@ Available Commands:
   mock        Scan use a recording without an active connection
 
 Flags:
-      --annotation stringToString    Add an annotation to the asset. (default [])
-      --asset-name string            User-override for the asset name
-      --detect-cicd                  Try to detect CI/CD environments. If detected, set the asset category to 'cicd'. (default true)
-  -h, --help                         help for scan
-      --incognito                    Run in incognito mode. Do not report scan results to  Mondoo Platform.
-      --inventory-ansible            Set the inventory format to Ansible.
-      --inventory-domainlist         Set the inventory format to domain list.
-      --inventory-file string        Set the path to the inventory file.
-  -j, --json                         Run the query and return the object in a JSON structure.
-  -o, --output string                Set output format: compact, csv, full, json, summary, yaml (default "compact")
-      --platform-id string           Select a specific target asset by providing its platform ID.
-      --props stringToString         Custom values for properties (default [])
-      --querypack querypack-bundle   Set the query packs to execute. This requires querypack-bundle. You can specify multiple UIDs.
-  -f, --querypack-bundle strings     Path to local query pack file
+      --annotation stringToString     Add an annotation to the asset. (default [])
+      --asset-name string             User-override for the asset name
+      --detect-cicd                   Try to detect CI/CD environments. If detected, set the asset category to 'cicd'. (default true)
+  -h, --help                          help for scan
+      --incognito                     Run in incognito mode. Do not report scan results to  Mondoo Platform.
+      --inventory-file string         Set the path to the inventory file.
+      --inventory-format-ansible      Set the inventory format to Ansible.
+      --inventory-format-domainlist   Set the inventory format to domain list.
+  -j, --json                          Run the query and return the object in a JSON structure.
+  -o, --output string                 Set output format: compact, csv, full, json, summary, yaml (default "compact")
+      --platform-id string            Select a specific target asset by providing its platform ID.
+      --props stringToString          Custom values for properties (default [])
+      --querypack querypack-bundle    Set the query packs to execute. This requires querypack-bundle. You can specify multiple UIDs.
+  -f, --querypack-bundle strings      Path to local query pack file
 
 Global Flags:
       --api-proxy string   Set proxy for communications with Mondoo API


### PR DESCRIPTION
Followup on https://github.com/mondoohq/cnspec/issues/1124 since we learned that the flag name was not intuitive.