### PR TITLE
🧹 not having snap is not an error, so we do not need to warn

### DIFF
--- a/providers/os/resources/packages/snap_packages.go
+++ b/providers/os/resources/packages/snap_packages.go
@@ -40,7 +40,7 @@ func (spm *SnapPkgManager) List() ([]Package, error) {
 	afs := &afero.Afero{Fs: fs}
 	_, dErr := afs.Stat(snapDir)
 	if dErr != nil {
-		log.Warn().Str("path", snapDir).Msg("cannot find snap dir")
+		log.Debug().Str("path", snapDir).Msg("cannot find snap dir")
 		return []Package{}, nil
 	}
 


### PR DESCRIPTION
Fixing the warning `! cannot find snap dir path=/snap` which is not required.