### PR TITLE
🐛 Fix panic: cannot label array index of type ref

### DIFF
--- a/mqlc/labels.go
+++ b/mqlc/labels.go
@@ -80,6 +80,14 @@ func createLabel(res *llx.CodeBundle, ref uint64, schema resources.ResourcesSche
 			} else {
 				label = "[" + idx.(string) + "]"
 			}
+		case types.Ref:
+			// try to resolve the ref to a label
+			ref := idx.(uint64)
+			argLabel, err := createLabel(res, ref, schema)
+			if err != nil {
+				return "", err
+			}
+			label = "[" + argLabel + "]"
 		default:
 			panic("cannot label array index of type " + arg.Type.Label())
 		}

--- a/mqlc/labels_test.go
+++ b/mqlc/labels_test.go
@@ -209,6 +209,21 @@ func TestLabels(t *testing.T) {
 				},
 			},
 		},
+		{
+			`
+			x = {"foo": "bar"}
+			y = "foo"
+			x[y] == "bar"
+			`,
+			&llx.Labels{
+				Labels: map[string]string{
+					"4OG3DaYfFbOlsn12IDd6agxfAm7nHDDYRfwGehCPOnJuv/XDtzJQevRswKHu2x2Ajce/XUx7bEMIeRdv0CVbxg==": "x[y] == \"bar\"",
+					"ESblt/NRDVk2IAipI7In+KIhVXWeIAoBQ6CJXvfLE9klBwRQhU+18b2zr9ObaUrWYnl8UdtMrGWCHnVcjzQ5tg==": "y",
+					"lXrsqrPWwS9C5nHl9rNtZSPxlKe4DSETNk2VIJVY1BajScbBSBX1YxmagbdpH3fmdzicv5eYVnJMrQm1HVeSBw==": "x[y]",
+					"mavQSLTkn3SiZumTQYLExutOalL7hQPhOGlZKf79X79YEdHf2ryS6Tr68ro3fKjRKL6o+1Sw9CqJTUUmzzRboA==": "x",
+				},
+			},
+		},
 	}
 
 	for i := range tests {


### PR DESCRIPTION
The following query

```
go run ./apps/cnspec run --ast -c '
x = {"foo": "bar"}
y = "foo"
x[y] == "bar"
'
```

was panicking with
```
panic: cannot label array index of type ref [recovered]
	panic: panic compiling "\nx = {\"foo\": \"bar\"}\ny = \"foo\"\nx[y] == \"bar\"\n": cannot label array index of type ref

goroutine 1 [running]:
go.mondoo.com/cnquery/v12/mqlc.Compile.func1()
	/home/jaym/workspace/mondoo/repos/cnquery/mqlc/mqlc.go:2231 +0xb3
panic({0x280ca80?, 0xc001888ea0?})
	/nix/store/5fap2y498jz0lgjm53p59m8kapfl0146-go-1.25.1/share/go/src/runtime/panic.go:783 +0x132
go.mondoo.com/cnquery/v12/mqlc.createLabel(0xc00188c1e0, 0x0?, {0x3478e60?, 0xc000b27bf0?})
	/home/jaym/workspace/mondoo/repos/cnquery/mqlc/labels.go:85 +0x77a
go.mondoo.com/cnquery/v12/mqlc.createLabel(0xc00188c1e0, 0x41016f?, {0x3478e60?, 0xc000b27bf0?})
	/home/jaym/workspace/mondoo/repos/cnquery/mqlc/labels.go:58 +0x27f
go.mondoo.com/cnquery/v12/mqlc.updateLabels(0xc00188c1e0, 0x0?, {0x3478e60, 0xc000b27bf0})
	/home/jaym/workspace/mondoo/repos/cnquery/mqlc/labels.go:191 +0x425
go.mondoo.com/cnquery/v12/mqlc.UpdateLabels(0xc00188c1e0, {0x3478e60, 0xc000b27bf0})
	/home/jaym/workspace/mondoo/repos/cnquery/mqlc/labels.go:140 +0xc5
go.mondoo.com/cnquery/v12/mqlc.compile({0x7ffcb6639b34?, 0x4?}, {0x0, 0x0}, {{0x3478e60, 0xc000b27bf0}, 0x0, {0x347b9d0, 0x4e51f40}, {0xc000544200, ...}})
	/home/jaym/workspace/mondoo/repos/cnquery/mqlc/mqlc.go:2207 +0x145
go.mondoo.com/cnquery/v12/mqlc.Compile({0x7ffcb6639b34?, 0xc0018873a8?}, {0x0?, 0x0?}, {{0x3478e60, 0xc000b27bf0}, 0x0, {0x347b9d0, 0x4e51f40}, {0xc000544200, ...}})
	/home/jaym/workspace/mondoo/repos/cnquery/mqlc/mqlc.go:2235 +0xbc
go.mondoo.com/cnquery/v12/apps/cnquery/cmd.(*cnqueryPlugin).RunQuery(0xc0007cd900?, 0xc0018876e8, 0xc00022bd00, {0x3456188, 0xc001888270})
	/home/jaym/workspace/mondoo/repos/cnquery/apps/cnquery/cmd/plugin.go:79 +0x6fb
go.mondoo.com/cnquery/v12/apps/cnquery/cmd.init.func21(0x4e027a0, 0xc00022bd00, 0xc001a948d0)
	/home/jaym/workspace/mondoo/repos/cnquery/apps/cnquery/cmd/run.go:88 +0x726
go.mondoo.com/cnquery/v12/cli/providers.setConnector.func2(0x4e027a0, {0xc00185bc50, 0x0, 0x3})
	/home/jaym/workspace/mondoo/repos/cnquery/cli/providers/providers.go:574 +0xb96
github.com/spf13/cobra.(*Command).execute(0x4e027a0, {0xc00185bbf0, 0x3, 0x3})
	/home/jaym/workspace/mondoo/.devenv/state/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1019 +0xae7
github.com/spf13/cobra.(*Command).ExecuteC(0x4dfeb40)
	/home/jaym/workspace/mondoo/.devenv/state/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1148 +0x465
github.com/spf13/cobra.(*Command).Execute(...)
	/home/jaym/workspace/mondoo/.devenv/state/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1071
go.mondoo.com/cnspec/v12/apps/cnspec/cmd.Execute()
	/home/jaym/workspace/mondoo/repos/cnspec/apps/cnspec/cmd/root.go:120 +0x7d
main.main()
	/home/jaym/workspace/mondoo/repos/cnspec/apps/cnspec/cnspec.go:16 +0x8c
exit status 2
```