### PR TITLE
🐛 Do not set device name for aws ebs conn.

### DIFF
--- a/providers/aws/connection/awsec2ebsconn/provider.go
+++ b/providers/aws/connection/awsec2ebsconn/provider.go
@@ -154,7 +154,6 @@ func NewAwsEbsConnection(id uint32, conf *inventory.Config, asset *inventory.Ass
 		conf.PlatformId = awsec2.MondooInstanceID(i.AccountID, targetRegion, convert.ToString(instanceinfo.InstanceId))
 	}
 	asset.PlatformIds = []string{conf.PlatformId}
-	asset.Connections[0].Options["device-name"] = volLocation
 	c.deviceLocation = volLocation
 
 	deviceConn, err := device.NewDeviceConnection(id, &inventory.Config{


### PR DESCRIPTION
Even though we tell AWS to mount the block somewhere it's no guarantee it will end up there. We drop the `device-name` config option and let the device connection find the partition itself.