### PR TITLE
✨ Detect Azure Edition and hotpatching for Windows

### DIFF
--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -734,6 +734,20 @@ func TestWindows2025Detector(t *testing.T) {
 	assert.Equal(t, []string{"windows", "os"}, di.Family)
 }
 
+func TestAzureWindows2025Detector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-azure-windows2025.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "windows", di.Name, "os name should be identified")
+	assert.Equal(t, "Windows Server 2025 Datacenter Azure Edition", di.Title, "os title should be identified")
+	assert.Equal(t, "26311", di.Version, "os version should be identified")
+	assert.Equal(t, "5000", di.Build, "os build version should be identified")
+	assert.Equal(t, "AMD64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"windows", "os"}, di.Family)
+	assert.Equal(t, "ServerTurbine", di.Labels["windows.mondoo.com/edition-id"])
+	assert.Equal(t, "false", di.Labels["windows.mondoo.com/hotpatch"])
+}
+
 func TestPhoton1Detector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-photon1.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/detector_test.go
+++ b/providers/os/detector/detector_test.go
@@ -108,6 +108,7 @@ func TestWindowsPlatform(t *testing.T) {
 				Labels: map[string]string{
 					"windows.mondoo.com/product-type":    "1",
 					"windows.mondoo.com/display-version": "21H2",
+					"windows.mondoo.com/edition-id":      "Professional",
 				},
 			},
 		},
@@ -133,6 +134,7 @@ func TestWindowsPlatform(t *testing.T) {
 				Labels: map[string]string{
 					"windows.mondoo.com/product-type":    "1",
 					"windows.mondoo.com/display-version": "23H2",
+					"windows.mondoo.com/edition-id":      "Professional",
 				},
 			},
 		},
@@ -158,6 +160,7 @@ func TestWindowsPlatform(t *testing.T) {
 				Labels: map[string]string{
 					"windows.mondoo.com/product-type":    "3",
 					"windows.mondoo.com/display-version": "21H2",
+					"windows.mondoo.com/edition-id":      "ServerStandard",
 				},
 			},
 		},

--- a/providers/os/detector/testdata/detect-azure-windows2025.toml
+++ b/providers/os/detector/testdata/detect-azure-windows2025.toml
@@ -1,0 +1,13 @@
+[commands."55dbc0e9b838caa11145eed07f6e73644bda27bf65a0c58a52291f9a18384481"]
+stdout="""
+{
+    "CurrentBuild":  "26311",
+    "UBR":  5000,
+    "InstallationType":  "Server",
+    "EditionID":  "ServerTurbine",
+    "ProductName":  "Windows Server 2025 Datacenter Azure Edition",
+    "DisplayVersion":  "24H2",
+    "Architecture":  "AMD64",
+    "ProductType":  "ServerNT"
+}
+"""

--- a/providers/os/detector/windows/hotpatch.go
+++ b/providers/os/detector/windows/hotpatch.go
@@ -1,0 +1,65 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package windows
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/v12/providers/os/connection/shared"
+	"go.mondoo.com/cnquery/v12/providers/os/resources/powershell"
+)
+
+const (
+	HotpatchPackage = "Hotpatch Enrollment Package"
+)
+
+type WindowsHotpatch struct {
+	Name                              string `json:"Name"`
+	HotPatchTableSize                 string `json:"HotPatchTableSize"`
+	EnableVirtualizationBasedSecurity string `json:"EnableVirtualizationBasedSecurity"`
+}
+
+func ParseWinRegistryHotpatch(r io.Reader) (bool, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return false, err
+	}
+
+	var hotpatch WindowsHotpatch
+	err = json.Unmarshal(data, &hotpatch)
+	if err != nil {
+		return false, err
+	}
+	log.Debug().Interface("Hotpatch", hotpatch).Msg("Parsed hotpatch information")
+
+	return hotpatch.Name == HotpatchPackage && hotpatch.EnableVirtualizationBasedSecurity == "1" && hotpatch.HotPatchTableSize != "0", nil
+}
+
+// https://learn.microsoft.com/en-us/windows-server/get-started/hotpatch
+// https://learn.microsoft.com/en-us/windows-server/get-started/enable-hotpatch-azure-edition
+
+// powershellGetWindowsHotpatch runs a powershell script to determine whether hotpatching is enabled on the system.
+func powershellGetWindowsHotpatch(conn shared.Connection, arch string) (bool, error) {
+	// FIXME: for windows 2025 this might be arm64
+	pscommand := `
+$info = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Update\TargetingInfo\DynamicInstalled\Hotpatch.` + strings.ToLower(arch) + `' -Name Name
+$sysInfo = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\DeviceGuard' -Name EnableVirtualizationBasedSecurity
+$hotpatch = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management' -Name HotPatchTableSize
+$sysInfo | Add-Member -MemberType NoteProperty -Name Name -Value $info.Name
+$hotpatch | Add-Member -MemberType NoteProperty -Name HotPatchTableSize -Value $hotpatch.HotPatchTableSize
+$sysInfo | Select-Object Name, EnableVirtualizationBasedSecurity, HotPatchTableSize | ConvertTo-Json
+`
+
+	log.Debug().Msg("checking Windows hotpatch runtime")
+	cmd, err := conn.RunCommand(powershell.Encode(pscommand))
+	if err != nil {
+		log.Debug().Err(err).Msg("could not run powershell command to get hotpatch information")
+		// Don't return an error here, as it is expected that this key may not exist
+		return false, nil
+	}
+	return ParseWinRegistryHotpatch(cmd.Stdout)
+}

