### PR TITLE
🧹 log success event for info messages on windows

### DIFF
--- a/logger/eventlog/eventlog_windows.go
+++ b/logger/eventlog/eventlog_windows.go
@@ -1,7 +1,7 @@
 // Copyright (c) Mondoo, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-// +build windows
+//go:build windows
 
 // Package eventlog provides a io.Writer to send the logs
 // to Windows event log.
@@ -86,7 +86,7 @@ func (w eventlogWriter) Write(p []byte) (n int, err error) {
 	case eventlog.Warning:
 		w.elog.Warning(1, string(p))
 	default:
-		w.elog.Info(1, string(p))
+		w.elog.Info(0, string(p))
 	}
 
 	return


### PR DESCRIPTION
i still think we are not using the windows event log correctly. It's not meant to store log messages but events that occur that are either sucessful or not... The current issue is that for info messages the windows log shows this:
![image](https://github.com/user-attachments/assets/889758e9-0e7d-4363-ae10-1231db6e91c7)

With this PR the message will be change to:
![image](https://github.com/user-attachments/assets/b72ed53c-aa8a-419a-b327-772a9e4c99f0)

For error and warning messages, we need to decide what we want to do. At the moment, they will be logged as "Incorrect function." as well. The codes are mapped according to this table https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/18d8fbe8-a967-4f1c-ae50-99ca8e491d2d