### PR TITLE
⭐️ improve rds resource

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -31,6 +31,7 @@ exo
 gcfs
 gcs
 geomatchstatement
+gibibytes
 gistfile
 gpu
 gvnic

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2126,6 +2126,8 @@ private aws.rds.dbcluster @defaults("id region") {
   activityStreamStatus string
   // Interval, in seconds, between points when Enhanced Monitoring metrics are collected
   monitoringInterval int
+  // Network type of the DB instance
+  networkType string
 }
 
 // Amazon RDS snapshot
@@ -2240,6 +2242,8 @@ private aws.rds.dbinstance @defaults("id region engine engineVersion") {
   activityStreamStatus string
   // List of pending maintenance actions for the database instance
   pendingMaintenanceActions() []aws.rds.pendingMaintenanceAction
+  // Network type of the DB instance
+  networkType string
 }
 
 // Amazon RDS pending maintenance action

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2026,6 +2026,8 @@ aws.rds {
   dbClusters() []aws.rds.dbcluster
   // List of RDS database clusters
   clusters() []aws.rds.dbcluster
+  // List of pending maintenance actions for the database instance
+  pendingMaintenanceActions() []aws.rds.pendingMaintenanceAction
 }
 
 // Amazon RDS Backup Setting
@@ -2232,6 +2234,26 @@ private aws.rds.dbinstance @defaults("id region engine engineVersion") {
   activityStreamMode string
   // Status of the database activity stream
   activityStreamStatus string
+  // List of pending maintenance actions for the database instance
+  pendingMaintenanceActions() []aws.rds.pendingMaintenanceAction
+}
+
+// Amazon RDS pending maintenance action
+private aws.rds.pendingMaintenanceAction {
+  // ARN for resource
+  resourceArn string
+  // Action to take
+  action string
+  // Description of the action
+  description string
+  // Auto applied after date
+  autoAppliedAfterDate time
+  // Current apply date
+  currentApplyDate time
+  // Forced apply date
+  forcedApplyDate time
+  // Opt-in status
+  optInStatus string
 }
 
 // Amazon ElastiCache

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2124,6 +2124,8 @@ private aws.rds.dbcluster @defaults("id region") {
   activityStreamMode string
   // Status of the database activity stream
   activityStreamStatus string
+  // Interval, in seconds, between points when Enhanced Monitoring metrics are collected
+  monitoringInterval int
 }
 
 // Amazon RDS snapshot
@@ -2160,6 +2162,8 @@ private aws.rds.snapshot @defaults("id region type encrypted createdAt") {
 private aws.rds.dbinstance @defaults("id region engine engineVersion") {
   // ARN for the database instance
   arn string
+  // Identifier for the database instance
+  id string
   // Name of the database instance
   name string
   // Number of days for which automated snapshots are retained
@@ -2186,8 +2190,8 @@ private aws.rds.dbinstance @defaults("id region engine engineVersion") {
   deletionProtection bool
   // Whether the instance is a Multi-AZ deployment
   multiAZ bool
-  // Identifier for the database instance
-  id string
+  // Interval, in seconds, between points when Enhanced Monitoring metrics are collected
+  monitoringInterval int
   // ARN of the CloudWatch log stream that receives the enhanced monitoring metrics data
   enhancedMonitoringResourceArn string
   // Tags for the database instance

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2112,6 +2112,16 @@ private aws.rds.dbcluster @defaults("id region") {
   backupSettings() []aws.rds.backupsetting
   // The life cycle type for the database engine. By default, this value is set to `open-source-rds-extended-support`, which enrolls your DB engine into Amazon RDS Extended Support. At the end of standard support, you can avoid charges for Extended Support by setting the value to `open-source-rds-extended-support-disabled`. In this case, creating the DB engine will fail if the DB major version is past its end of standard support date.
   engineLifecycleSupport string
+  // Expiration date for the instance certificate
+  certificateExpiresAt time
+  // ID of the Certificate Authority
+  certificateAuthority string
+  // Whether IAM database authentication is enabled
+  iamDatabaseAuthentication bool
+  // Mode of the database activity stream
+  activityStreamMode string
+  // Status of the database activity stream
+  activityStreamStatus string
 }
 
 // Amazon RDS snapshot
@@ -2210,6 +2220,18 @@ private aws.rds.dbinstance @defaults("id region engine engineVersion") {
   subnets() []aws.vpc.subnet
   // The life cycle type for the database engine. By default, this value is set to `open-source-rds-extended-support`, which enrolls your DB engine into Amazon RDS Extended Support. At the end of standard support, you can avoid charges for Extended Support by setting the value to `open-source-rds-extended-support-disabled`. In this case, creating the DB engine will fail if the DB major version is past its end of standard support date.
   engineLifecycleSupport string
+  // Expiration date for the instance certificate
+  certificateExpiresAt time
+  // ID of the Certificate Authority
+  certificateAuthority string
+  // Whether IAM database authentication is enabled
+  iamDatabaseAuthentication bool
+  // Assigned IAM instance profile
+  customIamInstanceProfile string
+  // Mode of the database activity stream
+  activityStreamMode string
+  // Status of the database activity stream
+  activityStreamStatus string
 }
 
 // Amazon ElastiCache

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2026,8 +2026,8 @@ aws.rds {
   dbClusters() []aws.rds.dbcluster
   // List of RDS database clusters
   clusters() []aws.rds.dbcluster
-  // List of pending maintenance actions for the database instance
-  pendingMaintenanceActions() []aws.rds.pendingMaintenanceAction
+  // List of all pending maintenance actions for the database instance
+  allPendingMaintenanceActions() []aws.rds.pendingMaintenanceAction
 }
 
 // Amazon RDS Backup Setting
@@ -2156,6 +2156,8 @@ private aws.rds.snapshot @defaults("id region type encrypted createdAt") {
   status string
   // The port that the database instance or cluster listens on
   port int
+  // Allocated storage size in gibibytes (GiB)
+  allocatedStorage int
   // The creation date of the snapshot
   createdAt time
 }

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -3219,6 +3219,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.dbcluster.activityStreamStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbcluster).GetActivityStreamStatus()).ToDataRes(types.String)
 	},
