### PR TITLE
🐛 ExtractString for ranges

### DIFF
--- a/llx/range_test.go
+++ b/llx/range_test.go
@@ -4,6 +4,8 @@
 package llx
 
 import (
+	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,7 +33,104 @@ func TestRange(t *testing.T) {
 	})
 
 	t.Run("line and column range", func(t *testing.T) {
-		r := RangePrimitive(NewRange().AddLineColumnRange(12, 12345678, 3, 1234567))
+		r := RangePrimitive(NewRange().AddLineColumnRange(12, 3, 12345678, 1234567))
 		assert.Equal(t, "12:3-12345678:1234567", r.LabelV2(nil))
+	})
+}
+
+var test3lines = `Line 1
+Line 2, Col 14
+Line 3, Col....17`
+
+func TestExtractRange(t *testing.T) {
+	t.Run("Lines", func(t *testing.T) {
+		lines := []struct {
+			line int
+			res  string
+		}{
+			{0, ""},
+			{1, "Line 1\n"},
+			{2, "Line 2, Col 14\n"},
+			{3, "Line 3, Col....17"},
+			{4, ""},
+		}
+		for i := range lines {
+			x := lines[i]
+			t.Run("line "+strconv.Itoa(x.line), func(t *testing.T) {
+				r := NewRange().AddLine(uint32(x.line))
+				assert.Equal(t, x.res, r.ExtractString(test3lines, DefaultExtractConfig))
+			})
+		}
+	})
+
+	t.Run("LineRanges", func(t *testing.T) {
+		lineRanges := []struct {
+			start int
+			end   int
+			res   string
+		}{
+			// first line only
+			{1, 1, "Line 1\n"},
+			// zero line, zero columns
+			{0, 1, "Line 1\n"},
+			{0, 2, "Line 1\nLine 2, Col 14\n"},
+			// multiple normal ranges
+			{1, 2, "Line 1\nLine 2, Col 14\n"},
+			{1, 3, "Line 1\nLine 2, Col 14\nLine 3, Col....17"},
+			{1, 99, "Line 1\nLine 2, Col 14\nLine 3, Col....17"},
+		}
+		for i := range lineRanges {
+			x := lineRanges[i]
+			t.Run(fmt.Sprintf("line %d-%d", x.start, x.end), func(t *testing.T) {
+				r := NewRange().AddLineRange(uint32(x.start), uint32(x.end))
+				assert.Equal(t, x.res, r.ExtractString(test3lines, DefaultExtractConfig))
+			})
+		}
+	})
+
+	t.Run("LineColumnRanges", func(t *testing.T) {
+		lineRanges := []struct {
+			start int
+			end   int
+			col1  int
+			col2  int
+			res   string
+		}{
+			// first line only
+			{1, 1, 1, 4, "Line"},
+			{1, 1, 1, 6, "Line 1"},
+			{1, 1, 1, 7, "Line 1\n"},
+			{1, 1, 1, 99, "Line 1\n"},
+			// zero line, zero columns
+			{0, 1, 1, 4, "Line"},
+			{0, 0, 1, 4, ""},
+			{1, 1, 0, 4, "Line"},
+			{1, 1, 0, 0, ""},
+			{1, 1, 0, 1, "L"},
+			{1, 1, 0, 99, "Line 1\n"},
+			{0, 1, 1, 6, "Line 1"},
+			{0, 1, 99, 6, "Line 1"},
+			{0, 2, 1, 0, "Line 1\n"},
+			{0, 99, 0, 0, "Line 1\nLine 2, Col 14\nLine 3, Col....17"},
+			// multiple normal ranges
+			{1, 2, 1, 0, "Line 1\n"},
+			{1, 2, 1, 1, "Line 1\nL"},
+			{1, 2, 1, 14, "Line 1\nLine 2, Col 14"},
+			{1, 2, 1, 15, "Line 1\nLine 2, Col 14\n"},
+			{1, 2, 1, 99, "Line 1\nLine 2, Col 14\n"},
+			{1, 3, 1, 0, "Line 1\nLine 2, Col 14\n"},
+			{1, 3, 1, 1, "Line 1\nLine 2, Col 14\nL"},
+			{1, 3, 1, 17, "Line 1\nLine 2, Col 14\nLine 3, Col....17"},
+			{1, 3, 1, 99, "Line 1\nLine 2, Col 14\nLine 3, Col....17"},
+			{1, 99, 0, 0, "Line 1\nLine 2, Col 14\nLine 3, Col....17"},
+			{1, 99, 1, 99, "Line 1\nLine 2, Col 14\nLine 3, Col....17"},
+		}
+		for i := range lineRanges {
+			x := lineRanges[i]
+			t.Run(fmt.Sprintf("line %d:%d-%d:%d", x.start, x.col1, x.end, x.col2), func(t *testing.T) {
+				r := NewRange().AddLineColumnRange(uint32(x.start), uint32(x.end), uint32(x.col1), uint32(x.col2))
+				assert.Equal(t, x.res, r.ExtractString(test3lines, DefaultExtractConfig))
+			})
+		}
 	})
 }

