### PR TITLE
Add init for aws.rds.dbcluster

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2092,7 +2092,7 @@ private aws.rds.backupsetting {
 }
 
 // Amazon RDS database cluster
-private aws.rds.dbcluster @defaults("id region") {
+private aws.rds.dbcluster @defaults("id region engine engineVersion") {
   // ARN for the database cluster
   arn string
   // Region where the database cluster exists

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2092,7 +2092,7 @@ private aws.rds.backupsetting {
 }
 
 // Amazon RDS database cluster
-private aws.rds.dbcluster @defaults("id region engine engineVersion") {
+aws.rds.dbcluster @defaults("id region engine engineVersion") {
   // ARN for the database cluster
   arn string
   // Region where the database cluster exists
@@ -2206,7 +2206,7 @@ private aws.rds.snapshot @defaults("id region type encrypted createdAt") {
 }
 
 // Amazon RDS database instance
-private aws.rds.dbinstance @defaults("id region engine engineVersion") {
+aws.rds.dbinstance @defaults("id region engine engineVersion") {
   // ARN for the database instance
   arn string
   // Identifier for the database instance

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -523,7 +523,7 @@ func init() {
 			Create: createAwsRdsBackupsetting,
 		},
 		"aws.rds.dbcluster": {
-			// to override args, implement: initAwsRdsDbcluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init: initAwsRdsDbcluster,
 			Create: createAwsRdsDbcluster,
 		},
 		"aws.rds.snapshot": {


### PR DESCRIPTION
Makes this resource work with the asset discover

```
cnquery> aws.rds.dbcluster{*}
aws.rds.dbcluster: {
  hostedZoneId: "1234"
  preferredBackupWindow: "08:29-08:59"
  region: "us-west-2"
  tags: {}
  id: "tim-cluster"
  createdTime: 2024-12-31 22:48:02.639 -0800 PST
  members: [
    0: aws.rds.dbinstance id="tim-cluster-instance-1" region="us-west-2" engine="aurora-postgresql" engineVersion="15.4"
  ]
  activityStreamMode: ""
  iamDatabaseAuthentication: false
  port: 5432
  availabilityZones: [
    0: "us-west-2a"
    1: "us-west-2b"
    2: "us-west-2d"
  ]
  storageAllocated: 1
  autoMinorVersionUpgrade: true
  engineLifecycleSupport: "open-source-rds-extended-support-disabled"
  storageType: null
  securityGroups: [
    0: aws.ec2.securitygroup id="sg-1234" name="default" region="us-west-2" vpc.id="vpc-ffa59787"
  ]
  storageIops: 0
  backupRetentionPeriod: 7
  latestRestorableTime: 2025-01-01 00:05:51.236 -0800 PST
  certificateAuthority: null
  storageEncrypted: true
  monitoringInterval: 60
  backupSettings: [
    0: aws.rds.backupsetting id = tim-cluster
  ]
  createdAt: 2024-12-31 22:48:02.639 -0800 PST
  multiAZ: false
  engine: "aurora-postgresql"
  status: "available"
  snapshots: []
  publiclyAccessible: null
  preferredMaintenanceWindow: "sun:11:45-sun:12:15"
  certificateExpiresAt: null
  endpoint: "tim-cluster.cluster-cvpi3ygjru5b.us-west-2.rds.amazonaws.com"
  arn: "arn:aws:rds:us-west-2:1234:cluster:tim-cluster"
  clusterDbInstanceClass: null
  engineVersion: "15.4"
  networkType: "IPV4"
  deletionProtection: false
  masterUsername: "postgres"
  activityStreamStatus: "stopped"
}
```