### PR TITLE
⭐ parse.xml

### DIFF
--- a/providers-sdk/v1/testutils/testdata/arch.json
+++ b/providers-sdk/v1/testutils/testdata/arch.json
@@ -155,6 +155,31 @@
         },
         {
           "Resource": "file",
+          "ID": "/dummy.xml",
+          "Fields": {
+            "content": {
+              "type": "\u0007",
+              "value": "\u003croot\u003e\n  \u003cbox\u003e\n    \u003chello a=\"1\"/\u003e\n  \u003c/box\u003e\n  \u003cbox\u003e\n    \u003cworld b=\"2\"\u003e\n      \u003cc\u003e3\u003c/c\u003e\n      4\n    \u003c/world\u003e\n  \u003c/box\u003e\n  \u003cbox\u003e🌎\u003c/box\u003e\n\u003c/root\u003e\n\n"
+            },
+            "path": {
+              "type": "\u0007",
+              "value": "/dummy.xml"
+            },
+            "permissions": {
+              "type": "\u001bfile.permissions",
+              "value": {
+                "Name": "file.permissions",
+                "ID": "-rw-r--r--"
+              }
+            },
+            "size": {
+              "type": "\u0005",
+              "value": 141
+            }
+          }
+        },
+        {
+          "Resource": "file",
           "ID": "/dummy.null.json",
           "Fields": {
             "content": {

--- a/providers/os/resources/mql_test.go
+++ b/providers/os/resources/mql_test.go
@@ -100,8 +100,8 @@ func TestMap(t *testing.T) {
 			Expectation: int64(1),
 		},
 		{
-			Code:        "parse.xml('/dummy.xml').params.root.length",
-			Expectation: int64(2),
+			Code:        "parse.xml('/dummy.xml').params.root.box.length",
+			Expectation: int64(3),
 		},
 		{
 			Code:        "parse.json('/dummy.json').params.length",

--- a/providers/os/resources/mql_test.go
+++ b/providers/os/resources/mql_test.go
@@ -96,6 +96,14 @@ func TestMap(t *testing.T) {
 			Expectation: map[string]interface{}{"a": int64(1), "b": int64(2)},
 		},
 		{
+			Code:        "parse.xml('/dummy.xml').params.length",
+			Expectation: int64(1),
+		},
+		{
+			Code:        "parse.xml('/dummy.xml').params.root.length",
+			Expectation: int64(2),
+		},
+		{
 			Code:        "parse.json('/dummy.json').params.length",
 			Expectation: int64(13),
 		},

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -470,6 +470,17 @@ parse.json {
   params(content) dict
 }
 
+// Parse XML files
+parse.xml {
+  init(path string)
+  // File that is parsed
+  file file
+  // Raw content of the file that is parsed
+  content(file) string
+  // The parsed parameters defined in this file
+  params(content) dict
+}
+
 // Parse plist files
 parse.plist {
   init(path string)

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -154,6 +154,10 @@ func init() {
 			Init: initParseJson,
 			Create: createParseJson,
 		},
+		"parse.xml": {
+			Init: initParseXml,
+			Create: createParseXml,
+		},
 		"parse.plist": {
 			Init: initParsePlist,
 			Create: createParsePlist,
@@ -1074,6 +1078,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"parse.json.params": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlParseJson).GetParams()).ToDataRes(types.Dict)
+	},
+	"parse.xml.file": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlParseXml).GetFile()).ToDataRes(types.Resource("file"))
+	},
+	"parse.xml.content": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlParseXml).GetContent()).ToDataRes(types.String)
+	},
+	"parse.xml.params": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlParseXml).GetParams()).ToDataRes(types.Dict)
 	},
 	"parse.plist.file": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlParsePlist).GetFile()).ToDataRes(types.Resource("file"))
