### PR TITLE
🐛 gitlab: fix GetProject for projects in subgroups

### DIFF
--- a/providers/gitlab/connection/connection.go
+++ b/providers/gitlab/connection/connection.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/url"
 	"os"
+	"path"
 	"strconv"
 	"strings"
 
@@ -169,7 +170,8 @@ func (c *GitLabConnection) PID() (interface{}, error) {
 	if c.projectName == "" {
 		return nil, errors.New("cannot look up gitlab project, no project path defined")
 	}
-	return url.QueryEscape(c.groupName) + "/" + url.QueryEscape(c.projectName), nil
+
+	return path.Join(c.groupName, c.projectName), nil
 }
 
 func (c *GitLabConnection) Project() (*gitlab.Project, error) {


### PR DESCRIPTION
PathEscape is handled by `go-gitlab` for at least past 2 years: https://github.com/xanzy/go-gitlab/blob/f4f54fa4a42d2004e5b269921578bfe529ab19a0/projects.go#L525

> Escaping escaped string would produce '/' -> '%2F' -> '%252F'