### PR TITLE
⭐ (parse.yaml): add option for multi-document YAML for parse.yaml

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -501,6 +501,8 @@ parse.yaml {
   content(file) string
   // The parsed parameters that are defined in this file
   params(content) dict
+  // Parsed yaml documents
+  documents(content) []dict
 }
 
 // Parse certificates from files

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -1110,6 +1110,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"parse.yaml.params": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlParseYaml).GetParams()).ToDataRes(types.Dict)
 	},
+	"parse.yaml.documents": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlParseYaml).GetDocuments()).ToDataRes(types.Array(types.Dict))
+	},
 	"parse.certificates.path": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlParseCertificates).GetPath()).ToDataRes(types.String)
 	},
@@ -3354,6 +3357,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"parse.yaml.params": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlParseYaml).Params, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
+		return
+	},
+	"parse.yaml.documents": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlParseYaml).Documents, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
 	"parse.certificates.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8479,6 +8486,7 @@ type mqlParseYaml struct {
 	File plugin.TValue[*mqlFile]
 	Content plugin.TValue[string]
 	Params plugin.TValue[interface{}]
+	Documents plugin.TValue[[]interface{}]
 }
 
 // createParseYaml creates a new instance of this resource
@@ -8541,6 +8549,17 @@ func (c *mqlParseYaml) GetParams() *plugin.TValue[interface{}] {
 		}
 
 		return c.params(vargContent.Data)
+	})
+}
+
+func (c *mqlParseYaml) GetDocuments() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.Documents, func() ([]interface{}, error) {
+		vargContent := c.GetContent()
+		if vargContent.Error != nil {
+			return nil, vargContent.Error
+		}
+
+		return c.documents(vargContent.Data)
 	})
 }
 

--- a/providers/os/resources/os.lr.manifest.yaml
+++ b/providers/os/resources/os.lr.manifest.yaml
@@ -786,6 +786,8 @@ resources:
   parse.yaml:
     fields:
       content: {}
+      documents:
+        min_mondoo_version: 9.0.0
       file: {}
       params: {}
     min_mondoo_version: 5.15.0

--- a/providers/os/resources/parse.go
+++ b/providers/os/resources/parse.go
@@ -342,71 +342,48 @@ func (s *mqlParseYaml) content(file *mqlFile) (string, error) {
 }
 
 func (s *mqlParseYaml) params(content string) (map[string]interface{}, error) {
+	res := make(map[string](interface{}))
+
 	if content == "" {
-		return map[string]interface{}{}, nil
+		return nil, nil
 	}
 
-	// Check if we have multiple documents by analyzing separator positions
-	hasMultipleDocuments := false
-
-	if strings.Contains(content, "---") {
-		// Split and filter out empty documents
-		yamlDocs := strings.Split(content, "---")
-		nonEmptyDocs := 0
-
-		for _, doc := range yamlDocs {
-			doc = strings.TrimSpace(doc)
-			if doc != "" {
-				nonEmptyDocs++
-			}
-		}
-
-		// If we have more than 1 non-empty document, it's multi-document
-		hasMultipleDocuments = nonEmptyDocs > 1
-	}
-
-	if hasMultipleDocuments {
-		// Split content by YAML document separator
-		yamlDocs := strings.Split(content, "---")
-		var documents []map[string]interface{}
-
-		for _, doc := range yamlDocs {
-			doc = strings.TrimSpace(doc)
-			if doc == "" {
-				continue
-			}
-
-			var parsed map[string]interface{}
-			err := yaml.Unmarshal([]byte(doc), &parsed)
-			if err != nil {
-				return nil, err
-			}
-
-			if parsed != nil && len(parsed) > 0 {
-				documents = append(documents, parsed)
-			}
-		}
-
-		// Return documents as a map with indexed keys for multi-document YAML
-		result := make(map[string]interface{})
-		for i, doc := range documents {
-			result[fmt.Sprintf("%d", i)] = doc
-		}
-		return result, nil
-	}
-
-	// Single document - parse as-is
-	var result map[string]interface{}
-	err := yaml.Unmarshal([]byte(content), &result)
+	err := yaml.Unmarshal([]byte(content), &res)
 	if err != nil {
 		return nil, err
 	}
 
-	if result == nil {
-		return map[string]interface{}{}, nil
+	return res, nil
+}
+
+func (s *mqlParseYaml) documents(content string) ([]interface{}, error) {
+	if content == "" {
+		return []interface{}{}, nil
 	}
 
-	return result, nil
+	var documents []interface{}
+
+	// Split content by YAML document separator
+	yamlDocs := strings.Split(content, "---")
+
+	for _, doc := range yamlDocs {
+		doc = strings.TrimSpace(doc)
+		if doc == "" {
+			continue
+		}
+
+		var parsed interface{}
+		err := yaml.Unmarshal([]byte(doc), &parsed)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse YAML document: %w", err)
+		}
+
+		if parsed != nil {
+			documents = append(documents, parsed)
+		}
+	}
+
+	return documents, nil
 }
 
 func initParsePlist(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/os/resources/parse_test.go
+++ b/providers/os/resources/parse_test.go
@@ -90,3 +90,219 @@ func TestParseXML(t *testing.T) {
 		},
 	})
 }
