### PR TITLE
🧹 add query in panic when compiling

### DIFF
--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -5,6 +5,7 @@ package mqlc
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 	"sort"
 	"strconv"
@@ -2180,6 +2181,12 @@ func compile(input string, props map[string]*llx.Primitive, compilerConf Compile
 func Compile(input string, props map[string]*llx.Primitive, conf CompilerConfig) (*llx.CodeBundle, error) {
 	// Note: we do not check the conf because it will get checked by the
 	// first CompileAST call. Do not use it earlier or add a check.
+	defer func() {
+		if r := recover(); r != nil {
+			errNew := fmt.Errorf("panic compiling %q: %v", input, r)
+			panic(errNew)
+		}
+	}()
 
 	res, err := compile(input, props, conf)
 	if err != nil {


### PR DESCRIPTION
```
panic: something bad [recovered]
	panic: panic compiling "asset { kind platform runtime version family }": something bad

goroutine 1 [running]:
go.mondoo.com/cnquery/v11/mqlc.Compile.func1()
	/home/jaym/workspace/mondoo/cnquery/mqlc/mqlc.go:2189 +0xb3
panic({0x256d240?, 0x30aef10?})
	/usr/lib/go/src/runtime/panic.go:785 +0x132
go.mondoo.com/cnquery/v11/mqlc.compile({0x2c3a735?, 0xc000a5fcf0?}, 0x0, {{0x30ec1f0, 0xc000742290}, 0x0, {0x30fa3d8, 0x49908a0}})
	/home/jaym/workspace/mondoo/cnquery/mqlc/mqlc.go:2177 +0x248
go.mondoo.com/cnquery/v11/mqlc.Compile({0x2c3a735?, 0x2?}, 0x2?, {{0x30ec1f0, 0xc000742290}, 0x0, {0x30fa3d8, 0x49908a0}})
	/home/jaym/workspace/mondoo/cnquery/mqlc/mqlc.go:2193 +0xbe
go.mondoo.com/cnquery/v11/explorer/executor.MustCompile({0x2c3a735, 0x2e})
	/home/jaym/workspace/mondoo/cnquery/explorer/executor/mustcompile.go:14 +0xf3
go.mondoo.com/cnspec/v11/policy/scan.init()
	/home/jaym/workspace/mondoo/cnspec/policy/scan/local_scanner.go:900 +0x25
exit status 2
```