### PR TITLE
Add support for Azure Web App slots and enhance resource handling

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,6 +1,7 @@
 ACCOUNTADMIN
 Adddays
 antispam
+appslot
 atlassian
 auditlog
 Auths

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -1067,6 +1067,8 @@ private azure.subscription.webService.appsite @defaults("id name location") {
   properties dict
   // App site identity
   identity dict
+  // Deployment slots for the web app site
+  slots() []azure.subscription.webService.appslot
   // App site configuration
   configuration() azure.subscription.webService.appsiteconfig
   // App site authentication settings
@@ -1086,6 +1088,48 @@ private azure.subscription.webService.appsite @defaults("id name location") {
   // FTP publishing method policies
   ftp() azure.subscription.webService.appsite.basicPublishingCredentialsPolicies
   // SCM publishing method policies
+  scm() azure.subscription.webService.appsite.basicPublishingCredentialsPolicies
+}
+
+// Azure Web app deployment slot
+private azure.subscription.webService.appslot @defaults("id name location") {
+  // App slot ID
+  id string
+  // App slot name
+  name string
+  // App slot kind
+  kind string
+  // App slot location
+  location string
+  // App slot type
+  type string
+  // App slot tags
+  tags map[string]string
+  // App slot properties
+  properties dict
+  // App slot identity
+  identity dict
+  // Parent web app site for this slot
+  parent() azure.subscription.webService.appsite
+  // App slot configuration
+  configuration() azure.subscription.webService.appsiteconfig
+  // App slot authentication settings
+  authenticationSettings() azure.subscription.webService.appsiteauthsettings
+  // App slot metadata
+  metadata() dict
+  // App slot application settings
+  applicationSettings() dict
+  // App slot connection settings
+  connectionSettings() dict
+  // App slot stack
+  stack() dict
+  // App slot diagnostic settings
+  diagnosticSettings() []azure.subscription.monitorService.diagnosticsetting
+  // List of functions for the app slot
+  functions() []azure.subscription.webService.function
+  // FTP publishing method policies for the slot
+  ftp() azure.subscription.webService.appsite.basicPublishingCredentialsPolicies
+  // SCM publishing method policies for the slot
   scm() azure.subscription.webService.appsite.basicPublishingCredentialsPolicies
 }
 

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -71,6 +71,7 @@ const (
 	ResourceAzureSubscriptionWebService                                                string = "azure.subscription.webService"
 	ResourceAzureSubscriptionWebServiceAppRuntimeStack                                 string = "azure.subscription.webService.appRuntimeStack"
 	ResourceAzureSubscriptionWebServiceAppsite                                         string = "azure.subscription.webService.appsite"
+	ResourceAzureSubscriptionWebServiceAppslot                                         string = "azure.subscription.webService.appslot"
 	ResourceAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies       string = "azure.subscription.webService.appsite.basicPublishingCredentialsPolicies"
 	ResourceAzureSubscriptionWebServiceAppsiteauthsettings                             string = "azure.subscription.webService.appsiteauthsettings"
 	ResourceAzureSubscriptionWebServiceAppsiteconfig                                   string = "azure.subscription.webService.appsiteconfig"
@@ -347,6 +348,10 @@ func init() {
 		"azure.subscription.webService.appsite": {
 			// to override args, implement: initAzureSubscriptionWebServiceAppsite(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAzureSubscriptionWebServiceAppsite,
+		},
+		"azure.subscription.webService.appslot": {
+			// to override args, implement: initAzureSubscriptionWebServiceAppslot(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAzureSubscriptionWebServiceAppslot,
 		},
 		"azure.subscription.webService.appsite.basicPublishingCredentialsPolicies": {
 			// to override args, implement: initAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -1920,6 +1925,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.webService.appsite.identity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetIdentity()).ToDataRes(types.Dict)
 	},
+	"azure.subscription.webService.appsite.slots": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetSlots()).ToDataRes(types.Array(types.Resource("azure.subscription.webService.appslot")))
+	},
 	"azure.subscription.webService.appsite.configuration": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetConfiguration()).ToDataRes(types.Resource("azure.subscription.webService.appsiteconfig"))
 	},
@@ -1949,6 +1957,63 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.webService.appsite.scm": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetScm()).ToDataRes(types.Resource("azure.subscription.webService.appsite.basicPublishingCredentialsPolicies"))
+	},
+	"azure.subscription.webService.appslot.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppslot).GetId()).ToDataRes(types.String)
+	},
+	"azure.subscription.webService.appslot.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppslot).GetName()).ToDataRes(types.String)
+	},
+	"azure.subscription.webService.appslot.kind": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppslot).GetKind()).ToDataRes(types.String)
+	},
+	"azure.subscription.webService.appslot.location": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppslot).GetLocation()).ToDataRes(types.String)
+	},
+	"azure.subscription.webService.appslot.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppslot).GetType()).ToDataRes(types.String)
+	},
+	"azure.subscription.webService.appslot.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppslot).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"azure.subscription.webService.appslot.properties": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppslot).GetProperties()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.webService.appslot.identity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppslot).GetIdentity()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.webService.appslot.parent": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppslot).GetParent()).ToDataRes(types.Resource("azure.subscription.webService.appsite"))
+	},
+	"azure.subscription.webService.appslot.configuration": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppslot).GetConfiguration()).ToDataRes(types.Resource("azure.subscription.webService.appsiteconfig"))
+	},
+	"azure.subscription.webService.appslot.authenticationSettings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppslot).GetAuthenticationSettings()).ToDataRes(types.Resource("azure.subscription.webService.appsiteauthsettings"))
+	},
+	"azure.subscription.webService.appslot.metadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppslot).GetMetadata()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.webService.appslot.applicationSettings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppslot).GetApplicationSettings()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.webService.appslot.connectionSettings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppslot).GetConnectionSettings()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.webService.appslot.stack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppslot).GetStack()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.webService.appslot.diagnosticSettings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppslot).GetDiagnosticSettings()).ToDataRes(types.Array(types.Resource("azure.subscription.monitorService.diagnosticsetting")))
+	},
+	"azure.subscription.webService.appslot.functions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppslot).GetFunctions()).ToDataRes(types.Array(types.Resource("azure.subscription.webService.function")))
+	},
+	"azure.subscription.webService.appslot.ftp": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppslot).GetFtp()).ToDataRes(types.Resource("azure.subscription.webService.appsite.basicPublishingCredentialsPolicies"))
+	},
+	"azure.subscription.webService.appslot.scm": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppslot).GetScm()).ToDataRes(types.Resource("azure.subscription.webService.appsite.basicPublishingCredentialsPolicies"))
 	},
 	"azure.subscription.webService.appsite.basicPublishingCredentialsPolicies.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies).GetId()).ToDataRes(types.String)
