### PR TITLE
🐛 mqlc: missing float builtin comparison

### DIFF
--- a/llx/builtin.go
+++ b/llx/builtin.go
@@ -182,6 +182,8 @@ func init() {
 			// == / !=
 			string("==" + types.Nil):                 {f: floatCmpNilV2, Label: "=="},
 			string("!=" + types.Nil):                 {f: floatNotNilV2, Label: "!="},
+			string("==" + types.Int):                 {f: floatCmpIntV2, Label: "=="},
+			string("!=" + types.Int):                 {f: floatNotIntV2, Label: "!="},
 			string("==" + types.Float):               {f: floatCmpFloatV2, Label: "=="},
 			string("!=" + types.Float):               {f: floatNotFloatV2, Label: "!="},
 			string("==" + types.String):              {f: floatCmpStringV2, Label: "=="},

--- a/providers/core/resources/mql_test.go
+++ b/providers/core/resources/mql_test.go
@@ -85,6 +85,10 @@ func TestCore_If(t *testing.T) {
 			Expectation: int64(789),
 		},
 		{
+			Code:        "if (1.0 == 1) { return 123 } return 456",
+			Expectation: int64(123),
+		},
+		{
 			// This test comes out from an issue we had where return was not
 			// generating a single entrypoint, causing the first reported
 			// value to be used as the return value.


### PR DESCRIPTION
When trying to compare a float with an integer, users will get this error:
```
cannot find operator handler: float == int
```

This adds the missing comparison.

Unblocks https://github.com/mondoohq/cnquery/pull/5504