### PR TITLE
🧹 Refactor auth opts for registries. Pass through opts when pulling registry images

### DIFF
--- a/providers/os/connection/container/auth/options.go
+++ b/providers/os/connection/container/auth/options.go
@@ -1,0 +1,71 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package auth
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/v10/logger"
+	"go.mondoo.com/cnquery/v10/providers-sdk/v1/vault"
+)
+
+func TransportOption(insecure bool) remote.Option {
+	tr := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	if insecure {
+		tr.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	}
+	return remote.WithTransport(tr)
+}
+
+func AuthOption(ref string, credentials []*vault.Credential) remote.Option {
+	for i := range credentials {
+		cred := credentials[i]
+		switch cred.Type {
+		case vault.CredentialType_password:
+			log.Debug().Msg("add password authentication")
+			cfg := authn.AuthConfig{
+				Username: cred.User,
+				Password: string(cred.Secret),
+			}
+			return remote.WithAuth((authn.FromConfig(cfg)))
+		case vault.CredentialType_bearer:
+			log.Debug().Str("token", string(cred.Secret)).Msg("add bearer authentication")
+			cfg := authn.AuthConfig{
+				Username:      cred.User,
+				RegistryToken: string(cred.Secret),
+			}
+			return remote.WithAuth((authn.FromConfig(cfg)))
+		default:
+			log.Warn().Msg("unknown credentials for container image")
+			logger.DebugJSON(credentials)
+		}
+	}
+	log.Debug().Msg("no credentials for container image, falling back to default auth")
+	return remote.WithAuthFromKeychain(ConstructKeychain(ref))
+}
+
+func DefaultOpts(ref string, insecure bool) []remote.Option {
+	return []remote.Option{AuthOption(ref, nil), TransportOption(insecure)}
+}

--- a/providers/os/connection/container/image/registry.go
+++ b/providers/os/connection/container/image/registry.go
@@ -4,139 +4,17 @@
 package image
 
 import (
-	"crypto/tls"
-	"net"
-	"net/http"
-	"time"
-
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/rs/zerolog/log"
-	"go.mondoo.com/cnquery/v10/logger"
-	"go.mondoo.com/cnquery/v10/providers-sdk/v1/vault"
-	"go.mondoo.com/cnquery/v10/providers/os/connection/container/auth"
 )
 
