### PR TITLE
⭐️ AWS neptune cluster and instance resources

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -88,6 +88,7 @@ sqli
 sqlimatchstatement
 sqlserver
 targetgroup
+tde
 testutils
 toplevel
 tpu

--- a/providers/aws/go.mod
+++ b/providers/aws/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/inspector2 v1.28.3
 	github.com/aws/aws-sdk-go-v2/service/kms v1.35.3
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.56.3
+	github.com/aws/aws-sdk-go-v2/service/neptune v1.33.3
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.30.2
 	github.com/aws/aws-sdk-go-v2/service/rds v1.82.0
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.46.4

--- a/providers/aws/go.sum
+++ b/providers/aws/go.sum
@@ -143,6 +143,8 @@ github.com/aws/aws-sdk-go-v2/service/kms v1.35.3 h1:UPTdlTOwWUX49fVi7cymEN6hDqCw
 github.com/aws/aws-sdk-go-v2/service/kms v1.35.3/go.mod h1:gjDP16zn+WWalyaUqwCCioQ8gU8lzttCCc9jYsiQI/8=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.56.3 h1:r/y4nQOln25cbjrD8Wmzhhvnvr2ObPjgcPvPdoU9yHs=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.56.3/go.mod h1:/4Vaddp+wJc1AA8ViAqwWKAcYykPV+ZplhmLQuq3RbQ=
+github.com/aws/aws-sdk-go-v2/service/neptune v1.33.3 h1:QIdrTiB9PV2xAkuSNObYT04w3Y7RDMqcR5HhqWM7/1E=
+github.com/aws/aws-sdk-go-v2/service/neptune v1.33.3/go.mod h1:yYc9uNpgXUgia6cNsQ0eZL6eAYtc2EgEIEdWSDim+uk=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.30.2 h1:+tGF0JH2u4HwneqNFAKFHqENwfpBweKj67+LbwTKpqE=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.30.2/go.mod h1:6wxO8s5wMumyNRsOgOgcIvqvF8rIf8Cj7Khhn/bFI0c=
 github.com/aws/aws-sdk-go-v2/service/rds v1.82.0 h1:+1qRsLNukmvIDNBjz5Osqy4dvIBLwpCeMhmrh9evOUw=

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2134,8 +2134,6 @@ private aws.rds.snapshot @defaults("id region type encrypted createdAt") {
   engineVersion string
   // The snapshot status
   status string
-  // The amount of storage allocated to the snapshot
-  allocatedStorage int
   // The port that the database instance or cluster listens on
   port int
   // The creation date of the snapshot
@@ -3238,4 +3236,138 @@ private aws.eks.cluster @defaults("arn version status") {
   supportType string
   // The authentication mode for the cluster
   authenticationMode string
+}
+
+// Amazon Neptune
+aws.neptune @defaults("clusters") {
+  // List of database clusters
+  clusters() []aws.neptune.cluster
+  // List of database instances
+  instances() []aws.neptune.instance
+}
+
+// Amazon Neptune cluster
+private aws.neptune.cluster @defaults("arn name status") {
+  // ARN for the cluster
+  arn string
+  // Name of the cluster
+  name string
+  // User-supplied DB cluster identifier
+  clusterIdentifier string
+  // User-supplied global database cluster identifier
+  globalClusterIdentifier string
+  // Name of the database engine
+  engine string
+  // Database engine version
+  engineVersion string
+  // Amazon KMS key identifier for the encrypted DB cluster
+  kmsKeyId string
+  // Region where the cluster exists
+  region string
+  // Time when the cluster was created
+  automaticRestartTime time
+  // List of EC2 Availability Zones
+  availabilityZones []string
+  // Number of days for which automatic DB snapshots are retained
+  backupRetentionPeriod int
+  // Time when the cluster was created
+  createdAt time
+  // Whether the DB cluster can be cloned across accounts
+  crossAccountClone bool
+  // DB cluster parameter group for the DB cluster
+  clusterParameterGroup string
+  // Subnet group associated with the DB cluster
+  subnetGroup string
+  // Amazon Region-unique, immutable identifier for the DB cluster
+  clusterResourceId string
+  // Whether the DB cluster has deletion protection enabled
+  deletionProtection bool
+  // Earliest time to which a database can be restored
+  earliestRestorableTime time
+  // Connection endpoint for the primary instance
+  endpoint string
+  // Whether mapping of Amazon Identity and Access Management (IAM) accounts to database accounts is enabled
+  iamDatabaseAuthenticationEnabled bool
+  // Latest time to which a database can be restored
+  latestRestorableTime time
+  // Username
+  masterUsername string
+  // Whether the cluster has instances in multiple availability zones
+  multiAZ bool
+  // Port that the database engine is listening on
+  port int
+  // Daily time range during which automated backups are created
+  preferredBackupWindow string
+  // Weekly time range during which system maintenance can occur
+  preferredMaintenanceWindow string
+  // Status of the cluster
+  status string
+  // Whether the DB cluster is encrypted
+  storageEncrypted bool
+  // Storage type
+  storageType string
+}
+
+// Amazon Neptune instance
+private aws.neptune.instance @defaults("arn name status"){
+  // ARN for the instance
+  arn string
+  // Name of the instance
+  name string
+  // User-supplied DB cluster identifier
+  clusterIdentifier string
+  // Whether minor version patches are applied automatically
+  autoMinorVersionUpgrade bool
+  // Name of the availability zone
+  availabilityZone string
+  // Number of days for which automatic DB snapshots are retained
+  backupRetentionPeriod int
+  // Name of the compute and memory capacity class
+  instanceClass string
+  // Status of the instance
+  status string
+  // Port that the database engine is listening on
+  port int
+  // Whether the instance has deletion protection enabled
+  deletionProtection bool
+  // List of log types that this DB instance is configured to export to CloudWatch logs
+  enabledCloudwatchLogsExports []string
+  // Connection endpoint
+  endpoint dict
+  // Name of the database engine
+  engine string
+  // Database engine version
+  engineVersion string
+  // Amazon CloudWatch Log ARN log stream to which the database writes the audit log
+  enhancedMonitoringResourceArn string
+  // Whether mapping of Amazon Identity and Access Management (IAM) accounts to database accounts is enabled
+  iamDatabaseAuthenticationEnabled bool
+  // Time when the cluster was created
+  createdAt time
+  // Amazon KMS key identifier for the encrypted DB instance
+  kmsKeyId string
+  // Latest time to which a database can be restored
+  latestRestorableTime time
+  // Username
+  masterUsername string
+  // Interval, in seconds, between points when Enhanced Monitoring metrics are collected
+  monitoringInterval int
+  // ARN for the IAM role that permits Neptune to send Enhanced Monitoring metrics to Amazon CloudWatch Logs
+  monitoringRoleArn string
+  // Whether the cluster has instances in multiple availability zones
+  multiAZ bool
+  // Daily time range during which automated backups are created
+  preferredBackupWindow string
+  // Weekly time range during which system maintenance can occur
+  preferredMaintenanceWindow string
+  // Specifies the order in which a Read Replica is promoted
+  promotionTier int
+  // Region where the cluster exists
+  region string
+  // Whether the DB cluster is encrypted
+  storageEncrypted bool
+  // Storage type
+  storageType string
+  // Key store with which the instance is associated for TDE encryption
+  tdeCredentialArn string
 }

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -738,6 +738,18 @@ func init() {
 			// to override args, implement: initAwsEksCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsEksCluster,
 		},
+		"aws.neptune": {
+			// to override args, implement: initAwsNeptune(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsNeptune,
+		},
+		"aws.neptune.cluster": {
+			// to override args, implement: initAwsNeptuneCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsNeptuneCluster,
+		},
+		"aws.neptune.instance": {
+			// to override args, implement: initAwsNeptuneInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsNeptuneInstance,
+		},
 	}
 }
 
