### PR TITLE
🐛 ensure ec2 instances get a name when scanned

### DIFF
--- a/providers/os/id/awsec2/metadata_cmd.go
+++ b/providers/os/id/awsec2/metadata_cmd.go
@@ -71,7 +71,7 @@ func (m *CommandInstanceMetadata) Identify() (Identity, error) {
 		return Identity{}, errors.Wrap(err, "failed to decode EC2 instance identity document")
 	}
 
-	name := ""
+	name := doc.InstanceID
 	// Note that the tags metadata service has to be enabled for this to work. If not, we fallback to trying to get the name
 	// via the aws API (if there's a config provided).
 	taggedName, err := m.instanceNameTag()

--- a/providers/os/id/awsec2/metadata_cmd_test.go
+++ b/providers/os/id/awsec2/metadata_cmd_test.go
@@ -38,7 +38,7 @@ func TestEC2RoleProviderInstanceIdentityUnixNoName(t *testing.T) {
 	ident, err := metadata.Identify()
 
 	assert.Nil(t, err)
-	assert.Equal(t, "", ident.InstanceName)
+	assert.Equal(t, "i-1234567890abcdef0", ident.InstanceName)
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/123456789012/regions/us-west-2/instances/i-1234567890abcdef0", ident.InstanceID)
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/aws/accounts/123456789012", ident.AccountID)
 }
@@ -68,7 +68,7 @@ func TestEC2RoleProviderInstanceIdentityWindowsNoName(t *testing.T) {
 	ident, err := metadata.Identify()
 
 	assert.Nil(t, err)
-	assert.Equal(t, "", ident.InstanceName)
+	assert.Equal(t, "i-1234567890abcdef0", ident.InstanceName)
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/123456789012/regions/us-east-1/instances/i-1234567890abcdef0", ident.InstanceID)
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/aws/accounts/123456789012", ident.AccountID)
 }


### PR DESCRIPTION
default to instance id for the name, give it the name if we get the tag

fixes https://github.com/mondoohq/cnspec/issues/1144