### PR TITLE
🧹 use platform name in purl not as namspace, add build qualifier

### DIFF
--- a/providers/os/resources/purl/platform_purl.go
+++ b/providers/os/resources/purl/platform_purl.go
@@ -29,7 +29,12 @@ func NewPlatformPurl(platform *inventory.Platform) (string, error) {
 	} else if platform.Build != "" {
 		distroQualifiers = append(distroQualifiers, platform.Build)
 	}
+
 	qualifiers[QualifierDistro] = strings.Join(distroQualifiers, "-")
+
+	if platform.Build != "" {
+		qualifiers["build"] = platform.Build
+	}
 
 	// e.g. used on suse linux
 	variantID, ok := platform.Labels["variant-id"]
@@ -39,8 +44,8 @@ func NewPlatformPurl(platform *inventory.Platform) (string, error) {
 
 	return packageurl.NewPackageURL(
 		string(Type_X_Platform),
-		platform.Name,
 		"",
+		platform.Name,
 		platform.Version,
 		NewQualifiers(qualifiers),
 		"",

--- a/providers/os/resources/purl/platform_purl_test.go
+++ b/providers/os/resources/purl/platform_purl_test.go
@@ -23,7 +23,7 @@ func TestNewPlatformPurl(t *testing.T) {
 				Name:    "ubuntu",
 				Version: "22.04",
 			},
-			want:    "pkg:platform/ubuntu/@22.04?distro=ubuntu-22.04",
+			want:    "pkg:platform/ubuntu@22.04?distro=ubuntu-22.04",
 			wantErr: "",
 		},
 		{
@@ -32,7 +32,7 @@ func TestNewPlatformPurl(t *testing.T) {
 				Name:    "windows",
 				Version: "19045",
 			},
-			want:    "pkg:platform/windows/@19045?distro=windows-19045",
+			want:    "pkg:platform/windows@19045?distro=windows-19045",
 			wantErr: "",
 		},
 		{
@@ -42,7 +42,7 @@ func TestNewPlatformPurl(t *testing.T) {
 				Version: "22.04",
 				Arch:    "amd64",
 			},
-			want:    "pkg:platform/ubuntu/@22.04?arch=amd64&distro=ubuntu-22.04",
+			want:    "pkg:platform/ubuntu@22.04?arch=amd64&distro=ubuntu-22.04",
 			wantErr: "",
 		},
 		{
@@ -52,7 +52,7 @@ func TestNewPlatformPurl(t *testing.T) {
 				Version: "22.04",
 				Arch:    "x86_64",
 			},
-			want:    "pkg:platform/ubuntu/@22.04?arch=x86_64&distro=ubuntu-22.04",
+			want:    "pkg:platform/ubuntu@22.04?arch=x86_64&distro=ubuntu-22.04",
 			wantErr: "",
 		},
 		{
@@ -62,17 +62,17 @@ func TestNewPlatformPurl(t *testing.T) {
 				Version: "22.04",
 				Arch:    "arm64",
 			},
-			want:    "pkg:platform/ubuntu/@22.04?arch=arm64&distro=ubuntu-22.04",
+			want:    "pkg:platform/ubuntu@22.04?arch=arm64&distro=ubuntu-22.04",
 			wantErr: "",
 		},
 		{
-			name: "macplatform with apple silicon",
+			name: "macOS with apple silicon",
 			platform: &inventory.Platform{
-				Name:    "macplatform",
+				Name:    "macos",
 				Version: "14.5.1",
 				Arch:    "arm64",
 			},
-			want:    "pkg:platform/macplatform/@14.5.1?arch=arm64&distro=macplatform-14.5.1",
+			want:    "pkg:platform/macos@14.5.1?arch=arm64&distro=macos-14.5.1",
 			wantErr: "",
 		},
 		{
@@ -82,7 +82,7 @@ func TestNewPlatformPurl(t *testing.T) {
 				Version: "19045",
 				Arch:    "x86",
 			},
-			want:    "pkg:platform/windows/@19045?arch=x86&distro=windows-19045",
+			want:    "pkg:platform/windows@19045?arch=x86&distro=windows-19045",
 			wantErr: "",
 		},
 		{
@@ -91,7 +91,7 @@ func TestNewPlatformPurl(t *testing.T) {
 				Name:    "vsphere",
 				Version: "7.0.3",
 			},
-			want:    "pkg:platform/vsphere/@7.0.3?distro=vsphere-7.0.3",
+			want:    "pkg:platform/vsphere@7.0.3?distro=vsphere-7.0.3",
 			wantErr: "",
 		},
 		{
@@ -101,7 +101,7 @@ func TestNewPlatformPurl(t *testing.T) {
 				Version: "7.0.3",
 				Arch:    "x86_64",
 			},
-			want:    "pkg:platform/esxi/@7.0.3?arch=x86_64&distro=esxi-7.0.3",
+			want:    "pkg:platform/esxi@7.0.3?arch=x86_64&distro=esxi-7.0.3",
 			wantErr: "",
 		},
 		{
@@ -110,7 +110,7 @@ func TestNewPlatformPurl(t *testing.T) {
 				Name:    "k8s-deployment",
 				Version: "1.27",
 			},
-			want:    "pkg:platform/k8s-deployment/@1.27?distro=k8s-deployment-1.27",
+			want:    "pkg:platform/k8s-deployment@1.27?distro=k8s-deployment-1.27",
 			wantErr: "",
 		},
 		{
@@ -118,7 +118,7 @@ func TestNewPlatformPurl(t *testing.T) {
 			platform: &inventory.Platform{
 				Name: "aws",
 			},
-			want:    "pkg:platform/aws/?distro=aws",
+			want:    "pkg:platform/aws?distro=aws",
 			wantErr: "",
 		},
 		{
@@ -126,7 +126,7 @@ func TestNewPlatformPurl(t *testing.T) {
 			platform: &inventory.Platform{
 				Name: "gcp",
 			},
-			want:    "pkg:platform/gcp/?distro=gcp",
+			want:    "pkg:platform/gcp?distro=gcp",
 			wantErr: "",
 		},
 		{
@@ -134,7 +134,7 @@ func TestNewPlatformPurl(t *testing.T) {
 			platform: &inventory.Platform{
 				Name: "azure",
 			},
-			want:    "pkg:platform/azure/?distro=azure",
+			want:    "pkg:platform/azure?distro=azure",
 			wantErr: "",
 		},
 		{
@@ -143,7 +143,7 @@ func TestNewPlatformPurl(t *testing.T) {
 				Name:  "centplatform",
 				Build: "8.5",
 			},
-			want:    "pkg:platform/centplatform/?distro=centplatform-8.5",
+			want:    "pkg:platform/centplatform?build=8.5&distro=centplatform-8.5",
 			wantErr: "",
 		},
 		{
@@ -159,7 +159,7 @@ func TestNewPlatformPurl(t *testing.T) {
 				Version: "12",
 				Title:   "Debian GNU/Linux 12 (bookworm)",
 			},
-			want:    "pkg:platform/debian/@12?distro=debian-12",
+			want:    "pkg:platform/debian@12?distro=debian-12",
 			wantErr: "",
 		},
 	}

--- a/sbom/generator/generator.go
+++ b/sbom/generator/generator.go
@@ -82,6 +82,7 @@ func GenerateBom(r *reporter.Report) []*sbom.Sbom {
 				bom.Asset.Name = rb.Asset.Name
 				bom.Asset.Platform.Name = rb.Asset.Platform
 				bom.Asset.Platform.Version = rb.Asset.Version
+				bom.Asset.Platform.Build = rb.Asset.Build
 				bom.Asset.Platform.Family = rb.Asset.Family
 				bom.Asset.Platform.Arch = rb.Asset.Arch
 				bom.Asset.Platform.Cpes = rb.Asset.CPEs

--- a/sbom/generator/report_collection.go
+++ b/sbom/generator/report_collection.go
@@ -16,6 +16,7 @@ type BomAsset struct {
 	Name     string            `json:"name,omitempty"`
 	Platform string            `json:"platform,omitempty"`
 	Version  string            `json:"version,omitempty"`
+	Build    string            `json:"build,omitempty"`
 	Family   []string          `json:"family,omitempty"`
 	Arch     string            `json:"arch,omitempty"`
 	CPEs     []string          `json:"cpes.map,omitempty"`

--- a/sbom/pack/pack.go
+++ b/sbom/pack/pack.go
@@ -5,6 +5,7 @@ package pack
 
 import (
 	_ "embed"
+
 	"go.mondoo.com/cnquery/v11/explorer"
 )
 

--- a/sbom/pack/sbom.mql.yaml
+++ b/sbom/pack/sbom.mql.yaml
@@ -10,7 +10,7 @@ packs:
     queries:
       - uid: mondoo-sbom-asset
         title: Retrieve information about the Platform
-        mql: asset { name platform version family arch ids labels cpes.map(uri) }
+        mql: asset { name platform version build family arch ids labels cpes.map(uri) }
       - uid: mondoo-sbom-packages
         title: Retrieve list of installed packages
         mql: packages { name version purl cpes.map(uri) arch origin format files.map(path) }


### PR DESCRIPTION
- we used the platform name in the namespace but not the name
- add build qualifier to include build versions in the purl
- collects build version for sbom generation