### PR TITLE
✨ Add support for comma-separated values on the same key for EC2 tag filters

### DIFF
--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -774,7 +774,7 @@ func (a *mqlAwsEc2) getEc2Instances(ctx context.Context, svc *ec2.Client, filter
 	for k, v := range filters.Tags {
 		params.Filters = append(params.Filters, ec2types.Filter{
 			Name:   aws.String(fmt.Sprintf("tag:%s", k)),
-			Values: []string{v},
+			Values: strings.Split(v, ","),
 		})
 	}
 	if len(filters.InstanceIds) > 0 {
@@ -1787,10 +1787,12 @@ func shouldExcludeInstance(instance ec2types.Instance, filters connection.Ec2Dis
 		}
 	}
 	for k, v := range filters.ExcludeTags {
-		for _, iTag := range instance.Tags {
-			if iTag.Key != nil && *iTag.Key == k &&
-				iTag.Value != nil && *iTag.Value == v {
-				return true
+		for _, tagValue := range strings.Split(v, ",") {
+			for _, iTag := range instance.Tags {
+				if iTag.Key != nil && *iTag.Key == k &&
+					iTag.Value != nil && *iTag.Value == tagValue {
+					return true
+				}
 			}
 		}
 	}

--- a/providers/aws/resources/aws_ec2_test.go
+++ b/providers/aws/resources/aws_ec2_test.go
@@ -79,18 +79,18 @@ func TestShouldExcludeInstance(t *testing.T) {
 	t.Run("should exclude instances with matching values for the same tag", func(t *testing.T) {
 		filters := connection.Ec2DiscoveryFilters{
 			ExcludeTags: map[string]string{
-				"key-1": "val1,val2,val3",
+				"key-1": "val-1,val-2,val-3",
 			},
 		}
-		require.False(t, shouldExcludeInstance(instance, filters))
+		require.True(t, shouldExcludeInstance(instance, filters))
 	})
 
 	t.Run("should not exclude instances when no tag values match", func(t *testing.T) {
 		filters := connection.Ec2DiscoveryFilters{
 			ExcludeTags: map[string]string{
-				"key-1": "val2,val3",
-				"key-2": "val1,val3",
-				"key-3": "val1,val2",
+				"key-1": "val-2,val-3",
+				"key-2": "val-1,val-3",
+				"key-3": "val-1,val-2",
 			},
 		}
 		require.False(t, shouldExcludeInstance(instance, filters))

--- a/providers/aws/resources/aws_ec2_test.go
+++ b/providers/aws/resources/aws_ec2_test.go
@@ -75,6 +75,26 @@ func TestShouldExcludeInstance(t *testing.T) {
 		}
 		require.False(t, shouldExcludeInstance(instance, filters))
 	})
+
+	t.Run("should exclude instances with matching values for the same tag", func(t *testing.T) {
+		filters := connection.Ec2DiscoveryFilters{
+			ExcludeTags: map[string]string{
+				"key-1": "val1,val2,val3",
+			},
+		}
+		require.False(t, shouldExcludeInstance(instance, filters))
+	})
+
+	t.Run("should not exclude instances when no tag values match", func(t *testing.T) {
+		filters := connection.Ec2DiscoveryFilters{
+			ExcludeTags: map[string]string{
+				"key-1": "val2,val3",
+				"key-2": "val1,val3",
+				"key-3": "val1,val2",
+			},
+		}
+		require.False(t, shouldExcludeInstance(instance, filters))
+	})
 }
 
 func TestDetermineApplicableRegions(t *testing.T) {


### PR DESCRIPTION
Closes #4739 

This adds the possibility of specifying comma-separated values for the same key in a include/exclude tag filter. Those filters can now be specified as follows:
```
ec2:tag:Name=name1,name2,name3
```
and
```
exclude:ec2:tag:Name=name1,name2,name3
```

We keep treating the filter as a single `key : value` so this is backwards compatible. We just expand the string value right before applying the filters.

#### Note:
There is a quirk with how filters are applied. Comma-separated values on the same key are applied with a logical `OR`. If we specify 2 tag filters on different keys, they are applied with a logical `AND`.