### PR TITLE
🐛 Fix find files panic for FS connections.

### DIFF
--- a/providers/os/fs/find_files.go
+++ b/providers/os/fs/find_files.go
@@ -13,9 +13,14 @@ func FindFiles(iofs fs.FS, from string, r *regexp.Regexp, typ string, perm *uint
 	matcher := createFindFilesMatcher(iofs, typ, r, perm)
 	matchedPaths := []string{}
 	err := fs.WalkDir(iofs, from, func(p string, d fs.DirEntry, err error) error {
-		if err := handleFsError(err); err != nil {
+		skip, err := handleFsError(err)
+		if err != nil {
 			return err
 		}
+		if skip {
+			return nil
+		}
+
 		if matcher.Match(p, d.Type()) {
 			matchedPaths = append(matchedPaths, p)
 		}

--- a/providers/os/fs/find_files_unix.go
+++ b/providers/os/fs/find_files_unix.go
@@ -13,15 +13,16 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// handleFsError checks if the error is a permission denied or non-existent file error and returns nil in such cases.
-func handleFsError(err error) error {
+// handleFsError checks if the error is a permission denied or non-existent file error and returns nil in such cases. the bool
+// indicates if the file should be skipped
+func handleFsError(err error) (bool, error) {
 	if err != nil {
 		// Check for denied permissions and non-existent files. This can sometimes happen, especially for procfs
 		// We don't want to error out in such cases. We can safely skip over the file.
 		if errors.Is(err, os.ErrPermission) || errors.Is(err, os.ErrNotExist) || errors.Is(err, os.ErrInvalid) || errors.Is(err, unix.EINVAL) {
-			return nil
+			return true, nil
 		}
-		return err
+		return true, err
 	}
-	return nil
+	return false, nil
 }

--- a/providers/os/fs/find_files_windows.go
+++ b/providers/os/fs/find_files_windows.go
@@ -12,14 +12,14 @@ import (
 )
 
 // handleFsError checks if the error is a permission denied or non-existent file error and returns nil in such cases.
-func handleFsError(err error) error {
+func handleFsError(err error) (bool, error) {
 	if err != nil {
 		// Check for denied permissions and non-existent files. This can sometimes happen, especially for procfs
 		// We don't want to error out in such cases. We can safely skip over the file.
 		if errors.Is(err, os.ErrPermission) || errors.Is(err, os.ErrNotExist) || errors.Is(err, os.ErrInvalid) {
-			return nil
+			return true, nil
 		}
-		return err
+		return true, err
 	}
-	return nil
+	return false, nil
 }


### PR DESCRIPTION
If files do not exist, we return `nil` from the `handleFsError` which means the `WalkDir` doesn't skip over that specific file. This lead to panics when running `files.find` query against an FS connection, e.g. `files.find(from: "/etc/audit/rules.d",regex:'.*\.rules$' , type: "file")`