### PR TITLE
Add a init to the aws.secretsmanager.secret resource

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1682,7 +1682,7 @@ aws.secretsmanager {
 }
 
 // AWS Secrets Manager secret
-private aws.secretsmanager.secret @defaults("arn name") {
+aws.secretsmanager.secret @defaults("arn name") {
   // ARN for the secret
   arn string
   // Creation date of the secret

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -651,7 +651,7 @@ func init() {
 			Create: createAwsSecretsmanager,
 		},
 		"aws.secretsmanager.secret": {
-			// to override args, implement: initAwsSecretsmanagerSecret(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAwsSecretsmanagerSecret,
 			Create: createAwsSecretsmanagerSecret,
 		},
 		"aws.ecs": {

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -3726,7 +3726,6 @@ resources:
         min_mondoo_version: 9.0.0
       rotationEnabled: {}
       tags: {}
-    is_private: true
     min_mondoo_version: 5.15.0
     platform:
       name:


### PR DESCRIPTION
Make this work with the new aws-secretsmanager-secret platform

More followup to https://github.com/mondoohq/cnquery/pull/6483

```
cnspec shell aws --discover secretsmanager-secrets

...

> aws.secretsmanager.secret
aws.secretsmanager.secret: aws.secretsmanager.secret arn="arn:aws:secretsmanager:us-east-1:123456789:secret:timapp-ECak5I" name="timapp"
> aws.secretsmanager.secret{*}
aws.secretsmanager.secret: {
  lastChangedDate: 2026-01-26 21:06:23.193 -0800 PST
  kmsKey: null
  tags: {
    environment: "prod"
  }
  createdAt: 2026-01-26 21:06:23.148 -0800 PST
  name: "timapp"
  arn: "arn:aws:secretsmanager:us-east-1:123456789:secret:timapp-ECak5I"
  description: "just a thing"
  lastRotatedDate: null
  nextRotationDate: null
  rotationEnabled: false
  primaryRegion: null
}
```