### PR TITLE
Add new fields to aws.autoscaling.group

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1031,7 +1031,7 @@ aws.autoscaling @defaults("groups") {
 }
 
 // AWS Auto Scaling group
-private aws.autoscaling.group @defaults("name region") {
+private aws.autoscaling.group @defaults("name region minSize maxSize") {
   // ARN for the autoscaling group
   arn string
   // Name of the group
@@ -1062,6 +1062,12 @@ private aws.autoscaling.group @defaults("name region") {
   desiredCapacity int
   // List of availability zones associated with the group
   availabilityZones []string
+  // Indicates whether Capacity Rebalancing is enabled
+  capacityRebalance bool
+  // The duration of the default instance warmup, in seconds
+  defaultInstanceWarmup int
+  // The EC2 instances associated with the group
+  instances []aws.ec2.instance
 }
 
 // AWS Elastic Load Balancing

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1060,6 +1060,8 @@ private aws.autoscaling.group @defaults("name region") {
   maxInstanceLifetime int
   // The desired size of the group
   desiredCapacity int
+  // List of availability zones associated with the group
+  availabilityZones []string
 }
 
 // AWS Elastic Load Balancing

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -1862,6 +1862,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.autoscaling.group.desiredCapacity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsAutoscalingGroup).GetDesiredCapacity()).ToDataRes(types.Int)
 	},
+	"aws.autoscaling.group.availabilityZones": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsAutoscalingGroup).GetAvailabilityZones()).ToDataRes(types.Array(types.String))
+	},
 	"aws.elb.classicLoadBalancers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElb).GetClassicLoadBalancers()).ToDataRes(types.Array(types.Resource("aws.elb.loadbalancer")))
 	},
@@ -2298,7 +2301,7 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlAwsCloudfrontDistribution).GetPriceClass()).ToDataRes(types.String)
 	},
 	"aws.cloudfront.distribution.cnames": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsCloudfrontDistribution).GetCnames()).ToDataRes(types.Array(types.Dict))
+		return (r.(*mqlAwsCloudfrontDistribution).GetCnames()).ToDataRes(types.Array(types.String))
 	},
 	"aws.cloudfront.distribution.origin.domainName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudfrontDistributionOrigin).GetDomainName()).ToDataRes(types.String)
@@ -5509,6 +5512,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.autoscaling.group.desiredCapacity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsAutoscalingGroup).DesiredCapacity, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.autoscaling.group.availabilityZones": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsAutoscalingGroup).AvailabilityZones, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
 	"aws.elb.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -13738,6 +13745,7 @@ type mqlAwsAutoscalingGroup struct {
 	CreatedAt plugin.TValue[*time.Time]
 	MaxInstanceLifetime plugin.TValue[int64]
 	DesiredCapacity plugin.TValue[int64]
+	AvailabilityZones plugin.TValue[[]interface{}]
 }
 
 // createAwsAutoscalingGroup creates a new instance of this resource
@@ -13831,6 +13839,10 @@ func (c *mqlAwsAutoscalingGroup) GetMaxInstanceLifetime() *plugin.TValue[int64] 
 
 func (c *mqlAwsAutoscalingGroup) GetDesiredCapacity() *plugin.TValue[int64] {
 	return &c.DesiredCapacity
+}
+
+func (c *mqlAwsAutoscalingGroup) GetAvailabilityZones() *plugin.TValue[[]interface{}] {
+	return &c.AvailabilityZones
 }
 
 // mqlAwsElb for the aws.elb resource

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -1865,6 +1865,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.autoscaling.group.availabilityZones": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsAutoscalingGroup).GetAvailabilityZones()).ToDataRes(types.Array(types.String))
 	},
+	"aws.autoscaling.group.capacityRebalance": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsAutoscalingGroup).GetCapacityRebalance()).ToDataRes(types.Bool)
+	},
+	"aws.autoscaling.group.defaultInstanceWarmup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsAutoscalingGroup).GetDefaultInstanceWarmup()).ToDataRes(types.Int)
+	},
+	"aws.autoscaling.group.instances": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsAutoscalingGroup).GetInstances()).ToDataRes(types.Array(types.Resource("aws.ec2.instance")))
+	},
 	"aws.elb.classicLoadBalancers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElb).GetClassicLoadBalancers()).ToDataRes(types.Array(types.Resource("aws.elb.loadbalancer")))
 	},
