### PR TITLE
🐛 ensure we scan all ecr images, do not rely on tags

### DIFF
--- a/providers/aws/resources/discovery_conversion.go
+++ b/providers/aws/resources/discovery_conversion.go
@@ -415,17 +415,18 @@ func addConnectionInfoToEcrAsset(image *mqlAwsEcrImage, conn *connection.AwsConn
 	for i := range image.Tags.Data {
 		tag := image.Tags.Data[i].(string)
 		imageTags = append(imageTags, tag)
-		a.Connections = append(a.Connections, &inventory.Config{
-			Type: "registry-image",
-			Host: image.Uri.Data + ":" + tag,
-			Options: map[string]string{
-				"region":  image.Region.Data,
-				"profile": conn.Profile(),
-			},
-			DelayDiscovery: true,
-		})
-
 	}
+
+	a.Connections = append(a.Connections, &inventory.Config{
+		Type: "registry-image",
+		Host: image.Uri.Data + "@" + image.Digest.Data,
+		Options: map[string]string{
+			"region":  image.Region.Data,
+			"profile": conn.Profile(),
+		},
+		DelayDiscovery: true,
+	})
+
 	a.Labels = make(map[string]string)
 	// store digest
 	a.Labels[fmt.Sprintf("ecr.%s.amazonaws.com/digest", image.Region.Data)] = image.Digest.Data


### PR DESCRIPTION
the ecr-credential-helper library had tag based examples that we used when adding in the functionality. those aren't actually needed, we just need the full uri this changes to code to do that so we will no longer skip no-tag images

![Screenshot 2024-05-22 at 11 39 25](https://github.com/mondoohq/cnquery/assets/10341541/cca9e560-d670-4712-a4d8-3053ce623e10)
![Screenshot 2024-05-22 at 11 39 32](https://github.com/mondoohq/cnquery/assets/10341541/fd49f05f-2640-40de-b809-9c3ba9738cd1)
