### PR TITLE
✨ Support searching /dev/disk/by-id aliases.

### DIFF
--- a/providers/gcp/connection/gcpinstancesnapshot/provider.go
+++ b/providers/gcp/connection/gcpinstancesnapshot/provider.go
@@ -116,7 +116,7 @@ func NewGcpSnapshotConnection(id uint32, conf *inventory.Config, asset *inventor
 	// setup disk image so and attach it to the instance
 	var diskUrl string
 	mi := mountInfo{
-		deviceName: "/dev/sdh",
+		deviceName: "cnspec",
 	}
 	switch target.TargetType {
 	case "instance":


### PR DESCRIPTION
This fixes the GCP snapshot scanning. In GCP devices are aliased under `/dev/disk-by-id/<device-name>`. This PR builds on top of the already supported alias finding by looking into that directory as well