### PR TITLE
✨ Add platform detection for LEDE Linux

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -783,6 +783,17 @@ var mxlinux = &PlatformResolver{
 	},
 }
 
+var lede = &PlatformResolver{
+	Name:     "lede",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		if pf.Name == "lede" {
+			return true, nil
+		}
+		return false, nil
+	},
+}
+
 var openwrt = &PlatformResolver{
 	Name:     "openwrt",
 	IsFamily: false,
@@ -1190,7 +1201,7 @@ var eulerFamily = &PlatformResolver{
 var linuxFamily = &PlatformResolver{
 	Name:     inventory.FAMILY_LINUX,
 	IsFamily: true,
-	Children: []*PlatformResolver{archFamily, redhatFamily, debianFamily, suseFamily, eulerFamily, bottlerocket, amazonlinux, alpine, gentoo, busybox, photon, windriver, openwrt, plcnext, mageia, azurelinux, flatcar, defaultLinux},
+	Children: []*PlatformResolver{archFamily, redhatFamily, debianFamily, suseFamily, eulerFamily, bottlerocket, amazonlinux, alpine, gentoo, busybox, photon, windriver, lede, openwrt, plcnext, mageia, azurelinux, flatcar, defaultLinux},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		detected := false
 		osrd := NewOSReleaseDetector(conn)

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -322,6 +322,17 @@ func TestPoposDetector(t *testing.T) {
 	assert.Equal(t, []string{"debian", "linux", "unix", "os"}, di.Family)
 }
 
+func TestLedeDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-lede.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "lede", di.Name, "os name should be identified")
+	assert.Equal(t, "LEDE Reboot 17.01.6", di.Title, "os title should be identified")
+	assert.Equal(t, "17.01.6", di.Version, "os version should be identified")
+	assert.Equal(t, "aarch64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
+}
+
 func TestOpenWrtDetector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-openwrt.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/testdata/detect-lede.toml
+++ b/providers/os/detector/testdata/detect-lede.toml
@@ -1,0 +1,30 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "aarch64"
+
+[commands."uname -r"]
+stdout = "4.4.198"
+
+[files."/etc/os-release"]
+content = """
+NAME="LEDE"
+VERSION="17.01.6, Reboot"
+ID="lede"
+ID_LIKE="lede openwrt"
+PRETTY_NAME="LEDE Reboot 17.01.6"
+VERSION_ID="17.01.6"
+HOME_URL="http://lede-project.org/"
+BUG_URL="http://bugs.lede-project.org/"
+SUPPORT_URL="http://forum.lede-project.org/"
+BUILD_ID="r3979-2252731af4"
+LEDE_BOARD="mtk/mt7622"
+LEDE_ARCH="aarch64_cortex-a53_neon-vfpv4"
+LEDE_TAINTS="no-all mklibs busybox"
+LEDE_DEVICE_MANUFACTURER="LEDE"
+LEDE_DEVICE_MANUFACTURER_URL="http://lede-project.org/"
+LEDE_DEVICE_PRODUCT="Generic"
+LEDE_DEVICE_REVISION="v0"
+LEDE_RELEASE="LEDE Reboot 17.01.6 r3979-2252731af4"
+"""


### PR DESCRIPTION
## Summary
- Add LEDE (Linux Embedded Development Environment) as a recognized Linux distribution in the OS provider platform detector
- LEDE is the predecessor to OpenWrt, commonly found on Ubiquiti access points
- Detection works via the `ID="lede"` field in `/etc/os-release`

Closes #35

## Test plan
- [x] `TestLedeDetector` passes — detects LEDE 17.01.6 on aarch64
- [x] `TestOpenWrtDetector` still passes — no regression
- [ ] Verify on a real LEDE device if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)