### PR TITLE
🔨 new `logger.FuncDur()` + no cache expiration

### DIFF
--- a/explorer/scan/discovery.go
+++ b/explorer/scan/discovery.go
@@ -6,6 +6,7 @@ package scan
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/cli/config"
@@ -16,6 +17,7 @@ import (
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory/manager"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/upstream"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/tracer"
 )
 
 type AssetWithRuntime struct {
@@ -151,6 +153,8 @@ func DiscoverAssets(ctx context.Context, inv *inventory.Inventory, upstream *ups
 }
 
 func discoverAssets(rootAssetWithRuntime *AssetWithRuntime, resolvedRootAsset *inventory.Asset, discoveredAssets *DiscoveredAssets, runtimeLabels map[string]string, upstream *upstream.UpstreamConfig, recording llx.Recording) {
+	defer tracer.FuncDur(time.Now(), "explorer.discoverAssets")
+
 	// It is possible that we did not discover any assets under the root asset. In that case the inventory
 	// would be nil and we can return
 	if rootAssetWithRuntime.Runtime.Provider.Connection.Inventory == nil {

--- a/explorer/scan/discovery.go
+++ b/explorer/scan/discovery.go
@@ -12,12 +12,12 @@ import (
 	"go.mondoo.com/cnquery/v11/cli/config"
 	"go.mondoo.com/cnquery/v11/cli/execruntime"
 	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/logger"
 	"go.mondoo.com/cnquery/v11/providers"
 	inventory "go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory/manager"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/upstream"
-	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/tracer"
 )
 
 type AssetWithRuntime struct {
@@ -153,7 +153,7 @@ func DiscoverAssets(ctx context.Context, inv *inventory.Inventory, upstream *ups
 }
 
 func discoverAssets(rootAssetWithRuntime *AssetWithRuntime, resolvedRootAsset *inventory.Asset, discoveredAssets *DiscoveredAssets, runtimeLabels map[string]string, upstream *upstream.UpstreamConfig, recording llx.Recording) {
-	defer tracer.FuncDur(time.Now(), "explorer.discoverAssets")
+	defer logger.FuncDur(time.Now(), "explorer.discoverAssets")
 
 	// It is possible that we did not discover any assets under the root asset. In that case the inventory
 	// would be nil and we can return

--- a/llx/llx.go
+++ b/llx/llx.go
@@ -10,10 +10,12 @@ import (
 	"sort"
 	"strconv"
 	"sync"
+	"time"
 
 	uuid "github.com/gofrs/uuid"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/resources"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/tracer"
 	"go.mondoo.com/cnquery/v11/types"
 	"go.mondoo.com/cnquery/v11/utils/multierr"
 )
@@ -322,6 +324,8 @@ func (b *blockExecutor) mustLookup(ref uint64) *RawData {
 
 // run code with a runtime and return results
 func (b *blockExecutor) run() {
+	defer tracer.FuncDur(time.Now(), "llx.blockExecutor.run")
+
 	for ref, codeID := range b.callbackPoints {
 		if !b.isInMyBlock(ref) {
 			v := b.mustLookup(ref)

--- a/llx/llx.go
+++ b/llx/llx.go
@@ -14,8 +14,8 @@ import (
 
 	uuid "github.com/gofrs/uuid"
 	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/v11/logger"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/resources"
-	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/tracer"
 	"go.mondoo.com/cnquery/v11/types"
 	"go.mondoo.com/cnquery/v11/utils/multierr"
 )
@@ -324,7 +324,7 @@ func (b *blockExecutor) mustLookup(ref uint64) *RawData {
 
 // run code with a runtime and return results
 func (b *blockExecutor) run() {
-	defer tracer.FuncDur(time.Now(), "llx.blockExecutor.run")
+	defer logger.FuncDur(time.Now(), "llx.blockExecutor.run")
 
 	for ref, codeID := range b.callbackPoints {
 		if !b.isInMyBlock(ref) {

--- a/logger/tracer.go
+++ b/logger/tracer.go
@@ -1,7 +1,7 @@
 // Copyright (c) Mondoo, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package tracer
+package logger
 
 import (
 	"time"
@@ -10,12 +10,12 @@ import (
 )
 
 // FuncDur must be used in a `defer` statement. It receives the function name and the time
-// when a function started and logs out the time it took to run.
+// when the function started and logs out the time it took to execute.
 //
 // ```go
 //
 //	func MyFunction() {
-//		defer tracer.FuncDur(time.Now(), "mypackage.MyFunction")
+//		defer logger.FuncDur(time.Now(), "mypackage.MyFunction")
 //
 //		...
 //	}
@@ -24,5 +24,5 @@ import (
 func FuncDur(start time.Time, name string) {
 	log.Trace().Str("func", name).
 		TimeDiff("took", time.Now(), start).
-		Msgf("tracer.FuncDur>")
+		Msgf("logger.FuncDur>")
 }

--- a/providers-sdk/v1/util/tracer/func.go
+++ b/providers-sdk/v1/util/tracer/func.go
@@ -1,0 +1,28 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package tracer
+
+import (
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// FuncDur must be used in a `defer` statement. It receives the function name and the time
+// when a function started and logs out the time it took to run.
+//
+// ```go
+//
+//	func MyFunction() {
+//		defer tracer.FuncDur(time.Now(), "mypackage.MyFunction")
+//
+//		...
+//	}
+//
+// ```
+func FuncDur(start time.Time, name string) {
+	log.Trace().Str("func", name).
+		TimeDiff("took", time.Now(), start).
+		Msgf("tracer.FuncDur>")
+}

--- a/providers/github/provider/provider.go
+++ b/providers/github/provider/provider.go
@@ -11,10 +11,10 @@ import (
 	"time"
 
 	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/logger"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/upstream"
-	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/tracer"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/vault"
 	"go.mondoo.com/cnquery/v11/providers/github/connection"
 	"go.mondoo.com/cnquery/v11/providers/github/resources"
@@ -189,7 +189,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 }
 
 func (s *Service) detect(asset *inventory.Asset, conn *connection.GithubConnection) error {
-	defer tracer.FuncDur(time.Now(), "provider.github.service.detect")
+	defer logger.FuncDur(time.Now(), "provider.github.service.detect")
 
 	conf := asset.Connections[0]
 	asset.Name = conf.Host
@@ -215,7 +215,7 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.GithubConnecti
 }
 
 func (s *Service) discover(conn *connection.GithubConnection) (*inventory.Inventory, error) {
-	defer tracer.FuncDur(time.Now(), "provider.github.service.discover")
+	defer logger.FuncDur(time.Now(), "provider.github.service.discover")
 
 	conf := conn.Asset().Connections[0]
 	if conf.Discover == nil {

--- a/providers/github/provider/provider.go
+++ b/providers/github/provider/provider.go
@@ -8,11 +8,13 @@ import (
 	"errors"
 	"os"
 	"strings"
+	"time"
 
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/upstream"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/tracer"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/vault"
 	"go.mondoo.com/cnquery/v11/providers/github/connection"
 	"go.mondoo.com/cnquery/v11/providers/github/resources"
@@ -187,6 +189,8 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 }
 
 func (s *Service) detect(asset *inventory.Asset, conn *connection.GithubConnection) error {
+	defer tracer.FuncDur(time.Now(), "provider.github.service.detect")
+
 	conf := asset.Connections[0]
 	asset.Name = conf.Host
 
@@ -211,6 +215,8 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.GithubConnecti
 }
 
 func (s *Service) discover(conn *connection.GithubConnection) (*inventory.Inventory, error) {
+	defer tracer.FuncDur(time.Now(), "provider.github.service.discover")
+
 	conf := conn.Asset().Connections[0]
 	if conf.Discover == nil {
 		return nil, nil

--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -12,9 +12,9 @@ import (
 	"github.com/google/go-github/v62/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/logger"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
-	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/tracer"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/vault"
 	"go.mondoo.com/cnquery/v11/providers/github/connection"
 	"go.mondoo.com/cnquery/v11/utils/stringx"
@@ -51,7 +51,7 @@ func handleTargets(targets []string) []string {
 }
 
 func discover(runtime *plugin.Runtime, targets []string) ([]*inventory.Asset, error) {
-	defer tracer.FuncDur(time.Now(), "provider.github.discover")
+	defer logger.FuncDur(time.Now(), "provider.github.discover")
 
 	conn := runtime.Connection.(*connection.GithubConnection)
 	conf := conn.Asset().Connections[0]

--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/gobwas/glob"
 	"github.com/google/go-github/v62/github"
@@ -13,6 +14,7 @@ import (
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/tracer"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/vault"
 	"go.mondoo.com/cnquery/v11/providers/github/connection"
 	"go.mondoo.com/cnquery/v11/utils/stringx"
@@ -49,6 +51,8 @@ func handleTargets(targets []string) []string {
 }
 
 func discover(runtime *plugin.Runtime, targets []string) ([]*inventory.Asset, error) {
+	defer tracer.FuncDur(time.Now(), "provider.github.discover")
+
 	conn := runtime.Connection.(*connection.GithubConnection)
 	conf := conn.Asset().Connections[0]
 	assetList := []*inventory.Asset{}

--- a/providers/github/resources/github.go
+++ b/providers/github/resources/github.go
@@ -29,7 +29,7 @@ func getUser(ctx context.Context, runtime *plugin.Runtime, conn *connection.Gith
 	}
 	g := obj.(*mqlGithub)
 	if g.memoize == nil {
-		g.memoize = memoize.NewMemoizer(30*time.Minute, 1*time.Hour)
+		g.memoize = memoize.NewMemoizer(0, 0)
 	}
 	res, err, _ := g.memoize.Memoize("user-"+user, func() (interface{}, error) {
 		log.Debug().Msgf("fetching user %s", user)
@@ -49,7 +49,7 @@ func getOrg(ctx context.Context, runtime *plugin.Runtime, conn *connection.Githu
 	}
 	g := obj.(*mqlGithub)
 	if g.memoize == nil {
-		g.memoize = memoize.NewMemoizer(30*time.Minute, 1*time.Hour)
+		g.memoize = memoize.NewMemoizer(0, 0)
 	}
 	res, err, _ := g.memoize.Memoize("org-"+name, func() (interface{}, error) {
 		log.Debug().Msgf("fetching organization %s", name)

--- a/providers/github/resources/github.go
+++ b/providers/github/resources/github.go
@@ -23,8 +23,8 @@ type mqlGithubInternal struct {
 }
 
 var (
-	cacheExpirationTime = 2 * time.Hour
-	cacheCleanupTime    = 4 * time.Hour
+	cacheExpirationTime = 24 * time.Hour
+	cacheCleanupTime    = 48 * time.Hour
 )
 
 func getUser(ctx context.Context, runtime *plugin.Runtime, conn *connection.GithubConnection, user string) (*github.User, error) {

--- a/providers/github/resources/github.go
+++ b/providers/github/resources/github.go
@@ -22,6 +22,11 @@ type mqlGithubInternal struct {
 	memoize *memoize.Memoizer
 }
 
+var (
+	cacheExpirationTime = 2 * time.Hour
+	cacheCleanupTime    = 4 * time.Hour
+)
+
 func getUser(ctx context.Context, runtime *plugin.Runtime, conn *connection.GithubConnection, user string) (*github.User, error) {
 	obj, err := CreateResource(runtime, "github", map[string]*llx.RawData{})
 	if err != nil {
@@ -29,8 +34,9 @@ func getUser(ctx context.Context, runtime *plugin.Runtime, conn *connection.Gith
 	}
 	g := obj.(*mqlGithub)
 	if g.memoize == nil {
-		g.memoize = memoize.NewMemoizer(0, 0)
+		g.memoize = memoize.NewMemoizer(cacheExpirationTime, cacheCleanupTime)
 	}
+
 	res, err, _ := g.memoize.Memoize("user-"+user, func() (interface{}, error) {
 		log.Debug().Msgf("fetching user %s", user)
 		user, _, err := conn.Client().Users.Get(ctx, user)
@@ -49,7 +55,7 @@ func getOrg(ctx context.Context, runtime *plugin.Runtime, conn *connection.Githu
 	}
 	g := obj.(*mqlGithub)
 	if g.memoize == nil {
-		g.memoize = memoize.NewMemoizer(0, 0)
+		g.memoize = memoize.NewMemoizer(cacheExpirationTime, cacheCleanupTime)
 	}
 	res, err, _ := g.memoize.Memoize("org-"+name, func() (interface{}, error) {
 		log.Debug().Msgf("fetching organization %s", name)

--- a/providers/github/resources/github_org.go
+++ b/providers/github/resources/github_org.go
@@ -7,11 +7,13 @@ import (
 	"errors"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/go-github/v62/github"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/convert"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/tracer"
 	"go.mondoo.com/cnquery/v11/providers/github/connection"
 	"go.mondoo.com/cnquery/v11/types"
 )
@@ -31,6 +33,7 @@ func initGithubOrganization(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	if len(args) > 2 {
 		return args, nil, nil
 	}
+	defer tracer.FuncDur(time.Now(), "provider.github.initGithubOrganization")
 
 	conn := runtime.Connection.(*connection.GithubConnection)
 
@@ -251,6 +254,8 @@ func (g *mqlGithubOrganization) teams() ([]interface{}, error) {
 }
 
 func (g *mqlGithubOrganization) repositories() ([]interface{}, error) {
+	defer tracer.FuncDur(time.Now(), "provider.github.repositories")
+
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 
 	if g.Login.Error != nil {
@@ -299,6 +304,8 @@ func (g *mqlGithubOrganization) repositories() ([]interface{}, error) {
 }
 
 func (g *mqlGithubOrganization) webhooks() ([]interface{}, error) {
+	defer tracer.FuncDur(time.Now(), "provider.github.webhooks")
+
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 
 	if g.Login.Error != nil {

--- a/providers/github/resources/github_org.go
+++ b/providers/github/resources/github_org.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/google/go-github/v62/github"
 	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/logger"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/convert"
-	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/tracer"
 	"go.mondoo.com/cnquery/v11/providers/github/connection"
 	"go.mondoo.com/cnquery/v11/types"
 )
@@ -33,7 +33,7 @@ func initGithubOrganization(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	defer tracer.FuncDur(time.Now(), "provider.github.initGithubOrganization")
+	defer logger.FuncDur(time.Now(), "provider.github.initGithubOrganization")
 
 	conn := runtime.Connection.(*connection.GithubConnection)
 
@@ -254,7 +254,7 @@ func (g *mqlGithubOrganization) teams() ([]interface{}, error) {
 }
 
 func (g *mqlGithubOrganization) repositories() ([]interface{}, error) {
-	defer tracer.FuncDur(time.Now(), "provider.github.repositories")
+	defer logger.FuncDur(time.Now(), "provider.github.repositories")
 
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 
@@ -304,7 +304,7 @@ func (g *mqlGithubOrganization) repositories() ([]interface{}, error) {
 }
 
 func (g *mqlGithubOrganization) webhooks() ([]interface{}, error) {
-	defer tracer.FuncDur(time.Now(), "provider.github.webhooks")
+	defer logger.FuncDur(time.Now(), "provider.github.webhooks")
 
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -15,9 +15,9 @@ import (
 	"github.com/google/go-github/v62/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/logger"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/convert"
-	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/tracer"
 	"go.mondoo.com/cnquery/v11/providers/github/connection"
 	"go.mondoo.com/cnquery/v11/types"
 )
@@ -134,7 +134,7 @@ func initGithubRepository(runtime *plugin.Runtime, args map[string]*llx.RawData)
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	defer tracer.FuncDur(time.Now(), "provider.github.initGithubRepository")
+	defer logger.FuncDur(time.Now(), "provider.github.initGithubRepository")
 
 	conn := runtime.Connection.(*connection.GithubConnection)
 

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -10,12 +10,14 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/go-github/v62/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/convert"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/tracer"
 	"go.mondoo.com/cnquery/v11/providers/github/connection"
 	"go.mondoo.com/cnquery/v11/types"
 )
@@ -132,6 +134,8 @@ func initGithubRepository(runtime *plugin.Runtime, args map[string]*llx.RawData)
 	if len(args) > 2 {
 		return args, nil, nil
 	}
+	defer tracer.FuncDur(time.Now(), "provider.github.initGithubRepository")
+
 	conn := runtime.Connection.(*connection.GithubConnection)
 
 	// determine the owner object

--- a/providers/github/resources/github_user.go
+++ b/providers/github/resources/github_user.go
@@ -12,8 +12,8 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/google/go-github/v62/github"
 	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/logger"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
-	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/tracer"
 	"go.mondoo.com/cnquery/v11/providers/github/connection"
 	"go.mondoo.com/cnquery/v11/types"
 	"go.mondoo.com/cnquery/v11/utils/stringx"
@@ -37,7 +37,7 @@ func initGithubUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 		return args, nil, nil
 	}
 
-	defer tracer.FuncDur(time.Now(), "provider.github.initGithubUser")
+	defer logger.FuncDur(time.Now(), "provider.github.initGithubUser")
 	conn := runtime.Connection.(*connection.GithubConnection)
 
 	userLogin := ""

--- a/providers/github/resources/github_user.go
+++ b/providers/github/resources/github_user.go
@@ -7,11 +7,13 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/google/go-github/v62/github"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/tracer"
 	"go.mondoo.com/cnquery/v11/providers/github/connection"
 	"go.mondoo.com/cnquery/v11/types"
 	"go.mondoo.com/cnquery/v11/utils/stringx"
@@ -35,6 +37,7 @@ func initGithubUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 		return args, nil, nil
 	}
 
+	defer tracer.FuncDur(time.Now(), "provider.github.initGithubUser")
 	conn := runtime.Connection.(*connection.GithubConnection)
 
 	userLogin := ""


### PR DESCRIPTION
A couple of changes here:
    
**🧹 Do not expire the cache for github provider**

    We do not have a long running server where we need to clear our cache
    every once in a while, instead we execute a single scan and we expect it
    to finish (end execution) which ultimately clears the cache. For those
    long running executions, we want to persist the cache until we finish
    scanning.

    This change sets the github provider cache to No expiration.

**🔧 new `tracer.FuncDur()`**

    `FuncDur` must be used in a `defer` statement.

    This new helper function receives the function name and the time
    when a function started and logs out the time it took to run.

 ```go
package mypackage

func MyFunction() {
    defer tracer.FuncDur(time.Now(), "mypackage.MyFunction")

    ...
}
 ```

Signed-off-by: Salim Afiune Maya <afiune@mondoo.com>