### PR TITLE
 🧹 Reduce the number of times we try to get platform ident

### DIFF
--- a/providers-sdk/v1/sysinfo/sysinfo.go
+++ b/providers-sdk/v1/sysinfo/sysinfo.go
@@ -4,15 +4,12 @@
 package sysinfo
 
 import (
-	"errors"
-
 	"github.com/rs/zerolog/log"
 
 	"go.mondoo.com/cnquery/v11"
 	"go.mondoo.com/cnquery/v11/cli/execruntime"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v11/providers/os/connection/local"
-	"go.mondoo.com/cnquery/v11/providers/os/detector"
 	"go.mondoo.com/cnquery/v11/providers/os/id"
 	"go.mondoo.com/cnquery/v11/providers/os/id/hostname"
 	"go.mondoo.com/cnquery/v11/providers/os/resources/networkinterface"
@@ -47,18 +44,14 @@ func Get() (*SystemInfo, error) {
 		Type: "local",
 	}, &asset)
 
-	fingerprint, err := id.IdentifyPlatform(conn, asset.Platform, asset.IdDetector)
+	fingerprint, platform, err := id.IdentifyPlatform(conn, asset.Platform, asset.IdDetector)
 	if err == nil {
 		if len(fingerprint.PlatformIDs) > 0 {
 			sysInfo.PlatformId = fingerprint.PlatformIDs[0]
 		}
 	}
 
-	var ok bool
-	sysInfo.Platform, ok = detector.DetectOS(conn)
-	if !ok {
-		return nil, errors.New("failed to detect the OS")
-	}
+	sysInfo.Platform = platform
 
 	sysInfo.Hostname, _ = hostname.Hostname(conn, sysInfo.Platform)
 

--- a/providers/os/id/platform.go
+++ b/providers/os/id/platform.go
@@ -35,12 +35,12 @@ type PlatformInfo struct {
 	RelatedPlatformIDs []string
 }
 
-func IdentifyPlatform(conn shared.Connection, p *inventory.Platform, idDetectors []string) (*PlatformFingerprint, error) {
+func IdentifyPlatform(conn shared.Connection, p *inventory.Platform, idDetectors []string) (*PlatformFingerprint, *inventory.Platform, error) {
 	var ok bool
 	if p == nil {
 		p, ok = detector.DetectOS(conn)
 		if !ok {
-			return nil, errors.New("cannot detect os")
+			return nil, nil, errors.New("cannot detect os")
 		}
 	}
 
@@ -99,7 +99,7 @@ func IdentifyPlatform(conn shared.Connection, p *inventory.Platform, idDetectors
 
 	// if we found zero platform ids something went wrong
 	if len(platformIds) == 0 {
-		return nil, errors.New("could not determine a platform identifier")
+		return nil, nil, errors.New("could not determine a platform identifier")
 	}
 
 	fingerprint.PlatformIDs = platformIds
@@ -111,7 +111,7 @@ func IdentifyPlatform(conn shared.Connection, p *inventory.Platform, idDetectors
 	}
 
 	log.Debug().Interface("id-detector", idDetectors).Strs("platform-ids", platformIds).Msg("detected platform ids")
-	return &fingerprint, nil
+	return &fingerprint, p, nil
 }
 
 func GatherNameForPlatformId(id string) string {

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -312,11 +312,13 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 		case shared.Type_Local.String():
 			conn = local.NewConnection(connId, conf, asset)
 
-			fingerprint, err := id.IdentifyPlatform(conn, asset.Platform, asset.IdDetector)
+			fingerprint, p, err := id.IdentifyPlatform(conn, asset.Platform, asset.IdDetector)
 			if err == nil {
 				asset.Name = fingerprint.Name
 				asset.PlatformIds = fingerprint.PlatformIDs
 				asset.IdDetector = fingerprint.ActiveIdDetectors
+				asset.Platform = p
+				appendRelatedAssetsFromFingerprint(fingerprint, asset)
 			}
 
 		case shared.Type_SSH.String():
@@ -325,13 +327,15 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 				return nil, err
 			}
 
-			fingerprint, err := id.IdentifyPlatform(conn, asset.Platform, asset.IdDetector)
+			fingerprint, p, err := id.IdentifyPlatform(conn, asset.Platform, asset.IdDetector)
 			if err == nil {
 				if conn.Asset().Connections[0].Runtime != "vagrant" {
 					asset.Name = fingerprint.Name
 				}
 				asset.PlatformIds = fingerprint.PlatformIDs
 				asset.IdDetector = fingerprint.ActiveIdDetectors
+				asset.Platform = p
+				appendRelatedAssetsFromFingerprint(fingerprint, asset)
 			}
 
 		case shared.Type_Winrm.String():
@@ -340,11 +344,13 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 				return nil, err
 			}
 
-			fingerprint, err := id.IdentifyPlatform(conn, asset.Platform, asset.IdDetector)
+			fingerprint, p, err := id.IdentifyPlatform(conn, asset.Platform, asset.IdDetector)
 			if err == nil {
 				asset.Name = fingerprint.Name
 				asset.PlatformIds = fingerprint.PlatformIDs
 				asset.IdDetector = fingerprint.ActiveIdDetectors
+				asset.Platform = p
+				appendRelatedAssetsFromFingerprint(fingerprint, asset)
 			}
 
 		case shared.Type_Tar.String():
@@ -353,11 +359,13 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 				return nil, err
 			}
 
