### PR TITLE
🧹 Disable auto-update providers on push to main.

### DIFF
--- a/.github/workflows/release-providers.yml
+++ b/.github/workflows/release-providers.yml
@@ -1,13 +1,6 @@
 name: Trigger provider release
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "providers/**"
-      - "!providers/core/**"
-      - "!providers/*/config/config.go"
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
Long-term we should fix this to only update based on the commit diff that's been pushed to main. Now it updates all providers.