### PR TITLE
✨ expose docker.image repo digests

### DIFF
--- a/providers/os/resources/docker.go
+++ b/providers/os/resources/docker.go
@@ -43,6 +43,7 @@ func (p *mqlDocker) images() ([]any, error) {
 			"id":          llx.StringData(dImg.ID),
 			"size":        llx.IntData(dImg.Size),
 			"virtualsize": llx.IntData(dImg.VirtualSize),
+			"repoDigests": llx.ArrayData(llx.TArr2Raw(dImg.RepoDigests), types.String),
 			"labels":      llx.MapData(labels, types.String),
 			"tags":        llx.ArrayData(tags, types.String),
 		})

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -980,6 +980,8 @@ docker.image {
   size int
   // Virtual image size in kilobytes. Deprecated; use size instead
   virtualsize int
+  // Repo digests
+  repoDigests []string
   // Tag key value pairs
   tags []string
   // Labels key value pairs

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -1746,6 +1746,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"docker.image.virtualsize": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDockerImage).GetVirtualsize()).ToDataRes(types.Int)
 	},
+	"docker.image.repoDigests": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerImage).GetRepoDigests()).ToDataRes(types.Array(types.String))
+	},
 	"docker.image.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDockerImage).GetTags()).ToDataRes(types.Array(types.String))
 	},
@@ -4347,6 +4350,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"docker.image.virtualsize": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDockerImage).Virtualsize, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"docker.image.repoDigests": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerImage).RepoDigests, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"docker.image.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11751,6 +11758,7 @@ type mqlDockerImage struct {
 	Id          plugin.TValue[string]
 	Size        plugin.TValue[int64]
 	Virtualsize plugin.TValue[int64]
+	RepoDigests plugin.TValue[[]any]
 	Tags        plugin.TValue[[]any]
 	Labels      plugin.TValue[map[string]any]
 }
@@ -11802,6 +11810,10 @@ func (c *mqlDockerImage) GetSize() *plugin.TValue[int64] {
 
 func (c *mqlDockerImage) GetVirtualsize() *plugin.TValue[int64] {
 	return &c.Virtualsize
+}
+
+func (c *mqlDockerImage) GetRepoDigests() *plugin.TValue[[]any] {
+	return &c.RepoDigests
 }
 
 func (c *mqlDockerImage) GetTags() *plugin.TValue[[]any] {

--- a/providers/os/resources/os.lr.manifest.yaml
+++ b/providers/os/resources/os.lr.manifest.yaml
@@ -50,7 +50,6 @@ resources:
       params: {}
     min_mondoo_version: 9.0.0
   auditd.rule:
-    fields: {}
     is_private: true
     min_mondoo_version: 9.0.0
   auditd.rule.control:
@@ -285,6 +284,8 @@ resources:
     fields:
       id: {}
       labels: {}
+      repoDigests:
+        min_mondoo_version: 9.0.0
       size: {}
       tags: {}
       virtualsize: {}
@@ -343,7 +344,6 @@ resources:
     is_private: true
     min_mondoo_version: 5.15.0
   files:
-    fields: {}
     min_mondoo_version: latest
   files.find:
     fields:
@@ -474,7 +474,6 @@ resources:
       uuid: {}
     min_mondoo_version: 5.15.0
   machine:
-    fields: {}
     min_mondoo_version: 5.15.0
   machine.baseboard:
     fields:
@@ -1002,7 +1001,6 @@ resources:
       warndays: {}
     min_mondoo_version: 5.15.0
   sshd:
-    fields: {}
     min_mondoo_version: 5.15.0
   sshd.config:
     fields:


### PR DESCRIPTION
Expose `docker.image.repoDigests`:
```coffee
cnquery> docker.images[0]{*}
docker.images[0]: {
  size: 381060478
  tags: [
    0: "us-docker.pkg.dev/mondoohq/release/click2fix:prod"
  ]
  labels: {
    org.opencontainers.image.created: "2025-09-23T16:44:27Z"
    org.opencontainers.image.revision: "3b89287df3cc3bd1cc5ef8e277789631675abbeb"
    org.opencontainers.image.title: "cnspec"
    org.opencontainers.image.version: "12.2.1"
  }
  repoDigests: [
    0: "us-docker.pkg.dev/mondoohq/release/click2fix@sha256:c839611cea23dfab79632af088ebaa2a6fc7363c57f4707141de8521a27c80a9"
  ]
  virtualsize: 381060478
  id: "sha256:c839611cea23dfab79632af088ebaa2a6fc7363c57f4707141de8521a27c80a9"
}
``` 