### PR TITLE
✨ add accounts to the aws organization resource, --organization discovery

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -35,6 +35,8 @@ aws.organization @defaults("arn masterAccountEmail") {
   masterAccountId string
   // Email owner of the organization's master account
   masterAccountEmail string
+  // List of accounts that belong to the organization, if available to the caller
+  accounts() []aws.account
 }
 
 // Amazon Virtual Private Cloud (VPC)

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2090,6 +2090,8 @@ resources:
       - aws
   aws.organization:
     fields:
+      accounts:
+        min_mondoo_version: 9.0.0
       arn: {}
       featureSet: {}
       masterAccountEmail: {}

--- a/providers/aws/resources/aws_account.go
+++ b/providers/aws/resources/aws_account.go
@@ -6,18 +6,17 @@ package resources
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/organizations"
 	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers/aws/connection"
 )
 
 func (a *mqlAwsAccount) id() (string, error) {
-	if conn, ok := a.MqlRuntime.Connection.(*connection.AwsConnection); ok {
-		return "aws.account/" + conn.AccountId(), nil
-	}
-	return "", errors.New("wrong connection for aws account id call")
+	return "aws.account/" + a.Id.Data, nil
 }
 
 func (a *mqlAwsAccount) aliases() ([]interface{}, error) {
@@ -51,4 +50,51 @@ func (a *mqlAwsAccount) organization() (*mqlAwsOrganization, error) {
 			"masterAccountEmail": llx.StringDataPtr(org.Organization.MasterAccountEmail),
 		})
 	return res.(*mqlAwsOrganization), err
+}
+
+func (a *mqlAwsOrganization) accounts() ([]interface{}, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	client := conn.Organizations("") // no region for orgs, use configured region
+
+	orgAccounts, err := client.ListAccounts(context.TODO(), &organizations.ListAccountsInput{})
+	if err != nil {
+		return nil, err
+	}
+	accounts := []interface{}{}
+	for i := range orgAccounts.Accounts {
+		account := orgAccounts.Accounts[i]
+		res, err := CreateResource(a.MqlRuntime, "aws.account",
+			map[string]*llx.RawData{
+				"id": llx.StringDataPtr(account.Id),
+			})
+		if err != nil {
+			return nil, err
+		}
+		accounts = append(accounts, res.(*mqlAwsAccount))
+	}
+	return accounts, nil
+}
+
+func initAwsAccount(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) >= 2 {
+		return args, nil, nil
+	}
+	if len(args) == 0 {
+		if ids := getAssetIdentifier(runtime); ids != nil {
+			id := strings.TrimPrefix(ids.arn, "arn:aws:sts::")
+			args["id"] = llx.StringData(id)
+		}
+	}
+	if args["id"] == nil {
+		return args, nil, errors.New("no account id specified")
+	}
+	id := args["id"].Value.(string)
+	res, err := CreateResource(runtime, "aws.account",
+		map[string]*llx.RawData{
+			"id": llx.StringData(id),
+		})
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, res, nil
 }

--- a/providers/aws/resources/discovery_conversion.go
+++ b/providers/aws/resources/discovery_conversion.go
@@ -202,9 +202,9 @@ func accountAsset(conn *connection.AwsConnection, awsAccount *mqlAwsAccount) *in
 	name := AssembleIntegrationName(alias, accountId)
 
 	id := "//platformid.api.mondoo.app/runtime/aws/accounts/" + accountId
-
+	accountArn := "arn:aws:sts::" + accountId
 	return &inventory.Asset{
-		PlatformIds: []string{id},
+		PlatformIds: []string{id, accountArn},
 		Name:        name,
 		Platform:    connection.GetPlatformForObject("", accountId),
 		Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},


### PR DESCRIPTION
```
go run apps/cnquery/cnquery.go shell aws --discover organization --role arn:aws:iam::ACCOUNTID:role/test-org-list-accounts-role
```

```
cnquery> aws.account {  organization {accounts }}
aws.account: {
  organization: {
    accounts: [
      0: aws.account id="8913...."
      1: aws.account id="0724...."
```
<img width="194" alt="Screenshot 2024-05-09 at 21 03 29" src="https://github.com/mondoohq/cnquery/assets/10341541/97c20225-ea39-4e1b-a5cf-de43f42788d6">


```
→ connected to AWS Account
  ___ _ __   __ _ _   _  ___ _ __ _   _
 / __| '_ \ / _` | | | |/ _ \ '__| | | |
| (__| | | | (_| | |_| |  __/ |  | |_| |
 \___|_| |_|\__, |\__,_|\___|_|   \__, |
  mondoo™      |_|                |___/  interactive shell

cnquery> aws.account.id
aws.account.id: "8913..."
```
