### PR TITLE
Update the help text with consistent provider descriptions

### DIFF
--- a/providers-sdk/v1/util/version/version.go
+++ b/providers-sdk/v1/util/version/version.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"go.mondoo.com/cnquery/v11/utils/stringx"
 	"go/format"
 	"os"
 	"os/exec"
@@ -16,6 +15,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"go.mondoo.com/cnquery/v11/utils/stringx"
 
 	mastermind "github.com/Masterminds/semver"
 	tea "github.com/charmbracelet/bubbletea"
@@ -42,15 +43,15 @@ push it to a new branch.
 
   $ version update providers/*/ --increment=patch --commit
 
-The tool will also check if the provider go dependencies have changed since the 
+The tool will also check if the provider go dependencies have changed since the
 last version and will suggest to update them as well. To just clean up the go.mod
 and go.sum files, run:
 
-  $ version mod-tidy providers/*/ 
+  $ version mod-tidy providers/*/
 
 To update all provider go dependencies to the latest patch version, run:
 
-  $ version mod-update providers/*/ --patch 
+  $ version mod-update providers/*/ --patch
 
 To update all provider go dependencies to the latest version, run:
 

--- a/providers/atlassian/config/config.go
+++ b/providers/atlassian/config/config.go
@@ -23,7 +23,7 @@ var Config = plugin.Provider{
 		{
 			Name:  "atlassian",
 			Use:   "atlassian",
-			Short: "Atlassian",
+			Short: "an Atlassian Cloud Jira, Confluence or Bitbucket instance",
 			Long: `atlassian is designed for querying resources within Atlassian Cloud, including Jira, Confluence, and SCIM.
 
 Available Commands:
@@ -32,13 +32,13 @@ Available Commands:
   confluence                Specifies the Confluence instance to interact with.
   scim                      Specifies the SCIM instance to interact with.
 
-Examples: 
+Examples:
   cnquery shell atlassian admin --admin-token <token>
   cnquery shell atlassian jira --host <host> --user <user> --user-token <token>
   cnquery shell atlassian confluence --host <host> --user <user> --user-token <token>
   cnquery shell atlassian scim <directory-id> --scim-token <token>
 
-If the ATLASSIAN_ADMIN_TOKEN environment variable is set, the admin-token flag is not required. If the ATLASSIAN_USER, 
+If the ATLASSIAN_ADMIN_TOKEN environment variable is set, the admin-token flag is not required. If the ATLASSIAN_USER,
 ATLASSIAN_HOST, and ATLASSIAN_USER_TOKEN environment variables are set, the user, host, and user-token flags are not required.
 
 For SCIM, you receive both the token and the directory-id from Atlassian when you setup an identity provider.

--- a/providers/defaults.go
+++ b/providers/defaults.go
@@ -35,7 +35,7 @@ var DefaultProviders Providers = map[string]*Provider{
 				{
 					Name:  "atlassian",
 					Use:   "atlassian",
-					Short: "Atlassian",
+					Short: "an Atlassian Cloud Jira, Confluence or Bitbucket instance",
 				},
 			},
 		},
@@ -104,7 +104,7 @@ var DefaultProviders Providers = map[string]*Provider{
 				{
 					Name:  "gcp",
 					Use:   "gcp",
-					Short: "a Google Cloud project",
+					Short: "a Google Cloud project or folder",
 				},
 			},
 		},
@@ -239,7 +239,7 @@ var DefaultProviders Providers = map[string]*Provider{
 				{
 					Name:  "okta",
 					Use:   "okta",
-					Short: "Okta",
+					Short: "an Okta organization",
 				},
 			},
 		},

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -23,7 +23,7 @@ var Config = plugin.Provider{
 		{
 			Name:    "gcp",
 			Use:     "gcp",
-			Short:   "a Google Cloud project",
+			Short:   "a Google Cloud project or folder",
 			MaxArgs: 2,
 			Discovery: []string{
 				resources.DiscoveryAll,

--- a/providers/mock.go
+++ b/providers/mock.go
@@ -22,7 +22,7 @@ var mockProvider = Provider{
 			{
 				Name:  "mock",
 				Use:   "mock",
-				Short: "use a recording without an active connection",
+				Short: "a recording file without an active connection",
 			},
 			{
 				Name:     "upstream",

--- a/providers/okta/config/config.go
+++ b/providers/okta/config/config.go
@@ -17,7 +17,7 @@ var Config = plugin.Provider{
 		{
 			Name:      "okta",
 			Use:       "okta",
-			Short:     "Okta",
+			Short:     "an Okta organization",
 			Discovery: []string{},
 			Flags: []plugin.Flag{
 				{

--- a/test/commands/testdata/cnquery_run.ct
+++ b/test/commands/testdata/cnquery_run.ct
@@ -6,7 +6,7 @@ Usage:
   cnquery run [command]
 
 Available Commands:
-  mock        Run a query with use a recording without an active connection
+  mock        Run a query with a recording file without an active connection
 
 Flags:
       --ast                  Parse the query and return the abstract syntax tree (AST).

--- a/test/commands/testdata/cnquery_scan.ct
+++ b/test/commands/testdata/cnquery_scan.ct
@@ -14,7 +14,7 @@ Usage:
   cnquery scan [command]
 
 Available Commands:
-  mock        Scan use a recording without an active connection
+  mock        Scan a recording file without an active connection
 
 Flags:
       --annotation stringToString     Add an annotation to the asset. (default [])


### PR DESCRIPTION
Right now it's all over the place and we're not describing the actual things we scan within these larger technologies properly

Now:

```
Available Commands:
  arista           Scan an Arista EOS device
  atlassian        Scan an Atlassian Cloud Jira, Confluence or Bitbucket instance
  aws              Scan an AWS account
  azure            Scan an Azure subscription
  container        Scan a running container or container image
  docker           Scan a running Docker container or Docker image
  equinix          Scan an Equinix Metal organization
  filesystem       Scan a mounted file system target
  gcp              Scan a Google Cloud project or folder
  github           Scan a GitHub organization or repository
  gitlab           Scan a GitLab group or project
  google-workspace Scan a Google Workspace account
  host             Scan a remote host
  ipmi             Scan an IPMI interface
  k8s              Scan a Kubernetes cluster or local manifest file(s)
  local            Scan your local system
  mock             Scan use a recording without an active connection
  ms365            Scan a Microsoft 365 account
  oci              Scan an Oracle Cloud Infrastructure tenancy
  okta             Scan an Okta organization
  opcua            Scan an OPC UA device
  slack            Scan a Slack team
  ssh              Scan a remote system via SSH
  terraform        Scan a Terraform HCL file or directory
  vagrant          Scan a Vagrant host
  vcd              Scan a VMware Cloud Director installation
  vsphere          Scan a VMware vSphere installation
  winrm            Scan a remote system via WinRM
```