### PR TITLE
✨ cnquery run `--exit-1-on-failure`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist
 alpine-container.tar
 centos-container.tar
 ./cnquery
+test/commands/cnquery
 file1
 id_rsa
 id_rsa.pub

--- a/apps/cnquery/cmd/run.go
+++ b/apps/cnquery/cmd/run.go
@@ -32,6 +32,7 @@ func init() {
 	_ = RunCmd.Flags().MarkHidden("use-llx")
 	RunCmd.Flags().StringToString("annotations", nil, "Specify annotations for this run")
 	_ = RunCmd.Flags().MarkHidden("annotations")
+	RunCmd.Flags().Bool("exit-1-on-failure", false, "Exit with error code 1 if one or more query results fail")
 }
 
 var RunCmd = &cobra.Command{
@@ -53,6 +54,7 @@ var RunCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *plu
 	conf.DoAst, _ = cmd.Flags().GetBool("ast")
 	conf.DoInfo, _ = cmd.Flags().GetBool("info")
 	conf.DoParse, _ = cmd.Flags().GetBool("parse")
+	conf.Exit_1OnFailure, _ = cmd.Flags().GetBool("exit-1-on-failure")
 	if doJSON, _ := cmd.Flags().GetBool("json"); doJSON {
 		conf.Format = "json"
 	}

--- a/shared/proto/cnquery.pb.go
+++ b/shared/proto/cnquery.pb.go
@@ -26,22 +26,23 @@ const (
 )
 
 type RunQueryConfig struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	Command        string                 `protobuf:"bytes,1,opt,name=command,proto3" json:"command,omitempty"`
-	CallbackServer uint32                 `protobuf:"varint,2,opt,name=callback_server,json=callbackServer,proto3" json:"callback_server,omitempty"`
-	Inventory      *inventory.Inventory   `protobuf:"bytes,3,opt,name=inventory,proto3" json:"inventory,omitempty"`
-	Features       []byte                 `protobuf:"bytes,4,opt,name=features,proto3" json:"features,omitempty"`
-	DoParse        bool                   `protobuf:"varint,5,opt,name=do_parse,json=doParse,proto3" json:"do_parse,omitempty"`
-	DoAst          bool                   `protobuf:"varint,6,opt,name=do_ast,json=doAst,proto3" json:"do_ast,omitempty"`
-	DoInfo         bool                   `protobuf:"varint,13,opt,name=do_info,json=doInfo,proto3" json:"do_info,omitempty"`
-	DoRecord       bool                   `protobuf:"varint,7,opt,name=do_record,json=doRecord,proto3" json:"do_record,omitempty"`
-	Format         string                 `protobuf:"bytes,8,opt,name=format,proto3" json:"format,omitempty"`
-	PlatformId     string                 `protobuf:"bytes,9,opt,name=platform_id,json=platformId,proto3" json:"platform_id,omitempty"`
-	Incognito      bool                   `protobuf:"varint,10,opt,name=incognito,proto3" json:"incognito,omitempty"`
-	Output         string                 `protobuf:"bytes,11,opt,name=output,proto3" json:"output,omitempty"`
-	Input          string                 `protobuf:"bytes,12,opt,name=input,proto3" json:"input,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Command         string                 `protobuf:"bytes,1,opt,name=command,proto3" json:"command,omitempty"`
+	CallbackServer  uint32                 `protobuf:"varint,2,opt,name=callback_server,json=callbackServer,proto3" json:"callback_server,omitempty"`
+	Inventory       *inventory.Inventory   `protobuf:"bytes,3,opt,name=inventory,proto3" json:"inventory,omitempty"`
+	Features        []byte                 `protobuf:"bytes,4,opt,name=features,proto3" json:"features,omitempty"`
+	DoParse         bool                   `protobuf:"varint,5,opt,name=do_parse,json=doParse,proto3" json:"do_parse,omitempty"`
+	DoAst           bool                   `protobuf:"varint,6,opt,name=do_ast,json=doAst,proto3" json:"do_ast,omitempty"`
+	DoInfo          bool                   `protobuf:"varint,13,opt,name=do_info,json=doInfo,proto3" json:"do_info,omitempty"`
+	DoRecord        bool                   `protobuf:"varint,7,opt,name=do_record,json=doRecord,proto3" json:"do_record,omitempty"`
+	Format          string                 `protobuf:"bytes,8,opt,name=format,proto3" json:"format,omitempty"`
+	PlatformId      string                 `protobuf:"bytes,9,opt,name=platform_id,json=platformId,proto3" json:"platform_id,omitempty"`
+	Incognito       bool                   `protobuf:"varint,10,opt,name=incognito,proto3" json:"incognito,omitempty"`
+	Output          string                 `protobuf:"bytes,11,opt,name=output,proto3" json:"output,omitempty"`
+	Input           string                 `protobuf:"bytes,12,opt,name=input,proto3" json:"input,omitempty"`
+	Exit_1OnFailure bool                   `protobuf:"varint,14,opt,name=exit_1_on_failure,json=exit1OnFailure,proto3" json:"exit_1_on_failure,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *RunQueryConfig) Reset() {
@@ -165,6 +166,13 @@ func (x *RunQueryConfig) GetInput() string {
 	return ""
 }
 
+func (x *RunQueryConfig) GetExit_1OnFailure() bool {
+	if x != nil {
+		return x.Exit_1OnFailure
+	}
+	return false
+}
+
 type Empty struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -249,7 +257,7 @@ var File_cnquery_proto protoreflect.FileDescriptor
 
 const file_cnquery_proto_rawDesc = "" +
 	"\n" +
-	"\rcnquery.proto\x12\x05proto\x1a*providers-sdk/v1/inventory/inventory.proto\"\x9b\x03\n" +
+	"\rcnquery.proto\x12\x05proto\x1a*providers-sdk/v1/inventory/inventory.proto\"\xc6\x03\n" +
 	"\x0eRunQueryConfig\x12\x18\n" +
 	"\acommand\x18\x01 \x01(\tR\acommand\x12'\n" +
 	"\x0fcallback_server\x18\x02 \x01(\rR\x0ecallbackServer\x12=\n" +
@@ -265,7 +273,8 @@ const file_cnquery_proto_rawDesc = "" +
 	"\tincognito\x18\n" +
 	" \x01(\bR\tincognito\x12\x16\n" +
 	"\x06output\x18\v \x01(\tR\x06output\x12\x14\n" +
-	"\x05input\x18\f \x01(\tR\x05input\"\a\n" +
+	"\x05input\x18\f \x01(\tR\x05input\x12)\n" +
+	"\x11exit_1_on_failure\x18\x0e \x01(\bR\x0eexit1OnFailure\"\a\n" +
 	"\x05Empty\"\x1c\n" +
 	"\x06String\x12\x12\n" +
 	"\x04data\x18\x01 \x01(\tR\x04data2:\n" +

--- a/shared/proto/cnquery.proto
+++ b/shared/proto/cnquery.proto
@@ -24,6 +24,7 @@ message RunQueryConfig {
   bool incognito = 10;
   string output = 11;
   string input = 12;
+  bool exit_1_on_failure = 14;
 }
 
 message Empty {

--- a/test/commands/testdata/cnquery_run.ct
+++ b/test/commands/testdata/cnquery_run.ct
@@ -6,17 +6,30 @@ Usage:
   cnquery run [command]
 
 Available Commands:
+  container   Run a query with a running container or container image
+  device      Run a query with a block device target
+  docker      Run a query with a running Docker container, Docker image, or Dockerfile
+  filesystem  Run a query with a mounted file system target
+  local       Run a query with your local system
   mock        Run a query with a recording file without an active connection
   sbom        Run a query with read SBOM file on disk
+  ssh         Run a query with a remote system via SSH
+  vagrant     Run a query with a Vagrant host
+  winrm       Run a query with a remote system via WinRM
 
 Flags:
-      --ast                  Parse the query and return the abstract syntax tree (AST)
-  -c, --command string       MQL query to execute in the shell
-  -h, --help                 help for run
-      --info                 Parse the query and provide information about it
-  -j, --json                 Run the query and return the object in a JSON structure
-      --parse                Parse the query and return the logical structure
-      --platform-id string   Select a specific target asset by providing its platform ID
+      --ast                    Parse the query and return the abstract syntax tree (AST)
+  -c, --command string         MQL query to execute in the shell
+      --discover strings       Enable the discovery of nested assets. Supports: all, auto, container, container-images
+      --exit-1-on-failure      Exit with error code 1 if one or more query results fail
+  -h, --help                   help for run
+      --info                   Parse the query and provide information about it
+  -j, --json                   Run the query and return the object in a JSON structure
+      --parse                  Parse the query and return the logical structure
+      --platform-id string     Select a specific target asset by providing its platform ID
+      --record string          Record all resource calls and use resources in the recording
+      --sudo                   Elevate privileges with sudo
+      --use-recording string   Use a recording to inject resource data (read-only)
 
 Global Flags:
       --api-proxy string   Set proxy for communications with Mondoo Platform API

--- a/test/commands/testdata/cnquery_run_exit_1_on_failure.ct
+++ b/test/commands/testdata/cnquery_run_exit_1_on_failure.ct
@@ -1,0 +1,11 @@
+$ cnquery run local -c 1==2
+→ no Mondoo configuration file provided, using defaults
+[failed]  == 2
+  expected: == 2
+  actual:   1
+
+$ cnquery run local -c 1==2 --exit-1-on-failure --> FAIL
+→ no Mondoo configuration file provided, using defaults
+[failed]  == 2
+  expected: == 2
+  actual:   1

--- a/test/commands/testdata/cnquery_sbom.ct
+++ b/test/commands/testdata/cnquery_sbom.ct
@@ -17,14 +17,25 @@ Usage:
   cnquery sbom [command]
 
 Available Commands:
+  container   Collect a software bill of materials (SBOM) for a running container or container image
+  docker      Collect a software bill of materials (SBOM) for a running Docker container, Docker image, or Dockerfile
+  filesystem  Collect a software bill of materials (SBOM) for a mounted file system target
+  local       Collect a software bill of materials (SBOM) for your local system
   sbom        Collect a software bill of materials (SBOM) for read SBOM file on disk
+  ssh         Collect a software bill of materials (SBOM) for a remote system via SSH
+  vagrant     Collect a software bill of materials (SBOM) for a Vagrant host
+  winrm       Collect a software bill of materials (SBOM) for a remote system via WinRM
 
 Flags:
       --annotation stringToString   Add an annotation to the asset (default [])
       --asset-name string           User-override for the asset name
+      --discover strings            Enable the discovery of nested assets. Supports: all, auto, container, container-images
   -h, --help                        help for sbom
   -o, --output string               Set output format: json, cyclonedx-json, cyclonedx-xml, spdx-json, spdx-tag-value, table (default "list")
       --output-target string        Set output target to which the SBOM report will be written
+      --record string               Record all resource calls and use resources in the recording
+      --sudo                        Elevate privileges with sudo
+      --use-recording string        Use a recording to inject resource data (read-only)
       --with-evidence               Display evidence for each component
 
 Global Flags:

--- a/test/commands/testdata/cnquery_scan.ct
+++ b/test/commands/testdata/cnquery_scan.ct
@@ -14,13 +14,22 @@ Usage:
   cnquery scan [command]
 
 Available Commands:
+  container   Scan a running container or container image
+  device      Scan a block device target
+  docker      Scan a running Docker container, Docker image, or Dockerfile
+  filesystem  Scan a mounted file system target
+  local       Scan your local system
   mock        Scan a recording file without an active connection
   sbom        Scan read SBOM file on disk
+  ssh         Scan a remote system via SSH
+  vagrant     Scan a Vagrant host
+  winrm       Scan a remote system via WinRM
 
 Flags:
       --annotation stringToString     Add an annotation to the asset (default [])
       --asset-name string             User-override for the asset name
       --detect-cicd                   Try to detect CI/CD environments. If detected, set the asset category to 'cicd' (default true)
+      --discover strings              Enable the discovery of nested assets. Supports: all, auto, container, container-images
   -h, --help                          help for scan
       --incognito                     Run in incognito mode. Do not report scan results to Mondoo Platform
       --inventory-file string         Set the path to the inventory file
@@ -32,7 +41,10 @@ Flags:
       --props stringToString          Custom values for properties (default [])
       --querypack querypack-bundle    Set the query packs to execute. This requires querypack-bundle. You can specify multiple UIDs
   -f, --querypack-bundle strings      Path to local query pack file
+      --record string                 Record all resource calls and use resources in the recording
+      --sudo                          Elevate privileges with sudo
       --trace-id string               Trace identifier
+      --use-recording string          Use a recording to inject resource data (read-only)
 
 Global Flags:
       --api-proxy string   Set proxy for communications with Mondoo Platform API


### PR DESCRIPTION
This change adds a new flag named `--exit-1-on-failure` which will make
`cnquery` exit with code `1` if any query result failed.

Simple Example: **This should fail.**
```
cnquery run -c "1==2" --exit-1-on-failure
```

Closes https://github.com/mondoohq/cnspec/issues/1671