### PR TITLE
✨ support inRange on strings

### DIFF
--- a/llx/builtin.go
+++ b/llx/builtin.go
@@ -333,6 +333,7 @@ func init() {
 			string("contains" + types.Array(types.Regex)):  {f: stringContainsArrayRegex, Label: "contains"},
 			string("in"):        {f: stringInArray, Label: "in"},
 			string("notIn"):     {f: stringNotInArray, Label: "in"},
+			string("inRange"):   {f: stringInRange, Label: "inRange"},
 			string("find"):      {f: stringFindV2, Label: "find"},
 			string("camelcase"): {f: stringCamelcaseV2, Label: "camelcase"},
 			string("downcase"):  {f: stringDowncaseV2, Label: "downcase"},

--- a/llx/builtin_map.go
+++ b/llx/builtin_map.go
@@ -502,11 +502,13 @@ func dictInRange(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*Ra
 		return BoolFalse, 0, nil
 	}
 
-	switch x := bind.Value.(type) {
+	switch v := bind.Value.(type) {
 	case int64:
-		return int64InRange(e, x, chunk, ref)
+		return int64InRange(e, v, chunk, ref)
 	case float64:
-		return float64InRange(e, x, chunk, ref)
+		return float64InRange(e, v, chunk, ref)
+	case string:
+		return stringInRange(e, bind, chunk, ref)
 	default:
 		return nil, 0, errors.New("dict value does not support `inRange`")
 	}

--- a/llx/builtin_simple.go
+++ b/llx/builtin_simple.go
@@ -1613,6 +1613,21 @@ func int64InRange(e *blockExecutor, val int64, chunk *Chunk, ref uint64) (*RawDa
 		if float64(val) < minval {
 			return BoolFalse, 0, nil
 		}
+	case string:
+		f, err := strconv.ParseInt(minval, 10, 64)
+		if err == nil {
+			if val < f {
+				return BoolFalse, 0, nil
+			}
+		} else {
+			f, err := strconv.ParseFloat(minval, 64)
+			if err != nil {
+				return &RawData{Type: types.Bool, Error: errors.New("failed to parse minimum value of inRange as a number")}, 0, nil
+			}
+			if float64(val) < f {
+				return BoolFalse, 0, nil
+			}
+		}
 	}
 
 	maxRef := chunk.Function.Args[1]
@@ -1629,6 +1644,21 @@ func int64InRange(e *blockExecutor, val int64, chunk *Chunk, ref uint64) (*RawDa
 	case float64:
 		if float64(val) > maxval {
 			return BoolFalse, 0, nil
+		}
+	case string:
+		max, err := strconv.ParseInt(maxval, 10, 64)
+		if err == nil {
+			if val > max {
+				return BoolFalse, 0, nil
+			}
+		} else {
+			max, err := strconv.ParseFloat(maxval, 64)
+			if err != nil {
+				return &RawData{Type: types.Bool, Error: errors.New("failed to parse maximum value of inRange as a number")}, 0, nil
+			}
+			if float64(val) > max {
+				return BoolFalse, 0, nil
+			}
 		}
 	}
 
@@ -1668,6 +1698,21 @@ func float64InRange(e *blockExecutor, val float64, chunk *Chunk, ref uint64) (*R
 		if val > maxval {
 			return BoolFalse, 0, nil
 		}
+	case string:
+		max, err := strconv.ParseInt(maxval, 10, 64)
+		if err == nil {
+			if val > float64(max) {
+				return BoolFalse, 0, nil
+			}
+		} else {
+			max, err := strconv.ParseFloat(maxval, 64)
+			if err != nil {
+				return &RawData{Type: types.Bool, Error: errors.New("failed to parse maximum value of inRange as a number")}, 0, nil
+			}
+			if float64(val) > max {
+				return BoolFalse, 0, nil
+			}
+		}
 	}
 
 	return BoolTrue, 0, nil
@@ -1681,6 +1726,22 @@ func intInRange(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*Raw
 func floatInRange(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
 	val := bind.Value.(float64)
 	return float64InRange(e, val, chunk, ref)
+}
+
+func stringInRange(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
+	val := bind.Value.(string)
+
+	i, err := strconv.ParseInt(val, 10, 64)
+	if err == nil {
+		return int64InRange(e, i, chunk, ref)
+	}
+
+	f, err := strconv.ParseFloat(val, 64)
+	if err == nil {
+		return float64InRange(e, f, chunk, ref)
+	}
+
+	return &RawData{Type: types.Bool, Error: errors.New("can only check `inRange` on numbers")}, 0, nil
 }
 
 // float &&/|| T

--- a/mqlc/builtin.go
+++ b/mqlc/builtin.go
@@ -75,6 +75,10 @@ func init() {
 				typ: boolType, compile: compileStringInOrNotIn,
 				desc: "Checks if this string is not contained in an array of strings",
 			},
+			"inRange": {
+				typ: boolType, compile: compileNumberInRange,
+				desc: "Checks if the number is in range of a min and max",
+			},
 			"find": {
 				typ: stringArrayType, signature: FunctionSignature{Required: 1, Args: []types.Type{types.Regex}},
 				desc: "Find a regular expression in a string and return all matches as an array",

--- a/mqlc/builtin_simple.go
+++ b/mqlc/builtin_simple.go
@@ -193,11 +193,11 @@ func compileNumberInRange(c *compiler, typ types.Type, ref uint64, id string, ca
 		return types.Nil, errors.New("function " + id + " needs two arguments")
 	}
 
-	min, err := callArgTypeIs(c, call, id, "min", 0, types.Int, types.Float, types.Dict)
+	min, err := callArgTypeIs(c, call, id, "min", 0, types.Int, types.Float, types.Dict, types.String)
 	if err != nil {
 		return types.Nil, err
 	}
-	max, err := callArgTypeIs(c, call, id, "max", 1, types.Int, types.Float, types.Dict)
+	max, err := callArgTypeIs(c, call, id, "max", 1, types.Int, types.Float, types.Dict, types.String)
 	if err != nil {
 		return types.Nil, err
 	}

--- a/providers/core/resources/mql_test.go
+++ b/providers/core/resources/mql_test.go
@@ -374,6 +374,12 @@ func TestNumber_Methods(t *testing.T) {
 		{
 			Code: "3.0.inRange(1.0,2)", Expectation: false,
 		},
+		{
+			Code: "4.inRange('-4', '4')", Expectation: true,
+		},
+		{
+			Code: "5.inRange('-4', '4')", Expectation: false,
+		},
 	})
 }
 
@@ -479,6 +485,10 @@ func TestString_Methods(t *testing.T) {
 		{
 			Code:        "'hello ' + 'world'",
 			Expectation: "hello world",
+		},
+		{
+			Code:        "'23'.inRange(1,23)",
+			Expectation: true,
 		},
 	})
 }


### PR DESCRIPTION
The operator `inRange` currently only works on numbers. This makes it work with number-like strings as well, by parsing the number in the string and then comparing them.

```coffee
> "2".inRange(1,3)
true
```