### PR TITLE
🧹 use custom exist code when we shutdown the provider due to outstanding heartbeat

### DIFF
--- a/providers-sdk/v1/plugin/service.go
+++ b/providers-sdk/v1/plugin/service.go
@@ -247,7 +247,8 @@ func (s *Service) Heartbeat(req *HeartbeatReq) (*HeartbeatRes, error) {
 		s.heartbeatLock.Unlock()
 
 		if isDead {
-			os.Exit(1)
+			// use 4 since we actually do not want to reach the point, see tetraphobia
+			os.Exit(4)
 		}
 	}()
 


### PR DESCRIPTION
This will make it easier to identify cases where the heartbeat failed and the provider shut down without a panic.