### PR TITLE
🐛 Fix Rocky Linux PURLs

### DIFF
--- a/providers/os/resources/purl/purl.go
+++ b/providers/os/resources/purl/purl.go
@@ -82,6 +82,8 @@ func NewPackageURL(pf *inventory.Platform, t Type, name, version string, modifie
 		switch purlNamespace {
 		case "photon":
 			purlNamespace = "photon os"
+		case "rockylinux":
+			purlNamespace = "rocky-linux"
 		case "opensuse-leap":
 			purlNamespace = "opensuse"
 		case "opensuse-tumbleweed":

--- a/providers/os/resources/purl/purl_test.go
+++ b/providers/os/resources/purl/purl_test.go
@@ -264,6 +264,18 @@ func TestPackageURLString(t *testing.T) {
 		assert.Equal(t, expected, p.String())
 	})
 
+	t.Run("Rocky Linux package", func(t *testing.T) {
+		platform := &inventory.Platform{
+			Name:    "rockylinux",
+			Arch:    "x86_64",
+			Version: "8.6",
+			Labels:  nil,
+		}
+		p := purl.NewPackageURL(platform, purl.TypeRPM, "testpkg", "1.0.0")
+		expected := "pkg:rpm/rocky-linux/testpkg@1.0.0?arch=x86_64"
+		assert.Equal(t, expected, p.String())
+	})
+
 	t.Run("openSUSE package", func(t *testing.T) {
 		platform := &inventory.Platform{
 			Name:    "opensuse-leap",


### PR DESCRIPTION
Align the namespace with the OSV data.

'pkg:rpm/rockylinux/...' -> 'pkg:rpm/rocky-linux/...'