### PR TITLE
🐛 fix: scoring system json marshal

### DIFF
--- a/explorer/impact.go
+++ b/explorer/impact.go
@@ -165,20 +165,23 @@ func (s *ScoringSystem) UnmarshalYAML(node *yaml.Node) error {
 }
 
 func (s *ScoringSystem) MarshalJSON() ([]byte, error) {
+	var result string
 	switch *s {
 	case ScoringSystem_WORST:
-		return []byte("highest impact"), nil
+		result = "highest impact"
 	case ScoringSystem_WEIGHTED:
-		return []byte("weighted"), nil
+		result = "weighted"
 	case ScoringSystem_AVERAGE:
-		return []byte("average"), nil
+		result = "average"
 	case ScoringSystem_BANDED:
-		return []byte("banded"), nil
+		result = "banded"
 	case ScoringSystem_DECAYED:
-		return []byte("decayed"), nil
+		result = "decayed"
 	default:
-		return []byte("unknown"), nil
+		result = "unknown"
 	}
+
+	return json.Marshal(result) // will add quotes and escape if needed
 }
 
 func (s *ScoringSystem) MarshalYAML() (interface{}, error) {

--- a/explorer/impact.go
+++ b/explorer/impact.go
@@ -164,9 +164,9 @@ func (s *ScoringSystem) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
-func (s *ScoringSystem) MarshalJSON() ([]byte, error) {
+func (s ScoringSystem) MarshalJSON() ([]byte, error) {
 	var result string
-	switch *s {
+	switch s {
 	case ScoringSystem_WORST:
 		result = "highest impact"
 	case ScoringSystem_WEIGHTED:
@@ -184,8 +184,8 @@ func (s *ScoringSystem) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result) // will add quotes and escape if needed
 }
 
-func (s *ScoringSystem) MarshalYAML() (interface{}, error) {
-	switch *s {
+func (s ScoringSystem) MarshalYAML() (interface{}, error) {
+	switch s {
 	case ScoringSystem_WORST:
 		return "highest impact", nil
 	case ScoringSystem_WEIGHTED:
@@ -197,6 +197,6 @@ func (s *ScoringSystem) MarshalYAML() (interface{}, error) {
 	case ScoringSystem_DECAYED:
 		return "decayed", nil
 	default:
-		return *s, nil
+		return s, nil
 	}
 }

--- a/explorer/impact_test.go
+++ b/explorer/impact_test.go
@@ -5,10 +5,12 @@ package explorer
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestImpactParsing(t *testing.T) {
@@ -132,7 +134,7 @@ func TestImpactMerging(t *testing.T) {
 	}
 }
 
-func TestScoringSystemParsing(t *testing.T) {
+func TestScoringSystemParsingJSON(t *testing.T) {
 	s := ScoringSystem_DECAYED
 	raw, err := json.Marshal(s)
 	require.NoError(t, err)
@@ -140,4 +142,50 @@ func TestScoringSystemParsing(t *testing.T) {
 	err = json.Unmarshal(raw, &s)
 	require.NoError(t, err)
 	assert.Equal(t, ScoringSystem_DECAYED, s)
+}
+
+func TestScoringSystemParsingYAML(t *testing.T) {
+	s := ScoringSystem_DECAYED
+	raw, err := yaml.Marshal(s)
+	require.NoError(t, err)
+
+	err = yaml.Unmarshal(raw, &s)
+	require.NoError(t, err)
+	assert.Equal(t, ScoringSystem_DECAYED, s)
+}
+
+func TestScoringSystemPointerParsingJSON(t *testing.T) {
+	ss := ScoringSystem_DECAYED
+	data := struct {
+		ScoringSystem *ScoringSystem `json:"scoring_system"`
+	}{
+		&ss,
+	}
+
+	raw, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"scoring_system":"decayed"}`, string(raw))
+
+	err = json.Unmarshal(raw, &data)
+	require.NoError(t, err)
+	assert.Equal(t, ScoringSystem_DECAYED, *data.ScoringSystem)
+}
+
+func TestScoringSystemPointerParsingYAML(t *testing.T) {
+	ss := ScoringSystem_DECAYED
+	data := struct {
+		ScoringSystem *ScoringSystem `yaml:"scoring_system"`
+	}{
+		&ss,
+	}
+
+	raw, err := yaml.Marshal(data)
+	require.NoError(t, err)
+
+	assert.Equal(t, `scoring_system: decayed`, strings.Trim(string(raw), "\n"))
+
+	err = yaml.Unmarshal(raw, &data)
+	require.NoError(t, err)
+	assert.Equal(t, ScoringSystem_DECAYED, *data.ScoringSystem)
 }

--- a/explorer/impact_test.go
+++ b/explorer/impact_test.go
@@ -139,6 +139,8 @@ func TestScoringSystemParsingJSON(t *testing.T) {
 	raw, err := json.Marshal(s)
 	require.NoError(t, err)
 
+	assert.Equal(t, `"decayed"`, string(raw))
+
 	err = json.Unmarshal(raw, &s)
 	require.NoError(t, err)
 	assert.Equal(t, ScoringSystem_DECAYED, s)
@@ -148,6 +150,8 @@ func TestScoringSystemParsingYAML(t *testing.T) {
 	s := ScoringSystem_DECAYED
 	raw, err := yaml.Marshal(s)
 	require.NoError(t, err)
+
+	assert.Equal(t, `decayed`, strings.Trim(string(raw), "\n"))
 
 	err = yaml.Unmarshal(raw, &s)
 	require.NoError(t, err)


### PR DESCRIPTION
MarshalJSON was returning values unquoted, i.e. like:

```json
{
  "scoring_system": decayed
}
```