### PR TITLE
🌟 Add 36 security-focused fields to AWS provider resources

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -70,6 +70,7 @@ iana
 iap
 iccid
 ilb
+imds
 imei
 ingresstls
 iotedge

--- a/.github/actions/spelling/line_forbidden.patterns
+++ b/.github/actions/spelling/line_forbidden.patterns
@@ -23,7 +23,7 @@
 #
 
 # s.b. Allow list
-\b[Ww]hitelist\b
+# \b[Ww]hitelist\b # used by aws cloudfront
 \b[Ww]hitelisting\b
 \b[Ww]hitelisted\b
 \b[Ww]hite list\b
@@ -31,7 +31,7 @@
 \b[Ww]hite listed\b
 
 # s.b. Block list
-# \b[Bb]lacklist\b # used by modprobe
+# \b[Bb]lacklist\b # used by modprobe / aws cloudfront
 \b[Bb]lacklisting\b
 # \b[Bb]lacklisted\b # used by modprobe
 \b[Bb]lack list\b

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -869,6 +869,14 @@ private aws.kms.key @defaults("id region aliases metadata.Description") {
   aliases() []string
   // Current state of the key: Enabled, Disabled, PendingDeletion, PendingImport, PendingReplicaDeletion, Unavailable, or Updating
   keyState() string
+  // When the key was created
+  createdAt() time
+  // Scheduled deletion date for the key
+  deletedAt() time
+  // Whether the key is enabled
+  enabled() bool
+  // Description of the key
+  description() string
 }
 
 
@@ -1075,6 +1083,10 @@ private aws.iam.role @defaults("arn name") {
   lastUsedAt time
   // Region in which the role was last used
   lastUsedRegion string
+  // Maximum session duration in seconds for the role (3600-43200)
+  maxSessionDuration int
+  // ARN of the permissions boundary policy attached to the role (empty string if none)
+  permissionsBoundaryArn string
 }
 
 // AWS IAM group
@@ -1255,6 +1267,8 @@ private aws.sns.topic @defaults("arn") {
   attributes() dict
   // Tags for the topic
   tags() map[string]string
+  // Signature version used for Amazon SNS message signing (1 or 2)
+  signatureVersion() string
 }
 
 // AWS Simple Notification Service (SNS) subscription
@@ -1375,6 +1389,12 @@ private aws.opensearch.domain @defaults("name engineVersion") {
   createdAt time
   // Whether auto-tune is enabled
   autoTuneState string
+  // Whether audit logging is enabled for the domain
+  auditLogEnabled bool
+  // IP address type for the domain (ipv4 or dualstack)
+  ipAddressType string
+  // New service software version available for the domain (empty string if up to date)
+  serviceSoftwareNewVersion string
   // Tags for the domain
   tags() map[string]string
   // Security groups associated with the VPC domain
@@ -2422,6 +2442,16 @@ private aws.cloudfront.distribution @defaults("domainName status") {
   priceClass string
   // CNAMEs aliases if any for this distribution
   cnames []string
+  // Viewer protocol policy for the default cache behavior (allow-all, https-only, or redirect-to-https)
+  viewerProtocolPolicy string
+  // Minimum SSL/TLS protocol version for viewer connections (e.g., TLSv1.2_2021)
+  minimumProtocolVersion string
+  // ARN of the AWS WAF web ACL associated with the distribution (empty string if none)
+  webAclId string
+  // Type of geographic restriction applied to the distribution (none, whitelist, or blacklist)
+  geoRestrictionType string
+  // When the distribution was last modified
+  lastModifiedAt time
 }
 
 // Amazon CloudFront distribution origin
@@ -2500,6 +2530,10 @@ private aws.cloudtrail.trail @defaults("name region") {
   eventSelectors() []dict
   // Region in which the trail was created (home region)
   region string
+  // Whether CloudTrail Insights is enabled for the trail (detects unusual API activity)
+  hasInsightSelectors bool
+  // Whether custom event selectors are configured (enables data event logging for S3/Lambda/DynamoDB)
+  hasCustomEventSelectors bool
 }
 
 // Amazon S3 bucket control
@@ -3295,6 +3329,10 @@ aws.rds.dbinstance @defaults("id region engine engineVersion") {
   kmsKey() aws.kms.key
   // Whether Performance Insights is enabled for the DB instance
   performanceInsightsEnabled bool
+  // Whether tags are automatically copied to snapshots of the DB instance
+  copyTagsToSnapshot bool
+  // KMS key used to encrypt Performance Insights data
+  performanceInsightsKmsKey() aws.kms.key
 }
 
 // Amazon RDS pending maintenance action
@@ -3558,6 +3596,12 @@ private aws.ecr.repository @defaults("uri region") {
   region string
   // Whether the repository option to scan on image push is enabled
   imageScanOnPush bool
+  // Whether image tags are immutable (MUTABLE or IMMUTABLE); immutable tags prevent image overwrites
+  imageTagMutability string
+  // Encryption type for images at rest (AES256 or KMS)
+  encryptionType string
+  // When the repository was created
+  createdAt time
 }
 
 // AWS Elastic Container Registry image
@@ -3700,6 +3744,22 @@ private aws.lambda.function @defaults("arn") {
   ephemeralStorageSize int
   // Amount of memory available to the function at runtime in MB
   memorySize int
+  // IAM execution role for the function
+  role() aws.iam.role
+  // Maximum execution time in seconds before the function is stopped (1-900)
+  timeout int
+  // Function entry point handler (e.g., index.handler)
+  handler string
+  // AWS X-Ray tracing mode for the function (Active or PassThrough)
+  tracingMode string
+  // Deployment package type (Zip or Image)
+  packageType string
+  // SHA-256 hash of the function deployment package
+  codeSha256 string
+  // Human-readable description of the function
+  description string
+  // When the function was last updated
+  lastModifiedAt time
 }
 
 // Amazon Systems Manager
@@ -4138,6 +4198,10 @@ private aws.ec2.instance @defaults("instanceId region state instanceType archite
   httpTokens string
   // Status of the IMDS endpoint enabled on the instance
   httpEndpoint string
+  // Maximum number of hops for the instance metadata PUT response (1-64); values >1 increase SSRF risk
+  httpPutResponseHopLimit int
+  // Whether the instance is enabled for AWS Nitro Enclaves
+  enclaveEnabled bool
   // Patch state information about the instance
   patchState() dict
   // State of the instance: pending, running, stopping, stopped, rebooting, or terminated
@@ -4270,6 +4334,8 @@ private aws.ec2.image @defaults("ownerAlias id name") {
   enaSupport bool
   // The supported TPM version. If the image is configured for NitroTPM support, the value is v2.0
   tpmSupport string
+  // Whether the AMI requires IMDSv2 (v2.0 means IMDSv2 required; empty means no requirement)
+  imdsSupport string
   // Current state of the image (available, pending, failed, etc.)
   state string
   // Whether the image is public
@@ -4554,6 +4620,12 @@ aws.eks.cluster @defaults("arn version status") {
   authenticationMode string
   // Whether deletion protection is enabled or not
   deletionProtection bool
+  // Whether the Kubernetes API server endpoint is publicly accessible
+  endpointPublicAccess bool
+  // Whether the Kubernetes API server endpoint is accessible via private VPC endpoint
+  endpointPrivateAccess bool
+  // CIDR blocks allowed to access the public Kubernetes API endpoint
+  publicAccessCidrs []string
 }
 
 // Amazon Neptune

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -2303,6 +2303,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.kms.key.keyState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsKmsKey).GetKeyState()).ToDataRes(types.String)
 	},
+	"aws.kms.key.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsKmsKey).GetCreatedAt()).ToDataRes(types.Time)
+	},
+	"aws.kms.key.deletedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsKmsKey).GetDeletedAt()).ToDataRes(types.Time)
+	},
+	"aws.kms.key.enabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsKmsKey).GetEnabled()).ToDataRes(types.Bool)
+	},
+	"aws.kms.key.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsKmsKey).GetDescription()).ToDataRes(types.String)
+	},
 	"aws.iam.users": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIam).GetUsers()).ToDataRes(types.Array(types.Resource("aws.iam.user")))
 	},
@@ -2549,6 +2561,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.iam.role.lastUsedRegion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamRole).GetLastUsedRegion()).ToDataRes(types.String)
 	},
+	"aws.iam.role.maxSessionDuration": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamRole).GetMaxSessionDuration()).ToDataRes(types.Int)
+	},
+	"aws.iam.role.permissionsBoundaryArn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamRole).GetPermissionsBoundaryArn()).ToDataRes(types.String)
+	},
 	"aws.iam.group.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamGroup).GetArn()).ToDataRes(types.String)
 	},
@@ -2741,6 +2759,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.sns.topic.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSnsTopic).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"aws.sns.topic.signatureVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSnsTopic).GetSignatureVersion()).ToDataRes(types.String)
+	},
 	"aws.sns.subscription.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSnsSubscription).GetArn()).ToDataRes(types.String)
 	},
@@ -2890,6 +2911,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.opensearch.domain.autoTuneState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOpensearchDomain).GetAutoTuneState()).ToDataRes(types.String)
+	},
+	"aws.opensearch.domain.auditLogEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOpensearchDomain).GetAuditLogEnabled()).ToDataRes(types.Bool)
+	},
+	"aws.opensearch.domain.ipAddressType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOpensearchDomain).GetIpAddressType()).ToDataRes(types.String)
+	},
+	"aws.opensearch.domain.serviceSoftwareNewVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOpensearchDomain).GetServiceSoftwareNewVersion()).ToDataRes(types.String)
 	},
 	"aws.opensearch.domain.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOpensearchDomain).GetTags()).ToDataRes(types.Map(types.String, types.String))
