### PR TITLE
⭐ Extend sudoers resource to support all major OS paths

### DIFF
--- a/providers/os/resources/mock_internal_test.go
+++ b/providers/os/resources/mock_internal_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"github.com/spf13/afero"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+)
+
+// mockConn implements shared.Connection with only the Asset() method populated.
+type mockConn struct {
+	asset *inventory.Asset
+}
+
+func (m *mockConn) ID() uint32                                         { return 0 }
+func (m *mockConn) ParentID() uint32                                   { return 0 }
+func (m *mockConn) RunCommand(command string) (*shared.Command, error) { return nil, nil }
+func (m *mockConn) FileInfo(path string) (shared.FileInfoDetails, error) {
+	return shared.FileInfoDetails{}, nil
+}
+func (m *mockConn) FileSystem() afero.Fs               { return nil }
+func (m *mockConn) Name() string                       { return "mock" }
+func (m *mockConn) Type() shared.ConnectionType        { return "mock" }
+func (m *mockConn) Asset() *inventory.Asset            { return m.asset }
+func (m *mockConn) UpdateAsset(asset *inventory.Asset) {}
+func (m *mockConn) Capabilities() shared.Capabilities  { return 0 }
+
+// connWithPlatform returns a mockConn with the given platform name set.
+func connWithPlatform(name string) *mockConn {
+	return &mockConn{
+		asset: &inventory.Asset{
+			Platform: &inventory.Platform{
+				Name: name,
+			},
+		},
+	}
+}

--- a/providers/os/resources/sudoers_internal_test.go
+++ b/providers/os/resources/sudoers_internal_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestSudoersPathsForPlatform(t *testing.T) {
+	tests := []struct {
+		platform string
+		expected []string
+	}{
+		{"freebsd", []string{"/usr/local/etc/sudoers"}},
+		{"dragonflybsd", []string{"/usr/local/etc/sudoers"}},
+		{"openbsd", []string{"/usr/local/etc/sudoers"}},
+		{"netbsd", []string{"/usr/pkg/etc/sudoers"}},
+		{"aix", []string{"/opt/freeware/etc/sudoers"}},
+		{"debian", []string{"/etc/sudoers"}},
+		{"ubuntu", []string{"/etc/sudoers"}},
+		{"redhat", []string{"/etc/sudoers"}},
+		{"macos", []string{"/etc/sudoers"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.platform, func(t *testing.T) {
+			assert.Equal(t, tt.expected, sudoersPathsForPlatform(connWithPlatform(tt.platform)))
+		})
+	}
+
+	t.Run("nil platform", func(t *testing.T) {
+		conn := &mockConn{asset: &inventory.Asset{}}
+		assert.Equal(t, []string{"/etc/sudoers"}, sudoersPathsForPlatform(conn))
+	})
+}

--- a/providers/os/resources/sudoers_test.go
+++ b/providers/os/resources/sudoers_test.go
@@ -11,14 +11,21 @@ import (
 )
 
 func TestResource_Sudoers(t *testing.T) {
-	// Uses the global 'x' tester from os_test.go (LinuxMock with arch.json)
-	// For parsing unit tests, see sudoers/sudoers_test.go
-
 	t.Run("files are discovered", func(t *testing.T) {
 		res := x.TestQuery(t, "sudoers.files.length")
 		require.NotEmpty(t, res)
 		require.NoError(t, res[0].Data.Error)
 		assert.Equal(t, int64(1), res[0].Data.Value)
+	})
+
+	t.Run("content aggregates all files", func(t *testing.T) {
+		res := x.TestQuery(t, "sudoers.content")
+		require.NotEmpty(t, res)
+		require.NoError(t, res[0].Data.Error)
+		content := res[0].Data.Value.(string)
+		assert.Contains(t, content, "root ALL=(ALL:ALL) ALL")
+		assert.Contains(t, content, "ADMINS ALL=(ALL) NOPASSWD: ALL")
+		assert.Contains(t, content, "Defaults secure_path=")
 	})
 
 	t.Run("userSpecs parsing", func(t *testing.T) {


### PR DESCRIPTION
Only Linux/macOS use /etc/sudoers. Make sure we find the file in the right place no matter what OS the user is on