@@ -5041,6 +5106,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionWebServiceAppsite).Identity, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.webService.appsite.slots": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsite).Slots, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.webService.appsite.configuration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebServiceAppsite).Configuration, ok = plugin.RawToTValue[*mqlAzureSubscriptionWebServiceAppsiteconfig](v.Value, v.Error)
 		return
@@ -5079,6 +5148,86 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.webService.appsite.scm": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebServiceAppsite).Scm, ok = plugin.RawToTValue[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appslot.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppslot).__id, ok = v.Value.(string)
+		return
+	},
+	"azure.subscription.webService.appslot.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppslot).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appslot.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppslot).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appslot.kind": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppslot).Kind, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appslot.location": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppslot).Location, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appslot.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppslot).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appslot.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppslot).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appslot.properties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppslot).Properties, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appslot.identity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppslot).Identity, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appslot.parent": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppslot).Parent, ok = plugin.RawToTValue[*mqlAzureSubscriptionWebServiceAppsite](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appslot.configuration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppslot).Configuration, ok = plugin.RawToTValue[*mqlAzureSubscriptionWebServiceAppsiteconfig](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appslot.authenticationSettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppslot).AuthenticationSettings, ok = plugin.RawToTValue[*mqlAzureSubscriptionWebServiceAppsiteauthsettings](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appslot.metadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppslot).Metadata, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appslot.applicationSettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppslot).ApplicationSettings, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appslot.connectionSettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppslot).ConnectionSettings, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appslot.stack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppslot).Stack, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appslot.diagnosticSettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppslot).DiagnosticSettings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appslot.functions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppslot).Functions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appslot.ftp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppslot).Ftp, ok = plugin.RawToTValue[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appslot.scm": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppslot).Scm, ok = plugin.RawToTValue[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.webService.appsite.basicPublishingCredentialsPolicies.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12036,6 +12185,7 @@ type mqlAzureSubscriptionWebServiceAppsite struct {
 	Tags                   plugin.TValue[map[string]any]
 	Properties             plugin.TValue[any]
 	Identity               plugin.TValue[any]
+	Slots                  plugin.TValue[[]any]
 	Configuration          plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteconfig]
 	AuthenticationSettings plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteauthsettings]
 	Metadata               plugin.TValue[any]
