### PR TITLE
🧹 do not show warning if a python directory is not existing

### DIFF
--- a/providers/os/resources/python.go
+++ b/providers/os/resources/python.go
@@ -209,7 +209,7 @@ func collectPythonPackages(runtime *plugin.Runtime, fs afero.Fs, path string) ([
 	fileList, err := afs.ReadDir(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Warn().Err(err).Str("dir", path).Msg("unable to open directory")
+			log.Debug().Err(err).Str("dir", path).Msg("unable to open directory")
 			return []python.PackageDetails{}, nil
 		}
 		return nil, err


### PR DESCRIPTION
fixes #5402