### PR TITLE
If there is no init system, return empty services

### DIFF
--- a/providers/os/resources/services/testdata/photon.toml
+++ b/providers/os/resources/services/testdata/photon.toml
@@ -141,3 +141,11 @@ vmtoolsd.service                       enabled         enabled
 
 137 unit files listed.
 """
+
+[files."/sbin/init"]
+path = "/sbin/init"
+
+[files."/sbin/init".stat]
+mode = 33261
+uid = 0
+gid = 0

--- a/providers/os/resources/services/testdata/ubuntu2204.toml
+++ b/providers/os/resources/services/testdata/ubuntu2204.toml
@@ -267,3 +267,11 @@ x11-common.service                         masked          enabled
 
 263 unit files listed.
 """
+
+[files."/sbin/init"]
+path = "/sbin/init"
+
+[files."/sbin/init".stat]
+mode = 33261
+uid = 0
+gid = 0


### PR DESCRIPTION
If there is no init system, like in containers, we dont have something
managing services to list. This change modifies the code to return an
empty list in the case we do not detect `/sbin/init`