@@ -3212,9 +3224,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.snapshot.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsSnapshot).GetStatus()).ToDataRes(types.String)
 	},
-	"aws.rds.snapshot.allocatedStorage": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsRdsSnapshot).GetAllocatedStorage()).ToDataRes(types.Int)
-	},
 	"aws.rds.snapshot.port": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsSnapshot).GetPort()).ToDataRes(types.Int)
 	},
@@ -4549,6 +4558,189 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.eks.cluster.authenticationMode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEksCluster).GetAuthenticationMode()).ToDataRes(types.String)
+	},
+	"aws.neptune.clusters": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptune).GetClusters()).ToDataRes(types.Array(types.Resource("aws.neptune.cluster")))
+	},
+	"aws.neptune.instances": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptune).GetInstances()).ToDataRes(types.Array(types.Resource("aws.neptune.instance")))
+	},
+	"aws.neptune.cluster.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetArn()).ToDataRes(types.String)
+	},
+	"aws.neptune.cluster.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetName()).ToDataRes(types.String)
+	},
+	"aws.neptune.cluster.clusterIdentifier": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetClusterIdentifier()).ToDataRes(types.String)
+	},
+	"aws.neptune.cluster.globalClusterIdentifier": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetGlobalClusterIdentifier()).ToDataRes(types.String)
+	},
+	"aws.neptune.cluster.engine": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetEngine()).ToDataRes(types.String)
+	},
+	"aws.neptune.cluster.engineVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetEngineVersion()).ToDataRes(types.String)
+	},
+	"aws.neptune.cluster.kmsKeyId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetKmsKeyId()).ToDataRes(types.String)
+	},
+	"aws.neptune.cluster.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetRegion()).ToDataRes(types.String)
+	},
+	"aws.neptune.cluster.automaticRestartTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetAutomaticRestartTime()).ToDataRes(types.Time)
+	},
+	"aws.neptune.cluster.availabilityZones": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetAvailabilityZones()).ToDataRes(types.Array(types.String))
+	},
+	"aws.neptune.cluster.backupRetentionPeriod": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetBackupRetentionPeriod()).ToDataRes(types.Int)
+	},
+	"aws.neptune.cluster.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetCreatedAt()).ToDataRes(types.Time)
+	},
+	"aws.neptune.cluster.crossAccountClone": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetCrossAccountClone()).ToDataRes(types.Bool)
+	},
+	"aws.neptune.cluster.clusterParameterGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetClusterParameterGroup()).ToDataRes(types.String)
+	},
+	"aws.neptune.cluster.subnetGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetSubnetGroup()).ToDataRes(types.String)
+	},
+	"aws.neptune.cluster.clusterResourceId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetClusterResourceId()).ToDataRes(types.String)
+	},
+	"aws.neptune.cluster.deletionProtection": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetDeletionProtection()).ToDataRes(types.Bool)
+	},
+	"aws.neptune.cluster.earliestRestorableTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetEarliestRestorableTime()).ToDataRes(types.Time)
+	},
+	"aws.neptune.cluster.endpoint": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetEndpoint()).ToDataRes(types.String)
+	},
+	"aws.neptune.cluster.iamDatabaseAuthenticationEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetIamDatabaseAuthenticationEnabled()).ToDataRes(types.Bool)
+	},
+	"aws.neptune.cluster.latestRestorableTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetLatestRestorableTime()).ToDataRes(types.Time)
+	},
+	"aws.neptune.cluster.masterUsername": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetMasterUsername()).ToDataRes(types.String)
+	},
+	"aws.neptune.cluster.multiAZ": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetMultiAZ()).ToDataRes(types.Bool)
+	},
+	"aws.neptune.cluster.port": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetPort()).ToDataRes(types.Int)
+	},
+	"aws.neptune.cluster.preferredBackupWindow": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetPreferredBackupWindow()).ToDataRes(types.String)
+	},
+	"aws.neptune.cluster.preferredMaintenanceWindow": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetPreferredMaintenanceWindow()).ToDataRes(types.String)
+	},
+	"aws.neptune.cluster.status": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetStatus()).ToDataRes(types.String)
+	},
+	"aws.neptune.cluster.storageEncrypted": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetStorageEncrypted()).ToDataRes(types.Bool)
+	},
+	"aws.neptune.cluster.storageType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneCluster).GetStorageType()).ToDataRes(types.String)
+	},
+	"aws.neptune.instance.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetArn()).ToDataRes(types.String)
+	},
+	"aws.neptune.instance.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetName()).ToDataRes(types.String)
+	},
+	"aws.neptune.instance.clusterIdentifier": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetClusterIdentifier()).ToDataRes(types.String)
+	},
+	"aws.neptune.instance.autoMinorVersionUpgrade": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetAutoMinorVersionUpgrade()).ToDataRes(types.Bool)
+	},
+	"aws.neptune.instance.availabilityZone": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetAvailabilityZone()).ToDataRes(types.String)
+	},
+	"aws.neptune.instance.backupRetentionPeriod": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetBackupRetentionPeriod()).ToDataRes(types.Int)
+	},
+	"aws.neptune.instance.instanceClass": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetInstanceClass()).ToDataRes(types.String)
+	},
+	"aws.neptune.instance.status": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetStatus()).ToDataRes(types.String)
+	},
+	"aws.neptune.instance.port": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetPort()).ToDataRes(types.Int)
+	},
+	"aws.neptune.instance.deletionProtection": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetDeletionProtection()).ToDataRes(types.Bool)
+	},
+	"aws.neptune.instance.enabledCloudwatchLogsExports": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetEnabledCloudwatchLogsExports()).ToDataRes(types.Array(types.String))
+	},
+	"aws.neptune.instance.endpoint": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetEndpoint()).ToDataRes(types.Dict)
+	},
+	"aws.neptune.instance.engine": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetEngine()).ToDataRes(types.String)
+	},
+	"aws.neptune.instance.engineVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetEngineVersion()).ToDataRes(types.String)
+	},
+	"aws.neptune.instance.enhancedMonitoringResourceArn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetEnhancedMonitoringResourceArn()).ToDataRes(types.String)
+	},
+	"aws.neptune.instance.iamDatabaseAuthenticationEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetIamDatabaseAuthenticationEnabled()).ToDataRes(types.Bool)
+	},
+	"aws.neptune.instance.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetCreatedAt()).ToDataRes(types.Time)
+	},
+	"aws.neptune.instance.kmsKeyId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetKmsKeyId()).ToDataRes(types.String)
+	},
+	"aws.neptune.instance.latestRestorableTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetLatestRestorableTime()).ToDataRes(types.Time)
+	},
+	"aws.neptune.instance.masterUsername": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetMasterUsername()).ToDataRes(types.String)
+	},
+	"aws.neptune.instance.monitoringInterval": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetMonitoringInterval()).ToDataRes(types.Int)
+	},
+	"aws.neptune.instance.monitoringRoleArn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetMonitoringRoleArn()).ToDataRes(types.String)
+	},
+	"aws.neptune.instance.multiAZ": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetMultiAZ()).ToDataRes(types.Bool)
+	},
+	"aws.neptune.instance.preferredBackupWindow": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetPreferredBackupWindow()).ToDataRes(types.String)
+	},
+	"aws.neptune.instance.preferredMaintenanceWindow": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetPreferredMaintenanceWindow()).ToDataRes(types.String)
+	},
+	"aws.neptune.instance.promotionTier": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetPromotionTier()).ToDataRes(types.Int)
+	},
+	"aws.neptune.instance.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetRegion()).ToDataRes(types.String)
+	},
+	"aws.neptune.instance.storageEncrypted": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetStorageEncrypted()).ToDataRes(types.Bool)
+	},
+	"aws.neptune.instance.storageType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetStorageType()).ToDataRes(types.String)
+	},
+	"aws.neptune.instance.tdeCredentialArn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNeptuneInstance).GetTdeCredentialArn()).ToDataRes(types.String)
 	},
 }
 
