### PR TITLE
⭐ Expose kmsKeys in several AWS resources

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2553,7 +2553,7 @@ private aws.dynamodb.export {
   endTime() time
   // S3 SSE Algorithm for the export
   s3SseAlgorithm() string
-  // SSE KMS Key Id
+  // SSE KMS Key
   kmsKey() aws.kms.key
   // ARN for the export
   arn string
@@ -2789,6 +2789,8 @@ aws.rds.dbcluster @defaults("id region engine engineVersion") {
   globalClusterIdentifier string
   // CloudWatch Database Insights mode. Possible values are `standard` and `advanced`
   databaseInsightsMode string
+  // KMS key used for storage encryption
+  kmsKey() aws.kms.key
 }
 
 // Amazon RDS snapshot
@@ -2821,6 +2823,8 @@ private aws.rds.snapshot @defaults("id region type encrypted createdAt") {
   allocatedStorage int
   // Creation date of the snapshot
   createdAt time
+  // KMS key used for snapshot encryption
+  kmsKey() aws.kms.key
 }
 
 // Amazon RDS database instance
@@ -2913,6 +2917,8 @@ aws.rds.dbinstance @defaults("id region engine engineVersion") {
   preferredMaintenanceWindow string
   // Preferred backup window for the database cluster
   preferredBackupWindow string
+  // KMS key used for storage encryption
+  kmsKey() aws.kms.key
 }
 
 // Amazon RDS pending maintenance action
@@ -3592,6 +3598,8 @@ private aws.ec2.snapshot @defaults("id region volumeSize state") {
   encrypted bool
   // The storage tier in which the snapshot is stored
   storageTier string
+  // KMS key used for snapshot encryption
+  kmsKey() aws.kms.key
 }
 
 // Amazon EC2 (EBS) volume
@@ -3624,6 +3632,8 @@ private aws.ec2.volume @defaults("id region volumeType size encrypted state") {
   size int
   // Number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes, this represents the number of IOPS that are provisioned for the volume. For gp2 volumes, this represents the baseline performance of the volume and the rate at which the volume accumulates I/O credits for bursting.
   iops int
+  // KMS key used for volume encryption
+  kmsKey() aws.kms.key
 }
 
 // Amazon Inspector

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -4447,6 +4447,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.dbcluster.databaseInsightsMode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbcluster).GetDatabaseInsightsMode()).ToDataRes(types.String)
 	},
+	"aws.rds.dbcluster.kmsKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbcluster).GetKmsKey()).ToDataRes(types.Resource("aws.kms.key"))
+	},
 	"aws.rds.snapshot.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsSnapshot).GetArn()).ToDataRes(types.String)
 	},
@@ -4488,6 +4491,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.rds.snapshot.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsSnapshot).GetCreatedAt()).ToDataRes(types.Time)
+	},
+	"aws.rds.snapshot.kmsKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsSnapshot).GetKmsKey()).ToDataRes(types.Resource("aws.kms.key"))
 	},
 	"aws.rds.dbinstance.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbinstance).GetArn()).ToDataRes(types.String)
@@ -4620,6 +4626,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.rds.dbinstance.preferredBackupWindow": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbinstance).GetPreferredBackupWindow()).ToDataRes(types.String)
+	},
+	"aws.rds.dbinstance.kmsKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetKmsKey()).ToDataRes(types.Resource("aws.kms.key"))
 	},
 	"aws.rds.pendingMaintenanceAction.resourceArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsPendingMaintenanceAction).GetResourceArn()).ToDataRes(types.String)
@@ -5425,6 +5434,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.snapshot.storageTier": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Snapshot).GetStorageTier()).ToDataRes(types.String)
 	},
+	"aws.ec2.snapshot.kmsKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Snapshot).GetKmsKey()).ToDataRes(types.Resource("aws.kms.key"))
+	},
 	"aws.ec2.volume.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Volume).GetArn()).ToDataRes(types.String)
 	},
@@ -5466,6 +5478,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.volume.iops": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Volume).GetIops()).ToDataRes(types.Int)
+	},
+	"aws.ec2.volume.kmsKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Volume).GetKmsKey()).ToDataRes(types.Resource("aws.kms.key"))
 	},
 	"aws.inspector.coverages": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsInspector).GetCoverages()).ToDataRes(types.Array(types.Resource("aws.inspector.coverage")))
@@ -11363,6 +11378,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsRdsDbcluster).DatabaseInsightsMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.rds.dbcluster.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbcluster).KmsKey, ok = plugin.RawToTValue[*mqlAwsKmsKey](v.Value, v.Error)
+		return
+	},
 	"aws.rds.snapshot.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsSnapshot).__id, ok = v.Value.(string)
 		return
