### PR TITLE
⭐️ aws iam analyzer

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -896,6 +896,8 @@ private aws.iam.virtualmfadevice @defaults("serialNumber") {
 aws.iam.accessAnalyzer @defaults("analyzers") {
   // List of `aws.iam.accessanalyzer.analyzer` objects for all AWS IAM Access Analyzers configured within the account
   analyzers() []aws.iam.accessanalyzer.analyzer
+  // List all active findings for all analyzers and regions
+  findings() []aws.iam.accessanalyzer.finding
 }
 
 // AWS IAM Access Analyzer resource (provides an object representing an individual AWS IAM Access Analyzer configuration)
@@ -918,6 +920,34 @@ private aws.iam.accessanalyzer.analyzer @defaults("name type region status") {
   lastResourceAnalyzedAt time
   // Creation timestamp
   createdAt time
+}
+
+// AWS IAM Access Analyzer finding
+private aws.iam.accessanalyzer.finding @defaults("resourceType region type status") {
+  // Finding id
+  id string
+  // Error Message
+  error string
+  // Resource
+  resourceArn string
+  // Resource owner
+  resourceOwnerAccount string
+  // Resource type
+  resourceType string
+  // Finding type
+  type string
+  // Finding Status
+  status string
+  // Time the finding was generated
+  analyzedAt time
+  // Creation timestamp
+  createdAt time
+  // Creation timestamp
+  updatedAt time
+  // Region where the finding exists
+  region string
+  // Analyzer arn
+  analyzerArn string
 }
 
 // AWS SageMaker

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -899,7 +899,7 @@ aws.iam.accessAnalyzer @defaults("analyzers") {
 }
 
 // AWS IAM Access Analyzer resource (provides an object representing an individual AWS IAM Access Analyzer configuration)
-private aws.iam.accessanalyzer.analyzer @defaults("name type status") {
+private aws.iam.accessanalyzer.analyzer @defaults("name type region status") {
   // ARN for the analyzer
   arn string
   // Name for the analyzer
@@ -908,6 +908,8 @@ private aws.iam.accessanalyzer.analyzer @defaults("name type status") {
   status string
   // Type of analyzer: ACCOUNT or ORGANIZATION
   type string
+  // Region where the analyzer exists
+  region string
   // Tags for the analyzer
   tags map[string]string
   // The name of the last resource that was analyzed
@@ -917,7 +919,6 @@ private aws.iam.accessanalyzer.analyzer @defaults("name type status") {
   // Creation timestamp
   createdAt time
 }
-
 
 // AWS SageMaker
 aws.sagemaker {

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -3,9 +3,11 @@
 
 import "../../network/resources/network.lr"
 
-
 option provider = "go.mondoo.com/cnquery/v9/providers/aws"
 option go_package = "go.mondoo.com/cnquery/v11/providers/aws/resources"
+
+alias aws.accessAnalyzer = aws.iam.accessAnalyzer
+alias aws.accessAnalyzer.analyzer = aws.iam.accessanalyzer.analyzer
 
 // AWS resource
 aws @defaults("account.id") {
@@ -633,31 +635,6 @@ private aws.waf.ipset @defaults("name") {
   addresses dict
 }
 
-// AWS IAM Access Analyzer resource (for assessing the configuration of AWS IAM Access Analyzer)
-aws.accessAnalyzer @defaults("analyzers") {
-  // List of `aws.accessanalyzer.analyzer` objects for all AWS IAM Access Analyzers configured within the account
-  analyzers() []aws.accessanalyzer.analyzer
-}
-
-// AWS IAM Access Analyzer resource (provides an object representing an individual AWS IAM Access Analyzer configuration)
-private aws.accessanalyzer.analyzer @defaults("name type status") {
-  // ARN for the analyzer
-  arn string
-  // Name for the analyzer
-  name string
-  // Status of the analyzer: ACTIVE, CREATING, DISABLED, or FAILED
-  status string
-  // Type of analyzer: ACCOUNT or ORGANIZATION
-  type string
-  // Tags for the analyzer
-  tags map[string]string
-  // The name of the last resource that was analyzed
-  lastResourceAnalyzed string
-  // Last scan timestamp
-  lastResourceAnalyzedAt time
-  // Creation timestamp
-  createdAt time
-}
 
 // AWS Elastic File System (EFS) service
 aws.efs @defaults("filesystems") {
@@ -914,6 +891,33 @@ private aws.iam.virtualmfadevice @defaults("serialNumber") {
   // User associated with the MFA device
   user aws.iam.user
 }
+
+// AWS IAM Access Analyzer resource (for assessing the configuration of AWS IAM Access Analyzer)
+aws.iam.accessAnalyzer @defaults("analyzers") {
+  // List of `aws.iam.accessanalyzer.analyzer` objects for all AWS IAM Access Analyzers configured within the account
+  analyzers() []aws.iam.accessanalyzer.analyzer
+}
+
+// AWS IAM Access Analyzer resource (provides an object representing an individual AWS IAM Access Analyzer configuration)
+private aws.iam.accessanalyzer.analyzer @defaults("name type status") {
+  // ARN for the analyzer
+  arn string
+  // Name for the analyzer
+  name string
+  // Status of the analyzer: ACTIVE, CREATING, DISABLED, or FAILED
+  status string
+  // Type of analyzer: ACCOUNT or ORGANIZATION
+  type string
+  // Tags for the analyzer
+  tags map[string]string
+  // The name of the last resource that was analyzed
+  lastResourceAnalyzed string
+  // Last scan timestamp
+  lastResourceAnalyzedAt time
+  // Creation timestamp
+  createdAt time
+}
+
 
 // AWS SageMaker
 aws.sagemaker {

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -1785,6 +1785,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.iam.accessanalyzer.analyzer.type": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamAccessanalyzerAnalyzer).GetType()).ToDataRes(types.String)
 	},
+	"aws.iam.accessanalyzer.analyzer.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessanalyzerAnalyzer).GetRegion()).ToDataRes(types.String)
+	},
 	"aws.iam.accessanalyzer.analyzer.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamAccessanalyzerAnalyzer).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -6007,6 +6010,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.iam.accessanalyzer.analyzer.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamAccessanalyzerAnalyzer).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessanalyzer.analyzer.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessanalyzerAnalyzer).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.iam.accessanalyzer.analyzer.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -14678,6 +14685,7 @@ type mqlAwsIamAccessanalyzerAnalyzer struct {
 	Name plugin.TValue[string]
 	Status plugin.TValue[string]
 	Type plugin.TValue[string]
+	Region plugin.TValue[string]
 	Tags plugin.TValue[map[string]interface{}]
 	LastResourceAnalyzed plugin.TValue[string]
 	LastResourceAnalyzedAt plugin.TValue[*time.Time]
@@ -14735,6 +14743,10 @@ func (c *mqlAwsIamAccessanalyzerAnalyzer) GetStatus() *plugin.TValue[string] {
 
 func (c *mqlAwsIamAccessanalyzerAnalyzer) GetType() *plugin.TValue[string] {
 	return &c.Type
+}
+
+func (c *mqlAwsIamAccessanalyzerAnalyzer) GetRegion() *plugin.TValue[string] {
+	return &c.Region
 }
 
 func (c *mqlAwsIamAccessanalyzerAnalyzer) GetTags() *plugin.TValue[map[string]interface{}] {

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -250,6 +250,10 @@ func init() {
 			// to override args, implement: initAwsIamAccessanalyzerAnalyzer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsIamAccessanalyzerAnalyzer,
 		},
+		"aws.iam.accessanalyzer.finding": {
+			// to override args, implement: initAwsIamAccessanalyzerFinding(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsIamAccessanalyzerFinding,
+		},
 		"aws.sagemaker": {
 			// to override args, implement: initAwsSagemaker(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsSagemaker,
@@ -1773,6 +1777,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.iam.accessAnalyzer.analyzers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamAccessAnalyzer).GetAnalyzers()).ToDataRes(types.Array(types.Resource("aws.iam.accessanalyzer.analyzer")))
 	},
+	"aws.iam.accessAnalyzer.findings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessAnalyzer).GetFindings()).ToDataRes(types.Array(types.Resource("aws.iam.accessanalyzer.finding")))
+	},
 	"aws.iam.accessanalyzer.analyzer.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamAccessanalyzerAnalyzer).GetArn()).ToDataRes(types.String)
 	},
@@ -1799,6 +1806,42 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.iam.accessanalyzer.analyzer.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamAccessanalyzerAnalyzer).GetCreatedAt()).ToDataRes(types.Time)
+	},
+	"aws.iam.accessanalyzer.finding.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessanalyzerFinding).GetId()).ToDataRes(types.String)
+	},
+	"aws.iam.accessanalyzer.finding.error": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessanalyzerFinding).GetError()).ToDataRes(types.String)
+	},
+	"aws.iam.accessanalyzer.finding.resourceArn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessanalyzerFinding).GetResourceArn()).ToDataRes(types.String)
+	},
+	"aws.iam.accessanalyzer.finding.resourceOwnerAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessanalyzerFinding).GetResourceOwnerAccount()).ToDataRes(types.String)
+	},
+	"aws.iam.accessanalyzer.finding.resourceType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessanalyzerFinding).GetResourceType()).ToDataRes(types.String)
+	},
+	"aws.iam.accessanalyzer.finding.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessanalyzerFinding).GetType()).ToDataRes(types.String)
+	},
+	"aws.iam.accessanalyzer.finding.status": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessanalyzerFinding).GetStatus()).ToDataRes(types.String)
+	},
+	"aws.iam.accessanalyzer.finding.analyzedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessanalyzerFinding).GetAnalyzedAt()).ToDataRes(types.Time)
+	},
+	"aws.iam.accessanalyzer.finding.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessanalyzerFinding).GetCreatedAt()).ToDataRes(types.Time)
+	},
+	"aws.iam.accessanalyzer.finding.updatedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessanalyzerFinding).GetUpdatedAt()).ToDataRes(types.Time)
+	},
+	"aws.iam.accessanalyzer.finding.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessanalyzerFinding).GetRegion()).ToDataRes(types.String)
+	},
+	"aws.iam.accessanalyzer.finding.analyzerArn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessanalyzerFinding).GetAnalyzerArn()).ToDataRes(types.String)
 	},
 	"aws.sagemaker.endpoints": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSagemaker).GetEndpoints()).ToDataRes(types.Array(types.Resource("aws.sagemaker.endpoint")))
