### PR TITLE
MS365: Extend ms365.sharepointonline with DefaultLinkPermission

### DIFF
--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -1101,14 +1101,14 @@ ms365.sharepointonline {
   // SharePoint Online tenant sites
   spoSites() []ms365.sharepointonline.site
   // The default link permission for the tenant
-  defaultLinkPermission() []string
+  defaultLinkPermission() string
 }
 
 // Microsoft 365 SharePoint Site
 private ms365.sharepointonline.site {
   // The site URL
   url string
-  // Whether custom script execution on a particulate site allowed
+  // Whether custom script execution on a particular site allowed
   denyAddAndCustomizePages bool
 }
 

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -1100,6 +1100,8 @@ ms365.sharepointonline {
   spoTenantSyncClientRestriction() dict
   // SharePoint Online tenant sites
   spoSites() []ms365.sharepointonline.site
+  // The default link permission for the tenant
+  defaultLinkPermission() []string
 }
 
 // Microsoft 365 SharePoint Site

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -1616,7 +1616,7 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlMs365Sharepointonline).GetSpoSites()).ToDataRes(types.Array(types.Resource("ms365.sharepointonline.site")))
 	},
 	"ms365.sharepointonline.defaultLinkPermission": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlMs365Sharepointonline).GetDefaultLinkPermission()).ToDataRes(types.Array(types.String))
+		return (r.(*mqlMs365Sharepointonline).GetDefaultLinkPermission()).ToDataRes(types.String)
 	},
 	"ms365.sharepointonline.site.url": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMs365SharepointonlineSite).GetUrl()).ToDataRes(types.String)
@@ -3634,7 +3634,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		return
 	},
 	"ms365.sharepointonline.defaultLinkPermission": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlMs365Sharepointonline).DefaultLinkPermission, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		r.(*mqlMs365Sharepointonline).DefaultLinkPermission, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"ms365.sharepointonline.site.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8957,7 +8957,7 @@ type mqlMs365Sharepointonline struct {
 	SpoTenant plugin.TValue[interface{}]
 	SpoTenantSyncClientRestriction plugin.TValue[interface{}]
 	SpoSites plugin.TValue[[]interface{}]
-	DefaultLinkPermission plugin.TValue[[]interface{}]
+	DefaultLinkPermission plugin.TValue[string]
 }
 
 // createMs365Sharepointonline creates a new instance of this resource
@@ -9020,8 +9020,8 @@ func (c *mqlMs365Sharepointonline) GetSpoSites() *plugin.TValue[[]interface{}] {
 	})
 }
 
-func (c *mqlMs365Sharepointonline) GetDefaultLinkPermission() *plugin.TValue[[]interface{}] {
-	return plugin.GetOrCompute[[]interface{}](&c.DefaultLinkPermission, func() ([]interface{}, error) {
+func (c *mqlMs365Sharepointonline) GetDefaultLinkPermission() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.DefaultLinkPermission, func() (string, error) {
 		return c.defaultLinkPermission()
 	})
 }

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -1615,6 +1615,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"ms365.sharepointonline.spoSites": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMs365Sharepointonline).GetSpoSites()).ToDataRes(types.Array(types.Resource("ms365.sharepointonline.site")))
 	},
+	"ms365.sharepointonline.defaultLinkPermission": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365Sharepointonline).GetDefaultLinkPermission()).ToDataRes(types.Array(types.String))
+	},
 	"ms365.sharepointonline.site.url": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMs365SharepointonlineSite).GetUrl()).ToDataRes(types.String)
 	},
@@ -3628,6 +3631,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"ms365.sharepointonline.spoSites": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMs365Sharepointonline).SpoSites, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"ms365.sharepointonline.defaultLinkPermission": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365Sharepointonline).DefaultLinkPermission, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
 		return
 	},
 	"ms365.sharepointonline.site.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8950,6 +8957,7 @@ type mqlMs365Sharepointonline struct {
 	SpoTenant plugin.TValue[interface{}]
 	SpoTenantSyncClientRestriction plugin.TValue[interface{}]
 	SpoSites plugin.TValue[[]interface{}]
+	DefaultLinkPermission plugin.TValue[[]interface{}]
 }
 
 // createMs365Sharepointonline creates a new instance of this resource
@@ -9009,6 +9017,12 @@ func (c *mqlMs365Sharepointonline) GetSpoSites() *plugin.TValue[[]interface{}] {
 		}
 
 		return c.spoSites()
+	})
+}
+
+func (c *mqlMs365Sharepointonline) GetDefaultLinkPermission() *plugin.TValue[[]interface{}] {
+	return plugin.GetOrCompute[[]interface{}](&c.DefaultLinkPermission, func() ([]interface{}, error) {
+		return c.defaultLinkPermission()
 	})
 }
 

