### PR TITLE
✨ allow users to specify an updates_url

### DIFF
--- a/apps/cnquery/cmd/login.go
+++ b/apps/cnquery/cmd/login.go
@@ -36,7 +36,9 @@ func init() {
 	rootCmd.AddCommand(LoginCmd)
 	LoginCmd.Flags().StringP("token", "t", "", "Set a client registration token")
 	LoginCmd.Flags().StringToString("annotation", nil, "Set the client annotations")
-	LoginCmd.Flags().String("providers-url", "", "Set the providers URL")
+	LoginCmd.Flags().String("updates-url", "", "Set the updates URL for cnquery and provider updates")
+	LoginCmd.Flags().String("providers-url", "", "Set the providers URL (deprecated: use updates-url instead)")
+	_ = LoginCmd.Flags().MarkHidden("providers-url")
 	LoginCmd.Flags().String("name", "", "Set asset name")
 	LoginCmd.Flags().String("api-endpoint", "", "Set the Mondoo API endpoint")
 	LoginCmd.Flags().Int("timer", 0, "Set the scan interval in minutes")
@@ -65,11 +67,12 @@ You remain logged in until you explicitly log out using the 'logout' subcommand.
 		defer cnquery_providers.Coordinator.Shutdown()
 		token, _ := cmd.Flags().GetString("token")
 		annotations, _ := cmd.Flags().GetStringToString("annotation")
+		updatesURL, _ := cmd.Flags().GetString("updates-url")
 		providersURL, _ := cmd.Flags().GetString("providers-url")
 		timer, _ := cmd.Flags().GetInt("timer")
 		splay, _ := cmd.Flags().GetInt("splay")
 		apiEndpointOverride, _ := cmd.Flags().GetString("api-endpoint")
-		err := register(token, annotations, providersURL, timer, splay, apiEndpointOverride)
+		err := register(token, annotations, updatesURL, providersURL, timer, splay, apiEndpointOverride)
 		if err != nil {
 			if err == tokenValidationErr {
 				log.Error().Msg(err.Error())
@@ -112,7 +115,7 @@ You remain logged in until you explicitly log out using the 'logout' subcommand.
 	},
 }
 
-func register(token string, annotations map[string]string, providersURL string, timer int, splay int, apiEndpointOverride string) error {
+func register(token string, annotations map[string]string, updatesURL string, providersURL string, timer int, splay int, apiEndpointOverride string) error {
 	var err error
 	var credential *upstream.ServiceAccountCredentials
 
@@ -210,7 +213,11 @@ func register(token string, annotations map[string]string, providersURL string, 
 		viper.Set("private_key", confirmation.Credential.PrivateKey)
 		viper.Set("certificate", confirmation.Credential.Certificate)
 		viper.Set("annotations", annotations)
+		if updatesURL != "" {
+			viper.Set("updates_url", updatesURL)
+		}
 		if providersURL != "" {
+			log.Warn().Msgf("providers-url is deprecated, please use updates-url: %s", strings.TrimSuffix(providersURL, "/providers"))
 			viper.Set("providers_url", providersURL)
 		}
 		if timer > 0 {

--- a/apps/cnquery/cmd/root.go
+++ b/apps/cnquery/cmd/root.go
@@ -104,6 +104,7 @@ func init() {
 	viper.BindPFlag("api_proxy", rootCmd.PersistentFlags().Lookup("api-proxy"))
 	viper.BindPFlag("auto_update", rootCmd.PersistentFlags().Lookup("auto-update"))
 	_ = viper.BindEnv("features")
+	_ = viper.BindEnv("updates_url")
 	_ = viper.BindEnv("providers_url")
 
 	config.Init(rootCmd)

--- a/apps/cnquery/cnquery.go
+++ b/apps/cnquery/cnquery.go
@@ -23,10 +23,14 @@ func main() {
 
 	// Check for self-update before anything else
 	if shouldTrySelfUpdate() {
+		releaseURL := selfupdate.DefaultReleaseURL
+		if updatesURL := config.GetUpdatesURL(); updatesURL != "" {
+			releaseURL = updatesURL + "/cnquery/latest.json"
+		}
 		cfg := selfupdate.Config{
 			Enabled:         true,
 			RefreshInterval: selfupdate.DefaultRefreshInterval,
-			ReleaseURL:      selfupdate.DefaultReleaseURL,
+			ReleaseURL:      releaseURL,
 		}
 		if updated, err := selfupdate.CheckAndUpdate(cfg); err != nil {
 			// Log warning but don't block - only show in debug mode

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -197,6 +197,18 @@ func GetAutoUpdate() bool {
 	return true
 }
 
+// GetUpdatesURL returns the updates_url setting from viper config.
+// Returns empty string if not set (caller should use default).
+func GetUpdatesURL() string {
+	return viper.GetString("updates_url")
+}
+
+// GetProvidersURL returns the providers_url setting from viper config.
+// Returns empty string if not set (caller should use default).
+func GetProvidersURL() string {
+	return viper.GetString("providers_url")
+}
+
 // GetFeatures returns the features from viper config.
 // This can be called after InitViperConfig() to get features before cobra initialization.
 func GetFeatures() cnquery.Features {
@@ -258,9 +270,16 @@ type CommonOpts struct {
 	// annotations that will be applied to all assets
 	Annotations map[string]string `json:"annotations,omitempty" mapstructure:"annotations"`
 
+	// UpdatesURL is the base URL where updates are fetched from
+	// if not set, the default Mondoo releases URL is used (https://releases.mondoo.com)
+	// This can be a custom URL for an internal release registry
+	// If ProvidersURL is not set, providers will be fetched from UpdatesURL + "/providers"
+	UpdatesURL string `json:"updates_url,omitempty" mapstructure:"updates_url"`
+
 	// ProvidersURL is the URL where providers are downloaded from
 	// if not set, the default Mondoo provider URL is used
 	// This can be a custom URL for an internal provider registry
+	// Deprecated: use UpdatesURL instead
 	ProvidersURL string `json:"providers_url,omitempty" mapstructure:"providers_url"`
 }
 

--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -60,9 +60,19 @@ func detectConnectorName(args []string, rootCmd *cobra.Command, commands []*Comm
 
 	config.InitViperConfig()
 
+	// Determine the providers URL:
+	// 1. If providers_url is explicitly set, use it (deprecated)
+	// 2. Otherwise, if updates_url is set, use updates_url + "/providers"
+	// 3. Otherwise, use the default
 	if viper.IsSet("providers_url") {
 		if providersURL := viper.GetString("providers_url"); providersURL != "" {
+			updatesURL := strings.TrimSuffix(providersURL, "/providers")
+			log.Warn().Msgf("providers_url is deprecated, please use updates_url: %s", updatesURL)
 			providers.SetProviderRegistry(providers.NewMondooProviderRegistry(providers.WithBaseURL(providersURL)))
+		}
+	} else if viper.IsSet("updates_url") {
+		if updatesURL := viper.GetString("updates_url"); updatesURL != "" {
+			providers.SetProviderRegistry(providers.NewMondooProviderRegistry(providers.WithBaseURL(updatesURL + "/providers")))
 		}
 	}
 

--- a/providers/registry.go
+++ b/providers/registry.go
@@ -15,7 +15,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-var DefaultProviderRegistryURL = "https://releases.mondoo.com/providers"
+var DefaultUpdatesURL = "https://releases.mondoo.com"
+var DefaultProviderRegistryURL = DefaultUpdatesURL + "/providers"
 
 var registry ProviderRegistry = NewMondooProviderRegistry()
 


### PR DESCRIPTION
This is used for both provider updates and updating the core engine. Long-term we are looking to sunset the providers_url in favor of just having the updates_url.