### PR TITLE
Extended VPC flow log description with the logFormat field

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -219,6 +219,8 @@ private aws.vpc.flowlog @defaults("id region status") {
   destinationType string
    // Delivery log status for the flow log data
   deliverLogsStatus string
+  // Format for the flow log
+  logFormat string
   // Maximum interval of time during which a flow of packets is captured and aggregated into a flow log record: 60 seconds (1 minute) or 600 seconds (10 minutes)
   maxAggregationInterval int
   // Type of traffic to monitor: ACCEPT, ALL, and REJECT

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -1589,6 +1589,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.vpc.flowlog.deliverLogsStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcFlowlog).GetDeliverLogsStatus()).ToDataRes(types.String)
 	},
+	"aws.vpc.flowlog.logFormat": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcFlowlog).GetLogFormat()).ToDataRes(types.String)
+	},
 	"aws.vpc.flowlog.maxAggregationInterval": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcFlowlog).GetMaxAggregationInterval()).ToDataRes(types.Int)
 	},
@@ -7469,6 +7472,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.vpc.flowlog.deliverLogsStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcFlowlog).DeliverLogsStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.flowlog.logFormat": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcFlowlog).LogFormat, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.flowlog.maxAggregationInterval": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16743,6 +16750,7 @@ type mqlAwsVpcFlowlog struct {
 	Destination            plugin.TValue[string]
 	DestinationType        plugin.TValue[string]
 	DeliverLogsStatus      plugin.TValue[string]
+	LogFormat              plugin.TValue[string]
 	MaxAggregationInterval plugin.TValue[int64]
 	TrafficType            plugin.TValue[string]
 }
@@ -16813,6 +16821,10 @@ func (c *mqlAwsVpcFlowlog) GetDestinationType() *plugin.TValue[string] {
 
 func (c *mqlAwsVpcFlowlog) GetDeliverLogsStatus() *plugin.TValue[string] {
 	return &c.DeliverLogsStatus
+}
+
+func (c *mqlAwsVpcFlowlog) GetLogFormat() *plugin.TValue[string] {
+	return &c.LogFormat
 }
 
 func (c *mqlAwsVpcFlowlog) GetMaxAggregationInterval() *plugin.TValue[int64] {

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -4278,6 +4278,8 @@ resources:
       destinationType:
         min_mondoo_version: 9.0.0
       id: {}
+      logFormat:
+        min_mondoo_version: 9.0.0
       maxAggregationInterval:
         min_mondoo_version: 9.0.0
       region: {}

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -575,6 +575,7 @@ func (a *mqlAwsVpc) flowLogs() ([]any, error) {
 					"destinationType":        llx.StringData(string(flowLog.LogDestinationType)),
 					"deliverLogsStatus":      llx.StringDataPtr(flowLog.DeliverLogsStatus),
 					"id":                     llx.StringDataPtr(flowLog.FlowLogId),
+					"logFormat":              llx.StringDataPtr(flowLog.LogFormat),
 					"maxAggregationInterval": llx.IntDataDefault(flowLog.MaxAggregationInterval, 0),
 					"region":                 llx.StringData(a.Region.Data),
 					"status":                 llx.StringDataPtr(flowLog.FlowLogStatus),


### PR DESCRIPTION
To be able to check, compare the log format for a VPC flow log added the missing field, so that is also returned among the existing ones.