### PR TITLE
⭐️ Make following redirects configurable for http.get resource

### DIFF
--- a/providers/network/config/config.go
+++ b/providers/network/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
+	"go.mondoo.com/cnquery/v11/providers/network/connection"
 	"go.mondoo.com/cnquery/v11/providers/network/provider"
 )
 
@@ -41,6 +42,12 @@ var Config = plugin.Provider{
 					Type:    plugin.FlagType_Bool,
 					Default: "",
 					Desc:    "Disable TLS/SSL verification",
+				},
+				{
+					Long:    connection.OPTION_FOLLOW_REDIRECTS,
+					Type:    plugin.FlagType_Bool,
+					Default: "",
+					Desc:    "Follow HTTP redirects",
 				},
 			},
 		},

--- a/providers/network/provider/provider.go
+++ b/providers/network/provider/provider.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
@@ -44,6 +45,11 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		insecure, _ = found.RawData().Value.(bool)
 	}
 
+	options := map[string]string{}
+	if found, ok := req.Flags[connection.OPTION_FOLLOW_REDIRECTS]; ok {
+		options[connection.OPTION_FOLLOW_REDIRECTS] = strconv.FormatBool(found.RawData().Value.(bool))
+	}
+
 	asset := inventory.Asset{
 		Connections: []*inventory.Config{{
 			Type:     "host",
@@ -52,6 +58,7 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 			Path:     path,
 			Runtime:  scheme,
 			Insecure: insecure,
+			Options:  options,
 		}},
 	}
 

--- a/providers/network/resources/http.go
+++ b/providers/network/resources/http.go
@@ -75,13 +75,18 @@ func initHttpGet(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 			return nil, nil, err
 		}
 		args["url"] = llx.ResourceData(url, "url")
+		args["followRedirects"] = llx.BoolData(conn.FollowRedirects)
+	}
+
+	if _, ok := args["followRedirects"]; !ok {
+		args["followRedirects"] = llx.BoolData(false)
 	}
 
 	return args, nil, nil
 }
 
 func (x *mqlHttpGet) id() (string, error) {
-	return x.Url.Data.__id, nil
+	return strings.Join([]string{x.Url.Data.__id, strconv.FormatBool(x.FollowRedirects.Data)}, ";"), nil
 }
 
 func (x *mqlHttpGet) do() error {
@@ -97,7 +102,7 @@ func (x *mqlHttpGet) do() error {
 	}
 
 	conn := x.MqlRuntime.Connection.(*connection.HostConnection)
-	resp, err := conn.Client().Get(x.Url.Data.String.Data)
+	resp, err := conn.Client(x.FollowRedirects.Data).Get(x.Url.Data.String.Data)
 	x.resp.State = plugin.StateIsSet
 	x.resp.Data = resp
 	x.resp.Error = err

--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -19,9 +19,11 @@ http {}
 
 // HTTP GET requests
 http.get @defaults("url statusCode") {
-  init(rawUrl string)
+  init(rawUrl string, followRedirects bool)
   // URL for this request
   url url
+  // Follow redirects
+  followRedirects bool
   // Header returned from this request
   header() http.header
   // Status returned from this request

--- a/providers/network/resources/network.lr.go
+++ b/providers/network/resources/network.lr.go
@@ -198,6 +198,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"http.get.url": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHttpGet).GetUrl()).ToDataRes(types.Resource("url"))
 	},
+	"http.get.followRedirects": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHttpGet).GetFollowRedirects()).ToDataRes(types.Bool)
+	},
 	"http.get.header": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHttpGet).GetHeader()).ToDataRes(types.Resource("http.header"))
 	},
@@ -674,6 +677,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		},
 	"http.get.url": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHttpGet).Url, ok = plugin.RawToTValue[*mqlUrl](v.Value, v.Error)
+		return
+	},
+	"http.get.followRedirects": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHttpGet).FollowRedirects, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"http.get.header": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1476,6 +1483,7 @@ type mqlHttpGet struct {
 	__id string
 	mqlHttpGetInternal
 	Url plugin.TValue[*mqlUrl]
+	FollowRedirects plugin.TValue[bool]
 	Header plugin.TValue[*mqlHttpHeader]
 	StatusCode plugin.TValue[int64]
 	Version plugin.TValue[string]
@@ -1521,6 +1529,10 @@ func (c *mqlHttpGet) MqlID() string {
 
 func (c *mqlHttpGet) GetUrl() *plugin.TValue[*mqlUrl] {
 	return &c.Url
+}
+
+func (c *mqlHttpGet) GetFollowRedirects() *plugin.TValue[bool] {
+	return &c.FollowRedirects
 }
 
 func (c *mqlHttpGet) GetHeader() *plugin.TValue[*mqlHttpHeader] {

--- a/providers/network/resources/network.lr.manifest.yaml
+++ b/providers/network/resources/network.lr.manifest.yaml
@@ -91,6 +91,7 @@ resources:
   http.get:
     fields:
       body: {}
+      followRedirects: {}
       header: {}
       statusCode: {}
       url: {}

--- a/providers/network/resources/url.go
+++ b/providers/network/resources/url.go
@@ -82,7 +82,8 @@ func (x *mqlUrl) string() (string, error) {
 	}
 
 	host := x.Host.Data
-	if x.Port.Data != 0 {
+	isStandardPort := x.Port.Data == 80 && x.Scheme.Data == "http" || x.Port.Data == 443 && x.Scheme.Data == "https"
+	if x.Port.Data != 0 && !isStandardPort {
 		host += ":" + strconv.Itoa(int(x.Port.Data))
 	}
 


### PR DESCRIPTION
By default, we will not follow redirects. You can follow redirects with a flag:

```
go run ./apps/cnquery -- shell host --follow-redirects http://mondoo.com
```
