### PR TITLE
🐛 fix gentoo detector test files

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -9,6 +9,7 @@ on:
       - 'go.sum'
       - 'Makefile'
       - '.github/workflows/pr-test-lint.yml'
+      - '**.toml' # run tests when any recording changed
 
 jobs:
   # Check if there is any dirty change for go mod tidy

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -635,8 +635,8 @@ func TestGentooLinuxDetector(t *testing.T) {
 	assert.Nil(t, err, "was able to create the provider")
 
 	assert.Equal(t, "gentoo", di.Name, "os name should be identified")
-	assert.Equal(t, "Gentoo/Linux", di.Title, "os title should be identified")
-	assert.Equal(t, "2.4.1", di.Version, "os version should be identified")
+	assert.Equal(t, "Gentoo Linux", di.Title, "os title should be identified")
+	assert.Equal(t, "2.18", di.Version, "os version should be identified")
 	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
 	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
 }

--- a/providers/os/detector/testdata/detect-gentoo.toml
+++ b/providers/os/detector/testdata/detect-gentoo.toml
@@ -5,10 +5,10 @@ stdout = "Linux"
 stdout = "x86_64"
 
 [commands."uname -r"]
-stdout = "4.9.125-linuxkit"
+stdout = "6.1.69-gentoo-dist"
 
 [files."/etc/gentoo-release"]
-content = "Gentoo Base System release 2.4.1"
+content = "Gentoo Base System release 2.18"
 
 [files."/etc/os-release"]
 content = """


### PR DESCRIPTION
Folloup for https://github.com/mondoohq/cnquery/pull/6149 which broke the tests. This PR also adjust the GitHub actions to ensure we always run tests, when the toml file changes.