### PR TITLE
🧹 Wire up the remainder of aws.iam.role.createdAt

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -907,8 +907,10 @@ private aws.iam.group @defaults("arn name") {
   id string
   // Name of the group
   name string
-  // Time when the group was created
+  // Time when the group was created: deprecated, use createdAt
   createDate time
+  // Time when the group was created
+  createdAt time
   // List of usernames that belong to the group
   usernames []string
 }

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -1844,6 +1844,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.iam.group.createDate": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamGroup).GetCreateDate()).ToDataRes(types.Time)
 	},
+	"aws.iam.group.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamGroup).GetCreatedAt()).ToDataRes(types.Time)
+	},
 	"aws.iam.group.usernames": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamGroup).GetUsernames()).ToDataRes(types.Array(types.String))
 	},
@@ -6594,6 +6597,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.iam.group.createDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamGroup).CreateDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.iam.group.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamGroup).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.iam.group.usernames": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15963,6 +15970,7 @@ type mqlAwsIamGroup struct {
 	Id plugin.TValue[string]
 	Name plugin.TValue[string]
 	CreateDate plugin.TValue[*time.Time]
+	CreatedAt plugin.TValue[*time.Time]
 	Usernames plugin.TValue[[]interface{}]
 }
 
@@ -16017,6 +16025,10 @@ func (c *mqlAwsIamGroup) GetName() *plugin.TValue[string] {
 
 func (c *mqlAwsIamGroup) GetCreateDate() *plugin.TValue[*time.Time] {
 	return &c.CreateDate
+}
+
+func (c *mqlAwsIamGroup) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
 }
 
 func (c *mqlAwsIamGroup) GetUsernames() *plugin.TValue[[]interface{}] {

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2006,6 +2006,8 @@ resources:
     fields:
       arn: {}
       createDate: {}
+      createdAt:
+        min_mondoo_version: 9.0.0
       id: {}
       name: {}
       usernames: {}


### PR DESCRIPTION
It was in the code but not the lr which caused failures

```
[failed] [].all()
  error: [aws] cannot set 'createdAt' in resource 'aws.iam.group', field not found
```