### PR TITLE
🐛 ms365: check error before accessing resp

### DIFF
--- a/providers/ms365/resources/applications.go
+++ b/providers/ms365/resources/applications.go
@@ -8,9 +8,10 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"github.com/rs/zerolog/log"
 	"net/url"
 	"time"
+
+	"github.com/rs/zerolog/log"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/applications"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -253,6 +254,10 @@ func (a *mqlMicrosoftApplication) servicePrincipal() (*mqlMicrosoftServiceprinci
 			Filter: &filter,
 		},
 	})
+	if err != nil {
+		return nil, err
+	}
+
 	servicePrincipals := resp.GetValue()
 	if len(servicePrincipals) == 0 {
 		return nil, errors.New("service principal not found")


### PR DESCRIPTION
A panic was reported and this is the fix.
```
cnspec> microsoft.application{*}
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x40 pc=0x8b7baca]

goroutine 166 [running]:
go.mondoo.com/cnquery/v11/providers/ms365/resources.(*mqlMicrosoftApplication).servicePrincipal(0xc000b00008)
        /home/runner/_work/cnquery/cnquery/providers/ms365/resources/applications.go:256 +0x16a
go.mondoo.com/cnquery/v11/providers/ms365/resources.(*mqlMicrosoftApplication).GetServicePrincipal.func1()
        /home/runner/_work/cnquery/cnquery/providers/ms365/resources/ms365.lr.go:4301 +0x7f
go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin.GetOrCompute[...](0xc000b003c0?, 0x805385)
        /home/runner/_work/cnquery/cnquery/providers-sdk/v1/plugin/runtime.go:269 +0x37
go.mondoo.com/cnquery/v11/providers/ms365/resources.(*mqlMicrosoftApplication).GetServicePrincipal(0x2?)
        /home/runner/_work/cnquery/cnquery/providers/ms365/resources/ms365.lr.go:4290 +0x39
go.mondoo.com/cnquery/v11/providers/ms365/resources.init.func505({0xd734f18?, 0xc000b00008?})
        /home/runner/_work/cnquery/cnquery/providers/ms365/resources/ms365.lr.go:660 +0x30
go.mondoo.com/cnquery/v11/providers/ms365/resources.GetData({0xd734f18, 0xc000b00008}, {0xc000a88d90, 0x10}, 0xf61ba5?)
        /home/runner/_work/cnquery/cnquery/providers/ms365/resources/ms365.lr.go:1249 +0x16b
go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin.(*Service).GetData(0xb7c7e80?, 0xc0004f15e0)
        /home/runner/_work/cnquery/cnquery/providers-sdk/v1/plugin/service.go:195 +0x323
go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin.(*GRPCServer).GetData(0x147cb800?, {0xc3c4900?, 0xc000983900?}, 0x92ee05?)
        /home/runner/_work/cnquery/cnquery/providers-sdk/v1/plugin/grpc.go:129 +0x1e
go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin._ProviderPlugin_GetData_Handler({0xc3c4900, 0xc000474fa0}, {0xd7a6e40, 0xc000660fc0}, 0xc0004edf00, 0x0)
        /home/runner/_work/cnquery/cnquery/providers-sdk/v1/plugin/plugin_grpc.pb.go:318 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0003fae00, {0xd7a6e40, 0xc000660f30}, {0xd7b0c80, 0xc0001f8d00}, 0xc0006a6120, 0xc0003358c0, 0x14a03970, 0x0)
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.68.1/server.go:1394 +0xe2b
google.golang.org/grpc.(*Server).handleStream(0xc0003fae00, {0xd7b0c80, 0xc0001f8d00}, 0xc0006a6120)
```