### PR TITLE
Add new values to the k8s.node resource

### DIFF
--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -114,6 +114,12 @@ private k8s.node @defaults("name labels['kubernetes.io/arch'] labels['kubernetes
   name string
   // Kubernetes object type
   kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Node configuration information
+  nodeInfo dict
+  // Kubelet port
+  kubeletPort int
 }
 
 // Kubernetes Pod

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -364,6 +364,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.node.kind": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sNode).GetKind()).ToDataRes(types.String)
 	},
+	"k8s.node.created": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sNode).GetCreated()).ToDataRes(types.Time)
+	},
+	"k8s.node.nodeInfo": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sNode).GetNodeInfo()).ToDataRes(types.Dict)
+	},
+	"k8s.node.kubeletPort": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sNode).GetKubeletPort()).ToDataRes(types.Int)
+	},
 	"k8s.pod.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetId()).ToDataRes(types.String)
 	},
@@ -1498,6 +1507,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"k8s.node.kind": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sNode).Kind, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.node.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sNode).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"k8s.node.nodeInfo": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sNode).NodeInfo, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
+		return
+	},
+	"k8s.node.kubeletPort": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sNode).KubeletPort, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"k8s.pod.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3486,6 +3507,9 @@ type mqlK8sNode struct {
 	ResourceVersion plugin.TValue[string]
 	Name plugin.TValue[string]
 	Kind plugin.TValue[string]
+	Created plugin.TValue[*time.Time]
+	NodeInfo plugin.TValue[interface{}]
+	KubeletPort plugin.TValue[int64]
 }
 
 // createK8sNode creates a new instance of this resource
@@ -3555,6 +3579,18 @@ func (c *mqlK8sNode) GetName() *plugin.TValue[string] {
 
 func (c *mqlK8sNode) GetKind() *plugin.TValue[string] {
 	return &c.Kind
+}
+
+func (c *mqlK8sNode) GetCreated() *plugin.TValue[*time.Time] {
+	return &c.Created
+}
+
+func (c *mqlK8sNode) GetNodeInfo() *plugin.TValue[interface{}] {
+	return &c.NodeInfo
+}
+
+func (c *mqlK8sNode) GetKubeletPort() *plugin.TValue[int64] {
+	return &c.KubeletPort
 }
 
 // mqlK8sPod for the k8s.pod resource

--- a/providers/k8s/resources/k8s.lr.manifest.yaml
+++ b/providers/k8s/resources/k8s.lr.manifest.yaml
@@ -488,12 +488,18 @@ resources:
     fields:
       annotations:
         min_mondoo_version: 5.29.2
+      created:
+        min_mondoo_version: 9.0.0
       id:
         min_mondoo_version: 6.10.0
       kind: {}
+      kubeletPort:
+        min_mondoo_version: 9.0.0
       labels:
         min_mondoo_version: 5.29.2
       name: {}
+      nodeInfo:
+        min_mondoo_version: 9.0.0
       resourceVersion:
         min_mondoo_version: 5.29.2
       uid: {}


### PR DESCRIPTION
Fetch the creation date, the port, and the overall OS config.

```coffee
cnquery> k8s.nodes.first{ created nodeInfo kubeletPort }
k8s.nodes.first: {
  kubeletPort: 10250
  nodeInfo: {
    architecture: "arm64"
    bootID: "ae92580d-e68f-4108-8074-2c6e9c8e3351"
    containerRuntimeVersion: "docker://24.0.7"
    kernelVersion: "6.10.11-linuxkit"
    kubeProxyVersion: ""
    kubeletVersion: "v1.31.0"
    machineID: "c08bfdd8746d444497cb3dfe0a128dc2"
    operatingSystem: "linux"
    osImage: "Ubuntu 22.04.3 LTS"
    systemUUID: "c08bfdd8746d444497cb3dfe0a128dc2"
  }
  created: 2024-02-23 11:58:20 -0800 PST
}
```

Paging @imilchev to see if I did any of this correctly