### PR TITLE
🧹 fix benchmark

### DIFF
--- a/.github/workflows/main-benchmark.yml
+++ b/.github/workflows/main-benchmark.yml
@@ -44,7 +44,8 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ./cache
-          key: ${{ runner.os }}-benchmark
+          restore-keys: |
+            ${{ runner.os }}-benchmark
       # Run `github-action-benchmark` action
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
@@ -61,4 +62,4 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ./cache
-          key: ${{ runner.os }}-benchmark
+          key: ${{ runner.os }}-benchmark-${{ github.run_id }} 

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -153,7 +153,8 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ./cache
-          key: ${{ runner.os }}-benchmark
+          restore-keys: |
+            ${{ runner.os }}-benchmark
       # Run `github-action-benchmark` action
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1


### PR DESCRIPTION
saving the new benchmark on main seems to be not working correctly since the new version of the cache has immutable entries. This change should make sure we create a new cache entry for each run on main. Branch runs will pull latest cache entry with `restore-keys` 

Ref: https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache