### PR TITLE
🐛 Propagate AutoUpdate to all runtimes + avoid reinstalling deps

### DIFF
--- a/explorer/scan/benchmark/benchmark_test.go
+++ b/explorer/scan/benchmark/benchmark_test.go
@@ -5,6 +5,7 @@ package benchmark
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -14,6 +15,7 @@ import (
 	"go.mondoo.com/cnquery/v11"
 	"go.mondoo.com/cnquery/v11/explorer"
 	"go.mondoo.com/cnquery/v11/explorer/scan"
+	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/mqlc"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/testutils"
@@ -24,9 +26,18 @@ func init() {
 	zerolog.SetGlobalLevel(zerolog.Disabled)
 }
 
+// extract the runtime from the benchmark function since we want to focus on
+// compilation and scan time, not the preparation
+var runtime llx.Runtime
+
+func TestMain(m *testing.M) {
+	runtime = testutils.Local()
+	exitVal := m.Run()
+	os.Exit(exitVal)
+}
+
 func BenchmarkScan_SingleAsset(b *testing.B) {
 	ctx := context.Background()
-	runtime := testutils.Local()
 	conf := mqlc.NewConfig(runtime.Schema(), cnquery.DefaultFeatures)
 	job := &scan.Job{
 		Inventory: &inventory.Inventory{
@@ -73,7 +84,6 @@ func BenchmarkScan_SingleAsset(b *testing.B) {
 
 func BenchmarkScan_MultipleAssets(b *testing.B) {
 	ctx := context.Background()
-	runtime := testutils.Local()
 	conf := mqlc.NewConfig(runtime.Schema(), cnquery.DefaultFeatures)
 	job := &scan.Job{
 		Inventory: &inventory.Inventory{

--- a/explorer/scan/benchmark/benchmark_test.go
+++ b/explorer/scan/benchmark/benchmark_test.go
@@ -5,7 +5,6 @@ package benchmark
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -15,7 +14,6 @@ import (
 	"go.mondoo.com/cnquery/v11"
 	"go.mondoo.com/cnquery/v11/explorer"
 	"go.mondoo.com/cnquery/v11/explorer/scan"
-	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/mqlc"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/testutils"
@@ -26,18 +24,9 @@ func init() {
 	zerolog.SetGlobalLevel(zerolog.Disabled)
 }
 
-// extract the runtime from the benchmark function since we want to focus on
-// compilation and scan time, not the preparation
-var runtime llx.Runtime
-
-func TestMain(m *testing.M) {
-	runtime = testutils.Local()
-	exitVal := m.Run()
-	os.Exit(exitVal)
-}
-
 func BenchmarkScan_SingleAsset(b *testing.B) {
 	ctx := context.Background()
+	runtime := testutils.Local()
 	conf := mqlc.NewConfig(runtime.Schema(), cnquery.DefaultFeatures)
 	job := &scan.Job{
 		Inventory: &inventory.Inventory{
@@ -84,6 +73,7 @@ func BenchmarkScan_SingleAsset(b *testing.B) {
 
 func BenchmarkScan_MultipleAssets(b *testing.B) {
 	ctx := context.Background()
+	runtime := testutils.Local()
 	conf := mqlc.NewConfig(runtime.Schema(), cnquery.DefaultFeatures)
 	job := &scan.Job{
 		Inventory: &inventory.Inventory{

--- a/explorer/scan/discovery_test.go
+++ b/explorer/scan/discovery_test.go
@@ -141,8 +141,9 @@ func TestDiscoverAssets(t *testing.T) {
 	}
 
 	runtime := providers.Coordinator.NewRuntime()
+	assert.Nil(t, providers.SetDefaultRuntime(runtime))
 	runtime.AutoUpdate = providers.UpdateProvidersConfig{
-		Enabled:         false,
+		Enabled:         true,
 		RefreshInterval: 60 * 60,
 	}
 

--- a/explorer/scan/discovery_test.go
+++ b/explorer/scan/discovery_test.go
@@ -140,6 +140,12 @@ func TestDiscoverAssets(t *testing.T) {
 		}
 	}
 
+	runtime := providers.Coordinator.NewRuntime()
+	runtime.AutoUpdate = providers.UpdateProvidersConfig{
+		Enabled:         false,
+		RefreshInterval: 60 * 60,
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		inv := getInventory()
 		discoveredAssets, err := DiscoverAssets(context.Background(), inv, nil, recording.Null{})

--- a/providers-sdk/v1/testutils/testutils.go
+++ b/providers-sdk/v1/testutils/testutils.go
@@ -221,7 +221,7 @@ func Local() llx.Runtime {
 	schema.Add(mockprovider.Config.Name, mockSchema)
 
 	runtime := providers.Coordinator.NewRuntime()
-
+	providers.SetDefaultRuntime(runtime)
 	runtime.AutoUpdate = providers.UpdateProvidersConfig{
 		Enabled:         false,
 		RefreshInterval: 60 * 60,

--- a/providers-sdk/v1/testutils/testutils.go
+++ b/providers-sdk/v1/testutils/testutils.go
@@ -221,7 +221,7 @@ func Local() llx.Runtime {
 	schema.Add(mockprovider.Config.Name, mockSchema)
 
 	runtime := providers.Coordinator.NewRuntime()
-	providers.SetDefaultRuntime(runtime)
+	_ = providers.SetDefaultRuntime(runtime)
 	runtime.AutoUpdate = providers.UpdateProvidersConfig{
 		Enabled:         false,
 		RefreshInterval: 60 * 60,

--- a/providers-sdk/v1/testutils/testutils.go
+++ b/providers-sdk/v1/testutils/testutils.go
@@ -222,6 +222,11 @@ func Local() llx.Runtime {
 
 	runtime := providers.Coordinator.NewRuntime()
 
+	runtime.AutoUpdate = providers.UpdateProvidersConfig{
+		Enabled:         false,
+		RefreshInterval: 60 * 60,
+	}
+
 	provider := &providers.RunningProvider{
 		Name:   osconf.Config.Name,
 		ID:     osconf.Config.ID,

--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -123,6 +123,7 @@ func (c *coordinator) newRuntime() *Runtime {
 func (c *coordinator) NewRuntimeFrom(parent *Runtime) *Runtime {
 	res := c.NewRuntime()
 	res.UpstreamConfig = parent.UpstreamConfig
+	res.AutoUpdate = parent.AutoUpdate
 	res.recording = parent.Recording()
 	for k, v := range parent.providers {
 		res.providers[k] = v

--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -108,6 +108,9 @@ func (c *coordinator) newRuntime() *Runtime {
 		providers:       map[string]*ConnectedProvider{},
 		recording:       recording.Null{},
 		shutdownTimeout: defaultShutdownTimeout,
+		AutoUpdate: UpdateProvidersConfig{
+			Enabled: true,
+		},
 	}
 
 	c.mutex.Lock()

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -493,8 +493,8 @@ func installDependencies(provider *Provider, existing Providers) error {
 
 		// Check if dependency is already installed
 		depProvider := existing.Lookup(dependencyLookup)
-		if depProvider == nil {
-			continue
+		if depProvider != nil {
+			continue // exist
 		}
 
 		upstreamDep := DefaultProviders.Lookup(dependencyLookup)

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -181,7 +181,7 @@ func (r *Runtime) providerForAsset(asset *inventory.Asset) (*Provider, error) {
 			conn.Type = inventory.ConnBackendToType(conn.Backend)
 		}
 
-		provider, err := EnsureProvider(ProviderLookup{ConnType: conn.Type}, true, r.coordinator.Providers())
+		provider, err := EnsureProvider(ProviderLookup{ConnType: conn.Type}, r.AutoUpdate.Enabled, r.coordinator.Providers())
 		if err != nil {
 			errs.Add(err)
 			continue


### PR DESCRIPTION
This change fixes a number of things from our latest release:
* Removes hardcoded `AutoUpdate` setting and uses the config
* Avoids re-installing already installed dependencies
* Propagates the setting `AutoUpdate` to all runtimes created with a parent via `NewRuntimeFrom()`

<img src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlNzZ1Z29tZnM5bGlkaHE1Nm8xb29haHprbjQydzg3cDV1bmZtdGlnOCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/xT5LML2jr4jUnVwo5W/giphy.gif"/>