### PR TITLE
🐛 Use single mountpoint from lsblk.

### DIFF
--- a/providers/os/connection/snapshot/blockdevices.go
+++ b/providers/os/connection/snapshot/blockdevices.go
@@ -22,14 +22,14 @@ type BlockDevices struct {
 }
 
 type BlockDevice struct {
-	Name        string         `json:"name,omitempty"`
-	FsType      string         `json:"fstype,omitempty"`
-	Label       string         `json:"label,omitempty"`
-	Uuid        string         `json:"uuid,omitempty"`
-	PartUuid    string         `json:"partuuid,omitempty"`
-	MountPoints []string       `json:"mountpoints,omitempty"`
-	Children    []*BlockDevice `json:"children,omitempty"`
-	Size        Size           `json:"size,omitempty"`
+	Name       string         `json:"name,omitempty"`
+	FsType     string         `json:"fstype,omitempty"`
+	Label      string         `json:"label,omitempty"`
+	Uuid       string         `json:"uuid,omitempty"`
+	PartUuid   string         `json:"partuuid,omitempty"`
+	MountPoint string         `json:"mountpoint,omitempty"`
+	Children   []*BlockDevice `json:"children,omitempty"`
+	Size       Size           `json:"size,omitempty"`
 
 	// This is how the device was requested/searched as. It might differ from the actual name
 	// e.g. we treat /dev/sdm the same as /dev/xvdm, so RequestedName can be '/dev/sdm' while Name is '/dev/xvdm'
@@ -68,7 +68,7 @@ func (s *Size) UnmarshalJSON(data []byte) error {
 }
 
 func (cmdRunner *LocalCommandRunner) GetBlockDevices() (*BlockDevices, error) {
-	cmd, err := cmdRunner.RunCommand("lsblk -bo NAME,SIZE,FSTYPE,MOUNTPOINTS,LABEL,UUID,PARTUUID --json")
+	cmd, err := cmdRunner.RunCommand("lsblk -bo NAME,SIZE,FSTYPE,MOUNTPOINT,LABEL,UUID,PARTUUID --json")
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +209,7 @@ func (device *BlockDevice) GetPartitions(includeBoot bool, includeMounted bool) 
 
 		// skip mounted partitions unless includeMounted is true
 		if partition.isMounted() && !includeMounted {
-			log.Debug().Str("name", partition.Name).Strs("mountpoints", partition.MountPoints).Msg("skipping mounted partition")
+			log.Debug().Str("name", partition.Name).Str("mountpoint", partition.MountPoint).Msg("skipping mounted partition")
 			return false
 		}
 
@@ -235,7 +235,7 @@ func (device *BlockDevice) GetPartitions(includeBoot bool, includeMounted bool) 
 			log.Debug().
 				Str("name", partition.Name).
 				Str("fs_type", partition.FsType).
-				Strs("mountpoints", partition.MountPoints).
+				Str("mountpoint", partition.MountPoint).
 				Msg("skipping partition, because the filter did not match")
 		}
 	}

