### PR TITLE
🐛 Minor fixes and improvements to aws.ec2.instance

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -4332,8 +4332,10 @@ private aws.ec2.instance @defaults("instanceId region state instanceType archite
   iamInstanceProfile() aws.iam.instanceProfile
   // Image that was used for the instance
   image() aws.ec2.image
-  // Launch time of the instance
+  // Deprecated: use `launchedAt` instead
   launchTime time
+  // Launch time of the instance
+  launchedAt time
   // Private IP address for the instance
   privateIp string
   // Private DNS name for the instance
@@ -4342,7 +4344,7 @@ private aws.ec2.instance @defaults("instanceId region state instanceType archite
   keypair() aws.ec2.keypair
   // Time when the last state transition occurred
   stateTransitionTime time
-  // ARN of the VPC associated with the instance
+  // Deprecated: use `vpc` instead
   vpcArn string
   // Hypervisor type of the instance: ovm or xen
   hypervisor string

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -6482,6 +6482,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.instance.launchTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetLaunchTime()).ToDataRes(types.Time)
 	},
+	"aws.ec2.instance.launchedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Instance).GetLaunchedAt()).ToDataRes(types.Time)
+	},
 	"aws.ec2.instance.privateIp": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetPrivateIp()).ToDataRes(types.String)
 	},
@@ -15084,6 +15087,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.instance.launchTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Instance).LaunchTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instance.launchedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Instance).LaunchedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.instance.privateIp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -37383,6 +37390,7 @@ type mqlAwsEc2Instance struct {
 	IamInstanceProfile      plugin.TValue[*mqlAwsIamInstanceProfile]
 	Image                   plugin.TValue[*mqlAwsEc2Image]
 	LaunchTime              plugin.TValue[*time.Time]
+	LaunchedAt              plugin.TValue[*time.Time]
 	PrivateIp               plugin.TValue[string]
 	PrivateDnsName          plugin.TValue[string]
 	Keypair                 plugin.TValue[*mqlAwsEc2Keypair]
@@ -37595,6 +37603,10 @@ func (c *mqlAwsEc2Instance) GetImage() *plugin.TValue[*mqlAwsEc2Image] {
 
 func (c *mqlAwsEc2Instance) GetLaunchTime() *plugin.TValue[*time.Time] {
 	return &c.LaunchTime
+}
+
+func (c *mqlAwsEc2Instance) GetLaunchedAt() *plugin.TValue[*time.Time] {
+	return &c.LaunchedAt
 }
 
 func (c *mqlAwsEc2Instance) GetPrivateIp() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -541,6 +541,7 @@ aws.ec2.instance.instanceStatus 9.0.0
 aws.ec2.instance.instanceType 9.0.0
 aws.ec2.instance.keypair 9.0.0
 aws.ec2.instance.launchTime 9.0.0
+aws.ec2.instance.launchedAt 11.12.3
 aws.ec2.instance.networkInterfaces 11.1.0
 aws.ec2.instance.patchState 9.0.0
 aws.ec2.instance.platformDetails 9.0.0

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -694,6 +694,11 @@ func initAwsEc2Keypair(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 		if errors.As(err, &ae) {
 			if ae.ErrorCode() == "InvalidKeyPair.NotFound" {
 				log.Warn().Msgf("key %s does not exist in %s region", n, r)
+				args["fingerprint"] = llx.StringData("")
+				args["type"] = llx.StringData("")
+				args["tags"] = llx.MapData(map[string]any{}, types.String)
+				args["arn"] = llx.StringData("")
+				args["createdAt"] = llx.NilData
 				return args, nil, nil
 			}
 		}
@@ -713,6 +718,11 @@ func initAwsEc2Keypair(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 
 		return args, nil, nil
 	}
+	args["fingerprint"] = llx.StringData("")
+	args["type"] = llx.StringData("")
+	args["tags"] = llx.MapData(map[string]any{}, types.String)
+	args["arn"] = llx.StringData("")
+	args["createdAt"] = llx.NilData
 	return args, nil, nil
 }
 
@@ -1084,6 +1094,7 @@ func (a *mqlAwsEc2) gatherInstanceInfo(instances []ec2types.Instance, regionVal 
 			"instanceLifecycle":  llx.StringData(string(instance.InstanceLifecycle)),
 			"instanceType":       llx.StringData(string(instance.InstanceType)),
 			"launchTime":         llx.TimeDataPtr(instance.LaunchTime),
+			"launchedAt":         llx.TimeDataPtr(instance.LaunchTime),
 			"platformDetails":    llx.StringDataPtr(instance.PlatformDetails),
 			"privateDnsName":     llx.StringDataPtr(instance.PrivateDnsName),
 			"privateIp":          llx.StringDataPtr(instance.PrivateIpAddress),


### PR DESCRIPTION
- Don't fail when the keypair has been deleted
- Deprecate vpcArn
- Add launchedAt and deprecate launchTime