### PR TITLE
✨ fstab parser

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -75,6 +75,7 @@ ratebasedstatement
 regexmatchstatement
 regexpatternsetreferencestatement
 resourcegroup
+rootfs
 rulegroup
 rulegroupreferencestatement
 Sas

--- a/providers/os/resources/fstab.go
+++ b/providers/os/resources/fstab.go
@@ -15,7 +15,13 @@ import (
 
 func (f *mqlFstab) entries() ([]any, error) {
 	conn := f.MqlRuntime.Connection.(shared.Connection)
-	fstabFile, err := conn.FileSystem().Open("/etc/fstab")
+
+	fs := conn.FileSystem()
+	if fs == nil {
+		return nil, errors.New("filesystem not available")
+	}
+
+	fstabFile, err := fs.Open("/etc/fstab")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/os/resources/fstab.go
+++ b/providers/os/resources/fstab.go
@@ -36,7 +36,10 @@ func initFstab(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[strin
 }
 
 func (f *mqlFstab) entries() ([]any, error) {
-	conn := f.MqlRuntime.Connection.(shared.Connection)
+	conn, ok := f.MqlRuntime.Connection.(shared.Connection)
+	if !ok {
+		return nil, errors.New("wrong connection type")
+	}
 
 	fs := conn.FileSystem()
 	if fs == nil {

--- a/providers/os/resources/fstab.go
+++ b/providers/os/resources/fstab.go
@@ -1,0 +1,109 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+package resources
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"strconv"
+	"strings"
+
+	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/providers/os/connection/shared"
+)
+
+func (f *mqlFstab) entries() ([]any, error) {
+	conn := f.MqlRuntime.Connection.(shared.Connection)
+	fstabFile, err := conn.FileSystem().Open("/etc/fstab")
+	if err != nil {
+		return nil, err
+	}
+	defer fstabFile.Close()
+
+	entries, err := ParseFstab(fstabFile)
+	if err != nil {
+		return nil, err
+	}
+
+	resources := []any{}
+	for _, entry := range entries {
+		resource, err := CreateResource(f.MqlRuntime, "fstab.entry", map[string]*llx.RawData{
+			"device":     llx.StringData(entry.Device),
+			"mountpoint": llx.StringData(entry.Mountpoint),
+			"fstype":     llx.StringData(entry.Fstype),
+			"options":    llx.StringData(entry.Options),
+			"dump":       llx.IntDataPtr(entry.Dump),
+			"fsck":       llx.IntDataPtr(entry.Fsck),
+		})
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, resource)
+	}
+
+	return resources, nil
+}
+
+type FstabEntry struct {
+	Device     string
+	Mountpoint string
+	Fstype     string
+	Options    string
+	Dump       *int
+	Fsck       *int
+}
+
+func ParseFstab(file io.Reader) ([]FstabEntry, error) {
+	scanner := bufio.NewScanner(file)
+	scanner.Split(bufio.ScanLines)
+
+	var entries []FstabEntry
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Skip comments and empty lines
+		if line == "" || line[0] == '#' {
+			continue
+		}
+
+		record := strings.Fields(line)
+		if len(record) < 4 {
+			return nil, errors.New("invalid fstab entry")
+		}
+
+		var dump *int
+		if len(record) >= 5 {
+			_dump, err := strconv.Atoi(record[4])
+			if err != nil {
+				return nil, err
+			}
+			dump = &_dump
+		}
+
+		var fsck *int
+		if len(record) >= 6 {
+			_fsck, err := strconv.Atoi(record[5])
+			if err != nil {
+				return nil, err
+			}
+			fsck = &_fsck
+		}
+
+		entry := FstabEntry{
+			Device:     record[0],
+			Mountpoint: record[1],
+			Fstype:     record[2],
+			Options:    record[3],
+			Dump:       dump,
+			Fsck:       fsck,
+		}
+
+		entries = append(entries, entry)
+	}
+
+	return entries, nil
+}
+
+func (e *mqlFstabEntry) id() (string, error) {
+	return e.Device.Data, nil
+}

--- a/providers/os/resources/fstab_test.go
+++ b/providers/os/resources/fstab_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+package resources
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+)
+
+func TestFstabEntries(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		testdata := `# <device>                                <dir> <type> <options> <dump> <fsck>
+UUID=0a3407de-014b-458b-b5c1-848e92a327a3 /     ext4   defaults  0      1
+UUID=f9fe0b69-a280-415d-a03a-a32752370dee none  swap   defaults  0      0
+UUID=b411dc99-f0a0-4c87-9e05-184977be8539 /home ext4   defaults  0      2`
+
+		reader := strings.NewReader(testdata)
+		entries, err := ParseFstab(reader)
+
+		require.NoError(t, err)
+		require.Len(t, entries, 3)
+
+		require.Equal(t, FstabEntry{
+			Device:     "UUID=0a3407de-014b-458b-b5c1-848e92a327a3",
+			Mountpoint: "/",
+			Fstype:     "ext4",
+			Options:    "defaults",
+			Dump:       ptr.To(0),
+			Fsck:       ptr.To(1),
+		}, entries[0])
+		require.Equal(t, FstabEntry{
+			Device:     "UUID=f9fe0b69-a280-415d-a03a-a32752370dee",
+			Mountpoint: "none",
+			Fstype:     "swap",
+			Options:    "defaults",
+			Dump:       ptr.To(0),
+			Fsck:       ptr.To(0),
+		}, entries[1])
+		require.Equal(t, FstabEntry{
+			Device:     "UUID=b411dc99-f0a0-4c87-9e05-184977be8539",
+			Mountpoint: "/home",
+			Fstype:     "ext4",
+			Options:    "defaults",
+			Dump:       ptr.To(0),
+			Fsck:       ptr.To(2),
+		}, entries[2])
+	})
+
+	t.Run("short", func(t *testing.T) {
+		testdata := `# <device>                                <dir> <type> <options>
+UUID=0a3407de-014b-458b-b5c1-848e92a327a3 /     ext4   defaults
+UUID=f9fe0b69-a280-415d-a03a-a32752370dee none  swap   defaults
+UUID=b411dc99-f0a0-4c87-9e05-184977be8539 /home ext4   defaults`
+
+		reader := strings.NewReader(testdata)
+		entries, err := ParseFstab(reader)
+
+		require.NoError(t, err)
+		require.Len(t, entries, 3)
+
+		require.Equal(t, FstabEntry{
+			Device:     "UUID=0a3407de-014b-458b-b5c1-848e92a327a3",
+			Mountpoint: "/",
+			Fstype:     "ext4",
+			Options:    "defaults",
+		}, entries[0])
+		require.Equal(t, FstabEntry{
+			Device:     "UUID=f9fe0b69-a280-415d-a03a-a32752370dee",
+			Mountpoint: "none",
+			Fstype:     "swap",
+			Options:    "defaults",
+		}, entries[1])
+		require.Equal(t, FstabEntry{
+			Device:     "UUID=b411dc99-f0a0-4c87-9e05-184977be8539",
+			Mountpoint: "/home",
+			Fstype:     "ext4",
+			Options:    "defaults",
+		}, entries[2])
+	})
+
+	t.Run("valid (with tabs)", func(t *testing.T) {
+		testdata := `# <device>                                <dir> <type> <options> <dump> <fsck>
+LABEL=cloudimg-rootfs	/	 ext4	discard,commit=30,errors=remount-ro	0 1
+LABEL=BOOT	/boot	ext4	defaults	0 2
+LABEL=UEFI	/boot/efi	vfat	umask=0077	0 1`
+
+		reader := strings.NewReader(testdata)
+		entries, err := ParseFstab(reader)
+
+		require.NoError(t, err)
+		require.Len(t, entries, 3)
+
+		require.Equal(t, FstabEntry{
+			Device:     "LABEL=cloudimg-rootfs",
+			Mountpoint: "/",
+			Fstype:     "ext4",
+			Options:    "discard,commit=30,errors=remount-ro",
+			Dump:       ptr.To(0),
+			Fsck:       ptr.To(1),
+		}, entries[0])
+		require.Equal(t, FstabEntry{
+			Device:     "LABEL=BOOT",
+			Mountpoint: "/boot",
+			Fstype:     "ext4",
+			Options:    "defaults",
+			Dump:       ptr.To(0),
+			Fsck:       ptr.To(2),
+		}, entries[1])
+		require.Equal(t, FstabEntry{
+			Device:     "LABEL=UEFI",
+			Mountpoint: "/boot/efi",
+			Fstype:     "vfat",
+			Options:    "umask=0077",
+			Dump:       ptr.To(0),
+			Fsck:       ptr.To(1),
+		}, entries[2])
+	})
+
+	t.Run("invalid (too short)", func(t *testing.T) {
+		testdata := `# <device>                                <dir> <type>
+UUID=0a3407de-014b-458b-b5c1-848e92a327a3 /     ext4
+UUID=f9fe0b69-a280-415d-a03a-a32752370dee none  swap
+UUID=b411dc99-f0a0-4c87-9e05-184977be8539 /home ext4`
+
+		reader := strings.NewReader(testdata)
+		entries, err := ParseFstab(reader)
+
+		require.Error(t, err)
+		require.Nil(t, entries)
+	})
+
+	t.Run("invalid (not numeric dump)", func(t *testing.T) {
+		testdata := `# <device>                                <dir> <type> <options> <dump> <fsck>
+UUID=0a3407de-014b-458b-b5c1-848e92a327a3 /     ext4   defaults  0      1
+UUID=f9fe0b69-a280-415d-a03a-a32752370dee none  swap   defaults  0      0
+UUID=b411dc99-f0a0-4c87-9e05-184977be8539 /home ext4   defaults  A      2` // note the 'A' here
+
+		reader := strings.NewReader(testdata)
+		entries, err := ParseFstab(reader)
+
+		require.Error(t, err)
+		require.Nil(t, entries)
+	})
+
+	t.Run("invalid (not numeric fsck)", func(t *testing.T) {
+		testdata := `# <device>                                <dir> <type> <options> <dump> <fsck>
+UUID=0a3407de-014b-458b-b5c1-848e92a327a3 /     ext4   defaults  0      1
+UUID=f9fe0b69-a280-415d-a03a-a32752370dee none  swap   defaults  0      0
+UUID=b411dc99-f0a0-4c87-9e05-184977be8539 /home ext4   defaults  0      A` // note the 'A' here
+
+		reader := strings.NewReader(testdata)
+		entries, err := ParseFstab(reader)
+
+		require.Error(t, err)
+		require.Nil(t, entries)
+	})
+}

