### PR TITLE
✨ Remove redundant variable copying in AWS provider.

### DIFF
--- a/providers/aws/resources/aws_autoscaling.go
+++ b/providers/aws/resources/aws_autoscaling.go
@@ -130,9 +130,8 @@ func (a *mqlAwsAutoscaling) getGroups(conn *connection.AwsConnection) []*jobpool
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			svc := conn.Autoscaling(regionVal)
+			svc := conn.Autoscaling(region)
 			ctx := context.Background()
 			res := []interface{}{}
 
@@ -142,7 +141,7 @@ func (a *mqlAwsAutoscaling) getGroups(conn *connection.AwsConnection) []*jobpool
 				groups, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
 					return nil, err
@@ -174,7 +173,7 @@ func (a *mqlAwsAutoscaling) getGroups(conn *connection.AwsConnection) []*jobpool
 							"maxSize":                 llx.IntDataDefault(group.MaxSize, 0),
 							"minSize":                 llx.IntDataDefault(group.MinSize, 0),
 							"name":                    llx.StringDataPtr(group.AutoScalingGroupName),
-							"region":                  llx.StringData(regionVal),
+							"region":                  llx.StringData(region),
 							"tags":                    llx.MapData(autoscalingTagsToMap(group.Tags), types.String),
 						})
 					if err != nil {

--- a/providers/aws/resources/aws_backups.go
+++ b/providers/aws/resources/aws_backups.go
@@ -56,16 +56,15 @@ func (a *mqlAwsBackup) getVaults(conn *connection.AwsConnection) []*jobpool.Job 
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			svc := conn.Backup(regionVal)
+			svc := conn.Backup(region)
 			ctx := context.Background()
 			res := []interface{}{}
 
 			vaults, err := svc.ListBackupVaults(ctx, &backup.ListBackupVaultsInput{})
 			if err != nil {
 				if Is400AccessDeniedError(err) {
-					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+					log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 					return res, nil
 				}
 				return nil, err
@@ -76,7 +75,7 @@ func (a *mqlAwsBackup) getVaults(conn *connection.AwsConnection) []*jobpool.Job 
 						"arn":              llx.StringDataPtr(v.BackupVaultArn),
 						"name":             llx.StringDataPtr(v.BackupVaultName),
 						"createdAt":        llx.TimeDataPtr(v.CreationDate),
-						"region":           llx.StringData(regionVal),
+						"region":           llx.StringData(region),
 						"locked":           llx.BoolDataPtr(v.Locked),
 						"encryptionKeyArn": llx.StringDataPtr(v.EncryptionKeyArn),
 					})

