### PR TITLE
⭐️ support filtering discovered github repos

### DIFF
--- a/providers/github/config/config.go
+++ b/providers/github/config/config.go
@@ -29,6 +29,18 @@ var Config = plugin.Provider{
 					Default: "",
 					Desc:    "Provide GitHub personal access token.",
 				},
+				{
+					Long:    "repos-exclude",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "Filter out repositories matching these names.",
+				},
+				{
+					Long:    "repos",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "Only include repositories with matching names.",
+				},
 			},
 		},
 	},

--- a/providers/github/connection/connection.go
+++ b/providers/github/connection/connection.go
@@ -17,6 +17,11 @@ import (
 	"golang.org/x/oauth2"
 )
 
+const (
+	OPTION_REPOS         = "repos"
+	OPTION_REPOS_EXCLUDE = "repos-exclude"
+)
+
 type GithubConnection struct {
 	plugin.Connection
 	asset  *inventory.Asset

--- a/providers/github/go.mod
+++ b/providers/github/go.mod
@@ -8,6 +8,7 @@ toolchain go1.22.0
 
 require (
 	github.com/cockroachdb/errors v1.11.1
+	github.com/gobwas/glob v0.2.3
 	github.com/google/go-github/v59 v59.0.0
 	github.com/rs/zerolog v1.32.0
 	github.com/stretchr/testify v1.9.0
@@ -146,7 +147,6 @@ require (
 	github.com/go-toolsmith/typep v1.1.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1 // indirect
 	github.com/go-xmlfmt/xmlfmt v1.1.2 // indirect
-	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gofrs/uuid v4.4.0+incompatible // indirect

--- a/providers/github/provider/provider.go
+++ b/providers/github/provider/provider.go
@@ -82,6 +82,14 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		return nil, errors.New("invalid GitHub sub-command, supported are: org, user, or repo")
 	}
 
+	if repos, ok := req.Flags[connection.OPTION_REPOS]; ok {
+		conf.Options[connection.OPTION_REPOS] = string(repos.Value)
+	}
+
+	if repos, ok := req.Flags[connection.OPTION_REPOS_EXCLUDE]; ok {
+		conf.Options[connection.OPTION_REPOS_EXCLUDE] = string(repos.Value)
+	}
+
 	asset := inventory.Asset{
 		Connections: []*inventory.Config{conf},
 	}

--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -230,7 +230,7 @@ func (f *ReposFilter) skipRepo(namespace string) bool {
 		for _, ns := range f.include {
 			g, err := glob.Compile(ns)
 			if err != nil {
-				log.Error().Err(err).Msg("failed to compile glob")
+				log.Error().Err(err).Msg("failed to compile repos glob")
 				return false
 			}
 			if g.Match(namespace) {
@@ -248,7 +248,7 @@ func (f *ReposFilter) skipRepo(namespace string) bool {
 	for _, ns := range f.exclude {
 		g, err := glob.Compile(ns)
 		if err != nil {
-			log.Error().Err(err).Msg("failed to compile glob")
+			log.Error().Err(err).Msg("failed to compile repos exclude glob")
 			return false
 		}
 		if g.Match(namespace) {

--- a/providers/github/resources/discovery_test.go
+++ b/providers/github/resources/discovery_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
+	"go.mondoo.com/cnquery/v11/providers/github/connection"
+)
+
+func TestReposFilter_Include(t *testing.T) {
+	reposFilter := NewReposFilter(&inventory.Config{
+		Options: map[string]string{
+			connection.OPTION_REPOS: "repo1,repo2",
+		},
+	})
+	assert.False(t, reposFilter.skipRepo("repo1"))
+	assert.False(t, reposFilter.skipRepo("repo2"))
+	assert.True(t, reposFilter.skipRepo("repo3"))
+}
+
+func TestReposFilter_Exclude(t *testing.T) {
+	reposFilter := NewReposFilter(&inventory.Config{
+		Options: map[string]string{
+			connection.OPTION_REPOS_EXCLUDE: "repo1,repo2",
+		},
+	})
+	assert.True(t, reposFilter.skipRepo("repo1"))
+	assert.True(t, reposFilter.skipRepo("repo2"))
+	assert.False(t, reposFilter.skipRepo("repo3"))
+}

--- a/providers/github/resources/discovery_test.go
+++ b/providers/github/resources/discovery_test.go
@@ -32,3 +32,15 @@ func TestReposFilter_Exclude(t *testing.T) {
 	assert.True(t, reposFilter.skipRepo("repo2"))
 	assert.False(t, reposFilter.skipRepo("repo3"))
 }
+
+func TestReposFilter_Both(t *testing.T) {
+	reposFilter := NewReposFilter(&inventory.Config{
+		Options: map[string]string{
+			connection.OPTION_REPOS:         "repo3,repo1",
+			connection.OPTION_REPOS_EXCLUDE: "repo1,repo2",
+		},
+	})
+	assert.False(t, reposFilter.skipRepo("repo1")) // include takes precedence
+	assert.True(t, reposFilter.skipRepo("repo2"))
+	assert.False(t, reposFilter.skipRepo("repo3"))
+}


### PR DESCRIPTION
We can now filter out github repos using globs:
```
cnquery scan github org podkrepi-bg --repos-exclude api,frontend
```

```
cnquery scan github org podkrepi-bg --repos api,frontend
```