### PR TITLE
🐛 log error when getting latest cnquery version for status cli cmd

### DIFF
--- a/apps/cnquery/cmd/status.go
+++ b/apps/cnquery/cmd/status.go
@@ -105,7 +105,7 @@ func checkStatus() (Status, error) {
 
 	latestVersion, err := cnquery.GetLatestVersion(httpClient)
 	if err != nil {
-		return s, cli_errors.NewCommandError(errors.Wrap(err, "failed to get latest version"), 1)
+		log.Warn().Err(err).Msg("Failed to get latest version")
 	}
 
 	s.Client.LatestVersion = latestVersion


### PR DESCRIPTION
Desirable outcome:
- Log warning message that fetching the latest version failed, instead of throwing an error.

Follow up actions:
- Open PR with the new patch version in cnspec.