### PR TITLE
:star: Detect MX Linux as platform "mx" and family "debian"

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -612,6 +612,28 @@ var mageia = &PlatformResolver{
 	},
 }
 
+var mxlinux = &PlatformResolver{
+	Name:     "mxlinux",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		osrd := NewOSReleaseDetector(conn)
+		lsb, err := osrd.lsbconfig()
+		// we're not on mx if we can't read lsb
+		if err != nil {
+			return false, nil
+		}
+
+		if len(lsb["DISTRIB_ID"]) > 0 && strings.ToLower(lsb["DISTRIB_ID"]) == "mx" {
+			pf.Name = "mx"
+			pf.Version = lsb["DISTRIB_RELEASE"]
+			pf.Title = lsb["DISTRIB_DESCRIPTION"]
+			return true, nil
+		}
+
+		return false, nil
+	},
+}
+
 var openwrt = &PlatformResolver{
 	Name:     "openwrt",
 	IsFamily: false,
@@ -917,7 +939,7 @@ var redhatFamily = &PlatformResolver{
 var debianFamily = &PlatformResolver{
 	Name:     "debian",
 	IsFamily: true,
-	Children: []*PlatformResolver{debian, ubuntu, raspbian, kali, linuxmint, popos, elementary},
+	Children: []*PlatformResolver{mxlinux, debian, ubuntu, raspbian, kali, linuxmint, popos, elementary},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		return true, nil
 	},

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -921,3 +921,14 @@ func TestMageiaDetector(t *testing.T) {
 	assert.Equal(t, "aarch64", di.Arch, "os arch should be identified")
 	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
 }
+
+func TestMXLinuxDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-mx.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "mx", di.Name, "os name should be identified")
+	assert.Equal(t, "MX 23.2 Libretto", di.Title, "os title should be identified")
+	assert.Equal(t, "23.2", di.Version, "os version should be identified")
+	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"debian", "linux", "unix", "os"}, di.Family)
+}

--- a/providers/os/detector/testdata/detect-mx.toml
+++ b/providers/os/detector/testdata/detect-mx.toml
@@ -1,0 +1,30 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "6.1.0-18-amd64"
+
+[files."/etc/os-release"]
+content = """
+PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
+NAME="Debian GNU/Linux"
+VERSION_ID="12"
+VERSION="12 (bookworm)"
+VERSION_CODENAME=bookworm
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"
+"""
+
+[files."/etc/lsb-release"]
+content = """
+PRETTY_NAME="MX 23.2 Libretto"
+DISTRIB_ID=MX
+DISTRIB_RELEASE=23.2
+DISTRIB_CODENAME="Libretto"
+DISTRIB_DESCRIPTION="MX 23.2 Libretto"
+"""


### PR DESCRIPTION
/etc/os-release says debian, but /etc/lsb-release says mx.