### PR TITLE
Make properties work properly

### DIFF
--- a/explorer/bundle.go
+++ b/explorer/bundle.go
@@ -665,7 +665,9 @@ func LiftPropertiesToPack(pack *QueryPack, lookupQuery map[string]*Mquery) error
 	sort.Strings(keys)
 	for _, k := range keys {
 		prop := newPolicyProps[k]
-		prop.RefreshMRN(pack.Mrn)
+		if err := prop.RefreshMRN(pack.Mrn); err != nil {
+			return err
+		}
 		pack.Props = append(pack.Props, prop)
 	}
 	return nil

--- a/explorer/bundle.go
+++ b/explorer/bundle.go
@@ -10,6 +10,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -657,7 +658,13 @@ func LiftPropertiesToPack(pack *QueryPack, lookupQuery map[string]*Mquery) error
 			}
 		}
 	}
-	for _, prop := range newPolicyProps {
+	keys := make([]string, 0, len(newPolicyProps))
+	for k := range newPolicyProps {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		prop := newPolicyProps[k]
 		prop.RefreshMRN(pack.Mrn)
 		pack.Props = append(pack.Props, prop)
 	}

--- a/explorer/bundle_test.go
+++ b/explorer/bundle_test.go
@@ -158,3 +158,147 @@ queries:
 - uid: variant-nok
   mql: definitely_not_in_here
 `
+
+func TestProps_QueryPropsLifted(t *testing.T) {
+	// In this test, we expect that 3 properties are lifted to the pack:
+	// home, homeDir, and user.
+	// These must reference the queries prop through the for field
+	bundleYaml := `
+packs:
+  - uid: example1
+    name: Example policy 1
+    groups:
+      - title: group1
+        filters: return true
+        queries:
+          - uid: variant-1
+          - uid: variant-2
+          - uid: variant-3
+          - uid: variant-4
+queries:
+  - uid: variant-check
+    title: Variant check
+    variants:
+      - uid: variant-1
+      - uid: variant-2
+      - uid: variant-3
+
+  - uid: variant-1
+    mql: props.home + " on 1"
+    props:
+      - uid: home
+        mql: return "p1"
+
+  - uid: variant-2
+    mql: props.home + " on 2"
+    props:
+      - uid: home
+        mql: return "p2"
+
+  - uid: variant-3
+    mql: props.homeDir + " on 3"
+    props:
+      - uid: homeDir
+        mql: return "p3"
+  
+  - uid: variant-4
+    mql: props.user + " is the user"
+    props:
+      - uid: user
+        mql: return "ada"`
+
+	b, err := BundleFromYAML([]byte(bundleYaml))
+	require.NoError(t, err)
+	_, err = b.CompileExt(context.Background(), BundleCompileConf{
+		CompilerConfig: conf,
+		RemoveFailing:  true,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, b.Packs[0].Props, 3)
+	require.Len(t, b.Packs[0].Props[0].For, 2)
+	require.NotEmpty(t, b.Packs[0].Props[0].For[0].Mrn)
+	require.NotEmpty(t, b.Packs[0].Props[0].For[1].Mrn)
+	require.Equal(t, b.Queries[1].Props[0].Mrn, b.Packs[0].Props[0].For[0].Mrn)
+	require.Equal(t, b.Queries[2].Props[0].Mrn, b.Packs[0].Props[0].For[1].Mrn)
+	require.Len(t, b.Packs[0].Props[1].For, 1)
+	require.Equal(t, b.Queries[3].Props[0].Mrn, b.Packs[0].Props[1].For[0].Mrn)
+	require.Len(t, b.Packs[0].Props[2].For, 1)
+	require.Equal(t, b.Queries[4].Props[0].Mrn, b.Packs[0].Props[2].For[0].Mrn)
+}
+
+func TestProps_QueryPropMrnsResolved(t *testing.T) {
+	// In this test, we expect that the property mrns are resolved correctly
+	// and that the for field is set to the correct query mrn.
+	bundleYaml := `
+packs:
+  - uid: example1
+    name: Example policy 1
+    version: "1.0.0"
+    authors:
+      - name: Mondoo
+        email: hello@mondoo.com
+    groups:
+      - title: group1
+        filters: return true
+        queries:
+          - uid: variant-1
+          - uid: variant-2
+          - uid: variant-3
+          - uid: variant-4
+    props:
+      - uid: userHome
+        for:
+          - uid: home
+          - uid: homeDir
+        mql: return "ex"
+
+queries:
+  - uid: variant-check
+    title: Variant check
+    variants:
+      - uid: variant-1
+      - uid: variant-2
+      - uid: variant-3
+
+  - uid: variant-1
+    mql: props.home + " on 1"
+    props:
+      - uid: home
+        mql: return "p1"
+
+  - uid: variant-2
+    mql: props.home + " on 2"
+    props:
+      - uid: home
+        mql: return "p2"
+
+  - uid: variant-3
+    mql: props.homeDir + " on 3"
+    props:
+      - uid: homeDir
+        mql: return "p3"
+  
+  - uid: variant-4
+    mql: props.user + " is the user"
+    props:
+      - uid: user
+        mql: return "ada"`
+
+	b, err := BundleFromYAML([]byte(bundleYaml))
+	require.NoError(t, err)
+	_, err = b.CompileExt(context.Background(), BundleCompileConf{
+		CompilerConfig: conf,
+		RemoveFailing:  true,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, b.Packs[0].Props, 1)
+	require.Len(t, b.Packs[0].Props[0].For, 3)
+	require.NotEmpty(t, b.Packs[0].Props[0].For[0].Mrn)
+	require.NotEmpty(t, b.Packs[0].Props[0].For[1].Mrn)
+	require.NotEmpty(t, b.Packs[0].Props[0].For[2].Mrn)
+	require.Equal(t, b.Queries[1].Props[0].Mrn, b.Packs[0].Props[0].For[0].Mrn)
+	require.Equal(t, b.Queries[2].Props[0].Mrn, b.Packs[0].Props[0].For[1].Mrn)
+	require.Equal(t, b.Queries[3].Props[0].Mrn, b.Packs[0].Props[0].For[2].Mrn)
+}

--- a/explorer/mquery.go
+++ b/explorer/mquery.go
@@ -77,12 +77,6 @@ func (m *Mquery) RefreshMRN(ownerMRN string) error {
 	m.Mrn = nu
 	m.Uid = ""
 
-	for i := range m.Props {
-		if err := m.Props[i].RefreshMRN(ownerMRN); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 

--- a/explorer/mquery_test.go
+++ b/explorer/mquery_test.go
@@ -71,9 +71,11 @@ func TestMquery_Refresh(t *testing.T) {
 
 	err := a.RefreshMRN("//owner")
 	require.NoError(t, err)
+	err = a.Props[0].RefreshMRN(a.Mrn)
+	require.NoError(t, err)
 	assert.Equal(t, "//owner/queries/my-id0", a.Mrn)
 	assert.Empty(t, a.Uid)
-	assert.Equal(t, "//owner/queries/world", a.Props[0].Mrn)
+	assert.Equal(t, "//owner/queries/my-id0/properties/world", a.Props[0].Mrn)
 	assert.Empty(t, a.Props[0].Uid)
 
 	x := testutils.LinuxMock()
@@ -86,8 +88,8 @@ func TestMquery_Refresh(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	assert.Equal(t, "5KkJ/lLHnBM=", a.Checksum)
-	assert.Equal(t, "9NhbOk30tEg=", a.Props[0].Checksum)
+	assert.Equal(t, "g4cj2tMzHs4=", a.Checksum)
+	assert.Equal(t, "OSGvkbAIHFU=", a.Props[0].Checksum)
 }
 
 func TestMqueryMerge(t *testing.T) {

--- a/explorer/property_test.go
+++ b/explorer/property_test.go
@@ -25,9 +25,7 @@ func TestProperty_RefreshMrn(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "", in.Uid)
-	assert.Equal(t, "//my.owner/queries/uid1", in.Mrn)
-	assert.Equal(t, "", in.For[0].Uid)
-	assert.Equal(t, "//my.owner/queries/uid2", in.For[0].Mrn)
+	assert.Equal(t, "//my.owner/properties/uid1", in.Mrn)
 }
 
 func TestProperty_MustNotBeEmpty(t *testing.T) {

--- a/explorer/query_conductor.go
+++ b/explorer/query_conductor.go
@@ -153,8 +153,10 @@ func (s *LocalServices) Resolve(ctx context.Context, req *ResolveReq) (*Resolved
 
 		props := NewPropsCache()
 		props.Add(bundle.Props...)
+		props.Add(pack.Props...)
 
 		for i := range pack.Queries {
+			props.Add(pack.Queries[i].Props...)
 			err := s.addQueryToJob(ctx, pack.Queries[i], &job, props, supportedFilters, bundleMap)
 			if err != nil {
 				return nil, err
@@ -169,6 +171,7 @@ func (s *LocalServices) Resolve(ctx context.Context, req *ResolveReq) (*Resolved
 			}
 
 			for i := range group.Queries {
+				props.Add(group.Queries[i].Props...)
 				err := s.addQueryToJob(ctx, group.Queries[i], &job, props, supportedFilters, bundleMap)
 				if err != nil {
 					return nil, err

--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -591,7 +591,9 @@ func (s *localAssetScanner) mapPropOverrides() (*explorer.PropsReq, error) {
 				Mrn: propMrn,
 			})
 		}
-		newProp.RefreshMRN(s.job.Asset.Mrn)
+		if err := newProp.RefreshMRN(s.job.Asset.Mrn); err != nil {
+			return nil, err
+		}
 		propsReq.Props = append(propsReq.Props, newProp)
 	}
 

--- a/explorer/scan/local_scanner.go
+++ b/explorer/scan/local_scanner.go
@@ -547,26 +547,55 @@ func (s *localAssetScanner) prepareAsset() error {
 	}
 
 	if len(s.job.Props) != 0 {
-		propsReq := explorer.PropsReq{
-			EntityMrn: s.job.Asset.Mrn,
-			Props:     make([]*explorer.Property, len(s.job.Props)),
-		}
-		i := 0
-		for k, v := range s.job.Props {
-			propsReq.Props[i] = &explorer.Property{
-				Uid: k,
-				Mql: v,
-			}
-			i++
+		propsReq, err := s.mapPropOverrides()
+		if err != nil {
+			return fmt.Errorf("failed to map property overrides: %w", err)
 		}
 
-		_, err = conductor.SetProps(s.job.Ctx, &propsReq)
+		_, err = conductor.SetProps(s.job.Ctx, propsReq)
 		if err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func (s *localAssetScanner) mapPropOverrides() (*explorer.PropsReq, error) {
+	exposedProps := make(map[string][]string, len(s.job.Props))
+	for _, pol := range s.job.Bundle.Packs {
+		for _, prop := range pol.Props {
+			propUid, err := explorer.GetPropName(prop.Mrn)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get property name for %s: %w", prop.Mrn, err)
+			}
+			exposedProps[propUid] = append(exposedProps[propUid], prop.Mrn)
+		}
+	}
+
+	propsReq := explorer.PropsReq{
+		EntityMrn: s.job.Asset.Mrn,
+		Props:     make([]*explorer.Property, 0, len(s.job.Props)),
+	}
+	for k, v := range s.job.Props {
+		newProp := &explorer.Property{
+			Uid: k,
+			Mql: v,
+		}
+		forProps := exposedProps[k]
+		if len(forProps) == 0 {
+			continue
+		}
+		for _, propMrn := range forProps {
+			newProp.For = append(newProp.For, &explorer.ObjectRef{
+				Mrn: propMrn,
+			})
+		}
+		newProp.RefreshMRN(s.job.Asset.Mrn)
+		propsReq.Props = append(propsReq.Props, newProp)
+	}
+
+	return &propsReq, nil
 }
 
 var _assetDetectBundle *llx.CodeBundle


### PR DESCRIPTION
DO NOT MERGE

- Props are now namespaced to either a pack or query
- Props on packs need to reference props through `for`
- We will automatically make the `for` references if a pack does
  not define any props but includes queries with props

Examples:
```yaml
packs:
  - uid: example1
    name: Example policy 1
    version: "1.0.0"
    authors:
      - name: Mondoo
        email: hello@mondoo.com
    groups:
      - title: group1
        filters: return true
        queries:
          - uid: variant-1
          - uid: variant-2
          - uid: variant-3
          - uid: variant-4
    props:
      - uid: userHome
        for:
          - uid: home
          - uid: homeDir
        mql: return "ex"

queries:
  - uid: variant-check
    title: Variant check
    variants:
      - uid: variant-1
      - uid: variant-2
      - uid: variant-3

  - uid: variant-1
    mql: props.home + " on 1"
    props:
      - uid: home
        mql: return "p1"

  - uid: variant-2
    mql: props.home + " on 2"
    props:
      - uid: home
        mql: return "p2"

  - uid: variant-3
    mql: props.homeDir + " on 3"
    props:
      - uid: homeDir
        mql: return "p3"

  - uid: variant-4
    mql: props.user + " is the user"
    props:
      - uid: user
        mql: return "ada"
```

```
go run ./apps/cnquery scan -f packprops.mql.yaml --json| jq .
```

```json
{
  "assets": {
    "//explorer.api.mondoo.com/assets/309tMfGA9ieUOgzgBdSMBNSEl6t": {
      "mrn": "//explorer.api.mondoo.com/assets/309tMfGA9ieUOgzgBdSMBNSEl6t",
      "name": "planetexpress"
    }
  },
  "data": {
    "//explorer.api.mondoo.com/assets/309tMfGA9ieUOgzgBdSMBNSEl6t": {
      "values": {
        "FCEF4O8XoOs=": {
          "content": {
            "user.+": "ada is the user"
          }
        },
        "JvBACGPwF6o=": {
          "content": {}
        },
        "NsipGp24tRk=": {
          "content": {
            "home.+": "ex on 1"
          }
        },
        "OU6YpdHiWPQ=": {
          "content": {
            "home.+": "ex on 2"
          }
        },
        "V/uj0v1oehI=": {
          "content": {}
        },
        "yNnJGUyTSts=": {
          "content": {
            "homeDir.+": "ex on 3"
          }
        }
      }
    }
  }
}
```

```
go run ./apps/cnquery scan -f ~/Downloads/packprops.mql.yaml --json --props userHome="return 'foo'" | jq .
```

```json
{
  "assets": {
    "//explorer.api.mondoo.com/assets/309tWggTTzYD0E1FDi20NmN4Bh2": {
      "mrn": "//explorer.api.mondoo.com/assets/309tWggTTzYD0E1FDi20NmN4Bh2",
      "name": "planetexpress"
    }
  },
  "data": {
    "//explorer.api.mondoo.com/assets/309tWggTTzYD0E1FDi20NmN4Bh2": {
      "values": {
        "FCEF4O8XoOs=": {
          "content": {
            "user.+": "ada is the user"
          }
        },
        "JvBACGPwF6o=": {
          "content": {}
        },
        "NsipGp24tRk=": {
          "content": {
            "home.+": "foo on 1"
          }
        },
        "OAKBq9so/78=": {
          "content": {}
        },
        "OU6YpdHiWPQ=": {
          "content": {
            "home.+": "foo on 2"
          }
        },
        "yNnJGUyTSts=": {
          "content": {
            "homeDir.+": "foo on 3"
          }
        }
      }
    }
  }
}
```

```
# packprops2.mql.yaml
packs:
  - uid: example1
    name: Example policy 1
    version: "1.0.0"
    authors:
      - name: Mondoo
        email: hello@mondoo.com
    groups:
      - title: group1
        filters: return true
        queries:
          - uid: variant-1
          - uid: variant-2
          - uid: variant-3
          - uid: variant-4
queries:
  - uid: variant-check
    title: Variant check
    variants:
      - uid: variant-1
      - uid: variant-2
      - uid: variant-3

  - uid: variant-1
    mql: props.home + " on 1"
    props:
      - uid: home
        mql: return "p1"

  - uid: variant-2
    mql: props.home + " on 2"
    props:
      - uid: home
        mql: return "p2"

  - uid: variant-3
    mql: props.homeDir + " on 3"
    props:
      - uid: homeDir
        mql: return "p3"

  - uid: variant-4
    mql: props.user + " is the user"
    props:
      - uid: user
        mql: return "ada"
```

```
go run ./apps/cnquery scan -f ~/Downloads/packprops.mql.yaml --json --props home="return 'foo'" | jq .
```

```
{
  "assets": {
    "//explorer.api.mondoo.com/assets/309tniQ7vAYnVTMznDD7A94kqEV": {
      "mrn": "//explorer.api.mondoo.com/assets/309tniQ7vAYnVTMznDD7A94kqEV",
      "name": "planetexpress"
    }
  },
  "data": {
    "//explorer.api.mondoo.com/assets/309tniQ7vAYnVTMznDD7A94kqEV": {
      "values": {
        "FCEF4O8XoOs=": {
          "content": {
            "user.+": "ada is the user"
          }
        },
        "JvBACGPwF6o=": {
          "content": {}
        },
        "NsipGp24tRk=": {
          "content": {
            "home.+": "foo on 1"
          }
        },
        "OAKBq9so/78=": {
          "content": {}
        },
        "OU6YpdHiWPQ=": {
          "content": {
            "home.+": "foo on 2"
          }
        },
        "SHIUM1ACvIk=": {
          "content": {}
        },
        "yNnJGUyTSts=": {
          "content": {
            "homeDir.+": "p3 on 3"
          }
        }
      }
    }
  }
}
```

