### PR TITLE
🐛 remove dead providers from coordinator

### DIFF
--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -211,6 +211,14 @@ func (c *coordinator) RemoveRuntime(runtime *Runtime) {
 				log.Warn().Err(err).Str("provider", p.Name).Msg("failed to shut down provider")
 			}
 		}
+	} else {
+		// Check for killed/crashed providers and remove them from the list of running providers
+		for _, p := range c.runningByID {
+			if p.isCloseOrShutdown() {
+				log.Warn().Str("provider", p.Name).Msg("removing closed provider")
+				delete(c.runningByID, p.ID)
+			}
+		}
 	}
 
 	// If all providers have been killed, reset the connection IDs back to 0

--- a/providers/running_provider.go
+++ b/providers/running_provider.go
@@ -38,6 +38,7 @@ type RunningProvider struct {
 // initialize the heartbeat with the provider
 func (p *RunningProvider) heartbeat() error {
 	if err := p.doOneHeartbeat(p.interval + p.gracePeriod); err != nil {
+		log.Error().Err(err).Str("plugin", p.Name).Msg("error in plugin heartbeat")
 		if err := p.Shutdown(); err != nil {
 			log.Error().Err(err).Str("plugin", p.Name).Msg("error in plugin shutdown")
 		}
@@ -47,6 +48,7 @@ func (p *RunningProvider) heartbeat() error {
 	go func() {
 		for !p.isCloseOrShutdown() {
 			if err := p.doOneHeartbeat(p.interval + p.gracePeriod); err != nil {
+				log.Error().Err(err).Str("plugin", p.Name).Msg("error in plugin heartbeat")
 				if err := p.Shutdown(); err != nil {
 					log.Error().Err(err).Str("plugin", p.Name).Msg("error in plugin shutdown")
 				}

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -204,6 +204,11 @@ func (r *Runtime) Connect(req *plugin.ConnectReq) error {
 		runtime: r,
 	}
 
+	// TODO: we probably want to check here if the provider is dead and restart it
+	// if r.Provider.Instance.isCloseOrShutdown() {
+
+	// }
+
 	r.Provider.Connection, r.Provider.ConnectionError = r.Provider.Instance.Plugin.Connect(req, &callbacks)
 	if r.Provider.ConnectionError != nil {
 		return r.Provider.ConnectionError


### PR DESCRIPTION
This should minimize the impact of errors we have observed with the scan API. If a provider crashes, it doesn't get properly cleaned up and results in endless loop of failed scans because no provider instance is available. This change makes sure we remove dead providers after each scan, such that the next scan can start with a fresh provider.

This still has the issue that if we have 1 scan with 300 assets and the provider crashes after scanning the first asset, we will get 299 errors for the remaining assets. The issue should be gone with the next scan. A better approach is to detect that a provider instance is dead before connecting to it, if that is the case, we should implement restart logic. That should happen inside the runtime, since we keep a reference to the `RunningProvider` in all the runtimes for every asset of the scan. We need to make sure we update the same `RunningProvider` pointer with a new provider instance. 

I added a TODO to the code where I think this logic should be implemented.