### PR TITLE
✨ Streamline AWS discovery filters

### DIFF
--- a/providers/aws/connection/connection.go
+++ b/providers/aws/connection/connection.go
@@ -155,9 +155,9 @@ func parseOptsToFilters(opts map[string]string) DiscoveryFilters {
 		case k == "ec2:exclude:iid":
 			d.Ec2DiscoveryFilters.ExcludeInstanceIds = append(d.Ec2DiscoveryFilters.ExcludeInstanceIds, strings.Split(v, ",")...)
 		case strings.HasPrefix(k, "ec2:tag:"):
-			d.Ec2DiscoveryFilters.Tags[strings.TrimPrefix(k, "tag:")] = v
+			d.Ec2DiscoveryFilters.Tags[strings.TrimPrefix(k, "ec2:tag:")] = v
 		case strings.HasPrefix(k, "ec2:exclude:tag:"):
-			d.Ec2DiscoveryFilters.ExcludeTags[strings.TrimPrefix(k, "exclude:tag:")] = v
+			d.Ec2DiscoveryFilters.ExcludeTags[strings.TrimPrefix(k, "ec2:exclude:tag:")] = v
 		case k == "ecr:tags":
 			d.EcrDiscoveryFilters.Tags = append(d.EcrDiscoveryFilters.Tags, strings.Split(v, ",")...)
 		case k == "ecr:exclude:tags":

--- a/providers/aws/connection/connection.go
+++ b/providers/aws/connection/connection.go
@@ -149,9 +149,9 @@ func parseOptsToFilters(opts map[string]string) DiscoveryFilters {
 			d.DiscoveryFilters.Regions = append(d.DiscoveryFilters.Regions, strings.Split(v, ",")...)
 		case k == "exclude:regions":
 			d.DiscoveryFilters.ExcludeRegions = append(d.DiscoveryFilters.ExcludeRegions, strings.Split(v, ",")...)
-		case k == "ec2:iid":
+		case k == "ec2:instance-ids":
 			d.Ec2DiscoveryFilters.InstanceIds = append(d.Ec2DiscoveryFilters.InstanceIds, strings.Split(v, ",")...)
-		case k == "ec2:exclude:iid":
+		case k == "ec2:exclude:instance-ids":
 			d.Ec2DiscoveryFilters.ExcludeInstanceIds = append(d.Ec2DiscoveryFilters.ExcludeInstanceIds, strings.Split(v, ",")...)
 		case strings.HasPrefix(k, "ec2:tag:"):
 			d.Ec2DiscoveryFilters.Tags[strings.TrimPrefix(k, "ec2:tag:")] = v

--- a/providers/aws/connection/connection.go
+++ b/providers/aws/connection/connection.go
@@ -45,20 +45,20 @@ type DiscoveryFilters struct {
 	Ec2DiscoveryFilters Ec2DiscoveryFilters
 	EcrDiscoveryFilters EcrDiscoveryFilters
 	EcsDiscoveryFilters EcsDiscoveryFilters
-	DiscoveryFilters    GeneralResourceDiscoveryFilters
+	DiscoveryFilters    GeneralDiscoveryFilters
 }
 
 // ensure all underlying reference types aren't `nil`
 func EmptyDiscoveryFilters() DiscoveryFilters {
 	return DiscoveryFilters{
-		DiscoveryFilters:    GeneralResourceDiscoveryFilters{Regions: []string{}, ExcludeRegions: []string{}},
+		DiscoveryFilters:    GeneralDiscoveryFilters{Regions: []string{}, ExcludeRegions: []string{}},
 		Ec2DiscoveryFilters: Ec2DiscoveryFilters{InstanceIds: []string{}, ExcludeInstanceIds: []string{}, Tags: map[string]string{}, ExcludeTags: map[string]string{}},
 		EcrDiscoveryFilters: EcrDiscoveryFilters{Tags: []string{}, ExcludeTags: []string{}},
 		EcsDiscoveryFilters: EcsDiscoveryFilters{},
 	}
 }
 
-type GeneralResourceDiscoveryFilters struct {
+type GeneralDiscoveryFilters struct {
 	Regions        []string
 	ExcludeRegions []string
 }

--- a/providers/aws/connection/connection.go
+++ b/providers/aws/connection/connection.go
@@ -136,7 +136,6 @@ func NewAwsConnection(id uint32, asset *inventory.Asset, conf *inventory.Config)
 	c.scope = asset.Options["scope"]
 	c.connectionOptions = asset.Options
 	if conf.Discover != nil {
-		log.Warn().Interface("opts", conf.Discover.Filter).Msg("PARSING OPTS TO FILTERS!")
 		c.Filters = parseOptsToFilters(conf.Discover.Filter)
 	}
 	return c, nil
@@ -368,7 +367,6 @@ func (h *AwsConnection) Regions() ([]string, error) {
 
 	// include filters have precedense over exclude filters. in any normal situation they should be mutually exclusive.
 	regionLimits := h.Filters.DiscoveryFilters.Regions
-	log.Warn().Interface("regionLimits", regionLimits).Msg("region limits when Regions() is called")
 	if len(regionLimits) > 0 {
 		log.Debug().Interface("regions", regionLimits).Msg("using region limits")
 		// cache the regions as part of the provider instance

--- a/providers/aws/connection/connection_test.go
+++ b/providers/aws/connection/connection_test.go
@@ -9,76 +9,47 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// testParseOptsToFilters accepts a map which doesn't guarantee a deterministic iteration order. this means that slices
-// in the parsed filters need to be compared individually ensuring their elements match regardless of their order.
-func compareFilters(t *testing.T, expected, actual DiscoveryFilters) {
-	require.ElementsMatch(t, expected.Ec2DiscoveryFilters.Regions, actual.Ec2DiscoveryFilters.Regions)
-	require.ElementsMatch(t, expected.Ec2DiscoveryFilters.ExcludeRegions, actual.Ec2DiscoveryFilters.ExcludeRegions)
-
-	require.ElementsMatch(t, expected.Ec2DiscoveryFilters.InstanceIds, actual.Ec2DiscoveryFilters.InstanceIds)
-	require.ElementsMatch(t, expected.Ec2DiscoveryFilters.ExcludeInstanceIds, actual.Ec2DiscoveryFilters.ExcludeInstanceIds)
-
-	require.Equal(t, expected.Ec2DiscoveryFilters.Tags, actual.Ec2DiscoveryFilters.Tags)
-	require.Equal(t, expected.Ec2DiscoveryFilters.ExcludeTags, actual.Ec2DiscoveryFilters.ExcludeTags)
-
-	require.Equal(t, expected.EcsDiscoveryFilters, actual.EcsDiscoveryFilters)
-
-	require.ElementsMatch(t, expected.EcrDiscoveryFilters.Tags, actual.EcrDiscoveryFilters.Tags)
-
-	require.ElementsMatch(t, expected.GeneralDiscoveryFilters.Regions, actual.GeneralDiscoveryFilters.Regions)
-	require.Equal(t, expected.GeneralDiscoveryFilters.Tags, actual.GeneralDiscoveryFilters.Tags)
-}
-
 func TestParseOptsToFilters(t *testing.T) {
 	t.Run("all opts are mapped to discovery filters correctly", func(t *testing.T) {
 		opts := map[string]string{
+			// DiscoveryFilters.Regions
+			"regions": "us-east-1,us-west-1,eu-west-1",
+			// DiscoveryFilters.ExcludeRegions
+			"exclude:regions": "us-east-2,us-west-2,eu-west-2",
+			// Ec2DiscoveryFilters.InstanceIds
+			"ec2:iid": "iid-1,iid-2",
+			// Ec2DiscoveryFilters.ExcludeInstanceIds
+			"ec2:exclude:iid": "iid-1,iid-2",
 			// Ec2DiscoveryFilters.Tags
 			"ec2:tag:key1": "val1",
 			"ec2:tag:key2": "val2",
 			// Ec2DiscoveryFilters.ExcludeTags
-			"exclude:ec2:tag:key1": "val1",
-			"exclude:ec2:tag:key2": "val2",
-			// Ec2DiscoveryFilters.Regions
-			"ec2:regions": "us-east-1,us-west-1",
-			// Ec2DiscoveryFilters.ExcludeRegions
-			"exclude:ec2:regions": "us-east-1,us-west-1",
-			// Ec2DiscoveryFilters.InstanceIds
-			"ec2:instance-ids": "iid-1,iid-2",
-			// Ec2DiscoveryFilters.ExcludeInstanceIds
-			"exclude:ec2:instance-ids": "iid-1,iid-2",
-			// GeneralDiscoveryFilters.Regions
-			"all:regions": "us-east-1,us-west-1,eu-west-1",
-			// GeneralDiscoveryFilters.Tags
-			"all:tag:key1": "val1",
-			"all:tag:key2": "val2",
+			"ec2:exclude:tag:key1": "val1,val2",
+			"ec2:exclude:tag:key2": "val3",
 			// EcrDiscoveryFilters.Tags
 			"ecr:tags": "tag1,tag2",
+			// EcrDiscoveryFilters.ExcludeTags
+			"ecr:exclude:tags": "tag1,tag2",
 			// EcsDiscoveryFilters
 			"ecs:only-running-containers": "true",
 			"ecs:discover-images":         "T",
 			"ecs:discover-instances":      "false",
 		}
 		expected := DiscoveryFilters{
+			DiscoveryFilters: GeneralResourceDiscoveryFilters{
+				Regions:        []string{"us-east-1", "us-west-1", "eu-west-1"},
+				ExcludeRegions: []string{"us-east-2", "us-west-2", "eu-west-2"},
+			},
 			Ec2DiscoveryFilters: Ec2DiscoveryFilters{
-				Regions: []string{
-					"us-east-1", "us-west-1",
-				},
-				ExcludeRegions: []string{
-					"us-east-1", "us-west-1",
-				},
-				InstanceIds: []string{
-					"iid-1", "iid-2",
-				},
-				ExcludeInstanceIds: []string{
-					"iid-1", "iid-2",
-				},
+				InstanceIds:        []string{"iid-1", "iid-2"},
+				ExcludeInstanceIds: []string{"iid-1", "iid-2"},
 				Tags: map[string]string{
 					"key1": "val1",
 					"key2": "val2",
 				},
 				ExcludeTags: map[string]string{
-					"key1": "val1",
-					"key2": "val2",
+					"key1": "val1,val2",
+					"key2": "val3",
 				},
 			},
 			EcsDiscoveryFilters: EcsDiscoveryFilters{
@@ -86,33 +57,19 @@ func TestParseOptsToFilters(t *testing.T) {
 				DiscoverImages:        true,
 				DiscoverInstances:     false,
 			},
-			EcrDiscoveryFilters: EcrDiscoveryFilters{Tags: []string{
-				"tag1", "tag2",
-			}},
-			GeneralDiscoveryFilters: GeneralResourceDiscoveryFilters{
-				Regions: []string{
-					"us-east-1", "us-west-1", "eu-west-1",
-				},
-				Tags: map[string]string{
-					"key1": "val1",
-					"key2": "val2",
-				},
+			EcrDiscoveryFilters: EcrDiscoveryFilters{
+				Tags:        []string{"tag1", "tag2"},
+				ExcludeTags: []string{"tag1", "tag2"},
 			},
 		}
 
 		actual := parseOptsToFilters(opts)
-		compareFilters(t, expected, actual)
+		require.Equal(t, expected, actual)
 	})
 
 	t.Run("empty opts are mapped to discovery filters correctly", func(t *testing.T) {
-		expected := DiscoveryFilters{
-			Ec2DiscoveryFilters:     Ec2DiscoveryFilters{Tags: map[string]string{}, ExcludeTags: map[string]string{}},
-			EcsDiscoveryFilters:     EcsDiscoveryFilters{},
-			EcrDiscoveryFilters:     EcrDiscoveryFilters{Tags: []string{}},
-			GeneralDiscoveryFilters: GeneralResourceDiscoveryFilters{Tags: map[string]string{}},
-		}
-
+		expected := EmptyDiscoveryFilters()
 		actual := parseOptsToFilters(map[string]string{})
-		compareFilters(t, expected, actual)
+		require.Equal(t, expected, actual)
 	})
 }

--- a/providers/aws/connection/connection_test.go
+++ b/providers/aws/connection/connection_test.go
@@ -36,7 +36,7 @@ func TestParseOptsToFilters(t *testing.T) {
 			"ecs:discover-instances":      "false",
 		}
 		expected := DiscoveryFilters{
-			DiscoveryFilters: GeneralResourceDiscoveryFilters{
+			DiscoveryFilters: GeneralDiscoveryFilters{
 				Regions:        []string{"us-east-1", "us-west-1", "eu-west-1"},
 				ExcludeRegions: []string{"us-east-2", "us-west-2", "eu-west-2"},
 			},

--- a/providers/aws/connection/connection_test.go
+++ b/providers/aws/connection/connection_test.go
@@ -17,9 +17,9 @@ func TestParseOptsToFilters(t *testing.T) {
 			// DiscoveryFilters.ExcludeRegions
 			"exclude:regions": "us-east-2,us-west-2,eu-west-2",
 			// Ec2DiscoveryFilters.InstanceIds
-			"ec2:iid": "iid-1,iid-2",
+			"ec2:instance-ids": "iid-1,iid-2",
 			// Ec2DiscoveryFilters.ExcludeInstanceIds
-			"ec2:exclude:iid": "iid-1,iid-2",
+			"ec2:exclude:instance-ids": "iid-1,iid-2",
 			// Ec2DiscoveryFilters.Tags
 			"ec2:tag:key1": "val1",
 			"ec2:tag:key2": "val2",

--- a/providers/aws/provider/provider.go
+++ b/providers/aws/provider/provider.go
@@ -88,8 +88,8 @@ func parseFlagsToFiltersOpts(m map[string]*llx.Primitive) map[string]string {
 			"regions",
 			"exclude:regions",
 			// ec2 filters
-			"ec2:iid",
-			"ec2:exclude:iid",
+			"ec2:instance-ids",
+			"ec2:exclude:instance-ids",
 			"ec2:tag:",
 			"ec2:exclude:tag:",
 			// ecr filters

--- a/providers/aws/provider/provider.go
+++ b/providers/aws/provider/provider.go
@@ -84,16 +84,18 @@ func parseFlagsToFiltersOpts(m map[string]*llx.Primitive) map[string]string {
 
 	if x, ok := m["filters"]; ok && len(x.Map) != 0 {
 		knownTagPrefixes := []string{
-			"ec2:tag:",
-			"exclude:ec2:tag:",
-			"ec2:regions",
-			"exclude:ec2:regions",
-			"all:regions",
+			// general filters
 			"regions",
-			"ec2:instance-ids",
-			"exclude:ec2:instance-ids",
-			"all:tag:",
+			"exclude:regions",
+			// ec2 filters
+			"ec2:iid",
+			"ec2:exclude:iid",
+			"ec2:tag:",
+			"ec2:exclude:tag:",
+			// ecr filters
 			"ecr:tags",
+			"ecr:exclude:tags",
+			// ecs filters
 			"ecs:only-running-containers",
 			"ecs:discover-instances",
 			"ecs:discover-images",

--- a/providers/aws/resources/aws_ec2_test.go
+++ b/providers/aws/resources/aws_ec2_test.go
@@ -28,83 +28,71 @@ func TestShouldExcludeInstance(t *testing.T) {
 	}
 
 	t.Run("should exclude instance by id", func(t *testing.T) {
-		filters := connection.DiscoveryFilters{
-			Ec2DiscoveryFilters: connection.Ec2DiscoveryFilters{
-				ExcludeInstanceIds: []string{
-					"iid",
-				},
-				ExcludeTags: map[string]string{
-					"key-3": "val3",
-				},
+		filters := connection.Ec2DiscoveryFilters{
+			ExcludeInstanceIds: []string{
+				"iid",
+			},
+			ExcludeTags: map[string]string{
+				"key-3": "val3",
 			},
 		}
 		require.True(t, shouldExcludeInstance(instance, filters))
 	})
 
 	t.Run("should exclude instance by matching tag", func(t *testing.T) {
-		filters := connection.DiscoveryFilters{
-			Ec2DiscoveryFilters: connection.Ec2DiscoveryFilters{
-				ExcludeInstanceIds: []string{
-					"iid-2",
-				},
-				ExcludeTags: map[string]string{
-					"key-2": "val2",
-				},
+		filters := connection.Ec2DiscoveryFilters{
+			ExcludeInstanceIds: []string{
+				"iid-2",
+			},
+			ExcludeTags: map[string]string{
+				"key-2": "val2",
 			},
 		}
 		require.False(t, shouldExcludeInstance(instance, filters))
 	})
 
 	t.Run("should not exclude instance with only a matching tag key", func(t *testing.T) {
-		filters := connection.DiscoveryFilters{
-			Ec2DiscoveryFilters: connection.Ec2DiscoveryFilters{
-				ExcludeInstanceIds: []string{
-					"iid-2",
-				},
-				ExcludeTags: map[string]string{
-					"key-2": "val3",
-					"key-3": "val3",
-				},
+		filters := connection.Ec2DiscoveryFilters{
+			ExcludeInstanceIds: []string{
+				"iid-2",
+			},
+			ExcludeTags: map[string]string{
+				"key-2": "val3",
+				"key-3": "val3",
 			},
 		}
 		require.False(t, shouldExcludeInstance(instance, filters))
 	})
 
 	t.Run("should not exclude instance when instance id and tags don't match", func(t *testing.T) {
-		filters := connection.DiscoveryFilters{
-			Ec2DiscoveryFilters: connection.Ec2DiscoveryFilters{
-				ExcludeInstanceIds: []string{
-					"iid-2",
-				},
-				ExcludeTags: map[string]string{
-					"key-3": "val3",
-				},
+		filters := connection.Ec2DiscoveryFilters{
+			ExcludeInstanceIds: []string{
+				"iid-2",
+			},
+			ExcludeTags: map[string]string{
+				"key-3": "val3",
 			},
 		}
 		require.False(t, shouldExcludeInstance(instance, filters))
 	})
 
 	t.Run("should exclude instances with matching values for the same tag", func(t *testing.T) {
-		filters := connection.DiscoveryFilters{
-			Ec2DiscoveryFilters: connection.Ec2DiscoveryFilters{
-				ExcludeInstanceIds: []string{},
-				ExcludeTags: map[string]string{
-					"key-1": "val-1,val-2,val-3",
-				},
+		filters := connection.Ec2DiscoveryFilters{
+			ExcludeInstanceIds: []string{},
+			ExcludeTags: map[string]string{
+				"key-1": "val-1,val-2,val-3",
 			},
 		}
 		require.True(t, shouldExcludeInstance(instance, filters))
 	})
 
 	t.Run("should not exclude instances when no tag values match", func(t *testing.T) {
-		filters := connection.DiscoveryFilters{
-			Ec2DiscoveryFilters: connection.Ec2DiscoveryFilters{
-				ExcludeInstanceIds: []string{},
-				ExcludeTags: map[string]string{
-					"key-1": "val-2,val-3",
-					"key-2": "val-1,val-3",
-					"key-3": "val-1,val-2",
-				},
+		filters := connection.Ec2DiscoveryFilters{
+			ExcludeInstanceIds: []string{},
+			ExcludeTags: map[string]string{
+				"key-1": "val-2,val-3",
+				"key-2": "val-1,val-3",
+				"key-3": "val-1,val-2",
 			},
 		}
 		require.False(t, shouldExcludeInstance(instance, filters))

--- a/providers/aws/resources/aws_ec2_test.go
+++ b/providers/aws/resources/aws_ec2_test.go
@@ -28,103 +28,85 @@ func TestShouldExcludeInstance(t *testing.T) {
 	}
 
 	t.Run("should exclude instance by id", func(t *testing.T) {
-		filters := connection.Ec2DiscoveryFilters{
-			ExcludeInstanceIds: []string{
-				"iid",
-			},
-			ExcludeTags: map[string]string{
-				"key-3": "val3",
+		filters := connection.DiscoveryFilters{
+			Ec2DiscoveryFilters: connection.Ec2DiscoveryFilters{
+				ExcludeInstanceIds: []string{
+					"iid",
+				},
+				ExcludeTags: map[string]string{
+					"key-3": "val3",
+				},
 			},
 		}
 		require.True(t, shouldExcludeInstance(instance, filters))
 	})
 
 	t.Run("should exclude instance by matching tag", func(t *testing.T) {
-		filters := connection.Ec2DiscoveryFilters{
-			ExcludeInstanceIds: []string{
-				"iid-2",
-			},
-			ExcludeTags: map[string]string{
-				"key-2": "val2",
+		filters := connection.DiscoveryFilters{
+			Ec2DiscoveryFilters: connection.Ec2DiscoveryFilters{
+				ExcludeInstanceIds: []string{
+					"iid-2",
+				},
+				ExcludeTags: map[string]string{
+					"key-2": "val2",
+				},
 			},
 		}
 		require.False(t, shouldExcludeInstance(instance, filters))
 	})
 
 	t.Run("should not exclude instance with only a matching tag key", func(t *testing.T) {
-		filters := connection.Ec2DiscoveryFilters{
-			ExcludeInstanceIds: []string{
-				"iid-2",
-			},
-			ExcludeTags: map[string]string{
-				"key-2": "val3",
-				"key-3": "val3",
+		filters := connection.DiscoveryFilters{
+			Ec2DiscoveryFilters: connection.Ec2DiscoveryFilters{
+				ExcludeInstanceIds: []string{
+					"iid-2",
+				},
+				ExcludeTags: map[string]string{
+					"key-2": "val3",
+					"key-3": "val3",
+				},
 			},
 		}
 		require.False(t, shouldExcludeInstance(instance, filters))
 	})
 
 	t.Run("should not exclude instance when instance id and tags don't match", func(t *testing.T) {
-		filters := connection.Ec2DiscoveryFilters{
-			ExcludeInstanceIds: []string{
-				"iid-2",
-			},
-			ExcludeTags: map[string]string{
-				"key-3": "val3",
+		filters := connection.DiscoveryFilters{
+			Ec2DiscoveryFilters: connection.Ec2DiscoveryFilters{
+				ExcludeInstanceIds: []string{
+					"iid-2",
+				},
+				ExcludeTags: map[string]string{
+					"key-3": "val3",
+				},
 			},
 		}
 		require.False(t, shouldExcludeInstance(instance, filters))
 	})
 
 	t.Run("should exclude instances with matching values for the same tag", func(t *testing.T) {
-		filters := connection.Ec2DiscoveryFilters{
-			ExcludeTags: map[string]string{
-				"key-1": "val-1,val-2,val-3",
+		filters := connection.DiscoveryFilters{
+			Ec2DiscoveryFilters: connection.Ec2DiscoveryFilters{
+				ExcludeInstanceIds: []string{},
+				ExcludeTags: map[string]string{
+					"key-1": "val-1,val-2,val-3",
+				},
 			},
 		}
 		require.True(t, shouldExcludeInstance(instance, filters))
 	})
 
 	t.Run("should not exclude instances when no tag values match", func(t *testing.T) {
-		filters := connection.Ec2DiscoveryFilters{
-			ExcludeTags: map[string]string{
-				"key-1": "val-2,val-3",
-				"key-2": "val-1,val-3",
-				"key-3": "val-1,val-2",
+		filters := connection.DiscoveryFilters{
+			Ec2DiscoveryFilters: connection.Ec2DiscoveryFilters{
+				ExcludeInstanceIds: []string{},
+				ExcludeTags: map[string]string{
+					"key-1": "val-2,val-3",
+					"key-2": "val-1,val-3",
+					"key-3": "val-1,val-2",
+				},
 			},
 		}
 		require.False(t, shouldExcludeInstance(instance, filters))
-	})
-}
-
-func TestDetermineApplicableRegions(t *testing.T) {
-	t.Run("allow regions override initial region list", func(t *testing.T) {
-		initialRegions := []string{"a", "b"}
-		allowedRegions := []string{"b", "c"}
-		excludedRegions := []string{}
-
-		expected := []string{"b", "c"}
-		actual := determineApplicableRegions(initialRegions, allowedRegions, excludedRegions)
-		require.ElementsMatch(t, expected, actual)
-	})
-
-	t.Run("excluded regions work correctly", func(t *testing.T) {
-		initialRegions := []string{"a", "b"}
-		allowedRegions := []string{}
-		excludedRegions := []string{"b"}
-
-		expected := []string{"a"}
-		actual := determineApplicableRegions(initialRegions, allowedRegions, excludedRegions)
-		require.ElementsMatch(t, expected, actual)
-	})
-
-	t.Run("excluded regions not present in the initial slice are ignored", func(t *testing.T) {
-		initialRegions := []string{"a", "b"}
-		allowedRegions := []string{}
-		excludedRegions := []string{"b", "c", "d", "e"}
-
-		expected := []string{"a"}
-		actual := determineApplicableRegions(initialRegions, allowedRegions, excludedRegions)
-		require.ElementsMatch(t, expected, actual)
 	})
 }

--- a/providers/aws/resources/aws_ecr.go
+++ b/providers/aws/resources/aws_ecr.go
@@ -159,11 +159,10 @@ func (a *mqlAwsEcrRepository) images() ([]interface{}, error) {
 			return nil, err
 		}
 
-		for i := range res.ImageDetails {
-			image := res.ImageDetails[i]
+		for _, image := range res.ImageDetails {
 			tags := []interface{}{}
-			for i := range image.ImageTags {
-				tags = append(tags, image.ImageTags[i])
+			for _, imageTag := range image.ImageTags {
+				tags = append(tags, imageTag)
 			}
 			mqlImage, err := CreateResource(a.MqlRuntime, "aws.ecr.image",
 				map[string]*llx.RawData{

--- a/providers/aws/resources/discovery.go
+++ b/providers/aws/resources/discovery.go
@@ -120,7 +120,7 @@ func imageMatchesFilters(image *mqlAwsEcrImage, filters connection.EcrDiscoveryF
 }
 
 func containerMatchesFilters(container *mqlAwsEcsContainer, ecsFilters connection.EcsDiscoveryFilters) bool {
-	return ecsFilters.OnlyRunningContainers && container.Status.Data == "RUNNING"
+	return container.Status.Data == "RUNNING" || !ecsFilters.OnlyRunningContainers
 }
 
 func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {

--- a/providers/aws/resources/discovery_test.go
+++ b/providers/aws/resources/discovery_test.go
@@ -15,70 +15,31 @@ import (
 )
 
 func TestFilters(t *testing.T) {
+	// image filters
 	require.True(t, imageMatchesFilters(&mqlAwsEcrImage{
 		Tags: plugin.TValue[[]interface{}]{Data: []interface{}{"latest"}},
-	}, connection.DiscoveryFilters{}))
+	}, connection.EcrDiscoveryFilters{}))
+
 	require.True(t, imageMatchesFilters(&mqlAwsEcrImage{
 		Tags: plugin.TValue[[]interface{}]{Data: []interface{}{"latest"}},
-	}, connection.DiscoveryFilters{
-		EcrDiscoveryFilters: connection.EcrDiscoveryFilters{
-			Tags: []string{"latest"},
-		},
-	}))
+	}, connection.EcrDiscoveryFilters{Tags: []string{"latest"}}))
+
 	require.False(t, imageMatchesFilters(&mqlAwsEcrImage{
 		Tags: plugin.TValue[[]interface{}]{Data: []interface{}{"ubu", "test"}},
-	}, connection.DiscoveryFilters{
-		EcrDiscoveryFilters: connection.EcrDiscoveryFilters{
-			Tags: []string{"latest"},
-		},
-	}))
+	}, connection.EcrDiscoveryFilters{Tags: []string{"latest"}}))
+
+	// container filters
+	require.True(t, containerMatchesFilters(&mqlAwsEcsContainer{
+		Status: plugin.TValue[string]{Data: "RUNNING"},
+	}, connection.EcsDiscoveryFilters{}))
 
 	require.True(t, containerMatchesFilters(&mqlAwsEcsContainer{
 		Status: plugin.TValue[string]{Data: "RUNNING"},
-	}, connection.DiscoveryFilters{}))
-
-	require.True(t, containerMatchesFilters(&mqlAwsEcsContainer{
-		Status: plugin.TValue[string]{Data: "RUNNING"},
-	}, connection.DiscoveryFilters{EcsDiscoveryFilters: connection.EcsDiscoveryFilters{
-		OnlyRunningContainers: true,
-	}}))
+	}, connection.EcsDiscoveryFilters{OnlyRunningContainers: true}))
 
 	require.False(t, containerMatchesFilters(&mqlAwsEcsContainer{
 		Status: plugin.TValue[string]{Data: "STOPPED"},
-	}, connection.DiscoveryFilters{EcsDiscoveryFilters: connection.EcsDiscoveryFilters{
-		OnlyRunningContainers: true,
-	}}))
-
-	require.True(t, discoveredAssetMatchesGeneralFilters(&inventory.Asset{
-		Labels: map[string]string{"test": "val", "another": "value"},
-	}, connection.GeneralResourceDiscoveryFilters{}))
-	require.True(t, discoveredAssetMatchesGeneralFilters(&inventory.Asset{
-		Labels: nil,
-	}, connection.GeneralResourceDiscoveryFilters{}))
-	require.True(t, discoveredAssetMatchesGeneralFilters(&inventory.Asset{
-		Labels: map[string]string{"test": "val", "another": "value"},
-	}, connection.GeneralResourceDiscoveryFilters{Tags: map[string]string{"another": "value"}}))
-
-	require.False(t, discoveredAssetMatchesGeneralFilters(&inventory.Asset{
-		Labels: map[string]string{"test": "val", "another": "value"},
-	}, connection.GeneralResourceDiscoveryFilters{Tags: map[string]string{"something": "else"}}))
-	require.False(t, discoveredAssetMatchesGeneralFilters(&inventory.Asset{
-		Labels: nil,
-	}, connection.GeneralResourceDiscoveryFilters{Tags: map[string]string{"something": "else"}}))
-
-	require.True(t, shouldScanEcsContainerImages(connection.DiscoveryFilters{
-		EcsDiscoveryFilters: connection.EcsDiscoveryFilters{
-			DiscoverImages: true,
-		},
-	}))
-	require.False(t, shouldScanEcsContainerImages(connection.DiscoveryFilters{}))
-	require.True(t, shouldScanEcsContainerInstances(connection.DiscoveryFilters{
-		EcsDiscoveryFilters: connection.EcsDiscoveryFilters{
-			DiscoverImages:    false,
-			DiscoverInstances: true,
-		},
-	}))
-	require.False(t, shouldScanEcsContainerInstances(connection.DiscoveryFilters{}))
+	}, connection.EcsDiscoveryFilters{OnlyRunningContainers: true}))
 }
 
 func TestAddConnInfoToEc2Instances(t *testing.T) {


### PR DESCRIPTION
#### In this PR:
- Made include/exclude region filters general for all assets. Incorporated them in `.Regions()` function so that should be applied everywhere.
- Removed tag filter from the general discovery filters. It did not make sense to have the same tag filter for all discovered assets as that is way too restrictive and often times would conflict, e.g. if you filter by a tag you use for EC2 instances, that automatically ignores every other asset in your AWS account. Furthermore, many assets do not have tags (containers/accounts, etc) so you need to ensure you do not filter those out which makes having global tag filters difficult to implement properly and reason about. Likely in the future we can make the filters more modular and have dedicated filters for different assets.
- Modified the existing filter keys in an attempt to make them easier to use, e.g. `ec2:iid` instead of `ec2:instance-ids`. Also, changed `exclude:ec2:xyz` into `ec2:exclude:xyz` such that the resource type the filter applies to is at the start.
- Removed functions that were no longer applicable after refactor.
- Made some code improvements.
- Fixed bug where `DescribeClusters` and `DescribeTasks` were not retrieving tags from AWS. They have to be specifically requested.