### PR TITLE
✨ make azure resource changes non-breaking

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -2669,30 +2669,50 @@ private azure.subscription.cloudDefenderService @defaults("defenderForServers.en
   subscriptionId string
   // Whether the monitoring agent is automatically provisioned on new VMs
   monitoringAgentAutoProvision() bool
+  // Deprecated; use "forServers" instead. List of Defender for Servers components and whether they are enabled
+  defenderForServers() dict
   // List of Defender for Servers components and whether they are enabled
-  defenderForServers() azure.subscription.cloudDefenderService.defenderForServers
+  forServers() azure.subscription.cloudDefenderService.defenderForServers
+  // Deprecated; use "forAppServices" instead. Microsoft Defender for App Service configuration
+  defenderForAppServices() dict
   // Microsoft Defender for App Service configuration
-  defenderForAppServices() azure.subscription.cloudDefenderService.defenderForAppServices
+  forAppServices() azure.subscription.cloudDefenderService.defenderForAppServices
+  // Deprecated; use "forSqlServersOnMachines" instead. Microsoft Defender for SQL servers on machines configuration
+  defenderForSqlServersOnMachines() dict
   // Microsoft Defender for SQL servers on machines configuration
-  defenderForSqlServersOnMachines() azure.subscription.cloudDefenderService.defenderForSqlServersOnMachines
+  forSqlServersOnMachines() azure.subscription.cloudDefenderService.defenderForSqlServersOnMachines
+  // Deprecated; use "forSqlDatabases" instead. Microsoft Defender for Azure SQL Databases configuration
+  defenderForSqlDatabases() dict
   // Microsoft Defender for Azure SQL Databases configuration
-  defenderForSqlDatabases() azure.subscription.cloudDefenderService.defenderForSqlDatabases
+  forSqlDatabases() azure.subscription.cloudDefenderService.defenderForSqlDatabases
+  // Deprecated; use "forOpenSourceDatabases" instead. Microsoft Defender for open-source relational databases configuration
+  defenderForOpenSourceDatabases() dict
   // Microsoft Defender for open-source relational databases configuration
-  defenderForOpenSourceDatabases() azure.subscription.cloudDefenderService.defenderForOpenSourceDatabases
+  forOpenSourceDatabases() azure.subscription.cloudDefenderService.defenderForOpenSourceDatabases
+  // Deprecated; use "forCosmosDb" instead. Microsoft Defender for Azure Cosmos DB configuration
+  defenderForCosmosDb() dict
   // Microsoft Defender for Azure Cosmos DB configuration
-  defenderForCosmosDb() azure.subscription.cloudDefenderService.defenderForCosmosDb
+  forCosmosDb() azure.subscription.cloudDefenderService.defenderForCosmosDb
+  // Deprecated; use "forStorageAccounts" instead. Microsoft Defender for Storage Accounts configuration
+  defenderForStorageAccounts() dict
   // Microsoft Defender for Storage Accounts configuration
-  defenderForStorageAccounts() azure.subscription.cloudDefenderService.defenderForStorageAccounts
+  forStorageAccounts() azure.subscription.cloudDefenderService.defenderForStorageAccounts
+  // Deprecated; use "forKeyVaults" instead. Microsoft Defender for Key Vault configuration
+  defenderForKeyVaults() dict
   // Microsoft Defender for Key Vault configuration
-  defenderForKeyVaults() azure.subscription.cloudDefenderService.defenderForKeyVaults
+  forKeyVaults() azure.subscription.cloudDefenderService.defenderForKeyVaults
+  // Deprecated; use "forResourceManager" instead. Microsoft Defender for Resource Manager configuration
+  defenderForResourceManager() dict
   // Microsoft Defender for Resource Manager configuration
-  defenderForResourceManager() azure.subscription.cloudDefenderService.defenderForResourceManager
+  forResourceManager() azure.subscription.cloudDefenderService.defenderForResourceManager
   // Microsoft Defender for APIs configuration
   defenderForApis() azure.subscription.cloudDefenderService.defenderForApis
   // Microsoft Defender Cloud Security Posture Management (CSPM) configuration
   defenderCSPM() azure.subscription.cloudDefenderService.defenderCSPM
+  // Deprecated; use "forContainers" instead. Defender for Containers components configuration
+  defenderForContainers() dict
   // Defender for Containers components configuration
-  defenderForContainers() azure.subscription.cloudDefenderService.defenderForContainers
+  forContainers() azure.subscription.cloudDefenderService.defenderForContainers
   // List of configured security contacts
   securityContacts() []azure.subscription.cloudDefenderService.securityContact
   // Settings for MCAS

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -4174,31 +4174,58 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetMonitoringAgentAutoProvision()).ToDataRes(types.Bool)
 	},
 	"azure.subscription.cloudDefenderService.defenderForServers": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForServers()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForServers"))
