### PR TITLE
🌟 file.context on sshd

### DIFF
--- a/cli/printer/mql.go
+++ b/cli/printer/mql.go
@@ -731,12 +731,21 @@ func (print *Printer) Data(typ types.Type, data interface{}, codeID string, bund
 		}
 
 		return idline
+
 	case types.FunctionLike:
 		if d, ok := data.(uint64); ok {
 			return indent + fmt.Sprintf("=> <%d,0>", d>>32)
 		} else {
 			return indent + fmt.Sprintf("=> %#v", data)
 		}
+
+	case types.Range:
+		if d, ok := data.(llx.Range); ok {
+			return indent + d.String()
+		} else {
+			return indent + "<bad range>"
+		}
+
 	default:
 		return indent + fmt.Sprintf("🤷 %#v", data)
 	}

--- a/llx/data_conversions.go
+++ b/llx/data_conversions.go
@@ -44,6 +44,7 @@ func init() {
 		types.MapLike:      map2result,
 		types.ResourceLike: resource2result,
 		types.FunctionLike: function2result,
+		types.Range:        range2result,
 	}
 
 	primitiveConverters = map[types.Type]primitiveConverter{
@@ -65,6 +66,7 @@ func init() {
 		types.ResourceLike: presource2raw,
 		types.FunctionLike: pfunction2raw,
 		types.Ref:          pref2raw,
+		types.Range:        prange2raw,
 	}
 }
 
@@ -330,6 +332,14 @@ func function2result(value interface{}, typ types.Type) (*Primitive, error) {
 		return FunctionPrimitive(v), nil
 	}
 	return nil, errInvalidConversion(value, typ)
+}
+
+func range2result(value any, typ types.Type) (*Primitive, error) {
+	v, ok := value.(Range)
+	if !ok {
+		return nil, errInvalidConversion(value, typ)
+	}
+	return RangePrimitive(v), nil
 }
 
 func raw2primitive(value interface{}, typ types.Type) (*Primitive, error) {
@@ -626,6 +636,10 @@ func pref2raw(p *Primitive) *RawData {
 	} else {
 		return &RawData{Value: int32(bytes2int(p.Value)), Type: types.Type(p.Type)}
 	}
+}
+
+func prange2raw(p *Primitive) *RawData {
+	return RangeData(p.Value)
 }
 
 // Tries to resolve primitives; returns refs if they don't exist yet.

--- a/llx/primitives.go
+++ b/llx/primitives.go
@@ -359,7 +359,7 @@ func (p *Primitive) LabelV2(code *CodeV2) string {
 		return ""
 
 	case types.Range:
-		return RangeData(p.Value).String()
+		return Range(p.Value).String()
 
 	default:
 		return ""

--- a/llx/range_test.go
+++ b/llx/range_test.go
@@ -20,13 +20,18 @@ func TestRange(t *testing.T) {
 		assert.Equal(t, "12-18", r.LabelV2(nil))
 	})
 
+	t.Run("long line range", func(t *testing.T) {
+		r := RangePrimitive(NewRange().AddLineRange(1, 1234567))
+		assert.Equal(t, "1-1234567", r.LabelV2(nil))
+	})
+
 	t.Run("column range", func(t *testing.T) {
 		r := RangePrimitive(NewRange().AddColumnRange(12, 1, 28))
 		assert.Equal(t, "12:1-28", r.LabelV2(nil))
 	})
 
 	t.Run("line and column range", func(t *testing.T) {
-		r := RangePrimitive(NewRange().AddLineColumnRange(12, 18, 1, 28))
-		assert.Equal(t, "12:1-18:28", r.LabelV2(nil))
+		r := RangePrimitive(NewRange().AddLineColumnRange(12, 12345678, 3, 1234567))
+		assert.Equal(t, "12:3-12345678:1234567", r.LabelV2(nil))
 	})
 }

--- a/llx/rawdata.go
+++ b/llx/rawdata.go
@@ -580,6 +580,14 @@ func FunctionData(v int32, sig string) *RawData {
 	}
 }
 
+// RangeData creates a rawdata struct from a raw range
+func RangeData(r Range) *RawData {
+	return &RawData{
+		Type:  types.Range,
+		Value: r,
+	}
+}
+
 // RawResultByRef is used to sort an array of raw results
 type RawResultByRef []*RawResult
 

