### PR TITLE
🧹 improve user resource handling in Microsoft 365

### DIFF
--- a/providers/ms365/resources/groups.go
+++ b/providers/ms365/resources/groups.go
@@ -5,11 +5,8 @@ package resources
 
 import (
 	"context"
-	"errors"
-
 	"github.com/microsoftgraph/msgraph-sdk-go/groups"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
-
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers/ms365/connection"
 	"go.mondoo.com/cnquery/v11/types"
@@ -20,7 +17,59 @@ func (m *mqlMicrosoftGroup) id() (string, error) {
 }
 
 func (a *mqlMicrosoftGroup) members() ([]interface{}, error) {
-	return nil, errors.New("not implemented")
+	msResource, err := a.MqlRuntime.CreateResource(a.MqlRuntime, "microsoft", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	mqlMicrsoftResource := msResource.(*mqlMicrosoft)
+
+	groupId := a.Id.Data
+	conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)
+	graphClient, err := conn.GraphClient()
+	if err != nil {
+		return nil, err
+	}
+	top := int32(200)
+
+	queryParams := &groups.ItemMembersRequestBuilderGetQueryParameters{
+		Top: &top,
+	}
+	ctx := context.Background()
+	resp, err := graphClient.Groups().ByGroupId(groupId).Members().Get(ctx, &groups.ItemMembersRequestBuilderGetRequestConfiguration{
+		QueryParameters: queryParams,
+	})
+	if err != nil {
+		return nil, transformError(err)
+	}
+
+	res := []interface{}{}
+	for _, member := range resp.GetValue() {
+		memberId := member.GetId()
+		if memberId == nil {
+			continue
+		}
+
+		if member.GetOdataType() != nil && *member.GetOdataType() != "#microsoft.graph.user" {
+			continue
+		}
+
+		// if the user is already indexed, we can reuse it
+		userResource, ok := mqlMicrsoftResource.userById(*memberId)
+		if ok {
+			res = append(res, userResource)
+			continue
+		}
+
+		newUserResource, err := a.MqlRuntime.NewResource(a.MqlRuntime, "microsoft.user", map[string]*llx.RawData{
+			"id": llx.StringDataPtr(memberId),
+		})
+		if err != nil {
+			return nil, err
+		}
+		mqlMicrsoftResource.index(newUserResource.(*mqlMicrosoftUser))
+		res = append(res, newUserResource)
+	}
+	return res, nil
 }
 
 func (a *mqlMicrosoft) groups() ([]interface{}, error) {

--- a/providers/ms365/resources/groups.go
+++ b/providers/ms365/resources/groups.go
@@ -54,7 +54,7 @@ func (a *mqlMicrosoftGroup) members() ([]interface{}, error) {
 		}
 
 		// if the user is already indexed, we can reuse it
-		userResource, ok := mqlMicrsoftResource.userById(*memberId)
+		userResource, ok := mqlMicrosoftResource.userById(*memberId)
 		if ok {
 			res = append(res, userResource)
 			continue
@@ -66,7 +66,7 @@ func (a *mqlMicrosoftGroup) members() ([]interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		mqlMicrsoftResource.index(newUserResource.(*mqlMicrosoftUser))
+		mqlMicrosoftResource.index(newUserResource.(*mqlMicrosoftUser))
 		res = append(res, newUserResource)
 	}
 	return res, nil

--- a/providers/ms365/resources/groups.go
+++ b/providers/ms365/resources/groups.go
@@ -21,7 +21,7 @@ func (a *mqlMicrosoftGroup) members() ([]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	mqlMicrsoftResource := msResource.(*mqlMicrosoft)
+	mqlMicrosoftResource := msResource.(*mqlMicrosoft)
 
 	groupId := a.Id.Data
 	conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)

--- a/providers/ms365/resources/microsoft.go
+++ b/providers/ms365/resources/microsoft.go
@@ -13,8 +13,6 @@ import (
 type mqlMicrosoftInternal struct {
 	// index users by id
 	idxUsersById map[string]*mqlMicrosoftUser
-	// index users by principal name
-	idxUsersByPrincipalName map[string]*mqlMicrosoftUser
 }
 
 // initIndex ensures the user indexes are initialized,
@@ -23,16 +21,12 @@ func (a *mqlMicrosoft) initIndex() {
 	if a.idxUsersById == nil {
 		a.idxUsersById = make(map[string]*mqlMicrosoftUser)
 	}
-	if a.idxUsersByPrincipalName == nil {
-		a.idxUsersByPrincipalName = make(map[string]*mqlMicrosoftUser)
-	}
 }
 
 // index adds a user to the internal indexes
 func (a *mqlMicrosoft) index(user *mqlMicrosoftUser) {
 	a.initIndex()
 	a.idxUsersById[user.Id.Data] = user
-	a.idxUsersByPrincipalName[user.UserPrincipalName.Data] = user
 }
 
 // userById returns a user by id if it exists in the index

--- a/providers/ms365/resources/microsoft.go
+++ b/providers/ms365/resources/microsoft.go
@@ -10,6 +10,41 @@ import (
 	"go.mondoo.com/cnquery/v11/providers/ms365/connection"
 )
 
+type mqlMicrosoftInternal struct {
+	// index users by id
+	idxUsersById map[string]*mqlMicrosoftUser
+	// index users by principal name
+	idxUsersByPrincipalName map[string]*mqlMicrosoftUser
+}
+
+// initIndex ensures the user indexes are initialized,
+// can be called multiple times without side effects
+func (a *mqlMicrosoft) initIndex() {
+	if a.idxUsersById == nil {
+		a.idxUsersById = make(map[string]*mqlMicrosoftUser)
+	}
+	if a.idxUsersByPrincipalName == nil {
+		a.idxUsersByPrincipalName = make(map[string]*mqlMicrosoftUser)
+	}
+}
+
+// index adds a user to the internal indexes
+func (a *mqlMicrosoft) index(user *mqlMicrosoftUser) {
+	a.initIndex()
+	a.idxUsersById[user.Id.Data] = user
+	a.idxUsersByPrincipalName[user.UserPrincipalName.Data] = user
+}
+
+// userById returns a user by id if it exists in the index
+func (a *mqlMicrosoft) userById(id string) (*mqlMicrosoftUser, bool) {
+	if a.idxUsersById == nil {
+		return nil, false
+	}
+
+	res, ok := a.idxUsersById[id]
+	return res, ok
+}
+
 func (a *mqlMicrosoft) tenantDomainName() (string, error) {
 	conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)
 	graphClient, err := conn.GraphClient()

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -42,8 +42,8 @@ private microsoft.organization @defaults("displayName") {
   onPremisesSyncEnabled bool
 }
 
-// Microsoft user
-private microsoft.user @defaults("id displayName mail") {
+// Microsoft Entra ID user
+private microsoft.user @defaults("id displayName userPrincipalName") {
   // User ID
   id string
   // Whether the user account is enabled
@@ -197,6 +197,8 @@ microsoft.application @defaults("id displayName hasExpiredCredentials") {
   certificates []microsoft.keyCredential
   // Whether the credentials have expired
   hasExpiredCredentials() bool
+  // Application owner
+  owners() []microsoft.user
 }
 
 // Microsoft Entra AD Application certificate

--- a/providers/ms365/resources/ms365.lr.manifest.yaml
+++ b/providers/ms365/resources/ms365.lr.manifest.yaml
@@ -38,7 +38,7 @@ resources:
       notes:
         min_mondoo_version: 9.0.0
       owners:
-        min_mondoo_version: latest
+        min_mondoo_version: 9.0.0
       publisherDomain: {}
       secrets:
         min_mondoo_version: 9.0.0

--- a/providers/ms365/resources/ms365.lr.manifest.yaml
+++ b/providers/ms365/resources/ms365.lr.manifest.yaml
@@ -37,6 +37,8 @@ resources:
         min_mondoo_version: 9.0.0
       notes:
         min_mondoo_version: 9.0.0
+      owners:
+        min_mondoo_version: latest
       publisherDomain: {}
       secrets:
         min_mondoo_version: 9.0.0

--- a/providers/ms365/resources/users.go
+++ b/providers/ms365/resources/users.go
@@ -5,17 +5,20 @@ package resources
 
 import (
 	"context"
-
+	"errors"
+	"fmt"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
 	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/convert"
 	"go.mondoo.com/cnquery/v11/providers/ms365/connection"
 	"go.mondoo.com/cnquery/v11/types"
 )
 
-func (m *mqlMicrosoftUser) id() (string, error) {
-	return m.Id.Data, nil
+var userSelectFields = []string{
+	"id", "accountEnabled", "city", "companyName", "country", "createdDateTime", "department", "displayName", "employeeId", "givenName",
+	"jobTitle", "mail", "mobilePhone", "otherMails", "officeLocation", "postalCode", "state", "streetAddress", "surname", "userPrincipalName", "userType",
 }
 
 func (a *mqlMicrosoft) users() ([]interface{}, error) {
@@ -25,16 +28,17 @@ func (a *mqlMicrosoft) users() ([]interface{}, error) {
 		return nil, err
 	}
 
-	selectFields := []string{
-		"id", "accountEnabled", "city", "companyName", "country", "createdDateTime", "department", "displayName", "employeeId", "givenName",
-		"jobTitle", "mail", "mobilePhone", "otherMails", "officeLocation", "postalCode", "state", "streetAddress", "surname", "userPrincipalName", "userType",
-	}
+	// fetch user data
 	ctx := context.Background()
 	top := int32(999)
-	resp, err := graphClient.Users().Get(ctx, &users.UsersRequestBuilderGetRequestConfiguration{QueryParameters: &users.UsersRequestBuilderGetQueryParameters{
-		Select: selectFields,
-		Top:    &top,
-	}})
+	resp, err := graphClient.Users().Get(
+		ctx, &users.UsersRequestBuilderGetRequestConfiguration{
+			QueryParameters: &users.UsersRequestBuilderGetQueryParameters{
+				Select: userSelectFields,
+				Top:    &top,
+			},
+		},
+	)
 	if err != nil {
 		return nil, transformError(err)
 	}
@@ -42,39 +46,120 @@ func (a *mqlMicrosoft) users() ([]interface{}, error) {
 	if err != nil {
 		return nil, transformError(err)
 	}
+
+	// construct the result
 	res := []interface{}{}
 	for _, u := range users {
-		graphUser, err := CreateResource(a.MqlRuntime, "microsoft.user",
-			map[string]*llx.RawData{
-				"id":                llx.StringDataPtr(u.GetId()),
-				"accountEnabled":    llx.BoolDataPtr(u.GetAccountEnabled()),
-				"city":              llx.StringDataPtr(u.GetCity()),
-				"companyName":       llx.StringDataPtr(u.GetCompanyName()),
-				"country":           llx.StringDataPtr(u.GetCountry()),
-				"createdDateTime":   llx.TimeDataPtr(u.GetCreatedDateTime()),
-				"department":        llx.StringDataPtr(u.GetDepartment()),
-				"displayName":       llx.StringDataPtr(u.GetDisplayName()),
-				"employeeId":        llx.StringDataPtr(u.GetEmployeeId()),
-				"givenName":         llx.StringDataPtr(u.GetGivenName()),
-				"jobTitle":          llx.StringDataPtr(u.GetJobTitle()),
-				"mail":              llx.StringDataPtr(u.GetMail()),
-				"mobilePhone":       llx.StringDataPtr(u.GetMobilePhone()),
-				"otherMails":        llx.ArrayData(llx.TArr2Raw(u.GetOtherMails()), types.String),
-				"officeLocation":    llx.StringDataPtr(u.GetOfficeLocation()),
-				"postalCode":        llx.StringDataPtr(u.GetPostalCode()),
-				"state":             llx.StringDataPtr(u.GetState()),
-				"streetAddress":     llx.StringDataPtr(u.GetStreetAddress()),
-				"surname":           llx.StringDataPtr(u.GetSurname()),
-				"userPrincipalName": llx.StringDataPtr(u.GetUserPrincipalName()),
-				"userType":          llx.StringDataPtr(u.GetUserType()),
-			})
+		graphUser, err := newMqlMicrosoftUser(a.MqlRuntime, u)
 		if err != nil {
 			return nil, err
 		}
+		// index users by id and principal name
+		a.index(graphUser)
 		res = append(res, graphUser)
 	}
 
 	return res, nil
+}
+
+func initMicrosoftUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	// we only look up the user if we have been supplied by id, displayName or userPrincipalName
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+
+	rawId, okId := args["id"]
+	rawDisplayName, okDisplayName := args["displayName"]
+	rawPrincipalName, okPrincipalName := args["userPrincipalName"]
+
+	if !okId && !okDisplayName && !okPrincipalName {
+		return args, nil, nil
+	}
+
+	var filter *string
+	if okId {
+		idFilter := fmt.Sprintf("id eq '%s'", rawId.Value.(string))
+		filter = &idFilter
+	} else if okPrincipalName {
+		principalNameFilter := fmt.Sprintf("userPrincipalName eq '%s'", rawPrincipalName.Value.(string))
+		filter = &principalNameFilter
+	} else if okDisplayName {
+		displayNameFilter := fmt.Sprintf("displayName eq '%s'", rawDisplayName.Value.(string))
+		filter = &displayNameFilter
+	}
+	if filter == nil {
+		return nil, nil, errors.New("no filter found")
+	}
+
+	conn := runtime.Connection.(*connection.Ms365Connection)
+	graphClient, err := conn.GraphClient()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ctx := context.Background()
+	resp, err := graphClient.Users().Get(ctx, &users.UsersRequestBuilderGetRequestConfiguration{
+		QueryParameters: &users.UsersRequestBuilderGetQueryParameters{
+			Filter: filter,
+		},
+	})
+	if err != nil {
+		return nil, nil, transformError(err)
+	}
+
+	val := resp.GetValue()
+	if len(val) == 0 {
+		return nil, nil, errors.New("user not found")
+	}
+
+	userId := val[0].GetId()
+	if userId == nil {
+		return nil, nil, errors.New("user id not found")
+	}
+
+	// fetch user by id
+	user, err := graphClient.Users().ByUserId(*userId).Get(ctx, &users.UserItemRequestBuilderGetRequestConfiguration{})
+	if err != nil {
+		return nil, nil, transformError(err)
+	}
+	mqlMsApp, err := newMqlMicrosoftUser(runtime, user)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return nil, mqlMsApp, nil
+}
+
+func newMqlMicrosoftUser(runtime *plugin.Runtime, u models.Userable) (*mqlMicrosoftUser, error) {
+	graphUser, err := CreateResource(runtime, "microsoft.user",
+		map[string]*llx.RawData{
+			"__id":              llx.StringDataPtr(u.GetId()),
+			"id":                llx.StringDataPtr(u.GetId()),
+			"accountEnabled":    llx.BoolDataPtr(u.GetAccountEnabled()),
+			"city":              llx.StringDataPtr(u.GetCity()),
+			"companyName":       llx.StringDataPtr(u.GetCompanyName()),
+			"country":           llx.StringDataPtr(u.GetCountry()),
+			"createdDateTime":   llx.TimeDataPtr(u.GetCreatedDateTime()),
+			"department":        llx.StringDataPtr(u.GetDepartment()),
+			"displayName":       llx.StringDataPtr(u.GetDisplayName()),
+			"employeeId":        llx.StringDataPtr(u.GetEmployeeId()),
+			"givenName":         llx.StringDataPtr(u.GetGivenName()),
+			"jobTitle":          llx.StringDataPtr(u.GetJobTitle()),
+			"mail":              llx.StringDataPtr(u.GetMail()),
+			"mobilePhone":       llx.StringDataPtr(u.GetMobilePhone()),
+			"otherMails":        llx.ArrayData(llx.TArr2Raw(u.GetOtherMails()), types.String),
+			"officeLocation":    llx.StringDataPtr(u.GetOfficeLocation()),
+			"postalCode":        llx.StringDataPtr(u.GetPostalCode()),
+			"state":             llx.StringDataPtr(u.GetState()),
+			"streetAddress":     llx.StringDataPtr(u.GetStreetAddress()),
+			"surname":           llx.StringDataPtr(u.GetSurname()),
+			"userPrincipalName": llx.StringDataPtr(u.GetUserPrincipalName()),
+			"userType":          llx.StringDataPtr(u.GetUserType()),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return graphUser.(*mqlMicrosoftUser), nil
 }
 
 func (a *mqlMicrosoftUser) settings() (interface{}, error) {


### PR DESCRIPTION
This PR improves the `microsoft.user` resource.

**Simpler init functions**

User can easily created by their object id and principal name now:

```javascript
cnspec> microsoft.user(userPrincipalName: "ben@example.onmicrosoft.com")
microsoft.user: microsoft.user id="a692f8ff-42e3-4156-8ac2-523379d9b664" displayName="Ben Rockwood" userPrincipalName="ben@example.onmicrosoft.com"
```

```javascript
cnspec> microsoft.user(id: "a692f8ff-42e3-4156-8ac2-523379d9b664")
microsoft.user: microsoft.user id="a692f8ff-42e3-4156-8ac2-523379d9b664" displayName="Ben Rockwood" userPrincipalName="ben@example.onmicrosoft.com"
```

**Retrieve owner for application registration**

We added a new `owners` field to `microsoft.application` which allows you to see all owners of your application:

```javascript
cnspec> microsoft.application(name: "chris-testing") { name owners }
microsoft.application: {
  name: "chris-testing"
  owners: [
    0: microsoft.user id="efd9e3d3-eb7a-46f6-a560-09a894e00fdd" displayName="Christoph Hartmann" userPrincipalName="chris@example.onmicrosoft.com"
  ]
}
```

**Group members**

For groups, I it is essential to see all members. This can easily done now via:

```javascript
cnspec> microsoft.groups { name members }
```