### PR TITLE
🐛 use kind fully qualified names for k8s resources

### DIFF
--- a/providers/k8s/resources/clusterrole.go
+++ b/providers/k8s/resources/clusterrole.go
@@ -22,7 +22,7 @@ type mqlK8sRbacClusterroleInternal struct {
 }
 
 func (k *mqlK8s) clusterroles() ([]interface{}, error) {
-	return k8sResourceToMql(k.MqlRuntime, "clusterroles", func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
+	return k8sResourceToMql(k.MqlRuntime, gvkString(rbacv1.SchemeGroupVersion.WithKind("clusterroles")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 		clusterRole, ok := resource.(*rbacv1.ClusterRole)
 		if !ok {

--- a/providers/k8s/resources/clusterrolebinding.go
+++ b/providers/k8s/resources/clusterrolebinding.go
@@ -22,7 +22,7 @@ type mqlK8sRbacClusterrolebindingInternal struct {
 }
 
 func (k *mqlK8s) clusterrolebindings() ([]interface{}, error) {
-	return k8sResourceToMql(k.MqlRuntime, "clusterrolebindings", func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
+	return k8sResourceToMql(k.MqlRuntime, gvkString(rbacv1.SchemeGroupVersion.WithKind("clusterrolebindings")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
 		clusterRoleBinding, ok := resource.(*rbacv1.ClusterRoleBinding)

--- a/providers/k8s/resources/common.go
+++ b/providers/k8s/resources/common.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func k8sProvider(t plugin.Connection) (shared.Connection, error) {
@@ -26,6 +27,10 @@ func k8sProvider(t plugin.Connection) (shared.Connection, error) {
 }
 
 type resourceConvertFn func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error)
+
+func gvkString(gvk schema.GroupVersionKind) string {
+	return gvk.Kind + "." + gvk.Version + "." + gvk.Group
+}
 
 func k8sResourceToMql(r *plugin.Runtime, kind string, fn resourceConvertFn) ([]interface{}, error) {
 	kt, err := k8sProvider(r.Connection)

--- a/providers/k8s/resources/configmap.go
+++ b/providers/k8s/resources/configmap.go
@@ -22,7 +22,7 @@ type mqlK8sConfigmapInternal struct {
 }
 
 func (k *mqlK8s) configmaps() ([]interface{}, error) {
-	return k8sResourceToMql(k.MqlRuntime, "configmaps", func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
+	return k8sResourceToMql(k.MqlRuntime, gvkString(corev1.SchemeGroupVersion.WithKind("configmaps")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
 		cm, ok := resource.(*corev1.ConfigMap)

--- a/providers/k8s/resources/cronjob.go
+++ b/providers/k8s/resources/cronjob.go
@@ -22,7 +22,7 @@ type mqlK8sCronjobInternal struct {
 }
 
 func (k *mqlK8s) cronjobs() ([]interface{}, error) {
-	return k8sResourceToMql(k.MqlRuntime, batchv1.Resource("cronjobs").String(), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
+	return k8sResourceToMql(k.MqlRuntime, gvkString(batchv1.SchemeGroupVersion.WithKind("cronjobs")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
 		r, err := CreateResource(k.MqlRuntime, "k8s.cronjob", map[string]*llx.RawData{

--- a/providers/k8s/resources/daemonset.go
+++ b/providers/k8s/resources/daemonset.go
@@ -22,7 +22,7 @@ type mqlK8sDaemonsetInternal struct {
 }
 
 func (k *mqlK8s) daemonsets() ([]interface{}, error) {
-	return k8sResourceToMql(k.MqlRuntime, appsv1.Resource("daemonsets").String(), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
+	return k8sResourceToMql(k.MqlRuntime, gvkString(appsv1.SchemeGroupVersion.WithKind("daemonsets")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
 		r, err := CreateResource(k.MqlRuntime, "k8s.daemonset", map[string]*llx.RawData{

--- a/providers/k8s/resources/deployment.go
+++ b/providers/k8s/resources/deployment.go
@@ -22,7 +22,7 @@ type mqlK8sDeploymentInternal struct {
 }
 
 func (k *mqlK8s) deployments() ([]interface{}, error) {
-	return k8sResourceToMql(k.MqlRuntime, appsv1.Resource("deployments").String(), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
+	return k8sResourceToMql(k.MqlRuntime, gvkString(appsv1.SchemeGroupVersion.WithKind("deployments")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
 		r, err := CreateResource(k.MqlRuntime, "k8s.deployment", map[string]*llx.RawData{

--- a/providers/k8s/resources/ingress.go
+++ b/providers/k8s/resources/ingress.go
@@ -26,7 +26,7 @@ type mqlK8sIngressInternal struct {
 }
 
 func (k *mqlK8s) ingresses() ([]interface{}, error) {
-	return k8sResourceToMql(k.MqlRuntime, networkingv1.Resource("ingresses").String(), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
+	return k8sResourceToMql(k.MqlRuntime, gvkString(networkingv1.SchemeGroupVersion.WithKind("ingresses")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
 		ingress, ok := resource.(*networkingv1.Ingress)

--- a/providers/k8s/resources/job.go
+++ b/providers/k8s/resources/job.go
@@ -22,7 +22,7 @@ type mqlK8sJobInternal struct {
 }
 
 func (k *mqlK8s) jobs() ([]interface{}, error) {
-	return k8sResourceToMql(k.MqlRuntime, batchv1.Resource("jobs").String(), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
+	return k8sResourceToMql(k.MqlRuntime, gvkString(batchv1.SchemeGroupVersion.WithKind("jobs")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
 		r, err := CreateResource(k.MqlRuntime, "k8s.job", map[string]*llx.RawData{

--- a/providers/k8s/resources/networkpolicy.go
+++ b/providers/k8s/resources/networkpolicy.go
@@ -21,7 +21,7 @@ type mqlK8sNetworkpolicyInternal struct {
 }
 
 func (k *mqlK8s) networkPolicies() ([]interface{}, error) {
-	return k8sResourceToMql(k.MqlRuntime, networkingv1.Resource("networkpolicies").String(), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
+	return k8sResourceToMql(k.MqlRuntime, gvkString(networkingv1.SchemeGroupVersion.WithKind("networkpolicies")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
 		networkPolicy, ok := resource.(*networkingv1.NetworkPolicy)

--- a/providers/k8s/resources/node.go
+++ b/providers/k8s/resources/node.go
@@ -53,7 +53,7 @@ func initK8sNode(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 
 func (k *mqlK8s) nodes() ([]interface{}, error) {
 	k.mqlK8sInternal.nodesByName = make(map[string]*mqlK8sNode)
-	return k8sResourceToMql(k.MqlRuntime, corev1.Resource("nodes").String(), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
+	return k8sResourceToMql(k.MqlRuntime, gvkString(corev1.SchemeGroupVersion.WithKind("nodes")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		r, err := CreateResource(k.MqlRuntime, "k8s.node", map[string]*llx.RawData{
 			"id":              llx.StringData(objIdFromK8sObj(obj, objT)),
 			"uid":             llx.StringData(string(obj.GetUID())),

--- a/providers/k8s/resources/pod.go
+++ b/providers/k8s/resources/pod.go
@@ -22,7 +22,7 @@ type mqlK8sPodInternal struct {
 }
 
 func (k *mqlK8s) pods() ([]interface{}, error) {
-	return k8sResourceToMql(k.MqlRuntime, corev1.Resource("pods").String(), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
+	return k8sResourceToMql(k.MqlRuntime, gvkString(corev1.SchemeGroupVersion.WithKind("pods")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
 		r, err := CreateResource(k.MqlRuntime, "k8s.pod", map[string]*llx.RawData{

--- a/providers/k8s/resources/podsecuritypolicy.go
+++ b/providers/k8s/resources/podsecuritypolicy.go
@@ -20,7 +20,7 @@ type mqlK8sPodsecuritypolicyInternal struct {
 }
 
 func (k *mqlK8s) podSecurityPolicies() ([]interface{}, error) {
-	return k8sResourceToMql(k.MqlRuntime, policyv1beta1.Resource("podsecuritypolicies").String(), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
+	return k8sResourceToMql(k.MqlRuntime, gvkString(policyv1beta1.SchemeGroupVersion.WithKind("podsecuritypolicies")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
 		psp, ok := resource.(*policyv1beta1.PodSecurityPolicy)

--- a/providers/k8s/resources/replicaset.go
+++ b/providers/k8s/resources/replicaset.go
@@ -22,7 +22,7 @@ type mqlK8sReplicasetInternal struct {
 }
 
 func (k *mqlK8s) replicasets() ([]interface{}, error) {
-	return k8sResourceToMql(k.MqlRuntime, appsv1.Resource("replicasets").String(), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
+	return k8sResourceToMql(k.MqlRuntime, gvkString(appsv1.SchemeGroupVersion.WithKind("replicasets")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
 		r, err := CreateResource(k.MqlRuntime, "k8s.replicaset", map[string]*llx.RawData{

--- a/providers/k8s/resources/role.go
+++ b/providers/k8s/resources/role.go
@@ -22,7 +22,7 @@ type mqlK8sRbacRoleInternal struct {
 }
 
 func (k *mqlK8s) roles() ([]interface{}, error) {
-	return k8sResourceToMql(k.MqlRuntime, rbacv1.Resource("roles").String(), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
+	return k8sResourceToMql(k.MqlRuntime, gvkString(rbacv1.SchemeGroupVersion.WithKind("roles")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
 		role, ok := resource.(*rbacv1.Role)

--- a/providers/k8s/resources/rolebinding.go
+++ b/providers/k8s/resources/rolebinding.go
@@ -22,7 +22,7 @@ type mqlK8sRbacRolebindingInternal struct {
 }
 
 func (k *mqlK8s) rolebindings() ([]interface{}, error) {
-	return k8sResourceToMql(k.MqlRuntime, rbacv1.Resource("rolebindings").String(), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
+	return k8sResourceToMql(k.MqlRuntime, gvkString(rbacv1.SchemeGroupVersion.WithKind("rolebindings")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
 		roleBinding, ok := resource.(*rbacv1.RoleBinding)

--- a/providers/k8s/resources/secret.go
+++ b/providers/k8s/resources/secret.go
@@ -22,7 +22,7 @@ type mqlK8sSecretInternal struct {
 }
 
 func (k *mqlK8s) secrets() ([]interface{}, error) {
-	return k8sResourceToMql(k.MqlRuntime, corev1.Resource("secrets").String(), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
+	return k8sResourceToMql(k.MqlRuntime, gvkString(corev1.SchemeGroupVersion.WithKind("secrets")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
 		s, ok := resource.(*corev1.Secret)

--- a/providers/k8s/resources/service.go
+++ b/providers/k8s/resources/service.go
@@ -21,7 +21,7 @@ type mqlK8sServiceInternal struct {
 }
 
 func (k *mqlK8s) services() ([]interface{}, error) {
-	return k8sResourceToMql(k.MqlRuntime, corev1.Resource("services").String(), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
+	return k8sResourceToMql(k.MqlRuntime, gvkString(corev1.SchemeGroupVersion.WithKind("services")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 		srv, ok := resource.(*corev1.Service)
 		if !ok {

--- a/providers/k8s/resources/statefulset.go
+++ b/providers/k8s/resources/statefulset.go
@@ -22,7 +22,7 @@ type mqlK8sStatefulsetInternal struct {
 }
 
 func (k *mqlK8s) statefulsets() ([]interface{}, error) {
-	return k8sResourceToMql(k.MqlRuntime, appsv1.Resource("statefulsets").String(), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
+	return k8sResourceToMql(k.MqlRuntime, gvkString(appsv1.SchemeGroupVersion.WithKind("statefulsets")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (interface{}, error) {
 		ts := obj.GetCreationTimestamp()
 
 		r, err := CreateResource(k.MqlRuntime, "k8s.statefulset", map[string]*llx.RawData{


### PR DESCRIPTION
We should use kind instead of resources. Also the k8s library doesn't "stringify" the `GroupVersionKind` in the format that is expected by the server. Therefore we are doing that ourselves