+	"aws.rds.dbcluster.monitoringInterval": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetMonitoringInterval()).ToDataRes(types.Int)
+	},
 	"aws.rds.snapshot.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsSnapshot).GetArn()).ToDataRes(types.String)
 	},
@@ -3261,6 +3264,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.dbinstance.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbinstance).GetArn()).ToDataRes(types.String)
 	},
+	"aws.rds.dbinstance.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetId()).ToDataRes(types.String)
+	},
 	"aws.rds.dbinstance.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbinstance).GetName()).ToDataRes(types.String)
 	},
@@ -3300,8 +3306,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.dbinstance.multiAZ": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbinstance).GetMultiAZ()).ToDataRes(types.Bool)
 	},
-	"aws.rds.dbinstance.id": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsRdsDbinstance).GetId()).ToDataRes(types.String)
+	"aws.rds.dbinstance.monitoringInterval": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetMonitoringInterval()).ToDataRes(types.Int)
 	},
 	"aws.rds.dbinstance.enhancedMonitoringResourceArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbinstance).GetEnhancedMonitoringResourceArn()).ToDataRes(types.String)
@@ -8524,6 +8530,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsRdsDbcluster).ActivityStreamStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.rds.dbcluster.monitoringInterval": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).MonitoringInterval, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
 	"aws.rds.snapshot.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 			r.(*mqlAwsRdsSnapshot).__id, ok = v.Value.(string)
 			return
@@ -8588,6 +8598,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsRdsDbinstance).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.rds.dbinstance.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.rds.dbinstance.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsDbinstance).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -8640,8 +8654,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsRdsDbinstance).MultiAZ, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"aws.rds.dbinstance.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsRdsDbinstance).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+	"aws.rds.dbinstance.monitoringInterval": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).MonitoringInterval, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"aws.rds.dbinstance.enhancedMonitoringResourceArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21655,6 +21669,7 @@ type mqlAwsRdsDbcluster struct {
 	IamDatabaseAuthentication plugin.TValue[bool]
 	ActivityStreamMode plugin.TValue[string]
 	ActivityStreamStatus plugin.TValue[string]
+	MonitoringInterval plugin.TValue[int64]
 }
 
 // createAwsRdsDbcluster creates a new instance of this resource
@@ -21854,6 +21869,10 @@ func (c *mqlAwsRdsDbcluster) GetActivityStreamStatus() *plugin.TValue[string] {
 	return &c.ActivityStreamStatus
 }
 
+func (c *mqlAwsRdsDbcluster) GetMonitoringInterval() *plugin.TValue[int64] {
+	return &c.MonitoringInterval
+}
+
 // mqlAwsRdsSnapshot for the aws.rds.snapshot resource
 type mqlAwsRdsSnapshot struct {
 	MqlRuntime *plugin.Runtime
@@ -21971,6 +21990,7 @@ type mqlAwsRdsDbinstance struct {
 	__id string
 	mqlAwsRdsDbinstanceInternal
 	Arn plugin.TValue[string]
+	Id plugin.TValue[string]
 	Name plugin.TValue[string]
 	BackupRetentionPeriod plugin.TValue[int64]
 	Snapshots plugin.TValue[[]interface{}]
@@ -21984,7 +22004,7 @@ type mqlAwsRdsDbinstance struct {
 	EnabledCloudwatchLogsExports plugin.TValue[[]interface{}]
 	DeletionProtection plugin.TValue[bool]
 	MultiAZ plugin.TValue[bool]
-	Id plugin.TValue[string]
+	MonitoringInterval plugin.TValue[int64]
 	EnhancedMonitoringResourceArn plugin.TValue[string]
 	Tags plugin.TValue[map[string]interface{}]
 	DbInstanceClass plugin.TValue[string]
@@ -22052,6 +22072,10 @@ func (c *mqlAwsRdsDbinstance) GetArn() *plugin.TValue[string] {
 	return &c.Arn
 }
 
+func (c *mqlAwsRdsDbinstance) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
 func (c *mqlAwsRdsDbinstance) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
@@ -22116,8 +22140,8 @@ func (c *mqlAwsRdsDbinstance) GetMultiAZ() *plugin.TValue[bool] {
 	return &c.MultiAZ
 }
 
-func (c *mqlAwsRdsDbinstance) GetId() *plugin.TValue[string] {
-	return &c.Id
+func (c *mqlAwsRdsDbinstance) GetMonitoringInterval() *plugin.TValue[int64] {
+	return &c.MonitoringInterval
 }
 
 func (c *mqlAwsRdsDbinstance) GetEnhancedMonitoringResourceArn() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -3222,6 +3222,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.dbcluster.monitoringInterval": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbcluster).GetMonitoringInterval()).ToDataRes(types.Int)
 	},
+	"aws.rds.dbcluster.networkType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetNetworkType()).ToDataRes(types.String)
+	},
 	"aws.rds.snapshot.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsSnapshot).GetArn()).ToDataRes(types.String)
 	},
@@ -3380,6 +3383,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.rds.dbinstance.pendingMaintenanceActions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbinstance).GetPendingMaintenanceActions()).ToDataRes(types.Array(types.Resource("aws.rds.pendingMaintenanceAction")))
+	},
+	"aws.rds.dbinstance.networkType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetNetworkType()).ToDataRes(types.String)
 	},
 	"aws.rds.pendingMaintenanceAction.resourceArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsPendingMaintenanceAction).GetResourceArn()).ToDataRes(types.String)
