### PR TITLE
🐛 Fix connection types for network devices.

### DIFF
--- a/providers/defaults.go
+++ b/providers/defaults.go
@@ -481,7 +481,6 @@ var DefaultProviders Providers = map[string]*Provider{
 			},
 		},
 	},
-
 	"vcd": {
 		Provider: &plugin.Provider{
 			Name:            "vcd",
@@ -532,7 +531,7 @@ var DefaultProviders Providers = map[string]*Provider{
 		Provider: &plugin.Provider{
 			Name:            "networkdevices",
 			ID:              "go.mondoo.com/cnquery/providers/networkdevices",
-			ConnectionTypes: []string{"networkdevices"},
+			ConnectionTypes: []string{"nd-ssh", "ciscocatalyst"},
 			Connectors: []plugin.Connector{
 				{
 					Name:  "ciscocatalyst",

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -83,10 +83,10 @@ func (s ProviderLookup) String() string {
 		res = append(res, "provider="+s.ProviderName)
 	}
 	if s.ConnName != "" {
-		res = append(res, "name="+s.ConnName)
+		res = append(res, "conn name="+s.ConnName)
 	}
 	if s.ConnType != "" {
-		res = append(res, "name="+s.ConnType)
+		res = append(res, "conn type="+s.ConnType)
 	}
 	return strings.Join(res, " ")
 }


### PR DESCRIPTION
This ensures we install the network devices provider if it's missing in case we're using an inventory file with connection type `nd-ssh`