### PR TITLE
🐛 warn users not to use standalone filters

### DIFF
--- a/mqlc/builtin_resource.go
+++ b/mqlc/builtin_resource.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"strconv"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/mqlc/parser"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/resources"
@@ -152,6 +153,9 @@ func compileResourceWhere(c *compiler, typ types.Type, ref uint64, id string, ca
 	refs, err := c.blockExpressions([]*parser.Expression{arg.Value}, types.Array(types.Type(resource.ListType)), ref, bindingName)
 	if err != nil {
 		return types.Nil, err
+	}
+	if refs.isStandalone {
+		log.Warn().Msg("Detected a standalone function in a where-clause! Please make sure you use filter the list, as this is most likely unintended")
 	}
 	if refs.block == 0 {
 		return types.Nil, errors.New("called '" + id + "' clause without a function block")

--- a/mqlc/builtin_resource.go
+++ b/mqlc/builtin_resource.go
@@ -155,7 +155,7 @@ func compileResourceWhere(c *compiler, typ types.Type, ref uint64, id string, ca
 		return types.Nil, err
 	}
 	if refs.isStandalone {
-		log.Warn().Msg("Detected a standalone function in a where-clause! Please make sure you use filter the list, as this is most likely unintended")
+		log.Warn().Msg("Detected a standalone function in a WHERE clause! This is probably unintended. Be sure to filter the list.")
 	}
 	if refs.block == 0 {
 		return types.Nil, errors.New("called '" + id + "' clause without a function block")


### PR DESCRIPTION
The most common examples look like this:

```coffee
> packages.where("noname")

or

> packages.contains("something")
```

These will always be true, because they don't test the condition!

The correct use is:

```coffee
> packages.where(name == "noname")
```

This will be followed up by the linter (to catch this) and v12 which will make this a breaking change going forward.