### PR TITLE
🧹 improve mock to allow data loading via constructor

### DIFF
--- a/providers/os/connection/local/statutil/stat_test.go
+++ b/providers/os/connection/local/statutil/stat_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestLinuxStatCmd(t *testing.T) {
 	filepath, _ := filepath.Abs("./testdata/linux.toml")
-	p, err := mock.New(0, filepath, &inventory.Asset{})
+	p, err := mock.New(0, &inventory.Asset{}, mock.WithPath(filepath))
 	require.NoError(t, err)
 
 	statHelper := New(p)
@@ -46,7 +46,7 @@ func TestLinuxStatCmd(t *testing.T) {
 
 func TestOpenbsdStatCmd(t *testing.T) {
 	filepath, _ := filepath.Abs("./testdata/openbsd.toml")
-	p, err := mock.New(0, filepath, &inventory.Asset{})
+	p, err := mock.New(0, &inventory.Asset{}, mock.WithPath(filepath))
 	require.NoError(t, err)
 
 	statHelper := New(p)
@@ -66,7 +66,7 @@ func TestOpenbsdStatCmd(t *testing.T) {
 
 func TestAixStatCmd(t *testing.T) {
 	filepath, _ := filepath.Abs("./testdata/aix.toml")
-	p, err := mock.New(0, filepath, &inventory.Asset{})
+	p, err := mock.New(0, &inventory.Asset{}, mock.WithPath(filepath))
 	require.NoError(t, err)
 
 	statHelper := New(p)

--- a/providers/os/connection/ssh/cat/cat_test.go
+++ b/providers/os/connection/ssh/cat/cat_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestCatFs(t *testing.T) {
 	filepath, _ := filepath.Abs("./testdata/cat.toml")
-	p, err := mock.New(0, filepath, &inventory.Asset{})
+	p, err := mock.New(0, &inventory.Asset{}, mock.WithPath(filepath))
 	require.NoError(t, err)
 
 	flags := map[string]*llx.Primitive{

--- a/providers/os/connection/vagrant/cli_test.go
+++ b/providers/os/connection/vagrant/cli_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestVagrantSshConfigParsing(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/vagrant.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/vagrant.toml"))
 	require.NoError(t, err)
 
 	cmd, err := mock.RunCommand("vagrant ssh-config debian10")
@@ -31,7 +31,7 @@ func TestVagrantSshConfigParsing(t *testing.T) {
 }
 
 func TestVagrantStatusParsing(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/vagrant.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/vagrant.toml"))
 	require.NoError(t, err)
 
 	cmd, err := mock.RunCommand("vagrant status")

--- a/providers/os/connection/winrm/cat/cat_test.go
+++ b/providers/os/connection/winrm/cat/cat_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestCatFs(t *testing.T) {
 	filepath, _ := filepath.Abs("./testdata/winrm.toml")
-	p, err := mock.New(0, filepath, &inventory.Asset{})
+	p, err := mock.New(0, &inventory.Asset{}, mock.WithPath(filepath))
 	require.NoError(t, err)
 
 	catfs := cat.New(p)

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func detectPlatformFromMock(filepath string) (*inventory.Platform, error) {
-	mockConn, err := mock.New(0, filepath, &inventory.Asset{})
+	mockConn, err := mock.New(0, &inventory.Asset{}, mock.WithPath(filepath))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/os/id/aws/aws_test.go
+++ b/providers/os/id/aws/aws_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestDetectInstance(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/instance.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/instance.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -28,7 +28,7 @@ func TestDetectInstance(t *testing.T) {
 }
 
 func TestDetectInstanceArm(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/instancearm.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/instancearm.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -42,7 +42,7 @@ func TestDetectInstanceArm(t *testing.T) {
 }
 
 func TestDetectNotInstance(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/notinstance.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/notinstance.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -56,7 +56,7 @@ func TestDetectNotInstance(t *testing.T) {
 }
 
 func TestDetectContainer(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/container.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/container.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)

--- a/providers/os/id/awsec2/metadata_cmd_test.go
+++ b/providers/os/id/awsec2/metadata_cmd_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestEC2RoleProviderInstanceIdentityUnix(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/instance-identity_document_linux.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/instance-identity_document_linux.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -29,7 +29,7 @@ func TestEC2RoleProviderInstanceIdentityUnix(t *testing.T) {
 }
 
 func TestEC2RoleProviderInstanceIdentityUnixNoName(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/instance-identity_document_linux_no_tags.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/instance-identity_document_linux_no_tags.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -44,7 +44,7 @@ func TestEC2RoleProviderInstanceIdentityUnixNoName(t *testing.T) {
 }
 
 func TestEC2RoleProviderInstanceIdentityWindows(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/instance-identity_document_windows.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/instance-identity_document_windows.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -59,7 +59,7 @@ func TestEC2RoleProviderInstanceIdentityWindows(t *testing.T) {
 }
 
 func TestEC2RoleProviderInstanceIdentityWindowsNoName(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/instance-identity_document_windows_no_tags.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/instance-identity_document_windows_no_tags.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)

--- a/providers/os/id/awsecs/awsecs_test.go
+++ b/providers/os/id/awsecs/awsecs_test.go
@@ -23,7 +23,7 @@ func TestParseECSContainerId(t *testing.T) {
 }
 
 func TestEC2RoleProviderInstanceIdentityUnix(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/container-identity.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/container-identity.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)

--- a/providers/os/id/azcompute/azcompute_test.go
+++ b/providers/os/id/azcompute/azcompute_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestCommandProviderLinux(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/metadata_linux.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/metadata_linux.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -39,7 +39,7 @@ func TestCommandProviderLinux(t *testing.T) {
 }
 
 func TestCommandProviderWindows(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/metadata_windows.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/metadata_windows.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -62,7 +62,7 @@ func TestCommandProviderWindows(t *testing.T) {
 }
 
 func TestCommandProviderLinuxNoLoadbalancerInformation(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/metadata_linux_no_loadbalancer_info.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/metadata_linux_no_loadbalancer_info.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)

--- a/providers/os/id/gce/curl_test.go
+++ b/providers/os/id/gce/curl_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestRawMetadataLinux(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/metadata_raw_linux.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/metadata_raw_linux.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)

--- a/providers/os/id/gce/gce_test.go
+++ b/providers/os/id/gce/gce_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestCommandProviderLinux(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/metadata_linux.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/metadata_linux.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -30,7 +30,7 @@ func TestCommandProviderLinux(t *testing.T) {
 }
 
 func TestCommandProviderWindows(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/metadata_windows.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/metadata_windows.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)

--- a/providers/os/id/gcp/gcp_test.go
+++ b/providers/os/id/gcp/gcp_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestDetectLinuxInstance(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/instance_linux.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/instance_linux.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -28,7 +28,7 @@ func TestDetectLinuxInstance(t *testing.T) {
 }
 
 func TestDetectWindowsInstance(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/instance_windows.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/instance_windows.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -42,7 +42,7 @@ func TestDetectWindowsInstance(t *testing.T) {
 }
 
 func TestNoMatch(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/aws_instance.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/aws_instance.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)

--- a/providers/os/id/hostname/hostname_test.go
+++ b/providers/os/id/hostname/hostname_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestHostnameLinuxEtcHostname(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/hostname_arch.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/hostname_arch.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -27,7 +27,7 @@ func TestHostnameLinuxEtcHostname(t *testing.T) {
 }
 
 func TestHostnameLinux(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/hostname_linux.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/hostname_linux.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -39,7 +39,7 @@ func TestHostnameLinux(t *testing.T) {
 }
 
 func TestHostnameLinuxFqdn(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/hostname_fqdn.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/hostname_fqdn.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -51,7 +51,7 @@ func TestHostnameLinuxFqdn(t *testing.T) {
 }
 
 func TestHostnameLinuxGetentIPv4(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/hostname_getent_hosts_ipv4.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/hostname_getent_hosts_ipv4.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -63,7 +63,7 @@ func TestHostnameLinuxGetentIPv4(t *testing.T) {
 }
 
 func TestHostnameLinuxGetentIPv6(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/hostname_getent_hosts_ipv6.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/hostname_getent_hosts_ipv6.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -75,7 +75,7 @@ func TestHostnameLinuxGetentIPv6(t *testing.T) {
 }
 
 func TestHostnameWindows(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/hostname_windows.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/hostname_windows.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -87,7 +87,7 @@ func TestHostnameWindows(t *testing.T) {
 }
 
 func TestHostnameMacos(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/hostname_macos.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/hostname_macos.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)

--- a/providers/os/id/hypervisor/hypervisor_test.go
+++ b/providers/os/id/hypervisor/hypervisor_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestHypervisorDarwinMachdepCpuFeatures(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/macos_machdep_cpu_features.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/macos_machdep_cpu_features.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -28,7 +28,7 @@ func TestHypervisorDarwinMachdepCpuFeatures(t *testing.T) {
 }
 
 func TestHypervisorDarwinKernHvVMMPresent(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/macos_apple_virtualization_like_tart.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/macos_apple_virtualization_like_tart.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -40,7 +40,7 @@ func TestHypervisorDarwinKernHvVMMPresent(t *testing.T) {
 }
 
 func TestHypervisorDarwinSystemProfiler(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/macos_system_profiler.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/macos_system_profiler.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -52,7 +52,7 @@ func TestHypervisorDarwinSystemProfiler(t *testing.T) {
 }
 
 func TestHypervisorWindowsWin32Manufacturer(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/windows_ciminstance_win32_computersystem_manufacturer.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/windows_ciminstance_win32_computersystem_manufacturer.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -64,7 +64,7 @@ func TestHypervisorWindowsWin32Manufacturer(t *testing.T) {
 }
 
 func TestHypervisorWindowsWmicGetModel(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/windows_wmic_computersystem_get_model.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/windows_wmic_computersystem_get_model.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -76,7 +76,7 @@ func TestHypervisorWindowsWmicGetModel(t *testing.T) {
 }
 
 func TestHypervisorWindowsServer2022SMBIOSBIOSVersion(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/windows_serer_2022_running_hyper_v.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/windows_serer_2022_running_hyper_v.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -88,7 +88,7 @@ func TestHypervisorWindowsServer2022SMBIOSBIOSVersion(t *testing.T) {
 }
 
 func TestHypervisorLinuxDmidecode(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/linux_dmidecode.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/linux_dmidecode.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -100,7 +100,7 @@ func TestHypervisorLinuxDmidecode(t *testing.T) {
 }
 
 func TestHypervisorLinuxSystemdDetectVirt(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/linux_systemd_detect_virt.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/linux_systemd_detect_virt.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -112,7 +112,7 @@ func TestHypervisorLinuxSystemdDetectVirt(t *testing.T) {
 }
 
 func TestHypervisorLinuxDMIProductName(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/linux_dmi_product_name.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/linux_dmi_product_name.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -124,7 +124,7 @@ func TestHypervisorLinuxDMIProductName(t *testing.T) {
 }
 
 func TestHypervisorLinuxOpenShiftVirtualization(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/linux_openshift_virtualization.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/linux_openshift_virtualization.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)

--- a/providers/os/id/ibm/ibm_test.go
+++ b/providers/os/id/ibm/ibm_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestDetectLinuxInstance(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/instance_linux.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/instance_linux.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -36,7 +36,7 @@ func TestDetectLinuxInstance(t *testing.T) {
 }
 
 func TestDetectAIXInstance(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/instance_unix_aix.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/instance_unix_aix.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -56,7 +56,7 @@ func TestDetectAIXInstance(t *testing.T) {
 }
 
 func TestDetectInstanceWithoutMetadataService(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/instance_no_metadata.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/instance_no_metadata.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)

--- a/providers/os/id/networki/interfaces_test.go
+++ b/providers/os/id/networki/interfaces_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestInterfacesDarwin(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/macos.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/macos.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -62,7 +62,7 @@ func TestInterfacesDarwin(t *testing.T) {
 }
 
 func TestInterfacesLinux(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/linux_ip_addr_show_cmd.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/linux_ip_addr_show_cmd.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -109,7 +109,7 @@ func TestInterfacesLinux(t *testing.T) {
 }
 
 func TestInterfacesLinuxFallbackSysNetFilesystem(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/linux_sys_class_net_fs.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/linux_sys_class_net_fs.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -140,7 +140,7 @@ func TestInterfacesLinuxFallbackSysNetFilesystem(t *testing.T) {
 }
 
 func TestInterfacesWindows(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/windows_get_net_ip_cmd.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/windows_get_net_ip_cmd.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -196,7 +196,7 @@ func TestInterfacesWindows(t *testing.T) {
 
 func TestInterfacesWindowsFallbackIpconfigCmd(t *testing.T) {
 	// Note that ipconfig command doesn't have as much information as Get-NetIPAddress
-	conn, err := mock.New(0, "./testdata/windows_ipconfig.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/windows_ipconfig.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)

--- a/providers/os/id/platformid/linux_test.go
+++ b/providers/os/id/platformid/linux_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestLinuxMachineId(t *testing.T) {
 	filepath, _ := filepath.Abs("./testdata/linux_test.toml")
-	provider, err := mock.New(0, filepath, &inventory.Asset{})
+	provider, err := mock.New(0, &inventory.Asset{}, mock.WithPath(filepath))
 	require.NoError(t, err)
 
 	lid := LinuxIdProvider{connection: provider}

--- a/providers/os/id/platformid/osx_test.go
+++ b/providers/os/id/platformid/osx_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestMacOSMachineId(t *testing.T) {
 	filepath, _ := filepath.Abs("./testdata/osx_test.toml")
-	provider, err := mock.New(0, filepath, &inventory.Asset{})
+	provider, err := mock.New(0, &inventory.Asset{}, mock.WithPath(filepath))
 	require.NoError(t, err)
 
 	lid := MacOSIdProvider{connection: provider}

--- a/providers/os/id/platformid/win_test.go
+++ b/providers/os/id/platformid/win_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestGuidWindows(t *testing.T) {
-	provider, err := mock.New(0, "./testdata/guid_windows.toml", &inventory.Asset{})
+	provider, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/guid_windows.toml"))
 	require.NoError(t, err)
 
 	lid := WinIdProvider{connection: provider}

--- a/providers/os/id/vmware/vmtoolsd/vmtoolsd_test.go
+++ b/providers/os/id/vmware/vmtoolsd/vmtoolsd_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestDetectLinuxInstance(t *testing.T) {
-	conn, err := mock.New(0, "../testdata/instance_linux.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("../testdata/instance_linux.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -95,7 +95,7 @@ func TestDetectLinuxInstance(t *testing.T) {
 }
 
 func TestDetectLinuxInstanceWithoutVmtoolsd(t *testing.T) {
-	conn, err := mock.New(0, "../testdata/instance_linux_no_vmtoolsd.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("../testdata/instance_linux_no_vmtoolsd.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -130,7 +130,7 @@ func TestDetectLinuxInstanceWithoutVmtoolsd(t *testing.T) {
 }
 
 func TestDetectWindowsInstance(t *testing.T) {
-	conn, err := mock.New(0, "../testdata/instance_windows.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("../testdata/instance_windows.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -209,7 +209,7 @@ func TestDetectWindowsInstance(t *testing.T) {
 }
 
 func TestDetectWindowsInstanceWithoutVmtoolsd(t *testing.T) {
-	conn, err := mock.New(0, "../testdata/instance_windows_no_vmtoolsd.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("../testdata/instance_windows_no_vmtoolsd.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -245,7 +245,7 @@ func TestDetectWindowsInstanceWithoutVmtoolsd(t *testing.T) {
 }
 
 func TestNoMatch(t *testing.T) {
-	conn, err := mock.New(0, "../testdata/no_vmware_instance.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("../testdata/no_vmware_instance.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)

--- a/providers/os/id/vmware/vmware_test.go
+++ b/providers/os/id/vmware/vmware_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestDetectLinuxInstance(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/instance_linux.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/instance_linux.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -35,7 +35,7 @@ func TestDetectLinuxInstance(t *testing.T) {
 	)
 }
 func TestDetectLinuxInstanceWithoutVmtoolsd(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/instance_linux_no_vmtoolsd.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/instance_linux_no_vmtoolsd.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -51,7 +51,7 @@ func TestDetectLinuxInstanceWithoutVmtoolsd(t *testing.T) {
 }
 
 func TestDetectWindowsInstance(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/instance_windows.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/instance_windows.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -71,7 +71,7 @@ func TestDetectWindowsInstance(t *testing.T) {
 }
 
 func TestDetectWindowsInstanceWithoutVmtoolsd(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/instance_windows_no_vmtoolsd.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/instance_windows_no_vmtoolsd.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -87,7 +87,7 @@ func TestDetectWindowsInstanceWithoutVmtoolsd(t *testing.T) {
 }
 
 func TestNoMatch(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/no_vmware_instance.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/no_vmware_instance.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -521,7 +521,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 
 		// Do not expose mock connection as a supported type
 		case "mock":
-			conn, err = mock.New(connId, "", asset)
+			conn, err = mock.New(connId, asset)
 
 		default:
 			return nil, plugin.ErrUnsupportedProvider

--- a/providers/os/resources/groups/dscache_test.go
+++ b/providers/os/resources/groups/dscache_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestParseDscacheutilResult(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/osx.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/osx.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/os/resources/groups/etcgroups_test.go
+++ b/providers/os/resources/groups/etcgroups_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestParseLinuxEtcGroups(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/debian.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/debian.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +42,7 @@ func TestParseLinuxEtcGroups(t *testing.T) {
 }
 
 func TestParseFreebsd12EtcGroups(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/freebsd12.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/freebsd12.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,11 +71,11 @@ func TestParseFreebsd12EtcGroups(t *testing.T) {
 }
 
 func TestUnixGroupManager(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/debian.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Family: []string{"unix"},
 		},
-	})
+	}, mock.WithPath("./testdata/debian.toml"))
 	require.NoError(t, err)
 	gm := &UnixGroupManager{
 		conn: mock,

--- a/providers/os/resources/groups/manager_test.go
+++ b/providers/os/resources/groups/manager_test.go
@@ -14,11 +14,11 @@ import (
 )
 
 func TestManagerDebian(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/debian.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Family: []string{"unix", "linux", "debian"},
 		},
-	})
+	}, mock.WithPath("./testdata/debian.toml"))
 	require.NoError(t, err)
 
 	mm, err := groups.ResolveManager(mock)
@@ -36,11 +36,11 @@ func TestManagerDebian(t *testing.T) {
 }
 
 func TestManagerMacos(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/osx.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Family: []string{"darwin"},
 		},
-	})
+	}, mock.WithPath("./testdata/osx.toml"))
 	require.NoError(t, err)
 
 	mm, err := groups.ResolveManager(mock)
@@ -58,11 +58,11 @@ func TestManagerMacos(t *testing.T) {
 }
 
 func TestManagerFreebsd(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/freebsd12.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Family: []string{"unix", "bsd"},
 		},
-	})
+	}, mock.WithPath("./testdata/freebsd12.toml"))
 	require.NoError(t, err)
 
 	mm, err := groups.ResolveManager(mock)
@@ -80,11 +80,11 @@ func TestManagerFreebsd(t *testing.T) {
 }
 
 func TestManagerWindows(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/windows.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Family: []string{"windows"},
 		},
-	})
+	}, mock.WithPath("./testdata/windows.toml"))
 	require.NoError(t, err)
 
 	mm, err := groups.ResolveManager(mock)

--- a/providers/os/resources/groups/ps1getlocalgroup_test.go
+++ b/providers/os/resources/groups/ps1getlocalgroup_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestWindowsGroupsParserFromMock(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/windows.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/windows.toml"))
 	require.NoError(t, err)
 
 	f, err := mock.RunCommand("powershell -c \"Get-LocalGroup | ConvertTo-Json\"")

--- a/providers/os/resources/kernel/manager_test.go
+++ b/providers/os/resources/kernel/manager_test.go
@@ -13,13 +13,13 @@ import (
 )
 
 func TestManagerDebian(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/debian.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:    "debian",
 			Version: "8.0",
 			Family:  []string{"debian", "linux"},
 		},
-	})
+	}, mock.WithPath("./testdata/debian.toml"))
 	require.NoError(t, err)
 
 	mm, err := ResolveManager(mock)
@@ -31,13 +31,13 @@ func TestManagerDebian(t *testing.T) {
 }
 
 func TestManagerCentos(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/centos7.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:    "centos",
 			Version: "6.10",
 			Family:  []string{"linux", "redhat"},
 		},
-	})
+	}, mock.WithPath("./testdata/centos7.toml"))
 	require.NoError(t, err)
 
 	mm, err := ResolveManager(mock)
@@ -57,13 +57,13 @@ func TestManagerCentos(t *testing.T) {
 }
 
 func TestManagerAmazonLinux1(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/amznlinux1.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:    "amazonlinux",
 			Version: "2018.03",
 			Family:  []string{"linux"},
 		},
-	})
+	}, mock.WithPath("./testdata/amznlinux1.toml"))
 	require.NoError(t, err)
 
 	mm, err := ResolveManager(mock)
@@ -83,12 +83,12 @@ func TestManagerAmazonLinux1(t *testing.T) {
 }
 
 func TestManagerMacos(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/osx.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "macos",
 			Family: []string{"unix", "darwin"},
 		},
-	})
+	}, mock.WithPath("./testdata/osx.toml"))
 	require.NoError(t, err)
 
 	mm, err := ResolveManager(mock)
@@ -108,12 +108,12 @@ func TestManagerMacos(t *testing.T) {
 }
 
 func TestManagerFreebsd(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/freebsd14.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "freebsd",
 			Family: []string{"bsd", "unix", "os"},
 		},
-	})
+	}, mock.WithPath("./testdata/freebsd14.toml"))
 	require.NoError(t, err)
 
 	mm, err := ResolveManager(mock)
@@ -129,12 +129,12 @@ func TestManagerFreebsd(t *testing.T) {
 }
 
 func TestManagerOpenBSD(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/openbsd77.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "openbsd",
 			Family: []string{"bsd", "unix", "os"},
 		},
-	})
+	}, mock.WithPath("./testdata/openbsd77.toml"))
 	require.NoError(t, err)
 
 	mm, err := ResolveManager(mock)
@@ -149,12 +149,12 @@ func TestManagerOpenBSD(t *testing.T) {
 }
 
 func TestManagerAIX(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/aix.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "aix",
 			Family: []string{"unix"},
 		},
-	})
+	}, mock.WithPath("./testdata/aix.toml"))
 	require.NoError(t, err)
 
 	mm, err := ResolveManager(mock)

--- a/providers/os/resources/kernel/modules_test.go
+++ b/providers/os/resources/kernel/modules_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestLsmodParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/debian.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/debian.toml"))
 	require.NoError(t, err)
 
 	f, err := mock.RunCommand("/sbin/lsmod")
@@ -32,7 +32,7 @@ func TestLsmodParser(t *testing.T) {
 }
 
 func TestLinuxProcModulesParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/debian.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/debian.toml"))
 	require.NoError(t, err)
 
 	f, err := mock.FileSystem().Open("/proc/modules")
@@ -52,7 +52,7 @@ func TestLinuxProcModulesParser(t *testing.T) {
 }
 
 func TestKldstatParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/freebsd14.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/freebsd14.toml"))
 	require.NoError(t, err)
 
 	f, err := mock.RunCommand("kldstat")
@@ -71,7 +71,7 @@ func TestKldstatParser(t *testing.T) {
 }
 
 func TestKextstatParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/osx.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/osx.toml"))
 	require.NoError(t, err)
 
 	f, err := mock.RunCommand("kextstat")

--- a/providers/os/resources/kernel/sysctl_test.go
+++ b/providers/os/resources/kernel/sysctl_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestSysctlDebian(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/debian.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/debian.toml"))
 	require.NoError(t, err)
 
 	c, err := mock.RunCommand("/sbin/sysctl -a")
@@ -27,7 +27,7 @@ func TestSysctlDebian(t *testing.T) {
 }
 
 func TestSysctlMacos(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/osx.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/osx.toml"))
 	require.NoError(t, err)
 
 	c, err := mock.RunCommand("sysctl -a")
@@ -41,7 +41,7 @@ func TestSysctlMacos(t *testing.T) {
 }
 
 func TestSysctlFreebsd14(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/freebsd14.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/freebsd14.toml"))
 	require.NoError(t, err)
 
 	c, err := mock.RunCommand("sysctl -a")
@@ -55,7 +55,7 @@ func TestSysctlFreebsd14(t *testing.T) {
 }
 
 func TestSysctlFreebsd15(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/freebsd15.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/freebsd15.toml"))
 	require.NoError(t, err)
 
 	c, err := mock.RunCommand("sysctl -a")
@@ -69,7 +69,7 @@ func TestSysctlFreebsd15(t *testing.T) {
 }
 
 func TestSysctlOpenBSD(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/openbsd77.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/openbsd77.toml"))
 	require.NoError(t, err)
 
 	c, err := mock.RunCommand("sysctl -a")

--- a/providers/os/resources/logindefs/logindefs_test.go
+++ b/providers/os/resources/logindefs/logindefs_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestLoginDefsParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/debian.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/debian.toml"))
 	require.NoError(t, err)
 
 	f, err := mock.FileSystem().Open("/etc/login.defs")

--- a/providers/os/resources/macos/preferences_test.go
+++ b/providers/os/resources/macos/preferences_test.go
@@ -13,13 +13,13 @@ import (
 )
 
 func TestPreferences(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/user_preferences.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:    "macos",
 			Version: "13.0",
 			Family:  []string{"macos"},
 		},
-	})
+	}, mock.WithPath("./testdata/user_preferences.toml"))
 	require.NoError(t, err)
 
 	prefs := &Preferences{

--- a/providers/os/resources/macos/systemsetup_test.go
+++ b/providers/os/resources/macos/systemsetup_test.go
@@ -15,13 +15,13 @@ import (
 )
 
 func TestSystemSetup(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/systemsetup.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:    "macos",
 			Version: "13.0",
 			Family:  []string{"macos"},
 		},
-	})
+	}, mock.WithPath("./testdata/systemsetup.toml"))
 	require.NoError(t, err)
 
 	so := SystemSetupCmdOutput{}

--- a/providers/os/resources/mount/manager_test.go
+++ b/providers/os/resources/mount/manager_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 func TestManagerDebian(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/debian.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{Family: []string{"linux"}},
-	})
+	}, mock.WithPath("./testdata/debian.toml"))
 	require.NoError(t, err)
 
 	mm, err := mount.ResolveManager(mock)
@@ -28,9 +28,9 @@ func TestManagerDebian(t *testing.T) {
 }
 
 func TestManagerMacos(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/osx.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{Family: []string{"unix"}},
-	})
+	}, mock.WithPath("./testdata/osx.toml"))
 	require.NoError(t, err)
 
 	mm, err := mount.ResolveManager(mock)
@@ -42,9 +42,9 @@ func TestManagerMacos(t *testing.T) {
 }
 
 func TestManagerFreebsd(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/freebsd12.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{Family: []string{"unix"}},
-	})
+	}, mock.WithPath("./testdata/freebsd12.toml"))
 	require.NoError(t, err)
 
 	mm, err := mount.ResolveManager(mock)

--- a/providers/os/resources/mount/mount_test.go
+++ b/providers/os/resources/mount/mount_test.go
@@ -16,9 +16,9 @@ import (
 )
 
 func TestMountLinuxParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/debian.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{Family: []string{"linux"}},
-	})
+	}, mock.WithPath("./testdata/debian.toml"))
 	require.NoError(t, err)
 
 	f, err := mock.RunCommand("mount")
@@ -43,9 +43,9 @@ func TestMountLinuxParser(t *testing.T) {
 }
 
 func TestMountMacosParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/osx.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{Family: []string{"unix"}},
-	})
+	}, mock.WithPath("./testdata/osx.toml"))
 	require.NoError(t, err)
 
 	f, err := mock.RunCommand("mount")
