### PR TITLE
🧹 fix license header for BSD / MPL 2.0 licensed files

### DIFF
--- a/cli/shell/nyago.go
+++ b/cli/shell/nyago.go
@@ -1,5 +1,7 @@
-// Copyright (c) Mondoo, Inc.
-// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) Nihad Abbasov
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Code taken from: https://github.com/NARKOZ/go-nyancat
 
 package shell
 
@@ -13,8 +15,6 @@ import (
 
 	"github.com/pierrec/lz4/v4"
 )
-
-// Code taken from: https://github.com/NARKOZ/go-nyancat
 
 func nyago(width, height int) {
 	cdec, err := base64.StdEncoding.DecodeString(c)

--- a/providers/network/resources/certificates/extensions.go
+++ b/providers/network/resources/certificates/extensions.go
@@ -1,5 +1,11 @@
+// Copyright 2021 The Go Authors. All rights reserved.
 // Copyright (c) Mondoo, Inc.
 // SPDX-License-Identifier: BSD-3-Clause
+//
+// This code is based on the x509 parser from the Go standard library:
+// https://github.com/golang/go/blob/master/src/crypto/x509/parser.go
+// License of the Go standard library: BSD 3-Clause "New" or "Revised" License
+
 package certificates
 
 import (
@@ -17,9 +23,6 @@ import (
 	"unicode"
 )
 
-// This code is based on the x509 parser from the Go standard library:
-// https://github.com/golang/go/blob/master/src/crypto/x509/parser.go
-// License of the Go standard library: BSD 3-Clause "New" or "Revised" License
 var OIDExtensionSubjectAltName = asn1.ObjectIdentifier{2, 5, 29, 17}
 
 const (

--- a/providers/okta/resources/sdk/notifications.go
+++ b/providers/okta/resources/sdk/notifications.go
@@ -1,6 +1,7 @@
-// Copyright (c) Mondoo, Inc.
-// SPDX-License-Identifier: BUSL-1.1
-
+// Copyright (c) Okta, Inc.
+// SPDX-License-Identifier: MPL-2.0
+//
+// This code was derived from https://github.com/okta/terraform-provider-okta/blob/master/sdk/security_notification_emails.go
 package sdk
 
 import (
@@ -28,7 +29,6 @@ type SecurityNotificationEmails struct {
 
 // GetSecurityNotificationEmails retrieves the security configuration
 func (m *ApiExtension) GetSecurityNotificationEmails(ctx context.Context, orgId string, token string, client *http.Client) (*SecurityNotificationEmails, error) {
-	// This code was derived from https://github.com/okta/terraform-provider-okta/blob/master/sdk/security_notification_emails.go
 
 	// we need to split the orgId into orgName and domain because this API uses a different domain
 	orgName, domain, found := strings.Cut(orgId, ".")

--- a/providers/os/connection/ssh/keypair/edkey.go
+++ b/providers/os/connection/ssh/keypair/edkey.go
@@ -1,5 +1,8 @@
-// Copyright (c) Mondoo, Inc.
-// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) Michael Smith
+// SPDX-License-Identifier: MIT
+//
+// MarshalED25519PrivateKey writes ed25519 private keys into the new OpenSSH private key format.
+// This code is derived from https://github.com/mikesmitty/edkey which is MIT-Licensed
 
 package keypair
 
@@ -10,8 +13,6 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-// MarshalED25519PrivateKey writes ed25519 private keys into the new OpenSSH private key format.
-// This code is derived from https://github.com/mikesmitty/edkey which is MIT-Licensed
 func MarshalED25519PrivateKey(key ed25519.PrivateKey) []byte {
 	// Add our key header (followed by a null byte)
 	magic := append([]byte("openssh-key-v1"), 0)

--- a/providers/os/connection/winrm/cat/winstat.go
+++ b/providers/os/connection/winrm/cat/winstat.go
@@ -1,11 +1,11 @@
-// Copyright (c) Mondoo, Inc.
-// SPDX-License-Identifier: BUSL-1.1
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
 
-package cat
-
-// this implementation is derived from golang's internal stat implementation
+// This implementation is derived from golang's internal stat implementation
 // Golang licensed BSD-style license https://github.com/golang/go/blob/master/LICENSE
 // see  https://github.com/golang/go/blob/5d1a95175e693f5be0bc31ae9e6a7873318925eb/src/syscall/types_windows.go
+
+package cat
 
 import (
 	"os"


### PR DESCRIPTION
With https://github.com/mondoohq/cnquery/pull/1557 we used a tool to add headers. Since the existing attribution was not detected properly by the tool, it accidentally attached the BUSL 1.1 license. This fixes the header to avoid future confusion.