### PR TITLE
✨ add google workspace calendar and acl resources

### DIFF
--- a/providers/google-workspace/resources/calendars.go
+++ b/providers/google-workspace/resources/calendars.go
@@ -1,0 +1,71 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/providers/google-workspace/connection"
+	"google.golang.org/api/calendar/v3"
+)
+
+func (g *mqlGoogleworkspace) calendars() ([]interface{}, error) {
+	conn := g.MqlRuntime.Connection.(*connection.GoogleWorkspaceConnection)
+	calendarService, err := calendarService(conn, calendar.CalendarReadonlyScope, calendar.CalendarSettingsReadonlyScope)
+	if err != nil {
+		return nil, err
+	}
+	calendars, err := calendarService.CalendarList.List().Do()
+	if err != nil {
+		return nil, err
+	}
+	res := make([]interface{}, 0, len(calendars.Items))
+	for _, c := range calendars.Items {
+		r, err := CreateResource(g.MqlRuntime, "googleworkspace.calendar", map[string]*llx.RawData{
+			"__id":            llx.StringData(c.Id),
+			"summary":         llx.StringData(c.Summary),
+			"summaryOverride": llx.StringData(c.SummaryOverride),
+			"primary":         llx.BoolData(c.Primary),
+		})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, r)
+	}
+	return res, nil
+}
+
+func (g *mqlGoogleworkspaceCalendar) acl() ([]interface{}, error) {
+	conn := g.MqlRuntime.Connection.(*connection.GoogleWorkspaceConnection)
+	calendarService, err := calendarService(conn, calendar.CalendarScope)
+	if err != nil {
+		return nil, err
+	}
+	acls, err := calendarService.Acl.List(g.__id).Do()
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]interface{}, 0, len(acls.Items))
+	for _, a := range acls.Items {
+		scope, err := CreateResource(g.MqlRuntime, "googleworkspace.calendar.aclRule.scope", map[string]*llx.RawData{
+			"__id":  llx.StringData(a.Id + a.Scope.Type + a.Scope.Value),
+			"type":  llx.StringData(a.Scope.Type),
+			"value": llx.StringData(a.Scope.Value),
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		r, err := CreateResource(g.MqlRuntime, "googleworkspace.calendar.aclRule", map[string]*llx.RawData{
+			"__id":  llx.StringData(a.Id),
+			"role":  llx.StringData(a.Role),
+			"scope": llx.ResourceData(scope, "googleworkspace.calendar.aclRule.scope"),
+		})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, r)
+	}
+	return res, nil
+}

