### PR TITLE
✨ prefix the update-url if missing + better fallbacks

### DIFF
--- a/cli/selfupdate/selfupdate.go
+++ b/cli/selfupdate/selfupdate.go
@@ -121,15 +121,19 @@ func CheckAndUpdate(cfg Config) (bool, error) {
 
 	release, err := getLatestRelease(ctx, cfg.ReleaseURL)
 	if err != nil {
-		// Update marker even on failure to avoid repeated attempts
-		updateMarkerFile(binPath, cfg.BinaryName)
+		// We don't update the marker, which may lead to more checks against the URL
+		// but this is helpful when e.g. a network configuration wasn't set right.
+		// If users fix it and re-run commands it won't check which sucks. The
+		// request is fast so we opt to do it to avoid these temporary failures.
 		return false, errors.Wrap(err, "failed to fetch latest release")
 	}
 
 	// Compare versions
 	cmp, err := semver.Parser{}.Compare(release.Version, currentVersion)
 	if err != nil {
-		updateMarkerFile(binPath, cfg.BinaryName)
+		// We should only get here if something went really wrong with the version
+		// string that is being published. If that's the case, we don't set the
+		// marker and force the algo to try updating in case the error was fixed.
 		return false, errors.Wrap(err, "failed to compare versions")
 	}
 
@@ -150,13 +154,16 @@ func CheckAndUpdate(cfg Config) (bool, error) {
 	// Check if the bin directory is writable
 	if err := checkWritable(binPath); err != nil {
 		log.Warn().Str("path", binPath).Msg("self-update: cannot write to install directory, skipping")
-		updateMarkerFile(binPath, cfg.BinaryName)
+		// Since no download has occurred yet we opt to re-run the auto-update
+		// in case the error was fixed in the meantime.
 		return false, nil
 	}
 
 	// Download and install the update
 	binaryPath, err := downloadAndInstall(ctx, release, binPath, cfg.BinaryName)
 	if err != nil {
+		// If the download failed, we still set the marker because this is
+		// a larger step that can be annoying if it is re-run a lot.
 		updateMarkerFile(binPath, cfg.BinaryName)
 		return false, errors.Wrap(err, "failed to download and install update")
 	}
@@ -299,6 +306,16 @@ func updateMarkerFile(binPath string, binName string) {
 
 // getLatestRelease fetches and parses the latest release information
 func getLatestRelease(ctx context.Context, releaseURL string) (*Release, error) {
+	if !strings.HasPrefix(releaseURL, "https://") && !strings.HasPrefix(releaseURL, "http://") {
+		if idx := strings.Index(releaseURL, "://"); idx != -1 {
+			return nil, errors.Newf("unsupported URL scheme %q, only http and https are supported", releaseURL[:idx])
+		}
+		releaseURL = "https://" + releaseURL
+		if u, err := url.Parse(releaseURL); err != nil || u.Host == "" {
+			return nil, errors.Newf("invalid release URL %q", releaseURL)
+		}
+	}
+
 	client, err := httpClientWithRetry()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This now supports `UPDATES_URL=my.domain` instead of forcing the `https://` prefix.

We also avoid marking the auto-update completed when failed to fetch the URL, compare the versions, or verify that the update path is writeable, to allow users to quickly retry. We do however still mark it when the download failed, because redoing that step unintentionally is really annoying