### PR TITLE
✨ add parameter groups and cluster parameter group in AWS RDS

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2346,7 +2346,6 @@ aws.rds.clusterParameterGroup @defaults("name family region arn") {
   parameters() []aws.rds.parameterGroup.parameter
 }
 
-
 // Amazon RDS parameter groups
 aws.rds.parameterGroup @defaults("name family region arn") {
   // ARN for resource

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2332,14 +2332,15 @@ private aws.rds.pendingMaintenanceAction {
   optInStatus string
 }
 
+// Amazon RDS cluster parameter groups
 aws.rds.clusterParameterGroup @defaults("name family region arn") {
   // ARN for resource
   arn string
-  // Family of the Parameter Group
+  // Family of the parameter group
   family string
-  // Name of the Parameter Group
+  // Name of the parameter group
   name string
-  // Description of the Parameter Group
+  // Description of the parameter group
   description string
   // Region of the parameters
   region string
@@ -2350,47 +2351,47 @@ aws.rds.clusterParameterGroup @defaults("name family region arn") {
 aws.rds.parameterGroup @defaults("name family region arn") {
   // ARN for resource
   arn string
-  // Family of the Parameter Group
+  // Family of the parameter group
   family string
-  // Name of the Parameter Group
+  // Name of the parameter group
   name string
-  // Description of the Parameter Group
+  // Description of the parameter group
   description string
   // Region of the parameters
   region string
-  // The Parameters of the group
+  // The parameters of the group
   parameters() []aws.rds.parameterGroup.parameter
 }
 
 aws.rds.parameterGroup.parameter @defaults("name value") {
-  // Specifies the valid range of values for the parameter.
-	allowedValues string
-	// When to apply parameter updates.
-	applyMethod string
-	// Specifies the engine specific parameters type.
-	applyType string
-	// Specifies the valid data type for the parameter.
-	dataType string
-	// Provides a description of the parameter.
-	description string
-	// being changed.
-	isModifiable bool
-	// The earliest engine version to which the parameter can apply.
-	minimumEngineVersion string
-	// The name of the parameter.
-	name string
-	// The value of the parameter.
-	value string
-	// The source of the parameter value.
-	source string
-	// The valid DB engine modes.
-	supportedEngineModes []string
+  // Specifies the valid range of values for the parameter
+  allowedValues string
+  // When to apply parameter updates
+  applyMethod string
+  // Specifies the engine specific parameters type
+  applyType string
+  // Specifies the valid data type for the parameter
+  dataType string
+  // Provides a description of the parameter
+  description string
+  // being changed
+  isModifiable bool
+  // The earliest engine version to which the parameter can apply
+  minimumEngineVersion string
+  // The name of the parameter
+  name string
+  // The value of the parameter
+  value string
+  // The source of the parameter value
+  source string
+  // The valid DB engine modes
+  supportedEngineModes []string
 }
 
 
 // Amazon ElastiCache
 aws.elasticache @defaults("cacheClusters") {
-    // Deprecated: Use `cacheClusters` instead.
+  // Deprecated: Use `cacheClusters` instead.
   clusters() []dict
   // List of cache clusters
   cacheClusters() []aws.elasticache.cluster

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2342,6 +2342,33 @@ aws.rds.parameterGroup @defaults("name family region") {
   description string
   // Region of the paramaters
   region string
+  // The Parameters of the group
+  parameters() []aws.rds.parameterGroup.parameter
+}
+
+aws.rds.parameterGroup.parameter @defaults("name value") {
+  // Specifies the valid range of values for the parameter.
+	allowedValues string
+	// Indicates when to apply parameter updates.
+	applyMethod string
+	// Specifies the engine specific parameters type.
+	applyType string
+	// Specifies the valid data type for the parameter.
+	dataType string
+	// Provides a description of the parameter.
+	description string
+	// being changed.
+	isModifiable bool
+	// The earliest engine version to which the parameter can apply.
+	minimumEngineVersion string
+	// The name of the parameter.
+	name string
+	// The value of the parameter.
+	value string
+	// The source of the parameter value.
+	source string
+	// The valid DB engine modes.
+	supportedEngineModes []string
 }
 
 

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2340,7 +2340,7 @@ aws.rds.parameterGroup @defaults("name family region") {
   name string
   // Description of the Parameter Group
   description string
-  // Region of the paramaters
+  // Region of the parameters
   region string
   // The Parameters of the group
   parameters() []aws.rds.parameterGroup.parameter

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2349,7 +2349,7 @@ aws.rds.parameterGroup @defaults("name family region") {
 aws.rds.parameterGroup.parameter @defaults("name value") {
   // Specifies the valid range of values for the parameter.
 	allowedValues string
-	// Indicates when to apply parameter updates.
+	// When to apply parameter updates.
 	applyMethod string
 	// Specifies the engine specific parameters type.
 	applyType string

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2074,6 +2074,8 @@ aws.rds {
   clusters() []aws.rds.dbcluster
   // List of all pending maintenance actions for the database instance
   allPendingMaintenanceActions() []aws.rds.pendingMaintenanceAction
+  // List of all parameter groups
+  parameterGroups() []aws.rds.parameterGroup
 }
 
 // Amazon RDS Backup Setting
@@ -2182,6 +2184,8 @@ aws.rds.dbcluster @defaults("id region engine engineVersion") {
   preferredBackupWindow string
   // Whether the HTTP API endpoint is enabled
   httpEndpointEnabled bool
+  // Container for engine configuration values
+  parameterGroupName string
 }
 
 // Amazon RDS snapshot
@@ -2325,6 +2329,21 @@ private aws.rds.pendingMaintenanceAction {
   // Opt-in status
   optInStatus string
 }
+
+// Amazon RDS parameter groups
+aws.rds.parameterGroup @defaults("name family region") {
+  // ARN for resource
+  arn string
+  // Family of the Parameter Group
+  family string
+  // Name of the Parameter Group
+  name string
+  // Description of the Parameter Group
+  description string
+  // Region of the paramaters
+  region string
+}
+
 
 // Amazon ElastiCache
 aws.elasticache @defaults("cacheClusters") {

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2076,6 +2076,8 @@ aws.rds {
   allPendingMaintenanceActions() []aws.rds.pendingMaintenanceAction
   // List of all parameter groups
   parameterGroups() []aws.rds.parameterGroup
+  // List of all cluster parameter groups
+  clusterParameterGroups() []aws.rds.clusterParameterGroup
 }
 
 // Amazon RDS Backup Setting
@@ -2330,8 +2332,23 @@ private aws.rds.pendingMaintenanceAction {
   optInStatus string
 }
 
+aws.rds.clusterParameterGroup @defaults("name family region arn") {
+  // ARN for resource
+  arn string
+  // Family of the Parameter Group
+  family string
+  // Name of the Parameter Group
+  name string
+  // Description of the Parameter Group
+  description string
+  // Region of the parameters
+  region string
+  parameters() []aws.rds.parameterGroup.parameter
+}
+
+
 // Amazon RDS parameter groups
-aws.rds.parameterGroup @defaults("name family region") {
+aws.rds.parameterGroup @defaults("name family region arn") {
   // ARN for resource
   arn string
   // Family of the Parameter Group

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -538,6 +538,10 @@ func init() {
 			// to override args, implement: initAwsRdsPendingMaintenanceAction(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsRdsPendingMaintenanceAction,
 		},
+		"aws.rds.clusterParameterGroup": {
+			// to override args, implement: initAwsRdsClusterParameterGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsRdsClusterParameterGroup,
+		},
 		"aws.rds.parameterGroup": {
 			// to override args, implement: initAwsRdsParameterGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsRdsParameterGroup,
@@ -3184,6 +3188,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.parameterGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRds).GetParameterGroups()).ToDataRes(types.Array(types.Resource("aws.rds.parameterGroup")))
 	},
+	"aws.rds.clusterParameterGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRds).GetClusterParameterGroups()).ToDataRes(types.Array(types.Resource("aws.rds.clusterParameterGroup")))
+	},
 	"aws.rds.backupsetting.target": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsBackupsetting).GetTarget()).ToDataRes(types.String)
 	},
@@ -3531,6 +3538,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.rds.pendingMaintenanceAction.optInStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsPendingMaintenanceAction).GetOptInStatus()).ToDataRes(types.String)
+	},
+	"aws.rds.clusterParameterGroup.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsClusterParameterGroup).GetArn()).ToDataRes(types.String)
+	},
+	"aws.rds.clusterParameterGroup.family": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsClusterParameterGroup).GetFamily()).ToDataRes(types.String)
+	},
+	"aws.rds.clusterParameterGroup.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsClusterParameterGroup).GetName()).ToDataRes(types.String)
+	},
+	"aws.rds.clusterParameterGroup.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsClusterParameterGroup).GetDescription()).ToDataRes(types.String)
+	},
+	"aws.rds.clusterParameterGroup.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsClusterParameterGroup).GetRegion()).ToDataRes(types.String)
+	},
+	"aws.rds.clusterParameterGroup.parameters": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsClusterParameterGroup).GetParameters()).ToDataRes(types.Array(types.Resource("aws.rds.parameterGroup.parameter")))
 	},
 	"aws.rds.parameterGroup.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsParameterGroup).GetArn()).ToDataRes(types.String)
