### PR TITLE
⭐️ add m365 managed device support

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -120,3 +120,9 @@ vulnmgmt
 wil
 xoxp
 xssmatchstatement
+eas
+iccid
+imei
+manageddevice
+meid
+udid

--- a/providers/ms365/connection/scopes.go
+++ b/providers/ms365/connection/scopes.go
@@ -1,4 +1,0 @@
-// Copyright (c) Mondoo, Inc.
-// SPDX-License-Identifier: BUSL-1.1
-
-package connection

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -965,25 +965,25 @@ microsoft.devicemanagement {
 private microsoft.devicemanagement.manageddevice {
   // Managed device ID
   id string
-  // Unique Identifier for the user associated with the device
+  // Unique identifier for the user associated with the device
   userId string
   // Name of the device
   name string
   // Operating system of the device
   operatingSystem string
-  // Whether the device is jail broken or rooted.
+  // Whether the device is jail broken or rooted
   jailBroken string
   // Operating system version of the device
   osVersion string
   // Whether the device is Exchange ActiveSync activated
   easActivated bool
-  // Exchange ActiveSync Id of the device.
+  // Exchange ActiveSync Id of the device
   easDeviceId string
-  // Whether the device is Azure Active Directory registered
+  // Whether the device is Entra ID (previously Azure AD) registered
   azureADRegistered bool
   // Email(s) for the user associated with the device
   emailAddress string
-  // The unique identifier for the Azure Active Directory device
+  // The unique identifier for the Entra ID (previously Azure AD) device
   azureActiveDirectoryDeviceId string
   // Device category display name
   deviceCategoryDisplayName string
@@ -991,13 +991,13 @@ private microsoft.devicemanagement.manageddevice {
   isSupervised bool
   // Device encryption status
   isEncrypted bool
-  // Device user principal name.
+  // Device user principal name
   userPrincipalName string
-  // Model of the device
+  // Device model
   model string
-  // Manufacturer of the device
+  // Device manufacturer
   manufacturer string
-  // IMEI
+  // International Mobile Equipment Identity (IMEI)
   imei string
   // Serial number of the device
   serialNumber string
@@ -1005,17 +1005,17 @@ private microsoft.devicemanagement.manageddevice {
   androidSecurityPatchLevel string
   // User display name
   userDisplayName string
-  // Wi-Fi MAC
+  // Wi-Fi MAC address
   wiFiMacAddress string
-  // MEID
+  // Mobile Equipment Identifier (MEID)
   meid string
-  // Integrated Circuit Card Identifier
+  // Integrated Circuit Card Identifier (ICCID)
   iccid string
-  // Unique Device Identifier for iOS and macOS devices
+  // Unique Device Identifier (UDID) for iOS and macOS devices
   udid string
   // Notes on the device created by IT
   notes string
-  // Indicates Ethernet MAC Address of the device
+  // Ethernet MAC address of the device
   ethernetMacAddress string
   // Name of the enrollment profile assigned to the device
   enrollmentProfileName string

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -954,10 +954,73 @@ private microsoft.rolemanagement.roleassignment @defaults("id principalId") {
 
 // Microsoft device management
 microsoft.devicemanagement {
+  managedDevices() []microsoft.devicemanagement.manageddevice
   // List of device configurations
   deviceConfigurations() []microsoft.devicemanagement.deviceconfiguration
   // List of device compliance policies
   deviceCompliancePolicies() []microsoft.devicemanagement.devicecompliancepolicy
+}
+
+// Microsoft managed device
+private microsoft.devicemanagement.manageddevice {
+  // Managed device ID
+  id string
+  // Unique Identifier for the user associated with the device
+  userId string
+  // Name of the device
+  name string
+  // Operating system of the device
+  operatingSystem string
+  // Whether the device is jail broken or rooted.
+  jailBroken string
+  // Operating system version of the device
+  osVersion string
+  // Whether the device is Exchange ActiveSync activated
+  easActivated bool
+  // Exchange ActiveSync Id of the device.
+  easDeviceId string
+  // Whether the device is Azure Active Directory registered
+  azureADRegistered bool
+  // Email(s) for the user associated with the device
+  emailAddress string
+  // The unique identifier for the Azure Active Directory device
+  azureActiveDirectoryDeviceId string
+  // Device category display name
+  deviceCategoryDisplayName string
+  // Device supervised status
+  isSupervised bool
+  // Device encryption status
+  isEncrypted bool
+  // Device user principal name.
+  userPrincipalName string
+  // Model of the device
+  model string
+  // Manufacturer of the device
+  manufacturer string
+  // IMEI
+  imei string
+  // Serial number of the device
+  serialNumber string
+  // Android security patch level
+  androidSecurityPatchLevel string
+  // User display name
+  userDisplayName string
+  // Wi-Fi MAC
+  wiFiMacAddress string
+  // MEID
+  meid string
+  // Integrated Circuit Card Identifier
+  iccid string
+  // Unique Device Identifier for iOS and macOS devices
+  udid string
+  // Notes on the device created by IT
+  notes string
+  // Indicates Ethernet MAC Address of the device
+  ethernetMacAddress string
+  // Name of the enrollment profile assigned to the device
+  enrollmentProfileName string
+  // Protection state of the device
+  windowsProtectionState dict
 }
 
 // Microsoft device configuration

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -238,6 +238,10 @@ func init() {
 			// to override args, implement: initMicrosoftDevicemanagement(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMicrosoftDevicemanagement,
 		},
+		"microsoft.devicemanagement.manageddevice": {
+			// to override args, implement: initMicrosoftDevicemanagementManageddevice(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createMicrosoftDevicemanagementManageddevice,
+		},
 		"microsoft.devicemanagement.deviceconfiguration": {
 			// to override args, implement: initMicrosoftDevicemanagementDeviceconfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMicrosoftDevicemanagementDeviceconfiguration,
@@ -1444,11 +1448,101 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.rolemanagement.roleassignment.principal": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftRolemanagementRoleassignment).GetPrincipal()).ToDataRes(types.Dict)
 	},
+	"microsoft.devicemanagement.managedDevices": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagement).GetManagedDevices()).ToDataRes(types.Array(types.Resource("microsoft.devicemanagement.manageddevice")))
+	},
 	"microsoft.devicemanagement.deviceConfigurations": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftDevicemanagement).GetDeviceConfigurations()).ToDataRes(types.Array(types.Resource("microsoft.devicemanagement.deviceconfiguration")))
 	},
 	"microsoft.devicemanagement.deviceCompliancePolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftDevicemanagement).GetDeviceCompliancePolicies()).ToDataRes(types.Array(types.Resource("microsoft.devicemanagement.devicecompliancepolicy")))