@@ -8278,10 +8470,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsRdsSnapshot).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"aws.rds.snapshot.allocatedStorage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsRdsSnapshot).AllocatedStorage, ok = plugin.RawToTValue[int64](v.Value, v.Error)
-		return
-	},
 	"aws.rds.snapshot.port": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsSnapshot).Port, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
@@ -10272,6 +10460,262 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.eks.cluster.authenticationMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEksCluster).AuthenticationMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlAwsNeptune).__id, ok = v.Value.(string)
+			return
+		},
+	"aws.neptune.clusters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptune).Clusters, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instances": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptune).Instances, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlAwsNeptuneCluster).__id, ok = v.Value.(string)
+			return
+		},
+	"aws.neptune.cluster.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.clusterIdentifier": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).ClusterIdentifier, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.globalClusterIdentifier": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).GlobalClusterIdentifier, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.engine": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).Engine, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.engineVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).EngineVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.kmsKeyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).KmsKeyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.automaticRestartTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).AutomaticRestartTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.availabilityZones": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).AvailabilityZones, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.backupRetentionPeriod": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).BackupRetentionPeriod, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.crossAccountClone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).CrossAccountClone, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.clusterParameterGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).ClusterParameterGroup, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.subnetGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).SubnetGroup, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.clusterResourceId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).ClusterResourceId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.deletionProtection": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).DeletionProtection, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.earliestRestorableTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).EarliestRestorableTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.endpoint": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).Endpoint, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.iamDatabaseAuthenticationEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).IamDatabaseAuthenticationEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.latestRestorableTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).LatestRestorableTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.masterUsername": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).MasterUsername, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.multiAZ": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).MultiAZ, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.port": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).Port, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.preferredBackupWindow": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).PreferredBackupWindow, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.preferredMaintenanceWindow": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).PreferredMaintenanceWindow, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.storageEncrypted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).StorageEncrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.cluster.storageType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneCluster).StorageType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlAwsNeptuneInstance).__id, ok = v.Value.(string)
+			return
+		},
+	"aws.neptune.instance.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.clusterIdentifier": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).ClusterIdentifier, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.autoMinorVersionUpgrade": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).AutoMinorVersionUpgrade, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.availabilityZone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).AvailabilityZone, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.backupRetentionPeriod": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).BackupRetentionPeriod, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.instanceClass": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).InstanceClass, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.port": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).Port, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.deletionProtection": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).DeletionProtection, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.enabledCloudwatchLogsExports": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).EnabledCloudwatchLogsExports, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.endpoint": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).Endpoint, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.engine": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).Engine, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.engineVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).EngineVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.enhancedMonitoringResourceArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).EnhancedMonitoringResourceArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.iamDatabaseAuthenticationEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).IamDatabaseAuthenticationEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.kmsKeyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).KmsKeyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.latestRestorableTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).LatestRestorableTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.masterUsername": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).MasterUsername, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.monitoringInterval": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).MonitoringInterval, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.monitoringRoleArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).MonitoringRoleArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.multiAZ": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).MultiAZ, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.preferredBackupWindow": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).PreferredBackupWindow, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.preferredMaintenanceWindow": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).PreferredMaintenanceWindow, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.promotionTier": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).PromotionTier, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.storageEncrypted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).StorageEncrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.storageType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).StorageType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.neptune.instance.tdeCredentialArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNeptuneInstance).TdeCredentialArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 }
@@ -21212,7 +21656,6 @@ type mqlAwsRdsSnapshot struct {
 	Engine plugin.TValue[string]
 	EngineVersion plugin.TValue[string]
 	Status plugin.TValue[string]
-	AllocatedStorage plugin.TValue[int64]
 	Port plugin.TValue[int64]
 	CreatedAt plugin.TValue[*time.Time]
 }