@@ -5992,6 +6035,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsIamAccessAnalyzer).Analyzers, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
+	"aws.iam.accessAnalyzer.findings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessAnalyzer).Findings, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
 	"aws.iam.accessanalyzer.analyzer.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 			r.(*mqlAwsIamAccessanalyzerAnalyzer).__id, ok = v.Value.(string)
 			return
@@ -6030,6 +6077,58 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.iam.accessanalyzer.analyzer.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamAccessanalyzerAnalyzer).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessanalyzer.finding.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlAwsIamAccessanalyzerFinding).__id, ok = v.Value.(string)
+			return
+		},
+	"aws.iam.accessanalyzer.finding.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessanalyzerFinding).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessanalyzer.finding.error": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessanalyzerFinding).Error, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessanalyzer.finding.resourceArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessanalyzerFinding).ResourceArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessanalyzer.finding.resourceOwnerAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessanalyzerFinding).ResourceOwnerAccount, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessanalyzer.finding.resourceType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessanalyzerFinding).ResourceType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessanalyzer.finding.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessanalyzerFinding).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessanalyzer.finding.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessanalyzerFinding).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessanalyzer.finding.analyzedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessanalyzerFinding).AnalyzedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessanalyzer.finding.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessanalyzerFinding).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessanalyzer.finding.updatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessanalyzerFinding).UpdatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessanalyzer.finding.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessanalyzerFinding).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessanalyzer.finding.analyzerArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessanalyzerFinding).AnalyzerArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.sagemaker.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -14626,6 +14725,7 @@ type mqlAwsIamAccessAnalyzer struct {
 	__id string
 	// optional: if you define mqlAwsIamAccessAnalyzerInternal it will be used here
 	Analyzers plugin.TValue[[]interface{}]
+	Findings plugin.TValue[[]interface{}]
 }
 
 // createAwsIamAccessAnalyzer creates a new instance of this resource
