### PR TITLE
:star: Add more fields to gitlab project and group resources

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -6,6 +6,7 @@ atlassian
 auditlog
 Auths
 autoaccept
+autoclose
 autoprovisioned
 backupconfiguration
 backupsetting
@@ -59,6 +60,7 @@ jira
 jsonbody
 kqueue
 labelmatchstatement
+lfs
 liveanalytics
 loggingservice
 manageddevice

--- a/providers/gitlab/resources/gitlab.go
+++ b/providers/gitlab/resources/gitlab.go
@@ -41,7 +41,8 @@ func initGitlabGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 	args["requireTwoFactorAuthentication"] = llx.BoolData(grp.RequireTwoFactorAuth)
 	args["preventForkingOutsideGroup"] = llx.BoolData(grp.PreventForkingOutsideGroup)
 	args["mentionsDisabled"] = llx.BoolData(grp.MentionsDisabled)
-	args["emailsDisabled"] = llx.BoolData(grp.EmailsDisabled)
+	args["emailsDisabled"] = llx.BoolData(!grp.EmailsEnabled)
+	args["allowedEmailDomainsList"] = llx.StringData(grp.AllowedEmailDomainsList)
 
 	return args, nil, nil
 }
@@ -77,34 +78,37 @@ func (g *mqlGitlabGroup) projects() ([]any, error) {
 
 func getGitlabProjectArgs(prj *gitlab.Project) map[string]*llx.RawData {
 	return map[string]*llx.RawData{
-		"id":                          llx.IntData(int64(prj.ID)),
-		"name":                        llx.StringData(prj.Name),
-		"fullName":                    llx.StringData(prj.NameWithNamespace),
 		"allowMergeOnSkippedPipeline": llx.BoolData(prj.AllowMergeOnSkippedPipeline),
 		"archived":                    llx.BoolData(prj.Archived),
+		"autocloseReferencedIssues":   llx.BoolData(prj.AutocloseReferencedIssues),
 		"autoDevopsEnabled":           llx.BoolData(prj.AutoDevopsEnabled),
 		"containerRegistryEnabled":    llx.BoolData(prj.ContainerRegistryEnabled),
 		"createdAt":                   llx.TimeDataPtr(prj.CreatedAt),
 		"defaultBranch":               llx.StringData(prj.DefaultBranch),
 		"description":                 llx.StringData(prj.Description),
 		"emailsDisabled":              llx.BoolData(!prj.EmailsEnabled),
+		"emptyRepo":                   llx.BoolData(prj.EmptyRepo),
+		"fullName":                    llx.StringData(prj.NameWithNamespace),
+		"groupRunnersEnabled":         llx.BoolData(prj.GroupRunnersEnabled),
+		"id":                          llx.IntData(int64(prj.ID)),
 		"issuesEnabled":               llx.BoolData(prj.IssuesEnabled),
+		"jobsEnabled":                 llx.BoolData(prj.JobsEnabled),
+		"lfsEnabled":                  llx.BoolData(prj.LFSEnabled),
 		"mergeRequestsEnabled":        llx.BoolData(prj.MergeRequestsEnabled),
 		"mirror":                      llx.BoolData(prj.Mirror),
+		"name":                        llx.StringData(prj.Name),
 		"onlyAllowMergeIfAllDiscussionsAreResolved": llx.BoolData(prj.OnlyAllowMergeIfAllDiscussionsAreResolved),
 		"onlyAllowMergeIfPipelineSucceeds":          llx.BoolData(prj.OnlyAllowMergeIfPipelineSucceeds),
 		"packagesEnabled":                           llx.BoolData(prj.PackagesEnabled),
 		"path":                                      llx.StringData(prj.Path),
+		"removeSourceBranchAfterMerge":              llx.BoolData(prj.RemoveSourceBranchAfterMerge),
 		"requirementsEnabled":                       llx.BoolData(prj.RequirementsEnabled),
 		"serviceDeskEnabled":                        llx.BoolData(prj.ServiceDeskEnabled),
+		"sharedRunnersEnabled":                      llx.BoolData(prj.SharedRunnersEnabled),
 		"snippetsEnabled":                           llx.BoolData(prj.SnippetsEnabled),
 		"visibility":                                llx.StringData(string(prj.Visibility)),
 		"webURL":                                    llx.StringData(prj.WebURL),
 		"wikiEnabled":                               llx.BoolData(prj.WikiEnabled),
-		"jobsEnabled":                               llx.BoolData(prj.JobsEnabled),
-		"emptyRepo":                                 llx.BoolData(prj.EmptyRepo),
-		"sharedRunnersEnabled":                      llx.BoolData(prj.SharedRunnersEnabled),
-		"groupRunnersEnabled":                       llx.BoolData(prj.GroupRunnersEnabled),
 	}
 }
 

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -30,6 +30,8 @@ gitlab.group @defaults("name visibility webURL") {
   mentionsDisabled bool
   // List of all projects that belong to the group
   projects() []gitlab.project
+  // List of allowed email domains for the group
+  allowedEmailDomainsList string
 }
 
 // GitLab project
@@ -104,6 +106,12 @@ gitlab.project @defaults("fullName visibility webURL") {
   sharedRunnersEnabled bool
   // Whether the project is enabled for group runners
   groupRunnersEnabled bool
+  // Whether the merge request source brand is removed after merge
+  removeSourceBranchAfterMerge bool
+  // Whether the project has LFS enabled
+  lfsEnabled bool
+  // Whether the project has autoclose referenced issues enabled
+  autocloseReferencedIssues bool
 }
 
 // GitLab project approval rule

--- a/providers/gitlab/resources/gitlab.lr.go
+++ b/providers/gitlab/resources/gitlab.lr.go
@@ -179,6 +179,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gitlab.group.projects": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabGroup).GetProjects()).ToDataRes(types.Array(types.Resource("gitlab.project")))
 	},