+	},
+	"microsoft.devicemanagement.manageddevice.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetId()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.userId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetUserId()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetName()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.operatingSystem": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetOperatingSystem()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.jailBroken": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetJailBroken()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.osVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetOsVersion()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.easActivated": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetEasActivated()).ToDataRes(types.Bool)
+	},
+	"microsoft.devicemanagement.manageddevice.easDeviceId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetEasDeviceId()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.azureADRegistered": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetAzureADRegistered()).ToDataRes(types.Bool)
+	},
+	"microsoft.devicemanagement.manageddevice.emailAddress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetEmailAddress()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.azureActiveDirectoryDeviceId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetAzureActiveDirectoryDeviceId()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.deviceCategoryDisplayName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetDeviceCategoryDisplayName()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.isSupervised": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetIsSupervised()).ToDataRes(types.Bool)
+	},
+	"microsoft.devicemanagement.manageddevice.isEncrypted": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetIsEncrypted()).ToDataRes(types.Bool)
+	},
+	"microsoft.devicemanagement.manageddevice.userPrincipalName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetUserPrincipalName()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.model": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetModel()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.manufacturer": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetManufacturer()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.imei": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetImei()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.serialNumber": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetSerialNumber()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.androidSecurityPatchLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetAndroidSecurityPatchLevel()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.userDisplayName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetUserDisplayName()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.wiFiMacAddress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetWiFiMacAddress()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.meid": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetMeid()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.iccid": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetIccid()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.udid": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetUdid()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.notes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetNotes()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.ethernetMacAddress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetEthernetMacAddress()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.enrollmentProfileName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetEnrollmentProfileName()).ToDataRes(types.String)
+	},
+	"microsoft.devicemanagement.manageddevice.windowsProtectionState": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDevicemanagementManageddevice).GetWindowsProtectionState()).ToDataRes(types.Dict)
 	},
 	"microsoft.devicemanagement.deviceconfiguration.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftDevicemanagementDeviceconfiguration).GetId()).ToDataRes(types.String)
