### PR TITLE
Expand fields for GitLab project

### DIFF
--- a/providers/gitlab/config/config.go
+++ b/providers/gitlab/config/config.go
@@ -53,7 +53,7 @@ var Config = plugin.Provider{
 					Long:    "url",
 					Type:    plugin.FlagType_String,
 					Default: "",
-					Desc:    "Custom GitLab base url",
+					Desc:    "Custom GitLab base URL (https://example.com/)",
 				},
 			},
 		},

--- a/providers/gitlab/resources/gitlab.go
+++ b/providers/gitlab/resources/gitlab.go
@@ -103,7 +103,6 @@ func getGitlabProjectArgs(prj *gitlab.Project) map[string]*llx.RawData {
 		"wikiEnabled":                               llx.BoolData(prj.WikiEnabled),
 		"jobsEnabled":                               llx.BoolData(prj.JobsEnabled),
 		"emptyRepo":                                 llx.BoolData(prj.EmptyRepo),
-		"license":                                   llx.StringData(prj.License.Name),
 		"sharedRunnersEnabled":                      llx.BoolData(prj.SharedRunnersEnabled),
 		"groupRunnersEnabled":                       llx.BoolData(prj.GroupRunnersEnabled),
 	}
@@ -295,7 +294,6 @@ func (p *mqlGitlabProject) projectMembers() ([]interface{}, error) {
 			"id":       llx.IntData(int64(member.ID)),
 			"username": llx.StringData(member.Username),
 			"state":    llx.StringData(member.State),
-			"email":    llx.StringData(member.Email),
 			"name":     llx.StringData(member.Name),
 			"role":     llx.StringData(role),
 		}

--- a/providers/gitlab/resources/gitlab.go
+++ b/providers/gitlab/resources/gitlab.go
@@ -101,6 +101,11 @@ func getGitlabProjectArgs(prj *gitlab.Project) map[string]*llx.RawData {
 		"visibility":                                llx.StringData(string(prj.Visibility)),
 		"webURL":                                    llx.StringData(prj.WebURL),
 		"wikiEnabled":                               llx.BoolData(prj.WikiEnabled),
+		"jobsEnabled":                               llx.BoolData(prj.JobsEnabled),
+		"emptyRepo":                                 llx.BoolData(prj.EmptyRepo),
+		"license":                                   llx.StringData(prj.License.Name),
+		"sharedRunnersEnabled":                      llx.BoolData(prj.SharedRunnersEnabled),
+		"groupRunnersEnabled":                       llx.BoolData(prj.GroupRunnersEnabled),
 	}
 }
 
@@ -141,6 +146,7 @@ func (p *mqlGitlabProject) approvalSettings() (*mqlGitlabProjectApprovalSetting,
 		"mergeRequestsAuthorApproval":               llx.BoolData(approvalConfig.MergeRequestsAuthorApproval),
 		"mergeRequestsDisableCommittersApproval":    llx.BoolData(approvalConfig.MergeRequestsDisableCommittersApproval),
 		"requirePasswordToApprove":                  llx.BoolData(approvalConfig.RequirePasswordToApprove),
+		"selectiveCodeOwnerRemovals":                llx.BoolData(approvalConfig.SelectiveCodeOwnerRemovals),
 	}
 
 	mqlApprovalSettings, err := CreateResource(p.MqlRuntime, "gitlab.project.approvalSetting", approvalSettings)
