### PR TITLE
🧹 Suppress error message in recording

### DIFF
--- a/providers-sdk/v1/recording/recording.go
+++ b/providers-sdk/v1/recording/recording.go
@@ -392,7 +392,6 @@ func (r *recording) EnsureAsset(asset *inventory.Asset, providerID string, conne
 func (r *recording) AddData(connectionID uint32, resource string, id string, field string, data *llx.RawData) {
 	asset, ok := r.assets[connectionID]
 	if !ok {
-		log.Error().Uint32("connectionID", connectionID).Msg("cannot store recording, cannot find connection ID")
 		return
 	}
 


### PR DESCRIPTION
When I scan without credentials, I see these error messages:
```
x cannot store recording, cannot find connection ID connectionID=1
x cannot store recording, cannot find connection ID connectionID=1
x cannot store recording, cannot find connection ID connectionID=1
x cannot store recording, cannot find connection ID connectionID=1
x cannot store recording, cannot find connection ID connectionID=1
```

Its possible for us not to have an asset for a connection:
```
	id := getAssetIdForRecording(asset)
	if id == "" {
		log.Debug().Msg("cannot store asset in recording, asset has no id or mrn")
		return
	}
...
	r.assets[connectionID] = recordingAsset
```

And we later use it:
```
	asset, ok := r.assets[connectionID]
	if !ok {
		log.Error().Uint32("connectionID", connectionID).Msg("cannot store recording, cannot find connection ID")
		return
	}
```

Causing an error message

So I think the error message not useful as we explicitly allow not setting a asset for a connection