@@ -21298,10 +21741,6 @@ func (c *mqlAwsRdsSnapshot) GetEngineVersion() *plugin.TValue[string] {
 
 func (c *mqlAwsRdsSnapshot) GetStatus() *plugin.TValue[string] {
 	return &c.Status
-}
-
-func (c *mqlAwsRdsSnapshot) GetAllocatedStorage() *plugin.TValue[int64] {
-	return &c.AllocatedStorage
 }
 
 func (c *mqlAwsRdsSnapshot) GetPort() *plugin.TValue[int64] {
@@ -26587,4 +27026,455 @@ func (c *mqlAwsEksCluster) GetSupportType() *plugin.TValue[string] {
 
 func (c *mqlAwsEksCluster) GetAuthenticationMode() *plugin.TValue[string] {
 	return &c.AuthenticationMode
+}
+
+// mqlAwsNeptune for the aws.neptune resource
+type mqlAwsNeptune struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlAwsNeptuneInternal it will be used here
+	Clusters plugin.TValue[[]interface{}]
+	Instances plugin.TValue[[]interface{}]
+}
+
+// createAwsNeptune creates a new instance of this resource
+func createAwsNeptune(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsNeptune{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+	res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.neptune", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsNeptune) MqlName() string {
+	return "aws.neptune"
+}
+
+func (c *mqlAwsNeptune) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsNeptune) GetClusters() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.Clusters, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.neptune", c.__id, "clusters")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.clusters()
+	})
+}
+
+func (c *mqlAwsNeptune) GetInstances() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.Instances, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.neptune", c.__id, "instances")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.instances()
+	})
+}
+
+// mqlAwsNeptuneCluster for the aws.neptune.cluster resource
+type mqlAwsNeptuneCluster struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlAwsNeptuneClusterInternal it will be used here
+	Arn plugin.TValue[string]
+	Name plugin.TValue[string]
+	ClusterIdentifier plugin.TValue[string]
+	GlobalClusterIdentifier plugin.TValue[string]
+	Engine plugin.TValue[string]
+	EngineVersion plugin.TValue[string]
+	KmsKeyId plugin.TValue[string]
+	Region plugin.TValue[string]
+	AutomaticRestartTime plugin.TValue[*time.Time]
+	AvailabilityZones plugin.TValue[[]interface{}]
+	BackupRetentionPeriod plugin.TValue[int64]
+	CreatedAt plugin.TValue[*time.Time]
+	CrossAccountClone plugin.TValue[bool]
+	ClusterParameterGroup plugin.TValue[string]
+	SubnetGroup plugin.TValue[string]
+	ClusterResourceId plugin.TValue[string]
+	DeletionProtection plugin.TValue[bool]
+	EarliestRestorableTime plugin.TValue[*time.Time]
+	Endpoint plugin.TValue[string]
+	IamDatabaseAuthenticationEnabled plugin.TValue[bool]
+	LatestRestorableTime plugin.TValue[*time.Time]
+	MasterUsername plugin.TValue[string]
+	MultiAZ plugin.TValue[bool]
+	Port plugin.TValue[int64]
+	PreferredBackupWindow plugin.TValue[string]
+	PreferredMaintenanceWindow plugin.TValue[string]
+	Status plugin.TValue[string]
+	StorageEncrypted plugin.TValue[bool]
+	StorageType plugin.TValue[string]
+}
+
+// createAwsNeptuneCluster creates a new instance of this resource
+func createAwsNeptuneCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsNeptuneCluster{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.neptune.cluster", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsNeptuneCluster) MqlName() string {
+	return "aws.neptune.cluster"
+}
+
+func (c *mqlAwsNeptuneCluster) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsNeptuneCluster) GetArn() *plugin.TValue[string] {
+	return &c.Arn
+}
+
+func (c *mqlAwsNeptuneCluster) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAwsNeptuneCluster) GetClusterIdentifier() *plugin.TValue[string] {
+	return &c.ClusterIdentifier
+}
+
+func (c *mqlAwsNeptuneCluster) GetGlobalClusterIdentifier() *plugin.TValue[string] {
+	return &c.GlobalClusterIdentifier
+}
+
+func (c *mqlAwsNeptuneCluster) GetEngine() *plugin.TValue[string] {
+	return &c.Engine
+}
+
+func (c *mqlAwsNeptuneCluster) GetEngineVersion() *plugin.TValue[string] {
+	return &c.EngineVersion
+}
+
+func (c *mqlAwsNeptuneCluster) GetKmsKeyId() *plugin.TValue[string] {
+	return &c.KmsKeyId
+}
+
+func (c *mqlAwsNeptuneCluster) GetRegion() *plugin.TValue[string] {
+	return &c.Region
+}
+
+func (c *mqlAwsNeptuneCluster) GetAutomaticRestartTime() *plugin.TValue[*time.Time] {
+	return &c.AutomaticRestartTime
+}
+
+func (c *mqlAwsNeptuneCluster) GetAvailabilityZones() *plugin.TValue[[]interface{}] {
+	return &c.AvailabilityZones
+}
+
+func (c *mqlAwsNeptuneCluster) GetBackupRetentionPeriod() *plugin.TValue[int64] {
+	return &c.BackupRetentionPeriod
+}
+
+func (c *mqlAwsNeptuneCluster) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
+}
+
+func (c *mqlAwsNeptuneCluster) GetCrossAccountClone() *plugin.TValue[bool] {
+	return &c.CrossAccountClone
+}
+
+func (c *mqlAwsNeptuneCluster) GetClusterParameterGroup() *plugin.TValue[string] {
+	return &c.ClusterParameterGroup
+}
+
+func (c *mqlAwsNeptuneCluster) GetSubnetGroup() *plugin.TValue[string] {
+	return &c.SubnetGroup
+}
+
+func (c *mqlAwsNeptuneCluster) GetClusterResourceId() *plugin.TValue[string] {
+	return &c.ClusterResourceId
+}
+
+func (c *mqlAwsNeptuneCluster) GetDeletionProtection() *plugin.TValue[bool] {
+	return &c.DeletionProtection
+}
+
+func (c *mqlAwsNeptuneCluster) GetEarliestRestorableTime() *plugin.TValue[*time.Time] {
+	return &c.EarliestRestorableTime
+}
+
+func (c *mqlAwsNeptuneCluster) GetEndpoint() *plugin.TValue[string] {
+	return &c.Endpoint
+}
+
+func (c *mqlAwsNeptuneCluster) GetIamDatabaseAuthenticationEnabled() *plugin.TValue[bool] {
+	return &c.IamDatabaseAuthenticationEnabled
+}
+
+func (c *mqlAwsNeptuneCluster) GetLatestRestorableTime() *plugin.TValue[*time.Time] {
+	return &c.LatestRestorableTime
+}
+
+func (c *mqlAwsNeptuneCluster) GetMasterUsername() *plugin.TValue[string] {
+	return &c.MasterUsername
+}
+
+func (c *mqlAwsNeptuneCluster) GetMultiAZ() *plugin.TValue[bool] {
+	return &c.MultiAZ
+}
+
+func (c *mqlAwsNeptuneCluster) GetPort() *plugin.TValue[int64] {
+	return &c.Port
+}
+
+func (c *mqlAwsNeptuneCluster) GetPreferredBackupWindow() *plugin.TValue[string] {
+	return &c.PreferredBackupWindow
+}
+
+func (c *mqlAwsNeptuneCluster) GetPreferredMaintenanceWindow() *plugin.TValue[string] {
+	return &c.PreferredMaintenanceWindow
+}
+
+func (c *mqlAwsNeptuneCluster) GetStatus() *plugin.TValue[string] {
+	return &c.Status
+}
+
+func (c *mqlAwsNeptuneCluster) GetStorageEncrypted() *plugin.TValue[bool] {
+	return &c.StorageEncrypted
+}
+
+func (c *mqlAwsNeptuneCluster) GetStorageType() *plugin.TValue[string] {
+	return &c.StorageType
+}
+
+// mqlAwsNeptuneInstance for the aws.neptune.instance resource
+type mqlAwsNeptuneInstance struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlAwsNeptuneInstanceInternal it will be used here
+	Arn plugin.TValue[string]
+	Name plugin.TValue[string]
+	ClusterIdentifier plugin.TValue[string]
+	AutoMinorVersionUpgrade plugin.TValue[bool]
+	AvailabilityZone plugin.TValue[string]
+	BackupRetentionPeriod plugin.TValue[int64]
+	InstanceClass plugin.TValue[string]
+	Status plugin.TValue[string]
+	Port plugin.TValue[int64]
+	DeletionProtection plugin.TValue[bool]
+	EnabledCloudwatchLogsExports plugin.TValue[[]interface{}]
+	Endpoint plugin.TValue[interface{}]
+	Engine plugin.TValue[string]
+	EngineVersion plugin.TValue[string]
+	EnhancedMonitoringResourceArn plugin.TValue[string]
+	IamDatabaseAuthenticationEnabled plugin.TValue[bool]
+	CreatedAt plugin.TValue[*time.Time]
+	KmsKeyId plugin.TValue[string]
+	LatestRestorableTime plugin.TValue[*time.Time]
+	MasterUsername plugin.TValue[string]
+	MonitoringInterval plugin.TValue[int64]
+	MonitoringRoleArn plugin.TValue[string]
+	MultiAZ plugin.TValue[bool]
+	PreferredBackupWindow plugin.TValue[string]
+	PreferredMaintenanceWindow plugin.TValue[string]
+	PromotionTier plugin.TValue[int64]
+	Region plugin.TValue[string]
+	StorageEncrypted plugin.TValue[bool]
+	StorageType plugin.TValue[string]
+	TdeCredentialArn plugin.TValue[string]
+}
+
+// createAwsNeptuneInstance creates a new instance of this resource
+func createAwsNeptuneInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsNeptuneInstance{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.neptune.instance", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsNeptuneInstance) MqlName() string {
+	return "aws.neptune.instance"
+}
+
+func (c *mqlAwsNeptuneInstance) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsNeptuneInstance) GetArn() *plugin.TValue[string] {
+	return &c.Arn
+}
+
+func (c *mqlAwsNeptuneInstance) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAwsNeptuneInstance) GetClusterIdentifier() *plugin.TValue[string] {
+	return &c.ClusterIdentifier
+}
+
+func (c *mqlAwsNeptuneInstance) GetAutoMinorVersionUpgrade() *plugin.TValue[bool] {
+	return &c.AutoMinorVersionUpgrade
+}
+
+func (c *mqlAwsNeptuneInstance) GetAvailabilityZone() *plugin.TValue[string] {
+	return &c.AvailabilityZone
+}
+
+func (c *mqlAwsNeptuneInstance) GetBackupRetentionPeriod() *plugin.TValue[int64] {
+	return &c.BackupRetentionPeriod
+}
+
+func (c *mqlAwsNeptuneInstance) GetInstanceClass() *plugin.TValue[string] {
+	return &c.InstanceClass
+}
+
+func (c *mqlAwsNeptuneInstance) GetStatus() *plugin.TValue[string] {
+	return &c.Status
+}
+
+func (c *mqlAwsNeptuneInstance) GetPort() *plugin.TValue[int64] {
+	return &c.Port
+}
+
+func (c *mqlAwsNeptuneInstance) GetDeletionProtection() *plugin.TValue[bool] {
+	return &c.DeletionProtection
+}
+
+func (c *mqlAwsNeptuneInstance) GetEnabledCloudwatchLogsExports() *plugin.TValue[[]interface{}] {
+	return &c.EnabledCloudwatchLogsExports
+}
+
+func (c *mqlAwsNeptuneInstance) GetEndpoint() *plugin.TValue[interface{}] {
+	return &c.Endpoint
+}
+
+func (c *mqlAwsNeptuneInstance) GetEngine() *plugin.TValue[string] {
+	return &c.Engine
+}
+
+func (c *mqlAwsNeptuneInstance) GetEngineVersion() *plugin.TValue[string] {
+	return &c.EngineVersion
+}
+
+func (c *mqlAwsNeptuneInstance) GetEnhancedMonitoringResourceArn() *plugin.TValue[string] {
+	return &c.EnhancedMonitoringResourceArn
+}
+
+func (c *mqlAwsNeptuneInstance) GetIamDatabaseAuthenticationEnabled() *plugin.TValue[bool] {
+	return &c.IamDatabaseAuthenticationEnabled
+}
+
+func (c *mqlAwsNeptuneInstance) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
+}
+
+func (c *mqlAwsNeptuneInstance) GetKmsKeyId() *plugin.TValue[string] {
+	return &c.KmsKeyId
+}
+
+func (c *mqlAwsNeptuneInstance) GetLatestRestorableTime() *plugin.TValue[*time.Time] {
+	return &c.LatestRestorableTime
+}
+
+func (c *mqlAwsNeptuneInstance) GetMasterUsername() *plugin.TValue[string] {
+	return &c.MasterUsername
+}
+
+func (c *mqlAwsNeptuneInstance) GetMonitoringInterval() *plugin.TValue[int64] {
+	return &c.MonitoringInterval
+}
+
+func (c *mqlAwsNeptuneInstance) GetMonitoringRoleArn() *plugin.TValue[string] {
+	return &c.MonitoringRoleArn
+}
+
+func (c *mqlAwsNeptuneInstance) GetMultiAZ() *plugin.TValue[bool] {
+	return &c.MultiAZ
+}
+
+func (c *mqlAwsNeptuneInstance) GetPreferredBackupWindow() *plugin.TValue[string] {
+	return &c.PreferredBackupWindow
+}
+
+func (c *mqlAwsNeptuneInstance) GetPreferredMaintenanceWindow() *plugin.TValue[string] {
+	return &c.PreferredMaintenanceWindow
+}
+
+func (c *mqlAwsNeptuneInstance) GetPromotionTier() *plugin.TValue[int64] {
+	return &c.PromotionTier
+}
+
+func (c *mqlAwsNeptuneInstance) GetRegion() *plugin.TValue[string] {
+	return &c.Region
+}
+
+func (c *mqlAwsNeptuneInstance) GetStorageEncrypted() *plugin.TValue[bool] {
+	return &c.StorageEncrypted
+}
+
+func (c *mqlAwsNeptuneInstance) GetStorageType() *plugin.TValue[string] {
+	return &c.StorageType
+}
+
+func (c *mqlAwsNeptuneInstance) GetTdeCredentialArn() *plugin.TValue[string] {
+	return &c.TdeCredentialArn
 }

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2241,6 +2241,88 @@ resources:
     platform:
       name:
       - aws
