### PR TITLE
🐛 Fix mql compiler on 32-bit architectures

### DIFF
--- a/llx/code.go
+++ b/llx/code.go
@@ -113,7 +113,7 @@ func (l *CodeV2) Block(ref uint64) *Block {
 
 // LastBlockRef retrieves the ref for the last block in the code
 func (l *CodeV2) LastBlockRef() uint64 {
-	return uint64(len(l.Blocks) << 32)
+	return uint64(len(l.Blocks)) << 32
 }
 
 // AddBlock adds a new block at the end of this code and returns its ref


### PR DESCRIPTION
We were losing the top 32 bits of a reference

```
panic: panic compiling "asset.family.contains('linux')\npackages.where(name == /xorg|xserver|wayland/i).any(installed)\n": cannot compute checksum for chunk, it doesn't seem to reference a function on the stack -- map[assetMrn://assets.api.mondoo.app/spaces/*/assets/30Ky6WLkHDJMhi2repLO6yNUija assetName:adsbexchange assetPlatform:raspbian assetPlatformVersion:11 platformIDs://platformid.api.mondoo.app/hostname/adsbexchange spaceMrn://captain.api.mondoo.app/spaces/*]

goroutine 151 [running]:
runtime/debug.Stack()
	/home/runner/_work/_tool/go/1.25.1/x64/src/runtime/debug/stack.go:26 +0x78
go.mondoo.com/cnquery/v12/providers-sdk/v1/upstream/health.ReportPanic({0x2968410, 0x6}, {0x2e20958, 0x7}, {0x2e20960, 0x7}, {0x66854d4, 0x1, 0x1})
	/[email]/providers-sdk/v1/upstream/health/errors.go:32 +0xc8
panic({0x2575198, 0x66af9c8})
	/home/runner/_work/_tool/go/1.25.1/x64/src/runtime/panic.go:783 +0xfc
go.mondoo.com/cnquery/v12/mqlc.Compile.func1()
	/[email]/mqlc/mqlc.go:2239 +0xd4
panic({0x24c7778, 0x2e1d830})
	/home/runner/_work/_tool/go/1.25.1/x64/src/runtime/panic.go:783 +0xfc
go.mondoo.com/cnquery/v12/llx.(*Function).checksumV2(0x6984f30, 0x6984240)
	/[email]/llx/chunk.go:118 +0x264
go.mondoo.com/cnquery/v12/llx.(*Chunk).ChecksumV2(0x6984f00, 0x1, 0x6984240)
	/[email]/llx/chunk.go:105 +0x1d0
go.mondoo.com/cnquery/v12/llx.(*Block).AddChunk(0x60992c0, 0x6984240, 0x1, 0x6984f00)
	/[email]/llx/code.go:57 +0x44
go.mondoo.com/cnquery/v12/mqlc.(*compiler).addValueFieldChunks.func2(0x698b980, {0x6876500, 0x1, 0x10}, 0x1, 0x60992c0, 0x6984a20)
	/[email]/mqlc/mqlc.go:1813 +0x438
go.mondoo.com/cnquery/v12/mqlc.(*compiler).addValueFieldChunks.func6(0x698b970, 0x680ca80, {0x6876500, 0x1, 0x10})
	/[email]/mqlc/mqlc.go:1875 +0x68
go.mondoo.com/cnquery/v12/mqlc.(*compiler).addValueFieldChunks.func3(0x698b970, 0x680ca68, {0x6876500, 0x0, 0x10}, 0x680cae0)
	/[email]/mqlc/mqlc.go:1831 +0x2a4
go.mondoo.com/cnquery/v12/mqlc.(*compiler).addValueFieldChunks(0x686d650, 0x10000000b)
	/[email]/mqlc/mqlc.go:1873 +0xa18
go.mondoo.com/cnquery/v12/mqlc.(*compiler).postCompile(0x686d650)
```