### PR TITLE
🐛 fix panic in iptables

### DIFF
--- a/providers/os/resources/iptables.go
+++ b/providers/os/resources/iptables.go
@@ -274,17 +274,20 @@ func ParseStat(lines []string, ipv6 bool) ([]Stat, error) {
 			opts = strings.Join(o, " ")
 		}
 		entry := Stat{
-			LineNumber:  ln,
-			Packets:     pkts,
-			Bytes:       bts,
-			Target:      fields[3],
-			Protocol:    fields[4],
-			Opt:         fields[5],
-			Input:       fields[6],
-			Output:      fields[7],
-			Source:      fields[8],
-			Destination: fields[9],
-			Options:     opts,
+			LineNumber: ln,
+			Packets:    pkts,
+			Bytes:      bts,
+			Target:     fields[3],
+			Protocol:   fields[4],
+			Opt:        fields[5],
+			Input:      fields[6],
+			Output:     fields[7],
+			Source:     fields[8],
+			Options:    opts,
+		}
+
+		if len(fields) > 9 {
+			entry.Destination = fields[9]
 		}
 		entries = append(entries, entry)
 	}


### PR DESCRIPTION
Fix panic in iptables. We received reports with the following stack trace:
```
→ loaded configuration from /opt/mondoo/.config/mondoo/mondoo.yml using source default
→ using service account credentials
→ discover related assets for 1 asset(s)
→ synchronize assets
panic: runtime error: index out of range [9] with length 9
x panic: runtime error: index out of range [9] with length 9 name=os

x name=os
goroutine 49626 [running]:
x goroutine 49626 [running]: name=os
go.mondoo.com/cnquery/v12/providers/os/resources.ParseStat({0xc000651508?, 0x93, 0x45fa?}, 0x0)
x go.mondoo.com/cnquery/v12/providers/os/resources.ParseStat({0xc000651508?, 0x93, 0x45fa?}, 0x0) name=os
	/home/runner/_work/cnquery/cnquery/providers/os/resources/iptables.go:286 +0x78f
x 	/home/runner/_work/cnquery/cnquery/providers/os/resources/iptables.go:286 +0x78f name=os
go.mondoo.com/cnquery/v12/providers/os/resources.(*mqlIptables).input(0xc00347cd00)
x go.mondoo.com/cnquery/v12/providers/os/resources.(*mqlIptables).input(0xc00347cd00) name=os
	/home/runner/_work/cnquery/cnquery/providers/os/resources/iptables.go:98 +0x145
x 	/home/runner/_work/cnquery/cnquery/providers/os/resources/iptables.go:98 +0x145 name=os
go.mondoo.com/cnquery/v12/providers/os/resources.(*mqlIptables).GetInput.func1()
x go.mondoo.com/cnquery/v12/providers/os/resources.(*mqlIptables).GetInput.func1() name=os
	/home/runner/_work/cnquery/cnquery/providers/os/resources/os.lr.go:11744 +0x8b
x 	/home/runner/_work/cnquery/cnquery/providers/os/resources/os.lr.go:11744 +0x8b name=os
go.mondoo.com/cnquery/v12/providers-sdk/v1/plugin.GetOrCompute[...](0xc00347cd18?, 0x40fdb5)
x go.mondoo.com/cnquery/v12/providers-sdk/v1/plugin.GetOrCompute[...](0xc00347cd18?, 0x40fdb5) name=os
	/home/runner/_work/cnquery/cnquery/providers-sdk/v1/plugin/runtime.go:269 +0x3a
x 	/home/runner/_work/cnquery/cnquery/providers-sdk/v1/plugin/runtime.go:269 +0x3a name=os
go.mondoo.com/cnquery/v12/providers/os/resources.(*mqlIptables).GetInput(0x2d?)
x go.mondoo.com/cnquery/v12/providers/os/resources.(*mqlIptables).GetInput(0x2d?) name=os
	/home/runner/_work/cnquery/cnquery/providers/os/resources/os.lr.go:11733 +0x36
x 	/home/runner/_work/cnquery/cnquery/providers/os/resources/os.lr.go:11733 +0x36 name=os
go.mondoo.com/cnquery/v12/providers/os/resources.init.func1122({0x33f5fe0?, 0xc00347cd00?})
x go.mondoo.com/cnquery/v12/providers/os/resources.init.func1122({0x33f5fe0?, 0xc00347cd00?}) name=os
	/home/runner/_work/cnquery/cnquery/providers/os/resources/os.lr.go:1639 +0x30
x 	/home/runner/_work/cnquery/cnquery/providers/os/resources/os.lr.go:1639 +0x30 name=os
go.mondoo.com/cnquery/v12/providers/os/resources.GetData({0x33f5fe0, 0xc00347cd00}, {0xc00323b098, 0x5}, 0x5?)
x go.mondoo.com/cnquery/v12/providers/os/resources.GetData({0x33f5fe0, 0xc00347cd00}, {0xc00323b098, 0x5}, 0x5?) name=os
	/home/runner/_work/cnquery/cnquery/providers/os/resources/os.lr.go:2597 +0x16b
x 	/home/runner/_work/cnquery/cnquery/providers/os/resources/os.lr.go:2597 +0x16b name=os
go.mondoo.com/cnquery/v12/providers-sdk/v1/plugin.(*Service).GetData(0x68?, 0xc00326ad90)
x go.mondoo.com/cnquery/v12/providers-sdk/v1/plugin.(*Service).GetData(0x68?, 0xc00326ad90) name=os
	/home/runner/_work/cnquery/cnquery/providers-sdk/v1/plugin/service.go:208 +0x2f9
x 	/home/runner/_work/cnquery/cnquery/providers-sdk/v1/plugin/service.go:208 +0x2f9 name=os
go.mondoo.com/cnquery/v12/providers-sdk/v1/plugin.(*GRPCServer).GetData(0x2e3a360?, {0xc00326ad90?, 0xc0039fd8b8?}, 0x4fa745?)
x go.mondoo.com/cnquery/v12/providers-sdk/v1/plugin.(*GRPCServer).GetData(0x2e3a360?, {0xc00326ad90?, 0xc0039fd8b8?}, 0x4fa745?) name=os
	/home/runner/_work/cnquery/cnquery/providers-sdk/v1/plugin/grpc.go:137 +0x1e
x 	/home/runner/_work/cnquery/cnquery/providers-sdk/v1/plugin/grpc.go:137 +0x1e name=os
go.mondoo.com/cnquery/v12/providers-sdk/v1/plugin._ProviderPlugin_GetData_Handler({0x2d48d60, 0xc0009473c0}, {0x3412f60, 0xc003267ef0}, 0xc003243380, 0x0)
x go.mondoo.com/cnquery/v12/providers-sdk/v1/plugin._ProviderPlugin_GetData_Handler({0x2d48d60, 0xc0009473c0}, {0x3412f60, 0xc003267ef0}, 0xc003243380, 0x0) 
```

I am not sure in which cases we have 9 fields but at least this code change should make sure we don't panic