### PR TITLE
⭐ openeuler platform/family detection + package detection

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -817,13 +817,8 @@ var redhatFamily = &PlatformResolver{
 	IsFamily: true,
 	// NOTE: oracle pretends to be redhat with /etc/redhat-release and Red Hat Linux, therefore we
 	// want to check that platform before redhat
-	Children: []*PlatformResolver{oracle, rhel, centos, fedora, scientific, eurolinux, openeuler},
+	Children: []*PlatformResolver{oracle, rhel, centos, fedora, scientific, eurolinux},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
-		// openeuler does not have /etc/redhat-release but it is rhelish
-		if pf.Name == "openEuler" {
-			return true, nil
-		}
-
 		f, err := conn.FileSystem().Open("/etc/redhat-release")
 		if err != nil {
 			log.Debug().Err(err)
@@ -918,10 +913,19 @@ var archFamily = &PlatformResolver{
 	},
 }
 
+var eulerFamily = &PlatformResolver{
+	Name:     "euler",
+	IsFamily: true,
+	Children: []*PlatformResolver{openeuler},
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		return true, nil
+	},
+}
+
 var linuxFamily = &PlatformResolver{
 	Name:     inventory.FAMILY_LINUX,
 	IsFamily: true,
-	Children: []*PlatformResolver{archFamily, redhatFamily, debianFamily, suseFamily, amazonlinux, alpine, gentoo, busybox, photon, windriver, openwrt, ubios, plcnext, defaultLinux},
+	Children: []*PlatformResolver{archFamily, redhatFamily, debianFamily, suseFamily, eulerFamily, amazonlinux, alpine, gentoo, busybox, photon, windriver, openwrt, ubios, plcnext, defaultLinux},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		detected := false
 		osrd := NewOSReleaseDetector(conn)

--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -632,6 +632,18 @@ var plcnext = &PlatformResolver{
 	},
 }
 
