### PR TITLE
🐛 don't keep closed unprocessed runtimes in coordinator

### DIFF
--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -153,6 +153,9 @@ func (c *coordinator) unsafeRefreshRuntimes() {
 	var remaining []*Runtime
 	for i := range c.unprocessedRuntimes {
 		rt := c.unprocessedRuntimes[i]
+		if rt.isClosed {
+			continue
+		}
 		if asset := rt.asset(); asset == nil || !c.unsafeSetAssetRuntime(asset, rt) {
 			remaining = append(remaining, rt)
 		}


### PR DESCRIPTION
we are currently leaking memory for long-running cnquery/cnspec instances because the coordinator is keeping around closed unprocessed runtimes. This PR makes sure we throw away these runtimes