### PR TITLE
Migrate Code Signing from DigiCert to Azure Trusted Signer

### DIFF
--- a/.github/.goreleaser-unstable.yml
+++ b/.github/.goreleaser-unstable.yml
@@ -10,45 +10,45 @@ before:
   hooks:
     - make providers
 builds:
-  # - id: linux
-  #   main: ./apps/cnquery/cnquery.go
-  #   binary: cnquery
-  #   goos:
-  #     - linux
-  #   goarch:
-  #     - amd64
-  #     - 386
-  #     - arm64
-  #     - arm
-  #     - ppc64le
-  #     - s390x
-  #   # ARM 6= Raspberry Pi A, A+, B, B+, Zero
-  #   # ARM 7= Raspberry Pi 2, 3, 4
-  #   goarm:
-  #     - 6
-  #     - 7
-  #   flags:
-  #     - -tags="production netgo"
-  #   ldflags:
-  #     - "-extldflags=-static"
-  #     - -s -w -X go.mondoo.com/cnquery/v9.Version={{.Version}} -X go.mondoo.com/cnquery/v9.Build={{.ShortCommit}} -X go.mondoo.com/cnquery/v9.Date={{.Date}}
-  # - id: macos
-  #   main: ./apps/cnquery/cnquery.go
-  #   binary: cnquery
-  #   goos:
-  #     - darwin
-  #   goarch:
-  #     - amd64
-  #     - arm64
-  #   flags: -tags production
-  #   ldflags:
-  #     # clang + macos does not support static: - -extldflags "-static"
-  #     - -s -w -X go.mondoo.com/cnquery/v9.Version={{.Version}} -X go.mondoo.com/cnquery/v9.Build={{.ShortCommit}} -X go.mondoo.com/cnquery/v9.Date={{.Date}}
-  #   hooks:
-  #     post:
-  #       - cmd: /tmp/quill sign-and-notarize "{{ .Path }}" -vv || true
-  #         env:
-  #           - QUILL_LOG_FILE=/tmp/quill-{{ .Target }}.log
+  - id: linux
+    main: ./apps/cnquery/cnquery.go
+    binary: cnquery
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - 386
+      - arm64
+      - arm
+      - ppc64le
+      - s390x
+    # ARM 6= Raspberry Pi A, A+, B, B+, Zero
+    # ARM 7= Raspberry Pi 2, 3, 4
+    goarm:
+      - 6
+      - 7
+    flags:
+      - -tags="production netgo"
+    ldflags:
+      - "-extldflags=-static"
+      - -s -w -X go.mondoo.com/cnquery/v9.Version={{.Version}} -X go.mondoo.com/cnquery/v9.Build={{.ShortCommit}} -X go.mondoo.com/cnquery/v9.Date={{.Date}}
+  - id: macos
+    main: ./apps/cnquery/cnquery.go
+    binary: cnquery
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    flags: -tags production
+    ldflags:
+      # clang + macos does not support static: - -extldflags "-static"
+      - -s -w -X go.mondoo.com/cnquery/v9.Version={{.Version}} -X go.mondoo.com/cnquery/v9.Build={{.ShortCommit}} -X go.mondoo.com/cnquery/v9.Date={{.Date}}
+    hooks:
+      post:
+        - cmd: /tmp/quill sign-and-notarize "{{ .Path }}" -vv || true
+          env:
+            - QUILL_LOG_FILE=/tmp/quill-{{ .Target }}.log
   - id: windows
     main: ./apps/cnquery/cnquery.go
     binary: cnquery
@@ -65,215 +65,214 @@ builds:
     hooks:
       post:
         - cmd: jsign --storetype TRUSTEDSIGNING --keystore {{ .Env.TSIGN_AZURE_ENDPOINT }} --storepass {{ .Env.TSIGN_ACCESS_TOKEN }} --alias {{ .Env.TSIGN_ACCOUNT_NAME }}/{{ .Env.TSIGN_CERT_PROFILE_NAME }} '{{ .Path }}'
-
-# nfpms:
-  # -
-  #   maintainer: Mondoo <hello@mondoo.com>
-  #   description: Cloud-Native Asset Inventory Framework
-  #   homepage: https://mondoo.com/
-  #   vendor: Mondoo, Inc
-  #   license: MPL-2.0
-  #   formats:
-  #     - deb
-  #     - rpm
-  #   rpm:
-  #     signature:
-  #       key_file: '{{ .Env.GPG_KEY_PATH }}'
+nfpms:
+  -
+    maintainer: Mondoo <hello@mondoo.com>
+    description: Cloud-Native Asset Inventory Framework
+    homepage: https://mondoo.com/
+    vendor: Mondoo, Inc
+    license: MPL-2.0
+    formats:
+      - deb
+      - rpm
+    rpm:
+      signature:
+        key_file: '{{ .Env.GPG_KEY_PATH }}'
 archives:
   - id: releases
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     files:
       - none*
 checksum:
   name_template: '{{ .ProjectName }}_v{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 snapshot:
-  name_template: "{{ .Tag }}-snapshot"
+  version_template: "{{ .Tag }}-snapshot"
 changelog:
   use: github-native
