### PR TITLE
Resource improvements in the AWS provider

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2914,9 +2914,9 @@ private aws.ec2.snapshot @defaults("id region volumeSize state") {
   createVolumePermission() []dict
   // ID of the volume used to create the snapshot
   volumeId string
-  // Time when the snapshot was initiated
+  // Time when the snapshot began
   startTime time
-  // Time when the snapshot was completed
+  // Time when the snapshot completed
   completionTime time
   // Tags for the snapshot
   tags map[string]string

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -134,7 +134,7 @@ private aws.vpc.subnet @defaults("id cidrs region availabilityZone defaultForAva
   region string
   // The number of available IP addresses in the subnet
   availableIpAddressCount int
-  // Internet gateway blocking mode or off if VPC Block Public Access (VPC BPA) is not enabled
+  // Internet gateway blocking mode: block-bidirectional, block-ingress, or off
   internetGatewayBlockMode string
 }
 

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -80,6 +80,8 @@ private aws.vpc @defaults("id isDefault cidrBlock region") {
   serviceEndpoints() []aws.vpc.serviceEndpoint
   // List of peering connections associated with the VPC
   peeringConnections() []aws.vpc.peeringConnection
+  // Internet gateway blocking mode or off if VPC Block Public Access (VPC BPA) is not enabled
+  internetGatewayBlockMode string
 }
 
 // Amazon Virtual Private Cloud (VPC) route table
@@ -130,6 +132,10 @@ private aws.vpc.subnet @defaults("id cidrs region availabilityZone defaultForAva
   state string
   // Region in which the VPC subnet exists
   region string
+  // The number of available IP addresses in the subnet
+  availableIpAddressCount int
+  // Internet gateway blocking mode or off if VPC Block Public Access (VPC BPA) is not enabled
+  internetGatewayBlockMode string
 }
 
 // Amazon Virtual Private Cloud (VPC) endpoint
@@ -2692,12 +2698,12 @@ aws.ec2 {
 }
 
 // Amazon Elastic IP (EIP)
-private aws.ec2.eip {
+private aws.ec2.eip @defaults("publicIp attached privateIpAddress") {
   // Public IP address of the EIP
   publicIp string
   // Whether the Elastic IP is associated with an instance (false if no allocationId is present)
   attached bool
-  // Ec2 instance associated with the EIP
+  // EC2 instance associated with the EIP
   instance() aws.ec2.instance
   // ID of the network interface
   networkInterfaceId string
@@ -2910,6 +2916,8 @@ private aws.ec2.snapshot @defaults("id region volumeSize state") {
   volumeId string
   // Time when the snapshot was initiated
   startTime time
+  // Time when the snapshot was completed
+  completionTime time
   // Tags for the snapshot
   tags map[string]string
   // State of the snapshot: pending, completed, error, recoverable, or recovering
@@ -2920,6 +2928,8 @@ private aws.ec2.snapshot @defaults("id region volumeSize state") {
   description string
   // Whether the snapshot is encrypted
   encrypted bool
+  // The storage tier in which the snapshot is stored
+  storageTier string
 }
 
 // Amazon EC2 (EBS) volume
@@ -3166,6 +3176,10 @@ private aws.ec2.image @defaults("ownerAlias id name") {
   createdAt time
   // Date the image was deprecated
   deprecatedAt time
+  // Specifies whether enhanced networking with ENA is enabled
+  enaSupport bool
+  // The supported TPM version. If the image is configured for NitroTPM support, the value is v2.0
+  tpmSupport string
 }
 
 // Amazon EC2 instance block device

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -80,7 +80,7 @@ private aws.vpc @defaults("id isDefault cidrBlock region") {
   serviceEndpoints() []aws.vpc.serviceEndpoint
   // List of peering connections associated with the VPC
   peeringConnections() []aws.vpc.peeringConnection
-  // Internet gateway blocking mode or off if VPC Block Public Access (VPC BPA) is not enabled
+  // Internet gateway blocking mode: block-bidirectional, block-ingress, or off
   internetGatewayBlockMode string
 }
 

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -3176,7 +3176,7 @@ private aws.ec2.image @defaults("ownerAlias id name") {
   createdAt time
   // Date the image was deprecated
   deprecatedAt time
-  // Specifies whether enhanced networking with ENA is enabled
+  // Whether enhanced networking with ENA is enabled
   enaSupport bool
   // The supported TPM version. If the image is configured for NitroTPM support, the value is v2.0
   tpmSupport string

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -923,6 +923,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.vpc.peeringConnections": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpc).GetPeeringConnections()).ToDataRes(types.Array(types.Resource("aws.vpc.peeringConnection")))
 	},
+	"aws.vpc.internetGatewayBlockMode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpc).GetInternetGatewayBlockMode()).ToDataRes(types.String)
+	},
 	"aws.vpc.routetable.associations": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcRoutetable).GetAssociations()).ToDataRes(types.Array(types.Resource("aws.vpc.routetable.association")))
 	},
