### PR TITLE
✨ add inspector resource to show ec2,ecr,lambda coverage

### DIFF
--- a/providers/aws/go.mod
+++ b/providers/aws/go.mod
@@ -105,6 +105,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.5 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.5 // indirect
+	github.com/aws/aws-sdk-go-v2/service/inspector2 v1.24.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.3.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.6 // indirect

--- a/providers/aws/go.sum
+++ b/providers/aws/go.sum
@@ -188,6 +188,10 @@ github.com/aws/aws-sdk-go-v2/service/guardduty v1.41.1 h1:HbecqrH+phcfa2XVmFlJEj
 github.com/aws/aws-sdk-go-v2/service/guardduty v1.41.1/go.mod h1:qXyWkjk60YMVbYEBkQBYqk7d4WJTEPnQzxbWWQ5d6pI=
 github.com/aws/aws-sdk-go-v2/service/iam v1.32.0 h1:ZNlfPdw849gBo/lvLFbEEvpTJMij0LXqiNWZ+lIamlU=
 github.com/aws/aws-sdk-go-v2/service/iam v1.32.0/go.mod h1:aXWImQV0uTW35LM0A/T4wEg6R1/ReXUu4SM6/lUHYK0=
+github.com/aws/aws-sdk-go-v2/service/iam v1.31.4 h1:eVm30ZIDv//r6Aogat9I88b5YX1xASSLcEDqHYRPVl0=
+github.com/aws/aws-sdk-go-v2/service/iam v1.31.4/go.mod h1:aXWImQV0uTW35LM0A/T4wEg6R1/ReXUu4SM6/lUHYK0=
+github.com/aws/aws-sdk-go-v2/service/inspector2 v1.24.4 h1:0cHc8syoJJUzP5N2d6Hhtj3sUIBYUpFYW/p6q91ISko=
+github.com/aws/aws-sdk-go-v2/service/inspector2 v1.24.4/go.mod h1:tyMGN8hc2UtH6e6y6phOqN/O/L68Q8YYKZG2Ydsk3UI=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.2 h1:Ji0DY1xUsUr3I8cHps0G+XM3WWU16lP6yG8qu1GAZAs=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.2/go.mod h1:5CsjAbs3NlGQyZNFACh+zztPDI7fU6eW9QsxjfnuBKg=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.3.7 h1:ZMeFZ5yk+Ek+jNr1+uwCd2tG89t6oTS5yVWpa6yy2es=

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2375,6 +2375,67 @@ private aws.ec2.volume @defaults("id region volumeType size encrypted state") {
   iops int
 }
 
