### PR TITLE
✨ jira: created time and improved search

### DIFF
--- a/providers/atlassian/resources/atlassian.lr
+++ b/providers/atlassian/resources/atlassian.lr
@@ -116,6 +116,8 @@ atlassian.jira.issue @defaults("id") {
   status string
   // Description
   description string
+  // Issue create time in UTC
+  created time
 }
 
 // Jira server info

--- a/providers/atlassian/resources/atlassian.lr.go
+++ b/providers/atlassian/resources/atlassian.lr.go
@@ -271,6 +271,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"atlassian.jira.issue.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAtlassianJiraIssue).GetDescription()).ToDataRes(types.String)
 	},
+	"atlassian.jira.issue.created": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAtlassianJiraIssue).GetCreated()).ToDataRes(types.Time)
+	},
 	"atlassian.jira.serverInfo.baseUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAtlassianJiraServerInfo).GetBaseUrl()).ToDataRes(types.String)
 	},
@@ -560,6 +563,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"atlassian.jira.issue.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAtlassianJiraIssue).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"atlassian.jira.issue.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAtlassianJiraIssue).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"atlassian.jira.serverInfo.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1390,6 +1397,7 @@ type mqlAtlassianJiraIssue struct {
 	Project plugin.TValue[string]
 	Status plugin.TValue[string]
 	Description plugin.TValue[string]
+	Created plugin.TValue[*time.Time]
 }
 
 // createAtlassianJiraIssue creates a new instance of this resource
@@ -1443,6 +1451,10 @@ func (c *mqlAtlassianJiraIssue) GetStatus() *plugin.TValue[string] {
 
 func (c *mqlAtlassianJiraIssue) GetDescription() *plugin.TValue[string] {
 	return &c.Description
+}
+
+func (c *mqlAtlassianJiraIssue) GetCreated() *plugin.TValue[*time.Time] {
+	return &c.Created
 }
 
 // mqlAtlassianJiraServerInfo for the atlassian.jira.serverInfo resource

--- a/providers/atlassian/resources/atlassian.lr.manifest.yaml
+++ b/providers/atlassian/resources/atlassian.lr.manifest.yaml
@@ -147,6 +147,8 @@ resources:
     min_mondoo_version: 9.0.0
   atlassian.jira.issue:
     fields:
+      created:
+        min_mondoo_version: 9.0.0
       description: {}
       id: {}
       project: {}

--- a/providers/atlassian/resources/atlassian_jira.go
+++ b/providers/atlassian/resources/atlassian_jira.go
@@ -7,9 +7,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers/atlassian/connection/jira"
+)
+
+const (
+	JIRA_TIME_FORMAT               = "2006-01-02T15:04:05.999-0700"
+	JIRA_ISSUES_SEARCH_MAX_RESULTS = 1000
 )
 
 func (a *mqlAtlassianJira) id() (string, error) {
@@ -182,20 +188,26 @@ func (a *mqlAtlassianJira) issues() ([]interface{}, error) {
 	jira := conn.Client()
 	validate := ""
 	jql := "order by created DESC"
-	fields := []string{"status", "project", "description"}
+	fields := []string{"created", "status", "project", "description"}
 	expands := []string{"changelog", "renderedFields", "names", "schema", "transitions", "operations", "editmeta"}
-	issues, _, err := jira.Issue.Search.Get(context.Background(), jql, fields, expands, 0, 1000, validate)
+	issues, _, err := jira.Issue.Search.Get(context.Background(), jql, fields, expands, 0, JIRA_ISSUES_SEARCH_MAX_RESULTS, validate)
 	if err != nil {
 		return nil, err
 	}
 	res := []interface{}{}
 	for _, issue := range issues.Issues {
+		created, err := time.Parse(JIRA_TIME_FORMAT, issue.Fields.Created)
+		if err != nil {
+			return nil, err
+		}
+
 		mqlAtlassianJiraIssue, err := CreateResource(a.MqlRuntime, "atlassian.jira.issue",
 			map[string]*llx.RawData{
 				"id":          llx.StringData(issue.ID),
 				"project":     llx.StringData(issue.Fields.Project.Name),
 				"status":      llx.StringData(issue.Fields.Status.Name),
 				"description": llx.StringData(issue.Fields.Description),
+				"created":     llx.TimeData(created.UTC()),
 			})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
1. Adding `created` field to `atlassian.jira.issue`
2. Max results parameter defines maximum amount of issues that will be found by search, but API uses cursor style pagination and depending on the Jira instance returns 50 or 100 results per page. Therefore we must iterate to actually get all issues

Before:

```shell
$ cnquery providers | grep atlassian
  atlassian 11.0.24 with connectors: atlassian
$ cnquery run atlassian jira --host https://myjira.atlassian.net -c 'atlassian.jira.issues.length'
atlassian.jira.issues.length: 100
```

After:

```shell
$ go run apps/cnquery run atlassian jira --host https://myjira.atlassian.net -c 'atlassian.jira.issues.length'
atlassian.jira.issues.length: 311
```