### PR TITLE
ms365: teams meeting policy config allow cloud recording

### DIFF
--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -1336,6 +1336,8 @@ private ms365.teams.teamsMeetingPolicyConfig {
   allowExternalParticipantGiveRequestControl bool
   // Whether users can report security concerns
   allowSecurityEndUserReporting bool
+  // Whether cloud recording is allowed
+  allowCloudRecordingForCalls bool
 }
 
 // Teams meeting policy configuration

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -1937,6 +1937,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"ms365.teams.teamsMeetingPolicyConfig.allowSecurityEndUserReporting": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMs365TeamsTeamsMeetingPolicyConfig).GetAllowSecurityEndUserReporting()).ToDataRes(types.Bool)
 	},
+	"ms365.teams.teamsMeetingPolicyConfig.allowCloudRecordingForCalls": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365TeamsTeamsMeetingPolicyConfig).GetAllowCloudRecordingForCalls()).ToDataRes(types.Bool)
+	},
 	"ms365.teams.teamsMessagingPolicyConfig.allowSecurityEndUserReporting": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMs365TeamsTeamsMessagingPolicyConfig).GetAllowSecurityEndUserReporting()).ToDataRes(types.Bool)
 	},
@@ -4314,6 +4317,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"ms365.teams.teamsMeetingPolicyConfig.allowSecurityEndUserReporting": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMs365TeamsTeamsMeetingPolicyConfig).AllowSecurityEndUserReporting, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"ms365.teams.teamsMeetingPolicyConfig.allowCloudRecordingForCalls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365TeamsTeamsMeetingPolicyConfig).AllowCloudRecordingForCalls, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"ms365.teams.teamsMessagingPolicyConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10550,6 +10557,7 @@ type mqlMs365TeamsTeamsMeetingPolicyConfig struct {
 	DesignatedPresenterRoleMode plugin.TValue[string]
 	AllowExternalParticipantGiveRequestControl plugin.TValue[bool]
 	AllowSecurityEndUserReporting plugin.TValue[bool]
+	AllowCloudRecordingForCalls plugin.TValue[bool]
 }
 
 // createMs365TeamsTeamsMeetingPolicyConfig creates a new instance of this resource
@@ -10618,6 +10626,10 @@ func (c *mqlMs365TeamsTeamsMeetingPolicyConfig) GetAllowExternalParticipantGiveR
 
 func (c *mqlMs365TeamsTeamsMeetingPolicyConfig) GetAllowSecurityEndUserReporting() *plugin.TValue[bool] {
 	return &c.AllowSecurityEndUserReporting
+}
+
+func (c *mqlMs365TeamsTeamsMeetingPolicyConfig) GetAllowCloudRecordingForCalls() *plugin.TValue[bool] {
+	return &c.AllowCloudRecordingForCalls
 }
 
 // mqlMs365TeamsTeamsMessagingPolicyConfig for the ms365.teams.teamsMessagingPolicyConfig resource

--- a/providers/ms365/resources/ms365.lr.manifest.yaml
+++ b/providers/ms365/resources/ms365.lr.manifest.yaml
@@ -794,6 +794,7 @@ resources:
     fields:
       allowAnonymousUsersToJoinMeeting: {}
       allowAnonymousUsersToStartMeeting: {}
+      allowCloudRecordingForCalls: {}
       allowExternalNonTrustedMeetingChat: {}
       allowExternalParticipantGiveRequestControl: {}
       allowPSTNUsersToBypassLobby: {}

