### PR TITLE
Add useful default data for the k8s.node resource

### DIFF
--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -99,7 +99,7 @@ private k8s.namespace @defaults("name created") {
 }
 
 // Kubernetes node
-private k8s.node @defaults("name kind") {
+private k8s.node @defaults("name labels['kubernetes.io/arch'] labels['kubernetes.io/os'] ") {
   // Mondoo ID for the Kubernetes object
   id string
   // Kubernetes object UID


### PR DESCRIPTION
Expose the platform and architecture of the nodes


```
cnquery> k8s.nodes
k8s.nodes: [
  0: k8s.node name="ip-172-31-22-47.us-west-2.compute.internal" labels[kubernetes.io/arch]="amd64" labels[kubernetes.io/os]="linux"
  1: k8s.node name="ip-172-31-7-191.us-west-2.compute.internal" labels[kubernetes.io/arch]="amd64" labels[kubernetes.io/os]="linux"
]
```