### PR TITLE
⭐️ aws guardduty finding

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1211,7 +1211,7 @@ private aws.codebuild.project @defaults("arn name") {
 
 // Amazon GuardDuty for threat detection
 aws.guardduty {
-  // List of GuardDuty findings
+  // List of GuardDuty active findings
   findings() []aws.guardduty.finding
   // List of GuardDuty detectors
   detectors() []aws.guardduty.detector
@@ -1224,10 +1224,16 @@ private aws.guardduty.detector @defaults("id region") {
   // Region for the detector
   region string
   // Status of the detector: ENABLED or DISABLED
-  status string
+  status() string
+  // Feature set for the detector
+  features() []dict
+  // Tags for the project
+  tags() map[string]string
   // Publishing frequency for the detector
-  findingPublishingFrequency string
-  // List of unarchivedFindings found by the detector
+  findingPublishingFrequency() string
+  // List of active findings by detector
+  findings() []aws.guardduty.finding
+  // Deprecated: List of unarchivedFindings found by the detector, use `findings` instead
   unarchivedFindings() []dict
 }
 

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1211,6 +1211,8 @@ private aws.codebuild.project @defaults("arn name") {
 
 // Amazon GuardDuty for threat detection
 aws.guardduty {
+  // List of GuardDuty findings
+  findings() []aws.guardduty.finding
   // List of GuardDuty detectors
   detectors() []aws.guardduty.detector
 }
@@ -1227,6 +1229,30 @@ private aws.guardduty.detector @defaults("id region") {
   findingPublishingFrequency string
   // List of unarchivedFindings found by the detector
   unarchivedFindings() []dict
+}
+
+// AWS Guard Duty finding
+private aws.guardduty.finding @defaults("title region severity") {
+  // Unique ID for the finding
+  arn string
+  // ID of the finding
+  id string
+  // Region where the finding was found
+  region string
+  // Title
+  title string
+  // Description
+  description string
+  // Severity of the finding
+  severity float
+  // Confidence level of the finding
+  confidence float
+  // Type of the finding
+  type string
+  // Created at time
+  createdAt time
+  // Updated at time
+  updatedAt time
 }
 
 // AWS Security Hub

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -330,6 +330,10 @@ func init() {
 			Init: initAwsGuarddutyDetector,
 			Create: createAwsGuarddutyDetector,
 		},
+		"aws.guardduty.finding": {
+			// to override args, implement: initAwsGuarddutyFinding(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsGuarddutyFinding,
+		},
 		"aws.securityhub": {
 			// to override args, implement: initAwsSecurityhub(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsSecurityhub,
@@ -2130,6 +2134,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.codebuild.project.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCodebuildProject).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"aws.guardduty.findings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsGuardduty).GetFindings()).ToDataRes(types.Array(types.Resource("aws.guardduty.finding")))
+	},
 	"aws.guardduty.detectors": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsGuardduty).GetDetectors()).ToDataRes(types.Array(types.Resource("aws.guardduty.detector")))
 	},
@@ -2147,6 +2154,36 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.guardduty.detector.unarchivedFindings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsGuarddutyDetector).GetUnarchivedFindings()).ToDataRes(types.Array(types.Dict))
+	},
+	"aws.guardduty.finding.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsGuarddutyFinding).GetArn()).ToDataRes(types.String)
+	},
+	"aws.guardduty.finding.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsGuarddutyFinding).GetId()).ToDataRes(types.String)
+	},
+	"aws.guardduty.finding.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsGuarddutyFinding).GetRegion()).ToDataRes(types.String)
+	},
+	"aws.guardduty.finding.title": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsGuarddutyFinding).GetTitle()).ToDataRes(types.String)
+	},
+	"aws.guardduty.finding.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsGuarddutyFinding).GetDescription()).ToDataRes(types.String)
+	},
+	"aws.guardduty.finding.severity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsGuarddutyFinding).GetSeverity()).ToDataRes(types.Float)
+	},
+	"aws.guardduty.finding.confidence": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsGuarddutyFinding).GetConfidence()).ToDataRes(types.Float)
+	},
+	"aws.guardduty.finding.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsGuarddutyFinding).GetType()).ToDataRes(types.String)
+	},
+	"aws.guardduty.finding.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsGuarddutyFinding).GetCreatedAt()).ToDataRes(types.Time)
+	},
+	"aws.guardduty.finding.updatedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsGuarddutyFinding).GetUpdatedAt()).ToDataRes(types.Time)
 	},
 	"aws.securityhub.hubs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSecurityhub).GetHubs()).ToDataRes(types.Array(types.Resource("aws.securityhub.hub")))
