### PR TITLE
Add `machine.baseboard` support for AIX

### DIFF
--- a/providers/os/resources/smbios/aix.go
+++ b/providers/os/resources/smbios/aix.go
@@ -1,0 +1,87 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package smbios
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"strings"
+
+	"go.mondoo.com/cnquery/v11/providers/os/connection/shared"
+)
+
+// AIXSmbiosManager gets system information from AIX systems.
+// smbios is not a thing on AIX, but we implement this interface
+type AIXSmbiosManager struct {
+	provider shared.Connection
+}
+
+func (s *AIXSmbiosManager) Name() string {
+	return "AIX Smbios Manager"
+}
+
+func (s *AIXSmbiosManager) Info() (*SmBiosInfo, error) {
+
+	cmd, err := s.provider.RunCommand("prtconf")
+	if err != nil {
+		return nil, err
+	}
+	if cmd.ExitStatus != 0 {
+		stderr, err := io.ReadAll(cmd.Stderr)
+		if err != nil {
+			return nil, err
+		}
+		return nil, errors.New("failed to run prtconf: " + string(stderr))
+	}
+
+	baseBoardInfo, sysInfo, err := ParsePrtConf(cmd.Stdout)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SmBiosInfo{
+		BaseBoardInfo: baseBoardInfo,
+		SysInfo:       sysInfo,
+	}, nil
+}
+
+func ParsePrtConf(reader io.Reader) (BaseBoardInfo, SysInfo, error) {
+	baseBoardInfo := BaseBoardInfo{
+		Vendor: "IBM",
+	}
+	sysInfo := SysInfo{
+		Vendor: "IBM",
+		Family: "IBM Power Systems",
+	}
+
+	processLine := func(line, key string, target *string) {
+		if strings.Contains(line, key) {
+			parts := strings.Split(line, ":")
+			if len(parts) > 1 {
+				*target = strings.TrimSpace(parts[1])
+			}
+		}
+	}
+
+	// Read each line from the reader
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Process the line to extract relevant information
+
+		processLine(line, "System Model", &baseBoardInfo.Model)
+		sysInfo.Model = baseBoardInfo.Model
+
+		processLine(line, "Machine Serial Number", &baseBoardInfo.SerialNumber)
+		sysInfo.SerialNumber = baseBoardInfo.SerialNumber
+
+		processLine(line, "Firmware Version", &baseBoardInfo.Version)
+		sysInfo.Version = baseBoardInfo.Version
+	}
+	if err := scanner.Err(); err != nil {
+		return baseBoardInfo, sysInfo, err
+	}
+	return baseBoardInfo, sysInfo, nil
+}

--- a/providers/os/resources/smbios/smbios.go
+++ b/providers/os/resources/smbios/smbios.go
@@ -67,7 +67,11 @@ func ResolveManager(conn shared.Connection, pf *inventory.Platform) (SmBiosManag
 	if pf.IsFamily("darwin") {
 		biosM = &OSXSmbiosManager{provider: conn, platform: pf}
 	} else if pf.IsFamily(inventory.FAMILY_UNIX) {
-		biosM = &LinuxSmbiosManager{provider: conn}
+		if pf.Name == "aix" {
+			biosM = &AIXSmbiosManager{provider: conn}
+		} else {
+			biosM = &LinuxSmbiosManager{provider: conn}
+		}
 	} else if pf.IsFamily("windows") {
 		biosM = &WindowsSmbiosManager{provider: conn}
 	}

--- a/providers/os/resources/smbios/smbios_test.go
+++ b/providers/os/resources/smbios/smbios_test.go
@@ -257,3 +257,30 @@ func TestManagerWindows(t *testing.T) {
 		},
 	}, biosInfo)
 }