-# dockers: # https://goreleaser.com/customization/docker/
-#     # UBI containers
-#   - use: buildx
-#     goos: linux
-#     goarch: amd64
-#     dockerfile: Dockerfile-ubi
-#     image_templates:
-#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64"
-#     build_flag_templates:
-#       - "--platform=linux/amd64"
-#       - "--label=org.opencontainers.image.created={{.Date}}"
-#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
-#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-#       - "--label=org.opencontainers.image.version={{.Version}}"
-#       - "--target=root"
-#   - use: buildx
-#     goos: linux
-#     goarch: arm64
-#     dockerfile: Dockerfile-ubi
-#     image_templates:
-#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64"
-#     build_flag_templates:
-#       - "--platform=linux/arm64"
-#       - "--label=org.opencontainers.image.created={{.Date}}"
-#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
-#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-#       - "--label=org.opencontainers.image.version={{.Version}}"
-#       - "--target=root"
-#     # Standard containers
-#   - use: buildx
-#     goos: linux
-#     goarch: amd64
-#     image_templates:
-#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-amd64"
-#     build_flag_templates:
-#       - "--platform=linux/amd64"
-#       - "--label=org.opencontainers.image.created={{.Date}}"
-#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
-#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-#       - "--label=org.opencontainers.image.version={{.Version}}"
-#       - "--target=root"
-#   - use: buildx
-#     goos: linux
-#     goarch: arm64
-#     image_templates:
-#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8"
-#     build_flag_templates:
-#       - "--platform=linux/arm64/v8"
-#       - "--label=org.opencontainers.image.created={{.Date}}"
-#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
-#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-#       - "--label=org.opencontainers.image.version={{.Version}}"
-#       - "--target=root"
-#   - use: buildx
-#     goos: linux
-#     goarch: arm
-#     goarm: 6
-#     image_templates:
-#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv6"
-#     build_flag_templates:
-#       - "--platform=linux/arm/v6"
-#       - "--label=org.opencontainers.image.created={{.Date}}"
-#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
-#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-#       - "--label=org.opencontainers.image.version={{.Version}}"
-#       - "--target=root"
-#   - use: buildx
-#     goos: linux
-#     goarch: arm
-#     goarm: 7
-#     image_templates:
-#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv7"
-#     build_flag_templates:
-#       - "--platform=linux/arm/v7"
-#       - "--label=org.opencontainers.image.created={{.Date}}"
-#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
-#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-#       - "--label=org.opencontainers.image.version={{.Version}}"
-#       - "--target=root"
-#   # Rootless
-#     # UBI containers
-#   - use: buildx
-#     goos: linux
-#     goarch: amd64
-#     dockerfile: Dockerfile-ubi
-#     image_templates:
-#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64-rootless"
-#     build_flag_templates:
-#       - "--platform=linux/amd64"
-#       - "--label=org.opencontainers.image.created={{.Date}}"
-#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
-#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-#       - "--label=org.opencontainers.image.version={{.Version}}"
-#       - "--target=rootless"
-#   - use: buildx
-#     goos: linux
-#     goarch: arm64
-#     dockerfile: Dockerfile-ubi
-#     image_templates:
-#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64-rootless"
-#     build_flag_templates:
-#       - "--platform=linux/arm64/v8"
-#       - "--label=org.opencontainers.image.created={{.Date}}"
-#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
-#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-#       - "--label=org.opencontainers.image.version={{.Version}}"
-#       - "--target=rootless"
-#     # Standard containers
-#   - use: buildx
-#     goos: linux
-#     goarch: amd64
-#     image_templates:
-#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-amd64-rootless"
-#     build_flag_templates:
-#       - "--platform=linux/amd64"
-#       - "--label=org.opencontainers.image.created={{.Date}}"
-#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
-#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-#       - "--label=org.opencontainers.image.version={{.Version}}"
-#       - "--target=rootless"
-#   - use: buildx
-#     goos: linux
-#     goarch: arm64
-#     image_templates:
-#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8-rootless"
-#     build_flag_templates:
-#       - "--platform=linux/arm64/v8"
-#       - "--label=org.opencontainers.image.created={{.Date}}"
-#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
-#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-#       - "--label=org.opencontainers.image.version={{.Version}}"
-#       - "--target=rootless"
-#   - use: buildx
-#     goos: linux
-#     goarch: arm
-#     goarm: 6
-#     image_templates:
-#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv6-rootless"
-#     build_flag_templates:
-#       - "--platform=linux/arm/v6"
-#       - "--label=org.opencontainers.image.created={{.Date}}"
-#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
-#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-#       - "--label=org.opencontainers.image.version={{.Version}}"
-#       - "--target=rootless"
-#   - use: buildx
-#     goos: linux
-#     goarch: arm
-#     goarm: 7
-#     image_templates:
-#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv7-rootless"
-#     build_flag_templates:
-#       - "--platform=linux/arm/v7"
-#       - "--label=org.opencontainers.image.created={{.Date}}"
-#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
-#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-#       - "--label=org.opencontainers.image.version={{.Version}}"
-#       - "--target=rootless"
-# docker_manifests:  # https://goreleaser.com/customization/docker_manifest/
-#     # UBI containers
-#   - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}-ubi
-#     image_templates:
-#       - mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64
-#       - mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64
-#     # Standard containers
-#   - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}
-#     image_templates:
-#       - mondoo/{{ .ProjectName }}:{{ .Version }}-amd64
-#       - mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8
-#       - mondoo/{{ .ProjectName }}:{{ .Version }}-armv6
-#       - mondoo/{{ .ProjectName }}:{{ .Version }}-armv7
-#   # Rootless
-#     # UBI containers
-#   - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-rootless
-#     image_templates:
-#       - mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64-rootless
-#       - mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64-rootless
-#     # Standard containers
-#   - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}-rootless
-#     image_templates:
-#       - mondoo/{{ .ProjectName }}:{{ .Version }}-amd64-rootless
-#       - mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8-rootless
-#       - mondoo/{{ .ProjectName }}:{{ .Version }}-armv6-rootless
-#       - mondoo/{{ .ProjectName }}:{{ .Version }}-armv7-rootless
+dockers: # https://goreleaser.com/customization/docker/
+    # UBI containers
+  - use: buildx
+    goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile-ubi
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--target=root"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile-ubi
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64"
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--target=root"
+    # Standard containers
+  - use: buildx
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:{{ .Version }}-amd64"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--target=root"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8"
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--target=root"
+  - use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 6
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv6"
+    build_flag_templates:
+      - "--platform=linux/arm/v6"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--target=root"
+  - use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 7
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv7"
+    build_flag_templates:
+      - "--platform=linux/arm/v7"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--target=root"
+  # Rootless
+    # UBI containers
+  - use: buildx
+    goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile-ubi
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64-rootless"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--target=rootless"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile-ubi
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64-rootless"
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--target=rootless"
+    # Standard containers
+  - use: buildx
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:{{ .Version }}-amd64-rootless"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--target=rootless"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8-rootless"
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--target=rootless"
+  - use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 6
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv6-rootless"
+    build_flag_templates:
+      - "--platform=linux/arm/v6"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--target=rootless"
+  - use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 7
+    image_templates:
+      - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv7-rootless"
+    build_flag_templates:
+      - "--platform=linux/arm/v7"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--target=rootless"
+docker_manifests:  # https://goreleaser.com/customization/docker_manifest/
+    # UBI containers
+  - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}-ubi
+    image_templates:
+      - mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64
+      - mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64
+    # Standard containers
+  - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}
+    image_templates:
+      - mondoo/{{ .ProjectName }}:{{ .Version }}-amd64
+      - mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8
+      - mondoo/{{ .ProjectName }}:{{ .Version }}-armv6
+      - mondoo/{{ .ProjectName }}:{{ .Version }}-armv7
+  # Rootless
+    # UBI containers
+  - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-rootless
+    image_templates:
+      - mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64-rootless
+      - mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64-rootless
+    # Standard containers
+  - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}-rootless
+    image_templates:
+      - mondoo/{{ .ProjectName }}:{{ .Version }}-amd64-rootless
+      - mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8-rootless
+      - mondoo/{{ .ProjectName }}:{{ .Version }}-armv6-rootless
+      - mondoo/{{ .ProjectName }}:{{ .Version }}-armv7-rootless

--- a/.github/.goreleaser-unstable.yml
+++ b/.github/.goreleaser-unstable.yml
@@ -10,45 +10,45 @@ before:
   hooks:
     - make providers
 builds:
-  - id: linux
-    main: ./apps/cnquery/cnquery.go
-    binary: cnquery
-    goos:
-      - linux
-    goarch:
-      - amd64
-      - 386
-      - arm64
-      - arm
-      - ppc64le
-      - s390x
-    # ARM 6= Raspberry Pi A, A+, B, B+, Zero
-    # ARM 7= Raspberry Pi 2, 3, 4
-    goarm:
-      - 6
-      - 7
-    flags:
-      - -tags="production netgo"
-    ldflags:
-      - "-extldflags=-static"
-      - -s -w -X go.mondoo.com/cnquery/v9.Version={{.Version}} -X go.mondoo.com/cnquery/v9.Build={{.ShortCommit}} -X go.mondoo.com/cnquery/v9.Date={{.Date}}
-  - id: macos
-    main: ./apps/cnquery/cnquery.go
-    binary: cnquery
-    goos:
-      - darwin
-    goarch:
-      - amd64
-      - arm64
-    flags: -tags production
-    ldflags:
-      # clang + macos does not support static: - -extldflags "-static"
-      - -s -w -X go.mondoo.com/cnquery/v9.Version={{.Version}} -X go.mondoo.com/cnquery/v9.Build={{.ShortCommit}} -X go.mondoo.com/cnquery/v9.Date={{.Date}}
-    hooks:
-      post:
-        - cmd: /tmp/quill sign-and-notarize "{{ .Path }}" -vv || true
-          env:
-            - QUILL_LOG_FILE=/tmp/quill-{{ .Target }}.log
+  # - id: linux
+  #   main: ./apps/cnquery/cnquery.go
+  #   binary: cnquery
+  #   goos:
+  #     - linux
+  #   goarch:
+  #     - amd64
+  #     - 386
+  #     - arm64
+  #     - arm
+  #     - ppc64le
+  #     - s390x
+  #   # ARM 6= Raspberry Pi A, A+, B, B+, Zero
+  #   # ARM 7= Raspberry Pi 2, 3, 4
+  #   goarm:
+  #     - 6
+  #     - 7
+  #   flags:
+  #     - -tags="production netgo"
+  #   ldflags:
+  #     - "-extldflags=-static"
+  #     - -s -w -X go.mondoo.com/cnquery/v9.Version={{.Version}} -X go.mondoo.com/cnquery/v9.Build={{.ShortCommit}} -X go.mondoo.com/cnquery/v9.Date={{.Date}}
+  # - id: macos
+  #   main: ./apps/cnquery/cnquery.go
+  #   binary: cnquery
+  #   goos:
+  #     - darwin
+  #   goarch:
+  #     - amd64
+  #     - arm64
+  #   flags: -tags production
+  #   ldflags:
+  #     # clang + macos does not support static: - -extldflags "-static"
+  #     - -s -w -X go.mondoo.com/cnquery/v9.Version={{.Version}} -X go.mondoo.com/cnquery/v9.Build={{.ShortCommit}} -X go.mondoo.com/cnquery/v9.Date={{.Date}}
+  #   hooks:
+  #     post:
+  #       - cmd: /tmp/quill sign-and-notarize "{{ .Path }}" -vv || true
+  #         env:
+  #           - QUILL_LOG_FILE=/tmp/quill-{{ .Target }}.log
   - id: windows
     main: ./apps/cnquery/cnquery.go
     binary: cnquery
@@ -65,19 +65,19 @@ builds:
     hooks:
       post:
         - cmd: jsign --storetype DIGICERTONE --alias "{{ .Env.SM_CERT_ALIAS }}" --storepass "{{ .Env.SM_API_KEY }}|{{ .Env.SM_CLIENT_CERT_FILE}}|{{ .Env.SM_CLIENT_CERT_PASSWORD }}" --tsaurl "http://timestamp.digicert.com" '{{ .Path }}'
-nfpms:
-  -
-    maintainer: Mondoo <hello@mondoo.com>
-    description: Cloud-Native Asset Inventory Framework
-    homepage: https://mondoo.com/
-    vendor: Mondoo, Inc
-    license: MPL-2.0
-    formats:
-      - deb
-      - rpm
-    rpm:
-      signature:
-        key_file: '{{ .Env.GPG_KEY_PATH }}'
+# nfpms:
+  # -
+  #   maintainer: Mondoo <hello@mondoo.com>
+  #   description: Cloud-Native Asset Inventory Framework
+  #   homepage: https://mondoo.com/
+  #   vendor: Mondoo, Inc
+  #   license: MPL-2.0
+  #   formats:
+  #     - deb
+  #     - rpm
+  #   rpm:
+  #     signature:
+  #       key_file: '{{ .Env.GPG_KEY_PATH }}'
 archives:
   - id: releases
     format_overrides:
@@ -92,187 +92,187 @@ snapshot:
   name_template: "{{ .Tag }}-snapshot"
 changelog:
   use: github-native
