### PR TITLE
✨ Add docker.file.shell and docker.file.workdir resources

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -25,7 +25,6 @@ bytematchstatement
 cavium
 cdn
 certificatechains
-CHAPv
 clcerts
 cloudflare
 Clusterwide
@@ -140,13 +139,12 @@ ondemand
 ontap
 opcplc
 opensearch
-OPENZFS
 openssl
 openzfs
 orstatement
 ospf
 parallelquery
-paravirtual
+pipefail
 PAYG
 Pids
 portgroup
@@ -216,6 +214,7 @@ vulnmgmt
 webide
 WEBSERVERS
 wil
+workdir
 WORKSPACESUSER
 xssmatchstatement
 ZSTD

--- a/providers/os/resources/docker_file.go
+++ b/providers/os/resources/docker_file.go
@@ -190,11 +190,13 @@ func (p *mqlDockerFile) stage2resource(stage instructions.Stage) (*mqlDockerFile
 	var copy []any
 	var add []any
 	var volumes []any
+	var workdir []any
 	var unsupported []string
 	var entrypointRaw *instructions.EntrypointCommand
 	var cmdRaw *instructions.CmdCommand
 	var userRaw *instructions.UserCommand
 	var healthcheckRaw *instructions.HealthCheckCommand
+	var shellRaw *instructions.ShellCommand
 	for i := range stage.Commands {
 		switch v := stage.Commands[i].(type) {
 		case *instructions.EnvCommand:
@@ -316,6 +318,19 @@ func (p *mqlDockerFile) stage2resource(stage instructions.Stage) (*mqlDockerFile
 				volumes = append(volumes, resource)
 			}
 
+		case *instructions.ShellCommand:
+			shellRaw = v
+
+		case *instructions.WorkdirCommand:
+			resource, err := CreateResource(p.MqlRuntime, ResourceDockerFileWorkdir, map[string]*llx.RawData{
+				"__id": llx.StringData(p.locationID(v.Location())),
+				"path": llx.StringData(v.Path),
+			})
+			if err != nil {
+				return nil, err
+			}
+			workdir = append(workdir, resource)
+
 		default:
 			cmd := stage.Commands[i]
 			unsupported = append(unsupported, cmd.Name())
@@ -339,6 +354,7 @@ func (p *mqlDockerFile) stage2resource(stage instructions.Stage) (*mqlDockerFile
 		"copy":    llx.ArrayData(copy, types.Resource(ResourceDockerFileCopy)),
 		"expose":  llx.ArrayData(expose, types.Resource(ResourceDockerFileExpose)),
 		"volumes": llx.ArrayData(volumes, types.Resource(ResourceDockerFileVolume)),
+		"workdir": llx.ArrayData(workdir, types.Resource(ResourceDockerFileWorkdir)),
 	}
 
 	if entrypointRaw != nil {
@@ -416,6 +432,23 @@ func (p *mqlDockerFile) stage2resource(stage instructions.Stage) (*mqlDockerFile
 		args["healthcheck"] = llx.ResourceData(hcResource, ResourceDockerFileHealthcheck)
 	} else {
 		args["healthcheck"] = llx.NilData
+	}
+
+	if shellRaw != nil {
+		shell := make([]any, len(shellRaw.Shell))
+		for i, s := range shellRaw.Shell {
+			shell[i] = s
+		}
+		shellResource, err := CreateResource(p.MqlRuntime, ResourceDockerFileShell, map[string]*llx.RawData{
+			"__id":    llx.StringData(p.locationID(shellRaw.Location())),
+			"command": llx.ArrayData(shell, types.String),
+		})
+		if err != nil {
+			return nil, err
+		}
+		args["shell"] = llx.ResourceData(shellResource, ResourceDockerFileShell)
+	} else {
+		args["shell"] = llx.NilData
 	}
 
 	rawStage, err := CreateResource(p.MqlRuntime, ResourceDockerFileStage, args)

--- a/providers/os/resources/docker_file_test.go
+++ b/providers/os/resources/docker_file_test.go
@@ -16,20 +16,22 @@ func TestParseDockerfile(t *testing.T) {
 		purpose           string
 		subjectDockerFile string
 
-		expectedLabels          map[string]any
-		expectedEnv             func(r *plugin.Runtime) []any
-		expectedArg             func(r *plugin.Runtime) []any
-		expectedFromImage       string
-		expectedFromTag         string
-		expectedUser            plugin.TValue[*mqlDockerFileUser]
-		expectedCmd             plugin.TValue[*mqlDockerFileRun]
-		expectedEntrypoint      plugin.TValue[*mqlDockerFileRun]
-		expectedRunStruct       []plugin.TValue[*mqlDockerFileRun]
-		expectedCopyStruct      []plugin.TValue[*mqlDockerFileCopy]
-		expectedAddStruct       []plugin.TValue[*mqlDockerFileAdd]
-		expectedExposeStructArr []plugin.TValue[*mqlDockerFileExpose]
-		expectedHealthcheck     plugin.TValue[*mqlDockerFileHealthcheck]
-		expectedVolumeStructArr []plugin.TValue[*mqlDockerFileVolume]
+		expectedLabels           map[string]any
+		expectedEnv              func(r *plugin.Runtime) []any
+		expectedArg              func(r *plugin.Runtime) []any
+		expectedFromImage        string
+		expectedFromTag          string
+		expectedUser             plugin.TValue[*mqlDockerFileUser]
+		expectedCmd              plugin.TValue[*mqlDockerFileRun]
+		expectedEntrypoint       plugin.TValue[*mqlDockerFileRun]
+		expectedRunStruct        []plugin.TValue[*mqlDockerFileRun]
+		expectedCopyStruct       []plugin.TValue[*mqlDockerFileCopy]
+		expectedAddStruct        []plugin.TValue[*mqlDockerFileAdd]
+		expectedExposeStructArr  []plugin.TValue[*mqlDockerFileExpose]
+		expectedHealthcheck      plugin.TValue[*mqlDockerFileHealthcheck]
+		expectedVolumeStructArr  []plugin.TValue[*mqlDockerFileVolume]
+		expectedShell            plugin.TValue[*mqlDockerFileShell]
+		expectedWorkdirStructArr []plugin.TValue[*mqlDockerFileWorkdir]
 	}{
 		{
 			purpose: "minimal instructions with CMD",
@@ -205,6 +207,36 @@ HEALTHCHECK NONE
 				},
 			},
 		},
+		{
+			purpose: "with SHELL and WORKDIR",
+			subjectDockerFile: `
+FROM alpine
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+WORKDIR /app
+WORKDIR /app/src
+RUN echo hello | cat
+`,
+			expectedLabels:    map[string]any{},
+			expectedFromImage: "alpine",
+			expectedShell: plugin.TValue[*mqlDockerFileShell]{
+				Data: &mqlDockerFileShell{
+					Command: plugin.TValue[[]any]{Data: []any{"/bin/bash", "-o", "pipefail", "-c"}},
+				},
+			},
+			expectedWorkdirStructArr: []plugin.TValue[*mqlDockerFileWorkdir]{
+				{Data: &mqlDockerFileWorkdir{
+					Path: plugin.TValue[string]{Data: "/app"},
+				}},
+				{Data: &mqlDockerFileWorkdir{
+					Path: plugin.TValue[string]{Data: "/app/src"},
+				}},
+			},
+			expectedRunStruct: []plugin.TValue[*mqlDockerFileRun]{
+				{Data: &mqlDockerFileRun{
+					Script: plugin.TValue[string]{Data: "echo hello | cat"},
+				}},
+			},
+		},
 	}
 
 	for _, kase := range cases {
@@ -297,6 +329,19 @@ HEALTHCHECK NONE
 			for i, vol := range actualMqlDockerFileStage.Volumes.Data {
 				actualVol := vol.(*mqlDockerFileVolume)
 				require.Equal(t, kase.expectedVolumeStructArr[i].Data.Path.Data, actualVol.Path.Data)
+			}
+
+			if kase.expectedShell.Data == nil {
+				require.Nil(t, actualMqlDockerFileStage.Shell.Data)
+			} else {
+				require.NotNil(t, actualMqlDockerFileStage.Shell.Data)
+				require.Equal(t, kase.expectedShell.Data.Command.Data, actualMqlDockerFileStage.Shell.Data.Command.Data)
+			}
+
+			require.Equal(t, len(kase.expectedWorkdirStructArr), len(actualMqlDockerFileStage.Workdir.Data))
+			for i, wd := range actualMqlDockerFileStage.Workdir.Data {
+				actualWd := wd.(*mqlDockerFileWorkdir)
+				require.Equal(t, kase.expectedWorkdirStructArr[i].Data.Path.Data, actualWd.Path.Data)
 			}
 		})
 	}

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -943,6 +943,10 @@ private docker.file.stage @defaults("from.name") {
   healthcheck docker.file.healthcheck
   // VOLUME instructions in this Dockerfile
   volumes []docker.file.volume
+  // SHELL instruction in this Dockerfile
+  shell docker.file.shell
+  // WORKDIR instructions in this Dockerfile
+  workdir []docker.file.workdir
 }
 
 // Dockerfile ARG instructions
