### PR TITLE
✨ Authenticate against AKS cluster by mimicking kubelogin managed identity credential token flow.

### DIFF
--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -77,7 +77,7 @@ Examples:
 					Long:    "kubelogin",
 					Type:    plugin.FlagType_Bool,
 					Default: "false",
-					Desc:    "Authenticate against a remote Azure AD enabled Kubernetes cluster using a default user or system-assigned Azure identity.",
+					Desc:    "Authenticate against a remote Azure AD enabled Kubernetes cluster using an Azure identity.",
 				},
 			},
 		},

--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -73,6 +73,12 @@ Examples:
 					Default: "",
 					Desc:    "HTTP proxy to use for container pulls",
 				},
+				{
+					Long:    "kubelogin",
+					Type:    plugin.FlagType_Bool,
+					Default: "false",
+					Desc:    "Use kubelogin auth flow to authenticate against an AKS cluster using a managed identity credential.",
+				},
 			},
 		},
 	},

--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -77,7 +77,7 @@ Examples:
 					Long:    "kubelogin",
 					Type:    plugin.FlagType_Bool,
 					Default: "false",
-					Desc:    "Use kubelogin auth flow to authenticate against an AKS cluster using a managed identity credential.",
+					Desc:    "Authenticate against a remote Azure AD enabled Kubernetes cluster using a default user or system-assigned Azure identity.",
 				},
 			},
 		},

--- a/providers/k8s/connection/api/aks_auth.go
+++ b/providers/k8s/connection/api/aks_auth.go
@@ -60,7 +60,7 @@ func attemptKubeloginAuthFlow(asset *inventory.Asset, config *rest.Config) error
 		return errors.Wrap(err, "failed to get access token for Azure AKS authentication")
 	}
 
-	log.Debug().Str("bearer_token", token.Token).Msg("got access token")
+	log.Debug().Msg("got access token")
 
 	config.BearerToken = token.Token
 

--- a/providers/k8s/connection/api/auth.go
+++ b/providers/k8s/connection/api/auth.go
@@ -1,0 +1,70 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/azauth"
+	"go.mondoo.com/cnquery/v11/providers/k8s/connection/shared"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	// AKS Microsoft Entra server application ID used by AKS for user authentication. The bearer token needs to be issued
+	// for this application (aud claim in JWT).
+	// https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks
+	serverAppId  = "6dae42f8-4368-4678-94ff-3960e28e3630"
+	defaultScope = "/.default"
+)
+
+// attempt to get a bearer token using the kubelogin flow and attach it to the rest config
+func attemptKubeloginAuthFlow(asset *inventory.Asset, config *rest.Config) error {
+	var err error
+	kubeloginAuth := false
+	if val, ok := asset.Connections[0].Options[shared.OPTION_KUBELOGIN]; ok {
+		kubeloginAuth, err = strconv.ParseBool(val)
+		if err != nil {
+			return err
+		}
+	}
+
+	if !kubeloginAuth {
+		return nil
+	}
+
+	log.Debug().Msg("attempting to get a bearer token using the kubelogin flow")
+
+	// the managed identity token credential is used for AKS authentication
+	chainedToken, err := azauth.GetChainedToken(&azidentity.DefaultAzureCredentialOptions{
+		ClientOptions: azcore.ClientOptions{Cloud: cloud.AzurePublic},
+	})
+	if err != nil {
+		return err
+	}
+
+	scope := serverAppId + defaultScope
+	token, err := chainedToken.GetToken(context.Background(), policy.TokenRequestOptions{
+		Scopes: []string{scope},
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Info().Str("bearer_token", token.Token).Msg("got access token")
+
+	config.BearerToken = token.Token
+
+	// clear the exec provider since the code above bypasses the need to run `kubelogin get-token --server-id 6dae42f8-4368-4678-94ff-3960e28e3630`
+	config.ExecProvider = nil
+
+	return nil
+}

--- a/providers/k8s/connection/api/auth.go
+++ b/providers/k8s/connection/api/auth.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/azauth"
@@ -33,7 +34,7 @@ func attemptKubeloginAuthFlow(asset *inventory.Asset, config *rest.Config) error
 	if val, ok := asset.Connections[0].Options[shared.OPTION_KUBELOGIN]; ok {
 		kubeloginAuth, err = strconv.ParseBool(val)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "could not parse boolean from the kubelogin option value")
 		}
 	}
 
@@ -48,7 +49,7 @@ func attemptKubeloginAuthFlow(asset *inventory.Asset, config *rest.Config) error
 		ClientOptions: azcore.ClientOptions{Cloud: cloud.AzurePublic},
 	})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get chained token credential for Azure AKS authentication")
 	}
 
 	scope := serverAppId + defaultScope
