### PR TITLE
⭐ Detect gardenlinux platform and version

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -179,7 +179,13 @@ var debian = &PlatformResolver{
 			return false, nil
 		}
 
-		pf.Version = strings.TrimSpace(string(c))
+		// gardenlinux identifies itself as debian, but we want to set the proper name / version
+		if osr["GARDENLINUX_VERSION"] != "" {
+			pf.Name = "gardenlinux"
+			pf.Version = osr["GARDENLINUX_VERSION"]
+		} else {
+			pf.Version = strings.TrimSpace(string(c))
+		}
 
 		unamem, err := osrd.unamem()
 		if err == nil {

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -1050,3 +1050,14 @@ func TestEulerOSDetector(t *testing.T) {
 	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
 	assert.Equal(t, []string{"euler", "linux", "unix", "os"}, di.Family)
 }
+
+func TestGardenLinuxDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-gardenlinux.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "gardenlinux", di.Name, "os name should be identified")
+	assert.Equal(t, "Garden Linux 934.0", di.Title, "os title should be identified")
+	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"debian", "linux", "unix", "os"}, di.Family)
+	assert.Equal(t, "934.0", di.Version, "os version should be identified")
+}

--- a/providers/os/detector/testdata/detect-gardenlinux.toml
+++ b/providers/os/detector/testdata/detect-gardenlinux.toml
@@ -1,0 +1,28 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "4.9.125-linuxkit"
+
+[files."/etc/os-release"]
+content = """
+PRETTY_NAME="Garden Linux 934.0"
+NAME="Debian GNU/Linux"
+VERSION_CODENAME=bookworm
+ID=debian
+HOME_URL="https://gardenlinux.io/"
+SUPPORT_URL="https://github.com/gardenlinux/gardenlinux"
+BUG_REPORT_URL="https://github.com/gardenlinux/gardenlinux/issues"
+GARDENLINUX_FEATURES=_slim,base,server,cloud,kvm,_nopkg,_prod
+GARDENLINUX_VERSION=934.0
+GARDENLINUX_VERSION_AT_BUILD=934.0
+GARDENLINUX_COMMIT_ID_LONG=86f69dcbf95d0ab9c6909421d4082449cae05e16
+GARDENLINUX_COMMIT_ID=86f69dc
+VERSION_CODENAME=934.0
+"""
+
+[files."/etc/debian_version"]
+content = "bookworm/sid"


### PR DESCRIPTION
The os-release file is debian but with extra fields so add additional logic to our debian detection to check for those fields and return gardenlinux when present.