### PR TITLE
Removed Index path as it breaks the html of the releases website

### DIFF
--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -216,4 +216,3 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           repository: "mondoohq/releasr"
           event-type: reindex
-          client-payload: '{ "reindex-path": "providers" }'


### PR DESCRIPTION
When this runs the releases website only lists the providers package

<img width="894" height="304" alt="image" src="https://github.com/user-attachments/assets/d099e4b2-9b40-4886-9b07-58f0324b62c6" />

I've check the times of the workflow and there is no speed advantage for only reindexing a certain path due to the way it evaluates the bucket contents.

Remote Call - https://github.com/mondoohq/releasr/actions/runs/16296722224

Manual Trigger - https://github.com/mondoohq/releasr/actions/runs/16343633311

I'm proposing here to remove that path and just leave the job to run with the defaults.  Which is what I have to run to fix it :)

