### PR TITLE
⭐🛑 optional chaining: a.b.c vs a?.b?.c

### DIFF
--- a/llx/builtin.go
+++ b/llx/builtin.go
@@ -538,7 +538,8 @@ func init() {
 			string("/" + types.Float):                {f: dictDividedFloatV2, Label: "/"},
 			string("*" + types.Time):                 {f: dictTimesTimeV2, Label: "*"},
 			// fields
-			"[]":                              {f: dictGetIndexV2},
+			"[]":                              {f: dictGetIndex},
+			"[]?":                             {f: dictGetConditionalIndex},
 			"first":                           {f: dictGetFirstIndexV2},
 			"last":                            {f: dictGetLastIndexV2},
 			"{}":                              {f: dictBlockCallV2},
@@ -722,7 +723,8 @@ func init() {
 			"notEmpty": {f: arrayNotEmptyV2},
 		},
 		types.MapLike: {
-			"[]":                       {f: mapGetIndexV2},
+			"[]":                       {f: mapGetIndex},
+			"[]?":                      {f: mapGetConditionalIndex},
 			"length":                   {f: mapLengthV2},
 			"where":                    {f: mapWhereV2},
 			"$whereNot":                {f: mapWhereNotV2},

--- a/mqlc/parser/parser_test.go
+++ b/mqlc/parser/parser_test.go
@@ -71,6 +71,10 @@ func callIdent(ident string) *Call {
 	return &Call{Ident: &ident}
 }
 
+func callConditionalIdent(ident string) *Call {
+	return &Call{Ident: &ident, IsConditional: true}
+}
+
 type parserTest struct {
 	code string
 	res  *Expression
@@ -156,6 +160,10 @@ func TestParser_ParseValues(t *testing.T) {
 		{"name.last", &Expression{Operand: &Operand{
 			Value: vIdent("name"),
 			Calls: []*Call{callIdent("last")},
+		}}},
+		{"name?.last", &Expression{Operand: &Operand{
+			Value: vIdent("name"),
+			Calls: []*Call{callConditionalIdent("last")},
 		}}},
 		{"name[1]", &Expression{Operand: &Operand{
 			Value: vIdent("name"),


### PR DESCRIPTION
This introduces optional chaining in MQL. It also changes the behavior so that by default we do not blindly chain elements anymore but instead print errors when an element in the chain is `null`.

**Background**

Since MQL and cnspec are often used for security and compliance policies, we have to create a careful balance between user-comfort and precision. This means that e.g. a comparison like `user.id == 123` will work perfectly well, even if we compare strings and numbers, because the users intention is understood.

However, when chaining calls, we have so far sided on the side of comfort - maybe a bit too much. The current behavior - which is optional chaining by default - can lead to cases where the user intent is misunderstood. It's ok if an AI hallucinates (not really, but you get the point), but it's not ok for a query/policy engine to lead to such negative unexpected behaviors.

You can see a full example on display here:
https://github.com/mondoohq/cnquery/pull/6428

**Action**

The system makes all chaining mandatory non-null by default. This means that if you have json like this:

```json
{
  "a": {
    "b": "c"
  }
}
```

and called it with:

```
> parse.json('example.json').params.d.b
```

it would now produce an error:

```
> parse.json('example.json').params.d.b == "c"
[failed] parse.json.params.d.b == "c"
  error: cannot access field "b", parent element is null
```

This errors is new. It's becase the field `d` doesn't exist in this JSON.

This is where **optional chaining** comes back into the picture: It allows you to say "please don't print an error, just see if you can get the value" and thus use the previous behavior of MQL:

```
> parse.json('example.json').params.d?.b == "c"
[failed] parse.json.params.d.[]? == "c"
  expected: == "c"
  actual:   _
```

This is also in line with behaviors in JavaScript and TypeScript.

Kudos @LittleSalkin1806 for raising this issue!