### PR TITLE
Unify more of the aws resources on createdAt

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -768,20 +768,24 @@ private aws.iam.usercredentialreportentry @defaults("arn") {
 
   // IAM user
   user() aws.iam.user
-  // Time when user was created
+  // Time when user was created: deprecated, use createdAt
   userCreationTime() time
+  // Time when user was created
+  createdAt() time
 }
 
 // AWS IAM user
-private aws.iam.user @defaults("arn name") {
+private aws.iam.user @defaults("arn name createdAt") {
   // ARN of the IAM user
   arn string
   // ID of the IAM user
   id string
   // Name of the user
   name string
-  // Time when user was created
+  // Time when user was created: deprecated, use createdAt
   createDate time
+  // Time when user was created
+  createdAt time
   // Time when password was last used
   passwordLastUsed time
   // Tags for the IAM user
@@ -802,8 +806,10 @@ private aws.iam.user @defaults("arn name") {
 private aws.iam.instanceProfile @defaults("arn instanceProfileId") {
   // ARN of the instance profile
   arn string
-  // Time when the instance profile was created
+  // Time when the instance profile was created: deprecated, use createdAt
   createDate time
+  // Time when the instance profile was created
+  createdAt time
   // ID of the IAM instance profile
   instanceProfileId string
   // Name of the instance profile
@@ -836,8 +842,10 @@ private aws.iam.policy @defaults("arn name") {
   isAttachable() bool
   // Number of principal entities (users, groups, and roles) that the policy is attached to
   attachmentCount() int
-  // Time when the policy was created
+  // Time when the policy was created: deprecated, use createdAt
   createDate() time
+  // Time when the policy was created
+  createdAt() time
   // Time when the policy was updated
   updateDate() time
   // Scope of the policy
@@ -856,7 +864,7 @@ private aws.iam.policy @defaults("arn name") {
 }
 
 // AWS IAM policy version
-private aws.iam.policyversion @defaults("arn isDefaultVersion") {
+private aws.iam.policyversion @defaults("arn isDefaultVersion createdAt") {
   // ARN of the policy version
   arn string
   // Version ID
@@ -865,8 +873,10 @@ private aws.iam.policyversion @defaults("arn isDefaultVersion") {
   isDefaultVersion bool
   // JSON statements for this policy version
   document() dict
-  // Time when this policy version was created
+  // Time when this policy version was created: deprecated, use createdAt
   createDate time
+  // Time when this policy version was created
+  createdAt time
 }
 
 // AWS IAM role
@@ -881,8 +891,10 @@ private aws.iam.role @defaults("arn name") {
   description string
   // Tags associated with the role
   tags map[string]string
-  // Time when the role was created
+  // Time when the role was created: deprecated, use createdAt
   createDate time
+  // Time when the role was created
+  createdAt time
   // Policy document that grants an entity permission to assume the role
   assumeRolePolicyDocument dict
 }

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -1679,6 +1679,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.iam.usercredentialreportentry.userCreationTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamUsercredentialreportentry).GetUserCreationTime()).ToDataRes(types.Time)
 	},
+	"aws.iam.usercredentialreportentry.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamUsercredentialreportentry).GetCreatedAt()).ToDataRes(types.Time)
+	},
 	"aws.iam.user.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamUser).GetArn()).ToDataRes(types.String)
 	},
@@ -1690,6 +1693,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.iam.user.createDate": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamUser).GetCreateDate()).ToDataRes(types.Time)
+	},
+	"aws.iam.user.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamUser).GetCreatedAt()).ToDataRes(types.Time)
 	},
 	"aws.iam.user.passwordLastUsed": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamUser).GetPasswordLastUsed()).ToDataRes(types.Time)
@@ -1717,6 +1723,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.iam.instanceProfile.createDate": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamInstanceProfile).GetCreateDate()).ToDataRes(types.Time)
+	},
+	"aws.iam.instanceProfile.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamInstanceProfile).GetCreatedAt()).ToDataRes(types.Time)
 	},
 	"aws.iam.instanceProfile.instanceProfileId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamInstanceProfile).GetInstanceProfileId()).ToDataRes(types.String)
