### PR TITLE
⚙️ Expose auth options for registry image resolver, load ACR token lazily

### DIFF
--- a/providers/os/connection/container/auth/auth.go
+++ b/providers/os/connection/container/auth/auth.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/awslabs/amazon-ecr-credential-helper/ecr-login"
 	"github.com/google/go-containerregistry/pkg/authn"
-	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v10/providers/os/connection/container/acr"
 )
 
@@ -25,12 +24,7 @@ func getKeychains(name string) []authn.Keychain {
 		kcs = append(kcs, authn.NewKeychainFromHelper(ecr.NewECRHelper()))
 	}
 	if strings.Contains(name, acrIndicator) {
-		acr, err := acr.NewAcrAuthHelper()
-		if err == nil {
-			kcs = append(kcs, authn.NewKeychainFromHelper(acr))
-		} else {
-			log.Debug().Err(err).Msg("failed to create ACR auth helper")
-		}
+		kcs = append(kcs, authn.NewKeychainFromHelper(acr.NewAcrAuthHelper()))
 	}
 	return kcs
 }

--- a/providers/os/connection/container/image_connection.go
+++ b/providers/os/connection/container/image_connection.go
@@ -37,6 +37,7 @@ func NewImageConnection(id uint32, conf *inventory.Config, asset *inventory.Asse
 
 	return tar.NewConnection(id, conf, asset,
 		tar.WithFetchFn(func() (string, error) {
+			log.Debug().Msg("tar> starting image extract to temporary file")
 			err = tar.StreamToTmpFile(mutate.Extract(img), f)
 			if err != nil {
 				_ = os.Remove(f.Name())

--- a/providers/os/connection/tar/stream.go
+++ b/providers/os/connection/tar/stream.go
@@ -13,7 +13,7 @@ func RandomFile() (*os.File, error) {
 }
 
 // StreamToTmpFile streams a binary stream into a file. The user of this method
-// is responsible for deleting the file late
+// is responsible for deleting the file later
 func StreamToTmpFile(r io.ReadCloser, outFile *os.File) error {
 	defer outFile.Close()
 	_, err := io.Copy(outFile, r)

--- a/providers/os/resources/discovery/container_registry/resolver.go
+++ b/providers/os/resources/discovery/container_registry/resolver.go
@@ -31,7 +31,6 @@ func (r *Resolver) AvailableDiscoveryTargets() []string {
 	return []string{"auto", "all"}
 }
 
-// func (r *Resolver) Resolve(ctx context.Context, root *inventory.Asset, conf *inventory.Config, credsResolver vault.Resolver, sfn common.QuerySecretFn, userIdDetectors ...providers.PlatformIdDetector) ([]*inventory.Asset, error) {
 func (r *Resolver) Resolve(ctx context.Context, root *inventory.Asset, conf *inventory.Config, credsResolver vault.Resolver) ([]*inventory.Asset, error) {
 	resolved := []*inventory.Asset{}
 


### PR DESCRIPTION
* Load the token for the ACR auth helper lazily. That ensures that if there's an error it's not ignored
* Expose the options for the container registry resolver and add default fallbacks. This allows fine-tuning of auth opts against registries. For example, we can now initialise an azure token externally and pass that in.