### PR TITLE
Renamed jira created field to createdAt

### DIFF
--- a/providers/atlassian/resources/atlassian.lr
+++ b/providers/atlassian/resources/atlassian.lr
@@ -117,7 +117,7 @@ atlassian.jira.issue @defaults("id") {
   // Description
   description string
   // Issue create time in UTC
-  created time
+  createdAt time
 }
 
 // Jira server info

--- a/providers/atlassian/resources/atlassian_jira.go
+++ b/providers/atlassian/resources/atlassian_jira.go
@@ -212,7 +212,7 @@ func (a *mqlAtlassianJira) issues() ([]interface{}, error) {
 					"project":     llx.StringData(issue.Fields.Project.Name),
 					"status":      llx.StringData(issue.Fields.Status.Name),
 					"description": llx.StringData(issue.Fields.Description),
-					"created":     llx.TimeData(created.UTC()),
+					"createdAt":   llx.TimeData(created.UTC()),
 				})
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
createdAt is what we've been using in other providers. We should align this where we can