### PR TITLE
 ⭐ MS365: Add `externalAccessWithTrialTenants` field

### DIFF
--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -1841,6 +1841,8 @@ private ms365.teams.tenantFederationConfig {
   sharedSipAddressSpace bool
   // Whether to restrict Teams consumer to external user profiles
   restrictTeamsConsumerToExternalUserProfiles bool
+  // Whether external access with trial tenants is allowed (Allowed or Blocked)
+  externalAccessWithTrialTenants string
 }
 
 // Microsoft 365 Teams meeting policy configuration

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -2757,6 +2757,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"ms365.teams.tenantFederationConfig.restrictTeamsConsumerToExternalUserProfiles": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMs365TeamsTenantFederationConfig).GetRestrictTeamsConsumerToExternalUserProfiles()).ToDataRes(types.Bool)
 	},
+	"ms365.teams.tenantFederationConfig.externalAccessWithTrialTenants": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365TeamsTenantFederationConfig).GetExternalAccessWithTrialTenants()).ToDataRes(types.String)
+	},
 	"ms365.teams.teamsMeetingPolicyConfig.allowAnonymousUsersToJoinMeeting": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMs365TeamsTeamsMeetingPolicyConfig).GetAllowAnonymousUsersToJoinMeeting()).ToDataRes(types.Bool)
 	},
@@ -6040,6 +6043,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"ms365.teams.tenantFederationConfig.restrictTeamsConsumerToExternalUserProfiles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMs365TeamsTenantFederationConfig).RestrictTeamsConsumerToExternalUserProfiles, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"ms365.teams.tenantFederationConfig.externalAccessWithTrialTenants": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365TeamsTenantFederationConfig).ExternalAccessWithTrialTenants, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"ms365.teams.teamsMeetingPolicyConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15162,6 +15169,7 @@ type mqlMs365TeamsTenantFederationConfig struct {
 	TreatDiscoveredPartnersAsUnverified         plugin.TValue[bool]
 	SharedSipAddressSpace                       plugin.TValue[bool]
 	RestrictTeamsConsumerToExternalUserProfiles plugin.TValue[bool]
+	ExternalAccessWithTrialTenants              plugin.TValue[string]
 }
 
 // createMs365TeamsTenantFederationConfig creates a new instance of this resource
@@ -15234,6 +15242,10 @@ func (c *mqlMs365TeamsTenantFederationConfig) GetSharedSipAddressSpace() *plugin
 
 func (c *mqlMs365TeamsTenantFederationConfig) GetRestrictTeamsConsumerToExternalUserProfiles() *plugin.TValue[bool] {
 	return &c.RestrictTeamsConsumerToExternalUserProfiles
+}
+
+func (c *mqlMs365TeamsTenantFederationConfig) GetExternalAccessWithTrialTenants() *plugin.TValue[string] {
+	return &c.ExternalAccessWithTrialTenants
 }
 
 // mqlMs365TeamsTeamsMeetingPolicyConfig for the ms365.teams.teamsMeetingPolicyConfig resource

--- a/providers/ms365/resources/ms365.lr.manifest.yaml
+++ b/providers/ms365/resources/ms365.lr.manifest.yaml
@@ -1207,6 +1207,7 @@ resources:
       allowTeamsConsumerInbound: {}
       allowedDomains: {}
       blockedDomains: {}
+      externalAccessWithTrialTenants: {}
       identity: {}
       restrictTeamsConsumerToExternalUserProfiles: {}
       sharedSipAddressSpace: {}

--- a/providers/ms365/resources/ms365_teams.go
+++ b/providers/ms365/resources/ms365_teams.go
@@ -66,7 +66,7 @@ ConvertTo-Json -Depth 4 $msteams
 `
 
 type MsTeamsReport struct {
-	CsTeamsClientConfiguration      any                      `json:"CsTeamsClientConfiguration"`
+	CsTeamsClientConfiguration      any                              `json:"CsTeamsClientConfiguration"`
 	CsTenantFederationConfiguration *CsTenantFederationConfiguration `json:"CsTenantFederationConfiguration"`
 	CsTeamsMeetingPolicy            *CsTeamsMeetingPolicy            `json:"CsTeamsMeetingPolicy"`
 	CsTeamsMessagingPolicy          *CsTeamsMessagingPolicy          `json:"CsTeamsMessagingPolicy"`
@@ -81,6 +81,7 @@ type CsTenantFederationConfiguration struct {
 	TreatDiscoveredPartnersAsUnverified         bool     `json:"TreatDiscoveredPartnersAsUnverified"`
 	SharedSipAddressSpace                       bool     `json:"SharedSipAddressSpace"`
 	RestrictTeamsConsumerToExternalUserProfiles bool     `json:"RestrictTeamsConsumerToExternalUserProfiles"`
+	ExternalAccessWithTrialTenants              string   `json:"ExternalAccessWithTrialTenants"`
 	AllowedDomains                              []string `json:"AllowedDomains"`
 	// TODO: we need to figure out how to get this right when using Convert-ToJson
 	// it currently comes back as an empty json object {} but the pwsh cmdlet spits out a string-looking value
@@ -200,6 +201,7 @@ func (r *mqlMs365Teams) gatherTeamsReport() error {
 				"treatDiscoveredPartnersAsUnverified":         llx.BoolData(tenantConfig.TreatDiscoveredPartnersAsUnverified),
 				"sharedSipAddressSpace":                       llx.BoolData(tenantConfig.SharedSipAddressSpace),
 				"restrictTeamsConsumerToExternalUserProfiles": llx.BoolData(tenantConfig.RestrictTeamsConsumerToExternalUserProfiles),
+				"externalAccessWithTrialTenants":              llx.StringData(tenantConfig.ExternalAccessWithTrialTenants),
 			})
 		if mqlTenantConfigErr != nil {
 			r.CsTenantFederationConfiguration = plugin.TValue[*mqlMs365TeamsTenantFederationConfig]{State: plugin.StateIsSet, Error: mqlTenantConfigErr}


### PR DESCRIPTION
The `ms365.teams.csTenantFederationConfiguration` resource is missing the `ExternalAccessWithTrialTenants` property which controls federation with trial Teams tenants.

This property is available via Teams PowerShell:
```powershell
Get-CsTenantFederationConfiguration | Select-Object ExternalAccessWithTrialTenants
```

**Expected values:** `Allowed` or `Blocked`

**Desired MQL:**
```
ms365.teams.csTenantFederationConfiguration.externalAccessWithTrialTenants
```

Since cnquery already uses Teams PowerShell for the `csTenantFederationConfiguration` resource, this field should be added to the existing `CsTenantFederationConfiguration` struct in `ms365_teams.go`.

**Reference:** https://learn.microsoft.com/en-us/powershell/module/microsoftteams/get-cstenantfederationconfiguration

---

closes #6268 