### PR TITLE
Use better defaults for the Azure IP addressess

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -694,7 +694,7 @@ azure.subscription.networkService.interface @defaults("name location properties.
 }
 
 // Azure network IP address
-private azure.subscription.networkService.ipAddress @defaults("id name location") {
+private azure.subscription.networkService.ipAddress @defaults("name location ipAddress") {
   // IP address ID
   id string
   // IP address name


### PR DESCRIPTION
```coffee
azure.subscription.compute.vms.first.publicIpAddresses: [
  0: azure.subscription.networkService.ipAddress name="test-ip" location="westus" ipAddress="40.112.145.65"
]
```

This makes it possible to see the IP address attached to a VM without having to query into the IP as well