### PR TITLE
⭐ Services detection on flatcar

### DIFF
--- a/providers/os/resources/services/manager.go
+++ b/providers/os/resources/services/manager.go
@@ -181,6 +181,8 @@ func ResolveManager(conn shared.Connection) (OSServiceManager, error) {
 		osm = ResolveSystemdServiceManager(conn)
 	case asset.Platform.Name == "nobara": // fedora based
 		osm = ResolveSystemdServiceManager(conn)
+	case asset.Platform.Name == "flatcar":
+		osm = ResolveSystemdServiceManager(conn)
 	}
 
 	if osm == nil {


### PR DESCRIPTION
systemd-based:

```
core@localhost ~ $ systemctl
  UNIT                                                                                     LOAD   ACTIVE     SUB       DESCRIPTION      >
  boot.automount                                                                           loaded active     running   Boot partition Au>
  proc-sys-fs-binfmt_misc.automount                                                        loaded active     waiting   Arbitrary Executa>
  dev-disk-by\x2ddiskuuid-721fad77\x2dc395\x2d4420\x2da926\x2deff48fa62bfc.device          loaded activating tentative /dev/disk/by-disk>
  sys-devices-pci0000:00-0000:00:01.1-ata1-host0-target0:0:0-0:0:0:0-block-sda-sda1.device loaded active     plugged   VBOX_HARDDISK EFI>
  sys-devices-pci0000:00-0000:00:01.1-ata1-host0-target0:0:0-0:0:0:0-block-sda-sda2.device loaded active     plugged   VBOX_HARDDISK BIO>
  sys-devices-pci0000:00-0000:00:01.1-ata1-host0-target0:0:0-0:0:0:0-block-sda-sda3.device loaded active     plugged   VBOX_HARDDISK USR>
  sys-devices-pci0000:00-0000:00:01.1-ata1-host0-target0:0:0-0:0:0:0-block-sda-sda4.device loaded active     plugged   VBOX_HARDDISK USR>
  sys-devices-pci0000:00-0000:00:01.1-ata1-host0-target0:0:0-0:0:0:0-block-sda-sda6.device loaded active     plugged   VBOX_HARDDISK OEM
  sys-devices-pci0000:00-0000:00:01.1-ata1-host0-target0:0:0-0:0:0:0-block-sda-sda7.device loaded active     plugged   VBOX_HARDDISK OEM>
  sys-devices-pci0000:00-0000:00:01.1-ata1-host0-target0:0:0-0:0:0:0-block-sda-sda9.device loaded active     plugged   VBOX_HARDDISK ROOT
```