### PR TITLE
:star:  Expand data collected in aws.vpcs {routeTables {associations}}

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -102,7 +102,7 @@ private aws.vpc.routetable.associations @defaults("routeTableAssociationId gatew
   main string
   // Unique ID of the route table
   routeTableId
-  // The subnet of the oute table association
+  // The subnet of the route table association
   subnet() aws.vpc.subnet
 }
 

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -99,7 +99,7 @@ private aws.vpc.routetable.association @defaults("routeTableAssociationId gatewa
   // Unique ID of the associated gateway
   gatewayId string
   // Whether this is the main association
-  main string
+  main bool
   // Unique ID of the route table
   routeTableId string
   // Subnet of the route table association

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -91,7 +91,7 @@ private aws.vpc.routetable @defaults("id routes.length") {
 }
 
 // Amazon Virtual Private Cloud (VPC) route table association
-private aws.vpc.routetable.association @defaults("routeTableAssociationId gatewayId subnetId") {
+private aws.vpc.routetable.association @defaults("routeTableAssociationId gatewayId") {
   // Unique ID of the association
   routeTableAssociationId string
   // Association state

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -81,7 +81,7 @@ private aws.vpc @defaults("id isDefault cidrBlock region") {
 // Amazon Virtual Private Cloud (VPC) route table
 private aws.vpc.routetable @defaults("id routes.length") {
   // A list of association descriptions
-  associations() []aws.vpc.routetable.associations
+  associations() []aws.vpc.routetable.association
   // Unique ID of the route table
   id string
   // A list of route descriptions
@@ -90,8 +90,8 @@ private aws.vpc.routetable @defaults("id routes.length") {
   tags map[string]string
 }
 
-// Amazon Virtual Private Cloud (VPC) route table associations
-private aws.vpc.routetable.associations @defaults("routeTableAssociationId gatewayId subnetId") {
+// Amazon Virtual Private Cloud (VPC) route table association
+private aws.vpc.routetable.association @defaults("routeTableAssociationId gatewayId subnetId") {
   // Unique ID of the association
   routeTableAssociationId string
   // Association state

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -81,13 +81,29 @@ private aws.vpc @defaults("id isDefault cidrBlock region") {
 // Amazon Virtual Private Cloud (VPC) route table
 private aws.vpc.routetable @defaults("id routes.length") {
   // A list of association descriptions
-  associations []dict
+  associations() []aws.vpc.routetable.associations
   // Unique ID of the route table
   id string
   // A list of route descriptions
   routes []dict
   // Tags on the route table
   tags map[string]string
+}
+
+// Amazon Virtual Private Cloud (VPC) route table associations
+private aws.vpc.routetable.associations @defaults("routeTableAssociationId gatewayId subnetId") {
+  // Unique ID of the association ID
+  routeTableAssociationId
+  // the association state
+  associationsState []dict
+  // Unique ID of the associated gateway
+  gatewayId string
+  // Boolean if association is the main association
+  main string
+  // Unique ID of the route table
+  routeTableId
+  // The subnet of the oute table association
+  subnet() aws.vpc.subnet
 }
 
 // Amazon Virtual Private Cloud (VPC) subnet

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -95,7 +95,7 @@ private aws.vpc.routetable.association @defaults("routeTableAssociationId gatewa
   // Unique ID of the association
   routeTableAssociationId string
   // Association state
-  associationsState []dict
+  associationsState dict
   // Unique ID of the associated gateway
   gatewayId string
   // Whether this is the main association

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -80,6 +80,8 @@ private aws.vpc @defaults("id isDefault cidrBlock region") {
 
 // Amazon Virtual Private Cloud (VPC) route table
 private aws.vpc.routetable @defaults("id routes.length") {
+  // A list of association descriptions
+  associations []dict
   // Unique ID of the route table
   id string
   // A list of route descriptions

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -92,17 +92,17 @@ private aws.vpc.routetable @defaults("id routes.length") {
 
 // Amazon Virtual Private Cloud (VPC) route table associations
 private aws.vpc.routetable.associations @defaults("routeTableAssociationId gatewayId subnetId") {
-  // Unique ID of the association ID
+  // Unique ID of the association
   routeTableAssociationId
-  // the association state
+  // Association state
   associationsState []dict
   // Unique ID of the associated gateway
   gatewayId string
-  // Boolean if association is the main association
+  // Whether this is the main association
   main string
   // Unique ID of the route table
   routeTableId
-  // The subnet of the route table association
+  // Subnet of the route table association
   subnet() aws.vpc.subnet
 }
 

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -93,7 +93,7 @@ private aws.vpc.routetable @defaults("id routes.length") {
 // Amazon Virtual Private Cloud (VPC) route table associations
 private aws.vpc.routetable.associations @defaults("routeTableAssociationId gatewayId subnetId") {
   // Unique ID of the association
-  routeTableAssociationId
+  routeTableAssociationId string
   // Association state
   associationsState []dict
   // Unique ID of the associated gateway
@@ -101,7 +101,7 @@ private aws.vpc.routetable.associations @defaults("routeTableAssociationId gatew
   // Whether this is the main association
   main string
   // Unique ID of the route table
-  routeTableId
+  routeTableId string
   // Subnet of the route table association
   subnet() aws.vpc.subnet
 }

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -885,7 +885,7 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlAwsVpcRoutetable).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"aws.vpc.routetable.associations.routeTableAssociationId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsVpcRoutetableAssociations).GetRouteTableAssociationId()).ToDataRes(NO_TYPE_DETECTED)
+		return (r.(*mqlAwsVpcRoutetableAssociations).GetRouteTableAssociationId()).ToDataRes(types.String)
 	},
 	"aws.vpc.routetable.associations.associationsState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetableAssociations).GetAssociationsState()).ToDataRes(types.Array(types.Dict))
@@ -897,7 +897,7 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlAwsVpcRoutetableAssociations).GetMain()).ToDataRes(types.String)
 	},
 	"aws.vpc.routetable.associations.routeTableId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsVpcRoutetableAssociations).GetRouteTableId()).ToDataRes(NO_TYPE_DETECTED)
+		return (r.(*mqlAwsVpcRoutetableAssociations).GetRouteTableId()).ToDataRes(types.String)
 	},
 	"aws.vpc.routetable.associations.subnet": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetableAssociations).GetSubnet()).ToDataRes(types.Resource("aws.vpc.subnet"))
@@ -4542,7 +4542,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 			return
 		},
 	"aws.vpc.routetable.associations.routeTableAssociationId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsVpcRoutetableAssociations).RouteTableAssociationId, ok = plugin.RawToTValue[NO_TYPE_DETECTED](v.Value, v.Error)
+		r.(*mqlAwsVpcRoutetableAssociations).RouteTableAssociationId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.routetable.associations.associationsState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4558,7 +4558,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		return
 	},
 	"aws.vpc.routetable.associations.routeTableId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsVpcRoutetableAssociations).RouteTableId, ok = plugin.RawToTValue[NO_TYPE_DETECTED](v.Value, v.Error)
+		r.(*mqlAwsVpcRoutetableAssociations).RouteTableId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.routetable.associations.subnet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10420,11 +10420,11 @@ type mqlAwsVpcRoutetableAssociations struct {
 	MqlRuntime *plugin.Runtime
 	__id string
 	// optional: if you define mqlAwsVpcRoutetableAssociationsInternal it will be used here
-	RouteTableAssociationId plugin.TValue[NO_TYPE_DETECTED]
+	RouteTableAssociationId plugin.TValue[string]
 	AssociationsState plugin.TValue[[]interface{}]
 	GatewayId plugin.TValue[string]
 	Main plugin.TValue[string]
-	RouteTableId plugin.TValue[NO_TYPE_DETECTED]
+	RouteTableId plugin.TValue[string]
 	Subnet plugin.TValue[*mqlAwsVpcSubnet]
 }
 
@@ -10460,7 +10460,7 @@ func (c *mqlAwsVpcRoutetableAssociations) MqlID() string {
 	return c.__id
 }
 
-func (c *mqlAwsVpcRoutetableAssociations) GetRouteTableAssociationId() *plugin.TValue[NO_TYPE_DETECTED] {
+func (c *mqlAwsVpcRoutetableAssociations) GetRouteTableAssociationId() *plugin.TValue[string] {
 	return &c.RouteTableAssociationId
 }
 
@@ -10476,7 +10476,7 @@ func (c *mqlAwsVpcRoutetableAssociations) GetMain() *plugin.TValue[string] {
 	return &c.Main
 }
 
-func (c *mqlAwsVpcRoutetableAssociations) GetRouteTableId() *plugin.TValue[NO_TYPE_DETECTED] {
+func (c *mqlAwsVpcRoutetableAssociations) GetRouteTableId() *plugin.TValue[string] {
 	return &c.RouteTableId
 }
 

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -38,9 +38,9 @@ func init() {
 			// to override args, implement: initAwsVpcRoutetable(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsVpcRoutetable,
 		},
-		"aws.vpc.routetable.associations": {
-			// to override args, implement: initAwsVpcRoutetableAssociations(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
-			Create: createAwsVpcRoutetableAssociations,
+		"aws.vpc.routetable.association": {
+			// to override args, implement: initAwsVpcRoutetableAssociation(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsVpcRoutetableAssociation,
 		},
 		"aws.vpc.subnet": {
 			Init: initAwsVpcSubnet,
@@ -873,7 +873,7 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlAwsVpc).GetPeeringConnections()).ToDataRes(types.Array(types.Resource("aws.vpc.peeringConnection")))
 	},
 	"aws.vpc.routetable.associations": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsVpcRoutetable).GetAssociations()).ToDataRes(types.Array(types.Resource("aws.vpc.routetable.associations")))
+		return (r.(*mqlAwsVpcRoutetable).GetAssociations()).ToDataRes(types.Array(types.Resource("aws.vpc.routetable.association")))
 	},
 	"aws.vpc.routetable.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetable).GetId()).ToDataRes(types.String)
@@ -884,23 +884,23 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.vpc.routetable.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetable).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
-	"aws.vpc.routetable.associations.routeTableAssociationId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsVpcRoutetableAssociations).GetRouteTableAssociationId()).ToDataRes(types.String)
+	"aws.vpc.routetable.association.routeTableAssociationId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcRoutetableAssociation).GetRouteTableAssociationId()).ToDataRes(types.String)
 	},
