### PR TITLE
Switch the query packs to use the network.interfaces resource

### DIFF
--- a/content/mondoo-linux-inventory.mql.yaml
+++ b/content/mondoo-linux-inventory.mql.yaml
@@ -96,9 +96,7 @@ packs:
         mql: services.where(running == true) { name running enabled masked type }
       - uid: mondoo-linux-interface-configuration
         title: Network interface configuration
-        filters: mondoo.capabilities.contains("run-command")
-        mql: |
-          parse.json(content: command('ip -j a').stdout).params
+        mql: network.interfaces{*}
       - uid: mondoo-sshd-interface-configuration
         title: sshd configuration
         filters: package('openssh-server').installed || package('openssh').installed

--- a/content/mondoo-macos-inventory.mql.yaml
+++ b/content/mondoo-macos-inventory.mql.yaml
@@ -102,8 +102,7 @@ packs:
         mql: ports.where(state != "close") { user state port address protocol process remoteAddress remotePort }
       - uid: mondoo-macos-interface-configuration
         title: Network interface configuration
-        filters: mondoo.capabilities.contains("run-command")
-        mql: command("ifconfig").stdout
+        mql: network.interfaces{*}
       - uid: mondoo-macos-sshd-interface-configuration
         title: sshd configuration
         mql: sshd.config.params

--- a/content/mondoo-windows-inventory.mql.yaml
+++ b/content/mondoo-windows-inventory.mql.yaml
@@ -77,7 +77,7 @@ packs:
         mql: ports.where(state != "close") { user state port address protocol process remoteAddress remotePort }
       - uid: mondoo-windows-interface-configuration
         title: Network interfaces
-        mql: windows.computerInfo['CsNetworkAdapters']
+        mql: network.interfaces{*}
       - uid: mondoo-windows-computer-info
         title: Windows Computer/ System information
         mql: windows.computerInfo


### PR DESCRIPTION
This provides roughly the same data, but also works without shelling out on *nix