### PR TITLE
⭐️ Microsoft 365 service principal permmission field

### DIFF
--- a/providers/ms365/resources/microsoft.go
+++ b/providers/ms365/resources/microsoft.go
@@ -3,7 +3,14 @@
 
 package resources
 
+import (
+	"sync"
+)
+
+var idxUsersById = &sync.RWMutex{}
+
 type mqlMicrosoftInternal struct {
+	permissionIndexer
 	// index users by id
 	idxUsersById map[string]*mqlMicrosoftUser
 }
@@ -19,7 +26,9 @@ func (a *mqlMicrosoft) initIndex() {
 // index adds a user to the internal indexes
 func (a *mqlMicrosoft) index(user *mqlMicrosoftUser) {
 	a.initIndex()
+	idxUsersById.Lock()
 	a.idxUsersById[user.Id.Data] = user
+	idxUsersById.Unlock()
 }
 
 // userById returns a user by id if it exists in the index
@@ -28,6 +37,8 @@ func (a *mqlMicrosoft) userById(id string) (*mqlMicrosoftUser, bool) {
 		return nil, false
 	}
 
+	idxUsersById.RLock()
 	res, ok := a.idxUsersById[id]
+	idxUsersById.RUnlock()
 	return res, ok
 }

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -334,7 +334,7 @@ private microsoft.passwordCredential @defaults("description expires keyId") {
 }
 
 // Microsoft service principal (Enterprise application)
-private microsoft.serviceprincipal @defaults("name") {
+microsoft.serviceprincipal @defaults("name") {
   // Service principal Object ID
   id string
   // Service principal type

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -389,6 +389,8 @@ private microsoft.serviceprincipal @defaults("name") {
   isFirstParty() bool
   // Application roles
   appRoles []microsoft.application.role
+  // Permissions
+  permissions() []microsoft.application.permission
 }
 
 // Microsoft Service Principal Assignment
@@ -399,6 +401,24 @@ private microsoft.serviceprincipal.assignment @defaults("id") {
   displayName string
   // Service Principal Assignment type
   type string
+}
+
+// Microsoft Service Principal Permission
+private microsoft.application.permission @defaults("appName name type status") {
+  // Id of the API
+  appId string
+  // Name of the API
+  appName string
+  // Permission ID
+  id  string
+  // Permission name
+  name string
+  // Permission description
+  description string
+  // Type eg. `application` or `delegated`
+  type string
+  // Status
+  status string
 }
 
 // Microsoft Security

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -63,7 +63,7 @@ func init() {
 			Create: createMicrosoftPasswordCredential,
 		},
 		"microsoft.serviceprincipal": {
-			// to override args, implement: initMicrosoftServiceprincipal(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init: initMicrosoftServiceprincipal,
 			Create: createMicrosoftServiceprincipal,
 		},
 		"microsoft.serviceprincipal.assignment": {

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -70,6 +70,10 @@ func init() {
 			// to override args, implement: initMicrosoftServiceprincipalAssignment(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMicrosoftServiceprincipalAssignment,
 		},
+		"microsoft.application.permission": {
+			// to override args, implement: initMicrosoftApplicationPermission(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createMicrosoftApplicationPermission,
+		},
 		"microsoft.security": {
 			// to override args, implement: initMicrosoftSecurity(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMicrosoftSecurity,
@@ -726,6 +730,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.serviceprincipal.appRoles": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftServiceprincipal).GetAppRoles()).ToDataRes(types.Array(types.Resource("microsoft.application.role")))
 	},
+	"microsoft.serviceprincipal.permissions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftServiceprincipal).GetPermissions()).ToDataRes(types.Array(types.Resource("microsoft.application.permission")))
+	},
 	"microsoft.serviceprincipal.assignment.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftServiceprincipalAssignment).GetId()).ToDataRes(types.String)
 	},
@@ -734,6 +741,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"microsoft.serviceprincipal.assignment.type": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftServiceprincipalAssignment).GetType()).ToDataRes(types.String)
+	},
+	"microsoft.application.permission.appId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftApplicationPermission).GetAppId()).ToDataRes(types.String)
+	},
+	"microsoft.application.permission.appName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftApplicationPermission).GetAppName()).ToDataRes(types.String)
+	},
+	"microsoft.application.permission.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftApplicationPermission).GetId()).ToDataRes(types.String)
+	},
+	"microsoft.application.permission.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftApplicationPermission).GetName()).ToDataRes(types.String)
+	},
+	"microsoft.application.permission.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftApplicationPermission).GetDescription()).ToDataRes(types.String)
+	},
+	"microsoft.application.permission.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftApplicationPermission).GetType()).ToDataRes(types.String)
+	},
+	"microsoft.application.permission.status": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftApplicationPermission).GetStatus()).ToDataRes(types.String)
 	},
 	"microsoft.security.secureScores": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftSecurity).GetSecureScores()).ToDataRes(types.Array(types.Resource("microsoft.security.securityscore")))
