### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -1,4 +1,6 @@
 name: Code Test
+permissions:
+  contents: read
 
 ## Only trigger tests if source is changing
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/mondoohq/cnquery/security/code-scanning/14](https://github.com/mondoohq/cnquery/security/code-scanning/14)

To fix this, explicitly define minimal `permissions` for the workflow so that any job without its own `permissions` block (like `go-test`, `go-test-integration`, `go-race`, `go-bench`, and `event_file`) gets a restricted token. The best conservative default is to set `permissions: contents: read` at the workflow root, which is sufficient for typical checkout and read-only operations and is compatible with most third‑party actions. Jobs that already have custom permissions, such as `go-auto-approve`, will continue to use their own block and override the default.

Concretely, in `.github/workflows/pr-test-lint.yml`, add a top-level `permissions:` section right after the `name: Code Test` line (before `on:`). Set it to `contents: read`. No other changes are required to jobs, including `event_file`; it will now inherit the minimal read-only permissions. No additional imports or external libraries are needed, since this is only a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
