### PR TITLE
✨ Add VS Code extensions detection resource

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -2202,3 +2202,35 @@ private crontab.entry @defaults("user command") {
   // File containing this entry
   file file
 }
+
+// Visual Studio Code editor resources
+vscode {
+  // All installed VS Code extensions across all users
+  extensions() []vscode.extension
+  // Paths searched for VS Code extensions
+  paths() []string
+}
+
+// Visual Studio Code extension
+private vscode.extension @defaults("editor name version") {
+  // Unique extension identifier (publisher.name format)
+  identifier string
+  // Extension name from package.json
+  name string
+  // Extension display name from package.json
+  displayName string
+  // Extension version from package.json
+  version string
+  // Extension description from package.json
+  description string
+  // Extension publisher from package.json
+  publisher string
+  // Editor application (e.g., Visual Studio Code, Cursor, Windsurf)
+  editor string
+  // Path to the extension directory
+  path string
+  // VS Code engine version compatibility
+  vscodeVersion string
+  // Extension categories
+  categories []string
+}

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -171,6 +171,8 @@ const (
 	ResourceUsbDevice                  string = "usb.device"
 	ResourceCrontab                    string = "crontab"
 	ResourceCrontabEntry               string = "crontab.entry"
+	ResourceVscode                     string = "vscode"
+	ResourceVscodeExtension            string = "vscode.extension"
 )
 
 var resourceFactories map[string]plugin.ResourceFactory
@@ -792,6 +794,14 @@ func init() {
 		"crontab.entry": {
 			// to override args, implement: initCrontabEntry(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createCrontabEntry,
+		},
+		"vscode": {
+			// to override args, implement: initVscode(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createVscode,
+		},
+		"vscode.extension": {
+			// to override args, implement: initVscodeExtension(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createVscodeExtension,
 		},
 	}
 }
@@ -3167,6 +3177,42 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"crontab.entry.file": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCrontabEntry).GetFile()).ToDataRes(types.Resource("file"))
+	},
+	"vscode.extensions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVscode).GetExtensions()).ToDataRes(types.Array(types.Resource("vscode.extension")))
+	},
+	"vscode.paths": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVscode).GetPaths()).ToDataRes(types.Array(types.String))
+	},
+	"vscode.extension.identifier": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVscodeExtension).GetIdentifier()).ToDataRes(types.String)
+	},
+	"vscode.extension.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVscodeExtension).GetName()).ToDataRes(types.String)
+	},
+	"vscode.extension.displayName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVscodeExtension).GetDisplayName()).ToDataRes(types.String)
+	},
+	"vscode.extension.version": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVscodeExtension).GetVersion()).ToDataRes(types.String)
+	},
+	"vscode.extension.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVscodeExtension).GetDescription()).ToDataRes(types.String)
+	},
+	"vscode.extension.publisher": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVscodeExtension).GetPublisher()).ToDataRes(types.String)
+	},
+	"vscode.extension.editor": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVscodeExtension).GetEditor()).ToDataRes(types.String)
+	},
+	"vscode.extension.path": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVscodeExtension).GetPath()).ToDataRes(types.String)
+	},
+	"vscode.extension.vscodeVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVscodeExtension).GetVscodeVersion()).ToDataRes(types.String)
+	},
+	"vscode.extension.categories": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVscodeExtension).GetCategories()).ToDataRes(types.Array(types.String))
 	},
 }
 
