### PR TITLE
✨ Add gcp binary authorization resource

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -41,6 +41,7 @@ ingresstls
 iotedge
 ipsetforwardedipconfig
 ipsetreferencestatement
+istio
 jira
 jsonbody
 labelmatchstatement

--- a/providers/gcp/go.mod
+++ b/providers/gcp/go.mod
@@ -41,6 +41,7 @@ require (
 	cloud.google.com/go v0.114.0 // indirect
 	cloud.google.com/go/auth v0.5.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.2 // indirect
+	cloud.google.com/go/binaryauthorization v1.8.3
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	cloud.google.com/go/secretmanager v1.13.1 // indirect
 	cloud.google.com/go/storage v1.41.0 // indirect

--- a/providers/gcp/go.sum
+++ b/providers/gcp/go.sum
@@ -13,6 +13,8 @@ cloud.google.com/go/auth/oauth2adapt v0.2.2 h1:+TTV8aXpjeChS9M+aTtN/TjdQnzJvmzKF
 cloud.google.com/go/auth/oauth2adapt v0.2.2/go.mod h1:wcYjgpZI9+Yu7LyYBg4pqSiaRkfEK3GQcpb7C/uyF1Q=
 cloud.google.com/go/bigquery v1.61.0 h1:w2Goy9n6gh91LVi6B2Sc+HpBl8WbWhIyzdvVvrAuEIw=
 cloud.google.com/go/bigquery v1.61.0/go.mod h1:PjZUje0IocbuTOdq4DBOJLNYB0WF3pAKBHzAYyxCwFo=
+cloud.google.com/go/binaryauthorization v1.8.3 h1:RHnEM4HXbWShlGhPA0Jzj2YYETCHxmisNMU0OE2fXQM=
+cloud.google.com/go/binaryauthorization v1.8.3/go.mod h1:Cul4SsGlbzEsWPOz2sH8m+g2Xergb6ikspUyQ7iOThE=
 cloud.google.com/go/compute v1.27.0 h1:EGawh2RUnfHT5g8f/FX3Ds6KZuIBC77hZoDrBvEZw94=
 cloud.google.com/go/compute v1.27.0/go.mod h1:LG5HwRmWFKM2C5XxHRiNzkLLXW48WwvyVC0mfWsYPOM=
 cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=

--- a/providers/gcp/resources/binary_authorization.go
+++ b/providers/gcp/resources/binary_authorization.go
@@ -1,0 +1,138 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"fmt"
+
+	binaryauthorization "cloud.google.com/go/binaryauthorization/apiv1"
+	"cloud.google.com/go/binaryauthorization/apiv1/binaryauthorizationpb"
+	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
+	"go.mondoo.com/cnquery/v11/providers/gcp/connection"
+	"go.mondoo.com/cnquery/v11/types"
+	"google.golang.org/api/option"
+)
+
+func (g *mqlGcpProject) binaryAuthorization() (*mqlGcpProjectBinaryAuthorizationControl, error) {
+	if g.Id.Error != nil {
+		return nil, g.Id.Error
+	}
+	projectId := g.Id.Data
+
+	serviceEnabled, err := g.isServiceEnabled(service_binaryauthorization)
+	if err != nil {
+		return nil, err
+	}
+	if !serviceEnabled {
+		g.BinaryAuthorization.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
+	credentials, err := conn.Credentials(binaryauthorization.DefaultAuthScopes()...)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	c, err := binaryauthorization.NewSystemPolicyClient(ctx, option.WithCredentials(credentials), option.WithQuotaProject(projectId))
+	if err != nil {
+		return nil, err
+	}
+
+	defer c.Close()
+
+	name := fmt.Sprintf("projects/%s/policy", projectId)
+	resp, err := c.GetSystemPolicy(ctx, &binaryauthorizationpb.GetSystemPolicyRequest{
+		Name: name,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var admissionWhitelistPatterns []interface{}
+	for _, pattern := range resp.GetAdmissionWhitelistPatterns() {
+		admissionWhitelistPatterns = append(admissionWhitelistPatterns, pattern.GetNamePattern())
+	}
+
+	clusterAdmissionRules, err := g.toMqlBinaryAuthzAdmissionRules(resp.GetClusterAdmissionRules(), name, "clusterAdmissionRules")
+	if err != nil {
+		return nil, err
+	}
+
+	kubernetesNamespaceAdmissionRules, err := g.toMqlBinaryAuthzAdmissionRules(resp.GetKubernetesNamespaceAdmissionRules(), name, "kubernetesNamespaceAdmissionRules")
+	if err != nil {
+		return nil, err
+	}
+
+	kubernetesServiceAccountAdmissionRules, err := g.toMqlBinaryAuthzAdmissionRules(resp.GetKubernetesServiceAccountAdmissionRules(), name, "kubernetesServiceAccountAdmissionRules")
+	if err != nil {
+		return nil, err
+	}
+
+	istioServiceIdentityAdmissionRules, err := g.toMqlBinaryAuthzAdmissionRules(resp.GetIstioServiceIdentityAdmissionRules(), name, "istioServiceIdentityAdmissionRules")
+	if err != nil {
+		return nil, err
+	}
+
+	defaultAdmissionRule, err := g.toMqlBinaryAuthzAdmissionRule(resp.GetDefaultAdmissionRule(), fmt.Sprintf("%s/defaultAdmissionRule", name))
+	if err != nil {
+		return nil, err
+	}
+
+	updateTime := resp.GetUpdateTime().AsTime()
+
+	policy, err := CreateResource(g.MqlRuntime, "gcp.project.binaryAuthorizationControl.policy", map[string]*llx.RawData{
+		"__id":                                   llx.StringData(name),
+		"name":                                   llx.StringData(name),
+		"admissionWhitelistPatterns":             llx.ArrayData(admissionWhitelistPatterns, types.String),
+		"globalPolicyEvaluationMode":             llx.StringData(resp.GetGlobalPolicyEvaluationMode().String()),
+		"clusterAdmissionRules":                  llx.MapData(clusterAdmissionRules, types.Resource("gcp.project.binaryAuthorizationControl.admissionRule")),
+		"kubernetesNamespaceAdmissionRules":      llx.MapData(kubernetesNamespaceAdmissionRules, types.Resource("gcp.project.binaryAuthorizationControl.admissionRule")),
+		"kubernetesServiceAccountAdmissionRules": llx.MapData(kubernetesServiceAccountAdmissionRules, types.Resource("gcp.project.binaryAuthorizationControl.admissionRule")),
+		"istioServiceIdentityAdmissionRules":     llx.MapData(istioServiceIdentityAdmissionRules, types.Resource("gcp.project.binaryAuthorizationControl.admissionRule")),
+		"defaultAdmissionRule":                   llx.ResourceData(defaultAdmissionRule, "gcp.project.binaryAuthorizationControl.admissionRule"),
+		"updated":                                llx.TimeData(updateTime),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	bauthz, err := CreateResource(g.MqlRuntime, "gcp.project.binaryAuthorizationControl", map[string]*llx.RawData{
+		"__id":   llx.StringData(fmt.Sprintf("projects/%s/binaryAuthorizationControl", projectId)),
+		"policy": llx.ResourceData(policy, "gcp.project.binaryAuthorizationControl.policy"),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return bauthz.(*mqlGcpProjectBinaryAuthorizationControl), nil
+}
+
+func (g *mqlGcpProject) toMqlBinaryAuthzAdmissionRules(rules map[string]*binaryauthorizationpb.AdmissionRule, policyName string, ruleSetName string) (map[string]interface{}, error) {
+	mqlRules := make(map[string]interface{})
+	for ruleName, rule := range rules {
+		mqlId := fmt.Sprintf("%s/%s/%s", policyName, ruleSetName, ruleName)
+		mqlRule, err := g.toMqlBinaryAuthzAdmissionRule(rule, mqlId)
+		if err != nil {
+			return nil, err
+		}
+		mqlRules[ruleName] = mqlRule
+	}
+	return mqlRules, nil
+}
+
+func (g *mqlGcpProject) toMqlBinaryAuthzAdmissionRule(rule *binaryauthorizationpb.AdmissionRule, mqlId string) (plugin.Resource, error) {
+	var requiresAttestationsBy []interface{}
+	for _, attestation := range rule.GetRequireAttestationsBy() {
+		requiresAttestationsBy = append(requiresAttestationsBy, attestation)
+	}
+	return CreateResource(g.MqlRuntime, "gcp.project.binaryAuthorizationControl.admissionRule", map[string]*llx.RawData{
+		"__id":                  llx.StringData(mqlId),
+		"evaluationMode":        llx.StringData(rule.GetEvaluationMode().String()),
+		"requireAttestationsBy": llx.ArrayData(requiresAttestationsBy, types.String),
+	})
+}

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -138,6 +138,8 @@ gcp.project @defaults("name") {
   storage() gcp.project.storageService
   // Monitoring resources
   monitoring() gcp.project.monitoringService
+  // Binary Authorization resources
+  binaryAuthorization() gcp.project.binaryAuthorizationControl
 }
 
 // Google Cloud (GCP) service
@@ -2808,4 +2810,39 @@ private gcp.project.monitoringService.alertPolicy {
   updatedBy string
   // Configuration for notification channels notifications
   alertStrategy dict
+}
+
+private gcp.project.binaryAuthorizationControl {
+  // The policy for container image binary authorization
+  policy gcp.project.binaryAuthorizationControl.policy
+}
+
+private gcp.project.binaryAuthorizationControl.policy {
+  // The resource name
+  name string
+  // Controls the evaluation of a Google-maintained global admission policy for common system-level images
+  globalPolicyEvaluationMode string
+  // Admission policy allowlisting
+  admissionWhitelistPatterns []string
+  // Per-cluster admission rules
+  clusterAdmissionRules map[string]gcp.project.binaryAuthorizationControl.admissionRule
+  // Per-kubernetes-namespace admission rules
+  kubernetesNamespaceAdmissionRules map[string]gcp.project.binaryAuthorizationControl.admissionRule
+  // Per-kubernetes-service-account admission rules
+  kubernetesServiceAccountAdmissionRules map[string]gcp.project.binaryAuthorizationControl.admissionRule
+  // Per-istio-service-identity admission rules
+  istioServiceIdentityAdmissionRules map[string]gcp.project.binaryAuthorizationControl.admissionRule
+  // Default admission rule for a cluster without a per-cluster, per-kubernetes-service-account, or per-istio-service-identity admission rule
+  defaultAdmissionRule gcp.project.binaryAuthorizationControl.admissionRule
+  // Time when the policy was last updated
+  updated time
+}
+
+private gcp.project.binaryAuthorizationControl.admissionRule {
+  // How this admission rule will be evaluated
+  evaluationMode string
+  // The action when a pod creation is denied by the admission rule
+  enforcementMode string
+  // The resource names of the attestors that must attest to a container image
+  requireAttestationsBy []string
 }

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -506,6 +506,18 @@ func init() {
 			// to override args, implement: initGcpProjectMonitoringServiceAlertPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createGcpProjectMonitoringServiceAlertPolicy,
 		},
+		"gcp.project.binaryAuthorizationControl": {
+			// to override args, implement: initGcpProjectBinaryAuthorizationControl(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGcpProjectBinaryAuthorizationControl,
+		},
+		"gcp.project.binaryAuthorizationControl.policy": {
+			// to override args, implement: initGcpProjectBinaryAuthorizationControlPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGcpProjectBinaryAuthorizationControlPolicy,
+		},
+		"gcp.project.binaryAuthorizationControl.admissionRule": {
+			// to override args, implement: initGcpProjectBinaryAuthorizationControlAdmissionRule(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGcpProjectBinaryAuthorizationControlAdmissionRule,
+		},
 	}
 }
 
@@ -726,6 +738,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.monitoring": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProject).GetMonitoring()).ToDataRes(types.Resource("gcp.project.monitoringService"))
+	},
+	"gcp.project.binaryAuthorization": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProject).GetBinaryAuthorization()).ToDataRes(types.Resource("gcp.project.binaryAuthorizationControl"))
 	},
 	"gcp.service.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpService).GetProjectId()).ToDataRes(types.String)
@@ -4036,6 +4051,45 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.monitoringService.alertPolicy.alertStrategy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectMonitoringServiceAlertPolicy).GetAlertStrategy()).ToDataRes(types.Dict)
 	},
