### PR TITLE
add port option to the nmap provider

### DIFF
--- a/providers/nmap/README.md
+++ b/providers/nmap/README.md
@@ -125,3 +125,16 @@ nmap.version: {
   ]
 }
 ```
+
+## Inventory Yaml
+
+```yaml
+spec:
+  assets:
+    - name: "Web Server Scan"
+      connections:
+        - type: nmap
+          host: 192.168.1.1
+          options:
+            ports: "22,80,443"
+```

--- a/providers/nmap/config/config.go
+++ b/providers/nmap/config/config.go
@@ -30,6 +30,7 @@ Examples:
   cnspec shell nmap --networks 10.0.0.0/8,192.168.0.0/16
   cnspec shell nmap --networks "192.168.1.0/24" --discover hosts
   cnspec scan nmap host 192.168.1.1
+  cnspec shell nmap host 192.168.1.1 --ports 22,80,443
 `,
 			MinArgs: 0,
 			MaxArgs: 2,
@@ -44,6 +45,12 @@ Examples:
 					Type:    plugin.FlagType_List,
 					Default: "",
 					Desc:    "Comma-separated list of networks to scan (e.g., 10.0.0.0/8,192.168.0.0/16)",
+				},
+				{
+					Long:    "ports",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "Ports to scan (e.g., 22,80,443 or 1-1024)",
 				},
 			},
 		},

--- a/providers/nmap/provider/provider.go
+++ b/providers/nmap/provider/provider.go
@@ -81,6 +81,12 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		}
 	}
 
+	if ports, ok := flags["ports"]; ok {
+		if string(ports.Value) != "" {
+			conf.Options["ports"] = string(ports.Value)
+		}
+	}
+
 	asset := inventory.Asset{
 		Name:        name,
 		Connections: []*inventory.Config{conf},

--- a/providers/nmap/resources/discovery.go
+++ b/providers/nmap/resources/discovery.go
@@ -47,6 +47,11 @@ func Discover(runtime *plugin.Runtime, opts map[string]string) (*inventory.Inven
 			entry := hosts[i]
 			host := entry.(*mqlNmapHost)
 
+			childOpts := map[string]string{}
+			if ports, ok := conf.Options["ports"]; ok && ports != "" {
+				childOpts["ports"] = ports
+			}
+
 			a := &inventory.Asset{
 				Name: host.GetName().Data,
 				Connections: []*inventory.Config{
@@ -54,6 +59,7 @@ func Discover(runtime *plugin.Runtime, opts map[string]string) (*inventory.Inven
 						Type:        "nmap",
 						Host:        host.GetName().Data,
 						Credentials: conf.Credentials,
+						Options:     childOpts,
 					},
 				},
 			}

--- a/providers/nmap/resources/host.go
+++ b/providers/nmap/resources/host.go
@@ -96,15 +96,26 @@ func (r *mqlNmapHost) scan() error {
 
 	log.Info().Str("host", r.Name.Data).Str("id", r.MqlID()).Msg("Scanning host")
 
-	// nmap -sT -sV  -n --min-parallelism 100 -T4 192.168.1.0/24
-	scanner, err := nmap.NewScanner(
-		ctx,
+	// nmap -sT -sV  -n --min-parallelism 100 -T4 [-p ports] <target>
+	scanOpts := []nmap.Option{
 		nmap.WithConnectScan(),           // -sT
 		nmap.WithServiceInfo(),           // -sV
 		nmap.WithDisabledDNSResolution(), // -n
 		nmap.WithMinParallelism(100),
 		nmap.WithTimingTemplate(nmap.TimingAggressive),
 		nmap.WithTargets(r.Name.Data),
+	}
+
+	conn := r.MqlRuntime.Connection.(*connection.NmapConnection)
+	if conn.Conf.Options != nil {
+		if ports, ok := conn.Conf.Options["ports"]; ok && ports != "" {
+			scanOpts = append(scanOpts, nmap.WithPorts(ports)) // -p
+		}
+	}
+
+	scanner, err := nmap.NewScanner(
+		ctx,
+		scanOpts...,
 	)
 	if err != nil {
 		setError(err)


### PR DESCRIPTION
- Add --ports CLI flag to the nmap provider, allowing users to limit which ports nmap scans instead of scanning the full default range
- The flag passes nmap's -p option (e.g., --ports 22,80,443 or --ports 1-1024)
- Ports option is propagated to discovered hosts when using --networks --discover hosts
- Also usable via inventory config options.ports for query packs and policies