### PR TITLE
⭐️ Refactor device connection and partition mounting

### DIFF
--- a/providers/os/connection/device/device_connection.go
+++ b/providers/os/connection/device/device_connection.go
@@ -145,8 +145,8 @@ func NewDeviceConnection(connId uint32, conf *inventory.Config, asset *inventory
 
 func (c *DeviceConnection) tryDetectAsset(conf *inventory.Config, asset *inventory.Asset) {
 	for partition, block := range c.partitions {
-		log.Debug().Str("partition", partition).Str("path", block.MountPoint).Str("name", block.Name).Msg("device connection> trying to detect asset")
-		fsConn, err := TryDetectAssetFromPath(c.ID(), block.MountPoint, conf, asset)
+		log.Debug().Str("partition", partition).Str("path", block.RootFsPath()).Str("name", block.Name).Msg("device connection> trying to detect asset")
+		fsConn, err := TryDetectAssetFromPath(c.ID(), block.RootFsPath(), conf, asset)
 		if fsConn != nil {
 			c.FileSystemConnection = fsConn
 			return

--- a/providers/os/connection/device/device_connection.go
+++ b/providers/os/connection/device/device_connection.go
@@ -119,7 +119,7 @@ func NewDeviceConnection(connId uint32, conf *inventory.Config, asset *inventory
 	for _, part := range mountedPartitions {
 		deviceConnection.MountedDirs = append(deviceConnection.MountedDirs, part.MountPoint)
 		deviceConnection.partitions[part.MountPoint] = part
-		partNames = append(partNames, part.Name)
+		partNames = append(partNames, part.Partition.Name)
 	}
 	if skipAssetDetection {
 		log.Debug().Msg("device connection> skipping asset detection as requested")
@@ -144,15 +144,15 @@ func NewDeviceConnection(connId uint32, conf *inventory.Config, asset *inventory
 }
 
 func (c *DeviceConnection) tryDetectAsset(conf *inventory.Config, asset *inventory.Asset) {
-	for partition, block := range c.partitions {
-		log.Debug().Str("partition", partition).Str("path", block.RootFsPath()).Str("name", block.Name).Msg("device connection> trying to detect asset")
-		fsConn, err := TryDetectAssetFromPath(c.ID(), block.RootFsPath(), conf, asset)
+	for mp, partition := range c.partitions {
+		log.Debug().Str("mountpoint", mp).Str("path", partition.RootFsPath()).Str("name", partition.Partition.Name).Msg("device connection> trying to detect asset")
+		fsConn, err := TryDetectAssetFromPath(c.ID(), partition.RootFsPath(), conf, asset)
 		if fsConn != nil {
 			c.FileSystemConnection = fsConn
 			return
 		}
 		if err != nil {
-			log.Error().Err(err).Str("partition", partition).Msg("partition did not return an asset, continuing")
+			log.Error().Err(err).Str("mountpoint", mp).Str("name", partition.Partition.Name).Msg("partition did not return an asset, continuing")
 		}
 	}
 }

--- a/providers/os/connection/device/device_connection.go
+++ b/providers/os/connection/device/device_connection.go
@@ -5,7 +5,6 @@ package device
 
 import (
 	"errors"
-	"maps"
 	"runtime"
 	"slices"
 	"strings"
@@ -41,7 +40,7 @@ type DeviceConnection struct {
 
 	MountedDirs []string
 	// map of mountpoints to partition infos
-	partitions map[string]*snapshot.PartitionInfo
+	partitions map[string]*snapshot.MountedPartition
 
 	// whether to keep the devices mounted after the connection is closed
 	keepMounted bool
@@ -78,13 +77,13 @@ func NewDeviceConnection(connId uint32, conf *inventory.Config, asset *inventory
 	}
 	log.Debug().Str("manager", manager.Name()).Msg("device manager created")
 
-	blocks, err := manager.IdentifyMountTargets(conf.Options)
+	partitions, err := manager.IdentifyMountTargets(conf.Options)
 	if err != nil {
 		log.Warn().Err(err).Msg("device connection> unable to identify some mount targets, proceeding with the rest")
 	}
 
-	if len(blocks) == 0 {
-		return nil, errors.New("device connection> no blocks found, cannot perform a scan")
+	if len(partitions) == 0 {
+		return nil, errors.New("device connection> no partitions found, cannot perform a scan")
 	}
 
 	deviceConnection := &DeviceConnection{
@@ -109,45 +108,26 @@ func NewDeviceConnection(connId uint32, conf *inventory.Config, asset *inventory
 		asset.IdDetector = append(asset.IdDetector, ids.IdDetector_CloudDetect)
 	}
 
-	deviceConnection.partitions = make(map[string]*snapshot.PartitionInfo)
-
+	deviceConnection.partitions = make(map[string]*snapshot.MountedPartition)
 	skipAssetDetection := conf.Options[SkipAssetDetection] == "true"
 
-	// first, iterate over all blocks and mount them, if needed.
-	for _, block := range blocks {
-		logBuilder := log.Debug().
-			Str("name", block.Name).
-			Str("type", block.FsType).
-			Str("mountpoint", block.MountPoint)
-		if block.MountPoint == "" {
-			logBuilder.Msg("device connection> mounting block device")
-			scanDir, err := manager.Mount(block)
-			if err != nil {
-				log.Error().Err(err).Msg("unable to complete mount step")
-				continue
-			}
-			block.MountPoint = scanDir
-		} else {
-			logBuilder.Msg("device connection> already mounted block device")
-		}
-		if !stringx.Contains(deviceConnection.MountedDirs, block.MountPoint) {
-			log.Debug().
-				Str("name", block.Name).
-				Str("mountpoint", block.MountPoint).
-				Msg("device connection> adding mountpoint to mounted dirs")
-			deviceConnection.MountedDirs = append(deviceConnection.MountedDirs, block.MountPoint)
-		}
-
-		deviceConnection.partitions[block.RootDir()] = block
+	mountedPartitions, err := manager.Mount(partitions)
+	if err != nil {
+		log.Warn().Err(err).Msg("device connection> unable to mount some partitions, proceeding with the rest")
 	}
-
+	partNames := []string{}
+	for _, part := range mountedPartitions {
+		deviceConnection.MountedDirs = append(deviceConnection.MountedDirs, part.MountPoint)
+		deviceConnection.partitions[part.MountPoint] = part
+		partNames = append(partNames, part.Name)
+	}
 	if skipAssetDetection {
 		log.Debug().Msg("device connection> skipping asset detection as requested")
 		return deviceConnection, nil
 	}
 
 	log.Debug().
-		Strs("partitions", slices.Collect(maps.Keys(deviceConnection.partitions))).
+		Strs("partitions", partNames).
 		Strs("mountedDirs", deviceConnection.MountedDirs).
 		Msg("device connection> mounted partitions, proceeding with asset detection")
 
@@ -165,8 +145,8 @@ func NewDeviceConnection(connId uint32, conf *inventory.Config, asset *inventory
 
 func (c *DeviceConnection) tryDetectAsset(conf *inventory.Config, asset *inventory.Asset) {
 	for partition, block := range c.partitions {
-		log.Debug().Str("partition", partition).Str("path", block.RootDir()).Str("name", block.Name).Msg("device connection> trying to detect asset")
-		fsConn, err := TryDetectAssetFromPartition(c.ID(), block, conf, asset)
+		log.Debug().Str("partition", partition).Str("path", block.MountPoint).Str("name", block.Name).Msg("device connection> trying to detect asset")
+		fsConn, err := TryDetectAssetFromPath(c.ID(), block.MountPoint, conf, asset)
 		if fsConn != nil {
 			c.FileSystemConnection = fsConn
 			return
@@ -224,17 +204,12 @@ func (p *DeviceConnection) Conf() *inventory.Config {
 	return p.FileSystemConnection.Conf
 }
 
-func (p *DeviceConnection) Partitions() map[string]*snapshot.PartitionInfo {
+func (p *DeviceConnection) Partitions() map[string]*snapshot.MountedPartition {
 	if p.partitions == nil {
-		p.partitions = make(map[string]*snapshot.PartitionInfo)
+		p.partitions = make(map[string]*snapshot.MountedPartition)
 	}
 
 	return p.partitions
-}
-
-// TryDetectAsset tries to detect the OS on a given block device and returns the connection itself if an asset was detected
-func TryDetectAssetFromPartition(connId uint32, partition *snapshot.PartitionInfo, conf *inventory.Config, asset *inventory.Asset) (*fs.FileSystemConnection, error) {
-	return TryDetectAssetFromPath(connId, partition.RootDir(), conf, asset)
 }
 
 // TryDetectAssetFromPath tries to detect the OS on a given path and returns the connection itself if an asset was detected

--- a/providers/os/connection/device/device_manager.go
+++ b/providers/os/connection/device/device_manager.go
@@ -11,9 +11,9 @@ type DeviceManager interface {
 	// Name returns the name of the device manager
 	Name() string
 	// IdentifyMountTargets returns a list of partitions that match the given options and can be mounted
-	IdentifyMountTargets(opts map[string]string) ([]*snapshot.PartitionInfo, error)
-	// Mounts the partition and returns the directory it was mounted to
-	Mount(pi *snapshot.PartitionInfo) (string, error)
+	IdentifyMountTargets(opts map[string]string) ([]*snapshot.Partition, error)
+	// Mounts the partition and returns the directories it was mounted to
+	Mount(partitions []*snapshot.Partition) ([]*snapshot.MountedPartition, error)
 	// UnmountAndClose unmounts the partitions from the specified dirs and closes the device manager
 	UnmountAndClose()
 }

--- a/providers/os/connection/device/device_manager.go
+++ b/providers/os/connection/device/device_manager.go
@@ -12,7 +12,7 @@ type DeviceManager interface {
 	Name() string
 	// IdentifyMountTargets returns a list of partitions that match the given options and can be mounted
 	IdentifyMountTargets(opts map[string]string) ([]*snapshot.Partition, error)
-	// Mounts the partition and returns the directories it was mounted to
+	// Mounts partitions and returns the directories they were mounted to
 	Mount(partitions []*snapshot.Partition) ([]*snapshot.MountedPartition, error)
 	// UnmountAndClose unmounts the partitions from the specified dirs and closes the device manager
 	UnmountAndClose()

--- a/providers/os/connection/device/linux/device_manager.go
+++ b/providers/os/connection/device/linux/device_manager.go
@@ -56,7 +56,7 @@ func (d *LinuxDeviceManager) Name() string {
 	return "linux"
 }
 
-func (d *LinuxDeviceManager) IdentifyMountTargets(opts map[string]string) ([]*snapshot.PartitionInfo, error) {
+func (d *LinuxDeviceManager) IdentifyMountTargets(opts map[string]string) ([]*snapshot.Partition, error) {
 	if err := validateOpts(opts); err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (d *LinuxDeviceManager) IdentifyMountTargets(opts map[string]string) ([]*sn
 		deviceNames = append(deviceNames, opts[DeviceName])
 	}
 
-	var partitions []*snapshot.PartitionInfo
+	var partitions []*snapshot.Partition
 	var errs []error
 	mountAll := opts[MountAllPartitions] == "true"
 	includeMounted := opts[IncludeMounted] == "true"
@@ -101,51 +101,42 @@ func (d *LinuxDeviceManager) IdentifyMountTargets(opts map[string]string) ([]*sn
 		return partitions, errors.Join(errs...)
 	}
 
-	if opts[SkipAttemptExpandPartitions] == "true" {
-		return partitions, errors.Join(errs...)
-	}
-
-	partitions, err = d.attemptExpandPartitions(partitions)
-	errs = append(errs, err)
-
 	return partitions, errors.Join(errs...)
 }
 
-func (d *LinuxDeviceManager) attemptExpandPartitions(partitions []*snapshot.PartitionInfo) ([]*snapshot.PartitionInfo, error) {
+func (d *LinuxDeviceManager) attemptExpandPartitions(partitions []*snapshot.Partition) ([]*snapshot.MountedPartition, bool, error) {
 	log.Debug().Msg("attempting to expand partitions infos")
 
 	fstabEntries, err := d.hintFSTypes(partitions)
 	if err != nil {
 		log.Warn().Err(err).Msg("could not find fstab")
-		return partitions, nil
+		return nil, false, nil
 	}
 	log.Debug().Any("fstab", fstabEntries).Msg("fstab entries found")
 
-	partitions, err = d.mountWithFstab(partitions, fstabEntries)
+	mounted, err := d.mountWithFstab(partitions, fstabEntries)
 	if err != nil {
 		log.Error().Err(err).Msg("unable to mount partitions with fstab")
 		d.UnmountAndClose()
-		return partitions, nil
+		return nil, true, err
 	}
 
-	return partitions, nil
+	return mounted, true, nil
 }
 
-func (d *LinuxDeviceManager) hintFSTypes(partitions []*snapshot.PartitionInfo) ([]resources.FstabEntry, error) {
-	for i := range partitions {
-		partition := partitions[i]
-
-		dir, err := d.volumeMounter.MountP(&snapshot.MountPartitionDto{PartitionInfo: partition})
+func (d *LinuxDeviceManager) hintFSTypes(partitions []*snapshot.Partition) ([]resources.FstabEntry, error) {
+	for _, partition := range partitions {
+		dir, err := d.volumeMounter.Mount(partition.ToDefaultMountInput())
 		if err != nil {
 			continue
 		}
 		defer func() {
-			if err := d.volumeMounter.UmountP(partition); err != nil {
+			if err := d.volumeMounter.Umount(dir); err != nil {
 				log.Warn().Err(err).Str("device", partition.Name).Msg("unable to unmount partition")
 			}
 		}()
 
-		entries, err := d.attemptFindFstab(dir)
+		entries, err := d.attemptFindFstab(dir.MountPoint)
 		if err != nil {
 			return nil, err
 		}
@@ -153,7 +144,7 @@ func (d *LinuxDeviceManager) hintFSTypes(partitions []*snapshot.PartitionInfo) (
 			return entries, nil
 		}
 
-		if ok := d.attemptFindOSTree(dir, partition); ok {
+		if ok := d.attemptFindOSTree(dir.MountPoint, partition.Name); ok {
 			log.Debug().Str("device", partition.Name).Msg("ostree found")
 			return nil, nil
 		}
@@ -196,8 +187,8 @@ func (d *LinuxDeviceManager) attemptFindFstab(dir string) ([]resources.FstabEntr
 	return resources.ParseFstab(bytes.NewReader(fstabFile))
 }
 
-func (d *LinuxDeviceManager) attemptFindOSTree(dir string, partition *snapshot.PartitionInfo) bool {
-	log.Debug().Str("device", partition.Name).Msg("attempting to find ostree")
+func (d *LinuxDeviceManager) attemptFindOSTree(dir string, partitionName string) bool {
+	log.Debug().Str("device", partitionName).Str("path", dir).Msg("attempting to find ostree")
 
 	info, err := os.Stat(path.Join(dir, "ostree"))
 	if err != nil {
@@ -205,18 +196,18 @@ func (d *LinuxDeviceManager) attemptFindOSTree(dir string, partition *snapshot.P
 			return false
 		}
 
-		log.Error().Err(err).Str("device", partition.Name).Msg("unable to stat ostree")
+		log.Error().Err(err).Str("device", partitionName).Str("path", dir).Msg("unable to stat ostree")
 		return false
 	}
 
 	if !info.IsDir() {
-		log.Warn().Str("device", partition.Name).Msg("ostree is not a directory")
+		log.Warn().Str("device", partitionName).Str("path", dir).Msg("ostree is not a directory")
 		return false
 	}
 
 	entries, err := os.ReadDir(path.Join(dir, "ostree"))
 	if err != nil {
-		log.Error().Err(err).Str("device", partition.Name).Msg("unable to read ostree directory")
+		log.Error().Err(err).Str("device", partitionName).Str("path", dir).Msg("unable to read ostree directory")
 		return false
 	}
 
@@ -235,7 +226,7 @@ func (d *LinuxDeviceManager) attemptFindOSTree(dir string, partition *snapshot.P
 	})
 
 	if len(entries) == 0 {
-		log.Debug().Str("device", partition.Name).Msg("no ostree entries")
+		log.Debug().Str("device", partitionName).Str("path", dir).Msg("no ostree entries")
 		return false
 	}
 	if len(entries) > 1 {
@@ -246,119 +237,83 @@ func (d *LinuxDeviceManager) attemptFindOSTree(dir string, partition *snapshot.P
 		})
 	}
 
-	log.Debug().Str("device", partition.Name).Str("boot1", entries[0].Name()).Msg("found ostree deployment")
+	log.Debug().Str("device", partitionName).Str("path", dir).Str("boot1", entries[0].Name()).Msg("found ostree deployment")
 	boot1, err := os.Readlink(path.Join(dir, "ostree", entries[0].Name()))
 	if err != nil {
-		log.Error().Err(err).Str("device", partition.Name).Msg("unable to readlink boot.1")
+		log.Error().Err(err).Str("device", partitionName).Msg("unable to readlink boot.1")
 		return false
 	}
 
 	matches, err := filepath.Glob(path.Join(dir, "ostree", boot1, "*", "*", "0"))
 	if err != nil {
-		log.Error().Err(err).Str("device", partition.Name).Msg("unable to glob ostree")
+		log.Error().Err(err).Str("device", partitionName).Msg("unable to glob ostree")
 		return false
 	}
 
 	if len(matches) == 0 {
-		log.Debug().Str("device", partition.Name).Msg("no ostree matches")
+		log.Debug().Str("device", partitionName).Str("path", dir).Msg("no ostree matches")
 		return false
 	} else if len(matches) > 1 {
-		log.Warn().Str("device", partition.Name).Msg("multiple ostree matches")
+		log.Warn().Str("device", partitionName).Str("path", dir).Msg("multiple ostree matches")
 	}
-
-	partition.SetBind(strings.TrimPrefix(matches[0], dir))
 	return true
 }
 
-func pathDepth(path string) int {
-	if path == "/" {
-		return 0
-	}
-	return len(strings.Split(strings.Trim(path, "/"), "/"))
-}
-
 // mountWithFstab mounts partitions adjusting the mountpoint and mount options according to the discovered fstab entries
-func (d *LinuxDeviceManager) mountWithFstab(partitions []*snapshot.PartitionInfo, entries []resources.FstabEntry) ([]*snapshot.PartitionInfo, error) {
+func (d *LinuxDeviceManager) mountWithFstab(partitions []*snapshot.Partition, entries []resources.FstabEntry) ([]*snapshot.MountedPartition, error) {
 	// sort the entries by the length of the mountpoint, so we can mount the top level partitions first
 	sort.Slice(entries, func(i, j int) bool {
-		return pathDepth(entries[i].Mountpoint) < pathDepth(entries[j].Mountpoint)
+		return snapshot.PathDepth(entries[i].Mountpoint) < snapshot.PathDepth(entries[j].Mountpoint)
 	})
 
+	mps := []*snapshot.MountedPartition{}
 	rootScanDir := ""
 	for _, entry := range entries {
-		for i := range partitions {
-			partition := partitions[i]
-			mustAppend := false
-			if !cmpPartition2Fstab(partition, entry) {
-				continue
-			}
-
-			log.Debug().
-				Str("device", partition.Name).
-				Str("guest-mountpoint", entry.Mountpoint).
-				Str("host-mountpouint", partition.MountPoint).
-				Msg("partition matches fstab entry")
-
-			// if the partition is already mounted
-			if partition.MountPoint != "" {
-				mountedWithFstab := strings.HasPrefix(partition.MountPoint, rootScanDir)
-				// mounted without fstab consideration, unmount it
-				if rootScanDir == "" || !mountedWithFstab {
-					log.Debug().Str("device", partition.Name).Msg("partition already mounted")
-					// if the partition is mounted and is the root, we can keep it mounted
-					if entry.Mountpoint == "/" {
-						rootScanDir = partition.MountPoint
-						continue
-					}
-					if err := d.volumeMounter.UmountP(partition); err != nil {
-						log.Error().Err(err).Str("device", partition.Name).Msg("unable to unmount partition")
-						continue
-					}
-					partition.MountPoint = ""
-				} else if mountedWithFstab { // mounted with fstab, duplicate the partition (probably a subvolume)
-					partitionCopy := *partition
-					partition = &partitionCopy
-					mustAppend = true
-				}
-			}
-
-			var scanDir *string
-			if rootScanDir != "" {
-				scanDir = ptr.To(path.Join(rootScanDir, entry.Mountpoint))
-			}
-			partition.MountOptions = entry.Options
-
-			log.Debug().Str("device", partition.Name).
-				Strs("options", partition.MountOptions).
-				Any("scan-dir", scanDir).
-				Msg("mounting partition as subvolume")
-			mnt, err := d.volumeMounter.MountP(&snapshot.MountPartitionDto{
-				PartitionInfo: partition,
-				ScanDir:       scanDir,
-			})
-			if err != nil {
-				log.Error().Err(err).Str("device", partition.Name).Msg("unable to mount partition")
-				return partitions, err
-			}
-
-			partition.MountPoint = mnt
-			if entry.Mountpoint == "/" {
-				rootScanDir = mnt
-			}
-
-			if mustAppend {
-				partitions = append(partitions, partition)
-			} else {
-				partitions[i] = partition
-			}
-
-			break // partition matched, no need to check the rest
+		partition := getPartitionForFsTab(partitions, entry)
+		if partition == nil {
+			log.Debug().Str("device", entry.Device).Msg("no partition found for fstab entry")
+			continue
 		}
+
+		log.Debug().
+			Str("device", partition.Name).
+			Str("guest-mountpoint", entry.Mountpoint).
+			Msg("partition matches fstab entry")
+
+		var scanDir *string
+		if rootScanDir != "" {
+			scanDir = ptr.To(path.Join(rootScanDir, entry.Mountpoint))
+		}
+
+		log.Debug().Str("device", partition.Name).
+			Strs("options", entry.Options).
+			Any("scan-dir", scanDir).
+			Msg("mounting partition as subvolume")
+		mp, err := d.volumeMounter.Mount(partition.ToMountInput(entry.Options, scanDir))
+		if err != nil {
+			log.Error().Err(err).Str("device", partition.Name).Msg("unable to mount partition")
+			return nil, err
+		}
+
+		if entry.Mountpoint == "/" {
+			rootScanDir = mp.MountPoint
+		}
+		mps = append(mps, mp)
 	}
-	return partitions, nil
+	return mps, nil
 }
 
-func cmpPartition2Fstab(partition *snapshot.PartitionInfo, entry resources.FstabEntry) bool {
+func getPartitionForFsTab(partitions []*snapshot.Partition, entry resources.FstabEntry) *snapshot.Partition {
+	for _, partition := range partitions {
+		if cmpPartition2Fstab(partition, entry) {
+			log.Debug().Str("device", partition.Name).Msg("found partition for fstab entry")
+			return partition
+		}
+	}
+	return nil
+}
+
+func cmpPartition2Fstab(partition *snapshot.Partition, entry resources.FstabEntry) bool {
 	// Edge case: fstab entry is a symlink to a device mapper device (LVM2)
 	if strings.HasPrefix(entry.Device, "/dev/mapper/") {
 		return entry.Device == partition.Name
@@ -388,8 +343,24 @@ func cmpPartition2Fstab(partition *snapshot.PartitionInfo, entry resources.Fstab
 	}
 }
 
-func (d *LinuxDeviceManager) Mount(pi *snapshot.PartitionInfo) (string, error) {
-	return d.volumeMounter.MountP(&snapshot.MountPartitionDto{PartitionInfo: pi})
+func (d *LinuxDeviceManager) Mount(partitions []*snapshot.Partition) ([]*snapshot.MountedPartition, error) {
+	res := []*snapshot.MountedPartition{}
+	if d.opts[SkipAttemptExpandPartitions] != "true" {
+		mps, ok, err := d.attemptExpandPartitions(partitions)
+		if ok {
+			return mps, err
+		}
+	}
+
+	for _, partition := range partitions {
+		mounted, err := d.volumeMounter.Mount(partition.ToDefaultMountInput())
+		if err != nil {
+			log.Error().Err(err).Str("device", partition.Name).Msg("unable to mount partition")
+			continue
+		}
+		res = append(res, mounted)
+	}
+	return res, nil
 }
 
 func (d *LinuxDeviceManager) UnmountAndClose() {
@@ -399,7 +370,7 @@ func (d *LinuxDeviceManager) UnmountAndClose() {
 	}
 
 	if d.volumeMounter != nil {
-		err := d.volumeMounter.UnmountVolumeFromInstance()
+		err := d.volumeMounter.UnmountAll()
 		if err != nil {
 			log.Error().Err(err).Msg("unable to unmount volume")
 		}
@@ -477,10 +448,10 @@ func (c *LinuxDeviceManager) identifyDeviceViaLun(lun int) ([]snapshot.BlockDevi
 	return devices, nil
 }
 
-func (c *LinuxDeviceManager) identifyViaDeviceName(deviceName string, mountAll bool, includeMounted bool) ([]*snapshot.PartitionInfo, error) {
+func (c *LinuxDeviceManager) identifyViaDeviceName(deviceName string, mountAll bool, includeMounted bool) ([]*snapshot.Partition, error) {
 	if deviceName == "" {
 		log.Warn().Msg("can't identify partition via device name, no device name provided")
-		return []*snapshot.PartitionInfo{}, nil
+		return []*snapshot.Partition{}, nil
 	}
 
 	blockDevices, err := c.cmdRunner.GetBlockDevices()
@@ -502,5 +473,5 @@ func (c *LinuxDeviceManager) identifyViaDeviceName(deviceName string, mountAll b
 	if err != nil {
 		return nil, err
 	}
-	return []*snapshot.PartitionInfo{pi}, nil
+	return []*snapshot.Partition{pi}, nil
 }

--- a/providers/os/connection/device/linux/device_manager_test.go
+++ b/providers/os/connection/device/linux/device_manager_test.go
@@ -3,14 +3,12 @@
 package linux
 
 import (
-	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.mondoo.com/cnquery/v11/providers/os/connection/snapshot"
 	"go.mondoo.com/cnquery/v11/providers/os/resources"
 	"go.uber.org/mock/gomock"
-	"k8s.io/utils/ptr"
 )
 
 type deviceManagerTestFixture struct {
@@ -77,34 +75,38 @@ func TestMountWithFstab(t *testing.T) {
 			},
 		}
 
-		f.volumeMounter.EXPECT().Mount(&snapshot.MountPartitionInput{
-			MountOptions: []string{"defaults"},
-			FsType:       "ext4",
-			Name:         "/dev/sdf1",
-		}).Return("/tmp/scandir", nil).Times(1)
-		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
-			PartitionInfo: partitions[1], ScanDir: ptr.To("/tmp/scandir/boot/efi"),
-		})).Return("/tmp/scandir/boot/efi", nil).Times(1)
-		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
-			PartitionInfo: partitions[2], ScanDir: ptr.To("/tmp/scandir/data"),
-		})).Return("/tmp/scandir/data", nil).Times(1)
+		f.volumeMounter.
+			EXPECT().
+			Mount(&snapshot.MountPartitionInput{MountOptions: []string{"defaults"}, Partition: partitions[0]}).
+			Return(&snapshot.MountedPartition{Partition: partitions[0], MountOptions: []string{"defaults"}, MountPoint: "/tmp/scandir"}, nil).
+			Times(1)
+		f.volumeMounter.
+			EXPECT().
+			Mount(&snapshot.MountPartitionInput{MountOptions: []string{"defaults"}, Partition: partitions[1], MountDir: "/tmp/scandir/boot/efi"}).
+			Return(&snapshot.MountedPartition{Partition: partitions[1], MountOptions: []string{"defaults"}, MountPoint: "/tmp/scandir/boot/efi"}, nil).
+			Times(1)
+		f.volumeMounter.
+			EXPECT().
+			Mount(&snapshot.MountPartitionInput{MountOptions: []string{"defaults"}, Partition: partitions[2], MountDir: "/tmp/scandir/data"}).
+			Return(&snapshot.MountedPartition{Partition: partitions[2], MountOptions: []string{"defaults"}, MountPoint: "/tmp/scandir/data"}, nil).
+			Times(1)
 
 		result, err := f.dmgr.mountWithFstab(partitions, entries)
 		assert.NoError(t, err)
 		assert.Len(t, result, 3)
 
-		assert.Equal(t, "/dev/sdf1", result[0].Name)
+		assert.Equal(t, "/dev/sdf1", result[0].Partition.Name)
 		assert.Equal(t, "/tmp/scandir", result[0].MountPoint)
 
-		assert.Equal(t, "/dev/sdf3", result[1].Name)
+		assert.Equal(t, "/dev/sdf3", result[1].Partition.Name)
 		assert.Equal(t, "/tmp/scandir/boot/efi", result[1].MountPoint)
 
-		assert.Equal(t, "/dev/sdg1", result[2].Name)
+		assert.Equal(t, "/dev/sdg1", result[2].Partition.Name)
 		assert.Equal(t, "/tmp/scandir/data", result[2].MountPoint)
 	})
 
 	t.Run("double mounted", func(t *testing.T) {
-		partitions := []*snapshot.PartitionInfo{
+		partitions := []*snapshot.Partition{
 			{
 				Name:   "/dev/sdf1",
 				FsType: "btrfs",
@@ -148,41 +150,63 @@ func TestMountWithFstab(t *testing.T) {
 			},
 		}
 
-		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
-			PartitionInfo: partitions[0], ScanDir: nil,
-		})).Return("/tmp/scandir", nil).Times(1)
-		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
-			PartitionInfo: partitions[1], ScanDir: ptr.To("/tmp/scandir/boot/efi"),
-		})).Return("/tmp/scandir/boot/efi", nil).Times(1)
-		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
-			PartitionInfo: partitions[2], ScanDir: ptr.To("/tmp/scandir/data"),
-		})).Return("/tmp/scandir/data", nil).Times(1)
+		f.volumeMounter.
+			EXPECT().
+			Mount(&snapshot.MountPartitionInput{MountOptions: []string{"defaults"}, Partition: partitions[0]}).
+			Return(&snapshot.MountedPartition{Partition: partitions[0], MountOptions: []string{"defaults"}, MountPoint: "/tmp/scandir"}, nil).
+			Times(1)
+		f.volumeMounter.
+			EXPECT().
+			Mount(&snapshot.MountPartitionInput{MountOptions: []string{"defaults"}, Partition: partitions[1], MountDir: "/tmp/scandir/boot/efi"}).
+			Return(&snapshot.MountedPartition{Partition: partitions[1], MountOptions: []string{"defaults"}, MountPoint: "/tmp/scandir/boot/efi"}, nil).
+			Times(1)
+		f.volumeMounter.
+			EXPECT().
+			Mount(&snapshot.MountPartitionInput{MountOptions: []string{"defaults"}, Partition: partitions[2], MountDir: "/tmp/scandir/data"}).
+			Return(&snapshot.MountedPartition{Partition: partitions[2], MountOptions: []string{"defaults"}, MountPoint: "/tmp/scandir/data"}, nil).
+			Times(1)
 
-		f.volumeMounter.EXPECT().Mount(gomock.Cond(func(dto *snapshot.MountPartitionInput) bool {
-			return dto.Name == "/dev/sdf1" &&
-				slices.Equal(dto.MountOptions, entries[1].Options) &&
-				dto.ScanDir != nil && *dto.ScanDir == "/tmp/scandir/home"
-		})).Return("/tmp/scandir/home", nil).Times(1)
+		f.volumeMounter.
+			EXPECT().
+			Mount(&snapshot.MountPartitionInput{MountOptions: []string{"defaults"}, Partition: partitions[2], MountDir: "/tmp/scandir/home"}).
+			Return(&snapshot.MountedPartition{Partition: partitions[2], MountOptions: []string{"defaults"}, MountPoint: "/tmp/scandir/home"}, nil).
+			Times(1)
+
+		// f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
+		// 	Partition: partitions[0], ScanDir: nil,
+		// })).Return("/tmp/scandir", nil).Times(1)
+		// f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
+		// 	Partition: partitions[1], ScanDir: ptr.To("/tmp/scandir/boot/efi"),
+		// })).Return("/tmp/scandir/boot/efi", nil).Times(1)
+		// f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
+		// 	Partition: partitions[2], ScanDir: ptr.To("/tmp/scandir/data"),
+		// })).Return("/tmp/scandir/data", nil).Times(1)
+
+		// f.volumeMounter.EXPECT().Mount(gomock.Cond(func(dto *snapshot.MountPartitionInput) bool {
+		// 	return dto.Name == "/dev/sdf1" &&
+		// 		slices.Equal(dto.MountOptions, entries[1].Options) &&
+		// 		dto.ScanDir != nil && *dto.ScanDir == "/tmp/scandir/home"
+		// })).Return("/tmp/scandir/home", nil).Times(1)
 
 		result, err := f.dmgr.mountWithFstab(partitions, entries)
 		assert.NoError(t, err)
 		assert.Len(t, result, 4)
 
-		assert.Equal(t, "/dev/sdf1", result[0].Name)
+		assert.Equal(t, "/dev/sdf1", result[0].Partition.Name)
 		assert.Equal(t, "/tmp/scandir", result[0].MountPoint)
 
-		assert.Equal(t, "/dev/sdf3", result[1].Name)
+		assert.Equal(t, "/dev/sdf3", result[1].Partition.Name)
 		assert.Equal(t, "/tmp/scandir/boot/efi", result[1].MountPoint)
 
-		assert.Equal(t, "/dev/sdg1", result[2].Name)
+		assert.Equal(t, "/dev/sdg1", result[2].Partition.Name)
 		assert.Equal(t, "/tmp/scandir/data", result[2].MountPoint)
 
-		assert.Equal(t, "/dev/sdf1", result[3].Name)
+		assert.Equal(t, "/dev/sdf1", result[3].Partition.Name)
 		assert.Equal(t, "/tmp/scandir/home", result[3].MountPoint)
 	})
 
 	t.Run("no entries matched", func(t *testing.T) {
-		partitions := []*snapshot.PartitionInfo{
+		partitions := []*snapshot.Partition{
 			{
 				Name:   "/dev/sdf1",
 				FsType: "ext4",
@@ -224,18 +248,18 @@ func TestMountWithFstab(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, result, 3)
 
-		assert.Equal(t, "/dev/sdf1", result[0].Name)
+		assert.Equal(t, "/dev/sdf1", result[0].Partition.Name)
 		assert.Equal(t, "", result[0].MountPoint)
 
-		assert.Equal(t, "/dev/sdf3", result[1].Name)
+		assert.Equal(t, "/dev/sdf3", result[1].Partition.Name)
 		assert.Equal(t, "", result[1].MountPoint)
 
-		assert.Equal(t, "/dev/sdg1", result[2].Name)
+		assert.Equal(t, "/dev/sdg1", result[2].Partition.Name)
 		assert.Equal(t, "", result[2].MountPoint)
 	})
 
 	t.Run("root not found", func(t *testing.T) {
-		partitions := []*snapshot.PartitionInfo{
+		partitions := []*snapshot.Partition{
 			{
 				Name:   "/dev/sdf1",
 				FsType: "ext4",
@@ -273,29 +297,30 @@ func TestMountWithFstab(t *testing.T) {
 			},
 		}
 
-		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
-			PartitionInfo: partitions[1], ScanDir: nil,
-		})).Return("/tmp/scandir1", nil).Times(1)
-		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
-			PartitionInfo: partitions[2], ScanDir: nil,
-		})).Return("/tmp/scandir2", nil).Times(1)
+		f.volumeMounter.
+			EXPECT().
+			Mount(&snapshot.MountPartitionInput{MountOptions: []string{"defaults"}, Partition: partitions[1]}).
+			Return(&snapshot.MountedPartition{Partition: partitions[1], MountOptions: []string{"defaults"}, MountPoint: "/tmp/scandir1"}, nil).
+			Times(1)
+		f.volumeMounter.
+			EXPECT().
+			Mount(&snapshot.MountPartitionInput{MountOptions: []string{"defaults"}, Partition: partitions[1]}).
+			Return(&snapshot.MountedPartition{Partition: partitions[1], MountOptions: []string{"defaults"}, MountPoint: "/tmp/scandir2"}, nil).
+			Times(1)
 
 		result, err := f.dmgr.mountWithFstab(partitions, entries)
 		assert.NoError(t, err)
-		assert.Len(t, result, 3)
+		assert.Len(t, result, 2)
 
-		assert.Equal(t, "/dev/sdf1", result[0].Name)
-		assert.Equal(t, "", result[0].MountPoint)
+		assert.Equal(t, "/dev/sdf3", result[0].Partition.Name)
+		assert.Equal(t, "/tmp/scandir1", result[0].MountPoint)
 
-		assert.Equal(t, "/dev/sdf3", result[1].Name)
-		assert.Equal(t, "/tmp/scandir1", result[1].MountPoint)
-
-		assert.Equal(t, "/dev/sdg1", result[2].Name)
-		assert.Equal(t, "/tmp/scandir2", result[2].MountPoint)
+		assert.Equal(t, "/dev/sdg1", result[1].Partition.Name)
+		assert.Equal(t, "/tmp/scandir2", result[1].MountPoint)
 	})
 
 	t.Run("one not found", func(t *testing.T) {
-		partitions := []*snapshot.PartitionInfo{
+		partitions := []*snapshot.Partition{
 			{
 				Name:   "/dev/sdf1",
 				FsType: "ext4",
@@ -333,151 +358,25 @@ func TestMountWithFstab(t *testing.T) {
 			},
 		}
 
-		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
-			PartitionInfo: partitions[0], ScanDir: nil,
-		})).Return("/tmp/scandir", nil).Times(1)
-		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
-			PartitionInfo: partitions[1], ScanDir: ptr.To("/tmp/scandir/boot/efi"),
-		})).Return("/tmp/scandir/boot/efi", nil).Times(1)
+		f.volumeMounter.
+			EXPECT().
+			Mount(&snapshot.MountPartitionInput{MountOptions: []string{"defaults"}, Partition: partitions[0]}).
+			Return(&snapshot.MountedPartition{Partition: partitions[0], MountOptions: []string{"defaults"}, MountPoint: "/tmp/scandir"}, nil).
+			Times(1)
+		f.volumeMounter.
+			EXPECT().
+			Mount(&snapshot.MountPartitionInput{MountOptions: []string{"defaults"}, Partition: partitions[1], MountDir: "/tmp/scandir/boot/efi"}).
+			Return(&snapshot.MountedPartition{Partition: partitions[1], MountOptions: []string{"defaults"}, MountPoint: "/tmp/scandir/boot/efi"}, nil).
+			Times(1)
 
 		result, err := f.dmgr.mountWithFstab(partitions, entries)
 		assert.NoError(t, err)
-		assert.Len(t, result, 3)
+		assert.Len(t, result, 2)
 
-		assert.Equal(t, "/dev/sdf1", result[0].Name)
+		assert.Equal(t, "/dev/sdf1", result[0].Partition.Name)
 		assert.Equal(t, "/tmp/scandir", result[0].MountPoint)
 
-		assert.Equal(t, "/dev/sdf3", result[1].Name)
+		assert.Equal(t, "/dev/sdf3", result[1].Partition.Name)
 		assert.Equal(t, "/tmp/scandir/boot/efi", result[1].MountPoint)
-
-		assert.Equal(t, "/dev/sdg1", result[2].Name)
-		assert.Equal(t, "", result[2].MountPoint)
-	})
-
-	t.Run("test pre-mounted", func(t *testing.T) {
-		partitions := []*snapshot.PartitionInfo{
-			{
-				Name:   "/dev/sdf1",
-				FsType: "ext4",
-				Uuid:   "sdf1-uuid",
-			},
-			{
-				Name:       "/dev/sdf3",
-				FsType:     "fat32",
-				PartUuid:   "sdf3-uuid",
-				MountPoint: "/tmp/prescandir",
-			},
-			{
-				Name:   "/dev/sdg1",
-				FsType: "ext4",
-				Label:  "data-label",
-			},
-		}
-		entries := []resources.FstabEntry{
-			{
-				Device:     "UUID=sdf1-uuid",
-				Mountpoint: "/",
-				Fstype:     "ext4",
-				Options:    []string{"defaults"},
-			},
-			{
-				Device:     "PARTUUID=sdf3-uuid",
-				Mountpoint: "/boot/efi",
-				Fstype:     "fat32",
-				Options:    []string{"defaults"},
-			},
-			{
-				Device:     "LABEL=data-label",
-				Mountpoint: "/data",
-				Fstype:     "ext4",
-				Options:    []string{"defaults"},
-			},
-		}
-
-		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
-			PartitionInfo: partitions[0], ScanDir: nil,
-		})).Return("/tmp/scandir", nil).Times(1)
-		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
-			PartitionInfo: partitions[1], ScanDir: ptr.To("/tmp/scandir/boot/efi"),
-		})).Return("/tmp/scandir/boot/efi", nil).Times(1)
-		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
-			PartitionInfo: partitions[2], ScanDir: ptr.To("/tmp/scandir/data"),
-		})).Return("/tmp/scandir/data", nil).Times(1)
-
-		f.volumeMounter.EXPECT().UMount(partitions[1]).Return(nil).Times(1)
-
-		result, err := f.dmgr.mountWithFstab(partitions, entries)
-		assert.NoError(t, err)
-		assert.Len(t, result, 3)
-
-		assert.Equal(t, "/dev/sdf1", result[0].Name)
-		assert.Equal(t, "/tmp/scandir", result[0].MountPoint)
-
-		assert.Equal(t, "/dev/sdf3", result[1].Name)
-		assert.Equal(t, "/tmp/scandir/boot/efi", result[1].MountPoint)
-
-		assert.Equal(t, "/dev/sdg1", result[2].Name)
-		assert.Equal(t, "/tmp/scandir/data", result[2].MountPoint)
-	})
-
-	t.Run("test pre-mounted root", func(t *testing.T) {
-		partitions := []*snapshot.PartitionInfo{
-			{
-				Name:       "/dev/sdf1",
-				FsType:     "ext4",
-				Uuid:       "sdf1-uuid",
-				MountPoint: "/tmp/prescandir",
-			},
-			{
-				Name:     "/dev/sdf3",
-				FsType:   "fat32",
-				PartUuid: "sdf3-uuid",
-			},
-			{
-				Name:   "/dev/sdg1",
-				FsType: "ext4",
-				Label:  "data-label",
-			},
-		}
-		entries := []resources.FstabEntry{
-			{
-				Device:     "UUID=sdf1-uuid",
-				Mountpoint: "/",
-				Fstype:     "ext4",
-				Options:    []string{"defaults"},
-			},
-			{
-				Device:     "PARTUUID=sdf3-uuid",
-				Mountpoint: "/boot/efi",
-				Fstype:     "fat32",
-				Options:    []string{"defaults"},
-			},
-			{
-				Device:     "LABEL=data-label",
-				Mountpoint: "/data",
-				Fstype:     "ext4",
-				Options:    []string{"defaults"},
-			},
-		}
-
-		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
-			PartitionInfo: partitions[1], ScanDir: ptr.To("/tmp/prescandir/boot/efi"),
-		})).Return("/tmp/prescandir/boot/efi", nil).Times(1)
-		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
-			PartitionInfo: partitions[2], ScanDir: ptr.To("/tmp/prescandir/data"),
-		})).Return("/tmp/prescandir/data", nil).Times(1)
-
-		result, err := f.dmgr.mountWithFstab(partitions, entries)
-		assert.NoError(t, err)
-		assert.Len(t, result, 3)
-
-		assert.Equal(t, "/dev/sdf1", result[0].Name)
-		assert.Equal(t, "/tmp/prescandir", result[0].MountPoint)
-
-		assert.Equal(t, "/dev/sdf3", result[1].Name)
-		assert.Equal(t, "/tmp/prescandir/boot/efi", result[1].MountPoint)
-
-		assert.Equal(t, "/dev/sdg1", result[2].Name)
-		assert.Equal(t, "/tmp/prescandir/data", result[2].MountPoint)
 	})
 }