@@ -6545,6 +6582,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 			r.(*mqlAwsGuardduty).__id, ok = v.Value.(string)
 			return
 		},
+	"aws.guardduty.findings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsGuardduty).Findings, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
 	"aws.guardduty.detectors": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsGuardduty).Detectors, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
@@ -6571,6 +6612,50 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.guardduty.detector.unarchivedFindings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsGuarddutyDetector).UnarchivedFindings, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.guardduty.finding.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlAwsGuarddutyFinding).__id, ok = v.Value.(string)
+			return
+		},
+	"aws.guardduty.finding.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsGuarddutyFinding).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.guardduty.finding.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsGuarddutyFinding).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.guardduty.finding.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsGuarddutyFinding).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.guardduty.finding.title": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsGuarddutyFinding).Title, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.guardduty.finding.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsGuarddutyFinding).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.guardduty.finding.severity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsGuarddutyFinding).Severity, ok = plugin.RawToTValue[float64](v.Value, v.Error)
+		return
+	},
+	"aws.guardduty.finding.confidence": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsGuarddutyFinding).Confidence, ok = plugin.RawToTValue[float64](v.Value, v.Error)
+		return
+	},
+	"aws.guardduty.finding.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsGuarddutyFinding).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.guardduty.finding.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsGuarddutyFinding).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.guardduty.finding.updatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsGuarddutyFinding).UpdatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.securityhub.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16331,6 +16416,7 @@ type mqlAwsGuardduty struct {
 	MqlRuntime *plugin.Runtime
 	__id string
 	// optional: if you define mqlAwsGuarddutyInternal it will be used here
+	Findings plugin.TValue[[]interface{}]
 	Detectors plugin.TValue[[]interface{}]
 }
 
@@ -16369,6 +16455,22 @@ func (c *mqlAwsGuardduty) MqlName() string {
 
 func (c *mqlAwsGuardduty) MqlID() string {
 	return c.__id
+}
+
+func (c *mqlAwsGuardduty) GetFindings() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.Findings, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.guardduty", c.__id, "findings")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.findings()
+	})
 }
 
 func (c *mqlAwsGuardduty) GetDetectors() *plugin.TValue[[]interface{}] {
@@ -16456,6 +16558,95 @@ func (c *mqlAwsGuarddutyDetector) GetUnarchivedFindings() *plugin.TValue[[]inter
 	return plugin.GetOrCompute[[]interface{}](&c.UnarchivedFindings, func() ([]interface{}, error) {
 		return c.unarchivedFindings()
 	})
+}
+
+// mqlAwsGuarddutyFinding for the aws.guardduty.finding resource
+type mqlAwsGuarddutyFinding struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlAwsGuarddutyFindingInternal it will be used here
+	Arn plugin.TValue[string]
+	Id plugin.TValue[string]
+	Region plugin.TValue[string]
+	Title plugin.TValue[string]
+	Description plugin.TValue[string]
+	Severity plugin.TValue[float64]
+	Confidence plugin.TValue[float64]
+	Type plugin.TValue[string]
+	CreatedAt plugin.TValue[*time.Time]
+	UpdatedAt plugin.TValue[*time.Time]
+}
+
+// createAwsGuarddutyFinding creates a new instance of this resource
+func createAwsGuarddutyFinding(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsGuarddutyFinding{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.guardduty.finding", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsGuarddutyFinding) MqlName() string {
+	return "aws.guardduty.finding"
+}
+
+func (c *mqlAwsGuarddutyFinding) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsGuarddutyFinding) GetArn() *plugin.TValue[string] {
+	return &c.Arn
+}
+
+func (c *mqlAwsGuarddutyFinding) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAwsGuarddutyFinding) GetRegion() *plugin.TValue[string] {
+	return &c.Region
+}
+
+func (c *mqlAwsGuarddutyFinding) GetTitle() *plugin.TValue[string] {
+	return &c.Title
+}
+
+func (c *mqlAwsGuarddutyFinding) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlAwsGuarddutyFinding) GetSeverity() *plugin.TValue[float64] {
+	return &c.Severity
+}
+
+func (c *mqlAwsGuarddutyFinding) GetConfidence() *plugin.TValue[float64] {
+	return &c.Confidence
+}
+
+func (c *mqlAwsGuarddutyFinding) GetType() *plugin.TValue[string] {
+	return &c.Type
+}
+
+func (c *mqlAwsGuarddutyFinding) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
+}
+
+func (c *mqlAwsGuarddutyFinding) GetUpdatedAt() *plugin.TValue[*time.Time] {
+	return &c.UpdatedAt
 }
 
 // mqlAwsSecurityhub for the aws.securityhub resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -1897,7 +1897,7 @@ resources:
       type: {}
       updatedAt: {}
     is_private: true
