### PR TITLE
Add status to sbom package

### DIFF
--- a/sbom/sbom.proto
+++ b/sbom/sbom.proto
@@ -236,6 +236,8 @@ message Package {
   string origin = 22;
   // Package Vendor/Publisher
   string vendor = 23;
+  // Package Status, eg "COMMITED"
+  string status = 24;
 }
 
 enum EvidenceType {


### PR DESCRIPTION
Adds the status field to the sbom proto so we can use for determining efix in server. 