### PR TITLE
Improve the MQL resource pack docs generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -634,7 +634,7 @@ lr/docs/markdown: providers/lr
 		--docs-file providers/snowflake/resources/snowflake.lr.manifest.yaml \
 		--output ../docs/docs/mql/resources/snowflake-pack
 	./lr markdown providers/mondoo/resources/mondoo.lr \
-		--pack-name "Mondoo" \
+		--pack-name "Mondoo Platform" \
 		--description "The Mondoo resource pack lets you interact with Mondoo Platform and its assets and resources." \
 		--docs-file providers/mondoo/resources/mondoo.lr.manifest.yaml \
 		--output ../docs/docs/mql/resources/mondoo-pack

--- a/providers-sdk/v1/lr/cli/cmd/markdown.go
+++ b/providers-sdk/v1/lr/cli/cmd/markdown.go
@@ -171,7 +171,7 @@ func (l *lrSchemaRenderer) renderToc(packName string, description string, resour
 	builder.WriteString("\n")
 
 	// render content
-	builder.WriteString("# Mondoo " + packName + " Resource Pack Reference\n\n")
+	builder.WriteString("# " + packName + " MQL Resource Pack Reference\n\n")
 	builder.WriteString(description + "\n\n")
 	builder.WriteString("Resources included in this pack:\n\n")
 	rows := [][]string{}


### PR DESCRIPTION
- Rename the Mondoo pack to be Mondoo Platform so it's more clear what this does
- Avoid `Mondoo Mondoo Platform` by renaming the pack headers