### PR TITLE
⭐️ allow finding files by permissions

### DIFF
--- a/providers/os/connection/shared/shared.go
+++ b/providers/os/connection/shared/shared.go
@@ -103,7 +103,7 @@ func (c Capabilities) String() []string {
 }
 
 type FileSearch interface {
-	Find(from string, r *regexp.Regexp, typ string) ([]string, error)
+	Find(from string, r *regexp.Regexp, typ string, perm *uint32) ([]string, error)
 }
 
 type PerfStats struct {

--- a/providers/os/fs/find_files.go
+++ b/providers/os/fs/find_files.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"regexp"
 	"strings"
+
+	"golang.org/x/sys/unix"
 )
 
 func FindFiles(iofs fs.FS, from string, r *regexp.Regexp, typ string, perm *uint32) ([]string, error) {
@@ -34,7 +36,7 @@ func handleFsError(err error) error {
 	if err != nil {
 		// Check for denied permissions and non-existent files. This can sometimes happen, especially for procfs
 		// We don't want to error out in such cases. We can safely skip over the file.
-		if errors.Is(err, os.ErrPermission) || errors.Is(err, os.ErrNotExist) || errors.Is(err, os.ErrInvalid) {
+		if errors.Is(err, os.ErrPermission) || errors.Is(err, os.ErrNotExist) || errors.Is(err, os.ErrInvalid) || errors.Is(err, unix.EINVAL) {
 			return nil
 		}
 		return err

--- a/providers/os/fs/find_files_test.go
+++ b/providers/os/fs/find_files_test.go
@@ -147,17 +147,25 @@ func TestFindFiles(t *testing.T) {
 	mkFile(t, fs, "root/a/file1")
 	mkFile(t, fs, "root/a/file2")
 	mkFile(t, fs, "root/b/file1")
+	mkFile(t, fs, "root/c/file4")
+	require.NoError(t, fs.Chmod("root/c/file4", 0o002))
 
-	rootAFiles, err := FindFiles(afero.NewIOFS(fs), "root/a", nil, "f")
+	rootAFiles, err := FindFiles(afero.NewIOFS(fs), "root/a", nil, "f", nil)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, rootAFiles, []string{"root/a/file1", "root/a/file2"})
 
-	rootAFilesAndDir, err := FindFiles(afero.NewIOFS(fs), "root/a", nil, "f,d")
+	rootAFilesAndDir, err := FindFiles(afero.NewIOFS(fs), "root/a", nil, "f,d", nil)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, rootAFilesAndDir, []string{"root/a", "root/a/file1", "root/a/file2"})
 
-	rootBFiles, err := FindFiles(afero.NewIOFS(fs), "root", regexp.MustCompile("root/b.*"), "f")
+	rootBFiles, err := FindFiles(afero.NewIOFS(fs), "root", regexp.MustCompile("root/b.*"), "f", nil)
+	require.NoError(t, err)
 	assert.ElementsMatch(t, rootBFiles, []string{"root/b/file1"})
+
+	perm := uint32(0o002)
+	permFiles, err := FindFiles(afero.NewIOFS(fs), "root", nil, "f", &perm)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, permFiles, []string{"root/c/file4"})
 }
 
 func mkFile(t *testing.T, fs afero.Fs, name string) {

--- a/providers/os/fs/fs.go
+++ b/providers/os/fs/fs.go
@@ -113,7 +113,7 @@ func (t *MountedFs) Chown(name string, uid, gid int) error {
 	return notSupported
 }
 
-func (t *MountedFs) Find(from string, r *regexp.Regexp, typ string) ([]string, error) {
+func (t *MountedFs) Find(from string, r *regexp.Regexp, typ string, perm *uint32) ([]string, error) {
 	iofs := afero.NewIOFS(t)
-	return FindFiles(iofs, from, r, typ)
+	return FindFiles(iofs, from, r, typ, perm)
 }

--- a/providers/os/resources/files.go
+++ b/providers/os/resources/files.go
@@ -81,7 +81,13 @@ func (l *mqlFilesFind) list() ([]interface{}, error) {
 			return nil, errors.New("find is not supported for your platform")
 		}
 
-		foundFiles, err = fsSearch.Find(l.From.Data, compiledRegexp, l.Type.Data)
+		var perm *uint32
+		if l.Permissions.Data != 0o777 {
+			p := uint32(l.Permissions.Data)
+			perm = &p
+		}
+
+		foundFiles, err = fsSearch.Find(l.From.Data, compiledRegexp, l.Type.Data, perm)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When we search for riles with `RunCommand` capability, we use `find`. There we can provide permissions filters. In the cases, where we have no `RunCommand` capability we are manually looping over the filesystem files. 

The manual loop we have doesn't check for permissions matching. This is problematic for some queries that we have in our policies. For example:
```
files.find(from: "/", type: "file", xdev: false, permissions: 0002).all(path == "")
files.find(from: "/", type: "directory", xdev: false, permissions: 0002).all(permissions.sticky == true)
```
If we try to execute these queries in a filesystem scan (where no `RunCommand` capability is present), we will be adding all the files on the filesystem as an mql resource. This is very CPU and memory intensive and we have already encountered issues with that. This PR makes sure we match permissions when running a manual find. That significantly improves the performance for the query on my test system.

The easiest way to test this is to run `cnspec shell fs --path /` on a Linux machine. In the shell, try the first line of the query:
```
files.find(from: "/", type: "file", xdev: false, permissions: 0002).all(path == "")
```