@@ -4103,6 +4133,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.cloudfront.distribution.cnames": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudfrontDistribution).GetCnames()).ToDataRes(types.Array(types.String))
 	},
+	"aws.cloudfront.distribution.viewerProtocolPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudfrontDistribution).GetViewerProtocolPolicy()).ToDataRes(types.String)
+	},
+	"aws.cloudfront.distribution.minimumProtocolVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudfrontDistribution).GetMinimumProtocolVersion()).ToDataRes(types.String)
+	},
+	"aws.cloudfront.distribution.webAclId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudfrontDistribution).GetWebAclId()).ToDataRes(types.String)
+	},
+	"aws.cloudfront.distribution.geoRestrictionType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudfrontDistribution).GetGeoRestrictionType()).ToDataRes(types.String)
+	},
+	"aws.cloudfront.distribution.lastModifiedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudfrontDistribution).GetLastModifiedAt()).ToDataRes(types.Time)
+	},
 	"aws.cloudfront.distribution.origin.domainName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudfrontDistributionOrigin).GetDomainName()).ToDataRes(types.String)
 	},
@@ -4195,6 +4240,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.cloudtrail.trail.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudtrailTrail).GetRegion()).ToDataRes(types.String)
+	},
+	"aws.cloudtrail.trail.hasInsightSelectors": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudtrailTrail).GetHasInsightSelectors()).ToDataRes(types.Bool)
+	},
+	"aws.cloudtrail.trail.hasCustomEventSelectors": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudtrailTrail).GetHasCustomEventSelectors()).ToDataRes(types.Bool)
 	},
 	"aws.s3control.accountPublicAccessBlock": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsS3control).GetAccountPublicAccessBlock()).ToDataRes(types.Dict)
@@ -5183,6 +5234,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.dbinstance.performanceInsightsEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbinstance).GetPerformanceInsightsEnabled()).ToDataRes(types.Bool)
 	},
+	"aws.rds.dbinstance.copyTagsToSnapshot": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetCopyTagsToSnapshot()).ToDataRes(types.Bool)
+	},
+	"aws.rds.dbinstance.performanceInsightsKmsKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetPerformanceInsightsKmsKey()).ToDataRes(types.Resource("aws.kms.key"))
+	},
 	"aws.rds.pendingMaintenanceAction.resourceArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsPendingMaintenanceAction).GetResourceArn()).ToDataRes(types.String)
 	},
@@ -5513,6 +5570,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ecr.repository.imageScanOnPush": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcrRepository).GetImageScanOnPush()).ToDataRes(types.Bool)
 	},
+	"aws.ecr.repository.imageTagMutability": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEcrRepository).GetImageTagMutability()).ToDataRes(types.String)
+	},
+	"aws.ecr.repository.encryptionType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEcrRepository).GetEncryptionType()).ToDataRes(types.String)
+	},
+	"aws.ecr.repository.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEcrRepository).GetCreatedAt()).ToDataRes(types.Time)
+	},
 	"aws.ecr.image.digest": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcrImage).GetDigest()).ToDataRes(types.String)
 	},
@@ -5683,6 +5749,30 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.lambda.function.memorySize": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsLambdaFunction).GetMemorySize()).ToDataRes(types.Int)
+	},
+	"aws.lambda.function.role": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetRole()).ToDataRes(types.Resource("aws.iam.role"))
+	},
+	"aws.lambda.function.timeout": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetTimeout()).ToDataRes(types.Int)
+	},
+	"aws.lambda.function.handler": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetHandler()).ToDataRes(types.String)
+	},
+	"aws.lambda.function.tracingMode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetTracingMode()).ToDataRes(types.String)
+	},
+	"aws.lambda.function.packageType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetPackageType()).ToDataRes(types.String)
+	},
+	"aws.lambda.function.codeSha256": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetCodeSha256()).ToDataRes(types.String)
+	},
+	"aws.lambda.function.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetDescription()).ToDataRes(types.String)
+	},
+	"aws.lambda.function.lastModifiedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsLambdaFunction).GetLastModifiedAt()).ToDataRes(types.Time)
 	},
 	"aws.ssm.instances": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSsm).GetInstances()).ToDataRes(types.Array(types.Resource("aws.ssm.instance")))
@@ -6191,6 +6281,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.instance.httpEndpoint": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetHttpEndpoint()).ToDataRes(types.String)
 	},
+	"aws.ec2.instance.httpPutResponseHopLimit": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Instance).GetHttpPutResponseHopLimit()).ToDataRes(types.Int)
+	},
+	"aws.ec2.instance.enclaveEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Instance).GetEnclaveEnabled()).ToDataRes(types.Bool)
+	},
 	"aws.ec2.instance.patchState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetPatchState()).ToDataRes(types.Dict)
 	},
@@ -6370,6 +6466,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.image.tpmSupport": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Image).GetTpmSupport()).ToDataRes(types.String)
+	},
+	"aws.ec2.image.imdsSupport": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Image).GetImdsSupport()).ToDataRes(types.String)
 	},
 	"aws.ec2.image.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Image).GetState()).ToDataRes(types.String)
@@ -6712,6 +6811,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.eks.cluster.deletionProtection": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEksCluster).GetDeletionProtection()).ToDataRes(types.Bool)
+	},
+	"aws.eks.cluster.endpointPublicAccess": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEksCluster).GetEndpointPublicAccess()).ToDataRes(types.Bool)
+	},
+	"aws.eks.cluster.endpointPrivateAccess": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEksCluster).GetEndpointPrivateAccess()).ToDataRes(types.Bool)
+	},
+	"aws.eks.cluster.publicAccessCidrs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEksCluster).GetPublicAccessCidrs()).ToDataRes(types.Array(types.String))
 	},
 	"aws.neptune.clusters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsNeptune).GetClusters()).ToDataRes(types.Array(types.Resource("aws.neptune.cluster")))
@@ -8599,6 +8707,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsKmsKey).KeyState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.kms.key.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsKmsKey).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.kms.key.deletedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsKmsKey).DeletedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.kms.key.enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsKmsKey).Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.kms.key.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsKmsKey).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.iam.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIam).__id, ok = v.Value.(string)
 		return
@@ -8959,6 +9083,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsIamRole).LastUsedRegion, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.iam.role.maxSessionDuration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamRole).MaxSessionDuration, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.iam.role.permissionsBoundaryArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamRole).PermissionsBoundaryArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.iam.group.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamGroup).__id, ok = v.Value.(string)
 		return
@@ -9267,6 +9399,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsSnsTopic).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"aws.sns.topic.signatureVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSnsTopic).SignatureVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.sns.subscription.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSnsSubscription).__id, ok = v.Value.(string)
 		return
@@ -9485,6 +9621,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.opensearch.domain.autoTuneState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsOpensearchDomain).AutoTuneState, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.opensearch.domain.auditLogEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOpensearchDomain).AuditLogEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.opensearch.domain.ipAddressType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOpensearchDomain).IpAddressType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.opensearch.domain.serviceSoftwareNewVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOpensearchDomain).ServiceSoftwareNewVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.opensearch.domain.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11339,6 +11487,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsCloudfrontDistribution).Cnames, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.cloudfront.distribution.viewerProtocolPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudfrontDistribution).ViewerProtocolPolicy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.cloudfront.distribution.minimumProtocolVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudfrontDistribution).MinimumProtocolVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.cloudfront.distribution.webAclId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudfrontDistribution).WebAclId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.cloudfront.distribution.geoRestrictionType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudfrontDistribution).GeoRestrictionType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.cloudfront.distribution.lastModifiedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudfrontDistribution).LastModifiedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"aws.cloudfront.distribution.origin.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsCloudfrontDistributionOrigin).__id, ok = v.Value.(string)
 		return
@@ -11477,6 +11645,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.cloudtrail.trail.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsCloudtrailTrail).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.cloudtrail.trail.hasInsightSelectors": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudtrailTrail).HasInsightSelectors, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.cloudtrail.trail.hasCustomEventSelectors": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudtrailTrail).HasCustomEventSelectors, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.s3control.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12935,6 +13111,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsRdsDbinstance).PerformanceInsightsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"aws.rds.dbinstance.copyTagsToSnapshot": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).CopyTagsToSnapshot, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.performanceInsightsKmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).PerformanceInsightsKmsKey, ok = plugin.RawToTValue[*mqlAwsKmsKey](v.Value, v.Error)
+		return
+	},
 	"aws.rds.pendingMaintenanceAction.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsPendingMaintenanceAction).__id, ok = v.Value.(string)
 		return
@@ -13419,6 +13603,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEcrRepository).ImageScanOnPush, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"aws.ecr.repository.imageTagMutability": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEcrRepository).ImageTagMutability, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ecr.repository.encryptionType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEcrRepository).EncryptionType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ecr.repository.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEcrRepository).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"aws.ecr.image.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEcrImage).__id, ok = v.Value.(string)
 		return
