### PR TITLE
🐛 don't wait indefinitely when testing tls

### DIFF
--- a/providers/network/resources/tlsshake/tlsshake.go
+++ b/providers/network/resources/tlsshake/tlsshake.go
@@ -231,6 +231,9 @@ func (s *Tester) testTLS(proto string, target string, conf *ScanConfig) (int, er
 	if err != nil {
 		return 0, multierr.Wrap(err, "failed to connect to target")
 	}
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		return 0, err
+	}
 	defer conn.Close()
 
 	msg, cipherCount, err := s.helloTLSMsg(conf)


### PR DESCRIPTION
The current code can wait indefinitely if nothing gets sent over the network socket. I added a deadline to make sure if nothing comes back within 5s we just timeout.
