### PR TITLE
🧹 ’ -> ' in LR docs

### DIFF
--- a/providers/arista/resources/arista.lr
+++ b/providers/arista/resources/arista.lr
@@ -28,13 +28,13 @@ arista.eos {
   ntp() arista.eos.ntpSetting
 }
 
-// Arista EOS system’s operating configuration
+// Arista EOS system's operating configuration
 arista.eos.runningConfig {
   // EOS running-config
   content() string
 }
 
-// Arista EOS system’s operating configuration for a specific section
+// Arista EOS system's operating configuration for a specific section
 arista.eos.runningConfig.section {
   // Section name
   name string


### PR DESCRIPTION
Stick to the simpler form in the docs