### PR TITLE
🧹 use new filters

### DIFF
--- a/sbom/sbom.mql.yaml
+++ b/sbom/sbom.mql.yaml
@@ -5,7 +5,7 @@ packs:
   - uid: mondoo-sbom
     name: Mondoo SBOM
     filters:
-      - asset.family.contains("unix")
+      - mql: asset.family.contains("unix")
     queries:
       - uid: mondoo-sbom-asset
         title: Retrieve information about the Platform
@@ -21,7 +21,7 @@ packs:
         mql: npm.packages { name version purl cpes.map(uri) files.map(path) }
       - uid: mondoo-sbom-kernel-installed
         filters:
-          - asset.family.contains('linux')
-          - asset.runtime != 'container' && asset.kind != 'container' && asset.kind != 'container-image'
+          - mql: asset.family.contains('linux')
+          - mql: asset.runtime != 'container' && asset.kind != 'container' && asset.kind != 'container-image'
         title: Retrieve information about the installed kernel
         mql: kernel.installed


### PR DESCRIPTION
This updates the pack to use the latest filter structure to avoid warnings on command line:

```
! Found an old use of filters (as a list of strings). This will be removed in the next major version. Please migrate to:
- mql: filter 1
- mql: filter 2
```