@@ -71,9 +71,9 @@ func TestMountMacosParser(t *testing.T) {
 }
 
 func TestMountFreeBsdParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/freebsd12.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{Family: []string{"unix"}},
-	})
+	}, mock.WithPath("./testdata/freebsd12.toml"))
 	require.NoError(t, err)
 
 	f, err := mock.RunCommand("mount")
@@ -97,9 +97,9 @@ func TestMountFreeBsdParser(t *testing.T) {
 }
 
 func TestProcModulesParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/debian.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{Family: []string{"linux"}},
-	})
+	}, mock.WithPath("./testdata/debian.toml"))
 	require.NoError(t, err)
 
 	f, err := mock.FileSystem().Open("/proc/mounts")

--- a/providers/os/resources/networkinterface/interface_test.go
+++ b/providers/os/resources/networkinterface/interface_test.go
@@ -15,11 +15,11 @@ import (
 )
 
 func TestWindowsRemoteInterface(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/windows.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name: "windows",
 		},
-	})
+	}, mock.WithPath("./testdata/windows.toml"))
 	require.NoError(t, err)
 
 	ifaces := networkinterface.New(mock)
@@ -54,11 +54,11 @@ func TestMacOsRegex(t *testing.T) {
 }
 
 func TestMacOSRemoteInterface(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/macos.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name: "macos",
 		},
