### PR TITLE
GitHub repo discovery performance

### DIFF
--- a/providers/github/resources/github.go
+++ b/providers/github/resources/github.go
@@ -53,8 +53,8 @@ func getOrg(ctx context.Context, runtime *plugin.Runtime, conn *connection.Githu
 	}
 	res, err, _ := g.memoize.Memoize("org-"+name, func() (interface{}, error) {
 		log.Debug().Msgf("fetching organization %s", name)
-		user, _, err := conn.Client().Organizations.Get(ctx, name)
-		return user, err
+		org, _, err := conn.Client().Organizations.Get(ctx, name)
+		return org, err
 	})
 	if err != nil {
 		return nil, err

--- a/providers/github/resources/github.lr.go
+++ b/providers/github/resources/github.lr.go
@@ -2331,7 +2331,7 @@ func (c *mqlGitGpgSignature) GetSignature() *plugin.TValue[string] {
 type mqlGithubOrganization struct {
 	MqlRuntime *plugin.Runtime
 	__id string
-	// optional: if you define mqlGithubOrganizationInternal it will be used here
+	mqlGithubOrganizationInternal
 	Login plugin.TValue[string]
 	Id plugin.TValue[int64]
 	NodeId plugin.TValue[string]

--- a/providers/github/resources/github.lr.go
+++ b/providers/github/resources/github.lr.go
@@ -2669,7 +2669,7 @@ func (c *mqlGithubOrganization) GetHasRepositoryProjects() *plugin.TValue[bool] 
 type mqlGithubUser struct {
 	MqlRuntime *plugin.Runtime
 	__id string
-	// optional: if you define mqlGithubUserInternal it will be used here
+	mqlGithubUserInternal
 	Id plugin.TValue[int64]
 	Login plugin.TValue[string]
 	Name plugin.TValue[string]

--- a/providers/github/resources/github_org.go
+++ b/providers/github/resources/github_org.go
@@ -18,7 +18,7 @@ import (
 )
 
 type mqlGithubOrganizationInternal struct {
-	repoMap map[string]*mqlGithubRepository
+	repoCacheMap map[string]*mqlGithubRepository
 }
 
 func (g *mqlGithubOrganization) id() (string, error) {
@@ -280,6 +280,10 @@ func (g *mqlGithubOrganization) repositories() ([]interface{}, error) {
 		listOpts.Page = resp.NextPage
 	}
 
+	if g.repoCacheMap == nil {
+		g.repoCacheMap = make(map[string]*mqlGithubRepository)
+	}
+
 	res := []interface{}{}
 	for i := range allRepos {
 		repo := allRepos[i]
@@ -289,7 +293,7 @@ func (g *mqlGithubOrganization) repositories() ([]interface{}, error) {
 			return nil, err
 		}
 		res = append(res, r)
-		g.repoMap[repo.GetName()] = r
+		g.repoCacheMap[repo.GetName()] = r
 	}
 
 	return res, nil

--- a/providers/github/resources/github_org.go
+++ b/providers/github/resources/github_org.go
@@ -17,6 +17,10 @@ import (
 	"go.mondoo.com/cnquery/v11/types"
 )
 
+type mqlGithubOrganizationInternal struct {
+	repoMap map[string]*mqlGithubRepository
+}
+
 func (g *mqlGithubOrganization) id() (string, error) {
 	if g.Id.Error != nil {
 		return "", g.Id.Error
@@ -279,11 +283,13 @@ func (g *mqlGithubOrganization) repositories() ([]interface{}, error) {
 	res := []interface{}{}
 	for i := range allRepos {
 		repo := allRepos[i]
+
 		r, err := newMqlGithubRepository(g.MqlRuntime, repo)
 		if err != nil {
 			return nil, err
 		}
 		res = append(res, r)
+		g.repoMap[repo.GetName()] = r
 	}
 
 	return res, nil

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -131,9 +131,11 @@ func initGithubRepository(runtime *plugin.Runtime, args map[string]*llx.RawData)
 	}
 	conn := runtime.Connection.(*connection.GithubConnection)
 
+	// determine the owner object
 	var org *mqlGithubOrganization
 	var user *mqlGithubUser
 	var err error
+	owner := ""
 	orgId, err := conn.Organization()
 	if err == nil {
 		obj, err := NewResource(runtime, "github.organization", map[string]*llx.RawData{
@@ -154,12 +156,15 @@ func initGithubRepository(runtime *plugin.Runtime, args map[string]*llx.RawData)
 					return nil, nil, err
 				}
 				user = obj.(*mqlGithubUser)
+				owner = userId.Name
 			}
 		} else {
 			org = obj.(*mqlGithubOrganization)
+			owner = orgId.Name
 		}
 	}
 
+	// gather the repo name or fallback to the repo name defined in the connection
 	reponame := ""
 	if x, ok := args["name"]; ok {
 		reponame = x.Value.(string)
@@ -175,14 +180,24 @@ func initGithubRepository(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		return nil, nil, errors.New("name must be set for github.repository initialization")
 	}
 
-	var repos *plugin.TValue[[]interface{}]
 	if org != nil {
-		// to avoid loading a large list of repos, we first check if collect the repositories already, if not we just
-		// check an individual repository
-		repo, ok := org.repoMap[reponame]
+		// to avoid loading a large list of repos, we first check if the repositories is in the cached map
+		repo, ok := org.repoCacheMap[reponame]
 		if ok {
 			return args, repo, nil
 		}
+	} else if user != nil {
+		// to avoid loading a large list of repos, we first check if the repositories is in the cached map
+		repo, ok := user.repoCacheMap[reponame]
+		if ok {
+			return args, repo, nil
+		}
+	} else {
+		return nil, nil, errors.New("no user and no org specified")
+	}
+
+	// if the repo is not cached, we fetch it from the github api
+	if owner != "" {
 		// we reach this point if the repo was not cached
 		ghRepo, _, err := conn.Client().Repositories.Get(context.Background(), orgId.Name, reponame)
 		if err != nil {
@@ -193,20 +208,6 @@ func initGithubRepository(runtime *plugin.Runtime, args map[string]*llx.RawData)
 			return nil, nil, err
 		}
 		return args, r, nil
-	} else if user != nil {
-		repos = user.GetRepositories()
-		if repos.Error != nil {
-			return nil, nil, repos.Error
-		}
-
-		for _, obj := range repos.Data {
-			repo := obj.(*mqlGithubRepository)
-			if repo.Name.Data == reponame {
-				return args, repo, nil
-			}
-		}
-	} else {
-		return nil, nil, errors.New("no user and no org specified")
 	}
 
 	return args, nil, fmt.Errorf("could not find repository %q. Make sure the repository exists and the token has sufficient permissions to access it", reponame)


### PR DESCRIPTION
In the past we did some optimizations to fetch repositories only once. While this makes sense when we do discovery there are cases where fetching all repos from an org or user does not make sense. A specific case is when I just want to scan a single repo. 

```
cnquery shell github repo microsoftgraph/msgraph-sdk-go
```

That call should not fetch all repos of an org. It makes scanning an org for large organizations slower. This PR fixes it. It changes the code to leverage a cache. If that cache exists (eg. because a user called `github.organization.repositories`) then its used.

**before**

```
DEBUG=1 cnquery shell github repo microsoftgraph/msgraph-sdk-go
DBG performing request method=GET url=https://api.github.com/zen
DBG fetching organization microsoftgraph
DBG performing request method=GET url=https://api.github.com/orgs/microsoftgraph
DBG performing request method=GET url=https://api.github.com/orgs/microsoftgraph/repos?per_page=100&type=all
DBG performing request method=GET url=https://api.github.com/orgs/microsoftgraph/repos?page=2&per_page=100&type=all
DBG performing request method=GET url=https://api.github.com/orgs/microsoftgraph/repos?page=3&per_page=100&type=all
```

**after**

```
DBG fetching organization microsoftgraph
DBG performing request method=GET url=https://api.github.com/orgs/microsoftgraph
DBG performing request method=GET url=https://api.github.com/repos/microsoftgraph/msgraph-sdk-go
```