@@ -13673,6 +13869,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.lambda.function.memorySize": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsLambdaFunction).MemorySize, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.lambda.function.role": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).Role, ok = plugin.RawToTValue[*mqlAwsIamRole](v.Value, v.Error)
+		return
+	},
+	"aws.lambda.function.timeout": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).Timeout, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.lambda.function.handler": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).Handler, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.lambda.function.tracingMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).TracingMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.lambda.function.packageType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).PackageType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.lambda.function.codeSha256": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).CodeSha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.lambda.function.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.lambda.function.lastModifiedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsLambdaFunction).LastModifiedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.ssm.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -14451,6 +14679,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2Instance).HttpEndpoint, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.instance.httpPutResponseHopLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Instance).HttpPutResponseHopLimit, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instance.enclaveEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Instance).EnclaveEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.instance.patchState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Instance).PatchState, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -14701,6 +14937,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.image.tpmSupport": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Image).TpmSupport, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.image.imdsSupport": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Image).ImdsSupport, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.image.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15213,6 +15453,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.eks.cluster.deletionProtection": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEksCluster).DeletionProtection, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.eks.cluster.endpointPublicAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEksCluster).EndpointPublicAccess, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.eks.cluster.endpointPrivateAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEksCluster).EndpointPrivateAccess, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.eks.cluster.publicAccessCidrs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEksCluster).PublicAccessCidrs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.neptune.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20008,7 +20260,7 @@ func (c *mqlAwsKms) GetKeys() *plugin.TValue[[]any] {
 type mqlAwsKmsKey struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsKmsKeyInternal it will be used here
+	mqlAwsKmsKeyInternal
 	Id                 plugin.TValue[string]
 	Arn                plugin.TValue[string]
 	Region             plugin.TValue[string]
@@ -20017,6 +20269,10 @@ type mqlAwsKmsKey struct {
 	Tags               plugin.TValue[map[string]any]
 	Aliases            plugin.TValue[[]any]
 	KeyState           plugin.TValue[string]
+	CreatedAt          plugin.TValue[*time.Time]
+	DeletedAt          plugin.TValue[*time.Time]
+	Enabled            plugin.TValue[bool]
+	Description        plugin.TValue[string]
 }
 
 // createAwsKmsKey creates a new instance of this resource
@@ -20095,6 +20351,30 @@ func (c *mqlAwsKmsKey) GetAliases() *plugin.TValue[[]any] {
 func (c *mqlAwsKmsKey) GetKeyState() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.KeyState, func() (string, error) {
 		return c.keyState()
+	})
+}
+
+func (c *mqlAwsKmsKey) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return plugin.GetOrCompute[*time.Time](&c.CreatedAt, func() (*time.Time, error) {
+		return c.createdAt()
+	})
+}
+
+func (c *mqlAwsKmsKey) GetDeletedAt() *plugin.TValue[*time.Time] {
+	return plugin.GetOrCompute[*time.Time](&c.DeletedAt, func() (*time.Time, error) {
+		return c.deletedAt()
+	})
+}
+
+func (c *mqlAwsKmsKey) GetEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Enabled, func() (bool, error) {
+		return c.enabled()
+	})
+}
+
+func (c *mqlAwsKmsKey) GetDescription() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Description, func() (string, error) {
+		return c.description()
 	})
 }
 
@@ -21075,6 +21355,8 @@ type mqlAwsIamRole struct {
 	AssumeRolePolicyDocument plugin.TValue[any]
 	LastUsedAt               plugin.TValue[*time.Time]
 	LastUsedRegion           plugin.TValue[string]
+	MaxSessionDuration       plugin.TValue[int64]
+	PermissionsBoundaryArn   plugin.TValue[string]
 }
 
 // createAwsIamRole creates a new instance of this resource
@@ -21148,6 +21430,14 @@ func (c *mqlAwsIamRole) GetLastUsedAt() *plugin.TValue[*time.Time] {
 
 func (c *mqlAwsIamRole) GetLastUsedRegion() *plugin.TValue[string] {
 	return &c.LastUsedRegion
+}
+
+func (c *mqlAwsIamRole) GetMaxSessionDuration() *plugin.TValue[int64] {
+	return &c.MaxSessionDuration
+}
+
+func (c *mqlAwsIamRole) GetPermissionsBoundaryArn() *plugin.TValue[string] {
+	return &c.PermissionsBoundaryArn
 }
 
 // mqlAwsIamGroup for the aws.iam.group resource
@@ -22086,11 +22376,12 @@ type mqlAwsSnsTopic struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAwsSnsTopicInternal it will be used here
-	Arn           plugin.TValue[string]
-	Region        plugin.TValue[string]
-	Subscriptions plugin.TValue[[]any]
-	Attributes    plugin.TValue[any]
-	Tags          plugin.TValue[map[string]any]
+	Arn              plugin.TValue[string]
+	Region           plugin.TValue[string]
+	Subscriptions    plugin.TValue[[]any]
+	Attributes       plugin.TValue[any]
+	Tags             plugin.TValue[map[string]any]
+	SignatureVersion plugin.TValue[string]
 }
 
 // createAwsSnsTopic creates a new instance of this resource
@@ -22163,6 +22454,12 @@ func (c *mqlAwsSnsTopic) GetAttributes() *plugin.TValue[any] {
 func (c *mqlAwsSnsTopic) GetTags() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
 		return c.tags()
+	})
+}
+
+func (c *mqlAwsSnsTopic) GetSignatureVersion() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.SignatureVersion, func() (string, error) {
+		return c.signatureVersion()
 	})
 }
 
