### PR TITLE
Skip protection rules retrieval for unprotected branches

### DIFF
--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -453,6 +453,12 @@ func (g *mqlGithubBranch) protectionRules() (*mqlGithubBranchprotection, error) 
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 	var err error
 
+	// if the branch is not protected, we don't need to fetch the protection rules
+	if !g.IsProtected.Data {
+		g.ProtectionRules.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
 	if g.RepoName.Error != nil {
 		return nil, g.RepoName.Error
 	}


### PR DESCRIPTION
Resolves #3905 

---

Leaving Protection Rules retrieval as is, since Github API doesn't seem to return full information about Protection rules in GetBranch and just stub instead.
attempted with the tokens (and multiple orgs):
1. Fine-Grained (administration read-only)
2. Fine-Grained (everything read-only)
3. Classic (admin read-only)

Example:
```json
* * *
  "protected": true,
  "protection": {
    "enabled": true,
    "required_status_checks": {
      "enforcement_level": "off",
      "contexts": [

      ],
      "checks": [

      ]
    }
  },
  "protection_url": "https://api.github.com/repos/mondoohq/cnquery/branches/main/protection"
}
```