+		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForServers()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.cloudDefenderService.forServers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetForServers()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForServers"))
 	},
 	"azure.subscription.cloudDefenderService.defenderForAppServices": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForAppServices()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForAppServices"))
+		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForAppServices()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.cloudDefenderService.forAppServices": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetForAppServices()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForAppServices"))
 	},
 	"azure.subscription.cloudDefenderService.defenderForSqlServersOnMachines": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForSqlServersOnMachines()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForSqlServersOnMachines"))
+		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForSqlServersOnMachines()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.cloudDefenderService.forSqlServersOnMachines": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetForSqlServersOnMachines()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForSqlServersOnMachines"))
 	},
 	"azure.subscription.cloudDefenderService.defenderForSqlDatabases": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForSqlDatabases()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForSqlDatabases"))
+		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForSqlDatabases()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.cloudDefenderService.forSqlDatabases": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetForSqlDatabases()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForSqlDatabases"))
 	},
 	"azure.subscription.cloudDefenderService.defenderForOpenSourceDatabases": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForOpenSourceDatabases()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForOpenSourceDatabases"))
+		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForOpenSourceDatabases()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.cloudDefenderService.forOpenSourceDatabases": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetForOpenSourceDatabases()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForOpenSourceDatabases"))
 	},
 	"azure.subscription.cloudDefenderService.defenderForCosmosDb": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForCosmosDb()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForCosmosDb"))
+		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForCosmosDb()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.cloudDefenderService.forCosmosDb": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetForCosmosDb()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForCosmosDb"))
 	},
 	"azure.subscription.cloudDefenderService.defenderForStorageAccounts": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForStorageAccounts()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForStorageAccounts"))
+		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForStorageAccounts()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.cloudDefenderService.forStorageAccounts": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetForStorageAccounts()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForStorageAccounts"))
 	},
 	"azure.subscription.cloudDefenderService.defenderForKeyVaults": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForKeyVaults()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForKeyVaults"))
+		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForKeyVaults()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.cloudDefenderService.forKeyVaults": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetForKeyVaults()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForKeyVaults"))
 	},
 	"azure.subscription.cloudDefenderService.defenderForResourceManager": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForResourceManager()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForResourceManager"))
+		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForResourceManager()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.cloudDefenderService.forResourceManager": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetForResourceManager()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForResourceManager"))
 	},
 	"azure.subscription.cloudDefenderService.defenderForApis": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForApis()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForApis"))
@@ -4207,7 +4234,10 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderCSPM()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderCSPM"))
 	},
 	"azure.subscription.cloudDefenderService.defenderForContainers": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForContainers()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForContainers"))
+		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForContainers()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.cloudDefenderService.forContainers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetForContainers()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForContainers"))
 	},
 	"azure.subscription.cloudDefenderService.securityContacts": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetSecurityContacts()).ToDataRes(types.Array(types.Resource("azure.subscription.cloudDefenderService.securityContact")))
