### PR TITLE
🧹 ensure we always read the fine grained assets FF for AWS

### DIFF
--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -298,7 +298,7 @@ func TestCompiler_DeterministicChecksum(t *testing.T) {
 		azureConf := mqlc.NewConfig(azure_schema, features)
 		res, err := mqlc.Compile(mql, map[string]*llx.Primitive{}, azureConf)
 		require.Nil(t, err)
-		require.Equal(t, res.CodeV2.Id, "LkB8PP3xB2Q=")
+		require.Equal(t, res.CodeV2.Id, "h81H/YfoIRI=")
 	}
 }
 

--- a/providers/aws/resources/discovery.go
+++ b/providers/aws/resources/discovery.go
@@ -222,11 +222,11 @@ func Discover(runtime *plugin.Runtime, filters connection.DiscoveryFilters) (*in
 }
 
 func handleTargets(targets []string) []string {
+	if ENABLE_FINE_GRAINED_ASSETS {
+		return append(AllAPIResources, DiscoveryAccounts)
+	}
 	if len(targets) == 0 || stringx.Contains(targets, DiscoveryAuto) {
 		// default to auto if none defined
-		if ENABLE_FINE_GRAINED_ASSETS {
-			return AllAPIResources
-		}
 		return Auto
 	}
 


### PR DESCRIPTION
I'm not sure why I needed the second commit/why that test failed..