### PR TITLE
⭐️ simplify azure iam access

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -53,6 +53,8 @@ azure.subscription @defaults ("name") {
   // Azure Key Vault resources in the subscription
   keyVault() azure.subscription.keyVaultService
   // Authorization resources in the subscription
+  iam() azure.subscription.authorizationService
+  // Deprecated: use `iam` instead
   authorization() azure.subscription.authorizationService
   // Monitor resources in the subscription
   monitor() azure.subscription.monitorService
@@ -1736,23 +1738,27 @@ private azure.subscription.cloudDefenderService.securityContact @defaults("name 
   notificationsByRole dict
 }
 
-// Azure authorization
+// Azure IAM service
 private azure.subscription.authorizationService {
   // Subscription identifier
   subscriptionId string
   // Role definitions for the Azure subscription
+  roles() []azure.subscription.authorizationService.roleDefinition
+  // Deprecated: use `roles` instead
   roleDefinitions() []azure.subscription.authorizationService.roleDefinition
 }
 
 // Azure role definition
-private azure.subscription.authorizationService.roleDefinition @defaults ("id name scopes") {
+private azure.subscription.authorizationService.roleDefinition @defaults ("name type") {
   // ID of the role definition
   id string
   // Description of the role definition
   description string
   // Name of the role definition
   name string
-  // Whether the role definition is manually created
+  // Role type
+  type string
+  // Deprecated: use `type` instead
   isCustom bool
   // Scopes for which the role definition applies
   scopes []string

--- a/providers/azure/resources/azure.lr.manifest.yaml
+++ b/providers/azure/resources/azure.lr.manifest.yaml
@@ -20,6 +20,8 @@ resources:
       cloudDefender: {}
       compute: {}
       cosmosDb: {}
+      iam:
+        min_mondoo_version: 9.0.0
       id: {}
       keyVault: {}
       managedByTenants: {}
@@ -292,6 +294,8 @@ resources:
   azure.subscription.authorizationService:
     fields:
       roleDefinitions: {}
+      roles:
+        min_mondoo_version: 9.0.0
       subscriptionId: {}
     is_private: true
     min_mondoo_version: latest
@@ -309,6 +313,8 @@ resources:
       name: {}
       permissions: {}
       scopes: {}
+      type:
+        min_mondoo_version: 9.0.0
     is_private: true
     min_mondoo_version: latest
     platform:

--- a/providers/azure/resources/subscription.go
+++ b/providers/azure/resources/subscription.go
@@ -187,17 +187,6 @@ func (a *mqlAzureSubscription) keyVault() (*mqlAzureSubscriptionKeyVaultService,
 	return kvSvc, nil
 }
 
-func (a *mqlAzureSubscription) authorization() (*mqlAzureSubscriptionAuthorizationService, error) {
-	svc, err := NewResource(a.MqlRuntime, "azure.subscription.authorizationService", map[string]*llx.RawData{
-		"subscriptionId": llx.StringData(a.SubscriptionId.Data),
-	})
-	if err != nil {
-		return nil, err
-	}
-	authSvc := svc.(*mqlAzureSubscriptionAuthorizationService)
-	return authSvc, nil
-}
-
 func (a *mqlAzureSubscription) cloudDefender() (*mqlAzureSubscriptionCloudDefenderService, error) {
 	svc, err := NewResource(a.MqlRuntime, "azure.subscription.cloudDefenderService", map[string]*llx.RawData{
 		"subscriptionId": llx.StringData(a.SubscriptionId.Data),


### PR DESCRIPTION
This changes improves the Azure experience for IAM access. Instead of `azure.subscription.authorization.roleDefinitions` we can simply call `azure.subscription.iam.roles` now:

```
cnquery> azure.subscription.iam.roles
azure.subscription.iam.roles: [
  0: azure.subscription.authorizationService.roleDefinition name="Security-Team-CustomRole" type="CustomRole"
  1: azure.subscription.authorizationService.roleDefinition name="AcrPush" type="BuiltInRole"
  2: azure.subscription.authorizationService.roleDefinition name="API Management Service Contributor" type="BuiltInRole"
  ...
]
````