### PR TITLE
✨ Safe manipulation of `inventory.Platform`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -117,7 +117,7 @@ require (
 )
 
 require (
-	dario.cat/mergo v1.0.1 // indirect
+	dario.cat/mergo v1.0.1
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
 	github.com/ChrisTrenkamp/goxpath v0.0.0-20210404020558-97928f7e12b6 // indirect
 	github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092 // indirect

--- a/providers-sdk/v1/inventory/asset.go
+++ b/providers-sdk/v1/inventory/asset.go
@@ -178,3 +178,12 @@ func (a *Asset) AddMondooLabels(root *Asset) {
 		}
 	}
 }
+
+// SetPlatform is an accessor to correctly set the platform of the asset.
+func (a *Asset) SetPlatform(pf *Platform) {
+	if a.Platform == nil {
+		a.Platform = pf
+	} else {
+		a.Platform.Merge(pf)
+	}
+}

--- a/providers-sdk/v1/inventory/asset.go
+++ b/providers-sdk/v1/inventory/asset.go
@@ -179,8 +179,9 @@ func (a *Asset) AddMondooLabels(root *Asset) {
 	}
 }
 
-// SetPlatform is an accessor to correctly set the platform of the asset.
-func (a *Asset) SetPlatform(pf *Platform) {
+// MergePlatform merges the provided platform into the asset's platform.
+// If the asset's platform is `nil`, the provided platform is set.
+func (a *Asset) MergePlatform(pf *Platform) {
 	if a.Platform == nil {
 		a.Platform = pf
 	} else {

--- a/providers-sdk/v1/inventory/inventory.go
+++ b/providers-sdk/v1/inventory/inventory.go
@@ -7,8 +7,10 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"slices"
 	"strings"
 
+	"dario.cat/mergo"
 	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/segmentio/ksuid"
@@ -318,13 +320,20 @@ var (
 	FAMILY_WINDOWS = "windows"
 )
 
-func (p *Platform) IsFamily(family string) bool {
-	for i := range p.Family {
-		if p.Family[i] == family {
-			return true
+// Merge performs a deep merge of the provided platform.
+func (p *Platform) Merge(pf *Platform) {
+	if pf != nil {
+		if err := mergo.Merge(p, pf, mergo.WithOverride); err != nil {
+			log.Error().Err(err).
+				Interface("target", p).
+				Interface("source", pf).
+				Msg("unable to merge platform details")
 		}
 	}
-	return false
+}
+
+func (p *Platform) IsFamily(family string) bool {
+	return slices.Contains(p.Family, family)
 }
 
 func (p *Platform) PrettyTitle() string {

--- a/providers/os/provider/detector.go
+++ b/providers/os/provider/detector.go
@@ -47,11 +47,11 @@ func mapDetectors(raw []string) map[string]struct{} {
 }
 
 func (s *Service) detect(asset *inventory.Asset, conn shared.Connection) error {
-	var ok bool
-	asset.Platform, ok = detector.DetectOS(conn)
+	pf, ok := detector.DetectOS(conn)
 	if !ok {
 		return errors.New("failed to detect OS")
 	}
+	asset.SetPlatform(pf)
 	if asset.Platform.Kind == "" {
 		asset.Platform.Kind = inventory.AssetKindBaremetal
 	}

--- a/providers/os/provider/detector.go
+++ b/providers/os/provider/detector.go
@@ -51,7 +51,7 @@ func (s *Service) detect(asset *inventory.Asset, conn shared.Connection) error {
 	if !ok {
 		return errors.New("failed to detect OS")
 	}
-	asset.SetPlatform(pf)
+	asset.MergePlatform(pf)
 	if asset.Platform.Kind == "" {
 		asset.Platform.Kind = inventory.AssetKindBaremetal
 	}

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -379,7 +379,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 				}
 				asset.PlatformIds = fingerprint.PlatformIDs
 				asset.IdDetector = fingerprint.ActiveIdDetectors
-				asset.SetPlatform(p)
+				asset.MergePlatform(p)
 				appendRelatedAssetsFromFingerprint(fingerprint, asset)
 			}
 		case shared.Type_Device.String():
@@ -397,7 +397,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 				}
 				asset.PlatformIds = fingerprint.PlatformIDs
 				asset.IdDetector = fingerprint.ActiveIdDetectors
-				asset.SetPlatform(p)
+				asset.MergePlatform(p)
 				appendRelatedAssetsFromFingerprint(fingerprint, asset)
 			}
 
@@ -412,7 +412,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 				asset.Name = fingerprint.Name
 				asset.PlatformIds = fingerprint.PlatformIDs
 				asset.IdDetector = fingerprint.ActiveIdDetectors
-				asset.SetPlatform(p)
+				asset.MergePlatform(p)
 				appendRelatedAssetsFromFingerprint(fingerprint, asset)
 			}
 
@@ -427,7 +427,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 				asset.Name = fingerprint.Name
 				asset.PlatformIds = fingerprint.PlatformIDs
 				asset.IdDetector = fingerprint.ActiveIdDetectors
-				asset.SetPlatform(p)
+				asset.MergePlatform(p)
 				appendRelatedAssetsFromFingerprint(fingerprint, asset)
 			}
 
@@ -442,7 +442,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 				asset.Name = fingerprint.Name
 				asset.PlatformIds = fingerprint.PlatformIDs
 				asset.IdDetector = fingerprint.ActiveIdDetectors
-				asset.SetPlatform(p)
+				asset.MergePlatform(p)
 				appendRelatedAssetsFromFingerprint(fingerprint, asset)
 			}
 
@@ -494,7 +494,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 					asset.Name = fingerprint.Name
 					asset.PlatformIds = fingerprint.PlatformIDs
 					asset.IdDetector = fingerprint.ActiveIdDetectors
-					asset.SetPlatform(p)
+					asset.MergePlatform(p)
 				}
 			} else {
 				// In this case asset.Name should already be set via the inventory

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -379,7 +379,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 				}
 				asset.PlatformIds = fingerprint.PlatformIDs
 				asset.IdDetector = fingerprint.ActiveIdDetectors