-// Option is a functional option
-// see https://www.sohamkamani.com/golang/options-pattern/
-type Option func(*options) error
-
-type options struct {
-	insecure bool
-	auth     authn.Authenticator
+func GetImageDescriptor(ref name.Reference, opts ...remote.Option) (*remote.Descriptor, error) {
+	return remote.Get(ref, opts...)
 }
 
-func WithInsecure(insecure bool) Option {
-	return func(o *options) error {
-		o.insecure = insecure
-		return nil
-	}
-}
-
-func WithAuthenticator(auth authn.Authenticator) Option {
-	return func(o *options) error {
-		o.auth = auth
-		return nil
-	}
-}
-
-func AuthOption(credentials []*vault.Credential) []Option {
-	remoteOpts := []Option{}
-	for i := range credentials {
-		cred := credentials[i]
-		switch cred.Type {
-		case vault.CredentialType_password:
-			log.Debug().Msg("add password authentication")
-			cfg := authn.AuthConfig{
-				Username: cred.User,
-				Password: string(cred.Secret),
-			}
-			remoteOpts = append(remoteOpts, WithAuthenticator((authn.FromConfig(cfg))))
-		case vault.CredentialType_bearer:
-			log.Debug().Str("token", string(cred.Secret)).Msg("add bearer authentication")
-			cfg := authn.AuthConfig{
-				Username:      cred.User,
-				RegistryToken: string(cred.Secret),
-			}
-			remoteOpts = append(remoteOpts, WithAuthenticator((authn.FromConfig(cfg))))
-		default:
-			log.Warn().Msg("unknown credentials for container image")
-			logger.DebugJSON(credentials)
-		}
-	}
-	return remoteOpts
-}
-
-func DefaultAuthOpts(ref name.Reference) (authn.Authenticator, error) {
-	kc := auth.ConstructKeychain(ref.Name())
-	return kc.Resolve(ref.Context())
-}
-
-func GetImageDescriptor(ref name.Reference, opts ...Option) (*remote.Descriptor, error) {
-	o := &options{
-		insecure: false,
-	}
-
-	for _, option := range opts {
-		if err := option(o); err != nil {
-			return nil, err
-		}
-	}
-
-	if o.auth == nil {
-		auth, err := DefaultAuthOpts(ref)
-		if err != nil {
-			return nil, err
-		}
-		o.auth = auth
-	}
-
-	return remote.Get(ref, remote.WithAuth(o.auth))
-}
-
-func LoadImageFromRegistry(ref name.Reference, opts ...Option) (v1.Image, error) {
-	o := &options{
-		insecure: false,
-	}
-
-	for _, option := range opts {
-		if err := option(o); err != nil {
-			return nil, err
-		}
-	}
-
-	if o.auth == nil {
-		auth, err := DefaultAuthOpts(ref)
-		if err != nil {
-			return nil, err
-		}
-		o.auth = auth
-	}
-
-	// mimic http.DefaultTransport
-	tr := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-			DualStack: true,
-		}).DialContext,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-	}
-
-	if o.insecure {
-		tr.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: true,
-		}
-	}
-
-	img, err := remote.Image(ref, remote.WithAuth(o.auth), remote.WithTransport(tr))
+func LoadImageFromRegistry(ref name.Reference, opts ...remote.Option) (v1.Image, error) {
+	img, err := remote.Image(ref, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/os/connection/container/image/registry.go
+++ b/providers/os/connection/container/image/registry.go
@@ -7,13 +7,20 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"go.mondoo.com/cnquery/v10/providers/os/connection/container/auth"
 )
 
 func GetImageDescriptor(ref name.Reference, opts ...remote.Option) (*remote.Descriptor, error) {
+	if len(opts) == 0 {
+		opts = auth.DefaultOpts(ref.Name(), false)
+	}
 	return remote.Get(ref, opts...)
 }
 
 func LoadImageFromRegistry(ref name.Reference, opts ...remote.Option) (v1.Image, error) {
+	if len(opts) == 0 {
+		opts = auth.DefaultOpts(ref.Name(), false)
+	}
 	img, err := remote.Image(ref, opts...)
 	if err != nil {
 		return nil, err

--- a/providers/os/connection/container/image_connection.go
+++ b/providers/os/connection/container/image_connection.go
@@ -11,10 +11,12 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v10/providers-sdk/v1/plugin"
+	"go.mondoo.com/cnquery/v10/providers/os/connection/container/auth"
 	"go.mondoo.com/cnquery/v10/providers/os/connection/container/image"
 	"go.mondoo.com/cnquery/v10/providers/os/connection/tar"
 	"go.mondoo.com/cnquery/v10/providers/os/id/containerid"
@@ -61,10 +63,7 @@ func NewRegistryImage(id uint32, conf *inventory.Config, asset *inventory.Asset)
 	}
 	log.Debug().Str("ref", ref.Name()).Msg("found valid container registry reference")
 
-	registryOpts := []image.Option{image.WithInsecure(conf.Insecure)}
-	remoteOpts := image.AuthOption(conf.Credentials)
-	registryOpts = append(registryOpts, remoteOpts...)
-
+	registryOpts := []remote.Option{auth.TransportOption(conf.Insecure), auth.AuthOption(ref.Name(), conf.Credentials)}
 	img, err := image.LoadImageFromRegistry(ref, registryOpts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
 * Move all `remote.Options` code to `auth/options`
 * Ensure that if we pass external opts, those are also passed all the way down to the image fetching
 * Remove redundant code