### PR TITLE
⭐️ Microsoft 365 first party apps filtering

### DIFF
--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -313,6 +313,8 @@ private microsoft.serviceprincipal @defaults("name") {
   name string
   // Application ID
   appId string
+  // Application owner ID
+  appOwnerOrganizationId string
   // Application description
   description string
   // Service principal tags
@@ -335,6 +337,8 @@ private microsoft.serviceprincipal @defaults("name") {
   assignments []microsoft.serviceprincipal.assignment
   // Application template ID
   applicationTemplateId string
+  // Application publisher
+  verifiedPublisher dict
   // Login URL
   loginUrl string
   // Logout URL
@@ -349,8 +353,10 @@ private microsoft.serviceprincipal @defaults("name") {
   notificationEmailAddresses []string
   // App role assignment required
   appRoleAssignmentRequired bool
-  // Account enabled
+  // Deprecated: use `enabled` instead
   accountEnabled bool
+  // Whether it is a first-party Microsoft application
+  isFirstParty() bool
 }
 
 // Microsoft Service Principal Assignment

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -613,6 +613,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.serviceprincipal.appId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftServiceprincipal).GetAppId()).ToDataRes(types.String)
 	},
+	"microsoft.serviceprincipal.appOwnerOrganizationId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftServiceprincipal).GetAppOwnerOrganizationId()).ToDataRes(types.String)
+	},
 	"microsoft.serviceprincipal.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftServiceprincipal).GetDescription()).ToDataRes(types.String)
 	},
@@ -646,6 +649,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.serviceprincipal.applicationTemplateId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftServiceprincipal).GetApplicationTemplateId()).ToDataRes(types.String)
 	},
+	"microsoft.serviceprincipal.verifiedPublisher": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftServiceprincipal).GetVerifiedPublisher()).ToDataRes(types.Dict)
+	},
 	"microsoft.serviceprincipal.loginUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftServiceprincipal).GetLoginUrl()).ToDataRes(types.String)
 	},
@@ -669,6 +675,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"microsoft.serviceprincipal.accountEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftServiceprincipal).GetAccountEnabled()).ToDataRes(types.Bool)
+	},
+	"microsoft.serviceprincipal.isFirstParty": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftServiceprincipal).GetIsFirstParty()).ToDataRes(types.Bool)
 	},
 	"microsoft.serviceprincipal.assignment.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftServiceprincipalAssignment).GetId()).ToDataRes(types.String)
@@ -1606,6 +1615,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlMicrosoftServiceprincipal).AppId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"microsoft.serviceprincipal.appOwnerOrganizationId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftServiceprincipal).AppOwnerOrganizationId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"microsoft.serviceprincipal.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftServiceprincipal).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -1650,6 +1663,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlMicrosoftServiceprincipal).ApplicationTemplateId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"microsoft.serviceprincipal.verifiedPublisher": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftServiceprincipal).VerifiedPublisher, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
+		return
+	},
 	"microsoft.serviceprincipal.loginUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftServiceprincipal).LoginUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -1680,6 +1697,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"microsoft.serviceprincipal.accountEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftServiceprincipal).AccountEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"microsoft.serviceprincipal.isFirstParty": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftServiceprincipal).IsFirstParty, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"microsoft.serviceprincipal.assignment.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3486,6 +3507,7 @@ type mqlMicrosoftServiceprincipal struct {
 	Type plugin.TValue[string]
 	Name plugin.TValue[string]
 	AppId plugin.TValue[string]
+	AppOwnerOrganizationId plugin.TValue[string]
 	Description plugin.TValue[string]
 	Tags plugin.TValue[[]interface{}]
 	Enabled plugin.TValue[bool]
@@ -3497,6 +3519,7 @@ type mqlMicrosoftServiceprincipal struct {
 	Notes plugin.TValue[string]
 	Assignments plugin.TValue[[]interface{}]
 	ApplicationTemplateId plugin.TValue[string]
+	VerifiedPublisher plugin.TValue[interface{}]
 	LoginUrl plugin.TValue[string]
 	LogoutUrl plugin.TValue[string]
 	ServicePrincipalNames plugin.TValue[[]interface{}]
@@ -3505,6 +3528,7 @@ type mqlMicrosoftServiceprincipal struct {
 	NotificationEmailAddresses plugin.TValue[[]interface{}]
 	AppRoleAssignmentRequired plugin.TValue[bool]
 	AccountEnabled plugin.TValue[bool]
+	IsFirstParty plugin.TValue[bool]
 }
 
 // createMicrosoftServiceprincipal creates a new instance of this resource
@@ -3560,6 +3584,10 @@ func (c *mqlMicrosoftServiceprincipal) GetAppId() *plugin.TValue[string] {
 	return &c.AppId
 }
 
+func (c *mqlMicrosoftServiceprincipal) GetAppOwnerOrganizationId() *plugin.TValue[string] {
+	return &c.AppOwnerOrganizationId
+}
+
 func (c *mqlMicrosoftServiceprincipal) GetDescription() *plugin.TValue[string] {
 	return &c.Description
 }
@@ -3604,6 +3632,10 @@ func (c *mqlMicrosoftServiceprincipal) GetApplicationTemplateId() *plugin.TValue
 	return &c.ApplicationTemplateId
 }
 
