### PR TITLE
:star: Gather the kernel version on FreeBSD

### DIFF
--- a/providers/os/resources/kernel/manager.go
+++ b/providers/os/resources/kernel/manager.go
@@ -208,11 +208,23 @@ type FreebsdKernelManager struct {
 }
 
 func (s *FreebsdKernelManager) Name() string {
-	return "Freebsd Kernel Manager"
+	return "FreeBSD Kernel Manager"
 }
 
 func (s *FreebsdKernelManager) Info() (KernelInfo, error) {
-	return KernelInfo{}, nil
+	// Use `uname -v` to get the kernel version
+	cmd, err := s.conn.RunCommand("uname -v")
+	if err != nil {
+		return KernelInfo{}, errors.Wrap(err, "could not read kernel version")
+	}
+	version, err := io.ReadAll(cmd.Stdout)
+	if err != nil {
+		return KernelInfo{}, errors.Wrap(err, "could not read kernel version")
+	}
+
+	return KernelInfo{
+		Version: strings.TrimSpace(string(version)),
+	}, nil
 }
 
 func (s *FreebsdKernelManager) Parameters() (map[string]string, error) {

--- a/providers/os/resources/kernel/manager_test.go
+++ b/providers/os/resources/kernel/manager_test.go
@@ -108,7 +108,7 @@ func TestManagerMacos(t *testing.T) {
 }
 
 func TestManagerFreebsd(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/freebsd12.toml", &inventory.Asset{
+	mock, err := mock.New(0, "./testdata/freebsd14.toml", &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "freebsd",
 			Family: []string{"unix"},
@@ -121,7 +121,11 @@ func TestManagerFreebsd(t *testing.T) {
 	mounts, err := mm.Modules()
 	require.NoError(t, err)
 
-	assert.Equal(t, 4, len(mounts))
+	assert.Equal(t, 6, len(mounts))
+
+	info, err := mm.Info()
+	require.NoError(t, err)
+	assert.Equal(t, "FreeBSD 14.3-RELEASE releng/14.3-n271432-8c9ce319fef7 GENERIC", info.Version)
 }
 
 func TestManagerAIX(t *testing.T) {

--- a/providers/os/resources/kernel/modules_test.go
+++ b/providers/os/resources/kernel/modules_test.go
@@ -52,18 +52,18 @@ func TestLinuxProcModulesParser(t *testing.T) {
 }
 
 func TestKldstatParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/freebsd12.toml", &inventory.Asset{})
+	mock, err := mock.New(0, "./testdata/freebsd14.toml", &inventory.Asset{})
 	require.NoError(t, err)
 
 	f, err := mock.RunCommand("kldstat")
 	require.NoError(t, err)
 
 	entries := ParseKldstat(f.Stdout)
-	assert.Equal(t, 4, len(entries))
+	assert.Equal(t, 6, len(entries))
 
 	expected := &KernelModule{
 		Name:   "smbus.ko",
-		Size:   "a30",
+		Size:   "2178",
 		UsedBy: "1",
 	}
 	found := findModule(entries, "smbus.ko")

--- a/providers/os/resources/kernel/sysctl_test.go
+++ b/providers/os/resources/kernel/sysctl_test.go
@@ -41,7 +41,7 @@ func TestSysctlMacos(t *testing.T) {
 }
 
 func TestSysctlFreebsd(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/freebsd12.toml", &inventory.Asset{})
+	mock, err := mock.New(0, "./testdata/freebsd14.toml", &inventory.Asset{})
 	require.NoError(t, err)
 
 	c, err := mock.RunCommand("sysctl -a")

--- a/providers/os/resources/kernel/testdata/freebsd14.toml
+++ b/providers/os/resources/kernel/testdata/freebsd14.toml
@@ -1,9 +1,11 @@
 [commands."kldstat"]
 stdout = """Id Refs Address                Size Name
- 1    7 0xffffffff80200000  24bc3a8 kernel
- 2    1 0xffffffff82819000    2df63 vboxguest.ko
- 3    1 0xffffffff82847000     2468 intpm.ko
- 4    1 0xffffffff8284a000      a30 smbus.ko
+ 1   20 0xffffffff80200000  1f41458 kernel
+ 2    1 0xffffffff82142000     7808 cryptodev.ko
+ 4    1 0xffffffff82160000   5e9340 zfs.ko
+ 5    1 0xffffffff83018000     3220 intpm.ko
+ 6    1 0xffffffff8301c000     2178 smbus.ko
+ 7    1 0xffffffff8301f000    35b40 vboxguest.ko
 """
 
 [commands."uname -s"]
@@ -13,8 +15,10 @@ stdout = "FreeBSD"
 stdout = "amd64"
 
 [commands."uname -r"]
-stdout = "12.0-CURRENT"
+stdout = "14.3-RELEASE"
 
+[commands."uname -v"]
+stdout = "FreeBSD 14.3-RELEASE releng/14.3-n271432-8c9ce319fef7 GENERIC"
 
 [commands."sysctl -a"]
 stdout = """security.bsd.see_other_uids: 1


### PR DESCRIPTION
Currently on FreeBSD we return an empty version of the Linux data structure:

```
cnquery> kernel.info
kernel.info: {
  args: null
  device: ""
  path: ""
  version: ""
}
```

Instead let's return the version of the kernel using 99.9% of the same logic we use on AIX:

```
cnquery> kernel.info
kernel.info: {
  version: "FreeBSD 14.3-RELEASE releng/14.3-n271432-8c9ce319fef7 GENERIC"
}