### PR TITLE
✨ Add NetScout Hardened OS platform detection

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -384,6 +384,18 @@ var qubes = &PlatformResolver{
 	},
 }
 
+var netscoutHardenedOS = &PlatformResolver{
+	Name:     "netscout-hardened-os",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		if pf.Name == "NetScout Hardened OS" {
+			pf.Name = "netscout-hardened-os"
+			return true, nil
+		}
+		return false, nil
+	},
+}
+
 var tails = &PlatformResolver{
 	Name:     "tails",
 	IsFamily: false,
@@ -1082,7 +1094,7 @@ var redhatFamily = &PlatformResolver{
 	IsFamily: true,
 	// NOTE: oracle pretends to be redhat with /etc/redhat-release and Red Hat Linux, therefore we
 	// want to check that platform before redhat
-	Children: []*PlatformResolver{oracle, rhel, centos, fedora, scientific, eurolinux, nobara, qubes},
+	Children: []*PlatformResolver{oracle, rhel, centos, fedora, scientific, eurolinux, nobara, qubes, netscoutHardenedOS},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		f, err := conn.FileSystem().Open("/etc/redhat-release")
 		if err != nil {

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -1134,6 +1134,17 @@ func TestKDENeonDetector(t *testing.T) {
 	assert.Equal(t, []string{"debian", "linux", "unix", "os"}, di.Family)
 }
 
+func TestNetscoutHardenedOSDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-netscout-hardened-os.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "netscout-hardened-os", di.Name, "os name should be identified")
+	assert.Equal(t, "NetScout Hardened OS", di.Title, "os title should be identified")
+	assert.Equal(t, "20", di.Version, "os version should be identified")
+	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"redhat", "linux", "unix", "os"}, di.Family)
+}
+
 func TestQubesOSDetector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-qubes.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/testdata/detect-netscout-hardened-os.toml
+++ b/providers/os/detector/testdata/detect-netscout-hardened-os.toml
@@ -1,0 +1,37 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "3.11.10-301.fc20.x86_64"
+
+[files."/etc/fedora-release"]
+content = "NetScout Hardened OS 20"
+
+[files."/etc/redhat-release"]
+content = "NetScout Hardened OS 20"
+
+[files."/etc/system-release"]
+content = "NetScout Hardened OS 20"
+
+[files."/etc/system-release-cpe"]
+content = "cpe:/o:fedoraproject:fedora:20"
+
+[files."/etc/os-release"]
+content = """
+NAME="NetScout Hardened OS"
+VERSION="20"
+ID="NetScout Hardened OS"
+VERSION_ID=20
+PRETTY_NAME="NetScout Hardened OS"
+ANSI_COLOR="0;34"
+CPE_NAME="cpe:/o:fedoraproject:fedora:20"
+HOME_URL="https://fedoraproject.org/"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
+REDHAT_BUGZILLA_PRODUCT="Fedora"
+REDHAT_BUGZILLA_PRODUCT_VERSION=20
+REDHAT_SUPPORT_PRODUCT="Fedora"
+REDHAT_SUPPORT_PRODUCT_VERSION=20
+"""


### PR DESCRIPTION
Detect NetScout Hardened OS as netscout-hardened-os in the redhat family.