### PR TITLE
🧹 mark AIX packages that have an efix applied

### DIFF
--- a/providers/os/resources/packages/aix_packages.go
+++ b/providers/os/resources/packages/aix_packages.go
@@ -36,6 +36,15 @@ func parseAixPackages(pf *inventory.Platform, r io.Reader) ([]Package, error) {
 		record := strings.Split(line, ":")
 
 		cpes, _ := cpe2.NewPackage2Cpe(record[1], record[1], record[2], "", pf.Arch)
+
+		state := record[4]
+		qualifiers := map[string]string{}
+
+		if record[7] != "" {
+			state = state + "|" + record[7]
+			qualifiers["efix"] = "locked"
+		}
+
 		// Fileset, Level, PtfID, State, Type, Description, EFIXLocked
 		pkgs = append(pkgs, Package{
 			Name:        record[1],
@@ -43,9 +52,10 @@ func parseAixPackages(pf *inventory.Platform, r io.Reader) ([]Package, error) {
 			Description: strings.TrimSpace(record[6]),
 			Format:      AixPkgFormat,
 			PUrl: purl.NewPackageURL(
-				pf, purl.TypeGeneric, record[1], record[2], purl.WithNamespace(pf.Name),
+				pf, purl.TypeGeneric, record[1], record[2], purl.WithNamespace(pf.Name), purl.WithQualifiers(qualifiers),
 			).String(),
-			CPEs: cpes,
+			CPEs:   cpes,
+			Status: state,
 		})
 
 	}

--- a/providers/os/resources/packages/aix_packages_test.go
+++ b/providers/os/resources/packages/aix_packages_test.go
@@ -7,10 +7,9 @@ import (
 	"os"
 	"testing"
 
-	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 )
 
 func TestParseAixPackages(t *testing.T) {
@@ -25,7 +24,7 @@ func TestParseAixPackages(t *testing.T) {
 
 	m, err := parseAixPackages(pf, f)
 	require.Nil(t, err)
-	assert.Equal(t, 16, len(m), "detected the right amount of packages")
+	assert.Equal(t, 17, len(m), "detected the right amount of packages")
 
 	p := Package{
 		Name:        "X11.apps.msmit",
@@ -37,6 +36,21 @@ func TestParseAixPackages(t *testing.T) {
 			"cpe:2.3:a:x11.apps.msmit:x11.apps.msmit:7.3.0:*:*:*:*:*:powerpc:*",
 		},
 		Format: "bff",
+		Status: "COMMITTED",
+	}
+	assert.Contains(t, m, p)
+
+	p = Package{
+		Name:        "bos.sysmgt.nim.client",
+		Version:     "7.3.3.0",
+		Description: "Network Install Manager - Client Tools",
+		PUrl:        "pkg:generic/aix/bos.sysmgt.nim.client@7.3.3.0?arch=powerpc&efix=locked",
+		CPEs: []string{
+			"cpe:2.3:a:bos.sysmgt.nim.client:bos.sysmgt.nim.client:7.3.3.0:*:*:*:*:*:powerpc:*",
+			"cpe:2.3:a:bos.sysmgt.nim.client:bos.sysmgt.nim.client:7.3.3:*:*:*:*:*:powerpc:*",
+		},
+		Format: "bff",
+		Status: "COMMITTED|EFIXLOCKED",
 	}
 	assert.Contains(t, m, p)
 }

--- a/providers/os/resources/packages/testdata/packages_aix.txt
+++ b/providers/os/resources/packages/testdata/packages_aix.txt
@@ -15,3 +15,4 @@
 /usr/lib/objrepos:X11.apps.util:7.3.0.0::COMMITTED:I:AIXwindows Utility Applications :
 /usr/lib/objrepos:X11.apps.xdm:7.3.0.0::COMMITTED:I:AIXwindows xdm Application :
 /usr/lib/objrepos:X11.apps.xterm:7.3.0.0::COMMITTED:I:AIXwindows xterm Application :
+/usr/lib/objrepos:bos.sysmgt.nim.client:7.3.3.0::COMMITTED:I:Network Install Manager - Client Tools :EFIXLOCKED

--- a/providers/os/resources/purl/purl.go
+++ b/providers/os/resources/purl/purl.go
@@ -33,6 +33,9 @@ type PackageURL struct {
 
 	// Used as metadata to fetch things like the architecture or linux distribution.
 	platform *inventory.Platform
+
+	// Optional: qualifiers
+	Qualifiers map[string]string
 }
 
 // NewQualifiers creates a new Qualifiers slice from a map of key/value pairs.
@@ -106,7 +109,11 @@ func NewPackageURL(pf *inventory.Platform, t Type, name, version string, modifie
 }
 
 func (purl PackageURL) String() string {
-	qualifiers := map[string]string{}
+	qualifiers := purl.Qualifiers
+	if qualifiers == nil {
+		qualifiers = map[string]string{}
+	}
+
 	if purl.Arch != "" {
 		qualifiers[QualifierArch] = purl.Arch
 	}
@@ -170,5 +177,11 @@ func WithEpoch(epoch string) Modifier {
 func WithNamespace(namespace string) Modifier {
 	return func(purl *PackageURL) {
 		purl.Namespace = namespace
+	}
+}
+
+func WithQualifiers(qualifiers map[string]string) Modifier {
+	return func(purl *PackageURL) {
+		purl.Qualifiers = qualifiers
 	}
 }


### PR DESCRIPTION
This reads the package state from AIX:

```
cnspec> packages.where(name == /bos.sysmgt./) { name version status purl}
packages.where.list: [
  0: {
    purl: "pkg:generic/aix/bos.sysmgt.hmc@7.3.3.0?arch=powerpc"
    version: "7.3.3.0"
    name: "bos.sysmgt.hmc"
    status: "COMMITTED"
  }
  1: {
    purl: "pkg:generic/aix/bos.sysmgt.loginlic@7.3.3.0?arch=powerpc"
    version: "7.3.3.0"
    name: "bos.sysmgt.loginlic"
    status: "COMMITTED"
  }
  2: {
    purl: "pkg:generic/aix/bos.sysmgt.nim.client@7.3.3.0?arch=powerpc&efix=locked"
    version: "7.3.3.0"
    name: "bos.sysmgt.nim.client"
    status: "COMMITTED|EFIXLOCKED"
  }
  3: {
    purl: "pkg:generic/aix/bos.sysmgt.pvc@7.3.3.0?arch=powerpc"
    version: "7.3.3.0"
    name: "bos.sysmgt.pvc"
    status: "COMMITTED"
  }
  4: {
    purl: "pkg:generic/aix/bos.sysmgt.quota@7.3.3.0?arch=powerpc"
    version: "7.3.3.0"
    name: "bos.sysmgt.quota"
    status: "COMMITTED"
  }
  5: {
    purl: "pkg:generic/aix/bos.sysmgt.serv_aid@7.3.3.0?arch=powerpc"
    version: "7.3.3.0"
    name: "bos.sysmgt.serv_aid"
    status: "COMMITTED"
  }
  6: {
    purl: "pkg:generic/aix/bos.sysmgt.smit@7.3.3.0?arch=powerpc"
    version: "7.3.3.0"
    name: "bos.sysmgt.smit"
    status: "COMMITTED"
  }
  7: {
    purl: "pkg:generic/aix/bos.sysmgt.sysbr@7.3.3.0?arch=powerpc&efix=locked"
    version: "7.3.3.0"
    name: "bos.sysmgt.sysbr"
    status: "COMMITTED|EFIXLOCKED"
  }
  8: {
    purl: "pkg:generic/aix/bos.sysmgt.trace@7.3.3.0?arch=powerpc"
    version: "7.3.3.0"
    name: "bos.sysmgt.trace"
    status: "COMMITTED"
  }
  9: {
    purl: "pkg:generic/aix/bos.sysmgt.hmc@7.3.3.0?arch=powerpc"
    version: "7.3.3.0"
    name: "bos.sysmgt.hmc"
    status: "COMMITTED"
  }
  10: {
    purl: "pkg:generic/aix/bos.sysmgt.loginlic@7.3.3.0?arch=powerpc"
    version: "7.3.3.0"
    name: "bos.sysmgt.loginlic"
    status: "COMMITTED"
  }
  11: {
    purl: "pkg:generic/aix/bos.sysmgt.nim.client@7.3.3.0?arch=powerpc&efix=locked"
    version: "7.3.3.0"
    name: "bos.sysmgt.nim.client"
    status: "COMMITTED|EFIXLOCKED"
  }
  12: {
    purl: "pkg:generic/aix/bos.sysmgt.pvc@7.3.3.0?arch=powerpc"
    version: "7.3.3.0"
    name: "bos.sysmgt.pvc"
    status: "COMMITTED"
  }
  13: {
    purl: "pkg:generic/aix/bos.sysmgt.quota@7.3.3.0?arch=powerpc"
    version: "7.3.3.0"
    name: "bos.sysmgt.quota"
    status: "COMMITTED"
  }
  14: {
    purl: "pkg:generic/aix/bos.sysmgt.serv_aid@7.3.3.0?arch=powerpc"
    version: "7.3.3.0"
    name: "bos.sysmgt.serv_aid"
    status: "COMMITTED"
  }
  15: {
    purl: "pkg:generic/aix/bos.sysmgt.smit@7.3.3.0?arch=powerpc"
    version: "7.3.3.0"
    name: "bos.sysmgt.smit"
    status: "COMMITTED"
  }
  16: {
    purl: "pkg:generic/aix/bos.sysmgt.sysbr@7.3.3.0?arch=powerpc&efix=locked"
    version: "7.3.3.0"
    name: "bos.sysmgt.sysbr"
    status: "COMMITTED|EFIXLOCKED"
  }
  17: {
    purl: "pkg:generic/aix/bos.sysmgt.trace@7.3.3.0?arch=powerpc"
    version: "7.3.3.0"
    name: "bos.sysmgt.trace"
    status: "COMMITTED"
  }
]
cnspec> 
```