@@ -14673,6 +14773,22 @@ func (c *mqlAwsIamAccessAnalyzer) GetAnalyzers() *plugin.TValue[[]interface{}] {
 		}
 
 		return c.analyzers()
+	})
+}
+
+func (c *mqlAwsIamAccessAnalyzer) GetFindings() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.Findings, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.iam.accessAnalyzer", c.__id, "findings")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.findings()
 	})
 }
 
@@ -14763,6 +14879,105 @@ func (c *mqlAwsIamAccessanalyzerAnalyzer) GetLastResourceAnalyzedAt() *plugin.TV
 
 func (c *mqlAwsIamAccessanalyzerAnalyzer) GetCreatedAt() *plugin.TValue[*time.Time] {
 	return &c.CreatedAt
+}
+
+// mqlAwsIamAccessanalyzerFinding for the aws.iam.accessanalyzer.finding resource
+type mqlAwsIamAccessanalyzerFinding struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlAwsIamAccessanalyzerFindingInternal it will be used here
+	Id plugin.TValue[string]
+	Error plugin.TValue[string]
+	ResourceArn plugin.TValue[string]
+	ResourceOwnerAccount plugin.TValue[string]
+	ResourceType plugin.TValue[string]
+	Type plugin.TValue[string]
+	Status plugin.TValue[string]
+	AnalyzedAt plugin.TValue[*time.Time]
+	CreatedAt plugin.TValue[*time.Time]
+	UpdatedAt plugin.TValue[*time.Time]
+	Region plugin.TValue[string]
+	AnalyzerArn plugin.TValue[string]
+}
+
+// createAwsIamAccessanalyzerFinding creates a new instance of this resource
+func createAwsIamAccessanalyzerFinding(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsIamAccessanalyzerFinding{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.iam.accessanalyzer.finding", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsIamAccessanalyzerFinding) MqlName() string {
+	return "aws.iam.accessanalyzer.finding"
+}
+
+func (c *mqlAwsIamAccessanalyzerFinding) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsIamAccessanalyzerFinding) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAwsIamAccessanalyzerFinding) GetError() *plugin.TValue[string] {
+	return &c.Error
+}
+
+func (c *mqlAwsIamAccessanalyzerFinding) GetResourceArn() *plugin.TValue[string] {
+	return &c.ResourceArn
+}
+
+func (c *mqlAwsIamAccessanalyzerFinding) GetResourceOwnerAccount() *plugin.TValue[string] {
+	return &c.ResourceOwnerAccount
+}
+
+func (c *mqlAwsIamAccessanalyzerFinding) GetResourceType() *plugin.TValue[string] {
+	return &c.ResourceType
+}
+
+func (c *mqlAwsIamAccessanalyzerFinding) GetType() *plugin.TValue[string] {
+	return &c.Type
+}
+
+func (c *mqlAwsIamAccessanalyzerFinding) GetStatus() *plugin.TValue[string] {
+	return &c.Status
+}
+
+func (c *mqlAwsIamAccessanalyzerFinding) GetAnalyzedAt() *plugin.TValue[*time.Time] {
+	return &c.AnalyzedAt
+}
+
+func (c *mqlAwsIamAccessanalyzerFinding) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
+}
+
+func (c *mqlAwsIamAccessanalyzerFinding) GetUpdatedAt() *plugin.TValue[*time.Time] {
+	return &c.UpdatedAt
+}
+
+func (c *mqlAwsIamAccessanalyzerFinding) GetRegion() *plugin.TValue[string] {
+	return &c.Region
+}
+
+func (c *mqlAwsIamAccessanalyzerFinding) GetAnalyzerArn() *plugin.TValue[string] {
+	return &c.AnalyzerArn
 }
 
 // mqlAwsSagemaker for the aws.sagemaker resource

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -190,14 +190,6 @@ func init() {
 			// to override args, implement: initAwsWafIpset(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsWafIpset,
 		},