@@ -56,7 +57,7 @@ func attemptKubeloginAuthFlow(asset *inventory.Asset, config *rest.Config) error
 		Scopes: []string{scope},
 	})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get access token for Azure AKS authentication")
 	}
 
 	log.Debug().Str("bearer_token", token.Token).Msg("got access token")

--- a/providers/k8s/connection/api/auth.go
+++ b/providers/k8s/connection/api/auth.go
@@ -59,11 +59,12 @@ func attemptKubeloginAuthFlow(asset *inventory.Asset, config *rest.Config) error
 		return err
 	}
 
-	log.Info().Str("bearer_token", token.Token).Msg("got access token")
+	log.Debug().Str("bearer_token", token.Token).Msg("got access token")
 
 	config.BearerToken = token.Token
 
-	// clear the exec provider since the code above bypasses the need to run `kubelogin get-token --server-id 6dae42f8-4368-4678-94ff-3960e28e3630`
+	// clear the exec provider since the code above bypasses the need to run the command
+	// `kubelogin get-token --server-id {serverAppId}` since that would require the kubelogin CLI tool to be present
 	config.ExecProvider = nil
 
 	return nil

--- a/providers/k8s/connection/api/connection.go
+++ b/providers/k8s/connection/api/connection.go
@@ -67,6 +67,11 @@ func NewConnection(id uint32, asset *inventory.Asset, discoveryCache *resources.
 		return nil, err
 	}
 
+	err = attemptKubeloginAuthFlow(asset, config)
+	if err != nil {
+		return nil, err
+	}
+
 	// enable-client side throttling
 	// avoids the cli warning: Waited for 1.000907542s due to client-side throttling, not priority and fairness
 	config.QPS = 1000

--- a/providers/k8s/connection/shared/connection.go
+++ b/providers/k8s/connection/shared/connection.go
@@ -25,6 +25,7 @@ const (
 	OPTION_ADMISSION         = "k8s-admission-review"
 	OPTION_OBJECT_KIND       = "object-kind"
 	OPTION_CONTEXT           = "context"
+	OPTION_KUBELOGIN         = "kubelogin"
 	idPrefix                 = "//platformid.api.mondoo.app/runtime/k8s/uid/"
 )
 

--- a/providers/k8s/go.mod
+++ b/providers/k8s/go.mod
@@ -34,6 +34,11 @@ require (
 )
 
 require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.2
+)
+
+require (
 	cel.dev/expr v0.20.0 // indirect
 	cloud.google.com/go v0.118.3 // indirect
 	cloud.google.com/go/auth v0.15.0 // indirect
@@ -48,8 +53,6 @@ require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/99designs/keyring v1.2.2 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.4.0 // indirect

--- a/providers/k8s/provider/provider.go
+++ b/providers/k8s/provider/provider.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"context"
 	"errors"
+	"strconv"
 
 	"go.mondoo.com/cnquery/v11"
 	"go.mondoo.com/cnquery/v11/llx"
@@ -75,6 +76,10 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 
 	if ns, ok := req.Flags[shared.OPTION_NAMESPACE_EXCLUDE]; ok {
 		conf.Options[shared.OPTION_NAMESPACE_EXCLUDE] = string(ns.Value)
+	}
+
+	if val, ok := req.Flags[shared.OPTION_KUBELOGIN]; ok {
+		conf.Options[shared.OPTION_KUBELOGIN] = strconv.FormatBool(val.RawData().Value.(bool))
 	}
 
 	if containerProxy, ok := flags["container-proxy"]; ok {


### PR DESCRIPTION
#### In this PR:
Added a `--kubelogin` boolean flag to the Kubernetes provider which gives the option to authenticate against a remote AKS cluster using a JWT bearer token. This flow mimics the flow `kubelogin` ([docs](https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication)) uses without needing the `kubelogin` CLI to be present locally.

Azure provides us a kubeconfig file with the following exec:
```bash
kubelogin get-token --environment AzurePublicCloud --server-id {value} --client-id {value} --tenant-id {value} --login devicecode
```
this would then get modified to:
```bash
 kubelogin get-token --login msi --server-id {value}
 ```
which is the flow implemented in this PR (uses the inferred managed identity).

Running cnquery with:
```bash
cnquery shell k8s --kubelogin
```
yields
![image](https://github.com/user-attachments/assets/db5d60c6-6c33-436b-8e68-441b008d9eee)

Also compiled this into cnspec and ran it against a policy:
![image](https://github.com/user-attachments/assets/fd06122c-9ae3-4997-9aa7-085914c5fab2)


 #### Notes:
We initially wanted to pull in the entire [kubelogin](https://github.com/Azure/kubelogin) as a dependency but decided to hold off for now due to #2883 to be on the safe side and only used the relevant code from `azidentity`. We can always come back to this at a later point and include it since we're talking about 4-5 lines of code here.