### PR TITLE
🐛 fix azure.subscription.policy.assignments id

### DIFF
--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -16966,7 +16966,12 @@ func createAzureSubscriptionPolicyAssignment(runtime *plugin.Runtime, args map[s
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+	res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("azure.subscription.policy.assignment", res.__id)

--- a/providers/azure/resources/policy.go
+++ b/providers/azure/resources/policy.go
@@ -28,6 +28,10 @@ func initAzureSubscriptionPolicy(runtime *plugin.Runtime, args map[string]*llx.R
 	return args, nil, nil
 }
 
+func (a *mqlAzureSubscriptionPolicyAssignment) id() (string, error) {
+	return fmt.Sprintf("azure.subscription.policy/%s/%s", a.Scope.Data, a.Id.Data), nil
+}
+
 func (a *mqlAzureSubscriptionPolicy) assignments() ([]interface{}, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	ctx := context.Background()
@@ -51,7 +55,6 @@ func (a *mqlAzureSubscriptionPolicy) assignments() ([]interface{}, error) {
 		}
 
 		assignmentData := map[string]*llx.RawData{
-			"__id":            llx.StringData(fmt.Sprintf("azure.subscription.policy/%s/%s", assignment.Properties.Scope, assignment.Properties.DisplayName)),
 			"id":              llx.StringData(assignment.Properties.PolicyDefinitionID),
 			"name":            llx.StringData(assignment.Properties.DisplayName),
 			"scope":           llx.StringData(assignment.Properties.Scope),


### PR DESCRIPTION
Closes https://github.com/mondoohq/cnquery/issues/5040

The problem is that the `DisplayName` is not unique, but the `PolicyDefinitionID` is.