### PR TITLE
⭐ Gentoo package detection

### DIFF
--- a/providers/os/resources/packages/gentoo_packages.go
+++ b/providers/os/resources/packages/gentoo_packages.go
@@ -1,0 +1,85 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package packages
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"go.mondoo.com/cnquery/v12/providers/os/connection/shared"
+)
+
+const (
+	GentooPkgFormat = "gentoo"
+)
+
+type GentooPackage struct {
+	Name    string
+	Version string
+}
+
+func ParseGentooPackages(r io.Reader) ([]Package, error) {
+	pkgs := []Package{}
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		// Split by colon delimiter
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		name := strings.TrimSpace(parts[0])
+		version := strings.TrimSpace(parts[1])
+
+		pkgs = append(pkgs, Package{
+			Name:    name,
+			Version: version,
+			Format:  GentooPkgFormat,
+		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return pkgs, nil
+}
+
+type GentooPkgManager struct {
+	conn shared.Connection
+}
+
+func (f *GentooPkgManager) Name() string {
+	return "Gentoo Package Manager"
+}
+
+func (f *GentooPkgManager) Format() string {
+	return GentooPkgFormat
+}
+
+func (f *GentooPkgManager) List() ([]Package, error) {
+	cmd, err := f.conn.RunCommand("qlist -Iv --format '%{CATEGORY}/%{PN}:%{PVR}'")
+	if err != nil {
+		return nil, fmt.Errorf("could not read gentoo package list from qlist")
+	}
+
+	return ParseGentooPackages(cmd.Stdout)
+}
+
+func (f *GentooPkgManager) Available() (map[string]PackageUpdate, error) {
+	return map[string]PackageUpdate{}, nil
+}
+
+func (mpm *GentooPkgManager) Files(name string, version string, arch string) ([]FileRecord, error) {
+	// not yet implemented
+	return nil, nil
+}

--- a/providers/os/resources/packages/gentoo_packages_test.go
+++ b/providers/os/resources/packages/gentoo_packages_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package packages
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGentooPackages(t *testing.T) {
+	f, err := os.Open("testdata/gentoo_qlist.txt")
+	require.NoError(t, err)
+
+	m, err := ParseGentooPackages(f)
+	require.Nil(t, err)
+	assert.Equal(t, 13, len(m), "detected the right amount of packages")
+
+	p := Package{
+		Name:    "net-misc/curl",
+		Version: "8.4.0",
+		Format:  "gentoo",
+	}
+	assert.Contains(t, m, p)
+}

--- a/providers/os/resources/packages/packages.go
+++ b/providers/os/resources/packages/packages.go
@@ -133,6 +133,8 @@ func ResolveSystemPkgManagers(conn shared.Connection) ([]OperatingSystemPkgManag
 		pms = append(pms, &FreeBSDPkgManager{conn: conn})
 	case asset.Platform.Name == "aix":
 		pms = append(pms, &AixPkgManager{conn: conn, platform: asset.Platform})
+	case asset.Platform.Name == "gentoo":
+		pms = append(pms, &GentooPkgManager{conn: conn})
 	case asset.Platform.IsFamily("linux"):
 		// no clear package manager for linux platform found
 		// most likely we land here if we have a yocto-based system

--- a/providers/os/resources/packages/testdata/gentoo_qlist.txt
+++ b/providers/os/resources/packages/testdata/gentoo_qlist.txt
@@ -1,0 +1,13 @@
+acct-group/audio:0-r2
+acct-group/cdrom:0-r2
+acct-group/dialout:0-r2
+acct-group/disk:0-r2
+acct-group/floppy:0-r1
+acct-group/input:0-r2
+net-libs/libmnl:1.0.5
+net-libs/libnsl:2.0.1
+net-libs/libtirpc:1.3.4
+net-libs/nghttp2:1.57.0
+net-misc/curl:8.4.0
+net-misc/dhcpcd:10.0.5-r1
+net-misc/iputils:20221126-r1


### PR DESCRIPTION
Detect packages on gentoo systems:

```
cnquery> packages
packages.list: [
  0: package name="acct-group/audio" version="0-r2"
  1: package name="acct-group/cdrom" version="0-r2"
  2: package name="acct-group/dialout" version="0-r2"
  3: package name="acct-group/disk" version="0-r2"
  4: package name="acct-group/floppy" version="0-r1"
  5: package name="acct-group/input" version="0-r2"
  6: package name="acct-group/kmem" version="0-r2"
  7: package name="acct-group/kvm" version="0-r2"
  8: package name="acct-group/locate" version="0-r2"
  9: package name="acct-group/lp" version="0-r2"
  10: package name="acct-group/man" version="0-r2"
  11: package name="acct-group/messagebus" version="0-r2"
  12: package name="acct-group/nullmail" version="0-r1"
  13: package name="acct-group/portage" version="0-r1"
  14: package name="acct-group/render" version="0-r2"
  15: package name="acct-group/root" version="0-r1"
  16: package name="acct-group/sgx" version="0-r1"
  17: package name="acct-group/sshd" version="0-r2"
  18: package name="acct-group/tape" version="0-r2"
  19: package name="acct-group/tty" version="0-r2"
  20: package name="acct-group/usb" version="0-r2"
  21: package name="acct-group/vboxguest" version="0-r2"
  22: package name="acct-group/vboxsf" version="0-r2"
  23: package name="acct-group/video" version="0-r2"
  24: package name="acct-user/man" version="1-r2"
  25: package name="acct-user/messagebus" version="0-r2"
  26: package name="acct-user/nullmail" version="0-r1"
  27: package name="acct-user/portage" version="0-r2"
  28: package name="acct-user/sshd" version="0-r2"

...

```