+aws.inspector {
+  // List of coverage results for the AWS account
+	coverages() []aws.inspector.coverage
+}
+
+private aws.inspector.coverage {
+  // AccountId for the coverage finding
+	accountId string
+  // Resource Id for the coverage finding
+	resourceId string
+  // Resource type, e.g. AWS_EC2_INSTANCE
+	resourceType string
+  // Time when the coverage finding was last scanned
+	lastScannedAt time
+  // Reason for the coverage finding status
+  statusReason string
+  // Code for the coverage finding status
+  statusCode string
+  // Type of coverage finding
+  scanType string
+  // Region where it was found
+  region string
+  // Details about the ec2 instance associated with the finding
+	ec2Instance() aws.inspector.coverage.instance
+  // Details about the ecr image associated with the finding
+	ecrImage() aws.inspector.coverage.image
+  // Details about the ecr repo associated with the finding
+	ecrRepo() aws.inspector.coverage.repository
+  // Details about the lambda function associated with the finding
+	lambda() aws.lambda.function
+}
+
+private aws.inspector.coverage.instance {
+  // Platform for the ec2 instance
+  platform string
+  // Tags associated with the ec2 instance
+  tags map[string]string
+  // Image associated with the ec2 instance
+  image aws.ec2.image
+  // Region where the ec2 instance is found
+  region string
+}
+
+private aws.inspector.coverage.image {
+  // Time when the image was scanned
+  imagePulledAt time
+  // Tags associated with the image
+  tags map[string]string
+  // Region where the image is found
+  region string
+}
+
+private aws.inspector.coverage.repository {
+  // Name of the ECR repository
+  name string
+  // Scan frequency of the ECR repo
+  scanFrequency string
+  // Region where the ecr repo is found
+  region string
+}
+
 // Amazon EC2 instance
 private aws.ec2.instance @defaults("instanceId region state instanceType architecture platformDetails") {
   // ARN for the instance

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2377,18 +2377,18 @@ private aws.ec2.volume @defaults("id region volumeType size encrypted state") {
 
 aws.inspector {
   // List of coverage results for the AWS account
-	coverages() []aws.inspector.coverage
+  coverages() []aws.inspector.coverage
 }
 
 private aws.inspector.coverage {
   // AccountId for the coverage finding
-	accountId string
+  accountId string
   // Resource Id for the coverage finding
-	resourceId string
+  resourceId string
   // Resource type, e.g. AWS_EC2_INSTANCE
-	resourceType string
+  resourceType string
   // Time when the coverage finding was last scanned
-	lastScannedAt time
+  lastScannedAt time
   // Reason for the coverage finding status
   statusReason string
   // Code for the coverage finding status
@@ -2398,13 +2398,13 @@ private aws.inspector.coverage {
   // Region where it was found
   region string
   // Details about the ec2 instance associated with the finding
-	ec2Instance() aws.inspector.coverage.instance
+  ec2Instance() aws.inspector.coverage.instance
   // Details about the ecr image associated with the finding
-	ecrImage() aws.inspector.coverage.image
+  ecrImage() aws.inspector.coverage.image
   // Details about the ecr repo associated with the finding
-	ecrRepo() aws.inspector.coverage.repository
+  ecrRepo() aws.inspector.coverage.repository
   // Details about the lambda function associated with the finding
-	lambda() aws.lambda.function
+  lambda() aws.lambda.function
 }
 
 private aws.inspector.coverage.instance {

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -594,6 +594,26 @@ func init() {
 			Init: initAwsEc2Volume,
 			Create: createAwsEc2Volume,
 		},
+		"aws.inspector": {
+			// to override args, implement: initAwsInspector(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsInspector,
+		},
+		"aws.inspector.coverage": {
+			// to override args, implement: initAwsInspectorCoverage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsInspectorCoverage,
+		},
+		"aws.inspector.coverage.instance": {
+			// to override args, implement: initAwsInspectorCoverageInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsInspectorCoverageInstance,
+		},
+		"aws.inspector.coverage.image": {
+			// to override args, implement: initAwsInspectorCoverageImage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsInspectorCoverageImage,
+		},
+		"aws.inspector.coverage.repository": {
+			// to override args, implement: initAwsInspectorCoverageRepository(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsInspectorCoverageRepository,
+		},
 		"aws.ec2.instance": {
 			Init: initAwsEc2Instance,
 			Create: createAwsEc2Instance,
@@ -3382,6 +3402,75 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.volume.iops": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Volume).GetIops()).ToDataRes(types.Int)
+	},
+	"aws.inspector.coverages": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspector).GetCoverages()).ToDataRes(types.Array(types.Resource("aws.inspector.coverage")))
+	},
+	"aws.inspector.coverage.accountId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspectorCoverage).GetAccountId()).ToDataRes(types.String)
+	},
+	"aws.inspector.coverage.resourceId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspectorCoverage).GetResourceId()).ToDataRes(types.String)
+	},
+	"aws.inspector.coverage.resourceType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspectorCoverage).GetResourceType()).ToDataRes(types.String)
+	},
+	"aws.inspector.coverage.lastScannedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspectorCoverage).GetLastScannedAt()).ToDataRes(types.Time)
+	},
+	"aws.inspector.coverage.statusReason": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspectorCoverage).GetStatusReason()).ToDataRes(types.String)
+	},
+	"aws.inspector.coverage.statusCode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspectorCoverage).GetStatusCode()).ToDataRes(types.String)
+	},
+	"aws.inspector.coverage.scanType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspectorCoverage).GetScanType()).ToDataRes(types.String)
+	},
+	"aws.inspector.coverage.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspectorCoverage).GetRegion()).ToDataRes(types.String)
+	},
+	"aws.inspector.coverage.ec2Instance": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspectorCoverage).GetEc2Instance()).ToDataRes(types.Resource("aws.inspector.coverage.instance"))
+	},
+	"aws.inspector.coverage.ecrImage": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspectorCoverage).GetEcrImage()).ToDataRes(types.Resource("aws.inspector.coverage.image"))
+	},
+	"aws.inspector.coverage.ecrRepo": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspectorCoverage).GetEcrRepo()).ToDataRes(types.Resource("aws.inspector.coverage.repository"))
+	},
+	"aws.inspector.coverage.lambda": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspectorCoverage).GetLambda()).ToDataRes(types.Resource("aws.lambda.function"))
+	},
+	"aws.inspector.coverage.instance.platform": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspectorCoverageInstance).GetPlatform()).ToDataRes(types.String)
+	},
+	"aws.inspector.coverage.instance.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspectorCoverageInstance).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.inspector.coverage.instance.image": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspectorCoverageInstance).GetImage()).ToDataRes(types.Resource("aws.ec2.image"))
+	},
+	"aws.inspector.coverage.instance.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspectorCoverageInstance).GetRegion()).ToDataRes(types.String)
+	},
+	"aws.inspector.coverage.image.imagePulledAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspectorCoverageImage).GetImagePulledAt()).ToDataRes(types.Time)
+	},
+	"aws.inspector.coverage.image.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspectorCoverageImage).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.inspector.coverage.image.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspectorCoverageImage).GetRegion()).ToDataRes(types.String)
+	},
+	"aws.inspector.coverage.repository.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspectorCoverageRepository).GetName()).ToDataRes(types.String)
+	},
+	"aws.inspector.coverage.repository.scanFrequency": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspectorCoverageRepository).GetScanFrequency()).ToDataRes(types.String)
+	},
+	"aws.inspector.coverage.repository.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsInspectorCoverageRepository).GetRegion()).ToDataRes(types.String)
 	},
 	"aws.ec2.instance.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetArn()).ToDataRes(types.String)
