### PR TITLE
✨ support setting annotations on run/shell commands

### DIFF
--- a/apps/cnquery/cmd/run.go
+++ b/apps/cnquery/cmd/run.go
@@ -30,6 +30,8 @@ func init() {
 	RunCmd.Flags().MarkHidden("llx")
 	RunCmd.Flags().String("use-llx", "", "Run the code specified in the code bundle on disk")
 	RunCmd.Flags().MarkHidden("use-llx")
+	RunCmd.Flags().StringToString("annotations", nil, "Specify annotations for this run")
+	RunCmd.Flags().MarkHidden("annotations")
 }
 
 var RunCmd = &cobra.Command{
@@ -37,7 +39,8 @@ var RunCmd = &cobra.Command{
 	Short: "Run an MQL query",
 	Long:  `Run an MQL query on the CLI and displays its results.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
-		viper.BindPFlag("platform-id", cmd.Flags().Lookup("platform-id"))
+		_ = viper.BindPFlag("platform-id", cmd.Flags().Lookup("platform-id"))
+		_ = viper.BindPFlag("annotations", cmd.Flags().Lookup("annotations"))
 	},
 	// we have to initialize an empty run so it shows up as a runnable command in --help
 	Run: func(cmd *cobra.Command, args []string) {},
@@ -60,7 +63,11 @@ var RunCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *plu
 	if llx, _ := cmd.Flags().GetString("use-llx"); llx != "" {
 		conf.Input = llx
 	}
+
 	conf.PlatformId, _ = cmd.Flags().GetString("platform-id")
+	annotations, _ := cmd.Flags().GetStringToString("annotations")
+	cliRes.Asset.AddAnnotations(annotations)
+
 	in := &inventory.Inventory{
 		Spec: &inventory.InventorySpec{
 			Assets: []*inventory.Asset{cliRes.Asset},

--- a/apps/cnquery/cmd/run.go
+++ b/apps/cnquery/cmd/run.go
@@ -29,9 +29,9 @@ func init() {
 	RunCmd.Flags().String("llx", "", "Generate the executable code bundle and save it to the specified file.")
 	RunCmd.Flags().MarkHidden("llx")
 	RunCmd.Flags().String("use-llx", "", "Run the code specified in the code bundle on disk")
-	RunCmd.Flags().MarkHidden("use-llx")
+	_ = RunCmd.Flags().MarkHidden("use-llx")
 	RunCmd.Flags().StringToString("annotations", nil, "Specify annotations for this run")
-	RunCmd.Flags().MarkHidden("annotations")
+	_ = RunCmd.Flags().MarkHidden("annotations")
 }
 
 var RunCmd = &cobra.Command{

--- a/apps/cnquery/cmd/shell.go
+++ b/apps/cnquery/cmd/shell.go
@@ -30,7 +30,7 @@ func init() {
 	shellCmd.Flags().StringP("command", "c", "", "MQL query to executed in the shell.")
 	shellCmd.Flags().String("platform-id", "", "Select a specific target asset by providing its platform ID.")
 	shellCmd.Flags().StringToString("annotations", nil, "Specify annotations for this run")
-	shellCmd.Flags().MarkHidden("annotations")
+	_ = shellCmd.Flags().MarkHidden("annotations")
 }
 
 var shellCmd = &cobra.Command{

--- a/apps/cnquery/cmd/shell.go
+++ b/apps/cnquery/cmd/shell.go
@@ -29,6 +29,8 @@ func init() {
 
 	shellCmd.Flags().StringP("command", "c", "", "MQL query to executed in the shell.")
 	shellCmd.Flags().String("platform-id", "", "Select a specific target asset by providing its platform ID.")
+	shellCmd.Flags().StringToString("annotations", nil, "Specify annotations for this run")
+	shellCmd.Flags().MarkHidden("annotations")
 }
 
 var shellCmd = &cobra.Command{
@@ -36,7 +38,8 @@ var shellCmd = &cobra.Command{
 	Short: "Interactive query shell for MQL",
 	Long:  `Allows the interactive exploration of MQL queries`,
 	PreRun: func(cmd *cobra.Command, args []string) {
-		viper.BindPFlag("platform-id", cmd.Flags().Lookup("platform-id"))
+		_ = viper.BindPFlag("platform-id", cmd.Flags().Lookup("platform-id"))
+		_ = viper.BindPFlag("annotations", cmd.Flags().Lookup("annotations"))
 	},
 	// we have to initialize an empty run so it shows up as a runnable command in --help
 	Run: func(cmd *cobra.Command, args []string) {},
@@ -81,6 +84,9 @@ func ParseShellConfig(cmd *cobra.Command, cliRes *plugin.ParseCLIRes) *ShellConf
 			Creds:       conf.GetServiceCredential(),
 		}
 	}
+
+	annotations, _ := cmd.Flags().GetStringToString("annotations")
+	cliRes.Asset.AddAnnotations(annotations)
 
 	shellConf := ShellConfig{
 		Features:       config.Features,

--- a/providers-sdk/v1/inventory/asset.go
+++ b/providers-sdk/v1/inventory/asset.go
@@ -68,11 +68,14 @@ func (a *Asset) AddLabels(labels map[string]string) {
 }
 
 func (a *Asset) AddAnnotations(annotations map[string]string) {
+	if len(annotations) == 0 {
+		return
+	}
+
 	if a.Annotations == nil {
 		a.Annotations = map[string]string{}
 	}
 
-	// copy annotations
 	for k := range annotations {
 		a.Annotations[k] = annotations[k]
 	}

--- a/providers-sdk/v1/inventory/asset_test.go
+++ b/providers-sdk/v1/inventory/asset_test.go
@@ -43,7 +43,7 @@ func TestAddAnnotations(t *testing.T) {
 			},
 		}
 		asset.AddAnnotations(map[string]string{})
-		assert.Equal(t, map[string]string{}, asset.Annotations)
+		assert.Equal(t, nil, asset.Annotations)
 	})
 
 	t.Run("test nil", func(t *testing.T) {
@@ -53,7 +53,7 @@ func TestAddAnnotations(t *testing.T) {
 			},
 		}
 		asset.AddAnnotations(nil)
-		assert.Equal(t, map[string]string{}, asset.Annotations)
+		assert.Equal(t, nil, asset.Annotations)
 	})
 
 	t.Run("test merge", func(t *testing.T) {

--- a/providers-sdk/v1/inventory/asset_test.go
+++ b/providers-sdk/v1/inventory/asset_test.go
@@ -43,7 +43,7 @@ func TestAddAnnotations(t *testing.T) {
 			},
 		}
 		asset.AddAnnotations(map[string]string{})
-		assert.Equal(t, nil, asset.Annotations)
+		assert.Equal(t, map[string]string(nil), asset.Annotations)
 	})
 
 	t.Run("test nil", func(t *testing.T) {
@@ -53,7 +53,7 @@ func TestAddAnnotations(t *testing.T) {
 			},
 		}
 		asset.AddAnnotations(nil)
-		assert.Equal(t, nil, asset.Annotations)
+		assert.Equal(t, map[string]string(nil), asset.Annotations)
 	})
 
 	t.Run("test merge", func(t *testing.T) {


### PR DESCRIPTION
great for debugging, otherwise hidden to avoid distractions use via:

```bash
cnquery shell --annotations priority=high
```

Now you can

```
> asset.annotations
asset.annotations: {
  priority: "high"
}
```

(requires ^ https://github.com/mondoohq/cnquery/pull/3625)