### PR TITLE
⭐ Add region to aws.vpc.subnet

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -76,7 +76,7 @@ private aws.vpc.routetable @defaults("id routes.length") {
 }
 
 // Amazon Virtual Private Cloud (VPC) subnet
-private aws.vpc.subnet @defaults("id cidrs availabilityZone defaultForAvailabilityZone") {
+private aws.vpc.subnet @defaults("id cidrs region availabilityZone defaultForAvailabilityZone") {
   // ARN of the subnet
   arn string
   // Unique ID of the subnet
@@ -93,6 +93,8 @@ private aws.vpc.subnet @defaults("id cidrs availabilityZone defaultForAvailabili
   assignIpv6AddressOnCreation bool
   // The state of the subnet: pending or available
   state string
+  // Region in which the VPC subnet exists
+  region string
 }
 
 // Amazon Virtual Private Cloud (VPC) endpoint
@@ -103,7 +105,7 @@ private aws.vpc.endpoint @defaults("id type region") {
   type string
   // VPC in which the endpoint exists
   vpc string
-  // Region in which the VPC exists
+  // Region in which the VPC endpoint exists
   region string
   // The name of the endpoint service
   serviceName string
@@ -125,7 +127,7 @@ private aws.vpc.flowlog @defaults("id region status") {
   id string
   // VPC in which the flow log exists
   vpc string
-  // Region in which the flow log exists
+  // Region in which the VPC flow log exists
   region string
   // Status of the flow log
   status string

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -830,6 +830,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.vpc.subnet.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcSubnet).GetState()).ToDataRes(types.String)
 	},
+	"aws.vpc.subnet.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcSubnet).GetRegion()).ToDataRes(types.String)
+	},
 	"aws.vpc.endpoint.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcEndpoint).GetId()).ToDataRes(types.String)
 	},
@@ -3980,6 +3983,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.vpc.subnet.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcSubnet).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.subnet.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcSubnet).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.endpoint.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9033,6 +9040,7 @@ type mqlAwsVpcSubnet struct {
 	DefaultForAvailabilityZone plugin.TValue[bool]
 	AssignIpv6AddressOnCreation plugin.TValue[bool]
 	State plugin.TValue[string]
+	Region plugin.TValue[string]
 }
 
 // createAwsVpcSubnet creates a new instance of this resource
@@ -9102,6 +9110,10 @@ func (c *mqlAwsVpcSubnet) GetAssignIpv6AddressOnCreation() *plugin.TValue[bool] 
 
 func (c *mqlAwsVpcSubnet) GetState() *plugin.TValue[string] {
 	return &c.State
+}
+
+func (c *mqlAwsVpcSubnet) GetRegion() *plugin.TValue[string] {
+	return &c.Region
 }
 
 // mqlAwsVpcEndpoint for the aws.vpc.endpoint resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2658,6 +2658,7 @@ resources:
       defaultForAvailabilityZone: {}
       id: {}
       mapPublicIpOnLaunch: {}
+      region: {}
       state: {}
     is_private: true
     min_mondoo_version: 9.0.0

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -279,6 +279,7 @@ func (a *mqlAwsVpc) subnets() ([]interface{}, error) {
 					"defaultForAvailabilityZone":  llx.BoolDataPtr(subnet.DefaultForAz),
 					"id":                          llx.StringDataPtr(subnet.SubnetId),
 					"mapPublicIpOnLaunch":         llx.BoolDataPtr(subnet.MapPublicIpOnLaunch),
+					"region":                      llx.StringData(a.Region.Data),
 					"state":                       llx.StringData(string(subnet.State)),
 				})
 			if err != nil {


### PR DESCRIPTION
Also cleanup some descriptions and add region into the defaults for aws.vpc.subnet

```coffee
cnquery> aws.vpcs.first.subnets.first{*}
aws.vpcs.first.subnets.first: {
  availabilityZone: "ap-south-1c"
  cidrs: "172.31.16.0/20"
  arn: "arn:aws:ec2:ap-south-1:1234:subnet/subnet-1234"
  region: "ap-south-1"
  assignIpv6AddressOnCreation: false
  id: "subnet-1234"
  mapPublicIpOnLaunch: true
  state: "available"
  defaultForAvailabilityZone: true
}
```