### PR TITLE
⭐ V13: Improve recordings, allow looking up resources by asset mrn, platform ids or connection id.

### DIFF
--- a/llx/runtime.go
+++ b/llx/runtime.go
@@ -23,6 +23,14 @@ type Runtime interface {
 	AssetUpdated(asset *inventory.Asset)
 }
 
+// Allows looking up data for assets, based on different asset identifiers.
+// If set, Mrn is preferred, followed by PlatformIds, and lastly ConnectionId.
+type AssetRecordingLookup struct {
+	ConnectionId uint32
+	Mrn          string
+	PlatformIds  []string
+}
+
 type AddDataReq struct {
 	// the id of the connection that was used to fetch the data
 	ConnectionID uint32
@@ -42,7 +50,7 @@ type Recording interface {
 	Save() error
 	EnsureAsset(asset *inventory.Asset, provider string, connectionID uint32, conf *inventory.Config)
 	AddData(req AddDataReq)
-	GetData(connectionID uint32, resource string, resourceId string, field string) (*RawData, bool)
-	GetResource(connectionID uint32, resource string, resourceId string) (map[string]*RawData, bool)
+	GetData(lookup AssetRecordingLookup, resource string, resourceId string, field string) (*RawData, bool)
+	GetResource(lookup AssetRecordingLookup, resource string, resourceId string) (map[string]*RawData, bool)
 	GetAssetData(assetMrn string) (map[string]*ResourceRecording, bool)
 }

--- a/providers-sdk/v1/recording/asset_recording.go
+++ b/providers-sdk/v1/recording/asset_recording.go
@@ -4,6 +4,7 @@
 package recording
 
 import (
+	"fmt"
 	"sort"
 
 	"go.mondoo.com/cnquery/v12/llx"
@@ -82,6 +83,6 @@ func (asset *Asset) RefreshCache() {
 	}
 
 	for _, conn := range asset.Connections {
-		asset.connections[conn.Url] = &conn
+		asset.connections[fmt.Sprintf("%d", conn.Id)] = &conn
 	}
 }

--- a/providers-sdk/v1/recording/null_recording.go
+++ b/providers-sdk/v1/recording/null_recording.go
@@ -22,11 +22,11 @@ func (n Null) EnsureAsset(asset *inventory.Asset, provider string, connectionID 
 func (n Null) AddData(req llx.AddDataReq) {
 }
 
-func (n Null) GetData(connectionID uint32, resource string, id string, field string) (*llx.RawData, bool) {
+func (n Null) GetData(lookup llx.AssetRecordingLookup, resource string, id string, field string) (*llx.RawData, bool) {
 	return nil, false
 }
 
-func (n Null) GetResource(connectionID uint32, resource string, id string) (map[string]*llx.RawData, bool) {
+func (n Null) GetResource(lookup llx.AssetRecordingLookup, resource string, id string) (map[string]*llx.RawData, bool) {
 	return nil, false
 }
 

--- a/providers-sdk/v1/recording/readonly_recording.go
+++ b/providers-sdk/v1/recording/readonly_recording.go
@@ -1,0 +1,32 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package recording
+
+import (
+	"go.mondoo.com/cnquery/v12/llx"
+	"go.mondoo.com/cnquery/v12/providers-sdk/v1/inventory"
+)
+
+type readOnly struct {
+	*recording
+}
+
+func (n *readOnly) Save() error {
+	return nil
+}
+
+func (n *readOnly) EnsureAsset(asset *inventory.Asset, provider string, connectionID uint32, conf *inventory.Config) {
+	// For read-only recordings we are still loading from file, so that means
+	// we are severely lacking connection IDs.
+	lookup := llx.AssetRecordingLookup{
+		Mrn:         asset.Mrn,
+		PlatformIds: asset.PlatformIds,
+	}
+	if existing, ok := n.resolveAsset(lookup); ok {
+		n.assets.Set(connIdKey(connectionID), existing)
+	}
+}
+
+func (n *readOnly) AddData(req llx.AddDataReq) {
+}

--- a/providers-sdk/v1/recording/upstream_recording.go
+++ b/providers-sdk/v1/recording/upstream_recording.go
@@ -32,7 +32,7 @@ func NewUpstreamRecording(ctx context.Context, service resources.ResourcesExplor
 		resourcesCache: map[string]resourceCache{},
 	}
 
-	raw, ok := recording.GetResource(0, "asset", "")
+	raw, ok := recording.GetResource(llx.AssetRecordingLookup{Mrn: assetMrn}, "asset", "")
 	if !ok {
 		return nil, errors.New("failed to get asset info for " + assetMrn)
 	}
@@ -97,8 +97,8 @@ func (n *Upstream) AddData(req llx.AddDataReq) {
 	// future. (e.g. for shell)
 }
 
-func (n *Upstream) GetData(connectionID uint32, resource string, id string, field string) (*llx.RawData, bool) {
-	fields, ok := n.GetResource(connectionID, resource, id)
+func (n *Upstream) GetData(lookup llx.AssetRecordingLookup, resource string, id string, field string) (*llx.RawData, bool) {
+	fields, ok := n.GetResource(lookup, resource, id)
 	if !ok || len(fields) == 0 {
 		return nil, false
 	}
@@ -106,7 +106,7 @@ func (n *Upstream) GetData(connectionID uint32, resource string, id string, fiel
 	return res, ok
 }
 
-func (n *Upstream) GetResource(_ uint32, resource string, id string) (map[string]*llx.RawData, bool) {
+func (n *Upstream) GetResource(_ llx.AssetRecordingLookup, resource string, id string) (map[string]*llx.RawData, bool) {
 	n.lock.Lock()
 	defer n.lock.Unlock()
 

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -339,7 +339,7 @@ func (r *Runtime) CreateResource(name string, args map[string]*llx.Primitive) (l
 		return nil, err
 	}
 
-	if _, ok := r.Recording().GetResource(provider.Connection.Id, name, string(res.Data.Value)); !ok {
+	if _, ok := r.Recording().GetResource(llx.AssetRecordingLookup{ConnectionId: provider.Connection.Id}, name, string(res.Data.Value)); !ok {
 		addDataReq := llx.AddDataReq{
 			ConnectionID:      provider.Connection.Id,
 			Resource:          name,
@@ -441,7 +441,7 @@ func (r *Runtime) watchAndUpdate(resource string, resourceID string, field strin
 		}
 	}
 
-	if cached, ok := r.Recording().GetData(provider.Connection.Id, resource, resourceID, field); ok {
+	if cached, ok := r.Recording().GetData(llx.AssetRecordingLookup{ConnectionId: provider.Connection.Id}, resource, resourceID, field); ok {
 		return cached, nil
 	}
 


### PR DESCRIPTION
While technically not breaking since we do not change the recording format, we only change the lookup code, I think this is a good thing to consider v13.

This improves recordings asset lookup and mimics providers lookup: We now support either an asset mrn, any of the platform ids or the asset's connection id too. There are use cases where we cannot easily do the connection lookup which was in place until now, but we already have asset mrn or platform ids.

Other improvements:
 * Move read-only impl to its own file.
 * Cleanup `recording.go`. `GetData` and `GetResource` use the same code path underneath. `GetData` only checks the fields too since it supports field fetching.
 * Consistent tests for looking up things by mrn/platform ids/connection id.
 
 