### PR TITLE
ms365: Extend microsoft.policies with externalIdentitiesPolicy

### DIFF
--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -1106,6 +1106,21 @@ microsoft.policies {
   authenticationMethodsPolicy() microsoft.policies.authenticationMethodsPolicy
   // Activity-based timeout policies
   activityBasedTimeoutPolicies() []microsoft.policies.activityBasedTimeoutPolicy
+  // Tenant-wide policy that controls whether external users can leave a tenant
+  externalIdentitiesPolicy() microsoft.policies.externalIdentitiesPolicy
+}
+
+// Tenant-wide policy that controls whether external users can leave a tenant via self-service controls
+private microsoft.policies.externalIdentitiesPolicy @defaults("displayName allowExternalIdentitiesToLeave") {
+  // Policy ID
+  id string
+  // Policy display name
+  displayName string
+  // Policy description
+  description string
+  // Defines whether external users can leave the guest tenant. 
+  // If set to false, self-service controls are disabled, and the admin must manually remove the external user.
+  allowExternalIdentitiesToLeave bool
 }
 
 // Activity-based timeout policy
@@ -1121,6 +1136,7 @@ microsoft.policies.activityBasedTimeoutPolicy @defaults("displayName isOrganizat
   isOrganizationDefault bool
 }
 
+// Policy for enabling or disabling the Microsoft Entra admin consent workflow
 private microsoft.adminConsentRequestPolicy @defaults("isEnabled notifyReviewers") {
   // Specifies whether the admin consent request feature is enabled or disabled
   isEnabled bool
@@ -1136,6 +1152,7 @@ private microsoft.adminConsentRequestPolicy @defaults("isEnabled notifyReviewers
   version int
 }
 
+// List of reviewers for the admin consent
 private microsoft.graph.accessReviewReviewerScope @defaults("query queryType") {
   // The query specifying who will be the reviewer
   query string

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -270,6 +270,10 @@ func init() {
 			// to override args, implement: initMicrosoftPolicies(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMicrosoftPolicies,
 		},
+		"microsoft.policies.externalIdentitiesPolicy": {
+			// to override args, implement: initMicrosoftPoliciesExternalIdentitiesPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createMicrosoftPoliciesExternalIdentitiesPolicy,
+		},
 		"microsoft.policies.activityBasedTimeoutPolicy": {
 			// to override args, implement: initMicrosoftPoliciesActivityBasedTimeoutPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMicrosoftPoliciesActivityBasedTimeoutPolicy,
@@ -1718,6 +1722,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"microsoft.policies.activityBasedTimeoutPolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftPolicies).GetActivityBasedTimeoutPolicies()).ToDataRes(types.Array(types.Resource("microsoft.policies.activityBasedTimeoutPolicy")))
+	},
+	"microsoft.policies.externalIdentitiesPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftPolicies).GetExternalIdentitiesPolicy()).ToDataRes(types.Resource("microsoft.policies.externalIdentitiesPolicy"))
+	},
+	"microsoft.policies.externalIdentitiesPolicy.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftPoliciesExternalIdentitiesPolicy).GetId()).ToDataRes(types.String)
+	},
+	"microsoft.policies.externalIdentitiesPolicy.displayName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftPoliciesExternalIdentitiesPolicy).GetDisplayName()).ToDataRes(types.String)
+	},
+	"microsoft.policies.externalIdentitiesPolicy.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftPoliciesExternalIdentitiesPolicy).GetDescription()).ToDataRes(types.String)
+	},
+	"microsoft.policies.externalIdentitiesPolicy.allowExternalIdentitiesToLeave": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftPoliciesExternalIdentitiesPolicy).GetAllowExternalIdentitiesToLeave()).ToDataRes(types.Bool)
 	},
 	"microsoft.policies.activityBasedTimeoutPolicy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftPoliciesActivityBasedTimeoutPolicy).GetId()).ToDataRes(types.String)
@@ -4207,6 +4226,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"microsoft.policies.activityBasedTimeoutPolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftPolicies).ActivityBasedTimeoutPolicies, ok = plugin.RawToTValue[[]interface{}](v.Value, v.Error)
+		return
+	},
+	"microsoft.policies.externalIdentitiesPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftPolicies).ExternalIdentitiesPolicy, ok = plugin.RawToTValue[*mqlMicrosoftPoliciesExternalIdentitiesPolicy](v.Value, v.Error)
+		return
+	},
+	"microsoft.policies.externalIdentitiesPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlMicrosoftPoliciesExternalIdentitiesPolicy).__id, ok = v.Value.(string)
+			return
+		},
+	"microsoft.policies.externalIdentitiesPolicy.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftPoliciesExternalIdentitiesPolicy).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.policies.externalIdentitiesPolicy.displayName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftPoliciesExternalIdentitiesPolicy).DisplayName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.policies.externalIdentitiesPolicy.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftPoliciesExternalIdentitiesPolicy).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.policies.externalIdentitiesPolicy.allowExternalIdentitiesToLeave": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftPoliciesExternalIdentitiesPolicy).AllowExternalIdentitiesToLeave, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"microsoft.policies.activityBasedTimeoutPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10170,6 +10213,7 @@ type mqlMicrosoftPolicies struct {
 	ConsentPolicySettings plugin.TValue[interface{}]
 	AuthenticationMethodsPolicy plugin.TValue[*mqlMicrosoftPoliciesAuthenticationMethodsPolicy]
 	ActivityBasedTimeoutPolicies plugin.TValue[[]interface{}]
+	ExternalIdentitiesPolicy plugin.TValue[*mqlMicrosoftPoliciesExternalIdentitiesPolicy]
 }
 
 // createMicrosoftPolicies creates a new instance of this resource