@@ -7845,6 +7934,118 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.ec2.volume.iops": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Volume).Iops, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlAwsInspector).__id, ok = v.Value.(string)
+			return
+		},
+	"aws.inspector.coverages": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspector).Coverages, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.coverage.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlAwsInspectorCoverage).__id, ok = v.Value.(string)
+			return
+		},
+	"aws.inspector.coverage.accountId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspectorCoverage).AccountId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.coverage.resourceId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspectorCoverage).ResourceId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.coverage.resourceType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspectorCoverage).ResourceType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.coverage.lastScannedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspectorCoverage).LastScannedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.coverage.statusReason": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspectorCoverage).StatusReason, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.coverage.statusCode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspectorCoverage).StatusCode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.coverage.scanType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspectorCoverage).ScanType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.coverage.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspectorCoverage).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.coverage.ec2Instance": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspectorCoverage).Ec2Instance, ok = plugin.RawToTValue[*mqlAwsInspectorCoverageInstance](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.coverage.ecrImage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspectorCoverage).EcrImage, ok = plugin.RawToTValue[*mqlAwsInspectorCoverageImage](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.coverage.ecrRepo": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspectorCoverage).EcrRepo, ok = plugin.RawToTValue[*mqlAwsInspectorCoverageRepository](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.coverage.lambda": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspectorCoverage).Lambda, ok = plugin.RawToTValue[*mqlAwsLambdaFunction](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.coverage.instance.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlAwsInspectorCoverageInstance).__id, ok = v.Value.(string)
+			return
+		},
+	"aws.inspector.coverage.instance.platform": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspectorCoverageInstance).Platform, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.coverage.instance.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspectorCoverageInstance).Tags, ok = plugin.RawToTValue[map[string]interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.coverage.instance.image": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspectorCoverageInstance).Image, ok = plugin.RawToTValue[*mqlAwsEc2Image](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.coverage.instance.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspectorCoverageInstance).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.coverage.image.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlAwsInspectorCoverageImage).__id, ok = v.Value.(string)
+			return
+		},
+	"aws.inspector.coverage.image.imagePulledAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspectorCoverageImage).ImagePulledAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.coverage.image.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspectorCoverageImage).Tags, ok = plugin.RawToTValue[map[string]interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.coverage.image.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspectorCoverageImage).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.coverage.repository.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlAwsInspectorCoverageRepository).__id, ok = v.Value.(string)
+			return
+		},
+	"aws.inspector.coverage.repository.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspectorCoverageRepository).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.coverage.repository.scanFrequency": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspectorCoverageRepository).ScanFrequency, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.inspector.coverage.repository.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsInspectorCoverageRepository).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.instance.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20452,6 +20653,401 @@ func (c *mqlAwsEc2Volume) GetSize() *plugin.TValue[int64] {
 
 func (c *mqlAwsEc2Volume) GetIops() *plugin.TValue[int64] {
 	return &c.Iops
+}
+
+// mqlAwsInspector for the aws.inspector resource
+type mqlAwsInspector struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlAwsInspectorInternal it will be used here
+	Coverages plugin.TValue[[]interface{}]
+}
+
+// createAwsInspector creates a new instance of this resource
+func createAwsInspector(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsInspector{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+	res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.inspector", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsInspector) MqlName() string {
+	return "aws.inspector"
+}
+
+func (c *mqlAwsInspector) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsInspector) GetCoverages() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.Coverages, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.inspector", c.__id, "coverages")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.coverages()
+	})
+}
+
+// mqlAwsInspectorCoverage for the aws.inspector.coverage resource
+type mqlAwsInspectorCoverage struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	mqlAwsInspectorCoverageInternal
+	AccountId plugin.TValue[string]
+	ResourceId plugin.TValue[string]
+	ResourceType plugin.TValue[string]
+	LastScannedAt plugin.TValue[*time.Time]
+	StatusReason plugin.TValue[string]
+	StatusCode plugin.TValue[string]
+	ScanType plugin.TValue[string]
+	Region plugin.TValue[string]
+	Ec2Instance plugin.TValue[*mqlAwsInspectorCoverageInstance]
+	EcrImage plugin.TValue[*mqlAwsInspectorCoverageImage]
+	EcrRepo plugin.TValue[*mqlAwsInspectorCoverageRepository]
+	Lambda plugin.TValue[*mqlAwsLambdaFunction]
+}
+
+// createAwsInspectorCoverage creates a new instance of this resource
+func createAwsInspectorCoverage(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsInspectorCoverage{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+	res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.inspector.coverage", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsInspectorCoverage) MqlName() string {
+	return "aws.inspector.coverage"
+}
+
+func (c *mqlAwsInspectorCoverage) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsInspectorCoverage) GetAccountId() *plugin.TValue[string] {
+	return &c.AccountId
+}
+
+func (c *mqlAwsInspectorCoverage) GetResourceId() *plugin.TValue[string] {
+	return &c.ResourceId
+}
+
+func (c *mqlAwsInspectorCoverage) GetResourceType() *plugin.TValue[string] {
+	return &c.ResourceType
+}
+
+func (c *mqlAwsInspectorCoverage) GetLastScannedAt() *plugin.TValue[*time.Time] {
+	return &c.LastScannedAt
+}
+
+func (c *mqlAwsInspectorCoverage) GetStatusReason() *plugin.TValue[string] {
+	return &c.StatusReason
+}
+
+func (c *mqlAwsInspectorCoverage) GetStatusCode() *plugin.TValue[string] {
+	return &c.StatusCode
+}
+
+func (c *mqlAwsInspectorCoverage) GetScanType() *plugin.TValue[string] {
+	return &c.ScanType
+}
+
+func (c *mqlAwsInspectorCoverage) GetRegion() *plugin.TValue[string] {
+	return &c.Region
+}
+
+func (c *mqlAwsInspectorCoverage) GetEc2Instance() *plugin.TValue[*mqlAwsInspectorCoverageInstance] {
+	return plugin.GetOrCompute[*mqlAwsInspectorCoverageInstance](&c.Ec2Instance, func() (*mqlAwsInspectorCoverageInstance, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.inspector.coverage", c.__id, "ec2Instance")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsInspectorCoverageInstance), nil
+			}
+		}
+
+		return c.ec2Instance()
+	})
+}
+
+func (c *mqlAwsInspectorCoverage) GetEcrImage() *plugin.TValue[*mqlAwsInspectorCoverageImage] {
+	return plugin.GetOrCompute[*mqlAwsInspectorCoverageImage](&c.EcrImage, func() (*mqlAwsInspectorCoverageImage, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.inspector.coverage", c.__id, "ecrImage")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsInspectorCoverageImage), nil
+			}
+		}
+
+		return c.ecrImage()
+	})
+}
+
+func (c *mqlAwsInspectorCoverage) GetEcrRepo() *plugin.TValue[*mqlAwsInspectorCoverageRepository] {
+	return plugin.GetOrCompute[*mqlAwsInspectorCoverageRepository](&c.EcrRepo, func() (*mqlAwsInspectorCoverageRepository, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.inspector.coverage", c.__id, "ecrRepo")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsInspectorCoverageRepository), nil
+			}
+		}
+
+		return c.ecrRepo()
+	})
+}
+
+func (c *mqlAwsInspectorCoverage) GetLambda() *plugin.TValue[*mqlAwsLambdaFunction] {
+	return plugin.GetOrCompute[*mqlAwsLambdaFunction](&c.Lambda, func() (*mqlAwsLambdaFunction, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.inspector.coverage", c.__id, "lambda")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsLambdaFunction), nil
+			}
+		}
+
+		return c.lambda()
+	})
+}
+
+// mqlAwsInspectorCoverageInstance for the aws.inspector.coverage.instance resource
+type mqlAwsInspectorCoverageInstance struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	mqlAwsInspectorCoverageInstanceInternal
+	Platform plugin.TValue[string]
+	Tags plugin.TValue[map[string]interface{}]
+	Image plugin.TValue[*mqlAwsEc2Image]
+	Region plugin.TValue[string]
+}
+
+// createAwsInspectorCoverageInstance creates a new instance of this resource
+func createAwsInspectorCoverageInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsInspectorCoverageInstance{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+	res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.inspector.coverage.instance", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsInspectorCoverageInstance) MqlName() string {
+	return "aws.inspector.coverage.instance"
+}
+
+func (c *mqlAwsInspectorCoverageInstance) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsInspectorCoverageInstance) GetPlatform() *plugin.TValue[string] {
+	return &c.Platform
+}
+
+func (c *mqlAwsInspectorCoverageInstance) GetTags() *plugin.TValue[map[string]interface{}] {
+	return &c.Tags
+}
+
+func (c *mqlAwsInspectorCoverageInstance) GetImage() *plugin.TValue[*mqlAwsEc2Image] {
+	return &c.Image
+}
+
+func (c *mqlAwsInspectorCoverageInstance) GetRegion() *plugin.TValue[string] {
+	return &c.Region
+}
+
+// mqlAwsInspectorCoverageImage for the aws.inspector.coverage.image resource
+type mqlAwsInspectorCoverageImage struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlAwsInspectorCoverageImageInternal it will be used here
+	ImagePulledAt plugin.TValue[*time.Time]
+	Tags plugin.TValue[map[string]interface{}]
+	Region plugin.TValue[string]
+}
+
+// createAwsInspectorCoverageImage creates a new instance of this resource
+func createAwsInspectorCoverageImage(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsInspectorCoverageImage{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+	res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.inspector.coverage.image", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsInspectorCoverageImage) MqlName() string {
+	return "aws.inspector.coverage.image"
+}
+
+func (c *mqlAwsInspectorCoverageImage) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsInspectorCoverageImage) GetImagePulledAt() *plugin.TValue[*time.Time] {
+	return &c.ImagePulledAt
+}
+
+func (c *mqlAwsInspectorCoverageImage) GetTags() *plugin.TValue[map[string]interface{}] {
+	return &c.Tags
+}
+
+func (c *mqlAwsInspectorCoverageImage) GetRegion() *plugin.TValue[string] {
+	return &c.Region
+}
+
+// mqlAwsInspectorCoverageRepository for the aws.inspector.coverage.repository resource
+type mqlAwsInspectorCoverageRepository struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlAwsInspectorCoverageRepositoryInternal it will be used here
+	Name plugin.TValue[string]
+	ScanFrequency plugin.TValue[string]
+	Region plugin.TValue[string]
+}
+
+// createAwsInspectorCoverageRepository creates a new instance of this resource
+func createAwsInspectorCoverageRepository(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsInspectorCoverageRepository{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+	res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.inspector.coverage.repository", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsInspectorCoverageRepository) MqlName() string {
+	return "aws.inspector.coverage.repository"
+}
+
+func (c *mqlAwsInspectorCoverageRepository) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsInspectorCoverageRepository) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAwsInspectorCoverageRepository) GetScanFrequency() *plugin.TValue[string] {
+	return &c.ScanFrequency
+}
+
+func (c *mqlAwsInspectorCoverageRepository) GetRegion() *plugin.TValue[string] {
+	return &c.Region
 }
 
 // mqlAwsEc2Instance for the aws.ec2.instance resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -1881,6 +1881,69 @@ resources:
     platform:
       name:
       - aws
