### PR TITLE
⭐ GitHub: Improve the output of collaborators

### DIFF
--- a/providers/github/resources/github.lr
+++ b/providers/github/resources/github.lr
@@ -195,7 +195,7 @@ private github.team @defaults("id name") {
 }
 
 // GitHub collaborator
-private github.collaborator @defaults("user") {
+private github.collaborator @defaults("user.login user.name") {
   // Collaborator ID
   id int
   // Collaborator's user information
@@ -235,7 +235,7 @@ github.packages {
   private() []github.package
   // Internal packages
   internal() []github.package
-} 
+}
 
 // GitHub repository
 private github.repository @defaults("fullName") {


### PR DESCRIPTION
IDs are useless. List the human readable logins and names instead

Before:
```
cnquery> github.repository.adminCollaborators
github.repository.adminCollaborators: [
  0: github.collaborator user=github.user id = github.user/14072
]
```

Now:
```
cnquery> github.repository.adminCollaborators
github.repository.adminCollaborators: [
  0: github.collaborator user.login="bbobberson" user.name="Bob Bobberson"
]
```