### PR TITLE
🐳 Add provides cnquery to nfpms config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -75,6 +75,8 @@ nfpms:
     formats:
       - deb
       - rpm
+    provides:
+      - cnquery
     overrides:
       deb:
         conflicts:


### PR DESCRIPTION
## Summary
- Adds `provides: cnquery` to the nfpms configuration in `.goreleaser.yml`
- This allows package managers (apt/yum/dnf) to know that `mql` provides the `cnquery` capability
- Systems with dependencies on `cnquery` will be satisfied by installing `mql`

## Test plan
- [ ] Verify goreleaser config is valid: `goreleaser check`
- [ ] Build packages and verify the provides field is set correctly in deb/rpm metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)