### PR TITLE
🐛 properly handle insecure flag for host scans

### DIFF
--- a/providers/network/config/config.go
+++ b/providers/network/config/config.go
@@ -37,7 +37,7 @@ var Config = plugin.Provider{
 			Flags: []plugin.Flag{
 				{
 					Long:    "insecure",
-					Type:    plugin.FlagType_String,
+					Type:    plugin.FlagType_Bool,
 					Default: "",
 					Desc:    "Disable TLS/SSL verification.",
 					Option:  plugin.FlagOption_Hidden,

--- a/providers/network/connection/connection.go
+++ b/providers/network/connection/connection.go
@@ -4,21 +4,47 @@
 package connection
 
 import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"time"
+
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 )
 
 type HostConnection struct {
 	plugin.Connection
-	Conf  *inventory.Config
-	asset *inventory.Asset
+	Conf       *inventory.Config
+	asset      *inventory.Asset
+	httpClient *http.Client
 }
 
 func NewHostConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) *HostConnection {
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	if conf.Insecure {
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	}
+
 	return &HostConnection{
 		Connection: plugin.NewConnection(id, asset),
 		Conf:       conf,
 		asset:      asset,
+		httpClient: &http.Client{Transport: transport},
 	}
 }
 
@@ -35,4 +61,8 @@ func (p *HostConnection) FQDN() string {
 		return ""
 	}
 	return p.Conf.Host
+}
+
+func (p *HostConnection) Client() *http.Client {
+	return p.httpClient
 }

--- a/providers/network/resources/http.go
+++ b/providers/network/resources/http.go
@@ -96,7 +96,8 @@ func (x *mqlHttpGet) do() error {
 		return errors.New("missing URL for http.get")
 	}
 
-	resp, err := http.Get(x.Url.Data.String.Data)
+	conn := x.MqlRuntime.Connection.(*connection.HostConnection)
+	resp, err := conn.Client().Get(x.Url.Data.String.Data)
 	x.resp.State = plugin.StateIsSet
 	x.resp.Data = resp
 	x.resp.Error = err


### PR DESCRIPTION
Changed the `insecure` flag to bool. No idea why it was a string. Also added an HTTP client to the host connection, so we define all the properties in 1 place and re-use them where needed.

```
╰─ cnspec shell host https://localhost --insecure
→ loaded configuration from /Users/ivanmilchev/.config/mondoo/mondoo.yml using source default
→ connected to Network Host
  ___ _ __  ___ _ __   ___  ___ 
 / __| '_ \/ __| '_ \ / _ \/ __|
| (__| | | \__ \ |_) |  __/ (__ 
 \___|_| |_|___/ .__/ \___|\___|
   mondoo™     |_|              
cnspec> http.get
http.get: http.get url=url id = https://localhost:443 statusCode=200
```

Fixes #3995