### PR TITLE
✨ azure support for defender email notification sources

### DIFF
--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -2,9 +2,6 @@ module go.mondoo.com/cnquery/v11/providers/azure
 
 replace go.mondoo.com/cnquery/v11 => ../..
 
-// 0.14.0 onwards drops AlertNotifications from SecurityContacts. We need to find a replacement before we can upgrade.
-replace github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/security/armsecurity => github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/security/armsecurity v0.13.0
-
 go 1.23.0
 
 require (

--- a/providers/azure/go.sum
+++ b/providers/azure/go.sum
@@ -136,8 +136,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0 h1:wxQx2Bt4xzPIKvW59WQf1tJNx/ZZKPfN+EhPX3Z6CYY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0/go.mod h1:TpiwjwnW/khS0LKs4vW5UmmT9OWcxaveS8U7+tlknzo=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/security/armsecurity v0.13.0 h1:bvkjXDmjYA1qRJwqI+mmFYKioiLRUbR1eAOWsf4a+e4=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/security/armsecurity v0.13.0/go.mod h1:rVjowC1tCYv0Uw9/YHbrLzUjuTb8nMqih36SmasUhEo=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/security/armsecurity v0.14.0 h1:JfjIyBJvEvQNP/9MEUo1/6eoiPkiag2OZImw32xakcc=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/security/armsecurity v0.14.0/go.mod h1:HakuHOrWlp2G1WlFvkL7JApTZAbxRJnRiz+w4SYak5s=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0 h1:S087deZ0kP1RUg4pU7w9U9xpUedTCbOtz+mnd0+hrkQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0/go.mod h1:B4cEyXrWBmbfMDAPnpJ1di7MAt5DKP57jPEObAvZChg=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.6.0 h1:PiSrjRPpkQNjrM8H0WwKMnZUdu1RGMtd/LdGKUrOo+c=

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -1771,15 +1771,17 @@ private azure.subscription.cloudDefenderService @defaults("defenderForServers.en
 }
 
 // Microsoft Defender for Cloud security contact
-private azure.subscription.cloudDefenderService.securityContact @defaults("name alertNotifications.state"){
+private azure.subscription.cloudDefenderService.securityContact @defaults("id name"){
   // ID of the security contact
   id string
   // Name of the security contact
   name string
   // Emails that receive security alerts
   emails []string
-  // Alerts notification settings
+  // Deprecated: use `notificationSources` instead
   alertNotifications dict
+  // A collection of sources which evaluate the email notification
+  notificationSources dict
   // Notifications by role settings
   notificationsByRole dict
 }

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -2631,6 +2631,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.cloudDefenderService.securityContact.alertNotifications": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderServiceSecurityContact).GetAlertNotifications()).ToDataRes(types.Dict)
 	},
+	"azure.subscription.cloudDefenderService.securityContact.notificationSources": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderServiceSecurityContact).GetNotificationSources()).ToDataRes(types.Dict)
+	},
 	"azure.subscription.cloudDefenderService.securityContact.notificationsByRole": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderServiceSecurityContact).GetNotificationsByRole()).ToDataRes(types.Dict)
 	},
@@ -6118,6 +6121,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"azure.subscription.cloudDefenderService.securityContact.alertNotifications": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCloudDefenderServiceSecurityContact).AlertNotifications, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.securityContact.notificationSources": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderServiceSecurityContact).NotificationSources, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cloudDefenderService.securityContact.notificationsByRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15456,6 +15463,7 @@ type mqlAzureSubscriptionCloudDefenderServiceSecurityContact struct {
 	Name plugin.TValue[string]
 	Emails plugin.TValue[[]interface{}]
 	AlertNotifications plugin.TValue[interface{}]
+	NotificationSources plugin.TValue[interface{}]
 	NotificationsByRole plugin.TValue[interface{}]
 }
 
@@ -15510,6 +15518,10 @@ func (c *mqlAzureSubscriptionCloudDefenderServiceSecurityContact) GetEmails() *p
 
 func (c *mqlAzureSubscriptionCloudDefenderServiceSecurityContact) GetAlertNotifications() *plugin.TValue[interface{}] {
 	return &c.AlertNotifications
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderServiceSecurityContact) GetNotificationSources() *plugin.TValue[interface{}] {
+	return &c.NotificationSources
 }
 
 func (c *mqlAzureSubscriptionCloudDefenderServiceSecurityContact) GetNotificationsByRole() *plugin.TValue[interface{}] {

--- a/providers/azure/resources/azure.lr.manifest.yaml
+++ b/providers/azure/resources/azure.lr.manifest.yaml
@@ -437,6 +437,8 @@ resources:
       emails: {}
       id: {}
       name: {}
+      notificationSources:
+        min_mondoo_version: 9.0.0
       notificationsByRole: {}
     is_private: true
     min_mondoo_version: latest


### PR DESCRIPTION
~BREAKING CHANGE!!!~
----------------------

Azure deprecated `AlertNotifications` in favor of `NotificationSources`

https://learn.microsoft.com/en-us/rest/api/defenderforcloud/security-contacts/get?view=rest-defenderforcloud-2023-12-01-preview&tabs=Go#notificationssourceattackpath

This change is an alternative to https://github.com/mondoohq/cnquery/pull/5183 where we fetch the latest information about security contacts.

With this change we will now detect both notification sources, Alert and AttackPath.
```
cnquery> azure.subscription.cloudDefender.securityContacts { notificationSources }
azure.subscription.cloudDefender.securityContacts: [
  0: {
    notificationSources: {
      Alert: {
        minimalSeverity: "High"
        sourceType: "Alert"
      }
      AttackPath: {
        minimalRiskLevel: "Critical"
        sourceType: "AttackPath"
      }
    }
  }
]
```

Azure Portal Settings:

![Screenshot 2025-02-10 at 7 23 58 AM](https://github.com/user-attachments/assets/d488c4ed-148f-4eaf-90d6-eae8cbab0057)

Contributes to https://github.com/mondoohq/cnquery/issues/4997