### PR TITLE
Add `createdAt` to aws.applicationautoscaling.target

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1728,6 +1728,8 @@ private aws.applicationautoscaling.target @defaults("arn") {
   maxCapacity int
   // suspendedState for the auto scaling target
   suspendedState dict
+  // The creation date for the auto scaling target
+  createdAt time
 }
 
 // AWS Backup

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -2698,6 +2698,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.applicationautoscaling.target.suspendedState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsApplicationautoscalingTarget).GetSuspendedState()).ToDataRes(types.Dict)
 	},
+	"aws.applicationautoscaling.target.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsApplicationautoscalingTarget).GetCreatedAt()).ToDataRes(types.Time)
+	},
 	"aws.backup.vaults": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsBackup).GetVaults()).ToDataRes(types.Array(types.Resource("aws.backup.vault")))
 	},
@@ -7345,6 +7348,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.applicationautoscaling.target.suspendedState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsApplicationautoscalingTarget).SuspendedState, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.applicationautoscaling.target.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsApplicationautoscalingTarget).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.backup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -18854,6 +18861,7 @@ type mqlAwsApplicationautoscalingTarget struct {
 	MinCapacity plugin.TValue[int64]
 	MaxCapacity plugin.TValue[int64]
 	SuspendedState plugin.TValue[interface{}]
+	CreatedAt plugin.TValue[*time.Time]
 }
 
 // createAwsApplicationautoscalingTarget creates a new instance of this resource
@@ -18915,6 +18923,10 @@ func (c *mqlAwsApplicationautoscalingTarget) GetMaxCapacity() *plugin.TValue[int
 
 func (c *mqlAwsApplicationautoscalingTarget) GetSuspendedState() *plugin.TValue[interface{}] {
 	return &c.SuspendedState
+}
+
+func (c *mqlAwsApplicationautoscalingTarget) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
 }
 
 // mqlAwsBackup for the aws.backup resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -260,6 +260,8 @@ resources:
   aws.applicationautoscaling.target:
     fields:
       arn: {}
+      createdAt:
+        min_mondoo_version: 9.0.0
       maxCapacity: {}
       minCapacity: {}
       namespace: {}

--- a/providers/aws/resources/aws_applicationautoscaling.go
+++ b/providers/aws/resources/aws_applicationautoscaling.go
@@ -92,6 +92,7 @@ func (a *mqlAwsApplicationAutoscaling) getTargets(conn *connection.AwsConnection
 							"minCapacity":       llx.IntDataDefault(target.MinCapacity, 0),
 							"maxCapacity":       llx.IntDataDefault(target.MaxCapacity, 0),
 							"suspendedState":    llx.MapData(targetState, types.Any),
+							"createdAt":         llx.TimeDataPtr(target.CreationTime),
 						})
 					if err != nil {
 						return nil, err


### PR DESCRIPTION
It's useful to know when this was created