--- a/providers/os/resources/os.go
+++ b/providers/os/resources/os.go
@@ -680,3 +680,11 @@ func (s *mqlOsLinux) ip6tables() (*mqlIp6tables, error) {
 	}
 	return res.(*mqlIp6tables), nil
 }
+
+func (s *mqlOsLinux) fstab() (*mqlFstab, error) {
+	res, err := CreateResource(s.MqlRuntime, "fstab", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlFstab), nil
+}

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -945,7 +945,7 @@ private fstab.entry @defaults("device mountpoint") {
   mountpoint string
   // File system type, e.g., ext4
   fstype string
-  // Mount options, e.g., defaults
+  // Mount options, e.g., defaults (`man fstab` for details)
   options string
   // Dump frequency (0 for full backup or an integer above 0, incremental backup, copies all files new or modified since the last dump of a lower level)
   dump int

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -939,17 +939,17 @@ fstab @defaults("path") {
 }
 
 private fstab.entry @defaults("device mountpoint") {
-  // Device referenced in the fstab, e.g. LABEL=rootfs
+  // Device referenced in the fstab, e.g., LABEL=rootfs
   device string
-  // Mountpoint, e.g. '/'
+  // Mount point, e.g., '/'
   mountpoint string
-  // Filesystem type, e.g. ext4
+  // File system type, e.g., ext4
   fstype string
-  // Mount options, e.g. defaults
+  // Mount options, e.g., defaults
   options string
   // Dump frequency, e.g. 0
   dump int
-  // Filesystem check order, e.g. 1
+  // File system check order, e.g., 1
   fsck int
 }
 

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -310,6 +310,8 @@ os.linux {
   iptables() iptables
   // iptables firewall for IPv6
   ip6tables() ip6tables
+  // /etc/fstab entries
+  fstab() fstab
 }
 
 // Operating system root certificates
@@ -927,6 +929,25 @@ iptables.entry {
   options string
   // Input or output, which is used to create the ID
   chain string
+}
+
+fstab {
+  entries() []fstab.entry
+}
+
+private fstab.entry @defaults("device mountpoint") {
+  // Device referenced in the fstab, e.g. LABEL=rootfs
+  device string
+  // Mountpoint, e.g. '/'
+  mountpoint string
+  // Filesystem type, e.g. ext4
+  fstype string
+  // Mount options, e.g. defaults
+  options string
+  // Dump frequency, e.g. 0
+  dump int
+  // Filesystem check order, e.g. 1
+  fsck int
 }
 
 // Process on this system

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -947,7 +947,7 @@ private fstab.entry @defaults("device mountpoint") {
   fstype string
   // Mount options, e.g., defaults
   options string
-  // Dump frequency, e.g. 0
+  // Dump frequency (0 for full backup or an integer above 0, incremental backup, copies all files new or modified since the last dump of a lower level)
   dump int
   // File system check order, e.g., 1
   fsck int

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -931,7 +931,10 @@ iptables.entry {
   chain string
 }
 
-fstab {
+fstab @defaults("path") {
+  init(path? string)
+  path string
+
   entries() []fstab.entry
 }
 

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -298,6 +298,14 @@ func init() {
 			// to override args, implement: initIptablesEntry(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createIptablesEntry,
 		},
+		"fstab": {
+			// to override args, implement: initFstab(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createFstab,
+		},
+		"fstab.entry": {
+			// to override args, implement: initFstabEntry(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createFstabEntry,
+		},
 		"process": {
 			Init: initProcess,
 			Create: createProcess,
@@ -857,6 +865,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"os.linux.ip6tables": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOsLinux).GetIp6tables()).ToDataRes(types.Resource("ip6tables"))
+	},
+	"os.linux.fstab": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOsLinux).GetFstab()).ToDataRes(types.Resource("fstab"))
 	},
 	"os.rootCertificates.files": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOsRootCertificates).GetFiles()).ToDataRes(types.Array(types.Resource("file")))
