### PR TITLE
🐛 Handle unsupported Docker image manifest types gracefully

### DIFF
--- a/providers/os/connection/container/image/registry.go
+++ b/providers/os/connection/container/image/registry.go
@@ -4,6 +4,9 @@
 package image
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -23,6 +26,9 @@ func LoadImageFromRegistry(ref name.Reference, opts ...remote.Option) (v1.Image,
 	}
 	img, err := remote.Image(ref, opts...)
 	if err != nil {
+		if errors.Is(err, remote.ErrSchema1) {
+			return nil, fmt.Errorf("the container image %q uses Docker schema1 manifests which are no longer supported, try upgrading the image to a newer version", ref.Name())
+		}
 		return nil, err
 	}
 	return img, nil


### PR DESCRIPTION
## Summary
- Catch `remote.ErrSchema1` from go-containerregistry when loading remote container images
- Replace the raw library error (which includes a link to `go-containerregistry/issues/377`) with a clear, user-friendly message explaining the image uses unsupported Docker schema1 manifests
- Before: `unsupported MediaType: "application/vnd.docker.distribution.manifest.v1+prettyjws", see https://github.com/google/go-containerregistry/issues/377`
- After: `the container image "..." uses Docker schema1 manifests which are no longer supported, try upgrading the image to a newer version`

Closes #5151

## Test plan
- [ ] `cd providers/os && go build ./...` compiles
- [ ] Scan a schema1-only image (e.g. `nginx:1.7.11`) and verify the improved error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)