### PR TITLE
⭐️ MS365: Extend microsoft.conditionalAccess with authenticationMethodsPolicy

### DIFF
--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -162,6 +162,32 @@ microsoft.conditionalAccess {
   namedLocations microsoft.conditionalAccess.namedLocations
   // Policies collection
   policies() []microsoft.conditionalAccess.policy
+  // Tenant-wide authentication methods policy
+  authenticationMethodsPolicy() microsoft.conditionalAccess.authenticationMethodsPolicy
+}
+
+// The tenant-wide policy that controls which authentication methods are allowed
+private microsoft.conditionalAccess.authenticationMethodsPolicy @defaults("id displayName") {
+  // The identifier of the policy
+  id string
+  // The name of the policy
+  displayName string
+  // A description of the policy
+  description string
+  // The date and time of the last update to the policy
+  lastModifiedDateTime time
+  // The version of the policy in use
+  policyVersion string
+  // Represents the settings for each authentication method
+  authenticationMethodConfigurations []microsoft.conditionalAccess.authenticationMethodConfiguration
+}
+
+// Configuration for a specific authentication method.
+private microsoft.conditionalAccess.authenticationMethodConfiguration @defaults("id state") {
+  // The policy name
+  id string
+  // The policy name
+  state string
 }
 
 // Container for Microsoft Conditional Access Named Locations
@@ -964,7 +990,7 @@ microsoft.policies {
   authenticationMethodsPolicy() microsoft.policies.authenticationMethodsPolicy
 }
 
-// The tenant-wide policy that controls which authentication methods are allowed.
+// The tenant-wide policy that controls which authentication methods are allowed
 private microsoft.policies.authenticationMethodsPolicy @defaults("displayName") {
   // Policy ID
   id string
@@ -980,9 +1006,9 @@ private microsoft.policies.authenticationMethodsPolicy @defaults("displayName") 
   authenticationMethodConfigurations []microsoft.policies.authenticationMethodConfiguration
 }
 
-// Configuration for a specific authentication method.
+// Configuration for a specific authentication method
 private microsoft.policies.authenticationMethodConfiguration @defaults("state") {
-  // The policy name.
+  // The policy name
   id string
   // The state of the policy. Possible values are: enabled, disabled.
   state string

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -66,6 +66,14 @@ func init() {
 			// to override args, implement: initMicrosoftConditionalAccess(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMicrosoftConditionalAccess,
 		},
+		"microsoft.conditionalAccess.authenticationMethodsPolicy": {
+			// to override args, implement: initMicrosoftConditionalAccessAuthenticationMethodsPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createMicrosoftConditionalAccessAuthenticationMethodsPolicy,
+		},
+		"microsoft.conditionalAccess.authenticationMethodConfiguration": {
+			// to override args, implement: initMicrosoftConditionalAccessAuthenticationMethodConfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createMicrosoftConditionalAccessAuthenticationMethodConfiguration,
+		},
 		"microsoft.conditionalAccess.namedLocations": {
 			// to override args, implement: initMicrosoftConditionalAccessNamedLocations(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMicrosoftConditionalAccessNamedLocations,
@@ -550,6 +558,33 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"microsoft.conditionalAccess.policies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftConditionalAccess).GetPolicies()).ToDataRes(types.Array(types.Resource("microsoft.conditionalAccess.policy")))
+	},
+	"microsoft.conditionalAccess.authenticationMethodsPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftConditionalAccess).GetAuthenticationMethodsPolicy()).ToDataRes(types.Resource("microsoft.conditionalAccess.authenticationMethodsPolicy"))
+	},
+	"microsoft.conditionalAccess.authenticationMethodsPolicy.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy).GetId()).ToDataRes(types.String)
+	},
+	"microsoft.conditionalAccess.authenticationMethodsPolicy.displayName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy).GetDisplayName()).ToDataRes(types.String)
+	},
+	"microsoft.conditionalAccess.authenticationMethodsPolicy.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy).GetDescription()).ToDataRes(types.String)
+	},
+	"microsoft.conditionalAccess.authenticationMethodsPolicy.lastModifiedDateTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy).GetLastModifiedDateTime()).ToDataRes(types.Time)
+	},
+	"microsoft.conditionalAccess.authenticationMethodsPolicy.policyVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy).GetPolicyVersion()).ToDataRes(types.String)
+	},
+	"microsoft.conditionalAccess.authenticationMethodsPolicy.authenticationMethodConfigurations": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy).GetAuthenticationMethodConfigurations()).ToDataRes(types.Array(types.Resource("microsoft.conditionalAccess.authenticationMethodConfiguration")))
+	},
+	"microsoft.conditionalAccess.authenticationMethodConfiguration.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftConditionalAccessAuthenticationMethodConfiguration).GetId()).ToDataRes(types.String)
+	},
+	"microsoft.conditionalAccess.authenticationMethodConfiguration.state": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftConditionalAccessAuthenticationMethodConfiguration).GetState()).ToDataRes(types.String)
 	},
 	"microsoft.conditionalAccess.namedLocations.ipLocations": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftConditionalAccessNamedLocations).GetIpLocations()).ToDataRes(types.Array(types.Resource("microsoft.conditionalAccess.ipNamedLocation")))
