### PR TITLE
✨ Show running version of MS SQL based on KBs

### DIFF
--- a/providers/os/resources/packages/windows_packages.go
+++ b/providers/os/resources/packages/windows_packages.go
@@ -69,6 +69,10 @@ var (
 		WinArchArm:        "arm",
 		WinArchX86OnArm64: "x86onarm",
 	}
+
+	sqlHotfixRegExp = regexp.MustCompile(`^Hotfix .+ SQL Server`)
+	// Find the database engine package and use version as a reference for the update
+	msSqlServiceRegexp = regexp.MustCompile(`^SQL Server \d+ Database Engine Services$`)
 )
 
 type WSUSClassification int
@@ -618,7 +622,6 @@ func (win *WinPkgManager) Files(name string, version string, arch string) ([]Fil
 // findMsSqlHotfixes returns a list of hotfixes that are related to Microsoft SQL Server
 // The list is sorted by the hotfix id
 func findMsSqlHotfixes(packages []Package) []Package {
-	sqlHotfixRegExp := regexp.MustCompile(`^Hotfix .+ SQL Server`)
 	sqlHotfixes := []Package{}
 	for _, p := range packages {
 		if sqlHotfixRegExp.MatchString(p.Name) {
@@ -633,8 +636,6 @@ func findMsSqlHotfixes(packages []Package) []Package {
 
 // updateMsSqlPackages updates the version of the SQL Server packages to the latest hotfix version
 func updateMsSqlPackages(pkgs []Package, latestMsSqlHotfix Package) []Package {
-	// Find the database engine package and use version as a reference for the update
-	msSqlServiceRegexp := regexp.MustCompile(`^SQL Server \d+ Database Engine Services$`)
 	currentVersion := ""
 	for _, pkg := range pkgs {
 		if msSqlServiceRegexp.MatchString(pkg.Name) {


### PR DESCRIPTION
The single MS SQL Server packages do not show the correct version. Only in combination with the installed MS SQL KBs you can derive the running version.

Before:
```
packages.where.list: [
  0: {
    name: "Hotfix 4003 for SQL Server 2022 (KB5022375) (64-bit)"
    purl: "pkg:windows/windows/Hotfix%204003%20for%20SQL%20Server%202022%20%28KB5022375%29%20%2864-bit%29@16.0.4003.1?arch=AMD64"
    version: "16.0.4003.1"
  }
...
  14: {
    name: "Hotfix 4150 for SQL Server 2022 (KB5046059) (64-bit)"
    purl: "pkg:windows/windows/Hotfix%204150%20for%20SQL%20Server%202022%20%28KB5046059%29%20%2864-bit%29@16.0.4150.1?arch=AMD64"
    version: "16.0.4150.1"
  }
...
  27: {
    name: "SQL Server 2022 Database Engine Services"
    purl: "pkg:windows/windows/SQL%20Server%202022%20Database%20Engine%20Services@16.0.1000.6?arch=AMD64"
    version: "16.0.1000.6"
  }
...
```

Now:
```
packages.where.list: [
  0: {
    name: "Hotfix 4003 for SQL Server 2022 (KB5022375) (64-bit)"
    purl: "pkg:windows/windows/Hotfix%204003%20for%20SQL%20Server%202022%20%28KB5022375%29%20%2864-bit%29@16.0.4003.1?arch=AMD64"
    version: "16.0.4003.1"
  }
...
  14: {
    name: "Hotfix 4150 for SQL Server 2022 (KB5046059) (64-bit)"
    purl: "pkg:windows/windows/Hotfix%204150%20for%20SQL%20Server%202022%20%28KB5046059%29%20%2864-bit%29@16.0.4150.1?arch=AMD64"
    version: "16.0.4150.1"
  }
...
  27: {
    name: "SQL Server 2022 Database Engine Services"
    purl: "pkg:windows/windows/SQL%20Server%202022%20Database%20Engine%20Services@16.0.4150.1?arch=AMD64"
    version: "16.0.4150.1"
  }
```