### PR TITLE
✨ Support rpm modules for AlmaLinux

### DIFF
--- a/providers/os/resources/packages/testdata/packages_almalinux.toml
+++ b/providers/os/resources/packages/testdata/packages_almalinux.toml
@@ -1,0 +1,15 @@
+[commands."command -v rpm"]
+stdout="/usr/bin/rpm"
+
+[commands."rpm -E '%{_dbpath}'"]
+stdout="/var/lib/rpm"
+
+[commands."rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{MODULARITYLABEL}\\n'"]
+stdout="""
+php-xml 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__A module for PHP applications which use XML__php:7.4:8100020241212065510:eb0869e2
+php-mbstring 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__A module for PHP applications which need multi-byte string handling__php:7.4:8100020241212065510:eb0869e2
+php-common 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__Common files for PHP__php:7.4:8100020241212065510:eb0869e2
+php-cli 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__Command-line interface for PHP__php:7.4:8100020241212065510:eb0869e2
+php-fpm 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__PHP FastCGI Process Manager__php:7.4:8100020241212065510:eb0869e2
+php-json 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__JavaScript Object Notation extension for PHP__php:7.4:8100020241212065510:eb0869e2
+"""


### PR DESCRIPTION
Related to https://github.com/mondoohq/cnquery/pull/6391

To test this, create a container image:
```
FROM almalinux:8.10

RUN dnf module disable -y php:7.2 && dnf module enable -y php:7.4 &&  dnf module install -y php
```

Run cnquery:
```
cnquery run docker image almalinux8:php74 -c 'packages.where(name == /php/){ name purl }'
→ no Mondoo configuration file provided, using defaults
packages.where.list: [
  0: {
    purl: "pkg:rpm/almalinux/php-xml@0%3A7.4.33-2.module_el8.10.0%2B3935%2B28808425?arch=aarch64&distro=almalinux-8.10&rpmmod=php%3A7.4%3A8100020241212065510%3Aeb0869e2"
    name: "php-xml"
  }
  1: {
    purl: "pkg:rpm/almalinux/php-mbstring@0%3A7.4.33-2.module_el8.10.0%2B3935%2B28808425?arch=aarch64&distro=almalinux-8.10&rpmmod=php%3A7.4%3A8100020241212065510%3Aeb0869e2"
    name: "php-mbstring"
  }
  2: {
    purl: "pkg:rpm/almalinux/php-common@0%3A7.4.33-2.module_el8.10.0%2B3935%2B28808425?arch=aarch64&distro=almalinux-8.10&rpmmod=php%3A7.4%3A8100020241212065510%3Aeb0869e2"
    name: "php-common"
  }
  3: {
    purl: "pkg:rpm/almalinux/php-cli@0%3A7.4.33-2.module_el8.10.0%2B3935%2B28808425?arch=aarch64&distro=almalinux-8.10&rpmmod=php%3A7.4%3A8100020241212065510%3Aeb0869e2"
    name: "php-cli"
  }
  4: {
    purl: "pkg:rpm/almalinux/php-fpm@0%3A7.4.33-2.module_el8.10.0%2B3935%2B28808425?arch=aarch64&distro=almalinux-8.10&rpmmod=php%3A7.4%3A8100020241212065510%3Aeb0869e2"
    name: "php-fpm"
  }
  5: {
    purl: "pkg:rpm/almalinux/php-json@0%3A7.4.33-2.module_el8.10.0%2B3935%2B28808425?arch=aarch64&distro=almalinux-8.10&rpmmod=php%3A7.4%3A8100020241212065510%3Aeb0869e2"
    name: "php-json"
  }
]
```