--- a/providers/os/detector/windows/hotpatch_test.go
+++ b/providers/os/detector/windows/hotpatch_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package windows
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseWinRegistryHotpatch(t *testing.T) {
+
+	t.Run("parse hptpatching settings correctly", func(t *testing.T) {
+		data := `{
+			"Name":  "Hotpatch Enrollment Package",
+			"HotPatchTableSize": "4096",
+			"EnableVirtualizationBasedSecurity": "1"
+		}`
+
+		m, err := ParseWinRegistryHotpatch(strings.NewReader(data))
+		assert.Nil(t, err)
+		assert.True(t, m)
+	})
+
+	t.Run("parse missing table size", func(t *testing.T) {
+		data := `{
+			"Name":  "Hotpatch Enrollment Package",
+			"HotPatchTableSize": "0",
+			"EnableVirtualizationBasedSecurity": "1"
+		}`
+
+		m, err := ParseWinRegistryHotpatch(strings.NewReader(data))
+		assert.Nil(t, err)
+		assert.False(t, m)
+	})
+
+	t.Run("parse missing name", func(t *testing.T) {
+		data := `{
+			"Name":  "",
+			"HotPatchTableSize": "4096",
+			"EnableVirtualizationBasedSecurity": "1"
+		}`
+
+		m, err := ParseWinRegistryHotpatch(strings.NewReader(data))
+		assert.Nil(t, err)
+		assert.False(t, m)
+	})
+
+	t.Run("parse missing VBS", func(t *testing.T) {
+		data := `{
+			"Name":  "Hotpatch Enrollment Package",
+			"HotPatchTableSize": "1",
+			"EnableVirtualizationBasedSecurity": "0"
+		}`
+
+		m, err := ParseWinRegistryHotpatch(strings.NewReader(data))
+		assert.Nil(t, err)
+		assert.False(t, m)
+	})
+}

--- a/providers/os/detector/windows/hotpatch_unix.go
+++ b/providers/os/detector/windows/hotpatch_unix.go
@@ -1,0 +1,30 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build linux || darwin || netbsd || openbsd || freebsd
+// +build linux darwin netbsd openbsd freebsd
+
+package windows
+
+import (
+	"strconv"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/v12/providers-sdk/v1/inventory"
+	"go.mondoo.com/cnquery/v12/providers/os/connection/shared"
+)
+
+func GetWindowsHotpatch(conn shared.Connection, pf *inventory.Platform) (bool, error) {
+	buildNumber, err := strconv.Atoi(pf.Version)
+	if err != nil {
+		log.Error().Err(err).Msg("could not parse windows build number")
+	}
+	log.Debug().Int("buildNumber", buildNumber).Msg("parsed windows build number")
+	if buildNumber < 20348 {
+		return false, nil
+	}
+
+	// In case of Windows Server 2022+, check for hotpatching
+	// This can be activated for on-prem or Azure Editions
+	return powershellGetWindowsHotpatch(conn, pf.Arch)
+}

