### PR TITLE
⭐ MS365: Add `microsoft.identityGovernance.accessReviews` resource

### DIFF
--- a/providers/ms365/resources/identity_and_access.go
+++ b/providers/ms365/resources/identity_and_access.go
@@ -398,6 +398,22 @@ func newMqlAccessReviewDefinition(runtime *plugin.Runtime, d models.AccessReview
 		}
 	}
 
+	var mqlScope plugin.Resource
+	if scope := d.GetScope(); scope != nil {
+		if queryScope, ok := scope.(models.AccessReviewQueryScopeable); ok {
+			var err error
+			mqlScope, err = CreateResource(runtime, ResourceMicrosoftIdentityAndAccessAccessReviewDefinitionScope, map[string]*llx.RawData{
+				"__id":      llx.StringData(*d.GetId() + "_scope"),
+				"query":     llx.StringDataPtr(queryScope.GetQuery()),
+				"queryType": llx.StringDataPtr(queryScope.GetQueryType()),
+				"queryRoot": llx.StringDataPtr(queryScope.GetQueryRoot()),
+			})
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	var mqlAccessReviewScheduleSettings plugin.Resource
 	var err error
 
@@ -423,9 +439,9 @@ func newMqlAccessReviewDefinition(runtime *plugin.Runtime, d models.AccessReview
 			}
 		}
 
-		recurrenceDict := map[string]*llx.RawData{
-			"pattern": llx.DictData(patternDict),
-			"range":   llx.DictData(rangeDict),
+		recurrenceDict := map[string]any{
+			"pattern": patternDict,
+			"range":   rangeDict,
 		}
 
 		targetData := map[string]*llx.RawData{
@@ -435,6 +451,7 @@ func newMqlAccessReviewDefinition(runtime *plugin.Runtime, d models.AccessReview
 			"defaultDecision":                      llx.StringDataPtr(d.GetSettings().GetDefaultDecision()),
 			"defaultDecisionEnabled":               llx.BoolDataPtr(d.GetSettings().GetDefaultDecisionEnabled()),
 			"instanceDurationInDays":               llx.IntDataPtr(d.GetSettings().GetInstanceDurationInDays()),
+			"reminderNotificationsEnabled":         llx.BoolDataPtr(d.GetSettings().GetReminderNotificationsEnabled()),
 			"justificationRequiredOnApproval":      llx.BoolDataPtr(d.GetSettings().GetJustificationRequiredOnApproval()),
 			"mailNotificationsEnabled":             llx.BoolDataPtr(d.GetSettings().GetMailNotificationsEnabled()),
 			"recommendationsEnabled":               llx.BoolDataPtr(d.GetSettings().GetRecommendationsEnabled()),
@@ -453,6 +470,7 @@ func newMqlAccessReviewDefinition(runtime *plugin.Runtime, d models.AccessReview
 			"id":          llx.StringDataPtr(d.GetId()),
 			"displayName": llx.StringDataPtr(d.GetDisplayName()),
 			"status":      llx.StringDataPtr(d.GetStatus()),
+			"scope":       llx.ResourceData(mqlScope, ResourceMicrosoftIdentityAndAccessAccessReviewDefinitionScope),
 			"reviewers":   llx.DictData(reviewersDict),
 			"settings":    llx.ResourceData(mqlAccessReviewScheduleSettings, "microsoft.identityAndAccess.accessReviewDefinition.accessReviewScheduleSettings"),
 		})

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -55,10 +55,22 @@ private microsoft.identityAndAccess.accessReviewDefinition @defaults("id display
   // The status of the access review. Possible values are:
   // Initializing, NotStarted, Starting, InProgress, Completing, Completed, AutoReviewing, and AutoReviewed
   status string
+  // Defines the entities whose access is reviewed
+  scope microsoft.identityAndAccess.accessReviewDefinition.scope
   // This collection of access review scopes is used to define who are the reviewers
   reviewers dict
   // The settings for an access review series, see type definition below
   settings microsoft.identityAndAccess.accessReviewDefinition.accessReviewScheduleSettings
+}
+
+// Defines the scope of entities whose access is being reviewed
+private microsoft.identityAndAccess.accessReviewDefinition.scope @defaults("query queryType") {
+  // Query string defining which entities are in scope for the review
+  query string
+  // Type of query being used (e.g., "MicrosoftGraph")
+  queryType string
+  // Optional query root path
+  queryRoot string
 }
 
 // Configures the recurrence, notifications, and decision-handling for an access review series.

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -20,6 +20,7 @@ const (
 	ResourceMicrosoft                                                                                        string = "microsoft"
 	ResourceMicrosoftIdentityAndAccessAccessReviews                                                          string = "microsoft.identityAndAccess.accessReviews"
 	ResourceMicrosoftIdentityAndAccessAccessReviewDefinition                                                 string = "microsoft.identityAndAccess.accessReviewDefinition"
+	ResourceMicrosoftIdentityAndAccessAccessReviewDefinitionScope                                            string = "microsoft.identityAndAccess.accessReviewDefinition.scope"
 	ResourceMicrosoftIdentityAndAccessAccessReviewDefinitionAccessReviewScheduleSettings                     string = "microsoft.identityAndAccess.accessReviewDefinition.accessReviewScheduleSettings"
 	ResourceMicrosoftGroups                                                                                  string = "microsoft.groups"
 	ResourceMicrosoftSetting                                                                                 string = "microsoft.setting"
@@ -147,6 +148,10 @@ func init() {
 		"microsoft.identityAndAccess.accessReviewDefinition": {
 			// to override args, implement: initMicrosoftIdentityAndAccessAccessReviewDefinition(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMicrosoftIdentityAndAccessAccessReviewDefinition,
+		},
+		"microsoft.identityAndAccess.accessReviewDefinition.scope": {
+			// to override args, implement: initMicrosoftIdentityAndAccessAccessReviewDefinitionScope(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createMicrosoftIdentityAndAccessAccessReviewDefinitionScope,
 		},
 		"microsoft.identityAndAccess.accessReviewDefinition.accessReviewScheduleSettings": {
 			// to override args, implement: initMicrosoftIdentityAndAccessAccessReviewDefinitionAccessReviewScheduleSettings(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -725,11 +730,23 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.identityAndAccess.accessReviewDefinition.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftIdentityAndAccessAccessReviewDefinition).GetStatus()).ToDataRes(types.String)
 	},
+	"microsoft.identityAndAccess.accessReviewDefinition.scope": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftIdentityAndAccessAccessReviewDefinition).GetScope()).ToDataRes(types.Resource("microsoft.identityAndAccess.accessReviewDefinition.scope"))
+	},
 	"microsoft.identityAndAccess.accessReviewDefinition.reviewers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftIdentityAndAccessAccessReviewDefinition).GetReviewers()).ToDataRes(types.Dict)
 	},
 	"microsoft.identityAndAccess.accessReviewDefinition.settings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftIdentityAndAccessAccessReviewDefinition).GetSettings()).ToDataRes(types.Resource("microsoft.identityAndAccess.accessReviewDefinition.accessReviewScheduleSettings"))
+	},
+	"microsoft.identityAndAccess.accessReviewDefinition.scope.query": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftIdentityAndAccessAccessReviewDefinitionScope).GetQuery()).ToDataRes(types.String)
+	},
+	"microsoft.identityAndAccess.accessReviewDefinition.scope.queryType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftIdentityAndAccessAccessReviewDefinitionScope).GetQueryType()).ToDataRes(types.String)
+	},
+	"microsoft.identityAndAccess.accessReviewDefinition.scope.queryRoot": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftIdentityAndAccessAccessReviewDefinitionScope).GetQueryRoot()).ToDataRes(types.String)
 	},
 	"microsoft.identityAndAccess.accessReviewDefinition.accessReviewScheduleSettings.autoApplyDecisionsEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftIdentityAndAccessAccessReviewDefinitionAccessReviewScheduleSettings).GetAutoApplyDecisionsEnabled()).ToDataRes(types.Bool)
