### PR TITLE
Add fallback support for kernel.modules when lsmod is not available

### DIFF
--- a/providers/os/resources/kernel/modules_test.go
+++ b/providers/os/resources/kernel/modules_test.go
@@ -166,8 +166,8 @@ func TestLinuxSysModuleParserMissingFiles(t *testing.T) {
 
 	module := entries[0]
 	assert.Equal(t, "minimal_module", module.Name)
-	assert.Equal(t, "0", module.Size)    // Default when coresize is missing
-	assert.Equal(t, "0", module.UsedBy)  // Default when refcnt is missing
+	assert.Equal(t, "0", module.Size)   // Default when coresize is missing
+	assert.Equal(t, "0", module.UsedBy) // Default when refcnt is missing
 }
 
 func TestLinuxSysModuleParserNoSysModule(t *testing.T) {

--- a/providers/os/resources/kernel/modules_test.go
+++ b/providers/os/resources/kernel/modules_test.go
@@ -6,6 +6,7 @@ package kernel
 import (
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
@@ -87,6 +88,96 @@ func TestKextstatParser(t *testing.T) {
 	}
 	found := findModule(entries, "com.apple.kpi.mach")
 	assert.Equal(t, expected, found)
+}
+
+func TestLinuxSysModuleParser(t *testing.T) {
+	// Create an in-memory filesystem to simulate /sys/module structure
+	fs := afero.NewMemMapFs()
+
+	// Create /sys/module directory structure with test modules
+	err := fs.MkdirAll("/sys/module/cryptd", 0755)
+	require.NoError(t, err)
+	err = fs.MkdirAll("/sys/module/ext4", 0755)
+	require.NoError(t, err)
+	err = fs.MkdirAll("/sys/module/unloaded_module", 0755)
+	require.NoError(t, err)
+
+	// Create initstate files (live modules)
+	err = afero.WriteFile(fs, "/sys/module/cryptd/initstate", []byte("live\n"), 0644)
+	require.NoError(t, err)
+	err = afero.WriteFile(fs, "/sys/module/ext4/initstate", []byte("live\n"), 0644)
+	require.NoError(t, err)
+	// Create an unloaded module (should be filtered out)
+	err = afero.WriteFile(fs, "/sys/module/unloaded_module/initstate", []byte("going\n"), 0644)
+	require.NoError(t, err)
+
+	// Create coresize files
+	err = afero.WriteFile(fs, "/sys/module/cryptd/coresize", []byte("24576\n"), 0644)
+	require.NoError(t, err)
+	err = afero.WriteFile(fs, "/sys/module/ext4/coresize", []byte("589824\n"), 0644)
+	require.NoError(t, err)
+
+	// Create refcnt files
+	err = afero.WriteFile(fs, "/sys/module/cryptd/refcnt", []byte("3\n"), 0644)
+	require.NoError(t, err)
+	err = afero.WriteFile(fs, "/sys/module/ext4/refcnt", []byte("1\n"), 0644)
+	require.NoError(t, err)
+
+	// Parse the modules
+	entries, err := ParseLinuxSysModule(fs)
+	require.NoError(t, err)
+
+	// Should only find 2 live modules (unloaded_module should be filtered out)
+	assert.Equal(t, 2, len(entries))
+
+	// Check cryptd module
+	cryptd := findModule(entries, "cryptd")
+	require.NotNil(t, cryptd)
+	assert.Equal(t, "cryptd", cryptd.Name)
+	assert.Equal(t, "24576", cryptd.Size)
+	assert.Equal(t, "3", cryptd.UsedBy)
+
+	// Check ext4 module
+	ext4 := findModule(entries, "ext4")
+	require.NotNil(t, ext4)
+	assert.Equal(t, "ext4", ext4.Name)
+	assert.Equal(t, "589824", ext4.Size)
+	assert.Equal(t, "1", ext4.UsedBy)
+
+	// Ensure unloaded module is not included
+	unloaded := findModule(entries, "unloaded_module")
+	assert.Nil(t, unloaded)
+}
+
+func TestLinuxSysModuleParserMissingFiles(t *testing.T) {
+	// Test behavior when some files are missing
+	fs := afero.NewMemMapFs()
+
+	// Create module directory with only initstate
+	err := fs.MkdirAll("/sys/module/minimal_module", 0755)
+	require.NoError(t, err)
+	err = afero.WriteFile(fs, "/sys/module/minimal_module/initstate", []byte("live\n"), 0644)
+	require.NoError(t, err)
+	// No coresize or refcnt files
+
+	entries, err := ParseLinuxSysModule(fs)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(entries))
+
+	module := entries[0]
+	assert.Equal(t, "minimal_module", module.Name)
+	assert.Equal(t, "0", module.Size)    // Default when coresize is missing
+	assert.Equal(t, "0", module.UsedBy)  // Default when refcnt is missing
+}
+
+func TestLinuxSysModuleParserNoSysModule(t *testing.T) {
+	// Test behavior when /sys/module doesn't exist
+	fs := afero.NewMemMapFs()
+
+	entries, err := ParseLinuxSysModule(fs)
+	// Should not error, but return empty list
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(entries))
 }
 
 func findModule(modules []*KernelModule, name string) *KernelModule {

--- a/providers/os/resources/kernel/testdata/linux_no_lsmod.toml
+++ b/providers/os/resources/kernel/testdata/linux_no_lsmod.toml
@@ -1,0 +1,71 @@
+# Test data for Linux system without lsmod command but with /sys/module
+# This simulates a minimal Linux system where lsmod is not available
+
+[commands."/sbin/lsmod"]
+# Simulate lsmod command not found
+exit_status = 127
+stderr = "/sbin/lsmod: command not found"
+stdout = ""
+
+[files."/proc/modules"]
+# Simulate /proc/modules not available
+enoent = true
+
+# Simulate /sys/module directory structure
+[files."/sys/module"]
+content = ""
+[files."/sys/module".stat]
+isdir = true
+mode = 0o755
+
+[files."/sys/module/cryptd"]
+content = ""
+[files."/sys/module/cryptd".stat]
+isdir = true
+mode = 0o755
+
+[files."/sys/module/cryptd/initstate"]
+content = "live"
+
+[files."/sys/module/cryptd/coresize"]
+content = "24576"
+
+[files."/sys/module/cryptd/refcnt"]
+content = "3"
+
+[files."/sys/module/ext4"]
+content = ""
+[files."/sys/module/ext4".stat]
+isdir = true
+mode = 0o755
+
+[files."/sys/module/ext4/initstate"]
+content = "live"
+
+[files."/sys/module/ext4/coresize"]
+content = "589824"
+
+[files."/sys/module/ext4/refcnt"]
+content = "1"
+
+[files."/sys/module/unloaded_module"]
+content = ""
+[files."/sys/module/unloaded_module".stat]
+isdir = true
+mode = 0o755
+
+[files."/sys/module/unloaded_module/initstate"]
+content = "going"
+
+[files."/sys/module/unloaded_module/coresize"]
+content = "16384"
+
+[files."/sys/module/unloaded_module/refcnt"]
+content = "0"
+
+# Basic system info
+[files."/proc/version"]
+content = "Linux version 5.4.0-74-generic (buildd@lcy01-amd64-030) (gcc version 9.4.0 (Ubuntu 9.4.0-1ubuntu1~20.04.1)) #83-Ubuntu SMP Sat May 8 02:35:39 UTC 2021"
+
+[files."/proc/cmdline"]
+content = "BOOT_IMAGE=/boot/vmlinuz-5.4.0-74-generic root=UUID=12345678-1234-1234-1234-123456789012 ro quiet splash"


### PR DESCRIPTION
Fixes #5641

This commit implements a fallback mechanism for the kernel.modules resource when the lsmod command is not available on Linux systems. The implementation follows a three-tier approach:

1. Primary: Try /sbin/lsmod command (existing behavior)
2. Fallback 1: Read from /proc/modules if lsmod fails
3. Fallback 2: Parse /sys/module directory structure if /proc/modules is unavailable

Key changes:
- Added ParseLinuxSysModule() function to parse kernel modules from /sys/module
- Updated LinuxKernelManager.Modules() with comprehensive fallback logic
- Added extensive test coverage for all fallback scenarios
- Maintains backward compatibility with existing functionality

The /sys/module fallback reads module directories, checks initstate files for 'live' modules, and extracts size/reference count information from coresize and refcnt files respectively.

Testing:
- All existing tests continue to pass
- New tests verify fallback behavior and /sys/module parsing
- Mock test data simulates systems without lsmod or /proc/modules