### PR TITLE
🐛 fix coordinator race for shutting down providers

### DIFF
--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -204,7 +204,7 @@ func (c *coordinator) RemoveRuntime(runtime *Runtime) {
 	}
 
 	// Shutdown any providers that are not being used anymore
-	if len(c.runtimes) == 0 {
+	if len(c.runtimes) == 0 && len(c.unprocessedRuntimes) == 0 {
 		for _, p := range c.runningByID {
 			log.Debug().Msg("shutting down unused provider " + p.Name)
 			if err := c.stop(p); err != nil {


### PR DESCRIPTION
In #3775 a race condition in providers shutdown logic has been addressed. The issue described there almost never happens now but there are still some cases where we see the error: `ERR error encountered while scanning stdout error="read |0: file already closed"`

I went through the code and the only other reason where things may go wrong is if we have unprocessed runtimes at the moment we check for provider cleanup. I think to fix this case we need to make sure that there are no runtimes and no unprocessed runtimes before killing any providers.