### PR TITLE
⭐️ add container-proxy flag for scanning containers

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -198,6 +198,12 @@ var Config = plugin.Provider{
 					Default: "false",
 					Desc:    "Disable the in-memory cache for images. WARNING: This will slow down scans significantly.",
 				},
+				{
+					Long:    "container-proxy",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "HTTP proxy to use for container pulls",
+				},
 			},
 		},
 		{
@@ -230,6 +236,12 @@ var Config = plugin.Provider{
 					Type:    plugin.FlagType_Bool,
 					Default: "false",
 					Desc:    "Disable the in-memory cache for images. WARNING: This will slow down scans significantly.",
+				},
+				{
+					Long:    "container-proxy",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "HTTP proxy to use for container pulls",
 				},
 			},
 		},

--- a/providers/os/connection/container/registry_connection.go
+++ b/providers/os/connection/container/registry_connection.go
@@ -74,7 +74,12 @@ func (r *RegistryConnection) Asset() *inventory.Asset {
 }
 
 func (r *RegistryConnection) DiscoverImages() (*inventory.Inventory, error) {
-	resolver := container_registry.NewContainerRegistryResolver()
+	opts, err := container_registry.RemoteOptionsFromConfigOptions(r.asset.Connections[0])
+	if err != nil {
+		return nil, err
+	}
+
+	resolver := container_registry.NewContainerRegistryResolver(opts...)
 	host := r.asset.Connections[0].Host
 	assets, err := resolver.ListRegistry(host)
 	if err != nil {

--- a/providers/os/connection/shared/shared.go
+++ b/providers/os/connection/shared/shared.go
@@ -42,6 +42,8 @@ const (
 	Type_DockerSnapshot    ConnectionType = "docker-snapshot"
 	Type_ContainerRegistry ConnectionType = "container-registry"
 	Type_RegistryImage     ConnectionType = "registry-image"
+
+	ContainerProxyOption string = "container-proxy"
 )
 
 type Connection interface {

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -201,11 +201,19 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		asset.IdDetector = []string{idDetector}
 	}
 
+	if conf.Options == nil {
+		conf.Options = map[string]string{}
+	}
+
 	if disableCache, ok := flags["disable-cache"]; ok {
-		if conf.Options == nil {
-			conf.Options = map[string]string{}
-		}
 		conf.Options["disable-cache"] = strconv.FormatBool(disableCache.RawData().Value.(bool))
+	}
+
+	if containerProxy, ok := flags[shared.ContainerProxyOption]; ok {
+		proxyVal := containerProxy.RawData().Value.(string)
+		if proxyVal != "" {
+			conf.Options[shared.ContainerProxyOption] = proxyVal
+		}
 	}
 
 	res := plugin.ParseCLIRes{


### PR DESCRIPTION
we can now specify a container proxy for scanning containers:
```
cnquery scan docker ubuntu:latest --container-proxy http://localhost:3128
```

this is different from the `api-proxy` setting, which is used only to talk to the Mondoo platform. The `container-proxy` flag is used only for resolving and pulling containers