### PR TITLE
🧹 Add tech url segments for google workspace. Improve asset name

### DIFF
--- a/providers/google-workspace/config/config.go
+++ b/providers/google-workspace/config/config.go
@@ -58,11 +58,15 @@ The provider requires these three flags:
 	},
 	AssetUrlTrees: []*inventory.AssetUrlBranch{
 		{
-			PathSegments: []string{"technology=google-workspace"},
-			Key:          "customer",
-			Title:        "Customer",
+			PathSegments: []string{"technology=saas"},
+			Key:          "category",
 			Values: map[string]*inventory.AssetUrlBranch{
-				"*": nil,
+				"google-workspace": {
+					Key: "customer",
+					Values: map[string]*inventory.AssetUrlBranch{
+						"*": nil,
+					},
+				},
 			},
 		},
 	},

--- a/providers/google-workspace/config/config.go
+++ b/providers/google-workspace/config/config.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers/google-workspace/provider"
 )
@@ -52,6 +53,16 @@ The provider requires these three flags:
 					Default: "",
 					Desc:    "Email address of the user to impersonate in the session",
 				},
+			},
+		},
+	},
+	AssetUrlTrees: []*inventory.AssetUrlBranch{
+		{
+			PathSegments: []string{"technology=google-workspace"},
+			Key:          "customer",
+			Title:        "Customer",
+			Values: map[string]*inventory.AssetUrlBranch{
+				"*": nil,
 			},
 		},
 	},

--- a/providers/google-workspace/provider/provider.go
+++ b/providers/google-workspace/provider/provider.go
@@ -211,7 +211,7 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.GoogleWorkspac
 		Kind:                  "api",
 		Title:                 "Google Workspace",
 		Runtime:               "google-workspace",
-		TechnologyUrlSegments: []string{"google-workspace", conn.CustomerID()},
+		TechnologyUrlSegments: []string{"saas", "google-workspace", conn.CustomerID()},
 	}
 
 	asset.PlatformIds = []string{"//platformid.api.mondoo.app/runtime/googleworkspace/customer/" + conn.CustomerID()}

--- a/providers/google-workspace/provider/provider.go
+++ b/providers/google-workspace/provider/provider.go
@@ -201,9 +201,9 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.GoogleWorkspac
 	pd, err := resources.GetPrimaryDomain(conn)
 	if err != nil {
 		log.Error().Err(err).Msg("could not get primary domain for google workspace")
-		asset.Name = conn.CustomerID()
+		asset.Name = fmt.Sprintf("Google Workspace (%s)", conn.CustomerID())
 	} else {
-		asset.Name = fmt.Sprintf("%s %s", pd, conn.CustomerID())
+		asset.Name = fmt.Sprintf("Google Workspace %s (%s)", pd, conn.CustomerID())
 	}
 	asset.Platform = &inventory.Platform{
 		Name:                  "google-workspace",


### PR DESCRIPTION
* Add tech url segments for google workspace
* Asset name now is the primary domain + the customer id. E.g. ` Google Workspace mondoo.com B1g0kA3gQ`
* Improve error message when the creds, specified in `--credentials-path` do not exist.


Fixes #4403 