### PR TITLE
🐛 azure: fix web app runtime stacks

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -1026,7 +1026,29 @@ private azure.subscription.webService {
   // List of web apps
   apps() []azure.subscription.webService.appsite
   // Available runtimes
-  availableRuntimes() []dict
+  availableRuntimes() []azure.subscription.webService.appRuntimeStack
+}
+
+// Azure Web App runtime stack
+private azure.subscription.webService.appRuntimeStack @defaults("preferredOs runtimeVersion") {
+  // Web App stack name
+  name string
+  // Web App stack preferred OS
+  preferredOs string
+  // Web App runtime version
+  runtimeVersion string
+  // Web App stack major version name
+  majorVersion string
+  // Web App stack minor version name
+  minorVersion string
+  // Whether the stack version is auto-updated
+  autoUpdate bool
+  // Whether the stack is deprecated
+  deprecated bool
+  // Whether the stack is hidden
+  hidden bool
+  // End-of-life date for the minor version
+  endOfLifeDate time
 }
 
 // Azure Web app site

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -226,6 +226,10 @@ func init() {
 			Init: initAzureSubscriptionWebService,
 			Create: createAzureSubscriptionWebService,
 		},
+		"azure.subscription.webService.appRuntimeStack": {
+			// to override args, implement: initAzureSubscriptionWebServiceAppRuntimeStack(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAzureSubscriptionWebServiceAppRuntimeStack,
+		},
 		"azure.subscription.webService.appsite": {
 			// to override args, implement: initAzureSubscriptionWebServiceAppsite(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAzureSubscriptionWebServiceAppsite,
@@ -1740,7 +1744,34 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlAzureSubscriptionWebService).GetApps()).ToDataRes(types.Array(types.Resource("azure.subscription.webService.appsite")))
 	},
 	"azure.subscription.webService.availableRuntimes": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionWebService).GetAvailableRuntimes()).ToDataRes(types.Array(types.Dict))
+		return (r.(*mqlAzureSubscriptionWebService).GetAvailableRuntimes()).ToDataRes(types.Array(types.Resource("azure.subscription.webService.appRuntimeStack")))
+	},
+	"azure.subscription.webService.appRuntimeStack.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppRuntimeStack).GetName()).ToDataRes(types.String)
+	},
+	"azure.subscription.webService.appRuntimeStack.preferredOs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppRuntimeStack).GetPreferredOs()).ToDataRes(types.String)
+	},
+	"azure.subscription.webService.appRuntimeStack.runtimeVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppRuntimeStack).GetRuntimeVersion()).ToDataRes(types.String)
+	},
+	"azure.subscription.webService.appRuntimeStack.majorVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppRuntimeStack).GetMajorVersion()).ToDataRes(types.String)
+	},
+	"azure.subscription.webService.appRuntimeStack.minorVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppRuntimeStack).GetMinorVersion()).ToDataRes(types.String)
+	},
+	"azure.subscription.webService.appRuntimeStack.autoUpdate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppRuntimeStack).GetAutoUpdate()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.webService.appRuntimeStack.deprecated": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppRuntimeStack).GetDeprecated()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.webService.appRuntimeStack.hidden": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppRuntimeStack).GetHidden()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.webService.appRuntimeStack.endOfLifeDate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppRuntimeStack).GetEndOfLifeDate()).ToDataRes(types.Time)
 	},
 	"azure.subscription.webService.appsite.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetId()).ToDataRes(types.String)
