### PR TITLE
🧹 Use the registry directly to fetch Windows packages

### DIFF
--- a/providers/os/registry/registrykey_windows.go
+++ b/providers/os/registry/registrykey_windows.go
@@ -112,9 +112,9 @@ func GetNativeRegistryKeyItems(path string) ([]RegistryKeyItem, error) {
 	return res, nil
 }
 
-func GetNativeRegistryKeyChildren(path string) ([]RegistryKeyChild, error) {
-	log.Debug().Str("path", path).Msg("search registry key children using native registry api")
-	key, path, err := parseRegistryKeyPath(path)
+func GetNativeRegistryKeyChildren(fullPath string) ([]RegistryKeyChild, error) {
+	log.Debug().Str("path", fullPath).Msg("search registry key children using native registry api")
+	key, path, err := parseRegistryKeyPath(fullPath)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func GetNativeRegistryKeyChildren(path string) ([]RegistryKeyChild, error) {
 
 	for i, entry := range entries {
 		res[i] = RegistryKeyChild{
-			Path: path,
+			Path: fullPath,
 			Name: entry,
 		}
 	}

--- a/providers/os/resources/packages/windows_packages_test.go
+++ b/providers/os/resources/packages/windows_packages_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v11/providers/os/connection/mock"
+	"go.mondoo.com/cnquery/v11/providers/os/registry"
+	"go.mondoo.com/cnquery/v11/providers/os/resources/cpe"
 	"go.mondoo.com/cnquery/v11/providers/os/resources/powershell"
 )
 
@@ -108,4 +110,77 @@ func TestWindowsHotFixParser(t *testing.T) {
 	hotfixes, err = ParseWindowsHotfixes(strings.NewReader(""))
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(hotfixes), "detected the right amount of packages")
+}
+
+func TestGetPackageFromRegistryKeyItems(t *testing.T) {
+	t.Run("get package from registry key items that are empty", func(t *testing.T) {
+		items := []registry.RegistryKeyItem{}
+		p := getPackageFromRegistryKeyItems(items)
+		assert.Nil(t, p)
+	})
+	t.Run("get package from registry key items with missing required values", func(t *testing.T) {
+		items := []registry.RegistryKeyItem{
+			{
+				Key: "DisplayName",
+				Value: registry.RegistryKeyValue{
+					Kind:   registry.SZ,
+					String: "Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.28.29913",
+				},
+			},
+		}
+		p := getPackageFromRegistryKeyItems(items)
+		assert.Nil(t, p)
+	})
+
+	t.Run("get package from registry key items", func(t *testing.T) {
+		items := []registry.RegistryKeyItem{
+			{
+				Key: "DisplayName",
+				Value: registry.RegistryKeyValue{
+					Kind:   registry.SZ,
+					String: "Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.28.29913",
+				},
+			},
+			{
+				Key: "UninstallString",
+				Value: registry.RegistryKeyValue{
+					Kind:   registry.SZ,
+					String: "UninstallString",
+				},
+			},
+			{
+				Key: "DisplayVersion",
+				Value: registry.RegistryKeyValue{
+					Kind:   registry.SZ,
+					String: "14.28.29913.0",
+				},
+			},
+			{
+				Key: "Publisher",
+				Value: registry.RegistryKeyValue{
+					Kind:   registry.SZ,
+					String: "Microsoft Corporation",
+				},
+			},
+		}
+		p := getPackageFromRegistryKeyItems(items)
+		CPE, err := cpe.NewPackage2Cpe(
+			"Microsoft Corporation",
+			"Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.28.29913",
+			"14.28.29913.0",
+			"",
+			"")
+
+		assert.Nil(t, err)
+
+		expected := &Package{
+			Name:    "Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.28.29913",
+			Version: "14.28.29913.0",
+			Arch:    "",
+			Format:  "windows/app",
+			CPE:     CPE,
+		}
+		assert.NotNil(t, p)
+		assert.Equal(t, expected, p)
+	})
 }


### PR DESCRIPTION
After #4203 
Instead of running a powershell script, query the registry directly for the installed apps.
