### PR TITLE
✨ github: repo and org custom properties

### DIFF
--- a/providers-sdk/v1/util/convert/dict.go
+++ b/providers-sdk/v1/util/convert/dict.go
@@ -41,7 +41,7 @@ func JsonToDictSlice(v interface{}) ([]interface{}, error) {
 }
 
 // DictToTypedMap converts a `dict` into a `map[string]T` safely.
-// It discarts anything that can't be converted to `T`.
+// It discards anything that can't be converted to `T`.
 func DictToTypedMap[T any](d interface{}) map[string]T {
 	m := make(map[string]T)
 	dict, ok := d.(map[string]interface{})

--- a/providers-sdk/v1/util/convert/dict.go
+++ b/providers-sdk/v1/util/convert/dict.go
@@ -39,3 +39,18 @@ func JsonToDictSlice(v interface{}) ([]interface{}, error) {
 	}
 	return res, nil
 }
+
+// DictToTypedMap converts a `dict` into a `map[string]T` safely.
+// It discarts anything that can't be converted to `T`.
+func DictToTypedMap[T any](d interface{}) map[string]T {
+	m := make(map[string]T)
+	dict, ok := d.(map[string]interface{})
+	if ok {
+		for k, v := range dict {
+			if t, ok := v.(T); ok {
+				m[k] = t
+			}
+		}
+	}
+	return m
+}

--- a/providers-sdk/v1/util/convert/dict_test.go
+++ b/providers-sdk/v1/util/convert/dict_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package convert_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	subject "go.mondoo.com/cnquery/v11/providers-sdk/v1/util/convert"
+)
+
+func TestDictToMapStr_Int(t *testing.T) {
+	input := map[string]interface{}{
+		"one": 1,
+		"two": 2,
+		"bad": "not-an-int",
+	}
+	expected := map[string]int{
+		"one": 1,
+		"two": 2,
+	}
+
+	output := subject.DictToTypedMap[int](input)
+	assert.Equal(t, expected, output)
+}
+
+func TestDictToMapStr_String(t *testing.T) {
+	input := map[string]interface{}{
+		"a": "hello",
+		"b": "world",
+		"c": 123, // Should be ignored
+	}
+	expected := map[string]string{
+		"a": "hello",
+		"b": "world",
+	}
+
+	output := subject.DictToTypedMap[string](input)
+	assert.Equal(t, expected, output)
+}
+
+func TestDictToMapStr_EmptyInput(t *testing.T) {
+	output := subject.DictToTypedMap[int](nil)
+	assert.Empty(t, output)
+}
+
+func TestDictToMapStr_WrongType(t *testing.T) {
+	input := map[string]interface{}{
+		"x": []int{1, 2, 3},
+		"y": map[string]interface{}{"nested": "value"},
+	}
+	output := subject.DictToTypedMap[string](input)
+	assert.Empty(t, output)
+}
+
+func TestDictToMapStr_NonMapInput(t *testing.T) {
+	output := subject.DictToTypedMap[int]("not a map")
+	assert.Empty(t, output)
+}

--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -167,13 +167,6 @@ func org(runtime *plugin.Runtime, orgName string, conn *connection.GithubConnect
 				if customProperty.DefaultValue.IsSet() {
 					// if the default value of the org-leve custom property is set, use it as the label value
 					value = customProperty.DefaultValue.Data
-				} else if customProperty.Required.IsSet() {
-					// if not, and if the required field of the org-leve custom property is set, use it as to
-					// indicate if the property is required or not
-					value = "[not-required]"
-					if customProperty.Required.Data {
-						value = "[required]"
-					}
 				}
 				labels[customProperty.Name.Data] = value
 			}

--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -117,7 +117,7 @@ func org(runtime *plugin.Runtime, orgName string, conn *connection.GithubConnect
 			customProperty := org.GetCustomProperties().Data[j].(*mqlGithubOrganizationCustomProperty)
 			value := ""
 			if customProperty.DefaultValue.IsSet() {
-				// if the default value of the org-leve custom property is set, use it as the label value
+				// if the default value of the org-level custom property is set, use it as the label value
 				value = customProperty.DefaultValue.Data
 			}
 			labels[customProperty.Name.Data] = value

--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -206,7 +206,7 @@ func repo(runtime *plugin.Runtime, repoName string, owner string, conn *connecti
 		PlatformIds: []string{connection.NewGitHubRepoIdentifier(owner, repo.Name.Data)},
 		Name:        owner + "/" + repo.Name.Data,
 		Platform:    connection.NewGitHubRepoPlatform(owner, repo.Name.Data),
-		Labels:      make(map[string]string),
+		Labels:      convert.DictToTypedMap[string](repo.CustomProperties.Data),
 		Connections: []*inventory.Config{cfg},
 	})
 

