### PR TITLE
✨ add docs to builtin types, expose their schema, and operators

### DIFF
--- a/cli/execruntime/README.md
+++ b/cli/execruntime/README.md
@@ -14,7 +14,7 @@ env.Name
 * Azure Build Pipeline [Spec](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops)
 * GitLab [Spec](https://docs.gitlab.com/ee/ci/variables/)
 * Google Cloud Build [Spec](https://cloud.google.com/cloud-build/docs/configuring-builds/substitute-variable-values#using_default_substitutions)
-* CircleCI [Spec](https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables)
+* CircleCI [Spec](https://circleci.com/docs/env-vars/#built-in-environment-variables)
 * Jenkins [Spec](https://wiki.jenkins.io/display/JENKINS/Building+a+software+project#Buildingasoftwareproject-belowJenkinsSetEnvironmentVariables)
 * Travis [Spec](https://docs.travis-ci.com/user/environment-variables/#default-environment-variables)
 * GoCD [Spec](https://docs.gocd.org/current/faq/environment_variables.html)

--- a/cli/execruntime/env_circle.go
+++ b/cli/execruntime/env_circle.go
@@ -5,7 +5,7 @@ package execruntime
 
 const CIRCLE = "circle"
 
-// see https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
+// see https://circleci.com/docs/env-vars/#built-in-environment-variables
 var circleciEnv = &RuntimeEnv{
 	Id:        CIRCLE,
 	Name:      "CircleCI",

--- a/mqlc/builtin.go
+++ b/mqlc/builtin.go
@@ -411,8 +411,11 @@ func availableFields(c *compiler, typ types.Type) map[string]llx.Documentation {
 	return res
 }
 
+// BuiltinSchema captures all internal types and their metadata.
 // We could have just as well used the `resources.Schema` here.
-// However, semantically t
+// However, semantically we are documenting types and not resources here.
+// The difference may not matter to an end-user (everything looks like types),
+// but it matters internally since they are handled differently.
 type BuiltinSchema struct {
 	Types map[string]*resources.ResourceInfo
 }

--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -839,7 +839,7 @@ func (c *compiler) compileBuiltinFunction(h *compileHandler, id string, binding 
 		return types.Nil, err
 	}
 
-	resType := h.typ(binding.typ)
+	resType := h.returnType(binding.typ)
 	c.addChunk(&llx.Chunk{
 		Call: llx.Chunk_FUNCTION,
 		Id:   id,

--- a/mqlc/parser/operators.go
+++ b/mqlc/parser/operators.go
@@ -28,7 +28,7 @@ const (
 	OpRemainder
 )
 
-var operatorsMap = map[string]Operator{
+var Operators = map[string]Operator{
 	"=":  OpAssignment,
 	"&&": OpAnd,
 	"||": OpOr,
@@ -51,7 +51,7 @@ var operatorsStrings map[Operator]string
 
 func init() {
 	operatorsStrings = make(map[Operator]string)
-	for k, v := range operatorsMap {
+	for k, v := range Operators {
 		operatorsStrings[v] = k
 	}
 }
@@ -64,7 +64,7 @@ func (o *Operator) Capture(s []string) error {
 		sop += s[1]
 	}
 
-	*o = operatorsMap[sop]
+	*o = Operators[sop]
 	return nil
 }
 

--- a/mqlc/parser/parser.go
+++ b/mqlc/parser/parser.go
@@ -29,17 +29,18 @@ var (
 
 var tokenNames map[rune]string
 
+const LexerRegex = `(\s+)` +
+	`|(?P<Ident>[a-zA-Z$_][a-zA-Z0-9_]*)` +
+	`|(?P<Float>[-+]?\d*\.\d+([eE][-+]?\d+)?)` +
+	`|(?P<Int>[-+]?\d+([eE][-+]?\d+)?)` +
+	`|(?P<String>'[^']*'|"[^"]*")` +
+	`|(?P<Comment>(//|#)[^\n]*(\n|\z))` +
+	`|(?P<Regex>/([^\\/]+|\\.)+/[msi]*)` +
+	`|(?P<Op>[-+*/%,:.=<>!|&~;])` +
+	`|(?P<Call>[(){}\[\]])`
+
 func init() {
-	mqlLexer = lexer.Must(lexer.Regexp(`(\s+)` +
-		`|(?P<Ident>[a-zA-Z$_][a-zA-Z0-9_]*)` +
-		`|(?P<Float>[-+]?\d*\.\d+([eE][-+]?\d+)?)` +
-		`|(?P<Int>[-+]?\d+([eE][-+]?\d+)?)` +
-		`|(?P<String>'[^']*'|"[^"]*")` +
-		`|(?P<Comment>(//|#)[^\n]*(\n|\z))` +
-		`|(?P<Regex>/([^\\/]+|\\.)+/[msi]*)` +
-		`|(?P<Op>[-+*/%,:.=<>!|&~;])` +
-		`|(?P<Call>[(){}\[\]])`,
-	))
+	mqlLexer = lexer.Must(lexer.Regexp(LexerRegex))
 
 	syms := mqlLexer.Symbols()
 

--- a/types/types.go
+++ b/types/types.go
@@ -271,10 +271,25 @@ var labelfun map[byte]func(Type) string
 
 func init() {
 	labelfun = map[byte]func(Type) string{
-		byteArray:    func(s Type) string { return "[]" + s.Label() },
-		byteMap:      func(s Type) string { return "map[" + Type(s[0]).Label() + "]" + s[1:].Label() },
-		byteResource: func(s Type) string { return string(s) },
-		byteFunction: func(f Type) string { return "function(..??..)" },
+		byteArray: func(s Type) string {
+			if s == "" {
+				return "[]"
+			}
+			return "[]" + s.Label()
+		},
+		byteMap: func(s Type) string {
+			if s == "" {
+				return "map"
+			}
+			return "map[" + Type(s[0]).Label() + "]" + s[1:].Label()
+		},
+		byteResource: func(s Type) string {
+			if s == "" {
+				return "resource"
+			}
+			return string(s)
+		},
+		byteFunction: func(f Type) string { return "func()" },
 	}
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -118,6 +118,32 @@ const (
 	Range = Type(rune(byteRange))
 )
 
+// All returns a list of all types available
+func All() []Type {
+	return []Type{
+		Unset,
+		Any,
+		Nil,
+		Ref,
+		Bool,
+		Int,
+		Float,
+		String,
+		Regex,
+		Time,
+		Dict,
+		Score,
+		Block,
+		Empty,
+		Version,
+		IP,
+		ArrayLike,
+		MapLike,
+		ResourceLike,
+		FunctionLike,
+	}
+}
+
 // NotSet returns true if the type has no information
 func (typ Type) NotSet() bool {
 	return typ == ""

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -33,7 +33,7 @@ func TestTypes(t *testing.T) {
 		{T: Array(String), ExpectedLabel: "[]string"},
 		{T: Map(String, String), ExpectedLabel: "map[string]string"},
 		{T: Resource("mockresource"), ExpectedLabel: "mockresource"},
-		{T: Function('f', []Type{String, Int}), ExpectedLabel: "function(..??..)"},
+		{T: Function('f', []Type{String, Int}), ExpectedLabel: "func()"},
 	}
 
 	for i := range list {


### PR DESCRIPTION
This only gets the ball rolling, but it starts to expose these builtin types and starts to add docs to them. A lot more work needs to be done to give docs to all of them, but it gets us started at least.

We now also get programmatic access to the `mqlc.BuiltinDocs`, which is a `Schema` containing all our types and their fields and functions.