@@ -5516,6 +5525,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.autoscaling.group.availabilityZones": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsAutoscalingGroup).AvailabilityZones, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.autoscaling.group.capacityRebalance": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsAutoscalingGroup).CapacityRebalance, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.autoscaling.group.defaultInstanceWarmup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsAutoscalingGroup).DefaultInstanceWarmup, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.autoscaling.group.instances": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsAutoscalingGroup).Instances, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
 	"aws.elb.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -13746,6 +13767,9 @@ type mqlAwsAutoscalingGroup struct {
 	MaxInstanceLifetime plugin.TValue[int64]
 	DesiredCapacity plugin.TValue[int64]
 	AvailabilityZones plugin.TValue[[]interface{}]
+	CapacityRebalance plugin.TValue[bool]
+	DefaultInstanceWarmup plugin.TValue[int64]
+	Instances plugin.TValue[[]interface{}]
 }
 
 // createAwsAutoscalingGroup creates a new instance of this resource
@@ -13843,6 +13867,18 @@ func (c *mqlAwsAutoscalingGroup) GetDesiredCapacity() *plugin.TValue[int64] {
 
 func (c *mqlAwsAutoscalingGroup) GetAvailabilityZones() *plugin.TValue[[]interface{}] {
 	return &c.AvailabilityZones
+}
+
+func (c *mqlAwsAutoscalingGroup) GetCapacityRebalance() *plugin.TValue[bool] {
+	return &c.CapacityRebalance
+}
+
+func (c *mqlAwsAutoscalingGroup) GetDefaultInstanceWarmup() *plugin.TValue[int64] {
+	return &c.DefaultInstanceWarmup
+}
+
+func (c *mqlAwsAutoscalingGroup) GetInstances() *plugin.TValue[[]interface{}] {
+	return &c.Instances
 }
 
 // mqlAwsElb for the aws.elb resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -303,6 +303,8 @@ resources:
         The `aws.autoscaling.group` resource provides fields representing an individual AWS auto scaling group within the account. For usage, read the `aws.autoscaling` resource documentation.
     fields:
       arn: {}
+      availabilityZones:
+        min_mondoo_version: 9.0.0
       createdAt:
         min_mondoo_version: 9.0.0
       defaultCooldown:

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -305,15 +305,21 @@ resources:
       arn: {}
       availabilityZones:
         min_mondoo_version: 9.0.0
+      capacityRebalance:
+        min_mondoo_version: 9.0.0
       createdAt:
         min_mondoo_version: 9.0.0
       defaultCooldown:
+        min_mondoo_version: 9.0.0
+      defaultInstanceWarmup:
         min_mondoo_version: 9.0.0
       desiredCapacity:
         min_mondoo_version: 9.0.0
       healthCheckGracePeriod:
         min_mondoo_version: 9.0.0
       healthCheckType: {}
+      instances:
+        min_mondoo_version: 9.0.0
       launchConfigurationName:
         min_mondoo_version: 9.0.0
       loadBalancerNames: {}

--- a/providers/aws/resources/aws_autoscaling.go
+++ b/providers/aws/resources/aws_autoscaling.go
@@ -74,9 +74,14 @@ func (a *mqlAwsAutoscaling) getGroups(conn *connection.AwsConnection) []*jobpool
 					for _, name := range group.LoadBalancerNames {
 						lbNames = append(lbNames, name)
 					}
+					availabilityZones := []interface{}{}
+					for _, zone := range group.AvailabilityZones {
+						availabilityZones = append(availabilityZones, zone)
+					}
 					mqlGroup, err := CreateResource(a.MqlRuntime, "aws.autoscaling.group",
 						map[string]*llx.RawData{
 							"arn":                     llx.StringDataPtr(group.AutoScalingGroupARN),
+							"availabilityZones":       llx.ArrayData(availabilityZones, types.String),
 							"createdAt":               llx.TimeDataPtr(group.CreatedTime),
 							"defaultCooldown":         llx.IntDataDefault(group.DefaultCooldown, 0),
 							"desiredCapacity":         llx.IntDataDefault(group.DesiredCapacity, 0),

--- a/providers/aws/resources/aws_autoscaling.go
+++ b/providers/aws/resources/aws_autoscaling.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
@@ -78,15 +79,30 @@ func (a *mqlAwsAutoscaling) getGroups(conn *connection.AwsConnection) []*jobpool
 					for _, zone := range group.AvailabilityZones {
 						availabilityZones = append(availabilityZones, zone)
 					}
+					groupInstances := []interface{}{}
+					for _, instance := range group.Instances {
+						mqlInstance, err := NewResource(a.MqlRuntime, "aws.ec2.instance",
+							map[string]*llx.RawData{
+								"arn": llx.StringData(fmt.Sprintf(ec2InstanceArnPattern, regionVal, conn.AccountId(), convert.ToString(instance.InstanceId))),
+							})
+						if err != nil {
+							return nil, err
+						}
+						groupInstances = append(groupInstances, mqlInstance)
+					}
+
 					mqlGroup, err := CreateResource(a.MqlRuntime, "aws.autoscaling.group",
 						map[string]*llx.RawData{
 							"arn":                     llx.StringDataPtr(group.AutoScalingGroupARN),
 							"availabilityZones":       llx.ArrayData(availabilityZones, types.String),
+							"capacityRebalance":       llx.BoolDataPtr(group.CapacityRebalance),
 							"createdAt":               llx.TimeDataPtr(group.CreatedTime),
 							"defaultCooldown":         llx.IntDataDefault(group.DefaultCooldown, 0),
+							"defaultInstanceWarmup":   llx.IntDataDefault(group.DefaultInstanceWarmup, 0),
 							"desiredCapacity":         llx.IntDataDefault(group.DesiredCapacity, 0),
 							"healthCheckGracePeriod":  llx.IntDataDefault(group.HealthCheckGracePeriod, 0),
 							"healthCheckType":         llx.StringDataPtr(group.HealthCheckType),
+							"instances":               llx.ArrayData(groupInstances, types.Resource("aws.ec2.instance")),
 							"launchConfigurationName": llx.StringDataPtr(group.LaunchConfigurationName),
 							"loadBalancerNames":       llx.ArrayData(lbNames, types.String),
 							"maxInstanceLifetime":     llx.IntDataDefault(group.MaxInstanceLifetime, 0),


### PR DESCRIPTION
Add new fields for checking on autoscaling groups.
- Add min/max to the defaults
- Add instances
- Add capacityRebalance
- Add defaultInstanceWarmup

The core bit of value here is the instances. We're going to need these to go from EKS cluster -> EKS nodegroup -> Nodes. EKS node groups use autoscaling groups so with this we can get cluster nodes now:

```
cnquery> aws.autoscaling.groups[15]{*}
aws.autoscaling.groups[15]: {
  instances: [
    0: aws.ec2.instance instanceId="i-12345" region="us-west-2" state="running" instanceType="t3.nano" architecture="x86_64" platformDetails="Linux/UNIX"
  ]
  desiredCapacity: 1
  capacityRebalance: true
  availabilityZones: [
    0: "us-west-2a"
    1: "us-west-2b"
    2: "us-west-2c"
    3: "us-west-2d"
  ]
  tags: {
    eks:cluster-name: "tim_test"
    eks:nodegroup-name: "high_cpu"
    k8s.io/cluster-autoscaler/enabled: "true"
    k8s.io/cluster-autoscaler/tim_test: "owned"
    kubernetes.io/cluster/tim_test: "owned"
  }
  loadBalancerNames: []
  createdAt: 2024-03-29 10:49:34.821 -0700 PDT
  healthCheckType: "EC2"
  maxInstanceLifetime: 0
  defaultInstanceWarmup: 0
  launchConfigurationName: null
  healthCheckGracePeriod: 15
  defaultCooldown: 300
  maxSize: 1
  name: "eks-high_cpu-b6c745aa-49c7-bc5c-67f0-12345"
  region: "us-west-2"
  arn: "arn:aws:autoscaling:us-west-2:12345:autoScalingGroup:5d3e8910-148c-4867-a73a-12345:autoScalingGroupName/eks-high_cpu-b6c745aa-49c7-bc5c-67f0-12345"
  minSize: 1
}
```