### PR TITLE
🐛 Fix regex for matching RPM packages with unorthodox vendor name

### DIFF
--- a/providers/os/resources/packages/rpm_packages.go
+++ b/providers/os/resources/packages/rpm_packages.go
@@ -30,7 +30,7 @@ const (
 	RpmPkgFormat = "rpm"
 )
 
-var RPM_REGEX = regexp.MustCompile(`^([\w-+]*)\s(\d*|\(none\)):([\w\d-+.:]+)\s([\w\d]*|\(none\))__([\w\d\s,\.]+)__(.*)$`)
+var RPM_REGEX = regexp.MustCompile(`^([\w-+]*)\s(\d*|\(none\)):([\w\d-+.:]+)\s([\w\d]*|\(none\))__([\w\d\s,/<>:\.]+)__(.*)$`)
 
 // ParseRpmPackages parses output from:
 // rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}\n'

--- a/providers/os/resources/packages/rpm_packages.go
+++ b/providers/os/resources/packages/rpm_packages.go
@@ -292,7 +292,7 @@ func (rpm *RpmPkgManager) staticList() ([]Package, error) {
 			version = version + "-" + pkg.Release
 		}
 
-		rpmPkg := newRpmPackage(rpm.platform, pkg.Name, version, pkg.Arch, epoch, pkg.Vendor, pkg.Summary)
+		rpmPkg := newRpmPackage(rpm.platform, pkg.Name, version, pkg.Arch, epoch, cleanupVendorName(pkg.Vendor), pkg.Summary)
 
 		// determine all files attached
 		records := []FileRecord{}

--- a/providers/os/resources/packages/rpm_packages.go
+++ b/providers/os/resources/packages/rpm_packages.go
@@ -58,7 +58,10 @@ func ParseRpmPackages(pf *inventory.Platform, input io.Reader) []Package {
 			if arch == "(none)" {
 				arch = ""
 			}
-			pkg := newRpmPackage(pf, name, version, arch, epoch, m[5], m[6])
+
+			vendor := cleanupVendorName(m[5])
+
+			pkg := newRpmPackage(pf, name, version, arch, epoch, vendor, m[6])
 			pkg.FilesAvailable = PkgFilesAsync // when we use commands we need to fetch the files async
 			pkgs = append(pkgs, pkg)
 
@@ -97,8 +100,19 @@ func newRpmPackage(pf *inventory.Platform, name, version, arch, epoch, vendor, d
 	}
 }
 
+// matches a closed pair of angle brackets with any number of characters inside.
+var CLEANUP_VENDOR_REGEX = regexp.MustCompile(`<.*>`)
+
+// it is possible for the vendor name to contain a HTML tag with a website inside, e.g. SUSE.
+// we remove it because it is not necessary and later causes troubles for the CPE generation.
+// this assumes angle brackets are not used anywhere else in the names of vendors which is already the case.
+func cleanupVendorName(vendor string) string {
+	cleaned := CLEANUP_VENDOR_REGEX.ReplaceAllString(vendor, "")
+	return strings.TrimRight(cleaned, " ")
+}
+
 // RpmPkgManager is the package manager for Redhat, CentOS, Oracle, Photon and Suse
-// it support two modes: runtime where the rpm command is available and static analysis for images (e.g. container tar)
+// it supports two modes: runtime where the rpm command is available and static analysis for images (e.g. container tar)
 // If the RpmPkgManager is used in static mode, it extracts the rpm database from the system and copies it to the local
 // filesystem to run a local rpm command to extract the data. The static analysis is always slower than using the running
 // one since more data need to copied. Therefore the runtime check should be preferred over the static analysis

--- a/providers/os/resources/packages/rpm_packages_test.go
+++ b/providers/os/resources/packages/rpm_packages_test.go
@@ -343,7 +343,7 @@ func TestSuSEParser(t *testing.T) {
 	assert.Equal(t, p, m[0], p.Name)
 }
 
