### PR TITLE
:bug: docker file `Dockerfile` not found

### DIFF
--- a/providers/os/connection/docker/docker_file_connection.go
+++ b/providers/os/connection/docker/docker_file_connection.go
@@ -66,7 +66,7 @@ func NewDockerfileConnection(_ uint32,
 		return nil, errors.New("no inventory connections")
 	}
 
-	if url, ok := asset.Connections[0].Options["ssh-url"]; ok {
+	if url, ok := conf.Options["ssh-url"]; ok {
 		domain, org, repo, err := urlx.ParseGitSshUrl(url)
 		if err != nil {
 			return nil, err

--- a/providers/os/connection/docker/docker_file_connection.go
+++ b/providers/os/connection/docker/docker_file_connection.go
@@ -64,17 +64,13 @@ func NewDockerfileConnection(_ uint32,
 	// this helps with running commands against the local connection
 	asset.Platform.Family = append(asset.Platform.Family, localFamily...)
 
-	if len(asset.GetConnections()) == 0 { // prevents panics by accesssing `asset.Connections[0]`
-		return nil, errors.New("no inventory connections")
-	}
-
 	if url, ok := conf.Options["ssh-url"]; ok {
 		domain, org, repo, err := urlx.ParseGitSshUrl(url)
 		if err != nil {
 			return nil, err
 		}
 		platformID := "//platformid.api.mondoo.app/runtime/dockerfile/domain/" + domain + "/org/" + org + "/repo/" + repo
-		asset.Connections[0].PlatformId = platformID
+		conf.PlatformId = platformID
 		asset.PlatformIds = []string{platformID}
 		asset.Name = "Dockerfile analysis " + org + "/" + repo
 
@@ -84,7 +80,7 @@ func NewDockerfileConnection(_ uint32,
 		hash := hex.EncodeToString(h.Sum(nil))
 		platformID := "//platformid.api.mondoo.app/runtime/dockerfile/hash/" + hash
 
-		asset.Connections[0].PlatformId = platformID
+		conf.PlatformId = platformID
 		asset.PlatformIds = []string{platformID}
 		asset.Name = "Dockerfile analysis " + filename
 	}

--- a/providers/os/connection/docker/docker_file_connection.go
+++ b/providers/os/connection/docker/docker_file_connection.go
@@ -49,7 +49,6 @@ func NewDockerfileConnection(_ uint32,
 	var filename string
 	if !stat.IsDir() {
 		filename = filepath.Base(absSrc)
-		absSrc = filepath.Dir(absSrc)
 		conf.Path = absSrc
 	}
 
@@ -90,7 +89,9 @@ func NewDockerfileConnection(_ uint32,
 
 	conn := &DockerfileConnection{
 		LocalConnection: localConn,
-		Filename:        filepath.Join(conf.Path, filename),
+		// here we must use the absolute path of the Dockerfile so
+		// that we find the file downstream
+		Filename: absSrc,
 	}
 
 	return conn, nil

--- a/providers/os/connection/docker/docker_file_connection.go
+++ b/providers/os/connection/docker/docker_file_connection.go
@@ -21,6 +21,8 @@ var _ shared.Connection = &DockerfileConnection{}
 
 type DockerfileConnection struct {
 	*local.LocalConnection
+	// Filename must be the absolute path of the Dockerfile so
+	// that we find the file downstream
 	Filename string
 }
 

--- a/providers/os/connection/docker/docker_file_connection.go
+++ b/providers/os/connection/docker/docker_file_connection.go
@@ -21,14 +21,15 @@ var _ shared.Connection = &DockerfileConnection{}
 
 type DockerfileConnection struct {
 	*local.LocalConnection
-	// Filename must be the absolute path of the Dockerfile so
+	// FileAbsSrc must be the absolute path of the Dockerfile so
 	// that we find the file downstream
-	Filename string
+	FileAbsSrc string
 }
 
 func NewDockerfileConnection(_ uint32,
 	conf *inventory.Config, asset *inventory.Asset,
-	localConn *local.LocalConnection, localFamily []string) (*DockerfileConnection, error) {
+	localConn *local.LocalConnection, localFamily []string,
+) (*DockerfileConnection, error) {
 	if conf == nil {
 		return nil, errors.New("missing configuration to create dockerfile connection")
 	}
@@ -89,7 +90,7 @@ func NewDockerfileConnection(_ uint32,
 		LocalConnection: localConn,
 		// here we must use the absolute path of the Dockerfile so
 		// that we find the file downstream
-		Filename: absSrc,
+		FileAbsSrc: absSrc,
 	}
 
 	return conn, nil

--- a/providers/os/connection/docker/docker_file_connection_test.go
+++ b/providers/os/connection/docker/docker_file_connection_test.go
@@ -60,6 +60,6 @@ func TestNewDockerfileConnection(t *testing.T) {
 			[]string{})
 		require.Nil(t, err)
 		require.NotNil(t, subject)
-		require.Equal(t, dockerfile.Name(), subject.Filename)
+		require.Equal(t, dockerfile.Name(), subject.FileAbsSrc)
 	})
 }

--- a/providers/os/connection/docker/docker_file_connection_test.go
+++ b/providers/os/connection/docker/docker_file_connection_test.go
@@ -42,26 +42,6 @@ func TestNewDockerfileConnection(t *testing.T) {
 		require.NotNil(t, err)
 		require.Contains(t, err.Error(), "no such file or directory")
 	})
-	t.Run("valid path that exist but no inventory connections", func(t *testing.T) {
-		dockerfile, err := os.CreateTemp("", "Dockerfile")
-		require.Nil(t, err)
-		defer os.Remove(dockerfile.Name())
-		_, err = dockerfile.WriteString("FROM debian:stable")
-		require.Nil(t, err)
-		conf := &inventory.Config{
-			Path: dockerfile.Name(),
-		}
-		asset := &inventory.Asset{}
-		local := local.NewConnection(0, conf, asset)
-		subject, err := NewDockerfileConnection(0,
-			conf,
-			asset,
-			local,
-			[]string{})
-		require.Nil(t, subject)
-		require.NotNil(t, err)
-		require.Contains(t, err.Error(), "no inventory connections")
-	})
 	t.Run("valid path that exist", func(t *testing.T) {
 		dockerfile, err := os.CreateTemp("", "Dockerfile")
 		require.Nil(t, err)

--- a/providers/os/connection/docker/docker_file_connection_test.go
+++ b/providers/os/connection/docker/docker_file_connection_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package docker
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
+	"go.mondoo.com/cnquery/v11/providers/os/connection/local"
+)
+
+func TestNewDockerfileConnection(t *testing.T) {
+	t.Run("without path", func(t *testing.T) {
+		conf := &inventory.Config{}
+		asset := &inventory.Asset{}
+		local := local.NewConnection(0, conf, asset)
+		subject, err := NewDockerfileConnection(0,
+			conf,
+			asset,
+			local,
+			[]string{})
+		require.Nil(t, subject)
+		require.NotNil(t, err)
+		require.Equal(t, "please specify a target path for the dockerfile connection", err.Error())
+	})
+
+	t.Run("valid path not exist", func(t *testing.T) {
+		conf := &inventory.Config{
+			Path: "Dockerfile",
+		}
+		asset := &inventory.Asset{}
+		local := local.NewConnection(0, conf, asset)
+		subject, err := NewDockerfileConnection(0,
+			conf,
+			asset,
+			local,
+			[]string{})
+		require.Nil(t, subject)
+		require.NotNil(t, err)
+		require.Contains(t, err.Error(), "no such file or directory")
+	})
+	t.Run("valid path that exist but no inventory connections", func(t *testing.T) {
+		conf := &inventory.Config{
+			Path: "Dockerfile",
+		}
+		asset := &inventory.Asset{}
+		local := local.NewConnection(0, conf, asset)
+		subject, err := NewDockerfileConnection(0,
+			conf,
+			asset,
+			local,
+			[]string{})
+		require.Nil(t, subject)
+		require.NotNil(t, err)
+		require.Contains(t, err.Error(), "no inventory connections")
+	})
+	t.Run("valid path that exist", func(t *testing.T) {
+		dockerfile, err := os.CreateTemp("", "Dockerfile")
+		require.Nil(t, err)
+		defer os.Remove(dockerfile.Name())
+		dockerfile.WriteString("FROM debian:stable")
+		conf := &inventory.Config{
+			Path: dockerfile.Name(),
+		}
+		asset := &inventory.Asset{Connections: []*inventory.Config{{}}}
+		local := local.NewConnection(0, conf, asset)
+		subject, err := NewDockerfileConnection(0,
+			conf,
+			asset,
+			local,
+			[]string{})
+		require.Nil(t, err)
+		require.NotNil(t, subject)
+		require.Equal(t, dockerfile.Name(), subject.Filename)
+	})
+}

--- a/providers/os/connection/docker/docker_file_connection_test.go
+++ b/providers/os/connection/docker/docker_file_connection_test.go
@@ -43,8 +43,12 @@ func TestNewDockerfileConnection(t *testing.T) {
 		require.Contains(t, err.Error(), "no such file or directory")
 	})
 	t.Run("valid path that exist but no inventory connections", func(t *testing.T) {
+		dockerfile, err := os.CreateTemp("", "Dockerfile")
+		require.Nil(t, err)
+		defer os.Remove(dockerfile.Name())
+		dockerfile.WriteString("FROM debian:stable")
 		conf := &inventory.Config{
-			Path: "Dockerfile",
+			Path: dockerfile.Name(),
 		}
 		asset := &inventory.Asset{}
 		local := local.NewConnection(0, conf, asset)

--- a/providers/os/connection/docker/docker_file_connection_test.go
+++ b/providers/os/connection/docker/docker_file_connection_test.go
@@ -46,7 +46,8 @@ func TestNewDockerfileConnection(t *testing.T) {
 		dockerfile, err := os.CreateTemp("", "Dockerfile")
 		require.Nil(t, err)
 		defer os.Remove(dockerfile.Name())
-		dockerfile.WriteString("FROM debian:stable")
+		_, err = dockerfile.WriteString("FROM debian:stable")
+		require.Nil(t, err)
 		conf := &inventory.Config{
 			Path: dockerfile.Name(),
 		}
@@ -65,7 +66,8 @@ func TestNewDockerfileConnection(t *testing.T) {
 		dockerfile, err := os.CreateTemp("", "Dockerfile")
 		require.Nil(t, err)
 		defer os.Remove(dockerfile.Name())
-		dockerfile.WriteString("FROM debian:stable")
+		_, err = dockerfile.WriteString("FROM debian:stable")
+		require.Nil(t, err)
 		conf := &inventory.Config{
 			Path: dockerfile.Name(),
 		}

--- a/providers/os/resources/docker_file.go
+++ b/providers/os/resources/docker_file.go
@@ -49,7 +49,7 @@ func initDockerFile(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 			return nil, nil, errors.New("path must be supplied as a string")
 		}
 	} else if dfc, ok := runtime.Connection.(*docker.DockerfileConnection); ok {
-		path = dfc.Filename
+		path = dfc.FileAbsSrc
 	}
 
 	// we assume the default name for the dockerfile if it was not provided


### PR DESCRIPTION
Fixes https://github.com/mondoohq/cnquery/issues/3962

* Renamed the file because my editor was complaining about the name being `dockerfile*`
* Returned the full absolute path instead of the relative path
* Added tests that cover this change 