### PR TITLE
🐛 Add dependencies to `ResourceSchema` interface

### DIFF
--- a/providers-sdk/v1/resources/schema.go
+++ b/providers-sdk/v1/resources/schema.go
@@ -12,6 +12,7 @@ type ResourcesSchema interface {
 	LookupField(resource string, field string) (*ResourceInfo, *Field)
 	FindField(resource *ResourceInfo, field string) (FieldPath, []*Field, bool)
 	AllResources() map[string]*ResourceInfo
+	AllDependencies() map[string]*ProviderInfo
 }
 
 // Add another schema and return yourself. other may be nil.
@@ -101,6 +102,20 @@ func (s *Schema) Add(other ResourcesSchema) ResourcesSchema {
 		}
 	}
 
+	for k, v := range other.AllDependencies() {
+		if existing, ok := s.Dependencies[k]; ok {
+			if v.Name != "" {
+				existing.Name = v.Name
+			}
+		} else {
+			pi := &ProviderInfo{
+				Id:   v.Id,
+				Name: v.Name,
+			}
+			s.Dependencies[k] = pi
+		}
+	}
+
 	return s
 }
 
@@ -162,4 +177,8 @@ func (s *Schema) FindField(resource *ResourceInfo, field string) (FieldPath, []*
 
 func (s *Schema) AllResources() map[string]*ResourceInfo {
 	return s.Resources
+}
+
+func (s *Schema) AllDependencies() map[string]*ProviderInfo {
+	return s.Dependencies
 }


### PR DESCRIPTION
We use the `ResourcesSchema` interface to interact with the `resources` package. However, when we introduced provider dependencies into `resource.Schema`, we didn't update or extend this interface accordingly.

A few additional issues were observed:
* When loading providers, we only read the `{provider}.json` file, but not the corresponding `{provider}.resources.json` metadata file.
* For built-in providers, we intentionally skip loading files—but we also forgot to pass the schema. This omission results in errors like:
```
x provider without schema, unable to look up dependencies provider=core
```
* While `ResourcesSchema` is used consistently throughout the codebase, it’s not used within `providers.Provider.Schema`.

This change addresses all of the issues mentioned above.

