### PR TITLE
🧹 ms365: update Microsoft Graph SDK to latest

### DIFF
--- a/providers/ms365/go.mod
+++ b/providers/ms365/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/microsoft/kiota-abstractions-go v1.9.3
 	github.com/microsoft/kiota-authentication-azure-go v1.3.1
-	github.com/microsoftgraph/msgraph-beta-sdk-go v0.158.0
-	github.com/microsoftgraph/msgraph-sdk-go v1.94.0
+	github.com/microsoftgraph/msgraph-beta-sdk-go v0.159.0
+	github.com/microsoftgraph/msgraph-sdk-go v1.96.0
 	github.com/microsoftgraph/msgraph-sdk-go-core v1.4.0
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.11.1

--- a/providers/ms365/go.sum
+++ b/providers/ms365/go.sum
@@ -304,8 +304,6 @@ github.com/hashicorp/go-sockaddr v1.0.7 h1:G+pTkSO01HpR5qCxg7lxfsFEZaG+C0VssTy/9
 github.com/hashicorp/go-sockaddr v1.0.7/go.mod h1:FZQbEYa1pxkQ7WLpyXJ6cbjpT8q0YgQaK/JakXqGyWw=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/go-version v1.8.0 h1:KAkNb1HAiZd1ukkxDFGmokVZe1Xy9HG6NUp+bPle2i4=
-github.com/hashicorp/go-version v1.8.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl v1.0.1-vault-7 h1:ag5OxFVy3QYTFTJODRzTKVZ6xvdfLLCA1cy/Y6xGI0I=
 github.com/hashicorp/hcl v1.0.1-vault-7/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
 github.com/hashicorp/vault/api v1.22.0 h1:+HYFquE35/B74fHoIeXlZIP2YADVboaPjaSicHEZiH0=
@@ -398,10 +396,10 @@ github.com/microsoft/kiota-serialization-multipart-go v1.1.2 h1:1pUyA1QgIeKslQwb
 github.com/microsoft/kiota-serialization-multipart-go v1.1.2/go.mod h1:j2K7ZyYErloDu7Kuuk993DsvfoP7LPWvAo7rfDpdPio=
 github.com/microsoft/kiota-serialization-text-go v1.1.3 h1:8z7Cebn0YAAr++xswVgfdxZjnAZ4GOB9O7XP4+r5r/M=
 github.com/microsoft/kiota-serialization-text-go v1.1.3/go.mod h1:NDSvz4A3QalGMjNboKKQI9wR+8k+ih8UuagNmzIRgTQ=
-github.com/microsoftgraph/msgraph-beta-sdk-go v0.158.0 h1:YqVRIreyfq1ovKMWlNxN6h99rvWuv55Qwpd8KDpj8As=
-github.com/microsoftgraph/msgraph-beta-sdk-go v0.158.0/go.mod h1:Jni/H4UkOMppKMY5GmdXkukT9IscFNdvRF2HvSQolYg=
-github.com/microsoftgraph/msgraph-sdk-go v1.94.0 h1:gyu3qDBhbnnFhCG6E6hixeLwPpysalWnJfGMxmNy6jA=
-github.com/microsoftgraph/msgraph-sdk-go v1.94.0/go.mod h1:JBHC+/jxEODRr1TmV5caB84mJF4whlpTLHPveVJ0DFA=
+github.com/microsoftgraph/msgraph-beta-sdk-go v0.159.0 h1:xN4msNReu4U0TUnelu3se2Or/tm8v/YCJM1nINHS4B0=
+github.com/microsoftgraph/msgraph-beta-sdk-go v0.159.0/go.mod h1:Jni/H4UkOMppKMY5GmdXkukT9IscFNdvRF2HvSQolYg=
+github.com/microsoftgraph/msgraph-sdk-go v1.96.0 h1:UnqyTX8Ils9tJ7QLaR2yVF3ctXCvRUp2gl3BThIteJk=
+github.com/microsoftgraph/msgraph-sdk-go v1.96.0/go.mod h1:JBHC+/jxEODRr1TmV5caB84mJF4whlpTLHPveVJ0DFA=
 github.com/microsoftgraph/msgraph-sdk-go-core v1.4.0 h1:0SrIoFl7TQnMRrsi5TFaeNe0q8KO5lRzRp4GSCCL2So=
 github.com/microsoftgraph/msgraph-sdk-go-core v1.4.0/go.mod h1:A1iXs+vjsRjzANxF6UeKv2ACExG7fqTwHHbwh1FL+EE=
 github.com/miekg/dns v1.1.72 h1:vhmr+TF2A3tuoGNkLDFK9zi36F2LS+hKTRW0Uf8kbzI=


### PR DESCRIPTION
## Summary
- Update `msgraph-sdk-go` v1.94.0 → v1.96.0
- Update `msgraph-beta-sdk-go` v0.158.0 → v0.159.0

All other MS365-related dependencies (kiota, msgraph-sdk-go-core) were already at their latest versions.

## Test plan
- [x] Provider builds cleanly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)