### PR TITLE
Fix a docs server failure due to field description

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -676,7 +676,7 @@ sshd.config {
   file() file
   // A list of lexically sorted files making up the SSH server configuration
   files(file) []file
-  // Deprecated: Please use file.content or files{content} instead. Will be removed in v12.
+  // Deprecated: Please use `file.content` or `files{content}` instead. This field will be removed in v12.
   content(file) string
   // Configuration values of this SSH server
   params(file) map[string]string


### PR DESCRIPTION
files{content} was getting parsed as mdx and causing docusaurus failures