--- a/providers/github/resources/github.lr
+++ b/providers/github/resources/github.lr
@@ -140,21 +140,21 @@ github.organization @defaults("login name") {
 
 // GitHub organization-level custom property
 private github.organization.customProperty @defaults("name required") {
-  // The name of the property.
+  // The name of the property
   name string
-  // Short description of the property.
+  // Short description of the property
   description string
-  // SourceType is the source type of the property where it has been created.
+  // The source type of the property (where it was created)
   sourceType string
-  // The type of the value for the property.
+  // The type of the value for the property
   valueType string
-  // Whether the property is required.
+  // Whether the property is required
   required bool
-  // Default value of the property.
+  // Default value of the property
   defaultValue string
-  // An ordered list of the allowed values of the property.
+  // An ordered list of the allowed values of the property
   allowedValues []string
-  // Who can edit the values of the property.
+  // Who can edit the values of the property
   valuesEditableBy string
 }
 

--- a/providers/github/resources/github.lr
+++ b/providers/github/resources/github.lr
@@ -144,9 +144,9 @@ private github.organization.customProperty @defaults("name required") {
   name string
   // Short description of the property
   description string
-  // The source type of the property (where it was created)
+  // Source type of the property (where it was created)
   sourceType string
-  // The type of the value for the property
+  // Type of the value for the property
   valueType string
   // Whether the property is required
   required bool

--- a/providers/github/resources/github.lr
+++ b/providers/github/resources/github.lr
@@ -134,6 +134,28 @@ github.organization @defaults("login name") {
   hasOrganizationProjects bool
   // Whether projects in the organization have projects
   hasRepositoryProjects bool
+  // Organization custom properties
+  customProperties() []github.organization.customProperty
+}
+
+// GitHub organization-level custom property
+private github.organization.customProperty @defaults("name required") {
+  // The name of the property.
+  name string
+  // Short description of the property.
+  description string
+  // SourceType is the source type of the property where it has been created.
+  sourceType string
+  // The type of the value for the property.
+  valueType string
+  // Whether the property is required.
+  required bool
+  // Default value of the property.
+  defaultValue string
+  // An ordered list of the allowed values of the property.
+  allowedValues []string
+  // Who can edit the values of the property.
+  valuesEditableBy string
 }
 
 // GitHub user
@@ -308,6 +330,8 @@ private github.repository @defaults("fullName") {
   hasDiscussions bool
   // Whether the repository is an organization repository template
   isTemplate bool
+  // Repository custom properties
+  customProperties dict
   // List of open merge requests for the repository
   openMergeRequests() []github.mergeRequest
   // List of closed merge requests for the repository

--- a/providers/github/resources/github.lr.go
+++ b/providers/github/resources/github.lr.go
@@ -38,6 +38,10 @@ func init() {
 			Init: initGithubOrganization,
 			Create: createGithubOrganization,
 		},
+		"github.organization.customProperty": {
+			// to override args, implement: initGithubOrganizationCustomProperty(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGithubOrganizationCustomProperty,
+		},
 		"github.user": {
 			Init: initGithubUser,
 			Create: createGithubUser,
@@ -357,6 +361,33 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"github.organization.hasRepositoryProjects": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubOrganization).GetHasRepositoryProjects()).ToDataRes(types.Bool)
 	},
+	"github.organization.customProperties": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubOrganization).GetCustomProperties()).ToDataRes(types.Array(types.Resource("github.organization.customProperty")))
+	},
+	"github.organization.customProperty.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubOrganizationCustomProperty).GetName()).ToDataRes(types.String)
+	},
+	"github.organization.customProperty.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubOrganizationCustomProperty).GetDescription()).ToDataRes(types.String)
+	},
+	"github.organization.customProperty.sourceType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubOrganizationCustomProperty).GetSourceType()).ToDataRes(types.String)
+	},
+	"github.organization.customProperty.valueType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubOrganizationCustomProperty).GetValueType()).ToDataRes(types.String)
+	},
+	"github.organization.customProperty.required": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubOrganizationCustomProperty).GetRequired()).ToDataRes(types.Bool)
+	},
+	"github.organization.customProperty.defaultValue": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubOrganizationCustomProperty).GetDefaultValue()).ToDataRes(types.String)
+	},
+	"github.organization.customProperty.allowedValues": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubOrganizationCustomProperty).GetAllowedValues()).ToDataRes(types.Array(types.String))
+	},
+	"github.organization.customProperty.valuesEditableBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubOrganizationCustomProperty).GetValuesEditableBy()).ToDataRes(types.String)
+	},
 	"github.user.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubUser).GetId()).ToDataRes(types.Int)
 	},
