### PR TITLE
Fix the vmware technology URLs

### DIFF
--- a/providers/vsphere/provider/provider.go
+++ b/providers/vsphere/provider/provider.go
@@ -184,7 +184,7 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.VsphereConnect
 		Build:                 vSphereInfo.Build,
 		Kind:                  "api",
 		Runtime:               "vsphere",
-		TechnologyUrlSegments: []string{"vsphere", "vsphere", vSphereInfo.Version + "-" + vSphereInfo.Build},
+		TechnologyUrlSegments: []string{"vmware", "vsphere", vSphereInfo.Version + "-" + vSphereInfo.Build},
 	}
 
 	id, err := conn.Identifier()

--- a/providers/vsphere/resources/discovery.go
+++ b/providers/vsphere/resources/discovery.go
@@ -134,7 +134,7 @@ func discoverDatacenter(conn *connection.VsphereConnection, datacenterResource *
 					Kind:                  "baremetal",
 					Runtime:               "vsphere-host",
 					Family:                []string{connection.Family},
-					TechnologyUrlSegments: []string{"vsphere", "esxi", esxiVersion.Version + "-" + esxiVersion.Build},
+					TechnologyUrlSegments: []string{"vmware", "esxi", esxiVersion.Version + "-" + esxiVersion.Build},
 				},
 				Connections: []*inventory.Config{clonedConfig}, // pass-in the parent connection config
 				Labels: map[string]string{


### PR DESCRIPTION
The top level here should really be vmware so we don't end up with vsphere under vsphere

Paging @arlimus on this one