### PR TITLE
✨ Extend GardenLinux detection

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -196,6 +196,26 @@ var debian = &PlatformResolver{
 	},
 }
 
+var gardenlinux = &PlatformResolver{
+	Name:     "gardenlinux",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		if pf.Name != "gardenlinux" {
+			return false, nil
+		}
+		osrd := NewOSReleaseDetector(conn)
+
+		osr, err := osrd.osrelease()
+		if err != nil {
+			return false, nil
+		}
+
+		pf.Version = osr["GARDENLINUX_VERSION"]
+
+		return true, nil
+	},
+}
+
 var ubuntu = &PlatformResolver{
 	Name:     "ubuntu",
 	IsFamily: false,
@@ -1086,7 +1106,7 @@ var redhatFamily = &PlatformResolver{
 var debianFamily = &PlatformResolver{
 	Name:     "debian",
 	IsFamily: true,
-	Children: []*PlatformResolver{mxlinux, debian, ubuntu, raspbian, kali, linuxmint, popos, elementary, zorin, parrot, cumulus},
+	Children: []*PlatformResolver{mxlinux, debian, ubuntu, raspbian, kali, linuxmint, popos, elementary, zorin, parrot, cumulus, gardenlinux},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		return true, nil
 	},

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -1089,6 +1089,17 @@ func TestGardenLinuxDetector(t *testing.T) {
 	assert.Equal(t, "934.0", di.Version, "os version should be identified")
 }
 
+func TestGardenLinuxDetector_1877(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-gardenlinux_1877.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "gardenlinux", di.Name, "os name should be identified")
+	assert.Equal(t, "Garden Linux 1877.9", di.Title, "os title should be identified")
+	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"debian", "linux", "unix", "os"}, di.Family)
+	assert.Equal(t, "1877.9", di.Version, "os version should be identified")
+}
+
 func TestCachyOSDetector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-cachyos.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/testdata/detect-gardenlinux_1877.toml
+++ b/providers/os/detector/testdata/detect-gardenlinux_1877.toml
@@ -1,0 +1,30 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "4.9.125-linuxkit"
+
+[files."/etc/os-release"]
+content = """
+ID=gardenlinux
+ID_LIKE=debian
+NAME="Garden Linux"
+PRETTY_NAME="Garden Linux 1877.9"
+IMAGE_VERSION=1877.9
+VARIANT_ID=container-arm64
+HOME_URL="https://gardenlinux.io"
+SUPPORT_URL="https://github.com/gardenlinux/gardenlinux"
+BUG_REPORT_URL="https://github.com/gardenlinux/gardenlinux/issues"
+GARDENLINUX_CNAME=container-arm64-1877.9
+GARDENLINUX_PLATFORM=container
+GARDENLINUX_FEATURES=_slim,base,container
+GARDENLINUX_VERSION=1877.9
+GARDENLINUX_COMMIT_ID=171a5397
+GARDENLINUX_COMMIT_ID_LONG=171a5397058b93b419f5127d6247b0bdb7b1844d
+"""
+
+[files."/etc/debian_version"]
+content = "bookworm/sid"


### PR DESCRIPTION
Newer image versions no longer identify as Debian. we need separate discovery for them.