### PR TITLE
:star: Add new fields / resources to api gateway / autoscaling

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1469,6 +1469,18 @@ private aws.autoscaling.group @defaults("name region minSize maxSize") {
   defaultInstanceWarmup int
   // EC2 instances associated with the group
   instances() []aws.ec2.instance
+  // Unit of measurement for desired capacity (attribute-based instance type selection)
+  desiredCapacityType string
+  // Current size of the warm pool
+  warmPoolSize int
+  // Predicted capacity from predictive scaling
+  predictedCapacity int
+  // Name of the placement group for launched instances
+  placementGroup string
+  // Whether newly launched instances are protected from scale-in termination
+  newInstancesProtectedFromScaleIn bool
+  // Target groups associated with the group
+  targetGroups() []aws.elb.targetgroup
 }
 
 // AWS Auto Scaling group tag
@@ -2595,6 +2607,10 @@ private aws.applicationAutoscaling.target @defaults("arn") {
   namespace string
   // ARN of the auto scaling target
   arn string
+  // Resource identifier for the target
+  resourceId string
+  // Region where the target exists
+  region string
   // Scalable dimension for the target
   scalableDimension string
   // Minimum capacity set for the auto scaling target
@@ -2605,6 +2621,62 @@ private aws.applicationAutoscaling.target @defaults("arn") {
   suspendedState dict
   // Creation date for the auto scaling target
   createdAt time
+  // Scaling policies attached to this target
+  policies() []aws.applicationAutoscaling.policy
+  // Scheduled scaling actions for this target
+  scheduledActions() []aws.applicationAutoscaling.scheduledAction
+}
+
+// AWS Application Auto Scaling policy
+private aws.applicationAutoscaling.policy @defaults("arn name policyType") {
+  // ARN of the scaling policy
+  arn string
+  // Name of the scaling policy
+  name string
+  // Type of scaling policy: TargetTrackingScaling, StepScaling, or PredictiveScaling
+  policyType string
+  // Resource identifier associated with the policy
+  resourceId string
+  // Scalable dimension associated with the policy
+  scalableDimension string
+  // Service namespace
+  namespace string
+  // Date the policy was created
+  createdAt time
+  // CloudWatch alarms associated with the policy
+  alarms []dict
+  // Target tracking scaling policy configuration
+  targetTrackingConfig dict
+  // Step scaling policy configuration
+  stepScalingConfig dict
+  // Predictive scaling policy configuration
+  predictiveScalingConfig dict
+}
+
+// AWS Application Auto Scaling scheduled action
+private aws.applicationAutoscaling.scheduledAction @defaults("arn name schedule") {
+  // ARN of the scheduled action
+  arn string
+  // Name of the scheduled action
+  name string
+  // Schedule expression (cron, rate, or at)
+  schedule string
+  // Timezone for the schedule
+  timezone string
+  // Resource identifier associated with the action
+  resourceId string
+  // Scalable dimension associated with the action
+  scalableDimension string
+  // Service namespace
+  namespace string
+  // Date the scheduled action was created
+  createdAt time
+  // Date the action is scheduled to start
+  startAt time
+  // Date the action is scheduled to end
+  endAt time
+  // Min and max capacity to set when the action runs
+  scalableTargetAction dict
 }
 
 // AWS Elastic Disaster Recovery (DRS)
@@ -3488,6 +3560,20 @@ private aws.apigateway.restapi @defaults("name id") {
   region string
   // Tags for the REST API
   tags map[string]string
+  // Source of the API key for metering requests (HEADER or AUTHORIZER)
+  apiKeySource string
+  // Whether the default execute-api endpoint is disabled
+  disableExecuteApiEndpoint bool
+  // Minimum payload size in bytes for compression (0 to enable for all, -1 if disabled)
+  minimumCompressionSize int
+  // Supported binary media types
+  binaryMediaTypes []string
+  // Version identifier for the API
+  version string
+  // TLS version and cipher suite for the API (TLS_1_0 or TLS_1_2)
+  securityPolicy string
+  // Resource policy for the API (JSON string)
+  policy string
 }
 
 // Amazon API Gateway REST API stages
@@ -3504,6 +3590,26 @@ private aws.apigateway.stage @defaults("arn") {
   deploymentId string
   // Method settings for the stage
   methodSettings dict
+  // Whether a cache cluster is enabled for the stage
+  cacheClusterEnabled bool
+  // Size of the cache cluster (0.5, 1.6, 6.1, 13.5, 28.4, 58.2, 118, 237)
+  cacheClusterSize string
+  // Status of the cache cluster
+  cacheClusterStatus string
+  // Client certificate ID for mutual TLS with backend
+  clientCertificateId string
+  // ARN of the WAF web ACL associated with the stage
+  webAclArn string
+  // Time when the stage was created
+  createdAt time
+  // Time when the stage was last updated
+  lastUpdatedAt time
+  // Documentation version associated with the stage
+  documentationVersion string
+  // Stage variables
+  variables map[string]string
+  // Tags for the stage
+  tags map[string]string
 }
 
 // AWS Lambda

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -179,15 +179,31 @@ resources:
       desc: |
         The `aws.apigateway.restapi` resource provides fields representing an individual REST API configured within the AWS account. For usage, read the `aws.apigateway` resource documentation.
     fields:
+      apiKeySource:
+        min_mondoo_version: 9.0.0
       arn: {}
+      binaryMediaTypes:
+        min_mondoo_version: 9.0.0
+      createdAt:
+        min_mondoo_version: 9.0.0
       createdDate: {}
       description: {}
+      disableExecuteApiEndpoint:
+        min_mondoo_version: 9.0.0
       id: {}
+      minimumCompressionSize:
+        min_mondoo_version: 9.0.0
       name: {}
+      policy:
+        min_mondoo_version: 9.0.0
       region: {}
+      securityPolicy:
+        min_mondoo_version: 9.0.0
       stages: {}
       tags:
         min_mondoo_version: 5.16.0
+      version:
+        min_mondoo_version: 9.0.0
     is_private: true
     min_mondoo_version: 5.15.0
     platform:
@@ -199,11 +215,35 @@ resources:
         The `aws.apigateway.stage` resource provides fields representing an individual stage configured on a REST API. For usage, read the `aws.apigateway` resource documentation.
     fields:
       arn: {}
+      cacheClusterEnabled:
+        min_mondoo_version: 9.0.0
+      cacheClusterSize:
+        min_mondoo_version: 9.0.0
+      cacheClusterStatus:
+        min_mondoo_version: 9.0.0
+      clientCertificateId:
+        min_mondoo_version: 9.0.0
+      createdAt:
+        min_mondoo_version: 9.0.0
+      createdDate:
+        min_mondoo_version: 9.0.0
       deploymentId: {}
       description: {}
+      documentationVersion:
+        min_mondoo_version: 9.0.0
+      lastUpdatedAt:
+        min_mondoo_version: 9.0.0
+      lastUpdatedDate:
+        min_mondoo_version: 9.0.0
       methodSettings: {}
       name: {}
+      tags:
+        min_mondoo_version: 9.0.0
       tracingEnabled: {}
+      variables:
+        min_mondoo_version: 9.0.0
+      webAclArn:
+        min_mondoo_version: 9.0.0
     is_private: true
     min_mondoo_version: 5.15.0
     platform:
@@ -239,6 +279,42 @@ resources:
     platform:
       name:
       - aws
+  aws.applicationAutoscaling.policy:
+    fields:
+      alarms: {}
+      arn: {}
+      createdAt: {}
+      name: {}
+      namespace: {}
+      policyType: {}
+      predictiveScalingConfig: {}
+      resourceId: {}
+      scalableDimension: {}
+      stepScalingConfig: {}
+      targetTrackingConfig: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
+    platform:
+      name:
+      - aws
+  aws.applicationAutoscaling.scheduledAction:
+    fields:
+      arn: {}
+      createdAt: {}
+      endAt: {}
+      name: {}
+      namespace: {}
+      resourceId: {}
+      scalableDimension: {}
+      scalableTargetAction: {}
+      schedule: {}
+      startAt: {}
+      timezone: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
+    platform:
+      name:
+      - aws
   aws.applicationAutoscaling.target:
     fields:
       arn: {}
@@ -247,7 +323,15 @@ resources:
       maxCapacity: {}
       minCapacity: {}
       namespace: {}
+      policies:
+        min_mondoo_version: 9.0.0
+      region:
+        min_mondoo_version: 9.0.0
+      resourceId:
+        min_mondoo_version: 9.0.0
       scalableDimension: {}
+      scheduledActions:
+        min_mondoo_version: 9.0.0
       suspendedState: {}
     is_private: true
     min_mondoo_version: 6.11.1
@@ -299,6 +383,8 @@ resources:
         min_mondoo_version: 9.0.0
       desiredCapacity:
         min_mondoo_version: 9.0.0
+      desiredCapacityType:
+        min_mondoo_version: 9.0.0
       healthCheckGracePeriod:
         min_mondoo_version: 9.0.0
       healthCheckType: {}
@@ -314,12 +400,22 @@ resources:
       minSize:
         min_mondoo_version: 9.0.0
       name: {}
+      newInstancesProtectedFromScaleIn:
+        min_mondoo_version: 9.0.0
+      placementGroup:
+        min_mondoo_version: 9.0.0
+      predictedCapacity:
+        min_mondoo_version: 9.0.0
       region:
         min_mondoo_version: 9.0.0
       tagSpecifications:
         min_mondoo_version: 9.0.0
       tags:
         min_mondoo_version: 5.16.0
+      targetGroups:
+        min_mondoo_version: 9.0.0
+      warmPoolSize:
+        min_mondoo_version: 9.0.0
     is_private: true
     min_mondoo_version: 5.15.0
     platform:

--- a/providers/aws/resources/aws_apigateway.go
+++ b/providers/aws/resources/aws_apigateway.go
@@ -76,13 +76,20 @@ func (a *mqlAwsApigateway) getRestApis(conn *connection.AwsConnection) []*jobpoo
 
 					mqlRestApi, err := CreateResource(a.MqlRuntime, ResourceAwsApigatewayRestapi,
 						map[string]*llx.RawData{
-							"arn":         llx.StringData(fmt.Sprintf(apiArnPattern, region, conn.AccountId(), convert.ToValue(restApi.Id))),
-							"id":          llx.StringData(convert.ToValue(restApi.Id)),
-							"name":        llx.StringData(convert.ToValue(restApi.Name)),
-							"description": llx.StringData(convert.ToValue(restApi.Description)),
-							"createdDate": llx.TimeDataPtr(restApi.CreatedDate),
-							"region":      llx.StringData(region),
-							"tags":        llx.MapData(toInterfaceMap(restApi.Tags), types.String),
+							"arn":                       llx.StringData(fmt.Sprintf(apiArnPattern, region, conn.AccountId(), convert.ToValue(restApi.Id))),
+							"id":                        llx.StringData(convert.ToValue(restApi.Id)),
+							"name":                      llx.StringData(convert.ToValue(restApi.Name)),
+							"description":               llx.StringData(convert.ToValue(restApi.Description)),
+							"createdDate":               llx.TimeDataPtr(restApi.CreatedDate),
+							"region":                    llx.StringData(region),
+							"tags":                      llx.MapData(toInterfaceMap(restApi.Tags), types.String),
+							"apiKeySource":              llx.StringData(string(restApi.ApiKeySource)),
+							"disableExecuteApiEndpoint": llx.BoolData(restApi.DisableExecuteApiEndpoint),
+							"minimumCompressionSize":    llx.IntDataDefault(restApi.MinimumCompressionSize, -1),
+							"binaryMediaTypes":          llx.ArrayData(convert.SliceAnyToInterface(restApi.BinaryMediaTypes), types.String),
+							"version":                   llx.StringData(convert.ToValue(restApi.Version)),
+							"securityPolicy":            llx.StringData(string(restApi.SecurityPolicy)),
+							"policy":                    llx.StringData(convert.ToValue(restApi.Policy)),
 						})
 					if err != nil {
 						return nil, err
@@ -164,12 +171,22 @@ func (a *mqlAwsApigatewayRestapi) stages() ([]any, error) {
 		}
 		mqlStage, err := CreateResource(a.MqlRuntime, ResourceAwsApigatewayStage,
 			map[string]*llx.RawData{
-				"arn":            llx.StringData(fmt.Sprintf(apiStageArnPattern, region, conn.AccountId(), restApiId, convert.ToValue(stage.StageName))),
-				"name":           llx.StringData(convert.ToValue(stage.StageName)),
-				"description":    llx.StringData(convert.ToValue(stage.Description)),
-				"tracingEnabled": llx.BoolData(stage.TracingEnabled),
-				"deploymentId":   llx.StringData(convert.ToValue(stage.DeploymentId)),
-				"methodSettings": llx.MapData(dictMethodSettings, types.Any),
+				"arn":                  llx.StringData(fmt.Sprintf(apiStageArnPattern, region, conn.AccountId(), restApiId, convert.ToValue(stage.StageName))),
+				"name":                 llx.StringData(convert.ToValue(stage.StageName)),
+				"description":          llx.StringData(convert.ToValue(stage.Description)),
+				"tracingEnabled":       llx.BoolData(stage.TracingEnabled),
+				"deploymentId":         llx.StringData(convert.ToValue(stage.DeploymentId)),
+				"methodSettings":       llx.MapData(dictMethodSettings, types.Any),
+				"cacheClusterEnabled":  llx.BoolData(stage.CacheClusterEnabled),
+				"cacheClusterSize":     llx.StringData(string(stage.CacheClusterSize)),
+				"cacheClusterStatus":   llx.StringData(string(stage.CacheClusterStatus)),
+				"clientCertificateId":  llx.StringData(convert.ToValue(stage.ClientCertificateId)),
+				"webAclArn":            llx.StringData(convert.ToValue(stage.WebAclArn)),
+				"createdAt":            llx.TimeDataPtr(stage.CreatedDate),
+				"lastUpdatedAt":        llx.TimeDataPtr(stage.LastUpdatedDate),
+				"documentationVersion": llx.StringData(convert.ToValue(stage.DocumentationVersion)),
+				"variables":            llx.MapData(toInterfaceMap(stage.Variables), types.String),
+				"tags":                 llx.MapData(toInterfaceMap(stage.Tags), types.String),
 			})
 		if err != nil {
 			return nil, err

--- a/providers/aws/resources/aws_applicationautoscaling.go
+++ b/providers/aws/resources/aws_applicationautoscaling.go
@@ -26,6 +26,14 @@ func (a *mqlAwsApplicationAutoscalingTarget) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
+func (a *mqlAwsApplicationAutoscalingPolicy) id() (string, error) {
+	return a.Arn.Data, nil
+}
+
+func (a *mqlAwsApplicationAutoscalingScheduledAction) id() (string, error) {
+	return a.Arn.Data, nil
+}
+
 func (a *mqlAwsApplicationAutoscaling) scalableTargets() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	namespace := a.Namespace.Data
@@ -85,6 +93,8 @@ func (a *mqlAwsApplicationAutoscaling) getTargets(conn *connection.AwsConnection
 						map[string]*llx.RawData{
 							"arn":               llx.StringData(fmt.Sprintf("arn:aws:application-autoscaling:%s:%s:%s/%s", region, conn.AccountId(), namespace, convert.ToValue(target.ResourceId))),
 							"namespace":         llx.StringData(string(target.ServiceNamespace)),
+							"resourceId":        llx.StringData(convert.ToValue(target.ResourceId)),
+							"region":            llx.StringData(region),
 							"scalableDimension": llx.StringData(string(target.ScalableDimension)),
 							"minCapacity":       llx.IntDataDefault(target.MinCapacity, 0),
 							"maxCapacity":       llx.IntDataDefault(target.MaxCapacity, 0),
@@ -102,4 +112,133 @@ func (a *mqlAwsApplicationAutoscaling) getTargets(conn *connection.AwsConnection
 		tasks = append(tasks, jobpool.NewJob(f))
 	}
 	return tasks
+}
+
+func (a *mqlAwsApplicationAutoscalingTarget) policies() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	region := a.Region.Data
+	namespace := a.Namespace.Data
+	resourceId := a.ResourceId.Data
+	scalableDimension := a.ScalableDimension.Data
+
+	svc := conn.ApplicationAutoscaling(region)
+	ctx := context.Background()
+	res := []any{}
+
+	ns := aatypes.ServiceNamespace(namespace)
+	sd := aatypes.ScalableDimension(scalableDimension)
+	params := &applicationautoscaling.DescribeScalingPoliciesInput{
+		ServiceNamespace:  ns,
+		ResourceId:        &resourceId,
+		ScalableDimension: sd,
+	}
+	paginator := applicationautoscaling.NewDescribeScalingPoliciesPaginator(svc, params)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not gather application autoscaling policies")
+		}
+
+		for _, policy := range page.ScalingPolicies {
+			alarms := []any{}
+			for _, alarm := range policy.Alarms {
+				alarmDict, err := convert.JsonToDict(alarm)
+				if err != nil {
+					return nil, err
+				}
+				alarms = append(alarms, alarmDict)
+			}
+
+			targetTrackingConfig, err := convert.JsonToDict(policy.TargetTrackingScalingPolicyConfiguration)
+			if err != nil {
+				return nil, err
+			}
+
+			stepScalingConfig, err := convert.JsonToDict(policy.StepScalingPolicyConfiguration)
+			if err != nil {
+				return nil, err
+			}
+
+			predictiveScalingConfig, err := convert.JsonToDict(policy.PredictiveScalingPolicyConfiguration)
+			if err != nil {
+				return nil, err
+			}
+
+			mqlPolicy, err := CreateResource(a.MqlRuntime, "aws.applicationAutoscaling.policy",
+				map[string]*llx.RawData{
+					"arn":                     llx.StringDataPtr(policy.PolicyARN),
+					"name":                    llx.StringDataPtr(policy.PolicyName),
+					"policyType":              llx.StringData(string(policy.PolicyType)),
+					"resourceId":              llx.StringDataPtr(policy.ResourceId),
+					"scalableDimension":       llx.StringData(string(policy.ScalableDimension)),
+					"namespace":               llx.StringData(string(policy.ServiceNamespace)),
+					"createdAt":               llx.TimeDataPtr(policy.CreationTime),
+					"alarms":                  llx.ArrayData(alarms, types.Dict),
+					"targetTrackingConfig":    llx.DictData(targetTrackingConfig),
+					"stepScalingConfig":       llx.DictData(stepScalingConfig),
+					"predictiveScalingConfig": llx.DictData(predictiveScalingConfig),
+				})
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlPolicy)
+		}
+	}
+
+	return res, nil
+}
+
+func (a *mqlAwsApplicationAutoscalingTarget) scheduledActions() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	region := a.Region.Data
+	namespace := a.Namespace.Data
+	resourceId := a.ResourceId.Data
+	scalableDimension := a.ScalableDimension.Data
+
+	svc := conn.ApplicationAutoscaling(region)
+	ctx := context.Background()
+	res := []any{}
+
+	ns := aatypes.ServiceNamespace(namespace)
+	sd := aatypes.ScalableDimension(scalableDimension)
+	params := &applicationautoscaling.DescribeScheduledActionsInput{
+		ServiceNamespace:  ns,
+		ResourceId:        &resourceId,
+		ScalableDimension: sd,
+	}
+	paginator := applicationautoscaling.NewDescribeScheduledActionsPaginator(svc, params)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not gather application autoscaling scheduled actions")
+		}
+
+		for _, action := range page.ScheduledActions {
+			scalableTargetAction, err := convert.JsonToDict(action.ScalableTargetAction)
+			if err != nil {
+				return nil, err
+			}
+
+			mqlAction, err := CreateResource(a.MqlRuntime, "aws.applicationAutoscaling.scheduledAction",
+				map[string]*llx.RawData{
+					"arn":                  llx.StringDataPtr(action.ScheduledActionARN),
+					"name":                 llx.StringDataPtr(action.ScheduledActionName),
+					"schedule":             llx.StringDataPtr(action.Schedule),
+					"timezone":             llx.StringDataPtr(action.Timezone),
+					"resourceId":           llx.StringDataPtr(action.ResourceId),
+					"scalableDimension":    llx.StringData(string(action.ScalableDimension)),
+					"namespace":            llx.StringData(string(action.ServiceNamespace)),
+					"createdAt":            llx.TimeDataPtr(action.CreationTime),
+					"startAt":              llx.TimeDataPtr(action.StartTime),
+					"endAt":                llx.TimeDataPtr(action.EndTime),
+					"scalableTargetAction": llx.DictData(scalableTargetAction),
+				})
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlAction)
+		}
+	}
+
+	return res, nil
 }


### PR DESCRIPTION
Add new fields to `aws.autoscaling.group` and
`aws.applicationAutoscaling.target` including autoscaling policies and scheduled actions.

Add new fields to `aws.apigateway.stage` and `aws.apigateway.restapi`