### PR TITLE
⭐️ github terraform discovery

### DIFF
--- a/providers/github/connection/platform.go
+++ b/providers/github/connection/platform.go
@@ -16,6 +16,7 @@ const (
 	DiscoveryRepository   = "repository" // deprecated: use repos
 	DiscoveryUser         = "user"       // deprecated: use users
 	DiscoveryOrganization = "organization"
+	DiscoveryTerraform    = "terraform"
 )
 
 var (
@@ -62,7 +63,6 @@ func (c *GithubConnection) PlatformInfo() (*inventory.Platform, error) {
 	}
 
 	if userId := conf.Options["user"]; userId != "" {
-
 		return NewGithubUserPlatform(userId), nil
 	}
 


### PR DESCRIPTION
We can now do terraform discovery for github. Things to note:
- to discover terraform, we need to discover the repo too, this means we provide 2 flags now
```
cnspec scan github repo mondoohq/X--discover repository,terraform 
```
- we use mql to loop over the files and check for terraform files. This means we are caching the directory tree for the repo as we go. Later we can use the same approach when looking for k8s manifests and dockerifiles and can work with the cached tree
- we are cloning the repos in the terraform provider on `Connect`, which means if I am currently scanning a github org, we will pull all repos with terraform files immediately on discovery... We need to change that to only clone the repos on starting the scan and not before. (delayed discovery)
- we probably need to move the clone step to the github/gitlab providers (or to a separate git provider) when we start scanning for k8s manifests and dockerfiles we shouldn't clone the same repo multiple times for each provider