### PR TITLE
⭐️ aws.elasticache.serverlessCaches resource

### DIFF
--- a/providers/aws/resources/aws.go
+++ b/providers/aws/resources/aws.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 
@@ -44,6 +45,10 @@ const (
 	apiArnPattern               = "arn:aws:apigateway:%s:%s::/apis/%s"
 	apiStageArnPattern          = "arn:aws:apigateway:%s:%s::/apis/%s/stages/%s"
 )
+
+func NewSecurityGroupArn(region, accountID, sgID string) string {
+	return fmt.Sprintf(securityGroupArnPattern, region, accountID, sgID)
+}
 
 func (a *mqlAws) regions() ([]interface{}, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2270,8 +2270,10 @@ private aws.rds.pendingMaintenanceAction {
 aws.elasticache @defaults("cacheClusters") {
     // Deprecated. Use `cacheClusters` instead.
   clusters() []dict
-  // List of clusters
+  // List of cache clusters
   cacheClusters() []aws.elasticache.cluster
+  // List of serverless caches
+  serverlessCaches() []aws.elasticache.serverlessCache
 }
 
 // Amazon ElastiCache cluster
@@ -2330,6 +2332,36 @@ private aws.elasticache.cluster @defaults("cacheClusterId region nodeType engine
   transitEncryptionEnabled bool
   // Whether migrating clients to use in-transit encryption (with no downtime) is allowed
   transitEncryptionMode string
+}
+
+// Amazon ElastiCache serverless cache
+private aws.elasticache.serverlessCache @defaults("name description status engine engineVersion") {
+  // ARN for the cache
+  arn string
+  // Unique identifier of the serverless cache
+  name string
+  // Description of the serverless cache
+  description string
+  // The name of the cache engine used for this cluster: Memcached or Redis
+  engine string
+  // The version of the cache engine that is used in this cluster
+  engineVersion string
+  // Version number of the engine the serverless cache is compatible with
+  majorEngineVersion string
+  // ID of the Amazon Web Services Key Management Service (KMS) key
+  kmsKeyId string
+  // A list of VPC security groups associated with the cluster
+  securityGroups []aws.ec2.securitygroup
+  // The number of days for which ElastiCache retains automatic cluster snapshots before deleting them
+  snapshotRetentionLimit int
+  // Time that a cache snapshot will be created
+  dailySnapshotTime string
+  // Status of the serverless cache
+  status string
+  // Region where the cache exists
+  region string
+  // Time when the serverless cache was created
+  createdAt time
 }
 
 // Amazon Redshift

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2325,7 +2325,7 @@ private aws.elasticache.cluster @defaults("cacheClusterId region nodeType engine
   // Region where the cluster exists
   region string
   // A list of VPC security groups associated with the cluster
-  securityGroups []aws.ec2.securitygroup
+  securityGroups() []aws.ec2.securitygroup
   // The number of days for which ElastiCache retains automatic cluster snapshots before deleting them
   snapshotRetentionLimit int
   // Whether in-transit encryption is enabled
@@ -2351,7 +2351,7 @@ private aws.elasticache.serverlessCache @defaults("name description status engin
   // ID of the Amazon Web Services Key Management Service (KMS) key
   kmsKeyId string
   // A list of VPC security groups associated with the cluster
-  securityGroups []aws.ec2.securitygroup
+  securityGroups() []aws.ec2.securitygroup
   // The number of days for which ElastiCache retains automatic cluster snapshots before deleting them
   snapshotRetentionLimit int
   // Time that a cache snapshot will be created

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -542,6 +542,10 @@ func init() {
 			// to override args, implement: initAwsElasticacheCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsElasticacheCluster,
 		},
+		"aws.elasticache.serverlessCache": {
+			// to override args, implement: initAwsElasticacheServerlessCache(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsElasticacheServerlessCache,
+		},
 		"aws.redshift": {
 			// to override args, implement: initAwsRedshift(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsRedshift,
@@ -3429,6 +3433,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.elasticache.cacheClusters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticache).GetCacheClusters()).ToDataRes(types.Array(types.Resource("aws.elasticache.cluster")))
 	},
+	"aws.elasticache.serverlessCaches": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticache).GetServerlessCaches()).ToDataRes(types.Array(types.Resource("aws.elasticache.serverlessCache")))
+	},
 	"aws.elasticache.cluster.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheCluster).GetArn()).ToDataRes(types.String)
 	},
