### PR TITLE
⭐️ expose docker host config

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -880,9 +880,8 @@ docker.image {
 }
 
 // Docker container
-docker.container {
+docker.container @defaults("names.first status"){
   embed os.linux as os
-
   // Container ID
   id string
   // Container command
@@ -899,6 +898,8 @@ docker.container {
   status string
   // Label key value pairs
   labels map[string]string
+  // Container configuration that depends on the host running the container
+  hostConfig() dict
 }
 
 // IPv4 tables

--- a/providers/os/resources/os.lr.manifest.yaml
+++ b/providers/os/resources/os.lr.manifest.yaml
@@ -134,6 +134,8 @@ resources:
         The `docker.container` resource provides fields for assessing running Docker containers.
     fields:
       command: {}
+      hostConfig:
+        min_mondoo_version: 9.0.0
       id: {}
       image: {}
       imageid: {}


### PR DESCRIPTION
This exposes the docker host config and allows us to write the following checks:

*Ensure NET_RAW capability is not enabled*

```javascript
docker.containers.all(hostConfig.CapDrop.contains("ALL") || hostConfig.CapDrop.contains("NET_RAW"))
```

*Check that no privileged container are running*

```
docker.containers.none(hostConfig.Privileged)
```
