### PR TITLE
🧹 Update GH deps to v81

### DIFF
--- a/providers/github/connection/connection.go
+++ b/providers/github/connection/connection.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/cockroachdb/errors"
-	"github.com/google/go-github/v75/github"
+	"github.com/google/go-github/v81/github"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/mitchellh/hashstructure/v2"
 	"github.com/rs/zerolog"

--- a/providers/github/connection/connection_test.go
+++ b/providers/github/connection/connection_test.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/go-github/v75/github"
+	"github.com/google/go-github/v81/github"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/cnquery/v12/providers-sdk/v1/inventory"
 	"go.mondoo.com/cnquery/v12/providers-sdk/v1/vault"

--- a/providers/github/go.mod
+++ b/providers/github/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.17.0
 	github.com/cockroachdb/errors v1.12.0
 	github.com/gobwas/glob v0.2.3
-	github.com/google/go-github/v75 v75.0.0
+	github.com/google/go-github/v81 v81.0.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/rs/zerolog v1.34.0
@@ -135,6 +135,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-containerregistry v0.20.7 // indirect
+	github.com/google/go-github/v75 v75.0.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/providers/github/go.sum
+++ b/providers/github/go.sum
@@ -457,6 +457,8 @@ github.com/google/go-containerregistry v0.20.7 h1:24VGNpS0IwrOZ2ms2P1QE3Xa5X9p4p
 github.com/google/go-containerregistry v0.20.7/go.mod h1:Lx5LCZQjLH1QBaMPeGwsME9biPeo1lPx6lbGj/UmzgM=
 github.com/google/go-github/v75 v75.0.0 h1:k7q8Bvg+W5KxRl9Tjq16a9XEgVY1pwuiG5sIL7435Ic=
 github.com/google/go-github/v75 v75.0.0/go.mod h1:H3LUJEA1TCrzuUqtdAQniBNwuKiQIqdGKgBo1/M/uqI=
+github.com/google/go-github/v81 v81.0.0 h1:hTLugQRxSLD1Yei18fk4A5eYjOGLUBKAl/VCqOfFkZc=
+github.com/google/go-github/v81 v81.0.0/go.mod h1:upyjaybucIbBIuxgJS7YLOZGziyvvJ92WX6WEBNE3sM=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/gobwas/glob"
-	"github.com/google/go-github/v75/github"
+	"github.com/google/go-github/v81/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v12/llx"
 	"go.mondoo.com/cnquery/v12/logger"

--- a/providers/github/resources/git.go
+++ b/providers/github/resources/git.go
@@ -4,7 +4,7 @@
 package resources
 
 import (
-	"github.com/google/go-github/v75/github"
+	"github.com/google/go-github/v81/github"
 	"go.mondoo.com/cnquery/v12/llx"
 	"go.mondoo.com/cnquery/v12/providers-sdk/v1/plugin"
 )

--- a/providers/github/resources/github.go
+++ b/providers/github/resources/github.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/google/go-github/v75/github"
+	"github.com/google/go-github/v81/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v12/llx"
 	"go.mondoo.com/cnquery/v12/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_org.go
+++ b/providers/github/resources/github_org.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/google/go-github/v75/github"
+	"github.com/google/go-github/v81/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v12/internal/workerpool"
 	"go.mondoo.com/cnquery/v12/llx"

--- a/providers/github/resources/github_package.go
+++ b/providers/github/resources/github_package.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v75/github"
+	"github.com/google/go-github/v81/github"
 	"go.mondoo.com/cnquery/v12/llx"
 	"go.mondoo.com/cnquery/v12/providers-sdk/v1/plugin"
 	"go.mondoo.com/cnquery/v12/providers-sdk/v1/util/convert"

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/go-github/v75/github"
+	"github.com/google/go-github/v81/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v12/llx"
 	"go.mondoo.com/cnquery/v12/logger"

--- a/providers/github/resources/github_team.go
+++ b/providers/github/resources/github_team.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v75/github"
+	"github.com/google/go-github/v81/github"
 	"go.mondoo.com/cnquery/v12/llx"
 	"go.mondoo.com/cnquery/v12/providers/github/connection"
 )

--- a/providers/github/resources/github_user.go
+++ b/providers/github/resources/github_user.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/google/go-github/v75/github"
+	"github.com/google/go-github/v81/github"
 	"go.mondoo.com/cnquery/v12/llx"
 	"go.mondoo.com/cnquery/v12/logger"
 	"go.mondoo.com/cnquery/v12/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_workflow.go
+++ b/providers/github/resources/github_workflow.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v75/github"
+	"github.com/google/go-github/v81/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/cnquery/v12/providers-sdk/v1/util/convert"
 	"go.mondoo.com/cnquery/v12/providers/github/connection"


### PR DESCRIPTION
v75 is still used by another dep so we get both for now.