### PR TITLE
⭐️ gcp: support storage lifecycle rules

### DIFF
--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -936,6 +936,80 @@ private gcp.project.storageService.bucket @defaults("id") {
   retentionPolicy dict
   // Encryption
   encryption dict
+  // Lifecycle configuration
+  lifecycle []gcp.project.storageService.bucket.lifecycleRule
+}
+
+// Google Cloud bucket's lifecycle configuration
+private gcp.project.storageService.bucket.lifecycleRule {
+  // The action to take
+  action gcp.project.storageService.bucket.lifecycleRuleAction
+  // The condition(s) under which the action will be taken
+  condition gcp.project.storageService.bucket.lifecycleRuleCondition
+}
+
+// A lifecycle management rule, which is made of an action to take and
+// the condition(s) under which the action will be taken
+private gcp.project.storageService.bucket.lifecycleRuleAction @defaults("type storageClass") {
+  // Target storage class. Required iff the type of the action is SetStorageClass
+  storageClass string
+  // Type of the action. Currently, only Delete, SetStorageClass, and
+  // AbortIncompleteMultipartUpload are supported
+  type string
+}
+
+// The condition(s) under which the action will be taken
+private gcp.project.storageService.bucket.lifecycleRuleCondition @defaults("age numNewerVersions") {
+  // Age of an object (in days). This condition is satisfied when an object
+  // reaches the specified age
+  age int
+  // CreatedBefore: A date in RFC 3339 format with only the date part (for
+  // instance, "2013-01-15"). This condition is satisfied when an object is
+  // created before midnight of the specified date in UTC
+  createdBefore string
+  // CustomTimeBefore: A date in RFC 3339 format with only the date part (for
+  // instance, "2013-01-15"). This condition is satisfied when the custom time on
+  // an object is before this date in UTC
+  customTimeBefore string
+  // DaysSinceCustomTime: Number of days elapsed since the user-specified
+  // timestamp set on an object. The condition is satisfied if the days elapsed
+  // is at least this number. If no custom timestamp is specified on an object,
+  // the condition does not apply
+  daysSinceCustomTime int
+  // DaysSinceNoncurrentTime: Number of days elapsed since the noncurrent
+  // timestamp of an object. The condition is satisfied if the days elapsed is at
+  // least this number. This condition is relevant only for versioned objects.
+  // The value of the field must be a nonnegative integer. If it's zero, the
+  // object version will become eligible for Lifecycle action as soon as it
+  // becomes noncurrent
+  daysSinceNoncurrentTime int
+  // IsLive: Relevant only for versioned objects. If the value is true, this
+  // condition matches live objects; if the value is false, it matches archived
+  // objects
+  isLive bool
+  // MatchesPattern: A regular expression that satisfies the RE2 syntax. This
+  // condition is satisfied when the name of the object matches the RE2 pattern
+  matchesPattern string
+  // MatchesPrefix: List of object name prefixes. This condition will be
+  // satisfied when at least one of the prefixes exactly matches the beginning of
+  // the object name
+  matchesPrefix []string
+  // MatchesStorageClass: Objects having any of the storage classes specified by
+  // this condition will be matched
+  matchesStorageClass []string
+  // MatchesSuffix: List of object name suffixes. This condition will be
+  // satisfied when at least one of the suffixes exactly matches the end of the
+  // object name
+  matchesSuffix []string
+  // NoncurrentTimeBefore: A date in RFC 3339 format with only the date part (for
+  // instance, "2013-01-15"). This condition is satisfied when the noncurrent
+  // time on an object is before this date in UTC. This condition is relevant
+  // only for versioned objects
+  noncurrentTimeBefore string
+  // NumNewerVersions: Relevant only for versioned objects. If the value is N,
+  // this condition is satisfied when there are at least N versions (including
+  // the live version) newer than this version of the object
+  numNewerVersions int
 }
 
 // Google Cloud (GCP) SQL resources
