### PR TITLE
⭐️ support cnquery sbom with shell

### DIFF
--- a/providers/sbom.go
+++ b/providers/sbom.go
@@ -95,6 +95,7 @@ func (s *sbomProviderService) Connect(req *plugin.ConnectReq, callback plugin.Pr
 		sbom.NewCycloneDX(sbom.FormatCycloneDxXML),
 		sbom.NewSPDX(sbom.FormatSpdxTagValue),
 		sbom.NewSPDX(sbom.FormatSpdxJSON),
+		sbom.New(sbom.FormatJson),
 	)
 
 	var sbomReport *sbom.Sbom

--- a/sbom/cnquery_bom.go
+++ b/sbom/cnquery_bom.go
@@ -5,6 +5,7 @@ package sbom
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 )
 
@@ -52,6 +53,11 @@ func (ccx *CnqueryBOM) Parse(r io.Reader) (*Sbom, error) {
 	err := json.NewDecoder(r).Decode(&s)
 	if err != nil {
 		return nil, err
+	}
+
+	// Test if the SBOM has a valid structure
+	if s.Asset == nil {
+		return nil, fmt.Errorf("unable to parse cnquery SBOM: missing asset information")
 	}
 
 	return &s, nil

--- a/sbom/spdx.go
+++ b/sbom/spdx.go
@@ -168,13 +168,13 @@ func (s *Spdx) Parse(r io.Reader) (*Sbom, error) {
 	// try to parse all supported SPDX format
 	if s.Format == FormatSpdxTagValue {
 		doc, err := tagvalue.Read(r)
-		if err == nil {
+		if err == nil && doc.SPDXVersion != "" {
 			return s.convertToSbom(doc), nil
 		}
 	} else if s.Format == FormatSpdxJSON {
 		var doc spdx.Document
 		err := json.NewDecoder(r).Decode(&doc)
-		if err == nil {
+		if err == nil && doc.SPDXVersion != "" {
 			return s.convertToSbom(&doc), nil
 		}
 	}


### PR DESCRIPTION
This adds support to use cnquery shell sbom with cnquery's own sbom format.

First create a new sbom for a container:

```shell
cnquery sbom container rockylinux:9 --output cyclonedx-json --output-target rockylinux.cyclonedx.json
```

Then you can use the sbom file to connect with the shell:

```shell
$ cnquery shell sbom rockylinux.cyclonedx.json
→ connected to 
  ___ _ __   __ _ _   _  ___ _ __ _   _ 
 / __| '_ \ / _` | | | |/ _ \ '__| | | |
| (__| | | | (_| | |_| |  __/ |  | |_| |
 \___|_| |_|\__, |\__,_|\___|_|   \__, |
  mondoo™      |_|                |___/  interactive shell

cnquery> asset.platform
asset.platform: "rockylinux"
cnquery> packages
packages.list: [
  0: package name="libgcc" version="0:11.4.1-2.1.el9"
  1: package name="crypto-policies" version="0:20230731-1.git94f0e2c.el9_3.1"
  2: package name="tzdata" version="0:2023c-1.el9"
  3: package name="rocky-gpg-keys" version="0:9.3-1.1.el9"
  4: package name="rocky-release" version="0:9.3-1.1.el9"
  5: package name="rocky-repos" version="0:9.3-1.1.el9"

```

To achieve that we added the decoder to the list of decoders we try to load data from. In addition we made spdx more robust so that it fails properly if the spdx json does not include a spdx version.
