### PR TITLE
✨ Add shieldedInstanceConfig sub-resource to gcp.compute.instance

### DIFF
--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -542,10 +542,21 @@ func newMqlComputeServiceInstance(projectId string, zone *mqlGcpProjectComputeSe
 	var enableIntegrityMonitoring bool
 	var enableSecureBoot bool
 	var enableVtpm bool
+	var mqlShieldedInstanceConfig plugin.Resource
 	if instance.ShieldedInstanceConfig != nil {
 		enableIntegrityMonitoring = instance.ShieldedInstanceConfig.EnableIntegrityMonitoring
 		enableSecureBoot = instance.ShieldedInstanceConfig.EnableSecureBoot
 		enableVtpm = instance.ShieldedInstanceConfig.EnableVtpm
+		var err error
+		mqlShieldedInstanceConfig, err = CreateResource(runtime, "gcp.project.computeService.instance.shieldedInstanceConfig", map[string]*llx.RawData{
+			"id":                        llx.StringData(fmt.Sprintf("%d/shieldedInstanceConfig", instance.Id)),
+			"enableIntegrityMonitoring": llx.BoolData(enableIntegrityMonitoring),
+			"enableSecureBoot":          llx.BoolData(enableSecureBoot),
+			"enableVtpm":                llx.BoolData(enableVtpm),
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var enableDisplay bool
@@ -630,6 +641,7 @@ func newMqlComputeServiceInstance(projectId string, zone *mqlGcpProjectComputeSe
 		"resourcePolicies":           llx.ArrayData(convert.SliceAnyToInterface(instance.ResourcePolicies), types.String),
 		"physicalHostResourceStatus": llx.StringData(physicalHost),
 		"scheduling":                 llx.DictData(scheduling),
+		"shieldedInstanceConfig":     llx.ResourceData(mqlShieldedInstanceConfig, "gcp.project.computeService.instance.shieldedInstanceConfig"),
 		"enableIntegrityMonitoring":  llx.BoolData(enableIntegrityMonitoring),
 		"enableSecureBoot":           llx.BoolData(enableSecureBoot),
 		"enableVtpm":                 llx.BoolData(enableVtpm),

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -769,11 +769,13 @@ private gcp.project.computeService.instance @defaults("name") {
   physicalHostResourceStatus string
   // Scheduling options including preemptibility, automatic restart, and maintenance behavior
   scheduling dict
-  // Whether Shielded Instance integrity monitoring is enabled
+  // Shielded Instance configuration
+  shieldedInstanceConfig gcp.project.computeService.instance.shieldedInstanceConfig
+  // Deprecated: Use shieldedInstanceConfig.enableIntegrityMonitoring instead
   enableIntegrityMonitoring bool
-  // Whether Shielded Instance secure boot is enabled
+  // Deprecated: Use shieldedInstanceConfig.enableSecureBoot instead
   enableSecureBoot bool
-  // Whether Shielded Instance vTPM is enabled
+  // Deprecated: Use shieldedInstanceConfig.enableVtpm instead
   enableVtpm bool
   // Whether VM has been restricted from starting because Compute Engine has detected suspicious activity
   startRestricted bool
@@ -795,6 +797,18 @@ private gcp.project.computeService.instance @defaults("name") {
   machineType() gcp.project.computeService.machineType
   // Instance zone
   zone gcp.project.computeService.zone
+}
+
+// Google Cloud (GCP) Compute Shielded Instance configuration
+private gcp.project.computeService.instance.shieldedInstanceConfig @defaults("enableSecureBoot enableVtpm") {
+  // Internal ID
+  id string
+  // Whether integrity monitoring is enabled
+  enableIntegrityMonitoring bool
+  // Whether secure boot is enabled
+  enableSecureBoot bool
+  // Whether vTPM is enabled
+  enableVtpm bool
 }
 
 // Google Cloud (GCP) Compute service account

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -43,6 +43,7 @@ const (
 	ResourceGcpProjectComputeServiceZone                                              string = "gcp.project.computeService.zone"
 	ResourceGcpProjectComputeServiceMachineType                                       string = "gcp.project.computeService.machineType"
 	ResourceGcpProjectComputeServiceInstance                                          string = "gcp.project.computeService.instance"
+	ResourceGcpProjectComputeServiceInstanceShieldedInstanceConfig                    string = "gcp.project.computeService.instance.shieldedInstanceConfig"
 	ResourceGcpProjectComputeServiceServiceaccount                                    string = "gcp.project.computeService.serviceaccount"
 	ResourceGcpProjectComputeServiceDisk                                              string = "gcp.project.computeService.disk"
 	ResourceGcpProjectComputeServiceAttachedDisk                                      string = "gcp.project.computeService.attachedDisk"
@@ -297,6 +298,10 @@ func init() {
 		"gcp.project.computeService.instance": {
 			Init:   initGcpProjectComputeServiceInstance,
 			Create: createGcpProjectComputeServiceInstance,
+		},
+		"gcp.project.computeService.instance.shieldedInstanceConfig": {
+			// to override args, implement: initGcpProjectComputeServiceInstanceShieldedInstanceConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGcpProjectComputeServiceInstanceShieldedInstanceConfig,
 		},
 		"gcp.project.computeService.serviceaccount": {
 			// to override args, implement: initGcpProjectComputeServiceServiceaccount(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -1921,6 +1926,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.instance.scheduling": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetScheduling()).ToDataRes(types.Dict)
 	},
+	"gcp.project.computeService.instance.shieldedInstanceConfig": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstance).GetShieldedInstanceConfig()).ToDataRes(types.Resource("gcp.project.computeService.instance.shieldedInstanceConfig"))
+	},
 	"gcp.project.computeService.instance.enableIntegrityMonitoring": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetEnableIntegrityMonitoring()).ToDataRes(types.Bool)
 	},
@@ -1959,6 +1967,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.instance.zone": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetZone()).ToDataRes(types.Resource("gcp.project.computeService.zone"))
+	},
+	"gcp.project.computeService.instance.shieldedInstanceConfig.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig).GetId()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.instance.shieldedInstanceConfig.enableIntegrityMonitoring": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig).GetEnableIntegrityMonitoring()).ToDataRes(types.Bool)
+	},
+	"gcp.project.computeService.instance.shieldedInstanceConfig.enableSecureBoot": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig).GetEnableSecureBoot()).ToDataRes(types.Bool)
+	},
+	"gcp.project.computeService.instance.shieldedInstanceConfig.enableVtpm": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig).GetEnableVtpm()).ToDataRes(types.Bool)
 	},
 	"gcp.project.computeService.serviceaccount.email": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceServiceaccount).GetEmail()).ToDataRes(types.String)