--- a/llx/range_test.go
+++ b/llx/range_test.go
@@ -43,6 +43,12 @@ Line 2, Col 14
 Line 3, Col....17`
 
 func TestExtractRange(t *testing.T) {
+	confAllContent := ExtractConfig{
+		MaxContentLines: 999999,
+		MaxColumns:      999999,
+		ShowLines:       false,
+	}
+
 	t.Run("Lines", func(t *testing.T) {
 		lines := []struct {
 			line int
@@ -58,7 +64,7 @@ func TestExtractRange(t *testing.T) {
 			x := lines[i]
 			t.Run("line "+strconv.Itoa(x.line), func(t *testing.T) {
 				r := NewRange().AddLine(uint32(x.line))
-				assert.Equal(t, x.res, r.ExtractString(test3lines, DefaultExtractConfig))
+				assert.Equal(t, x.res, r.ExtractString(test3lines, confAllContent))
 			})
 		}
 	})
@@ -83,7 +89,7 @@ func TestExtractRange(t *testing.T) {
 			x := lineRanges[i]
 			t.Run(fmt.Sprintf("line %d-%d", x.start, x.end), func(t *testing.T) {
 				r := NewRange().AddLineRange(uint32(x.start), uint32(x.end))
-				assert.Equal(t, x.res, r.ExtractString(test3lines, DefaultExtractConfig))
+				assert.Equal(t, x.res, r.ExtractString(test3lines, confAllContent))
 			})
 		}
 	})
@@ -129,7 +135,7 @@ func TestExtractRange(t *testing.T) {
 			x := lineRanges[i]
 			t.Run(fmt.Sprintf("line %d:%d-%d:%d", x.start, x.col1, x.end, x.col2), func(t *testing.T) {
 				r := NewRange().AddLineColumnRange(uint32(x.start), uint32(x.end), uint32(x.col1), uint32(x.col2))
-				assert.Equal(t, x.res, r.ExtractString(test3lines, DefaultExtractConfig))
+				assert.Equal(t, x.res, r.ExtractString(test3lines, confAllContent))
 			})
 		}
 	})

--- a/providers/os/resources/file.go
+++ b/providers/os/resources/file.go
@@ -244,5 +244,5 @@ func (r *mqlFileContext) content(file *mqlFile, rnge llx.Range) (string, error) 
 		return "", fileContent.Error
 	}
 
-	return rnge.ExtractString(fileContent.Data), nil
+	return rnge.ExtractString(fileContent.Data, llx.DefaultExtractConfig), nil
 }

--- a/providers/os/resources/sshd/params.go
+++ b/providers/os/resources/sshd/params.go
@@ -163,8 +163,8 @@ func ParseBlocks(rootPath string, globPathContent func(string) (string, error)) 
 
 		if key == "Match" {
 			// wrap up context on the previous block
-			curBlock.Context.Range = curBlock.Context.Range.AddLineRange(uint32(curBlock.Context.curLine), uint32(curLineIdx))
-			curBlock.Context.curLine = curLineIdx + 1
+			curBlock.Context.Range = curBlock.Context.Range.AddLineRange(uint32(curBlock.Context.curLine), uint32(curLineIdx-1))
+			curBlock.Context.curLine = curLineIdx
 
 			// This key is the only that we don't add to any params. It is stored
 			// in the condition of each block and can be accessed there.

--- a/providers/os/resources/sshd/params.go
+++ b/providers/os/resources/sshd/params.go
@@ -163,7 +163,7 @@ func ParseBlocks(rootPath string, globPathContent func(string) (string, error)) 
 
 		if key == "Match" {
 			// wrap up context on the previous block
-			curBlock.Context.Range = curBlock.Context.Range.AddLineRange(uint32(curBlock.Context.curLine), uint32(curLineIdx-1))
+			curBlock.Context.Range = curBlock.Context.Range.AddLineRange(uint32(curBlock.Context.curLine), uint32(curLineIdx))
 			curBlock.Context.curLine = curLineIdx
 
 			// This key is the only that we don't add to any params. It is stored


### PR DESCRIPTION
Add a test-suite and tests to make sure the range extractor works as expected, including misconfigured ranges.

Please note, this is not yet about fancy content excerpt printing on CLI, just about making sure the extraction of content using a range works as expected.

Basically now we get correct content:

```
> sshd.config.blocks { criteria context context.content }
sshd.config.blocks: [
  0: {
    criteria: ""
    context: file.context file.path="/pub/go/src/github.com/mondoohq/cnquery/sshdconfig" range=    1-171
    context.content: "# 
# Ansible managed
#
... lots of content, just removed it here but needs proper handling ...
"
  }
  1: {
    criteria: "Group sftp-users"
    context: file.context file.path="/pub/go/src/github.com/mondoohq/cnquery/sshdconfig" range=    173-176
    context.content: "Match Group sftp-users
       X11Forwarding no
       PermitRootLogin no
       AllowTCPForwarding yes
"
  }
  2: {
    criteria: "User myservice"
    context: file.context file.path="/pub/go/src/github.com/mondoohq/cnquery/sshdconfig" range=    178-181
    context.content: "Match User myservice

"
  }
]
```

As you can see from the options, the next PR will tackle fancy excerpts