### PR TITLE
🐛 bring back loading provider flags from env vars

### DIFF
--- a/test/providers/os_test.go
+++ b/test/providers/os_test.go
@@ -226,7 +226,7 @@ func TestProvidersEnvVarsLoading(t *testing.T) {
 		}
 	})
 
-	t.Run("command with	flags set to not bind to config (ConfigEntry=\"-\")", func(t *testing.T) {
+	t.Run("command with flags set to not bind to config (ConfigEntry=\"-\")", func(t *testing.T) {
 		t.Run("should work via direct flag", func(t *testing.T) {
 			r := test.NewCliTestRunner("./cnquery", "run", "ssh", "localhost", "-c", "ls", "-p", "test", "-v")
 			err := r.Run()

--- a/test/providers/os_test.go
+++ b/test/providers/os_test.go
@@ -4,15 +4,16 @@
 package providers
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.mondoo.com/cnquery/v11/test"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/v11/test"
 )
 
 var once sync.Once
@@ -184,4 +185,44 @@ func TestOsProviderSharedTests(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestProvidersEnvVarsLoading(t *testing.T) {
+	t.Run("command WITHOUT path should not find any package", func(t *testing.T) {
+		r := test.NewCliTestRunner("./cnquery", "run", "fs", "-c", mqlPackagesQuery, "-j")
+		err := r.Run()
+		require.NoError(t, err)
+		assert.Equal(t, 0, r.ExitCode())
+		assert.NotNil(t, r.Stdout())
+		assert.NotNil(t, r.Stderr())
+
+		var c mqlPackages
+		err = r.Json(&c)
+		assert.NoError(t, err)
+
+		// No packages
+		assert.Empty(t, c)
+	})
+	t.Run("command WITH path should find packages", func(t *testing.T) {
+		os.Setenv("MONDOO_PATH", "./testdata/fs")
+		defer os.Unsetenv("MONDOO_PATH")
+		// Note we are not passing the flag "--path ./testdata/fs"
+		r := test.NewCliTestRunner("./cnquery", "run", "fs", "-c", mqlPackagesQuery, "-j")
+		err := r.Run()
+		require.NoError(t, err)
+		assert.Equal(t, 0, r.ExitCode())
+		assert.NotNil(t, r.Stdout())
+		assert.NotNil(t, r.Stderr())
+
+		var c mqlPackages
+		err = r.Json(&c)
+		assert.NoError(t, err)
+
+		// Should have packages
+		if assert.NotEmpty(t, c) {
+			x := c[0]
+			assert.NotNil(t, x.Packages)
+			assert.True(t, len(x.Packages) > 0)
+		}
+	})
 }


### PR DESCRIPTION
The problem from my original PR https://github.com/mondoohq/cnquery/pull/4847  to load provider flags from environment
variables was that I didn't consider the case where a provider defines a flag with
`ConfigEntry = "-"`. For those cases, we do NOT bind the flag to the `viper` config
and therefore, we couldn't load these flags.

This PR fixes that issue and, for those flags that are not bind to the config, we will
continue to fetch the value directly from the flag itself, that is, from `cobra`.