### PR TITLE
⭐️ extend microsoft entra id application resource to search for expiring credentials

### DIFF
--- a/providers/ms365/resources/applications.go
+++ b/providers/ms365/resources/applications.go
@@ -6,6 +6,9 @@ package resources
 import (
 	"context"
 	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/applications"
@@ -42,8 +45,57 @@ func (a *mqlMicrosoft) applications() ([]interface{}, error) {
 	return res, nil
 }
 
-// expiredCredentials returns true if any of the credentials of the application are expired
-func (a *mqlMicrosoftApplication) expiredCredentials() (bool, error) {
+func initMicrosoftApplication(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	// we only look up the package, if we have been supplied by its name and nothing else
+	raw, ok := args["name"]
+	if !ok || len(args) != 1 {
+		return args, nil, nil
+	}
+	name := raw.Value.(string)
+
+	conn := runtime.Connection.(*connection.Ms365Connection)
+	graphClient, err := conn.GraphClient()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// https://graph.microsoft.com/v1.0/servicePrincipals?$count=true&$search="displayName:teams"&$select=id,displayName
+	filter := fmt.Sprintf("displayName eq '%s'", url.QueryEscape(name))
+	ctx := context.Background()
+	resp, err := graphClient.Applications().Get(ctx, &applications.ApplicationsRequestBuilderGetRequestConfiguration{
+		QueryParameters: &applications.ApplicationsRequestBuilderGetQueryParameters{
+			Filter: &filter,
+		},
+	})
+	if err != nil {
+		return nil, nil, transformError(err)
+	}
+
+	val := resp.GetValue()
+	if len(val) == 0 {
+		return nil, nil, errors.New("application not found")
+	}
+
+	applicationId := val[0].GetId()
+	if applicationId == nil {
+		return nil, nil, errors.New("application id not found")
+	}
+
+	// https://graph.microsoft.com/v1.0/applications/{application-id}
+	app, err := graphClient.Applications().ByApplicationId(*applicationId).Get(ctx, &applications.ApplicationItemRequestBuilderGetRequestConfiguration{})
+	if err != nil {
+		return nil, nil, transformError(err)
+	}
+	mqlMsApp, err := newMqlMicrosoftApplication(runtime, app)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return nil, mqlMsApp, nil
+}
+
+// hasExpiredCredentials returns true if any of the credentials of the application are expired
+func (a *mqlMicrosoftApplication) hasExpiredCredentials() (bool, error) {
 	certificates := a.GetCertificates()
 	for _, val := range certificates.Data {
 		cert := val.(*mqlMicrosoftKeyCredential)
@@ -62,8 +114,8 @@ func (a *mqlMicrosoftApplication) expiredCredentials() (bool, error) {
 	return false, nil
 }
 
+// newMqlMicrosoftApplication creates a new mqlMicrosoftApplication resource
 func newMqlMicrosoftApplication(runtime *plugin.Runtime, app models.Applicationable) (*mqlMicrosoftApplication, error) {
-
 	info, _ := convert.JsonToDictSlice(app.GetInfo())
 
 	// certificates
@@ -95,6 +147,7 @@ func newMqlMicrosoftApplication(runtime *plugin.Runtime, app models.Applicationa
 			"createdDateTime": llx.TimeDataPtr(app.GetCreatedDateTime()),
 			"createdAt":       llx.TimeDataPtr(app.GetCreatedDateTime()),
 			"displayName":     llx.StringDataPtr(app.GetDisplayName()),
+			"name":            llx.StringDataPtr(app.GetDisplayName()),
 			"description":     llx.StringDataPtr(app.GetDescription()),
 			"notes":           llx.StringDataPtr(app.GetNotes()),
 			"publisherDomain": llx.StringDataPtr(app.GetPublisherDomain()),
@@ -111,6 +164,7 @@ func newMqlMicrosoftApplication(runtime *plugin.Runtime, app models.Applicationa
 	return mqlResource.(*mqlMicrosoftApplication), nil
 }
 
+// newMqlMicrosoftKeyCredential creates a new mqlMicrosoftKeyCredential resource
 func newMqlMicrosoftKeyCredential(runtime *plugin.Runtime, app models.KeyCredentialable) (*mqlMicrosoftKeyCredential, error) {
 	endDate := app.GetEndDateTime()
 	expired := true
@@ -135,6 +189,7 @@ func newMqlMicrosoftKeyCredential(runtime *plugin.Runtime, app models.KeyCredent
 	return mqlResource.(*mqlMicrosoftKeyCredential), nil
 }
 
+// newMqlMicrosoftPasswordCredential creates a new mqlMicrosoftPasswordCredential resource
 func newMqlMicrosoftPasswordCredential(runtime *plugin.Runtime, app models.PasswordCredentialable) (*mqlMicrosoftPasswordCredential, error) {
 	endDate := app.GetEndDateTime()
 	expired := true

--- a/providers/ms365/resources/applications.go
+++ b/providers/ms365/resources/applications.go
@@ -5,17 +5,17 @@ package resources
 
 import (
 	"context"
+	"encoding/base64"
+	"time"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/applications"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/convert"
 	"go.mondoo.com/cnquery/v11/providers/ms365/connection"
 	"go.mondoo.com/cnquery/v11/types"
 )
-
-func (m *mqlMicrosoftApplication) id() (string, error) {
-	return m.Id.Data, nil
-}
 
 func (a *mqlMicrosoft) applications() ([]interface{}, error) {
 	conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)
@@ -32,16 +32,7 @@ func (a *mqlMicrosoft) applications() ([]interface{}, error) {
 	res := []interface{}{}
 	apps := resp.GetValue()
 	for _, app := range apps {
-		mqlResource, err := CreateResource(a.MqlRuntime, "microsoft.application",
-			map[string]*llx.RawData{
-				"id":              llx.StringDataPtr(app.GetId()),
-				"appId":           llx.StringDataPtr(app.GetAppId()),
-				"createdDateTime": llx.TimeDataPtr(app.GetCreatedDateTime()),
-				"displayName":     llx.StringDataPtr(app.GetDisplayName()),
-				"publisherDomain": llx.StringDataPtr(app.GetPublisherDomain()),
-				"signInAudience":  llx.StringDataPtr(app.GetSignInAudience()),
-				"identifierUris":  llx.ArrayData(convert.SliceAnyToInterface(app.GetIdentifierUris()), types.String),
-			})
+		mqlResource, err := newMqlMicrosoftApplication(a.MqlRuntime, app)
 		if err != nil {
 			return nil, err
 		}
@@ -49,4 +40,119 @@ func (a *mqlMicrosoft) applications() ([]interface{}, error) {
 	}
 
 	return res, nil
+}
+
+// expiredCredentials returns true if any of the credentials of the application are expired
+func (a *mqlMicrosoftApplication) expiredCredentials() (bool, error) {
+	certificates := a.GetCertificates()
+	for _, val := range certificates.Data {
+		cert := val.(*mqlMicrosoftKeyCredential)
+		if cert.GetExpired().Data {
+			return true, nil
+		}
+	}
+
+	secrets := a.GetSecrets()
+	for _, val := range secrets.Data {
+		secret := val.(*mqlMicrosoftPasswordCredential)
+		if secret.GetExpired().Data {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func newMqlMicrosoftApplication(runtime *plugin.Runtime, app models.Applicationable) (*mqlMicrosoftApplication, error) {
+
+	info, _ := convert.JsonToDictSlice(app.GetInfo())
+
+	// certificates
+	var certificates []interface{}
+	keycredentials := app.GetKeyCredentials()
+	for _, keycredential := range keycredentials {
+		cert, err := newMqlMicrosoftKeyCredential(runtime, keycredential)
+		if err != nil {
+			return nil, err
+		}
+		certificates = append(certificates, cert)
+	}
+	// secrets
+	var secrets []interface{}
+	clientSecrets := app.GetPasswordCredentials()
+	for _, clientSecret := range clientSecrets {
+		secret, err := newMqlMicrosoftPasswordCredential(runtime, clientSecret)
+		if err != nil {
+			return nil, err
+		}
+		secrets = append(secrets, secret)
+	}
+
+	mqlResource, err := CreateResource(runtime, "microsoft.application",
+		map[string]*llx.RawData{
+			"__id":            llx.StringDataPtr(app.GetId()),
+			"id":              llx.StringDataPtr(app.GetId()),
+			"appId":           llx.StringDataPtr(app.GetAppId()),
+			"createdDateTime": llx.TimeDataPtr(app.GetCreatedDateTime()),
+			"createdAt":       llx.TimeDataPtr(app.GetCreatedDateTime()),
+			"displayName":     llx.StringDataPtr(app.GetDisplayName()),
+			"description":     llx.StringDataPtr(app.GetDescription()),
+			"notes":           llx.StringDataPtr(app.GetNotes()),
+			"publisherDomain": llx.StringDataPtr(app.GetPublisherDomain()),
+			"signInAudience":  llx.StringDataPtr(app.GetSignInAudience()),
+			"tags":            llx.ArrayData(convert.SliceAnyToInterface(app.GetTags()), types.String),
+			"identifierUris":  llx.ArrayData(convert.SliceAnyToInterface(app.GetIdentifierUris()), types.String),
+			"info":            llx.DictData(info),
+			"secrets":         llx.ArrayData(secrets, types.Resource("microsoft.passwordCredential")),
+			"certificates":    llx.ArrayData(certificates, types.Resource("microsoft.keyCredential")),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return mqlResource.(*mqlMicrosoftApplication), nil
+}
+
+func newMqlMicrosoftKeyCredential(runtime *plugin.Runtime, app models.KeyCredentialable) (*mqlMicrosoftKeyCredential, error) {
+	endDate := app.GetEndDateTime()
+	expired := true
+	if endDate != nil {
+		expired = endDate.Before(time.Now())
+	}
+
+	mqlResource, err := CreateResource(runtime, "microsoft.keyCredential",
+		map[string]*llx.RawData{
+			"__id":        llx.StringData(app.GetKeyId().String()),
+			"keyId":       llx.StringData(app.GetKeyId().String()),
+			"description": llx.StringDataPtr(app.GetDisplayName()),
+			"usage":       llx.StringDataPtr(app.GetUsage()),
+			"thumbprint":  llx.StringData(base64.StdEncoding.EncodeToString(app.GetCustomKeyIdentifier())),
+			"type":        llx.StringDataPtr(app.GetTypeEscaped()),
+			"expires":     llx.TimeDataPtr(endDate),
+			"expired":     llx.BoolData(expired),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return mqlResource.(*mqlMicrosoftKeyCredential), nil
+}
+
+func newMqlMicrosoftPasswordCredential(runtime *plugin.Runtime, app models.PasswordCredentialable) (*mqlMicrosoftPasswordCredential, error) {
+	endDate := app.GetEndDateTime()
+	expired := true
+	if endDate != nil {
+		expired = endDate.Before(time.Now())
+	}
+
+	mqlResource, err := CreateResource(runtime, "microsoft.passwordCredential",
+		map[string]*llx.RawData{
+			"__id":        llx.StringData(app.GetKeyId().String()),
+			"keyId":       llx.StringData(app.GetKeyId().String()),
+			"description": llx.StringDataPtr(app.GetDisplayName()),
+			"hint":        llx.StringDataPtr(app.GetHint()),
+			"expires":     llx.TimeDataPtr(endDate),
+			"expired":     llx.BoolData(expired),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return mqlResource.(*mqlMicrosoftPasswordCredential), nil
 }

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -162,7 +162,7 @@ private microsoft.domaindnsrecord @defaults("id label") {
   properties dict
 }
 
-// Microsoft application
+// Microsoft Entra ID application registration
 microsoft.application @defaults("id displayName hasExpiredCredentials") {
   init(name string)
   // Application ID
@@ -171,7 +171,7 @@ microsoft.application @defaults("id displayName hasExpiredCredentials") {
   appId string
   // Application display name
   name string
-  // Deprecated: Application display name use `name` instead
+  // Deprecated: Use `name` instead
   displayName string
   // Description
   description string
@@ -181,7 +181,7 @@ microsoft.application @defaults("id displayName hasExpiredCredentials") {
   tags []string
   // Application creation date
   createdAt time
-  // Deprecated: Application creation date use `createdAt` instead
+  // Deprecated: Use `createdAt` instead
   createdDateTime time
   // Application identifier URIs
   identifierUris []string
@@ -195,11 +195,11 @@ microsoft.application @defaults("id displayName hasExpiredCredentials") {
   secrets []microsoft.passwordCredential
   // Certificates
   certificates []microsoft.keyCredential
-  // Indicates assigned expired credentials
+  // Whether the credentials have expired
   hasExpiredCredentials() bool
 }
 
-// Certificate Secret
+// Microsoft Entra AD Application certificate
 private microsoft.keyCredential @defaults("thumbprint description expires keyId") {
   // Certificate ID
   keyId string
@@ -213,11 +213,11 @@ private microsoft.keyCredential @defaults("thumbprint description expires keyId"
   usage string
   // Certificate expiration date
   expires time
-  // Indicates expired secret
+  // Whether the secret has expired
   expired bool
 }
 
-// Password Secret
+// Microsoft Entra AD Application secrets
 private microsoft.passwordCredential @defaults("description expires keyId") {
   // Secret ID
   keyId string
@@ -227,7 +227,7 @@ private microsoft.passwordCredential @defaults("description expires keyId") {
   hint string
   // Secret expiration date
   expires time
-  // Indicates expired secret
+  // Whether the secret has expired
   expired bool
 }
 

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -163,21 +163,69 @@ private microsoft.domaindnsrecord @defaults("id label") {
 }
 
 // Microsoft application
-private microsoft.application @defaults("id displayName") {
+private microsoft.application @defaults("id displayName expiredCredentials") {
   // Application ID
   id string
   // Application app ID
   appId string
+  // Application display name
+  displayName string
+  // Description
+  description string
+  // Notes
+  notes string
+  // Tags
+  tags []string
   // Application creation date
+  createdAt time
+  // Deprecated: Application creation date use `createdAt` instead
   createdDateTime time
   // Application identifier URIs
   identifierUris []string
-  // Application display name
-  displayName string
   // Application publisher domain
   publisherDomain string
   // Application sign-in audience
   signInAudience string
+  // Basic profile information
+  info dict
+  // Client secrets
+  secrets []microsoft.passwordCredential
+  // Certificates
+  certificates []microsoft.keyCredential
+  // Indicates assigned expired credentials
+  expiredCredentials() bool
+}
+
+// Certificate Secret
+private microsoft.keyCredential @defaults("thumbprint description expires keyId") {
+  // Certificate ID
+  keyId string
+  // Description
+  description string
+  // Certificate thumbprint
+  thumbprint string
+  // Certificate type
+  type string
+  // Certificate usage
+  usage string
+  // Certificate expiration date
+  expires time
+  // Indicates if the secret is expired
+  expired bool
+}
+
+// Password Secret
+private microsoft.passwordCredential @defaults("description expires keyId") {
+  // Secret ID
+  keyId string
+  // Description
+  description string
+  // Secret hint
+  hint string
+  // Secret expiration date
+  expires time
+  // Indicates if the secret is expired
+  expired bool
 }
 
 // Microsoft service principal

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -163,12 +163,15 @@ private microsoft.domaindnsrecord @defaults("id label") {
 }
 
 // Microsoft application
-private microsoft.application @defaults("id displayName expiredCredentials") {
+microsoft.application @defaults("id displayName hasExpiredCredentials") {
+  init(name string)
   // Application ID
   id string
   // Application app ID
   appId string
   // Application display name
+  name string
+  // Deprecated: Application display name use `name` instead
   displayName string
   // Description
   description string
@@ -193,7 +196,7 @@ private microsoft.application @defaults("id displayName expiredCredentials") {
   // Certificates
   certificates []microsoft.keyCredential
   // Indicates assigned expired credentials
-  expiredCredentials() bool
+  hasExpiredCredentials() bool
 }
 
 // Certificate Secret
@@ -210,7 +213,7 @@ private microsoft.keyCredential @defaults("thumbprint description expires keyId"
   usage string
   // Certificate expiration date
   expires time
-  // Indicates if the secret is expired
+  // Indicates expired secret
   expired bool
 }
 
@@ -224,7 +227,7 @@ private microsoft.passwordCredential @defaults("description expires keyId") {
   hint string
   // Secret expiration date
   expires time
-  // Indicates if the secret is expired
+  // Indicates expired secret
   expired bool
 }
 

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -46,6 +46,14 @@ func init() {
 			// to override args, implement: initMicrosoftApplication(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMicrosoftApplication,
 		},
+		"microsoft.keyCredential": {
+			// to override args, implement: initMicrosoftKeyCredential(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createMicrosoftKeyCredential,
+		},
+		"microsoft.passwordCredential": {
+			// to override args, implement: initMicrosoftPasswordCredential(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createMicrosoftPasswordCredential,
+		},
 		"microsoft.serviceprincipal": {
 			// to override args, implement: initMicrosoftServiceprincipal(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMicrosoftServiceprincipal,
@@ -409,20 +417,80 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.application.appId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftApplication).GetAppId()).ToDataRes(types.String)
 	},
+	"microsoft.application.displayName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftApplication).GetDisplayName()).ToDataRes(types.String)
+	},
+	"microsoft.application.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftApplication).GetDescription()).ToDataRes(types.String)
+	},
+	"microsoft.application.notes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftApplication).GetNotes()).ToDataRes(types.String)
+	},
+	"microsoft.application.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftApplication).GetTags()).ToDataRes(types.Array(types.String))
+	},
+	"microsoft.application.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftApplication).GetCreatedAt()).ToDataRes(types.Time)
+	},
 	"microsoft.application.createdDateTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftApplication).GetCreatedDateTime()).ToDataRes(types.Time)
 	},
 	"microsoft.application.identifierUris": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftApplication).GetIdentifierUris()).ToDataRes(types.Array(types.String))
 	},
-	"microsoft.application.displayName": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlMicrosoftApplication).GetDisplayName()).ToDataRes(types.String)
-	},
 	"microsoft.application.publisherDomain": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftApplication).GetPublisherDomain()).ToDataRes(types.String)
 	},
 	"microsoft.application.signInAudience": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftApplication).GetSignInAudience()).ToDataRes(types.String)
+	},
+	"microsoft.application.info": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftApplication).GetInfo()).ToDataRes(types.Dict)
+	},
+	"microsoft.application.secrets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftApplication).GetSecrets()).ToDataRes(types.Array(types.Resource("microsoft.passwordCredential")))
+	},
+	"microsoft.application.certificates": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftApplication).GetCertificates()).ToDataRes(types.Array(types.Resource("microsoft.keyCredential")))
+	},
+	"microsoft.application.expiredCredentials": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftApplication).GetExpiredCredentials()).ToDataRes(types.Bool)
+	},
+	"microsoft.keyCredential.keyId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftKeyCredential).GetKeyId()).ToDataRes(types.String)
+	},
+	"microsoft.keyCredential.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftKeyCredential).GetDescription()).ToDataRes(types.String)
+	},
+	"microsoft.keyCredential.thumbprint": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftKeyCredential).GetThumbprint()).ToDataRes(types.String)
+	},
+	"microsoft.keyCredential.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftKeyCredential).GetType()).ToDataRes(types.String)
+	},
+	"microsoft.keyCredential.usage": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftKeyCredential).GetUsage()).ToDataRes(types.String)
+	},
+	"microsoft.keyCredential.expires": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftKeyCredential).GetExpires()).ToDataRes(types.Time)
+	},
+	"microsoft.keyCredential.expired": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftKeyCredential).GetExpired()).ToDataRes(types.Bool)
+	},
+	"microsoft.passwordCredential.keyId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftPasswordCredential).GetKeyId()).ToDataRes(types.String)
+	},
+	"microsoft.passwordCredential.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftPasswordCredential).GetDescription()).ToDataRes(types.String)
+	},
+	"microsoft.passwordCredential.hint": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftPasswordCredential).GetHint()).ToDataRes(types.String)
+	},
+	"microsoft.passwordCredential.expires": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftPasswordCredential).GetExpires()).ToDataRes(types.Time)
+	},
+	"microsoft.passwordCredential.expired": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftPasswordCredential).GetExpired()).ToDataRes(types.Bool)
 	},
 	"microsoft.serviceprincipal.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftServiceprincipal).GetId()).ToDataRes(types.String)
