### PR TITLE
🐛 aws: initialize asset options

### DIFF
--- a/providers/aws/connection/connection.go
+++ b/providers/aws/connection/connection.go
@@ -109,6 +109,9 @@ func NewAwsConnection(id uint32, asset *inventory.Asset, conf *inventory.Config)
 	}
 
 	// merge the options to make sure we don't miss anything
+	if asset.Options == nil {
+		asset.Options = map[string]string{}
+	}
 	maps.Copy(asset.Options, conf.Options)
 
 	opts := parseFlagsForConnectionOptions(asset.Options, conf.GetCredentials())

--- a/providers/aws/connection/connection_test.go
+++ b/providers/aws/connection/connection_test.go
@@ -7,7 +7,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 )
+
+func TestNewAwsConnection(t *testing.T) {
+	conn, err := NewAwsConnection(123, &inventory.Asset{}, &inventory.Config{})
+	require.Nil(t, err)
+	require.NotNil(t, conn)
+}
 
 func TestParseOptsToFilters(t *testing.T) {
 	t.Run("all opts are mapped to discovery filters correctly", func(t *testing.T) {


### PR DESCRIPTION
Fixes panic:
```
│ DBG new aws connection                                                                                                                                                                                                                                                                                                     │
│ panic: assignment to entry in nil map                                                                                                                                                                                                                                                                                      │
│                                                                                                                                                                                                                                                                                                                            │
│ goroutine 37 [running]:                                                                                                                                                                                                                                                                                                    │
│ maps.Copy[...](...)                                                                                                                                                                                                                                                                                                        │
│     /home/runner/_work/_tool/go/1.24.0/x64/src/maps/maps.go:64                                                                                                                                                                                                                                                             │
│ go.mondoo.com/cnquery/v11/providers/aws/connection.NewAwsConnection(0x1, 0xc000bda640, 0xc000d26000)                                                                                                                                                                                                                       │
│     /home/runner/_work/cnquery/cnquery/providers/aws/connection/connection.go:112 +0x24c                                                                                                                                                                                                                                   │
│ go.mondoo.com/cnquery/v11/providers/aws/provider.(*Service).connect.func1(0x1)                                                                                                                                                                                                                                             │
│     /home/runner/_work/cnquery/cnquery/providers/aws/provider/provider.go:239 +0x170                                                                                                                                                                                                                                       │
│ go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin.(*Service).AddRuntime(0xc0009c0000, 0xc000d26000, 0xc000be9778)                                                                                                                                                                                                          │
│     /home/runner/_work/cnquery/cnquery/providers-sdk/v1/plugin/service.go:68 +0xed                                                                                                                                                                                                                                         │
│ go.mondoo.com/cnquery/v11/providers/aws/provider.(*Service).connect(0xc000baa2a0?, 0x1?, {0xa3afe38?, 0xc00099c950?})                                                                                                                                                                                                      │
│     /home/runner/_work/cnquery/cnquery/providers/aws/provider/provider.go:225 +0x6f                                                                                                                                                                                                                                        │
│ go.mondoo.com/cnquery/v11/providers/aws/provider.(*Service).Connect(0xc000496008, 0xc000802a20, {0xa3afe38, 0xc00099c950})                                                                                                                                                                                                 │
│     /home/runner/_work/cnquery/cnquery/providers/aws/provider/provider.go:183 +0xb0                                                                                                                                                                                                                                        │
│ go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin.(*GRPCServer).Connect(0xc0001d8140, {0x92a78a0?, 0xc000bb58b8?}, 0xc000802a20)                                                                                                                                                                                           │
│     /home/runner/_work/cnquery/cnquery/providers-sdk/v1/plugin/grpc.go:104 +0xd5                                                                                                                                                                                                                                           │
│ go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin._ProviderPlugin_Connect_Handler({0x92a78a0, 0xc0001d8140}, {0xa3b9e38, 0xc000bb8c00}, 0xc000bf0100, 0x0)                                                                                                                                                                 │
│     /home/runner/_work/cnquery/cnquery/providers-sdk/v1/plugin/plugin_grpc.pb.go:246 +0x1a6                                                                                                                                                                                                                                │
│ google.golang.org/grpc.(*Server).processUnaryRPC(0xc0003e0a00, {0xa3b9e38, 0xc000bb8b70}, 0xc000802840, 0xc00099a900, 0xdf496d0, 0x0)                                                                                                                                                                                      │
│     /home/runner/go/pkg/mod/google.golang.org/grpc@v1.71.0/server.go:1405 +0x1036                                                                                                                                                                                                                                          │
│ google.golang.org/grpc.(*Server).handleStream(0xc0003e0a00, {0xa3ba4d8, 0xc000a9c680}, 0xc000802840)                                                                                                                                                                                                                       │
│     /home/runner/go/pkg/mod/google.golang.org/grpc@v1.71.0/server.go:1815 +0xb88                                                                                                                                                                                                                                           │
│ google.golang.org/grpc.(*Server).serveStreams.func2.1()                                                                                                                                                                                                                                                                    │
│     /home/runner/go/pkg/mod/google.golang.org/grpc@v1.71.0/server.go:1035 +0x7f                                                                                                                                                                                                                                            │
│ created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 13                                                                                                                                                                                                                                             │
│     /home/runner/go/pkg/mod/google.golang.org/grpc@v1.71.0/server.go:1046 +0x11d                                                                                                                                                                                                                                           │
```