### PR TITLE
⭐ Allow overriding provider registry url

### DIFF
--- a/apps/cnquery/cmd/root.go
+++ b/apps/cnquery/cmd/root.go
@@ -121,6 +121,7 @@ func init() {
 	viper.BindPFlag("api_proxy", rootCmd.PersistentFlags().Lookup("api-proxy"))
 	viper.BindPFlag("auto_update", rootCmd.PersistentFlags().Lookup("auto-update"))
 	viper.BindEnv("features")
+	viper.BindEnv("registry_url")
 
 	config.Init(rootCmd)
 }

--- a/apps/cnquery/cmd/status.go
+++ b/apps/cnquery/cmd/status.go
@@ -262,7 +262,7 @@ func getProviders() ([]string, []string, error) {
 	}
 	for _, provider := range allProviders {
 		installed = append(installed, provider.Name)
-		latestVersion, err := providers.LatestVersion(provider.Name)
+		latestVersion, err := providers.LatestVersion(context.Background(), provider.Name)
 		if err != nil {
 			continue
 		}

--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -53,10 +53,17 @@ func AttachCLIs(rootCmd *cobra.Command, commands ...*Command) error {
 	return nil
 }
 
-func detectConnectorName(args []string, rootCmd *cobra.Command, commands []*Command, providers providers.Providers) (string, bool) {
+func detectConnectorName(args []string, rootCmd *cobra.Command, commands []*Command, existing providers.Providers) (string, bool) {
 	autoUpdate := true
 
 	config.InitViperConfig()
+
+	if viper.IsSet("registry_url") {
+		if registryURL := viper.GetString("registry_url"); registryURL != "" && !strings.HasPrefix(registryURL, "http") {
+			providers.SetProviderRegistry(providers.NewMondooProviderRegistry(providers.WithBaseURL(registryURL)))
+		}
+	}
+
 	if viper.IsSet("auto_update") {
 		autoUpdate = viper.GetBool("auto_update")
 	}
@@ -84,8 +91,8 @@ func detectConnectorName(args []string, rootCmd *cobra.Command, commands []*Comm
 		attachPFlags(flags, cmd.Command.Flags())
 	}
 
-	for i := range providers {
-		provider := providers[i]
+	for i := range existing {
+		provider := existing[i]
 		for j := range provider.Connectors {
 			conn := provider.Connectors[j]
 			for k := range conn.Flags {

--- a/providers/registry.go
+++ b/providers/registry.go
@@ -1,0 +1,146 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
+)
+
+var registry ProviderRegistry = NewMondooProviderRegistry()
+
+// SetProviderRegistry allows setting a custom provider registry implementation.
+// It must be called before any provider installation occurs.
+func SetProviderRegistry(r ProviderRegistry) {
+	registry = r
+}
+
+// ProviderRegistry defines the interface for provider registries that can
+// fetch provider versions and download provider packages.
+type ProviderRegistry interface {
+	// GetLatestVersion returns the latest version available for the given provider name
+	GetLatestVersion(ctx context.Context, name string) (string, error)
+
+	// DownloadProvider downloads a provider package and returns a ReadCloser for the content
+	DownloadProvider(ctx context.Context, name, version, os, arch string) (io.ReadCloser, error)
+}
+
+// MondooProviderRegistry implements ProviderRegistry for Mondoo's provider registry
+type MondooProviderRegistry struct {
+	BaseURL string
+}
+
+// MondooProviderRegistryOption defines a function type for configuring MondooProviderRegistry
+type MondooProviderRegistryOption func(*MondooProviderRegistry)
+
+// WithBaseURL sets the base URL for the provider registry
+func WithBaseURL(baseURL string) MondooProviderRegistryOption {
+	return func(r *MondooProviderRegistry) {
+		r.BaseURL = baseURL
+	}
+}
+
+// NewMondooProviderRegistry creates a new MondooProviderRegistry with the given options.
+// By default, it uses "https://releases.mondoo.com/providers" as the base URL.
+func NewMondooProviderRegistry(opts ...MondooProviderRegistryOption) *MondooProviderRegistry {
+	r := &MondooProviderRegistry{
+		BaseURL: "https://releases.mondoo.com/providers",
+	}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	return r
+}
+
+func LatestVersion(ctx context.Context, name string) (string, error) {
+	return registry.GetLatestVersion(ctx, name)
+}
+
+// GetLatestVersion fetches the latest version for the given provider name
+func (r *MondooProviderRegistry) GetLatestVersion(ctx context.Context, name string) (string, error) {
+	client, err := httpClientWithRetry()
+	if err != nil {
+		return "", err
+	}
+
+	latestURL, err := url.JoinPath(r.BaseURL, "latest.json")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to construct latest version URL")
+	}
+
+	res, err := client.Get(latestURL)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		log.Debug().Err(err).Msg("reading latest.json failed")
+		return "", errors.New("failed to read response from upstream provider versions")
+	}
+
+	var upstreamVersions ProviderVersions
+	err = json.Unmarshal(data, &upstreamVersions)
+	if err != nil {
+		log.Debug().Err(err).Msg("parsing latest.json failed")
+		return "", errors.New("failed to parse response from upstream provider versions")
+	}
+
+	var latestVersion string
+	for i := range upstreamVersions.Providers {
+		if upstreamVersions.Providers[i].Name == name {
+			latestVersion = upstreamVersions.Providers[i].Version
+			break
+		}
+	}
+
+	if latestVersion == "" {
+		return "", errors.New("cannot determine latest version of provider '" + name + "'")
+	}
+	return latestVersion, nil
+}
+
+// DownloadProvider downloads a provider package from the registry
+func (r *MondooProviderRegistry) DownloadProvider(ctx context.Context, name, version, os, arch string) (io.ReadCloser, error) {
+	// Build the filename using the same pattern as the original
+	filename := fmt.Sprintf("%s_%s_%s_%s.tar.xz", name, version, os, arch)
+
+	// Construct the download URL using url.JoinPath for robust path handling
+	downloadURL, err := url.JoinPath(r.BaseURL, name, version, filename)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to construct download URL")
+	}
+
+	log.Debug().Str("url", downloadURL).Msg("downloading provider from URL")
+
+	client, err := httpClientWithRetry()
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := client.Get(downloadURL)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to download "+name+"-"+version)
+	}
+
+	if res.StatusCode == http.StatusNotFound {
+		return nil, errors.New("cannot find provider " + name + "-" + version + " under url " + downloadURL)
+	} else if res.StatusCode != http.StatusOK {
+		log.Debug().Str("url", downloadURL).Int("status", res.StatusCode).Msg("failed to download from URL (status code)")
+		res.Body.Close()
+		return nil, errors.New("failed to download " + name + "-" + version + ", received status code: " + res.Status)
+	}
+
+	return res.Body, nil
+}

--- a/providers/registry_test.go
+++ b/providers/registry_test.go
@@ -1,0 +1,180 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMondooProviderRegistry(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     []MondooProviderRegistryOption
+		expected string
+	}{
+		{
+			name:     "default registry",
+			opts:     nil,
+			expected: "https://releases.mondoo.com/providers",
+		},
+		{
+			name:     "custom base URL",
+			opts:     []MondooProviderRegistryOption{WithBaseURL("https://my-registry.com/providers")},
+			expected: "https://my-registry.com/providers",
+		},
+		{
+			name:     "custom base URL with trailing slash",
+			opts:     []MondooProviderRegistryOption{WithBaseURL("https://my-registry.com/providers/")},
+			expected: "https://my-registry.com/providers/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := NewMondooProviderRegistry(tt.opts...)
+			assert.Equal(t, tt.expected, registry.BaseURL)
+		})
+	}
+}
+
+func TestMondooProviderRegistry_GetLatestVersion(t *testing.T) {
+	// Create a mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/latest.json" {
+			versions := ProviderVersions{
+				Providers: []ProviderVersion{
+					{Name: "aws", Version: "1.2.3"},
+					{Name: "azure", Version: "2.4.6"},
+					{Name: "gcp", Version: "3.1.4"},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(versions)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	registry := NewMondooProviderRegistry(WithBaseURL(server.URL))
+
+	tests := []struct {
+		name     string
+		provider string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "existing provider",
+			provider: "aws",
+			want:     "1.2.3",
+			wantErr:  false,
+		},
+		{
+			name:     "another existing provider",
+			provider: "azure",
+			want:     "2.4.6",
+			wantErr:  false,
+		},
+		{
+			name:     "non-existing provider",
+			provider: "nonexistent",
+			want:     "",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			got, err := registry.GetLatestVersion(ctx, tt.provider)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "cannot determine latest version")
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestMondooProviderRegistry_GetLatestVersion_ServerError(t *testing.T) {
+	// Test server returning an error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	registry := NewMondooProviderRegistry(WithBaseURL(server.URL))
+	ctx := context.Background()
+
+	_, err := registry.GetLatestVersion(ctx, "aws")
+	assert.Error(t, err)
+}
+
+func TestMondooProviderRegistry_GetLatestVersion_InvalidJSON(t *testing.T) {
+	// Test server returning invalid JSON
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/latest.json" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte("invalid json"))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	registry := NewMondooProviderRegistry(WithBaseURL(server.URL))
+	ctx := context.Background()
+
+	_, err := registry.GetLatestVersion(ctx, "aws")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestMondooProviderRegistry_DownloadProvider(t *testing.T) {
+	expectedContent := "fake-provider-content"
+
+	// Create a mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check the expected path format: /aws/1.2.3/aws_1.2.3_linux_amd64.tar.xz
+		expectedPath := "/aws/1.2.3/aws_1.2.3_linux_amd64.tar.xz"
+		if r.URL.Path == expectedPath {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.Write([]byte(expectedContent))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	registry := NewMondooProviderRegistry(WithBaseURL(server.URL))
+	ctx := context.Background()
+
+	t.Run("successful download", func(t *testing.T) {
+		reader, err := registry.DownloadProvider(ctx, "aws", "1.2.3", "linux", "amd64")
+		require.NoError(t, err)
+		defer reader.Close()
+
+		content, err := io.ReadAll(reader)
+		require.NoError(t, err)
+		assert.Equal(t, expectedContent, string(content))
+	})
+
+	t.Run("provider not found", func(t *testing.T) {
+		_, err := registry.DownloadProvider(ctx, "nonexistent", "1.0.0", "linux", "amd64")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot find provider")
+	})
+}


### PR DESCRIPTION
You can override the provider registry by either setting
```
registry_url: https://releases.mondoo.com/providers
```
in your mondoo config

or by setting the `MONDOO_REGISTRY_URL` environment variable

Future Improvements:
- We should cache the provider manifest for some period of time
- We can use etags to check if the provider manifest has actually changed

I was unable to figure out how to make it work with a command line flag given we call these functions before cobra parses them