@@ -1124,6 +1192,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlMicrosoftApplication).AppId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"microsoft.application.displayName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftApplication).DisplayName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.application.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftApplication).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.application.notes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftApplication).Notes, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.application.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftApplication).Tags, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"microsoft.application.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftApplication).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"microsoft.application.createdDateTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftApplication).CreatedDateTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -1132,16 +1220,84 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlMicrosoftApplication).IdentifierUris, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
-	"microsoft.application.displayName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlMicrosoftApplication).DisplayName, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"microsoft.application.publisherDomain": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftApplication).PublisherDomain, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"microsoft.application.signInAudience": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftApplication).SignInAudience, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.application.info": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftApplication).Info, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
+		return
+	},
+	"microsoft.application.secrets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftApplication).Secrets, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"microsoft.application.certificates": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftApplication).Certificates, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"microsoft.application.expiredCredentials": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftApplication).ExpiredCredentials, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"microsoft.keyCredential.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlMicrosoftKeyCredential).__id, ok = v.Value.(string)
+			return
+		},
+	"microsoft.keyCredential.keyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftKeyCredential).KeyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.keyCredential.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftKeyCredential).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.keyCredential.thumbprint": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftKeyCredential).Thumbprint, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.keyCredential.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftKeyCredential).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.keyCredential.usage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftKeyCredential).Usage, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.keyCredential.expires": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftKeyCredential).Expires, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"microsoft.keyCredential.expired": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftKeyCredential).Expired, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"microsoft.passwordCredential.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlMicrosoftPasswordCredential).__id, ok = v.Value.(string)
+			return
+		},
+	"microsoft.passwordCredential.keyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftPasswordCredential).KeyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.passwordCredential.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftPasswordCredential).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.passwordCredential.hint": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftPasswordCredential).Hint, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.passwordCredential.expires": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftPasswordCredential).Expires, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"microsoft.passwordCredential.expired": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftPasswordCredential).Expired, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"microsoft.serviceprincipal.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2483,11 +2639,19 @@ type mqlMicrosoftApplication struct {
 	// optional: if you define mqlMicrosoftApplicationInternal it will be used here
 	Id plugin.TValue[string]
 	AppId plugin.TValue[string]
+	DisplayName plugin.TValue[string]
+	Description plugin.TValue[string]
+	Notes plugin.TValue[string]
+	Tags plugin.TValue[[]interface{}]
+	CreatedAt plugin.TValue[*time.Time]
 	CreatedDateTime plugin.TValue[*time.Time]
 	IdentifierUris plugin.TValue[[]interface{}]
-	DisplayName plugin.TValue[string]
 	PublisherDomain plugin.TValue[string]
 	SignInAudience plugin.TValue[string]
+	Info plugin.TValue[interface{}]
+	Secrets plugin.TValue[[]interface{}]
+	Certificates plugin.TValue[[]interface{}]
+	ExpiredCredentials plugin.TValue[bool]
 }
 
 // createMicrosoftApplication creates a new instance of this resource
