### PR TITLE
⭐ Add new fields to ms365.exchangeonline.reportsubmissionpolicies

### DIFF
--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -1585,8 +1585,8 @@ private ms365.exchangeonline.reportSubmissionPolicy {
   junkReviewResultMessage string
   // Custom message shown for not junk review result
   notJunkReviewResultMessage string
-  // Sender address for notifications
-  notificationSenderAddress []string
+  // Sender addresses for notifications
+  notificationSenderAddresses []string
   // Whether to use a custom notification sender
   enableCustomNotificationSender bool
   // Whether to use organization branding in notifications

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -2417,8 +2417,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"ms365.exchangeonline.reportSubmissionPolicy.notJunkReviewResultMessage": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMs365ExchangeonlineReportSubmissionPolicy).GetNotJunkReviewResultMessage()).ToDataRes(types.String)
 	},
-	"ms365.exchangeonline.reportSubmissionPolicy.notificationSenderAddress": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlMs365ExchangeonlineReportSubmissionPolicy).GetNotificationSenderAddress()).ToDataRes(types.Array(types.String))
+	"ms365.exchangeonline.reportSubmissionPolicy.notificationSenderAddresses": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365ExchangeonlineReportSubmissionPolicy).GetNotificationSenderAddresses()).ToDataRes(types.Array(types.String))
 	},
 	"ms365.exchangeonline.reportSubmissionPolicy.enableCustomNotificationSender": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMs365ExchangeonlineReportSubmissionPolicy).GetEnableCustomNotificationSender()).ToDataRes(types.Bool)
@@ -5359,8 +5359,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlMs365ExchangeonlineReportSubmissionPolicy).NotJunkReviewResultMessage, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"ms365.exchangeonline.reportSubmissionPolicy.notificationSenderAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlMs365ExchangeonlineReportSubmissionPolicy).NotificationSenderAddress, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+	"ms365.exchangeonline.reportSubmissionPolicy.notificationSenderAddresses": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365ExchangeonlineReportSubmissionPolicy).NotificationSenderAddresses, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"ms365.exchangeonline.reportSubmissionPolicy.enableCustomNotificationSender": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -13117,7 +13117,7 @@ type mqlMs365ExchangeonlineReportSubmissionPolicy struct {
 	NotificationFooterMessage                   plugin.TValue[string]
 	JunkReviewResultMessage                     plugin.TValue[string]
 	NotJunkReviewResultMessage                  plugin.TValue[string]
-	NotificationSenderAddress                   plugin.TValue[[]any]
+	NotificationSenderAddresses                 plugin.TValue[[]any]
 	EnableCustomNotificationSender              plugin.TValue[bool]
 	EnableOrganizationBranding                  plugin.TValue[bool]
 	DisableQuarantineReportingOption            plugin.TValue[bool]
@@ -13219,8 +13219,8 @@ func (c *mqlMs365ExchangeonlineReportSubmissionPolicy) GetNotJunkReviewResultMes
 	return &c.NotJunkReviewResultMessage
 }
 
-func (c *mqlMs365ExchangeonlineReportSubmissionPolicy) GetNotificationSenderAddress() *plugin.TValue[[]any] {
-	return &c.NotificationSenderAddress
+func (c *mqlMs365ExchangeonlineReportSubmissionPolicy) GetNotificationSenderAddresses() *plugin.TValue[[]any] {
+	return &c.NotificationSenderAddresses
 }
 
 func (c *mqlMs365ExchangeonlineReportSubmissionPolicy) GetEnableCustomNotificationSender() *plugin.TValue[bool] {

--- a/providers/ms365/resources/ms365.lr.manifest.yaml
+++ b/providers/ms365/resources/ms365.lr.manifest.yaml
@@ -976,7 +976,7 @@ resources:
       junkReviewResultMessage: {}
       notJunkReviewResultMessage: {}
       notificationFooterMessage: {}
-      notificationSenderAddress: {}
+      notificationSenderAddresses: {}
       phishingReviewResultMessage: {}
       postSubmitMessageEnabled: {}
       preSubmitMessageEnabled: {}

--- a/providers/ms365/resources/ms365_exchange.go
+++ b/providers/ms365/resources/ms365_exchange.go
@@ -285,7 +285,7 @@ func convertReportSubmissionPolicy(r *mqlMs365Exchangeonline, data []*ReportSubm
 				"notificationFooterMessage":                   llx.StringData(t.NotificationFooterMessage),
 				"junkReviewResultMessage":                     llx.StringData(t.JunkReviewResultMessage),
 				"notJunkReviewResultMessage":                  llx.StringData(t.NotJunkReviewResultMessage),
-				"notificationSenderAddress":                   llx.ArrayData(llx.TArr2Raw(t.NotificationSenderAddress), types.String),
+				"notificationSenderAddresses":                 llx.ArrayData(llx.TArr2Raw(t.NotificationSenderAddress), types.String),
 				"enableCustomNotificationSender":              llx.BoolData(t.EnableCustomNotificationSender),
 				"enableOrganizationBranding":                  llx.BoolData(t.EnableOrganizationBranding),
 				"disableQuarantineReportingOption":            llx.BoolData(t.DisableQuarantineReportingOption),


### PR DESCRIPTION
Usage: `ms365 --certificate-path ${MS365_CERTIFICATE_PATH} --tenant-id ${MS365_TENANT_ID} --client-id ${MS365_CLIENT_ID} -c "ms365.exchangeonline.reportSubmissionPolicies { * }"`
Expected output:
```
ms365.exchangeonline.reportSubmissionPolicies: [
  0: {
    notificationFooterMessage: ""
    reportNotJunkToCustomizedAddress: true
    reportPhishAddresses: [
      0: "REDACTED"
    ]
   .....
    notificationSenderAddress: []
    reportNotJunkAddresses: [
      0: "REDACTED"
    ]
    reportJunkAddresses: [
      0: "REDACTED"
    ]
    enableReportToMicrosoft: false
    phishingReviewResultMessage: ""
    reportJunkToCustomizedAddress: true
  }
]
```