@@ -286,9 +292,12 @@ func (p *mqlGitlabProject) projectMembers() ([]interface{}, error) {
 	for _, member := range members {
 		role := mapAccessLevelToRole(int(member.AccessLevel))
 		memberInfo := map[string]*llx.RawData{
-			"id":   llx.IntData(int64(member.ID)),
-			"name": llx.StringData(member.Name),
-			"role": llx.StringData(role),
+			"id":       llx.IntData(int64(member.ID)),
+			"username": llx.StringData(member.Username),
+			"state":    llx.StringData(member.State),
+			"email":    llx.StringData(member.Email),
+			"name":     llx.StringData(member.Name),
+			"role":     llx.StringData(role),
 		}
 
 		mqlMember, err := CreateResource(p.MqlRuntime, "gitlab.project.member", memberInfo)

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -98,7 +98,7 @@ gitlab.project @defaults("fullName visibility webURL") {
   webhooks() []gitlab.project.webhook
   // Whether CI jobs are enabled
   jobsEnabled bool
-  // Whether the repo is empty or not
+  // Whether the repo is empty
   emptyRepo bool
 	// The license of the project if present
   license string

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -66,21 +66,21 @@ gitlab.project @defaults("fullName visibility webURL") {
   onlyAllowMergeIfAllDiscussionsAreResolved bool
   // Whether the issues feature is enabled
   issuesEnabled bool
-	// Whether the merge request feature is enabled
+  // Whether the merge request feature is enabled
   mergeRequestsEnabled bool
-	// Whether the wiki feature is enabled
+  // Whether the wiki feature is enabled
   wikiEnabled bool
-	// Whether the snippets feature is enabled
+  // Whether the snippets feature is enabled
   snippetsEnabled bool
-	// Whether the container registry feature is enabled
+  // Whether the container registry feature is enabled
   containerRegistryEnabled bool
-	// Whether the Service Desk feature is enabled
+  // Whether the Service Desk feature is enabled
   serviceDeskEnabled bool
-	// Whether the packages feature is enabled
+  // Whether the packages feature is enabled
   packagesEnabled bool
-	// Whether the Auto DevOps feature is enabled
+  // Whether the Auto DevOps feature is enabled
   autoDevopsEnabled bool
-	// Whether the requirements feature is enabled
+  // Whether the requirements feature is enabled
   requirementsEnabled bool
   // Approval rules for the project
   approvalRules() []gitlab.project.approvalRule
@@ -101,9 +101,9 @@ gitlab.project @defaults("fullName visibility webURL") {
   // Whether the repo is empty
   emptyRepo bool
   // Whether the project is enabled for shared runners
-	sharedRunnersEnabled bool
+  sharedRunnersEnabled bool
   // Whether the project is enabled for group runners
-	groupRunnersEnabled bool
+  groupRunnersEnabled bool
 }
 
 // GitLab project approval rule

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -43,7 +43,7 @@ gitlab.project @defaults("fullName visibility webURL") {
   // Project path
   path string
   // Create date of the project
-  createdAt time  
+  createdAt time
   // Project description
   description string
   // Default Git branch
@@ -96,6 +96,16 @@ gitlab.project @defaults("fullName visibility webURL") {
   projectFiles() []gitlab.project.file
   // List of webhooks for the project
   webhooks() []gitlab.project.webhook
+  // Whether CI jobs are enabled
+  jobsEnabled bool
+  // Whether the repo is empty or not
+  emptyRepo bool
+	// The license of the project if present
+  license string
+  // Whether the project is enabled for shared runners
+	sharedRunnersEnabled bool
+  // Whether the project is enabled for group runners
+	groupRunnersEnabled bool
 }
 
 
@@ -123,6 +133,8 @@ private gitlab.project.approvalSetting @defaults("approvalsBeforeMerge requirePa
   mergeRequestsDisableCommittersApproval bool
   // Whether a password is required to approve
   requirePasswordToApprove bool
+  // Whether approvals are reset from Code Owners if their files changed
+  selectiveCodeOwnerRemovals bool
 }
 
 
@@ -146,6 +158,12 @@ gitlab.project.member @defaults("id name role") {
   name string
   // Member role
   role string
+  // Member username
+  username string
+  // Member email
+  email string
+  // Member state
+  state string
 }
 
 // GitLab project file

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -100,14 +100,11 @@ gitlab.project @defaults("fullName visibility webURL") {
   jobsEnabled bool
   // Whether the repo is empty
   emptyRepo bool
-	// The license of the project if present
-  license string
   // Whether the project is enabled for shared runners
 	sharedRunnersEnabled bool
   // Whether the project is enabled for group runners
 	groupRunnersEnabled bool
 }
-
 
 // GitLab project approval rule
 private gitlab.project.approvalRule @defaults("id name approvalsRequired") {
@@ -137,7 +134,6 @@ private gitlab.project.approvalSetting @defaults("approvalsBeforeMerge requirePa
   selectiveCodeOwnerRemovals bool
 }
 
-
 // GitLab protected branch
 private gitlab.project.protectedBranch @defaults("name allowForcePush") {
   // Branch name
@@ -151,7 +147,7 @@ private gitlab.project.protectedBranch @defaults("name allowForcePush") {
 }
 
 // GitLab project member
-gitlab.project.member @defaults("id name role") {
+gitlab.project.member @defaults("username role name") {
   // Member ID
   id int
   // Member name
@@ -160,8 +156,6 @@ gitlab.project.member @defaults("id name role") {
   role string
   // Member username
   username string
-  // Member email
-  email string
   // Member state
   state string
 }

--- a/providers/gitlab/resources/gitlab.lr.go
+++ b/providers/gitlab/resources/gitlab.lr.go
@@ -247,6 +247,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gitlab.project.webhooks": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetWebhooks()).ToDataRes(types.Array(types.Resource("gitlab.project.webhook")))
 	},
+	"gitlab.project.jobsEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetJobsEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.emptyRepo": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetEmptyRepo()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.license": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetLicense()).ToDataRes(types.String)
+	},
+	"gitlab.project.sharedRunnersEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetSharedRunnersEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.groupRunnersEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetGroupRunnersEnabled()).ToDataRes(types.Bool)
+	},
 	"gitlab.project.approvalRule.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProjectApprovalRule).GetId()).ToDataRes(types.Int)
 	},
@@ -274,6 +289,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gitlab.project.approvalSetting.requirePasswordToApprove": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProjectApprovalSetting).GetRequirePasswordToApprove()).ToDataRes(types.Bool)
 	},
+	"gitlab.project.approvalSetting.selectiveCodeOwnerRemovals": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProjectApprovalSetting).GetSelectiveCodeOwnerRemovals()).ToDataRes(types.Bool)
+	},
 	"gitlab.project.protectedBranch.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProjectProtectedBranch).GetName()).ToDataRes(types.String)
 	},
