### PR TITLE
✨ support gke auth in k8s provider

### DIFF
--- a/providers/k8s/connection/api/connection.go
+++ b/providers/k8s/connection/api/connection.go
@@ -72,6 +72,11 @@ func NewConnection(id uint32, asset *inventory.Asset, discoveryCache *resources.
 		return nil, err
 	}
 
+	err = attemptGKEAuthFlow(config)
+	if err != nil {
+		return nil, err
+	}
+
 	// enable-client side throttling
 	// avoids the cli warning: Waited for 1.000907542s due to client-side throttling, not priority and fairness
 	config.QPS = 1000

--- a/providers/k8s/connection/api/gke_auth.go
+++ b/providers/k8s/connection/api/gke_auth.go
@@ -1,0 +1,58 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"context"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/oauth2/google"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	// GCP scope required for GKE cluster access
+	gcpCloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+)
+
+// attemptGKEAuthFlow detects GKE clusters and obtains a bearer token using GCP credentials.
+// This bypasses the need for gke-gcloud-auth-plugin to be installed.
+func attemptGKEAuthFlow(config *rest.Config) error {
+	// Auto-detect GKE by checking if the ExecProvider references gke-gcloud-auth-plugin
+	if config.ExecProvider == nil {
+		return nil
+	}
+	if !strings.Contains(config.ExecProvider.Command, "gke-gcloud-auth-plugin") {
+		return nil
+	}
+
+	log.Debug().Msg("detected GKE cluster, attempting to get bearer token using GCP credentials")
+
+	// Get GCP credentials using the default chain:
+	// 1. GOOGLE_APPLICATION_CREDENTIALS env var
+	// 2. gcloud CLI credentials (~/.config/gcloud/application_default_credentials.json)
+	// 3. GCE metadata service (when running on GCP)
+	ctx := context.Background()
+	creds, err := google.FindDefaultCredentials(ctx, gcpCloudPlatformScope)
+	if err != nil {
+		return errors.Wrap(err, "failed to get GCP credentials for GKE authentication")
+	}
+
+	token, err := creds.TokenSource.Token()
+	if err != nil {
+		return errors.Wrap(err, "failed to get access token for GKE authentication")
+	}
+
+	config.BearerToken = token.AccessToken
+
+	// Clear the exec provider since we've obtained the token directly,
+	// bypassing the need for gke-gcloud-auth-plugin
+	config.ExecProvider = nil
+
+	log.Debug().Msg("successfully obtained GKE bearer token using GCP credentials")
+
+	return nil
+}

--- a/providers/k8s/go.mod
+++ b/providers/k8s/go.mod
@@ -23,6 +23,7 @@ require (
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
+	golang.org/x/oauth2 v0.34.0
 )
 
 require (
@@ -288,7 +289,6 @@ require (
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
-	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/term v0.39.0 // indirect


### PR DESCRIPTION
This will allow us to use credentials that rely on the `gke-gcloud-auth-plugin`. It is useful for WIF, for example