### PR TITLE
🐛 make startup-script attribute multiline string for gcp

### DIFF
--- a/providers/os/id/metadata/crawler.go
+++ b/providers/os/id/metadata/crawler.go
@@ -93,6 +93,7 @@ var multilineStringFields = []string{
 	// GCP
 	"instance/service-accounts/*/scopes",
 	"instance/attributes/ssh-keys",
+	"instance/attributes/startup-script",
 }
 
 // isMultilineString checks if a path should be treated as a raw multiline string.


### PR DESCRIPTION
`instance/attributes/startup-script` should be treated as a multi-line string and we should not attempt to parse it as json or anything else. This fixes an issue where having a bash script as a `startup-script` becomes an endless loop