### PR TITLE
🐛 Return error if no platform information

### DIFF
--- a/providers-sdk/v1/sysinfo/sysinfo.go
+++ b/providers-sdk/v1/sysinfo/sysinfo.go
@@ -4,6 +4,8 @@
 package sysinfo
 
 import (
+	"errors"
+
 	"github.com/rs/zerolog/log"
 
 	"go.mondoo.com/cnquery/v11"
@@ -44,11 +46,15 @@ func Get() (*SystemInfo, error) {
 		Type: "local",
 	}, &asset)
 
-	fingerprint, platform, err := id.IdentifyPlatform(conn, asset.Platform, asset.IdDetector)
-	if err == nil {
+	fingerprint, platform, _ := id.IdentifyPlatform(conn, asset.Platform, asset.IdDetector)
+	if fingerprint != nil {
 		if len(fingerprint.PlatformIDs) > 0 {
 			sysInfo.PlatformId = fingerprint.PlatformIDs[0]
 		}
+	}
+
+	if platform == nil {
+		return nil, errors.New("failed to detect the OS")
 	}
 
 	sysInfo.Platform = platform

--- a/providers/os/id/platform.go
+++ b/providers/os/id/platform.go
@@ -99,7 +99,7 @@ func IdentifyPlatform(conn shared.Connection, p *inventory.Platform, idDetectors
 
 	// if we found zero platform ids something went wrong
 	if len(platformIds) == 0 {
-		return nil, nil, errors.New("could not determine a platform identifier")
+		return nil, p, errors.New("could not determine a platform identifier")
 	}
 
 	fingerprint.PlatformIDs = platformIds


### PR DESCRIPTION
`SystemInfo.Get` used to return an error if it couldn't get the platform information.
This regressed in https://github.com/mondoohq/cnquery/pull/3660 where nil platform info stopped returning an error