### PR TITLE
:star: Improve default values for AWS instance block devices

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2762,7 +2762,7 @@ private aws.ec2.image @defaults("arn") {
   createdAt time
 }
 
-// Amazon EC2 instance device
+// Amazon EC2 instance block device
 private aws.ec2.instance.device @defaults("deviceName volumeId status") {
   // Boolean to denote whether volume should be deleted on instance termination
   deleteOnTermination bool

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2763,7 +2763,7 @@ private aws.ec2.image @defaults("arn") {
 }
 
 // Amazon EC2 instance device
-private aws.ec2.instance.device {
+private aws.ec2.instance.device @defaults("deviceName volumeId status") {
   // Boolean to denote whether volume should be deleted on instance termination
   deleteOnTermination bool
   // Status of the device


### PR DESCRIPTION
This improves the output of attached disks when querying the whole instance:

Old:

```
  deviceMappings: [
    0: aws.ec2.instance.device id = vol-09dce9b718d427cf5
  ]
```

New:

```
  deviceMappings: [
    0: aws.ec2.instance.device deviceName="/dev/sda1" volumeId="vol-09dce9b718d427cf5" status="attached"
  ]
```