### PR TITLE
🐛 fix smbios unix family filter

### DIFF
--- a/providers/os/id/aws/aws.go
+++ b/providers/os/id/aws/aws.go
@@ -26,7 +26,7 @@ func readValue(conn shared.Connection, fPath string) string {
 
 func Detect(conn shared.Connection, p *inventory.Platform, smbiosMgr smbios.SmBiosManager) (string, string, []string) {
 	var values []string
-	if p.IsFamily("linux") {
+	if p.IsFamily(inventory.FAMILY_LINUX) {
 		// Fetching the data from the smbios manager is slow for some transports
 		// because it iterates through files we don't need to check. This
 		// is an optimization for our sshfs. Also, be aware that on linux,

--- a/providers/os/resources/smbios/smbios.go
+++ b/providers/os/resources/smbios/smbios.go
@@ -66,7 +66,7 @@ func ResolveManager(conn shared.Connection, pf *inventory.Platform) (SmBiosManag
 	// check darwin before unix since darwin is also a unix
 	if pf.IsFamily("darwin") {
 		biosM = &OSXSmbiosManager{provider: conn, platform: pf}
-	} else if pf.IsFamily("linux") {
+	} else if pf.IsFamily(inventory.FAMILY_UNIX) {
 		biosM = &LinuxSmbiosManager{provider: conn}
 	} else if pf.IsFamily("windows") {
 		biosM = &WindowsSmbiosManager{provider: conn}

--- a/providers/os/resources/smbios/smbios_test.go
+++ b/providers/os/resources/smbios/smbios_test.go
@@ -83,6 +83,52 @@ func Test_WindowsSmbiosChassis_AdHoc(t *testing.T) {
 	require.Equal(t, []string{""}, chassis[4].GetChassisTypes().Value())
 }
 
+func TestManagerUnixFamily(t *testing.T) {
+	// special case where we detect a unix system other than darwin
+	// use centos and change the platform family
+	conn, err := mock.New(0, "./testdata/centos.toml", &inventory.Asset{})
+	require.NoError(t, err)
+	platform, ok := detector.DetectOS(conn)
+	require.True(t, ok)
+	platform.Family = []string{"unix"}
+
+	mm, err := ResolveManager(conn, platform)
+	require.NoError(t, err)
+	biosInfo, err := mm.Info()
+	require.NoError(t, err)
+	assert.Equal(t, &SmBiosInfo{
+		BIOS: BiosInfo{
+			Vendor:      "innotek GmbH",
+			Version:     "VirtualBox",
+			ReleaseDate: "12/01/2006",
+		},
+		SysInfo: SysInfo{
+			Vendor:       "innotek GmbH",
+			Model:        "VirtualBox",
+			Version:      "1.2",
+			SerialNumber: "0",
+			UUID:         "64f118d3-0060-4a4c-bf1f-a11d655c4d6f",
+			Family:       "Virtual Machine",
+			SKU:          "",
+		},
+		BaseBoardInfo: BaseBoardInfo{
+			Vendor:       "Oracle Corporation",
+			Model:        "VirtualBox",
+			Version:      "1.2",
+			SerialNumber: "0",
+			AssetTag:     "",
+		},
+		ChassisInfo: ChassisInfo{
+			Vendor:       "Oracle Corporation",
+			Model:        "",
+			Version:      "",
+			SerialNumber: "",
+			AssetTag:     "",
+			Type:         "1",
+		},
+	}, biosInfo)
+}
+
 func TestManagerCentos(t *testing.T) {
 	conn, err := mock.New(0, "./testdata/centos.toml", &inventory.Asset{})
 	require.NoError(t, err)


### PR DESCRIPTION
Why do we need this? Mainly because our `aws` provider sets the platform family to unix.

https://github.com/mondoohq/cnquery/blob/fa345791676d0a3773fcaad9d70bc9a92b24815e/providers/aws/resources/discovery_conversion.go#L242-L250

Since we check for `darwin` first, this shouldn't have any implication for the `smbios` package, though, changing the `aws` provider may have implications that we can't detect.

This issue prevented our `clouddetect` package to identify some aws assets correctly.