@@ -8534,6 +8540,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsRdsDbcluster).MonitoringInterval, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
+	"aws.rds.dbcluster.networkType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).NetworkType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.rds.snapshot.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 			r.(*mqlAwsRdsSnapshot).__id, ok = v.Value.(string)
 			return
@@ -8752,6 +8762,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.rds.dbinstance.pendingMaintenanceActions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsDbinstance).PendingMaintenanceActions, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.networkType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).NetworkType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.rds.pendingMaintenanceAction.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21670,6 +21684,7 @@ type mqlAwsRdsDbcluster struct {
 	ActivityStreamMode plugin.TValue[string]
 	ActivityStreamStatus plugin.TValue[string]
 	MonitoringInterval plugin.TValue[int64]
+	NetworkType plugin.TValue[string]
 }
 
 // createAwsRdsDbcluster creates a new instance of this resource
@@ -21873,6 +21888,10 @@ func (c *mqlAwsRdsDbcluster) GetMonitoringInterval() *plugin.TValue[int64] {
 	return &c.MonitoringInterval
 }
 
+func (c *mqlAwsRdsDbcluster) GetNetworkType() *plugin.TValue[string] {
+	return &c.NetworkType
+}
+
 // mqlAwsRdsSnapshot for the aws.rds.snapshot resource
 type mqlAwsRdsSnapshot struct {
 	MqlRuntime *plugin.Runtime
@@ -22029,6 +22048,7 @@ type mqlAwsRdsDbinstance struct {
 	ActivityStreamMode plugin.TValue[string]
 	ActivityStreamStatus plugin.TValue[string]
 	PendingMaintenanceActions plugin.TValue[[]interface{}]
+	NetworkType plugin.TValue[string]
 }
 
 // createAwsRdsDbinstance creates a new instance of this resource
@@ -22274,6 +22294,10 @@ func (c *mqlAwsRdsDbinstance) GetPendingMaintenanceActions() *plugin.TValue[[]in
 
 		return c.pendingMaintenanceActions()
 	})
+}
+
+func (c *mqlAwsRdsDbinstance) GetNetworkType() *plugin.TValue[string] {
+	return &c.NetworkType
 }
 
 // mqlAwsRdsPendingMaintenanceAction for the aws.rds.pendingMaintenanceAction resource

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -3197,6 +3197,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.dbcluster.engineLifecycleSupport": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbcluster).GetEngineLifecycleSupport()).ToDataRes(types.String)
 	},
+	"aws.rds.dbcluster.certificateExpiresAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetCertificateExpiresAt()).ToDataRes(types.Time)
+	},
+	"aws.rds.dbcluster.certificateAuthority": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetCertificateAuthority()).ToDataRes(types.String)
+	},
+	"aws.rds.dbcluster.iamDatabaseAuthentication": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetIamDatabaseAuthentication()).ToDataRes(types.Bool)
+	},
+	"aws.rds.dbcluster.activityStreamMode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetActivityStreamMode()).ToDataRes(types.String)
+	},
+	"aws.rds.dbcluster.activityStreamStatus": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetActivityStreamStatus()).ToDataRes(types.String)
+	},
 	"aws.rds.snapshot.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsSnapshot).GetArn()).ToDataRes(types.String)
 	},
@@ -3331,6 +3346,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.rds.dbinstance.engineLifecycleSupport": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbinstance).GetEngineLifecycleSupport()).ToDataRes(types.String)
+	},
+	"aws.rds.dbinstance.certificateExpiresAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetCertificateExpiresAt()).ToDataRes(types.Time)
+	},
+	"aws.rds.dbinstance.certificateAuthority": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetCertificateAuthority()).ToDataRes(types.String)
+	},
+	"aws.rds.dbinstance.iamDatabaseAuthentication": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetIamDatabaseAuthentication()).ToDataRes(types.Bool)
+	},
+	"aws.rds.dbinstance.customIamInstanceProfile": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetCustomIamInstanceProfile()).ToDataRes(types.String)
+	},
+	"aws.rds.dbinstance.activityStreamMode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetActivityStreamMode()).ToDataRes(types.String)
+	},
+	"aws.rds.dbinstance.activityStreamStatus": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetActivityStreamStatus()).ToDataRes(types.String)
 	},
 	"aws.elasticache.clusters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticache).GetClusters()).ToDataRes(types.Array(types.Dict))