@@ -6854,6 +6900,62 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"crontab.entry.file": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlCrontabEntry).File, ok = plugin.RawToTValue[*mqlFile](v.Value, v.Error)
+		return
+	},
+	"vscode.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVscode).__id, ok = v.Value.(string)
+		return
+	},
+	"vscode.extensions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVscode).Extensions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"vscode.paths": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVscode).Paths, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"vscode.extension.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVscodeExtension).__id, ok = v.Value.(string)
+		return
+	},
+	"vscode.extension.identifier": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVscodeExtension).Identifier, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"vscode.extension.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVscodeExtension).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"vscode.extension.displayName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVscodeExtension).DisplayName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"vscode.extension.version": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVscodeExtension).Version, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"vscode.extension.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVscodeExtension).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"vscode.extension.publisher": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVscodeExtension).Publisher, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"vscode.extension.editor": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVscodeExtension).Editor, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"vscode.extension.path": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVscodeExtension).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"vscode.extension.vscodeVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVscodeExtension).VscodeVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"vscode.extension.categories": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVscodeExtension).Categories, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 }
@@ -19350,4 +19452,166 @@ func (c *mqlCrontabEntry) GetCommand() *plugin.TValue[string] {
 
 func (c *mqlCrontabEntry) GetFile() *plugin.TValue[*mqlFile] {
 	return &c.File
+}
+
+// mqlVscode for the vscode resource
+type mqlVscode struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlVscodeInternal it will be used here
+	Extensions plugin.TValue[[]any]
+	Paths      plugin.TValue[[]any]
+}
+
+// createVscode creates a new instance of this resource
+func createVscode(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlVscode{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("vscode", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlVscode) MqlName() string {
+	return "vscode"
+}
+
+func (c *mqlVscode) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlVscode) GetExtensions() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Extensions, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("vscode", c.__id, "extensions")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.extensions()
+	})
+}
+
+func (c *mqlVscode) GetPaths() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Paths, func() ([]any, error) {
+		return c.paths()
+	})
+}
+
+// mqlVscodeExtension for the vscode.extension resource
+type mqlVscodeExtension struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlVscodeExtensionInternal it will be used here
+	Identifier    plugin.TValue[string]
+	Name          plugin.TValue[string]
+	DisplayName   plugin.TValue[string]
+	Version       plugin.TValue[string]
+	Description   plugin.TValue[string]
+	Publisher     plugin.TValue[string]
+	Editor        plugin.TValue[string]
+	Path          plugin.TValue[string]
+	VscodeVersion plugin.TValue[string]
+	Categories    plugin.TValue[[]any]
+}
+
+// createVscodeExtension creates a new instance of this resource
+func createVscodeExtension(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlVscodeExtension{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("vscode.extension", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlVscodeExtension) MqlName() string {
+	return "vscode.extension"
+}
+
+func (c *mqlVscodeExtension) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlVscodeExtension) GetIdentifier() *plugin.TValue[string] {
+	return &c.Identifier
+}
+
+func (c *mqlVscodeExtension) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlVscodeExtension) GetDisplayName() *plugin.TValue[string] {
+	return &c.DisplayName
+}
+
+func (c *mqlVscodeExtension) GetVersion() *plugin.TValue[string] {
+	return &c.Version
+}
+
+func (c *mqlVscodeExtension) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlVscodeExtension) GetPublisher() *plugin.TValue[string] {
+	return &c.Publisher
+}
+
+func (c *mqlVscodeExtension) GetEditor() *plugin.TValue[string] {
+	return &c.Editor
+}
+
+func (c *mqlVscodeExtension) GetPath() *plugin.TValue[string] {
+	return &c.Path
+}
+
+func (c *mqlVscodeExtension) GetVscodeVersion() *plugin.TValue[string] {
+	return &c.VscodeVersion
+}
+
+func (c *mqlVscodeExtension) GetCategories() *plugin.TValue[[]any] {
+	return &c.Categories
 }

--- a/providers/os/resources/os.lr.manifest.yaml
+++ b/providers/os/resources/os.lr.manifest.yaml
@@ -1310,6 +1310,25 @@ resources:
           name != "Guest"
         }
       title: Search for a specific SID and check for its values
+  vscode:
+    fields:
+      extensions: {}
+      paths: {}
+    min_mondoo_version: 9.0.0
+  vscode.extension:
+    fields:
+      categories: {}
+      description: {}
+      displayName: {}
+      editor: {}
+      identifier: {}
+      name: {}
+      path: {}
+      publisher: {}
+      version: {}
+      vscodeVersion: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
   vuln.advisory:
     fields:
       description: {}

