### PR TITLE
🌟 Adds GKE autoscaling resource

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -4,6 +4,7 @@ atlassian
 auditlog
 Auths
 autoaccept
+autoprovisioned
 autoscaler
 backupconfiguration
 backupsetting

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -1765,6 +1765,31 @@ private gcp.project.gkeService.cluster.nodepool @defaults("name") {
   status string
   // Node management configuration
   management dict
+  // Autoscaler configuration for this NodePool
+  autoscaling gcp.project.gkeService.cluster.nodepool.autoscaling
+}
+
+private gcp.project.gkeService.cluster.nodepool.autoscaling @defaults( "enabled" ) {
+  // Is autoscaling enabled for this node pool.
+  enabled bool
+  // Minimum number of nodes for one location in the node pool. Must be greater
+  // than or equal to 0 and less than or equal to max_node_count.
+  minNodeCount int
+  // Maximum number of nodes for one location in the node pool. Must be >=
+  // min_node_count. There has to be enough quota to scale up the cluster.
+  maxNodeCount int
+  // Can this node pool be deleted automatically.
+  autoprovisioned bool
+  // Minimum number of nodes in the node pool. Must be greater than or equal
+  // to 0 and less than or equal to total_max_node_count.
+  // The total_*_node_count fields are mutually exclusive with the *_node_count
+  // fields.
+  totalMinNodeCount int
+  // Maximum number of nodes in the node pool. Must be greater than or equal to
+  // total_min_node_count. There has to be enough quota to scale up the cluster.
+  // The total_*_node_count fields are mutually exclusive with the *_node_count
+  // fields.
+  totalMaxNodeCount int
 }
 
 // Google Kubernetes Engine (GKE) node pool-Level network configuration

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -266,6 +266,10 @@ func init() {
 			// to override args, implement: initGcpProjectGkeServiceClusterNodepool(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createGcpProjectGkeServiceClusterNodepool,
 		},
+		"gcp.project.gkeService.cluster.nodepool.autoscaling": {
+			// to override args, implement: initGcpProjectGkeServiceClusterNodepoolAutoscaling(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGcpProjectGkeServiceClusterNodepoolAutoscaling,
+		},
 		"gcp.project.gkeService.cluster.nodepool.networkConfig": {
 			// to override args, implement: initGcpProjectGkeServiceClusterNodepoolNetworkConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createGcpProjectGkeServiceClusterNodepoolNetworkConfig,
@@ -2814,6 +2818,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.gkeService.cluster.nodepool.management": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceClusterNodepool).GetManagement()).ToDataRes(types.Dict)
+	},
+	"gcp.project.gkeService.cluster.nodepool.autoscaling": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceClusterNodepool).GetAutoscaling()).ToDataRes(types.Resource("gcp.project.gkeService.cluster.nodepool.autoscaling"))
+	},
+	"gcp.project.gkeService.cluster.nodepool.autoscaling.enabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolAutoscaling).GetEnabled()).ToDataRes(types.Bool)
+	},
+	"gcp.project.gkeService.cluster.nodepool.autoscaling.minNodeCount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolAutoscaling).GetMinNodeCount()).ToDataRes(types.Int)
+	},
+	"gcp.project.gkeService.cluster.nodepool.autoscaling.maxNodeCount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolAutoscaling).GetMaxNodeCount()).ToDataRes(types.Int)
+	},
+	"gcp.project.gkeService.cluster.nodepool.autoscaling.autoprovisioned": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolAutoscaling).GetAutoprovisioned()).ToDataRes(types.Bool)
+	},
+	"gcp.project.gkeService.cluster.nodepool.autoscaling.totalMinNodeCount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolAutoscaling).GetTotalMinNodeCount()).ToDataRes(types.Int)
+	},
+	"gcp.project.gkeService.cluster.nodepool.autoscaling.totalMaxNodeCount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolAutoscaling).GetTotalMaxNodeCount()).ToDataRes(types.Int)
 	},
 	"gcp.project.gkeService.cluster.nodepool.networkConfig.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolNetworkConfig).GetId()).ToDataRes(types.String)
@@ -7477,6 +7502,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"gcp.project.gkeService.cluster.nodepool.management": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceClusterNodepool).Management, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.nodepool.autoscaling": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceClusterNodepool).Autoscaling, ok = plugin.RawToTValue[*mqlGcpProjectGkeServiceClusterNodepoolAutoscaling](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.nodepool.autoscaling.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlGcpProjectGkeServiceClusterNodepoolAutoscaling).__id, ok = v.Value.(string)
+			return
+		},
+	"gcp.project.gkeService.cluster.nodepool.autoscaling.enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceClusterNodepoolAutoscaling).Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.nodepool.autoscaling.minNodeCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceClusterNodepoolAutoscaling).MinNodeCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.nodepool.autoscaling.maxNodeCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceClusterNodepoolAutoscaling).MaxNodeCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.nodepool.autoscaling.autoprovisioned": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceClusterNodepoolAutoscaling).Autoprovisioned, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.nodepool.autoscaling.totalMinNodeCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceClusterNodepoolAutoscaling).TotalMinNodeCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.nodepool.autoscaling.totalMaxNodeCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceClusterNodepoolAutoscaling).TotalMaxNodeCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"gcp.project.gkeService.cluster.nodepool.networkConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16906,6 +16963,7 @@ type mqlGcpProjectGkeServiceClusterNodepool struct {
 	InstanceGroupUrls plugin.TValue[[]interface{}]
 	Status plugin.TValue[string]
 	Management plugin.TValue[interface{}]
