### PR TITLE
✨ version(.., type: "semver")

### DIFF
--- a/llx/builtin_global.go
+++ b/llx/builtin_global.go
@@ -233,8 +233,16 @@ func versionCall(e *blockExecutor, f *Function, ref uint64) (*RawData, uint64, e
 				typ := strings.ToLower(t)
 				switch typ {
 				case "semver":
-					if !version.IsSemver() {
+					if version.typ != SEMVER {
 						return &RawData{Error: errors.New("version '" + raw + "' is not a semantic version"), Value: raw, Type: types.Version}, 0, nil
+					}
+				case "debian":
+					if version.typ != SEMVER && version.typ != DEBIAN_VERSION {
+						return &RawData{Error: errors.New("version '" + raw + "' is not a debian version"), Value: raw, Type: types.Version}, 0, nil
+					}
+				case "python":
+					if version.typ != SEMVER && version.typ != PYTHON_VERSION {
+						return &RawData{Error: errors.New("version '" + raw + "' is not a python version"), Value: raw, Type: types.Version}, 0, nil
 					}
 				case "all":
 					break

--- a/llx/builtin_version.go
+++ b/llx/builtin_version.go
@@ -37,6 +37,10 @@ func NewVersion(s string) Version {
 	}
 }
 
+func (v *Version) IsSemver() bool {
+	return v.Version != nil && v.epoch == 0
+}
+
 func parseEpoch(v string) (*semver.Version, int) {
 	prefix := reEpoch.FindString(v)
 	if prefix == "" {

--- a/llx/builtin_version.go
+++ b/llx/builtin_version.go
@@ -11,12 +11,22 @@ import (
 	"go.mondoo.com/cnquery/v11/types"
 )
 
+type VersionType byte
+
+const (
+	UNKNOWN_VERSION VersionType = iota + 1
+	SEMVER
+	DEBIAN_VERSION
+	PYTHON_VERSION
+)
+
 // Version type, an abstract representation of a software version.
 // It is designed to parse and compare version strings.
 // It is built on semver and adds support for epochs (deb, rpm, python).
 type Version struct {
 	*semver.Version
 	src   string
+	typ   VersionType
 	epoch int
 }
 
@@ -25,42 +35,45 @@ var reEpoch = regexp.MustCompile("^[0-9]+[:!]")
 func NewVersion(s string) Version {
 	epoch := 0
 
+	var typ VersionType
 	x, err := semver.NewVersion(s)
-	if err != nil {
-		x, epoch = parseEpoch(s)
+	if err == nil {
+		typ = SEMVER
+	} else {
+		x, epoch, typ = parseEpoch(s)
 	}
 
 	return Version{
 		Version: x,
 		src:     s,
+		typ:     typ,
 		epoch:   epoch,
 	}
 }
 
-func (v *Version) IsSemver() bool {
-	return v.Version != nil && v.epoch == 0
-}
-
-func parseEpoch(v string) (*semver.Version, int) {
+func parseEpoch(v string) (*semver.Version, int, VersionType) {
 	prefix := reEpoch.FindString(v)
 	if prefix == "" {
-		return nil, 0
+		return nil, 0, UNKNOWN_VERSION
 	}
 
 	remainder := v[len(prefix):]
 	epochStr := v[:len(prefix)-1]
 	res, err := semver.NewVersion(remainder)
 	if err != nil {
-		return nil, 0
+		return nil, 0, UNKNOWN_VERSION
 	}
 
 	// invalid epoch means we discard the entire version string
 	epoch, err := strconv.Atoi(epochStr)
 	if err != nil {
-		return nil, 0
+		return nil, 0, UNKNOWN_VERSION
 	}
 
-	return res, epoch
+	if prefix[len(prefix)-1] == ':' {
+		return res, epoch, DEBIAN_VERSION
+	}
+	return res, epoch, PYTHON_VERSION
 }
 
 // Compare compares this version to another one. It returns -1, 0, or 1 if

--- a/mqlc/typemaps.go
+++ b/mqlc/typemaps.go
@@ -36,14 +36,27 @@ func compileTypeConversion(llxID string, typ types.Type) fieldCompiler {
 			return types.Nil, errNotConversion
 		}
 
-		arg := call.Function[0]
-		if arg == nil || arg.Value == nil || arg.Value.Operand == nil || arg.Value.Operand.Value == nil {
-			return types.Nil, errors.New("failed to get parameter for '" + id + "'")
+		otherMap := map[string]*llx.Primitive{}
+		args := []*llx.Primitive{}
+		for i := range call.Function {
+			arg := call.Function[i]
+			if arg == nil || arg.Value == nil || arg.Value.Operand == nil || arg.Value.Operand.Value == nil {
+				return types.Nil, errors.New("failed to get parameter for '" + id + "'")
+			}
+
+			argValue, err := c.compileExpression(arg.Value)
+			if err != nil {
+				return types.Nil, err
+			}
+			if arg.Name != "" {
+				otherMap[arg.Name] = argValue
+			} else {
+				args = append(args, argValue)
+			}
 		}
 
-		argValue, err := c.compileExpression(arg.Value)
-		if err != nil {
-			return types.Nil, err
+		if len(otherMap) != 0 {
+			args = append(args, llx.MapPrimitive(otherMap, types.Any))
 		}
 
 		c.addChunk(&llx.Chunk{
@@ -51,7 +64,7 @@ func compileTypeConversion(llxID string, typ types.Type) fieldCompiler {
 			Id:   llxID,
 			Function: &llx.Function{
 				Type: string(typ),
-				Args: []*llx.Primitive{argValue},
+				Args: args,
 			},
 		})
 

--- a/providers/core/resources/mql_test.go
+++ b/providers/core/resources/mql_test.go
@@ -997,6 +997,21 @@ func TestVersion(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("version type set to semver", func(t *testing.T) {
+		x.TestSimple(t, []testutils.SimpleTest{
+			{
+				Code:        "version('1.2.3', type: 'semver')",
+				ResultIndex: 0, Expectation: "1.2.3",
+			},
+		})
+		x.TestSimpleErrors(t, []testutils.SimpleTest{
+			{
+				Code:        "version('1:1.2.3', type: 'semver')",
+				ResultIndex: 1, Expectation: "version '1:1.2.3' is not a semantic version",
+			},
+		})
+	})
 }
 
 func TestResource_Default(t *testing.T) {


### PR DESCRIPTION
```
cnquery> version("1.2.3", type: 'semver')
version: 1.2.3

cnquery> version("1:1.2.3", type: 'semver')
version '1:1.2.3' is not a semantic version
version: 1:1.2.3

cnquery> version("1:1.2.3", type: 'debian')
version: 1:1.2.3

cnquery> version("1!1.2.3", type: 'python')
version: 1!1.2.3

cnquery> version("1:1.2.3")
version: 1:1.2.3
```

Also adds support for parsing named arguments on builtin type conversion functions (like `version`).

Part 1 of https://github.com/mondoohq/cnquery/pull/5106#issuecomment-2606678743