### PR TITLE
🐛 guard against assignment to entry in nil map in device connection

### DIFF
--- a/providers/os/connection/device/device_connection.go
+++ b/providers/os/connection/device/device_connection.go
@@ -70,6 +70,9 @@ func NewDeviceConnection(connId uint32, conf *inventory.Config, asset *inventory
 		res.Close()
 		return nil, err
 	}
+	if conf.Options == nil {
+		conf.Options = make(map[string]string)
+	}
 
 	conf.Options["path"] = scanDir
 	// create and initialize fs provider


### PR DESCRIPTION
just in case conf.Options is nil

```
	/home/runner/_work/_tool/go/1.22.2/x64/src/runtime/panic.go:770 +0x124
go.mondoo.com/cnquery/v11/providers/os/connection/device.NewDeviceConnection(0x1, 0x40003d80f0, 0x4000f76640)
	/home/runner/_work/purplebox-aws/cnquery/providers/os/connection/device/device_connection.go:74 +0x274
go.mondoo.com/cnquery/v11/providers/os/provider.(*Service).connect.func1(0x1)
```