### PR TITLE
Fix integration tests failing with go test -cover

### DIFF
--- a/test/cli_test_runner.go
+++ b/test/cli_test_runner.go
@@ -7,7 +7,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
+	"strings"
 )
 
 type Runner interface {
@@ -69,4 +71,18 @@ func (c *cliTestRunner) Stderr() []byte {
 
 func (c *cliTestRunner) Json(v any) error {
 	return json.Unmarshal(c.Stdout(), v)
+}
+
+// BuildEnv returns the current environment with GOCOVERDIR removed.
+// When tests run with -cover, Go sets GOCOVERDIR which is inherited by child
+// processes. Programs spawned via "go run" or "go build" are not built with
+// -cover, so they fail at exit when trying to write coverage data.
+func BuildEnv() []string {
+	var env []string
+	for _, e := range os.Environ() {
+		if !strings.HasPrefix(e, "GOCOVERDIR=") {
+			env = append(env, e)
+		}
+	}
+	return env
 }

--- a/test/commands/cli_test.go
+++ b/test/commands/cli_test.go
@@ -9,35 +9,21 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"strings"
 	"sync"
 	"testing"
 
 	"github.com/google/go-cmdtest"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/test"
 )
 
 var once sync.Once
 var testDir string
 
-// buildEnv returns the current environment with GOCOVERDIR removed.
-// When tests run with -cover, Go sets GOCOVERDIR which is inherited by child
-// processes. Programs spawned via "go run" or "go build" are not built with
-// -cover, so they fail at exit when trying to write coverage data.
-func buildEnv() []string {
-	var env []string
-	for _, e := range os.Environ() {
-		if !strings.HasPrefix(e, "GOCOVERDIR=") {
-			env = append(env, e)
-		}
-	}
-	return env
-}
-
 func setup() {
 	// build cnquery
 	cmd := exec.Command("go", "build", "../../apps/mql/mql.go")
-	cmd.Env = buildEnv()
+	cmd.Env = test.BuildEnv()
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	if err := cmd.Run(); err != nil {
@@ -46,7 +32,7 @@ func setup() {
 
 	// install local provider
 	providerCmd := exec.Command("bash", "-c", "cd ../.. && make providers/build/os providers/install/os")
-	providerCmd.Env = buildEnv()
+	providerCmd.Env = test.BuildEnv()
 	if err := providerCmd.Run(); err != nil {
 		log.Fatalf("building os provider: %v", err)
 	}

--- a/test/providers/os_test.go
+++ b/test/providers/os_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"sync"
 	"testing"
 
@@ -19,32 +18,18 @@ import (
 
 var once sync.Once
 
-// buildEnv returns the current environment with GOCOVERDIR removed.
-// When tests run with -cover, Go sets GOCOVERDIR which is inherited by child
-// processes. Programs spawned via "go run" or "go build" are not built with
-// -cover, so they fail at exit when trying to write coverage data.
-func buildEnv() []string {
-	var env []string
-	for _, e := range os.Environ() {
-		if !strings.HasPrefix(e, "GOCOVERDIR=") {
-			env = append(env, e)
-		}
-	}
-	return env
-}
-
 // setup builds mql locally
 func setup() {
 	// build mql
 	cmd := exec.Command("go", "build", "../../apps/mql/mql.go")
-	cmd.Env = buildEnv()
+	cmd.Env = test.BuildEnv()
 	if err := cmd.Run(); err != nil {
 		log.Fatalf("building mql: %v", err)
 	}
 
 	// install local provider
 	providerCmd := exec.Command("bash", "-c", "cd ../.. && make providers/build/os providers/install/os")
-	providerCmd.Env = buildEnv()
+	providerCmd.Env = test.BuildEnv()
 	if err := providerCmd.Run(); err != nil {
 		log.Fatalf("building os provider: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Strip `GOCOVERDIR` from the environment passed to child build commands in integration test setup
- When `go test -cover` runs, Go sets `GOCOVERDIR` which is inherited by child processes (`go build`, `go run`, `make`). These aren't built with `-cover` and fail at exit when trying to write coverage data
- Fixes the `program not built with -cover` error in `test/commands` and `test/providers`

## Test plan
- [ ] CI `go-test-integration` job passes with `-cover` flag
- [x] Normal `make providers/build/os` still works without changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)