+	"gcp.project.binaryAuthorizationControl.policy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBinaryAuthorizationControl).GetPolicy()).ToDataRes(types.Resource("gcp.project.binaryAuthorizationControl.policy"))
+	},
+	"gcp.project.binaryAuthorizationControl.policy.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBinaryAuthorizationControlPolicy).GetName()).ToDataRes(types.String)
+	},
+	"gcp.project.binaryAuthorizationControl.policy.globalPolicyEvaluationMode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBinaryAuthorizationControlPolicy).GetGlobalPolicyEvaluationMode()).ToDataRes(types.String)
+	},
+	"gcp.project.binaryAuthorizationControl.policy.admissionWhitelistPatterns": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBinaryAuthorizationControlPolicy).GetAdmissionWhitelistPatterns()).ToDataRes(types.Array(types.String))
+	},
+	"gcp.project.binaryAuthorizationControl.policy.clusterAdmissionRules": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBinaryAuthorizationControlPolicy).GetClusterAdmissionRules()).ToDataRes(types.Map(types.String, types.Resource("gcp.project.binaryAuthorizationControl.admissionRule")))
+	},
+	"gcp.project.binaryAuthorizationControl.policy.kubernetesNamespaceAdmissionRules": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBinaryAuthorizationControlPolicy).GetKubernetesNamespaceAdmissionRules()).ToDataRes(types.Map(types.String, types.Resource("gcp.project.binaryAuthorizationControl.admissionRule")))
+	},
+	"gcp.project.binaryAuthorizationControl.policy.kubernetesServiceAccountAdmissionRules": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBinaryAuthorizationControlPolicy).GetKubernetesServiceAccountAdmissionRules()).ToDataRes(types.Map(types.String, types.Resource("gcp.project.binaryAuthorizationControl.admissionRule")))
+	},
+	"gcp.project.binaryAuthorizationControl.policy.istioServiceIdentityAdmissionRules": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBinaryAuthorizationControlPolicy).GetIstioServiceIdentityAdmissionRules()).ToDataRes(types.Map(types.String, types.Resource("gcp.project.binaryAuthorizationControl.admissionRule")))
+	},
+	"gcp.project.binaryAuthorizationControl.policy.defaultAdmissionRule": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBinaryAuthorizationControlPolicy).GetDefaultAdmissionRule()).ToDataRes(types.Resource("gcp.project.binaryAuthorizationControl.admissionRule"))
+	},
+	"gcp.project.binaryAuthorizationControl.policy.updated": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBinaryAuthorizationControlPolicy).GetUpdated()).ToDataRes(types.Time)
+	},
+	"gcp.project.binaryAuthorizationControl.admissionRule.evaluationMode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBinaryAuthorizationControlAdmissionRule).GetEvaluationMode()).ToDataRes(types.String)
+	},
+	"gcp.project.binaryAuthorizationControl.admissionRule.enforcementMode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBinaryAuthorizationControlAdmissionRule).GetEnforcementMode()).ToDataRes(types.String)
+	},
+	"gcp.project.binaryAuthorizationControl.admissionRule.requireAttestationsBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBinaryAuthorizationControlAdmissionRule).GetRequireAttestationsBy()).ToDataRes(types.Array(types.String))
+	},
 }
 
 func GetData(resource plugin.Resource, field string, args map[string]*llx.RawData) *plugin.DataRes {
@@ -4270,6 +4324,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"gcp.project.monitoring": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProject).Monitoring, ok = plugin.RawToTValue[*mqlGcpProjectMonitoringService](v.Value, v.Error)
+		return
+	},
+	"gcp.project.binaryAuthorization": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProject).BinaryAuthorization, ok = plugin.RawToTValue[*mqlGcpProjectBinaryAuthorizationControl](v.Value, v.Error)
 		return
 	},
 	"gcp.service.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9152,6 +9210,70 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlGcpProjectMonitoringServiceAlertPolicy).AlertStrategy, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
 		return
 	},