@@ -1833,6 +1861,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlMicrosoftServiceprincipal).AppRoles, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
+	"microsoft.serviceprincipal.permissions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftServiceprincipal).Permissions, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
 	"microsoft.serviceprincipal.assignment.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 			r.(*mqlMicrosoftServiceprincipalAssignment).__id, ok = v.Value.(string)
 			return
@@ -1847,6 +1879,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"microsoft.serviceprincipal.assignment.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftServiceprincipalAssignment).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.application.permission.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlMicrosoftApplicationPermission).__id, ok = v.Value.(string)
+			return
+		},
+	"microsoft.application.permission.appId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftApplicationPermission).AppId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.application.permission.appName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftApplicationPermission).AppName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.application.permission.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftApplicationPermission).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.application.permission.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftApplicationPermission).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.application.permission.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftApplicationPermission).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.application.permission.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftApplicationPermission).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.application.permission.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftApplicationPermission).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"microsoft.security.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3801,6 +3865,7 @@ type mqlMicrosoftServiceprincipal struct {
 	AccountEnabled plugin.TValue[bool]
 	IsFirstParty plugin.TValue[bool]
 	AppRoles plugin.TValue[[]interface{}]
+	Permissions plugin.TValue[[]interface{}]
 }
 
 // createMicrosoftServiceprincipal creates a new instance of this resource
@@ -3950,6 +4015,22 @@ func (c *mqlMicrosoftServiceprincipal) GetAppRoles() *plugin.TValue[[]interface{
 	return &c.AppRoles
 }
 
+func (c *mqlMicrosoftServiceprincipal) GetPermissions() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.Permissions, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft.serviceprincipal", c.__id, "permissions")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.permissions()
+	})
+}
+
 // mqlMicrosoftServiceprincipalAssignment for the microsoft.serviceprincipal.assignment resource
 type mqlMicrosoftServiceprincipalAssignment struct {
 	MqlRuntime *plugin.Runtime
@@ -4007,6 +4088,80 @@ func (c *mqlMicrosoftServiceprincipalAssignment) GetDisplayName() *plugin.TValue
 
 func (c *mqlMicrosoftServiceprincipalAssignment) GetType() *plugin.TValue[string] {
 	return &c.Type
+}
+
+// mqlMicrosoftApplicationPermission for the microsoft.application.permission resource
+type mqlMicrosoftApplicationPermission struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlMicrosoftApplicationPermissionInternal it will be used here
+	AppId plugin.TValue[string]
+	AppName plugin.TValue[string]
+	Id plugin.TValue[string]
+	Name plugin.TValue[string]
+	Description plugin.TValue[string]
+	Type plugin.TValue[string]
+	Status plugin.TValue[string]
+}
+
+// createMicrosoftApplicationPermission creates a new instance of this resource
+func createMicrosoftApplicationPermission(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMicrosoftApplicationPermission{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("microsoft.application.permission", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMicrosoftApplicationPermission) MqlName() string {
+	return "microsoft.application.permission"
+}
+
+func (c *mqlMicrosoftApplicationPermission) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMicrosoftApplicationPermission) GetAppId() *plugin.TValue[string] {
+	return &c.AppId
+}
+
+func (c *mqlMicrosoftApplicationPermission) GetAppName() *plugin.TValue[string] {
+	return &c.AppName
+}
+
+func (c *mqlMicrosoftApplicationPermission) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlMicrosoftApplicationPermission) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlMicrosoftApplicationPermission) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlMicrosoftApplicationPermission) GetType() *plugin.TValue[string] {
+	return &c.Type
+}
+
+func (c *mqlMicrosoftApplicationPermission) GetStatus() *plugin.TValue[string] {
+	return &c.Status
 }
 
 // mqlMicrosoftSecurity for the microsoft.security resource

