### PR TITLE
✨ Support Red Hat EUS and E4S/SAP support types

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -829,6 +829,9 @@ var redhatFamily = &PlatformResolver{
 			modules := getActivatedRhelModules(conn)
 			pf.Metadata["redhat/modules"] = strings.Join(modules, ",")
 
+			// RHEL has mutliple support levels, identify them via repository files
+			pf.Metadata["redhat/support-type"] = strings.Join(getActivatedRhelSupportLevels(conn), ",")
+
 			return true, nil
 		}
 

--- a/providers/os/detector/detector_rhel_test.go
+++ b/providers/os/detector/detector_rhel_test.go
@@ -108,3 +108,98 @@ state=enabled`,
 		})
 	}
 }
+
+func TestGetActivatedRhelSupportLevels(t *testing.T) {
+	tests := []struct {
+		name     string
+		files    map[string]string
+		expected []string
+	}{
+		{
+			name:     "no repos directory",
+			files:    map[string]string{},
+			expected: []string{},
+		},
+		{
+			name: "empty repos directory",
+			files: map[string]string{
+				"/etc/yum.repos.d": "",
+			},
+			expected: []string{},
+		},
+		{
+			name: "eus repos",
+			files: map[string]string{
+				"/etc/yum.repos.d/rhel.repo": `[rhel-8-for-x86_64-baseos-eus-rpms]
+name=Red Hat Enterprise Linux 8 for x86_64 - BaseOS - Extended Update Support (RPMs)
+enabled=1`,
+			},
+			expected: []string{"eus"},
+		},
+		{
+			name: "disabled eus repo",
+			files: map[string]string{
+				"/etc/yum.repos.d/rhel.repo": `[rhel-8-for-x86_64-baseos-eus-rpms]
+name=Red Hat Enterprise Linux 8 for x86_64 - BaseOS - Extended Update Support (RPMs)
+enabled=0`,
+			},
+			expected: []string{},
+		},
+		{
+			name: "multiple repos",
+			files: map[string]string{
+				"/etc/yum.repos.d/1.repo": `[rhui-rhel-8-for-x86_64-baseos-e4s-rhui-rpms]
+name=Red Hat Enterprise Linux 8 for x86_64 - BaseOS - Update Services for SAP Solutions from RHUI (RPMs)
+enabled=1
+[rhui-rhel-8-for-x86_64-appstream-e4s-rhui-rpms]
+name=Red Hat Enterprise Linux 8 for x86_64 - AppStream - Update Services for SAP Solutions from RHUI (RPMs)
+enabled=1
+`,
+				"/etc/yum.repos.d/2.repo": `[rhel-8-for-x86_64-baseos-eus-rpms]
+name=Red Hat Enterprise Linux 8 for x86_64 - BaseOS - Extended Update Support (RPMs)
+enabled=1`,
+			},
+			expected: []string{"e4s", "eus"},
+		},
+		{
+			name: "invalid content",
+			files: map[string]string{
+				"/etc/yum.repos.d/rhel.repo": `invalid content`,
+			},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock filesystem
+			fs := afero.NewMemMapFs()
+
+			// Create the directory structure
+			if len(tt.files) > 0 {
+				err := fs.MkdirAll("/etc/yum.repos.d", 0o755)
+				assert.NoError(t, err)
+			}
+
+			// Create the files
+			for path, content := range tt.files {
+				if path == "/etc/yum.repos.d" {
+					continue
+				}
+				err := afero.WriteFile(fs, path, []byte(content), 0o644)
+				assert.NoError(t, err)
+			}
+
+			// Create a mock connection
+			conn := &mockConnection{
+				fs: fs,
+			}
+
+			// Call the function
+			result := getActivatedRhelSupportLevels(conn)
+
+			// Compare results
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
When Extended Update Support (EUS) or Enhanced Extended Update Support (E4S) is active, add it to the support types.

```
asset: {
  version: "8.6"
  platformMetadata: {
    distro-id: "rhel"
    redhat/support-type: "e4s"
  }
  title: "Red Hat Enterprise Linux 8.6 (Ootpa), Virtual machine"
  labels: {
    distro-id: "rhel"
  }
  platform: "redhat"
...
```