### PR TITLE
🧹 Bump protoc version

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,1 +1,2 @@
 golang-version=1.23.4
+protoc-version=31.x

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -38,6 +38,7 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ env.protoc-version }}
           
       - name: Log in to the Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -53,6 +53,7 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ env.protoc-version }}
 
       - name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@v2'

--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -42,6 +42,7 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ env.protoc-version }}
 
       - name: Check generated files
         run: |

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -117,6 +117,7 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ env.protoc-version }}
 
       - name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@v2'

--- a/.github/workflows/release-providers.yml
+++ b/.github/workflows/release-providers.yml
@@ -36,6 +36,7 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ env.protoc-version }}
 
       - name: Check for provider updates
         id: update-providers


### PR DESCRIPTION
The default of the action is 23.x

See: https://github.com/mondoohq/cnquery/actions/runs/15556336298/job/43797872462
And: https://github.com/arduino/setup-protoc/issues/99