### PR TITLE
🎉 slack-11.0.4

### DIFF
--- a/providers/slack/config/config.go
+++ b/providers/slack/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "slack",
 	ID:              "go.mondoo.com/cnquery/v9/providers/slack",
-	Version:         "11.0.3",
+	Version:         "11.0.4",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by cnquery's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.