--- a/providers/ms365/resources/ms365.lr.manifest.yaml
+++ b/providers/ms365/resources/ms365.lr.manifest.yaml
@@ -663,6 +663,7 @@ resources:
       - microsoft365
   ms365.sharepointonline:
     fields:
+      defaultLinkPermission: {}
       spoSites: {}
       spoTenant: {}
       spoTenantSyncClientRestriction: {}

--- a/providers/ms365/resources/ms365_sharepoint.go
+++ b/providers/ms365/resources/ms365_sharepoint.go
@@ -30,6 +30,7 @@ Import-Module PnP.PowerShell
 Connect-PnPOnline -AccessToken $token -Url $url
 
 $SPOTenant = (Get-PnPTenant)
+$DefaultLinkPermission = (Get-PnPTenant -DefaultLinkPermission)
 $SPOTenantSyncClientRestriction = (Get-PnPTenantSyncClientRestriction)
 $SPOSite = (Get-PnPTenantSite)
 
@@ -37,6 +38,7 @@ $sharepoint = New-Object PSObject
 Add-Member -InputObject $sharepoint -MemberType NoteProperty -Name SPOTenant -Value $SPOTenant
 Add-Member -InputObject $sharepoint -MemberType NoteProperty -Name SPOTenantSyncClientRestriction -Value $SPOTenantSyncClientRestriction
 Add-Member -InputObject $sharepoint -MemberType NoteProperty -Name SPOSite -Value $SPOSite
+Add-Member -InputObject $sharepoint -MemberType NoteProperty -Name DefaultLinkPermission -Value $DefaultLinkPermissio
 
 Disconnect-PnPOnline
 
@@ -44,9 +46,10 @@ ConvertTo-Json -Depth 4 $sharepoint -EnumsAsStrings
 `
 
 type SharepointOnlineReport struct {
-	SpoTenant                      interface{} `json:"SPOTenant"`
-	SpoTenantSyncClientRestriction interface{} `json:"SPOTenantSyncClientRestriction"`
-	SpoSite                        []*SpoSite  `json:"SPOSite"`
+	SpoTenant                      interface{}   `json:"SPOTenant"`
+	SpoTenantSyncClientRestriction interface{}   `json:"SPOTenantSyncClientRestriction"`
+	SpoSite                        []*SpoSite    `json:"SPOSite"`
+	DefaultLinkPermission          []interface{} `json:"DefaultLinkPermission"`
 }
 
 type SpoSite struct {
@@ -59,9 +62,10 @@ func (m *mqlMs365SharepointonlineSite) id() (string, error) {
 }
 
 type mqlMs365SharepointonlineInternal struct {
-	sharepointLock sync.Mutex
-	fetched        bool
-	fetchErr       error
+	sharepointLock        sync.Mutex
+	fetched               bool
+	fetchErr              error
+	DefaultLinkPermission plugin.TValue[[]interface{}]
 }
 
 func (r *mqlMs365Sharepointonline) getTenant() (string, error) {
@@ -192,6 +196,9 @@ func (r *mqlMs365Sharepointonline) getSharepointOnlineReport() error {
 		sites = append(sites, mqlSpoSite)
 	}
 	r.SpoSites = plugin.TValue[[]interface{}]{Data: sites, State: plugin.StateIsSet, Error: sitesErr}
+	
+	r.DefaultLinkPermission = plugin.TValue[[]interface{}]{Data: report.DefaultLinkPermission, State: plugin.StateIsSet}
+
 	return nil
 }
 
@@ -204,5 +211,9 @@ func (r *mqlMs365Sharepointonline) spoTenantSyncClientRestriction() (interface{}
 }
 
 func (r *mqlMs365Sharepointonline) spoSites() ([]interface{}, error) {
+	return nil, r.getSharepointOnlineReport()
+}
+
+func (r *mqlMs365Sharepointonline) defaultLinkPermission() ([]interface{}, error) {
 	return nil, r.getSharepointOnlineReport()
 }

--- a/providers/ms365/resources/ms365_sharepoint.go
+++ b/providers/ms365/resources/ms365_sharepoint.go
@@ -30,7 +30,7 @@ Import-Module PnP.PowerShell
 Connect-PnPOnline -AccessToken $token -Url $url
 
 $SPOTenant = (Get-PnPTenant)
-$DefaultLinkPermission = (Get-PnPTenant | Select-Object DefaultLinkPermission)
+$DefaultLinkPermission = (Get-PnPTenant | Select-Object -ExpandProperty DefaultLinkPermission)
 $SPOTenantSyncClientRestriction = (Get-PnPTenantSyncClientRestriction)
 $SPOSite = (Get-PnPTenantSite)
 
@@ -38,7 +38,7 @@ $sharepoint = New-Object PSObject
 Add-Member -InputObject $sharepoint -MemberType NoteProperty -Name SPOTenant -Value $SPOTenant
 Add-Member -InputObject $sharepoint -MemberType NoteProperty -Name SPOTenantSyncClientRestriction -Value $SPOTenantSyncClientRestriction
 Add-Member -InputObject $sharepoint -MemberType NoteProperty -Name SPOSite -Value $SPOSite
-Add-Member -InputObject $sharepoint -MemberType NoteProperty -Name DefaultLinkPermission -Value $DefaultLinkPermissio
+Add-Member -InputObject $sharepoint -MemberType NoteProperty -Name DefaultLinkPermission -Value $DefaultLinkPermission
 
 Disconnect-PnPOnline
 
@@ -46,10 +46,10 @@ ConvertTo-Json -Depth 4 $sharepoint -EnumsAsStrings
 `
 
 type SharepointOnlineReport struct {
-	SpoTenant                      interface{}   `json:"SPOTenant"`
-	SpoTenantSyncClientRestriction interface{}   `json:"SPOTenantSyncClientRestriction"`
-	SpoSite                        []*SpoSite    `json:"SPOSite"`
-	DefaultLinkPermission          []interface{} `json:"DefaultLinkPermission"`
+	SpoTenant                      interface{} `json:"SPOTenant"`
+	SpoTenantSyncClientRestriction interface{} `json:"SPOTenantSyncClientRestriction"`
+	SpoSite                        []*SpoSite  `json:"SPOSite"`
+	DefaultLinkPermission          string      `json:"DefaultLinkPermission"`
 }
 
 type SpoSite struct {
@@ -197,7 +197,8 @@ func (r *mqlMs365Sharepointonline) getSharepointOnlineReport() error {
 	}
 	r.SpoSites = plugin.TValue[[]interface{}]{Data: sites, State: plugin.StateIsSet, Error: sitesErr}
 	
-	r.DefaultLinkPermission = plugin.TValue[[]interface{}]{Data: report.DefaultLinkPermission, State: plugin.StateIsSet}
+	defaultLinkPermissionSlice := []interface{}{report.DefaultLinkPermission}
+	r.DefaultLinkPermission = plugin.TValue[[]interface{}]{Data: defaultLinkPermissionSlice, State: plugin.StateIsSet}
 
 	return nil
 }

