### PR TITLE
🐛 Fix id for vulnerability.exchange

### DIFF
--- a/providers/core/resources/core.lr.go
+++ b/providers/core/resources/core.lr.go
@@ -1528,7 +1528,12 @@ func createVulnerabilityExchange(runtime *plugin.Runtime, args map[string]*llx.R
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+	res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("vulnerability.exchange", res.__id)

--- a/providers/core/resources/vulnerability_exchange.go
+++ b/providers/core/resources/vulnerability_exchange.go
@@ -1,0 +1,8 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+func (v *mqlVulnerabilityExchange) id() (string, error) {
+	return v.Id.Data, nil
+}


### PR DESCRIPTION
Before:
```
cnquery ...  -c "shodan.host.vulnerabilities { vulnerability.exchange ( id: _,  source: 'shodan' )}" 
→ loaded configuration from /etc/opt/mondoo/mondoo.yml using source default
shodan.host.vulnerabilities: [
  0: {
    vulnerability.exchange: vulnerability.exchange id="CVE-2023-44487" source="shodan"
  }
  1: {
    vulnerability.exchange: vulnerability.exchange id="CVE-2023-44487" source="shodan"
  }
...
```

With this PR:
```
cnquery ... -c "shodan.host.vulnerabilities { vulnerability.exchange ( id: _,  source: 'shodan' )}"      
→ loaded configuration from /etc/opt/mondoo/mondoo.yml using source default
shodan.host.vulnerabilities: [
  0: {
    vulnerability.exchange: vulnerability.exchange id="CVE-2023-44487" source="shodan"
  }
  1: {
    vulnerability.exchange: vulnerability.exchange id="CVE-2019-9516" source="shodan"
  }
...
```