### PR TITLE
Add explicit permissions block to reusable lint workflow

### DIFF
--- a/.github/workflows/reusable-lint-providers.yml
+++ b/.github/workflows/reusable-lint-providers.yml
@@ -8,6 +8,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `permissions: contents: read` to `reusable-lint-providers.yml`

## Background

Reusable workflows (`workflow_call`) without an explicit `permissions` block inherit whatever permissions the caller grants. This means if a new caller is added with broader permissions (e.g. `contents: write`), this workflow would silently gain those elevated permissions.

Adding an explicit `permissions` block acts as a ceiling — the workflow can never exceed `contents: read` regardless of what callers grant.

## Test plan

- [ ] Verify `Lint Providers` workflow still passes when called from `Code Test` and `Extended Linting`

🤖 Generated with [Claude Code](https://claude.com/claude-code)