### PR TITLE
🐛 fix provider shutdown race condition

### DIFF
--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -203,17 +203,9 @@ func (c *coordinator) RemoveRuntime(runtime *Runtime) {
 		}
 	}
 
-	// Analyze the providers that are still being used by active runtimes
-	usedProviders := map[string]struct{}{}
-	for _, r := range c.runtimes {
-		for _, p := range r.providers {
-			usedProviders[p.Instance.ID] = struct{}{}
-		}
-	}
-
 	// Shutdown any providers that are not being used anymore
-	for id, p := range c.runningByID {
-		if _, ok := usedProviders[id]; !ok {
+	if len(c.runtimes) == 0 {
+		for _, p := range c.runningByID {
 			log.Debug().Msg("shutting down unused provider " + p.Name)
 			if err := c.stop(p); err != nil {
 				log.Warn().Err(err).Str("provider", p.Name).Msg("failed to shut down provider")

--- a/providers/coordinator_test.go
+++ b/providers/coordinator_test.go
@@ -113,6 +113,7 @@ func TestRemoveRuntime_StopUnusedProvider(t *testing.T) {
 
 	// Setup another provider with another runtime
 	mockPlugin2 := NewMockProviderPlugin(ctrl)
+	mockPlugin2.EXPECT().Shutdown(gomock.Any()).Times(1).Return(nil, nil)
 	p2 := &RunningProvider{
 		ID:     "provider2",
 		Plugin: mockPlugin2,
@@ -140,12 +141,12 @@ func TestRemoveRuntime_StopUnusedProvider(t *testing.T) {
 		},
 	}
 
-	// Remove the first runtime
+	// Remove all runtimes
 	c.RemoveRuntime(r1)
+	c.RemoveRuntime(r2)
 
-	// Verify that the first provider is stopped
-	assert.NotContains(t, c.runningByID, "provider1")
-	assert.Contains(t, c.runningByID, "provider2")
+	// Verify that all provider are stopped
+	assert.Empty(t, c.runningByID)
 }
 
 func TestRemoveRuntime_UsedProvider(t *testing.T) {


### PR DESCRIPTION
We have a race condition where providers can be killed at the moment a scan is starting. Then we see errors like: https://github.com/mondoohq/mondoo-operator/issues/1091 This problem occurs specifically when we can start concurrent scans with a single cnspec instance. Currently, that is only when using `serve-api` command.

The issue is that the providers list in runtime isn't using a lock so we can run into race conditions. I changed the implementation to only kill providers if there are no active runtimes, since at the moment we don't have a thread-safe way to compare the providers for each runtime