### PR TITLE
🐛 Fix vault CLI flag sorting in docs

### DIFF
--- a/providers-sdk/v1/vault/config.go
+++ b/providers-sdk/v1/vault/config.go
@@ -6,6 +6,7 @@ package vault
 import (
 	"encoding/json"
 	"errors"
+	"sort"
 	"strings"
 )
 
@@ -65,6 +66,7 @@ func TypeIds() []string {
 	for _, v := range vaultMarshalNameMap {
 		types = append(types, v)
 	}
+	sort.Strings(types)
 	return types
 }
 


### PR DESCRIPTION
Now the values are sorted and always appear in the same order in _cnquery_vault_configure.md_.

```
      --type string             possible values: aws-parameter-store | aws-secrets-manager | encrypted-file | gcp-berglas | gcp-secret-manager | hashicorp-vault | keyring | linux-kernel-keyring | memory | none
```