### PR TITLE
Replace vpcId with vpc in the elb resource

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1092,7 +1092,7 @@ private aws.elb.loadbalancer @defaults("name region elbType scheme vpcId dnsName
   scheme string
   // A list of attributes for the load balancer
   attributes() []dict
-  // The ID of the VPC where the load balancer is located
+  // Deprecated. Use vpc instead
   vpcId string
   // Date and time when the load balancer was created
   createdTime time
@@ -1106,6 +1106,8 @@ private aws.elb.loadbalancer @defaults("name region elbType scheme vpcId dnsName
   region string
   // The type of ELB. Possible values are `network`, `application`, or `gateway`
   elbType string
+  // VPC where the load balancer is located
+  vpc aws.vpc
 }
 
 // AWS CodeBuild for building and testing code

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -1943,6 +1943,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.elb.loadbalancer.elbType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbLoadbalancer).GetElbType()).ToDataRes(types.String)
 	},
+	"aws.elb.loadbalancer.vpc": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElbLoadbalancer).GetVpc()).ToDataRes(types.Resource("aws.vpc"))
+	},
 	"aws.codebuild.projects": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCodebuild).GetProjects()).ToDataRes(types.Array(types.Resource("aws.codebuild.project")))
 	},
@@ -5725,6 +5728,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.elb.loadbalancer.elbType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElbLoadbalancer).ElbType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.elb.loadbalancer.vpc": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElbLoadbalancer).Vpc, ok = plugin.RawToTValue[*mqlAwsVpc](v.Value, v.Error)
 		return
 	},
 	"aws.codebuild.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -14249,6 +14256,7 @@ type mqlAwsElbLoadbalancer struct {
 	HostedZoneId plugin.TValue[string]
 	Region plugin.TValue[string]
 	ElbType plugin.TValue[string]
+	Vpc plugin.TValue[*mqlAwsVpc]
 }
 
 // createAwsElbLoadbalancer creates a new instance of this resource
@@ -14342,6 +14350,10 @@ func (c *mqlAwsElbLoadbalancer) GetRegion() *plugin.TValue[string] {
 
 func (c *mqlAwsElbLoadbalancer) GetElbType() *plugin.TValue[string] {
 	return &c.ElbType
+}
+
+func (c *mqlAwsElbLoadbalancer) GetVpc() *plugin.TValue[*mqlAwsVpc] {
+	return &c.Vpc
 }
 
 // mqlAwsCodebuild for the aws.codebuild resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -1583,6 +1583,8 @@ resources:
       scheme: {}
       securityGroups:
         min_mondoo_version: 9.0.0
+      vpc:
+        min_mondoo_version: 9.0.0
       vpcId:
         min_mondoo_version: 9.0.0
     is_private: true

--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -177,19 +177,19 @@ func (a *mqlAwsElb) getLoadBalancers(conn *connection.AwsConnection) []*jobpool.
 						"vpcId":             llx.StringDataPtr(lb.VpcId),
 						"elbType":           llx.StringData(string(lb.Type)),
 						"region":            llx.StringData(regionVal),
+						"vpc":               llx.NilData, // set vpc to nil as default, if vpc is not set
 					}
 
-					mqlVpc, err := NewResource(a.MqlRuntime, "aws.vpc",
-						map[string]*llx.RawData{
-							"arn": llx.StringData(fmt.Sprintf(vpcArnPattern, regionVal, conn.AccountId(), convert.ToString(lb.VpcId))),
-						})
-					if err != nil {
-						return nil, err
-					}
-					if mqlVpc != nil {
+					if lb.VpcId != nil {
+						mqlVpc, err := NewResource(a.MqlRuntime, "aws.vpc",
+							map[string]*llx.RawData{
+								"arn": llx.StringData(fmt.Sprintf(vpcArnPattern, regionVal, conn.AccountId(), convert.ToString(lb.VpcId))),
+							})
+						if err != nil {
+							return nil, err
+						}
+						// update the vpc setting
 						args["vpc"] = llx.ResourceData(mqlVpc, mqlVpc.MqlName())
-					} else {
-						args["vpc"] = llx.NilData
 					}
 
 					mqlLb, err := CreateResource(a.MqlRuntime, "aws.elb.loadbalancer", args)


### PR DESCRIPTION
Instead of giving someone an ID we should give them the actual resource. This is where MQL really shines. This is somewhat copy/paste from ec2 land.

```coffee
aws.elb.loadBalancers.first.vpc: {
  state: "available"
  region: "us-west-2"
  cidrBlock: "172.31.0.0/16"
  instanceTenancy: "default"
  arn: "arn:aws:vpc:us-west-2:12345678910:id/vpc-1234567"
  id: "vpc-1234567"
  routeTables: [
    0: aws.vpc.routetable id="rtb-1234567" routes.length=2
  ]
  endpoints: []
  isDefault: true
  tags: {}
  flowLogs: []
  subnets: [
    0: aws.vpc.subnet id="subnet-1234567" cidrs="172.31.32.0/20" availabilityZone="us-west-2a" defaultForAvailabilityZone=true
    1: aws.vpc.subnet id="subnet-1234567" cidrs="172.31.0.0/20" availabilityZone="us-west-2c" defaultForAvailabilityZone=true
    2: aws.vpc.subnet id="subnet-1234567" cidrs="172.31.48.0/20" availabilityZone="us-west-2d" defaultForAvailabilityZone=true
    3: aws.vpc.subnet id="subnet-1234567" cidrs="172.31.16.0/20" availabilityZone="us-west-2b" defaultForAvailabilityZone=true
  ]
}
```