### PR TITLE
🐛 support inRange for nil values in maps

### DIFF
--- a/llx/builtin_simple.go
+++ b/llx/builtin_simple.go
@@ -1719,16 +1719,26 @@ func float64InRange(e *blockExecutor, val float64, chunk *Chunk, ref uint64) (*R
 }
 
 func intInRange(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
+	if bind.Value == nil {
+		return BoolFalse, 0, nil
+	}
 	val := bind.Value.(int64)
 	return int64InRange(e, val, chunk, ref)
 }
 
 func floatInRange(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
+	if bind.Value == nil {
+		return BoolFalse, 0, nil
+	}
 	val := bind.Value.(float64)
 	return float64InRange(e, val, chunk, ref)
 }
 
 func stringInRange(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
+	if bind.Value == nil {
+		return BoolFalse, 0, nil
+	}
+
 	val := bind.Value.(string)
 
 	i, err := strconv.ParseInt(val, 10, 64)

--- a/providers/core/resources/mql_test.go
+++ b/providers/core/resources/mql_test.go
@@ -805,6 +805,11 @@ func TestMap(t *testing.T) {
 			Code:        m + ".c.inRange(0,3)",
 			ResultIndex: 0, Expectation: true,
 		},
+		{
+			// works with nil value
+			Code:        m + ".d.inRange(0,3)",
+			ResultIndex: 0, Expectation: false,
+		},
 		// contains
 		{
 			Code:        m + ".contains(key == 'a')",


### PR DESCRIPTION
This was previously producing errors or would outright crash with a panic if the value was not set. Maps have fixed types, so it looks for typed functions to do the actual test. However, since a key of a map may not exist, the typed value may still be nil.