### PR TITLE
Negotiate docker API versions instead of hardcoding an old release

### DIFF
--- a/providers/os/resources/docker.go
+++ b/providers/os/resources/docker.go
@@ -5,12 +5,12 @@ package resources
 
 import (
 	"context"
-	"os"
 	"strings"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v12/llx"
 	"go.mondoo.com/cnquery/v12/providers-sdk/v1/util/convert"
 	"go.mondoo.com/cnquery/v12/types"
@@ -142,8 +142,10 @@ func (p *mqlDockerContainer) hostConfig() (any, error) {
 }
 
 func dockerClient() (*client.Client, error) {
-	// set docker api version for macos
-	os.Setenv("DOCKER_API_VERSION", "1.26")
-	// Start new docker container
-	return client.NewClientWithOpts(client.FromEnv)
+	cl, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return nil, err
+	}
+	log.Debug().Msgf("docker client> negotiated API version %s", cl.ClientVersion())
+	return cl, nil
 }


### PR DESCRIPTION
On both my Mac and my Debian 13 host the previous provider failed because the API version we hard coded is no longer supported by the Docker daemon. Instead of hard coding a version, let's negotiate a version.

Previous macOS / Debian 13 experience:

```
> docker.containers
error: Error response from daemon: client version 1.26 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version
```

New output:

```
> docker.containers
⣾  Executing query...

DBG starting query execution qrid=Pd9L/79Rd68=
                                              DBG resource docker has no MQL ID defined, this is usually an issue with the resource, please open a GitHub issue at https://github.com/mondoohq/cnquery/issues
                                       ⣽  Executing query...
ker client> negotiated API version 1.51
DBG finished query execution qrid=Pd9L/79Rd68=
                                              DBG rU1VESyZ4XZ24JDvSCc4UF/ZNY/Y9yo007/AJ1jecV2EM+Wd9IAUpLCA6aBPqvS9QHZ9QNBUhhwGz1r82PI1+g== finished                                     docker.containers: [
  0: docker.container names.first="musing_khayyam" status="Up 7 seconds"
]
```
