### PR TITLE
⭐ Add github.milestone + more PR fields

### DIFF
--- a/providers/github/resources/github.lr
+++ b/providers/github/resources/github.lr
@@ -394,6 +394,8 @@ github.repository @defaults("fullName") {
   openIssues() []github.issue
   // List of repository closed issues
   closedIssues() []github.issue
+  // List of repository milestones
+  milestones() []github.milestone
   // Repository license
   license() github.license
   // Repository code of conduct
@@ -594,6 +596,10 @@ private github.mergeRequest @defaults("id state") {
   reviews() []github.review
   // Pull request repository name
   repoName string
+  // Pull request milestone
+  milestone github.milestone
+  // Time when the pull request was merged
+  mergedAt time
 }
 
 // GitHub repository review
@@ -658,6 +664,38 @@ private github.gistfile @defaults("filename") {
   content() string
 }
 
+// GitHub milestone
+private github.milestone @defaults("title state") {
+  // Milestone ID
+  id int
+  // Milestone number
+  number int
+  // Milestone title
+  title string
+  // Milestone description
+  description string
+  // Milestone state (open or closed)
+  state string
+  // Milestone URL
+  url string
+  // Milestone web URL
+  htmlUrl string
+  // Milestone creator
+  creator github.user
+  // Number of open issues in this milestone
+  openIssues int
+  // Number of closed issues in this milestone
+  closedIssues int
+  // Milestone creation time
+  createdAt time
+  // Milestone update time
+  updatedAt time
+  // Milestone closed time
+  closedAt time
+  // Milestone due date
+  dueOn time
+}
+
 // GitHub issue
 private github.issue @defaults("title") {
   // Issue ID
@@ -686,6 +724,8 @@ private github.issue @defaults("title") {
   draft bool
   // Whether the issue is locked
   locked bool
+  // Issue milestone
+  milestone github.milestone
 }
 
 // GitHub Dependabot alert

--- a/providers/github/resources/github.lr.manifest.yaml
+++ b/providers/github/resources/github.lr.manifest.yaml
@@ -191,6 +191,7 @@ resources:
       draft: {}
       id: {}
       locked: {}
+      milestone: {}
       number: {}
       state: {}
       title: {}
@@ -213,6 +214,10 @@ resources:
       createdAt: {}
       id: {}
       labels: {}
+      mergedAt:
+        min_mondoo_version: 9.0.0
+      milestone:
+        min_mondoo_version: 9.0.0
       number: {}
       owner: {}
       repoName: {}
@@ -221,6 +226,24 @@ resources:
       title: {}
     is_private: true
     min_mondoo_version: 6.4.0
+  github.milestone:
+    fields:
+      closedAt: {}
+      closedIssues: {}
+      createdAt: {}
+      creator: {}
+      description: {}
+      dueOn: {}
+      htmlUrl: {}
+      id: {}
+      number: {}
+      openIssues: {}
+      state: {}
+      title: {}
+      updatedAt: {}
+      url: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
   github.organization:
     fields:
       advancedSecurityEnabledForNewRepos:
@@ -450,6 +473,8 @@ resources:
         min_mondoo_version: 7.14.0
       license:
         min_mondoo_version: 7.14.0
+      milestones:
+        min_mondoo_version: 9.0.0
       name: {}
       openIssues:
         min_mondoo_version: 7.14.0


### PR DESCRIPTION
Understand when a PR was merged + what milestone it was part of

```coffee
> github.repository.milestones
github.repository.milestones: [
  0: github.milestone title="Release" state="open"
]
```

```coffee
> github.repository.milestones.first{*}
github.repository.milestones.first: {
  state: "open"
  openIssues: 1
  number: 1
  title: "Release"
  htmlUrl: "https://github.com/mondoohq/example/milestone/1"
  description: ""
  id: 123456789
  creator: github.user login="foo" name="Foo Bar" email="foo@example.com" company="Mondoo"
  closedIssues: 3
  createdAt: 2025-06-13 02:04:53 -0700 PDT
  url: "https://api.github.com/repos/mondoohq/example/milestones/1"
  dueOn: null
  closedAt: null
  updatedAt: 2025-10-28 07:18:58 -0700 PDT
}
```

```coffee
> github.repository.closedMergeRequests.first.mergedAt
github.repository.closedMergeRequests.first.mergedAt: 2026-01-20 04:27:29 -0800 PST
```