+
+func TestParseYaml(t *testing.T) {
+	x.TestSimple(t, []testutils.SimpleTest{
+		// Basic single document tests
+		{
+			Code:        `parse.yaml(content: "simple: test").params`,
+			ResultIndex: 0,
+			Expectation: map[string]interface{}{
+				"simple": "test",
+			},
+		},
+		{
+			Code:        `parse.yaml(content: "number: 42").params`,
+			ResultIndex: 0,
+			Expectation: map[string]interface{}{
+				"number": float64(42),
+			},
+		},
+		{
+			Code:        `parse.yaml(content: "enabled: true").params`,
+			ResultIndex: 0,
+			Expectation: map[string]interface{}{
+				"enabled": true,
+			},
+		},
+		{
+			Code:        `parse.yaml(content: "parent:\n  child: value").params`,
+			ResultIndex: 0,
+			Expectation: map[string]interface{}{
+				"parent": map[string]interface{}{
+					"child": "value",
+				},
+			},
+		},
+
+		// Empty content
+		{
+			Code:        `parse.yaml(content: "").params`,
+			ResultIndex: 0,
+			Expectation: map[string]interface{}{},
+		},
+
+		// Single document with leading --- (common pattern)
+		{
+			Code:        `parse.yaml(content: "---\nname: single-doc\nversion: 1.2").params`,
+			ResultIndex: 0,
+			Expectation: map[string]interface{}{
+				"name":    "single-doc",
+				"version": float64(1.2),
+			},
+		},
+
+		// Single document with trailing ---
+		{
+			Code:        `parse.yaml(content: "name: trailing-doc\nversion: 1.2\n---").params`,
+			ResultIndex: 0,
+			Expectation: map[string]interface{}{
+				"name":    "trailing-doc",
+				"version": float64(1.2),
+			},
+		},
+
+		// Single document with both leading and trailing ---
+		{
+			Code:        `parse.yaml(content: "---\nname: wrapped-doc\nversion: 1.2\n---").params`,
+			ResultIndex: 0,
+			Expectation: map[string]interface{}{
+				"name":    "wrapped-doc",
+				"version": float64(1.2),
+			},
+		},
+
+		// True multi-document YAML
+		{
+			Code:        `parse.yaml(content: "name: doc1\n---\nname: doc2").params`,
+			ResultIndex: 0,
+			Expectation: map[string]interface{}{
+				"0": map[string]interface{}{"name": "doc1"},
+				"1": map[string]interface{}{"name": "doc2"},
+			},
+		},
+
+		// Multi-document with leading ---
+		{
+			Code:        `parse.yaml(content: "---\nname: doc1\n---\nname: doc2").params`,
+			ResultIndex: 0,
+			Expectation: map[string]interface{}{
+				"0": map[string]interface{}{"name": "doc1"},
+				"1": map[string]interface{}{"name": "doc2"},
+			},
+		},
+
+		// Multi-document with trailing ---
+		{
+			Code:        `parse.yaml(content: "name: doc1\n---\nname: doc2\n---").params`,
+			ResultIndex: 0,
+			Expectation: map[string]interface{}{
+				"0": map[string]interface{}{"name": "doc1"},
+				"1": map[string]interface{}{"name": "doc2"},
+			},
+		},
+
+		// Three documents
+		{
+			Code:        `parse.yaml(content: "name: doc1\n---\nname: doc2\n---\nname: doc3").params`,
+			ResultIndex: 0,
+			Expectation: map[string]interface{}{
+				"0": map[string]interface{}{"name": "doc1"},
+				"1": map[string]interface{}{"name": "doc2"},
+				"2": map[string]interface{}{"name": "doc3"},
+			},
+		},
+
+		// Access specific document from multi-document
+		{
+			Code:        `parse.yaml(content: "name: doc1\n---\nname: doc2").params["0"]`,
+			ResultIndex: 0,
+			Expectation: map[string]interface{}{"name": "doc1"},
+		},
+		{
+			Code:        `parse.yaml(content: "name: doc1\n---\nname: doc2").params["1"]`,
+			ResultIndex: 0,
+			Expectation: map[string]interface{}{"name": "doc2"},
+		},
+
+		// Multi-document with empty documents (should be skipped)
+		{
+			Code:        `parse.yaml(content: "name: doc1\n---\n\n---\nname: doc2").params`,
+			ResultIndex: 0,
+			Expectation: map[string]interface{}{
+				"0": map[string]interface{}{"name": "doc1"},
+				"1": map[string]interface{}{"name": "doc2"},
+			},
+		},
+
+		// Complex nested structures
+		{
+			Code:        `parse.yaml(content: "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: test\ndata:\n  key1: value1\n  key2: value2").params`,
+			ResultIndex: 0,
+			Expectation: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "test",
+				},
+				"data": map[string]interface{}{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+		},
+
+		// Arrays in YAML
+		{
+			Code:        `parse.yaml(content: "items:\n  - name: item1\n  - name: item2").params`,
+			ResultIndex: 0,
+			Expectation: map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"name": "item1"},
+					map[string]interface{}{"name": "item2"},
+				},
+			},
+		},
+
+		// Multi-document with different structures
+		{
+			Code:        `parse.yaml(content: "apiVersion: v1\nkind: Service\n---\napiVersion: apps/v1\nkind: Deployment").params`,
+			ResultIndex: 0,
+			Expectation: map[string]interface{}{
+				"0": map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Service",
+				},
+				"1": map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+				},
+			},
+		},
+
+		// Edge case: just separators
+		{
+			Code:        `parse.yaml(content: "---").params`,
+			ResultIndex: 0,
+			Expectation: map[string]interface{}{},
+		},
+
+		// Edge case: multiple separators only
+		{
+			Code:        `parse.yaml(content: "---\n---").params`,
+			ResultIndex: 0,
+			Expectation: map[string]interface{}{},
+		},
+
+		// Kubernetes-style manifest
+		{
+			Code:        `parse.yaml(content: "---\napiVersion: v1\nkind: Pod\nmetadata:\n  name: test-pod\nspec:\n  containers:\n  - name: test\n    image: nginx").params`,
+			ResultIndex: 0,
+			Expectation: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"name": "test-pod",
+				},
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name":  "test",
+							"image": "nginx",
+						},
+					},
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
### Description of your changes
add documents option for parse.yaml to have multi-document YAML
* added Unit-Tests