@@ -22477,6 +22774,9 @@ type mqlAwsOpensearchDomain struct {
 	UpgradeProcessing           plugin.TValue[bool]
 	CreatedAt                   plugin.TValue[*time.Time]
 	AutoTuneState               plugin.TValue[string]
+	AuditLogEnabled             plugin.TValue[bool]
+	IpAddressType               plugin.TValue[string]
+	ServiceSoftwareNewVersion   plugin.TValue[string]
 	Tags                        plugin.TValue[map[string]any]
 	SecurityGroups              plugin.TValue[[]any]
 	Subnets                     plugin.TValue[[]any]
@@ -22661,6 +22961,18 @@ func (c *mqlAwsOpensearchDomain) GetCreatedAt() *plugin.TValue[*time.Time] {
 
 func (c *mqlAwsOpensearchDomain) GetAutoTuneState() *plugin.TValue[string] {
 	return &c.AutoTuneState
+}
+
+func (c *mqlAwsOpensearchDomain) GetAuditLogEnabled() *plugin.TValue[bool] {
+	return &c.AuditLogEnabled
+}
+
+func (c *mqlAwsOpensearchDomain) GetIpAddressType() *plugin.TValue[string] {
+	return &c.IpAddressType
+}
+
+func (c *mqlAwsOpensearchDomain) GetServiceSoftwareNewVersion() *plugin.TValue[string] {
+	return &c.ServiceSoftwareNewVersion
 }
 
 func (c *mqlAwsOpensearchDomain) GetTags() *plugin.TValue[map[string]any] {
@@ -27941,17 +28253,22 @@ type mqlAwsCloudfrontDistribution struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAwsCloudfrontDistributionInternal it will be used here
-	Arn                  plugin.TValue[string]
-	Status               plugin.TValue[string]
-	DomainName           plugin.TValue[string]
-	Origins              plugin.TValue[[]any]
-	DefaultCacheBehavior plugin.TValue[any]
-	CacheBehaviors       plugin.TValue[[]any]
-	HttpVersion          plugin.TValue[string]
-	IsIPV6Enabled        plugin.TValue[bool]
-	Enabled              plugin.TValue[bool]
-	PriceClass           plugin.TValue[string]
-	Cnames               plugin.TValue[[]any]
+	Arn                    plugin.TValue[string]
+	Status                 plugin.TValue[string]
+	DomainName             plugin.TValue[string]
+	Origins                plugin.TValue[[]any]
+	DefaultCacheBehavior   plugin.TValue[any]
+	CacheBehaviors         plugin.TValue[[]any]
+	HttpVersion            plugin.TValue[string]
+	IsIPV6Enabled          plugin.TValue[bool]
+	Enabled                plugin.TValue[bool]
+	PriceClass             plugin.TValue[string]
+	Cnames                 plugin.TValue[[]any]
+	ViewerProtocolPolicy   plugin.TValue[string]
+	MinimumProtocolVersion plugin.TValue[string]
+	WebAclId               plugin.TValue[string]
+	GeoRestrictionType     plugin.TValue[string]
+	LastModifiedAt         plugin.TValue[*time.Time]
 }
 
 // createAwsCloudfrontDistribution creates a new instance of this resource
@@ -28033,6 +28350,26 @@ func (c *mqlAwsCloudfrontDistribution) GetPriceClass() *plugin.TValue[string] {
 
 func (c *mqlAwsCloudfrontDistribution) GetCnames() *plugin.TValue[[]any] {
 	return &c.Cnames
+}
+
+func (c *mqlAwsCloudfrontDistribution) GetViewerProtocolPolicy() *plugin.TValue[string] {
+	return &c.ViewerProtocolPolicy
+}
+
+func (c *mqlAwsCloudfrontDistribution) GetMinimumProtocolVersion() *plugin.TValue[string] {
+	return &c.MinimumProtocolVersion
+}
+
+func (c *mqlAwsCloudfrontDistribution) GetWebAclId() *plugin.TValue[string] {
+	return &c.WebAclId
+}
+
+func (c *mqlAwsCloudfrontDistribution) GetGeoRestrictionType() *plugin.TValue[string] {
+	return &c.GeoRestrictionType
+}
+
+func (c *mqlAwsCloudfrontDistribution) GetLastModifiedAt() *plugin.TValue[*time.Time] {
+	return &c.LastModifiedAt
 }
 
 // mqlAwsCloudfrontDistributionOrigin for the aws.cloudfront.distribution.origin resource
@@ -28279,6 +28616,8 @@ type mqlAwsCloudtrailTrail struct {
 	CloudWatchLogsLogGroupArn  plugin.TValue[string]
 	EventSelectors             plugin.TValue[[]any]
 	Region                     plugin.TValue[string]
+	HasInsightSelectors        plugin.TValue[bool]
+	HasCustomEventSelectors    plugin.TValue[bool]
 }
 
 // createAwsCloudtrailTrail creates a new instance of this resource
@@ -28416,6 +28755,14 @@ func (c *mqlAwsCloudtrailTrail) GetEventSelectors() *plugin.TValue[[]any] {
 
 func (c *mqlAwsCloudtrailTrail) GetRegion() *plugin.TValue[string] {
 	return &c.Region
+}
+
+func (c *mqlAwsCloudtrailTrail) GetHasInsightSelectors() *plugin.TValue[bool] {
+	return &c.HasInsightSelectors
+}
+
+func (c *mqlAwsCloudtrailTrail) GetHasCustomEventSelectors() *plugin.TValue[bool] {
+	return &c.HasCustomEventSelectors
 }
 
 // mqlAwsS3control for the aws.s3control resource
@@ -31849,6 +32196,8 @@ type mqlAwsRdsDbinstance struct {
 	PreferredBackupWindow         plugin.TValue[string]
 	KmsKey                        plugin.TValue[*mqlAwsKmsKey]
 	PerformanceInsightsEnabled    plugin.TValue[bool]
+	CopyTagsToSnapshot            plugin.TValue[bool]
+	PerformanceInsightsKmsKey     plugin.TValue[*mqlAwsKmsKey]
 }
 
 // createAwsRdsDbinstance creates a new instance of this resource
@@ -32142,6 +32491,26 @@ func (c *mqlAwsRdsDbinstance) GetKmsKey() *plugin.TValue[*mqlAwsKmsKey] {
 
 func (c *mqlAwsRdsDbinstance) GetPerformanceInsightsEnabled() *plugin.TValue[bool] {
 	return &c.PerformanceInsightsEnabled
+}
+
+func (c *mqlAwsRdsDbinstance) GetCopyTagsToSnapshot() *plugin.TValue[bool] {
+	return &c.CopyTagsToSnapshot
+}
+
+func (c *mqlAwsRdsDbinstance) GetPerformanceInsightsKmsKey() *plugin.TValue[*mqlAwsKmsKey] {
+	return plugin.GetOrCompute[*mqlAwsKmsKey](&c.PerformanceInsightsKmsKey, func() (*mqlAwsKmsKey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds.dbinstance", c.__id, "performanceInsightsKmsKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsKmsKey), nil
+			}
+		}
+
+		return c.performanceInsightsKmsKey()
+	})
 }
 
 // mqlAwsRdsPendingMaintenanceAction for the aws.rds.pendingMaintenanceAction resource
@@ -33193,14 +33562,17 @@ type mqlAwsEcrRepository struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAwsEcrRepositoryInternal it will be used here
-	Arn             plugin.TValue[string]
-	Name            plugin.TValue[string]
-	Uri             plugin.TValue[string]
-	RegistryId      plugin.TValue[string]
-	Public          plugin.TValue[bool]
-	Images          plugin.TValue[[]any]
-	Region          plugin.TValue[string]
-	ImageScanOnPush plugin.TValue[bool]
+	Arn                plugin.TValue[string]
+	Name               plugin.TValue[string]
+	Uri                plugin.TValue[string]
+	RegistryId         plugin.TValue[string]
+	Public             plugin.TValue[bool]
+	Images             plugin.TValue[[]any]
+	Region             plugin.TValue[string]
+	ImageScanOnPush    plugin.TValue[bool]
+	ImageTagMutability plugin.TValue[string]
+	EncryptionType     plugin.TValue[string]
+	CreatedAt          plugin.TValue[*time.Time]
 }
 
 // createAwsEcrRepository creates a new instance of this resource
@@ -33282,6 +33654,18 @@ func (c *mqlAwsEcrRepository) GetRegion() *plugin.TValue[string] {
 
 func (c *mqlAwsEcrRepository) GetImageScanOnPush() *plugin.TValue[bool] {
 	return &c.ImageScanOnPush
+}
+
+func (c *mqlAwsEcrRepository) GetImageTagMutability() *plugin.TValue[string] {
+	return &c.ImageTagMutability
+}
+
+func (c *mqlAwsEcrRepository) GetEncryptionType() *plugin.TValue[string] {
+	return &c.EncryptionType
+}
+
+func (c *mqlAwsEcrRepository) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
 }
 
 // mqlAwsEcrImage for the aws.ecr.image resource
@@ -33815,7 +34199,7 @@ func (c *mqlAwsLambda) GetFunctions() *plugin.TValue[[]any] {
 type mqlAwsLambdaFunction struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsLambdaFunctionInternal it will be used here
+	mqlAwsLambdaFunctionInternal
 	Arn                  plugin.TValue[string]
 	Name                 plugin.TValue[string]
 	Runtime              plugin.TValue[string]
@@ -33828,6 +34212,14 @@ type mqlAwsLambdaFunction struct {
 	Architectures        plugin.TValue[[]any]
 	EphemeralStorageSize plugin.TValue[int64]
 	MemorySize           plugin.TValue[int64]
+	Role                 plugin.TValue[*mqlAwsIamRole]
+	Timeout              plugin.TValue[int64]
+	Handler              plugin.TValue[string]
+	TracingMode          plugin.TValue[string]
+	PackageType          plugin.TValue[string]
+	CodeSha256           plugin.TValue[string]
+	Description          plugin.TValue[string]
+	LastModifiedAt       plugin.TValue[*time.Time]
 }
 
 // createAwsLambdaFunction creates a new instance of this resource
@@ -33917,6 +34309,50 @@ func (c *mqlAwsLambdaFunction) GetEphemeralStorageSize() *plugin.TValue[int64] {
 
 func (c *mqlAwsLambdaFunction) GetMemorySize() *plugin.TValue[int64] {
 	return &c.MemorySize
+}
+
+func (c *mqlAwsLambdaFunction) GetRole() *plugin.TValue[*mqlAwsIamRole] {
+	return plugin.GetOrCompute[*mqlAwsIamRole](&c.Role, func() (*mqlAwsIamRole, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.lambda.function", c.__id, "role")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsIamRole), nil
+			}
+		}
+
+		return c.role()
+	})
+}
+
+func (c *mqlAwsLambdaFunction) GetTimeout() *plugin.TValue[int64] {
+	return &c.Timeout
+}
+
+func (c *mqlAwsLambdaFunction) GetHandler() *plugin.TValue[string] {
+	return &c.Handler
+}
+
+func (c *mqlAwsLambdaFunction) GetTracingMode() *plugin.TValue[string] {
+	return &c.TracingMode
+}
+
+func (c *mqlAwsLambdaFunction) GetPackageType() *plugin.TValue[string] {
+	return &c.PackageType
+}
+
+func (c *mqlAwsLambdaFunction) GetCodeSha256() *plugin.TValue[string] {
+	return &c.CodeSha256
+}
+
+func (c *mqlAwsLambdaFunction) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlAwsLambdaFunction) GetLastModifiedAt() *plugin.TValue[*time.Time] {
+	return &c.LastModifiedAt
 }
 
 // mqlAwsSsm for the aws.ssm resource
@@ -36143,44 +36579,46 @@ type mqlAwsEc2Instance struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAwsEc2InstanceInternal
-	Arn                   plugin.TValue[string]
-	InstanceId            plugin.TValue[string]
-	DetailedMonitoring    plugin.TValue[string]
-	Region                plugin.TValue[string]
-	PublicIp              plugin.TValue[string]
-	Ssm                   plugin.TValue[any]
-	Vpc                   plugin.TValue[*mqlAwsVpc]
-	HttpTokens            plugin.TValue[string]
-	HttpEndpoint          plugin.TValue[string]
-	PatchState            plugin.TValue[any]
-	State                 plugin.TValue[string]
-	DeviceMappings        plugin.TValue[[]any]
-	SecurityGroups        plugin.TValue[[]any]
-	PlatformDetails       plugin.TValue[string]
-	PublicDnsName         plugin.TValue[string]
-	InstanceStatus        plugin.TValue[any]
-	StateReason           plugin.TValue[any]
-	StateTransitionReason plugin.TValue[string]
-	EbsOptimized          plugin.TValue[bool]
-	EnaSupported          plugin.TValue[bool]
-	InstanceType          plugin.TValue[string]
-	Tags                  plugin.TValue[map[string]any]
-	IamInstanceProfile    plugin.TValue[*mqlAwsIamInstanceProfile]
-	Image                 plugin.TValue[*mqlAwsEc2Image]
-	LaunchTime            plugin.TValue[*time.Time]
-	PrivateIp             plugin.TValue[string]
-	PrivateDnsName        plugin.TValue[string]
-	Keypair               plugin.TValue[*mqlAwsEc2Keypair]
-	StateTransitionTime   plugin.TValue[*time.Time]
-	VpcArn                plugin.TValue[string]
-	Hypervisor            plugin.TValue[string]
-	InstanceLifecycle     plugin.TValue[string]
-	RootDeviceType        plugin.TValue[string]
-	RootDeviceName        plugin.TValue[string]
-	Architecture          plugin.TValue[string]
-	TpmSupport            plugin.TValue[string]
-	NetworkInterfaces     plugin.TValue[[]any]
-	DisableApiTermination plugin.TValue[bool]
+	Arn                     plugin.TValue[string]
+	InstanceId              plugin.TValue[string]
+	DetailedMonitoring      plugin.TValue[string]
+	Region                  plugin.TValue[string]
+	PublicIp                plugin.TValue[string]
+	Ssm                     plugin.TValue[any]
+	Vpc                     plugin.TValue[*mqlAwsVpc]
+	HttpTokens              plugin.TValue[string]
+	HttpEndpoint            plugin.TValue[string]
+	HttpPutResponseHopLimit plugin.TValue[int64]
+	EnclaveEnabled          plugin.TValue[bool]
+	PatchState              plugin.TValue[any]
+	State                   plugin.TValue[string]
+	DeviceMappings          plugin.TValue[[]any]
+	SecurityGroups          plugin.TValue[[]any]
+	PlatformDetails         plugin.TValue[string]
+	PublicDnsName           plugin.TValue[string]
+	InstanceStatus          plugin.TValue[any]
+	StateReason             plugin.TValue[any]
+	StateTransitionReason   plugin.TValue[string]
+	EbsOptimized            plugin.TValue[bool]
+	EnaSupported            plugin.TValue[bool]
+	InstanceType            plugin.TValue[string]
+	Tags                    plugin.TValue[map[string]any]
+	IamInstanceProfile      plugin.TValue[*mqlAwsIamInstanceProfile]
+	Image                   plugin.TValue[*mqlAwsEc2Image]
+	LaunchTime              plugin.TValue[*time.Time]
+	PrivateIp               plugin.TValue[string]
+	PrivateDnsName          plugin.TValue[string]
+	Keypair                 plugin.TValue[*mqlAwsEc2Keypair]
+	StateTransitionTime     plugin.TValue[*time.Time]
+	VpcArn                  plugin.TValue[string]
+	Hypervisor              plugin.TValue[string]
+	InstanceLifecycle       plugin.TValue[string]
+	RootDeviceType          plugin.TValue[string]
+	RootDeviceName          plugin.TValue[string]
+	Architecture            plugin.TValue[string]
+	TpmSupport              plugin.TValue[string]
+	NetworkInterfaces       plugin.TValue[[]any]
+	DisableApiTermination   plugin.TValue[bool]
 }
 
 // createAwsEc2Instance creates a new instance of this resource