-	"aws.vpc.routetable.associations.associationsState": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsVpcRoutetableAssociations).GetAssociationsState()).ToDataRes(types.Array(types.Dict))
+	"aws.vpc.routetable.association.associationsState": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcRoutetableAssociation).GetAssociationsState()).ToDataRes(types.Array(types.Dict))
 	},
-	"aws.vpc.routetable.associations.gatewayId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsVpcRoutetableAssociations).GetGatewayId()).ToDataRes(types.String)
+	"aws.vpc.routetable.association.gatewayId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcRoutetableAssociation).GetGatewayId()).ToDataRes(types.String)
 	},
-	"aws.vpc.routetable.associations.main": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsVpcRoutetableAssociations).GetMain()).ToDataRes(types.String)
+	"aws.vpc.routetable.association.main": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcRoutetableAssociation).GetMain()).ToDataRes(types.String)
 	},
-	"aws.vpc.routetable.associations.routeTableId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsVpcRoutetableAssociations).GetRouteTableId()).ToDataRes(types.String)
+	"aws.vpc.routetable.association.routeTableId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcRoutetableAssociation).GetRouteTableId()).ToDataRes(types.String)
 	},
-	"aws.vpc.routetable.associations.subnet": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsVpcRoutetableAssociations).GetSubnet()).ToDataRes(types.Resource("aws.vpc.subnet"))
+	"aws.vpc.routetable.association.subnet": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcRoutetableAssociation).GetSubnet()).ToDataRes(types.Resource("aws.vpc.subnet"))
 	},
 	"aws.vpc.subnet.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcSubnet).GetArn()).ToDataRes(types.String)
