### PR TITLE
🧹 Add new methods for detecting and mounting in the volume mounter.

### DIFF
--- a/providers/os/connection/device/device_connection.go
+++ b/providers/os/connection/device/device_connection.go
@@ -47,7 +47,7 @@ func NewDeviceConnection(connId uint32, conf *inventory.Config, asset *inventory
 	}
 	log.Debug().Str("manager", manager.Name()).Msg("device manager created")
 
-	blocks, err := manager.IdentifyBlockDevice(conf.Options)
+	blocks, err := manager.IdentifyMountTargets(conf.Options)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func NewDeviceConnection(connId uint32, conf *inventory.Config, asset *inventory
 		return nil, errors.New("internal>blocks size is not equal to 1.")
 	}
 	block := blocks[0]
-	log.Debug().Str("device", block.DeviceName).Msg("identified block for mounting")
+	log.Debug().Str("name", block.Name).Str("type", block.FsType).Msg("identified partition for mounting")
 
 	res := &DeviceConnection{
 		Connection:    plugin.NewConnection(connId, asset),

--- a/providers/os/connection/device/device_manager.go
+++ b/providers/os/connection/device/device_manager.go
@@ -3,11 +3,17 @@
 
 package device
 
-import "go.mondoo.com/cnquery/v11/providers/os/connection/device/shared"
+import (
+	"go.mondoo.com/cnquery/v11/providers/os/connection/snapshot"
+)
 
 type DeviceManager interface {
+	// Name returns the name of the device manager
 	Name() string
-	IdentifyBlockDevice(opts map[string]string) ([]shared.MountInfo, error)
-	Mount(mi shared.MountInfo) (string, error)
+	// IdentifyMountTargets returns a list of partitions that match the given options and can be mounted
+	IdentifyMountTargets(opts map[string]string) ([]*snapshot.PartitionInfo, error)
+	// Mounts the partition and returns the directory it was mounted to
+	Mount(pi *snapshot.PartitionInfo) (string, error)
+	// UnmountAndClose unmounts the partitions from the specified dirs and closes the device manager
 	UnmountAndClose()
 }

--- a/providers/os/connection/device/linux/device_manager.go
+++ b/providers/os/connection/device/linux/device_manager.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
-	"go.mondoo.com/cnquery/v11/providers/os/connection/device/shared"
 	"go.mondoo.com/cnquery/v11/providers/os/connection/snapshot"
 )
 
@@ -37,7 +36,7 @@ func (d *LinuxDeviceManager) Name() string {
 	return "linux"
 }
 
