### PR TITLE
🐛 fix github provider by checking for `nil` errors

### DIFF
--- a/internal/workerpool/collector.go
+++ b/internal/workerpool/collector.go
@@ -53,7 +53,9 @@ func (c *collector[R]) GetValues() (slice []R) {
 func (c *collector[R]) GetErrors() (slice []error) {
 	results := c.GetResults()
 	for i := range results {
-		slice = append(slice, results[i].Error)
+		if results[i].Error != nil {
+			slice = append(slice, results[i].Error)
+		}
 	}
 	return
 }

--- a/providers/github/resources/github_org.go
+++ b/providers/github/resources/github_org.go
@@ -304,11 +304,12 @@ func (g *mqlGithubOrganization) repositories() ([]interface{}, error) {
 
 		// check if any request failed
 		if errs := workerPool.GetErrors(); len(errs) != 0 {
-			err := errors.Join(errs...)
-			if strings.Contains(err.Error(), "404") {
-				return nil, nil
+			if err := errors.Join(errs...); err != nil {
+				if strings.Contains(err.Error(), "404") {
+					return nil, nil
+				}
+				return nil, err
 			}
-			return nil, err
 		}
 	}
 


### PR DESCRIPTION
When workers return empty results with `nil` errors, the `workerpool` would return those
`nil` errors. 

This change fixes that issue by not returning `nil` errors.