### PR TITLE
🐛 improve windows hypervisor detection

### DIFF
--- a/providers/os/id/hypervisor/hypervisor_test.go
+++ b/providers/os/id/hypervisor/hypervisor_test.go
@@ -75,6 +75,18 @@ func TestHypervisorWindowsWmicGetModel(t *testing.T) {
 	assert.Equal(t, "VirtualBox", hypervisor)
 }
 
+func TestHypervisorWindowsServer2022SMBIOSBIOSVersion(t *testing.T) {
+	conn, err := mock.New(0, "./testdata/windows_serer_2022_running_hyper_v.toml", &inventory.Asset{})
+	require.NoError(t, err)
+	platform, ok := detector.DetectOS(conn)
+	require.True(t, ok)
+
+	hypervisor, ok := subject.Hypervisor(conn, platform)
+	require.True(t, ok)
+
+	assert.Equal(t, "Hyper-V", hypervisor)
+}
+
 func TestHypervisorLinuxDmidecode(t *testing.T) {
 	conn, err := mock.New(0, "./testdata/linux_dmidecode.toml", &inventory.Asset{})
 	require.NoError(t, err)

--- a/providers/os/id/hypervisor/testdata/windows_serer_2022_running_hyper_v.toml
+++ b/providers/os/id/hypervisor/testdata/windows_serer_2022_running_hyper_v.toml
@@ -1,0 +1,17 @@
+[commands."wmic os get * /format:csv"]
+stdout = """Node,BootDevice,BuildNumber,BuildType,Caption,CodeSet,CountryCode,CreationClassName,CSCreationClassName,CSDVersion,CSName,CurrentTimeZone,DataExecutionPrevention_32BitApplications,DataExecutionPrevention_Available,DataExecutionPrevention_Drivers,DataExecutionPrevention_SupportPolicy,Debug,Description,Distributed,EncryptionLevel,ForegroundApplicationBoost,FreePhysicalMemory,FreeSpaceInPagingFiles,FreeVirtualMemory,InstallDate,LargeSystemCache,LastBootUpTime,LocalDateTime,Locale,Manufacturer,MaxNumberOfProcesses,MaxProcessMemorySize,MUILanguages,Name,NumberOfLicensedUsers,NumberOfProcesses,NumberOfUsers,OperatingSystemSKU,Organization,OSArchitecture,OSLanguage,OSProductSuite,OSType,OtherTypeDescription,PAEEnabled,PlusProductID,PlusVersionNumber,PortableOperatingSystem,Primary,ProductType,RegisteredUser,SerialNumber,ServicePackMajorVersion,ServicePackMinorVersion,SizeStoredInPagingFiles,Status,SuiteMask,SystemDevice,SystemDirectory,SystemDrive,TotalSwapSpaceSize,TotalVirtualMemorySize,TotalVisibleMemorySize,Version,WindowsDirectory
+WIN-VM1,\\Device\\HarddiskVolume1,14393,Multiprocessor Free,Microsoft Windows Server 2022 Standard Evaluation,1252,1,Win32_OperatingSystem,Win32_ComputerSystem,,WIN-VM1,-420,TRUE,TRUE,TRUE,3,FALSE,,FALSE,256,2,1629000,1179648,2833804,20180313201557.000000-420,,20180630024418.280385-420,20180630024734.124000-420,0409,Microsoft Corporation,4294967295,137438953344,{en-US},Microsoft Windows Server 2022 Standard Evaluation|C:\\Windows|\\Device\\Harddisk0\\Partition2,0,35,1,79,Virtual Machine,64-bit,1033,272,18,,,,,FALSE,TRUE,3,,00378-00000-00000-AA739,0,0,1179648,OK,272,\\Device\\HarddiskVolume2,C:\\Windows\\system32,C:,,3276340,2096692,10.0.14393,C:\\Windows"""
+
+[commands.a9bba5b30cdf1d9081a05519d8c5f33d1fc7157fc0ed4529905f6f6246581861]
+command = "powershell.exe -NoProfile -EncodedCommand JABQAHIAbwBnAHIAZQBzAHMAUAByAGUAZgBlAHIAZQBuAGMAZQA9ACcAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQAnADsAdwBtAGkAYwAgAGMAbwBtAHAAdQB0AGUAcgBzAHkAcwB0AGUAbQAgAGcAZQB0ACAAbQBvAGQAZQBsAA=="
+stdout = """Model
+Virtual Machine"""
+
+[commands.e95b1c2663517850f70fe12275de440c78fdbd6ad9547788ea06e551b67a8618]
+command = "powershell.exe -NoProfile -EncodedCommand JABQAHIAbwBnAHIAZQBzAHMAUAByAGUAZgBlAHIAZQBuAGMAZQA9ACcAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQAnADsARwBlAHQALQBDAGkAbQBJAG4AcwB0AGEAbgBjAGUAIAAtAEMAbABhAHMAcwBOAGEAbQBlACAAVwBpAG4AMwAyAF8AQwBvAG0AcAB1AHQAZQByAFMAeQBzAHQAZQBtACAAfAAgAFMAZQBsAGUAYwB0AC0ATwBiAGoAZQBjAHQAIAAtAEUAeABwAGEAbgBkAFAAcgBvAHAAZQByAHQAeQAgAE0AYQBuAHUAZgBhAGMAdAB1AHIAZQByAA=="
+stdout = """Microsoft Corporation"""
+
+[commands.8eb624f6d9b8837df9664a2c15fc2a42f182bcfd91b22d9f85281633ca04934e]
+command = "powershell.exe -NoProfile -EncodedCommand JABQAHIAbwBnAHIAZQBzAHMAUAByAGUAZgBlAHIAZQBuAGMAZQA9ACcAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQAnADsARwBlAHQALQBDAGkAbQBJAG4AcwB0AGEAbgBjAGUAIAAtAEMAbABhAHMAcwBOAGEAbQBlACAAVwBpAG4AMwAyAF8AQgBJAE8AUwAgAHwAIABTAGUAbABlAGMAdAAtAE8AYgBqAGUAYwB0ACAALQBFAHgAcABhAG4AZABQAHIAbwBwAGUAcgB0AHkAIABTAE0AQgBJAE8AUwBCAEkATwBTAFYAZQByAHMAaQBvAG4A"
+stdout = """Hyper-V UEFI Release v4.0"""
+

--- a/providers/os/id/hypervisor/windows_h.go
+++ b/providers/os/id/hypervisor/windows_h.go
@@ -3,21 +3,30 @@
 
 package hypervisor
 
+import "github.com/rs/zerolog/log"
+
+var windowsDetectionCommands = []string{
+	// System model is the preferred detection
+	"wmic computersystem get model",
+	// Fallback to check the computer manufacturer
+	"Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Manufacturer",
+	// Modern configurations like Windows Server 2022 running Hyper-V return generic data
+	// so we need a more reliable method, we are going to check the SMBIOSBIOSVersion as
+	// our last detection
+	"Get-CimInstance -ClassName Win32_BIOS | Select-Object -ExpandProperty SMBIOSBIOSVersion",
+}
+
 // detectWindowsHypervisor detects the hypervisor on Windows.
 func (h *hyper) detectWindowsHypervisor() (string, bool) {
-	stdout, err := h.RunCommand("wmic computersystem get model")
-	if err == nil {
-		if hypervisor, ok := mapHypervisor(stdout); ok {
-			return hypervisor, ok
+	for _, command := range windowsDetectionCommands {
+		stdout, err := h.RunCommand(command)
+		if err == nil {
+			if hypervisor, ok := mapHypervisor(stdout); ok {
+				return hypervisor, ok
+			}
 		}
-	}
 
-	// Use PowerShell as fallback
-	stdout, err = h.RunCommand(
-		"Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty Manufacturer",
-	)
-	if err == nil {
-		return mapHypervisor(stdout)
+		log.Debug().Err(err).Str("command", command).Msg("could not detect hypervisor")
 	}
 
 	return "", false


### PR DESCRIPTION
Modern configurations like Windows Server 2022 running Hyper-V return
generic data so we need a more reliable method, we are going to check the
SMBIOSBIOSVersion as our last detection.

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlY3U1djk0cnhqZ2IzeDA5bjUzZmVwNmh4ZTdubmk0bmk0Mno3eGxoMiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/hVazFLob1BnLpuWoXx/giphy.gif"/>