### PR TITLE
🧹 Fix deprecated/removed parameters for golangci

### DIFF
--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -4,8 +4,8 @@
 # See https://golangci-lint.run/usage/configuration/ for configuration options
 run:
   timeout: 5m
-  skip-dirs:
-  skip-files:
+  exclude-dirs:
+  exclude-files:
     - ".*\\.pb\\.go$"
     - ".*\\.lr\\.go$"
   modules-download-mode: readonly

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,8 +4,8 @@
 # See https://golangci-lint.run/usage/configuration/ for configuration options
 run:
   timeout: 5m
-  skip-dirs:
-  skip-files:
+  exclude-dirs:
+  exclude-files:
     - ".*\\.pb\\.go$"
     - ".*\\.lr\\.go$"
   modules-download-mode: readonly


### PR DESCRIPTION
This fixes https://github.com/mondoohq/cnquery/actions/runs/13896435625/job/38878008963\?pr\=5321