### PR TITLE
🧹 improve provider release version detect

### DIFF
--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -54,7 +54,7 @@ jobs:
               continue
             fi
             cd providers/$p
-            REPO_VERSION=$(grep Version config/config.go | cut -f2 -d\")
+            REPO_VERSION=$(grep Version: config/config.go | cut -f2 -d\")
             STATUS_CODE=$(curl -s -o /dev/null -I -w "%{http_code}" https://releases.mondoo.com/providers/${p}/latest.json)
             if [ "$STATUS_CODE" -eq "404" ]; then
               DIST_VERSION="unreleased"


### PR DESCRIPTION
we wrongfully detect versions for some providers because we `grep` for `Version`. Some of the providers have a flag that is called "Version", which conflicts. Searching for `Version:` should limit the results to just the Go struct