-	})
+	}, mock.WithPath("./testdata/macos.toml"))
 	require.NoError(t, err)
 
 	ifaces := networkinterface.New(mock)
@@ -85,12 +85,12 @@ func TestMacOSRemoteInterface(t *testing.T) {
 }
 
 func TestLinuxRemoteInterface(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/linux_remote.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "linux",
 			Family: []string{"linux"},
 		},
-	})
+	}, mock.WithPath("./testdata/linux_remote.toml"))
 	require.NoError(t, err)
 
 	ifaces := networkinterface.New(mock)
@@ -124,12 +124,12 @@ func TestLinuxRemoteInterface(t *testing.T) {
 }
 
 func TestLinuxRemoteInterfaceFlannel(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/linux_flannel.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "linux",
 			Family: []string{"linux"},
 		},
-	})
+	}, mock.WithPath("./testdata/linux_flannel.toml"))
 	require.NoError(t, err)
 
 	ifaces := networkinterface.New(mock)

--- a/providers/os/resources/packages/apk_packages_test.go
+++ b/providers/os/resources/packages/apk_packages_test.go
@@ -22,7 +22,7 @@ func TestAlpineApkdbParser(t *testing.T) {
 		},
 	}
 
-	mock, err := mock.New(0, "./testdata/packages_apk.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/packages_apk.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -237,7 +237,7 @@ func TestAlpineApkdbParser(t *testing.T) {
 }
 
 func TestApkUpdateParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/updates_apk.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/updates_apk.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/os/resources/packages/dpkg_packages_test.go
