### PR TITLE
🧹 Rename github connection Hash to OptionsHash

### DIFF
--- a/providers/github/connection/connection.go
+++ b/providers/github/connection/connection.go
@@ -41,7 +41,7 @@ type GithubConnection struct {
 	ctx    context.Context
 
 	// Used to avoid verifying a client with the same options more than once
-	Hash uint64
+	OptionsHash uint64
 }
 
 type githubConnectionOptions struct {
@@ -127,11 +127,11 @@ func NewGithubConnection(id uint32, asset *inventory.Asset) (*GithubConnection, 
 	hash, err := hashstructure.Hash(connectionOpts, hashstructure.FormatV2, nil)
 
 	return &GithubConnection{
-		Connection: plugin.NewConnection(id, asset),
-		asset:      asset,
-		client:     client,
-		ctx:        ctx,
-		Hash:       hash,
+		Connection:  plugin.NewConnection(id, asset),
+		asset:       asset,
+		client:      client,
+		ctx:         ctx,
+		OptionsHash: hash,
 	}, nil
 }
 

--- a/providers/github/provider/provider.go
+++ b/providers/github/provider/provider.go
@@ -186,7 +186,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 		}
 
 		// verify the connection only once
-		_, _, err = s.Memoize(fmt.Sprintf("conn_%d", conn.Hash), func() (any, error) {
+		_, _, err = s.Memoize(fmt.Sprintf("conn_%d", conn.OptionsHash), func() (any, error) {
 			log.Debug().Msg("verifying github connection client")
 			err := conn.Verify()
 			return nil, err


### PR DESCRIPTION
## Summary
- Renames `GithubConnection.Hash` to `GithubConnection.OptionsHash` to clarify its purpose — it stores a hash of the connection options used to deduplicate client verification.
- Requested in code review on #4980.

Closes #4995

## Test plan
- [x] `go build ./...` passes for the GitHub provider
- [x] gofmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)