@@ -2627,6 +2701,7 @@ private gcp.project.cloudRunService.container @defaults("name image") {
   // Compute resource requirements by the container
   resources dict
   // List of ports to expose from the container
+  // @afiune Fix issue int32 not parse as dict
   ports []dict
   // Volumes to mount into the container's file system
   volumeMounts []dict

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -138,6 +138,18 @@ func init() {
 			Init: initGcpProjectStorageServiceBucket,
 			Create: createGcpProjectStorageServiceBucket,
 		},
+		"gcp.project.storageService.bucket.lifecycleRule": {
+			// to override args, implement: initGcpProjectStorageServiceBucketLifecycleRule(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGcpProjectStorageServiceBucketLifecycleRule,
+		},
+		"gcp.project.storageService.bucket.lifecycleRuleAction": {
+			// to override args, implement: initGcpProjectStorageServiceBucketLifecycleRuleAction(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGcpProjectStorageServiceBucketLifecycleRuleAction,
+		},
+		"gcp.project.storageService.bucket.lifecycleRuleCondition": {
+			// to override args, implement: initGcpProjectStorageServiceBucketLifecycleRuleCondition(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGcpProjectStorageServiceBucketLifecycleRuleCondition,
+		},
 		"gcp.project.sqlService": {
 			// to override args, implement: initGcpProjectSqlService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createGcpProjectSqlService,
@@ -1785,6 +1797,57 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.storageService.bucket.encryption": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectStorageServiceBucket).GetEncryption()).ToDataRes(types.Dict)
+	},
+	"gcp.project.storageService.bucket.lifecycle": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucket).GetLifecycle()).ToDataRes(types.Array(types.Resource("gcp.project.storageService.bucket.lifecycleRule")))
+	},
+	"gcp.project.storageService.bucket.lifecycleRule.action": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucketLifecycleRule).GetAction()).ToDataRes(types.Resource("gcp.project.storageService.bucket.lifecycleRuleAction"))
+	},
+	"gcp.project.storageService.bucket.lifecycleRule.condition": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucketLifecycleRule).GetCondition()).ToDataRes(types.Resource("gcp.project.storageService.bucket.lifecycleRuleCondition"))
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleAction.storageClass": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleAction).GetStorageClass()).ToDataRes(types.String)
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleAction.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleAction).GetType()).ToDataRes(types.String)
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.age": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).GetAge()).ToDataRes(types.Int)
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.createdBefore": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).GetCreatedBefore()).ToDataRes(types.String)
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.customTimeBefore": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).GetCustomTimeBefore()).ToDataRes(types.String)
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.daysSinceCustomTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).GetDaysSinceCustomTime()).ToDataRes(types.Int)
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.daysSinceNoncurrentTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).GetDaysSinceNoncurrentTime()).ToDataRes(types.Int)
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.isLive": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).GetIsLive()).ToDataRes(types.Bool)
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.matchesPattern": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).GetMatchesPattern()).ToDataRes(types.String)
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.matchesPrefix": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).GetMatchesPrefix()).ToDataRes(types.Array(types.String))
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.matchesStorageClass": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).GetMatchesStorageClass()).ToDataRes(types.Array(types.String))
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.matchesSuffix": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).GetMatchesSuffix()).ToDataRes(types.Array(types.String))
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.noncurrentTimeBefore": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).GetNoncurrentTimeBefore()).ToDataRes(types.String)
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.numNewerVersions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).GetNumNewerVersions()).ToDataRes(types.Int)
 	},
 	"gcp.project.sqlService.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlService).GetProjectId()).ToDataRes(types.String)