@@ -581,6 +612,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"github.repository.isTemplate": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubRepository).GetIsTemplate()).ToDataRes(types.Bool)
+	},
+	"github.repository.customProperties": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubRepository).GetCustomProperties()).ToDataRes(types.Dict)
 	},
 	"github.repository.openMergeRequests": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubRepository).GetOpenMergeRequests()).ToDataRes(types.Array(types.Resource("github.mergeRequest")))
@@ -1229,6 +1263,46 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlGithubOrganization).HasRepositoryProjects, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"github.organization.customProperties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubOrganization).CustomProperties, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"github.organization.customProperty.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlGithubOrganizationCustomProperty).__id, ok = v.Value.(string)
+			return
+		},
+	"github.organization.customProperty.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubOrganizationCustomProperty).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"github.organization.customProperty.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubOrganizationCustomProperty).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"github.organization.customProperty.sourceType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubOrganizationCustomProperty).SourceType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"github.organization.customProperty.valueType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubOrganizationCustomProperty).ValueType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"github.organization.customProperty.required": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubOrganizationCustomProperty).Required, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"github.organization.customProperty.defaultValue": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubOrganizationCustomProperty).DefaultValue, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"github.organization.customProperty.allowedValues": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubOrganizationCustomProperty).AllowedValues, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"github.organization.customProperty.valuesEditableBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubOrganizationCustomProperty).ValuesEditableBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"github.user.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 			r.(*mqlGithubUser).__id, ok = v.Value.(string)
 			return
@@ -1551,6 +1625,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"github.repository.isTemplate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGithubRepository).IsTemplate, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"github.repository.customProperties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubRepository).CustomProperties, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
 		return
 	},
 	"github.repository.openMergeRequests": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2438,6 +2516,7 @@ type mqlGithubOrganization struct {
 	Packages plugin.TValue[[]interface{}]
 	HasOrganizationProjects plugin.TValue[bool]
 	HasRepositoryProjects plugin.TValue[bool]
+	CustomProperties plugin.TValue[[]interface{}]
 }
 
 // createGithubOrganization creates a new instance of this resource