@@ -8743,6 +8768,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsRds).ParameterGroups, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
+	"aws.rds.clusterParameterGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRds).ClusterParameterGroups, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
 	"aws.rds.backupsetting.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 			r.(*mqlAwsRdsBackupsetting).__id, ok = v.Value.(string)
 			return
@@ -9225,6 +9254,34 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.rds.pendingMaintenanceAction.optInStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsPendingMaintenanceAction).OptInStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.clusterParameterGroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlAwsRdsClusterParameterGroup).__id, ok = v.Value.(string)
+			return
+		},
+	"aws.rds.clusterParameterGroup.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsClusterParameterGroup).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.clusterParameterGroup.family": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsClusterParameterGroup).Family, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.clusterParameterGroup.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsClusterParameterGroup).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.clusterParameterGroup.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsClusterParameterGroup).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.clusterParameterGroup.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsClusterParameterGroup).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.clusterParameterGroup.parameters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsClusterParameterGroup).Parameters, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
 	"aws.rds.parameterGroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -22293,6 +22350,7 @@ type mqlAwsRds struct {
 	Clusters plugin.TValue[[]interface{}]
 	AllPendingMaintenanceActions plugin.TValue[[]interface{}]
 	ParameterGroups plugin.TValue[[]interface{}]