@@ -3268,6 +3281,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"parse.json.params": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlParseJson).Params, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
+		return
+	},
+	"parse.xml.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlParseXml).__id, ok = v.Value.(string)
+			return
+		},
+	"parse.xml.file": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlParseXml).File, ok = plugin.RawToTValue[*mqlFile](v.Value, v.Error)
+		return
+	},
+	"parse.xml.content": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlParseXml).Content, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"parse.xml.params": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlParseXml).Params, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
 		return
 	},
 	"parse.plist.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8229,6 +8258,79 @@ func (c *mqlParseJson) GetContent() *plugin.TValue[string] {
 }
 
 func (c *mqlParseJson) GetParams() *plugin.TValue[interface{}] {
+	return plugin.GetOrCompute[interface{}](&c.Params, func() (interface{}, error) {
+		vargContent := c.GetContent()
+		if vargContent.Error != nil {
+			return nil, vargContent.Error
+		}
+
+		return c.params(vargContent.Data)
+	})
+}
+
+// mqlParseXml for the parse.xml resource
+type mqlParseXml struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlParseXmlInternal it will be used here
+	File plugin.TValue[*mqlFile]
+	Content plugin.TValue[string]
+	Params plugin.TValue[interface{}]
+}
+
+// createParseXml creates a new instance of this resource
+func createParseXml(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlParseXml{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+	res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("parse.xml", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlParseXml) MqlName() string {
+	return "parse.xml"
+}
+
+func (c *mqlParseXml) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlParseXml) GetFile() *plugin.TValue[*mqlFile] {
+	return &c.File
+}
+
+func (c *mqlParseXml) GetContent() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Content, func() (string, error) {
+		vargFile := c.GetFile()
+		if vargFile.Error != nil {
+			return "", vargFile.Error
+		}
+
+		return c.content(vargFile.Data)
+	})
+}
+
+func (c *mqlParseXml) GetParams() *plugin.TValue[interface{}] {
 	return plugin.GetOrCompute[interface{}](&c.Params, func() (interface{}, error) {
 		vargContent := c.GetContent()
 		if vargContent.Error != nil {

--- a/providers/os/resources/os.lr.manifest.yaml
+++ b/providers/os/resources/os.lr.manifest.yaml
@@ -767,6 +767,12 @@ resources:
       file: {}
       params: {}
     min_mondoo_version: 5.15.0
+  parse.xml:
+    fields:
+      content: {}
+      file: {}
+      params: {}
+    min_mondoo_version: 9.0.0
   parse.yaml:
     fields:
       content: {}

--- a/providers/os/resources/parse.go
+++ b/providers/os/resources/parse.go
@@ -165,7 +165,9 @@ func (x *xmlElem) addAttr(a []xml.Attr) {
 	if len(a) == 0 {
 		return
 	}
-	x.attributes = map[string]string{}
+	if x.attributes == nil {
+		x.attributes = map[string]string{}
+	}
 	for ai := range a {
 		attr := a[ai]
 		x.attributes[attrName(attr.Name)] = attr.Value

--- a/providers/os/resources/parse.go
+++ b/providers/os/resources/parse.go
@@ -204,10 +204,12 @@ func (x *xmlElem) UnmarshalXML(decoder *xml.Decoder, start xml.StartElement) err
 		case xml.CharData:
 			cur := path[len(path)-1]
 			v := strings.TrimSpace(string(elem))
-			cur.children = append(cur.children, &xmlElem{
-				data:      v,
-				isElement: false,
-			})
+			if v != "" {
+				cur.children = append(cur.children, &xmlElem{
+					data:      v,
+					isElement: false,
+				})
+			}
 		}
 	}
 }
@@ -229,7 +231,11 @@ func (x *xmlElem) _params() (string, bool, map[string]any) {
 		if !isElem {
 			field := "__text"
 			if cur, ok := res[field]; ok {
-				res[field] = cur.(string) + data
+				if cur.(string) != "" {
+					res[field] = cur.(string) + "\n" + data
+				} else {
+					res[field] = data
+				}
 			} else {
 				res[field] = data
 			}

--- a/providers/os/resources/parse.go
+++ b/providers/os/resources/parse.go
@@ -6,7 +6,9 @@ package resources
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"errors"
+	"io"
 	"strings"
 
 	"go.mondoo.com/cnquery/v11/checksums"
@@ -128,6 +130,184 @@ func (s *mqlParseJson) params(content string) (interface{}, error) {
 		return nil, err
 	}
 	return res, nil
+}
+
+func initParseXml(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if err := fileFromPathOrContent(runtime, args); err != nil {
+		return nil, nil, err
+	}
+
+	return args, nil, nil
+}
+
+func (s *mqlParseXml) id() (string, error) {
+	if s.File.Data == nil {
+		return "", errors.New("no file provided for parse.json")
+	}
+
+	file := s.File.Data
+	return file.Path.Data, nil
+}
+
+func (s *mqlParseXml) content(file *mqlFile) (string, error) {
+	c := file.GetContent()
+	return c.Data, c.Error
+}
+
+type xmlElem struct {
+	attributes map[string]string
+	children   []*xmlElem
+	data       string
+	isElement  bool
+}
+
+func (x *xmlElem) addAttr(a []xml.Attr) {
+	if len(a) == 0 {
+		return
+	}
+	x.attributes = map[string]string{}
+	for ai := range a {
+		attr := a[ai]
+		x.attributes[attrName(attr.Name)] = attr.Value
+	}
+}
+
+func (x *xmlElem) UnmarshalXML(decoder *xml.Decoder, start xml.StartElement) error {
+	x.data = start.Name.Local
+	x.isElement = true
+	path := []*xmlElem{
+		x,
+	}
+	path[0].addAttr(start.Attr)
+
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+
+		switch elem := token.(type) {
+		case xml.StartElement:
+			nu := &xmlElem{
+				data:      elem.Name.Local,
+				isElement: true,
+			}
+			nu.addAttr(elem.Attr)
+			parent := path[len(path)-1]
+			parent.children = append(parent.children, nu)
+			path = append(path, nu)
+		case xml.EndElement:
+			path = path[:len(path)-1]
+		case xml.CharData:
+			cur := path[len(path)-1]
+			v := strings.TrimSpace(string(elem))
+			cur.children = append(cur.children, &xmlElem{
+				data:      v,
+				isElement: false,
+			})
+		}
+	}
+}
+
+func (x *xmlElem) _params() (string, bool, map[string]any) {
+	if !x.isElement {
+		return x.data, x.isElement, nil
+	}
+	res := map[string]any{}
+	for k, v := range x.attributes {
+		res["@"+k] = v
+	}
+
+	for i := range x.children {
+		child := x.children[i]
+		data, isElem, params := child._params()
+
+		// text data is added flat
+		if !isElem {
+			field := "__text"
+			if cur, ok := res[field]; ok {
+				res[field] = cur.(string) + data
+			} else {
+				res[field] = data
+			}
+			continue
+		}
+
+		if len(params) == 1 {
+			if text, ok := params["__text"]; ok {
+				exist, ok := res[data]
+				if !ok {
+					res[data] = text
+					continue
+				}
+
+				arr, ok := exist.([]any)
+				if ok {
+					arr = append(arr, text)
+				} else {
+					arr = []any{exist, text}
+				}
+				res[data] = arr
+
+				continue
+			}
+		}
+
+		// if the key doesn't exist, we just store it as a flat value
+		cur, ok := res[data]
+		if !ok {
+			res[data] = params
+			continue
+		}
+
+		// if the key does exist, we need to turn it into a list or append
+		// to any existing list
+		arr, ok := cur.([]any)
+		if ok {
+			arr = append(arr, params)
+		} else {
+			arr = []any{cur, params}
+		}
+		res[data] = arr
+	}
+
+	return x.data, true, res
+}
+
+func (x *xmlElem) params() map[string]any {
+	key, isElem, params := x._params()
+	if !isElem {
+		return map[string]any{"__text": key}
+	}
+	if len(params) == 1 {
+		if data, ok := params["__text"]; ok {
+			return map[string]any{key: data}
+		}
+	}
+	return map[string]any{key: params}
+}
+
+func attrName(n xml.Name) string {
+	if n.Space == "" {
+		return n.Local
+	}
+	return n.Space + ":" + n.Local
+}
+
+func (s *mqlParseXml) params(content string) (interface{}, error) {
+	if content == "" {
+		return nil, nil
+	}
+
+	var res xmlElem
+	if err := xml.Unmarshal([]byte(content), &res); err != nil {
+		return nil, err
+	}
+
+	return res.params(), nil
 }
 
 func initParseYaml(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/os/resources/parse_test.go
+++ b/providers/os/resources/parse_test.go
@@ -43,9 +43,19 @@ func TestParseXML(t *testing.T) {
 			Expectation: map[string]any{"root": map[string]any{}},
 		},
 		{
-			Code:        "parse.xml(content: '<root>world</root>').params",
+			Code:        "parse.xml(content: '<root>\n\t\t\n</root>').params",
+			ResultIndex: 0,
+			Expectation: map[string]any{"root": map[string]any{}},
+		},
+		{
+			Code:        "parse.xml(content: '<root>\n\tworld\n</root>').params",
 			ResultIndex: 0,
 			Expectation: map[string]any{"root": "world"},
+		},
+		{
+			Code:        "parse.xml(content: '<root>\n\tworld\n\twide\n</root>').params",
+			ResultIndex: 0,
+			Expectation: map[string]any{"root": "world\n\twide"},
 		},
 		{
 			Code:        "parse.xml(content: '<root><box /></root>').params",
@@ -66,14 +76,14 @@ func TestParseXML(t *testing.T) {
 			}}},
 		},
 		{
-			Code:        "parse.xml(content: '<root><box><hello a=\"1\"/></box><box><world b=\"2\"><c>3</c>4</world></box><box>🌎</box></root>').params",
+			Code:        "parse.xml(content: '<root><box><hello a=\"1\"/></box><box><world b=\"2\">1<c>3</c>4</world></box><box>🌎</box></root>').params",
 			ResultIndex: 0,
 			Expectation: map[string]any{"root": map[string]any{"box": []any{
 				map[string]any{"hello": map[string]any{"@a": "1"}},
 				map[string]any{"world": map[string]any{
 					"@b":     "2",
 					"c":      "3",
-					"__text": "4",
+					"__text": "1\n4",
 				}},
 				"🌎",
 			}}},

--- a/providers/os/resources/parse_test.go
+++ b/providers/os/resources/parse_test.go
@@ -34,3 +34,49 @@ func TestParseJson(t *testing.T) {
 		},
 	})
 }
