### PR TITLE
🐛 support features on cnquery run

### DIFF
--- a/apps/cnquery/cmd/plugin.go
+++ b/apps/cnquery/cmd/plugin.go
@@ -62,6 +62,7 @@ func (c *cnqueryPlugin) RunQuery(conf *run.RunQueryConfig, runtime *providers.Ru
 	if optsErr != nil {
 		log.Fatal().Err(optsErr).Msg("could not load configuration")
 	}
+	conf.Features = opts.GetFeatures()
 
 	config.DisplayUsedConfig()
 


### PR DESCRIPTION
For some reason we had missed to migrate the feature-setting from env variables for this command