### PR TITLE
💡 add a tracker for provider/resources/fields suggestions

### DIFF
--- a/docs/resources-ideas.md
+++ b/docs/resources-ideas.md
@@ -23,3 +23,13 @@ To make suggestions, please follow this schema:
 
 We will regularly review this document and cross things off as they get done.
 
+
+## os
+
+- modprobe.d
+  - files: find all files across modprobe, to simplify this:
+    ```
+    file("/etc/modprobe.d/atm.conf").exists &&
+    file("/etc/modprobe.d/atm.conf").content.contains("install atm /bin/false") &&
+    file("/etc/modprobe.d/atm.conf").content.contains("blacklist atm")
+    ```


### PR DESCRIPTION
## modprobe config resource

A resource for gathering all modprobe .d files so you can simply search for specific config entries. Right now we're coding into our checks the configs which means everything will fail until users comply with our expected paths and that's not great.

Current check:
```
file("/etc/modprobe.d/atm.conf").exists &&
file("/etc/modprobe.d/atm.conf").content.contains("install atm /bin/false") &&
file("/etc/modprobe.d/atm.conf").content.contains("blacklist atm")
```

## sudoers config resource

A resource that gathers the various sudoers configs and exposes those. Allows us to eliminate props that are doing that work today

```
    props:
      - uid: mondooLinuxSecuritySudoersFiles
        title: Return the files from /etc/sudoers.d
        mql: |
          sudoersFiles = files.find(from: "/etc/sudoers.d/", type: 'file').list.map(path) + ["/etc/sudoers"]
          return sudoersFiles.map(file(_).content.lines.where(_ == /^[^#]/)).flat
    mql: |
      props.mondooLinuxSecuritySudoersFiles
        .where(_ == /Defaults/)
        .any(_ == /logfile=\"\/var\/log\/sudo\.log\"/)
```

## limits config resource

A resource that gathers all the individual limits files and exposes those in a single resource call

Current check:
```
    mql: |
      securityLimitFiles = files.find(from: '/etc/security/limits.d/', type: 'file')
        .list.where(basename == /\.(conf)$/)
        .map(path)

      securityLimitAllFiles = securityLimitFiles + ["/etc/security/limits.conf"]

      securityLimitAllFiles.map(file(_).content.lines.where( _ == /^[^#]/ )).flat.one(_ == /\*\s+hard\s+core\s+0/)

      kernel.parameters['fs.suid_dumpable'] == 0
      if(service("coredump").enabled || service("coredump").running) {
        parse.ini("/etc/systemd/coredump.conf").sections['Coredump']['ProcessSizeMax'] == 0
        parse.ini("/etc/systemd/coredump.conf").sections['Coredump']['Storage'] == 'none'
      }
```


## 