### PR TITLE
🧹 cache windows smbios response 

### DIFF
--- a/providers/os/id/aws/aws.go
+++ b/providers/os/id/aws/aws.go
@@ -24,7 +24,7 @@ func readValue(conn shared.Connection, fPath string) string {
 	return string(content)
 }
 
-func Detect(conn shared.Connection, p *inventory.Platform) (string, string, []string) {
+func Detect(conn shared.Connection, p *inventory.Platform, smbiosMgr smbios.SmBiosManager) (string, string, []string) {
 	var values []string
 	if p.IsFamily("linux") {
 		// Fetching the data from the smbios manager is slow for some transports
@@ -38,11 +38,7 @@ func Detect(conn shared.Connection, p *inventory.Platform) (string, string, []st
 			readValue(conn, "/sys/class/dmi/id/bios_vendor"),
 		}
 	} else {
-		mgr, err := smbios.ResolveManager(conn, p)
-		if err != nil {
-			return "", "", nil
-		}
-		info, err := mgr.Info()
+		info, err := smbiosMgr.Info()
 		if err != nil {
 			log.Debug().Err(err).Msg("failed to query smbios")
 			return "", "", nil

--- a/providers/os/id/aws/aws_test.go
+++ b/providers/os/id/aws/aws_test.go
@@ -11,6 +11,7 @@ import (
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v11/providers/os/connection/mock"
 	"go.mondoo.com/cnquery/v11/providers/os/detector"
+	"go.mondoo.com/cnquery/v11/providers/os/resources/smbios"
 )
 
 func TestDetectInstance(t *testing.T) {
@@ -19,7 +20,10 @@ func TestDetectInstance(t *testing.T) {
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
 
-	identifier, name, related := Detect(conn, platform)
+	mgr, err := smbios.ResolveManager(conn, platform)
+	require.NoError(t, err)
+
+	identifier, name, related := Detect(conn, platform, mgr)
 
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/123456789012/regions/us-west-2/instances/i-1234567890abcdef0", identifier)
 	assert.Equal(t, "ec2-name", name)
@@ -33,7 +37,10 @@ func TestDetectInstanceArm(t *testing.T) {
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
 
-	identifier, name, related := Detect(conn, platform)
+	mgr, err := smbios.ResolveManager(conn, platform)
+	require.NoError(t, err)
+
+	identifier, name, related := Detect(conn, platform, mgr)
 
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/123456789012/regions/us-west-2/instances/i-1234567890abcdef0", identifier)
 	assert.Equal(t, "ec2-name", name)
@@ -47,7 +54,10 @@ func TestDetectNotInstance(t *testing.T) {
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
 
-	identifier, name, related := Detect(conn, platform)
+	mgr, err := smbios.ResolveManager(conn, platform)
+	require.NoError(t, err)
+
+	identifier, name, related := Detect(conn, platform, mgr)
 
 	assert.Equal(t, "", identifier)
 	assert.Equal(t, "", name)
@@ -61,7 +71,10 @@ func TestDetectContainer(t *testing.T) {
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
 
-	identifier, name, related := Detect(conn, platform)
+	mgr, err := smbios.ResolveManager(conn, platform)
+	require.NoError(t, err)
+
+	identifier, name, related := Detect(conn, platform, mgr)
 
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/aws/ecs/v1/accounts/172746783610/regions/us-east-1/container/vjtest/f088b38d61ac45d6a946b5aebbe7197a/314e35e0-2d0a-4408-b37e-16063461d73a", identifier)
 	assert.Equal(t, "fargate-app", name)

--- a/providers/os/id/azure/azure.go
+++ b/providers/os/id/azure/azure.go
@@ -18,7 +18,7 @@ const (
 	azureIdentifierFileLinux = "/sys/class/dmi/id/sys_vendor"
 )
 
-func Detect(conn shared.Connection, pf *inventory.Platform) (string, string, []string) {
+func Detect(conn shared.Connection, pf *inventory.Platform, smbiosMgr smbios.SmBiosManager) (string, string, []string) {
 	sysVendor := ""
 	if pf.IsFamily("linux") {
 		// Fetching the product version from the smbios manager is slow
@@ -33,11 +33,7 @@ func Detect(conn shared.Connection, pf *inventory.Platform) (string, string, []s
 		}
 		sysVendor = string(content)
 	} else {
-		mgr, err := smbios.ResolveManager(conn, pf)
-		if err != nil {
-			return "", "", nil
-		}
-		info, err := mgr.Info()
+		info, err := smbiosMgr.Info()
 		if err != nil {
 			log.Debug().Err(err).Msg("failed to query smbios")
 			return "", "", nil

--- a/providers/os/id/gcp/gcp.go
+++ b/providers/os/id/gcp/gcp.go
@@ -18,7 +18,7 @@ const (
 	gceIdentifierFileLinux = "/sys/class/dmi/id/product_name"
 )
 
-func Detect(conn shared.Connection, p *inventory.Platform) (string, string, []string) {
+func Detect(conn shared.Connection, p *inventory.Platform, smbiosMgr smbios.SmBiosManager) (string, string, []string) {
 	productName := ""
 	if p.IsFamily("linux") {
 		// Fetching the product version from the smbios manager is slow
@@ -33,11 +33,7 @@ func Detect(conn shared.Connection, p *inventory.Platform) (string, string, []st
 		}
 		productName = string(content)
 	} else {
-		mgr, err := smbios.ResolveManager(conn, p)
-		if err != nil {
-			return "", "", nil
-		}
-		info, err := mgr.Info()
+		info, err := smbiosMgr.Info()
 		if err != nil {
 			log.Debug().Err(err).Msg("failed to query smbios")
 			return "", "", nil

--- a/providers/os/id/gcp/gcp_test.go
+++ b/providers/os/id/gcp/gcp_test.go
@@ -11,6 +11,7 @@ import (
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v11/providers/os/connection/mock"
 	"go.mondoo.com/cnquery/v11/providers/os/detector"
+	"go.mondoo.com/cnquery/v11/providers/os/resources/smbios"
 )
 
 func TestDetectLinuxInstance(t *testing.T) {
@@ -19,7 +20,10 @@ func TestDetectLinuxInstance(t *testing.T) {
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
 
-	identifier, name, relatedIdentifiers := Detect(conn, platform)
+	mgr, err := smbios.ResolveManager(conn, platform)
+	require.NoError(t, err)
+
+	identifier, name, relatedIdentifiers := Detect(conn, platform, mgr)
 
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/gcp/compute/v1/projects/mondoo-dev-262313/zones/us-central1-a/instances/6001244637815193808", identifier)
 	assert.Equal(t, "", name)
@@ -33,7 +37,10 @@ func TestDetectWindowsInstance(t *testing.T) {
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
 
-	identifier, name, relatedIdentifiers := Detect(conn, platform)
+	mgr, err := smbios.ResolveManager(conn, platform)
+	require.NoError(t, err)
+
+	identifier, name, relatedIdentifiers := Detect(conn, platform, mgr)
 
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/gcp/compute/v1/projects/mondoo-dev-262313/zones/us-central1-a/instances/5275377306317132843", identifier)
 	assert.Equal(t, "", name)
@@ -47,7 +54,10 @@ func TestNoMatch(t *testing.T) {
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
 
-	identifier, name, relatedIdentifiers := Detect(conn, platform)
+	mgr, err := smbios.ResolveManager(conn, platform)
+	require.NoError(t, err)
+
+	identifier, name, relatedIdentifiers := Detect(conn, platform, mgr)
 
 	assert.Empty(t, identifier)
 	assert.Empty(t, name)

--- a/providers/os/provider/detector.go
+++ b/providers/os/provider/detector.go
@@ -19,6 +19,7 @@ import (
 	"go.mondoo.com/cnquery/v11/providers/os/id/ids"
 	"go.mondoo.com/cnquery/v11/providers/os/id/machineid"
 	"go.mondoo.com/cnquery/v11/providers/os/id/sshhostkey"
+	"go.mondoo.com/cnquery/v11/providers/os/resources/smbios"
 )
 
 // default id detectors
@@ -75,8 +76,13 @@ func (s *Service) detect(asset *inventory.Asset, conn shared.Connection) error {
 	}
 
 	if hasDetector(detectors, ids.IdDetector_CloudDetect) {
+		mgr, err := smbios.ResolveManager(conn, asset.Platform)
+		if err != nil {
+			return err
+		}
+
 		log.Debug().Msg("run cloud platform detector")
-		if id, name, related := aws.Detect(conn, asset.Platform); id != "" {
+		if id, name, related := aws.Detect(conn, asset.Platform, mgr); id != "" {
 			asset.PlatformIds = append(asset.PlatformIds, id)
 			if name != "" {
 				// if we weren't able to detect a name for this asset, don't update to an empty value
@@ -85,12 +91,12 @@ func (s *Service) detect(asset *inventory.Asset, conn shared.Connection) error {
 			asset.RelatedAssets = append(asset.RelatedAssets, relatedIds2assets(related)...)
 		}
 
-		if id, _, related := azure.Detect(conn, asset.Platform); id != "" {
+		if id, _, related := azure.Detect(conn, asset.Platform, mgr); id != "" {
 			asset.PlatformIds = append(asset.PlatformIds, id)
 			asset.RelatedAssets = append(asset.RelatedAssets, relatedIds2assets(related)...)
 		}
 
-		if id, _, related := gcp.Detect(conn, asset.Platform); id != "" {
+		if id, _, related := gcp.Detect(conn, asset.Platform, mgr); id != "" {
 			asset.PlatformIds = append(asset.PlatformIds, id)
 			asset.RelatedAssets = append(asset.RelatedAssets, relatedIds2assets(related)...)
 		}

--- a/providers/os/resources/smbios/win.go
+++ b/providers/os/resources/smbios/win.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"io"
 	"strconv"
+	"sync"
 
 	"go.mondoo.com/cnquery/v11/providers/os/connection/shared"
 	"go.mondoo.com/cnquery/v11/providers/os/resources/powershell"
@@ -128,6 +129,8 @@ type smbiosSystemProduct struct {
 // https://docs.microsoft.com/en-us/windows-hardware/drivers/bringup/smbios
 type WindowsSmbiosManager struct {
 	provider shared.Connection
+	smInfo   *SmBiosInfo
+	lock     sync.Mutex
 }
 
 func (s *WindowsSmbiosManager) Name() string {
@@ -135,6 +138,12 @@ func (s *WindowsSmbiosManager) Name() string {
 }
 
 func (s *WindowsSmbiosManager) Info() (*SmBiosInfo, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.smInfo != nil {
+		return s.smInfo, nil
+	}
+
 	c, err := s.provider.RunCommand(powershell.Encode(smbiosWindowsScript))
 	if err != nil {
 		return nil, err

--- a/providers/os/resources/smbios/win.go
+++ b/providers/os/resources/smbios/win.go
@@ -193,6 +193,7 @@ func (s *WindowsSmbiosManager) Info() (*SmBiosInfo, error) {
 			Type:         winBios.Chassis[0].GetChassisTypes().Value()[0],
 		},
 	}
+	s.smInfo = &smInfo
 
 	return &smInfo, nil
 }


### PR DESCRIPTION
Retrieving the smbios info for windows can be expensive. This PR makes sure the resposne is cached in the manager and that we use a single manager during detection. It will make sure we will run the powershell script once instead of 3 times