### PR TITLE
🧹 Mark docker.image.virtualsize deprecated

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -969,7 +969,7 @@ docker.image {
   id string
   // Image size in kilobytes
   size int
-  // Virtual image size in kilobytes
+  // Virtual image size in kilobytes. Deprecated; use size instead
   virtualsize int
   // Tag key value pairs
   tags []string


### PR DESCRIPTION
This is deprecated in the SDK and is replaced with size which we already use