### PR TITLE
Fix a compilation failure in `aws.iam.policies` + deprecation fixes

### DIFF
--- a/content/mondoo-aws-incident-response.mql.yaml
+++ b/content/mondoo-aws-incident-response.mql.yaml
@@ -164,7 +164,7 @@ queries:
         id
         tags
         attachedPolicies
-        createDate
+        createdAt
         accessKeys
         loginProfile
         groups
@@ -183,7 +183,7 @@ queries:
       aws.iam.group {
         arn
         name
-        createDate
+        createdAt
         id
         usernames
       }
@@ -201,8 +201,8 @@ queries:
       aws.iam.policies.
         where( name == /FullAccess/i && attachmentCount != 0) {
           name
-          createDate
-          updateDate
+          createdAt
+          updatedAt
           attachedUsers
           attachedGroups
           attachedRoles

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -843,7 +843,7 @@ private aws.iam.policy @defaults("arn name") {
   // Time when the policy was created
   createdAt() time
   // Time when the policy was updated
-  updateDate() time
+  updatedAt() time
   // Scope of the policy
   scope() string
   // List of versions for the policy

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -1804,8 +1804,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.iam.policy.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamPolicy).GetCreatedAt()).ToDataRes(types.Time)
 	},
-	"aws.iam.policy.updateDate": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAwsIamPolicy).GetUpdateDate()).ToDataRes(types.Time)
+	"aws.iam.policy.updatedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamPolicy).GetUpdatedAt()).ToDataRes(types.Time)
 	},
 	"aws.iam.policy.scope": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamPolicy).GetScope()).ToDataRes(types.String)
@@ -6733,8 +6733,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsIamPolicy).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
-	"aws.iam.policy.updateDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAwsIamPolicy).UpdateDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+	"aws.iam.policy.updatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamPolicy).UpdatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.iam.policy.scope": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16175,7 +16175,7 @@ type mqlAwsIamPolicy struct {
 	IsAttachable plugin.TValue[bool]
 	AttachmentCount plugin.TValue[int64]
 	CreatedAt plugin.TValue[*time.Time]
-	UpdateDate plugin.TValue[*time.Time]
+	UpdatedAt plugin.TValue[*time.Time]
 	Scope plugin.TValue[string]
 	Versions plugin.TValue[[]any]
 	DefaultVersion plugin.TValue[*mqlAwsIamPolicyversion]
@@ -16195,12 +16195,7 @@ func createAwsIamPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		return res, err
 	}
 
-	if res.__id == "" {
-	res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("aws.iam.policy", res.__id)
@@ -16261,9 +16256,9 @@ func (c *mqlAwsIamPolicy) GetCreatedAt() *plugin.TValue[*time.Time] {
 	})
 }
 