@@ -294,6 +312,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gitlab.project.member.role": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProjectMember).GetRole()).ToDataRes(types.String)
+	},
+	"gitlab.project.member.username": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProjectMember).GetUsername()).ToDataRes(types.String)
+	},
+	"gitlab.project.member.email": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProjectMember).GetEmail()).ToDataRes(types.String)
+	},
+	"gitlab.project.member.state": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProjectMember).GetState()).ToDataRes(types.String)
 	},
 	"gitlab.project.file.path": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProjectFile).GetPath()).ToDataRes(types.String)
@@ -505,6 +532,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlGitlabProject).Webhooks, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
+	"gitlab.project.jobsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).JobsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.emptyRepo": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).EmptyRepo, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.license": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).License, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.sharedRunnersEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).SharedRunnersEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.groupRunnersEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).GroupRunnersEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gitlab.project.approvalRule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 			r.(*mqlGitlabProjectApprovalRule).__id, ok = v.Value.(string)
 			return
@@ -549,6 +596,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlGitlabProjectApprovalSetting).RequirePasswordToApprove, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"gitlab.project.approvalSetting.selectiveCodeOwnerRemovals": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProjectApprovalSetting).SelectiveCodeOwnerRemovals, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gitlab.project.protectedBranch.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 			r.(*mqlGitlabProjectProtectedBranch).__id, ok = v.Value.(string)
 			return
@@ -583,6 +634,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"gitlab.project.member.role": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabProjectMember).Role, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.member.username": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProjectMember).Username, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.member.email": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProjectMember).Email, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.member.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProjectMember).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gitlab.project.file.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -793,6 +856,11 @@ type mqlGitlabProject struct {
 	ProjectMembers plugin.TValue[[]interface{}]
 	ProjectFiles plugin.TValue[[]interface{}]
 	Webhooks plugin.TValue[[]interface{}]
+	JobsEnabled plugin.TValue[bool]
+	EmptyRepo plugin.TValue[bool]
+	License plugin.TValue[string]
+	SharedRunnersEnabled plugin.TValue[bool]
+	GroupRunnersEnabled plugin.TValue[bool]
 }
 
 // createGitlabProject creates a new instance of this resource
@@ -1030,6 +1098,26 @@ func (c *mqlGitlabProject) GetWebhooks() *plugin.TValue[[]interface{}] {
 	})
 }
 