@@ -10072,39 +10102,75 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"azure.subscription.cloudDefenderService.defenderForServers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForServers, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers](v.Value, v.Error)
+		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForServers, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.forServers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderService).ForServers, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cloudDefenderService.defenderForAppServices": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForAppServices, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForAppServices](v.Value, v.Error)
+		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForAppServices, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.forAppServices": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderService).ForAppServices, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForAppServices](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cloudDefenderService.defenderForSqlServersOnMachines": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForSqlServersOnMachines, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines](v.Value, v.Error)
+		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForSqlServersOnMachines, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.forSqlServersOnMachines": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderService).ForSqlServersOnMachines, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cloudDefenderService.defenderForSqlDatabases": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForSqlDatabases, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlDatabases](v.Value, v.Error)
+		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForSqlDatabases, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.forSqlDatabases": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderService).ForSqlDatabases, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlDatabases](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cloudDefenderService.defenderForOpenSourceDatabases": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForOpenSourceDatabases, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases](v.Value, v.Error)
+		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForOpenSourceDatabases, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.forOpenSourceDatabases": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderService).ForOpenSourceDatabases, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cloudDefenderService.defenderForCosmosDb": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForCosmosDb, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForCosmosDb](v.Value, v.Error)
+		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForCosmosDb, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.forCosmosDb": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderService).ForCosmosDb, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForCosmosDb](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cloudDefenderService.defenderForStorageAccounts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForStorageAccounts, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts](v.Value, v.Error)
+		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForStorageAccounts, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.forStorageAccounts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderService).ForStorageAccounts, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cloudDefenderService.defenderForKeyVaults": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForKeyVaults, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults](v.Value, v.Error)
+		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForKeyVaults, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.forKeyVaults": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderService).ForKeyVaults, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cloudDefenderService.defenderForResourceManager": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForResourceManager, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForResourceManager](v.Value, v.Error)
+		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForResourceManager, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.forResourceManager": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderService).ForResourceManager, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForResourceManager](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cloudDefenderService.defenderForApis": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10116,7 +10182,11 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"azure.subscription.cloudDefenderService.defenderForContainers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForContainers, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers](v.Value, v.Error)
+		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForContainers, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.forContainers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderService).ForContainers, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cloudDefenderService.securityContacts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -24075,18 +24145,28 @@ type mqlAzureSubscriptionCloudDefenderService struct {
 	// optional: if you define mqlAzureSubscriptionCloudDefenderServiceInternal it will be used here
 	SubscriptionId                  plugin.TValue[string]
 	MonitoringAgentAutoProvision    plugin.TValue[bool]
-	DefenderForServers              plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers]
-	DefenderForAppServices          plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForAppServices]
-	DefenderForSqlServersOnMachines plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines]
-	DefenderForSqlDatabases         plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlDatabases]
-	DefenderForOpenSourceDatabases  plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases]
-	DefenderForCosmosDb             plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForCosmosDb]
-	DefenderForStorageAccounts      plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts]
-	DefenderForKeyVaults            plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults]
-	DefenderForResourceManager      plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForResourceManager]
+	DefenderForServers              plugin.TValue[any]
+	ForServers                      plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers]
+	DefenderForAppServices          plugin.TValue[any]
+	ForAppServices                  plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForAppServices]
+	DefenderForSqlServersOnMachines plugin.TValue[any]
+	ForSqlServersOnMachines         plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines]
+	DefenderForSqlDatabases         plugin.TValue[any]
+	ForSqlDatabases                 plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlDatabases]
+	DefenderForOpenSourceDatabases  plugin.TValue[any]
+	ForOpenSourceDatabases          plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases]
+	DefenderForCosmosDb             plugin.TValue[any]
+	ForCosmosDb                     plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForCosmosDb]
+	DefenderForStorageAccounts      plugin.TValue[any]
+	ForStorageAccounts              plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts]
+	DefenderForKeyVaults            plugin.TValue[any]
+	ForKeyVaults                    plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults]
+	DefenderForResourceManager      plugin.TValue[any]
+	ForResourceManager              plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForResourceManager]
 	DefenderForApis                 plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForApis]
 	DefenderCSPM                    plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderCSPM]
-	DefenderForContainers           plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers]
+	DefenderForContainers           plugin.TValue[any]
+	ForContainers                   plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers]
 	SecurityContacts                plugin.TValue[[]any]
 	SettingsMCAS                    plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceSettings]
 	SettingsWDATP                   plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceSettings]
@@ -24140,10 +24220,16 @@ func (c *mqlAzureSubscriptionCloudDefenderService) GetMonitoringAgentAutoProvisi
 	})
 }
 
-func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForServers() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers] {
-	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers](&c.DefenderForServers, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers, error) {
+func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForServers() *plugin.TValue[any] {
+	return plugin.GetOrCompute[any](&c.DefenderForServers, func() (any, error) {
+		return c.defenderForServers()
+	})
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderService) GetForServers() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers](&c.ForServers, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers, error) {
 		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService", c.__id, "defenderForServers")
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService", c.__id, "forServers")
 			if err != nil {
 				return nil, err
 			}
@@ -24152,14 +24238,20 @@ func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForServers() *plug
 			}
 		}
 
-		return c.defenderForServers()
+		return c.forServers()
 	})
 }
 
-func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForAppServices() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForAppServices] {
-	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForAppServices](&c.DefenderForAppServices, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForAppServices, error) {
+func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForAppServices() *plugin.TValue[any] {
+	return plugin.GetOrCompute[any](&c.DefenderForAppServices, func() (any, error) {
+		return c.defenderForAppServices()
+	})
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderService) GetForAppServices() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForAppServices] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForAppServices](&c.ForAppServices, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForAppServices, error) {
 		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService", c.__id, "defenderForAppServices")
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService", c.__id, "forAppServices")
 			if err != nil {
 				return nil, err
 			}
@@ -24168,14 +24260,20 @@ func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForAppServices() *
 			}
 		}
 
