### PR TITLE
✨ support more types in [].join()

### DIFF
--- a/cli/printer/mql.go
+++ b/cli/printer/mql.go
@@ -776,25 +776,8 @@ func (print *Printer) data(typ types.Type, data any, checksum string, indent str
 		}
 		return print.Secondary(fmt.Sprintf("/%s/", data))
 	case types.Time:
-		if data == nil {
-			return print.Secondary("null")
-		}
-		time := data.(*time.Time)
-		if time == nil {
-			return print.Secondary("null")
-		}
+		return print.Secondary(llx.StringifyValue(data, types.Time))
 
-		if *time == llx.NeverPastTime || *time == llx.NeverFutureTime {
-			return print.Secondary("Never")
-		}
-
-		if time.Unix() > 0 {
-			return print.Secondary(time.String())
-		}
-
-		durationStr := llx.TimeToDurationString(*time)
-
-		return print.Secondary(durationStr)
 	case types.Dict:
 		return print.dict(typ, data, indent, cache)
 

--- a/llx/builtin_simple.go
+++ b/llx/builtin_simple.go
@@ -5,7 +5,6 @@ package llx
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"regexp"
 	"strconv"
@@ -2550,31 +2549,6 @@ func TimeToDuration(t *time.Time) int64 {
 // DurationToTime takes a duration in seconds and turns it into a time object
 func DurationToTime(i int64) time.Time {
 	return time.Unix(i+zeroTimeOffset, 0)
-}
-
-func TimeToDurationString(t time.Time) string {
-	seconds := TimeToDuration(&t)
-	minutes := seconds / 60
-	hours := minutes / 60
-	days := hours / 24
-
-	var res strings.Builder
-	if days > 0 {
-		res.WriteString(fmt.Sprintf("%d days ", days))
-	}
-	if hours%24 != 0 {
-		res.WriteString(fmt.Sprintf("%d hours ", hours%24))
-	}
-	if minutes%60 != 0 {
-		res.WriteString(fmt.Sprintf("%d minutes ", minutes%60))
-	}
-	// if we haven't printed any of the other pieces (days/hours/minutes) then print this
-	// if we have, then check if this is non-zero
-	if minutes == 0 || seconds%60 != 0 {
-		res.WriteString(fmt.Sprintf("%d seconds", seconds%60))
-	}
-
-	return strings.TrimSpace(res.String())
 }
 
 func timeSecondsV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {

--- a/llx/strings.go
+++ b/llx/strings.go
@@ -1,0 +1,87 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Note for unit tests: We are currently using `mql_test.go` in core tests
+// as a proxy to test the stringify approach. Once we migrate all MQL
+// string generation to the below functions, we should migrate and expand
+// on testing in a more unified way.
+
+package llx
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.mondoo.com/cnquery/v12/types"
+)
+
+// StringifyValue turns a raw golang value into a string
+func StringifyValue(value any, typHint types.Type) string {
+	switch v := value.(type) {
+	case string:
+		switch typHint {
+		case types.Regex:
+			// FIXME: doesn't properly escape the contents of the regex
+			var res strings.Builder
+			res.WriteByte('/')
+			res.WriteString(v)
+			res.WriteByte('/')
+			return res.String()
+		case types.Version:
+			return "v" + v
+		default:
+			return v
+		}
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(v)
+	case nil:
+		return "null"
+	case *time.Time:
+		if v.Equal(NeverPastTime) || v.Equal(NeverFutureTime) {
+			return "Never"
+		}
+
+		if v.Unix() > 0 {
+			return v.String()
+		}
+
+		return TimeToDurationString(*v)
+
+	case RawIP:
+		return v.String()
+
+	default:
+		return fmt.Sprintf("%#v", value)
+	}
+}
+
+func TimeToDurationString(t time.Time) string {
+	seconds := TimeToDuration(&t)
+	minutes := seconds / 60
+	hours := minutes / 60
+	days := hours / 24
+
+	var res strings.Builder
+	if days > 0 {
+		res.WriteString(fmt.Sprintf("%d days ", days))
+	}
+	if hours%24 != 0 {
+		res.WriteString(fmt.Sprintf("%d hours ", hours%24))
+	}
+	if minutes%60 != 0 {
+		res.WriteString(fmt.Sprintf("%d minutes ", minutes%60))
+	}
+	// if we haven't printed any of the other pieces (days/hours/minutes) then print this
+	// if we have, then check if this is non-zero
+	if minutes == 0 || seconds%60 != 0 {
+		res.WriteString(fmt.Sprintf("%d seconds", seconds%60))
+	}
+
+	return strings.TrimSpace(res.String())
+}

--- a/mqlc/builtin_array.go
+++ b/mqlc/builtin_array.go
@@ -529,9 +529,9 @@ func compileArrayFlat(c *compiler, typ types.Type, ref uint64, id string, call *
 
 func compileArrayJoin(c *compiler, typ types.Type, ref uint64, id string, call *parser.Call) (types.Type, error) {
 	switch typ.Child() {
-	case types.String, types.Dict:
+	case types.String, types.Dict, types.Float, types.Int, types.Bool, types.Nil, types.Regex, types.Version, types.Time, types.Score, types.IP, types.Unset:
 	default:
-		return types.Nil, errors.New("can only call join() on arrays that have strings in them")
+		return types.Nil, errors.New("can only call join() on arrays with elements that can be turned into strings")
 	}
 
 	var args []*llx.Primitive = nil

--- a/providers/core/resources/mql_test.go
+++ b/providers/core/resources/mql_test.go
@@ -472,10 +472,6 @@ func TestString_Methods(t *testing.T) {
 			Expectation: []any{"hello", "world"},
 		},
 		{
-			Code:        "'1.2.3.4'.split('.').reverse.join(':')",
-			Expectation: "4:3:2:1",
-		},
-		{
 			Code:        "'he\nll\no'.lines",
 			Expectation: []any{"he", "ll", "o"},
 		},
@@ -494,6 +490,10 @@ func TestString_Methods(t *testing.T) {
 		{
 			Code:        "'23'.inRange(1,23)",
 			Expectation: true,
+		},
+		{
+			Code:        "'1.2.3.4'.split('.').reverse.join(':')",
+			Expectation: "4:3:2:1",
 		},
 	})
 }
@@ -740,6 +740,51 @@ func TestArray(t *testing.T) {
 			Code:        "[3,1,3,4,2] - [3,4,5]",
 			Expectation: []any{int64(1), int64(2)},
 		},
+	})
+
+	t.Run("join()", func(t *testing.T) {
+		x.TestSimple(t, []testutils.SimpleTest{
+			{
+				Code:        "[].join('---')",
+				Expectation: "",
+			},
+			{
+				Code:        "['no','rm','al'].join('')",
+				Expectation: "normal",
+			},
+			{
+				Code:        "[1,2,3].join('-')",
+				Expectation: "1-2-3",
+			},
+			{
+				Code:        "[1.2,3.4].join('+')",
+				Expectation: "1.2+3.4",
+			},
+			{
+				Code:        "[null,null].join('^')",
+				Expectation: "null^null",
+			},
+			{
+				Code:        "[true, false].join('&&&')",
+				Expectation: "true&&&false",
+			},
+			{
+				Code:        "[/yo/,/re/].join('+')",
+				Expectation: "/yo/+/re/",
+			},
+			{
+				Code:        "[version('1.0'), version('2.3')].join(', ')",
+				Expectation: "v1.0, v2.3",
+			},
+			{
+				Code:        "[Never, Never].join(' ')",
+				Expectation: "Never Never",
+			},
+			{
+				Code:        "[ip('1.2.3.4/24'), ip('::')].join('\t')",
+				Expectation: "1.2.3.4/24\t::",
+			},
+		})
 	})
 }
 


### PR DESCRIPTION
Amongst others, you can now join on simple types like numbers and booleans, but also complex types like versions, regexes, and ip addresses, to name a few.

From the updated MQL tests in this PR:

```coffee
> [1, 2, 3].join('-')
"1-2-3"

> [1.2, 3.4].join('+')
"1.2+3.4"

> [null, null].join('^')
"null^null"

> [true, false].join('&&&')
"true&&&false"

> [/yo/,/re/].join('+')
"/yo/+/re/"

> [version('1.0'), version('2.3')].join(', ')
"v1.0, v2.3"

> [Never, Never].join(' ')
"Never Never"

> [ip('1.2.3.4/24'), ip('::')].join('\t')
"1.2.3.4/24\t::"

```

There is one important departure from our JS/TS roots and that is `[null, null].join`. We intend to be consistent on the stringification of `null` values and thus cannot have it just be an empty string. This is getting ahead of future printing and making sure this case is handled consistently.