### PR TITLE
Improve printing of discovery options in help

### DIFF
--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -227,7 +227,7 @@ func genBuiltinFlags(discoveries ...string) []plugin.Flag {
 		{
 			Long: "discover",
 			Type: plugin.FlagType_List,
-			Desc: "Enable the discovery of nested assets. Supports: " + strings.Join(supportedDiscoveries, ","),
+			Desc: "Enable the discovery of nested assets. Supports: " + strings.Join(supportedDiscoveries, ", "),
 		},
 		{
 			Long:   "pretty",


### PR DESCRIPTION
Current:

```
--discover strings             Enable the discovery of nested assets. Supports: all,auto,repos,users,organization,terraform,k8s-manifests
```

With this PR

```
--discover strings             Enable the discovery of nested assets. Supports: all, auto, repos, users, organization, terraform, k8s-manifests
```