### PR TITLE
Fix Windows Query Pack to correctly parse currently logged in user

### DIFF
--- a/content/mondoo-windows-inventory.mql.yaml
+++ b/content/mondoo-windows-inventory.mql.yaml
@@ -194,7 +194,7 @@ packs:
         docs:
           desc: Lists currently logged-in users by checking Explorer processes.
         mql: |
-          parse.json(content: powershell("Get-Process -IncludeUserName explorer | Select-Object Username | ConvertTo-Json").stdout).params
+          parse.json(content: powershell("Get-Process -IncludeUserName explorer | Select-Object Username | ConvertTo-Json").stdout).params.UserName
       - uid: mondoo-windows-exchange-server-version
         title: Exchange Server Version
         docs:


### PR DESCRIPTION
Updated MQL to extract UserName from logged-in users. Previously:
```
{
  UserName: "win11-mondoo\\user"
}
```

Now:
```
"win11-mondoo\\user"
```