### PR TITLE
✨ azure: new `appsite` fields `ftp` & `scm`

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -86,6 +86,7 @@ rulegroup
 rulegroupreferencestatement
 Sas
 scim
+scm
 serviceprincipals
 signin
 singlequeryargument

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -1077,7 +1077,7 @@ private azure.subscription.webService.appsite.basicPublishingCredentialsPolicies
   name string
   // Resource type
   type string
-  // Publishing method policy
+  // Whether to allow access to a publishing method
   allow bool
 }
 

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -1063,6 +1063,22 @@ private azure.subscription.webService.appsite @defaults("id name location") {
   diagnosticSettings() []azure.subscription.monitorService.diagnosticsetting
   // List of functions for the web app site
   functions() []azure.subscription.webService.function
+  // FTP publishing method policies
+  ftp() azure.subscription.webService.appsite.basicPublishingCredentialsPolicies
+  // SCM publishing method policies
+  scm() azure.subscription.webService.appsite.basicPublishingCredentialsPolicies
+}
+
+// Azure AppSite basic publishing credentials policies
+private azure.subscription.webService.appsite.basicPublishingCredentialsPolicies @defaults("id allow") {
+  // Resource ID
+  id string
+  // Resource name
+  name string
+  // Resource type
+  type string
+  // Publishing method policy
+  allow bool
 }
 
 // Azure AppSite authentication settings

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -230,6 +230,10 @@ func init() {
 			// to override args, implement: initAzureSubscriptionWebServiceAppsite(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAzureSubscriptionWebServiceAppsite,
 		},
+		"azure.subscription.webService.appsite.basicPublishingCredentialsPolicies": {
+			// to override args, implement: initAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies,
+		},
 		"azure.subscription.webService.appsiteauthsettings": {
 			// to override args, implement: initAzureSubscriptionWebServiceAppsiteauthsettings(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAzureSubscriptionWebServiceAppsiteauthsettings,
@@ -1781,6 +1785,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.webService.appsite.functions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetFunctions()).ToDataRes(types.Array(types.Resource("azure.subscription.webService.function")))
+	},
+	"azure.subscription.webService.appsite.ftp": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetFtp()).ToDataRes(types.Resource("azure.subscription.webService.appsite.basicPublishingCredentialsPolicies"))
+	},
+	"azure.subscription.webService.appsite.scm": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetScm()).ToDataRes(types.Resource("azure.subscription.webService.appsite.basicPublishingCredentialsPolicies"))
+	},
+	"azure.subscription.webService.appsite.basicPublishingCredentialsPolicies.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies).GetId()).ToDataRes(types.String)
+	},
+	"azure.subscription.webService.appsite.basicPublishingCredentialsPolicies.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies).GetName()).ToDataRes(types.String)
+	},
+	"azure.subscription.webService.appsite.basicPublishingCredentialsPolicies.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies).GetType()).ToDataRes(types.String)
+	},
+	"azure.subscription.webService.appsite.basicPublishingCredentialsPolicies.allow": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies).GetAllow()).ToDataRes(types.Bool)
 	},
 	"azure.subscription.webService.appsiteauthsettings.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsiteauthsettings).GetId()).ToDataRes(types.String)
@@ -4834,6 +4856,34 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"azure.subscription.webService.appsite.functions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebServiceAppsite).Functions, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appsite.ftp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsite).Ftp, ok = plugin.RawToTValue[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appsite.scm": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsite).Scm, ok = plugin.RawToTValue[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appsite.basicPublishingCredentialsPolicies.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies).__id, ok = v.Value.(string)
+			return
+		},
+	"azure.subscription.webService.appsite.basicPublishingCredentialsPolicies.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appsite.basicPublishingCredentialsPolicies.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appsite.basicPublishingCredentialsPolicies.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appsite.basicPublishingCredentialsPolicies.allow": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies).Allow, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.webService.appsiteauthsettings.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11670,6 +11720,8 @@ type mqlAzureSubscriptionWebServiceAppsite struct {
 	Stack plugin.TValue[interface{}]
 	DiagnosticSettings plugin.TValue[[]interface{}]
 	Functions plugin.TValue[[]interface{}]
+	Ftp plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies]
+	Scm plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies]
 }
 
 // createAzureSubscriptionWebServiceAppsite creates a new instance of this resource
@@ -11827,6 +11879,102 @@ func (c *mqlAzureSubscriptionWebServiceAppsite) GetFunctions() *plugin.TValue[[]
 
 		return c.functions()
 	})
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsite) GetFtp() *plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies](&c.Ftp, func() (*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.appsite", c.__id, "ftp")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies), nil
+			}
+		}
+
+		return c.ftp()
+	})
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsite) GetScm() *plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies](&c.Scm, func() (*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.appsite", c.__id, "scm")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies), nil
+			}
+		}
+
+		return c.scm()
+	})
+}
+
+// mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies for the azure.subscription.webService.appsite.basicPublishingCredentialsPolicies resource
+type mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPoliciesInternal it will be used here
+	Id plugin.TValue[string]
+	Name plugin.TValue[string]
+	Type plugin.TValue[string]
+	Allow plugin.TValue[bool]
+}
+
+// createAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies creates a new instance of this resource
+func createAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+	res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("azure.subscription.webService.appsite.basicPublishingCredentialsPolicies", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies) MqlName() string {
+	return "azure.subscription.webService.appsite.basicPublishingCredentialsPolicies"
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies) GetType() *plugin.TValue[string] {
+	return &c.Type
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies) GetAllow() *plugin.TValue[bool] {
+	return &c.Allow
 }
 
 // mqlAzureSubscriptionWebServiceAppsiteauthsettings for the azure.subscription.webService.appsiteauthsettings resource

