### PR TITLE
🐛 Fix panic in types.Type.Underlying() with empty type

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -156,6 +156,9 @@ func Array(typ Type) Type {
 
 // IsArray checks if this type is an array
 func (typ Type) IsArray() bool {
+	if typ.NotSet() {
+		return false
+	}
 	return typ[0] == byteArray
 }
 
@@ -169,6 +172,9 @@ func Map(key, value Type) Type {
 
 // IsMap checks if this type is a map
 func (typ Type) IsMap() bool {
+	if typ.NotSet() {
+		return false
+	}
 	return typ[0] == byteMap
 }
 
@@ -209,13 +215,19 @@ func Function(required rune, args []Type) Type {
 	return FunctionLike + Type(required) + Type(sig)
 }
 
-// IsFunction checks if this type is a map
+// IsFunction checks if this type is a function
 func (typ Type) IsFunction() bool {
+	if typ.NotSet() {
+		return false
+	}
 	return typ[0] == byteFunction
 }
 
 // Underlying returns the basic type, e.g. types.MapLike instead of types.Map(..)
 func (typ Type) Underlying() Type {
+	if typ.NotSet() {
+		return NoType
+	}
 	return Type(typ[0])
 }
 
@@ -244,6 +256,9 @@ func Enforce(left, right Type) (Type, bool) {
 
 // Child returns the child type of arrays and maps
 func (typ Type) Child() Type {
+	if typ.NotSet() {
+		return NoType
+	}
 	switch typ[0] {
 	case byteDict:
 		return Dict
@@ -257,7 +272,7 @@ func (typ Type) Child() Type {
 
 // Key returns the key type of a map
 func (typ Type) Key() Type {
-	if typ[0] != byteMap {
+	if typ.NotSet() || typ[0] != byteMap {
 		panic("cannot retrieve key type of non-map type " + typ.Label())
 	}
 	return Type(typ[1])
@@ -266,6 +281,9 @@ func (typ Type) Key() Type {
 // ResourceName return the name of a resource. Has to be a resource type,
 // otherwise this call panics.
 func (typ Type) ResourceName() string {
+	if typ.NotSet() {
+		panic("cannot determine type name of empty type")
+	}
 	if typ[0] == byteResource {
 		return string(typ[1:])
 	}

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTypes(t *testing.T) {
@@ -42,4 +43,60 @@ func TestTypes(t *testing.T) {
 		// test for human friendly name
 		assert.Equal(t, test.ExpectedLabel, test.T.Label())
 	}
+}
+
+func TestEmptyType(t *testing.T) {
+	empty := Type("")
+
+	t.Run("NotSet returns true for empty type", func(t *testing.T) {
+		assert.True(t, empty.NotSet())
+	})
+
+	t.Run("Underlying returns NoType for empty type", func(t *testing.T) {
+		// This should not panic
+		result := empty.Underlying()
+		assert.Equal(t, NoType, result)
+	})
+
+	t.Run("IsArray returns false for empty type", func(t *testing.T) {
+		// This should not panic
+		assert.False(t, empty.IsArray())
+	})
+
+	t.Run("IsMap returns false for empty type", func(t *testing.T) {
+		// This should not panic
+		assert.False(t, empty.IsMap())
+	})
+
+	t.Run("IsFunction returns false for empty type", func(t *testing.T) {
+		// This should not panic
+		assert.False(t, empty.IsFunction())
+	})
+
+	t.Run("IsResource returns false for empty type", func(t *testing.T) {
+		// This should not panic
+		assert.False(t, empty.IsResource())
+	})
+
+	t.Run("Child returns NoType for empty type", func(t *testing.T) {
+		// This should not panic
+		result := empty.Child()
+		assert.Equal(t, NoType, result)
+	})
+
+	t.Run("Label returns EMPTY for empty type", func(t *testing.T) {
+		assert.Equal(t, "EMPTY", empty.Label())
+	})
+
+	t.Run("Key panics for empty type", func(t *testing.T) {
+		require.Panics(t, func() {
+			empty.Key()
+		})
+	})
+
+	t.Run("ResourceName panics for empty type", func(t *testing.T) {
+		require.Panics(t, func() {
+			empty.ResourceName()
+		})
+	})
 }


### PR DESCRIPTION
## Summary

- Adds bounds checking to `Type` methods that access `typ[0]` directly
- Prevents panic when processing arrays with empty/malformed child types
- Adds comprehensive tests for empty type handling

## Test plan

- [x] Added `TestEmptyType` with subtests covering all edge cases
- [x] Existing `types` tests pass
- [x] `llx` and `mqlc` tests pass

## Root Cause

The panic occurs in `types.Type.Underlying()` when:
1. A resource returns an array with a malformed type (just the array marker byte `\x19` without child type info)
2. `array2result()` calls `typ.Child()` which returns `typ[1:]` → empty string `""`
3. For each array element, `raw2primitive(element, "")` is called with empty type
4. `raw2primitive` calls `typ.Underlying()` on the empty type
5. `Underlying()` tries to access `typ[0]` on empty string → **panic**

## Methods Fixed

| Method | Fix |
|--------|-----|
| `Underlying()` | Returns `NoType` instead of panicking |
| `IsArray()` | Returns `false` instead of panicking |
| `IsMap()` | Returns `false` instead of panicking |
| `IsFunction()` | Returns `false` instead of panicking |
| `Child()` | Returns `NoType` instead of panicking |
| `Key()` | Added `NotSet()` check before accessing `typ[0]` |
| `ResourceName()` | Added empty type check with clear message |

Fixes #6537