### PR TITLE
⚠️ Warn if an MQL resource does not have id set.

### DIFF
--- a/providers-sdk/v1/lr/go.go
+++ b/providers-sdk/v1/lr/go.go
@@ -170,7 +170,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		if res != nil {
 		  mqlId := res.MqlID()
 			if mqlId == "" {
-			  log.Warn().Msgf("resource %s has no MQL ID defined, this is usually a dev issue with the resource, please open a Github issue", name)
+			  log.Warn().Msgf("resource %s has no MQL ID defined, this is usually a dev issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
 			}
 			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
@@ -190,7 +190,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 
 	mqlId := res.MqlID()
 	if mqlId == "" {
-		log.Warn().Msgf("resource %s has no MQL ID defined, this is usually a dev issue with the resource, please open a Github issue", name)
+		log.Warn().Msgf("resource %s has no MQL ID defined, this is usually a dev issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
 	}
 	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
@@ -217,7 +217,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 
 	mqlId := res.MqlID()
 	if mqlId == "" {
-		log.Warn().Msgf("resource %s has no MQL ID defined, this is usually a dev issue with the resource, please open a Github issue", name)
+		log.Warn().Msgf("resource %s has no MQL ID defined, this is usually a dev issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
 	}
 	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {

--- a/providers-sdk/v1/lr/go.go
+++ b/providers-sdk/v1/lr/go.go
@@ -168,7 +168,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-		  mqlId := res.MqlID()
+			mqlId := res.MqlID()
 			if mqlId == "" {
 			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
 			}

--- a/providers-sdk/v1/lr/go.go
+++ b/providers-sdk/v1/lr/go.go
@@ -120,6 +120,7 @@ package resources
 import (
 	"errors"%s
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"%s
@@ -167,7 +168,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+		  mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Warn().Msgf("resource %s has no MQL ID defined, this is usually a dev issue with the resource, please open a Github issue", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -183,7 +188,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Warn().Msgf("resource %s has no MQL ID defined, this is usually a dev issue with the resource, please open a Github issue", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -206,7 +215,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Warn().Msgf("resource %s has no MQL ID defined, this is usually a dev issue with the resource, please open a Github issue", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers-sdk/v1/lr/go.go
+++ b/providers-sdk/v1/lr/go.go
@@ -170,7 +170,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		if res != nil {
 		  mqlId := res.MqlID()
 			if mqlId == "" {
-			  log.Warn().Msgf("resource %s has no MQL ID defined, this is usually a dev issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
 			}
 			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
@@ -190,7 +190,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 
 	mqlId := res.MqlID()
 	if mqlId == "" {
-		log.Warn().Msgf("resource %s has no MQL ID defined, this is usually a dev issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
 	}
 	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
@@ -217,7 +217,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 
 	mqlId := res.MqlID()
 	if mqlId == "" {
-		log.Warn().Msgf("resource %s has no MQL ID defined, this is usually a dev issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
 	}
 	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {

--- a/providers-sdk/v1/testutils/mockprovider/resources/mockprovider.lr.go
+++ b/providers-sdk/v1/testutils/mockprovider/resources/mockprovider.lr.go
@@ -8,6 +8,7 @@ package resources
 import (
 	"errors"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -52,7 +53,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -68,7 +73,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -91,7 +100,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/ansible/resources/ansible.lr.go
+++ b/providers/ansible/resources/ansible.lr.go
@@ -8,6 +8,7 @@ package resources
 import (
 	"errors"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -52,7 +53,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -68,7 +73,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -91,7 +100,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/arista/resources/arista.lr.go
+++ b/providers/arista/resources/arista.lr.go
@@ -8,6 +8,7 @@ package resources
 import (
 	"errors"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -84,7 +85,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -100,7 +105,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -123,7 +132,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/atlassian/resources/atlassian.lr.go
+++ b/providers/atlassian/resources/atlassian.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -105,7 +106,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -121,7 +126,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -144,7 +153,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -821,7 +822,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -837,7 +842,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -860,7 +869,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -473,7 +474,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -489,7 +494,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -512,7 +521,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/cloudflare/resources/cloudflare.lr.go
+++ b/providers/cloudflare/resources/cloudflare.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -113,7 +114,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -129,7 +134,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -152,7 +161,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/cloudformation/resources/cloudformation.lr.go
+++ b/providers/cloudformation/resources/cloudformation.lr.go
@@ -8,6 +8,7 @@ package resources
 import (
 	"errors"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -48,7 +49,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -64,7 +69,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -87,7 +96,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/core/resources/core.lr.go
+++ b/providers/core/resources/core.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -81,7 +82,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -97,7 +102,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -120,7 +129,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/equinix/resources/equinix.lr.go
+++ b/providers/equinix/resources/equinix.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -57,7 +58,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -73,7 +78,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -96,7 +105,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -565,7 +566,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -581,7 +586,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -604,7 +613,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/github/resources/github.lr.go
+++ b/providers/github/resources/github.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -141,7 +142,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -157,7 +162,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -180,7 +189,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/gitlab/resources/gitlab.lr.go
+++ b/providers/gitlab/resources/gitlab.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -69,7 +70,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -85,7 +90,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -108,7 +117,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/google-workspace/resources/google-workspace.lr.go
+++ b/providers/google-workspace/resources/google-workspace.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -101,7 +102,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -117,7 +122,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -140,7 +149,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/ipmi/resources/ipmi.lr.go
+++ b/providers/ipmi/resources/ipmi.lr.go
@@ -8,6 +8,7 @@ package resources
 import (
 	"errors"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -44,7 +45,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -60,7 +65,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -83,7 +92,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -185,7 +186,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -201,7 +206,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -224,7 +233,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/mondoo/resources/mondoo.lr.go
+++ b/providers/mondoo/resources/mondoo.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -57,7 +58,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -73,7 +78,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -96,7 +105,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -429,7 +430,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -445,7 +450,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -468,7 +477,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/network/resources/network.lr.go
+++ b/providers/network/resources/network.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -137,7 +138,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -153,7 +158,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -176,7 +185,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/nmap/resources/nmap.lr.go
+++ b/providers/nmap/resources/nmap.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -57,7 +58,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -73,7 +78,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -96,7 +105,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -113,7 +114,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -129,7 +134,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -152,7 +161,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/okta/resources/okta.lr.go
+++ b/providers/okta/resources/okta.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -97,7 +98,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -113,7 +118,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -136,7 +145,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/opcua/resources/opcua.lr.go
+++ b/providers/opcua/resources/opcua.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -53,7 +54,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -69,7 +74,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -92,7 +101,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -565,7 +566,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -581,7 +586,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -604,7 +613,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/shodan/resources/shodan.lr.go
+++ b/providers/shodan/resources/shodan.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -61,7 +62,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -77,7 +82,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -100,7 +109,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/slack/resources/slack.lr.go
+++ b/providers/slack/resources/slack.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -73,7 +74,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -89,7 +94,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -112,7 +121,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/snowflake/resources/snowflake.lr.go
+++ b/providers/snowflake/resources/snowflake.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -89,7 +90,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -105,7 +110,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -128,7 +137,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/tailscale/resources/tailscale.lr.go
+++ b/providers/tailscale/resources/tailscale.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -49,7 +50,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -65,7 +70,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -88,7 +97,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/terraform/resources/terraform.lr.go
+++ b/providers/terraform/resources/terraform.lr.go
@@ -8,6 +8,7 @@ package resources
 import (
 	"errors"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -96,7 +97,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -112,7 +117,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -135,7 +144,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/vcd/resources/vcd.lr.go
+++ b/providers/vcd/resources/vcd.lr.go
@@ -8,6 +8,7 @@ package resources
 import (
 	"errors"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -84,7 +85,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -100,7 +105,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -123,7 +132,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}

--- a/providers/vsphere/resources/vsphere.lr.go
+++ b/providers/vsphere/resources/vsphere.lr.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v11/llx"
 	"go.mondoo.com/cnquery/v11/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v11/types"
@@ -137,7 +138,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		}
 
 		if res != nil {
-			id := name+"\x00"+res.MqlID()
+			mqlId := res.MqlID()
+			if mqlId == "" {
+			  log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+			}
+			id := name + "\x00" + mqlId
 			if x, ok := runtime.Resources.Get(id); ok {
 				return x, nil
 			}
@@ -153,7 +158,11 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}
@@ -176,7 +185,11 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, err
 	}
 
-	id := name+"\x00"+res.MqlID()
+	mqlId := res.MqlID()
+	if mqlId == "" {
+		log.Debug().Msgf("resource %s has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues", name)
+	}
+	id := name + "\x00" + mqlId
 	if x, ok := runtime.Resources.Get(id); ok {
 		return x, nil
 	}


### PR DESCRIPTION
Only warn for now since this will break existing resources that do not have an id set. We should first see how many such resources we have and only make this mandatory after

I need to regen all lr code but id like to first review the actual LR compiler change