### PR TITLE
🧹 Fix moved parameters for golangci

### DIFF
--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -4,11 +4,13 @@
 # See https://golangci-lint.run/usage/configuration/ for configuration options
 run:
   timeout: 5m
+  modules-download-mode: readonly
+
+issues:
   exclude-dirs:
   exclude-files:
     - ".*\\.pb\\.go$"
     - ".*\\.lr\\.go$"
-  modules-download-mode: readonly
 
 linters:
   disable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,11 +4,13 @@
 # See https://golangci-lint.run/usage/configuration/ for configuration options
 run:
   timeout: 5m
+  modules-download-mode: readonly
+
+issues:
   exclude-dirs:
   exclude-files:
     - ".*\\.pb\\.go$"
     - ".*\\.lr\\.go$"
-  modules-download-mode: readonly
 
 linters:
   disable-all: true


### PR DESCRIPTION
This fixes https://github.com/mondoohq/cnquery/actions/runs/13896435625/job/38878008963\?pr\=5321

Follow-up to https://github.com/mondoohq/cnquery/pull/5325

They were not only renamed, but also moved to a different section.