### PR TITLE
🐛 allow cross-provider containers from k8s

### DIFF
--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -347,7 +347,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 		var err error
 
 		switch conf.Type {
-		case shared.Type_Local.String():
+		case shared.Type_Local.String(), "k8s": // FIXME: k8s is a temp workaround for cross-provider resources
 			conn = local.NewConnection(connId, conf, asset)
 
 			fingerprint, p, err := id.IdentifyPlatform(conn, asset.Platform, asset.IdDetector)

--- a/providers/os/resources/container.go
+++ b/providers/os/resources/container.go
@@ -14,8 +14,13 @@ func initContainerImage(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 	if len(args) > 1 {
 		return args, nil, nil
 	}
-	conn := runtime.Connection.(*tar.Connection)
-	reference := conn.Metadata.Labels["docker.io/digests"]
+
+	reference := ""
+	if ref, ok := args["reference"]; ok {
+		reference = ref.Value.(string)
+	} else if tarConn, ok := runtime.Connection.(*tar.Connection); ok {
+		reference = tarConn.Metadata.Labels["docker.io/digests"]
+	}
 
 	ref, err := name.ParseReference(reference)
 	if err != nil {


### PR DESCRIPTION
This is not a proper fix but a workaround to make sure the specific command works. We will need to re-visit cross-provider resources at some point.

Fixes #4472