### PR TITLE
🐛 Replace fsconn with local connection for docker files, allow running commands

### DIFF
--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -26,6 +26,7 @@ import (
 	"go.mondoo.com/cnquery/v11/providers/os/connection/tar"
 	"go.mondoo.com/cnquery/v11/providers/os/connection/vagrant"
 	"go.mondoo.com/cnquery/v11/providers/os/connection/winrm"
+	"go.mondoo.com/cnquery/v11/providers/os/detector"
 	"go.mondoo.com/cnquery/v11/providers/os/id"
 	"go.mondoo.com/cnquery/v11/providers/os/resources"
 	"go.mondoo.com/cnquery/v11/providers/os/resources/discovery/docker_engine"
@@ -402,7 +403,15 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 			conn, err = docker.NewContainerImageConnection(connId, conf, asset)
 
 		case shared.Type_DockerFile.String():
-			conn, err = docker.NewDockerfile(connId, conf, asset)
+			local := local.NewConnection(connId, conf, asset)
+			// we need to identify the local OS family so that we're able to resolve the file details
+			// properly
+			localFamily := []string{}
+			os, ok := detector.DetectOS(local)
+			if ok {
+				localFamily = os.Family
+			}
+			conn, err = docker.NewDockerfileConnection(connId, conf, asset, local, localFamily)
 
 		case shared.Type_DockerRegistry.String(), shared.Type_ContainerRegistry.String():
 			conn, err = container.NewRegistryConnection(connId, asset)

--- a/providers/os/resources/docker_file.go
+++ b/providers/os/resources/docker_file.go
@@ -16,11 +16,23 @@ import (
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers/os/connection/docker"
+	"go.mondoo.com/cnquery/v11/providers/os/connection/local"
+	"go.mondoo.com/cnquery/v11/providers/os/connection/ssh"
 	"go.mondoo.com/cnquery/v11/types"
 	"go.mondoo.com/cnquery/v11/utils/multierr"
 )
 
 func initDockerFile(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	// the dockerfile connection is a wrapper around the local one
+	// NOTE: we might have to extend this in the future if we start supporting docker files from other connections (e.g. tar)
+	_, isDockerConn := runtime.Connection.(*docker.DockerfileConnection)
+	_, isSshConn := runtime.Connection.(*ssh.Connection)
+	_, isLocalConn := runtime.Connection.(*local.LocalConnection)
+	// if neither, we set the file to nil.
+	if !isDockerConn && !isSshConn && !isLocalConn {
+		return args, nil, nil
+	}
+
 	// if users supply a file, we don't have to run any fancy initialization,
 	// since most of this function deals with trying to find the dockerfile
 	if _, ok := args["file"]; ok {

--- a/providers/os/resources/user.go
+++ b/providers/os/resources/user.go
@@ -16,6 +16,7 @@ import (
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers/os/connection/shared"
 	"go.mondoo.com/cnquery/v11/providers/os/resources/users"
+	"go.mondoo.com/cnquery/v11/utils/multierr"
 )
 
 func (x *mqlUser) id() (string, error) {
@@ -118,13 +119,16 @@ func (x *mqlUsers) list() ([]interface{}, error) {
 
 	conn := x.MqlRuntime.Connection.(shared.Connection)
 	um, err := users.ResolveManager(conn)
-	if um == nil || err != nil {
+	if err != nil {
+		return nil, multierr.Wrap(err, "cannot resolve users manager")
+	}
+	if um == nil {
 		return nil, errors.New("cannot find users manager")
 	}
 
 	users, err := um.List()
 	if err != nil {
-		return nil, errors.New("could not retrieve users list")
+		return nil, multierr.Wrap(err, "could not retrieve users list")
 	}
 
 	var res []interface{}


### PR DESCRIPTION
Fixes #3813
 * Replace the FS conn with a local connection as we need this to able to fully resolve the docker file's properties (such as the owner).
 * Inject the local OS's family into the dockerfile asset to help the local connection run the right commands to be able to fetch users
 * Improve error messages that come from the users manager