### PR TITLE
🧹 introduce a new --team-id argument for slack provider

### DIFF
--- a/providers/slack/config/config.go
+++ b/providers/slack/config/config.go
@@ -28,6 +28,12 @@ var Config = plugin.Provider{
 					Default: "",
 					Desc:    "Slack API token",
 				},
+				{
+					Long:    "team-id",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "Team ID (required for org token)",
+				},
 			},
 		},
 	},

--- a/providers/slack/provider/provider.go
+++ b/providers/slack/provider/provider.go
@@ -36,7 +36,16 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	}
 
 	conf := &inventory.Config{
-		Type: req.Connector,
+		Type:    req.Connector,
+		Options: map[string]string{},
+	}
+
+	teamID := ""
+	if x, ok := flags["team-id"]; ok && len(x.Value) != 0 {
+		teamID = string(x.Value)
+	}
+	if teamID != "" {
+		conf.Options["team-id"] = teamID
 	}
 
 	token := ""
@@ -162,7 +171,9 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 }
 
 func (s *Service) detect(asset *inventory.Asset, conn *connection.SlackConnection) error {
-	asset.Name = "Slack team " + conn.TeamName()
+	teamInfo := conn.TeamInfo()
+
+	asset.Name = "Slack team " + teamInfo.Name
 	asset.Platform = &inventory.Platform{
 		Name:    "slack-team",
 		Family:  []string{"slack"},
@@ -170,6 +181,6 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.SlackConnectio
 		Title:   "Slack Team",
 		Runtime: "slack",
 	}
-	asset.PlatformIds = []string{"//platformid.api.mondoo.app/runtime/slack/team/" + conn.TeamID()}
+	asset.PlatformIds = []string{"//platformid.api.mondoo.app/runtime/slack/team/" + teamInfo.ID}
 	return nil
 }

--- a/providers/slack/resources/team.go
+++ b/providers/slack/resources/team.go
@@ -23,11 +23,7 @@ func initSlackTeam(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[s
 		return nil, nil, errors.New("cannot retrieve new data while using a mock connection")
 	}
 
-	teamInfo, err := client.GetTeamInfo()
-	if err != nil {
-		return nil, nil, err
-	}
-
+	teamInfo := conn.TeamInfo()
 	args["id"] = llx.StringData(teamInfo.ID)
 	args["name"] = llx.StringData(teamInfo.Name)
 	args["domain"] = llx.StringData(teamInfo.Domain)

--- a/providers/slack/resources/users.go
+++ b/providers/slack/resources/users.go
@@ -28,14 +28,8 @@ func (s *mqlSlackUsers) list() ([]interface{}, error) {
 
 	ctx := context.Background()
 
-	// get team id
-	teamInfo, err := client.GetTeamInfo()
-	if err != nil {
-		return nil, err
-	}
-
 	// requires users:read scope
-	users, err := client.GetUsersContext(ctx, slack.GetUsersOptionTeamID(teamInfo.ID), slack.GetUsersOptionLimit(999))
+	users, err := client.GetUsersContext(ctx, slack.GetUsersOptionTeamID(conn.TeamInfo().ID), slack.GetUsersOptionLimit(999))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change is required to support org tokens which supports accessing multiple teams.