### PR TITLE
🧹 calculate k8s specs and manifests on demand

### DIFF
--- a/providers/k8s/resources/clusterrole.go
+++ b/providers/k8s/resources/clusterrole.go
@@ -24,12 +24,6 @@ type mqlK8sRbacClusterroleInternal struct {
 func (k *mqlK8s) clusterroles() ([]interface{}, error) {
 	return k8sResourceToMql(k.MqlRuntime, "clusterroles", func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
-
-		manifest, err := convert.JsonToDict(resource)
-		if err != nil {
-			return nil, err
-		}
-
 		clusterRole, ok := resource.(*rbacv1.ClusterRole)
 		if !ok {
 			return nil, errors.New("not a k8s clusterrole")
@@ -52,7 +46,6 @@ func (k *mqlK8s) clusterroles() ([]interface{}, error) {
 			"name":            llx.StringData(obj.GetName()),
 			"kind":            llx.StringData(objT.GetKind()),
 			"created":         llx.TimeData(ts.Time),
-			"manifest":        llx.DictData(manifest),
 			"rules":           llx.ArrayData(rules, types.Dict),
 			"aggregationRule": llx.DictData(aggregationRule),
 		})
@@ -62,6 +55,14 @@ func (k *mqlK8s) clusterroles() ([]interface{}, error) {
 		r.(*mqlK8sRbacClusterrole).obj = clusterRole
 		return r, nil
 	})
+}
+
+func (k *mqlK8sRbacClusterrole) manifest() (map[string]interface{}, error) {
+	manifest, err := convert.JsonToDict(k.obj)
+	if err != nil {
+		return nil, err
+	}
+	return manifest, nil
 }
 
 func (k *mqlK8sRbacClusterrole) id() (string, error) {

--- a/providers/k8s/resources/clusterrolebinding.go
+++ b/providers/k8s/resources/clusterrolebinding.go
@@ -25,11 +25,6 @@ func (k *mqlK8s) clusterrolebindings() ([]interface{}, error) {
 	return k8sResourceToMql(k.MqlRuntime, "clusterrolebindings", func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
-		manifest, err := convert.JsonToDict(resource)
-		if err != nil {
-			return nil, err
-		}
-
 		clusterRoleBinding, ok := resource.(*rbacv1.ClusterRoleBinding)
 		if !ok {
 			return nil, errors.New("not a k8s clusterrolebinding")
@@ -52,7 +47,6 @@ func (k *mqlK8s) clusterrolebindings() ([]interface{}, error) {
 			"name":            llx.StringData(obj.GetName()),
 			"kind":            llx.StringData(objT.GetKind()),
 			"created":         llx.TimeData(ts.Time),
-			"manifest":        llx.DictData(manifest),
 			"subjects":        llx.ArrayData(subjects, types.Dict),
 			"roleRef":         llx.DictData(roleRef),
 		})
@@ -62,6 +56,14 @@ func (k *mqlK8s) clusterrolebindings() ([]interface{}, error) {
 		r.(*mqlK8sRbacClusterrolebinding).obj = clusterRoleBinding
 		return r, nil
 	})
+}
+
+func (k *mqlK8sRbacClusterrolebinding) manifest() (map[string]interface{}, error) {
+	manifest, err := convert.JsonToDict(k.obj)
+	if err != nil {
+		return nil, err
+	}
+	return manifest, nil
 }
 
 func (k *mqlK8sRbacClusterrolebinding) id() (string, error) {

--- a/providers/k8s/resources/configmap.go
+++ b/providers/k8s/resources/configmap.go
@@ -25,11 +25,6 @@ func (k *mqlK8s) configmaps() ([]interface{}, error) {
 	return k8sResourceToMql(k.MqlRuntime, "configmaps", func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
-		manifest, err := convert.JsonToDict(resource)
-		if err != nil {
-			return nil, err
-		}
-
 		cm, ok := resource.(*corev1.ConfigMap)
 		if !ok {
 			return nil, errors.New("not a k8s configmap")
@@ -43,7 +38,6 @@ func (k *mqlK8s) configmaps() ([]interface{}, error) {
 			"namespace":       llx.StringData(obj.GetNamespace()),
 			"kind":            llx.StringData(objT.GetKind()),
 			"created":         llx.TimeData(ts.Time),
-			"manifest":        llx.DictData(manifest),
 			"data":            llx.MapData(convert.MapToInterfaceMap(cm.Data), types.String),
 		})
 		if err != nil {
@@ -52,6 +46,14 @@ func (k *mqlK8s) configmaps() ([]interface{}, error) {
 		r.(*mqlK8sConfigmap).obj = cm
 		return r, nil
 	})
+}
+
+func (k *mqlK8sConfigmap) manifest() (map[string]interface{}, error) {
+	manifest, err := convert.JsonToDict(k.obj)
+	if err != nil {
+		return nil, err
+	}
+	return manifest, nil
 }
 
 func (k *mqlK8sConfigmap) id() (string, error) {

--- a/providers/k8s/resources/cronjob.go
+++ b/providers/k8s/resources/cronjob.go
@@ -25,21 +25,6 @@ func (k *mqlK8s) cronjobs() ([]interface{}, error) {
 	return k8sResourceToMql(k.MqlRuntime, "cronjobs", func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
-		manifest, err := convert.JsonToDict(resource)
-		if err != nil {
-			return nil, err
-		}
-
-		podSpec, err := resources.GetPodSpec(resource)
-		if err != nil {
-			return nil, err
-		}
-
-		podSpecDict, err := convert.JsonToDict(podSpec)
-		if err != nil {
-			return nil, err
-		}
-
 		r, err := CreateResource(k.MqlRuntime, "k8s.cronjob", map[string]*llx.RawData{
 			"id":              llx.StringData(objIdFromK8sObj(obj, objT)),
 			"uid":             llx.StringData(string(obj.GetUID())),
@@ -48,8 +33,6 @@ func (k *mqlK8s) cronjobs() ([]interface{}, error) {
 			"namespace":       llx.StringData(obj.GetNamespace()),
 			"kind":            llx.StringData(objT.GetKind()),
 			"created":         llx.TimeData(ts.Time),
-			"manifest":        llx.DictData(manifest),
-			"podSpec":         llx.DictData(podSpecDict),
 		})
 		if err != nil {
 			return nil, err
@@ -62,6 +45,26 @@ func (k *mqlK8s) cronjobs() ([]interface{}, error) {
 		r.(*mqlK8sCronjob).obj = cj
 		return r, nil
 	})
+}
+
+func (k *mqlK8sCronjob) manifest() (map[string]interface{}, error) {
+	manifest, err := convert.JsonToDict(k.obj)
+	if err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+func (k *mqlK8sCronjob) podSpec() (map[string]interface{}, error) {
+	podSpec, err := resources.GetPodSpec(k.obj)
+	if err != nil {
+		return nil, err
+	}
+	dict, err := convert.JsonToDict(podSpec)
+	if err != nil {
+		return nil, err
+	}
+	return dict, nil
 }
 
 func (k *mqlK8sCronjob) id() (string, error) {

--- a/providers/k8s/resources/deployment.go
+++ b/providers/k8s/resources/deployment.go
@@ -25,21 +25,6 @@ func (k *mqlK8s) deployments() ([]interface{}, error) {
 	return k8sResourceToMql(k.MqlRuntime, "deployments", func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
-		manifest, err := convert.JsonToDict(resource)
-		if err != nil {
-			return nil, err
-		}
-
-		podSpec, err := resources.GetPodSpec(resource)
-		if err != nil {
-			return nil, err
-		}
-
-		podSpecDict, err := convert.JsonToDict(podSpec)
-		if err != nil {
-			return nil, err
-		}
-
 		r, err := CreateResource(k.MqlRuntime, "k8s.deployment", map[string]*llx.RawData{
 			"id":              llx.StringData(objIdFromK8sObj(obj, objT)),
 			"uid":             llx.StringData(string(obj.GetUID())),
@@ -48,8 +33,6 @@ func (k *mqlK8s) deployments() ([]interface{}, error) {
 			"namespace":       llx.StringData(obj.GetNamespace()),
 			"kind":            llx.StringData(objT.GetKind()),
 			"created":         llx.TimeData(ts.Time),
-			"manifest":        llx.DictData(manifest),
-			"podSpec":         llx.DictData(podSpecDict),
 		})
 		if err != nil {
 			return nil, err
@@ -62,6 +45,26 @@ func (k *mqlK8s) deployments() ([]interface{}, error) {
 		r.(*mqlK8sDeployment).obj = d
 		return r, nil
 	})
+}
+
+func (k *mqlK8sDeployment) manifest() (map[string]interface{}, error) {
+	manifest, err := convert.JsonToDict(k.obj)
+	if err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+func (k *mqlK8sDeployment) podSpec() (map[string]interface{}, error) {
+	podSpec, err := resources.GetPodSpec(k.obj)
+	if err != nil {
+		return nil, err
+	}
+	dict, err := convert.JsonToDict(podSpec)
+	if err != nil {
+		return nil, err
+	}
+	return dict, nil
 }
 
 func (k *mqlK8sDeployment) id() (string, error) {

--- a/providers/k8s/resources/ingress.go
+++ b/providers/k8s/resources/ingress.go
@@ -29,11 +29,6 @@ func (k *mqlK8s) ingresses() ([]interface{}, error) {
 	return k8sResourceToMql(k.MqlRuntime, "ingresses", func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
-		manifest, err := convert.JsonToDict(resource)
-		if err != nil {
-			return nil, err
-		}
-
 		ingress, ok := resource.(*networkingv1.Ingress)
 		if !ok {
 			return nil, errors.New("not a k8s ingress")
@@ -54,7 +49,6 @@ func (k *mqlK8s) ingresses() ([]interface{}, error) {
 			"namespace":       llx.StringData(obj.GetNamespace()),
 			"kind":            llx.StringData(objT.GetKind()),
 			"created":         llx.TimeData(ts.Time),
-			"manifest":        llx.DictData(manifest),
 			"rules":           llx.ArrayData(rules, types.Resource("k8s.ingressrule")),
 		})
 		if err != nil {
@@ -79,6 +73,14 @@ func (k *mqlK8sIngress) tls() ([]interface{}, error) {
 	}
 
 	return tls, nil
+}
+
+func (k *mqlK8sIngress) manifest() (map[string]interface{}, error) {
+	manifest, err := convert.JsonToDict(k.obj)
+	if err != nil {
+		return nil, err
+	}
+	return manifest, nil
 }
 
 func (k *mqlK8sIngress) id() (string, error) {

--- a/providers/k8s/resources/job.go
+++ b/providers/k8s/resources/job.go
@@ -25,21 +25,6 @@ func (k *mqlK8s) jobs() ([]interface{}, error) {
 	return k8sResourceToMql(k.MqlRuntime, "jobs", func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
-		manifest, err := convert.JsonToDict(resource)
-		if err != nil {
-			return nil, err
-		}
-
-		podSpec, err := resources.GetPodSpec(resource)
-		if err != nil {
-			return nil, err
-		}
-
-		podSpecDict, err := convert.JsonToDict(podSpec)
-		if err != nil {
-			return nil, err
-		}
-
 		r, err := CreateResource(k.MqlRuntime, "k8s.job", map[string]*llx.RawData{
 			"id":              llx.StringData(objIdFromK8sObj(obj, objT)),
 			"uid":             llx.StringData(string(obj.GetUID())),
@@ -48,8 +33,6 @@ func (k *mqlK8s) jobs() ([]interface{}, error) {
 			"namespace":       llx.StringData(obj.GetNamespace()),
 			"kind":            llx.StringData(objT.GetKind()),
 			"created":         llx.TimeData(ts.Time),
-			"manifest":        llx.DictData(manifest),
-			"podSpec":         llx.DictData(podSpecDict),
 		})
 		if err != nil {
 			return nil, err
@@ -62,6 +45,26 @@ func (k *mqlK8s) jobs() ([]interface{}, error) {
 		r.(*mqlK8sJob).obj = j
 		return r, nil
 	})
+}
+
+func (k *mqlK8sJob) manifest() (map[string]interface{}, error) {
+	manifest, err := convert.JsonToDict(k.obj)
+	if err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+func (k *mqlK8sJob) podSpec() (map[string]interface{}, error) {
+	podSpec, err := resources.GetPodSpec(k.obj)
+	if err != nil {
+		return nil, err
+	}
+	dict, err := convert.JsonToDict(podSpec)
+	if err != nil {
+		return nil, err
+	}
+	return dict, nil
 }
 
 func (k *mqlK8sJob) id() (string, error) {

--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -88,7 +88,7 @@ private k8s.namespace @defaults("name created") {
   // Kubernetes object creation timestamp
   created time
   // Full resource manifest
-  manifest dict
+  manifest() dict
   // Kubernetes object type
   kind string
   // Kubernetes labels
@@ -138,9 +138,9 @@ private k8s.pod @defaults("namespace name created"){
   // Kubernetes object creation timestamp
   created time
   // Full resource manifest
-  manifest dict
+  manifest() dict
   // Pod description
-  podSpec dict
+  podSpec() dict
   // Ephemeral containers
   ephemeralContainers() []k8s.ephemeralContainer
   // Init containers
@@ -172,9 +172,9 @@ private k8s.deployment @defaults("namespace name created") {
   // Kubernetes object creation timestamp
   created time
   // Full resource manifest
-  manifest dict
+  manifest() dict
   // Pod description
-  podSpec dict
+  podSpec() dict
   // Init containers
   initContainers() []k8s.initContainer
   // Contained containers
@@ -202,9 +202,9 @@ private k8s.daemonset @defaults("namespace name created") {
   // Kubernetes object creation timestamp
   created time
   // Full resource manifest
-  manifest dict
+  manifest() dict
   // Pod description
-  podSpec dict
+  podSpec() dict
   // Init containers
   initContainers() []k8s.initContainer
   // Contained containers
@@ -232,9 +232,9 @@ private k8s.statefulset @defaults("namespace name created") {
   // Kubernetes object creation timestamp
   created time
   // Full resource manifest
-  manifest dict
+  manifest() dict
   // Pod description
-  podSpec dict
+  podSpec() dict
   // Init containers
   initContainers() []k8s.initContainer
   // Contained containers
@@ -262,9 +262,9 @@ private k8s.replicaset @defaults("namespace name created") {
   // Kubernetes object creation timestamp
   created time
   // Full resource manifest
-  manifest dict
+  manifest() dict
   // Pod description
-  podSpec dict
+  podSpec() dict
   // Init containers
   initContainers() []k8s.initContainer
   // Contained containers
@@ -292,9 +292,9 @@ private k8s.job @defaults("namespace name created") {
   // Kubernetes object creation timestamp
   created time
   // Full resource manifest
-  manifest dict
+  manifest() dict
   // Pod description
-  podSpec dict
+  podSpec() dict
   // Init containers
   initContainers() []k8s.initContainer
   // Contained containers
@@ -322,9 +322,9 @@ private k8s.cronjob @defaults("namespace name created") {
   // Kubernetes object creation timestamp
   created time
   // Full resource manifest
-  manifest dict
+  manifest() dict
   // Pod description
-  podSpec dict
+  podSpec() dict
   // Init containers
   initContainers() []k8s.initContainer
   // Contained containers
@@ -462,7 +462,7 @@ private k8s.secret @defaults("namespace name created") {
   // Kubernetes object creation timestamp
   created time
   // Full resource manifest
-  manifest dict
+  manifest() dict
   // Secret type
   type string
   // Secret certificates
@@ -490,7 +490,7 @@ private k8s.configmap @defaults("namespace name created") {
   // Kubernetes object creation timestamp
   created time
   // Full resource manifest
-  manifest dict
+  manifest() dict
   // Configuration data
   data map[string]string
 }
@@ -516,9 +516,9 @@ private k8s.service @defaults("namespace name created") {
   // Kubernetes object creation timestamp
   created time
   // Full resource manifest
-  manifest dict
+  manifest() dict
   // Service Spec
-  spec dict
+  spec() dict
 }
 
 // Kubernetes Ingress resource backend
@@ -608,7 +608,7 @@ private k8s.ingress @defaults("namespace name created") {
   // Kubernetes object creation timestamp
   created time
   // Full resource manifest
-  manifest dict
+  manifest() dict
   // Ingress rules
   rules []k8s.ingressrule
   // Ingress TLS data
@@ -636,7 +636,7 @@ private k8s.serviceaccount @defaults("namespace name created") {
   // Kubernetes object creation timestamp
   created time
   // Full resource manifest
-  manifest dict
+  manifest() dict
   // List of secrets that Pods running using this service account are allowed to use
   secrets []dict
   // List of references to secrets in the same namespace to use for pulling any images
@@ -664,7 +664,7 @@ private k8s.rbac.clusterrole @defaults("name created") {
   // Kubernetes object creation timestamp
   created time
   // Full resource manifest
-  manifest dict
+  manifest() dict
   // ClusterRole rules
   rules []dict
   // ClusterRole aggregation rule
@@ -690,7 +690,7 @@ private k8s.rbac.clusterrolebinding @defaults("name created") {
   // Kubernetes object creation timestamp
   created time
   // Full resource manifest
-  manifest dict
+  manifest() dict
   // References to the objects the role applies to
   subjects []dict
   // ClusterRole in the global namespace
@@ -718,7 +718,7 @@ private k8s.rbac.role @defaults("name namespace") {
   // Kubernetes object creation timestamp
   created time
   // Full resource manifest
-  manifest dict
+  manifest() dict
   // Cluster Role Rules
   rules []dict
 }
@@ -744,7 +744,7 @@ private k8s.rbac.rolebinding @defaults("name namespace created") {
   // Kubernetes object creation timestamp
   created time
   // Full resource manifest
-  manifest dict
+  manifest() dict
   // Subjects holds references to the objects the role applies to
   subjects []dict
   // RoleRef can only reference a ClusterRole in the global namespace
@@ -770,9 +770,9 @@ private k8s.podsecuritypolicy {
   // Kubernetes object creation timestamp
   created time
   // Full resource manifest
-  manifest dict
+  manifest() dict
   // Policy Spec
-  spec dict
+  spec() dict
 }
 
 // Kubernetes Network Policy
@@ -796,9 +796,9 @@ private k8s.networkpolicy @defaults("namespace name created") {
   // Kubernetes object creation timestamp
   created time
   // Full resource manifest
-  manifest dict
+  manifest() dict
   // Network policy spec
-  spec dict
+  spec() dict
 }
 
 // Kubernetes CustomResource
@@ -822,7 +822,7 @@ private k8s.customresource @defaults("name namespace created") {
   // Kubernetes object creation timestamp
   created time
   // Full resource manifest
-  manifest dict
+  manifest() dict
 }
 
 // Kubernetes AdmissionReview

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -3453,7 +3453,9 @@ func (c *mqlK8sNamespace) GetCreated() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlK8sNamespace) GetManifest() *plugin.TValue[interface{}] {
-	return &c.Manifest
+	return plugin.GetOrCompute[interface{}](&c.Manifest, func() (interface{}, error) {
+		return c.manifest()
+	})
 }
 
 func (c *mqlK8sNamespace) GetKind() *plugin.TValue[string] {
@@ -3660,11 +3662,15 @@ func (c *mqlK8sPod) GetCreated() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlK8sPod) GetManifest() *plugin.TValue[interface{}] {
-	return &c.Manifest
+	return plugin.GetOrCompute[interface{}](&c.Manifest, func() (interface{}, error) {
+		return c.manifest()
+	})
 }
 
 func (c *mqlK8sPod) GetPodSpec() *plugin.TValue[interface{}] {
-	return &c.PodSpec
+	return plugin.GetOrCompute[interface{}](&c.PodSpec, func() (interface{}, error) {
+		return c.podSpec()
+	})
 }
 
 func (c *mqlK8sPod) GetEphemeralContainers() *plugin.TValue[[]interface{}] {
@@ -3829,11 +3835,15 @@ func (c *mqlK8sDeployment) GetCreated() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlK8sDeployment) GetManifest() *plugin.TValue[interface{}] {
-	return &c.Manifest
+	return plugin.GetOrCompute[interface{}](&c.Manifest, func() (interface{}, error) {
+		return c.manifest()
+	})
 }
 
 func (c *mqlK8sDeployment) GetPodSpec() *plugin.TValue[interface{}] {
-	return &c.PodSpec
+	return plugin.GetOrCompute[interface{}](&c.PodSpec, func() (interface{}, error) {
+		return c.podSpec()
+	})
 }
 
 func (c *mqlK8sDeployment) GetInitContainers() *plugin.TValue[[]interface{}] {
@@ -3966,11 +3976,15 @@ func (c *mqlK8sDaemonset) GetCreated() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlK8sDaemonset) GetManifest() *plugin.TValue[interface{}] {
-	return &c.Manifest
+	return plugin.GetOrCompute[interface{}](&c.Manifest, func() (interface{}, error) {
+		return c.manifest()
+	})
 }
 
 func (c *mqlK8sDaemonset) GetPodSpec() *plugin.TValue[interface{}] {
-	return &c.PodSpec
+	return plugin.GetOrCompute[interface{}](&c.PodSpec, func() (interface{}, error) {
+		return c.podSpec()
+	})
 }
 
 func (c *mqlK8sDaemonset) GetInitContainers() *plugin.TValue[[]interface{}] {
@@ -4103,11 +4117,15 @@ func (c *mqlK8sStatefulset) GetCreated() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlK8sStatefulset) GetManifest() *plugin.TValue[interface{}] {
-	return &c.Manifest
+	return plugin.GetOrCompute[interface{}](&c.Manifest, func() (interface{}, error) {
+		return c.manifest()
+	})
 }
 
 func (c *mqlK8sStatefulset) GetPodSpec() *plugin.TValue[interface{}] {
-	return &c.PodSpec
+	return plugin.GetOrCompute[interface{}](&c.PodSpec, func() (interface{}, error) {
+		return c.podSpec()
+	})
 }
 
 func (c *mqlK8sStatefulset) GetInitContainers() *plugin.TValue[[]interface{}] {
@@ -4240,11 +4258,15 @@ func (c *mqlK8sReplicaset) GetCreated() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlK8sReplicaset) GetManifest() *plugin.TValue[interface{}] {
-	return &c.Manifest
+	return plugin.GetOrCompute[interface{}](&c.Manifest, func() (interface{}, error) {
+		return c.manifest()
+	})
 }
 
 func (c *mqlK8sReplicaset) GetPodSpec() *plugin.TValue[interface{}] {
-	return &c.PodSpec
+	return plugin.GetOrCompute[interface{}](&c.PodSpec, func() (interface{}, error) {
+		return c.podSpec()
+	})
 }
 
 func (c *mqlK8sReplicaset) GetInitContainers() *plugin.TValue[[]interface{}] {
@@ -4377,11 +4399,15 @@ func (c *mqlK8sJob) GetCreated() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlK8sJob) GetManifest() *plugin.TValue[interface{}] {
-	return &c.Manifest
+	return plugin.GetOrCompute[interface{}](&c.Manifest, func() (interface{}, error) {
+		return c.manifest()
+	})
 }
 
 func (c *mqlK8sJob) GetPodSpec() *plugin.TValue[interface{}] {
-	return &c.PodSpec
+	return plugin.GetOrCompute[interface{}](&c.PodSpec, func() (interface{}, error) {
+		return c.podSpec()
+	})
 }
 
 func (c *mqlK8sJob) GetInitContainers() *plugin.TValue[[]interface{}] {
@@ -4514,11 +4540,15 @@ func (c *mqlK8sCronjob) GetCreated() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlK8sCronjob) GetManifest() *plugin.TValue[interface{}] {
-	return &c.Manifest
+	return plugin.GetOrCompute[interface{}](&c.Manifest, func() (interface{}, error) {
+		return c.manifest()
+	})
 }
 
 func (c *mqlK8sCronjob) GetPodSpec() *plugin.TValue[interface{}] {
-	return &c.PodSpec
+	return plugin.GetOrCompute[interface{}](&c.PodSpec, func() (interface{}, error) {
+		return c.podSpec()
+	})
 }
 
 func (c *mqlK8sCronjob) GetInitContainers() *plugin.TValue[[]interface{}] {
@@ -5063,7 +5093,9 @@ func (c *mqlK8sSecret) GetCreated() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlK8sSecret) GetManifest() *plugin.TValue[interface{}] {
-	return &c.Manifest
+	return plugin.GetOrCompute[interface{}](&c.Manifest, func() (interface{}, error) {
+		return c.manifest()
+	})
 }
 
 func (c *mqlK8sSecret) GetType() *plugin.TValue[string] {
@@ -5182,7 +5214,9 @@ func (c *mqlK8sConfigmap) GetCreated() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlK8sConfigmap) GetManifest() *plugin.TValue[interface{}] {
-	return &c.Manifest
+	return plugin.GetOrCompute[interface{}](&c.Manifest, func() (interface{}, error) {
+		return c.manifest()
+	})
 }
 
 func (c *mqlK8sConfigmap) GetData() *plugin.TValue[map[string]interface{}] {
@@ -5285,11 +5319,15 @@ func (c *mqlK8sService) GetCreated() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlK8sService) GetManifest() *plugin.TValue[interface{}] {
-	return &c.Manifest
+	return plugin.GetOrCompute[interface{}](&c.Manifest, func() (interface{}, error) {
+		return c.manifest()
+	})
 }
 
 func (c *mqlK8sService) GetSpec() *plugin.TValue[interface{}] {
-	return &c.Spec
+	return plugin.GetOrCompute[interface{}](&c.Spec, func() (interface{}, error) {
+		return c.spec()
+	})
 }
 
 // mqlK8sIngressresourceref for the k8s.ingressresourceref resource
@@ -5758,7 +5796,9 @@ func (c *mqlK8sIngress) GetCreated() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlK8sIngress) GetManifest() *plugin.TValue[interface{}] {
-	return &c.Manifest
+	return plugin.GetOrCompute[interface{}](&c.Manifest, func() (interface{}, error) {
+		return c.manifest()
+	})
 }
 
 func (c *mqlK8sIngress) GetRules() *plugin.TValue[[]interface{}] {
@@ -5879,7 +5919,9 @@ func (c *mqlK8sServiceaccount) GetCreated() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlK8sServiceaccount) GetManifest() *plugin.TValue[interface{}] {
-	return &c.Manifest
+	return plugin.GetOrCompute[interface{}](&c.Manifest, func() (interface{}, error) {
+		return c.manifest()
+	})
 }
 
 func (c *mqlK8sServiceaccount) GetSecrets() *plugin.TValue[[]interface{}] {
@@ -5986,7 +6028,9 @@ func (c *mqlK8sRbacClusterrole) GetCreated() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlK8sRbacClusterrole) GetManifest() *plugin.TValue[interface{}] {
-	return &c.Manifest
+	return plugin.GetOrCompute[interface{}](&c.Manifest, func() (interface{}, error) {
+		return c.manifest()
+	})
 }
 
 func (c *mqlK8sRbacClusterrole) GetRules() *plugin.TValue[[]interface{}] {
@@ -6089,7 +6133,9 @@ func (c *mqlK8sRbacClusterrolebinding) GetCreated() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlK8sRbacClusterrolebinding) GetManifest() *plugin.TValue[interface{}] {
-	return &c.Manifest
+	return plugin.GetOrCompute[interface{}](&c.Manifest, func() (interface{}, error) {
+		return c.manifest()
+	})
 }
 
 func (c *mqlK8sRbacClusterrolebinding) GetSubjects() *plugin.TValue[[]interface{}] {
@@ -6196,7 +6242,9 @@ func (c *mqlK8sRbacRole) GetCreated() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlK8sRbacRole) GetManifest() *plugin.TValue[interface{}] {
-	return &c.Manifest
+	return plugin.GetOrCompute[interface{}](&c.Manifest, func() (interface{}, error) {
+		return c.manifest()
+	})
 }
 
 func (c *mqlK8sRbacRole) GetRules() *plugin.TValue[[]interface{}] {
@@ -6300,7 +6348,9 @@ func (c *mqlK8sRbacRolebinding) GetCreated() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlK8sRbacRolebinding) GetManifest() *plugin.TValue[interface{}] {
-	return &c.Manifest
+	return plugin.GetOrCompute[interface{}](&c.Manifest, func() (interface{}, error) {
+		return c.manifest()
+	})
 }
 
 func (c *mqlK8sRbacRolebinding) GetSubjects() *plugin.TValue[[]interface{}] {
@@ -6402,11 +6452,15 @@ func (c *mqlK8sPodsecuritypolicy) GetCreated() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlK8sPodsecuritypolicy) GetManifest() *plugin.TValue[interface{}] {
-	return &c.Manifest
+	return plugin.GetOrCompute[interface{}](&c.Manifest, func() (interface{}, error) {
+		return c.manifest()
+	})
 }
 
 func (c *mqlK8sPodsecuritypolicy) GetSpec() *plugin.TValue[interface{}] {
-	return &c.Spec
+	return plugin.GetOrCompute[interface{}](&c.Spec, func() (interface{}, error) {
+		return c.spec()
+	})
 }
 
 // mqlK8sNetworkpolicy for the k8s.networkpolicy resource
@@ -6505,11 +6559,15 @@ func (c *mqlK8sNetworkpolicy) GetCreated() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlK8sNetworkpolicy) GetManifest() *plugin.TValue[interface{}] {
-	return &c.Manifest
+	return plugin.GetOrCompute[interface{}](&c.Manifest, func() (interface{}, error) {
+		return c.manifest()
+	})
 }
 
 func (c *mqlK8sNetworkpolicy) GetSpec() *plugin.TValue[interface{}] {
-	return &c.Spec
+	return plugin.GetOrCompute[interface{}](&c.Spec, func() (interface{}, error) {
+		return c.spec()
+	})
 }
 
 // mqlK8sCustomresource for the k8s.customresource resource
@@ -6607,7 +6665,9 @@ func (c *mqlK8sCustomresource) GetCreated() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlK8sCustomresource) GetManifest() *plugin.TValue[interface{}] {
-	return &c.Manifest
+	return plugin.GetOrCompute[interface{}](&c.Manifest, func() (interface{}, error) {
+		return c.manifest()
+	})
 }
 
 // mqlK8sAdmissionreview for the k8s.admissionreview resource

--- a/providers/k8s/resources/namespace.go
+++ b/providers/k8s/resources/namespace.go
@@ -38,11 +38,6 @@ func (k *mqlK8s) namespaces() ([]interface{}, error) {
 	for _, ns := range nss {
 		ts := ns.GetCreationTimestamp()
 
-		manifest, err := convert.JsonToDict(ns)
-		if err != nil {
-			return nil, err
-		}
-
 		objT, err := meta.TypeAccessor(&ns)
 		if err != nil {
 			log.Error().Err(err).Msg("could not access object attributes")
@@ -50,12 +45,11 @@ func (k *mqlK8s) namespaces() ([]interface{}, error) {
 		}
 
 		r, err := CreateResource(k.MqlRuntime, "k8s.namespace", map[string]*llx.RawData{
-			"id":       llx.StringData(objIdFromK8sObj(&ns.ObjectMeta, objT)),
-			"uid":      llx.StringData(string(ns.UID)),
-			"name":     llx.StringData(ns.Name),
-			"created":  llx.TimeData(ts.Time),
-			"manifest": llx.DictData(manifest),
-			"kind":     llx.StringData(ns.Kind),
+			"id":      llx.StringData(objIdFromK8sObj(&ns.ObjectMeta, objT)),
+			"uid":     llx.StringData(string(ns.UID)),
+			"name":    llx.StringData(ns.Name),
+			"created": llx.TimeData(ts.Time),
+			"kind":    llx.StringData(ns.Kind),
 		})
 		if err != nil {
 			return nil, err
@@ -65,6 +59,14 @@ func (k *mqlK8s) namespaces() ([]interface{}, error) {
 		resp = append(resp, r)
 	}
 	return resp, nil
+}
+
+func (k *mqlK8sNamespace) manifest() (map[string]interface{}, error) {
+	manifest, err := convert.JsonToDict(k.obj)
+	if err != nil {
+		return nil, err
+	}
+	return manifest, nil
 }
 
 func (k *mqlK8sNamespace) id() (string, error) {

--- a/providers/k8s/resources/networkpolicy.go
+++ b/providers/k8s/resources/networkpolicy.go
@@ -24,11 +24,6 @@ func (k *mqlK8s) networkPolicies() ([]interface{}, error) {
 	return k8sResourceToMql(k.MqlRuntime, "networkpolicies", func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
-		manifest, err := convert.JsonToDict(resource)
-		if err != nil {
-			return nil, err
-		}
-
 		networkPolicy, ok := resource.(*networkingv1.NetworkPolicy)
 		if !ok {
 			return nil, errors.New("not a k8s networkpolicy")
@@ -47,7 +42,6 @@ func (k *mqlK8s) networkPolicies() ([]interface{}, error) {
 			"namespace":       llx.StringData(obj.GetNamespace()),
 			"kind":            llx.StringData(objT.GetKind()),
 			"created":         llx.TimeData(ts.Time),
-			"manifest":        llx.DictData(manifest),
 			"spec":            llx.DictData(spec),
 		})
 		if err != nil {
@@ -56,6 +50,22 @@ func (k *mqlK8s) networkPolicies() ([]interface{}, error) {
 		r.(*mqlK8sNetworkpolicy).obj = networkPolicy
 		return r, nil
 	})
+}
+
+func (k *mqlK8sNetworkpolicy) manifest() (map[string]interface{}, error) {
+	manifest, err := convert.JsonToDict(k.obj)
+	if err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+func (k *mqlK8sNetworkpolicy) spec() (map[string]interface{}, error) {
+	dict, err := convert.JsonToDict(k.obj.Spec)
+	if err != nil {
+		return nil, err
+	}
+	return dict, nil
 }
 
 func (k *mqlK8sNetworkpolicy) id() (string, error) {

--- a/providers/k8s/resources/podsecuritypolicy.go
+++ b/providers/k8s/resources/podsecuritypolicy.go
@@ -23,19 +23,9 @@ func (k *mqlK8s) podSecurityPolicies() ([]interface{}, error) {
 	return k8sResourceToMql(k.MqlRuntime, "podsecuritypolicies", func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
-		manifest, err := convert.JsonToDict(resource)
-		if err != nil {
-			return nil, err
-		}
-
 		psp, ok := resource.(*policyv1beta1.PodSecurityPolicy)
 		if !ok {
 			return nil, errors.New("not a k8s podsecuritypolicy")
-		}
-
-		spec, err := convert.JsonToDict(psp.Spec)
-		if err != nil {
-			return nil, err
 		}
 
 		r, err := CreateResource(k.MqlRuntime, "k8s.podsecuritypolicy", map[string]*llx.RawData{
@@ -45,8 +35,6 @@ func (k *mqlK8s) podSecurityPolicies() ([]interface{}, error) {
 			"name":            llx.StringData(obj.GetName()),
 			"kind":            llx.StringData(objT.GetKind()),
 			"created":         llx.TimeData(ts.Time),
-			"manifest":        llx.DictData(manifest),
-			"spec":            llx.DictData(spec),
 		})
 		if err != nil {
 			return nil, err
@@ -54,6 +42,22 @@ func (k *mqlK8s) podSecurityPolicies() ([]interface{}, error) {
 		r.(*mqlK8sPodsecuritypolicy).obj = psp
 		return r, nil
 	})
+}
+
+func (k *mqlK8sPodsecuritypolicy) manifest() (map[string]interface{}, error) {
+	manifest, err := convert.JsonToDict(k.obj)
+	if err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+func (k *mqlK8sPodsecuritypolicy) spec() (map[string]interface{}, error) {
+	dict, err := convert.JsonToDict(k.obj.Spec)
+	if err != nil {
+		return nil, err
+	}
+	return dict, nil
 }
 
 func (k *mqlK8sPodsecuritypolicy) id() (string, error) {

--- a/providers/k8s/resources/replicaset.go
+++ b/providers/k8s/resources/replicaset.go
@@ -25,21 +25,6 @@ func (k *mqlK8s) replicasets() ([]interface{}, error) {
 	return k8sResourceToMql(k.MqlRuntime, "replicasets", func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
-		manifest, err := convert.JsonToDict(resource)
-		if err != nil {
-			return nil, err
-		}
-
-		podSpec, err := resources.GetPodSpec(resource)
-		if err != nil {
-			return nil, err
-		}
-
-		podSpecDict, err := convert.JsonToDict(podSpec)
-		if err != nil {
-			return nil, err
-		}
-
 		r, err := CreateResource(k.MqlRuntime, "k8s.replicaset", map[string]*llx.RawData{
 			"id":              llx.StringData(objIdFromK8sObj(obj, objT)),
 			"uid":             llx.StringData(string(obj.GetUID())),
@@ -48,8 +33,6 @@ func (k *mqlK8s) replicasets() ([]interface{}, error) {
 			"namespace":       llx.StringData(obj.GetNamespace()),
 			"kind":            llx.StringData(objT.GetKind()),
 			"created":         llx.TimeData(ts.Time),
-			"manifest":        llx.DictData(manifest),
-			"podSpec":         llx.DictData(podSpecDict),
 		})
 		if err != nil {
 			return nil, err
@@ -62,6 +45,26 @@ func (k *mqlK8s) replicasets() ([]interface{}, error) {
 		r.(*mqlK8sReplicaset).obj = rs
 		return r, nil
 	})
+}
+
+func (k *mqlK8sReplicaset) manifest() (map[string]interface{}, error) {
+	manifest, err := convert.JsonToDict(k.obj)
+	if err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+func (k *mqlK8sReplicaset) podSpec() (map[string]interface{}, error) {
+	podSpec, err := resources.GetPodSpec(k.obj)
+	if err != nil {
+		return nil, err
+	}
+	dict, err := convert.JsonToDict(podSpec)
+	if err != nil {
+		return nil, err
+	}
+	return dict, nil
 }
 
 func (k *mqlK8sReplicaset) id() (string, error) {

--- a/providers/k8s/resources/role.go
+++ b/providers/k8s/resources/role.go
@@ -25,11 +25,6 @@ func (k *mqlK8s) roles() ([]interface{}, error) {
 	return k8sResourceToMql(k.MqlRuntime, "roles", func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
-		manifest, err := convert.JsonToDict(resource)
-		if err != nil {
-			return nil, err
-		}
-
 		role, ok := resource.(*rbacv1.Role)
 		if !ok {
 			return nil, errors.New("not a k8s role")
@@ -48,7 +43,6 @@ func (k *mqlK8s) roles() ([]interface{}, error) {
 			"namespace":       llx.StringData(obj.GetNamespace()),
 			"kind":            llx.StringData(objT.GetKind()),
 			"created":         llx.TimeData(ts.Time),
-			"manifest":        llx.DictData(manifest),
 			"rules":           llx.ArrayData(rules, types.Dict),
 		})
 		if err != nil {
@@ -57,6 +51,14 @@ func (k *mqlK8s) roles() ([]interface{}, error) {
 		r.(*mqlK8sRbacRole).obj = role
 		return r, nil
 	})
+}
+
+func (k *mqlK8sRbacRole) manifest() (map[string]interface{}, error) {
+	manifest, err := convert.JsonToDict(k.obj)
+	if err != nil {
+		return nil, err
+	}
+	return manifest, nil
 }
 
 func (k *mqlK8sRbacRole) id() (string, error) {

--- a/providers/k8s/resources/rolebinding.go
+++ b/providers/k8s/resources/rolebinding.go
@@ -25,11 +25,6 @@ func (k *mqlK8s) rolebindings() ([]interface{}, error) {
 	return k8sResourceToMql(k.MqlRuntime, "rolebinding", func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
-		manifest, err := convert.JsonToDict(resource)
-		if err != nil {
-			return nil, err
-		}
-
 		roleBinding, ok := resource.(*rbacv1.RoleBinding)
 		if !ok {
 			return nil, errors.New("not a k8s rolebinding")
@@ -53,7 +48,6 @@ func (k *mqlK8s) rolebindings() ([]interface{}, error) {
 			"namespace":       llx.StringData(obj.GetNamespace()),
 			"kind":            llx.StringData(objT.GetKind()),
 			"created":         llx.TimeData(ts.Time),
-			"manifest":        llx.DictData(manifest),
 			"subjects":        llx.ArrayData(subjects, types.Dict),
 			"roleRef":         llx.DictData(roleRef),
 		})
@@ -63,6 +57,14 @@ func (k *mqlK8s) rolebindings() ([]interface{}, error) {
 		r.(*mqlK8sRbacRolebinding).obj = roleBinding
 		return r, nil
 	})
+}
+
+func (k *mqlK8sRbacRolebinding) manifest() (map[string]interface{}, error) {
+	manifest, err := convert.JsonToDict(k.obj)
+	if err != nil {
+		return nil, err
+	}
+	return manifest, nil
 }
 
 func (k *mqlK8sRbacRolebinding) id() (string, error) {

--- a/providers/k8s/resources/secret.go
+++ b/providers/k8s/resources/secret.go
@@ -25,11 +25,6 @@ func (k *mqlK8s) secrets() ([]interface{}, error) {
 	return k8sResourceToMql(k.MqlRuntime, "secrets.v1.", func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
-		manifest, err := convert.JsonToDict(resource)
-		if err != nil {
-			return nil, err
-		}
-
 		s, ok := resource.(*corev1.Secret)
 		if !ok {
 			return nil, errors.New("not a k8s secret")
@@ -43,7 +38,6 @@ func (k *mqlK8s) secrets() ([]interface{}, error) {
 			"namespace":       llx.StringData(obj.GetNamespace()),
 			"kind":            llx.StringData(objT.GetKind()),
 			"created":         llx.TimeData(ts.Time),
-			"manifest":        llx.DictData(manifest),
 			"type":            llx.StringData(string(s.Type)),
 		})
 		if err != nil {
@@ -53,6 +47,14 @@ func (k *mqlK8s) secrets() ([]interface{}, error) {
 		r.(*mqlK8sSecret).metaObj = obj
 		return r, nil
 	})
+}
+
+func (k *mqlK8sSecret) manifest() (map[string]interface{}, error) {
+	manifest, err := convert.JsonToDict(k.obj)
+	if err != nil {
+		return nil, err
+	}
+	return manifest, nil
 }
 
 func (k *mqlK8sSecret) id() (string, error) {

--- a/providers/k8s/resources/statefulset.go
+++ b/providers/k8s/resources/statefulset.go
@@ -25,21 +25,6 @@ func (k *mqlK8s) statefulsets() ([]interface{}, error) {
 	return k8sResourceToMql(k.MqlRuntime, "statefulsets", func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
-		manifest, err := convert.JsonToDict(resource)
-		if err != nil {
-			return nil, err
-		}
-
-		podSpec, err := resources.GetPodSpec(resource)
-		if err != nil {
-			return nil, err
-		}
-
-		podSpecDict, err := convert.JsonToDict(podSpec)
-		if err != nil {
-			return nil, err
-		}
-
 		r, err := CreateResource(k.MqlRuntime, "k8s.statefulset", map[string]*llx.RawData{
 			"id":              llx.StringData(objIdFromK8sObj(obj, objT)),
 			"uid":             llx.StringData(string(obj.GetUID())),
@@ -48,8 +33,6 @@ func (k *mqlK8s) statefulsets() ([]interface{}, error) {
 			"namespace":       llx.StringData(obj.GetNamespace()),
 			"kind":            llx.StringData(objT.GetKind()),
 			"created":         llx.TimeData(ts.Time),
-			"manifest":        llx.DictData(manifest),
-			"podSpec":         llx.DictData(podSpecDict),
 		})
 		if err != nil {
 			return nil, err
@@ -62,6 +45,26 @@ func (k *mqlK8s) statefulsets() ([]interface{}, error) {
 		r.(*mqlK8sStatefulset).obj = s
 		return r, nil
 	})
+}
+
+func (k *mqlK8sStatefulset) manifest() (map[string]interface{}, error) {
+	manifest, err := convert.JsonToDict(k.obj)
+	if err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+func (k *mqlK8sStatefulset) podSpec() (map[string]interface{}, error) {
+	podSpec, err := resources.GetPodSpec(k.obj)
+	if err != nil {
+		return nil, err
+	}
+	dict, err := convert.JsonToDict(podSpec)
+	if err != nil {
+		return nil, err
+	}
+	return dict, nil
 }
 
 func (k *mqlK8sStatefulset) id() (string, error) {


### PR DESCRIPTION
only calculate specs and manifests when requested. This improves memory usage and allocations for the case where we don't use these fields in queries