@@ -4537,32 +4537,32 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsVpcRoutetable).Tags, ok = plugin.RawToTValue[map[string]interface{}](v.Value, v.Error)
 		return
 	},
-	"aws.vpc.routetable.associations.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-			r.(*mqlAwsVpcRoutetableAssociations).__id, ok = v.Value.(string)
+	"aws.vpc.routetable.association.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlAwsVpcRoutetableAssociation).__id, ok = v.Value.(string)
 			return
 		},
-	"aws.vpc.routetable.associations.routeTableAssociationId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsVpcRoutetableAssociations).RouteTableAssociationId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+	"aws.vpc.routetable.association.routeTableAssociationId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcRoutetableAssociation).RouteTableAssociationId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"aws.vpc.routetable.associations.associationsState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsVpcRoutetableAssociations).AssociationsState, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+	"aws.vpc.routetable.association.associationsState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcRoutetableAssociation).AssociationsState, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
-	"aws.vpc.routetable.associations.gatewayId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsVpcRoutetableAssociations).GatewayId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+	"aws.vpc.routetable.association.gatewayId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcRoutetableAssociation).GatewayId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"aws.vpc.routetable.associations.main": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsVpcRoutetableAssociations).Main, ok = plugin.RawToTValue[string](v.Value, v.Error)
+	"aws.vpc.routetable.association.main": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcRoutetableAssociation).Main, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"aws.vpc.routetable.associations.routeTableId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsVpcRoutetableAssociations).RouteTableId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+	"aws.vpc.routetable.association.routeTableId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcRoutetableAssociation).RouteTableId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"aws.vpc.routetable.associations.subnet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsVpcRoutetableAssociations).Subnet, ok = plugin.RawToTValue[*mqlAwsVpcSubnet](v.Value, v.Error)
+	"aws.vpc.routetable.association.subnet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcRoutetableAssociation).Subnet, ok = plugin.RawToTValue[*mqlAwsVpcSubnet](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.subnet.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10343,7 +10343,7 @@ func (c *mqlAwsVpc) GetPeeringConnections() *plugin.TValue[[]interface{}] {
 type mqlAwsVpcRoutetable struct {
 	MqlRuntime *plugin.Runtime
 	__id string
-	// optional: if you define mqlAwsVpcRoutetableInternal it will be used here
+	mqlAwsVpcRoutetableInternal
 	Associations plugin.TValue[[]interface{}]
 	Id plugin.TValue[string]
 	Routes plugin.TValue[[]interface{}]
@@ -10415,11 +10415,11 @@ func (c *mqlAwsVpcRoutetable) GetTags() *plugin.TValue[map[string]interface{}] {
 	return &c.Tags
 }
 
-// mqlAwsVpcRoutetableAssociations for the aws.vpc.routetable.associations resource
-type mqlAwsVpcRoutetableAssociations struct {
+// mqlAwsVpcRoutetableAssociation for the aws.vpc.routetable.association resource
+type mqlAwsVpcRoutetableAssociation struct {
 	MqlRuntime *plugin.Runtime
 	__id string
-	// optional: if you define mqlAwsVpcRoutetableAssociationsInternal it will be used here
+	// optional: if you define mqlAwsVpcRoutetableAssociationInternal it will be used here
 	RouteTableAssociationId plugin.TValue[string]
 	AssociationsState plugin.TValue[[]interface{}]
 	GatewayId plugin.TValue[string]
@@ -10428,9 +10428,9 @@ type mqlAwsVpcRoutetableAssociations struct {
 	Subnet plugin.TValue[*mqlAwsVpcSubnet]
 }
 
-// createAwsVpcRoutetableAssociations creates a new instance of this resource
-func createAwsVpcRoutetableAssociations(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
-	res := &mqlAwsVpcRoutetableAssociations{
+// createAwsVpcRoutetableAssociation creates a new instance of this resource
+func createAwsVpcRoutetableAssociation(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsVpcRoutetableAssociation{
 		MqlRuntime: runtime,
 	}
 
@@ -10442,7 +10442,7 @@ func createAwsVpcRoutetableAssociations(runtime *plugin.Runtime, args map[string
 	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
-		args, err = runtime.ResourceFromRecording("aws.vpc.routetable.associations", res.__id)
+		args, err = runtime.ResourceFromRecording("aws.vpc.routetable.association", res.__id)
 		if err != nil || args == nil {
 			return res, err
 		}
@@ -10452,38 +10452,38 @@ func createAwsVpcRoutetableAssociations(runtime *plugin.Runtime, args map[string
 	return res, nil
 }
 
-func (c *mqlAwsVpcRoutetableAssociations) MqlName() string {
-	return "aws.vpc.routetable.associations"
+func (c *mqlAwsVpcRoutetableAssociation) MqlName() string {
+	return "aws.vpc.routetable.association"
 }
 
-func (c *mqlAwsVpcRoutetableAssociations) MqlID() string {
+func (c *mqlAwsVpcRoutetableAssociation) MqlID() string {
 	return c.__id
 }
 
-func (c *mqlAwsVpcRoutetableAssociations) GetRouteTableAssociationId() *plugin.TValue[string] {
+func (c *mqlAwsVpcRoutetableAssociation) GetRouteTableAssociationId() *plugin.TValue[string] {
 	return &c.RouteTableAssociationId
 }
 
-func (c *mqlAwsVpcRoutetableAssociations) GetAssociationsState() *plugin.TValue[[]interface{}] {
+func (c *mqlAwsVpcRoutetableAssociation) GetAssociationsState() *plugin.TValue[[]interface{}] {
 	return &c.AssociationsState
 }
 
-func (c *mqlAwsVpcRoutetableAssociations) GetGatewayId() *plugin.TValue[string] {
+func (c *mqlAwsVpcRoutetableAssociation) GetGatewayId() *plugin.TValue[string] {
 	return &c.GatewayId
 }
 
-func (c *mqlAwsVpcRoutetableAssociations) GetMain() *plugin.TValue[string] {
+func (c *mqlAwsVpcRoutetableAssociation) GetMain() *plugin.TValue[string] {
 	return &c.Main
 }
 
-func (c *mqlAwsVpcRoutetableAssociations) GetRouteTableId() *plugin.TValue[string] {
+func (c *mqlAwsVpcRoutetableAssociation) GetRouteTableId() *plugin.TValue[string] {
 	return &c.RouteTableId
 }
 
-func (c *mqlAwsVpcRoutetableAssociations) GetSubnet() *plugin.TValue[*mqlAwsVpcSubnet] {
+func (c *mqlAwsVpcRoutetableAssociation) GetSubnet() *plugin.TValue[*mqlAwsVpcSubnet] {
 	return plugin.GetOrCompute[*mqlAwsVpcSubnet](&c.Subnet, func() (*mqlAwsVpcSubnet, error) {
 		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.vpc.routetable.associations", c.__id, "subnet")
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.vpc.routetable.association", c.__id, "subnet")
 			if err != nil {
 				return nil, err
 			}

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -10399,7 +10399,7 @@ func (c *mqlAwsVpcRoutetable) GetAssociations() *plugin.TValue[[]interface{}] {
 			}
 		}
 
-		return c.Associations()
+		return c.associations()
 	})
 }
 
@@ -10492,7 +10492,7 @@ func (c *mqlAwsVpcRoutetableAssociations) GetSubnet() *plugin.TValue[*mqlAwsVpcS
 			}
 		}
 
-		return c.Subnet()
+		return c.subnet()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -868,6 +868,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.vpc.peeringConnections": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpc).GetPeeringConnections()).ToDataRes(types.Array(types.Resource("aws.vpc.peeringConnection")))
 	},
+	"aws.vpc.routetable.associations": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcRoutetable).GetAssociations()).ToDataRes(types.Array(types.Dict))
+	},
 	"aws.vpc.routetable.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetable).GetId()).ToDataRes(types.String)
 	},
@@ -4496,7 +4499,11 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 			r.(*mqlAwsVpcRoutetable).__id, ok = v.Value.(string)
 			return
 		},
-	"aws.vpc.routetable.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+	"aws.vpc.routetable.associations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcRoutetable).Associations, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+		"aws.vpc.routetable.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcRoutetable).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
@@ -10287,6 +10294,7 @@ type mqlAwsVpcRoutetable struct {
 	MqlRuntime *plugin.Runtime
 	__id string
 	// optional: if you define mqlAwsVpcRoutetableInternal it will be used here
+	Associations plugin.TValue[[]interface{}]
 	Id plugin.TValue[string]
 	Routes plugin.TValue[[]interface{}]
 	Tags plugin.TValue[map[string]interface{}]
@@ -10327,6 +10335,10 @@ func (c *mqlAwsVpcRoutetable) MqlName() string {
 
 func (c *mqlAwsVpcRoutetable) MqlID() string {
 	return c.__id
+}
+
+func (c *mqlAwsVpcRoutetable) GetAssociations() *plugin.TValue[[]interface{}] {
+	return &c.Associations
 }
 
 func (c *mqlAwsVpcRoutetable) GetId() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -10419,7 +10419,7 @@ func (c *mqlAwsVpcRoutetable) GetTags() *plugin.TValue[map[string]interface{}] {
 type mqlAwsVpcRoutetableAssociation struct {
 	MqlRuntime *plugin.Runtime
 	__id string
-	// optional: if you define mqlAwsVpcRoutetableAssociationInternal it will be used here
+	mqlAwsVpcRoutetableAssociationInternal
 	RouteTableAssociationId plugin.TValue[string]
 	AssociationsState plugin.TValue[[]interface{}]
 	GatewayId plugin.TValue[string]

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -888,13 +888,13 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlAwsVpcRoutetableAssociation).GetRouteTableAssociationId()).ToDataRes(types.String)
 	},
 	"aws.vpc.routetable.association.associationsState": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsVpcRoutetableAssociation).GetAssociationsState()).ToDataRes(types.Array(types.Dict))
+		return (r.(*mqlAwsVpcRoutetableAssociation).GetAssociationsState()).ToDataRes(types.Dict)
 	},
 	"aws.vpc.routetable.association.gatewayId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetableAssociation).GetGatewayId()).ToDataRes(types.String)
 	},
 	"aws.vpc.routetable.association.main": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsVpcRoutetableAssociation).GetMain()).ToDataRes(types.String)
+		return (r.(*mqlAwsVpcRoutetableAssociation).GetMain()).ToDataRes(types.Bool)
 	},
 	"aws.vpc.routetable.association.routeTableId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetableAssociation).GetRouteTableId()).ToDataRes(types.String)
@@ -4546,7 +4546,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		return
 	},
 	"aws.vpc.routetable.association.associationsState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsVpcRoutetableAssociation).AssociationsState, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		r.(*mqlAwsVpcRoutetableAssociation).AssociationsState, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.routetable.association.gatewayId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4554,7 +4554,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		return
 	},
 	"aws.vpc.routetable.association.main": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsVpcRoutetableAssociation).Main, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		r.(*mqlAwsVpcRoutetableAssociation).Main, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.routetable.association.routeTableId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10421,9 +10421,9 @@ type mqlAwsVpcRoutetableAssociation struct {
 	__id string
 	mqlAwsVpcRoutetableAssociationInternal
 	RouteTableAssociationId plugin.TValue[string]
-	AssociationsState plugin.TValue[[]interface{}]
+	AssociationsState plugin.TValue[interface{}]
 	GatewayId plugin.TValue[string]
-	Main plugin.TValue[string]
+	Main plugin.TValue[bool]
 	RouteTableId plugin.TValue[string]
 	Subnet plugin.TValue[*mqlAwsVpcSubnet]
 }
