### PR TITLE
✨ Use AWS built-in paginators.

### DIFF
--- a/providers/aws/resources/aws_account.go
+++ b/providers/aws/resources/aws_account.go
@@ -87,8 +87,9 @@ func (c *mqlAwsAccount) tags() (map[string]interface{}, error) {
 	// account or by a member account that is a delegated administrator for an
 	// Amazon Web Services service.
 	tags := make(map[string]interface{})
-	for {
-		res, err := client.ListTagsForResource(context.TODO(), input)
+	paginator := organizations.NewListTagsForResourcePaginator(client, input)
+	for paginator.HasMorePages() {
+		res, err := paginator.NextPage(context.Background())
 		if err != nil {
 			return nil, err
 		}
@@ -96,11 +97,6 @@ func (c *mqlAwsAccount) tags() (map[string]interface{}, error) {
 		for _, tag := range res.Tags {
 			tags[*tag.Key] = *tag.Value
 		}
-
-		if res.NextToken == nil {
-			break
-		}
-		input.NextToken = res.NextToken
 	}
 
 	return tags, nil

--- a/providers/aws/resources/aws_codedeploy.go
+++ b/providers/aws/resources/aws_codedeploy.go
@@ -63,10 +63,10 @@ func (c *mqlAwsCodedeploy) getApplicationResources(conn *connection.AwsConnectio
 			ctx := context.Background()
 			appResources := []interface{}{}
 
-			var nextToken *string
-			for {
-				input := &codedeploy.ListApplicationsInput{NextToken: nextToken}
-				output, err := svc.ListApplications(ctx, input)
+			params := &codedeploy.ListApplicationsInput{}
+			paginator := codedeploy.NewListApplicationsPaginator(svc, params)
+			for paginator.HasMorePages() {
+				output, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
 						log.Warn().Str("region", reg).Msg("error accessing CodeDeploy applications in region")
@@ -100,11 +100,6 @@ func (c *mqlAwsCodedeploy) getApplicationResources(conn *connection.AwsConnectio
 						appResources = append(appResources, mqlApp)
 					}
 				}
-
-				if output.NextToken == nil {
-					break
-				}
-				nextToken = output.NextToken
 			}
 			return jobpool.JobResult(appResources), nil
 		}
@@ -140,13 +135,12 @@ func (a *mqlAwsCodedeployApplication) deploymentGroups() ([]interface{}, error) 
 	ctx := context.Background()
 	dgResources := []interface{}{}
 
-	var nextToken *string
-	for {
-		listInput := &codedeploy.ListDeploymentGroupsInput{
-			ApplicationName: aws.String(a.ApplicationName.Data),
-			NextToken:       nextToken,
-		}
-		listOutput, err := svc.ListDeploymentGroups(ctx, listInput)
+	params := &codedeploy.ListDeploymentGroupsInput{
+		ApplicationName: aws.String(a.ApplicationName.Data),
+	}
+	paginator := codedeploy.NewListDeploymentGroupsPaginator(svc, params)
+	for paginator.HasMorePages() {
+		listOutput, err := paginator.NextPage(ctx)
 		if err != nil {
 			return nil, errors.Wrapf(err, "could not list deployment groups for application %s", a.ApplicationName.Data)
 		}
@@ -185,11 +179,6 @@ func (a *mqlAwsCodedeployApplication) deploymentGroups() ([]interface{}, error) 
 				dgResources = append(dgResources, mqlDg)
 			}
 		}
-
-		if listOutput.NextToken == nil {
-			break
-		}
-		nextToken = listOutput.NextToken
 	}
 	return dgResources, nil
 }
@@ -378,17 +367,15 @@ func listDeployments(runtime *plugin.Runtime, region string, appName, dgName *st
 	ctx := context.Background()
 	depResources := []interface{}{}
 
-	var nextToken *string
-	for {
-		listInput := &codedeploy.ListDeploymentsInput{
-			ApplicationName:     appName,
-			DeploymentGroupName: dgName,
-			NextToken:           nextToken,
-		}
-		// Potentially filter by IncludeOnlyStatuses for active ones if desired
-		// listInput.IncludeOnlyStatuses = []codedeploytypes.DeploymentStatus{DeploymentStatusInProgress, DeploymentStatusQueued, DeploymentStatusReady}
-
-		listOutput, err := svc.ListDeployments(ctx, listInput)
+	// Potentially filter by IncludeOnlyStatuses for active ones if desired
+	// IncludeOnlyStatuses: []codedeploytypes.DeploymentStatus{DeploymentStatusInProgress, DeploymentStatusQueued, DeploymentStatusReady}
+	params := &codedeploy.ListDeploymentsInput{
+		ApplicationName:     appName,
+		DeploymentGroupName: dgName,
+	}
+	paginator := codedeploy.NewListDeploymentsPaginator(svc, params)
+	for paginator.HasMorePages() {
+		listOutput, err := paginator.NextPage(ctx)
 		if err != nil {
 			return nil, errors.Wrapf(err, "could not list deployments for app %s, group %s", aws.ToString(appName), aws.ToString(dgName))
 		}
@@ -430,11 +417,6 @@ func listDeployments(runtime *plugin.Runtime, region string, appName, dgName *st
 				depResources = append(depResources, mqlDep)
 			}
 		}
-
-		if listOutput.NextToken == nil {
-			break
-		}
-		nextToken = listOutput.NextToken
 	}
 	return depResources, nil
 }

--- a/providers/aws/resources/aws_ecr.go
+++ b/providers/aws/resources/aws_ecr.go
@@ -276,13 +276,12 @@ func (a *mqlAwsEcr) publicRepositories() ([]interface{}, error) {
 	svc := conn.EcrPublic("us-east-1") // only supported for us-east-1
 	res := []interface{}{}
 
+	// TODO: @vasil - use pagination?
 	repoResp, err := svc.DescribeRepositories(context.TODO(), &ecrpublic.DescribeRepositoriesInput{RegistryId: aws.String(conn.AccountId())})
 	if err != nil {
 		return nil, err
 	}
-	for i := range repoResp.Repositories {
-		r := repoResp.Repositories[i]
-
+	for _, r := range repoResp.Repositories {
 		mqlRepoResource, err := CreateResource(a.MqlRuntime, "aws.ecr.repository",
 			map[string]*llx.RawData{
 				"arn":             llx.StringDataPtr(r.RepositoryArn),

--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -67,7 +67,7 @@ func (a *mqlAwsS3) buckets() ([]interface{}, error) {
 		o.Limit = 100
 	})
 	for paginator.HasMorePages() {
-		output, err := paginator.NextPage(context.TODO())
+		output, err := paginator.NextPage(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -75,9 +75,7 @@ func (a *mqlAwsS3) buckets() ([]interface{}, error) {
 	}
 
 	res := []interface{}{}
-	for i := range totalBuckets {
-		bucket := totalBuckets[i]
-
+	for _, bucket := range totalBuckets {
 		location, err := svc.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
 			Bucket: bucket.Name,
 		})
@@ -338,9 +336,7 @@ func (a *mqlAwsS3Bucket) acl() ([]interface{}, error) {
 	}
 
 	res := []interface{}{}
-	for i := range acl.Grants {
-		grant := acl.Grants[i]
-
+	for _, grant := range acl.Grants {
 		// NOTE: not all grantees have URI and IDs, canonical users have id, groups have URIs and the
 		// display name may not be unique
 		if grant.Grantee == nil || (grant.Grantee.URI == nil && grant.Grantee.ID == nil) {

--- a/providers/aws/resources/aws_sagemaker.go
+++ b/providers/aws/resources/aws_sagemaker.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
 	"github.com/aws/smithy-go/transport/http"
 	"github.com/rs/zerolog/log"
@@ -57,10 +56,10 @@ func (a *mqlAwsSagemaker) getEndpoints(conn *connection.AwsConnection) []*jobpoo
 			ctx := context.Background()
 			res := []interface{}{}
 
-			nextToken := aws.String("no_token_to_start_with")
 			params := &sagemaker.ListEndpointsInput{}
-			for nextToken != nil {
-				endpoints, err := svc.ListEndpoints(ctx, params)
+			paginator := sagemaker.NewListEndpointsPaginator(svc, params)
+			for paginator.HasMorePages() {
+				endpoints, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
 						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
@@ -85,10 +84,6 @@ func (a *mqlAwsSagemaker) getEndpoints(conn *connection.AwsConnection) []*jobpoo
 						return nil, err
 					}
 					res = append(res, mqlEndpoint)
-				}
-				nextToken = endpoints.NextToken
-				if endpoints.NextToken != nil {
-					params.NextToken = nextToken
 				}
 			}
 			return jobpool.JobResult(res), nil
@@ -145,10 +140,10 @@ func (a *mqlAwsSagemaker) getNotebookInstances(conn *connection.AwsConnection) [
 			ctx := context.Background()
 			res := []interface{}{}
 
-			nextToken := aws.String("no_token_to_start_with")
 			params := &sagemaker.ListNotebookInstancesInput{}
-			for nextToken != nil {
-				notebookInstances, err := svc.ListNotebookInstances(ctx, &sagemaker.ListNotebookInstancesInput{})
+			paginator := sagemaker.NewListNotebookInstancesPaginator(svc, params)
+			for paginator.HasMorePages() {
+				notebookInstances, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
 						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
@@ -172,10 +167,6 @@ func (a *mqlAwsSagemaker) getNotebookInstances(conn *connection.AwsConnection) [
 						return nil, err
 					}
 					res = append(res, mqlEndpoint)
-				}
-				nextToken = notebookInstances.NextToken
-				if notebookInstances.NextToken != nil {
-					params.NextToken = nextToken
 				}
 			}
 			return jobpool.JobResult(res), nil

--- a/providers/aws/resources/aws_securityhub.go
+++ b/providers/aws/resources/aws_securityhub.go
@@ -47,15 +47,14 @@ func (a *mqlAwsSecurityhub) getHubs(conn *connection.AwsConnection) []*jobpool.J
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			svc := conn.Securityhub(regionVal)
+			svc := conn.Securityhub(region)
 			ctx := context.Background()
 			res := []interface{}{}
 			secHub, err := svc.DescribeHub(ctx, &securityhub.DescribeHubInput{})
 			if err != nil {
 				if Is400AccessDeniedError(err) {
-					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+					log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 					return res, nil
 				}
 				var notFoundErr *types.InvalidAccessException


### PR DESCRIPTION
#### In this PR:
- Replaces `NextToken` and `NextMarker` code with the built-in AWS Go SDK paginators.
- Replaces `for i := range` loops with `for _, item := range`.
- Partially simplifies old for loops with variable reassignment. There are too many remaining occurrences so I decided to finish it in a separate PR. Example:
```go
for _, region := range regions {
    regionVal := region // removed
    ...
}
```
