### PR TITLE
🐛 Order LR resources before generating schema.

### DIFF
--- a/providers-sdk/v1/mqlr/lrcore/testdata/new.lr
+++ b/providers-sdk/v1/mqlr/lrcore/testdata/new.lr
@@ -1,3 +1,5 @@
+option provider = "test"
+
 sshd {}
 
 sshd.config {


### PR DESCRIPTION
Since the AST resources is a map, generating schema from it is not deterministic, we've seen some changes if schema is regenerated. This ensures the map is always sorted and extends some tests