### PR TITLE
🐛 Update NetBSD package/service implementation to avoid path issues

### DIFF
--- a/providers/os/resources/packages/netbsd_packages.go
+++ b/providers/os/resources/packages/netbsd_packages.go
@@ -152,7 +152,7 @@ func (n *NetBSDPkgManager) Format() string {
 }
 
 func (n *NetBSDPkgManager) List() ([]Package, error) {
-	cmd, err := n.conn.RunCommand("pkg_info -X -a")
+	cmd, err := n.conn.RunCommand("/usr/sbin/pkg_info -X -a")
 	if err != nil {
 		return nil, fmt.Errorf("could not read netbsd package list")
 	}

--- a/providers/os/resources/services/netbsdrcservice.go
+++ b/providers/os/resources/services/netbsdrcservice.go
@@ -24,14 +24,14 @@ func (s *NetBsdServiceManager) Name() string {
 
 func (s *NetBsdServiceManager) List() ([]*Service, error) {
 	// Fetch all available services
-	c, err := s.conn.RunCommand("service -l")
+	c, err := s.conn.RunCommand("/usr/sbin/service -l")
 	if err != nil {
 		return nil, err
 	}
 	allServices := ParseNetBsdServiceList(c.Stdout)
 
 	// Fetch enabled services
-	c, err = s.conn.RunCommand("service -e")
+	c, err = s.conn.RunCommand("/usr/sbin/service -e")
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (s *NetBsdServiceManager) List() ([]*Service, error) {
 
 // checkServiceStatus checks if a service is currently running by executing service <name> status
 func (s *NetBsdServiceManager) checkServiceStatus(name string) (bool, error) {
-	cmd := "service " + name + " status"
+	cmd := "/usr/sbin/service " + name + " status"
 	c, err := s.conn.RunCommand(cmd)
 	if err != nil {
 		// Command execution failed (not just non-zero exit)

--- a/providers/os/resources/services/testdata/netbsd9.toml
+++ b/providers/os/resources/services/testdata/netbsd9.toml
@@ -1,4 +1,4 @@
-[commands."service -l"]
+[commands."/usr/sbin/service -l"]
 stdout = """/etc/rc.d/bootconf.sh
 /etc/rc.d/ccd
 /etc/rc.d/cgd
@@ -57,7 +57,7 @@ stdout = """/etc/rc.d/bootconf.sh
 /etc/rc.d/ypbind
 """
 
-[commands."service -e"]
+[commands."/usr/sbin/service -e"]
 stdout = """/etc/rc.d/cron
 /etc/rc.d/dhcpcd
 /etc/rc.d/ntpd
@@ -66,27 +66,27 @@ stdout = """/etc/rc.d/cron
 /etc/rc.d/syslogd
 """
 
-[commands."service cron status"]
+[commands."/usr/sbin/service cron status"]
 stdout = "cron is running as pid 245."
 exit_status =0
 
-[commands."service dhcpcd status"]
+[commands."/usr/sbin/service dhcpcd status"]
 stdout = "dhcpcd is running as pid 182."
 exit_status =0
 
-[commands."service ntpd status"]
+[commands."/usr/sbin/service ntpd status"]
 stdout = "ntpd is not running."
 exit_status =1
 
-[commands."service postfix status"]
+[commands."/usr/sbin/service postfix status"]
 stdout = "postfix is running."
 exit_status =0
 
-[commands."service sshd status"]
+[commands."/usr/sbin/service sshd status"]
 stdout = "sshd is running as pid 389."
 exit_status =0
 
-[commands."service syslogd status"]
+[commands."/usr/sbin/service syslogd status"]
 stdout = "syslogd is running as pid 156."
 exit_status =0
 


### PR DESCRIPTION
Use the full path to the commands. These commands work fine when I'm SSH'd into the box, but they're not working with the provider. I tried them with the `command` resource and they also failed. This fixed it.

```
> services
services.list: [
  0: service name="ipfs" running=false enabled=false type="netbsd"
  1: service name="ipfilter" running=false enabled=false type="netbsd"
  2: service name="rwho" running=false enabled=false type="netbsd"
  3: service name="dhcpd6" running=false enabled=false type="netbsd"
  4: service name="timed" running=false enabled=false type="netbsd"
  5: service name="envsys" running=false enabled=false type="netbsd"
  6: service name="npf_boot" running=false enabled=false type="netbsd"
  7: service name="NETWORKING" running=false enabled=false type="netbsd"
  8: service name="rarpd" running=false enabled=false type="netbsd"
  9: service name="postfix" running=false enabled=true type="netbsd"
  10: service name="LOGIN" running=false enabled=false type="netbsd"
  11: service name="pflogd" running=false enabled=false type="netbsd"
  12: service name="accounting" running=false enabled=false type="netbsd"
  13: service name="amd" running=false enabled=false type="netbsd"
  14: service name="screenblank" running=false enabled=false type="netbsd"
  15: service name="fsck" running=false enabled=false type="netbsd"
  16: service name="identd" running=false enabled=false type="netbsd"
  17: service name="swap2" running=false enabled=false type="netbsd"
  18: service name="ldconfig" running=false enabled=true type="netbsd"
  19: service name="dhcpcd" running=true enabled=true type="netbsd"
  20: service name="automount" running=false enabled=false type="netbsd"
  21: service name="rtclocaltime" running=false enabled=false type="netbsd"
  22: service name="syslogd" running=true enabled=true type="netbsd"
  23: service name="wscons" running=false enabled=true type="netbsd"
  24: service name="mountcritlocal" running=false enabled=false type="netbsd"
  25: service name="rtadvd" running=false enabled=false type="netbsd"
  26: service name="resize_root" running=false enabled=false type="netbsd"
  27: service name="ttys" running=false enabled=false type="netbsd"
  28: service name="iscsi_target" running=false enabled=false type="netbsd"
  29: service name="tpctl" running=false enabled=false type="netbsd"
  30: service name="lpd" running=false enabled=false type="netbsd"
  31: service name="bluetooth" running=false enabled=false type="netbsd"
  32: service name="wdogctl" running=false enabled=false type="netbsd"
  33: service name="DISKS" running=false enabled=false type="netbsd"
  34: service name="network" running=false enabled=false type="netbsd"
  35: service name="yppasswdd" running=false enabled=false type="netbsd"
  36: service name="devpubd" running=false enabled=false type="netbsd"
  37: service name="npfd" running=false enabled=false type="netbsd"
  38: service name="lvm" running=false enabled=false type="netbsd"
  39: service name="rbootd" running=false enabled=false type="netbsd"
  40: service name="powerd" running=true enabled=true type="netbsd"
  41: service name="ifwatchd" running=false enabled=false type="netbsd"
  42: service name="mountcritremote" running=false enabled=false type="netbsd"
  43: service name="random_seed" running=false enabled=true type="netbsd"
  44: service name="quota" running=false enabled=true type="netbsd"
  45: service name="irdaattach" running=false enabled=false type="netbsd"
  46: service name="altqd" running=false enabled=false type="netbsd"
  47: service name="veriexec" running=false enabled=false type="netbsd"
  48: service name="isibootd" running=false enabled=false type="netbsd"
  49: service name="root" running=false enabled=false type="netbsd"
  50: service name="raidframeparity" running=false enabled=false type="netbsd"
  51: service name="named" running=false enabled=false type="netbsd"
  52: service name="bootparams" running=false enabled=false type="netbsd"
  53: service name="pwcheck" running=false enabled=false type="netbsd"
  54: service name="racoon" running=false enabled=false type="netbsd"
  55: service name="ccd" running=false enabled=true type="netbsd"
  56: service name="dhcrelay" running=false enabled=false type="netbsd"
  57: service name="inetd" running=true enabled=true type="netbsd"
  58: service name="zfs" running=false enabled=false type="netbsd"
  59: service name="nfsd" running=false enabled=false type="netbsd"
  60: service name="hostapd" running=false enabled=false type="netbsd"
  61: service name="mountall" running=false enabled=false type="netbsd"
  62: service name="virecover" running=false enabled=true type="netbsd"
  63: service name="local" running=false enabled=false type="netbsd"
  64: service name="ndbootd" running=false enabled=false type="netbsd"
  65: service name="ftp_proxy" running=false enabled=false type="netbsd"
  66: service name="httpd" running=false enabled=false type="netbsd"
  67: service name="fsck_root" running=false enabled=false type="netbsd"
  68: service name="mountd" running=false enabled=false type="netbsd"
  69: service name="moused" running=false enabled=false type="netbsd"
  70: service name="cron" running=true enabled=true type="netbsd"
  71: service name="makemandb" running=false enabled=true type="netbsd"
  72: service name="pf_boot" running=false enabled=false type="netbsd"
  73: service name="ip6addrctl" running=true enabled=true type="netbsd"
  74: service name="savecore" running=false enabled=true type="netbsd"
  75: service name="unbound" running=false enabled=false type="netbsd"
  76: service name="routed" running=false enabled=false type="netbsd"
  77: service name="sshd" running=true enabled=true type="netbsd"
  78: service name="npf" running=false enabled=false type="netbsd"
  79: service name="iscsid" running=false enabled=false type="netbsd"
  80: service name="wsmoused" running=false enabled=false type="netbsd"
  81: service name="modules" running=false enabled=true type="netbsd"
  82: service name="cgd" running=false enabled=true type="netbsd"
  83: service name="ypserv" running=false enabled=false type="netbsd"
  84: service name="route6d" running=false enabled=false type="netbsd"
  85: service name="gpio" running=false enabled=false type="netbsd"
  86: service name="mixerctl" running=false enabled=false type="netbsd"
  87: service name="motd" running=false enabled=true type="netbsd"
  88: service name="ntpd" running=false enabled=false type="netbsd"
  89: service name="mdnsd" running=false enabled=false type="netbsd"
  90: service name="autounmountd" running=false enabled=false type="netbsd"
  91: service name="ypbind" running=false enabled=false type="netbsd"
  92: service name="rpcbind" running=false enabled=false type="netbsd"
  93: service name="newsyslog" running=false enabled=false type="netbsd"
  94: service name="nfslocking" running=false enabled=false type="netbsd"
  95: service name="ftpd" running=false enabled=false type="netbsd"
  96: service name="ipsec" running=false enabled=false type="netbsd"
  97: service name="kdc" running=false enabled=false type="netbsd"
  98: service name="ipnat" running=false enabled=false type="netbsd"
  99: service name="blacklistd" running=false enabled=false type="netbsd"
  100: service name="cleartmp" running=false enabled=true type="netbsd"
  101: service name="SERVERS" running=false enabled=false type="netbsd"
  102: service name="DAEMON" running=false enabled=false type="netbsd"
  103: service name="wpa_supplicant" running=false enabled=false type="netbsd"
  104: service name="ipmon" running=false enabled=false type="netbsd"
  105: service name="dmesg" running=false enabled=true type="netbsd"
  106: service name="sysctl" running=false enabled=false type="netbsd"
  107: service name="dhcpd" running=false enabled=false type="netbsd"
  108: service name="ldpd" running=false enabled=false type="netbsd"
  109: service name="rndctl" running=false enabled=false type="netbsd"
  110: service name="sysdb" running=false enabled=true type="netbsd"
  111: service name="ppp" running=false enabled=true type="netbsd"
  112: service name="swap1" running=false enabled=false type="netbsd"
  113: service name="perusertmp" running=false enabled=false type="netbsd"
  114: service name="mrouted" running=false enabled=false type="netbsd"
  115: service name="staticroute" running=false enabled=false type="netbsd"
  116: service name="ntpdate" running=false enabled=true type="netbsd"
  117: service name="securelevel" running=false enabled=false type="netbsd"
  118: service name="bootconf.sh" running=false enabled=false type="netbsd"
  119: service name="automountd" running=false enabled=false type="netbsd"
  120: service name="raidframe" running=false enabled=true type="netbsd"
  121: service name="smtoff" running=false enabled=false type="netbsd"
  122: service name="pf" running=false enabled=false type="netbsd"
  123: service name="apmd" running=false enabled=false type="netbsd"
  124: service name="mopd" running=false enabled=false type="netbsd"
]
> packages
packages.list: [
  0: package name="vim-share" version="9.0.2122"
  1: package name="vim" version="9.0.2122"
  2: package name="libunistring" version="1.1"
  3: package name="libidn2" version="2.3.4"
  4: package name="xmlcatmgr" version="2.2nb1"
  5: package name="libxml2" version="2.10.4nb6"
  6: package name="nghttp2" version="1.58.0nb1"
  7: package name="curl" version="8.5.0"
  8: package name="libpsl" version="0.21.2nb1"
  9: package name="wget" version="1.21.4nb2"
  10: package name="sudo" version="1.9.15p2"
  11: package name="bash" version="5.2.21nb1"
  12: package name="pkg_install" version="20211115nb1"
  13: package name="pkgin" version="23.8.1nb2"
  14: package name="slocate" version="3.1nb1"
  15: package name="bash-completion" version="2.11"
  16: package name="ca-certificates" version="20230311nb3"
  17: package name="pkg_alternatives" version="1.7"
  18: package name="dmidecode" version="3.5nb1"
]
```