### PR TITLE
Add kernel modules and version for AIX

### DIFF
--- a/providers/os/resources/kernel.go
+++ b/providers/os/resources/kernel.go
@@ -23,11 +23,11 @@ func initKernel(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[stri
 	platform := conn.Asset().Platform
 
 	supported := false
-	if platform.IsFamily("linux") || platform.IsFamily("darwin") || platform.Name == "freebsd" {
+	if platform.IsFamily("linux") || platform.IsFamily("darwin") || platform.Name == "freebsd" || platform.Name == "aix" {
 		supported = true
 	}
 
-	if supported == false {
+	if !supported {
 		return nil, nil, errors.New("kernel resource is only supported for unix platforms")
 	}
 

--- a/providers/os/resources/kernel/manager_test.go
+++ b/providers/os/resources/kernel/manager_test.go
@@ -123,3 +123,27 @@ func TestManagerFreebsd(t *testing.T) {
 
 	assert.Equal(t, 4, len(mounts))
 }
+
+func TestManagerAIX(t *testing.T) {
+	mock, err := mock.New(0, "./testdata/aix.toml", &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:   "aix",
+			Family: []string{"unix"},
+		},
+	})
+	require.NoError(t, err)
+
+	mm, err := ResolveManager(mock)
+	require.NoError(t, err)
+	modules, err := mm.Modules()
+	require.NoError(t, err)
+	require.Equal(t, []*KernelModule{
+		{Name: "bpf", Size: "d000"},
+		{Name: "autofs.ext", Size: "36000"},
+		{Name: "ahafs.ext", Size: "1d000"},
+	}, modules)
+
+	info, err := mm.Info()
+	require.NoError(t, err)
+	assert.Equal(t, "7300-03-00-2446", info.Version)
+}

--- a/providers/os/resources/kernel/testdata/aix.toml
+++ b/providers/os/resources/kernel/testdata/aix.toml
@@ -1,0 +1,13 @@
+[commands."uname -s"]
+stdout = "AIX"
+
+[commands."genkex"]
+stdout = """Text address     Size File
+
+f10009d5b06d8000     d000 /usr/lib/drivers/bpf
+f10009d5b06a2000    36000 /usr/lib/drivers/autofs.ext
+f10009d5b0685000    1d000 /usr/lib/drivers/ahafs.ext
+"""
+
+[commands."oslevel -s"]
+stdout = "7300-03-00-2446"


### PR DESCRIPTION
```
cnquery> kernel.modules
kernel.modules: [
  0: kernel.module name="bpf" loaded=true
  1: kernel.module name="autofs.ext" loaded=true
  2: kernel.module name="ahafs.ext" loaded=true
  3: kernel.module name="pfcurh" loaded=true
  4: kernel.module name="pfccache" loaded=true
  5: kernel.module name="pfcreg" loaded=true
  6: kernel.module name="pfcdd" loaded=true
  7: kernel.module name="if_en" loaded=true
  8: kernel.module name="cfs.ext" loaded=true
  9: kernel.module name="random" loaded=true
  10: kernel.module name="nfs.ext" loaded=true
  11: kernel.module name="krpc.ext" loaded=true
  12: kernel.module name="nfs_kdes.ext" loaded=true
  13: kernel.module name="cluster" loaded=true
  14: kernel.module name="posix_aiopin" loaded=true
  15: kernel.module name="posix_aio.ext" loaded=true
  16: kernel.module name="aiopin" loaded=true
  17: kernel.module name="aio.ext" loaded=true
  18: kernel.module name="smt_loadpin" loaded=true
  19: kernel.module name="smt_load" loaded=true
  20: kernel.module name="perfvmmstat" loaded=true
  21: kernel.module name="pmsvcs" loaded=true
  22: kernel.module name="iscsidd" loaded=true
  23: kernel.module name="perfstat" loaded=true
  24: kernel.module name="ptydd" loaded=true
  25: kernel.module name="netinet" loaded=true
  26: kernel.module name="pkcs11" loaded=true
  27: kernel.module name="ldterm" loaded=true
  28: kernel.module name="eth_demux" loaded=true
  29: kernel.module name="vioentdd" loaded=true
  30: kernel.module name="vconsdd" loaded=true
  31: kernel.module name="storfwork" loaded=true
  32: kernel.module name="coreprobe.ext" loaded=true
  33: kernel.module name="tirdwr" loaded=true
  34: kernel.module name="timod" loaded=true
  35: kernel.module name="xtiso" loaded=true
  36: kernel.module name="stdmod" loaded=true
  37: kernel.module name="sc" loaded=true
  38: kernel.module name="spx" loaded=true
  39: kernel.module name="stddev" loaded=true
  40: kernel.module name="ttydbg" loaded=true
  41: kernel.module name="ttydbg_pinned" loaded=true
  42: kernel.module name="pse" loaded=true
  43: kernel.module name="hdcrypt" loaded=true
  44: kernel.module name="clickext" loaded=true
  45: kernel.module name="hd_pin_bot" loaded=true
  46: kernel.module name="hd_pin" loaded=true
  47: kernel.module name="aixdiskpcmke" loaded=true
  48: kernel.module name="scsidiskpin" loaded=true
  49: kernel.module name="scsidisk" loaded=true
  50: kernel.module name="vscsi_initdd" loaded=true
  51: kernel.module name="vdev_busdd" loaded=true
  52: kernel.module name="planar_pal_chrp" loaded=true
  53: kernel.module name="unix" loaded=true
]
```

Fixes https://github.com/mondoohq/cnquery/issues/5541