--- a/providers-sdk/v1/lr/go.go
+++ b/providers-sdk/v1/lr/go.go
@@ -628,6 +628,8 @@ func (t *SimpleType) typeItems(ast *LR) types.Type {
 		return types.Time
 	case "dict":
 		return types.Dict
+	case "range":
+		return types.Range
 	default:
 		return resourceType(t.Type, ast)
 	}
@@ -696,6 +698,8 @@ func (t *SimpleType) mondooTypeItems(b *goBuilder) string {
 		return "types.Regex"
 	case "time":
 		return "types.Time"
+	case "range":
+		return "types.Range"
 	case "dict":
 		return "types.Dict"
 	default:
@@ -757,6 +761,7 @@ var primitiveTypes = map[string]string{
 	"int":    "int64",
 	"float":  "float64",
 	"time":   "*time.Time",
+	"range":  "llx.Range",
 	"regex":  "string",
 	"dict":   "interface{}",
 	"any":    "interface{}",
@@ -788,6 +793,7 @@ var primitiveZeros = map[string]string{
 	"int":    "0",
 	"float":  "0.0",
 	"time":   "nil",
+	"range":  "nil",
 	"dict":   "nil",
 	"any":    "nil",
 }

--- a/providers-sdk/v1/lr/lr_test.go
+++ b/providers-sdk/v1/lr/lr_test.go
@@ -258,6 +258,7 @@ func TestParse(t *testing.T) {
 				BasicField: &BasicField{
 					ID:   "context",
 					Type: Type{SimpleType: &SimpleType{"file.context"}},
+					Args: &FieldArgs{},
 				},
 				Comments: []string{"Contextual info, where this resource is located and defined"},
 			},

--- a/providers-sdk/v1/lr/lr_test.go
+++ b/providers-sdk/v1/lr/lr_test.go
@@ -247,12 +247,21 @@ func TestParse(t *testing.T) {
 		field map[string]int
 	}`)
 
-		fields := []*Field{{
-			BasicField: &BasicField{
-				ID:   "field",
-				Type: Type{MapType: &MapType{Key: SimpleType{"string"}, Value: Type{SimpleType: &SimpleType{"int"}}}},
+		fields := []*Field{
+			{
+				BasicField: &BasicField{
+					ID:   "field",
+					Type: Type{MapType: &MapType{Key: SimpleType{"string"}, Value: Type{SimpleType: &SimpleType{"int"}}}},
+				},
 			},
-		}}
+			{
+				BasicField: &BasicField{
+					ID:   "context",
+					Type: Type{SimpleType: &SimpleType{"file.context"}},
+				},
+				Comments: []string{"Contextual info, where this resource is located and defined"},
+			},
+		}
 		require.NotEmpty(t, res.Resources)
 		assert.Equal(t, "sth", res.Resources[0].ID)
 		assert.Equal(t, "file.context", res.Resources[0].Context)

--- a/providers-sdk/v1/lr/schema.go
+++ b/providers-sdk/v1/lr/schema.go
@@ -11,8 +11,6 @@ import (
 	"go.mondoo.com/cnquery/v11/types"
 )
 
-var CONTEXT_FIELD = "context"
-
 func Schema(ast *LR) (*resources.Schema, error) {
 	provider, ok := ast.Options["provider"]
 	if !ok {
@@ -177,20 +175,6 @@ func resourceFields(r *Resource, ast *LR) (map[string]*resources.Field, error) {
 			Desc:        desc,
 			Refs:        refs,
 			IsEmbedded:  f.BasicField.isEmbedded,
-		}
-	}
-
-	if r.Context != "" {
-		if _, ok := fields[CONTEXT_FIELD]; ok {
-			return nil, errors.New("'" + CONTEXT_FIELD + "' field already exists on resource " + r.ID)
-		}
-		fields[CONTEXT_FIELD] = &resources.Field{
-			Name:        CONTEXT_FIELD,
-			Type:        r.Context,
-			IsMandatory: true,
-			Title:       "Context",
-			Desc:        "Contextual info, where this resource is located and defined",
-			IsEmbedded:  false,
 		}
 	}
 

--- a/providers/os/resources/file.go
+++ b/providers/os/resources/file.go
@@ -219,3 +219,30 @@ func (l *mqlFilePermissions) id() (string, error) {
 func (l *mqlFilePermissions) string() (string, error) {
 	return l.__id, nil
 }
+
+func (r *mqlFileContext) id() (string, error) {
+	if r.File.Data == nil {
+		return "", errors.New("need file to exist for file.context ID")
+	}
+
+	fileID, err := r.File.Data.id()
+	if err != nil {
+		return "", err
+	}
+
+	rng := r.Range.Data.String()
+	return fileID + ":" + rng, nil
+}
+
+func (r *mqlFileContext) content(file *mqlFile, rnge llx.Range) (string, error) {
+	if file == nil {
+		return "", errors.New("no file information for file.context")
+	}
+
+	fileContent := file.GetContent()
+	if fileContent.Error != nil {
+		return "", fileContent.Error
+	}
+
+	return rnge.ExtractString(fileContent.Data), nil
+}

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -373,6 +373,15 @@ file @defaults("path size permissions.string") {
   empty(path) bool
 }
 
+private file.context @defaults("file.path range") {
+  // File referenced by this file context
+  file file
+  // Range of content in the file
+  range range
+  // Content for this range in the file, shown as an excerpt
+  content(file, range) string
+}
+
 // Access permissions for a given file
 private file.permissions @defaults("string") {
   // Raw POSIX mode for the permissions
@@ -702,7 +711,7 @@ sshd.config {
   permitRootLogin(params) []string
 }
 
-private sshd.config.matchBlock @defaults("criteria") {
+private sshd.config.matchBlock @defaults("criteria") @context("file.context") {
   // The match criteria for this block
   criteria string
   // Configuration values in this block

--- a/providers/os/resources/os.lr.manifest.yaml
+++ b/providers/os/resources/os.lr.manifest.yaml
@@ -348,6 +348,13 @@ resources:
           permissions.isDirectory
         }
       title: Test if a directory exists
+  file.context:
+    fields:
+      content: {}
+      file: {}
+      range: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
   file.permissions:
     fields:
       group_executable: {}
@@ -1028,7 +1035,11 @@ resources:
   sshd.config.matchBlock:
     fields:
       condition: {}
+      context:
+        min_mondoo_version: 9.0.0
       criteria: {}
+      file:
+        min_mondoo_version: 9.0.0
       params: {}
     is_private: true
     min_mondoo_version: latest

--- a/providers/os/resources/sshd_test.go
+++ b/providers/os/resources/sshd_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/testutils"
 )
 
@@ -79,7 +80,9 @@ func TestResource_SSHD(t *testing.T) {
 	})
 
 	t.Run("parse blocks", func(t *testing.T) {
-		res := x.TestQuery(t, "sshd.config.blocks.map(criteria)")
+		var res []*llx.RawResult
+
+		res = x.TestQuery(t, "sshd.config.blocks.map(criteria)")
 		assert.NotEmpty(t, res)
 		assert.Empty(t, res[0].Result().Error)
 		assert.Equal(t, []any{"", "Group sftp-users", "User myservice"}, res[0].Data.Value)
@@ -88,7 +91,28 @@ func TestResource_SSHD(t *testing.T) {
 		assert.NotEmpty(t, res)
 		assert.Empty(t, res[0].Result().Error)
 		assert.Equal(t, []any{"no", "yes", nil}, res[0].Data.Value)
+
+		ranges := []any{
+			llx.NewRange().AddLineRange(1, 172),
+			llx.NewRange().AddLineRange(173, 177),
+			llx.NewRange().AddLineRange(178, 180),
+		}
+		res = x.TestQuery(t, "sshd.config.blocks.map(context.range)")
+		assert.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, ranges, res[0].Data.Value)
+
+		paths := []any{
+			"/etc/ssh/sshd_config",
+			"/etc/ssh/sshd_config",
+			"/etc/ssh/sshd_config",
+		}
+		res = x.TestQuery(t, "sshd.config.blocks.map(context.file.path)")
+		assert.NotEmpty(t, res)
+		assert.Empty(t, res[0].Result().Error)
+		assert.Equal(t, paths, res[0].Data.Value)
 	})
+
 	t.Run("expose block match criteria in params.Match", func(t *testing.T) {
 		res := x.TestQuery(t, "sshd.config.params.Match")
 		assert.NotEmpty(t, res)


### PR DESCRIPTION
remaining todos after this: fix printing of the range, fix extractor, and make a nice context extraction

```
> sshd.config.blocks { criteria context }
sshd.config.blocks: [
  0: {
    criteria: ""
    context: file.context file.path="/etc/ssh/sshdconfig" range=1-172
  }
  1: {
    criteria: "Group sftp-users"
    context: file.context file.path="/etc/ssh/sshdconfig" range=173-177
  }
  2: {
    criteria: "User myservice"
    context: file.context file.path="/etc/ssh/sshdconfig" range=178-181
  }
]

```