### PR TITLE
🧹 Set default workflow permissions

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -6,9 +6,17 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+      statuses: write
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the Mondoo CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,9 @@ on:
   schedule:
     - cron: "30 17 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -3,19 +3,22 @@ name: goreleaser edge containers
 on:
   push:
     branches:
-      - 'main'
+      - "main"
   workflow_dispatch:
 
 env:
   REGISTRY: docker.io
 
+permissions:
+  contents: read
+
 jobs:
   goreleaser:
     permissions:
       # Add "contents" to write release
-      contents: 'write'
+      contents: "write"
       # Add "id-token" for google-github-actions/auth
-      id-token: 'write'
+      id-token: "write"
 
     runs-on:
       group: Default
@@ -40,7 +43,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ env.protoc-version }}
-          
+
       - name: Log in to the Container registry
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
@@ -52,7 +55,7 @@ jobs:
         run: |
           VERSION=$(make version)
           git tag ${VERSION/\+/-}
-          
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -3,11 +3,11 @@ name: goreleaser
 on:
   push:
     tags:
-      - '*'
+      - "*"
   workflow_dispatch:
     inputs:
       skip-publish:
-        description: 'Skip publishing to releases.mondoo.com?'
+        description: "Skip publishing to releases.mondoo.com?"
         type: boolean
         required: false
         default: false
@@ -17,7 +17,7 @@ on:
         default: false
         type: boolean
       goreleaser-snapshot:
-        description: 'Run goreleaser in snapshot mode, which will not publish and bypass tag checks.'
+        description: "Run goreleaser in snapshot mode, which will not publish and bypass tag checks."
         required: false
         default: false
         type: boolean
@@ -30,13 +30,16 @@ on:
 env:
   REGISTRY: docker.io
 
+permissions:
+  contents: read
+
 jobs:
   goreleaser:
     permissions:
       # Add "contents" to write release
-      contents: 'write'
+      contents: "write"
       # Add "id-token" for google-github-actions/auth
-      id-token: 'write'
+      id-token: "write"
 
     runs-on:
       group: Default
@@ -61,7 +64,7 @@ jobs:
 
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV
-      
+
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
@@ -74,8 +77,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ env.protoc-version }}
 
-      - name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093' # v3.0.0
+      - name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093" # v3.0.0
         with:
           workload_identity_provider: ${{ secrets.GCP_WIP }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
@@ -86,10 +89,10 @@ jobs:
           base64 -d <<<"$GPG_KEY" > "$gpgkey"
           echo "GPG_KEY_PATH=$gpgkey" >> $GITHUB_ENV
         env:
-          GPG_KEY: '${{ secrets.GPG_KEY}}'
+          GPG_KEY: "${{ secrets.GPG_KEY}}"
 
-# jsign and azure-cli are both requirements for Azure Trusted Signing and these actions to authenticate
-# These packages have been installed on the self-hosted runner using ansible from the private repo
+      # jsign and azure-cli are both requirements for Azure Trusted Signing and these actions to authenticate
+      # These packages have been installed on the self-hosted runner using ansible from the private repo
 
       - name: Azure login
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
@@ -112,11 +115,10 @@ jobs:
           echo "Access token prefix: ${PREFIX}..."
           echo "TSIGN_ACCESS_TOKEN=$TSIGN_ACCESS_TOKEN" >> $GITHUB_OUTPUT
 
-
       - name: Install Quill for Mac Signing and Notarization
         run: |
-            curl -sSfL https://raw.githubusercontent.com/anchore/quill/main/install.sh | sh -s -- -b /tmp
-            /tmp/quill help
+          curl -sSfL https://raw.githubusercontent.com/anchore/quill/main/install.sh | sh -s -- -b /tmp
+          /tmp/quill help
 
       - name: Log in to the Container registry
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
@@ -149,7 +151,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CERT_PASSWORD: ${{ steps.gcp_secrets.outputs.code_sign_cert_challenge }}
           NFPM_DEFAULT_RPM_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          QUILL_SIGN_PASSWORD: ''
+          QUILL_SIGN_PASSWORD: ""
           QUILL_SIGN_P12: ${{ secrets.APPLE_SIGN_P12 }}
           QUILL_NOTARY_KEY: ${{ secrets.APPLE_NOTARY_KEY }}
           QUILL_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
@@ -175,7 +177,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CERT_PASSWORD: ${{ steps.gcp_secrets.outputs.code_sign_cert_challenge }}
           NFPM_DEFAULT_RPM_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          QUILL_SIGN_PASSWORD: ''
+          QUILL_SIGN_PASSWORD: ""
           QUILL_SIGN_P12: ${{ secrets.APPLE_SIGN_P12 }}
           QUILL_NOTARY_KEY: ${{ secrets.APPLE_NOTARY_KEY }}
           QUILL_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
@@ -217,5 +219,5 @@ jobs:
           repository: "mondoohq/cnspec"
           event-type: update-cnquery
           client-payload: '{
-              "version": "${{  github.ref_name }}"
+            "version": "${{  github.ref_name }}"
             }'

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -3,6 +3,9 @@ name: License Test
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   license-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -6,6 +6,9 @@ name: Link Checking
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   md-links:
     name: Run markdown link check

