### PR TITLE
✨ Authored and Commited dates to :octocat: commits

### DIFF
--- a/providers/github/resources/github.lr
+++ b/providers/github/resources/github.lr
@@ -492,6 +492,10 @@ private github.commit @defaults("sha") {
   commit git.commit
   // Commit stats
   stats dict
+  // Authored Date
+  authoredDate time
+  // Commited Date
+  commitedDate time
 }
 
 // GitHub repository pull request

--- a/providers/github/resources/github.lr
+++ b/providers/github/resources/github.lr
@@ -494,8 +494,8 @@ private github.commit @defaults("sha") {
   stats dict
   // Authored Date
   authoredDate time
-  // Commited Date
-  commitedDate time
+  // Committed Date
+  committedDate time
 }
 
 // GitHub repository pull request

--- a/providers/github/resources/github.lr.go
+++ b/providers/github/resources/github.lr.go
@@ -810,6 +810,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"github.commit.stats": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubCommit).GetStats()).ToDataRes(types.Dict)
 	},
+	"github.commit.authoredDate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubCommit).GetAuthoredDate()).ToDataRes(types.Time)
+	},
+	"github.commit.commitedDate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubCommit).GetCommitedDate()).ToDataRes(types.Time)
+	},
 	"github.mergeRequest.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubMergeRequest).GetId()).ToDataRes(types.Int)
 	},
@@ -1863,6 +1869,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"github.commit.stats": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGithubCommit).Stats, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
+		return
+	},
+	"github.commit.authoredDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubCommit).AuthoredDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"github.commit.commitedDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubCommit).CommitedDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"github.mergeRequest.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4341,6 +4355,8 @@ type mqlGithubCommit struct {
 	Committer plugin.TValue[*mqlGithubUser]
 	Commit plugin.TValue[*mqlGitCommit]
 	Stats plugin.TValue[interface{}]
+	AuthoredDate plugin.TValue[*time.Time]
+	CommitedDate plugin.TValue[*time.Time]
 }
 
 // createGithubCommit creates a new instance of this resource
@@ -4410,6 +4426,14 @@ func (c *mqlGithubCommit) GetCommit() *plugin.TValue[*mqlGitCommit] {
 
 func (c *mqlGithubCommit) GetStats() *plugin.TValue[interface{}] {
 	return &c.Stats
+}
+
+func (c *mqlGithubCommit) GetAuthoredDate() *plugin.TValue[*time.Time] {
+	return &c.AuthoredDate
+}
+
+func (c *mqlGithubCommit) GetCommitedDate() *plugin.TValue[*time.Time] {
+	return &c.CommitedDate
 }
 
 // mqlGithubMergeRequest for the github.mergeRequest resource

--- a/providers/github/resources/github.lr.go
+++ b/providers/github/resources/github.lr.go
@@ -813,8 +813,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"github.commit.authoredDate": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubCommit).GetAuthoredDate()).ToDataRes(types.Time)
 	},
-	"github.commit.commitedDate": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGithubCommit).GetCommitedDate()).ToDataRes(types.Time)
+	"github.commit.committedDate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubCommit).GetCommittedDate()).ToDataRes(types.Time)
 	},
 	"github.mergeRequest.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubMergeRequest).GetId()).ToDataRes(types.Int)
@@ -1875,8 +1875,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlGithubCommit).AuthoredDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
-	"github.commit.commitedDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGithubCommit).CommitedDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+	"github.commit.committedDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubCommit).CommittedDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"github.mergeRequest.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4356,7 +4356,7 @@ type mqlGithubCommit struct {
 	Commit plugin.TValue[*mqlGitCommit]
 	Stats plugin.TValue[interface{}]
 	AuthoredDate plugin.TValue[*time.Time]
-	CommitedDate plugin.TValue[*time.Time]
+	CommittedDate plugin.TValue[*time.Time]
 }
 
 // createGithubCommit creates a new instance of this resource
@@ -4432,8 +4432,8 @@ func (c *mqlGithubCommit) GetAuthoredDate() *plugin.TValue[*time.Time] {
 	return &c.AuthoredDate
 }
 
