### PR TITLE
🧹 return the correct value for aws account id when connected to subresource

### DIFF
--- a/providers/aws/resources/aws_account.go
+++ b/providers/aws/resources/aws_account.go
@@ -6,7 +6,6 @@ package resources
 import (
 	"context"
 	"errors"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/organizations"
@@ -111,11 +110,10 @@ func initAwsAccount(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 	if len(args) >= 2 {
 		return args, nil, nil
 	}
+
 	if len(args) == 0 {
-		if ids := getAssetIdentifier(runtime); ids != nil {
-			id := strings.TrimPrefix(ids.arn, "arn:aws:sts::")
-			args["id"] = llx.StringData(id)
-		}
+		conn := runtime.Connection.(*connection.AwsConnection)
+		args["id"] = llx.StringData(conn.AccountId())
 	}
 	if args["id"] == nil {
 		return args, nil, errors.New("no account id specified")


### PR DESCRIPTION
e.g. an s3 bucket, iam user

we were actually returning the arn of the iam user and s3 bucket in those cases, because we were grabbing the asset identifier ARN value.

this ensures we always return the account id.

tested with `cnspec shell aws `, `cnspec shell aws --discover iam-user`, `cnspec shell aws --discover s3-bucket`