### PR TITLE
🐛 Fix goreleaser config version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 ---
+version: 2
 project_name: cnquery
 env:
   - CGO_ENABLED=0


### PR DESCRIPTION
This currently errors: https://github.com/mondoohq/cnquery/actions/runs/9510396645/job/26214809633
```
only configurations files on version: 2 are supported, yours is version: 0, please update your configuration
```

For the fix, search https://carlosbecker.com/posts/goreleaser-v2/ for 'version:'.