-		"aws.accessAnalyzer": {
-			// to override args, implement: initAwsAccessAnalyzer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
-			Create: createAwsAccessAnalyzer,
-		},
-		"aws.accessanalyzer.analyzer": {
-			// to override args, implement: initAwsAccessanalyzerAnalyzer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
-			Create: createAwsAccessanalyzerAnalyzer,
-		},
 		"aws.efs": {
 			// to override args, implement: initAwsEfs(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsEfs,
@@ -249,6 +241,14 @@ func init() {
 		"aws.iam.virtualmfadevice": {
 			// to override args, implement: initAwsIamVirtualmfadevice(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsIamVirtualmfadevice,
+		},
+		"aws.iam.accessAnalyzer": {
+			// to override args, implement: initAwsIamAccessAnalyzer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsIamAccessAnalyzer,
+		},
+		"aws.iam.accessanalyzer.analyzer": {
+			// to override args, implement: initAwsIamAccessanalyzerAnalyzer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsIamAccessanalyzerAnalyzer,
 		},
 		"aws.sagemaker": {
 			// to override args, implement: initAwsSagemaker(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -1479,33 +1479,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.waf.ipset.addresses": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWafIpset).GetAddresses()).ToDataRes(types.Dict)
 	},
-	"aws.accessAnalyzer.analyzers": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsAccessAnalyzer).GetAnalyzers()).ToDataRes(types.Array(types.Resource("aws.accessanalyzer.analyzer")))
-	},
-	"aws.accessanalyzer.analyzer.arn": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsAccessanalyzerAnalyzer).GetArn()).ToDataRes(types.String)
-	},
-	"aws.accessanalyzer.analyzer.name": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsAccessanalyzerAnalyzer).GetName()).ToDataRes(types.String)
-	},
-	"aws.accessanalyzer.analyzer.status": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsAccessanalyzerAnalyzer).GetStatus()).ToDataRes(types.String)
-	},
-	"aws.accessanalyzer.analyzer.type": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsAccessanalyzerAnalyzer).GetType()).ToDataRes(types.String)
-	},
-	"aws.accessanalyzer.analyzer.tags": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsAccessanalyzerAnalyzer).GetTags()).ToDataRes(types.Map(types.String, types.String))
-	},
-	"aws.accessanalyzer.analyzer.lastResourceAnalyzed": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsAccessanalyzerAnalyzer).GetLastResourceAnalyzed()).ToDataRes(types.String)
-	},
-	"aws.accessanalyzer.analyzer.lastResourceAnalyzedAt": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsAccessanalyzerAnalyzer).GetLastResourceAnalyzedAt()).ToDataRes(types.Time)
-	},
-	"aws.accessanalyzer.analyzer.createdAt": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsAccessanalyzerAnalyzer).GetCreatedAt()).ToDataRes(types.Time)
-	},
 	"aws.efs.filesystems": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEfs).GetFilesystems()).ToDataRes(types.Array(types.Resource("aws.efs.filesystem")))
 	},
@@ -1796,6 +1769,33 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.iam.virtualmfadevice.user": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamVirtualmfadevice).GetUser()).ToDataRes(types.Resource("aws.iam.user"))
+	},
+	"aws.iam.accessAnalyzer.analyzers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessAnalyzer).GetAnalyzers()).ToDataRes(types.Array(types.Resource("aws.iam.accessanalyzer.analyzer")))
+	},
+	"aws.iam.accessanalyzer.analyzer.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessanalyzerAnalyzer).GetArn()).ToDataRes(types.String)
+	},
+	"aws.iam.accessanalyzer.analyzer.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessanalyzerAnalyzer).GetName()).ToDataRes(types.String)
+	},
+	"aws.iam.accessanalyzer.analyzer.status": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessanalyzerAnalyzer).GetStatus()).ToDataRes(types.String)
+	},
+	"aws.iam.accessanalyzer.analyzer.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessanalyzerAnalyzer).GetType()).ToDataRes(types.String)
+	},
+	"aws.iam.accessanalyzer.analyzer.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessanalyzerAnalyzer).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.iam.accessanalyzer.analyzer.lastResourceAnalyzed": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessanalyzerAnalyzer).GetLastResourceAnalyzed()).ToDataRes(types.String)
+	},
+	"aws.iam.accessanalyzer.analyzer.lastResourceAnalyzedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessanalyzerAnalyzer).GetLastResourceAnalyzedAt()).ToDataRes(types.Time)
+	},
+	"aws.iam.accessanalyzer.analyzer.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessanalyzerAnalyzer).GetCreatedAt()).ToDataRes(types.Time)
 	},
 	"aws.sagemaker.endpoints": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSagemaker).GetEndpoints()).ToDataRes(types.Array(types.Resource("aws.sagemaker.endpoint")))
@@ -5541,50 +5541,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsWafIpset).Addresses, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
 		return
 	},
-	"aws.accessAnalyzer.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-			r.(*mqlAwsAccessAnalyzer).__id, ok = v.Value.(string)
-			return
-		},
-	"aws.accessAnalyzer.analyzers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsAccessAnalyzer).Analyzers, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
-		return
-	},
-	"aws.accessanalyzer.analyzer.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-			r.(*mqlAwsAccessanalyzerAnalyzer).__id, ok = v.Value.(string)
-			return
-		},
-	"aws.accessanalyzer.analyzer.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsAccessanalyzerAnalyzer).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"aws.accessanalyzer.analyzer.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsAccessanalyzerAnalyzer).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"aws.accessanalyzer.analyzer.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsAccessanalyzerAnalyzer).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"aws.accessanalyzer.analyzer.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsAccessanalyzerAnalyzer).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"aws.accessanalyzer.analyzer.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsAccessanalyzerAnalyzer).Tags, ok = plugin.RawToTValue[map[string]interface{}](v.Value, v.Error)
-		return
-	},
-	"aws.accessanalyzer.analyzer.lastResourceAnalyzed": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsAccessanalyzerAnalyzer).LastResourceAnalyzed, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"aws.accessanalyzer.analyzer.lastResourceAnalyzedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsAccessanalyzerAnalyzer).LastResourceAnalyzedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
-		return
-	},
-	"aws.accessanalyzer.analyzer.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsAccessanalyzerAnalyzer).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
-		return
-	},
 	"aws.efs.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 			r.(*mqlAwsEfs).__id, ok = v.Value.(string)
 			return
