### PR TITLE
ci: pipeline fixes for v13 release

### DIFF
--- a/.github/.goreleaser-unstable.yml
+++ b/.github/.goreleaser-unstable.yml
@@ -78,14 +78,14 @@ nfpms:
     overrides:
       deb:
         conflicts:
-          - cnquery (<= 13)
+          - cnquery (< 13)
         replaces:
-          - cnquery (<= 13)
+          - cnquery (< 13)
       rpm:
         conflicts:
-          - cnquery <= 13
-        obsoletes:
-          - cnquery <= 13
+          - cnquery < 13
+        replaces:
+          - cnquery < 13
     rpm:
       signature:
         key_file: '{{ .Env.GPG_KEY_PATH }}'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -78,14 +78,14 @@ nfpms:
     overrides:
       deb:
         conflicts:
-          - cnquery (<= 13)
+          - cnquery (< 13)
         replaces:
-          - cnquery (<= 13)
+          - cnquery (< 13)
       rpm:
         conflicts:
-          - cnquery <= 13
-        obsoletes:
-          - cnquery <= 13
+          - cnquery < 13
+        replaces:
+          - cnquery < 13
     rpm:
       signature:
         key_file: '{{ .Env.GPG_KEY_PATH }}'


### PR DESCRIPTION
- Add `conflicts:` statement for cnquery <-> mql package for clean upgrade
- Publish containers tagged with major version on unstable release