-func TestVendorRegex(t *testing.T) {
+func TestVendorNameCleanup(t *testing.T) {
 	vendorFromRpm := "SUSE LLC"
 	actual := cleanupVendorName(vendorFromRpm)
 	require.Equal(t, "SUSE LLC", actual)

--- a/providers/os/resources/packages/rpm_packages_test.go
+++ b/providers/os/resources/packages/rpm_packages_test.go
@@ -322,22 +322,53 @@ func TestSuSEParser(t *testing.T) {
 	assert.Equal(t, 1, len(m), "detected the right amount of packages")
 
 	p := Package{
-		Name:        "grep",
-		Version:     "3.1-150000.4.6.1",
-		Vendor:      "SUSE LLC <https://www.suse.com/>",
+		Name:    "grep",
+		Version: "3.1-150000.4.6.1",
+		// Note that the tag <https://suse.com/> has been removed.
+		Vendor:      "SUSE LLC",
 		Arch:        "x86_64",
 		Description: "Print lines matching a pattern",
 		PUrl:        "pkg:rpm/suse/grep@3.1-150000.4.6.1?arch=x86_64&distro=suse-15.6",
 		CPEs: []string{
-			"cpe:2.3:a:suse_llc_\\<https:grep:3.1-150000.4.6.1:*:*:*:*:*:x86_64:*",
-			"cpe:2.3:a:suse_llc_\\<https:grep:3.1-150000.4:*:*:*:*:*:x86_64:*",
-			"cpe:2.3:a:suse_llc_\\<https:grep:3.1:*:*:*:*:*:x86_64:*",
-			"cpe:2.3:a:suse_llc_\\<https:grep:3.1-150000.4.6.1:*:*:*:*:*:*:*",
-			"cpe:2.3:a:suse_llc_\\<https:grep:3.1-150000.4:*:*:*:*:*:*:*",
-			"cpe:2.3:a:suse_llc_\\<https:grep:3.1:*:*:*:*:*:*:*",
+			"cpe:2.3:a:suse_llc:grep:3.1-150000.4.6.1:*:*:*:*:*:x86_64:*",
+			"cpe:2.3:a:suse_llc:grep:3.1-150000.4:*:*:*:*:*:x86_64:*",
+			"cpe:2.3:a:suse_llc:grep:3.1:*:*:*:*:*:x86_64:*",
+			"cpe:2.3:a:suse_llc:grep:3.1-150000.4.6.1:*:*:*:*:*:*:*",
+			"cpe:2.3:a:suse_llc:grep:3.1-150000.4:*:*:*:*:*:*:*",
+			"cpe:2.3:a:suse_llc:grep:3.1:*:*:*:*:*:*:*",
 		},
 		Format:         RpmPkgFormat,
 		FilesAvailable: PkgFilesAsync,
 	}
 	assert.Equal(t, p, m[0], p.Name)
+}
+
+func TestVendorRegex(t *testing.T) {
+	vendorFromRpm := "SUSE LLC"
+	actual := cleanupVendorName(vendorFromRpm)
+	require.Equal(t, "SUSE LLC", actual)
+
+	vendorFromRpm = "SUSE LLC<https://suse.com/>"
+	actual = cleanupVendorName(vendorFromRpm)
+	require.Equal(t, "SUSE LLC", actual)
+
+	vendorFromRpm = "SUSE LLC <https://suse.com/>"
+	actual = cleanupVendorName(vendorFromRpm)
+	require.Equal(t, "SUSE LLC", actual)
+
+	vendorFromRpm = "SUSE LLC     <https://suse.com/>"
+	actual = cleanupVendorName(vendorFromRpm)
+	require.Equal(t, "SUSE LLC", actual)
+
+	vendorFromRpm = "SUSE LLC <abc><def>"
+	actual = cleanupVendorName(vendorFromRpm)
+	require.Equal(t, "SUSE LLC", actual)
+
+	vendorFromRpm = "SUSE LLC <>"
+	actual = cleanupVendorName(vendorFromRpm)
+	require.Equal(t, "SUSE LLC", actual)
+
+	vendorFromRpm = "SUSE LLC <<>>"
+	actual = cleanupVendorName(vendorFromRpm)
+	require.Equal(t, "SUSE LLC", actual)
 }


### PR DESCRIPTION
Fixes #4714 

SuSE's vendor name changed for some reason from `SUSE LLC` to `SUSE LLC <https://www.suse.com/>` which no longer matched the regex pattern.

### In this PR:
- Added `/`, `:`, `<` and `>` as allowed characters in the vendor regex pattern.
- Cleaned up vendor name after the fact and removed this tag at the earliest opportunity. It is not particularly useful and was causing trouble with CPEs generation.
    - Used regex to remove any string of characters from the vendor name between a closed pair of angle brackets `<...>`. That way, we are agnostic as to what the contents of this tag are and we do not hardcode some arbitrary string which may change in the future. This assumes that angle brackets are not used in some other way in the vendor name which I think is a fair assumption given that this is an edge case.
- Added unit tests to verify that the packages are correctly parsed and the regex trims out the tag correctly.

Manually tested this on a VM running SuSE 15.6 and `packages.list` produces a correct output:
![image](https://github.com/user-attachments/assets/d6c86385-0fd7-4c1a-9369-437950dd0373)

@chris-rock Let me know in case any of my assumptions are invalid and you'd like to handle this differently.