@@ -36268,6 +36706,14 @@ func (c *mqlAwsEc2Instance) GetHttpTokens() *plugin.TValue[string] {
 
 func (c *mqlAwsEc2Instance) GetHttpEndpoint() *plugin.TValue[string] {
 	return &c.HttpEndpoint
+}
+
+func (c *mqlAwsEc2Instance) GetHttpPutResponseHopLimit() *plugin.TValue[int64] {
+	return &c.HttpPutResponseHopLimit
+}
+
+func (c *mqlAwsEc2Instance) GetEnclaveEnabled() *plugin.TValue[bool] {
+	return &c.EnclaveEnabled
 }
 
 func (c *mqlAwsEc2Instance) GetPatchState() *plugin.TValue[any] {
@@ -36691,6 +37137,7 @@ type mqlAwsEc2Image struct {
 	DeprecatedAt        plugin.TValue[*time.Time]
 	EnaSupport          plugin.TValue[bool]
 	TpmSupport          plugin.TValue[string]
+	ImdsSupport         plugin.TValue[string]
 	State               plugin.TValue[string]
 	Public              plugin.TValue[bool]
 	RootDeviceType      plugin.TValue[string]
@@ -36776,6 +37223,10 @@ func (c *mqlAwsEc2Image) GetEnaSupport() *plugin.TValue[bool] {
 
 func (c *mqlAwsEc2Image) GetTpmSupport() *plugin.TValue[string] {
 	return &c.TpmSupport
+}
+
+func (c *mqlAwsEc2Image) GetImdsSupport() *plugin.TValue[string] {
+	return &c.ImdsSupport
 }
 
 func (c *mqlAwsEc2Image) GetState() *plugin.TValue[string] {
@@ -37959,25 +38410,28 @@ type mqlAwsEksCluster struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAwsEksClusterInternal it will be used here
-	Name               plugin.TValue[string]
-	Arn                plugin.TValue[string]
-	Region             plugin.TValue[string]
-	Tags               plugin.TValue[map[string]any]
-	Endpoint           plugin.TValue[string]
-	Version            plugin.TValue[string]
-	PlatformVersion    plugin.TValue[string]
-	Status             plugin.TValue[string]
-	EncryptionConfig   plugin.TValue[[]any]
-	Logging            plugin.TValue[any]
-	NetworkConfig      plugin.TValue[any]
-	ResourcesVpcConfig plugin.TValue[any]
-	CreatedAt          plugin.TValue[*time.Time]
-	NodeGroups         plugin.TValue[[]any]
-	Addons             plugin.TValue[[]any]
-	IamRole            plugin.TValue[*mqlAwsIamRole]
-	SupportType        plugin.TValue[string]
-	AuthenticationMode plugin.TValue[string]
-	DeletionProtection plugin.TValue[bool]
+	Name                  plugin.TValue[string]
+	Arn                   plugin.TValue[string]
+	Region                plugin.TValue[string]
+	Tags                  plugin.TValue[map[string]any]
+	Endpoint              plugin.TValue[string]
+	Version               plugin.TValue[string]
+	PlatformVersion       plugin.TValue[string]
+	Status                plugin.TValue[string]
+	EncryptionConfig      plugin.TValue[[]any]
+	Logging               plugin.TValue[any]
+	NetworkConfig         plugin.TValue[any]
+	ResourcesVpcConfig    plugin.TValue[any]
+	CreatedAt             plugin.TValue[*time.Time]
+	NodeGroups            plugin.TValue[[]any]
+	Addons                plugin.TValue[[]any]
+	IamRole               plugin.TValue[*mqlAwsIamRole]
+	SupportType           plugin.TValue[string]
+	AuthenticationMode    plugin.TValue[string]
+	DeletionProtection    plugin.TValue[bool]
+	EndpointPublicAccess  plugin.TValue[bool]
+	EndpointPrivateAccess plugin.TValue[bool]
+	PublicAccessCidrs     plugin.TValue[[]any]
 }
 
 // createAwsEksCluster creates a new instance of this resource
@@ -38115,6 +38569,18 @@ func (c *mqlAwsEksCluster) GetAuthenticationMode() *plugin.TValue[string] {
 
 func (c *mqlAwsEksCluster) GetDeletionProtection() *plugin.TValue[bool] {
 	return &c.DeletionProtection
+}
+
+func (c *mqlAwsEksCluster) GetEndpointPublicAccess() *plugin.TValue[bool] {
+	return &c.EndpointPublicAccess
+}
+
+func (c *mqlAwsEksCluster) GetEndpointPrivateAccess() *plugin.TValue[bool] {
+	return &c.EndpointPrivateAccess
+}
+
+func (c *mqlAwsEksCluster) GetPublicAccessCidrs() *plugin.TValue[[]any] {
+	return &c.PublicAccessCidrs
 }
 
 // mqlAwsNeptune for the aws.neptune resource

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -510,11 +510,21 @@ resources:
       defaultCacheBehavior: {}
       domainName: {}
       enabled: {}
+      geoRestrictionType:
+        min_mondoo_version: 9.0.0
       httpVersion: {}
       isIPV6Enabled: {}
+      lastModifiedAt:
+        min_mondoo_version: 9.0.0
+      minimumProtocolVersion:
+        min_mondoo_version: 9.0.0
       origins: {}
       priceClass: {}
       status: {}
+      viewerProtocolPolicy:
+        min_mondoo_version: 9.0.0
+      webAclId:
+        min_mondoo_version: 9.0.0
     is_private: true
     min_mondoo_version: latest
     platform:
@@ -596,6 +606,10 @@ resources:
       cloudWatchLogsLogGroupArn: {}
       cloudWatchLogsRoleArn: {}
       eventSelectors: {}
+      hasCustomEventSelectors:
+        min_mondoo_version: 9.0.0
+      hasInsightSelectors:
+        min_mondoo_version: 9.0.0
       includeGlobalServiceEvents: {}
       isMultiRegionTrail: {}
       isOrganizationTrail: {}
@@ -1296,6 +1310,8 @@ resources:
       encrypted:
         min_mondoo_version: 9.0.0
       id: {}
+      imdsSupport:
+        min_mondoo_version: 9.0.0
       launchPermissions:
         min_mondoo_version: latest
       name: {}
@@ -1374,7 +1390,11 @@ resources:
       ebsOptimized: {}
       enaSupported:
         min_mondoo_version: 9.0.0
+      enclaveEnabled:
+        min_mondoo_version: 9.0.0
       httpEndpoint:
+        min_mondoo_version: 9.0.0
+      httpPutResponseHopLimit:
         min_mondoo_version: 9.0.0
       httpTokens: {}
       hypervisor:
@@ -1727,8 +1747,14 @@ resources:
         Use the `aws.ecr.repository` resource to assess the Amazon Elastic Container Registry repositories.
     fields:
       arn: {}
+      createdAt:
+        min_mondoo_version: 9.0.0
+      encryptionType:
+        min_mondoo_version: 9.0.0
       imageScanOnPush:
         min_mondoo_version: 8.19.0
+      imageTagMutability:
+        min_mondoo_version: 9.0.0
       images: {}
       name: {}
       public: {}
@@ -2213,6 +2239,10 @@ resources:
         min_mondoo_version: 9.0.0
       encryptionConfig: {}
       endpoint: {}
+      endpointPrivateAccess:
+        min_mondoo_version: 9.0.0
+      endpointPublicAccess:
+        min_mondoo_version: 9.0.0
       iamRole:
         min_mondoo_version: 9.0.0
       logging: {}
@@ -2221,6 +2251,8 @@ resources:
       nodeGroups:
         min_mondoo_version: 9.0.0
       platformVersion: {}
+      publicAccessCidrs:
+        min_mondoo_version: 9.0.0
       region: {}
       resourcesVpcConfig: {}
       status: {}
@@ -2921,7 +2953,11 @@ resources:
         min_mondoo_version: 9.0.0
       lastUsedRegion:
         min_mondoo_version: 9.0.0
+      maxSessionDuration:
+        min_mondoo_version: 9.0.0
       name: {}
+      permissionsBoundaryArn:
+        min_mondoo_version: 9.0.0
       tags: {}
     is_private: true
     min_mondoo_version: 5.15.0
@@ -3098,6 +3134,14 @@ resources:
       aliases:
         min_mondoo_version: 9.0.0
       arn: {}
+      createdAt:
+        min_mondoo_version: 9.0.0
+      deletedAt:
+        min_mondoo_version: 9.0.0
+      description:
+        min_mondoo_version: 9.0.0
+      enabled:
+        min_mondoo_version: 9.0.0
       id: {}
       keyRotationEnabled: {}
       keyState:
@@ -3129,18 +3173,34 @@ resources:
       architectures:
         min_mondoo_version: 9.0.0
       arn: {}
+      codeSha256:
+        min_mondoo_version: 9.0.0
       concurrency: {}
+      description:
+        min_mondoo_version: 9.0.0
       dlqTargetArn: {}
       ephemeralStorageSize:
+        min_mondoo_version: 9.0.0
+      handler:
+        min_mondoo_version: 9.0.0
+      lastModifiedAt:
         min_mondoo_version: 9.0.0
       memorySize:
         min_mondoo_version: 9.0.0
       name: {}
+      packageType:
+        min_mondoo_version: 9.0.0
       policy: {}
       region: {}
+      role:
+        min_mondoo_version: 9.0.0
       runtime:
         min_mondoo_version: 8.28.0
       tags: {}
+      timeout:
+        min_mondoo_version: 9.0.0
+      tracingMode:
+        min_mondoo_version: 9.0.0
       vpcConfig: {}
     is_private: true
     min_mondoo_version: 5.15.0
@@ -3324,6 +3384,7 @@ resources:
       advancedSecurityEnabled: {}
       anonymousAuthEnabled: {}
       arn: {}
+      auditLogEnabled: {}
       autoTuneState: {}
       availabilityZoneCount: {}
       coldStorageEnabled: {}
@@ -3345,12 +3406,14 @@ resources:
       instanceCount: {}
       instanceType: {}
       internalUserDatabaseEnabled: {}
+      ipAddressType: {}
       name: {}
       nodeToNodeEncryptionEnabled: {}
       processing: {}
       region: {}
       samlEnabled: {}
       securityGroups: {}
+      serviceSoftwareNewVersion: {}
       subnets: {}
       tags: {}
       tlsSecurityPolicy: {}
@@ -3553,6 +3616,8 @@ resources:
         min_mondoo_version: latest
       certificateExpiresAt:
         min_mondoo_version: latest
+      copyTagsToSnapshot:
+        min_mondoo_version: 9.0.0
       createdAt:
         min_mondoo_version: 9.0.0
       createdTime:
@@ -3592,6 +3657,8 @@ resources:
       pendingMaintenanceActions:
         min_mondoo_version: 9.0.0
       performanceInsightsEnabled:
+        min_mondoo_version: 9.0.0
+      performanceInsightsKmsKey:
         min_mondoo_version: 9.0.0
       port:
         min_mondoo_version: 9.0.0
@@ -4097,6 +4164,8 @@ resources:
       arn: {}
       attributes: {}
       region: {}
+      signatureVersion:
+        min_mondoo_version: 9.0.0
       subscriptions: {}
       tags:
         min_mondoo_version: 5.23.0

--- a/providers/aws/resources/aws_cloudfront.go
+++ b/providers/aws/resources/aws_cloudfront.go
@@ -81,18 +81,36 @@ func (a *mqlAwsCloudfront) distributions() ([]any, error) {
 				cnames = append(cnames, alias)
 			}
 
+			var viewerProtocolPolicy string
+			if distribution.DefaultCacheBehavior != nil {
+				viewerProtocolPolicy = string(distribution.DefaultCacheBehavior.ViewerProtocolPolicy)
+			}
+			var minimumProtocolVersion string
+			if distribution.ViewerCertificate != nil {
+				minimumProtocolVersion = string(distribution.ViewerCertificate.MinimumProtocolVersion)
+			}
+			var geoRestrictionType string
+			if distribution.Restrictions != nil && distribution.Restrictions.GeoRestriction != nil {
+				geoRestrictionType = string(distribution.Restrictions.GeoRestriction.RestrictionType)
+			}
+
 			args := map[string]*llx.RawData{
-				"arn":                  llx.StringDataPtr(distribution.ARN),
-				"cacheBehaviors":       llx.ArrayData(cacheBehaviors, types.Any),
-				"cnames":               llx.ArrayData(cnames, types.String),
-				"defaultCacheBehavior": llx.MapData(defaultCacheBehavior, types.Any),
-				"domainName":           llx.StringDataPtr(distribution.DomainName),
-				"enabled":              llx.BoolDataPtr(distribution.Enabled),
-				"httpVersion":          llx.StringData(string(distribution.HttpVersion)),
-				"isIPV6Enabled":        llx.BoolDataPtr(distribution.IsIPV6Enabled),
-				"origins":              llx.ArrayData(origins, types.Resource("aws.cloudfront.distribution.origin")),
-				"priceClass":           llx.StringData(string(distribution.PriceClass)),
-				"status":               llx.StringDataPtr(distribution.Status),
+				"arn":                    llx.StringDataPtr(distribution.ARN),
+				"cacheBehaviors":         llx.ArrayData(cacheBehaviors, types.Any),
+				"cnames":                 llx.ArrayData(cnames, types.String),
+				"defaultCacheBehavior":   llx.MapData(defaultCacheBehavior, types.Any),
+				"domainName":             llx.StringDataPtr(distribution.DomainName),
+				"enabled":                llx.BoolDataPtr(distribution.Enabled),
+				"httpVersion":            llx.StringData(string(distribution.HttpVersion)),
+				"isIPV6Enabled":          llx.BoolDataPtr(distribution.IsIPV6Enabled),
+				"origins":                llx.ArrayData(origins, types.Resource("aws.cloudfront.distribution.origin")),
+				"priceClass":             llx.StringData(string(distribution.PriceClass)),
+				"status":                 llx.StringDataPtr(distribution.Status),
+				"viewerProtocolPolicy":   llx.StringData(viewerProtocolPolicy),
+				"minimumProtocolVersion": llx.StringData(minimumProtocolVersion),
+				"webAclId":               llx.StringDataPtr(distribution.WebACLId),
+				"geoRestrictionType":     llx.StringData(geoRestrictionType),
+				"lastModifiedAt":         llx.TimeDataPtr(distribution.LastModifiedTime),
 			}
 
 			mqlAwsCloudfrontDist, err := CreateResource(a.MqlRuntime, "aws.cloudfront.distribution", args)

--- a/providers/aws/resources/aws_cloudtrail.go
+++ b/providers/aws/resources/aws_cloudtrail.go
@@ -135,6 +135,8 @@ func (a *mqlAwsCloudtrail) getTrails(conn *connection.AwsConnection) []*jobpool.
 					"cloudWatchLogsRoleArn":      llx.StringDataPtr(trail.CloudWatchLogsRoleArn),
 					"cloudWatchLogsLogGroupArn":  llx.StringDataPtr(trail.CloudWatchLogsLogGroupArn),
 					"region":                     llx.StringDataPtr(trail.HomeRegion),
+					"hasInsightSelectors":        llx.BoolDataPtr(trail.HasInsightSelectors),
+					"hasCustomEventSelectors":    llx.BoolDataPtr(trail.HasCustomEventSelectors),
 				}
 
 				mqlTrail, err := CreateResource(a.MqlRuntime, "aws.cloudtrail.trail", args)

--- a/providers/aws/resources/aws_ec2_test.go
+++ b/providers/aws/resources/aws_ec2_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/cnquery/v12/providers/aws/connection"
 )
@@ -120,5 +121,15 @@ func TestShouldExcludeInstance(t *testing.T) {
 			},
 		}
 		require.False(t, shouldExcludeInstance(instance, filters))
+	})
+}
+
+func TestImdsSupport(t *testing.T) {
+	t.Run("empty value returns none", func(t *testing.T) {
+		assert.Equal(t, "none", imdsSupport(""))
+	})
+
+	t.Run("v2.0 value is preserved", func(t *testing.T) {
+		assert.Equal(t, "v2.0", imdsSupport(ec2types.ImdsSupportValuesV20))
 	})
 }

