### PR TITLE
✨ support impact by name

### DIFF
--- a/.github/actions/link-check/config.json
+++ b/.github/actions/link-check/config.json
@@ -1,3 +1,3 @@
 {
-  "aliveStatusCodes": [429, 200]
+  "aliveStatusCodes": [429, 406, 200]
 }

--- a/explorer/impact.go
+++ b/explorer/impact.go
@@ -29,6 +29,14 @@ func (v *Impact) HumanReadable() string {
 	}
 }
 
+var ImpactValues = map[string]int32{
+	"critical": 95,
+	"high":     80,
+	"medium":   55,
+	"low":      20,
+	"none":     0,
+}
+
 func (v *Impact) AddBase(base *Impact) {
 	if base == nil {
 		return
@@ -73,6 +81,16 @@ func (v *Impact) UnmarshalJSON(data []byte) error {
 		if v.Value.Value < 0 || v.Value.Value > 100 {
 			return errors.New("impact must be between 0 and 100")
 		}
+		return nil
+	}
+
+	var word string
+	if err := json.Unmarshal(data, &word); err == nil {
+		num, ok := ImpactValues[word]
+		if !ok {
+			return errors.New("impact can only be critical, high, medium, low, or none or a numeric value")
+		}
+		v.Value = &ImpactValue{Value: num}
 		return nil
 	}
 

--- a/explorer/impact_test.go
+++ b/explorer/impact_test.go
@@ -19,13 +19,12 @@ func TestImpactParsing(t *testing.T) {
 		data  string
 		res   *Impact
 	}{
-		{
-			"simple number",
-			"30",
-			&Impact{
-				Value: &ImpactValue{Value: 30},
-			},
-		},
+		{"simple number", "30", &Impact{Value: &ImpactValue{Value: 30}}},
+		{"critical", "\"critical\"", &Impact{Value: &ImpactValue{Value: 95}}},
+		{"high", "\"high\"", &Impact{Value: &ImpactValue{Value: 80}}},
+		{"medium", "\"medium\"", &Impact{Value: &ImpactValue{Value: 55}}},
+		{"low", "\"low\"", &Impact{Value: &ImpactValue{Value: 20}}},
+		{"none", "\"none\"", &Impact{Value: &ImpactValue{Value: 0}}},
 		{
 			"complex definition",
 			`{"weight": 20, "value": 40}`,


### PR DESCRIPTION
You can now specify the impact as a name, instead of just a number. For example:

```yaml
- uid: my-query
  title: A critical check that needs to succeed
  impact: critical
  ...
```

The keywords are: `critical`, `high`, `medium`, `low`, and `none`.