@@ -1034,6 +1038,18 @@ private docker.file.healthcheck @defaults("test") {
 // Dockerfile VOLUME instruction
 private docker.file.volume @defaults("path") {
   // Volume mount path
+  path string
+}
+
+// Dockerfile SHELL instruction
+private docker.file.shell @defaults("command") {
+  // Shell executable and flags (e.g., ["/bin/bash", "-o", "pipefail", "-c"])
+  command []string
+}
+
+// Dockerfile WORKDIR instruction
+private docker.file.workdir @defaults("path") {
+  // Working directory path
   path string
 }
 

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -97,6 +97,8 @@ const (
 	ResourceDockerFileCopy             string = "docker.file.copy"
 	ResourceDockerFileHealthcheck      string = "docker.file.healthcheck"
 	ResourceDockerFileVolume           string = "docker.file.volume"
+	ResourceDockerFileShell            string = "docker.file.shell"
+	ResourceDockerFileWorkdir          string = "docker.file.workdir"
 	ResourceDockerImage                string = "docker.image"
 	ResourceDockerContainer            string = "docker.container"
 	ResourceContainerd                 string = "containerd"
@@ -512,6 +514,14 @@ func init() {
 		"docker.file.volume": {
 			// to override args, implement: initDockerFileVolume(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createDockerFileVolume,
+		},
+		"docker.file.shell": {
+			// to override args, implement: initDockerFileShell(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createDockerFileShell,
+		},
+		"docker.file.workdir": {
+			// to override args, implement: initDockerFileWorkdir(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createDockerFileWorkdir,
 		},
 		"docker.image": {
 			// to override args, implement: initDockerImage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -1895,6 +1905,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"docker.file.stage.volumes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDockerFileStage).GetVolumes()).ToDataRes(types.Array(types.Resource("docker.file.volume")))
 	},
+	"docker.file.stage.shell": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFileStage).GetShell()).ToDataRes(types.Resource("docker.file.shell"))
+	},
+	"docker.file.stage.workdir": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFileStage).GetWorkdir()).ToDataRes(types.Array(types.Resource("docker.file.workdir")))
+	},
 	"docker.file.arg.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDockerFileArg).GetName()).ToDataRes(types.String)
 	},
