### PR TITLE
🐛 Fix missing package arch in windows and macos

### DIFF
--- a/providers/os/resources/packages/macos_packages.go
+++ b/providers/os/resources/packages/macos_packages.go
@@ -60,6 +60,7 @@ func ParseMacOSPackages(platform *inventory.Platform, input io.Reader) ([]Packag
 		pkgs[i].Version = entry.Version
 		pkgs[i].Format = MacosPkgFormat
 		pkgs[i].FilesAvailable = PkgFilesIncluded
+		pkgs[i].Arch = platform.Arch
 		pkgs[i].PUrl = purl.NewPackageURL(
 			platform, purl.TypeMacos, entry.Name, entry.Version,
 		).String()

--- a/providers/os/resources/packages/macos_packages_test.go
+++ b/providers/os/resources/packages/macos_packages_test.go
@@ -39,6 +39,7 @@ func TestMacOsXPackageParser(t *testing.T) {
 	assert.Equal(t, packages.PkgFilesIncluded, m[0].FilesAvailable)
 	assert.Equal(t, "pkg:macos/macos/Preview@10.0?arch=x86_64", m[0].PUrl)
 	assert.Equal(t, []packages.FileRecord{{Path: "/Applications/Preview.app"}}, m[0].Files)
+	assert.Equal(t, m[0].Arch, "x86_64")
 
 	assert.Equal(t, "Contacts", m[1].Name, "pkg name detected")
 	assert.Equal(t, "11.0", m[1].Version, "pkg version detected")

--- a/providers/os/resources/packages/windows_packages.go
+++ b/providers/os/resources/packages/windows_packages.go
@@ -470,6 +470,7 @@ func getPackageFromRegistryKeyItems(children []registry.RegistryKeyItem, platfor
 		Name:    displayName,
 		Version: displayVersion,
 		Format:  "windows/app",
+		Arch:    platform.Arch,
 		Vendor:  publisher,
 		PUrl: purl.NewPackageURL(
 			platform, purl.TypeWindows, displayName, displayVersion,
@@ -582,6 +583,7 @@ func ParseWindowsAppPackages(platform *inventory.Platform, input io.Reader) ([]P
 			Format:  "windows/app",
 			CPEs:    cpeWfns,
 			Vendor:  entry.Publisher,
+			Arch:    platform.Arch,
 			PUrl: purl.NewPackageURL(
 				platform, purl.TypeWindows, entry.DisplayName, entry.DisplayVersion,
 			).String(),

--- a/providers/os/resources/packages/windows_packages_test.go
+++ b/providers/os/resources/packages/windows_packages_test.go
@@ -36,7 +36,7 @@ func TestWindowsAppPackagesParser(t *testing.T) {
 	assert.Equal(t, Package{
 		Name:    "Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.28.29913",
 		Version: "14.28.29913.0",
-		Arch:    "",
+		Arch:    "x86",
 		Format:  "windows/app",
 		PUrl:    `pkg:windows/windows/Microsoft%20Visual%20C%2B%2B%202015-2019%20Redistributable%20%28x86%29%20-%2014.28.29913@14.28.29913.0?arch=x86`,
 		CPEs: []string{
@@ -208,7 +208,7 @@ func TestGetPackageFromRegistryKeyItems(t *testing.T) {
 		expected := &Package{
 			Name:    "Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.28.29913",
 			Version: "14.28.29913.0",
-			Arch:    "",
+			Arch:    "x86",
 			Format:  "windows/app",
 			CPEs:    CPEs,
 			Vendor:  "Microsoft Corporation",


### PR DESCRIPTION
- Fixes an issue with missing arch in packages for windows and macos 