### PR TITLE
⭐ Add ELB region + elbType to the classic load balancers

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1104,7 +1104,7 @@ private aws.elb.loadbalancer @defaults("name region elbType scheme vpcId dnsName
   hostedZoneId string
   // Region where the load balancer exists
   region string
-  // The type of ELB. Possible values are `network`, `application`, or `gateway`
+  // The type of ELB. Possible values are `network`, `application`, `gateway`, or `classic`
   elbType string
   // VPC where the load balancer is located
   vpc aws.vpc

--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -75,13 +75,14 @@ func (a *mqlAwsElb) getClassicLoadBalancers(conn *connection.AwsConnection) []*j
 					mqlLb, err := CreateResource(a.MqlRuntime, "aws.elb.loadbalancer",
 						map[string]*llx.RawData{
 							"arn":                  llx.StringData(fmt.Sprintf(elbv1LbArnPattern, regionVal, conn.AccountId(), convert.ToString(lb.LoadBalancerName))),
-							"listenerDescriptions": llx.AnyData(jsonListeners),
+							"createdTime":          llx.TimeDataPtr(lb.CreatedTime),
 							"dnsName":              llx.StringDataPtr(lb.DNSName),
+							"elbType":              llx.StringData("classic"),
+							"listenerDescriptions": llx.AnyData(jsonListeners),
 							"name":                 llx.StringDataPtr(lb.LoadBalancerName),
+							"region":               llx.StringData(regionVal),
 							"scheme":               llx.StringDataPtr(lb.Scheme),
 							"vpcId":                llx.StringDataPtr(lb.VPCId),
-							"createdTime":          llx.TimeDataPtr(lb.CreatedTime),
-							"region":               llx.StringData(regionVal),
 						})
 					if err != nil {
 						return nil, err

--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -81,6 +81,7 @@ func (a *mqlAwsElb) getClassicLoadBalancers(conn *connection.AwsConnection) []*j
 							"scheme":               llx.StringDataPtr(lb.Scheme),
 							"vpcId":                llx.StringDataPtr(lb.VPCId),
 							"createdTime":          llx.TimeDataPtr(lb.CreatedTime),
+							"region":               llx.StringData(regionVal),
 						})
 					if err != nil {
 						return nil, err


### PR DESCRIPTION
This was already added to the NLB/ALBs

```coffee
aws.elb.classicLoadBalancers: [
  0: aws.elb.loadbalancer name="tim-classic" region="us-west-2" elbType="classic" scheme="internal" vpcId="vpc-1234" dnsName="internal-tim-classic-1234.us-west-2.elb.amazonaws.com"
]
```