@@ -2501,12 +2665,7 @@ func createMicrosoftApplication(runtime *plugin.Runtime, args map[string]*llx.Ra
 		return res, err
 	}
 
-	if res.__id == "" {
-	res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("microsoft.application", res.__id)
@@ -2535,6 +2694,26 @@ func (c *mqlMicrosoftApplication) GetAppId() *plugin.TValue[string] {
 	return &c.AppId
 }
 
+func (c *mqlMicrosoftApplication) GetDisplayName() *plugin.TValue[string] {
+	return &c.DisplayName
+}
+
+func (c *mqlMicrosoftApplication) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlMicrosoftApplication) GetNotes() *plugin.TValue[string] {
+	return &c.Notes
+}
+
+func (c *mqlMicrosoftApplication) GetTags() *plugin.TValue[[]interface{}] {
+	return &c.Tags
+}
+
+func (c *mqlMicrosoftApplication) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
+}
+
 func (c *mqlMicrosoftApplication) GetCreatedDateTime() *plugin.TValue[*time.Time] {
 	return &c.CreatedDateTime
 }
@@ -2543,16 +2722,168 @@ func (c *mqlMicrosoftApplication) GetIdentifierUris() *plugin.TValue[[]interface
 	return &c.IdentifierUris
 }
 
-func (c *mqlMicrosoftApplication) GetDisplayName() *plugin.TValue[string] {
-	return &c.DisplayName
-}
-
 func (c *mqlMicrosoftApplication) GetPublisherDomain() *plugin.TValue[string] {
 	return &c.PublisherDomain
 }
 
 func (c *mqlMicrosoftApplication) GetSignInAudience() *plugin.TValue[string] {
 	return &c.SignInAudience
+}
+
+func (c *mqlMicrosoftApplication) GetInfo() *plugin.TValue[interface{}] {
+	return &c.Info
+}
+
+func (c *mqlMicrosoftApplication) GetSecrets() *plugin.TValue[[]interface{}] {
+	return &c.Secrets
+}
+
+func (c *mqlMicrosoftApplication) GetCertificates() *plugin.TValue[[]interface{}] {
+	return &c.Certificates
+}
+
+func (c *mqlMicrosoftApplication) GetExpiredCredentials() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.ExpiredCredentials, func() (bool, error) {
+		return c.expiredCredentials()
+	})
+}
+
+// mqlMicrosoftKeyCredential for the microsoft.keyCredential resource
+type mqlMicrosoftKeyCredential struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlMicrosoftKeyCredentialInternal it will be used here
+	KeyId plugin.TValue[string]
+	Description plugin.TValue[string]
+	Thumbprint plugin.TValue[string]
+	Type plugin.TValue[string]
+	Usage plugin.TValue[string]
+	Expires plugin.TValue[*time.Time]
+	Expired plugin.TValue[bool]
+}
+
+// createMicrosoftKeyCredential creates a new instance of this resource
+func createMicrosoftKeyCredential(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMicrosoftKeyCredential{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("microsoft.keyCredential", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMicrosoftKeyCredential) MqlName() string {
+	return "microsoft.keyCredential"
+}
+
+func (c *mqlMicrosoftKeyCredential) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMicrosoftKeyCredential) GetKeyId() *plugin.TValue[string] {
+	return &c.KeyId
+}
+
+func (c *mqlMicrosoftKeyCredential) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlMicrosoftKeyCredential) GetThumbprint() *plugin.TValue[string] {
+	return &c.Thumbprint
+}
+
+func (c *mqlMicrosoftKeyCredential) GetType() *plugin.TValue[string] {
+	return &c.Type
+}
+
+func (c *mqlMicrosoftKeyCredential) GetUsage() *plugin.TValue[string] {
+	return &c.Usage
+}
+
+func (c *mqlMicrosoftKeyCredential) GetExpires() *plugin.TValue[*time.Time] {
+	return &c.Expires
+}
+
+func (c *mqlMicrosoftKeyCredential) GetExpired() *plugin.TValue[bool] {
+	return &c.Expired
+}
+
+// mqlMicrosoftPasswordCredential for the microsoft.passwordCredential resource
+type mqlMicrosoftPasswordCredential struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlMicrosoftPasswordCredentialInternal it will be used here
+	KeyId plugin.TValue[string]
+	Description plugin.TValue[string]
+	Hint plugin.TValue[string]
+	Expires plugin.TValue[*time.Time]
+	Expired plugin.TValue[bool]
+}
+
+// createMicrosoftPasswordCredential creates a new instance of this resource
+func createMicrosoftPasswordCredential(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMicrosoftPasswordCredential{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("microsoft.passwordCredential", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMicrosoftPasswordCredential) MqlName() string {
+	return "microsoft.passwordCredential"
+}
+
+func (c *mqlMicrosoftPasswordCredential) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMicrosoftPasswordCredential) GetKeyId() *plugin.TValue[string] {
+	return &c.KeyId
+}
+
+func (c *mqlMicrosoftPasswordCredential) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlMicrosoftPasswordCredential) GetHint() *plugin.TValue[string] {
+	return &c.Hint
+}
+
+func (c *mqlMicrosoftPasswordCredential) GetExpires() *plugin.TValue[*time.Time] {
+	return &c.Expires
+}
+
+func (c *mqlMicrosoftPasswordCredential) GetExpired() *plugin.TValue[bool] {
+	return &c.Expired
 }
 
 // mqlMicrosoftServiceprincipal for the microsoft.serviceprincipal resource