@@ -12115,6 +12265,22 @@ func (c *mqlAzureSubscriptionWebServiceAppsite) GetProperties() *plugin.TValue[a
 
 func (c *mqlAzureSubscriptionWebServiceAppsite) GetIdentity() *plugin.TValue[any] {
 	return &c.Identity
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsite) GetSlots() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Slots, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.appsite", c.__id, "slots")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.slots()
+	})
 }
 
 func (c *mqlAzureSubscriptionWebServiceAppsite) GetConfiguration() *plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteconfig] {
@@ -12225,6 +12391,237 @@ func (c *mqlAzureSubscriptionWebServiceAppsite) GetScm() *plugin.TValue[*mqlAzur
 	return plugin.GetOrCompute[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies](&c.Scm, func() (*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies, error) {
 		if c.MqlRuntime.HasRecording {
 			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.appsite", c.__id, "scm")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies), nil
+			}
+		}
+
+		return c.scm()
+	})
+}
+
+// mqlAzureSubscriptionWebServiceAppslot for the azure.subscription.webService.appslot resource
+type mqlAzureSubscriptionWebServiceAppslot struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAzureSubscriptionWebServiceAppslotInternal it will be used here
+	Id                     plugin.TValue[string]
+	Name                   plugin.TValue[string]
+	Kind                   plugin.TValue[string]
+	Location               plugin.TValue[string]
+	Type                   plugin.TValue[string]
+	Tags                   plugin.TValue[map[string]any]
+	Properties             plugin.TValue[any]
+	Identity               plugin.TValue[any]
+	Parent                 plugin.TValue[*mqlAzureSubscriptionWebServiceAppsite]
+	Configuration          plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteconfig]
+	AuthenticationSettings plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteauthsettings]
+	Metadata               plugin.TValue[any]
+	ApplicationSettings    plugin.TValue[any]
+	ConnectionSettings     plugin.TValue[any]
+	Stack                  plugin.TValue[any]
+	DiagnosticSettings     plugin.TValue[[]any]
+	Functions              plugin.TValue[[]any]
+	Ftp                    plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies]
+	Scm                    plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies]
+}
+
+// createAzureSubscriptionWebServiceAppslot creates a new instance of this resource
+func createAzureSubscriptionWebServiceAppslot(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAzureSubscriptionWebServiceAppslot{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("azure.subscription.webService.appslot", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppslot) MqlName() string {
+	return "azure.subscription.webService.appslot"
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppslot) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppslot) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppslot) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppslot) GetKind() *plugin.TValue[string] {
+	return &c.Kind
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppslot) GetLocation() *plugin.TValue[string] {
+	return &c.Location
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppslot) GetType() *plugin.TValue[string] {
+	return &c.Type
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppslot) GetTags() *plugin.TValue[map[string]any] {
+	return &c.Tags
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppslot) GetProperties() *plugin.TValue[any] {
+	return &c.Properties
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppslot) GetIdentity() *plugin.TValue[any] {
+	return &c.Identity
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppslot) GetParent() *plugin.TValue[*mqlAzureSubscriptionWebServiceAppsite] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionWebServiceAppsite](&c.Parent, func() (*mqlAzureSubscriptionWebServiceAppsite, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.appslot", c.__id, "parent")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionWebServiceAppsite), nil
+			}
+		}
+
+		return c.parent()
+	})
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppslot) GetConfiguration() *plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteconfig] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionWebServiceAppsiteconfig](&c.Configuration, func() (*mqlAzureSubscriptionWebServiceAppsiteconfig, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.appslot", c.__id, "configuration")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionWebServiceAppsiteconfig), nil
+			}
+		}
+
+		return c.configuration()
+	})
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppslot) GetAuthenticationSettings() *plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteauthsettings] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionWebServiceAppsiteauthsettings](&c.AuthenticationSettings, func() (*mqlAzureSubscriptionWebServiceAppsiteauthsettings, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.appslot", c.__id, "authenticationSettings")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionWebServiceAppsiteauthsettings), nil
+			}
+		}
+
+		return c.authenticationSettings()
+	})
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppslot) GetMetadata() *plugin.TValue[any] {
+	return plugin.GetOrCompute[any](&c.Metadata, func() (any, error) {
+		return c.metadata()
+	})
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppslot) GetApplicationSettings() *plugin.TValue[any] {
+	return plugin.GetOrCompute[any](&c.ApplicationSettings, func() (any, error) {
+		return c.applicationSettings()
+	})
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppslot) GetConnectionSettings() *plugin.TValue[any] {
+	return plugin.GetOrCompute[any](&c.ConnectionSettings, func() (any, error) {
+		return c.connectionSettings()
+	})
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppslot) GetStack() *plugin.TValue[any] {
+	return plugin.GetOrCompute[any](&c.Stack, func() (any, error) {
+		return c.stack()
+	})
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppslot) GetDiagnosticSettings() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.DiagnosticSettings, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.appslot", c.__id, "diagnosticSettings")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.diagnosticSettings()
+	})
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppslot) GetFunctions() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Functions, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.appslot", c.__id, "functions")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.functions()
+	})
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppslot) GetFtp() *plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies](&c.Ftp, func() (*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.appslot", c.__id, "ftp")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies), nil
+			}
+		}
+
+		return c.ftp()
+	})
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppslot) GetScm() *plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies](&c.Scm, func() (*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.appslot", c.__id, "scm")
 			if err != nil {
 				return nil, err
 			}

--- a/providers/azure/resources/azure.lr.manifest.yaml
+++ b/providers/azure/resources/azure.lr.manifest.yaml
@@ -2919,6 +2919,8 @@ resources:
       properties: {}
       scm:
         min_mondoo_version: 9.0.0
+      slots:
+        min_mondoo_version: 9.0.0
       stack: {}
       tags: {}
       type: {}
@@ -2971,6 +2973,32 @@ resources:
     refs:
     - title: Azure Web documentation
       url: https://learn.microsoft.com/en-us/azure/?product=web
+  azure.subscription.webService.appslot:
+    fields:
+      applicationSettings: {}
+      authenticationSettings: {}
+      configuration: {}
+      connectionSettings: {}
+      diagnosticSettings: {}
+      ftp: {}
+      functions: {}
+      id: {}
+      identity: {}
+      kind: {}
+      location: {}
+      metadata: {}
+      name: {}
+      parent: {}
+      properties: {}
+      scm: {}
+      stack: {}
+      tags: {}
+      type: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
+    platform:
+      name:
+      - azure
   azure.subscription.webService.function:
     fields:
       id: {}

--- a/providers/azure/resources/web.go
+++ b/providers/azure/resources/web.go
@@ -63,6 +63,148 @@ type AzureWebAppStackRuntime struct {
 	EndOfLifeDate time.Time `json:"endOfLifeDate,omitempty"`
 }
 
+func createWebAppResourceFromSite(runtime *plugin.Runtime, resourceType string, site *web.Site) (any, error) {
+	if site == nil {
+		return nil, errors.New("site cannot be nil")
+	}
+
+	properties := map[string]any{}
+	if site.Properties != nil {
+		var err error
+		properties, err = convert.JsonToDict(site.Properties)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	identity := map[string]any{}
+	if site.Identity != nil {
+		var err error
+		identity, err = convert.JsonToDict(site.Identity)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return CreateResource(runtime, resourceType,
+		map[string]*llx.RawData{
+			"id":         llx.StringDataPtr(site.ID),
+			"name":       llx.StringDataPtr(site.Name),
+			"location":   llx.StringDataPtr(site.Location),
+			"tags":       llx.MapData(convert.PtrMapStrToInterface(site.Tags), types.String),
+			"type":       llx.StringDataPtr(site.Type),
+			"kind":       llx.StringDataPtr(site.Kind),
+			"properties": llx.DictData(properties),
+			"identity":   llx.DictData(identity),
+		})
+}
+
+func computeWebAppStack(runtime *plugin.Runtime, config *mqlAzureSubscriptionWebServiceAppsiteconfig, metadata any) (any, error) {
+	if config == nil {
+		return nil, errors.New("web app configuration is nil")
+	}
+
+	configProperties := config.Properties.Data
+
+	data, err := json.Marshal(configProperties)
+	if err != nil {
+		return nil, err
+	}
+
+	var properties web.SiteConfig
+	err = json.Unmarshal(data, &properties)
+	if err != nil {
+		return nil, err
+	}
+
+	runtimeInfo := AzureWebAppStackRuntime{
+		Os: "windows",
+	}
+
+	if properties.LinuxFxVersion == nil && properties.WindowsFxVersion == nil {
+		return nil, errors.New("could not determine stack version")
+	}
+
+	if properties.LinuxFxVersion != nil && len(*properties.LinuxFxVersion) > 0 {
+		runtimeInfo.Os = "linux"
+		runtimeInfo.ID = *properties.LinuxFxVersion
+
+		fxversion := strings.Split(*properties.LinuxFxVersion, "|")
+		runtimeInfo.Name = strings.ToLower(fxversion[0])
+		runtimeInfo.MinorVersion = strings.ToLower(fxversion[1])
+	} else {
+		metadataMap, ok := metadata.(map[string]any)
+		if !ok {
+			return nil, nil
+		}
+
+		stack, ok := metadataMap["CURRENT_STACK"].(string)
+		if !ok {
+			return nil, nil
+		}
+		version := ""
+		switch stack {
+		case "dotnet":
+			stack = "aspnet"
+			version = convert.ToValue(properties.NetFrameworkVersion)
+		case "dotnetcore":
+			version = "3.1"
+		case "php":
+			version = convert.ToValue(properties.PhpVersion)
+		case "python":
+			version = convert.ToValue(properties.PythonVersion)
+		case "node":
+			version = convert.ToValue(properties.NodeVersion)
+		case "powershell":
+			version = convert.ToValue(properties.PowerShellVersion)
+		case "java":
+			version = convert.ToValue(properties.JavaVersion)
+		case "javaContainer":
+			version = convert.ToValue(properties.JavaContainerVersion)
+		}
+
+		runtimeInfo.Name = strings.ToLower(stack)
+		runtimeInfo.ID = strings.ToUpper(stack) + "|" + version
+		runtimeInfo.MinorVersion = version
+	}
+
+	obj, err := CreateResource(runtime, "azure.subscription.webService", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	azureWeb := obj.(*mqlAzureSubscriptionWebService)
+	runtimesPlugin := azureWeb.GetAvailableRuntimes()
+	if runtimesPlugin.Error != nil {
+		return nil, runtimesPlugin.Error
+	}
+
+	runtimes := runtimesPlugin.Data
+	var match map[string]any
+
+	for i := range runtimes {
+		rt := runtimes[i]
+		hashmap := rt.(map[string]any)
+		if (hashmap["name"] == runtimeInfo.Name && hashmap["minorVersion"] == runtimeInfo.MinorVersion) || hashmap["id"] == runtimeInfo.ID {
+			match = hashmap
+		}
+	}
+
+	if match != nil {
+		if match["isDefault"] != nil {
+			runtimeInfo.IsDefault = match["isDefault"].(bool)
+		}
+		if match["isDeprecated"] != nil {
+			runtimeInfo.IsDeprecated = match["isDeprecated"].(bool)
+		}
+	} else {
+		if len(runtimeInfo.MinorVersion) > 0 {
+			runtimeInfo.IsDeprecated = true
+		}
+	}
+
+	return convert.JsonToDict(runtimeInfo)
+}
+
 func (a *mqlAzureSubscriptionWebService) id() (string, error) {
 	return "azure.subscription.web/" + a.SubscriptionId.Data, nil
 }
@@ -96,6 +238,47 @@ func (a *mqlAzureSubscriptionWebServiceAppsiteconfig) id() (string, error) {
 func (a *mqlAzureSubscriptionWebServiceAppsite) diagnosticSettings() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	return getDiagnosticSettings(a.Id.Data, a.MqlRuntime, conn)
+}
+
+func (a *mqlAzureSubscriptionWebServiceAppsite) slots() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+	token := conn.Token()
+	resourceID, err := ParseResourceID(a.Id.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	site, err := resourceID.Component("sites")
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := web.NewWebAppsClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	pager := client.NewListSlotsPager(resourceID.ResourceGroup, site, &web.WebAppsClientListSlotsOptions{})
+	res := []any{}
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, entry := range page.Value {
+			slotResource, err := createWebAppResourceFromSite(a.MqlRuntime, "azure.subscription.webService.appslot", entry)
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, slotResource)
+		}
+	}
+
+	return res, nil
 }
 
 func (a *mqlAzureSubscriptionWebService) apps() ([]any, error) {
@@ -529,6 +712,307 @@ func (a *mqlAzureSubscriptionWebServiceAppsite) functions() ([]any, error) {
 	return res, nil
 }
 
+func (a *mqlAzureSubscriptionWebServiceAppslot) webAppsClient() (*connection.AzureConnection, context.Context, *ResourceID, *web.WebAppsClient, string, string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+
+	resourceID, err := ParseResourceID(a.Id.Data)
+	if err != nil {
+		return nil, nil, nil, nil, "", "", err
+	}
+
+	site, err := resourceID.Component("sites")
+	if err != nil {
+		return nil, nil, nil, nil, "", "", err
+	}
+
+	slot, err := resourceID.Component("slots")
+	if err != nil {
+		return nil, nil, nil, nil, "", "", err
+	}
+
+	client, err := web.NewWebAppsClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, nil, nil, nil, "", "", err
+	}
+
+	return conn, ctx, resourceID, client, site, slot, nil
+}
+
+func (a *mqlAzureSubscriptionWebServiceAppslot) id() (string, error) {
+	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionWebServiceAppslot) diagnosticSettings() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	return getDiagnosticSettings(a.Id.Data, a.MqlRuntime, conn)
+}
+
+func (a *mqlAzureSubscriptionWebServiceAppslot) parent() (*mqlAzureSubscriptionWebServiceAppsite, error) {
+	_, ctx, resourceID, client, site, _, err := a.webAppsClient()
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.Get(ctx, resourceID.ResourceGroup, site, &web.WebAppsClientGetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	parentResource, err := createWebAppResourceFromSite(a.MqlRuntime, "azure.subscription.webService.appsite", &response.Site)
+	if err != nil {
+		return nil, err
+	}
+
+	return parentResource.(*mqlAzureSubscriptionWebServiceAppsite), nil
+}
+
+func (a *mqlAzureSubscriptionWebServiceAppslot) configuration() (*mqlAzureSubscriptionWebServiceAppsiteconfig, error) {
+	_, ctx, resourceID, client, site, slot, err := a.webAppsClient()
+	if err != nil {
+		return nil, err
+	}
+
+	configuration, err := client.GetConfigurationSlot(ctx, resourceID.ResourceGroup, site, slot, &web.WebAppsClientGetConfigurationSlotOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	properties := map[string]any{}
+	if configuration.Properties != nil {
+		props, err := convert.JsonToDict(configuration.Properties)
+		if err != nil {
+			return nil, err
+		}
+		properties = props
+	}
+
+	res, err := CreateResource(a.MqlRuntime, "azure.subscription.webService.appsiteconfig",
+		map[string]*llx.RawData{
+			"id":         llx.StringDataPtr(configuration.ID),
+			"name":       llx.StringDataPtr(configuration.Name),
+			"kind":       llx.StringDataPtr(configuration.Kind),
+			"type":       llx.StringDataPtr(configuration.Type),
+			"properties": llx.DictData(properties),
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	return res.(*mqlAzureSubscriptionWebServiceAppsiteconfig), nil
+}
+
+func (a *mqlAzureSubscriptionWebServiceAppslot) authenticationSettings() (*mqlAzureSubscriptionWebServiceAppsiteauthsettings, error) {
+	_, ctx, resourceID, client, site, slot, err := a.webAppsClient()
+	if err != nil {
+		return nil, err
+	}
+
+	configuration, err := client.GetAuthSettingsSlot(ctx, resourceID.ResourceGroup, site, slot, &web.WebAppsClientGetAuthSettingsSlotOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	properties := map[string]any{}
+	if configuration.Properties != nil {
+		props, err := convert.JsonToDict(configuration.Properties)
+		if err != nil {
+			return nil, err
+		}
+		properties = props
+	}
+
+	res, err := CreateResource(a.MqlRuntime, "azure.subscription.webService.appsiteauthsettings",
+		map[string]*llx.RawData{
+			"id":         llx.StringDataPtr(configuration.ID),
+			"name":       llx.StringDataPtr(configuration.Name),
+			"kind":       llx.StringDataPtr(configuration.Kind),
+			"type":       llx.StringDataPtr(configuration.Type),
+			"properties": llx.DictData(properties),
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	return res.(*mqlAzureSubscriptionWebServiceAppsiteauthsettings), nil
+}
+
+func (a *mqlAzureSubscriptionWebServiceAppslot) metadata() (any, error) {
+	_, ctx, resourceID, client, site, slot, err := a.webAppsClient()
+	if err != nil {
+		return nil, err
+	}
+
+	metadata, err := client.ListMetadataSlot(ctx, resourceID.ResourceGroup, site, slot, &web.WebAppsClientListMetadataSlotOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	res := make(map[string]any)
+
+	for k := range metadata.Properties {
+		res[k] = convert.ToValue(metadata.Properties[k])
+	}
+
+	return res, nil
+}
+
+func (a *mqlAzureSubscriptionWebServiceAppslot) applicationSettings() (any, error) {
+	_, ctx, resourceID, client, site, slot, err := a.webAppsClient()
+	if err != nil {
+		return nil, err
+	}
+
+	settings, err := client.ListApplicationSettingsSlot(ctx, resourceID.ResourceGroup, site, slot, &web.WebAppsClientListApplicationSettingsSlotOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	res := make(map[string]any)
+
+	for k := range settings.Properties {
+		res[k] = convert.ToValue(settings.Properties[k])
+	}
+
+	return res, nil
+}
+
+func (a *mqlAzureSubscriptionWebServiceAppslot) connectionSettings() (any, error) {
+	_, ctx, resourceID, client, site, slot, err := a.webAppsClient()
+	if err != nil {
+		return nil, err
+	}
+
+	settings, err := client.ListConnectionStringsSlot(ctx, resourceID.ResourceGroup, site, slot, &web.WebAppsClientListConnectionStringsSlotOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	res := make(map[string]any)
+
+	for k := range settings.Properties {
+		value, err := convert.JsonToDict(settings.Properties[k])
+		if err != nil {
+			return nil, err
+		}
+
+		res[k] = value
+	}
+
+	return res, nil
+}
+
+func (a *mqlAzureSubscriptionWebServiceAppslot) stack() (any, error) {
+	configPlugin := a.GetConfiguration()
+	if configPlugin.Error != nil {
+		return nil, configPlugin.Error
+	}
+	config := configPlugin.Data
+
+	metadataPlugin := a.GetMetadata()
+	if metadataPlugin.Error != nil {
+		return nil, metadataPlugin.Error
+	}
+	metadata := metadataPlugin.Data
+
+	return computeWebAppStack(a.MqlRuntime, config, metadata)
+}
+
+func (a *mqlAzureSubscriptionWebServiceAppslot) functions() ([]any, error) {
+	_, ctx, resourceID, client, site, slot, err := a.webAppsClient()
+	if err != nil {
+		return nil, err
+	}
+
+	pager := client.NewListInstanceFunctionsSlotPager(resourceID.ResourceGroup, site, slot, &web.WebAppsClientListInstanceFunctionsSlotOptions{})
+	res := []any{}
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, entry := range page.Value {
+			props, err := convert.JsonToDict(entry.Properties)
+			if err != nil {
+				return nil, err
+			}
+			mqlAzure, err := CreateResource(a.MqlRuntime, "azure.subscription.webService.function",
+				map[string]*llx.RawData{
+					"id":         llx.StringDataPtr(entry.ID),
+					"name":       llx.StringDataPtr(entry.Name),
+					"type":       llx.StringDataPtr(entry.Type),
+					"kind":       llx.StringDataPtr(entry.Kind),
+					"properties": llx.AnyData(props),
+				})
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlAzure)
+		}
+	}
+
+	return res, nil
+}
+
+func (a *mqlAzureSubscriptionWebServiceAppslot) ftp() (*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies, error) {
+	_, ctx, resourceID, client, site, slot, err := a.webAppsClient()
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.GetFtpAllowedSlot(ctx, resourceID.ResourceGroup, site, slot, &web.WebAppsClientGetFtpAllowedSlotOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	args := map[string]*llx.RawData{
+		"id":   llx.StringDataPtr(response.ID),
+		"name": llx.StringDataPtr(response.Name),
+		"type": llx.StringDataPtr(response.Type),
+	}
+	if response.Properties != nil {
+		args["allow"] = llx.BoolDataPtr(response.Properties.Allow)
+	}
+
+	mqlResource, err := CreateResource(a.MqlRuntime, "azure.subscription.webService.appsite.basicPublishingCredentialsPolicies", args)
+	if err != nil {
+		return nil, err
+	}
+
+	return mqlResource.(*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies), nil
+}
+
+func (a *mqlAzureSubscriptionWebServiceAppslot) scm() (*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies, error) {
+	_, ctx, resourceID, client, site, slot, err := a.webAppsClient()
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.GetScmAllowedSlot(ctx, resourceID.ResourceGroup, site, slot, &web.WebAppsClientGetScmAllowedSlotOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	args := map[string]*llx.RawData{
+		"id":   llx.StringDataPtr(response.ID),
+		"name": llx.StringDataPtr(response.Name),
+		"type": llx.StringDataPtr(response.Type),
+	}
+	if response.Properties != nil {
+		args["allow"] = llx.BoolDataPtr(response.Properties.Allow)
+	}
+
+	mqlResource, err := CreateResource(a.MqlRuntime, "azure.subscription.webService.appsite.basicPublishingCredentialsPolicies", args)
+	if err != nil {
+		return nil, err
+	}
+
+	return mqlResource.(*mqlAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies), nil
+}
+
 func (a *mqlAzureSubscriptionWebServiceFunction) id() (string, error) {
 	return a.id()
 }
@@ -581,127 +1065,15 @@ func (a *mqlAzureSubscriptionWebServiceAppsite) stack() (any, error) {
 	if configPlugin.Error != nil {
 		return nil, configPlugin.Error
 	}
-
 	config := configPlugin.Data
-	// read configuration into go struct
-	configProperties := config.Properties.Data
 
-	// unmarshal into go struct for easier access
-	data, err := json.Marshal(configProperties)
-	if err != nil {
-		return nil, err
-	}
-
-	var properties web.SiteConfig
-	err = json.Unmarshal(data, &properties)
-	if err != nil {
-		return nil, err
-	}
-	// get metadata
 	metadataPlugin := a.GetMetadata()
 	if metadataPlugin.Error != nil {
 		return nil, metadataPlugin.Error
 	}
 	metadata := metadataPlugin.Data
 
-	runtime := AzureWebAppStackRuntime{
-		Os: "windows",
-	}
-
-	if properties.LinuxFxVersion == nil && properties.WindowsFxVersion == nil {
-		return nil, errors.New("could not determine stack version")
-	}
-
-	if properties.LinuxFxVersion != nil && len(*properties.LinuxFxVersion) > 0 {
-		runtime.Os = "linux"
-		runtime.ID = *properties.LinuxFxVersion
-
-		fxversion := strings.Split(*properties.LinuxFxVersion, "|")
-		runtime.Name = strings.ToLower(fxversion[0])
-		runtime.MinorVersion = strings.ToLower(fxversion[1])
-	} else {
-		metadata, ok := metadata.(map[string]any)
-		if !ok {
-			return nil, nil // see behavior below
-		}
-
-		// read runtime from metadata, it works completely different than on linux
-		// NOTE: also take care of the runtime version for dotnet.
-		stack, ok := metadata["CURRENT_STACK"].(string)
-		if !ok {
-			// This doesn't seem to be consistently set
-			// https://stackoverflow.com/questions/63950946/azure-app-service-get-stack-settings-via-api#comment113188903_63987100
-			// https://github.com/mondoohq/installer/issues/157
-			return nil, nil
-		}
-		version := ""
-		switch stack {
-		case "dotnet":
-			stack = "aspnet" // needs to be overwritten (do not ask)
-			version = convert.ToValue(properties.NetFrameworkVersion)
-		case "dotnetcore":
-			// NOTE: this will always return v4.0 no matter what you set (which is definitely wrong for dotnetcore)
-			// The UI let you select different version, but in configure it does not show the version again
-			// therefore we have no way than to hardcode the value for now
-			version = "3.1"
-		case "php":
-			version = convert.ToValue(properties.PhpVersion)
-		case "python":
-			version = convert.ToValue(properties.PythonVersion)
-		case "node":
-			version = convert.ToValue(properties.NodeVersion)
-		case "powershell":
-			version = convert.ToValue(properties.PowerShellVersion)
-		case "java":
-			version = convert.ToValue(properties.JavaVersion)
-		case "javaContainer":
-			version = convert.ToValue(properties.JavaContainerVersion)
-		}
-
-		runtime.Name = strings.ToLower(stack)
-		runtime.ID = strings.ToUpper(stack) + "|" + version
-		runtime.MinorVersion = version
-	}
-
-	// fetch available runtimes and check if they are included
-	// if they are included, leverage their additional properties
-	// if they are not included they are either eol or custom
-	obj, err := CreateResource(a.MqlRuntime, "azure.subscription.webService", map[string]*llx.RawData{})
-	if err != nil {
-		return nil, err
-	}
-	azureWeb := obj.(*mqlAzureSubscriptionWebService)
-	runtimesPlugin := azureWeb.GetAvailableRuntimes()
-	if runtimesPlugin.Error != nil {
-		return nil, runtimesPlugin.Error
-	}
-
-	runtimes := runtimesPlugin.Data
-	var match map[string]any
-
-	for i := range runtimes {
-		rt := runtimes[i]
-		hashmap := rt.(map[string]any)
-		if (hashmap["name"] == runtime.Name && hashmap["minorVersion"] == runtime.MinorVersion) || hashmap["id"] == runtime.ID {
-			match = hashmap
-		}
-	}
-
-	if match != nil {
-		if match["isDefault"] != nil {
-			runtime.IsDefault = match["isDefault"].(bool)
-		}
-		if match["isDeprecated"] != nil {
-			runtime.IsDeprecated = match["isDeprecated"].(bool)
-		}
-	} else {
-		// NOTE: it is only deprecated if a version number is provided, otherwise it is going to auto-update
-		if len(runtime.MinorVersion) > 0 {
-			runtime.IsDeprecated = true
-		}
-	}
-
-	return convert.JsonToDict(runtime)
+	return computeWebAppStack(a.MqlRuntime, config, metadata)
 }
 
 func (a *mqlAzureSubscriptionWebServiceAppsite) applicationSettings() (any, error) {

--- a/providers/azure/resources/web.go
+++ b/providers/azure/resources/web.go
@@ -409,7 +409,7 @@ func (a *mqlAzureSubscriptionWebService) availableRuntimes() ([]any, error) {
 						isPlatformEol(convert.ToValue(entry.Name), convert.ToValue(major.Value))
 
 					id := strings.Join([]string{
-						"azure.subscription", subId,
+						ResourceAzureSubscription, subId,
 						"webService.appRuntimeStack", os, runtimeVersion,
 					}, "/")
 

--- a/providers/azure/resources/web.go
+++ b/providers/azure/resources/web.go
@@ -270,7 +270,7 @@ func (a *mqlAzureSubscriptionWebServiceAppsite) slots() ([]any, error) {
 			return nil, err
 		}
 		for _, entry := range page.Value {
-			slotResource, err := createWebAppResourceFromSite(a.MqlRuntime, "azure.subscription.webService.appslot", entry)
+			slotResource, err := createWebAppResourceFromSite(a.MqlRuntime, ResourceAzureSubscriptionWebServiceAppslot, entry)
 			if err != nil {
 				return nil, err
 			}
@@ -310,7 +310,7 @@ func (a *mqlAzureSubscriptionWebService) apps() ([]any, error) {
 				return nil, err
 			}
 
-			mqlAzure, err := CreateResource(a.MqlRuntime, "azure.subscription.webService.appsite",
+			mqlAzure, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionWebServiceAppsite,
 				map[string]*llx.RawData{
 					"id":         llx.StringDataPtr(entry.ID),
 					"name":       llx.StringDataPtr(entry.Name),
@@ -408,7 +408,8 @@ func (a *mqlAzureSubscriptionWebService) availableRuntimes() ([]any, error) {
 					deprecated := convert.ToValue(settings.IsDeprecated) ||
 						isPlatformEol(convert.ToValue(entry.Name), convert.ToValue(major.Value))
 
-					id := strings.Join([]string{"azure.subscription", subId,
+					id := strings.Join([]string{
+						"azure.subscription", subId,
 						"webService.appRuntimeStack", os, runtimeVersion,
 					}, "/")
 
@@ -417,7 +418,7 @@ func (a *mqlAzureSubscriptionWebService) availableRuntimes() ([]any, error) {
 					}
 					mapIDs[id] = struct{}{}
 
-					resource, err := NewResource(a.MqlRuntime, "azure.subscription.webService.appRuntimeStack",
+					resource, err := NewResource(a.MqlRuntime, ResourceAzureSubscriptionWebServiceAppRuntimeStack,
 						map[string]*llx.RawData{
 							"__id":           llx.StringData(id),
 							"name":           llx.StringData(stackName),

--- a/providers/azure/resources/web.go
+++ b/providers/azure/resources/web.go
@@ -168,7 +168,7 @@ func computeWebAppStack(runtime *plugin.Runtime, config *mqlAzureSubscriptionWeb
 		runtimeInfo.MinorVersion = version
 	}
 
-	obj, err := CreateResource(runtime, "azure.subscription.webService", map[string]*llx.RawData{})
+	obj, err := CreateResource(runtime, ResourceAzureSubscriptionWebService, map[string]*llx.RawData{})
 	if err != nil {
 		return nil, err
 	}
@@ -477,7 +477,7 @@ func (a *mqlAzureSubscriptionWebServiceAppsite) configuration() (*mqlAzureSubscr
 		return nil, err
 	}
 
-	res, err := CreateResource(a.MqlRuntime, "azure.subscription.webService.appsiteconfig",
+	res, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionWebServiceAppsiteconfig,
 		map[string]*llx.RawData{
 			"id":         llx.StringDataPtr(entry.ID),
 			"name":       llx.StringDataPtr(entry.Name),
@@ -524,7 +524,7 @@ func (a *mqlAzureSubscriptionWebServiceAppsite) authenticationSettings() (*mqlAz
 		return nil, err
 	}
 
-	res, err := CreateResource(a.MqlRuntime, "azure.subscription.webService.appsiteauthsettings",
+	res, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionWebServiceAppsiteauthsettings,
 		map[string]*llx.RawData{
 			"id":         llx.StringDataPtr(configuration.ID),
 			"name":       llx.StringDataPtr(configuration.Name),
@@ -610,7 +610,7 @@ func (a *mqlAzureSubscriptionWebServiceAppsite) ftp() (*mqlAzureSubscriptionWebS
 	if response.Properties != nil {
 		args["allow"] = llx.BoolDataPtr(response.Properties.Allow)
 	}
-	mqlResource, err := CreateResource(a.MqlRuntime, "azure.subscription.webService.appsite.basicPublishingCredentialsPolicies", args)
+	mqlResource, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies, args)
 	if err != nil {
 		return nil, err
 	}
@@ -655,7 +655,7 @@ func (a *mqlAzureSubscriptionWebServiceAppsite) scm() (*mqlAzureSubscriptionWebS
 	if response.Properties != nil {
 		args["allow"] = llx.BoolDataPtr(response.Properties.Allow)
 	}
-	mqlResource, err := CreateResource(a.MqlRuntime, "azure.subscription.webService.appsite.basicPublishingCredentialsPolicies", args)
+	mqlResource, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies, args)
 	if err != nil {
 		return nil, err
 	}
@@ -696,7 +696,7 @@ func (a *mqlAzureSubscriptionWebServiceAppsite) functions() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
-			mqlAzure, err := CreateResource(a.MqlRuntime, "azure.subscription.webService.function",
+			mqlAzure, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionWebServiceFunction,
 				map[string]*llx.RawData{
 					"id":         llx.StringDataPtr(entry.ID),
 					"name":       llx.StringDataPtr(entry.Name),
@@ -762,7 +762,7 @@ func (a *mqlAzureSubscriptionWebServiceAppslot) parent() (*mqlAzureSubscriptionW
 		return nil, err
 	}
 
-	parentResource, err := createWebAppResourceFromSite(a.MqlRuntime, "azure.subscription.webService.appsite", &response.Site)
+	parentResource, err := createWebAppResourceFromSite(a.MqlRuntime, ResourceAzureSubscriptionWebServiceAppsite, &response.Site)
 	if err != nil {
 		return nil, err
 	}
@@ -790,7 +790,7 @@ func (a *mqlAzureSubscriptionWebServiceAppslot) configuration() (*mqlAzureSubscr
 		properties = props
 	}
 
-	res, err := CreateResource(a.MqlRuntime, "azure.subscription.webService.appsiteconfig",
+	res, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionWebServiceAppsiteconfig,
 		map[string]*llx.RawData{
 			"id":         llx.StringDataPtr(configuration.ID),
 			"name":       llx.StringDataPtr(configuration.Name),
@@ -825,7 +825,7 @@ func (a *mqlAzureSubscriptionWebServiceAppslot) authenticationSettings() (*mqlAz
 		properties = props
 	}
 
-	res, err := CreateResource(a.MqlRuntime, "azure.subscription.webService.appsiteauthsettings",
+	res, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionWebServiceAppsiteauthsettings,
 		map[string]*llx.RawData{
 			"id":         llx.StringDataPtr(configuration.ID),
 			"name":       llx.StringDataPtr(configuration.Name),
@@ -940,7 +940,7 @@ func (a *mqlAzureSubscriptionWebServiceAppslot) functions() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
-			mqlAzure, err := CreateResource(a.MqlRuntime, "azure.subscription.webService.function",
+			mqlAzure, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionWebServiceFunction,
 				map[string]*llx.RawData{
 					"id":         llx.StringDataPtr(entry.ID),
 					"name":       llx.StringDataPtr(entry.Name),
@@ -978,7 +978,7 @@ func (a *mqlAzureSubscriptionWebServiceAppslot) ftp() (*mqlAzureSubscriptionWebS
 		args["allow"] = llx.BoolDataPtr(response.Properties.Allow)
 	}
 
-	mqlResource, err := CreateResource(a.MqlRuntime, "azure.subscription.webService.appsite.basicPublishingCredentialsPolicies", args)
+	mqlResource, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies, args)
 	if err != nil {
 		return nil, err
 	}
@@ -1006,7 +1006,7 @@ func (a *mqlAzureSubscriptionWebServiceAppslot) scm() (*mqlAzureSubscriptionWebS
 		args["allow"] = llx.BoolDataPtr(response.Properties.Allow)
 	}
 
-	mqlResource, err := CreateResource(a.MqlRuntime, "azure.subscription.webService.appsite.basicPublishingCredentialsPolicies", args)
+	mqlResource, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionWebServiceAppsiteBasicPublishingCredentialsPolicies, args)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
```
cnspec> azure.subscription.web.apps[1].slots[0].configuration.properties
azure.subscription.web.apps[1].slots[0].configuration.properties: {
  acrUseManagedIdentityCreds: false
  alwaysOn: true
  appCommandLine: ""
  autoHealEnabled: false
  azureStorageAccounts: {}
  cors: {
    allowedOrigins: [
      0: "xxx"
    ]
    supportCredentials: false
  }
  ```
  
  ```
  cnspec> azure.subscription.web.apps[1].slots[0].properties
azure.subscription.web.apps[1].slots[0].properties: {
  availabilityState: "Normal"
  clientAffinityEnabled: false
  clientCertEnabled: false
  clientCertMode: "Required"
  containerSize: 1536.000000
  customDomainVerificationId: "xxx"
  dailyMemoryTimeQuota: 0.000000
  defaultHostName: "xxx"
  enabled: true
  enabledHostNames: [
    0: "xxx"
    1: "xxx"
  ]
  ```