### PR TITLE
🐛 mqlc: compile builtin functions without constraint block

### DIFF
--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -1644,6 +1644,10 @@ func (c *compiler) postCompile() {
 				// default fields
 				ref = chunk.Function.Binding
 				chunk := code.Chunk(ref)
+				if chunk.Function == nil {
+					// nothing to expand
+					continue
+				}
 				typ = types.Type(chunk.Function.Type)
 				expanded := c.expandResourceFields(chunk, typ, ref)
 				// when no defaults are defined or query isn't about a resource, no block was added


### PR DESCRIPTION
Fixes https://github.com/mondoohq/cnquery/issues/5248

Tracing this issue from the beginning of the compilation until the end, I noticed that our compiler
does the right thing by not passing any constraint block when there is none, the issue is in the
post compilation where we expand any builtin function block  `"$one", "$all", "$none", "$any"`.

This is a very small change that checks if there is a valid block to expand, and if not, we continue
the processing of other blocks.