### PR TITLE
🧹 Remove discovery filters parameter from Discover

### DIFF
--- a/providers/aws/connection/connection.go
+++ b/providers/aws/connection/connection.go
@@ -143,16 +143,16 @@ func parseOptsToFilters(opts map[string]string) DiscoveryFilters {
 			d.Ec2DiscoveryFilters.Tags[strings.TrimPrefix(k, "ec2:tag:")] = v
 		case strings.HasPrefix(k, "exclude:ec2:tag:"):
 			d.Ec2DiscoveryFilters.ExcludeTags[strings.TrimPrefix(k, "exclude:ec2:tag:")] = v
-		case strings.HasPrefix(k, "ec2:region:"):
-			d.Ec2DiscoveryFilters.Regions = append(d.Ec2DiscoveryFilters.Regions, v)
-		case strings.HasPrefix(k, "exclude:ec2:region"):
-			d.Ec2DiscoveryFilters.ExcludeRegions = append(d.Ec2DiscoveryFilters.ExcludeRegions, v)
-		case strings.HasPrefix(k, "all:region:"), strings.HasPrefix(k, "region:"):
-			d.GeneralDiscoveryFilters.Regions = append(d.GeneralDiscoveryFilters.Regions, v)
-		case strings.HasPrefix(k, "ec2:instance-id:"):
-			d.Ec2DiscoveryFilters.InstanceIds = append(d.Ec2DiscoveryFilters.InstanceIds, v)
-		case strings.HasPrefix(k, "exclude:ec2:instance-id:"):
-			d.Ec2DiscoveryFilters.ExcludeInstanceIds = append(d.Ec2DiscoveryFilters.ExcludeInstanceIds, v)
+		case strings.HasPrefix(k, "ec2:regions"):
+			d.Ec2DiscoveryFilters.Regions = append(d.Ec2DiscoveryFilters.Regions, strings.Split(v, ",")...)
+		case strings.HasPrefix(k, "exclude:ec2:regions"):
+			d.Ec2DiscoveryFilters.ExcludeRegions = append(d.Ec2DiscoveryFilters.ExcludeRegions, strings.Split(v, ",")...)
+		case strings.HasPrefix(k, "all:regions"), strings.HasPrefix(k, "regions"):
+			d.GeneralDiscoveryFilters.Regions = append(d.GeneralDiscoveryFilters.Regions, strings.Split(v, ",")...)
+		case strings.HasPrefix(k, "ec2:instance-ids"):
+			d.Ec2DiscoveryFilters.InstanceIds = append(d.Ec2DiscoveryFilters.InstanceIds, strings.Split(v, ",")...)
+		case strings.HasPrefix(k, "exclude:ec2:instance-ids"):
+			d.Ec2DiscoveryFilters.ExcludeInstanceIds = append(d.Ec2DiscoveryFilters.ExcludeInstanceIds, strings.Split(v, ",")...)
 		case strings.HasPrefix(k, "all:tag:"):
 			d.GeneralDiscoveryFilters.Tags[strings.TrimPrefix(k, "all:tag:")] = v
 		case strings.HasPrefix(k, "ecr:tag:"):

--- a/providers/aws/connection/connection.go
+++ b/providers/aws/connection/connection.go
@@ -143,20 +143,20 @@ func parseOptsToFilters(opts map[string]string) DiscoveryFilters {
 			d.Ec2DiscoveryFilters.Tags[strings.TrimPrefix(k, "ec2:tag:")] = v
 		case strings.HasPrefix(k, "exclude:ec2:tag:"):
 			d.Ec2DiscoveryFilters.ExcludeTags[strings.TrimPrefix(k, "exclude:ec2:tag:")] = v
-		case strings.HasPrefix(k, "ec2:regions"):
+		case k == "ec2:regions":
 			d.Ec2DiscoveryFilters.Regions = append(d.Ec2DiscoveryFilters.Regions, strings.Split(v, ",")...)
-		case strings.HasPrefix(k, "exclude:ec2:regions"):
+		case k == "exclude:ec2:regions":
 			d.Ec2DiscoveryFilters.ExcludeRegions = append(d.Ec2DiscoveryFilters.ExcludeRegions, strings.Split(v, ",")...)
-		case strings.HasPrefix(k, "all:regions"), strings.HasPrefix(k, "regions"):
+		case k == "all:regions", k == "regions":
 			d.GeneralDiscoveryFilters.Regions = append(d.GeneralDiscoveryFilters.Regions, strings.Split(v, ",")...)
-		case strings.HasPrefix(k, "ec2:instance-ids"):
+		case k == "ec2:instance-ids":
 			d.Ec2DiscoveryFilters.InstanceIds = append(d.Ec2DiscoveryFilters.InstanceIds, strings.Split(v, ",")...)
-		case strings.HasPrefix(k, "exclude:ec2:instance-ids"):
+		case k == "exclude:ec2:instance-ids":
 			d.Ec2DiscoveryFilters.ExcludeInstanceIds = append(d.Ec2DiscoveryFilters.ExcludeInstanceIds, strings.Split(v, ",")...)
 		case strings.HasPrefix(k, "all:tag:"):
 			d.GeneralDiscoveryFilters.Tags[strings.TrimPrefix(k, "all:tag:")] = v
-		case strings.HasPrefix(k, "ecr:tag:"):
-			d.EcrDiscoveryFilters.Tags = append(d.EcrDiscoveryFilters.Tags, v)
+		case k == "ecr:tags":
+			d.EcrDiscoveryFilters.Tags = append(d.EcrDiscoveryFilters.Tags, strings.Split(v, ",")...)
 		case k == "ecs:only-running-containers":
 			parsed, err := strconv.ParseBool(v)
 			if err == nil {

--- a/providers/aws/connection/connection.go
+++ b/providers/aws/connection/connection.go
@@ -149,9 +149,9 @@ func parseOptsToFilters(opts map[string]string) DiscoveryFilters {
 			d.Ec2DiscoveryFilters.ExcludeRegions = append(d.Ec2DiscoveryFilters.ExcludeRegions, v)
 		case strings.HasPrefix(k, "all:region:"), strings.HasPrefix(k, "region:"):
 			d.GeneralDiscoveryFilters.Regions = append(d.GeneralDiscoveryFilters.Regions, v)
-		case strings.HasPrefix(k, "instance-id:"):
+		case strings.HasPrefix(k, "ec2:instance-id:"):
 			d.Ec2DiscoveryFilters.InstanceIds = append(d.Ec2DiscoveryFilters.InstanceIds, v)
-		case strings.HasPrefix(k, "exclude:instance-id:"):
+		case strings.HasPrefix(k, "exclude:ec2:instance-id:"):
 			d.Ec2DiscoveryFilters.ExcludeInstanceIds = append(d.Ec2DiscoveryFilters.ExcludeInstanceIds, v)
 		case strings.HasPrefix(k, "all:tag:"):
 			d.GeneralDiscoveryFilters.Tags[strings.TrimPrefix(k, "all:tag:")] = v

--- a/providers/aws/connection/connection_test.go
+++ b/providers/aws/connection/connection_test.go
@@ -52,8 +52,7 @@ func TestParseOptsToFilters(t *testing.T) {
 			"all:tag:key1": "val1",
 			"all:tag:key2": "val2",
 			// EcrDiscoveryFilters.Tags
-			"ecr:tag:tag1": "tag1",
-			"ecr:tag:tag2": "tag2",
+			"ecr:tags": "tag1,tag2",
 			// EcsDiscoveryFilters
 			"ecs:only-running-containers": "true",
 			"ecs:discover-images":         "T",

--- a/providers/aws/connection/connection_test.go
+++ b/providers/aws/connection/connection_test.go
@@ -23,7 +23,7 @@ func compareFilters(t *testing.T, expected, actual DiscoveryFilters) {
 
 	require.Equal(t, expected.EcsDiscoveryFilters, actual.EcsDiscoveryFilters)
 
-	require.Equal(t, expected.EcrDiscoveryFilters.Tags, actual.EcrDiscoveryFilters.Tags)
+	require.ElementsMatch(t, expected.EcrDiscoveryFilters.Tags, actual.EcrDiscoveryFilters.Tags)
 
 	require.ElementsMatch(t, expected.GeneralDiscoveryFilters.Regions, actual.GeneralDiscoveryFilters.Regions)
 	require.Equal(t, expected.GeneralDiscoveryFilters.Tags, actual.GeneralDiscoveryFilters.Tags)
@@ -50,7 +50,20 @@ func TestParseOptsToFilters(t *testing.T) {
 			// Ec2DiscoveryFilters.ExcludeInstanceIds
 			"exclude:instance-id:iid-1": "iid-1",
 			"exclude:instance-id:iid-2": "iid-2",
-			// TODO: @vasil - include others?
+			// GeneralDiscoveryFilters.Regions
+			"all:region:us-east-1": "us-east-1",
+			"all:region:us-west-1": "us-west-1",
+			"region:eu-west-1":     "eu-west-1",
+			// GeneralDiscoveryFilters.Tags
+			"all:tag:key1": "val1",
+			"all:tag:key2": "val2",
+			// EcrDiscoveryFilters.Tags
+			"ecr:tag:tag1": "tag1",
+			"ecr:tag:tag2": "tag2",
+			// EcsDiscoveryFilters
+			"ecs:only-running-containers": "true",
+			"ecs:discover-images":         "T",
+			"ecs:discover-instances":      "false",
 		}
 		expected := DiscoveryFilters{
 			Ec2DiscoveryFilters: Ec2DiscoveryFilters{
@@ -75,9 +88,23 @@ func TestParseOptsToFilters(t *testing.T) {
 					"key2": "val2",
 				},
 			},
-			EcsDiscoveryFilters:     EcsDiscoveryFilters{},
-			EcrDiscoveryFilters:     EcrDiscoveryFilters{Tags: []string{}},
-			GeneralDiscoveryFilters: GeneralResourceDiscoveryFilters{Tags: map[string]string{}},
+			EcsDiscoveryFilters: EcsDiscoveryFilters{
+				OnlyRunningContainers: true,
+				DiscoverImages:        true,
+				DiscoverInstances:     false,
+			},
+			EcrDiscoveryFilters: EcrDiscoveryFilters{Tags: []string{
+				"tag1", "tag2",
+			}},
+			GeneralDiscoveryFilters: GeneralResourceDiscoveryFilters{
+				Regions: []string{
+					"us-east-1", "us-west-1", "eu-west-1",
+				},
+				Tags: map[string]string{
+					"key1": "val1",
+					"key2": "val2",
+				},
+			},
 		}
 
 		actual := parseOptsToFilters(opts)

--- a/providers/aws/connection/connection_test.go
+++ b/providers/aws/connection/connection_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package connection
 
 import (

--- a/providers/aws/connection/connection_test.go
+++ b/providers/aws/connection/connection_test.go
@@ -1,0 +1,95 @@
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// testParseOptsToFilters accepts a map which doesn't guarantee a deterministic iteration order. this means that slices
+// in the parsed filters need to be compared individually ensuring their elements match regardless of their order.
+func compareFilters(t *testing.T, expected, actual DiscoveryFilters) {
+	require.ElementsMatch(t, expected.Ec2DiscoveryFilters.Regions, actual.Ec2DiscoveryFilters.Regions)
+	require.ElementsMatch(t, expected.Ec2DiscoveryFilters.ExcludeRegions, actual.Ec2DiscoveryFilters.ExcludeRegions)
+
+	require.ElementsMatch(t, expected.Ec2DiscoveryFilters.InstanceIds, actual.Ec2DiscoveryFilters.InstanceIds)
+	require.ElementsMatch(t, expected.Ec2DiscoveryFilters.ExcludeInstanceIds, actual.Ec2DiscoveryFilters.ExcludeInstanceIds)
+
+	require.Equal(t, expected.Ec2DiscoveryFilters.Tags, actual.Ec2DiscoveryFilters.Tags)
+	require.Equal(t, expected.Ec2DiscoveryFilters.ExcludeTags, actual.Ec2DiscoveryFilters.ExcludeTags)
+
+	require.Equal(t, expected.EcsDiscoveryFilters, actual.EcsDiscoveryFilters)
+
+	require.Equal(t, expected.EcrDiscoveryFilters.Tags, actual.EcrDiscoveryFilters.Tags)
+
+	require.ElementsMatch(t, expected.GeneralDiscoveryFilters.Regions, actual.GeneralDiscoveryFilters.Regions)
+	require.Equal(t, expected.GeneralDiscoveryFilters.Tags, actual.GeneralDiscoveryFilters.Tags)
+}
+
+func TestParseOptsToFilters(t *testing.T) {
+	t.Run("all opts are mapped to discovery filters correctly", func(t *testing.T) {
+		opts := map[string]string{
+			// Ec2DiscoveryFilters.Tags
+			"ec2:tag:key1": "val1",
+			"ec2:tag:key2": "val2",
+			// Ec2DiscoveryFilters.ExcludeTags
+			"exclude:ec2:tag:key1": "val1",
+			"exclude:ec2:tag:key2": "val2",
+			// Ec2DiscoveryFilters.Regions
+			"ec2:region:us-east-1": "us-east-1",
+			"ec2:region:us-west-1": "us-west-1",
+			// Ec2DiscoveryFilters.ExcludeRegions
+			"exclude:ec2:region:us-east-1": "us-east-1",
+			"exclude:ec2:region:us-west-1": "us-west-1",
+			// Ec2DiscoveryFilters.InstanceIds
+			"instance-id:iid-1": "iid-1",
+			"instance-id:iid-2": "iid-2",
+			// Ec2DiscoveryFilters.ExcludeInstanceIds
+			"exclude:instance-id:iid-1": "iid-1",
+			"exclude:instance-id:iid-2": "iid-2",
+			// TODO: @vasil - include others?
+		}
+		expected := DiscoveryFilters{
+			Ec2DiscoveryFilters: Ec2DiscoveryFilters{
+				Regions: []string{
+					"us-east-1", "us-west-1",
+				},
+				ExcludeRegions: []string{
+					"us-east-1", "us-west-1",
+				},
+				InstanceIds: []string{
+					"iid-1", "iid-2",
+				},
+				ExcludeInstanceIds: []string{
+					"iid-1", "iid-2",
+				},
+				Tags: map[string]string{
+					"key1": "val1",
+					"key2": "val2",
+				},
+				ExcludeTags: map[string]string{
+					"key1": "val1",
+					"key2": "val2",
+				},
+			},
+			EcsDiscoveryFilters:     EcsDiscoveryFilters{},
+			EcrDiscoveryFilters:     EcrDiscoveryFilters{Tags: []string{}},
+			GeneralDiscoveryFilters: GeneralResourceDiscoveryFilters{Tags: map[string]string{}},
+		}
+
+		actual := parseOptsToFilters(opts)
+		compareFilters(t, expected, actual)
+	})
+
+	t.Run("empty opts are mapped to discovery filters correctly", func(t *testing.T) {
+		expected := DiscoveryFilters{
+			Ec2DiscoveryFilters:     Ec2DiscoveryFilters{Tags: map[string]string{}, ExcludeTags: map[string]string{}},
+			EcsDiscoveryFilters:     EcsDiscoveryFilters{},
+			EcrDiscoveryFilters:     EcrDiscoveryFilters{Tags: []string{}},
+			GeneralDiscoveryFilters: GeneralResourceDiscoveryFilters{Tags: map[string]string{}},
+		}
+
+		actual := parseOptsToFilters(map[string]string{})
+		compareFilters(t, expected, actual)
+	})
+}

--- a/providers/aws/connection/connection_test.go
+++ b/providers/aws/connection/connection_test.go
@@ -45,11 +45,11 @@ func TestParseOptsToFilters(t *testing.T) {
 			"exclude:ec2:region:us-east-1": "us-east-1",
 			"exclude:ec2:region:us-west-1": "us-west-1",
 			// Ec2DiscoveryFilters.InstanceIds
-			"instance-id:iid-1": "iid-1",
-			"instance-id:iid-2": "iid-2",
+			"ec2:instance-id:iid-1": "iid-1",
+			"ec2:instance-id:iid-2": "iid-2",
 			// Ec2DiscoveryFilters.ExcludeInstanceIds
-			"exclude:instance-id:iid-1": "iid-1",
-			"exclude:instance-id:iid-2": "iid-2",
+			"exclude:ec2:instance-id:iid-1": "iid-1",
+			"exclude:ec2:instance-id:iid-2": "iid-2",
 			// GeneralDiscoveryFilters.Regions
 			"all:region:us-east-1": "us-east-1",
 			"all:region:us-west-1": "us-west-1",

--- a/providers/aws/connection/connection_test.go
+++ b/providers/aws/connection/connection_test.go
@@ -39,21 +39,15 @@ func TestParseOptsToFilters(t *testing.T) {
 			"exclude:ec2:tag:key1": "val1",
 			"exclude:ec2:tag:key2": "val2",
 			// Ec2DiscoveryFilters.Regions
-			"ec2:region:us-east-1": "us-east-1",
-			"ec2:region:us-west-1": "us-west-1",
+			"ec2:regions": "us-east-1,us-west-1",
 			// Ec2DiscoveryFilters.ExcludeRegions
-			"exclude:ec2:region:us-east-1": "us-east-1",
-			"exclude:ec2:region:us-west-1": "us-west-1",
+			"exclude:ec2:regions": "us-east-1,us-west-1",
 			// Ec2DiscoveryFilters.InstanceIds
-			"ec2:instance-id:iid-1": "iid-1",
-			"ec2:instance-id:iid-2": "iid-2",
+			"ec2:instance-ids": "iid-1,iid-2",
 			// Ec2DiscoveryFilters.ExcludeInstanceIds
-			"exclude:ec2:instance-id:iid-1": "iid-1",
-			"exclude:ec2:instance-id:iid-2": "iid-2",
+			"exclude:ec2:instance-ids": "iid-1,iid-2",
 			// GeneralDiscoveryFilters.Regions
-			"all:region:us-east-1": "us-east-1",
-			"all:region:us-west-1": "us-west-1",
-			"region:eu-west-1":     "eu-west-1",
+			"all:regions": "us-east-1,us-west-1,eu-west-1",
 			// GeneralDiscoveryFilters.Tags
 			"all:tag:key1": "val1",
 			"all:tag:key2": "val2",

--- a/providers/aws/provider/provider.go
+++ b/providers/aws/provider/provider.go
@@ -93,7 +93,7 @@ func parseFlagsToFiltersOpts(m map[string]*llx.Primitive) map[string]string {
 			"ec2:instance-ids",
 			"exclude:ec2:instance-ids",
 			"all:tag:",
-			"ecr:tag:",
+			"ecr:tags",
 			"ecs:only-running-containers",
 			"ecs:discover-instances",
 			"ecs:discover-images",

--- a/providers/aws/provider/provider.go
+++ b/providers/aws/provider/provider.go
@@ -269,5 +269,5 @@ func (s *Service) discover(conn *connection.AwsConnection) (*inventory.Inventory
 		return nil, err
 	}
 
-	return resources.Discover(runtime, conn.Filters)
+	return resources.Discover(runtime)
 }

--- a/providers/aws/provider/provider.go
+++ b/providers/aws/provider/provider.go
@@ -83,15 +83,27 @@ func parseFlagsToFiltersOpts(m map[string]*llx.Primitive) map[string]string {
 	o := make(map[string]string, 0)
 
 	if x, ok := m["filters"]; ok && len(x.Map) != 0 {
+		knownTagPrefixes := []string{
+			"ec2:tag:",
+			"exclude:ec2:tag:",
+			"ec2:regions",
+			"exclude:ec2:regions",
+			"all:regions",
+			"regions",
+			"ec2:instance-ids",
+			"exclude:ec2:instance-ids",
+			"all:tag:",
+			"ecr:tag:",
+			"ecs:only-running-containers",
+			"ecs:discover-instances",
+			"ecs:discover-images",
+		}
 		for k, v := range x.Map {
-			if strings.Contains(k, "tag:") {
-				o[k] = string(v.Value)
-			}
-			if k == "instance-id" {
-				o[k] = string(v.Value)
-			}
-			if strings.Contains(k, "region") {
-				o[k] = string(v.Value)
+			for _, prefix := range knownTagPrefixes {
+				if strings.HasPrefix(k, prefix) {
+					o[k] = string(v.Value)
+					break
+				}
 			}
 		}
 	}

--- a/providers/aws/resources/aws.go
+++ b/providers/aws/resources/aws.go
@@ -70,6 +70,16 @@ func Is400AccessDeniedError(err error) bool {
 	return false
 }
 
+func Is400InstanceNotFoundError(err error) bool {
+	var respErr *http.ResponseError
+	if errors.As(err, &respErr) {
+		if respErr.HTTPStatusCode() == 400 && (strings.Contains(respErr.Error(), "InvalidInstanceID.NotFound") || strings.Contains(respErr.Error(), "InvalidInstanceID.Malformed")) {
+			return true
+		}
+	}
+	return false
+}
+
 func strMapToInterface(m map[string]string) map[string]interface{} {
 	res := map[string]interface{}{}
 	for k, v := range m {

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -26,6 +26,7 @@ import (
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/cnquery/v11/providers/aws/connection"
 	"go.mondoo.com/cnquery/v11/types"
+	"go.mondoo.com/cnquery/v11/utils/stringx"
 )
 
 func (e *mqlAwsEc2) id() (string, error) {
@@ -1792,22 +1793,15 @@ func shouldExcludeInstance(instance ec2types.Instance, filters connection.Ec2Dis
 // given an initial set of regions, applies the allowed regions filter and the excluded regions filter on it
 // returning a resulting slice of only applicable region to which queries should be targeted
 func determineApplicableRegions(regions, regionsToInclude, regionsToExclude []string) []string {
-	res := regions
 	if len(regionsToInclude) > 0 {
-		res = regionsToInclude
+		return regionsToInclude
 	}
-	for _, regionToExclude := range regionsToExclude {
-		res = removeElement(res, regionToExclude)
-	}
-	return res
-}
-
-func removeElement(slice []string, value string) []string {
-	result := []string{}
-	for _, v := range slice {
-		if v != value {
-			result = append(result, v)
+	res := []string{}
+	for _, r := range regions {
+		if !stringx.Contains(regionsToExclude, r) {
+			res = append(res, r)
 		}
 	}
-	return result
+
+	return res
 }

--- a/providers/aws/resources/aws_ec2_test.go
+++ b/providers/aws/resources/aws_ec2_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package resources
 
 import (

--- a/providers/aws/resources/aws_ec2_test.go
+++ b/providers/aws/resources/aws_ec2_test.go
@@ -76,3 +76,35 @@ func TestShouldExcludeInstance(t *testing.T) {
 		require.False(t, shouldExcludeInstance(instance, filters))
 	})
 }
+
+func TestDetermineApplicableRegions(t *testing.T) {
+	t.Run("allow regions override initial region list", func(t *testing.T) {
+		initialRegions := []string{"a", "b"}
+		allowedRegions := []string{"b", "c"}
+		excludedRegions := []string{}
+
+		expected := []string{"b", "c"}
+		actual := determineApplicableRegions(initialRegions, allowedRegions, excludedRegions)
+		require.ElementsMatch(t, expected, actual)
+	})
+
+	t.Run("excluded regions work correctly", func(t *testing.T) {
+		initialRegions := []string{"a", "b"}
+		allowedRegions := []string{}
+		excludedRegions := []string{"b"}
+
+		expected := []string{"a"}
+		actual := determineApplicableRegions(initialRegions, allowedRegions, excludedRegions)
+		require.ElementsMatch(t, expected, actual)
+	})
+
+	t.Run("excluded regions not present in the initial slice are ignored", func(t *testing.T) {
+		initialRegions := []string{"a", "b"}
+		allowedRegions := []string{}
+		excludedRegions := []string{"b", "c", "d", "e"}
+
+		expected := []string{"a"}
+		actual := determineApplicableRegions(initialRegions, allowedRegions, excludedRegions)
+		require.ElementsMatch(t, expected, actual)
+	})
+}

--- a/providers/aws/resources/aws_ec2_test.go
+++ b/providers/aws/resources/aws_ec2_test.go
@@ -1,0 +1,75 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/v11/providers/aws/connection"
+)
+
+func TestShouldExcludeInstance(t *testing.T) {
+	instance := ec2types.Instance{
+		InstanceId: aws.String("iid"),
+		Tags: []ec2types.Tag{
+			{
+				Key:   aws.String("key-1"),
+				Value: aws.String("val-1"),
+			},
+			{
+				Key:   aws.String("key-2"),
+				Value: aws.String("val-2"),
+			},
+		},
+	}
+
+	t.Run("should exclude instance by id", func(t *testing.T) {
+		filters := connection.Ec2DiscoveryFilters{
+			ExcludeInstanceIds: []string{
+				"iid",
+			},
+			ExcludeTags: map[string]string{
+				"key-3": "val3",
+			},
+		}
+		require.True(t, shouldExcludeInstance(instance, filters))
+	})
+
+	t.Run("should exclude instance by matching tag", func(t *testing.T) {
+		filters := connection.Ec2DiscoveryFilters{
+			ExcludeInstanceIds: []string{
+				"iid-2",
+			},
+			ExcludeTags: map[string]string{
+				"key-2": "val2",
+			},
+		}
+		require.False(t, shouldExcludeInstance(instance, filters))
+	})
+
+	t.Run("should not exclude instance with only a matching tag key", func(t *testing.T) {
+		filters := connection.Ec2DiscoveryFilters{
+			ExcludeInstanceIds: []string{
+				"iid-2",
+			},
+			ExcludeTags: map[string]string{
+				"key-2": "val3",
+				"key-3": "val3",
+			},
+		}
+		require.False(t, shouldExcludeInstance(instance, filters))
+	})
+
+	t.Run("should not exclude instance when instance id and tags don't match", func(t *testing.T) {
+		filters := connection.Ec2DiscoveryFilters{
+			ExcludeInstanceIds: []string{
+				"iid-2",
+			},
+			ExcludeTags: map[string]string{
+				"key-3": "val3",
+			},
+		}
+		require.False(t, shouldExcludeInstance(instance, filters))
+	})
+}

--- a/providers/aws/resources/discovery.go
+++ b/providers/aws/resources/discovery.go
@@ -96,15 +96,6 @@ var AllAPIResources = []string{
 	DiscoverySagemakerNotebookInstances,
 }
 
-func contains(sl []string, s string) bool {
-	for i := range sl {
-		if sl[i] == s {
-			return true
-		}
-	}
-	return false
-}
-
 func containsInterfaceSlice(sl []interface{}, s string) bool {
 	for i := range sl {
 		if sl[i].(string) == s {

--- a/providers/aws/resources/discovery_test.go
+++ b/providers/aws/resources/discovery_test.go
@@ -15,64 +15,6 @@ import (
 )
 
 func TestFilters(t *testing.T) {
-	require.True(t, instanceMatchesFilters(&mqlAwsEc2Instance{InstanceId: plugin.TValue[string]{Data: "i-test"}}, connection.DiscoveryFilters{
-		Ec2DiscoveryFilters: connection.Ec2DiscoveryFilters{
-			InstanceIds: []string{"i-test"},
-		},
-	},
-	))
-	require.True(t, instanceMatchesFilters(&mqlAwsEc2Instance{
-		InstanceId: plugin.TValue[string]{Data: "i-test"},
-		Tags:       plugin.TValue[map[string]interface{}]{Data: map[string]interface{}{"tester2": "val2", "test-tag": "val"}},
-	}, connection.DiscoveryFilters{
-		Ec2DiscoveryFilters: connection.Ec2DiscoveryFilters{
-			InstanceIds: []string{"i-test"},
-			Tags:        map[string]string{"tester2": "val2"},
-		},
-	},
-	))
-	require.True(t, instanceMatchesFilters(&mqlAwsEc2Instance{
-		InstanceId: plugin.TValue[string]{Data: "i-test"},
-		Tags:       plugin.TValue[map[string]interface{}]{Data: map[string]interface{}{"tester2": "val2", "test-tag": "val"}},
-		Region:     plugin.TValue[string]{Data: "us-west-1"},
-	}, connection.DiscoveryFilters{
-		Ec2DiscoveryFilters: connection.Ec2DiscoveryFilters{
-			Regions: []string{"us-east-2", "us-east-1", "us-west-1"},
-		},
-	},
-	))
-	require.True(t, instanceMatchesFilters(&mqlAwsEc2Instance{
-		InstanceId: plugin.TValue[string]{Data: "i-test"},
-		Tags:       plugin.TValue[map[string]interface{}]{Data: map[string]interface{}{"tester2": "val2", "test-tag": "val"}},
-		Region:     plugin.TValue[string]{Data: "us-west-1"},
-	}, connection.DiscoveryFilters{}))
-	require.False(t, instanceMatchesFilters(&mqlAwsEc2Instance{InstanceId: plugin.TValue[string]{Data: "i-test"}}, connection.DiscoveryFilters{
-		Ec2DiscoveryFilters: connection.Ec2DiscoveryFilters{
-			InstanceIds: []string{"i-test2"},
-		},
-	},
-	))
-	require.False(t, instanceMatchesFilters(&mqlAwsEc2Instance{
-		InstanceId: plugin.TValue[string]{Data: "i-test"},
-		Tags:       plugin.TValue[map[string]interface{}]{Data: map[string]interface{}{"tester2": "val2", "test-tag": "val"}},
-	}, connection.DiscoveryFilters{
-		Ec2DiscoveryFilters: connection.Ec2DiscoveryFilters{
-			InstanceIds: []string{"i-test"},
-			Tags:        map[string]string{"test-tag": "val2"},
-		},
-	},
-	))
-	require.False(t, instanceMatchesFilters(&mqlAwsEc2Instance{
-		InstanceId: plugin.TValue[string]{Data: "i-test"},
-		Tags:       plugin.TValue[map[string]interface{}]{Data: map[string]interface{}{"tester2": "val2", "test-tag": "val"}},
-		Region:     plugin.TValue[string]{Data: "us-west-2"},
-	}, connection.DiscoveryFilters{
-		Ec2DiscoveryFilters: connection.Ec2DiscoveryFilters{
-			Regions: []string{"us-east-2", "us-east-1", "us-west-1"},
-		},
-	},
-	))
-
 	require.True(t, imageMatchesFilters(&mqlAwsEcrImage{
 		Tags: plugin.TValue[[]interface{}]{Data: []interface{}{"latest"}},
 	}, connection.DiscoveryFilters{}))


### PR DESCRIPTION
#### In this PR:
- Removed `DiscoveryFilters` from `Discover(...)` function and use the parameters from the `AwsConnection` instead.
- Fixed parsing of inventory config discovery filters into `DiscoveryFilters` struct.
- Added new cases for ECS filters to be specified from inventory because they were only passed down from the removed parameter in `Discovery(...)`.
- Removed duplicate filtering of EC2 instances inside the AWS discovery that was already done by `GetInstances()`.
- Added corresponding exclude filters in `Ec2DiscoveryFilters`.
- Filter out EC2 instances if they match the values specified in the exclude filters. `ExcludeRegions` happens before the call to AWS, `ExcludeTags` and `ExcludeInstanceIds` happen after (AWS doesn't support server-side filtering for those).
- Added unit tests for a couple of functions.

#### Note:
Changing the signature for `Discovery` means everyone using the AWS provider and wanting to filter discovered instances must specify these filters in their inventory config discovery filters map.