### PR TITLE
🐛 Normalize partition labels before checking them and sort by size

### DIFF
--- a/providers/os/connection/snapshot/blockdevices.go
+++ b/providers/os/connection/snapshot/blockdevices.go
@@ -213,20 +213,21 @@ func (blockEntries BlockDevices) GetUnmountedBlockEntry() (*PartitionInfo, error
 }
 
 func findVolume(children []BlockDevice) *PartitionInfo {
-	var fs *PartitionInfo
 	for i := range children {
 		entry := children[i]
 		if entry.IsNotBootOrRootVolumeAndUnmounted() {
 			// we are NOT searching for the root volume here, so we can exclude the "sda" and "xvda" volumes
 			devFsName := "/dev/" + entry.Name
-			fs = &PartitionInfo{Name: devFsName, FsType: entry.FsType}
+			return &PartitionInfo{Name: devFsName, FsType: entry.FsType}
 		}
 	}
-	return fs
+	return nil
 }
 
 func (entry BlockDevice) IsNoBootVolume() bool {
-	return entry.Uuid != "" && entry.FsType != "" && entry.FsType != "vfat" && entry.Label != "EFI" && entry.Label != "boot"
+	typ := strings.ToLower(entry.FsType)
+	label := strings.ToLower(entry.Label)
+	return entry.Uuid != "" && typ != "" && typ != "vfat" && label != "efi" && label != "boot"
 }
 
 func (entry BlockDevice) IsNoBootVolumeAndUnmounted() bool {

--- a/providers/os/connection/snapshot/blockdevices.go
+++ b/providers/os/connection/snapshot/blockdevices.go
@@ -213,15 +213,19 @@ func (blockEntries BlockDevices) GetUnmountedBlockEntry() (*PartitionInfo, error
 }
 
 func findVolume(children []BlockDevice) *PartitionInfo {
+	candidates := []BlockDevice{}
 	for i := range children {
 		entry := children[i]
 		if entry.IsNotBootOrRootVolumeAndUnmounted() {
 			// we are NOT searching for the root volume here, so we can exclude the "sda" and "xvda" volumes
-			devFsName := "/dev/" + entry.Name
-			return &PartitionInfo{Name: devFsName, FsType: entry.FsType}
+			candidates = append(candidates, entry)
 		}
 	}
-	return nil
+	if len(candidates) == 0 {
+		return nil
+	}
+	sortPartitionsBySize(candidates)
+	return &PartitionInfo{Name: "/dev/" + candidates[0].Name, FsType: candidates[0].FsType}
 }
 
 func (entry BlockDevice) IsNoBootVolume() bool {

--- a/providers/os/connection/snapshot/blockdevices_test.go
+++ b/providers/os/connection/snapshot/blockdevices_test.go
@@ -107,7 +107,7 @@ func TestGetMountablePartitionByDevice(t *testing.T) {
 					Name: "sde",
 					Children: []BlockDevice{
 						{Uuid: "12346", FsType: "xfs", Size: 110, Label: "ROOT", Name: "sde1"},
-						{Uuid: "12345", FsType: "xfs", Size: 120, Label: "boot", Name: "sde2"},
+						{Uuid: "12345", FsType: "xfs", Size: 120, Label: "BOOT", Name: "sde2"},
 					},
 				},
 			},
@@ -395,7 +395,7 @@ func TestAttachedBlockEntryMultipleMatch(t *testing.T) {
 	info, err := blockEntries.GetUnnamedBlockEntry()
 	require.NoError(t, err)
 	require.Equal(t, "xfs", info.FsType)
-	require.True(t, strings.Contains(info.Name, "xvdh4"))
+	require.True(t, strings.Contains(info.Name, "xvdh3"))
 }
 
 func TestAttachedBlockEntryFedora(t *testing.T) {

--- a/providers/os/connection/snapshot/testdata/alma9_attached.json
+++ b/providers/os/connection/snapshot/testdata/alma9_attached.json
@@ -89,6 +89,7 @@
         {
           "name": "xvdh3",
           "fstype": "xfs",
+          "size": 101,
           "fsver": null,
           "label": null,
           "uuid": "31f80bf2-f73c-4350-bd3e-1dfe82e691f9",
@@ -102,6 +103,7 @@
           "name": "xvdh4",
           "fstype": "xfs",
           "fsver": null,
+          "size": 100,
           "label": null,
           "uuid": "b6b03ca5-4431-4db9-a1fb-f13c8566f779",
           "fsavail": null,


### PR DESCRIPTION
This ensures that when filtering out partitions, both `BOOT` and `boot` labels are filtered out. Also ensure that we sort the partitions by size and return the largest one.