### PR TITLE
🐛 armresources has not returned properties for cosmo pg service

### DIFF
--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/99designs/keyring v1.2.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmosforpostgresql/armcosmosforpostgresql v1.1.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 // indirect

--- a/providers/azure/go.sum
+++ b/providers/azure/go.sum
@@ -102,6 +102,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontai
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.4.0/go.mod h1:U5gpsREQZE6SLk1t/cFfc1eMhYAlYpEzvaYXuDfefy8=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos v1.0.0 h1:Fv8iibGn1eSw0lt2V3cTsuokBEnOP+M//n8OiMcCgTM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos v1.0.0/go.mod h1:Qpe/qN9d5IQ7WPtTXMRCd6+BWTnhi3sxXVys6oJ5Vho=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmosforpostgresql/armcosmosforpostgresql v1.1.0 h1:TyXI0pf9V67/vn7Vo2BebOz4B/fLj9Kt3UcrQBXMrvE=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmosforpostgresql/armcosmosforpostgresql v1.1.0/go.mod h1:s//ycXE53yRslaDdkNrCEANgvrdSOaUuqcBCJg5VEX0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2 h1:mLY+pNLjCUeKhgnAJWAKhEUQM+RJQo2H1fuGSw1Ky1E=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2/go.mod h1:FbdwsQ2EzwvXxOPcMFYO8ogEc9uMMIj3YkmCdXdAFmk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -14446,12 +14446,7 @@ func createAzureSubscriptionCosmosDbServiceAccount(runtime *plugin.Runtime, args
 		return res, err
 	}
 
-	if res.__id == "" {
-	res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("azure.subscription.cosmosDbService.account", res.__id)


### PR DESCRIPTION
The azure resource API has not returned the properties, therefore we using the specific api to get it:

```
cnquery> azure.subscription.cosmosDb.accounts[3] { * }
azure.subscription.cosmosDb.accounts[3]: {
  kind: null
  type: "Microsoft.DBforPostgreSQL/serverGroupsv2"
  properties: {
    administratorLogin: "citus"
    citusVersion: "12.1"
    coordinatorEnablePublicIpAccess: true
    coordinatorServerEdition: "GeneralPurpose"
    coordinatorStorageQuotaInMb: 131072.000000
    coordinatorVCores: 2.000000
    earliestRestoreTime: "2025-06-20T08:11:05Z"
    enableHa: false
    enableShardsOnCoordinator: true
    maintenanceWindow: {
      customWindow: "Disabled"
      dayOfWeek: 0.000000
      startHour: 0.000000
      startMinute: 0.000000
    }
    nodeCount: 0.000000
    nodeEnablePublicIpAccess: false
    nodeServerEdition: "MemoryOptimized"
    nodeStorageQuotaInMb: 524288.000000
    nodeVCores: 4.000000
    postgresqlVersion: "16"
    privateEndpointConnections: []
    provisioningState: "Succeeded"
    readReplicas: []
    serverNames: [
      0: {
        fullyQualifiedDomainName: "c-pg13212312.slcpwnta2xkzyh.postgres.cosmos.azure.com"
        name: "pg13212312-c"
      }
    ]
    state: "Ready"
  }
  location: "eastus"
  id: "/subscriptions/e9ee8090-9784-42d6-9534-bc1d881eeff6/resourceGroups/DefaultResourceGroup-CUS/providers/Microsoft.DBforPostgreSQL/serverGroupsv2/pg13212312"
  name: "pg13212312"
  tags: {}
}
```