@@ -6023,6 +5979,50 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.iam.virtualmfadevice.user": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamVirtualmfadevice).User, ok = plugin.RawToTValue[*mqlAwsIamUser](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessAnalyzer.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlAwsIamAccessAnalyzer).__id, ok = v.Value.(string)
+			return
+		},
+	"aws.iam.accessAnalyzer.analyzers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessAnalyzer).Analyzers, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessanalyzer.analyzer.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlAwsIamAccessanalyzerAnalyzer).__id, ok = v.Value.(string)
+			return
+		},
+	"aws.iam.accessanalyzer.analyzer.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessanalyzerAnalyzer).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessanalyzer.analyzer.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessanalyzerAnalyzer).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessanalyzer.analyzer.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessanalyzerAnalyzer).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessanalyzer.analyzer.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessanalyzerAnalyzer).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessanalyzer.analyzer.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessanalyzerAnalyzer).Tags, ok = plugin.RawToTValue[map[string]interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessanalyzer.analyzer.lastResourceAnalyzed": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessanalyzerAnalyzer).LastResourceAnalyzed, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessanalyzer.analyzer.lastResourceAnalyzedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessanalyzerAnalyzer).LastResourceAnalyzedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessanalyzer.analyzer.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessanalyzerAnalyzer).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.sagemaker.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -13272,146 +13272,6 @@ func (c *mqlAwsWafIpset) GetAddresses() *plugin.TValue[interface{}] {
 	return &c.Addresses
 }
 
