### PR TITLE
Updates OS query packs Intalled Packages query

### DIFF
--- a/content/mondoo-linux-incident-response.mql.yaml
+++ b/content/mondoo-linux-incident-response.mql.yaml
@@ -43,7 +43,7 @@ packs:
         mql: os.uptime
       - uid: mondoo-linux-incident-response-installed-packages
         title: Installed packages
-        mql: packages { name version arch installed }
+        mql: packages { name version arch installed epoch origin purl }
       - uid: mondoo-linux-incident-response-running-services
         title: Running services
         mql: services.where(running == true) { name running enabled masked type }

--- a/content/mondoo-linux-inventory.mql.yaml
+++ b/content/mondoo-linux-inventory.mql.yaml
@@ -89,7 +89,7 @@ packs:
         mql: os.uptime
       - uid: mondoo-linux-installed-packages
         title: Installed packages
-        mql: packages { name version arch installed }
+        mql: packages { name version arch installed epoch origin purl }
       - uid: mondoo-linux-running-services
         title: Running services
         filters: mondoo.capabilities.contains("run-command")

--- a/content/mondoo-macos-inventory.mql.yaml
+++ b/content/mondoo-macos-inventory.mql.yaml
@@ -87,7 +87,7 @@ packs:
         mql: users.where( name != /^_/ && shell != "/usr/bin/false" && name != "root")
       - uid: mondoo-macos-packages
         title: Installed packages
-        mql: packages { name version arch installed }
+        mql: packages { name version arch installed epoch origin purl }
       - uid: mondoo-macos-running-services
         title: Running services
         filters: mondoo.capabilities.contains("run-command")

--- a/content/mondoo-windows-inventory.mql.yaml
+++ b/content/mondoo-windows-inventory.mql.yaml
@@ -56,7 +56,7 @@ packs:
         mql: users
       - uid: mondoo-windows-packages
         title: Installed packages
-        mql: packages { name version arch installed }
+        mql: packages { name version arch installed epoch origin purl }
       - uid: mondoo-windows-hotfixes
         title: All installed Windows hotfixes
         mql: windows.hotfixes { hotfixId installedOn }


### PR DESCRIPTION
Updates the Installed packages query to collect additional fields...

**BEFORE**
```sh
packages { name version arch installed }
```

**AFTER**
```sh
packages { name version arch installed epoch origin purl }
```