### PR TITLE
⭐️ Add Azure `cloudDefender.defenderForApis` and `cloudDefender.defenderCSPM` resource

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -2082,7 +2082,15 @@ private azure.subscription.cloudDefenderService.defenderCSPM @defaults("enabled 
   // Sub-plan for Defender CSPM
   subPlan string
   // Extensions configured for Defender CSPM
-  extensions []dict
+  extensions() []azure.subscription.cloudDefenderService.defenderCSPM.extension
+}
+
+// Microsoft Defender CSPM extension
+private azure.subscription.cloudDefenderService.defenderCSPM.extension {
+  // Extension name
+  name string
+  // Whether the extension is enabled
+  isEnabled bool
 }
 
 // Microsoft Defender for Cloud security contact

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -120,6 +120,7 @@ const (
 	ResourceAzureSubscriptionCloudDefenderServiceSettings                              string = "azure.subscription.cloudDefenderService.settings"
 	ResourceAzureSubscriptionCloudDefenderServiceDefenderForApis                       string = "azure.subscription.cloudDefenderService.defenderForApis"
 	ResourceAzureSubscriptionCloudDefenderServiceDefenderCSPM                          string = "azure.subscription.cloudDefenderService.defenderCSPM"
+	ResourceAzureSubscriptionCloudDefenderServiceDefenderCSPMExtension                 string = "azure.subscription.cloudDefenderService.defenderCSPM.extension"
 	ResourceAzureSubscriptionCloudDefenderServiceSecurityContact                       string = "azure.subscription.cloudDefenderService.securityContact"
 	ResourceAzureSubscriptionAuthorizationService                                      string = "azure.subscription.authorizationService"
 	ResourceAzureSubscriptionAuthorizationServiceRoleDefinition                        string = "azure.subscription.authorizationService.roleDefinition"
@@ -555,6 +556,10 @@ func init() {
 		"azure.subscription.cloudDefenderService.defenderCSPM": {
 			// to override args, implement: initAzureSubscriptionCloudDefenderServiceDefenderCSPM(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAzureSubscriptionCloudDefenderServiceDefenderCSPM,
+		},
+		"azure.subscription.cloudDefenderService.defenderCSPM.extension": {
+			// to override args, implement: initAzureSubscriptionCloudDefenderServiceDefenderCSPMExtension(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAzureSubscriptionCloudDefenderServiceDefenderCSPMExtension,
 		},
 		"azure.subscription.cloudDefenderService.securityContact": {
 			// to override args, implement: initAzureSubscriptionCloudDefenderServiceSecurityContact(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -3211,7 +3216,13 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderCSPM).GetSubPlan()).ToDataRes(types.String)
 	},
 	"azure.subscription.cloudDefenderService.defenderCSPM.extensions": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderCSPM).GetExtensions()).ToDataRes(types.Array(types.Dict))
+		return (r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderCSPM).GetExtensions()).ToDataRes(types.Array(types.Resource("azure.subscription.cloudDefenderService.defenderCSPM.extension")))
+	},
+	"azure.subscription.cloudDefenderService.defenderCSPM.extension.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderCSPMExtension).GetName()).ToDataRes(types.String)
+	},
+	"azure.subscription.cloudDefenderService.defenderCSPM.extension.isEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderCSPMExtension).GetIsEnabled()).ToDataRes(types.Bool)
 	},
 	"azure.subscription.cloudDefenderService.securityContact.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderServiceSecurityContact).GetId()).ToDataRes(types.String)
@@ -7323,6 +7334,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.cloudDefenderService.defenderCSPM.extensions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderCSPM).Extensions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.defenderCSPM.extension.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderCSPMExtension).__id, ok = v.Value.(string)
+		return
+	},
+	"azure.subscription.cloudDefenderService.defenderCSPM.extension.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderCSPMExtension).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.defenderCSPM.extension.isEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderCSPMExtension).IsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cloudDefenderService.securityContact.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -18217,7 +18240,73 @@ func (c *mqlAzureSubscriptionCloudDefenderServiceDefenderCSPM) GetSubPlan() *plu
 }
 
 func (c *mqlAzureSubscriptionCloudDefenderServiceDefenderCSPM) GetExtensions() *plugin.TValue[[]any] {
-	return &c.Extensions
+	return plugin.GetOrCompute[[]any](&c.Extensions, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService.defenderCSPM", c.__id, "extensions")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.extensions()
+	})
+}
+
+// mqlAzureSubscriptionCloudDefenderServiceDefenderCSPMExtension for the azure.subscription.cloudDefenderService.defenderCSPM.extension resource
+type mqlAzureSubscriptionCloudDefenderServiceDefenderCSPMExtension struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAzureSubscriptionCloudDefenderServiceDefenderCSPMExtensionInternal it will be used here
+	Name      plugin.TValue[string]
+	IsEnabled plugin.TValue[bool]
+}
+
+// createAzureSubscriptionCloudDefenderServiceDefenderCSPMExtension creates a new instance of this resource
+func createAzureSubscriptionCloudDefenderServiceDefenderCSPMExtension(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAzureSubscriptionCloudDefenderServiceDefenderCSPMExtension{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("azure.subscription.cloudDefenderService.defenderCSPM.extension", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderServiceDefenderCSPMExtension) MqlName() string {
+	return "azure.subscription.cloudDefenderService.defenderCSPM.extension"
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderServiceDefenderCSPMExtension) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderServiceDefenderCSPMExtension) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderServiceDefenderCSPMExtension) GetIsEnabled() *plugin.TValue[bool] {
+	return &c.IsEnabled
 }
 
 // mqlAzureSubscriptionCloudDefenderServiceSecurityContact for the azure.subscription.cloudDefenderService.securityContact resource

--- a/providers/azure/resources/azure.lr.manifest.yaml
+++ b/providers/azure/resources/azure.lr.manifest.yaml
@@ -585,6 +585,15 @@ resources:
     platform:
       name:
       - azure
+  azure.subscription.cloudDefenderService.defenderCSPM.extension:
+    fields:
+      isEnabled: {}
+      name: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
+    platform:
+      name:
+      - azure
   azure.subscription.cloudDefenderService.defenderForApis:
     fields:
       enabled: {}


### PR DESCRIPTION
Adds resource for `cloudDefender.defenderForApis` and `cloudDefender.defenderCSPM`. 
Verified with commands `go run ./apps/cnquery/cnquery.go run azure -c "azure.subscription.cloudDefender.defenderCSPM{*}"` and `go run ./apps/cnquery/cnquery.go run azure -c "azure.subscription.cloudDefender.defenderForApis{*}"`

Closes https://github.com/mondoohq/cnquery/issues/6255