### PR TITLE
Add 2 new fields to EKS clusters

### DIFF
--- a/providers/aws/go.mod
+++ b/providers/aws/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.25.3
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.44.3
 	github.com/aws/aws-sdk-go-v2/service/efs v1.31.3
-	github.com/aws/aws-sdk-go-v2/service/eks v1.46.2
+	github.com/aws/aws-sdk-go-v2/service/eks v1.47.0
 	github.com/aws/aws-sdk-go-v2/service/elasticache v1.40.3
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.26.3
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.33.3

--- a/providers/aws/go.sum
+++ b/providers/aws/go.sum
@@ -111,8 +111,8 @@ github.com/aws/aws-sdk-go-v2/service/ecs v1.44.3 h1:JkVDQ9mfUSwMOGWIEmyB74mIznjK
 github.com/aws/aws-sdk-go-v2/service/ecs v1.44.3/go.mod h1:MsQWy/90Xwn3cy5u+eiiXqC521xIm21wOODIweLo4hs=
 github.com/aws/aws-sdk-go-v2/service/efs v1.31.3 h1:vHNTbv0pFB/E19MokZcWAxZIggWgcLlcixNePBe6iZc=
 github.com/aws/aws-sdk-go-v2/service/efs v1.31.3/go.mod h1:P1X7sDHKpqZCLac7bRsFF/EN2REOgmeKStQTa14FpEA=
-github.com/aws/aws-sdk-go-v2/service/eks v1.46.2 h1:byyz/tBy/uGyucr/QLE1UmTuGaJx9ge19aWUZCiOMCc=
-github.com/aws/aws-sdk-go-v2/service/eks v1.46.2/go.mod h1:awleuSoavuUt32hemzWdSrI47zq7slFtIj8St07EXpE=
+github.com/aws/aws-sdk-go-v2/service/eks v1.47.0 h1:u0VeIQ02COfhmp37ub8zv29bdRtosCYzXoWd+QRebbY=
+github.com/aws/aws-sdk-go-v2/service/eks v1.47.0/go.mod h1:awleuSoavuUt32hemzWdSrI47zq7slFtIj8St07EXpE=
 github.com/aws/aws-sdk-go-v2/service/elasticache v1.40.3 h1:nmEN5lGIAShc0nNFjvUk2/YYlsTSwX2n1XF37Av93Yw=
 github.com/aws/aws-sdk-go-v2/service/elasticache v1.40.3/go.mod h1:OcUtpbcNsyMdA/Wv5XenKl8aG3yrqA6HVIOF7ms+Ikc=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.26.3 h1:5B2Dq2zy/hgtEO3wITnOZiyh6e+GyuHTGw6bK/8+L3w=

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -3157,7 +3157,7 @@ private aws.eks.cluster @defaults("arn version status") {
   addons() []aws.eks.addon
   // The IAM role that provides permissions for the Kubernetes control plane to make calls to Amazon Web Services API operations on your behalf
   iamRole aws.iam.role
-  // The Kubernetes support policy of the cluster. `STANDARD` support automatically upgrades at the end of standard support. `EXTENDED` automatically enters extended support at the end of standard support.
+  // The Kubernetes support policy of the cluster. (`STANDARD` support automatically upgrades at the end of standard support. `EXTENDED` automatically enters extended support at the end of standard support.)
   supportType string
   // The authentication mode for the cluster
   authenticationMode string

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -3147,7 +3147,7 @@ private aws.eks.cluster @defaults("arn version status") {
   logging dict
   // Kubernetes network configuration
   networkConfig dict
-  //  VPC configuration
+  // VPC configuration
   resourcesVpcConfig dict
   // Cluster creation timestamp
   createdAt time
@@ -3157,4 +3157,8 @@ private aws.eks.cluster @defaults("arn version status") {
   addons() []aws.eks.addon
   // The IAM role that provides permissions for the Kubernetes control plane to make calls to Amazon Web Services API operations on your behalf
   iamRole aws.iam.role
+  // The Kubernetes support policy of the cluster. `STANDARD` support automatically upgrades at the end of standard support. `EXTENDED` automatically enters extended support at the end of standard support.
+  supportType string
+  // The authentication mode for the cluster
+  authenticationMode string
 }

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -3157,7 +3157,7 @@ private aws.eks.cluster @defaults("arn version status") {
   addons() []aws.eks.addon
   // The IAM role that provides permissions for the Kubernetes control plane to make calls to Amazon Web Services API operations on your behalf
   iamRole aws.iam.role
-  // The Kubernetes support policy of the cluster. (`STANDARD` support automatically upgrades at the end of standard support. `EXTENDED` automatically enters extended support at the end of standard support.)
+  // The Kubernetes support policy of the cluster. (`STANDARD` support automatically upgrades at the end of standard support. `EXTENDED` automatically enters extended support at the end of standard support)
   supportType string
   // The authentication mode for the cluster
   authenticationMode string

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -4437,6 +4437,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.eks.cluster.iamRole": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEksCluster).GetIamRole()).ToDataRes(types.Resource("aws.iam.role"))
 	},
+	"aws.eks.cluster.supportType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEksCluster).GetSupportType()).ToDataRes(types.String)
+	},
+	"aws.eks.cluster.authenticationMode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEksCluster).GetAuthenticationMode()).ToDataRes(types.String)
+	},
 }
 
 func GetData(resource plugin.Resource, field string, args map[string]*llx.RawData) *plugin.DataRes {
@@ -10011,6 +10017,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.eks.cluster.iamRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEksCluster).IamRole, ok = plugin.RawToTValue[*mqlAwsIamRole](v.Value, v.Error)
+		return
+	},
+	"aws.eks.cluster.supportType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEksCluster).SupportType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.eks.cluster.authenticationMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEksCluster).AuthenticationMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 }
@@ -25880,6 +25894,8 @@ type mqlAwsEksCluster struct {
 	NodeGroups plugin.TValue[[]interface{}]
 	Addons plugin.TValue[[]interface{}]
 	IamRole plugin.TValue[*mqlAwsIamRole]
+	SupportType plugin.TValue[string]
+	AuthenticationMode plugin.TValue[string]
 }
 
 // createAwsEksCluster creates a new instance of this resource