+	"gcp.project.binaryAuthorizationControl.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlGcpProjectBinaryAuthorizationControl).__id, ok = v.Value.(string)
+			return
+		},
+	"gcp.project.binaryAuthorizationControl.policy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBinaryAuthorizationControl).Policy, ok = plugin.RawToTValue[*mqlGcpProjectBinaryAuthorizationControlPolicy](v.Value, v.Error)
+		return
+	},
+	"gcp.project.binaryAuthorizationControl.policy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlGcpProjectBinaryAuthorizationControlPolicy).__id, ok = v.Value.(string)
+			return
+		},
+	"gcp.project.binaryAuthorizationControl.policy.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBinaryAuthorizationControlPolicy).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.binaryAuthorizationControl.policy.globalPolicyEvaluationMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBinaryAuthorizationControlPolicy).GlobalPolicyEvaluationMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.binaryAuthorizationControl.policy.admissionWhitelistPatterns": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBinaryAuthorizationControlPolicy).AdmissionWhitelistPatterns, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"gcp.project.binaryAuthorizationControl.policy.clusterAdmissionRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBinaryAuthorizationControlPolicy).ClusterAdmissionRules, ok = plugin.RawToTValue[map[string]interface{}](v.Value, v.Error)
+		return
+	},
+	"gcp.project.binaryAuthorizationControl.policy.kubernetesNamespaceAdmissionRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBinaryAuthorizationControlPolicy).KubernetesNamespaceAdmissionRules, ok = plugin.RawToTValue[map[string]interface{}](v.Value, v.Error)
+		return
+	},
+	"gcp.project.binaryAuthorizationControl.policy.kubernetesServiceAccountAdmissionRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBinaryAuthorizationControlPolicy).KubernetesServiceAccountAdmissionRules, ok = plugin.RawToTValue[map[string]interface{}](v.Value, v.Error)
+		return
+	},
+	"gcp.project.binaryAuthorizationControl.policy.istioServiceIdentityAdmissionRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBinaryAuthorizationControlPolicy).IstioServiceIdentityAdmissionRules, ok = plugin.RawToTValue[map[string]interface{}](v.Value, v.Error)
+		return
+	},
+	"gcp.project.binaryAuthorizationControl.policy.defaultAdmissionRule": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBinaryAuthorizationControlPolicy).DefaultAdmissionRule, ok = plugin.RawToTValue[*mqlGcpProjectBinaryAuthorizationControlAdmissionRule](v.Value, v.Error)
+		return
+	},
+	"gcp.project.binaryAuthorizationControl.policy.updated": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBinaryAuthorizationControlPolicy).Updated, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"gcp.project.binaryAuthorizationControl.admissionRule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlGcpProjectBinaryAuthorizationControlAdmissionRule).__id, ok = v.Value.(string)
+			return
+		},
+	"gcp.project.binaryAuthorizationControl.admissionRule.evaluationMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBinaryAuthorizationControlAdmissionRule).EvaluationMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.binaryAuthorizationControl.admissionRule.enforcementMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBinaryAuthorizationControlAdmissionRule).EnforcementMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.binaryAuthorizationControl.admissionRule.requireAttestationsBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBinaryAuthorizationControlAdmissionRule).RequireAttestationsBy, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
 }
 
 func SetData(resource plugin.Resource, field string, val *llx.RawData) error {
@@ -9622,6 +9744,7 @@ type mqlGcpProject struct {
 	AccessApprovalSettings plugin.TValue[*mqlGcpAccessApprovalSettings]
 	Storage plugin.TValue[*mqlGcpProjectStorageService]
 	Monitoring plugin.TValue[*mqlGcpProjectMonitoringService]
+	BinaryAuthorization plugin.TValue[*mqlGcpProjectBinaryAuthorizationControl]
 }
 
 // createGcpProject creates a new instance of this resource
@@ -10030,6 +10153,22 @@ func (c *mqlGcpProject) GetMonitoring() *plugin.TValue[*mqlGcpProjectMonitoringS
 		}
 
 		return c.monitoring()
+	})
+}
+
+func (c *mqlGcpProject) GetBinaryAuthorization() *plugin.TValue[*mqlGcpProjectBinaryAuthorizationControl] {
+	return plugin.GetOrCompute[*mqlGcpProjectBinaryAuthorizationControl](&c.BinaryAuthorization, func() (*mqlGcpProjectBinaryAuthorizationControl, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project", c.__id, "binaryAuthorization")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectBinaryAuthorizationControl), nil
+			}
+		}
+
+		return c.binaryAuthorization()
 	})
 }
 