--- a/providers/ms365/resources/ms365.lr.manifest.yaml
+++ b/providers/ms365/resources/ms365.lr.manifest.yaml
@@ -158,7 +158,7 @@ resources:
       hint: {}
       keyId: {}
     is_private: true
-    min_mondoo_version: latest
+    min_mondoo_version: 9.0.0
   microsoft.policies:
     fields:
       adminConsentRequestPolicy: {}

--- a/providers/ms365/resources/ms365.lr.manifest.yaml
+++ b/providers/ms365/resources/ms365.lr.manifest.yaml
@@ -137,7 +137,7 @@ resources:
       type: {}
       usage: {}
     is_private: true
-    min_mondoo_version: latest
+    min_mondoo_version: 9.0.0
   microsoft.organization:
     fields:
       assignedPlans: {}

--- a/providers/ms365/resources/ms365.lr.manifest.yaml
+++ b/providers/ms365/resources/ms365.lr.manifest.yaml
@@ -19,12 +19,28 @@ resources:
   microsoft.application:
     fields:
       appId: {}
+      certificates:
+        min_mondoo_version: 9.0.0
+      createdAt:
+        min_mondoo_version: 9.0.0
       createdDateTime: {}
+      description:
+        min_mondoo_version: 9.0.0
       displayName: {}