+	ClusterParameterGroups plugin.TValue[[]interface{}]
 }
 
 // createAwsRds creates a new instance of this resource
@@ -22425,6 +22483,22 @@ func (c *mqlAwsRds) GetParameterGroups() *plugin.TValue[[]interface{}] {
 		}
 
 		return c.parameterGroups()
+	})
+}
+
+func (c *mqlAwsRds) GetClusterParameterGroups() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.ClusterParameterGroups, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds", c.__id, "clusterParameterGroups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.clusterParameterGroups()
 	})
 }
 
@@ -23331,6 +23405,87 @@ func (c *mqlAwsRdsPendingMaintenanceAction) GetForcedApplyDate() *plugin.TValue[
 
 func (c *mqlAwsRdsPendingMaintenanceAction) GetOptInStatus() *plugin.TValue[string] {
 	return &c.OptInStatus
+}
+
+// mqlAwsRdsClusterParameterGroup for the aws.rds.clusterParameterGroup resource
+type mqlAwsRdsClusterParameterGroup struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlAwsRdsClusterParameterGroupInternal it will be used here
+	Arn plugin.TValue[string]
+	Family plugin.TValue[string]
+	Name plugin.TValue[string]
+	Description plugin.TValue[string]
+	Region plugin.TValue[string]
+	Parameters plugin.TValue[[]interface{}]
+}
+
+// createAwsRdsClusterParameterGroup creates a new instance of this resource
+func createAwsRdsClusterParameterGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsRdsClusterParameterGroup{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.rds.clusterParameterGroup", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsRdsClusterParameterGroup) MqlName() string {
+	return "aws.rds.clusterParameterGroup"
+}
+
+func (c *mqlAwsRdsClusterParameterGroup) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsRdsClusterParameterGroup) GetArn() *plugin.TValue[string] {
+	return &c.Arn
+}
+
+func (c *mqlAwsRdsClusterParameterGroup) GetFamily() *plugin.TValue[string] {
+	return &c.Family
+}
+
+func (c *mqlAwsRdsClusterParameterGroup) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAwsRdsClusterParameterGroup) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlAwsRdsClusterParameterGroup) GetRegion() *plugin.TValue[string] {
+	return &c.Region
+}
+
+func (c *mqlAwsRdsClusterParameterGroup) GetParameters() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.Parameters, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds.clusterParameterGroup", c.__id, "parameters")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.parameters()
+	})
 }
 
 // mqlAwsRdsParameterGroup for the aws.rds.parameterGroup resource

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -538,6 +538,10 @@ func init() {
 			// to override args, implement: initAwsRdsPendingMaintenanceAction(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsRdsPendingMaintenanceAction,
 		},
