### PR TITLE
:sparkles: Extend `azure.subscription.policy.assignments` to include `{parameters}` field 

### DIFF
--- a/providers/azure/resources/armsecurity.go
+++ b/providers/azure/resources/armsecurity.go
@@ -195,6 +195,9 @@ type PolicyAssignment struct {
 			AllowedSkus struct {
 				Value string `json:"value"`
 			} `json:"allowedSkus"`
+			Effect struct {
+				Value string `json:"value"`
+			} `json:"effect"`
 		} `json:"parameters"`
 		Scope     string        `json:"scope"`
 		NotScopes []interface{} `json:"notScopes"`

--- a/providers/azure/resources/armsecurity.go
+++ b/providers/azure/resources/armsecurity.go
@@ -198,6 +198,9 @@ type PolicyAssignment struct {
 			Effect struct {
 				Value string `json:"value"`
 			} `json:"effect"`
+			ApprovedExtensions struct {
+				Value []string `json:"value"`
+			} `json:"approvedExtensions"`
 		} `json:"parameters"`
 		Scope     string        `json:"scope"`
 		NotScopes []interface{} `json:"notScopes"`

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -2006,6 +2006,8 @@ private azure.subscription.policy.assignment @defaults("name enforcementMode") {
   description string
   // Policy enforcement Mode
   enforcementMode string
+  // Policy parameters
+  parameters dict
 }
 
 // Azure IoT Hub Service

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -6545,7 +6545,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		return
 	},
 	"azure.subscription.policy.assignment.parameters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionPolicyAssignment).Parameters, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		r.(*mqlAzureSubscriptionPolicyAssignment).Parameters, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.iotService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16620,7 +16620,7 @@ type mqlAzureSubscriptionPolicyAssignment struct {
 	Scope plugin.TValue[string]
 	Description plugin.TValue[string]
 	EnforcementMode plugin.TValue[string]
-	Parameters plugin.TValue[map[string]interface{}]
+	Parameters plugin.TValue[interface{}]
 }
 
 // createAzureSubscriptionPolicyAssignment creates a new instance of this resource

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -6544,6 +6544,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAzureSubscriptionPolicyAssignment).EnforcementMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.policy.assignment.parameters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionPolicyAssignment).Parameters, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.iotService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 			r.(*mqlAzureSubscriptionIotService).__id, ok = v.Value.(string)
 			return

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -2907,6 +2907,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.policy.assignment.enforcementMode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionPolicyAssignment).GetEnforcementMode()).ToDataRes(types.String)
 	},
+	"azure.subscription.policy.assignment.parameters": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionPolicyAssignment).GetParameters()).ToDataRes(types.Dict)
+	},
 	"azure.subscription.iotService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionIotService).GetSubscriptionId()).ToDataRes(types.String)
 	},
@@ -16613,6 +16616,7 @@ type mqlAzureSubscriptionPolicyAssignment struct {
 	Scope plugin.TValue[string]
 	Description plugin.TValue[string]
 	EnforcementMode plugin.TValue[string]
+	Parameters plugin.TValue[map[string]interface{}]
 }
 
 // createAzureSubscriptionPolicyAssignment creates a new instance of this resource
@@ -16665,6 +16669,10 @@ func (c *mqlAzureSubscriptionPolicyAssignment) GetDescription() *plugin.TValue[s
 
 func (c *mqlAzureSubscriptionPolicyAssignment) GetEnforcementMode() *plugin.TValue[string] {
 	return &c.EnforcementMode
+}
+
+func (c *mqlAzureSubscriptionPolicyAssignment) GetParameters() *plugin.TValue[string] {
+	return &c.Parameters
 }
 
 // mqlAzureSubscriptionIotService for the azure.subscription.iotService resource

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -16675,7 +16675,7 @@ func (c *mqlAzureSubscriptionPolicyAssignment) GetEnforcementMode() *plugin.TVal
 	return &c.EnforcementMode
 }
 
