### PR TITLE
⭐️ add resource to easily gather macos system information

### DIFF
--- a/providers/os/resources/macos_hardware.go
+++ b/providers/os/resources/macos_hardware.go
@@ -1,0 +1,76 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"encoding/json"
+	"errors"
+
+	"go.mondoo.com/cnquery/v12/llx"
+	"go.mondoo.com/cnquery/v12/providers-sdk/v1/plugin"
+)
+
+func initMacosHardware(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if args == nil {
+		args = map[string]*llx.RawData{}
+	}
+
+	// MQL equivalent in CLI
+	// parse.json(content: command('system_profiler SPHardwareDataType -json').stdout).params['SPHardwareDataType'].first['chip_type']
+	res, err := NewResource(runtime, "command", map[string]*llx.RawData{
+		"command": llx.StringData("system_profiler SPHardwareDataType -json"),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cmd, ok := res.(*mqlCommand)
+	if !ok {
+		return nil, nil, errors.New("could not run command")
+	}
+
+	jsonData := cmd.GetStdout().Data
+
+	type machineJsonData struct {
+		SPHardwareDataType []struct {
+			ActivationLockStatus string `json:"activation_lock_status"`
+			BootRomVersion       string `json:"boot_rom_version"`
+			ChipType             string `json:"chip_type"`
+			MachineModel         string `json:"machine_model"`
+			MachineName          string `json:"machine_name"`
+			ModelNumber          string `json:"model_number"`
+			NumberProcessors     string `json:"number_processors"`
+			OsLoaderVersion      string `json:"os_loader_version"`
+			PhysicalMemory       string `json:"physical_memory"`
+			PlatformUUID         string `json:"platform_uuid"`
+			ProvisioningUUID     string `json:"provisioning_uuid"`
+			SerialNumber         string `json:"serial_number"`
+		} `json:"SPHardwareDataType"`
+	}
+
+	var resp machineJsonData
+	err = json.Unmarshal([]byte(jsonData), &resp)
+	if err != nil {
+		return nil, nil, errors.New("could not gather hardware information")
+	}
+	if len(resp.SPHardwareDataType) == 0 {
+		return nil, nil, errors.New("could not gather hardware information")
+	}
+
+	hardware := resp.SPHardwareDataType[0]
+	args["activationLockStatus"] = llx.StringData(hardware.ActivationLockStatus)
+	args["bootRomVersion"] = llx.StringData(hardware.BootRomVersion)
+	args["chipType"] = llx.StringData(hardware.ChipType)
+	args["machineModel"] = llx.StringData(hardware.MachineModel)
+	args["machineName"] = llx.StringData(hardware.MachineName)
+	args["modelNumber"] = llx.StringData(hardware.ModelNumber)
+	args["numberProcessors"] = llx.StringData(hardware.NumberProcessors)
+	args["osLoaderVersion"] = llx.StringData(hardware.OsLoaderVersion)
+	args["physicalMemory"] = llx.StringData(hardware.PhysicalMemory)
+	args["platformUUID"] = llx.StringData(hardware.PlatformUUID)
+	args["provisioningUDID"] = llx.StringData(hardware.ProvisioningUUID)
+	args["serialNumber"] = llx.StringData(hardware.SerialNumber)
+
+	return args, nil, nil
+}

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -1452,6 +1452,8 @@ npm.package @defaults("name version purl") {
 
 // macOS specific resources
 macos {
+  // macOS computer name
+  computerName() string
   // macOS user defaults
   userPreferences() map[string]dict
   // macOS user defaults for current host
@@ -1460,6 +1462,34 @@ macos {
   globalAccountPolicies() dict
   // System extensions
   systemExtensions() []macos.systemExtension
+}
+
+// macOS hardware overview
+macos.hardware @defaults("machineName chipType physicalMemory serialNumber") {
+  // Activation Lock security feature
+  activationLockStatus string
+  // Boot ROM (firmware) version identifier
+  bootRomVersion string
+  // Processor chip type (e.g., "Apple M1", "Apple M2", "Intel")
+  chipType string
+  // Specific model identifier (e.g., "MacBookPro18,3")
+  machineModel string
+  // User-friendly hardware name (e.g., "MacBook Pro")
+  machineName string
+  // Apple's model number for the device (e.g., "A2442")
+  modelNumber string
+  // Total number of processor cores
+  numberProcessors string
+  // Version of the OS bootloader
+  osLoaderVersion string
+  // Total RAM installed (e.g., "16 GB")
+  physicalMemory string
+  // Universally unique identifier for the hardware platform
+  platformUUID string
+  // Unique Device Identifier for MDM provisioning
+  provisioningUDID string
+  // Apple's unique serial number for the device
+  serialNumber string
 }
 
 // macOS application layer firewall (ALF) service

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -126,6 +126,7 @@ const (
 	ResourceNpmPackages            string = "npm.packages"
 	ResourceNpmPackage             string = "npm.package"
 	ResourceMacos                  string = "macos"
+	ResourceMacosHardware          string = "macos.hardware"
 	ResourceMacosAlf               string = "macos.alf"
 	ResourceMacosTimemachine       string = "macos.timemachine"
 	ResourceMacosSystemsetup       string = "macos.systemsetup"
@@ -591,6 +592,10 @@ func init() {
 		"macos": {
 			// to override args, implement: initMacos(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMacos,
+		},
+		"macos.hardware": {
+			Init:   initMacosHardware,
+			Create: createMacosHardware,
 		},
 		"macos.alf": {
 			Init:   initMacosAlf,
@@ -2238,6 +2243,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"npm.package.files": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNpmPackage).GetFiles()).ToDataRes(types.Array(types.Resource("pkgFileInfo")))
 	},
+	"macos.computerName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacos).GetComputerName()).ToDataRes(types.String)
+	},
 	"macos.userPreferences": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMacos).GetUserPreferences()).ToDataRes(types.Map(types.String, types.Dict))
 	},