@@ -1757,6 +1766,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.iam.policy.createDate": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamPolicy).GetCreateDate()).ToDataRes(types.Time)
 	},
+	"aws.iam.policy.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamPolicy).GetCreatedAt()).ToDataRes(types.Time)
+	},
 	"aws.iam.policy.updateDate": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamPolicy).GetUpdateDate()).ToDataRes(types.Time)
 	},
@@ -1793,6 +1805,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.iam.policyversion.createDate": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamPolicyversion).GetCreateDate()).ToDataRes(types.Time)
 	},
+	"aws.iam.policyversion.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamPolicyversion).GetCreatedAt()).ToDataRes(types.Time)
+	},
 	"aws.iam.role.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamRole).GetArn()).ToDataRes(types.String)
 	},
@@ -1810,6 +1825,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.iam.role.createDate": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamRole).GetCreateDate()).ToDataRes(types.Time)
+	},
+	"aws.iam.role.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamRole).GetCreatedAt()).ToDataRes(types.Time)
 	},
 	"aws.iam.role.assumeRolePolicyDocument": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamRole).GetAssumeRolePolicyDocument()).ToDataRes(types.Dict)
@@ -6330,6 +6348,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsIamUsercredentialreportentry).UserCreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"aws.iam.usercredentialreportentry.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamUsercredentialreportentry).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"aws.iam.user.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 			r.(*mqlAwsIamUser).__id, ok = v.Value.(string)
 			return
@@ -6348,6 +6370,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.iam.user.createDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamUser).CreateDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.iam.user.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamUser).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.iam.user.passwordLastUsed": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6388,6 +6414,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.iam.instanceProfile.createDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamInstanceProfile).CreateDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.iam.instanceProfile.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamInstanceProfile).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.iam.instanceProfile.instanceProfileId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6450,6 +6480,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsIamPolicy).CreateDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"aws.iam.policy.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamPolicy).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"aws.iam.policy.updateDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamPolicy).UpdateDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -6502,6 +6536,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsIamPolicyversion).CreateDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"aws.iam.policyversion.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamPolicyversion).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"aws.iam.role.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 			r.(*mqlAwsIamRole).__id, ok = v.Value.(string)
 			return
@@ -6528,6 +6566,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.iam.role.createDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamRole).CreateDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.iam.role.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamRole).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.iam.role.assumeRolePolicyDocument": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15089,6 +15131,7 @@ type mqlAwsIamUsercredentialreportentry struct {
 	PasswordNextRotation plugin.TValue[*time.Time]
 	User plugin.TValue[*mqlAwsIamUser]
 	UserCreationTime plugin.TValue[*time.Time]
+	CreatedAt plugin.TValue[*time.Time]
 }
 
 // createAwsIamUsercredentialreportentry creates a new instance of this resource
@@ -15274,6 +15317,12 @@ func (c *mqlAwsIamUsercredentialreportentry) GetUserCreationTime() *plugin.TValu
 	})
 }
 
