### PR TITLE
Expand data collected in gcp.project.sqlService.instance.settings.ipConfiguration

### DIFF
--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -1132,6 +1132,10 @@ private gcp.project.sqlService.instance.settings.ipConfiguration {
   privateNetwork string
   // Whether SSL connections over IP are enforced
   requireSsl bool
+  // Specifies how SSL/TLS is enforced in database connections.
+  sslMode string
+  // Controls connectivity to private IP instances from Google services, such as BigQuery.
+  enablePrivatePathForGoogleCloudServices bool
 }
 
 // Google Cloud (GCP) SQL instance settings maintenance window

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -2032,6 +2032,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.sqlService.instance.settings.ipConfiguration.requireSsl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).GetRequireSsl()).ToDataRes(types.Bool)
 	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.sslMode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).GetSslMode()).ToDataRes(types.String)
+	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.enablePrivatePathForGoogleCloudServices": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).GetEnablePrivatePathForGoogleCloudServices()).ToDataRes(types.Bool)
+	},
 	"gcp.project.sqlService.instance.settings.maintenanceWindow.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsMaintenanceWindow).GetId()).ToDataRes(types.String)
 	},
@@ -6180,6 +6186,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"gcp.project.sqlService.instance.settings.ipConfiguration.requireSsl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).RequireSsl, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.sslMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).SslMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.enablePrivatePathForGoogleCloudServices": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).EnablePrivatePathForGoogleCloudServices, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.sqlService.instance.settings.maintenanceWindow.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -14025,6 +14039,8 @@ type mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration struct {
 	Ipv4Enabled plugin.TValue[bool]
 	PrivateNetwork plugin.TValue[string]
 	RequireSsl plugin.TValue[bool]
+	SslMode plugin.TValue[string]
+	EnablePrivatePathForGoogleCloudServices plugin.TValue[bool]
 }
 
 // createGcpProjectSqlServiceInstanceSettingsIpConfiguration creates a new instance of this resource
@@ -14086,6 +14102,14 @@ func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetPrivateNetwo
 
 func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetRequireSsl() *plugin.TValue[bool] {
 	return &c.RequireSsl
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetSslMode() *plugin.TValue[string] {
+	return &c.SslMode
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetEnablePrivatePathForGoogleCloudServices() *plugin.TValue[bool] {
+	return &c.EnablePrivatePathForGoogleCloudServices
 }
 
 // mqlGcpProjectSqlServiceInstanceSettingsMaintenanceWindow for the gcp.project.sqlService.instance.settings.maintenanceWindow resource

--- a/providers/gcp/resources/gcp.lr.manifest.yaml
+++ b/providers/gcp/resources/gcp.lr.manifest.yaml
@@ -2383,10 +2383,12 @@ resources:
     fields:
       allocatedIpRange: {}
       authorizedNetworks: {}
+      enablePrivatePathForGoogleCloudServices: {}
       id: {}
       ipv4Enabled: {}
       privateNetwork: {}
       requireSsl: {}
+      sslMode: {}
     is_private: true
     min_mondoo_version: latest
     platform:

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -233,12 +233,14 @@ func (g *mqlGcpProjectSqlService) instances() ([]interface{}, error) {
 			}
 
 			mqlIpCfg, err = CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings.ipConfiguration", map[string]*llx.RawData{
-				"id":                 llx.StringData(fmt.Sprintf("%s/settings/ipConfiguration", instanceId)),
-				"allocatedIpRange":   llx.StringData(s.IpConfiguration.AllocatedIpRange),
-				"authorizedNetworks": llx.ArrayData(mqlAclEntries, types.Dict),
-				"ipv4Enabled":        llx.BoolData(s.IpConfiguration.Ipv4Enabled),
-				"privateNetwork":     llx.StringData(s.IpConfiguration.PrivateNetwork),
-				"requireSsl":         llx.BoolData(s.IpConfiguration.RequireSsl),
+				"allocatedIpRange":                        llx.StringData(s.IpConfiguration.AllocatedIpRange),
+				"authorizedNetworks":                      llx.ArrayData(mqlAclEntries, types.Dict),
+				"enablePrivatePathForGoogleCloudServices": llx.BoolData(s.IpConfiguration.EnablePrivatePathForGoogleCloudServices),
+				"id":             llx.StringData(fmt.Sprintf("%s/settings/ipConfiguration", instanceId)),
+				"ipv4Enabled":    llx.BoolData(s.IpConfiguration.Ipv4Enabled),
+				"privateNetwork": llx.StringData(s.IpConfiguration.PrivateNetwork),
+				"requireSsl":     llx.BoolData(s.IpConfiguration.RequireSsl),
+				"sslMode":        llx.StringData(s.IpConfiguration.SslMode),
 			})
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Fixes #4158 

```coffee
cnquery> gcp.project.sql.instances {settings.ipConfiguration {*}}
gcp.project.sql.instances: [
  0: {
    settings.ipConfiguration: {
      requireSsl: false
      privateNetwork: ""
      id: "tim-learning-project/tim/settings/ipConfiguration"
      ipv4Enabled: true
      allocatedIpRange: ""
      authorizedNetworks: [
        0: {
          expirationTime: ""
          kind: "sql#aclEntry"
          name: "tim"
          value: "97.115.94.0/24"
        }
      ]
    }
  }
]
```