### PR TITLE
🎉 os-11.4.52

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "11.4.51",
+	Version: "11.4.52",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by cnquery's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.