### PR TITLE
🧹 include depth in files.find resource id

### DIFF
--- a/providers/os/resources/files.go
+++ b/providers/os/resources/files.go
@@ -40,6 +40,7 @@ func octal2string(o int64) string {
 func (l *mqlFilesFind) id() (string, error) {
 	var id strings.Builder
 	id.WriteString(l.From.Data)
+
 	if !l.Xdev.Data {
 		id.WriteString(" -xdev")
 	}
@@ -53,6 +54,10 @@ func (l *mqlFilesFind) id() (string, error) {
 
 	if l.Name.Data != "" {
 		id.WriteString(" name=" + l.Name.Data)
+	}
+
+	if l.Depth.Data > 0 {
+		id.WriteString(" depth=" + strconv.Itoa(int(l.Depth.Data)))
 	}
 
 	if l.Permissions.Data != 0o777 {


### PR DESCRIPTION
Extracted from https://github.com/mondoohq/cnquery/pull/6297

```
files.find(from: "/Users", type: "file", depth: 3) {
            path
}
```

and then

```
files.find(from: "/Users", type: "file", depth: 2) {
            path
}
```

It was previously resolved to the same resource. Since depth was changed, the results may differ and we need to re-evaluate. 