### PR TITLE
⭐️ add macos.systemExtensions as new resource

### DIFF
--- a/providers/os/resources/macos_systemextension.go
+++ b/providers/os/resources/macos_systemextension.go
@@ -1,0 +1,109 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+
+	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/convert"
+	"go.mondoo.com/cnquery/v11/providers/os/connection/shared"
+	"go.mondoo.com/cnquery/v11/types"
+)
+
+func (m *mqlMacos) systemExtensions() ([]interface{}, error) {
+	conn := m.MqlRuntime.Connection.(shared.Connection)
+
+	f, err := conn.FileSystem().Open("/Library/SystemExtensions/db.plist")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	systemExtensionDb, err := Decode(f)
+	if err != nil {
+		return nil, err
+	}
+
+	extensions := systemExtensionDb["extensions"].([]interface{})
+	extensionPolicies := systemExtensionDb["extensionPolicies"].([]interface{})
+
+	list := []interface{}{}
+	for i := range extensions {
+		ex, err := newMacosSystemExtension(m.MqlRuntime, extensions[i].(map[string]interface{}), extensionPolicies)
+		if err != nil {
+			return nil, err
+		}
+		list = append(list, ex)
+	}
+
+	return list, nil
+}
+
+func newMacosSystemExtension(runtime *plugin.Runtime, extension plistData, extensionPolicies []interface{}) (*mqlMacosSystemExtension, error) {
+	uuid := extension.GetString("uniqueID")
+	identifier := extension.GetString("identifier")
+	teamID := extension.GetString("teamID")
+	isMdmManaged := false
+	for i := range extensionPolicies {
+		policy, ok := extensionPolicies[i].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		plistPolicy := plistData(policy)
+
+		// check if the team id is in allowedTeamIDs list
+		allowedTeams := plistPolicy.GetPlistData("allowedTeamIDs")
+		for k := range allowedTeams {
+			list := allowedTeams[k].([]interface{})
+			for j := range list {
+				if list[j].(string) == teamID {
+					isMdmManaged = true
+					break
+				}
+			}
+		}
+
+		// if it is not in the team id list, check allowedExtensions list
+		allowedExtensions := plistPolicy.GetPlistData("allowedExtensions")
+		for k := range allowedExtensions {
+			list := allowedExtensions[k].([]interface{})
+			for j := range list {
+				if list[j].(string) == identifier {
+					isMdmManaged = true
+					break
+				}
+			}
+		}
+	}
+
+	pkg, err := CreateResource(runtime, "macos.systemExtension", map[string]*llx.RawData{
+		"__id":       llx.StringData(uuid),
+		"identifier": llx.StringData(identifier),
+		"uuid":       llx.StringData(uuid),
+		"version":    llx.StringData(extension.GetString("bundleVersion", "CFBundleShortVersionString")),
+		"categories": llx.ArrayData(convert.SliceAnyToInterface(extension.GetList("categories")), types.String),
+		"state":      llx.StringData(extension.GetString("state")),
+		"teamID":     llx.StringData(teamID),
+		"bundlePath": llx.StringData(extension.GetString("container", "bundlePath")),
+		"mdmManaged": llx.BoolData(isMdmManaged),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	s := pkg.(*mqlMacosSystemExtension)
+	return s, nil
+}
+
+func (m *mqlMacosSystemExtension) enabled() (bool, error) {
+	state := m.GetState()
+	return strings.Contains(state.Data, "enabled"), nil
+}
+
+func (m *mqlMacosSystemExtension) active() (bool, error) {
+	state := m.GetState()
+	return strings.Contains(state.Data, "activated"), nil
+}

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -1302,6 +1302,8 @@ macos {
   userHostPreferences() map[string]dict
   // macOS global account policies
   globalAccountPolicies() dict
+  // System extensions
+  systemExtensions() []macos.systemExtension
 }
 
 // macOS application layer firewall (ALF) service
@@ -1398,6 +1400,30 @@ windows {
 
   // Information about optional features in a Windows image.
   optionalFeatures() []windows.optionalFeature
+}
+
+// macOS system extension
+private macos.systemExtension @defaults("teamID identifier version state"){
+  // Identifier of the system extension
+  identifier string
+  // System extension unique identifier
+  uuid string
+  // Version of the system extension
+  version string
+  // Categories of the system extension
+  categories []string
+  // State of the system extension
+  state string
+  // Indicates whether the system extension is enabled
+  enabled() bool
+  // Indicates whether the system extension is active
+  active() bool
+  // Team identifier of the system extension
+  teamID string
+  // Path to the system extension
+  bundlePath string
+  // Indicates whether the system extension is MDM managed
+  mdmManaged bool
 }
 
 // Windows hotfix resource

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -1414,15 +1414,15 @@ private macos.systemExtension @defaults("teamID identifier version state"){
   categories []string
   // State of the system extension
   state string
-  // Indicates whether the system extension is enabled
+  // Whether the system extension is enabled
   enabled() bool
-  // Indicates whether the system extension is active
+  // Whether the system extension is active
   active() bool
   // Team identifier of the system extension
   teamID string
   // Path to the system extension
   bundlePath string
-  // Indicates whether the system extension is MDM managed
+  // Whether the system extension is MDM managed
   mdmManaged bool
 }
 

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -426,6 +426,10 @@ func init() {
 			// to override args, implement: initWindows(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createWindows,
 		},
+		"macos.systemExtension": {
+			// to override args, implement: initMacosSystemExtension(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createMacosSystemExtension,
+		},
 		"windows.hotfix": {
 			Init: initWindowsHotfix,
 			Create: createWindowsHotfix,
@@ -1880,6 +1884,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"macos.globalAccountPolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMacos).GetGlobalAccountPolicies()).ToDataRes(types.Dict)
 	},
+	"macos.systemExtensions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacos).GetSystemExtensions()).ToDataRes(types.Array(types.Resource("macos.systemExtension")))
+	},
 	"macos.alf.allowDownloadSignedEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMacosAlf).GetAllowDownloadSignedEnabled()).ToDataRes(types.Int)
 	},
