### PR TITLE
🤖 Auto approve dep bump and provider release PRs

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -179,7 +179,7 @@ jobs:
     # For now, we only auto approve and merge provider release PRs created by mondoo-tools.
     # We have to check the commit author, because the PR is created by "github-actions[bot]"
     # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#startswith
-    if: ${{ startsWith(github.ref, 'refs/heads/version/providers_update_') && github.event.commits[0].author.username == 'mondoo-tools' }}
+    if: ${{ (startsWith(github.ref, 'refs/heads/version/providers_update_') || startsWith(github.ref, 'refs/heads/version/deps_update_')) && github.event.commits[0].author.username == 'mondoo-tools' }}
     permissions:
       contents: write
       pull-requests: write
@@ -191,10 +191,20 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           filterOutClosed: true
           filterOutDraft: true
-      - name: Approve a PR
-        uses: fastify/github-action-merge-dependabot@v3
+      # fetch a token for the mondoo-mergebot app
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
         with:
-          pr-number: ${{ steps.pr.outputs.number }}
+          app-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
+          private-key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
+      # automerge using bot token
+      - name: Approve and merge a PR
+        run: |
+          gh pr review ${{ steps.pr.outputs.number }} --approve
+          gh pr merge ${{ steps.pr.outputs.number }} --squash
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           
   event_file:
     name: "Store event file"


### PR DESCRIPTION
Porting over the changes we did in the cnspec repo:
https://github.com/mondoohq/cnspec/blob/main/.github/workflows/pr-test-lint.yml#L138-L151

This will approve and merge these sorts of PRs:
https://github.com/mondoohq/cnquery/pull/4956
https://github.com/mondoohq/cnquery/pull/4948