-func (c *mqlAwsIamPolicy) GetUpdateDate() *plugin.TValue[*time.Time] {
-	return plugin.GetOrCompute[*time.Time](&c.UpdateDate, func() (*time.Time, error) {
-		return c.updateDate()
+func (c *mqlAwsIamPolicy) GetUpdatedAt() *plugin.TValue[*time.Time] {
+	return plugin.GetOrCompute[*time.Time](&c.UpdatedAt, func() (*time.Time, error) {
+		return c.updatedAt()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2042,8 +2042,8 @@ resources:
       title: Return a list of users that do not have MFA configured along with the
         ARN, name, and associated IAM Groups
     - query: "aws.iam.credentialReport.\n  where(\n    passwordEnabled &&\n    accessKey1Active
-        &&\n    userCreationTime < time.today\n  ).\n  all(\n    accessKey1LastUsedDate
-        != null\n  ) \n"
+        &&\n    createdAt < time.today\n  ).\n  all(\n    accessKey1LastUsedDate !=
+        null\n  ) \n"
       title: Do not setup access keys during initial user setup for all IAM users
         that have a console password
   aws.iam.accessAnalyzer:
@@ -2161,7 +2161,8 @@ resources:
       policyId:
         min_mondoo_version: 9.0.0
       scope: {}
-      updateDate: {}
+      updatedAt:
+        min_mondoo_version: 9.0.0
       versions: {}
     is_private: true
     min_mondoo_version: 5.15.0
@@ -2254,7 +2255,6 @@ resources:
       passwordNextRotation: {}
       properties: {}
       user: {}
-      userCreationTime: {}
     is_private: true
     min_mondoo_version: 5.15.0
     platform:

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -403,14 +403,13 @@ func (a *mqlAwsIam) mqlPolicies(policies []iamtypes.Policy) ([]any, error) {
 		mqlAwsIamPolicy, err := CreateResource(a.MqlRuntime, "aws.iam.policy",
 			map[string]*llx.RawData{
 				"arn":             llx.StringDataPtr(policy.Arn),
-				"id":              llx.StringDataPtr(policy.PolicyId),
 				"policyId":        llx.StringDataPtr(policy.PolicyId),
 				"name":            llx.StringDataPtr(policy.PolicyName),
 				"description":     llx.StringDataPtr(policy.Description),
 				"isAttachable":    llx.BoolData(policy.IsAttachable),
 				"attachmentCount": llx.IntDataDefault(policy.AttachmentCount, 0),
-				"createDate":      llx.TimeDataPtr(policy.CreateDate),
-				"updateDate":      llx.TimeDataPtr(policy.UpdateDate),
+				"createdAt":       llx.TimeDataPtr(policy.CreateDate),
+				"updatedAt":       llx.TimeDataPtr(policy.UpdateDate),
 			})
 		if err != nil {
 			return nil, err
@@ -893,13 +892,6 @@ func (a *mqlAwsIamUser) attachedPolicies() ([]any, error) {
 	return res, nil
 }
 
-func (a *mqlAwsIamPolicy) id() (string, error) {
-	if a == nil {
-		return "", nil
-	}
-	return a.Arn.Data, nil
-}
-
 type mqlAwsIamPolicyInternal struct {
 	cachePolicy *iamtypes.Policy
 }
@@ -984,7 +976,7 @@ func (a *mqlAwsIamPolicy) createdAt() (*time.Time, error) {
 	return policy.CreateDate, nil
 }
 
-func (a *mqlAwsIamPolicy) updateDate() (*time.Time, error) {
+func (a *mqlAwsIamPolicy) updatedAt() (*time.Time, error) {
 	arn := a.Arn.Data
 
 	policy, err := a.loadPolicy(arn)


### PR DESCRIPTION
- Fully remove `id` from `aws.iam.policy` to fix compilation errors
- Update a leftover `createDate` to be `createdAt` in `aws.iam.policy` to match our other AWS resources
- Fix the docs example for `aws.iam.credentialReport` to not use `userCreateTime`
- Update the aws incident response query pack to use the new `aws.iam.policy` fields


```coffeescript
cnquery> aws.iam.policies.first{*}
aws.iam.policies.first: {
  updatedAt: 2023-05-03 22:29:29 -0700 PDT
  attachedGroups: []
  versions: [
    0: aws.iam.policyversion arn="arn:aws:iam::123:policy/service-role/CodeBuildBasePolicy-S3_Terraform-us-east-2" isDefaultVersion=true createdAt=2023-05-03 22:29:29 -0700 PDT
    1: aws.iam.policyversion arn="arn:aws:iam::123:policy/service-role/CodeBuildBasePolicy-S3_Terraform-us-east-2" isDefaultVersion=false createdAt=2022-11-27 13:27:54 -0800 PST
  ]
  arn: "arn:aws:iam::123:policy/service-role/CodeBuildBasePolicy-S3_Terraform-us-east-2"
  defaultVersion: aws.iam.policyversion arn="arn:aws:iam::123:policy/service-role/CodeBuildBasePolicy-S3_Terraform-us-east-2" isDefaultVersion=true createdAt=2023-05-03 22:29:29 -0700 PDT
  policyId: "123"
  attachedRoles: [
    0: aws.iam.role arn="arn:aws:iam::123:role/service-role/codebuild-S3_Terraform-service-role" name="codebuild-S3_Terraform-service-role"
  ]
  scope: "local"
  name: "CodeBuildBasePolicy-S3_Terraform-us-east-2"
  createdAt: 2022-11-27 13:27:54 -0800 PST
  attachedUsers: []
  description: null
  isAttachable: true
  attachmentCount: 1
}
```