+	"gitlab.group.allowedEmailDomainsList": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabGroup).GetAllowedEmailDomainsList()).ToDataRes(types.String)
+	},
 	"gitlab.project.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetId()).ToDataRes(types.Int)
 	},
@@ -283,6 +286,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gitlab.project.groupRunnersEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProject).GetGroupRunnersEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.removeSourceBranchAfterMerge": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetRemoveSourceBranchAfterMerge()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.lfsEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetLfsEnabled()).ToDataRes(types.Bool)
+	},
+	"gitlab.project.autocloseReferencedIssues": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGitlabProject).GetAutocloseReferencedIssues()).ToDataRes(types.Bool)
 	},
 	"gitlab.project.approvalRule.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGitlabProjectApprovalRule).GetId()).ToDataRes(types.Int)
@@ -421,6 +433,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gitlab.group.projects": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabGroup).Projects, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gitlab.group.allowedEmailDomainsList": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabGroup).AllowedEmailDomainsList, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gitlab.project.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -565,6 +581,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gitlab.project.groupRunnersEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGitlabProject).GroupRunnersEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.removeSourceBranchAfterMerge": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).RemoveSourceBranchAfterMerge, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.lfsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).LfsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gitlab.project.autocloseReferencedIssues": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGitlabProject).AutocloseReferencedIssues, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gitlab.project.approvalRule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -732,6 +760,7 @@ type mqlGitlabGroup struct {
 	EmailsDisabled                 plugin.TValue[bool]
 	MentionsDisabled               plugin.TValue[bool]
 	Projects                       plugin.TValue[[]any]
+	AllowedEmailDomainsList        plugin.TValue[string]
 }
 
 // createGitlabGroup creates a new instance of this resource
