### PR TITLE
🐛 Apply ECS and ECR filters in general and not only during discovery.

### DIFF
--- a/providers/aws/connection/filters.go
+++ b/providers/aws/connection/filters.go
@@ -132,10 +132,46 @@ type EcrDiscoveryFilters struct {
 	ExcludeTags []string
 }
 
+func (f EcrDiscoveryFilters) IsFilteredOutByTags(imageTags []string) bool {
+	return !f.MatchesIncludeTags(imageTags) || f.MatchesExcludeTags(imageTags)
+}
+
+func (f EcrDiscoveryFilters) MatchesIncludeTags(imageTags []string) bool {
+	if len(f.Tags) == 0 {
+		return true
+	}
+
+	for _, filterTag := range f.Tags {
+		if slices.Contains(imageTags, filterTag) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// note: if this function returns `true`, it means that the resource should be skipped
+func (f EcrDiscoveryFilters) MatchesExcludeTags(imageTags []string) bool {
+	for _, filterTag := range f.ExcludeTags {
+		if slices.Contains(imageTags, filterTag) {
+			return true
+		}
+	}
+
+	return false
+}
+
 type EcsDiscoveryFilters struct {
 	OnlyRunningContainers bool
 	DiscoverImages        bool
 	DiscoverInstances     bool
+}
+
+func (f EcsDiscoveryFilters) MatchesOnlyRunningContainers(containerState string) bool {
+	if !f.OnlyRunningContainers {
+		return true
+	}
+	return containerState == "RUNNING"
 }
 
 // Given a key-value pair that matches a key, return the boolean value of the key.

--- a/providers/aws/resources/aws_ecr.go
+++ b/providers/aws/resources/aws_ecr.go
@@ -163,6 +163,10 @@ func (a *mqlAwsEcrRepository) images() ([]any, error) {
 				return nil, err
 			}
 			for _, image := range res.ImageDetails {
+				if conn.Filters.Ecr.IsFilteredOutByTags(image.ImageTags) {
+					log.Debug().Str("repository", name).Strs("tags", image.ImageTags).Msg("skipping ecr public image due to tag filters")
+					continue
+				}
 				mqlImage, err := CreateResource(a.MqlRuntime, ResourceAwsEcrImage,
 					map[string]*llx.RawData{
 						"digest":     llx.StringDataPtr(image.ImageDigest),
@@ -196,6 +200,10 @@ func (a *mqlAwsEcrRepository) images() ([]any, error) {
 			return nil, err
 		}
 		for _, image := range res.ImageDetails {
+			if conn.Filters.Ecr.IsFilteredOutByTags(image.ImageTags) {
+				log.Debug().Str("repository", name).Strs("tags", image.ImageTags).Msg("skipping ecr private image due to tag filters")
+				continue
+			}
 			mqlImage, err := CreateResource(a.MqlRuntime, ResourceAwsEcrImage,
 				map[string]*llx.RawData{
 					"arn":                  llx.StringData(ecrImageArn(ImageInfo{Region: region, RegistryId: convert.ToValue(image.RegistryId), RepoName: name, Digest: convert.ToValue(image.ImageDigest)})),

--- a/providers/aws/resources/aws_ecs.go
+++ b/providers/aws/resources/aws_ecs.go
@@ -408,6 +408,11 @@ func (t *mqlAwsEcsTask) containers() ([]any, error) {
 			name = name + "-" + publicIp
 		}
 
+		if !conn.Filters.Ecs.MatchesOnlyRunningContainers(convert.ToValue(c.LastStatus)) {
+			log.Debug().Str("container", name).Str("state", convert.ToValue(c.LastStatus)).Msg("skipping ecs container due to not being in a running state")
+			continue
+		}
+
 		mqlContainer, err := CreateResource(t.MqlRuntime, "aws.ecs.container",
 			map[string]*llx.RawData{
 				"arn":               llx.StringDataPtr(c.ContainerArn),

--- a/providers/aws/resources/discovery_test.go
+++ b/providers/aws/resources/discovery_test.go
@@ -10,37 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/cnquery/v12/providers-sdk/v1/inventory"
-	"go.mondoo.com/cnquery/v12/providers-sdk/v1/plugin"
-	"go.mondoo.com/cnquery/v12/providers/aws/connection"
 )
-
-func TestFilters(t *testing.T) {
-	// image filters
-	require.True(t, imageMatchesFilters(&mqlAwsEcrImage{
-		Tags: plugin.TValue[[]any]{Data: []any{"latest"}},
-	}, connection.EcrDiscoveryFilters{}))
-
-	require.True(t, imageMatchesFilters(&mqlAwsEcrImage{
-		Tags: plugin.TValue[[]any]{Data: []any{"latest"}},
-	}, connection.EcrDiscoveryFilters{Tags: []string{"latest"}}))
-
-	require.False(t, imageMatchesFilters(&mqlAwsEcrImage{
-		Tags: plugin.TValue[[]any]{Data: []any{"ubu", "test"}},
-	}, connection.EcrDiscoveryFilters{Tags: []string{"latest"}}))
-
-	// container filters
-	require.True(t, containerMatchesFilters(&mqlAwsEcsContainer{
-		Status: plugin.TValue[string]{Data: "RUNNING"},
-	}, connection.EcsDiscoveryFilters{}))
-
-	require.True(t, containerMatchesFilters(&mqlAwsEcsContainer{
-		Status: plugin.TValue[string]{Data: "RUNNING"},
-	}, connection.EcsDiscoveryFilters{OnlyRunningContainers: true}))
-
-	require.False(t, containerMatchesFilters(&mqlAwsEcsContainer{
-		Status: plugin.TValue[string]{Data: "STOPPED"},
-	}, connection.EcsDiscoveryFilters{OnlyRunningContainers: true}))
-}
 
 func TestAddConnInfoToEc2Instances(t *testing.T) {
 	info := instanceInfo{}


### PR DESCRIPTION
These ECR/ECS filters were only being applied during discovery. This moves the filter evaluation at the API call level which makes sure it works in general without the `--discover` flag. This also allows us to remove some more legacy functions.

Output from a test run:
```
cnquery> aws.ecr.privateRepositories { images { * } }
DBG skipping ecr private image due to tag filters repository=vasil/testrepo tags=["latest"]
DBG finished query execution qrid=pMXEAtU4uJI=
DBG VMlGZugtMv/xdwgWLhX3vB+R4ISz9WJWSaUexK0uzPagiwaJlAbh0Of8J4lyxMmU5Ipd6OI7FrnApcoNVZQUag== finished
DBG graph has received all datapoints
aws.ecr.privateRepositories: [
  0: {
    images: []
  }
]
```