### PR TITLE
fixed lastModifiedBy value

### DIFF
--- a/providers/ms365/resources/identity_and_access.go
+++ b/providers/ms365/resources/identity_and_access.go
@@ -98,10 +98,13 @@ func (a *mqlMicrosoftIdentityAndAccess) list() ([]interface{}, error) {
 
 func newMqlRoleManagementPolicy(runtime *plugin.Runtime, u models.UnifiedRoleManagementPolicyable) (*mqlMicrosoftIdentityAndAccessPolicy, error) {
 	lastModifiedByDict := map[string]interface{}{}
+	var err error
 
 	if u.GetLastModifiedBy() != nil {
-		lastModifiedByDict["id"] = llx.StringDataPtr(u.GetLastModifiedBy().GetId())
-		lastModifiedByDict["displayName"] = llx.StringDataPtr(u.GetLastModifiedBy().GetDisplayName())
+		lastModifiedByDict, err = convert.JsonToDict(newLastModifiedBy(u.GetLastModifiedBy()))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	resource, err := CreateResource(runtime, "microsoft.identityAndAccess.policy",

--- a/providers/ms365/resources/structs.go
+++ b/providers/ms365/resources/structs.go
@@ -92,6 +92,11 @@ type VerifiedDomain struct {
 	Type         string `json:"type"`
 }
 
+type LastModifiedBy struct {
+	Id          string `json:"id"`
+	DisplayName string `json:"displayName"`
+}
+
 func newVerifiedDomains(p []models.VerifiedDomainable) []VerifiedDomain {
 	res := []VerifiedDomain{}
 	for i := range p {
@@ -107,6 +112,13 @@ func newVerifiedDomain(p models.VerifiedDomainable) VerifiedDomain {
 		IsInitial:    convert.ToValue(p.GetIsInitial()),
 		Name:         convert.ToValue(p.GetName()),
 		Type:         convert.ToValue(p.GetTypeEscaped()),
+	}
+}
+
+func newLastModifiedBy(p models.Identityable) LastModifiedBy {
+	return LastModifiedBy{
+		Id:          convert.ToValue(p.GetId()),
+		DisplayName: convert.ToValue(p.GetDisplayName()),
 	}
 }
 


### PR DESCRIPTION
fixing `lastModifiedBy: failed to convert dict to primitive, unsupported child type: *llx.RawData` error message

resolve #5704

```graphQL
cnquery> microsoft.identityAndAccess(filter: "scopeId eq '/' and scopeType eq 'Directory'")[0] { * }
microsoft.identityAndAccess.list[0]: {
  rules: [
    0: microsoft.identityAndAccess.policy.rule id="Expiration_Admin_Eligibility"
    1: microsoft.identityAndAccess.policy.rule id="Enablement_Admin_Eligibility"
    2: microsoft.identityAndAccess.policy.rule id="Notification_Admin_Admin_Eligibility"
    3: microsoft.identityAndAccess.policy.rule id="Notification_Requestor_Admin_Eligibility"
    4: microsoft.identityAndAccess.policy.rule id="Notification_Approver_Admin_Eligibility"
    5: microsoft.identityAndAccess.policy.rule id="Expiration_Admin_Assignment"
    6: microsoft.identityAndAccess.policy.rule id="Enablement_Admin_Assignment"
    7: microsoft.identityAndAccess.policy.rule id="Notification_Admin_Admin_Assignment"
    8: microsoft.identityAndAccess.policy.rule id="Notification_Requestor_Admin_Assignment"
    9: microsoft.identityAndAccess.policy.rule id="Notification_Approver_Admin_Assignment"
    10: microsoft.identityAndAccess.policy.rule id="Expiration_EndUser_Assignment"
    11: microsoft.identityAndAccess.policy.rule id="Enablement_EndUser_Assignment"
    12: microsoft.identityAndAccess.policy.rule id="Approval_EndUser_Assignment"
    13: microsoft.identityAndAccess.policy.rule id="AuthenticationContext_EndUser_Assignment"
    14: microsoft.identityAndAccess.policy.rule id="Notification_Admin_EndUser_Assignment"
    15: microsoft.identityAndAccess.policy.rule id="Notification_Requestor_EndUser_Assignment"
    16: microsoft.identityAndAccess.policy.rule id="Notification_Approver_EndUser_Assignment"
  ]
  lastModifiedBy: {
    displayName: ""
    id: ""
  }
  description: "Directory"
  displayName: "Directory"
  scopeType: "Directory"
  scopeId: "/"
  lastModifiedDateTime: null
  id: "Directory_d9abc6fc-fd88-4480-a931-2f7939adbac2_dfa825e1-e256-4d03-b2ea-4075472f4aff"
  isOrganizationDefault: false
}
```