### PR TITLE
⭐ Add depguard tp the linter rule to restrict viper usage

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,16 @@ linters-settings:
 
   depguard:
     rules:
+      prevent-viper-in-internal-packages:
+        files:
+          - "$all"
+          - "!$test"
+          - "!**/cmd/**"
+          - "!**/cli/**"
+          - "!**/local_scanner.go"
+        deny:
+          - pkg: "github.com/spf13/viper"
+            desc: "viper should only be used in CLI packages (under cmd/ or cli/)"
       denied-packages:
         deny:
           - pkg: "gotest.tools"


### PR DESCRIPTION
Introduces a new `depguard` rule to prevent the `github.com/spf13/viper`
package from being imported outside of designated CLI packages.