+		"aws.rds.parameterGroup": {
+			// to override args, implement: initAwsRdsParameterGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsRdsParameterGroup,
+		},
 		"aws.elasticache": {
 			// to override args, implement: initAwsElasticache(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsElasticache,
@@ -3173,6 +3177,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.allPendingMaintenanceActions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRds).GetAllPendingMaintenanceActions()).ToDataRes(types.Array(types.Resource("aws.rds.pendingMaintenanceAction")))
 	},
+	"aws.rds.parameterGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRds).GetParameterGroups()).ToDataRes(types.Array(types.Resource("aws.rds.parameterGroup")))
+	},
 	"aws.rds.backupsetting.target": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsBackupsetting).GetTarget()).ToDataRes(types.String)
 	},
@@ -3322,6 +3329,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.rds.dbcluster.httpEndpointEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbcluster).GetHttpEndpointEnabled()).ToDataRes(types.Bool)
+	},
+	"aws.rds.dbcluster.parameterGroupName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetParameterGroupName()).ToDataRes(types.String)
 	},
 	"aws.rds.snapshot.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsSnapshot).GetArn()).ToDataRes(types.String)
@@ -3517,6 +3527,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.rds.pendingMaintenanceAction.optInStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsPendingMaintenanceAction).GetOptInStatus()).ToDataRes(types.String)
+	},
+	"aws.rds.parameterGroup.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsParameterGroup).GetArn()).ToDataRes(types.String)
+	},
+	"aws.rds.parameterGroup.family": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsParameterGroup).GetFamily()).ToDataRes(types.String)
+	},
+	"aws.rds.parameterGroup.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsParameterGroup).GetName()).ToDataRes(types.String)
+	},
+	"aws.rds.parameterGroup.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsParameterGroup).GetDescription()).ToDataRes(types.String)
+	},
+	"aws.rds.parameterGroup.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsParameterGroup).GetRegion()).ToDataRes(types.String)
 	},
 	"aws.elasticache.clusters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticache).GetClusters()).ToDataRes(types.Array(types.Dict))
@@ -8674,6 +8699,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsRds).AllPendingMaintenanceActions, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
+	"aws.rds.parameterGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRds).ParameterGroups, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
 	"aws.rds.backupsetting.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 			r.(*mqlAwsRdsBackupsetting).__id, ok = v.Value.(string)
 			return
