### PR TITLE
🐛 Fix network.interfaces sysfs detection skipping symlinks over SFTP

### DIFF
--- a/providers/os/id/networki/interfaces_test.go
+++ b/providers/os/id/networki/interfaces_test.go
@@ -139,6 +139,32 @@ func TestInterfacesLinuxFallbackSysNetFilesystem(t *testing.T) {
 	}
 }
 
+func TestInterfacesLinuxSysfsSymlinks(t *testing.T) {
+	// On real Linux over SFTP, /sys/class/net/ entries are symlinks
+	// and IsDir() returns false. This test verifies sysfs detection
+	// still works when entries are not directories (i.e. symlinks).
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/linux_sys_class_net_symlinks.toml"))
+	require.NoError(t, err)
+	platform, ok := detector.DetectOS(conn)
+	require.True(t, ok)
+
+	interfaces, err := subject.Interfaces(conn, platform)
+	require.NoError(t, err)
+	assert.Len(t, interfaces, 2)
+
+	index := subject.FindInterface(interfaces, subject.Interface{Name: "enp0s3"})
+	if assert.NotEqual(t, -1, index) {
+		enp0s3 := interfaces[index]
+		assert.Equal(t, "enp0s3", enp0s3.Name)
+		assert.Equal(t, "08:00:27:ac:25:39", enp0s3.MACAddress)
+		assert.Equal(t, 1500, enp0s3.MTU)
+		if assert.NotNil(t, enp0s3.Active) {
+			assert.True(t, *enp0s3.Active)
+		}
+		assert.ElementsMatch(t, []string{"MULTICAST", "BROADCAST", "UP"}, enp0s3.Flags)
+	}
+}
+
 func TestInterfacesWindows(t *testing.T) {
 	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/windows_get_net_ip_cmd.toml"))
 	require.NoError(t, err)

--- a/providers/os/id/networki/linux_n.go
+++ b/providers/os/id/networki/linux_n.go
@@ -136,13 +136,6 @@ func (n *neti) getLinuxSysfsInterfaces() (interfaces []Interface, err error) {
 	log.Debug().Int("dir_entries", len(dirEntries)).Msg("os.network.interface> read /sys/class/net")
 
 	for _, entry := range dirEntries {
-		if !entry.IsDir() {
-			log.Trace().
-				Str("name", filepath.Join("/sys/class/net", entry.Name())).
-				Msg("os.network.interfaces> not a directory, skipping")
-			continue
-		}
-
 		ifaceName := entry.Name()
 		iinterface := Interface{Name: ifaceName}
 

--- a/providers/os/id/networki/testdata/linux_sys_class_net_symlinks.toml
+++ b/providers/os/id/networki/testdata/linux_sys_class_net_symlinks.toml
@@ -1,0 +1,45 @@
+# Simulates /sys/class/net/ entries as symlinks (isdir = false)
+# as they appear over SFTP on real Linux systems like Mageia.
+# On real Linux, entries in /sys/class/net/ are symlinks to device
+# directories (e.g. /sys/devices/...), and SFTP reports IsDir()=false.
+
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "5.7.19-desktop-3.mga8"
+
+[files."/sys/class/net"]
+stat.isdir = true
+
+[files."/sys/class/net/enp0s3"]
+stat.isdir = false
+[files."/sys/class/net/enp0s3/address"]
+content = "08:00:27:ac:25:39"
+[files."/sys/class/net/enp0s3/operstate"]
+content = "up"
+[files."/sys/class/net/enp0s3/mtu"]
+content = "1500"
+[files."/sys/class/net/enp0s3/flags"]
+content = "0x1003"
+
+[files."/sys/class/net/lo"]
+stat.isdir = false
+[files."/sys/class/net/lo/address"]
+content = "00:00:00:00:00:00"
+[files."/sys/class/net/lo/operstate"]
+content = "up"
+
+[commands."ip route show"]
+stdout = """
+default via 10.0.2.2 dev enp0s3 proto dhcp metric 100
+10.0.2.0/24 dev enp0s3 proto kernel scope link src 10.0.2.15 metric 100
+"""
+
+[commands."ip -6 route show"]
+stdout = """
+fe80::/64 dev enp0s3 proto kernel metric 256 pref medium
+"""


### PR DESCRIPTION
## Summary

- Fixes `network.interfaces` returning empty on Mageia Linux (and other distros) when connecting over SSH
- On real Linux, `/sys/class/net/` entries are **symlinks** to device directories. Over SFTP, `ReadDir` correctly reports `IsDir()=false` for symlinks, but the code's `IsDir()` gate skipped them, causing sysfs fallback detection to return no interfaces
- Removes the `IsDir()` check — all subsequent file reads (`address`, `mtu`, `flags`, `operstate`) are already guarded with error checks and gracefully handle non-existent paths
- Adds test with mock data where sysfs entries are not directories (`isdir=false`), simulating SFTP symlink behavior

Fixes #6115

## Test plan

- [x] New test `TestInterfacesLinuxSysfsSymlinks` with `isdir=false` entries — verifies interfaces are detected with MAC, MTU, flags
- [x] Existing `TestInterfacesLinuxFallbackSysNetFilesystem` still passes (entries as directories)
- [x] All other networki tests pass (Linux, macOS, Windows)
- [ ] Manual verification: `cnquery shell vagrant default` on Mageia box → `network.interfaces` returns interfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)