### PR TITLE
🐛 only inform on unsupported providers

### DIFF
--- a/cli/printer/mql.go
+++ b/cli/printer/mql.go
@@ -364,7 +364,7 @@ func (print *Printer) refMap(typ types.Type, data map[string]interface{}, codeID
 		label := print.defaultLabel(k, bundle)
 		val := v.(*llx.RawData)
 
-		if val.Error == plugin.ErrUnsupportedProvider {
+		if plugin.IsUnsupportedProviderError(val.Error) {
 			res.WriteString("  " + label + print.Disabled(MsgUnsupported) + "\n")
 			continue
 		}
@@ -388,7 +388,7 @@ func (print *Printer) refMap(typ types.Type, data map[string]interface{}, codeID
 			label := print.label(k, bundle, true)
 			val := v.(*llx.RawData)
 
-			if val.Error == plugin.ErrUnsupportedProvider {
+			if plugin.IsUnsupportedProviderError(val.Error) {
 				res.WriteString(indent + "  " + label + print.Disabled(MsgUnsupported) + "\n")
 				continue
 			}
@@ -860,7 +860,7 @@ func filterErrors(e error) error {
 	if e == nil {
 		return nil
 	}
-	if e == plugin.ErrUnsupportedProvider {
+	if plugin.IsUnsupportedProviderError(e) {
 		return nil
 	}
 	merr, ok := e.(*multierr.Errors)
@@ -868,7 +868,9 @@ func filterErrors(e error) error {
 		return e
 	}
 
-	filtered := merr.Filter(func(e error) bool { return e == plugin.ErrUnsupportedProvider })
+	filtered := merr.Filter(func(e error) bool {
+		return plugin.IsUnsupportedProviderError(e)
+	})
 	if len(filtered.Errors) == 0 {
 		return nil
 	}

--- a/providers-sdk/v1/plugin/errors.go
+++ b/providers-sdk/v1/plugin/errors.go
@@ -3,10 +3,13 @@
 
 package plugin
 
-import "errors"
+import (
+	"errors"
+)
 
 var (
 	ErrProviderTypeDoesNotMatch = errors.New("provider type does not match")
+	ErrUnsupportedProvider      = errors.New("unsupported provider")
 	ErrRunCommandNotImplemented = errors.New("provider does not implement RunCommand")
 	ErrFileInfoNotImplemented   = errors.New("provider does not implement FileInfo")
 )

--- a/providers-sdk/v1/plugin/errors.go
+++ b/providers-sdk/v1/plugin/errors.go
@@ -5,6 +5,8 @@ package plugin
 
 import (
 	"errors"
+
+	"google.golang.org/grpc/status"
 )
 
 var (
@@ -13,3 +15,16 @@ var (
 	ErrRunCommandNotImplemented = errors.New("provider does not implement RunCommand")
 	ErrFileInfoNotImplemented   = errors.New("provider does not implement FileInfo")
 )
+
+// IsUnsupportedProviderError checks if the given errors indicates an unsupported provider
+// for either a direct (non-grpc) transmission or a GRPC-based call
+func IsUnsupportedProviderError(e error) bool {
+	if e == ErrUnsupportedProvider {
+		return true
+	}
+	st, ok := status.FromError(e)
+	if !ok {
+		return false
+	}
+	return st.Message() == ErrUnsupportedProvider.Error()
+}

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -506,7 +506,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 			conn, err = mock.New(connId, "", asset)
 
 		default:
-			return nil, errors.New("cannot find connection type " + conf.Type)
+			return nil, plugin.ErrUnsupportedProvider
 		}
 
 		if err != nil {

--- a/providers/terraform/provider/provider.go
+++ b/providers/terraform/provider/provider.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 
 	"github.com/rs/zerolog/log"
-
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
@@ -166,7 +165,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 			}
 
 		default:
-			return nil, errors.New("cannot find connection type " + conf.Type)
+			return nil, plugin.ErrUnsupportedProvider
 		}
 
 		var upstream *upstream.UpstreamClient

--- a/providers/vsphere/connection/connection.go
+++ b/providers/vsphere/connection/connection.go
@@ -47,7 +47,7 @@ func NewVsphereConnection(id uint32, asset *inventory.Asset, conf *inventory.Con
 
 	// initialize vSphere connection
 	if conf.Type != "vsphere" {
-		return nil, errors.New("connection type is not supported for vSphere connection: " + conf.Type)
+		return nil, plugin.ErrUnsupportedProvider
 	}
 
 	// search for password secret

--- a/utils/multierr/errors.go
+++ b/utils/multierr/errors.go
@@ -42,6 +42,17 @@ func (m *Errors) Add(err ...error) {
 	}
 }
 
+func (m *Errors) Filter(f func(e error) bool) *Errors {
+	res := Errors{}
+	for i := range m.Errors {
+		cur := m.Errors[i]
+		if !f(cur) {
+			res.Errors = append(res.Errors, cur)
+		}
+	}
+	return &res
+}
+
 func (m *Errors) Error() string {
 	var res strings.Builder
 


### PR DESCRIPTION
Fixes #5389

Instead of showing errors like in the issue above, we now show a simple message where fields are not supported: 

```
asset: {
  cpes: unsupported platform
  kind: "api"
  build: ""
  version: ""
  platformMetadata: {}
  title: "AWS Account"
  annotations: {}
  purl: unsupported platform
  arch: ""
  labels: {}
  platform: "aws"
  vulnerabilityReport: unsupported platform
  runtime: "aws"
  ids: [
    0: "//platformid.api.mondoo.app/runtime/aws/accounts/162854405951"
    1: "arn:aws:sts::162854405951"
  ]
  name: "AWS Account 162854405951"
  fqdn: ""
  family: []
}
```