### PR TITLE
✨ Detect Oracle UEK kernels

### DIFF
--- a/providers/os/resources/kernel.go
+++ b/providers/os/resources/kernel.go
@@ -110,6 +110,28 @@ func (k *mqlKernel) installed() ([]any, error) {
 					})
 				}
 			}
+		} else if platform.Name == "oraclelinux" {
+			// ORacleLinux is an rpm based systems, but might be running the UEK kernel
+			// kernel version is  "6.12.0-105.51.5.el9uek.x86_64"
+			// filter by packages named "kernel" OR "kernel-uek"
+			filterKernel = func(pkg *mqlPackage) {
+				if pkg.Name.Data == "kernel" || pkg.Name.Data == "kernel-uek" {
+					version := pkg.Version.Data
+					arch := pkg.Arch.Data
+
+					kernelName := version + "." + arch
+					running := false
+					if kernelName == runningKernelVersion {
+						running = true
+					}
+
+					res = append(res, KernelVersion{
+						Name:    pkg.Name.Data,
+						Version: version,
+						Running: running,
+					})
+				}
+			}
 		} else if platform.IsFamily("redhat") || platform.Name == "amazonlinux" {
 			// rpm based systems
 			// kernel version is  "3.10.0-1160.11.1.el7.x86_64"


### PR DESCRIPTION
OracleLinux is part of the `redhat` family:
```
asset.family: [
  0: "redhat"
  1: "linux"
  2: "unix"
  3: "os"
]
```

So, we so far only discovered `kernel` packages for the running kernel:
```
kernel.installed: [
  0: {
    name: "kernel"
    running: false
    version: "5.14.0-570.60.1.0.1.el9_6"
  }
]
```

We missed discovering UEK kernels:
```
[XXX ~]$ uname -a
Linux instance-20260112-121325 6.12.0-105.51.5.el9uek.x86_64 #1 SMP PREEMPT_DYNAMIC Tue Oct 14 19:55:41 PDT 2025 x86_64 x86_64 x86_64 GNU/Linux
```

With the separate handling for `oraclelinux`, we now also discover the UEK kernels:
```
kernel.installed: [
  0: {
    name: "kernel"
    running: false
    version: "5.14.0-570.60.1.0.1.el9_6"
  }
  1: {
    name: "kernel-uek"
    running: true
    version: "6.12.0-105.51.5.el9uek"
  }
]
```

## Testing

You can spin up an Oracle Linux VM on GCP. They use UEK kernels by default.

The run
```
cnquery run ssh -i ~/.ssh/<your key>@1.2.3.4 -c 'kernel.installed'
```