### PR TITLE
⭐️ detect Suse OS variant id

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -888,6 +888,9 @@ var linuxFamily = &PlatformResolver{
 		if pf.Labels == nil {
 			pf.Labels = map[string]string{}
 		}
+		if pf.Metadata == nil {
+			pf.Metadata = map[string]string{}
+		}
 
 		lsb, err := osrd.lsbconfig()
 		// ignore lsb config if we got an error
@@ -916,7 +919,9 @@ var linuxFamily = &PlatformResolver{
 		} else {
 			if len(osr["ID"]) > 0 {
 				pf.Name = osr["ID"]
+				// Deprecated: remove in 12.0
 				pf.Labels[LabelDistroID] = osr["ID"]
+				pf.Metadata[LabelDistroID] = osr["ID"]
 			}
 			if len(osr["PRETTY_NAME"]) > 0 {
 				pf.Title = osr["PRETTY_NAME"]
@@ -927,6 +932,12 @@ var linuxFamily = &PlatformResolver{
 
 			if len(osr["BUILD_ID"]) > 0 {
 				pf.Build = osr["BUILD_ID"]
+			}
+
+			if len(osr["VARIANT_ID"]) > 0 {
+				// Deprecated: remove in 12.0
+				pf.Labels["variant-id"] = osr["VARIANT_ID"]
+				pf.Metadata["variant-id"] = osr["VARIANT_ID"]
 			}
 
 			detected = true

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -498,6 +498,21 @@ func TestSuse15Detector(t *testing.T) {
 	assert.Equal(t, []string{"suse", "linux", "unix", "os"}, di.Family)
 }
 
+func TestSuse15SapDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-suse-sles-15-sap.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "sles", di.Name, "os name should be identified")
+	assert.Equal(t, "SUSE Linux Enterprise Server 15 SP2", di.Title, "os title should be identified")
+	assert.Equal(t, "15.2", di.Version, "os version should be identified")
+	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"suse", "linux", "unix", "os"}, di.Family)
+	assert.Equal(t, map[string]string{
+		"distro-id":  "sles",
+		"variant-id": "sles-sap",
+	}, di.Labels)
+}
+
 func TestSuse5MicroDetector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-suse-micro-5.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/testdata/detect-suse-sles-15-sap.toml
+++ b/providers/os/detector/testdata/detect-suse-sles-15-sap.toml
@@ -1,0 +1,21 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "5.3.18-24.46-default"
+
+[files."/etc/os-release"]
+content = """
+NAME="SLES"
+VERSION="15-SP2"
+VERSION_ID="15.2"
+PRETTY_NAME="SUSE Linux Enterprise Server 15 SP2"
+ID="sles"
+ID_LIKE="suse"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles:15:sp2"
+VARIANT_ID="sles-sap"
+"""

--- a/providers/os/resources/purl/platform_purl.go
+++ b/providers/os/resources/purl/platform_purl.go
@@ -31,6 +31,12 @@ func NewPlatformPurl(platform *inventory.Platform) (string, error) {
 	}
 	qualifiers[QualifierDistro] = strings.Join(distroQualifiers, "-")
 
+	// e.g. used on suse linux
+	variantID, ok := platform.Labels["variant-id"]
+	if ok && variantID != "" {
+		qualifiers["variant-id"] = variantID
+	}
+
 	return packageurl.NewPackageURL(
 		string(Type_X_Platform),
 		platform.Name,


### PR DESCRIPTION
This PR adds support to detect Suse SLES variants.

```
→ connected to SUSE Linux Enterprise Server 15 SP2
  ___ _ __   __ _ _   _  ___ _ __ _   _ 
 / __| '_ \ / _` | | | |/ _ \ '__| | | |
| (__| | | | (_| | |_| |  __/ |  | |_| |
 \___|_| |_|\__, |\__,_|\___|_|   \__, |
  mondoo™      |_|                |___/  interactive shell

cnquery> asset.platformMetadata
asset.platformMetadata: {
  distro-id: "sles"
  variant-id: "sles-sap"
}
```