### PR TITLE
🧹 network: update default dialer timeout to 2s

### DIFF
--- a/providers/network/resources/tls.go
+++ b/providers/network/resources/tls.go
@@ -28,7 +28,7 @@ var reTarget = regexp.MustCompile("([^/:]+?)(:\\d+)?$")
 
 var rexUrlDomain = regexp.MustCompile(regex.UrlDomain)
 
-var DefaultDialerTimeout = time.Minute * 1
+var DefaultDialerTimeout = tlsshake.DefaultTimeout
 
 // Returns the connection's port adjusted for TLS.
 // If no port is set, we estimate what it might be from the scheme.


### PR DESCRIPTION
We are seeing some slow queries that try to access `tls.params`, this is because we have
a timeout of 1m per TLS version, a total of 5 versions so this query could end up running
for 5 minutes.

Since the `tlsshake` package has already a 2s timeout, re-use it to avoid slow queries.