-// mqlAwsAccessAnalyzer for the aws.accessAnalyzer resource
-type mqlAwsAccessAnalyzer struct {
-	MqlRuntime *plugin.Runtime
-	__id string
-	// optional: if you define mqlAwsAccessAnalyzerInternal it will be used here
-	Analyzers plugin.TValue[[]interface{}]
-}
-
-// createAwsAccessAnalyzer creates a new instance of this resource
-func createAwsAccessAnalyzer(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
-	res := &mqlAwsAccessAnalyzer{
-		MqlRuntime: runtime,
-	}
-
-	err := SetAllData(res, args)
-	if err != nil {
-		return res, err
-	}
-
-	// to override __id implement: id() (string, error)
-
-	if runtime.HasRecording {
-		args, err = runtime.ResourceFromRecording("aws.accessAnalyzer", res.__id)
-		if err != nil || args == nil {
-			return res, err
-		}
-		return res, SetAllData(res, args)
-	}
-
-	return res, nil
-}
-
-func (c *mqlAwsAccessAnalyzer) MqlName() string {
-	return "aws.accessAnalyzer"
-}
-
-func (c *mqlAwsAccessAnalyzer) MqlID() string {
-	return c.__id
-}
-
-func (c *mqlAwsAccessAnalyzer) GetAnalyzers() *plugin.TValue[[]interface{}] {
-	return plugin.GetOrCompute[[]interface{}](&c.Analyzers, func() ([]interface{}, error) {
-		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.accessAnalyzer", c.__id, "analyzers")
-			if err != nil {
-				return nil, err
-			}
-			if d != nil {
-				return d.Value.([]interface{}), nil
-			}
-		}
-
-		return c.analyzers()
-	})
-}
-
-// mqlAwsAccessanalyzerAnalyzer for the aws.accessanalyzer.analyzer resource
-type mqlAwsAccessanalyzerAnalyzer struct {
-	MqlRuntime *plugin.Runtime
-	__id string
-	// optional: if you define mqlAwsAccessanalyzerAnalyzerInternal it will be used here
-	Arn plugin.TValue[string]
-	Name plugin.TValue[string]
-	Status plugin.TValue[string]
-	Type plugin.TValue[string]
-	Tags plugin.TValue[map[string]interface{}]
-	LastResourceAnalyzed plugin.TValue[string]
-	LastResourceAnalyzedAt plugin.TValue[*time.Time]
-	CreatedAt plugin.TValue[*time.Time]
-}
-
-// createAwsAccessanalyzerAnalyzer creates a new instance of this resource
-func createAwsAccessanalyzerAnalyzer(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
-	res := &mqlAwsAccessanalyzerAnalyzer{
-		MqlRuntime: runtime,
-	}
-
-	err := SetAllData(res, args)
-	if err != nil {
-		return res, err
-	}
-
-	if res.__id == "" {
-	res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if runtime.HasRecording {
-		args, err = runtime.ResourceFromRecording("aws.accessanalyzer.analyzer", res.__id)
-		if err != nil || args == nil {
-			return res, err
-		}
-		return res, SetAllData(res, args)
-	}
-
-	return res, nil
-}
-
-func (c *mqlAwsAccessanalyzerAnalyzer) MqlName() string {
-	return "aws.accessanalyzer.analyzer"
-}
-
-func (c *mqlAwsAccessanalyzerAnalyzer) MqlID() string {
-	return c.__id
-}
-
-func (c *mqlAwsAccessanalyzerAnalyzer) GetArn() *plugin.TValue[string] {
-	return &c.Arn
-}
-
-func (c *mqlAwsAccessanalyzerAnalyzer) GetName() *plugin.TValue[string] {
-	return &c.Name
-}
-
-func (c *mqlAwsAccessanalyzerAnalyzer) GetStatus() *plugin.TValue[string] {
-	return &c.Status
-}
-
-func (c *mqlAwsAccessanalyzerAnalyzer) GetType() *plugin.TValue[string] {
-	return &c.Type
-}
-
-func (c *mqlAwsAccessanalyzerAnalyzer) GetTags() *plugin.TValue[map[string]interface{}] {
-	return &c.Tags
-}
-
-func (c *mqlAwsAccessanalyzerAnalyzer) GetLastResourceAnalyzed() *plugin.TValue[string] {
-	return &c.LastResourceAnalyzed
-}
-
-func (c *mqlAwsAccessanalyzerAnalyzer) GetLastResourceAnalyzedAt() *plugin.TValue[*time.Time] {
-	return &c.LastResourceAnalyzedAt
-}
-
-func (c *mqlAwsAccessanalyzerAnalyzer) GetCreatedAt() *plugin.TValue[*time.Time] {
-	return &c.CreatedAt
-}
-
 // mqlAwsEfs for the aws.efs resource
 type mqlAwsEfs struct {
 	MqlRuntime *plugin.Runtime
@@ -14751,6 +14611,146 @@ func (c *mqlAwsIamVirtualmfadevice) GetEnableDate() *plugin.TValue[*time.Time] {
 
 func (c *mqlAwsIamVirtualmfadevice) GetUser() *plugin.TValue[*mqlAwsIamUser] {
 	return &c.User
+}
+
+// mqlAwsIamAccessAnalyzer for the aws.iam.accessAnalyzer resource
+type mqlAwsIamAccessAnalyzer struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlAwsIamAccessAnalyzerInternal it will be used here
+	Analyzers plugin.TValue[[]interface{}]
+}
+
+// createAwsIamAccessAnalyzer creates a new instance of this resource
+func createAwsIamAccessAnalyzer(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsIamAccessAnalyzer{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.iam.accessAnalyzer", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsIamAccessAnalyzer) MqlName() string {
+	return "aws.iam.accessAnalyzer"
+}
+
+func (c *mqlAwsIamAccessAnalyzer) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsIamAccessAnalyzer) GetAnalyzers() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.Analyzers, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.iam.accessAnalyzer", c.__id, "analyzers")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.analyzers()
+	})
+}
+
+// mqlAwsIamAccessanalyzerAnalyzer for the aws.iam.accessanalyzer.analyzer resource
+type mqlAwsIamAccessanalyzerAnalyzer struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlAwsIamAccessanalyzerAnalyzerInternal it will be used here
+	Arn plugin.TValue[string]
+	Name plugin.TValue[string]
+	Status plugin.TValue[string]
+	Type plugin.TValue[string]
+	Tags plugin.TValue[map[string]interface{}]
+	LastResourceAnalyzed plugin.TValue[string]
+	LastResourceAnalyzedAt plugin.TValue[*time.Time]
+	CreatedAt plugin.TValue[*time.Time]
+}
+
+// createAwsIamAccessanalyzerAnalyzer creates a new instance of this resource
+func createAwsIamAccessanalyzerAnalyzer(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsIamAccessanalyzerAnalyzer{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+	res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.iam.accessanalyzer.analyzer", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsIamAccessanalyzerAnalyzer) MqlName() string {
+	return "aws.iam.accessanalyzer.analyzer"
+}
+
+func (c *mqlAwsIamAccessanalyzerAnalyzer) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsIamAccessanalyzerAnalyzer) GetArn() *plugin.TValue[string] {
+	return &c.Arn
+}
+
+func (c *mqlAwsIamAccessanalyzerAnalyzer) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAwsIamAccessanalyzerAnalyzer) GetStatus() *plugin.TValue[string] {
+	return &c.Status
+}
+
+func (c *mqlAwsIamAccessanalyzerAnalyzer) GetType() *plugin.TValue[string] {
+	return &c.Type
+}
+
+func (c *mqlAwsIamAccessanalyzerAnalyzer) GetTags() *plugin.TValue[map[string]interface{}] {
+	return &c.Tags
+}
+
+func (c *mqlAwsIamAccessanalyzerAnalyzer) GetLastResourceAnalyzed() *plugin.TValue[string] {
+	return &c.LastResourceAnalyzed
+}
+
+func (c *mqlAwsIamAccessanalyzerAnalyzer) GetLastResourceAnalyzedAt() *plugin.TValue[*time.Time] {
+	return &c.LastResourceAnalyzedAt
+}
+
+func (c *mqlAwsIamAccessanalyzerAnalyzer) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
 }
 
 // mqlAwsSagemaker for the aws.sagemaker resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -1936,6 +1936,7 @@ resources:
       lastResourceAnalyzed: {}
       lastResourceAnalyzedAt: {}
       name: {}
+      region: {}
       status: {}
       tags: {}
       type: {}

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -69,7 +69,6 @@ resources:
       tags:
         min_mondoo_version: 5.16.0
       type: {}
-    is_private: true
     min_mondoo_version: 5.15.0
     platform:
       name:
@@ -1923,6 +1922,28 @@ resources:
         != null\n  ) \n"
       title: Do not setup access keys during initial user setup for all IAM users
         that have a console password
