### PR TITLE
#498 BURP: Remove dispatch event for releases.mondoo.com

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -161,18 +161,6 @@ jobs:
             cat $f
           done
 
-      - name: Publish Release to releases.mondoo.com
-        if: ${{ ! steps.skip-publish.outputs.skip-publish }}
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.RELEASR_ACTION_TOKEN }}
-          repository: "mondoohq/releasr"
-          event-type: publish-release
-          client-payload: '{
-              "repository": "${{ github.event.repository.name }}",
-              "version":  "${{  github.ref_name }}"
-            }'
-
       # At this point we know the docker container is published.
       # We can now trigger the cnquery bump in cnspec, which will also trigger the release of cnspec.
       # The docker container is a pre-requisite for cnspec release.


### PR DESCRIPTION
Remove repository-dispatch event triggering a release to releases.mondoo.com. Releases will be entirely managed inside the [installer](https://github.com/mondoohq/installer/) repo in the future.