@@ -8436,6 +8469,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsRdsDbcluster).EngineLifecycleSupport, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.rds.dbcluster.certificateExpiresAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).CertificateExpiresAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.certificateAuthority": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).CertificateAuthority, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.iamDatabaseAuthentication": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).IamDatabaseAuthentication, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.activityStreamMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).ActivityStreamMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.activityStreamStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).ActivityStreamStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.rds.snapshot.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 			r.(*mqlAwsRdsSnapshot).__id, ok = v.Value.(string)
 			return
@@ -8622,6 +8675,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.rds.dbinstance.engineLifecycleSupport": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsDbinstance).EngineLifecycleSupport, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.certificateExpiresAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).CertificateExpiresAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.certificateAuthority": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).CertificateAuthority, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.iamDatabaseAuthentication": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).IamDatabaseAuthentication, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.customIamInstanceProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).CustomIamInstanceProfile, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.activityStreamMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).ActivityStreamMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.activityStreamStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).ActivityStreamStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.elasticache.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21485,6 +21562,11 @@ type mqlAwsRdsDbcluster struct {
 	LatestRestorableTime plugin.TValue[*time.Time]
 	BackupSettings plugin.TValue[[]interface{}]
 	EngineLifecycleSupport plugin.TValue[string]
+	CertificateExpiresAt plugin.TValue[*time.Time]
+	CertificateAuthority plugin.TValue[string]
+	IamDatabaseAuthentication plugin.TValue[bool]
+	ActivityStreamMode plugin.TValue[string]
+	ActivityStreamStatus plugin.TValue[string]
 }
 
 // createAwsRdsDbcluster creates a new instance of this resource
@@ -21664,6 +21746,26 @@ func (c *mqlAwsRdsDbcluster) GetEngineLifecycleSupport() *plugin.TValue[string] 
 	return &c.EngineLifecycleSupport
 }
 
+func (c *mqlAwsRdsDbcluster) GetCertificateExpiresAt() *plugin.TValue[*time.Time] {
+	return &c.CertificateExpiresAt
+}
+
+func (c *mqlAwsRdsDbcluster) GetCertificateAuthority() *plugin.TValue[string] {
+	return &c.CertificateAuthority
+}
+
+func (c *mqlAwsRdsDbcluster) GetIamDatabaseAuthentication() *plugin.TValue[bool] {
+	return &c.IamDatabaseAuthentication
+}
+
+func (c *mqlAwsRdsDbcluster) GetActivityStreamMode() *plugin.TValue[string] {
+	return &c.ActivityStreamMode
+}
+
+func (c *mqlAwsRdsDbcluster) GetActivityStreamStatus() *plugin.TValue[string] {
+	return &c.ActivityStreamStatus
+}
+
 // mqlAwsRdsSnapshot for the aws.rds.snapshot resource
 type mqlAwsRdsSnapshot struct {
 	MqlRuntime *plugin.Runtime
@@ -21812,6 +21914,12 @@ type mqlAwsRdsDbinstance struct {
 	BackupSettings plugin.TValue[[]interface{}]
 	Subnets plugin.TValue[[]interface{}]
 	EngineLifecycleSupport plugin.TValue[string]
+	CertificateExpiresAt plugin.TValue[*time.Time]
+	CertificateAuthority plugin.TValue[string]
+	IamDatabaseAuthentication plugin.TValue[bool]
+	CustomIamInstanceProfile plugin.TValue[string]
+	ActivityStreamMode plugin.TValue[string]
+	ActivityStreamStatus plugin.TValue[string]
 }
 
 // createAwsRdsDbinstance creates a new instance of this resource
@@ -22013,6 +22121,30 @@ func (c *mqlAwsRdsDbinstance) GetSubnets() *plugin.TValue[[]interface{}] {
 
 func (c *mqlAwsRdsDbinstance) GetEngineLifecycleSupport() *plugin.TValue[string] {
 	return &c.EngineLifecycleSupport
+}
+
+func (c *mqlAwsRdsDbinstance) GetCertificateExpiresAt() *plugin.TValue[*time.Time] {
+	return &c.CertificateExpiresAt
+}
+
+func (c *mqlAwsRdsDbinstance) GetCertificateAuthority() *plugin.TValue[string] {
+	return &c.CertificateAuthority
+}
+
+func (c *mqlAwsRdsDbinstance) GetIamDatabaseAuthentication() *plugin.TValue[bool] {
+	return &c.IamDatabaseAuthentication
+}
+
+func (c *mqlAwsRdsDbinstance) GetCustomIamInstanceProfile() *plugin.TValue[string] {
+	return &c.CustomIamInstanceProfile
+}
+
+func (c *mqlAwsRdsDbinstance) GetActivityStreamMode() *plugin.TValue[string] {
+	return &c.ActivityStreamMode
+}
+
+func (c *mqlAwsRdsDbinstance) GetActivityStreamStatus() *plugin.TValue[string] {
+	return &c.ActivityStreamStatus
 }
 
 // mqlAwsElasticache for the aws.elasticache resource

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -3084,8 +3084,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.clusters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRds).GetClusters()).ToDataRes(types.Array(types.Resource("aws.rds.dbcluster")))
 	},
