### PR TITLE
🐛 prevent aws ebs panics

### DIFF
--- a/providers/aws/connection/awsec2ebsconn/destroy.go
+++ b/providers/aws/connection/awsec2ebsconn/destroy.go
@@ -15,6 +15,9 @@ import (
 )
 
 func (c *AwsEbsConnection) DetachVolumeFromInstance(ctx context.Context, volume *awsec2ebstypes.VolumeInfo) error {
+	if volume == nil {
+		return nil // no-op
+	}
 	log.Info().Msg("detach volume")
 	deviceName := c.deviceLocation
 	res, err := c.scannerRegionEc2svc.DetachVolume(ctx, &ec2.DetachVolumeInput{

--- a/providers/aws/connection/awsec2ebsconn/provider.go
+++ b/providers/aws/connection/awsec2ebsconn/provider.go
@@ -192,6 +192,15 @@ func (c *AwsEbsConnection) Close() {
 	if c.DeviceProvider != nil {
 		c.DeviceProvider.Close()
 	}
+
+	// close volume: we detach and delete it
+	//
+	// first, check if we have volume information
+	if c.scanVolumeInfo == nil {
+		log.Debug().Msg("skipping 'closing' volume, no volume information")
+		return
+	}
+
 	ctx := context.Background()
 	err := c.DetachVolumeFromInstance(ctx, c.scanVolumeInfo)
 	if err != nil {

--- a/providers/aws/provider/provider.go
+++ b/providers/aws/provider/provider.go
@@ -42,7 +42,11 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 
 	// handle aws subcommands
 	if len(req.Args) >= 3 && req.Args[0] == "ec2" {
-		return &plugin.ParseCLIRes{Asset: handleAwsEc2Subcommands(req.Args, opts)}, nil
+		asset, err := handleAwsEc2Subcommands(req.Args, opts)
+		if err != nil {
+			return nil, err
+		}
+		return &plugin.ParseCLIRes{Asset: asset}, nil
 	}
 
 	inventoryConfig := &inventory.Config{
@@ -66,7 +70,7 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	return &plugin.ParseCLIRes{Asset: &asset}, nil
 }
 
-func handleAwsEc2Subcommands(args []string, opts map[string]string) *inventory.Asset {
+func handleAwsEc2Subcommands(args []string, opts map[string]string) (*inventory.Asset, error) {
 	asset := &inventory.Asset{}
 	switch args[1] {
 	case "instance-connect":
@@ -76,7 +80,7 @@ func handleAwsEc2Subcommands(args []string, opts map[string]string) *inventory.A
 	case "ebs":
 		return resources.EbsConnectAsset(args, opts)
 	}
-	return asset
+	return asset, nil
 }
 
 func parseFlagsToFiltersOpts(m map[string]*llx.Primitive) map[string]string {

--- a/providers/aws/resources/discovery_conversion.go
+++ b/providers/aws/resources/discovery_conversion.go
@@ -660,7 +660,7 @@ func MondooECSContainerID(containerArn string) string {
 	return "//platformid.api.mondoo.app/runtime/aws/ecs/v1/accounts/" + account + "/regions/" + region + "/" + id
 }
 
-func SSMConnectAsset(args []string, opts map[string]string) *inventory.Asset {
+func SSMConnectAsset(args []string, opts map[string]string) (*inventory.Asset, error) {
 	var user, id string
 	if len(args) == 3 {
 		if args[0] == "ec2" && args[1] == "ssm" {
@@ -686,10 +686,10 @@ func SSMConnectAsset(args []string, opts map[string]string) *inventory.Asset {
 		},
 		Options: opts,
 	}}
-	return asset
+	return asset, nil
 }
 
-func InstanceConnectAsset(args []string, opts map[string]string) *inventory.Asset {
+func InstanceConnectAsset(args []string, opts map[string]string) (*inventory.Asset, error) {
 	var user, id string
 	if len(args) == 3 {
 		if args[0] == "ec2" && args[1] == "instance-connect" {
@@ -715,19 +715,25 @@ func InstanceConnectAsset(args []string, opts map[string]string) *inventory.Asse
 		},
 		Options: opts,
 	}}
-	return asset
+	return asset, nil
 }
 
-func EbsConnectAsset(args []string, opts map[string]string) *inventory.Asset {
+func EbsConnectAsset(args []string, opts map[string]string) (*inventory.Asset, error) {
 	var target, targetType string
 	if len(args) >= 3 {
 		if args[0] == "ec2" && args[1] == "ebs" {
 			// parse for target type: instance, volume, snapshot
 			switch args[2] {
 			case awsec2ebstypes.EBSTargetVolume:
+				if len(args) != 4 {
+					return nil, errors.New("missing target volume")
+				}
 				target = args[3]
 				targetType = awsec2ebstypes.EBSTargetVolume
 			case awsec2ebstypes.EBSTargetSnapshot:
+				if len(args) != 4 {
+					return nil, errors.New("missing snapshot-id")
+				}
 				target = args[3]
 				targetType = awsec2ebstypes.EBSTargetSnapshot
 			default:
@@ -749,5 +755,5 @@ func EbsConnectAsset(args []string, opts map[string]string) *inventory.Asset {
 		Runtime:  "aws-ebs",
 		Options:  opts,
 	}}
-	return asset
+	return asset, nil
 }


### PR DESCRIPTION
Found two panics.

One when we don't specify the ebs snapshot id.
```
[ec2-user@ip-172-31-6-3 ~]$ cnspec shell aws ec2 ebs snapshot
panic: runtime error: index out of range [3] with length 3

goroutine 34 [running]:
go.mondoo.com/cnquery/v11/providers/aws/resources.EbsConnectAsset({0xc0003ce140?, 0xc0009634b8?, 0x41a453?}, 0xc000560ed0)
	/home/runner/_work/cnquery/cnquery/providers/aws/resources/discovery_conversion.go:731 +0x385
go.mondoo.com/cnquery/v11/providers/aws/provider.handleAwsEc2Subcommands({0xc0003ce140, 0x3, 0x4}, 0xc000560ed0)
	/home/runner/_work/cnquery/cnquery/providers/aws/provider/provider.go:77 +0x85
go.mondoo.com/cnquery/v11/providers/aws/provider.(*Service).ParseCLI(0xc0000c4d30?, 0xc0008b9ce0)
	/home/runner/_work/cnquery/cnquery/providers/aws/provider/provider.go:45 +0x2dd
```

The second one when we don't have permissions to access the snapshot, but we still try to detach from it.
```
→ detach volume
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x7f2234e]

goroutine 37 [running]:
go.mondoo.com/cnquery/v11/providers/aws/connection/awsec2ebsconn.(*AwsEbsConnection).DetachVolumeFromInstance(0xc0008a7600, {0xa20a4a0, 0xdce2c80}, 0x0)
	/home/runner/_work/cnquery/cnquery/providers/aws/connection/awsec2ebsconn/destroy.go:21 +0xee
go.mondoo.com/cnquery/v11/providers/aws/connection/awsec2ebsconn.(*AwsEbsConnection).Close(0xc0008a7600)
	/home/runner/_work/cnquery/cnquery/providers/aws/connection/awsec2ebsconn/provider.go:196 +0x1c5
go.mondoo.com/cnquery/v11/providers/aws/connection/awsec2ebsconn.NewAwsEbsConnection(0x1, 0xc00006b2c0, 0xc0003f0b40)
```