### PR TITLE
🧹 add tags to ec2 instances

### DIFF
--- a/providers/aws/resources/discovery_conversion.go
+++ b/providers/aws/resources/discovery_conversion.go
@@ -250,6 +250,8 @@ func addConnectionInfoToEc2Asset(instance *mqlAwsEc2Instance, accountId string, 
 	asset.Labels["mondoo.com/region"] = instance.Region.Data
 	asset.Labels["mondoo.com/platform"] = instance.PlatformDetails.Data
 	asset.Labels["mondoo.com/instance-type"] = instance.InstanceType.Data
+	asset.Labels["mondoo.com/parent-id"] = accountId
+	asset.Labels["mondoo.com/instance-id"] = instance.InstanceId.Data
 
 	if instance.GetImage().Data != nil {
 		asset.Labels["mondoo.com/image"] = instance.GetImage().Data.Id.Data
@@ -285,6 +287,7 @@ func addConnectionInfoToEc2Asset(instance *mqlAwsEc2Instance, accountId string, 
 					User: probableUsername,
 					Type: vault.CredentialType_aws_ec2_ssm_session,
 				})
+				asset.Labels["mondoo.com/ssm-connection"] = "Online"
 			}
 		}
 	} else {


### PR DESCRIPTION
these labels are useful for users, and were included in v8, but were removed when moving to v9. adding them back in