@@ -2249,6 +2257,42 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"macos.systemExtensions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMacos).GetSystemExtensions()).ToDataRes(types.Array(types.Resource("macos.systemExtension")))
+	},
+	"macos.hardware.activationLockStatus": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosHardware).GetActivationLockStatus()).ToDataRes(types.String)
+	},
+	"macos.hardware.bootRomVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosHardware).GetBootRomVersion()).ToDataRes(types.String)
+	},
+	"macos.hardware.chipType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosHardware).GetChipType()).ToDataRes(types.String)
+	},
+	"macos.hardware.machineModel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosHardware).GetMachineModel()).ToDataRes(types.String)
+	},
+	"macos.hardware.machineName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosHardware).GetMachineName()).ToDataRes(types.String)
+	},
+	"macos.hardware.modelNumber": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosHardware).GetModelNumber()).ToDataRes(types.String)
+	},
+	"macos.hardware.numberProcessors": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosHardware).GetNumberProcessors()).ToDataRes(types.String)
+	},
+	"macos.hardware.osLoaderVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosHardware).GetOsLoaderVersion()).ToDataRes(types.String)
+	},
+	"macos.hardware.physicalMemory": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosHardware).GetPhysicalMemory()).ToDataRes(types.String)
+	},
+	"macos.hardware.platformUUID": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosHardware).GetPlatformUUID()).ToDataRes(types.String)
+	},
+	"macos.hardware.provisioningUDID": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosHardware).GetProvisioningUDID()).ToDataRes(types.String)
+	},
+	"macos.hardware.serialNumber": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosHardware).GetSerialNumber()).ToDataRes(types.String)
 	},
 	"macos.alf.allowDownloadSignedEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMacosAlf).GetAllowDownloadSignedEnabled()).ToDataRes(types.Int)
@@ -5150,6 +5194,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlMacos).__id, ok = v.Value.(string)
 		return
 	},
+	"macos.computerName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacos).ComputerName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"macos.userPreferences": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMacos).UserPreferences, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -5164,6 +5212,58 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"macos.systemExtensions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMacos).SystemExtensions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"macos.hardware.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosHardware).__id, ok = v.Value.(string)
+		return
+	},
+	"macos.hardware.activationLockStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosHardware).ActivationLockStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"macos.hardware.bootRomVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosHardware).BootRomVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"macos.hardware.chipType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosHardware).ChipType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"macos.hardware.machineModel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosHardware).MachineModel, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"macos.hardware.machineName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosHardware).MachineName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"macos.hardware.modelNumber": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosHardware).ModelNumber, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"macos.hardware.numberProcessors": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosHardware).NumberProcessors, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"macos.hardware.osLoaderVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosHardware).OsLoaderVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"macos.hardware.physicalMemory": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosHardware).PhysicalMemory, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"macos.hardware.platformUUID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosHardware).PlatformUUID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"macos.hardware.provisioningUDID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosHardware).ProvisioningUDID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"macos.hardware.serialNumber": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosHardware).SerialNumber, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"macos.alf.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -14579,6 +14679,7 @@ type mqlMacos struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlMacosInternal it will be used here
+	ComputerName          plugin.TValue[string]
 	UserPreferences       plugin.TValue[map[string]any]
 	UserHostPreferences   plugin.TValue[map[string]any]
 	GlobalAccountPolicies plugin.TValue[any]
@@ -14617,6 +14718,12 @@ func (c *mqlMacos) MqlID() string {
 	return c.__id
 }
 
+func (c *mqlMacos) GetComputerName() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ComputerName, func() (string, error) {
+		return c.computerName()
+	})
+}
+
 func (c *mqlMacos) GetUserPreferences() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.UserPreferences, func() (map[string]any, error) {
 		return c.userPreferences()
@@ -14649,6 +14756,105 @@ func (c *mqlMacos) GetSystemExtensions() *plugin.TValue[[]any] {
 
 		return c.systemExtensions()
 	})
