### PR TITLE
Remove a deprecated field from a query pack

### DIFF
--- a/content/mondoo-gcp-inventory.mql.yaml
+++ b/content/mondoo-gcp-inventory.mql.yaml
@@ -41,7 +41,6 @@ queries:
           gcp.project {
             name
             id
-            number
             state
             labels
           }


### PR DESCRIPTION
This has been replaced with ID which we already collect