--- a/.github/workflows/pr-extended-linting.yml
+++ b/.github/workflows/pr-extended-linting.yml
@@ -4,9 +4,12 @@ name: Extended Linting
 on:
   pull_request:
     paths:
-      - '**.go'
-      - '**.mod'
-      - 'go.sum'
+      - "**.go"
+      - "**.mod"
+      - "go.sum"
+
+permissions:
+  contents: read
 
 jobs:
   golangci-lint:
@@ -27,7 +30,7 @@ jobs:
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
           go-version: ">=${{ env.golang-version }}"
-          cache: false      
+          cache: false
       - name: Generate test files
         run: make test/generate
       - name: Run golangci-lint

--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -4,12 +4,15 @@ name: Generated Code Test
 on:
   push:
     paths:
-      - '**.proto'
-      - '**.lr'
-      - '**.go'
+      - "**.proto"
+      - "**.lr"
+      - "**.go"
 
 env:
   PROTO_VERSION: "21.7"
+
+permissions:
+  contents: read
 
 jobs:
   # Check if there is any dirty change for generated files
@@ -32,10 +35,10 @@ jobs:
       # We do not permit sudo on self-hosted runners
       - name: "Ensure GCC is installed"
         run: |
-          if gcc --version; then 
-            echo "Good to go"; 
-          else 
-            echo "Install GCC on the runner."; 
+          if gcc --version; then
+            echo "Good to go";
+          else
+            echo "Install GCC on the runner.";
           fi
 
         # Note we do not use apt install -y protobuf-compiler` since it is too old

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -4,12 +4,15 @@ name: Code Test
 on:
   push:
     paths:
-      - '**.go'
-      - '**.mod'
-      - 'go.sum'
-      - 'Makefile'
-      - '.github/workflows/pr-test-lint.yml'
-      - '**.toml' # run tests when any recording changed
+      - "**.go"
+      - "**.mod"
+      - "go.sum"
+      - "Makefile"
+      - ".github/workflows/pr-test-lint.yml"
+      - "**.toml" # run tests when any recording changed
+
+permissions:
+  contents: read
 
 jobs:
   # Check if there is any dirty change for go mod tidy
@@ -77,8 +80,8 @@ jobs:
           go-version: ">=${{ env.golang-version }}"
           cache: false
 
-      - name: 'Set up gcloud CLI'
-        uses: 'google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db' # v3.0.1
+      - name: "Set up gcloud CLI"
+        uses: "google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db" # v3.0.1
 
       - name: Set provider env
         run: echo "PROVIDERS_PATH=${PWD}/.providers" >> $GITHUB_ENV
@@ -92,10 +95,10 @@ jobs:
         run: make providers/test
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: success() || failure()        # run this step even if previous step failed
+        if: success() || failure() # run this step even if previous step failed
         with:
           name: test-results
-          path: '*.xml'
+          path: "*.xml"
 
   go-test-integration:
     runs-on:
@@ -114,8 +117,8 @@ jobs:
           go-version: ">=${{ env.golang-version }}"
           cache: false
 
-      - name: 'Set up gcloud CLI'
-        uses: 'google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db' # v3.0.1
+      - name: "Set up gcloud CLI"
+        uses: "google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db" # v3.0.1
 
       - name: Set provider env
         run: echo "PROVIDERS_PATH=${PWD}/.providers" >> $GITHUB_ENV
@@ -126,7 +129,7 @@ jobs:
         run: make test/integration
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: success() || failure()        # run this step even if previous step failed
+        if: success() || failure() # run this step even if previous step failed
         with:
           name: test-results-cli
           path: report.xml
@@ -182,7 +185,7 @@ jobs:
         uses: benchmark-action/github-action-benchmark@4bdcce38c94cec68da58d012ac24b7b1155efe8b # v1.20.7
         with:
           # What benchmark tool the output.txt came from
-          tool: 'go'
+          tool: "go"
           # Where the output from the benchmark tool is stored
           output-file-path: benchmark.txt
           # Where the previous data file is stored
@@ -192,7 +195,7 @@ jobs:
           summary-always: true
           fail-on-alert: true
           save-data-file: false
-          alert-threshold: '150%'
+          alert-threshold: "150%"
 
   go-auto-approve:
     runs-on: ubuntu-latest
