### PR TITLE
🧹 generate lr.go files during testing to verify all is checked in

### DIFF
--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -49,6 +49,7 @@ jobs:
           protoc --version
           make prep
           make cnquery/generate
+          SKIP_COMPILE=yes make providers/build
           git diff --exit-code *.go
           git diff --exit-code providers/**/*.lr.json
           git diff --exit-code providers/**/*.resources.json

--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,12 @@ define buildProvider
 	./lr docs json ${$@_HOME}/resources/${$@_NAME}.lr.manifest.yaml
 	echo "--> [${$@_NAME}] generate CLI json"
 	cd ${$@_HOME} && go run ./gen/main.go .
-	echo "--> [${$@_NAME}] creating ${$@_BIN}"
-	cd ${$@_HOME} && GOOS=${TARGETOS} go build -o ${$@_DIST_BIN}${BIN_SUFFIX} ./main.go
+	@if [ "$(SKIP_COMPILE)" = "yes" ]; then \
+		echo "--> [${$@_NAME}] skipping compile"; \
+	else \
+		echo "--> [${$@_NAME}] creating ${$@_BIN}"; \
+		cd ${$@_HOME} && GOOS=${TARGETOS} go build -o ${$@_DIST_BIN}${BIN_SUFFIX} ./main.go; \
+	fi
 endef
 
 define buildProviderDist


### PR DESCRIPTION
With the switch to the individual providers have have not included the generation of the .lr.go files into our test suite. This has lead a couple of times to the situation that the provider compilation failed and we had to check it in afterwards. This prevents this case by checking that all files are checked in.