@@ -1505,6 +1516,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"iptables.entry.chain": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlIptablesEntry).GetChain()).ToDataRes(types.String)
+	},
+	"fstab.entries": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlFstab).GetEntries()).ToDataRes(types.Array(types.Resource("fstab.entry")))
+	},
+	"fstab.entry.device": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlFstabEntry).GetDevice()).ToDataRes(types.String)
+	},
+	"fstab.entry.mountpoint": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlFstabEntry).GetMountpoint()).ToDataRes(types.String)
+	},
+	"fstab.entry.fstype": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlFstabEntry).GetFstype()).ToDataRes(types.String)
+	},
+	"fstab.entry.options": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlFstabEntry).GetOptions()).ToDataRes(types.String)
+	},
+	"fstab.entry.dump": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlFstabEntry).GetDump()).ToDataRes(types.Int)
+	},
+	"fstab.entry.fsck": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlFstabEntry).GetFsck()).ToDataRes(types.Int)
 	},
 	"process.pid": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProcess).GetPid()).ToDataRes(types.Int)
@@ -2807,6 +2839,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlOsLinux).Ip6tables, ok = plugin.RawToTValue[*mqlIp6tables](v.Value, v.Error)
 		return
 	},
+	"os.linux.fstab": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOsLinux).Fstab, ok = plugin.RawToTValue[*mqlFstab](v.Value, v.Error)
+		return
+	},
 	"os.rootCertificates.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 			r.(*mqlOsRootCertificates).__id, ok = v.Value.(string)
 			return
