### PR TITLE
🐛 Fix recordings, do not store assets if they do not have an MRN or an id

### DIFF
--- a/providers-sdk/v1/recording/asset_recording.go
+++ b/providers-sdk/v1/recording/asset_recording.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Asset struct {
-	Asset       assetInfo    `json:"asset"`
+	Asset       *assetInfo   `json:"asset"`
 	Connections []connection `json:"connections"`
 	Resources   []Resource   `json:"resources"`
 
@@ -38,7 +38,7 @@ type connection struct {
 	ProviderID string `json:"provider"`
 	Connector  string `json:"connector"`
 	Version    string `json:"version"`
-	id         uint32 `json:"-"`
+	Id         uint32 `json:"id"`
 }
 
 type Resource struct {

--- a/providers-sdk/v1/recording/asset_recording_test.go
+++ b/providers-sdk/v1/recording/asset_recording_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package recording
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/cnquery/v12/providers-sdk/v1/inventory"
+)
+
+func TestAssetRecording(t *testing.T) {
+	t.Run("add asset by id only", func(t *testing.T) {
+		rec := &recording{
+			assets: map[uint32]*Asset{},
+			Assets: []*Asset{},
+		}
+
+		asset := &inventory.Asset{
+			Id:          "asset-id",
+			PlatformIds: []string{},
+			Platform:    &inventory.Platform{},
+		}
+		conf := &inventory.Config{
+			Type: "local",
+		}
+		rec.EnsureAsset(asset, "provider", 1, conf)
+
+		require.Len(t, rec.assets, 1)
+		require.Len(t, rec.Assets, 1)
+		require.Len(t, rec.Assets[0].connections, 1)
+		require.Len(t, rec.Assets[0].Resources, 0)
+		a := rec.Assets[0].Asset
+		require.Equal(t, "asset-id", a.ID)
+		require.Equal(t, []string{}, a.PlatformIDs)
+
+		// re-add again, should be idempotent
+		asset.PlatformIds = []string{"platform-id"}
+		rec.EnsureAsset(asset, "provider", 1, conf)
+		require.Len(t, rec.assets, 1)
+		require.Len(t, rec.Assets, 1)
+		require.Len(t, rec.Assets[0].connections, 1)
+		require.Len(t, rec.Assets[0].Resources, 0)
+		a = rec.Assets[0].Asset
+		require.Equal(t, "asset-id", a.ID)
+		require.Equal(t, []string{"platform-id"}, a.PlatformIDs)
+	})
+
+	t.Run("add asset by id and mrn", func(t *testing.T) {
+		rec := &recording{
+			assets: map[uint32]*Asset{},
+			Assets: []*Asset{},
+		}
+
+		asset := &inventory.Asset{
+			Id:          "asset-id",
+			PlatformIds: []string{"platform-id"},
+			Platform:    &inventory.Platform{},
+		}
+		conf := &inventory.Config{
+			Type: "local",
+		}
+		rec.EnsureAsset(asset, "provider", 1, conf)
+
+		require.Len(t, rec.assets, 1)
+		require.Len(t, rec.Assets, 1)
+		require.Len(t, rec.Assets[0].connections, 1)
+		require.Len(t, rec.Assets[0].Resources, 0)
+		a := rec.Assets[0].Asset
+		require.Equal(t, "asset-id", a.ID)
+		require.Equal(t, []string{"platform-id"}, a.PlatformIDs)
+
+		// re-add again by MRN, ensure nothing gets duplicated
+		asset.Mrn = "asset-mrn"
+		asset.PlatformIds = []string{"platform-id", "asset-mrn"}
+		rec.EnsureAsset(asset, "provider", 1, conf)
+		require.Len(t, rec.assets, 1)
+		require.Len(t, rec.Assets, 1)
+		require.Len(t, rec.Assets[0].connections, 1)
+		require.Len(t, rec.Assets[0].Resources, 0)
+		a = rec.Assets[0].Asset
+
+		require.Equal(t, "asset-mrn", a.ID)
+		require.Equal(t, []string{"platform-id", "asset-mrn"}, a.PlatformIDs)
+	})
+}

--- a/providers-sdk/v1/recording/upstream_recording.go
+++ b/providers-sdk/v1/recording/upstream_recording.go
@@ -106,7 +106,7 @@ func (n *Upstream) GetData(connectionID uint32, resource string, id string, fiel
 	return res, ok
 }
 
-func (n *Upstream) GetResource(connectionID uint32, resource string, id string) (map[string]*llx.RawData, bool) {
+func (n *Upstream) GetResource(_ uint32, resource string, id string) (map[string]*llx.RawData, bool) {
 	n.lock.Lock()
 	defer n.lock.Unlock()
 

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -290,7 +290,12 @@ func (r *Runtime) Connect(req *plugin.ConnectReq) error {
 }
 
 func (r *Runtime) AssetUpdated(asset *inventory.Asset) {
-	r.Recording().EnsureAsset(r.Provider.Connection.Asset, r.Provider.Instance.ID, r.Provider.Connection.Id, asset.Connections[0])
+	rec := r.Recording()
+	rec.EnsureAsset(
+		r.Provider.Connection.Asset,
+		r.Provider.Instance.ID,
+		r.Provider.Connection.Id,
+		asset.Connections[0])
 }
 
 func (r *Runtime) CreateResource(name string, args map[string]*llx.Primitive) (llx.Resource, error) {


### PR DESCRIPTION
* Do not store assets without MRN or an id. We do not know what to do with those assets, so best to not just store them at all
* Adding an asset by MRN after it's been added by id will now overwrite the asset
* Ensure `runtime.AssetUpdated` gets called when we update the asset's MRN. Recordings that get sent upstream are only retrieved by MRN so we need to ensure that every time the MRN gets updated we need to update the recording
* Some tests for adding an asset to a recording. We should start adding more of those to make the recording bug-free now that we are storing it upstream

To test, first run `make cnquery/install`, then run this qp:
```
packs:
  - uid: rec-test
    name: Recording test
    filters:
      - mql: asset.family.contains("unix")
    queries:
      - uid: packages
        title: packages
        mql: packages
      - uid: users
        title: users
        mql: users
      - uid: services
        title: services
        mql: services
```

```
~/go/bin/cnquery scan -f qp.yaml --record recording.json
```

Then load the recording:
```
~/go/bin/cnquery shell --use-recording recording.json
```

Accessing `packages`, `users` and `services` should be instant