### PR TITLE
🔒 Pin quill install script to v0.5.1 commit hash

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -130,7 +130,8 @@ jobs:
 
       - name: Install Quill for Mac Signing and Notarization
         run: |
-          curl -sSfL https://raw.githubusercontent.com/anchore/quill/main/install.sh | sh -s -- -b /tmp
+          # anchore/quill v0.5.1
+          curl -sSfL https://raw.githubusercontent.com/anchore/quill/026e6f927f9b7ddfc764f205fd681cdc2be9380e/install.sh | sh -s -- -b /tmp
           /tmp/quill help
 
       - name: Log in to the Container registry


### PR DESCRIPTION
## Summary

- Pins the anchore/quill `install.sh` download URL from `main` branch reference to the specific commit hash (`026e6f927f9b7ddfc764f205fd681cdc2be9380e`) corresponding to v0.5.1
- Adds a version comment for easier identification of the pinned version

## Why pin to a commit hash?

Referencing `main` means our CI fetches whatever the latest commit happens to be at build time. This is a supply-chain risk:

- **Immutability**: A commit hash is immutable — it always resolves to the exact same content. A branch ref like `main` changes with every push.
- **Tamper resistance**: If the upstream repo is compromised (e.g., a maintainer account is hijacked), an attacker could push malicious code to `main` that our CI would blindly execute. A pinned hash is unaffected.
- **Reproducibility**: Builds are deterministic — the same hash always produces the same install script, making debugging and auditing easier.
- **Intentional upgrades**: Updates require an explicit PR to change the hash, creating a reviewable audit trail instead of silent, unreviewed changes.

This follows the same pattern already used for other CI dependencies in this repo (e.g., the pinned golangci-lint in #6769).

## Test plan

- [ ] Verify goreleaser workflow still installs quill successfully
- [ ] Confirm Mac signing and notarization works in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)