### PR TITLE
Pin and update golangci-lint to v2.10.1 in CI workflows

### DIFF
--- a/.github/workflows/pr-extended-linting.yml
+++ b/.github/workflows/pr-extended-linting.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: latest
+          version: v2.10.1
           args: --config=.github/.golangci.yaml --timeout=30m
           only-new-issues: true
           skip-cache: true

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: latest
+          version: v2.10.1
 
   golangci-lint-providers:
     uses: ./.github/workflows/reusable-lint-providers.yml

--- a/.github/workflows/reusable-lint-providers.yml
+++ b/.github/workflows/reusable-lint-providers.yml
@@ -27,7 +27,7 @@ jobs:
           cache: false
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@e2e40021c9007020676c93680a36e3ab06c6cd33    #v2.8.0
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@5d1e709b7be35cb2025444e19de266b056b7b7ee    #v2.10.1
 
       - name: Run golangci-lint on all providers
         env:


### PR DESCRIPTION
## Summary

- Pin `golangci-lint` binary from `latest` to `v2.10.1` in `pr-test-lint.yml` and `pr-extended-linting.yml`
- Update `golangci-lint` from `v2.8.0` to `v2.10.1` in `reusable-lint-providers.yml`

## Background

The `golangci/golangci-lint-action` in `pr-test-lint.yml` and `pr-extended-linting.yml` was correctly SHA-pinned, but its `version: latest` parameter caused it to download whatever `golangci-lint` binary was newest at runtime. A compromised binary release would be fetched despite the action itself being pinned.

This also bumps `reusable-lint-providers.yml` from `v2.8.0` → `v2.10.1` (commit `5d1e709b7b`) so all three lint workflows use a consistent, pinned version.

## Test plan

- [ ] `golangci-lint` job in `Code Test` workflow passes
- [ ] `Extended Linting` workflow passes
- [ ] `Lint Providers` reusable workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)