### PR TITLE
✨ gate auto-updates behind feature-flag in v13

### DIFF
--- a/apps/cnquery/cnquery.go
+++ b/apps/cnquery/cnquery.go
@@ -98,6 +98,11 @@ func shouldTrySelfUpdate() bool {
 	// Initialize viper to read config files (same as detectConnectorName in cli/providers)
 	config.InitViperConfig()
 
+	// Check if the AutoUpdateEngine feature flag is enabled
+	if !config.GetFeatures().IsActive(cnquery.AutoUpdateEngine) {
+		return false
+	}
+
 	// Get auto_update setting from config (defaults to true if not set)
 	autoUpdate := config.GetAutoUpdate()
 

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -197,6 +197,13 @@ func GetAutoUpdate() bool {
 	return true
 }
 
+// GetFeatures returns the features from viper config.
+// This can be called after InitViperConfig() to get features before cobra initialization.
+func GetFeatures() cnquery.Features {
+	features, _ := cnquery.InitFeatures(viper.GetStringSlice("features")...)
+	return features
+}
+
 func Read() (*Config, error) {
 	// load viper config into a struct
 	var opts Config

--- a/feature_string.go
+++ b/feature_string.go
@@ -21,11 +21,12 @@ func _() {
 	_ = x[ResourceContext-11]
 	_ = x[FailIfNoEntryPoints-12]
 	_ = x[UploadResultsV2-13]
+	_ = x[AutoUpdateEngine-14]
 }
 
-const _Feature_name = "MassQueriesPiperCodeBoolAssertionsK8sNodeDiscoveryMQLAssetContextErrorsAsFailuresStoreResourcesDataFineGrainedAssetsSerialNumberAsIDForceShellCompletionResourceContextFailIfNoEntryPointsUploadResultsV2"
+const _Feature_name = "MassQueriesPiperCodeBoolAssertionsK8sNodeDiscoveryMQLAssetContextErrorsAsFailuresStoreResourcesDataFineGrainedAssetsSerialNumberAsIDForceShellCompletionResourceContextFailIfNoEntryPointsUploadResultsV2AutoUpdateEngine"
 
-var _Feature_index = [...]uint8{0, 11, 20, 34, 50, 65, 81, 99, 116, 132, 152, 167, 186, 201}
+var _Feature_index = [...]uint8{0, 11, 20, 34, 50, 65, 81, 99, 116, 132, 152, 167, 186, 201, 217}
 
 func (i Feature) String() string {
 	idx := int(i) - 1

--- a/features.go
+++ b/features.go
@@ -77,9 +77,14 @@ const (
 	// status: new
 	UploadResultsV2 Feature = 13
 
+	// Auto-update the execution engine
+	// start:  v13.x
+	// status: new
+	AutoUpdateEngine Feature = 14
+
 	// Placeholder to indicate how many feature flags exist. This number
 	// is changing with every new feature and cannot be used as a featureflag itself.
-	MAX_FEATURES byte = 14
+	MAX_FEATURES byte = 15
 )
 
 var FeaturesValue = map[string]Feature{
@@ -96,6 +101,7 @@ var FeaturesValue = map[string]Feature{
 	"ResourceContext":      ResourceContext,
 	"FailIfNoEntryPoints":  FailIfNoEntryPoints,
 	"UploadResultsV2":      UploadResultsV2,
+	"AutoUpdateEngine":     AutoUpdateEngine,
 }
 
 // DefaultFeatures are a set of default flags that are active
@@ -110,4 +116,5 @@ var DefaultFeatures = Features{
 var AvailableFeatures = Features{
 	byte(MQLAssetContext),
 	byte(UploadResultsV2),
+	byte(AutoUpdateEngine),
 }

--- a/features.yaml
+++ b/features.yaml
@@ -78,3 +78,8 @@ Features:
   idx: 13
   start: v12.x
   status: new
+- id: AutoUpdateEngine
+  desc: Auto-update the execution engine
+  idx: 14
+  start: v13.x
+  status: new


### PR DESCRIPTION
This is done as a safety measure, since auto-update has far-reaching consequences (more than auto-updating providers)

after https://github.com/mondoohq/cnquery/pull/6513 (that's where we need to tackle the failing go-bench test)