### PR TITLE
⭐ auditd.config

### DIFF
--- a/providers-sdk/v1/testutils/testdata/arch.json
+++ b/providers-sdk/v1/testutils/testdata/arch.json
@@ -1090,6 +1090,35 @@
           }
         },
         {
+          "Resource": "file",
+          "ID": "/etc/audit/auditd.conf",
+          "Fields": {
+            "content": {
+              "type": "\u0007",
+              "value": "#\n# This file controls the configuration of the audit daemon\n#\n\nlocal_events = yes\nwrite_logs = yes\nLOG_FILE = /var/log/audit/AuDiT.log\nlog_group = root\nLOG_FORMAT = ENRICHED\nflush = INCREMENTAL_ASYNC\nfreq = 50\nmax_log_file = 8\nnum_logs = 5\npriority_boost = 4\nname_format = NONE\n##name = mydomain\nmax_log_file_action = ROTATE\nspace_left = 75\nspace_left_action = SYSLOG\nverify_email = yes\naction_mail_acct = root\nadmin_space_left = 50\nadmin_space_left_action = SUSPEND\ndisk_full_action = SUSPEND\ndisk_error_action = SUSPEND\nuse_libwrap = yes\n##tcp_listen_port = 60\ntcp_listen_queue = 5\ntcp_max_per_addr = 1\n##tcp_client_ports = 1024-65535\ntcp_client_max_idle = 0\ntransport = TCP\nkrb5_principal = auditd\n##krb5_key_file = /etc/audit/audit.key\ndistribute_network = no\nq_depth = 2000\noverflow_action = SYSLOG\nmax_restarts = 10\nplugin_dir = /etc/audit/plugins.d\nend_of_event_timeout = 2\n"
+            },
+            "exists": {
+              "type": "\u0004",
+              "value": true
+            },
+            "path": {
+              "type": "\u0007",
+              "value": "/etc/audit/auditd.conf"
+            },
+            "permissions": {
+              "type": "\u001bfile.permissions",
+              "value": {
+                "Name": "file.permissions",
+                "ID": "-rw-r--r--"
+              }
+            },
+            "size": {
+              "type": "\u0005",
+              "value": 882
+            }
+          }
+        },
+        {
           "Resource": "user",
           "ID": "user/0/root",
           "Fields": {

--- a/providers/os/resources/auditd.go
+++ b/providers/os/resources/auditd.go
@@ -1,0 +1,137 @@
+// copyright: 2019, Dominik Richter and Christoph Hartmann
+// author: Dominik Richter
+// author: Christoph Hartmann
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+
+	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
+	"go.mondoo.com/cnquery/v11/providers/os/resources/parsers"
+	"go.mondoo.com/cnquery/v11/utils/multierr"
+)
+
+type mqlAuditdConfigInternal struct {
+	lock sync.Mutex
+}
+
+func initAuditdConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if x, ok := args["path"]; ok {
+		path, ok := x.Value.(string)
+		if !ok {
+			return nil, nil, errors.New("wrong type for 'path' in auditd.config initialization, it must be a string")
+		}
+
+		f, err := CreateResource(runtime, "file", map[string]*llx.RawData{
+			"path": llx.StringData(path),
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		args["file"] = llx.ResourceData(f, "file")
+
+		delete(args, "path")
+	}
+
+	return args, nil, nil
+}
+
+const defaultAuditdConfig = "/etc/audit/auditd.conf"
+
+func (s *mqlAuditdConfig) id() (string, error) {
+	file := s.GetFile()
+	if file.Error != nil {
+		return "", file.Error
+	}
+
+	return file.Data.Path.Data, nil
+}
+
+func (s *mqlAuditdConfig) file() (*mqlFile, error) {
+	f, err := CreateResource(s.MqlRuntime, "file", map[string]*llx.RawData{
+		"path": llx.StringData(defaultAuditdConfig),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return f.(*mqlFile), nil
+}
+
+func (s *mqlAuditdConfig) parse(file *mqlFile) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if file == nil {
+		return errors.New("no base auditd config file to read")
+	}
+
+	content := file.GetContent()
+	if content.Error != nil {
+		return content.Error
+	}
+
+	ini := parsers.ParseIni(content.Data, "=")
+
+	res := make(map[string]any, len(ini.Fields))
+	s.Params.Data = res
+	s.Params.State = plugin.StateIsSet
+
+	if len(ini.Fields) == 0 {
+		return nil
+	}
+
+	root := ini.Fields[""]
+	if root == nil {
+		s.Params.Error = errors.New("failed to parse auditd config")
+		return s.Params.Error
+	}
+
+	fields, ok := root.(map[string]any)
+	if !ok {
+		s.Params.Error = errors.New("failed to parse auditd config (invalid data retrieved)")
+		return s.Params.Error
+	}
+
+	var errs multierr.Errors
+	for k, v := range fields {
+		key := strings.ToLower(k)
+		if s, ok := v.(string); ok {
+			if slices.Contains(auditdDowncaseKeywords, key) {
+				res[key] = strings.ToLower(s)
+			} else {
+				res[key] = s
+			}
+		} else {
+			errs.Add(fmt.Errorf("can't parse field '"+s+"', value is %+v", v))
+		}
+	}
+
+	s.Params.Error = errs.Deduplicate()
+	return s.Params.Error
+}
+
+func (s *mqlAuditdConfig) params(file *mqlFile) (map[string]any, error) {
+	return nil, s.parse(file)
+}
+
+var auditdDowncaseKeywords = []string{
+	"local_events",
+	"write_logs",
+	"log_format",
+	"flush",
+	"max_log_file_action",
+	"verify_email",
+	"space_left_action",
+	"admin_space_left_action",
+	"disk_full_action",
+	"disk_error_action",
+	"use_libwrap",
+	"enable_krb5",
+	"overflow_action",
+}

--- a/providers/os/resources/auditd_test.go
+++ b/providers/os/resources/auditd_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/testutils"
+)
+
+func TestResource_AuditdConfig(t *testing.T) {
+	x.TestSimpleErrors(t, []testutils.SimpleTest{
+		{
+			Code:        "auditd.config('nopath').params",
+			ResultIndex: 0,
+			Expectation: "file 'nopath' not found",
+		},
+	})
+
+	t.Run("auditd file path", func(t *testing.T) {
+		res := x.TestQuery(t, "auditd.config.file.path")
+		assert.NotEmpty(t, res)
+		assert.NoError(t, res[0].Data.Error)
+	})
+
+	t.Run("auditd params", func(t *testing.T) {
+		res := x.TestQuery(t, "auditd.config.params")
+		assert.NotEmpty(t, res)
+		assert.NoError(t, res[0].Data.Error)
+	})
+
+	t.Run("auditd is downcasing relevant params", func(t *testing.T) {
+		res := x.TestQuery(t, "auditd.config.params.log_format")
+		assert.NotEmpty(t, res)
+		assert.NoError(t, res[0].Data.Error)
+		assert.Equal(t, "enriched", res[0].Data.Value)
+	})
+
+	t.Run("auditd is NOT downcasing other params", func(t *testing.T) {
+		res := x.TestQuery(t, "auditd.config.params.log_file")
+		assert.NotEmpty(t, res)
+		assert.NoError(t, res[0].Data.Error)
+		assert.Equal(t, "/var/log/audit/AuDiT.log", res[0].Data.Value)
+	})
+}

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -722,6 +722,14 @@ private sshd.config.matchBlock @defaults("criteria") @context("file.context") {
   params map[string]string
 }
 
+auditd.config {
+  init(path? string)
+  // File of this Auditd configuration
+  file() file
+  // Conifguration values of this config
+  params(file) map[string]string
+}
+
 // Service on this system
 service @defaults("name running enabled type") {
   init(name string)

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -726,7 +726,7 @@ auditd.config {
   init(path? string)
   // File of this Auditd configuration
   file() file
-  // Conifguration values of this config
+  // Configuration values of this config
   params(file) map[string]string
 }
 

--- a/providers/os/resources/os.lr.manifest.yaml
+++ b/providers/os/resources/os.lr.manifest.yaml
@@ -45,6 +45,16 @@ resources:
       vector: {}
     is_private: true
     min_mondoo_version: 5.15.0
+  auditd.conf:
+    fields:
+      file: {}
+      params: {}
+    min_mondoo_version: 9.0.0
+  auditd.config:
+    fields:
+      file: {}
+      params: {}
+    min_mondoo_version: 9.0.0
   auditpol:
     fields:
       list:


### PR DESCRIPTION
Add the auditd resource. You can access the configuration via `params` like this:

```coffee
> auditd.config.params
{
  action_mail_acct: "root"
  admin_space_left: "50"
  admin_space_left_action: "suspend"
  disk_error_action: "suspend"
  disk_full_action: "suspend"
  distribute_network: "no"
...

> auditd.config.params.log_format
"enriched"
```

By default, it will read out `/etc/audit/auditd.conf`.  All parameters are lowercase by default. As with similar resources, you can change the path of the file via the first parameter i.e. `auditd.config('/my/path')...`.

Note:
- We downcase all keys in the file, because auditd appears to be case-insensitive
- We do the same to only some of the values. Please check if the list is correct, otherwise feedback is welcome! We felt it was dangerous to downcase everything, because e.g. filenames, usernames and groups are being specified, all of which may be case-sensitive