### PR TITLE
add disableApiTermination field to aws.ec2.instance

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -3380,6 +3380,8 @@ private aws.ec2.instance @defaults("instanceId region state instanceType archite
   tpmSupport string
   // List of network interfaces for the instance
   networkInterfaces() []aws.ec2.networkinterface
+  // Whether API termination protection is enabled for the instance
+  disableApiTermination() bool
 }
 
 // AWS EC2 network interface

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -5083,6 +5083,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.instance.networkInterfaces": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetNetworkInterfaces()).ToDataRes(types.Array(types.Resource("aws.ec2.networkinterface")))
 	},
+	"aws.ec2.instance.disableApiTermination": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Instance).GetDisableApiTermination()).ToDataRes(types.Bool)
+	},
 	"aws.ec2.networkinterface.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Networkinterface).GetId()).ToDataRes(types.String)
 	},
@@ -11875,6 +11878,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.instance.networkInterfaces": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Instance).NetworkInterfaces, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instance.disableApiTermination": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Instance).DisableApiTermination, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.networkinterface.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -29605,6 +29612,7 @@ type mqlAwsEc2Instance struct {
 	Architecture          plugin.TValue[string]
 	TpmSupport            plugin.TValue[string]
 	NetworkInterfaces     plugin.TValue[[]any]
+	DisableApiTermination plugin.TValue[bool]
 }
 
 // createAwsEc2Instance creates a new instance of this resource
@@ -29867,6 +29875,12 @@ func (c *mqlAwsEc2Instance) GetNetworkInterfaces() *plugin.TValue[[]any] {
 		}
 
 		return c.networkInterfaces()
+	})
+}
+
+func (c *mqlAwsEc2Instance) GetDisableApiTermination() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.DisableApiTermination, func() (bool, error) {
+		return c.disableApiTermination()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -1172,6 +1172,8 @@ resources:
       arn: {}
       detailedMonitoring: {}
       deviceMappings: {}
+      disableApiTermination:
+        min_mondoo_version: latest
       ebsOptimized: {}
       enaSupported:
         min_mondoo_version: 9.0.0

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -1472,6 +1472,29 @@ func (a *mqlAwsEc2Instance) instanceStatus() (any, error) {
 	return res, nil
 }
 
+func (a *mqlAwsEc2Instance) disableApiTermination() (bool, error) {
+	instanceId := a.InstanceId.Data
+	region := a.Region.Data
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+
+	svc := conn.Ec2(region)
+	ctx := context.Background()
+
+	result, err := svc.DescribeInstanceAttribute(ctx, &ec2.DescribeInstanceAttributeInput{
+		InstanceId: aws.String(instanceId),
+		Attribute:  ec2types.InstanceAttributeNameDisableApiTermination,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	if result.DisableApiTermination != nil && result.DisableApiTermination.Value != nil {
+		return *result.DisableApiTermination.Value, nil
+	}
+
+	return false, nil
+}
+
 // # go.mondoo.com/cnquery/v12/providers/aws/resources
 // resources/aws.lr.go:15420:12: c.iamRole undefined (type *mqlAwsIamInstanceProfile has no field or method iamRole, but does have field IamRole)
 // make[1]: *** [providers/build/aws] Error 1


### PR DESCRIPTION
Add a new field to expose the DisableApiTermination instance attribute, which indicates whether termination protection is enabled for an EC2 instance.

This field makes a separate API call (DescribeInstanceAttribute) when accessed, following the pattern used by similar fields like instanceStatus.