### PR TITLE
Detect parrot OS as asset.family debian

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -212,6 +212,17 @@ var zorin = &PlatformResolver{
 	},
 }
 
+var parrot = &PlatformResolver{
+	Name:     "parrot",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		if pf.Name == "parrot" {
+			return true, nil
+		}
+		return false, nil
+	},
+}
+
 var raspbian = &PlatformResolver{
 	Name:     "raspbian",
 	IsFamily: false,
@@ -983,7 +994,7 @@ var redhatFamily = &PlatformResolver{
 var debianFamily = &PlatformResolver{
 	Name:     "debian",
 	IsFamily: true,
-	Children: []*PlatformResolver{mxlinux, debian, ubuntu, raspbian, kali, linuxmint, popos, elementary, zorin},
+	Children: []*PlatformResolver{mxlinux, debian, ubuntu, raspbian, kali, linuxmint, popos, elementary, zorin, parrot},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		return true, nil
 	},

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -955,6 +955,17 @@ func TestZorinLinuxDetector(t *testing.T) {
 	assert.Equal(t, []string{"debian", "linux", "unix", "os"}, di.Family)
 }
 
+func TestParrotLinuxDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-parrot.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "parrot", di.Name, "os name should be identified")
+	assert.Equal(t, "Parrot OS 5.3 (Electro Ara)", di.Title, "os title should be identified")
+	assert.Equal(t, "5.3", di.Version, "os version should be identified")
+	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"debian", "linux", "unix", "os"}, di.Family)
+}
+
 func TestSteamOSDetector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-steamos.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/testdata/detect-parrot.toml
+++ b/providers/os/detector/testdata/detect-parrot.toml
@@ -1,0 +1,25 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "6.1.0-1parrot1-amd64"
+
+[files."/etc/os-release"]
+content = """
+PRETTY_NAME="Parrot OS 5.3 (Electro Ara)"
+NAME="Parrot OS"
+VERSION_ID="5.3"
+VERSION="5.3 (Electro Ara)"
+VERSION_CODENAME=ara
+ID=parrot
+ID_LIKE=debian
+HOME_URL="https://www.parrotsec.org/"
+SUPPORT_URL="https://community.parrotsec.org/"
+BUG_REPORT_URL="https://community.parrotsec.org/"
+"""
+
+[files."/etc/debian_version"]
+content = "parrot"


### PR DESCRIPTION
It's debian with a pile of packages added on top. This will give is package and service support that currently do not work