### PR TITLE
⭐️ integrate networkdiscovery provider

### DIFF
--- a/providers/network/config/config.go
+++ b/providers/network/config/config.go
@@ -19,6 +19,7 @@ var Config = plugin.Provider{
 		"go.mondoo.com/cnquery/providers/os",
 		"go.mondoo.com/cnquery/providers/k8s",
 		"go.mondoo.com/cnquery/providers/aws",
+		"go.mondoo.com/cnquery/providers/networkdiscovery",
 		// FIXME: DEPRECATED, remove in v12.0 vv
 		// Until v10 providers had a version indication in their ID. With v10
 		// this is no longer the case. Once we get far enough away from legacy

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -640,7 +640,7 @@ func (r *Runtime) lookupResourceProvider(resource string) (*ConnectedProvider, *
 		"go.mondoo.com/cnquery/providers/os",
 		"go.mondoo.com/cnquery/providers/ms365",
 		"go.mondoo.com/cnquery/providers/azure",
-
+		"go.mondoo.com/cnquery/providers/networkdiscovery",
 		// FIXME: DEPRECATED, remove in v12.0 vv
 		// Providers traditionally had a version indication in their ID. With v10
 		// this is no longer necessary (but still supported due to a bug,


### PR DESCRIPTION
This commit registers the new `networkdiscovery` provider within the core `cnquery` application, enabling its use for asset discovery and cross-provider queries.