### PR TITLE
🐛 pin armsecurity package inside cnquery mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module go.mondoo.com/cnquery/v11
 
 go 1.22
 
+// 0.14.0 onwards drops AlertNotifications from SecurityContacts. We need to find a replacement before we can upgrade.
+replace github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/security/armsecurity => github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/security/armsecurity v0.13.0
+
 toolchain go1.22.0
 
 require (


### PR DESCRIPTION
I was unable to build cnquery when trying to build it with the azure provider.
```
$ go run ./providers-sdk/v1/util/configure/configure.go edit-providers -f providers.yaml azure
→ configured providers providers=["azure"]
$ make providers/config
go run ./providers-sdk/v1/util/configure/configure.go -f providers.yaml -o providers/builtin_dev.go
→ (1/3) configured builtin providers path=providers/builtin_dev.go providers=["azure"]
DBG build provider 1/2 provider=azure
→ (2/3) built providers providers=["azure"]
DBG go mod tidy
→ (3/3) rewired dependencies/files path=providers/builtin_dev.go providers=["azure"]
$ make cnquery/build/linux
GOOS=linux GOARCH=amd64 go build -tags production -ldflags "-s -w -X go.mondoo.com/cnquery/v11.Version=v11.5.0 -X go.mondoo.com/cnquery/v11.Build=d122b18db -s -w" apps/cnquery/cnquery.go
# go.mondoo.com/cnquery/v11/providers/azure/resources
providers/azure/resources/cloud_defender.go:192:68: contact.Properties.AlertNotifications undefined (type *armsecurity.ContactProperties has no field or method AlertNotifications)
make: *** [cnquery/build/linux] Error 1
```

My guess is that we pinned the package in here https://github.com/mondoohq/cnquery/pull/4062 at the provider level
but not at the top level.

When pinning it there, the build just worked. 

<img src="https://media0.giphy.com/media/e9naycep2pz7OHQ4n0/giphy.gif"/>
