### PR TITLE
✨ Extend AWS Provider: aws.iam.samlProviders 

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -718,6 +718,10 @@ aws.iam {
   // List of server certificates stored in IAM
   serverCertificates() []dict
   instanceProfiles() []aws.iam.instanceProfile
+  // List of SAML 2.0 identity providers configured in IAM
+  samlProviders() []aws.iam.samlProvider
+  // List of OpenID Connect (OIDC) identity providers configured in IAM
+  oidcProviders() []aws.iam.oidcProvider
 }
 
 // Entry in AWS IAM credential report
@@ -913,6 +917,38 @@ private aws.iam.virtualmfadevice @defaults("serialNumber") {
   enableDate time
   // User associated with the MFA device
   user() aws.iam.user
+}
+
+// AWS IAM SAML 2.0 identity provider
+private aws.iam.samlProvider @defaults("arn name") {
+  // ARN of the SAML provider
+  arn string
+  // Name of the SAML provider
+  name string
+  // Time when the SAML provider was created
+  createdAt time
+  // SAML metadata document expiration time
+  validUntil time
+  // SAML metadata document in XML format
+  metadataDocument string
+  // Tags associated with the SAML provider
+  tags map[string]string
+}
+
+// AWS IAM OpenID Connect (OIDC) identity provider
+private aws.iam.oidcProvider @defaults("arn url") {
+  // ARN of the OIDC provider
+  arn string
+  // URL of the identity provider
+  url string
+  // List of client IDs (audiences) for the OIDC provider
+  clientIds []string
+  // List of server certificate thumbprints for the OIDC provider
+  thumbprints []string
+  // Time when the OIDC provider was created
+  createdAt time
+  // Tags associated with the OIDC provider
+  tags map[string]string
 }
 
 // AWS IAM Access Analyzer resource (for assessing the configuration of AWS IAM Access Analyzer)

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -247,6 +247,14 @@ func init() {
 			// to override args, implement: initAwsIamVirtualmfadevice(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsIamVirtualmfadevice,
 		},
+		"aws.iam.samlProvider": {
+			// to override args, implement: initAwsIamSamlProvider(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsIamSamlProvider,
+		},
+		"aws.iam.oidcProvider": {
+			// to override args, implement: initAwsIamOidcProvider(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsIamOidcProvider,
+		},
 		"aws.iam.accessAnalyzer": {
 			// to override args, implement: initAwsIamAccessAnalyzer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsIamAccessAnalyzer,
@@ -1660,6 +1668,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.iam.instanceProfiles": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIam).GetInstanceProfiles()).ToDataRes(types.Array(types.Resource("aws.iam.instanceProfile")))
 	},
+	"aws.iam.samlProviders": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIam).GetSamlProviders()).ToDataRes(types.Array(types.Resource("aws.iam.samlProvider")))
+	},
+	"aws.iam.oidcProviders": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIam).GetOidcProviders()).ToDataRes(types.Array(types.Resource("aws.iam.oidcProvider")))
+	},
 	"aws.iam.usercredentialreportentry.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamUsercredentialreportentry).GetProperties()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -1884,6 +1898,42 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.iam.virtualmfadevice.user": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamVirtualmfadevice).GetUser()).ToDataRes(types.Resource("aws.iam.user"))
