### PR TITLE
🐛 Github: access personal repos: 

### DIFF
--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -155,7 +155,6 @@ func initGithubRepository(runtime *plugin.Runtime, args map[string]*llx.RawData)
 				}
 				user = obj.(*mqlGithubUser)
 			}
-			return nil, nil, err
 		} else {
 			org = obj.(*mqlGithubOrganization)
 		}


### PR DESCRIPTION
redundant error return with personal account as the repo owner(not an org)