--- a/providers/google-workspace/resources/google-workspace.go
+++ b/providers/google-workspace/resources/google-workspace.go
@@ -9,6 +9,7 @@ import (
 	"go.mondoo.com/cnquery/v11/providers/google-workspace/connection"
 	directory "google.golang.org/api/admin/directory/v1"
 	reports "google.golang.org/api/admin/reports/v1"
+	"google.golang.org/api/calendar/v3"
 	cloudidentity "google.golang.org/api/cloudidentity/v1"
 	"google.golang.org/api/groupssettings/v1"
 	"google.golang.org/api/option"
@@ -36,6 +37,16 @@ func directoryService(conn *connection.GoogleWorkspaceConnection, scopes ...stri
 
 	directoryService, err := directory.NewService(context.Background(), option.WithHTTPClient(client))
 	return directoryService, err
+}
+
+func calendarService(conn *connection.GoogleWorkspaceConnection, scopes ...string) (*calendar.Service, error) {
+	client, err := conn.Client(scopes...)
+	if err != nil {
+		return nil, err
+	}
+
+	calendarsService, err := calendar.NewService(context.Background(), option.WithHTTPClient(client))
+	return calendarsService, err
 }
 
 func cloudIdentityService(conn *connection.GoogleWorkspaceConnection, scopes ...string) (*cloudidentity.Service, error) {

--- a/providers/google-workspace/resources/google-workspace.lr
+++ b/providers/google-workspace/resources/google-workspace.lr
@@ -18,6 +18,36 @@ googleworkspace {
   roles() []googleworkspace.role
   // Retrieves a list of all apps for the Google Workspace account
   connectedApps() []googleworkspace.connectedApp
+  // Retrieves a list of all calendars for the Google Workspace account
+  calendars() []googleworkspace.calendar
+}
+
+// Google Workspace calendar
+private googleworkspace.calendar @defaults("summary") {
+  // Title of the calendar
+  summary string
+  // The summary that the authenticated user has set for this calendar
+  summaryOverride string
+  // Whether the calendar is the primary calendar for the authenticated user
+  primary bool
+  // ACL rules for the calendar
+  acl() []googleworkspace.calendar.aclRule
+}
+
+// Google Workspace calendar ACL rule
+private googleworkspace.calendar.aclRule @defaults("role") {
+  // The role assigned to the scope. Possible values are none, freeBusyReader, reader, writer, owner
+  role string
+  // The extent to which calendar access is granted by this ACL rule
+  scope googleworkspace.calendar.aclRule.scope
+}
+
+// Google Workspace calendar ACL rule scope
+private googleworkspace.calendar.aclRule.scope @defaults("type") {
+  // The type of the scope. Possible values are default, user, group, domain
+  type string
+  // The email address of the user or group, or the name of a domain depending on the scope type
+  value string
 }
 
 // Google Workspace organizational unit

--- a/providers/google-workspace/resources/google-workspace.lr.go
+++ b/providers/google-workspace/resources/google-workspace.lr.go
@@ -22,6 +22,18 @@ func init() {
 			// to override args, implement: initGoogleworkspace(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createGoogleworkspace,
 		},
+		"googleworkspace.calendar": {
+			// to override args, implement: initGoogleworkspaceCalendar(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGoogleworkspaceCalendar,
+		},
+		"googleworkspace.calendar.aclRule": {
+			// to override args, implement: initGoogleworkspaceCalendarAclRule(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGoogleworkspaceCalendarAclRule,
+		},
+		"googleworkspace.calendar.aclRule.scope": {
+			// to override args, implement: initGoogleworkspaceCalendarAclRuleScope(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGoogleworkspaceCalendarAclRuleScope,
+		},
 		"googleworkspace.orgUnit": {
 			// to override args, implement: initGoogleworkspaceOrgUnit(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createGoogleworkspaceOrgUnit,
@@ -155,6 +167,33 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"googleworkspace.connectedApps": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGoogleworkspace).GetConnectedApps()).ToDataRes(types.Array(types.Resource("googleworkspace.connectedApp")))
+	},
+	"googleworkspace.calendars": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspace).GetCalendars()).ToDataRes(types.Array(types.Resource("googleworkspace.calendar")))
+	},
+	"googleworkspace.calendar.summary": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceCalendar).GetSummary()).ToDataRes(types.String)
+	},
+	"googleworkspace.calendar.summaryOverride": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceCalendar).GetSummaryOverride()).ToDataRes(types.String)
+	},
+	"googleworkspace.calendar.primary": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceCalendar).GetPrimary()).ToDataRes(types.Bool)
+	},
+	"googleworkspace.calendar.acl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceCalendar).GetAcl()).ToDataRes(types.Array(types.Resource("googleworkspace.calendar.aclRule")))
+	},
+	"googleworkspace.calendar.aclRule.role": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceCalendarAclRule).GetRole()).ToDataRes(types.String)
+	},
+	"googleworkspace.calendar.aclRule.scope": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceCalendarAclRule).GetScope()).ToDataRes(types.Resource("googleworkspace.calendar.aclRule.scope"))
+	},
+	"googleworkspace.calendar.aclRule.scope.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceCalendarAclRuleScope).GetType()).ToDataRes(types.String)
+	},
+	"googleworkspace.calendar.aclRule.scope.value": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceCalendarAclRuleScope).GetValue()).ToDataRes(types.String)
 	},
 	"googleworkspace.orgUnit.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGoogleworkspaceOrgUnit).GetId()).ToDataRes(types.String)
@@ -422,6 +461,54 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"googleworkspace.connectedApps": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGoogleworkspace).ConnectedApps, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.calendars": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspace).Calendars, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.calendar.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlGoogleworkspaceCalendar).__id, ok = v.Value.(string)
+			return
+		},
+	"googleworkspace.calendar.summary": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceCalendar).Summary, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.calendar.summaryOverride": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceCalendar).SummaryOverride, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.calendar.primary": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceCalendar).Primary, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.calendar.acl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceCalendar).Acl, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.calendar.aclRule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlGoogleworkspaceCalendarAclRule).__id, ok = v.Value.(string)
+			return
+		},
+	"googleworkspace.calendar.aclRule.role": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceCalendarAclRule).Role, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.calendar.aclRule.scope": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceCalendarAclRule).Scope, ok = plugin.RawToTValue[*mqlGoogleworkspaceCalendarAclRuleScope](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.calendar.aclRule.scope.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlGoogleworkspaceCalendarAclRuleScope).__id, ok = v.Value.(string)
+			return
+		},
+	"googleworkspace.calendar.aclRule.scope.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceCalendarAclRuleScope).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.calendar.aclRule.scope.value": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceCalendarAclRuleScope).Value, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"googleworkspace.orgUnit.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -811,6 +898,7 @@ type mqlGoogleworkspace struct {
 	Groups plugin.TValue[[]interface{}]
 	Roles plugin.TValue[[]interface{}]
 	ConnectedApps plugin.TValue[[]interface{}]
+	Calendars plugin.TValue[[]interface{}]
 }
 
 // createGoogleworkspace creates a new instance of this resource
@@ -944,6 +1032,191 @@ func (c *mqlGoogleworkspace) GetConnectedApps() *plugin.TValue[[]interface{}] {
 
 		return c.connectedApps()
 	})