-dockers: # https://goreleaser.com/customization/docker/
-    # UBI containers
-  - use: buildx
-    goos: linux
-    goarch: amd64
-    dockerfile: Dockerfile-ubi
-    image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64"
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--target=root"
-  - use: buildx
-    goos: linux
-    goarch: arm64
-    dockerfile: Dockerfile-ubi
-    image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64"
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--target=root"
-    # Standard containers
-  - use: buildx
-    goos: linux
-    goarch: amd64
-    image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-amd64"
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--target=root"
-  - use: buildx
-    goos: linux
-    goarch: arm64
-    image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8"
-    build_flag_templates:
-      - "--platform=linux/arm64/v8"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--target=root"
-  - use: buildx
-    goos: linux
-    goarch: arm
-    goarm: 6
-    image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv6"
-    build_flag_templates:
-      - "--platform=linux/arm/v6"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--target=root"
-  - use: buildx
-    goos: linux
-    goarch: arm
-    goarm: 7
-    image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv7"
-    build_flag_templates:
-      - "--platform=linux/arm/v7"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--target=root"
-  # Rootless
-    # UBI containers
-  - use: buildx
-    goos: linux
-    goarch: amd64
-    dockerfile: Dockerfile-ubi
-    image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64-rootless"
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--target=rootless"
-  - use: buildx
-    goos: linux
-    goarch: arm64
-    dockerfile: Dockerfile-ubi
-    image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64-rootless"
-    build_flag_templates:
-      - "--platform=linux/arm64/v8"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--target=rootless"
-    # Standard containers
-  - use: buildx
-    goos: linux
-    goarch: amd64
-    image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-amd64-rootless"
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--target=rootless"
-  - use: buildx
-    goos: linux
-    goarch: arm64
-    image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8-rootless"
-    build_flag_templates:
-      - "--platform=linux/arm64/v8"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--target=rootless"
-  - use: buildx
-    goos: linux
-    goarch: arm
-    goarm: 6
-    image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv6-rootless"
-    build_flag_templates:
-      - "--platform=linux/arm/v6"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--target=rootless"
-  - use: buildx
-    goos: linux
-    goarch: arm
-    goarm: 7
-    image_templates:
-      - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv7-rootless"
-    build_flag_templates:
-      - "--platform=linux/arm/v7"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--target=rootless"
-docker_manifests:  # https://goreleaser.com/customization/docker_manifest/
-    # UBI containers
-  - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}-ubi
-    image_templates:
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64
-    # Standard containers
-  - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}
-    image_templates:
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-amd64
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-armv6
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-armv7
-  # Rootless
-    # UBI containers
-  - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-rootless
-    image_templates:
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64-rootless
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64-rootless
-    # Standard containers
-  - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}-rootless
-    image_templates:
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-amd64-rootless
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8-rootless
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-armv6-rootless
-      - mondoo/{{ .ProjectName }}:{{ .Version }}-armv7-rootless
+# dockers: # https://goreleaser.com/customization/docker/
+#     # UBI containers
+#   - use: buildx
+#     goos: linux
+#     goarch: amd64
+#     dockerfile: Dockerfile-ubi
+#     image_templates:
+#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64"
+#     build_flag_templates:
+#       - "--platform=linux/amd64"
+#       - "--label=org.opencontainers.image.created={{.Date}}"
+#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
+#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+#       - "--label=org.opencontainers.image.version={{.Version}}"
+#       - "--target=root"
+#   - use: buildx
+#     goos: linux
+#     goarch: arm64
+#     dockerfile: Dockerfile-ubi
+#     image_templates:
+#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64"
+#     build_flag_templates:
+#       - "--platform=linux/arm64"
+#       - "--label=org.opencontainers.image.created={{.Date}}"
+#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
+#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+#       - "--label=org.opencontainers.image.version={{.Version}}"
+#       - "--target=root"
+#     # Standard containers
+#   - use: buildx
+#     goos: linux
+#     goarch: amd64
+#     image_templates:
+#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-amd64"
+#     build_flag_templates:
+#       - "--platform=linux/amd64"
+#       - "--label=org.opencontainers.image.created={{.Date}}"
+#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
+#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+#       - "--label=org.opencontainers.image.version={{.Version}}"
+#       - "--target=root"
+#   - use: buildx
+#     goos: linux
+#     goarch: arm64
+#     image_templates:
+#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8"
+#     build_flag_templates:
+#       - "--platform=linux/arm64/v8"
+#       - "--label=org.opencontainers.image.created={{.Date}}"
+#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
+#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+#       - "--label=org.opencontainers.image.version={{.Version}}"
+#       - "--target=root"
+#   - use: buildx
+#     goos: linux
+#     goarch: arm
+#     goarm: 6
+#     image_templates:
+#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv6"
+#     build_flag_templates:
+#       - "--platform=linux/arm/v6"
+#       - "--label=org.opencontainers.image.created={{.Date}}"
+#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
+#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+#       - "--label=org.opencontainers.image.version={{.Version}}"
+#       - "--target=root"
+#   - use: buildx
+#     goos: linux
+#     goarch: arm
+#     goarm: 7
+#     image_templates:
+#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv7"
+#     build_flag_templates:
+#       - "--platform=linux/arm/v7"
+#       - "--label=org.opencontainers.image.created={{.Date}}"
+#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
+#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+#       - "--label=org.opencontainers.image.version={{.Version}}"
+#       - "--target=root"
+#   # Rootless
+#     # UBI containers
+#   - use: buildx
+#     goos: linux
+#     goarch: amd64
+#     dockerfile: Dockerfile-ubi
+#     image_templates:
+#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64-rootless"
+#     build_flag_templates:
+#       - "--platform=linux/amd64"
+#       - "--label=org.opencontainers.image.created={{.Date}}"
+#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
+#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+#       - "--label=org.opencontainers.image.version={{.Version}}"
+#       - "--target=rootless"
+#   - use: buildx
+#     goos: linux
+#     goarch: arm64
+#     dockerfile: Dockerfile-ubi
+#     image_templates:
+#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64-rootless"
+#     build_flag_templates:
+#       - "--platform=linux/arm64/v8"
+#       - "--label=org.opencontainers.image.created={{.Date}}"
+#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
+#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+#       - "--label=org.opencontainers.image.version={{.Version}}"
+#       - "--target=rootless"
+#     # Standard containers
+#   - use: buildx
+#     goos: linux
+#     goarch: amd64
+#     image_templates:
+#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-amd64-rootless"
+#     build_flag_templates:
+#       - "--platform=linux/amd64"
+#       - "--label=org.opencontainers.image.created={{.Date}}"
+#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
+#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+#       - "--label=org.opencontainers.image.version={{.Version}}"
+#       - "--target=rootless"
+#   - use: buildx
+#     goos: linux
+#     goarch: arm64
+#     image_templates:
+#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8-rootless"
+#     build_flag_templates:
+#       - "--platform=linux/arm64/v8"
+#       - "--label=org.opencontainers.image.created={{.Date}}"
+#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
+#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+#       - "--label=org.opencontainers.image.version={{.Version}}"
+#       - "--target=rootless"
+#   - use: buildx
+#     goos: linux
+#     goarch: arm
+#     goarm: 6
+#     image_templates:
+#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv6-rootless"
+#     build_flag_templates:
+#       - "--platform=linux/arm/v6"
+#       - "--label=org.opencontainers.image.created={{.Date}}"
+#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
+#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+#       - "--label=org.opencontainers.image.version={{.Version}}"
+#       - "--target=rootless"
+#   - use: buildx
+#     goos: linux
+#     goarch: arm
+#     goarm: 7
+#     image_templates:
+#       - "mondoo/{{ .ProjectName }}:{{ .Version }}-armv7-rootless"
+#     build_flag_templates:
+#       - "--platform=linux/arm/v7"
+#       - "--label=org.opencontainers.image.created={{.Date}}"
+#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
+#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+#       - "--label=org.opencontainers.image.version={{.Version}}"
+#       - "--target=rootless"
+# docker_manifests:  # https://goreleaser.com/customization/docker_manifest/
+#     # UBI containers
+#   - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}-ubi
+#     image_templates:
+#       - mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64
+#       - mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64
+#     # Standard containers
+#   - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}
+#     image_templates:
+#       - mondoo/{{ .ProjectName }}:{{ .Version }}-amd64
+#       - mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8
+#       - mondoo/{{ .ProjectName }}:{{ .Version }}-armv6
+#       - mondoo/{{ .ProjectName }}:{{ .Version }}-armv7
+#   # Rootless
+#     # UBI containers
+#   - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-rootless
+#     image_templates:
+#       - mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64-rootless
+#       - mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-arm64-rootless
+#     # Standard containers
+#   - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}-rootless
+#     image_templates:
+#       - mondoo/{{ .ProjectName }}:{{ .Version }}-amd64-rootless
+#       - mondoo/{{ .ProjectName }}:{{ .Version }}-arm64v8-rootless
+#       - mondoo/{{ .ProjectName }}:{{ .Version }}-armv6-rootless
+#       - mondoo/{{ .ProjectName }}:{{ .Version }}-armv7-rootless

