### PR TITLE
🎉 aws-11.0.3, gcp-11.0.3, azure-11.0.3

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "11.0.2",
+	Version:         "11.0.3",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "azure",
 	ID:      "go.mondoo.com/cnquery/v9/providers/azure",
-	Version: "11.0.2",
+	Version: "11.0.3",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(azureinstancesnapshot.SnapshotConnectionType),

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "11.0.2",
+	Version: "11.0.3",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
This release was created by cnquery's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.