### PR TITLE
🐛 fix mql printer for `RawIP`

### DIFF
--- a/cli/printer/mql.go
+++ b/cli/printer/mql.go
@@ -787,6 +787,9 @@ func (print *Printer) Data(typ types.Type, data interface{}, codeID string, bund
 		return print.Secondary(data.(string))
 
 	case types.IP:
+		if data == nil {
+			return print.Secondary("null")
+		}
 		return print.Secondary(data.(llx.RawIP).String())
 
 	case types.ArrayLike:

--- a/cli/printer/printer_test.go
+++ b/cli/printer/printer_test.go
@@ -176,6 +176,20 @@ func TestPrinter(t *testing.T) {
 					"]",
 			},
 		},
+		{
+			"ip(\"\")",
+			"", // ignore
+			[]string{
+				"ip: null",
+			},
+		},
+		{
+			"ip(\"1.2.3.4\")",
+			"", // ignore
+			[]string{
+				"ip: 1.2.3.4",
+			},
+		},
 	})
 }
 


### PR DESCRIPTION
Fixes this panic:
```
panic: interface conversion: interface {} is nil, not llx.RawIP [recovered]
	panic: interface conversion: interface {} is nil, not llx.RawIP

goroutine 1 [running]:
go.mondoo.com/cnquery/v11/providers-sdk/v1/upstream/health.ReportPanic({0x2f11b42, 0x7}, {0x3374d80, 0x8}, {0x3374d90, 0x9}, {0x0, 0x0, 0x0?})
	/Users/afiune/go/src/go.mondoo.com/cnquery/providers-sdk/v1/upstream/health/errors.go:32 +0x16c
panic({0x2a2ac80?, 0xc0008675c0?})
	/opt/homebrew/Cellar/go/1.23.4/libexec/src/runtime/panic.go:785 +0x132
go.mondoo.com/cnquery/v11/cli/printer.(*Printer).Data(0x4e6d350, {0x4c36c78, 0x1}, {0x0, 0x0}, {0xc000886600, 0x58}, 0xc0008786e0, {0xc00087b378, 0x4})
	/Users/afiune/go/src/go.mondoo.com/cnquery/cli/printer/mql.go:790 +0x1ef1
go.mondoo.com/cnquery/v11/cli/printer.(*Printer).refMap(0x4e6d350, {0x8?, 0xc000886720?}, 0xc0008660f0, {0x30?, 0xa?}, 0xc0008786e0, {0x2f0c1f3, 0x2})
	/Users/afiune/go/src/go.mondoo.com/cnquery/cli/printer/mql.go:398 +0xff8
go.mondoo.com/cnquery/v11/cli/printer.(*Printer).Data(0x4e6d350, {0x2f0c2a5, 0x1}, {0x29b94e0, 0xc0008660f0}, {0xc000886720, 0x58}, 0xc0008786e0, {0x2f0c1f3, 0x2})
	/Users/afiune/go/src/go.mondoo.com/cnquery/cli/printer/mql.go:784 +0x745
```