### PR TITLE
🎉 os-11.3.31

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "11.3.30",
+	Version: "11.3.31",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
```
➜  cnquery git:(main) version update providers/os
crawling git history....................................................................................................................................................................................................................................................................................................................................................................................
! looks like there is no previous version in your commit history => we assume this is the first version commit
→ provider changed changes=373 provider=os version=11.3.30
→ set new version previous=11.3.30 provider=os version=11.3.31
→ updated config path=providers/os/config/config.go
→ git add providers/os/config/config.go && git commit -m "🎉 os-11.3.31"
```