### PR TITLE
🐛 fully discover gcp orgs

### DIFF
--- a/providers/gcp/resources/discovery.go
+++ b/providers/gcp/resources/discovery.go
@@ -183,6 +183,12 @@ func discoverOrganization(conn *connection.GcpConnection, gcpOrg *mqlGcpOrganiza
 				Labels:      map[string]string{},
 				Connections: []*inventory.Config{projectConf}, // pass-in the parent connection config
 			})
+
+			projectAssets, err := discoverProject(conn, project)
+			if err != nil {
+				return nil, err
+			}
+			assetList = append(assetList, projectAssets...)
 		}
 	}
 	if stringx.ContainsAnyOf(conn.Conf.Discover.Targets, DiscoveryAll, DiscoveryAuto, DiscoveryFolders) {


### PR DESCRIPTION
make sure when we scan a gcp org, we also discover all the resources under a project

~TODO: this needs to be tested to confirm it works correctly~