### PR TITLE
🐛 do not load all python package dependencies on init

### DIFF
--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -13148,7 +13148,7 @@ func (c *mqlPython) GetToplevel() *plugin.TValue[[]interface{}] {
 type mqlPythonPackage struct {
 	MqlRuntime *plugin.Runtime
 	__id string
-	// optional: if you define mqlPythonPackageInternal it will be used here
+	mqlPythonPackageInternal
 	Id plugin.TValue[string]
 	Name plugin.TValue[string]
 	File plugin.TValue[*mqlFile]


### PR DESCRIPTION
Seems like we try to pre-load all dependencies as MQL resources during initialization of python packages. It looks like in some cases this can result in a stack overflow. I don't fully understand python deps but at least with this new approach we will only populate the dependency field if explicitly requested. That should remove the stack overflow and hopefully makes the code easier to follow