### PR TITLE
Fix dict array dict

### DIFF
--- a/llx/builtin_map.go
+++ b/llx/builtin_map.go
@@ -364,9 +364,17 @@ func dictGetIndexV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (
 		if t != types.Int {
 			return nil, 0, errors.New("Called [] with wrong type " + t.Label())
 		}
-		// ^^ TODO
 
 		key := int(bytes2int(args[0].Value))
+		if key < 0 {
+			if -key > len(x) {
+				return nil, 0, errors.New("array index out of bound (trying to access element " + strconv.Itoa(key) + ", max: " + strconv.Itoa(len(x)-1) + ")")
+			}
+			key = len(x) + key
+		}
+		if key >= len(x) {
+			return nil, 0, errors.New("array index out of bound (trying to access element " + strconv.Itoa(key) + ", max: " + strconv.Itoa(len(x)-1) + ")")
+		}
 		return &RawData{
 			Value: x[key],
 			Type:  bind.Type,

--- a/mql/mql_test.go
+++ b/mql/mql_test.go
@@ -102,6 +102,40 @@ func TestCustomData(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{"a": "valuea", "b": "valueb"}, value.Value)
 }
 
+func TestJsonArrayBounds(t *testing.T) {
+	t.Run("out of bounds", func(t *testing.T) {
+		query := `x = parse.json(content: '{"arr": []}').params
+	x['arr'][0]`
+		value, err := mql.Exec(query, runtime(), features, nil)
+		require.NoError(t, err)
+		require.Contains(t, value.Error.Error(), "array index out of bound")
+	})
+
+	t.Run("positive index", func(t *testing.T) {
+		query := `x = parse.json(content: '{"arr": [1, 2, 3]}').params
+x['arr'][1]`
+		value, err := mql.Exec(query, runtime(), features, nil)
+		require.NoError(t, err)
+		require.Equal(t, float64(2), value.Value)
+	})
+
+	t.Run("negative index", func(t *testing.T) {
+		query := `x = parse.json(content: '{"arr": [1, 2, 3]}').params
+x['arr'][-1]`
+		value, err := mql.Exec(query, runtime(), features, nil)
+		require.NoError(t, err)
+		require.Equal(t, float64(3), value.Value)
+	})
+
+	t.Run("negative index out of bounds", func(t *testing.T) {
+		query := `x = parse.json(content: '{"arr": [1, 2, 3]}').params
+x['arr'][-4]`
+		value, err := mql.Exec(query, runtime(), features, nil)
+		require.NoError(t, err)
+		require.Contains(t, value.Error.Error(), "array index out of bound")
+	})
+}
+
 func TestMqlProps(t *testing.T) {
 	query := "props.a + props.b"
 	props := map[string]*llx.Primitive{


### PR DESCRIPTION
I can get cnquery to panic with the following:
```
go run ./apps/cnspec/ run local -c "
lsblkDevice = parse.json(content: command('lsblk -a --json -s overlay').stdout).params
lsblkDevice['blockdevices'][0]['children'][0]['type'] == 'crypt' || lsblkDevice['blockdevices'][0]['type'] == 'crypt'
"
```

```
panic: runtime error: index out of range [0] with length 0

goroutine 93 [running]:
go.mondoo.com/cnquery/v11/llx.dictGetIndexV2(0x32c9590?, 0xc001b86180, 0x2cd4c13?, 0x2?)
	/home/jaym/workspace/mondoo/cnquery/llx/builtin_map.go:371 +0x64b
go.mondoo.com/cnquery/v11/llx.(*blockExecutor).runBoundFunction(0xc0004a9f10, 0xc001b86180, 0xc00181c280, 0x100000007)
	/home/jaym/workspace/mondoo/cnquery/llx/builtin.go:905 +0x16e
go.mondoo.com/cnquery/v11/llx.(*blockExecutor).runFunction(0xc0004a9f10, 0xc00181c280, 0x100000007)
	/home/jaym/workspace/mondoo/cnquery/llx/llx.go:816 +0x173
go.mondoo.com/cnquery/v11/llx.(*blockExecutor).runChunk(0xc0004a9f10, 0xc0017d9058?, 0x100000007)
	/home/jaym/workspace/mondoo/cnquery/llx/llx.go:833 +0x225
go.mondoo.com/cnquery/v11/llx.(*blockExecutor).runRef(0xc001a84b60?, 0x0?)
	/home/jaym/workspace/mondoo/cnquery/llx/llx.go:858 +0xd9
go.mondoo.com/cnquery/v11/llx.(*blockExecutor).runChain(0xc0004a9f10, 0x40cae6?)
	/home/jaym/workspace/mondoo/cnquery/llx/llx.go:890 +0x94
go.mondoo.com/cnquery/v11/llx.(*blockExecutor).triggerChain(0xc0004a9f10, 0x100000004, 0xc001b860f0)
	/home/jaym/workspace/mondoo/cnquery/llx/llx.go:962 +0x32e
go.mondoo.com/cnquery/v11/llx.runResourceFunction.func1({0x2886360, 0xc001b86060}, {0x0, 0x0})
	/home/jaym/workspace/mondoo/cnquery/llx/builtin.go:852 +0x209
go.mondoo.com/cnquery/v11/providers.(*Runtime).WatchAndUpdate(0xc000679780, {0x3269188, 0xc001908440}, {0xc0011bfd00, 0x6}, {0xc0012cc100, 0x31}, 0xc001902ea0)
	/home/jaym/workspace/mondoo/cnquery/providers/runtime.go:385 +0xe2
go.mondoo.com/cnquery/v11/llx.runResourceFunction(0xc0004a9f10, 0xc001902e40?, 0xc00181c0f0, 0x100000004)
	/home/jaym/workspace/mondoo/cnquery/llx/builtin.go:833 +0x2d7
go.mondoo.com/cnquery/v11/llx.(*blockExecutor).runBoundFunction(0xc0004a9f10, 0xc001902e40, 0xc00181c0f0, 0x100000004)
	/home/jaym/workspace/mondoo/cnquery/llx/builtin.go:899 +0x38a
go.mondoo.com/cnquery/v11/llx.(*blockExecutor).runFunction(0xc0004a9f10, 0xc00181c0f0, 0x100000004)
	/home/jaym/workspace/mondoo/cnquery/llx/llx.go:816 +0x173
go.mondoo.com/cnquery/v11/llx.(*blockExecutor).runChunk(0xc0004a9f10, 0xc0017d9528?, 0x100000004)
	/home/jaym/workspace/mondoo/cnquery/llx/llx.go:833 +0x225
go.mondoo.com/cnquery/v11/llx.(*blockExecutor).runRef(0xc001a84b60?, 0xc00056f6e0?)
	/home/jaym/workspace/mondoo/cnquery/llx/llx.go:858 +0xd9
go.mondoo.com/cnquery/v11/llx.(*blockExecutor).runChain(0xc0004a9f10, 0x40cae6?)
	/home/jaym/workspace/mondoo/cnquery/llx/llx.go:890 +0x94
go.mondoo.com/cnquery/v11/llx.(*blockExecutor).triggerChain(0xc0004a9f10, 0x100000002, 0xc00056f710)
	/home/jaym/workspace/mondoo/cnquery/llx/llx.go:962 +0x32e
go.mondoo.com/cnquery/v11/llx.runResourceFunction.func1({0x26848e0, 0xc00178e570}, {0x0, 0x0})
	/home/jaym/workspace/mondoo/cnquery/llx/builtin.go:852 +0x209
go.mondoo.com/cnquery/v11/providers.(*Runtime).WatchAndUpdate(0xc000679780, {0x3269188, 0xc000ac39e0}, {0xc0011bfcf8, 0x6}, {0xc0011c9f00, 0x31}, 0xc00182c3c0)
	/home/jaym/workspace/mondoo/cnquery/providers/runtime.go:385 +0xe2
go.mondoo.com/cnquery/v11/llx.runResourceFunction(0xc0004a9f10, 0xc00182c360?, 0xc000b0fef0, 0x100000002)
	/home/jaym/workspace/mondoo/cnquery/llx/builtin.go:833 +0x2d7
go.mondoo.com/cnquery/v11/llx.(*blockExecutor).runBoundFunction(0xc0004a9f10, 0xc00182c360, 0xc000b0fef0, 0x100000002)
	/home/jaym/workspace/mondoo/cnquery/llx/builtin.go:899 +0x38a
go.mondoo.com/cnquery/v11/llx.(*blockExecutor).runFunction(0xc0004a9f10, 0xc000b0fef0, 0x100000002)
	/home/jaym/workspace/mondoo/cnquery/llx/llx.go:816 +0x173
go.mondoo.com/cnquery/v11/llx.(*blockExecutor).runChunk(0xc0004a9f10, 0xc00182b9f8?, 0x100000002)
	/home/jaym/workspace/mondoo/cnquery/llx/llx.go:833 +0x225
go.mondoo.com/cnquery/v11/llx.(*blockExecutor).runRef(0xc001a84b60?, 0xc0000e7a70?)
	/home/jaym/workspace/mondoo/cnquery/llx/llx.go:858 +0xd9
go.mondoo.com/cnquery/v11/llx.(*blockExecutor).runChain(0xc0004a9f10, 0x2cdb239?)
	/home/jaym/workspace/mondoo/cnquery/llx/llx.go:890 +0x94
go.mondoo.com/cnquery/v11/llx.(*blockExecutor).run(0xc0004a9f10)
	/home/jaym/workspace/mondoo/cnquery/llx/llx.go:358 +0x317
go.mondoo.com/cnquery/v11/llx.(*MQLExecutorV2).Run(0xc000d0f140?)
	/home/jaym/workspace/mondoo/cnquery/llx/llx.go:288 +0x53
go.mondoo.com/cnquery/v11/mql/internal.(*executionManager).executeCodeBundle(0xc000d0f440, 0xc0011e0be0, 0xc001a81c20, {0x0, 0x0})
	/home/jaym/workspace/mondoo/cnquery/mql/internal/execution_manager.go:170 +0x5b9
go.mondoo.com/cnquery/v11/mql/internal.(*executionManager).Start.func1()
	/home/jaym/workspace/mondoo/cnquery/mql/internal/execution_manager.go:88 +0x1cb
created by go.mondoo.com/cnquery/v11/mql/internal.(*executionManager).Start in goroutine 1
	/home/jaym/workspace/mondoo/cnquery/mql/internal/execution_manager.go:57 +0x65
```

I've made the index lookup behave like a regular typed array