### PR TITLE
⭐️ os network interfaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -286,6 +286,7 @@ require (
 
 require (
 	github.com/GoogleCloudPlatform/berglas/v2 v2.0.7
+	github.com/endobit/oui v0.5.0
 	// pin v0.19.0
 	github.com/moby/buildkit v0.19.0
 	github.com/moby/sys/mount v0.3.4

--- a/go.sum
+++ b/go.sum
@@ -314,6 +314,8 @@ github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
+github.com/endobit/oui v0.5.0 h1:/XI8/Jr4nmL1AnLcE4SuC8CKmRcr8+AsQGDUQZ9Dk+o=
+github.com/endobit/oui v0.5.0/go.mod h1:cOHrBXZvcHjpHWHILEOAvIAnMR4zvXAXuCwRsjtQ9iI=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/providers/aws/go.mod
+++ b/providers/aws/go.mod
@@ -138,6 +138,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/dvsekhvalnov/jose2go v1.8.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/endobit/oui v0.5.0 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
 	github.com/facebookincubator/nvdtools v0.1.5 // indirect

--- a/providers/aws/go.sum
+++ b/providers/aws/go.sum
@@ -381,6 +381,8 @@ github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
+github.com/endobit/oui v0.5.0 h1:/XI8/Jr4nmL1AnLcE4SuC8CKmRcr8+AsQGDUQZ9Dk+o=
+github.com/endobit/oui v0.5.0/go.mod h1:cOHrBXZvcHjpHWHILEOAvIAnMR4zvXAXuCwRsjtQ9iI=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -116,6 +116,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/dvsekhvalnov/jose2go v1.8.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/endobit/oui v0.5.0 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
 	github.com/facebookincubator/nvdtools v0.1.5 // indirect

--- a/providers/azure/go.sum
+++ b/providers/azure/go.sum
@@ -353,6 +353,8 @@ github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
+github.com/endobit/oui v0.5.0 h1:/XI8/Jr4nmL1AnLcE4SuC8CKmRcr8+AsQGDUQZ9Dk+o=
+github.com/endobit/oui v0.5.0/go.mod h1:cOHrBXZvcHjpHWHILEOAvIAnMR4zvXAXuCwRsjtQ9iI=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/providers/gcp/go.mod
+++ b/providers/gcp/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/endobit/oui v0.5.0 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
 	github.com/facebookincubator/nvdtools v0.1.5 // indirect

--- a/providers/gcp/go.sum
+++ b/providers/gcp/go.sum
@@ -313,6 +313,8 @@ github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
+github.com/endobit/oui v0.5.0 h1:/XI8/Jr4nmL1AnLcE4SuC8CKmRcr8+AsQGDUQZ9Dk+o=
+github.com/endobit/oui v0.5.0/go.mod h1:cOHrBXZvcHjpHWHILEOAvIAnMR4zvXAXuCwRsjtQ9iI=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/providers/github/go.mod
+++ b/providers/github/go.mod
@@ -102,6 +102,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/dvsekhvalnov/jose2go v1.8.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/endobit/oui v0.5.0 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
 	github.com/facebookincubator/nvdtools v0.1.5 // indirect

--- a/providers/github/go.sum
+++ b/providers/github/go.sum
@@ -295,6 +295,8 @@ github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
+github.com/endobit/oui v0.5.0 h1:/XI8/Jr4nmL1AnLcE4SuC8CKmRcr8+AsQGDUQZ9Dk+o=
+github.com/endobit/oui v0.5.0/go.mod h1:cOHrBXZvcHjpHWHILEOAvIAnMR4zvXAXuCwRsjtQ9iI=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/providers/google-workspace/go.mod
+++ b/providers/google-workspace/go.mod
@@ -96,6 +96,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/dvsekhvalnov/jose2go v1.8.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/endobit/oui v0.5.0 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
 	github.com/facebookincubator/nvdtools v0.1.5 // indirect

--- a/providers/google-workspace/go.sum
+++ b/providers/google-workspace/go.sum
@@ -293,6 +293,8 @@ github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
+github.com/endobit/oui v0.5.0 h1:/XI8/Jr4nmL1AnLcE4SuC8CKmRcr8+AsQGDUQZ9Dk+o=
+github.com/endobit/oui v0.5.0/go.mod h1:cOHrBXZvcHjpHWHILEOAvIAnMR4zvXAXuCwRsjtQ9iI=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/providers/k8s/go.mod
+++ b/providers/k8s/go.mod
@@ -119,6 +119,7 @@ require (
 	github.com/dvsekhvalnov/jose2go v1.8.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.2 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/endobit/oui v0.5.0 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
 	github.com/evanphx/json-patch v5.9.0+incompatible // indirect

--- a/providers/k8s/go.sum
+++ b/providers/k8s/go.sum
@@ -295,6 +295,8 @@ github.com/emicklei/go-restful/v3 v3.11.2 h1:1onLa9DcsMYO9P+CXaL0dStDqQ2EHHXLiz+
 github.com/emicklei/go-restful/v3 v3.11.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
+github.com/endobit/oui v0.5.0 h1:/XI8/Jr4nmL1AnLcE4SuC8CKmRcr8+AsQGDUQZ9Dk+o=
+github.com/endobit/oui v0.5.0/go.mod h1:cOHrBXZvcHjpHWHILEOAvIAnMR4zvXAXuCwRsjtQ9iI=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/providers/os/id/networki/darwin_n.go
+++ b/providers/os/id/networki/darwin_n.go
@@ -1,0 +1,280 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package networki
+
+import (
+	"bufio"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/convert"
+	"howett.net/plist"
+)
+
+// detectDarwinInterfaces detects network interfaces on Darwin.
+func (n *neti) detectDarwinInterfaces() ([]Interface, error) {
+	detectors := []func() ([]Interface, error){
+		n.getMacIfconfigInterfaces,
+		n.getMacSystemConfigInterfaces,
+		// Detector via: `networksetup -listallhardwareports`
+		// Detector via: `netstat -I <interface_name>`
+		n.getMacGatewayDetails,
+	}
+
+	var errs []error
+	interfaces := []Interface{}
+	for _, detectFn := range detectors {
+		detectedInterfaces, err := detectFn()
+		if err != nil {
+			log.Debug().Err(err).Msg("os.network.interface> unable to detect network interfaces")
+			errs = append(errs, err)
+			continue
+		}
+		interfaces = AddOrUpdateInterfaces(interfaces, detectedInterfaces)
+	}
+
+	if len(interfaces) == 0 {
+		return interfaces, errors.Join(errs...)
+	}
+
+	return interfaces, nil
+}
+
+func (n *neti) getMacSystemConfigInterfaces() ([]Interface, error) {
+	var interfaces []Interface
+	content, err := afero.ReadFile(
+		n.connection.FileSystem(),
+		"/Library/Preferences/SystemConfiguration/NetworkInterfaces.plist",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var result map[string]any
+	if _, err := plist.Unmarshal(content, &result); err != nil {
+		return nil, err
+	}
+
+	if entries, ok := result["Interfaces"].([]any); ok {
+		for _, entry := range entries {
+			if iface, ok := entry.(map[string]any); ok {
+				iName, ok := iface["BSD Name"].(string)
+				if !ok {
+					log.Trace().
+						Interface("interface", iface).
+						Str("detector", "SystemConfiguration").
+						Msg("os.network.interface> unable to detect network interface")
+					continue
+				}
+
+				// Check if the interface is hidden, if so, don't add it
+				if hidden, ok := iface["HiddenInterface"].(bool); ok && hidden {
+					log.Debug().
+						Interface("interface", iface).
+						Str("detector", "SystemConfiguration").
+						Msg("os.network.interface> found hidden network interface, skipping")
+					continue
+				}
+
+				intf := Interface{
+					Name: iName,
+				}
+
+				if active, ok := iface["Active"].(bool); ok {
+					intf.Active = &active
+				}
+
+				interfaces = append(interfaces, intf)
+			}
+		}
+	}
+
+	log.Debug().
+		Interface("interfaces", interfaces).
+		Str("detector", "SystemConfiguration").
+		Msg("os.network.interfaces> discovered")
+	return interfaces, nil
+}
+
+func (n *neti) getMacGatewayDetails() (interfaces []Interface, err error) {
+	cmd := exec.Command("netstat", "-rn")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	for scanner.Scan() {
+		// we are looking for lines like this one
+		//
+		// Destination        Gateway            Flags               Netif
+		// default            192.168.86.1       UGScg                en0
+		fields := strings.Fields(strings.TrimSpace(scanner.Text()))
+		if len(fields) > 3 && isDefaultRoute(fields[0]) {
+
+			gatewayVersion := IPv4
+			if strings.Contains(fields[1], ":") {
+				gatewayVersion = IPv6
+			}
+
+			interfaces = append(interfaces, Interface{
+				Name: fields[3],
+				enrichments: func(in *Interface) {
+					for i := range in.IPAddresses {
+						version, ok := in.IPAddresses[i].Version()
+						if !ok {
+							continue
+						}
+						if version == gatewayVersion {
+							in.IPAddresses[i].Gateway = fields[1]
+						}
+					}
+				},
+			})
+		}
+	}
+	return
+}
+
+func (n *neti) getMacIfconfigInterfaces() (interfaces []Interface, err error) {
+	output, err := n.RunCommand("ifconfig")
+	if err != nil {
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	var currentInterface *Interface
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		// Match interface name
+		if strings.Contains(line, "flags=") {
+			fields := strings.Fields(line)
+			if len(fields) > 0 {
+				if currentInterface != nil {
+					interfaces = append(interfaces, *currentInterface)
+				}
+				currentInterface = &Interface{Name: strings.TrimSuffix(fields[0], ":")}
+				if strings.HasPrefix(currentInterface.Name, "vmnet") {
+					currentInterface.Virtual = convert.ToPtr(true)
+				}
+			}
+		}
+
+		if currentInterface != nil {
+			// Match MAC address
+			if strings.Contains(line, "ether") {
+				fields := strings.Fields(line)
+				if len(fields) > 1 {
+					currentInterface.SetMAC(fields[1])
+				}
+			}
+
+			// Match IPv4 address, CIDR, and netmask
+			if strings.HasPrefix(line, "inet ") {
+				fields := strings.Fields(line)
+				if len(fields) > 1 {
+					ip := fields[1]
+					ipv4, ok := NewIPAddress(ip)
+					if !ok {
+						log.Trace().Str("ip", ip).Msg("not a valid ipaddress, skipping")
+						continue
+					}
+					if len(fields) > 3 {
+						// netmask found
+						netmask := fields[3]
+						ipv4 = NewIPv4WithMask(ip, netmask)
+					}
+					currentInterface.AddOrUpdateIP(ipv4)
+				}
+			}
+
+			// Match IPv6 address, CIDR, and netmask
+			if strings.HasPrefix(line, "inet6 ") {
+				fields := strings.Fields(line)
+				if len(fields) > 1 {
+					ip := fields[1]
+					// Check if the ip address has a scope id like "fe80::1%lo0"
+					if strings.Contains(ip, "%") {
+						ipWithScope := strings.Split(ip, "%")
+						ip = ipWithScope[0]
+						if ipWithScope[1] != currentInterface.Name {
+							log.Debug().
+								Str("scope_id", ipWithScope[1]).
+								Str("interface_name", currentInterface.Name).
+								Msg("ipv6 scope id and interface name mismatched")
+						}
+					}
+					ipv6, ok := NewIPAddress(ip)
+					if !ok {
+						log.Trace().Str("ip", ip).Msg("not a valid ipaddress, skipping")
+						continue
+					}
+					if len(fields) > 3 {
+						// prefix length found
+						prefixLength := parseInt(fields[3])
+						ipv6 = NewIPv6WithPrefixLength(ip, prefixLength)
+					}
+					currentInterface.AddOrUpdateIP(ipv6)
+				}
+			}
+
+			// Match MTU
+			if strings.Contains(line, "mtu") {
+				fields := strings.Fields(line)
+				for i, f := range fields {
+					if f == "mtu" && i+1 < len(fields) {
+						currentInterface.MTU = parseInt(fields[i+1])
+					}
+				}
+			}
+
+			// Match status [active/inactive]
+			if strings.Contains(line, "status:") {
+				fields := strings.Fields(line)
+				if len(fields) > 1 {
+					if fields[1] == "active" {
+						currentInterface.Active = convert.ToPtr(true)
+					} else if fields[1] == "inactive" {
+						currentInterface.Active = convert.ToPtr(false)
+					}
+				}
+			}
+
+			// Match flags
+			if strings.Contains(line, "flags=") {
+				flagsMatch := regexp.MustCompile(`flags=([0-9]+)<([^>]+)>`).FindStringSubmatch(line)
+				if len(flagsMatch) > 2 {
+					currentInterface.Flags = strings.Split(flagsMatch[2], ",")
+				}
+			}
+		}
+	}
+
+	if currentInterface != nil {
+		interfaces = append(interfaces, *currentInterface)
+	}
+
+	log.Debug().
+		Interface("interfaces", interfaces).
+		Str("detector", "cmd.ifconfig").
+		Msg("os.network.interfaces> discovered")
+	return interfaces, nil
+}
+
+func parseInt(s string) int {
+	val, err := strconv.Atoi(s)
+	if err != nil {
+		return 0
+	}
+	return val
+}

--- a/providers/os/id/networki/darwin_n.go
+++ b/providers/os/id/networki/darwin_n.go
@@ -9,10 +9,11 @@ import (
 	"strconv"
 	"strings"
 
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/convert"
+
 	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
-	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/convert"
 	"howett.net/plist"
 )
 

--- a/providers/os/id/networki/darwin_n.go
+++ b/providers/os/id/networki/darwin_n.go
@@ -5,7 +5,6 @@ package networki
 
 import (
 	"bufio"
-	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -103,8 +102,7 @@ func (n *neti) getMacSystemConfigInterfaces() ([]Interface, error) {
 }
 
 func (n *neti) getMacGatewayDetails() (interfaces []Interface, err error) {
-	cmd := exec.Command("netstat", "-rn")
-	output, err := cmd.Output()
+	output, err := n.RunCommand("netstat -rn")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/os/id/networki/interfaces.go
+++ b/providers/os/id/networki/interfaces.go
@@ -81,8 +81,8 @@ type enrichmentFn func(in *Interface)
 // the interface since it uses it to populate the Vendor field.
 func (i *Interface) SetMAC(mac string) {
 	if mac != "" {
-		i.MACAddress = mac
-		i.Vendor = oui.Vendor(mac)
+		i.MACAddress = strings.ReplaceAll(mac, "-", ":")
+		i.Vendor = oui.Vendor(i.MACAddress)
 	}
 }
 

--- a/providers/os/id/networki/interfaces.go
+++ b/providers/os/id/networki/interfaces.go
@@ -90,7 +90,7 @@ func (i *Interface) SetMAC(mac string) {
 func AddOrUpdateInterfaces(interfaces1, interfaces2 []Interface) (interfaces []Interface) {
 	interfaces = interfaces1
 	for _, iinterface := range interfaces2 {
-		index := findInterface(interfaces, iinterface)
+		index := FindInterface(interfaces, iinterface)
 
 		if index < 0 {
 			// not found, add
@@ -150,8 +150,8 @@ func mergeInterfaces(i1, i2 Interface) Interface {
 	return i1
 }
 
-// findInterface finds an interface from a list of interfaces.
-func findInterface(interfaces []Interface, iinterface Interface) int {
+// FindInterface finds an interface from a list of interfaces.
+func FindInterface(interfaces []Interface, iinterface Interface) int {
 	return slices.IndexFunc(interfaces, func(i Interface) bool {
 		return i.Name == iinterface.Name
 	})
@@ -168,7 +168,7 @@ func (i *Interface) AddOrUpdateIP(ips ...IPAddress) {
 			continue
 		}
 
-		index := i.findIP(ip.IP)
+		index := i.FindIP(ip.IP)
 		if index < 0 {
 			// not found, add
 			log.Trace().Str("ip", ip.IP.String()).Msg("os.network.interface> add ip")
@@ -188,8 +188,8 @@ func (i *Interface) mergeIP(index int, ip IPAddress) {
 	i.IPAddresses[index] = merged
 }
 
-// findIP finds an ip address inside a network interface.
-func (i *Interface) findIP(ip net.IP) int {
+// FindIP finds an ip address inside a network interface.
+func (i *Interface) FindIP(ip net.IP) int {
 	return slices.IndexFunc(i.IPAddresses, func(address IPAddress) bool {
 		return address.IP.Equal(ip)
 	})

--- a/providers/os/id/networki/interfaces.go
+++ b/providers/os/id/networki/interfaces.go
@@ -224,6 +224,8 @@ func isDefaultRoute(field string) bool {
 	return field == "default" ||
 		// IPv4
 		field == "0.0.0.0" ||
+		field == "0.0.0.0/0" ||
 		// IPv6
-		field == "::/0"
+		field == "::/0" ||
+		field == "::"
 }

--- a/providers/os/id/networki/interfaces.go
+++ b/providers/os/id/networki/interfaces.go
@@ -1,0 +1,229 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package networki
+
+import (
+	"errors"
+	"io"
+	"net"
+	"slices"
+	"strings"
+
+	"github.com/endobit/oui"
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
+	"go.mondoo.com/cnquery/v11/providers/os/connection/shared"
+	"go.mondoo.com/cnquery/v11/providers/os/resources/powershell"
+)
+
+// neti is a helper struct to avoid passing the connection and platform
+// as function arguments.
+type neti struct {
+	connection shared.Connection
+	platform   *inventory.Platform
+}
+
+// Interfaces returns the network interfaces of the system.
+//
+// NOTE we are not using `net.Interfaces()` since the implementation use syscall's
+// which do not work for SSH connection types.
+func Interfaces(conn shared.Connection, pf *inventory.Platform) ([]Interface, error) {
+	n := &neti{conn, pf}
+
+	if pf.IsFamily(inventory.FAMILY_LINUX) {
+		return n.detectLinuxInterfaces()
+	}
+	if pf.IsFamily(inventory.FAMILY_DARWIN) {
+		return n.detectDarwinInterfaces()
+	}
+	if pf.IsFamily(inventory.FAMILY_WINDOWS) && conn.Capabilities().Has(shared.Capability_File) {
+		return n.detectWindowsInterfaces()
+	}
+
+	return nil, errors.New("your platform is not supported for the detection of network interfaces")
+}
+
+// runCommand is a wrapper around connection.RunCommand that helps execute commands
+// and read the standard output for unix and windows systems.
+func (n *neti) RunCommand(commandString string) (string, error) {
+	if n.platform.IsFamily(inventory.FAMILY_WINDOWS) {
+		commandString = powershell.Encode(commandString)
+	}
+	cmd, err := n.connection.RunCommand(commandString)
+	if err != nil {
+		return "", err
+	}
+
+	data, err := io.ReadAll(cmd.Stdout)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(data)), nil
+}
+
+type Interface struct {
+	Name        string      `json:"name"`
+	MACAddress  string      `json:"mac_address"`
+	Vendor      string      `json:"vendor"`
+	IPAddresses []IPAddress `json:"ip_addresses"`
+	MTU         int         `json:"mtu"`
+	Flags       []string    `json:"flags"`
+	Active      *bool       `json:"active"`
+	Virtual     *bool       `json:"virtual"`
+
+	enrichments enrichmentFn
+}
+type enrichmentFn func(in *Interface)
+
+// SetMAC is the recommended way to configure the MAC address of
+// the interface since it uses it to populate the Vendor field.
+func (i *Interface) SetMAC(mac string) {
+	if mac != "" {
+		i.MACAddress = mac
+		i.Vendor = oui.Vendor(mac)
+	}
+}
+
+// AddOrUpdateInterfaces adds or updates one or many network interfaces
+func AddOrUpdateInterfaces(interfaces1, interfaces2 []Interface) (interfaces []Interface) {
+	interfaces = interfaces1
+	for _, iinterface := range interfaces2 {
+		index := findInterface(interfaces, iinterface)
+
+		if index < 0 {
+			// not found, add
+			log.Trace().Str("name", iinterface.Name).Msg("os.network.interface> add interface")
+			interfaces = append(interfaces, iinterface)
+			index = len(interfaces) - 1
+		} else {
+			// found, update
+			log.Trace().Str("name", iinterface.Name).Msg("os.network.interface> update interface")
+			merged := mergeInterfaces(interfaces[index], iinterface)
+			interfaces[index] = merged
+		}
+
+		// enritchments function
+		if iinterface.enrichments != nil {
+			log.Trace().Str("name", iinterface.Name).Msg("os.network.interface> enrichments")
+			iinterface.enrichments(&interfaces[index])
+		}
+	}
+	return
+}
+
+// mergeInterfaces merges two interfaces giving precedence to the first interface (i1).
+func mergeInterfaces(i1, i2 Interface) Interface {
+	log.Trace().
+		Interface("i1", i1).
+		Interface("i2", i2).
+		Msg("os.network.interface> merging interfaces")
+
+	if i1.Name == "" {
+		i1.Name = i2.Name
+	}
+	if i1.MACAddress == "" {
+		i1.SetMAC(i2.MACAddress)
+	}
+	if i1.Vendor == "" {
+		i1.Vendor = i2.Vendor
+	}
+	if i1.MTU == 0 {
+		i1.MTU = i2.MTU
+	}
+	if i1.Active == nil {
+		i1.Active = i2.Active
+	}
+	if i1.Virtual == nil {
+		i1.Virtual = i2.Virtual
+	}
+
+	for _, flag := range i2.Flags {
+		if !slices.Contains(i1.Flags, flag) {
+			i1.Flags = append(i1.Flags, flag)
+		}
+	}
+
+	i1.AddOrUpdateIP(i2.IPAddresses...)
+
+	return i1
+}
+
+// findInterface finds an interface from a list of interfaces.
+func findInterface(interfaces []Interface, iinterface Interface) int {
+	return slices.IndexFunc(interfaces, func(i Interface) bool {
+		return i.Name == iinterface.Name
+	})
+}
+
+// AddOrUpdateIP adds or updates one or many IPAddresses
+func (i *Interface) AddOrUpdateIP(ips ...IPAddress) {
+	if i.IPAddresses == nil {
+		i.IPAddresses = make([]IPAddress, 0)
+	}
+
+	for _, ip := range ips {
+		if ip.IP == nil {
+			continue
+		}
+
+		index := i.findIP(ip.IP)
+		if index < 0 {
+			// not found, add
+			log.Trace().Str("ip", ip.IP.String()).Msg("os.network.interface> add ip")
+			i.IPAddresses = append(i.IPAddresses, ip)
+			continue
+		}
+
+		// found, update
+		log.Trace().Str("ip", ip.IP.String()).Msg("os.network.interface> update ip")
+		i.mergeIP(index, ip)
+	}
+}
+
+// mergeIP merges the ip address into the provided index.
+func (i *Interface) mergeIP(index int, ip IPAddress) {
+	merged := mergeIPs(i.IPAddresses[index], ip)
+	i.IPAddresses[index] = merged
+}
+
+// findIP finds an ip address inside a network interface.
+func (i *Interface) findIP(ip net.IP) int {
+	return slices.IndexFunc(i.IPAddresses, func(address IPAddress) bool {
+		return address.IP.Equal(ip)
+	})
+}
+
+// mergeIPs merges two ip addresses giving precedence to the first address (ip1).
+func mergeIPs(ip1, ip2 IPAddress) IPAddress {
+	log.Trace().
+		Interface("ip1", ip1).
+		Interface("ip2", ip2).
+		Msg("os.network.interface> merging ip addresses")
+
+	if ip1.Subnet == "" {
+		ip1.Subnet = ip2.Subnet
+	}
+	if ip1.Gateway == "" {
+		ip1.Gateway = ip2.Gateway
+	}
+	if ip1.CIDR == "" {
+		ip1.CIDR = ip2.CIDR
+	}
+	if ip1.Broadcast == "" {
+		ip1.Broadcast = ip2.Broadcast
+	}
+	return ip1
+}
+
+// isDefaultRoute returns true if the provided field matches one of the
+// possible default route formats.
+func isDefaultRoute(field string) bool {
+	// human readable
+	return field == "default" ||
+		// IPv4
+		field == "0.0.0.0" ||
+		// IPv6
+		field == "::/0"
+}

--- a/providers/os/id/networki/interfaces_internal_test.go
+++ b/providers/os/id/networki/interfaces_internal_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package networki
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetMAC(t *testing.T) {
+	iface := &Interface{}
+	iface.SetMAC("00:1A:2B:3C:4D:5E")
+	assert.Equal(t, "00:1A:2B:3C:4D:5E", iface.MACAddress)
+	assert.Equal(t, "Ayecom Technology", iface.Vendor)
+}
+
+func TestAddOrUpdateInterfaces(t *testing.T) {
+	iface1 := Interface{Name: "eth0", MACAddress: "00:1A:2B:3C:4D:5E"}
+	iface2 := Interface{Name: "eth1", MACAddress: "00:1A:2B:3C:4D:5F"}
+	result := AddOrUpdateInterfaces([]Interface{iface1}, []Interface{iface2})
+	assert.Len(t, result, 2)
+
+	// Test updating an existing interface
+	iface3 := Interface{Name: "eth0", MTU: 1500}
+	result = AddOrUpdateInterfaces(result, []Interface{iface3})
+	assert.Len(t, result, 2)
+	assert.Equal(t, 1500, result[0].MTU)
+}
+
+func TestMergeInterfaces(t *testing.T) {
+	iface1 := Interface{Name: "eth0", MACAddress: ""}
+	iface2 := Interface{Name: "eth0", MACAddress: "00:1A:2B:3C:4D:5E"}
+	merged := mergeInterfaces(iface1, iface2)
+	assert.Equal(t, "00:1A:2B:3C:4D:5E", merged.MACAddress)
+
+	// Test merging flags
+	iface1.Flags = []string{"UP"}
+	iface2.Flags = []string{"BROADCAST"}
+	merged = mergeInterfaces(iface1, iface2)
+	assert.ElementsMatch(t, []string{"UP", "BROADCAST"}, merged.Flags)
+}
+
+func TestAddOrUpdateIP(t *testing.T) {
+	iface := &Interface{Name: "eth0"}
+	ip1 := IPAddress{IP: net.ParseIP("192.168.1.1")}
+	iface.AddOrUpdateIP(ip1)
+	assert.Len(t, iface.IPAddresses, 1)
+	assert.Equal(t, "192.168.1.1", iface.IPAddresses[0].IP.String())
+
+	// Test updating an existing IP
+	ip2 := IPAddress{IP: net.ParseIP("192.168.1.1"), Subnet: "192.168.1.0/24"}
+	iface.AddOrUpdateIP(ip2)
+	assert.Len(t, iface.IPAddresses, 1)
+	assert.Equal(t, "192.168.1.0/24", iface.IPAddresses[0].Subnet)
+
+	// Test adding a new IP
+	ip3 := IPAddress{IP: net.ParseIP("192.168.1.2")}
+	iface.AddOrUpdateIP(ip3)
+	assert.Len(t, iface.IPAddresses, 2)
+}

--- a/providers/os/id/networki/interfaces_test.go
+++ b/providers/os/id/networki/interfaces_test.go
@@ -153,8 +153,8 @@ func TestInterfacesWindows(t *testing.T) {
 	if assert.NotEqual(t, -1, index) {
 		ethernet0 := interfaces[index]
 		assert.Equal(t, "Ethernet0", ethernet0.Name)
-		assert.Equal(t, "00-50-56-B0-9A-A5", ethernet0.MACAddress)
-		assert.Equal(t, "", ethernet0.Vendor)
+		assert.Equal(t, "00:50:56:B0:9A:A5", ethernet0.MACAddress)
+		assert.Equal(t, "VMware", ethernet0.Vendor)
 		assert.Equal(t, 1500, ethernet0.MTU)
 		if assert.NotNil(t, ethernet0.Active) {
 			assert.True(t, *ethernet0.Active)
@@ -210,8 +210,8 @@ func TestInterfacesWindowsFallbackIpconfigCmd(t *testing.T) {
 	if assert.NotEqual(t, -1, index) {
 		ethernet0 := interfaces[index]
 		assert.Equal(t, "Ethernet0", ethernet0.Name)
-		assert.Equal(t, "00-50-56-B0-9A-A5", ethernet0.MACAddress)
-		assert.Equal(t, "", ethernet0.Vendor)
+		assert.Equal(t, "00:50:56:B0:9A:A5", ethernet0.MACAddress)
+		assert.Equal(t, "VMware", ethernet0.Vendor)
 		// can't get these fields
 		assert.Equal(t, 0, ethernet0.MTU)
 		assert.Nil(t, ethernet0.Active)

--- a/providers/os/id/networki/interfaces_test.go
+++ b/providers/os/id/networki/interfaces_test.go
@@ -107,3 +107,58 @@ func TestInterfacesLinux(t *testing.T) {
 		}
 	}
 }
+
+func TestInterfacesWindows(t *testing.T) {
+	conn, err := mock.New(0, "./testdata/windows.toml", &inventory.Asset{})
+	require.NoError(t, err)
+	platform, ok := detector.DetectOS(conn)
+	require.True(t, ok)
+
+	interfaces, err := subject.Interfaces(conn, platform)
+	require.NoError(t, err)
+	assert.Len(t, interfaces, 4)
+
+	index := subject.FindInterface(interfaces, subject.Interface{Name: "Ethernet0"})
+	if assert.NotEqual(t, -1, index) {
+		ethernet0 := interfaces[index]
+		assert.Equal(t, "Ethernet0", ethernet0.Name)
+		assert.Equal(t, "00-50-56-B0-9A-A5", ethernet0.MACAddress)
+		assert.Equal(t, "", ethernet0.Vendor)
+		assert.Equal(t, 1500, ethernet0.MTU)
+		if assert.NotNil(t, ethernet0.Active) {
+			assert.True(t, *ethernet0.Active)
+		}
+		if assert.NotNil(t, ethernet0.Virtual) {
+			assert.False(t, *ethernet0.Virtual)
+
+		}
+		assert.Empty(t, ethernet0.Flags)
+		if assert.NotEmpty(t, ethernet0.IPAddresses) {
+			i4 := ethernet0.FindIP(net.ParseIP("192.168.5.38"))
+			if assert.NotEqual(t, -1, i4) {
+				ipv4 := ethernet0.IPAddresses[i4]
+				assert.Equal(t, "192.168.5.38", ipv4.IP.String())
+				assert.Equal(t, "192.168.5.38/24", ipv4.CIDR)
+				assert.Equal(t, "192.168.5.0/24", ipv4.Subnet)
+				assert.Equal(t, "192.168.5.255", ipv4.Broadcast)
+				assert.Equal(t, "192.168.5.1", ipv4.Gateway)
+			}
+		}
+	}
+
+	index = subject.FindInterface(interfaces, subject.Interface{Name: "Teredo Tunneling Pseudo-Interface"})
+	if assert.NotEqual(t, -1, index) {
+		teredoTunneling := interfaces[index]
+		if assert.NotEmpty(t, teredoTunneling.IPAddresses) {
+			i6 := teredoTunneling.FindIP(net.ParseIP("2001:0:2851:782c:869:1f7d:a331:f3e1"))
+			if assert.NotEqual(t, -1, i6) {
+				ipv6 := teredoTunneling.IPAddresses[i6]
+				assert.Equal(t, "2001:0:2851:782c:869:1f7d:a331:f3e1", ipv6.IP.String())
+				assert.Equal(t, "2001:0:2851:782c:869:1f7d:a331:f3e1/64", ipv6.CIDR)
+				assert.Equal(t, "2001:0:2851:782c::/64", ipv6.Subnet)
+				assert.Equal(t, "", ipv6.Broadcast)
+				assert.Equal(t, "::", ipv6.Gateway)
+			}
+		}
+	}
+}

--- a/providers/os/id/networki/interfaces_test.go
+++ b/providers/os/id/networki/interfaces_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package networki
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetMAC(t *testing.T) {
+	iface := &Interface{}
+	iface.SetMAC("00:1A:2B:3C:4D:5E")
+	assert.Equal(t, "00:1A:2B:3C:4D:5E", iface.MACAddress)
+	assert.Equal(t, "Ayecom Technology", iface.Vendor)
+}
+
+func TestAddOrUpdateInterfaces(t *testing.T) {
+	iface1 := Interface{Name: "eth0", MACAddress: "00:1A:2B:3C:4D:5E"}
+	iface2 := Interface{Name: "eth1", MACAddress: "00:1A:2B:3C:4D:5F"}
+	result := AddOrUpdateInterfaces([]Interface{iface1}, []Interface{iface2})
+	assert.Len(t, result, 2)
+
+	// Test updating an existing interface
+	iface3 := Interface{Name: "eth0", MTU: 1500}
+	result = AddOrUpdateInterfaces(result, []Interface{iface3})
+	assert.Len(t, result, 2)
+	assert.Equal(t, 1500, result[0].MTU)
+}
+
+func TestMergeInterfaces(t *testing.T) {
+	iface1 := Interface{Name: "eth0", MACAddress: ""}
+	iface2 := Interface{Name: "eth0", MACAddress: "00:1A:2B:3C:4D:5E"}
+	merged := mergeInterfaces(iface1, iface2)
+	assert.Equal(t, "00:1A:2B:3C:4D:5E", merged.MACAddress)
+
+	// Test merging flags
+	iface1.Flags = []string{"UP"}
+	iface2.Flags = []string{"BROADCAST"}
+	merged = mergeInterfaces(iface1, iface2)
+	assert.ElementsMatch(t, []string{"UP", "BROADCAST"}, merged.Flags)
+}
+
+func TestAddOrUpdateIP(t *testing.T) {
+	iface := &Interface{Name: "eth0"}
+	ip1 := IPAddress{IP: net.ParseIP("192.168.1.1")}
+	iface.AddOrUpdateIP(ip1)
+	assert.Len(t, iface.IPAddresses, 1)
+	assert.Equal(t, "192.168.1.1", iface.IPAddresses[0].IP.String())
+
+	// Test updating an existing IP
+	ip2 := IPAddress{IP: net.ParseIP("192.168.1.1"), Subnet: "192.168.1.0/24"}
+	iface.AddOrUpdateIP(ip2)
+	assert.Len(t, iface.IPAddresses, 1)
+	assert.Equal(t, "192.168.1.0/24", iface.IPAddresses[0].Subnet)
+
+	// Test adding a new IP
+	ip3 := IPAddress{IP: net.ParseIP("192.168.1.2")}
+	iface.AddOrUpdateIP(ip3)
+	assert.Len(t, iface.IPAddresses, 2)
+}

--- a/providers/os/id/networki/ipaddress.go
+++ b/providers/os/id/networki/ipaddress.go
@@ -1,0 +1,267 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package networki
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+)
+
+// IPAddress structure that contains details about an IP address (v4 or v6)
+type IPAddress struct {
+	IP        net.IP `json:"ip"`
+	Subnet    string `json:"subnet"`
+	CIDR      string `json:"cidr"`
+	Broadcast string `json:"broadcast"`
+	Gateway   string `json:"gateway"`
+}
+
+// IPVersion represents either a version 4 or version 6 of an ip address.
+type IPVersion string
+
+const (
+	IPv4 IPVersion = "IPv4"
+	IPv6 IPVersion = "IPv6"
+)
+
+// Version returns the version of the ip address.
+func (address IPAddress) Version() (IPVersion, bool) {
+	if address.IP != nil {
+		if address.IP.To4() != nil {
+			return IPv4, true
+		}
+		if address.IP.To16() != nil {
+			return IPv6, true
+		}
+	}
+	return IPVersion(""), false
+}
+
+// NewIPAddress generates a new IPAddress and returns if it is valid or not
+func NewIPAddress(ip string) (address IPAddress, ok bool) {
+	address = IPAddress{
+		IP: net.ParseIP(ip),
+	}
+	if address.IP != nil {
+		ok = true
+	}
+	return
+}
+
+// NewIPv4WithMask generates a new IPAddress using the IP address and
+// subnet mask. It calculates the subnet, CIDR and broadcast address.
+func NewIPv4WithMask(ip, mask string) IPAddress {
+	subnet := calculateSubnetFromIPv4AndMask(ip, mask)
+	return NewIPWithSubnet(ip, subnet)
+}
+
+// NewIPWithPrefixLength generates a new IPAddress using the IP address and prefix length.
+func NewIPWithPrefixLength(ip string, prefixLength int) (address IPAddress, ok bool) {
+	if strings.Contains(ip, ":") {
+		address = NewIPv6WithPrefixLength(ip, prefixLength)
+	} else {
+		address = NewIPv4WithPrefixLength(ip, prefixLength)
+	}
+
+	if address.IP != nil {
+		ok = true
+	}
+
+	return
+}
+
+// NewIPv4WithPrefixLength generates a new IPAddress using the IP address and
+// prefix length. It calculates the subnet, CIDR and broadcast address.
+//
+// NOTE: Use for IPv4 only.
+func NewIPv4WithPrefixLength(ip string, prefixLength int) IPAddress {
+	subnet := calculateSubnetFromIPv4AndPrefixLength(ip, prefixLength)
+	return NewIPWithSubnet(ip, subnet)
+}
+
+// NewIPv6WithPrefixLength generates a new IPAddress using the IP address
+// and prefix length. It calculates the subnet and CIDR format.
+//
+// NOTE: Use for IPv6 only.
+func NewIPv6WithPrefixLength(ip string, prefixLength int) IPAddress {
+	subnet := calculateSubnetFromIPv6AndPrefixLength(ip, prefixLength)
+	return NewIPWithSubnet(ip, subnet)
+}
+
+// NewIPWithSubnet generates a new IPAddress using the IP address and
+// subnet in a CIDR format (e.g. 172.31.16.0/20 or 2001:db8::/64).
+// It calculates the CIDR and, only for IPv4, the broadcast address.
+func NewIPWithSubnet(ip, subnet string) IPAddress {
+	address := IPAddress{
+		IP:     net.ParseIP(ip),
+		Subnet: subnet,
+	}
+
+	// Calculate the CIDR
+	_, network, err := net.ParseCIDR(subnet)
+	if err != nil {
+		log.Debug().Err(err).Msg("IPAddress> invalid subnet")
+		return address
+	}
+	ones, _ := network.Mask.Size()
+	if address.IP != nil {
+		address.CIDR = fmt.Sprintf("%s/%d", address.IP.String(), ones)
+	}
+
+	// Calculate the broadcast address
+	address.Broadcast = broadcastAddressFrom(address.CIDR)
+
+	return address
+}
+
+// broadcastAddressFrom calculates the broadcast address for a given subnet
+func broadcastAddressFrom(cidr string) string {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		log.Debug().Err(err).Msg("broadcastAddressFrom> invalid CIDR")
+		return ""
+	}
+
+	// Convert IP to a byte slice
+	ip := ipNet.IP.To4()
+	if ip == nil {
+		// the IP address is v6, they don't have broadcast
+		log.Debug().Str("CIDR", cidr).Msg("broadcastAddressFrom> IPv6 detected, skipping")
+		return ""
+	}
+
+	// Calculate broadcast address: set all host bits to 1
+	broadcast := make(net.IP, len(ip))
+	copy(broadcast, ip)
+	for i, maskByte := range ipNet.Mask {
+		broadcast[i] |= ^maskByte
+	}
+
+	return broadcast.String()
+}
+
+// calculateSubnetFromIPAndMask calculates the subnet network address from an IPv4 and subnet mask
+func calculateSubnetFromIPv4AndMask(ipv4Str, maskStr string) string {
+	// Parse the IPv4 address
+	ip := net.ParseIP(ipv4Str).To4()
+	if ip == nil {
+		log.Debug().
+			Str("ipaddress", ipv4Str).
+			Str("mask", maskStr).
+			Msg("calculateSubnetFromIPv4AndMask> invalid IPv4 address")
+		return ""
+	}
+
+	mask, err := parseIPv4Mask(maskStr)
+	if err != nil {
+		log.Debug().
+			Str("ipaddress", ipv4Str).
+			Str("mask", maskStr).
+			Msg("calculateSubnetFromIPv4AndMask> invalid subnet mask")
+		return ""
+	}
+
+	// Calculate the network address (bitwise AND)
+	network := make(net.IP, len(ip))
+	for i := range ip {
+		network[i] = ip[i] & mask[i]
+	}
+
+	// Get CIDR notation from the mask
+	ones, _ := mask.Size()
+	if ones == 0 {
+		log.Debug().
+			Str("ipaddress", ipv4Str).
+			Str("mask", maskStr).
+			Msg("calculateSubnetFromIPv4AndMask> invalid subnet mask CIDR")
+		return ""
+	}
+	return fmt.Sprintf("%s/%d", network.String(), ones)
+}
+
+// calculateSubnetFromIPv6AndPrefixLength calculates the subnet from an IPv6 address and prefix length.
+func calculateSubnetFromIPv6AndPrefixLength(ipStr string, prefixLength int) string {
+	// Parse the IPv6 address
+	ip := net.ParseIP(ipStr)
+	if ip == nil || ip.To4() != nil {
+		log.Debug().Msg("calculateSubnetFromIPv6AndPrefixLength> invalid IPv6 address")
+		return ""
+	}
+
+	// Convert IP to 16-byte format
+	ip = ip.To16()
+
+	// Create subnet mask from prefix length
+	mask := net.CIDRMask(prefixLength, 128)
+
+	// Calculate the network address (bitwise AND)
+	network := make(net.IP, len(ip))
+	for i := range ip {
+		network[i] = ip[i] & mask[i]
+	}
+
+	// Return subnet in CIDR notation
+	return fmt.Sprintf("%s/%d", network.String(), prefixLength)
+}
+
+// calculateSubnetFromIPv4AndPrefixLength calculates the subnet from an IPv4 address and prefix length.
+func calculateSubnetFromIPv4AndPrefixLength(ipStr string, prefixLength int) string {
+	// Parse the IPv4 address
+	ip := net.ParseIP(ipStr)
+	if ip == nil || ip.To4() == nil {
+		fmt.Println("calculateSubnetFromIPv4AndPrefixLength> invalid IPv4 address")
+		return ""
+	}
+
+	// Convert to IPv4 format
+	ip = ip.To4()
+
+	// Create subnet mask from prefix length
+	mask := net.CIDRMask(prefixLength, 32)
+
+	// Calculate the network address (bitwise AND)
+	network := make(net.IP, len(ip))
+	for i := range ip {
+		network[i] = ip[i] & mask[i]
+	}
+
+	// Return subnet in CIDR notation
+	return fmt.Sprintf("%s/%d", network.String(), prefixLength)
+}
+
+// parseIPv4Mask parses a subnet mask in either binary or hex formats
+func parseIPv4Mask(maskStr string) (net.IPMask, error) {
+	msgErr := "unable to parse mask"
+
+	// Try parsing the subnet mask with format 255.255.255.255
+	var b1, b2, b3, b4 int
+	n, err := fmt.Sscanf(maskStr, "%d.%d.%d.%d", &b1, &b2, &b3, &b4)
+	if err == nil && n == 4 {
+		return net.IPv4Mask(byte(b1), byte(b2), byte(b3), byte(b4)), nil
+	}
+
+	// Try parsing the subnet mask with format 0xffffffff
+	if !strings.HasPrefix(maskStr, "0x") || len(maskStr) != 10 {
+		return nil, errors.New(msgErr)
+	}
+
+	// Convert hex string to a 32-bit integer
+	maskInt, err := strconv.ParseUint(maskStr[2:], 16, 32)
+	if err != nil {
+		return nil, errors.New(msgErr)
+	}
+
+	// Convert to 4 bytes (big-endian)
+	return net.IPv4Mask(
+		byte((maskInt>>24)&0xFF),
+		byte((maskInt>>16)&0xFF),
+		byte((maskInt>>8)&0xFF),
+		byte(maskInt&0xFF),
+	), nil
+}

--- a/providers/os/id/networki/ipaddress_test.go
+++ b/providers/os/id/networki/ipaddress_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package networki
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewIPAddress(t *testing.T) {
+	// Valid IPv4
+	ip, ok := NewIPAddress("192.168.1.1")
+	assert.True(t, ok)
+	assert.Equal(t, "192.168.1.1", ip.IP.String())
+
+	// Valid IPv6
+	ip, ok = NewIPAddress("2001:db8::1")
+	assert.True(t, ok)
+	assert.Equal(t, "2001:db8::1", ip.IP.String())
+
+	// Invalid IP
+	ip, ok = NewIPAddress("invalid-ip")
+	assert.False(t, ok)
+}
+
+func TestVersion(t *testing.T) {
+	// IPv4 Address
+	ip, _ := NewIPAddress("192.168.1.1")
+	ver, valid := ip.Version()
+	assert.True(t, valid)
+	assert.Equal(t, IPv4, ver)
+
+	// IPv6 Address
+	ip, _ = NewIPAddress("2001:db8::1")
+	ver, valid = ip.Version()
+	assert.True(t, valid)
+	assert.Equal(t, IPv6, ver)
+}
+
+func TestNewIPv4WithMask(t *testing.T) {
+	address := NewIPv4WithMask("192.168.1.1", "255.255.255.0")
+	assert.Equal(t, "192.168.1.0/24", address.Subnet)
+	assert.Equal(t, "192.168.1.255", address.Broadcast)
+}
+
+func TestNewIPWithPrefixLength(t *testing.T) {
+	address, ok := NewIPWithPrefixLength("192.168.1.1", 24)
+	assert.True(t, ok)
+	assert.Equal(t, "192.168.1.0/24", address.Subnet)
+}
+
+func TestNewIPv6WithPrefixLength(t *testing.T) {
+	address := NewIPv6WithPrefixLength("2001:db8::1", 64)
+	assert.Equal(t, "2001:db8::/64", address.Subnet)
+}
+
+func TestBroadcastAddressFrom(t *testing.T) {
+	broadcast := broadcastAddressFrom("192.168.1.0/24")
+	assert.Equal(t, "192.168.1.255", broadcast)
+
+	broadcast = broadcastAddressFrom("2001:db8::/64")
+	assert.Equal(t, "", broadcast) // IPv6 has no broadcast
+}
+
+func TestCalculateSubnetFromIPv4AndMask(t *testing.T) {
+	subnet := calculateSubnetFromIPv4AndMask("192.168.1.10", "255.255.255.0")
+	assert.Equal(t, "192.168.1.0/24", subnet)
+}
+
+func TestParseIPv4Mask(t *testing.T) {
+	mask, err := parseIPv4Mask("255.255.255.0")
+	assert.NoError(t, err)
+	assert.Equal(t, net.IPv4Mask(255, 255, 255, 0), mask)
+
+	mask, err = parseIPv4Mask("0xffffff00")
+	assert.NoError(t, err)
+	assert.Equal(t, net.IPv4Mask(255, 255, 255, 0), mask)
+
+	_, err = parseIPv4Mask("invalid-mask")
+	assert.Error(t, err)
+}

--- a/providers/os/id/networki/linux_n.go
+++ b/providers/os/id/networki/linux_n.go
@@ -1,0 +1,279 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package networki
+
+import (
+	"bufio"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/convert"
+)
+
+// detectLinuxInterfaces detects network interfaces on Linux.
+func (n *neti) detectLinuxInterfaces() ([]Interface, error) {
+	detectors := []func() ([]Interface, error){
+		n.getLinuxCmdInterfaces,
+		n.getLinuxSysfsInterfaces,
+		n.getLinuxIPv4GatewayDetails,
+		n.getLinuxIPv6GatewayDetails,
+	}
+
+	var errs []error
+	interfaces := []Interface{}
+	for _, detectFn := range detectors {
+		detectedInterfaces, err := detectFn()
+		if err != nil {
+			log.Debug().Err(err).
+				Msg("os.network.interface> unable to detect network interfaces")
+			errs = append(errs, err)
+			continue
+		}
+		interfaces = AddOrUpdateInterfaces(interfaces, detectedInterfaces)
+	}
+
+	if len(interfaces) == 0 {
+		return interfaces, errors.Join(errs...)
+	}
+
+	return interfaces, nil
+}
+
+func (n *neti) getLinuxIPv4GatewayDetails() (interfaces []Interface, err error) {
+	output, err := n.RunCommand("ip route show")
+	if err != nil {
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	for scanner.Scan() {
+		// we are looking for lines like this one
+		//
+		// default via 172.31.16.1 dev enX0
+		fields := strings.Fields(strings.TrimSpace(scanner.Text()))
+		if len(fields) > 4 && isDefaultRoute(fields[0]) {
+			interfaces = append(interfaces, Interface{
+				Name: fields[4],
+				enrichments: func(in *Interface) {
+					for i := range in.IPAddresses {
+						if version, ok := in.IPAddresses[i].Version(); ok && version == IPv4 {
+							in.IPAddresses[i].Gateway = fields[2]
+						}
+					}
+				},
+			})
+		}
+	}
+	return
+}
+
+func (n *neti) getLinuxIPv6GatewayDetails() (interfaces []Interface, err error) {
+	output, err := n.RunCommand("ip -6 route show")
+	if err != nil {
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	for scanner.Scan() {
+		// we are looking for lines like this one
+		//
+		// default via 2001:db8::1 dev enX1
+		fields := strings.Fields(strings.TrimSpace(scanner.Text()))
+		if len(fields) > 4 && isDefaultRoute(fields[0]) {
+			interfaces = append(interfaces, Interface{
+				Name: fields[4],
+				enrichments: func(in *Interface) {
+					for i := range in.IPAddresses {
+						if version, ok := in.IPAddresses[i].Version(); ok && version == IPv6 {
+							in.IPAddresses[i].Gateway = fields[2]
+						}
+					}
+				},
+			})
+		}
+	}
+	return
+}
+
+func (n *neti) getLinuxSysfsInterfaces() (interfaces []Interface, err error) {
+	dirEntries, err := afero.ReadDir(n.connection.FileSystem(), "/sys/class/net/")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range dirEntries {
+		if !entry.IsDir() {
+			log.Trace().
+				Str("name", filepath.Join("/sys/class/net", entry.Name())).
+				Msg("os.network.interfaces> not a directory, skipping")
+			continue
+		}
+
+		ifaceName := entry.Name()
+		iinterface := Interface{Name: ifaceName}
+
+		// Read MAC Address
+		macAddress, err := afero.ReadFile(
+			n.connection.FileSystem(),
+			filepath.Join("/sys/class/net/", ifaceName, "address"),
+		)
+		if err == nil {
+			iinterface.MACAddress = strings.TrimSpace(string(macAddress))
+		}
+
+		// Read MTU
+		mtu, err := afero.ReadFile(
+			n.connection.FileSystem(),
+			filepath.Join("/sys/class/net/", ifaceName, "mtu"),
+		)
+		if err == nil {
+			iinterface.MTU = parseInt(strings.TrimSpace(string(mtu)))
+		}
+
+		// Read Flags
+		flags, err := afero.ReadFile(
+			n.connection.FileSystem(),
+			filepath.Join("/sys/class/net/", ifaceName, "flags"),
+		)
+		if err == nil {
+			iinterface.Flags = parseHexFlags(strings.TrimSpace(string(flags)))
+		}
+
+		// Read Status
+		operstate, err := afero.ReadFile(
+			n.connection.FileSystem(),
+			filepath.Join("/sys/class/net/", ifaceName, "operstate"),
+		)
+		if err == nil {
+			switch strings.TrimSpace(strings.ToLower(string(operstate))) {
+			case "up":
+				iinterface.Active = convert.ToPtr(true)
+			case "down":
+				iinterface.Active = convert.ToPtr(false)
+			}
+		}
+
+		// TODO we could fetch statistics from here, like `tx_queue_len` or `rx_bytes` and `tx_bytes`
+		// iinterface.Statistics = getLinuxInterfaceStats(ifaceName)
+
+		interfaces = append(interfaces, iinterface)
+	}
+
+	return
+}
+
+func parseHexFlags(hexStr string) []string {
+	flagsMap := map[int]string{
+		0x1:    "UP",
+		0x2:    "BROADCAST",
+		0x4:    "DEBUG",
+		0x8:    "LOOPBACK",
+		0x10:   "POINTOPOINT",
+		0x20:   "NOTRAILERS",
+		0x40:   "RUNNING",
+		0x80:   "NOARP",
+		0x100:  "PROMISC",
+		0x200:  "ALLMULTI",
+		0x400:  "MASTER",
+		0x800:  "SLAVE",
+		0x1000: "MULTICAST",
+		0x2000: "PORTSEL",
+		0x4000: "AUTOMEDIA",
+		0x8000: "DYNAMIC",
+	}
+	flagsInt, err := strconv.ParseInt(hexStr, 16, 32)
+	if err != nil {
+		return []string{}
+	}
+	var flags []string
+	for bit, name := range flagsMap {
+		if int(flagsInt)&bit != 0 {
+			flags = append(flags, name)
+		}
+	}
+	return flags
+}
+
+func (n *neti) getLinuxCmdInterfaces() ([]Interface, error) {
+	output, err := n.RunCommand("ip addr show")
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		interfaces     = []Interface{}
+		scanner        = bufio.NewScanner(strings.NewReader(string(output)))
+		interfaceRegex = regexp.MustCompile(`^\d+: ([^:]+): <([^>]+)> mtu (\d+)`)
+		macRegex       = regexp.MustCompile(`link/ether ([0-9a-fA-F:]+) `)
+		ipRegex        = regexp.MustCompile(`inet ([0-9\.]+)/([0-9]+)`)
+		ip6Regex       = regexp.MustCompile(`inet6 ([0-9a-fA-F:]+)/([0-9]+) scope (global|link|host)`)
+		// TODO @afiune we could add additional information to the interface struct like
+		//  * `altname` (alternative name)
+		//  * `metric` (priority or cost of a network interface)
+	)
+
+	var currentInterface *Interface
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		if matches := interfaceRegex.FindStringSubmatch(line); matches != nil {
+			if currentInterface != nil {
+				interfaces = append(interfaces, *currentInterface)
+			}
+			mtu := parseInt(matches[3])
+			flags := strings.Split(matches[2], ",")
+			active := strings.Contains(matches[2], "UP")
+			virtual := strings.HasPrefix(matches[1], "veth") || strings.HasPrefix(matches[1], "virbr")
+			currentInterface = &Interface{
+				Name:        matches[1],
+				MTU:         mtu,
+				Flags:       flags,
+				Active:      &active,
+				Virtual:     &virtual,
+				IPAddresses: []IPAddress{},
+			}
+		} else if currentInterface != nil {
+			if matches := macRegex.FindStringSubmatch(line); matches != nil {
+				// Match MAC address
+				currentInterface.SetMAC(matches[1])
+			} else if matches := ipRegex.FindStringSubmatch(line); matches != nil {
+				// Match IPv4 address
+				ip := NewIPv4WithPrefixLength(
+					matches[1],
+					parseInt(matches[2]),
+				)
+				// if ip.Broadcast != matches[3] {
+				// log.Debug().
+				// Str("gen_broadcast", ip.Broadcast).
+				// Str("cmd_broadcast", matches[3]).
+				// Msg("getLinuxCmdInterfaces> broadcast mismatch")
+				// ip.Broadcast = matches[3]
+				// }
+				currentInterface.AddOrUpdateIP(ip)
+			} else if matches := ip6Regex.FindStringSubmatch(line); matches != nil {
+				// Match IPv6 address
+				ip := NewIPv6WithPrefixLength(matches[1], parseInt(matches[2]))
+				currentInterface.AddOrUpdateIP(ip)
+			}
+		}
+	}
+
+	if currentInterface != nil {
+		interfaces = append(interfaces, *currentInterface)
+	}
+
+	log.Debug().
+		Interface("interfaces", interfaces).
+		Str("detector", "cmd.ip_addr_show").
+		Msg("os.network.interfaces> discovered")
+	return interfaces, nil
+}

--- a/providers/os/id/networki/linux_n.go
+++ b/providers/os/id/networki/linux_n.go
@@ -10,10 +10,11 @@ import (
 	"strconv"
 	"strings"
 
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/convert"
+
 	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
-	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/convert"
 )
 
 // detectLinuxInterfaces detects network interfaces on Linux.

--- a/providers/os/id/networki/linux_n_internal_test.go
+++ b/providers/os/id/networki/linux_n_internal_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package networki
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseHexFlags(t *testing.T) {
+	tests := []struct {
+		hexStr   string
+		expected []string
+	}{
+		{"1", []string{"UP"}},
+		{"2", []string{"BROADCAST"}},
+		{"3", []string{"UP", "BROADCAST"}},
+		{"8", []string{"LOOPBACK"}},
+		{"10", []string{"POINTOPOINT"}},
+		{"40", []string{"RUNNING"}},
+		{"100", []string{"PROMISC"}},
+		{"400", []string{"MASTER"}},
+		{"1003", []string{"BROADCAST", "MULTICAST", "UP"}},
+		{"8000", []string{"DYNAMIC"}},
+		{"8001", []string{"UP", "DYNAMIC"}},
+		{"FFFF", []string{"UP", "BROADCAST", "DEBUG", "LOOPBACK", "POINTOPOINT", "NOTRAILERS", "RUNNING", "NOARP", "PROMISC", "ALLMULTI", "MASTER", "SLAVE", "MULTICAST", "PORTSEL", "AUTOMEDIA", "DYNAMIC"}},
+		{"0", []string{}},       // No flags set
+		{"invalid", []string{}}, // Invalid hex input
+	}
+
+	for _, test := range tests {
+		t.Run("hexStr="+test.hexStr, func(t *testing.T) {
+			assert.ElementsMatch(t, test.expected, parseHexFlags(test.hexStr))
+		})
+	}
+}

--- a/providers/os/id/networki/testdata/linux.toml
+++ b/providers/os/id/networki/testdata/linux.toml
@@ -1,0 +1,45 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "4.9.125-linuxkit"
+
+[files."/sys/class/net/enX0/address"]
+content = "0a:ff:de:6b:e3:19"
+
+[files."/sys/class/net/enX0/operstate"]
+content = "up"
+
+[commands."ip addr show"]
+stdout = """
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+    inet6 ::1/128 scope host noprefixroute
+       valid_lft forever preferred_lft forever
+2: enX0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc fq_codel state UP group default qlen 1000
+    link/ether 0a:ff:de:6b:e3:19 brd ff:ff:ff:ff:ff:ff
+    altname eni-087a980ef8e9331bc
+    altname device-number-0.0
+    inet 172.31.24.71/20 metric 512 brd 172.31.31.255 scope global dynamic enX0
+       valid_lft 3284sec preferred_lft 3284sec
+    inet6 fe80::8ff:deff:fe6b:e319/64 scope link proto kernel_ll
+       valid_lft forever preferred_lft forever
+"""
+
+[commands."ip route show"]
+stdout = """
+default via 172.31.16.1 dev enX0 proto dhcp src 172.31.24.71 metric 512
+172.31.0.2 via 172.31.16.1 dev enX0 proto dhcp src 172.31.24.71 metric 512
+172.31.16.0/20 dev enX0 proto kernel scope link src 172.31.24.71 metric 512
+172.31.16.1 dev enX0 proto dhcp scope link src 172.31.24.71 metric 512
+"""
+
+[commands."ip -6 route show"]
+stdout = """
+fe80::/64 dev enX0 proto kernel metric 256 pref medium
+"""

--- a/providers/os/id/networki/testdata/linux_ip_addr_show_cmd.toml
+++ b/providers/os/id/networki/testdata/linux_ip_addr_show_cmd.toml
@@ -7,12 +7,6 @@ stdout = "x86_64"
 [commands."uname -r"]
 stdout = "4.9.125-linuxkit"
 
-[files."/sys/class/net/enX0/address"]
-content = "0a:ff:de:6b:e3:19"
-
-[files."/sys/class/net/enX0/operstate"]
-content = "up"
-
 [commands."ip addr show"]
 stdout = """
 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000

--- a/providers/os/id/networki/testdata/linux_sys_class_net_fs.toml
+++ b/providers/os/id/networki/testdata/linux_sys_class_net_fs.toml
@@ -1,0 +1,45 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "4.9.125-linuxkit"
+
+[files."/sys/class/net"]
+stat.isdir = true
+
+[files."/sys/class/net/enX0"]
+stat.isdir = true
+[files."/sys/class/net/enX0/address"]
+content = "0a:ff:de:6b:e3:19"
+[files."/sys/class/net/enX0/operstate"]
+content = "up"
+[files."/sys/class/net/enX0/mtu"]
+content = "9001"
+[files."/sys/class/net/enX0/flags"]
+content = "0x1003"
+[files."/sys/class/net/enX0/device/devtype"]
+content = "vif"
+
+[files."/sys/class/net/lo"]
+stat.isdir = true
+[files."/sys/class/net/lo/address"]
+content = "00:00:00:00:00:00"
+[files."/sys/class/net/lo/operstate"]
+content = "up"
+
+[commands."ip route show"]
+stdout = """
+default via 172.31.16.1 dev enX0 proto dhcp src 172.31.24.71 metric 512
+172.31.0.2 via 172.31.16.1 dev enX0 proto dhcp src 172.31.24.71 metric 512
+172.31.16.0/20 dev enX0 proto kernel scope link src 172.31.24.71 metric 512
+172.31.16.1 dev enX0 proto dhcp scope link src 172.31.24.71 metric 512
+"""
+
+[commands."ip -6 route show"]
+stdout = """
+fe80::/64 dev enX0 proto kernel metric 256 pref medium
+"""
+

--- a/providers/os/id/networki/testdata/macos.toml
+++ b/providers/os/id/networki/testdata/macos.toml
@@ -1,0 +1,171 @@
+[commands."uname -s"]
+stdout = "Darwin"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "18.6.0"
+
+[commands."/usr/bin/sw_vers"]
+stdout = """
+ProductName:	macOS
+ProductVersion:	14.6
+BuildVersion:	23G80
+"""
+
+[commands."ifconfig"]
+stdout = """
+lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
+	options=1203<RXCSUM,TXCSUM,TXSTATUS,SW_TIMESTAMP>
+	inet 127.0.0.1 netmask 0xff000000
+	inet6 ::1 prefixlen 128
+	inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1
+	nd6 options=201<PERFORMNUD,DAD>
+gif0: flags=8010<POINTOPOINT,MULTICAST> mtu 1280
+stf0: flags=0<> mtu 1280
+anpi1: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+	options=400<CHANNEL_IO>
+	ether da:c9:78:c4:19:63
+	media: none
+	status: inactive
+anpi0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+	options=400<CHANNEL_IO>
+	ether da:c9:78:c4:19:62
+	media: none
+	status: inactive
+en4: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+	options=400<CHANNEL_IO>
+	ether da:c9:78:c4:19:42
+	nd6 options=201<PERFORMNUD,DAD>
+	media: none
+	status: inactive
+en5: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+	options=400<CHANNEL_IO>
+	ether da:c9:78:c4:19:43
+	nd6 options=201<PERFORMNUD,DAD>
+	media: none
+	status: inactive
+en1: flags=8963<UP,BROADCAST,SMART,RUNNING,PROMISC,SIMPLEX,MULTICAST> mtu 1500
+	options=460<TSO4,TSO6,CHANNEL_IO>
+	ether 36:01:7a:e7:49:c0
+	media: autoselect <full-duplex>
+	status: inactive
+en2: flags=8963<UP,BROADCAST,SMART,RUNNING,PROMISC,SIMPLEX,MULTICAST> mtu 1500
+	options=460<TSO4,TSO6,CHANNEL_IO>
+	ether 36:01:7a:e7:49:c4
+	media: autoselect <full-duplex>
+	status: inactive
+en3: flags=8963<UP,BROADCAST,SMART,RUNNING,PROMISC,SIMPLEX,MULTICAST> mtu 1500
+	options=460<TSO4,TSO6,CHANNEL_IO>
+	ether 36:01:7a:e7:49:c8
+	media: autoselect <full-duplex>
+	status: inactive
+bridge0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+	options=63<RXCSUM,TXCSUM,TSO4,TSO6>
+	ether 36:01:7a:e7:49:c0
+	Configuration:
+		id 0:0:0:0:0:0 priority 0 hellotime 0 fwddelay 0
+		maxage 0 holdcnt 0 proto stp maxaddr 100 timeout 1200
+		root id 0:0:0:0:0:0 priority 0 ifcost 0 port 0
+		ipfilter disabled flags 0x0
+	member: en1 flags=3<LEARNING,DISCOVER>
+	        ifmaxaddr 0 port 8 priority 0 path cost 0
+	member: en2 flags=3<LEARNING,DISCOVER>
+	        ifmaxaddr 0 port 9 priority 0 path cost 0
+	member: en3 flags=3<LEARNING,DISCOVER>
+	        ifmaxaddr 0 port 10 priority 0 path cost 0
+	nd6 options=201<PERFORMNUD,DAD>
+	media: <unknown type>
+	status: inactive
+ap1: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+	options=6460<TSO4,TSO6,CHANNEL_IO,PARTIAL_CSUM,ZEROINVERT_CSUM>
+	ether a2:a9:97:40:12:53
+	inet6 fe80::a0a9:97ff:fe40:1253%ap1 prefixlen 64 scopeid 0xc
+	nd6 options=201<PERFORMNUD,DAD>
+	media: autoselect (<unknown type>)
+	status: inactive
+en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+	options=6460<TSO4,TSO6,CHANNEL_IO,PARTIAL_CSUM,ZEROINVERT_CSUM>
+	ether 80:a9:97:40:12:53
+	inet6 fe80::183c:c9dd:a7f0:b83d%en0 prefixlen 64 secured scopeid 0xd
+	inet 192.168.86.36 netmask 0xffffff00 broadcast 192.168.86.255
+	inet6 fd19:f27d:7e31:1af4:1cd0:9dc4:e6b0:ab13 prefixlen 64 autoconf secured
+	nd6 options=201<PERFORMNUD,DAD>
+	media: autoselect
+	status: active
+awdl0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+	options=6460<TSO4,TSO6,CHANNEL_IO,PARTIAL_CSUM,ZEROINVERT_CSUM>
+	ether 96:4a:be:21:2d:b0
+	inet6 fe80::944a:beff:fe21:2db0%awdl0 prefixlen 64 scopeid 0xe
+	nd6 options=201<PERFORMNUD,DAD>
+	media: autoselect
+	status: active
+llw0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+	options=400<CHANNEL_IO>
+	ether 96:4a:be:21:2d:b0
+	inet6 fe80::944a:beff:fe21:2db0%llw0 prefixlen 64 scopeid 0xf
+	nd6 options=201<PERFORMNUD,DAD>
+	media: autoselect
+	status: active
+utun0: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1500
+	inet6 fe80::7d91:c6ce:adb9:86b7%utun0 prefixlen 64 scopeid 0x10
+	nd6 options=201<PERFORMNUD,DAD>
+utun1: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1380
+	inet6 fe80::e127:36d7:55a4:4b8a%utun1 prefixlen 64 scopeid 0x11
+	nd6 options=201<PERFORMNUD,DAD>
+utun2: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 2000
+	inet6 fe80::94df:880d:9a6c:9e41%utun2 prefixlen 64 scopeid 0x12
+	nd6 options=201<PERFORMNUD,DAD>
+utun3: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1000
+	inet6 fe80::ce81:b1c:bd2c:69e%utun3 prefixlen 64 scopeid 0x13
+	nd6 options=201<PERFORMNUD,DAD>
+utun4: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1380
+	inet6 fe80::4fc6:9f4d:d90d:bbc0%utun4 prefixlen 64 scopeid 0x15
+	nd6 options=201<PERFORMNUD,DAD>
+utun5: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1380
+	inet6 fe80::9a58:29e1:1584:1073%utun5 prefixlen 64 scopeid 0x16
+	nd6 options=201<PERFORMNUD,DAD>
+utun6: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1380
+	inet6 fe80::a302:6cfd:7ed8:ffbe%utun6 prefixlen 64 scopeid 0x1b
+	nd6 options=201<PERFORMNUD,DAD>
+utun7: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1380
+	inet6 fe80::e47c:9e3b:65f6:65ae%utun7 prefixlen 64 scopeid 0x1c
+	nd6 options=201<PERFORMNUD,DAD>
+utun8: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1420
+	options=6460<TSO4,TSO6,CHANNEL_IO,PARTIAL_CSUM,ZEROINVERT_CSUM>
+	inet 172.31.253.17 --> 172.31.253.17 netmask 0xffffff00
+ipsec0: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1500
+	options=6460<TSO4,TSO6,CHANNEL_IO,PARTIAL_CSUM,ZEROINVERT_CSUM>
+	inet6 fe80::82a9:97ff:fe40:1253%ipsec0 prefixlen 64 scopeid 0x14
+	inet6 2607:fb91:797d:bdcc:cf2e:18a7:75f8:33f8 prefixlen 64
+	nd6 options=201<PERFORMNUD,DAD>
+"""
+
+[commands."netstat -rn"]
+stdout = """
+Routing tables
+
+Internet:
+Destination        Gateway            Flags               Netif Expire
+default            192.168.86.1       UGScg                 en0
+default            link#29            UCSIg               utun8
+127                127.0.0.1          UCS                   lo0
+127.0.0.1          127.0.0.1          UH                    lo0
+
+Internet6:
+Destination                             Gateway                                 Flags               Netif Expire
+default                                 fe80::%utun0                            UGcIg               utun0
+default                                 fe80::%utun1                            UGcIg               utun1
+default                                 fe80::%utun2                            UGcIg               utun2
+default                                 fe80::%utun3                            UGcIg               utun3
+default                                 2607:fb91:797d:bdcc::                   UGcIg              ipsec0
+default                                 fe80::%utun4                            UGcIg               utun4
+default                                 fe80::%utun5                            UGcIg               utun5
+default                                 fe80::%utun6                            UGcIg               utun6
+default                                 fe80::%utun7                            UGcIg               utun7
+::1                                     ::1                                     UHL                   lo0
+2607:fb91:797d:bdcc::/64                fe80::82a9:97ff:fe40:1253%ipsec0        Uc                 ipsec0
+2607:fb91:797d:bdcc:cf2e:18a7:75f8:33f8 link#20                                 UHL                   lo0
+fd19:f27d:7e31:1af4::/64                link#13                                 UC                    en0
+"""

--- a/providers/os/id/networki/testdata/windows.toml
+++ b/providers/os/id/networki/testdata/windows.toml
@@ -1,0 +1,127 @@
+[commands."wmic os get * /format:csv"]
+stdout = """Node,BootDevice,BuildNumber,BuildType,Caption,CodeSet,CountryCode,CreationClassName,CSCreationClassName,CSDVersion,CSName,CurrentTimeZone,DataExecutionPrevention_32BitApplications,DataExecutionPrevention_Available,DataExecutionPrevention_Drivers,DataExecutionPrevention_SupportPolicy,Debug,Description,Distributed,EncryptionLevel,ForegroundApplicationBoost,FreePhysicalMemory,FreeSpaceInPagingFiles,FreeVirtualMemory,InstallDate,LargeSystemCache,LastBootUpTime,LocalDateTime,Locale,Manufacturer,MaxNumberOfProcesses,MaxProcessMemorySize,MUILanguages,Name,NumberOfLicensedUsers,NumberOfProcesses,NumberOfUsers,OperatingSystemSKU,Organization,OSArchitecture,OSLanguage,OSProductSuite,OSType,OtherTypeDescription,PAEEnabled,PlusProductID,PlusVersionNumber,PortableOperatingSystem,Primary,ProductType,RegisteredUser,SerialNumber,ServicePackMajorVersion,ServicePackMinorVersion,SizeStoredInPagingFiles,Status,SuiteMask,SystemDevice,SystemDirectory,SystemDrive,TotalSwapSpaceSize,TotalVirtualMemorySize,TotalVisibleMemorySize,Version,WindowsDirectory
+WIN-VM1,\\Device\\HarddiskVolume1,14393,Multiprocessor Free,Microsoft Windows Server 2016 Standard Evaluation,1252,1,Win32_OperatingSystem,Win32_ComputerSystem,,WIN-VM1,-420,TRUE,TRUE,TRUE,3,FALSE,,FALSE,256,2,1629000,1179648,2833804,20180313201557.000000-420,,20180630024418.280385-420,20180630024734.124000-420,0409,Microsoft Corporation,4294967295,137438953344,{en-US},Microsoft Windows Server 2016 Standard Evaluation|C:\\Windows|\\Device\\Harddisk0\\Partition2,0,35,1,79,Virtual Machine,64-bit,1033,272,18,,,,,FALSE,TRUE,3,,00378-00000-00000-AA739,0,0,1179648,OK,272,\\Device\\HarddiskVolume2,C:\\Windows\\system32,C:,,3276340,2096692,10.0.14393,C:\\Windows"""
+
+[commands.b05a0aec65511e0cb331b6647c490b3b12fd4f1f4d8ed6321af73eb6e640ed20]
+command = "powershell.exe -NoProfile -EncodedCommand JABQAHIAbwBnAHIAZQBzAHMAUAByAGUAZgBlAHIAZQBuAGMAZQA9ACcAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQAnADsAaQBwAGMAbwBuAGYAaQBnACAALwBhAGwAbAA="
+stdout = """
+
+Windows IP Configuration
+
+   Host Name . . . . . . . . . . . . : WIN-1TAG48OVDGP
+   Primary Dns Suffix  . . . . . . . :
+   Node Type . . . . . . . . . . . . : Hybrid
+   IP Routing Enabled. . . . . . . . : No
+   WINS Proxy Enabled. . . . . . . . : No
+   DNS Suffix Search List. . . . . . : localdomain
+
+Ethernet adapter Ethernet0:
+
+   Connection-specific DNS Suffix  . : localdomain
+   Description . . . . . . . . . . . : Intel(R) 82574L Gigabit Network Connection
+   Physical Address. . . . . . . . . : 00-50-56-B0-9A-A5
+   DHCP Enabled. . . . . . . . . . . : Yes
+   Autoconfiguration Enabled . . . . : Yes
+   Link-local IPv6 Address . . . . . : fe80::bc2b:599c:b679:ca2d%5(Preferred)
+   IPv4 Address. . . . . . . . . . . : 192.168.5.38(Preferred)
+   Subnet Mask . . . . . . . . . . . : 255.255.255.0
+   Lease Obtained. . . . . . . . . . : Thursday, February 29, 2024 2:18:10 AM
+   Lease Expires . . . . . . . . . . : Wednesday, April 2, 2025 8:44:36 PM
+   Default Gateway . . . . . . . . . : 192.168.5.1
+   DHCP Server . . . . . . . . . . . : 192.168.5.1
+   DHCPv6 IAID . . . . . . . . . . . : 50334761
+   DHCPv6 Client DUID. . . . . . . . : 00-01-00-01-29-BB-F7-F3-00-50-56-B0-9A-A5
+   DNS Servers . . . . . . . . . . . : 192.168.5.1
+   NetBIOS over Tcpip. . . . . . . . : Enabled
+
+Tunnel adapter isatap.localdomain:
+
+   Media State . . . . . . . . . . . : Media disconnected
+   Connection-specific DNS Suffix  . : localdomain
+   Description . . . . . . . . . . . : Microsoft ISATAP Adapter
+   Physical Address. . . . . . . . . : 00-00-00-00-00-00-00-E0
+   DHCP Enabled. . . . . . . . . . . : No
+   Autoconfiguration Enabled . . . . : Yes
+
+Tunnel adapter Teredo Tunneling Pseudo-Interface:
+
+   Connection-specific DNS Suffix  . :
+   Description . . . . . . . . . . . : Teredo Tunneling Pseudo-Interface
+   Physical Address. . . . . . . . . : 00-00-00-00-00-00-00-E0
+   DHCP Enabled. . . . . . . . . . . : No
+   Autoconfiguration Enabled . . . . : Yes
+   IPv6 Address. . . . . . . . . . . : 2001:0:2851:782c:869:1f7d:a331:f3e1(Preferred)
+   Link-local IPv6 Address . . . . . : fe80::869:1f7d:a331:f3e1%4(Preferred)
+   Default Gateway . . . . . . . . . : ::
+   DHCPv6 IAID . . . . . . . . . . . : 134217728
+   DHCPv6 Client DUID. . . . . . . . : 00-01-00-01-29-BB-F7-F3-00-50-56-B0-9A-A5
+   NetBIOS over Tcpip. . . . . . . . : Disabled
+"""
+
+[commands.5afc4ad753005aac7dd9abb8c323afaa1f88560672012b76b0e0b621f4c3808e]
+command = "powershell.exe -NoProfile -EncodedCommand JABQAHIAbwBnAHIAZQBzAHMAUAByAGUAZgBlAHIAZQBuAGMAZQA9ACcAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQAnADsACgAgACAARwBlAHQALQBOAGUAdABJAFAASQBuAHQAZQByAGYAYQBjAGUAIAB8ACAACgAgACAAIAAgAFMAZQBsAGUAYwB0AC0ATwBiAGoAZQBjAHQAIABJAG4AdABlAHIAZgBhAGMAZQBJAG4AZABlAHgALAAgAEkAbgB0AGUAcgBmAGEAYwBlAEEAbABpAGEAcwAsACAATgBsAE0AdAB1ACwAIABDAG8AbgBuAGUAYwB0AGkAbwBuAFMAdABhAHQAZQAsACAAQQBkAGQAcgBlAHMAcwBGAGEAbQBpAGwAeQAsAAoAIAAgACAAIABAAHsAIABOAGEAbQBlAD0AJwBNAGEAYwBBAGQAZAByAGUAcwBzACcAOwAgAEUAeABwAHIAZQBzAHMAaQBvAG4APQB7ACAAKABHAGUAdAAtAE4AZQB0AEEAZABhAHAAdABlAHIAIAAtAEkAbgB0AGUAcgBmAGEAYwBlAEkAbgBkAGUAeAAgACQAXwAuAEkAbgB0AGUAcgBmAGEAYwBlAEkAbgBkAGUAeAApAC4ATQBhAGMAQQBkAGQAcgBlAHMAcwAgAH0AIAB9ACwACgAgACAAIAAgAEAAewAgAE4AYQBtAGUAPQAnAEkAUABBAGQAZAByAGUAcwBzAGUAcwAnADsAIABFAHgAcAByAGUAcwBzAGkAbwBuAD0AewAKACAAIAAgACAAIAAgACgARwBlAHQALQBOAGUAdABJAFAAQQBkAGQAcgBlAHMAcwAgAC0ASQBuAHQAZQByAGYAYQBjAGUASQBuAGQAZQB4ACAAJABfAC4ASQBuAHQAZQByAGYAYQBjAGUASQBuAGQAZQB4ACkAIAB8AAoAIAAgACAAIAAgACAAUwBlAGwAZQBjAHQALQBPAGIAagBlAGMAdAAgAEkAbgB0AGUAcgBmAGEAYwBlAEEAbABpAGEAcwAsACAAQQBkAGQAcgBlAHMAcwBGAGEAbQBpAGwAeQAsACAASQBQAEEAZABkAHIAZQBzAHMALAAgAFAAcgBlAGYAaQB4AEwAZQBuAGcAdABoACAAfAAKACAAIAAgACAAIAAgAEMAbwBuAHYAZQByAHQAVABvAC0ASgBzAG8AbgAKACAAIAAgACAAfQAgAH0ALAAKACAAIAAgACAAQAB7ACAATgBhAG0AZQA9ACcAVgBpAHIAdAB1AGEAbAAnADsAIABFAHgAcAByAGUAcwBzAGkAbwBuAD0AewAgACgARwBlAHQALQBOAGUAdABBAGQAYQBwAHQAZQByACAALQBJAG4AdABlAHIAZgBhAGMAZQBJAG4AZABlAHgAIAAkAF8ALgBJAG4AdABlAHIAZgBhAGMAZQBJAG4AZABlAHgAKQAuAFYAaQByAHQAdQBhAGwAIAB9ACAAfQAgAHwACgAgACAAIAAgAEMAbwBuAHYAZQByAHQAVABvAC0ASgBzAG8AbgAKAAkA"
+stdout = """
+[
+    {
+        "InterfaceIndex":  4,
+        "InterfaceAlias":  "Teredo Tunneling Pseudo-Interface",
+        "NlMtu":  1280,
+        "ConnectionState":  1,
+        "AddressFamily":  23,
+        "MacAddress":  null,
+        "IPAddresses":  "[    {        \\\"InterfaceAlias\\\":  \\\"Teredo Tunneling Pseudo-Interface\\\",        \\\"AddressFamily\\\":  23,        \\\"IPAddress\\\":  \\\"fe80::869:1f7d:a331:f3e1%4\\\",        \\\"PrefixLength\\\":  64    },    { \\\"InterfaceAlias\\\":  \\\"Teredo Tunneling Pseudo-Interface\\\",        \\\"AddressFamily\\\":  23,        \\\"IPAddress\\\": \\\"2001:0:2851:782c:869:1f7d:a331:f3e1\\\",        \\\"PrefixLength\\\":  64    }]",
+        "Virtual":  null
+    },
+    {
+        "InterfaceIndex":  2,
+        "InterfaceAlias":  "isatap.localdomain",
+        "NlMtu":  1280,
+        "ConnectionState":  0,
+        "AddressFamily":  23,
+        "MacAddress":  null,
+        "IPAddresses":  "{    \\\"InterfaceAlias\\\":  \\\"isatap.localdomain\\\",    \\\"AddressFamily\\\":  23,    \\\"IPAddress\\\":  \\\"fe80::5efe:192.168.5.38%2\\\",    \\\"PrefixLength\\\":  128}",
+        "Virtual":  null
+    },
+    {
+        "InterfaceIndex":  5,
+        "InterfaceAlias":  "Ethernet0",
+        "NlMtu":  1500,
+        "ConnectionState":  1,
+        "AddressFamily":  23,
+        "MacAddress":  "00-50-56-B0-9A-A5",
+        "IPAddresses":  "[    {        \\\"InterfaceAlias\\\":  \\\"Ethernet0\\\",        \\\"AddressFamily\\\":  23, \\\"IPAddress\\\":  \\\"fe80::bc2b:599c:b679:ca2d%5\\\",        \\\"PrefixLength\\\":  64    },    {        \\\"InterfaceAlias\\\":  \\\"Ethernet0\\\",        \\\"AddressFamily\\\":  2,        \\\"IPAddress\\\":  \\\"192.168.5.38\\\",        \\\"PrefixLength\\\": 24    }]",
+        "Virtual":  false
+    },
+    {
+        "InterfaceIndex":  1,
+        "InterfaceAlias":  "Loopback Pseudo-Interface 1",
+        "NlMtu":  4294967295,
+        "ConnectionState":  1,
+        "AddressFamily":  23,
+        "MacAddress":  null,
+        "IPAddresses":  "[    {        \\\"InterfaceAlias\\\":  \\\"Loopback Pseudo-Interface 1\\\",        \\\"AddressFamily\\\":  23,        \\\"IPAddress\\\":  \\\"::1\\\",        \\\"PrefixLength\\\":  128    },    {        \\\"InterfaceAlias\\\": \\\"Loopback Pseudo-Interface 1\\\",        \\\"AddressFamily\\\":  2,        \\\"IPAddress\\\":  \\\"127.0.0.1\\\",        \\\"PrefixLength\\\":  8    }]",
+        "Virtual":  null
+    },
+    {
+        "InterfaceIndex":  5,
+        "InterfaceAlias":  "Ethernet0",
+        "NlMtu":  1500,
+        "ConnectionState":  1,
+        "AddressFamily":  2,
+        "MacAddress":  "00-50-56-B0-9A-A5",
+        "IPAddresses":  "[    {        \\\"InterfaceAlias\\\":  \\\"Ethernet0\\\",        \\\"AddressFamily\\\":  23, \\\"IPAddress\\\":  \\\"fe80::bc2b:599c:b679:ca2d%5\\\",        \\\"PrefixLength\\\":  64    },    {        \\\"InterfaceAlias\\\":  \\\"Ethernet0\\\",        \\\"AddressFamily\\\":  2,        \\\"IPAddress\\\":  \\\"192.168.5.38\\\",        \\\"PrefixLength\\\": 24    }]",
+        "Virtual":  false
+    },
+    {
+        "InterfaceIndex":  1,
+        "InterfaceAlias":  "Loopback Pseudo-Interface 1",
+        "NlMtu":  4294967295,
+        "ConnectionState":  1,
+        "AddressFamily":  2,
+        "MacAddress":  null,
+        "IPAddresses":  "[    {        \\\"InterfaceAlias\\\":  \\\"Loopback Pseudo-Interface 1\\\",        \\\"AddressFamily\\\":  23,        \\\"IPAddress\\\":  \\\"::1\\\",        \\\"PrefixLength\\\":  128    },    {        \\\"InterfaceAlias\\\": \\\"Loopback Pseudo-Interface 1\\\",        \\\"AddressFamily\\\":  2,        \\\"IPAddress\\\":  \\\"127.0.0.1\\\",        \\\"PrefixLength\\\":  8    }]",
+        "Virtual":  null
+    }
+]
+"""
+

--- a/providers/os/id/networki/testdata/windows_get_net_ip_cmd.toml
+++ b/providers/os/id/networki/testdata/windows_get_net_ip_cmd.toml
@@ -2,64 +2,8 @@
 stdout = """Node,BootDevice,BuildNumber,BuildType,Caption,CodeSet,CountryCode,CreationClassName,CSCreationClassName,CSDVersion,CSName,CurrentTimeZone,DataExecutionPrevention_32BitApplications,DataExecutionPrevention_Available,DataExecutionPrevention_Drivers,DataExecutionPrevention_SupportPolicy,Debug,Description,Distributed,EncryptionLevel,ForegroundApplicationBoost,FreePhysicalMemory,FreeSpaceInPagingFiles,FreeVirtualMemory,InstallDate,LargeSystemCache,LastBootUpTime,LocalDateTime,Locale,Manufacturer,MaxNumberOfProcesses,MaxProcessMemorySize,MUILanguages,Name,NumberOfLicensedUsers,NumberOfProcesses,NumberOfUsers,OperatingSystemSKU,Organization,OSArchitecture,OSLanguage,OSProductSuite,OSType,OtherTypeDescription,PAEEnabled,PlusProductID,PlusVersionNumber,PortableOperatingSystem,Primary,ProductType,RegisteredUser,SerialNumber,ServicePackMajorVersion,ServicePackMinorVersion,SizeStoredInPagingFiles,Status,SuiteMask,SystemDevice,SystemDirectory,SystemDrive,TotalSwapSpaceSize,TotalVirtualMemorySize,TotalVisibleMemorySize,Version,WindowsDirectory
 WIN-VM1,\\Device\\HarddiskVolume1,14393,Multiprocessor Free,Microsoft Windows Server 2016 Standard Evaluation,1252,1,Win32_OperatingSystem,Win32_ComputerSystem,,WIN-VM1,-420,TRUE,TRUE,TRUE,3,FALSE,,FALSE,256,2,1629000,1179648,2833804,20180313201557.000000-420,,20180630024418.280385-420,20180630024734.124000-420,0409,Microsoft Corporation,4294967295,137438953344,{en-US},Microsoft Windows Server 2016 Standard Evaluation|C:\\Windows|\\Device\\Harddisk0\\Partition2,0,35,1,79,Virtual Machine,64-bit,1033,272,18,,,,,FALSE,TRUE,3,,00378-00000-00000-AA739,0,0,1179648,OK,272,\\Device\\HarddiskVolume2,C:\\Windows\\system32,C:,,3276340,2096692,10.0.14393,C:\\Windows"""
 
-[commands.b05a0aec65511e0cb331b6647c490b3b12fd4f1f4d8ed6321af73eb6e640ed20]
-command = "powershell.exe -NoProfile -EncodedCommand JABQAHIAbwBnAHIAZQBzAHMAUAByAGUAZgBlAHIAZQBuAGMAZQA9ACcAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQAnADsAaQBwAGMAbwBuAGYAaQBnACAALwBhAGwAbAA="
-stdout = """
-
-Windows IP Configuration
-
-   Host Name . . . . . . . . . . . . : WIN-1TAG48OVDGP
-   Primary Dns Suffix  . . . . . . . :
-   Node Type . . . . . . . . . . . . : Hybrid
-   IP Routing Enabled. . . . . . . . : No
-   WINS Proxy Enabled. . . . . . . . : No
-   DNS Suffix Search List. . . . . . : localdomain
-
-Ethernet adapter Ethernet0:
-
-   Connection-specific DNS Suffix  . : localdomain
-   Description . . . . . . . . . . . : Intel(R) 82574L Gigabit Network Connection
-   Physical Address. . . . . . . . . : 00-50-56-B0-9A-A5
-   DHCP Enabled. . . . . . . . . . . : Yes
-   Autoconfiguration Enabled . . . . : Yes
-   Link-local IPv6 Address . . . . . : fe80::bc2b:599c:b679:ca2d%5(Preferred)
-   IPv4 Address. . . . . . . . . . . : 192.168.5.38(Preferred)
-   Subnet Mask . . . . . . . . . . . : 255.255.255.0
-   Lease Obtained. . . . . . . . . . : Thursday, February 29, 2024 2:18:10 AM
-   Lease Expires . . . . . . . . . . : Wednesday, April 2, 2025 8:44:36 PM
-   Default Gateway . . . . . . . . . : 192.168.5.1
-   DHCP Server . . . . . . . . . . . : 192.168.5.1
-   DHCPv6 IAID . . . . . . . . . . . : 50334761
-   DHCPv6 Client DUID. . . . . . . . : 00-01-00-01-29-BB-F7-F3-00-50-56-B0-9A-A5
-   DNS Servers . . . . . . . . . . . : 192.168.5.1
-   NetBIOS over Tcpip. . . . . . . . : Enabled
-
-Tunnel adapter isatap.localdomain:
-
-   Media State . . . . . . . . . . . : Media disconnected
-   Connection-specific DNS Suffix  . : localdomain
-   Description . . . . . . . . . . . : Microsoft ISATAP Adapter
-   Physical Address. . . . . . . . . : 00-00-00-00-00-00-00-E0
-   DHCP Enabled. . . . . . . . . . . : No
-   Autoconfiguration Enabled . . . . : Yes
-
-Tunnel adapter Teredo Tunneling Pseudo-Interface:
-
-   Connection-specific DNS Suffix  . :
-   Description . . . . . . . . . . . : Teredo Tunneling Pseudo-Interface
-   Physical Address. . . . . . . . . : 00-00-00-00-00-00-00-E0
-   DHCP Enabled. . . . . . . . . . . : No
-   Autoconfiguration Enabled . . . . : Yes
-   IPv6 Address. . . . . . . . . . . : 2001:0:2851:782c:869:1f7d:a331:f3e1(Preferred)
-   Link-local IPv6 Address . . . . . : fe80::869:1f7d:a331:f3e1%4(Preferred)
-   Default Gateway . . . . . . . . . : ::
-   DHCPv6 IAID . . . . . . . . . . . : 134217728
-   DHCPv6 Client DUID. . . . . . . . : 00-01-00-01-29-BB-F7-F3-00-50-56-B0-9A-A5
-   NetBIOS over Tcpip. . . . . . . . : Disabled
-"""
-
-[commands.5afc4ad753005aac7dd9abb8c323afaa1f88560672012b76b0e0b621f4c3808e]
-command = "powershell.exe -NoProfile -EncodedCommand JABQAHIAbwBnAHIAZQBzAHMAUAByAGUAZgBlAHIAZQBuAGMAZQA9ACcAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQAnADsACgAgACAARwBlAHQALQBOAGUAdABJAFAASQBuAHQAZQByAGYAYQBjAGUAIAB8ACAACgAgACAAIAAgAFMAZQBsAGUAYwB0AC0ATwBiAGoAZQBjAHQAIABJAG4AdABlAHIAZgBhAGMAZQBJAG4AZABlAHgALAAgAEkAbgB0AGUAcgBmAGEAYwBlAEEAbABpAGEAcwAsACAATgBsAE0AdAB1ACwAIABDAG8AbgBuAGUAYwB0AGkAbwBuAFMAdABhAHQAZQAsACAAQQBkAGQAcgBlAHMAcwBGAGEAbQBpAGwAeQAsAAoAIAAgACAAIABAAHsAIABOAGEAbQBlAD0AJwBNAGEAYwBBAGQAZAByAGUAcwBzACcAOwAgAEUAeABwAHIAZQBzAHMAaQBvAG4APQB7ACAAKABHAGUAdAAtAE4AZQB0AEEAZABhAHAAdABlAHIAIAAtAEkAbgB0AGUAcgBmAGEAYwBlAEkAbgBkAGUAeAAgACQAXwAuAEkAbgB0AGUAcgBmAGEAYwBlAEkAbgBkAGUAeAApAC4ATQBhAGMAQQBkAGQAcgBlAHMAcwAgAH0AIAB9ACwACgAgACAAIAAgAEAAewAgAE4AYQBtAGUAPQAnAEkAUABBAGQAZAByAGUAcwBzAGUAcwAnADsAIABFAHgAcAByAGUAcwBzAGkAbwBuAD0AewAKACAAIAAgACAAIAAgACgARwBlAHQALQBOAGUAdABJAFAAQQBkAGQAcgBlAHMAcwAgAC0ASQBuAHQAZQByAGYAYQBjAGUASQBuAGQAZQB4ACAAJABfAC4ASQBuAHQAZQByAGYAYQBjAGUASQBuAGQAZQB4ACkAIAB8AAoAIAAgACAAIAAgACAAUwBlAGwAZQBjAHQALQBPAGIAagBlAGMAdAAgAEkAbgB0AGUAcgBmAGEAYwBlAEEAbABpAGEAcwAsACAAQQBkAGQAcgBlAHMAcwBGAGEAbQBpAGwAeQAsACAASQBQAEEAZABkAHIAZQBzAHMALAAgAFAAcgBlAGYAaQB4AEwAZQBuAGcAdABoACAAfAAKACAAIAAgACAAIAAgAEMAbwBuAHYAZQByAHQAVABvAC0ASgBzAG8AbgAKACAAIAAgACAAfQAgAH0ALAAKACAAIAAgACAAQAB7ACAATgBhAG0AZQA9ACcAVgBpAHIAdAB1AGEAbAAnADsAIABFAHgAcAByAGUAcwBzAGkAbwBuAD0AewAgACgARwBlAHQALQBOAGUAdABBAGQAYQBwAHQAZQByACAALQBJAG4AdABlAHIAZgBhAGMAZQBJAG4AZABlAHgAIAAkAF8ALgBJAG4AdABlAHIAZgBhAGMAZQBJAG4AZABlAHgAKQAuAFYAaQByAHQAdQBhAGwAIAB9ACAAfQAgAHwACgAgACAAIAAgAEMAbwBuAHYAZQByAHQAVABvAC0ASgBzAG8AbgAKAAkA"
+[commands.9bdb7d4328cfd930f31fcca52e96d413d5e4cfe0339761e7342eec1dc9f3d544]
+command = "powershell.exe -NoProfile -EncodedCommand JABQAHIAbwBnAHIAZQBzAHMAUAByAGUAZgBlAHIAZQBuAGMAZQA9ACcAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQAnADsACgAgACAARwBlAHQALQBOAGUAdABJAFAASQBuAHQAZQByAGYAYQBjAGUAIAB8ACAACgAgACAAIAAgAFMAZQBsAGUAYwB0AC0ATwBiAGoAZQBjAHQAIABJAG4AdABlAHIAZgBhAGMAZQBJAG4AZABlAHgALAAgAEkAbgB0AGUAcgBmAGEAYwBlAEEAbABpAGEAcwAsACAATgBsAE0AdAB1ACwAIABDAG8AbgBuAGUAYwB0AGkAbwBuAFMAdABhAHQAZQAsACAAQQBkAGQAcgBlAHMAcwBGAGEAbQBpAGwAeQAsAAoAIAAgACAAIABAAHsAIABOAGEAbQBlAD0AJwBNAGEAYwBBAGQAZAByAGUAcwBzACcAOwAgAEUAeABwAHIAZQBzAHMAaQBvAG4APQB7ACAAKABHAGUAdAAtAE4AZQB0AEEAZABhAHAAdABlAHIAIAAtAEkAbgB0AGUAcgBmAGEAYwBlAEkAbgBkAGUAeAAgACQAXwAuAEkAbgB0AGUAcgBmAGEAYwBlAEkAbgBkAGUAeAApAC4ATQBhAGMAQQBkAGQAcgBlAHMAcwAgAH0AIAB9ACwACgAgACAAIAAgAEAAewAgAE4AYQBtAGUAPQAnAEkAUABBAGQAZAByAGUAcwBzAGUAcwAnADsAIABFAHgAcAByAGUAcwBzAGkAbwBuAD0AewAKACAAIAAgACAAIAAgACgARwBlAHQALQBOAGUAdABJAFAAQQBkAGQAcgBlAHMAcwAgAC0ASQBuAHQAZQByAGYAYQBjAGUASQBuAGQAZQB4ACAAJABfAC4ASQBuAHQAZQByAGYAYQBjAGUASQBuAGQAZQB4ACkAIAB8AAoAIAAgACAAIAAgACAAUwBlAGwAZQBjAHQALQBPAGIAagBlAGMAdAAgAEkAbgB0AGUAcgBmAGEAYwBlAEEAbABpAGEAcwAsACAAQQBkAGQAcgBlAHMAcwBGAGEAbQBpAGwAeQAsACAASQBQAEEAZABkAHIAZQBzAHMALAAgAFAAcgBlAGYAaQB4AEwAZQBuAGcAdABoACAAfAAKACAAIAAgACAAIAAgAEMAbwBuAHYAZQByAHQAVABvAC0ASgBzAG8AbgAKACAAIAAgACAAfQAgAH0ALAAKACAAIAAgACAAQAB7ACAATgBhAG0AZQA9ACcARABlAGYAYQB1AGwAdABHAGEAdABlAHcAYQB5ACcAOwAgAEUAeABwAHIAZQBzAHMAaQBvAG4APQB7AAoAIAAgACAAIAAgACAAKABHAGUAdAAtAE4AZQB0AFIAbwB1AHQAZQAgAC0ASQBuAHQAZQByAGYAYQBjAGUASQBuAGQAZQB4ACAAJABfAC4ASQBuAHQAZQByAGYAYQBjAGUASQBuAGQAZQB4ACAAfAAgAFcAaABlAHIAZQAtAE8AYgBqAGUAYwB0ACAAewAgACQAXwAuAEQAZQBzAHQAaQBuAGEAdABpAG8AbgBQAHIAZQBmAGkAeAAgAC0AZQBxACAAJwAwAC4AMAAuADAALgAwAC8AMAAnACAALQBvAHIAIAAkAF8ALgBEAGUAcwB0AGkAbgBhAHQAaQBvAG4AUAByAGUAZgBpAHgAIAAtAGUAcQAgACcAOgA6AC8AMAAnACAAfQApACAAfAAKACAAIAAgACAAIAAgAFMAZQBsAGUAYwB0AC0ATwBiAGoAZQBjAHQAIAAtAEUAeABwAGEAbgBkAFAAcgBvAHAAZQByAHQAeQAgAE4AZQB4AHQASABvAHAAIAAtAEUAcgByAG8AcgBBAGMAdABpAG8AbgAgAFMAaQBsAGUAbgB0AGwAeQBDAG8AbgB0AGkAbgB1AGUACgAgACAAIAAgAH0AIAB9ACwACgAgACAAIAAgAEAAewAgAE4AYQBtAGUAPQAnAFYAaQByAHQAdQBhAGwAJwA7ACAARQB4AHAAcgBlAHMAcwBpAG8AbgA9AHsAIAAoAEcAZQB0AC0ATgBlAHQAQQBkAGEAcAB0AGUAcgAgAC0ASQBuAHQAZQByAGYAYQBjAGUASQBuAGQAZQB4ACAAJABfAC4ASQBuAHQAZQByAGYAYQBjAGUASQBuAGQAZQB4ACkALgBWAGkAcgB0AHUAYQBsACAAfQAgAH0AIAB8AAoAIAAgACAAIABDAG8AbgB2AGUAcgB0AFQAbwAtAEoAcwBvAG4ACgAJAA=="
 stdout = """
 [
     {
@@ -70,6 +14,7 @@ stdout = """
         "AddressFamily":  23,
         "MacAddress":  null,
         "IPAddresses":  "[    {        \\\"InterfaceAlias\\\":  \\\"Teredo Tunneling Pseudo-Interface\\\",        \\\"AddressFamily\\\":  23,        \\\"IPAddress\\\":  \\\"fe80::869:1f7d:a331:f3e1%4\\\",        \\\"PrefixLength\\\":  64    },    { \\\"InterfaceAlias\\\":  \\\"Teredo Tunneling Pseudo-Interface\\\",        \\\"AddressFamily\\\":  23,        \\\"IPAddress\\\": \\\"2001:0:2851:782c:869:1f7d:a331:f3e1\\\",        \\\"PrefixLength\\\":  64    }]",
+        "DefaultGateway":  "::",
         "Virtual":  null
     },
     {
@@ -80,6 +25,9 @@ stdout = """
         "AddressFamily":  23,
         "MacAddress":  null,
         "IPAddresses":  "{    \\\"InterfaceAlias\\\":  \\\"isatap.localdomain\\\",    \\\"AddressFamily\\\":  23,    \\\"IPAddress\\\":  \\\"fe80::5efe:192.168.5.38%2\\\",    \\\"PrefixLength\\\":  128}",
+        "DefaultGateway":  {
+
+        },
         "Virtual":  null
     },
     {
@@ -90,6 +38,7 @@ stdout = """
         "AddressFamily":  23,
         "MacAddress":  "00-50-56-B0-9A-A5",
         "IPAddresses":  "[    {        \\\"InterfaceAlias\\\":  \\\"Ethernet0\\\",        \\\"AddressFamily\\\":  23, \\\"IPAddress\\\":  \\\"fe80::bc2b:599c:b679:ca2d%5\\\",        \\\"PrefixLength\\\":  64    },    {        \\\"InterfaceAlias\\\":  \\\"Ethernet0\\\",        \\\"AddressFamily\\\":  2,        \\\"IPAddress\\\":  \\\"192.168.5.38\\\",        \\\"PrefixLength\\\": 24    }]",
+        "DefaultGateway":  "192.168.5.1",
         "Virtual":  false
     },
     {
@@ -100,6 +49,7 @@ stdout = """
         "AddressFamily":  23,
         "MacAddress":  null,
         "IPAddresses":  "[    {        \\\"InterfaceAlias\\\":  \\\"Loopback Pseudo-Interface 1\\\",        \\\"AddressFamily\\\":  23,        \\\"IPAddress\\\":  \\\"::1\\\",        \\\"PrefixLength\\\":  128    },    {        \\\"InterfaceAlias\\\": \\\"Loopback Pseudo-Interface 1\\\",        \\\"AddressFamily\\\":  2,        \\\"IPAddress\\\":  \\\"127.0.0.1\\\",        \\\"PrefixLength\\\":  8    }]",
+        "DefaultGateway":  { },
         "Virtual":  null
     },
     {
@@ -110,6 +60,7 @@ stdout = """
         "AddressFamily":  2,
         "MacAddress":  "00-50-56-B0-9A-A5",
         "IPAddresses":  "[    {        \\\"InterfaceAlias\\\":  \\\"Ethernet0\\\",        \\\"AddressFamily\\\":  23, \\\"IPAddress\\\":  \\\"fe80::bc2b:599c:b679:ca2d%5\\\",        \\\"PrefixLength\\\":  64    },    {        \\\"InterfaceAlias\\\":  \\\"Ethernet0\\\",        \\\"AddressFamily\\\":  2,        \\\"IPAddress\\\":  \\\"192.168.5.38\\\",        \\\"PrefixLength\\\": 24    }]",
+        "DefaultGateway":  "192.168.5.1",
         "Virtual":  false
     },
     {
@@ -120,8 +71,8 @@ stdout = """
         "AddressFamily":  2,
         "MacAddress":  null,
         "IPAddresses":  "[    {        \\\"InterfaceAlias\\\":  \\\"Loopback Pseudo-Interface 1\\\",        \\\"AddressFamily\\\":  23,        \\\"IPAddress\\\":  \\\"::1\\\",        \\\"PrefixLength\\\":  128    },    {        \\\"InterfaceAlias\\\": \\\"Loopback Pseudo-Interface 1\\\",        \\\"AddressFamily\\\":  2,        \\\"IPAddress\\\":  \\\"127.0.0.1\\\",        \\\"PrefixLength\\\":  8    }]",
+        "DefaultGateway":  { },
         "Virtual":  null
     }
 ]
 """
-

--- a/providers/os/id/networki/testdata/windows_ipconfig.toml
+++ b/providers/os/id/networki/testdata/windows_ipconfig.toml
@@ -1,0 +1,59 @@
+[commands."wmic os get * /format:csv"]
+stdout = """Node,BootDevice,BuildNumber,BuildType,Caption,CodeSet,CountryCode,CreationClassName,CSCreationClassName,CSDVersion,CSName,CurrentTimeZone,DataExecutionPrevention_32BitApplications,DataExecutionPrevention_Available,DataExecutionPrevention_Drivers,DataExecutionPrevention_SupportPolicy,Debug,Description,Distributed,EncryptionLevel,ForegroundApplicationBoost,FreePhysicalMemory,FreeSpaceInPagingFiles,FreeVirtualMemory,InstallDate,LargeSystemCache,LastBootUpTime,LocalDateTime,Locale,Manufacturer,MaxNumberOfProcesses,MaxProcessMemorySize,MUILanguages,Name,NumberOfLicensedUsers,NumberOfProcesses,NumberOfUsers,OperatingSystemSKU,Organization,OSArchitecture,OSLanguage,OSProductSuite,OSType,OtherTypeDescription,PAEEnabled,PlusProductID,PlusVersionNumber,PortableOperatingSystem,Primary,ProductType,RegisteredUser,SerialNumber,ServicePackMajorVersion,ServicePackMinorVersion,SizeStoredInPagingFiles,Status,SuiteMask,SystemDevice,SystemDirectory,SystemDrive,TotalSwapSpaceSize,TotalVirtualMemorySize,TotalVisibleMemorySize,Version,WindowsDirectory
+WIN-VM1,\\Device\\HarddiskVolume1,14393,Multiprocessor Free,Microsoft Windows Server 2016 Standard Evaluation,1252,1,Win32_OperatingSystem,Win32_ComputerSystem,,WIN-VM1,-420,TRUE,TRUE,TRUE,3,FALSE,,FALSE,256,2,1629000,1179648,2833804,20180313201557.000000-420,,20180630024418.280385-420,20180630024734.124000-420,0409,Microsoft Corporation,4294967295,137438953344,{en-US},Microsoft Windows Server 2016 Standard Evaluation|C:\\Windows|\\Device\\Harddisk0\\Partition2,0,35,1,79,Virtual Machine,64-bit,1033,272,18,,,,,FALSE,TRUE,3,,00378-00000-00000-AA739,0,0,1179648,OK,272,\\Device\\HarddiskVolume2,C:\\Windows\\system32,C:,,3276340,2096692,10.0.14393,C:\\Windows"""
+
+[commands.b05a0aec65511e0cb331b6647c490b3b12fd4f1f4d8ed6321af73eb6e640ed20]
+command = "powershell.exe -NoProfile -EncodedCommand JABQAHIAbwBnAHIAZQBzAHMAUAByAGUAZgBlAHIAZQBuAGMAZQA9ACcAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQAnADsAaQBwAGMAbwBuAGYAaQBnACAALwBhAGwAbAA="
+stdout = """
+
+Windows IP Configuration
+
+   Host Name . . . . . . . . . . . . : WIN-1TAG48OVDGP
+   Primary Dns Suffix  . . . . . . . :
+   Node Type . . . . . . . . . . . . : Hybrid
+   IP Routing Enabled. . . . . . . . : No
+   WINS Proxy Enabled. . . . . . . . : No
+   DNS Suffix Search List. . . . . . : localdomain
+
+Ethernet adapter Ethernet0:
+
+   Connection-specific DNS Suffix  . : localdomain
+   Description . . . . . . . . . . . : Intel(R) 82574L Gigabit Network Connection
+   Physical Address. . . . . . . . . : 00-50-56-B0-9A-A5
+   DHCP Enabled. . . . . . . . . . . : Yes
+   Autoconfiguration Enabled . . . . : Yes
+   Link-local IPv6 Address . . . . . : fe80::bc2b:599c:b679:ca2d%5(Preferred)
+   IPv4 Address. . . . . . . . . . . : 192.168.5.38(Preferred)
+   Subnet Mask . . . . . . . . . . . : 255.255.255.0
+   Lease Obtained. . . . . . . . . . : Thursday, February 29, 2024 2:18:10 AM
+   Lease Expires . . . . . . . . . . : Wednesday, April 2, 2025 8:44:36 PM
+   Default Gateway . . . . . . . . . : 192.168.5.1
+   DHCP Server . . . . . . . . . . . : 192.168.5.1
+   DHCPv6 IAID . . . . . . . . . . . : 50334761
+   DHCPv6 Client DUID. . . . . . . . : 00-01-00-01-29-BB-F7-F3-00-50-56-B0-9A-A5
+   DNS Servers . . . . . . . . . . . : 192.168.5.1
+   NetBIOS over Tcpip. . . . . . . . : Enabled
+
+Tunnel adapter isatap.localdomain:
+
+   Media State . . . . . . . . . . . : Media disconnected
+   Connection-specific DNS Suffix  . : localdomain
+   Description . . . . . . . . . . . : Microsoft ISATAP Adapter
+   Physical Address. . . . . . . . . : 00-00-00-00-00-00-00-E0
+   DHCP Enabled. . . . . . . . . . . : No
+   Autoconfiguration Enabled . . . . : Yes
+
+Tunnel adapter Teredo Tunneling Pseudo-Interface:
+
+   Connection-specific DNS Suffix  . :
+   Description . . . . . . . . . . . : Teredo Tunneling Pseudo-Interface
+   Physical Address. . . . . . . . . : 00-00-00-00-00-00-00-E0
+   DHCP Enabled. . . . . . . . . . . : No
+   Autoconfiguration Enabled . . . . : Yes
+   IPv6 Address. . . . . . . . . . . : 2001:0:2851:782c:869:1f7d:a331:f3e1(Preferred)
+   Link-local IPv6 Address . . . . . : fe80::869:1f7d:a331:f3e1%4(Preferred)
+   Default Gateway . . . . . . . . . : ::
+   DHCPv6 IAID . . . . . . . . . . . : 134217728
+   DHCPv6 Client DUID. . . . . . . . : 00-01-00-01-29-BB-F7-F3-00-50-56-B0-9A-A5
+   NetBIOS over Tcpip. . . . . . . . : Disabled
+"""

--- a/providers/os/id/networki/windows_n.go
+++ b/providers/os/id/networki/windows_n.go
@@ -1,0 +1,242 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package networki
+
+import (
+	"bufio"
+	"encoding/json"
+	"regexp"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
+)
+
+// detectWindowsInterfaces detects network interfaces on Windows.
+func (n *neti) detectWindowsInterfaces() ([]Interface, error) {
+	detectors := []func() ([]Interface, error){
+		n.getWindowsIpconfigCmdInterfaces,
+		n.getWindowsGetNetIPInterfaceCmdInterfaces,
+	}
+
+	var errs []error
+	interfaces := []Interface{}
+	for _, detectFn := range detectors {
+		detectedInterfaces, err := detectFn()
+		if err != nil {
+			log.Debug().Err(err).
+				Msg("os.network.interface> unable to detect network interfaces")
+			errs = append(errs, err)
+			continue
+		}
+		interfaces = AddOrUpdateInterfaces(interfaces, detectedInterfaces)
+	}
+
+	if len(interfaces) == 0 {
+		return interfaces, errors.Join(errs...)
+	}
+
+	return interfaces, nil
+}
+
+func (n *neti) getWindowsGetNetIPInterfaceCmdInterfaces() (interfaces []Interface, err error) {
+	cmd := `
+  Get-NetIPInterface | 
+    Select-Object InterfaceIndex, InterfaceAlias, NlMtu, ConnectionState, AddressFamily,
+    @{ Name='MacAddress'; Expression={ (Get-NetAdapter -InterfaceIndex $_.InterfaceIndex).MacAddress } },
+    @{ Name='IPAddresses'; Expression={
+      (Get-NetIPAddress -InterfaceIndex $_.InterfaceIndex) |
+      Select-Object InterfaceAlias, AddressFamily, IPAddress, PrefixLength |
+      ConvertTo-Json
+    } },
+    @{ Name='Virtual'; Expression={ (Get-NetAdapter -InterfaceIndex $_.InterfaceIndex).Virtual } } |
+    ConvertTo-Json
+	`
+	output, err := n.RunCommand(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	var netInterfaces []map[string]any
+	err = json.Unmarshal([]byte(output), &netInterfaces)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Trace().Interface("output", netInterfaces).Msg("os.network.interface> net interface cmd")
+
+	for _, adapter := range netInterfaces {
+		iinterface := Interface{
+			Name: adapter["InterfaceAlias"].(string),
+		}
+
+		// Get MAC address
+		if value, ok := adapter["MacAddress"].(string); ok {
+			iinterface.SetMAC(value)
+		}
+		// Get MTU
+		if value, ok := adapter["NlMtu"].(float64); ok {
+			iinterface.MTU = int(value)
+		}
+
+		// Get Status
+		if state, ok := adapter["ConnectionState"].(float64); ok {
+			active := true
+			if state == 0 {
+				active = false
+			}
+			iinterface.Active = &active
+		}
+
+		// Detect virtual interface
+		if virtual, ok := adapter["Virtual"].(bool); ok {
+			iinterface.Virtual = &virtual
+		}
+
+		// Get IP Addresses (v4 or v6) in JSON format
+		if data, ok := adapter["IPAddresses"].(string); ok {
+			var ipaddresses []map[string]any
+			err = json.Unmarshal([]byte(data), &ipaddresses)
+			if err != nil {
+				log.Debug().Err(err).
+					Str("data", data).
+					Str("detector", "cmd.Get-NetIPInterface").
+					Msg("os.network.interface> unable to detect IPAddresses")
+			}
+
+			var (
+				ipaddress IPAddress
+				valid     bool
+			)
+			for _, ipMap := range ipaddresses {
+				if ip, ok := ipMap["IPAddress"].(string); ok {
+					// Get the prefix length
+					if prefixLength, ok := ipMap["PrefixLength"].(float64); ok {
+						ipaddress, valid = NewIPWithPrefixLength(ip, int(prefixLength))
+					} else {
+						// No prefix, plain ip address
+						ipaddress, valid = NewIPAddress(ip)
+					}
+
+					if valid {
+						iinterface.AddOrUpdateIP(ipaddress)
+					}
+				}
+			}
+		}
+
+		interfaces = append(interfaces, iinterface)
+	}
+
+	return
+}
+
+func (n *neti) getWindowsIpconfigCmdInterfaces() (interfaces []Interface, err error) {
+	output, err := n.RunCommand("ipconfig /all")
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		ips                  []IPAddress
+		gateways             []string
+		currentInterface     *Interface
+		interfaceHeaderRegex = regexp.MustCompile(`^(Ethernet|Wireless|Bluetooth|VPN|Local Area Connection|Wi-Fi|Cellular|Tunnel) adapter (.+):$`)
+	)
+
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		// We are looking for an output like this one to identify a new interface
+		//
+		// Ethernet adapter Ethernet0:
+		if matches := interfaceHeaderRegex.FindStringSubmatch(line); matches != nil {
+			if currentInterface != nil {
+				updateWindowsNetInterface(currentInterface, ips, gateways)
+				interfaces = append(interfaces, *currentInterface)
+			}
+
+			// New interface initialization
+			currentInterface = &Interface{Name: matches[2]}
+			ips = make([]IPAddress, 0)
+			gateways = make([]string, 0)
+		}
+
+		if currentInterface != nil {
+			fields := strings.Fields(line)
+			if len(fields) < 2 {
+				continue
+			}
+			switch {
+			case strings.HasPrefix(line, "Physical Address"):
+				currentInterface.SetMAC(lastField(fields))
+			case strings.HasPrefix(line, "IPv4 Address"):
+				fallthrough
+			case strings.HasPrefix(line, "IPv6 Address"):
+				ip, ok := NewIPAddress(cleanIPString(lastField(fields)))
+				if ok {
+					ips = append(ips, ip)
+				}
+			case strings.HasPrefix(line, "Subnet Mask"):
+				// Subnet mask are only valid for IPv4
+				subnet := lastField(fields)
+				for i := range ips {
+					if version, ok := ips[i].Version(); ok && version == IPv4 {
+						ips[i] = NewIPv4WithMask(ips[i].IP.String(), subnet)
+					}
+				}
+			case strings.HasPrefix(line, "Default Gateway"):
+				// collect the gateways found to inject them as part of the enrichments
+				gateways = append(gateways, lastField(fields))
+			}
+		}
+	}
+
+	if currentInterface != nil {
+		updateWindowsNetInterface(currentInterface, ips, gateways)
+		interfaces = append(interfaces, *currentInterface)
+	}
+
+	log.Debug().
+		Interface("interfaces", interfaces).
+		Str("detector", "cmd.ipconfig_/all").
+		Msg("os.network.interfaces> discovered")
+	return
+}
+
+func lastField(fields []string) string {
+	if len(fields) > 2 {
+		return fields[len(fields)-1]
+	}
+	return ""
+}
+
+func cleanIPString(ip string) string {
+	re := regexp.MustCompile(`\(.*?\)$`)
+	return strings.TrimSpace(re.ReplaceAllString(ip, ""))
+}
+
+func updateWindowsNetInterface(currentInterface *Interface, ips []IPAddress, gateways []string) {
+	currentInterface.AddOrUpdateIP(ips...)
+	if len(gateways) == 0 {
+		// no enrichments needed
+		return
+	}
+	currentInterface.enrichments = func(in *Interface) {
+		for g := range gateways {
+			// IPv4 (default)
+			gateway := gateways[g]
+			gatewayVersion := IPv4
+			if strings.Contains(gateway, ":") {
+				// IPv6
+				gatewayVersion = IPv6
+			}
+			for i := range in.IPAddresses {
+				if version, ok := in.IPAddresses[i].Version(); ok && version == gatewayVersion {
+					in.IPAddresses[i].Gateway = gateway
+				}
+			}
+		}
+	}
+}

--- a/providers/os/resources/cloud.go
+++ b/providers/os/resources/cloud.go
@@ -72,7 +72,7 @@ func (i *mqlCloudInstance) privateIpv4() (value []interface{}, err error) {
 	if i.instanceMd != nil {
 		var resource plugin.Resource
 		for _, ipaddress := range i.instanceMd.PrivateIpv4 {
-			resource, err = NewResource(i.MqlRuntime, "ipv4Address", map[string]*llx.RawData{
+			resource, err = NewResource(i.MqlRuntime, "ipAddress", map[string]*llx.RawData{
 				"__id":      llx.StringData(ipaddress.IP),
 				"ip":        llx.IPData(llx.ParseIP(ipaddress.IP)),
 				"subnet":    llx.IPData(llx.ParseIP(ipaddress.Subnet)),
@@ -93,7 +93,7 @@ func (i *mqlCloudInstance) publicIpv4() (value []interface{}, err error) {
 	if i.instanceMd != nil {
 		var resource plugin.Resource
 		for _, ipaddress := range i.instanceMd.PublicIpv4 {
-			resource, err = NewResource(i.MqlRuntime, "ipv4Address", map[string]*llx.RawData{
+			resource, err = NewResource(i.MqlRuntime, "ipAddress", map[string]*llx.RawData{
 				"__id":      llx.StringData(ipaddress.IP),
 				"ip":        llx.IPData(llx.ParseIP(ipaddress.IP)),
 				"subnet":    llx.IPData(llx.ParseIP(ipaddress.Subnet)),

--- a/providers/os/resources/network.go
+++ b/providers/os/resources/network.go
@@ -1,0 +1,69 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/util/convert"
+	"go.mondoo.com/cnquery/v11/providers/os/connection/shared"
+	"go.mondoo.com/cnquery/v11/providers/os/id/networki"
+	"go.mondoo.com/cnquery/v11/types"
+)
+
+func (c *mqlNetwork) interfaces() ([]any, error) {
+	log.Debug().Msg("os.network> interfaces")
+	conn := c.MqlRuntime.Connection.(shared.Connection)
+	platform := conn.Asset().Platform
+
+	interfaces, err := networki.Interfaces(conn, platform)
+	if err != nil {
+		log.Error().Err(err).Msg("unable to detect network interfaces")
+		c.Interfaces = plugin.TValue[[]any]{State: plugin.StateIsSet | plugin.StateIsNull}
+		return nil, nil
+	}
+
+	var resources []any
+	if interfaces != nil {
+		var resource plugin.Resource
+		for _, neti := range interfaces {
+			log.Debug().Interface("interface", neti).Msg("os.network> adding interface")
+
+			ipaddresses := []interface{}{}
+			for _, ipaddress := range neti.IPAddresses {
+				resource, err = NewResource(c.MqlRuntime, "ipAddress", map[string]*llx.RawData{
+					"__id":      llx.StringData(ipaddress.IP.String()),
+					"ip":        llx.IPData(llx.ParseIP(ipaddress.IP.String())),
+					"cidr":      llx.IPData(llx.ParseIP(ipaddress.CIDR)),
+					"broadcast": llx.IPData(llx.ParseIP(ipaddress.Broadcast)),
+					"gateway":   llx.IPData(llx.ParseIP(ipaddress.Gateway)),
+					"subnet":    llx.IPData(llx.ParseIP(ipaddress.Subnet)),
+				})
+				if err != nil { // non-critical error
+					log.Error().Err(err).Msg("unable to create ipaddress resource")
+					continue
+				}
+				ipaddresses = append(ipaddresses, resource)
+			}
+
+			resource, err = NewResource(c.MqlRuntime, "networkInterface", map[string]*llx.RawData{
+				"__id":    llx.StringData(neti.Name + "/" + neti.MACAddress),
+				"name":    llx.StringData(neti.Name),
+				"mac":     llx.StringData(neti.MACAddress),
+				"mtu":     llx.IntData(neti.MTU),
+				"active":  llx.BoolDataPtr(neti.Active),
+				"virtual": llx.BoolDataPtr(neti.Virtual),
+				"vendor":  llx.StringData(neti.Vendor),
+				"flags":   llx.ArrayData(convert.SliceAnyToInterface(neti.Flags), types.String),
+				"ips":     llx.ArrayData(ipaddresses, types.Resource("ipAddress")),
+			})
+			if err != nil {
+				return resources, nil
+			}
+			resources = append(resources, resource)
+		}
+	}
+	return resources, nil
+}

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -1706,25 +1706,50 @@ private cloudInstance @defaults("publicHostname privateHostname") {
   // Cloud instance public hostname
   publicHostname() string
   // List of public IPv4 addresses
-  publicIpv4() []ipv4Address
+  publicIpv4() []ipAddress
   // Cloud instance private hostname
   privateHostname() string
   // List of private IPv4 addresses
-  privateIpv4() []ipv4Address
+  privateIpv4() []ipAddress
   // Raw access to the cloud instance metadata
   metadata() dict
 }
 
-// IPv4 address with additional networking details
-ipv4Address @defaults("ip") {
-  // Unique number that identifies a device on a network (e.g. 172.31.24.71)
+// IP address (v4 or v6) with additional networking details
+ipAddress @defaults("ip") {
+  // Unique number that identifies a device on a network (e.g. 172.31.24.71 or 2001:0:2851:782c:869:1f7d:a331:f3e1)
   ip ip
-  // Logical subdivision of a network (e.g. 172.31.16.0/20)
+  // Logical subdivision of a network (e.g. 172.31.16.0/20 or 2001:db8::/64)
   subnet ip
-  // Classless Inter-Domain Routing notation (e.g. 172.31.24.71/20)
+  // Classless Inter-Domain Routing notation (e.g. 172.31.24.71/20 or 2001:0:2851:782c:869:1f7d:a331:f3e1/64)
   cidr ip
   // Network address used to transmit to all devices connected to a network
   broadcast ip
   // IP address that acts as the entry point to another, or external, network
   gateway ip
+}
+
+// Network information on this system
+network {
+  // Network interfaces
+  interfaces() []networkInterface
+}
+
+private networkInterface @defaults("name mac active") {
+  // Name of the network interface
+  name string
+  // Unique 12-digit hexadecimal identifier assigned by the manufacturer
+  mac string
+  // Company that manufactures the network interface
+  vendor string
+  // List of IP addresses assigned to the network interface (v4 and v6)
+  ips []ipAddress
+  // Maximum transmission unit
+  mtu int
+  // Information about an interface's status and capabilities
+  flags []string
+  // Status of the network interface
+  active bool
+  // Whether a network interface is virtual of not
+  virtual bool
 }

--- a/providers/os/resources/os.lr.manifest.yaml
+++ b/providers/os/resources/os.lr.manifest.yaml
@@ -351,6 +351,14 @@ resources:
       input: {}
       output: {}
     min_mondoo_version: 5.15.0
+  ipAddress:
+    fields:
+      broadcast: {}
+      cidr: {}
+      gateway: {}
+      ip: {}
+      subnet: {}
+    min_mondoo_version: 11.45.0
   iptables:
     fields:
       input: {}
@@ -371,14 +379,6 @@ resources:
       source: {}
       target: {}
     min_mondoo_version: 5.15.0
-  ipv4Address:
-    fields:
-      broadcast: {}
-      cidr: {}
-      gateway: {}
-      ip: {}
-      subnet: {}
-    min_mondoo_version: 11.45.0
   kernel:
     fields:
       info: {}
@@ -566,6 +566,27 @@ resources:
       options: {}
       path: {}
     min_mondoo_version: 5.15.0
+  network:
+    fields:
+      interfaces: {}
+    min_mondoo_version: 9.0.0
+  networkInterface:
+    fields:
+      active: {}
+      driver: {}
+      firmware: {}
+      flags: {}
+      ips: {}
+      mac: {}
+      manufacturer: {}
+      model: {}
+      mtu: {}
+      name: {}
+      status: {}
+      vendor: {}
+      virtual: {}
+    is_private: true
+    min_mondoo_version: 11.45.0
   npm.package:
     fields:
       cpes: {}


### PR DESCRIPTION
This change introduces a new resource to the `os` provider called `network`, this
resource today gathers all the network interfaces from the system and additional
information about the interface like ip addresses (v4 and v6), subnet, gateway, the
status and flags of the interface, as well as the MAC address.

# Data Collection Methods

The new `networki` package has an entry point function called `Interfaces()` that
returns the list of interfaces in the system. The way this function work is by detecting
the operating system we are connected to, and based of that information, it runs multiple
detector functions to collect as much information from different sources:
```go
detectors := []func() ([]Interface, error){
	...
}
```

In the future, we can add more of these to enhance the data we collect.

# Testing

Ran tests agains all three operating systems we need to support.

## `macOS` 🍎 

![Screenshot 2025-03-28 at 1 50 36 PM](https://github.com/user-attachments/assets/ce594341-b19b-41ce-9c22-3c37b53d1466)

## `Windows` 🪟 

![Screenshot 2025-04-01 at 3 54 59 PM](https://github.com/user-attachments/assets/71b8ace4-2861-44a5-a6a9-a603c6303c00)

## `Linux` 🐧 

### `amazonlinux`

![Screenshot 2025-04-01 at 4 11 07 PM](https://github.com/user-attachments/assets/c51135d3-5219-4090-9750-328c182da154)

### `Debian`

![Screenshot 2025-04-01 at 4 11 48 PM](https://github.com/user-attachments/assets/085a45b2-e859-4b15-a476-1af38388c67c)
