### PR TITLE
🧹 Update all provider examples to use cnspec commands

### DIFF
--- a/providers/ansible/config/config.go
+++ b/providers/ansible/config/config.go
@@ -22,7 +22,7 @@ var Config = plugin.Provider{
 			Long: `Use the ansible provider to query resources in an Ansible playbook, including tasks, roles, handlers, and variables.
 
 Examples:
-  cnquery shell ansible <path>
+  cnspec shell ansible <path>
   cnspec scan ansible <path>
 `,
 			MinArgs:   1,

--- a/providers/arista/config/config.go
+++ b/providers/arista/config/config.go
@@ -22,7 +22,7 @@ var Config = plugin.Provider{
 			Long: `Use the arista provider to query resources on an Arista EOS network device, including system information, interfaces, and configuration.
 
 Examples:
-  cnquery shell arista <user@host>
+  cnspec shell arista <user@host>
   cnspec scan arista <user@host> --ask-pass
 `,
 			Discovery: []string{},

--- a/providers/atlassian/config/config.go
+++ b/providers/atlassian/config/config.go
@@ -36,10 +36,10 @@ Available commands:
   scim                      SCIM instance
 
 Examples:
-  cnquery shell atlassian admin --admin-token <token>
-  cnquery shell atlassian jira --host <host> --user <user> --user-token <token>
-  cnquery shell atlassian confluence --host <host> --user <user> --user-token <token>
-  cnquery shell atlassian scim <directory-id> --scim-token <token>
+  cnspec shell atlassian admin --admin-token <token>
+  cnspec shell atlassian jira --host <host> --user <user> --user-token <token>
+  cnspec shell atlassian confluence --host <host> --user <user> --user-token <token>
+  cnspec shell atlassian scim <directory-id> --scim-token <token>
 
 Notes:
   If you set the ATLASSIAN_ADMIN_TOKEN environment variable, you can omit the admin-token flag. 

--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -39,10 +39,10 @@ Available commands:
 																									Provide the snapshot ID
 
 Examples:
-  cnquery shell aws
+  cnspec shell aws
 	cnspec scan aws
-	cnquery scan aws -f mondoo-aws-incident-response.mql.yaml --querypack mondoo-incident-response-aws
-	cnquery shell aws --role <role-arn>
+	cnspec scan aws -f mondoo-aws-incident-response.mql.yaml --querypack mondoo-incident-response-aws
+	cnspec shell aws --role <role-arn>
 	cnspec scan aws ec2 instance-connect <user@host>
 	cnspec scan aws ec2 instance-connect <user@host> --identity-file <path>
 	cnspec scan aws ec2 ebs <snapshot-id>

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -29,10 +29,10 @@ var Config = plugin.Provider{
 Examples run in your shell:
   cnspec scan azure compute instance <instance-name> --client-id <your-client-id> --tenant-id <your-tenant-id> --client-secret <your-client-secret-value>
   cnspec scan azure compute snapshot <snapshot-name> --client-id <your-client-id> --tenant-id <your-tenant-id> --client-secret <your-client-secret-value>
-  cnquery shell azure <subscription-name> --client-id <your-client-id> --tenant-id <your-tenant-id> --client-secret <your-client-secret-value>
+  cnspec shell azure <subscription-name> --client-id <your-client-id> --tenant-id <your-tenant-id> --client-secret <your-client-secret-value>
 
 Examples run in the Azure CLI:	
-  cnquery shell azure
+  cnspec shell azure
   cnspec scan azure --subscription <specific-subscription-id>
 `,
 			MinArgs: 0,

--- a/providers/cloudflare/config/config.go
+++ b/providers/cloudflare/config/config.go
@@ -21,7 +21,7 @@ var Config = plugin.Provider{
 			Long: `Use the cloudflare provider to query resources in your Cloudflare account, including zones, DNS records, and account settings.
 
 Examples:
-  cnquery shell cloudflare --token <access_token>
+  cnspec shell cloudflare --token <access_token>
   cnspec scan cloudflare --token <access_token>
 
 Notes:

--- a/providers/cloudformation/config/config.go
+++ b/providers/cloudformation/config/config.go
@@ -22,7 +22,7 @@ var Config = plugin.Provider{
 			Long: `Use the cloudformation provider to query AWS CloudFormation templates or AWS SAM templates, including resources, parameters, outputs, and mappings.
 
 Examples:
-  cnquery shell cloudformation <path>
+  cnspec shell cloudformation <path>
   cnspec scan cloudformation <path>
 `,
 			MinArgs:   1,

--- a/providers/equinix/config/config.go
+++ b/providers/equinix/config/config.go
@@ -25,8 +25,8 @@ Available commands:
   project <project-id>      Specifies the project to interact with, using the project identifier.
 
 Examples:
-  cnquery shell equinix org <org-id> --token <api-token>
-  cnquery shell equinix project <project-id> --token <api-token>
+  cnspec shell equinix org <org-id> --token <api-token>
+  cnspec shell equinix project <project-id> --token <api-token>
   cnspec scan equinix org <org-id> --token <api-token>
 
 Notes:

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -27,7 +27,7 @@ var Config = plugin.Provider{
 			Long: `Use the gcp provider to query resources within Google Cloud Platform (GCP), including databases, services, instances, containers, and more.
 
 Examples without logging into and configuring GCP:
-  cnquery shell gcp org <ORGANIZATION-ID> --credentials-path <PATH-TO-YOUR-SERVICE-ACCT>
+  cnspec shell gcp org <ORGANIZATION-ID> --credentials-path <PATH-TO-YOUR-SERVICE-ACCT>
   cnspec scan gcp project <PROJECT-ID> --credentials-path <PATH-TO-YOUR-SERVICE-ACCT>
 
 Note:
@@ -35,7 +35,7 @@ Note:
 
 Examples with the GCP project configured:
   cnspec scan gcp folder <FOLDER-ID>
-  cnquery shell gcp project
+  cnspec shell gcp project
 `,
 			MaxArgs: 2,
 			Discovery: []string{

--- a/providers/github/config/config.go
+++ b/providers/github/config/config.go
@@ -29,8 +29,8 @@ Available commands:
 Examples:
   cnspec scan github org <ORG_NAME> --discover organization
   cnspec scan github org <ORG_NAME> --repos "<REPO1>,<REPO2>"
-  cnquery shell github org <ORG_NAME>
-  cnquery shell github org <YOUR-GITHUB-ORG> --app-id <YOUR-GITHUB-APP-ID> --app-installation-id <YOUR-GITHUB-APP-INSTALL-ID> --app-private-key <PATH-TO-PEM-FILE>
+  cnspec shell github org <ORG_NAME>
+  cnspec shell github org <YOUR-GITHUB-ORG> --app-id <YOUR-GITHUB-APP-ID> --app-installation-id <YOUR-GITHUB-APP-INSTALL-ID> --app-private-key <PATH-TO-PEM-FILE>
 
 Notes:
   Mondoo needs a personal access token to scan a GitHub organization, public repo, or private repo. The token's level of access determines how much information Mondoo can retrieve. Supply your personal access token to Mondoo by setting the GITHUB_TOKEN environment variable. To learn how, read https://mondoo.com/docs/cnspec/saas/github/.

--- a/providers/gitlab/config/config.go
+++ b/providers/gitlab/config/config.go
@@ -35,8 +35,8 @@ Examples:
   cnspec scan gitlab --group <GROUP_NAME> --project <PROJECT_NAME> --token <YOUR_TOKEN>
   cnspec scan gitlab --group <GROUP_NAME> --discover projects --token <YOUR_TOKEN>
   cnspec scan gitlab --discover terraform --token <YOUR_TOKEN>
-  cnquery shell gitlab --group <GROUP_NAME> --token <YOUR_TOKEN>
-  cnquery shell gitlab --group <GROUP_NAME> --project <PROJECT_NAME> --token <YOUR_TOKEN>
+  cnspec shell gitlab --group <GROUP_NAME> --token <YOUR_TOKEN>
+  cnspec shell gitlab --group <GROUP_NAME> --project <PROJECT_NAME> --token <YOUR_TOKEN>
 
 Notes:
   Mondoo needs a personal access token to scan a GitLab group or project. The token's level of access determines how much information Mondoo can retrieve. Instead of providing a token with every command, you can supply your personal access token to Mondoo by setting the GITLAB_TOKEN environment variable. To learn how, read https://mondoo.com/docs/cnspec/saas/gitlab/.

--- a/providers/google-workspace/config/config.go
+++ b/providers/google-workspace/config/config.go
@@ -22,8 +22,8 @@ var Config = plugin.Provider{
 			Long: `Use the google-workspace provider to query resources in a Google Workspace domain.
 
 Examples:
-  cnquery shell google-workspace --customer-id <customer-id>
-  cnquery shell google-workspace --credentials-path <credentials-path> --customer-id <customer-id>
+  cnspec shell google-workspace --customer-id <customer-id>
+  cnspec shell google-workspace --credentials-path <credentials-path> --customer-id <customer-id>
   cnspec scan google-workspace --credentials-path <credentials-path> --customer-id <customer-id>
 
 Note:

--- a/providers/ipinfo/config/config.go
+++ b/providers/ipinfo/config/config.go
@@ -21,10 +21,10 @@ var Config = plugin.Provider{
 			Long: `Use the ipinfo provider to query IP address information from ipinfo.io, including the IP address, hostname, and whether the IP address is a bogon.
 
 Examples:
-  cnquery shell ipinfo
-  cnquery run ipinfo -c "ipinfo(ip('8.8.8.8')){*}"
-  cnquery run ipinfo -c "ipinfo(){*}"  # Query your public IP"
-  cnquery run -c "network.interfaces.map(ips.map(_.ip)).flat.map(ipinfo(_){*})"
+  cnspec shell ipinfo
+  cnspec run ipinfo -c "ipinfo(ip('8.8.8.8')){*}"
+  cnspec run ipinfo -c "ipinfo(){*}"  # Query your public IP"
+  cnspec run -c "network.interfaces.map(ips.map(_.ip)).flat.map(ipinfo(_){*})"
 
 Notes:
   - Pass an IP address to query information about that specific IP: ipinfo(ip("1.1.1.1"))

--- a/providers/ipmi/config/config.go
+++ b/providers/ipmi/config/config.go
@@ -25,7 +25,7 @@ IPMI provides management and monitoring capabilities independently of the host s
 firmware (BIOS or UEFI), and operating system.
 
 Examples:
-  cnquery shell ipmi <user@host>
+  cnspec shell ipmi <user@host>
 	cnspec scan ipmi <user@host>
 `,
 			MinArgs:   1,

--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -27,7 +27,7 @@ Requirement:
   To query or scan a Kubernetes cluster, you must install kubectl on your workstation. To learn how, read https://kubernetes.io/docs/tasks/tools/. 
 
 Examples:
-  cnquery shell k8s
+  cnspec shell k8s
   cnspec scan k8s
   cnspec scan k8s <MANIFEST-FILE>
 `,

--- a/providers/mondoo/config/config.go
+++ b/providers/mondoo/config/config.go
@@ -23,7 +23,7 @@ var Config = plugin.Provider{
 To query Mondoo Platform from a workstation, the workstation must be registered with Mondoo Platform. To learn how to register a workstation, read https://mondoo.com/docs/cnspec/cnspec-adv-install/registration/. 
 
 Examples:
-  cnquery shell mondoo
+  cnspec shell mondoo
 	cnspec scan mondoo
 `,
 			MinArgs:   0,

--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -23,7 +23,7 @@ var Config = plugin.Provider{
 			Long: `Use the ms365 provider to query resources within Microsoft 365, including organizations, users, roles, SharePoint sites, and more.
 
 Examples:
-  cnquery shell ms365 --certificate-path <PATH-TO-YOUR-PEM> --tenant-id <YOUR-TENANT-ID> --client-id <YOUR-CLIENT-ID>
+  cnspec shell ms365 --certificate-path <PATH-TO-YOUR-PEM> --tenant-id <YOUR-TENANT-ID> --client-id <YOUR-CLIENT-ID>
   cnspec scan ms365 --certificate-path <PATH-TO-YOUR-PEM> --tenant-id <YOUR-TENANT-ID> --client-id <YOUR-CLIENT-ID>
 
 Notes:

--- a/providers/network/config/config.go
+++ b/providers/network/config/config.go
@@ -37,7 +37,7 @@ var Config = plugin.Provider{
 			Long: `Use the host provider to query remote HTTP or HTTPS hosts. 
 
 Examples:
-  cnquery shell host <YOUR-DOMAIN-OR-IP>
+  cnspec shell host <YOUR-DOMAIN-OR-IP>
   cnspec scan host <YOUR-DOMAIN-OR-IP>
 
 Note:

--- a/providers/oci/config/config.go
+++ b/providers/oci/config/config.go
@@ -22,10 +22,10 @@ var Config = plugin.Provider{
 			Long: `Use the oci provider to query resources in an Oracle Cloud Infrastructure tenancy, including compute instances, networks, storage, and identity resources.
 
 Examples:
-  cnquery shell oci --tenancy <tenancy_ocid> --user <user_ocid> --region <region> --key-path <path_to_private_key> --fingerprint <key_fingerprint>
+  cnspec shell oci --tenancy <tenancy_ocid> --user <user_ocid> --region <region> --key-path <path_to_private_key> --fingerprint <key_fingerprint>
   cnspec scan oci --tenancy <tenancy_ocid> --user <user_ocid> --region <region> --key-path <path_to_private_key> --fingerprint <key_fingerprint>
-  cnquery shell oci --profile MYPROFILE
-  cnquery shell oci --config-file /path/to/config --profile MYPROFILE
+  cnspec shell oci --profile MYPROFILE
+  cnspec shell oci --config-file /path/to/config --profile MYPROFILE
 `,
 			Discovery: []string{},
 			Flags: []plugin.Flag{

--- a/providers/okta/config/config.go
+++ b/providers/okta/config/config.go
@@ -24,7 +24,7 @@ var Config = plugin.Provider{
 To query an Okta organization, you need the organization's domain and an API token to access that domain. To learn how, read https://mondoo.com/docs/cnquery/saas/okta/.
 
 Examples:
-  cnquery shell okta -organization <okta-domain> -token <api-token>
+  cnspec shell okta -organization <okta-domain> -token <api-token>
 	cnspec scan okta -organization <okta-domain> -token <api-token>
 `,
 			Discovery: []string{},

--- a/providers/opcua/config/config.go
+++ b/providers/opcua/config/config.go
@@ -21,7 +21,7 @@ var Config = plugin.Provider{
 			Long: `Use the opcua provider to query resources on an Open Platform Communications Unified Architecture (OPC UA) server or device. OPC UA is a protocol for machine-to-machine communication in industrial automation.
 
 Examples:
-  cnquery shell opcua --endpoint opc.tcp://<host>:<port>
+  cnspec shell opcua --endpoint opc.tcp://<host>:<port>
   cnspec scan opcua --endpoint opc.tcp://<host>:<port>
 `,
 			Discovery: []string{},

--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -38,7 +38,7 @@ var Config = plugin.Provider{
 			Long: `Use the local provider to query your local system. This is the default provider. There's no need to specify local in a command.  
 
 Examples:
-  cnquery shell
+  cnspec shell
   cnspec scan
   cnspec scan -o json > FILENAME.json
 `,
@@ -73,7 +73,7 @@ Examples:
 
 Examples:
   cnspec scan ssh USER@IP-ADDRESS --ask-pass
-  cnquery shell ssh USER@IP-ADDRESS --ask-pass
+  cnspec shell ssh USER@IP-ADDRESS --ask-pass
 `,
 			MinArgs: 1,
 			MaxArgs: 1,
@@ -130,7 +130,7 @@ Examples:
 
 Examples:
   cnspec scan winrm USER@HOST --ask-pass
-  cnquery shell winrm USER@HOST --ask-pass
+  cnspec shell winrm USER@HOST --ask-pass
 `,
 			MinArgs: 1,
 			MaxArgs: 1,
@@ -173,7 +173,7 @@ Examples:
 
 Examples:
   cnspec scan vagrant HOST
-  cnquery shell vagrant HOST
+  cnspec shell vagrant HOST
 `,
 			MinArgs: 1,
 			MaxArgs: 1,
@@ -201,7 +201,7 @@ Examples:
 
 Examples:
   cnspec scan container ubuntu:latest
-  cnquery shell container ubuntu:latest
+  cnspec shell container ubuntu:latest
 `,
 			MinArgs: 1,
 			MaxArgs: 2,
@@ -296,7 +296,7 @@ Examples:
 
 Examples:
   cnspec scan filesystem <MOUNT-PATH-TO-FILE-SYSTEM>
-  cnquery shell fs <MOUNT-PATH-TO-FILE-SYSTEM>
+  cnspec shell fs <MOUNT-PATH-TO-FILE-SYSTEM>
 `,
 			MinArgs: 0,
 			MaxArgs: 1,
@@ -318,7 +318,7 @@ Examples:
 
 Examples:
   cnspec scan device --lun <LOGICAL-UNIT-NUMBER>
-  cnquery shell device --device-name <NAME-OF-LINUX-DEVICE>
+  cnspec shell device --device-name <NAME-OF-LINUX-DEVICE>
 `,
 			MinArgs: 0,
 			MaxArgs: 0,

--- a/providers/shodan/config/config.go
+++ b/providers/shodan/config/config.go
@@ -23,8 +23,8 @@ var Config = plugin.Provider{
 			Long: `Use the shodan provider to query domain and IP security information in the Shodan search engine.
 
 Examples:
-  cnquery shell shodan --token <api-token>
-  cnquery shell shodan --networks <ip-range> --discover hosts
+  cnspec shell shodan --token <api-token>
+  cnspec shell shodan --networks <ip-range> --discover hosts
   cnspec scan shodan --token <api-token>
 
 Notes:

--- a/providers/slack/config/config.go
+++ b/providers/slack/config/config.go
@@ -22,7 +22,7 @@ var Config = plugin.Provider{
 			Long: `Use the slack provider to query resources in a Slack team.
 
 Examples:
-  cnquery shell slack --token <api-token>
+  cnspec shell slack --token <api-token>
   cnspec scan slack --team-id <team-id> --token <api-token>
 `,
 			MinArgs:   0,

--- a/providers/snowflake/config/config.go
+++ b/providers/snowflake/config/config.go
@@ -25,7 +25,7 @@ To access a Snowflake account, you must first authenticate with Snowflake. To do
 Once you successfully authenticate, you can scan or query the Snowflake account.
 
 Example:
-  cnquery shell snowflake --account <account id> --region <region> --user <your id> --role <the role you use> --identity-file <path to your private RSA key>
+  cnspec shell snowflake --account <account id> --region <region> --user <your id> --role <the role you use> --identity-file <path to your private RSA key>
   cnspec scan snowflake --account <account id> --region <region> --user <your id> --role <the role you use> --identity-file <path to your private RSA key>
 `,
 			Discovery: []string{},

--- a/providers/tailscale/config/config.go
+++ b/providers/tailscale/config/config.go
@@ -29,11 +29,11 @@ known as a tailnet.
 
 To authenticate using an API access token:
 
-  cnquery shell tailscale --token <access-token>
+  cnspec shell tailscale --token <access-token>
 
 To authenticate using an OAuth client:
 
-  cnquery shell tailscale --client-id <id> --client-secret <secret>
+  cnspec shell tailscale --client-id <id> --client-secret <secret>
 
 You can also use the default environment variables '%s', '%s',
 and '%s' to provide your credentials.

--- a/providers/terraform/config/config.go
+++ b/providers/terraform/config/config.go
@@ -32,7 +32,7 @@ Available commands:
   state                      Terraform state file
 
 Examples:
-  cnquery shell terraform <PATH-TO-HCL-DIRECTORY>
+  cnspec shell terraform <PATH-TO-HCL-DIRECTORY>
   cnspec scan terraform <PATH-TO-HCL-FILE>
   cnspec scan terraform plan <PATH-TO-PLAN-JSON>
   cnspec scan terraform state <PATH-TO-STATE-JSON>

--- a/providers/vcd/config/config.go
+++ b/providers/vcd/config/config.go
@@ -21,7 +21,7 @@ var Config = plugin.Provider{
 			Long: `Use the vcd provider to query resources in a VMware Cloud Director environment. The VMware Cloud Director platform facilitates the operation and management of virtual resources within a multi-tenant cloud environment.
 
 			Examples:
-			  cnquery shell vcd --user <USER-NAME> --host <HOST-NAME> --ask-pass
+			  cnspec shell vcd --user <USER-NAME> --host <HOST-NAME> --ask-pass
 				cnspec scan vcd --user <USER-NAME> --host <HOST-NAME> --password <PASSWORD>
 `,
 			Discovery: []string{},

--- a/providers/vsphere/config/config.go
+++ b/providers/vsphere/config/config.go
@@ -24,7 +24,7 @@ var Config = plugin.Provider{
 
 Examples:
   cnspec scan vsphere <USER>@<HOST> --askpass
-	cnquery shell vsphere <USER>@<HOST> --password <YOUR-PASSWORD>
+	cnspec shell vsphere <USER>@<HOST> --password <YOUR-PASSWORD>
 `,
 			Discovery: []string{
 				resources.DiscoveryApi,


### PR DESCRIPTION
## Summary
- Replace `cnquery shell` with `cnspec shell` and `cnquery scan` with `cnspec scan` in all provider config examples
- Follows up on #6817 which made this change for the nmap provider
- 29 provider configs updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)