@@ -26005,4 +26021,12 @@ func (c *mqlAwsEksCluster) GetAddons() *plugin.TValue[[]interface{}] {
 
 func (c *mqlAwsEksCluster) GetIamRole() *plugin.TValue[*mqlAwsIamRole] {
 	return &c.IamRole
+}
+
+func (c *mqlAwsEksCluster) GetSupportType() *plugin.TValue[string] {
+	return &c.SupportType
+}
+
+func (c *mqlAwsEksCluster) GetAuthenticationMode() *plugin.TValue[string] {
+	return &c.AuthenticationMode
 }

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -1539,6 +1539,8 @@ resources:
       addons:
         min_mondoo_version: 9.0.0
       arn: {}
+      authenticationMode:
+        min_mondoo_version: 9.0.0
       createdAt: {}
       encryptionConfig: {}
       endpoint: {}
@@ -1553,6 +1555,8 @@ resources:
       region: {}
       resourcesVpcConfig: {}
       status: {}
+      supportType:
+        min_mondoo_version: 9.0.0
       tags: {}
       version: {}
     is_private: true

--- a/providers/aws/resources/aws_eks.go
+++ b/providers/aws/resources/aws_eks.go
@@ -98,19 +98,21 @@ func (a *mqlAwsEks) getClusters(conn *connection.AwsConnection) []*jobpool.Job {
 
 				args := map[string]*llx.RawData{
 					"arn":                llx.StringDataPtr(cluster.Arn),
-					"name":               llx.StringDataPtr(cluster.Name),
-					"region":             llx.StringData(regionVal),
-					"version":            llx.StringDataPtr(cluster.Version),
-					"platformVersion":    llx.StringDataPtr(cluster.PlatformVersion),
-					"tags":               llx.MapData(strMapToInterface(cluster.Tags), types.String),
-					"status":             llx.StringData(string(cluster.Status)),
-					"encryptionConfig":   llx.ArrayData(encryptionConfig, types.Any),
+					"authenticationMode": llx.StringData(string(cluster.AccessConfig.AuthenticationMode)),
 					"createdAt":          llx.TimeDataPtr(cluster.CreatedAt),
+					"encryptionConfig":   llx.ArrayData(encryptionConfig, types.Any),
 					"endpoint":           llx.StringDataPtr(cluster.Endpoint),
-					"logging":            llx.MapData(logging, types.Any),
-					"networkConfig":      llx.MapData(kubernetesNetworkConfig, types.Any),
-					"resourcesVpcConfig": llx.MapData(vpcConfig, types.Any),
 					"iamRole":            llx.NilData, // set iamRole to nil as default, if iam is not set
+					"logging":            llx.MapData(logging, types.Any),
+					"name":               llx.StringDataPtr(cluster.Name),
+					"networkConfig":      llx.MapData(kubernetesNetworkConfig, types.Any),
+					"platformVersion":    llx.StringDataPtr(cluster.PlatformVersion),
+					"region":             llx.StringData(regionVal),
+					"resourcesVpcConfig": llx.MapData(vpcConfig, types.Any),
+					"status":             llx.StringData(string(cluster.Status)),
+					"supportType":        llx.StringData(string(cluster.UpgradePolicy.SupportType)),
+					"tags":               llx.MapData(strMapToInterface(cluster.Tags), types.String),
+					"version":            llx.StringDataPtr(cluster.Version),
 				}
 
 				if cluster.RoleArn != nil {


### PR DESCRIPTION
The support policy requires the latest SDK release.

```
cnquery> aws.eks.clusters{supportType authenticationMode}
aws.eks.clusters: [
  0: {
    supportType: "EXTENDED"
    authenticationMode: "API_AND_CONFIG_MAP"
  }
]
```