### PR TITLE
🐛 Fix bug in gke networkPolicyConfig

### DIFF
--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -525,7 +525,7 @@ func (g *mqlGcpProjectGkeService) clusters() ([]interface{}, error) {
 		if c.NetworkPolicy != nil {
 			networkPolicyConfig = map[string]interface{}{
 				"enabled":  c.NetworkPolicy.Enabled,
-				"provider": c.NetworkPolicy.Provider,
+				"provider": c.NetworkPolicy.Provider.String(),
 			}
 		}
 


### PR DESCRIPTION
Fixes the following error message
```
failed to convert dict to primitive, unsupported child type: containerpb.NetworkPolicy_Provider
```

Fixes #3868 