-func (d *LinuxDeviceManager) IdentifyBlockDevice(opts map[string]string) ([]shared.MountInfo, error) {
+func (d *LinuxDeviceManager) IdentifyMountTargets(opts map[string]string) ([]*snapshot.PartitionInfo, error) {
 	if err := validateOpts(opts); err != nil {
 		return nil, err
 	}
@@ -46,20 +45,26 @@ func (d *LinuxDeviceManager) IdentifyBlockDevice(opts map[string]string) ([]shar
 		if err != nil {
 			return nil, err
 		}
-		return d.identifyViaLun(lun)
+		pi, err := d.identifyViaLun(lun)
+		if err != nil {
+			return nil, err
+		}
+		return []*snapshot.PartitionInfo{pi}, nil
 	}
 
-	return d.identifyViaDeviceName(opts[DeviceName])
+	pi, err := d.identifyViaDeviceName(opts[DeviceName])
+	if err != nil {
+		return nil, err
+	}
+	return []*snapshot.PartitionInfo{pi}, nil
 }
 
-func (d *LinuxDeviceManager) Mount(mi shared.MountInfo) (string, error) {
-	// TODO: we should make the volume mounter return the scan dir from Mount()
-	// TODO: use the mount info to mount the volume
-	err := d.volumeMounter.Mount()
+func (d *LinuxDeviceManager) Mount(pi *snapshot.PartitionInfo) (string, error) {
+	scanDir, err := d.volumeMounter.MountP(pi)
 	if err != nil {
 		return "", err
 	}
-	return d.volumeMounter.ScanDir, nil
+	return scanDir, nil
 }
 
 func (d *LinuxDeviceManager) UnmountAndClose() {
@@ -92,7 +97,7 @@ func validateOpts(opts map[string]string) error {
 	return nil
 }
 
-func (c *LinuxDeviceManager) identifyViaLun(lun int) ([]shared.MountInfo, error) {
+func (c *LinuxDeviceManager) identifyViaLun(lun int) (*snapshot.PartitionInfo, error) {
 	scsiDevices, err := c.listScsiDevices()
 	if err != nil {
 		return nil, err
@@ -104,43 +109,26 @@ func (c *LinuxDeviceManager) identifyViaLun(lun int) ([]shared.MountInfo, error)
 		return nil, errors.New("no matching scsi devices found")
 	}
 
+	var target string
 	// if we have exactly one device present at the LUN we can directly point the volume mounter towards it
 	if len(filteredScsiDevices) == 1 {
-		return []shared.MountInfo{{DeviceName: filteredScsiDevices[0].VolumePath}}, nil
-	}
-
-	// we have multiple devices at the same LUN. we find the first non-mounted block devices in that list
-	blockDevices, err := c.volumeMounter.CmdRunner.GetBlockDevices()
-	if err != nil {
-		return nil, err
-	}
-	target, err := findMatchingDeviceByBlock(filteredScsiDevices, blockDevices)
-	if err != nil {
-		return nil, err
-	}
-	c.volumeMounter.VolumeAttachmentLoc = target
-	return []shared.MountInfo{{DeviceName: target}}, nil
-}
-
-func (c *LinuxDeviceManager) identifyViaDeviceName(deviceName string) ([]shared.MountInfo, error) {
-	blockDevices, err := c.volumeMounter.CmdRunner.GetBlockDevices()
-	if err != nil {
-		return nil, err
-	}
-	// this is a best-effort approach, we try to find the first unmounted block device as we don't have the device name
-	if deviceName == "" {
-		fsInfo, err := blockDevices.GetUnmountedBlockEntry()
+		target = filteredScsiDevices[0].VolumePath
+	} else {
+		// we have multiple devices at the same LUN. we find the first non-mounted block devices in that list
+		blockDevices, err := c.volumeMounter.CmdRunner.GetBlockDevices()
 		if err != nil {
 			return nil, err
 		}
-		c.volumeMounter.VolumeAttachmentLoc = deviceName
-		return []shared.MountInfo{{DeviceName: fsInfo.Name}}, nil
+		target, err = findMatchingDeviceByBlock(filteredScsiDevices, blockDevices)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	fsInfo, err := blockDevices.GetBlockEntryByName(deviceName)
-	if err != nil {
-		return nil, err
-	}
-	c.volumeMounter.VolumeAttachmentLoc = deviceName
-	return []shared.MountInfo{{DeviceName: fsInfo.Name}}, nil
+	return c.volumeMounter.GetDeviceForMounting(target)
+}
+
+func (c *LinuxDeviceManager) identifyViaDeviceName(deviceName string) (*snapshot.PartitionInfo, error) {
+	// GetDeviceForMounting also supports passing in empty strings, in that case we do a best-effort guess
+	return c.volumeMounter.GetDeviceForMounting(deviceName)
 }

--- a/providers/os/connection/device/linux/device_manager.go
+++ b/providers/os/connection/device/linux/device_manager.go
@@ -60,11 +60,7 @@ func (d *LinuxDeviceManager) IdentifyMountTargets(opts map[string]string) ([]*sn
 }
 
 func (d *LinuxDeviceManager) Mount(pi *snapshot.PartitionInfo) (string, error) {
-	scanDir, err := d.volumeMounter.MountP(pi)
-	if err != nil {
-		return "", err
-	}
-	return scanDir, nil
+	return d.volumeMounter.MountP(pi)
 }
 
 func (d *LinuxDeviceManager) UnmountAndClose() {

--- a/providers/os/connection/device/shared/mountinfo.go
+++ b/providers/os/connection/device/shared/mountinfo.go
@@ -1,8 +1,0 @@
-// Copyright (c) Mondoo, Inc.
-// SPDX-License-Identifier: BUSL-1.1
-
-package shared
-
-type MountInfo struct {
-	DeviceName string
-}

--- a/providers/os/connection/snapshot/blockdevices_test.go
+++ b/providers/os/connection/snapshot/blockdevices_test.go
@@ -21,9 +21,9 @@ func TestGetMatchingBlockEntryByName(t *testing.T) {
 		{Name: "sdx", Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 	}...)
 
-	realFsInfo, err := blockEntries.GetBlockEntryByName("/dev/sdx")
+	realPartitionInfo, err := blockEntries.GetBlockEntryByName("/dev/sdx")
 	require.Nil(t, err)
-	require.Equal(t, fsInfo{FsType: "xfs", Name: "/dev/sdh1"}, *realFsInfo)
+	require.Equal(t, PartitionInfo{FsType: "xfs", Name: "/dev/sdh1"}, *realPartitionInfo)
 
 	blockEntries = BlockDevices{BlockDevices: []BlockDevice{RootDevice}}
 	blockEntries.BlockDevices = append(blockEntries.BlockDevices, []BlockDevice{
@@ -31,9 +31,9 @@ func TestGetMatchingBlockEntryByName(t *testing.T) {
 		{Name: "xvdx", Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "xvdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 	}...)
 
-	realFsInfo, err = blockEntries.GetBlockEntryByName("/dev/sdx")
+	realPartitionInfo, err = blockEntries.GetBlockEntryByName("/dev/sdx")
 	require.Nil(t, err)
-	require.Equal(t, fsInfo{FsType: "xfs", Name: "/dev/xvdh1"}, *realFsInfo)
+	require.Equal(t, PartitionInfo{FsType: "xfs", Name: "/dev/xvdh1"}, *realPartitionInfo)
 
 	blockEntries = BlockDevices{BlockDevices: []BlockDevice{RootDevice}}
 	blockEntries.BlockDevices = append(blockEntries.BlockDevices, []BlockDevice{
@@ -41,20 +41,20 @@ func TestGetMatchingBlockEntryByName(t *testing.T) {
 		{Name: "xvdh", Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "xvdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 	}...)
 
-	realFsInfo, err = blockEntries.GetBlockEntryByName("/dev/xvdh")
+	realPartitionInfo, err = blockEntries.GetBlockEntryByName("/dev/xvdh")
 	require.Nil(t, err)
-	require.Equal(t, fsInfo{FsType: "xfs", Name: "/dev/xvdh1"}, *realFsInfo)
+	require.Equal(t, PartitionInfo{FsType: "xfs", Name: "/dev/xvdh1"}, *realPartitionInfo)
 
 	blockEntries = BlockDevices{BlockDevices: []BlockDevice{RootDevice}}
 	blockEntries.BlockDevices = append(blockEntries.BlockDevices, []BlockDevice{
 		{Name: "nvme0n1", Children: []BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 	}...)
 
-	realFsInfo, err = blockEntries.GetBlockEntryByName("/dev/sdh")
+	_, err = blockEntries.GetBlockEntryByName("/dev/sdh")
 	require.Error(t, err)
 
 	blockEntries = BlockDevices{BlockDevices: []BlockDevice{RootDevice}}
-	realFsInfo, err = blockEntries.GetBlockEntryByName("/dev/sdh")
+	_, err = blockEntries.GetBlockEntryByName("/dev/sdh")
 	require.Error(t, err)
 }
 
@@ -63,16 +63,16 @@ func TestGetNonRootBlockEntry(t *testing.T) {
 	blockEntries.BlockDevices = append(blockEntries.BlockDevices, []BlockDevice{
 		{Name: "nvme0n1", Children: []BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 	}...)
-	realFsInfo, err := blockEntries.GetUnmountedBlockEntry()
+	realPartitionInfo, err := blockEntries.GetUnmountedBlockEntry()
 	require.Nil(t, err)
-	require.Equal(t, fsInfo{FsType: "xfs", Name: "/dev/nvmd1n1"}, *realFsInfo)
+	require.Equal(t, PartitionInfo{FsType: "xfs", Name: "/dev/nvmd1n1"}, *realPartitionInfo)
 }
 
 func TestGetRootBlockEntry(t *testing.T) {
 	blockEntries := BlockDevices{BlockDevices: []BlockDevice{RootDevice}}
-	realFsInfo, err := blockEntries.GetRootBlockEntry()
+	realPartitionInfo, err := blockEntries.GetRootBlockEntry()
 	require.Nil(t, err)
-	require.Equal(t, fsInfo{FsType: "xfs", Name: "/dev/sda1"}, *realFsInfo)
+	require.Equal(t, PartitionInfo{FsType: "xfs", Name: "/dev/sda1"}, *realPartitionInfo)
 }
 
 func TestGetRootBlockEntryRhel8(t *testing.T) {
@@ -83,13 +83,13 @@ func TestGetRootBlockEntryRhel8(t *testing.T) {
 	err = json.Unmarshal(data, &blockEntries)
 	require.NoError(t, err)
 
-	rootFsInfo, err := blockEntries.GetRootBlockEntry()
+	rootPartitionInfo, err := blockEntries.GetRootBlockEntry()
 	require.NoError(t, err)
-	require.Equal(t, fsInfo{FsType: "xfs", Name: "/dev/sda2"}, *rootFsInfo)
+	require.Equal(t, PartitionInfo{FsType: "xfs", Name: "/dev/sda2"}, *rootPartitionInfo)
 
-	rootFsInfo, err = blockEntries.GetUnnamedBlockEntry()
+	rootPartitionInfo, err = blockEntries.GetUnnamedBlockEntry()
 	require.NoError(t, err)
-	require.Equal(t, fsInfo{FsType: "xfs", Name: "/dev/sdc2"}, *rootFsInfo)
+	require.Equal(t, PartitionInfo{FsType: "xfs", Name: "/dev/sdc2"}, *rootPartitionInfo)
 }
 
 func TestGetRootBlockEntryRhelNoLabels(t *testing.T) {
@@ -100,13 +100,13 @@ func TestGetRootBlockEntryRhelNoLabels(t *testing.T) {
 	err = json.Unmarshal(data, &blockEntries)
 	require.NoError(t, err)
 
-	rootFsInfo, err := blockEntries.GetRootBlockEntry()
+	rootPartitionInfo, err := blockEntries.GetRootBlockEntry()
 	require.NoError(t, err)
-	require.Equal(t, fsInfo{FsType: "xfs", Name: "/dev/sda2"}, *rootFsInfo)
+	require.Equal(t, PartitionInfo{FsType: "xfs", Name: "/dev/sda2"}, *rootPartitionInfo)
 
-	rootFsInfo, err = blockEntries.GetUnnamedBlockEntry()
+	rootPartitionInfo, err = blockEntries.GetUnnamedBlockEntry()
 	require.NoError(t, err)
-	require.Equal(t, fsInfo{FsType: "ext4", Name: "/dev/sdb1"}, *rootFsInfo)
+	require.Equal(t, PartitionInfo{FsType: "ext4", Name: "/dev/sdb1"}, *rootPartitionInfo)
 }
 
 func TestAttachedBlockEntry(t *testing.T) {


### PR DESCRIPTION
Split the detection of the partition we're mounting from the actual mounting process. To not make any changes to existing code that's using the volume mounter, I've added two new functions there:  `GetDeviceForMounting` and `MountP` (artition)

The device manager's interface was also reworked:
 * Changed `IdentifyBlockDevice` to `IdentifyMountTargets` to better account for the fact we can have multiple targets (even if unimplemented)
 * `Mount` now returns the scan dir where it was mounted