### PR TITLE
🐛 fix auto-update check interval

### DIFF
--- a/cli/selfupdate/selfupdate.go
+++ b/cli/selfupdate/selfupdate.go
@@ -54,7 +54,7 @@ type Config struct {
 	// Used to match archive entries and construct platform-specific filenames.
 	BinaryName string
 	// CurrentVersion is the current version of the running binary.
-	// If "unstable", self-update is skipped.
+	// If "x.y.z-rolling", self-update is skipped.
 	CurrentVersion string
 }
 
@@ -85,9 +85,9 @@ func CheckAndUpdate(cfg Config) (bool, error) {
 		return false, nil
 	}
 
-	// Skip if version is "unstable" (dev build)
+	// Skip if version is "rolling" (dev build)
 	currentVersion := cfg.CurrentVersion
-	if currentVersion == "unstable" {
+	if strings.HasSuffix(currentVersion, "-rolling") {
 		log.Debug().Msg("self-update: skipping, running unstable/dev build")
 		return false, nil
 	}

--- a/exec/testdata/arch.toml
+++ b/exec/testdata/arch.toml
@@ -2,7 +2,7 @@
 providers = ["core", "os"]
 
 [mondoo.""]
-version = "unstable"
+version = "v13.0.0-rolling"
 build = "development"
 
 [command."uname -s"]

--- a/mql.go
+++ b/mql.go
@@ -47,7 +47,7 @@ var DisableMaxLimit string
 // valid semver version including build version (e.g. 4.10.0+4900), where 4900 is a forward rolling int
 func GetVersion() string {
 	if Version == "" {
-		return "unstable"
+		return "v13.0.0-rolling"
 	}
 	return Version
 }
@@ -105,7 +105,7 @@ func GetCoreVersion() string {
 	}
 
 	if v == "" {
-		return "unstable"
+		return "v13.0.0-rolling"
 	}
 	return v
 }


### PR DESCRIPTION
it was looking at the folder, which can be incorrect if one binary was updated but not the other