@@ -10464,7 +10464,7 @@ func (c *mqlAwsVpcRoutetableAssociation) GetRouteTableAssociationId() *plugin.TV
 	return &c.RouteTableAssociationId
 }
 
-func (c *mqlAwsVpcRoutetableAssociation) GetAssociationsState() *plugin.TValue[[]interface{}] {
+func (c *mqlAwsVpcRoutetableAssociation) GetAssociationsState() *plugin.TValue[interface{}] {
 	return &c.AssociationsState
 }
 
@@ -10472,7 +10472,7 @@ func (c *mqlAwsVpcRoutetableAssociation) GetGatewayId() *plugin.TValue[string] {
 	return &c.GatewayId
 }
 
-func (c *mqlAwsVpcRoutetableAssociation) GetMain() *plugin.TValue[string] {
+func (c *mqlAwsVpcRoutetableAssociation) GetMain() *plugin.TValue[bool] {
 	return &c.Main
 }
 

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -4503,7 +4503,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsVpcRoutetable).Associations, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
-		"aws.vpc.routetable.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+	"aws.vpc.routetable.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcRoutetable).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2941,7 +2941,7 @@ resources:
     platform:
       name:
       - aws
-  aws.vpc.routetable.associations:
+  aws.vpc.routetable.association:
     fields:
       associationsState: {}
       gatewayId: {}