+  aws.iam.accessAnalyzer:
+    fields:
+      analyzers: {}
+    min_mondoo_version: latest
+    platform:
+      name:
+      - aws
+  aws.iam.accessanalyzer.analyzer:
+    fields:
+      arn: {}
+      createdAt: {}
+      lastResourceAnalyzed: {}
+      lastResourceAnalyzedAt: {}
+      name: {}
+      status: {}
+      tags: {}
+      type: {}
+    is_private: true
+    min_mondoo_version: latest
+    platform:
+      name:
+      - aws
   aws.iam.group:
     docs:
       desc: |

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -1925,7 +1925,8 @@ resources:
   aws.iam.accessAnalyzer:
     fields:
       analyzers: {}
-    min_mondoo_version: latest
+      findings: {}
+    min_mondoo_version: 9.0.0
     platform:
       name:
       - aws
@@ -1941,7 +1942,26 @@ resources:
       tags: {}
       type: {}
     is_private: true
-    min_mondoo_version: latest
+    min_mondoo_version: 9.0.0
+    platform:
+      name:
+      - aws
+  aws.iam.accessanalyzer.finding:
+    fields:
+      analyzedAt: {}
+      analyzerArn: {}
+      createdAt: {}
+      error: {}
+      id: {}
+      region: {}
+      resourceArn: {}
+      resourceOwnerAccount: {}
+      resourceType: {}
+      status: {}
+      type: {}
+      updatedAt: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
     platform:
       name:
       - aws