@@ -4819,6 +4850,46 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"azure.subscription.webService.availableRuntimes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebService).AvailableRuntimes, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appRuntimeStack.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlAzureSubscriptionWebServiceAppRuntimeStack).__id, ok = v.Value.(string)
+			return
+		},
+	"azure.subscription.webService.appRuntimeStack.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppRuntimeStack).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appRuntimeStack.preferredOs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppRuntimeStack).PreferredOs, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appRuntimeStack.runtimeVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppRuntimeStack).RuntimeVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appRuntimeStack.majorVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppRuntimeStack).MajorVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appRuntimeStack.minorVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppRuntimeStack).MinorVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appRuntimeStack.autoUpdate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppRuntimeStack).AutoUpdate, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appRuntimeStack.deprecated": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppRuntimeStack).Deprecated, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appRuntimeStack.hidden": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppRuntimeStack).Hidden, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appRuntimeStack.endOfLifeDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppRuntimeStack).EndOfLifeDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.webService.appsite.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11766,8 +11837,102 @@ func (c *mqlAzureSubscriptionWebService) GetApps() *plugin.TValue[[]interface{}]
 
 func (c *mqlAzureSubscriptionWebService) GetAvailableRuntimes() *plugin.TValue[[]interface{}] {
 	return plugin.GetOrCompute[[]interface{}](&c.AvailableRuntimes, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService", c.__id, "availableRuntimes")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
 		return c.availableRuntimes()
 	})
+}
+
+// mqlAzureSubscriptionWebServiceAppRuntimeStack for the azure.subscription.webService.appRuntimeStack resource
+type mqlAzureSubscriptionWebServiceAppRuntimeStack struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlAzureSubscriptionWebServiceAppRuntimeStackInternal it will be used here
+	Name plugin.TValue[string]
+	PreferredOs plugin.TValue[string]
+	RuntimeVersion plugin.TValue[string]
+	MajorVersion plugin.TValue[string]
+	MinorVersion plugin.TValue[string]
+	AutoUpdate plugin.TValue[bool]
+	Deprecated plugin.TValue[bool]
+	Hidden plugin.TValue[bool]
+	EndOfLifeDate plugin.TValue[*time.Time]
+}
+
+// createAzureSubscriptionWebServiceAppRuntimeStack creates a new instance of this resource
+func createAzureSubscriptionWebServiceAppRuntimeStack(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAzureSubscriptionWebServiceAppRuntimeStack{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("azure.subscription.webService.appRuntimeStack", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppRuntimeStack) MqlName() string {
+	return "azure.subscription.webService.appRuntimeStack"
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppRuntimeStack) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppRuntimeStack) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppRuntimeStack) GetPreferredOs() *plugin.TValue[string] {
+	return &c.PreferredOs
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppRuntimeStack) GetRuntimeVersion() *plugin.TValue[string] {
+	return &c.RuntimeVersion
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppRuntimeStack) GetMajorVersion() *plugin.TValue[string] {
+	return &c.MajorVersion
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppRuntimeStack) GetMinorVersion() *plugin.TValue[string] {
+	return &c.MinorVersion
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppRuntimeStack) GetAutoUpdate() *plugin.TValue[bool] {
+	return &c.AutoUpdate
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppRuntimeStack) GetDeprecated() *plugin.TValue[bool] {
+	return &c.Deprecated
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppRuntimeStack) GetHidden() *plugin.TValue[bool] {
+	return &c.Hidden
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppRuntimeStack) GetEndOfLifeDate() *plugin.TValue[*time.Time] {
+	return &c.EndOfLifeDate
 }
 
 // mqlAzureSubscriptionWebServiceAppsite for the azure.subscription.webService.appsite resource

--- a/providers/azure/resources/azure.lr.manifest.yaml
+++ b/providers/azure/resources/azure.lr.manifest.yaml
@@ -2892,6 +2892,22 @@ resources:
     refs:
     - title: Azure Web documentation
       url: https://learn.microsoft.com/en-us/azure/?product=web
+  azure.subscription.webService.appRuntimeStack:
+    fields:
+      autoUpdate: {}
+      deprecated: {}
+      endOfLifeDate: {}
+      hidden: {}
+      majorVersion: {}
+      minorVersion: {}
+      name: {}
+      preferredOs: {}
+      runtimeVersion: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
+    platform:
+      name:
+      - azure
   azure.subscription.webService.appsite:
     fields:
       applicationSettings: {}

