### PR TITLE
⚡️ filtered resources: `microsoft.users` & `microsoft.roles`

### DIFF
--- a/providers/ms365/resources/api_query_parameters.go
+++ b/providers/ms365/resources/api_query_parameters.go
@@ -1,0 +1,76 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.mondoo.com/cnquery/v11/llx"
+)
+
+// newListResourceIdFromArguments generates a new __id for a list resource that has query
+// parameters `filter` and/or `search`. We need to use these parameters as the resource id
+// so that different query parameters, or no parameter, create different resources.
+//
+// If none is set, the default id returned is `all`
+func newListResourceIdFromArguments(resourceName string, args map[string]*llx.RawData) *llx.RawData {
+	filter, filterExist := args["filter"]
+	search, searchExist := args["search"]
+
+	if filterExist || searchExist {
+		id := resourceName
+		if filterExist {
+			id += fmt.Sprintf("/filter-%s", filter.Value.(string))
+		}
+		if searchExist {
+			id += fmt.Sprintf("/search-%s", search.Value.(string))
+		}
+		return llx.StringData(id)
+	}
+
+	return llx.StringData(resourceName + "/all")
+}
+
+// parseSearch tries to help the user understand the format of Microsoft API searches.
+// By default, if the user runs a simple search of one field, we scape it for them,
+// though if more complicated searches with ANDs/ORs are provided, we let the user know
+// that they need to scape the query on their own.
+//
+// Simple search:
+//
+//	resource(search: "property:my value goes here")
+//
+// Multiple fields search:
+//
+//	resource(search: '"property1:one value" and "property2:something else and complex"')
+func parseSearch(search string) (string, error) {
+	if !strings.Contains(search, ":") {
+		return "", errors.New("search is not of right format: \"property:value\"")
+	}
+
+	if strings.Contains(search, "\"") {
+		// the search filter is already scaped
+		return search, nil
+	}
+
+	if len(strings.Split(search, ":")) > 2 {
+		// special case for multi field search like `displayName:foo or mail:bar`
+		// witout scaping the filters on their own
+		return "", errors.New("search with multiple fields is not of right format: " +
+			"'\"property:value\" [AND | OR] \"property:value\"'")
+	}
+
+	// scape simple search filter like: `displayName:my name`
+	return fmt.Sprintf("\"%s\"", search), nil
+}
+
+// We do not have a parseFilter function since those query parameters can be passed as is,
+// and the APIs return helpful information to the user.
+//
+// https://learn.microsoft.com/en-us/graph/filter-query-parameter?tabs=http#filter-using-lambda-operators
+// func parseFilter(search string) (string, error) {
+// return "", nil
+// }

--- a/providers/ms365/resources/applications.go
+++ b/providers/ms365/resources/applications.go
@@ -30,12 +30,14 @@ func (a *mqlMicrosoft) applications() ([]interface{}, error) {
 		return nil, err
 	}
 	ctx := context.Background()
+
 	top := int32(500)
