### PR TITLE
Ignore packages with empty names

### DIFF
--- a/providers/os/resources/packages/windows_packages.go
+++ b/providers/os/resources/packages/windows_packages.go
@@ -452,6 +452,10 @@ func getPackageFromRegistryKeyItems(children []registry.RegistryKeyItem, platfor
 		return nil
 	}
 
+	if displayName == "" {
+		return nil
+	}
+
 	pkg := &Package{
 		Name:    displayName,
 		Version: displayVersion,
@@ -471,6 +475,7 @@ func getPackageFromRegistryKeyItems(children []registry.RegistryKeyItem, platfor
 		}
 	} else {
 		log.Debug().Msg("ignored package since information is missing")
+		return nil
 	}
 	return pkg
 }

--- a/providers/os/resources/packages/windows_packages.go
+++ b/providers/os/resources/packages/windows_packages.go
@@ -452,8 +452,10 @@ func getPackageFromRegistryKeyItems(children []registry.RegistryKeyItem, platfor
 		return nil
 	}
 
-	if displayName == "" {
+	if displayName == "" || displayVersion == "" {
+		log.Debug().Msg("ignored package since information is missing")
 		return nil
+
 	}
 
 	pkg := &Package{
@@ -466,17 +468,13 @@ func getPackageFromRegistryKeyItems(children []registry.RegistryKeyItem, platfor
 		).String(),
 	}
 
-	if displayName != "" && displayVersion != "" {
-		cpeWfns, err := cpe.NewPackage2Cpe(publisher, displayName, displayVersion, "", "")
-		if err != nil {
-			log.Debug().Err(err).Str("name", displayName).Str("version", displayVersion).Msg("could not create cpe for windows app package")
-		} else {
-			pkg.CPEs = cpeWfns
-		}
+	cpeWfns, err := cpe.NewPackage2Cpe(publisher, displayName, displayVersion, "", "")
+	if err != nil {
+		log.Debug().Err(err).Str("name", displayName).Str("version", displayVersion).Msg("could not create cpe for windows app package")
 	} else {
-		log.Debug().Msg("ignored package since information is missing")
-		return nil
+		pkg.CPEs = cpeWfns
 	}
+
 	return pkg
 }
 


### PR DESCRIPTION
If the package has an empty name skip it. It can cause errors downstream later due to creating invalid PUrls that can't be parsed.

Fixes: #5261.