### PR TITLE
🐛 Load provider flags from environment variables

### DIFF
--- a/test/providers/os_test.go
+++ b/test/providers/os_test.go
@@ -4,15 +4,16 @@
 package providers
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.mondoo.com/cnquery/v11/test"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/v11/test"
 )
 
 var once sync.Once
@@ -184,4 +185,44 @@ func TestOsProviderSharedTests(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestProvidersEnvVarsLoading(t *testing.T) {
+	t.Run("command WITHOUT path should not find any package", func(t *testing.T) {
+		r := test.NewCliTestRunner("./cnquery", "run", "fs", "-c", mqlPackagesQuery, "-j")
+		err := r.Run()
+		require.NoError(t, err)
+		assert.Equal(t, 0, r.ExitCode())
+		assert.NotNil(t, r.Stdout())
+		assert.NotNil(t, r.Stderr())
+
+		var c mqlPackages
+		err = r.Json(&c)
+		assert.NoError(t, err)
+
+		// No packages
+		assert.Empty(t, c)
+	})
+	t.Run("command WITH path should find packages", func(t *testing.T) {
+		os.Setenv("MONDOO_PATH", "./testdata/fs")
+		defer os.Unsetenv("MONDOO_PATH")
+		// Note we are not passing the flag "--path ./testdata/fs"
+		r := test.NewCliTestRunner("./cnquery", "run", "fs", "-c", mqlPackagesQuery, "-j")
+		err := r.Run()
+		require.NoError(t, err)
+		assert.Equal(t, 0, r.ExitCode())
+		assert.NotNil(t, r.Stdout())
+		assert.NotNil(t, r.Stderr())
+
+		var c mqlPackages
+		err = r.Json(&c)
+		assert.NoError(t, err)
+
+		// Should have packages
+		if assert.NotEmpty(t, c) {
+			x := c[0]
+			assert.NotNil(t, x.Packages)
+			assert.True(t, len(x.Packages) > 0)
+		}
+	})
 }


### PR DESCRIPTION
This change allows `cnquery` to load all provider flags via environment variables. For instance, if a provider exposes a flag named `foo`, the user can export the environment variable `MONDOO_FOO` to provide a value.

The trick here was to switch loading the flag values from `cobra` to `viper`, since we already ran `viper.BindPFlag()` inside the command `PreRun`, we can now use `viper.Get()` directly.