+var openeuler = &PlatformResolver{
+	Name:     "openeuler",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		if pf.Name == "openEuler" {
+			pf.Name = "openeuler"
+			return true, nil
+		}
+		return false, nil
+	},
+}
+
 // fallback linux detection, since we do not know the system, the family detection may not be correct
 var defaultLinux = &PlatformResolver{
 	Name:     "generic-linux",
@@ -805,8 +817,13 @@ var redhatFamily = &PlatformResolver{
 	IsFamily: true,
 	// NOTE: oracle pretends to be redhat with /etc/redhat-release and Red Hat Linux, therefore we
 	// want to check that platform before redhat
-	Children: []*PlatformResolver{oracle, rhel, centos, fedora, scientific, eurolinux},
+	Children: []*PlatformResolver{oracle, rhel, centos, fedora, scientific, eurolinux, openeuler},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		// openeuler does not have /etc/redhat-release but it is rhelish
+		if pf.Name == "openEuler" {
+			return true, nil
+		}
+
 		f, err := conn.FileSystem().Open("/etc/redhat-release")
 		if err != nil {
 			log.Debug().Err(err)

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -889,3 +889,14 @@ func TestElementaryOSDetector(t *testing.T) {
 	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
 	assert.Equal(t, []string{"debian", "linux", "unix", "os"}, di.Family)
 }
+
+func TestOpenEulerDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-openeuler.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "openeuler", di.Name, "os name should be identified")
+	assert.Equal(t, "openEuler 24.03 (LTS-SP2)", di.Title, "os title should be identified")
+	assert.Equal(t, "24.03", di.Version, "os version should be identified")
+	assert.Equal(t, "aarch64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"redhat", "linux", "unix", "os"}, di.Family)
+}

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -898,5 +898,5 @@ func TestOpenEulerDetector(t *testing.T) {
 	assert.Equal(t, "openEuler 24.03 (LTS-SP2)", di.Title, "os title should be identified")
 	assert.Equal(t, "24.03", di.Version, "os version should be identified")
 	assert.Equal(t, "aarch64", di.Arch, "os arch should be identified")
-	assert.Equal(t, []string{"redhat", "linux", "unix", "os"}, di.Family)
+	assert.Equal(t, []string{"euler", "linux", "unix", "os"}, di.Family)
 }

--- a/providers/os/detector/testdata/detect-openeuler.toml
+++ b/providers/os/detector/testdata/detect-openeuler.toml
@@ -1,0 +1,18 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "aarch64"
+
+[commands."uname -r"]
+stdout = "6.10.14-linuxkit"
+
+[files."/etc/os-release"]
+content = """
+NAME="openEuler"
+VERSION="24.03 (LTS-SP2)"
+ID="openEuler"
+VERSION_ID="24.03"
+PRETTY_NAME="openEuler 24.03 (LTS-SP2)"
+ANSI_COLOR="0;31"
+"""

--- a/providers/os/id/networki/linux_n.go
+++ b/providers/os/id/networki/linux_n.go
@@ -67,6 +67,7 @@ func (n *neti) detectLinuxInterfaces() ([]Interface, error) {
 func (n *neti) getLinuxIPv4GatewayDetails() (interfaces []Interface, err error) {
 	output, err := n.RunCommand("ip route show")
 	if err != nil {
+		log.Debug().Msg("os.network.interface> could not run ip route show")
 		return nil, err
 	}
 
@@ -95,6 +96,7 @@ func (n *neti) getLinuxIPv4GatewayDetails() (interfaces []Interface, err error) 
 func (n *neti) getLinuxIPv6GatewayDetails() (interfaces []Interface, err error) {
 	output, err := n.RunCommand("ip -6 route show")
 	if err != nil {
+		log.Debug().Msg("os.network.interface> could not run ip -6 route show")
 		return nil, err
 	}
 
@@ -123,6 +125,7 @@ func (n *neti) getLinuxIPv6GatewayDetails() (interfaces []Interface, err error) 
 func (n *neti) getLinuxSysfsInterfaces() (interfaces []Interface, err error) {
 	dirEntries, err := afero.ReadDir(n.connection.FileSystem(), "/sys/class/net")
 	if err != nil {
+		log.Debug().Msg("os.network.interface> could not read /sys/class/net")
 		return nil, err
 	}
 
@@ -238,6 +241,7 @@ func parseHexFlags(hexStr string) []string {
 func (n *neti) getLinuxCmdInterfaces() ([]Interface, error) {
 	output, err := n.RunCommand("ip addr show")
 	if err != nil {
+		log.Debug().Msg("os.network.interface> could not run ip addr show")
 		return nil, err
 	}
 

--- a/providers/os/resources/packages/packages.go
+++ b/providers/os/resources/packages/packages.go
@@ -107,7 +107,7 @@ func ResolveSystemPkgManagers(conn shared.Connection) ([]OperatingSystemPkgManag
 		pms = append(pms, &SnapPkgManager{conn: conn, platform: asset.Platform})
 	case asset.Platform.Name == "amazonlinux" || asset.Platform.Name == "photon" || asset.Platform.Name == "wrlinux":
 		fallthrough
-	case asset.Platform.IsFamily("redhat"): // rhel family
+	case asset.Platform.IsFamily("redhat") || asset.Platform.IsFamily("euler"): // rhel and euler based systems
 		pms = append(pms, &RpmPkgManager{conn: conn, platform: asset.Platform})
 		if asset.Platform.Name == "fedora" {
 			// https: // snapcraft.io/docs/distro-support
@@ -117,7 +117,7 @@ func ResolveSystemPkgManagers(conn shared.Connection) ([]OperatingSystemPkgManag
 		pms = append(pms, &SusePkgManager{RpmPkgManager{conn: conn, platform: asset.Platform}})
 	case asset.Platform.Name == "alpine" || asset.Platform.Name == "wolfi": // alpine & wolfi share apk
 		pms = append(pms, &AlpinePkgManager{conn: conn, platform: asset.Platform})
-	case asset.Platform.Name == "macos": // mac os family
+	case asset.Platform.Name == "macos": // macos family
 		pms = append(pms, &MacOSPkgManager{conn: conn, platform: asset.Platform})
 	case asset.Platform.Name == "windows":
 		pms = append(pms, &WinPkgManager{conn: conn, platform: asset.Platform})

--- a/providers/os/resources/packages/rpm_packages.go
+++ b/providers/os/resources/packages/rpm_packages.go
@@ -239,6 +239,7 @@ func (rpm *RpmPkgManager) staticList() ([]Package, error) {
 		"/usr/lib/sysimage/rpm/rpmdb.sqlite", // used on fedora 36+ and photon4
 		"/var/lib/rpm/rpmdb.sqlite",          // used on fedora 33-35
 		"/var/lib/rpm/Packages",              // used on fedora 32
+		"/var/lib/rpm/Packages.db",           // used on openeuler
 	}
 	var tmpRpmDBFile string
 	var detectedPath string


### PR DESCRIPTION
openeuler is RHEL based, but it doesn't have an /etc/os-release file. Detect the package + the family with a special check for openeuler within the redhat family check. Also add the path where it stores the RPM db so we can parse package data.