### PR TITLE
🧹 Make path an arg, not a flag for the FS conn.

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -249,16 +249,17 @@ var Config = plugin.Provider{
 		{
 			Name:    "filesystem",
 			Aliases: []string{"fs"},
-			Use:     "filesystem [flags]",
+			Use:     "filesystem PATH [flags]",
 			Short:   "a mounted file system target",
 			MinArgs: 0,
-			MaxArgs: 0,
+			MaxArgs: 1,
 			Flags: []plugin.Flag{
 				{
 					Long:    "path",
 					Type:    plugin.FlagType_String,
 					Default: "",
 					Desc:    "Path to a local file or directory for the connection to use.",
+					Option:  plugin.FlagOption_Deprecated,
 				},
 			},
 		},

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -134,6 +134,11 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		}
 	case "filesystem", "fs":
 		conf.Type = shared.Type_FileSystem.String()
+		if len(req.Args) > 0 {
+			conf.Path = req.Args[0]
+		} else {
+			log.Warn().Msg("no path provided as an arg, looking for --path flag")
+		}
 	}
 
 	user := ""


### PR DESCRIPTION
Aligns the provider with #4105 by having the path as an arg.  Passing it in as a flag is still supported, but deprecated