--- a/providers/os/resources/vscode.go
+++ b/providers/os/resources/vscode.go
@@ -1,0 +1,238 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
+	"go.mondoo.com/cnquery/v12/llx"
+	"go.mondoo.com/cnquery/v12/providers/os/connection/shared"
+	"go.mondoo.com/cnquery/v12/types"
+)
+
+// vsCodeEditor represents a VS Code-based editor with its extension directory
+type vsCodeEditor struct {
+	dir  string // Extension directory relative to user home
+	name string // Human-readable editor name
+}
+
+// VS Code extension directories relative to user home (same across platforms)
+var vsCodeEditors = []vsCodeEditor{
+	{".vscode/extensions", "Visual Studio Code"},
+	{".vscode-insiders/extensions", "Visual Studio Code Insiders"},
+	{".vscode-oss/extensions", "VSCodium"},
+	{".cursor/extensions", "Cursor"},
+	{".antigravity/extensions", "Antigravity"},
+	{".windsurf/extensions", "Windsurf"},
+	{".positron/extensions", "Positron"},
+	{".kiro/extensions", "Kiro"},
+}
+
+// invalidHomeDirs contains home directories that should be skipped (system accounts)
+var invalidHomeDirs = map[string]bool{
+	"":                      true,
+	"/var/empty":            true,
+	"/nonexistent":          true,
+	"/dev/null":             true,
+	"/":                     true,
+	"/var":                  true,
+	"/usr":                  true,
+	"/bin":                  true,
+	"/sbin":                 true,
+	"C:\\Windows\\System32": true,
+	"C:\\Windows\\system32\\config\\systemprofile": true,
+}
+
+// vscodePackageJSON represents the package.json structure for VS Code extensions
+type vscodePackageJSON struct {
+	Name        string   `json:"name"`
+	DisplayName string   `json:"displayName"`
+	Publisher   string   `json:"publisher"`
+	Version     string   `json:"version"`
+	Description string   `json:"description"`
+	Categories  []string `json:"categories"`
+	Engines     struct {
+		VSCode string `json:"vscode"`
+	} `json:"engines"`
+}
+
+func (c *mqlVscode) id() (string, error) {
+	return "vscode", nil
+}
+
+func (c *mqlVscode) paths() ([]any, error) {
+	conn := c.MqlRuntime.Connection.(shared.Connection)
+	afs := &afero.Afero{Fs: conn.FileSystem()}
+
+	// Get all users to find home directories
+	usersResource, err := CreateResource(c.MqlRuntime, "users", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+
+	userList := usersResource.(*mqlUsers).GetList()
+	if userList.Error != nil {
+		return nil, userList.Error
+	}
+
+	var paths []string
+
+	for _, u := range userList.Data {
+		user := u.(*mqlUser)
+		homeDir := user.GetHome().Data
+
+		if invalidHomeDirs[homeDir] {
+			continue
+		}
+
+		for _, editor := range vsCodeEditors {
+			extensionsDir := filepath.Join(homeDir, editor.dir)
+			// Use DirExists which is more efficient than Exists for directories
+			exists, err := afs.DirExists(extensionsDir)
+			if err != nil || !exists {
+				continue
+			}
+			paths = append(paths, extensionsDir)
+		}
+	}
+
+	sort.Strings(paths)
+
+	result := make([]any, len(paths))
+	for i, p := range paths {
+		result[i] = p
+	}
+	return result, nil
+}
+
+func (c *mqlVscode) extensions() ([]any, error) {
+	conn := c.MqlRuntime.Connection.(shared.Connection)
+	afs := &afero.Afero{Fs: conn.FileSystem()}
+
+	// Get all users to find home directories
+	usersResource, err := CreateResource(c.MqlRuntime, "users", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+
+	userList := usersResource.(*mqlUsers).GetList()
+	if userList.Error != nil {
+		return nil, userList.Error
+	}
+
+	var extensions []any
+	seen := make(map[string]bool)
+
+	for _, u := range userList.Data {
+		user := u.(*mqlUser)
+		homeDir := user.GetHome().Data
+
+		if invalidHomeDirs[homeDir] {
+			continue
+		}
+
+		for _, editor := range vsCodeEditors {
+			extensionsDir := filepath.Join(homeDir, editor.dir)
+
+			// ReadDir will fail if directory doesn't exist - no need for separate Exists check
+			entries, err := afs.ReadDir(extensionsDir)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					log.Debug().Err(err).Str("path", extensionsDir).Msg("failed to read VS Code extensions directory")
+				}
+				continue
+			}
+
+			for _, entry := range entries {
+				if !entry.IsDir() {
+					continue
+				}
+
+				// Skip .obsolete directory
+				if entry.Name() == ".obsolete" {
+					continue
+				}
+
+				extPath := filepath.Join(extensionsDir, entry.Name())
+				packageJSONPath := filepath.Join(extPath, "package.json")
+
+				// ReadFile will fail if file doesn't exist - no need for separate Exists check
+				pkgJSON, err := readVSCodePackageJSON(afs, packageJSONPath)
+				if err != nil {
+					if !os.IsNotExist(err) {
+						log.Debug().Err(err).Str("path", packageJSONPath).Msg("failed to parse VS Code extension package.json")
+					}
+					continue
+				}
+
+				// Create unique identifier
+				identifier := pkgJSON.Publisher + "." + pkgJSON.Name
+				if identifier == "." {
+					// Fallback to directory name if publisher/name not available
+					identifier = entry.Name()
+				}
+
+				// Create unique ID for caching (including path to handle multiple installs)
+				uniqueID := identifier + "|" + extPath
+
+				if seen[uniqueID] {
+					continue
+				}
+				seen[uniqueID] = true
+
+				// Convert categories to []any
+				categories := make([]any, len(pkgJSON.Categories))
+				for i, cat := range pkgJSON.Categories {
+					categories[i] = cat
+				}
+
+				// Create extension resource
+				ext, err := CreateResource(c.MqlRuntime, "vscode.extension", map[string]*llx.RawData{
+					"__id":          llx.StringData(uniqueID),
+					"identifier":    llx.StringData(identifier),
+					"name":          llx.StringData(pkgJSON.Name),
+					"displayName":   llx.StringData(pkgJSON.DisplayName),
+					"version":       llx.StringData(pkgJSON.Version),
+					"description":   llx.StringData(pkgJSON.Description),
+					"publisher":     llx.StringData(pkgJSON.Publisher),
+					"editor":        llx.StringData(editor.name),
+					"path":          llx.StringData(extPath),
+					"vscodeVersion": llx.StringData(pkgJSON.Engines.VSCode),
+					"categories":    llx.ArrayData(categories, types.String),
+				})
+				if err != nil {
+					log.Debug().Err(err).Str("extension", identifier).Msg("failed to create VS Code extension resource")
+					continue
+				}
+				extensions = append(extensions, ext)
+			}
+		}
+	}
+
+	return extensions, nil
+}
+
+func (e *mqlVscodeExtension) id() (string, error) {
+	return e.Identifier.Data + "|" + e.Path.Data, nil
+}
+
+// readVSCodePackageJSON reads and parses a VS Code extension package.json file
+func readVSCodePackageJSON(afs *afero.Afero, path string) (*vscodePackageJSON, error) {
+	data, err := afs.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var pkg vscodePackageJSON
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return nil, err
+	}
+
+	return &pkg, nil
+}


