### PR TITLE
🐛 Fix docker/container registry scanning. Clean the container code a bit

### DIFF
--- a/providers/os/connection/container/auth/auth.go
+++ b/providers/os/connection/container/auth/auth.go
@@ -4,36 +4,39 @@
 package auth
 
 import (
+	"strings"
+
+	"github.com/awslabs/amazon-ecr-credential-helper/ecr-login"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/rs/zerolog/log"
-	"go.mondoo.com/cnquery/v10/logger"
-	"go.mondoo.com/cnquery/v10/providers-sdk/v1/vault"
-	"go.mondoo.com/cnquery/v10/providers/os/connection/container/image"
+	"go.mondoo.com/cnquery/v10/providers/os/connection/container/acr"
 )
 
-func AuthOption(credentials []*vault.Credential) []image.Option {
-	remoteOpts := []image.Option{}
-	for i := range credentials {
-		cred := credentials[i]
-		switch cred.Type {
-		case vault.CredentialType_password:
-			log.Debug().Msg("add password authentication")
-			cfg := authn.AuthConfig{
-				Username: cred.User,
-				Password: string(cred.Secret),
-			}
-			remoteOpts = append(remoteOpts, image.WithAuthenticator((authn.FromConfig(cfg))))
-		case vault.CredentialType_bearer:
-			log.Debug().Str("token", string(cred.Secret)).Msg("add bearer authentication")
-			cfg := authn.AuthConfig{
-				Username:      cred.User,
-				RegistryToken: string(cred.Secret),
-			}
-			remoteOpts = append(remoteOpts, image.WithAuthenticator((authn.FromConfig(cfg))))
-		default:
-			log.Warn().Msg("unknown credentials for container image")
-			logger.DebugJSON(credentials)
+const (
+	acrIndicator = ".azurecr.io"
+	ecrIndicator = ".ecr."
+)
+
+func getKeychains(name string) []authn.Keychain {
+	kcs := []authn.Keychain{
+		authn.DefaultKeychain,
+	}
+	if strings.Contains(name, ecrIndicator) {
+		kcs = append(kcs, authn.NewKeychainFromHelper(ecr.NewECRHelper()))
+	}
+	if strings.Contains(name, acrIndicator) {
+		acr, err := acr.NewAcrAuthHelper()
+		if err == nil {
+			kcs = append(kcs, authn.NewKeychainFromHelper(acr))
+		} else {
+			log.Debug().Err(err).Msg("failed to create ACR auth helper")
 		}
 	}
-	return remoteOpts
+	return kcs
+}
+
+// ConstructKeychain creates a keychain for the given registry name
+// It will add the default docker keychain and additional keychains for ECR and ACR, if those are determined to be used
+func ConstructKeychain(name string) authn.Keychain {
+	return authn.NewMultiKeychain(getKeychains(name)...)
 }

--- a/providers/os/connection/container/auth/auth_test.go
+++ b/providers/os/connection/container/auth/auth_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConstructKeychain(t *testing.T) {
+	t.Run("default keychain only", func(t *testing.T) {
+		keychain := getKeychains("test")
+		require.Equal(t, 1, len(keychain))
+	})
+	t.Run("default keychain and ecr keychain", func(t *testing.T) {
+		keychain := getKeychains("0000000000.dkr.ecr.us-east-1.amazonaws.com/test")
+		require.Equal(t, 2, len(keychain))
+	})
+
+	t.Run("default keychain and acr keychain", func(t *testing.T) {
+		keychain := getKeychains("test.azurecr.io")
+		require.Equal(t, 2, len(keychain))
+	})
+}

--- a/providers/os/connection/container/image_connection.go
+++ b/providers/os/connection/container/image_connection.go
@@ -15,7 +15,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/plugin"
-	"go.mondoo.com/cnquery/v10/providers/os/connection/container/auth"
 	"go.mondoo.com/cnquery/v10/providers/os/connection/container/image"
 	"go.mondoo.com/cnquery/v10/providers/os/connection/tar"
 	"go.mondoo.com/cnquery/v10/providers/os/id/containerid"
@@ -62,7 +61,7 @@ func NewRegistryImage(id uint32, conf *inventory.Config, asset *inventory.Asset)
 	log.Debug().Str("ref", ref.Name()).Msg("found valid container registry reference")
 
 	registryOpts := []image.Option{image.WithInsecure(conf.Insecure)}
-	remoteOpts := auth.AuthOption(conf.Credentials)
+	remoteOpts := image.AuthOption(conf.Credentials)
 	registryOpts = append(registryOpts, remoteOpts...)
 
 	img, err := image.LoadImageFromRegistry(ref, registryOpts...)

--- a/providers/os/connection/container/registry_connection.go
+++ b/providers/os/connection/container/registry_connection.go
@@ -1,0 +1,84 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package container
+
+import (
+	"errors"
+
+	"github.com/spf13/afero"
+	"go.mondoo.com/cnquery/v10/providers-sdk/v1/inventory"
+	"go.mondoo.com/cnquery/v10/providers-sdk/v1/plugin"
+	"go.mondoo.com/cnquery/v10/providers/os/connection/shared"
+	"go.mondoo.com/cnquery/v10/providers/os/resources/discovery/container_registry"
+)
+
+var _ shared.Connection = &RegistryConnection{}
+
+type RegistryConnection struct {
+	plugin.Connection
+	asset *inventory.Asset
+}
+
+func (r *RegistryConnection) Capabilities() shared.Capabilities {
+	return shared.Capabilities(0)
+}
+
+func (r *RegistryConnection) FileInfo(path string) (shared.FileInfoDetails, error) {
+	return shared.FileInfoDetails{}, plugin.ErrFileInfoNotImplemented
+}
+
+func (r *RegistryConnection) FileSystem() afero.Fs {
+	panic("unimplemented")
+}
+
+func (r *RegistryConnection) RunCommand(command string) (*shared.Command, error) {
+	return nil, errors.New("unimplemented")
+}
+
+func (r *RegistryConnection) Type() shared.ConnectionType {
+	return shared.Type_ContainerRegistry
+}
+
+func (r *RegistryConnection) UpdateAsset(asset *inventory.Asset) {
+	r.asset = asset
+}
+
+func NewRegistryConnection(id uint32, asset *inventory.Asset) (*RegistryConnection, error) {
+	conn := &RegistryConnection{
+		Connection: plugin.NewConnection(id, asset),
+		asset:      asset,
+	}
+
+	return conn, nil
+}
+
+func (r *RegistryConnection) Name() string {
+	return "container-registry"
+}
+
+func (r *RegistryConnection) ID() uint32 {
+	return r.Connection.ID()
+}
+
+func (r *RegistryConnection) ParentID() uint32 {
+	return r.Connection.ParentID()
+}
+
+func (r *RegistryConnection) Close() error {
+	return nil
+}
+
+func (r *RegistryConnection) Asset() *inventory.Asset {
+	return r.asset
+}
+
+func (r *RegistryConnection) DiscoverImages() (*inventory.Inventory, error) {
+	resolver := container_registry.NewContainerRegistryResolver()
+	host := r.asset.Connections[0].Host
+	assets, err := resolver.ListRegistry(host)
+	if err != nil {
+		return nil, err
+	}
+	return inventory.New(inventory.WithAssets(assets...)), nil
+}

--- a/providers/os/connection/docker/container_connection.go
+++ b/providers/os/connection/docker/container_connection.go
@@ -258,7 +258,7 @@ func NewContainerImageConnection(id uint32, conf *inventory.Config, asset *inven
 	}
 
 	// The requested image isn't locally available, but we can pull it from a remote registry.
-	if len(resolvedAssets) > 0 && resolvedAssets[0].Connections[0].Type == "container-registry" {
+	if len(resolvedAssets) > 0 && resolvedAssets[0].Connections[0].Type == string(shared.Type_RegistryImage) {
 		asset.Name = resolvedAssets[0].Name
 		asset.PlatformIds = resolvedAssets[0].PlatformIds
 		asset.Labels = resolvedAssets[0].Labels

--- a/providers/os/connection/docker/container_connection.go
+++ b/providers/os/connection/docker/container_connection.go
@@ -258,7 +258,7 @@ func NewContainerImageConnection(id uint32, conf *inventory.Config, asset *inven
 	}
 
 	// The requested image isn't locally available, but we can pull it from a remote registry.
-	if len(resolvedAssets) > 0 && resolvedAssets[0].Connections[0].Type == string(shared.Type_RegistryImage) {
+	if len(resolvedAssets) > 0 && resolvedAssets[0].Connections[0].Type == shared.Type_RegistryImage.String() {
 		asset.Name = resolvedAssets[0].Name
 		asset.PlatformIds = resolvedAssets[0].PlatformIds
 		asset.Labels = resolvedAssets[0].Labels

--- a/providers/os/resources/discovery/container_registry/registry_test.go
+++ b/providers/os/resources/discovery/container_registry/registry_test.go
@@ -49,7 +49,7 @@ func TestHarbor(t *testing.T) {
 		require.NoError(t, err, url)
 
 		// check that we resolved it correctly and we got a specific shasum
-		assert.Equal(t, "container-registry", a.Connections[0].Type)
+		assert.Equal(t, "registry-image", a.Connections[0].Type)
 		assert.True(t, strings.HasPrefix(a.Connections[0].Host, "index.docker.io/library/centos"), url)
 		assert.True(t, len(strings.Split(a.Connections[0].Host, "@")) == 2, url)
 	}

--- a/providers/os/resources/discovery/docker_engine/resolver.go
+++ b/providers/os/resources/discovery/docker_engine/resolver.go
@@ -199,7 +199,6 @@ func (k *Resolver) images(ctx context.Context, root *inventory.Asset, conf *inve
 	rr := container_registry.Resolver{
 		NoStrictValidation: true,
 	}
-	// return rr.Resolve(ctx, root, conf, credsResolver, sfn)
 	return rr.Resolve(ctx, root, conf, credsResolver)
 }
 


### PR DESCRIPTION
Fix scanning a registry, this had never worked properly as it was trying to connect to an image instead. Create a new `RegistryConnection` that can discover all images inside the registry and return those.

ECR registry:
```
~/go/bin/cnquery shell container registry 012973331918.dkr.ecr.us-east-1.amazonaws.com      
! using builtin provider for os
! using builtin provider for os
→ loaded configuration from /Users/preslavgerchev/.config/mondoo/mondoo.yml using source default
! using builtin provider for os
! using builtin provider for os
! using builtin provider for os

    Available assets                                                    
                                                                        
  > 1. 012973331918.dkr.ecr.us-east-1.amazonaws.com/preslav@e073956021b9
    2. 012973331918.dkr.ecr.us-east-1.amazonaws.com/os@64f4252c7916  
```

ACR registry:
```
~/go/bin/cnquery shell container registry testpremiumacrpreslav.azurecr.io      
! using builtin provider for os
! using builtin provider for os
→ loaded configuration from /Users/preslavgerchev/.config/mondoo/mondoo.yml using source default
! using builtin provider for os
! using builtin provider for os
! using builtin provider for os

    Available assets                                                    
                                                                        
  > 1. testpremiumacrpreslav.azurecr.io/os/debian@64f4252c7916          
    2. testpremiumacrpreslav.azurecr.io/samples/hello-world@92c7f9c92844
```

Images still work:

A single ECR image:
```
~/go/bin/cnquery shell container image 012973331918.dkr.ecr.us-east-1.amazonaws.com/os:latest
! using builtin provider for os
! using builtin provider for os
→ loaded configuration from /Users/preslavgerchev/.config/mondoo/mondoo.yml using source default
! using builtin provider for os
→ connected to Debian GNU/Linux 11 (bullseye)
  ___ _ __   __ _ _   _  ___ _ __ _   _ 
 / __| '_ \ / _` | | | |/ _ \ '__| | | |
| (__| | | | (_| | |_| |  __/ |  | |_| |
 \___|_| |_|\__, |\__,_|\___|_|   \__, |
  mondoo™      |_|                |___/  interactive shell

cnquery> 
```


A single ACR image:
```
~/go/bin/cnquery shell container image testpremiumacrpreslav.azurecr.io/os/debian:bullseye      
! using builtin provider for os
! using builtin provider for os
→ loaded configuration from /Users/preslavgerchev/.config/mondoo/mondoo.yml using source default
! using builtin provider for os
→ connected to Debian GNU/Linux 11 (bullseye)
  ___ _ __   __ _ _   _  ___ _ __ _   _ 
 / __| '_ \ / _` | | | |/ _ \ '__| | | |
| (__| | | | (_| | |_| |  __/ |  | |_| |
 \___|_| |_|\__, |\__,_|\___|_|   \__, |
  mondoo™      |_|                |___/  interactive shell

cnquery> 
```

