### PR TITLE
🐛 Reorder the auditd rule resource operator regex parsing

### DIFF
--- a/providers/os/resources/auditd.go
+++ b/providers/os/resources/auditd.go
@@ -257,7 +257,9 @@ func parseKeyVal(line string) (string, string, int) {
 	return line[:keyend], line[valstart:valend], i
 }
 
-var reOperator = regexp.MustCompile(`(=|!=|<|<=|>|>=)`)
+// Make sure this regex matches the most complete form first (ie >=) before
+// matching the shorter forms (ie =)
+var reOperator = regexp.MustCompile(`(!=|<=|>=|=|>|<)`)
 
 func (s *mqlAuditdRules) parse(content string, errors *multierr.Errors) {
 	s.Syscalls.State = plugin.StateIsSet


### PR DESCRIPTION
Ensure that ">=" and "<=" parse properly

Before this the fields were not getting parses correctly when using >= or <= operators:

```
    fields: [
      0: {
        key: "auid"
        op: ">" <-- This should be ">="
        value: "=1000" <-- This should be "1000"
      }
```