### PR TITLE
Update goreleaser for v12

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,7 +31,7 @@ builds:
       - -tags="production netgo"
     ldflags:
       - "-extldflags=-static"
-      - -s -w -X go.mondoo.com/cnquery/v11.Version={{.Version}} -X go.mondoo.com/cnquery/v11.Build={{.ShortCommit}} -X go.mondoo.com/cnquery/v11.Date={{.Date}}
+      - -s -w -X go.mondoo.com/cnquery/v12.Version={{.Version}} -X go.mondoo.com/cnquery/v12.Build={{.ShortCommit}} -X go.mondoo.com/cnquery/v12.Date={{.Date}}
   - id: macos
     main: ./apps/cnquery/cnquery.go
     binary: cnquery
@@ -43,7 +43,7 @@ builds:
     flags: -tags production
     ldflags:
       # clang + macos does not support static: - -extldflags "-static"
-      - -s -w -X go.mondoo.com/cnquery/v11.Version={{.Version}} -X go.mondoo.com/cnquery/v11.Build={{.ShortCommit}} -X go.mondoo.com/cnquery/v11.Date={{.Date}}
+      - -s -w -X go.mondoo.com/cnquery/v12.Version={{.Version}} -X go.mondoo.com/cnquery/v12.Build={{.ShortCommit}} -X go.mondoo.com/cnquery/v12.Date={{.Date}}
     hooks:
       post:
         - cmd: /tmp/quill sign-and-notarize "{{ .Path }}" -vv || true
@@ -61,7 +61,7 @@ builds:
     flags: -tags production -buildmode exe
     ldflags:
       - "-extldflags -static"
-      - -s -w -X go.mondoo.com/cnquery/v11.Version={{.Version}} -X go.mondoo.com/cnquery/v11.Build={{.ShortCommit}} -X go.mondoo.com/cnquery/v11.Date={{.Date}}
+      - -s -w -X go.mondoo.com/cnquery/v12.Version={{.Version}} -X go.mondoo.com/cnquery/v12.Build={{.ShortCommit}} -X go.mondoo.com/cnquery/v12.Date={{.Date}}
     hooks:
       post:
         - cmd: jsign --storetype TRUSTEDSIGNING --keystore {{ .Env.TSIGN_AZURE_ENDPOINT }} --storepass {{ .Env.TSIGN_ACCESS_TOKEN }} --alias {{ .Env.TSIGN_ACCOUNT_NAME }}/{{ .Env.TSIGN_CERT_PROFILE_NAME }} '{{ .Path }}'

--- a/apps/provider-scaffold/README.md
+++ b/apps/provider-scaffold/README.md
@@ -11,7 +11,7 @@ go install apps/provider-scaffold/provider-scaffold.go
 ## Usage
 
 ```shell
-provider-scaffold --path providers/your-provider --provider-id your-provider --provider-name "Your Provider" --go-package go.mondoo.com/cnquery/v11/providers/your-provider
+provider-scaffold --path providers/your-provider --provider-id your-provider --provider-name "Your Provider" --go-package go.mondoo.com/cnquery/v12/providers/your-provider
 ```
 
 Now you have a full provider skeleton in `providers/your-provider` that you can start to implement.

--- a/providers/gcp/resources/discovery_test.go
+++ b/providers/gcp/resources/discovery_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.mondoo.com/cnquery/v11/providers-sdk/v1/inventory"
+	"go.mondoo.com/cnquery/v12/providers-sdk/v1/inventory"
 )
 
 func TestGetDiscoveryTargets(t *testing.T) {

--- a/providers/os/resources/languages/python/testdata/rhel.json
+++ b/providers/os/resources/languages/python/testdata/rhel.json
@@ -24,7 +24,7 @@
       "connections": [
         {
           "url": "docker-image://registry.access.redhat.com/ubi8/ubi",
-          "provider": "go.mondoo.com/cnquery/v11/providers/os",
+          "provider": "go.mondoo.com/cnquery/v12/providers/os",
           "connector": "docker-image",
           "version": ""
         }


### PR DESCRIPTION
I’ve made some updates to the goreleaser config to reflect the major version change. I also stumbled upon a few other references to version 11 that were hiding under the carpet.