### PR TITLE
🐛 Fix azure storage blob properties missing id field

### DIFF
--- a/providers/azure/resources/storage.go
+++ b/providers/azure/resources/storage.go
@@ -498,7 +498,7 @@ func toMqlServiceStorageProperties(runtime *plugin.Runtime, props table.ServiceP
 func toMqlBlobServiceStorageProperties(runtime *plugin.Runtime, props table.ServiceProperties, blobProps storage.BlobServiceProperties, serviceType, parentId string) (*mqlAzureSubscriptionStorageServiceAccountServiceBlobProperties, error) {
 	loggingRetentionPolicy, err := CreateResource(runtime, ResourceAzureSubscriptionStorageServiceAccountServicePropertiesRetentionPolicy,
 		map[string]*llx.RawData{
-			"__id":          llx.StringData(fmt.Sprintf("%s/%s/properties/logging/retentionPolicy", parentId, serviceType)),
+			"id":            llx.StringData(fmt.Sprintf("%s/%s/properties/logging/retentionPolicy", parentId, serviceType)),
 			"retentionDays": llx.IntDataDefault(props.Logging.RetentionPolicy.Days, 0),
 			"enabled":       llx.BoolDataPtr(props.Logging.RetentionPolicy.Enabled),
 		})
@@ -507,7 +507,7 @@ func toMqlBlobServiceStorageProperties(runtime *plugin.Runtime, props table.Serv
 	}
 	logging, err := CreateResource(runtime, ResourceAzureSubscriptionStorageServiceAccountServicePropertiesLogging,
 		map[string]*llx.RawData{
-			"__id":            llx.StringData(fmt.Sprintf("%s/%s/properties/logging", parentId, serviceType)),
+			"id":              llx.StringData(fmt.Sprintf("%s/%s/properties/logging", parentId, serviceType)),
 			"retentionPolicy": llx.ResourceData(loggingRetentionPolicy, "retentionPolicy"),
 			"delete":          llx.BoolDataPtr(props.Logging.Delete),
 			"write":           llx.BoolDataPtr(props.Logging.Write),
@@ -519,7 +519,7 @@ func toMqlBlobServiceStorageProperties(runtime *plugin.Runtime, props table.Serv
 	}
 	minuteMetricsRetentionPolicy, err := CreateResource(runtime, ResourceAzureSubscriptionStorageServiceAccountServicePropertiesRetentionPolicy,
 		map[string]*llx.RawData{
-			"__id":          llx.StringData(fmt.Sprintf("%s/%s/properties/minuteMetrics/retentionPolicy", parentId, serviceType)),
+			"id":            llx.StringData(fmt.Sprintf("%s/%s/properties/minuteMetrics/retentionPolicy", parentId, serviceType)),
 			"retentionDays": llx.IntDataDefault(props.MinuteMetrics.RetentionPolicy.Days, 0),
 			"enabled":       llx.BoolDataPtr(props.MinuteMetrics.RetentionPolicy.Enabled),
 		})
@@ -528,7 +528,7 @@ func toMqlBlobServiceStorageProperties(runtime *plugin.Runtime, props table.Serv
 	}
 	minuteMetrics, err := CreateResource(runtime, ResourceAzureSubscriptionStorageServiceAccountServicePropertiesMetrics,
 		map[string]*llx.RawData{
-			"__id":            llx.StringData(fmt.Sprintf("%s/%s/properties/minuteMetrics/", parentId, serviceType)),
+			"id":              llx.StringData(fmt.Sprintf("%s/%s/properties/minuteMetrics/", parentId, serviceType)),
 			"retentionPolicy": llx.ResourceData(minuteMetricsRetentionPolicy, "retentionPolicy"),
 			"enabled":         llx.BoolDataPtr(props.MinuteMetrics.Enabled),
 			"includeAPIs":     llx.BoolDataPtr(props.MinuteMetrics.IncludeAPIs),
@@ -539,7 +539,7 @@ func toMqlBlobServiceStorageProperties(runtime *plugin.Runtime, props table.Serv
 	}
 	hourMetricsRetentionPolicy, err := CreateResource(runtime, ResourceAzureSubscriptionStorageServiceAccountServicePropertiesRetentionPolicy,
 		map[string]*llx.RawData{
-			"__id":          llx.StringData(fmt.Sprintf("%s/%s/properties/hourMetrics/retentionPolicy", parentId, serviceType)),
+			"id":            llx.StringData(fmt.Sprintf("%s/%s/properties/hourMetrics/retentionPolicy", parentId, serviceType)),
 			"retentionDays": llx.IntDataDefault(props.HourMetrics.RetentionPolicy.Days, 0),
 			"enabled":       llx.BoolDataPtr(props.HourMetrics.RetentionPolicy.Enabled),
 		})
@@ -548,7 +548,7 @@ func toMqlBlobServiceStorageProperties(runtime *plugin.Runtime, props table.Serv
 	}
 	hourMetrics, err := CreateResource(runtime, ResourceAzureSubscriptionStorageServiceAccountServicePropertiesMetrics,
 		map[string]*llx.RawData{
-			"__id":            llx.StringData(fmt.Sprintf("%s/%s/properties/hourMetrics", parentId, serviceType)),
+			"id":              llx.StringData(fmt.Sprintf("%s/%s/properties/hourMetrics", parentId, serviceType)),
 			"retentionPolicy": llx.ResourceData(hourMetricsRetentionPolicy, "retentionPolicy"),
 			"enabled":         llx.BoolDataPtr(props.HourMetrics.Enabled),
 			"includeAPIs":     llx.BoolDataPtr(props.HourMetrics.IncludeAPIs),
@@ -566,7 +566,7 @@ func toMqlBlobServiceStorageProperties(runtime *plugin.Runtime, props table.Serv
 
 	settings, err := CreateResource(runtime, ResourceAzureSubscriptionStorageServiceAccountServiceBlobProperties,
 		map[string]*llx.RawData{
-			"__id":                llx.StringData(fmt.Sprintf("%s/%s/properties", parentId, serviceType)),
+			"id":                  llx.StringData(fmt.Sprintf("%s/%s/properties", parentId, serviceType)),
 			"minuteMetrics":       llx.ResourceData(minuteMetrics, "minuteMetrics"),
 			"hourMetrics":         llx.ResourceData(hourMetrics, "hourMetrics"),
 			"logging":             llx.ResourceData(logging, "logging"),


### PR DESCRIPTION
## Summary
- Fixed `toMqlBlobServiceStorageProperties` using `"__id"` instead of `"id"` as the map key in all 7 `CreateResource` calls
- These resources declare an explicit `id string` field with `@defaults("id")` in their `.lr` definitions, so `"__id"` only set the cache key without populating the required `id` field
- This caused "cannot convert primitive with NO type information" errors when querying `blobProperties` (e.g. `azure.subscription.storageService.accounts.first{*}`)

## Test plan
- [ ] Rebuild and install the azure provider (`make providers/build/azure && make providers/install/azure`)
- [ ] Run `mql run azure -c "azure.subscription.storageService.accounts.first{*}"` and verify `blobProperties` resolves without error
- [ ] Run `mql run azure -c "azure.subscription.storageService.accounts { blobProperties }"` to verify all accounts work

This fixes this previous failure:

```
> azure.subscription.storageService.accounts.first.blobProperties
error: 1 error occurred:
enter ru* cannot convert primitive with NO type information
```