### PR TITLE
Add a resource for parsing journald

### DIFF
--- a/providers/os/resources/journald.go
+++ b/providers/os/resources/journald.go
@@ -1,0 +1,136 @@
+// copyright: 2019, Dominik Richter and Christoph Hartmann
+// author: Dominik Richter
+// author: Christoph Hartmann
+// author: Tim Smith
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+
+	"go.mondoo.com/cnquery/v11/llx"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
+	"go.mondoo.com/cnquery/v11/providers/os/resources/parsers"
+	"go.mondoo.com/cnquery/v11/utils/multierr"
+)
+
+type mqlJournaldConfigInternal struct {
+	lock sync.Mutex
+}
+
+func initJournaldConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if x, ok := args["path"]; ok {
+		path, ok := x.Value.(string)
+		if !ok {
+			return nil, nil, errors.New("wrong type for 'path' in journald.config initialization, it must be a string")
+		}
+
+		f, err := CreateResource(runtime, "file", map[string]*llx.RawData{
+			"path": llx.StringData(path),
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		args["file"] = llx.ResourceData(f, "file")
+
+		delete(args, "path")
+	}
+
+	return args, nil, nil
+}
+
+const defaultJournaldConfig = "/etc/systemd/journald.conf"
+
+func (s *mqlJournaldConfig) id() (string, error) {
+	file := s.GetFile()
+	if file.Error != nil {
+		return "", file.Error
+	}
+
+	return file.Data.Path.Data, nil
+}
+
+func (s *mqlJournaldConfig) file() (*mqlFile, error) {
+	f, err := CreateResource(s.MqlRuntime, "file", map[string]*llx.RawData{
+		"path": llx.StringData(defaultJournaldConfig),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return f.(*mqlFile), nil
+}
+
+func (s *mqlJournaldConfig) parse(file *mqlFile) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if file == nil {
+		return errors.New("no base journald config file to read")
+	}
+
+	content := file.GetContent()
+	if content.Error != nil {
+		return content.Error
+	}
+
+	ini := parsers.ParseIni(content.Data, "=")
+
+	res := make(map[string]any, len(ini.Fields))
+	s.Params.Data = res
+	s.Params.State = plugin.StateIsSet
+
+	if len(ini.Fields) == 0 {
+		return nil
+	}
+
+	root := ini.Fields["Journal"]
+	if root == nil {
+		s.Params.Error = errors.New("failed to parse journald config")
+		return s.Params.Error
+	}
+
+	fields, ok := root.(map[string]any)
+	if !ok {
+		s.Params.Error = errors.New("failed to parse journald config (invalid data retrieved)")
+		return s.Params.Error
+	}
+
+	var errs multierr.Errors
+	for k, v := range fields {
+		key := strings.ToLower(k)
+		if s, ok := v.(string); ok {
+			if slices.Contains(journaldDowncaseKeywords, key) {
+				res[key] = strings.ToLower(s)
+			} else {
+				res[key] = s
+			}
+		} else {
+			errs.Add(fmt.Errorf("can't parse field '"+s+"', value is %+v", v))
+		}
+	}
+
+	s.Params.Error = errs.Deduplicate()
+	return s.Params.Error
+}
+
+func (s *mqlJournaldConfig) params(file *mqlFile) (map[string]any, error) {
+	return nil, s.parse(file)
+}
+
+// These are the boolean options in journald.conf which are case insensitive
+// See https://www.man7.org/linux/man-pages/man5/journald.conf.5.html
+var journaldDowncaseKeywords = []string{
+	"Compress",
+	"Seal",
+	"ForwardToSyslog",
+	"ForwardToKMsg",
+	"ForwardToConsole",
+	"ForwardToWall",
+	"ForwardToSocket",
+	"ReadKMsg",
+	"Audit",
+}

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -742,6 +742,15 @@ auditd.config {
   params(file) map[string]string
 }
 
+// systemd journald configuration
+journald.config {
+  init(path? string)
+  // File of this journald configuration
+  file() file
+  // Configuration values of this config
+  params(file) map[string]string
+}
+
 // Service on this system
 service @defaults("name running enabled type") {
   init(name string)

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -238,6 +238,10 @@ func init() {
 			Init: initAuditdConfig,
 			Create: createAuditdConfig,
 		},
+		"journald.config": {
+			Init: initJournaldConfig,
+			Create: createJournaldConfig,
+		},
 		"service": {
 			Init: initService,
 			Create: createService,
@@ -1349,6 +1353,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"auditd.config.params": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAuditdConfig).GetParams()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"journald.config.file": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlJournaldConfig).GetFile()).ToDataRes(types.Resource("file"))
+	},
+	"journald.config.params": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlJournaldConfig).GetParams()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"service.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlService).GetName()).ToDataRes(types.String)
@@ -3731,6 +3741,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"auditd.config.params": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAuditdConfig).Params, ok = plugin.RawToTValue[map[string]interface{}](v.Value, v.Error)
+		return
+	},
+	"journald.config.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlJournaldConfig).__id, ok = v.Value.(string)
+			return
+		},
+	"journald.config.file": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlJournaldConfig).File, ok = plugin.RawToTValue[*mqlFile](v.Value, v.Error)
+		return
+	},
+	"journald.config.params": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlJournaldConfig).Params, ok = plugin.RawToTValue[map[string]interface{}](v.Value, v.Error)
 		return
 	},
 	"service.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10041,6 +10063,79 @@ func (c *mqlAuditdConfig) GetFile() *plugin.TValue[*mqlFile] {
 }
 
 func (c *mqlAuditdConfig) GetParams() *plugin.TValue[map[string]interface{}] {
+	return plugin.GetOrCompute[map[string]interface{}](&c.Params, func() (map[string]interface{}, error) {
+		vargFile := c.GetFile()
+		if vargFile.Error != nil {
+			return nil, vargFile.Error
+		}
+
+		return c.params(vargFile.Data)
+	})
+}
+
+// mqlJournaldConfig for the journald.config resource
+type mqlJournaldConfig struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	mqlJournaldConfigInternal
+	File plugin.TValue[*mqlFile]
+	Params plugin.TValue[map[string]interface{}]
+}
+
+// createJournaldConfig creates a new instance of this resource
+func createJournaldConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlJournaldConfig{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+	res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("journald.config", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlJournaldConfig) MqlName() string {
+	return "journald.config"
+}
+
+func (c *mqlJournaldConfig) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlJournaldConfig) GetFile() *plugin.TValue[*mqlFile] {
+	return plugin.GetOrCompute[*mqlFile](&c.File, func() (*mqlFile, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("journald.config", c.__id, "file")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlFile), nil
+			}
+		}
+
+		return c.file()
+	})
+}
+
+func (c *mqlJournaldConfig) GetParams() *plugin.TValue[map[string]interface{}] {
 	return plugin.GetOrCompute[map[string]interface{}](&c.Params, func() (map[string]interface{}, error) {
 		vargFile := c.GetFile()
 		if vargFile.Error != nil {

--- a/providers/os/resources/os.lr.manifest.yaml
+++ b/providers/os/resources/os.lr.manifest.yaml
@@ -389,6 +389,11 @@ resources:
       source: {}
       target: {}
     min_mondoo_version: 5.15.0
+  journald.config:
+    fields:
+      file: {}
+      params: {}
+    min_mondoo_version: 9.0.0
   kernel:
     fields:
       info: {}


### PR DESCRIPTION
Replaces a query like this:

```
["/etc/systemd/journald.conf"].where(file(_).exists) {
  file(_) {
    parse.ini("/etc/systemd/journald.conf").sections["Journal"]["ForwardToSyslog"].downcase == "yes"
  }
}
```

with this

```
journald.config.params.ForwardToSyslog == "yes"
```