### PR TITLE
🧹 refactor packages for filesystem handling

### DIFF
--- a/providers/os/connection/device/linux/device_manager.go
+++ b/providers/os/connection/device/linux/device_manager.go
@@ -19,7 +19,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"go.mondoo.com/cnquery/v12/providers/os/connection/snapshot"
-	"go.mondoo.com/cnquery/v12/providers/os/fs"
+	"go.mondoo.com/cnquery/v12/providers/os/mountedfs"
 	"go.mondoo.com/cnquery/v12/providers/os/resources"
 )
 
@@ -201,7 +201,7 @@ func (d *LinuxDeviceManager) attemptFindFstab(dir string) ([]resources.FstabEntr
 
 	mnt, fstab := path.Split(strings.TrimSpace(string(out)))
 	fstabFile, err := afero.ReadFile(
-		fs.NewMountedFs(mnt),
+		mountedfs.NewMountedFs(mnt),
 		path.Base(fstab))
 	if err != nil {
 		log.Error().Err(err).Msg("error reading fstab")

--- a/providers/os/connection/fs/filesystem.go
+++ b/providers/os/connection/fs/filesystem.go
@@ -12,7 +12,7 @@ import (
 	"go.mondoo.com/cnquery/v12/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v12/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v12/providers/os/connection/shared"
-	"go.mondoo.com/cnquery/v12/providers/os/fs"
+	"go.mondoo.com/cnquery/v12/providers/os/mountedfs"
 )
 
 var (
@@ -33,7 +33,7 @@ func NewFileSystemConnectionWithClose(id uint32, conf *inventory.Config, asset *
 
 	log.Debug().Str("path", path).Msg("load filesystem")
 
-	return NewFileSystemConnectionWithFs(id, conf, asset, path, closeFN, fs.NewMountedFs(path))
+	return NewFileSystemConnectionWithFs(id, conf, asset, path, closeFN, mountedfs.NewMountedFs(path))
 }
 
 func NewFileSystemConnectionWithFs(id uint32, conf *inventory.Config, asset *inventory.Asset, path string, closeFN func(), fs afero.Fs) (*FileSystemConnection, error) {
@@ -69,7 +69,7 @@ func (c *FileSystemConnection) RunCommand(command string) (*shared.Command, erro
 
 func (c *FileSystemConnection) FileSystem() afero.Fs {
 	if c.fs == nil {
-		c.fs = fs.NewMountedFs(c.MountedDir)
+		c.fs = mountedfs.NewMountedFs(c.MountedDir)
 	}
 	return c.fs
 }

--- a/providers/os/connection/tar/fs.go
+++ b/providers/os/connection/tar/fs.go
@@ -193,8 +193,7 @@ func (fs *FS) tar(path string, header *tar.Header) (io.ReadCloser, error) {
 	return tarReader, nil
 }
 
-// searches for files and returns the file info
-// regex can be nil
+// Find searches for files and returns the file info, regex can be nil
 func (fs *FS) Find(from string, r *regexp.Regexp, typ string, perm *uint32, depth *int) ([]string, error) {
 	list := []string{}
 	for k := range fs.FileMap {

--- a/providers/os/fsutil/find_files.go
+++ b/providers/os/fsutil/find_files.go
@@ -1,7 +1,7 @@
 // Copyright (c) Mondoo, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package fs
+package fsutil
 
 import (
 	"io/fs"

--- a/providers/os/fsutil/find_files_test.go
+++ b/providers/os/fsutil/find_files_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Mondoo, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package fs
+package fsutil
 
 import (
 	"fmt"

--- a/providers/os/fsutil/find_files_unix.go
+++ b/providers/os/fsutil/find_files_unix.go
@@ -4,7 +4,7 @@
 //go:build linux || darwin || netbsd || openbsd || freebsd
 // +build linux darwin netbsd openbsd freebsd
 
-package fs
+package fsutil
 
 import (
 	"errors"

--- a/providers/os/fsutil/find_files_windows.go
+++ b/providers/os/fsutil/find_files_windows.go
@@ -4,7 +4,7 @@
 //go:build windows
 // +build windows
 
-package fs
+package fsutil
 
 import (
 	"errors"

--- a/providers/os/mountedfs/file.go
+++ b/providers/os/mountedfs/file.go
@@ -1,7 +1,7 @@
 // Copyright (c) Mondoo, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package fs
+package mountedfs
 
 import (
 	"os"

--- a/providers/os/mountedfs/fs.go
+++ b/providers/os/mountedfs/fs.go
@@ -1,7 +1,7 @@
 // Copyright (c) Mondoo, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package fs
+package mountedfs
 
 import (
 	"errors"
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/afero"
 	"go.mondoo.com/cnquery/v12/providers/os/connection/shared"
+	"go.mondoo.com/cnquery/v12/providers/os/fsutil"
 )
 
 var _ shared.FileSearch = (*MountedFs)(nil)
@@ -118,5 +119,5 @@ func (t *MountedFs) Chown(name string, uid, gid int) error {
 
 func (t *MountedFs) Find(from string, r *regexp.Regexp, typ string, perm *uint32, depth *int) ([]string, error) {
 	iofs := afero.NewIOFS(t)
-	return FindFiles(iofs, from, r, typ, perm, depth)
+	return fsutil.FindFiles(iofs, from, r, typ, perm, depth)
 }

--- a/providers/os/resources/services/systemd_test.go
+++ b/providers/os/resources/services/systemd_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/cnquery/v12/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v12/providers/os/connection/mock"
-	"go.mondoo.com/cnquery/v12/providers/os/fs"
+	"go.mondoo.com/cnquery/v12/providers/os/mountedfs"
 )
 
 func TestSystemDExtractDescription(t *testing.T) {
@@ -112,7 +112,7 @@ func TestParseServiceSystemDUnitFilesPhoton(t *testing.T) {
 
 func TestSystemdFS(t *testing.T) {
 	s := SystemdFSServiceManager{
-		Fs: fs.NewMountedFs("testdata/systemd"),
+		Fs: mountedfs.NewMountedFs("testdata/systemd"),
 	}
 
 	services, err := s.List()


### PR DESCRIPTION
Extracted from https://github.com/mondoohq/cnquery/pull/6297

This refactors the code:

- extract the files find implementation used for mounted fs so that we can reuse it for other filesystem implementations
- rename `providers/os/fs` to `providers/os/mountedfs`

No functional changes.