### PR TITLE
🧹 extract proto error for better cli rendering

### DIFF
--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -5,6 +5,7 @@ package providers
 
 import (
 	"encoding/json"
+	"go.mondoo.com/ranger-rpc/status"
 	"os"
 	"strings"
 
@@ -473,7 +474,12 @@ func setConnector(provider *plugin.Provider, connector *plugin.Connector, run fu
 		if err != nil {
 			runtime.Close()
 			providers.Coordinator.Shutdown()
-			log.Error().Err(err).Msg("failed to parse cli arguments")
+			s, ok := status.FromError(err)
+			if ok {
+				log.Error().Msg(s.Message())
+			} else {
+				log.Error().Err(err).Msg("failed to parse cli arguments")
+			}
 			cmd.Help()
 			return
 		}

--- a/providers/atlassian/provider/provider.go
+++ b/providers/atlassian/provider/provider.go
@@ -6,6 +6,8 @@ package provider
 import (
 	"context"
 	"errors"
+	"go.mondoo.com/ranger-rpc/codes"
+	"go.mondoo.com/ranger-rpc/status"
 
 	"go.mondoo.com/cnquery/v10/llx"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/inventory"
@@ -38,12 +40,12 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	}
 
 	if len(req.Args) == 0 {
-		return nil, errors.New("missing argument, use `atlassian jira`, `atlassian admin`, `atlassian confluence`, or `atlassian scim {directoryID}`")
+		return nil, status.Error(codes.InvalidArgument, "missing argument, use `atlassian jira`, `atlassian admin`, `atlassian confluence`, or `atlassian scim {directoryID}`")
 	}
 
 	if req.Args[0] == "scim" {
 		if len(req.Args) != 2 {
-			return nil, errors.New("missing argument, scim requires a directory id `atlassian scim {directoryID}`")
+			return nil, status.Error(codes.InvalidArgument, "missing argument, scim requires a directory id `atlassian scim {directoryID}`")
 		}
 	}
 

--- a/providers/equinix/provider/provider.go
+++ b/providers/equinix/provider/provider.go
@@ -6,6 +6,8 @@ package provider
 import (
 	"context"
 	"errors"
+	"go.mondoo.com/ranger-rpc/codes"
+	"go.mondoo.com/ranger-rpc/status"
 	"os"
 
 	"go.mondoo.com/cnquery/v10/llx"
@@ -36,7 +38,7 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	}
 
 	if len(req.Args) != 2 {
-		return nil, errors.New("missing argument, use `equinix project <project-id>`")
+		return nil, status.Error(codes.InvalidArgument, "missing argument, use `equinix project <project-id>`")
 	}
 
 	conf := &inventory.Config{

--- a/providers/gcp/provider/provider.go
+++ b/providers/gcp/provider/provider.go
@@ -6,6 +6,8 @@ package provider
 import (
 	"context"
 	"errors"
+	"go.mondoo.com/ranger-rpc/codes"
+	"go.mondoo.com/ranger-rpc/status"
 	"os"
 
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/vault"
@@ -75,7 +77,7 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	}
 
 	if len(req.Args) != 2 {
-		return nil, errors.New("missing argument, use `gcp project id`, `gcp organization id`, `gcp folder id`, `gcp instance name`, or `gcp snapshot name`")
+		return nil, status.Error(codes.InvalidArgument, "missing argument, use `gcp project id`, `gcp organization id`, `gcp folder id`, `gcp instance name`, or `gcp snapshot name`")
 	}
 
 	conf := &inventory.Config{


### PR DESCRIPTION
**before**

```
> cnquery scan gcp help
x failed to parse cli arguments error="rpc error: code = Unknown desc = rpc error: code = InvalidArgument desc = missing argument, use `gcp project id`, `gcp organization id`, `gcp folder id`, `gcp instance name`, or `gcp snapshot name`"
```

**new**

```
> cnquery scan gcp help
x missing argument, use `gcp project id`, `gcp organization id`, `gcp folder id`, `gcp instance name`, or `gcp snapshot name`
```