### PR TITLE
🐛 fix readdirnames for docker scans

### DIFF
--- a/providers/os/connection/docker/file.go
+++ b/providers/os/connection/docker/file.go
@@ -106,9 +106,12 @@ func (f *File) Readdirnames(n int) ([]string, error) {
 	}
 
 	// extract names
-	basenames := make([]string, len(directories))
-	for i := range directories {
-		basenames[i] = filepath.Base(directories[i])
+	basenames := []string{}
+	for _, dir := range directories {
+		if dir == "" {
+			continue
+		}
+		basenames = append(basenames, filepath.Base(dir))
 	}
 	return basenames, nil
 }


### PR DESCRIPTION
Fixes #8322

To trigger the issue use the following Dockerfile:
```Dockerfile
FROM wordpress

RUN touch /root/known_host
RUN mkdir /var/www/.ssh
RUN ln -s /root/known_hosts /var/www/.ssh/known_hosts
```

Or just pull the image from my repo: `ivanmilchev/test:loop` (I provided amd64 and arm64 images)

1. Run the image: `docker run -d ivanmilchev/test:loop`
2. Get the running container ID with `docker ps`
3. Run a container scan for the running container `cnspec scan docker <<CONTAINER_ID>>` (it must be cnspec. The issue isn't present in cnquery)

With the updated provider from this PR, the scan should finish successfully