+  aws.inspector:
+    fields:
+      coverage: {}
+      coverages: {}
+    min_mondoo_version: latest
+    platform:
+      name:
+      - aws
+  aws.inspector.coverage:
+    fields:
+      accountId: {}
+      ec2Instance: {}
+      ec2Instances: {}
+      ecrImage: {}
+      ecrImages: {}
+      ecrRepo: {}
+      ecrRepos: {}
+      lambda: {}
+      lambdas: {}
+      lastScannedAt: {}
+      region: {}
+      resourceId: {}
+      resourceType: {}
+      scanStatus: {}
+      scanType: {}
+      statusCode: {}
+      statusReason: {}
+    is_private: true
+    min_mondoo_version: latest
+    platform:
+      name:
+      - aws
+  aws.inspector.coverage.image:
+    fields:
+      imagePulledAt: {}
+      region: {}
+      tags: {}
+    is_private: true
+    min_mondoo_version: latest
+    platform:
+      name:
+      - aws
+  aws.inspector.coverage.instance:
+    fields:
+      image: {}
+      platform: {}
+      region: {}
+      tags: {}
+    is_private: true
+    min_mondoo_version: latest
+    platform:
+      name:
+      - aws
+  aws.inspector.coverage.repository:
+    fields:
+      name: {}
+      region: {}
+      scanFrequency: {}
+    is_private: true
+    min_mondoo_version: latest
+    platform:
+      name:
+      - aws
   aws.kms:
     docs:
       desc: "Use the `aws.kms` resource to assess the configuration of AWS KMS keys.