-		return c.defenderForAppServices()
+		return c.forAppServices()
 	})
 }
 
-func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForSqlServersOnMachines() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines] {
-	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines](&c.DefenderForSqlServersOnMachines, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines, error) {
+func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForSqlServersOnMachines() *plugin.TValue[any] {
+	return plugin.GetOrCompute[any](&c.DefenderForSqlServersOnMachines, func() (any, error) {
+		return c.defenderForSqlServersOnMachines()
+	})
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderService) GetForSqlServersOnMachines() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines](&c.ForSqlServersOnMachines, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines, error) {
 		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService", c.__id, "defenderForSqlServersOnMachines")
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService", c.__id, "forSqlServersOnMachines")
 			if err != nil {
 				return nil, err
 			}
@@ -24184,14 +24282,20 @@ func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForSqlServersOnMac
 			}
 		}
 
-		return c.defenderForSqlServersOnMachines()
+		return c.forSqlServersOnMachines()
 	})
 }
 
-func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForSqlDatabases() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlDatabases] {
-	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlDatabases](&c.DefenderForSqlDatabases, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlDatabases, error) {
+func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForSqlDatabases() *plugin.TValue[any] {
+	return plugin.GetOrCompute[any](&c.DefenderForSqlDatabases, func() (any, error) {
+		return c.defenderForSqlDatabases()
+	})
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderService) GetForSqlDatabases() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlDatabases] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlDatabases](&c.ForSqlDatabases, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlDatabases, error) {
 		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService", c.__id, "defenderForSqlDatabases")
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService", c.__id, "forSqlDatabases")
 			if err != nil {
 				return nil, err
 			}
@@ -24200,14 +24304,20 @@ func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForSqlDatabases() 
 			}
 		}
 
-		return c.defenderForSqlDatabases()
+		return c.forSqlDatabases()
 	})
 }
 
-func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForOpenSourceDatabases() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases] {
-	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases](&c.DefenderForOpenSourceDatabases, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases, error) {
+func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForOpenSourceDatabases() *plugin.TValue[any] {
+	return plugin.GetOrCompute[any](&c.DefenderForOpenSourceDatabases, func() (any, error) {
+		return c.defenderForOpenSourceDatabases()
+	})
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderService) GetForOpenSourceDatabases() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases](&c.ForOpenSourceDatabases, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases, error) {
 		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService", c.__id, "defenderForOpenSourceDatabases")
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService", c.__id, "forOpenSourceDatabases")
 			if err != nil {
 				return nil, err
 			}
@@ -24216,14 +24326,20 @@ func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForOpenSourceDatab
 			}
 		}
 
-		return c.defenderForOpenSourceDatabases()
+		return c.forOpenSourceDatabases()
 	})
 }
 
-func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForCosmosDb() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForCosmosDb] {
-	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForCosmosDb](&c.DefenderForCosmosDb, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForCosmosDb, error) {
+func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForCosmosDb() *plugin.TValue[any] {
+	return plugin.GetOrCompute[any](&c.DefenderForCosmosDb, func() (any, error) {
+		return c.defenderForCosmosDb()
+	})
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderService) GetForCosmosDb() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForCosmosDb] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForCosmosDb](&c.ForCosmosDb, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForCosmosDb, error) {
 		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService", c.__id, "defenderForCosmosDb")
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService", c.__id, "forCosmosDb")
 			if err != nil {
 				return nil, err
 			}
@@ -24232,14 +24348,20 @@ func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForCosmosDb() *plu
 			}
 		}
 
-		return c.defenderForCosmosDb()
+		return c.forCosmosDb()
 	})
 }
 
-func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForStorageAccounts() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts] {
-	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts](&c.DefenderForStorageAccounts, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts, error) {
+func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForStorageAccounts() *plugin.TValue[any] {
+	return plugin.GetOrCompute[any](&c.DefenderForStorageAccounts, func() (any, error) {
+		return c.defenderForStorageAccounts()
+	})
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderService) GetForStorageAccounts() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts](&c.ForStorageAccounts, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts, error) {
 		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService", c.__id, "defenderForStorageAccounts")
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService", c.__id, "forStorageAccounts")
 			if err != nil {
 				return nil, err
 			}
@@ -24248,14 +24370,20 @@ func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForStorageAccounts
 			}
 		}
 
