### PR TITLE
🐛 fix docker image scan for remote images

### DIFF
--- a/providers/os/connection/container/image_connection.go
+++ b/providers/os/connection/container/image_connection.go
@@ -6,6 +6,7 @@ package container
 import (
 	"errors"
 	"os"
+	"slices"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -95,7 +96,9 @@ func NewRegistryImage(id uint32, conf *inventory.Config, asset *inventory.Asset)
 	if len(asset.PlatformIds) == 0 {
 		asset.PlatformIds = []string{identifier}
 	} else {
-		asset.PlatformIds = append(asset.PlatformIds, identifier)
+		if !slices.Contains(asset.PlatformIds, identifier) {
+			asset.PlatformIds = append(asset.PlatformIds, identifier)
+		}
 	}
 
 	// set the platform architecture using the image configuration

--- a/providers/os/connection/docker/container_connection.go
+++ b/providers/os/connection/docker/container_connection.go
@@ -237,6 +237,15 @@ func NewContainerImageConnection(id uint32, conf *inventory.Config, asset *inven
 			return nil, err
 		}
 	}
+	if conf.Options == nil {
+		conf.Options = map[string]string{}
+	}
+	// FIXME: DEPRECATED, remove in v12.0 vv
+	// The DelayDiscovery flag should always be set from v12
+	if conf.Options == nil || conf.Options[plugin.DISABLE_DELAYED_DISCOVERY_OPTION] == "" {
+		conf.DelayDiscovery = true // Delay discovery, to make sure we don't directly download the image
+	}
+	// ^^
 	// Determine whether the image is locally present or not.
 	resolver := dockerDiscovery.Resolver{}
 	resolvedAssets, err := resolver.Resolve(context.Background(), asset, conf, nil)
@@ -297,16 +306,7 @@ func NewContainerImageConnection(id uint32, conf *inventory.Config, asset *inven
 	}
 	filename = tmpFile.Name()
 
-	if conf.Options == nil {
-		conf.Options = map[string]string{}
-	}
 	conf.Options[tar.OPTION_FILE] = filename
-	// FIXME: DEPRECATED, remove in v12.0 vv
-	// The DelayDiscovery flag should always be set from v12
-	if conf.Options == nil || conf.Options[plugin.DISABLE_DELAYED_DISCOVERY_OPTION] == "" {
-		conf.DelayDiscovery = true // Delay discovery, to make sure we don't directly download the image
-	}
-	// ^^
 
 	tarConn, err := tar.NewConnection(
 		id,


### PR DESCRIPTION
makes sure we can scan docker images that aren't present locally