### PR TITLE
🐛 Don't parse the systemd summary line as a service

### DIFF
--- a/providers/os/resources/services/manager_test.go
+++ b/providers/os/resources/services/manager_test.go
@@ -50,7 +50,7 @@ func TestManagerDragonflybsd5(t *testing.T) {
 	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "dragonflybsd",
-			Family: []string{"unix"},
+			Family: []string{"bsd", "unix", "os"},
 		},
 	}, mock.WithPath("./testdata/dragonfly5.toml"))
 	require.NoError(t, err)
@@ -67,7 +67,7 @@ func TestManagerOpenBsd6(t *testing.T) {
 	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "openbsd",
-			Family: []string{"unix"},
+			Family: []string{"unix", "os"},
 		},
 	}, mock.WithPath("./testdata/openbsd6.toml"))
 	require.NoError(t, err)
@@ -84,7 +84,7 @@ func TestManagerWindows(t *testing.T) {
 	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "windows",
-			Family: []string{"windows"},
+			Family: []string{"windows", "os"},
 		},
 	}, mock.WithPath("./testdata/windows2019.toml"))
 	require.NoError(t, err)
@@ -102,7 +102,7 @@ func TestManagerUbuntu2204(t *testing.T) {
 		Platform: &inventory.Platform{
 			Name:    "ubuntu",
 			Version: "22.04",
-			Family:  []string{"ubuntu", "linux"},
+			Family:  []string{"ubuntu", "linux", "unix", "os"},
 		},
 	}, mock.WithPath("./testdata/ubuntu2204.toml"))
 	require.NoError(t, err)
@@ -112,15 +112,15 @@ func TestManagerUbuntu2204(t *testing.T) {
 	serviceList, err := mm.List()
 	require.NoError(t, err)
 
-	assert.Equal(t, 264, len(serviceList))
+	assert.Equal(t, 263, len(serviceList))
 }
 
 func TestManagerPhoton(t *testing.T) {
 	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:    "photon",
-			Version: "8.1.10",
-			Family:  []string{"photon", "linux"},
+			Version: "3.0",
+			Family:  []string{"linux", "unix", "os"},
 		},
 	}, mock.WithPath("./testdata/photon.toml"))
 	require.NoError(t, err)
@@ -130,5 +130,5 @@ func TestManagerPhoton(t *testing.T) {
 	serviceList, err := mm.List()
 	require.NoError(t, err)
 
-	assert.Equal(t, 138, len(serviceList))
+	assert.Equal(t, 137, len(serviceList))
 }

--- a/providers/os/resources/services/systemd.go
+++ b/providers/os/resources/services/systemd.go
@@ -59,6 +59,10 @@ func ParseServiceSystemDUnitFiles(input io.Reader) ([]*Service, error) {
 			continue
 		}
 
+		if strings.Contains(line, "unit files listed.") {
+			continue // skip the summary line
+		}
+
 		name := strings.TrimSuffix(fields[0], ".service")
 
 		service := &Service{

--- a/providers/os/resources/services/systemd_test.go
+++ b/providers/os/resources/services/systemd_test.go
@@ -62,7 +62,7 @@ func TestParseServiceSystemDUnitFiles(t *testing.T) {
 
 	m, err := ParseServiceSystemDUnitFiles(c.Stdout)
 	assert.Nil(t, err)
-	assert.Equal(t, 264, len(m), "detected the right amount of services")
+	assert.Equal(t, 263, len(m), "detected the right amount of services")
 
 	// check first element
 	assert.Equal(t, "accounts-daemon", m[0].Name, "service name detected")
@@ -81,7 +81,7 @@ func TestParseServiceSystemDUnitFilesPhoton(t *testing.T) {
 	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{
 			Name:   "photon",
-			Family: []string{"redhat", "linux"},
+			Family: []string{"linux", "unix", "os"},
 		},
 	}, mock.WithPath("./testdata/photon.toml"))
 	if err != nil {
@@ -95,7 +95,7 @@ func TestParseServiceSystemDUnitFilesPhoton(t *testing.T) {
 
 	m, err := ParseServiceSystemDUnitFiles(c.Stdout)
 	assert.Nil(t, err)
-	assert.Equal(t, 138, len(m), "detected the right amount of services")
+	assert.Equal(t, 137, len(m), "detected the right amount of services")
 
 	// check first element
 	assert.Equal(t, "autovt@", m[0].Name, "service name detected")


### PR DESCRIPTION
Right now we parse the summary line:

```
...
zerotier-one.service                   disabled        enabled

194 unit files listed.
```

Into a bogus service:

```
ccnquery> services.last
services.list.last: service name="194" running=false enabled=false type="systemd"
```

Instead let's skip that line based on the text contained.

Fixes https://github.com/mondoohq/cnquery/issues/6199