### PR TITLE
🐛 shutdown unused providers

### DIFF
--- a/providers/coordinator_test.go
+++ b/providers/coordinator_test.go
@@ -139,6 +139,7 @@ func TestRemoveRuntime_StopUnusedProvider(t *testing.T) {
 			"platformId1": r1,
 			"platformId2": r2,
 		},
+		unprocessedRuntimes: []*Runtime{{}},
 	}
 
 	// Remove all runtimes


### PR DESCRIPTION
i noticed we never kill the unused providers in the scan api mode because we always have a couple of empty unprocessed runtimes (that are used for initializing the scanner). Those shouldn't block cleaning up unused providers