### PR TITLE
🐛 Fix SUSE PURLs

### DIFF
--- a/providers/os/resources/purl/purl.go
+++ b/providers/os/resources/purl/purl.go
@@ -78,8 +78,16 @@ func NewPackageURL(pf *inventory.Platform, t Type, name, version string, modifie
 		purl.Arch = pf.Arch
 
 		purlNamespace := pf.Name
-		if purlNamespace == "photon" {
+		// Some special cases for the namespace
+		switch purlNamespace {
+		case "photon":
 			purlNamespace = "photon os"
+		case "opensuse-leap":
+			purlNamespace = "opensuse"
+		case "opensuse-tumbleweed":
+			purlNamespace = "opensuse"
+		case "sles":
+			purlNamespace = "suse"
 		}
 		if purlNamespace != "" {
 			purl.Namespace = purlNamespace
@@ -140,7 +148,6 @@ func (purl PackageURL) distroQualifiers() (string, bool) {
 	} else if purl.platform.Build != "" {
 		distroQualifiers = append(distroQualifiers, purl.platform.Build)
 	}
-
 	return strings.Join(distroQualifiers, "-"), true
 }
 

--- a/providers/os/resources/purl/purl_test.go
+++ b/providers/os/resources/purl/purl_test.go
@@ -263,4 +263,28 @@ func TestPackageURLString(t *testing.T) {
 		expected := "pkg:rpm/photon%20os/testpkg@1.0.0?arch=x86_64&distro=photon-4.0"
 		assert.Equal(t, expected, p.String())
 	})
+
+	t.Run("openSUSE package", func(t *testing.T) {
+		platform := &inventory.Platform{
+			Name:    "opensuse-leap",
+			Arch:    "x86_64",
+			Version: "15.4",
+			Labels:  nil,
+		}
+		p := purl.NewPackageURL(platform, purl.TypeRPM, "testpkg", "1.0.0")
+		expected := "pkg:rpm/opensuse/testpkg@1.0.0?arch=x86_64"
+		assert.Equal(t, expected, p.String())
+	})
+
+	t.Run("SUSE package", func(t *testing.T) {
+		platform := &inventory.Platform{
+			Name:    "sles",
+			Arch:    "x86_64",
+			Version: "15.4",
+			Labels:  nil,
+		}
+		p := purl.NewPackageURL(platform, purl.TypeRPM, "testpkg", "1.0.0")
+		expected := "pkg:rpm/suse/testpkg@1.0.0?arch=x86_64"
+		assert.Equal(t, expected, p.String())
+	})
 }


### PR DESCRIPTION
Align the namespace with the osv ecosystem.

'pkg:rpm/sles/...' -> 'pkg:rpm/suse/...'
...