### PR TITLE
🐛 properly handle volumes for fedora snapshot scanning

### DIFF
--- a/providers/os/connection/snapshot/blockdevices_test.go
+++ b/providers/os/connection/snapshot/blockdevices_test.go
@@ -192,3 +192,17 @@ func TestAttachedBlockEntryMultipleMatch(t *testing.T) {
 	require.Equal(t, "xfs", info.fstype)
 	require.True(t, strings.Contains(info.name, "xvdh4"))
 }
+
+func TestAttachedBlockEntryFedora(t *testing.T) {
+	data, err := os.ReadFile("./testdata/fedora_attached.json")
+	require.NoError(t, err)
+
+	blockEntries := blockDevices{}
+	err = json.Unmarshal(data, &blockEntries)
+	require.NoError(t, err)
+
+	info, err := blockEntries.GetUnnamedBlockEntry()
+	require.NoError(t, err)
+	require.Equal(t, "xfs", info.fstype)
+	require.True(t, strings.Contains(info.name, "xvdh4"))
+}

--- a/providers/os/connection/snapshot/testdata/fedora_attached.json
+++ b/providers/os/connection/snapshot/testdata/fedora_attached.json
@@ -1,0 +1,116 @@
+{
+  "blockdevices": [
+    {
+      "name": "xvda",
+      "fstype": null,
+      "fsver": null,
+      "label": null,
+      "uuid": null,
+      "fsavail": null,
+      "fsuse%": null,
+      "mountpoints": [
+        null
+      ],
+      "children": [
+        {
+          "name": "xvda1",
+          "fstype": "xfs",
+          "fsver": null,
+          "label": "/",
+          "uuid": "ddd4de1a-d036-454d-ba9a-a04efe92aa41",
+          "fsavail": "6.4G",
+          "fsuse%": "19%",
+          "mountpoints": [
+            "/"
+          ]
+        },
+        {
+          "name": "xvda127",
+          "fstype": null,
+          "fsver": null,
+          "label": null,
+          "uuid": null,
+          "fsavail": null,
+          "fsuse%": null,
+          "mountpoints": [
+            null
+          ]
+        },
+        {
+          "name": "xvda128",
+          "fstype": "vfat",
+          "fsver": "FAT16",
+          "label": null,
+          "uuid": "E6E9-5CB0",
+          "fsavail": "8.7M",
+          "fsuse%": "13%",
+          "mountpoints": [
+            "/boot/efi"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "xvdh",
+      "fstype": null,
+      "fsver": null,
+      "label": null,
+      "uuid": null,
+      "fsavail": null,
+      "fsuse%": null,
+      "mountpoints": [
+        null
+      ],
+      "children": [
+        {
+          "name": "xvdh1",
+          "fstype": null,
+          "fsver": null,
+          "label": null,
+          "uuid": null,
+          "fsavail": null,
+          "fsuse%": null,
+          "mountpoints": [
+            null
+          ]
+        },
+        {
+          "name": "xvdh2",
+          "fstype": "vfat",
+          "fsver": "FAT16",
+          "label": "EFI-SYSTEM",
+          "uuid": "F6BC-CA0C",
+          "fsavail": null,
+          "fsuse%": null,
+          "mountpoints": [
+            null
+          ]
+        },
+        {
+          "name": "xvdh3",
+          "fstype": "ext4",
+          "fsver": "1.0",
+          "label": "boot",
+          "uuid": "04645376-3f91-4b60-98f5-455ec712d4c5",
+          "fsavail": null,
+          "fsuse%": null,
+          "mountpoints": [
+            null
+          ]
+        },
+        {
+          "name": "xvdh4",
+          "fstype": "xfs",
+          "fsver": null,
+          "label": "root",
+          "uuid": "abfe041f-7315-4fc8-a707-c599cd4b87fa",
+          "fsavail": null,
+          "fsuse%": "35%",
+          "mountpoints": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
we were incorrectly relying on the fsuse field before, this fixes that