### PR TITLE
⭐ Extend microsoft.users to contain the data for assignedLicenses

### DIFF
--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -81,6 +81,14 @@ microsoft.users {
   search string
 }
 
+// This type represents a single license assigned to a user.
+private microsoft.user.assignedLicense @defaults("skuId") {
+  // A collection of the unique identifiers for plans that have been disabled.
+  disabledPlans []string
+  // The unique identifier for the SKU.
+  skuId string
+}
+
 // Microsoft Conditional Access Policies
 microsoft.conditionalAccess {
   // Named locations container
@@ -367,6 +375,8 @@ private microsoft.user @defaults("id displayName userPrincipalName") {
   identities []microsoft.user.identity
   // The user's audit log
   auditlog() microsoft.user.auditlog
+  // The licenses that are assigned to the user, including inherited (group-based) licenses
+  assignedLicenses []microsoft.user.assignedLicense
 }
 
 // Microsoft user audit log

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -38,6 +38,10 @@ func init() {
 			Init: initMicrosoftUsers,
 			Create: createMicrosoftUsers,
 		},
+		"microsoft.user.assignedLicense": {
+			// to override args, implement: initMicrosoftUserAssignedLicense(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createMicrosoftUserAssignedLicense,
+		},
 		"microsoft.conditionalAccess": {
 			// to override args, implement: initMicrosoftConditionalAccess(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMicrosoftConditionalAccess,
@@ -422,6 +426,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.users.list": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftUsers).GetList()).ToDataRes(types.Array(types.Resource("microsoft.user")))
 	},
+	"microsoft.user.assignedLicense.disabledPlans": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftUserAssignedLicense).GetDisabledPlans()).ToDataRes(types.Array(types.String))
+	},
+	"microsoft.user.assignedLicense.skuId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftUserAssignedLicense).GetSkuId()).ToDataRes(types.String)
+	},
 	"microsoft.conditionalAccess.namedLocations": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftConditionalAccess).GetNamedLocations()).ToDataRes(types.Resource("microsoft.conditionalAccess.namedLocations"))
 	},
@@ -727,6 +737,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"microsoft.user.auditlog": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftUser).GetAuditlog()).ToDataRes(types.Resource("microsoft.user.auditlog"))
+	},
+	"microsoft.user.assignedLicenses": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftUser).GetAssignedLicenses()).ToDataRes(types.Array(types.Resource("microsoft.user.assignedLicense")))
 	},
 	"microsoft.user.auditlog.userId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftUserAuditlog).GetUserId()).ToDataRes(types.String)
@@ -1757,6 +1770,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlMicrosoftUsers).List, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
+	"microsoft.user.assignedLicense.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlMicrosoftUserAssignedLicense).__id, ok = v.Value.(string)
+			return
+		},
+	"microsoft.user.assignedLicense.disabledPlans": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftUserAssignedLicense).DisabledPlans, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"microsoft.user.assignedLicense.skuId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftUserAssignedLicense).SkuId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"microsoft.conditionalAccess.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 			r.(*mqlMicrosoftConditionalAccess).__id, ok = v.Value.(string)
 			return
@@ -2243,6 +2268,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"microsoft.user.auditlog": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftUser).Auditlog, ok = plugin.RawToTValue[*mqlMicrosoftUserAuditlog](v.Value, v.Error)
+		return
+	},
+	"microsoft.user.assignedLicenses": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftUser).AssignedLicenses, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
 	"microsoft.user.auditlog.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4083,6 +4112,55 @@ func (c *mqlMicrosoftUsers) GetList() *plugin.TValue[[]interface{}] {
 	})
 }
 
+// mqlMicrosoftUserAssignedLicense for the microsoft.user.assignedLicense resource
+type mqlMicrosoftUserAssignedLicense struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlMicrosoftUserAssignedLicenseInternal it will be used here
+	DisabledPlans plugin.TValue[[]interface{}]
+	SkuId plugin.TValue[string]
+}
+
+// createMicrosoftUserAssignedLicense creates a new instance of this resource
+func createMicrosoftUserAssignedLicense(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMicrosoftUserAssignedLicense{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("microsoft.user.assignedLicense", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMicrosoftUserAssignedLicense) MqlName() string {
+	return "microsoft.user.assignedLicense"
+}
+
+func (c *mqlMicrosoftUserAssignedLicense) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMicrosoftUserAssignedLicense) GetDisabledPlans() *plugin.TValue[[]interface{}] {
+	return &c.DisabledPlans
+}
+
+func (c *mqlMicrosoftUserAssignedLicense) GetSkuId() *plugin.TValue[string] {
+	return &c.SkuId
+}
+
 // mqlMicrosoftConditionalAccess for the microsoft.conditionalAccess resource
 type mqlMicrosoftConditionalAccess struct {
 	MqlRuntime *plugin.Runtime
@@ -5289,6 +5367,7 @@ type mqlMicrosoftUser struct {
 	CreationType plugin.TValue[string]
 	Identities plugin.TValue[[]interface{}]
 	Auditlog plugin.TValue[*mqlMicrosoftUserAuditlog]
+	AssignedLicenses plugin.TValue[[]interface{}]
 }
 
 // createMicrosoftUser creates a new instance of this resource
@@ -5469,6 +5548,10 @@ func (c *mqlMicrosoftUser) GetAuditlog() *plugin.TValue[*mqlMicrosoftUserAuditlo
 
 		return c.auditlog()
 	})
+}
+
+func (c *mqlMicrosoftUser) GetAssignedLicenses() *plugin.TValue[[]interface{}] {
+	return &c.AssignedLicenses
 }
 
 // mqlMicrosoftUserAuditlog for the microsoft.user.auditlog resource

--- a/providers/ms365/resources/ms365.lr.manifest.yaml
+++ b/providers/ms365/resources/ms365.lr.manifest.yaml
@@ -492,6 +492,7 @@ resources:
   microsoft.user:
     fields:
       accountEnabled: {}
+      assignedLicenses: {}
       auditlog: {}
       authMethods: {}
       city: {}
@@ -520,6 +521,12 @@ resources:
       surname: {}
       userPrincipalName: {}
       userType: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
+  microsoft.user.assignedLicense:
+    fields:
+      disabledPlans: {}
+      skuId: {}
     is_private: true
     min_mondoo_version: 9.0.0
   microsoft.user.auditlog:
@@ -564,6 +571,7 @@ resources:
     min_mondoo_version: 9.0.0
   microsoft.users:
     fields:
+      assignedLicenses: {}
       filter: {}
       list: {}
       search: {}


### PR DESCRIPTION
This should work like this:

```
microsoft.users {assignedLicenses}
microsoft.users.list: [
  0: {
    assignedLicenses: [
      0: microsoft.user.assignedLicense skuId="c42b9cae-ea4f-4ab7-9717-81576235ccac"
    ]
  }
  1: {
    assignedLicenses: []
  }
  2: {
    assignedLicenses: [
      0: microsoft.user.assignedLicense skuId="c42b9cae-ea4f-4ab7-9717-81576235ccac"
    ]
  }
```