@@ -8880,6 +8909,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.rds.dbcluster.httpEndpointEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsDbcluster).HttpEndpointEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbcluster.parameterGroupName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).ParameterGroupName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.rds.snapshot.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9152,6 +9185,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.rds.pendingMaintenanceAction.optInStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsPendingMaintenanceAction).OptInStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.parameterGroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlAwsRdsParameterGroup).__id, ok = v.Value.(string)
+			return
+		},
+	"aws.rds.parameterGroup.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsParameterGroup).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.parameterGroup.family": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsParameterGroup).Family, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.parameterGroup.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsParameterGroup).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.parameterGroup.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsParameterGroup).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.parameterGroup.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsParameterGroup).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.elasticache.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -22143,6 +22200,7 @@ type mqlAwsRds struct {
 	DbClusters plugin.TValue[[]interface{}]
 	Clusters plugin.TValue[[]interface{}]
 	AllPendingMaintenanceActions plugin.TValue[[]interface{}]
+	ParameterGroups plugin.TValue[[]interface{}]
 }
 
 // createAwsRds creates a new instance of this resource
@@ -22259,6 +22317,22 @@ func (c *mqlAwsRds) GetAllPendingMaintenanceActions() *plugin.TValue[[]interface
 		}
 
 		return c.allPendingMaintenanceActions()
+	})
+}
+
+func (c *mqlAwsRds) GetParameterGroups() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.ParameterGroups, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds", c.__id, "parameterGroups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.parameterGroups()
 	})
 }
 
@@ -22413,6 +22487,7 @@ type mqlAwsRdsDbcluster struct {
 	PreferredMaintenanceWindow plugin.TValue[string]
 	PreferredBackupWindow plugin.TValue[string]
 	HttpEndpointEnabled plugin.TValue[bool]
+	ParameterGroupName plugin.TValue[string]
 }
 
 // createAwsRdsDbcluster creates a new instance of this resource
@@ -22646,6 +22721,10 @@ func (c *mqlAwsRdsDbcluster) GetPreferredBackupWindow() *plugin.TValue[string] {
 
 func (c *mqlAwsRdsDbcluster) GetHttpEndpointEnabled() *plugin.TValue[bool] {
 	return &c.HttpEndpointEnabled
+}
+
+func (c *mqlAwsRdsDbcluster) GetParameterGroupName() *plugin.TValue[string] {
+	return &c.ParameterGroupName
 }
 
 // mqlAwsRdsSnapshot for the aws.rds.snapshot resource
@@ -23160,6 +23239,70 @@ func (c *mqlAwsRdsPendingMaintenanceAction) GetForcedApplyDate() *plugin.TValue[
 
 func (c *mqlAwsRdsPendingMaintenanceAction) GetOptInStatus() *plugin.TValue[string] {
 	return &c.OptInStatus
+}
+
+// mqlAwsRdsParameterGroup for the aws.rds.parameterGroup resource
+type mqlAwsRdsParameterGroup struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlAwsRdsParameterGroupInternal it will be used here
+	Arn plugin.TValue[string]
+	Family plugin.TValue[string]
+	Name plugin.TValue[string]
+	Description plugin.TValue[string]
+	Region plugin.TValue[string]
+}
+
+// createAwsRdsParameterGroup creates a new instance of this resource
+func createAwsRdsParameterGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsRdsParameterGroup{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.rds.parameterGroup", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsRdsParameterGroup) MqlName() string {
+	return "aws.rds.parameterGroup"
+}
+
+func (c *mqlAwsRdsParameterGroup) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsRdsParameterGroup) GetArn() *plugin.TValue[string] {
+	return &c.Arn
+}
+
+func (c *mqlAwsRdsParameterGroup) GetFamily() *plugin.TValue[string] {
+	return &c.Family
+}
+
+func (c *mqlAwsRdsParameterGroup) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAwsRdsParameterGroup) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlAwsRdsParameterGroup) GetRegion() *plugin.TValue[string] {
+	return &c.Region
 }
 
 // mqlAwsElasticache for the aws.elasticache resource

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -542,6 +542,10 @@ func init() {
 			// to override args, implement: initAwsRdsParameterGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsRdsParameterGroup,
 		},