-func (c *mqlAzureSubscriptionPolicyAssignment) GetParameters() *plugin.TValue[string] {
+func (c *mqlAzureSubscriptionPolicyAssignment) GetParameters() *plugin.TValue[interface{}] {
 	return &c.Parameters
 }
 

--- a/providers/azure/resources/azure.lr.manifest.yaml
+++ b/providers/azure/resources/azure.lr.manifest.yaml
@@ -2060,8 +2060,8 @@ resources:
       enforcementMode: {}
       id: {}
       name: {}
-      scope: {}
       parameters: {}
+      scope: {}
     is_private: true
     min_mondoo_version: 9.0.0
     platform:

--- a/providers/azure/resources/azure.lr.manifest.yaml
+++ b/providers/azure/resources/azure.lr.manifest.yaml
@@ -2061,6 +2061,7 @@ resources:
       id: {}
       name: {}
       scope: {}
+      parameters: {}
     is_private: true
     min_mondoo_version: 9.0.0
     platform:

--- a/providers/azure/resources/policy.go
+++ b/providers/azure/resources/policy.go
@@ -10,6 +10,7 @@ import (
 
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/convert"
 	"go.mondoo.com/cnquery/v11/providers/azure/connection"
 )
 
@@ -44,12 +45,11 @@ func (a *mqlAzureSubscriptionPolicy) assignments() ([]interface{}, error) {
 
 	res := []interface{}{}
 	for _, assignment := range pas.PolicyAssignments {
-		properties, err := convert.JsonToDict(assignment.Properties)
+		parameters, err := convert.JsonToDict(assignment.Properties.Parameters)
 		if err != nil {
 			return nil, err
 		}
 
-	for _, assignment := range pas.PolicyAssignments {
 		assignmentData := map[string]*llx.RawData{
 			"__id":            llx.StringData(fmt.Sprintf("azure.subscription.policy/%s/%s", assignment.Properties.Scope, assignment.Properties.DisplayName)),
 			"id":              llx.StringData(assignment.Properties.PolicyDefinitionID),
@@ -57,7 +57,7 @@ func (a *mqlAzureSubscriptionPolicy) assignments() ([]interface{}, error) {
 			"scope":           llx.StringData(assignment.Properties.Scope),
 			"description":     llx.StringData(assignment.Properties.Description),
 			"enforcementMode": llx.StringData(assignment.Properties.EnforcementMode),
-			"parameters":      llx.StringData(assignment.Properties.Parameters),
+			"parameters":      llx.DictData(parameters),
 		}
 
 		mqlAssignment, err := CreateResource(a.MqlRuntime, "azure.subscription.policy.assignment", assignmentData)

--- a/providers/azure/resources/policy.go
+++ b/providers/azure/resources/policy.go
@@ -44,6 +44,12 @@ func (a *mqlAzureSubscriptionPolicy) assignments() ([]interface{}, error) {
 
 	res := []interface{}{}
 	for _, assignment := range pas.PolicyAssignments {
+		properties, err := convert.JsonToDict(assignment.Properties)
+		if err != nil {
+			return nil, err
+		}
+
+	for _, assignment := range pas.PolicyAssignments {
 		assignmentData := map[string]*llx.RawData{
 			"__id":            llx.StringData(fmt.Sprintf("azure.subscription.policy/%s/%s", assignment.Properties.Scope, assignment.Properties.DisplayName)),
 			"id":              llx.StringData(assignment.Properties.PolicyDefinitionID),

--- a/providers/azure/resources/policy.go
+++ b/providers/azure/resources/policy.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/providers/azure/connection"
@@ -50,6 +51,7 @@ func (a *mqlAzureSubscriptionPolicy) assignments() ([]interface{}, error) {
 			"scope":           llx.StringData(assignment.Properties.Scope),
 			"description":     llx.StringData(assignment.Properties.Description),
 			"enforcementMode": llx.StringData(assignment.Properties.EnforcementMode),
+			"parameters":      llx.StringData(assignment.Properties.Parameters),
 		}
 
 		mqlAssignment, err := CreateResource(a.MqlRuntime, "azure.subscription.policy.assignment", assignmentData)


### PR DESCRIPTION
extend `azure.subscription.policy.assignments` to include `{parameters}` field 

```
  }
  6: {
    parameters: {
      allowedSkus: {
        value: ""
      }
      approvedExtensions: {
        value: [
          0: "GuestAttestation"
        ]
      }
      effect: {
        value: "Deny"
      }
    }
  }

```