### PR TITLE
🐛 fix `aws.s3.bucket.policy` panic

### DIFF
--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -122,7 +122,7 @@ func initAwsS3BucketPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData
 	}
 	// then use it to get its policy
 	policyResource := s3bucketResource.(*mqlAwsS3Bucket).GetPolicy()
-	if policyResource != nil {
+	if policyResource != nil && policyResource.State == plugin.StateIsSet {
 		return args, policyResource.Data, nil
 	}
 
@@ -249,6 +249,7 @@ func (a *mqlAwsS3Bucket) policy() (*mqlAwsS3BucketPolicy, error) {
 	}
 
 	// no bucket policy found, return nil for the policy
+	a.Policy.State = plugin.StateIsNull | plugin.StateIsSet
 	return nil, nil
 }
 


### PR DESCRIPTION
This fixes a panic reported by @mm-weber 
```
cnspec> aws.s3.bucket.policy
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x80676e0]

goroutine 1274 [running]:
go.mondoo.com/cnquery/v11/providers/aws/resources.(*mqlAwsS3BucketPolicy).MqlID(0x88a7380?)
	/home/manuel/go/src/go.mondoo.io/cnquery/providers/aws/resources/aws.lr.go:20888
go.mondoo.com/cnquery/v11/providers/aws/resources.NewResource(0xc00171b3e0, {0xc000b20ea0, 0x14}, 0xc000d315f0)
	/home/manuel/go/src/go.mondoo.io/cnquery/providers/aws/resources/aws.lr.go:796 +0x1df
go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin.(*Service).GetData(0x8e7ad40?, 0xc000842d90)
	/home/manuel/go/src/go.mondoo.io/cnquery/providers-sdk/v1/plugin/service.go:160 +0x9b
go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin.(*GRPCServer).GetData(0xd84ffa0?, {0x914cce0?, 0xc001a098b8?}, 0x57a6a5?)
	/home/manuel/go/src/go.mondoo.io/cnquery/providers-sdk/v1/plugin/grpc.go:129 +0x1e
go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin._ProviderPlugin_GetData_Handler({0x914cce0, 0xc000466040}, {0xa195560, 0xc000d315c0}, 0xc00107cb80, 0x0)
	/home/manuel/go/src/go.mondoo.io/cnquery/providers-sdk/v1/plugin/plugin_grpc.pb.go:318 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0006de600, {0xa195560, 0xc000d31530}, 0xc0010cade0, 0xc000962f90, 0xdbd90d0, 0x0)
	/home/manuel/.gvm/pkgsets/go1.23.1/global/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1400 +0x103b
google.golang.org/grpc.(*Server).handleStream(0xc0006de600, {0xa195b18, 0xc00056f1e0}, 0xc0010cade0)
	/home/manuel/.gvm/pkgsets/go1.23.1/global/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1810 +0xbaa
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	/home/manuel/.gvm/pkgsets/go1.23.1/global/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1030 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 55
	/home/manuel/.gvm/pkgsets/go1.23.1/global/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1041 +0x125
rpc error: code = Unavailable desc = error reading from server: EOF
aws.s3.bucket.policy: no data available
cnspec> x plugin process exited error="exit status 2" id=4031091 plugin=/home/manuel/.config/mondoo/providers/aws/aws
cnspec> 
cnspec> x error in plugin heartbeat error="rpc error: code = Unavailable desc = connection error: desc = \"transport: error while dialing: dial unix /tmp/plugin4150905855: connect: connection refused\"" plugin=aws
x error in plugin heartbeat error="cannot establish heartbeat with the provider plugin for aws" plugin=aws
x error in plugin shutdown error="rpc error: code = Unavailable desc = connection error: desc = \"transport: error while dialing: dial unix /tmp/plugin4150905855: connect: connection refused\"" plugin=aws
```