@@ -5835,6 +5898,86 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"gcp.project.storageService.bucket.encryption": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectStorageServiceBucket).Encryption, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
+		return
+	},
+	"gcp.project.storageService.bucket.lifecycle": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucket).Lifecycle, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"gcp.project.storageService.bucket.lifecycleRule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlGcpProjectStorageServiceBucketLifecycleRule).__id, ok = v.Value.(string)
+			return
+		},
+	"gcp.project.storageService.bucket.lifecycleRule.action": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucketLifecycleRule).Action, ok = plugin.RawToTValue[*mqlGcpProjectStorageServiceBucketLifecycleRuleAction](v.Value, v.Error)
+		return
+	},
+	"gcp.project.storageService.bucket.lifecycleRule.condition": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucketLifecycleRule).Condition, ok = plugin.RawToTValue[*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition](v.Value, v.Error)
+		return
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleAction.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleAction).__id, ok = v.Value.(string)
+			return
+		},
+	"gcp.project.storageService.bucket.lifecycleRuleAction.storageClass": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleAction).StorageClass, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleAction.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleAction).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).__id, ok = v.Value.(string)
+			return
+		},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.age": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).Age, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.createdBefore": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).CreatedBefore, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.customTimeBefore": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).CustomTimeBefore, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.daysSinceCustomTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).DaysSinceCustomTime, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.daysSinceNoncurrentTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).DaysSinceNoncurrentTime, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.isLive": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).IsLive, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.matchesPattern": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).MatchesPattern, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.matchesPrefix": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).MatchesPrefix, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.matchesStorageClass": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).MatchesStorageClass, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.matchesSuffix": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).MatchesSuffix, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.noncurrentTimeBefore": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).NoncurrentTimeBefore, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.storageService.bucket.lifecycleRuleCondition.numNewerVersions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition).NumNewerVersions, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"gcp.project.sqlService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -13232,6 +13375,7 @@ type mqlGcpProjectStorageServiceBucket struct {
 	IamConfiguration plugin.TValue[interface{}]
 	RetentionPolicy plugin.TValue[interface{}]
 	Encryption plugin.TValue[interface{}]
+	Lifecycle plugin.TValue[[]interface{}]
 }
 
 // createGcpProjectStorageServiceBucket creates a new instance of this resource
