### PR TITLE
Updates aws.account.id resource

### DIFF
--- a/providers/aws/resources/aws_account.go
+++ b/providers/aws/resources/aws_account.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (a *mqlAwsAccount) id() (string, error) {
-	return "aws.account/" + a.Id.Data, nil
+	return a.Id.Data, nil
 }
 
 func (a *mqlAwsAccount) aliases() ([]interface{}, error) {


### PR DESCRIPTION
This PR updates the `aws.account.id` resource to only return the account ID. The previous version concatenates the string "aws.account/" to the account id. That string is redundant because the resource is already `aws.account.id` 

## OLD VERSION:
```
cnspec> aws.account.id 
aws.account.id: "aws.account/177043759666"
``` 

### NEW VERSION:
```
cnquery> aws.account.id
aws.account.id: "177043759666"
```
