### PR TITLE
🧹🐛 Don't show private resources in the shell auto complete

### DIFF
--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -213,21 +213,23 @@ func addResourceSuggestions(schema resources.ResourcesSchema, name string, res *
 
 	suggested := findFuzzy(name, names)
 
-	res.Suggestions = make([]*llx.Documentation, len(suggested))
 	var info *resources.ResourceInfo
 	for i := range suggested {
 		field := suggested[i].Target
 		info = resourceInfos[field]
 		if info != nil {
-			res.Suggestions[i] = &llx.Documentation{
+			if info.GetPrivate() {
+				continue
+			}
+			res.Suggestions = append(res.Suggestions, &llx.Documentation{
 				Field: field,
 				Title: info.Title,
 				Desc:  info.Desc,
-			}
+			})
 		} else {
-			res.Suggestions[i] = &llx.Documentation{
+			res.Suggestions = append(res.Suggestions, &llx.Documentation{
 				Field: field,
-			}
+			})
 		}
 	}
 }

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -1910,7 +1910,7 @@ func TestSuggestions(t *testing.T) {
 		{
 			// resource suggestions
 			"ssh",
-			[]string{"os.unix.sshd", "sshd", "sshd.config", "sshd.config.matchBlock", "windows.security.health"},
+			[]string{"os.unix.sshd", "sshd", "sshd.config", "windows.security.health"},
 			errors.New("cannot find resource for identifier 'ssh'"),
 			nil,
 		},


### PR DESCRIPTION
apparently private resources are still suggested in cnquery/cnspec shell

For example `aws.ecs.instance` is marked as private and shouldn't be accessible directly [but only via `aws.ecs.containerInstances` ](https://github.com/mondoohq/cnquery/blob/bc3c52de14289111b4db528950ffb2dca391bafb/providers/aws/resources/aws.lr#L1266)

But here is what we can see:
<img width="940" alt="Screenshot 2024-07-08 at 20 50 36" src="https://github.com/mondoohq/cnquery/assets/32666515/7ae8fc08-151b-4652-b086-8e577ffc8ce3">

Same for lots of other resources.