-			fingerprint, err := id.IdentifyPlatform(conn, asset.Platform, asset.IdDetector)
+			fingerprint, p, err := id.IdentifyPlatform(conn, asset.Platform, asset.IdDetector)
 			if err == nil {
 				asset.Name = fingerprint.Name
 				asset.PlatformIds = fingerprint.PlatformIDs
 				asset.IdDetector = fingerprint.ActiveIdDetectors
+				asset.Platform = p
+				appendRelatedAssetsFromFingerprint(fingerprint, asset)
 			}
 
 		case shared.Type_DockerSnapshot.String():
@@ -366,11 +374,13 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 				return nil, err
 			}
 
-			fingerprint, err := id.IdentifyPlatform(conn, asset.Platform, asset.IdDetector)
+			fingerprint, p, err := id.IdentifyPlatform(conn, asset.Platform, asset.IdDetector)
 			if err == nil {
 				asset.Name = fingerprint.Name
 				asset.PlatformIds = fingerprint.PlatformIDs
 				asset.IdDetector = fingerprint.ActiveIdDetectors
+				asset.Platform = p
+				appendRelatedAssetsFromFingerprint(fingerprint, asset)
 			}
 
 		case shared.Type_Vagrant.String():
@@ -408,11 +418,12 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 			// This is a workaround to set Google COS platform IDs when scanned from inside k8s
 			pID, err := conn.(*fs.FileSystemConnection).Identifier()
 			if err != nil {
-				fingerprint, err := id.IdentifyPlatform(conn, asset.Platform, asset.IdDetector)
+				fingerprint, p, err := id.IdentifyPlatform(conn, asset.Platform, asset.IdDetector)
 				if err == nil {
 					asset.Name = fingerprint.Name
 					asset.PlatformIds = fingerprint.PlatformIDs
 					asset.IdDetector = fingerprint.ActiveIdDetectors
+					asset.Platform = p
 				}
 			} else {
 				// In this case asset.Name should already be set via the inventory

--- a/providers/os/provider/provider_test.go
+++ b/providers/os/provider/provider_test.go
@@ -39,10 +39,8 @@ func TestLocalConnectionIdDetectors(t *testing.T) {
 	require.Contains(t, connectResp.Asset.IdDetector, ids.IdDetector_Hostname)
 	require.Contains(t, connectResp.Asset.IdDetector, ids.IdDetector_CloudDetect)
 	require.NotContains(t, connectResp.Asset.IdDetector, ids.IdDetector_SshHostkey)
-	// here we have the hostname twice, as platformid and stand alone
-	// This get's cleaned up later in the code
-	// FIXME: this should only be 1
-	require.Len(t, connectResp.Asset.PlatformIds, 2)
+
+	require.Len(t, connectResp.Asset.PlatformIds, 1)
 
 	shutdownconnectResp, err := srv.Shutdown(&plugin.ShutdownReq{})
 	require.NoError(t, err)
@@ -92,7 +90,7 @@ func TestLocalConnectionIdDetectors_DelayedDiscovery(t *testing.T) {
 	require.Contains(t, connectResp.Asset.IdDetector, ids.IdDetector_CloudDetect)
 	require.NotContains(t, connectResp.Asset.IdDetector, ids.IdDetector_SshHostkey)
 	require.Len(t, connectResp.Asset.PlatformIds, 1)
-	require.Nil(t, connectResp.Asset.Platform)
+	require.Nil(t, connectResp.Asset.Platform) // Why does this need to be nil
 
 	// Disable delayed discovery and reconnect
 	connectResp.Asset.Connections[0].DelayDiscovery = false
@@ -106,8 +104,8 @@ func TestLocalConnectionIdDetectors_DelayedDiscovery(t *testing.T) {
 	require.Contains(t, connectResp.Asset.IdDetector, ids.IdDetector_Hostname)
 	require.Contains(t, connectResp.Asset.IdDetector, ids.IdDetector_CloudDetect)
 	require.NotContains(t, connectResp.Asset.IdDetector, ids.IdDetector_SshHostkey)
-	// Now the platformIDs are cleaned up
-	require.Len(t, connectResp.Asset.PlatformIds, 2)
+
+	require.Len(t, connectResp.Asset.PlatformIds, 1)
 	// Verify the platform is set
 	require.NotNil(t, connectResp.Asset.Platform)
 

--- a/providers/os/provider/provider_test.go
+++ b/providers/os/provider/provider_test.go
@@ -76,7 +76,8 @@ func TestLocalConnectionIdDetectors_DelayedDiscovery(t *testing.T) {
 		Asset: &inventory.Asset{
 			Connections: []*inventory.Config{
 				{
-					Type:           "local",
+					Type:           "docker-image",
+					Host:           "alpine:3.19",
 					DelayDiscovery: true,
 				},
 			},
@@ -85,12 +86,9 @@ func TestLocalConnectionIdDetectors_DelayedDiscovery(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, connectResp)
 
-	require.Len(t, connectResp.Asset.IdDetector, 2)
-	require.Contains(t, connectResp.Asset.IdDetector, ids.IdDetector_Hostname)
-	require.Contains(t, connectResp.Asset.IdDetector, ids.IdDetector_CloudDetect)
-	require.NotContains(t, connectResp.Asset.IdDetector, ids.IdDetector_SshHostkey)
-	require.Len(t, connectResp.Asset.PlatformIds, 1)
-	require.Nil(t, connectResp.Asset.Platform) // Why does this need to be nil
+	require.Len(t, connectResp.Asset.IdDetector, 0)
+	require.Len(t, connectResp.Asset.PlatformIds, 2)
+	require.Nil(t, connectResp.Asset.Platform)
 
 	// Disable delayed discovery and reconnect
 	connectResp.Asset.Connections[0].DelayDiscovery = false
@@ -100,12 +98,7 @@ func TestLocalConnectionIdDetectors_DelayedDiscovery(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, connectResp)
 
-	require.Len(t, connectResp.Asset.IdDetector, 2)
-	require.Contains(t, connectResp.Asset.IdDetector, ids.IdDetector_Hostname)
-	require.Contains(t, connectResp.Asset.IdDetector, ids.IdDetector_CloudDetect)
-	require.NotContains(t, connectResp.Asset.IdDetector, ids.IdDetector_SshHostkey)
-
-	require.Len(t, connectResp.Asset.PlatformIds, 1)
+	require.Len(t, connectResp.Asset.PlatformIds, 2)
 	// Verify the platform is set
 	require.NotNil(t, connectResp.Asset.Platform)
 


### PR DESCRIPTION
 We were getting platform identity information multiple times. We would
 connect, then see the asset's platform not set, and redo it.