+		"aws.rds.parameterGroup.parameter": {
+			// to override args, implement: initAwsRdsParameterGroupParameter(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsRdsParameterGroupParameter,
+		},
 		"aws.elasticache": {
 			// to override args, implement: initAwsElasticache(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsElasticache,
@@ -3542,6 +3546,42 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.rds.parameterGroup.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsParameterGroup).GetRegion()).ToDataRes(types.String)
+	},
+	"aws.rds.parameterGroup.parameters": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsParameterGroup).GetParameters()).ToDataRes(types.Array(types.Resource("aws.rds.parameterGroup.parameter")))
+	},
+	"aws.rds.parameterGroup.parameter.allowedValues": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsParameterGroupParameter).GetAllowedValues()).ToDataRes(types.String)
+	},
+	"aws.rds.parameterGroup.parameter.applyMethod": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsParameterGroupParameter).GetApplyMethod()).ToDataRes(types.String)
+	},
+	"aws.rds.parameterGroup.parameter.applyType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsParameterGroupParameter).GetApplyType()).ToDataRes(types.String)
+	},
+	"aws.rds.parameterGroup.parameter.dataType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsParameterGroupParameter).GetDataType()).ToDataRes(types.String)
+	},
+	"aws.rds.parameterGroup.parameter.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsParameterGroupParameter).GetDescription()).ToDataRes(types.String)
+	},
+	"aws.rds.parameterGroup.parameter.isModifiable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsParameterGroupParameter).GetIsModifiable()).ToDataRes(types.Bool)
+	},
+	"aws.rds.parameterGroup.parameter.minimumEngineVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsParameterGroupParameter).GetMinimumEngineVersion()).ToDataRes(types.String)
+	},
+	"aws.rds.parameterGroup.parameter.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsParameterGroupParameter).GetName()).ToDataRes(types.String)
+	},
+	"aws.rds.parameterGroup.parameter.value": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsParameterGroupParameter).GetValue()).ToDataRes(types.String)
+	},
+	"aws.rds.parameterGroup.parameter.source": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsParameterGroupParameter).GetSource()).ToDataRes(types.String)
+	},
+	"aws.rds.parameterGroup.parameter.supportedEngineModes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsParameterGroupParameter).GetSupportedEngineModes()).ToDataRes(types.Array(types.String))
 	},
 	"aws.elasticache.clusters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticache).GetClusters()).ToDataRes(types.Array(types.Dict))
@@ -9209,6 +9249,58 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.rds.parameterGroup.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsParameterGroup).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.parameterGroup.parameters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsParameterGroup).Parameters, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"aws.rds.parameterGroup.parameter.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlAwsRdsParameterGroupParameter).__id, ok = v.Value.(string)
+			return
+		},
+	"aws.rds.parameterGroup.parameter.allowedValues": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsParameterGroupParameter).AllowedValues, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.parameterGroup.parameter.applyMethod": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsParameterGroupParameter).ApplyMethod, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.parameterGroup.parameter.applyType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsParameterGroupParameter).ApplyType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.parameterGroup.parameter.dataType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsParameterGroupParameter).DataType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.parameterGroup.parameter.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsParameterGroupParameter).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.parameterGroup.parameter.isModifiable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsParameterGroupParameter).IsModifiable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.rds.parameterGroup.parameter.minimumEngineVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsParameterGroupParameter).MinimumEngineVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.parameterGroup.parameter.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsParameterGroupParameter).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.parameterGroup.parameter.value": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsParameterGroupParameter).Value, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.parameterGroup.parameter.source": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsParameterGroupParameter).Source, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.parameterGroup.parameter.supportedEngineModes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsParameterGroupParameter).SupportedEngineModes, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
 	"aws.elasticache.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -23251,6 +23343,7 @@ type mqlAwsRdsParameterGroup struct {
 	Name plugin.TValue[string]
 	Description plugin.TValue[string]
 	Region plugin.TValue[string]