@@ -2218,6 +2253,50 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"microsoft.conditionalAccess.policies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftConditionalAccess).Policies, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"microsoft.conditionalAccess.authenticationMethodsPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftConditionalAccess).AuthenticationMethodsPolicy, ok = plugin.RawToTValue[*mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy](v.Value, v.Error)
+		return
+	},
+	"microsoft.conditionalAccess.authenticationMethodsPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy).__id, ok = v.Value.(string)
+			return
+		},
+	"microsoft.conditionalAccess.authenticationMethodsPolicy.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.conditionalAccess.authenticationMethodsPolicy.displayName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy).DisplayName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.conditionalAccess.authenticationMethodsPolicy.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.conditionalAccess.authenticationMethodsPolicy.lastModifiedDateTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy).LastModifiedDateTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"microsoft.conditionalAccess.authenticationMethodsPolicy.policyVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy).PolicyVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.conditionalAccess.authenticationMethodsPolicy.authenticationMethodConfigurations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy).AuthenticationMethodConfigurations, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"microsoft.conditionalAccess.authenticationMethodConfiguration.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlMicrosoftConditionalAccessAuthenticationMethodConfiguration).__id, ok = v.Value.(string)
+			return
+		},
+	"microsoft.conditionalAccess.authenticationMethodConfiguration.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftConditionalAccessAuthenticationMethodConfiguration).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.conditionalAccess.authenticationMethodConfiguration.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftConditionalAccessAuthenticationMethodConfiguration).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"microsoft.conditionalAccess.namedLocations.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5249,6 +5328,7 @@ type mqlMicrosoftConditionalAccess struct {
 	// optional: if you define mqlMicrosoftConditionalAccessInternal it will be used here
 	NamedLocations plugin.TValue[*mqlMicrosoftConditionalAccessNamedLocations]
 	Policies plugin.TValue[[]interface{}]
+	AuthenticationMethodsPolicy plugin.TValue[*mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy]
 }
 
 // createMicrosoftConditionalAccess creates a new instance of this resource
@@ -5301,6 +5381,140 @@ func (c *mqlMicrosoftConditionalAccess) GetPolicies() *plugin.TValue[[]interface
 
 		return c.policies()
 	})