--- a/providers/aws/resources/aws_cloudtrail.go
+++ b/providers/aws/resources/aws_cloudtrail.go
@@ -203,10 +203,8 @@ func (a *mqlAwsCloudtrailTrail) id() (string, error) {
 }
 
 func (a *mqlAwsCloudtrailTrail) status() (interface{}, error) {
-	regionValue := a.Region.Data
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-
-	svc := conn.Cloudtrail(regionValue)
+	svc := conn.Cloudtrail(a.Region.Data)
 	ctx := context.Background()
 
 	arnValue := a.Arn.Data
@@ -223,10 +221,8 @@ func (a *mqlAwsCloudtrailTrail) status() (interface{}, error) {
 }
 
 func (a *mqlAwsCloudtrailTrail) eventSelectors() ([]interface{}, error) {
-	regionValue := a.Region.Data
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-
-	svc := conn.Cloudtrail(regionValue)
+	svc := conn.Cloudtrail(a.Region.Data)
 	ctx := context.Background()
 
 	arnValue := a.Arn.Data

--- a/providers/aws/resources/aws_codebuild.go
+++ b/providers/aws/resources/aws_codebuild.go
@@ -48,9 +48,8 @@ func (a *mqlAwsCodebuild) getProjects(conn *connection.AwsConnection) []*jobpool
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			svc := conn.Codebuild(regionVal)
+			svc := conn.Codebuild(region)
 			ctx := context.Background()
 
 			res := []interface{}{}
@@ -60,7 +59,7 @@ func (a *mqlAwsCodebuild) getProjects(conn *connection.AwsConnection) []*jobpool
 				projects, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
 					return nil, err
@@ -70,7 +69,7 @@ func (a *mqlAwsCodebuild) getProjects(conn *connection.AwsConnection) []*jobpool
 					mqlProject, err := CreateResource(a.MqlRuntime, "aws.codebuild.project",
 						map[string]*llx.RawData{
 							"name":   llx.StringData(project),
-							"region": llx.StringData(regionVal),
+							"region": llx.StringData(region),
 						})
 					if err != nil {
 						return nil, err

--- a/providers/aws/resources/aws_dms.go
+++ b/providers/aws/resources/aws_dms.go
@@ -54,11 +54,10 @@ func (a *mqlAwsDms) getReplicationInstances(conn *connection.AwsConnection) []*j
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("dms>getReplicationInstances>calling aws with region %s", regionVal)
+			log.Debug().Msgf("dms>getReplicationInstances>calling aws with region %s", region)
 
-			svc := conn.Dms(regionVal)
+			svc := conn.Dms(region)
 			ctx := context.Background()
 			res := []interface{}{}
 
@@ -68,7 +67,7 @@ func (a *mqlAwsDms) getReplicationInstances(conn *connection.AwsConnection) []*j
 				replicationInstances, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return nil, nil
 					}
 					return nil, err

--- a/providers/aws/resources/aws_dynamodb.go
+++ b/providers/aws/resources/aws_dynamodb.go
@@ -80,11 +80,10 @@ func (a *mqlAwsDynamodb) getExports(conn *connection.AwsConnection) []*jobpool.J
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("dynamodb>getExports>calling aws with region %s", regionVal)
+			log.Debug().Msgf("dynamodb>getExports>calling aws with region %s", region)
 
-			svc := conn.Dynamodb(regionVal)
+			svc := conn.Dynamodb(region)
 			ctx := context.Background()
 			res := []interface{}{}
 
@@ -92,7 +91,7 @@ func (a *mqlAwsDynamodb) getExports(conn *connection.AwsConnection) []*jobpool.J
 			listExportsResp, err := svc.ListExports(ctx, &dynamodb.ListExportsInput{})
 			if err != nil {
 				if Is400AccessDeniedError(err) {
-					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+					log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 					return res, nil
 				}
 				return nil, errors.Wrap(err, "could not gather aws dynamodb exports")
@@ -368,11 +367,10 @@ func (a *mqlAwsDynamodb) getLimits(conn *connection.AwsConnection) []*jobpool.Jo
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("dynamodb>getLimits>calling aws with region %s", regionVal)
+			log.Debug().Msgf("dynamodb>getLimits>calling aws with region %s", region)
 
-			svc := conn.Dynamodb(regionVal)
+			svc := conn.Dynamodb(region)
 			ctx := context.Background()
 			res := []interface{}{}
 
@@ -380,7 +378,7 @@ func (a *mqlAwsDynamodb) getLimits(conn *connection.AwsConnection) []*jobpool.Jo
 			limitsResp, err := svc.DescribeLimits(ctx, &dynamodb.DescribeLimitsInput{})
 			if err != nil {
 				if Is400AccessDeniedError(err) {
-					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+					log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 					return res, nil
 				}
 				return nil, errors.Wrap(err, "could not gather aws dynamodb backups")
@@ -388,8 +386,8 @@ func (a *mqlAwsDynamodb) getLimits(conn *connection.AwsConnection) []*jobpool.Jo
 
 			mqlLimits, err := CreateResource(a.MqlRuntime, "aws.dynamodb.limit",
 				map[string]*llx.RawData{
-					"arn":             llx.StringData(fmt.Sprintf(limitsArn, regionVal, conn.AccountId())),
-					"region":          llx.StringData(regionVal),
+					"arn":             llx.StringData(fmt.Sprintf(limitsArn, region, conn.AccountId())),
+					"region":          llx.StringData(region),
 					"accountMaxRead":  llx.IntData(*limitsResp.AccountMaxReadCapacityUnits),
 					"accountMaxWrite": llx.IntData(*limitsResp.AccountMaxWriteCapacityUnits),
 					"tableMaxRead":    llx.IntData(*limitsResp.TableMaxReadCapacityUnits),
@@ -456,11 +454,10 @@ func (a *mqlAwsDynamodb) getTables(conn *connection.AwsConnection) []*jobpool.Jo
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("dynamodb>getTables>calling aws with region %s", regionVal)
+			log.Debug().Msgf("dynamodb>getTables>calling aws with region %s", region)
 
-			svc := conn.Dynamodb(regionVal)
+			svc := conn.Dynamodb(region)
 			ctx := context.Background()
 			res := []interface{}{}
 
@@ -468,7 +465,7 @@ func (a *mqlAwsDynamodb) getTables(conn *connection.AwsConnection) []*jobpool.Jo
 			listTablesResp, err := svc.ListTables(ctx, &dynamodb.ListTablesInput{})
 			if err != nil {
 				if Is400AccessDeniedError(err) {
-					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+					log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 					return res, nil
 				}
 				return nil, errors.Wrap(err, "could not gather aws dynamodb tables")
@@ -490,9 +487,9 @@ func (a *mqlAwsDynamodb) getTables(conn *connection.AwsConnection) []*jobpool.Jo
 
 				mqlTable, err := CreateResource(a.MqlRuntime, "aws.dynamodb.table",
 					map[string]*llx.RawData{
-						"arn":                       llx.StringData(fmt.Sprintf(dynamoTableArnPattern, regionVal, conn.AccountId(), tableName)),
+						"arn":                       llx.StringData(fmt.Sprintf(dynamoTableArnPattern, region, conn.AccountId(), tableName)),
 						"name":                      llx.StringData(tableName),
-						"region":                    llx.StringData(regionVal),
+						"region":                    llx.StringData(region),
 						"sseDescription":            llx.DictData(sseDict),
 						"provisionedThroughput":     llx.DictData(throughputDict),
 						"createdTime":               llx.TimeDataPtr(table.Table.CreationDateTime),

--- a/providers/aws/resources/aws_eks.go
+++ b/providers/aws/resources/aws_eks.go
@@ -53,18 +53,17 @@ func (a *mqlAwsEks) getClusters(conn *connection.AwsConnection) []*jobpool.Job {
 		return []*jobpool.Job{{Err: err}} // return the error
 	}
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("eks>getClusters>calling aws with region %s", regionVal)
+			log.Debug().Msgf("eks>getClusters>calling aws with region %s", region)
 
-			svc := conn.Eks(regionVal)
+			svc := conn.Eks(region)
 			ctx := context.Background()
 			res := []interface{}{}
 
 			describeClusterRes, err := svc.ListClusters(ctx, &eks.ListClustersInput{})
 			if err != nil {
 				if Is400AccessDeniedError(err) {
-					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+					log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 					return res, nil
 				}
 				return nil, err
@@ -107,7 +106,7 @@ func (a *mqlAwsEks) getClusters(conn *connection.AwsConnection) []*jobpool.Job {
 					"name":               llx.StringDataPtr(cluster.Name),
 					"networkConfig":      llx.MapData(kubernetesNetworkConfig, types.Any),
 					"platformVersion":    llx.StringDataPtr(cluster.PlatformVersion),
-					"region":             llx.StringData(regionVal),
+					"region":             llx.StringData(region),
 					"resourcesVpcConfig": llx.MapData(vpcConfig, types.Any),
 					"status":             llx.StringData(string(cluster.Status)),
 					"supportType":        llx.StringData(string(cluster.UpgradePolicy.SupportType)),

--- a/providers/aws/resources/aws_elasticache.go
+++ b/providers/aws/resources/aws_elasticache.go
@@ -49,11 +49,10 @@ func (a *mqlAwsElasticache) getClusters(conn *connection.AwsConnection) []*jobpo
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("elasticache>getClusters>calling aws with region %s", regionVal)
+			log.Debug().Msgf("elasticache>getClusters>calling aws with region %s", region)
 
-			svc := conn.Elasticache(regionVal)
+			svc := conn.Elasticache(region)
 			ctx := context.Background()
 			var res interface{}
 
@@ -63,7 +62,7 @@ func (a *mqlAwsElasticache) getClusters(conn *connection.AwsConnection) []*jobpo
 				clusters, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
 					return nil, err
@@ -111,11 +110,10 @@ func (a *mqlAwsElasticache) getCacheClusters(conn *connection.AwsConnection) []*
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("elasticache>getCacheClusters>calling aws with region %s", regionVal)
+			log.Debug().Msgf("elasticache>getCacheClusters>calling aws with region %s", region)
 
-			svc := conn.Elasticache(regionVal)
+			svc := conn.Elasticache(region)
 			ctx := context.Background()
 			res := []interface{}{}
 
@@ -125,7 +123,7 @@ func (a *mqlAwsElasticache) getCacheClusters(conn *connection.AwsConnection) []*
 				clusters, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
 					return nil, err
@@ -134,7 +132,7 @@ func (a *mqlAwsElasticache) getCacheClusters(conn *connection.AwsConnection) []*
 					return nil, nil
 				}
 				for _, cluster := range clusters.CacheClusters {
-					mqlCluster, err := newMqlAwsElasticacheCluster(a.MqlRuntime, regionVal, conn.AccountId(), cluster)
+					mqlCluster, err := newMqlAwsElasticacheCluster(a.MqlRuntime, region, conn.AccountId(), cluster)
 					if err != nil {
 						return nil, err
 					}
@@ -250,11 +248,10 @@ func (a *mqlAwsElasticache) getServerlessCaches(conn *connection.AwsConnection) 
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("elasticache>getServerlessClusters>calling aws with region %s", regionVal)
+			log.Debug().Msgf("elasticache>getServerlessClusters>calling aws with region %s", region)
 
-			svc := conn.Elasticache(regionVal)
+			svc := conn.Elasticache(region)
 			ctx := context.Background()
 			res := []interface{}{}
 
@@ -264,7 +261,7 @@ func (a *mqlAwsElasticache) getServerlessCaches(conn *connection.AwsConnection) 
 				caches, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
 					return nil, err
@@ -273,7 +270,7 @@ func (a *mqlAwsElasticache) getServerlessCaches(conn *connection.AwsConnection) 
 					return nil, nil
 				}
 				for _, cache := range caches.ServerlessCaches {
-					mqlCache, err := newMqlAwsElasticacheServerlessCache(a.MqlRuntime, regionVal, conn.AccountId(), cache)
+					mqlCache, err := newMqlAwsElasticacheServerlessCache(a.MqlRuntime, region, conn.AccountId(), cache)
 					if err != nil {
 						return nil, err
 					}

--- a/providers/aws/resources/aws_emr.go
+++ b/providers/aws/resources/aws_emr.go
@@ -51,9 +51,8 @@ func (a *mqlAwsEmr) getClusters(conn *connection.AwsConnection) []*jobpool.Job {
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			svc := conn.Emr(regionVal)
+			svc := conn.Emr(region)
 			ctx := context.Background()
 
 			res := []interface{}{}
@@ -64,7 +63,7 @@ func (a *mqlAwsEmr) getClusters(conn *connection.AwsConnection) []*jobpool.Job {
 				clusters, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
 					return nil, err

--- a/providers/aws/resources/aws_es.go
+++ b/providers/aws/resources/aws_es.go
@@ -49,16 +49,15 @@ func (a *mqlAwsEs) getDomains(conn *connection.AwsConnection) []*jobpool.Job {
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			svc := conn.Es(regionVal)
+			svc := conn.Es(region)
 			ctx := context.Background()
 			res := []interface{}{}
 
 			domains, err := svc.ListDomainNames(ctx, &elasticsearchservice.ListDomainNamesInput{})
 			if err != nil {
 				if Is400AccessDeniedError(err) {
-					log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+					log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 					return res, nil
 				}
 				return nil, err
@@ -70,7 +69,7 @@ func (a *mqlAwsEs) getDomains(conn *connection.AwsConnection) []*jobpool.Job {
 				mqlDomain, err := NewResource(a.MqlRuntime, "aws.es.domain",
 					map[string]*llx.RawData{
 						"name":   llx.StringDataPtr(domain.DomainName),
-						"region": llx.StringData(regionVal),
+						"region": llx.StringData(region),
 					})
 				if err != nil {
 					return nil, err

--- a/providers/aws/resources/aws_inspector.go
+++ b/providers/aws/resources/aws_inspector.go
@@ -53,9 +53,8 @@ func (a *mqlAwsInspector) getCoverage(conn *connection.AwsConnection) []*jobpool
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			svc := conn.Inspector(regionVal)
+			svc := conn.Inspector(region)
 			ctx := context.Background()
 			res := []interface{}{}
 
@@ -65,7 +64,7 @@ func (a *mqlAwsInspector) getCoverage(conn *connection.AwsConnection) []*jobpool
 				coverages, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
 					return nil, err
@@ -83,7 +82,7 @@ func (a *mqlAwsInspector) getCoverage(conn *connection.AwsConnection) []*jobpool
 							"statusReason":  llx.StringData(string(coverage.ScanStatus.Reason)),
 							"statusCode":    llx.StringData(string(coverage.ScanStatus.StatusCode)),
 							"scanType":      llx.StringData(string(coverage.ScanType)),
-							"region":        llx.StringData(regionVal),
+							"region":        llx.StringData(region),
 						},
 					)
 					if err != nil {

--- a/providers/aws/resources/aws_kms.go
+++ b/providers/aws/resources/aws_kms.go
@@ -52,11 +52,10 @@ func (a *mqlAwsKms) getKeys(conn *connection.AwsConnection) []*jobpool.Job {
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("kms>getKeys>calling aws with region %s", regionVal)
+			log.Debug().Msgf("kms>getKeys>calling aws with region %s", region)
 
-			svc := conn.Kms(regionVal)
+			svc := conn.Kms(region)
 			res := []interface{}{}
 
 			keys := make([]types.KeyListEntry, 0)
@@ -77,7 +76,7 @@ func (a *mqlAwsKms) getKeys(conn *connection.AwsConnection) []*jobpool.Job {
 					map[string]*llx.RawData{
 						"id":     llx.StringDataPtr(key.KeyId),
 						"arn":    llx.StringDataPtr(key.KeyArn),
-						"region": llx.StringData(regionVal),
+						"region": llx.StringData(region),
 					})
 				if err != nil {
 					return nil, err

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -52,11 +52,10 @@ func (a *mqlAwsLambda) getFunctions(conn *connection.AwsConnection) []*jobpool.J
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("lambda>getFunctions>calling aws with region %s", regionVal)
+			log.Debug().Msgf("lambda>getFunctions>calling aws with region %s", region)
 
-			svc := conn.Lambda(regionVal)
+			svc := conn.Lambda(region)
 			ctx := context.Background()
 			res := []interface{}{}
 			params := &lambda.ListFunctionsInput{}
@@ -65,7 +64,7 @@ func (a *mqlAwsLambda) getFunctions(conn *connection.AwsConnection) []*jobpool.J
 				functionsResp, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
 					return nil, errors.Wrap(err, "could not gather aws lambda functions")
@@ -93,7 +92,7 @@ func (a *mqlAwsLambda) getFunctions(conn *connection.AwsConnection) []*jobpool.J
 							"runtime":      llx.StringData(string(function.Runtime)),
 							"dlqTargetArn": llx.StringData(dlqTarget),
 							"vpcConfig":    llx.MapData(vpcConfigJson, types.Any),
-							"region":       llx.StringData(regionVal),
+							"region":       llx.StringData(region),
 							"tags":         llx.MapData(tags, types.String),
 						})
 					if err != nil {

--- a/providers/aws/resources/aws_neptune.go
+++ b/providers/aws/resources/aws_neptune.go
@@ -50,11 +50,10 @@ func (a *mqlAwsNeptune) getDbClusters(conn *connection.AwsConnection) []*jobpool
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("neptune>getDbClusters>calling aws with region %s", regionVal)
+			log.Debug().Msgf("neptune>getDbClusters>calling aws with region %s", region)
 
-			svc := conn.Neptune(regionVal)
+			svc := conn.Neptune(region)
 			ctx := context.Background()
 			res := []interface{}{}
 
@@ -72,7 +71,7 @@ func (a *mqlAwsNeptune) getDbClusters(conn *connection.AwsConnection) []*jobpool
 				cluster, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
 					return nil, err
@@ -81,7 +80,7 @@ func (a *mqlAwsNeptune) getDbClusters(conn *connection.AwsConnection) []*jobpool
 					return nil, nil
 				}
 				for _, cluster := range cluster.DBClusters {
-					mqlCluster, err := newMqlAwsNeptuneCluster(a.MqlRuntime, regionVal, cluster)
+					mqlCluster, err := newMqlAwsNeptuneCluster(a.MqlRuntime, region, cluster)
 					if err != nil {
 						return nil, err
 					}
@@ -164,11 +163,10 @@ func (a *mqlAwsNeptune) getDbInstances(conn *connection.AwsConnection) []*jobpoo
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("neptune>getDbInstances>calling aws with region %s", regionVal)
+			log.Debug().Msgf("neptune>getDbInstances>calling aws with region %s", region)
 
-			svc := conn.Neptune(regionVal)
+			svc := conn.Neptune(region)
 			ctx := context.Background()
 			res := []interface{}{}
 
@@ -186,7 +184,7 @@ func (a *mqlAwsNeptune) getDbInstances(conn *connection.AwsConnection) []*jobpoo
 				cluster, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
 					return nil, err
@@ -195,7 +193,7 @@ func (a *mqlAwsNeptune) getDbInstances(conn *connection.AwsConnection) []*jobpoo
 					return nil, nil
 				}
 				for _, instance := range cluster.DBInstances {
-					mqlNeptuneInstance, err := newMqlAwsNeptuneInstance(a.MqlRuntime, regionVal, instance)
+					mqlNeptuneInstance, err := newMqlAwsNeptuneInstance(a.MqlRuntime, region, instance)
 					if err != nil {
 						return nil, err
 					}

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -95,11 +95,10 @@ func (a *mqlAwsRds) getClusterParameterGroups(conn *connection.AwsConnection) []
 		return []*jobpool.Job{{Err: err}}
 	}
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("rds>getClusterParameterGroup>calling aws with region %s", regionVal)
+			log.Debug().Msgf("rds>getClusterParameterGroup>calling aws with region %s", region)
 			res := []interface{}{}
-			svc := conn.Rds(regionVal)
+			svc := conn.Rds(region)
 			ctx := context.Background()
 
 			params := &rds.DescribeDBClusterParameterGroupsInput{}
@@ -108,7 +107,7 @@ func (a *mqlAwsRds) getClusterParameterGroups(conn *connection.AwsConnection) []
 				DBClusterParameterGroups, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
 					return nil, err
@@ -152,11 +151,10 @@ func (a *mqlAwsRds) getParameterGroups(conn *connection.AwsConnection) []*jobpoo
 		return []*jobpool.Job{{Err: err}}
 	}
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("rds>getParameterGroup>calling aws with region %s", regionVal)
+			log.Debug().Msgf("rds>getParameterGroup>calling aws with region %s", region)
 			res := []interface{}{}
-			svc := conn.Rds(regionVal)
+			svc := conn.Rds(region)
 			ctx := context.Background()
 
 			params := &rds.DescribeDBParameterGroupsInput{}
@@ -165,7 +163,7 @@ func (a *mqlAwsRds) getParameterGroups(conn *connection.AwsConnection) []*jobpoo
 				dbParameterGroups, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
 					return nil, err
@@ -193,12 +191,11 @@ func (a *mqlAwsRds) getDbInstances(conn *connection.AwsConnection) []*jobpool.Jo
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("rds>getDbInstances>calling aws with region %s", regionVal)
+			log.Debug().Msgf("rds>getDbInstances>calling aws with region %s", region)
 
 			res := []interface{}{}
-			svc := conn.Rds(regionVal)
+			svc := conn.Rds(region)
 			ctx := context.Background()
 
 			params := &rds.DescribeDBInstancesInput{}
@@ -207,7 +204,7 @@ func (a *mqlAwsRds) getDbInstances(conn *connection.AwsConnection) []*jobpool.Jo
 				dbInstances, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
 					return nil, err
@@ -219,7 +216,7 @@ func (a *mqlAwsRds) getDbInstances(conn *connection.AwsConnection) []*jobpool.Jo
 						continue
 					}
 
-					mqlDBInstance, err := newMqlAwsRdsInstance(a.MqlRuntime, regionVal, conn.AccountId(), dbInstance)
+					mqlDBInstance, err := newMqlAwsRdsInstance(a.MqlRuntime, region, conn.AccountId(), dbInstance)
 					if err != nil {
 						return nil, err
 					}
@@ -260,12 +257,11 @@ func (a *mqlAwsRds) getPendingMaintenanceActions(conn *connection.AwsConnection)
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("rds>getDbInstances>calling aws with region %s", regionVal)
+			log.Debug().Msgf("rds>getDbInstances>calling aws with region %s", region)
 
 			res := []interface{}{}
-			svc := conn.Rds(regionVal)
+			svc := conn.Rds(region)
 			ctx := context.Background()
 
 			params := &rds.DescribePendingMaintenanceActionsInput{}
@@ -697,12 +693,11 @@ func (a *mqlAwsRds) getDbClusters(conn *connection.AwsConnection) []*jobpool.Job
 		return []*jobpool.Job{{Err: err}}
 	}
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("rds>getDbClusters>calling aws with region %s", regionVal)
+			log.Debug().Msgf("rds>getDbClusters>calling aws with region %s", region)
 
 			res := []interface{}{}
-			svc := conn.Rds(regionVal)
+			svc := conn.Rds(region)
 			ctx := context.Background()
 
 			params := &rds.DescribeDBClustersInput{}
@@ -711,7 +706,7 @@ func (a *mqlAwsRds) getDbClusters(conn *connection.AwsConnection) []*jobpool.Job
 				dbClusters, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
 					return nil, err
@@ -724,7 +719,7 @@ func (a *mqlAwsRds) getDbClusters(conn *connection.AwsConnection) []*jobpool.Job
 						continue
 					}
 
-					mqlDbCluster, err := newMqlAwsRdsCluster(a.MqlRuntime, regionVal, conn.AccountId(), cluster)
+					mqlDbCluster, err := newMqlAwsRdsCluster(a.MqlRuntime, region, conn.AccountId(), cluster)
 					if err != nil {
 						return nil, err
 					}

--- a/providers/aws/resources/aws_sagemaker.go
+++ b/providers/aws/resources/aws_sagemaker.go
@@ -50,9 +50,8 @@ func (a *mqlAwsSagemaker) getEndpoints(conn *connection.AwsConnection) []*jobpoo
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			svc := conn.Sagemaker(regionVal)
+			svc := conn.Sagemaker(region)
 			ctx := context.Background()
 			res := []interface{}{}
 
@@ -62,7 +61,7 @@ func (a *mqlAwsSagemaker) getEndpoints(conn *connection.AwsConnection) []*jobpoo
 				endpoints, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
 					return nil, err
@@ -77,7 +76,7 @@ func (a *mqlAwsSagemaker) getEndpoints(conn *connection.AwsConnection) []*jobpoo
 						map[string]*llx.RawData{
 							"arn":    llx.StringDataPtr(endpoint.EndpointArn),
 							"name":   llx.StringDataPtr(endpoint.EndpointName),
-							"region": llx.StringData(regionVal),
+							"region": llx.StringData(region),
 							"tags":   llx.MapData(tags, types.String),
 						})
 					if err != nil {
@@ -134,9 +133,8 @@ func (a *mqlAwsSagemaker) getNotebookInstances(conn *connection.AwsConnection) [
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			svc := conn.Sagemaker(regionVal)
+			svc := conn.Sagemaker(region)
 			ctx := context.Background()
 			res := []interface{}{}
 
@@ -146,7 +144,7 @@ func (a *mqlAwsSagemaker) getNotebookInstances(conn *connection.AwsConnection) [
 				notebookInstances, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
 					return nil, err
@@ -160,7 +158,7 @@ func (a *mqlAwsSagemaker) getNotebookInstances(conn *connection.AwsConnection) [
 						map[string]*llx.RawData{
 							"arn":    llx.StringData(convert.ToValue(instance.NotebookInstanceArn)),
 							"name":   llx.StringData(convert.ToValue(instance.NotebookInstanceName)),
-							"region": llx.StringData(regionVal),
+							"region": llx.StringData(region),
 							"tags":   llx.MapData(tags, types.String),
 						})
 					if err != nil {

--- a/providers/aws/resources/aws_secretsmanager.go
+++ b/providers/aws/resources/aws_secretsmanager.go
@@ -52,9 +52,8 @@ func (a *mqlAwsSecretsmanager) getSecrets(conn *connection.AwsConnection) []*job
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			svc := conn.Secretsmanager(regionVal)
+			svc := conn.Secretsmanager(region)
 			ctx := context.Background()
 
 			res := []interface{}{}
@@ -65,7 +64,7 @@ func (a *mqlAwsSecretsmanager) getSecrets(conn *connection.AwsConnection) []*job
 				secrets, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
 					return nil, err

--- a/providers/aws/resources/aws_sqs.go
+++ b/providers/aws/resources/aws_sqs.go
@@ -56,9 +56,8 @@ func (a *mqlAwsSqs) getQueues(conn *connection.AwsConnection) []*jobpool.Job {
 	}
 
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			svc := conn.Sqs(regionVal)
+			svc := conn.Sqs(region)
 			ctx := context.Background()
 			res := []interface{}{}
 
@@ -68,7 +67,7 @@ func (a *mqlAwsSqs) getQueues(conn *connection.AwsConnection) []*jobpool.Job {
 				qs, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
 					return nil, err
@@ -77,7 +76,7 @@ func (a *mqlAwsSqs) getQueues(conn *connection.AwsConnection) []*jobpool.Job {
 					mqlTopic, err := CreateResource(a.MqlRuntime, "aws.sqs.queue",
 						map[string]*llx.RawData{
 							"url":    llx.StringData(q),
-							"region": llx.StringData(regionVal),
+							"region": llx.StringData(region),
 						},
 					)
 					if err != nil {

--- a/providers/aws/resources/aws_timestream.go
+++ b/providers/aws/resources/aws_timestream.go
@@ -62,15 +62,14 @@ func (a *mqlAwsTimestreamLiveanalytics) getDatabases(conn *connection.AwsConnect
 	}
 
 	for _, region := range regions {
-		regionVal := region
-		if !slices.Contains(timeStreamLiveRegions, regionVal) {
-			log.Debug().Str("region", regionVal).Msg("skipping region since timestream is not available in this region")
+		if !slices.Contains(timeStreamLiveRegions, region) {
+			log.Debug().Str("region", region).Msg("skipping region since timestream is not available in this region")
 			continue
 		}
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("timestream>getDatabases>calling aws with region %s", regionVal)
+			log.Debug().Msgf("timestream>getDatabases>calling aws with region %s", region)
 
-			svc := conn.TimestreamLiveAnalytics(regionVal)
+			svc := conn.TimestreamLiveAnalytics(region)
 			ctx := context.Background()
 			res := []interface{}{}
 
@@ -80,7 +79,7 @@ func (a *mqlAwsTimestreamLiveanalytics) getDatabases(conn *connection.AwsConnect
 				resp, err := paginator.NextPage(ctx)
 				if err != nil {
 					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", regionVal).Msg("error accessing region for AWS API")
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
 					return nil, err
@@ -95,7 +94,7 @@ func (a *mqlAwsTimestreamLiveanalytics) getDatabases(conn *connection.AwsConnect
 							"arn":        llx.StringDataPtr(database.Arn),
 							"name":       llx.StringDataPtr(database.DatabaseName),
 							"kmsKeyId":   llx.StringDataPtr(database.KmsKeyId),
-							"region":     llx.StringData(regionVal),
+							"region":     llx.StringData(region),
 							"createdAt":  llx.TimeDataPtr(database.CreationTime),
 							"updatedAt":  llx.TimeDataPtr(database.LastUpdatedTime),
 							"tableCount": llx.IntData(database.TableCount),

--- a/providers/oci/resources/identity.go
+++ b/providers/oci/resources/identity.go
@@ -74,11 +74,10 @@ func (o *mqlOciIdentity) getUsers(conn *connection.OciConnection) []*jobpool.Job
 		return []*jobpool.Job{{Err: err}} // return the error
 	}
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci with region %s", regionVal)
+			log.Debug().Msgf("calling oci with region %s", region)
 
-			svc, err := conn.IdentityClientWithRegion(*regionVal.RegionKey)
+			svc, err := conn.IdentityClientWithRegion(*region.RegionKey)
 			if err != nil {
 				return nil, err
 			}
@@ -400,11 +399,10 @@ func (o *mqlOciIdentity) getGroups(conn *connection.OciConnection) []*jobpool.Jo
 		return []*jobpool.Job{{Err: err}} // return the error
 	}
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci with region %s", regionVal)
+			log.Debug().Msgf("calling oci with region %s", region)
 
-			svc, err := conn.IdentityClientWithRegion(*regionVal.RegionKey)
+			svc, err := conn.IdentityClientWithRegion(*region.RegionKey)
 			if err != nil {
 				return nil, err
 			}
@@ -501,11 +499,10 @@ func (o *mqlOciIdentity) getPolicies(conn *connection.OciConnection) []*jobpool.
 		return []*jobpool.Job{{Err: err}} // return the error
 	}
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci with region %s", regionVal)
+			log.Debug().Msgf("calling oci with region %s", region)
 
-			svc, err := conn.IdentityClientWithRegion(*regionVal.RegionKey)
+			svc, err := conn.IdentityClientWithRegion(*region.RegionKey)
 			if err != nil {
 				return nil, err
 			}

--- a/providers/oci/resources/identity.go
+++ b/providers/oci/resources/identity.go
@@ -334,9 +334,6 @@ func (o *mqlOciIdentityUser) groups() ([]interface{}, error) {
 	for i := range list.Data {
 		grp := list.Data[i].(*mqlOciIdentityGroup)
 		id := grp.Id.Data
-		if err != nil {
-			return nil, err
-		}
 		_, ok := grpMember[id]
 		if ok {
 			res = append(res, grp)

--- a/providers/oci/resources/network.go
+++ b/providers/oci/resources/network.go
@@ -74,11 +74,10 @@ func (o *mqlOciNetwork) getVcns(conn *connection.OciConnection) []*jobpool.Job {
 		return []*jobpool.Job{{Err: err}} // return the error
 	}
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci with region %s", regionVal)
+			log.Debug().Msgf("calling oci with region %s", region)
 
-			svc, err := conn.NetworkClient(*regionVal.RegionKey)
+			svc, err := conn.NetworkClient(*region.RegionKey)
 			if err != nil {
 				return nil, err
 			}
@@ -216,11 +215,10 @@ func (o *mqlOciNetwork) getSecurityLists(conn *connection.OciConnection) []*jobp
 		return []*jobpool.Job{{Err: err}} // return the error
 	}
 	for _, region := range regions {
-		regionVal := region
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci with region %s", regionVal)
+			log.Debug().Msgf("calling oci with region %s", region)
 
-			svc, err := conn.NetworkClient(*regionVal.RegionKey)
+			svc, err := conn.NetworkClient(*region.RegionKey)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
#### In this PR:
- Since Go >=1.22 we don't need to copy the loop variable anymore. Removed such code from the AWS provider since it was prevalent there.
- Removed redundant err check that was resulting in a compiler warning.