@@ -1990,6 +1997,36 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"windows.optionalFeatures": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindows).GetOptionalFeatures()).ToDataRes(types.Array(types.Resource("windows.optionalFeature")))
+	},
+	"macos.systemExtension.identifier": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosSystemExtension).GetIdentifier()).ToDataRes(types.String)
+	},
+	"macos.systemExtension.uuid": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosSystemExtension).GetUuid()).ToDataRes(types.String)
+	},
+	"macos.systemExtension.version": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosSystemExtension).GetVersion()).ToDataRes(types.String)
+	},
+	"macos.systemExtension.categories": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosSystemExtension).GetCategories()).ToDataRes(types.Array(types.String))
+	},
+	"macos.systemExtension.state": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosSystemExtension).GetState()).ToDataRes(types.String)
+	},
+	"macos.systemExtension.enabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosSystemExtension).GetEnabled()).ToDataRes(types.Bool)
+	},
+	"macos.systemExtension.active": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosSystemExtension).GetActive()).ToDataRes(types.Bool)
+	},
+	"macos.systemExtension.teamID": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosSystemExtension).GetTeamID()).ToDataRes(types.String)
+	},
+	"macos.systemExtension.bundlePath": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosSystemExtension).GetBundlePath()).ToDataRes(types.String)
+	},
+	"macos.systemExtension.mdmManaged": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosSystemExtension).GetMdmManaged()).ToDataRes(types.Bool)
 	},
 	"windows.hotfix.hotfixId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsHotfix).GetHotfixId()).ToDataRes(types.String)
@@ -4428,6 +4465,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlMacos).GlobalAccountPolicies, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
 		return
 	},
+	"macos.systemExtensions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacos).SystemExtensions, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
 	"macos.alf.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 			r.(*mqlMacosAlf).__id, ok = v.Value.(string)
 			return
