### PR TITLE
🐛 :octocat: fix infinite loop on repos listing

### DIFF
--- a/providers/github/resources/github.go
+++ b/providers/github/resources/github.go
@@ -77,5 +77,4 @@ func githubTimestamp(ts *github.Timestamp) *time.Time {
 
 const (
 	paginationPerPage = 100
-	workers           = 10
 )


### PR DESCRIPTION
**Improvements:**

* The worker pool size is now dynamically calculated based on the expected number of repository pages, rather than using a fixed value.
* Added a failsafe mechanism in the repository fetching logic to stop requesting additional pages when the expected number of pages plus pending workers has been reached. This helps prevent unnecessary requests and handles cases where permission issues may prevent all repositories from being listed.