+++ b/providers/os/resources/packages/dpkg_packages_test.go
@@ -23,7 +23,7 @@ func TestDpkgParser(t *testing.T) {
 		},
 	}
 
-	mock, err := mock.New(0, "./testdata/packages_dpkg.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/packages_dpkg.toml"))
 	require.NoError(t, err)
 	f, err := mock.FileSystem().Open("/var/lib/dpkg/status")
 	require.NoError(t, err)
@@ -131,7 +131,7 @@ func TestDpkgParserStatusD(t *testing.T) {
 		},
 	}
 
-	mock, err := mock.New(0, "./testdata/packages_dpkg_statusd.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/packages_dpkg_statusd.toml"))
 	require.NoError(t, err)
 	f, err := mock.FileSystem().Open("/var/lib/dpkg/status.d/base")
 	require.NoError(t, err)
@@ -161,7 +161,7 @@ and the text of several common licenses in use on Debian systems.`,
 }
 
 func TestDpkgUpdateParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/updates_dpkg.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/updates_dpkg.toml"))
 	require.NoError(t, err)
 	c, err := mock.RunCommand("DEBIAN_FRONTEND=noninteractive apt-get upgrade --dry-run")
 	require.NoError(t, err)

--- a/providers/os/resources/packages/macos_packages_test.go
+++ b/providers/os/resources/packages/macos_packages_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestMacOsXPackageParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/packages_macos.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/packages_macos.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/os/resources/packages/opkg_packages_test.go
+++ b/providers/os/resources/packages/opkg_packages_test.go
@@ -48,7 +48,7 @@ firewall - 2016-11-29-1`
 }
 
 func TestOpkgStatusParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/packages_opkg_statusfile.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/packages_opkg_statusfile.toml"))
 	require.NoError(t, err)
 	f, err := mock.FileSystem().Open("/usr/lib/opkg/status")
 	require.NoError(t, err)
