### PR TITLE
🔨 new `logger.FuncDur()`

### DIFF
--- a/explorer/scan/discovery.go
+++ b/explorer/scan/discovery.go
@@ -6,11 +6,13 @@ package scan
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/cli/config"
 	"go.mondoo.com/cnquery/v11/cli/execruntime"
 	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/logger"
 	"go.mondoo.com/cnquery/v11/providers"
 	inventory "go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory/manager"
@@ -151,6 +153,8 @@ func DiscoverAssets(ctx context.Context, inv *inventory.Inventory, upstream *ups
 }
 
 func discoverAssets(rootAssetWithRuntime *AssetWithRuntime, resolvedRootAsset *inventory.Asset, discoveredAssets *DiscoveredAssets, runtimeLabels map[string]string, upstream *upstream.UpstreamConfig, recording llx.Recording) {
+	defer logger.FuncDur(time.Now(), "explorer.discoverAssets")
+
 	// It is possible that we did not discover any assets under the root asset. In that case the inventory
 	// would be nil and we can return
 	if rootAssetWithRuntime.Runtime.Provider.Connection.Inventory == nil {

--- a/llx/llx.go
+++ b/llx/llx.go
@@ -10,9 +10,11 @@ import (
 	"sort"
 	"strconv"
 	"sync"
+	"time"
 
 	uuid "github.com/gofrs/uuid"
 	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/v11/logger"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/resources"
 	"go.mondoo.com/cnquery/v11/types"
 	"go.mondoo.com/cnquery/v11/utils/multierr"
@@ -322,6 +324,8 @@ func (b *blockExecutor) mustLookup(ref uint64) *RawData {
 
 // run code with a runtime and return results
 func (b *blockExecutor) run() {
+	defer logger.FuncDur(time.Now(), "llx.blockExecutor.run")
+
 	for ref, codeID := range b.callbackPoints {
 		if !b.isInMyBlock(ref) {
 			v := b.mustLookup(ref)

--- a/logger/tracer.go
+++ b/logger/tracer.go
@@ -1,0 +1,28 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package logger
+
+import (
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// FuncDur must be used in a `defer` statement. It receives the function name and the time
+// when the function started and logs out the time it took to execute.
+//
+// ```go
+//
+//	func MyFunction() {
+//		defer logger.FuncDur(time.Now(), "mypackage.MyFunction")
+//
+//		...
+//	}
+//
+// ```
+func FuncDur(start time.Time, name string) {
+	log.Trace().Str("func", name).
+		TimeDiff("took", time.Now(), start).
+		Msgf("logger.FuncDur>")
+}

--- a/providers/github/provider/provider.go
+++ b/providers/github/provider/provider.go
@@ -8,8 +8,10 @@ import (
 	"errors"
 	"os"
 	"strings"
+	"time"
 
 	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/logger"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/upstream"
@@ -187,6 +189,8 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 }
 
 func (s *Service) detect(asset *inventory.Asset, conn *connection.GithubConnection) error {
+	defer logger.FuncDur(time.Now(), "provider.github.service.detect")
+
 	conf := asset.Connections[0]
 	asset.Name = conf.Host
 
@@ -211,6 +215,8 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.GithubConnecti
 }
 
 func (s *Service) discover(conn *connection.GithubConnection) (*inventory.Inventory, error) {
+	defer logger.FuncDur(time.Now(), "provider.github.service.discover")
+
 	conf := conn.Asset().Connections[0]
 	if conf.Discover == nil {
 		return nil, nil

--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -6,11 +6,13 @@ package resources
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/gobwas/glob"
 	"github.com/google/go-github/v62/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/logger"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/vault"
@@ -49,6 +51,8 @@ func handleTargets(targets []string) []string {
 }
 
 func discover(runtime *plugin.Runtime, targets []string) ([]*inventory.Asset, error) {
+	defer logger.FuncDur(time.Now(), "provider.github.discover")
+
 	conn := runtime.Connection.(*connection.GithubConnection)
 	conf := conn.Asset().Connections[0]
 	assetList := []*inventory.Asset{}

--- a/providers/github/resources/github_org.go
+++ b/providers/github/resources/github_org.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/go-github/v62/github"
 	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/logger"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/convert"
 	"go.mondoo.com/cnquery/v11/providers/github/connection"
@@ -31,6 +33,7 @@ func initGithubOrganization(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	if len(args) > 2 {
 		return args, nil, nil
 	}
+	defer logger.FuncDur(time.Now(), "provider.github.initGithubOrganization")
 
 	conn := runtime.Connection.(*connection.GithubConnection)
 
@@ -251,6 +254,8 @@ func (g *mqlGithubOrganization) teams() ([]interface{}, error) {
 }
 
 func (g *mqlGithubOrganization) repositories() ([]interface{}, error) {
+	defer logger.FuncDur(time.Now(), "provider.github.repositories")
+
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 
 	if g.Login.Error != nil {
@@ -299,6 +304,8 @@ func (g *mqlGithubOrganization) repositories() ([]interface{}, error) {
 }
 
 func (g *mqlGithubOrganization) webhooks() ([]interface{}, error) {
+	defer logger.FuncDur(time.Now(), "provider.github.webhooks")
+
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 
 	if g.Login.Error != nil {

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -10,10 +10,12 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/go-github/v62/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/logger"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/convert"
 	"go.mondoo.com/cnquery/v11/providers/github/connection"
@@ -132,6 +134,8 @@ func initGithubRepository(runtime *plugin.Runtime, args map[string]*llx.RawData)
 	if len(args) > 2 {
 		return args, nil, nil
 	}
+	defer logger.FuncDur(time.Now(), "provider.github.initGithubRepository")
+
 	conn := runtime.Connection.(*connection.GithubConnection)
 
 	// determine the owner object

--- a/providers/github/resources/github_user.go
+++ b/providers/github/resources/github_user.go
@@ -7,10 +7,12 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/google/go-github/v62/github"
 	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/logger"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers/github/connection"
 	"go.mondoo.com/cnquery/v11/types"
@@ -35,6 +37,7 @@ func initGithubUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 		return args, nil, nil
 	}
 
+	defer logger.FuncDur(time.Now(), "provider.github.initGithubUser")
 	conn := runtime.Connection.(*connection.GithubConnection)
 
 	userLogin := ""


### PR DESCRIPTION
`FuncDur` must be used in a `defer` statement.

This new helper function receives the function name and the time when the
function started and logs out the time it took to run.

Example:
```go
package mypackage

func MyFunction() {
   defer logger.FuncDur(time.Now(), "mypackage.MyFunction")

   ...
}
```