### PR TITLE
🧹 default to MQL asset context

### DIFF
--- a/featureflags.go
+++ b/featureflags.go
@@ -66,7 +66,8 @@ const (
 	// MQLAssetContext feature flag
 	//
 	// start: v7.0
-	// end:   v8.0
+	// updated: v11.0  We default to embed flags and re-use this feature for actual asset context
+	// end:   v12.0
 	MQLAssetContext
 
 	// ErrorsAsFailures feature flag

--- a/llx/llx.go
+++ b/llx/llx.go
@@ -693,15 +693,17 @@ func pargs2argmap(b *blockExecutor, ref uint64, args []*Primitive) (map[string]*
 
 func (b *blockExecutor) createResource(name string, binding uint64, f *Function, ref uint64) (*RawData, uint64, error) {
 	runtime := b.ctx.runtime
-	if binding != 0 {
-		panic("NOT SURE HOW TO RESOLVE THIS")
-		// res, dref, err := b.resolveRef(binding, ref)
-		// if dref != 0 || err != nil {
-		// 	return res, dref, err
-		// }
-		// mqlResource := res.Value.(resourceInterface).MqlResource()
-		// runtime = mqlResource.MqlRuntime
-	}
+	// if binding != 0 {
+	// // This happens with aliases, like:
+	// // > os.unix.sshd.config.file.path
+	// // TODO: Re-connect cross-provider resource calls in this part
+	// res, dref, err := b.resolveRef(binding, ref)
+	// if dref != 0 || err != nil {
+	// 	return res, dref, err
+	// }
+	// mqlResource := res.Value.(resourceInterface).MqlResource()
+	// // runtime = mqlResource.MqlRuntime
+	// }
 
 	args, rref, err := pargs2argmap(b, ref, f.Args)
 	if err != nil || rref != 0 {

--- a/mql/mql_test.go
+++ b/mql/mql_test.go
@@ -150,7 +150,7 @@ func TestResourceAliases(t *testing.T) {
 				"_":   llx.ResourceData(&llx.MockResource{Name: "sshd"}, "os.unix.sshd"),
 				"__s": llx.NilData,
 				"__t": llx.BoolData(true),
-				"k6rlXoYpV48Qd19gKeNl+/IiPnkI5VNQBiqZBca3gDKsIRiLcpXQUlDv52x9sscIWiqOMpC7+x/aBpY0IUq0ww==": llx.StringData("/etc/ssh/sshd_config"),
+				"SM/iGp+gb6JBt0bBm5RWqTtPLKzx6ebI+nUm4Q6LCQDuEu1QSRsWqEI3Tl/oK+u0b0eit+nTLhNdjlsOdIIDJQ==": llx.StringData("/etc/ssh/sshd_config"),
 			},
 		},
 	})


### PR DESCRIPTION
We had this feature-flag since v7, aimed to make it the default in v8. Until now, it has not been mainlined.

This is changing today. Compiling with context is generally very helpful and provides nice auto-complete on embedded resources (similar to how you can access embedded fields in golang structs).

There is more work to be done, namely that we want to tie the context of the connection to the MQL execution itself. This will allow us to call fields without constantly refering to the global context in the future. (i.e. instead of `docker.file.sth`, once you connect to a Dockerfile you can just call `sth`). For this reason, we retain the feature-flag and will complete its functionality in this major release.

Note: I deactivated one level of functionality which had been degraded since v9, namely: cross-provider calling of MQL queries. We are restoring this with provider provider initialization (which hasn't been added yet). The release of v9 had removed this because providers were then individually packaged and structured and we hadn't yet had the time to migrate this functionality. Without the change in this PR, these types of calls/usages all resulted in a panic, jfyi