### PR TITLE
🐛 Fix google workspace asset url

### DIFF
--- a/providers/google-workspace/config/config.go
+++ b/providers/google-workspace/config/config.go
@@ -58,15 +58,10 @@ The provider requires these three flags:
 	},
 	AssetUrlTrees: []*inventory.AssetUrlBranch{
 		{
-			PathSegments: []string{"technology=saas"},
-			Key:          "category",
+			PathSegments: []string{"technology=saas", "provider=google-workspace"},
+			Key:          "customer",
 			Values: map[string]*inventory.AssetUrlBranch{
-				"google-workspace": {
-					Key: "customer",
-					Values: map[string]*inventory.AssetUrlBranch{
-						"*": nil,
-					},
-				},
+				"*": nil,
 			},
 		},
 	},


### PR DESCRIPTION
`saas` is now a common tree and needs to behave properly with the other providers