### PR TITLE
🛑 switch to json v2 output format

### DIFF
--- a/cli/reporter/reporter.go
+++ b/cli/reporter/reporter.go
@@ -44,7 +44,7 @@ var Formats = map[string]Format{
 	"yml":     YAML,
 	"json-v1": JSONv1,
 	"json-v2": JSONv2,
-	"json":    JSONv1,
+	"json":    JSONv2,
 	"csv":     CSV,
 }
 


### PR DESCRIPTION
This PR enables the v2 json format as standard. The new format is accessible via:

```
cnquery scan local --json
```

or 

```
cnquery scan local --output json
```

For backwards-compatibility, the old format is available via:

```
cnquery scan local --output json-v1
```