### PR TITLE
Replace repo-level token with GH App

### DIFF
--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -188,10 +188,18 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ ! inputs.skip_publish }}
     steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.MONDOO_CHECKOUT_APP_ID }}
+          private-key: ${{ secrets.MONDOO_CHECKOUT_APP_PRIVATE_KEY }}
+          owner: mondoohq
+          repositories: |
       - name: Trigger Reindex of releases.mondoo.com
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.RELEASR_ACTION_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           repository: "mondoohq/releasr"
           event-type: reindex
           client-payload: '{ }'

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -196,6 +196,7 @@ jobs:
           private-key: ${{ secrets.MONDOO_CHECKOUT_APP_PRIVATE_KEY }}
           owner: mondoohq
           repositories: |
+            releasr
       - name: Trigger Reindex of releases.mondoo.com
         uses: peter-evans/repository-dispatch@v3
         with:


### PR DESCRIPTION
RELEASR_ACTION_TOKEN seems to have expired: `Error: Bad credentials`