### PR TITLE
🐛 Align photon PURL namespace with ecosystem

### DIFF
--- a/providers/os/resources/packages/rpm_packages_test.go
+++ b/providers/os/resources/packages/rpm_packages_test.go
@@ -255,7 +255,7 @@ func TestPhoton4ImageParser(t *testing.T) {
 		Vendor:      "VMware, Inc.",
 		Arch:        "x86_64",
 		Description: "Ncurses Libraries",
-		PUrl:        "pkg:rpm/photon/ncurses-libs@6.2-6.ph4?arch=x86_64&distro=photon-4.0",
+		PUrl:        "pkg:rpm/photon%20os/ncurses-libs@6.2-6.ph4?arch=x86_64&distro=photon-4.0",
 		CPEs: []string{
 			"cpe:2.3:a:vmware\\,_inc.:ncurses-libs:6.2-6.ph4:*:*:*:*:*:x86_64:*",
 			"cpe:2.3:a:vmware\\,_inc.:ncurses-libs:6.2:*:*:*:*:*:x86_64:*",
@@ -273,7 +273,7 @@ func TestPhoton4ImageParser(t *testing.T) {
 		Vendor:      "VMware, Inc.",
 		Arch:        "x86_64",
 		Description: "Bourne-Again SHell",
-		PUrl:        "pkg:rpm/photon/bash@5.0-4.ph4?arch=x86_64&distro=photon-4.0",
+		PUrl:        "pkg:rpm/photon%20os/bash@5.0-4.ph4?arch=x86_64&distro=photon-4.0",
 		CPEs: []string{
 			"cpe:2.3:a:vmware\\,_inc.:bash:5.0-4.ph4:*:*:*:*:*:x86_64:*",
 			"cpe:2.3:a:vmware\\,_inc.:bash:5.0:*:*:*:*:*:x86_64:*",
@@ -291,7 +291,7 @@ func TestPhoton4ImageParser(t *testing.T) {
 		Vendor:      "VMware, Inc.",
 		Arch:        "x86_64",
 		Description: "sqlite3 library",
-		PUrl:        "pkg:rpm/photon/sqlite-libs@3.38.5-4.ph4?arch=x86_64&distro=photon-4.0",
+		PUrl:        "pkg:rpm/photon%20os/sqlite-libs@3.38.5-4.ph4?arch=x86_64&distro=photon-4.0",
 		CPEs: []string{
 			"cpe:2.3:a:vmware\\,_inc.:sqlite-libs:3.38.5-4.ph4:*:*:*:*:*:x86_64:*",
 			"cpe:2.3:a:vmware\\,_inc.:sqlite-libs:3.38.5-4:*:*:*:*:*:x86_64:*",

--- a/providers/os/resources/purl/purl.go
+++ b/providers/os/resources/purl/purl.go
@@ -77,9 +77,14 @@ func NewPackageURL(pf *inventory.Platform, t Type, name, version string, modifie
 		// use the platform architecture for the package
 		purl.Arch = pf.Arch
 
-		if pf.Name != "" {
-			purl.Namespace = pf.Name
+		purlNamespace := pf.Name
+		if purlNamespace == "photon" {
+			purlNamespace = "photon os"
 		}
+		if purlNamespace != "" {
+			purl.Namespace = purlNamespace
+		}
+
 	}
 
 	// apply modifiers

--- a/providers/os/resources/purl/purl_test.go
+++ b/providers/os/resources/purl/purl_test.go
@@ -237,4 +237,30 @@ func TestPackageURLString(t *testing.T) {
 		expected := "pkg:rpm/redhat/testpkg@1.0.0?arch=x86_64&distro=rhel-9.2"
 		assert.Equal(t, expected, p.String())
 	})
+
+	t.Run("Photon package", func(t *testing.T) {
+		platform := &inventory.Platform{
+			Name:    "photon",
+			Arch:    "x86_64",
+			Version: "4.0",
+			Labels:  nil,
+		}
+		p := purl.NewPackageURL(platform, purl.TypeRPM, "testpkg", "1.0.0")
+		expected := "pkg:rpm/photon%20os/testpkg@1.0.0?arch=x86_64"
+		assert.Equal(t, expected, p.String())
+	})
+
+	t.Run("Photon package with distro-id and name", func(t *testing.T) {
+		platform := &inventory.Platform{
+			Name:    "photon",
+			Arch:    "x86_64",
+			Version: "4.0",
+			Labels: map[string]string{
+				"distro-id": "photon",
+			},
+		}
+		p := purl.NewPackageURL(platform, purl.TypeRPM, "testpkg", "1.0.0")
+		expected := "pkg:rpm/photon%20os/testpkg@1.0.0?arch=x86_64&distro=photon-4.0"
+		assert.Equal(t, expected, p.String())
+	})
 }


### PR DESCRIPTION
Align the namespace with the osv ecosystem.

'pkg:rpm/photon/...' -> 'pkg:rpm/photon%20os/...'