+      expiredCredentials:
+        min_mondoo_version: 9.0.0
       id: {}
       identifierUris: {}
+      info:
+        min_mondoo_version: 9.0.0
+      notes:
+        min_mondoo_version: 9.0.0
       publisherDomain: {}
+      secrets:
+        min_mondoo_version: 9.0.0
       signInAudience: {}
+      tags:
+        min_mondoo_version: 9.0.0
     is_private: true
     min_mondoo_version: 5.15.0
   microsoft.devicemanagement:
@@ -108,6 +124,19 @@ resources:
         min_mondoo_version: 9.0.0
     is_private: true
     min_mondoo_version: 5.15.0
+  microsoft.keyCredential:
+    fields:
+      description: {}
+      displayName: {}
+      expired: {}
+      expires: {}
+      hint: {}
+      keyId: {}
+      thumbprint: {}
+      type: {}
+      usage: {}
+    is_private: true
+    min_mondoo_version: latest
   microsoft.organization:
     fields:
       assignedPlans: {}
@@ -119,6 +148,16 @@ resources:
       verifiedDomains: {}
     is_private: true
     min_mondoo_version: 5.15.0
+  microsoft.passwordCredential:
+    fields:
+      description: {}
+      displayName: {}
+      expired: {}
+      expires: {}
+      hint: {}
+      keyId: {}
+    is_private: true
+    min_mondoo_version: latest
   microsoft.policies:
     fields:
       adminConsentRequestPolicy: {}