+func (c *mqlMicrosoftServiceprincipal) GetVerifiedPublisher() *plugin.TValue[interface{}] {
+	return &c.VerifiedPublisher
+}
+
 func (c *mqlMicrosoftServiceprincipal) GetLoginUrl() *plugin.TValue[string] {
 	return &c.LoginUrl
 }
@@ -3634,6 +3666,12 @@ func (c *mqlMicrosoftServiceprincipal) GetAppRoleAssignmentRequired() *plugin.TV
 
 func (c *mqlMicrosoftServiceprincipal) GetAccountEnabled() *plugin.TValue[bool] {
 	return &c.AccountEnabled
+}
+
+func (c *mqlMicrosoftServiceprincipal) GetIsFirstParty() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsFirstParty, func() (bool, error) {
+		return c.isFirstParty()
+	})
 }
 
 // mqlMicrosoftServiceprincipalAssignment for the microsoft.serviceprincipal.assignment resource

--- a/providers/ms365/resources/ms365.lr.manifest.yaml
+++ b/providers/ms365/resources/ms365.lr.manifest.yaml
@@ -265,6 +265,8 @@ resources:
         min_mondoo_version: 9.0.0
       appId:
         min_mondoo_version: 9.0.0
+      appOwnerOrganizationId:
+        min_mondoo_version: 9.0.0
       appRoleAssignmentRequired:
         min_mondoo_version: 9.0.0
       appRoleAssignments:
@@ -282,6 +284,8 @@ resources:
       homepageUrl:
         min_mondoo_version: latest
       id: {}
+      isFirstParty:
+        min_mondoo_version: 9.0.0
       loginUrl:
         min_mondoo_version: 9.0.0
       logoutUrl:
@@ -310,6 +314,8 @@ resources:
         min_mondoo_version: latest
       userAccessUrl:
         min_mondoo_version: latest
+      verifiedPublisher:
+        min_mondoo_version: 9.0.0
       visibleToUsers:
         min_mondoo_version: latest
     is_private: true

--- a/providers/ms365/resources/serviceprincipals.go
+++ b/providers/ms365/resources/serviceprincipals.go
@@ -17,6 +17,8 @@ import (
 )
 
 const (
+	// Microsoft Entra Tenant IDs for first party apps as defined in
+	// https://learn.microsoft.com/en-us/troubleshoot/azure/entra/entra-id/governance/verify-first-party-apps-sign-in
 	MicrosoftEntraTenantID = "f8cdef31-a31e-4b4a-93e4-5f571e91255a"
 	MicrosoftTenantID      = "72f988bf-86f1-41af-91ab-2d7cd011db47"
 )

--- a/providers/ms365/resources/structs.go
+++ b/providers/ms365/resources/structs.go
@@ -933,3 +933,17 @@ func newCertificationable(s models.Certificationable) *Certificationable {
 		LastCertificationDateTime:       s.GetLastCertificationDateTime(),
 	}
 }
+
+type VerifiedPublisher struct {
+	DisplayName         *string    `json:"name"`
+	VerifiedPublisherId *string    `json:"verifiedPublisherId"`
+	CreatedAt           *time.Time `json:"createdAt"`
+}
+
+func newVerifiedPublisher(p models.VerifiedPublisherable) VerifiedPublisher {
+	return VerifiedPublisher{
+		DisplayName:         p.GetDisplayName(),
+		VerifiedPublisherId: p.GetVerifiedPublisherId(),
+		CreatedAt:           p.GetAddedDateTime(),
+	}
+}


### PR DESCRIPTION
When you want to verify enterprise apps and their permissions, it is essential to focus on the right enterprise applications. Therefore we introduce a new field `isFirstParty` to service principals:

```
cnquery> microsoft.serviceprincipals.where( isFirstParty == false)
microsoft.serviceprincipals.where: [
  0: microsoft.serviceprincipal name="chris-ms365"
  1: microsoft.serviceprincipal name="chris-mac-test"
]
```