--- a/providers/os/detector/windows/hotpatch_windows.go
+++ b/providers/os/detector/windows/hotpatch_windows.go
@@ -1,0 +1,84 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build windows
+// +build windows
+
+package windows
+
+import (
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/cnquery/v12/providers-sdk/v1/inventory"
+	"go.mondoo.com/cnquery/v12/providers/os/connection/shared"
+	"golang.org/x/sys/windows/registry"
+)
+
+func GetWindowsHotpatch(conn shared.Connection, pf *inventory.Platform) (bool, error) {
+	log.Debug().Msg("checking windows hotpatch")
+
+	buildNumber, err := strconv.Atoi(pf.Version)
+	if err != nil {
+		log.Error().Err(err).Msg("could not parse windows build number")
+	}
+	log.Debug().Int("buildNumber", buildNumber).Msg("parsed windows build number")
+	if buildNumber < 20348 {
+		return false, nil
+	}
+	// In case of Windows Server 2022+, check for hotpatching
+	// This can be activated for on-prem or Azure Editions
+
+	// if we are running locally on windows, we want to avoid using powershell to be faster
+	if conn.Type() == shared.Type_Local && runtime.GOOS == "windows" {
+		k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion\Update\TargetingInfo\DynamicInstalled\Hotpatch.`+strings.ToLower(pf.Arch), registry.QUERY_VALUE)
+		if err != nil {
+			log.Debug().Err(err).Msg("could not open registry key DynamicInstalled")
+			// Don't return an error here, as it is expected that this key may not exist
+			return false, nil
+		}
+		defer k.Close()
+
+		hotpatchName, _, err := k.GetStringValue("Name")
+		if err != nil && err != registry.ErrNotExist {
+			return false, err
+		}
+
+		systemKey, err := registry.OpenKey(registry.LOCAL_MACHINE, `SYSTEM\CurrentControlSet\Control\DeviceGuard`, registry.QUERY_VALUE)
+		if err != nil {
+			log.Debug().Err(err).Msg("could not open registry key DeviceGuard")
+			// Don't return an error here, as it is expected that this key may not exist
+			return false, nil
+		}
+		defer systemKey.Close()
+
+		enableVirtualizationBasedSecurity, _, err := systemKey.GetIntegerValue("EnableVirtualizationBasedSecurity")
+		if err != nil && err != registry.ErrNotExist {
+			log.Debug().Err(err).Msg("could not get EnableVirtualizationBasedSecurity value")
+			return false, err
+		}
+
+		memoryKey, err := registry.OpenKey(registry.LOCAL_MACHINE, `SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management`, registry.QUERY_VALUE)
+		if err != nil {
+			log.Debug().Err(err).Msg("could not open registry key Memory Management")
+			// Don't return an error here, as it is expected that this key may not exist
+			return false, nil
+		}
+		defer memoryKey.Close()
+
+		hotPatchTableSize, _, err := memoryKey.GetIntegerValue("HotPatchTableSize")
+		if err != nil && err != registry.ErrNotExist {
+			log.Debug().Err(err).Msg("could not get HotPatchTableSize value")
+			return false, err
+		}
+
+		log.Debug().Str("hotpatchName", hotpatchName).Int("enableVirtualizationBasedSecurity", int(enableVirtualizationBasedSecurity)).Int("hotPatchTableSize", int(hotPatchTableSize)).Msg("parsed windows hotpatch settings")
+
+		return hotpatchName == HotpatchPackage && enableVirtualizationBasedSecurity == 1 && hotPatchTableSize > 0, nil
+	}
+
+	// for all non-local checks use powershell
+	return powershellGetWindowsHotpatch(conn, pf.Arch)
+}


### PR DESCRIPTION
This is an Azure 2022 image with Hotpatching enabled by default:
<img width="775" height="237" alt="Screenshot 2025-12-31 at 08 26 39" src="https://github.com/user-attachments/assets/65329e2e-e690-48e9-8cf1-fa63b3f75bf5" />

Windows 2025 has is not enabled by default:
<img width="866" height="275" alt="Screenshot 2025-12-31 at 08 32 34" src="https://github.com/user-attachments/assets/e345ce14-461c-4e44-9534-ca97bd4233dc" />

But you can add the registry key and get the hotpatching:
<img width="856" height="298" alt="Screenshot 2025-12-31 at 09 22 49" src="https://github.com/user-attachments/assets/ebac05b8-49a7-4562-b6b7-d1840042bd5c" />