+	},
+	"aws.iam.samlProvider.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamSamlProvider).GetArn()).ToDataRes(types.String)
+	},
+	"aws.iam.samlProvider.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamSamlProvider).GetName()).ToDataRes(types.String)
+	},
+	"aws.iam.samlProvider.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamSamlProvider).GetCreatedAt()).ToDataRes(types.Time)
+	},
+	"aws.iam.samlProvider.validUntil": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamSamlProvider).GetValidUntil()).ToDataRes(types.Time)
+	},
+	"aws.iam.samlProvider.metadataDocument": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamSamlProvider).GetMetadataDocument()).ToDataRes(types.String)
+	},
+	"aws.iam.samlProvider.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamSamlProvider).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.iam.oidcProvider.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamOidcProvider).GetArn()).ToDataRes(types.String)
+	},
+	"aws.iam.oidcProvider.url": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamOidcProvider).GetUrl()).ToDataRes(types.String)
+	},
+	"aws.iam.oidcProvider.clientIds": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamOidcProvider).GetClientIds()).ToDataRes(types.Array(types.String))
+	},
+	"aws.iam.oidcProvider.thumbprints": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamOidcProvider).GetThumbprints()).ToDataRes(types.Array(types.String))
+	},
+	"aws.iam.oidcProvider.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamOidcProvider).GetCreatedAt()).ToDataRes(types.Time)
+	},
+	"aws.iam.oidcProvider.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamOidcProvider).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"aws.iam.accessAnalyzer.analyzers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamAccessAnalyzer).GetAnalyzers()).ToDataRes(types.Array(types.Resource("aws.iam.accessanalyzer.analyzer")))
@@ -6521,6 +6571,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 		r.(*mqlAwsIam).InstanceProfiles, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.iam.samlProviders": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIam).SamlProviders, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.iam.oidcProviders": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIam).OidcProviders, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.iam.usercredentialreportentry.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 			r.(*mqlAwsIamUsercredentialreportentry).__id, ok = v.Value.(string)
 			return
@@ -6855,6 +6913,62 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool {
 	},
 	"aws.iam.virtualmfadevice.user": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamVirtualmfadevice).User, ok = plugin.RawToTValue[*mqlAwsIamUser](v.Value, v.Error)
+		return
+	},
+	"aws.iam.samlProvider.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlAwsIamSamlProvider).__id, ok = v.Value.(string)
+			return
+		},
+	"aws.iam.samlProvider.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamSamlProvider).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.samlProvider.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamSamlProvider).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.samlProvider.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamSamlProvider).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.iam.samlProvider.validUntil": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamSamlProvider).ValidUntil, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.iam.samlProvider.metadataDocument": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamSamlProvider).MetadataDocument, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.samlProvider.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamSamlProvider).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.iam.oidcProvider.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+			r.(*mqlAwsIamOidcProvider).__id, ok = v.Value.(string)
+			return
+		},
+	"aws.iam.oidcProvider.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamOidcProvider).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.oidcProvider.url": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamOidcProvider).Url, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.oidcProvider.clientIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamOidcProvider).ClientIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.iam.oidcProvider.thumbprints": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamOidcProvider).Thumbprints, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.iam.oidcProvider.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamOidcProvider).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.iam.oidcProvider.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamOidcProvider).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"aws.iam.accessAnalyzer.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15506,6 +15620,8 @@ type mqlAwsIam struct {
 	VirtualMfaDevices plugin.TValue[[]any]
 	ServerCertificates plugin.TValue[[]any]
 	InstanceProfiles plugin.TValue[[]any]
+	SamlProviders plugin.TValue[[]any]
+	OidcProviders plugin.TValue[[]any]
 }
 
 // createAwsIam creates a new instance of this resource
@@ -15688,6 +15804,38 @@ func (c *mqlAwsIam) GetInstanceProfiles() *plugin.TValue[[]any] {
 		}
 
 		return c.instanceProfiles()
+	})
+}
+
+func (c *mqlAwsIam) GetSamlProviders() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.SamlProviders, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.iam", c.__id, "samlProviders")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.samlProviders()
+	})
+}
+
+func (c *mqlAwsIam) GetOidcProviders() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.OidcProviders, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.iam", c.__id, "oidcProviders")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.oidcProviders()
 	})
 }
 
@@ -16636,6 +16784,154 @@ func (c *mqlAwsIamVirtualmfadevice) GetUser() *plugin.TValue[*mqlAwsIamUser] {
 
 		return c.user()
 	})
