### PR TITLE
✨Adde ECS container asset labels

### DIFF
--- a/providers/aws/resources/discovery_conversion.go
+++ b/providers/aws/resources/discovery_conversion.go
@@ -24,13 +24,16 @@ import (
 )
 
 const (
-	MondooRegionLabelKey       = "mondoo.com/region"
-	MondooInstanceLabelKey     = "mondoo.com/instance-id"
-	MondooPlatformLabelKey     = "mondoo.com/platform"
-	MondooLaunchTimeLabelKey   = "mondoo.com/launch-time"
-	MondooInstanceTypeLabelKey = "mondoo.com/instance-type"
-	MondooParentIdLabelKey     = "mondoo.com/parent-id"
-	MondooImageLabelKey        = "mondoo.com/image"
+	MondooRegionLabelKey        = "mondoo.com/region"
+	MondooInstanceLabelKey      = "mondoo.com/instance-id"
+	MondooPlatformLabelKey      = "mondoo.com/platform"
+	MondooLaunchTimeLabelKey    = "mondoo.com/launch-time"
+	MondooInstanceTypeLabelKey  = "mondoo.com/instance-type"
+	MondooParentIdLabelKey      = "mondoo.com/parent-id"
+	MondooImageLabelKey         = "mondoo.com/image"
+	MondooContainerNameLabelKey = "mondoo.com/container-name"
+	MondooClusterNameLabelKey   = "mondoo.com/cluster-name"
+	MondooTaskArnLabelKey       = "mondoo.com/task-arn"
 )
 
 type mqlObject struct {
@@ -567,10 +570,10 @@ func addConnectionInfoToECSContainerAsset(container *mqlAwsEcsContainer, account
 
 	// set some values as asset labels for ease of access during scanning
 	a.Labels = map[string]string{
-		"cluster_name":   container.ClusterName.Data,
-		"task_arn":       taskArn,
-		"container_name": container.ContainerName.Data,
-		"region":         container.Region.Data,
+		MondooClusterNameLabelKey:   container.ClusterName.Data,
+		MondooTaskArnLabelKey:       taskArn,
+		MondooContainerNameLabelKey: container.ContainerName.Data,
+		MondooRegionLabelKey:        container.Region.Data,
 	}
 
 	return a

--- a/providers/aws/resources/discovery_conversion.go
+++ b/providers/aws/resources/discovery_conversion.go
@@ -565,6 +565,14 @@ func addConnectionInfoToECSContainerAsset(container *mqlAwsEcsContainer, account
 			}, conn)
 	}
 
+	// set some values as asset labels for ease of access during scanning
+	a.Labels = map[string]string{
+		"cluster_name":   container.ClusterName.Data,
+		"task_arn":       taskArn,
+		"container_name": container.ContainerName.Data,
+		"region":         container.Region.Data,
+	}
+
 	return a
 }
 


### PR DESCRIPTION
The four properties `region`, `task_arn`, `cluster_name` and `container_name` are used to execute a command against a specific container. Having them all as asset labels makes extracting the information during scanning much easier than when everything is scattered around.

Note: `ContainerName` is used from the container MQL asset because the regular `Name` is just `{ContainerName}-{PublicIpAddress}` while AWS only needs the name without the IP.