### PR TITLE
✨ terraform.resources( resource, name )

### DIFF
--- a/llx/matcher.go
+++ b/llx/matcher.go
@@ -1,0 +1,67 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package llx
+
+import (
+	"errors"
+	"regexp"
+
+	"go.mondoo.com/cnquery/v12/types"
+)
+
+func falseMatcher(s string) bool {
+	return false
+}
+
+// StringOrRegexMatcher uses an input term, as rawdata, to create
+// a matcher that can be used against strings. This is useful when
+// you have create function that takes an argument that is meant to
+// be used as a matcher or filter against a string.
+//
+// For example:
+//
+//	myresource.list( nameFilter )
+//
+// In this example, nameFilter is the term, specified by a user,
+// which can be a string or a regex. We return a matcher function you
+// can now use against any string to see if it satisfies the criteria.
+//
+// Returns nil, nil if term == nil
+// In all other cases you will get either a matcher or an error.
+func StringOrRegexMatcher(term *RawData) (func(string) bool, error) {
+	if term == nil || term.Type == types.Nil {
+		return nil, nil
+	}
+
+	if term.Value == nil {
+		return falseMatcher, nil
+	}
+
+	switch term.Type {
+	case types.Regex:
+		v, ok := term.Value.(string)
+		if !ok {
+			return nil, errors.New("incorrect value for a regex: " + term.String())
+		}
+		re, err := regexp.Compile(v)
+		if err != nil {
+			return nil, errors.New("invalid regex: /" + v + "/")
+		}
+		return func(in string) bool {
+			return re.MatchString(in)
+		}, nil
+
+	case types.String, types.Dict:
+		v, ok := term.Value.(string)
+		if !ok {
+			return nil, errors.New("not a valid string: " + term.String())
+		}
+		return func(in string) bool {
+			return in == v
+		}, nil
+
+	default:
+		return nil, errors.New("matcher must be a string or regex")
+	}
+}

--- a/llx/matcher_test.go
+++ b/llx/matcher_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package llx_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/v12/llx"
+)
+
+func TestStringOrRegexMatcher(t *testing.T) {
+	tests := []struct {
+		term    *llx.RawData
+		matches []string
+		fails   []string
+	}{
+		{
+			term:    llx.StringData("word"),
+			matches: []string{"word"},
+			fails:   []string{"", "myword", "wordle"},
+		},
+		{
+			term:    llx.StringData(""),
+			matches: []string{""},
+			fails:   []string{"myword", "wordle"},
+		},
+		{
+			term:    llx.RegexData("my.*"),
+			matches: []string{"myword", "ohmy"},
+			fails:   []string{"", "wordle"},
+		},
+		{
+			term:    llx.DictData("word"),
+			matches: []string{"word"},
+			fails:   []string{"", "myword", "wordle"},
+		},
+		{
+			term:    llx.NilData,
+			matches: []string{"", "all"},
+			fails:   []string{},
+		},
+	}
+
+	for i := range tests {
+		cur := tests[i]
+		t.Run(cur.term.String(), func(t *testing.T) {
+			m, err := llx.StringOrRegexMatcher(cur.term)
+			require.NoError(t, err)
+
+			if m == nil {
+				assert.Empty(t, cur.fails)
+				return
+			}
+
+			for _, s := range cur.matches {
+				assert.True(t, m(s), "matches "+s)
+			}
+			for _, s := range cur.fails {
+				assert.False(t, m(s), "matches "+s)
+			}
+		})
+	}
+}

--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -774,7 +774,7 @@ func (c *compiler) unnamedArgs(callerLabel string, init *resources.Init, args []
 
 		expected := init.Args[idx]
 		expectedType := types.Type(expected.Type)
-		if vType != expectedType {
+		if vType != expectedType && expectedType != types.Any {
 			// TODO: We are looking for dict types to see if we can type-cast them
 			// This needs massive improvements to dynamically cast them in LLX.
 			// For a full description see: https://gitlab.com/mondoolabs/mondoo/-/issues/241

--- a/providers-sdk/v1/lr/go.go
+++ b/providers-sdk/v1/lr/go.go
@@ -647,6 +647,8 @@ func (t *SimpleType) typeItems(ast *LR) types.Type {
 		return types.IP
 	case "range":
 		return types.Range
+	case "any":
+		return types.Any
 	default:
 		return resourceType(t.Type, ast)
 	}
@@ -723,6 +725,8 @@ func (t *SimpleType) mondooTypeItems(b *goBuilder) string {
 		return "types.Version"
 	case "ip":
 		return "types.IP"
+	case "any":
+		return "types.Any"
 	default:
 		if name, ok := b.importName(t.Type); ok {
 			return "types.Resource(\"" + name + "\")"

--- a/providers/terraform/resources/terraform.lr
+++ b/providers/terraform/resources/terraform.lr
@@ -27,7 +27,7 @@ terraform {
 // All blocks with the type resource
 terraform.resources {
   []terraform.block
-  init(resource? string, name? string)
+  init(resource? any, name? any)
 }
 
 // Terraform configuration file (.tf or .tf.json file)


### PR DESCRIPTION
Simple accessor for terraform, now supports both names and regex.

Here's an example. For the Terraform HCL file:

```hcl
resource "aws_instance" "example-1" {
  ami           = "ami-a1b2c3d4"
  instance_type = "t2.micro"
}

resource "aws_instance" "example-2" {
  ami           = "ami-a1b2c3d4"
  instance_type = "t2.micro"
}
```

You can now run

```coffee
# get all the "aws_instance" resources:
terraform.resources("aws_instance")

# get a specific resource:
terraform.resources("aws_instance", "example-1")

# grab resources via regex:
terraform.resources(/aws_/)

# you can even combine string and regex searches:
terraform.resources("aws_instance", /example-[0-9]+/)
```