@@ -72,11 +72,11 @@ func TestOpkgStatusParser(t *testing.T) {
 
 func TestOpkgManager(t *testing.T) {
 	filepath, _ := filepath.Abs("./testdata/packages_opkg.toml")
-	conn, err := mock.New(0, filepath, &inventory.Asset{
+	conn, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name: "openwrt",
 		},
-	})
+	}, mock.WithPath(filepath))
 	require.NoError(t, err)
 
 	pms, err := packages.ResolveSystemPkgManagers(conn)

--- a/providers/os/resources/packages/rpm_packages_test.go
+++ b/providers/os/resources/packages/rpm_packages_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestRedhat8Parser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/packages_redhat8.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/packages_redhat8.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/os/resources/packages/rpm_updates_test.go
+++ b/providers/os/resources/packages/rpm_updates_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestRpmUpdateParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/updates_rpm.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/updates_rpm.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,7 +38,7 @@ func TestRpmUpdateParser(t *testing.T) {
 }
 
 func TestZypperUpdateParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/updates_zypper.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/updates_zypper.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/os/resources/packages/solaris_packages_test.go
+++ b/providers/os/resources/packages/solaris_packages_test.go
@@ -86,11 +86,11 @@ pkg://solaris/compress/p7zip@9.20.1,5.11-0.175.1.0.0.24.0:20120904T170605Z   i--
 
 func TestSolarisManager(t *testing.T) {
 	filepath, _ := filepath.Abs("./testdata/packages_solaris11.toml")
-	conn, err := mock.New(0, filepath, &inventory.Asset{
+	conn, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name: "solaris",
 		},
-	})
+	}, mock.WithPath(filepath))
 	require.NoError(t, err)
 
 	pms, err := ResolveSystemPkgManagers(conn)

--- a/providers/os/resources/packages/windows_packages_test.go
+++ b/providers/os/resources/packages/windows_packages_test.go
@@ -54,11 +54,11 @@ func TestWindowsAppPackagesParser(t *testing.T) {
 }
 
 func TestWindowsAppxPackagesParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/windows_2019.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Family: []string{"windows"},
 		},
-	})
+	}, mock.WithPath("./testdata/windows_2019.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,11 +122,11 @@ func TestWindowsAppxPackagesParser(t *testing.T) {
 }
 
 func TestWindowsHotFixParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/windows_2019.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Family: []string{"windows"},
 		},
-	})
+	}, mock.WithPath("./testdata/windows_2019.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/os/resources/processes/manager_test.go
+++ b/providers/os/resources/processes/manager_test.go
@@ -14,11 +14,11 @@ import (
 )
 
 func TestManagerDebian(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/debian.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Family: []string{"linux", "unix"},
 		},
-	})
+	}, mock.WithPath("./testdata/debian.toml"))
 	require.NoError(t, err)
 
 	mm, err := processes.ResolveManager(mock)
@@ -30,11 +30,11 @@ func TestManagerDebian(t *testing.T) {
 }
 
 func TestManagerMacos(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/osx.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Family: []string{"unix", "darwin"},
 		},
-	})
+	}, mock.WithPath("./testdata/osx.toml"))
 	require.NoError(t, err)
 
 	mm, err := processes.ResolveManager(mock)
@@ -46,11 +46,11 @@ func TestManagerMacos(t *testing.T) {
 }
 
 func TestManagerFreebsd(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/freebsd12.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Family: []string{"unix", "freebsd"},
 		},
-	})
+	}, mock.WithPath("./testdata/freebsd12.toml"))
 	require.NoError(t, err)
 
 	mm, err := processes.ResolveManager(mock)
@@ -62,7 +62,7 @@ func TestManagerFreebsd(t *testing.T) {
 }
 
 // func TestManagerWindows(t *testing.T) {
-//  mock, err := mock.New(0, "./testdata/windows.toml")
+//  mock, err := mock.New(0, nil, mock.WithPath("./testdata/windows.toml"))
 // 	require.NoError(t, err)
 // 	m, err := motor.New(mock)
 // 	require.NoError(t, err)

--- a/providers/os/resources/processes/unixps_test.go
+++ b/providers/os/resources/processes/unixps_test.go
@@ -17,11 +17,11 @@ import (
 )
 
 func TestLinuxPSProcessParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/debian.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Family: []string{"linux"},
 		},
