### PR TITLE
Fix spoofable author check in auto-merge workflow

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -162,9 +162,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [golangci-lint, golangci-lint-providers, go-test, go-test-integration, go-mod]
     # For now, we only auto approve and merge provider release PRs created by mondoo-tools.
-    # We have to check the commit author, because the PR is created by "github-actions[bot]"
-    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#startswith
-    if: ${{ (startsWith(github.ref, 'refs/heads/version/providers_update_') || startsWith(github.ref, 'refs/heads/version/deps_update_')) && github.event.commits[0].author.username == 'mondoo-tools' }}
+    # We use github.actor (the authenticated GitHub user who pushed) instead of
+    # github.event.commits[0].author.username (the git commit author) because git commit
+    # metadata is user-controlled and can be spoofed by anyone via git config.
+    # github.actor is set by GitHub's authentication layer and is tamper-proof.
+    if: ${{ (startsWith(github.ref, 'refs/heads/version/providers_update_') || startsWith(github.ref, 'refs/heads/version/deps_update_')) && github.actor == 'mondoo-tools' }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

- Replace `github.event.commits[0].author.username` with `github.actor` in the `go-auto-approve` job condition
- The git commit author field is user-controlled metadata — anyone can forge it with `git config user.name`
- `github.actor` is set by GitHub's authentication layer and cannot be spoofed

## Background

The `go-auto-approve` job in `pr-test-lint.yml` auto-approves and merges provider update PRs when they come from `mondoo-tools`. Previously it verified the author using `github.event.commits[0].author.username`, which reads from git commit metadata. This is trivially spoofable:

```bash
git config user.name "mondoo-tools"
git commit -m "whatever"
git push origin version/providers_update_evil
```

If all tests pass, the job would auto-approve and merge it.

`github.actor` is the authenticated GitHub user who triggered the workflow run, verified by GitHub's auth layer, and is tamper-proof.

## Test plan

- [ ] Verify the existing `mondoo-tools` automated provider update flow still triggers auto-merge correctly
- [ ] Confirm that pushes from other users to `version/providers_update_*` branches do not trigger auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)