@@ -11421,6 +11440,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.rds.snapshot.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsSnapshot).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.rds.snapshot.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsSnapshot).KmsKey, ok = plugin.RawToTValue[*mqlAwsKmsKey](v.Value, v.Error)
 		return
 	},
 	"aws.rds.dbinstance.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11601,6 +11624,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.rds.dbinstance.preferredBackupWindow": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsDbinstance).PreferredBackupWindow, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).KmsKey, ok = plugin.RawToTValue[*mqlAwsKmsKey](v.Value, v.Error)
 		return
 	},
 	"aws.rds.pendingMaintenanceAction.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12819,6 +12846,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2Snapshot).StorageTier, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.snapshot.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Snapshot).KmsKey, ok = plugin.RawToTValue[*mqlAwsKmsKey](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.volume.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Volume).__id, ok = v.Value.(string)
 		return
@@ -12877,6 +12908,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.volume.iops": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Volume).Iops, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.volume.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Volume).KmsKey, ok = plugin.RawToTValue[*mqlAwsKmsKey](v.Value, v.Error)
 		return
 	},
 	"aws.inspector.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -28320,6 +28355,7 @@ type mqlAwsRdsDbcluster struct {
 	ParameterGroupName         plugin.TValue[string]
 	GlobalClusterIdentifier    plugin.TValue[string]
 	DatabaseInsightsMode       plugin.TValue[string]
+	KmsKey                     plugin.TValue[*mqlAwsKmsKey]
 }
 
 // createAwsRdsDbcluster creates a new instance of this resource
@@ -28567,11 +28603,27 @@ func (c *mqlAwsRdsDbcluster) GetDatabaseInsightsMode() *plugin.TValue[string] {
 	return &c.DatabaseInsightsMode
 }
 
+func (c *mqlAwsRdsDbcluster) GetKmsKey() *plugin.TValue[*mqlAwsKmsKey] {
+	return plugin.GetOrCompute[*mqlAwsKmsKey](&c.KmsKey, func() (*mqlAwsKmsKey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds.dbcluster", c.__id, "kmsKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsKmsKey), nil
+			}
+		}
+
+		return c.kmsKey()
+	})
+}
+
 // mqlAwsRdsSnapshot for the aws.rds.snapshot resource
 type mqlAwsRdsSnapshot struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsRdsSnapshotInternal it will be used here
+	mqlAwsRdsSnapshotInternal
 	Arn               plugin.TValue[string]
 	Id                plugin.TValue[string]
 	Attributes        plugin.TValue[[]any]
@@ -28586,6 +28638,7 @@ type mqlAwsRdsSnapshot struct {
 	Port              plugin.TValue[int64]
 	AllocatedStorage  plugin.TValue[int64]
 	CreatedAt         plugin.TValue[*time.Time]
+	KmsKey            plugin.TValue[*mqlAwsKmsKey]
 }
 
 // createAwsRdsSnapshot creates a new instance of this resource
@@ -28683,6 +28736,22 @@ func (c *mqlAwsRdsSnapshot) GetCreatedAt() *plugin.TValue[*time.Time] {
 	return &c.CreatedAt
 }
 
+func (c *mqlAwsRdsSnapshot) GetKmsKey() *plugin.TValue[*mqlAwsKmsKey] {
+	return plugin.GetOrCompute[*mqlAwsKmsKey](&c.KmsKey, func() (*mqlAwsKmsKey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds.snapshot", c.__id, "kmsKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsKmsKey), nil
+			}
+		}
+
+		return c.kmsKey()
+	})
+}
+
 // mqlAwsRdsDbinstance for the aws.rds.dbinstance resource
 type mqlAwsRdsDbinstance struct {
 	MqlRuntime *plugin.Runtime
@@ -28732,6 +28801,7 @@ type mqlAwsRdsDbinstance struct {
 	NetworkType                   plugin.TValue[string]
 	PreferredMaintenanceWindow    plugin.TValue[string]
 	PreferredBackupWindow         plugin.TValue[string]
+	KmsKey                        plugin.TValue[*mqlAwsKmsKey]
 }
 
 // createAwsRdsDbinstance creates a new instance of this resource
@@ -29005,6 +29075,22 @@ func (c *mqlAwsRdsDbinstance) GetPreferredMaintenanceWindow() *plugin.TValue[str
 
 func (c *mqlAwsRdsDbinstance) GetPreferredBackupWindow() *plugin.TValue[string] {
 	return &c.PreferredBackupWindow
+}
+
+func (c *mqlAwsRdsDbinstance) GetKmsKey() *plugin.TValue[*mqlAwsKmsKey] {
+	return plugin.GetOrCompute[*mqlAwsKmsKey](&c.KmsKey, func() (*mqlAwsKmsKey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds.dbinstance", c.__id, "kmsKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsKmsKey), nil
+			}
+		}
+
+		return c.kmsKey()
+	})
 }
 
 // mqlAwsRdsPendingMaintenanceAction for the aws.rds.pendingMaintenanceAction resource
