### PR TITLE
🧹 Add a title to the aws-secretsmanager-secrets platform

### DIFF
--- a/providers/aws/connection/platform.go
+++ b/providers/aws/connection/platform.go
@@ -138,6 +138,8 @@ func getTitleForPlatformName(name string) string {
 		return "AWS ECR Image"
 	case "aws-eks-cluster":
 		return "AWS EKS Cluster"
+	case "aws-secretsmanager-secret":
+		return "AWS Secrets Manager Secret"
 	}
 	return "Amazon Web Services"
 }


### PR DESCRIPTION
Make sure it gets a unique title for display on the asset pages:

```
> asset.title
asset.title: "AWS Secrets Manager Secret"
```

Followup from https://github.com/mondoohq/cnquery/pull/6483