### PR TITLE
🐛 fix missing connections for discovered duplicate assets

### DIFF
--- a/explorer/scan/discovery.go
+++ b/explorer/scan/discovery.go
@@ -167,6 +167,12 @@ func discoverAssets(rootAssetWithRuntime *AssetWithRuntime, resolvedRootAsset *i
 			continue
 		}
 
+		// If no asset was returned and no error, then we observed a duplicate asset with a
+		// runtime that already exists.
+		if assetWithRuntime == nil {
+			continue
+		}
+
 		resolvedAsset := assetWithRuntime.Runtime.Provider.Connection.Asset
 		if len(resolvedAsset.PlatformIds) > 0 {
 			prepareAsset(resolvedAsset, resolvedRootAsset, runtimeLabels)
@@ -196,6 +202,12 @@ func createRuntimeForAsset(asset *inventory.Asset, upstream *upstream.UpstreamCo
 	if err != nil {
 		return nil, err
 	}
+
+	// If the runtime already has a connection, it means we have a duplicate asset
+	if runtime.Provider.Connection != nil {
+		return nil, nil
+	}
+
 	if err = runtime.SetRecording(recording); err != nil {
 		return nil, err
 	}

--- a/explorer/scan/discovery_test.go
+++ b/explorer/scan/discovery_test.go
@@ -149,6 +149,10 @@ func TestDiscoverAssets(t *testing.T) {
 		assert.Equal(t, "mondoo-operator-123", discoveredAssets.Assets[0].Asset.ManagedBy)
 		assert.Equal(t, "mondoo-operator-123", discoveredAssets.Assets[1].Asset.ManagedBy)
 		assert.Equal(t, "mondoo-operator-123", discoveredAssets.Assets[2].Asset.ManagedBy)
+
+		for _, asset := range discoveredAssets.Assets {
+			asset.Runtime.Close()
+		}
 	})
 
 	t.Run("with duplicate root assets", func(t *testing.T) {
@@ -160,6 +164,10 @@ func TestDiscoverAssets(t *testing.T) {
 		// Make sure no duplicates are returned
 		assert.Len(t, discoveredAssets.Assets, 3)
 		assert.Len(t, discoveredAssets.Errors, 0)
+
+		for _, asset := range discoveredAssets.Assets {
+			asset.Runtime.Close()
+		}
 	})
 
 	t.Run("with duplicate discovered assets", func(t *testing.T) {
@@ -171,6 +179,10 @@ func TestDiscoverAssets(t *testing.T) {
 		// Make sure no duplicates are returned
 		assert.Len(t, discoveredAssets.Assets, 3)
 		assert.Len(t, discoveredAssets.Errors, 0)
+
+		for _, asset := range discoveredAssets.Assets {
+			asset.Runtime.Close()
+		}
 	})
 
 	t.Run("copy root asset annotations", func(t *testing.T) {
@@ -188,6 +200,10 @@ func TestDiscoverAssets(t *testing.T) {
 				assert.Equal(t, v, asset.Asset.Annotations[k])
 			}
 		}
+
+		for _, asset := range discoveredAssets.Assets {
+			asset.Runtime.Close()
+		}
 	})
 
 	t.Run("copy root asset managedBy", func(t *testing.T) {
@@ -198,6 +214,10 @@ func TestDiscoverAssets(t *testing.T) {
 
 		for _, asset := range discoveredAssets.Assets {
 			assert.Equal(t, inv.Spec.Assets[0].ManagedBy, asset.Asset.ManagedBy)
+		}
+
+		for _, asset := range discoveredAssets.Assets {
+			asset.Runtime.Close()
 		}
 	})
 
@@ -220,6 +240,10 @@ func TestDiscoverAssets(t *testing.T) {
 		for _, asset := range discoveredAssets.Assets {
 			require.Contains(t, asset.Asset.Labels, "mondoo.com/exec-environment")
 			assert.Equal(t, "actions.github.com", asset.Asset.Labels["mondoo.com/exec-environment"])
+		}
+
+		for _, asset := range discoveredAssets.Assets {
+			asset.Runtime.Close()
 		}
 	})
 
@@ -244,6 +268,10 @@ func TestDiscoverAssets(t *testing.T) {
 			require.Contains(t, asset.Asset.Labels, "mondoo.com/exec-environment")
 			assert.Equal(t, "actions.github.com", asset.Asset.Labels["mondoo.com/exec-environment"])
 		}
+
+		for _, asset := range discoveredAssets.Assets {
+			asset.Runtime.Close()
+		}
 	})
 
 	t.Run("scannable root asset", func(t *testing.T) {
@@ -253,5 +281,9 @@ func TestDiscoverAssets(t *testing.T) {
 		discoveredAssets, err := DiscoverAssets(context.Background(), inv, nil, recording.Null{})
 		require.NoError(t, err)
 		assert.Len(t, discoveredAssets.Assets, 1)
+
+		for _, asset := range discoveredAssets.Assets {
+			asset.Runtime.Close()
+		}
 	})
 }


### PR DESCRIPTION
if we discover multiple assets with the same platform IDs, they will get their runtimes messed up. We will close the runtime and the first asset will show errors that the connection was not found. We need to skip over duplicate assets before creating runtime for them