-	"aws.rds.pendingMaintenanceActions": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsRds).GetPendingMaintenanceActions()).ToDataRes(types.Array(types.Resource("aws.rds.pendingMaintenanceAction")))
+	"aws.rds.allPendingMaintenanceActions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRds).GetAllPendingMaintenanceActions()).ToDataRes(types.Array(types.Resource("aws.rds.pendingMaintenanceAction")))
 	},
 	"aws.rds.backupsetting.target": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsBackupsetting).GetTarget()).ToDataRes(types.String)
@@ -3260,6 +3260,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.rds.snapshot.port": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsSnapshot).GetPort()).ToDataRes(types.Int)
+	},
+	"aws.rds.snapshot.allocatedStorage": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsSnapshot).GetAllocatedStorage()).ToDataRes(types.Int)
 	},
 	"aws.rds.snapshot.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsSnapshot).GetCreatedAt()).ToDataRes(types.Time)
@@ -8348,8 +8351,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsRds).Clusters, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
-	"aws.rds.pendingMaintenanceActions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsRds).PendingMaintenanceActions, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+	"aws.rds.allPendingMaintenanceActions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRds).AllPendingMaintenanceActions, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
 	"aws.rds.backupsetting.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8594,6 +8597,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.rds.snapshot.port": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsSnapshot).Port, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.rds.snapshot.allocatedStorage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsSnapshot).AllocatedStorage, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"aws.rds.snapshot.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21418,7 +21425,7 @@ type mqlAwsRds struct {
 	Instances plugin.TValue[[]interface{}]
 	DbClusters plugin.TValue[[]interface{}]
 	Clusters plugin.TValue[[]interface{}]
-	PendingMaintenanceActions plugin.TValue[[]interface{}]
+	AllPendingMaintenanceActions plugin.TValue[[]interface{}]
 }
 
 // createAwsRds creates a new instance of this resource
@@ -21522,10 +21529,10 @@ func (c *mqlAwsRds) GetClusters() *plugin.TValue[[]interface{}] {
 	})
 }
 
-func (c *mqlAwsRds) GetPendingMaintenanceActions() *plugin.TValue[[]interface{}] {
-	return plugin.GetOrCompute[[]interface{}](&c.PendingMaintenanceActions, func() ([]interface{}, error) {
+func (c *mqlAwsRds) GetAllPendingMaintenanceActions() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.AllPendingMaintenanceActions, func() ([]interface{}, error) {
 		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds", c.__id, "pendingMaintenanceActions")
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds", c.__id, "allPendingMaintenanceActions")
 			if err != nil {
 				return nil, err
 			}
@@ -21534,7 +21541,7 @@ func (c *mqlAwsRds) GetPendingMaintenanceActions() *plugin.TValue[[]interface{}]
 			}
 		}
 
-		return c.pendingMaintenanceActions()
+		return c.allPendingMaintenanceActions()
 	})
 }
 
@@ -21909,6 +21916,7 @@ type mqlAwsRdsSnapshot struct {
 	EngineVersion plugin.TValue[string]
 	Status plugin.TValue[string]
 	Port plugin.TValue[int64]
+	AllocatedStorage plugin.TValue[int64]
 	CreatedAt plugin.TValue[*time.Time]
 }
 
