### PR TITLE
🏃 Improve azure provider performance

### DIFF
--- a/providers/azure/provider/provider.go
+++ b/providers/azure/provider/provider.go
@@ -231,6 +231,10 @@ func (s *Service) discover(conn shared.AzureConnection) (*inventory.Inventory, e
 		return nil, nil
 	}
 
+	if len(conn.Config().Discover.Targets) == 0 {
+		return nil, nil
+	}
+
 	runtime, err := s.GetRuntime(conn.ID())
 	if err != nil {
 		return nil, err

--- a/providers/azure/resources/discovery.go
+++ b/providers/azure/resources/discovery.go
@@ -95,13 +95,13 @@ func Discover(runtime *plugin.Runtime, rootConf *inventory.Config) (*inventory.I
 	subsWithConfigs := make([]subWithConfig, len(subs))
 	for i := range subs {
 		sub := subs[i]
-		subsWithConfigs[i] = subWithConfig{sub: sub, conf: getSubConfig(conn.Conf, sub)}
+		subsWithConfigs[i] = subWithConfig{sub: sub, conf: getSubConfig(conn.Conf, conn.ID(), sub)}
 	}
 
 	if stringx.ContainsAnyOf(targets, DiscoverySubscriptions, DiscoveryAll, DiscoveryAuto) {
 		// we've already discovered those, simply add them as assets
 		for _, s := range subsWithConfigs {
-			assets = append(assets, subToAsset(s.sub, s.conf))
+			assets = append(assets, subToAsset(s.sub, s.conf, conn.ID()))
 		}
 	}
 	matchingTargets := []string{DiscoveryAll}
@@ -715,7 +715,8 @@ func discoverSubscriptions(conn *connection.AzureConnection, filter connection.S
 	return subs, nil
 }
 
-func subToAsset(sub subscriptions.Subscription, conf *inventory.Config) *inventory.Asset {
+func subToAsset(sub subscriptions.Subscription, conf *inventory.Config, parentConnId uint32) *inventory.Asset {
+	copyConf := conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(parentConnId))
 	platformId := "//platformid.api.mondoo.app/runtime/azure/subscriptions/" + *sub.SubscriptionID
 	tenantId := "unknown"
 	if sub.TenantID != nil {
@@ -731,18 +732,15 @@ func subToAsset(sub subscriptions.Subscription, conf *inventory.Config) *invento
 			TechnologyUrlSegments: []string{"azure", tenantId, *sub.SubscriptionID, "account"},
 		},
 		Name:        fmt.Sprintf("Azure subscription %s", *sub.DisplayName),
-		Connections: []*inventory.Config{conf},
+		Connections: []*inventory.Config{copyConf},
 		PlatformIds: []string{platformId},
 	}
 }
 
 // creates a config with filled in subscription and tenant id, this config can be used by the subscription asset
 // or any assets that are discovered within that subscription
-func getSubConfig(rootConf *inventory.Config, sub subscriptions.Subscription) *inventory.Config {
-	cfg := rootConf.Clone()
-	// note: we make sure to wipe out the discovery here, we don't want to re-discover when
-	// connecting to an asset
-	cfg.Discover = nil
+func getSubConfig(rootConf *inventory.Config, parentId uint32, sub subscriptions.Subscription) *inventory.Config {
+	cfg := rootConf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(parentId))
 	if cfg.Options == nil {
 		cfg.Options = map[string]string{}
 	}


### PR DESCRIPTION
* Use parent connections to take advantage of MQL cache.
* Ensure we do not discover subs multiple times, that's redundant