+  aws.neptune:
+    fields:
+      clusters: {}
+      instances: {}
+    min_mondoo_version: 9.0.0
+    platform:
+      name:
+      - aws
+  aws.neptune.cluster:
+    fields:
+      arn: {}
+      automaticRestartTime: {}
+      availabilityZones: {}
+      backupRetentionPeriod: {}
+      clusterIdentifier: {}
+      clusterParameterGroup: {}
+      clusterResourceId: {}
+      createdAt: {}
+      crossAccountClone: {}
+      deletionProtection: {}
+      earliestRestorableTime: {}
+      endpoint: {}
+      engine: {}
+      engineVersion: {}
+      globalClusterIdentifier: {}
+      iamDatabaseAuthenticationEnabled: {}
+      kmsKeyId: {}
+      latestRestorableTime: {}
+      masterUsername: {}
+      multiAZ: {}
+      name: {}
+      port: {}
+      preferredBackupWindow: {}
+      preferredMaintenanceWindow: {}
+      region: {}
+      status: {}
+      storageEncrypted: {}
+      storageType: {}
+      subnetGroup: {}
+      tags: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
+    platform:
+      name:
+      - aws
+  aws.neptune.instance:
+    fields:
+      arn: {}
+      autoMinorVersionUpgrade: {}
+      availabilityZone: {}
+      backupRetentionPeriod: {}
+      clusterIdentifier: {}
+      createdAt: {}
+      deletionProtection: {}
+      enabledCloudwatchLogsExports: {}
+      endpoint: {}
+      engine: {}
+      engineVersion: {}
+      enhancedMonitoringResourceArn: {}
+      iamDatabaseAuthenticationEnabled: {}
+      instanceClass: {}
+      kmsKeyId: {}
+      latestRestorableTime: {}
+      masterUsername: {}
+      monitoringInterval: {}
+      monitoringRoleArn: {}
+      multiAZ: {}
+      name: {}
+      port: {}
+      preferredBackupWindow: {}
+      preferredMaintenanceWindow: {}
+      promotionTier: {}
+      region: {}
+      status: {}
+      storageEncrypted: {}
+      storageType: {}
+      tdeCredentialArn: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
+    platform:
+      name:
+      - aws
   aws.organization:
     fields:
       accounts:

