### PR TITLE
Revert "🧹 Bump goreleaser version to v2.9.0"

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -120,7 +120,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: v2.9.0 # needs regular updates
+          version: v2.5.1
           args: release --clean --timeout 120m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -137,7 +137,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: v2.9.0 # needs regular updates
+          version: latest
           args: release -f .github/.goreleaser-unstable.yml --clean --timeout 120m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts mondoohq/cnquery#5514

The signature failure is back: https://github.com/mondoohq/cnquery/actions/runs/14995885041/job/42129874396