### PR TITLE
🐛 Detect windows 11 name

### DIFF
--- a/providers/os/detector/detector_test.go
+++ b/providers/os/detector/detector_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
+	win "go.mondoo.com/cnquery/v11/providers/os/detector/windows"
 )
 
 func TestFamilyParents(t *testing.T) {
@@ -77,4 +78,97 @@ func TestFamilies(t *testing.T) {
 	assert.Equal(t, true, di.IsFamily("unix"), "unix should be a family")
 	assert.Equal(t, true, di.IsFamily("bsd"), "bsd should be a family")
 	assert.Equal(t, true, di.IsFamily("darwin"), "darwin should be a family")
+}
+
+func TestWindowsPlatform(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  win.WindowsCurrentVersion
+		expected *inventory.Platform
+	}{
+		{
+			name: "windows 10",
+			current: win.WindowsCurrentVersion{
+				CurrentBuild:     "19044",
+				EditionID:        "Professional",
+				ReleaseId:        "2009",
+				InstallationType: "Client",
+				ProductName:      "Windows 10 Pro",
+				DisplayVersion:   "21H2",
+				UBR:              2728,
+				Architecture:     "x64",
+				ProductType:      "WinNT",
+			},
+			expected: &inventory.Platform{
+				Name:    "windows",
+				Title:   "Windows 10 Pro",
+				Version: "19044",
+				Build:   "2728",
+				Arch:    "x64",
+				Labels: map[string]string{
+					"windows.mondoo.com/product-type":    "1",
+					"windows.mondoo.com/display-version": "21H2",
+				},
+			},
+		},
+		{
+			name: "windows 11",
+			current: win.WindowsCurrentVersion{
+				CurrentBuild:     "22631",
+				EditionID:        "Professional",
+				ReleaseId:        "23H2",
+				InstallationType: "Client",
+				ProductName:      "Windows 10 Pro",
+				DisplayVersion:   "23H2",
+				UBR:              2506,
+				Architecture:     "x64",
+				ProductType:      "WinNT",
+			},
+			expected: &inventory.Platform{
+				Name:    "windows",
+				Title:   "Windows 11 Pro",
+				Version: "22631",
+				Build:   "2506",
+				Arch:    "x64",
+				Labels: map[string]string{
+					"windows.mondoo.com/product-type":    "1",
+					"windows.mondoo.com/display-version": "23H2",
+				},
+			},
+		},
+		{
+			name: "windows server",
+			current: win.WindowsCurrentVersion{
+				CurrentBuild:     "20348",
+				EditionID:        "ServerStandard",
+				ReleaseId:        "21H2",
+				InstallationType: "Server",
+				ProductName:      "Windows Server 2022 Standard",
+				DisplayVersion:   "21H2",
+				UBR:              1972,
+				Architecture:     "x64",
+				ProductType:      "ServerNT",
+			},
+			expected: &inventory.Platform{
+				Name:    "windows",
+				Title:   "Windows Server 2022 Standard",
+				Version: "20348",
+				Build:   "1972",
+				Arch:    "x64",
+				Labels: map[string]string{
+					"windows.mondoo.com/product-type":    "3",
+					"windows.mondoo.com/display-version": "21H2",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pf := &inventory.Platform{}
+			platformFromWinCurrentVersion(pf, &tt.current)
+
+			assert.Equal(t, tt.expected, pf)
+		})
+	}
 }

--- a/providers/os/detector/detector_win.go
+++ b/providers/os/detector/detector_win.go
@@ -5,6 +5,7 @@ package detector
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
@@ -26,24 +27,7 @@ func runtimeWindowsDetector(pf *inventory.Platform, conn shared.Connection) (boo
 	//  try to get build + ubr number (win 10+, 2019+)
 	current, err := win.GetWindowsOSBuild(conn)
 	if err == nil && current.UBR > 0 {
-		pf.Name = "windows"
-		pf.Title = current.ProductName
-		pf.Version = current.CurrentBuild
-		pf.Build = strconv.Itoa(current.UBR)
-		pf.Arch = current.Architecture
-
-		var productType string
-		switch current.ProductType {
-		case "WinNT":
-			productType = "1" // Workstation
-		case "ServerNT":
-			productType = "3" // Server
-		case "LanmanNT":
-			productType = "2" // Domain Controller
-		}
-
-		pf.Labels["windows.mondoo.com/product-type"] = productType
-		pf.Labels["windows.mondoo.com/display-version"] = current.DisplayVersion
+		platformFromWinCurrentVersion(pf, current)
 		return true, nil
 	}
 
@@ -65,7 +49,35 @@ func runtimeWindowsDetector(pf *inventory.Platform, conn shared.Connection) (boo
 	pf.Arch = data.OSArchitecture
 	pf.Labels["windows.mondoo.com/product-type"] = data.ProductType
 
+	correctForWindows11(pf)
 	return true, nil
+}
+
+func platformFromWinCurrentVersion(pf *inventory.Platform, current *win.WindowsCurrentVersion) {
+	pf.Name = "windows"
+	pf.Title = current.ProductName
+	pf.Version = current.CurrentBuild
+	pf.Build = strconv.Itoa(current.UBR)
+	pf.Arch = current.Architecture
+
+	var productType string
+	switch current.ProductType {
+	case "WinNT":
+		productType = "1" // Workstation
+	case "ServerNT":
+		productType = "3" // Server
+	case "LanmanNT":
+		productType = "2" // Domain Controller
+	}
+
+	if pf.Labels == nil {
+		pf.Labels = map[string]string{}
+	}
+
+	pf.Labels["windows.mondoo.com/product-type"] = productType
+	pf.Labels["windows.mondoo.com/display-version"] = current.DisplayVersion
+
+	correctForWindows11(pf)
 }
 
 func staticWindowsDetector(pf *inventory.Platform, conn shared.Connection) (bool, error) {
@@ -111,5 +123,23 @@ func staticWindowsDetector(pf *inventory.Platform, conn shared.Connection) (bool
 			pf.Version = currentBuildNumber.Value.String
 		}
 	}
+
+	correctForWindows11(pf)
+
 	return true, nil
+}
+
+// correctForWindows11 replaces the windows 10 title with windows 11 if the build number is greater than 22000
+// See https://techcommunity.microsoft.com/discussions/windows-management/windows-10-21h2-and-windows-11-21h2-both-show-up-as-2009-release/2994441
+func correctForWindows11(pf *inventory.Platform) {
+	if strings.Contains(pf.Title, "10") {
+		buildNumber, err := strconv.Atoi(pf.Version)
+		if err != nil {
+			return
+		}
+		if buildNumber >= 22000 {
+			// replace 10 with 11
+			pf.Title = strings.Replace(pf.Title, "10", "11", 1)
+		}
+	}
 }


### PR DESCRIPTION
Windows 11 returns `Windows 10` for `ProductName` in `HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion`. We use that as the platform title. This corrects the platform title if its a build that falls into with windows 11 build numbers