### PR TITLE
🐛 handle arguments dereferencing in built-in `ip` constructor

### DIFF
--- a/llx/builtin_global.go
+++ b/llx/builtin_global.go
@@ -260,11 +260,23 @@ func ipCall(e *blockExecutor, f *Function, ref uint64) (*RawData, uint64, error)
 	}
 
 	arg := f.Args[0]
-	if arg.Type != string(types.String) && arg.Type != string(types.Int) && arg.Type != string(types.Dict) {
+
+	var (
+		res  *RawData
+		dref uint64
+		err  error
+	)
+
+	switch arg.Type {
+	case string(types.String), string(types.Int), string(types.Dict):
+		res, dref, err = e.resolveValue(arg, ref)
+	case string(types.Ref):
+		srcRef, _ := arg.RefV2()
+		res, dref, err = e.resolveRef(srcRef, ref)
+	default:
 		return nil, 0, errors.New("called `ip` with incorrect argument type, expected string or int")
 	}
 
-	res, dref, err := e.resolveValue(arg, ref)
 	if err != nil || dref != 0 || res == nil {
 		return res, dref, err
 	}


### PR DESCRIPTION
this fix adds handling arguments dereferencing when `ipCall` is invoked with the argument passed down from a function/clojure.

For example the following expression:
```
cnquery> ["8.8.8.8"].map(ip(_))
map: [
  0: no data available
]
```
This happens due to the `called `ip` with incorrect argument type, expected string or int` returned from `ipCall`(built-in `ip` constructor) under the hood.

This patch resolves it:
```
cnquery> ["8.8.8.8"].map(ip(_))
map: [
  0: 8.8.8.8
]
```

### Possible Caveat / Concern

Effectively type checking is redundant, since `ipCall` invokes `any2ip` to actually parse the argument into `ip` resource. BUT, if we go the `Ref` logical branch it will be down to one (only the `any2ip`).