### PR TITLE
🧹 Explicitly fetch go-containerregistry

### DIFF
--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -42,6 +42,9 @@ jobs:
           version mod-update . --latest
           version mod-update providers/*/ --latest
           version mod-tidy providers/*/
+          # This is first updated and later downgraded by another dependency
+          # Unless this is fixed, bump it back up
+          go get github.com/google/go-containerregistry@v0.20.7
           version mod-tidy .
 
       - name: Prepare title and branch name


### PR DESCRIPTION
That should prevent such commits: https://github.com/mondoohq/cnquery/pull/6413/commits/e5eb36fe3d42fc03b6b1aaa8398ce64fb6b26815

and bring back our automatic updates.