### PR TITLE
🧹 Use pointer types when AWS/GCP when we can

### DIFF
--- a/providers/aws/resources/aws_dynamodb.go
+++ b/providers/aws/resources/aws_dynamodb.go
@@ -388,10 +388,10 @@ func (a *mqlAwsDynamodb) getLimits(conn *connection.AwsConnection) []*jobpool.Jo
 				map[string]*llx.RawData{
 					"arn":             llx.StringData(fmt.Sprintf(limitsArn, region, conn.AccountId())),
 					"region":          llx.StringData(region),
-					"accountMaxRead":  llx.IntData(*limitsResp.AccountMaxReadCapacityUnits),
-					"accountMaxWrite": llx.IntData(*limitsResp.AccountMaxWriteCapacityUnits),
-					"tableMaxRead":    llx.IntData(*limitsResp.TableMaxReadCapacityUnits),
-					"tableMaxWrite":   llx.IntData(*limitsResp.TableMaxWriteCapacityUnits),
+					"accountMaxRead":  llx.IntDataPtr(limitsResp.AccountMaxReadCapacityUnits),
+					"accountMaxWrite": llx.IntDataPtr(limitsResp.AccountMaxWriteCapacityUnits),
+					"tableMaxRead":    llx.IntDataPtr(limitsResp.TableMaxReadCapacityUnits),
+					"tableMaxWrite":   llx.IntDataPtr(limitsResp.TableMaxWriteCapacityUnits),
 				})
 			if err != nil {
 				return nil, err

--- a/providers/aws/resources/aws_inspector.go
+++ b/providers/aws/resources/aws_inspector.go
@@ -193,7 +193,7 @@ func (a *mqlAwsInspectorCoverage) lambda() (*mqlAwsLambdaFunction, error) {
 	if a.cacheCoverage != nil && a.cacheCoverage.ResourceMetadata != nil && a.cacheCoverage.ResourceMetadata.LambdaFunction != nil {
 		l, err := NewResource(a.MqlRuntime, "aws.lambda.function",
 			map[string]*llx.RawData{
-				"name":   llx.StringData(*a.cacheCoverage.ResourceMetadata.LambdaFunction.FunctionName),
+				"name":   llx.StringDataPtr(a.cacheCoverage.ResourceMetadata.LambdaFunction.FunctionName),
 				"region": llx.StringData(a.Region.Data),
 			})
 		if err == nil {

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -407,7 +407,7 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 			"replicationType":             llx.StringData(s.ReplicationType),
 			"settingsVersion":             llx.IntData(s.SettingsVersion),
 			"sqlServerAuditConfig":        llx.DictData(mqlSqlServerAuditCfg),
-			"storageAutoResize":           llx.BoolData(*s.StorageAutoResize),
+			"storageAutoResize":           llx.BoolDataPtr(s.StorageAutoResize),
 			"storageAutoResizeLimit":      llx.IntData(s.StorageAutoResizeLimit),
 			"tier":                        llx.StringData(s.Tier),
 			"timeZone":                    llx.StringData(s.TimeZone),


### PR DESCRIPTION
Make sure we're using the pointer types everywhere