### PR TITLE
🧪 experiment: avoid caching `aws` clients

### DIFF
--- a/providers/aws/connection/clients.go
+++ b/providers/aws/connection/clients.go
@@ -65,13 +65,27 @@ type CacheEntry struct {
 }
 
 // Cache is a map containing CacheEntry values
-type ClientsCache struct{ sync.Map }
+type ClientsCache struct {
+	sync.Map
+
+	disabled bool
+}
 
 // Store a Cache Entry
-func (c *ClientsCache) Store(key string, v *CacheEntry) { c.Map.Store(key, v) }
+func (c *ClientsCache) Store(key string, v *CacheEntry) {
+	if c.disabled {
+		return
+	}
+
+	c.Map.Store(key, v)
+}
 
 // Load a Cache Entry
 func (c *ClientsCache) Load(key string) (*CacheEntry, bool) {
+	if c.disabled {
+		return nil, false
+	}
+
 	res, ok := c.Map.Load(key)
 	if res == nil {
 		return nil, ok
@@ -80,7 +94,13 @@ func (c *ClientsCache) Load(key string) (*CacheEntry, bool) {
 }
 
 // Delete a Cache Entry
-func (c *ClientsCache) Delete(key string) { c.Map.Delete(key) }
+func (c *ClientsCache) Delete(key string) {
+	if c.disabled {
+		return
+	}
+
+	c.Map.Delete(key)
+}
 
 func (t *AwsConnection) Organizations(region string) *organizations.Client {
 	// if no region value is sent in, use the configured region

--- a/providers/aws/connection/clients_test.go
+++ b/providers/aws/connection/clients_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientsCache(t *testing.T) {
+	t.Run("cache enabled by default", func(t *testing.T) {
+		subject := ClientsCache{}
+		subject.Store("key", &CacheEntry{Data: "value"})
+		entry, found := subject.Load("key")
+		require.True(t, found)
+		require.NotNil(t, entry)
+	})
+	t.Run("cache disabled", func(t *testing.T) {
+		subject := ClientsCache{disabled: true}
+		subject.Store("key", &CacheEntry{Data: "value"})
+		entry, found := subject.Load("key")
+		require.False(t, found)
+		require.Nil(t, entry)
+	})
+}

--- a/providers/aws/connection/connection.go
+++ b/providers/aws/connection/connection.go
@@ -101,11 +101,12 @@ func NewMockConnection(id uint32, asset *inventory.Asset, conf *inventory.Config
 }
 
 func NewAwsConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*AwsConnection, error) {
-	log.Debug().Msg("new aws connection")
+	log.Trace().Msg("new aws connection")
 	// check flags for connection options
 	c := &AwsConnection{
 		awsConfigOptions: []func(*config.LoadOptions) error{},
 		Filters:          EmptyDiscoveryFilters(),
+		clientcache:      ClientsCache{disabled: true},
 	}
 
 	// merge the options to make sure we don't miss anything


### PR DESCRIPTION
The caching of clients for the `aws` provider assumes that we will cache clients
globally but in reality we cache clients per runtime, and when we have thousands
of runtimes we are essentially storing thousands of clients in memory.

Before removing or reimplementing this code, we will try to disable the caching and measure.