### PR TITLE
⭐️ Detect packages on Wolfi container distro

### DIFF
--- a/providers/os/resources/packages/packages.go
+++ b/providers/os/resources/packages/packages.go
@@ -105,7 +105,7 @@ func ResolveSystemPkgManager(conn shared.Connection) (OperatingSystemPkgManager,
 		pm = &RpmPkgManager{conn: conn, platform: asset.Platform}
 	case asset.Platform.IsFamily("suse"): // suse handling
 		pm = &SusePkgManager{RpmPkgManager{conn: conn, platform: asset.Platform}}
-	case asset.Platform.Name == "alpine": // alpine
+	case asset.Platform.Name == "alpine" || asset.Platform.Name == "wolfi": // alpine & wolfi share apk
 		pm = &AlpinePkgManager{conn: conn, platform: asset.Platform}
 	case asset.Platform.Name == "macos": // mac os family
 		pm = &MacOSPkgManager{conn: conn}


### PR DESCRIPTION
This distro uses apk so add it to the mapping.

```
cnquery shell container image cgr.dev/chainguard/caddy
→ connected to Wolfi
  ___ _ __   __ _ _   _  ___ _ __ _   _
 / __| '_ \ / _` | | | |/ _ \ '__| | | |
| (__| | | | (_| | |_| |  __/ |  | |_| |
 \___|_| |_|\__, |\__,_|\___|_|   \__, |
  mondoo™      |_|                |___/  interactive shell

cnquery> packages
packages.list: [
  0: package name="ca-certificates-bundle" version="1708982311:20240226-r0"
  1: package name="caddy" version="1710420294:2.7.6-r4"
  2: package name="wolfi-baselayout" version="1701735113:20230201-r7"
]
```