### PR TITLE
🐛 Fix panic when failing to run hostname cmds.

### DIFF
--- a/providers/os/id/hostname/hostname.go
+++ b/providers/os/id/hostname/hostname.go
@@ -112,8 +112,16 @@ func Hostname(conn shared.Connection, pf *inventory.Platform) (string, bool) {
 // and read the standard output all in one function.
 func runCommand(conn shared.Connection, commandString string) (string, error) {
 	cmd, err := conn.RunCommand(commandString)
-	if err != nil && cmd.ExitStatus == 0 {
+	if err != nil {
 		return "", err
+	}
+
+	if cmd.ExitStatus != 0 {
+		outErr, err := io.ReadAll(cmd.Stderr)
+		if err != nil {
+			return "", err
+		}
+		return "", fmt.Errorf("failed to run command: %s", outErr)
 	}
 
 	data, err := io.ReadAll(cmd.Stdout)


### PR DESCRIPTION
The device connection was panicking since we were doing the following check:
```
if err != nil && cmd.ExitStatus != 0
```

If the command exec errs, it's likely `cmd` is nil, so we cannot access it. To reproduce, run
```sh
DEBUG=1 /tmp/cnquery scan device --device-name /dev/sda --include-mounted --mount-all-partitions
```
on a unix machine, replace `/dev/sda` with the root partition device.