### PR TITLE
🐛 detect if tls is enabled

### DIFF
--- a/providers/network/resources/socket.go
+++ b/providers/network/resources/socket.go
@@ -3,8 +3,11 @@
 
 package resources
 
-import "strconv"
+import (
+	"net"
+	"strconv"
+)
 
 func (s *mqlSocket) id() (string, error) {
-	return s.Protocol.Data + "://" + s.Address.Data + ":" + strconv.Itoa(int(s.Port.Data)), nil
+	return s.Protocol.Data + "://" + net.JoinHostPort(s.Address.Data, strconv.Itoa(int(s.Port.Data))), nil
 }

--- a/providers/os/resources/port.go
+++ b/providers/os/resources/port.go
@@ -602,8 +602,12 @@ func (p *mqlPorts) listMacos() ([]interface{}, error) {
 			}
 			// lsof presents a process listening on any ipv6 address as listening on "*"
 			// change this to a more ipv6-friendly formatting
-			if protocol == "ipv6" && strings.HasPrefix(localAddress, "*") {
-				localAddress = strings.Replace(localAddress, "*", "[::]", 1)
+			if strings.HasPrefix(localAddress, "*") {
+				if strings.HasSuffix(protocol, "6") {
+					localAddress = strings.Replace(localAddress, "*", "::1", 1)
+				} else {
+					localAddress = strings.Replace(localAddress, "*", "127.0.0.1", 1)
+				}
 			}
 
 			state, ok := TCP_STATES[fd.TcpState()]
@@ -649,7 +653,11 @@ func (s *mqlPort) id() (string, error) {
 
 func (s *mqlPort) tls(address string, port int64, proto string) (plugin.Resource, error) {
 	if address == "" || address == "0.0.0.0" {
-		address = "127.0.0.1"
+		if proto == "tcp6" {
+			address = "::1"
+		} else {
+			address = "127.0.0.1"
+		}
 	}
 
 	socket, err := s.MqlRuntime.CreateSharedResource("socket", map[string]*llx.RawData{


### PR DESCRIPTION
The `tls` resource is part of multiple core providers, it requires a `socket`
to know the host, port and protocol, many fields of this resource require
that the server (configured in the socket) speaks TLS and not plain text
(like HTTP), therefore this change makes it so that we only detect once if
the socket is running on TLS or not. If not, we return null properly to
indicate that there are no certificates, if it does, then we collect TLS
information.

Additionally, I am setting a default timeout of one minute to dial to the
socket compared to what was before (unlimited=no timeout).

Finally, if the TLS tester returns a timeout, we don't error the detection
but instead, we set the fields as null.

# Tests

## Host that speaks TLS

![Screenshot 2025-05-13 at 10 17 59 PM](https://github.com/user-attachments/assets/3effb5d6-da77-4fec-986a-cddf86880066)

## Host that speaks plain text (NO TLS)
![Screenshot 2025-05-13 at 10 18 12 PM](https://github.com/user-attachments/assets/a6e0bd24-dbef-4df7-b981-bd9066c58ae4)

## Listening ports on my local computer 

![Screenshot 2025-05-13 at 10 20 07 PM](https://github.com/user-attachments/assets/c71ba184-df17-431f-a0b2-157f36cd72fb)

