### PR TITLE
🧹 return empty DataRes when value not set

### DIFF
--- a/providers-sdk/v1/plugin/runtime.go
+++ b/providers-sdk/v1/plugin/runtime.go
@@ -196,9 +196,7 @@ type TValue[T any] struct {
 
 func (x *TValue[T]) ToDataRes(typ types.Type) *DataRes {
 	if !x.IsSet() {
-		return &DataRes{
-			Data: &llx.Primitive{Type: string(types.Nil)},
-		}
+		return &DataRes{}
 	}
 	if x.IsNull() {
 		if x.Error != nil {


### PR DESCRIPTION
this change was causing some behaviour differences in scoring