### PR TITLE
⭐️ gitlab k8s manifest discovery

### DIFF
--- a/explorer/scan/discovery.go
+++ b/explorer/scan/discovery.go
@@ -151,6 +151,12 @@ func DiscoverAssets(ctx context.Context, inv *inventory.Inventory, upstream *ups
 }
 
 func discoverAssets(rootAssetWithRuntime *AssetWithRuntime, resolvedRootAsset *inventory.Asset, discoveredAssets *DiscoveredAssets, runtimeLabels map[string]string, upstream *upstream.UpstreamConfig, recording llx.Recording) {
+	// It is possible that we did not discover any assets under the root asset. In that case the inventory
+	// would be nil and we can return
+	if rootAssetWithRuntime.Runtime.Provider.Connection.Inventory == nil {
+		return
+	}
+
 	// for all discovered assets, we apply mondoo-specific labels and annotations that come from the root asset
 	for _, a := range rootAssetWithRuntime.Runtime.Provider.Connection.Inventory.Spec.Assets {
 		// create runtime for root asset

--- a/providers/gitlab/provider/provider.go
+++ b/providers/gitlab/provider/provider.go
@@ -30,7 +30,8 @@ const (
 	DiscoveryGroup   = "groups"
 	DiscoveryProject = "projects"
 	// -- chained git discovery options --
-	DiscoveryTerraform = "terraform"
+	DiscoveryTerraform    = "terraform"
+	DiscoveryK8sManifests = "k8s-manifests"
 )
 
 type Service struct {


### PR DESCRIPTION
- add k8s manifest discovery for gitlab scans
- skip over mql yaml files for gitlab and github
- fix panic in cnquery when no k8s manifests are discovered for a cloned repo

```
./cnquery scan gitlab --group mondoolabs --discover k8s-manifests
```