### PR TITLE
✨ Support rpm modules for Oracle

### DIFF
--- a/providers/os/resources/packages/testdata/packages_oracle.toml
+++ b/providers/os/resources/packages/testdata/packages_oracle.toml
@@ -1,0 +1,13 @@
+[commands."command -v rpm"]
+stdout="/usr/bin/rpm"
+
+[commands."rpm -E '%{_dbpath}'"]
+stdout="/var/lib/rpm"
+
+[commands."rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{MODULARITYLABEL}\\n'"]
+stdout="""
+adcli 0:0.9.2-1.el9 x86_64__Oracle America__Active Directory enrollment__(none)
+at 0:3.1.23-12.el9_6 x86_64__Oracle America__Job spooling tools__(none)
+ruby 0:3.1.7-146.module+el9.5.0+90564+273a1edd x86_64__Oracle America__An interpreter of object-oriented scripting language__ruby:3.1:9050020250506050702:2e2f0e1c
+ruby-default-gems 0:3.1.7-146.module+el9.5.0+90564+273a1edd noarch__Oracle America__Default gems which are part of Ruby StdLib__ruby:3.1:9050020250506050702:2e2f0e1c
+"""


### PR DESCRIPTION
This adds a qualifier to the PURL when applicable:
```
cnquery run ssh -i ~/.ssh/ssh_key you@1.2.3.4 -c 'packages.where(name == /^r/){ name purl }'
→ no Mondoo configuration file provided, using defaults
packages.where.list: [
...
  23: {
    name: "rootfiles"
    purl: "pkg:rpm/oraclelinux/rootfiles@8.1-34.el9?arch=noarch&distro=ol-9.6"
  }
  24: {
    name: "ruby-libs"
    purl: "pkg:rpm/oraclelinux/ruby-libs@3.1.7-146.module%2Bel9.5.0%2B90564%2B273a1edd?arch=x86_64&distro=ol-9.6&rpmmod=ruby%3A3.1%3A9050020250506050702%3A2e2f0e1c"
  }
  25: {
    name: "rubygem-bigdecimal"
    purl: "pkg:rpm/oraclelinux/rubygem-bigdecimal@3.1.1-146.module%2Bel9.5.0%2B90564%2B273a1edd?arch=x86_64&distro=ol-9.6&rpmmod=ruby%3A3.1%3A9050020250506050702%3A2e2f0e1c"
  }
...
```

This does not change how this works for other distros:
```
cnquery run container image registry.suse.com/bci/bci-base:15.7 -c "packages{ name purl }"
→ no Mondoo configuration file provided, using defaults
packages.list: [
  0: {
    purl: "pkg:rpm/suse/libtirpc-netconfig@0%3A1.3.4-150300.3.23.1?arch=x86_64&distro=sles-15.7"
    name: "libtirpc-netconfig"
  }
```

To test this, you can create an Oracle VM on GCP.
Afterwards you need to install a module, e.g., ruby:
```
sudo dnf module enable ruby:3.1
sudo dnf module install ruby
```