--- a/providers/ms365/resources/ms365.lr.manifest.yaml
+++ b/providers/ms365/resources/ms365.lr.manifest.yaml
@@ -27,11 +27,13 @@ resources:
       description:
         min_mondoo_version: 9.0.0
       displayName: {}
-      expiredCredentials:
+      hasExpiredCredentials:
         min_mondoo_version: 9.0.0
       id: {}
       identifierUris: {}
       info:
+        min_mondoo_version: 9.0.0
+      name:
         min_mondoo_version: 9.0.0
       notes:
         min_mondoo_version: 9.0.0
@@ -41,7 +43,6 @@ resources:
       signInAudience: {}
       tags:
         min_mondoo_version: 9.0.0
-    is_private: true
     min_mondoo_version: 5.15.0
   microsoft.devicemanagement:
     fields:


### PR DESCRIPTION
This PR adds a new applicability to quickly identify expiring credentials for Microsoft Entra ID Application Registrations.

First we connect to our [Microsoft 365 account](https://mondoo.com/docs/cnspec/saas/ms365/#log-into-microsoft-365) via shell `cnspec shell ms365 --tenant-id bb22a034-d544-4b9e-a222-6a166840f64c`

**Quickly see all application in Entra ID**

Just type `microsoft.applications` and you see an overview of all applications and if the application has expired credentials.

```coffeescript
cnspec> microsoft.applications
microsoft.applications: [
  0: microsoft.application id="0030c47a-6318-431a-9f85-1b051484c7cf" displayName="chis-mac-testing" hasExpiredCredentials=true
]
cnspec>
```

**Verify an specific application has no expired credentials**

For applications it is essential that attached credentials are valid. This can easily be tested via: 

```coffeescript
cncnspec> microsoft.application(name: "chis-testing").hasExpiredCredentials
[ok] value: true
```

**List all application with expired credentials**

For operations, it is important to see easily all applications that have expired credentials. This can easily be achieved via:

```coffeescript
cnspec> microsoft.applications.none(hasExpiredCredentials)
[failed] [].none()
  actual:   [
    0: microsoft.application displayName="chis-mac-testing" id="0030c47a-6318-431a-9f85-1b051484c7cf" hasExpiredCredentials=true
  ]
```

**Ensure no client secrets are used**

To verify that no applications use client secrets run the following queries:

```coffeescript
cnspec> microsoft.applications.none(secrets != empty)
[failed] [].none()
  actual:   [
    0: microsoft.application displayName="chis-mac-testing" id="0030c47a-6318-431a-9f85-1b051484c7cf" hasExpiredCredentials=true {
      secrets: [
        0: microsoft.application microsoft.passwordCredential id = 0030c47a-6318-431a-9f85-1b051484c7cf
      ]
    }
  ]
``` 

**Application details**

We extended the details for applications:

```coffeescript
microsoft.application(name: "chis-mac-testing") { * }
microsoft.application: {
  appId: "0030c47a-6318-431a-9f85-1b051484c7cf"
  hasExpiredCredentials: true
  createdAt: 2022-10-08 20:47:57 +0200 CEST
  identifierUris: []
  tags: [
    0: "tag1"
  ]
  name: "chis-mac-testing"
  secrets: [
    0: microsoft.passwordCredential description="Password uploaded on Fri Jul 05 2024" expires=2025-01-01 10:37:17.872 +0100 CET keyId="0030c47a-6318-431a-9f85-1b051484c7cf"
  ]
  certificates: [
    0: microsoft.keyCredential thumbprint="1CECDD980A4F255D399E6C9625C13FBF872CD994" description="O=example, L=SF, S=CA, C=US" expires=2023-10-08 17:42:09 +0200 CEST keyId="8173c250-6909-47af-a56f-6332223eee1a"
  ]
  info: []
  publisherDomain: "exmple.onmicrosoft.com"
  notes: "internal notes"
  createdDateTime: 2022-10-08 20:47:57 +0200 CEST
  description: "description value"
  id: "0030c47a-6318-431a-9f85-1b051484c7cf"
}
```

