### PR TITLE
✨ Add microsoft.user.mfaEnabled field.

### DIFF
--- a/providers/ms365/connection/adapter.go
+++ b/providers/ms365/connection/adapter.go
@@ -8,6 +8,7 @@ import (
 	errors "github.com/cockroachdb/errors"
 	"github.com/microsoft/kiota-abstractions-go/authentication"
 	a "github.com/microsoft/kiota-authentication-azure-go"
+	beta "github.com/microsoftgraph/msgraph-beta-sdk-go"
 	msgraphsdkgo "github.com/microsoftgraph/msgraph-sdk-go"
 )
 
@@ -36,6 +37,22 @@ func graphClient(token azcore.TokenCredential) (*msgraphsdkgo.GraphServiceClient
 	return graphClient, nil
 }
 
+func betaGraphClient(token azcore.TokenCredential) (*beta.GraphServiceClient, error) {
+	providerFunc := func() (authentication.AuthenticationProvider, error) {
+		return a.NewAzureIdentityAuthenticationProviderWithScopes(token, DefaultMSGraphScopes)
+	}
+	adapter, err := newGraphRequestAdapterWithFn(providerFunc)
+	if err != nil {
+		return nil, err
+	}
+	graphClient := beta.NewGraphServiceClient(adapter)
+	return graphClient, nil
+}
+
 func (conn *Ms365Connection) GraphClient() (*msgraphsdkgo.GraphServiceClient, error) {
 	return graphClient(conn.Token())
+}
+
+func (conn *Ms365Connection) BetaGraphClient() (*beta.GraphServiceClient, error) {
+	return betaGraphClient(conn.Token())
 }

--- a/providers/ms365/go.mod
+++ b/providers/ms365/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/microsoft/kiota-abstractions-go v1.7.0
 	github.com/microsoft/kiota-authentication-azure-go v1.1.0
+	github.com/microsoftgraph/msgraph-beta-sdk-go v0.111.0
 	github.com/microsoftgraph/msgraph-sdk-go v1.51.0
 	github.com/microsoftgraph/msgraph-sdk-go-core v1.2.1
 	github.com/rs/zerolog v1.33.0

--- a/providers/ms365/go.sum
+++ b/providers/ms365/go.sum
@@ -315,6 +315,8 @@ github.com/microsoft/kiota-serialization-multipart-go v1.0.0 h1:3O5sb5Zj+moLBiJy
 github.com/microsoft/kiota-serialization-multipart-go v1.0.0/go.mod h1:yauLeBTpANk4L03XD985akNysG24SnRJGaveZf+p4so=
 github.com/microsoft/kiota-serialization-text-go v1.0.0 h1:XOaRhAXy+g8ZVpcq7x7a0jlETWnWrEum0RhmbYrTFnA=
 github.com/microsoft/kiota-serialization-text-go v1.0.0/go.mod h1:sM1/C6ecnQ7IquQOGUrUldaO5wj+9+v7G2W3sQ3fy6M=
+github.com/microsoftgraph/msgraph-beta-sdk-go v0.111.0 h1:IhaMYOdiN76xwkYGVAb7QwkOkjSZTrBMwv+5xCpf2sY=
+github.com/microsoftgraph/msgraph-beta-sdk-go v0.111.0/go.mod h1:GJhFAbcwHwtiqspxJnurVNr6XZBfVtdccVEC1+6+vjo=
 github.com/microsoftgraph/msgraph-sdk-go v1.51.0 h1:IfRY0uVHToT8X9k6Ri19tKdt8hwPomji2yx5YsKoaw4=
 github.com/microsoftgraph/msgraph-sdk-go v1.51.0/go.mod h1:MVTeFCCih3qXy9D0q+f4NdOyumFnMZ+Ppcpurgd30TY=
 github.com/microsoftgraph/msgraph-sdk-go-core v1.2.1 h1:P1wpmn3xxfPMFJHg+PJPcusErfRkl63h6OdAnpDbkS8=

--- a/providers/ms365/resources/microsoft.go
+++ b/providers/ms365/resources/microsoft.go
@@ -9,10 +9,18 @@ import (
 
 var idxUsersById = &sync.RWMutex{}
 
+type mfaResp struct {
+	// holds the error if that is what the request returned
+	err    error
+	mfaMap map[string]bool
+}
+
 type mqlMicrosoftInternal struct {
 	permissionIndexer
 	// index users by id
 	idxUsersById map[string]*mqlMicrosoftUser
+	// the response when asking for the user registration details
+	mfaResp mfaResp
 }
 
 // initIndex ensures the user indexes are initialized,

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -122,6 +122,8 @@ private microsoft.user @defaults("id displayName userPrincipalName") {
   contact() dict
   // Authentication information
   authMethods() microsoft.user.authenticationMethods
+  // Whether MFA is enabled for the user.
+  mfaEnabled() bool
 }
 
 // Microsoft Entra authentication methods

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -381,6 +381,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.user.authMethods": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftUser).GetAuthMethods()).ToDataRes(types.Resource("microsoft.user.authenticationMethods"))
 	},
+	"microsoft.user.mfaEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftUser).GetMfaEnabled()).ToDataRes(types.Bool)
+	},
 	"microsoft.user.authenticationMethods.count": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftUserAuthenticationMethods).GetCount()).ToDataRes(types.Int)
 	},
@@ -1375,6 +1378,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"microsoft.user.authMethods": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftUser).AuthMethods, ok = plugin.RawToTValue[*mqlMicrosoftUserAuthenticationMethods](v.Value, v.Error)
+		return
+	},
+	"microsoft.user.mfaEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftUser).MfaEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"microsoft.user.authenticationMethods.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2978,6 +2985,7 @@ type mqlMicrosoftUser struct {
 	Job plugin.TValue[interface{}]
 	Contact plugin.TValue[interface{}]
 	AuthMethods plugin.TValue[*mqlMicrosoftUserAuthenticationMethods]
+	MfaEnabled plugin.TValue[bool]
 }
 
 // createMicrosoftUser creates a new instance of this resource
@@ -3127,6 +3135,12 @@ func (c *mqlMicrosoftUser) GetAuthMethods() *plugin.TValue[*mqlMicrosoftUserAuth
 		}
 
 		return c.authMethods()
+	})
+}
+
+func (c *mqlMicrosoftUser) GetMfaEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.MfaEnabled, func() (bool, error) {
+		return c.mfaEnabled()
 	})
 }
 

--- a/providers/ms365/resources/ms365.lr.manifest.yaml
+++ b/providers/ms365/resources/ms365.lr.manifest.yaml
@@ -433,6 +433,8 @@ resources:
         min_mondoo_version: 9.0.0
       jobTitle: {}
       mail: {}
+      mfaEnabled:
+        min_mondoo_version: 9.0.0
       mobilePhone: {}
       officeLocation: {}
       otherMails: {}


### PR DESCRIPTION
Uses the beta-available only API for listing user details: https://learn.microsoft.com/en-us/graph/api/authenticationmethodsroot-list-userregistrationdetails?view=graph-rest-1.0&tabs=http


This API is only available for P1/P2 licenses. When running the query against a tenant that doesn't have that license:
```
 4: {
    mfaEnabled: Neither tenant is B2C or tenant doesn't have premium license
    displayName: "Chris Test"
  }
```

When running against a properly licensed tenant:
```
 30: {
    mfaEnabled: true
    displayName: "Preslav Gerchev"
  }
```

The code ensures that we can still grab users, even if the user registration details API call fails.
  
  