@@ -3370,12 +3464,136 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 			r.(*mqlMicrosoftDevicemanagement).__id, ok = v.Value.(string)
 			return
 		},
+	"microsoft.devicemanagement.managedDevices": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagement).ManagedDevices, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
 	"microsoft.devicemanagement.deviceConfigurations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftDevicemanagement).DeviceConfigurations, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
 	"microsoft.devicemanagement.deviceCompliancePolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftDevicemanagement).DeviceCompliancePolicies, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlMicrosoftDevicemanagementManageddevice).__id, ok = v.Value.(string)
+			return
+		},
+	"microsoft.devicemanagement.manageddevice.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.userId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).UserId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.operatingSystem": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).OperatingSystem, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.jailBroken": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).JailBroken, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.osVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).OsVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.easActivated": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).EasActivated, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.easDeviceId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).EasDeviceId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.azureADRegistered": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).AzureADRegistered, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.emailAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).EmailAddress, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.azureActiveDirectoryDeviceId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).AzureActiveDirectoryDeviceId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.deviceCategoryDisplayName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).DeviceCategoryDisplayName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.isSupervised": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).IsSupervised, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.isEncrypted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).IsEncrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.userPrincipalName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).UserPrincipalName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.model": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).Model, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.manufacturer": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).Manufacturer, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.imei": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).Imei, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.serialNumber": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).SerialNumber, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.androidSecurityPatchLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).AndroidSecurityPatchLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.userDisplayName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).UserDisplayName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.wiFiMacAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).WiFiMacAddress, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.meid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).Meid, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.iccid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).Iccid, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.udid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).Udid, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.notes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).Notes, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.ethernetMacAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).EthernetMacAddress, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.enrollmentProfileName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).EnrollmentProfileName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.devicemanagement.manageddevice.windowsProtectionState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDevicemanagementManageddevice).WindowsProtectionState, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
 		return
 	},
 	"microsoft.devicemanagement.deviceconfiguration.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8227,6 +8445,7 @@ type mqlMicrosoftDevicemanagement struct {
 	MqlRuntime *plugin.Runtime
 	__id string
 	// optional: if you define mqlMicrosoftDevicemanagementInternal it will be used here
+	ManagedDevices plugin.TValue[[]interface{}]
 	DeviceConfigurations plugin.TValue[[]interface{}]
 	DeviceCompliancePolicies plugin.TValue[[]interface{}]
 }
@@ -8263,6 +8482,22 @@ func (c *mqlMicrosoftDevicemanagement) MqlID() string {
 	return c.__id
 }
 