+}
+
+// mqlAwsIamSamlProvider for the aws.iam.samlProvider resource
+type mqlAwsIamSamlProvider struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlAwsIamSamlProviderInternal it will be used here
+	Arn plugin.TValue[string]
+	Name plugin.TValue[string]
+	CreatedAt plugin.TValue[*time.Time]
+	ValidUntil plugin.TValue[*time.Time]
+	MetadataDocument plugin.TValue[string]
+	Tags plugin.TValue[map[string]any]
+}
+
+// createAwsIamSamlProvider creates a new instance of this resource
+func createAwsIamSamlProvider(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsIamSamlProvider{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+	res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.iam.samlProvider", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsIamSamlProvider) MqlName() string {
+	return "aws.iam.samlProvider"
+}
+
+func (c *mqlAwsIamSamlProvider) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsIamSamlProvider) GetArn() *plugin.TValue[string] {
+	return &c.Arn
+}
+
+func (c *mqlAwsIamSamlProvider) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAwsIamSamlProvider) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
+}
+
+func (c *mqlAwsIamSamlProvider) GetValidUntil() *plugin.TValue[*time.Time] {
+	return &c.ValidUntil
+}
+
+func (c *mqlAwsIamSamlProvider) GetMetadataDocument() *plugin.TValue[string] {
+	return &c.MetadataDocument
+}
+
+func (c *mqlAwsIamSamlProvider) GetTags() *plugin.TValue[map[string]any] {
+	return &c.Tags
+}
+
+// mqlAwsIamOidcProvider for the aws.iam.oidcProvider resource
+type mqlAwsIamOidcProvider struct {
+	MqlRuntime *plugin.Runtime
+	__id string
+	// optional: if you define mqlAwsIamOidcProviderInternal it will be used here
+	Arn plugin.TValue[string]
+	Url plugin.TValue[string]
+	ClientIds plugin.TValue[[]any]
+	Thumbprints plugin.TValue[[]any]
+	CreatedAt plugin.TValue[*time.Time]
+	Tags plugin.TValue[map[string]any]
+}
+
+// createAwsIamOidcProvider creates a new instance of this resource
+func createAwsIamOidcProvider(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsIamOidcProvider{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+	res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.iam.oidcProvider", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsIamOidcProvider) MqlName() string {
+	return "aws.iam.oidcProvider"
+}
+
+func (c *mqlAwsIamOidcProvider) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsIamOidcProvider) GetArn() *plugin.TValue[string] {
+	return &c.Arn
+}
+
+func (c *mqlAwsIamOidcProvider) GetUrl() *plugin.TValue[string] {
+	return &c.Url
+}
+
+func (c *mqlAwsIamOidcProvider) GetClientIds() *plugin.TValue[[]any] {
+	return &c.ClientIds
+}
+
+func (c *mqlAwsIamOidcProvider) GetThumbprints() *plugin.TValue[[]any] {
+	return &c.Thumbprints
+}
+
+func (c *mqlAwsIamOidcProvider) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
+}
+
+func (c *mqlAwsIamOidcProvider) GetTags() *plugin.TValue[map[string]any] {
+	return &c.Tags
 }
 
 // mqlAwsIamAccessAnalyzer for the aws.iam.accessAnalyzer resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2009,8 +2009,12 @@ resources:
       groups: {}
       instanceProfiles:
         min_mondoo_version: 9.0.0
+      oidcProviders:
+        min_mondoo_version: 9.0.0
       policies: {}
       roles: {}
+      samlProviders:
+        min_mondoo_version: 9.0.0
       serverCertificates: {}
       users: {}
       virtualMfaDevices: {}
@@ -2141,6 +2145,19 @@ resources:
     platform:
       name:
       - aws
+  aws.iam.oidcProvider:
+    fields:
+      arn: {}
+      clientIds: {}
+      createdAt: {}
+      tags: {}
+      thumbprints: {}
+      url: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
+    platform:
+      name:
+      - aws
   aws.iam.policy:
     docs:
       desc: |
@@ -2200,6 +2217,19 @@ resources:
       tags: {}
     is_private: true
     min_mondoo_version: 5.15.0
+    platform:
+      name:
+      - aws
+  aws.iam.samlProvider:
+    fields:
+      arn: {}
+      createdAt: {}
+      metadataDocument: {}
+      name: {}
+      tags: {}
+      validUntil: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
     platform:
       name:
       - aws

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -1453,3 +1453,111 @@ func initAwsIamInstanceProfile(runtime *plugin.Runtime, args map[string]*llx.Raw
 	}
 	return args, nil, nil
 }
