### PR TITLE
📝 Update go version to 1.22 in development.md

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -6,14 +6,14 @@
 
 Before building from source, be sure to install:
 
-- [Go 1.21.0+](https://golang.org/dl/)
+- [Go 1.22.0+](https://golang.org/dl/)
 - [Protocol Buffers v21+](https://github.com/protocolbuffers/protobuf/releases)
 
-On macOS systems with Homebrew, run: `brew install go@1.21 protobuf`
+On macOS systems with Homebrew, run: `brew install go@1.22 protobuf`
 
 ## Install from source
 
-1. Verify that you have Go 1.21+ installed:
+1. Verify that you have Go 1.22+ installed:
 
    ```
    $ go version
@@ -184,7 +184,7 @@ to use the latest updates from the different repos without having to commit and 
 Here is a sample config for `go.work` in the root folder of `cnquery` and `cnspec`:
 
 ```
-go 1.21
+go 1.22
 
 use (
    ./cnquery


### PR DESCRIPTION
This is what our `go.mod` says https://github.com/mondoohq/cnquery/blob/main/go.mod#L3

<img src="https://media0.giphy.com/media/wpgYasZ0tBrP4lCgS3/giphy-downsized-medium.gif"/>