--- a/providers/os/connection/snapshot/blockdevices_test.go
+++ b/providers/os/connection/snapshot/blockdevices_test.go
@@ -62,7 +62,7 @@ func TestFindDevice(t *testing.T) {
 	t.Run("match by exact name", func(t *testing.T) {
 		blockEntries := BlockDevices{
 			BlockDevices: []*BlockDevice{
-				{Name: "sda", Children: []*BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
+				{Name: "sda", Children: []*BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoint: "/"}}},
 				{Name: "nvme0n1", Children: []*BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 				{Name: "sdx", Children: []*BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 			},
@@ -77,7 +77,7 @@ func TestFindDevice(t *testing.T) {
 	t.Run("match by alias name", func(t *testing.T) {
 		blockEntries := BlockDevices{
 			BlockDevices: []*BlockDevice{
-				{Name: "sda", Children: []*BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
+				{Name: "sda", Children: []*BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoint: "/"}}},
 				{Name: "nvme0n1", Children: []*BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 				{Name: "sdx", Aliases: []string{"xvdx"}, Children: []*BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 			},
@@ -92,7 +92,7 @@ func TestFindDevice(t *testing.T) {
 	t.Run("match by interchangeable name", func(t *testing.T) {
 		blockEntries := BlockDevices{
 			BlockDevices: []*BlockDevice{
-				{Name: "sda", Children: []*BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
+				{Name: "sda", Children: []*BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoint: "/"}}},
 				{Name: "nvme0n1", Children: []*BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 				{Name: "xvdc", Children: []*BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 			},
@@ -107,7 +107,7 @@ func TestFindDevice(t *testing.T) {
 	t.Run("no match", func(t *testing.T) {
 		blockEntries := BlockDevices{
 			BlockDevices: []*BlockDevice{
-				{Name: "sda", Children: []*BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
+				{Name: "sda", Children: []*BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoint: "/"}}},
 				{Name: "nvme0n1", Children: []*BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 				{Name: "xvdc", Children: []*BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 			},
@@ -121,7 +121,7 @@ func TestFindDevice(t *testing.T) {
 	t.Run("multiple matches by trailing letter", func(t *testing.T) {
 		blockEntries := BlockDevices{
 			BlockDevices: []*BlockDevice{
-				{Name: "sda", Children: []*BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
+				{Name: "sda", Children: []*BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoint: "/"}}},
 				{Name: "nvme0n1", Children: []*BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 				{Name: "stc", Children: []*BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 				{Name: "xvdc", Children: []*BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
@@ -137,7 +137,7 @@ func TestFindDevice(t *testing.T) {
 	t.Run("perfect match and trailing letter matches", func(t *testing.T) {
 		blockEntries := BlockDevices{
 			BlockDevices: []*BlockDevice{
-				{Name: "sda", Children: []*BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
+				{Name: "sda", Children: []*BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoint: "/"}}},
 				{Name: "nvme0n1", Children: []*BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 				{Name: "sta", Children: []*BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 				{Name: "xvda", Children: []*BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
@@ -156,7 +156,7 @@ func TestFindDevice(t *testing.T) {
 				{Name: "xvda", Children: []*BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 				{Name: "sta", Children: []*BlockDevice{{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sdh1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
 				{Name: "nvme0n1", Children: []*BlockDevice{{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "nvmd1n1"}, {Uuid: "12345", FsType: "", Label: "EFI"}}},
-				{Name: "sda", Children: []*BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}}}},
+				{Name: "sda", Children: []*BlockDevice{{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoint: "/"}}},
 			},
 		}
 
@@ -172,7 +172,7 @@ func TestGetMountablePartition(t *testing.T) {
 		block := BlockDevice{
 			Name: "sda",
 			Children: []*BlockDevice{
-				{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}},
+				{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoint: "/"},
 			},
 		}
 		_, err := block.GetMountablePartition()
@@ -184,7 +184,7 @@ func TestGetMountablePartition(t *testing.T) {
 		block := BlockDevice{
 			Name: "sda",
 			Children: []*BlockDevice{
-				{Uuid: "1234", FsType: "", Label: "ROOT", Name: "sda1", MountPoints: []string{}},
+				{Uuid: "1234", FsType: "", Label: "ROOT", Name: "sda1", MountPoint: ""},
 			},
 		}
 		_, err := block.GetMountablePartition()
@@ -196,7 +196,7 @@ func TestGetMountablePartition(t *testing.T) {
 		block := BlockDevice{
 			Name: "sda",
 			Children: []*BlockDevice{
-				{Uuid: "1234", FsType: "xfs", Label: "EFI", Name: "sda1", MountPoints: []string{}},
+				{Uuid: "1234", FsType: "xfs", Label: "EFI", Name: "sda1", MountPoint: ""},
 			},
 		}
 		_, err := block.GetMountablePartition()
@@ -208,7 +208,7 @@ func TestGetMountablePartition(t *testing.T) {
 		block := BlockDevice{
 			Name: "sda",
 			Children: []*BlockDevice{
-				{Uuid: "1234", FsType: "vfat", Label: "", Name: "sda1", MountPoints: []string{}},
+				{Uuid: "1234", FsType: "vfat", Label: "", Name: "sda1", MountPoint: ""},
 			},
 		}
 		_, err := block.GetMountablePartition()
@@ -220,7 +220,7 @@ func TestGetMountablePartition(t *testing.T) {
 		block := BlockDevice{
 			Name: "sda",
 			Children: []*BlockDevice{
-				{Uuid: "1234", FsType: "xfs", Label: "boot", Name: "sda1", MountPoints: []string{}},
+				{Uuid: "1234", FsType: "xfs", Label: "boot", Name: "sda1", MountPoint: ""},
 			},
 		}
 		_, err := block.GetMountablePartition()
@@ -270,11 +270,11 @@ func TestGetPartitions(t *testing.T) {
 			Name: "sda",
 			Children: []*BlockDevice{
 				// already mounted
-				{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}},
-				{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "sda2", MountPoints: []string{}},
-				{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sda3", MountPoints: []string{}},
+				{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoint: "/"},
+				{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "sda2", MountPoint: ""},
+				{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sda3", MountPoint: ""},
 				// no fs type
-				{Uuid: "12347", FsType: "", Label: "ROOT", Name: "sda4", MountPoints: []string{}},
+				{Uuid: "12347", FsType: "", Label: "ROOT", Name: "sda4", MountPoint: ""},
 			},
 		}
 		parts, err := block.GetPartitions(true, false)
@@ -306,11 +306,11 @@ func TestGetPartitions(t *testing.T) {
 			Name: "sda",
 			Children: []*BlockDevice{
 				// already mounted
-				{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoints: []string{"/"}},
-				{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "sda2", MountPoints: []string{}},
-				{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sda3", MountPoints: []string{}},
+				{Uuid: "1234", FsType: "xfs", Label: "ROOT", Name: "sda1", MountPoint: "/"},
+				{Uuid: "12345", FsType: "xfs", Label: "ROOT", Name: "sda2", MountPoint: ""},
+				{Uuid: "12346", FsType: "xfs", Label: "ROOT", Name: "sda3", MountPoint: ""},
 				// no fs type
-				{Uuid: "12347", FsType: "", Label: "ROOT", Name: "sda4", MountPoints: []string{}},
+				{Uuid: "12347", FsType: "", Label: "ROOT", Name: "sda4", MountPoint: ""},
 			},
 		}
 		parts, err := block.GetPartitions(true, true)
@@ -327,11 +327,11 @@ func TestGetPartitions(t *testing.T) {
 		block := BlockDevice{
 			Name: "sda",
 			Children: []*BlockDevice{
-				{Uuid: "1234", FsType: "fat32", Label: "EFI", Name: "sda1", MountPoints: []string{}},
+				{Uuid: "1234", FsType: "fat32", Label: "EFI", Name: "sda1", MountPoint: ""},
 				{
-					Uuid: "12345", FsType: "lvm2_member", Label: "LVM", Name: "sda2", MountPoints: []string{}, Children: []*BlockDevice{
-						{Uuid: "lv12346", FsType: "lvm", Label: "ROOT", Name: "rootvg-rootlv", MountPoints: []string{}},
-						{Uuid: "lv12347", FsType: "lvm", Label: "HOME", Name: "rootvg-homelv", MountPoints: []string{}},
+					Uuid: "12345", FsType: "lvm2_member", Label: "LVM", Name: "sda2", MountPoint: "", Children: []*BlockDevice{
+						{Uuid: "lv12346", FsType: "lvm", Label: "ROOT", Name: "rootvg-rootlv", MountPoint: ""},
+						{Uuid: "lv12347", FsType: "lvm", Label: "HOME", Name: "rootvg-homelv", MountPoint: ""},
 					},
 				},
 			},

--- a/providers/os/connection/snapshot/partition.go
+++ b/providers/os/connection/snapshot/partition.go
@@ -74,9 +74,5 @@ func (entry BlockDevice) isNoBootVolume() bool {
 }
 
 func (entry BlockDevice) isMounted() bool {
-	if len(entry.MountPoints) == 1 && entry.MountPoints[0] == "" {
-		// This is a special case where the partition is not mounted
-		return false
-	}
-	return len(entry.MountPoints) > 0
+	return entry.MountPoint != ""
 }

--- a/providers/os/connection/snapshot/partition_test.go
+++ b/providers/os/connection/snapshot/partition_test.go
@@ -12,55 +12,55 @@ import (
 func TestIsNoBootVolume(t *testing.T) {
 	t.Run("is not boot", func(t *testing.T) {
 		block := BlockDevice{
-			Uuid:        "12345",
-			FsType:      "xfs",
-			Label:       "label",
-			Name:        "sda2",
-			MountPoints: []string{},
+			Uuid:       "12345",
+			FsType:     "xfs",
+			Label:      "label",
+			Name:       "sda2",
+			MountPoint: "",
 		}
 		require.True(t, block.isNoBootVolume())
 	})
 
 	t.Run("is boot (boot label)", func(t *testing.T) {
 		block := BlockDevice{
-			Uuid:        "12345",
-			FsType:      "vfat",
-			Label:       "BOOT",
-			Name:        "sda1",
-			MountPoints: []string{},
+			Uuid:       "12345",
+			FsType:     "vfat",
+			Label:      "BOOT",
+			Name:       "sda1",
+			MountPoint: "",
 		}
 		require.False(t, block.isNoBootVolume())
 	})
 
 	t.Run("is boot (vfat label)", func(t *testing.T) {
 		block := BlockDevice{
-			Uuid:        "12345",
-			FsType:      "vfat",
-			Label:       "vfat",
-			Name:        "sda1",
-			MountPoints: []string{"/boot"},
+			Uuid:       "12345",
+			FsType:     "vfat",
+			Label:      "vfat",
+			Name:       "sda1",
+			MountPoint: "/boot",
 		}
 		require.False(t, block.isNoBootVolume())
 	})
 
 	t.Run("is boot (efi label)", func(t *testing.T) {
 		block := BlockDevice{
-			Uuid:        "12345",
-			FsType:      "vfat",
-			Label:       "efi",
-			Name:        "sda1",
-			MountPoints: []string{"/boot"},
+			Uuid:       "12345",
+			FsType:     "vfat",
+			Label:      "efi",
+			Name:       "sda1",
+			MountPoint: "/boot",
 		}
 		require.False(t, block.isNoBootVolume())
 	})
 
 	t.Run("is boot (empty uuid)", func(t *testing.T) {
 		block := BlockDevice{
-			Uuid:        "",
-			FsType:      "vfat",
-			Label:       "test",
-			Name:        "sda1",
-			MountPoints: []string{"/boot"},
+			Uuid:       "",
+			FsType:     "vfat",
+			Label:      "test",
+			Name:       "sda1",
+			MountPoint: "/boot",
 		}
 		require.False(t, block.isNoBootVolume())
 	})
@@ -69,35 +69,22 @@ func TestIsNoBootVolume(t *testing.T) {
 func TestIsMounted(t *testing.T) {
 	t.Run("is mounted", func(t *testing.T) {
 		block := BlockDevice{
-			Uuid:        "12345",
-			FsType:      "xfs",
-			Label:       "label",
-			Name:        "sda2",
-			MountPoints: []string{"/mnt"},
+			Uuid:       "12345",
+			FsType:     "xfs",
+			Label:      "label",
+			Name:       "sda2",
+			MountPoint: "/mnt",
 		}
 		require.True(t, block.isMounted())
 	})
 
 	t.Run("is not mounted", func(t *testing.T) {
 		block := BlockDevice{
-			Uuid:        "12345",
-			FsType:      "xfs",
-			Label:       "label",
-			Name:        "sda2",
-			MountPoints: []string{},
-		}
-		require.False(t, block.isMounted())
-	})
-
-	t.Run("is not mounted (special case)", func(t *testing.T) {
-		block := BlockDevice{
-			Uuid:   "12345",
-			FsType: "xfs",
-			Label:  "label",
-			Name:   "sda2",
-			// lsblk returns an empty string for unmounted partitions
-			// and not an empty array
-			MountPoints: []string{""},
+			Uuid:       "12345",
+			FsType:     "xfs",
+			Label:      "label",
+			Name:       "sda2",
+			MountPoint: "",
 		}
 		require.False(t, block.isMounted())
 	})


### PR DESCRIPTION
Older versions of lsblk do not support `MOUNTPOINTS`.