### PR TITLE
✨ use github-client internal rate-limits timer

### DIFF
--- a/providers/github/connection/connection.go
+++ b/providers/github/connection/connection.go
@@ -68,6 +68,8 @@ func NewGithubConnection(id uint32, asset *inventory.Asset) (*GithubConnection, 
 		}
 	}
 
+	// set the context so github client can handle backoff
+	// (default behaviour is to send fake 403 response bypassing the retry logic)
 	ctx := context.WithValue(context.Background(), github.SleepUntilPrimaryRateLimitResetWhenRateLimited, true)
 
 	// perform a quick call to verify the token's validity.

--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -319,7 +319,7 @@ func discoverTerraform(conn *connection.GithubConnection, repo *mqlGithubReposit
 	}
 
 	var res []*inventory.Asset
-	hasTf, err := hasTerraformHcl(conn.Client(), repo)
+	hasTf, err := hasTerraformHcl(conn.Context(), conn.Client(), repo)
 	if err != nil {
 		log.Error().Err(err).Str("project", repo.FullName.Data).Msg("failed to discover terraform repo")
 	} else if hasTf {
@@ -338,9 +338,9 @@ func discoverTerraform(conn *connection.GithubConnection, repo *mqlGithubReposit
 }
 
 // hasTerraformHcl will check if the repository contains terraform files
-func hasTerraformHcl(client *github.Client, repo *mqlGithubRepository) (bool, error) {
+func hasTerraformHcl(ctx context.Context, client *github.Client, repo *mqlGithubRepository) (bool, error) {
 	query := "repo:" + repo.FullName.Data + " extension:tf"
-	res, _, err := client.Search.Code(context.Background(), query, &github.SearchOptions{})
+	res, _, err := client.Search.Code(ctx, query, &github.SearchOptions{})
 	if err != nil {
 		return false, err
 	}
@@ -380,7 +380,7 @@ func discoverK8sManifests(conn *connection.GithubConnection, repo *mqlGithubRepo
 	}
 
 	var res []*inventory.Asset
-	hasTf, err := hasYaml(conn.Client(), repo)
+	hasTf, err := hasYaml(conn.Context(), conn.Client(), repo)
 	if err != nil {
 		log.Error().Err(err).Str("project", repo.FullName.Data).Msg("failed to discover k8s manifests repo")
 	} else if hasTf {
@@ -400,9 +400,9 @@ func discoverK8sManifests(conn *connection.GithubConnection, repo *mqlGithubRepo
 }
 
 // hasYaml will check if the repository contains YAML files
-func hasYaml(client *github.Client, repo *mqlGithubRepository) (bool, error) {
+func hasYaml(ctx context.Context, client *github.Client, repo *mqlGithubRepository) (bool, error) {
 	query := "repo:" + repo.FullName.Data + " extension:yaml OR extension:yml"
-	res, _, err := client.Search.Code(context.Background(), query, &github.SearchOptions{})
+	res, _, err := client.Search.Code(ctx, query, &github.SearchOptions{})
 	if err != nil {
 		return false, err
 	}

--- a/providers/github/resources/github_org.go
+++ b/providers/github/resources/github_org.go
@@ -4,7 +4,6 @@
 package resources
 
 import (
-	"context"
 	"errors"
 	"strconv"
 	"strings"
@@ -47,7 +46,7 @@ func initGithubOrganization(runtime *plugin.Runtime, args map[string]*llx.RawDat
 		}
 	}
 
-	org, err := getOrg(context.Background(), runtime, conn, name)
+	org, err := getOrg(conn.Context(), runtime, conn, name)
 	if err != nil {
 		return args, nil, err
 	}
@@ -108,7 +107,7 @@ func (g *mqlGithubOrganization) members() ([]interface{}, error) {
 	}
 	var allMembers []*github.User
 	for {
-		members, resp, err := conn.Client().Organizations.ListMembers(context.Background(), orgLogin, listOpts)
+		members, resp, err := conn.Client().Organizations.ListMembers(conn.Context(), orgLogin, listOpts)
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
 				return nil, nil
@@ -153,7 +152,7 @@ func (g *mqlGithubOrganization) owners() ([]interface{}, error) {
 	}
 	var allMembers []*github.User
 	for {
-		members, resp, err := conn.Client().Organizations.ListMembers(context.Background(), orgLogin, listOpts)
+		members, resp, err := conn.Client().Organizations.ListMembers(conn.Context(), orgLogin, listOpts)
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
 				return nil, nil
@@ -216,7 +215,7 @@ func (g *mqlGithubOrganization) teams() ([]interface{}, error) {
 	}
 	var allTeams []*github.Team
 	for {
-		teams, resp, err := conn.Client().Teams.ListTeams(context.Background(), orgLogin, listOpts)
+		teams, resp, err := conn.Client().Teams.ListTeams(conn.Context(), orgLogin, listOpts)
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
 				return nil, nil
@@ -266,7 +265,7 @@ func (g *mqlGithubOrganization) repositories() ([]interface{}, error) {
 
 	var allRepos []*github.Repository
 	for {
-		repos, resp, err := conn.Client().Repositories.ListByOrg(context.Background(), orgLogin, listOpts)
+		repos, resp, err := conn.Client().Repositories.ListByOrg(conn.Context(), orgLogin, listOpts)
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
 				return nil, nil
@@ -312,7 +311,7 @@ func (g *mqlGithubOrganization) webhooks() ([]interface{}, error) {
 	}
 	var allHooks []*github.Hook
 	for {
-		hooks, resp, err := conn.Client().Organizations.ListHooks(context.TODO(), ownerLogin, listOpts)
+		hooks, resp, err := conn.Client().Organizations.ListHooks(conn.Context(), ownerLogin, listOpts)
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
 				return nil, nil
@@ -374,7 +373,7 @@ func (g *mqlGithubOrganization) packages() ([]interface{}, error) {
 
 		var allPackages []*github.Package
 		for {
-			packages, resp, err := conn.Client().Organizations.ListPackages(context.Background(), ownerLogin, listOpts)
+			packages, resp, err := conn.Client().Organizations.ListPackages(conn.Context(), ownerLogin, listOpts)
 			if err != nil {
 				if strings.Contains(err.Error(), "404") {
 					return nil, nil
@@ -445,7 +444,7 @@ func (g *mqlGithubPackage) repository() (*mqlGithubRepository, error) {
 	}
 	ownerLogin := owner.Login.Data
 
-	repo, _, err := conn.Client().Repositories.Get(context.Background(), ownerLogin, repoName)
+	repo, _, err := conn.Client().Repositories.Get(conn.Context(), ownerLogin, repoName)
 	if err != nil {
 		return nil, err
 	}
@@ -465,7 +464,7 @@ func (g *mqlGithubOrganization) installations() ([]interface{}, error) {
 	}
 	var allOrgInstallations []*github.Installation
 	for {
-		orgInstallations, resp, err := conn.Client().Organizations.ListInstallations(context.Background(), orgLogin, listOpts)
+		orgInstallations, resp, err := conn.Client().Organizations.ListInstallations(conn.Context(), orgLogin, listOpts)
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
 				return nil, nil

--- a/providers/github/resources/github_package.go
+++ b/providers/github/resources/github_package.go
@@ -4,7 +4,6 @@
 package resources
 
 import (
-	"context"
 	"strconv"
 	"strings"
 
@@ -70,7 +69,7 @@ func newMqlGithubPackages(runtime *plugin.Runtime, visibility *string) ([]any, e
 
 		var allPackages []*github.Package
 		for {
-			packages, resp, err := conn.Client().Organizations.ListPackages(context.Background(), orgId.Name, listOpts)
+			packages, resp, err := conn.Client().Organizations.ListPackages(conn.Context(), orgId.Name, listOpts)
 			if err != nil {
 				if strings.Contains(err.Error(), "404") {
 					return nil, nil

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -4,7 +4,6 @@
 package resources
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -199,7 +198,7 @@ func initGithubRepository(runtime *plugin.Runtime, args map[string]*llx.RawData)
 	// if the repo is not cached, we fetch it from the github api
 	if owner != "" {
 		// we reach this point if the repo was not cached
-		ghRepo, _, err := conn.Client().Repositories.Get(context.Background(), orgId.Name, reponame)
+		ghRepo, _, err := conn.Client().Repositories.Get(conn.Context(), orgId.Name, reponame)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -236,7 +235,7 @@ func (g *mqlGithubRepository) license() (*mqlGithubLicense, error) {
 	}
 	ownerLogin := ownerName.Login.Data
 
-	repoLicense, _, err := conn.Client().Repositories.License(context.Background(), ownerLogin, repoName)
+	repoLicense, _, err := conn.Client().Repositories.License(conn.Context(), ownerLogin, repoName)
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return nil, errors.New("not found")
@@ -282,7 +281,7 @@ func (g *mqlGithubRepository) getMergeRequests(state string) ([]interface{}, err
 	}
 	var allPulls []*github.PullRequest
 	for {
-		pulls, resp, err := conn.Client().PullRequests.List(context.TODO(), ownerLogin, repoName, listOpts)
+		pulls, resp, err := conn.Client().PullRequests.List(conn.Context(), ownerLogin, repoName, listOpts)
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
 				return nil, nil
@@ -402,7 +401,7 @@ func (g *mqlGithubRepository) branches() ([]interface{}, error) {
 	}
 	var allBranches []*github.Branch
 	for {
-		branches, resp, err := conn.Client().Repositories.ListBranches(context.TODO(), ownerLogin, repoName, listOpts)
+		branches, resp, err := conn.Client().Repositories.ListBranches(conn.Context(), ownerLogin, repoName, listOpts)
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
 				return nil, nil
@@ -488,7 +487,7 @@ func (g *mqlGithubBranch) protectionRules() (*mqlGithubBranchprotection, error) 
 	}
 	ownerName := owner.Login.Data
 
-	branchProtection, _, err := conn.Client().Repositories.GetBranchProtection(context.TODO(), ownerName, repoName, branchName)
+	branchProtection, _, err := conn.Client().Repositories.GetBranchProtection(conn.Context(), ownerName, repoName, branchName)
 	if err != nil {
 		// NOTE it is possible that the branch does not have any protection rules, therefore we don't return an error
 		if strings.Contains(err.Error(), "Not Found") {
@@ -560,7 +559,7 @@ func (g *mqlGithubBranch) protectionRules() (*mqlGithubBranchprotection, error) 
 		return nil, err
 	}
 
-	sc, _, err := conn.Client().Repositories.GetSignaturesProtectedBranch(context.TODO(), ownerName, repoName, branchName)
+	sc, _, err := conn.Client().Repositories.GetSignaturesProtectedBranch(conn.Context(), ownerName, repoName, branchName)
 	if err != nil {
 		log.Debug().Err(err).Msg("note: branch protection can only be accessed by admin users")
 		return nil, err
@@ -607,7 +606,7 @@ func newMqlGithubCommit(runtime *plugin.Runtime, rc *github.RepositoryCommit, ow
 
 	// if the github author is nil, we have to load the commit again
 	if rc.Author == nil {
-		rc, _, err = conn.Client().Repositories.GetCommit(context.TODO(), owner, repo, rc.GetSHA(), nil)
+		rc, _, err = conn.Client().Repositories.GetCommit(conn.Context(), owner, repo, rc.GetSHA(), nil)
 		if err != nil {
 			return nil, err
 		}
@@ -678,7 +677,7 @@ func (g *mqlGithubRepository) commits() ([]interface{}, error) {
 	}
 	var allCommits []*github.RepositoryCommit
 	for {
-		commits, resp, err := conn.Client().Repositories.ListCommits(context.TODO(), ownerLogin, repoName, listOpts)
+		commits, resp, err := conn.Client().Repositories.ListCommits(conn.Context(), ownerLogin, repoName, listOpts)
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
 				return nil, nil
@@ -729,7 +728,7 @@ func (g *mqlGithubMergeRequest) reviews() ([]interface{}, error) {
 	}
 	var allReviews []*github.PullRequestReview
 	for {
-		reviews, resp, err := conn.Client().PullRequests.ListReviews(context.TODO(), ownerLogin, repoName, int(prID), listOpts)
+		reviews, resp, err := conn.Client().PullRequests.ListReviews(conn.Context(), ownerLogin, repoName, int(prID), listOpts)
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
 				return nil, nil
@@ -794,7 +793,7 @@ func (g *mqlGithubMergeRequest) commits() ([]interface{}, error) {
 	}
 	var allCommits []*github.RepositoryCommit
 	for {
-		commits, resp, err := conn.Client().PullRequests.ListCommits(context.TODO(), ownerLogin, repoName, int(prID), listOpts)
+		commits, resp, err := conn.Client().PullRequests.ListCommits(conn.Context(), ownerLogin, repoName, int(prID), listOpts)
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
 				return nil, nil
@@ -841,7 +840,7 @@ func (g *mqlGithubRepository) contributors() ([]interface{}, error) {
 	}
 	var allContributors []*github.Contributor
 	for {
-		contributors, resp, err := conn.Client().Repositories.ListContributors(context.TODO(), ownerLogin, repoName, listOpts)
+		contributors, resp, err := conn.Client().Repositories.ListContributors(conn.Context(), ownerLogin, repoName, listOpts)
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
 				return nil, nil
@@ -889,7 +888,7 @@ func (g *mqlGithubRepository) collaborators() ([]interface{}, error) {
 	}
 	var allContributors []*github.User
 	for {
-		contributors, resp, err := conn.Client().Repositories.ListCollaborators(context.TODO(), ownerLogin, repoName, listOpts)
+		contributors, resp, err := conn.Client().Repositories.ListCollaborators(conn.Context(), ownerLogin, repoName, listOpts)
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
 				return nil, nil
@@ -952,7 +951,7 @@ func (g *mqlGithubRepository) releases() ([]interface{}, error) {
 	}
 	var allReleases []*github.RepositoryRelease
 	for {
-		releases, resp, err := conn.Client().Repositories.ListReleases(context.TODO(), ownerLogin, repoName, listOpts)
+		releases, resp, err := conn.Client().Repositories.ListReleases(conn.Context(), ownerLogin, repoName, listOpts)
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
 				return nil, nil
@@ -1013,7 +1012,7 @@ func (g *mqlGithubRepository) webhooks() ([]interface{}, error) {
 	}
 	var allWebhooks []*github.Hook
 	for {
-		hooks, resp, err := conn.Client().Repositories.ListHooks(context.TODO(), ownerLogin, repoName, listOpts)
+		hooks, resp, err := conn.Client().Repositories.ListHooks(conn.Context(), ownerLogin, repoName, listOpts)
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
 				return nil, nil
@@ -1082,7 +1081,7 @@ func (g *mqlGithubRepository) workflows() ([]interface{}, error) {
 	}
 	var allWorkflows []*github.Workflow
 	for {
-		workflows, resp, err := conn.Client().Actions.ListWorkflows(context.Background(), ownerLogin, repoName, listOpts)
+		workflows, resp, err := conn.Client().Actions.ListWorkflows(conn.Context(), ownerLogin, repoName, listOpts)
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
 				return nil, nil
@@ -1159,7 +1158,7 @@ func (g *mqlGithubRepository) files() ([]interface{}, error) {
 		return nil, owner.Login.Error
 	}
 	ownerLogin := owner.Login.Data
-	_, dirContent, _, err := conn.Client().Repositories.GetContents(context.TODO(), ownerLogin, repoName, "", &github.RepositoryContentGetOptions{})
+	_, dirContent, _, err := conn.Client().Repositories.GetContents(conn.Context(), ownerLogin, repoName, "", &github.RepositoryContentGetOptions{})
 	if err != nil {
 		log.Error().Err(err).Msg("unable to get contents list")
 		if strings.Contains(err.Error(), "404") {
@@ -1243,7 +1242,7 @@ func (g *mqlGithubFile) files() ([]interface{}, error) {
 		return nil, g.Path.Error
 	}
 	path := g.Path.Data
-	_, dirContent, _, err := conn.Client().Repositories.GetContents(context.TODO(), ownerName, repoName, path, &github.RepositoryContentGetOptions{})
+	_, dirContent, _, err := conn.Client().Repositories.GetContents(conn.Context(), ownerName, repoName, path, &github.RepositoryContentGetOptions{})
 	if err != nil {
 		log.Error().Err(err).Msg("unable to get contents list")
 		if strings.Contains(err.Error(), "404") {
@@ -1299,7 +1298,7 @@ func (g *mqlGithubFile) content() (string, error) {
 		return "", g.Path.Error
 	}
 	path := g.Path.Data
-	fileContent, _, _, err := conn.Client().Repositories.GetContents(context.TODO(), ownerName, repoName, path, &github.RepositoryContentGetOptions{})
+	fileContent, _, _, err := conn.Client().Repositories.GetContents(conn.Context(), ownerName, repoName, path, &github.RepositoryContentGetOptions{})
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			log.Debug().Err(err).
@@ -1345,7 +1344,7 @@ func (g *mqlGithubRepository) forks() ([]interface{}, error) {
 	}
 	var allForks []*github.Repository
 	for {
-		forks, resp, err := conn.Client().Repositories.ListForks(context.Background(), ownerLogin, repoName, listOpts)
+		forks, resp, err := conn.Client().Repositories.ListForks(conn.Context(), ownerLogin, repoName, listOpts)
 		if err != nil {
 			log.Error().Err(err).Msg("unable to get contents list")
 			if strings.Contains(err.Error(), "404") {
@@ -1393,7 +1392,7 @@ func (g *mqlGithubRepository) stargazers() ([]interface{}, error) {
 	}
 	var allStargazers []*github.Stargazer
 	for {
-		stargazers, resp, err := conn.Client().Activity.ListStargazers(context.Background(), ownerLogin, repoName, listOpts)
+		stargazers, resp, err := conn.Client().Activity.ListStargazers(conn.Context(), ownerLogin, repoName, listOpts)
 		if err != nil {
 			log.Error().Err(err).Msg("unable to get contents list")
 			if strings.Contains(err.Error(), "404") {
@@ -1464,7 +1463,7 @@ func (g *mqlGithubRepository) getIssues(state string) ([]interface{}, error) {
 	}
 	var allIssues []*github.Issue
 	for {
-		issues, resp, err := conn.Client().Issues.ListByRepo(context.Background(), ownerLogin, repoName, listOpts)
+		issues, resp, err := conn.Client().Issues.ListByRepo(conn.Context(), ownerLogin, repoName, listOpts)
 		if err != nil {
 			log.Error().Err(err).Msg("unable to get contents list")
 			if strings.Contains(err.Error(), "404") {

--- a/providers/github/resources/github_team.go
+++ b/providers/github/resources/github_team.go
@@ -4,7 +4,6 @@
 package resources
 
 import (
-	"context"
 	"errors"
 	"strconv"
 	"strings"
@@ -43,7 +42,7 @@ func (g *mqlGithubTeam) repositories() ([]interface{}, error) {
 	listOpts := &github.ListOptions{}
 	var allRepos []*github.Repository
 	for {
-		repos, resp, err := conn.Client().Teams.ListTeamReposByID(context.Background(), orgID, teamID, listOpts)
+		repos, resp, err := conn.Client().Teams.ListTeamReposByID(conn.Context(), orgID, teamID, listOpts)
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
 				return nil, nil
@@ -96,7 +95,7 @@ func (g *mqlGithubTeam) members() ([]interface{}, error) {
 	}
 	var allMembers []*github.User
 	for {
-		members, resp, err := conn.Client().Teams.ListTeamMembersByID(context.Background(), orgID, teamID, listOpts)
+		members, resp, err := conn.Client().Teams.ListTeamMembersByID(conn.Context(), orgID, teamID, listOpts)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/github/resources/github_user.go
+++ b/providers/github/resources/github_user.go
@@ -4,7 +4,6 @@
 package resources
 
 import (
-	"context"
 	"io"
 	"strconv"
 	"strings"
@@ -50,7 +49,7 @@ func initGithubUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 	}
 
 	// finally grab the user from github
-	githubUser, err := getUser(context.Background(), runtime, conn, userLogin)
+	githubUser, err := getUser(conn.Context(), runtime, conn, userLogin)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -110,7 +109,7 @@ func (g *mqlGithubUser) repositories() ([]interface{}, error) {
 
 	var allRepos []*github.Repository
 	for {
-		repos, resp, err := conn.Client().Repositories.ListByUser(context.Background(), githubLogin, listOpts)
+		repos, resp, err := conn.Client().Repositories.ListByUser(conn.Context(), githubLogin, listOpts)
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
 				return nil, nil
@@ -164,7 +163,7 @@ func (g *mqlGithubUser) gists() ([]interface{}, error) {
 
 	var allGists []*github.Gist
 	for {
-		gists, resp, err := conn.Client().Gists.List(context.Background(), userLogin, listOpts)
+		gists, resp, err := conn.Client().Gists.List(conn.Context(), userLogin, listOpts)
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
 				return nil, nil

--- a/providers/github/resources/github_workflow.go
+++ b/providers/github/resources/github_workflow.go
@@ -4,7 +4,6 @@
 package resources
 
 import (
-	"context"
 	"errors"
 	"strconv"
 	"strings"
@@ -61,7 +60,7 @@ func (g *mqlGithubWorkflow) file() (*mqlGithubFile, error) {
 
 	// TODO: no branch support yet
 	// if we workflow is running for a branch only, we do not see from the response the branch name
-	fileContent, _, _, err := conn.Client().Repositories.GetContents(context.Background(), ownerLogin, repoName, filePath, &github.RepositoryContentGetOptions{})
+	fileContent, _, _, err := conn.Client().Repositories.GetContents(conn.Context(), ownerLogin, repoName, filePath, &github.RepositoryContentGetOptions{})
 	if err != nil {
 		// TODO: should this be an error
 		if strings.Contains(err.Error(), "404") {


### PR DESCRIPTION
Github Client is handling rate-limits internally out of the box, which means if rate limits are reached, client will return fake 403 API Rate limits response before even trying out retryable client.
Unfortunately we can't use `bypassRateLimitCheck` strategy, because it's private, but we can use `SleepUntilPrimaryRateLimitResetWhenRateLimited` instead, which should be doing just the same job as the retryable client.
Secondary limits must still be handled by retryable client.