--- a/providers/aws/resources/aws_neptune.go
+++ b/providers/aws/resources/aws_neptune.go
@@ -1,0 +1,229 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/service/neptune"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/convert"
+	"go.mondoo.com/cnquery/v11/types"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/jobpool"
+	"go.mondoo.com/cnquery/v11/providers/aws/connection"
+)
+
+func (a *mqlAwsNeptune) id() (string, error) {
+	return "aws.neptune", nil
+}
+
+func (a *mqlAwsNeptune) clusters() ([]interface{}, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	res := []interface{}{}
+	poolOfJobs := jobpool.CreatePool(a.getDbClusters(conn), 5)
+	poolOfJobs.Run()
+
+	// check for errors
+	if poolOfJobs.HasErrors() {
+		return nil, poolOfJobs.GetErrors()
+	}
+	// get all the results
+	for i := range poolOfJobs.Jobs {
+		if poolOfJobs.Jobs[i].Result != nil {
+			res = append(res, poolOfJobs.Jobs[i].Result.([]interface{})...)
+		}
+	}
+
+	return res, nil
+}
+
+func (a *mqlAwsNeptune) getDbClusters(conn *connection.AwsConnection) []*jobpool.Job {
+	tasks := make([]*jobpool.Job, 0)
+	regions, err := conn.Regions()
+	if err != nil {
+		return []*jobpool.Job{{Err: err}}
+	}
+
+	for _, region := range regions {
+		regionVal := region
+		f := func() (jobpool.JobResult, error) {
+			log.Debug().Msgf("neptune>getDbClusters>calling aws with region %s", regionVal)
+
+			svc := conn.Neptune(regionVal)
+			ctx := context.Background()
+			res := []interface{}{}
+
+			var marker *string
+			for {
+				cluster, err := svc.DescribeDBClusters(ctx, &neptune.DescribeDBClustersInput{
+					Marker: marker,
+				})
+				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
+					return nil, err
+				}
+				if len(cluster.DBClusters) == 0 {
+					return nil, nil
+				}
+				for i := range cluster.DBClusters {
+					cluster := cluster.DBClusters[i]
+
+					mqlCluster, err := CreateResource(a.MqlRuntime, "aws.neptune.cluster",
+						map[string]*llx.RawData{
+							"__id":                             llx.StringDataPtr(cluster.DBClusterArn),
+							"arn":                              llx.StringDataPtr(cluster.DBClusterArn),
+							"name":                             llx.StringDataPtr(cluster.DatabaseName),
+							"clusterIdentifier":                llx.StringDataPtr(cluster.DBClusterIdentifier),
+							"globalClusterIdentifier":          llx.StringDataPtr(cluster.GlobalClusterIdentifier),
+							"engine":                           llx.StringDataPtr(cluster.Engine),
+							"engineVersion":                    llx.StringDataPtr(cluster.EngineVersion),
+							"kmsKeyId":                         llx.StringDataPtr(cluster.KmsKeyId),
+							"region":                           llx.StringData(regionVal),
+							"automaticRestartTime":             llx.TimeDataPtr(cluster.AutomaticRestartTime),
+							"availabilityZones":                llx.ArrayData(convert.SliceAnyToInterface(cluster.AvailabilityZones), types.String),
+							"backupRetentionPeriod":            llx.IntDataPtr(cluster.BackupRetentionPeriod),
+							"createdAt":                        llx.TimeDataPtr(cluster.ClusterCreateTime),
+							"crossAccountClone":                llx.BoolDataPtr(cluster.CrossAccountClone),
+							"clusterParameterGroup":            llx.StringDataPtr(cluster.DBClusterParameterGroup),
+							"subnetGroup":                      llx.StringDataPtr(cluster.DBSubnetGroup),
+							"clusterResourceId":                llx.StringDataPtr(cluster.DbClusterResourceId),
+							"deletionProtection":               llx.BoolDataPtr(cluster.DeletionProtection),
+							"earliestRestorableTime":           llx.TimeDataPtr(cluster.EarliestRestorableTime),
+							"endpoint":                         llx.StringDataPtr(cluster.Endpoint),
+							"iamDatabaseAuthenticationEnabled": llx.BoolDataPtr(cluster.IAMDatabaseAuthenticationEnabled),
+							"latestRestorableTime":             llx.TimeDataPtr(cluster.LatestRestorableTime),
+							"masterUsername":                   llx.StringDataPtr(cluster.MasterUsername),
+							"multiAZ":                          llx.BoolDataPtr(cluster.MultiAZ),
+							"port":                             llx.IntDataPtr(cluster.Port),
+							"preferredBackupWindow":            llx.StringDataPtr(cluster.PreferredBackupWindow),
+							"preferredMaintenanceWindow":       llx.StringDataPtr(cluster.PreferredMaintenanceWindow),
+							"status":                           llx.StringDataPtr(cluster.Status),
+							"storageEncrypted":                 llx.BoolDataPtr(cluster.StorageEncrypted),
+							"storageType":                      llx.StringDataPtr(cluster.StorageType),
+						})
+					if err != nil {
+						return nil, err
+					}
+					res = append(res, mqlCluster)
+				}
+				if cluster.Marker == nil {
+					break
+				}
+				marker = cluster.Marker
+			}
+			return jobpool.JobResult(res), nil
+		}
+		tasks = append(tasks, jobpool.NewJob(f))
+	}
+	return tasks
+}
+
+func (a *mqlAwsNeptune) instances() ([]interface{}, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	res := []interface{}{}
+	poolOfJobs := jobpool.CreatePool(a.getDbInstances(conn), 5)
+	poolOfJobs.Run()
+
+	// check for errors
+	if poolOfJobs.HasErrors() {
+		return nil, poolOfJobs.GetErrors()
+	}
+	// get all the results
+	for i := range poolOfJobs.Jobs {
+		if poolOfJobs.Jobs[i].Result != nil {
+			res = append(res, poolOfJobs.Jobs[i].Result.([]interface{})...)
+		}
+	}
+
+	return res, nil
+}
+
+func (a *mqlAwsNeptune) getDbInstances(conn *connection.AwsConnection) []*jobpool.Job {
+	tasks := make([]*jobpool.Job, 0)
+	regions, err := conn.Regions()
+	if err != nil {
+		return []*jobpool.Job{{Err: err}}
+	}
+
+	for _, region := range regions {
+		regionVal := region
+		f := func() (jobpool.JobResult, error) {
+			log.Debug().Msgf("neptune>getDbInstances>calling aws with region %s", regionVal)
+
+			svc := conn.Neptune(regionVal)
+			ctx := context.Background()
+			res := []interface{}{}
+
+			var marker *string
+			for {
+				cluster, err := svc.DescribeDBInstances(ctx, &neptune.DescribeDBInstancesInput{
+					Marker: marker,
+				})
+				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						return res, nil
+					}
+					return nil, err
+				}
+				if len(cluster.DBInstances) == 0 {
+					return nil, nil
+				}
+				for i := range cluster.DBInstances {
+					instance := cluster.DBInstances[i]
+
+					endpoint, _ := convert.JsonToDictSlice(instance.Endpoint)
+
+					mqlCluster, err := CreateResource(a.MqlRuntime, "aws.neptune.instance",
+						map[string]*llx.RawData{
+							"__id":                             llx.StringDataPtr(instance.DBInstanceArn),
+							"arn":                              llx.StringDataPtr(instance.DBInstanceArn),
+							"name":                             llx.StringDataPtr(instance.DBName),
+							"clusterIdentifier":                llx.StringDataPtr(instance.DBClusterIdentifier),
+							"engine":                           llx.StringDataPtr(instance.Engine),
+							"engineVersion":                    llx.StringDataPtr(instance.EngineVersion),
+							"kmsKeyId":                         llx.StringDataPtr(instance.KmsKeyId),
+							"region":                           llx.StringData(regionVal),
+							"autoMinorVersionUpgrade":          llx.BoolDataPtr(instance.AutoMinorVersionUpgrade),
+							"availabilityZone":                 llx.StringDataPtr(instance.AvailabilityZone),
+							"backupRetentionPeriod":            llx.IntDataPtr(instance.BackupRetentionPeriod),
+							"createdAt":                        llx.TimeDataPtr(instance.InstanceCreateTime),
+							"instanceClass":                    llx.StringDataPtr(instance.DBInstanceClass),
+							"deletionProtection":               llx.BoolDataPtr(instance.DeletionProtection),
+							"monitoringInterval":               llx.IntDataPtr(instance.MonitoringInterval),
+							"monitoringRoleArn":                llx.StringDataPtr(instance.MonitoringRoleArn),
+							"latestRestorableTime":             llx.TimeDataPtr(instance.LatestRestorableTime),
+							"enabledCloudwatchLogsExports":     llx.ArrayData(convert.SliceAnyToInterface(instance.EnabledCloudwatchLogsExports), types.String),
+							"enhancedMonitoringResourceArn":    llx.StringDataPtr(instance.EnhancedMonitoringResourceArn),
+							"endpoint":                         llx.DictData(endpoint),
+							"iamDatabaseAuthenticationEnabled": llx.BoolDataPtr(instance.IAMDatabaseAuthenticationEnabled),
+							"masterUsername":                   llx.StringDataPtr(instance.MasterUsername),
+							"multiAZ":                          llx.BoolDataPtr(instance.MultiAZ),
+							"port":                             llx.IntDataPtr(instance.DbInstancePort),
+							"preferredBackupWindow":            llx.StringDataPtr(instance.PreferredBackupWindow),
+							"preferredMaintenanceWindow":       llx.StringDataPtr(instance.PreferredMaintenanceWindow),
+							"status":                           llx.StringDataPtr(instance.DBInstanceStatus),
+							"storageType":                      llx.StringDataPtr(instance.StorageType),
+							"storageEncrypted":                 llx.BoolDataPtr(instance.StorageEncrypted),
+						})
+					if err != nil {
+						return nil, err
+					}
+					res = append(res, mqlCluster)
+				}
+				if cluster.Marker == nil {
+					break
+				}
+				marker = cluster.Marker
+			}
+			return jobpool.JobResult(res), nil
+		}
+		tasks = append(tasks, jobpool.NewJob(f))
+	}
+	return tasks
+}


### PR DESCRIPTION
This PR adds new resources to query AWS Neptune for its configuration

```javascript
cnquery> aws.neptune.clusters
aws.neptune.clusters: [
  0: aws.neptune.cluster arn="arn:aws:rds:us-east-1:162854405951:cluster:db-neptune-1" name=null status="available"
]
cnquery> aws.neptune.instances
aws.neptune.instances: [
  0: aws.neptune.instance arn="arn:aws:rds:us-east-1:162854405951:db:db-neptune-1-instance-1" name=null status="available"
]
```