### PR TITLE
✨ dockerfile.expose

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -786,6 +786,16 @@ docker.file.stage @defaults("from.name") {
   add []docker.file.add
   // COPY instructions in this Dockerfile
   copy []docker.file.copy
+  // EXPOSE instructions in this Dockerfile
+  expose []docker.file.expose
+}
+
+// Dockerfile expose instruction
+docker.file.expose @defaults("port protocol") {
+  // Port that is exposed
+  port int
+  // Protocol that is exposed (evaluates to `tcp` if not specified)
+  protocol string
 }
 
 // Dockerfile from instructions

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -254,6 +254,10 @@ func init() {
 			// to override args, implement: initDockerFileStage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createDockerFileStage,
 		},
+		"docker.file.expose": {
+			// to override args, implement: initDockerFileExpose(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createDockerFileExpose,
+		},
 		"docker.file.from": {
 			// to override args, implement: initDockerFileFrom(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createDockerFileFrom,
@@ -1323,6 +1327,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"docker.file.stage.copy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDockerFileStage).GetCopy()).ToDataRes(types.Array(types.Resource("docker.file.copy")))
+	},
+	"docker.file.stage.expose": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFileStage).GetExpose()).ToDataRes(types.Array(types.Resource("docker.file.expose")))
+	},
+	"docker.file.expose.port": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFileExpose).GetPort()).ToDataRes(types.Int)
+	},
+	"docker.file.expose.protocol": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFileExpose).GetProtocol()).ToDataRes(types.String)
 	},
 	"docker.file.from.platform": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDockerFileFrom).GetPlatform()).ToDataRes(types.String)
@@ -3471,6 +3484,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"docker.file.stage.copy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDockerFileStage).Copy, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"docker.file.stage.expose": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileStage).Expose, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"docker.file.expose.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlDockerFileExpose).__id, ok = v.Value.(string)
+			return
+		},
+	"docker.file.expose.port": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileExpose).Port, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"docker.file.expose.protocol": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileExpose).Protocol, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"docker.file.from.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9476,6 +9505,7 @@ type mqlDockerFileStage struct {
 	Entrypoint plugin.TValue[*mqlDockerFileRun]
 	Add plugin.TValue[[]interface{}]
 	Copy plugin.TValue[[]interface{}]
+	Expose plugin.TValue[[]interface{}]
 }
 
 // createDockerFileStage creates a new instance of this resource
@@ -9540,6 +9570,59 @@ func (c *mqlDockerFileStage) GetAdd() *plugin.TValue[[]interface{}] {
 
 func (c *mqlDockerFileStage) GetCopy() *plugin.TValue[[]interface{}] {
 	return &c.Copy
+}
+
+func (c *mqlDockerFileStage) GetExpose() *plugin.TValue[[]interface{}] {
+	return &c.Expose
+}
+
+// mqlDockerFileExpose for the docker.file.expose resource
+type mqlDockerFileExpose struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlDockerFileExposeInternal it will be used here
+	Port plugin.TValue[int64]
+	Protocol plugin.TValue[string]
+}
+
+// createDockerFileExpose creates a new instance of this resource
+func createDockerFileExpose(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlDockerFileExpose{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("docker.file.expose", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlDockerFileExpose) MqlName() string {
+	return "docker.file.expose"
+}
+
+func (c *mqlDockerFileExpose) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlDockerFileExpose) GetPort() *plugin.TValue[int64] {
+	return &c.Port
+}
+
+func (c *mqlDockerFileExpose) GetProtocol() *plugin.TValue[string] {
+	return &c.Protocol
 }
 
 // mqlDockerFileFrom for the docker.file.from resource

--- a/providers/os/resources/os.lr.manifest.yaml
+++ b/providers/os/resources/os.lr.manifest.yaml
@@ -143,6 +143,11 @@ resources:
       dst: {}
       src: {}
     min_mondoo_version: latest
+  docker.file.expose:
+    fields:
+      port: {}
+      protocol: {}
+    min_mondoo_version: latest
   docker.file.from:
     fields:
       digest: {}
@@ -162,6 +167,7 @@ resources:
       copy: {}
       entrypoint: {}
       env: {}
+      expose: {}
       file: {}
       from: {}
       run: {}

--- a/providers/os/resources/os.lr.manifest.yaml
+++ b/providers/os/resources/os.lr.manifest.yaml
@@ -147,7 +147,7 @@ resources:
     fields:
       port: {}
       protocol: {}
-    min_mondoo_version: latest
+    min_mondoo_version: 9.0.0
   docker.file.from:
     fields:
       digest: {}


### PR DESCRIPTION
1. Adds support for the `EXPOSE` keyword in dockerfiles. Adds them as a list of entries and defaults the protocol if not set
2. Fixes a bug where IDs were not set for a range of docker resources
3. Removes the warnings for unsupported keywords in Dockerfiles. We already know what can be supported by looking at the fields we expose.

Looking deeper into the library too, we have a bit more work to properly support some of the contextual keywords...