@@ -979,6 +982,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.vpc.subnet.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcSubnet).GetRegion()).ToDataRes(types.String)
+	},
+	"aws.vpc.subnet.availableIpAddressCount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcSubnet).GetAvailableIpAddressCount()).ToDataRes(types.Int)
+	},
+	"aws.vpc.subnet.internetGatewayBlockMode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcSubnet).GetInternetGatewayBlockMode()).ToDataRes(types.String)
 	},
 	"aws.vpc.endpoint.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcEndpoint).GetId()).ToDataRes(types.String)
@@ -4205,6 +4214,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.snapshot.startTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Snapshot).GetStartTime()).ToDataRes(types.Time)
 	},
+	"aws.ec2.snapshot.completionTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Snapshot).GetCompletionTime()).ToDataRes(types.Time)
+	},
 	"aws.ec2.snapshot.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Snapshot).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -4219,6 +4231,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.snapshot.encrypted": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Snapshot).GetEncrypted()).ToDataRes(types.Bool)
+	},
+	"aws.ec2.snapshot.storageTier": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Snapshot).GetStorageTier()).ToDataRes(types.String)
 	},
 	"aws.ec2.volume.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Volume).GetArn()).ToDataRes(types.String)
@@ -4528,6 +4543,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.image.deprecatedAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Image).GetDeprecatedAt()).ToDataRes(types.Time)
+	},
+	"aws.ec2.image.enaSupport": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Image).GetEnaSupport()).ToDataRes(types.Bool)
+	},
+	"aws.ec2.image.tpmSupport": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Image).GetTpmSupport()).ToDataRes(types.String)
 	},
 	"aws.ec2.instance.device.deleteOnTermination": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2InstanceDevice).GetDeleteOnTermination()).ToDataRes(types.Bool)
@@ -5169,6 +5190,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsVpc).PeeringConnections, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
+	"aws.vpc.internetGatewayBlockMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpc).InternetGatewayBlockMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.vpc.routetable.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 			r.(*mqlAwsVpcRoutetable).__id, ok = v.Value.(string)
 			return
@@ -5255,6 +5280,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.vpc.subnet.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcSubnet).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.subnet.availableIpAddressCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcSubnet).AvailableIpAddressCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.subnet.internetGatewayBlockMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcSubnet).InternetGatewayBlockMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.endpoint.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10177,6 +10210,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsEc2Snapshot).StartTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.snapshot.completionTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Snapshot).CompletionTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.snapshot.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Snapshot).Tags, ok = plugin.RawToTValue[map[string]interface{}](v.Value, v.Error)
 		return
@@ -10195,6 +10232,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.ec2.snapshot.encrypted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Snapshot).Encrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.snapshot.storageTier": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Snapshot).StorageTier, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.volume.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10647,6 +10688,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.ec2.image.deprecatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Image).DeprecatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.image.enaSupport": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Image).EnaSupport, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.image.tpmSupport": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Image).TpmSupport, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.instance.device.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11653,6 +11702,7 @@ type mqlAwsVpc struct {
 	NatGateways plugin.TValue[[]interface{}]
 	ServiceEndpoints plugin.TValue[[]interface{}]
 	PeeringConnections plugin.TValue[[]interface{}]
+	InternetGatewayBlockMode plugin.TValue[string]
 }
 
 // createAwsVpc creates a new instance of this resource
@@ -11840,6 +11890,10 @@ func (c *mqlAwsVpc) GetPeeringConnections() *plugin.TValue[[]interface{}] {
 	})
 }
 
