### PR TITLE
feat: keep block devices mounted option

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -313,6 +313,12 @@ var Config = plugin.Provider{
 					Option: plugin.FlagOption_Hidden,
 				},
 				{
+					Long:   "keep-mounted",
+					Type:   plugin.FlagType_Bool,
+					Desc:   "Keep mounted block devices mounted after the scan",
+					Option: plugin.FlagOption_Hidden,
+				},
+				{
 					Long:   "platform-ids",
 					Type:   plugin.FlagType_List,
 					Desc:   "List of platform IDs to inject to the asset",

--- a/providers/os/connection/device/device_connection.go
+++ b/providers/os/connection/device/device_connection.go
@@ -140,7 +140,7 @@ func NewDeviceConnection(connId uint32, conf *inventory.Config, asset *inventory
 	}
 
 	// if none of the blocks returned a platform that we could detect, we return an error
-	if asset.Platform == nil {
+	if asset.Platform == nil && !skipAssetDetection {
 		res.Close()
 		return nil, errors.New("device connection> no platform detected")
 	}

--- a/providers/os/connection/device/device_connection.go
+++ b/providers/os/connection/device/device_connection.go
@@ -24,7 +24,10 @@ import (
 	"go.mondoo.com/cnquery/v11/providers/os/id/ids"
 )
 
-const PlatformIdInject = "inject-platform-ids"
+const (
+	PlatformIdInject = "inject-platform-ids"
+	KeepMounted      = "keep-mounted"
+)
 
 type DeviceConnection struct {
 	*fs.FileSystemConnection
@@ -139,7 +142,7 @@ func (c *DeviceConnection) Close() {
 		return
 	}
 
-	if c.deviceManager != nil {
+	if c.deviceManager != nil && c.Conf().Options[KeepMounted] != "true" {
 		c.deviceManager.UnmountAndClose()
 	}
 }

--- a/providers/os/connection/device/device_connection.go
+++ b/providers/os/connection/device/device_connection.go
@@ -39,6 +39,9 @@ type DeviceConnection struct {
 	MountedDirs []string
 	// map of mountpoints to partition infos
 	partitions map[string]*snapshot.PartitionInfo
+
+	// whether to keep the devices mounted after the connection is closed
+	keepMounted bool
 }
 
 func getDeviceManager(conf *inventory.Config) (DeviceManager, error) {
@@ -89,6 +92,7 @@ func NewDeviceConnection(connId uint32, conf *inventory.Config, asset *inventory
 	if conf.Options == nil {
 		conf.Options = make(map[string]string)
 	}
+	res.keepMounted = conf.Options[KeepMounted] == "true"
 
 	if len(asset.IdDetector) == 0 {
 		asset.IdDetector = []string{ids.IdDetector_Hostname, ids.IdDetector_SshHostkey}
@@ -150,7 +154,7 @@ func (c *DeviceConnection) Close() {
 		return
 	}
 
-	if c.deviceManager != nil && c.Conf().Options[KeepMounted] != "true" {
+	if c.deviceManager != nil && !c.keepMounted {
 		c.deviceManager.UnmountAndClose()
 	}
 }

--- a/providers/os/connection/device/device_connection.go
+++ b/providers/os/connection/device/device_connection.go
@@ -25,8 +25,9 @@ import (
 )
 
 const (
-	PlatformIdInject = "inject-platform-ids"
-	KeepMounted      = "keep-mounted"
+	PlatformIdInject   = "inject-platform-ids"
+	KeepMounted        = "keep-mounted"
+	SkipAssetDetection = "skip-asset-detection"
 )
 
 type DeviceConnection struct {
@@ -95,6 +96,8 @@ func NewDeviceConnection(connId uint32, conf *inventory.Config, asset *inventory
 
 	res.partitions = make(map[string]*snapshot.PartitionInfo)
 
+	skipAssetDetection := conf.Options[SkipAssetDetection] == "true"
+
 	// we iterate over all the blocks and try to run OS detection on each one of them
 	// we only return one asset, if we find the right block (e.g. the one with the root FS)
 	for _, block := range blocks {
@@ -117,6 +120,11 @@ func NewDeviceConnection(connId uint32, conf *inventory.Config, asset *inventory
 
 		if asset.Platform != nil {
 			log.Debug().Msg("device connection> asset already detected, skipping")
+			continue
+		}
+
+		if skipAssetDetection {
+			log.Debug().Msg("device connection> skipping asset detection as requested")
 			continue
 		}
 

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -252,6 +252,9 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	if includeMounted, ok := flags["include-mounted"]; ok {
 		conf.Options["include-mounted"] = strconv.FormatBool(includeMounted.RawData().Value.(bool))
 	}
+	if keepMounted, ok := flags["keep-mounted"]; ok {
+		conf.Options["keep-mounted"] = strconv.FormatBool(keepMounted.RawData().Value.(bool))
+	}
 
 	if platformIDs, ok := flags["platform-ids"]; ok {
 		platformIDs := platformIDs.Array


### PR DESCRIPTION
+ skip asset detection option for the connections, that reuse device connection for blocks mounting, but have their own asset