+}
+
+func (c *mqlGoogleworkspace) GetCalendars() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.Calendars, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("googleworkspace", c.__id, "calendars")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.calendars()
+	})
+}
+
+// mqlGoogleworkspaceCalendar for the googleworkspace.calendar resource
+type mqlGoogleworkspaceCalendar struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlGoogleworkspaceCalendarInternal it will be used here
+	Summary plugin.TValue[string]
+	SummaryOverride plugin.TValue[string]
+	Primary plugin.TValue[bool]
+	Acl plugin.TValue[[]interface{}]
+}
+
+// createGoogleworkspaceCalendar creates a new instance of this resource
+func createGoogleworkspaceCalendar(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGoogleworkspaceCalendar{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("googleworkspace.calendar", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGoogleworkspaceCalendar) MqlName() string {
+	return "googleworkspace.calendar"
+}
+
+func (c *mqlGoogleworkspaceCalendar) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGoogleworkspaceCalendar) GetSummary() *plugin.TValue[string] {
+	return &c.Summary
+}
+
+func (c *mqlGoogleworkspaceCalendar) GetSummaryOverride() *plugin.TValue[string] {
+	return &c.SummaryOverride
+}
+
+func (c *mqlGoogleworkspaceCalendar) GetPrimary() *plugin.TValue[bool] {
+	return &c.Primary
+}
+
+func (c *mqlGoogleworkspaceCalendar) GetAcl() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.Acl, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("googleworkspace.calendar", c.__id, "acl")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.acl()
+	})
+}
+
+// mqlGoogleworkspaceCalendarAclRule for the googleworkspace.calendar.aclRule resource
+type mqlGoogleworkspaceCalendarAclRule struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlGoogleworkspaceCalendarAclRuleInternal it will be used here
+	Role plugin.TValue[string]
+	Scope plugin.TValue[*mqlGoogleworkspaceCalendarAclRuleScope]
+}
+
+// createGoogleworkspaceCalendarAclRule creates a new instance of this resource
+func createGoogleworkspaceCalendarAclRule(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGoogleworkspaceCalendarAclRule{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("googleworkspace.calendar.aclRule", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGoogleworkspaceCalendarAclRule) MqlName() string {
+	return "googleworkspace.calendar.aclRule"
+}
+
+func (c *mqlGoogleworkspaceCalendarAclRule) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGoogleworkspaceCalendarAclRule) GetRole() *plugin.TValue[string] {
+	return &c.Role
+}
+
+func (c *mqlGoogleworkspaceCalendarAclRule) GetScope() *plugin.TValue[*mqlGoogleworkspaceCalendarAclRuleScope] {
+	return &c.Scope
+}
+
+// mqlGoogleworkspaceCalendarAclRuleScope for the googleworkspace.calendar.aclRule.scope resource
+type mqlGoogleworkspaceCalendarAclRuleScope struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlGoogleworkspaceCalendarAclRuleScopeInternal it will be used here
+	Type plugin.TValue[string]
+	Value plugin.TValue[string]
+}
+
+// createGoogleworkspaceCalendarAclRuleScope creates a new instance of this resource
+func createGoogleworkspaceCalendarAclRuleScope(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGoogleworkspaceCalendarAclRuleScope{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("googleworkspace.calendar.aclRule.scope", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGoogleworkspaceCalendarAclRuleScope) MqlName() string {
+	return "googleworkspace.calendar.aclRule.scope"
+}
+
+func (c *mqlGoogleworkspaceCalendarAclRuleScope) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGoogleworkspaceCalendarAclRuleScope) GetType() *plugin.TValue[string] {
+	return &c.Type
+}
+
+func (c *mqlGoogleworkspaceCalendarAclRuleScope) GetValue() *plugin.TValue[string] {
+	return &c.Value
 }
 
 // mqlGoogleworkspaceOrgUnit for the googleworkspace.orgUnit resource

--- a/providers/google-workspace/resources/google-workspace.lr.manifest.yaml
+++ b/providers/google-workspace/resources/google-workspace.lr.manifest.yaml
@@ -4,12 +4,38 @@
 resources:
   googleworkspace:
     fields:
+      calendars: {}
       connectedApps: {}
       domains: {}
       groups: {}
       orgUnits: {}
       roles: {}
       users: {}
+    min_mondoo_version: latest
+  googleworkspace.calendar:
+    fields:
+      acl: {}
+      name: {}
+      primary: {}
+      summary: {}
+      summaryOverride: {}
+    is_private: true
+    min_mondoo_version: latest
+  googleworkspace.calendar.acl:
+    fields:
+      role: {}
+    min_mondoo_version: latest
+  googleworkspace.calendar.aclRule:
+    fields:
+      role: {}
+      scope: {}
+    is_private: true
+    min_mondoo_version: latest
+  googleworkspace.calendar.aclRule.scope:
+    fields:
+      type: {}
+      value: {}
+    is_private: true
     min_mondoo_version: latest
   googleworkspace.connectedApp:
     fields:


### PR DESCRIPTION
Adds support for google workspace calendars and their acl rules.

New scopes required for the permissions:
```
https://www.googleapis.com/auth/calendar.readonly
https://www.googleapis.com/auth/calendar.settings.readonly
https://www.googleapis.com/auth/calendar
```

Note that the last scope is not a readonly scope but it is required to retrieve the ACL for the calendars as per [Google's documentation](https://developers.google.com/calendar/api/v3/reference/acl/list#auth)

Fixes #4271