### PR TITLE
🐛 Handle errors in array map

### DIFF
--- a/llx/builtin_array.go
+++ b/llx/builtin_array.go
@@ -435,6 +435,9 @@ func arrayMapV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*Raw
 	}
 
 	err = e.runFunctionBlocks(argsList, fref, func(results []arrayBlockCallResult, errs []error) {
+		var anyError multierr.Errors
+		anyError.Add(errs...)
+
 		mappedType := types.Unset
 		resList := []any{}
 		f := e.ctx.code.Block(fref)
@@ -452,6 +455,7 @@ func arrayMapV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*Raw
 		data := &RawData{
 			Type:  types.Array(mappedType),
 			Value: resList,
+			Error: anyError.Deduplicate(),
 		}
 		e.cache.Store(ref, &stepCache{
 			Result:   data,

--- a/mql/mql_test.go
+++ b/mql/mql_test.go
@@ -533,3 +533,16 @@ func TestMapRefLookup(t *testing.T) {
 		},
 	})
 }
+
+func TestArrayMapError(t *testing.T) {
+	x := testutils.InitTester(testutils.LinuxMock())
+	x.TestSimple(t, []testutils.SimpleTest{
+		{
+			Code: `
+				["a"].map(file(_).content)
+			`,
+			ResultIndex: 0,
+			Error:       "1 error occurred:\n\t* file 'a' not found\n",
+		},
+	})
+}


### PR DESCRIPTION
Fixes the following panic
```
❯ cat exists
a
b
c
d

❯ cat dne
cat: dne: No such file or directory

❯ cnspec run -c 'fl = ["exists", "dne", "exists"]; fl.map(file(_).content.lines).flat.unique'

→ Connecting to your local system. To learn how to scan other platforms, use the --help flag.
→ no Mondoo configuration file provided, using defaults
panic: interface conversion: interface {} is nil, not string

goroutine 84 [running]:
go.mondoo.com/cnquery/v12/types.init.func4({0x0?, 0x0?}, {0x105d2e600?, 0x14000fe60f0?})
        /Users/jaym/workspace/mondoo/repos/cnquery/types/types.go:353 +0x90
go.mondoo.com/cnquery/v12/llx.detectDupes({0x105cf1360?, 0x14001100330?}, {0x14000bc4356?, 0x0?})
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/builtin_array.go:601 +0x378
go.mondoo.com/cnquery/v12/llx.arrayUniqueV2(0x14000bc4356?, 0x140010591a0, 0x1400088c220?, 0x6?)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/builtin_array.go:789 +0x30
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).runBoundFunction(0x140004411f0, 0x140010591a0, 0x14001220d70, 0x100000005)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/builtin.go:914 +0x144
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).runFunction(0x140004411f0, 0x14001220d70, 0x100000005)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:816 +0x154
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).runChunk(0x140004411f0, 0x105364ab4?, 0x100000005)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:833 +0x204
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).runRef(0x140010b9870?, 0x1043c4690?)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:858 +0xec
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).runChain(0x140004411f0, 0x12e5824a0?)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:890 +0x88
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).triggerChain(0x140004411f0, 0x100000003, 0x14001059140)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:962 +0x2b8
go.mondoo.com/cnquery/v12/llx.arrayMapV2.func1({0x140012018f0, 0x3, 0x1400023a840?}, {0x140011061c0, 0x2, 0x10437d7a8?})
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/builtin_array.go:464 +0x3c0
go.mondoo.com/cnquery/v12/llx.(*arrayBlockCallResults).update(0x14000441260, 0x2, 0x14001106340)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:495 +0x344
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).runFunctionBlocks.func1(0x1400048e380?)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:561 +0x28
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).runFunctionBlock.reportSync.func1(0x14001106340)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:377 +0x68
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).runChain(0x1400048e380, 0x12e5824a0?)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:904 +0x2b0
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).triggerChain(0x1400048e380, 0x200000003, 0x140010590b0)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:962 +0x2b8
go.mondoo.com/cnquery/v12/llx.runResourceFunction.func1({0x105d2e600, 0x14000fe64b0}, {0x0, 0x0})
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/builtin.go:860 +0x1b8
go.mondoo.com/cnquery/v12/providers.(*Runtime).WatchAndUpdate(0x140010b7e00, {0x1062af888, 0x140011062a0}, {0x1400088c200, 0x7}, {0x14000b940c0, 0x31}, 0x14001058f30)
        /Users/jaym/workspace/mondoo/repos/cnquery/providers/runtime.go:406 +0xa8
go.mondoo.com/cnquery/v12/llx.runResourceFunction(0x1400048e380, 0x14001058ed0?, 0x14001220b40, 0x200000003)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/builtin.go:841 +0x270
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).runBoundFunction(0x1400048e380, 0x14001058ed0, 0x14001220b40, 0x200000003)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/builtin.go:908 +0x31c
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).runFunction(0x1400048e380, 0x14001220b40, 0x200000003)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:816 +0x154
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).runChunk(0x1400048e380, 0x105364ab4?, 0x200000003)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:833 +0x204
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).runRef(0x14000fe62d0?, 0x1043da184?)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:858 +0xec
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).runChain(0x1400048e380, 0x10585e7fd?)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:890 +0x88
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).run(0x1400048e380)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:358 +0x294
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).runFunctionBlock(0x140004411f0, {0x14000632388, 0x1, 0x140010bd300?}, 0x200000000, 0x14001100180)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:589 +0x188
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).runFunctionBlocks(0x140004411f0, {0x14001220dc0, 0x3, 0x10535ffcc?}, 0x200000000, 0x90?)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:560 +0x100
go.mondoo.com/cnquery/v12/llx.arrayMapV2(0x140004411f0, 0x2?, 0x14001220c30, 0x100000003)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/builtin_array.go:437 +0x3e8
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).runBoundFunction(0x140004411f0, 0x14001201770, 0x14001220c30, 0x100000003)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/builtin.go:914 +0x144
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).runFunction(0x140004411f0, 0x14001220c30, 0x100000003)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:816 +0x154
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).runChunk(0x140004411f0, 0x105364ab4?, 0x100000003)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:833 +0x204
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).runRef(0x140010b9870?, 0x1043da184?)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:858 +0xec
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).runChain(0x140004411f0, 0x10585e7fd?)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:890 +0x88
go.mondoo.com/cnquery/v12/llx.(*blockExecutor).run(0x140004411f0)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:358 +0x294
go.mondoo.com/cnquery/v12/llx.(*MQLExecutorV2).Run(0x140010b3440?)
        /Users/jaym/workspace/mondoo/repos/cnquery/llx/llx.go:288 +0x5c
go.mondoo.com/cnquery/v12/mql/internal.(*executionManager).executeCodeBundle(0x140010b36e0, 0x140010c10e0, 0x140012014a0, {0x0, 0x0})
        /Users/jaym/workspace/mondoo/repos/cnquery/mql/internal/execution_manager.go:169 +0x43c
go.mondoo.com/cnquery/v12/mql/internal.(*executionManager).Start.func1()
        /Users/jaym/workspace/mondoo/repos/cnquery/mql/internal/execution_manager.go:88 +0x150
created by go.mondoo.com/cnquery/v12/mql/internal.(*executionManager).Start in goroutine 1
        /Users/jaym/workspace/mondoo/repos/cnquery/mql/internal/execution_manager.go:57 +0x6c
exit status 2
```

The issue is we were not hanlding errors in the map, causing unique to be given a string array with null values. The comparison operators assumed there would be no null values