### PR TITLE
⭐ print file context to CLI

### DIFF
--- a/feature_string.go
+++ b/feature_string.go
@@ -18,11 +18,12 @@ func _() {
 	_ = x[FineGrainedAssets-8]
 	_ = x[SerialNumberAsID-9]
 	_ = x[ForceShellCompletion-10]
+	_ = x[ResourceContext-11]
 }
 
-const _Feature_name = "MassQueriesPiperCodeBoolAssertionsK8sNodeDiscoveryMQLAssetContextErrorsAsFailuresStoreResourcesDataFineGrainedAssetsSerialNumberAsIDForceShellCompletion"
+const _Feature_name = "MassQueriesPiperCodeBoolAssertionsK8sNodeDiscoveryMQLAssetContextErrorsAsFailuresStoreResourcesDataFineGrainedAssetsSerialNumberAsIDForceShellCompletionResourceContext"
 
-var _Feature_index = [...]uint8{0, 11, 20, 34, 50, 65, 81, 99, 116, 132, 152}
+var _Feature_index = [...]uint8{0, 11, 20, 34, 50, 65, 81, 99, 116, 132, 152, 167}
 
 func (i Feature) String() string {
 	i -= 1

--- a/featureflags.go
+++ b/featureflags.go
@@ -99,6 +99,11 @@ const (
 	// desc:  Forces shell completion to be enabled (for windows)
 	// start: v11.x
 	ForceShellCompletion
+
+	// ResourceContext feature flag
+	// desc:  Automatically add resource context to results and prints it
+	// start: v11.x
+	ResourceContext
 )
 
 // FeaturesValue is a map from feature name to feature flag
@@ -112,6 +117,7 @@ var FeaturesValue = map[string]Feature{
 	FineGrainedAssets.String():    FineGrainedAssets,
 	SerialNumberAsID.String():     SerialNumberAsID,
 	ForceShellCompletion.String(): ForceShellCompletion,
+	ResourceContext.String():      ResourceContext,
 }
 
 // DefaultFeatures are a set of default flags that are active

--- a/llx/range.go
+++ b/llx/range.go
@@ -171,6 +171,10 @@ func (r Range) ExtractAll() [][]uint32 {
 	return res
 }
 
+func (r Range) IsEmpty() bool {
+	return len(r) == 0
+}
+
 func (r Range) String() string {
 	var res strings.Builder
 
@@ -221,7 +225,7 @@ type ExtractConfig struct {
 }
 
 var DefaultExtractConfig = ExtractConfig{
-	MaxLines:          8,
+	MaxLines:          5,
 	MaxColumns:        100,
 	ShowLineNumbers:   true,
 	LineNumberPadding: 2,

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -374,7 +374,7 @@ file @defaults("path size permissions.string") {
 }
 
 // File context is a range of lines/columns in a file
-private file.context @defaults("file.path range") {
+private file.context @defaults("file.path range content") {
   // File referenced by this file context
   file file
   // Range of content in the file


### PR DESCRIPTION
Specialized printer for file context for resources that support it:

```
sshd.config.blocks: [
  0: sshd.config.matchBlock criteria=""
     in /pub/go/src/go.mondoo.com/cnquery/sshd_config:1-172
       1:  # #
       2:  # Ansible managed
     ...
     171:  RevokedKeys /etc/ssh/revoked_keys
     172:

  1: sshd.config.matchBlock criteria="Group sftp-users"
     in /pub/go/src/go.mondoo.com/cnquery/sshd_config:173-177
     173:  Match Group sftp-users
     174:         X11Forwarding no
     175:         PermitRootLogin no
     176:         AllowTCPForwarding yes
     177:

  2: sshd.config.matchBlock criteria="User myservice"
     in /pub/go/src/go.mondoo.com/cnquery/sshd_config:178-181
     178:  Match User myservice
     179:
     180:
]
```