-    min_mondoo_version: latest
+    min_mondoo_version: 9.0.0
     platform:
       name:
       - aws

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -1868,10 +1868,16 @@ resources:
       desc: |
         The `aws.guardduty.detector` resource provides fields for assessing the configuration of individual Amazon GuardDuty Detectors. For usage, read the `aws.guardduty` resource documentation
     fields:
+      features:
+        min_mondoo_version: 9.0.0
       findingPublishingFrequency: {}
+      findings:
+        min_mondoo_version: 9.0.0
       id: {}
       region: {}
       status: {}
+      tags:
+        min_mondoo_version: 9.0.0
       unarchivedFindings: {}
     is_private: true
     min_mondoo_version: 5.15.0

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -1838,6 +1838,8 @@ resources:
         Use the `aws.guardduty` resource to assess the configuration of the AWS GuardDuty service. The resource provides a list of `aws.guardduty.detector` resources representing GuardDuty Detectors deployed across all enabled regions.
     fields:
       detectors: {}
+      findings:
+        min_mondoo_version: 9.0.0
     min_mondoo_version: 5.15.0
     platform:
       name:
@@ -1873,6 +1875,23 @@ resources:
       unarchivedFindings: {}
     is_private: true
     min_mondoo_version: 5.15.0
+    platform:
+      name:
+      - aws
+  aws.guardduty.finding:
+    fields:
+      arn: {}
+      confidence: {}
+      createdAt: {}
+      description: {}
+      id: {}
+      region: {}
+      severity: {}
+      title: {}
+      type: {}
+      updatedAt: {}
+    is_private: true
+    min_mondoo_version: latest
     platform:
       name:
       - aws

--- a/providers/aws/resources/aws_guardduty.go
+++ b/providers/aws/resources/aws_guardduty.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/guardduty"
 	"github.com/aws/aws-sdk-go-v2/service/guardduty/types"
@@ -94,6 +95,31 @@ func (a *mqlAwsGuardduty) getDetectors(conn *connection.AwsConnection) []*jobpoo
 	return tasks
 }
 
