### PR TITLE
🧹 Return the actual BSD service name

### DIFF
--- a/providers/os/resources/services/bsdinit.go
+++ b/providers/os/resources/services/bsdinit.go
@@ -6,6 +6,7 @@ package services
 import (
 	"bufio"
 	"io"
+	"path/filepath"
 	"strings"
 
 	"go.mondoo.com/cnquery/v12/providers/os/connection/shared"
@@ -17,11 +18,12 @@ func ParseBsdInit(input io.Reader) ([]*Service, error) {
 	for scanner.Scan() {
 		line := scanner.Text()
 		services = append(services, &Service{
-			Name:      strings.TrimSpace(line),
+			Name:      filepath.Base(strings.TrimSpace(line)),
 			Enabled:   true,
 			Installed: true,
 			Running:   true,
 			Type:      "bsd",
+			Path:      strings.TrimSpace(line),
 		})
 	}
 	return services, nil

--- a/providers/os/resources/services/bsdinit_test.go
+++ b/providers/os/resources/services/bsdinit_test.go
@@ -31,7 +31,8 @@ func TestParseBsdInit(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 25, len(m), "detected the right amount of services")
 
-	assert.Equal(t, "/etc/rc.d/hostid", m[0].Name, "service name detected")
+	assert.Equal(t, "hostid", m[0].Name, "service name detected")
+	assert.Equal(t, "/etc/rc.d/hostid", m[0].Path, "service file path detected")
 	assert.Equal(t, true, m[0].Running, "service is running")
 	assert.Equal(t, true, m[0].Installed, "service is installed")
 	assert.Equal(t, "bsd", m[0].Type, "service type is added")

--- a/providers/os/resources/services/manager.go
+++ b/providers/os/resources/services/manager.go
@@ -20,6 +20,7 @@ type Service struct {
 	Running     bool
 	Enabled     bool
 	Masked      bool
+	Path        string
 }
 
 type State string


### PR DESCRIPTION
Instead of the path to the init file return the service name. Fixes https://github.com/mondoohq/cnquery/issues/6140