### PR TITLE
⭐️ go package to create `tmp.File()`

### DIFF
--- a/apps/cnquery/cmd/scan.go
+++ b/apps/cnquery/cmd/scan.go
@@ -47,9 +47,15 @@ func init() {
 	_ = scanCmd.Flags().MarkHidden("inventory-domainlist")
 
 	// bundles, packs & incognito mode
-	_ = scanCmd.Flags().Bool("incognito", false, "Run in incognito mode. Do not report scan results to Mondoo Platform")
-	_ = scanCmd.Flags().StringSlice("querypack", nil, "Set the query packs to execute. This requires `querypack-bundle`. You can specify multiple UIDs")
-	_ = scanCmd.Flags().StringSliceP("querypack-bundle", "f", nil, "Path to local query pack file")
+	_ = scanCmd.Flags().Bool("incognito",
+		false,
+		"Run in incognito mode. Do not report scan results to Mondoo Platform")
+	_ = scanCmd.Flags().StringSlice("querypack",
+		nil,
+		"Set the query packs to execute. This requires `querypack-bundle`. You can specify multiple UIDs")
+	_ = scanCmd.Flags().StringSliceP("querypack-bundle",
+		"f",
+		nil, "Path to local query pack file")
 	// flag completion command
 	_ = scanCmd.RegisterFlagCompletionFunc("querypack", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return getQueryPacksForCompletion(), cobra.ShellCompDirectiveDefault

--- a/cli/tmp/file.go
+++ b/cli/tmp/file.go
@@ -1,0 +1,28 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package tmp
+
+// This go package should be used across cnquery to generate temporary files
+// and directories.
+
+import (
+	"os"
+
+	"github.com/rs/zerolog/log"
+)
+
+// File creates a new temporary file.
+//
+// By default `File()` uses the default directory to create a new temporary file,
+// to change the temporary directory use the environment variable `MONDOO_TMP_DIR`
+func File() (*os.File, error) {
+	tmpDir := ""
+	if os.Getenv("MONDOO_TMP_DIR") != "" {
+		tmpDir = os.Getenv("MONDOO_TMP_DIR")
+		log.Debug().
+			Str("custom_tmp_dir", tmpDir).
+			Msg("creating temp file in custom temp directory")
+	}
+	return os.CreateTemp(tmpDir, "mondoo.tmp")
+}

--- a/providers/os/connection/container/image_connection.go
+++ b/providers/os/connection/container/image_connection.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/v11/cli/tmp"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers/os/connection/container/auth"
@@ -30,7 +31,7 @@ func NewImageConnection(id uint32, conf *inventory.Config, asset *inventory.Asse
 		conf.DelayDiscovery = true // Delay discovery, to make sure we don't directly download the image
 	}
 	// ^^
-	f, err := tar.RandomFile()
+	f, err := tmp.File()
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +152,7 @@ func NewFromTar(id uint32, conf *inventory.Config, asset *inventory.Asset) (*tar
 	// we need to extract the image from the tar file and create a new tar connection
 	imageFilename := ""
 
-	f, err := tar.RandomFile()
+	f, err := tmp.File()
 	if err != nil {
 		return nil, err
 	}

--- a/providers/os/connection/docker/container_connection.go
+++ b/providers/os/connection/docker/container_connection.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
+	"go.mondoo.com/cnquery/v11/cli/tmp"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers/os/connection/container"
@@ -299,7 +300,7 @@ func NewContainerImageConnection(id uint32, conf *inventory.Config, asset *inven
 
 	// cache file locally
 	var filename string
-	tmpFile, err := tar.RandomFile()
+	tmpFile, err := tmp.File()
 	if err != nil {
 		return nil, err
 	}

--- a/providers/os/connection/docker/snapshot_connection.go
+++ b/providers/os/connection/docker/snapshot_connection.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 
+	"go.mondoo.com/cnquery/v11/cli/tmp"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v11/providers/os/connection/shared"
 	"go.mondoo.com/cnquery/v11/providers/os/connection/tar"
@@ -21,7 +22,7 @@ type SnapshotConnection struct {
 // NewSnapshotConnection creates a snapshot for a docker engine container and opens it
 func NewSnapshotConnection(id uint32, conf *inventory.Config, asset *inventory.Asset) (*SnapshotConnection, error) {
 	// cache container on local disk
-	f, err := tar.RandomFile()
+	f, err := tmp.File()
 	if err != nil {
 		return nil, err
 	}

--- a/providers/os/connection/tar/stream.go
+++ b/providers/os/connection/tar/stream.go
@@ -8,10 +8,6 @@ import (
 	"os"
 )
 
-func RandomFile() (*os.File, error) {
-	return os.CreateTemp("", "mondoo.inspection")
-}
-
 // StreamToTmpFile streams a binary stream into a file. The user of this method
 // is responsible for deleting the file later
 func StreamToTmpFile(r io.ReadCloser, outFile *os.File) error {


### PR DESCRIPTION
This go package should be used across `cnquery` to generate temporary files and directories.

`tmp.File()` creates a new temporary file.

By default `File()` uses the default directory to create a new temporary file, to change the temporary directory use the environment variable `MONDOO_TMP_DIR`