### PR TITLE
🐛 k8s: don't fail during api resource discovery

### DIFF
--- a/providers/k8s/connection/shared/resources/discovery.go
+++ b/providers/k8s/connection/shared/resources/discovery.go
@@ -73,9 +73,8 @@ func (d *Discovery) SupportedResourceTypes() (*ApiResourceIndex, error) {
 	log.Debug().Msg("query api resource types")
 	resList, err := d.discoveryClient.ServerPreferredResources()
 	if err != nil {
-		var groupDiscoveryErr *discovery.ErrGroupDiscoveryFailed
-		if errors.As(err, groupDiscoveryErr) {
-			log.Warn().Err(err).Msg("one or more kubernetes API groups fail to load")
+		if discovery.IsGroupDiscoveryFailedError(err) {
+			log.Debug().Err(err).Msg("one or more kubernetes API groups fail to load")
 		} else {
 			return nil, errors.Wrap(err, "failed to fetch api resource types from kubernetes")
 		}

--- a/providers/k8s/connection/shared/resources/discovery.go
+++ b/providers/k8s/connection/shared/resources/discovery.go
@@ -73,7 +73,7 @@ func (d *Discovery) SupportedResourceTypes() (*ApiResourceIndex, error) {
 	log.Debug().Msg("query api resource types")
 	resList, err := d.discoveryClient.ServerPreferredResources()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to fetch api resource types from kubernetes")
+		log.Warn().Err(err).Msg("failed to fetch api resource types from kubernetes")
 	}
 	log.Debug().Msgf("found %d api resource types", len(resList))
 

--- a/providers/k8s/connection/shared/resources/discovery.go
+++ b/providers/k8s/connection/shared/resources/discovery.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -73,7 +73,12 @@ func (d *Discovery) SupportedResourceTypes() (*ApiResourceIndex, error) {
 	log.Debug().Msg("query api resource types")
 	resList, err := d.discoveryClient.ServerPreferredResources()
 	if err != nil {
-		log.Warn().Err(err).Msg("failed to fetch api resource types from kubernetes")
+		var groupDiscoveryErr *discovery.ErrGroupDiscoveryFailed
+		if errors.As(err, groupDiscoveryErr) {
+			log.Warn().Err(err).Msg("one or more kubernetes API groups fail to load")
+		} else {
+			return nil, errors.Wrap(err, "failed to fetch api resource types from kubernetes")
+		}
 	}
 	log.Debug().Msgf("found %d api resource types", len(resList))
 


### PR DESCRIPTION
Closes https://github.com/mondoohq/cnquery/issues/5165

A sand-boxed cluster doesn't have metrics server enabled:
https://cloud.google.com/kubernetes-engine/docs/concepts/sandbox-pods#limitations-incompatible

This code fails just because that single API resource, out of 40+ resources, fails.

![Screenshot 2025-02-18 at 6 30 06 PM](https://github.com/user-attachments/assets/4cda506f-1c18-4c64-b2cd-b255437030ae)

Now we will just display a warning that "some" api resources aren't available.