### PR TITLE
✨ Expand scanning granularity in GCP

### DIFF
--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -51,7 +51,7 @@ Examples with the GCP project configured:
 				resources.DiscoveryStorageBuckets,
 				resources.DiscoveryBigQueryDatasets,
 				resources.DiscoverCloudSQLMySQL,
-				resources.DiscoverCloudSQLPostgres,
+				resources.DiscoverCloudSQLPostgreSQL,
 				resources.DiscoverCloudSQLSQLServer,
 				resources.DiscoverCloudDNSZones,
 				resources.DiscoverCloudKMSKeyrings,

--- a/providers/gcp/connection/platform.go
+++ b/providers/gcp/connection/platform.go
@@ -6,6 +6,7 @@ package connection
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
 )
@@ -52,7 +53,7 @@ func (c *GcpConnection) PlatformInfo() (*inventory.Platform, error) {
 	if c.opts.platformOverride != "" && c.opts.platformOverride != "gcp" {
 		return &inventory.Platform{
 			Name:    c.opts.platformOverride,
-			Title:   getTitleForPlatformName(c.opts.platformOverride),
+			Title:   GetTitleForPlatformName(c.opts.platformOverride),
 			Family:  []string{"google"},
 			Kind:    "gcp-object",
 			Runtime: "gcp",
@@ -89,7 +90,7 @@ func (c *GcpConnection) PlatformInfo() (*inventory.Platform, error) {
 	return nil, errors.New("unsupported resource type")
 }
 
-func getTitleForPlatformName(name string) string {
+func GetTitleForPlatformName(name string) string {
 	switch name {
 	case "gcp-organization":
 		return "GCP Organization"
@@ -112,17 +113,26 @@ func getTitleForPlatformName(name string) string {
 	case "gcp-bigquery-dataset":
 		return "GCP BigQuery Dataset"
 	case "gcp-sql-mysql":
-		return "GCP Cloud SQL MySQL"
-	case "gcp-sql-postgres":
-		return "GCP Cloud SQL Postgres"
+		return "GCP Cloud SQL for MySQL"
+	case "gcp-sql-postgresql":
+		return "GCP Cloud SQL for PostgreSQL"
 	case "gcp-sql-sqlserver":
-		return "GCP Cloud SQL SQL Server"
+		return "GCP Cloud SQL for SQL Server"
 	case "gcp-dns-zone":
 		return "GCP Cloud DNS Zone"
 	case "gcp-kms-keyring":
 		return "GCP Cloud KMS Keyring"
 	}
 	return "Google Cloud Platform"
+}
+
+func ParseCloudSQLType(googleType string) string {
+	switch lower := strings.ToLower(googleType); {
+	case lower == "postgres":
+		return "postgresql"
+	default:
+		return lower
+	}
 }
 
 func ResourceTechnologyUrl(service, project, region, objectType, name string) []string {
@@ -152,7 +162,7 @@ func ResourceTechnologyUrl(service, project, region, objectType, name string) []
 		}
 	case "cloud-sql":
 		switch objectType {
-		case "mysql", "postgres", "sqlserver":
+		case "mysql", "postgresql", "sqlserver":
 			return []string{"gcp", project, "cloud-sql", region, objectType}
 		default:
 			return []string{"gcp", project, "cloud-sql", region, "other"}


### PR DESCRIPTION
Fine grained asset scanning \(scanning more cloud resources as assets\) makes it easier to explore, understand, and triage security findings\. When individual resources are discovered as assets then users can view asset overview information, create exceptions, and create tickets for individual findings\.

<p></p>

Let's improve our GCP experience by scanning more cloud resources as assets, so that we provide improved visibility into GCP security:

- Cloud SQL PostgreSQL `gcp.project.sql.instances.where(databaseInstalledVersion == /^POSTGRES_/)`

- Cloud SQL MySQL `gcp.project.sql.instances.where(databaseInstalledVersion == /^MYSQL_/)`

- Cloud SQL SQL Server  `gcp.project.sql.instances.where(databaseInstalledVersion == /^SQL_/)`

- Cloud DNS zone `gcp.project.dnsService.managedzone`

- KMS keyrings `gcp.project.kmsService.keyring`

## Test

Ran a scan and the platform showed up the asset. Now we need to write policies.

![Screenshot 2025-06-30 at 2 21 15 PM](https://github.com/user-attachments/assets/a1b5dcbb-06f8-4421-ba3a-7b1f59d48fcf)