--- a/providers/ms365/resources/ms365.lr.manifest.yaml
+++ b/providers/ms365/resources/ms365.lr.manifest.yaml
@@ -72,6 +72,8 @@ resources:
       publisherDomain: {}
       requestSignatureVerification:
         min_mondoo_version: 9.0.0
+      requiredResourceAccess:
+        min_mondoo_version: 9.0.0
       samlMetadataUrl:
         min_mondoo_version: 9.0.0
       secrets:
@@ -94,6 +96,18 @@ resources:
       web:
         min_mondoo_version: 9.0.0
     min_mondoo_version: 5.15.0
+  microsoft.application.permission:
+    fields:
+      adminConsent: {}
+      appId: {}
+      appName: {}
+      description: {}
+      id: {}
+      name: {}
+      status: {}
+      type: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
   microsoft.application.role:
     fields:
       allowedMemberTypes: {}
@@ -321,6 +335,8 @@ resources:
       notes:
         min_mondoo_version: latest
       notificationEmailAddresses:
+        min_mondoo_version: 9.0.0
+      permissions:
         min_mondoo_version: 9.0.0
       preferredSingleSignOnMode:
         min_mondoo_version: 9.0.0

--- a/providers/ms365/resources/ms365.lr.manifest.yaml
+++ b/providers/ms365/resources/ms365.lr.manifest.yaml
@@ -360,7 +360,6 @@ resources:
         min_mondoo_version: 9.0.0
       visibleToUsers:
         min_mondoo_version: latest
-    is_private: true
     min_mondoo_version: 5.15.0
   microsoft.serviceprincipal.appRoleAssignment:
     fields:

