### PR TITLE
✨ adds `llx.IPData()` for easy initialization

### DIFF
--- a/llx/builtin_global.go
+++ b/llx/builtin_global.go
@@ -276,7 +276,7 @@ func ipCall(e *blockExecutor, f *Function, ref uint64) (*RawData, uint64, error)
 		return nil, 0, errors.New("called `ip` with unsupported type (expected string)")
 	}
 
-	return &RawData{Type: types.IP, Value: raw}, 0, nil
+	return IPData(raw), 0, nil
 }
 
 func stringCall(e *blockExecutor, f *Function, ref uint64) (*RawData, uint64, error) {

--- a/llx/rawdata.go
+++ b/llx/rawdata.go
@@ -177,6 +177,8 @@ func rawDataString(typ types.Type, value interface{}) string {
 		default:
 			return "map[?]?"
 		}
+	case types.IP:
+		return value.(string)
 	default:
 		return "?value? (typ:" + typ.Label() + ")"
 	}

--- a/llx/rawdata.go
+++ b/llx/rawdata.go
@@ -588,6 +588,21 @@ func RangeData(r Range) *RawData {
 	}
 }
 
+// IPData creates a rawdata struct from a raw ip address
+func IPData(ip string) *RawData {
+	return &RawData{
+		Type:  types.IP,
+		Value: ip,
+	}
+}
+
+func IPDataPtr(ip *string) *RawData {
+	if ip == nil {
+		return NilData
+	}
+	return IPData(*ip)
+}
+
 // RawResultByRef is used to sort an array of raw results
 type RawResultByRef []*RawResult
 

--- a/llx/rawdata_test.go
+++ b/llx/rawdata_test.go
@@ -47,6 +47,7 @@ func TestRawData_String(t *testing.T) {
 		{DictData(map[string]interface{}{"a": "b"}), "{\"a\":\"b\"}"},
 		{ArrayData([]interface{}{"a", "b"}, types.String), "[\"a\",\"b\"]"},
 		{MapData(map[string]interface{}{"a": "b"}, types.String), "{\"a\":\"b\"}"},
+		{IPData("1.2.3.4"), "1.2.3.4"},
 		// implicit nil:
 		{&RawData{types.String, nil, nil}, "<null>"},
 	}


### PR DESCRIPTION
This helps us write 
```go
llx.IPData("1.2.3.4")
```
rather than 
```go
&llx.RawData{Type: types.IP, Value: "1.2.3.4"}
```