### PR TITLE
🎉 os-11.2.33

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "11.2.32",
+	Version: "11.2.33",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by cnquery's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.