### PR TITLE
🧹 make ansible inventory parser more restrict

### DIFF
--- a/explorer/scan/discovery.go
+++ b/explorer/scan/discovery.go
@@ -74,7 +74,7 @@ func (d *DiscoveredAssets) GetAssetsByPlatformID(platformID string) []*AssetWith
 func DiscoverAssets(ctx context.Context, inv *inventory.Inventory, upstream *upstream.UpstreamConfig, recording llx.Recording) (*DiscoveredAssets, error) {
 	im, err := manager.NewManager(manager.WithInventory(inv, providers.DefaultRuntime()))
 	if err != nil {
-		return nil, errors.New("failed to resolve inventory for connection")
+		return nil, errors.New("failed to resolve inventory for connection: " + err.Error())
 	}
 	invAssets := im.GetAssets()
 	if len(invAssets) == 0 {

--- a/providers-sdk/v1/inventory/ansibleinventory/inventory.go
+++ b/providers-sdk/v1/inventory/ansibleinventory/inventory.go
@@ -30,6 +30,10 @@ type All struct {
 }
 
 func Parse(data []byte) (*Inventory, error) {
+	if !IsInventory(data) {
+		return nil, errors.New("unsupported ansible inventory, use `ansible-inventory -i {inventory} --list` to convert it first")
+	}
+
 	inventory := Inventory{}
 	err := inventory.Decode(data)
 	if err != nil {
@@ -52,13 +56,15 @@ func IsInventory(data []byte) bool {
 		return false
 	}
 
-	// if the all key is there, its a ansible yaml
+	// if the all key is there, its a ansible format
 	// NOTE: as this point we only support fully resolved ansible config
 	_, ok := raw["all"]
-	if ok {
-		return true
+	if !ok {
+		return false
 	}
-	return false
+
+	_, ok = raw["_meta"]
+	return ok
 }
 
 func (i *Inventory) Decode(data []byte) error {

--- a/providers-sdk/v1/inventory/ansibleinventory/inventory_test.go
+++ b/providers-sdk/v1/inventory/ansibleinventory/inventory_test.go
@@ -44,6 +44,41 @@ func TestValidInventory(t *testing.T) {
 	}
 }
 `
+	assert.False(t, ansibleinventory.IsInventory([]byte(jsonFile)))
+
+	jsonFile = `
+all:
+  hosts:
+    ub2204:
+      ansible_host: 34.69.247.108
+      ansible_user: chris
+      ansible_ssh_private_key_file: ~/.ssh/id_ed25519
+`
+	assert.False(t, ansibleinventory.IsInventory([]byte(jsonFile)))
+
+	jsonFile = `
+{
+    "_meta": {
+        "hostvars": {
+            "ub2204": {
+                "ansible_host": "34.69.247.108",
+                "ansible_ssh_private_key_file": "~/.ssh/id_ed25519",
+                "ansible_user": "chris"
+            }
+        }
+    },
+    "all": {
+        "children": [
+            "ungrouped"
+        ]
+    },
+    "ungrouped": {
+        "hosts": [
+            "ub2204"
+        ]
+    }
+}
+`
 	assert.True(t, ansibleinventory.IsInventory([]byte(jsonFile)))
 }
 

--- a/providers-sdk/v1/inventory/inventory.go
+++ b/providers-sdk/v1/inventory/inventory.go
@@ -5,6 +5,7 @@ package inventory
 
 import (
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 
@@ -172,10 +173,18 @@ func (p *Inventory) PreProcess() error {
 		if cred.PrivateKeyPath != "" {
 			path := cred.PrivateKeyPath
 
-			// special handling for relative filenames, instead of loading
-			// private keys from relative to the work directory, we want to
-			// load the files relative to the source inventory
-			if !filepath.IsAbs(cred.PrivateKeyPath) {
+			if strings.HasPrefix(path, "~/") {
+				// special handling for ~
+				usr, err := user.Current()
+				if err != nil {
+					return err
+				}
+				path = filepath.Join(usr.HomeDir, path[2:])
+			} else if !filepath.IsAbs(cred.PrivateKeyPath) {
+				// special handling for relative filenames, instead of loading
+				// private keys from relative to the work directory, we want to
+				// load the files relative to the source inventory
+
 				// we handle credentials relative to the inventory file
 				fileLoc, ok := p.Metadata.Labels[InventoryFilePath]
 				if ok {


### PR DESCRIPTION
**Restricter Ansible Inventory Parsing**

This implementation makes the ansible inventory parser more restrict. It tests the passed inventory data and returns a proper error. 

While the following inventory is a valid ansible inventory, cnquery & cnspec only parse fully resolved inventories.

```yaml
all:
  hosts:
    ub2204:
      ansible_host: 34.69.247.108
      ansible_user: chris
      ansible_ssh_private_key_file: ~/.ssh/id_ed25519
```

Instead of a silent pass-through where the inventory could not be parsed and therefore resolves 0 assets, we return a proper error now. This also prevents that the inventory falls back to local machine.

```shell
> cnspec scan --inventory-format-ansible --inventory-file ansible-inventory.yaml
→ load inventory inventory-file=providers-sdk/v1/inventory/ansibleinventory/testdata/ansible-inventory.yaml
→ use ansible inventory
FTL failed to parse inventory error="could not parse inventory: unsupported ansible inventory, use `ansible-inventory -i {inventory} --list` to convert it first"
```

This message highlights the solution. We need to convert the ansible inventory first with the `ansible-inventory` command.

**Handle relative paths for identities eg. ~/.ssh/.id_rsa**

Before this PR we could not handle `~/.ssh/.id_rsa` properly. This issue in combination with the case above resulted in unexpected user behavior. This PR changes that and resolves `~` to the home directory.