### PR TITLE
🐛 regenerate providers/defaults.go after cnquery => mql rename

### DIFF
--- a/providers/defaults.go
+++ b/providers/defaults.go
@@ -11,27 +11,14 @@ import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 // to tell users what providers are used for common connections, when there
 // is no other way to find out.
 var DefaultProviders Providers = map[string]*Provider{
-	"ai": {
-		Provider: &plugin.Provider{
-			Name:            "ai",
-			ID:              "go.mondoo.com/cnquery/providers/ai",
-			ConnectionTypes: []string{"mcp"},
-			Connectors: []plugin.Connector{
-				{
-					Name:  "mcp",
-					Use:   "mcp http://example.com",
-					Short: "Model Context Protocol Provider",
-				},
-			},
-		},
-	},
 
 	"ansible": {
 		Provider: &plugin.Provider{
 			Name:            "ansible",
-			ID:              "go.mondoo.com/cnquery/v12/providers/ansible",
+			ID:              "go.mondoo.com/mql/v13/providers/ansible",
 			ConnectionTypes: []string{"ansible"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "ansible",
 					Use:   "ansible PATH",
@@ -47,6 +34,7 @@ var DefaultProviders Providers = map[string]*Provider{
 			ID:              "go.mondoo.com/cnquery/v9/providers/arista",
 			ConnectionTypes: []string{"arista"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "arista",
 					Use:   "arista user@host",
@@ -62,6 +50,7 @@ var DefaultProviders Providers = map[string]*Provider{
 			ID:              "go.mondoo.com/cnquery/v9/providers/atlassian",
 			ConnectionTypes: []string{"atlassian", "jira", "admin", "confluence", "scim"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "atlassian",
 					Use:   "atlassian",
@@ -77,6 +66,7 @@ var DefaultProviders Providers = map[string]*Provider{
 			ID:              "go.mondoo.com/cnquery/v9/providers/aws",
 			ConnectionTypes: []string{"aws", "ebs"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "aws",
 					Use:   "aws",
@@ -92,6 +82,7 @@ var DefaultProviders Providers = map[string]*Provider{
 			ID:              "go.mondoo.com/cnquery/v9/providers/azure",
 			ConnectionTypes: []string{"azure", "azure-snapshot"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "azure",
 					Use:   "azure",
@@ -103,14 +94,15 @@ var DefaultProviders Providers = map[string]*Provider{
 
 	"cloudflare": {
 		Provider: &plugin.Provider{
-			Name:            "cloudformation",
-			ID:              "go.mondoo.com/cnquery/v12/providers/cloudformation",
-			ConnectionTypes: []string{"cloudformation"},
+			Name:            "cloudflare",
+			ID:              "go.mondoo.com/mql/v13/providers/cloudflare",
+			ConnectionTypes: []string{"cloudflare"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "cloudflare",
 					Use:   "cloudflare",
-					Short: "Cloudflare provider",
+					Short: "a Cloudflare account",
 				},
 			},
 		},
@@ -118,10 +110,11 @@ var DefaultProviders Providers = map[string]*Provider{
 
 	"cloudformation": {
 		Provider: &plugin.Provider{
-			Name:            "cloudflare",
-			ID:              "go.mondoo.com/cnquery/v12/providers/cloudflare",
-			ConnectionTypes: []string{"cloudflare"},
+			Name:            "cloudformation",
+			ID:              "go.mondoo.com/mql/v13/providers/cloudformation",
+			ConnectionTypes: []string{"cloudformation"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "cloudformation",
 					Use:   "cloudformation PATH",
@@ -146,6 +139,7 @@ var DefaultProviders Providers = map[string]*Provider{
 			ID:              "go.mondoo.com/cnquery/v9/providers/equinix",
 			ConnectionTypes: []string{"equinix"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "equinix",
 					Use:   "equinix [org <org id>] [project <project-id>] [--token <token>]",
@@ -161,6 +155,7 @@ var DefaultProviders Providers = map[string]*Provider{
 			ID:              "go.mondoo.com/cnquery/v9/providers/gcp",
 			ConnectionTypes: []string{"gcp", "gcp-snapshot"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "gcp",
 					Use:   "gcp",
@@ -176,6 +171,7 @@ var DefaultProviders Providers = map[string]*Provider{
 			ID:              "go.mondoo.com/cnquery/v9/providers/github",
 			ConnectionTypes: []string{"github"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "github",
 					Use:   "github",
@@ -191,6 +187,7 @@ var DefaultProviders Providers = map[string]*Provider{
 			ID:              "go.mondoo.com/cnquery/v9/providers/gitlab",
 			ConnectionTypes: []string{"gitlab", "gitlab-group", "gitlab-project"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "gitlab",
 					Use:   "gitlab",
@@ -206,6 +203,7 @@ var DefaultProviders Providers = map[string]*Provider{
 			ID:              "go.mondoo.com/cnquery/v9/providers/google-workspace",
 			ConnectionTypes: []string{"google-workspace"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "google-workspace",
 					Use:   "google-workspace [--credentials-path <credentials-path>] [--customer-id <customer-id>] [--impersonated-user-email <impersonated-user-email>]",
@@ -221,6 +219,7 @@ var DefaultProviders Providers = map[string]*Provider{
 			ID:              "go.mondoo.com/cnquery/providers/ipinfo",
 			ConnectionTypes: []string{"ipinfo"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "ipinfo",
 					Use:   "ipinfo",
@@ -236,6 +235,7 @@ var DefaultProviders Providers = map[string]*Provider{
 			ID:              "go.mondoo.com/cnquery/v9/providers/ipmi",
 			ConnectionTypes: []string{"ipmi"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "ipmi",
 					Use:   "ipmi USER@HOST",
@@ -251,6 +251,7 @@ var DefaultProviders Providers = map[string]*Provider{
 			ID:              "go.mondoo.com/cnquery/v9/providers/k8s",
 			ConnectionTypes: []string{"k8s"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "k8s",
 					Use:   "k8s (optional MANIFEST path)",
@@ -263,9 +264,10 @@ var DefaultProviders Providers = map[string]*Provider{
 	"mondoo": {
 		Provider: &plugin.Provider{
 			Name:            "mondoo",
-			ID:              "go.mondoo.com/cnquery/v12/providers/mondoo",
+			ID:              "go.mondoo.com/mql/v13/providers/mondoo",
 			ConnectionTypes: []string{"mondoo"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "mondoo",
 					Use:   "mondoo",
@@ -281,6 +283,7 @@ var DefaultProviders Providers = map[string]*Provider{
 			ID:              "go.mondoo.com/cnquery/v9/providers/ms365",
 			ConnectionTypes: []string{"ms365"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "ms365",
 					Use:   "ms365",
@@ -296,6 +299,7 @@ var DefaultProviders Providers = map[string]*Provider{
 			ID:              "go.mondoo.com/cnquery/v9/providers/network",
 			ConnectionTypes: []string{"host"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "host",
 					Use:   "host HOST",
@@ -308,9 +312,10 @@ var DefaultProviders Providers = map[string]*Provider{
 	"nmap": {
 		Provider: &plugin.Provider{
 			Name:            "nmap",
-			ID:              "go.mondoo.com/cnquery/v12/providers/nmap",
+			ID:              "go.mondoo.com/mql/v13/providers/nmap",
 			ConnectionTypes: []string{"nmap"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "nmap",
 					Use:   "nmap",
@@ -326,6 +331,7 @@ var DefaultProviders Providers = map[string]*Provider{
 			ID:              "go.mondoo.com/cnquery/v9/providers/oci",
 			ConnectionTypes: []string{"oci"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "oci",
 					Use:   "oci",
@@ -341,6 +347,7 @@ var DefaultProviders Providers = map[string]*Provider{
 			ID:              "go.mondoo.com/cnquery/v9/providers/okta",
 			ConnectionTypes: []string{"okta"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "okta",
 					Use:   "okta",
@@ -356,6 +363,7 @@ var DefaultProviders Providers = map[string]*Provider{
 			ID:              "go.mondoo.com/cnquery/v9/providers/opcua",
 			ConnectionTypes: []string{"opcua"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "opcua",
 					Use:   "opcua [--endpoint <endpoint>]",
@@ -371,6 +379,7 @@ var DefaultProviders Providers = map[string]*Provider{
 			ID:              "go.mondoo.com/cnquery/v9/providers/os",
 			ConnectionTypes: []string{"local", "ssh", "tar", "docker-snapshot", "vagrant", "docker-container", "docker-image", "docker-file", "docker-registry", "container-registry", "registry-image", "filesystem", "winrm", "device"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "local",
 					Use:   "local",
@@ -425,9 +434,10 @@ var DefaultProviders Providers = map[string]*Provider{
 	"shodan": {
 		Provider: &plugin.Provider{
 			Name:            "shodan",
-			ID:              "go.mondoo.com/cnquery/v12/providers/shodan",
+			ID:              "go.mondoo.com/mql/v13/providers/shodan",
 			ConnectionTypes: []string{"shodan"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "shodan",
 					Use:   "shodan",
@@ -443,6 +453,7 @@ var DefaultProviders Providers = map[string]*Provider{
 			ID:              "go.mondoo.com/cnquery/v9/providers/slack",
 			ConnectionTypes: []string{"slack"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "slack",
 					Use:   "slack",
@@ -455,9 +466,10 @@ var DefaultProviders Providers = map[string]*Provider{
 	"snowflake": {
 		Provider: &plugin.Provider{
 			Name:            "snowflake",
-			ID:              "go.mondoo.com/cnquery/v12/providers/snowflake",
+			ID:              "go.mondoo.com/mql/v13/providers/snowflake",
 			ConnectionTypes: []string{"snowflake"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "snowflake",
 					Use:   "snowflake",
@@ -470,9 +482,10 @@ var DefaultProviders Providers = map[string]*Provider{
 	"tailscale": {
 		Provider: &plugin.Provider{
 			Name:            "tailscale",
-			ID:              "go.mondoo.com/cnquery/v12/providers/tailscale",
+			ID:              "go.mondoo.com/mql/v13/providers/tailscale",
 			ConnectionTypes: []string{"tailscale"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "tailscale",
 					Use:   "tailscale",
@@ -486,8 +499,9 @@ var DefaultProviders Providers = map[string]*Provider{
 		Provider: &plugin.Provider{
 			Name:            "terraform",
 			ID:              "go.mondoo.com/cnquery/v9/providers/terraform",
-			ConnectionTypes: []string{},
+			ConnectionTypes: []string{"terraform-state", "terraform-plan", "terraform-hcl", "terraform-hcl-git"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "terraform",
 					Use:   "terraform PATH",
@@ -503,6 +517,7 @@ var DefaultProviders Providers = map[string]*Provider{
 			ID:              "go.mondoo.com/cnquery/v9/providers/vcd",
 			ConnectionTypes: []string{"vcd"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "vcd",
 					Use:   "vcd [--user <user>] [--host <host>] [--organization <organization>] [--ask-pass] [--password <password>]",
@@ -518,85 +533,13 @@ var DefaultProviders Providers = map[string]*Provider{
 			ID:              "go.mondoo.com/cnquery/v9/providers/vsphere",
 			ConnectionTypes: []string{"vsphere"},
 			Connectors: []plugin.Connector{
+
 				{
 					Name:  "vsphere",
 					Use:   "vsphere user@host",
 					Short: "a VMware vSphere installation",
 				},
 			},
-		},
-	},
-	"networkdiscovery": {
-		Provider: &plugin.Provider{
-			Name:            "networkdiscovery",
-			ID:              "go.mondoo.com/cnquery/providers/networkdiscovery",
-			ConnectionTypes: []string{"networkdiscovery"},
-			CrossProviderTypes: []string{
-				"go.mondoo.com/cnquery/providers/network",
-				"go.mondoo.com/cnquery/v12/providers/network",
-			},
-			Connectors: []plugin.Connector{
-				{
-					Name:  "networkdiscovery",
-					Use:   "networkdiscovery DOMAIN_NAME",
-					Short: "Discover subdomains for a given domain.",
-				},
-			},
-		},
-	},
-	"networkdevices": {
-		Provider: &plugin.Provider{
-			Name:            "networkdevices",
-			ID:              "go.mondoo.com/cnquery/providers/networkdevices",
-			ConnectionTypes: []string{"nd-ssh", "ciscocatalyst"},
-			Connectors: []plugin.Connector{
-				{
-					Name:  "ciscocatalyst",
-					Use:   "ciscocatalyst hostname",
-					Short: "Cisco Catalyst Connection",
-				},
-				{
-					Name:  "nd-ssh",
-					Use:   "nd-ssh user@host",
-					Short: "a remote network device via SSH",
-				},
-			},
-		},
-	},
-	"fortios": {
-		Provider: &plugin.Provider{
-			Name:            "fortios",
-			ID:              "go.mondoo.com/cnquery/providers/fortios",
-			ConnectionTypes: []string{"fortios"},
-			Connectors: []plugin.Connector{
-				{
-					Name:  "fortios",
-					Use:   "fortios",
-					Short: "a remote FortiOS system",
-				},
-			},
-		},
-	},
-	"panos": {
-		Provider: &plugin.Provider{
-			Name:            "panos",
-			ID:              "go.mondoo.com/cnquery/providers/panos",
-			ConnectionTypes: []string{"panos"},
-			Connectors: []plugin.Connector{
-				{
-					Name:  "panos",
-					Use:   "panos",
-					Short: "a remote PAN-OS system",
-				},
-			},
-		},
-	},
-	"yara": {
-		Provider: &plugin.Provider{
-			Name:            "yara",
-			ID:              "go.mondoo.com/cnquery/providers/yara",
-			ConnectionTypes: []string(nil),
-			Connectors:      []plugin.Connector{},
 		},
 	},
 }


### PR DESCRIPTION
## Problem

The nightly policy linter in [cnspec-enterprise-policies](https://github.com/mondoohq/cnspec-enterprise-policies/actions/runs/22386466257) is failing with **26 `bundle-unknown-field` errors** like:

```
cannot find installed provider for id=go.mondoo.com/cnquery/v12/providers/shodan
```

### Root cause

PR #6599 (`cnquery => mql`) changed provider IDs in `config.go` files from `go.mondoo.com/cnquery/v12/providers/X` to `go.mondoo.com/mql/v13/providers/X`, but `providers/defaults.go` was **not regenerated**. The stale string constants in `defaults.go` still reference the old `cnquery/v12` IDs.

The nightly CI builds edge providers (which register with new `mql/v13` IDs) but `cnspec-latest` resolves provider requirements using the default IDs. Since the defaults say `cnquery/v12` but the installed providers have `mql/v13`, the linter reports 26 missing-provider errors.

### Fix

Run `make providers/defaults` to regenerate from actual `config.go` files.

### Changes

| Category | Details |
|----------|---------|
| **ID updates** | 8 providers updated: ansible, cloudflare, cloudformation, mondoo, nmap, shodan, snowflake, tailscale (`cnquery/v12` → `mql/v13`) |
| **Bug fix** | Swapped cloudflare/cloudformation `Name` fields corrected |
| **Bug fix** | terraform `ConnectionTypes` updated from empty to actual types |
| **Cleanup** | Removed enterprise providers (`ai`, `networkdiscovery`, `networkdevices`, `fortios`, `panos`, `yara`) that were manually appended to this auto-generated file; these live in `cnquery-enterprise-providers`, not `cnquery` |

### Verification

- `go build ./providers/` compiles clean
- All 8 previously-stale IDs now match their respective `config.go` files
- Older providers (aws, azure, gcp, etc.) retain their original `v9` IDs unchanged