+
+func (a *mqlAwsIam) samlProviders() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+
+	svc := conn.Iam("")
+	ctx := context.Background()
+
+	res := []any{}
+	// List all SAML providers
+	listResp, err := svc.ListSAMLProviders(ctx, &iam.ListSAMLProvidersInput{})
+	if err != nil {
+		return nil, errors.Wrap(err, "could not gather aws iam saml providers")
+	}
+
+	// For each SAML provider, fetch detailed information
+	for _, provider := range listResp.SAMLProviderList {
+		if provider.Arn == nil {
+			continue
+		}
+
+		getResp, err := svc.GetSAMLProvider(ctx, &iam.GetSAMLProviderInput{
+			SAMLProviderArn: provider.Arn,
+		})
+		if err != nil {
+			log.Warn().Err(err).Str("arn", *provider.Arn).Msg("could not get saml provider details")
+			continue
+		}
+
+		// Extract provider name from ARN
+		arnParsed, err := arn.Parse(*provider.Arn)
+		if err != nil {
+			log.Warn().Err(err).Str("arn", *provider.Arn).Msg("could not parse saml provider arn")
+			continue
+		}
+		name := strings.TrimPrefix(arnParsed.Resource, "saml-provider/")
+
+		mqlSamlProvider, err := CreateResource(a.MqlRuntime, "aws.iam.samlProvider",
+			map[string]*llx.RawData{
+				"arn":              llx.StringDataPtr(provider.Arn),
+				"name":             llx.StringData(name),
+				"createdAt":        llx.TimeDataPtr(provider.CreateDate),
+				"validUntil":       llx.TimeDataPtr(getResp.ValidUntil),
+				"metadataDocument": llx.StringDataPtr(getResp.SAMLMetadataDocument),
+				"tags":             llx.MapData(iamTagsToMap(getResp.Tags), types.String),
+			})
+		if err != nil {
+			return nil, err
+		}
+
+		res = append(res, mqlSamlProvider)
+	}
+
+	return res, nil
+}
+
+func (a *mqlAwsIam) oidcProviders() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+
+	svc := conn.Iam("")
+	ctx := context.Background()
+
+	res := []any{}
+	// List all OIDC providers
+	listResp, err := svc.ListOpenIDConnectProviders(ctx, &iam.ListOpenIDConnectProvidersInput{})
+	if err != nil {
+		return nil, errors.Wrap(err, "could not gather aws iam oidc providers")
+	}
+
+	// For each OIDC provider, fetch detailed information
+	for _, provider := range listResp.OpenIDConnectProviderList {
+		if provider.Arn == nil {
+			continue
+		}
+
+		getResp, err := svc.GetOpenIDConnectProvider(ctx, &iam.GetOpenIDConnectProviderInput{
+			OpenIDConnectProviderArn: provider.Arn,
+		})
+		if err != nil {
+			log.Warn().Err(err).Str("arn", *provider.Arn).Msg("could not get oidc provider details")
+			continue
+		}
+
+		mqlOidcProvider, err := CreateResource(a.MqlRuntime, "aws.iam.oidcProvider",
+			map[string]*llx.RawData{
+				"arn":         llx.StringDataPtr(provider.Arn),
+				"url":         llx.StringDataPtr(getResp.Url),
+				"clientIds":   llx.ArrayData(convert.SliceAnyToInterface(getResp.ClientIDList), types.String),
+				"thumbprints": llx.ArrayData(convert.SliceAnyToInterface(getResp.ThumbprintList), types.String),
+				"createdAt":   llx.TimeDataPtr(getResp.CreateDate),
+				"tags":        llx.MapData(iamTagsToMap(getResp.Tags), types.String),
+			})
+		if err != nil {
+			return nil, err
+		}
+
+		res = append(res, mqlOidcProvider)
+	}
+
+	return res, nil
+}
+
+func (a *mqlAwsIamSamlProvider) id() (string, error) {
+	return a.Arn.Data, nil
+}
+
+func (a *mqlAwsIamOidcProvider) id() (string, error) {
+	return a.Arn.Data, nil
+}

