### PR TITLE
⭐️ human readable impact value

### DIFF
--- a/explorer/impact.go
+++ b/explorer/impact.go
@@ -14,10 +14,10 @@ import (
 // Impact represents severity rating scale when impact is provided as human-readable string value
 var impactMapping = map[string]int32{
 	"none":     0,
-	"low":      10,
-	"medium":   40,
-	"high":     70,
-	"critical": 100,
+	"low":      20,
+	"medium":   55,
+	"high":     80,
+	"critical": 95,
 }
 
 func (v *Impact) HumanReadable() string {

--- a/explorer/impact_test.go
+++ b/explorer/impact_test.go
@@ -38,14 +38,14 @@ func TestImpactParsing(t *testing.T) {
 			"critical rating",
 			`"critical"`,
 			&Impact{
-				Value: &ImpactValue{Value: 100},
+				Value: &ImpactValue{Value: 95},
 			},
 		},
 		{
 			"low rating",
 			`"low"`,
 			&Impact{
-				Value: &ImpactValue{Value: 10},
+				Value: &ImpactValue{Value: 20},
 			},
 		},
 	}

--- a/explorer/impact_test.go
+++ b/explorer/impact_test.go
@@ -34,6 +34,20 @@ func TestImpactParsing(t *testing.T) {
 				Value:  &ImpactValue{Value: 40},
 			},
 		},
+		{
+			"critical rating",
+			`"critical"`,
+			&Impact{
+				Value: &ImpactValue{Value: 100},
+			},
+		},
+		{
+			"low rating",
+			`"low"`,
+			&Impact{
+				Value: &ImpactValue{Value: 10},
+			},
+		},
 	}
 
 	for i := range tests {
@@ -70,6 +84,11 @@ func TestImpactParsing(t *testing.T) {
 			"invalid high impact in complex struct",
 			`{"value": 101, "weight": 90}`,
 			"impact must be between 0 and 100",
+		},
+		{
+			"invalid string value",
+			`"mycustomcritical"`,
+			"impact must use critical, high, medium, low or none",
 		},
 	}
 


### PR DESCRIPTION
Previously we only supported int values for query impacts, see https://github.com/mondoohq/cnspec-policies/blob/main/core/mondoo-linux-security.mql.yaml#L344

```yaml
  - uid: mondoo-linux-security-address-space-layout-randomization-aslr-is-enabled
    title: Ensure address space layout randomization (ASLR) is enabled
    impact: 90
    filters: |
      asset.kind != "container-image"
      asset.runtime != "docker-container"
    mql: |
      kernel.parameters["kernel.randomize_va_space"] == 2
```

With this change, we can also use typical ratings which makes it easier for users to read the values:

```yaml
  - uid: mondoo-linux-security-address-space-layout-randomization-aslr-is-enabled
    title: Ensure address space layout randomization (ASLR) is enabled
    impact: "critical"
    filters: |
      asset.kind != "container-image"
      asset.runtime != "docker-container"
    mql: |
      kernel.parameters["kernel.randomize_va_space"] == 2
```