### PR TITLE
Add `deprecatedAt` field to aws.ec2.image

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2893,7 +2893,7 @@ private aws.ec2.keypair @defaults("name type region") {
 }
 
 // Amazon EC2 image (AMI)
-private aws.ec2.image @defaults("arn") {
+private aws.ec2.image @defaults("ownerAlias id name") {
   // ARN for the AMI
   arn string
   // ID of the image
@@ -2908,6 +2908,8 @@ private aws.ec2.image @defaults("arn") {
   ownerAlias string
   // Date the image was created
   createdAt time
+  // Date the image was deprecated
+  deprecatedAt time
 }
 
 // Amazon EC2 instance block device

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -4132,6 +4132,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.image.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Image).GetCreatedAt()).ToDataRes(types.Time)
 	},
+	"aws.ec2.image.deprecatedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Image).GetDeprecatedAt()).ToDataRes(types.Time)
+	},
 	"aws.ec2.instance.device.deleteOnTermination": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2InstanceDevice).GetDeleteOnTermination()).ToDataRes(types.Bool)
 	},
@@ -9481,6 +9484,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.ec2.image.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Image).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.image.deprecatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Image).DeprecatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.instance.device.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -24508,6 +24515,7 @@ type mqlAwsEc2Image struct {
 	OwnerId plugin.TValue[string]
 	OwnerAlias plugin.TValue[string]
 	CreatedAt plugin.TValue[*time.Time]
+	DeprecatedAt plugin.TValue[*time.Time]
 }
 
 // createAwsEc2Image creates a new instance of this resource
@@ -24573,6 +24581,10 @@ func (c *mqlAwsEc2Image) GetOwnerAlias() *plugin.TValue[string] {
 
 func (c *mqlAwsEc2Image) GetCreatedAt() *plugin.TValue[*time.Time] {
 	return &c.CreatedAt
+}
+
+func (c *mqlAwsEc2Image) GetDeprecatedAt() *plugin.TValue[*time.Time] {
+	return &c.DeprecatedAt
 }
 
 // mqlAwsEc2InstanceDevice for the aws.ec2.instance.device resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -988,6 +988,8 @@ resources:
       arn: {}
       createdAt:
         min_mondoo_version: 9.0.0
+      deprecatedAt:
+        min_mondoo_version: 9.0.0
       id: {}
       name: {}
       ownerAlias:

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -1092,6 +1092,7 @@ func initAwsEc2Image(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		args["ownerId"] = llx.NilData
 		args["ownerAlias"] = llx.NilData
 		args["createdAt"] = llx.NilData
+		args["deprecatedAt"] = llx.NilData
 		return args, nil, nil
 	}
 
@@ -1103,11 +1104,17 @@ func initAwsEc2Image(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		args["architecture"] = llx.StringData(string(image.Architecture))
 		args["ownerId"] = llx.StringData(convert.ToString(image.OwnerId))
 		args["ownerAlias"] = llx.StringData(convert.ToString(image.ImageOwnerAlias))
-		t, err := time.Parse(time.RFC3339, *image.CreationDate)
+		createTime, err := time.Parse(time.RFC3339, *image.CreationDate)
 		if err == nil {
-			args["createdAt"] = llx.TimeData(t)
+			args["createdAt"] = llx.TimeData(createTime)
 		} else {
 			args["createdAt"] = llx.NilData
+		}
+		deprecateTime, err := time.Parse(time.RFC3339, *image.DeprecationTime)
+		if err == nil {
+			args["deprecatedAt"] = llx.TimeData(deprecateTime)
+		} else {
+			args["deprecatedAt"] = llx.NilData
 		}
 		return args, nil, nil
 	}


### PR DESCRIPTION
Images have an EOL date

```
aws.ec2.instances.first.image: {
  ownerAlias: "amazon"
  deprecatedAt: 2026-02-13 21:24:09 -0800 PST
  id: "ami-0f9c44e98edf38a2b"
  architecture: "x86_64"
  ownerId: "801119661308"
  createdAt: 2024-02-13 21:24:09 -0800 PST
  arn: "arn:aws:ec2:us-east-1:177043759123:image/ami-0f9c44e98edf38a2b"
  name: "Windows_Server-2022-English-Full-Base-2024.02.14"
}
```