### PR TITLE
🐛 make terraform.file private

### DIFF
--- a/providers/terraform/resources/terraform.lr
+++ b/providers/terraform/resources/terraform.lr
@@ -27,7 +27,7 @@ terraform {
 }
 
 // Terraform configuration file (.tf or .tf.json file)
-terraform.file @defaults("path") {
+private terraform.file @defaults("path") {
   // Terraform (.tf or tf.json file)
   path string
   // All blocks within the file


### PR DESCRIPTION
We only access the files via terraform.files, since there are multiple files that can be accessed. terraform.file is only used as the object but not as a direct resource that can be initiated