### PR TITLE
🐛 fix int-map key types

### DIFF
--- a/llx/data_conversions.go
+++ b/llx/data_conversions.go
@@ -286,7 +286,7 @@ func stringmap2result(value interface{}, typ types.Type) (*Primitive, error) {
 }
 
 func intmap2result(value interface{}, typ types.Type) (*Primitive, error) {
-	m, ok := value.(map[int32]interface{})
+	m, ok := value.(map[int64]interface{})
 	if !ok {
 		return nil, errInvalidConversion(value, typ)
 	}
@@ -294,7 +294,7 @@ func intmap2result(value interface{}, typ types.Type) (*Primitive, error) {
 	ct := typ.Child()
 	var err error
 	for k, v := range m {
-		res[strconv.FormatInt(int64(k), 10)], err = raw2primitive(v, ct)
+		res[strconv.FormatInt(k, 10)], err = raw2primitive(v, ct)
 		if err != nil {
 			return nil, err
 		}

--- a/llx/rawdata.go
+++ b/llx/rawdata.go
@@ -322,7 +322,7 @@ func isTruthy(data interface{}, typ types.Type) (bool, bool) {
 			}
 
 		case types.Int:
-			m := data.(map[int]interface{})
+			m := data.(map[int64]interface{})
 			for _, v := range m {
 				t1, f1 := isTruthy(v, typ.Child())
 				if f1 {


### PR DESCRIPTION
We currently don't have deep support for int-maps, since we don't have any use-cases for them yet. That said, they have been supported in the underlying stack for when we need them. Unfortunately a few of the supporting elements have been out of sync.

This change aligns data conversions in llx to use int64 maps. Ditto for `isTruthy` in rawdata. There are a few more to tackle...