### PR TITLE
🧹 print cmd help when the arguments could not be parsed

### DIFF
--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -473,7 +473,9 @@ func setConnector(provider *plugin.Provider, connector *plugin.Connector, run fu
 		if err != nil {
 			runtime.Close()
 			providers.Coordinator.Shutdown()
-			log.Fatal().Err(err).Msg("failed to parse cli arguments")
+			log.Error().Err(err).Msg("failed to parse cli arguments")
+			cmd.Help()
+			return
 		}
 
 		if cliRes == nil {


### PR DESCRIPTION
This change prints the cmd help when the command could not be executed.

**before**

```shell
> cnquery scan gcp help
x failed to parse cli arguments error="rpc error: code = Unknown desc = missing argument, use `gcp project id`, `gcp organization id`, `gcp folder id`, `gcp instance name`, or `gcp snapshot name`"
```

**after**

```shell
> cnquery scan gcp help
x failed to parse cli arguments error="rpc error: code = Unknown desc = missing argument, use `gcp project id`, `gcp organization id`, `gcp folder id`, `gcp instance name`, or `gcp snapshot name`"
Scan a Google Cloud project

Usage:
  cnquery scan gcp [flags]

Flags:
      --annotation stringToString     Add an annotation to the asset. (default [])
      --asset-name string             User-override for the asset name
      --create-snapshot               [gcp snapshot, gcp instance] create a new snapshot instead of using the latest available snapshot (only used for instance)
      --credentials-path string       The path to the service account credentials to access the APIs with
      --detect-cicd                   Try to detect CI/CD environments. If detected, set the asset category to 'cicd'. (default true)
      --discover strings              Enable the discovery of nested assets. Supports: all,auto,all,auto,organization,folders,instances,projects,compute-images,compute-networks,compute-subnetworks,compute-firewalls,gke-clusters,storage-buckets,bigquery-datasets
  -h, --help                          help for gcp
      --incognito                     Run in incognito mode. Do not report scan results to  Mondoo Platform.
      --inventory-file string         Set the path to the inventory file.
      --inventory-format-ansible      Set the inventory format to Ansible.
      --inventory-format-domainlist   Set the inventory format to domain list.
  -j, --json                          Run the query and return the object in a JSON structure.
  -o, --output string                 Set output format: compact, csv, full, json, summary, yaml (default "compact")
      --platform-id string            Select a specific target asset by providing its platform ID.
      --project-id string             [gcp snapshot, instance] specify the GCP project ID where the target instance is located
      --props stringToString          Custom values for properties (default [])
      --querypack querypack-bundle    Set the query packs to execute. This requires querypack-bundle. You can specify multiple UIDs.
  -f, --querypack-bundle strings      Path to local query pack file
      --record string                 Record all resource calls and use resources in the recording
      --repository string             [gcp gcr] specify the GCR repository to scan
      --use-recording string          Use a recording to inject resource data (read-only)
      --zone string                   [gcp snapshot, gcp instance] specify the GCP zone where the target instance is located

Global Flags:
      --api-proxy string   Set proxy for communications with Mondoo API
      --auto-update        Enable automatic provider installation and update (default true)
      --config string      Set config file path (default $HOME/.config/mondoo/mondoo.yml)
      --log-level string   Set log level: error, warn, info, debug, trace (default "info")
  -v, --verbose            Enable verbose output
```