### PR TITLE
⭐ sample

### DIFF
--- a/llx/builtin.go
+++ b/llx/builtin.go
@@ -537,6 +537,7 @@ func init() {
 			"keys":                            {f: dictKeysV2, Label: "keys"},
 			"values":                          {f: dictValuesV2, Label: "values"},
 			"where":                           {f: dictWhere, Label: "where"},
+			"sample":                          {f: dictSample, Label: "sample"},
 			"recurse":                         {f: dictRecurse, Label: "recurse"},
 			"$whereNot":                       {f: dictWhereNot},
 			"$all":                            {f: dictAllV2},
@@ -587,6 +588,7 @@ func init() {
 			"length":                   {f: arrayLengthV2},
 			"where":                    {f: arrayWhereV2},
 			"$whereNot":                {f: arrayWhereNotV2},
+			"sample":                   {f: arraySample},
 			"$all":                     {f: arrayAllV2},
 			"$none":                    {f: arrayNoneV2},
 			"$any":                     {f: arrayAnyV2},
@@ -682,6 +684,7 @@ func init() {
 			"length":                   {f: mapLengthV2},
 			"where":                    {f: mapWhereV2},
 			"$whereNot":                {f: mapWhereNotV2},
+			"sample":                   {f: mapSample},
 			"$any":                     {f: mapAny},
 			"$one":                     {f: mapOne},
 			"$none":                    {f: mapNone},
@@ -723,6 +726,7 @@ func init() {
 			// fields
 			"where":     {f: resourceWhereV2},
 			"$whereNot": {f: resourceWhereNotV2},
+			"sample":    {f: resourceSample},
 			"map":       {f: resourceMapV2},
 			"length":    {f: resourceLengthV2},
 			"{}": {f: func(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {

--- a/mqlc/builtin.go
+++ b/mqlc/builtin.go
@@ -28,6 +28,7 @@ var (
 	dictType        = func(t types.Type) types.Type { return types.Dict }
 	blockType       = func(t types.Type) types.Type { return types.Block }
 	dictArrayType   = func(t types.Type) types.Type { return types.Array(types.Dict) }
+	sameType        = func(t types.Type) types.Type { return t }
 )
 
 var builtinFunctions map[types.Type]map[string]compileHandler
@@ -78,6 +79,7 @@ func init() {
 			"first":        {typ: dictType, signature: FunctionSignature{}},
 			"last":         {typ: dictType, signature: FunctionSignature{}},
 			"where":        {compile: compileDictWhere, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
+			"sample":       {typ: sameType, signature: FunctionSignature{Required: 1, Args: []types.Type{types.Int}}},
 			"recurse":      {compile: compileDictRecurse, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
 			"contains":     {compile: compileDictContains, typ: boolType, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
 			"in":           {typ: boolType, signature: FunctionSignature{Required: 1, Args: []types.Type{types.Array(types.String)}}},
@@ -101,6 +103,7 @@ func init() {
 			"{}":           {typ: arrayBlockType, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
 			"length":       {typ: intType, signature: FunctionSignature{}},
 			"where":        {compile: compileArrayWhere, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
+			"sample":       {typ: sameType, signature: FunctionSignature{Required: 1, Args: []types.Type{types.Int}}},
 			"duplicates":   {compile: compileArrayDuplicates, signature: FunctionSignature{Required: 0, Args: []types.Type{types.String}}},
 			"unique":       {compile: compileArrayUnique, signature: FunctionSignature{Required: 0}},
 			"in":           {typ: boolType, compile: compileStringIn, signature: FunctionSignature{Required: 1, Args: []types.Type{types.Array(types.String)}}},
@@ -122,6 +125,7 @@ func init() {
 			"keys":     {typ: stringArrayType, signature: FunctionSignature{}},
 			"values":   {compile: compileMapValues, signature: FunctionSignature{}},
 			"where":    {compile: compileMapWhere, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
+			"sample":   {typ: sameType, signature: FunctionSignature{Required: 1, Args: []types.Type{types.Int}}},
 			"contains": {compile: compileMapContains, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
 			"all":      {compile: compileMapAll, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
 			"one":      {compile: compileMapOne, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
@@ -131,6 +135,7 @@ func init() {
 			// "":       compileHandler{compile: compileResourceDefault},
 			"length":   {compile: compileResourceLength, signature: FunctionSignature{}},
 			"where":    {compile: compileResourceWhere, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
+			"sample":   {compile: compileResourceSample, signature: FunctionSignature{Required: 1, Args: []types.Type{types.Int}}},
 			"contains": {compile: compileResourceContains, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
 			"all":      {compile: compileResourceAll, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},
 			"any":      {compile: compileResourceAny, signature: FunctionSignature{Required: 1, Args: []types.Type{types.FunctionLike}}},

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -1924,7 +1924,7 @@ func TestSuggestions(t *testing.T) {
 		{
 			// list resource with empty field call
 			"users.",
-			[]string{"all", "any", "contains", "length", "list", "map", "none", "one", "where"},
+			[]string{"all", "any", "contains", "length", "list", "map", "none", "one", "sample", "where"},
 			errors.New("incomplete query, missing identifier after '.' at <source>:1:7"),
 			nil,
 		},


### PR DESCRIPTION
Introduce the `sample` command, which extracts a number of samples from any list or map:

```
> [1,2,3,4,5,6,7,8,9,10].sample(3)
sample: [
  0: 2
  1: 10
  2: 9
]
```

Any time you run this, you'll (most likely) get a different set of results.

```
> {'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5}.sample(3)
sample: {
  a: 1
  b: 2
  e: 5
}
```

Duplicates are not allowed, unless of course the original data has duplicates. Ultimately every entry is only picked once.

```
> users.sample(3)
users.sample: [
  0: user id = user/972/deepin-one
  1: user id = user/991/systemd-network
  2: user id = user/973/systemd-timesync
]