### PR TITLE
⭐ Add launchd.jobs resource

### DIFF
--- a/providers/os/resources/launchd_test.go
+++ b/providers/os/resources/launchd_test.go
@@ -558,7 +558,10 @@ func TestLaunchdFullPlistParsing(t *testing.T) {
 		"StartCalendarInterval": []any{
 			map[string]any{"Hour": float64(3), "Minute": float64(0)},
 		},
-		"Disabled": false,
+		"StandardOutPath":   "/var/log/example.out.log",
+		"StandardErrorPath": "/var/log/example.err.log",
+		"RootDirectory":     "/var/lib/example",
+		"Disabled":          false,
 	}
 
 	// Test all field extractions
@@ -568,6 +571,9 @@ func TestLaunchdFullPlistParsing(t *testing.T) {
 	assert.Equal(t, "daemon", launchdGetString(data, "UserName"))
 	assert.Equal(t, "daemon", launchdGetString(data, "GroupName"))
 	assert.Equal(t, "Background", launchdGetString(data, "ProcessType"))
+	assert.Equal(t, "/var/log/example.out.log", launchdGetString(data, "StandardOutPath"))
+	assert.Equal(t, "/var/log/example.err.log", launchdGetString(data, "StandardErrorPath"))
+	assert.Equal(t, "/var/lib/example", launchdGetString(data, "RootDirectory"))
 
 	assert.True(t, launchdGetBool(data, "RunAtLoad"))
 	assert.False(t, launchdGetBool(data, "Disabled"))
@@ -612,6 +618,9 @@ func TestLaunchdMinimalPlist(t *testing.T) {
 	assert.Nil(t, launchdParseKeepAlive(data))
 	assert.Nil(t, launchdGetDict(data, "Sockets"))
 	assert.Equal(t, map[string]any{}, launchdGetStringMap(data, "EnvironmentVariables"))
+	assert.Equal(t, "", launchdGetString(data, "StandardOutPath"))
+	assert.Equal(t, "", launchdGetString(data, "StandardErrorPath"))
+	assert.Equal(t, "", launchdGetString(data, "RootDirectory"))
 }
 
 // Integration tests using TOML-based mock filesystem
@@ -640,6 +649,9 @@ func TestLaunchdPlistFromMockFS(t *testing.T) {
 	assert.Equal(t, "daemon", launchdGetString(data, "UserName"))
 	assert.Equal(t, "daemon", launchdGetString(data, "GroupName"))
 	assert.Equal(t, "Background", launchdGetString(data, "ProcessType"))
+	assert.Equal(t, "/var/log/example.out.log", launchdGetString(data, "StandardOutPath"))
+	assert.Equal(t, "/var/log/example.err.log", launchdGetString(data, "StandardErrorPath"))
+	assert.Equal(t, "/var/lib/example", launchdGetString(data, "RootDirectory"))
 
 	assert.Equal(t, []any{"/usr/local/bin/example", "--daemon"},
 		launchdGetStringArray(data, "ProgramArguments"))

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -1971,6 +1971,12 @@ private launchd.job @defaults("label type") {
   machServices dict
   // Watch paths that trigger the job
   watchPaths []string
+  // Path to redirect stdout
+  stdoutPath string
+  // Path to redirect stderr
+  stderrPath string
+  // Directory to chroot to before launch
+  rootDirectory string
   // The plist file resource
   file file
   // Full parsed plist content

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -2998,6 +2998,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"launchd.job.watchPaths": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlLaunchdJob).GetWatchPaths()).ToDataRes(types.Array(types.String))
 	},
+	"launchd.job.stdoutPath": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlLaunchdJob).GetStdoutPath()).ToDataRes(types.String)
+	},
+	"launchd.job.stderrPath": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlLaunchdJob).GetStderrPath()).ToDataRes(types.String)
+	},
+	"launchd.job.rootDirectory": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlLaunchdJob).GetRootDirectory()).ToDataRes(types.String)
+	},
 	"launchd.job.file": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlLaunchdJob).GetFile()).ToDataRes(types.Resource("file"))
 	},