-	})
+	}, mock.WithPath("./testdata/debian.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,11 +49,11 @@ func TestLinuxPSProcessParser(t *testing.T) {
 }
 
 func TestOSxPSProcessParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/osx.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Family: []string{"unix"},
 		},
-	})
+	}, mock.WithPath("./testdata/osx.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,11 +77,11 @@ func TestOSxPSProcessParser(t *testing.T) {
 }
 
 func TestUnixPSProcessParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/freebsd12.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Family: []string{"unix"},
 		},
-	})
+	}, mock.WithPath("./testdata/freebsd12.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,12 +105,12 @@ func TestUnixPSProcessParser(t *testing.T) {
 }
 
 func TestAixPSProcessParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/aix72.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "aix",
 			Family: []string{"unix"},
 		},
-	})
+	}, mock.WithPath("./testdata/aix72.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/os/resources/procfs/cpu_info_test.go
+++ b/providers/os/resources/procfs/cpu_info_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestParseProcCpuX64(t *testing.T) {
-	trans, err := mock.New(0, "./testdata/cpu-info-x64.toml", &inventory.Asset{})
+	trans, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/cpu-info-x64.toml"))
 	require.NoError(t, err)
 
 	f, err := trans.FileSystem().Open("/proc/cpuinfo")
@@ -71,7 +71,7 @@ func TestParseProcCpuX64(t *testing.T) {
 }
 
 func TestParseProcCpuArm(t *testing.T) {
-	trans, err := mock.New(0, "./testdata/cpu-info-aarch64.toml", &inventory.Asset{})
+	trans, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/cpu-info-aarch64.toml"))
 	require.NoError(t, err)
 
 	f, err := trans.FileSystem().Open("/proc/cpuinfo")

--- a/providers/os/resources/procfs/processes_test.go
+++ b/providers/os/resources/procfs/processes_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestParseProcessStatus(t *testing.T) {
-	trans, err := mock.New(0, "./testdata/process-pid1.toml", &inventory.Asset{})
+	trans, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/process-pid1.toml"))
 	require.NoError(t, err)
 
 	f, err := trans.FileSystem().Open("/proc/1/status")
@@ -29,7 +29,7 @@ func TestParseProcessStatus(t *testing.T) {
 }
 
 func TestParseProcessCmdline(t *testing.T) {
-	trans, err := mock.New(0, "./testdata/process-pid1.toml", &inventory.Asset{})
+	trans, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/process-pid1.toml"))
 	require.NoError(t, err)
 
 	f, err := trans.FileSystem().Open("/proc/1/cmdline")

--- a/providers/os/resources/reboot/debian_test.go
+++ b/providers/os/resources/reboot/debian_test.go
@@ -15,12 +15,12 @@ import (
 
 func TestRebootLinux(t *testing.T) {
 	filepath, _ := filepath.Abs("./testdata/ubuntu_reboot.toml")
-	provider, err := mock.New(0, filepath, &inventory.Asset{
+	provider, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "ubuntu",
 			Family: []string{"linux", "debian", "ubuntu"},
 		},
-	})
+	}, mock.WithPath(filepath))
 	require.NoError(t, err)
 
 	lb := DebianReboot{conn: provider}
@@ -31,12 +31,12 @@ func TestRebootLinux(t *testing.T) {
 
 func TestNoRebootLinux(t *testing.T) {
 	filepath, _ := filepath.Abs("./testdata/ubuntu_noreboot.toml")
-	provider, err := mock.New(0, filepath, &inventory.Asset{
+	provider, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "ubuntu",
 			Family: []string{"linux", "debian", "ubuntu"},
 		},
-	})
+	}, mock.WithPath(filepath))
 	require.NoError(t, err)
 
 	lb := DebianReboot{conn: provider}

--- a/providers/os/resources/reboot/reboot_test.go
+++ b/providers/os/resources/reboot/reboot_test.go
@@ -15,12 +15,12 @@ import (
 
 func TestRebootOnUbuntu(t *testing.T) {
 	filepath, _ := filepath.Abs("./testdata/ubuntu_reboot.toml")
-	mock, err := mock.New(0, filepath, &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "ubuntu",
 			Family: []string{"linux", "debian", "ubuntu"},
 		},
-	})
+	}, mock.WithPath(filepath))
 	require.NoError(t, err)
 
 	lb, err := New(mock)
@@ -33,12 +33,12 @@ func TestRebootOnUbuntu(t *testing.T) {
 
 func TestRebootOnRhel(t *testing.T) {
 	filepath, _ := filepath.Abs("./testdata/redhat_kernel_reboot.toml")
-	mock, err := mock.New(0, filepath, &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "redhat",
 			Family: []string{"linux", "redhat"},
 		},
-	})
+	}, mock.WithPath(filepath))
 	require.NoError(t, err)
 
 	lb, err := New(mock)
@@ -52,12 +52,12 @@ func TestRebootOnRhel(t *testing.T) {
 
 func TestRebootOnWindows(t *testing.T) {
 	filepath, _ := filepath.Abs("./testdata/windows_reboot.toml")
-	mock, err := mock.New(0, filepath, &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "windows",
 			Family: []string{"windows"},
 		},
-	})
+	}, mock.WithPath(filepath))
 	require.NoError(t, err)
 
 	lb, err := New(mock)

--- a/providers/os/resources/reboot/rhel_test.go
+++ b/providers/os/resources/reboot/rhel_test.go
@@ -15,12 +15,12 @@ import (
 
 func TestRhelKernelLatest(t *testing.T) {
 	filepath, _ := filepath.Abs("./testdata/redhat_kernel_reboot.toml")
-	mock, err := mock.New(0, filepath, &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "redhat",
 			Family: []string{"linux", "redhat"},
 		},
-	})
+	}, mock.WithPath(filepath))
 	require.NoError(t, err)
 
 	lb := RpmNewestKernel{conn: mock}
@@ -31,13 +31,13 @@ func TestRhelKernelLatest(t *testing.T) {
 
 func TestAmznContainerWithoutKernel(t *testing.T) {
 	filepath, _ := filepath.Abs("./testdata/amzn_kernel_container.toml")
-	mock, err := mock.New(0, filepath, &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:    "amazonlinux",
 			Version: "2018.03",
 			Family:  []string{"linux"},
 		},
-	})
+	}, mock.WithPath(filepath))
 	require.NoError(t, err)
 
 	lb := RpmNewestKernel{conn: mock}
@@ -49,13 +49,13 @@ func TestAmznContainerWithoutKernel(t *testing.T) {
 
 func TestAmznEc2Kernel(t *testing.T) {
 	filepath, _ := filepath.Abs("./testdata/amzn_kernel_ec2.toml")
-	mock, err := mock.New(0, filepath, &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:    "amazonlinux",
 			Version: "2018.03",
 			Family:  []string{"linux"},
 		},
-	})
+	}, mock.WithPath(filepath))
 	require.NoError(t, err)
 
 	lb := RpmNewestKernel{conn: mock}

--- a/providers/os/resources/services/alpine_openrc_test.go
+++ b/providers/os/resources/services/alpine_openrc_test.go
@@ -13,11 +13,11 @@ import (
 )
 
 func TestManagerAlpineImage(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/alpine-image.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name: "alpine",
 		},
-	})
+	}, mock.WithPath("./testdata/alpine-image.toml"))
 	require.NoError(t, err)
 
 	mm, err := ResolveManager(mock)