@@ -228,13 +231,13 @@ jobs:
           gh pr merge ${{ steps.pr.outputs.number }} --squash
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-          
+
   event_file:
     name: "Store event file"
     runs-on: ubuntu-latest
     steps:
-    - name: Upload
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-      with:
-        name: Event File
-        path: ${{ github.event_path }}
+      - name: Upload
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: Event File
+          path: ${{ github.event_path }}

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -22,6 +22,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 env:
   BUCKET: releases-us.mondoo.io
   SKIP_PROVIDERS: "core"

--- a/.github/workflows/release-providers.yml
+++ b/.github/workflows/release-providers.yml
@@ -5,6 +5,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update-deps:
     runs-on: ubuntu-latest
@@ -12,11 +15,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-# https://github.com/peter-evans/create-pull-request/issues/48
-# https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#push-using-ssh-deploy-keys
-# tl;dr:
-# The GITHUB_TOKEN is limited when creating PRs from a workflow
-# becasue of that we use a ssh key for which the limitations do not apply
+      # https://github.com/peter-evans/create-pull-request/issues/48
+      # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#push-using-ssh-deploy-keys
+      # tl;dr:
+      # The GITHUB_TOKEN is limited when creating PRs from a workflow
+      # becasue of that we use a ssh key for which the limitations do not apply
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
@@ -53,7 +56,7 @@ jobs:
           echo "COMMIT_TITLE=${COMMIT_MSG}" >> $GITHUB_OUTPUT
           echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
 
-# We have to use this extensions, becasuse `gh pr create` does not support the ssh key case
+      # We have to use this extensions, becasuse `gh pr create` does not support the ssh key case
       - name: Create pull request
         id: cpr
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0

--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -5,6 +5,8 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: read
 jobs:
   spelling:
     name: Run spell check

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,29 +1,31 @@
-
-name: 'Test Report'
+name: "Test Report"
 on:
   workflow_run:
-    workflows: ['Code Test'] # runs after tests
+    workflows: ["Code Test"] # runs after tests
     types:
       - completed
+
+permissions:
+  contents: read
 jobs:
   report:
     permissions:
-      actions: read        # Required to read the artifact
-      contents: read       # Required to read the source
-      checks: write        # Required to write the results
+      actions: read # Required to read the artifact
+      contents: read # Required to read the source
+      checks: write # Required to write the results
       pull-requests: write # Required to write comments
     runs-on: ubuntu-latest
     steps:
-    - name: Download and Extract Artifacts
-      uses: dawidd6/action-download-artifact@0bd50d53a6d7fb5cb921e607957e9cc12b4ce392 # v12
-      with:
-        run_id: ${{ github.event.workflow_run.id }}
-        path: artifacts
+      - name: Download and Extract Artifacts
+        uses: dawidd6/action-download-artifact@0bd50d53a6d7fb5cb921e607957e9cc12b4ce392 # v12
+        with:
+          run_id: ${{ github.event.workflow_run.id }}
+          path: artifacts
 
-    - name: Publish Test Results
-      uses: EnricoMi/publish-unit-test-result-action@27d65e188ec43221b20d26de30f4892fad91df2f # v2.22.0
-      with:
-        commit: ${{ github.event.workflow_run.head_sha }}
-        event_file: artifacts/Event File/event.json
-        event_name: ${{ github.event.workflow_run.event }}
-        files: "artifacts/**/*.xml"
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@27d65e188ec43221b20d26de30f4892fad91df2f # v2.22.0
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "artifacts/**/*.xml"

--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -5,6 +5,9 @@ on:
     - cron: "11 8 * * 1" # every monday
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update-deps:
     runs-on: ubuntu-latest
@@ -12,11 +15,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-# https://github.com/peter-evans/create-pull-request/issues/48
-# https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#push-using-ssh-deploy-keys
-# tl;dr:
-# The GITHUB_TOKEN is limited when creating PRs from a workflow
-# because of that we use a ssh key for which the limitations do not apply
+      # https://github.com/peter-evans/create-pull-request/issues/48
+      # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#push-using-ssh-deploy-keys
+      # tl;dr:
+      # The GITHUB_TOKEN is limited when creating PRs from a workflow
+      # because of that we use a ssh key for which the limitations do not apply
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
@@ -49,7 +52,7 @@ jobs:
           echo "COMMIT_TITLE=${COMMIT_MSG}" >> $GITHUB_OUTPUT
           echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
 
-# We have to use this extensions, because `gh pr create` does not support the ssh key case
+      # We have to use this extensions, because `gh pr create` does not support the ssh key case
       - name: Create pull request
         id: cpr
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0


### PR DESCRIPTION
This addresses the CodeQL alerts: https://github.com/mondoohq/cnquery/security/code-scanning

This sets default permissions on the workflow level. The various jobs have extended permissions when needed.