+func (c *mqlGitlabProject) GetJobsEnabled() *plugin.TValue[bool] {
+	return &c.JobsEnabled
+}
+
+func (c *mqlGitlabProject) GetEmptyRepo() *plugin.TValue[bool] {
+	return &c.EmptyRepo
+}
+
+func (c *mqlGitlabProject) GetLicense() *plugin.TValue[string] {
+	return &c.License
+}
+
+func (c *mqlGitlabProject) GetSharedRunnersEnabled() *plugin.TValue[bool] {
+	return &c.SharedRunnersEnabled
+}
+
+func (c *mqlGitlabProject) GetGroupRunnersEnabled() *plugin.TValue[bool] {
+	return &c.GroupRunnersEnabled
+}
+
 // mqlGitlabProjectApprovalRule for the gitlab.project.approvalRule resource
 type mqlGitlabProjectApprovalRule struct {
 	MqlRuntime *plugin.Runtime
@@ -1095,6 +1183,7 @@ type mqlGitlabProjectApprovalSetting struct {
 	MergeRequestsAuthorApproval plugin.TValue[bool]
 	MergeRequestsDisableCommittersApproval plugin.TValue[bool]
 	RequirePasswordToApprove plugin.TValue[bool]
+	SelectiveCodeOwnerRemovals plugin.TValue[bool]
 }
 
 // createGitlabProjectApprovalSetting creates a new instance of this resource
@@ -1151,6 +1240,10 @@ func (c *mqlGitlabProjectApprovalSetting) GetMergeRequestsDisableCommittersAppro
 
 func (c *mqlGitlabProjectApprovalSetting) GetRequirePasswordToApprove() *plugin.TValue[bool] {
 	return &c.RequirePasswordToApprove
+}
+
+func (c *mqlGitlabProjectApprovalSetting) GetSelectiveCodeOwnerRemovals() *plugin.TValue[bool] {
+	return &c.SelectiveCodeOwnerRemovals
 }
 
 // mqlGitlabProjectProtectedBranch for the gitlab.project.protectedBranch resource
@@ -1225,6 +1318,9 @@ type mqlGitlabProjectMember struct {
 	Id plugin.TValue[int64]
 	Name plugin.TValue[string]
 	Role plugin.TValue[string]
+	Username plugin.TValue[string]
+	Email plugin.TValue[string]
+	State plugin.TValue[string]
 }
 
 // createGitlabProjectMember creates a new instance of this resource
@@ -1274,6 +1370,18 @@ func (c *mqlGitlabProjectMember) GetName() *plugin.TValue[string] {
 
 func (c *mqlGitlabProjectMember) GetRole() *plugin.TValue[string] {
 	return &c.Role
+}
+
+func (c *mqlGitlabProjectMember) GetUsername() *plugin.TValue[string] {
+	return &c.Username
+}
+
+func (c *mqlGitlabProjectMember) GetEmail() *plugin.TValue[string] {
+	return &c.Email
+}
+
+func (c *mqlGitlabProjectMember) GetState() *plugin.TValue[string] {
+	return &c.State
 }
 
 // mqlGitlabProjectFile for the gitlab.project.file resource

--- a/providers/gitlab/resources/gitlab.lr.go
+++ b/providers/gitlab/resources/gitlab.lr.go
@@ -253,9 +253,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gitlab.project.emptyRepo": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetEmptyRepo()).ToDataRes(types.Bool)
 	},
-	"gitlab.project.license": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGitlabProject).GetLicense()).ToDataRes(types.String)
-	},
 	"gitlab.project.sharedRunnersEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetSharedRunnersEnabled()).ToDataRes(types.Bool)
 	},
@@ -315,9 +312,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gitlab.project.member.username": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProjectMember).GetUsername()).ToDataRes(types.String)
-	},
-	"gitlab.project.member.email": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGitlabProjectMember).GetEmail()).ToDataRes(types.String)
 	},
 	"gitlab.project.member.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProjectMember).GetState()).ToDataRes(types.String)
@@ -540,10 +534,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlGitlabProject).EmptyRepo, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"gitlab.project.license": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGitlabProject).License, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gitlab.project.sharedRunnersEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabProject).SharedRunnersEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -638,10 +628,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"gitlab.project.member.username": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabProjectMember).Username, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"gitlab.project.member.email": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGitlabProjectMember).Email, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gitlab.project.member.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -858,7 +844,6 @@ type mqlGitlabProject struct {
 	Webhooks plugin.TValue[[]interface{}]
 	JobsEnabled plugin.TValue[bool]
 	EmptyRepo plugin.TValue[bool]
-	License plugin.TValue[string]
 	SharedRunnersEnabled plugin.TValue[bool]
 	GroupRunnersEnabled plugin.TValue[bool]
 }
@@ -1106,10 +1091,6 @@ func (c *mqlGitlabProject) GetEmptyRepo() *plugin.TValue[bool] {
 	return &c.EmptyRepo
 }
 
-func (c *mqlGitlabProject) GetLicense() *plugin.TValue[string] {
-	return &c.License
-}
-
 func (c *mqlGitlabProject) GetSharedRunnersEnabled() *plugin.TValue[bool] {
 	return &c.SharedRunnersEnabled
 }
@@ -1319,7 +1300,6 @@ type mqlGitlabProjectMember struct {
 	Name plugin.TValue[string]
 	Role plugin.TValue[string]
 	Username plugin.TValue[string]
-	Email plugin.TValue[string]
 	State plugin.TValue[string]
 }
 