@@ -45,11 +45,11 @@ func TestManagerAlpineImage(t *testing.T) {
 }
 
 func TestManagerAlpineContainer(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/alpine-container.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name: "alpine",
 		},
-	})
+	}, mock.WithPath("./testdata/alpine-container.toml"))
 	require.NoError(t, err)
 
 	mm, err := ResolveManager(mock)

--- a/providers/os/resources/services/bsdinit_test.go
+++ b/providers/os/resources/services/bsdinit_test.go
@@ -13,12 +13,12 @@ import (
 )
 
 func TestParseBsdInit(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/freebsd12.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "freebsd",
 			Family: []string{"unix"},
 		},
-	})
+	}, mock.WithPath("./testdata/freebsd12.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/os/resources/services/launchd_test.go
+++ b/providers/os/resources/services/launchd_test.go
@@ -13,12 +13,12 @@ import (
 )
 
 func TestParseServiceLaunchD(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/osx.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "macos",
 			Family: []string{"unix", "darwin"},
 		},
-	})
+	}, mock.WithPath("./testdata/osx.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/os/resources/services/manager_test.go
+++ b/providers/os/resources/services/manager_test.go
@@ -13,12 +13,12 @@ import (
 )
 
 func TestManagerMacos(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/osx.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "macos",
 			Family: []string{"unix", "darwin"},
 		},
-	})
+	}, mock.WithPath("./testdata/osx.toml"))
 	require.NoError(t, err)
 
 	mm, err := services.ResolveManager(mock)
@@ -30,12 +30,12 @@ func TestManagerMacos(t *testing.T) {
 }
 
 func TestManagerFreebsd(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/freebsd12.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "freebsd",
 			Family: []string{"unix"},
 		},
-	})
+	}, mock.WithPath("./testdata/freebsd12.toml"))
 	require.NoError(t, err)
 
 	mm, err := services.ResolveManager(mock)
@@ -47,12 +47,12 @@ func TestManagerFreebsd(t *testing.T) {
 }
 
 func TestManagerDragonflybsd5(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/dragonfly5.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "dragonflybsd",
 			Family: []string{"unix"},
 		},
-	})
+	}, mock.WithPath("./testdata/dragonfly5.toml"))
 	require.NoError(t, err)
 
 	mm, err := services.ResolveManager(mock)
@@ -64,12 +64,12 @@ func TestManagerDragonflybsd5(t *testing.T) {
 }
 
 func TestManagerOpenBsd6(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/openbsd6.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "openbsd",
 			Family: []string{"unix"},
 		},
-	})
+	}, mock.WithPath("./testdata/openbsd6.toml"))
 	require.NoError(t, err)
 
 	mm, err := services.ResolveManager(mock)
@@ -81,12 +81,12 @@ func TestManagerOpenBsd6(t *testing.T) {
 }
 
 func TestManagerWindows(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/windows2019.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "windows",
 			Family: []string{"windows"},
 		},
-	})
+	}, mock.WithPath("./testdata/windows2019.toml"))
 	require.NoError(t, err)
 
 	mm, err := services.ResolveManager(mock)
@@ -98,13 +98,13 @@ func TestManagerWindows(t *testing.T) {
 }
 
 func TestManagerUbuntu2204(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/ubuntu2204.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:    "ubuntu",
 			Version: "22.04",
 			Family:  []string{"ubuntu", "linux"},
 		},
-	})
+	}, mock.WithPath("./testdata/ubuntu2204.toml"))
 	require.NoError(t, err)
 
 	mm, err := services.ResolveManager(mock)
@@ -116,13 +116,13 @@ func TestManagerUbuntu2204(t *testing.T) {
 }
 
 func TestManagerPhoton(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/photon.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:    "photon",
 			Version: "8.1.10",
 			Family:  []string{"photon", "linux"},
 		},
-	})
+	}, mock.WithPath("./testdata/photon.toml"))
 	require.NoError(t, err)
 
 	mm, err := services.ResolveManager(mock)

--- a/providers/os/resources/services/openbsdrcctl_test.go
+++ b/providers/os/resources/services/openbsdrcctl_test.go
@@ -13,11 +13,11 @@ import (
 )
 
 func TestParseOpenbsdServicesRunning(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/openbsd6.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name: "openbsd",
 		},
-	})
+	}, mock.WithPath("./testdata/openbsd6.toml"))
 	require.NoError(t, err)
 
 	openbsd := OpenBsdRcctlServiceManager{conn: mock}

--- a/providers/os/resources/services/systemd_test.go
+++ b/providers/os/resources/services/systemd_test.go
@@ -45,12 +45,12 @@ Nov 03 06:51:44 mondoopad avahi-daemon[1219]: Registering new address record for
 }
 
 func TestParseServiceSystemDUnitFiles(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/ubuntu2204.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "ubuntu",
 			Family: []string{"ubuntu", "linux"},
 		},
-	})
+	}, mock.WithPath("./testdata/ubuntu2204.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,12 +78,12 @@ func TestParseServiceSystemDUnitFiles(t *testing.T) {
 }
 
 func TestParseServiceSystemDUnitFilesPhoton(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/photon.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "photon",
 			Family: []string{"redhat", "linux"},
 		},
-	})
+	}, mock.WithPath("./testdata/photon.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/os/resources/services/sysv_test.go
+++ b/providers/os/resources/services/sysv_test.go
@@ -13,12 +13,12 @@ import (
 )
 
 func TestParseSysvServices(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/amzn1.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "amazonlinux",
 			Family: []string{"linux"},
 		},
-	})
+	}, mock.WithPath("./testdata/amzn1.toml"))
 	require.NoError(t, err)
 
 	sysv := SysVServiceManager{conn: mock}
@@ -28,12 +28,12 @@ func TestParseSysvServices(t *testing.T) {
 }
 
 func TestParseSysvServicesRunlevel(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/amzn1.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "amazonlinux",
 			Family: []string{"linux"},
 		},
-	})
+	}, mock.WithPath("./testdata/amzn1.toml"))
 	require.NoError(t, err)
 
 	sysv := SysVServiceManager{conn: mock}
@@ -44,12 +44,12 @@ func TestParseSysvServicesRunlevel(t *testing.T) {
 }
 
 func TestParseSysvServicesRunning(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/amzn1.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "amazonlinux",
 			Family: []string{"linux"},
 		},
-	})
+	}, mock.WithPath("./testdata/amzn1.toml"))
 	require.NoError(t, err)
 
 	sysv := SysVServiceManager{conn: mock}

--- a/providers/os/resources/services/upstart_test.go
+++ b/providers/os/resources/services/upstart_test.go
@@ -13,12 +13,12 @@ import (
 )
 
 func TestParseUpstartServicesRunning(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/ubuntu1404.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "ubuntu",
 			Family: []string{"linux", "ubuntu"},
 		},
-	})
+	}, mock.WithPath("./testdata/ubuntu1404.toml"))
 	require.NoError(t, err)
 
 	upstart := UpstartServiceManager{SysVServiceManager{conn: mock}}

