### PR TITLE
🧹 refactor os users initialization and lookups

### DIFF
--- a/providers/os/resources/group.go
+++ b/providers/os/resources/group.go
@@ -79,19 +79,16 @@ func (x *mqlGroup) id() (string, error) {
 }
 
 func (x *mqlGroup) members() ([]interface{}, error) {
-	raw, err := CreateResource(x.MqlRuntime, "users", nil)
-	if err != nil {
-		return nil, errors.New("cannot get users info for group: " + err.Error())
-	}
-	users := raw.(*mqlUsers)
-
-	if err := users.refreshCache(nil); err != nil {
-		return nil, err
-	}
-
 	res := make([]interface{}, len(x.membersArr))
 	for i, name := range x.membersArr {
-		res[i] = users.usersByName[name]
+		user, err := NewResource(x.MqlRuntime, "user", map[string]*llx.RawData{
+			"name": llx.StringData(name),
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		res[i] = user
 	}
 
 	return res, nil

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -7755,7 +7755,7 @@ func (c *mqlPrivatekey) GetEncrypted() *plugin.TValue[bool] {
 type mqlUsers struct {
 	MqlRuntime *plugin.Runtime
 	__id string
-	mqlUsersInternal
+	// optional: if you define mqlUsersInternal it will be used here
 	List plugin.TValue[[]interface{}]
 }
 

--- a/providers/os/resources/user.go
+++ b/providers/os/resources/user.go
@@ -38,7 +38,7 @@ func initUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string
 	rawName, nameOk := args["name"]
 	rawUID, idOk := args["uid"]
 	if !nameOk && !idOk {
-		return args, nil, nil
+		return args, nil, errors.New("cannot find user, no search criteria provided")
 	}
 
 	raw, err := CreateResource(runtime, "users", nil)
@@ -113,7 +113,7 @@ func (x *mqlUsers) list() ([]interface{}, error) {
 	// any subsequent calls are locked until user detection finishes; at this point
 	// we only need to return a non-nil error field and it will pull the data from cache
 	if x.usersByID != nil {
-		return nil, nil
+		return nil, errors.New("no users found")
 	}
 
 	conn := x.MqlRuntime.Connection.(shared.Connection)


### PR DESCRIPTION
This is a different approach for managing the os users. Instead of caching and locking things, we can just use MQL and it's init functions. That still means we are going to be looping over the whole list of users instead of using a map in some cases. However, the code is simple and it matches what we do with resources in other providers.

Will need further testing to confirm it works correctly