### PR TITLE
Extend User permissions with `AllowedToReadBitlockerKeysForOwnedDevice`

### DIFF
--- a/providers/ms365/resources/structs.go
+++ b/providers/ms365/resources/structs.go
@@ -252,6 +252,8 @@ type DefaultUserRolePermissions struct {
 	AllowedToCreateTenants *bool `json:"allowedToCreateTenants"`
 	// List of permission grant policies assigned.
 	PermissionGrantPoliciesAssigned []string `json:"permissionGrantPoliciesAssigned"`
+	// Indicates whether the registered owners of a device can read their own BitLocker recovery keys with default user role.
+	AllowedToReadBitlockerKeysForOwnedDevice *bool `json:"allowedToReadBitlockerKeysForOwnedDevice"`
 }
 
 func newDefaultUserRolePermissions(a models.DefaultUserRolePermissionsable) *DefaultUserRolePermissions {
@@ -259,11 +261,12 @@ func newDefaultUserRolePermissions(a models.DefaultUserRolePermissionsable) *Def
 		return nil
 	}
 	return &DefaultUserRolePermissions{
-		AllowedToCreateApps:             a.GetAllowedToCreateApps(),
-		AllowedToCreateSecurityGroups:   a.GetAllowedToCreateSecurityGroups(),
-		AllowedToReadOtherUsers:         a.GetAllowedToReadOtherUsers(),
-		AllowedToCreateTenants:          a.GetAllowedToCreateTenants(),
-		PermissionGrantPoliciesAssigned: a.GetPermissionGrantPoliciesAssigned(),
+		AllowedToCreateApps:                      a.GetAllowedToCreateApps(),
+		AllowedToCreateSecurityGroups:            a.GetAllowedToCreateSecurityGroups(),
+		AllowedToReadOtherUsers:                  a.GetAllowedToReadOtherUsers(),
+		AllowedToCreateTenants:                   a.GetAllowedToCreateTenants(),
+		PermissionGrantPoliciesAssigned:          a.GetPermissionGrantPoliciesAssigned(),
+		AllowedToReadBitlockerKeysForOwnedDevice: a.GetAllowedToReadBitlockerKeysForOwnedDevice(),
 	}
 }
 


### PR DESCRIPTION
Adds new field `allowedToReadBitlockerKeysForOwnedDevice` to `defaultUserRolePermissions`. 
This PR should resolve the issue https://github.com/mondoohq/cnquery/issues/5756
```
➜  cnquery git:(mate/5756/ms365-add-allowed_tor_read_bitlocker_keys) ✗ go run ./apps/cnquery/cnquery.go run ms365 --certificate-path ${MS365_CERTIFICATE_PATH} --tenant-id ${MS365_TENANT_ID} --client-id ${MS365_CLIENT_ID} -c "microsoft.policies.authorizationPolicy.defaultUserRolePermissions"
microsoft.policies.authorizationPolicy.defaultUserRolePermissions: {
  allowedToCreateApps: false
  allowedToCreateSecurityGroups: false
  allowedToCreateTenants: false
  allowedToReadBitlockerKeysForOwnedDevice: false
  allowedToReadOtherUsers: false
  permissionGrantPoliciesAssigned: [
    0: "REDACTED"
    1: "REDACTED"
    2: "REDACTED"
  ]
}
```