### PR TITLE
✨ Extend: aws.kms.keys {tags}

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -725,6 +725,8 @@ private aws.kms.key @defaults("id region metadata.Description") {
   keyRotationEnabled() bool
   // Metadata for the key
   metadata() dict
+  // Tags for the KMS key
+  tags() map[string]string
 }
 
 

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -1868,6 +1868,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.kms.key.metadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsKmsKey).GetMetadata()).ToDataRes(types.Dict)
 	},
+	"aws.kms.key.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsKmsKey).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"aws.iam.users": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIam).GetUsers()).ToDataRes(types.Array(types.Resource("aws.iam.user")))
 	},
@@ -6779,6 +6782,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.kms.key.metadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsKmsKey).Metadata, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"aws.kms.key.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsKmsKey).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"aws.iam.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15909,6 +15916,7 @@ type mqlAwsKmsKey struct {
 	Region             plugin.TValue[string]
 	KeyRotationEnabled plugin.TValue[bool]
 	Metadata           plugin.TValue[any]
+	Tags               plugin.TValue[map[string]any]
 }
 
 // createAwsKmsKey creates a new instance of this resource
@@ -15969,6 +15977,12 @@ func (c *mqlAwsKmsKey) GetKeyRotationEnabled() *plugin.TValue[bool] {
 func (c *mqlAwsKmsKey) GetMetadata() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.Metadata, func() (any, error) {
 		return c.metadata()
+	})
+}
+
+func (c *mqlAwsKmsKey) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -2396,6 +2396,8 @@ resources:
       keyRotationEnabled: {}
       metadata: {}
       region: {}
+      tags:
+        min_mondoo_version: 9.0.0
     is_private: true
     min_mondoo_version: 5.15.0
     platform:
@@ -3784,7 +3786,6 @@ resources:
       name:
       - aws
   aws.waf.rule.statement.ratebasedstatement:
-    fields: {}
     is_private: true
     min_mondoo_version: 9.0.0
     platform:

--- a/providers/aws/resources/aws_kms.go
+++ b/providers/aws/resources/aws_kms.go
@@ -119,6 +119,27 @@ func (a *mqlAwsKmsKey) keyRotationEnabled() (bool, error) {
 	return key.KeyRotationEnabled, nil
 }
 
+func (a *mqlAwsKmsKey) tags() (map[string]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	keyArn := a.Arn.Data
+
+	svc := conn.Kms(a.Region.Data)
+	ctx := context.Background()
+
+	tags, err := svc.ListResourceTags(ctx, &kms.ListResourceTagsInput{KeyId: &keyArn})
+	if err != nil {
+		return nil, err
+	}
+
+	res := map[string]any{}
+	for i := range tags.Tags {
+		tag := tags.Tags[i]
+		res[convert.ToValue(tag.TagKey)] = convert.ToValue(tag.TagValue)
+	}
+
+	return res, nil
+}
+
 func (a *mqlAwsKmsKey) id() (string, error) {
 	return a.Arn.Data, nil
 }


### PR DESCRIPTION
Extends the aws.kms.keys with the {tags} field, like so:

```
aws.kms.key: {
  tags: {
    GitHubOrg: "xxx"
    GitHubRepo: "yyy"
    Name: "foo"
    <something>: "true"
  }
}
```