@@ -4590,6 +4631,50 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"windows.optionalFeatures": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlWindows).OptionalFeatures, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"macos.systemExtension.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlMacosSystemExtension).__id, ok = v.Value.(string)
+			return
+		},
+	"macos.systemExtension.identifier": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosSystemExtension).Identifier, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"macos.systemExtension.uuid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosSystemExtension).Uuid, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"macos.systemExtension.version": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosSystemExtension).Version, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"macos.systemExtension.categories": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosSystemExtension).Categories, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"macos.systemExtension.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosSystemExtension).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"macos.systemExtension.enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosSystemExtension).Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"macos.systemExtension.active": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosSystemExtension).Active, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"macos.systemExtension.teamID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosSystemExtension).TeamID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"macos.systemExtension.bundlePath": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosSystemExtension).BundlePath, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"macos.systemExtension.mdmManaged": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosSystemExtension).MdmManaged, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"windows.hotfix.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12722,6 +12807,7 @@ type mqlMacos struct {
 	UserPreferences plugin.TValue[map[string]interface{}]
 	UserHostPreferences plugin.TValue[map[string]interface{}]
 	GlobalAccountPolicies plugin.TValue[interface{}]
+	SystemExtensions plugin.TValue[[]interface{}]
 }
 
 // createMacos creates a new instance of this resource
@@ -12771,6 +12857,22 @@ func (c *mqlMacos) GetUserHostPreferences() *plugin.TValue[map[string]interface{
 func (c *mqlMacos) GetGlobalAccountPolicies() *plugin.TValue[interface{}] {
 	return plugin.GetOrCompute[interface{}](&c.GlobalAccountPolicies, func() (interface{}, error) {
 		return c.globalAccountPolicies()
+	})
+}
+
+func (c *mqlMacos) GetSystemExtensions() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.SystemExtensions, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("macos", c.__id, "systemExtensions")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.systemExtensions()
 	})
 }
 
@@ -13205,6 +13307,99 @@ func (c *mqlWindows) GetOptionalFeatures() *plugin.TValue[[]interface{}] {
 
 		return c.optionalFeatures()
 	})
+}
+
+// mqlMacosSystemExtension for the macos.systemExtension resource
+type mqlMacosSystemExtension struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlMacosSystemExtensionInternal it will be used here
+	Identifier plugin.TValue[string]
+	Uuid plugin.TValue[string]
+	Version plugin.TValue[string]
+	Categories plugin.TValue[[]interface{}]
+	State plugin.TValue[string]
+	Enabled plugin.TValue[bool]
+	Active plugin.TValue[bool]
+	TeamID plugin.TValue[string]
+	BundlePath plugin.TValue[string]
+	MdmManaged plugin.TValue[bool]
+}
+
+// createMacosSystemExtension creates a new instance of this resource
+func createMacosSystemExtension(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMacosSystemExtension{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("macos.systemExtension", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMacosSystemExtension) MqlName() string {
+	return "macos.systemExtension"
+}
+
+func (c *mqlMacosSystemExtension) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMacosSystemExtension) GetIdentifier() *plugin.TValue[string] {
+	return &c.Identifier
+}
+
+func (c *mqlMacosSystemExtension) GetUuid() *plugin.TValue[string] {
+	return &c.Uuid
+}
+
+func (c *mqlMacosSystemExtension) GetVersion() *plugin.TValue[string] {
+	return &c.Version
+}
+
+func (c *mqlMacosSystemExtension) GetCategories() *plugin.TValue[[]interface{}] {
+	return &c.Categories
+}
+
+func (c *mqlMacosSystemExtension) GetState() *plugin.TValue[string] {
+	return &c.State
+}
+
+func (c *mqlMacosSystemExtension) GetEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Enabled, func() (bool, error) {
+		return c.enabled()
+	})
+}
+
+func (c *mqlMacosSystemExtension) GetActive() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Active, func() (bool, error) {
+		return c.active()
+	})
+}
+
+func (c *mqlMacosSystemExtension) GetTeamID() *plugin.TValue[string] {
+	return &c.TeamID
+}
+
+func (c *mqlMacosSystemExtension) GetBundlePath() *plugin.TValue[string] {
+	return &c.BundlePath
+}
+
+func (c *mqlMacosSystemExtension) GetMdmManaged() *plugin.TValue[bool] {
+	return &c.MdmManaged
 }
 
 // mqlWindowsHotfix for the windows.hotfix resource