+func (c *mqlMicrosoftDevicemanagement) GetManagedDevices() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.ManagedDevices, func() ([]interface{}, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft.devicemanagement", c.__id, "managedDevices")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]interface{}), nil
+			}
+		}
+
+		return c.managedDevices()
+	})
+}
+
 func (c *mqlMicrosoftDevicemanagement) GetDeviceConfigurations() *plugin.TValue[[]interface{}] {
 	return plugin.GetOrCompute[[]interface{}](&c.DeviceConfigurations, func() ([]interface{}, error) {
 		if c.MqlRuntime.HasRecording {
@@ -8293,6 +8528,190 @@ func (c *mqlMicrosoftDevicemanagement) GetDeviceCompliancePolicies() *plugin.TVa
 
 		return c.deviceCompliancePolicies()
 	})
+}
+
+// mqlMicrosoftDevicemanagementManageddevice for the microsoft.devicemanagement.manageddevice resource
+type mqlMicrosoftDevicemanagementManageddevice struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlMicrosoftDevicemanagementManageddeviceInternal it will be used here
+	Id plugin.TValue[string]
+	UserId plugin.TValue[string]
+	Name plugin.TValue[string]
+	OperatingSystem plugin.TValue[string]
+	JailBroken plugin.TValue[string]
+	OsVersion plugin.TValue[string]
+	EasActivated plugin.TValue[bool]
+	EasDeviceId plugin.TValue[string]
+	AzureADRegistered plugin.TValue[bool]
+	EmailAddress plugin.TValue[string]
+	AzureActiveDirectoryDeviceId plugin.TValue[string]
+	DeviceCategoryDisplayName plugin.TValue[string]
+	IsSupervised plugin.TValue[bool]
+	IsEncrypted plugin.TValue[bool]
+	UserPrincipalName plugin.TValue[string]
+	Model plugin.TValue[string]
+	Manufacturer plugin.TValue[string]
+	Imei plugin.TValue[string]
+	SerialNumber plugin.TValue[string]
+	AndroidSecurityPatchLevel plugin.TValue[string]
+	UserDisplayName plugin.TValue[string]
+	WiFiMacAddress plugin.TValue[string]
+	Meid plugin.TValue[string]
+	Iccid plugin.TValue[string]
+	Udid plugin.TValue[string]
+	Notes plugin.TValue[string]
+	EthernetMacAddress plugin.TValue[string]
+	EnrollmentProfileName plugin.TValue[string]
+	WindowsProtectionState plugin.TValue[interface{}]
+}
+
+// createMicrosoftDevicemanagementManageddevice creates a new instance of this resource
+func createMicrosoftDevicemanagementManageddevice(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMicrosoftDevicemanagementManageddevice{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("microsoft.devicemanagement.manageddevice", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) MqlName() string {
+	return "microsoft.devicemanagement.manageddevice"
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetUserId() *plugin.TValue[string] {
+	return &c.UserId
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetOperatingSystem() *plugin.TValue[string] {
+	return &c.OperatingSystem
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetJailBroken() *plugin.TValue[string] {
+	return &c.JailBroken
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetOsVersion() *plugin.TValue[string] {
+	return &c.OsVersion
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetEasActivated() *plugin.TValue[bool] {
+	return &c.EasActivated
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetEasDeviceId() *plugin.TValue[string] {
+	return &c.EasDeviceId
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetAzureADRegistered() *plugin.TValue[bool] {
+	return &c.AzureADRegistered
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetEmailAddress() *plugin.TValue[string] {
+	return &c.EmailAddress
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetAzureActiveDirectoryDeviceId() *plugin.TValue[string] {
+	return &c.AzureActiveDirectoryDeviceId
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetDeviceCategoryDisplayName() *plugin.TValue[string] {
+	return &c.DeviceCategoryDisplayName
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetIsSupervised() *plugin.TValue[bool] {
+	return &c.IsSupervised
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetIsEncrypted() *plugin.TValue[bool] {
+	return &c.IsEncrypted
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetUserPrincipalName() *plugin.TValue[string] {
+	return &c.UserPrincipalName
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetModel() *plugin.TValue[string] {
+	return &c.Model
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetManufacturer() *plugin.TValue[string] {
+	return &c.Manufacturer
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetImei() *plugin.TValue[string] {
+	return &c.Imei
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetSerialNumber() *plugin.TValue[string] {
+	return &c.SerialNumber
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetAndroidSecurityPatchLevel() *plugin.TValue[string] {
+	return &c.AndroidSecurityPatchLevel
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetUserDisplayName() *plugin.TValue[string] {
+	return &c.UserDisplayName
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetWiFiMacAddress() *plugin.TValue[string] {
+	return &c.WiFiMacAddress
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetMeid() *plugin.TValue[string] {
+	return &c.Meid
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetIccid() *plugin.TValue[string] {
+	return &c.Iccid
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetUdid() *plugin.TValue[string] {
+	return &c.Udid
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetNotes() *plugin.TValue[string] {
+	return &c.Notes
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetEthernetMacAddress() *plugin.TValue[string] {
+	return &c.EthernetMacAddress
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetEnrollmentProfileName() *plugin.TValue[string] {
+	return &c.EnrollmentProfileName
+}
+
+func (c *mqlMicrosoftDevicemanagementManageddevice) GetWindowsProtectionState() *plugin.TValue[interface{}] {
+	return &c.WindowsProtectionState
 }
 
 // mqlMicrosoftDevicemanagementDeviceconfiguration for the microsoft.devicemanagement.deviceconfiguration resource

--- a/providers/ms365/resources/ms365.lr.manifest.yaml
+++ b/providers/ms365/resources/ms365.lr.manifest.yaml
@@ -252,6 +252,7 @@ resources:
     fields:
       deviceCompliancePolicies: {}
       deviceConfigurations: {}
+      managedDevices: {}
     min_mondoo_version: 9.0.0
   microsoft.devicemanagement.devicecompliancepolicy:
     fields:
@@ -274,6 +275,40 @@ resources:
       lastModifiedDateTime: {}
       properties: {}
       version: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
+  microsoft.devicemanagement.manageddevice:
+    fields:
+      androidSecurityPatchLevel: {}
+      azureADRegistered: {}
+      azureActiveDirectoryDeviceId: {}
+      deviceCategoryDisplayName: {}
+      easActivated: {}
+      easDeviceId: {}
+      emailAddress: {}
+      enrollmentProfileName: {}
+      ethernetMacAddress: {}
+      iccid: {}
+      id: {}
+      imei: {}
+      isEncrypted: {}
+      isSupervised: {}
+      jailBroken: {}
+      manufacturer: {}
+      meid: {}
+      model: {}
+      name: {}
+      notes: {}
+      operatingSystem: {}
+      osVersion: {}
+      protectionState: {}
+      serialNumber: {}
+      udid: {}
+      userDisplayName: {}
+      userId: {}
+      userPrincipalName: {}
+      wiFiMacAddress: {}
+      windowsProtectionState: {}
     is_private: true
     min_mondoo_version: 9.0.0
   microsoft.devices:

--- a/providers/ms365/resources/structs.go
+++ b/providers/ms365/resources/structs.go
@@ -1011,3 +1011,161 @@ func newCompanySubscription(p models.CompanySubscriptionable) companySubscriptio
 	}
 	return sub
 }
+
+type WindowsProtectionState struct {
+	ID                             *string                     `json:"id,omitempty"`
+	AntiMalwareVersion             *string                     `json:"antiMalwareVersion,omitempty"`
+	DetectedMalwareState           []WindowsDeviceMalwareState `json:"detectedMalwareState,omitempty"`
+	DeviceState                    *string                     `json:"deviceState,omitempty"` // WindowsDeviceHealthState enum
+	EngineVersion                  *string                     `json:"engineVersion,omitempty"`
+	FullScanOverdue                *bool                       `json:"fullScanOverdue,omitempty"`
+	FullScanRequired               *bool                       `json:"fullScanRequired,omitempty"`
+	IsVirtualMachine               *bool                       `json:"isVirtualMachine,omitempty"`
+	LastFullScanDateTime           *time.Time                  `json:"lastFullScanDateTime,omitempty"`
+	LastFullScanSignatureVersion   *string                     `json:"lastFullScanSignatureVersion,omitempty"`
+	LastQuickScanDateTime          *time.Time                  `json:"lastQuickScanDateTime,omitempty"`
+	LastQuickScanSignatureVersion  *string                     `json:"lastQuickScanSignatureVersion,omitempty"`
+	LastReportedDateTime           *time.Time                  `json:"lastReportedDateTime,omitempty"`
+	MalwareProtectionEnabled       *bool                       `json:"malwareProtectionEnabled,omitempty"`
+	NetworkInspectionSystemEnabled *bool                       `json:"networkInspectionSystemEnabled,omitempty"`
+	ProductStatus                  *string                     `json:"productStatus,omitempty"` // WindowsDefenderProductStatus enum
+	QuickScanOverdue               *bool                       `json:"quickScanOverdue,omitempty"`
+	RealTimeProtectionEnabled      *bool                       `json:"realTimeProtectionEnabled,omitempty"`
+	RebootRequired                 *bool                       `json:"rebootRequired,omitempty"`
+	SignatureUpdateOverdue         *bool                       `json:"signatureUpdateOverdue,omitempty"`
+	SignatureVersion               *string                     `json:"signatureVersion,omitempty"`
+	TamperProtectionEnabled        *bool                       `json:"tamperProtectionEnabled,omitempty"`
+}
+
+type WindowsDeviceMalwareState struct {
+	ID                       *string    `json:"id,omitempty"`
+	AdditionalInformation    *string    `json:"additionalInformation,omitempty"`
+	Category                 *string    `json:"category,omitempty"`
+	DisplayName              *string    `json:"displayName,omitempty"`
+	ExecutionState           *string    `json:"executionState,omitempty"`
+	InitialDetectionDateTime *time.Time `json:"initialDetectionDateTime,omitempty"`
+	LastStateChangeDateTime  *time.Time `json:"lastStateChangeDateTime,omitempty"`
+	Severity                 *string    `json:"severity,omitempty"`
+	State                    *string    `json:"state,omitempty"`
+	ThreatState              *string    `json:"threatState,omitempty"`
+}
+
+func newWindowsProtectionState(p models.WindowsProtectionStateable) *WindowsProtectionState {
+	if p == nil {
+		return nil
+	}
+
+	result := &WindowsProtectionState{
+		AntiMalwareVersion:             p.GetAntiMalwareVersion(),
+		EngineVersion:                  p.GetEngineVersion(),
+		FullScanOverdue:                p.GetFullScanOverdue(),
+		FullScanRequired:               p.GetFullScanRequired(),
+		IsVirtualMachine:               p.GetIsVirtualMachine(),
+		LastFullScanSignatureVersion:   p.GetLastFullScanSignatureVersion(),
+		LastQuickScanSignatureVersion:  p.GetLastQuickScanSignatureVersion(),
+		MalwareProtectionEnabled:       p.GetMalwareProtectionEnabled(),
+		NetworkInspectionSystemEnabled: p.GetNetworkInspectionSystemEnabled(),
+		QuickScanOverdue:               p.GetQuickScanOverdue(),
+		RealTimeProtectionEnabled:      p.GetRealTimeProtectionEnabled(),
+		RebootRequired:                 p.GetRebootRequired(),
+		SignatureUpdateOverdue:         p.GetSignatureUpdateOverdue(),
+		SignatureVersion:               p.GetSignatureVersion(),
+		TamperProtectionEnabled:        p.GetTamperProtectionEnabled(),
+	}
+
+	// Handle the ID from the base Entity interface
+	if entity, ok := p.(models.Entityable); ok {
+		result.ID = entity.GetId()
+	}
+
+	// Convert enum values to strings
+	if deviceState := p.GetDeviceState(); deviceState != nil {
+		deviceStateStr := deviceState.String()
+		result.DeviceState = &deviceStateStr
+	}
+
+	if productStatus := p.GetProductStatus(); productStatus != nil {
+		productStatusStr := productStatus.String()
+		result.ProductStatus = &productStatusStr
+	}
+
+	// Convert time pointers
+	if lastFullScan := p.GetLastFullScanDateTime(); lastFullScan != nil {
+		converted := time.Time(*lastFullScan)
+		result.LastFullScanDateTime = &converted
+	}
+
+	if lastQuickScan := p.GetLastQuickScanDateTime(); lastQuickScan != nil {
+		converted := time.Time(*lastQuickScan)
+		result.LastQuickScanDateTime = &converted
+	}
+
+	if lastReported := p.GetLastReportedDateTime(); lastReported != nil {
+		converted := time.Time(*lastReported)
+		result.LastReportedDateTime = &converted
+	}
+
+	// Convert detected malware states
+	if malwareStates := p.GetDetectedMalwareState(); malwareStates != nil {
+		result.DetectedMalwareState = make([]WindowsDeviceMalwareState, len(malwareStates))
+		for i, state := range malwareStates {
+			result.DetectedMalwareState[i] = *newWindowsDeviceMalwareState(state)
+		}
+	}
+
+	return result
+}
+
+func newWindowsDeviceMalwareState(m models.WindowsDeviceMalwareStateable) *WindowsDeviceMalwareState {
+	if m == nil {
+		return nil
+	}
+
+	result := &WindowsDeviceMalwareState{
+		DisplayName: m.GetDisplayName(),
+	}
+
+	// Handle the ID from the base Entity interface
+	if entity, ok := m.(models.Entityable); ok {
+		result.ID = entity.GetId()
+	}
+
+	// Convert enum fields to strings (adjust based on actual enum types)
+	if category := m.GetCategory(); category != nil {
+		categoryStr := category.String()
+		result.Category = &categoryStr
+	}
+
+	if execState := m.GetExecutionState(); execState != nil {
+		execStateStr := execState.String()
+		result.ExecutionState = &execStateStr
+	}
+
+	if severity := m.GetSeverity(); severity != nil {
+		severityStr := severity.String()
+		result.Severity = &severityStr
+	}
+
+	if state := m.GetState(); state != nil {
+		stateStr := state.String()
+		result.State = &stateStr
+	}
+
+	if threatState := m.GetThreatState(); threatState != nil {
+		threatStateStr := threatState.String()
+		result.ThreatState = &threatStateStr
+	}
+
+	// Convert time fields
+	if initialDetection := m.GetInitialDetectionDateTime(); initialDetection != nil {
+		converted := time.Time(*initialDetection)
+		result.InitialDetectionDateTime = &converted
+	}
+
+	if lastStateChange := m.GetLastStateChangeDateTime(); lastStateChange != nil {
+		converted := time.Time(*lastStateChange)
+		result.LastStateChangeDateTime = &converted
+	}
+
+	return result
+}


### PR DESCRIPTION
Add support for intune managed devices

```
cnquery> microsoft.devicemanagement.managedDevices { * }
microsoft.devicemanagement.managedDevices: [
  0: {
    manufacturer: "Apple"
    model: "VirtualMac2,1"
    imei: ""
    emailAddress: "john@example.onmicrosoft.com"
    name: "admin’s Virtual Machine"
    azureActiveDirectoryDeviceId: "bf860ef6-a23c-4029-84a7-dc8548cbe67c"
    isSupervised: true
    wiFiMacAddress: ""
    iccid: null
    udid: null
    userDisplayName: "John  Doe"
    easActivated: true
    osVersion: "14.4.1 (23E224)"
    operatingSystem: "macOS"
    meid: ""
    easDeviceId: "ApplAB1AB2A1A1"
    isEncrypted: false
    ethernetMacAddress: null
    userId: "42f9eb1c-d5e8-427f-95f4-b8007c60e587"
    notes: null
    azureADRegistered: true
    enrollmentProfileName: null
    windowsProtectionState: {}
    serialNumber: "AB1AB2A1A1"
    jailBroken: "Unknown"
    androidSecurityPatchLevel: ""
    id: "0eb09c4e-6e7b-4fab-97cb-71078b2cf73a"
    userPrincipalName: "pjohn@example.onmicrosoft.com"
    deviceCategoryDisplayName: "Unknown"
  }
]
```