--- a/providers/ms365/resources/ms365_teams.go
+++ b/providers/ms365/resources/ms365_teams.go
@@ -80,6 +80,7 @@ type CsTeamsMeetingPolicy struct {
 	DesignatedPresenterRoleMode                string `json:"DesignatedPresenterRoleMode"`
 	AllowExternalParticipantGiveRequestControl bool   `json:"AllowExternalParticipantGiveRequestControl"`
 	AllowSecurityEndUserReporting              bool   `json:"AllowSecurityEndUserReporting"`
+	AllowCloudRecording                        bool   `json:"AllowCloudRecording"`
 }
 
 type CsTeamsMessagingPolicy struct {
@@ -204,6 +205,7 @@ func (r *mqlMs365Teams) gatherTeamsReport() error {
 				"designatedPresenterRoleMode":                llx.StringData(teamsPolicy.DesignatedPresenterRoleMode),
 				"allowExternalParticipantGiveRequestControl": llx.BoolData(teamsPolicy.AllowExternalParticipantGiveRequestControl),
 				"allowSecurityEndUserReporting":              llx.BoolData(teamsPolicy.AllowSecurityEndUserReporting),
+				"allowCloudRecording":                        llx.BoolData(teamsPolicy.AllowCloudRecording),
 			})
 		if mqlTeamsPolicyErr != nil {
 			r.CsTeamsMeetingPolicy = plugin.TValue[*mqlMs365TeamsTeamsMeetingPolicyConfig]{State: plugin.StateIsSet, Error: mqlTeamsPolicyErr}

--- a/providers/ms365/resources/ms365_teams.go
+++ b/providers/ms365/resources/ms365_teams.go
@@ -33,10 +33,14 @@ Install-Module -Name MicrosoftTeams -Scope CurrentUser -Force
 Import-Module MicrosoftTeams
 Connect-MicrosoftTeams -AccessTokens @("$graphToken", "$teamsToken")
 
+# Fetch all the necessary policies
 $CsTeamsClientConfiguration = (Get-CsTeamsClientConfiguration)
 $CsTenantFederationConfiguration = (Get-CsTenantFederationConfiguration)
 $CsTeamsMeetingPolicy = (Get-CsTeamsMeetingPolicy -Identity Global)
 $CsTeamsMessagingPolicy = (Get-CsTeamsMessagingPolicy -Identity Global)
+# Fetch the calling policy to get the cloud recording setting
+$callingPolicy = (Get-CsTeamsCallingPolicy -Identity Global)
+$CsTeamsMeetingPolicy | Add-Member -NotePropertyName "AllowCloudRecordingForCalls" -NotePropertyValue $callingPolicy.AllowCloudRecordingForCalls
 
 $msteams = New-Object PSObject
 Add-Member -InputObject $msteams -MemberType NoteProperty -Name CsTeamsClientConfiguration -Value $CsTeamsClientConfiguration
@@ -80,7 +84,7 @@ type CsTeamsMeetingPolicy struct {
 	DesignatedPresenterRoleMode                string `json:"DesignatedPresenterRoleMode"`
 	AllowExternalParticipantGiveRequestControl bool   `json:"AllowExternalParticipantGiveRequestControl"`
 	AllowSecurityEndUserReporting              bool   `json:"AllowSecurityEndUserReporting"`
-	AllowCloudRecording                        bool   `json:"AllowCloudRecording"`
+	AllowCloudRecordingForCalls                bool   `json:"AllowCloudRecordingForCalls"`
 }
 
 type CsTeamsMessagingPolicy struct {
@@ -205,7 +209,7 @@ func (r *mqlMs365Teams) gatherTeamsReport() error {
 				"designatedPresenterRoleMode":                llx.StringData(teamsPolicy.DesignatedPresenterRoleMode),
 				"allowExternalParticipantGiveRequestControl": llx.BoolData(teamsPolicy.AllowExternalParticipantGiveRequestControl),
 				"allowSecurityEndUserReporting":              llx.BoolData(teamsPolicy.AllowSecurityEndUserReporting),
-				"allowCloudRecording":                        llx.BoolData(teamsPolicy.AllowCloudRecording),
+				"allowCloudRecordingForCalls":                llx.BoolData(teamsPolicy.AllowCloudRecordingForCalls),
 			})
 		if mqlTeamsPolicyErr != nil {
 			r.CsTeamsMeetingPolicy = plugin.TValue[*mqlMs365TeamsTeamsMeetingPolicyConfig]{State: plugin.StateIsSet, Error: mqlTeamsPolicyErr}


### PR DESCRIPTION
I don't think this was working correctly before, but now hopefully it does

```graphQL
cnquery> ms365.teams.csTeamsMeetingPolicy.allowAnonymousUsersToJoinMeeting
[ok] value: true

cnquery> ms365.teams.teamsMeetingPolicyConfig {allowAnonymousUsersToJoinMeeting}
ms365.teams.teamsMeetingPolicyConfig: {
  allowAnonymousUsersToJoinMeeting: true
}
cnquery> ms365.teams.teamsMeetingPolicyConfig {*}
ms365.teams.teamsMeetingPolicyConfig: {
  allowExternalNonTrustedMeetingChat: true
  allowAnonymousUsersToJoinMeeting: true
  allowAnonymousUsersToStartMeeting: true
  allowPSTNUsersToBypassLobby: true
  allowCloudRecordingForCalls: false
  allowExternalParticipantGiveRequestControl: true
  allowSecurityEndUserReporting: false
  meetingChatEnabledType: "Enabled"
  designatedPresenterRoleMode: "EveryoneInCompanyUserOverride"
  autoAdmittedUsers: "EveryoneInCompany"
}
cnquery> 
```
resolve #5620