@@ -3853,6 +3889,42 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"iptables.entry.chain": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlIptablesEntry).Chain, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"fstab.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlFstab).__id, ok = v.Value.(string)
+			return
+		},
+	"fstab.entries": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlFstab).Entries, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"fstab.entry.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlFstabEntry).__id, ok = v.Value.(string)
+			return
+		},
+	"fstab.entry.device": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlFstabEntry).Device, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"fstab.entry.mountpoint": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlFstabEntry).Mountpoint, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"fstab.entry.fstype": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlFstabEntry).Fstype, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"fstab.entry.options": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlFstabEntry).Options, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"fstab.entry.dump": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlFstabEntry).Dump, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"fstab.entry.fsck": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlFstabEntry).Fsck, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"process.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6780,6 +6852,7 @@ type mqlOsLinux struct {
 	Unix plugin.TValue[*mqlOsUnix]
 	Iptables plugin.TValue[*mqlIptables]
 	Ip6tables plugin.TValue[*mqlIp6tables]
+	Fstab plugin.TValue[*mqlFstab]
 }
 
 // createOsLinux creates a new instance of this resource
@@ -6864,6 +6937,22 @@ func (c *mqlOsLinux) GetIp6tables() *plugin.TValue[*mqlIp6tables] {
 		}
 
 		return c.ip6tables()