--- a/providers/os/resources/shadow/shadow_test.go
+++ b/providers/os/resources/shadow/shadow_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestParseShadow(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/debian.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/debian.toml"))
 	require.NoError(t, err)
 
 	f, err := mock.FileSystem().Open("/etc/shadow")

--- a/providers/os/resources/smbios/smbios_test.go
+++ b/providers/os/resources/smbios/smbios_test.go
@@ -86,7 +86,7 @@ func Test_WindowsSmbiosChassis_AdHoc(t *testing.T) {
 func TestManagerUnixFamily(t *testing.T) {
 	// special case where we detect a unix system other than darwin
 	// use centos and change the platform family
-	conn, err := mock.New(0, "./testdata/centos.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/centos.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -130,7 +130,7 @@ func TestManagerUnixFamily(t *testing.T) {
 }
 
 func TestManagerCentos(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/centos.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/centos.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -173,7 +173,7 @@ func TestManagerCentos(t *testing.T) {
 }
 
 func TestManagerMacos(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/macos.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/macos.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -216,7 +216,7 @@ func TestManagerMacos(t *testing.T) {
 }
 
 func TestManagerWindows(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/windows.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/windows.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
@@ -259,7 +259,7 @@ func TestManagerWindows(t *testing.T) {
 }
 
 func TestManagerAIX(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/aix.toml", &inventory.Asset{})
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/aix.toml"))
 	require.NoError(t, err)
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)

--- a/providers/os/resources/updates/suse_updates_test.go
+++ b/providers/os/resources/updates/suse_updates_test.go
@@ -13,9 +13,9 @@ import (
 
 // SUSE OS updates
 func TestZypperPatchParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/updates_zypper.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{Name: "suse"},
-	})
+	}, mock.WithPath("./testdata/updates_zypper.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/os/resources/updates/win_updates_test.go
+++ b/providers/os/resources/updates/win_updates_test.go
@@ -16,9 +16,9 @@ import (
 )
 
 func TestWinOSUpdatesParser(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/updates_win.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{Name: "windows"},
-	})
+	}, mock.WithPath("./testdata/updates_win.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/os/resources/uptime/uptime_test.go
+++ b/providers/os/resources/uptime/uptime_test.go
@@ -14,11 +14,11 @@ import (
 )
 
 func TestUptimeOnLinux(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/linux.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Family: []string{"unix"},
 		},
-	})
+	}, mock.WithPath("./testdata/linux.toml"))
 	require.NoError(t, err)
 
 	ut, err := uptime.New(mock)
@@ -31,11 +31,11 @@ func TestUptimeOnLinux(t *testing.T) {
 
 func TestUptimeOnLinuxLcDecimalDe(t *testing.T) {
 	// LC_NUMERIC=de_DE.UTF-8 on Ubuntu 22.04
-	mock, err := mock.New(0, "./testdata/linux_de.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Family: []string{"unix"},
 		},
-	})
+	}, mock.WithPath("./testdata/linux_de.toml"))
 	require.NoError(t, err)
 
 	ut, err := uptime.New(mock)
@@ -47,11 +47,11 @@ func TestUptimeOnLinuxLcDecimalDe(t *testing.T) {
 }
 
 func TestUptimeOnFreebsd(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/freebsd12.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Family: []string{"unix"},
 		},
-	})
+	}, mock.WithPath("./testdata/freebsd12.toml"))
 	require.NoError(t, err)
 
 	ut, err := uptime.New(mock)
@@ -64,11 +64,11 @@ func TestUptimeOnFreebsd(t *testing.T) {
 }
 
 func TestUptimeOnWindows(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/windows.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Family: []string{"windows"},
 		},
-	})
+	}, mock.WithPath("./testdata/windows.toml"))
 	require.NoError(t, err)
 
 	ut, err := uptime.New(mock)

--- a/providers/os/resources/users/dscl_test.go
+++ b/providers/os/resources/users/dscl_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestParseDsclListResult(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/osx.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/osx.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/os/resources/users/etcpasswd_test.go
+++ b/providers/os/resources/users/etcpasswd_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestParseLinuxEtcPasswd(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/debian.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/debian.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,7 +38,7 @@ func TestParseLinuxEtcPasswd(t *testing.T) {
 }
 
 func TestParseFreebsdLinuxEtcPasswd(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/freebsd12.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/freebsd12.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,11 +62,11 @@ func TestParseFreebsdLinuxEtcPasswd(t *testing.T) {
 }
 
 func TestParseLinuxGetentPasswd(t *testing.T) {
-	conn, err := mock.New(0, "./testdata/oraclelinux_getent_passwd.toml", &inventory.Asset{
+	conn, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Family: []string{"os", "unix", "linux", "redhat"},
 		},
-	})
+	}, mock.WithPath("./testdata/oraclelinux_getent_passwd.toml"))
 	require.NoError(t, err)
 	m, err := users.ResolveManager(conn)
 	require.Nil(t, err)

--- a/providers/os/resources/users/manager_test.go
+++ b/providers/os/resources/users/manager_test.go
@@ -14,11 +14,11 @@ import (
 )
 
 func TestManagerDebian(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/debian.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Family: []string{"unix", "linux", "debian"},
 		},
-	})
+	}, mock.WithPath("./testdata/debian.toml"))
 	require.NoError(t, err)
 
 	mm, err := users.ResolveManager(mock)
@@ -38,11 +38,11 @@ func TestManagerDebian(t *testing.T) {
 }
 
 func TestManagerMacos(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/osx.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Family: []string{"darwin"},
 		},
-	})
+	}, mock.WithPath("./testdata/osx.toml"))
 	require.NoError(t, err)
 
 	mm, err := users.ResolveManager(mock)
@@ -62,11 +62,11 @@ func TestManagerMacos(t *testing.T) {
 }
 
 func TestManagerFreebsd(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/freebsd12.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Family: []string{"unix", "bsd"},
 		},
-	})
+	}, mock.WithPath("./testdata/freebsd12.toml"))
 	require.NoError(t, err)
 
 	mm, err := users.ResolveManager(mock)
@@ -86,11 +86,11 @@ func TestManagerFreebsd(t *testing.T) {
 }
 
 func TestManagerWindows(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/windows.toml", &inventory.Asset{
+	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Family: []string{"windows"},
 		},
-	})
+	}, mock.WithPath("./testdata/windows.toml"))
 	require.NoError(t, err)
 
 	mm, err := users.ResolveManager(mock)

--- a/providers/os/resources/windows/auditpol_test.go
+++ b/providers/os/resources/windows/auditpol_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestParseAuditpol(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/auditpol.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/auditpol.toml"))
 	require.NoError(t, err)
 
 	f, err := mock.RunCommand("auditpol /get /category:* /r")

--- a/providers/os/resources/windows/secpol_test.go
+++ b/providers/os/resources/windows/secpol_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestParseSecpol(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/secpol.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/secpol.toml"))
 	require.NoError(t, err)
 
 	encoded := powershell.Encode(SecpolScript)

--- a/providers/os/resources/yum/yum_test.go
+++ b/providers/os/resources/yum/yum_test.go
@@ -63,7 +63,7 @@ Repo-filename: /etc/yum.repos.d/CentOS-Media.repo
 }
 
 func TestYumRepoRhel7(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/yum_rhel7.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/yum_rhel7.toml"))
 	require.NoError(t, err)
 
 	cmd, err := mock.RunCommand(RhelYumRepoListCommand)
@@ -80,7 +80,7 @@ func TestYumRepoRhel7(t *testing.T) {
 }
 
 func TestYumRepoRhel8(t *testing.T) {
-	mock, err := mock.New(0, "./testdata/yum_rhel8.toml", &inventory.Asset{})
+	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/yum_rhel8.toml"))
 	require.NoError(t, err)
 
 	cmd, err := mock.RunCommand(RhelYumRepoListCommand)


### PR DESCRIPTION
extracted from https://github.com/mondoohq/cnquery/pull/6096/files to make it easier to use mock with inline test data.