### PR TITLE
🧹 ensure macOS asset name is ascii characters only

### DIFF
--- a/providers/os/provider/detector.go
+++ b/providers/os/provider/detector.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"errors"
 	"slices"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v12/providers-sdk/v1/inventory"
@@ -160,9 +161,21 @@ func (s *Service) assetName(asset *inventory.Asset, conn shared.Connection) {
 			data, err := plist.Decode(f)
 			if err == nil {
 				if computerName, ok := data.GetString("System", "System", "ComputerName"); ok {
-					asset.Name = computerName
+					asset.Name = RemoveNonASCII(computerName)
 				}
 			}
 		}
 	}
+}
+
+// RemoveNonASCII removes all non-ASCII characters
+// macOS may use non ASCII charaters for the computer name. This breaks the progress bar until v12.13.0
+func RemoveNonASCII(s string) string {
+	var result strings.Builder
+	for _, c := range s {
+		if c <= 127 {
+			result.WriteRune(c)
+		}
+	}
+	return result.String()
 }

--- a/providers/os/provider/detector_test.go
+++ b/providers/os/provider/detector_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/muesli/reflow/ansi"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAssetName(t *testing.T) {
+	data := []byte{77, 97, 110, 97, 103, 101, 100, 226, 128, 153, 115, 32, 86, 105, 114, 116, 117, 97, 108, 32, 77, 97, 99, 104, 105, 110, 101}
+	str := string(data)
+	assert.Equal(t, "Managed’s Virtual Machine", str)
+	assert.True(t, len(RemoveNonASCII(str)) <= ansi.PrintableRuneWidth(str))
+}

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -306,7 +306,7 @@ func (s *Service) Connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	}
 
 	// for some assets we need to do additional asset name detection, eg. macOS
-	// s.assetName(req.Asset, conn)
+	s.assetName(req.Asset, conn)
 
 	log.Debug().Str("asset", req.Asset.Name).Msg("detected asset")
 


### PR DESCRIPTION
This change is required to make this provider improvement work with older cnquery/cnspec versions pre 12.13.0. The problem was that macOS computer name may include non-ansi characters. For future versions, we also improved the progress bar in https://github.com/mondoohq/cnquery/pull/6294

Followup for https://github.com/mondoohq/cnquery/pull/6235