@@ -13337,6 +13481,207 @@ func (c *mqlGcpProjectStorageServiceBucket) GetRetentionPolicy() *plugin.TValue[
 
 func (c *mqlGcpProjectStorageServiceBucket) GetEncryption() *plugin.TValue[interface{}] {
 	return &c.Encryption
+}
+
+func (c *mqlGcpProjectStorageServiceBucket) GetLifecycle() *plugin.TValue[[]interface{}] {
+	return &c.Lifecycle
+}
+
+// mqlGcpProjectStorageServiceBucketLifecycleRule for the gcp.project.storageService.bucket.lifecycleRule resource
+type mqlGcpProjectStorageServiceBucketLifecycleRule struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlGcpProjectStorageServiceBucketLifecycleRuleInternal it will be used here
+	Action plugin.TValue[*mqlGcpProjectStorageServiceBucketLifecycleRuleAction]
+	Condition plugin.TValue[*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition]
+}
+
+// createGcpProjectStorageServiceBucketLifecycleRule creates a new instance of this resource
+func createGcpProjectStorageServiceBucketLifecycleRule(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGcpProjectStorageServiceBucketLifecycleRule{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("gcp.project.storageService.bucket.lifecycleRule", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGcpProjectStorageServiceBucketLifecycleRule) MqlName() string {
+	return "gcp.project.storageService.bucket.lifecycleRule"
+}
+
+func (c *mqlGcpProjectStorageServiceBucketLifecycleRule) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGcpProjectStorageServiceBucketLifecycleRule) GetAction() *plugin.TValue[*mqlGcpProjectStorageServiceBucketLifecycleRuleAction] {
+	return &c.Action
+}
+
+func (c *mqlGcpProjectStorageServiceBucketLifecycleRule) GetCondition() *plugin.TValue[*mqlGcpProjectStorageServiceBucketLifecycleRuleCondition] {
+	return &c.Condition
+}
+
+// mqlGcpProjectStorageServiceBucketLifecycleRuleAction for the gcp.project.storageService.bucket.lifecycleRuleAction resource
+type mqlGcpProjectStorageServiceBucketLifecycleRuleAction struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlGcpProjectStorageServiceBucketLifecycleRuleActionInternal it will be used here
+	StorageClass plugin.TValue[string]
+	Type plugin.TValue[string]
+}
+
+// createGcpProjectStorageServiceBucketLifecycleRuleAction creates a new instance of this resource
+func createGcpProjectStorageServiceBucketLifecycleRuleAction(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGcpProjectStorageServiceBucketLifecycleRuleAction{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("gcp.project.storageService.bucket.lifecycleRuleAction", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGcpProjectStorageServiceBucketLifecycleRuleAction) MqlName() string {
+	return "gcp.project.storageService.bucket.lifecycleRuleAction"
+}
+
+func (c *mqlGcpProjectStorageServiceBucketLifecycleRuleAction) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGcpProjectStorageServiceBucketLifecycleRuleAction) GetStorageClass() *plugin.TValue[string] {
+	return &c.StorageClass
+}
+
+func (c *mqlGcpProjectStorageServiceBucketLifecycleRuleAction) GetType() *plugin.TValue[string] {
+	return &c.Type
+}
+
+// mqlGcpProjectStorageServiceBucketLifecycleRuleCondition for the gcp.project.storageService.bucket.lifecycleRuleCondition resource
+type mqlGcpProjectStorageServiceBucketLifecycleRuleCondition struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlGcpProjectStorageServiceBucketLifecycleRuleConditionInternal it will be used here
+	Age plugin.TValue[int64]
+	CreatedBefore plugin.TValue[string]
+	CustomTimeBefore plugin.TValue[string]
+	DaysSinceCustomTime plugin.TValue[int64]
+	DaysSinceNoncurrentTime plugin.TValue[int64]
+	IsLive plugin.TValue[bool]
+	MatchesPattern plugin.TValue[string]
+	MatchesPrefix plugin.TValue[[]interface{}]
+	MatchesStorageClass plugin.TValue[[]interface{}]
+	MatchesSuffix plugin.TValue[[]interface{}]
+	NoncurrentTimeBefore plugin.TValue[string]
+	NumNewerVersions plugin.TValue[int64]
+}
+
+// createGcpProjectStorageServiceBucketLifecycleRuleCondition creates a new instance of this resource
+func createGcpProjectStorageServiceBucketLifecycleRuleCondition(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGcpProjectStorageServiceBucketLifecycleRuleCondition{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("gcp.project.storageService.bucket.lifecycleRuleCondition", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGcpProjectStorageServiceBucketLifecycleRuleCondition) MqlName() string {
+	return "gcp.project.storageService.bucket.lifecycleRuleCondition"
+}
+
+func (c *mqlGcpProjectStorageServiceBucketLifecycleRuleCondition) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGcpProjectStorageServiceBucketLifecycleRuleCondition) GetAge() *plugin.TValue[int64] {
+	return &c.Age
+}
+
+func (c *mqlGcpProjectStorageServiceBucketLifecycleRuleCondition) GetCreatedBefore() *plugin.TValue[string] {
+	return &c.CreatedBefore
+}
+
+func (c *mqlGcpProjectStorageServiceBucketLifecycleRuleCondition) GetCustomTimeBefore() *plugin.TValue[string] {
+	return &c.CustomTimeBefore
+}
+
+func (c *mqlGcpProjectStorageServiceBucketLifecycleRuleCondition) GetDaysSinceCustomTime() *plugin.TValue[int64] {
+	return &c.DaysSinceCustomTime
+}
+
+func (c *mqlGcpProjectStorageServiceBucketLifecycleRuleCondition) GetDaysSinceNoncurrentTime() *plugin.TValue[int64] {
+	return &c.DaysSinceNoncurrentTime
+}
+
+func (c *mqlGcpProjectStorageServiceBucketLifecycleRuleCondition) GetIsLive() *plugin.TValue[bool] {
+	return &c.IsLive
+}
+
+func (c *mqlGcpProjectStorageServiceBucketLifecycleRuleCondition) GetMatchesPattern() *plugin.TValue[string] {
+	return &c.MatchesPattern
+}
+
+func (c *mqlGcpProjectStorageServiceBucketLifecycleRuleCondition) GetMatchesPrefix() *plugin.TValue[[]interface{}] {
+	return &c.MatchesPrefix
+}
+
+func (c *mqlGcpProjectStorageServiceBucketLifecycleRuleCondition) GetMatchesStorageClass() *plugin.TValue[[]interface{}] {
+	return &c.MatchesStorageClass
+}
+
+func (c *mqlGcpProjectStorageServiceBucketLifecycleRuleCondition) GetMatchesSuffix() *plugin.TValue[[]interface{}] {
+	return &c.MatchesSuffix
+}
+
+func (c *mqlGcpProjectStorageServiceBucketLifecycleRuleCondition) GetNoncurrentTimeBefore() *plugin.TValue[string] {
+	return &c.NoncurrentTimeBefore
+}
+
+func (c *mqlGcpProjectStorageServiceBucketLifecycleRuleCondition) GetNumNewerVersions() *plugin.TValue[int64] {
+	return &c.NumNewerVersions
 }
 
 // mqlGcpProjectSqlService for the gcp.project.sqlService resource

--- a/providers/gcp/resources/gcp.lr.manifest.yaml
+++ b/providers/gcp/resources/gcp.lr.manifest.yaml
@@ -2361,6 +2361,8 @@ resources:
       iamPolicy: {}
       id: {}
       labels: {}
+      lifecycle:
+        min_mondoo_version: 9.0.0
       location: {}
       locationType: {}
       name: {}
@@ -2377,6 +2379,55 @@ resources:
     refs:
     - title: About Cloud Storage buckets
       url: https://cloud.google.com/storage/docs/buckets
+  gcp.project.storageService.bucket.lifecycleRule:
+    fields:
+      action: {}
+      condition: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
+    platform:
+      name:
+      - gcp
+  gcp.project.storageService.bucket.lifecycleRuleAction:
+    fields:
+      storageClass: {}
+      type: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
+    platform:
+      name:
+      - gcp
+  gcp.project.storageService.bucket.lifecycleRuleCondition:
+    fields:
+      Age: {}
+      CreatedBefore: {}
+      CustomTimeBefore: {}
+      DaysSinceCustomTime: {}
+      DaysSinceNoncurrentTime: {}
+      IsLive: {}
+      MatchesPattern: {}
+      MatchesPrefix: {}
+      MatchesStorageClass: {}
+      MatchesSuffix: {}
+      NoncurrentTimeBefore: {}
+      NumNewerVersions: {}
+      age: {}
+      createdBefore: {}
+      customTimeBefore: {}
+      daysSinceCustomTime: {}
+      daysSinceNoncurrentTime: {}
+      isLive: {}
+      matchesPattern: {}
+      matchesPrefix: {}
+      matchesStorageClass: {}
+      matchesSuffix: {}
+      noncurrentTimeBefore: {}
+      numNewerVersions: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
+    platform:
+      name:
+      - gcp
   gcp.projects:
     fields:
       children: {}

--- a/providers/gcp/resources/storage.go
+++ b/providers/gcp/resources/storage.go
@@ -119,6 +119,10 @@ func (g *mqlGcpProjectStorageService) buckets() ([]interface{}, error) {
 			"iamConfiguration": llx.DictData(iamConfigurationDict),
 			"retentionPolicy":  llx.DictData(retentionPolicy),
 			"encryption":       llx.DictData(enc),
+			"lifecycle": llx.ArrayData(
+				storageLifecycleRulesToArrayInterface(g.MqlRuntime, bucket.Id, bucket.Lifecycle),
+				types.Resource("gcp.project.storageService.bucket.lifecycleRule"),
+			),
 		})
 		if err != nil {
 			return nil, err
@@ -126,6 +130,85 @@ func (g *mqlGcpProjectStorageService) buckets() ([]interface{}, error) {
 		res = append(res, mqlInstance)
 	}
 	return res, nil
+}
+
+func storageLifecycleRulesToArrayInterface(runtime *plugin.Runtime, bucketId string, lifecycle *storage.BucketLifecycle) (list []any) {
+	if lifecycle == nil {
+		return
+	}
+	for i, rule := range lifecycle.Rule {
+		if rule == nil {
+			continue
+		}
+
+		var (
+			action      plugin.Resource
+			condition   plugin.Resource
+			err         error
+			skip        = true
+			ruleRawData = map[string]*llx.RawData{}
+		)
+
+		// create rule action resource
+		if rule.Action != nil {
+			action, err = CreateResource(runtime, "gcp.project.storageService.bucket.lifecycleRuleAction", map[string]*llx.RawData{
+				"__id": llx.StringData(
+					fmt.Sprintf("gcp.project.storageService.bucket.lifecycleRuleAction/%s/%d", bucketId, i),
+				),
+				"storageClass": llx.StringData(rule.Action.StorageClass),
+				"type":         llx.StringData(rule.Action.Type),
+			})
+			if err != nil {
+				continue
+			}
+			ruleRawData["action"] = llx.ResourceData(action, action.MqlName())
+			skip = true
+		}
+
+		// create rule condition resource
+		if rule.Condition != nil {
+			condition, err = CreateResource(runtime, "gcp.project.storageService.bucket.lifecycleRuleCondition", map[string]*llx.RawData{
+				"__id": llx.StringData(
+					fmt.Sprintf("gcp.project.storageService.bucket.lifecycleRuleCondition/%s/%d", bucketId, i),
+				),
+				"age":                     llx.IntDataPtr(rule.Condition.Age),
+				"daysSinceCustomTime":     llx.IntData(rule.Condition.DaysSinceCustomTime),
+				"daysSinceNoncurrentTime": llx.IntData(rule.Condition.DaysSinceNoncurrentTime),
+				"numNewerVersions":        llx.IntData(rule.Condition.NumNewerVersions),
+				"isLive":                  llx.BoolDataPtr(rule.Condition.IsLive),
+				"createdBefore":           llx.StringData(rule.Condition.CreatedBefore),
+				"customTimeBefore":        llx.StringData(rule.Condition.CustomTimeBefore),
+				"matchesPattern":          llx.StringData(rule.Condition.MatchesPattern),
+				"noncurrentTimeBefore":    llx.StringData(rule.Condition.NoncurrentTimeBefore),
+				"matchesPrefix":           llx.ArrayData(convert.SliceAnyToInterface(rule.Condition.MatchesPrefix), types.String),
+				"matchesStorageClass":     llx.ArrayData(convert.SliceAnyToInterface(rule.Condition.MatchesStorageClass), types.String),
+				"matchesSuffix":           llx.ArrayData(convert.SliceAnyToInterface(rule.Condition.MatchesSuffix), types.String),
+			})
+			if err != nil {
+				continue
+			}
+			ruleRawData["condition"] = llx.ResourceData(condition, condition.MqlName())
+			skip = false
+		}
+
+		// if the rule doesn't have an action or a condition, skip it
+		if skip {
+			continue
+		}
+
+		// add the rule id
+		ruleRawData["__id"] = llx.StringData(
+			fmt.Sprintf("gcp.project.storageService.bucket.lifecycleRule/%s/%d", bucketId, i),
+		)
+
+		r, err := CreateResource(runtime, "gcp.project.storageService.bucket.lifecycleRule", ruleRawData)
+		if err != nil {
+			continue
+		}
+		list = append(list, r)
+	}
+
+	return
 }
 
 func (g *mqlGcpProjectStorageServiceBucket) id() (string, error) {


### PR DESCRIPTION
Adds support for Storage Lifecycle configuration.

https://cloud.google.com/storage/docs/lifecycle#configuration

```
cnquery> gcp.project.storage.buckets.where( lifecycle != empty) {name lifecycle.first {*}}
gcp.project.storage.buckets.where: [
  0: {
    lifecycle.first: {
      condition: gcp.project.storageService.bucket.lifecycleRuleCondition age=null numNewerVersions=3
      action: gcp.project.storageService.bucket.lifecycleRuleAction type="Delete" storageClass=""
    }
    name: "gcf-v2-sources-239626230709-us-central1"
  }
  1: {
    lifecycle.first: {
      condition: gcp.project.storageService.bucket.lifecycleRuleCondition age=30 numNewerVersions=0
      action: gcp.project.storageService.bucket.lifecycleRuleAction type="Delete" storageClass=""
    }
    name: "lunalectric-bucket-owjv"
  }
]
```