### PR TITLE
Add securityGroups, availabilityZones, and hostedZoneId to ELBs

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1096,6 +1096,10 @@ private aws.elb.loadbalancer @defaults("arn name") {
   vpcId string
   // Date and time when the load balancer was created
   createdTime time
+  // Availability zone where the load balancer runs
+  availabilityZones []string
+  // VPC security groups for the load balancer
+  securityGroups []aws.ec2.securitygroup
 }
 
 // AWS CodeBuild for building and testing code

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1100,6 +1100,8 @@ private aws.elb.loadbalancer @defaults("arn name") {
   availabilityZones []string
   // VPC security groups for the load balancer
   securityGroups []aws.ec2.securitygroup
+  // The ID of the Amazon Route 53 hosted zone associated with the load balancer
+  hostedZoneId string
 }
 
 // AWS CodeBuild for building and testing code

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -1934,6 +1934,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.elb.loadbalancer.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbLoadbalancer).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
 	},
+	"aws.elb.loadbalancer.hostedZoneId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElbLoadbalancer).GetHostedZoneId()).ToDataRes(types.String)
+	},
 	"aws.codebuild.projects": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCodebuild).GetProjects()).ToDataRes(types.Array(types.Resource("aws.codebuild.project")))
 	},
@@ -5704,6 +5707,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.elb.loadbalancer.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElbLoadbalancer).SecurityGroups, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.elb.loadbalancer.hostedZoneId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElbLoadbalancer).HostedZoneId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.codebuild.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -14225,6 +14232,7 @@ type mqlAwsElbLoadbalancer struct {
 	CreatedTime plugin.TValue[*time.Time]
 	AvailabilityZones plugin.TValue[[]interface{}]
 	SecurityGroups plugin.TValue[[]interface{}]
+	HostedZoneId plugin.TValue[string]
 }
 
 // createAwsElbLoadbalancer creates a new instance of this resource
@@ -14306,6 +14314,10 @@ func (c *mqlAwsElbLoadbalancer) GetAvailabilityZones() *plugin.TValue[[]interfac
 
 func (c *mqlAwsElbLoadbalancer) GetSecurityGroups() *plugin.TValue[[]interface{}] {
 	return &c.SecurityGroups
+}
+
+func (c *mqlAwsElbLoadbalancer) GetHostedZoneId() *plugin.TValue[string] {
+	return &c.HostedZoneId
 }
 
 // mqlAwsCodebuild for the aws.codebuild resource

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -1928,6 +1928,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.elb.loadbalancer.createdTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbLoadbalancer).GetCreatedTime()).ToDataRes(types.Time)
 	},
+	"aws.elb.loadbalancer.availabilityZones": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElbLoadbalancer).GetAvailabilityZones()).ToDataRes(types.Array(types.String))
+	},
+	"aws.elb.loadbalancer.securityGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElbLoadbalancer).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
+	},
 	"aws.codebuild.projects": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCodebuild).GetProjects()).ToDataRes(types.Array(types.Resource("aws.codebuild.project")))
 	},
@@ -5690,6 +5696,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.elb.loadbalancer.createdTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElbLoadbalancer).CreatedTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.elb.loadbalancer.availabilityZones": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElbLoadbalancer).AvailabilityZones, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.elb.loadbalancer.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElbLoadbalancer).SecurityGroups, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
 	"aws.codebuild.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -14209,6 +14223,8 @@ type mqlAwsElbLoadbalancer struct {
 	Attributes plugin.TValue[[]interface{}]
 	VpcId plugin.TValue[string]
 	CreatedTime plugin.TValue[*time.Time]
+	AvailabilityZones plugin.TValue[[]interface{}]
+	SecurityGroups plugin.TValue[[]interface{}]
 }
 
 // createAwsElbLoadbalancer creates a new instance of this resource
@@ -14282,6 +14298,14 @@ func (c *mqlAwsElbLoadbalancer) GetVpcId() *plugin.TValue[string] {
 
 func (c *mqlAwsElbLoadbalancer) GetCreatedTime() *plugin.TValue[*time.Time] {
 	return &c.CreatedTime
+}
+
+func (c *mqlAwsElbLoadbalancer) GetAvailabilityZones() *plugin.TValue[[]interface{}] {
+	return &c.AvailabilityZones
+}
+
+func (c *mqlAwsElbLoadbalancer) GetSecurityGroups() *plugin.TValue[[]interface{}] {
+	return &c.SecurityGroups
 }
 
 // mqlAwsCodebuild for the aws.codebuild resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -1572,6 +1572,8 @@ resources:
       createdTime:
         min_mondoo_version: 9.0.0
       dnsName: {}
+      hostedZoneId:
+        min_mondoo_version: 9.0.0
       listenerDescriptions: {}
       name: {}
       scheme: {}

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -1567,12 +1567,16 @@ resources:
     fields:
       arn: {}
       attributes: {}
+      availabilityZones:
+        min_mondoo_version: 9.0.0
       createdTime:
         min_mondoo_version: 9.0.0
       dnsName: {}
       listenerDescriptions: {}
       name: {}
       scheme: {}
+      securityGroups:
+        min_mondoo_version: 9.0.0
       vpcId:
         min_mondoo_version: 9.0.0
     is_private: true

--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -171,6 +171,7 @@ func (a *mqlAwsElb) getLoadBalancers(conn *connection.AwsConnection) []*jobpool.
 							"availabilityZones": llx.ArrayData(availabilityZones, types.String),
 							"createdTime":       llx.TimeDataPtr(lb.CreatedTime),
 							"dnsName":           llx.StringDataPtr(lb.DNSName),
+							"hostedZoneId":      llx.StringDataPtr(lb.CanonicalHostedZoneId),
 							"name":              llx.StringDataPtr(lb.LoadBalancerName),
 							"scheme":            llx.StringData(string(lb.Scheme)),
 							"securityGroups":    llx.ArrayData(sgs, types.Resource("aws.ec2.securitygroup")),


### PR DESCRIPTION
This is pretty important information for a load balancer

```coffee
aws.elb.loadBalancers.first: {
  securityGroups: [
    0: aws.ec2.securitygroup id="sg-1234567" name="default" region="us-west-2" vpc.id="vpc-1234567"
  ]
  hostedZoneId: "12345678910"
  availabilityZones: [
    0: "us-west-2b"
    1: "us-west-2a"
  ]
}
```