### PR TITLE
🐛 Convert to durations for JSON

### DIFF
--- a/cli/printer/mql.go
+++ b/cli/printer/mql.go
@@ -764,28 +764,9 @@ func (print *Printer) Data(typ types.Type, data interface{}, codeID string, bund
 			return print.Secondary(time.String())
 		}
 
-		seconds := llx.TimeToDuration(time)
-		minutes := seconds / 60
-		hours := minutes / 60
-		days := hours / 24
+		durationStr := llx.TimeToDurationString(*time)
 
-		var res strings.Builder
-		if days > 0 {
-			res.WriteString(fmt.Sprintf("%d days ", days))
-		}
-		if hours%24 != 0 {
-			res.WriteString(fmt.Sprintf("%d hours ", hours%24))
-		}
-		if minutes%24 != 0 {
-			res.WriteString(fmt.Sprintf("%d minutes ", minutes%60))
-		}
-		// if we haven't printed any of the other pieces (days/hours/minutes) then print this
-		// if we have, then check if this is non-zero
-		if minutes == 0 || seconds%60 != 0 {
-			res.WriteString(fmt.Sprintf("%d seconds", seconds%60))
-		}
-
-		return print.Secondary(res.String())
+		return print.Secondary(durationStr)
 	case types.Dict:
 		return print.dict(typ, data, codeID, bundle, indent)
 

--- a/llx/builtin_simple.go
+++ b/llx/builtin_simple.go
@@ -5,6 +5,7 @@ package llx
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"regexp"
 	"strconv"
@@ -2532,6 +2533,31 @@ func TimeToDuration(t *time.Time) int64 {
 // DurationToTime takes a duration in seconds and turns it into a time object
 func DurationToTime(i int64) time.Time {
 	return time.Unix(i+zeroTimeOffset, 0)
+}
+
+func TimeToDurationString(t time.Time) string {
+	seconds := TimeToDuration(&t)
+	minutes := seconds / 60
+	hours := minutes / 60
+	days := hours / 24
+
+	var res strings.Builder
+	if days > 0 {
+		res.WriteString(fmt.Sprintf("%d days ", days))
+	}
+	if hours%24 != 0 {
+		res.WriteString(fmt.Sprintf("%d hours ", hours%24))
+	}
+	if minutes%60 != 0 {
+		res.WriteString(fmt.Sprintf("%d minutes ", minutes%60))
+	}
+	// if we haven't printed any of the other pieces (days/hours/minutes) then print this
+	// if we have, then check if this is non-zero
+	if minutes == 0 || seconds%60 != 0 {
+		res.WriteString(fmt.Sprintf("%d seconds", seconds%60))
+	}
+
+	return strings.TrimSpace(res.String())
 }
 
 func timeSecondsV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {

--- a/llx/rawdata_json.go
+++ b/llx/rawdata_json.go
@@ -379,9 +379,19 @@ func rawDataJSON(typ types.Type, data interface{}, codeID string, bundle *CodeBu
 			return nil
 		}
 
-		b, err := time.MarshalJSON()
-		buf.Write(b)
-		return err
+		if time.Unix() > 0 {
+			b, err := time.MarshalJSON()
+			if err != nil {
+				return err
+			}
+			buf.Write(b)
+		} else {
+			buf.WriteByte('"')
+			buf.WriteString(TimeToDurationString(*time))
+			buf.WriteByte('"')
+		}
+
+		return nil
 
 	case types.Dict:
 		return rawDictJSON(typ, data, buf)

--- a/llx/rawdata_json_test.go
+++ b/llx/rawdata_json_test.go
@@ -56,6 +56,17 @@ func TestRawDataJson_nevertime(t *testing.T) {
 	require.True(t, json.Valid(res.Bytes()))
 }
 
+func TestRawDataJson_duration(t *testing.T) {
+	const mins = 60         // 1 minute in seconds
+	const hours = 60 * mins // 1 hour in seconds
+	const days = 24 * hours // 24 hours in seconds
+	dur := DurationToTime(4*days + 13*hours + 42*mins)
+	var res bytes.Buffer
+	require.NoError(t, rawDataJSON(types.Time, &dur, "", &CodeBundle{}, &res))
+	require.Equal(t, res.String(), "\"4 days 13 hours 42 minutes\"")
+	require.True(t, json.Valid(res.Bytes()))
+}
+
 func TestRawDataJson_Umlauts(t *testing.T) {
 	var res bytes.Buffer
 	require.NoError(t, rawDataJSON(types.String, "Systemintegrit\x84t", "blfbjef", &CodeBundle{}, &res))


### PR DESCRIPTION
They were being put in as a timestamp

Also, fixes an issue where we were saying there are 24 mins in an hour instead of 60