### PR TITLE
🐛 properly parse flags for commands containing --

### DIFF
--- a/.github/workflows/main-benchmark.yml
+++ b/.github/workflows/main-benchmark.yml
@@ -46,7 +46,7 @@ jobs:
           path: ./cache
           key: ${{ runner.os }}-benchmark-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-benchmark
+            ${{ runner.os }}-benchmark-
       # Run `github-action-benchmark` action
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -155,7 +155,7 @@ jobs:
           path: ./cache
           key: ${{ runner.os }}-benchmark-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-benchmark
+            ${{ runner.os }}-benchmark-
       # Run `github-action-benchmark` action
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1

--- a/providers/os/resources/processes/flag.go
+++ b/providers/os/resources/processes/flag.go
@@ -38,6 +38,9 @@ func (f *FlagSet) ParseCommand(cmd string) error {
 	n := len(args)
 	for i := 0; i < n; i++ {
 		key := args[i]
+		if key == "--" {
+			break
+		}
 		if strings.HasPrefix(key, "-") {
 			if i+1 < n && !strings.HasPrefix(args[i+1], "-") {
 				preparedArgs = append(preparedArgs, key+"="+args[i+1])

--- a/providers/os/resources/processes/flag_test.go
+++ b/providers/os/resources/processes/flag_test.go
@@ -120,6 +120,17 @@ func TestFlagParser(t *testing.T) {
 				"node-labels":               "eks.amazonaws.com/sourceLaunchTemplateVersion=1,alpha.eksctl.io/nodegroup-name=ng-1c08897f,alpha.eksctl.io/cluster-name=cluster1,eks.amazonaws.com/nodegroup-image=ami-0656dd273bd6e9a2f,eks.amazonaws.com/capacityType=ON_DEMAND,eks.amazonaws.com/nodegroup=ng-1c08897f,eks.amazonaws.com/sourceLaunchTemplateId=lt-079b3a8f38d6aa1a9",
 			},
 		},
+		{
+			cmd:   "tini -- fleetcontroller gitjob --gitjob-image rancher/fleet:v0.10.2",
+			flags: map[string]string{},
+		},
+		{
+			cmd: "/sbin/agetty -o -p -- \\u --noclear - linux",
+			flags: map[string]string{
+				"o": "",
+				"p": "",
+			},
+		},
 	}
 
 	for i := range tests {


### PR DESCRIPTION
We don't properly parse commands that contain `--` syntax. For example:
- `/package/admin/s6/command/s6-svscan -d4 -- /run/service`
- `tini -- fleetcontroller gitjob --gitjob-image rancher/fleet:v0.10.2`
Those currently return an error `bad flag syntax: ...`

This PR makes sure we only parse flags as long as we don't encounter `--`. Once we have `--` we terminate flag parsing as anything after that is not a flag. This also what cobra does -> https://github.com/spf13/cobra/blob/v1.8.1/command.go#L659-L661