### PR TITLE
🔨 print datapoints as well as entrypoints in ast view

### DIFF
--- a/cli/printer/mql.go
+++ b/cli/printer/mql.go
@@ -953,6 +953,15 @@ func (print *Printer) CodeV2(code *llx.CodeV2, bundle *llx.CodeBundle, indent st
 				res.WriteString(" ")
 			}
 		}
+		if len(block.Datapoints) != 0 {
+			res.WriteString("] datapoints: [")
+			for idx, ep := range block.Datapoints {
+				res.WriteString(fmt.Sprintf("<%d,%d>", ep>>32, ep&0xFFFFFFFF))
+				if idx != len(block.Datapoints)-1 {
+					res.WriteString(" ")
+				}
+			}
+		}
 		res.WriteString("]\n")
 
 		for j := range block.Chunks {

--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -2014,10 +2014,8 @@ func (c *compiler) updateEntrypoints(collectRefDatapoints bool) {
 	// 3. resolve operators
 	for ref := range entrypoints {
 		dps := code.RefDatapoints(ref)
-		if dps != nil {
-			for i := range dps {
-				datapoints[dps[i]] = struct{}{}
-			}
+		for i := range dps {
+			datapoints[dps[i]] = struct{}{}
 		}
 	}
 


### PR DESCRIPTION
This won't affect any end-users, but it's very helpful for debugging purposes.