### PR TITLE
🐛 Fix ms365 Teams blockedDomains returning empty value

### DIFF
--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -1942,7 +1942,7 @@ private ms365.teams.tenantFederationConfig {
   // ID of the collection of tenant federation configuration settings
   identity string
   // Blocked domains
-  blockedDomains dict
+  blockedDomains []string
   // Allowed domains
   allowedDomains []string
   // Whether federated users are allowed

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -2906,7 +2906,7 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlMs365TeamsTenantFederationConfig).GetIdentity()).ToDataRes(types.String)
 	},
 	"ms365.teams.tenantFederationConfig.blockedDomains": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlMs365TeamsTenantFederationConfig).GetBlockedDomains()).ToDataRes(types.Dict)
+		return (r.(*mqlMs365TeamsTenantFederationConfig).GetBlockedDomains()).ToDataRes(types.Array(types.String))
 	},
 	"ms365.teams.tenantFederationConfig.allowedDomains": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMs365TeamsTenantFederationConfig).GetAllowedDomains()).ToDataRes(types.Array(types.String))
@@ -6413,7 +6413,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"ms365.teams.tenantFederationConfig.blockedDomains": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlMs365TeamsTenantFederationConfig).BlockedDomains, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		r.(*mqlMs365TeamsTenantFederationConfig).BlockedDomains, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"ms365.teams.tenantFederationConfig.allowedDomains": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15940,7 +15940,7 @@ type mqlMs365TeamsTenantFederationConfig struct {
 	__id       string
 	// optional: if you define mqlMs365TeamsTenantFederationConfigInternal it will be used here
 	Identity                                    plugin.TValue[string]
-	BlockedDomains                              plugin.TValue[any]
+	BlockedDomains                              plugin.TValue[[]any]
 	AllowedDomains                              plugin.TValue[[]any]
 	AllowFederatedUsers                         plugin.TValue[bool]
 	AllowPublicUsers                            plugin.TValue[bool]
@@ -15988,7 +15988,7 @@ func (c *mqlMs365TeamsTenantFederationConfig) GetIdentity() *plugin.TValue[strin
 	return &c.Identity
 }
 
-func (c *mqlMs365TeamsTenantFederationConfig) GetBlockedDomains() *plugin.TValue[any] {
+func (c *mqlMs365TeamsTenantFederationConfig) GetBlockedDomains() *plugin.TValue[[]any] {
 	return &c.BlockedDomains
 }
 

--- a/providers/ms365/resources/ms365_teams.go
+++ b/providers/ms365/resources/ms365_teams.go
@@ -53,7 +53,15 @@ if ($null -ne $CsTenantFederationConfiguration.AllowedDomains) {
 }
 $CsTenantFederationConfiguration.AllowedDomains = $allowedList
 
-$CsTenantFederationConfiguration | Add-Member -MemberType NoteProperty -Name "AllowedDomainsClean" -Value $allowedList
+$blockedList = New-Object System.Collections.Generic.List[string]
+if ($null -ne $CsTenantFederationConfiguration.BlockedDomains) {
+  foreach ($item in $CsTenantFederationConfiguration.BlockedDomains) {
+    $itemAsString = $item.ToString()
+    $domainValue = ($itemAsString -split '=')[1]
+    $blockedList.Add($domainValue)
+  }
+}
+$CsTenantFederationConfiguration.BlockedDomains = $blockedList
 
 $msteams = New-Object PSObject
 Add-Member -InputObject $msteams -MemberType NoteProperty -Name CsTeamsClientConfiguration -Value $CsTeamsClientConfiguration
@@ -83,9 +91,7 @@ type CsTenantFederationConfiguration struct {
 	RestrictTeamsConsumerToExternalUserProfiles bool     `json:"RestrictTeamsConsumerToExternalUserProfiles"`
 	ExternalAccessWithTrialTenants              string   `json:"ExternalAccessWithTrialTenants"`
 	AllowedDomains                              []string `json:"AllowedDomains"`
-	// TODO: we need to figure out how to get this right when using Convert-ToJson
-	// it currently comes back as an empty json object {} but the pwsh cmdlet spits out a string-looking value
-	BlockedDomains any `json:"BlockedDomains"`
+	BlockedDomains                              []string `json:"BlockedDomains"`
 }
 
 type CsTeamsMeetingPolicy struct {
@@ -188,11 +194,10 @@ func (r *mqlMs365Teams) gatherTeamsReport() error {
 
 	if report.CsTenantFederationConfiguration != nil {
 		tenantConfig := report.CsTenantFederationConfiguration
-		tenantConfigBlockedDomains, _ := convert.JsonToDict(tenantConfig.BlockedDomains)
 		mqlTenantConfig, mqlTenantConfigErr := CreateResource(r.MqlRuntime, "ms365.teams.tenantFederationConfig",
 			map[string]*llx.RawData{
 				"identity":                                    llx.StringData(tenantConfig.Identity),
-				"blockedDomains":                              llx.DictData(tenantConfigBlockedDomains),
+				"blockedDomains":                              llx.ArrayData(convert.SliceAnyToInterface(tenantConfig.BlockedDomains), types.String),
 				"allowedDomains":                              llx.ArrayData(convert.SliceAnyToInterface(tenantConfig.AllowedDomains), types.String),
 				"allowFederatedUsers":                         llx.BoolData(tenantConfig.AllowFederatedUsers),
 				"allowPublicUsers":                            llx.BoolData(tenantConfig.AllowPublicUsers),


### PR DESCRIPTION
## Summary
- Fixes #3047 — `blockedDomains` in `ms365.teams.tenantFederationConfig` was always returning an empty object `{}` because the PowerShell `ConvertTo-Json` can't properly serialize the special domain collection objects from `Get-CsTenantFederationConfiguration`
- Added the same domain extraction processing to `BlockedDomains` that already existed for `AllowedDomains` (iterate items, `.ToString()`, split on `=`)
- Changed the field type from `dict` to `[]string` to match `allowedDomains` and properly expose the domain list

## Test plan
- [ ] Verify `ms365.teams.csTenantFederationConfiguration.blockedDomains` returns a string array with an MS365 tenant that has blocked domains configured
- [ ] Verify `ms365.teams.csTenantFederationConfiguration.allowedDomains` still works correctly (no regression)
- [ ] Verify empty blocked domains returns `[]` instead of `{}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)