@@ -2880,12 +2897,32 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlMicrosoftIdentityAndAccessAccessReviewDefinition).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"microsoft.identityAndAccess.accessReviewDefinition.scope": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftIdentityAndAccessAccessReviewDefinition).Scope, ok = plugin.RawToTValue[*mqlMicrosoftIdentityAndAccessAccessReviewDefinitionScope](v.Value, v.Error)
+		return
+	},
 	"microsoft.identityAndAccess.accessReviewDefinition.reviewers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftIdentityAndAccessAccessReviewDefinition).Reviewers, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"microsoft.identityAndAccess.accessReviewDefinition.settings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftIdentityAndAccessAccessReviewDefinition).Settings, ok = plugin.RawToTValue[*mqlMicrosoftIdentityAndAccessAccessReviewDefinitionAccessReviewScheduleSettings](v.Value, v.Error)
+		return
+	},
+	"microsoft.identityAndAccess.accessReviewDefinition.scope.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftIdentityAndAccessAccessReviewDefinitionScope).__id, ok = v.Value.(string)
+		return
+	},
+	"microsoft.identityAndAccess.accessReviewDefinition.scope.query": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftIdentityAndAccessAccessReviewDefinitionScope).Query, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.identityAndAccess.accessReviewDefinition.scope.queryType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftIdentityAndAccessAccessReviewDefinitionScope).QueryType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.identityAndAccess.accessReviewDefinition.scope.queryRoot": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftIdentityAndAccessAccessReviewDefinitionScope).QueryRoot, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"microsoft.identityAndAccess.accessReviewDefinition.accessReviewScheduleSettings.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6410,6 +6447,7 @@ type mqlMicrosoftIdentityAndAccessAccessReviewDefinition struct {
 	Id          plugin.TValue[string]
 	DisplayName plugin.TValue[string]
 	Status      plugin.TValue[string]
+	Scope       plugin.TValue[*mqlMicrosoftIdentityAndAccessAccessReviewDefinitionScope]
 	Reviewers   plugin.TValue[any]
 	Settings    plugin.TValue[*mqlMicrosoftIdentityAndAccessAccessReviewDefinitionAccessReviewScheduleSettings]
 }
