### PR TITLE
🧹 improve github org discovery

### DIFF
--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -104,7 +104,9 @@ func org(runtime *plugin.Runtime, orgName string, conn *connection.GithubConnect
 		return nil, err
 	}
 
-	if reposFilter.empty() {
+	// only scan the org if the discover flag is provided, this allows you to scan all repos in an org with simply using
+	// --discover repos. If users provide a repo filter, we also want to skip org scan.
+	if stringx.ContainsAnyOf(targets, connection.DiscoveryOrganization, connection.DiscoveryAll, connection.DiscoveryAuto) && reposFilter.empty() {
 		assetList = append(assetList, &inventory.Asset{
 			PlatformIds: []string{connection.NewGithubOrgIdentifier(org.Login.Data)},
 			Name:        org.Name.Data,


### PR DESCRIPTION
Aligns the discovery with the user expectation:

- by default the org is scanned when user uses `cnquery scan github org <gh-org>`
- skip org scan if `cnquery scan github org <gh-org> --repos <repo1,repo2>` is used where 
- skip org scan if `scan github org <gh-org> --discover repos` is used