### PR TITLE
✨ Detect activated RHEL modules

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -821,6 +821,10 @@ var redhatFamily = &PlatformResolver{
 				pf.Version = release
 			}
 
+			// RHEL can have various modules activated, identify them via filesystem
+			modules := getActivatedRhelModules(conn)
+			pf.Metadata["redhat/modules"] = strings.Join(modules, ",")
+
 			return true, nil
 		}
 

--- a/providers/os/detector/detector_rhel.go
+++ b/providers/os/detector/detector_rhel.go
@@ -6,6 +6,7 @@ package detector
 import (
 	"bufio"
 	"bytes"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/afero"
@@ -39,7 +40,7 @@ func getActivatedRhelModules(conn shared.Connection) []string {
 			continue
 		}
 
-		content, err := afs.ReadFile(modulesDir + "/" + file.Name())
+		content, err := afs.ReadFile(filepath.Join(modulesDir, file.Name()))
 		if err != nil {
 			continue
 		}

--- a/providers/os/detector/detector_rhel.go
+++ b/providers/os/detector/detector_rhel.go
@@ -1,0 +1,72 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package detector
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+
+	"github.com/spf13/afero"
+	"go.mondoo.com/cnquery/v11/providers/os/connection/shared"
+)
+
+const (
+	modulesDir = "/etc/dnf/modules.d"
+)
+
+type RhelModule struct {
+	Name  string
+	State string
+}
+
+func getActivatedRhelModules(conn shared.Connection) []string {
+	afs := &afero.Afero{Fs: conn.FileSystem()}
+	ok, err := afs.DirExists(modulesDir)
+	if err != nil || !ok {
+		return []string{}
+	}
+
+	files, err := afs.ReadDir(modulesDir)
+	if err != nil {
+		return []string{}
+	}
+
+	modules := []string{}
+	for _, file := range files {
+		if !strings.HasSuffix(file.Name(), ".module") {
+			continue
+		}
+
+		content, err := afs.ReadFile(modulesDir + "/" + file.Name())
+		if err != nil {
+			continue
+		}
+
+		module := RhelModule{}
+		scanner := bufio.NewScanner(bytes.NewReader(content))
+		for scanner.Scan() {
+			s := strings.Split(scanner.Text(), "=")
+			if len(s) != 2 {
+				continue
+			}
+
+			switch strings.ToLower(s[0]) {
+			case "name":
+				module.Name = strings.TrimSpace(s[1])
+			case "state":
+				module.State = strings.TrimSpace(s[1])
+			}
+		}
+
+		// We are only interested in enabled modules
+		if module.State != "enabled" {
+			continue
+		}
+
+		modules = append(modules, module.Name)
+	}
+
+	return modules
+}

--- a/providers/os/detector/detector_rhel_test.go
+++ b/providers/os/detector/detector_rhel_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package detector
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetActivatedRhelModules(t *testing.T) {
+	tests := []struct {
+		name     string
+		files    map[string]string
+		expected []string
+	}{
+		{
+			name:     "no modules directory",
+			files:    map[string]string{},
+			expected: []string{},
+		},
+		{
+			name: "empty modules directory",
+			files: map[string]string{
+				"/etc/dnf/modules.d": "",
+			},
+			expected: []string{},
+		},
+		{
+			name: "valid modules",
+			files: map[string]string{
+				"/etc/dnf/modules.d/maven.module": `[maven]
+name=maven
+stream=3.8
+profiles=
+state=enabled`,
+			},
+			expected: []string{"maven"},
+		},
+		{
+			name: "disabled module",
+			files: map[string]string{
+				"/etc/dnf/modules.d/maven.module": `[maven]
+name=maven
+stream=3.8
+profiles=
+state=disabled`,
+			},
+			expected: []string{},
+		},
+		{
+			name: "multiple modules",
+			files: map[string]string{
+				"/etc/dnf/modules.d/maven.module": `[maven]
+name=maven
+stream=3.8
+profiles=
+state=enabled`,
+				"/etc/dnf/modules.d/python36.module": `[python36]
+name=python36
+stream=3.6
+profiles=
+state=enabled`,
+			},
+			expected: []string{"maven", "python36"},
+		},
+		{
+			name: "invalid content",
+			files: map[string]string{
+				"/etc/dnf/modules.d/invalid.module": `invalid content`,
+			},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock filesystem
+			fs := afero.NewMemMapFs()
+
+			// Create the directory structure
+			if len(tt.files) > 0 {
+				err := fs.MkdirAll("/etc/dnf/modules.d", 0o755)
+				assert.NoError(t, err)
+			}
+
+			// Create the files
+			for path, content := range tt.files {
+				if path == "/etc/dnf/modules.d" {
+					continue
+				}
+				err := afero.WriteFile(fs, path, []byte(content), 0o644)
+				assert.NoError(t, err)
+			}
+
+			// Create a mock connection
+			conn := &mockConnection{
+				fs: fs,
+			}
+
+			// Call the function
+			result := getActivatedRhelModules(conn)
+
+			// Compare results
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Implements: https://github.com/mondoohq/cnquery/issues/5695

Example RHEL 9 GCP VM:
```
cnquery run ssh -i ~/.ssh/google_compute_engine XXX -c "asset.platformMetadata" 
→ loaded configuration from /etc/opt/mondoo/mondoo.yml using source default
asset.platformMetadata: {
  distro-id: "rhel"
  redhat/modules: ""
}
```

With enabled maven module:
```
asset.platformMetadata: {
  distro-id: "rhel"
  rhel/modules: "maven"
}
```

RHEL 8 GCP VM:
```
asset.platformMetadata: {
  distro-id: "rhel"
  redhat/modules: "python36,virt"
}
```