### PR TITLE
🧹 Only consider devices via LUN when they have no mounted partitions at all

### DIFF
--- a/providers/os/connection/device/linux/lun.go
+++ b/providers/os/connection/device/linux/lun.go
@@ -72,16 +72,20 @@ func findMatchingDeviceByBlock(scsiDevices scsiDevices, blockDevices *snapshot.B
 		return snapshot.BlockDevice{}, errors.New("no matching blocks found")
 	}
 
+	var matching *snapshot.BlockDevice
 	for _, b := range matchingBlocks {
 		log.Debug().Str("name", b.Name).Msg("device connection> checking block")
 		for _, ch := range b.Children {
 			if len(ch.MountPoint) > 0 && ch.MountPoint != "" {
-				log.Debug().Str("name", ch.Name).Msg("device connection> has mounted partitons, skipping")
-			} else {
-				// we found a block that has no mounted partitions
-				return b, nil
+				log.Debug().Str("name", ch.Name).Str("mountpoint", ch.MountPoint).Str("parent", b.Name).Msg("device connection> has mounted partitons, skipping parent block")
+				break
 			}
+			matching = &b
 		}
+	}
+
+	if matching != nil {
+		return *matching, nil
 	}
 
 	return snapshot.BlockDevice{}, errors.New("no matching block found")

--- a/providers/os/connection/device/linux/lun_test.go
+++ b/providers/os/connection/device/linux/lun_test.go
@@ -64,6 +64,9 @@ func TestFindDeviceByBlock(t *testing.T) {
 							Name:       "sda1",
 							MountPoint: "/",
 						},
+						{
+							Name: "sda2",
+						},
 					},
 				},
 				{
@@ -118,6 +121,9 @@ func TestFindDeviceByBlock(t *testing.T) {
 						{
 							Name:       "sda1",
 							MountPoint: "/",
+						},
+						{
+							Name: "sda2",
 						},
 					},
 				},


### PR DESCRIPTION
Slight improvement to how we determine what block device we should scan when there's more than one candidate. We look for a block device with 0 mounted partitions. Improve logging as well to make it clear