### PR TITLE
🐛 omit storing `force` flag in config

### DIFF
--- a/apps/cnquery/cmd/login.go
+++ b/apps/cnquery/cmd/login.go
@@ -200,9 +200,6 @@ func register(token string, annotations map[string]string, timer int, splay int,
 		}
 
 		log.Debug().Msg("store configuration")
-		// overwrite force, otherwise it will be stored
-		viper.Set("force", false)
-
 		// update configuration file, api-endpoint is set automatically
 		viper.Set("agent_mrn", confirmation.AgentMrn)
 		viper.Set("api_endpoint", confirmation.Credential.ApiEndpoint)

--- a/cli/config/store.go
+++ b/cli/config/store.go
@@ -13,6 +13,9 @@ import (
 	"github.com/spf13/viper"
 )
 
+// list of field keys to avoid writing to disk
+var fieldKeysToOmit = []string{"force"}
+
 func StoreConfig() error {
 	path := viper.ConfigFileUsed()
 	log.Info().Str("path", path).Msg("saving config")
@@ -34,6 +37,11 @@ func StoreConfig() error {
 		}
 	} else if err != nil {
 		return errors.Wrap(err, "failed to check stats for mondoo config")
+	}
+
+	// omit fields before storing the configuration
+	for _, field := range fieldKeysToOmit {
+		viper.Set(field, nil)
 	}
 
 	return viper.WriteConfig()

--- a/cli/config/store_test.go
+++ b/cli/config/store_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package config_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	subject "go.mondoo.com/cnquery/v11/cli/config"
+	"gopkg.in/yaml.v2"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreConfig(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	viper.SetFs(fs)
+	tempDir := "/tmp/config_test"
+	configPath := filepath.Join(tempDir, "config.yaml")
+	viper.SetConfigFile(configPath)
+
+	t.Run("creates new config file when missing", func(t *testing.T) {
+		err := subject.StoreConfig()
+		require.NoError(t, err)
+
+		exists, err := afero.Exists(fs, configPath)
+		require.NoError(t, err)
+		assert.True(t, exists, "config file should be created")
+	})
+
+	t.Run("writes to existing config file", func(t *testing.T) {
+		// Pre-create the config file
+		assert.NoError(t, afero.WriteFile(fs, configPath, []byte("initial data"), 0o644))
+
+		viper.Set("key", "value")
+		err := subject.StoreConfig()
+		require.NoError(t, err)
+
+		// Validate YAML format of the stored file
+		content, err := afero.ReadFile(fs, configPath)
+		assert.NoError(t, err, "Should be able to read the config file")
+
+		var yamlData map[string]interface{}
+		err = yaml.Unmarshal(content, &yamlData)
+		assert.NoError(t, err, "Config file should be valid YAML")
+
+		// Verify the saved key-value pair in YAML format
+		assert.Equal(t, "value", yamlData["key"], "Config should retain stored values")
+	})
+
+	t.Run("correctly omits writing fields that we don't want to store", func(t *testing.T) {
+		// valid
+		viper.Set("key", "value")
+		// omit field
+		viper.Set("force", false)
+
+		// store config
+		err := subject.StoreConfig()
+		require.NoError(t, err)
+
+		// Validate no force field is written to disk
+		content, err := afero.ReadFile(fs, configPath)
+		assert.NoError(t, err)
+
+		var yamlData map[string]interface{}
+		err = yaml.Unmarshal(content, &yamlData)
+		assert.NoError(t, err, "Config file should be valid YAML")
+
+		// Verify valid field
+		assert.Equal(t, "value", yamlData["key"], "should store valid field")
+		// Verify invalid field
+		_, exist := yamlData["force"]
+		assert.False(t, exist, "should not store omitted field")
+	})
+
+	t.Run("handles error when failing to write config file", func(t *testing.T) {
+		readOnlyFs := afero.NewReadOnlyFs(fs)
+		viper.SetFs(readOnlyFs)
+
+		err := subject.StoreConfig()
+		assert.Error(t, err)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -272,7 +272,7 @@ require (
 	google.golang.org/api v0.221.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250212204824-5a70512c5d8b // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.28.9 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect
 	modernc.org/libc v1.61.13 // indirect


### PR DESCRIPTION
Additionally, we have a way to add more fields we want to omit from storing
in the config.