### PR TITLE
Pin self-hosted jobs to group instead of label

### DIFF
--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -17,7 +17,8 @@ jobs:
       # Add "id-token" for google-github-actions/auth
       id-token: 'write'
 
-    runs-on: self-hosted
+    runs-on:
+      group: Default
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -38,7 +38,8 @@ jobs:
       # Add "id-token" for google-github-actions/auth
       id-token: 'write'
 
-    runs-on: self-hosted
+    runs-on:
+      group: Default
     environment: prod
     timeout-minutes: 120
     steps:

--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -14,7 +14,8 @@ env:
 jobs:
   # Check if there is any dirty change for generated files
   generated-files:
-    runs-on: self-hosted
+    runs-on:
+      group: Default
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -60,7 +60,8 @@ jobs:
           version: latest
 
   go-test:
-    runs-on: self-hosted
+    runs-on:
+      group: Default
     timeout-minutes: 120
     steps:
       - name: Checkout code
@@ -96,7 +97,8 @@ jobs:
           path: '*.xml'
 
   go-test-integration:
-    runs-on: self-hosted
+    runs-on:
+      group: Default
     timeout-minutes: 120
     steps:
       - name: Checkout code

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -98,7 +98,8 @@ jobs:
 
   provider-build:
     name: "${{ matrix.provider }}"
-    runs-on: self-hosted
+    runs-on:
+      group: Default
     environment: prod
     timeout-minutes: 120
     permissions:


### PR DESCRIPTION
use 
```    
runs-on:
  group: Default
```
instead of the default label for all self-hosted runners:
``` 
runs-on: self-hosted
```