### PR TITLE
🐛 lsblk: empty mountpoints

### DIFF
--- a/providers/os/resources/lsblk.go
+++ b/providers/os/resources/lsblk.go
@@ -35,19 +35,6 @@ func (l *mqlLsblk) list() ([]interface{}, error) {
 		d := blockEntries.Blockdevices[i]
 		for i := range d.Children {
 			entry := d.Children[i]
-			// Some versions of the lsblk return [null] instead of empty array
-			entry.Mountpoints = slices.Collect(func(yield func(interface{}) bool) {
-				for _, m := range entry.Mountpoints {
-					if m != nil && !yield(m) {
-						return
-					}
-				}
-			})
-			// Some versions of the lsblk return the mountpoint instead of the mountpoints array
-			if len(entry.Mountpoints) == 0 && entry.Mountpoint != "" {
-				entry.Mountpoints = append(entry.Mountpoints, entry.Mountpoint)
-			}
-
 			mqlLsblkEntry, err := CreateResource(l.MqlRuntime, "lsblk.entry", map[string]*llx.RawData{
 				"name":        llx.StringData(entry.Name),
 				"fstype":      llx.StringData(entry.Fstype),
@@ -69,6 +56,27 @@ func parseBlockEntries(data []byte) (blockdevices, error) {
 	if err := json.Unmarshal(data, &blockEntries); err != nil {
 		return blockEntries, err
 	}
+
+	for i := range blockEntries.Blockdevices {
+		d := blockEntries.Blockdevices[i]
+		for j := range d.Children {
+			entry := d.Children[j]
+			// Some versions of the lsblk return [null] instead of empty array
+			entry.Mountpoints = slices.Collect(func(yield func(interface{}) bool) {
+				for _, m := range entry.Mountpoints {
+					if m != nil && !yield(m) {
+						return
+					}
+				}
+			})
+			// Some versions of the lsblk return the mountpoint instead of the mountpoints array
+			if len(entry.Mountpoints) == 0 && entry.Mountpoint != "" {
+				entry.Mountpoints = append(entry.Mountpoints, entry.Mountpoint)
+			}
+			blockEntries.Blockdevices[i].Children[j] = entry
+		}
+	}
+
 	return blockEntries, nil
 }
 

--- a/providers/os/resources/lsblk_test.go
+++ b/providers/os/resources/lsblk_test.go
@@ -158,11 +158,12 @@ func TestParseBlockEntries(t *testing.T) {
 		Name:       "xvda",
 		Mountpoint: "",
 		Children: []blockdevice{{
-			Name:       "xvda1",
-			Fstype:     "xfs",
-			Label:      "/",
-			Uuid:       "e6c06bf4-70a3-4524-84fa-35484afc0d19",
-			Mountpoint: "/",
+			Name:        "xvda1",
+			Fstype:      "xfs",
+			Label:       "/",
+			Uuid:        "e6c06bf4-70a3-4524-84fa-35484afc0d19",
+			Mountpoint:  "/",
+			Mountpoints: []interface{}{"/"},
 		}},
 	}})
 }

--- a/providers/os/resources/lsblk_test.go
+++ b/providers/os/resources/lsblk_test.go
@@ -96,8 +96,8 @@ func TestParseBlockEntries(t *testing.T) {
  }`
 	devices, err := parseBlockEntries([]byte(data))
 	assert.Nil(t, err)
-	assert.Equal(t, len(devices.Blockdevices), 5)
-	assert.Equal(t, devices.Blockdevices, []blockdevice{{
+	assert.Equal(t, 5, len(devices.Blockdevices))
+	assert.Equal(t, []blockdevice{{
 		Name:        "loop0",
 		Fstype:      "squashfs",
 		Label:       "",
@@ -140,7 +140,7 @@ func TestParseBlockEntries(t *testing.T) {
 		Label:       "storage01",
 		Uuid:        "6060df9a-7e53-439c-9189-ba9657161fd4",
 		Mountpoints: []interface{}{nil},
-	}})
+	}}, devices.Blockdevices)
 
 	data = `{
 		"blockdevices": [


### PR DESCRIPTION
Depending on a version of lsblk json output might differ slightly
Has `MOUNTPOINT` only: https://man7.org/linux/man-pages/man8/lsblk.8.html
Has both `MOUNTPOINT` and `MOUNTPOINTS`  https://man.archlinux.org/man/lsblk.8.en#:~:text=The%20relationship%20between,with%20the%20device.

Bonus: handle `null` entries