### PR TITLE
🧹 ensure we grab the non-boot volume when multiple xfs uuid volumes

### DIFF
--- a/providers/os/connection/snapshot/blockdevices_test.go
+++ b/providers/os/connection/snapshot/blockdevices_test.go
@@ -178,3 +178,17 @@ func TestAttachedBlockEntryRhel(t *testing.T) {
 	require.Equal(t, "xfs", info.fstype)
 	require.True(t, strings.Contains(info.name, "nvme1n1"))
 }
+
+func TestAttachedBlockEntryMultipleMatch(t *testing.T) {
+	data, err := os.ReadFile("./testdata/alma9_attached.json")
+	require.NoError(t, err)
+
+	blockEntries := blockDevices{}
+	err = json.Unmarshal(data, &blockEntries)
+	require.NoError(t, err)
+
+	info, err := blockEntries.GetUnnamedBlockEntry()
+	require.NoError(t, err)
+	require.Equal(t, "xfs", info.fstype)
+	require.True(t, strings.Contains(info.name, "xvdh4"))
+}

--- a/providers/os/connection/snapshot/testdata/alma9_attached.json
+++ b/providers/os/connection/snapshot/testdata/alma9_attached.json
@@ -1,0 +1,116 @@
+{
+  "blockdevices": [
+    {
+      "name": "xvda",
+      "fstype": null,
+      "fsver": null,
+      "label": null,
+      "uuid": null,
+      "fsavail": null,
+      "fsuse%": null,
+      "mountpoints": [
+        null
+      ],
+      "children": [
+        {
+          "name": "xvda1",
+          "fstype": "xfs",
+          "fsver": null,
+          "label": "/",
+          "uuid": "3d668946-b9eb-4d6b-acbd-da437d796ee8",
+          "fsavail": "6.4G",
+          "fsuse%": "19%",
+          "mountpoints": [
+            "/"
+          ]
+        },
+        {
+          "name": "xvda127",
+          "fstype": null,
+          "fsver": null,
+          "label": null,
+          "uuid": null,
+          "fsavail": null,
+          "fsuse%": null,
+          "mountpoints": [
+            null
+          ]
+        },
+        {
+          "name": "xvda128",
+          "fstype": "vfat",
+          "fsver": "FAT16",
+          "label": null,
+          "uuid": "1753-28B3",
+          "fsavail": "8.7M",
+          "fsuse%": "13%",
+          "mountpoints": [
+            "/boot/efi"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "xvdh",
+      "fstype": null,
+      "fsver": null,
+      "label": null,
+      "uuid": null,
+      "fsavail": null,
+      "fsuse%": null,
+      "mountpoints": [
+        null
+      ],
+      "children": [
+        {
+          "name": "xvdh1",
+          "fstype": null,
+          "fsver": null,
+          "label": null,
+          "uuid": null,
+          "fsavail": null,
+          "fsuse%": null,
+          "mountpoints": [
+            null
+          ]
+        },
+        {
+          "name": "xvdh2",
+          "fstype": "vfat",
+          "fsver": "FAT16",
+          "label": null,
+          "uuid": "C8BB-FC87",
+          "fsavail": null,
+          "fsuse%": null,
+          "mountpoints": [
+            null
+          ]
+        },
+        {
+          "name": "xvdh3",
+          "fstype": "xfs",
+          "fsver": null,
+          "label": null,
+          "uuid": "31f80bf2-f73c-4350-bd3e-1dfe82e691f9",
+          "fsavail": null,
+          "fsuse%": null,
+          "mountpoints": [
+            null
+          ]
+        },
+        {
+          "name": "xvdh4",
+          "fstype": "xfs",
+          "fsver": null,
+          "label": null,
+          "uuid": "b6b03ca5-4431-4db9-a1fb-f13c8566f779",
+          "fsavail": null,
+          "fsuse%": null,
+          "mountpoints": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
we've seen this on a few machines including almalinux. the boot volume is not labeled as a boot volume. we've consistently seen in this case that the last of the matching entries is the volume we want. this slight change in logic allows us to ensure we get the last matching entry of the entries.

example:
```
{
               "name": "xvdh3",
               "fstype": "xfs",
               "fsver": null,
               "label": null,
               "uuid": "bea841a6-6299-40c4-9586-87fedcd61150",
               "fsavail": null,
               "fsuse%": null,
               "mountpoints": [
                   null
               ]
            },{
               "name": "xvdh4",
               "fstype": "xfs",
               "fsver": null,
               "label": null,
               "uuid": "e2445d71-21eb-4c58-a6f7-f8009badd586",
               "fsavail": null,
               "fsuse%": null,
               "mountpoints": [
                   null
               ]
            }
```
xvdh3 is actually a boot volume, xvdh4 is what we care about