### PR TITLE
✨ Do not error out on SBOM generation, use the sbom ErrorMessage instead

### DIFF
--- a/apps/cnquery/cmd/sbom.go
+++ b/apps/cnquery/cmd/sbom.go
@@ -95,10 +95,7 @@ var sbomCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *pl
 		logger.DebugDumpJSON("mondoo-sbom-report", data)
 	}
 
-	boms, err := generator.NewBom(cnspecReport)
-	if err != nil {
-		log.Fatal().Err(err).Msg("failed to parse bom")
-	}
+	boms := generator.GenerateBom(cnspecReport)
 
 	var exporter sbom.FormatSpecificationHandler
 	output := viper.GetString("output")

--- a/sbom/cnquery_bom_test.go
+++ b/sbom/cnquery_bom_test.go
@@ -17,8 +17,7 @@ func TestSimpleBomOutput(t *testing.T) {
 	report, err := generator.LoadReport("./testdata/alpine.json")
 	require.NoError(t, err)
 
-	sboms, err := generator.GenerateBom(report)
-	require.NoError(t, err)
+	sboms := generator.GenerateBom(report)
 
 	// store bom in different formats
 	selectedBom := sboms[0]

--- a/sbom/cyclonedx_test.go
+++ b/sbom/cyclonedx_test.go
@@ -19,8 +19,7 @@ func TestCycloneDxOutput(t *testing.T) {
 	report, err := generator.LoadReport("./testdata/alpine.json")
 	require.NoError(t, err)
 
-	sboms, err := generator.GenerateBom(report)
-	require.NoError(t, err)
+	sboms := generator.GenerateBom(report)
 
 	// store bom in different formats
 	selectedBom := sboms[0]

--- a/sbom/generator/generator.go
+++ b/sbom/generator/generator.go
@@ -18,21 +18,10 @@ import (
 
 var LABEL_KERNEL_RUNNING = "mondoo.com/os/kernel-running"
 
-// NewBom creates a BOM from a cnquery report
-func NewBom(report *reporter.Report) ([]*sbom.Sbom, error) {
-	return GenerateBom(report)
-}
-
-func GenerateBomV2(r *reporter.Report) []*sbom.Sbom {
-	sboms, _ := GenerateBom(r)
-	return sboms
-}
-
 // GenerateBom generates a BOM from a cnquery json report collection
-// depercated: Use GenerateBomV2 instead
-func GenerateBom(r *reporter.Report) ([]*sbom.Sbom, error) {
+func GenerateBom(r *reporter.Report) []*sbom.Sbom {
 	if r == nil {
-		return nil, nil
+		return nil
 	}
 
 	generator := &sbom.Generator{
@@ -182,7 +171,7 @@ func GenerateBom(r *reporter.Report) ([]*sbom.Sbom, error) {
 		}
 		boms = append(boms, bom)
 	}
-	return boms, nil
+	return boms
 }
 
 // enrichPlatformIds adds the platform id based on cnquery ids

--- a/sbom/generator/report_collection.go
+++ b/sbom/generator/report_collection.go
@@ -5,8 +5,9 @@ package generator
 
 import (
 	"encoding/json"
-	"go.mondoo.com/cnquery/v11/cli/reporter"
 	"os"
+
+	"go.mondoo.com/cnquery/v11/cli/reporter"
 	"sigs.k8s.io/yaml"
 )
 
@@ -59,7 +60,6 @@ func LoadReport(filename string) (*reporter.Report, error) {
 	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
-
 	}
 	var report *reporter.Report
 	err = yaml.Unmarshal(data, &report)

--- a/sbom/generator/sbom_test.go
+++ b/sbom/generator/sbom_test.go
@@ -17,8 +17,7 @@ func TestSbomGeneration(t *testing.T) {
 		report, err := LoadReport("../testdata/alpine.json")
 		require.NoError(t, err)
 
-		sboms, err := GenerateBom(report)
-		require.NoError(t, err)
+		sboms := GenerateBom(report)
 
 		// store bom in different formats
 		selectedBom := sboms[0]
@@ -58,8 +57,7 @@ func TestSbomGeneration(t *testing.T) {
 		report, err := LoadReport("testdata/alpine-failed-package.json")
 		require.NoError(t, err)
 
-		sboms, err := GenerateBom(report)
-		require.NoError(t, err)
+		sboms := GenerateBom(report)
 
 		// store bom in different formats
 		selectedBom := sboms[0]

--- a/sbom/generator/sbom_test.go
+++ b/sbom/generator/sbom_test.go
@@ -4,52 +4,67 @@
 package generator
 
 import (
-	"go.mondoo.com/cnquery/v11/sbom"
 	"testing"
+
+	"go.mondoo.com/cnquery/v11/sbom"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSbomGeneration(t *testing.T) {
-	report, err := LoadReport("../testdata/alpine.json")
-	require.NoError(t, err)
+	t.Run("generate sbom from a full report", func(t *testing.T) {
+		report, err := LoadReport("../testdata/alpine.json")
+		require.NoError(t, err)
 
-	sboms, err := GenerateBom(report)
-	require.NoError(t, err)
+		sboms, err := GenerateBom(report)
+		require.NoError(t, err)
 
-	// store bom in different formats
-	selectedBom := sboms[0]
+		// store bom in different formats
+		selectedBom := sboms[0]
 
-	assert.Equal(t, "alpine:latest", selectedBom.Asset.Name)
-	assert.Equal(t, "trace-alpine", selectedBom.Asset.TraceId)
-	assert.Equal(t, "aarch64", selectedBom.Asset.Platform.Arch)
-	assert.Equal(t, "alpine", selectedBom.Asset.Platform.Name)
-	assert.Equal(t, "3.19.0", selectedBom.Asset.Platform.Version)
-	assert.Equal(t, []string{"//platformid.api.mondoo.app/runtime/docker/images/1dc785547989b0db1c3cd9949c57574393e69bea98bfe044b0588e24721aa402"}, selectedBom.Asset.PlatformIds)
+		assert.Equal(t, "alpine:latest", selectedBom.Asset.Name)
+		assert.Equal(t, "trace-alpine", selectedBom.Asset.TraceId)
+		assert.Equal(t, "aarch64", selectedBom.Asset.Platform.Arch)
+		assert.Equal(t, "alpine", selectedBom.Asset.Platform.Name)
+		assert.Equal(t, "3.19.0", selectedBom.Asset.Platform.Version)
+		assert.Equal(t, []string{"//platformid.api.mondoo.app/runtime/docker/images/1dc785547989b0db1c3cd9949c57574393e69bea98bfe044b0588e24721aa402"}, selectedBom.Asset.PlatformIds)
 
-	// search os package
-	pkg := findProtoPkg(selectedBom.Packages, "alpine-baselayout")
-	assert.Equal(t, "alpine-baselayout", pkg.Name)
-	assert.Contains(t, pkg.EvidenceList, &sbom.Evidence{
-		Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-		Value: "etc/profile.d/color_prompt.sh.disabled",
+		// search os package
+		pkg := findProtoPkg(selectedBom.Packages, "alpine-baselayout")
+		assert.Equal(t, "alpine-baselayout", pkg.Name)
+		assert.Contains(t, pkg.EvidenceList, &sbom.Evidence{
+			Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
+			Value: "etc/profile.d/color_prompt.sh.disabled",
+		})
+
+		// search python package
+		pkg = findProtoPkg(selectedBom.Packages, "pip")
+		assert.Equal(t, "pip", pkg.Name)
+		assert.Contains(t, pkg.EvidenceList, &sbom.Evidence{
+			Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
+			Value: "/opt/lib/python3.9/site-packages/pip-21.2.4.dist-info/METADATA",
+		})
+
+		// search npm package
+		pkg = findProtoPkg(selectedBom.Packages, "npm")
+		assert.Equal(t, "npm", pkg.Name)
+		assert.Contains(t, pkg.EvidenceList, &sbom.Evidence{
+			Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
+			Value: "/opt/lib/node_modules/npm/package.json",
+		})
 	})
+	t.Run("generate sbom from a report with a package error", func(t *testing.T) {
+		report, err := LoadReport("testdata/alpine-failed-package.json")
+		require.NoError(t, err)
 
-	// search python package
-	pkg = findProtoPkg(selectedBom.Packages, "pip")
-	assert.Equal(t, "pip", pkg.Name)
-	assert.Contains(t, pkg.EvidenceList, &sbom.Evidence{
-		Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-		Value: "/opt/lib/python3.9/site-packages/pip-21.2.4.dist-info/METADATA",
-	})
+		sboms, err := GenerateBom(report)
+		require.NoError(t, err)
 
-	// search npm package
-	pkg = findProtoPkg(selectedBom.Packages, "npm")
-	assert.Equal(t, "npm", pkg.Name)
-	assert.Contains(t, pkg.EvidenceList, &sbom.Evidence{
-		Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-		Value: "/opt/lib/node_modules/npm/package.json",
+		// store bom in different formats
+		selectedBom := sboms[0]
+		assert.Equal(t, sbom.Status_STATUS_FAILED, selectedBom.Status)
+		assert.Contains(t, selectedBom.ErrorMessage, "failed to parse bom fields json data")
 	})
 }
 

--- a/sbom/generator/testdata/alpine-failed-package.json
+++ b/sbom/generator/testdata/alpine-failed-package.json
@@ -1,0 +1,74 @@
+{
+    "assets": {
+        "//explorer.api.mondoo.com/assets/2cNOBxIv7117UjcqsDBvKUgwkKw": {
+            "mrn": "//explorer.api.mondoo.com/assets/2cNOBxIv7117UjcqsDBvKUgwkKw",
+            "name": "alpine:latest",
+            "trace_id": "trace-alpine"
+        }
+    },
+    "data": {
+        "//explorer.api.mondoo.com/assets/2cNOBxIv7117UjcqsDBvKUgwkKw": {
+            "values": {
+                "//local.cnquery.io/run/local-execution/queries/mondoo-sbom-asset": {
+                    "content": {
+                        "asset": {
+                            "version": "3.19.0",
+                            "arch": "aarch64",
+                            "labels": {
+                                "distro-id": "alpine"
+                            },
+                            "platform": "alpine",
+                            "ids": [
+                                "//platformid.api.mondoo.app/runtime/docker/images/1dc785547989b0db1c3cd9949c57574393e69bea98bfe044b0588e24721aa402"
+                            ],
+                            "name": "alpine:latest",
+                            "cpes.map": [
+                                "cpe:2.3:o:alpinelinux:alpine_linux:3.19.0:*:*:*:*:*:*:*"
+                            ]
+                        }
+                    }
+                },
+                "//local.cnquery.io/run/local-execution/queries/mondoo-sbom-packages": {
+                    "content": {
+                        "packages.list": {
+                            "error": "error fetching sbom packages"
+                        }
+                    }
+                },
+                "//local.cnquery.io/run/local-execution/queries/mondoo-sbom-python-packages": {
+                    "content": {
+                        "python.packages": [
+                            {
+                                "name": "pip",
+                                "version": "21.2.4",
+                                "cpes.map": [
+                                    "cpe:2.3:a:pip_project:pip:21.2.4:*:*:*:*:*:*:*"
+                                ],
+                                "purl": "pkg:pypi/pip@21.2.4",
+                                "file.path": "/opt/lib/python3.9/site-packages/pip-21.2.4.dist-info/METADATA"
+                            }
+                        ]
+                    }
+                },
+                "//local.cnquery.io/run/local-execution/queries/mondoo-sbom-npm-packages": {
+                    "content": {
+                        "npm.packages.list": [
+                            {
+                                "name": "npm",
+                                "files.map": [
+                                    "/opt/lib/node_modules/npm/package.json"
+                                ],
+                                "cpes.map": [
+                                    "cpe:2.3:a:npm:npm:10.2.4:*:*:*:*:*:*:*"
+                                ],
+                                "purl": "pkg:npm/npm@10.2.4",
+                                "version": "10.2.4"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    },
+    "errors": {}
+}

--- a/sbom/spdx_test.go
+++ b/sbom/spdx_test.go
@@ -18,8 +18,7 @@ func TestSpdxOutput(t *testing.T) {
 	report, err := generator.LoadReport("./testdata/alpine.json")
 	require.NoError(t, err)
 
-	sboms, err := generator.GenerateBom(report)
-	require.NoError(t, err)
+	sboms := generator.GenerateBom(report)
 
 	// store bom in different formats
 	selectedBom := sboms[0]


### PR DESCRIPTION
This ensures that if the SBOM query pack errors out, we still get an SBOM pack with a status of Failed and the correct error message. If one of the queries error out the whole SBOM generation will fail. For example, this report will fail without the current changes:
```json
// this is just the sbom packages piece, the rest is omitted for brevity
"//local.cnquery.io/run/local-execution/queries/mondoo-sbom-packages": {
                    "content": {
                        "packages.list": {
                            "error": "error fetching sbom packages for some reason"
                        }
                    }
                }
```
