### PR TITLE
🧹 silence error logs for handled error

### DIFF
--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -1301,10 +1301,12 @@ func (g *mqlGithubFile) content() (string, error) {
 	path := g.Path.Data
 	fileContent, _, _, err := conn.Client().Repositories.GetContents(context.TODO(), ownerName, repoName, path, &github.RepositoryContentGetOptions{})
 	if err != nil {
-		log.Error().Err(err).Msg("unable to get contents list")
 		if strings.Contains(err.Error(), "404") {
+			log.Debug().Err(err).
+				Msg("unable to get contents list")
 			return "", nil
 		}
+		log.Error().Err(err).Msg("unable to get contents list")
 		return "", err
 	}
 


### PR DESCRIPTION
404 is an expected response for repo/directory being empty (which is even handled already), but there would still be lots of unnecessary error logs, not welcoming and sometimes misleading in the interactive mode especially