### PR TITLE
🐛 declare additional attributes that are multiline strings

### DIFF
--- a/providers/os/id/metadata/crawler.go
+++ b/providers/os/id/metadata/crawler.go
@@ -93,7 +93,10 @@ var multilineStringFields = []string{
 	// GCP
 	"instance/service-accounts/*/scopes",
 	"instance/attributes/ssh-keys",
+	"instance/attributes/sshKeys",
 	"instance/attributes/startup-script",
+	"instance/attributes/shutdown-script",
+	"instance/attributes/user-data",
 }
 
 // isMultilineString checks if a path should be treated as a raw multiline string.


### PR DESCRIPTION
The `user-data` attribute was not being recognised as a multi-line attribute, resulting in a loop and subsequent scan failure. This issue was reported by a customer. 
The other attributes were added after reviewing the Google schema, so I decided to take advantage of this opportunity to include them now. For reference, the other SSH attribute is deprecated, but I thought it prudent to add it nonetheless.