### PR TITLE
Update away from deprecated GitLab field

### DIFF
--- a/providers/gitlab/resources/gitlab.go
+++ b/providers/gitlab/resources/gitlab.go
@@ -41,7 +41,7 @@ func initGitlabGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 	args["requireTwoFactorAuthentication"] = llx.BoolData(grp.RequireTwoFactorAuth)
 	args["preventForkingOutsideGroup"] = llx.BoolData(grp.PreventForkingOutsideGroup)
 	args["mentionsDisabled"] = llx.BoolData(grp.MentionsDisabled)
-	args["emailsDisabled"] = llx.BoolData(grp.EmailsDisabled)
+	args["emailsDisabled"] = llx.BoolData(!grp.EmailsEnabled)
 
 	return args, nil, nil
 }


### PR DESCRIPTION
Keep our field the same, but avoid this deprecated call