### PR TITLE
✨ Fetch registry packages for Windows filesystem connections

### DIFF
--- a/providers/os/registry/registryhandler.go
+++ b/providers/os/registry/registryhandler.go
@@ -101,3 +101,11 @@ func (r *RegistryHandler) GetRegistryItemValue(registryId string, path, key stri
 	}
 	return GetNativeRegistryKeyItem(regPath, key)
 }
+
+func (r *RegistryHandler) GetNativeRegistryKeyChildren(registryId string, path string) ([]RegistryKeyChild, error) {
+	regPath, err := r.getRegistryKeyPath(registryId, path)
+	if err != nil {
+		return nil, err
+	}
+	return GetNativeRegistryKeyChildren(regPath)
+}


### PR DESCRIPTION
After #4204 

```
PS C:\Users\mondoo> ./cnquery run fs --path F:\ -c 'packages'
Flag --path has been deprecated, has been deprecated
Flag --path has been deprecated, has been deprecated
WRN using builtin provider for os
WRN no path provided as an arg, looking for --path flag
WRN using builtin provider for os
- no Mondoo configuration file provided, using defaults
WRN using builtin provider for os
packages.list: [
  0: package name="Microsoft Edge" version="124.0.2478.97"
]
```