### PR TITLE
⭐️ check for enabled gcp services

### DIFF
--- a/providers/gcp/resources/access_approval.go
+++ b/providers/gcp/resources/access_approval.go
@@ -33,6 +33,15 @@ func (g *mqlGcpProject) accessApprovalSettings() (*mqlGcpAccessApprovalSettings,
 	}
 	id := g.Id.Data
 
+	serviceEnabled, err := g.isServiceEnabled(service_accessapproval)
+	if err != nil {
+		return nil, err
+	}
+	if !serviceEnabled {
+		g.AccessApprovalSettings.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
 	return accessApprovalSettings(g.MqlRuntime, fmt.Sprintf("projects/%s/accessApprovalSettings", id))
 }
 

--- a/providers/gcp/resources/apikeys.go
+++ b/providers/gcp/resources/apikeys.go
@@ -25,6 +25,14 @@ func (g *mqlGcpProject) apiKeys() ([]interface{}, error) {
 	}
 	projectId := g.Id.Data
 
+	serviceEnabled, err := g.isServiceEnabled(service_apikeys)
+	if err != nil {
+		return nil, err
+	}
+	if !serviceEnabled {
+		return nil, nil
+	}
+
 	client, err := conn.Client(apikeys.CloudPlatformReadOnlyScope)
 	if err != nil {
 		return nil, err

--- a/providers/gcp/resources/bigquery.go
+++ b/providers/gcp/resources/bigquery.go
@@ -33,6 +33,10 @@ func initGcpProjectBigqueryService(runtime *plugin.Runtime, args map[string]*llx
 	return args, nil, nil
 }
 
+type mqlGcpProjectBigqueryServiceInternal struct {
+	serviceEnabled bool
+}
+
 func (g *mqlGcpProjectBigqueryService) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error
@@ -53,7 +57,15 @@ func (g *mqlGcpProject) bigquery() (*mqlGcpProjectBigqueryService, error) {
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlGcpProjectBigqueryService), nil
+
+	serviceEnabled, err := g.isServiceEnabled(service_bigquery)
+	if err != nil {
+		return nil, err
+	}
+	bqService := res.(*mqlGcpProjectBigqueryService)
+	bqService.serviceEnabled = serviceEnabled
+
+	return bqService, nil
 }
 
 func (g *mqlGcpProjectBigqueryService) datasets() ([]interface{}, error) {

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -42,6 +42,10 @@ func initGcpProjectComputeService(runtime *plugin.Runtime, args map[string]*llx.
 	return args, nil, nil
 }
 
+type mqlGcpProjectComputeServiceInternal struct {
+	serviceEnabled bool
+}
+
 func (g *mqlGcpProject) compute() (*mqlGcpProjectComputeService, error) {
 	if g.Id.Error != nil {
 		return nil, g.Id.Error
@@ -54,7 +58,16 @@ func (g *mqlGcpProject) compute() (*mqlGcpProjectComputeService, error) {
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlGcpProjectComputeService), nil
+
+	serviceEnabled, err := g.isServiceEnabled(service_compute)
+	if err != nil {
+		return nil, err
+	}
+
+	computeService := res.(*mqlGcpProjectComputeService)
+	computeService.serviceEnabled = serviceEnabled
+
+	return computeService, nil
 }
 
 func (g *mqlGcpProjectComputeService) id() (string, error) {
@@ -87,6 +100,11 @@ func initGcpProjectComputeServiceRegion(runtime *plugin.Runtime, args map[string
 }
 
 func (g *mqlGcpProjectComputeService) regions() ([]interface{}, error) {
+	// when the service is not enabled, we return nil
+	if !g.serviceEnabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -136,6 +154,11 @@ func (g *mqlGcpProjectComputeServiceZone) region() (interface{}, error) {
 }
 
 func (g *mqlGcpProjectComputeService) zones() ([]interface{}, error) {
+	// when the service is not enabled, we return nil
+	if !g.serviceEnabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -219,6 +242,11 @@ func newMqlMachineType(runtime *plugin.Runtime, entry *compute.MachineType, proj
 }
 
 func (g *mqlGcpProjectComputeService) machineTypes() ([]interface{}, error) {
+	// when the service is not enabled, we return nil
+	if !g.serviceEnabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -558,7 +586,7 @@ func newMqlComputeServiceInstance(projectId string, zone *mqlGcpProjectComputeSe
 	var mqlConfCompute map[string]interface{}
 	if instance.ConfidentialInstanceConfig != nil {
 		type mqlConfidentialInstanceConfig struct {
-			Enabled bool `json:"enabled,omitempty"`
+			Enabled bool `json:"serviceEnabled,omitempty"`
 		}
 		mqlConfCompute, err = convert.JsonToDict(
 			mqlConfidentialInstanceConfig{Enabled: instance.ConfidentialInstanceConfig.EnableConfidentialCompute})
@@ -616,6 +644,11 @@ func newMqlComputeServiceInstance(projectId string, zone *mqlGcpProjectComputeSe
 }
 
 func (g *mqlGcpProjectComputeService) instances() ([]interface{}, error) {
+	// when the service is not enabled, we return nil
+	if !g.serviceEnabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -701,6 +734,11 @@ func (g *mqlGcpProjectComputeServiceDisk) zone() (interface{}, error) {
 }
 
 func (g *mqlGcpProjectComputeService) disks() ([]interface{}, error) {
+	// when the service is not enabled, we return nil
+	if !g.serviceEnabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -865,6 +903,11 @@ func initGcpProjectComputeServiceFirewall(runtime *plugin.Runtime, args map[stri
 }
 
 func (g *mqlGcpProjectComputeService) firewalls() ([]interface{}, error) {
+	// when the service is not enabled, we return nil
+	if !g.serviceEnabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -956,6 +999,11 @@ func (g *mqlGcpProjectComputeServiceSnapshot) sourceDisk() (interface{}, error) 
 }
 
 func (g *mqlGcpProjectComputeService) snapshots() ([]interface{}, error) {
+	// when the service is not enabled, we return nil
+	if !g.serviceEnabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -1070,6 +1118,11 @@ func (g *mqlGcpProjectComputeServiceImage) sourceDisk() (interface{}, error) {
 }
 
 func (g *mqlGcpProjectComputeService) images() ([]interface{}, error) {
+	// when the service is not enabled, we return nil
+	if !g.serviceEnabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -1204,6 +1257,11 @@ func initGcpProjectComputeServiceNetwork(runtime *plugin.Runtime, args map[strin
 }
 
 func (g *mqlGcpProjectComputeService) networks() ([]interface{}, error) {
+	// when the service is not enabled, we return nil
+	if !g.serviceEnabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -1451,6 +1509,11 @@ func newMqlSubnetwork(projectId string, runtime *plugin.Runtime, subnetwork *com
 }
 
 func (g *mqlGcpProjectComputeService) subnetworks() ([]interface{}, error) {
+	// when the service is not enabled, we return nil
+	if !g.serviceEnabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -1539,6 +1602,11 @@ func newMqlRouter(projectId string, region *mqlGcpProjectComputeServiceRegion, r
 }
 
 func (g *mqlGcpProjectComputeService) routers() ([]interface{}, error) {
+	// when the service is not enabled, we return nil
+	if !g.serviceEnabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -1601,6 +1669,11 @@ func (g *mqlGcpProjectComputeService) routers() ([]interface{}, error) {
 }
 
 func (g *mqlGcpProjectComputeService) backendServices() ([]interface{}, error) {
+	// when the service is not enabled, we return nil
+	if !g.serviceEnabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -1754,7 +1827,7 @@ func (g *mqlGcpProjectComputeService) backendServices() ([]interface{}, error) {
 			var mqlIap interface{}
 			if b.Iap != nil {
 				mqlIap = map[string]interface{}{
-					"enabled":                  b.Iap.Enabled,
+					"serviceEnabled":           b.Iap.Enabled,
 					"oauth2ClientId":           b.Iap.Oauth2ClientId,
 					"oauth2ClientSecret":       b.Iap.Oauth2ClientSecret,
 					"oauth2ClientSecretSha256": b.Iap.Oauth2ClientSecretSha256,
@@ -1876,6 +1949,11 @@ func networkMode(n *compute.Network) string {
 }
 
 func (g *mqlGcpProjectComputeService) addresses() ([]interface{}, error) {
+	// when the service is not enabled, we return nil
+	if !g.serviceEnabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}

--- a/providers/gcp/resources/dns.go
+++ b/providers/gcp/resources/dns.go
@@ -18,6 +18,10 @@ import (
 	"google.golang.org/api/option"
 )
 
+type mqlGcpProjectDnsServiceInternal struct {
+	serviceEnabled bool
+}
+
 func (g *mqlGcpProjectDnsService) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error
@@ -38,7 +42,16 @@ func (g *mqlGcpProject) dns() (*mqlGcpProjectDnsService, error) {
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlGcpProjectDnsService), nil
+
+	serviceEnabled, err := g.isServiceEnabled(service_dns)
+	if err != nil {
+		return nil, err
+	}
+
+	dnsService := res.(*mqlGcpProjectDnsService)
+	dnsService.serviceEnabled = serviceEnabled
+
+	return dnsService, nil
 }
 
 func initGcpProjectDnsService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -68,6 +81,11 @@ func (g *mqlGcpProjectDnsServiceManagedzone) id() (string, error) {
 }
 
 func (g *mqlGcpProjectDnsService) managedZones() ([]interface{}, error) {
+	// when the service is not enabled, we return nil
+	if !g.serviceEnabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -149,6 +167,11 @@ func (g *mqlGcpProjectDnsServicePolicy) id() (string, error) {
 }
 
 func (g *mqlGcpProjectDnsService) policies() ([]interface{}, error) {
+	// when the service is not enabled, we return nil
+	if !g.serviceEnabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}

--- a/providers/gcp/resources/essential_contacts.go
+++ b/providers/gcp/resources/essential_contacts.go
@@ -23,6 +23,14 @@ func (g *mqlGcpProject) essentialContacts() ([]interface{}, error) {
 	}
 	projectId := g.Id.Data
 
+	serviceEnabled, err := g.isServiceEnabled(service_essential_contacts)
+	if err != nil {
+		return nil, err
+	}
+	if !serviceEnabled {
+		return nil, nil
+	}
+
 	client, err := conn.Client(essentialcontacts.CloudPlatformScope)
 	if err != nil {
 		return nil, err

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -9522,7 +9522,7 @@ func (c *mqlGcpProjects) GetList() *plugin.TValue[[]interface{}] {
 type mqlGcpProject struct {
 	MqlRuntime *plugin.Runtime
 	__id string
-	// optional: if you define mqlGcpProjectInternal it will be used here
+	mqlGcpProjectInternal
 	Id plugin.TValue[string]
 	Name plugin.TValue[string]
 	ParentId plugin.TValue[string]
@@ -10206,7 +10206,7 @@ func (c *mqlGcpResourcemanagerBinding) GetRole() *plugin.TValue[string] {
 type mqlGcpProjectComputeService struct {
 	MqlRuntime *plugin.Runtime
 	__id string
-	// optional: if you define mqlGcpProjectComputeServiceInternal it will be used here
+	mqlGcpProjectComputeServiceInternal
 	ProjectId plugin.TValue[string]
 	Instances plugin.TValue[[]interface{}]
 	Snapshots plugin.TValue[[]interface{}]
@@ -14026,7 +14026,7 @@ func (c *mqlGcpProjectSqlServiceInstanceSettingsPasswordValidationPolicy) GetReu
 type mqlGcpProjectBigqueryService struct {
 	MqlRuntime *plugin.Runtime
 	__id string
-	// optional: if you define mqlGcpProjectBigqueryServiceInternal it will be used here
+	mqlGcpProjectBigqueryServiceInternal
 	ProjectId plugin.TValue[string]
 	Datasets plugin.TValue[[]interface{}]
 }
@@ -14683,7 +14683,7 @@ func (c *mqlGcpProjectBigqueryServiceRoutine) GetType() *plugin.TValue[string] {
 type mqlGcpProjectDnsService struct {
 	MqlRuntime *plugin.Runtime
 	__id string
-	// optional: if you define mqlGcpProjectDnsServiceInternal it will be used here
+	mqlGcpProjectDnsServiceInternal
 	ProjectId plugin.TValue[string]
 	ManagedZones plugin.TValue[[]interface{}]
 	Policies plugin.TValue[[]interface{}]
@@ -15047,7 +15047,7 @@ func (c *mqlGcpProjectDnsServicePolicy) GetNetworks() *plugin.TValue[[]interface
 type mqlGcpProjectGkeService struct {
 	MqlRuntime *plugin.Runtime
 	__id string
-	// optional: if you define mqlGcpProjectGkeServiceInternal it will be used here
+	mqlGcpProjectGkeServiceInternal
 	ProjectId plugin.TValue[string]
 	Clusters plugin.TValue[[]interface{}]
 }

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -21,6 +21,10 @@ import (
 	"google.golang.org/api/option"
 )
 
+type mqlGcpProjectGkeServiceInternal struct {
+	serviceEnabled bool
+}
+
 func (g *mqlGcpProjectGkeService) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error
@@ -41,7 +45,16 @@ func (g *mqlGcpProject) gke() (*mqlGcpProjectGkeService, error) {
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlGcpProjectGkeService), nil
+
+	serviceEnabled, err := g.isServiceEnabled(service_gke)
+	if err != nil {
+		return nil, err
+	}
+
+	gkeService := res.(*mqlGcpProjectGkeService)
+	gkeService.serviceEnabled = serviceEnabled
+
+	return gkeService, nil
 }
 
 func (g *mqlGcpProjectGkeServiceCluster) id() (string, error) {
@@ -175,6 +188,11 @@ func (g *mqlGcpProjectGkeServiceClusterNetworkConfig) id() (string, error) {
 }
 
 func (g *mqlGcpProjectGkeService) clusters() ([]interface{}, error) {
+	// when the service is not enabled, we return nil
+	if !g.serviceEnabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}

--- a/providers/gcp/resources/services.go
+++ b/providers/gcp/resources/services.go
@@ -7,15 +7,25 @@ import (
 	"context"
 	"strings"
 
-	"go.mondoo.com/cnquery/v10/llx"
-	"go.mondoo.com/cnquery/v10/providers-sdk/v1/plugin"
-	"go.mondoo.com/cnquery/v10/providers/gcp/connection"
-
 	serviceusage "cloud.google.com/go/serviceusage/apiv1"
 	"cloud.google.com/go/serviceusage/apiv1/serviceusagepb"
 	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/v10/llx"
+	"go.mondoo.com/cnquery/v10/providers-sdk/v1/plugin"
+	"go.mondoo.com/cnquery/v10/providers/gcp/connection"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
+)
+
+const (
+	service_compute            = "compute.googleapis.com"
+	service_gke                = "container.googleapis.com"
+	service_bigquery           = "bigquery.googleapis.com"
+	service_essential_contacts = "essentialcontacts.googleapis.com"
+	service_dns                = "dns.googleapis.com"
+	service_accessapproval     = "accessapproval.googleapis.com"
+	service_apikeys            = "apikeys.googleapis.com"
+	service_dataproc           = "dataproc.googleapis.com"
 )
 
 func serviceName(name string) string {
@@ -24,6 +34,11 @@ func serviceName(name string) string {
 }
 
 func (g *mqlGcpProject) services() ([]interface{}, error) {
+	return g.fetchServices("")
+}
+
+// fetches the gcp services with a filter, e.g. "state:ENABLED"
+func (g *mqlGcpProject) fetchServices(filter string) ([]interface{}, error) {
 	if g.Id.Error != nil {
 		return nil, g.Id.Error
 	}
@@ -50,8 +65,8 @@ func (g *mqlGcpProject) services() ([]interface{}, error) {
 	//service.Config.Title
 
 	it := c.ListServices(ctx, &serviceusagepb.ListServicesRequest{
-		Parent: `projects/` + projectId,
-		// Filter:   "state:ENABLED",
+		Parent:   `projects/` + projectId,
+		Filter:   filter,
 		PageSize: 200,
 	})
 


### PR DESCRIPTION
This change makes better use of GCPs service API. It checks if the service is enabled before MQL tries to fetch data (which will return in errors).

```
error: googleapi: Error 403: Compute Engine API has not been used in project example-test before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/compute.googleapis.com/overview?project=example-test then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.
Details:
[
  {
    "@type": "type.googleapis.com/google.rpc.Help",
    "links": [
      {
        "description": "Google developers console API activation",
        "url": "https://console.developers.google.com/apis/api/compute.googleapis.com/overview?project=example-test"
      }
]
```