### PR TITLE
🐛 fix fetching of fields for role definitions

### DIFF
--- a/providers/ms365/resources/rolemanagement.go
+++ b/providers/ms365/resources/rolemanagement.go
@@ -22,7 +22,11 @@ func fetchRoles(runtime *plugin.Runtime) ([]interface{}, error) {
 	}
 	ctx := context.Background()
 
-	resp, err := graphClient.RoleManagement().Directory().RoleDefinitions().Get(ctx, &rolemanagement.DirectoryRoleDefinitionsRequestBuilderGetRequestConfiguration{})
+	resp, err := graphClient.RoleManagement().Directory().RoleDefinitions().Get(ctx, &rolemanagement.DirectoryRoleDefinitionsRequestBuilderGetRequestConfiguration{
+		QueryParameters: &rolemanagement.DirectoryRoleDefinitionsRequestBuilderGetQueryParameters{
+			Select: []string{"id", "description", "displayName", "isBuiltIn", "isEnabled", "rolePermissions", "templateId", "version"},
+		},
+	})
 	if err != nil {
 		return nil, transformError(err)
 	}


### PR DESCRIPTION
We need to fetch the field `isBuiltIn` when we fetch roles. This allows us to filter roles quickly:

```javascript
cnquery> microsoft.roles.where(isBuiltIn == false)
microsoft.roles.where: []
```
