### PR TITLE
🧹 cloudformation: update rain SDK to v1.24.3

### DIFF
--- a/providers/cloudformation/go.mod
+++ b/providers/cloudformation/go.mod
@@ -1,11 +1,11 @@
 module go.mondoo.com/mql/v13/providers/cloudformation
 
-go 1.25.1
+go 1.26.0
 
 replace go.mondoo.com/mql/v13 => ../..
 
 require (
-	github.com/aws-cloudformation/rain v1.24.2
+	github.com/aws-cloudformation/rain v1.24.3
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.0.0-pre1

--- a/providers/cloudformation/go.sum
+++ b/providers/cloudformation/go.sum
@@ -77,8 +77,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/aws-cloudformation/rain v1.24.2 h1:mBlBwkZTavTdP3fr81gGR1NrQEAhcncs9hcKc1qn+jo=
-github.com/aws-cloudformation/rain v1.24.2/go.mod h1:mg8IIq7r1ss1wDClMqgtovZO2CDNokE+w9i9XRvvBEE=
+github.com/aws-cloudformation/rain v1.24.3 h1:n/ZylHMgGHTDcZLo49TjE9z0kWrsdPWLrmVoLuLh4ig=
+github.com/aws-cloudformation/rain v1.24.3/go.mod h1:/MdRW1x1OFuoTJJU52g6m6hMNNh4HLvVttrdlCtL8Bk=
 github.com/aws/aws-sdk-go-v2 v1.41.1 h1:ABlyEARCDLN034NhxlRUSZr4l71mh+T5KAeGh6cerhU=
 github.com/aws/aws-sdk-go-v2 v1.41.1/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
 github.com/aws/aws-sdk-go-v2/config v1.32.7 h1:vxUyWGUwmkQ2g19n7JY/9YL8MfAIl7bTesIUykECXmY=
@@ -312,8 +312,6 @@ github.com/hashicorp/go-sockaddr v1.0.7 h1:G+pTkSO01HpR5qCxg7lxfsFEZaG+C0VssTy/9
 github.com/hashicorp/go-sockaddr v1.0.7/go.mod h1:FZQbEYa1pxkQ7WLpyXJ6cbjpT8q0YgQaK/JakXqGyWw=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/go-version v1.8.0 h1:KAkNb1HAiZd1ukkxDFGmokVZe1Xy9HG6NUp+bPle2i4=
-github.com/hashicorp/go-version v1.8.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl v1.0.1-vault-7 h1:ag5OxFVy3QYTFTJODRzTKVZ6xvdfLLCA1cy/Y6xGI0I=
 github.com/hashicorp/hcl v1.0.1-vault-7/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
 github.com/hashicorp/vault/api v1.22.0 h1:+HYFquE35/B74fHoIeXlZIP2YADVboaPjaSicHEZiH0=


### PR DESCRIPTION
## Summary
- **cloudformation**: `aws-cloudformation/rain` v1.24.2 → v1.24.3
- Go directive bumped to 1.26.0 (required by rain v1.24.3)

The following providers were already at their latest versions (no changes needed):
- **arista**: `aristanetworks/goeapi` v1.0.0
- **ansible**: no external SDK deps
- **ipinfo**: `ipinfo/go/v2` v2.12.0
- **ipmi**: `vmware/goipmi` v0.0.0-20181114...
- **equinix**: `packethost/packngo` v0.31.0
- **nmap**: `Ullaakut/nmap/v3` v3.1.0
- **network**: no own go.mod (part of parent module)
- **opcua**: `gopcua/opcua` v0.8.0

## Test plan
- [x] Provider builds cleanly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)