--- a/providers/aws/resources/aws_iam_identity_providers_test.go
+++ b/providers/aws/resources/aws_iam_identity_providers_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"go.mondoo.com/cnquery/v12/providers-sdk/v1/testutils"
+)
+
+func TestAwsIamSamlProviders(t *testing.T) {
+	t.Run("list SAML providers", func(t *testing.T) {
+		res := testutils.InitTester(t, testutils.LinuxMock())
+		r := res.TestQuery(t, "aws.iam.samlProviders")
+		assert := r.ErrorAsAssertion
+		assert.NoError()
+	})
+}
+
+func TestAwsIamOidcProviders(t *testing.T) {
+	t.Run("list OIDC providers", func(t *testing.T) {
+		res := testutils.InitTester(t, testutils.LinuxMock())
+		r := res.TestQuery(t, "aws.iam.oidcProviders")
+		assert := r.ErrorAsAssertion
+		assert.NoError()
+	})
+}
+
+func TestAwsIamSamlProviderFields(t *testing.T) {
+	t.Run("access SAML provider fields", func(t *testing.T) {
+		res := testutils.InitTester(t, testutils.LinuxMock())
+		r := res.TestQuery(t, "aws.iam.samlProviders { arn name createdAt validUntil tags }")
+		assert := r.ErrorAsAssertion
+		assert.NoError()
+	})
+}
+
+func TestAwsIamOidcProviderFields(t *testing.T) {
+	t.Run("access OIDC provider fields", func(t *testing.T) {
+		res := testutils.InitTester(t, testutils.LinuxMock())
+		r := res.TestQuery(t, "aws.iam.oidcProviders { arn url clientIds thumbprints createdAt tags }")
+		assert := r.ErrorAsAssertion
+		assert.NoError()
+	})
+}


### PR DESCRIPTION
Added two new private resources:

#### `aws.iam.samlProvider`
```lr
private aws.iam.samlProvider @defaults("arn name") {
  arn string                    // ARN of the SAML provider
  name string                   // Name of the SAML provider
  createdAt time                // Creation timestamp
  validUntil time              // SAML metadata document expiration
  metadataDocument string      // SAML metadata document XML
  tags map[string]string       // Tags on the provider
}
```

#### `aws.iam.oidcProvider`
```lr
private aws.iam.oidcProvider @defaults("arn url") {
  arn string                   // ARN of the OIDC provider
  url string                   // URL of the identity provider
  clientIds []string          // List of client IDs (audiences)
  thumbprints []string        // List of server certificate thumbprints
  createdAt time              // Creation timestamp
  tags map[string]string      // Tags on the provider
}
```

#### Extended `aws.iam` Resource
Added two new fields to the main `aws.iam` resource:
```lr
samlProviders() []aws.iam.samlProvider    // List of SAML 2.0 identity providers
oidcProviders() []aws.iam.oidcProvider    // List of OIDC identity providers
```

### 2. Implementation (`providers/aws/resources/aws_iam.go`)

Implemented four methods:

#### `samlProviders()` - Lines 1457-1509
- Uses AWS API `iam:ListSAMLProviders` to list all SAML providers
- Fetches detailed information using `iam:GetSAMLProvider` for each provider
- Extracts provider name from ARN
- Creates MQL resources with all required fields including tags

#### `oidcProviders()` - Lines 1511-1555
- Uses AWS API `iam:ListOpenIDConnectProviders` to list all OIDC providers
- Fetches detailed information using `iam:GetOpenIDConnectProvider` for each provider
- Creates MQL resources with all required fields including tags

#### Resource ID Methods
- `mqlAwsIamSamlProvider.id()` - Returns the provider ARN
- `mqlAwsIamOidcProvider.id()` - Returns the provider ARN

### 3. Test File (`providers/aws/resources/aws_iam_identity_providers_test.go`)

Created comprehensive unit tests:
- Test listing SAML providers
- Test listing OIDC providers
- Test accessing SAML provider fields
- Test accessing OIDC provider fields