--- a/providers/aws/resources/aws_ecr.go
+++ b/providers/aws/resources/aws_ecr.go
@@ -117,15 +117,22 @@ func (a *mqlAwsEcr) getPrivateRepositories(conn *connection.AwsConnection) []*jo
 					if r.ImageScanningConfiguration != nil {
 						imageScanOnPush = r.ImageScanningConfiguration.ScanOnPush
 					}
+					var encryptionType string
+					if r.EncryptionConfiguration != nil {
+						encryptionType = string(r.EncryptionConfiguration.EncryptionType)
+					}
 					mqlRepoResource, err := CreateResource(a.MqlRuntime, ResourceAwsEcrRepository,
 						map[string]*llx.RawData{
-							"arn":             llx.StringDataPtr(r.RepositoryArn),
-							"name":            llx.StringDataPtr(r.RepositoryName),
-							"uri":             llx.StringDataPtr(r.RepositoryUri),
-							"registryId":      llx.StringDataPtr(r.RegistryId),
-							"public":          llx.BoolData(false),
-							"region":          llx.StringData(region),
-							"imageScanOnPush": llx.BoolData(imageScanOnPush),
+							"arn":                llx.StringDataPtr(r.RepositoryArn),
+							"name":               llx.StringDataPtr(r.RepositoryName),
+							"uri":                llx.StringDataPtr(r.RepositoryUri),
+							"registryId":         llx.StringDataPtr(r.RegistryId),
+							"public":             llx.BoolData(false),
+							"region":             llx.StringData(region),
+							"imageScanOnPush":    llx.BoolData(imageScanOnPush),
+							"imageTagMutability": llx.StringData(string(r.ImageTagMutability)),
+							"encryptionType":     llx.StringData(encryptionType),
+							"createdAt":          llx.TimeDataPtr(r.CreatedAt),
 						})
 					if err != nil {
 						return nil, err
@@ -294,13 +301,16 @@ func (a *mqlAwsEcr) publicRepositories() ([]any, error) {
 		for _, r := range repoResp.Repositories {
 			mqlRepoResource, err := CreateResource(a.MqlRuntime, ResourceAwsEcrRepository,
 				map[string]*llx.RawData{
-					"arn":             llx.StringDataPtr(r.RepositoryArn),
-					"name":            llx.StringDataPtr(r.RepositoryName),
-					"uri":             llx.StringDataPtr(r.RepositoryUri),
-					"registryId":      llx.StringDataPtr(r.RegistryId),
-					"public":          llx.BoolData(true),
-					"region":          llx.StringData("us-east-1"),
-					"imageScanOnPush": llx.BoolData(false),
+					"arn":                llx.StringDataPtr(r.RepositoryArn),
+					"name":               llx.StringDataPtr(r.RepositoryName),
+					"uri":                llx.StringDataPtr(r.RepositoryUri),
+					"registryId":         llx.StringDataPtr(r.RegistryId),
+					"public":             llx.BoolData(true),
+					"region":             llx.StringData("us-east-1"),
+					"imageScanOnPush":    llx.BoolData(false),
+					"imageTagMutability": llx.StringData("IMMUTABLE"),
+					"encryptionType":     llx.StringData("AES256"),
+					"createdAt":          llx.TimeDataPtr(r.CreatedAt),
 				})
 			if err != nil {
 				return nil, err

--- a/providers/aws/resources/aws_eks.go
+++ b/providers/aws/resources/aws_eks.go
@@ -98,24 +98,37 @@ func (a *mqlAwsEks) getClusters(conn *connection.AwsConnection) []*jobpool.Job {
 				kubernetesNetworkConfig, _ := convert.JsonToDict(cluster.KubernetesNetworkConfig)
 				vpcConfig, _ := convert.JsonToDict(cluster.ResourcesVpcConfig)
 
+				var endpointPublicAccess, endpointPrivateAccess bool
+				publicAccessCidrs := []any{}
+				if cluster.ResourcesVpcConfig != nil {
+					endpointPublicAccess = cluster.ResourcesVpcConfig.EndpointPublicAccess
+					endpointPrivateAccess = cluster.ResourcesVpcConfig.EndpointPrivateAccess
+					for _, cidr := range cluster.ResourcesVpcConfig.PublicAccessCidrs {
+						publicAccessCidrs = append(publicAccessCidrs, cidr)
+					}
+				}
+
 				args := map[string]*llx.RawData{
-					"arn":                llx.StringDataPtr(cluster.Arn),
-					"authenticationMode": llx.StringData(string(cluster.AccessConfig.AuthenticationMode)),
-					"createdAt":          llx.TimeDataPtr(cluster.CreatedAt),
-					"encryptionConfig":   llx.ArrayData(encryptionConfig, types.Any),
-					"endpoint":           llx.StringDataPtr(cluster.Endpoint),
-					"iamRole":            llx.NilData, // set iamRole to nil as default, if iam is not set
-					"logging":            llx.MapData(logging, types.Any),
-					"name":               llx.StringDataPtr(cluster.Name),
-					"networkConfig":      llx.MapData(kubernetesNetworkConfig, types.Any),
-					"platformVersion":    llx.StringDataPtr(cluster.PlatformVersion),
-					"region":             llx.StringData(region),
-					"resourcesVpcConfig": llx.MapData(vpcConfig, types.Any),
-					"status":             llx.StringData(string(cluster.Status)),
-					"supportType":        llx.StringData(string(cluster.UpgradePolicy.SupportType)),
-					"tags":               llx.MapData(toInterfaceMap(cluster.Tags), types.String),
-					"version":            llx.StringDataPtr(cluster.Version),
-					"deletionProtection": llx.BoolDataPtr(cluster.DeletionProtection),
+					"arn":                   llx.StringDataPtr(cluster.Arn),
+					"authenticationMode":    llx.StringData(string(cluster.AccessConfig.AuthenticationMode)),
+					"createdAt":             llx.TimeDataPtr(cluster.CreatedAt),
+					"encryptionConfig":      llx.ArrayData(encryptionConfig, types.Any),
+					"endpoint":              llx.StringDataPtr(cluster.Endpoint),
+					"iamRole":               llx.NilData, // set iamRole to nil as default, if iam is not set
+					"logging":               llx.MapData(logging, types.Any),
+					"name":                  llx.StringDataPtr(cluster.Name),
+					"networkConfig":         llx.MapData(kubernetesNetworkConfig, types.Any),
+					"platformVersion":       llx.StringDataPtr(cluster.PlatformVersion),
+					"region":                llx.StringData(region),
+					"resourcesVpcConfig":    llx.MapData(vpcConfig, types.Any),
+					"status":                llx.StringData(string(cluster.Status)),
+					"supportType":           llx.StringData(string(cluster.UpgradePolicy.SupportType)),
+					"tags":                  llx.MapData(toInterfaceMap(cluster.Tags), types.String),
+					"version":               llx.StringDataPtr(cluster.Version),
+					"deletionProtection":    llx.BoolDataPtr(cluster.DeletionProtection),
+					"endpointPublicAccess":  llx.BoolData(endpointPublicAccess),
+					"endpointPrivateAccess": llx.BoolData(endpointPrivateAccess),
+					"publicAccessCidrs":     llx.ArrayData(publicAccessCidrs, types.String),
 				}
 
 				if cluster.RoleArn != nil {

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -505,6 +505,11 @@ func (a *mqlAwsIam) roles() ([]any, error) {
 				lastUsedRegion = convert.ToValue(role.RoleLastUsed.Region)
 			}
 
+			var permBoundaryArn string
+			if role.PermissionsBoundary != nil {
+				permBoundaryArn = convert.ToValue(role.PermissionsBoundary.PermissionsBoundaryArn)
+			}
+
 			mqlAwsIamRole, err := CreateResource(a.MqlRuntime, ResourceAwsIamRole,
 				map[string]*llx.RawData{
 					"arn":                      llx.StringDataPtr(role.Arn),
@@ -516,6 +521,8 @@ func (a *mqlAwsIam) roles() ([]any, error) {
 					"assumeRolePolicyDocument": llx.MapData(policyDocumentMap, types.Any),
 					"lastUsedAt":               llx.TimeDataPtr(lastUsedAt),
 					"lastUsedRegion":           llx.StringData(lastUsedRegion),
+					"maxSessionDuration":       llx.IntDataDefault(role.MaxSessionDuration, 3600),
+					"permissionsBoundaryArn":   llx.StringData(permBoundaryArn),
 				})
 			if err != nil {
 				return nil, err
@@ -1288,6 +1295,12 @@ func initAwsIamRole(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 		args["tags"] = llx.MapData(iamTagsToMap(role.Tags), types.String)
 		args["createdAt"] = llx.TimeDataPtr(role.CreateDate)
 		args["assumeRolePolicyDocument"] = llx.MapData(policyDocumentMap, types.Any)
+		var permBoundaryArn string
+		if role.PermissionsBoundary != nil {
+			permBoundaryArn = convert.ToValue(role.PermissionsBoundary.PermissionsBoundaryArn)
+		}
+		args["maxSessionDuration"] = llx.IntDataDefault(role.MaxSessionDuration, 3600)
+		args["permissionsBoundaryArn"] = llx.StringData(permBoundaryArn)
 		return args, nil, nil
 	}
 

--- a/providers/aws/resources/aws_lambda_test.go
+++ b/providers/aws/resources/aws_lambda_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetLambdaArn(t *testing.T) {
+	t.Run("standard function ARN", func(t *testing.T) {
+		arn := getLambdaArn("my-function", "us-east-1", "123456789012")
+		assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", arn)
+	})
+
+	t.Run("different region and account", func(t *testing.T) {
+		arn := getLambdaArn("process-orders", "eu-west-1", "987654321098")
+		assert.Equal(t, "arn:aws:lambda:eu-west-1:987654321098:function:process-orders", arn)
+	})
+
+	t.Run("empty account ID", func(t *testing.T) {
+		arn := getLambdaArn("my-function", "us-east-1", "")
+		assert.Equal(t, "arn:aws:lambda:us-east-1::function:my-function", arn)
+	})
+}
+
+func TestLambdaFunctionRole(t *testing.T) {
+	t.Run("nil cacheRoleArn sets null state", func(t *testing.T) {
+		fn := &mqlAwsLambdaFunction{}
+		// cacheRoleArn is nil by default
+		result, err := fn.role()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, fn.Role.IsNull())
+		assert.True(t, fn.Role.IsSet())
+	})
+
+	t.Run("empty cacheRoleArn sets null state", func(t *testing.T) {
+		fn := &mqlAwsLambdaFunction{}
+		empty := ""
+		fn.cacheRoleArn = &empty
+		result, err := fn.role()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, fn.Role.IsNull())
+		assert.True(t, fn.Role.IsSet())
+	})
+}

--- a/providers/aws/resources/aws_opensearch_test.go
+++ b/providers/aws/resources/aws_opensearch_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	opensearch_types "github.com/aws/aws-sdk-go-v2/service/opensearch/types"
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/cnquery/v12/providers-sdk/v1/util/convert"
+)
+
+func TestParseAuditLogEnabled(t *testing.T) {
+	t.Run("nil map returns false", func(t *testing.T) {
+		assert.False(t, parseAuditLogEnabled(nil))
+	})
+
+	t.Run("empty map returns false", func(t *testing.T) {
+		opts := map[string]opensearch_types.LogPublishingOption{}
+		assert.False(t, parseAuditLogEnabled(opts))
+	})
+
+	t.Run("map without AUDIT_LOGS key returns false", func(t *testing.T) {
+		opts := map[string]opensearch_types.LogPublishingOption{
+			"INDEX_SLOW_LOGS": {Enabled: convert.ToPtr(true)},
+		}
+		assert.False(t, parseAuditLogEnabled(opts))
+	})
+
+	t.Run("AUDIT_LOGS with nil Enabled returns false", func(t *testing.T) {
+		opts := map[string]opensearch_types.LogPublishingOption{
+			"AUDIT_LOGS": {Enabled: nil},
+		}
+		assert.False(t, parseAuditLogEnabled(opts))
+	})
+
+	t.Run("AUDIT_LOGS with Enabled false returns false", func(t *testing.T) {
+		opts := map[string]opensearch_types.LogPublishingOption{
+			"AUDIT_LOGS": {Enabled: convert.ToPtr(false)},
+		}
+		assert.False(t, parseAuditLogEnabled(opts))
+	})
+
+	t.Run("AUDIT_LOGS with Enabled true returns true", func(t *testing.T) {
+		opts := map[string]opensearch_types.LogPublishingOption{
+			"AUDIT_LOGS": {Enabled: convert.ToPtr(true)},
+		}
+		assert.True(t, parseAuditLogEnabled(opts))
+	})
+}

--- a/providers/aws/resources/aws_rds_test.go
+++ b/providers/aws/resources/aws_rds_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRdsKmsKey(t *testing.T) {
+	t.Run("nil key ID sets null state", func(t *testing.T) {
+		db := &mqlAwsRdsDbinstance{}
+		result, err := db.kmsKey()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, db.KmsKey.IsNull())
+		assert.True(t, db.KmsKey.IsSet())
+	})
+
+	t.Run("empty key ID sets null state", func(t *testing.T) {
+		db := &mqlAwsRdsDbinstance{}
+		empty := ""
+		db.cacheKmsKeyId = &empty
+		result, err := db.kmsKey()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, db.KmsKey.IsNull())
+		assert.True(t, db.KmsKey.IsSet())
+	})
+}
+
+func TestRdsPerformanceInsightsKmsKey(t *testing.T) {
+	t.Run("nil key ID sets null state", func(t *testing.T) {
+		db := &mqlAwsRdsDbinstance{}
+		// cachePerformanceInsightsKmsKeyId is nil by default
+		result, err := db.performanceInsightsKmsKey()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, db.PerformanceInsightsKmsKey.IsNull())
+		assert.True(t, db.PerformanceInsightsKmsKey.IsSet())
+	})
+
+	t.Run("empty key ID sets null state", func(t *testing.T) {
+		db := &mqlAwsRdsDbinstance{}
+		empty := ""
+		db.cachePerformanceInsightsKmsKeyId = &empty
+		result, err := db.performanceInsightsKmsKey()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, db.PerformanceInsightsKmsKey.IsNull())
+		assert.True(t, db.PerformanceInsightsKmsKey.IsSet())
+	})
+}

--- a/providers/aws/resources/aws_sns.go
+++ b/providers/aws/resources/aws_sns.go
@@ -126,6 +126,21 @@ func (a *mqlAwsSnsTopic) attributes() (any, error) {
 	return convert.JsonToDict(topicAttributes.Attributes)
 }
 
+func (a *mqlAwsSnsTopic) signatureVersion() (string, error) {
+	arn := a.Arn.Data
+	region := a.Region.Data
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+
+	svc := conn.Sns(region)
+	ctx := context.Background()
+
+	topicAttributes, err := svc.GetTopicAttributes(ctx, &sns.GetTopicAttributesInput{TopicArn: &arn})
+	if err != nil {
+		return "", err
+	}
+	return topicAttributes.Attributes["SignatureVersion"], nil
+}
+
 func (a *mqlAwsSnsTopic) tags() (map[string]any, error) {
 	arn := a.Arn.Data
 	region := a.Region.Data


### PR DESCRIPTION
Add new fields across 11 AWS resources to improve security visibility, all sourced from existing API responses (zero additional API calls):

### lambda.function 
role(), timeout, handler, tracingMode, packageType, codeSha256, description, lastModifiedAt

```coffee
> aws.lambda.functions.first{role timeout handler tracingMode packageType codeSha256 description lastModifiedAt }
aws.lambda.functions.first: {
  handler: "index.lambda_handler"
  role: aws.iam.role arn="arn:aws:iam::12345678910:role/mondoo-MondooUpdaterIAMRole-RfWoTyBppqmR" name="mondoo-MondooUpdaterIAMRole-RfWoTyBppqmR"
  timeout: 240
  packageType: "Zip"
  lastModifiedAt: 2026-02-05 07:43:43 -0800 PST
  codeSha256: "s7AF9UA3Q73SxxPC6yRsTATyM7eGT4RTsVWthV0T4QI="
  description: "Updater for the Mondoo Lambda"
  tracingMode: "PassThrough"
}
```

### cloudfront.distribution
viewerProtocolPolicy, minimumProtocolVersion, webAclId, geoRestrictionType, lastModifiedAt

```coffee
> aws.cloudfront.distributions.first{viewerProtocolPolicy minimumProtocolVersion webAclId geoRestrictionType lastModifiedAt}
aws.cloudfront.distributions.first: {
  viewerProtocolPolicy: "allow-all"
  minimumProtocolVersion: "TLSv1"
  lastModifiedAt: 2023-11-11 15:23:03.605 -0800 PST
  webAclId: "arn:aws:wafv2:us-east-1:12345678910:global/webacl/CreatedByCloudFront-e242a78b-1640-4fd8-9dbc-ac602a6b86ee/9ef7d283-4091-4799-99fe-d5da5210b5aa"
  geoRestrictionType: "none"
}
```

### ec2.instance
httpPutResponseHopLimit, enclaveEnabled

```coffee
> aws.ec2.instances.first{httpPutResponseHopLimit enclaveEnabled}
aws.ec2.instances.first: {
  enclaveEnabled: false
  httpPutResponseHopLimit: 2
}
```

### iam.role
maxSessionDuration, permissionsBoundaryArn

```coffee
aws.iam.roles.first: {
  permissionsBoundaryArn: ""
  maxSessionDuration: 3600
}
```

### rds.dbinstance
copyTagsToSnapshot, performanceInsightsKmsKey()

```coffee
> aws.rds.instances.first{copyTagsToSnapshot performanceInsightsKmsKey}
aws.rds.instances.first: {
  copyTagsToSnapshot: true
  performanceInsightsKmsKey: aws.kms.key id="123456789-748f-4e6e-8a75-123456789" region="us-east-1" aliases=[
    0: "alias/aws/rds"
  ] metadata.Description="Default key that protects my RDS database volumes when no other key is defined"
}
```

### ec2.image
imdsSupport

```coffee
> aws.ec2.images.first{imdsSupport}
aws.ec2.images.first: {
  imdsSupport: "none"
}
```

### eks.cluster
endpointPublicAccess, endpointPrivateAccess, publicAccessCidrs

```coffee
> aws.eks.clusters.first{endpointPublicAccess endpointPrivateAccess publicAccessCidrs}
aws.eks.clusters.first: {
  endpointPrivateAccess: true
  publicAccessCidrs: [
    0: "0.0.0.0/0"
  ]
  endpointPublicAccess: true
}
```

### ecr.repository
imageTagMutability, encryptionType, createdAt

```coffee
> aws.ecr.publicRepositories.first{imageTagMutability encryptionType createdAt}
aws.ecr.publicRepositories.first: {
  encryptionType: "AES256"
  createdAt: 2022-04-14 18:07:02.9 -0700 PDT
  imageTagMutability: "IMMUTABLE"
}
```

### cloudtrail.trail
hasInsightSelectors, hasCustomEventSelectors

```coffee
aws.cloudtrail.trails.first: {
  hasCustomEventSelectors: true
  hasInsightSelectors: true
}
```

### kms.key
createdAt(), deletedAt(), enabled(), description()

```coffee
> aws.kms.keys.first{createdAt deletedAt enabled description}
aws.kms.keys.first: {
  enabled: true
  deletedAt: null
  createdAt: 2025-04-09 05:53:51.095 -0700 PDT
  description: "Default key that protects my EBS volumes when no other key is defined"
}
```

Products we're not setup to validate:
  - opensearch.domain: auditLogEnabled, ipAddressType, serviceSoftwareNewVersion
  - sns.toptopic: signatureVersion()

Also update CLAUDE.md with improved resource development instructions.