### PR TITLE
🐛 Fix azure storage container init returning wrong resource

### DIFF
--- a/providers/azure/resources/storage.go
+++ b/providers/azure/resources/storage.go
@@ -784,11 +784,10 @@ func initAzureSubscriptionStorageServiceAccountContainer(runtime *plugin.Runtime
 		for _, c := range containers.Data {
 			container := c.(*mqlAzureSubscriptionStorageServiceAccountContainer)
 			if container.Id.Data == id {
-				return args, storageAcc, nil
+				return args, container, nil
 			}
-
 		}
 	}
 
-	return nil, nil, errors.New("azure storage account does not exist")
+	return nil, nil, errors.New("azure storage container does not exist")
 }


### PR DESCRIPTION
## Summary
- Fixes #1991 — `azure.subscription.storageService.account.container{*}` failed with "cannot find field 'etag' in resource 'azure.subscription.storageService.account'"
- The `initAzureSubscriptionStorageServiceAccountContainer` function was returning the parent `storageAcc` instead of the matched `container` when resolving a container by ID (copy-paste bug from the account init function above)
- MQL then treated the storage account as the container resource, and field lookups for container-specific fields like `etag` failed against the wrong resource type

## Test plan
- [ ] `cnquery shell azure --discover all`, select a storage container, run `azure.subscription.storageService.account.container{*}` — should return all fields including `etag`
- [ ] Verify `azure.subscription.storageService.account.containers { etag }` still works when querying from an account context

🤖 Generated with [Claude Code](https://claude.com/claude-code)