+func initAwsGuarddutyDetector(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+
+	if args["id"] == nil && args["region"] == nil {
+		return nil, nil, errors.New("name and region required to fetch guardduty detector")
+	}
+
+	id := args["id"].Value.(string)
+	region := args["region"].Value.(string)
+	conn := runtime.Connection.(*connection.AwsConnection)
+
+	svc := conn.Guardduty(region)
+	ctx := context.Background()
+	detector, err := svc.GetDetector(ctx, &guardduty.GetDetectorInput{DetectorId: &id})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	args["status"] = llx.StringData(string(detector.Status))
+	args["findingPublishingFrequency"] = llx.StringData(string(detector.FindingPublishingFrequency))
+	return args, nil, nil
+}
+
 func (a *mqlAwsGuarddutyDetector) unarchivedFindings() ([]interface{}, error) {
 	id := a.Id.Data
 	region := a.Region.Data
@@ -122,27 +148,160 @@ func (a *mqlAwsGuarddutyDetector) unarchivedFindings() ([]interface{}, error) {
 	return convert.JsonToDictSlice(findingDetails.Findings)
 }
 
-func initAwsGuarddutyDetector(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	if len(args) > 2 {
-		return args, nil, nil
+func (a *mqlAwsGuardduty) findings() ([]interface{}, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+
+	// we need to retrieve all the detectors first and we group them by region to request all findings
+	detectorMap := map[string][]string{}
+	detectorList := a.GetDetectors()
+	for _, detector := range detectorList.Data {
+		detectorInstance, ok := detector.(*mqlAwsGuarddutyDetector)
+		if !ok {
+			return nil, errors.New("error casting to detector instance")
+		}
+
+		region := detectorInstance.GetRegion().Data
+		if detectorMap[region] == nil {
+			detectorMap[region] = []string{}
+		}
+
+		detectorMap[region] = append(detectorMap[region], detectorInstance.GetId().Data)
 	}
 
-	if args["id"] == nil && args["region"] == nil {
-		return nil, nil, errors.New("name and region required to fetch guardduty detector")
+	res := []interface{}{}
+	poolOfJobs := jobpool.CreatePool(a.listFindings(conn, detectorMap), 5)
+	poolOfJobs.Run()
+
+	// check for errors
+	if poolOfJobs.HasErrors() {
+		return nil, poolOfJobs.GetErrors()
 	}
+	// get all the results
+	for i := range poolOfJobs.Jobs {
+		res = append(res, poolOfJobs.Jobs[i].Result.([]interface{})...)
+	}
+	return res, nil
+}
 
-	id := args["id"].Value.(string)
-	region := args["region"].Value.(string)
-	conn := runtime.Connection.(*connection.AwsConnection)
-
-	svc := conn.Guardduty(region)
-	ctx := context.Background()
-	detector, err := svc.GetDetector(ctx, &guardduty.GetDetectorInput{DetectorId: &id})
+func (a *mqlAwsGuardduty) listFindings(conn *connection.AwsConnection, detectorMap map[string][]string) []*jobpool.Job {
+	tasks := make([]*jobpool.Job, 0)
+	regions, err := conn.Regions()
 	if err != nil {
-		return nil, nil, err
+		return []*jobpool.Job{{Err: err}}
 	}
 
-	args["status"] = llx.StringData(string(detector.Status))
-	args["findingPublishingFrequency"] = llx.StringData(string(detector.FindingPublishingFrequency))
-	return args, nil, nil
+	for _, region := range regions {
+		regionVal := region
+		f := func() (jobpool.JobResult, error) {
+			svc := conn.Guardduty(regionVal)
+
+			res := []interface{}{}
+			detectorList := detectorMap[regionVal]
+			for _, detectorId := range detectorList {
+				ctx := context.Background()
+
+				findingIds := []string{}
+				params := &guardduty.ListFindingsInput{
+					DetectorId: &detectorId,
+					FindingCriteria: &types.FindingCriteria{
+						Criterion: map[string]types.Condition{
+							"region": {
+								Equals: []string{regionVal},
+							},
+							"service.archived": {
+								Equals: []string{"false"},
+							},
+						},
+					},
+				}
+
+				nextToken := aws.String("no_token_to_start_with")
+				for nextToken != nil {
+					detectors, err := svc.ListFindings(ctx, params)
+					if err != nil {
+						if Is400AccessDeniedError(err) {
+							log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+							return nil, nil
+						}
+						return nil, err
+					}
+
+					findingIds = append(findingIds, detectors.FindingIds...)
+					nextToken = detectors.NextToken
+					// AWS returns empty string as pointer :-)
+					if nextToken != nil && *nextToken != "" {
+						params.NextToken = nextToken
+					} else {
+						nextToken = nil
+					}
+				}
+
+				// fetch all findings
+				findingDetails, err := svc.GetFindings(ctx, &guardduty.GetFindingsInput{
+					FindingIds: findingIds,
+					DetectorId: &detectorId,
+				})
+				if err != nil {
+					return nil, err
+				}
+
+				for _, finding := range findingDetails.Findings {
+					mqlFinding, err := newMqlAwsGuardDutyFinding(a.MqlRuntime, finding)
+					if err != nil {
+						return nil, err
+					}
+					res = append(res, mqlFinding)
+				}
+			}
+			return jobpool.JobResult(res), nil
+		}
+		tasks = append(tasks, jobpool.NewJob(f))
+	}
+	return tasks
+}
+
+func newMqlAwsGuardDutyFinding(runtime *plugin.Runtime, finding types.Finding) (*mqlAwsGuarddutyFinding, error) {
+	var severity float64
+	if finding.Severity != nil {
+		severity = *finding.Severity
+	}
+
+	var confidence float64
+	if finding.Confidence != nil {
+		confidence = *finding.Confidence
+	}
+
+	res, err := CreateResource(runtime, "aws.guardduty.finding", map[string]*llx.RawData{
+		"__id":        llx.StringDataPtr(finding.Arn),
+		"arn":         llx.StringDataPtr(finding.Arn),
+		"id":          llx.StringDataPtr(finding.Id),
+		"region":      llx.StringDataPtr(finding.Region),
+		"title":       llx.StringDataPtr(finding.Title),
+		"description": llx.StringDataPtr(finding.Description),
+		"severity":    llx.FloatData(severity),
+		"confidence":  llx.FloatData(confidence),
+		"type":        llx.StringDataPtr(finding.Type),
+		"createdAt":   llx.TimeDataPtr(parseAwsTimestampPtr(finding.CreatedAt)),
+		"updatedAt":   llx.TimeDataPtr(parseAwsTimestampPtr(finding.UpdatedAt)),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsGuarddutyFinding), nil
+}
+
+func parseAwsTimestampPtr(value *string) *time.Time {
+	if value == nil {
+		return nil
+	}
+	return parseAwsTimestamp(*value)
+}
+
+func parseAwsTimestamp(value string) *time.Time {
+	timestamp, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		log.Warn().Err(err).Str("timestamp", value).Msg("failed to parse timestamp")
+		return nil
+	}
+	return &timestamp
 }


### PR DESCRIPTION
**Speed up guard duty resource**

Instead of fetching all data during resource creation, we fetch the detector details only when we need it.

```coffeescript
cnquery> aws.guardduty.detectors
aws.guardduty.detectors: [
  0: aws.guardduty.detector id="b4c62d82c40ccf1edd2e6b6868a65872" region="ap-south-1"
  1: aws.guardduty.detector id="e6c62d82c19690d3d48422efa0d24e02" region="eu-north-1"
  2: aws.guardduty.detector id="a4c62d82c13dc4274e9de5a16b74aa40" region="eu-west-3"
  3: aws.guardduty.detector id="40c62d82c69edf8da843fa1f8a9a3839" region="eu-west-2"
...
```

**Use guard duty finding resource for detector**

Previously, we `aws.guardduty.detectors.first.unarchivedFindings` on the resource which was exposed as dict. This made it a bit more difficult than required to navigate. Therefore we introduced a new field to fetch the new `aws.guardduty.finding` resource. 

```coffeescript
cnquery> aws.guardduty.detectors.first.findings
aws.guardduty.detectors.first.findings: [
  0: aws.guardduty.finding title="The user AssumedRole : AWSReservedSSO_AdministratorAccess_fbe5db295482914d is anomalously invoking APIs commonly used in Discovery tactics." region="ap-south-1" severity=2
]
```

**Cross-region findings**

To easily see the guard duty results cross-region, we introduced a new resource `aws.guardduty.findings`. This fetches all findings from all regions simply list them out:

```coffeescript
cnquery> aws.guardduty.findings
aws.guardduty.findings: [
  0: aws.guardduty.finding title="The user AssumedRole : AWSReservedSSO_AdministratorAccess_fbe5db295482914d is anomalously invoking APIs commonly used in Discovery tactics." region="ap-south-1" severity=2
...
]
```