### PR TITLE
🐛 fix aws.eks.clusters { * } panic

### DIFF
--- a/providers/aws/resources/aws_eks.go
+++ b/providers/aws/resources/aws_eks.go
@@ -273,6 +273,10 @@ func (a *mqlAwsEksNodegroup) diskSize() (int64, error) {
 	if err != nil {
 		return 0, err
 	}
+	if ng.DiskSize == nil {
+		a.DiskSize.State = plugin.StateIsNull | plugin.StateIsSet
+		return 0, nil
+	}
 	return int64(*ng.DiskSize), nil
 }
 


### PR DESCRIPTION
fix for aws.eks.clusters { * }

```
cnquery> aws.eks.clusters
aws.eks.clusters: [
  0: aws.eks.cluster arn="arn:aws:eks:us-west-2:-----:cluster/tim_test" version="1.30" status="ACTIVE"
]
cnquery> aws.eks.clusters { * }
aws.eks.clusters: [
  0: {
    networkConfig: {
```

fixes https://github.com/mondoohq/cnquery/issues/4257