### PR TITLE
ms365: added  missing resource fields in microsoft.organization resource

### DIFF
--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -74,6 +74,12 @@ microsoft.tenant @defaults("name") {
   settings() microsoft.tenant.settings
   // Company-wide settings for Microsoft Forms
   formsSettings() microsoft.tenant.formsSettings
+  // Privacy profile data with contact email and statement URL
+  privacyProfile dict
+  // List of technical notification mails
+  technicalNotificationMails []string
+  // Preferred language
+  preferredLanguage string
 }
 
 // Company-wide configuration for apps and services.

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -490,6 +490,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.tenant.formsSettings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftTenant).GetFormsSettings()).ToDataRes(types.Resource("microsoft.tenant.formsSettings"))
 	},
+	"microsoft.tenant.privacyProfile": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftTenant).GetPrivacyProfile()).ToDataRes(types.Dict)
+	},
+	"microsoft.tenant.technicalNotificationMails": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftTenant).GetTechnicalNotificationMails()).ToDataRes(types.Array(types.String))
+	},
+	"microsoft.tenant.preferredLanguage": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftTenant).GetPreferredLanguage()).ToDataRes(types.String)
+	},
 	"microsoft.tenant.settings.isAppAndServicesTrialEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftTenantSettings).GetIsAppAndServicesTrialEnabled()).ToDataRes(types.Bool)
 	},
@@ -2212,6 +2221,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"microsoft.tenant.formsSettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftTenant).FormsSettings, ok = plugin.RawToTValue[*mqlMicrosoftTenantFormsSettings](v.Value, v.Error)
+		return
+	},
+	"microsoft.tenant.privacyProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftTenant).PrivacyProfile, ok = plugin.RawToTValue[interface{}](v.Value, v.Error)
+		return
+	},
+	"microsoft.tenant.technicalNotificationMails": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftTenant).TechnicalNotificationMails, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"microsoft.tenant.preferredLanguage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftTenant).PreferredLanguage, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"microsoft.tenant.settings.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5004,6 +5025,9 @@ type mqlMicrosoftTenant struct {
 	Subscriptions plugin.TValue[[]interface{}]
 	Settings plugin.TValue[*mqlMicrosoftTenantSettings]
 	FormsSettings plugin.TValue[*mqlMicrosoftTenantFormsSettings]
+	PrivacyProfile plugin.TValue[interface{}]
+	TechnicalNotificationMails plugin.TValue[[]interface{}]
+	PreferredLanguage plugin.TValue[string]
 }
 
 // createMicrosoftTenant creates a new instance of this resource
@@ -5119,6 +5143,18 @@ func (c *mqlMicrosoftTenant) GetFormsSettings() *plugin.TValue[*mqlMicrosoftTena
 
 		return c.formsSettings()
 	})
+}
+
+func (c *mqlMicrosoftTenant) GetPrivacyProfile() *plugin.TValue[interface{}] {
+	return &c.PrivacyProfile
+}
+
+func (c *mqlMicrosoftTenant) GetTechnicalNotificationMails() *plugin.TValue[[]interface{}] {
+	return &c.TechnicalNotificationMails
+}
+
+func (c *mqlMicrosoftTenant) GetPreferredLanguage() *plugin.TValue[string] {
+	return &c.PreferredLanguage
 }
 
 // mqlMicrosoftTenantSettings for the microsoft.tenant.settings resource

--- a/providers/ms365/resources/ms365.lr.manifest.yaml
+++ b/providers/ms365/resources/ms365.lr.manifest.yaml
@@ -598,9 +598,12 @@ resources:
       id: {}
       name: {}
       onPremisesSyncEnabled: {}
+      preferredLanguage: {}
+      privacyProfile: {}
       provisionedPlans: {}
       settings: {}
       subscriptions: {}
+      technicalNotificationMails: {}
       type: {}
       verifiedDomains: {}
     min_mondoo_version: 9.0.0

--- a/providers/ms365/resources/structs.go
+++ b/providers/ms365/resources/structs.go
@@ -128,12 +128,24 @@ type UnifiedRolePermission struct {
 	ExcludedResourceActions []string `json:"excludedResourceActions"`
 }
 
+type PrivacyProfileable struct {
+	ContactEmail string `json:"contactEmail"`
+	StatementUrl string `json:"statementUrl"`
+}
+
 func newUnifiedRolePermissions(p []models.UnifiedRolePermissionable) []UnifiedRolePermission {
 	res := []UnifiedRolePermission{}
 	for i := range p {
 		res = append(res, newUnifiedRolePermission(p[i]))
 	}
 	return res
+}
+
+func newPrivacyProfile(p models.PrivacyProfileable) PrivacyProfileable {
+	return PrivacyProfileable{
+		ContactEmail: convert.ToValue(p.GetContactEmail()),
+		StatementUrl: convert.ToValue(p.GetStatementUrl()),
+	}
 }
 
 func newUnifiedRolePermission(p models.UnifiedRolePermissionable) UnifiedRolePermission {


### PR DESCRIPTION
Added missing fields to `microsoft.tenant` resource

```graphQL
cnquery> microsoft.tenant{privacyProfile technicalNotificationMails preferredLanguage}
microsoft.tenant: {
  preferredLanguage: "en"
  technicalNotificationMails: [
    0: "chris@mondoo.io"
  ]
  privacyProfile: {
    contactEmail: "john@mondoo.onmicrosoft.com"
    statementUrl: "https://example.com/privacy"
  }
}
```

resolve #5672