### PR TITLE
🐛 Fix endless KMS retrieval loop.

### DIFF
--- a/providers/aws/resources/aws_kms.go
+++ b/providers/aws/resources/aws_kms.go
@@ -65,7 +65,7 @@ func (a *mqlAwsKms) getKeys(conn *connection.AwsConnection) []*jobpool.Job {
 					if Is400AccessDeniedError(err) {
 						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
 					}
-					continue
+					break
 				}
 
 				for _, key := range keyList.Keys {


### PR DESCRIPTION
If an err happens when we're fetching KMS key, we continue and do not break. This means we get to retry again, however if the error is consistent (say a 403) we will never exit this loop. Instead, let's break out of the loop if we encounter an error.