### PR TITLE
🐛 RPM: fix match "(none)" vendor

### DIFF
--- a/providers/os/resources/packages/rpm_packages.go
+++ b/providers/os/resources/packages/rpm_packages.go
@@ -30,7 +30,7 @@ const (
 	RpmPkgFormat = "rpm"
 )
 
-var RPM_REGEX = regexp.MustCompile(`^([\w-+]*)\s(\d*|\(none\)):([\w\d-+.:]+)\s([\w\d]*|\(none\))__([\w\d\s,/<>:\.]+)__(.*)$`)
+var RPM_REGEX = regexp.MustCompile(`^([\w-+]*)\s(\d*|\(none\)):([\w\d-+.:]+)\s([\w\d]*|\(none\))__([\w\d\s,/<>:\.|\(none\)]+)__(.*)$`)
 
 // ParseRpmPackages parses output from:
 // rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}\n'

--- a/providers/os/resources/packages/rpm_packages_test.go
+++ b/providers/os/resources/packages/rpm_packages_test.go
@@ -37,7 +37,7 @@ func TestRedhat8Parser(t *testing.T) {
 	}
 
 	m := ParseRpmPackages(pf, c.Stdout)
-	assert.Equal(t, 190, len(m), "detected the right amount of packages")
+	assert.Equal(t, 192, len(m), "detected the right amount of packages")
 
 	p := Package{
 		Name:        "ncurses-base",
@@ -144,6 +144,24 @@ func TestRedhat8Parser(t *testing.T) {
 		},
 		Format:         RpmPkgFormat,
 		FilesAvailable: PkgFilesAsync,
+	}
+	assert.Equal(t, p, findPkg(m, p.Name), p.Name)
+
+	// Package with (none) vendor and arch
+	p = Package{
+		Name:           "gpg-pubkey",
+		Version:        "d4082792-5b32db75",
+		Vendor:         "(none)",
+		Description:    "gpg(Red Hat, Inc. (auxiliary key) <security@redhat.com>)",
+		Format:         RpmPkgFormat,
+		FilesAvailable: PkgFilesAsync,
+		PUrl:           "pkg:rpm/rhel/gpg-pubkey@d4082792-5b32db75?distro=rhel-8.4",
+		CPEs: []string{
+			"cpe:2.3:a:\\(none\\):gpg-pubkey:d4082792-5b32db75:*:*:*:*:*:*:*",
+			"cpe:2.3:a:\\(none\\):gpg-pubkey:d4082792:*:*:*:*:*:*:*",
+			"cpe:2.3:a:\\(none\\):gpg-pubkey:d4082792-5b32db75:*:*:*:*:*:*:*",
+			"cpe:2.3:a:\\(none\\):gpg-pubkey:d4082792:*:*:*:*:*:*:*",
+		},
 	}
 	assert.Equal(t, p, findPkg(m, p.Name), p.Name)
 


### PR DESCRIPTION
```sh
cnquery run -c 'packages' | grep pulse
```

```
  601: package name="pulseaudio-libs" version="16.1-8.fc40"
  650: package name="pulsesecure" version="2:9.1-R14"
  653: package name="pipewire-pulseaudio" version="1.0.9-1.fc40"
```

---
```sh
cnquery run -c 'packages.where(name == /pulse.*/) { name description vendor epoch version arch }'
```

```graphql
packages.where.list: [
  0: {
    name: "pulseaudio-libs"
    description: "Libraries for PulseAudio clients"
    vendor: "Fedora Project"
    version: "16.1-8.fc40"
    epoch: ""
    arch: "x86_64"
  }
  1: {
    name: "pulsesecure"
    description: "Pulse Secure Client For Linux"
    vendor: "(none)"
    version: "2:22.7-R1"
    epoch: "2"
    arch: "x86_64"
  }
  2: {
    name: "pipewire-pulseaudio"
    description: "PipeWire PulseAudio implementation"
    vendor: "Fedora Project"
    version: "1.0.9-1.fc40"
    epoch: ""
    arch: "x86_64"
  }
]
```