### PR TITLE
🧹 do not hide insecure flag for network provider

### DIFF
--- a/providers/network/config/config.go
+++ b/providers/network/config/config.go
@@ -40,7 +40,6 @@ var Config = plugin.Provider{
 					Type:    plugin.FlagType_Bool,
 					Default: "",
 					Desc:    "Disable TLS/SSL verification.",
-					Option:  plugin.FlagOption_Hidden,
 				},
 			},
 		},


### PR DESCRIPTION
not sure why it was hidden in the first place