@@ -10274,6 +10318,81 @@ func (c *mqlMicrosoftPolicies) GetActivityBasedTimeoutPolicies() *plugin.TValue[
 
 		return c.activityBasedTimeoutPolicies()
 	})
+}
+
+func (c *mqlMicrosoftPolicies) GetExternalIdentitiesPolicy() *plugin.TValue[*mqlMicrosoftPoliciesExternalIdentitiesPolicy] {
+	return plugin.GetOrCompute[*mqlMicrosoftPoliciesExternalIdentitiesPolicy](&c.ExternalIdentitiesPolicy, func() (*mqlMicrosoftPoliciesExternalIdentitiesPolicy, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft.policies", c.__id, "externalIdentitiesPolicy")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlMicrosoftPoliciesExternalIdentitiesPolicy), nil
+			}
+		}
+
+		return c.externalIdentitiesPolicy()
+	})
+}
+
+// mqlMicrosoftPoliciesExternalIdentitiesPolicy for the microsoft.policies.externalIdentitiesPolicy resource
+type mqlMicrosoftPoliciesExternalIdentitiesPolicy struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlMicrosoftPoliciesExternalIdentitiesPolicyInternal it will be used here
+	Id plugin.TValue[string]
+	DisplayName plugin.TValue[string]
+	Description plugin.TValue[string]
+	AllowExternalIdentitiesToLeave plugin.TValue[bool]
+}
+
+// createMicrosoftPoliciesExternalIdentitiesPolicy creates a new instance of this resource
+func createMicrosoftPoliciesExternalIdentitiesPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMicrosoftPoliciesExternalIdentitiesPolicy{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("microsoft.policies.externalIdentitiesPolicy", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMicrosoftPoliciesExternalIdentitiesPolicy) MqlName() string {
+	return "microsoft.policies.externalIdentitiesPolicy"
+}
+
+func (c *mqlMicrosoftPoliciesExternalIdentitiesPolicy) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMicrosoftPoliciesExternalIdentitiesPolicy) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlMicrosoftPoliciesExternalIdentitiesPolicy) GetDisplayName() *plugin.TValue[string] {
+	return &c.DisplayName
+}
+
+func (c *mqlMicrosoftPoliciesExternalIdentitiesPolicy) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlMicrosoftPoliciesExternalIdentitiesPolicy) GetAllowExternalIdentitiesToLeave() *plugin.TValue[bool] {
+	return &c.AllowExternalIdentitiesToLeave
 }
 
 // mqlMicrosoftPoliciesActivityBasedTimeoutPolicy for the microsoft.policies.activityBasedTimeoutPolicy resource

--- a/providers/ms365/resources/ms365.lr.manifest.yaml
+++ b/providers/ms365/resources/ms365.lr.manifest.yaml
@@ -510,6 +510,7 @@ resources:
       authenticationMethodsPolicy: {}
       authorizationPolicy: {}
       consentPolicySettings: {}
+      externalIdentitiesPolicy: {}
       identitySecurityDefaultsEnforcementPolicy: {}
       permissionGrantPolicies: {}
     min_mondoo_version: 9.0.0
@@ -535,6 +536,14 @@ resources:
       id: {}
       lastModifiedDateTime: {}
       policyVersion: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
+  microsoft.policies.externalIdentitiesPolicy:
+    fields:
+      allowExternalIdentitiesToLeave: {}
+      description: {}
+      displayName: {}
+      id: {}
     is_private: true
     min_mondoo_version: 9.0.0
   microsoft.rolemanagement:

--- a/providers/ms365/resources/policies.go
+++ b/providers/ms365/resources/policies.go
@@ -267,3 +267,29 @@ func (a *mqlMicrosoftPolicies) adminConsentRequestPolicy() (*mqlMicrosoftAdminCo
 
 	return resource.(*mqlMicrosoftAdminConsentRequestPolicy), nil
 }
+
+func (a *mqlMicrosoftPolicies) externalIdentitiesPolicy() (*mqlMicrosoftPoliciesExternalIdentitiesPolicy, error) {
+	conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)
+	betaGraphClient, err := conn.BetaGraphClient()
+	if err != nil {
+		return nil, err
+	}
+	policy, err := betaGraphClient.Policies().ExternalIdentitiesPolicy().Get(context.Background(), nil)
+	if err != nil {
+		return nil, transformError(err)
+	}
+
+	mqlPolicy, err := CreateResource(a.MqlRuntime, "microsoft.policies.externalIdentitiesPolicy",
+		map[string]*llx.RawData{
+			"__id":                           llx.StringDataPtr(policy.GetId()),
+			"id":                             llx.StringDataPtr(policy.GetId()),
+			"displayName":                    llx.StringDataPtr(policy.GetDisplayName()),
+			"description":                    llx.StringDataPtr(policy.GetDescription()),
+			"allowExternalIdentitiesToLeave": llx.BoolDataPtr(policy.GetAllowExternalIdentitiesToLeave()),
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	return mqlPolicy.(*mqlMicrosoftPoliciesExternalIdentitiesPolicy), nil
+}


### PR DESCRIPTION
Added microsoft.policies.externalIdentitiesPolicy 

```graphQL
cnquery> microsoft.policies {externalIdentitiesPolicy {*}}
microsoft.policies: {
  externalIdentitiesPolicy: {
    id: "externalIdentityPolicy"
    description: null
    allowDeletedIdentitiesDataRemoval: false
    allowExternalIdentitiesToLeave: true
    displayName: "External Identities Policy"
  }
}
```

resolves #5606