### PR TITLE
✨ IBM cloud detect + AIX

### DIFF
--- a/providers/os/id/azure/azure.go
+++ b/providers/os/id/azure/azure.go
@@ -20,7 +20,7 @@ const (
 
 func Detect(conn shared.Connection, pf *inventory.Platform) (string, string, []string) {
 	sysVendor := ""
-	if pf.IsFamily("linux") {
+	if pf.IsFamily(inventory.FAMILY_LINUX) {
 		// Fetching the product version from the smbios manager is slow
 		// because it iterates through files we don't need to check. This
 		// is an optimization for our sshfs. Also, be aware that on linux,

--- a/providers/os/id/clouddetect/clouddetect.go
+++ b/providers/os/id/clouddetect/clouddetect.go
@@ -12,6 +12,7 @@ import (
 	"go.mondoo.com/cnquery/v11/providers/os/id/aws"
 	"go.mondoo.com/cnquery/v11/providers/os/id/azure"
 	"go.mondoo.com/cnquery/v11/providers/os/id/gcp"
+	"go.mondoo.com/cnquery/v11/providers/os/id/ibm"
 	"go.mondoo.com/cnquery/v11/providers/os/id/vmware"
 )
 
@@ -32,6 +33,7 @@ var (
 	GCP     CloudProviderType = "GCP"
 	AZURE   CloudProviderType = "AZURE"
 	VMWARE  CloudProviderType = "VMWARE"
+	IBM     CloudProviderType = "IBM"
 )
 
 var detectors = map[CloudProviderType]detectorFunc{
@@ -39,6 +41,7 @@ var detectors = map[CloudProviderType]detectorFunc{
 	GCP:    gcp.Detect,
 	AZURE:  azure.Detect,
 	VMWARE: vmware.Detect,
+	IBM:    ibm.Detect,
 }
 
 // PlatformInfo contains platform information gathered from one of our cloud detectors.

--- a/providers/os/id/gcp/gcp.go
+++ b/providers/os/id/gcp/gcp.go
@@ -20,7 +20,7 @@ const (
 
 func Detect(conn shared.Connection, p *inventory.Platform) (string, string, []string) {
 	productName := ""
-	if p.IsFamily("linux") {
+	if p.IsFamily(inventory.FAMILY_LINUX) {
 		// Fetching the product version from the smbios manager is slow
 		// because it iterates through files we don't need to check. This
 		// is an optimization for our sshfs. Also, be aware that on linux,

--- a/providers/os/id/ibm/ibm_test.go
+++ b/providers/os/id/ibm/ibm_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ibm_test
+
+import (
+	"testing"
+
+	subject "go.mondoo.com/cnquery/v11/providers/os/id/ibm"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
+	"go.mondoo.com/cnquery/v11/providers/os/connection/mock"
+	"go.mondoo.com/cnquery/v11/providers/os/detector"
+)
+
+func TestDetectLinuxInstance(t *testing.T) {
+	conn, err := mock.New(0, "./testdata/instance_linux.toml", &inventory.Asset{})
+	require.NoError(t, err)
+	platform, ok := detector.DetectOS(conn)
+	require.True(t, ok)
+
+	identifier, name, relatedIdentifiers := subject.Detect(conn, platform)
+
+	assert.Equal(t,
+		"//platformid.api.mondoo.app/runtime/ibm/compute/v1/accounts/bbb1e1386b1c419f929ecf7499b20ab6/location/us-east-2/instances/0767_596409db-cb61-4d33-9550-6b86b503ed12",
+		identifier,
+	)
+	assert.Equal(t, "salim-test", name)
+	require.Len(t, relatedIdentifiers, 1)
+	assert.Equal(t,
+		"//platformid.api.mondoo.app/runtime/ibm/compute/v1/accounts/bbb1e1386b1c419f929ecf7499b20ab6",
+		relatedIdentifiers[0],
+	)
+}
+
+func TestDetectAIXInstance(t *testing.T) {
+	conn, err := mock.New(0, "./testdata/instance_unix_aix.toml", &inventory.Asset{})
+	require.NoError(t, err)
+	platform, ok := detector.DetectOS(conn)
+	require.True(t, ok)
+
+	identifier, name, relatedIdentifiers := subject.Detect(conn, platform)
+
+	assert.Equal(t,
+		"//platformid.api.mondoo.app/runtime/ibm/compute/v1/accounts/bbb1e1386b1c419f929ecf7499b20ab6/location/us-east-2/instances/0767_596409db-cb61-4d33-9550-6b86b503ed12",
+		identifier,
+	)
+	assert.Equal(t, "salim-test", name)
+	require.Len(t, relatedIdentifiers, 1)
+	assert.Equal(t,
+		"//platformid.api.mondoo.app/runtime/ibm/compute/v1/accounts/bbb1e1386b1c419f929ecf7499b20ab6",
+		relatedIdentifiers[0],
+	)
+}
+
+func TestDetectInstanceWithoutMetadataService(t *testing.T) {
+	conn, err := mock.New(0, "./testdata/instance_no_metadata.toml", &inventory.Asset{})
+	require.NoError(t, err)
+	platform, ok := detector.DetectOS(conn)
+	require.True(t, ok)
+
+	// If the metadata service in the IBM cloud instance is not turned on, we can't detect much
+
+	identifier, name, relatedIdentifiers := subject.Detect(conn, platform)
+	assert.Empty(t, identifier)
+	assert.Empty(t, name)
+	require.Empty(t, relatedIdentifiers)
+}

--- a/providers/os/id/ibm/testdata/instance_linux.toml
+++ b/providers/os/id/ibm/testdata/instance_linux.toml
@@ -1,0 +1,222 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "4.9.125-linuxkit"
+
+[files."/sys/class/dmi/id/chassis_vendor"]
+  path = "/sys/class/dmi/id/chassis_vendor"
+  enoent = false
+  content = "IBM:Cloud Compute Server 1.0:bx2-2x8"
+
+[commands."curl -H \"Metadata-Flavor: ibm\" -X PUT \"http://169.254.169.254/instance_identity/v1/token?version=2025-05-20\" -d '{}'"]
+stdout = """
+{"access_token":"MYTOKEN","created_at":"2025-05-28T20:14:51.056Z","expires_at":"2025-05-28T20:19:51.056Z","expires_in":300}
+"""
+
+[commands."curl -H \"Authorization: Bearer MYTOKEN\" -v http://169.254.169.254/metadata/v1/instance?version=2025-05-20"]
+stdout = """
+{
+  "availability_policy": {
+    "host_failure": "restart"
+  },
+  "bandwidth": 4000,
+  "boot_volume_attachment": {
+    "device": {
+      "id": "0767-68e2ea44-39bf-46a8-8f5c-f11175e3629b-wp2qb"
+    },
+    "id": "0767-68e2ea44-39bf-46a8-8f5c-f11175e3629b",
+    "name": "hayride-rumble-juggling-blur",
+    "volume": {
+      "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::volume:r014-d61682bc-d86e-419b-a313-b5c83fce9d50",
+      "id": "r014-d61682bc-d86e-419b-a313-b5c83fce9d50",
+      "name": "salim-test-boot-1748376813000",
+      "resource_type": "volume"
+    }
+  },
+  "cluster_network_attachments": [],
+  "confidential_compute_mode": "disabled",
+  "created_at": "2025-05-27T20:15:28.000Z",
+  "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::instance:0767_596409db-cb61-4d33-9550-6b86b503ed12",
+  "disks": [],
+  "enable_secure_boot": false,
+  "health_reasons": [],
+  "health_state": "ok",
+  "id": "0767_596409db-cb61-4d33-9550-6b86b503ed12",
+  "image": {
+    "crn": "crn:v1:bluemix:public:is:us-east:a/811f8abfbd32425597dc7ba40da98fa6::image:r014-a2cb25b9-9f8e-4e84-b2a3-d931f557e10d",
+    "id": "r014-a2cb25b9-9f8e-4e84-b2a3-d931f557e10d",
+    "name": "ibm-centos-stream-9-amd64-10",
+    "resource_type": "image"
+  },
+  "lifecycle_reasons": [],
+  "lifecycle_state": "stable",
+  "memory": 8,
+  "metadata_service": {
+    "enabled": true,
+    "protocol": "http",
+    "response_hop_limit": 1
+  },
+  "name": "salim-test",
+  "network_attachments": [
+    {
+      "id": "0767-fdba0aee-7016-499d-977b-043d81e52c70",
+      "name": "eth0",
+      "primary_ip": {
+        "address": "10.241.64.4",
+        "id": "0767-74cad75f-3215-4388-b3e8-c570df6a71c5",
+        "name": "ergonomic-sneak-line-region",
+        "resource_type": "subnet_reserved_ip"
+      },
+      "resource_type": "instance_network_attachment",
+      "subnet": {
+        "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::subnet:0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+        "id": "0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+        "name": "sn-20250515-02",
+        "resource_type": "subnet"
+      },
+      "virtual_network_interface": {
+        "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::virtual-network-interface:0767-9b9e77ac-d0d9-4cf6-bdaf-fd7757f2d91b",
+        "id": "0767-9b9e77ac-d0d9-4cf6-bdaf-fd7757f2d91b",
+        "name": "stipulate-fetch-repeater-swear",
+        "resource_type": "virtual_network_interface"
+      }
+    },
+    {
+      "id": "0767-51be678a-59e6-4983-af90-ef5dc10bcd59",
+      "name": "eth1",
+      "primary_ip": {
+        "address": "10.241.64.5",
+        "id": "0767-aed82f99-03ee-4d1a-b5cf-93d2a00c2598",
+        "name": "unwoven-smilingly-chair-imaging",
+        "resource_type": "subnet_reserved_ip"
+      },
+      "resource_type": "instance_network_attachment",
+      "subnet": {
+        "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::subnet:0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+        "id": "0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+        "name": "sn-20250515-02",
+        "resource_type": "subnet"
+      },
+      "virtual_network_interface": {
+        "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::virtual-network-interface:0767-ded1545d-3fac-4f82-8eac-167352025ddd",
+        "id": "0767-ded1545d-3fac-4f82-8eac-167352025ddd",
+        "name": "rope-flounder-vending-epidural",
+        "resource_type": "virtual_network_interface"
+      }
+    }
+  ],
+  "network_interfaces": [
+    {
+      "id": "0767-fdba0aee-7016-499d-977b-043d81e52c70",
+      "name": "eth0",
+      "primary_ipv4_address": "10.241.64.4",
+      "resource_type": "network_interface",
+      "subnet": {
+        "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::subnet:0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+        "id": "0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+        "name": "sn-20250515-02",
+        "resource_type": "subnet"
+      }
+    },
+    {
+      "id": "0767-51be678a-59e6-4983-af90-ef5dc10bcd59",
+      "name": "eth1",
+      "primary_ipv4_address": "10.241.64.5",
+      "resource_type": "network_interface",
+      "subnet": {
+        "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::subnet:0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+        "id": "0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+        "name": "sn-20250515-02",
+        "resource_type": "subnet"
+      }
+    }
+  ],
+  "numa_count": 1,
+  "primary_network_attachment": {
+    "id": "0767-fdba0aee-7016-499d-977b-043d81e52c70",
+    "name": "eth0",
+    "primary_ip": {
+      "address": "10.241.64.4",
+      "id": "0767-74cad75f-3215-4388-b3e8-c570df6a71c5",
+      "name": "ergonomic-sneak-line-region",
+      "resource_type": "subnet_reserved_ip"
+    },
+    "resource_type": "instance_network_attachment",
+    "subnet": {
+      "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::subnet:0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+      "id": "0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+      "name": "sn-20250515-02",
+      "resource_type": "subnet"
+    },
+    "virtual_network_interface": {
+      "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::virtual-network-interface:0767-9b9e77ac-d0d9-4cf6-bdaf-fd7757f2d91b",
+      "id": "0767-9b9e77ac-d0d9-4cf6-bdaf-fd7757f2d91b",
+      "name": "stipulate-fetch-repeater-swear",
+      "resource_type": "virtual_network_interface"
+    }
+  },
+  "primary_network_interface": {
+    "id": "0767-fdba0aee-7016-499d-977b-043d81e52c70",
+    "name": "eth0",
+    "primary_ipv4_address": "10.241.64.4",
+    "resource_type": "network_interface",
+    "subnet": {
+      "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::subnet:0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+      "id": "0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+      "name": "sn-20250515-02",
+      "resource_type": "subnet"
+    }
+  },
+  "profile": {
+    "name": "bx2-2x8",
+    "resource_type": "instance_profile"
+  },
+  "reservation_affinity": {
+    "policy": "automatic",
+    "pool": []
+  },
+  "resource_group": {
+    "id": "ba706c0ae6a34b5b80de06375ee2ea9e",
+    "name": "Default"
+  },
+  "resource_type": "instance",
+  "startable": true,
+  "status": "running",
+  "status_reasons": [],
+  "total_network_bandwidth": 3000,
+  "total_volume_bandwidth": 1000,
+  "vcpu": {
+    "architecture": "amd64",
+    "count": 2,
+    "manufacturer": "intel"
+  },
+  "volume_attachments": [
+    {
+      "device": {
+        "id": "0767-68e2ea44-39bf-46a8-8f5c-f11175e3629b-wp2qb"
+      },
+      "id": "0767-68e2ea44-39bf-46a8-8f5c-f11175e3629b",
+      "name": "hayride-rumble-juggling-blur",
+      "volume": {
+        "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::volume:r014-d61682bc-d86e-419b-a313-b5c83fce9d50",
+        "id": "r014-d61682bc-d86e-419b-a313-b5c83fce9d50",
+        "name": "salim-test-boot-1748376813000",
+        "resource_type": "volume"
+      }
+    }
+  ],
+  "vpc": {
+    "crn": "crn:v1:bluemix:public:is:us-east:a/bbb1e1386b1c419f929ecf7499b20ab6::vpc:r014-70f79485-7f94-4158-bb20-32b64b5dc1e9",
+    "id": "r014-70f79485-7f94-4158-bb20-32b64b5dc1e9",
+    "name": "sample-vpc",
+    "resource_type": "vpc"
+  },
+  "zone": {
+    "name": "us-east-2"
+  }
+}
+"""

--- a/providers/os/id/ibm/testdata/instance_no_metadata.toml
+++ b/providers/os/id/ibm/testdata/instance_no_metadata.toml
@@ -1,0 +1,34 @@
+[commands."uname -s"]
+stdout = "AIX"
+
+[commands."uname -m"]
+stdout = "00CC00A04B00"
+
+[commands."uname -rvp"]
+stdout = "3 7 powerpc"
+
+[commands."oslevel -s"]
+stdout = "7300-03-00-2446"
+
+[commands."prtconf"]
+stdout = """
+System Model: IBM,9009-22A
+Machine Serial Number: 78C00A0
+Processor Type: PowerPC_POWER9
+Processor Implementation Mode: POWER 9
+Processor Version: PV_9_Compat
+Number Of Processors: 1
+Processor Clock Speed: 2500 MHz
+CPU Type: 64-bit
+Kernel Type: 64-bit
+LPAR Info: 37 ans-4-51e59a83-000373d8
+Memory Size: 2048 MB
+Good Memory Size: 2048 MB
+Platform Firmware level: VL950_168
+Firmware Version: IBM,FW950.C1 (VL950_168)
+Console Login: enable
+Auto Restart: true
+Full Core: false
+NX Crypto Acceleration: Capable and Enabled
+In-Core Crypto Acceleration: Capable, but not Enabled
+"""

--- a/providers/os/id/ibm/testdata/instance_unix_aix.toml
+++ b/providers/os/id/ibm/testdata/instance_unix_aix.toml
@@ -1,0 +1,244 @@
+[commands."uname -s"]
+stdout = "AIX"
+
+[commands."uname -m"]
+stdout = "00CC00A04B00"
+
+[commands."uname -rvp"]
+stdout = "3 7 powerpc"
+
+[commands."oslevel -s"]
+stdout = "7300-03-00-2446"
+
+[commands."prtconf"]
+stdout = """
+System Model: IBM,9009-22A
+Machine Serial Number: 78C00A0
+Processor Type: PowerPC_POWER9
+Processor Implementation Mode: POWER 9
+Processor Version: PV_9_Compat
+Number Of Processors: 1
+Processor Clock Speed: 2500 MHz
+CPU Type: 64-bit
+Kernel Type: 64-bit
+LPAR Info: 37 ans-4-51e59a83-000373d8
+Memory Size: 2048 MB
+Good Memory Size: 2048 MB
+Platform Firmware level: VL950_168
+Firmware Version: IBM,FW950.C1 (VL950_168)
+Console Login: enable
+Auto Restart: true
+Full Core: false
+NX Crypto Acceleration: Capable and Enabled
+In-Core Crypto Acceleration: Capable, but not Enabled
+"""
+
+[commands."curl -H \"Metadata-Flavor: ibm\" -X PUT \"http://169.254.169.254/instance_identity/v1/token?version=2025-05-20\" -d '{}'"]
+stdout = """
+{"access_token":"MYTOKEN","created_at":"2025-05-28T20:14:51.056Z","expires_at":"2025-05-28T20:19:51.056Z","expires_in":300}
+"""
+
+[commands."curl -H \"Authorization: Bearer MYTOKEN\" -v http://169.254.169.254/metadata/v1/instance?version=2025-05-20"]
+stdout = """
+{
+  "availability_policy": {
+    "host_failure": "restart"
+  },
+  "bandwidth": 4000,
+  "boot_volume_attachment": {
+    "device": {
+      "id": "0767-68e2ea44-39bf-46a8-8f5c-f11175e3629b-wp2qb"
+    },
+    "id": "0767-68e2ea44-39bf-46a8-8f5c-f11175e3629b",
+    "name": "hayride-rumble-juggling-blur",
+    "volume": {
+      "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::volume:r014-d61682bc-d86e-419b-a313-b5c83fce9d50",
+      "id": "r014-d61682bc-d86e-419b-a313-b5c83fce9d50",
+      "name": "salim-test-boot-1748376813000",
+      "resource_type": "volume"
+    }
+  },
+  "cluster_network_attachments": [],
+  "confidential_compute_mode": "disabled",
+  "created_at": "2025-05-27T20:15:28.000Z",
+  "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::instance:0767_596409db-cb61-4d33-9550-6b86b503ed12",
+  "disks": [],
+  "enable_secure_boot": false,
+  "health_reasons": [],
+  "health_state": "ok",
+  "id": "0767_596409db-cb61-4d33-9550-6b86b503ed12",
+  "image": {
+    "crn": "crn:v1:bluemix:public:is:us-east:a/811f8abfbd32425597dc7ba40da98fa6::image:r014-a2cb25b9-9f8e-4e84-b2a3-d931f557e10d",
+    "id": "r014-a2cb25b9-9f8e-4e84-b2a3-d931f557e10d",
+    "name": "ibm-centos-stream-9-amd64-10",
+    "resource_type": "image"
+  },
+  "lifecycle_reasons": [],
+  "lifecycle_state": "stable",
+  "memory": 8,
+  "metadata_service": {
+    "enabled": true,
+    "protocol": "http",
+    "response_hop_limit": 1
+  },
+  "name": "salim-test",
+  "network_attachments": [
+    {
+      "id": "0767-fdba0aee-7016-499d-977b-043d81e52c70",
+      "name": "eth0",
+      "primary_ip": {
+        "address": "10.241.64.4",
+        "id": "0767-74cad75f-3215-4388-b3e8-c570df6a71c5",
+        "name": "ergonomic-sneak-line-region",
+        "resource_type": "subnet_reserved_ip"
+      },
+      "resource_type": "instance_network_attachment",
+      "subnet": {
+        "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::subnet:0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+        "id": "0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+        "name": "sn-20250515-02",
+        "resource_type": "subnet"
+      },
+      "virtual_network_interface": {
+        "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::virtual-network-interface:0767-9b9e77ac-d0d9-4cf6-bdaf-fd7757f2d91b",
+        "id": "0767-9b9e77ac-d0d9-4cf6-bdaf-fd7757f2d91b",
+        "name": "stipulate-fetch-repeater-swear",
+        "resource_type": "virtual_network_interface"
+      }
+    },
+    {
+      "id": "0767-51be678a-59e6-4983-af90-ef5dc10bcd59",
+      "name": "eth1",
+      "primary_ip": {
+        "address": "10.241.64.5",
+        "id": "0767-aed82f99-03ee-4d1a-b5cf-93d2a00c2598",
+        "name": "unwoven-smilingly-chair-imaging",
+        "resource_type": "subnet_reserved_ip"
+      },
+      "resource_type": "instance_network_attachment",
+      "subnet": {
+        "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::subnet:0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+        "id": "0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+        "name": "sn-20250515-02",
+        "resource_type": "subnet"
+      },
+      "virtual_network_interface": {
+        "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::virtual-network-interface:0767-ded1545d-3fac-4f82-8eac-167352025ddd",
+        "id": "0767-ded1545d-3fac-4f82-8eac-167352025ddd",
+        "name": "rope-flounder-vending-epidural",
+        "resource_type": "virtual_network_interface"
+      }
+    }
+  ],
+  "network_interfaces": [
+    {
+      "id": "0767-fdba0aee-7016-499d-977b-043d81e52c70",
+      "name": "eth0",
+      "primary_ipv4_address": "10.241.64.4",
+      "resource_type": "network_interface",
+      "subnet": {
+        "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::subnet:0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+        "id": "0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+        "name": "sn-20250515-02",
+        "resource_type": "subnet"
+      }
+    },
+    {
+      "id": "0767-51be678a-59e6-4983-af90-ef5dc10bcd59",
+      "name": "eth1",
+      "primary_ipv4_address": "10.241.64.5",
+      "resource_type": "network_interface",
+      "subnet": {
+        "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::subnet:0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+        "id": "0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+        "name": "sn-20250515-02",
+        "resource_type": "subnet"
+      }
+    }
+  ],
+  "numa_count": 1,
+  "primary_network_attachment": {
+    "id": "0767-fdba0aee-7016-499d-977b-043d81e52c70",
+    "name": "eth0",
+    "primary_ip": {
+      "address": "10.241.64.4",
+      "id": "0767-74cad75f-3215-4388-b3e8-c570df6a71c5",
+      "name": "ergonomic-sneak-line-region",
+      "resource_type": "subnet_reserved_ip"
+    },
+    "resource_type": "instance_network_attachment",
+    "subnet": {
+      "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::subnet:0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+      "id": "0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+      "name": "sn-20250515-02",
+      "resource_type": "subnet"
+    },
+    "virtual_network_interface": {
+      "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::virtual-network-interface:0767-9b9e77ac-d0d9-4cf6-bdaf-fd7757f2d91b",
+      "id": "0767-9b9e77ac-d0d9-4cf6-bdaf-fd7757f2d91b",
+      "name": "stipulate-fetch-repeater-swear",
+      "resource_type": "virtual_network_interface"
+    }
+  },
+  "primary_network_interface": {
+    "id": "0767-fdba0aee-7016-499d-977b-043d81e52c70",
+    "name": "eth0",
+    "primary_ipv4_address": "10.241.64.4",
+    "resource_type": "network_interface",
+    "subnet": {
+      "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::subnet:0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+      "id": "0767-a714c3db-5bc7-4199-8408-1e68ac45bceb",
+      "name": "sn-20250515-02",
+      "resource_type": "subnet"
+    }
+  },
+  "profile": {
+    "name": "bx2-2x8",
+    "resource_type": "instance_profile"
+  },
+  "reservation_affinity": {
+    "policy": "automatic",
+    "pool": []
+  },
+  "resource_group": {
+    "id": "ba706c0ae6a34b5b80de06375ee2ea9e",
+    "name": "Default"
+  },
+  "resource_type": "instance",
+  "startable": true,
+  "status": "running",
+  "status_reasons": [],
+  "total_network_bandwidth": 3000,
+  "total_volume_bandwidth": 1000,
+  "vcpu": {
+    "architecture": "amd64",
+    "count": 2,
+    "manufacturer": "intel"
+  },
+  "volume_attachments": [
+    {
+      "device": {
+        "id": "0767-68e2ea44-39bf-46a8-8f5c-f11175e3629b-wp2qb"
+      },
+      "id": "0767-68e2ea44-39bf-46a8-8f5c-f11175e3629b",
+      "name": "hayride-rumble-juggling-blur",
+      "volume": {
+        "crn": "crn:v1:bluemix:public:is:us-east-2:a/bbb1e1386b1c419f929ecf7499b20ab6::volume:r014-d61682bc-d86e-419b-a313-b5c83fce9d50",
+        "id": "r014-d61682bc-d86e-419b-a313-b5c83fce9d50",
+        "name": "salim-test-boot-1748376813000",
+        "resource_type": "volume"
+      }
+    }
+  ],
+  "vpc": {
+    "crn": "crn:v1:bluemix:public:is:us-east:a/bbb1e1386b1c419f929ecf7499b20ab6::vpc:r014-70f79485-7f94-4158-bb20-32b64b5dc1e9",
+    "id": "r014-70f79485-7f94-4158-bb20-32b64b5dc1e9",
+    "name": "sample-vpc",
+    "resource_type": "vpc"
+  },
+  "zone": {
+    "name": "us-east-2"
+  }
+}
+"""
+

--- a/providers/os/id/ibmcompute/ibmcompute.go
+++ b/providers/os/id/ibmcompute/ibmcompute.go
@@ -1,0 +1,454 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ibmcompute
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
+	"go.mondoo.com/cnquery/v11/providers/os/connection/shared"
+)
+
+// By default, instances are created with the metadata service endpoint disabled. You can
+// enable the metadata service either when creating a VPC instance or by updating the VPC
+// instance after creation.
+//
+// https://cloud.ibm.com/apidocs/vpc-metadata#get-instance
+//
+
+const identityURLPath = "/metadata/v1/instance?version=2025-05-20"
+
+type Identity struct {
+	InstanceName string
+	InstanceID   string
+	PlatformMrns []string
+}
+
+type InstanceIdentifier interface {
+	Identify() (Identity, error)
+	RawMetadata() (any, error)
+}
+
+type commandInstanceMetadata struct {
+	conn     shared.Connection
+	platform *inventory.Platform
+
+	// used internally to avoid fetching a token multiple times
+	token string
+}
+
+func Resolve(conn shared.Connection, pf *inventory.Platform) (InstanceIdentifier, error) {
+	return &commandInstanceMetadata{conn, pf, ""}, nil
+}
+
+func (m *commandInstanceMetadata) Identify() (Identity, error) {
+	instance, err := m.instanceIdentity()
+	if err != nil {
+		return Identity{}, err
+	}
+
+	log.Debug().Interface("instance", instance).Msg("identity")
+
+	platformMrns := []string{}
+	mondooInstanceID := "//platformid.api.mondoo.app/runtime/ibm/compute/v1"
+
+	// Add the scope if we can find it
+	if scope, ok := instance.Scope(); ok {
+		mondooInstanceID += "/" + scope.String()
+
+		// Add the owner of the resource to the platform MRNs
+		platformMrns = append(platformMrns, "//platformid.api.mondoo.app/runtime/ibm/compute/v1/"+scope.String())
+	}
+
+	// Add the location if we can find it
+	if location, ok := instance.Location(); ok {
+		mondooInstanceID += "/location/" + location
+	}
+
+	// finally, add the instance id
+	mondooInstanceID += "/instances/" + instance.ID
+
+	return Identity{
+		InstanceID:   mondooInstanceID,
+		InstanceName: instance.Name,
+		PlatformMrns: platformMrns,
+	}, nil
+}
+
+func (m *commandInstanceMetadata) RawMetadata() (any, error) {
+	return m.instanceIdentity()
+}
+
+func (m *commandInstanceMetadata) GetMetadataValue(path string) (string, error) {
+	return m.curlDocument(path)
+}
+
+func (m *commandInstanceMetadata) getToken() (string, error) {
+	if m.token != "" {
+		return m.token, nil
+	}
+
+	var commandString string
+	switch {
+	case m.platform.IsFamily(inventory.FAMILY_UNIX):
+		commandString = unixTokenCmdString()
+	case m.platform.IsFamily(inventory.FAMILY_WINDOWS):
+		commandString = windowsTokenCmdString()
+	default:
+		return "", errors.New("your platform is not supported by ibm metadata identifier resource")
+	}
+
+	cmd, err := m.conn.RunCommand(commandString)
+	if err != nil {
+		return "", err
+	}
+
+	data, err := io.ReadAll(cmd.Stdout)
+	if err != nil {
+		return "", err
+	}
+
+	var tokenResponse struct {
+		AccessToken string    `json:"access_token"`
+		CreatedAt   time.Time `json:"created_at"`
+		ExpiresAt   time.Time `json:"expires_at"`
+		ExpiresIn   int       `json:"expires_in"`
+	}
+	if err := json.Unmarshal(data, &tokenResponse); err != nil {
+		return "", err
+	}
+
+	m.token = tokenResponse.AccessToken
+
+	return m.token, err
+}
+
+func (m *commandInstanceMetadata) curlDocument(metadataPath string) (string, error) {
+	token, err := m.getToken()
+	if err != nil {
+		return "", err
+	}
+
+	var commandString string
+	switch {
+	case m.platform.IsFamily(inventory.FAMILY_UNIX):
+		commandString = unixMetadataCmdString(token, metadataPath)
+	case m.platform.IsFamily(inventory.FAMILY_WINDOWS):
+		commandString = windowsMetadataCmdString(token, metadataPath)
+	default:
+		return "", errors.New("your platform is not supported by aws metadata identifier resource")
+	}
+
+	log.Debug().Str("command_string", commandString).Msg("running os command")
+	cmd, err := m.conn.RunCommand(commandString)
+	if err != nil {
+		return "", err
+	}
+	data, err := io.ReadAll(cmd.Stdout)
+	return strings.TrimSpace(string(data)), err
+}
+
+func (m *commandInstanceMetadata) instanceIdentity() (*Instance, error) {
+	doc, err := m.curlDocument(identityURLPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(doc) == 0 {
+		return nil, errors.New("metadata service returned an empty response")
+	}
+
+	instance := Instance{}
+	if err := json.NewDecoder(strings.NewReader(doc)).Decode(&instance); err != nil {
+		return nil, errors.Wrap(err, "failed to decode IBM instance identity response")
+	}
+
+	return &instance, nil
+}
+
+type Instance struct {
+	BootVolumeAttachment struct {
+		Device struct {
+			ID string `json:"id"`
+		} `json:"device"`
+		ID     string `json:"id"`
+		Name   string `json:"name"`
+		Volume struct {
+			CRN          string `json:"crn"`
+			ID           string `json:"id"`
+			Name         string `json:"name"`
+			ResourceType string `json:"resource_type"`
+		} `json:"volume"`
+	} `json:"boot_volume_attachment"`
+	ClusterNetworkAttachments []any     `json:"cluster_network_attachments"`
+	ConfidentialComputeMode   string    `json:"confidential_compute_mode"`
+	CreatedAt                 time.Time `json:"created_at"`
+	CRN                       string    `json:"crn"`
+	DedicatedHost             struct {
+		CRN          string `json:"crn"`
+		ID           string `json:"id"`
+		Name         string `json:"name"`
+		ResourceType string `json:"resource_type"`
+	} `json:"dedicated_host"`
+	Disks            []any  `json:"disks"`
+	EnableSecureBoot bool   `json:"enable_secure_boot"`
+	HealthReasons    []any  `json:"health_reasons"`
+	HealthState      string `json:"health_state"`
+	ID               string `json:"id"`
+	Image            struct {
+		CRN          string `json:"crn"`
+		ID           string `json:"id"`
+		Name         string `json:"name"`
+		ResourceType string `json:"resource_type"`
+	} `json:"image"`
+	LifecycleReasons []any  `json:"lifecycle_reasons"`
+	LifecycleState   string `json:"lifecycle_state"`
+	Memory           int    `json:"memory"`
+	MetadataService  struct {
+		Enabled          bool   `json:"enabled"`
+		Protocol         string `json:"protocol"`
+		ResponseHopLimit int    `json:"response_hop_limit"`
+	} `json:"metadata_service"`
+	Name               string `json:"name"`
+	NetworkAttachments []struct {
+		ID        string `json:"id"`
+		Name      string `json:"name"`
+		PrimaryIP struct {
+			Address      string `json:"address"`
+			ID           string `json:"id"`
+			Name         string `json:"name"`
+			ResourceType string `json:"resource_type"`
+		} `json:"primary_ip"`
+		ResourceType string `json:"resource_type"`
+		Subnet       struct {
+			CRN          string `json:"crn"`
+			ID           string `json:"id"`
+			Name         string `json:"name"`
+			ResourceType string `json:"resource_type"`
+		} `json:"subnet"`
+		VirtualNetworkInterface struct {
+			CRN          string `json:"crn"`
+			ID           string `json:"id"`
+			Name         string `json:"name"`
+			ResourceType string `json:"resource_type"`
+		} `json:"virtual_network_interface"`
+	} `json:"network_attachments"`
+	NetworkInterfaces []struct {
+		ID                 string `json:"id"`
+		Name               string `json:"name"`
+		PrimaryIpv4Address string `json:"primary_ipv4_address"`
+		ResourceType       string `json:"resource_type"`
+		Subnet             struct {
+			CRN          string `json:"crn"`
+			ID           string `json:"id"`
+			Name         string `json:"name"`
+			ResourceType string `json:"resource_type"`
+		} `json:"subnet"`
+	} `json:"network_interfaces"`
+	NumaCount       int `json:"numa_count"`
+	PlacementTarget struct {
+		CRN          string `json:"crn"`
+		ID           string `json:"id"`
+		Name         string `json:"name"`
+		ResourceType string `json:"resource_type"`
+	} `json:"placement_target"`
+	PrimaryNetworkAttachment struct {
+		ID        string `json:"id"`
+		Name      string `json:"name"`
+		PrimaryIP struct {
+			Address      string `json:"address"`
+			ID           string `json:"id"`
+			Name         string `json:"name"`
+			ResourceType string `json:"resource_type"`
+		} `json:"primary_ip"`
+		ResourceType string `json:"resource_type"`
+		Subnet       struct {
+			CRN          string `json:"crn"`
+			ID           string `json:"id"`
+			Name         string `json:"name"`
+			ResourceType string `json:"resource_type"`
+		} `json:"subnet"`
+		VirtualNetworkInterface struct {
+			CRN          string `json:"crn"`
+			ID           string `json:"id"`
+			Name         string `json:"name"`
+			ResourceType string `json:"resource_type"`
+		} `json:"virtual_network_interface"`
+	} `json:"primary_network_attachment"`
+	PrimaryNetworkInterface struct {
+		ID                 string `json:"id"`
+		Name               string `json:"name"`
+		PrimaryIpv4Address string `json:"primary_ipv4_address"`
+		ResourceType       string `json:"resource_type"`
+		Subnet             struct {
+			CRN          string `json:"crn"`
+			ID           string `json:"id"`
+			Name         string `json:"name"`
+			ResourceType string `json:"resource_type"`
+		} `json:"subnet"`
+	} `json:"primary_network_interface"`
+	Profile struct {
+		Name         string `json:"name"`
+		ResourceType string `json:"resource_type"`
+	} `json:"profile"`
+	ReservationAffinity struct {
+		Policy string `json:"policy"`
+		Pool   []any  `json:"pool"`
+	} `json:"reservation_affinity"`
+	ResourceGroup struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"resource_group"`
+	ResourceType          string `json:"resource_type"`
+	Startable             bool   `json:"startable"`
+	Status                string `json:"status"`
+	StatusReasons         []any  `json:"status_reasons"`
+	TotalNetworkBandwidth int    `json:"total_network_bandwidth"`
+	TotalVolumeBandwidth  int    `json:"total_volume_bandwidth"`
+	Vcpu                  struct {
+		Architecture string `json:"architecture"`
+		Count        int    `json:"count"`
+		Manufacturer string `json:"manufacturer"`
+	} `json:"vcpu"`
+	VolumeAttachments []struct {
+		Device struct {
+			ID string `json:"id"`
+		} `json:"device"`
+		ID     string `json:"id"`
+		Name   string `json:"name"`
+		Volume struct {
+			CRN          string `json:"crn"`
+			ID           string `json:"id"`
+			Name         string `json:"name"`
+			ResourceType string `json:"resource_type"`
+		} `json:"volume"`
+	} `json:"volume_attachments"`
+	Vpc struct {
+		CRN          string `json:"crn"`
+		ID           string `json:"id"`
+		Name         string `json:"name"`
+		ResourceType string `json:"resource_type"`
+	} `json:"vpc"`
+	Zone struct {
+		Name string `json:"name"`
+	} `json:"zone"`
+}
+
+// CRN format
+//
+// The base canonical format of a CRN is:
+//
+//	crn:version:cname:ctype:service-name:location:scope:service-instance:resource-type:resource
+//
+// https://cloud.ibm.com/docs/account?topic=account-crn
+var crnRegex = regexp.MustCompile(`^crn:([^:]*):([^:]*):([^:]*):([^:]*):([^:]*):([^:]*):([^:]*):([^:]*):([^:]*)$`)
+
+type CRN struct {
+	Version         string // e.g., "v1"
+	CName           string // Cloud name, e.g., "bluemix"
+	CType           string // Cloud type, e.g., "public"
+	ServiceName     string // e.g., "iam"
+	Location        string // e.g., "us-south"
+	Scope           string // e.g., ""
+	ServiceInstance string // e.g., "a/123456"
+	ResourceType    string // e.g., "resource-type"
+	Resource        string // e.g., "resource-id"
+}
+
+func ParseCRN(input string) (*CRN, error) {
+	matches := crnRegex.FindStringSubmatch(input)
+	if matches == nil {
+		return nil, fmt.Errorf("invalid CRN format")
+	}
+	return &CRN{
+		Version:         matches[1],
+		CName:           matches[2],
+		CType:           matches[3],
+		ServiceName:     matches[4],
+		Location:        matches[5],
+		Scope:           matches[6],
+		ServiceInstance: matches[7],
+		ResourceType:    matches[8],
+		Resource:        matches[9],
+	}, nil
+}
+
+func (i *Instance) ParsedCRN() (*CRN, error) {
+	return ParseCRN(i.CRN)
+}
+
+// The cloud geography/region/zone/data center that the resource resides.
+//
+// https://cloud.ibm.com/docs/account?topic=account-crn
+func (i *Instance) Location() (string, bool) {
+	if crn, err := i.ParsedCRN(); err == nil {
+		return crn.Location, true
+	}
+	return "", false
+}
+
+type Scope struct {
+	Prefix string // "a", "o", "s" or other custom scope types
+	ID     string // the identifier (e.g., account ID, org GUID, space GUID)
+}
+
+var scopeRegex = regexp.MustCompile(`^(?:(a|o|s)/([^/]+))?$`)
+
+func ParseScope(scopeStr string) (*Scope, error) {
+	if scopeStr == "" {
+		return nil, nil // Global scope (no owner)
+	}
+
+	matches := scopeRegex.FindStringSubmatch(scopeStr)
+	if matches == nil {
+		return nil, fmt.Errorf("invalid scope format")
+	}
+
+	return &Scope{
+		Prefix: matches[1],
+		ID:     matches[2],
+	}, nil
+}
+
+func (s *Scope) String() string {
+	// https://cloud.ibm.com/docs/account?topic=account-crn
+	switch s.Prefix {
+	case "a":
+		return "accounts/" + s.ID
+	case "o":
+		return "organizations/" + s.ID
+	case "s":
+		return "spaces/" + s.ID
+	}
+
+	return "global/" + s.ID
+}
+
+// The scope segment identifies the containment or owner of the resource. Some
+// resources do not require an owner (they can be considered global). In this
+// case, the scope segment is empty (a blank string).
+//
+// The value of the scope segment must be formatted as {scopePrefix}/{id}. The
+// scopePrefix represents the format that is used to identify the owner or
+// containment. The id represents the identity of the owner or containment in
+// a format that is specific to the scopePrefix.
+//
+// https://cloud.ibm.com/docs/account?topic=account-crn
+func (i *Instance) Scope() (*Scope, bool) {
+	if crn, err := i.ParsedCRN(); err == nil {
+		if scope, err := ParseScope(crn.Scope); err == nil {
+			return scope, true
+		}
+		log.Debug().Err(err).
+			Str("scope_string", crn.Scope).
+			Msg("id.ibmcompute> unable to parse CRN scope")
+	}
+	return nil, false
+}

--- a/providers/os/id/ibmcompute/metadata_unix_cmd.go
+++ b/providers/os/id/ibmcompute/metadata_unix_cmd.go
@@ -1,0 +1,26 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ibmcompute
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	baseUnix     = `-H "Authorization: Bearer %s" -v http://169.254.169.254/%s`
+	tokenURLUnix = `-H "Metadata-Flavor: ibm" -X PUT "http://169.254.169.254/instance_identity/v1/token?version=2025-05-20" -d '{}'`
+)
+
+func unixCurlParams(token, path string) string {
+	return fmt.Sprintf(baseUnix, token, path)
+}
+
+func unixTokenCmdString() string {
+	return "curl " + tokenURLUnix
+}
+
+func unixMetadataCmdString(token, metadataPath string) string {
+	return fmt.Sprintf("curl %s", unixCurlParams(token, strings.TrimPrefix(metadataPath, "/")))
+}

--- a/providers/os/id/ibmcompute/metadata_windows_cmd.go
+++ b/providers/os/id/ibmcompute/metadata_windows_cmd.go
@@ -1,0 +1,38 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package ibmcompute
+
+import (
+	"fmt"
+	"strings"
+
+	"go.mondoo.com/cnquery/v11/providers/os/resources/powershell"
+)
+
+const (
+	baseWindows = `
+$Headers = @{
+    "Authorization" = "Bearer %s"
+}
+Invoke-RestMethod -TimeoutSec 1 -Headers $Headers -Uri "http://169.254.169.254/%s" -UseBasicParsing | ConvertTo-Json
+`
+	tokenURLWindows = `
+$Headers = @{
+    "Metadata-Flavor" = "ibm"
+}
+Invoke-RestMethod -Method Put -Uri "http://169.254.169.254/instance_identity/v1/token?version=2025-05-20" -Headers $Headers -TimeoutSec 1 -UseBasicParsing | ConvertTo-Json
+`
+)
+
+func windowsCurlCmd(token, path string) string {
+	return fmt.Sprintf(baseWindows, token, path)
+}
+
+func windowsTokenCmdString() string {
+	return powershell.Encode(tokenURLWindows)
+}
+
+func windowsMetadataCmdString(token, metadataPath string) string {
+	return powershell.Encode(windowsCurlCmd(token, strings.TrimPrefix(metadataPath, "/")))
+}

--- a/providers/os/resources/cloud/cloud.go
+++ b/providers/os/resources/cloud/cloud.go
@@ -41,6 +41,8 @@ func Resolve(conn shared.Connection) (OSCloud, error) {
 		return &azure{conn}, nil
 	case clouddetect.VMWARE:
 		return &vmware{conn}, nil
+	case clouddetect.IBM:
+		return &ibm{conn}, nil
 	default:
 		return &none{}, nil
 	}

--- a/providers/os/resources/cloud/ibm.go
+++ b/providers/os/resources/cloud/ibm.go
@@ -1,0 +1,46 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package cloud
+
+import (
+	"errors"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/v11/providers/os/connection/shared"
+	"go.mondoo.com/cnquery/v11/providers/os/id/ibmcompute"
+)
+
+const IBM Provider = "IBM"
+
+// ibm implements the OSCloud interface for IBM Cloud
+type ibm struct {
+	conn shared.Connection
+}
+
+func (i *ibm) Provider() Provider {
+	return IBM
+}
+
+func (i *ibm) Instance() (*InstanceMetadata, error) {
+	mdsvc, err := ibmcompute.Resolve(i.conn, i.conn.Asset().GetPlatform())
+	if err != nil {
+		log.Debug().Err(err).Msg("os.cloud.ibm> failed to get metadata resolver")
+		return nil, err
+	}
+	metadata, err := mdsvc.RawMetadata()
+	if err != nil {
+		log.Debug().Err(err).Msg("os.cloud.ibm> failed to get raw metadata")
+		return nil, err
+	}
+	if metadata == nil {
+		log.Debug().Msg("os.cloud.ibm> no metadata found")
+		return nil, errors.New("no metadata")
+	}
+
+	instanceMd := &InstanceMetadata{Metadata: metadata}
+
+	// TODO extract network information
+
+	return instanceMd, nil
+}


### PR DESCRIPTION
Enhance our cloud detect package to detect IBM instances. This change follows the patterns
already implemented for AWS, GCP, Azure, and VMware.

🚫 **Note** that IBM Cloud doesn't have the Metadata service turned on by default, users must opt-in
to have it available. Only those instances are the ones we will detect.

Docs: https://cloud.ibm.com/docs/vpc?topic=vpc-imd-configure-service&interface=ui#imd-metadata-service-enable

From the UI, you can turn it on when launching the instance

![image](https://github.com/user-attachments/assets/08309a0d-7bd6-4457-b08d-7b8e9ac4059c)

Or, accessing advance options after launch.

![image](https://github.com/user-attachments/assets/004386e7-7f66-4a3a-aa08-506d6da21207)

## Cloud Detection for `IBM`

![Screenshot 2025-05-28 at 2 20 09 PM](https://github.com/user-attachments/assets/6dac507e-079c-4bbf-8d86-ea351485dcb2)

##Minimal Instance Metadata

I added the raw metadata that needs to be parsed on a follow up PR.

![Screenshot 2025-05-28 at 2 21 23 PM](https://github.com/user-attachments/assets/58c82869-71f5-454a-81a1-9644c919f6a7)