@@ -2950,6 +2950,18 @@ resources:
       routeTableId: {}
       subnet: {}
     is_private: true
+    min_mondoo_version: latest
+    platform:
+      name:
+      - aws
+  aws.vpc.routetable.associations:
+    fields:
+      associationsState: {}
+      gatewayId: {}
+      main: {}
+      routeTableAssociationId: {}
+      routeTableId: {}
+      subnet: {}
     min_mondoo_version: 9.0.0
     platform:
       name:

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2950,7 +2950,7 @@ resources:
       routeTableId: {}
       subnet: {}
     is_private: true
-    min_mondoo_version: latest
+    min_mondoo_version: 9.0.0
     platform:
       name:
       - aws

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2930,13 +2930,27 @@ resources:
       - aws
   aws.vpc.routetable:
     fields:
-      associations: {}
+      associations:
+        min_mondoo_version: 9.0.0
       id: {}
       routes: {}
       tags:
         min_mondoo_version: 9.0.0
     is_private: true
     min_mondoo_version: 5.15.0
+    platform:
+      name:
+      - aws
+  aws.vpc.routetable.associations:
+    fields:
+      routeTableAssociationId: {}
+      associationsState: {}
+      gatewayId: {}
+      main: {}
+      routeTableId: {}
+      subnet: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
     platform:
       name:
       - aws

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2792,7 +2792,8 @@ resources:
       peeringConnections:
         min_mondoo_version: 9.0.0
       region: {}