--- a/providers/aws/resources/aws_iam_accessanalyzer.go
+++ b/providers/aws/resources/aws_iam_accessanalyzer.go
@@ -5,9 +5,10 @@ package resources
 
 import (
 	"context"
+	"errors"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
 	aatypes "github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/jobpool"
@@ -89,6 +90,118 @@ func (a *mqlAwsIamAccessAnalyzer) getAnalyzers(conn *connection.AwsConnection) [
 					}
 					nextToken = analyzers.NextToken
 					if analyzers.NextToken != nil {
+						params.NextToken = nextToken
+					}
+				}
+			}
+			return jobpool.JobResult(res), nil
+		}
+		tasks = append(tasks, jobpool.NewJob(f))
+	}
+	return tasks
+}
+
+func (a *mqlAwsIamAccessAnalyzer) findings() ([]interface{}, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+
+	analyzerMap := map[string][]string{}
+
+	// we need to retrieve all the analyzers first and we group them by region to request all findings
+	analyzerList := a.GetAnalyzers()
+	for _, analyzer := range analyzerList.Data {
+		analyzerInstance, ok := analyzer.(*mqlAwsIamAccessanalyzerAnalyzer)
+		if !ok {
+			return nil, errors.New("error casting to analyzer instance")
+		}
+
+		region := analyzerInstance.GetRegion().Data
+		if analyzerMap[region] == nil {
+			analyzerMap[region] = []string{}
+		}
+
+		analyzerMap[region] = append(analyzerMap[region], analyzerInstance.GetArn().Data)
+	}
+
+	// collect the list of findings
+	res := []interface{}{}
+
+	// start ppol and run the jobs
+	poolOfJobs := jobpool.CreatePool(a.listFindings(conn, analyzerMap), 5)
+	poolOfJobs.Run()
+
+	// check for errors
+	if poolOfJobs.HasErrors() {
+		return nil, poolOfJobs.GetErrors()
+	}
+
+	for i := range poolOfJobs.Jobs {
+		results := poolOfJobs.Jobs[i].Result.([]interface{})
+		res = append(res, results...)
+	}
+	return res, nil
+}
+
+func (a *mqlAwsIamAccessAnalyzer) listFindings(conn *connection.AwsConnection, analyzerMap map[string][]string) []*jobpool.Job {
+	tasks := make([]*jobpool.Job, 0)
+	regions, err := conn.Regions()
+	if err != nil {
+		return []*jobpool.Job{{Err: err}}
+	}
+
+	for i := range regions {
+		regionVal := regions[i]
+		f := func() (jobpool.JobResult, error) {
+			svc := conn.AccessAnalyzer(regionVal)
+			res := []interface{}{}
+
+			analyzerList := analyzerMap[regionVal]
+			for _, analyzerArn := range analyzerList {
+
+				ctx := context.Background()
+
+				nextToken := aws.String("no_token_to_start_with")
+				params := &accessanalyzer.ListFindingsV2Input{
+					AnalyzerArn: aws.String(analyzerArn),
+					Filter: map[string]aatypes.Criterion{
+						"status": {
+							Eq: []string{"ACTIVE"},
+						},
+					},
+				}
+				for nextToken != nil {
+					findings, err := svc.ListFindingsV2(ctx, params)
+					if err != nil {
+						if Is400AccessDeniedError(err) {
+							log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+							return res, nil
+						}
+						log.Error().Err(err).Str("region", regionVal).Msg("error listing analyzers")
+						return nil, err
+					}
+					for _, finding := range findings.Findings {
+						mqlIamAnalyzserFindings, err := CreateResource(a.MqlRuntime, "aws.iam.accessanalyzer.finding",
+							map[string]*llx.RawData{
+								"__id":                 llx.StringDataPtr(finding.Id),
+								"id":                   llx.StringDataPtr(finding.Id),
+								"error":                llx.StringDataPtr(finding.Error),
+								"resourceArn":          llx.StringDataPtr(finding.Resource),
+								"resourceOwnerAccount": llx.StringDataPtr(finding.ResourceOwnerAccount),
+								"resourceType":         llx.StringData(string(finding.ResourceType)),
+								"status":               llx.StringData(string(finding.Status)),
+								"type":                 llx.StringData(string(finding.FindingType)),
+								"createdAt":            llx.TimeDataPtr(finding.CreatedAt),
+								"updatedAt":            llx.TimeDataPtr(finding.UpdatedAt),
+								"analyzedAt":           llx.TimeDataPtr(finding.AnalyzedAt),
+								"region":               llx.StringData(regionVal),
+								"analyzerArn":          llx.StringData(analyzerArn),
+							})
+						if err != nil {
+							return nil, err
+						}
+						res = append(res, mqlIamAnalyzserFindings)
+					}
+					nextToken = findings.NextToken
+					if findings.NextToken != nil {
 						params.NextToken = nextToken
 					}
 				}

--- a/providers/aws/resources/aws_iam_accessanalyzer.go
+++ b/providers/aws/resources/aws_iam_accessanalyzer.go
@@ -16,11 +16,11 @@ import (
 	"go.mondoo.com/cnquery/v11/types"
 )
 
-func (a *mqlAwsAccessanalyzerAnalyzer) id() (string, error) {
+func (a *mqlAwsIamAccessanalyzerAnalyzer) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
-func (a *mqlAwsAccessAnalyzer) analyzers() ([]interface{}, error) {
+func (a *mqlAwsIamAccessAnalyzer) analyzers() ([]interface{}, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
 	res := []interface{}{}
@@ -39,7 +39,7 @@ func (a *mqlAwsAccessAnalyzer) analyzers() ([]interface{}, error) {
 	return res, nil
 }
 
-func (a *mqlAwsAccessAnalyzer) getAnalyzers(conn *connection.AwsConnection) []*jobpool.Job {
+func (a *mqlAwsIamAccessAnalyzer) getAnalyzers(conn *connection.AwsConnection) []*jobpool.Job {
 	tasks := make([]*jobpool.Job, 0)
 	regions, err := conn.Regions()
 	if err != nil {
@@ -65,7 +65,7 @@ func (a *mqlAwsAccessAnalyzer) getAnalyzers(conn *connection.AwsConnection) []*j
 					return nil, err
 				}
 				for _, analyzer := range analyzers.Analyzers {
-					mqlAnalyzer, err := CreateResource(a.MqlRuntime, "aws.accessanalyzer.analyzer",
+					mqlAnalyzer, err := CreateResource(a.MqlRuntime, "aws.iam.accessanalyzer.analyzer",
 						map[string]*llx.RawData{
 							"arn":                    llx.StringDataPtr(analyzer.Arn),
 							"createdAt":              llx.TimeDataPtr(analyzer.CreatedAt),


### PR DESCRIPTION
This RP improves the AWS IAM Analyzer resource.

**Rename**

The resource has been moved from `aws.accessAnalyzer` to `aws.iam.accessAnalyzer` better align with AWS naming scheme. We established an alias, so that no migration is required. Old queries keep working as expected.

To check that the default analyzer runs in all aws regions run the following query:

```
cnspec> aws.regions.containsAll(aws.iam.accessAnalyzer.analyzers.where(name == "default-analyzer").map(region))
[ok] value: []
```

**Analyzer**

To verify the analyzer running in AWS, we improved the `aws.iam.accessAnalyzer`  to also include org-level analyzer that apply to the region and activated "unused" analyzer. The following shell output illustrate the new ACCOUNT_UNUSED_ACCESS type analyzer in the list

```
cnspec> aws.iam.accessAnalyzer.analyzers
aws.iam.accessAnalyzer.analyzers: [
  0: aws.iam.accessanalyzer.analyzer name="default-analyzer" type="ACCOUNT" region="ap-south-1" status="ACTIVE"
  ...
  15: aws.iam.accessanalyzer.analyzer name="UnusedAccess-ConsoleAnalyzer-380ebc35-c704-4edd-bb2f-8e5050ba02be" type="ACCOUNT_UNUSED_ACCESS" region="us-east-2" status="ACTIVE"
  16: aws.iam.accessanalyzer.analyzer name="default-analyzer" type="ACCOUNT" region="us-west-1" status="ACTIVE"
  17: aws.iam.accessanalyzer.analyzer name="default-analyzer" type="ACCOUNT" region="us-west-2" status="ACTIVE"
]
```

**Findings**

We introduce a new `aws.iam.accessAnalyzer.findings` resource that returns all active findings for all regions. This allows you to easily see all open findings for all regions:

```
cnspec> aws.iam.accessAnalyzer.findings
aws.iam.accessAnalyzer.findings: [
  0: aws.iam.accessanalyzer.finding resourceType="AWS::IAM::Role" region="ap-south-1" type="ExternalAccess" status="ACTIVE"
  1: aws.iam.accessanalyzer.finding resourceType="AWS::IAM::Role" region="ap-south-1" type="ExternalAccess" status="ACTIVE"
  2: aws.iam.accessanalyzer.finding resourceType="AWS::IAM::Role" region="ap-south-1" type="ExternalAccess" status="ACTIVE"
  3: aws.iam.accessanalyzer.finding resourceType="AWS::IAM::Role" region="eu-north-1" type="ExternalAccess" status="ACTIVE"
  4: aws.iam.accessanalyzer.finding resourceType="AWS::IAM::Role" region="eu-north-1" type="ExternalAccess" status="ACTIVE"
  5: aws.iam.accessanalyzer.finding resourceType="AWS::IAM::Role" region="eu-north-1" type="ExternalAccess" status="ACTIVE"
  6: aws.iam.accessanalyzer.finding resourceType="AWS::IAM::Role" region="eu-west-3" type="ExternalAccess" status="ACTIVE"
  ....
}
```