-	resp, err := graphClient.Applications().Get(ctx, &applications.ApplicationsRequestBuilderGetRequestConfiguration{
+	opts := &applications.ApplicationsRequestBuilderGetRequestConfiguration{
 		QueryParameters: &applications.ApplicationsRequestBuilderGetQueryParameters{
 			Top: &top,
 		},
-	})
+	}
+	resp, err := graphClient.Applications().Get(ctx, opts)
 	if err != nil {
 		return nil, transformError(err)
 	}

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -11,7 +11,7 @@ microsoft {
   // Deprecated: use `microsoft.tenant` instead
   organizations() []microsoft.tenant
   // List of users
-  users() []microsoft.user
+  users() microsoft.users
   // List of groups
   groups() []microsoft.group
   // List of domains
@@ -23,7 +23,7 @@ microsoft {
   // List of enterprise applications
   enterpriseApplications() []microsoft.serviceprincipal
   // List of roles
-  roles() []microsoft.rolemanagement.roledefinition
+  roles() microsoft.roles
   // Microsoft 365 settings
   settings() dict
   // The connected tenant's default domain name
@@ -54,6 +54,17 @@ microsoft.tenant @defaults("name") {
   type string
   // Commercial subscription
   subscriptions() []dict
+}
+
+// List of Microsoft Entra users with optional filters
+microsoft.users {
+  []microsoft.user
+
+  init(filter? string, search? string)
+  // Filter users by property values
+  filter string
+  // Search users by search phrases
+  search string
 }
 
 // Microsoft Conditional Access Policies
@@ -571,11 +582,21 @@ microsoft.policies {
   consentPolicySettings() dict
 }
 
+// List of Microsoft Entra role definitions with optional filters
+microsoft.roles {
+  []microsoft.rolemanagement.roledefinition
+
+  init(filter? string, search? string)
+  // Filter roles by property values
+  filter string
+  // Search roles by search phrases
+  search string
+}
 
 // Deprecated: use `microsoft.roles` instead
 microsoft.rolemanagement {
   // Deprecated: use `microsoft.roles` instead
-  roleDefinitions() []microsoft.rolemanagement.roledefinition
+  roleDefinitions() microsoft.roles
 }
 
 // Microsoft role definition

--- a/providers/ms365/resources/ms365.lr.manifest.yaml
+++ b/providers/ms365/resources/ms365.lr.manifest.yaml
@@ -5,102 +5,59 @@ resources:
   microsoft:
     fields:
       applications: {}
-      conditionalAccess:
-        min_mondoo_version: 9.0.0
       domains: {}
-      enterpriseApplications:
-        min_mondoo_version: latest
+      enterpriseApplications: {}
       groups: {}
       organizations: {}
-      roles:
-        min_mondoo_version: 9.0.0
+      roles: {}
       serviceprincipals: {}
       settings: {}
-      tenantDomainName:
-        min_mondoo_version: latest
+      tenantDomainName: {}
       users: {}
-    min_mondoo_version: 5.15.0
+    min_mondoo_version: 9.0.0
   microsoft.application:
     fields:
-      api:
-        min_mondoo_version: 9.0.0
+      api: {}
       appId: {}
-      appRoles:
-        min_mondoo_version: 9.0.0
-      applicationTemplateId:
-        min_mondoo_version: 9.0.0
-      certificates:
-        min_mondoo_version: 9.0.0
-      certification:
-        min_mondoo_version: 9.0.0
-      createdAt:
-        min_mondoo_version: 9.0.0
+      appRoles: {}
+      applicationTemplateId: {}
+      certificates: {}
+      certification: {}
+      createdAt: {}
       createdDateTime: {}
-      defaultRedirectUri:
-        min_mondoo_version: 9.0.0
-      description:
-        min_mondoo_version: 9.0.0
-      dict:
-        min_mondoo_version: 9.0.0
-      disabledByMicrosoftStatus:
-        min_mondoo_version: 9.0.0
+      defaultRedirectUri: {}
+      description: {}
+      disabledByMicrosoftStatus: {}
       displayName: {}
-      groupMembershipClaims:
-        min_mondoo_version: 9.0.0
-      hasExpiredCredentials:
-        min_mondoo_version: 9.0.0
+      groupMembershipClaims: {}
+      hasExpiredCredentials: {}
       id: {}
       identifierUris: {}
-      info:
-        min_mondoo_version: 9.0.0
-      isDeviceOnlyAuthSupported:
-        min_mondoo_version: 9.0.0
-      isFallbackPublicClient:
-        min_mondoo_version: 9.0.0
-      name:
-        min_mondoo_version: 9.0.0
-      nativeAuthenticationApisEnabled:
-        min_mondoo_version: 9.0.0
-      notes:
-        min_mondoo_version: 9.0.0
-      optionalClaims:
-        min_mondoo_version: 9.0.0
-      owners:
-        min_mondoo_version: 9.0.0
-      parentalControlSettings:
-        min_mondoo_version: 9.0.0
-      publicClient:
-        min_mondoo_version: 9.0.0
+      info: {}
+      isDeviceOnlyAuthSupported: {}
+      isFallbackPublicClient: {}
+      name: {}
+      nativeAuthenticationApisEnabled: {}
+      notes: {}
+      optionalClaims: {}
+      owners: {}
+      parentalControlSettings: {}
+      publicClient: {}
       publisherDomain: {}
-      requestSignatureVerification:
-        min_mondoo_version: 9.0.0
-      requiredResourceAccess:
-        min_mondoo_version: 9.0.0
-      samlMetadataUrl:
-        min_mondoo_version: 9.0.0
-      secrets:
-        min_mondoo_version: 9.0.0
-      serviceManagementReference:
-        min_mondoo_version: 9.0.0
-      servicePrincipal:
-        min_mondoo_version: 9.0.0
-      servicePrincipalLockConfiguration:
-        min_mondoo_version: 9.0.0
+      requestSignatureVerification: {}
+      samlMetadataUrl: {}
+      secrets: {}
+      serviceManagementReference: {}
+      servicePrincipal: {}
+      servicePrincipalLockConfiguration: {}
       signInAudience: {}
-      spa:
-        min_mondoo_version: 9.0.0
-      string:
-        min_mondoo_version: 9.0.0
-      tags:
-        min_mondoo_version: 9.0.0
-      tokenEncryptionKeyId:
-        min_mondoo_version: 9.0.0
-      web:
-        min_mondoo_version: 9.0.0
-    min_mondoo_version: 5.15.0
+      spa: {}
+      tags: {}
+      tokenEncryptionKeyId: {}
+      web: {}
+    min_mondoo_version: 9.0.0
   microsoft.application.permission:
     fields:
-      adminConsent: {}
       appId: {}
       appName: {}
       description: {}
@@ -143,7 +100,7 @@ resources:
     fields:
       deviceCompliancePolicies: {}
       deviceConfigurations: {}
-    min_mondoo_version: 5.15.0
+    min_mondoo_version: 9.0.0
   microsoft.devicemanagement.devicecompliancepolicy:
     fields:
       assignments: {}
@@ -155,7 +112,7 @@ resources:
       properties: {}
       version: {}
     is_private: true
-    min_mondoo_version: 5.15.0
+    min_mondoo_version: 9.0.0
   microsoft.devicemanagement.deviceconfiguration:
     fields:
       createdDateTime: {}
@@ -166,7 +123,7 @@ resources:
       properties: {}
       version: {}
     is_private: true
-    min_mondoo_version: 5.15.0
+    min_mondoo_version: 9.0.0
   microsoft.domain:
     fields:
       authenticationType: {}
@@ -182,7 +139,7 @@ resources:
       serviceConfigurationRecords: {}
       supportedServices: {}
     is_private: true
-    min_mondoo_version: 5.15.0
+    min_mondoo_version: 9.0.0
   microsoft.domaindnsrecord:
     fields:
       id: {}
@@ -193,60 +150,36 @@ resources:
       supportedService: {}
       ttl: {}
     is_private: true
-    min_mondoo_version: 5.15.0
-  microsoft.enterpriseApplication:
-    fields:
-      id: {}
-      name: {}
-      tags: {}
-      type: {}
-    min_mondoo_version: latest
+    min_mondoo_version: 9.0.0
   microsoft.group:
     fields:
       displayName: {}
-      groupTypes:
-        min_mondoo_version: 9.0.0
+      groupTypes: {}
       id: {}
       mail: {}
       mailEnabled: {}
       mailNickname: {}
       members: {}
-      membershipRule:
-        min_mondoo_version: 9.0.0
-      membershipRuleProcessingState:
-        min_mondoo_version: 9.0.0
+      membershipRule: {}
+      membershipRuleProcessingState: {}
       securityEnabled: {}
-      visibility:
-        min_mondoo_version: 9.0.0
+      visibility: {}
     is_private: true
-    min_mondoo_version: 5.15.0
+    min_mondoo_version: 9.0.0
   microsoft.keyCredential:
     fields:
       description: {}
-      displayName: {}
       expired: {}
       expires: {}
-      hint: {}
       keyId: {}
       thumbprint: {}
       type: {}
       usage: {}
     is_private: true
     min_mondoo_version: 9.0.0
-  microsoft.organization:
-    fields:
-      assignedPlans: {}
-      createdDateTime: {}
-      displayName: {}
-      id: {}
-      onPremisesSyncEnabled:
-        min_mondoo_version: 9.0.0
-      verifiedDomains: {}
-    min_mondoo_version: 5.15.0
   microsoft.passwordCredential:
     fields:
       description: {}
-      displayName: {}
       expired: {}
       expires: {}
       hint: {}
@@ -255,19 +188,16 @@ resources:
     min_mondoo_version: 9.0.0
   microsoft.policies:
     fields:
-      ConsentPolicySettings:
-        min_mondoo_version: 9.0.0
       adminConsentRequestPolicy: {}
       authorizationPolicy: {}
-      consentPolicySettings:
-        min_mondoo_version: 9.0.0
+      consentPolicySettings: {}
       identitySecurityDefaultsEnforcementPolicy: {}
       permissionGrantPolicies: {}
-    min_mondoo_version: 5.15.0
+    min_mondoo_version: 9.0.0
   microsoft.rolemanagement:
     fields:
       roleDefinitions: {}
-    min_mondoo_version: 5.15.0
+    min_mondoo_version: 9.0.0
   microsoft.rolemanagement.roleassignment:
     fields:
       id: {}
@@ -275,7 +205,7 @@ resources:
       principalId: {}
       roleDefinitionId: {}
     is_private: true
-    min_mondoo_version: 5.15.0
+    min_mondoo_version: 9.0.0
   microsoft.rolemanagement.roledefinition:
     fields:
       assignments: {}
@@ -288,14 +218,24 @@ resources:
       templateId: {}
       version: {}
     is_private: true
-    min_mondoo_version: 5.15.0
+    min_mondoo_version: 9.0.0
+  microsoft.rolemanagement.roledefinitions:
+    fields:
+      filter: {}
+      list: {}
+    min_mondoo_version: 9.0.0
+  microsoft.roles:
+    fields:
+      filter: {}
+      list: {}
+      search: {}
+    min_mondoo_version: 9.0.0
   microsoft.security:
     fields:
       latestSecureScores: {}
-      riskyUsers:
-        min_mondoo_version: 9.0.0
+      riskyUsers: {}
       secureScores: {}
-    min_mondoo_version: 5.15.0
+    min_mondoo_version: 9.0.0
   microsoft.security.riskyUser:
     fields:
       id: {}
@@ -321,86 +261,45 @@ resources:
       maxScore: {}
       vendorInformation: {}
     is_private: true
-    min_mondoo_version: 5.15.0
+    min_mondoo_version: 9.0.0
   microsoft.serviceprincipal:
     fields:
-      accountEnabled:
-        min_mondoo_version: 9.0.0
-      appId:
-        min_mondoo_version: 9.0.0
-      appOwnerOrganizationId:
-        min_mondoo_version: 9.0.0
-      appRoleAssignmentRequired:
-        min_mondoo_version: 9.0.0
-      appRoleAssignments:
-        min_mondoo_version: latest
-      appRoles:
-        min_mondoo_version: 9.0.0
-      applicationTemplateId:
-        min_mondoo_version: 9.0.0
-      assignmentRequired:
-        min_mondoo_version: latest
-      assignments:
-        min_mondoo_version: latest
-      description:
-        min_mondoo_version: 9.0.0
-      enabled:
-        min_mondoo_version: latest
-      homepageUrl:
-        min_mondoo_version: latest
+      accountEnabled: {}
+      appId: {}
+      appOwnerOrganizationId: {}
+      appRoleAssignmentRequired: {}
+      appRoles: {}
+      applicationTemplateId: {}
+      assignmentRequired: {}
+      assignments: {}
+      description: {}
+      enabled: {}
+      homepageUrl: {}
       id: {}
-      isFirstParty:
-        min_mondoo_version: 9.0.0
-      loginUrl:
-        min_mondoo_version: 9.0.0
-      logoutUrl:
-        min_mondoo_version: 9.0.0
-      name:
-        min_mondoo_version: latest
-      notes:
-        min_mondoo_version: latest
-      notificationEmailAddresses:
-        min_mondoo_version: 9.0.0
-      permissions:
-        min_mondoo_version: 9.0.0
-      preferredSingleSignOnMode:
-        min_mondoo_version: 9.0.0
-      properties:
-        min_mondoo_version: latest
-      replyUrls:
-        min_mondoo_version: latest
-      servicePrincipalNames:
-        min_mondoo_version: 9.0.0
-      signInAudience:
-        min_mondoo_version: 9.0.0
-      tags:
-        min_mondoo_version: latest
-      termsOfServiceUrl:
-        min_mondoo_version: latest
-      type:
-        min_mondoo_version: latest
-      userAccessUrl:
-        min_mondoo_version: latest
-      verifiedPublisher:
-        min_mondoo_version: 9.0.0
-      visibleToUsers:
-        min_mondoo_version: latest
-    min_mondoo_version: 5.15.0
-  microsoft.serviceprincipal.appRoleAssignment:
-    fields:
-      displayName: {}
-      id: {}
+      isFirstParty: {}
+      loginUrl: {}
+      logoutUrl: {}
+      name: {}
+      notes: {}
+      notificationEmailAddresses: {}
+      permissions: {}
+      preferredSingleSignOnMode: {}
+      replyUrls: {}
+      servicePrincipalNames: {}
+      signInAudience: {}
+      tags: {}
+      termsOfServiceUrl: {}
       type: {}
-    min_mondoo_version: latest
+      verifiedPublisher: {}
+      visibleToUsers: {}
+    min_mondoo_version: 9.0.0
   microsoft.serviceprincipal.assignment:
     fields:
-      appId: {}
       displayName: {}
       id: {}
-      resourceName: {}
       type: {}
     is_private: true
-    min_mondoo_version: latest
+    min_mondoo_version: 9.0.0
   microsoft.tenant:
     fields:
       assignedPlans: {}
@@ -411,7 +310,6 @@ resources:
       name: {}
       onPremisesSyncEnabled: {}
       provisionedPlans: {}
-      subscription: {}
       subscriptions: {}
       type: {}
       verifiedDomains: {}
@@ -419,45 +317,36 @@ resources:
   microsoft.user:
     fields:
       accountEnabled: {}
-      auditlog:
-        min_mondoo_version: 9.0.0
-      authMethods:
-        min_mondoo_version: 9.0.0
+      auditlog: {}
+      authMethods: {}
       city: {}
       companyName: {}
-      contact:
-        min_mondoo_version: 9.0.0
+      contact: {}
       country: {}
       createdDateTime: {}
-      creationType:
-        min_mondoo_version: 9.0.0
+      creationType: {}
       department: {}
       displayName: {}
       employeeId: {}
       givenName: {}
       id: {}
-      identities:
-        min_mondoo_version: 9.0.0
-      job:
-        min_mondoo_version: 9.0.0
+      identities: {}
+      job: {}
       jobTitle: {}
       mail: {}
-      mfaEnabled:
-        min_mondoo_version: 9.0.0
+      mfaEnabled: {}
       mobilePhone: {}
       officeLocation: {}
       otherMails: {}
       postalCode: {}
       settings: {}
-      signins:
-        min_mondoo_version: 9.0.0
       state: {}
       streetAddress: {}
       surname: {}
       userPrincipalName: {}
       userType: {}
     is_private: true
-    min_mondoo_version: 5.15.0
+    min_mondoo_version: 9.0.0
   microsoft.user.auditlog:
     fields:
       lastInteractiveSignIn: {}
@@ -493,11 +382,17 @@ resources:
       createdDateTime: {}
       id: {}
       interactive: {}
-      requestId: {}
       resourceDisplayName: {}
       userDisplayName: {}
       userId: {}
     is_private: true
+    min_mondoo_version: 9.0.0
+  microsoft.users:
+    fields:
+      filter: {}
+      list: {}
+      search: {}
+      userPrincipalName: {}
     min_mondoo_version: 9.0.0
   ms365.exchangeonline:
     fields:
@@ -514,20 +409,15 @@ resources:
       owaMailboxPolicy: {}
       phishFilterPolicy: {}
       remoteDomain: {}
-      reportSubmissionPolicies:
-        min_mondoo_version: 9.0.0
+      reportSubmissionPolicies: {}
       roleAssignmentPolicy: {}
       safeAttachmentPolicy: {}
       safeLinksPolicy: {}
-      sharedMailboxes:
-        min_mondoo_version: 9.2.13
+      sharedMailboxes: {}
       sharingPolicy: {}
-      teamsProtectionPolicies:
-        min_mondoo_version: latest
-      teamsProtectionPolicy:
-        min_mondoo_version: latest
+      teamsProtectionPolicies: {}
       transportRule: {}
-    min_mondoo_version: 5.15.0
+    min_mondoo_version: 9.0.0
     platform:
       name:
       - microsoft365
@@ -537,7 +427,7 @@ resources:
       identity: {}
       user: {}
     is_private: true
-    min_mondoo_version: 9.2.13
+    min_mondoo_version: 9.0.0
     platform:
       name:
       - microsoft365
@@ -547,7 +437,7 @@ resources:
       enabled: {}
       identity: {}
     is_private: true
-    min_mondoo_version: latest
+    min_mondoo_version: 9.0.0
     platform:
       name:
       - microsoft365
@@ -562,7 +452,7 @@ resources:
       reportPhishAddresses: {}
       reportPhishToCustomizedAddress: {}
     is_private: true
-    min_mondoo_version: latest
+    min_mondoo_version: 9.0.0
     platform:
       name:
       - microsoft365
@@ -577,11 +467,10 @@ resources:
       - microsoft365
   ms365.sharepointonline:
     fields:
-      spoSites:
-        min_mondoo_version: 9.0.0
+      spoSites: {}
       spoTenant: {}
       spoTenantSyncClientRestriction: {}
-    min_mondoo_version: 5.15.0
+    min_mondoo_version: 9.0.0
     platform:
       name:
       - microsoft365
@@ -597,13 +486,10 @@ resources:
   ms365.teams:
     fields:
       csTeamsClientConfiguration: {}
-      csTeamsMeetingPolicy:
-        min_mondoo_version: 9.0.0
-      csTeamsMessagingPolicy:
-        min_mondoo_version: 9.0.0
-      csTenantFederationConfiguration:
-        min_mondoo_version: 9.0.0
-    min_mondoo_version: 5.15.0
+      csTeamsMeetingPolicy: {}
+      csTeamsMessagingPolicy: {}
+      csTenantFederationConfiguration: {}
+    min_mondoo_version: 9.0.0
     platform:
       name:
       - microsoft365
@@ -619,7 +505,7 @@ resources:
       designatedPresenterRoleMode: {}
       meetingChatEnabledType: {}
     is_private: true
-    min_mondoo_version: latest
+    min_mondoo_version: 9.0.0
     platform:
       name:
       - microsoft365
@@ -637,11 +523,9 @@ resources:
       allowPublicUsers: {}
       allowTeamsConsumer: {}
       allowTeamsConsumerInbound: {}
-      allowedDomains: {}
       blockedDomains: {}
       identity: {}
       restrictTeamsConsumerToExternalUserProfiles: {}
-      sestrictTeamsConsumerToExternalUserProfiles: {}
       sharedSipAddressSpace: {}
       treatDiscoveredPartnersAsUnverified: {}
     is_private: true

--- a/providers/ms365/resources/ms365_exchange.go
+++ b/providers/ms365/resources/ms365_exchange.go
@@ -503,7 +503,7 @@ func (m *mqlMs365ExchangeonlineExoMailbox) user() (*mqlMicrosoftUser, error) {
 	if users.Error != nil {
 		return nil, users.Error
 	}
-	for _, u := range users.Data {
+	for _, u := range users.Data.List.Data {
 		mqlUser := u.(*mqlMicrosoftUser)
 		if mqlUser.Id.Data == externalId {
 			return mqlUser, nil


### PR DESCRIPTION
When writing policies that require fetching huge amount of data only to search or filter for specific resources, we fetch all resources and then we apply the filters using the builtin functions `where()` `any()` and more.

An example of a policy check that uses these patterns is:
```
// search for emergency accounts
microsoft.users.any(displayName == /emergency/)

// emrgIds holds the ids which match the above criteria
emrgID = microsoft.users.where(displayName == /emergency/).map(id)

// check if at least one of the accounts identified as such is attached to the "Global Administrator" role
microsoft.rolemanagement.roleDefinitions.where(displayName == "Global Administrator").all(assignments.any(principalId == emrgID))
```

To improve these resources, I am proposing a new pattern, similar to the one used at https://github.com/mondoohq/cnquery/pull/5156, but with the difference that it doesn't override builtin functions, instead it leverages list resources which are natively supported in MQL with additional query parameters `filter` and `search`.

These query parameters will be used directly when executing API requests against Microsoft Graph API. These query parameters are documented at:

https://learn.microsoft.com/en-us/graph/filter-query-parameter?tabs=http#filter-using-lambda-operators

The above example can be rewritten using these two new filtered resources like:

```
// search for emergency accounts
microsoft.users(search: "displayName:emergency").any()

// emrgIds holds the ids which match the above criteria
emrgID = microsoft.users(search: "displayName:emergency").map(id)

// check if at least one of the accounts identified as such is attached to the "Global Administrator" role
microsoft.roles(filter: "displayName eq 'Global Administrator'").all(assignments.any(principalId == emrgID))
```

Additionally, since these query parameters are directly passed to Microsoft API's, we can write very complex filters for these two new resources.

A couple examples are:
```
microsoft.roles(filter: "isBuiltIn eq true and startswith(displayName, 'Global')")
microsoft.users(filter: "accountEnabled eq true AND userType eq 'Member'", search: "officeLocation:berlin")
```

Closes https://github.com/mondoohq/cnquery/issues/5110