### PR TITLE
⭐ OCI: Add --profile and --config-file flags, fix --region parsing

### DIFF
--- a/providers/oci/config/config.go
+++ b/providers/oci/config/config.go
@@ -24,6 +24,8 @@ var Config = plugin.Provider{
 Examples:
   cnquery shell oci --tenancy <tenancy_ocid> --user <user_ocid> --region <region> --key-path <path_to_private_key> --fingerprint <key_fingerprint>
   cnspec scan oci --tenancy <tenancy_ocid> --user <user_ocid> --region <region> --key-path <path_to_private_key> --fingerprint <key_fingerprint>
+  cnquery shell oci --profile MYPROFILE
+  cnquery shell oci --config-file /path/to/config --profile MYPROFILE
 `,
 			Discovery: []string{},
 			Flags: []plugin.Flag{
@@ -62,6 +64,18 @@ Examples:
 					Type:    plugin.FlagType_String,
 					Default: "",
 					Desc:    "Passphrase for the private key file, if encrypted",
+				},
+				{
+					Long:    "profile",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "OCI config profile name (e.g., DEFAULT)",
+				},
+				{
+					Long:    "config-file",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "Path to OCI config file (default: ~/.oci/config)",
 				},
 			},
 		},

--- a/providers/oci/connection/connection.go
+++ b/providers/oci/connection/connection.go
@@ -28,7 +28,10 @@ func NewOciConnection(id uint32, asset *inventory.Asset, conf *inventory.Config)
 	}
 
 	// initialize your connection here
-	var configProvider common.ConfigurationProvider
+	var (
+		configProvider common.ConfigurationProvider
+		err            error
+	)
 	// if we have passed in credentials, assume we want to pass in all values explicitly.
 	if len(conf.Credentials) > 0 {
 		fingerprint := conf.Options["fingerprint"]
@@ -54,7 +57,19 @@ func NewOciConnection(id uint32, asset *inventory.Asset, conf *inventory.Config)
 		}
 		configProvider = common.NewRawConfigurationProvider(tenancyOcid, userOcid, region, fingerprint, string(pkey.Secret), nil)
 	} else {
-		configProvider = common.DefaultConfigProvider()
+		profile := conf.Options["profile"]
+		configFile := conf.Options["config-file"]
+		if profile != "" || configFile != "" {
+			if profile == "" {
+				profile = "DEFAULT"
+			}
+			configProvider, err = common.ConfigurationProviderFromFileWithProfile(configFile, profile, "")
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			configProvider = common.DefaultConfigProvider()
+		}
 	}
 	tenancyOcid, err := configProvider.TenancyOCID()
 	if err != nil {

--- a/providers/oci/provider/provider.go
+++ b/providers/oci/provider/provider.go
@@ -53,7 +53,7 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	}
 
 	region := ""
-	if x, ok := flags["user"]; ok && len(x.Value) != 0 {
+	if x, ok := flags["region"]; ok && len(x.Value) != 0 {
 		region = string(x.Value)
 	}
 
@@ -72,6 +72,16 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		keySecret = string(x.Value)
 	}
 
+	profile := ""
+	if x, ok := flags["profile"]; ok && len(x.Value) != 0 {
+		profile = string(x.Value)
+	}
+
+	configFile := ""
+	if x, ok := flags["config-file"]; ok && len(x.Value) != 0 {
+		configFile = string(x.Value)
+	}
+
 	if tenancy != "" {
 		conf.Options["tenancy"] = tenancy
 	}
@@ -83,6 +93,12 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	}
 	if user != "" {
 		conf.Options["user"] = user
+	}
+	if profile != "" {
+		conf.Options["profile"] = profile
+	}
+	if configFile != "" {
+		conf.Options["config-file"] = configFile
 	}
 
 	if keyPath != "" {


### PR DESCRIPTION
## Summary
- **Bug fix**: `--region` flag was broken — `ParseCLI` read `flags["user"]` instead of `flags["region"]`
- **New flag**: `--profile` to select an OCI config profile (uses `ConfigurationProviderFromFileWithProfile` from the OCI SDK)
- **New flag**: `--config-file` to specify a custom OCI config file path (default: `~/.oci/config`)

Closes #4499

## Test plan
- [ ] `go build ./...` passes for the OCI provider
- [ ] `mql shell oci` works with default config (no flags)
- [ ] `mql shell oci --region us-ashburn-1` correctly passes the region
- [ ] `mql shell oci --profile MYPROFILE` reads the named profile
- [ ] `mql shell oci --config-file /path/to/config` reads the custom config file

🤖 Generated with [Claude Code](https://claude.com/claude-code)