### PR TITLE
🐛 Fix network.interfaces gateway parsing for peer interfaces

### DIFF
--- a/providers/os/id/networki/interfaces.go
+++ b/providers/os/id/networki/interfaces.go
@@ -151,10 +151,31 @@ func mergeInterfaces(i1, i2 Interface) Interface {
 }
 
 // FindInterface finds an interface from a list of interfaces.
+// It first tries an exact name match, then falls back to matching
+// by base interface name to handle peer interfaces (e.g. eth0@if103).
 func FindInterface(interfaces []Interface, iinterface Interface) int {
-	return slices.IndexFunc(interfaces, func(i Interface) bool {
+	// Try exact match first
+	idx := slices.IndexFunc(interfaces, func(i Interface) bool {
 		return i.Name == iinterface.Name
 	})
+	if idx >= 0 {
+		return idx
+	}
+
+	// Fall back to base name match (handles peer interfaces like eth0@if103)
+	base := baseInterfaceName(iinterface.Name)
+	return slices.IndexFunc(interfaces, func(i Interface) bool {
+		return baseInterfaceName(i.Name) == base
+	})
+}
+
+// baseInterfaceName strips the peer suffix (@ifN) from interface names.
+// For example, "eth0@if103" returns "eth0", while "enX0" returns "enX0".
+func baseInterfaceName(name string) string {
+	if i := strings.Index(name, "@"); i != -1 {
+		return name[:i]
+	}
+	return name
 }
 
 // AddOrUpdateIP adds or updates one or many IPAddresses

--- a/providers/os/id/networki/interfaces_internal_test.go
+++ b/providers/os/id/networki/interfaces_internal_test.go
@@ -43,6 +43,43 @@ func TestMergeInterfaces(t *testing.T) {
 	assert.ElementsMatch(t, []string{"UP", "BROADCAST"}, merged.Flags)
 }
 
+func TestBaseInterfaceName(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{"eth0@if103", "eth0"},
+		{"eth0@if104", "eth0"},
+		{"veth123@if5", "veth123"},
+		{"enX0", "enX0"},
+		{"lo", "lo"},
+		{"", ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, baseInterfaceName(test.name))
+		})
+	}
+}
+
+func TestFindInterfacePeerName(t *testing.T) {
+	interfaces := []Interface{
+		{Name: "lo"},
+		{Name: "eth0@if104"},
+	}
+
+	// Exact match still works
+	assert.Equal(t, 0, FindInterface(interfaces, Interface{Name: "lo"}))
+	assert.Equal(t, 1, FindInterface(interfaces, Interface{Name: "eth0@if104"}))
+
+	// Base name match: "eth0" finds "eth0@if104"
+	assert.Equal(t, 1, FindInterface(interfaces, Interface{Name: "eth0"}))
+
+	// No match
+	assert.Equal(t, -1, FindInterface(interfaces, Interface{Name: "enX0"}))
+}
+
 func TestAddOrUpdateIP(t *testing.T) {
 	iface := &Interface{Name: "eth0"}
 	ip1 := IPAddress{IP: net.ParseIP("192.168.1.1")}

--- a/providers/os/id/networki/interfaces_test.go
+++ b/providers/os/id/networki/interfaces_test.go
@@ -108,6 +108,45 @@ func TestInterfacesLinux(t *testing.T) {
 	}
 }
 
+func TestInterfacesLinuxPeerInterface(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/linux_peer_interface.toml"))
+	require.NoError(t, err)
+	platform, ok := detector.DetectOS(conn)
+	require.True(t, ok)
+
+	interfaces, err := subject.Interfaces(conn, platform)
+	require.NoError(t, err)
+	assert.Len(t, interfaces, 2)
+
+	// The interface is named eth0@if104 (peer interface) but the routing table
+	// uses the base name eth0. Verify that the gateway is correctly assigned.
+	index := subject.FindInterface(interfaces, subject.Interface{Name: "eth0@if104"})
+	if assert.NotEqual(t, -1, index) {
+		eth0 := interfaces[index]
+		assert.Equal(t, "eth0@if104", eth0.Name)
+		assert.Equal(t, "02:42:ac:11:00:04", eth0.MACAddress)
+		assert.Equal(t, 1500, eth0.MTU)
+		if assert.NotNil(t, eth0.Active) {
+			assert.True(t, *eth0.Active)
+		}
+		if assert.NotEmpty(t, eth0.IPAddresses) {
+			i4 := eth0.FindIP(net.ParseIP("172.17.0.4"))
+			if assert.NotEqual(t, -1, i4) {
+				ipv4 := eth0.IPAddresses[i4]
+				assert.Equal(t, "172.17.0.4", ipv4.IP.String())
+				assert.Equal(t, "172.17.0.4/16", ipv4.CIDR)
+				assert.Equal(t, "172.17.0.0/16", ipv4.Subnet)
+				assert.Equal(t, "172.17.255.255", ipv4.Broadcast)
+				assert.Equal(t, "172.17.0.1", ipv4.Gateway)
+			}
+		}
+	}
+
+	// Also verify that FindInterface can locate the peer interface by its base name
+	index = subject.FindInterface(interfaces, subject.Interface{Name: "eth0"})
+	assert.NotEqual(t, -1, index)
+}
+
 func TestInterfacesLinuxFallbackSysNetFilesystem(t *testing.T) {
 	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/linux_sys_class_net_fs.toml"))
 	require.NoError(t, err)

--- a/providers/os/id/networki/testdata/linux_peer_interface.toml
+++ b/providers/os/id/networki/testdata/linux_peer_interface.toml
@@ -1,0 +1,29 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "5.15.0-1043-aws"
+
+[commands."ip addr show"]
+stdout = """
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+103: eth0@if104: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default
+    link/ether 02:42:ac:11:00:04 brd ff:ff:ff:ff:ff:ff link-netnsid 0
+    inet 172.17.0.4/16 brd 172.17.255.255 scope global eth0
+       valid_lft forever preferred_lft forever
+"""
+
+[commands."ip route show"]
+stdout = """
+default via 172.17.0.1 dev eth0
+172.17.0.0/16 dev eth0 proto kernel scope link src 172.17.0.4
+"""
+
+[commands."ip -6 route show"]
+stdout = ""


### PR DESCRIPTION
## Summary

- Fixes gateway not being assigned to peer interfaces (e.g. `eth0@if103`) in Docker containers and network namespace setups
- `ip addr show` reports the full peer name (`eth0@if103`) while `ip route show` uses only the base name (`eth0`), causing `FindInterface` exact match to fail and gateway enrichment to never apply
- `FindInterface` now falls back to base interface name matching (stripping `@ifN` suffix) when exact match fails

Fixes #6010

## Test plan

- [x] Unit tests for `baseInterfaceName` helper (peer names, normal names, empty string)
- [x] Unit tests for `FindInterface` with peer interface name matching
- [x] Integration test with mock Docker container data (`linux_peer_interface.toml`) verifying gateway `172.17.0.1` is assigned to `eth0@if104`
- [x] Existing tests still pass (normal interfaces, sysfs fallback, macOS, Windows)
- [ ] Manual verification: `mql shell docker container <id>` → `network.interfaces { name ipaddresses }` shows gateway on peer interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)