@@ -32251,7 +32337,7 @@ func (c *mqlAwsEc2Internetgateway) GetAttachments() *plugin.TValue[[]any] {
 type mqlAwsEc2Snapshot struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsEc2SnapshotInternal it will be used here
+	mqlAwsEc2SnapshotInternal
 	Arn                    plugin.TValue[string]
 	Id                     plugin.TValue[string]
 	Region                 plugin.TValue[string]
@@ -32265,6 +32351,7 @@ type mqlAwsEc2Snapshot struct {
 	Description            plugin.TValue[string]
 	Encrypted              plugin.TValue[bool]
 	StorageTier            plugin.TValue[string]
+	KmsKey                 plugin.TValue[*mqlAwsKmsKey]
 }
 
 // createAwsEc2Snapshot creates a new instance of this resource
@@ -32358,11 +32445,27 @@ func (c *mqlAwsEc2Snapshot) GetStorageTier() *plugin.TValue[string] {
 	return &c.StorageTier
 }
 
+func (c *mqlAwsEc2Snapshot) GetKmsKey() *plugin.TValue[*mqlAwsKmsKey] {
+	return plugin.GetOrCompute[*mqlAwsKmsKey](&c.KmsKey, func() (*mqlAwsKmsKey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2.snapshot", c.__id, "kmsKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsKmsKey), nil
+			}
+		}
+
+		return c.kmsKey()
+	})
+}
+
 // mqlAwsEc2Volume for the aws.ec2.volume resource
 type mqlAwsEc2Volume struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsEc2VolumeInternal it will be used here
+	mqlAwsEc2VolumeInternal
 	Arn                plugin.TValue[string]
 	Id                 plugin.TValue[string]
 	Attachments        plugin.TValue[[]any]
@@ -32377,6 +32480,7 @@ type mqlAwsEc2Volume struct {
 	Throughput         plugin.TValue[int64]
 	Size               plugin.TValue[int64]
 	Iops               plugin.TValue[int64]
+	KmsKey             plugin.TValue[*mqlAwsKmsKey]
 }
 
 // createAwsEc2Volume creates a new instance of this resource
@@ -32470,6 +32574,22 @@ func (c *mqlAwsEc2Volume) GetSize() *plugin.TValue[int64] {
 
 func (c *mqlAwsEc2Volume) GetIops() *plugin.TValue[int64] {
 	return &c.Iops
+}
+
+func (c *mqlAwsEc2Volume) GetKmsKey() *plugin.TValue[*mqlAwsKmsKey] {
+	return plugin.GetOrCompute[*mqlAwsKmsKey](&c.KmsKey, func() (*mqlAwsKmsKey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2.volume", c.__id, "kmsKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsKmsKey), nil
+			}
+		}
+
+		return c.kmsKey()
+	})
 }
 
 // mqlAwsInspector for the aws.inspector resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -1529,6 +1529,8 @@ resources:
       encrypted:
         min_mondoo_version: 9.0.0
       id: {}
+      kmsKey:
+        min_mondoo_version: 9.0.0
       region: {}
       startTime: {}
       state: {}
@@ -1569,6 +1571,8 @@ resources:
       encrypted: {}
       id: {}
       iops:
+        min_mondoo_version: 9.0.0
+      kmsKey:
         min_mondoo_version: 9.0.0
       multiAttachEnabled:
         min_mondoo_version: 9.0.0
@@ -3239,6 +3243,8 @@ resources:
       iamDatabaseAuthentication:
         min_mondoo_version: latest
       id: {}
+      kmsKey:
+        min_mondoo_version: 9.0.0
       latestRestorableTime:
         min_mondoo_version: 9.0.0
       masterUsername:
@@ -3324,6 +3330,8 @@ resources:
       iamDatabaseAuthentication:
         min_mondoo_version: latest
       id: {}
+      kmsKey:
+        min_mondoo_version: 9.0.0
       latestRestorableTime:
         min_mondoo_version: 9.0.0
       masterUsername:
@@ -3426,6 +3434,8 @@ resources:
         min_mondoo_version: 9.0.0
       id: {}
       isClusterSnapshot: {}
+      kmsKey:
+        min_mondoo_version: 9.0.0
       port:
         min_mondoo_version: 9.0.0
       region: {}


### PR DESCRIPTION
Directly expose the keys

```
> aws.rds.dbinstance.kmsKey
aws.rds.dbinstance.kmsKey: aws.kms.key id="12345678910" region="us-east-1" aliases=[
  0: "alias/aws/rds"
] metadata.Description="Default key that protects my RDS database volumes when no other key is defined"
>
```