--- a/providers/os/resources/os.lr.manifest.yaml
+++ b/providers/os/resources/os.lr.manifest.yaml
@@ -506,6 +506,8 @@ resources:
   macos:
     fields:
       globalAccountPolicies: {}
+      systemExtensions:
+        min_mondoo_version: latest
       userHostPreferences: {}
       userPreferences: {}
     min_mondoo_version: 5.15.0
@@ -527,6 +529,22 @@ resources:
     fields:
       authorizationDB: {}
     min_mondoo_version: 5.15.0
+  macos.systemExtension:
+    fields:
+      active: {}
+      bundleID: {}
+      bundlePath: {}
+      categories: {}
+      enabled: {}
+      identifier: {}
+      mdmManaged: {}
+      name: {}
+      state: {}
+      teamID: {}
+      uuid: {}
+      version: {}
+    is_private: true
+    min_mondoo_version: latest
   macos.systemsetup:
     fields:
       allowPowerButtonToSleepComputer: {}

--- a/providers/os/resources/os.lr.manifest.yaml
+++ b/providers/os/resources/os.lr.manifest.yaml
@@ -544,7 +544,7 @@ resources:
       uuid: {}
       version: {}
     is_private: true
-    min_mondoo_version: latest
+    min_mondoo_version: 9.0.0
   macos.systemsetup:
     fields:
       allowPowerButtonToSleepComputer: {}

--- a/providers/os/resources/os.lr.manifest.yaml
+++ b/providers/os/resources/os.lr.manifest.yaml
@@ -507,7 +507,7 @@ resources:
     fields:
       globalAccountPolicies: {}
       systemExtensions:
-        min_mondoo_version: latest
+        min_mondoo_version: 9.0.0
       userHostPreferences: {}
       userPreferences: {}
     min_mondoo_version: 5.15.0


### PR DESCRIPTION
List all macOS system extensions

```coffeescript
cnquery> macos.systemExtensions
macos.systemExtensions: [
  0: macos.systemExtension teamID="P3FGV63VK7" identifier="io.kandji.KandjiAgent.ESF-Extension" version="1.8.10" state="activated_enabled"
  1: macos.systemExtension teamID="X9E956P446" identifier="com.crowdstrike.falcon.Agent" version="7.17" state="activated_enabled"
  2: macos.systemExtension teamID="2MMRE5MTB8" identifier="com.obsproject.obs-studio.mac-camera-extension" version="30.1.2" state="activated_waiting_for_user"
  3: macos.systemExtension teamID="X9E956P446" identifier="com.crowdstrike.falcon.Agent" version="7.16" state="terminated_waiting_to_uninstall_on_reboot"
  4: macos.systemExtension teamID="P3FGV63VK7" identifier="io.kandji.KandjiAgent.ESF-Extension" version="1.8.9" state="terminated_waiting_to_uninstall_on_reboot"
  5: macos.systemExtension teamID="DE8Y96K9QP" identifier="com.cisco.anyconnect.macos.acsockext" version="4.9.06037" state="activated_enabled"
]
```

To list extensions that are not mdm managed:

```coffeescript
cnquery> macos.systemExtensions.where(mdmManaged == false )
macos.systemExtensions.where: [
  0: macos.systemExtension teamID="2MMRE5MTB8" identifier="com.obsproject.obs-studio.mac-camera-extension" version="30.1.2" state="activated_waiting_for_user"
  1: macos.systemExtension teamID="DE8Y96K9QP" identifier="com.cisco.anyconnect.macos.acsockext" version="4.9.06037" state="activated_enabled"
]
```