-				asset.Platform = p
+				asset.SetPlatform(p)
 				appendRelatedAssetsFromFingerprint(fingerprint, asset)
 			}
 		case shared.Type_Device.String():
@@ -397,7 +397,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 				}
 				asset.PlatformIds = fingerprint.PlatformIDs
 				asset.IdDetector = fingerprint.ActiveIdDetectors
-				asset.Platform = p
+				asset.SetPlatform(p)
 				appendRelatedAssetsFromFingerprint(fingerprint, asset)
 			}
 
@@ -412,7 +412,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 				asset.Name = fingerprint.Name
 				asset.PlatformIds = fingerprint.PlatformIDs
 				asset.IdDetector = fingerprint.ActiveIdDetectors
-				asset.Platform = p
+				asset.SetPlatform(p)
 				appendRelatedAssetsFromFingerprint(fingerprint, asset)
 			}
 
@@ -427,7 +427,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 				asset.Name = fingerprint.Name
 				asset.PlatformIds = fingerprint.PlatformIDs
 				asset.IdDetector = fingerprint.ActiveIdDetectors
-				asset.Platform = p
+				asset.SetPlatform(p)
 				appendRelatedAssetsFromFingerprint(fingerprint, asset)
 			}
 
@@ -442,7 +442,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 				asset.Name = fingerprint.Name
 				asset.PlatformIds = fingerprint.PlatformIDs
 				asset.IdDetector = fingerprint.ActiveIdDetectors
-				asset.Platform = p
+				asset.SetPlatform(p)
 				appendRelatedAssetsFromFingerprint(fingerprint, asset)
 			}
 
@@ -494,7 +494,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 					asset.Name = fingerprint.Name
 					asset.PlatformIds = fingerprint.PlatformIDs
 					asset.IdDetector = fingerprint.ActiveIdDetectors
-					asset.Platform = p
+					asset.SetPlatform(p)
 				}
 			} else {
 				// In this case asset.Name should already be set via the inventory

--- a/providers/terraform/provider/detector.go
+++ b/providers/terraform/provider/detector.go
@@ -51,7 +51,7 @@ func (s *Service) detect(asset *inventory.Asset, _ *connection.Connection) error
 			TechnologyUrlSegments: []string{"iac", "terraform", "hcl"},
 		}
 	}
-	asset.SetPlatform(p)
+	asset.MergePlatform(p)
 
 	// we always prefer the git url since it is more reliable
 	url, ok := asset.Connections[0].Options["ssh-url"]

--- a/providers/terraform/provider/detector.go
+++ b/providers/terraform/provider/detector.go
@@ -17,7 +17,7 @@ import (
 	"go.mondoo.com/cnquery/v11/utils/urlx"
 )
 
-func (s *Service) detect(asset *inventory.Asset, conn *connection.Connection) error {
+func (s *Service) detect(asset *inventory.Asset, _ *connection.Connection) error {
 	var p *inventory.Platform
 	connType := asset.Connections[0].Type
 	switch connType {
@@ -51,7 +51,7 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.Connection) er
 			TechnologyUrlSegments: []string{"iac", "terraform", "hcl"},
 		}
 	}
-	asset.Platform = p
+	asset.SetPlatform(p)
 
 	// we always prefer the git url since it is more reliable
 	url, ok := asset.Connections[0].Options["ssh-url"]


### PR DESCRIPTION
One of the core data structures of Mondoo’s plugin system is the `inventory.Asset` struct that contains details about an asset, including platform information that is stored in `Asset.Platform`.

The `inventory.Platform` struct stores important information used by the Mondoo platform (`server`) like the runtime, the platform kind, and additional metadata.

When we run `cnquery` or `cnspec` most of the times the first thing we do is an initial discovery to detect the asset and platform we are going to scan, then we pass these core data structures to our providers where, sometimes, we do additional discovery and enrichment of data. An example of this is the discovery of AWS instances (`aws` provider) that later gets enriched with additional information from the `os` provider.

# Change

We are introducing two accessors. One at the Asset level and the other one directly into the Platform struct. These new accessor should be used through out the code base to safely manipulate the platform of an asset.