### PR TITLE
✨ Use rpm database path as evidence instead of files contained in the…

### DIFF
--- a/providers/os/resources/packages/rpm_packages_test.go
+++ b/providers/os/resources/packages/rpm_packages_test.go
@@ -191,9 +191,8 @@ func TestRedhat8Parser(t *testing.T) {
 	}
 	pkgFiles, err := mgr.Files(p.Name, p.Version, p.Arch)
 	require.NoError(t, err)
-	assert.Equal(t, 15, len(pkgFiles), "detected the right amount of package files")
-	assert.Contains(t, pkgFiles, FileRecord{Path: "/usr/share/doc/which"})
-	assert.Contains(t, pkgFiles, FileRecord{Path: "/usr/share/info/which.info.gz"})
+	assert.Equal(t, 1, len(pkgFiles), "detected the right amount of package files")
+	assert.Contains(t, pkgFiles, FileRecord{Path: "/var/lib/rpm/rpmdb.sqlite"})
 }
 
 func TestPhoton4ImageParser(t *testing.T) {

--- a/providers/os/resources/packages/testdata/packages_redhat8.toml
+++ b/providers/os/resources/packages/testdata/packages_redhat8.toml
@@ -1,6 +1,9 @@
 [commands."command -v rpm"]
 stdout="/usr/bin/rpm"
 
+[commands."rpm -E '%{_dbpath}'"]
+stdout="/var/lib/rpm/rpmdb.sqlite"
+
 [commands."rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}\\n'"]
 stdout="""
 tzdata 0:2021c-1.el8 noarch__Red Hat, Inc.__Timezone data


### PR DESCRIPTION
… rpm

This alignes the rpm packages with dpkg and Windows: https://github.com/mondoohq/cnquery/pull/5399

https://github.com/mondoohq/cnquery/pull/5770