--- a/providers/aws/resources/aws_inspector.go
+++ b/providers/aws/resources/aws_inspector.go
@@ -1,0 +1,219 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/inspector2"
+	"github.com/aws/aws-sdk-go-v2/service/inspector2/types"
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/v10/llx"
+
+	"go.mondoo.com/cnquery/v10/providers-sdk/v1/plugin"
+	"go.mondoo.com/cnquery/v10/providers-sdk/v1/util/convert"
+	"go.mondoo.com/cnquery/v10/providers-sdk/v1/util/jobpool"
+	"go.mondoo.com/cnquery/v10/providers/aws/connection"
+	llxtypes "go.mondoo.com/cnquery/v10/types"
+)
+
+func (a *mqlAwsInspector) id() (string, error) {
+	return "aws.inspector", nil
+}
+
+func (a *mqlAwsInspectorCoverage) id() (string, error) {
+	return a.AccountId.Data + "/" + a.ResourceId.Data, nil
+}
+
+func (a *mqlAwsInspector) coverages() ([]interface{}, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	res := []interface{}{}
+	poolOfJobs := jobpool.CreatePool(a.getCoverage(conn), 5)
+	poolOfJobs.Run()
+
+	// check for errors
+	if poolOfJobs.HasErrors() {
+		return nil, poolOfJobs.GetErrors()
+	}
+	// get all the results
+	for i := range poolOfJobs.Jobs {
+		res = append(res, poolOfJobs.Jobs[i].Result.([]interface{})...)
+	}
+
+	return res, nil
+}
+
+func (a *mqlAwsInspector) getCoverage(conn *connection.AwsConnection) []*jobpool.Job {
+	tasks := make([]*jobpool.Job, 0)
+	regions, err := conn.Regions()
+	if err != nil {
+		return []*jobpool.Job{{Err: err}}
+	}
+
+	for _, region := range regions {
+		regionVal := region
+		f := func() (jobpool.JobResult, error) {
+			svc := conn.Inspector(regionVal)
+			ctx := context.Background()
+			res := []interface{}{}
+
+			nextToken := aws.String("no_token_to_start_with")
+			params := &inspector2.ListCoverageInput{}
+			for nextToken != nil {
+				coverages, err := svc.ListCoverage(ctx, params)
+				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
+					return nil, err
+				}
+				for _, coverage := range coverages.CoveredResources {
+					if coverage.AccountId == nil || coverage.ResourceId == nil {
+						continue
+					}
+					mqlCoverage, err := CreateResource(a.MqlRuntime, "aws.inspector.coverage",
+						map[string]*llx.RawData{
+							"accountId":     llx.StringDataPtr(coverage.AccountId),
+							"resourceId":    llx.StringDataPtr(coverage.ResourceId),
+							"resourceType":  llx.StringData(string(coverage.ResourceType)),
+							"lastScannedAt": llx.TimeDataPtr(coverage.LastScannedAt),
+							"statusReason":  llx.StringData(string(coverage.ScanStatus.Reason)),
+							"statusCode":    llx.StringData(string(coverage.ScanStatus.StatusCode)),
+							"scanType":      llx.StringData(string(coverage.ScanType)),
+							"region":        llx.StringData(regionVal),
+						},
+					)
+					if err != nil {
+						return nil, err
+					}
+					mqlCoverage.(*mqlAwsInspectorCoverage).cacheCoverage = &coverage
+					res = append(res, mqlCoverage)
+				}
+				nextToken = coverages.NextToken
+				if coverages.NextToken != nil {
+					params.NextToken = nextToken
+				}
+			}
+			return jobpool.JobResult(res), nil
+		}
+		tasks = append(tasks, jobpool.NewJob(f))
+	}
+	return tasks
+}
+
+type mqlAwsInspectorCoverageInternal struct {
+	cacheCoverage *types.CoveredResource
+}
+
+type mqlAwsInspectorCoverageInstanceInternal struct {
+	cacheAmiId string
+}
+
+func (a *mqlAwsInspectorCoverageInstance) id() (string, error) {
+	strTags := ""
+	for k, v := range a.Tags.Data {
+		strTags = strTags + k + "/" + v.(string) + "/"
+	}
+	return a.Region.Data + "/" + strTags, nil
+}
+
+func (a *mqlAwsInspectorCoverage) ec2Instance() (*mqlAwsInspectorCoverageInstance, error) {
+	if a.cacheCoverage != nil && a.cacheCoverage.ResourceMetadata != nil && a.cacheCoverage.ResourceMetadata.Ec2 != nil {
+		conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+		args := map[string]*llx.RawData{
+			"platform": llx.StringData(string(a.cacheCoverage.ResourceMetadata.Ec2.Platform)),
+			"tags":     llx.MapData(mapConversion(a.cacheCoverage.ResourceMetadata.Ec2.Tags), llxtypes.String),
+			"region":   llx.StringData(a.Region.Data),
+		}
+		image, err := NewResource(a.MqlRuntime, "aws.ec2.image", map[string]*llx.RawData{
+			"arn": llx.StringData(fmt.Sprintf(imageArnPattern, a.Region.Data, conn.AccountId(), convert.ToString(a.cacheCoverage.ResourceMetadata.Ec2.AmiId))),
+		})
+		if err == nil {
+			args["image"] = llx.ResourceData(image, "aws.ec2.image")
+		}
+		mqlEc2Instance, err := CreateResource(a.MqlRuntime, "aws.inspector.coverage.instance", args)
+		if err == nil {
+			mqlEc2Instance.(*mqlAwsInspectorCoverageInstance).cacheAmiId = *a.cacheCoverage.ResourceMetadata.Ec2.AmiId
+			return mqlEc2Instance.(*mqlAwsInspectorCoverageInstance), err
+		}
+	}
+	a.Ec2Instance.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
+}
+
+func mapConversion(m map[string]string) map[string]interface{} {
+	newMap := make(map[string]interface{})
+	for k, v := range m {
+		newMap[k] = v
+	}
+	return newMap
+}
+
+func listMapConversion(m []string) map[string]interface{} {
+	newMap := make(map[string]interface{})
+	for _, k := range m {
+		newMap[k] = ""
+	}
+	return newMap
+}
+
+func (a *mqlAwsInspectorCoverageImage) id() (string, error) {
+	tagString := ""
+	for k, v := range a.Tags.Data {
+		tagString = tagString + k + "/" + v.(string) + "/"
+	}
+	return a.Region.Data + "/" + tagString, nil
+}
+
+func (a *mqlAwsInspectorCoverage) ecrImage() (*mqlAwsInspectorCoverageImage, error) {
+	if a.cacheCoverage != nil && a.cacheCoverage.ResourceMetadata != nil && a.cacheCoverage.ResourceMetadata.EcrImage != nil {
+		mqlEcr, err := CreateResource(a.MqlRuntime, "aws.inspector.coverage.image", map[string]*llx.RawData{
+			"tags":          llx.MapData(listMapConversion(a.cacheCoverage.ResourceMetadata.EcrImage.Tags), llxtypes.String),
+			"imagePulledAt": llx.TimeDataPtr(a.cacheCoverage.ResourceMetadata.EcrImage.ImagePulledAt),
+			"region":        llx.StringData(a.Region.Data),
+		})
+		if err == nil {
+			return mqlEcr.(*mqlAwsInspectorCoverageImage), err
+		}
+	}
+	a.EcrImage.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
+}
+
+func (a *mqlAwsInspectorCoverageRepository) id() (string, error) {
+	return a.Region.Data + "/" + a.Name.Data, nil
+}
+
+func (a *mqlAwsInspectorCoverage) ecrRepo() (*mqlAwsInspectorCoverageRepository, error) {
+	if a.cacheCoverage != nil && a.cacheCoverage.ResourceMetadata != nil && a.cacheCoverage.ResourceMetadata.EcrRepository != nil {
+		mqlEcr, err := CreateResource(a.MqlRuntime, "aws.inspector.coverage.repository", map[string]*llx.RawData{
+			"name":          llx.StringDataPtr(a.cacheCoverage.ResourceMetadata.EcrRepository.Name),
+			"scanFrequency": llx.StringData(string(a.cacheCoverage.ResourceMetadata.EcrRepository.ScanFrequency)),
+			"region":        llx.StringData(a.Region.Data),
+		})
+		if err == nil {
+			return mqlEcr.(*mqlAwsInspectorCoverageRepository), err
+		}
+	}
+	a.EcrRepo.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
+}
+
+func (a *mqlAwsInspectorCoverage) lambda() (*mqlAwsLambdaFunction, error) {
+	if a.cacheCoverage != nil && a.cacheCoverage.ResourceMetadata != nil && a.cacheCoverage.ResourceMetadata.LambdaFunction != nil {
+		l, err := NewResource(a.MqlRuntime, "aws.lambda.function",
+			map[string]*llx.RawData{
+				"name":   llx.StringData(*a.cacheCoverage.ResourceMetadata.LambdaFunction.FunctionName),
+				"region": llx.StringData(a.Region.Data),
+			})
+		if err == nil {
+			return l.(*mqlAwsLambdaFunction), nil
+		}
+	}
+	a.Lambda.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
+}


### PR DESCRIPTION
```
  }
  7: {
    scanType: "PACKAGE"
    resourceId: "i------------"
    resourceType: "AWS_EC2_INSTANCE"
    region: "us-east-1"
    ecrRepo: null
    lambda: null
    statusReason: "UNMANAGED_EC2_INSTANCE"
    ecrImage: null
    statusCode: "INACTIVE"
    ec2Instance: aws.inspector.coverage.instance id = us-east-1/owner/patrick@mondoo.com/Name/amazonlinux2-for-ebs-volume-scan/
    lastScannedAt: null
    accountId: "921877-----"
  }
]
```