@@ -6458,12 +6496,70 @@ func (c *mqlMicrosoftIdentityAndAccessAccessReviewDefinition) GetStatus() *plugi
 	return &c.Status
 }
 
+func (c *mqlMicrosoftIdentityAndAccessAccessReviewDefinition) GetScope() *plugin.TValue[*mqlMicrosoftIdentityAndAccessAccessReviewDefinitionScope] {
+	return &c.Scope
+}
+
 func (c *mqlMicrosoftIdentityAndAccessAccessReviewDefinition) GetReviewers() *plugin.TValue[any] {
 	return &c.Reviewers
 }
 
 func (c *mqlMicrosoftIdentityAndAccessAccessReviewDefinition) GetSettings() *plugin.TValue[*mqlMicrosoftIdentityAndAccessAccessReviewDefinitionAccessReviewScheduleSettings] {
 	return &c.Settings
+}
+
+// mqlMicrosoftIdentityAndAccessAccessReviewDefinitionScope for the microsoft.identityAndAccess.accessReviewDefinition.scope resource
+type mqlMicrosoftIdentityAndAccessAccessReviewDefinitionScope struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlMicrosoftIdentityAndAccessAccessReviewDefinitionScopeInternal it will be used here
+	Query     plugin.TValue[string]
+	QueryType plugin.TValue[string]
+	QueryRoot plugin.TValue[string]
+}
+
+// createMicrosoftIdentityAndAccessAccessReviewDefinitionScope creates a new instance of this resource
+func createMicrosoftIdentityAndAccessAccessReviewDefinitionScope(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMicrosoftIdentityAndAccessAccessReviewDefinitionScope{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("microsoft.identityAndAccess.accessReviewDefinition.scope", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMicrosoftIdentityAndAccessAccessReviewDefinitionScope) MqlName() string {
+	return "microsoft.identityAndAccess.accessReviewDefinition.scope"
+}
+
+func (c *mqlMicrosoftIdentityAndAccessAccessReviewDefinitionScope) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMicrosoftIdentityAndAccessAccessReviewDefinitionScope) GetQuery() *plugin.TValue[string] {
+	return &c.Query
+}
+
+func (c *mqlMicrosoftIdentityAndAccessAccessReviewDefinitionScope) GetQueryType() *plugin.TValue[string] {
+	return &c.QueryType
+}
+
+func (c *mqlMicrosoftIdentityAndAccessAccessReviewDefinitionScope) GetQueryRoot() *plugin.TValue[string] {
+	return &c.QueryRoot
 }
 
 // mqlMicrosoftIdentityAndAccessAccessReviewDefinitionAccessReviewScheduleSettings for the microsoft.identityAndAccess.accessReviewDefinition.accessReviewScheduleSettings resource

--- a/providers/ms365/resources/ms365.lr.manifest.yaml
+++ b/providers/ms365/resources/ms365.lr.manifest.yaml
@@ -443,6 +443,7 @@ resources:
       displayName: {}
       id: {}
       reviewers: {}
+      scope: {}
       settings: {}
       status: {}
     is_private: true
@@ -459,6 +460,13 @@ resources:
       recommendationsEnabled: {}
       recurrence: {}
       reminderNotificationsEnabled: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
+  microsoft.identityAndAccess.accessReviewDefinition.scope:
+    fields:
+      query: {}
+      queryRoot: {}
+      queryType: {}
     is_private: true
     min_mondoo_version: 9.0.0
   microsoft.identityAndAccess.accessReviews:


### PR DESCRIPTION
This was already done in `microsoft.identityAndAccess.accessReviewDefinition`. I just added the `scope` resource.

-----

We need access to Access Review schedule definitions from Microsoft Graph API to query configured access reviews for users, groups, and roles.

**API Endpoint:**
```
GET https://graph.microsoft.com/v1.0/identityGovernance/accessReviews/definitions
```

**Response:**
```json
{
  "value": [
    {
      "id": "guid",
      "displayName": "Guest User Review",
      "scope": {
        "query": "/users?$filter=userType eq 'Guest'",
        "queryType": "MicrosoftGraph"
      },
      "settings": {
        "recurrence": {
          "pattern": { "type": "monthly" }
        }
      },
      "reviewers": [...]
    }
  ]
}
```

**Desired MQL:**
```
microsoft.identityGovernance.accessReviews {
  id
  displayName
  scope
  settings
  reviewers
}
```

**Permissions required:** `AccessReview.Read.All`

**Reference:** https://learn.microsoft.com/en-us/graph/api/resources/accessreviewsv2-overview

---

closes #6271 