--- a/providers/azure/resources/azure.lr.manifest.yaml
+++ b/providers/azure/resources/azure.lr.manifest.yaml
@@ -2880,6 +2880,8 @@ resources:
       connectionSettings: {}
       diagnosticSettings:
         min_mondoo_version: 9.0.0
+      ftp:
+        min_mondoo_version: 9.0.0
       functions:
         min_mondoo_version: 9.0.0
       id: {}
@@ -2889,6 +2891,8 @@ resources:
       metadata: {}
       name: {}
       properties: {}
+      scm:
+        min_mondoo_version: 9.0.0
       stack: {}
       tags: {}
       type: {}
@@ -2900,6 +2904,17 @@ resources:
     refs:
     - title: Azure Web documentation
       url: https://learn.microsoft.com/en-us/azure/?product=web
+  azure.subscription.webService.appsite.basicPublishingCredentialsPolicies:
+    fields:
+      allow: {}
+      id: {}
+      name: {}
+      type: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
+    platform:
+      name:
+      - azure
   azure.subscription.webService.appsiteauthsettings:
     fields:
       id: {}

--- a/providers/azure/resources/web.go
+++ b/providers/azure/resources/web.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -392,6 +393,92 @@ func (a *mqlAzureSubscriptionWebServiceAppsite) metadata() (interface{}, error) 
 	}
 
 	return res, nil
+}
+
+func (a *mqlAzureSubscriptionWebServiceAppsite) ftp() (*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+	token := conn.Token()
+	id := a.Id.Data
+	resourceID, err := ParseResourceID(id)
+	if err != nil {
+		return nil, err
+	}
+	client, err := web.NewWebAppsClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	site, err := resourceID.Component("sites")
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.GetFtpAllowed(ctx, resourceID.ResourceGroup, site, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	args := map[string]*llx.RawData{
+		"id":   llx.StringDataPtr(response.ID),
+		"name": llx.StringDataPtr(response.Name),
+		"type": llx.StringDataPtr(response.Type),
+	}
+	if response.Properties != nil {
+		args["allow"] = llx.BoolDataPtr(response.Properties.Allow)
+	}
+	mqlResource, err := CreateResource(a.MqlRuntime, "azure.subscription.webService.appsite.basicPublishingCredentialsPolicies", args)
+	if err != nil {
+		return nil, err
+	}
+	return mqlResource.(*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies), nil
+}
+
+func (a *mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies) id() (string, error) {
+	return fmt.Sprintf("%s/%s", a.Id.Data, a.Name.Data), nil
+}
+
+func (a *mqlAzureSubscriptionWebServiceAppsite) scm() (*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+	token := conn.Token()
+	id := a.Id.Data
+	resourceID, err := ParseResourceID(id)
+	if err != nil {
+		return nil, err
+	}
+	client, err := web.NewWebAppsClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	site, err := resourceID.Component("sites")
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.GetScmAllowed(ctx, resourceID.ResourceGroup, site, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	args := map[string]*llx.RawData{
+		"id":   llx.StringDataPtr(response.ID),
+		"name": llx.StringDataPtr(response.Name),
+		"type": llx.StringDataPtr(response.Type),
+	}
+	if response.Properties != nil {
+		args["allow"] = llx.BoolDataPtr(response.Properties.Allow)
+	}
+	mqlResource, err := CreateResource(a.MqlRuntime, "azure.subscription.webService.appsite.basicPublishingCredentialsPolicies", args)
+	if err != nil {
+		return nil, err
+	}
+	return mqlResource.(*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies), nil
 }
 
 func (a *mqlAzureSubscriptionWebServiceAppsite) functions() ([]interface{}, error) {


### PR DESCRIPTION
```
cnquery> azure.subscription.web.apps { ftp {*} scm {*} }
azure.subscription.web.apps: [
  0: {
    ftp: {
      type: "Microsoft.Web/sites/basicPublishingCredentialsPolicies"
      allow: true
      name: "ftp"
      id: "/subscriptions/abc123-1111-2222-3333-abc123xyz890/resourceGroups/azure-group-9d81d/providers/Microsoft.Web/sites/app-275u5hwyego5q/basicPublishingCredentialsPolicies/ftp"
    }
    scm: {
      allow: true
      name: "scm"
      id: "/subscriptions/abc123-1111-2222-3333-abc123xyz890/resourceGroups/azure-group-9d81d/providers/Microsoft.Web/sites/app-275u5hwyego5q/basicPublishingCredentialsPolicies/scm"
      type: "Microsoft.Web/sites/basicPublishingCredentialsPolicies"
    }
  }
]
```

Closes https://github.com/mondoohq/cnquery/issues/5056