--- a/providers/os/connection/device/linux/device_manager_test.go
+++ b/providers/os/connection/device/linux/device_manager_test.go
@@ -35,7 +35,6 @@ func newFixture(t *testing.T) *deviceManagerTestFixture {
 
 func TestMountWithFstab(t *testing.T) {
 	f := newFixture(t)
-
 	t.Run("happy path", func(t *testing.T) {
 		partitions := []*snapshot.Partition{
 			{
@@ -98,11 +97,11 @@ func TestMountWithFstab(t *testing.T) {
 		assert.Equal(t, "/dev/sdf1", result[0].Partition.Name)
 		assert.Equal(t, "/tmp/scandir", result[0].MountPoint)
 
-		assert.Equal(t, "/dev/sdf3", result[1].Partition.Name)
-		assert.Equal(t, "/tmp/scandir/boot/efi", result[1].MountPoint)
+		assert.Equal(t, "/dev/sdg1", result[1].Partition.Name)
+		assert.Equal(t, "/tmp/scandir/data", result[1].MountPoint)
 
-		assert.Equal(t, "/dev/sdg1", result[2].Partition.Name)
-		assert.Equal(t, "/tmp/scandir/data", result[2].MountPoint)
+		assert.Equal(t, "/dev/sdf3", result[2].Partition.Name)
+		assert.Equal(t, "/tmp/scandir/boot/efi", result[2].MountPoint)
 	})
 
 	t.Run("double mounted", func(t *testing.T) {
@@ -152,41 +151,24 @@ func TestMountWithFstab(t *testing.T) {
 
 		f.volumeMounter.
 			EXPECT().
-			Mount(&snapshot.MountPartitionInput{MountOptions: []string{"defaults"}, Partition: partitions[0]}).
+			Mount(&snapshot.MountPartitionInput{MountOptions: []string{"defaults", "subvolume=root"}, Partition: partitions[0]}).
 			Return(&snapshot.MountedPartition{Partition: partitions[0], MountOptions: []string{"defaults"}, MountPoint: "/tmp/scandir"}, nil).
 			Times(1)
 		f.volumeMounter.
 			EXPECT().
-			Mount(&snapshot.MountPartitionInput{MountOptions: []string{"defaults"}, Partition: partitions[1], MountDir: "/tmp/scandir/boot/efi"}).
-			Return(&snapshot.MountedPartition{Partition: partitions[1], MountOptions: []string{"defaults"}, MountPoint: "/tmp/scandir/boot/efi"}, nil).
+			Mount(&snapshot.MountPartitionInput{MountOptions: []string{"defaults", "subvolume=home"}, Partition: partitions[0], MountDir: "/tmp/scandir/home"}).
+			Return(&snapshot.MountedPartition{Partition: partitions[0], MountOptions: []string{"defaults"}, MountPoint: "/tmp/scandir/home"}, nil).
 			Times(1)
 		f.volumeMounter.
 			EXPECT().
 			Mount(&snapshot.MountPartitionInput{MountOptions: []string{"defaults"}, Partition: partitions[2], MountDir: "/tmp/scandir/data"}).
 			Return(&snapshot.MountedPartition{Partition: partitions[2], MountOptions: []string{"defaults"}, MountPoint: "/tmp/scandir/data"}, nil).
 			Times(1)
-
 		f.volumeMounter.
 			EXPECT().
-			Mount(&snapshot.MountPartitionInput{MountOptions: []string{"defaults"}, Partition: partitions[2], MountDir: "/tmp/scandir/home"}).
-			Return(&snapshot.MountedPartition{Partition: partitions[2], MountOptions: []string{"defaults"}, MountPoint: "/tmp/scandir/home"}, nil).
+			Mount(&snapshot.MountPartitionInput{MountOptions: []string{"defaults"}, Partition: partitions[1], MountDir: "/tmp/scandir/boot/efi"}).
+			Return(&snapshot.MountedPartition{Partition: partitions[1], MountOptions: []string{"defaults"}, MountPoint: "/tmp/scandir/boot/efi"}, nil).
 			Times(1)
-
-		// f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
-		// 	Partition: partitions[0], ScanDir: nil,
-		// })).Return("/tmp/scandir", nil).Times(1)
-		// f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
-		// 	Partition: partitions[1], ScanDir: ptr.To("/tmp/scandir/boot/efi"),
-		// })).Return("/tmp/scandir/boot/efi", nil).Times(1)
-		// f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
-		// 	Partition: partitions[2], ScanDir: ptr.To("/tmp/scandir/data"),
-		// })).Return("/tmp/scandir/data", nil).Times(1)
-
-		// f.volumeMounter.EXPECT().Mount(gomock.Cond(func(dto *snapshot.MountPartitionInput) bool {
-		// 	return dto.Name == "/dev/sdf1" &&
-		// 		slices.Equal(dto.MountOptions, entries[1].Options) &&
-		// 		dto.ScanDir != nil && *dto.ScanDir == "/tmp/scandir/home"
-		// })).Return("/tmp/scandir/home", nil).Times(1)
 
 		result, err := f.dmgr.mountWithFstab(partitions, entries)
 		assert.NoError(t, err)
@@ -195,14 +177,14 @@ func TestMountWithFstab(t *testing.T) {
 		assert.Equal(t, "/dev/sdf1", result[0].Partition.Name)
 		assert.Equal(t, "/tmp/scandir", result[0].MountPoint)
 
-		assert.Equal(t, "/dev/sdf3", result[1].Partition.Name)
-		assert.Equal(t, "/tmp/scandir/boot/efi", result[1].MountPoint)
+		assert.Equal(t, "/dev/sdf1", result[1].Partition.Name)
+		assert.Equal(t, "/tmp/scandir/home", result[1].MountPoint)
 
 		assert.Equal(t, "/dev/sdg1", result[2].Partition.Name)
 		assert.Equal(t, "/tmp/scandir/data", result[2].MountPoint)
 
-		assert.Equal(t, "/dev/sdf1", result[3].Partition.Name)
-		assert.Equal(t, "/tmp/scandir/home", result[3].MountPoint)
+		assert.Equal(t, "/dev/sdf3", result[3].Partition.Name)
+		assert.Equal(t, "/tmp/scandir/boot/efi", result[3].MountPoint)
 	})
 
 	t.Run("no entries matched", func(t *testing.T) {
@@ -246,16 +228,7 @@ func TestMountWithFstab(t *testing.T) {
 
 		result, err := f.dmgr.mountWithFstab(partitions, entries)
 		assert.NoError(t, err)
-		assert.Len(t, result, 3)
-
-		assert.Equal(t, "/dev/sdf1", result[0].Partition.Name)
-		assert.Equal(t, "", result[0].MountPoint)
-
-		assert.Equal(t, "/dev/sdf3", result[1].Partition.Name)
-		assert.Equal(t, "", result[1].MountPoint)
-
-		assert.Equal(t, "/dev/sdg1", result[2].Partition.Name)
-		assert.Equal(t, "", result[2].MountPoint)
+		assert.Len(t, result, 0)
 	})
 
 	t.Run("root not found", func(t *testing.T) {
@@ -299,8 +272,8 @@ func TestMountWithFstab(t *testing.T) {
 
 		f.volumeMounter.
 			EXPECT().
-			Mount(&snapshot.MountPartitionInput{MountOptions: []string{"defaults"}, Partition: partitions[1]}).
-			Return(&snapshot.MountedPartition{Partition: partitions[1], MountOptions: []string{"defaults"}, MountPoint: "/tmp/scandir1"}, nil).
+			Mount(&snapshot.MountPartitionInput{MountOptions: []string{"defaults"}, Partition: partitions[2]}).
+			Return(&snapshot.MountedPartition{Partition: partitions[2], MountOptions: []string{"defaults"}, MountPoint: "/tmp/scandir1"}, nil).
 			Times(1)
 		f.volumeMounter.
 			EXPECT().
@@ -312,10 +285,10 @@ func TestMountWithFstab(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, result, 2)
 
-		assert.Equal(t, "/dev/sdf3", result[0].Partition.Name)
+		assert.Equal(t, "/dev/sdg1", result[0].Partition.Name)
 		assert.Equal(t, "/tmp/scandir1", result[0].MountPoint)
 
-		assert.Equal(t, "/dev/sdg1", result[1].Partition.Name)
+		assert.Equal(t, "/dev/sdf3", result[1].Partition.Name)
 		assert.Equal(t, "/tmp/scandir2", result[1].MountPoint)
 	})
 

--- a/providers/os/connection/device/linux/device_manager_test.go
+++ b/providers/os/connection/device/linux/device_manager_test.go
@@ -39,7 +39,7 @@ func TestMountWithFstab(t *testing.T) {
 	f := newFixture(t)
 
 	t.Run("happy path", func(t *testing.T) {
-		partitions := []*snapshot.PartitionInfo{
+		partitions := []*snapshot.Partition{
 			{
 				Name:   "/dev/sdf1",
 				FsType: "ext4",
@@ -77,13 +77,15 @@ func TestMountWithFstab(t *testing.T) {
 			},
 		}
 
-		f.volumeMounter.EXPECT().MountP(gomock.Eq(&snapshot.MountPartitionDto{
-			PartitionInfo: partitions[0], ScanDir: nil,
-		})).Return("/tmp/scandir", nil).Times(1)
-		f.volumeMounter.EXPECT().MountP(gomock.Eq(&snapshot.MountPartitionDto{
+		f.volumeMounter.EXPECT().Mount(&snapshot.MountPartitionInput{
+			MountOptions: []string{"defaults"},
+			FsType:       "ext4",
+			Name:         "/dev/sdf1",
+		}).Return("/tmp/scandir", nil).Times(1)
+		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
 			PartitionInfo: partitions[1], ScanDir: ptr.To("/tmp/scandir/boot/efi"),
 		})).Return("/tmp/scandir/boot/efi", nil).Times(1)
-		f.volumeMounter.EXPECT().MountP(gomock.Eq(&snapshot.MountPartitionDto{
+		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
 			PartitionInfo: partitions[2], ScanDir: ptr.To("/tmp/scandir/data"),
 		})).Return("/tmp/scandir/data", nil).Times(1)
 
@@ -146,17 +148,17 @@ func TestMountWithFstab(t *testing.T) {
 			},
 		}
 
-		f.volumeMounter.EXPECT().MountP(gomock.Eq(&snapshot.MountPartitionDto{
+		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
 			PartitionInfo: partitions[0], ScanDir: nil,
 		})).Return("/tmp/scandir", nil).Times(1)
-		f.volumeMounter.EXPECT().MountP(gomock.Eq(&snapshot.MountPartitionDto{
+		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
 			PartitionInfo: partitions[1], ScanDir: ptr.To("/tmp/scandir/boot/efi"),
 		})).Return("/tmp/scandir/boot/efi", nil).Times(1)
-		f.volumeMounter.EXPECT().MountP(gomock.Eq(&snapshot.MountPartitionDto{
+		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
 			PartitionInfo: partitions[2], ScanDir: ptr.To("/tmp/scandir/data"),
 		})).Return("/tmp/scandir/data", nil).Times(1)
 
-		f.volumeMounter.EXPECT().MountP(gomock.Cond(func(dto *snapshot.MountPartitionDto) bool {
+		f.volumeMounter.EXPECT().Mount(gomock.Cond(func(dto *snapshot.MountPartitionInput) bool {
 			return dto.Name == "/dev/sdf1" &&
 				slices.Equal(dto.MountOptions, entries[1].Options) &&
 				dto.ScanDir != nil && *dto.ScanDir == "/tmp/scandir/home"
@@ -271,10 +273,10 @@ func TestMountWithFstab(t *testing.T) {
 			},
 		}
 
-		f.volumeMounter.EXPECT().MountP(gomock.Eq(&snapshot.MountPartitionDto{
+		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
 			PartitionInfo: partitions[1], ScanDir: nil,
 		})).Return("/tmp/scandir1", nil).Times(1)
-		f.volumeMounter.EXPECT().MountP(gomock.Eq(&snapshot.MountPartitionDto{
+		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
 			PartitionInfo: partitions[2], ScanDir: nil,
 		})).Return("/tmp/scandir2", nil).Times(1)
 
@@ -331,10 +333,10 @@ func TestMountWithFstab(t *testing.T) {
 			},
 		}
 
-		f.volumeMounter.EXPECT().MountP(gomock.Eq(&snapshot.MountPartitionDto{
+		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
 			PartitionInfo: partitions[0], ScanDir: nil,
 		})).Return("/tmp/scandir", nil).Times(1)
-		f.volumeMounter.EXPECT().MountP(gomock.Eq(&snapshot.MountPartitionDto{
+		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
 			PartitionInfo: partitions[1], ScanDir: ptr.To("/tmp/scandir/boot/efi"),
 		})).Return("/tmp/scandir/boot/efi", nil).Times(1)
 
@@ -392,17 +394,17 @@ func TestMountWithFstab(t *testing.T) {
 			},
 		}
 
-		f.volumeMounter.EXPECT().MountP(gomock.Eq(&snapshot.MountPartitionDto{
+		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
 			PartitionInfo: partitions[0], ScanDir: nil,
 		})).Return("/tmp/scandir", nil).Times(1)
-		f.volumeMounter.EXPECT().MountP(gomock.Eq(&snapshot.MountPartitionDto{
+		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
 			PartitionInfo: partitions[1], ScanDir: ptr.To("/tmp/scandir/boot/efi"),
 		})).Return("/tmp/scandir/boot/efi", nil).Times(1)
-		f.volumeMounter.EXPECT().MountP(gomock.Eq(&snapshot.MountPartitionDto{
+		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
 			PartitionInfo: partitions[2], ScanDir: ptr.To("/tmp/scandir/data"),
 		})).Return("/tmp/scandir/data", nil).Times(1)
 
-		f.volumeMounter.EXPECT().UmountP(partitions[1]).Return(nil).Times(1)
+		f.volumeMounter.EXPECT().UMount(partitions[1]).Return(nil).Times(1)
 
 		result, err := f.dmgr.mountWithFstab(partitions, entries)
 		assert.NoError(t, err)
@@ -458,10 +460,10 @@ func TestMountWithFstab(t *testing.T) {
 			},
 		}
 
-		f.volumeMounter.EXPECT().MountP(gomock.Eq(&snapshot.MountPartitionDto{
+		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
 			PartitionInfo: partitions[1], ScanDir: ptr.To("/tmp/prescandir/boot/efi"),
 		})).Return("/tmp/prescandir/boot/efi", nil).Times(1)
-		f.volumeMounter.EXPECT().MountP(gomock.Eq(&snapshot.MountPartitionDto{
+		f.volumeMounter.EXPECT().Mount(gomock.Eq(&snapshot.MountPartitionInput{
 			PartitionInfo: partitions[2], ScanDir: ptr.To("/tmp/prescandir/data"),
 		})).Return("/tmp/prescandir/data", nil).Times(1)
 

--- a/providers/os/connection/device/windows/device_manager.go
+++ b/providers/os/connection/device/windows/device_manager.go
@@ -42,7 +42,7 @@ func (d *WindowsDeviceManager) Name() string {
 	return "windows"
 }
 
-func (d *WindowsDeviceManager) IdentifyMountTargets(opts map[string]string) ([]*snapshot.PartitionInfo, error) {
+func (d *WindowsDeviceManager) IdentifyMountTargets(opts map[string]string) ([]*snapshot.Partition, error) {
 	log.Debug().Msg("device connection> identifying mount targets")
 	diskDrives, err := d.IdentifyDiskDrives()
 	if err != nil {
@@ -83,11 +83,11 @@ func (d *WindowsDeviceManager) IdentifyMountTargets(opts map[string]string) ([]*
 	if err != nil {
 		return nil, err
 	}
-	partitionInfo := &snapshot.PartitionInfo{
+	partitionInfo := &snapshot.Partition{
 		Name:   partition.DriveLetter,
 		FsType: "Windows",
 	}
-	return []*snapshot.PartitionInfo{partitionInfo}, nil
+	return []*snapshot.Partition{partitionInfo}, nil
 }
 
 // validates the options provided to the device manager
@@ -106,13 +106,26 @@ func validateOpts(opts map[string]string) error {
 	return nil
 }
 
-func (d *WindowsDeviceManager) Mount(pi *snapshot.PartitionInfo) (string, error) {
-	// note: we do not (yet) do the mounting in windows. for now, we simply return the drive letter
-	// as that means the drive is already mounted
-	if strings.HasSuffix(pi.Name, ":") {
-		return pi.Name, nil
+func (d *WindowsDeviceManager) Mount(partitions []*snapshot.Partition) ([]*snapshot.MountedPartition, error) {
+	res := []*snapshot.MountedPartition{}
+	for _, partition := range partitions {
+		name := partition.Name
+		if !strings.HasSuffix(name, ":") {
+			name += ":"
+		}
+		mp := &snapshot.MountedPartition{
+			Name:         partition.Name,
+			FsType:       partition.FsType,
+			Label:        partition.Label,
+			Uuid:         partition.Uuid,
+			PartUuid:     partition.PartUuid,
+			MountPoint:   name,
+			MountOptions: []string{}, // Windows does not use mount options like Linux
+			Aliases:      partition.Aliases,
+		}
+		res = append(res, mp)
 	}
-	return pi.Name + ":", nil
+	return res, nil
 }
 
 func (d *WindowsDeviceManager) UnmountAndClose() {

--- a/providers/os/connection/device/windows/device_manager.go
+++ b/providers/os/connection/device/windows/device_manager.go
@@ -114,14 +114,9 @@ func (d *WindowsDeviceManager) Mount(partitions []*snapshot.Partition) ([]*snaps
 			name += ":"
 		}
 		mp := &snapshot.MountedPartition{
-			Name:         partition.Name,
-			FsType:       partition.FsType,
-			Label:        partition.Label,
-			Uuid:         partition.Uuid,
-			PartUuid:     partition.PartUuid,
+			Partition:    partition,
 			MountPoint:   name,
 			MountOptions: []string{}, // Windows does not use mount options like Linux
-			Aliases:      partition.Aliases,
 		}
 		res = append(res, mp)
 	}

--- a/providers/os/connection/snapshot/blockdevices.go
+++ b/providers/os/connection/snapshot/blockdevices.go
@@ -207,7 +207,7 @@ func (device *BlockDevice) GetPartitions(includeBoot bool, includeMounted bool) 
 			return false
 		}
 
-		// sltekip mounted partitions unless includeMounted is true
+		// skip mounted partitions unless includeMounted is true
 		if partition.isMounted() && !includeMounted {
 			log.Debug().Str("name", partition.Name).Strs("mountpoints", partition.MountPoints).Msg("skipping mounted partition")
 			return false

--- a/providers/os/connection/snapshot/blockdevices.go
+++ b/providers/os/connection/snapshot/blockdevices.go
@@ -18,30 +18,34 @@ import (
 )
 
 type BlockDevices struct {
-	BlockDevices []BlockDevice `json:"blockDevices,omitempty"`
+	BlockDevices []*BlockDevice `json:"blockDevices,omitempty"`
 }
 
 type BlockDevice struct {
-	Name        string        `json:"name,omitempty"`
-	FsType      string        `json:"fstype,omitempty"`
-	Label       string        `json:"label,omitempty"`
-	Uuid        string        `json:"uuid,omitempty"`
-	PartUuid    string        `json:"partuuid,omitempty"`
-	MountPoints []string      `json:"mountpoints,omitempty"`
-	Children    []BlockDevice `json:"children,omitempty"`
-	Size        Size          `json:"size,omitempty"`
+	Name        string         `json:"name,omitempty"`
+	FsType      string         `json:"fstype,omitempty"`
+	Label       string         `json:"label,omitempty"`
+	Uuid        string         `json:"uuid,omitempty"`
+	PartUuid    string         `json:"partuuid,omitempty"`
+	MountPoints []string       `json:"mountpoints,omitempty"`
+	Children    []*BlockDevice `json:"children,omitempty"`
+	Size        Size           `json:"size,omitempty"`
 
-	Aliases []string `json:"-"`
+	// This is how the device was requested/searched as. It might differ from the actual name
+	// e.g. we treat /dev/sdm the same as /dev/xvdm, so RequestedName can be '/dev/sdm' while Name is '/dev/xvdm'
+	RequestedName string   `json:"-"`
+	Aliases       []string `json:"-"`
 }
 
 func (b BlockDevice) Partition(devPath string) *Partition {
 	return &Partition{
-		Name:     path.Join(devPath, b.Name),
-		FsType:   b.FsType,
-		Label:    b.Label,
-		Uuid:     b.Uuid,
-		PartUuid: b.PartUuid,
-		Aliases:  b.Aliases,
+		Name:          path.Join(devPath, b.Name),
+		FsType:        b.FsType,
+		Label:         b.Label,
+		Uuid:          b.Uuid,
+		PartUuid:      b.PartUuid,
+		Aliases:       b.Aliases,
+		RequestedName: b.RequestedName,
 	}
 }
 
@@ -120,21 +124,21 @@ func (blockEntries *BlockDevices) findAliases() {
 }
 
 // Searches for a device by name
-func (blockEntries BlockDevices) FindDevice(requested string) (BlockDevice, error) {
+func (blockEntries BlockDevices) FindDevice(requested string) (*BlockDevice, error) {
 	log.Debug().Str("device", requested).Msg("searching for device")
 
 	devices := blockEntries.BlockDevices
 	if len(devices) == 0 {
-		return BlockDevice{}, fmt.Errorf("no block devices found")
+		return nil, fmt.Errorf("no block devices found")
 	}
 
 	requestedName := strings.TrimPrefix(requested, "/dev/")
 	lmsCache := map[string]int{}
 	bestMatch := struct {
-		Device BlockDevice
+		Device *BlockDevice
 		Lms    int
 	}{
-		Device: BlockDevice{},
+		Device: nil,
 		Lms:    0,
 	}
 
@@ -144,6 +148,7 @@ func (blockEntries BlockDevices) FindDevice(requested string) (BlockDevice, erro
 			Strs("aliases", d.Aliases).
 			Msg("checking device")
 		if d.Name == requestedName {
+			d.RequestedName = requested
 			return d, nil
 		}
 
@@ -163,6 +168,7 @@ func (blockEntries BlockDevices) FindDevice(requested string) (BlockDevice, erro
 	}
 
 	if bestMatch.Lms > 0 {
+		bestMatch.Device.RequestedName = requested
 		return bestMatch.Device, nil
 	}
 
@@ -171,11 +177,11 @@ func (blockEntries BlockDevices) FindDevice(requested string) (BlockDevice, erro
 		Any("checked_names", lmsCache).
 		Msg("no device found")
 
-	return BlockDevice{}, fmt.Errorf("no block device found with name %s", requested)
+	return nil, fmt.Errorf("no block device found with name %s", requested)
 }
 
 // Searches all the partitions in the device and finds one that can be mounted. It must be unmounted, non-boot partition
-func (device BlockDevice) GetPartitions(includeBoot bool, includeMounted bool) ([]*Partition, error) {
+func (device *BlockDevice) GetPartitions(includeBoot bool, includeMounted bool) ([]*Partition, error) {
 	log.Debug().Str("device", device.Name).Msg("get partitions for device")
 
 	blockDevices := &BlockDevices{
@@ -189,7 +195,7 @@ func (device BlockDevice) GetPartitions(includeBoot bool, includeMounted bool) (
 	sortBlockDevicesBySize(blockDevices.BlockDevices)
 	blockDevices.findAliases()
 
-	filter := func(partition BlockDevice) bool {
+	filter := func(partition *BlockDevice) bool {
 		if partition.FsType == "" {
 			log.Debug().Str("name", partition.Name).Msg("skipping partition without filesystem type")
 			return false
@@ -241,8 +247,8 @@ func (device BlockDevice) GetPartitions(includeBoot bool, includeMounted bool) (
 	return partitions, nil
 }
 
-func mapLVM2Partitions(part BlockDevice) (partitions []*Partition) {
-	for _, p := range part.Children {
+func mapLVM2Partitions(device *BlockDevice) (partitions []*Partition) {
+	for _, p := range device.Children {
 		partitions = append(partitions, p.Partition("/dev/mapper"))
 	}
 
@@ -250,7 +256,7 @@ func mapLVM2Partitions(part BlockDevice) (partitions []*Partition) {
 }
 
 // If multiple partitions meet this criteria, the largest one is returned.
-func (device BlockDevice) GetMountablePartition() (*Partition, error) {
+func (device *BlockDevice) GetMountablePartition() (*Partition, error) {
 	// return the largest partition. we can extend this to be a parameter in the future
 	partitions, err := device.GetPartitions(false, false)
 	if err != nil {
@@ -260,15 +266,14 @@ func (device BlockDevice) GetMountablePartition() (*Partition, error) {
 	return partitions[0], nil
 }
 
-func sortBlockDevicesBySize(partitions []BlockDevice) {
+func sortBlockDevicesBySize(partitions []*BlockDevice) {
 	sort.Slice(partitions, func(i, j int) bool {
 		return partitions[i].Size > partitions[j].Size
 	})
 }
 
 func (blockEntries *BlockDevices) findAlias(alias, path string) {
-	for i := range blockEntries.BlockDevices {
-		device := blockEntries.BlockDevices[i]
+	for _, device := range blockEntries.BlockDevices {
 		if alias == device.Name {
 			log.Debug().
 				Str("alias", alias).
@@ -276,7 +281,6 @@ func (blockEntries *BlockDevices) findAlias(alias, path string) {
 				Str("name", device.Name).
 				Msg("found alias")
 			device.Aliases = append(device.Aliases, path)
-			blockEntries.BlockDevices[i] = device
 			return
 		}
 	}

--- a/providers/os/connection/snapshot/blockdevices_test.go
+++ b/providers/os/connection/snapshot/blockdevices_test.go
@@ -61,10 +61,10 @@ func TestBlockDevicesUnmarshal(t *testing.T) {
 func TestFindDevice(t *testing.T) {
 	t.Run("match by exact name", func(t *testing.T) {
 		blockEntries := BlockDevices{
-			BlockDevices: []BlockDevice{
-				{Name: "sda", Children: []BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
-				{Name: "nvme0n1", Children: []BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
-				{Name: "sdx", Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
+			BlockDevices: []*BlockDevice{
+				{Name: "sda", Children: []*BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
+				{Name: "nvme0n1", Children: []*BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
+				{Name: "sdx", Children: []*BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 			},
 		}
 
@@ -76,10 +76,10 @@ func TestFindDevice(t *testing.T) {
 
 	t.Run("match by alias name", func(t *testing.T) {
 		blockEntries := BlockDevices{
-			BlockDevices: []BlockDevice{
-				{Name: "sda", Children: []BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
-				{Name: "nvme0n1", Children: []BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
-				{Name: "sdx", Aliases: []string{"xvdx"}, Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
+			BlockDevices: []*BlockDevice{
+				{Name: "sda", Children: []*BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
+				{Name: "nvme0n1", Children: []*BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
+				{Name: "sdx", Aliases: []string{"xvdx"}, Children: []*BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 			},
 		}
 
@@ -91,10 +91,10 @@ func TestFindDevice(t *testing.T) {
 
 	t.Run("match by interchangeable name", func(t *testing.T) {
 		blockEntries := BlockDevices{
-			BlockDevices: []BlockDevice{
-				{Name: "sda", Children: []BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
-				{Name: "nvme0n1", Children: []BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
-				{Name: "xvdc", Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
+			BlockDevices: []*BlockDevice{
+				{Name: "sda", Children: []*BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
+				{Name: "nvme0n1", Children: []*BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
+				{Name: "xvdc", Children: []*BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 			},
 		}
 
@@ -106,10 +106,10 @@ func TestFindDevice(t *testing.T) {
 
 	t.Run("no match", func(t *testing.T) {
 		blockEntries := BlockDevices{
-			BlockDevices: []BlockDevice{
-				{Name: "sda", Children: []BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
-				{Name: "nvme0n1", Children: []BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
-				{Name: "xvdc", Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
+			BlockDevices: []*BlockDevice{
+				{Name: "sda", Children: []*BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
+				{Name: "nvme0n1", Children: []*BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
+				{Name: "xvdc", Children: []*BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 			},
 		}
 
@@ -120,11 +120,11 @@ func TestFindDevice(t *testing.T) {
 
 	t.Run("multiple matches by trailing letter", func(t *testing.T) {
 		blockEntries := BlockDevices{
-			BlockDevices: []BlockDevice{
-				{Name: "sda", Children: []BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
-				{Name: "nvme0n1", Children: []BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
-				{Name: "stc", Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
-				{Name: "xvdc", Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
+			BlockDevices: []*BlockDevice{
+				{Name: "sda", Children: []*BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
+				{Name: "nvme0n1", Children: []*BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
+				{Name: "stc", Children: []*BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
+				{Name: "xvdc", Children: []*BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 			},
 		}
 
@@ -136,11 +136,11 @@ func TestFindDevice(t *testing.T) {
 
 	t.Run("perfect match and trailing letter matches", func(t *testing.T) {
 		blockEntries := BlockDevices{
-			BlockDevices: []BlockDevice{
-				{Name: "sda", Children: []BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
-				{Name: "nvme0n1", Children: []BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
-				{Name: "sta", Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
-				{Name: "xvda", Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
+			BlockDevices: []*BlockDevice{
+				{Name: "sda", Children: []*BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
+				{Name: "nvme0n1", Children: []*BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
+				{Name: "sta", Children: []*BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
+				{Name: "xvda", Children: []*BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 			},
 		}
 
@@ -152,11 +152,11 @@ func TestFindDevice(t *testing.T) {
 
 	t.Run("perfect match and trailing letter matches (scrambled)", func(t *testing.T) {
 		blockEntries := BlockDevices{
-			BlockDevices: []BlockDevice{
-				{Name: "xvda", Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
-				{Name: "sta", Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
-				{Name: "nvme0n1", Children: []BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
-				{Name: "sda", Children: []BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
+			BlockDevices: []*BlockDevice{
+				{Name: "xvda", Children: []*BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
+				{Name: "sta", Children: []*BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
+				{Name: "nvme0n1", Children: []*BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
+				{Name: "sda", Children: []*BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
 			},
 		}
 
@@ -171,7 +171,7 @@ func TestGetMountablePartition(t *testing.T) {
 	t.Run("no suitable partition (mounted)", func(t *testing.T) {
 		block := BlockDevice{
 			Name: "sda",
-			Children: []BlockDevice{
+			Children: []*BlockDevice{
 				{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}},
 			},
 		}
@@ -183,7 +183,7 @@ func TestGetMountablePartition(t *testing.T) {
 	t.Run("no suitable partition (no fs type)", func(t *testing.T) {
 		block := BlockDevice{
 			Name: "sda",
-			Children: []BlockDevice{
+			Children: []*BlockDevice{
 				{Uuid: "1234", FsType: "", Label: "ROOT", Name: "sda1", MountPoints: []string{}},
 			},
 		}
@@ -195,7 +195,7 @@ func TestGetMountablePartition(t *testing.T) {
 	t.Run("no suitable partition (EFI label)", func(t *testing.T) {
 		block := BlockDevice{
 			Name: "sda",
-			Children: []BlockDevice{
+			Children: []*BlockDevice{
 				{Uuid: "1234", FsType: "xfs", Label: "EFI", Name: "sda1", MountPoints: []string{}},
 			},
 		}
@@ -207,7 +207,7 @@ func TestGetMountablePartition(t *testing.T) {
 	t.Run("no suitable partition (vfat fs type)", func(t *testing.T) {
 		block := BlockDevice{
 			Name: "sda",
-			Children: []BlockDevice{
+			Children: []*BlockDevice{
 				{Uuid: "1234", FsType: "vfat", Label: "", Name: "sda1", MountPoints: []string{}},
 			},
 		}
@@ -219,7 +219,7 @@ func TestGetMountablePartition(t *testing.T) {
 	t.Run("no suitable partition (boot label)", func(t *testing.T) {
 		block := BlockDevice{
 			Name: "sda",
-			Children: []BlockDevice{
+			Children: []*BlockDevice{
 				{Uuid: "1234", FsType: "xfs", Label: "boot", Name: "sda1", MountPoints: []string{}},
 			},
 		}
@@ -231,7 +231,7 @@ func TestGetMountablePartition(t *testing.T) {
 	t.Run("no suitable partition (empty)", func(t *testing.T) {
 		block := BlockDevice{
 			Name:     "sda",
-			Children: []BlockDevice{},
+			Children: []*BlockDevice{},
 		}
 		_, err := block.GetMountablePartition()
 		require.Error(t, err)
@@ -241,7 +241,7 @@ func TestGetMountablePartition(t *testing.T) {
 	t.Run("suitable single partition", func(t *testing.T) {
 		block := BlockDevice{
 			Name: "sde",
-			Children: []BlockDevice{
+			Children: []*BlockDevice{
 				{Uuid: "12346", FsType: "xfs", Size: 110, Label: "ROOT", Name: "sde1"},
 			},
 		}
@@ -253,7 +253,7 @@ func TestGetMountablePartition(t *testing.T) {
 	t.Run("largest suitable partition", func(t *testing.T) {
 		block := BlockDevice{
 			Name: "sda",
-			Children: []BlockDevice{
+			Children: []*BlockDevice{
 				{Uuid: "12346", FsType: "xfs", Size: 110, Label: "ROOT", Name: "sda1"},
 				{Uuid: "12346", FsType: "xfs", Size: 120, Label: "ROOT", Name: "sda2"},
 			},
@@ -268,7 +268,7 @@ func TestGetPartitions(t *testing.T) {
 	t.Run("get all non-mounted partitions", func(t *testing.T) {
 		block := BlockDevice{
 			Name: "sda",
-			Children: []BlockDevice{
+			Children: []*BlockDevice{
 				// already mounted
 				{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}},
 				{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "sda2", MountPoints: []string{}},
@@ -304,7 +304,7 @@ func TestGetPartitions(t *testing.T) {
 	t.Run("get all partitions (include mounted)", func(t *testing.T) {
 		block := BlockDevice{
 			Name: "sda",
-			Children: []BlockDevice{
+			Children: []*BlockDevice{
 				// already mounted
 				{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}},
 				{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "sda2", MountPoints: []string{}},
@@ -326,10 +326,10 @@ func TestGetPartitions(t *testing.T) {
 	t.Run("lvm2 partitions", func(t *testing.T) {
 		block := BlockDevice{
 			Name: "sda",
-			Children: []BlockDevice{
+			Children: []*BlockDevice{
 				{Uuid: "1234", FsType: "fat32", Label: "EFI", Name: "sda1", MountPoints: []string{}},
 				{
-					Uuid: "12345", FsType: "lvm2_member", Label: "LVM", Name: "sda2", MountPoints: []string{}, Children: []BlockDevice{
+					Uuid: "12345", FsType: "lvm2_member", Label: "LVM", Name: "sda2", MountPoints: []string{}, Children: []*BlockDevice{
 						{Uuid: "lv12346", FsType: "lvm", Label: "ROOT", Name: "rootvg-rootlv", MountPoints: []string{}},
 						{Uuid: "lv12347", FsType: "lvm", Label: "HOME", Name: "rootvg-homelv", MountPoints: []string{}},
 					},

--- a/providers/os/connection/snapshot/blockdevices_test.go
+++ b/providers/os/connection/snapshot/blockdevices_test.go
@@ -13,18 +13,18 @@ import (
 func TestBlockDevicesUnmarshal(t *testing.T) {
 	common := `{
    "blockdevices": [
-      {"name": "nvme1n1", "size": 8589934592, "fstype": null, "mountpoint": null, "label": null, "uuid": null,
+      {"name": "nvme1n1", "size": 8589934592, "fstype": null, "mountpoints": null, "label": null, "uuid": null,
          "children": [
-            {"name": "nvme1n1p1", "size": 7515127296, "fstype": "ext4", "mountpoint": null, "label": "cloudimg-rootfs", "uuid": "d84ccd9b-0384-4314-88be-5bd38eb59f30"},
-            {"name": "nvme1n1p14", "size": 4194304, "fstype": null, "mountpoint": null, "label": null, "uuid": null},
-            {"name": "nvme1n1p15", "size": 111149056, "fstype": "vfat", "mountpoint": null, "label": "UEFI", "uuid": "9601-9938"},
-            {"name": "nvme1n1p16", "size": 957350400, "fstype": "ext4", "mountpoint": null, "label": "BOOT", "uuid": "c2032e48-1c8e-4f92-87c6-9db270bf4274"}
+            {"name": "nvme1n1p1", "size": 7515127296, "fstype": "ext4", "mountpoints": null, "label": "cloudimg-rootfs", "uuid": "d84ccd9b-0384-4314-88be-5bd38eb59f30"},
+            {"name": "nvme1n1p14", "size": 4194304, "fstype": null, "mountpoints": null, "label": null, "uuid": null},
+            {"name": "nvme1n1p15", "size": 111149056, "fstype": "vfat", "mountpoints": null, "label": "UEFI", "uuid": "9601-9938"},
+            {"name": "nvme1n1p16", "size": 957350400, "fstype": "ext4", "mountpoints": null, "label": "BOOT", "uuid": "c2032e48-1c8e-4f92-87c6-9db270bf4274"}
          ]
       },
-      {"name": "nvme0n1", "size": "8589934592", "fstype": null, "mountpoint": null, "label": null, "uuid": null,
+      {"name": "nvme0n1", "size": "8589934592", "fstype": null, "mountpoints": null, "label": null, "uuid": null,
          "children": [
-            {"name": "nvme0n1p1", "size": 8578383360, "fstype": "xfs", "mountpoint": "/", "label": "/", "uuid": "804f6603-f3df-4054-8161-50bd9cbd9cf9"},
-            {"name": "nvme0n1p128", "size": 10485760, "fstype": "vfat", "mountpoint": "/boot/efi", "label": null, "uuid": "BCB5-3E0E"}
+            {"name": "nvme0n1p1", "size": 8578383360, "fstype": "xfs", "mountpoints": ["/"], "label": "/", "uuid": "804f6603-f3df-4054-8161-50bd9cbd9cf9"},
+            {"name": "nvme0n1p128", "size": 10485760, "fstype": "vfat", "mountpoints": ["/boot/efi"], "label": null, "uuid": "BCB5-3E0E"}
          ]
       }
    ]
@@ -36,18 +36,18 @@ func TestBlockDevicesUnmarshal(t *testing.T) {
 
 	stringer := `{
    "blockdevices": [
-      {"name": "nvme1n1", "size": "8589934592", "fstype": null, "mountpoint": null, "label": null, "uuid": null,
+      {"name": "nvme1n1", "size": "8589934592", "fstype": null, "mountpoints": null, "label": null, "uuid": null,
          "children": [
-            {"name": "nvme1n1p1", "size": "7515127296", "fstype": "ext4", "mountpoint": null, "label": "cloudimg-rootfs", "uuid": "d84ccd9b-0384-4314-88be-5bd38eb59f30"},
-            {"name": "nvme1n1p14", "size": "4194304", "fstype": null, "mountpoint": null, "label": null, "uuid": null},
-            {"name": "nvme1n1p15", "size": "111149056", "fstype": "vfat", "mountpoint": null, "label": "UEFI", "uuid": "9601-9938"},
-            {"name": "nvme1n1p16", "size": "957350400", "fstype": "ext4", "mountpoint": null, "label": "BOOT", "uuid": "c2032e48-1c8e-4f92-87c6-9db270bf4274"}
+            {"name": "nvme1n1p1", "size": "7515127296", "fstype": "ext4", "mountpoints": null, "label": "cloudimg-rootfs", "uuid": "d84ccd9b-0384-4314-88be-5bd38eb59f30"},
+            {"name": "nvme1n1p14", "size": "4194304", "fstype": null, "mountpoints": null, "label": null, "uuid": null},
+            {"name": "nvme1n1p15", "size": "111149056", "fstype": "vfat", "mountpoints": null, "label": "UEFI", "uuid": "9601-9938"},
+            {"name": "nvme1n1p16", "size": "957350400", "fstype": "ext4", "mountpoints": null, "label": "BOOT", "uuid": "c2032e48-1c8e-4f92-87c6-9db270bf4274"}
          ]
       },
-      {"name": "nvme0n1", "size": "8589934592", "fstype": null, "mountpoint": null, "label": null, "uuid": null,
+      {"name": "nvme0n1", "size": "8589934592", "fstype": null, "mountpoints": null, "label": null, "uuid": null,
          "children": [
-            {"name": "nvme0n1p1", "size": "8578383360", "fstype": "xfs", "mountpoint": "/", "label": "/", "uuid": "804f6603-f3df-4054-8161-50bd9cbd9cf9"},
-            {"name": "nvme0n1p128", "size": "10485760", "fstype": "vfat", "mountpoint": "/boot/efi", "label": null, "uuid": "BCB5-3E0E"}
+            {"name": "nvme0n1p1", "size": "8578383360", "fstype": "xfs", "mountpoints": ["/"], "label": "/", "uuid": "804f6603-f3df-4054-8161-50bd9cbd9cf9"},
+            {"name": "nvme0n1p128", "size": "10485760", "fstype": "vfat", "mountpoints": ["/boot/efi"], "label": null, "uuid": "BCB5-3E0E"}
          ]
       }
    ]
@@ -62,7 +62,7 @@ func TestFindDevice(t *testing.T) {
 	t.Run("match by exact name", func(t *testing.T) {
 		blockEntries := BlockDevices{
 			BlockDevices: []BlockDevice{
-				{Name: "sda", Children: []BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoint: "/"}}},
+				{Name: "sda", Children: []BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
 				{Name: "nvme0n1", Children: []BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 				{Name: "sdx", Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 			},
@@ -77,7 +77,7 @@ func TestFindDevice(t *testing.T) {
 	t.Run("match by alias name", func(t *testing.T) {
 		blockEntries := BlockDevices{
 			BlockDevices: []BlockDevice{
-				{Name: "sda", Children: []BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoint: "/"}}},
+				{Name: "sda", Children: []BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
 				{Name: "nvme0n1", Children: []BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 				{Name: "sdx", Aliases: []string{"xvdx"}, Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 			},
@@ -92,7 +92,7 @@ func TestFindDevice(t *testing.T) {
 	t.Run("match by interchangeable name", func(t *testing.T) {
 		blockEntries := BlockDevices{
 			BlockDevices: []BlockDevice{
-				{Name: "sda", Children: []BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoint: "/"}}},
+				{Name: "sda", Children: []BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
 				{Name: "nvme0n1", Children: []BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 				{Name: "xvdc", Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 			},
@@ -107,7 +107,7 @@ func TestFindDevice(t *testing.T) {
 	t.Run("no match", func(t *testing.T) {
 		blockEntries := BlockDevices{
 			BlockDevices: []BlockDevice{
-				{Name: "sda", Children: []BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoint: "/"}}},
+				{Name: "sda", Children: []BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
 				{Name: "nvme0n1", Children: []BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 				{Name: "xvdc", Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 			},
@@ -121,7 +121,7 @@ func TestFindDevice(t *testing.T) {
 	t.Run("multiple matches by trailing letter", func(t *testing.T) {
 		blockEntries := BlockDevices{
 			BlockDevices: []BlockDevice{
-				{Name: "sda", Children: []BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoint: "/"}}},
+				{Name: "sda", Children: []BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
 				{Name: "nvme0n1", Children: []BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 				{Name: "stc", Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 				{Name: "xvdc", Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
@@ -137,7 +137,7 @@ func TestFindDevice(t *testing.T) {
 	t.Run("perfect match and trailing letter matches", func(t *testing.T) {
 		blockEntries := BlockDevices{
 			BlockDevices: []BlockDevice{
-				{Name: "sda", Children: []BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoint: "/"}}},
+				{Name: "sda", Children: []BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
 				{Name: "nvme0n1", Children: []BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 				{Name: "sta", Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 				{Name: "xvda", Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
@@ -156,7 +156,7 @@ func TestFindDevice(t *testing.T) {
 				{Name: "xvda", Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 				{Name: "sta", Children: []BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 				{Name: "nvme0n1", Children: []BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
-				{Name: "sda", Children: []BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoint: "/"}}},
+				{Name: "sda", Children: []BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
 			},
 		}
 
@@ -172,7 +172,7 @@ func TestGetMountablePartition(t *testing.T) {
 		block := BlockDevice{
 			Name: "sda",
 			Children: []BlockDevice{
-				{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoint: "/"},
+				{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}},
 			},
 		}
 		_, err := block.GetMountablePartition()
@@ -184,7 +184,7 @@ func TestGetMountablePartition(t *testing.T) {
 		block := BlockDevice{
 			Name: "sda",
 			Children: []BlockDevice{
-				{Uuid: "1234", FsType: "", Label: "ROOT", Name: "sda1", MountPoint: ""},
+				{Uuid: "1234", FsType: "", Label: "ROOT", Name: "sda1", MountPoints: []string{}},
 			},
 		}
 		_, err := block.GetMountablePartition()
@@ -196,7 +196,7 @@ func TestGetMountablePartition(t *testing.T) {
 		block := BlockDevice{
 			Name: "sda",
 			Children: []BlockDevice{
-				{Uuid: "1234", FsType: "xfs", Label: "EFI", Name: "sda1", MountPoint: ""},
+				{Uuid: "1234", FsType: "xfs", Label: "EFI", Name: "sda1", MountPoints: []string{}},
 			},
 		}
 		_, err := block.GetMountablePartition()
@@ -208,7 +208,7 @@ func TestGetMountablePartition(t *testing.T) {
 		block := BlockDevice{
 			Name: "sda",
 			Children: []BlockDevice{
-				{Uuid: "1234", FsType: "vfat", Label: "", Name: "sda1", MountPoint: ""},
+				{Uuid: "1234", FsType: "vfat", Label: "", Name: "sda1", MountPoints: []string{}},
 			},
 		}
 		_, err := block.GetMountablePartition()
@@ -220,7 +220,7 @@ func TestGetMountablePartition(t *testing.T) {
 		block := BlockDevice{
 			Name: "sda",
 			Children: []BlockDevice{
-				{Uuid: "1234", FsType: "xfs", Label: "boot", Name: "sda1", MountPoint: ""},
+				{Uuid: "1234", FsType: "xfs", Label: "boot", Name: "sda1", MountPoints: []string{}},
 			},
 		}
 		_, err := block.GetMountablePartition()
@@ -247,7 +247,7 @@ func TestGetMountablePartition(t *testing.T) {
 		}
 		partition, err := block.GetMountablePartition()
 		require.Nil(t, err)
-		require.Equal(t, &PartitionInfo{FsType: "xfs", Name: "/dev/sde1", Uuid: "12346", Label: "ROOT"}, partition)
+		require.Equal(t, &Partition{FsType: "xfs", Name: "/dev/sde1", Uuid: "12346", Label: "ROOT"}, partition)
 	})
 
 	t.Run("largest suitable partition", func(t *testing.T) {
@@ -260,7 +260,7 @@ func TestGetMountablePartition(t *testing.T) {
 		}
 		partition, err := block.GetMountablePartition()
 		require.Nil(t, err)
-		require.Equal(t, &PartitionInfo{FsType: "xfs", Name: "/dev/sda2", Uuid: "12346", Label: "ROOT"}, partition)
+		require.Equal(t, &Partition{FsType: "xfs", Name: "/dev/sda2", Uuid: "12346", Label: "ROOT"}, partition)
 	})
 }
 
@@ -270,16 +270,16 @@ func TestGetPartitions(t *testing.T) {
 			Name: "sda",
 			Children: []BlockDevice{
 				// already mounted
-				{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoint: "/"},
-				{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "sda2", MountPoint: ""},
-				{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sda3", MountPoint: ""},
+				{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}},
+				{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "sda2", MountPoints: []string{}},
+				{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sda3", MountPoints: []string{}},
 				// no fs type
-				{Uuid: "12347", FsType: "", Label: "ROOT", Name: "sda4", MountPoint: ""},
+				{Uuid: "12347", FsType: "", Label: "ROOT", Name: "sda4", MountPoints: []string{}},
 			},
 		}
 		parts, err := block.GetPartitions(true, false)
 		require.NoError(t, err)
-		expected := []*PartitionInfo{
+		expected := []*Partition{
 			{Name: "/dev/sda2", FsType: "xfs", Uuid: "12345", Label: "ROOT"},
 			{Name: "/dev/sda3", FsType: "xfs", Uuid: "12346", Label: "ROOT"},
 		}
@@ -295,7 +295,7 @@ func TestGetPartitions(t *testing.T) {
 		}
 		parts, err := block.GetPartitions(true, false)
 		require.NoError(t, err)
-		expected := []*PartitionInfo{
+		expected := []*Partition{
 			{Name: "/dev/sda", FsType: "xfs", Uuid: "1234", Label: "ROOT"},
 		}
 		require.ElementsMatch(t, expected, parts)
@@ -306,17 +306,17 @@ func TestGetPartitions(t *testing.T) {
 			Name: "sda",
 			Children: []BlockDevice{
 				// already mounted
-				{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoint: "/"},
-				{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "sda2", MountPoint: ""},
-				{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sda3", MountPoint: ""},
+				{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}},
+				{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "sda2", MountPoints: []string{}},
+				{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sda3", MountPoints: []string{}},
 				// no fs type
-				{Uuid: "12347", FsType: "", Label: "ROOT", Name: "sda4", MountPoint: ""},
+				{Uuid: "12347", FsType: "", Label: "ROOT", Name: "sda4", MountPoints: []string{}},
 			},
 		}
 		parts, err := block.GetPartitions(true, true)
 		require.NoError(t, err)
-		expected := []*PartitionInfo{
-			{Name: "/dev/sda1", FsType: "xfs", Uuid: "1234", Label: "ROOT", MountPoint: "/"},
+		expected := []*Partition{
+			{Name: "/dev/sda1", FsType: "xfs", Uuid: "1234", Label: "ROOT"},
 			{Name: "/dev/sda2", FsType: "xfs", Uuid: "12345", Label: "ROOT"},
 			{Name: "/dev/sda3", FsType: "xfs", Uuid: "12346", Label: "ROOT"},
 		}
@@ -327,11 +327,11 @@ func TestGetPartitions(t *testing.T) {
 		block := BlockDevice{
 			Name: "sda",
 			Children: []BlockDevice{
-				{Uuid: "1234", FsType: "fat32", Label: "EFI", Name: "sda1", MountPoint: ""},
+				{Uuid: "1234", FsType: "fat32", Label: "EFI", Name: "sda1", MountPoints: []string{}},
 				{
-					Uuid: "12345", FsType: "lvm2_member", Label: "LVM", Name: "sda2", MountPoint: "", Children: []BlockDevice{
-						{Uuid: "lv12346", FsType: "lvm", Label: "ROOT", Name: "rootvg-rootlv", MountPoint: ""},
-						{Uuid: "lv12347", FsType: "lvm", Label: "HOME", Name: "rootvg-homelv", MountPoint: ""},
+					Uuid: "12345", FsType: "lvm2_member", Label: "LVM", Name: "sda2", MountPoints: []string{}, Children: []BlockDevice{
+						{Uuid: "lv12346", FsType: "lvm", Label: "ROOT", Name: "rootvg-rootlv", MountPoints: []string{}},
+						{Uuid: "lv12347", FsType: "lvm", Label: "HOME", Name: "rootvg-homelv", MountPoints: []string{}},
 					},
 				},
 			},
@@ -340,7 +340,7 @@ func TestGetPartitions(t *testing.T) {
 		parts, err := block.GetPartitions(true, false)
 		require.NoError(t, err)
 
-		expected := []*PartitionInfo{
+		expected := []*Partition{
 			{Name: "/dev/sda1", FsType: "fat32", Uuid: "1234", Label: "EFI"},
 			{Name: "/dev/mapper/rootvg-rootlv", FsType: "lvm", Uuid: "lv12346", Label: "ROOT"},
 			{Name: "/dev/mapper/rootvg-homelv", FsType: "lvm", Uuid: "lv12347", Label: "HOME"},

--- a/providers/os/connection/snapshot/partition.go
+++ b/providers/os/connection/snapshot/partition.go
@@ -31,12 +31,7 @@ type Partition struct {
 
 func (p *Partition) ToMountInput(opts []string, mountDir string) *MountPartitionInput {
 	return &MountPartitionInput{
-		Name:         p.Name,
-		FsType:       p.FsType,
-		Label:        p.Label,
-		Uuid:         p.Uuid,
-		PartUuid:     p.PartUuid,
-		RootPath:     p.RootPath,
+		Partition:    p,
 		MountOptions: opts,
 		MountDir:     mountDir,
 	}
@@ -47,50 +42,24 @@ func (p *Partition) ToDefaultMountInput() *MountPartitionInput {
 }
 
 type MountedPartition struct {
-	// Device name (e.g. /dev/sda1)
-	Name string
-	// Filesystem type (e.g. ext4)
-	FsType string
-
-	// Resolved device name aliases (e.g. /dev/sda1 -> /dev/nvme0n1p1)
-	Aliases []string
-	// (optional) Label is the partition label
-	Label string
-	// (optional) UUID is the volume UUID
-	Uuid       string
+	Partition *Partition
+	// MountPoint is the directory where the partition is mounted
 	MountPoint string
-	// (optional) PartUuid is the partition UUID
-	PartUuid string
-	// (optional) MountOptions are the mount options
+	// MountOptions are the mount options
 	MountOptions []string
-
-	// if specified, indicates where the root filesystem is present on the partition
-	// this is useful for ostree where the root fs is not under the mounted partition directly
-	// but is nested in a folder somewhere (e.g. boot.1)
-	// e.g. ostree/boot.1.1/fedora-coreos/1f65edba61a143a78be83340f66d3e247e20ec48a539724ca037607c7bdf4942/0
-	rootPath string
 }
 
 // MountPartitionInput is the input for the Mount method
 type MountPartitionInput struct {
+	Partition    *Partition
 	MountOptions []string
-	FsType       string
-	Label        string
-	PartUuid     string
-	Uuid         string
-	Name         string
 	// if specfied, mount the partition at this directory
 	MountDir string
-	// if specified, indicates where the root filesystem is present on the partition
-	// this is useful for ostree where the root fs is not under the mounted partition directly
-	// but is nested in a folder somewhere (e.g. boot.1)
-	// e.g. ostree/boot.1.1/fedora-coreos/1f65edba61a143a78be83340f66d3e247e20ec48a539724ca037607c7bdf4942/0
-	RootPath string
 }
 
 // Gets the path on the mounted partition where the root filesystem is located.
 func (mp *MountedPartition) RootFsPath() string {
-	return path.Join(mp.MountPoint, mp.rootPath)
+	return path.Join(mp.MountPoint, mp.Partition.RootPath)
 }
 
 func (entry BlockDevice) isNoBootVolume() bool {

--- a/providers/os/connection/snapshot/partition.go
+++ b/providers/os/connection/snapshot/partition.go
@@ -27,6 +27,11 @@ type Partition struct {
 	// but is nested in a folder somewhere (e.g. boot.1)
 	// e.g. ostree/boot.1.1/fedora-coreos/1f65edba61a143a78be83340f66d3e247e20ec48a539724ca037607c7bdf4942/0
 	RootPath string
+
+	// RequestedName is the name of the partition as requested by the user.
+	// This might differ from the actual Name if the partition was found using interchangeable names.
+	// E.g. this could be '/dev/sdm' while Name is '/dev/xvdm' since we treat [sd]m and [xvd]m the same.
+	RequestedName string
 }
 
 func (p *Partition) ToMountInput(opts []string, mountDir string) *MountPartitionInput {

--- a/providers/os/connection/snapshot/partition_test.go
+++ b/providers/os/connection/snapshot/partition_test.go
@@ -12,55 +12,55 @@ import (
 func TestIsNoBootVolume(t *testing.T) {
 	t.Run("is not boot", func(t *testing.T) {
 		block := BlockDevice{
-			Uuid:       "12345",
-			FsType:     "xfs",
-			Label:      "label",
-			Name:       "sda2",
-			MountPoint: "",
+			Uuid:        "12345",
+			FsType:      "xfs",
+			Label:       "label",
+			Name:        "sda2",
+			MountPoints: []string{},
 		}
 		require.True(t, block.isNoBootVolume())
 	})
 
 	t.Run("is boot (boot label)", func(t *testing.T) {
 		block := BlockDevice{
-			Uuid:       "12345",
-			FsType:     "vfat",
-			Label:      "BOOT",
-			Name:       "sda1",
-			MountPoint: "/boot",
+			Uuid:        "12345",
+			FsType:      "vfat",
+			Label:       "BOOT",
+			Name:        "sda1",
+			MountPoints: []string{},
 		}
 		require.False(t, block.isNoBootVolume())
 	})
 
 	t.Run("is boot (vfat label)", func(t *testing.T) {
 		block := BlockDevice{
-			Uuid:       "12345",
-			FsType:     "vfat",
-			Label:      "vfat",
-			Name:       "sda1",
-			MountPoint: "/boot",
+			Uuid:        "12345",
+			FsType:      "vfat",
+			Label:       "vfat",
+			Name:        "sda1",
+			MountPoints: []string{"/boot"},
 		}
 		require.False(t, block.isNoBootVolume())
 	})
 
 	t.Run("is boot (efi label)", func(t *testing.T) {
 		block := BlockDevice{
-			Uuid:       "12345",
-			FsType:     "vfat",
-			Label:      "efi",
-			Name:       "sda1",
-			MountPoint: "/boot",
+			Uuid:        "12345",
+			FsType:      "vfat",
+			Label:       "efi",
+			Name:        "sda1",
+			MountPoints: []string{"/boot"},
 		}
 		require.False(t, block.isNoBootVolume())
 	})
 
 	t.Run("is boot (empty uuid)", func(t *testing.T) {
 		block := BlockDevice{
-			Uuid:       "",
-			FsType:     "vfat",
-			Label:      "test",
-			Name:       "sda1",
-			MountPoint: "/boot",
+			Uuid:        "",
+			FsType:      "vfat",
+			Label:       "test",
+			Name:        "sda1",
+			MountPoints: []string{"/boot"},
 		}
 		require.False(t, block.isNoBootVolume())
 	})
@@ -69,22 +69,35 @@ func TestIsNoBootVolume(t *testing.T) {
 func TestIsMounted(t *testing.T) {
 	t.Run("is mounted", func(t *testing.T) {
 		block := BlockDevice{
-			Uuid:       "12345",
-			FsType:     "xfs",
-			Label:      "label",
-			Name:       "sda2",
-			MountPoint: "/mnt",
+			Uuid:        "12345",
+			FsType:      "xfs",
+			Label:       "label",
+			Name:        "sda2",
+			MountPoints: []string{"/mnt"},
 		}
 		require.True(t, block.isMounted())
 	})
 
 	t.Run("is not mounted", func(t *testing.T) {
 		block := BlockDevice{
-			Uuid:       "12345",
-			FsType:     "xfs",
-			Label:      "label",
-			Name:       "sda2",
-			MountPoint: "",
+			Uuid:        "12345",
+			FsType:      "xfs",
+			Label:       "label",
+			Name:        "sda2",
+			MountPoints: []string{},
+		}
+		require.False(t, block.isMounted())
+	})
+
+	t.Run("is not mounted (special case)", func(t *testing.T) {
+		block := BlockDevice{
+			Uuid:   "12345",
+			FsType: "xfs",
+			Label:  "label",
+			Name:   "sda2",
+			// lsblk returns an empty string for unmounted partitions
+			// and not an empty array
+			MountPoints: []string{""},
 		}
 		require.False(t, block.isMounted())
 	})

--- a/providers/os/connection/snapshot/volumemounter.go
+++ b/providers/os/connection/snapshot/volumemounter.go
@@ -55,18 +55,16 @@ func (m *volumeMounter) Mount(input *MountPartitionInput) (*MountedPartition, er
 		return nil, errors.New("mount device> partition fs type is required")
 	}
 
-	var dir string
-	var err error
-	if input.ScanDir == nil {
-		dir, err = m.createScanDir()
+	mountDir := input.MountDir
+	if mountDir == "" {
+		dir, err := m.createScanDir()
 		if err != nil {
 			return nil, err
 		}
-	} else {
-		dir = *input.ScanDir
+		mountDir = dir
 	}
 
-	m.scanDirs[dir] = input.Name
+	m.scanDirs[mountDir] = input.Name
 
 	mp := &MountedPartition{
 		Name:         input.Name,
@@ -75,9 +73,10 @@ func (m *volumeMounter) Mount(input *MountPartitionInput) (*MountedPartition, er
 		Uuid:         input.Uuid,
 		PartUuid:     input.PartUuid,
 		MountOptions: input.MountOptions,
-		MountPoint:   dir,
+		MountPoint:   mountDir,
+		rootPath:     input.RootPath,
 	}
-	return mp, m.mountVolume(input, dir)
+	return mp, m.mountVolume(input, mountDir)
 }
 
 func (m *volumeMounter) Umount(partition *MountedPartition) error {

--- a/providers/os/connection/snapshot/volumemounter.go
+++ b/providers/os/connection/snapshot/volumemounter.go
@@ -4,7 +4,10 @@
 package snapshot
 
 import (
+	"maps"
 	"os"
+	"slices"
+	"sort"
 	"strings"
 
 	"go.mondoo.com/cnquery/v11/utils/stringx"
@@ -20,15 +23,15 @@ const (
 
 //go:generate mockgen -source=./volumemounter.go -destination=./mock_volumemounter.go -package=snapshot
 type VolumeMounter interface {
-	MountP(dto *MountPartitionDto) (string, error)
-	UmountP(partition *PartitionInfo) error
-	UnmountVolumeFromInstance() error
+	Mount(input *MountPartitionInput) (*MountedPartition, error)
+	Umount(partition *MountedPartition) error
+	UnmountAll() error
 	RemoveTempScanDir() error
 }
 
 type volumeMounter struct {
 	// the tmp dirs we create; serves as the directory we mount the volumes to
-	// maps the device name to the directory
+	// maps directory name to the partition name
 	scanDirs  map[string]string
 	cmdRunner *LocalCommandRunner
 }
@@ -41,56 +44,55 @@ func NewVolumeMounter(shell []string) VolumeMounter {
 }
 
 // Mounts a specific partition and returns the directory it was mounted to
-func (m *volumeMounter) MountP(dto *MountPartitionDto) (string, error) {
-	if dto == nil {
-		return "", errors.New("mount device> partition is required")
+func (m *volumeMounter) Mount(input *MountPartitionInput) (*MountedPartition, error) {
+	if input == nil {
+		return nil, errors.New("mount device> partition is required")
 	}
-
-	partition := dto.PartitionInfo
-	if partition == nil {
-		return "", errors.New("mount device> partition is required")
+	if input.Name == "" {
+		return nil, errors.New("mount device> partition name is required")
 	}
-	if partition.Name == "" {
-		return "", errors.New("mount device> partition name is required")
-	}
-	if partition.FsType == "" {
-		return "", errors.New("mount device> partition fs type is required")
+	if input.FsType == "" {
+		return nil, errors.New("mount device> partition fs type is required")
 	}
 
 	var dir string
 	var err error
-	if dto.ScanDir == nil {
+	if input.ScanDir == nil {
 		dir, err = m.createScanDir()
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 	} else {
-		dir = *dto.ScanDir
+		dir = *input.ScanDir
 	}
 
-	m.scanDirs[partition.key()] = dir
+	m.scanDirs[dir] = input.Name
 
-	return dir, m.mountVolume(dto)
+	mp := &MountedPartition{
+		Name:         input.Name,
+		FsType:       input.FsType,
+		Label:        input.Label,
+		Uuid:         input.Uuid,
+		PartUuid:     input.PartUuid,
+		MountOptions: input.MountOptions,
+		MountPoint:   dir,
+	}
+	return mp, m.mountVolume(input, dir)
 }
 
-func (m *volumeMounter) UmountP(partition *PartitionInfo) error {
+func (m *volumeMounter) Umount(partition *MountedPartition) error {
 	if partition == nil {
 		return errors.New("unmount device> partition is required")
 	}
 	if partition.Name == "" {
 		return errors.New("unmount device> partition name is required")
 	}
-	key := partition.key()
-	dir, ok := m.scanDirs[key]
-	if !ok {
-		return errors.New("unmount device> partition not found")
-	}
-	log.Debug().Str("dir", dir).Str("name", partition.Name).Msg("unmount volume")
-	if err := Unmount(dir); err != nil {
-		log.Warn().Err(err).Str("dir", dir).Msg("failed to unmount dir")
+	log.Debug().Str("dir", partition.MountPoint).Str("name", partition.Name).Msg("unmount volume")
+	if err := Unmount(partition.MountPoint); err != nil {
+		log.Warn().Err(err).Str("dir", partition.MountPoint).Msg("failed to unmount dir")
 		return err
 	}
-	delete(m.scanDirs, key)
+	delete(m.scanDirs, partition.MountPoint)
 
 	return nil
 }
@@ -105,17 +107,16 @@ func (m *volumeMounter) createScanDir() (string, error) {
 	return dir, nil
 }
 
-func (m *volumeMounter) mountVolume(fsInfo *MountPartitionDto) error {
-	opts := fsInfo.MountOptions
-	if fsInfo.FsType == "xfs" {
+func (m *volumeMounter) mountVolume(input *MountPartitionInput, dir string) error {
+	opts := input.MountOptions
+	if input.FsType == "xfs" {
 		opts = append(opts, "nouuid")
 	}
 	opts = stringx.DedupStringArray(opts)
 	opts = sanitizeOptions(opts)
 
-	scanDir := m.scanDirs[fsInfo.key()]
-	log.Debug().Str("fstype", fsInfo.FsType).Str("device", fsInfo.Name).Str("scandir", scanDir).Str("opts", strings.Join(opts, ",")).Msg("mount volume to scan dir")
-	return Mount(fsInfo.Name, scanDir, fsInfo.FsType, opts)
+	log.Debug().Str("fstype", input.FsType).Str("device", input.Name).Str("dir", dir).Strs("opts", opts).Msg("mount volume to scan dir")
+	return Mount(input.Name, dir, input.FsType, opts)
 }
 
 func sanitizeOptions(options []string) []string {
@@ -133,17 +134,22 @@ func sanitizeOptions(options []string) []string {
 	return sanitized
 }
 
-func (m *volumeMounter) UnmountVolumeFromInstance() error {
+func (m *volumeMounter) UnmountAll() error {
 	if len(m.scanDirs) == 0 {
 		log.Warn().Msg("no scan dirs to unmount, skipping")
 		return nil
 	}
 
 	var errs []error
-	for name, dir := range m.scanDirs {
+	dirs := slices.Collect(maps.Keys(m.scanDirs))
+	// sort the entries by the length of the mountpoint, so we can mount the deepest directories first
+	sort.Slice(dirs, func(i, j int) bool {
+		return PathDepth(dirs[i]) > PathDepth(dirs[j])
+	})
+	for _, dir := range dirs {
 		log.Debug().
 			Str("dir", dir).
-			Str("name", name).
+			Str("partition", m.scanDirs[dir]).
 			Msg("unmount volume")
 		if err := Unmount(dir); err != nil {
 			log.Warn().
@@ -157,10 +163,10 @@ func (m *volumeMounter) UnmountVolumeFromInstance() error {
 
 func (m *volumeMounter) RemoveTempScanDir() error {
 	var errs []error
-	for name, dir := range m.scanDirs {
+	for dir, partition := range m.scanDirs {
 		log.Debug().
 			Str("dir", dir).
-			Str("name", name).
+			Str("partition", partition).
 			Msg("remove created dir")
 		if err := os.RemoveAll(dir); err != nil {
 			log.Error().Err(err).
@@ -171,4 +177,11 @@ func (m *volumeMounter) RemoveTempScanDir() error {
 	}
 
 	return errors.Join(errs...)
+}
+
+func PathDepth(path string) int {
+	if path == "/" {
+		return 0
+	}
+	return len(strings.Split(strings.Trim(path, "/"), "/"))
 }


### PR DESCRIPTION
* Add new structs
    * `Partition` : simply indicates a partition that should be mounted. It has no mountpoint information as we do not differentiate between a mounted and a non-mounted partition here. The filtering happens when doing `lsblk` and using `BlockDevices`
    * `MountedPartitionInput`: `Partition` + `MountOptions` and `MountDir`
    * `MountedPartition`: `Partition` + `MountOptions` and `MountPoint`. We could unite this and the input struct but I like keeping them split. 
* All connections now do their own mounting in their own tmp folders. This means that connections do not rely on one another anymore. 
* Improve the device manager interface to make the functions more intuitive. 
* Improve the volume mounter interface to make it more intuitive.
* Overall code improvements where possible