+
+func TestParseXML(t *testing.T) {
+	x.TestSimple(t, []testutils.SimpleTest{
+		{
+			Code:        "parse.xml(content: '<root />').params",
+			ResultIndex: 0,
+			Expectation: map[string]any{"root": map[string]any{}},
+		},
+		{
+			Code:        "parse.xml(content: '<root>world</root>').params",
+			ResultIndex: 0,
+			Expectation: map[string]any{"root": "world"},
+		},
+		{
+			Code:        "parse.xml(content: '<root><box /></root>').params",
+			ResultIndex: 0,
+			Expectation: map[string]any{"root": map[string]any{"box": map[string]any{}}},
+		},
+		{
+			Code:        "parse.xml(content: '<root><box>world</box></root>').params",
+			ResultIndex: 0,
+			Expectation: map[string]any{"root": map[string]any{"box": "world"}},
+		},
+		{
+			Code:        "parse.xml(content: '<root><box>hello</box><box>world</box></root>').params",
+			ResultIndex: 0,
+			Expectation: map[string]any{"root": map[string]any{"box": []any{
+				"hello",
+				"world",
+			}}},
+		},
+		{
+			Code:        "parse.xml(content: '<root><box><hello a=\"1\"/></box><box><world b=\"2\"><c>3</c>4</world></box><box>🌎</box></root>').params",
+			ResultIndex: 0,
+			Expectation: map[string]any{"root": map[string]any{"box": []any{
+				map[string]any{"hello": map[string]any{"@a": "1"}},
+				map[string]any{"world": map[string]any{
+					"@b":     "2",
+					"c":      "3",
+					"__text": "4",
+				}},
+				"🌎",
+			}}},
+		},
+	})
+}