@@ -831,6 +860,10 @@ func (c *mqlGitlabGroup) GetProjects() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlGitlabGroup) GetAllowedEmailDomainsList() *plugin.TValue[string] {
+	return &c.AllowedEmailDomainsList
+}
+
 // mqlGitlabProject for the gitlab.project resource
 type mqlGitlabProject struct {
 	MqlRuntime *plugin.Runtime
@@ -871,6 +904,9 @@ type mqlGitlabProject struct {
 	EmptyRepo                                 plugin.TValue[bool]
 	SharedRunnersEnabled                      plugin.TValue[bool]
 	GroupRunnersEnabled                       plugin.TValue[bool]
+	RemoveSourceBranchAfterMerge              plugin.TValue[bool]
+	LfsEnabled                                plugin.TValue[bool]
+	AutocloseReferencedIssues                 plugin.TValue[bool]
 }
 
 // createGitlabProject creates a new instance of this resource
@@ -1122,6 +1158,18 @@ func (c *mqlGitlabProject) GetSharedRunnersEnabled() *plugin.TValue[bool] {
 
 func (c *mqlGitlabProject) GetGroupRunnersEnabled() *plugin.TValue[bool] {
 	return &c.GroupRunnersEnabled
+}
+
+func (c *mqlGitlabProject) GetRemoveSourceBranchAfterMerge() *plugin.TValue[bool] {
+	return &c.RemoveSourceBranchAfterMerge
+}
+
+func (c *mqlGitlabProject) GetLfsEnabled() *plugin.TValue[bool] {
+	return &c.LfsEnabled
+}
+
+func (c *mqlGitlabProject) GetAutocloseReferencedIssues() *plugin.TValue[bool] {
+	return &c.AutocloseReferencedIssues
 }
 
 // mqlGitlabProjectApprovalRule for the gitlab.project.approvalRule resource

--- a/providers/gitlab/resources/gitlab.lr.manifest.yaml
+++ b/providers/gitlab/resources/gitlab.lr.manifest.yaml
@@ -4,6 +4,8 @@
 resources:
   gitlab.group:
     fields:
+      allowedEmailDomainsList:
+        min_mondoo_version: 9.0.0
       createdAt:
         min_mondoo_version: 9.0.0
       description: {}
@@ -34,6 +36,8 @@ resources:
         min_mondoo_version: 9.0.0
       autoDevopsEnabled:
         min_mondoo_version: 9.0.0
+      autocloseReferencedIssues:
+        min_mondoo_version: 9.0.0
       containerRegistryEnabled:
         min_mondoo_version: 9.0.0
       createdAt:
@@ -54,6 +58,8 @@ resources:
         min_mondoo_version: 9.0.0
       jobsEnabled:
         min_mondoo_version: 9.0.0
+      lfsEnabled:
+        min_mondoo_version: 9.0.0
       mergeMethod:
         min_mondoo_version: 9.0.0
       mergeRequestsEnabled:
@@ -73,6 +79,8 @@ resources:
       projectMembers:
         min_mondoo_version: 9.0.0
       protectedBranches:
+        min_mondoo_version: 9.0.0
+      removeSourceBranchAfterMerge:
         min_mondoo_version: 9.0.0
       requirementsEnabled:
         min_mondoo_version: 9.0.0


### PR DESCRIPTION
Use some of the fancy new things available in the latest SDK

Group:

```coffee
gitlab.group: {
  name: "GitLab.org"
  webURL: "https://gitlab.com/groups/gitlab-org"
  createdAt: 2013-09-25 23:02:04 -0700 PDT
  path: "gitlab-org"
  mentionsDisabled: true
  description: "Open source software to collaborate on code"
  id: 9970
  requireTwoFactorAuthentication: true
  allowedEmailDomainsList: ""
  projects: [
    0: gitlab.project fullName="GitLab.org / moa" visibility="public" webURL="https://gitlab.com/gitlab-org/moa"
    1: gitlab.project fullName="GitLab.org / Duo UI Next" visibility="public" webURL="https://gitlab.com/gitlab-org/duo-ui-next"
    2: gitlab.project fullName="GitLab.org / Group Level Templates" visibility="public" webURL="https://gitlab.com/gitlab-org/group-level-templates"
    3: gitlab.project fullName="GitLab.org / GLQL" visibility="public" webURL="https://gitlab.com/gitlab-org/glql"
    4: gitlab.project fullName="GitLab.org / Duo UI" visibility="public" webURL="https://gitlab.com/gitlab-org/duo-ui"
    5: gitlab.project fullName="GitLab.org / gitlab-org - Security Policy project" visibility="public" webURL="https://gitlab.com/gitlab-org/gitlab-org-security-policy-project"
    6: gitlab.project fullName="GitLab.org / Step Runner" visibility="public" webURL="https://gitlab.com/gitlab-org/step-runner"
    7: gitlab.project fullName="GitLab.org / Value Stream Dashboard reports generator" visibility="public" webURL="https://gitlab.com/gitlab-org/vsd-reports-generator"
    8: gitlab.project fullName="GitLab.org / git-test" visibility="public" webURL="https://gitlab.com/gitlab-org/git-test"
    9: gitlab.project fullName="GitLab.org / Gitlab Zoekt" visibility="public" webURL="https://gitlab.com/gitlab-org/gitlab-zoekt-indexer"
    10: gitlab.project fullName="GitLab.org / Data Quality" visibility="public" webURL="https://gitlab.com/gitlab-org/data-quality"
    11: gitlab.project fullName="GitLab.org / public-image-archive" visibility="public" webURL="https://gitlab.com/gitlab-org/public-image-archive"
    12: gitlab.project fullName="GitLab.org / GitLab Terraform Provider" visibility="public" webURL="https://gitlab.com/gitlab-org/terraform-provider-gitlab"
    13: gitlab.project fullName="GitLab.org / GitLab Docs Archives" visibility="public" webURL="https://gitlab.com/gitlab-org/gitlab-docs-archives"
    14: gitlab.project fullName="GitLab.org / gitlab-web-ide-vscode-fork" visibility="public" webURL="https://gitlab.com/gitlab-org/gitlab-web-ide-vscode-fork"
    15: gitlab.project fullName="GitLab.org / wg-next-prioritization-adoption" visibility="public" webURL="https://gitlab.com/gitlab-org/wg-next-prioritization-adoption"
    16: gitlab.project fullName="GitLab.org / enhancements" visibility="public" webURL="https://gitlab.com/gitlab-org/enhancements"
    17: gitlab.project fullName="GitLab.org / OS License Checker" visibility="public" webURL="https://gitlab.com/gitlab-org/os-license-checker"
    18: gitlab.project fullName="GitLab.org / Release Sample Projects" visibility="public" webURL="https://gitlab.com/gitlab-org/release-sample-projects"
    19: gitlab.project fullName="GitLab.org / gitlab-web-ide" visibility="public" webURL="https://gitlab.com/gitlab-org/gitlab-web-ide"
    20: gitlab.project fullName="GitLab.org / labkit-python" visibility="public" webURL="https://gitlab.com/gitlab-org/labkit-python"
    21: gitlab.project fullName="GitLab.org / GitLab Metrics Exporter" visibility="public" webURL="https://gitlab.com/gitlab-org/gitlab-metrics-exporter"
    22: gitlab.project fullName="GitLab.org / cli" visibility="public" webURL="https://gitlab.com/gitlab-org/cli"
    23: gitlab.project fullName="GitLab.org / golang-crypto" visibility="public" webURL="https://gitlab.com/gitlab-org/golang-crypto"
    24: gitlab.project fullName="GitLab.org / config-audit-tool" visibility="public" webURL="https://gitlab.com/gitlab-org/config-audit-tool"
    25: gitlab.project fullName="GitLab.org / App Modernization 2021" visibility="public" webURL="https://gitlab.com/gitlab-org/app-modernization-2021"
    26: gitlab.project fullName="GitLab.org / App Modernization" visibility="public" webURL="https://gitlab.com/gitlab-org/app-modernization"
    27: gitlab.project fullName="GitLab.org / golang-archive-zip" visibility="public" webURL="https://gitlab.com/gitlab-org/golang-archive-zip"
    28: gitlab.project fullName="GitLab.org / rb-ipynbdiff" visibility="public" webURL="https://gitlab.com/gitlab-org/rb-ipynbdiff"
    29: gitlab.project fullName="GitLab.org / docker-build-test" visibility="public" webURL="https://gitlab.com/gitlab-org/docker-build-test"
    30: gitlab.project fullName="GitLab.org / jh-upstream-report" visibility="public" webURL="https://gitlab.com/gitlab-org/jh-upstream-report"
    31: gitlab.project fullName="GitLab.org / gitlab-rdoc" visibility="public" webURL="https://gitlab.com/gitlab-org/gitlab-rdoc"
    32: gitlab.project fullName="GitLab.org / Mnohr Permissions Test" visibility="public" webURL="https://gitlab.com/gitlab-org/mnohr-permissions-test"
    33: gitlab.project fullName="GitLab.org / developer.gitlab.com" visibility="public" webURL="https://gitlab.com/gitlab-org/developer.gitlab.com"
    34: gitlab.project fullName="GitLab.org / test-cveid-btn" visibility="public" webURL="https://gitlab.com/gitlab-org/test-cveid-btn"
    35: gitlab.project fullName="GitLab.org / agg-test1" visibility="public" webURL="https://gitlab.com/gitlab-org/agg-test1"
    36: gitlab.project fullName="GitLab.org / samtest" visibility="public" webURL="https://gitlab.com/gitlab-org/samtest"
    37: gitlab.project fullName="GitLab.org / GitLab Advisory Database Open Source Edition" visibility="public" webURL="https://gitlab.com/gitlab-org/advisories-community"
    38: gitlab.project fullName="GitLab.org / file-mirror" visibility="public" webURL="https://gitlab.com/gitlab-org/file-mirror"
    39: gitlab.project fullName="GitLab.org / file" visibility="public" webURL="https://gitlab.com/gitlab-org/file"
    40: gitlab.project fullName="GitLab.org / ruby-magic" visibility="public" webURL="https://gitlab.com/gitlab-org/ruby-magic"
    41: gitlab.project fullName="GitLab.org / mail-smtp_pool" visibility="public" webURL="https://gitlab.com/gitlab-org/mail-smtp_pool"
    42: gitlab.project fullName="GitLab.org / Jschafer Test Blank Proj" visibility="public" webURL="https://gitlab.com/gitlab-org/jschafer-test-blank-proj"
    43: gitlab.project fullName="GitLab.org / GitLab fork of fog-google" visibility="public" webURL="https://gitlab.com/gitlab-org/gitlab-fog-google"
    44: gitlab.project fullName="GitLab.org / Gitlab Pry Byebug" visibility="public" webURL="https://gitlab.com/gitlab-org/gitlab-pry-byebug"
    45: gitlab.project fullName="GitLab.org / GitLab Codesandbox Client" visibility="public" webURL="https://gitlab.com/gitlab-org/gitlab-codesandbox-client"
    46: gitlab.project fullName="GitLab.org / Gitlab feature flag alert" visibility="public" webURL="https://gitlab.com/gitlab-org/gitlab-feature-flag-alert"
    47: gitlab.project fullName="GitLab.org / GitLab Docs Shell" visibility="public" webURL="https://gitlab.com/gitlab-org/docs-shell"
    48: gitlab.project fullName="GitLab.org / Reference Architectures" visibility="public" webURL="https://gitlab.com/gitlab-org/reference-architectures"
    49: gitlab.project fullName="GitLab.org / pg_query" visibility="public" webURL="https://gitlab.com/gitlab-org/pg_query"
    50: gitlab.project fullName="GitLab.org / libpg_query" visibility="public" webURL="https://gitlab.com/gitlab-org/libpg_query"
    51: gitlab.project fullName="GitLab.org / Waypoint Images" visibility="public" webURL="https://gitlab.com/gitlab-org/waypoint-images"
    52: gitlab.project fullName="GitLab.org / Snowplow Micro Configuration" visibility="public" webURL="https://gitlab.com/gitlab-org/snowplow-micro-configuration"
    53: gitlab.project fullName="GitLab.org / Snowplow Micro" visibility="public" webURL="https://gitlab.com/gitlab-org/snowplow-micro"
    54: gitlab.project fullName="GitLab.org / partial-clone-demo" visibility="public" webURL="https://gitlab.com/gitlab-org/partial-clone-demo"
    55: gitlab.project fullName="GitLab.org / Terraform AWS RDS Aurora" visibility="public" webURL="https://gitlab.com/gitlab-org/gitlab-terraform-aws-rds-aurora"
    56: gitlab.project fullName="GitLab.org / Go MimeDB" visibility="public" webURL="https://gitlab.com/gitlab-org/go-mimedb"
    57: gitlab.project fullName="GitLab.org / licensee" visibility="public" webURL="https://gitlab.com/gitlab-org/licensee"
    58: gitlab.project fullName="GitLab.org / ci-cd-testing-ux" visibility="public" webURL="https://gitlab.com/gitlab-org/ci-cd-testing-ux"
    59: gitlab.project fullName="GitLab.org / Security Rewards Program Leaderboard" visibility="public" webURL="https://gitlab.com/gitlab-org/security-rewards"
    60: gitlab.project fullName="GitLab.org / gitlab-snippet-test" visibility="public" webURL="https://gitlab.com/gitlab-org/gitlab-snippet-test"
    61: gitlab.project fullName="GitLab.org / rspec_profiling_stats" visibility="public" webURL="https://gitlab.com/gitlab-org/rspec_profiling_stats"
    62: gitlab.project fullName="GitLab.org / pubsubbeat" visibility="public" webURL="https://gitlab.com/gitlab-org/pubsubbeat"
    63: gitlab.project fullName="GitLab.org / Terraform Images" visibility="public" webURL="https://gitlab.com/gitlab-org/terraform-images"
    64: gitlab.project fullName="GitLab.org / gitlab-sketch-plugin" visibility="public" webURL="https://gitlab.com/gitlab-org/gitlab-sketch-plugin"
    65: gitlab.project fullName="GitLab.org / gitlab-figma-plugin" visibility="public" webURL="https://gitlab.com/gitlab-org/gitlab-figma-plugin"
    66: gitlab.project fullName="GitLab.org / GitLab CVE assignments" visibility="public" webURL="https://gitlab.com/gitlab-org/cves"
    67: gitlab.project fullName="GitLab.org / Auto Devops v12.10" visibility="public" webURL="https://gitlab.com/gitlab-org/auto-devops-v12-10"
    68: gitlab.project fullName="GitLab.org / test_codeowners" visibility="public" webURL="https://gitlab.com/gitlab-org/test_codeowners"
    69: gitlab.project fullName="GitLab.org / Sitespeed Journeys" visibility="public" webURL="https://gitlab.com/gitlab-org/sitespeed-journeys"
    70: gitlab.project fullName="GitLab.org / version-app-codeclimate-rubocop" visibility="public" webURL="https://gitlab.com/gitlab-org/version-app-codeclimate-rubocop"
    71: gitlab.project fullName="GitLab.org / version-app-codeclimate" visibility="public" webURL="https://gitlab.com/gitlab-org/version-app-codeclimate"
    72: gitlab.project fullName="GitLab.org / CI-CD UX Team" visibility="public" webURL="https://gitlab.com/gitlab-org/ci-cd-ux"
    73: gitlab.project fullName="GitLab.org / Snowplow Go Collector" visibility="public" webURL="https://gitlab.com/gitlab-org/snowplow-go-collector"
    74: gitlab.project fullName="GitLab.org / jfr-container-builder" visibility="public" webURL="https://gitlab.com/gitlab-org/jfr-container-builder"
    75: gitlab.project fullName="GitLab.org / expand-unchanged-file" visibility="public" webURL="https://gitlab.com/gitlab-org/expand-unchanged-file"
    76: gitlab.project fullName="GitLab.org / libgit2" visibility="public" webURL="https://gitlab.com/gitlab-org/libgit2"
    77: gitlab.project fullName="GitLab.org / Jira Issue Generator" visibility="public" webURL="https://gitlab.com/gitlab-org/jira-issue-generator"
    78: gitlab.project fullName="GitLab.org / GitLab Derailed Benchmarks" visibility="public" webURL="https://gitlab.com/gitlab-org/gitlab-derailed_benchmarks"
    79: gitlab.project fullName="GitLab.org / GitLab Status Page" visibility="public" webURL="https://gitlab.com/gitlab-org/status-page"
    80: gitlab.project fullName="GitLab.org / cloudflare_exporter" visibility="public" webURL="https://gitlab.com/gitlab-org/cloudflare_exporter"
    81: gitlab.project fullName="GitLab.org / release-cli" visibility="public" webURL="https://gitlab.com/gitlab-org/release-cli"
    82: gitlab.project fullName="GitLab.org / version-app-buildpack" visibility="public" webURL="https://gitlab.com/gitlab-org/version-app-buildpack"
    83: gitlab.project fullName="GitLab.org / GitLab Puma" visibility="public" webURL="https://gitlab.com/gitlab-org/gitlab-puma"
    84: gitlab.project fullName="GitLab.org / releasepost" visibility="public" webURL="https://gitlab.com/gitlab-org/releasepost"
    85: gitlab.project fullName="GitLab.org / Dev Test Project" visibility="public" webURL="https://gitlab.com/gitlab-org/dev-test-project"
    86: gitlab.project fullName="GitLab.org / cloud-deploy" visibility="public" webURL="https://gitlab.com/gitlab-org/cloud-deploy"
    87: gitlab.project fullName="GitLab.org / GraphQL Sandbox" visibility="public" webURL="https://gitlab.com/gitlab-org/graphql-sandbox"
    88: gitlab.project fullName="GitLab.org / dylangriffith-security-test" visibility="public" webURL="https://gitlab.com/gitlab-org/dylangriffith-security-test"
    89: gitlab.project fullName="GitLab.org / GitLab-Git" visibility="public" webURL="https://gitlab.com/gitlab-org/gitlab-git"
    90: gitlab.project fullName="GitLab.org / iglu" visibility="public" webURL="https://gitlab.com/gitlab-org/iglu"
    91: gitlab.project fullName="GitLab.org / test-transfer-project" visibility="public" webURL="https://gitlab.com/gitlab-org/test-transfer-project"
    92: gitlab.project fullName="GitLab.org / gitlab-orchestrator" visibility="public" webURL="https://gitlab.com/gitlab-org/gitlab-orchestrator"
    93: gitlab.project fullName="GitLab.org / GitLab Environment Toolkit" visibility="public" webURL="https://gitlab.com/gitlab-org/gitlab-environment-toolkit"
    94: gitlab.project fullName="GitLab.org / test project pipelines usability" visibility="public" webURL="https://gitlab.com/gitlab-org/test-project-pipelines-usability"
    95: gitlab.project fullName="GitLab.org / verify-stage" visibility="public" webURL="https://gitlab.com/gitlab-org/verify-stage"
    96: gitlab.project fullName="GitLab.org / package-stage" visibility="public" webURL="https://gitlab.com/gitlab-org/package-stage"
    97: gitlab.project fullName="GitLab.org / gitlab-peek" visibility="public" webURL="https://gitlab.com/gitlab-org/gitlab-peek"
    98: gitlab.project fullName="GitLab.org / release-stage" visibility="public" webURL="https://gitlab.com/gitlab-org/release-stage"
    99: gitlab.project fullName="GitLab.org / container-registry" visibility="public" webURL="https://gitlab.com/gitlab-org/container-registry"
  ]
  visibility: "public"
  emailsDisabled: false
  preventForkingOutsideGroup: false
}
```

Project:

```coffee
gitlab.group.projects.first: {
  webURL: "https://gitlab.com/gitlab-org/moa"
  issuesEnabled: true
  approvalRules: [
    0: gitlab.project.approvalRule id=69189438 name="All Members" approvalsRequired=1
  ]
  wikiEnabled: true
  requirementsEnabled: true
  path: "moa"
  createdAt: 2025-09-04 00:08:52.331 -0700 PDT
  containerRegistryEnabled: true
  autocloseReferencedIssues: true
  name: "moa"
  visibility: "public"
  id: 74166478
  defaultBranch: "main"
  description: ""
  lfsEnabled: true
  archived: false
  serviceDeskEnabled: true
  removeSourceBranchAfterMerge: true
  projectFiles: [
    0: gitlab.project.file path=".gitlab-ci.yml" type="blob"
    1: gitlab.project.file path=".gitlab/scripts/benchmetric/benchmetric.go" type="blob"
    2: gitlab.project.file path=".tool-versions" type="blob"
    3: gitlab.project.file path="CONTRIBUTING.md" type="blob"
    4: gitlab.project.file path="LICENSE" type="blob"
    5: gitlab.project.file path="Makefile" type="blob"
    6: gitlab.project.file path="README.md" type="blob"
    7: gitlab.project.file path="go.mod" type="blob"
    8: gitlab.project.file path="go.sum" type="blob"
    9: gitlab.project.file path="internal/ast/ast.go" type="blob"
    10: gitlab.project.file path="internal/ast/operator.go" type="blob"
    11: gitlab.project.file path="internal/lexer/scanner.go" type="blob"
  ]
  mergeMethod: "merge"
  webhooks: GET https://gitlab.com/api/v4/projects/74166478/hooks: 403 {message: 403 Forbidden}
  emailsDisabled: false
  mirror: false
  emptyRepo: false
  groupRunnersEnabled: false
  jobsEnabled: true
  approvalSettings: GET https://gitlab.com/api/v4/projects/74166478/approvals: 403 {message: 403 Forbidden}
  allowMergeOnSkippedPipeline: false
  autoDevopsEnabled: false
  onlyAllowMergeIfAllDiscussionsAreResolved: true
  sharedRunnersEnabled: true
  onlyAllowMergeIfPipelineSucceeds: true
  fullName: "GitLab.org / moa"
  packagesEnabled: true
  mergeRequestsEnabled: true
  protectedBranches: [
    0: gitlab.project.protectedBranch name="main" allowForcePush=false
  ]
  snippetsEnabled: true
  projectMembers: [
    0: gitlab.project.member username="sytses" role="Developer" name="Sid Sijbrandij"
    1: gitlab.project.member username="marin" role="Owner" name="Marin Jankovski"
    2: gitlab.project.member username="stanhu" role="Owner" name="Stan Hu"
    3: gitlab.project.member username="dblessing" role="Developer" name="Drew Blessing"
    4: gitlab.project.member username="brodock" role="Developer" name="Gabriel Mazetto"
    5: gitlab.project.member username="grzesiek" role="Developer" name="Grzegorz Bizon"
    6: gitlab.project.member username="dbalexandre" role="Developer" name="Douglas Barbosa Alexandre"
    7: gitlab.project.member username="tmaczukin" role="Maintainer" name="Tomasz Maczukin"
    8: gitlab.project.member username="rymai" role="Developer" name="Rémy Coutable"
    9: gitlab.project.member username="luke" role="Developer" name="Luke Babb"
    10: gitlab.project.member username="jameslopez" role="Maintainer" name="James Lopez"
    11: gitlab.project.member username="annabeldunstone" role="Developer" name="Annabel Dunstone Gray"
    12: gitlab.project.member username="felipe_artur" role="Developer" name="Felipe Cardozo"
    13: gitlab.project.member username="ayufan" role="Developer" name="Kamil Trzciński"
    14: gitlab.project.member username="chriscool" role="Developer" name="Christian Couder"
    15: gitlab.project.member username="alejandro" role="Developer" name="Alejandro Rodríguez"
    16: gitlab.project.member username="tauriedavis" role="Developer" name="Taurie Davis"
    17: gitlab.project.member username="eliran.mesika" role="Developer" name="Eliran Mesika"
    18: gitlab.project.member username="ahanselka" role="Maintainer" name="Alex Hanselka"
    19: gitlab.project.member username="ahmadsherif" role="Developer" name="Ahmad Sherif"
  ]
}
```