@@ -1984,6 +2000,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"docker.file.volume.path": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDockerFileVolume).GetPath()).ToDataRes(types.String)
+	},
+	"docker.file.shell.command": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFileShell).GetCommand()).ToDataRes(types.Array(types.String))
+	},
+	"docker.file.workdir.path": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFileWorkdir).GetPath()).ToDataRes(types.String)
 	},
 	"docker.image.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDockerImage).GetId()).ToDataRes(types.String)
@@ -5117,6 +5139,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDockerFileStage).Volumes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"docker.file.stage.shell": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileStage).Shell, ok = plugin.RawToTValue[*mqlDockerFileShell](v.Value, v.Error)
+		return
+	},
+	"docker.file.stage.workdir": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileStage).Workdir, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"docker.file.arg.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDockerFileArg).__id, ok = v.Value.(string)
 		return
@@ -5275,6 +5305,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"docker.file.volume.path": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDockerFileVolume).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"docker.file.shell.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileShell).__id, ok = v.Value.(string)
+		return
+	},
+	"docker.file.shell.command": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileShell).Command, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"docker.file.workdir.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileWorkdir).__id, ok = v.Value.(string)
+		return
+	},
+	"docker.file.workdir.path": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFileWorkdir).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"docker.image.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -13321,6 +13367,8 @@ type mqlDockerFileStage struct {
 	Expose      plugin.TValue[[]any]
 	Healthcheck plugin.TValue[*mqlDockerFileHealthcheck]
 	Volumes     plugin.TValue[[]any]
