### PR TITLE
🧹 simplify the `aws.rds` resource

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2014,10 +2014,14 @@ private aws.sqs.queue {
 
 // Amazon Relational Database Service (RDS)
 aws.rds {
-  // List of database instances
+  // Deprecated. Use `instances` instead
   dbInstances() []aws.rds.dbinstance
-  // List of RDS database clusters
+  // List of database instances
+  instances() []aws.rds.dbinstance
+  // Deprecated: Use `clusters` instead
   dbClusters() []aws.rds.dbcluster
+  // List of RDS database clusters
+  clusters() []aws.rds.dbcluster
 }
 
 // Amazon RDS Backup Setting

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -3053,8 +3053,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.dbInstances": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRds).GetDbInstances()).ToDataRes(types.Array(types.Resource("aws.rds.dbinstance")))
 	},
+	"aws.rds.instances": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRds).GetInstances()).ToDataRes(types.Array(types.Resource("aws.rds.dbinstance")))
+	},
 	"aws.rds.dbClusters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRds).GetDbClusters()).ToDataRes(types.Array(types.Resource("aws.rds.dbcluster")))
+	},
+	"aws.rds.clusters": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRds).GetClusters()).ToDataRes(types.Array(types.Resource("aws.rds.dbcluster")))
 	},
 	"aws.rds.backupsetting.target": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsBackupsetting).GetTarget()).ToDataRes(types.String)
@@ -8048,8 +8054,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsRds).DbInstances, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
+	"aws.rds.instances": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRds).Instances, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
 	"aws.rds.dbClusters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRds).DbClusters, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.rds.clusters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRds).Clusters, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
 	"aws.rds.backupsetting.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20757,7 +20771,9 @@ type mqlAwsRds struct {
 	__id string
 	// optional: if you define mqlAwsRdsInternal it will be used here
 	DbInstances plugin.TValue[[]interface{}]
+	Instances plugin.TValue[[]interface{}]
 	DbClusters plugin.TValue[[]interface{}]
+	Clusters plugin.TValue[[]interface{}]
 }
 
 // createAwsRds creates a new instance of this resource
@@ -20813,6 +20829,22 @@ func (c *mqlAwsRds) GetDbInstances() *plugin.TValue[[]interface{}] {
 	})
 }
 
+func (c *mqlAwsRds) GetInstances() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.Instances, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds", c.__id, "instances")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.instances()
+	})
+}
+
 func (c *mqlAwsRds) GetDbClusters() *plugin.TValue[[]interface{}] {
 	return plugin.GetOrCompute[[]interface{}](&c.DbClusters, func() ([]interface{}, error) {
 		if c.MqlRuntime.HasRecording {
@@ -20826,6 +20858,22 @@ func (c *mqlAwsRds) GetDbClusters() *plugin.TValue[[]interface{}] {
 		}
 
 		return c.dbClusters()
+	})
+}
+
+func (c *mqlAwsRds) GetClusters() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.Clusters, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds", c.__id, "clusters")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.clusters()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2258,8 +2258,12 @@ resources:
       desc: |
         Use the `aws.rds` resource to assess the configuration of AWS RDS deployments. The resource returns lists of `aws.rds.dbcluster`, `aws.rds.dbinstance`, and `aws.rds.snapshot` resources, each with fields for assessing the configuration of those assets.
     fields:
+      clusters:
+        min_mondoo_version: 9.0.0
       dbClusters: {}
       dbInstances: {}
+      instances:
+        min_mondoo_version: 9.0.0
     min_mondoo_version: 5.15.0
     platform:
       name:

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -27,7 +27,13 @@ func (a *mqlAwsRds) id() (string, error) {
 	return "aws.rds", nil
 }
 
+// Deprecated: use instances() instead
 func (a *mqlAwsRds) dbInstances() ([]interface{}, error) {
+	return a.instances()
+}
+
+// instances returns all RDS instances
+func (a *mqlAwsRds) instances() ([]interface{}, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	res := []interface{}{}
 	poolOfJobs := jobpool.CreatePool(a.getDbInstances(conn), 5)
@@ -180,7 +186,13 @@ func rdsTagsToMap(tags []rdstypes.Tag) map[string]interface{} {
 	return tagsMap
 }
 
+// Deprecated: use clusters() instead
 func (a *mqlAwsRds) dbClusters() ([]interface{}, error) {
+	return a.clusters()
+}
+
+// clusters returns all RDS clusters
+func (a *mqlAwsRds) clusters() ([]interface{}, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	res := []interface{}{}
 	poolOfJobs := jobpool.CreatePool(a.getDbClusters(conn), 5)


### PR DESCRIPTION
With this change it is easier to access the resources in the `aws.rds` namespace.

- rename `aws.rds.dbInstances` to `aws.rds.instances`
- rename `aws.rds.dbClusters` to `aws.rds.clusters`

Everything stays backwards compatible. `aws.rds.dbInstances` and  `aws.rds.dbClusters` will be removed in the next major version.