### PR TITLE
⭐️ expose github default branch to make the access easier

### DIFF
--- a/providers/github/resources/github.lr
+++ b/providers/github/resources/github.lr
@@ -316,6 +316,8 @@ private github.repository @defaults("fullName") {
   branches() []github.branch
   // Default branch name for the repository
   defaultBranchName string
+  // Default branch
+  defaultBranch() github.branch
   // List of commits for the repository
   commits() []github.commit
   // List of contributors for the repository

--- a/providers/github/resources/github.lr.manifest.yaml
+++ b/providers/github/resources/github.lr.manifest.yaml
@@ -157,7 +157,7 @@ resources:
       updatedAt: {}
       url: {}
     is_private: true
-    min_mondoo_version: latest
+    min_mondoo_version: 9.0.0
   github.license:
     fields:
       key: {}
@@ -165,7 +165,7 @@ resources:
       spdxId: {}
       url: {}
     is_private: true
-    min_mondoo_version: latest
+    min_mondoo_version: 9.0.0
   github.mergeRequest:
     fields:
       assignees: {}
@@ -309,9 +309,9 @@ resources:
   github.repository:
     fields:
       MergeRequests:
-        min_mondoo_version: latest
+        min_mondoo_version: 9.0.0
       allMergeRequests:
-        min_mondoo_version: latest
+        min_mondoo_version: 9.0.0
       allowAutoMerge:
         min_mondoo_version: 6.4.0
       allowForking:
@@ -330,7 +330,7 @@ resources:
       closedIssues:
         min_mondoo_version: 7.14.0
       closedMergeRequests:
-        min_mondoo_version: latest
+        min_mondoo_version: 9.0.0
       collaborators:
         min_mondoo_version: 6.11.0
       commits:
@@ -338,6 +338,8 @@ resources:
       contributors:
         min_mondoo_version: 6.4.0
       createdAt: {}
+      defaultBranch:
+        min_mondoo_version: 9.0.0
       defaultBranchName:
         min_mondoo_version: 6.4.0
       description: {}


### PR DESCRIPTION
This simplifies the access to the default branch.

**Before**

```coffeescript
cnquery> github.repository.branches.where(isDefault == true).all(isProtected == true)
[ok] value: true
```

**After**

```coffeescript
cnquery> github.repository.defaultBranch.isProtected
[ok] value: true
```