--- a/.github/.goreleaser-unstable.yml
+++ b/.github/.goreleaser-unstable.yml
@@ -64,7 +64,8 @@ builds:
       - -s -w -X go.mondoo.com/cnquery/v9.Version={{.Version}} -X go.mondoo.com/cnquery/v9.Build={{.ShortCommit}} -X go.mondoo.com/cnquery/v9.Date={{.Date}}
     hooks:
       post:
-        - cmd: jsign --storetype DIGICERTONE --alias "{{ .Env.SM_CERT_ALIAS }}" --storepass "{{ .Env.SM_API_KEY }}|{{ .Env.SM_CLIENT_CERT_FILE}}|{{ .Env.SM_CLIENT_CERT_PASSWORD }}" --tsaurl "http://timestamp.digicert.com" '{{ .Path }}'
+        - cmd: jsign --storetype TRUSTEDSIGNING --keystore {{ .Env.TSIGN_AZURE_ENDPOINT }} --storepass {{ .Env.TSIGN_ACCESS_TOKEN }} --alias {{ .Env.TSIGN_ACCOUNT_NAME }}/{{ .Env.TSIGN_CERT_PROFILE_NAME }} '{{ .Path }}'
+
 # nfpms:
   # -
   #   maintainer: Mondoo <hello@mondoo.com>

--- a/.github/.goreleaser-unstable.yml
+++ b/.github/.goreleaser-unstable.yml
@@ -82,7 +82,7 @@ archives:
   - id: releases
     format_overrides:
       - goos: windows
-        formats: [zip]
+        format: zip
     files:
       - none*
 checksum:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -21,7 +21,11 @@ on:
         required: false
         default: false
         type: boolean
-
+      upload-artifacts:
+        description: "Uploading artifacts to workflow"
+        required: false
+        default: false
+        type: boolean
 
 env:
   REGISTRY: docker.io
@@ -212,6 +216,14 @@ jobs:
             ls -l $f
             cat $f
           done