+	})
+}
+
+func (c *mqlOsLinux) GetFstab() *plugin.TValue[*mqlFstab] {
+	return plugin.GetOrCompute[*mqlFstab](&c.Fstab, func() (*mqlFstab, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("os.linux", c.__id, "fstab")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlFstab), nil
+			}
+		}
+
+		return c.fstab()
 	})
 }
 
@@ -10594,6 +10683,136 @@ func (c *mqlIptablesEntry) GetOptions() *plugin.TValue[string] {
 
 func (c *mqlIptablesEntry) GetChain() *plugin.TValue[string] {
 	return &c.Chain
+}
+
+// mqlFstab for the fstab resource
+type mqlFstab struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlFstabInternal it will be used here
+	Entries plugin.TValue[[]interface{}]
+}
+
+// createFstab creates a new instance of this resource
+func createFstab(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlFstab{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("fstab", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlFstab) MqlName() string {
+	return "fstab"
+}
+
+func (c *mqlFstab) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlFstab) GetEntries() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.Entries, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("fstab", c.__id, "entries")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.entries()
+	})
+}
+
+// mqlFstabEntry for the fstab.entry resource
+type mqlFstabEntry struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlFstabEntryInternal it will be used here
+	Device plugin.TValue[string]
+	Mountpoint plugin.TValue[string]
+	Fstype plugin.TValue[string]
+	Options plugin.TValue[string]
+	Dump plugin.TValue[int64]
+	Fsck plugin.TValue[int64]
+}
+
+// createFstabEntry creates a new instance of this resource
+func createFstabEntry(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlFstabEntry{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+	res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("fstab.entry", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlFstabEntry) MqlName() string {
+	return "fstab.entry"
+}
+
+func (c *mqlFstabEntry) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlFstabEntry) GetDevice() *plugin.TValue[string] {
+	return &c.Device
+}
+
+func (c *mqlFstabEntry) GetMountpoint() *plugin.TValue[string] {
+	return &c.Mountpoint
+}
+
+func (c *mqlFstabEntry) GetFstype() *plugin.TValue[string] {
+	return &c.Fstype
+}
+
+func (c *mqlFstabEntry) GetOptions() *plugin.TValue[string] {
+	return &c.Options
+}
+
+func (c *mqlFstabEntry) GetDump() *plugin.TValue[int64] {
+	return &c.Dump
+}
+
+func (c *mqlFstabEntry) GetFsck() *plugin.TValue[int64] {
+	return &c.Fsck
 }
 
 // mqlProcess for the process resource

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -299,7 +299,7 @@ func init() {
 			Create: createIptablesEntry,
 		},
 		"fstab": {
-			// to override args, implement: initFstab(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init: initFstab,
 			Create: createFstab,
 		},
 		"fstab.entry": {
@@ -1516,6 +1516,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"iptables.entry.chain": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlIptablesEntry).GetChain()).ToDataRes(types.String)
+	},
+	"fstab.path": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlFstab).GetPath()).ToDataRes(types.String)
 	},
 	"fstab.entries": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlFstab).GetEntries()).ToDataRes(types.Array(types.Resource("fstab.entry")))