--- a/providers/azure/resources/web.go
+++ b/providers/azure/resources/web.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/rs/zerolog/log"
@@ -27,31 +28,39 @@ import (
 var majorVersionRegex = regexp.MustCompile(`^(\d+)`)
 
 func isPlatformEol(platform string, version string) bool {
+	if version == "" {
+		return false
+	}
+	if platform != "node" {
+		return false
+	}
 	m := majorVersionRegex.FindString(version)
-	if platform == "node" {
+	val, err := strconv.Atoi(m)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Str("platform", platform).
+			Str("version", version).
+			Msg("could not parse the azure webapp version")
+		return false
+	}
 
-		val, err := strconv.Atoi(m)
-		if err != nil {
-			log.Error().Err(err).Str("platform", platform).Str("version", version).Msg("could not parse the azure webapp version")
-			return false
-		}
-
-		if val < 10 || val == 11 {
-			return true
-		}
+	if val < 10 || val == 11 {
+		return true
 	}
 	return false
 }
 
 type AzureWebAppStackRuntime struct {
-	Name         string `json:"name,omitempty"`
-	ID           string `json:"id,omitempty"`
-	Os           string `json:"os,omitempty"`
-	MajorVersion string `json:"majorVersion,omitempty"`
-	MinorVersion string `json:"minorVersion,omitempty"`
-	IsDeprecated bool   `json:"isDeprecated,omitempty"`
-	IsHidden     bool   `json:"isHidden,omitempty"`
-	IsDefault    bool   `json:"isDefault,omitempty"`
+	Name          string    `json:"name,omitempty"`
+	ID            string    `json:"id,omitempty"`
+	Os            string    `json:"os,omitempty"`
+	MajorVersion  string    `json:"majorVersion,omitempty"`
+	MinorVersion  string    `json:"minorVersion,omitempty"`
+	IsDeprecated  bool      `json:"isDeprecated,omitempty"`
+	IsHidden      bool      `json:"isHidden,omitempty"`
+	IsDefault     bool      `json:"isDefault,omitempty"`
+	EndOfLifeDate time.Time `json:"endOfLifeDate,omitempty"`
 }
 
 func (a *mqlAzureSubscriptionWebService) id() (string, error) {
@@ -152,108 +161,96 @@ func (a *mqlAzureSubscriptionWebService) availableRuntimes() ([]interface{}, err
 	}
 
 	res := []interface{}{}
-	windows := web.Enum15Windows
-	// NOTE: we do not return MQL resource since stacks do not have their own proper id in azure
-	windowsPager := client.NewGetAvailableStacksPager(&web.ProviderClientGetAvailableStacksOptions{OSTypeSelected: &windows})
-	for windowsPager.More() {
-		page, err := windowsPager.NextPage(ctx)
+	mapIDs := map[string]struct{}{}
+	pager := client.NewGetWebAppStacksPager(&web.ProviderClientGetWebAppStacksOptions{
+		StackOsType: convert.ToPtr(web.Enum19All),
+	})
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
 		if err != nil {
 			return nil, err
 		}
 		for _, entry := range page.Value {
-
 			majorVersions := entry.Properties.MajorVersions
-			for j := range majorVersions {
-				majorVersion := majorVersions[j]
-
-				// NOTE: yes, not all major versions include minor versions
-				minorVersions := majorVersion.MinorVersions
-
-				// special handling for dotnet and aspdotnet
-				if len(minorVersions) == 0 {
-
-					// NOTE: for dotnet, it seems the runtime is using the display version to create a stack
-					// BUT: the stack itself reports the runtime version, therefore we need it to match the stacks
-					runtimeVersion := convert.ToValue(majorVersion.RuntimeVersion)
-					// for dotnet, no runtime version is returned, therefore we need to use the display version
-					if len(runtimeVersion) == 0 {
-						runtimeVersion = convert.ToValue(majorVersion.DisplayVersion)
+			stackName := convert.ToValue(entry.Name)
+			for _, major := range majorVersions {
+				majorText := convert.ToValue(major.DisplayText)
+				for _, minor := range major.MinorVersions {
+					minorText := convert.ToValue(minor.DisplayText)
+					if minor.StackSettings == nil {
+						log.Debug().
+							Str("stack_name", stackName).
+							Str("major_version", majorText).
+							Str("minor_version", minorText).
+							Msg("no stack settings, skipping")
+						continue
 					}
 
-					runtime := AzureWebAppStackRuntime{
-						Name: convert.ToValue(entry.Name),
-
-						ID:           strings.ToUpper(convert.ToValue(entry.Name)) + "|" + runtimeVersion,
-						Os:           "windows",
-						MajorVersion: convert.ToValue(majorVersion.DisplayVersion),
-						IsDeprecated: convert.ToValue(majorVersion.IsDeprecated),
-						IsHidden:     convert.ToValue(majorVersion.IsHidden),
-						IsDefault:    convert.ToValue(majorVersion.IsDefault),
+					var os string
+					var settings *web.WebAppRuntimeSettings
+					switch convert.ToValue(entry.Properties.PreferredOs) {
+					case "linux":
+						settings = minor.StackSettings.LinuxRuntimeSettings
+						os = "linux"
+					case "windows":
+						settings = minor.StackSettings.WindowsRuntimeSettings
+						os = "windows"
 					}
-					properties, err := convert.JsonToDict(runtime)
+
+					if settings == nil {
+						log.Debug().
+							Str("stack_name", stackName).
+							Str("major_version", majorText).
+							Str("preferred_os", string(convert.ToValue(entry.Properties.PreferredOs))).
+							Interface("stack_settings", minor.StackSettings).
+							Msg("unknown runtime settings, skipping")
+						continue
+					}
+
+					runtimeVersion := convert.ToValue(settings.RuntimeVersion)
+					if runtimeVersion == "" {
+						// some app runtimes like java doesn't return a runtime version, so we try
+						// to build it like "stackName|minorVersion"
+						runtimeVersion = strings.ToUpper(stackName + "|" + convert.ToValue(minor.Value))
+					} else if stackName == "dotnet" {
+						// dotnet doesn't format the runtime the same way like the rest of the runtimes
+						// so we try to format it to match what the Azure portal shows
+						dotNet := ".NET"
+						if strings.Contains(convert.ToValue(major.Value), "asp") {
+							dotNet = "ASP.NET"
+						}
+						runtimeVersion = strings.ToUpper(dotNet + "|" + convert.ToValue(minor.Value))
+					}
+
+					deprecated := convert.ToValue(settings.IsDeprecated) ||
+						isPlatformEol(convert.ToValue(entry.Name), convert.ToValue(major.Value))
+
+					id := strings.Join([]string{"azure.subscription", subId,
+						"webService.appRuntimeStack", os, runtimeVersion,
+					}, "/")
+
+					if _, exist := mapIDs[id]; exist {
+						continue
+					}
+					mapIDs[id] = struct{}{}
+
+					resource, err := NewResource(a.MqlRuntime, "azure.subscription.webService.appRuntimeStack",
+						map[string]*llx.RawData{
+							"__id":           llx.StringData(id),
+							"name":           llx.StringData(stackName),
+							"preferredOs":    llx.StringData(os),
+							"runtimeVersion": llx.StringData(runtimeVersion),
+							"deprecated":     llx.BoolData(deprecated),
+							"autoUpdate":     llx.BoolDataPtr(settings.IsAutoUpdate),
+							"hidden":         llx.BoolDataPtr(settings.IsHidden),
+							"endOfLifeDate":  llx.TimeDataPtr(settings.EndOfLifeDate),
+							"majorVersion":   llx.StringDataPtr(major.Value),
+							"minorVersion":   llx.StringDataPtr(minor.Value),
+						})
 					if err != nil {
 						return nil, err
 					}
-					res = append(res, properties)
-				}
-
-				for l := range minorVersions {
-					minorVersion := minorVersions[l]
-
-					runtime := AzureWebAppStackRuntime{
-						Name:         convert.ToValue(entry.Name),
-						ID:           strings.ToUpper(convert.ToValue(entry.Name)) + "|" + convert.ToValue(minorVersion.RuntimeVersion),
-						Os:           "windows",
-						MinorVersion: convert.ToValue(minorVersion.DisplayVersion),
-						MajorVersion: convert.ToValue(majorVersion.DisplayVersion),
-						IsDeprecated: convert.ToValue(majorVersion.IsDeprecated) || isPlatformEol(convert.ToValue(entry.Name), convert.ToValue(minorVersion.RuntimeVersion)),
-						IsHidden:     convert.ToValue(majorVersion.IsHidden),
-						IsDefault:    convert.ToValue(majorVersion.IsDefault),
-					}
-
-					properties, err := convert.JsonToDict(runtime)
-					if err != nil {
-						return nil, err
-					}
-					res = append(res, properties)
-				}
-			}
-		}
-	}
-
-	linux := web.Enum15Linux
-	// fetch all linux stacks
-	linuxPager := client.NewGetAvailableStacksPager(&web.ProviderClientGetAvailableStacksOptions{OSTypeSelected: &linux})
-	for linuxPager.More() {
-		page, err := linuxPager.NextPage(ctx)
-		if err != nil {
-			return nil, err
-		}
-		for _, entry := range page.Value {
-
-			majorVersions := entry.Properties.MajorVersions
-			for j := range majorVersions {
-				majorVersion := majorVersions[j]
-
-				minorVersions := majorVersion.MinorVersions
-				for l := range minorVersions {
-					minorVersion := minorVersions[l]
-					runtime := AzureWebAppStackRuntime{
-						Name:         convert.ToValue(entry.Name),
-						ID:           convert.ToValue(minorVersion.RuntimeVersion),
-						Os:           "linux",
-						MinorVersion: convert.ToValue(minorVersion.DisplayVersion),
-						MajorVersion: convert.ToValue(majorVersion.DisplayVersion),
-						IsDeprecated: convert.ToValue(majorVersion.IsDeprecated),
-						IsHidden:     convert.ToValue(majorVersion.IsHidden),
-						IsDefault:    convert.ToValue(majorVersion.IsDefault),
-					}
-
-					properties, err := convert.JsonToDict(runtime)
-					if err != nil {
-						return nil, err
-					}
-					res = append(res, properties)
+					res = append(res, resource)
 				}
 			}
 		}

--- a/providers/azure/resources/web_test.go
+++ b/providers/azure/resources/web_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestParseVersion(t *testing.T) {
+	assert.False(t, isPlatformEol("python", ""))
+	assert.False(t, isPlatformEol("python", "3.7"))
 	assert.False(t, isPlatformEol("node", "12-lts"))
 	assert.False(t, isPlatformEol("node", "10-lts"))
 	assert.True(t, isPlatformEol("node", "11.1"))


### PR DESCRIPTION
Closes https://github.com/mondoohq/cnquery/issues/5386

This change fixes the way we fetch app runtime stacks and exposes a native MQL resource
to make it easier to write policies against this data.

**List all runtime stacks**
![Screenshot 2025-05-05 at 12 08 35 PM](https://github.com/user-attachments/assets/d978a5c2-a148-4d78-a216-79006ee37515)

**List all Python minor versions**
![Screenshot 2025-05-05 at 12 03 25 PM](https://github.com/user-attachments/assets/f3e82805-93bd-4a11-ab11-338e2b4878f9)