### PR TITLE
✨ expose k8s container statuses for pods

### DIFF
--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -155,6 +155,8 @@ private k8s.pod @defaults("namespace name created"){
   initContainers() []k8s.initContainer
   // Contained containers
   containers() []k8s.container
+  // Container statuses
+  containerStatuses() []k8s.containerStatus
   // Node the pod runs on
   node() k8s.node
 }
@@ -375,6 +377,22 @@ private k8s.container @defaults("name") {
   env dict
   // envFrom settings
   envFrom dict
+}
+
+// Kubernetes container status
+private k8s.containerStatus @defaults("name") {
+  // Name of the container
+  name string
+  // Whether the container is currently passing its readiness check
+  ready bool
+  // The amount of times the container has been restarted
+  restartCount int
+  // Name of the container image that the container is running
+  image string
+  // The image ID of the container's image
+  imageId string
+  // The ID of the container in the format '<type>://<container_id>'
+  containerId string
 }
 
 // Kubernetes init container

--- a/providers/k8s/resources/k8s.lr.manifest.yaml
+++ b/providers/k8s/resources/k8s.lr.manifest.yaml
@@ -185,6 +185,19 @@ resources:
     platform:
       name:
       - kubernetes
+  k8s.containerStatus:
+    fields:
+      containerId: {}
+      image: {}
+      imageId: {}
+      name: {}
+      ready: {}
+      restartCount: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
+    platform:
+      name:
+      - kubernetes
   k8s.cronjob:
     fields:
       annotations:
@@ -534,6 +547,8 @@ resources:
     fields:
       annotations: {}
       apiVersion: {}
+      containerStatuses:
+        min_mondoo_version: 9.0.0
       containers: {}
       created: {}
       ephemeralContainers:


### PR DESCRIPTION
We can query container statuses as such:
```coffee
cnquery> k8s.pods[0].containerStatuses{*}
k8s.pods[0].containerStatuses: [
  0: {
    imageId: "quay.io/jetstack/cert-manager-controller@sha256:1143471c90db621faee43ed53f250d0fcec9c86303ca83661c787d59486d2ff4"
    ready: true
    name: "cert-manager-controller"
    restartCount: 0
    image: "quay.io/jetstack/cert-manager-controller:v1.10.1"
    containerId: "containerd://b8b62a39c0229a103840226aa9c733f6178d26d3e0ad6ed28de8b836f40549c0"
  }
]
```