-      routeTables: {}
+      routeTables:
+        min_mondoo_version: 9.0.0
       serviceEndpoints:
         min_mondoo_version: 9.0.0
       state: {}

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2954,18 +2954,6 @@ resources:
     platform:
       name:
       - aws
-  aws.vpc.routetable.associations:
-    fields:
-      associationsState: {}
-      gatewayId: {}
-      main: {}
-      routeTableAssociationId: {}
-      routeTableId: {}
-      subnet: {}
-    min_mondoo_version: 9.0.0
-    platform:
-      name:
-      - aws
   aws.vpc.serviceEndpoint:
     fields:
       acceptanceRequired: {}

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2943,10 +2943,10 @@ resources:
       - aws
   aws.vpc.routetable.associations:
     fields:
-      routeTableAssociationId: {}
       associationsState: {}
       gatewayId: {}
       main: {}
+      routeTableAssociationId: {}
       routeTableId: {}
       subnet: {}
     is_private: true

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2929,6 +2929,7 @@ resources:
       - aws
   aws.vpc.routetable:
     fields:
+      associations: {}
       id: {}
       routes: {}
       tags:

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -578,7 +578,7 @@ func (a *mqlAwsVpcRoutetable) associations() ([]interface{}, error) {
 		}
 		mqlAssoc, err := CreateResource(a.MqlRuntime, "aws.vpc.routetable.association", map[string]*llx.RawData{
 			"routeTableAssociationId": llx.StringDataPtr(assoc.RouteTableAssociationId),
-			"associationsState":       llx.AnyData(state),
+			"associationsState":       llx.AnyData(assoc.state),
 			"gatewayId":               llx.StringDataPtr(assoc.GatewayId),
 			"main":                    llx.BoolDataPtr(assoc.Main),
 			"routeTableId":            llx.StringDataPtr(assoc.RouteTableId),

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -578,7 +578,7 @@ func (a *mqlAwsVpcRoutetable) associations() ([]interface{}, error) {
 		}
 		mqlAssoc, err := CreateResource(a.MqlRuntime, "aws.vpc.routetable.association", map[string]*llx.RawData{
 			"routeTableAssociationId": llx.StringDataPtr(assoc.RouteTableAssociationId),
-			"associationsState":       llx.MapData(state, types.String),
+			"associationsState":       llx.DictData(state),
 			"gatewayId":               llx.StringDataPtr(assoc.GatewayId),
 			"main":                    llx.BoolDataPtr(assoc.Main),
 			"routeTableId":            llx.StringDataPtr(assoc.RouteTableId),

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -546,11 +546,16 @@ func (a *mqlAwsVpc) routeTables() ([]interface{}, error) {
 			if err != nil {
 				return nil, err
 			}
+			dictAssociations, err := convert.JsonToDictSlice(routeTable.Associations)
+			if err != nil {
+				return nil, err
+			}
 			mqlRouteTable, err := CreateResource(a.MqlRuntime, "aws.vpc.routetable",
 				map[string]*llx.RawData{
-					"id":     llx.StringDataPtr(routeTable.RouteTableId),
-					"routes": llx.ArrayData(dictRoutes, types.Any),
-					"tags":   llx.MapData(Ec2TagsToMap(routeTable.Tags), types.String),
+					"associations": llx.ArrayData(dictAssociations, types.Any),
+					"id":           llx.StringDataPtr(routeTable.RouteTableId),
+					"routes":       llx.ArrayData(dictRoutes, types.Any),
+					"tags":         llx.MapData(Ec2TagsToMap(routeTable.Tags), types.String),
 				})
 			if err != nil {
 				return nil, err

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -586,7 +586,7 @@ func (a *mqlAwsVpcRoutetable) associations() ([]interface{}, error) {
 		}
 		res = append(res, mqlAssoc)
 	}
-	return nil, nil
+	return res, nil
 }
 
 func (a *mqlAwsVpcRoutetableAssociation) subnet() (*mqlAwsVpcSubnet, error) {

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -578,7 +578,7 @@ func (a *mqlAwsVpcRoutetable) associations() ([]interface{}, error) {
 		}
 		mqlAssoc, err := CreateResource(a.MqlRuntime, "aws.vpc.routetable.association", map[string]*llx.RawData{
 			"routeTableAssociationId": llx.StringDataPtr(assoc.RouteTableAssociationId),
-			"associationsState":       llx.AnyData(assoc.state),
+			"associationsState":       llx.MapData(state, types.String),
 			"gatewayId":               llx.StringDataPtr(assoc.GatewayId),
 			"main":                    llx.BoolDataPtr(assoc.Main),
 			"routeTableId":            llx.StringDataPtr(assoc.RouteTableId),


### PR DESCRIPTION
adds missing info, so we can connect `subnets` to `routeTables`

![image](https://github.com/mondoohq/cnquery/assets/112621871/79153a17-038c-445f-b4f2-572f3fbeb899)
