### PR TITLE
🐛 fix map named access chaining

### DIFF
--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -1452,6 +1452,7 @@ func (c *compiler) compileOperand(operand *parser.Operand) (*llx.Primitive, erro
 						Args:    []*llx.Primitive{llx.StringPrimitive(id)},
 					},
 				})
+				typ = typ.Child()
 			} else {
 				typ = resType
 			}

--- a/providers-sdk/v1/testutils/testdata/arch.json
+++ b/providers-sdk/v1/testutils/testdata/arch.json
@@ -134,7 +134,7 @@
           "Fields": {
             "content": {
               "type": "\u0007",
-              "value": "{\n  \"_\": null,\n  \"true\": true,\n  \"1\": 1,\n  \"1.0\": 1.0,\n  \"int-array\": [1,2,3],\n  \"dict\": {\n    \"ee\": 3,\n    \"ej\": 4,\n    \"ek\": 5\n  },\n  \"f\": [{\"ff\": 3}],\n  \"string-array\": [\"a\", \"b\", \"c\"],\n  \"hello\": \"hello\",\n  \"date\": \"2016-01-28T23:02:24Z\",\n  \"aoa\": [[1, 2], 3],\n  \"users\": [\n    {\n      \"name\": \"yor\",\n      \"children\": [\n        {\"name\": \"anya\"}\n      ]\n    },\n    {\"name\": \"loid\"}\n  ],\n  \"zzzlast\": \"🌒\"}\n"
+              "value": "{\n  \"_\": null,\n  \"true\": true,\n  \"1\": 1,\n  \"1.0\": 1.0,\n  \"e\": {\"1\": 1, \"hi\": \"hello\"},\n  \"eins\": \"1\",\n  \"int-array\": [1,2,3],\n  \"dict\": {\n    \"ee\": 3,\n    \"ej\": 4,\n    \"ek\": 5\n  },\n  \"f\": [{\"ff\": 3}],\n  \"string-array\": [\"a\", \"b\", \"c\"],\n  \"hello\": \"hello\",\n  \"date\": \"2016-01-28T23:02:24Z\",\n  \"aoa\": [[1, 2], 3],\n  \"users\": [\n    {\n      \"name\": \"yor\",\n      \"children\": [\n        {\"name\": \"anya\"}\n      ]\n    },\n    {\"name\": \"loid\"}\n  ],\n  \"zzzlast\": \"🌒\"}\n"
             },
             "path": {
               "type": "\u0007",
@@ -149,7 +149,7 @@
             },
             "size": {
               "type": "\u0005",
-              "value": 266
+              "value": 439
             }
           }
         },

--- a/providers/core/resources/mql_test.go
+++ b/providers/core/resources/mql_test.go
@@ -801,6 +801,10 @@ func TestMap(t *testing.T) {
 			Code:        m + ".c",
 			ResultIndex: 0, Expectation: int64(2),
 		},
+		{
+			Code:        m + ".c.inRange(0,3)",
+			ResultIndex: 0, Expectation: true,
+		},
 		// contains
 		{
 			Code:        m + ".contains(key == 'a')",

--- a/providers/os/resources/mql_test.go
+++ b/providers/os/resources/mql_test.go
@@ -71,7 +71,7 @@ func TestOS_Vars(t *testing.T) {
 	x.TestSimple(t, []testutils.SimpleTest{
 		{
 			Code:        "p = file('/dummy.json'); parse.json(file: p).params.length",
-			Expectation: int64(13),
+			Expectation: int64(15),
 		},
 	})
 }
@@ -105,15 +105,15 @@ func TestMap(t *testing.T) {
 		},
 		{
 			Code:        "parse.json('/dummy.json').params.length",
-			Expectation: int64(13),
+			Expectation: int64(15),
 		},
 		{
 			Code:        "parse.json('/dummy.json').params.keys.length",
-			Expectation: int64(13),
+			Expectation: int64(15),
 		},
 		{
 			Code:        "parse.json('/dummy.json').params.values.length",
-			Expectation: int64(13),
+			Expectation: int64(15),
 		},
 		{
 			Code: "parse.json('/dummy.json').params { _['Protocol'] != 1 }",
@@ -277,6 +277,18 @@ func TestDict_Methods_In(t *testing.T) {
 			ResultIndex: 1,
 			Expectation: false,
 		},
+		{
+			// embedded value doesn't exist
+			Code:        p + "params.e.hi.in(['hello','world'])",
+			ResultIndex: 1,
+			Expectation: true,
+		},
+		{
+			// embedded value doesn't exist
+			Code:        p + "params.e.hi.in(['world'])",
+			ResultIndex: 1,
+			Expectation: false,
+		},
 	})
 }
 
@@ -310,6 +322,12 @@ func TestDict_Methods_InRange(t *testing.T) {
 		},
 		{
 			Code:        p + "params['1'].inRange(3,4)",
+			ResultIndex: 1,
+			Expectation: false,
+		},
+		{
+			// value doesn't exist
+			Code:        p + "params['123'].inRange(0,999)",
 			ResultIndex: 1,
 			Expectation: false,
 		},


### PR DESCRIPTION
Discovered a really nasty bug when accessing maps through the shortcut chaining of identifiers:

```coffee
> sshd.config.params.Port.inRange(20, 23)
cannot find function "[]" for type "string"
```

This is caused by an error in how the type was handled when chaining this way. This is now fixed.

```coffee
> sshd.config.params.Port.inRange(20,23)
true
```