### PR TITLE
🐛 Use explicitly specified asset name in SSH connection.

### DIFF
--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -373,7 +373,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 
 			fingerprint, p, err := id.IdentifyPlatform(conn, req, asset.Platform, asset.IdDetector)
 			if err == nil {
-				if conn.Asset().Connections[0].Runtime != "vagrant" {
+				if asset.Name == "" && conn.Asset().Connections[0].Runtime != "vagrant" {
 					asset.Name = fingerprint.Name
 				}
 				asset.PlatformIds = fingerprint.PlatformIDs


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4d34447c-8ce7-43fb-bea4-cefd164db647)
