### PR TITLE
✨ Warn on LR duplicates. Add --fail-on-duplicates flag to fail the LR compilation

### DIFF
--- a/providers-sdk/v1/lr/lr_test.go
+++ b/providers-sdk/v1/lr/lr_test.go
@@ -318,3 +318,47 @@ func TestParseLR(t *testing.T) {
 		})
 	}
 }
+
+func TestGetFieldPaths(t *testing.T) {
+	res := &Resource{
+		ID: "name",
+		Body: &ResourceDef{
+			Fields: []*Field{
+				{BasicField: &BasicField{ID: "field1", Type: Type{SimpleType: &SimpleType{"string"}}}},
+				{BasicField: &BasicField{ID: "field2", Type: Type{SimpleType: &SimpleType{"int"}}}},
+				{Embeddable: &Embeddable{Type: "os.any"}},
+				{Init: &Init{Args: []TypedArg{{ID: "arg1", Type: Type{SimpleType: &SimpleType{"string"}}}}}},
+			},
+		},
+	}
+	paths := res.GetFieldPaths()
+	assert.Equal(t, []string{"name.field1", "name.field2"}, paths)
+}
+
+func TestGetDuplicates(t *testing.T) {
+	res1 := &Resource{
+		ID: "res1",
+		Body: &ResourceDef{
+			Fields: []*Field{
+				{BasicField: &BasicField{ID: "res2", Type: Type{SimpleType: &SimpleType{"resource"}}}},
+				{BasicField: &BasicField{ID: "field2", Type: Type{SimpleType: &SimpleType{"int"}}}},
+				{Embeddable: &Embeddable{Type: "os.any"}},
+				{Init: &Init{Args: []TypedArg{{ID: "arg1", Type: Type{SimpleType: &SimpleType{"string"}}}}}},
+			},
+		},
+	}
+	res2 := &Resource{
+		ID: "res1.res2",
+		Body: &ResourceDef{
+			Fields: []*Field{
+				{BasicField: &BasicField{ID: "value", Type: Type{SimpleType: &SimpleType{"string"}}}},
+			},
+		},
+	}
+	lr := &LR{
+		Resources: []*Resource{res1, res2},
+	}
+
+	dups := lr.GetDuplicates()
+	assert.Equal(t, []string{"res1.res2"}, dups)
+}


### PR DESCRIPTION
To test, run LR compilation with `--fail-on-duplicates`. This is currently set to false to not break any pipeline as we already have such duplicates in our code base. Need to see how to start actively using this to start trimming down duplicates