+	Shell       plugin.TValue[*mqlDockerFileShell]
+	Workdir     plugin.TValue[[]any]
 }
 
 // createDockerFileStage creates a new instance of this resource
@@ -13409,6 +13457,14 @@ func (c *mqlDockerFileStage) GetHealthcheck() *plugin.TValue[*mqlDockerFileHealt
 
 func (c *mqlDockerFileStage) GetVolumes() *plugin.TValue[[]any] {
 	return &c.Volumes
+}
+
+func (c *mqlDockerFileStage) GetShell() *plugin.TValue[*mqlDockerFileShell] {
+	return &c.Shell
+}
+
+func (c *mqlDockerFileStage) GetWorkdir() *plugin.TValue[[]any] {
+	return &c.Workdir
 }
 
 // mqlDockerFileArg for the docker.file.arg resource
@@ -13948,6 +14004,94 @@ func (c *mqlDockerFileVolume) MqlID() string {
 }
 
 func (c *mqlDockerFileVolume) GetPath() *plugin.TValue[string] {
+	return &c.Path
+}
+
+// mqlDockerFileShell for the docker.file.shell resource
+type mqlDockerFileShell struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlDockerFileShellInternal it will be used here
+	Command plugin.TValue[[]any]
+}
+
+// createDockerFileShell creates a new instance of this resource
+func createDockerFileShell(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlDockerFileShell{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("docker.file.shell", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlDockerFileShell) MqlName() string {
+	return "docker.file.shell"
+}
+
+func (c *mqlDockerFileShell) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlDockerFileShell) GetCommand() *plugin.TValue[[]any] {
+	return &c.Command
+}
+
+// mqlDockerFileWorkdir for the docker.file.workdir resource
+type mqlDockerFileWorkdir struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlDockerFileWorkdirInternal it will be used here
+	Path plugin.TValue[string]
+}
+
+// createDockerFileWorkdir creates a new instance of this resource
+func createDockerFileWorkdir(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlDockerFileWorkdir{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("docker.file.workdir", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlDockerFileWorkdir) MqlName() string {
+	return "docker.file.workdir"
+}
+
+func (c *mqlDockerFileWorkdir) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlDockerFileWorkdir) GetPath() *plugin.TValue[string] {
 	return &c.Path
 }
 

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -185,6 +185,8 @@ docker.file.healthcheck.timeout 11.8.14
 docker.file.instructions 11.0.2
 docker.file.run 11.0.2
 docker.file.run.script 11.0.2
+docker.file.shell 11.8.15
+docker.file.shell.command 11.8.15
 docker.file.stage 11.0.2
 docker.file.stage.add 11.0.2
 docker.file.stage.arg 11.0.2
@@ -198,14 +200,18 @@ docker.file.stage.from 11.0.2
 docker.file.stage.healthcheck 11.8.14
 docker.file.stage.labels 11.0.2
 docker.file.stage.run 11.0.2
+docker.file.stage.shell 11.8.15
 docker.file.stage.user 11.0.2
 docker.file.stage.volumes 11.8.14
+docker.file.stage.workdir 11.8.15
 docker.file.stages 11.0.2
 docker.file.user 11.1.3
 docker.file.user.group 11.1.3
 docker.file.user.user 11.1.3
 docker.file.volume 11.8.14
 docker.file.volume.path 11.8.14
+docker.file.workdir 11.8.15
+docker.file.workdir.path 11.8.15
 docker.image 9.0.0
 docker.image.id 9.0.0
 docker.image.labels 9.0.0


### PR DESCRIPTION
## Summary
- Add `docker.file.shell` resource to expose the Dockerfile `SHELL` instruction (executable and flags)
- Add `docker.file.workdir` resource to expose Dockerfile `WORKDIR` instructions (directory paths)
- Both are accessible via `docker.file.stage.shell` and `docker.file.stage.workdir`
- Extends the recent healthcheck/volume work from #6773

## Test plan
- [x] Unit tests added for SHELL and WORKDIR parsing
- [ ] Verify `mql run docker.file("/path/to/Dockerfile").stages { shell workdir }` returns expected values
- [ ] Confirm existing Dockerfile parsing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)