@@ -21997,6 +22005,10 @@ func (c *mqlAwsRdsSnapshot) GetStatus() *plugin.TValue[string] {
 
 func (c *mqlAwsRdsSnapshot) GetPort() *plugin.TValue[int64] {
 	return &c.Port
+}
+
+func (c *mqlAwsRdsSnapshot) GetAllocatedStorage() *plugin.TValue[int64] {
+	return &c.AllocatedStorage
 }
 
 func (c *mqlAwsRdsSnapshot) GetCreatedAt() *plugin.TValue[*time.Time] {

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2431,6 +2431,8 @@ resources:
       masterUsername:
         min_mondoo_version: 9.0.0
       members: {}
+      monitoringInterval:
+        min_mondoo_version: 9.0.0
       multiAZ:
         min_mondoo_version: 9.0.0
       port:
@@ -2503,6 +2505,8 @@ resources:
       latestRestorableTime:
         min_mondoo_version: 9.0.0
       masterUsername:
+        min_mondoo_version: 9.0.0
+      monitoringInterval:
         min_mondoo_version: 9.0.0
       multiAZ: {}
       name: {}

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2435,6 +2435,8 @@ resources:
         min_mondoo_version: 9.0.0
       multiAZ:
         min_mondoo_version: 9.0.0
+      networkType:
+        min_mondoo_version: 9.0.0
       port:
         min_mondoo_version: 9.0.0
       publiclyAccessible:
@@ -2510,6 +2512,8 @@ resources:
         min_mondoo_version: 9.0.0
       multiAZ: {}
       name: {}
+      networkType:
+        min_mondoo_version: 9.0.0
       pendingMaintenanceActions:
         min_mondoo_version: 9.0.0
       port:

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2344,13 +2344,13 @@ resources:
       desc: |
         Use the `aws.rds` resource to assess the configuration of AWS RDS deployments. The resource returns lists of `aws.rds.dbcluster`, `aws.rds.dbinstance`, and `aws.rds.snapshot` resources, each with fields for assessing the configuration of those assets.
     fields:
+      allPendingMaintenanceActions:
+        min_mondoo_version: 9.0.0
       clusters:
         min_mondoo_version: 9.0.0
       dbClusters: {}
       dbInstances: {}
       instances:
-        min_mondoo_version: 9.0.0
-      pendingMaintenanceActions:
         min_mondoo_version: 9.0.0
     min_mondoo_version: 5.15.0
     platform:

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2388,6 +2388,10 @@ resources:
       desc: |
         The `aws.rds.dbcluster` resource provides fields for assessing the configuration of AWS RDS Clusters.
     fields:
+      activityStreamMode:
+        min_mondoo_version: latest
+      activityStreamStatus:
+        min_mondoo_version: latest
       arn: {}
       autoMinorVersionUpgrade:
         min_mondoo_version: 9.0.0
@@ -2397,6 +2401,10 @@ resources:
         min_mondoo_version: 9.0.0
       backupSettings:
         min_mondoo_version: 9.0.0
+      certificateAuthority:
+        min_mondoo_version: latest
+      certificateExpiresAt:
+        min_mondoo_version: latest
       clusterDbInstanceClass:
         min_mondoo_version: 9.0.0
       createdTime:
@@ -2413,6 +2421,8 @@ resources:
         min_mondoo_version: 9.0.0
       hostedZoneId:
         min_mondoo_version: 9.0.0
+      iamDatabaseAuthentication:
+        min_mondoo_version: latest
       id: {}
       latestRestorableTime:
         min_mondoo_version: 9.0.0
@@ -2450,6 +2460,10 @@ resources:
       desc: |
         The `aws.rds.dbinstance` resource provides fields for assessing the configuration of RDS instances. For usage, read the `aws.rds` resource documentation.
     fields:
+      activityStreamMode:
+        min_mondoo_version: latest
+      activityStreamStatus:
+        min_mondoo_version: latest
       arn: {}
       autoMinorVersionUpgrade:
         min_mondoo_version: 8.22.0
@@ -2458,8 +2472,14 @@ resources:
       backupRetentionPeriod: {}
       backupSettings:
         min_mondoo_version: 9.0.0
+      certificateAuthority:
+        min_mondoo_version: latest
+      certificateExpiresAt:
+        min_mondoo_version: latest
       createdTime:
         min_mondoo_version: 9.0.0
+      customIamInstanceProfile:
+        min_mondoo_version: latest
       dbInstanceClass:
         min_mondoo_version: 5.19.1
       dbInstanceIdentifier:
@@ -2475,6 +2495,8 @@ resources:
       engineVersion:
         min_mondoo_version: 9.0.0
       enhancedMonitoringResourceArn: {}
+      iamDatabaseAuthentication:
+        min_mondoo_version: latest
       id: {}
       latestRestorableTime:
         min_mondoo_version: 9.0.0

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2350,6 +2350,8 @@ resources:
       dbInstances: {}
       instances:
         min_mondoo_version: 9.0.0
+      pendingMaintenanceActions:
+        min_mondoo_version: 9.0.0
     min_mondoo_version: 5.15.0
     platform:
       name:
@@ -2504,6 +2506,8 @@ resources:
         min_mondoo_version: 9.0.0
       multiAZ: {}
       name: {}
+      pendingMaintenanceActions:
+        min_mondoo_version: 9.0.0
       port:
         min_mondoo_version: 9.0.0
       publiclyAccessible: {}
@@ -2525,6 +2529,20 @@ resources:
       tags: {}
     is_private: true
     min_mondoo_version: 5.15.0
+    platform:
+      name:
+      - aws
+  aws.rds.pendingMaintenanceAction:
+    fields:
+      action: {}
+      autoAppliedAfterDate: {}
+      currentApplyDate: {}
+      description: {}
+      forcedApplyDate: {}
+      optInStatus: {}
+      resourceArn: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
     platform:
       name:
       - aws

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -162,7 +162,7 @@ func (a *mqlAwsRds) getDbInstances(conn *connection.AwsConnection) []*jobpool.Jo
 }
 
 // pendingMaintenanceActions returns all pending maintaince actions for all RDS instances
-func (a *mqlAwsRds) pendingMaintenanceActions() ([]interface{}, error) {
+func (a *mqlAwsRds) allPendingMaintenanceActions() ([]interface{}, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	res := []interface{}{}
 	poolOfJobs := jobpool.CreatePool(a.getPpendingMaintenanceActions(conn), 5)
@@ -180,7 +180,7 @@ func (a *mqlAwsRds) pendingMaintenanceActions() ([]interface{}, error) {
 	return res, nil
 }
 
-func (a *mqlAwsRds) getPpendingMaintenanceActions(conn *connection.AwsConnection) []*jobpool.Job {
+func (a *mqlAwsRds) getPendingMaintenanceActions(conn *connection.AwsConnection) []*jobpool.Job {
 	tasks := make([]*jobpool.Job, 0)
 	regions, err := conn.Regions()
 	if err != nil {
@@ -210,7 +210,7 @@ func (a *mqlAwsRds) getPpendingMaintenanceActions(conn *connection.AwsConnection
 					}
 					for _, action := range resp.PendingMaintenanceActionDetails {
 						resourceArn := *resp.ResourceIdentifier
-						mqlDbSnapshot, err := newMqlAwsPendingMaintainceAction(a.MqlRuntime, region, resourceArn, action)
+						mqlPendingAction, err := newMqlAwsPendingMaintainceAction(a.MqlRuntime, region, resourceArn, action)
 						if err != nil {
 							return nil, err
 						}

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -165,7 +165,7 @@ func (a *mqlAwsRds) getDbInstances(conn *connection.AwsConnection) []*jobpool.Jo
 func (a *mqlAwsRds) allPendingMaintenanceActions() ([]interface{}, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	res := []interface{}{}
-	poolOfJobs := jobpool.CreatePool(a.getPpendingMaintenanceActions(conn), 5)
+	poolOfJobs := jobpool.CreatePool(a.getPendingMaintenanceActions(conn), 5)
 	poolOfJobs.Run()
 
 	// check for errors
@@ -210,11 +210,11 @@ func (a *mqlAwsRds) getPendingMaintenanceActions(conn *connection.AwsConnection)
 					}
 					for _, action := range resp.PendingMaintenanceActionDetails {
 						resourceArn := *resp.ResourceIdentifier
-						mqlPendingAction, err := newMqlAwsPendingMaintainceAction(a.MqlRuntime, region, resourceArn, action)
+						mqlPendingAction, err := newMqlAwsPendingMaintenanceAction(a.MqlRuntime, region, resourceArn, action)
 						if err != nil {
 							return nil, err
 						}
-						res = append(res, mqlDbSnapshot)
+						res = append(res, mqlPendingAction)
 					}
 				}
 				if pendingMaintainanceList.Marker == nil {
@@ -349,7 +349,7 @@ func (a *mqlAwsRdsDbinstance) pendingMaintenanceActions() ([]interface{}, error)
 			}
 			for _, action := range resp.PendingMaintenanceActionDetails {
 				resourceArn := *resp.ResourceIdentifier
-				mqlDbSnapshot, err := newMqlAwsPendingMaintainceAction(a.MqlRuntime, region, resourceArn, action)
+				mqlDbSnapshot, err := newMqlAwsPendingMaintenanceAction(a.MqlRuntime, region, resourceArn, action)
 				if err != nil {
 					return nil, err
 				}
@@ -364,8 +364,8 @@ func (a *mqlAwsRdsDbinstance) pendingMaintenanceActions() ([]interface{}, error)
 	return res, nil
 }
 
-// newMqlAwsPendingMaintainceaction creates a new mqlAwsRdsPendingMaintenanceActions from a rdstypes.PendingMaintenanceAction
-func newMqlAwsPendingMaintainceAction(runtime *plugin.Runtime, region string, resourceArn string, maintenanceAction rdstypes.PendingMaintenanceAction) (*mqlAwsRdsPendingMaintenanceAction, error) {
+// newMqlAwsPendingMaintenanceAction creates a new mqlAwsRdsPendingMaintenanceActions from a rdstypes.PendingMaintenanceAction
+func newMqlAwsPendingMaintenanceAction(runtime *plugin.Runtime, region string, resourceArn string, maintenanceAction rdstypes.PendingMaintenanceAction) (*mqlAwsRdsPendingMaintenanceAction, error) {
 	action := ""
 	if maintenanceAction.Action != nil {
 		action = *maintenanceAction.Action

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -140,6 +140,7 @@ func (a *mqlAwsRds) getDbInstances(conn *connection.AwsConnection) []*jobpool.Jo
 							"customIamInstanceProfile":      llx.StringDataPtr(dbInstance.CustomIamInstanceProfile),
 							"activityStreamMode":            llx.StringData(string(dbInstance.ActivityStreamMode)),
 							"activityStreamStatus":          llx.StringData(string(dbInstance.ActivityStreamStatus)),
+							"networkType":                   llx.StringDataPtr(dbInstance.NetworkType),
 						})
 					if err != nil {
 						return nil, err
@@ -521,6 +522,7 @@ func (a *mqlAwsRds) getDbClusters(conn *connection.AwsConnection) []*jobpool.Job
 							"activityStreamMode":        llx.StringData(string(cluster.ActivityStreamMode)),
 							"activityStreamStatus":      llx.StringData(string(cluster.ActivityStreamStatus)),
 							"monitoringInterval":        llx.IntDataPtr(cluster.MonitoringInterval),
+							"networkType":               llx.StringDataPtr(cluster.NetworkType),
 						})
 					if err != nil {
 						return nil, err

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -117,6 +117,7 @@ func (a *mqlAwsRds) getDbInstances(conn *connection.AwsConnection) []*jobpool.Jo
 							"engine":                        llx.StringDataPtr(dbInstance.Engine),
 							"engineLifecycleSupport":        llx.StringDataPtr(dbInstance.EngineLifecycleSupport),
 							"engineVersion":                 llx.StringDataPtr(dbInstance.EngineVersion),
+							"monitoringInterval":            llx.IntDataPtr(dbInstance.MonitoringInterval),
 							"enhancedMonitoringResourceArn": llx.StringDataPtr(dbInstance.EnhancedMonitoringResourceArn),
 							"id":                            llx.StringDataPtr(dbInstance.DBInstanceIdentifier),
 							"latestRestorableTime":          llx.TimeDataPtr(dbInstance.LatestRestorableTime),
@@ -519,6 +520,7 @@ func (a *mqlAwsRds) getDbClusters(conn *connection.AwsConnection) []*jobpool.Job
 							"iamDatabaseAuthentication": llx.BoolDataPtr(cluster.IAMDatabaseAuthenticationEnabled),
 							"activityStreamMode":        llx.StringData(string(cluster.ActivityStreamMode)),
 							"activityStreamStatus":      llx.StringData(string(cluster.ActivityStreamStatus)),
+							"monitoringInterval":        llx.IntDataPtr(cluster.MonitoringInterval),
 						})
 					if err != nil {
 						return nil, err


### PR DESCRIPTION
after https://github.com/mondoohq/cnquery/pull/4526

The AWS RDS `aws.rds.instances` resource is handy to quickly see the RDS instances, their engines and engine version:

```javascript
aws.rds.instances: [
  0: aws.rds.dbinstance id="database-1" region="us-east-1" engine="postgres" engineVersion="16.4"
  1: aws.rds.dbinstance id="database-2" region="us-east-1" engine="sqlserver-ex" engineVersion="15.00.4382.1.v1"
  2: aws.rds.dbinstance id="database-2-instance-1" region="us-east-1" engine="aurora-postgresql" engineVersion="15.4"
  3: aws.rds.dbinstance id="database-3" region="us-east-1" engine="postgres" engineVersion="11.22-rds.20240418"
  4: aws.rds.dbinstance id="docdb-2024-08-11-08-16-54" region="us-east-1" engine="docdb" engineVersion="5.0.0"
]
```

With this PR we extend the existing resource to become even more useful to verify that your RDS databases are configured correctly.

**Certificate configuration**

To ensure you have enabled certificate authentication you can check now if a `certificateAuthority` was attached

```javascript
aws.rds.instances.all(certificateAuthority != empty)
```

**Check if RDS databases is using IAM authentication**

MQL now exposes a new field `iamDatabaseAuthentication`. This is handy when you want to verify that all database instances need to use IAM authentication:

```javascript
aws.rds.instances.all(iamDatabaseAuthentication)
```

**Expose activity stream mode**

The new exposed `activityStreamStatus` field allows us to quickly verify that all aurora instances have an active activity stream:

```javascript
aws.rds.instances.where(storageType == "aurora").all(activityStreamStatus == "started")
```

**expose status for cluster and instance**

The new `status` field allows you to quickly verify if all instances are available:

```javascript
cnspec> aws.rds.instances { id status }
aws.rds.instances: [
  0: {
    status: "available"
    id: "database-1"
  }
  1: {
    status: "available"
    id: "database-2"
  }
  2: {
    status: "available"
    id: "database-2-instance-1"
  }
  3: {
    status: "available"
    id: "database-3"
  }
  4: {
    status: "available"
    id: "docdb-2024-08-11-08-16-54"
  }
]
```

To check that all are available, just use:

```javascript
cnspec> aws.rds.instances.all(status == "available")
[ok] value: true
```

**Pending maintenance actions**

It is often important to know that all databases are properly maintained. While AWS abstracts a lot of maintaince into RDS service, the engine may need an upgrade that leads to a downtime of the database. You can easily verify that no maintenance actions are  open:

```javascript
// global for all rds instances
aws.rds.allPendingMaintenanceActions == empty
```

You can also see individual maintenance actions for individual instances:

```javascript
cnspec> aws.rds.instances { id pendingMaintenanceActions}
aws.rds.instances: [
  0: {
    pendingMaintenanceActions: []
    id: "database-1"
  }
  1: {
    pendingMaintenanceActions: []
    id: "database-2"
  }
  2: {
    pendingMaintenanceActions: []
    id: "database-2-instance-1"
  }
  3: {
    pendingMaintenanceActions: []
    id: "database-3"
  }
  4: {
    pendingMaintenanceActions: []
    id: "docdb-2024-08-11-08-16-54"
  }
]
```

**expose AWS RDS instance monitoring interval**

With the `enhancedMonitoringResourceArn` field and  `monitoringInterval` you verify that all databases have enhanced monitoring enabled and a monitoring interval is set

```javascript
cnspec> aws.rds.instances.all(enhancedMonitoringResourceArn != empty && monitoringInterval > 0)
[failed] [].all()
  actual:   [
    0: aws.rds.dbinstance engineVersion="15.00.4382.1.v1" region="us-east-1" engine="sqlserver-ex" id="database-2" {
      monitoringInterval: 0
      enhancedMonitoringResourceArn: null
    }
    1: aws.rds.dbinstance engineVersion="11.22-rds.20240418" region="us-east-1" engine="postgres" id="database-3" {
      monitoringInterval: 0
      enhancedMonitoringResourceArn: null
    }
    2: aws.rds.dbinstance engineVersion="5.0.0" region="us-east-1" engine="docdb" id="docdb-2024-08-11-08-16-54" {
      monitoringInterval: 0
      enhancedMonitoringResourceArn: null
    }
  ]
```

**expose AWS RDS network type**

To see which network types the databases use, we added a new `networkType` field to the instances and clusters:

```javascript
cnspec> aws.rds.instances { id engine networkType }
aws.rds.instances: [
  0: {
    networkType: "IPV4"
    engine: "postgres"
    id: "database-1"
  }
  1: {
    networkType: "IPV4"
    engine: "sqlserver-ex"
    id: "database-2"
  }
  2: {
    networkType: "IPV4"
    engine: "aurora-postgresql"
    id: "database-2-instance-1"
  }
  3: {
    networkType: "IPV4"
    engine: "postgres"
    id: "database-3"
  }
  4: {
    networkType: "IPV4"
    engine: "docdb"
    id: "docdb-2024-08-11-08-16-54"
  }
]
```
