### PR TITLE
🔥🪟 use reg.exe to (un)load sub keys

### DIFF
--- a/providers/os/registry/registryhandler_windows.go
+++ b/providers/os/registry/registryhandler_windows.go
@@ -7,48 +7,14 @@
 package registry
 
 import (
-	"syscall"
-	"unsafe"
-
-	"github.com/rs/zerolog/log"
-)
-
-var (
-	advapi32 = syscall.NewLazyDLL("advapi32.dll")
-	// note: we're using the W (RegLoadKeyW and NOT RegLoadKeyA) versions of these functions to work with UTF16 strings
-	regLoadKey   = advapi32.NewProc("RegLoadKeyW")
-	regUnloadKey = advapi32.NewProc("RegUnLoadKeyW")
+	"fmt"
+	"os/exec"
 )
 
 func LoadRegistrySubkey(key, path string) error {
-	keyPtr, err := syscall.UTF16PtrFromString(key)
-	if err != nil {
-		return err
-	}
-	pathPtr, err := syscall.UTF16PtrFromString(path)
-	if err != nil {
-		return err
-	}
-	_, _, err = regLoadKey.Call(syscall.HKEY_LOCAL_MACHINE, uintptr(unsafe.Pointer(keyPtr)), uintptr(unsafe.Pointer(pathPtr)))
-	// the Microsoft docs indicate that the return value is 0 on success
-	if syserr, ok := err.(syscall.Errno); ok && syserr != 0 {
-		log.Debug().Err(syserr).Msg("could not load registry subkey")
-		return err
-	}
-	return nil
+	return exec.Command("cmd", "/C", "reg", "load", fmt.Sprintf(`HKEY_LOCAL_MACHINE\%s`, key), path).Run()
 }
 
 func UnloadRegistrySubkey(key string) error {
-	keyPtr, err := syscall.UTF16PtrFromString(key)
-	if err != nil {
-		return err
-	}
-
-	_, _, err = regUnloadKey.Call(syscall.HKEY_LOCAL_MACHINE, uintptr(unsafe.Pointer(keyPtr)))
-	// the Microsoft docs indicate that the return value is 0 on success
-	if syserr, ok := err.(syscall.Errno); ok && syserr != 0 {
-		log.Debug().Err(syserr).Msg("could not unload registry subkey")
-		return err
-	}
-	return nil
+	return exec.Command("cmd", "/C", "reg", "unload", fmt.Sprintf(`HKEY_LOCAL_MACHINE\%s`, key)).Run()
 }


### PR DESCRIPTION
Proof-of-concept that we can use the `reg` command instead of the syscall that doesn't seem to work when running with `SYSTEM` user.

https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/reg

This ain't pretty...

<img src="https://media0.giphy.com/media/wqbAfFwjU8laXMWZ09/giphy.gif"/>