@@ -3509,6 +3516,45 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.elasticache.cluster.transitEncryptionMode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheCluster).GetTransitEncryptionMode()).ToDataRes(types.String)
+	},
+	"aws.elasticache.serverlessCache.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheServerlessCache).GetArn()).ToDataRes(types.String)
+	},
+	"aws.elasticache.serverlessCache.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheServerlessCache).GetName()).ToDataRes(types.String)
+	},
+	"aws.elasticache.serverlessCache.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheServerlessCache).GetDescription()).ToDataRes(types.String)
+	},
+	"aws.elasticache.serverlessCache.engine": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheServerlessCache).GetEngine()).ToDataRes(types.String)
+	},
+	"aws.elasticache.serverlessCache.engineVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheServerlessCache).GetEngineVersion()).ToDataRes(types.String)
+	},
+	"aws.elasticache.serverlessCache.majorEngineVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheServerlessCache).GetMajorEngineVersion()).ToDataRes(types.String)
+	},
+	"aws.elasticache.serverlessCache.kmsKeyId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheServerlessCache).GetKmsKeyId()).ToDataRes(types.String)
+	},
+	"aws.elasticache.serverlessCache.securityGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheServerlessCache).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
+	},
+	"aws.elasticache.serverlessCache.snapshotRetentionLimit": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheServerlessCache).GetSnapshotRetentionLimit()).ToDataRes(types.Int)
+	},
+	"aws.elasticache.serverlessCache.dailySnapshotTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheServerlessCache).GetDailySnapshotTime()).ToDataRes(types.String)
+	},
+	"aws.elasticache.serverlessCache.status": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheServerlessCache).GetStatus()).ToDataRes(types.String)
+	},
+	"aws.elasticache.serverlessCache.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheServerlessCache).GetRegion()).ToDataRes(types.String)
+	},
+	"aws.elasticache.serverlessCache.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheServerlessCache).GetCreatedAt()).ToDataRes(types.Time)
 	},
 	"aws.redshift.clusters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRedshift).GetClusters()).ToDataRes(types.Array(types.Resource("aws.redshift.cluster")))
@@ -8882,6 +8928,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsElasticache).CacheClusters, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
+	"aws.elasticache.serverlessCaches": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticache).ServerlessCaches, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
 	"aws.elasticache.cluster.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 			r.(*mqlAwsElasticacheCluster).__id, ok = v.Value.(string)
 			return
@@ -8992,6 +9042,62 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.elasticache.cluster.transitEncryptionMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElasticacheCluster).TransitEncryptionMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.serverlessCache.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlAwsElasticacheServerlessCache).__id, ok = v.Value.(string)
+			return
+		},
+	"aws.elasticache.serverlessCache.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheServerlessCache).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.serverlessCache.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheServerlessCache).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.serverlessCache.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheServerlessCache).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.serverlessCache.engine": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheServerlessCache).Engine, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.serverlessCache.engineVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheServerlessCache).EngineVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.serverlessCache.majorEngineVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheServerlessCache).MajorEngineVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.serverlessCache.kmsKeyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheServerlessCache).KmsKeyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.serverlessCache.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheServerlessCache).SecurityGroups, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.serverlessCache.snapshotRetentionLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheServerlessCache).SnapshotRetentionLimit, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.serverlessCache.dailySnapshotTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheServerlessCache).DailySnapshotTime, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.serverlessCache.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheServerlessCache).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.serverlessCache.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheServerlessCache).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.serverlessCache.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheServerlessCache).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.redshift.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -22536,6 +22642,7 @@ type mqlAwsElasticache struct {
 	// optional: if you define mqlAwsElasticacheInternal it will be used here
 	Clusters plugin.TValue[[]interface{}]
 	CacheClusters plugin.TValue[[]interface{}]
+	ServerlessCaches plugin.TValue[[]interface{}]
 }
 
 // createAwsElasticache creates a new instance of this resource
