### PR TITLE
⭐ add version.inRange support

### DIFF
--- a/llx/builtin.go
+++ b/llx/builtin.go
@@ -583,6 +583,7 @@ func init() {
 			string("<=" + types.String):  {f: versionLTEversion, Label: "<="},
 			string(">=" + types.String):  {f: versionGTEversion, Label: ">="},
 			"epoch":                      {f: versionEpoch},
+			"inRange":                    {f: versionInRange, Label: "inRange"},
 		},
 		types.ArrayLike: {
 			"[]":                       {f: arrayGetIndexV2},

--- a/llx/builtin_global.go
+++ b/llx/builtin_global.go
@@ -247,7 +247,7 @@ func versionCall(e *blockExecutor, f *Function, ref uint64) (*RawData, uint64, e
 				case "all":
 					break
 				default:
-					return nil, 0, errors.New("unauppoerws `type=" + t + "` in `version` call")
+					return nil, 0, errors.New("unsupported `type=" + t + "` in `version` call")
 				}
 			}
 		}

--- a/mqlc/builtin.go
+++ b/mqlc/builtin.go
@@ -97,7 +97,8 @@ func init() {
 			"values": {typ: dictArrayType, signature: FunctionSignature{}},
 		},
 		types.Version: {
-			"epoch": {typ: intType, signature: FunctionSignature{}},
+			"epoch":   {typ: intType, signature: FunctionSignature{}},
+			"inRange": {typ: intType, compile: compileVersionInRange},
 		},
 		types.ArrayLike: {
 			"[]":           {typ: childType, signature: FunctionSignature{Required: 1, Args: []types.Type{types.Int}}},

--- a/mqlc/builtin_simple.go
+++ b/mqlc/builtin_simple.go
@@ -239,3 +239,29 @@ func compileTimeInRange(c *compiler, typ types.Type, ref uint64, id string, call
 	})
 	return types.Bool, nil
 }
+
+func compileVersionInRange(c *compiler, _ types.Type, ref uint64, id string, call *parser.Call) (types.Type, error) {
+	if call == nil || len(call.Function) != 2 {
+		return types.Nil, errors.New("function " + id + " needs two arguments")
+	}
+
+	min, err := callArgTypeIs(c, call, id, "min", 0, types.String)
+	if err != nil {
+		return types.Nil, err
+	}
+	max, err := callArgTypeIs(c, call, id, "max", 1, types.String)
+	if err != nil {
+		return types.Nil, err
+	}
+
+	c.addChunk(&llx.Chunk{
+		Call: llx.Chunk_FUNCTION,
+		Id:   "inRange",
+		Function: &llx.Function{
+			Type:    string(types.Bool),
+			Binding: ref,
+			Args:    []*llx.Primitive{min, max},
+		},
+	})
+	return types.Bool, nil
+}

--- a/providers/core/resources/mql_test.go
+++ b/providers/core/resources/mql_test.go
@@ -1012,6 +1012,25 @@ func TestVersion(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("version inRange", func(t *testing.T) {
+		x.TestSimple(t, []testutils.SimpleTest{
+			{Code: "version('1.2.3').inRange('>= 1.0.0', '< 2.0.0')", ResultIndex: 0, Expectation: true},
+			{Code: "version('1.2.3').inRange('>= 1.0.0', '< 1.2.0')", ResultIndex: 0, Expectation: false},
+			{Code: "version('1.2.3').inRange('>= 1.0.0', '<= 1.2.3')", ResultIndex: 0, Expectation: true},
+			{Code: "version('1.2.3').inRange('>= 1.0.0', '< 1.2.3')", ResultIndex: 0, Expectation: false},
+			{Code: "version('1.2.3').inRange('>= 1.2.3', '< 2.0.0')", ResultIndex: 0, Expectation: true},
+			{Code: "version('1.2.3').inRange('> 1.2.3', '< 2.0.0')", ResultIndex: 0, Expectation: false},
+			{Code: "version('1.2.3').inRange('1.0.0', '1.2.3')", ResultIndex: 0, Expectation: true},
+			{Code: "version('1.2.3').inRange('1.2.3', '2.0.0')", ResultIndex: 0, Expectation: true},
+			{Code: "version('1.2.3').inRange('1.2.3', '1.2.3')", ResultIndex: 0, Expectation: true},
+		})
+
+		x.TestSimpleErrors(t, []testutils.SimpleTest{
+			{Code: "version('1:1.2.3').inRange('>= 1.0.0', '< 2.0.0')", ResultIndex: 0, Expectation: "inRange is only supported on comparable versions (epoch doesn't work yet)"},
+			{Code: "version('1.2.3.4.5').inRange('>= 1.0.0', '< 2.0.0')", ResultIndex: 0, Expectation: "inRange is only supported on comparable versions (semver or similar)"},
+		})
+	})
 }
 
 func TestResource_Default(t *testing.T) {


### PR DESCRIPTION
After #5208

Part 2 of https://github.com/mondoohq/cnquery/pull/5106#issuecomment-2606678743

Best seen in the tests, here are a few examples:
    
```
> version('1.2.3').inRange('>= 1.0.0', '< 2.0.0')
true

> version('1.2.3').inRange('1.2.0', '1.2.3')
true
```