-		return c.defenderForStorageAccounts()
+		return c.forStorageAccounts()
 	})
 }
 
-func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForKeyVaults() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults] {
-	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults](&c.DefenderForKeyVaults, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults, error) {
+func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForKeyVaults() *plugin.TValue[any] {
+	return plugin.GetOrCompute[any](&c.DefenderForKeyVaults, func() (any, error) {
+		return c.defenderForKeyVaults()
+	})
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderService) GetForKeyVaults() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults](&c.ForKeyVaults, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults, error) {
 		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService", c.__id, "defenderForKeyVaults")
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService", c.__id, "forKeyVaults")
 			if err != nil {
 				return nil, err
 			}
@@ -24264,14 +24392,20 @@ func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForKeyVaults() *pl
 			}
 		}
 
-		return c.defenderForKeyVaults()
+		return c.forKeyVaults()
 	})
 }
 
-func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForResourceManager() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForResourceManager] {
-	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForResourceManager](&c.DefenderForResourceManager, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForResourceManager, error) {
+func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForResourceManager() *plugin.TValue[any] {
+	return plugin.GetOrCompute[any](&c.DefenderForResourceManager, func() (any, error) {
+		return c.defenderForResourceManager()
+	})
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderService) GetForResourceManager() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForResourceManager] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForResourceManager](&c.ForResourceManager, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForResourceManager, error) {
 		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService", c.__id, "defenderForResourceManager")
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService", c.__id, "forResourceManager")
 			if err != nil {
 				return nil, err
 			}
@@ -24280,7 +24414,7 @@ func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForResourceManager
 			}
 		}
 
-		return c.defenderForResourceManager()
+		return c.forResourceManager()
 	})
 }
 
@@ -24316,10 +24450,16 @@ func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderCSPM() *plugin.TVa
 	})
 }
 
-func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForContainers() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers] {
-	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers](&c.DefenderForContainers, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers, error) {
+func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForContainers() *plugin.TValue[any] {
+	return plugin.GetOrCompute[any](&c.DefenderForContainers, func() (any, error) {
+		return c.defenderForContainers()
+	})
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderService) GetForContainers() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers](&c.ForContainers, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers, error) {
 		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService", c.__id, "defenderForContainers")
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService", c.__id, "forContainers")
 			if err != nil {
 				return nil, err
 			}
@@ -24328,7 +24468,7 @@ func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForContainers() *p
 			}
 		}
 
-		return c.defenderForContainers()
+		return c.forContainers()
 	})
 }
 

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -383,6 +383,16 @@ azure.subscription.cloudDefenderService.defenderForStorageAccounts.replacedBy 11
 azure.subscription.cloudDefenderService.defenderForStorageAccounts.resourcesCoverageStatus 11.6.1
 azure.subscription.cloudDefenderService.defenderForStorageAccounts.subPlan 11.6.1
 azure.subscription.cloudDefenderService.defenderForStorageAccounts.subscriptionId 11.6.1
+azure.subscription.cloudDefenderService.forAppServices 11.6.3
+azure.subscription.cloudDefenderService.forContainers 11.6.3
+azure.subscription.cloudDefenderService.forCosmosDb 11.6.3
+azure.subscription.cloudDefenderService.forKeyVaults 11.6.3
+azure.subscription.cloudDefenderService.forOpenSourceDatabases 11.6.3
+azure.subscription.cloudDefenderService.forResourceManager 11.6.3
+azure.subscription.cloudDefenderService.forServers 11.6.3
+azure.subscription.cloudDefenderService.forSqlDatabases 11.6.3
+azure.subscription.cloudDefenderService.forSqlServersOnMachines 11.6.3
+azure.subscription.cloudDefenderService.forStorageAccounts 11.6.3
 azure.subscription.cloudDefenderService.monitoringAgentAutoProvision 9.0.1
 azure.subscription.cloudDefenderService.securityContact 9.0.1
 azure.subscription.cloudDefenderService.securityContact.alertNotifications 9.0.1

--- a/providers/azure/resources/cloud_defender.go
+++ b/providers/azure/resources/cloud_defender.go
@@ -129,6 +129,36 @@ func commonPricingArgs(props *security.PricingProperties, mqlResourceName, subId
 	return args
 }
 