### PR DESCRIPTION
Add new `vscode` resource to detect installed extensions across VS Code-based editors:
- Visual Studio Code
- VS Code Insiders
- VSCodium
- Cursor
- Antigravity
- Windsurf
- Positron
- Kiro

The resource scans extension directories for all users and parses package.json to extract extension metadata including identifier, version, publisher, description, editor, and categories.

Example usage:

```javascript
  vscode.extensions { editor name version }
  vscode.paths
```

Example output:

```javascript
> vscode.extensions
vscode.extensions: [
  0: vscode.extension editor="Visual Studio Code" name="codesnap" version="1.3.4"
  1: vscode.extension editor="Visual Studio Code" name="claude-code" version="2.1.11"
  2: vscode.extension editor="Visual Studio Code" name="claude-code" version="2.1.15"
  3: vscode.extension editor="Visual Studio Code" name="claude-code" version="2.1.16"
  4: vscode.extension editor="Visual Studio Code" name="claude-code" version="2.1.17"
  5: vscode.extension editor="Visual Studio Code" name="claude-code" version="2.1.19"
  6: vscode.extension editor="Visual Studio Code" name="trivy-vulnerability-scanner" version="1.8.11"
  7: vscode.extension editor="Visual Studio Code" name="bruno" version="4.5.0"

```