+func (c *mqlAwsVpc) GetInternetGatewayBlockMode() *plugin.TValue[string] {
+	return &c.InternetGatewayBlockMode
+}
+
 // mqlAwsVpcRoutetable for the aws.vpc.routetable resource
 type mqlAwsVpcRoutetable struct {
 	MqlRuntime *plugin.Runtime
@@ -12011,6 +12065,8 @@ type mqlAwsVpcSubnet struct {
 	AssignIpv6AddressOnCreation plugin.TValue[bool]
 	State plugin.TValue[string]
 	Region plugin.TValue[string]
+	AvailableIpAddressCount plugin.TValue[int64]
+	InternetGatewayBlockMode plugin.TValue[string]
 }
 
 // createAwsVpcSubnet creates a new instance of this resource
@@ -12084,6 +12140,14 @@ func (c *mqlAwsVpcSubnet) GetState() *plugin.TValue[string] {
 
 func (c *mqlAwsVpcSubnet) GetRegion() *plugin.TValue[string] {
 	return &c.Region
+}
+
+func (c *mqlAwsVpcSubnet) GetAvailableIpAddressCount() *plugin.TValue[int64] {
+	return &c.AvailableIpAddressCount
+}
+
+func (c *mqlAwsVpcSubnet) GetInternetGatewayBlockMode() *plugin.TValue[string] {
+	return &c.InternetGatewayBlockMode
 }
 
 // mqlAwsVpcEndpoint for the aws.vpc.endpoint resource
@@ -26000,11 +26064,13 @@ type mqlAwsEc2Snapshot struct {
 	CreateVolumePermission plugin.TValue[[]interface{}]
 	VolumeId plugin.TValue[string]
 	StartTime plugin.TValue[*time.Time]
+	CompletionTime plugin.TValue[*time.Time]
 	Tags plugin.TValue[map[string]interface{}]
 	State plugin.TValue[string]
 	VolumeSize plugin.TValue[int64]
 	Description plugin.TValue[string]
 	Encrypted plugin.TValue[bool]
+	StorageTier plugin.TValue[string]
 }
 
 // createAwsEc2Snapshot creates a new instance of this resource
@@ -26070,6 +26136,10 @@ func (c *mqlAwsEc2Snapshot) GetStartTime() *plugin.TValue[*time.Time] {
 	return &c.StartTime
 }
 
+func (c *mqlAwsEc2Snapshot) GetCompletionTime() *plugin.TValue[*time.Time] {
+	return &c.CompletionTime
+}
+
 func (c *mqlAwsEc2Snapshot) GetTags() *plugin.TValue[map[string]interface{}] {
 	return &c.Tags
 }
@@ -26088,6 +26158,10 @@ func (c *mqlAwsEc2Snapshot) GetDescription() *plugin.TValue[string] {
 
 func (c *mqlAwsEc2Snapshot) GetEncrypted() *plugin.TValue[bool] {
 	return &c.Encrypted
+}
+
+func (c *mqlAwsEc2Snapshot) GetStorageTier() *plugin.TValue[string] {
+	return &c.StorageTier
 }
 
 // mqlAwsEc2Volume for the aws.ec2.volume resource
@@ -27143,6 +27217,8 @@ type mqlAwsEc2Image struct {
 	OwnerAlias plugin.TValue[string]
 	CreatedAt plugin.TValue[*time.Time]
 	DeprecatedAt plugin.TValue[*time.Time]
+	EnaSupport plugin.TValue[bool]
+	TpmSupport plugin.TValue[string]
 }
 
 // createAwsEc2Image creates a new instance of this resource
@@ -27212,6 +27288,14 @@ func (c *mqlAwsEc2Image) GetCreatedAt() *plugin.TValue[*time.Time] {
 
 func (c *mqlAwsEc2Image) GetDeprecatedAt() *plugin.TValue[*time.Time] {
 	return &c.DeprecatedAt
+}
+
+func (c *mqlAwsEc2Image) GetEnaSupport() *plugin.TValue[bool] {
+	return &c.EnaSupport
+}
+
+func (c *mqlAwsEc2Image) GetTpmSupport() *plugin.TValue[string] {
+	return &c.TpmSupport
 }
 
 // mqlAwsEc2InstanceDevice for the aws.ec2.instance.device resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -956,11 +956,15 @@ resources:
         min_mondoo_version: 9.0.0
       deprecatedAt:
         min_mondoo_version: 9.0.0
+      enaSupport:
+        min_mondoo_version: 9.0.0
       id: {}
       name: {}
       ownerAlias:
         min_mondoo_version: 5.22.0
       ownerId: {}
+      tpmSupport:
+        min_mondoo_version: 9.0.0
     is_private: true
     min_mondoo_version: 5.15.0
     platform:
@@ -1198,6 +1202,8 @@ resources:
         The `aws.ec2.snapshot` resource provides fields for assessing the configuration of EBS snapshots within an AWS account. For usage, see `aws.ec2` resource documentation.
     fields:
       arn: {}
+      completionTime:
+        min_mondoo_version: 9.0.0
       createVolumePermission: {}
       description:
         min_mondoo_version: 9.0.0
@@ -1207,6 +1213,8 @@ resources:
       region: {}
       startTime: {}
       state: {}
+      storageTier:
+        min_mondoo_version: 9.0.0
       tags: {}
       volumeId: {}
       volumeSize:
@@ -3106,6 +3114,8 @@ resources:
       id: {}
       instanceTenancy:
         min_mondoo_version: 9.0.0
+      internetGatewayBlockMode:
+        min_mondoo_version: 9.0.0
       isDefault: {}
       name:
         min_mondoo_version: 9.0.0
@@ -3274,9 +3284,11 @@ resources:
       arn: {}
       assignIpv6AddressOnCreation: {}
       availabilityZone: {}
+      availableIpAddressCount: {}
       cidrs: {}
       defaultForAvailabilityZone: {}
       id: {}
+      internetGatewayBlockMode: {}
       mapPublicIpOnLaunch: {}
       region: {}
       state: {}

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -88,15 +88,16 @@ func (a *mqlAws) getVpcs(conn *connection.AwsConnection) []*jobpool.Job {
 					}
 					mqlVpc, err := CreateResource(a.MqlRuntime, "aws.vpc",
 						map[string]*llx.RawData{
-							"arn":             llx.StringData(fmt.Sprintf(vpcArnPattern, regionVal, conn.AccountId(), convert.ToString(v.VpcId))),
-							"id":              llx.StringDataPtr(v.VpcId),
-							"name":            llx.StringData(name),
-							"state":           llx.StringData(string(v.State)),
-							"isDefault":       llx.BoolData(convert.ToBool(v.IsDefault)),
-							"instanceTenancy": llx.StringData(string(v.InstanceTenancy)),
-							"cidrBlock":       llx.StringDataPtr(v.CidrBlock),
-							"region":          llx.StringData(regionVal),
-							"tags":            llx.MapData(Ec2TagsToMap(v.Tags), types.String),
+							"arn":                      llx.StringData(fmt.Sprintf(vpcArnPattern, regionVal, conn.AccountId(), convert.ToString(v.VpcId))),
+							"cidrBlock":                llx.StringDataPtr(v.CidrBlock),
+							"id":                       llx.StringDataPtr(v.VpcId),
+							"instanceTenancy":          llx.StringData(string(v.InstanceTenancy)),
+							"internetGatewayBlockMode": llx.StringData(string(v.BlockPublicAccessStates.InternetGatewayBlockMode)),
+							"isDefault":                llx.BoolData(convert.ToBool(v.IsDefault)),
+							"name":                     llx.StringData(name),
+							"region":                   llx.StringData(regionVal),
+							"state":                    llx.StringData(string(v.State)),
+							"tags":                     llx.MapData(Ec2TagsToMap(v.Tags), types.String),
 						})
 					if err != nil {
 						log.Error().Msg(err.Error())
@@ -651,9 +652,11 @@ func (a *mqlAwsVpc) subnets() ([]interface{}, error) {
 					"arn":                         llx.StringData(fmt.Sprintf(subnetArnPattern, a.Region.Data, conn.AccountId(), convert.ToString(subnet.SubnetId))),
 					"assignIpv6AddressOnCreation": llx.BoolDataPtr(subnet.AssignIpv6AddressOnCreation),
 					"availabilityZone":            llx.StringDataPtr(subnet.AvailabilityZone),
+					"availableIpAddressCount":     llx.IntDataPtr(subnet.AvailableIpAddressCount),
 					"cidrs":                       llx.StringDataPtr(subnet.CidrBlock),
 					"defaultForAvailabilityZone":  llx.BoolDataPtr(subnet.DefaultForAz),
 					"id":                          llx.StringDataPtr(subnet.SubnetId),
+					"internetGatewayBlockMode":    llx.StringData(string(subnet.BlockPublicAccessStates.InternetGatewayBlockMode)),
 					"mapPublicIpOnLaunch":         llx.BoolDataPtr(subnet.MapPublicIpOnLaunch),
 					"region":                      llx.StringData(a.Region.Data),
 					"state":                       llx.StringData(string(subnet.State)),


### PR DESCRIPTION
- Default values for the aws.ec2.eip resource
- Add `completionTime` and `storageTier` to aws.ec2.snapshot
- Add `internetGatewayBlockMode` to `aws.vpc` and `aws.vpc.subnet`
- Add `availableIpAddressCount` to `aws.vpc.subnet`
- Add `enaSupport` and `tpmSupport` to `aws.ec2.image`