--- a/providers/ms365/resources/serviceprincipals.go
+++ b/providers/ms365/resources/serviceprincipals.go
@@ -5,10 +5,11 @@ package resources
 
 import (
 	"context"
-	"github.com/rs/zerolog/log"
+	"sync"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/serviceprincipals"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/convert"
@@ -24,26 +25,136 @@ const (
 	MicrosoftTenantID      = "72f988bf-86f1-41af-91ab-2d7cd011db47"
 )
 
-func (m *mqlMicrosoftServiceprincipal) id() (string, error) {
-	return m.Id.Data, nil
+// index for service principal app roles
+var idxAppRoleMutex = &sync.RWMutex{}
+var idxOauthScopeMutex = &sync.RWMutex{}
+var idxAppNamesMutex = &sync.RWMutex{}
+
+type roleCache struct {
+	id         string
+	desc       string
+	permission string
 }
 
-func (m *mqlMicrosoftServiceprincipalAssignment) id() (string, error) {
-	return m.Id.Data, nil
+type oauth2PermissionScope struct {
+	id         string
+	desc       string
+	permission string
 }
 
-// enterprise applications are just service principals with a special tag, attached to them
-// this is the same way the portal UI fetches the enterprise apps by looking for the tag
-func (a *mqlMicrosoft) enterpriseApplications() ([]interface{}, error) {
-	conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)
-	top := int32(999)
-	filter := "tags/Any(x: x eq 'WindowsAzureActiveDirectoryIntegratedApp')"
-	params := &serviceprincipals.ServicePrincipalsRequestBuilderGetQueryParameters{
-		Top:    &top,
-		Filter: &filter,
-		Expand: []string{"appRoleAssignedTo"},
+type PermissionIndexer interface {
+	IndexAppName(spId, appName string)
+	IndexAppRole(spId string, roles ...models.AppRoleable)
+	IndexOauthScope(spId string, scopes ...models.PermissionScopeable)
+}
+
+// creates a new permission indexer to cache the service principal app roles and oauth scopes
+type permissionIndexer struct {
+	// permission index key : appId/roleID value: permission
+	idxAppRoles map[string]*roleCache
+	// permission index key : appId/permission value: permission
+	idxOauthPermissionScopes map[string]*oauth2PermissionScope
+	// index of app names by appId
+	idxAppNames map[string]string
+}
+
+func (idx *permissionIndexer) initAppRoleIndex() {
+	if idx.idxAppRoles == nil {
+		idx.idxAppRoles = make(map[string]*roleCache)
 	}
-	return fetchServicePrincipals(a.MqlRuntime, conn, params)
+}
+
+func (idx *permissionIndexer) initOauthPermissionScopeIndex() {
+	if idx.idxOauthPermissionScopes == nil {
+		idx.idxOauthPermissionScopes = make(map[string]*oauth2PermissionScope)
+	}
+}
+
+func (idx *permissionIndexer) initAppNameIndex() {
+	if idx.idxAppNames == nil {
+		idx.idxAppNames = make(map[string]string)
+	}
+}
+
+func (idx *permissionIndexer) IndexAppName(spId, name string) {
+	idx.initAppNameIndex()
+	idxAppNamesMutex.Lock()
+	idx.idxAppNames[spId] = name
+	idxAppNamesMutex.Unlock()
+}
+
+func (idx *permissionIndexer) appName(appId string) (string, bool) {
+	if idx.idxAppNames == nil {
+		return "", false
+	}
+	idxAppNamesMutex.RLock()
+	name, ok := idx.idxAppNames[appId]
+	idxAppNamesMutex.RUnlock()
+	return name, ok
+}
+
+// index all app roles we've seen for service-accounts
+func (idx *permissionIndexer) IndexAppRole(spId string, roles ...models.AppRoleable) {
+	idx.initAppRoleIndex()
+	idxAppRoleMutex.Lock()
+	for _, r := range roles {
+		roleId := r.GetId()
+		if roleId == nil || roleId.String() == "" {
+			continue
+		}
+
+		rCache := &roleCache{
+			id:         roleId.String(),
+			desc:       convert.ToString(r.GetDisplayName()),
+			permission: convert.ToString(r.GetValue()),
+		}
+
+		idx.idxAppRoles[spId+"/"+rCache.id] = rCache
+		idx.idxAppRoles[spId+"/"+rCache.permission] = rCache
+	}
+	idxAppRoleMutex.Unlock()
+}
+
+// appRole returns a role by appId and roleID
+func (idx *permissionIndexer) appRole(spId, roleId string) (*roleCache, bool) {
+	if idx.idxAppRoles == nil {
+		return nil, false
+	}
+	idxAppRoleMutex.RLock()
+	role, ok := idx.idxAppRoles[spId+"/"+roleId]
+	idxAppRoleMutex.RUnlock()
+	return role, ok
+}
+
+// index all oauth scopes we've seen for service-accounts
+func (idx *permissionIndexer) IndexOauthScope(spId string, scopes ...models.PermissionScopeable) {
+	idxOauthScopeMutex.Lock()
+	idx.initOauthPermissionScopeIndex()
+	for _, s := range scopes {
+		scopeId := s.GetId()
+		if scopeId == nil || scopeId.String() == "" {
+			continue
+		}
+
+		scope := &oauth2PermissionScope{
+			id:         scopeId.String(),
+			desc:       convert.ToString(s.GetAdminConsentDisplayName()),
+			permission: convert.ToString(s.GetValue()),
+		}
+
+		idx.idxOauthPermissionScopes[spId+"/"+scope.permission] = scope
+	}
+	idxOauthScopeMutex.Unlock()
+}
+
+func (idx *permissionIndexer) getOauthPermissionScope(appId, permission string) (*oauth2PermissionScope, bool) {
+	if idx.idxOauthPermissionScopes == nil {
+		return nil, false
+	}
+	idxOauthScopeMutex.RLock()
+	scope, ok := idx.idxOauthPermissionScopes[appId+"/"+permission]
+	idxOauthScopeMutex.RUnlock()
+	return scope, ok
 }
 
 var servicePrincipalFields = []string{
@@ -70,6 +181,29 @@ var servicePrincipalFields = []string{
 	"accountEnabled",
 	"verifiedPublisher",
 	"appRoles",
+	"oauth2PermissionScopes",
+}
+
+func (m *mqlMicrosoftServiceprincipal) id() (string, error) {
+	return m.Id.Data, nil
+}
+
+func (m *mqlMicrosoftServiceprincipalAssignment) id() (string, error) {
+	return m.Id.Data, nil
+}
+
+// enterprise applications are just service principals with a special tag, attached to them
+// this is the same way the portal UI fetches the enterprise apps by looking for the tag
+func (a *mqlMicrosoft) enterpriseApplications() ([]interface{}, error) {
+	conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)
+	top := int32(999)
+	filter := "tags/Any(x: x eq 'WindowsAzureActiveDirectoryIntegratedApp')"
+	params := &serviceprincipals.ServicePrincipalsRequestBuilderGetQueryParameters{
+		Top:    &top,
+		Filter: &filter,
+		Expand: []string{"appRoleAssignedTo"},
+	}
+	return fetchServicePrincipals(a.MqlRuntime, conn, params, nil)
 }
 
 func (a *mqlMicrosoft) serviceprincipals() ([]interface{}, error) {
@@ -79,10 +213,11 @@ func (a *mqlMicrosoft) serviceprincipals() ([]interface{}, error) {
 		Top:    &top,
 		Select: servicePrincipalFields,
 	}
-	return fetchServicePrincipals(a.MqlRuntime, conn, params)
+
+	return fetchServicePrincipals(a.MqlRuntime, conn, params, a)
 }
 
-func fetchServicePrincipals(runtime *plugin.Runtime, conn *connection.Ms365Connection, params *serviceprincipals.ServicePrincipalsRequestBuilderGetQueryParameters) ([]interface{}, error) {
+func fetchServicePrincipals(runtime *plugin.Runtime, conn *connection.Ms365Connection, params *serviceprincipals.ServicePrincipalsRequestBuilderGetQueryParameters, permissionIndexer PermissionIndexer) ([]interface{}, error) {
 	graphClient, err := conn.GraphClient()
 	if err != nil {
 		return nil, err
@@ -100,9 +235,17 @@ func fetchServicePrincipals(runtime *plugin.Runtime, conn *connection.Ms365Conne
 	}
 	res := []interface{}{}
 	for _, sp := range sps {
+		// create resource
 		mqlResource, err := newMqlMicrosoftServicePrincipal(runtime, sp)
 		if err != nil {
 			return nil, err
+		}
+
+		// also fill up the index
+		if permissionIndexer != nil {
+			permissionIndexer.IndexAppName(convert.ToString(sp.GetId()), *sp.GetDisplayName())
+			permissionIndexer.IndexAppRole(convert.ToString(sp.GetId()), sp.GetAppRoles()...)
+			permissionIndexer.IndexOauthScope(convert.ToString(sp.GetId()), sp.GetOauth2PermissionScopes()...)
 		}
 		res = append(res, mqlResource)
 	}
@@ -204,4 +347,100 @@ func (a *mqlMicrosoftServiceprincipal) isFirstParty() (bool, error) {
 		return true, nil
 	}
 	return false, nil
+}
+
+func (a *mqlMicrosoftServiceprincipal) permissions() ([]interface{}, error) {
+	conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)
+	graphClient, err := conn.GraphClient()
+	if err != nil {
+		return nil, err
+	}
+	servicePrincipalId := a.Id.Data
+
+	res, err := CreateResource(a.MqlRuntime, "microsoft", nil)
+	if err != nil {
+		return nil, err
+	}
+	mqlMicrosoftResource := res.(*mqlMicrosoft)
+
+	// fetch service credentials to build up the app role index
+	mqlMicrosoftResource.GetServiceprincipals()
+
+	// fetch all role assignments for the service principal, those are "application" types
+	ctx := context.Background()
+	grantedApplicationRolesResp, err := graphClient.ServicePrincipals().ByServicePrincipalId(servicePrincipalId).AppRoleAssignments().Get(ctx, &serviceprincipals.ItemAppRoleAssignmentsRequestBuilderGetRequestConfiguration{})
+	if err != nil {
+		return nil, transformError(err)
+	}
+
+	// TODO: also list ungranted app roles
+	list := []interface{}{}
+	appRolesAssignments := grantedApplicationRolesResp.GetValue()
+	for _, roleAssignment := range appRolesAssignments {
+		assignmentID := roleAssignment.GetId()
+		spId := roleAssignment.GetResourceId()  // id of the service account
+		roleId := roleAssignment.GetAppRoleId() // id of the app role on the service account
+
+		if assignmentID == nil || spId == nil || roleId == nil {
+			continue
+		}
+		role, ok := mqlMicrosoftResource.appRole(spId.String(), roleId.String())
+		if !ok {
+			log.Debug().Msgf("role not found in cache: %v", roleId)
+			continue
+		}
+
+		assignment, err := CreateResource(a.MqlRuntime, "microsoft.application.permission", map[string]*llx.RawData{
+			"__id":        llx.StringDataPtr(assignmentID),
+			"appId":       llx.StringData(spId.String()),
+			"appName":     llx.StringDataPtr(roleAssignment.GetResourceDisplayName()),
+			"description": llx.StringData(role.desc),
+			"id":          llx.StringData(roleId.String()),
+			"name":        llx.StringData(role.permission),
+			"type":        llx.StringData("application"),
+			"status":      llx.StringData("granted"),
+		})
+		if err != nil {
+			return nil, err
+		}
+		list = append(list, assignment)
+	}
+
+	oauthResp, err := graphClient.ServicePrincipals().ByServicePrincipalId(servicePrincipalId).Oauth2PermissionGrants().Get(ctx, &serviceprincipals.ItemOauth2PermissionGrantsRequestBuilderGetRequestConfiguration{})
+	delegatedRolesAssignments := oauthResp.GetValue()
+	for _, roleAssignment := range delegatedRolesAssignments {
+
+		spId := roleAssignment.GetResourceId() // id of the service account
+		if spId == nil {
+			continue
+		}
+
+		appName, _ := mqlMicrosoftResource.appName(*spId)
+		scope := roleAssignment.GetScope()
+		if scope == nil {
+			continue
+		}
+
+		desc := ""
+		role, ok := mqlMicrosoftResource.getOauthPermissionScope(*spId, *scope)
+		if ok {
+			desc = role.desc
+		}
+
+		assignment, err := CreateResource(a.MqlRuntime, "microsoft.application.permission", map[string]*llx.RawData{
+			"__id":        llx.StringDataPtr(roleAssignment.GetId()),
+			"appId":       llx.StringDataPtr(spId),
+			"appName":     llx.StringData(appName),
+			"description": llx.StringData(desc),
+			"id":          llx.StringDataPtr(roleAssignment.GetId()),
+			"name":        llx.StringDataPtr(scope),
+			"type":        llx.StringData("delegated"),
+			"status":      llx.StringData("granted"),
+		})
+		if err != nil {
+			return nil, err
+		}
+		list = append(list, assignment)
+	}
+	return list, nil
 }


### PR DESCRIPTION
after https://github.com/mondoohq/cnquery/pull/4574

One of the challenges for Microsoft 365 applications is to verify that permissions are set properly.

**Permissions for one specific app**

Application permissions are managed via service principal in Microsoft Entra ID. You can easily check a specific application:

```javascript
cnquery> microsoft.serviceprincipal(name: "chris-mac-test") { permissions }
microsoft.serviceprincipal: {
  permissions: [
    0: microsoft.application.permission appName="Microsoft Graph" name="User.ReadBasic.All" type="application" status="granted"
    1: microsoft.application.permission appName="Microsoft Graph" name="Directory.Read.All" type="application" status="granted"
    2: microsoft.application.permission appName="Microsoft Graph" name="User.Read.All" type="application" status="granted"
    3: microsoft.application.permission appName="Microsoft Graph" name="IdentityRiskyUser.Read.All" type="application" status="granted"
    4: microsoft.application.permission appName="Microsoft Graph" name="Organization.Read.All" type="application" status="granted"
    5: microsoft.application.permission appName="Microsoft Graph" name="Policy.Read.IdentityProtection" type="application" status="granted"
    6: microsoft.application.permission appName="Microsoft Graph" name="User.Read" type="delegated" status="granted"
  ]
}
```

> Note: names are not unqiue, therefore it is always more accurate to use the uuid as identifier

```javascript
cnquery> microsoft.serviceprincipal(id: "20401fcc-5786-4984-84e4-5a1b1cd4f38f") { permissions }
microsoft.serviceprincipal: {
  permissions: [
    0: microsoft.application.permission appName="Microsoft Graph" name="User.ReadBasic.All" type="application" status="granted"
    1: microsoft.application.permission appName="Microsoft Graph" name="Directory.Read.All" type="application" status="granted"
    2: microsoft.application.permission appName="Microsoft Graph" name="User.Read.All" type="application" status="granted"
    3: microsoft.application.permission appName="Microsoft Graph" name="IdentityRiskyUser.Read.All" type="application" status="granted"
    4: microsoft.application.permission appName="Microsoft Graph" name="Organization.Read.All" type="application" status="granted"
    5: microsoft.application.permission appName="Microsoft Graph" name="Policy.Read.IdentityProtection" type="application" status="granted"
    6: microsoft.application.permission appName="Microsoft Graph" name="User.Read" type="delegated" status="granted"
  ]
}
```

**Quickly see all permissions used by enterprise apps**

```javascript
cnquery> microsoft.enterpriseApplications { name permissions }
microsoft.enterpriseApplications: [
  0: {
    permissions: [
      0: microsoft.application.permission appName="Microsoft Graph" name="User.ReadBasic.All" type="application" status="granted"
      1: microsoft.application.permission appName="Microsoft Graph" name="Directory.Read.All" type="application" status="granted"
      2: microsoft.application.permission appName="Microsoft Graph" name="User.Read.All" type="application" status="granted"
      3: microsoft.application.permission appName="Microsoft Graph" name="IdentityRiskyUser.Read.All" type="application" status="granted"
      4: microsoft.application.permission appName="Microsoft Graph" name="Organization.Read.All" type="application" status="granted"
      5: microsoft.application.permission appName="Microsoft Graph" name="Policy.Read.IdentityProtection" type="application" status="granted"
      6: microsoft.application.permission appName="Microsoft Graph" name="User.Read" type="delegated" status="granted"
    ]
    name: "chris-mac-test"
  }
  ...
]
```


**Verify no write permission is used**

```javascript
cnquery> microsoft.enterpriseApplications.all(permissions.none(name == /Write/))
```

**Verify no write delegated permission is used**

```javascript
cnquery> microsoft.enterpriseApplications.all(permissions.none(type == "delegated"))
[failed] [].all()
  actual:   [
    0 : microsoft.serviceprincipal name="chris-mac-test" {
      permissions: [
        ...
      ]
    }
  ]
```