+	Parameters plugin.TValue[[]interface{}]
 }
 
 // createAwsRdsParameterGroup creates a new instance of this resource
@@ -23303,6 +23396,116 @@ func (c *mqlAwsRdsParameterGroup) GetDescription() *plugin.TValue[string] {
 
 func (c *mqlAwsRdsParameterGroup) GetRegion() *plugin.TValue[string] {
 	return &c.Region
+}
+
+func (c *mqlAwsRdsParameterGroup) GetParameters() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.Parameters, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds.parameterGroup", c.__id, "parameters")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.parameters()
+	})
+}
+
+// mqlAwsRdsParameterGroupParameter for the aws.rds.parameterGroup.parameter resource
+type mqlAwsRdsParameterGroupParameter struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlAwsRdsParameterGroupParameterInternal it will be used here
+	AllowedValues plugin.TValue[string]
+	ApplyMethod plugin.TValue[string]
+	ApplyType plugin.TValue[string]
+	DataType plugin.TValue[string]
+	Description plugin.TValue[string]
+	IsModifiable plugin.TValue[bool]
+	MinimumEngineVersion plugin.TValue[string]
+	Name plugin.TValue[string]
+	Value plugin.TValue[string]
+	Source plugin.TValue[string]
+	SupportedEngineModes plugin.TValue[[]interface{}]
+}
+
+// createAwsRdsParameterGroupParameter creates a new instance of this resource
+func createAwsRdsParameterGroupParameter(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsRdsParameterGroupParameter{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.rds.parameterGroup.parameter", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsRdsParameterGroupParameter) MqlName() string {
+	return "aws.rds.parameterGroup.parameter"
+}
+
+func (c *mqlAwsRdsParameterGroupParameter) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsRdsParameterGroupParameter) GetAllowedValues() *plugin.TValue[string] {
+	return &c.AllowedValues
+}
+
+func (c *mqlAwsRdsParameterGroupParameter) GetApplyMethod() *plugin.TValue[string] {
+	return &c.ApplyMethod
+}
+
+func (c *mqlAwsRdsParameterGroupParameter) GetApplyType() *plugin.TValue[string] {
+	return &c.ApplyType
+}
+
+func (c *mqlAwsRdsParameterGroupParameter) GetDataType() *plugin.TValue[string] {
+	return &c.DataType
+}
+
+func (c *mqlAwsRdsParameterGroupParameter) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlAwsRdsParameterGroupParameter) GetIsModifiable() *plugin.TValue[bool] {
+	return &c.IsModifiable
+}
+
+func (c *mqlAwsRdsParameterGroupParameter) GetMinimumEngineVersion() *plugin.TValue[string] {
+	return &c.MinimumEngineVersion
+}
+
+func (c *mqlAwsRdsParameterGroupParameter) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAwsRdsParameterGroupParameter) GetValue() *plugin.TValue[string] {
+	return &c.Value
+}
+
+func (c *mqlAwsRdsParameterGroupParameter) GetSource() *plugin.TValue[string] {
+	return &c.Source
+}
+
+func (c *mqlAwsRdsParameterGroupParameter) GetSupportedEngineModes() *plugin.TValue[[]interface{}] {
+	return &c.SupportedEngineModes
 }
 
 // mqlAwsElasticache for the aws.elasticache resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2625,9 +2625,27 @@ resources:
       family: {}
       id: {}
       name: {}
+      parameters: {}
       region:
         min_mondoo_version: 9.0.0
     min_mondoo_version: 5.15.0
