### PR TITLE
🐛 fix `aws.s3.bucket.policy` resource

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1822,9 +1822,11 @@ private aws.s3.bucket.corsrule @defaults("name") {
 }
 
 // Amazon S3 bucket policy
-private aws.s3.bucket.policy @defaults("bucketName exists version") {
+private aws.s3.bucket.policy @defaults("bucketName version") {
   // Unique ID for the policy
   id string
+  // Deprecated
+  name string
   // Bucket name that this policy belongs
   bucketName string
   // Document for the policy
@@ -1833,10 +1835,7 @@ private aws.s3.bucket.policy @defaults("bucketName exists version") {
   version() string
   // List of statements for the policy
   statements() []dict
-  // Whether the bucket policy exists
-  exists bool
 }
-
 
 // AWS Application Auto Scaling
 aws.applicationAutoscaling @defaults("namespace") {

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1825,7 +1825,7 @@ private aws.s3.bucket.corsrule @defaults("name") {
 private aws.s3.bucket.policy @defaults("bucketName version") {
   // Unique ID for the policy
   id string
-  // Deprecated
+  // Deprecated. Use `bucketName` instead
   name string
   // Bucket name that this policy belongs
   bucketName string

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1822,17 +1822,19 @@ private aws.s3.bucket.corsrule @defaults("name") {
 }
 
 // Amazon S3 bucket policy
-private aws.s3.bucket.policy @defaults("name version") {
+private aws.s3.bucket.policy @defaults("bucketName exists version") {
   // Unique ID for the policy
   id string
-  // Name for the policy
-  name string
+  // Bucket name that this policy belongs
+  bucketName string
   // Document for the policy
   document string
   // Version of the policy
   version() string
   // List of statements for the policy
   statements() []dict
+  // Whether the bucket policy exists
+  exists bool
 }
 
 

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -2879,6 +2879,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.s3.bucket.policy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsS3BucketPolicy).GetId()).ToDataRes(types.String)
 	},
+	"aws.s3.bucket.policy.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsS3BucketPolicy).GetName()).ToDataRes(types.String)
+	},
 	"aws.s3.bucket.policy.bucketName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsS3BucketPolicy).GetBucketName()).ToDataRes(types.String)
 	},
@@ -2890,9 +2893,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.s3.bucket.policy.statements": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsS3BucketPolicy).GetStatements()).ToDataRes(types.Array(types.Dict))
-	},
-	"aws.s3.bucket.policy.exists": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsS3BucketPolicy).GetExists()).ToDataRes(types.Bool)
 	},
 	"aws.applicationAutoscaling.namespace": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsApplicationAutoscaling).GetNamespace()).ToDataRes(types.String)
@@ -8209,6 +8209,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsS3BucketPolicy).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.s3.bucket.policy.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsS3BucketPolicy).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.s3.bucket.policy.bucketName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsS3BucketPolicy).BucketName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -8223,10 +8227,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.s3.bucket.policy.statements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsS3BucketPolicy).Statements, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
-		return
-	},
-	"aws.s3.bucket.policy.exists": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsS3BucketPolicy).Exists, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.applicationAutoscaling.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20844,11 +20844,11 @@ type mqlAwsS3BucketPolicy struct {
 	__id string
 	// optional: if you define mqlAwsS3BucketPolicyInternal it will be used here
 	Id plugin.TValue[string]
+	Name plugin.TValue[string]
 	BucketName plugin.TValue[string]
 	Document plugin.TValue[string]
 	Version plugin.TValue[string]
 	Statements plugin.TValue[[]interface{}]
-	Exists plugin.TValue[bool]
 }
 
 // createAwsS3BucketPolicy creates a new instance of this resource
@@ -20892,6 +20892,10 @@ func (c *mqlAwsS3BucketPolicy) GetId() *plugin.TValue[string] {
 	return &c.Id
 }
 
+func (c *mqlAwsS3BucketPolicy) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
 func (c *mqlAwsS3BucketPolicy) GetBucketName() *plugin.TValue[string] {
 	return &c.BucketName
 }
@@ -20910,10 +20914,6 @@ func (c *mqlAwsS3BucketPolicy) GetStatements() *plugin.TValue[[]interface{}] {
 	return plugin.GetOrCompute[[]interface{}](&c.Statements, func() ([]interface{}, error) {
 		return c.statements()
 	})
-}
-
-func (c *mqlAwsS3BucketPolicy) GetExists() *plugin.TValue[bool] {
-	return &c.Exists
 }
 
 // mqlAwsApplicationAutoscaling for the aws.applicationAutoscaling resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2845,7 +2845,11 @@ resources:
       desc: |
         Bucket policies grant permission to your Amazon S3 resources
     fields:
+      bucketName:
+        min_mondoo_version: 9.0.0
       document: {}
+      exists:
+        min_mondoo_version: 9.0.0
       id: {}
       name: {}
       statements: {}

--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -202,7 +202,11 @@ func (a *mqlAwsS3Bucket) policy() (*mqlAwsS3BucketPolicy, error) {
 	policy, err := svc.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{
 		Bucket: &bucketname,
 	})
-	if err != nil && !isNotFoundForS3(err) {
+	if err != nil {
+		if isNotFoundForS3(err) {
+			a.Policy.State = plugin.StateIsNull | plugin.StateIsSet
+			return nil, nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
This change allows running `aws.s3.bucket.policy` when in discovery mode.

```
cnspec shell aws --discover s3-buckets
```

Also, fixes the issue discovered at https://github.com/mondoohq/cnquery/pull/5218
where we noticed that the policy resource doesn't implement the `id()` func properly.

Closes https://github.com/mondoohq/cnquery/issues/5169