### PR TITLE
✨ integer-based IP addresses

### DIFF
--- a/llx/builtin_global.go
+++ b/llx/builtin_global.go
@@ -263,20 +263,26 @@ func ipCall(e *blockExecutor, f *Function, ref uint64) (*RawData, uint64, error)
 	}
 
 	arg := f.Args[0]
-	if arg.Type != string(types.String) {
-		return nil, 0, errors.New("called `ip` with incorrect argument type, expected string")
+	if arg.Type != string(types.String) && arg.Type != string(types.Int) && arg.Type != string(types.Dict) {
+		return nil, 0, errors.New("called `ip` with incorrect argument type, expected string or int")
 	}
 
 	res, dref, err := e.resolveValue(arg, ref)
 	if err != nil || dref != 0 || res == nil {
 		return res, dref, err
 	}
+
 	raw, ok := res.Value.(string)
-	if !ok {
-		return nil, 0, errors.New("called `ip` with unsupported type (expected string)")
+	if ok {
+		return IPData(raw), 0, nil
 	}
 
-	return IPData(raw), 0, nil
+	rawInt, ok := res.Value.(int64)
+	if ok {
+		return IPData(int2ip(rawInt)), 0, nil
+	}
+
+	return nil, 0, errors.New("called `ip` with unsupported type (expected string or int)")
 }
 
 func stringCall(e *blockExecutor, f *Function, ref uint64) (*RawData, uint64, error) {

--- a/llx/builtin_ip.go
+++ b/llx/builtin_ip.go
@@ -59,6 +59,23 @@ func NewIP(s string) IP {
 
 var bitmasks = []byte{0x00, 0x80, 0xc0, 0xe0, 0xf0, 0xf8, 0xfc, 0xfe, 0xff}
 
+func int2ip(i int64) string {
+	cur := i
+
+	d := byte(cur % 256)
+	cur = cur >> 8
+
+	c := byte(cur % 256)
+	cur = cur >> 8
+
+	b := byte(cur % 256)
+	cur = cur >> 8
+
+	a := byte(cur % 256)
+
+	return net.IPv4(a, b, c, d).String()
+}
+
 func countMaskBits(b []byte) int {
 	var res int
 	for _, cur := range b {

--- a/llx/builtin_ip.go
+++ b/llx/builtin_ip.go
@@ -62,16 +62,16 @@ var bitmasks = []byte{0x00, 0x80, 0xc0, 0xe0, 0xf0, 0xf8, 0xfc, 0xfe, 0xff}
 func int2ip(i int64) string {
 	cur := i
 
-	d := byte(cur % 256)
+	d := byte(cur & 0xff)
 	cur = cur >> 8
 
-	c := byte(cur % 256)
+	c := byte(cur & 0xff)
 	cur = cur >> 8
 
-	b := byte(cur % 256)
+	b := byte(cur & 0xff)
 	cur = cur >> 8
 
-	a := byte(cur % 256)
+	a := byte(cur & 0xff)
 
 	return net.IPv4(a, b, c, d).String()
 }

--- a/llx/builtin_ip_test.go
+++ b/llx/builtin_ip_test.go
@@ -39,3 +39,9 @@ func TestCreateMask(t *testing.T) {
 		})
 	}
 }
+
+func TestIntIP(t *testing.T) {
+	assert.Equal(t, "172.0.0.1", int2ip(2885681153))
+	assert.Equal(t, "0.0.0.0", int2ip(0))
+	assert.Equal(t, "255.255.255.255", int2ip(1<<33-1))
+}

--- a/providers/core/resources/mql_test.go
+++ b/providers/core/resources/mql_test.go
@@ -1042,6 +1042,7 @@ func TestIP(t *testing.T) {
 			{Code: "ip('1.2.3.4').prefixLength", Expectation: int64(8)},
 			{Code: "ip('128.2.3.4').prefixLength", Expectation: int64(16)},
 			{Code: "ip('192.2.3.4').prefixLength", Expectation: int64(24)},
+			{Code: "ip(2885681153) == ip('172.0.0.1')", Expectation: true, ResultIndex: 2},
 		})
 	})
 


### PR DESCRIPTION
As suggested by @frozen425 add support for integer-based IP addresses:

```coffee
> ip(2885681153)
ip: "172.0.0.1"
```

Currently limited to IPv4 only, I'm not sure yet what the approach would be for 128bit addresses (IPv6) with only 64-bit integers...