### PR TITLE
🧹 Rename functions in blockdevices.go. Add more tests, sort suitable partitions by size before choosing one.

### DIFF
--- a/providers/os/connection/device/linux/device_manager.go
+++ b/providers/os/connection/device/linux/device_manager.go
@@ -121,10 +121,10 @@ func (c *LinuxDeviceManager) identifyViaLun(lun int) (*snapshot.PartitionInfo, e
 		}
 	}
 
-	return c.volumeMounter.GetDeviceForMounting(target)
+	return c.volumeMounter.GetMountablePartition(target)
 }
 
 func (c *LinuxDeviceManager) identifyViaDeviceName(deviceName string) (*snapshot.PartitionInfo, error) {
-	// GetDeviceForMounting also supports passing in empty strings, in that case we do a best-effort guess
-	return c.volumeMounter.GetDeviceForMounting(deviceName)
+	// GetMountablePartition also supports passing in empty strings, in that case we do a best-effort guess
+	return c.volumeMounter.GetMountablePartition(deviceName)
 }

--- a/providers/os/connection/snapshot/blockdevices.go
+++ b/providers/os/connection/snapshot/blockdevices.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -19,12 +20,12 @@ type BlockDevices struct {
 
 type BlockDevice struct {
 	Name       string        `json:"name,omitempty"`
-	FsType     string        `json:"FsType,omitempty"`
+	FsType     string        `json:"fstype,omitempty"`
 	Label      string        `json:"label,omitempty"`
 	Uuid       string        `json:"uuid,omitempty"`
 	MountPoint string        `json:"mountpoint,omitempty"`
 	Children   []BlockDevice `json:"children,omitempty"`
-	FsUse      string        `json:"fsuse%,omitempty"`
+	Size       int           `json:"size,omitempty"`
 }
 
 type PartitionInfo struct {
@@ -33,7 +34,7 @@ type PartitionInfo struct {
 }
 
 func (cmdRunner *LocalCommandRunner) GetBlockDevices() (*BlockDevices, error) {
-	cmd, err := cmdRunner.RunCommand("lsblk -f --json")
+	cmd, err := cmdRunner.RunCommand("lsblk -bo NAME,SIZE,FSTYPE,MOUNTPOINT,LABEL,UUID --json")
 	if err != nil {
 		return nil, err
 	}
@@ -52,6 +53,7 @@ func (cmdRunner *LocalCommandRunner) GetBlockDevices() (*BlockDevices, error) {
 	if err := json.Unmarshal(data, blockEntries); err != nil {
 		return nil, err
 	}
+	log.Debug().Str("blockEntries", string(data)).Msg("debug>block entries")
 	return blockEntries, nil
 }
 
@@ -71,19 +73,23 @@ func (blockEntries BlockDevices) GetRootBlockEntry() (*PartitionInfo, error) {
 	return nil, errors.New("target volume not found on instance")
 }
 
-func (blockEntries BlockDevices) GetBlockEntryByName(name string) (*PartitionInfo, error) {
-	log.Debug().Str("name", name).Msg("get matching block entry")
+// Searches all the partitions in the target device and finds one that can be mounted. It must be unmounted, non-boot partition
+// If multiple partitions meet this criteria, the largest one is returned.
+func (blockEntries BlockDevices) GetMountablePartitionByDevice(device string) (*PartitionInfo, error) {
+	log.Debug().Str("device", device).Msg("get partitions for device")
+	var block BlockDevice
+	partitions := []BlockDevice{}
 	var secondName string
-	if strings.HasPrefix(name, "/dev/sd") {
+	if strings.HasPrefix(device, "/dev/sd") {
 		// sdh and xvdh are interchangeable
-		end := strings.TrimPrefix(name, "/dev/sd")
+		end := strings.TrimPrefix(device, "/dev/sd")
 		secondName = "/dev/xvd" + end
 	}
 	for i := range blockEntries.BlockDevices {
 		d := blockEntries.BlockDevices[i]
 		log.Debug().Str("name", d.Name).Interface("children", d.Children).Interface("mountpoint", d.MountPoint).Msg("found block device")
 		fullDeviceName := "/dev/" + d.Name
-		if name != fullDeviceName { // check if the device name matches
+		if device != fullDeviceName { // check if the device name matches
 			if secondName == "" {
 				continue
 			}
@@ -91,16 +97,37 @@ func (blockEntries BlockDevices) GetBlockEntryByName(name string) (*PartitionInf
 				continue
 			}
 		}
-		log.Debug().Str("location", d.Name).Msg("found match")
-		for i := range d.Children {
-			entry := d.Children[i]
-			if entry.IsNotBootOrRootVolumeAndUnmounted() {
-				devFsName := "/dev/" + entry.Name
-				return &PartitionInfo{Name: devFsName, FsType: entry.FsType}, nil
-			}
+		log.Debug().Str("name", d.Name).Msg("found matching device")
+		block = d
+		break
+	}
+	if len(block.Name) == 0 {
+		return nil, fmt.Errorf("no block device found with name %s", device)
+	}
+
+	for _, partition := range block.Children {
+		log.Debug().Str("name", partition.Name).Int("size", partition.Size).Msg("checking partition")
+		if partition.IsNotBootOrRootVolumeAndUnmounted() {
+			partitions = append(partitions, partition)
 		}
 	}
-	return nil, errors.New("target volume not found on instance")
+
+	if len(partitions) == 0 {
+		return nil, fmt.Errorf("no suitable partitions found on device %s", block.Name)
+	}
+
+	// sort the candidates by size, so we can pick the largest one
+	sortPartitionsBySize(partitions)
+
+	// return the largest partition. we can extend this to be a parameter in the future
+	devFsName := "/dev/" + partitions[0].Name
+	return &PartitionInfo{Name: devFsName, FsType: partitions[0].FsType}, nil
+}
+
+func sortPartitionsBySize(partitions []BlockDevice) {
+	sort.Slice(partitions, func(i, j int) bool {
+		return partitions[i].Size > partitions[j].Size
+	})
 }
 
 func (blockEntries BlockDevices) GetUnnamedBlockEntry() (*PartitionInfo, error) {

--- a/providers/os/connection/snapshot/blockdevices.go
+++ b/providers/os/connection/snapshot/blockdevices.go
@@ -53,7 +53,6 @@ func (cmdRunner *LocalCommandRunner) GetBlockDevices() (*BlockDevices, error) {
 	if err := json.Unmarshal(data, blockEntries); err != nil {
 		return nil, err
 	}
-	log.Debug().Str("blockEntries", string(data)).Msg("debug>block entries")
 	return blockEntries, nil
 }
 


### PR DESCRIPTION
* Rename `GetDeviceForMounting` to `GetMountablePartition`
* Rename `GetBlockByEntryName` to `GetMountablePartitionByDevice`
* Change the cmd we run to be more extensible, using `lsblk -o OPTS` allows us to include things easily.
* Sort all suitable partitions and pick the largest one. In the case where we have non-mounted, non-boot partitions and we cannot distinguish between them, we simply take the biggest one
* Update tests