### PR TITLE
🧹 Empty exclude dirs are not longer supported - 2nd config file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,6 @@ run:
   modules-download-mode: readonly
 
 issues:
-  exclude-dirs:
   exclude-files:
     - ".*\\.pb\\.go$"
     - ".*\\.lr\\.go$"


### PR DESCRIPTION
Fixes: https://github.com/mondoohq/cnquery/actions/runs/13915522402/job/38937767869\?pr\=5321