+	Autoscaling plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolAutoscaling]
 }
 
 // createGcpProjectGkeServiceClusterNodepool creates a new instance of this resource
@@ -16983,6 +17041,79 @@ func (c *mqlGcpProjectGkeServiceClusterNodepool) GetStatus() *plugin.TValue[stri
 
 func (c *mqlGcpProjectGkeServiceClusterNodepool) GetManagement() *plugin.TValue[interface{}] {
 	return &c.Management
+}
+
+func (c *mqlGcpProjectGkeServiceClusterNodepool) GetAutoscaling() *plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolAutoscaling] {
+	return &c.Autoscaling
+}
+
+// mqlGcpProjectGkeServiceClusterNodepoolAutoscaling for the gcp.project.gkeService.cluster.nodepool.autoscaling resource
+type mqlGcpProjectGkeServiceClusterNodepoolAutoscaling struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlGcpProjectGkeServiceClusterNodepoolAutoscalingInternal it will be used here
+	Enabled plugin.TValue[bool]
+	MinNodeCount plugin.TValue[int64]
+	MaxNodeCount plugin.TValue[int64]
+	Autoprovisioned plugin.TValue[bool]
+	TotalMinNodeCount plugin.TValue[int64]
+	TotalMaxNodeCount plugin.TValue[int64]
+}
+
+// createGcpProjectGkeServiceClusterNodepoolAutoscaling creates a new instance of this resource
+func createGcpProjectGkeServiceClusterNodepoolAutoscaling(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGcpProjectGkeServiceClusterNodepoolAutoscaling{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("gcp.project.gkeService.cluster.nodepool.autoscaling", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGcpProjectGkeServiceClusterNodepoolAutoscaling) MqlName() string {
+	return "gcp.project.gkeService.cluster.nodepool.autoscaling"
+}
+
+func (c *mqlGcpProjectGkeServiceClusterNodepoolAutoscaling) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGcpProjectGkeServiceClusterNodepoolAutoscaling) GetEnabled() *plugin.TValue[bool] {
+	return &c.Enabled
+}
+
+func (c *mqlGcpProjectGkeServiceClusterNodepoolAutoscaling) GetMinNodeCount() *plugin.TValue[int64] {
+	return &c.MinNodeCount
+}
+
+func (c *mqlGcpProjectGkeServiceClusterNodepoolAutoscaling) GetMaxNodeCount() *plugin.TValue[int64] {
+	return &c.MaxNodeCount
+}
+
+func (c *mqlGcpProjectGkeServiceClusterNodepoolAutoscaling) GetAutoprovisioned() *plugin.TValue[bool] {
+	return &c.Autoprovisioned
+}
+
+func (c *mqlGcpProjectGkeServiceClusterNodepoolAutoscaling) GetTotalMinNodeCount() *plugin.TValue[int64] {
+	return &c.TotalMinNodeCount
+}
+
+func (c *mqlGcpProjectGkeServiceClusterNodepoolAutoscaling) GetTotalMaxNodeCount() *plugin.TValue[int64] {
+	return &c.TotalMaxNodeCount
 }
 
 // mqlGcpProjectGkeServiceClusterNodepoolNetworkConfig for the gcp.project.gkeService.cluster.nodepool.networkConfig resource

--- a/providers/gcp/resources/gcp.lr.manifest.yaml
+++ b/providers/gcp/resources/gcp.lr.manifest.yaml
@@ -1531,6 +1531,8 @@ resources:
       url: https://cloud.google.com/kubernetes-engine/docs/best-practices/networking
   gcp.project.gkeService.cluster.nodepool:
     fields:
+      autoscaling:
+        min_mondoo_version: 9.0.0
       config: {}
       id: {}
       initialNodeCount: {}
@@ -1549,6 +1551,19 @@ resources:
     refs:
     - title: About node pools
       url: https://cloud.google.com/kubernetes-engine/docs/concepts/node-pools
+  gcp.project.gkeService.cluster.nodepool.autoscaling:
+    fields:
+      autoprovisioned: {}
+      enabled: {}
+      maxNodeCount: {}
+      minNodeCount: {}
+      totalMaxNodeCount: {}
+      totalMinNodeCount: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
+    platform:
+      name:
+      - gcp
   gcp.project.gkeService.cluster.nodepool.config:
     fields:
       accelerators: {}


### PR DESCRIPTION
This PR adds the ability to get GKE node pool autoscaling configuration

```
cnquery> gcp.project.gke.clusters { nodePools.first { autoscaling {*}}}
gcp.project.gke.clusters: [
  0: {
    nodePools.first: {
      autoscaling: {
        minNodeCount: 0
        totalMinNodeCount: 0
        enabled: true
        totalMaxNodeCount: 0
        maxNodeCount: 1000
        autoprovisioned: false
      }
    }
  }
]
```