@@ -3895,6 +3898,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 			r.(*mqlFstab).__id, ok = v.Value.(string)
 			return
 		},
+	"fstab.path": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlFstab).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"fstab.entries": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlFstab).Entries, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
@@ -10690,6 +10697,7 @@ type mqlFstab struct {
 	MqlRuntime *plugin.Runtime
 	__id string
 	// optional: if you define mqlFstabInternal it will be used here
+	Path plugin.TValue[string]
 	Entries plugin.TValue[[]interface{}]
 }
 
@@ -10723,6 +10731,10 @@ func (c *mqlFstab) MqlName() string {
 
 func (c *mqlFstab) MqlID() string {
 	return c.__id
+}
+
+func (c *mqlFstab) GetPath() *plugin.TValue[string] {
+	return &c.Path
 }
 
 func (c *mqlFstab) GetEntries() *plugin.TValue[[]interface{}] {

--- a/providers/os/resources/os.lr.manifest.yaml
+++ b/providers/os/resources/os.lr.manifest.yaml
@@ -389,6 +389,7 @@ resources:
   fstab:
     fields:
       entries: {}
+      path: {}
     min_mondoo_version: 9.0.0
   fstab.entry:
     fields:

--- a/providers/os/resources/os.lr.manifest.yaml
+++ b/providers/os/resources/os.lr.manifest.yaml
@@ -386,6 +386,20 @@ resources:
       type: {}
       xdev: {}
     min_mondoo_version: 5.15.0
+  fstab:
+    fields:
+      entries: {}
+    min_mondoo_version: 9.0.0
+  fstab.entry:
+    fields:
+      device: {}
+      dump: {}
+      fsck: {}
+      fstype: {}
+      mountpoint: {}
+      options: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
   group:
     fields:
       gid: {}
@@ -673,6 +687,8 @@ resources:
     min_mondoo_version: 6.19.0
   os.linux:
     fields:
+      fstab:
+        min_mondoo_version: 9.0.0
       ip6tables: {}
       iptables: {}
       unix: {}


### PR DESCRIPTION
```
cnquery run -c "fstab.entries { * }"
fstab.entries: [
  0: {
    fsck: 1
    options: "defaults,noatime"
    device: "UUID=7c4e7e0e-ce36-42f9-b456-16f78f3a1eb1"
    fstype: "xfs"
    mountpoint: "/"
    dump: 1
  }
  1: {
    fsck: 2
    options: "defaults,noatime,uid=0,gid=0,umask=0077,shortname=winnt,x-systemd.automount"
    device: "UUID=C155-24D2"
    fstype: "vfat"
    mountpoint: "/boot/efi"
    dump: 0
  }
]
```

#### Device connection example
```
cnquery run device -c "fstab.entries { * }" --device-name sdby
fstab.entries: [
  0: {
    fsck: 1
    options: "discard,commit=30,errors=remount-ro"
    device: "LABEL=cloudimg-rootfs"
    fstype: "ext4"
    mountpoint: "/"
    dump: 0
  }
  1: {
    fsck: 2
    options: "defaults"
    device: "LABEL=BOOT"
    fstype: "ext4"
    mountpoint: "/boot"
    dump: 0
  }
  2: {
    fsck: 1
    options: "umask=0077"
    device: "LABEL=UEFI"
    fstype: "vfat"
    mountpoint: "/boot/efi"
    dump: 0
  }
]
```