+}
+
+// mqlMacosHardware for the macos.hardware resource
+type mqlMacosHardware struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlMacosHardwareInternal it will be used here
+	ActivationLockStatus plugin.TValue[string]
+	BootRomVersion       plugin.TValue[string]
+	ChipType             plugin.TValue[string]
+	MachineModel         plugin.TValue[string]
+	MachineName          plugin.TValue[string]
+	ModelNumber          plugin.TValue[string]
+	NumberProcessors     plugin.TValue[string]
+	OsLoaderVersion      plugin.TValue[string]
+	PhysicalMemory       plugin.TValue[string]
+	PlatformUUID         plugin.TValue[string]
+	ProvisioningUDID     plugin.TValue[string]
+	SerialNumber         plugin.TValue[string]
+}
+
+// createMacosHardware creates a new instance of this resource
+func createMacosHardware(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMacosHardware{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("macos.hardware", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMacosHardware) MqlName() string {
+	return "macos.hardware"
+}
+
+func (c *mqlMacosHardware) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMacosHardware) GetActivationLockStatus() *plugin.TValue[string] {
+	return &c.ActivationLockStatus
+}
+
+func (c *mqlMacosHardware) GetBootRomVersion() *plugin.TValue[string] {
+	return &c.BootRomVersion
+}
+
+func (c *mqlMacosHardware) GetChipType() *plugin.TValue[string] {
+	return &c.ChipType
+}
+
+func (c *mqlMacosHardware) GetMachineModel() *plugin.TValue[string] {
+	return &c.MachineModel
+}
+
+func (c *mqlMacosHardware) GetMachineName() *plugin.TValue[string] {
+	return &c.MachineName
+}
+
+func (c *mqlMacosHardware) GetModelNumber() *plugin.TValue[string] {
+	return &c.ModelNumber
+}
+
+func (c *mqlMacosHardware) GetNumberProcessors() *plugin.TValue[string] {
+	return &c.NumberProcessors
+}
+
+func (c *mqlMacosHardware) GetOsLoaderVersion() *plugin.TValue[string] {
+	return &c.OsLoaderVersion
+}
+
+func (c *mqlMacosHardware) GetPhysicalMemory() *plugin.TValue[string] {
+	return &c.PhysicalMemory
+}
+
+func (c *mqlMacosHardware) GetPlatformUUID() *plugin.TValue[string] {
+	return &c.PlatformUUID
+}
+
+func (c *mqlMacosHardware) GetProvisioningUDID() *plugin.TValue[string] {
+	return &c.ProvisioningUDID
+}
+
+func (c *mqlMacosHardware) GetSerialNumber() *plugin.TValue[string] {
+	return &c.SerialNumber
 }
 
 // mqlMacosAlf for the macos.alf resource

--- a/providers/os/resources/os.lr.manifest.yaml
+++ b/providers/os/resources/os.lr.manifest.yaml
@@ -508,6 +508,8 @@ resources:
     min_mondoo_version: 5.15.0
   macos:
     fields:
+      computerName:
+        min_mondoo_version: 9.0.0
       globalAccountPolicies: {}
       systemExtensions:
         min_mondoo_version: 9.0.0
@@ -528,6 +530,21 @@ resources:
       stealthEnabled: {}
       version: {}
     min_mondoo_version: 5.15.0
+  macos.hardware:
+    fields:
+      activationLockStatus: {}
+      bootRomVersion: {}
+      chipType: {}
+      machineModel: {}
+      machineName: {}
+      modelNumber: {}
+      numberProcessors: {}
+      osLoaderVersion: {}
+      physicalMemory: {}
+      platformUUID: {}
+      provisioningUDID: {}
+      serialNumber: {}
+    min_mondoo_version: 9.0.0
   macos.systemExtension:
     fields:
       active: {}


### PR DESCRIPTION
This PR makes it much easier to gather macOS hardware information:

```javascript
> cnquery> macos.computerName
macos.computerName: "John Doe"
cnquery> macos.hardware
macos.hardware: macos.hardware machineName="MacBook Pro" chipType="Apple M3 Max" physicalMemory="64 GB" serialNumber="AAAAAAAAAA"
cnquery> macos.hardware { * }
macos.hardware: {
  bootRomVersion: "11881.140.96"
  machineModel: "Mac15,8"
  machineName: "MacBook Pro"
  provisioningUDID: ""
  physicalMemory: "64 GB"
  osLoaderVersion: "11881.140.96"
  serialNumber: "AAAAAAAAAA"
  platformUUID: "56f74699-cb04-41ae-87ee-28bc498f1832"
  activationLockStatus: "activation_lock_disabled"
  numberProcessors: "proc 16:12:4"
  chipType: "Apple M3 Max"
  modelNumber: "AAAAAAAA/A"
}
```