### PR TITLE
🧹 deactivate auto-updates of engine for windows by default

### DIFF
--- a/features.go
+++ b/features.go
@@ -79,7 +79,7 @@ const (
 
 	// Auto-update the execution engine
 	// start:  v13.x
-	// status: default
+	// status: new
 	AutoUpdateEngine Feature = 14
 
 	// Placeholder to indicate how many feature flags exist. This number
@@ -110,11 +110,11 @@ var DefaultFeatures = Features{
 	byte(SerialNumberAsID),
 	byte(ForceShellCompletion),
 	byte(ResourceContext),
-	byte(AutoUpdateEngine),
 }
 
 // AvailableFeatures are a set of flags that can be activated
 var AvailableFeatures = Features{
 	byte(MQLAssetContext),
 	byte(UploadResultsV2),
+	byte(AutoUpdateEngine),
 }

--- a/features.yaml
+++ b/features.yaml
@@ -82,4 +82,4 @@ Features:
   desc: Auto-update the execution engine
   idx: 14
   start: v13.x
-  status: default
+  status: new

--- a/features_autoupdate.go
+++ b/features_autoupdate.go
@@ -1,0 +1,13 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+// TODO: Remove this file once AutoUpdateEngine is set to "default" status
+// in features.yaml (i.e. enabled on all platforms including Windows).
+
+//go:build !windows
+
+package mql
+
+func init() {
+	DefaultFeatures = append(DefaultFeatures, byte(AutoUpdateEngine))
+}


### PR DESCRIPTION
The current approach still requires users to approve the firewall for the newly installed binary. We need to change the auto-update approach for windows to replace the existing binary instead to avoid these firewall problems.