### PR TITLE
🧹 add cloudflare to default providers

### DIFF
--- a/providers/defaults.go
+++ b/providers/defaults.go
@@ -101,6 +101,21 @@ var DefaultProviders Providers = map[string]*Provider{
 		},
 	},
 
+	"cloudflare": {
+		Provider: &plugin.Provider{
+			Name:            "cloudflare",
+			ID:              "go.mondoo.com/cnquery/v11/providers/cloudflare",
+			ConnectionTypes: []string{"cloudflare"},
+			Connectors: []plugin.Connector{
+				{
+					Name:  "cloudflare",
+					Use:   "cloudflare",
+					Short: "Cloudflare provider",
+				},
+			},
+		},
+	},
+
 	"core": {
 		Provider: &plugin.Provider{
 			Name:            "core",


### PR DESCRIPTION
Adds cloudflare to the default provider.

```
cnquery run cloudflare -c "cloudflare.zones[1] { name dns { * } }"
→ installing provider 'cloudflare' version=11.0.5
→ successfully installed cloudflare provider path=/Users/chris/.config/mondoo/providers/cloudflare version=11.0.5
→ loaded configuration from /Users/chris/.config/mondoo/mondoo.yml using source default
```