### PR TITLE
📄 Update resource count and docs link

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This directory contains information to help Claude AI assistants understand and 
 
 ## 1. Project Context
 
-**mql** (formerly cnquery) is a cloud-native infrastructure querying tool. It uses **MQL (Mondoo Query Language)** to query over 850 resources across cloud accounts (AWS, Azure, GCP), Kubernetes, containers, OS internals, and APIs.
+**mql** (formerly cnquery) is a cloud-native infrastructure querying tool. It uses **MQL (Mondoo Query Language)** to query over 1,300 resources across cloud accounts (AWS, Azure, GCP), Kubernetes, containers, OS internals, and APIs.
 
 > **v13 Rename:** In v13 the project was renamed from `cnquery` to `mql`. The Go module is `go.mondoo.com/mql/v13`, the CLI binary is `mql`, and all build targets use the `mql/` prefix. The `scan` and `sbom` subcommands have moved to **cnspec**.
 
@@ -516,7 +516,7 @@ Use emojis in commit messages (but don't worry about it, since you're NEVER goin
 ## 10. Additional Resources
 
 ### External Documentation
-- [Official Documentation](https://mondoo.com/docs/cnquery/home/)
+- [Official Documentation](https://mondoo.com/docs/llms.txt)
 - [MQL Introduction](https://mondoohq.github.io/mql-intro/index.html)
 - [MQL Language Reference](https://mondoo.com/docs/mql/resources/)
 - [GitHub Repository](https://github.com/mondoohq/mql)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Open source, cloud-native asset inventory and discovery**
 
-MQL is a cloud-native tool for querying your entire infrastructure. Built upon Mondoo's security data fabric, it answers thousands of questions about your infrastructure and integrates with over 850 resources across cloud accounts, Kubernetes, containers, services, VMs, APIs, and more.
+MQL is a cloud-native tool for querying your entire infrastructure. Built upon Mondoo's security data fabric, it answers thousands of questions about your infrastructure and integrates with over 1,300 resources across cloud accounts, Kubernetes, containers, services, VMs, APIs, and more.
 
 ![MQL run example](.github/images/mql-run.gif)
 


### PR DESCRIPTION
## Summary
- Updated resource count from "over 850" to "over 1,300" in both `README.md` and `CLAUDE.md` (actual count: 1,356 across 30 providers)
- Updated CLAUDE.md docs link to point to `llms.txt` for LLM-friendly documentation access

## Test plan
- [ ] Verify links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)