### PR TITLE
🐛 Fix Github provider workflow configuration panic

### DIFF
--- a/providers/github/resources/github_workflow.go
+++ b/providers/github/resources/github_workflow.go
@@ -65,7 +65,6 @@ func (g *mqlGithubWorkflow) file() (*mqlGithubFile, error) {
 	ownerLogin := fullNameSplit[0]
 	repoName := fullNameSplit[1]
 
-	// Get the repository to find the default branch
 	repo, _, err := conn.Client().Repositories.Get(conn.Context(), ownerLogin, repoName)
 	if err != nil {
 		return nil, err
@@ -94,9 +93,8 @@ func (g *mqlGithubWorkflow) file() (*mqlGithubFile, error) {
 			Str("branch", defaultBranch).
 			Msg("failed to get workflow file contents")
 
-		// TODO: should this be an error
 		if strings.Contains(err.Error(), "404") {
-			return nil, nil
+			return nil, errors.New("file not found, got 404")
 		}
 		return nil, err
 	}


### PR DESCRIPTION
Closes https://github.com/mondoohq/cnquery/issues/6209
Example query after the fix: 

```
github.repository.workflows[0].configuration: {
  jobs: {
    build: {
      name: "Build"
      needs: "test"
      runs-on: "ubuntu-latest"
      steps: [
        0: {
          uses: "actions/checkout@v4"
        }
        1: {
          name: "Set up Go"
          uses: "actions/setup-go@v5"
          with: {
            cache: true
            go-version: "1.24.9"
          }
        }
        2: {
          name: "Build Linux AMD64"
          run: "GOOS=linux GOARCH=amd64 go build -ldflags=\"-s -w\" -o beacon-linux_amd64 ./cmd/beacon"
        }
        3: {
          name: "Build Linux ARM64"
          run: "GOOS=linux GOARCH=arm64 go build -ldflags=\"-s -w\" -o beacon-linux_arm64 ./cmd/beacon"
        }
        4: {
          name: "Build Linux ARM"
          run: "GOOS=linux GOARCH=arm GOARM=7 go build -ldflags=\"-s -w\" -o beacon-linux_arm ./cmd/beacon"
        }
        5: {
          name: "Build macOS AMD64"
          run: "GOOS=darwin GOARCH=amd64 go build -ldflags=\"-s -w\" -o beacon-darwin_amd64 ./cmd/beacon"
        }
        6: {
          name: "Build macOS ARM64"
          run: "GOOS=darwin GOARCH=arm64 go build -ldflags=\"-s -w\" -o beacon-darwin_arm64 ./cmd/beacon"
        }
        7: {
          name: "Generate checksums"
          run: "sha256sum beacon-linux_amd64 beacon-linux_arm64 beacon-linux_arm beacon-darwin_amd64 beacon-darwin_arm64 > checksums.txt
cat checksums.txt
"
```