### PR TITLE
🐛 provider installer timeout fix

### DIFF
--- a/providers/providers.go
+++ b/providers/providers.go
@@ -431,7 +431,7 @@ func installVersion(name string, version string) (*Provider, error) {
 		Dst: DefaultPath,
 	})
 	if err != nil {
-		log.Debug().Str("url", url).Msg("failed to install form URL (download)")
+		log.Debug().Str("url", url).Msg("failed to install from URL (download)")
 		return nil, errors.Wrap(err, "failed to install "+name+"-"+version)
 	}
 


### PR DESCRIPTION
I've been testing cnquery on a machine with heavily degraded disk and network performance and stumbled upon the following bug
If download and/or unpacking takes longer than 30 seconds (currently set Timeout) - context used during the request gets auto-cancelled (per set Timeout as expected). 
Problem tho is that resulting `io.ReadCloser` http client returns has timeout check embedded into it, so when our `walkTarXz` function tries to unpack the tarball, `Read()` returns error like in the log, **despite provider was downloaded sucessfuly**.

This behaviour is well explained here: https://github.com/golang/go/issues/49366

Example logs:
```
DBG performing request method=GET url=https://releases.mondoo.com/providers/latest.json
→ installing provider 'os' version=11.2.22
DBG installing provider from URL url=https://releases.mondoo.com/providers/os/11.2.22/os_11.2.22_linux_amd64.tar.xz
DBG performing request method=GET url=https://releases.mondoo.com/providers/os/11.2.22/os_11.2.22_linux_amd64.tar.xz
DBG create temp directory to unpack providers
DBG unpacking providers path=/opt/mondoo/providers/.providers-unpack202145731
DBG unpacking file dest=/opt/mondoo/providers/.providers-unpack202145731/os name=os
DBG failed to install form URL (download) url=https://releases.mondoo.com/providers/os/11.2.22/os_11.2.22_linux_amd64.tar.xz
FTL failed to install error="failed to install os-11.2.22: context deadline exceeded (Client.Timeout or context cancellation while reading body)"

real	0m35.974s
user	0m3.538s
sys	0m3.487s
```