### PR TITLE
🐛 Fix non-breaking spaces in MS SQL GDR packages

### DIFF
--- a/providers/os/resources/packages/windows_packages.go
+++ b/providers/os/resources/packages/windows_packages.go
@@ -72,8 +72,8 @@ var (
 		WinArchX86OnArm64: "x86onarm",
 	}
 
-	sqlGDRUpdateRegExp = regexp.MustCompile(`^GDR \d+ .+ SQL Server \d+ \(KB\d+\)`)
-	sqlHotfixRegExp    = regexp.MustCompile(`^Hotfix .+ SQL Server`)
+	sqlGDRUpdateRegExp = regexp.MustCompile(`^GDR.\d+.+SQL.Server.\d+.\(KB\d+\)`)
+	sqlHotfixRegExp    = regexp.MustCompile(`^Hotfix.+SQL.Server`)
 	// Find the database engine package and use version as a reference for the update
 	msSqlServiceRegexp = regexp.MustCompile(`^SQL Server \d+ Database Engine Services$`)
 )
@@ -715,6 +715,8 @@ func createPackage(name, version, format, arch, publisher, installLocation strin
 		purlType = purl.TypeAppx
 	}
 
+	// replace non-breaking spaces with regular spaces
+	name = strings.ReplaceAll(name, "\u00a0", " ")
 	pkg := &Package{
 		Name:    name,
 		Version: version,


### PR DESCRIPTION
MS SQL GDR updates may contain non-breaking spaces:
<img width="1252" height="119" alt="Screenshot from 2025-08-21 15-30-13" src="https://github.com/user-attachments/assets/34960a96-a9a0-4946-b08b-0cc785040488" />
<img width="990" height="119" alt="Screenshot from 2025-08-21 15-29-39" src="https://github.com/user-attachments/assets/613885b3-de1d-4401-9b30-0bf09454774c" />