-func (c *mqlGithubCommit) GetCommitedDate() *plugin.TValue[*time.Time] {
-	return &c.CommitedDate
+func (c *mqlGithubCommit) GetCommittedDate() *plugin.TValue[*time.Time] {
+	return &c.CommittedDate
 }
 
 // mqlGithubMergeRequest for the github.mergeRequest resource

--- a/providers/github/resources/github.lr.manifest.yaml
+++ b/providers/github/resources/github.lr.manifest.yaml
@@ -76,8 +76,12 @@ resources:
   github.commit:
     fields:
       author: {}
+      authoredDate:
+        min_mondoo_version: 9.0.0
       commit:
         min_mondoo_version: 6.11.0
+      commitedDate:
+        min_mondoo_version: 9.0.0
       committer: {}
       message: {}
       organizationName: {}

--- a/providers/github/resources/github.lr.manifest.yaml
+++ b/providers/github/resources/github.lr.manifest.yaml
@@ -82,6 +82,8 @@ resources:
         min_mondoo_version: 6.11.0
       commitedDate:
         min_mondoo_version: 9.0.0
+      committedDate:
+        min_mondoo_version: 9.0.0
       committer: {}
       message: {}
       organizationName: {}

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -685,16 +685,16 @@ func newMqlGithubCommit(runtime *plugin.Runtime, rc *github.RepositoryCommit, ow
 	}
 
 	return CreateResource(runtime, "github.commit", map[string]*llx.RawData{
-		"url":          llx.StringData(rc.GetURL()),
-		"sha":          llx.StringData(sha),
-		"author":       llx.AnyData(githubAuthor),
-		"committer":    llx.AnyData(githubCommitter),
-		"owner":        llx.StringData(owner),
-		"repository":   llx.StringData(repo),
-		"commit":       llx.AnyData(mqlGitCommit),
-		"stats":        llx.MapData(stats, types.Any),
-		"authoredDate": llx.TimeData(rc.Commit.Author.Date.Time),
-		"commitedDate": llx.TimeData(rc.Commit.Committer.Date.Time),
+		"url":           llx.StringData(rc.GetURL()),
+		"sha":           llx.StringData(sha),
+		"author":        llx.AnyData(githubAuthor),
+		"committer":     llx.AnyData(githubCommitter),
+		"owner":         llx.StringData(owner),
+		"repository":    llx.StringData(repo),
+		"commit":        llx.AnyData(mqlGitCommit),
+		"stats":         llx.MapData(stats, types.Any),
+		"authoredDate":  llx.TimeData(rc.Commit.Author.Date.Time),
+		"committedDate": llx.TimeData(rc.Commit.Committer.Date.Time),
 	})
 }
 

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -645,7 +645,7 @@ func newMqlGithubCommit(runtime *plugin.Runtime, rc *github.RepositoryCommit, ow
 	conn := runtime.Connection.(*connection.GithubConnection)
 
 	// if the github author is nil, we have to load the commit again
-	if rc.Author == nil {
+	if rc.Author == nil || rc.Commit == nil {
 		rc, _, err = conn.Client().Repositories.GetCommit(conn.Context(), owner, repo, rc.GetSHA(), nil)
 		if err != nil {
 			return nil, err
@@ -685,14 +685,16 @@ func newMqlGithubCommit(runtime *plugin.Runtime, rc *github.RepositoryCommit, ow
 	}
 
 	return CreateResource(runtime, "github.commit", map[string]*llx.RawData{
-		"url":        llx.StringData(rc.GetURL()),
-		"sha":        llx.StringData(sha),
-		"author":     llx.AnyData(githubAuthor),
-		"committer":  llx.AnyData(githubCommitter),
-		"owner":      llx.StringData(owner),
-		"repository": llx.StringData(repo),
-		"commit":     llx.AnyData(mqlGitCommit),
-		"stats":      llx.MapData(stats, types.Any),
+		"url":          llx.StringData(rc.GetURL()),
+		"sha":          llx.StringData(sha),
+		"author":       llx.AnyData(githubAuthor),
+		"committer":    llx.AnyData(githubCommitter),
+		"owner":        llx.StringData(owner),
+		"repository":   llx.StringData(repo),
+		"commit":       llx.AnyData(mqlGitCommit),
+		"stats":        llx.MapData(stats, types.Any),
+		"authoredDate": llx.TimeData(rc.Commit.Author.Date.Time),
+		"commitedDate": llx.TimeData(rc.Commit.Committer.Date.Time),
 	})
 }
 


### PR DESCRIPTION
Introduces authored and commited dates to `github.commit` resource
From Github Docs:
> ... the author date is used to calculate when a commit was made. Whereas, in a repository, the commit date is used to calculate when a commit was made in the repository

Can be used like
```
github.repository.commits.where(authoredDate > parse.date('2019-01-01'))
github.repository.commits.where(commitedDate > parse.date('2019-01-01'))
```

---

