### PR TITLE
⚡ aws/backup: add pagination to ListBackupVaults

### DIFF
--- a/providers/aws/resources/aws_backups.go
+++ b/providers/aws/resources/aws_backups.go
@@ -63,31 +63,34 @@ func (a *mqlAwsBackup) getVaults(conn *connection.AwsConnection) []*jobpool.Job 
 			ctx := context.Background()
 			res := []any{}
 
-			vaults, err := svc.ListBackupVaults(ctx, &backup.ListBackupVaultsInput{})
-			if err != nil {
-				if Is400AccessDeniedError(err) {
-					log.Warn().Str("region", region).Msg("error accessing region for AWS API")
-					return res, nil
-				}
-				return nil, err
-			}
-			for _, v := range vaults.BackupVaultList {
-				mqlGroup, err := CreateResource(a.MqlRuntime, "aws.backup.vault",
-					map[string]*llx.RawData{
-						"arn":              llx.StringDataPtr(v.BackupVaultArn),
-						"createdAt":        llx.TimeDataPtr(v.CreationDate),
-						"encryptionKeyArn": llx.StringDataPtr(v.EncryptionKeyArn),
-						"locked":           llx.BoolDataPtr(v.Locked),
-						"lockedAt":         llx.TimeDataPtr(v.LockDate),
-						"maxRetentionDays": llx.IntDataPtr(v.MaxRetentionDays),
-						"minRetentionDays": llx.IntDataPtr(v.MinRetentionDays),
-						"name":             llx.StringDataPtr(v.BackupVaultName),
-						"region":           llx.StringData(region),
-					})
+			paginator := backup.NewListBackupVaultsPaginator(svc, &backup.ListBackupVaultsInput{})
+			for paginator.HasMorePages() {
+				page, err := paginator.NextPage(ctx)
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
-				res = append(res, mqlGroup)
+				for _, v := range page.BackupVaultList {
+					mqlGroup, err := CreateResource(a.MqlRuntime, "aws.backup.vault",
+						map[string]*llx.RawData{
+							"arn":              llx.StringDataPtr(v.BackupVaultArn),
+							"createdAt":        llx.TimeDataPtr(v.CreationDate),
+							"encryptionKeyArn": llx.StringDataPtr(v.EncryptionKeyArn),
+							"locked":           llx.BoolDataPtr(v.Locked),
+							"lockedAt":         llx.TimeDataPtr(v.LockDate),
+							"maxRetentionDays": llx.IntDataPtr(v.MaxRetentionDays),
+							"minRetentionDays": llx.IntDataPtr(v.MinRetentionDays),
+							"name":             llx.StringDataPtr(v.BackupVaultName),
+							"region":           llx.StringData(region),
+						})
+					if err != nil {
+						return nil, err
+					}
+					res = append(res, mqlGroup)
+				}
 			}
 
 			return jobpool.JobResult(res), nil


### PR DESCRIPTION
## Summary
- Add pagination to `ListBackupVaults` using the AWS SDK paginator, ensuring all vaults are returned for accounts with more than one page of results
- Follows the same pattern already used by `ListBackupPlans` and `ListRecoveryPointsByBackupVault` in the same file

## Test plan
- [ ] Build the AWS provider: `make providers/build/aws && make providers/install/aws`
- [ ] Run `mql run aws -c "aws.backup.vaults { arn name }"` and verify vaults are listed
- [ ] Verify on an account with many backup vaults that all are returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)