### How has this code been tested
```
make providers/build/os
make providers/install/os
make build artifacts.platform
```

single manifest:
```
cnquery> parse.yaml(content: command("cat t2.yaml").stdout).params
parse.yaml.params: {
  apiVersion: "ec2.aws.upbound.io/v1beta1"
  kind: "Instance"
  metadata: {
    annotations: {
      crossplane.io/composition-resource-name: "instance"
    }
    generateName: "ec2-with-root-snapshot-"
    labels: {
      crossplane.io/composite: "ec2-with-root-snapshot"
    }
    name: "ec2-with-root-snapshot"
    ownerReferences: [
      0: {
        apiVersion: "aws.haarchri.io/v1alpha1"
        blockOwnerDeletion: true
        controller: true
        kind: "XEC2Instance"
        name: "ec2-with-root-snapshot"
        uid: ""
      }
    ]
  }
  spec: {
    forProvider: {
      ami: "ami-12345678910"
      iamInstanceProfile: "haarchriDefault"
      instanceType: "t3.nano"
      region: "us-east-1"
      rootBlockDevice: [
        0: {
          kmsKeyId: "arn:12345678910"
          volumeSize: 500.000000
        }
      ]
      subnetId: "subnet-12345678910"
      tags: {
        Name: "ec2-with-root-snapshot"
      }
      vpcSecurityGroupIds: [
        0: "sg-12345678910"
      ]
    }
  }
}
```