+// getSimpleDictPricing fetches pricing data for a Defender component and returns it as a dict
+// with a single "enabled" boolean field. Used by the deprecated defenderForX() dict methods.
+func (a *mqlAzureSubscriptionCloudDefenderService) getSimpleDictPricing(azurePricingName string) (any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+	token := conn.Token()
+	subId := a.SubscriptionId.Data
+
+	clientFactory, err := armsecurity.NewClientFactory(subId, token, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	pricing, err := clientFactory.NewPricingsClient().Get(ctx, fmt.Sprintf("subscriptions/%s", subId), azurePricingName, &security.PricingsClientGetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	type simplePricing struct {
+		Enabled bool `json:"enabled"`
+	}
+
+	resp := simplePricing{}
+	if pricing.Properties != nil && pricing.Properties.PricingTier != nil {
+		resp.Enabled = *pricing.Properties.PricingTier == security.PricingTierStandard
+	}
+
+	return convert.JsonToDict(resp)
+}
+
 // getSimpleDefenderPricing fetches pricing data for a Defender component and creates a typed resource.
 func (a *mqlAzureSubscriptionCloudDefenderService) getSimpleDefenderPricing(azurePricingName, mqlResourceName string) (plugin.Resource, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
@@ -150,7 +180,59 @@ func (a *mqlAzureSubscriptionCloudDefenderService) getSimpleDefenderPricing(azur
 	return CreateResource(a.MqlRuntime, mqlResourceName, args)
 }
 
-func (a *mqlAzureSubscriptionCloudDefenderService) defenderForServers() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers, error) {
+func (a *mqlAzureSubscriptionCloudDefenderService) defenderForServers() (any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+	token := conn.Token()
+	subId := a.SubscriptionId.Data
+	clientFactory, err := armsecurity.NewClientFactory(subId, token, nil)
+	if err != nil {
+		return nil, err
+	}
+	vmPricing, err := clientFactory.NewPricingsClient().Get(ctx, fmt.Sprintf("subscriptions/%s", subId), "VirtualMachines", &security.PricingsClientGetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	armConn, err := getArmSecurityConnection(ctx, conn, subId)
+	if err != nil {
+		return nil, err
+	}
+	list, err := getPolicyAssignments(ctx, armConn)
+	if err != nil {
+		return nil, err
+	}
+	serverVASetings, err := getServerVulnAssessmentSettings(ctx, armConn)
+	if err != nil {
+		return nil, err
+	}
+
+	type defenderForServers struct {
+		Enabled                         bool   `json:"enabled"`
+		VulnerabilityManagementToolName string `json:"vulnerabilityManagementToolName"`
+	}
+
+	resp := defenderForServers{}
+	if vmPricing.Properties.PricingTier != nil {
+		resp.Enabled = *vmPricing.Properties.PricingTier == security.PricingTierStandard
+	}
+
+	for _, it := range list.PolicyAssignments {
+		if it.Properties.PolicyDefinitionID == vaQualysPolicyDefinitionId {
+			resp.Enabled = true
+			resp.VulnerabilityManagementToolName = "Microsoft Defender for Cloud integrated Qualys scanner"
+		}
+	}
+	for _, sett := range serverVASetings.Settings {
+		if sett.Properties.SelectedProvider == "MdeTvm" && sett.Name == "AzureServersSetting" {
+			resp.Enabled = true
+			resp.VulnerabilityManagementToolName = "Microsoft Defender vulnerability management"
+		}
+	}
+	return convert.JsonToDict(resp)
+}
+
+func (a *mqlAzureSubscriptionCloudDefenderService) forServers() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	ctx := context.Background()
 	token := conn.Token()
@@ -205,7 +287,11 @@ func (a *mqlAzureSubscriptionCloudDefenderService) defenderForServers() (*mqlAzu
 	return resource.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers), nil
 }
 
-func (a *mqlAzureSubscriptionCloudDefenderService) defenderForAppServices() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForAppServices, error) {
+func (a *mqlAzureSubscriptionCloudDefenderService) defenderForAppServices() (any, error) {
+	return a.getSimpleDictPricing("AppServices")
+}
+
+func (a *mqlAzureSubscriptionCloudDefenderService) forAppServices() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForAppServices, error) {
 	resource, err := a.getSimpleDefenderPricing("AppServices", ResourceAzureSubscriptionCloudDefenderServiceDefenderForAppServices)
 	if err != nil {
 		return nil, err
@@ -213,7 +299,11 @@ func (a *mqlAzureSubscriptionCloudDefenderService) defenderForAppServices() (*mq
 	return resource.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForAppServices), nil
 }
 
-func (a *mqlAzureSubscriptionCloudDefenderService) defenderForSqlServersOnMachines() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines, error) {
+func (a *mqlAzureSubscriptionCloudDefenderService) defenderForSqlServersOnMachines() (any, error) {
+	return a.getSimpleDictPricing("SqlServerVirtualMachines")
+}
+
+func (a *mqlAzureSubscriptionCloudDefenderService) forSqlServersOnMachines() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines, error) {
 	resource, err := a.getSimpleDefenderPricing("SqlServerVirtualMachines", ResourceAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines)
 	if err != nil {
 		return nil, err
@@ -221,7 +311,11 @@ func (a *mqlAzureSubscriptionCloudDefenderService) defenderForSqlServersOnMachin
 	return resource.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines), nil
 }
 
-func (a *mqlAzureSubscriptionCloudDefenderService) defenderForSqlDatabases() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlDatabases, error) {
+func (a *mqlAzureSubscriptionCloudDefenderService) defenderForSqlDatabases() (any, error) {
+	return a.getSimpleDictPricing("SqlServers")
+}
+
+func (a *mqlAzureSubscriptionCloudDefenderService) forSqlDatabases() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlDatabases, error) {
 	resource, err := a.getSimpleDefenderPricing("SqlServers", ResourceAzureSubscriptionCloudDefenderServiceDefenderForSqlDatabases)
 	if err != nil {
 		return nil, err
@@ -229,7 +323,11 @@ func (a *mqlAzureSubscriptionCloudDefenderService) defenderForSqlDatabases() (*m
 	return resource.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlDatabases), nil
 }
 
-func (a *mqlAzureSubscriptionCloudDefenderService) defenderForOpenSourceDatabases() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases, error) {
+func (a *mqlAzureSubscriptionCloudDefenderService) defenderForOpenSourceDatabases() (any, error) {
+	return a.getSimpleDictPricing("OpenSourceRelationalDatabases")
+}
+
+func (a *mqlAzureSubscriptionCloudDefenderService) forOpenSourceDatabases() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases, error) {
 	resource, err := a.getSimpleDefenderPricing("OpenSourceRelationalDatabases", ResourceAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases)
 	if err != nil {
 		return nil, err
@@ -237,7 +335,11 @@ func (a *mqlAzureSubscriptionCloudDefenderService) defenderForOpenSourceDatabase
 	return resource.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases), nil
 }
 
-func (a *mqlAzureSubscriptionCloudDefenderService) defenderForCosmosDb() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForCosmosDb, error) {
+func (a *mqlAzureSubscriptionCloudDefenderService) defenderForCosmosDb() (any, error) {
+	return a.getSimpleDictPricing("CosmosDbs")
+}
+
+func (a *mqlAzureSubscriptionCloudDefenderService) forCosmosDb() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForCosmosDb, error) {
 	resource, err := a.getSimpleDefenderPricing("CosmosDbs", ResourceAzureSubscriptionCloudDefenderServiceDefenderForCosmosDb)
 	if err != nil {
 		return nil, err
@@ -245,7 +347,11 @@ func (a *mqlAzureSubscriptionCloudDefenderService) defenderForCosmosDb() (*mqlAz
 	return resource.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForCosmosDb), nil
 }
 
-func (a *mqlAzureSubscriptionCloudDefenderService) defenderForStorageAccounts() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts, error) {
+func (a *mqlAzureSubscriptionCloudDefenderService) defenderForStorageAccounts() (any, error) {
+	return a.getSimpleDictPricing("StorageAccounts")
+}
+
+func (a *mqlAzureSubscriptionCloudDefenderService) forStorageAccounts() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts, error) {
 	resource, err := a.getSimpleDefenderPricing("StorageAccounts", ResourceAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts)
 	if err != nil {
 		return nil, err
@@ -253,7 +359,11 @@ func (a *mqlAzureSubscriptionCloudDefenderService) defenderForStorageAccounts() 
 	return resource.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts), nil
 }
 
