### PR TITLE
Add Ansible long-form CLI help

### DIFF
--- a/providers/ansible/config/config.go
+++ b/providers/ansible/config/config.go
@@ -16,9 +16,14 @@ var Config = plugin.Provider{
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{
-			Name:      "ansible",
-			Use:       "ansible PATH",
-			Short:     "an Ansible playbook",
+			Name:  "ansible",
+			Use:   "ansible PATH",
+			Short: "an Ansible playbook",
+			Long: `Use the ansible provider to query resources in an Ansible playbook.
+
+Example:
+  cnquery shell ansible <path>
+`,
 			MinArgs:   1,
 			MaxArgs:   1,
 			Discovery: []string{},


### PR DESCRIPTION
Adds long-form CLI help for the Ansible provider.
From what I could see in the code, there are no subcommands and only the path is required. So this is one super simple. Did I miss anything, @chris-rock? 
Thanks!