### PR TITLE
🧹 Deprecate aws.ec2.image arn field

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -5166,7 +5166,7 @@ private aws.ec2.keypair @defaults("name type region") {
 
 // Amazon EC2 image (AMI)
 private aws.ec2.image @defaults("ownerAlias id name") {
-  // ARN for the AMI
+  // Deprecated: AMIs do not have ARNs. Use `id` instead.
   arn string
   // ID of the image
   id string


### PR DESCRIPTION
## Summary
- AMIs do not have ARNs, only AMI IDs. Marks the `arn` field on `aws.ec2.image` as deprecated, directing users to use the `id` field instead.
- The field remains functional for backward compatibility and can be fully removed in v13.

Fixes #6358

## Test plan
- [ ] Verify `aws.ec2.image { arn }` still returns data (backward compat)
- [ ] Verify `aws.ec2.image { id }` returns the AMI ID
- [ ] Confirm deprecation comment appears in generated docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)