+
+func TestManagerAIX(t *testing.T) {
+	conn, err := mock.New(0, "./testdata/aix.toml", &inventory.Asset{})
+	require.NoError(t, err)
+	platform, ok := detector.DetectOS(conn)
+	require.True(t, ok)
+
+	mm, err := ResolveManager(conn, platform)
+	require.NoError(t, err)
+	biosInfo, err := mm.Info()
+	require.NoError(t, err)
+	assert.Equal(t, &SmBiosInfo{
+		SysInfo: SysInfo{
+			Vendor:       "IBM",
+			Model:        "IBM,9009-22A",
+			Version:      "IBM,FW950.D0 (VL950_175)",
+			SerialNumber: "7835450",
+			Family:       "IBM Power Systems",
+		},
+		BaseBoardInfo: BaseBoardInfo{
+			Vendor:       "IBM",
+			Model:        "IBM,9009-22A",
+			Version:      "IBM,FW950.D0 (VL950_175)",
+			SerialNumber: "7835450",
+		},
+	}, biosInfo)
+}

--- a/providers/os/resources/smbios/testdata/aix.toml
+++ b/providers/os/resources/smbios/testdata/aix.toml
@@ -1,0 +1,69 @@
+[commands."uname -s"]
+stdout = "AIX"
+
+[commands."prtconf"]
+stdout = """
+System Model: IBM,9009-22A
+Machine Serial Number: 7835450
+Processor Type: PowerPC_POWER9
+Processor Implementation Mode: POWER 9
+Processor Version: PV_9_Compat
+Number Of Processors: 1
+Processor Clock Speed: 2500 MHz
+CPU Type: 64-bit
+Kernel Type: 64-bit
+LPAR Info: 41 p1256-pvm1-76faa655-0000096b
+Memory Size: 2048 MB
+Good Memory Size: 2048 MB
+Platform Firmware level: VL950_175
+Firmware Version: IBM,FW950.D0 (VL950_175)
+Console Login: enable
+Auto Restart: true
+Full Core: false
+NX Crypto Acceleration: Capable and Enabled
+In-Core Crypto Acceleration: Capable, but not Enabled
+
+Network Information
+        Host Name: p1256-pvm1
+        IP Address: 129.40.51.113
+        Sub Netmask: 255.255.255.240
+        Gateway: 129.40.51.126
+        Name Server:
+        Domain Name:
+
+Paging Space Information
+        Total Paging Space: 4096MB
+        Percent Used: 0%
+
+Volume Groups Information
+==============================================================================
+Active VGs
+==============================================================================
+rootvg:
+PV_NAME           PV STATE          TOTAL PPs   FREE PPs    FREE DISTRIBUTION
+hdisk0            active            799         380         103..00..00..117..160
+==============================================================================
+
+INSTALLED RESOURCE LIST
+
+The following resources are installed on the machine.
++/- = Added or deleted from Resource List.
+*   = Diagnostic support not available.
+
+  Model Architecture: chrp
+  Model Implementation: Multiple Processor, PCI bus
+
++ sys0                                                            System Object
++ sysplanar0                                                      System Planar
+* vio0                                                            Virtual I/O Bus
+* ent0             U9009.22A.7835450-V41-C32-T1                   Virtual I/O Ethernet Adapter (l-lan)
+* vscsi1           U9009.22A.7835450-V41-C3-T1                    Virtual SCSI Client Adapter
+* vscsi0           U9009.22A.7835450-V41-C2-T1                    Virtual SCSI Client Adapter
+* cd0              U9009.22A.7835450-V41-C2-T1-L8200000000000000  Virtual SCSI Optical Served by VIO Server
+* hdisk0           U9009.22A.7835450-V41-C2-T1-L8100000000000000  Virtual SCSI Disk Drive
+* vsa0             U9009.22A.7835450-V41-C0                       LPAR Virtual Serial Adapter
+* vty0             U9009.22A.7835450-V41-C0-L0                    Asynchronous Terminal
++ L2cache0                                                        L2 Cache
++ mem0                                                            Memory
++ proc0                                                           Processor
+"""


### PR DESCRIPTION
```
cnquery> machine.baseboard { * }
machine.baseboard: {
  version: "IBM,FW950.D0 (VL950_175)"
  manufacturer: "IBM"
  serial: "7835450"
  assetTag: ""
  product: "IBM,9009-22A"
}
```

Fixes https://github.com/mondoohq/cnquery/issues/5542