@@ -7386,6 +7406,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceInstance).Scheduling, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.instance.shieldedInstanceConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstance).ShieldedInstanceConfig, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.instance.enableIntegrityMonitoring": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstance).EnableIntegrityMonitoring, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -7436,6 +7460,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.instance.zone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstance).Zone, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceZone](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.instance.shieldedInstanceConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig).__id, ok = v.Value.(string)
+		return
+	},
+	"gcp.project.computeService.instance.shieldedInstanceConfig.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.instance.shieldedInstanceConfig.enableIntegrityMonitoring": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig).EnableIntegrityMonitoring, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.instance.shieldedInstanceConfig.enableSecureBoot": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig).EnableSecureBoot, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.instance.shieldedInstanceConfig.enableVtpm": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig).EnableVtpm, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.serviceaccount.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16834,6 +16878,7 @@ type mqlGcpProjectComputeServiceInstance struct {
 	ResourcePolicies           plugin.TValue[[]any]
 	PhysicalHostResourceStatus plugin.TValue[string]
 	Scheduling                 plugin.TValue[any]
+	ShieldedInstanceConfig     plugin.TValue[*mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig]
 	EnableIntegrityMonitoring  plugin.TValue[bool]
 	EnableSecureBoot           plugin.TValue[bool]
 	EnableVtpm                 plugin.TValue[bool]
@@ -16990,6 +17035,10 @@ func (c *mqlGcpProjectComputeServiceInstance) GetScheduling() *plugin.TValue[any
 	return &c.Scheduling
 }
 
+func (c *mqlGcpProjectComputeServiceInstance) GetShieldedInstanceConfig() *plugin.TValue[*mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig] {
+	return &c.ShieldedInstanceConfig
+}
+
 func (c *mqlGcpProjectComputeServiceInstance) GetEnableIntegrityMonitoring() *plugin.TValue[bool] {
 	return &c.EnableIntegrityMonitoring
 }
@@ -17052,6 +17101,65 @@ func (c *mqlGcpProjectComputeServiceInstance) GetMachineType() *plugin.TValue[*m
 
 func (c *mqlGcpProjectComputeServiceInstance) GetZone() *plugin.TValue[*mqlGcpProjectComputeServiceZone] {
 	return &c.Zone
+}
+
+// mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig for the gcp.project.computeService.instance.shieldedInstanceConfig resource
+type mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlGcpProjectComputeServiceInstanceShieldedInstanceConfigInternal it will be used here
+	Id                        plugin.TValue[string]
+	EnableIntegrityMonitoring plugin.TValue[bool]
+	EnableSecureBoot          plugin.TValue[bool]
+	EnableVtpm                plugin.TValue[bool]
+}
+
+// createGcpProjectComputeServiceInstanceShieldedInstanceConfig creates a new instance of this resource
+func createGcpProjectComputeServiceInstanceShieldedInstanceConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("gcp.project.computeService.instance.shieldedInstanceConfig", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig) MqlName() string {
+	return "gcp.project.computeService.instance.shieldedInstanceConfig"
+}
+
+func (c *mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig) GetEnableIntegrityMonitoring() *plugin.TValue[bool] {
+	return &c.EnableIntegrityMonitoring
+}
+
+func (c *mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig) GetEnableSecureBoot() *plugin.TValue[bool] {
+	return &c.EnableSecureBoot
+}
+
+func (c *mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig) GetEnableVtpm() *plugin.TValue[bool] {
+	return &c.EnableVtpm
 }
 
 // mqlGcpProjectComputeServiceServiceaccount for the gcp.project.computeService.serviceaccount resource

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -717,6 +717,11 @@ gcp.project.computeService.instance.reservationAffinity 9.0.0
 gcp.project.computeService.instance.resourcePolicies 9.0.0
 gcp.project.computeService.instance.scheduling 9.0.0
 gcp.project.computeService.instance.serviceAccounts 9.0.0
+gcp.project.computeService.instance.shieldedInstanceConfig 11.6.3
+gcp.project.computeService.instance.shieldedInstanceConfig.enableIntegrityMonitoring 11.6.3
+gcp.project.computeService.instance.shieldedInstanceConfig.enableSecureBoot 11.6.3
+gcp.project.computeService.instance.shieldedInstanceConfig.enableVtpm 11.6.3
+gcp.project.computeService.instance.shieldedInstanceConfig.id 11.6.3
 gcp.project.computeService.instance.sourceMachineImage 9.0.0
 gcp.project.computeService.instance.startRestricted 9.0.0
 gcp.project.computeService.instance.status 9.0.0


### PR DESCRIPTION
## Summary
- Add `gcp.project.computeService.instance.shieldedInstanceConfig` sub-resource with `enableVtpm`, `enableSecureBoot`, and `enableIntegrityMonitoring` fields
- Matches the Google API / Terraform structure and existing patterns in GKE and Dataproc
- Existing inline fields on the instance are preserved but marked as deprecated for backward compatibility

Closes #5488

## Test plan
- [ ] `cd providers/gcp && go build ./...` compiles
- [ ] `mql run gcp -c "gcp.compute.instances { shieldedInstanceConfig { * } }"` returns config data
- [ ] `mql run gcp -c "gcp.compute.instances { enableVtpm }"` still works (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)