### PR TITLE
🐛 fix long-standing print issues in assertions

### DIFF
--- a/cli/printer/mql.go
+++ b/cli/printer/mql.go
@@ -280,15 +280,12 @@ func (print *Printer) array(typ types.Type, data []interface{}, checksum string,
 			}
 		}
 	} else {
-		inlinePrint := *cache
-		inlinePrint.isInline = true
-
 		for i := range data {
 			res.WriteString(fmt.Sprintf(
 				indent+"  %d: %s%s\n",
 				i,
 				listType,
-				print.data(typ.Child(), data[i], checksum, indent+"  ", &inlinePrint),
+				print.data(typ.Child(), data[i], checksum, indent+"  ", cache),
 			))
 		}
 	}
@@ -388,6 +385,8 @@ func (print *Printer) refMap(data map[string]any, checksum string, indent string
 		}
 	}
 
+	inlineCache := *cache
+	inlineCache.isInline = true
 	for _, k := range labeledKeys {
 		if k == "_" {
 			continue
@@ -412,7 +411,7 @@ func (print *Printer) refMap(data map[string]any, checksum string, indent string
 			continue
 		}
 
-		data := print.data(val.Type, val.Value, k, "", cache)
+		data := print.data(val.Type, val.Value, k, "", &inlineCache)
 		res.WriteString(label + data + " ")
 	}
 

--- a/cli/printer/mql.go
+++ b/cli/printer/mql.go
@@ -551,20 +551,6 @@ func (print *Printer) intMap(typ types.Type, data map[int]interface{}, indent st
 	return res.String()
 }
 
-var codeBlockIds = map[string]struct{}{
-	"{}": {},
-	"if": {},
-}
-
-func isCodeBlock(checksum string, bundle *llx.CodeBundle) bool {
-	if bundle == nil {
-		return false
-	}
-
-	_, ok := bundle.Labels.Labels[checksum]
-	return ok
-}
-
 func (print *Printer) resourceContext(data any, checksum string, indent string, cache *printCache) (string, bool) {
 	m, ok := data.(map[string]any)
 	if !ok {


### PR DESCRIPTION
This is a start to tackle some long-standing printing issues we have experienced with results.

Take the following example:

```sh
> cnquery run -c "terraform.blocks.none(arguments.source == /google/)" terraform tf
```

The current output will look like this:

```coffee
[failed] [].none()
  actual:   [
    0: terraform.block type="module" labels=[
  0: terraform.block "project-factory"
] {
      arguments: {
        source: "terraform-google-modules/project-factory/google"
        version: "14.4.0"
      }
      arguments.source: "terraform-google-modules/project-factory/google"
    }
  ]
```

As you can see, the printing of the `actual` value is really broken. If we focus on the problem, we see it's related to how the labels are printed.

Here is the fixed version:

```coffee
[failed] [].none()
  actual:   [
    0: terraform.block type="module" labels=["project-factory"] {
      arguments: {
        source: "terraform-google-modules/project-factory/google"
        version: "14.4.0"
      }
      arguments.source: "terraform-google-modules/project-factory/google"
    }
  ]
```

In the fix I realized that both the array-printer as well as ref-printer are both broken. They were both referencing the first entrypoint of the first block of code in every code bundle. Of course the printer is cycling through all data and thus this is incorrect as soon as we start to print anything but the first entrypoint.

The other issue was that codeIDs (in actuality checksums) were incorrectly propagated. The code bundle indeed contains a codeID, but we can't use them, because auto-expansion uses checksums. The new code for expanding list assertions also uses checksums now, so both are aligned.

This isn't the end of the issue, it's just the beginning. The immediate follow-up will address the unnecessary resolution of the comparable, as seen in the example posted above (printing of `arguments`). This gets pretty bad with terraform particulary.