### PR TITLE
⭐️ inventory template support

### DIFF
--- a/apps/cnquery/cmd/root.go
+++ b/apps/cnquery/cmd/root.go
@@ -214,15 +214,11 @@ func getCobraScanConfig(cmd *cobra.Command, runtime *providers.Runtime, cliRes *
 	config.DisplayUsedConfig()
 
 	props := viper.GetStringMapString("props")
-	annotations := viper.GetStringMapString("annotation")
 
 	// merge the config and the user-provided annotations with the latter having precedence
 	optAnnotations := opts.Annotations
 	if optAnnotations == nil {
 		optAnnotations = map[string]string{}
-	}
-	for k, v := range annotations {
-		optAnnotations[k] = v
 	}
 
 	assetName := viper.GetString("asset-name")

--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -31,6 +31,8 @@ func init() {
 	_ = scanCmd.Flags().String("platform-id", "", "Select a specific target asset by providing its platform ID.")
 
 	_ = scanCmd.Flags().String("inventory-file", "", "Set the path to the inventory file.")
+	_ = scanCmd.Flags().String("inventory-template", "", "Set the path to the inventory template.")
+	_ = scanCmd.Flags().MarkHidden("inventory-template")
 
 	_ = scanCmd.Flags().Bool("inventory-format-ansible", false, "Set the inventory format to Ansible.")
 	// "inventory-ansible" is deprecated, use "inventory-format-ansible" instead
@@ -89,6 +91,7 @@ To manually configure a query pack, use this:
 
 		_ = viper.BindPFlag("platform-id", cmd.Flags().Lookup("platform-id"))
 		_ = viper.BindPFlag("inventory-file", cmd.Flags().Lookup("inventory-file"))
+		_ = viper.BindPFlag("inventory-template", cmd.Flags().Lookup("inventory-template"))
 		_ = viper.BindPFlag("inventory-ansible", cmd.Flags().Lookup("inventory-ansible"))
 		_ = viper.BindPFlag("inventory-domainlist", cmd.Flags().Lookup("inventory-domainlist"))
 		_ = viper.BindPFlag("querypack-bundle", cmd.Flags().Lookup("querypack-bundle"))
@@ -97,15 +100,15 @@ To manually configure a query pack, use this:
 		_ = viper.BindPFlag("trace-id", cmd.Flags().Lookup("trace-id"))
 		_ = viper.BindPFlag("category", cmd.Flags().Lookup("category"))
 
-		_ = viper.BindPFlag("annotations", cmd.Flags().Lookup("annotations"))
-		_ = viper.BindPFlag("props", cmd.Flags().Lookup("props"))
-
 		// for all assets
 		_ = viper.BindPFlag("incognito", cmd.Flags().Lookup("incognito"))
 		_ = viper.BindPFlag("insecure", cmd.Flags().Lookup("insecure"))
 		_ = viper.BindPFlag("querypacks", cmd.Flags().Lookup("querypack"))
 		_ = viper.BindPFlag("sudo.active", cmd.Flags().Lookup("sudo"))
 		_ = viper.BindPFlag("record", cmd.Flags().Lookup("record"))
+		// NOTE: we may "annotation" to "annotations" to align it with the internal config struct
+		_ = viper.BindPFlag("annotations", cmd.Flags().Lookup("annotation"))
+		_ = viper.BindPFlag("props", cmd.Flags().Lookup("props"))
 
 		_ = viper.BindPFlag("output", cmd.Flags().Lookup("output"))
 		_ = viper.BindPFlag("json", cmd.Flags().Lookup("json"))

--- a/cli/inventoryloader/inventory_test.go
+++ b/cli/inventoryloader/inventory_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package inventoryloader
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+func TestInventoryTemplate(t *testing.T) {
+	os.Setenv("MY_APPLICATION", "app1")
+	os.Setenv("OPERATING_ENVIRONMENT", "dev")
+	inventoryTemplate := `
+spec:
+  assets:
+    - name: Scenario TF {{ getenv "OPERATING_ENVIRONMENT" }}
+      connections:
+        - type: terraform-hcl
+          options:
+            ignore-dot-terraform: "false"
+            path: okta.tf
+      annotations:
+        Application: {{ getenv "MY_APPLICATION" }}
+        OperatingEnv: {{ getenv "OPERATING_ENVIRONMENT" }}
+`
+
+	data, err := renderTemplate([]byte(inventoryTemplate))
+	require.NoError(t, err)
+
+	assert.Contains(t, string(data), "Application: app1")
+	assert.Contains(t, string(data), "Scenario TF dev")
+}


### PR DESCRIPTION
When cnquery is used in CI/CD pipelines, users want to leverage the inventory file which allows a lot of pre-configuration. If you want to scan different assets for different environments you also want to re-use the same template but allow some custom variables so that usage in CI/CD is easier. This PR introduces inventory templates. Just define a template and use the `getenv` function to access environment variables:

```yaml
spec:
  assets:
    - name: {{ getenv "ASSET_NAME" }}
      connections:
        - type: local
          discover:
            targets:
              - auto
      annotations:
        application:  {{ getenv "APPLICATION" }}
```

This inventory can now be used as following:

```shell
ASSET_NAME="my_asset" APPLICATION="my-super-app" cnquery scan --inventory-template template.yaml
```