### PR TITLE
🧹 provide more info on errors in make providers/config

### DIFF
--- a/providers-sdk/v1/util/configure/configure.go
+++ b/providers-sdk/v1/util/configure/configure.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"go/format"
@@ -198,8 +199,12 @@ func init() {
 func buildProviders(providers []string) {
 	for i, provider := range providers {
 		cmd := exec.Command("make", "providers/build/"+provider)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
 		log.Debug().Str("provider", provider).Msg("build provider " + strconv.Itoa(i+1) + "/" + strconv.Itoa(len(providers)))
 		if err := cmd.Run(); err != nil {
+			fmt.Println(out.String())
 			log.Error().Err(err).Str("provider", provider).Msg("failed to build provider")
 		}
 


### PR DESCRIPTION
We currently silently eat all output, which is not helpful when errors occur. This provides the output with any errors that might have led to the build failing. Pure QoL...