### PR TITLE
Fix ms365 authenticationRequirements

### DIFF
--- a/providers/ms365/resources/users.go
+++ b/providers/ms365/resources/users.go
@@ -826,7 +826,7 @@ func (a *mqlMicrosoftUser) authenticationRequirements() (*mqlMicrosoftUserAuthen
 		return nil, transformError(err)
 	}
 
-	mqlAuthRequirements, err := CreateResource(a.MqlRuntime, "microsoft.user.AuthenticationRequirements",
+	mqlAuthRequirements, err := CreateResource(a.MqlRuntime, ResourceMicrosoftUserAuthenticationRequirements,
 		map[string]*llx.RawData{
 			"__id":            llx.StringData(userID),
 			"perUserMfaState": llx.StringData(authRequirements.GetPerUserMfaState().String()),


### PR DESCRIPTION
There was a typo in the resource name. Should be `microsoft.user.authenticationRequirements`.