@@ -1374,10 +1354,6 @@ func (c *mqlGitlabProjectMember) GetRole() *plugin.TValue[string] {
 
 func (c *mqlGitlabProjectMember) GetUsername() *plugin.TValue[string] {
 	return &c.Username
-}
-
-func (c *mqlGitlabProjectMember) GetEmail() *plugin.TValue[string] {
-	return &c.Email
 }
 
 func (c *mqlGitlabProjectMember) GetState() *plugin.TValue[string] {

--- a/providers/gitlab/resources/gitlab.lr.manifest.yaml
+++ b/providers/gitlab/resources/gitlab.lr.manifest.yaml
@@ -21,7 +21,6 @@ resources:
       visibility: {}
       webURL:
         min_mondoo_version: 9.0.0
-    maturity: experimental
     min_mondoo_version: 5.15.0
   gitlab.project:
     fields:
@@ -44,10 +43,18 @@ resources:
       description: {}
       emailsDisabled:
         min_mondoo_version: 9.0.0
+      emptyRepo:
+        min_mondoo_version: 9.0.0
       fullName:
+        min_mondoo_version: 9.0.0
+      groupRunnersEnabled:
         min_mondoo_version: 9.0.0
       id: {}
       issuesEnabled:
+        min_mondoo_version: 9.0.0
+      jobsEnabled:
+        min_mondoo_version: 9.0.0
+      license:
         min_mondoo_version: 9.0.0
       mergeMethod:
         min_mondoo_version: 9.0.0
@@ -73,6 +80,8 @@ resources:
         min_mondoo_version: 9.0.0
       serviceDeskEnabled:
         min_mondoo_version: 9.0.0
+      sharedRunnersEnabled:
+        min_mondoo_version: 9.0.0
       snippetsEnabled:
         min_mondoo_version: 9.0.0
       visibility: {}
@@ -82,7 +91,6 @@ resources:
         min_mondoo_version: 9.0.0
       wikiEnabled:
         min_mondoo_version: 9.0.0
-    maturity: experimental
     min_mondoo_version: 5.15.0
   gitlab.project.approvalRule:
     fields:
@@ -99,6 +107,7 @@ resources:
       mergeRequestsDisableCommittersApproval: {}
       requirePasswordToApprove: {}
       resetApprovalsOnPush: {}
+      selectiveCodeOwnerRemovals: {}
     is_private: true
     min_mondoo_version: 9.0.0
   gitlab.project.file:
@@ -111,9 +120,12 @@ resources:
     min_mondoo_version: 9.0.0
   gitlab.project.member:
     fields:
+      email: {}
       id: {}
       name: {}
       role: {}
+      state: {}
+      username: {}
     min_mondoo_version: 9.0.0
   gitlab.project.protectedBranch:
     fields:

--- a/providers/gitlab/resources/gitlab.lr.manifest.yaml
+++ b/providers/gitlab/resources/gitlab.lr.manifest.yaml
@@ -54,8 +54,6 @@ resources:
         min_mondoo_version: 9.0.0
       jobsEnabled:
         min_mondoo_version: 9.0.0
-      license:
-        min_mondoo_version: 9.0.0
       mergeMethod:
         min_mondoo_version: 9.0.0
       mergeRequestsEnabled:
@@ -120,7 +118,6 @@ resources:
     min_mondoo_version: 9.0.0
   gitlab.project.member:
     fields:
-      email: {}
       id: {}
       name: {}
       role: {}


### PR DESCRIPTION
Get some more data

```coffee
gitlab.group.projects.first.projectMembers: [
  0: gitlab.project.member username="root" role="Owner" name="Administrator"
  1: gitlab.project.member username="group_3_bot_b7fcf7deff3b60d0c34254b9fe169255" role="Reporter" name="mondoo-scanner"
]
```

```coffee
cnquery> gitlab.group.projects.first{jobsEnabled emptyRepo sharedRunnersEnabled groupRunnersEnabled}
gitlab.group.projects.first: {
  emptyRepo: false
  groupRunnersEnabled: true
  jobsEnabled: true
  sharedRunnersEnabled: true
}
```

```coffee
cnquery> gitlab.group.projects.first.approvalSettings{*}
gitlab.group.projects.first.approvalSettings: {
  mergeRequestsAuthorApproval: false
  mergeRequestsDisableCommittersApproval: false
  approvalsBeforeMerge: 0
  resetApprovalsOnPush: false
  requirePasswordToApprove: false
  selectiveCodeOwnerRemovals: false
  disableOverridingApproversPerMergeRequest: false
}
```