### PR TITLE
🐛 gcp: add compute scope when listing zones

### DIFF
--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -166,7 +166,7 @@ func (g *mqlGcpProjectComputeService) zones() ([]interface{}, error) {
 
 	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
 
-	client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope)
+	client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope, compute.ComputeReadonlyScope)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I got this error when scanning a gcp project with a service account:
```
error: rpc error: code = Unknown desc = googleapi: Error 403: Request had insufficient authentication scopes.
Details:
[
  {
    "@type": "type.googleapis.com/google.rpc.ErrorInfo",
    "domain": "googleapis.com",
    "metadatas": {
      "method": "compute.v1.ZonesService.List",
      "service": "compute.googleapis.com"
    },
    "reason": "ACCESS_TOKEN_SCOPE_INSUFFICIENT"
  }
]

More details:
Reason: insufficientPermissions, Message: Insufficient Permission
```

the change fixes it