### PR DESCRIPTION
Add support for parsing XML files, either by providing the file or by providing the XML contents directly.

Using inline data:

```coffee
> parse.xml(content: '<root />').params
parse.xml.params: {
  root: {}
}
```

Via file `example.xml`:

```xml
<root>
  <box>
    <hello a="1"/>
  </box>
  <box>
    <world b="2">
      <c>3</c>
      4
    </world>
  </box>
  <box>🌎</box>
</root>
```

Running this in MQL:

```coffee
> parse.json('example.xml').params
parse.xml.params: {
  root: {
    box: [
      0: {
        hello: {
          @a: "1"
        }
      }
...
```

Since the conversion from XML to a flat (JSON-like) structure isn't standardized, we took an approach very similar to other formatters (e.g. [xq](https://github.com/sibprogrammer/xq), [jsonformatter](https://jsonformatter.org/xml-to-json)). This means:

- single items are added as a flat child element, e.g. the first `<box/>` element has a flat field `hello` above
- once there are multiple elements, they are turned into a list, e.g. `root.box` is an array above
- attributes are added as `@attribute` fields in the element
- if an element only has text contents, the value is just set to the text, e.g. `<root>val</root>` is turned into `{"root": "val"}`
- if an element has a mix of child elements and text contents, all text contents are added to the `__text` child field

Future consideration are to add access to the entire XML structure, which is more complex to traverse, but may be required for some use-cases. We will also handle streaming data separately (for all of these formats)