### PR TITLE
🧹 introduce a name field for vpc resource

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -52,6 +52,8 @@ private aws.vpc @defaults("id isDefault cidrBlock region") {
   arn string
   // ID of the VPC
   id string
+  // Name of the VPC
+  name string
   // IPv4 CIDR block of the VPC
   cidrBlock string
   // State of the VPC: pending or available

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -845,6 +845,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.vpc.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpc).GetId()).ToDataRes(types.String)
 	},
+	"aws.vpc.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpc).GetName()).ToDataRes(types.String)
+	},
 	"aws.vpc.cidrBlock": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpc).GetCidrBlock()).ToDataRes(types.String)
 	},
@@ -4619,6 +4622,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.vpc.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpc).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpc).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.cidrBlock": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10503,6 +10510,7 @@ type mqlAwsVpc struct {
 	// optional: if you define mqlAwsVpcInternal it will be used here
 	Arn plugin.TValue[string]
 	Id plugin.TValue[string]
+	Name plugin.TValue[string]
 	CidrBlock plugin.TValue[string]
 	State plugin.TValue[string]
 	IsDefault plugin.TValue[bool]
@@ -10561,6 +10569,10 @@ func (c *mqlAwsVpc) GetArn() *plugin.TValue[string] {
 
 func (c *mqlAwsVpc) GetId() *plugin.TValue[string] {
 	return &c.Id
+}
+
+func (c *mqlAwsVpc) GetName() *plugin.TValue[string] {
+	return &c.Name
 }
 
 func (c *mqlAwsVpc) GetCidrBlock() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2863,6 +2863,8 @@ resources:
       instanceTenancy:
         min_mondoo_version: 9.0.0
       isDefault: {}
+      name:
+        min_mondoo_version: 9.0.0
       natGateways:
         min_mondoo_version: 9.0.0
       peeringConnections:

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -77,11 +77,20 @@ func (a *mqlAws) getVpcs(conn *connection.AwsConnection) []*jobpool.Job {
 
 				for i := range vpcs.Vpcs {
 					v := vpcs.Vpcs[i]
-
+					name := ""
+					if v.Tags != nil {
+						for _, tag := range v.Tags {
+							if tag.Key != nil && *tag.Key == "Name" && tag.Value != nil {
+								name = *tag.Value
+								break
+							}
+						}
+					}
 					mqlVpc, err := CreateResource(a.MqlRuntime, "aws.vpc",
 						map[string]*llx.RawData{
 							"arn":             llx.StringData(fmt.Sprintf(vpcArnPattern, regionVal, conn.AccountId(), convert.ToString(v.VpcId))),
 							"id":              llx.StringDataPtr(v.VpcId),
+							"name":            llx.StringData(name),
 							"state":           llx.StringData(string(v.State)),
 							"isDefault":       llx.BoolData(convert.ToBool(v.IsDefault)),
 							"instanceTenancy": llx.StringData(string(v.InstanceTenancy)),


### PR DESCRIPTION
The name is encoded in the `Name` tag. Exposing this as a direct field makes it way more easier to access. For example you can now write a simple check that you should have other VPC than the default one:

```coffeescript
aws.vpcs.where(name != "Default VPC") != empty
```