### PR TITLE
🧹 Empty exclude dirs are no longer supported

### DIFF
--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -7,7 +7,6 @@ run:
   modules-download-mode: readonly
 
 issues:
-  exclude-dirs:
   exclude-files:
     - ".*\\.pb\\.go$"
     - ".*\\.lr\\.go$"


### PR DESCRIPTION
Fixes: https://github.com/mondoohq/cnquery/actions/runs/13915522402/job/38937767869\?pr\=5321