multi-document yaml:
```
cnquery>  parse.yaml(content: command("cat tt.yaml").stdout).documents
parse.yaml.documents: [
  0: {
    apiVersion: "aws.haarchri.io/v1alpha1"
    kind: "XEC2Instance"
    metadata: {
      name: "ec2-with-root-snapshot"
    }
    status: {
      conditions: [
        0: {
          lastTransitionTime: "2024-01-01T00:00:00Z"
          message: "Unready resources: instance"
          reason: "Creating"
          status: "False"
          type: "Ready"
        }
      ]
    }
  }
  1: {
    apiVersion: "ec2.aws.upbound.io/v1beta1"
    kind: "Instance"
    metadata: {
      annotations: {
        crossplane.io/composition-resource-name: "instance"
      }
      generateName: "ec2-with-root-snapshot-"
      labels: {
        crossplane.io/composite: "ec2-with-root-snapshot"
      }
      name: "ec2-with-root-snapshot"
      ownerReferences: [
        0: {
          apiVersion: "aws.haarchri.io/v1alpha1"
          blockOwnerDeletion: true
          controller: true
          kind: "XEC2Instance"
          name: "ec2-with-root-snapshot"
          uid: ""
        }
      ]
    }
    spec: {
      forProvider: {
        ami: "ami-12345678910"
        iamInstanceProfile: "haarchriDefault"
        instanceType: "t3.nano"
        region: "us-east-1"
        rootBlockDevice: [
          0: {
            kmsKeyId: "arn:12345678910"
            volumeSize: 500.000000
          }
        ]
        subnetId: "subnet-12345678910"
        tags: {
          Name: "ec2-with-root-snapshot"
        }
        vpcSecurityGroupIds: [
          0: "sg-12345678910"
        ]
      }
    }
  }
]
```

query something in multi-document yaml:
```
cnquery> parse.yaml(content: command("cat tt.yaml").stdout).documents.where(kind == "Instance").where(apiVersion == "ec2.aws.upbound.io/v1beta1")[0].spec.forProvider.rootBlockDevice.all(kmsKeyId!=empty)
[ok] value: true
```

```
cnquery> parse.yaml(content: command("cat tt.yaml").stdout).documents.where(kind == "Instance").where(apiVersion == "ec2.aws.upbound.io/v1beta1")[0].spec.forProvider
parse.yaml.documents.where.where[0].spec.forProvider: {
  ami: "ami-12345678910"
  iamInstanceProfile: "haarchriDefault"
  instanceType: "t3.nano"
  region: "us-east-1"
  rootBlockDevice: [
    0: {
      kmsKeyId: "arn:12345678910"
      volumeSize: 500.000000
    }
  ]
  subnetId: "subnet-12345678910"
  tags: {
    Name: "ec2-with-root-snapshot"
  }
  vpcSecurityGroupIds: [
    0: "sg-12345678910"
  ]
}
```