### PR TITLE
🐛 print line+column range correctly

### DIFF
--- a/llx/range.go
+++ b/llx/range.go
@@ -197,9 +197,9 @@ func (r Range) String() string {
 		case 4:
 			res.WriteString(strconv.Itoa(int(x[0])))
 			res.WriteString(":")
-			res.WriteString(strconv.Itoa(int(x[1])))
-			res.WriteString("-")
 			res.WriteString(strconv.Itoa(int(x[2])))
+			res.WriteString("-")
+			res.WriteString(strconv.Itoa(int(x[1])))
 			res.WriteString(":")
 			res.WriteString(strconv.Itoa(int(x[3])))
 		}

--- a/llx/range_test.go
+++ b/llx/range_test.go
@@ -33,7 +33,7 @@ func TestRange(t *testing.T) {
 	})
 
 	t.Run("line and column range", func(t *testing.T) {
-		r := RangePrimitive(NewRange().AddLineColumnRange(12, 3, 12345678, 1234567))
+		r := RangePrimitive(NewRange().AddLineColumnRange(12, 12345678, 3, 1234567))
 		assert.Equal(t, "12:3-12345678:1234567", r.LabelV2(nil))
 	})
 }


### PR DESCRIPTION
There was a mixup with how this method works, because it adds line start
+ end before adding each column. I had it sorted differently earlier and this was a leftover on the CLI printer that messed it up.