-func (a *mqlAzureSubscriptionCloudDefenderService) defenderForKeyVaults() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults, error) {
+func (a *mqlAzureSubscriptionCloudDefenderService) defenderForKeyVaults() (any, error) {
+	return a.getSimpleDictPricing("KeyVaults")
+}
+
+func (a *mqlAzureSubscriptionCloudDefenderService) forKeyVaults() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults, error) {
 	resource, err := a.getSimpleDefenderPricing("KeyVaults", ResourceAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults)
 	if err != nil {
 		return nil, err
@@ -261,7 +371,11 @@ func (a *mqlAzureSubscriptionCloudDefenderService) defenderForKeyVaults() (*mqlA
 	return resource.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults), nil
 }
 
-func (a *mqlAzureSubscriptionCloudDefenderService) defenderForResourceManager() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForResourceManager, error) {
+func (a *mqlAzureSubscriptionCloudDefenderService) defenderForResourceManager() (any, error) {
+	return a.getSimpleDictPricing("Arm")
+}
+
+func (a *mqlAzureSubscriptionCloudDefenderService) forResourceManager() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForResourceManager, error) {
 	resource, err := a.getSimpleDefenderPricing("Arm", ResourceAzureSubscriptionCloudDefenderServiceDefenderForResourceManager)
 	if err != nil {
 		return nil, err
@@ -346,7 +460,94 @@ func (a *mqlAzureSubscriptionCloudDefenderService) monitoringAgentAutoProvision(
 	return autoProvision == security.AutoProvisionOn, nil
 }
 
-func (a *mqlAzureSubscriptionCloudDefenderService) defenderForContainers() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers, error) {
+func (a *mqlAzureSubscriptionCloudDefenderService) defenderForContainers() (any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+	subId := a.SubscriptionId.Data
+
+	armConn, err := getArmSecurityConnection(ctx, conn, subId)
+	if err != nil {
+		return nil, err
+	}
+
+	pas, err := getPolicyAssignments(ctx, armConn)
+	if err != nil {
+		return nil, err
+	}
+
+	type extension struct {
+		Name      string `json:"name"`
+		IsEnabled bool   `json:"isEnabled"`
+	}
+
+	type defenderForContainers struct {
+		DefenderDaemonSet        bool        `json:"defenderDaemonSet"`
+		AzurePolicyForKubernetes bool        `json:"azurePolicyForKubernetes"`
+		Enabled                  bool        `json:"enabled"`
+		Extensions               []extension `json:"extensions"`
+	}
+
+	kubernetesDefender := false
+	arcDefender := false
+	kubernetesPolicyExt := false
+	arcPolicyExt := false
+	for _, it := range pas.PolicyAssignments {
+		if it.Properties.PolicyDefinitionID == arcClusterDefenderExtensionDefinitionId &&
+			it.Properties.Scope == fmt.Sprintf("/subscriptions/%s", subId) {
+			arcDefender = true
+		}
+		if it.Properties.PolicyDefinitionID == kubernetesClusterDefenderExtensionDefinitionId &&
+			it.Properties.Scope == fmt.Sprintf("/subscriptions/%s", subId) {
+			kubernetesDefender = true
+		}
+		if it.Properties.PolicyDefinitionID == arcClusterPolicyExtensionDefinitionId &&
+			it.Properties.Scope == fmt.Sprintf("/subscriptions/%s", subId) {
+			arcPolicyExt = true
+		}
+		if it.Properties.PolicyDefinitionID == kubernetesClusterPolicyExtensionDefinitionId &&
+			it.Properties.Scope == fmt.Sprintf("/subscriptions/%s", subId) {
+			kubernetesPolicyExt = true
+		}
+	}
+
+	// Check if Defender for Containers is enabled by querying the pricing tier
+	clientFactory, err := armsecurity.NewClientFactory(subId, armConn.token, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	containersPricing, err := clientFactory.NewPricingsClient().Get(ctx, fmt.Sprintf("subscriptions/%s", subId), "Containers", &security.PricingsClientGetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	enabled := false
+	if containersPricing.Properties.PricingTier != nil {
+		enabled = *containersPricing.Properties.PricingTier == security.PricingTierStandard
+	}
+	extensions := []extension{}
+	for _, ext := range containersPricing.Properties.Extensions {
+		if ext.IsEnabled == nil || ext.Name == nil {
+			continue
+		}
+		e := false
+		if *ext.IsEnabled == security.IsEnabledTrue {
+			e = true
+		}
+		extensions = append(extensions, extension{Name: *ext.Name, IsEnabled: e})
+	}
+
+	def := defenderForContainers{
+		DefenderDaemonSet:        arcDefender && kubernetesDefender,
+		AzurePolicyForKubernetes: arcPolicyExt && kubernetesPolicyExt,
+		Enabled:                  enabled,
+		Extensions:               extensions,
+	}
+
+	return convert.JsonToDict(def)
+}
+
+func (a *mqlAzureSubscriptionCloudDefenderService) forContainers() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	ctx := context.Background()
 	subId := a.SubscriptionId.Data


### PR DESCRIPTION
This makes the latest changes in the azure provider non-breaking, instead of breaking. We need to keep the non-breaking ones around for just a tad longer before they can be removed. Also, doing it this way we avoid changing the type of the fields thus keeping it compiler-compliant (note tho: in most cases the type-change was transparent, but we are trying to be more defensive here to avoid breaking anyone). The new fields are becoming canon.