### PR TITLE
🐛 Prevent trailing space in ParseProcessCmdline output

### DIFF
--- a/providers/os/resources/procfs/processes.go
+++ b/providers/os/resources/procfs/processes.go
@@ -102,7 +102,10 @@ func ParseProcessCmdline(content io.Reader) (string, error) {
 	parts := bytes.Split(data, []byte{0})
 	var strParts []string
 	for _, p := range parts {
-		strParts = append(strParts, strings.TrimSpace(string(p)))
+		s := strings.TrimSpace(string(p))
+		if s != "" {
+			strParts = append(strParts, s)
+		}
 	}
 
 	return strings.Join(strParts, " "), nil


### PR DESCRIPTION
The ParseProcessCmdline function was producing output with an
erroneous trailing space when processing /proc/[pid]/cmdline files.
This is because the cmdline format uses null bytes as argument
separators and includes a final null terminator for the entire
argument list.

