### PR TITLE
🐛 return the rpm version including the release when static analysis is used

### DIFF
--- a/providers/os/resources/packages/rpm_packages.go
+++ b/providers/os/resources/packages/rpm_packages.go
@@ -256,7 +256,12 @@ func (rpm *RpmPkgManager) staticList() ([]Package, error) {
 
 	resultList := []Package{}
 	for _, pkg := range pkgList {
-		rpmPkg := newRpmPackage(rpm.platform, pkg.Name, pkg.Version, pkg.Arch, strconv.Itoa(pkg.EpochNum()), pkg.Summary)
+		version := pkg.Version
+		if pkg.Release != "" {
+			version = version + "-" + pkg.Release
+		}
+
+		rpmPkg := newRpmPackage(rpm.platform, pkg.Name, version, pkg.Arch, strconv.Itoa(pkg.EpochNum()), pkg.Summary)
 
 		// determine all files attached
 		records := []FileRecord{}


### PR DESCRIPTION
For versions like `attr 2.4.48-1.ph4` we only returned `attr 2.4.48` and `-1.ph4` was missing.