### PR TITLE
🧹 improve computer info retrieval for windows

### DIFF
--- a/providers/os/resources/windows.go
+++ b/providers/os/resources/windows.go
@@ -5,6 +5,8 @@ package resources
 
 import (
 	"errors"
+	"io"
+	"strings"
 
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
@@ -24,6 +26,33 @@ func (s *mqlWindows) computerInfo() (map[string]interface{}, error) {
 	executedCmd, err := conn.RunCommand(encodedCmd)
 	if err != nil {
 		return nil, err
+	}
+
+	// If the exit code is not 0, then we got an error and we should read stderr for details
+	if executedCmd.ExitStatus != 0 {
+		stderr, err := io.ReadAll(executedCmd.Stderr)
+		if err != nil {
+			return nil, err
+		}
+
+		// If the command is too long, then we fallback to the short command
+		if strings.HasPrefix(string(stderr), "The command line is too long.") {
+			encodedCmd := powershell.Encode(windows.PSGetComputerInfoShort)
+			executedCmd, err = conn.RunCommand(encodedCmd)
+			if err != nil {
+				return nil, err
+			}
+
+			if executedCmd.ExitStatus != 0 {
+				stderr, err := io.ReadAll(executedCmd.Stderr)
+				if err != nil {
+					return nil, err
+				}
+				return nil, errors.New("failed to retrieve computer info: " + string(stderr))
+			}
+		} else {
+			return nil, errors.New("failed to retrieve computer info: " + string(stderr))
+		}
 	}
 
 	return windows.ParseComputerInfo(executedCmd.Stdout)

--- a/providers/os/resources/windows/computerinfo.go
+++ b/providers/os/resources/windows/computerinfo.go
@@ -8,6 +8,14 @@ import (
 	"io"
 )
 
+// PSGetComputerInfoShort is a PowerShell script that retrieves computer information.
+// This is inteded to be used only as fallback when PSGetComputerInfo fails because
+// the command is too long.
+const PSGetComputerInfoShort = `Get-ComputerInfo | ConvertTo-Json`
+
+// PSGetComputerInfo is a PowerShell script that retrieves computer information. It also
+// implements a fallback to work on systems with winrm disabled. See https://github.com/mondoohq/cnquery/pull/4520
+// for more information.
 const PSGetComputerInfo = `
 function Get-CustomComputerInfo {
     $bios = Get-CimInstance -ClassName Win32_BIOS


### PR DESCRIPTION
In https://github.com/mondoohq/cnquery/pull/4520 we introduced a fallback mechanism to be able to retrieve the windows computer info for machines that don't have winrm enabled. However, this change affected some clients where we run into command prompt command length limits. https://learn.microsoft.com/en-gb/troubleshoot/windows-client/shell-experience/command-line-string-limitation

An easy way to reproduce the error is if you try to run `windows.computerInfo` via ssh. That always connets to a command prompt and triggers the length limitation error:
```
 cnspec run ssh admin@my-win-machine --password mypass -c windows.computerInfo

! could not find keys in ssh agent
unexpected end of JSON input
windows.computerInfo: null
```

In this PR:
- we make sure to read stderr if the command's exit code is non-zero
- we use the short computer info powershell command in case the long one fails with "The command line is too long."
- we return any other errors that occured during the execution of the computer info command
