### PR TITLE
⭐ improve access to roles in Microsoft 365

### DIFF
--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -20,6 +20,8 @@ microsoft {
   serviceprincipals() []microsoft.serviceprincipal
   // List of enterprise applications
   enterpriseApplications() []microsoft.serviceprincipal
+  // List of roles
+  roles() []microsoft.rolemanagement.roledefinition
   // Microsoft 365 settings
   settings() dict
   // The connected tenant's default domain name
@@ -357,9 +359,9 @@ microsoft.policies {
   permissionGrantPolicies() []dict
 }
 
-// Microsoft role management
+// Deprecated: use `microsoft.roles` instead
 microsoft.rolemanagement {
-  // List of role definitions
+  // Deprecated: use `microsoft.roles` instead
   roleDefinitions() []microsoft.rolemanagement.roledefinition
 }
 

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -231,6 +231,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.enterpriseApplications": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoft).GetEnterpriseApplications()).ToDataRes(types.Array(types.Resource("microsoft.serviceprincipal")))
 	},
+	"microsoft.roles": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoft).GetRoles()).ToDataRes(types.Array(types.Resource("microsoft.rolemanagement.roledefinition")))
+	},
 	"microsoft.settings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoft).GetSettings()).ToDataRes(types.Dict)
 	},
@@ -984,6 +987,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"microsoft.enterpriseApplications": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoft).EnterpriseApplications, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"microsoft.roles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoft).Roles, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
 	"microsoft.settings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2090,6 +2097,7 @@ type mqlMicrosoft struct {
 	Applications plugin.TValue[[]interface{}]
 	Serviceprincipals plugin.TValue[[]interface{}]
 	EnterpriseApplications plugin.TValue[[]interface{}]
+	Roles plugin.TValue[[]interface{}]
 	Settings plugin.TValue[interface{}]
 	TenantDomainName plugin.TValue[string]
 }
@@ -2235,6 +2243,22 @@ func (c *mqlMicrosoft) GetEnterpriseApplications() *plugin.TValue[[]interface{}]
 		}
 
 		return c.enterpriseApplications()
+	})
+}
+
+func (c *mqlMicrosoft) GetRoles() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.Roles, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft", c.__id, "roles")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.roles()
 	})
 }
 

--- a/providers/ms365/resources/ms365.lr.manifest.yaml
+++ b/providers/ms365/resources/ms365.lr.manifest.yaml
@@ -10,6 +10,8 @@ resources:
         min_mondoo_version: latest
       groups: {}
       organizations: {}
+      roles:
+        min_mondoo_version: 9.0.0
       serviceprincipals: {}
       settings: {}
       tenantDomainName:


### PR DESCRIPTION
Simplify the way we access roles in Microsoft 365:

Instead of `microsoft.rolemanagement.roleDefinitions` we can just type:

```javascript
cnquery> microsoft.roles
microsoft.roles: [
  0: microsoft.rolemanagement.roledefinition id="62e90394-69f5-4237-9190-012177145e10" displayName="Global Administrator"
  1: microsoft.rolemanagement.roledefinition id="10dae51f-b6af-4016-8d66-8c2a99b929b3" displayName="Guest User"
  2: microsoft.rolemanagement.roledefinition id="2af84b1e-32c8-42b7-82bc-daa82404023b" displayName="Restricted Guest User"
  3: microsoft.rolemanagement.roledefinition id="95e79109-95c0-4d8e-aee3-d01accf2d47b" displayName="Guest Inviter"
...
```