### PR TITLE
🐛 Allow ref's to be used as keys in map lookups

### DIFF
--- a/mql/mql_test.go
+++ b/mql/mql_test.go
@@ -513,3 +513,18 @@ func TestResource_Empty_Panic_Issue6017(t *testing.T) {
 		},
 	})
 }
+
+func TestMapRefLookup(t *testing.T) {
+	x := testutils.InitTester(testutils.LinuxMock())
+	x.TestSimple(t, []testutils.SimpleTest{
+		{
+			Code: `
+				x = {"foo": "bar"}
+				y = "foo"; z = y;
+				x[z] == "bar"
+			`,
+			ResultIndex: 2,
+			Expectation: true,
+		},
+	})
+}


### PR DESCRIPTION
Fixes the following query:
```
x = {"foo": "bar"}
y = "foo"; z = y;
x[z] == "bar"
```