### PR TITLE
🧹   Set default values to -1 for non-existent registry keys Instead of null  (Windows)

### DIFF
--- a/providers/os/resources/registrykey.go
+++ b/providers/os/resources/registrykey.go
@@ -244,11 +244,11 @@ func initRegistrykeyProperty(runtime *plugin.Runtime, args map[string]*llx.RawDa
 		return nil, nil, err
 	}
 
-	// set default values
+	// set default values instead of null (llx.NilData) to Negative to avoid Error
 	args["exists"] = llx.BoolFalse
-	args["data"] = llx.DictData(nil)
-	args["value"] = llx.NilData
-	args["type"] = llx.NilData
+	args["data"] = llx.StringData("-1")
+	args["value"] = llx.StringData("-1")
+	args["type"] = llx.StringData("-1")
 
 	// path exists
 	if exists.Data {


### PR DESCRIPTION
![Screenshot from 2024-08-01 14-18-23](https://github.com/user-attachments/assets/06cd2f0c-91c6-4ec3-8423-4bf03643bad4)


When exists is Flase, it means that the Key does not exist, and it gets **-1** for other stuff!