@@ -2731,6 +2810,106 @@ func (c *mqlGithubOrganization) GetHasOrganizationProjects() *plugin.TValue[bool
 
 func (c *mqlGithubOrganization) GetHasRepositoryProjects() *plugin.TValue[bool] {
 	return &c.HasRepositoryProjects
+}
+
+func (c *mqlGithubOrganization) GetCustomProperties() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.CustomProperties, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("github.organization", c.__id, "customProperties")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.customProperties()
+	})
+}
+
+// mqlGithubOrganizationCustomProperty for the github.organization.customProperty resource
+type mqlGithubOrganizationCustomProperty struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlGithubOrganizationCustomPropertyInternal it will be used here
+	Name plugin.TValue[string]
+	Description plugin.TValue[string]
+	SourceType plugin.TValue[string]
+	ValueType plugin.TValue[string]
+	Required plugin.TValue[bool]
+	DefaultValue plugin.TValue[string]
+	AllowedValues plugin.TValue[[]interface{}]
+	ValuesEditableBy plugin.TValue[string]
+}
+
+// createGithubOrganizationCustomProperty creates a new instance of this resource
+func createGithubOrganizationCustomProperty(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGithubOrganizationCustomProperty{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+	res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("github.organization.customProperty", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGithubOrganizationCustomProperty) MqlName() string {
+	return "github.organization.customProperty"
+}
+
+func (c *mqlGithubOrganizationCustomProperty) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGithubOrganizationCustomProperty) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlGithubOrganizationCustomProperty) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlGithubOrganizationCustomProperty) GetSourceType() *plugin.TValue[string] {
+	return &c.SourceType
+}
+
+func (c *mqlGithubOrganizationCustomProperty) GetValueType() *plugin.TValue[string] {
+	return &c.ValueType
+}
+
+func (c *mqlGithubOrganizationCustomProperty) GetRequired() *plugin.TValue[bool] {
+	return &c.Required
+}
+
+func (c *mqlGithubOrganizationCustomProperty) GetDefaultValue() *plugin.TValue[string] {
+	return &c.DefaultValue
+}
+
+func (c *mqlGithubOrganizationCustomProperty) GetAllowedValues() *plugin.TValue[[]interface{}] {
+	return &c.AllowedValues
+}
+
+func (c *mqlGithubOrganizationCustomProperty) GetValuesEditableBy() *plugin.TValue[string] {
+	return &c.ValuesEditableBy
 }
 
 // mqlGithubUser for the github.user resource