+
+      - name: Upload artifacts
+        if: ${{ inputs.upload-artifacts == true }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-artifacts
+          path: dist/*.zip
+          retention-days: 7
 
       # At this point we know the docker container is published.
       # We can now trigger the cnquery bump in cnspec, which will also trigger the release of cnspec.

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: false
         type: boolean
+      goreleaser-snapshot:
+        description: 'Run goreleaser in snapshot mode, which will not publish and bypass tag checks.'
+        required: false
+        default: false
+        type: boolean
 
 
 env:
@@ -35,7 +40,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Skip Publish for Alpha and Beta Tags
         id: skip-publish
@@ -171,7 +177,10 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release -f .github/.goreleaser-unstable.yml --clean --timeout 120m
+          args: |
+            release -f .github/.goreleaser-unstable.yml \
+            ${{ inputs.goreleaser-snapshot == 'true' && '--snapshot' || '' }} \
+            --clean --timeout 120m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CERT_PASSWORD: ${{ steps.gcp_secrets.outputs.code_sign_cert_challenge }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -137,7 +137,9 @@ jobs:
             echo "Error: Access token is empty"
             exit 1
           fi
-          echo "TSIGN_ACCESS_TOKEN=$TSIGN_ACCESS_TOKEN" >> $GITHUB_ENV
+          PREFIX="${TSIGN_ACCESS_TOKEN:0:8}"
+          echo "Access token prefix: ${PREFIX}..."
+          echo "TSIGN_ACCESS_TOKEN=$TSIGN_ACCESS_TOKEN" >> $GITHUB_OUTPUT
 
 
       - name: Install Quill for Mac Signing and Notarization
@@ -171,7 +173,7 @@ jobs:
           TSIGN_AZURE_ENDPOINT: ${{ vars.TSIGN_AZURE_ENDPOINT }}
           TSIGN_ACCOUNT_NAME: ${{ vars.TSIGN_ACCOUNT_NAME }}
           TSIGN_CERT_PROFILE_NAME: ${{ github.event.inputs.use-test-cert == 'true' && vars.TSIGN_TEST_CERT_PROFILE_NAME || vars.TSIGN_CERT_PROFILE_NAME }}
-          TSIGN_ACCESS_TOKEN: ${{ steps.get_token.outputs.tsign_access_token }}
+          TSIGN_ACCESS_TOKEN: ${{ steps.get_token.outputs.TSIGN_ACCESS_TOKEN }}
 
       - name: Run GoReleaser (w/o Docker Release)
         if: ${{ inputs.skip-publish == true }}
@@ -197,7 +199,7 @@ jobs:
           TSIGN_AZURE_ENDPOINT: ${{ vars.TSIGN_AZURE_ENDPOINT }}
           TSIGN_ACCOUNT_NAME: ${{ vars.TSIGN_ACCOUNT_NAME }}
           TSIGN_CERT_PROFILE_NAME: ${{ github.event.inputs.use-test-cert == 'true' && vars.TSIGN_TEST_CERT_PROFILE_NAME || vars.TSIGN_CERT_PROFILE_NAME }}
-          TSIGN_ACCESS_TOKEN: ${{ steps.get_token.outputs.tsign_access_token }}
+          TSIGN_ACCESS_TOKEN: ${{ steps.get_token.outputs.TSIGN_ACCESS_TOKEN }}
 
       - name: Check RPMs
         run: |

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -78,13 +78,6 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WIP }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
-      - id: 'gcp_secrets'
-        uses: 'google-github-actions/get-secretmanager-secrets@v2'
-        with:
-          secrets: |-
-            code_sign_cert_b64:mondoo-base-infra/mondoo_code_sign_certificate_pfx_b64
-            code_sign_cert_challenge:mondoo-base-infra/mondoo_code_sign_challenge
-
       - name: "Write RPM Signing Cert"
         run: |
           gpgkey="$(mktemp -t gpgkey.XXX)"
@@ -92,30 +85,6 @@ jobs:
           echo "GPG_KEY_PATH=$gpgkey" >> $GITHUB_ENV
         env:
           GPG_KEY: '${{ secrets.GPG_KEY}}'
-
-#      - name: "Write Windows Signing Cert"
-#        run: |
-#          cert="$(mktemp -t cert.XXX)"
-#          base64 -d <<<"$CERT_CONTENTS" > "$cert"
-#          echo "CERT_FILE=$cert" >> $GITHUB_ENV
-#        env:
-#          CERT_CONTENTS: '${{ steps.gcp_secrets.outputs.code_sign_cert_b64 }}'
-#
-#      - name: Configure DigiCert Signing Variables
-#        shell: bash
-#        run: |
-#          # CertLocker Authentication Certifiate
-#          CERT_PATH="$(mktemp -t cert.XXX)"
-#          echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > ${CERT_PATH}
-#          echo "SM_CLIENT_CERT_FILE=${CERT_PATH}" >> "$GITHUB_ENV"
-#          echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV"
-#          # CertLocker API Key & Host
-#          echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> "$GITHUB_ENV"
-#          echo "SM_HOST=${{ secrets.SM_HOST }}" >> "$GITHUB_ENV"
-#          # DigiCert CertLocker Code Signing Certificate
-#          echo "SM_CODE_SIGNING_CERT_SHA1_HASH=${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}" >> "$GITHUB_ENV"
-#          echo "SM_CERT_ALIAS=${{ secrets.SM_CERT_ALIAS }}" >> "$GITHUB_ENV"
-#
 
 # jsign and azure-cli are both requirements for Azure Trusted Signing and these actions to authenticate
 # These packages have been installed on the self-hosted runner using ansible from the private repo
@@ -234,7 +203,7 @@ jobs:
       # We can now trigger the cnquery bump in cnspec, which will also trigger the release of cnspec.
       # The docker container is a pre-requisite for cnspec release.
       - name: Trigger cnquery bump in cnspec
-        if: ${{ ! steps.skip-publish.outputs.skip-publish }}
+        if: ${{ inputs.skip-publish != true }}
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.RELEASR_ACTION_TOKEN }}
@@ -243,8 +212,3 @@ jobs:
           client-payload: '{
               "version": "${{  github.ref_name }}"
             }'
-
-      - name: Cleanup
-        if: always()
-        run:
-          rm -f ${CERT_PATH}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -151,7 +151,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Run GoReleaser (w/ Docker Release)
-        if: ${{ ! steps.skip-publish.outputs.skip-publish }}
+        if: ${{ inputs.skip-publish != 'true' }}
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
@@ -172,7 +172,7 @@ jobs:
           TSIGN_ACCESS_TOKEN: ${{ steps.get_token.outputs.tsign_access_token }}
 
       - name: Run GoReleaser (w/o Docker Release)
-        if: ${{ steps.skip-publish.outputs.skip-publish == 'true' }}
+        if: ${{ inputs.skip-publish == 'true'}}
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Skip Publish for Alpha and Beta Tags
         id: skip-publish
-        if: contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') || inputs.skip-publish == 'true'
+        if: contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') || inputs.skip-publish == true
         run: |
           echo "Skipping publish for alpha and beta tags"
           echo "skip-publish=true" >> $GITHUB_OUTPUT
@@ -153,7 +153,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Run GoReleaser (w/ Docker Release)
-        if: ${{ inputs.skip-publish != 'true' }}
+        if: ${{ inputs.skip-publish != true }}
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
@@ -174,14 +174,14 @@ jobs:
           TSIGN_ACCESS_TOKEN: ${{ steps.get_token.outputs.tsign_access_token }}
 
       - name: Run GoReleaser (w/o Docker Release)
-        if: ${{ inputs.skip-publish == 'true'}}
+        if: ${{ inputs.skip-publish == true }}
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest
           args: |
             release -f .github/.goreleaser-unstable.yml \
-            ${{ inputs.goreleaser-snapshot == 'true' && '--snapshot' || '' }} \
+            ${{ inputs.goreleaser-snapshot == true && '--snapshot' || '' }} \
             --clean --timeout 120m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -40,8 +40,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
-          fetch-tags: true
+          fetch-depth: 0
+
+      - name: Dump all inputs
+        run: echo "${{ toJSON(inputs) }}"
 
       - name: Skip Publish for Alpha and Beta Tags
         id: skip-publish

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -127,12 +127,21 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      # Run GoReleaser
+      # This will build the binaries, create the docker images, and publish the release to Git
+      # we are currently pinned to v2.5.1 because of a bug in v2.6.0 that causes the release to fail
+      # specifically with the signing of the RPM packages
+      # if you upgrade then when validating the signatures 'rpm -qpi dist/*.rpm' it will error with
+      # Header RSA signature: BAD (package tag 268: invalid OpenPGP signature)
+      # This is because a goreleaser dep was changed to https://github.com/goreleaser/nfpm/releases/tag/v2.41.2
+      # created a discussion on the issue here https://github.com/orgs/goreleaser/discussions/5943
+
       - name: Run GoReleaser (w/ Docker Release)
         if: ${{ inputs.skip-publish != true }}
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: v2.11.2
+          version: v2.5.1
           args: >
             release
             --config .goreleaser.yml
@@ -157,7 +166,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: v2.6.0
+          version: v2.5.1
           args: >
             release
             ${{ inputs.goreleaser-snapshot == true && '--snapshot' || '' }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -157,7 +157,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: v2.6.1
+          version: v2.6.0
           args: >
             release
             ${{ inputs.goreleaser-snapshot == true && '--snapshot' || '' }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -11,6 +11,11 @@ on:
         type: boolean
         required: false
         default: false
+      use-test-cert:
+        description: "Use test certificate profile (not publicly trusted)"
+        required: false
+        default: false
+        type: boolean
 
 
 env:
@@ -76,33 +81,53 @@ jobs:
         env:
           GPG_KEY: '${{ secrets.GPG_KEY}}'
 
-      - name: "Write Windows Signing Cert"
+#      - name: "Write Windows Signing Cert"
+#        run: |
+#          cert="$(mktemp -t cert.XXX)"
+#          base64 -d <<<"$CERT_CONTENTS" > "$cert"
+#          echo "CERT_FILE=$cert" >> $GITHUB_ENV
+#        env:
+#          CERT_CONTENTS: '${{ steps.gcp_secrets.outputs.code_sign_cert_b64 }}'
+#
+#      - name: Configure DigiCert Signing Variables
+#        shell: bash
+#        run: |
+#          # CertLocker Authentication Certifiate
+#          CERT_PATH="$(mktemp -t cert.XXX)"
+#          echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > ${CERT_PATH}
+#          echo "SM_CLIENT_CERT_FILE=${CERT_PATH}" >> "$GITHUB_ENV"
+#          echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV"
+#          # CertLocker API Key & Host
+#          echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> "$GITHUB_ENV"
+#          echo "SM_HOST=${{ secrets.SM_HOST }}" >> "$GITHUB_ENV"
+#          # DigiCert CertLocker Code Signing Certificate
+#          echo "SM_CODE_SIGNING_CERT_SHA1_HASH=${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}" >> "$GITHUB_ENV"
+#          echo "SM_CERT_ALIAS=${{ secrets.SM_CERT_ALIAS }}" >> "$GITHUB_ENV"
+#
+      - name: Install the required version of jSign (Windows Signing Tool)
         run: |
-          cert="$(mktemp -t cert.XXX)"
-          base64 -d <<<"$CERT_CONTENTS" > "$cert"
-          echo "CERT_FILE=$cert" >> $GITHUB_ENV
-        env:
-          CERT_CONTENTS: '${{ steps.gcp_secrets.outputs.code_sign_cert_b64 }}'
+          curl -LO https://github.com/ebourg/jsign/releases/download/7.1/jsign_7.1_all.deb
+          sudo dpkg -i ./jsign_7.1_all.deb
 
-      - name: Configure DigiCert Signing Variables
-        shell: bash
+      - name: Log in to Azure for Code Signing
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.TSIGN_AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.TSIGN_AZURE_TENANT_ID }}
+          client-secret: ${{ secrets.TSIGN_AZURE_CLIENT_SECRET }}
+
+      - name: Get Azure AD Access Token to trusted signing
+        id: get_token
         run: |
-          # CertLocker Authentication Certifiate
-          CERT_PATH="$(mktemp -t cert.XXX)"
-          echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > ${CERT_PATH}
-          echo "SM_CLIENT_CERT_FILE=${CERT_PATH}" >> "$GITHUB_ENV"
-          echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV"
-          # CertLocker API Key & Host
-          echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> "$GITHUB_ENV"
-          echo "SM_HOST=${{ secrets.SM_HOST }}" >> "$GITHUB_ENV"
-          # DigiCert CertLocker Code Signing Certificate
-          echo "SM_CODE_SIGNING_CERT_SHA1_HASH=${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}" >> "$GITHUB_ENV"
-          echo "SM_CERT_ALIAS=${{ secrets.SM_CERT_ALIAS }}" >> "$GITHUB_ENV"
+          set -e  # Stop on first error
+          TSIGN_ACCESS_TOKEN=$(az account get-access-token --resource https://codesigning.azure.net --query accessToken -o tsv)
 
-      # - name: Install jSign (Windows Signing Tool) -- Required for public runners
-      #   run: |
-      #     curl -LO https://github.com/ebourg/jsign/releases/download/5.0/jsign_5.0_all.deb
-      #     sudo dpkg -i ./jsign_5.0_all.deb
+          if [ -z "$TSIGN_ACCESS_TOKEN" ]; then
+            echo "Error: Access token is empty"
+            exit 1
+          fi
+          echo "TSIGN_ACCESS_TOKEN=$TSIGN_ACCESS_TOKEN" >> $GITHUB_ENV
+
 
       - name: Install Quill for Mac Signing and Notarization
         run: |
@@ -132,6 +157,10 @@ jobs:
           QUILL_NOTARY_KEY: ${{ secrets.APPLE_NOTARY_KEY }}
           QUILL_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
           QUILL_NOTARY_ISSUER: ${{ secrets.APPLE_NOTARY_ISSUER }}
+          TSIGN_AZURE_ENDPOINT: ${{ vars.TSIGN_AZURE_ENDPOINT }}
+          TSIGN_ACCOUNT_NAME: ${{ vars.TSIGN_ACCOUNT_NAME }}
+          TSIGN_CERT_PROFILE_NAME: ${{ github.event.inputs.use-test-cert == 'true' && vars.TSIGN_TEST_CERT_PROFILE_NAME || vars.TSIGN_CERT_PROFILE_NAME }}
+          TSIGN_ACCESS_TOKEN: ${{ steps.get_token.outputs.tsign_access_token }}
 
       - name: Run GoReleaser (w/o Docker Release)
         if: ${{ steps.skip-publish.outputs.skip-publish == 'true' }}
@@ -149,6 +178,10 @@ jobs:
           QUILL_NOTARY_KEY: ${{ secrets.APPLE_NOTARY_KEY }}
           QUILL_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
           QUILL_NOTARY_ISSUER: ${{ secrets.APPLE_NOTARY_ISSUER }}
+          TSIGN_AZURE_ENDPOINT: ${{ vars.TSIGN_AZURE_ENDPOINT }}
+          TSIGN_ACCOUNT_NAME: ${{ vars.TSIGN_ACCOUNT_NAME }}
+          TSIGN_CERT_PROFILE_NAME: ${{ github.event.inputs.use-test-cert == 'true' && vars.TSIGN_TEST_CERT_PROFILE_NAME || vars.TSIGN_CERT_PROFILE_NAME }}
+          TSIGN_ACCESS_TOKEN: ${{ steps.get_token.outputs.tsign_access_token }}
 
       - name: Check RPMs
         run: |

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -105,17 +105,22 @@ jobs:
 #          echo "SM_CERT_ALIAS=${{ secrets.SM_CERT_ALIAS }}" >> "$GITHUB_ENV"
 #
       #  This is required but needs to installed already, it should be done my ansible and the private-runner repo
-      # - name: Install the required version of jSign (Windows Signing Tool)
-      #   run: |
-      #     curl -LO https://github.com/ebourg/jsign/releases/download/7.1/jsign_7.1_all.deb
-      #     sudo dpkg -i ./jsign_7.1_all.deb
+      - name: Install the required version of jSign (Windows Signing Tool)
+        run: |
+          #curl -LO https://github.com/ebourg/jsign/releases/download/7.1/jsign_7.1_all.deb
+          #dpkg -i ./jsign_7.1_all.deb
+          jsign --help
 
       - name: Log in to Azure for Code Signing
         uses: azure/login@v1
         with:
-          client-id: ${{ secrets.TSIGN_AZURE_CLIENT_ID }}
-          tenant-id: ${{ vars.TSIGN_AZURE_TENANT_ID }}
-          client-secret: ${{ secrets.TSIGN_AZURE_CLIENT_SECRET }}
+          creds: >-
+            {
+              "clientId": "${{ secrets.TSIGN_AZURE_CLIENT_ID }}",
+              "clientSecret": "${{ secrets.TSIGN_AZURE_CLIENT_SECRET }}",
+              "tenantId": "${{ vars.TSIGN_AZURE_TENANT_ID}}",
+              "subscriptionId": "${{ vars.TSIGN_AZURE_SUBSCRIPTION_ID }}"
+            }
 
       - name: Get Azure AD Access Token to trusted signing
         id: get_token

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -39,6 +39,7 @@ jobs:
       id-token: 'write'
 
     runs-on: self-hosted
+    environment: prod
     timeout-minutes: 120
     steps:
       - name: Checkout
@@ -89,16 +90,12 @@ jobs:
 # jsign and azure-cli are both requirements for Azure Trusted Signing and these actions to authenticate
 # These packages have been installed on the self-hosted runner using ansible from the private repo
 
-      - name: Log in to Azure for Code Signing
+      - name: Azure login
         uses: azure/login@v2
         with:
-          creds: >-
-            {
-              "clientId": "${{ secrets.TSIGN_AZURE_CLIENT_ID }}",
-              "clientSecret": "${{ secrets.TSIGN_AZURE_CLIENT_SECRET }}",
-              "tenantId": "${{ vars.TSIGN_AZURE_TENANT_ID}}",
-              "subscriptionId": "${{ vars.TSIGN_AZURE_SUBSCRIPTION_ID }}"
-            }
+          client-id: ${{ secrets.TSIGN_AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.TSIGN_AZURE_TENANT_ID}}
+          subscription-id: ${{ vars.TSIGN_AZURE_SUBSCRIPTION_ID }}
 
       - name: Get Azure AD Access Token to trusted signing
         id: get_token

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -178,11 +178,13 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
-          args: |
-            release -f .github/.goreleaser-unstable.yml \
-            ${{ inputs.goreleaser-snapshot == true && '--snapshot' || '' }} \
-            --clean --timeout 120m
+          version: '~> v2'
+          args: >
+            release
+            ${{ inputs.goreleaser-snapshot == true && '--snapshot' || '' }}
+            --config .github/.goreleaser-unstable.yml
+            --clean
+            --timeout 120m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CERT_PASSWORD: ${{ steps.gcp_secrets.outputs.code_sign_cert_challenge }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -104,10 +104,11 @@ jobs:
 #          echo "SM_CODE_SIGNING_CERT_SHA1_HASH=${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}" >> "$GITHUB_ENV"
 #          echo "SM_CERT_ALIAS=${{ secrets.SM_CERT_ALIAS }}" >> "$GITHUB_ENV"
 #
-      - name: Install the required version of jSign (Windows Signing Tool)
-        run: |
-          curl -LO https://github.com/ebourg/jsign/releases/download/7.1/jsign_7.1_all.deb
-          sudo dpkg -i ./jsign_7.1_all.deb
+      #  This is required but needs to installed already, it should be done my ansible and the private-runner repo
+      # - name: Install the required version of jSign (Windows Signing Tool)
+      #   run: |
+      #     curl -LO https://github.com/ebourg/jsign/releases/download/7.1/jsign_7.1_all.deb
+      #     sudo dpkg -i ./jsign_7.1_all.deb
 
       - name: Log in to Azure for Code Signing
         uses: azure/login@v1

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -157,7 +157,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: v2.11.2
+          version: v2.6.1
           args: >
             release
             ${{ inputs.goreleaser-snapshot == true && '--snapshot' || '' }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -104,19 +104,9 @@ jobs:
 #          echo "SM_CODE_SIGNING_CERT_SHA1_HASH=${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}" >> "$GITHUB_ENV"
 #          echo "SM_CERT_ALIAS=${{ secrets.SM_CERT_ALIAS }}" >> "$GITHUB_ENV"
 #
-      #  This is required but needs to installed already, it should be done my ansible and the private-runner repo
-      - name: Install the required version of jSign (Windows Signing Tool)
-        run: |
-          curl -LO https://github.com/ebourg/jsign/releases/download/7.1/jsign_7.1_all.deb
-          dpkg -i ./jsign_7.1_all.deb
 
-      # Install Azure CLI for azure/login to work
-      - name: Azure CLI script
-        uses: azure/cli@v2
-        with:
-          azcliversion: latest
-          inlineScript: |
-            az version
+# jsign and azure-cli are both requirements for Azure Trusted Signing and these actions to authenticate
+# These packages have been installed on the self-hosted runner using ansible from the private repo
 
       - name: Log in to Azure for Code Signing
         uses: azure/login@v2

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -163,8 +163,12 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: v2.5.1
-          args: release --clean --timeout 120m
+          version: v2.11.2
+          args: >
+            release
+            --config .goreleaser.yml
+            --clean
+            --timeout 120m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CERT_PASSWORD: ${{ steps.gcp_secrets.outputs.code_sign_cert_challenge }}
@@ -184,7 +188,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: '~> v2'
+          version: v2.11.2
           args: >
             release
             ${{ inputs.goreleaser-snapshot == true && '--snapshot' || '' }}
@@ -208,6 +212,7 @@ jobs:
       - name: Check RPMs
         run: |
           rpm -qpi dist/*.rpm
+
       - name: Output Quill Logs
         if: ${{ failure() }}
         run: |

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -107,12 +107,19 @@ jobs:
       #  This is required but needs to installed already, it should be done my ansible and the private-runner repo
       - name: Install the required version of jSign (Windows Signing Tool)
         run: |
-          #curl -LO https://github.com/ebourg/jsign/releases/download/7.1/jsign_7.1_all.deb
-          #dpkg -i ./jsign_7.1_all.deb
-          jsign --help
+          curl -LO https://github.com/ebourg/jsign/releases/download/7.1/jsign_7.1_all.deb
+          dpkg -i ./jsign_7.1_all.deb
+
+      # Install Azure CLI for azure/login to work
+      - name: Azure CLI script
+        uses: azure/cli@v2
+        with:
+          azcliversion: latest
+          inlineScript: |
+            az version
 
       - name: Log in to Azure for Code Signing
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
           creds: >-
             {

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -64,7 +64,7 @@ builds:
       - -s -w -X go.mondoo.com/cnquery/v11.Version={{.Version}} -X go.mondoo.com/cnquery/v11.Build={{.ShortCommit}} -X go.mondoo.com/cnquery/v11.Date={{.Date}}
     hooks:
       post:
-        - cmd: jsign --storetype DIGICERTONE --alias "{{ .Env.SM_CERT_ALIAS }}" --storepass "{{ .Env.SM_API_KEY }}|{{ .Env.SM_CLIENT_CERT_FILE}}|{{ .Env.SM_CLIENT_CERT_PASSWORD }}" --tsaurl "http://timestamp.digicert.com" '{{ .Path }}'
+        - cmd: jsign --storetype TRUSTEDSIGNING --keystore {{ .Env.TSIGN_AZURE_ENDPOINT }} --storepass {{ .Env.TSIGN_ACCESS_TOKEN }} --alias {{ .Env.TSIGN_ACCOUNT_NAME }}/{{ .Env.TSIGN_CERT_PROFILE_NAME }} '{{ .Path }}'
 nfpms:
   -
     maintainer: Mondoo <hello@mondoo.com>
@@ -82,7 +82,7 @@ archives:
   - id: releases
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     files:
       - none*
 checksum:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -82,7 +82,7 @@ archives:
   - id: releases
     format_overrides:
       - goos: windows
-        formats: [zip]
+        format: zip
     files:
       - none*
 checksum:


### PR DESCRIPTION
**Summary**
This PR updates the Windows file signing process from DigiCert to Azure Trusted Signer.

**Key Changes**
* Removed redundant tasks: Some tasks became unnecessary after switching to Azure and were removed to simplify the workflow.

* Azure-specific tasks: Added new tasks to handle authentication required for jsign to work with Azure.

  * Note: jsign was upgraded on the runner to version 7.1, which supports trusted signing.

* Task conditionals update: During development, some task inputs changed to booleans, breaking existing conditionals. These have been updated accordingly.

* Goreleaser upgrade attempt:

  * Attempted to upgrade goreleaser, which worked for most targets.

  * However, the resulting RPM signatures were invalid, so we’ve remained pinned to version 2.5.1.

  * Comments were added in the code to clarify this limitation.

**Workflow Improvements**
* New inputs were added to the workflow_dispatch to aid with troubleshooting:

  * use-test-cert: Signs the binary using our test certificate (not publicly trusted).

  * goreleaser-snapshot: Enables snapshot mode in goreleaser, bypassing tag checks so you can build from any commit.

  * upload-artifacts: Uploads binaries to the workflow run—useful for inspecting outputs when not publishing.