### PR TITLE
✨ Simplify retrieval of devices via logical unit numbers.

### DIFF
--- a/providers/os/connection/device/device_connection.go
+++ b/providers/os/connection/device/device_connection.go
@@ -77,10 +77,11 @@ func NewDeviceConnection(connId uint32, conf *inventory.Config, asset *inventory
 
 	blocks, err := manager.IdentifyMountTargets(conf.Options)
 	if err != nil {
-		return nil, err
+		log.Warn().Err(err).Msg("device connection> unable to identify some mount targets, proceeding with the rest")
 	}
+
 	if len(blocks) == 0 {
-		return nil, errors.New("device connection> internal: blocks found")
+		return nil, errors.New("device connection> no blocks found, cannot perform a scan")
 	}
 
 	res := &DeviceConnection{

--- a/providers/os/connection/device/windows/device_manager.go
+++ b/providers/os/connection/device/windows/device_manager.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	LunOption          = "lun"
+	LunsOption         = "luns"
 	SerialNumberOption = "serial-number"
 )
 
@@ -91,14 +92,14 @@ func (d *WindowsDeviceManager) IdentifyMountTargets(opts map[string]string) ([]*
 
 // validates the options provided to the device manager
 func validateOpts(opts map[string]string) error {
-	lun := opts[LunOption]
-	serialNumber := opts[SerialNumberOption]
+	lunPresent := opts[LunOption] != "" || opts[LunsOption] != ""
+	serialNumberPresent := opts[SerialNumberOption] != ""
 
-	if lun != "" && serialNumber != "" {
+	if lunPresent && serialNumberPresent {
 		return errors.New("lun and serial-number are mutually exclusive options")
 	}
 
-	if lun == "" && serialNumber == "" {
+	if !lunPresent && !serialNumberPresent {
 		return errors.New("either lun or serial-number must be provided")
 	}
 

--- a/providers/os/connection/device/windows/device_manager_test.go
+++ b/providers/os/connection/device/windows/device_manager_test.go
@@ -18,6 +18,14 @@ func TestValidateOpts(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("valid (only LUNS)", func(t *testing.T) {
+		opts := map[string]string{
+			LunsOption: "0,1,2",
+		}
+		err := validateOpts(opts)
+		require.NoError(t, err)
+	})
+
 	t.Run("valid (only serial number)", func(t *testing.T) {
 		opts := map[string]string{
 			SerialNumberOption: "0",
@@ -29,7 +37,7 @@ func TestValidateOpts(t *testing.T) {
 	t.Run("invalid (both LUN and serial number are provided", func(t *testing.T) {
 		opts := map[string]string{
 			SerialNumberOption: "1234",
-			LunOption:          "1",
+			LunsOption:         "1",
 		}
 		err := validateOpts(opts)
 		require.Error(t, err)


### PR DESCRIPTION
Do not fetch devices by lun. Instead fetch the matching device names, that way we ensure there's only one code path for fetching devices which is via their name