@@ -22597,6 +22704,22 @@ func (c *mqlAwsElasticache) GetCacheClusters() *plugin.TValue[[]interface{}] {
 	})
 }
 
+func (c *mqlAwsElasticache) GetServerlessCaches() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.ServerlessCaches, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.elasticache", c.__id, "serverlessCaches")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.serverlessCaches()
+	})
+}
+
 // mqlAwsElasticacheCluster for the aws.elasticache.cluster resource
 type mqlAwsElasticacheCluster struct {
 	MqlRuntime *plugin.Runtime
@@ -22642,12 +22765,7 @@ func createAwsElasticacheCluster(runtime *plugin.Runtime, args map[string]*llx.R
 		return res, err
 	}
 
-	if res.__id == "" {
-	res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("aws.elasticache.cluster", res.__id)
@@ -22774,6 +22892,110 @@ func (c *mqlAwsElasticacheCluster) GetTransitEncryptionEnabled() *plugin.TValue[
 
 func (c *mqlAwsElasticacheCluster) GetTransitEncryptionMode() *plugin.TValue[string] {
 	return &c.TransitEncryptionMode
+}
+
+// mqlAwsElasticacheServerlessCache for the aws.elasticache.serverlessCache resource
+type mqlAwsElasticacheServerlessCache struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlAwsElasticacheServerlessCacheInternal it will be used here
+	Arn plugin.TValue[string]
+	Name plugin.TValue[string]
+	Description plugin.TValue[string]
+	Engine plugin.TValue[string]
+	EngineVersion plugin.TValue[string]
+	MajorEngineVersion plugin.TValue[string]
+	KmsKeyId plugin.TValue[string]
+	SecurityGroups plugin.TValue[[]interface{}]
+	SnapshotRetentionLimit plugin.TValue[int64]
+	DailySnapshotTime plugin.TValue[string]
+	Status plugin.TValue[string]
+	Region plugin.TValue[string]
+	CreatedAt plugin.TValue[*time.Time]
+}
+
+// createAwsElasticacheServerlessCache creates a new instance of this resource
+func createAwsElasticacheServerlessCache(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsElasticacheServerlessCache{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.elasticache.serverlessCache", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsElasticacheServerlessCache) MqlName() string {
+	return "aws.elasticache.serverlessCache"
+}
+
+func (c *mqlAwsElasticacheServerlessCache) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsElasticacheServerlessCache) GetArn() *plugin.TValue[string] {
+	return &c.Arn
+}
+
+func (c *mqlAwsElasticacheServerlessCache) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAwsElasticacheServerlessCache) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlAwsElasticacheServerlessCache) GetEngine() *plugin.TValue[string] {
+	return &c.Engine
+}
+
+func (c *mqlAwsElasticacheServerlessCache) GetEngineVersion() *plugin.TValue[string] {
+	return &c.EngineVersion
+}
+
+func (c *mqlAwsElasticacheServerlessCache) GetMajorEngineVersion() *plugin.TValue[string] {
+	return &c.MajorEngineVersion
+}
+
+func (c *mqlAwsElasticacheServerlessCache) GetKmsKeyId() *plugin.TValue[string] {
+	return &c.KmsKeyId
+}
+
+func (c *mqlAwsElasticacheServerlessCache) GetSecurityGroups() *plugin.TValue[[]interface{}] {
+	return &c.SecurityGroups
+}
+
+func (c *mqlAwsElasticacheServerlessCache) GetSnapshotRetentionLimit() *plugin.TValue[int64] {
+	return &c.SnapshotRetentionLimit
+}
+
+func (c *mqlAwsElasticacheServerlessCache) GetDailySnapshotTime() *plugin.TValue[string] {
+	return &c.DailySnapshotTime
+}
+
+func (c *mqlAwsElasticacheServerlessCache) GetStatus() *plugin.TValue[string] {
+	return &c.Status
+}
+
+func (c *mqlAwsElasticacheServerlessCache) GetRegion() *plugin.TValue[string] {
+	return &c.Region
+}
+
+func (c *mqlAwsElasticacheServerlessCache) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
 }
 
 // mqlAwsRedshift for the aws.redshift resource

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -22724,7 +22724,7 @@ func (c *mqlAwsElasticache) GetServerlessCaches() *plugin.TValue[[]interface{}] 
 type mqlAwsElasticacheCluster struct {
 	MqlRuntime *plugin.Runtime
 	__id string
-	// optional: if you define mqlAwsElasticacheClusterInternal it will be used here
+	mqlAwsElasticacheClusterInternal
 	Arn plugin.TValue[string]
 	AtRestEncryptionEnabled plugin.TValue[bool]
 	AuthTokenEnabled plugin.TValue[bool]
@@ -22879,7 +22879,19 @@ func (c *mqlAwsElasticacheCluster) GetRegion() *plugin.TValue[string] {
 }
 
 func (c *mqlAwsElasticacheCluster) GetSecurityGroups() *plugin.TValue[[]interface{}] {
-	return &c.SecurityGroups
+	return plugin.GetOrCompute[[]interface{}](&c.SecurityGroups, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.elasticache.cluster", c.__id, "securityGroups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.securityGroups()
+	})
 }
 
 func (c *mqlAwsElasticacheCluster) GetSnapshotRetentionLimit() *plugin.TValue[int64] {
@@ -22898,7 +22910,7 @@ func (c *mqlAwsElasticacheCluster) GetTransitEncryptionMode() *plugin.TValue[str
 type mqlAwsElasticacheServerlessCache struct {
 	MqlRuntime *plugin.Runtime
 	__id string
-	// optional: if you define mqlAwsElasticacheServerlessCacheInternal it will be used here
+	mqlAwsElasticacheServerlessCacheInternal
 	Arn plugin.TValue[string]
 	Name plugin.TValue[string]
 	Description plugin.TValue[string]
@@ -22975,7 +22987,19 @@ func (c *mqlAwsElasticacheServerlessCache) GetKmsKeyId() *plugin.TValue[string] 
 }
 
 func (c *mqlAwsElasticacheServerlessCache) GetSecurityGroups() *plugin.TValue[[]interface{}] {
-	return &c.SecurityGroups
+	return plugin.GetOrCompute[[]interface{}](&c.SecurityGroups, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.elasticache.serverlessCache", c.__id, "securityGroups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.securityGroups()
+	})
 }
 
 func (c *mqlAwsElasticacheServerlessCache) GetSnapshotRetentionLimit() *plugin.TValue[int64] {

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -1553,6 +1553,8 @@ resources:
     fields:
       cacheClusters: {}
       clusters: {}
+      serverlessCaches:
+        min_mondoo_version: 9.0.0
     min_mondoo_version: 5.15.0
     platform:
       name:
@@ -1599,6 +1601,26 @@ resources:
       transitEncryptionMode: {}
     is_private: true
     min_mondoo_version: latest
+    platform:
+      name:
+      - aws
+  aws.elasticache.serverlessCache:
+    fields:
+      arn: {}
+      createdAt: {}
+      dailySnapshotTime: {}
+      description: {}
+      engine: {}
+      engineVersion: {}
+      kmsKeyId: {}
+      majorEngineVersion: {}
+      name: {}
+      region: {}
+      securityGroups: {}
+      snapshotRetentionLimit: {}
+      status: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
     platform:
       name:
       - aws

--- a/providers/aws/resources/aws_elasticache.go
+++ b/providers/aws/resources/aws_elasticache.go
@@ -107,10 +107,6 @@ func (a *mqlAwsElasticache) cacheClusters() ([]interface{}, error) {
 	return res, nil
 }
 
-func (a *mqlAwsElasticacheCluster) id() (string, error) {
-	return a.Arn.Data, nil
-}
-
 func (a *mqlAwsElasticache) getCacheClusters(conn *connection.AwsConnection) []*jobpool.Job {
 	tasks := make([]*jobpool.Job, 0)
 	regions, err := conn.Regions()
@@ -175,9 +171,10 @@ func (a *mqlAwsElasticache) getCacheClusters(conn *connection.AwsConnection) []*
 
 					mqlCluster, err := CreateResource(a.MqlRuntime, "aws.elasticache.cluster",
 						map[string]*llx.RawData{
+							"__id":                      llx.StringDataPtr(cluster.ARN),
 							"arn":                       llx.StringDataPtr(cluster.ARN),
-							"atRestEncryptionEnabled":   llx.BoolData(convert.ToBool(cluster.AtRestEncryptionEnabled)),
-							"authTokenEnabled":          llx.BoolData(convert.ToBool(cluster.AuthTokenEnabled)),
+							"atRestEncryptionEnabled":   llx.BoolDataPtr(cluster.AtRestEncryptionEnabled),
+							"authTokenEnabled":          llx.BoolDataPtr(cluster.AuthTokenEnabled),
 							"authTokenLastModifiedDate": llx.TimeDataPtr(cluster.AuthTokenLastModifiedDate),
 							"autoMinorVersionUpgrade":   llx.BoolDataPtr(cluster.AutoMinorVersionUpgrade),
 							"cacheClusterCreateTime":    llx.TimeDataPtr(cluster.CacheClusterCreateTime),
@@ -200,7 +197,7 @@ func (a *mqlAwsElasticache) getCacheClusters(conn *connection.AwsConnection) []*
 							"region":                    llx.StringData(regionVal),
 							"securityGroups":            llx.ArrayData(sgs, types.Resource("aws.ec2.securitygroup")),
 							"snapshotRetentionLimit":    llx.IntDataDefault(cluster.SnapshotRetentionLimit, 0),
-							"transitEncryptionEnabled":  llx.BoolData(convert.ToBool(cluster.TransitEncryptionEnabled)),
+							"transitEncryptionEnabled":  llx.BoolDataPtr(cluster.TransitEncryptionEnabled),
 							"transitEncryptionMode":     llx.StringData(string(cluster.TransitEncryptionMode)),
 						})
 					if err != nil {
@@ -212,6 +209,107 @@ func (a *mqlAwsElasticache) getCacheClusters(conn *connection.AwsConnection) []*
 					break
 				}
 				marker = clusters.Marker
+			}
+			return jobpool.JobResult(res), nil
+		}
+		tasks = append(tasks, jobpool.NewJob(f))
+	}
+	return tasks
+}
+
+func (a *mqlAwsElasticache) serverlessCaches() ([]interface{}, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	res := []interface{}{}
+	poolOfJobs := jobpool.CreatePool(a.getServerlessCaches(conn), 5)
+	poolOfJobs.Run()
+
+	// check for errors
+	if poolOfJobs.HasErrors() {
+		return nil, poolOfJobs.GetErrors()
+	}
+	// get all the results
+	for i := range poolOfJobs.Jobs {
+		if poolOfJobs.Jobs[i].Result != nil {
+			res = append(res, poolOfJobs.Jobs[i].Result.([]interface{})...)
+		}
+	}
+
+	return res, nil
+}
+
+func (a *mqlAwsElasticache) getServerlessCaches(conn *connection.AwsConnection) []*jobpool.Job {
+	tasks := make([]*jobpool.Job, 0)
+	regions, err := conn.Regions()
+	if err != nil {
+		return []*jobpool.Job{{Err: err}}
+	}
+
+	for _, region := range regions {
+		regionVal := region
+		f := func() (jobpool.JobResult, error) {
+			log.Debug().Msgf("elasticache>getServerlessClusters>calling aws with region %s", regionVal)
+
+			svc := conn.Elasticache(regionVal)
+			ctx := context.Background()
+			res := []interface{}{}
+
+			var marker *string
+			for {
+				caches, err := svc.DescribeServerlessCaches(ctx, &elasticache.DescribeServerlessCachesInput{
+					NextToken: marker,
+				})
+				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
+					return nil, err
+				}
+				if len(caches.ServerlessCaches) == 0 {
+					return nil, nil
+				}
+				for i := range caches.ServerlessCaches {
+					cache := caches.ServerlessCaches[i]
+
+					sgs := []interface{}{}
+					for i := range cache.SecurityGroupIds {
+						sgId := cache.SecurityGroupIds[i]
+						mqlSg, err := NewResource(a.MqlRuntime, "aws.ec2.securitygroup",
+							map[string]*llx.RawData{
+								"arn": llx.StringData(fmt.Sprintf(securityGroupArnPattern, regionVal, conn.AccountId(), sgId)),
+							})
+						if err != nil {
+							return nil, err
+						}
+						sgs = append(sgs, mqlSg)
+					}
+
+					mqlCluster, err := CreateResource(a.MqlRuntime, "aws.elasticache.serverlessCache",
+						map[string]*llx.RawData{
+							"__id":                   llx.StringDataPtr(cache.ARN),
+							"arn":                    llx.StringDataPtr(cache.ARN),
+							"name":                   llx.StringDataPtr(cache.ServerlessCacheName),
+							"description":            llx.StringDataPtr(cache.Description),
+							"engine":                 llx.StringDataPtr(cache.Engine),
+							"engineVersion":          llx.StringDataPtr(cache.FullEngineVersion),
+							"majorEngineVersion":     llx.StringDataPtr(cache.MajorEngineVersion),
+							"kmsKeyId":               llx.StringDataPtr(cache.KmsKeyId),
+							"region":                 llx.StringData(regionVal),
+							"securityGroups":         llx.ArrayData(sgs, types.Resource("aws.ec2.securitygroup")),
+							"snapshotRetentionLimit": llx.IntDataDefault(cache.SnapshotRetentionLimit, 0),
+							"dailySnapshotTime":      llx.StringDataPtr(cache.DailySnapshotTime),
+							"createdAt":              llx.TimeDataPtr(cache.CreateTime),
+							"status":                 llx.StringDataPtr(cache.Status),
+						})
+					if err != nil {
+						return nil, err
+					}
+					res = append(res, mqlCluster)
+				}
+				if caches.NextToken == nil {
+					break
+				}
+				marker = caches.NextToken
 			}
 			return jobpool.JobResult(res), nil
 		}

--- a/providers/aws/resources/aws_elasticache.go
+++ b/providers/aws/resources/aws_elasticache.go
@@ -5,7 +5,6 @@ package resources
 
 import (
 	"context"
-	"fmt"
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	elasticache_types "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 	"github.com/rs/zerolog/log"
@@ -16,6 +15,30 @@ import (
 	"go.mondoo.com/cnquery/v11/providers/aws/connection"
 	"go.mondoo.com/cnquery/v11/types"
 )
+
+type securityGroupIdHandler struct {
+	securityGroupArns []string
+}
+
+func (sgh *securityGroupIdHandler) setSecurityGroupArns(ids []string) {
+	sgh.securityGroupArns = ids
+}
+
+func (sgh *securityGroupIdHandler) newSecurityGroupResources(runtime *plugin.Runtime) ([]interface{}, error) {
+	sgs := []interface{}{}
+	for i := range sgh.securityGroupArns {
+		sgArn := sgh.securityGroupArns[i]
+		mqlSg, err := NewResource(runtime, "aws.ec2.securitygroup",
+			map[string]*llx.RawData{
+				"arn": llx.StringData(sgArn),
+			})
+		if err != nil {
+			return nil, err
+		}
+		sgs = append(sgs, mqlSg)
+	}
+	return sgs, nil
+}
 
 func (a *mqlAwsElasticache) id() (string, error) {
 	return "aws.elasticache", nil
@@ -156,6 +179,10 @@ func (a *mqlAwsElasticache) getCacheClusters(conn *connection.AwsConnection) []*
 	return tasks
 }
 
+type mqlAwsElasticacheClusterInternal struct {
+	securityGroupIdHandler
+}
+
 func newMqlAwsElasticacheCluster(runtime *plugin.Runtime, region string, accountID string, cluster elasticache_types.CacheCluster) (*mqlAwsElasticacheCluster, error) {
 	cacheNodes := []interface{}{}
 	for i := range cluster.CacheNodes {
@@ -174,20 +201,17 @@ func newMqlAwsElasticacheCluster(runtime *plugin.Runtime, region string, account
 		notificationConfiguration = convert.ToString(cluster.NotificationConfiguration.TopicArn)
 	}
 
-	sgs := []interface{}{}
+	sgs := []string{}
 	for i := range cluster.SecurityGroups {
 		sg := cluster.SecurityGroups[i]
-		mqlSg, err := NewResource(runtime, "aws.ec2.securitygroup",
-			map[string]*llx.RawData{
-				"arn": llx.StringData(fmt.Sprintf(securityGroupArnPattern, region, accountID, convert.ToString(sg.SecurityGroupId))),
-			})
-		if err != nil {
-			return nil, err
+		if sg.SecurityGroupId == nil {
+			log.Debug().Msgf("elasticache>newMqlAwsElasticacheCluster>missing security group id for cluster %s", *cluster.CacheClusterId)
+			continue
 		}
-		sgs = append(sgs, mqlSg)
+		sgs = append(sgs, NewSecurityGroupArn(region, accountID, convert.ToString(sg.SecurityGroupId)))
 	}
 
-	mqlCluster, err := CreateResource(runtime, "aws.elasticache.cluster",
+	resource, err := CreateResource(runtime, "aws.elasticache.cluster",
 		map[string]*llx.RawData{
 			"__id":                      llx.StringDataPtr(cluster.ARN),
 			"arn":                       llx.StringDataPtr(cluster.ARN),
@@ -213,7 +237,6 @@ func newMqlAwsElasticacheCluster(runtime *plugin.Runtime, region string, account
 			"numCacheNodes":             llx.IntDataDefault(cluster.NumCacheNodes, 0),
 			"preferredAvailabilityZone": llx.StringDataPtr(cluster.PreferredAvailabilityZone),
 			"region":                    llx.StringData(region),
-			"securityGroups":            llx.ArrayData(sgs, types.Resource("aws.ec2.securitygroup")),
 			"snapshotRetentionLimit":    llx.IntDataDefault(cluster.SnapshotRetentionLimit, 0),
 			"transitEncryptionEnabled":  llx.BoolDataPtr(cluster.TransitEncryptionEnabled),
 			"transitEncryptionMode":     llx.StringData(string(cluster.TransitEncryptionMode)),
@@ -221,7 +244,14 @@ func newMqlAwsElasticacheCluster(runtime *plugin.Runtime, region string, account
 	if err != nil {
 		return nil, err
 	}
-	return mqlCluster.(*mqlAwsElasticacheCluster), nil
+
+	mqlCluster := resource.(*mqlAwsElasticacheCluster)
+	mqlCluster.setSecurityGroupArns(sgs)
+	return mqlCluster, nil
+}
+
+func (a *mqlAwsElasticacheCluster) securityGroups() ([]interface{}, error) {
+	return a.newSecurityGroupResources(a.MqlRuntime)
 }
 
 func (a *mqlAwsElasticache) serverlessCaches() ([]interface{}, error) {
@@ -295,21 +325,18 @@ func (a *mqlAwsElasticache) getServerlessCaches(conn *connection.AwsConnection) 
 	return tasks
 }
 
+type mqlAwsElasticacheServerlessCacheInternal struct {
+	securityGroupIdHandler
+}
+
 func newMqlAwsElasticacheServerlessCache(runtime *plugin.Runtime, region string, accountID string, cache elasticache_types.ServerlessCache) (*mqlAwsElasticacheServerlessCache, error) {
-	sgs := []interface{}{}
+	sgArgs := []string{}
 	for i := range cache.SecurityGroupIds {
 		sgId := cache.SecurityGroupIds[i]
-		mqlSg, err := NewResource(runtime, "aws.ec2.securitygroup",
-			map[string]*llx.RawData{
-				"arn": llx.StringData(fmt.Sprintf(securityGroupArnPattern, region, accountID, sgId)),
-			})
-		if err != nil {
-			return nil, err
-		}
-		sgs = append(sgs, mqlSg)
+		sgArgs = append(sgArgs, NewSecurityGroupArn(region, accountID, sgId))
 	}
 
-	mqlCache, err := CreateResource(runtime, "aws.elasticache.serverlessCache",
+	resource, err := CreateResource(runtime, "aws.elasticache.serverlessCache",
 		map[string]*llx.RawData{
 			"__id":                   llx.StringDataPtr(cache.ARN),
 			"arn":                    llx.StringDataPtr(cache.ARN),
@@ -320,7 +347,6 @@ func newMqlAwsElasticacheServerlessCache(runtime *plugin.Runtime, region string,
 			"majorEngineVersion":     llx.StringDataPtr(cache.MajorEngineVersion),
 			"kmsKeyId":               llx.StringDataPtr(cache.KmsKeyId),
 			"region":                 llx.StringData(region),
-			"securityGroups":         llx.ArrayData(sgs, types.Resource("aws.ec2.securitygroup")),
 			"snapshotRetentionLimit": llx.IntDataDefault(cache.SnapshotRetentionLimit, 0),
 			"dailySnapshotTime":      llx.StringDataPtr(cache.DailySnapshotTime),
 			"createdAt":              llx.TimeDataPtr(cache.CreateTime),
@@ -329,5 +355,12 @@ func newMqlAwsElasticacheServerlessCache(runtime *plugin.Runtime, region string,
 	if err != nil {
 		return nil, err
 	}
-	return mqlCache.(*mqlAwsElasticacheServerlessCache), nil
+
+	mqlCache := resource.(*mqlAwsElasticacheServerlessCache)
+	mqlCache.setSecurityGroupArns(sgArgs)
+	return mqlCache, nil
+}
+
+func (a *mqlAwsElasticacheServerlessCache) securityGroups() ([]interface{}, error) {
+	return a.newSecurityGroupResources(a.MqlRuntime)
 }


### PR DESCRIPTION
AWS added ElastiCache Serverless for Redis and Memcached. This PR exposes those new server via the new `aws.elasticache.serverlessCaches` resource:

```javascript
cnquery> aws.elasticache.serverlessCaches { * }
aws.elasticache.serverlessCaches: [
  0: {
    region: "us-east-1"
    createdAt: 2024-08-11 21:45:02.836 +0200 CEST
    snapshotRetentionLimit: 0
    dailySnapshotTime: "05:00"
    description: "memache"
    status: "available"
    arn: "arn:aws:elasticache:us-east-1:012345678901:serverlesscache:cache1"
    kmsKeyId: null
    securityGroups: [
      0: aws.ec2.securitygroup id="sg-037203ba3346d36bd" name="default" region="us-east-1" vpc.id="vpc-03800db8f01981fb7"
    ]
    engineVersion: "1.6.22"
    name: "cache1"
    majorEngineVersion: "1.6"
    engine: "memcached"
  }
  1: {
    region: "us-east-1"
    createdAt: 2024-08-11 22:27:19.125 +0200 CEST
    snapshotRetentionLimit: 0
    dailySnapshotTime: "04:00"
    description: " "
    status: "available"
    arn: "arn:aws:elasticache:us-east-1:012345678901:serverlesscache:redis-cache"
    kmsKeyId: null
    securityGroups: [
      0: aws.ec2.securitygroup id="sg-037203ba3346d36bd" name="default" region="us-east-1" vpc.id="vpc-03800db8f01981fb7"
    ]
    engineVersion: "7.1"
    name: "redis-cache"
    majorEngineVersion: "7"
    engine: "redis"
  }
]
```