### PR TITLE
🐛 fix json output label for cnquery sbom

### DIFF
--- a/sbom/formats.go
+++ b/sbom/formats.go
@@ -42,7 +42,7 @@ func AllFormats() string {
 
 func New(fomat string) FormatSpecificationHandler {
 	switch fomat {
-	case FormatJson:
+	case FormatJson, "cnquery-json":
 		return &CnqueryBOM{}
 	case FormatCycloneDxJSON:
 		return &CycloneDX{


### PR DESCRIPTION
Now the command works as expected:

```
cnquery sbom --output cnquery-json
```