+}
+
+func (c *mqlMicrosoftConditionalAccess) GetAuthenticationMethodsPolicy() *plugin.TValue[*mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy] {
+	return plugin.GetOrCompute[*mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy](&c.AuthenticationMethodsPolicy, func() (*mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft.conditionalAccess", c.__id, "authenticationMethodsPolicy")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy), nil
+			}
+		}
+
+		return c.authenticationMethodsPolicy()
+	})
+}
+
+// mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy for the microsoft.conditionalAccess.authenticationMethodsPolicy resource
+type mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlMicrosoftConditionalAccessAuthenticationMethodsPolicyInternal it will be used here
+	Id plugin.TValue[string]
+	DisplayName plugin.TValue[string]
+	Description plugin.TValue[string]
+	LastModifiedDateTime plugin.TValue[*time.Time]
+	PolicyVersion plugin.TValue[string]
+	AuthenticationMethodConfigurations plugin.TValue[[]interface{}]
+}
+
+// createMicrosoftConditionalAccessAuthenticationMethodsPolicy creates a new instance of this resource
+func createMicrosoftConditionalAccessAuthenticationMethodsPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("microsoft.conditionalAccess.authenticationMethodsPolicy", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy) MqlName() string {
+	return "microsoft.conditionalAccess.authenticationMethodsPolicy"
+}
+
+func (c *mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy) GetDisplayName() *plugin.TValue[string] {
+	return &c.DisplayName
+}
+
+func (c *mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy) GetLastModifiedDateTime() *plugin.TValue[*time.Time] {
+	return &c.LastModifiedDateTime
+}
+
+func (c *mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy) GetPolicyVersion() *plugin.TValue[string] {
+	return &c.PolicyVersion
+}
+
+func (c *mqlMicrosoftConditionalAccessAuthenticationMethodsPolicy) GetAuthenticationMethodConfigurations() *plugin.TValue[[]interface{}] {
+	return &c.AuthenticationMethodConfigurations
+}
+
+// mqlMicrosoftConditionalAccessAuthenticationMethodConfiguration for the microsoft.conditionalAccess.authenticationMethodConfiguration resource
+type mqlMicrosoftConditionalAccessAuthenticationMethodConfiguration struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlMicrosoftConditionalAccessAuthenticationMethodConfigurationInternal it will be used here
+	Id plugin.TValue[string]
+	State plugin.TValue[string]
+}
+
+// createMicrosoftConditionalAccessAuthenticationMethodConfiguration creates a new instance of this resource
+func createMicrosoftConditionalAccessAuthenticationMethodConfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMicrosoftConditionalAccessAuthenticationMethodConfiguration{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("microsoft.conditionalAccess.authenticationMethodConfiguration", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMicrosoftConditionalAccessAuthenticationMethodConfiguration) MqlName() string {
+	return "microsoft.conditionalAccess.authenticationMethodConfiguration"
+}
+
+func (c *mqlMicrosoftConditionalAccessAuthenticationMethodConfiguration) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMicrosoftConditionalAccessAuthenticationMethodConfiguration) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlMicrosoftConditionalAccessAuthenticationMethodConfiguration) GetState() *plugin.TValue[string] {
+	return &c.State
 }
 
 // mqlMicrosoftConditionalAccessNamedLocations for the microsoft.conditionalAccess.namedLocations resource

--- a/providers/ms365/resources/ms365.lr.manifest.yaml
+++ b/providers/ms365/resources/ms365.lr.manifest.yaml
@@ -85,8 +85,25 @@ resources:
     min_mondoo_version: 9.0.0
   microsoft.conditionalAccess:
     fields:
+      authenticationMethodsPolicy: {}
       namedLocations: {}
       policies: {}
+    min_mondoo_version: 9.0.0
+  microsoft.conditionalAccess.authenticationMethodConfiguration:
+    fields:
+      id: {}
+      state: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
+  microsoft.conditionalAccess.authenticationMethodsPolicy:
+    fields:
+      authenticationMethodConfigurations: {}
+      description: {}
+      displayName: {}
+      id: {}
+      lastModifiedDateTime: {}
+      policyVersion: {}
+    is_private: true
     min_mondoo_version: 9.0.0
   microsoft.conditionalAccess.countryNamedLocation:
     fields:


### PR DESCRIPTION
```graphQL
cnquery> microsoft.conditionalAccess {authenticationMethodsPolicy{ id displayName description policyVersion lastModifiedDateTime policyVersion authenticationMethodConfigurations {id state} } }
microsoft.conditionalAccess: {
  authenticationMethodsPolicy: {
    policyVersion: "1.5"
    id: "authenticationMethodsPolicy"
    description: "The tenant-wide policy that controls which authentication methods are allowed in the tenant, authentication method registration requirements, and self-service password reset settings"
    displayName: "Authentication Methods Policy"
    authenticationMethodConfigurations: [
      0: {
        id: "Fido2"
        state: "disabled"
      }
      1: {
        id: "MicrosoftAuthenticator"
        state: "disabled"
      }
      2: {
        id: "Sms"
        state: "disabled"
      }
      3: {
        id: "TemporaryAccessPass"
        state: "disabled"
      }
      4: {
        id: "SoftwareOath"
        state: "disabled"
      }
      5: {
        id: "Voice"
        state: "disabled"
      }
      6: {
        id: "Email"
        state: "enabled"
      }
      7: {
        id: "X509Certificate"
        state: "disabled"
      }
    ]
    lastModifiedDateTime: 366 days
  }
}
```

resolve #5612