### PR TITLE
S3 staticWebsiteHosting now includes RedirectAllRequestsTo and RoutingRules

### DIFF
--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -711,6 +711,17 @@ func (a *mqlAwsS3Bucket) staticWebsiteHosting() (map[string]any, error) {
 		if website.IndexDocument != nil {
 			res["IndexDocument"] = convert.ToValue(website.IndexDocument.Suffix)
 		}
+
+		if website.RedirectAllRequestsTo != nil {
+			res["RedirectAllRequestsTo.HostName"] = convert.ToValue(website.RedirectAllRequestsTo.HostName)
+			if website.RedirectAllRequestsTo.Protocol != "" {
+				res["RedirectAllRequestsTo.Protocol"] = string(website.RedirectAllRequestsTo.Protocol)
+			}
+		}
+
+		if len(website.RoutingRules) > 0 {
+			res["RoutingRules"] = "configured"
+		}
 	}
 
 	return res, nil


### PR DESCRIPTION
Fixes #6505

The staticWebsiteHosting field was returning an empty map when an S3 bucket was configured with only RedirectAllRequestsTo (redirect requests for an object) without IndexDocument/ErrorDocument. This made it impossible to detect that static website hosting was enabled on such buckets.

Now includes:
- RedirectAllRequestsTo.HostName and RedirectAllRequestsTo.Protocol
- RoutingRules indicator when routing rules are configured