### PR TITLE
✨ Add support for input flags from providers

### DIFF
--- a/providers-sdk/v1/plugin/flag.go
+++ b/providers-sdk/v1/plugin/flag.go
@@ -20,6 +20,7 @@ const (
 	FlagOption_Deprecated
 	FlagOption_Required
 	FlagOption_Password
+	FlagOption_AskInput
 	// max: 8 options!
 )
 


### PR DESCRIPTION
This allows providers to define flags that require user input, usually passwords. The pattern that this currently supports is as following:
 * The provider must have a `value` and `ask-value` flags. If `ask-value` is set, we open a model to ask for the value which is then sent as `value` in the CLI flags of the provider. We could make this a bit more flexible (say, allow only `ask-value` so that users are forced into that path) but it requires some llx flags work.

Note this pattern is already implicitly required with the `password` and `ask-pass` flags. 

An example of such a flag combo:
```
{
	Long:        "enable-password",
	Type:        plugin.FlagType_String,
	Default:     "",
	Desc:        "Set the enable-password.",
	Option:      plugin.FlagOption_Password,
	ConfigEntry: "-",
},
{
	Long:        "ask-enable-password",
	Type:        plugin.FlagType_Bool,
	Option:      plugin.FlagOption_AskInput | plugin.FlagOption_Password,
	Default:     "false",
	Desc:        "Prompt for enable password",
	ConfigEntry: "-",
}
```

Note multiple ask inputs are supported:
```
➜ ~/go/bin/cnquery shell cool-provider something@host.com --ask-pass --ask-enable-password
Enter password: ****                 
Enter value for enable-password: *******              
→ loaded configuration from /Users/preslavgerchev/.config/mondoo/mondoo.yml using source default
```

> NOTE: only new providers should use that approach, since this requires a minimal cnspec version. We can assume this as standard with v13