@@ -21446,4 +21585,186 @@ func (c *mqlGcpProjectMonitoringServiceAlertPolicy) GetUpdatedBy() *plugin.TValu
 
 func (c *mqlGcpProjectMonitoringServiceAlertPolicy) GetAlertStrategy() *plugin.TValue[interface{}] {
 	return &c.AlertStrategy
+}
+
+// mqlGcpProjectBinaryAuthorizationControl for the gcp.project.binaryAuthorizationControl resource
+type mqlGcpProjectBinaryAuthorizationControl struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlGcpProjectBinaryAuthorizationControlInternal it will be used here
+	Policy plugin.TValue[*mqlGcpProjectBinaryAuthorizationControlPolicy]
+}
+
+// createGcpProjectBinaryAuthorizationControl creates a new instance of this resource
+func createGcpProjectBinaryAuthorizationControl(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGcpProjectBinaryAuthorizationControl{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("gcp.project.binaryAuthorizationControl", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGcpProjectBinaryAuthorizationControl) MqlName() string {
+	return "gcp.project.binaryAuthorizationControl"
+}
+
+func (c *mqlGcpProjectBinaryAuthorizationControl) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGcpProjectBinaryAuthorizationControl) GetPolicy() *plugin.TValue[*mqlGcpProjectBinaryAuthorizationControlPolicy] {
+	return &c.Policy
+}
+
+// mqlGcpProjectBinaryAuthorizationControlPolicy for the gcp.project.binaryAuthorizationControl.policy resource
+type mqlGcpProjectBinaryAuthorizationControlPolicy struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlGcpProjectBinaryAuthorizationControlPolicyInternal it will be used here
+	Name plugin.TValue[string]
+	GlobalPolicyEvaluationMode plugin.TValue[string]
+	AdmissionWhitelistPatterns plugin.TValue[[]interface{}]
+	ClusterAdmissionRules plugin.TValue[map[string]interface{}]
+	KubernetesNamespaceAdmissionRules plugin.TValue[map[string]interface{}]
+	KubernetesServiceAccountAdmissionRules plugin.TValue[map[string]interface{}]
+	IstioServiceIdentityAdmissionRules plugin.TValue[map[string]interface{}]
+	DefaultAdmissionRule plugin.TValue[*mqlGcpProjectBinaryAuthorizationControlAdmissionRule]
+	Updated plugin.TValue[*time.Time]
+}
+
+// createGcpProjectBinaryAuthorizationControlPolicy creates a new instance of this resource
+func createGcpProjectBinaryAuthorizationControlPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGcpProjectBinaryAuthorizationControlPolicy{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("gcp.project.binaryAuthorizationControl.policy", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGcpProjectBinaryAuthorizationControlPolicy) MqlName() string {
+	return "gcp.project.binaryAuthorizationControl.policy"
+}
+
+func (c *mqlGcpProjectBinaryAuthorizationControlPolicy) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGcpProjectBinaryAuthorizationControlPolicy) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlGcpProjectBinaryAuthorizationControlPolicy) GetGlobalPolicyEvaluationMode() *plugin.TValue[string] {
+	return &c.GlobalPolicyEvaluationMode
+}
+
+func (c *mqlGcpProjectBinaryAuthorizationControlPolicy) GetAdmissionWhitelistPatterns() *plugin.TValue[[]interface{}] {
+	return &c.AdmissionWhitelistPatterns
+}
+
+func (c *mqlGcpProjectBinaryAuthorizationControlPolicy) GetClusterAdmissionRules() *plugin.TValue[map[string]interface{}] {
+	return &c.ClusterAdmissionRules
+}
+
+func (c *mqlGcpProjectBinaryAuthorizationControlPolicy) GetKubernetesNamespaceAdmissionRules() *plugin.TValue[map[string]interface{}] {
+	return &c.KubernetesNamespaceAdmissionRules
+}
+
+func (c *mqlGcpProjectBinaryAuthorizationControlPolicy) GetKubernetesServiceAccountAdmissionRules() *plugin.TValue[map[string]interface{}] {
+	return &c.KubernetesServiceAccountAdmissionRules
+}
+
+func (c *mqlGcpProjectBinaryAuthorizationControlPolicy) GetIstioServiceIdentityAdmissionRules() *plugin.TValue[map[string]interface{}] {
+	return &c.IstioServiceIdentityAdmissionRules
+}
+
+func (c *mqlGcpProjectBinaryAuthorizationControlPolicy) GetDefaultAdmissionRule() *plugin.TValue[*mqlGcpProjectBinaryAuthorizationControlAdmissionRule] {
+	return &c.DefaultAdmissionRule
+}
+
+func (c *mqlGcpProjectBinaryAuthorizationControlPolicy) GetUpdated() *plugin.TValue[*time.Time] {
+	return &c.Updated
+}
+
+// mqlGcpProjectBinaryAuthorizationControlAdmissionRule for the gcp.project.binaryAuthorizationControl.admissionRule resource
+type mqlGcpProjectBinaryAuthorizationControlAdmissionRule struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlGcpProjectBinaryAuthorizationControlAdmissionRuleInternal it will be used here
+	EvaluationMode plugin.TValue[string]
+	EnforcementMode plugin.TValue[string]
+	RequireAttestationsBy plugin.TValue[[]interface{}]
+}
+
+// createGcpProjectBinaryAuthorizationControlAdmissionRule creates a new instance of this resource
+func createGcpProjectBinaryAuthorizationControlAdmissionRule(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGcpProjectBinaryAuthorizationControlAdmissionRule{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("gcp.project.binaryAuthorizationControl.admissionRule", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGcpProjectBinaryAuthorizationControlAdmissionRule) MqlName() string {
+	return "gcp.project.binaryAuthorizationControl.admissionRule"
+}
+
+func (c *mqlGcpProjectBinaryAuthorizationControlAdmissionRule) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGcpProjectBinaryAuthorizationControlAdmissionRule) GetEvaluationMode() *plugin.TValue[string] {
+	return &c.EvaluationMode
+}
+
+func (c *mqlGcpProjectBinaryAuthorizationControlAdmissionRule) GetEnforcementMode() *plugin.TValue[string] {
+	return &c.EnforcementMode
+}
+
+func (c *mqlGcpProjectBinaryAuthorizationControlAdmissionRule) GetRequireAttestationsBy() *plugin.TValue[[]interface{}] {
+	return &c.RequireAttestationsBy
 }

--- a/providers/gcp/resources/gcp.lr.manifest.yaml
+++ b/providers/gcp/resources/gcp.lr.manifest.yaml
@@ -175,6 +175,7 @@ resources:
       accessApprovalSettings: {}
       apiKeys: {}
       bigquery: {}
+      binaryAuthorization: {}
       cloudFunctions: {}
       cloudRun: {}
       commonInstanceMetadata: {}
@@ -373,6 +374,80 @@ resources:
     refs:
     - title: Introduction to tables
       url: https://cloud.google.com/bigquery/docs/tables-intro
+  gcp.project.binaryAuthorization:
+    fields:
+      admissionWhitelistPatterns: {}
+      clusterAdmissionRules: {}
+      defaultAdmissionRule: {}
+      globalPolicyEvaluationMode: {}
+      istioServiceIdentityAdmissionRules: {}
+      kubernetesNamespaceAdmissionRules: {}
+      kubernetesServiceAccountAdmissionRules: {}
+      name: {}
+      policy: {}
+      updated: {}
+    min_mondoo_version: latest
+    platform:
+      name:
+      - gcp
+  gcp.project.binaryAuthorization.admissionRule:
+    fields:
+      enforcementMode: {}
+      evaluationMode: {}
+      requireAttestationsBy: {}
+    min_mondoo_version: latest
+    platform:
+      name:
+      - gcp
+  gcp.project.binaryAuthorization.policy:
+    fields:
+      admissionWhitelistPatterns: {}
+      clusterAdmissionRules: {}
+      defaultAdmissionRule: {}
+      globalPolicyEvaluationMode: {}
+      istioServiceIdentityAdmissionRules: {}
+      kubernetesNamespaceAdmissionRules: {}
+      kubernetesServiceAccountAdmissionRules: {}
+      name: {}
+      updated: {}
+    min_mondoo_version: latest
+    platform:
+      name:
+      - gcp
+  gcp.project.binaryAuthorizationControl:
+    fields:
+      policy: {}
+    is_private: true
+    min_mondoo_version: latest
+    platform:
+      name:
+      - gcp
+  gcp.project.binaryAuthorizationControl.admissionRule:
+    fields:
+      enforcementMode: {}
+      evaluationMode: {}
+      requireAttestationsBy: {}
+    is_private: true
+    min_mondoo_version: latest
+    platform:
+      name:
+      - gcp
+  gcp.project.binaryAuthorizationControl.policy:
+    fields:
+      admissionWhitelistPatterns: {}
+      clusterAdmissionRules: {}
+      defaultAdmissionRule: {}
+      globalPolicyEvaluationMode: {}
+      istioServiceIdentityAdmissionRules: {}
+      kubernetesNamespaceAdmissionRules: {}
+      kubernetesServiceAccountAdmissionRules: {}
+      name: {}
+      updated: {}
+    is_private: true
+    min_mondoo_version: latest
+    platform:
+      name:
+      - gcp
   gcp.project.cloudFunction:
     fields:
       availableMemoryMb: {}

--- a/providers/gcp/resources/services.go
+++ b/providers/gcp/resources/services.go
@@ -18,14 +18,15 @@ import (
 )
 
 const (
-	service_compute            = "compute.googleapis.com"
-	service_gke                = "container.googleapis.com"
-	service_bigquery           = "bigquery.googleapis.com"
-	service_essential_contacts = "essentialcontacts.googleapis.com"
-	service_dns                = "dns.googleapis.com"
-	service_accessapproval     = "accessapproval.googleapis.com"
-	service_apikeys            = "apikeys.googleapis.com"
-	service_dataproc           = "dataproc.googleapis.com"
+	service_compute             = "compute.googleapis.com"
+	service_gke                 = "container.googleapis.com"
+	service_bigquery            = "bigquery.googleapis.com"
+	service_essential_contacts  = "essentialcontacts.googleapis.com"
+	service_dns                 = "dns.googleapis.com"
+	service_accessapproval      = "accessapproval.googleapis.com"
+	service_apikeys             = "apikeys.googleapis.com"
+	service_dataproc            = "dataproc.googleapis.com"
+	service_binaryauthorization = "binaryauthorization.googleapis.com"
 )
 
 func serviceName(name string) string {


### PR DESCRIPTION
```
cnquery> gcp.project.binaryAuthorization { policy { * } }
gcp.project.binaryAuthorization: {
  policy: {
    kubernetesServiceAccountAdmissionRules: {}
    name: "projects/manuel-development-3/policy"
    globalPolicyEvaluationMode: "GLOBAL_POLICY_EVALUATION_MODE_UNSPECIFIED"
    defaultAdmissionRule: gcp.project.binaryAuthorizationControl.admissionRule id = projects/manuel-development-3/policy/defaultAdmissionRule
    admissionWhitelistPatterns: [
      0: "asia.gcr.io/gke-multi-cloud-release/**"
      1: "asia.gcr.io/google-containers/addon-resizer:*"
      ...
```