--- a/providers/ms365/resources/ms365_sharepoint.go
+++ b/providers/ms365/resources/ms365_sharepoint.go
@@ -30,7 +30,7 @@ Import-Module PnP.PowerShell
 Connect-PnPOnline -AccessToken $token -Url $url
 
 $SPOTenant = (Get-PnPTenant)
-$DefaultLinkPermission = (Get-PnPTenant -DefaultLinkPermission)
+$DefaultLinkPermission = (Get-PnPTenant | Select-Object DefaultLinkPermission)
 $SPOTenantSyncClientRestriction = (Get-PnPTenantSyncClientRestriction)
 $SPOSite = (Get-PnPTenantSite)
 

--- a/providers/ms365/resources/ms365_sharepoint.go
+++ b/providers/ms365/resources/ms365_sharepoint.go
@@ -65,7 +65,7 @@ type mqlMs365SharepointonlineInternal struct {
 	sharepointLock        sync.Mutex
 	fetched               bool
 	fetchErr              error
-	DefaultLinkPermission plugin.TValue[[]interface{}]
+	DefaultLinkPermission plugin.TValue[string]
 }
 
 func (r *mqlMs365Sharepointonline) getTenant() (string, error) {
@@ -196,9 +196,8 @@ func (r *mqlMs365Sharepointonline) getSharepointOnlineReport() error {
 		sites = append(sites, mqlSpoSite)
 	}
 	r.SpoSites = plugin.TValue[[]interface{}]{Data: sites, State: plugin.StateIsSet, Error: sitesErr}
-	
-	defaultLinkPermissionSlice := []interface{}{report.DefaultLinkPermission}
-	r.DefaultLinkPermission = plugin.TValue[[]interface{}]{Data: defaultLinkPermissionSlice, State: plugin.StateIsSet}
+
+	r.DefaultLinkPermission = plugin.TValue[string]{Data: report.DefaultLinkPermission, State: plugin.StateIsSet}
 
 	return nil
 }
@@ -215,6 +214,6 @@ func (r *mqlMs365Sharepointonline) spoSites() ([]interface{}, error) {
 	return nil, r.getSharepointOnlineReport()
 }
 
-func (r *mqlMs365Sharepointonline) defaultLinkPermission() ([]interface{}, error) {
-	return nil, r.getSharepointOnlineReport()
+func (r *mqlMs365Sharepointonline) defaultLinkPermission() (string, error) {
+	return "", r.getSharepointOnlineReport()
 }


### PR DESCRIPTION
Extended `ms365.sharepointonline` with `DefaultLinkPermission`

```graphQL
cnquery> ms365.sharepointonline { defaultLinkPermission }
ms365.sharepointonline: {
  defaultLinkPermission: "Edit"
}
```

resolve #5616