### PR TITLE
✨ Add static field to service resource

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -863,6 +863,8 @@ service @defaults("name running enabled type") {
   type string
   // Whether the service is masked
   masked bool
+  // Whether the service is static (unit file has no [Install] section and cannot be enabled/disabled)
+  static bool
 }
 
 // Services configured on this system

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -1804,6 +1804,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"service.masked": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlService).GetMasked()).ToDataRes(types.Bool)
 	},
+	"service.static": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlService).GetStatic()).ToDataRes(types.Bool)
+	},
 	"services.list": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlServices).GetList()).ToDataRes(types.Array(types.Resource("service")))
 	},
@@ -4943,6 +4946,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"service.masked": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlService).Masked, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"service.static": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlService).Static, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"services.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12787,6 +12794,7 @@ type mqlService struct {
 	Enabled     plugin.TValue[bool]
 	Type        plugin.TValue[string]
 	Masked      plugin.TValue[bool]
+	Static      plugin.TValue[bool]
 }
 
 // createService creates a new instance of this resource
@@ -12852,6 +12860,10 @@ func (c *mqlService) GetType() *plugin.TValue[string] {
 
 func (c *mqlService) GetMasked() *plugin.TValue[bool] {
 	return &c.Masked
+}
+
+func (c *mqlService) GetStatic() *plugin.TValue[bool] {
+	return &c.Static
 }
 
 // mqlServices for the services resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -778,6 +778,7 @@ service.installed 9.0.0
 service.masked 9.0.0
 service.name 9.0.0
 service.running 9.0.0
+service.static 11.8.12
 service.type 9.0.0
 services 9.0.0
 services.list 9.0.0

--- a/providers/os/resources/services.go
+++ b/providers/os/resources/services.go
@@ -54,6 +54,7 @@ func initService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 	res.Type.State = plugin.StateIsSet | plugin.StateIsNull
 	res.Enabled = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
 	res.Masked = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	res.Static = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
 	return nil, res, nil
 }
 
@@ -102,6 +103,7 @@ func (x *mqlServices) list() ([]any, error) {
 			"masked":      llx.BoolData(srv.Masked),
 			"running":     llx.BoolData(srv.Running),
 			"type":        llx.StringData(srv.Type),
+			"static":      llx.BoolData(srv.Static),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/os/resources/services/manager.go
+++ b/providers/os/resources/services/manager.go
@@ -20,6 +20,7 @@ type Service struct {
 	Running     bool
 	Enabled     bool
 	Masked      bool
+	Static      bool
 	Path        string
 }
 

--- a/providers/os/resources/services/systemd.go
+++ b/providers/os/resources/services/systemd.go
@@ -69,6 +69,7 @@ func ParseServiceSystemDUnitFiles(input io.Reader) ([]*Service, error) {
 			Name:    name,
 			Enabled: fields[1] == "enabled",
 			Masked:  fields[1] == "masked",
+			Static:  fields[1] == "static",
 			Type:    "systemd",
 		}
 
@@ -173,6 +174,8 @@ type unitInfo struct {
 	// isDep is true of this unit is found in the dependency tree starting
 	// from the default.target
 	isDep bool
+	// hasInstall is true if the unit file has an [Install] section
+	hasInstall bool
 	// service is only set for socket units. It contains an optional name.target.
 	// If not provided, socketname.service is activated for the socket
 	service string
@@ -221,6 +224,7 @@ func (s *SystemdFSServiceManager) List() ([]*Service, error) {
 			Installed:   !v.missing,
 			Enabled:     !v.missing && v.isDep,
 			Masked:      v.masked,
+			Static:      !v.missing && !v.masked && !v.hasInstall,
 		})
 	}
 	return services, nil
@@ -415,6 +419,8 @@ func (s *SystemdFSServiceManager) readUnit(unitPath string, uInfo *unitInfo) err
 			}
 		} else if o.Section == "Socket" && o.Name == "Service" {
 			uInfo.service = o.Value
+		} else if o.Section == "Install" {
+			uInfo.hasInstall = true
 		}
 	}
 

--- a/providers/os/resources/services/systemd_test.go
+++ b/providers/os/resources/services/systemd_test.go
@@ -75,6 +75,17 @@ func TestParseServiceSystemDUnitFiles(t *testing.T) {
 	// check for masked element
 	assert.Equal(t, "cryptdisks", m[30].Name, "service name detected")
 	assert.Equal(t, true, m[30].Masked, "service is masked")
+	assert.Equal(t, false, m[30].Static, "masked service is not static")
+
+	// check for static element (alsa-restore is the third service, index 2)
+	assert.Equal(t, "alsa-restore", m[2].Name, "service name detected")
+	assert.Equal(t, true, m[2].Static, "service is static")
+	assert.Equal(t, false, m[2].Enabled, "static service is not enabled")
+	assert.Equal(t, false, m[2].Masked, "static service is not masked")
+
+	// check that enabled service is not static
+	assert.Equal(t, "accounts-daemon", m[0].Name, "service name detected")
+	assert.Equal(t, false, m[0].Static, "enabled service is not static")
 }
 
 func TestParseServiceSystemDUnitFilesPhoton(t *testing.T) {
@@ -133,6 +144,7 @@ func TestSystemdFS(t *testing.T) {
 		State:       ServiceUnknown,
 		Installed:   true,
 		Enabled:     true,
+		Static:      true,
 	}, servicesMap["aliased"])
 	assert.Contains(t, servicesMap, "aliased-wants")
 	assert.Contains(t, servicesMap, "aliased-requires")
@@ -163,6 +175,7 @@ func TestSystemdFS(t *testing.T) {
 		State:       ServiceUnknown,
 		Installed:   true,
 		Enabled:     true,
+		Static:      true,
 	}, servicesMap["implicit-socket"])
 	assert.Contains(t, servicesMap, "explicit-socket-service")
 	assert.Equal(t, &Service{
@@ -172,6 +185,7 @@ func TestSystemdFS(t *testing.T) {
 		State:       ServiceUnknown,
 		Installed:   true,
 		Enabled:     true,
+		Static:      true,
 	}, servicesMap["explicit-socket-service"])
 
 	// Relative path symlink


### PR DESCRIPTION
## Summary
- Closes #3288 — adds a `static` boolean field to the `service` resource
- A service is "static" when its systemd unit file has no `[Install]` section, meaning it cannot be enabled or disabled (it can only be pulled in as a dependency)
- Implemented for both systemd code paths:
  - **Command-based** (`systemctl list-unit-files`): parses the STATE column for "static"
  - **Filesystem-based** (container/image scanning): detects absence of `[Install]` section in unit files

## Usage
```
service("systemd-journald").static
# => true

services.where(static == true) { name }
```

## Test plan
- [x] Unit tests for command-based systemd parser (static, enabled, masked services)
- [x] Unit tests for filesystem-based systemd manager (services with/without `[Install]` sections)
- [ ] Interactive: `mql shell local -c "service('systemd-journald') { name static enabled }"` — static should be `true`
- [ ] Interactive: `mql shell local -c "service('sshd') { name static enabled }"` — static should be `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)