@@ -6826,6 +6835,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"launchd.job.watchPaths": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlLaunchdJob).WatchPaths, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"launchd.job.stdoutPath": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlLaunchdJob).StdoutPath, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"launchd.job.stderrPath": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlLaunchdJob).StderrPath, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"launchd.job.rootDirectory": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlLaunchdJob).RootDirectory, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"launchd.job.file": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -18937,6 +18958,9 @@ type mqlLaunchdJob struct {
 	Sockets               plugin.TValue[any]
 	MachServices          plugin.TValue[any]
 	WatchPaths            plugin.TValue[[]any]
+	StdoutPath            plugin.TValue[string]
+	StderrPath            plugin.TValue[string]
+	RootDirectory         plugin.TValue[string]
 	File                  plugin.TValue[*mqlFile]
 	Content               plugin.TValue[any]
 }
@@ -19052,6 +19076,18 @@ func (c *mqlLaunchdJob) GetMachServices() *plugin.TValue[any] {
 
 func (c *mqlLaunchdJob) GetWatchPaths() *plugin.TValue[[]any] {
 	return &c.WatchPaths
+}
+
+func (c *mqlLaunchdJob) GetStdoutPath() *plugin.TValue[string] {
+	return &c.StdoutPath
+}
+
+func (c *mqlLaunchdJob) GetStderrPath() *plugin.TValue[string] {
+	return &c.StderrPath
+}
+
+func (c *mqlLaunchdJob) GetRootDirectory() *plugin.TValue[string] {
+	return &c.RootDirectory
 }
 
 func (c *mqlLaunchdJob) GetFile() *plugin.TValue[*mqlFile] {

--- a/providers/os/resources/os.lr.manifest.yaml
+++ b/providers/os/resources/os.lr.manifest.yaml
@@ -596,11 +596,14 @@ resources:
       processType: {}
       program: {}
       programArguments: {}
+      rootDirectory: {}
       runAtLoad: {}
       sockets: {}
       source: {}
       startCalendarInterval: {}
       startInterval: {}
+      stderrPath: {}
+      stdoutPath: {}
       type: {}
       userName: {}
       watchPaths: {}

--- a/providers/os/resources/testdata/launchd_macos.toml
+++ b/providers/os/resources/testdata/launchd_macos.toml
@@ -63,6 +63,12 @@ content = """<?xml version="1.0" encoding="UTF-8"?>
 		<key>com.example.service</key>
 		<true/>
 	</dict>
+	<key>StandardOutPath</key>
+	<string>/var/log/example.out.log</string>
+	<key>StandardErrorPath</key>
+	<string>/var/log/example.err.log</string>
+	<key>RootDirectory</key>
+	<string>/var/lib/example</string>
 	<key>StartCalendarInterval</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Expose all the complexity of launchd on macOS

```coffeescript
launchd.jobs.first: {
  startInterval: 0
  keepAlive: {}
  groupName: ""
  label: "com.apple.bootpd"
  file: file path="/System/Library/LaunchDaemons/bootps.plist" size=721 permissions.string="-rw-r--r--"
  environmentVariables: {}
  workingDirectory: ""
  machServices: {}
  source: "system"
  userName: ""
  runAtLoad: false
  content: {
    Disabled: true
    Label: "com.apple.bootpd"
    ProgramArguments: [
      0: "/usr/libexec/bootpd"
    ]
    Sockets: {
      Listeners: {
        ReceivePacketInfo: true
        SockFamily: "IPv4"
        SockServiceName: "bootps"
        SockType: "dgram"
      }
    }
    inetdCompatibility: {
      Wait: true
    }
  }
  disabled: true
  path: "/System/Library/LaunchDaemons/bootps.plist"
  sockets: {
    Listeners: {
      ReceivePacketInfo: true
      SockFamily: "IPv4"
      SockServiceName: "bootps"
      SockType: "dgram"
    }
  }
  program: ""
  processType: ""
  watchPaths: []
  startCalendarInterval: []
  type: "daemon"
  programArguments: [
    0: "/usr/libexec/bootpd"
  ]
}
```