+func (c *mqlAwsIamUsercredentialreportentry) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return plugin.GetOrCompute[*time.Time](&c.CreatedAt, func() (*time.Time, error) {
+		return c.createdAt()
+	})
+}
+
 // mqlAwsIamUser for the aws.iam.user resource
 type mqlAwsIamUser struct {
 	MqlRuntime *plugin.Runtime
@@ -15283,6 +15332,7 @@ type mqlAwsIamUser struct {
 	Id plugin.TValue[string]
 	Name plugin.TValue[string]
 	CreateDate plugin.TValue[*time.Time]
+	CreatedAt plugin.TValue[*time.Time]
 	PasswordLastUsed plugin.TValue[*time.Time]
 	Tags plugin.TValue[map[string]interface{}]
 	Policies plugin.TValue[[]interface{}]
@@ -15343,6 +15393,10 @@ func (c *mqlAwsIamUser) GetName() *plugin.TValue[string] {
 
 func (c *mqlAwsIamUser) GetCreateDate() *plugin.TValue[*time.Time] {
 	return &c.CreateDate
+}
+
+func (c *mqlAwsIamUser) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
 }
 
 func (c *mqlAwsIamUser) GetPasswordLastUsed() *plugin.TValue[*time.Time] {
@@ -15410,6 +15464,7 @@ type mqlAwsIamInstanceProfile struct {
 	mqlAwsIamInstanceProfileInternal
 	Arn plugin.TValue[string]
 	CreateDate plugin.TValue[*time.Time]
+	CreatedAt plugin.TValue[*time.Time]
 	InstanceProfileId plugin.TValue[string]
 	InstanceProfileName plugin.TValue[string]
 	Tags plugin.TValue[map[string]interface{}]
@@ -15459,6 +15514,10 @@ func (c *mqlAwsIamInstanceProfile) GetArn() *plugin.TValue[string] {
 
 func (c *mqlAwsIamInstanceProfile) GetCreateDate() *plugin.TValue[*time.Time] {
 	return &c.CreateDate
+}
+
+func (c *mqlAwsIamInstanceProfile) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
 }
 
 func (c *mqlAwsIamInstanceProfile) GetInstanceProfileId() *plugin.TValue[string] {
@@ -15546,6 +15605,7 @@ type mqlAwsIamPolicy struct {
 	IsAttachable plugin.TValue[bool]
 	AttachmentCount plugin.TValue[int64]
 	CreateDate plugin.TValue[*time.Time]
+	CreatedAt plugin.TValue[*time.Time]
 	UpdateDate plugin.TValue[*time.Time]
 	Scope plugin.TValue[string]
 	Versions plugin.TValue[[]interface{}]
@@ -15633,6 +15693,12 @@ func (c *mqlAwsIamPolicy) GetAttachmentCount() *plugin.TValue[int64] {
 func (c *mqlAwsIamPolicy) GetCreateDate() *plugin.TValue[*time.Time] {
 	return plugin.GetOrCompute[*time.Time](&c.CreateDate, func() (*time.Time, error) {
 		return c.createDate()
+	})
+}
+
+func (c *mqlAwsIamPolicy) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return plugin.GetOrCompute[*time.Time](&c.CreatedAt, func() (*time.Time, error) {
+		return c.createdAt()
 	})
 }
 
@@ -15738,6 +15804,7 @@ type mqlAwsIamPolicyversion struct {
 	IsDefaultVersion plugin.TValue[bool]
 	Document plugin.TValue[interface{}]
 	CreateDate plugin.TValue[*time.Time]
+	CreatedAt plugin.TValue[*time.Time]
 }
 
 // createAwsIamPolicyversion creates a new instance of this resource
@@ -15799,6 +15866,10 @@ func (c *mqlAwsIamPolicyversion) GetCreateDate() *plugin.TValue[*time.Time] {
 	return &c.CreateDate
 }
 
+func (c *mqlAwsIamPolicyversion) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
+}
+
 // mqlAwsIamRole for the aws.iam.role resource
 type mqlAwsIamRole struct {
 	MqlRuntime *plugin.Runtime
@@ -15810,6 +15881,7 @@ type mqlAwsIamRole struct {
 	Description plugin.TValue[string]
 	Tags plugin.TValue[map[string]interface{}]
 	CreateDate plugin.TValue[*time.Time]
+	CreatedAt plugin.TValue[*time.Time]
 	AssumeRolePolicyDocument plugin.TValue[interface{}]
 }
 
@@ -15872,6 +15944,10 @@ func (c *mqlAwsIamRole) GetTags() *plugin.TValue[map[string]interface{}] {
 
 func (c *mqlAwsIamRole) GetCreateDate() *plugin.TValue[*time.Time] {
 	return &c.CreateDate
+}
+
+func (c *mqlAwsIamRole) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
 }
 
 func (c *mqlAwsIamRole) GetAssumeRolePolicyDocument() *plugin.TValue[interface{}] {

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2022,6 +2022,7 @@ resources:
     fields:
       arn: {}
       createDate: {}
+      createdAt: {}
       iamRoles: {}
       instanceProfileId: {}
       instanceProfileName: {}
@@ -2050,6 +2051,8 @@ resources:
       attachedUsers: {}
       attachmentCount: {}
       createDate: {}
+      createdAt:
+        min_mondoo_version: 9.0.0
       defaultVersion: {}
       description: {}
       id: {}
@@ -2072,6 +2075,8 @@ resources:
     fields:
       arn: {}
       createDate: {}
+      createdAt:
+        min_mondoo_version: 9.0.0
       document: {}
       isDefaultVersion: {}
       versionId: {}
@@ -2088,6 +2093,8 @@ resources:
       arn: {}
       assumeRolePolicyDocument: {}
       createDate: {}
+      createdAt:
+        min_mondoo_version: 9.0.0
       description: {}
       id: {}
       name: {}
@@ -2106,6 +2113,8 @@ resources:
       arn: {}
       attachedPolicies: {}
       createDate: {}
+      createdAt:
+        min_mondoo_version: 9.0.0
       groups: {}
       id: {}
       loginProfile:
@@ -2139,6 +2148,8 @@ resources:
       cert1LastRotated: {}
       cert2Active: {}
       cert2LastRotated: {}
+      createdAt:
+        min_mondoo_version: 9.0.0
       mfaActive: {}
       passwordEnabled: {}
       passwordLastChanged: {}

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -307,6 +307,7 @@ func (a *mqlAwsIam) createInstanceProfile(instanceProfile *iamtypes.InstanceProf
 		map[string]*llx.RawData{
 			"arn":                 llx.StringDataPtr(instanceProfile.Arn),
 			"createDate":          llx.TimeDataPtr(instanceProfile.CreateDate),
+			"createdAt":           llx.TimeDataPtr(instanceProfile.CreateDate),
 			"instanceProfileId":   llx.StringDataPtr(instanceProfile.InstanceProfileId),
 			"instanceProfileName": llx.StringDataPtr(instanceProfile.InstanceProfileName),
 			// "roles":               llx.MapDataPtr(instanceProfile.Roles),
@@ -354,6 +355,7 @@ func (a *mqlAwsIam) createIamUser(usr *iamtypes.User) (plugin.Resource, error) {
 			"id":               llx.StringDataPtr(usr.UserId),
 			"name":             llx.StringDataPtr(usr.UserName),
 			"createDate":       llx.TimeDataPtr(usr.CreateDate),
+			"createdAt":        llx.TimeDataPtr(usr.CreateDate),
 			"passwordLastUsed": llx.TimeDataPtr(usr.PasswordLastUsed),
 			"tags":             llx.MapData(iamTagsToMap(usr.Tags), types.String),
 		},
@@ -543,6 +545,7 @@ func (a *mqlAwsIam) roles() ([]interface{}, error) {
 					"description":              llx.StringDataPtr(role.Description),
 					"tags":                     llx.MapData(iamTagsToMap(role.Tags), types.String),
 					"createDate":               llx.TimeDataPtr(role.CreateDate),
+					"createdAt":                llx.TimeDataPtr(role.CreateDate),
 					"assumeRolePolicyDocument": llx.MapData(policyDocumentMap, types.Any),
 				})
 			if err != nil {
@@ -793,6 +796,10 @@ func (a *mqlAwsIamUsercredentialreportentry) user() (*mqlAwsIamUser, error) {
 	return mqlUser.(*mqlAwsIamUser), nil
 }
 
+func (a *mqlAwsIamUsercredentialreportentry) createdAt() (*time.Time, error) {
+	return a.getTimeValue("user_creation_time")
+}
+
 func (a *mqlAwsIamUsercredentialreportentry) userCreationTime() (*time.Time, error) {
 	return a.getTimeValue("user_creation_time")
 }
@@ -835,6 +842,7 @@ func initAwsIamUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 			args["id"] = llx.StringDataPtr(usr.UserId)
 			args["name"] = llx.StringDataPtr(usr.UserName)
 			args["createDate"] = llx.TimeDataPtr(usr.CreateDate)
+			args["createdAt"] = llx.TimeDataPtr(usr.CreateDate)
 			args["passwordLastUsed"] = llx.TimeDataPtr(usr.PasswordLastUsed)
 			args["tags"] = llx.MapData(iamTagsToMap(usr.Tags), types.String)
 
@@ -1046,6 +1054,16 @@ func (a *mqlAwsIamPolicy) createDate() (*time.Time, error) {
 	return policy.CreateDate, nil
 }
 
+func (a *mqlAwsIamPolicy) createdAt() (*time.Time, error) {
+	arn := a.Arn.Data
+
+	policy, err := a.loadPolicy(arn)
+	if err != nil {
+		return nil, err
+	}
+	return policy.CreateDate, nil
+}
+
 func (a *mqlAwsIamPolicy) updateDate() (*time.Time, error) {
 	arn := a.Arn.Data
 
@@ -1217,6 +1235,7 @@ func (a *mqlAwsIamPolicy) defaultVersion() (*mqlAwsIamPolicyversion, error) {
 					"versionId":        llx.StringDataPtr(policyversion.VersionId),
 					"isDefaultVersion": llx.BoolData(policyversion.IsDefaultVersion),
 					"createDate":       llx.TimeDataPtr(policyversion.CreateDate),
+					"createdAt":        llx.TimeDataPtr(policyversion.CreateDate),
 				})
 			if err != nil {
 				return nil, err
@@ -1250,6 +1269,7 @@ func (a *mqlAwsIamPolicy) versions() ([]interface{}, error) {
 				"versionId":        llx.StringDataPtr(policyversion.VersionId),
 				"isDefaultVersion": llx.BoolData(policyversion.IsDefaultVersion),
 				"createDate":       llx.TimeDataPtr(policyversion.CreateDate),
+				"createdAt":        llx.TimeDataPtr(policyversion.CreateDate),
 			})
 		if err != nil {
 			return nil, err
@@ -1356,6 +1376,7 @@ func initAwsIamRole(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 		args["description"] = llx.StringDataPtr(role.Description)
 		args["tags"] = llx.MapData(iamTagsToMap(role.Tags), types.String)
 		args["createDate"] = llx.TimeDataPtr(role.CreateDate)
+		args["createdAt"] = llx.TimeDataPtr(role.CreateDate)
 		args["assumeRolePolicyDocument"] = llx.MapData(policyDocumentMap, types.Any)
 		return args, nil, nil
 	}
@@ -1404,6 +1425,7 @@ func initAwsIamGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		args["id"] = llx.StringDataPtr(grp.GroupId)
 		args["name"] = llx.StringDataPtr(grp.GroupName)
 		args["createDate"] = llx.TimeDataPtr(grp.CreateDate)
+		args["createdAt"] = llx.TimeDataPtr(grp.CreateDate)
 		args["usernames"] = llx.ArrayData(usernames, types.String)
 		return args, nil, nil
 	}
@@ -1526,6 +1548,7 @@ func initAwsIamInstanceProfile(runtime *plugin.Runtime, args map[string]*llx.Raw
 		res, err := CreateResource(runtime, "aws.iam.instanceProfile", map[string]*llx.RawData{
 			"arn":                 llx.StringDataPtr(ip.Arn),
 			"createDate":          llx.TimeDataPtr(ip.CreateDate),
+			"createdAt":           llx.TimeDataPtr(ip.CreateDate),
 			"instanceProfileId":   llx.StringDataPtr(ip.InstanceProfileId),
 			"instanceProfileName": llx.StringDataPtr(ip.InstanceProfileName),
 			"tags":                llx.MapData(iamTagsToMap(ip.Tags), types.String),


### PR DESCRIPTION
createdAt is what Amazon uses in most of their SDK. Some of the older APIs use different values and in many cases we copied those over into our resources. This continues the work to unify all of the AWS resources on createdAt so it's easier to explore fields on resources without looking at the docs.

```
aws.iam.policies.first: {
  createdAt: 2022-11-27 13:27:54 -0800 PST
}

aws.iam.users.first: {
  createdAt: 2021-06-15 00:18:34 -0700 PDT
}

aws.iam.credentialReport.first: {
  createdAt: 2019-11-08 06:02:45 -0800 PST
}

aws.iam.instanceProfiles.first: {
  createdAt: 2024-07-22 11:57:13 -0700 PDT
}

aws.iam.policies.first.versions: [
  0: {
    createdAt: 2023-05-03 22:29:29 -0700 PDT
  }
  1: {
    createdAt: 2022-11-27 13:27:54 -0800 PST
  }
]

aws.iam.roles.first: {
  createdAt: 2024-06-27 13:10:34 -0700 PDT
}
```