### PR TITLE
✨ Detect activated SLES modules/extensions

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -422,7 +422,7 @@ var sles = &PlatformResolver{
 		if pf.Name == "sles" {
 			// SLES can have various modules/repos activated, identify them via filesystem
 			modules := getActivatedSlesModules(conn)
-			pf.Metadata["activated_modules"] = strings.Join(modules, ", ")
+			pf.Metadata["suse/modules"] = strings.Join(modules, ",")
 
 			return true, nil
 		}

--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -420,6 +420,10 @@ var sles = &PlatformResolver{
 	IsFamily: false,
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		if pf.Name == "sles" {
+			// SLES can have various modules/repos activated, identify them via filesystem
+			modules := getActivatedSlesModules(conn)
+			pf.Metadata["activated_modules"] = strings.Join(modules, ", ")
+
 			return true, nil
 		}
 		return false, nil

--- a/providers/os/detector/detector_sles.go
+++ b/providers/os/detector/detector_sles.go
@@ -1,0 +1,66 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package detector
+
+import (
+	"encoding/xml"
+	"strings"
+
+	"github.com/spf13/afero"
+	"go.mondoo.com/cnquery/v11/providers/os/connection/shared"
+)
+
+type SlesProduct struct {
+	Summary  string        `xml:"summary"`
+	Register RegisterEntry `xml:"register"`
+}
+
+type RegisterEntry struct {
+	Target string `xml:"target"`
+	Flavor string `xml:"flavor"`
+}
+
+func getActivatedSlesModules(conn shared.Connection) []string {
+	afs := &afero.Afero{Fs: conn.FileSystem()}
+	ok, err := afs.DirExists("/etc/products.d")
+	if err != nil || !ok {
+		return []string{}
+	}
+
+	files, err := afs.ReadDir("/etc/products.d")
+	if err != nil {
+		return []string{}
+	}
+
+	modules := []string{}
+	for _, file := range files {
+		if !strings.HasSuffix(file.Name(), ".prod") {
+			continue
+		}
+
+		content, err := afs.ReadFile("/etc/products.d/" + file.Name())
+		if err != nil {
+			continue
+		}
+
+		var product SlesProduct
+		err = xml.Unmarshal(content, &product)
+		if err != nil {
+			continue
+		}
+
+		// We are only interested in modules and extensions
+		if product.Register.Flavor != "module" && product.Register.Flavor != "extension" {
+			continue
+		}
+
+		// We need to trim the prefix "SUSE " for some modules, to match the ecosystem
+		// The same applies to the " Module" suffix
+		moduleName := strings.TrimPrefix(product.Summary, "SUSE ")
+		moduleName = strings.TrimSuffix(moduleName, " Module")
+		modules = append(modules, moduleName)
+	}
+
+	return modules
+}

--- a/providers/os/detector/detector_sles_test.go
+++ b/providers/os/detector/detector_sles_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package detector
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
+	"go.mondoo.com/cnquery/v11/providers/os/connection/shared"
+)
+
+type mockConnection struct {
+	fs afero.Fs
+}
+
+func (m *mockConnection) ID() uint32 {
+	return 1
+}
+
+func (m *mockConnection) ParentID() uint32 {
+	return 0
+}
+
+func (m *mockConnection) FileSystem() afero.Fs {
+	return m.fs
+}
+
+func (m *mockConnection) RunCommand(command string) (*shared.Command, error) {
+	return nil, nil
+}
+
+func (m *mockConnection) FileInfo(path string) (shared.FileInfoDetails, error) {
+	return shared.FileInfoDetails{}, nil
+}
+
+func (m *mockConnection) Name() string {
+	return "mock"
+}
+
+func (m *mockConnection) Type() shared.ConnectionType {
+	return shared.Type_Local
+}
+
+func (m *mockConnection) Asset() *inventory.Asset {
+	return &inventory.Asset{}
+}
+
+func (m *mockConnection) UpdateAsset(asset *inventory.Asset) {}
+
+func (m *mockConnection) Capabilities() shared.Capabilities {
+	return shared.Capability_File
+}
+
+func TestGetActivatedSlesModules(t *testing.T) {
+	tests := []struct {
+		name     string
+		files    map[string]string
+		expected []string
+	}{
+		{
+			name:     "no modules directory",
+			files:    map[string]string{},
+			expected: []string{},
+		},
+		{
+			name: "empty modules directory",
+			files: map[string]string{
+				"/etc/products.d": "",
+			},
+			expected: []string{},
+		},
+		{
+			name: "valid modules",
+			files: map[string]string{
+				"/etc/products.d/base.prod": `<?xml version="1.0" encoding="UTF-8"?>
+<product>
+  <summary>SUSE Linux Enterprise Server</summary>
+  <register>
+    <target>sles</target>
+  </register>
+</product>`,
+				"/etc/products.d/desktop.prod": `<?xml version="1.0" encoding="UTF-8"?>
+<product>
+  <summary>Basesystem Module</summary>
+  <register>
+    <target>sles</target>
+    <flavor>module</flavor>
+  </register>
+</product>`,
+				"/etc/products.d/we.prod": `<?xml version="1.0" encoding="UTF-8"?>
+<product>
+  <summary>SUSE Linux Enterprise High Availability Extension 15 SP5</summary>
+  <register>
+    <target>sles</target>
+    <flavor>extension</flavor>
+  </register>
+</product>`,
+			},
+			expected: []string{"Basesystem", "Linux Enterprise High Availability Extension 15 SP5"},
+		},
+		{
+			name: "invalid xml",
+			files: map[string]string{
+				"/etc/products.d/invalid.prod": `invalid xml content`,
+			},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock filesystem
+			fs := afero.NewMemMapFs()
+
+			// Create the directory structure
+			if len(tt.files) > 0 {
+				err := fs.MkdirAll("/etc/products.d", 0o755)
+				assert.NoError(t, err)
+			}
+
+			// Create the files
+			for path, content := range tt.files {
+				if path == "/etc/products.d" {
+					continue
+				}
+				err := afero.WriteFile(fs, path, []byte(content), 0o644)
+				assert.NoError(t, err)
+			}
+
+			// Create a mock connection
+			conn := &mockConnection{
+				fs: fs,
+			}
+
+			// Call the function
+			result := getActivatedSlesModules(conn)
+
+			// Compare results
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
This adds the actiavted SLES modules to the platform metadata.

```
cnquery run container image registry.suse.com/suse/sle15 -c "asset.platformMetadata"
→ loaded configuration from /etc/opt/mondoo/mondoo.yml using source default
asset.platformMetadata: {
  activated_modules: "Basesystem, Python 3, Server Applications"
  distro-id: "sles"
}
```