+    platform:
+      name:
+      - aws
+  aws.rds.parameterGroup.parameter:
+    fields:
+      allowedValues: {}
+      applyMethod: {}
+      applyType: {}
+      dataType: {}
+      description: {}
+      isModifiable: {}
+      minimumEngineVersion: {}
+      name: {}
+      source: {}
+      supportedEngineModes: {}
+      value: {}
+    min_mondoo_version: 9.0.0
     platform:
       name:
       - aws

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2408,6 +2408,8 @@ resources:
     fields:
       allPendingMaintenanceActions:
         min_mondoo_version: 9.0.0
+      clusterParameterGroups:
+        min_mondoo_version: 9.0.0
       clusters:
         min_mondoo_version: 9.0.0
       dbClusters: {}
@@ -2445,6 +2447,18 @@ resources:
       target: {}
       timezone: {}
     is_private: true
+    min_mondoo_version: 9.0.0
+    platform:
+      name:
+      - aws
+  aws.rds.clusterParameterGroup:
+    fields:
+      arn: {}
+      description: {}
+      family: {}
+      name: {}
+      parameters: {}
+      region: {}
     min_mondoo_version: 9.0.0
     platform:
       name:

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2414,6 +2414,8 @@ resources:
       dbInstances: {}
       instances:
         min_mondoo_version: 9.0.0
+      parameterGroups:
+        min_mondoo_version: 9.0.0
     min_mondoo_version: 5.15.0
     platform:
       name:
@@ -2502,6 +2504,8 @@ resources:
       multiAZ:
         min_mondoo_version: 9.0.0
       networkType:
+        min_mondoo_version: 9.0.0
+      parameterGroupName:
         min_mondoo_version: 9.0.0
       port:
         min_mondoo_version: 9.0.0
@@ -2610,6 +2614,19 @@ resources:
       subnets:
         min_mondoo_version: 9.0.0
       tags: {}
+    min_mondoo_version: 5.15.0
+    platform:
+      name:
+      - aws
+  aws.rds.parameterGroup:
+    fields:
+      arn: {}
+      description: {}
+      family: {}
+      id: {}
+      name: {}
+      region:
+        min_mondoo_version: 9.0.0
     min_mondoo_version: 5.15.0
     platform:
       name:

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -96,7 +96,6 @@ func (a *mqlAwsRds) getParameterGroups(conn *connection.AwsConnection) []*jobpoo
 					return nil, err
 				}
 				for _, dbParameterGroup := range DBParameterGroups.DBParameterGroups {
-
 					mqlParameterGroup, err := newMqlAwsParameterGroup(a.MqlRuntime, region, dbParameterGroup)
 					if err != nil {
 						return nil, err

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -246,6 +246,7 @@ type mqlAwsRdsDbinstanceInternal struct {
 func newMqlAwsParameterGroup(runtime *plugin.Runtime, region string, parameterGroup rds_types.DBParameterGroup) (*mqlAwsRdsParameterGroup, error) {
 	resource, err := CreateResource(runtime, "aws.rds.parameterGroup",
 		map[string]*llx.RawData{
+			"__id":        llx.StringData(fmt.Sprintf("%s/%s", *parameterGroup.DBParameterGroupArn, *parameterGroup.DBParameterGroupName)),
 			"arn":         llx.StringDataPtr(parameterGroup.DBParameterGroupArn),
 			"family":      llx.StringDataPtr(parameterGroup.DBParameterGroupFamily),
 			"name":        llx.StringDataPtr(parameterGroup.DBParameterGroupName),


### PR DESCRIPTION
Adding the `aws.rds.parameterGroup.parameter`, `aws.rds.parameterGroup` resources, as well as field for `aws.rds.dbcluster.parameterGroupName`.


![image](https://github.com/user-attachments/assets/686642de-c30b-46c9-8beb-2ecfab09ce9e)
![image](https://github.com/user-attachments/assets/2af6bf31-bff2-4533-992a-0b24d9e2bc8b)

https://github.com/mondoohq/cnquery/issues/5454