@@ -3309,6 +3488,7 @@ type mqlGithubRepository struct {
 	HasDownloads plugin.TValue[bool]
 	HasDiscussions plugin.TValue[bool]
 	IsTemplate plugin.TValue[bool]
+	CustomProperties plugin.TValue[interface{}]
 	OpenMergeRequests plugin.TValue[[]interface{}]
 	ClosedMergeRequests plugin.TValue[[]interface{}]
 	AllMergeRequests plugin.TValue[[]interface{}]
@@ -3501,6 +3681,10 @@ func (c *mqlGithubRepository) GetHasDiscussions() *plugin.TValue[bool] {
 
 func (c *mqlGithubRepository) GetIsTemplate() *plugin.TValue[bool] {
 	return &c.IsTemplate
+}
+
+func (c *mqlGithubRepository) GetCustomProperties() *plugin.TValue[interface{}] {
+	return &c.CustomProperties
 }
 
 func (c *mqlGithubRepository) GetOpenMergeRequests() *plugin.TValue[[]interface{}] {

--- a/providers/github/resources/github.lr.manifest.yaml
+++ b/providers/github/resources/github.lr.manifest.yaml
@@ -191,6 +191,8 @@ resources:
       company: {}
       createdAt:
         min_mondoo_version: 6.11.0
+      customProperties:
+        min_mondoo_version: 9.0.0
       defaultRepositoryPermission:
         min_mondoo_version: 6.11.0
       description: {}
@@ -260,6 +262,18 @@ resources:
       webhooks:
         min_mondoo_version: 6.11.0
     min_mondoo_version: 5.15.0
+  github.organization.customProperty:
+    fields:
+      allowedValues: {}
+      defaultValue: {}
+      description: {}
+      name: {}
+      required: {}
+      sourceType: {}
+      valueType: {}
+      valuesEditableBy: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
   github.package:
     fields:
       createdAt: {}
@@ -324,6 +338,8 @@ resources:
       contributors:
         min_mondoo_version: 6.4.0
       createdAt: {}
+      customProperties:
+        min_mondoo_version: 9.0.0
       defaultBranch:
         min_mondoo_version: 9.0.0
       defaultBranchName:

--- a/providers/github/resources/github_org.go
+++ b/providers/github/resources/github_org.go
@@ -127,7 +127,7 @@ func (g *mqlGithubOrganization) customProperties() ([]interface{}, error) {
 			"name":             llx.StringDataPtr(property.PropertyName),
 			"description":      llx.StringDataPtr(property.Description),
 			"sourceType":       llx.StringDataPtr(property.SourceType),
-			"valueType":        llx.StringDataPtr(&property.ValueType),
+			"valueType":        llx.StringData(property.ValueType),
 			"required":         llx.BoolDataPtr(property.Required),
 			"defaultValue":     llx.StringDataPtr(property.DefaultValue),
 			"allowedValues":    llx.ArrayData(convert.SliceAnyToInterface[string](property.AllowedValues), types.String),

--- a/providers/github/resources/github_org.go
+++ b/providers/github/resources/github_org.go
@@ -102,6 +102,46 @@ func initGithubOrganization(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	return args, nil, nil
 }
 
+func (g *mqlGithubOrganizationCustomProperty) id() (string, error) {
+	return "github.organization.customProperty/" + g.Name.Data, nil
+}
+
+func (g *mqlGithubOrganization) customProperties() ([]interface{}, error) {
+	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
+	if g.Login.Error != nil {
+		return nil, g.Login.Error
+	}
+	orgLogin := g.Login.Data
+
+	// API doesn't have pagination:
+	//
+	// https://docs.github.com/en/rest/orgs/custom-properties?apiVersion=2022-11-28#get-all-custom-properties-for-an-organization--parameters
+	customProperties, _, err := conn.Client().Organizations.GetAllCustomProperties(conn.Context(), orgLogin)
+	if err != nil {
+		return nil, err
+	}
+
+	resources := []interface{}{}
+	for _, property := range customProperties {
+		r, err := CreateResource(g.MqlRuntime, "github.organization.customProperty", map[string]*llx.RawData{
+			"name":             llx.StringDataPtr(property.PropertyName),
+			"description":      llx.StringDataPtr(property.Description),
+			"sourceType":       llx.StringDataPtr(property.SourceType),
+			"valueType":        llx.StringDataPtr(&property.ValueType),
+			"required":         llx.BoolDataPtr(property.Required),
+			"defaultValue":     llx.StringDataPtr(property.DefaultValue),
+			"allowedValues":    llx.ArrayData(convert.SliceAnyToInterface[string](property.AllowedValues), types.String),
+			"valuesEditableBy": llx.StringDataPtr(property.ValuesEditableBy),
+		})
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, r)
+	}
+
+	return resources, nil
+}
+
 func (g *mqlGithubOrganization) members() ([]interface{}, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 	if g.Login.Error != nil {

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -72,6 +72,7 @@ func newMqlGithubRepository(runtime *plugin.Runtime, repo *github.Repository) (*
 		"cloneUrl":          llx.StringData(repo.GetCloneURL()),
 		"sshUrl":            llx.StringData(repo.GetSSHURL()),
 		"owner":             llx.ResourceData(owner, owner.MqlName()),
+		"customProperties":  llx.DictData(repo.CustomProperties),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Relates to https://github.com/mondoohq/cnquery/pull/5227

GitHub has a new concept of Custom Properties which allow organizations to have their own properties on each repo in their GitHub orgs.

https://docs.github.com/en/organizations/managing-organization-settings

## 📖 User Story

As a user I need to be able to see GitHub Custom Properties I've set on my organizations and repositories using Mondoo, so I can understand key metadata values such as team ownership.

## Documentation updates @misterpantz 

To retrieve these custom properties, the authenticated user must be one of:
* An administrator for the organization.
* A user, or a user on a team, with the fine-grained permission of
`custom_properties_org_definitions_manager` in the organization.

From:
![Screenshot 2025-02-12 at 2 24 06 PM](https://github.com/user-attachments/assets/bbdaa046-4c59-4886-8bed-b9c08ceeeb9d)

To:
![Screenshot 2025-02-12 at 2 39 19 PM](https://github.com/user-attachments/assets/e7298467-1da7-435d-bb22-2a0df137154f)

## 🧪 Testing

### Repository

No custom properties:

![Screenshot 2025-02-12 at 10 03 22 AM](https://github.com/user-attachments/assets/686fe308-06a1-4ac5-991d-457e91616002)

With custom properties:

![Screenshot 2025-02-12 at 2 03 24 PM](https://github.com/user-attachments/assets/9b760839-6d5f-4a97-bff4-5b5da6342343)

![Screenshot 2025-02-12 at 10 03 14 AM](https://github.com/user-attachments/assets/af48ddd9-c496-4a06-84c5-d49ba7ba3cbf)

### Organization

![Screenshot 2025-02-12 at 2 33 13 PM](https://github.com/user-attachments/assets/a0f28318-78a5-49ad-8913-298f85424ab8)

![Screenshot 2025-02-12 at 2 35 38 PM](https://github.com/user-attachments/assets/70f1a304-bdd7-4d42-9872-a0b64d162705)
