### PR TITLE
🧹 Avoid needing to parse package header on Solaris

### DIFF
--- a/providers/os/resources/packages/solaris_packages.go
+++ b/providers/os/resources/packages/solaris_packages.go
@@ -89,7 +89,7 @@ func (script *SolarisPkgManager) Format() string {
 }
 
 func (s *SolarisPkgManager) List() ([]Package, error) {
-	cmd, err := s.conn.RunCommand("pkg list -v")
+	cmd, err := s.conn.RunCommand("pkg list -Hv")
 	if err != nil {
 		return nil, fmt.Errorf("could not read solaris package list")
 	}

--- a/providers/os/resources/packages/testdata/packages_solaris11.toml
+++ b/providers/os/resources/packages/testdata/packages_solaris11.toml
@@ -14,9 +14,8 @@ Copyright (c) 1983, 2012, Oracle and/or its affiliates.  All rights reserved.
                          Assembled 19 September 2012
 """
 
-[commands."pkg list -v"]
+[commands."pkg list -Hv"]
 stdout = """
-FMRI                                                                         IFO
 pkg://solaris/archiver/gnu-tar@1.26,5.11-0.175.1.0.0.24.0:20120904T170545Z   i--
 pkg://solaris/compress/bzip2@1.0.6,5.11-0.175.1.0.0.24.0:20120904T170602Z    i--
 pkg://solaris/compress/gzip@1.4,5.11-0.175.1.0.0.24.0:20120904T170603Z       i--


### PR DESCRIPTION
The `-H` flag skips the header so we can skip parsing this line