### PR TITLE
🐛 use `RawIP` inside sdk `lr` generator

### DIFF
--- a/llx/builtin_ip_test.go
+++ b/llx/builtin_ip_test.go
@@ -44,5 +44,6 @@ func TestCreateMask(t *testing.T) {
 func TestIntIP(t *testing.T) {
 	assert.Equal(t, net.ParseIP("172.0.0.1"), int2ip(2885681153))
 	assert.Equal(t, net.ParseIP("0.0.0.0"), int2ip(0))
+	assert.Equal(t, net.ParseIP(""), net.IP(nil))
 	assert.Equal(t, net.ParseIP("255.255.255.255"), int2ip(1<<33-1))
 }

--- a/llx/rawdata.go
+++ b/llx/rawdata.go
@@ -631,6 +631,9 @@ func VersionData(version string) *RawData {
 
 // IPData creates a rawdata struct from a raw ip address
 func IPData(ip RawIP) *RawData {
+	if ip.IP == nil {
+		return NilData
+	}
 	return &RawData{
 		Type:  types.IP,
 		Value: ip,

--- a/llx/rawdata_test.go
+++ b/llx/rawdata_test.go
@@ -49,6 +49,7 @@ func TestRawData_String(t *testing.T) {
 		{ArrayData([]interface{}{"a", "b"}, types.String), "[\"a\",\"b\"]"},
 		{MapData(map[string]interface{}{"a": "b"}, types.String), "{\"a\":\"b\"}"},
 		{IPData(ParseIP("1.2.3.4")), "1.2.3.4/8"},
+		{IPData(ParseIP("")), "<null>"},
 		// implicit nil:
 		{&RawData{types.String, nil, nil}, "<null>"},
 	}
@@ -126,6 +127,7 @@ func TestSuccess(t *testing.T) {
 		{TimeData(testTime), false, false},
 		{VersionData("1.2.3"), false, false},
 		{IPData(ParseIP("192.168.0.1")), false, false},
+		{IPData(ParseIP("")), false, false},
 		{ArrayData([]interface{}{}, types.Any), false, false},
 		{ArrayData([]interface{}{true, false, true}, types.Bool), false, true},
 		{ArrayData([]interface{}{true, true}, types.Bool), true, true},
@@ -202,6 +204,7 @@ func TestRawData_JSON(t *testing.T) {
 		// TimeData(now),
 		VersionData("1.2.3"),
 		IPData(ParseIP("192.168.0.1/13")),
+		IPData(ParseIP("")),
 		IPData(ParseIntIP(0)),
 		IPData(ParseIntIP(1<<33 - 1)),
 		IPData(ParseIP("2001:db8:3c4d:15::1a2f:1a2b/64")),

--- a/providers-sdk/v1/lr/go.go
+++ b/providers-sdk/v1/lr/go.go
@@ -773,7 +773,7 @@ var primitiveTypes = map[string]string{
 	"regex":   "string",
 	"dict":    "interface{}",
 	"version": "string",
-	"ip":      "string",
+	"ip":      "llx.RawIP",
 	"any":     "interface{}",
 }
 
@@ -807,7 +807,7 @@ var primitiveZeros = map[string]string{
 	"regex":   "\"\"",
 	"dict":    "nil",
 	"version": "\"\"",
-	"ip":      "\"\"",
+	"ip":      "nil",
 	"any":     "nil",
 }
 

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -5275,15 +5275,15 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 			return
 		},
 	"ipv4Address.ip": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlIpv4Address).Ip, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		r.(*mqlIpv4Address).Ip, ok = plugin.RawToTValue[llx.RawIP](v.Value, v.Error)
 		return
 	},
 	"ipv4Address.subnet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlIpv4Address).Subnet, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		r.(*mqlIpv4Address).Subnet, ok = plugin.RawToTValue[llx.RawIP](v.Value, v.Error)
 		return
 	},
 	"ipv4Address.cidr": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlIpv4Address).Cidr, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		r.(*mqlIpv4Address).Cidr, ok = plugin.RawToTValue[llx.RawIP](v.Value, v.Error)
 		return
 	},
 	"ipv4Address.broadcast": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15031,9 +15031,9 @@ type mqlIpv4Address struct {
 	MqlRuntime *plugin.Runtime
 	__id string
 	// optional: if you define mqlIpv4AddressInternal it will be used here
-	Ip plugin.TValue[string]
-	Subnet plugin.TValue[string]
-	Cidr plugin.TValue[string]
+	Ip plugin.TValue[llx.RawIP]
+	Subnet plugin.TValue[llx.RawIP]
+	Cidr plugin.TValue[llx.RawIP]
 	Broadcast plugin.TValue[string]
 	Gateway plugin.TValue[string]
 }
@@ -15070,15 +15070,15 @@ func (c *mqlIpv4Address) MqlID() string {
 	return c.__id
 }
 
-func (c *mqlIpv4Address) GetIp() *plugin.TValue[string] {
+func (c *mqlIpv4Address) GetIp() *plugin.TValue[llx.RawIP] {
 	return &c.Ip
 }
 
-func (c *mqlIpv4Address) GetSubnet() *plugin.TValue[string] {
+func (c *mqlIpv4Address) GetSubnet() *plugin.TValue[llx.RawIP] {
 	return &c.Subnet
 }
 
-func (c *mqlIpv4Address) GetCidr() *plugin.TValue[string] {
+func (c *mqlIpv4Address) GetCidr() *plugin.TValue[llx.RawIP] {
 	return &c.Cidr
 }
 


### PR DESCRIPTION
We switched the new `ip` type from a `string` to `llx.RawIP`, this change only modifies two things:

* The providers SDK generator to use the new `RawIP`
* The `IPData` accessor to return `NilData` when there is no valid ip