### PR TITLE
⚡ gcp: fix pagination bugs and reduce redundant API calls

### DIFF
--- a/providers/gcp/resources/bigquery.go
+++ b/providers/gcp/resources/bigquery.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"go.mondoo.com/mql/v13/llx"
@@ -187,6 +188,27 @@ func (g *mqlGcpProjectBigqueryService) datasets() ([]any, error) {
 	return res, nil
 }
 
+type mqlGcpProjectBigqueryServiceDatasetInternal struct {
+	clientOnce sync.Once
+	client     *bigquery.Client
+	clientErr  error
+}
+
+func (g *mqlGcpProjectBigqueryServiceDataset) getClient() (*bigquery.Client, error) {
+	g.clientOnce.Do(func() {
+		conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
+		httpClient, err := conn.Client("https://www.googleapis.com/auth/bigquery")
+		if err != nil {
+			g.clientErr = err
+			return
+		}
+		ctx := context.Background()
+		projectID := conn.ResourceID()
+		g.client, g.clientErr = bigquery.NewClient(ctx, projectID, option.WithHTTPClient(httpClient))
+	})
+	return g.client, g.clientErr
+}
+
 func (g *mqlGcpProjectBigqueryServiceDataset) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error
@@ -255,19 +277,11 @@ func (g *mqlGcpProjectBigqueryServiceDatasetAccessEntry) id() (string, error) {
 }
 
 func (g *mqlGcpProjectBigqueryServiceDataset) tables() ([]any, error) {
-	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
-
-	client, err := conn.Client("https://www.googleapis.com/auth/bigquery")
+	bigquerySvc, err := g.getClient()
 	if err != nil {
 		return nil, err
 	}
-
 	ctx := context.Background()
-	projectID := conn.ResourceID()
-	bigquerySvc, err := bigquery.NewClient(ctx, projectID, option.WithHTTPClient(client))
-	if err != nil {
-		return nil, err
-	}
 
 	if g.Id.Error != nil {
 		return nil, g.Id.Error
@@ -390,19 +404,11 @@ func (g *mqlGcpProjectBigqueryServiceTable) id() (string, error) {
 }
 
 func (g *mqlGcpProjectBigqueryServiceDataset) models() ([]any, error) {
-	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
-
-	client, err := conn.Client("https://www.googleapis.com/auth/bigquery")
+	bigquerySvc, err := g.getClient()
 	if err != nil {
 		return nil, err
 	}
-
 	ctx := context.Background()
-	projectID := conn.ResourceID()
-	bigquerySvc, err := bigquery.NewClient(ctx, projectID, option.WithHTTPClient(client))
-	if err != nil {
-		return nil, err
-	}
 
 	if g.Id.Error != nil {
 		return nil, g.Id.Error
@@ -476,19 +482,11 @@ func (g *mqlGcpProjectBigqueryServiceModel) id() (string, error) {
 }
 
 func (g *mqlGcpProjectBigqueryServiceDataset) routines() ([]any, error) {
-	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
-
-	client, err := conn.Client("https://www.googleapis.com/auth/bigquery")
+	bigquerySvc, err := g.getClient()
 	if err != nil {
 		return nil, err
 	}
-
 	ctx := context.Background()
-	projectID := conn.ResourceID()
-	bigquerySvc, err := bigquery.NewClient(ctx, projectID, option.WithHTTPClient(client))
-	if err != nil {
-		return nil, err
-	}
 
 	if g.Id.Error != nil {
 		return nil, g.Id.Error

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -21404,7 +21404,7 @@ func (c *mqlGcpProjectBigqueryService) GetDatasets() *plugin.TValue[[]any] {
 type mqlGcpProjectBigqueryServiceDataset struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectBigqueryServiceDatasetInternal it will be used here
+	mqlGcpProjectBigqueryServiceDatasetInternal
 	Id                       plugin.TValue[string]
 	ProjectId                plugin.TValue[string]
 	Name                     plugin.TValue[string]

--- a/providers/gcp/resources/logging.go
+++ b/providers/gcp/resources/logging.go
@@ -62,66 +62,67 @@ func (g *mqlGcpProjectLoggingservice) buckets() ([]any, error) {
 		return nil, err
 	}
 
-	buckets, err := loggingSvc.Projects.Locations.Buckets.List(fmt.Sprintf("projects/%s/locations/-", projectId)).Do()
-	if err != nil {
+	var mqlBuckets []any
+	req := loggingSvc.Projects.Locations.Buckets.List(fmt.Sprintf("projects/%s/locations/-", projectId))
+	if err := req.Pages(ctx, func(page *logging.ListBucketsResponse) error {
+		for _, bucket := range page.Buckets {
+
+			var mqlCmekSettingsDict map[string]any
+			if bucket.CmekSettings != nil {
+				type mqlCmekSettings struct {
+					KmsKeyName        string `json:"kmsKeyName"`
+					KmsKeyVersionName string `json:"kmsKeyVersionName"`
+					Name              string `json:"name"`
+					ServiceAccountId  string `json:"serviceAccountId"`
+				}
+				mqlCmekSettingsDict, err = convert.JsonToDict(mqlCmekSettings{
+					KmsKeyName:        bucket.CmekSettings.KmsKeyName,
+					KmsKeyVersionName: bucket.CmekSettings.KmsKeyVersionName,
+					Name:              bucket.CmekSettings.Name,
+					ServiceAccountId:  bucket.CmekSettings.ServiceAccountId,
+				})
+				if err != nil {
+					return err
+				}
+			}
+
+			indexConfigs := make([]any, 0, len(bucket.IndexConfigs))
+			for i, cfg := range bucket.IndexConfigs {
+				mqlIndexConfig, err := CreateResource(g.MqlRuntime, "gcp.project.loggingservice.bucket.indexConfigs", map[string]*llx.RawData{
+					"id":        llx.StringData(fmt.Sprintf("%s/indexConfigs/%d", bucket.Name, i)),
+					"created":   llx.TimeDataPtr(parseTime(cfg.CreateTime)),
+					"fieldPath": llx.StringData(cfg.FieldPath),
+					"type":      llx.StringData(cfg.Type),
+				})
+				if err != nil {
+					return err
+				}
+				indexConfigs = append(indexConfigs, mqlIndexConfig)
+			}
+
+			mqlBucket, err := CreateResource(g.MqlRuntime, "gcp.project.loggingservice.bucket", map[string]*llx.RawData{
+				"projectId":           llx.StringData(projectId),
+				"location":            llx.StringData(parseLocationFromPath(bucket.Name)),
+				"cmekSettings":        llx.DictData(mqlCmekSettingsDict),
+				"created":             llx.TimeDataPtr(parseTime(bucket.CreateTime)),
+				"description":         llx.StringData(bucket.Description),
+				"indexConfigs":        llx.ArrayData(indexConfigs, types.Resource("gcp.project.loggingservice.bucket.indexConfig")),
+				"lifecycleState":      llx.StringData(bucket.LifecycleState),
+				"locked":              llx.BoolData(bucket.Locked),
+				"name":                llx.StringData(bucket.Name),
+				"restrictedFields":    llx.ArrayData(convert.SliceAnyToInterface(bucket.RestrictedFields), types.String),
+				"retentionDays":       llx.IntData(bucket.RetentionDays),
+				"updated":             llx.TimeDataPtr(parseTime(bucket.UpdateTime)),
+				"logAnalyticsEnabled": llx.BoolData(bucket.AnalyticsEnabled),
+			})
+			if err != nil {
+				return err
+			}
+			mqlBuckets = append(mqlBuckets, mqlBucket)
+		}
+		return nil
+	}); err != nil {
 		return nil, err
-	}
-
-	mqlBuckets := make([]any, 0, len(buckets.Buckets))
-	for _, bucket := range buckets.Buckets {
-
-		var mqlCmekSettingsDict map[string]any
-		if bucket.CmekSettings != nil {
-			type mqlCmekSettings struct {
-				KmsKeyName        string `json:"kmsKeyName"`
-				KmsKeyVersionName string `json:"kmsKeyVersionName"`
-				Name              string `json:"name"`
-				ServiceAccountId  string `json:"serviceAccountId"`
-			}
-			mqlCmekSettingsDict, err = convert.JsonToDict(mqlCmekSettings{
-				KmsKeyName:        bucket.CmekSettings.KmsKeyName,
-				KmsKeyVersionName: bucket.CmekSettings.KmsKeyVersionName,
-				Name:              bucket.CmekSettings.Name,
-				ServiceAccountId:  bucket.CmekSettings.ServiceAccountId,
-			})
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		indexConfigs := make([]any, 0, len(bucket.IndexConfigs))
-		for i, cfg := range bucket.IndexConfigs {
-			mqlIndexConfig, err := CreateResource(g.MqlRuntime, "gcp.project.loggingservice.bucket.indexConfigs", map[string]*llx.RawData{
-				"id":        llx.StringData(fmt.Sprintf("%s/indexConfigs/%d", bucket.Name, i)),
-				"created":   llx.TimeDataPtr(parseTime(cfg.CreateTime)),
-				"fieldPath": llx.StringData(cfg.FieldPath),
-				"type":      llx.StringData(cfg.Type),
-			})
-			if err != nil {
-				return nil, err
-			}
-			indexConfigs = append(indexConfigs, mqlIndexConfig)
-		}
-
-		mqlBucket, err := CreateResource(g.MqlRuntime, "gcp.project.loggingservice.bucket", map[string]*llx.RawData{
-			"projectId":           llx.StringData(projectId),
-			"location":            llx.StringData(parseLocationFromPath(bucket.Name)),
-			"cmekSettings":        llx.DictData(mqlCmekSettingsDict),
-			"created":             llx.TimeDataPtr(parseTime(bucket.CreateTime)),
-			"description":         llx.StringData(bucket.Description),
-			"indexConfigs":        llx.ArrayData(indexConfigs, types.Resource("gcp.project.loggingservice.bucket.indexConfig")),
-			"lifecycleState":      llx.StringData(bucket.LifecycleState),
-			"locked":              llx.BoolData(bucket.Locked),
-			"name":                llx.StringData(bucket.Name),
-			"restrictedFields":    llx.ArrayData(convert.SliceAnyToInterface(bucket.RestrictedFields), types.String),
-			"retentionDays":       llx.IntData(bucket.RetentionDays),
-			"updated":             llx.TimeDataPtr(parseTime(bucket.UpdateTime)),
-			"logAnalyticsEnabled": llx.BoolData(bucket.AnalyticsEnabled),
-		})
-		if err != nil {
-			return nil, err
-		}
-		mqlBuckets = append(mqlBuckets, mqlBucket)
 	}
 	return mqlBuckets, nil
 }

--- a/providers/gcp/resources/project.go
+++ b/providers/gcp/resources/project.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"go.mondoo.com/mql/v13/llx"
@@ -34,6 +35,9 @@ func (g *mqlGcpProjects) id() (string, error) {
 type mqlGcpProjectInternal struct {
 	// serviceEnabled services
 	enabledServices map[string]struct{}
+	iamPolicyOnce   sync.Once
+	iamPolicyCache  *cloudresourcemanager.Policy
+	iamPolicyErr    error
 }
 
 func initGcpProject(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -121,26 +125,33 @@ func (g *mqlGcpProject) number() (string, error) {
 	return "", errors.New("not implemented")
 }
 
+func (g *mqlGcpProject) fetchIamPolicy() (*cloudresourcemanager.Policy, error) {
+	g.iamPolicyOnce.Do(func() {
+		projectId := g.Id.Data
+		conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
+		client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope, iam.CloudPlatformScope, compute.CloudPlatformScope)
+		if err != nil {
+			g.iamPolicyErr = err
+			return
+		}
+		ctx := context.Background()
+		svc, err := cloudresourcemanager.NewService(ctx, option.WithHTTPClient(client))
+		if err != nil {
+			g.iamPolicyErr = err
+			return
+		}
+		g.iamPolicyCache, g.iamPolicyErr = svc.Projects.GetIamPolicy(fmt.Sprintf("projects/%s", projectId), &cloudresourcemanager.GetIamPolicyRequest{}).Do()
+	})
+	return g.iamPolicyCache, g.iamPolicyErr
+}
+
 func (g *mqlGcpProject) iamPolicy() ([]any, error) {
 	if g.Id.Error != nil {
 		return nil, g.Id.Error
 	}
 	projectId := g.Id.Data
 
-	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
-
-	client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope, iam.CloudPlatformScope, compute.CloudPlatformScope)
-	if err != nil {
-		return nil, err
-	}
-
-	ctx := context.Background()
-	svc, err := cloudresourcemanager.NewService(ctx, option.WithHTTPClient(client))
-	if err != nil {
-		return nil, err
-	}
-
-	policy, err := svc.Projects.GetIamPolicy(fmt.Sprintf("projects/%s", projectId), &cloudresourcemanager.GetIamPolicyRequest{}).Do()
+	policy, err := g.fetchIamPolicy()
 	if err != nil {
 		return nil, err
 	}
@@ -169,20 +180,7 @@ func (g *mqlGcpProject) auditConfig() ([]any, error) {
 	}
 	projectId := g.Id.Data
 
-	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
-
-	client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope, iam.CloudPlatformScope, compute.CloudPlatformScope)
-	if err != nil {
-		return nil, err
-	}
-
-	ctx := context.Background()
-	svc, err := cloudresourcemanager.NewService(ctx, option.WithHTTPClient(client))
-	if err != nil {
-		return nil, err
-	}
-
-	policy, err := svc.Projects.GetIamPolicy(fmt.Sprintf("projects/%s", projectId), &cloudresourcemanager.GetIamPolicyRequest{}).Do()
+	policy, err := g.fetchIamPolicy()
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -137,327 +137,328 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 		return nil, err
 	}
 
-	sqlinstances, err := sqladminSvc.Instances.List(projectId).Do()
-	if err != nil {
-		return nil, err
-	}
+	var res []any
+	req := sqladminSvc.Instances.List(projectId)
+	if err := req.Pages(ctx, func(page *sqladmin.InstancesListResponse) error {
+		for i := range page.Items {
+			instance := page.Items[i]
+			instanceId := fmt.Sprintf("%s/%s", projectId, instance.Name)
 
-	res := make([]any, 0, len(sqlinstances.Items))
-	for i := range sqlinstances.Items {
-		instance := sqlinstances.Items[i]
-		instanceId := fmt.Sprintf("%s/%s", projectId, instance.Name)
-
-		type mqlDiskEncryptionCfg struct {
-			KmsKeyName string `json:"kmsKeyName"`
-		}
-		var mqlEncCfg map[string]any
-		if instance.DiskEncryptionConfiguration != nil {
-			mqlEncCfg, err = convert.JsonToDict(mqlDiskEncryptionCfg{
-				KmsKeyName: instance.DiskEncryptionConfiguration.KmsKeyName,
-			})
-			if err != nil {
-				return nil, err
+			type mqlDiskEncryptionCfg struct {
+				KmsKeyName string `json:"kmsKeyName"`
 			}
-		}
-
-		type mqlDiskEncryptionStatus struct {
-			KmsKeyVersionName string `json:"kmsKeyVersionName"`
-		}
-		var mqlEncStatus map[string]any
-		if instance.DiskEncryptionStatus != nil {
-			mqlEncStatus, err = convert.JsonToDict(mqlDiskEncryptionStatus{
-				KmsKeyVersionName: instance.DiskEncryptionStatus.KmsKeyVersionName,
-			})
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		type mqlFailoverReplicaCfg struct {
-			Available bool   `json:"available"`
-			Name      string `json:"name"`
-		}
-		var mqlFailoverReplica map[string]any
-		if instance.FailoverReplica != nil {
-			mqlFailoverReplica, err = convert.JsonToDict(mqlFailoverReplicaCfg{
-				Available: instance.FailoverReplica.Available,
-				Name:      instance.FailoverReplica.Name,
-			})
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		mqlIpAddresses := make([]any, 0, len(instance.IpAddresses))
-		for i, a := range instance.IpAddresses {
-			mqlIpAddress, err := CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.ipMapping", map[string]*llx.RawData{
-				"id":           llx.StringData(fmt.Sprintf("%s/ipAddresses%d", instanceId, i)),
-				"ipAddress":    llx.StringData(a.IpAddress),
-				"timeToRetire": llx.TimeDataPtr(parseTime(a.TimeToRetire)),
-				"type":         llx.StringData(a.Type),
-			})
-			if err != nil {
-				return nil, err
-			}
-			mqlIpAddresses = append(mqlIpAddresses, mqlIpAddress)
-		}
-
-		s := instance.Settings
-		dbFlags := make(map[string]string)
-		for _, f := range s.DatabaseFlags {
-			dbFlags[f.Name] = f.Value
-		}
-
-		type mqlActiveDirectoryCfg struct {
-			Domain string `json:"domain,omitempty"`
-		}
-		var mqlADCfg map[string]any
-		if s.ActiveDirectoryConfig != nil {
-			mqlADCfg, err = convert.JsonToDict(mqlActiveDirectoryCfg{
-				Domain: s.ActiveDirectoryConfig.Domain,
-			})
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		var mqlBackupCfg plugin.Resource
-		if s.BackupConfiguration != nil {
-			type mqlRetentionSettings struct {
-				RetainedBackups int64  `json:"retainedBackups"`
-				RetentionUnit   string `json:"retentionUnit"`
-			}
-			mqlRetention, err := convert.JsonToDict(mqlRetentionSettings{
-				RetainedBackups: s.BackupConfiguration.BackupRetentionSettings.RetainedBackups,
-				RetentionUnit:   s.BackupConfiguration.BackupRetentionSettings.RetentionUnit,
-			})
-			if err != nil {
-				return nil, err
-			}
-
-			mqlBackupCfg, err = CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings.backupconfiguration", map[string]*llx.RawData{
-				"id":                          llx.StringData(fmt.Sprintf("%s/settings/backupConfiguration", instanceId)),
-				"backupRetentionSettings":     llx.DictData(mqlRetention),
-				"binaryLogEnabled":            llx.BoolData(s.BackupConfiguration.BinaryLogEnabled),
-				"enabled":                     llx.BoolData(s.BackupConfiguration.Enabled),
-				"location":                    llx.StringData(s.BackupConfiguration.Location),
-				"pointInTimeRecoveryEnabled":  llx.BoolData(s.BackupConfiguration.PointInTimeRecoveryEnabled),
-				"startTime":                   llx.StringData(s.BackupConfiguration.StartTime),
-				"transactionLogRetentionDays": llx.IntData(s.BackupConfiguration.TransactionLogRetentionDays),
-			})
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		mqlDenyMaintenancePeriods := make([]any, 0, len(s.DenyMaintenancePeriods))
-		for i, p := range s.DenyMaintenancePeriods {
-			mqlPeriod, err := CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings.denyMaintenancePeriod", map[string]*llx.RawData{
-				"id":        llx.StringData(fmt.Sprintf("%s/settings/denyMaintenancePeriod%d", instanceId, i)),
-				"endDate":   llx.StringData(p.EndDate),
-				"startDate": llx.StringData(p.StartDate),
-				"time":      llx.StringData(p.Time),
-			})
-			if err != nil {
-				return nil, err
-			}
-			mqlDenyMaintenancePeriods = append(mqlDenyMaintenancePeriods, mqlPeriod)
-		}
-
-		type mqlInsightsCfg struct {
-			QueryInsightsEnabled  bool  `json:"queryInsightsEnabled"`
-			QueryPlansPerMinute   int64 `json:"queryPlansPerMinute"`
-			QueryStringLength     int64 `json:"queryStringLength"`
-			RecordApplicationTags bool  `json:"recordApplicationTags"`
-			RecordClientAddress   bool  `json:"recordClientAddress"`
-		}
-		var mqlInsightsConfig map[string]any
-		if s.InsightsConfig != nil {
-			mqlInsightsConfig, err = convert.JsonToDict(mqlInsightsCfg{
-				QueryInsightsEnabled:  s.InsightsConfig.QueryInsightsEnabled,
-				QueryPlansPerMinute:   s.InsightsConfig.QueryPlansPerMinute,
-				QueryStringLength:     s.InsightsConfig.QueryStringLength,
-				RecordApplicationTags: s.InsightsConfig.RecordApplicationTags,
-				RecordClientAddress:   s.InsightsConfig.RecordClientAddress,
-			})
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		type mqlAclEntry struct {
-			ExpirationTime string `json:"expirationTime"`
-			Kind           string `json:"kind"`
-			Name           string `json:"name"`
-			Value          string `json:"value"`
-		}
-		var mqlIpCfg plugin.Resource
-		if s.IpConfiguration != nil {
-			mqlAclEntries := make([]any, 0, len(s.IpConfiguration.AuthorizedNetworks))
-			for _, e := range s.IpConfiguration.AuthorizedNetworks {
-				mqlAclEntry, err := convert.JsonToDict(mqlAclEntry{
-					ExpirationTime: e.ExpirationTime,
-					Kind:           e.Kind,
-					Name:           e.Name,
-					Value:          e.Value,
+			var mqlEncCfg map[string]any
+			if instance.DiskEncryptionConfiguration != nil {
+				mqlEncCfg, err = convert.JsonToDict(mqlDiskEncryptionCfg{
+					KmsKeyName: instance.DiskEncryptionConfiguration.KmsKeyName,
 				})
 				if err != nil {
-					return nil, err
+					return err
 				}
-				mqlAclEntries = append(mqlAclEntries, mqlAclEntry)
 			}
 
-			mqlIpCfg, err = CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings.ipConfiguration", map[string]*llx.RawData{
-				"allocatedIpRange":                        llx.StringData(s.IpConfiguration.AllocatedIpRange),
-				"authorizedNetworks":                      llx.ArrayData(mqlAclEntries, types.Dict),
-				"enablePrivatePathForGoogleCloudServices": llx.BoolData(s.IpConfiguration.EnablePrivatePathForGoogleCloudServices),
-				"id":             llx.StringData(fmt.Sprintf("%s/settings/ipConfiguration", instanceId)),
-				"ipv4Enabled":    llx.BoolData(s.IpConfiguration.Ipv4Enabled),
-				"privateNetwork": llx.StringData(s.IpConfiguration.PrivateNetwork),
-				"requireSsl":     llx.BoolData(s.IpConfiguration.RequireSsl),
-				"sslMode":        llx.StringData(s.IpConfiguration.SslMode),
+			type mqlDiskEncryptionStatus struct {
+				KmsKeyVersionName string `json:"kmsKeyVersionName"`
+			}
+			var mqlEncStatus map[string]any
+			if instance.DiskEncryptionStatus != nil {
+				mqlEncStatus, err = convert.JsonToDict(mqlDiskEncryptionStatus{
+					KmsKeyVersionName: instance.DiskEncryptionStatus.KmsKeyVersionName,
+				})
+				if err != nil {
+					return err
+				}
+			}
+
+			type mqlFailoverReplicaCfg struct {
+				Available bool   `json:"available"`
+				Name      string `json:"name"`
+			}
+			var mqlFailoverReplica map[string]any
+			if instance.FailoverReplica != nil {
+				mqlFailoverReplica, err = convert.JsonToDict(mqlFailoverReplicaCfg{
+					Available: instance.FailoverReplica.Available,
+					Name:      instance.FailoverReplica.Name,
+				})
+				if err != nil {
+					return err
+				}
+			}
+
+			mqlIpAddresses := make([]any, 0, len(instance.IpAddresses))
+			for i, a := range instance.IpAddresses {
+				mqlIpAddress, err := CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.ipMapping", map[string]*llx.RawData{
+					"id":           llx.StringData(fmt.Sprintf("%s/ipAddresses%d", instanceId, i)),
+					"ipAddress":    llx.StringData(a.IpAddress),
+					"timeToRetire": llx.TimeDataPtr(parseTime(a.TimeToRetire)),
+					"type":         llx.StringData(a.Type),
+				})
+				if err != nil {
+					return err
+				}
+				mqlIpAddresses = append(mqlIpAddresses, mqlIpAddress)
+			}
+
+			s := instance.Settings
+			dbFlags := make(map[string]string)
+			for _, f := range s.DatabaseFlags {
+				dbFlags[f.Name] = f.Value
+			}
+
+			type mqlActiveDirectoryCfg struct {
+				Domain string `json:"domain,omitempty"`
+			}
+			var mqlADCfg map[string]any
+			if s.ActiveDirectoryConfig != nil {
+				mqlADCfg, err = convert.JsonToDict(mqlActiveDirectoryCfg{
+					Domain: s.ActiveDirectoryConfig.Domain,
+				})
+				if err != nil {
+					return err
+				}
+			}
+
+			var mqlBackupCfg plugin.Resource
+			if s.BackupConfiguration != nil {
+				type mqlRetentionSettings struct {
+					RetainedBackups int64  `json:"retainedBackups"`
+					RetentionUnit   string `json:"retentionUnit"`
+				}
+				mqlRetention, err := convert.JsonToDict(mqlRetentionSettings{
+					RetainedBackups: s.BackupConfiguration.BackupRetentionSettings.RetainedBackups,
+					RetentionUnit:   s.BackupConfiguration.BackupRetentionSettings.RetentionUnit,
+				})
+				if err != nil {
+					return err
+				}
+
+				mqlBackupCfg, err = CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings.backupconfiguration", map[string]*llx.RawData{
+					"id":                          llx.StringData(fmt.Sprintf("%s/settings/backupConfiguration", instanceId)),
+					"backupRetentionSettings":     llx.DictData(mqlRetention),
+					"binaryLogEnabled":            llx.BoolData(s.BackupConfiguration.BinaryLogEnabled),
+					"enabled":                     llx.BoolData(s.BackupConfiguration.Enabled),
+					"location":                    llx.StringData(s.BackupConfiguration.Location),
+					"pointInTimeRecoveryEnabled":  llx.BoolData(s.BackupConfiguration.PointInTimeRecoveryEnabled),
+					"startTime":                   llx.StringData(s.BackupConfiguration.StartTime),
+					"transactionLogRetentionDays": llx.IntData(s.BackupConfiguration.TransactionLogRetentionDays),
+				})
+				if err != nil {
+					return err
+				}
+			}
+
+			mqlDenyMaintenancePeriods := make([]any, 0, len(s.DenyMaintenancePeriods))
+			for i, p := range s.DenyMaintenancePeriods {
+				mqlPeriod, err := CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings.denyMaintenancePeriod", map[string]*llx.RawData{
+					"id":        llx.StringData(fmt.Sprintf("%s/settings/denyMaintenancePeriod%d", instanceId, i)),
+					"endDate":   llx.StringData(p.EndDate),
+					"startDate": llx.StringData(p.StartDate),
+					"time":      llx.StringData(p.Time),
+				})
+				if err != nil {
+					return err
+				}
+				mqlDenyMaintenancePeriods = append(mqlDenyMaintenancePeriods, mqlPeriod)
+			}
+
+			type mqlInsightsCfg struct {
+				QueryInsightsEnabled  bool  `json:"queryInsightsEnabled"`
+				QueryPlansPerMinute   int64 `json:"queryPlansPerMinute"`
+				QueryStringLength     int64 `json:"queryStringLength"`
+				RecordApplicationTags bool  `json:"recordApplicationTags"`
+				RecordClientAddress   bool  `json:"recordClientAddress"`
+			}
+			var mqlInsightsConfig map[string]any
+			if s.InsightsConfig != nil {
+				mqlInsightsConfig, err = convert.JsonToDict(mqlInsightsCfg{
+					QueryInsightsEnabled:  s.InsightsConfig.QueryInsightsEnabled,
+					QueryPlansPerMinute:   s.InsightsConfig.QueryPlansPerMinute,
+					QueryStringLength:     s.InsightsConfig.QueryStringLength,
+					RecordApplicationTags: s.InsightsConfig.RecordApplicationTags,
+					RecordClientAddress:   s.InsightsConfig.RecordClientAddress,
+				})
+				if err != nil {
+					return err
+				}
+			}
+
+			type mqlAclEntry struct {
+				ExpirationTime string `json:"expirationTime"`
+				Kind           string `json:"kind"`
+				Name           string `json:"name"`
+				Value          string `json:"value"`
+			}
+			var mqlIpCfg plugin.Resource
+			if s.IpConfiguration != nil {
+				mqlAclEntries := make([]any, 0, len(s.IpConfiguration.AuthorizedNetworks))
+				for _, e := range s.IpConfiguration.AuthorizedNetworks {
+					mqlAclEntry, err := convert.JsonToDict(mqlAclEntry{
+						ExpirationTime: e.ExpirationTime,
+						Kind:           e.Kind,
+						Name:           e.Name,
+						Value:          e.Value,
+					})
+					if err != nil {
+						return err
+					}
+					mqlAclEntries = append(mqlAclEntries, mqlAclEntry)
+				}
+
+				mqlIpCfg, err = CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings.ipConfiguration", map[string]*llx.RawData{
+					"allocatedIpRange":                        llx.StringData(s.IpConfiguration.AllocatedIpRange),
+					"authorizedNetworks":                      llx.ArrayData(mqlAclEntries, types.Dict),
+					"enablePrivatePathForGoogleCloudServices": llx.BoolData(s.IpConfiguration.EnablePrivatePathForGoogleCloudServices),
+					"id":             llx.StringData(fmt.Sprintf("%s/settings/ipConfiguration", instanceId)),
+					"ipv4Enabled":    llx.BoolData(s.IpConfiguration.Ipv4Enabled),
+					"privateNetwork": llx.StringData(s.IpConfiguration.PrivateNetwork),
+					"requireSsl":     llx.BoolData(s.IpConfiguration.RequireSsl),
+					"sslMode":        llx.StringData(s.IpConfiguration.SslMode),
+				})
+				if err != nil {
+					return err
+				}
+			}
+
+			type mqlLocationPref struct {
+				FollowGaeApplication string `json:"followGaeApplication"`
+				SecondaryZone        string `json:"secondaryZone"`
+				Zone                 string `json:"zone"`
+			}
+			var mqlLocationP map[string]any
+			if s.LocationPreference != nil {
+				mqlLocationP, err = convert.JsonToDict(mqlLocationPref{
+					FollowGaeApplication: s.LocationPreference.FollowGaeApplication,
+					SecondaryZone:        s.LocationPreference.SecondaryZone,
+					Zone:                 s.LocationPreference.Zone,
+				})
+				if err != nil {
+					return err
+				}
+			}
+
+			var mqlMaintenanceWindow plugin.Resource
+			if s.MaintenanceWindow != nil {
+				mqlMaintenanceWindow, err = CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings.maintenanceWindow", map[string]*llx.RawData{
+					"id":          llx.StringData(fmt.Sprintf("%s/settings/maintenanceWindow", instanceId)),
+					"day":         llx.IntData(s.MaintenanceWindow.Day),
+					"hour":        llx.IntData(s.MaintenanceWindow.Hour),
+					"updateTrack": llx.StringData(s.MaintenanceWindow.UpdateTrack),
+				})
+				if err != nil {
+					return err
+				}
+			}
+
+			var mqlPwdValidationPolicy plugin.Resource
+			if s.PasswordValidationPolicy != nil {
+				mqlPwdValidationPolicy, err = CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings.passwordValidationPolicy", map[string]*llx.RawData{
+					"id":                        llx.StringData(fmt.Sprintf("%s/settings/passwordValidationPolicy", instanceId)),
+					"complexity":                llx.StringData(s.PasswordValidationPolicy.Complexity),
+					"disallowUsernameSubstring": llx.BoolData(s.PasswordValidationPolicy.DisallowUsernameSubstring),
+					"enabledPasswordPolicy":     llx.BoolData(s.PasswordValidationPolicy.EnablePasswordPolicy),
+					"minLength":                 llx.IntData(s.PasswordValidationPolicy.MinLength),
+					"passwordChangeInterval":    llx.StringData(s.PasswordValidationPolicy.PasswordChangeInterval),
+					"reuseInterval":             llx.IntData(s.PasswordValidationPolicy.ReuseInterval),
+				})
+				if err != nil {
+					return err
+				}
+			}
+
+			type mqlSqlServerAuditConfig struct {
+				Bucket            string `json:"bucket"`
+				RetentionInterval string `json:"retentionInterval"`
+				UploadInterval    string `json:"uploadInterval"`
+			}
+			var mqlSqlServerAuditCfg map[string]any
+			if s.SqlServerAuditConfig != nil {
+				mqlSqlServerAuditCfg, err = convert.JsonToDict(mqlSqlServerAuditConfig{
+					Bucket:            s.SqlServerAuditConfig.Bucket,
+					RetentionInterval: s.SqlServerAuditConfig.RetentionInterval,
+					UploadInterval:    s.SqlServerAuditConfig.UploadInterval,
+				})
+				if err != nil {
+					return err
+				}
+			}
+
+			mqlSettings, err := CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings", map[string]*llx.RawData{
+				"activationPolicy":            llx.StringData(s.ActivationPolicy),
+				"activeDirectoryConfig":       llx.DictData(mqlADCfg),
+				"availabilityType":            llx.StringData(s.AvailabilityType),
+				"backupConfiguration":         llx.DictData(mqlBackupCfg),
+				"collation":                   llx.StringData(s.Collation),
+				"connectorEnforcement":        llx.StringData(s.ConnectorEnforcement),
+				"crashSafeReplicationEnabled": llx.BoolData(s.CrashSafeReplicationEnabled),
+				"databaseFlags":               llx.MapData(convert.MapToInterfaceMap(dbFlags), types.String),
+				"databaseReplicationEnabled":  llx.BoolData(s.DatabaseReplicationEnabled),
+				"dataDiskSizeGb":              llx.IntData(s.DataDiskSizeGb),
+				"dataDiskType":                llx.StringData(s.DataDiskType),
+				"deletionProtectionEnabled":   llx.BoolData(s.DeletionProtectionEnabled),
+				"denyMaintenancePeriods":      llx.ArrayData(mqlDenyMaintenancePeriods, types.Resource("gcp.project.sqlService.instance.settings.denyMaintenancePeriod")),
+				"insightsConfig":              llx.DictData(mqlInsightsConfig),
+				"instanceName":                llx.StringData(instance.Name),
+				"ipConfiguration":             llx.DictData(mqlIpCfg),
+				"locationPreference":          llx.DictData(mqlLocationP),
+				"maintenanceWindow":           llx.ResourceData(mqlMaintenanceWindow, "gcp.project.sqlService.instance.settings.maintenanceWindow"),
+				"passwordValidationPolicy":    llx.ResourceData(mqlPwdValidationPolicy, "gcp.project.sqlService.instance.settings.passwordValidationPolicy"),
+				"pricingPlan":                 llx.StringData(s.PricingPlan),
+				"projectId":                   llx.StringData(projectId),
+				"replicationType":             llx.StringData(s.ReplicationType),
+				"settingsVersion":             llx.IntData(s.SettingsVersion),
+				"sqlServerAuditConfig":        llx.DictData(mqlSqlServerAuditCfg),
+				"storageAutoResize":           llx.BoolDataPtr(s.StorageAutoResize),
+				"storageAutoResizeLimit":      llx.IntData(s.StorageAutoResizeLimit),
+				"tier":                        llx.StringData(s.Tier),
+				"timeZone":                    llx.StringData(s.TimeZone),
+				"userLabels":                  llx.MapData(convert.MapToInterfaceMap(s.UserLabels), types.String),
 			})
 			if err != nil {
-				return nil, err
+				return err
 			}
-		}
 
-		type mqlLocationPref struct {
-			FollowGaeApplication string `json:"followGaeApplication"`
-			SecondaryZone        string `json:"secondaryZone"`
-			Zone                 string `json:"zone"`
-		}
-		var mqlLocationP map[string]any
-		if s.LocationPreference != nil {
-			mqlLocationP, err = convert.JsonToDict(mqlLocationPref{
-				FollowGaeApplication: s.LocationPreference.FollowGaeApplication,
-				SecondaryZone:        s.LocationPreference.SecondaryZone,
-				Zone:                 s.LocationPreference.Zone,
+			mqlInstance, err := CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance", map[string]*llx.RawData{
+				"availableMaintenanceVersions": llx.ArrayData(convert.SliceAnyToInterface(instance.AvailableMaintenanceVersions), types.String),
+				"backendType":                  llx.StringData(instance.BackendType),
+				"connectionName":               llx.StringData(instance.ConnectionName),
+				"created":                      llx.TimeDataPtr(parseTime(instance.CreateTime)),
+				"databaseInstalledVersion":     llx.StringData(instance.DatabaseInstalledVersion),
+				"databaseVersion":              llx.StringData(instance.DatabaseVersion),
+				"diskEncryptionConfiguration":  llx.DictData(mqlEncCfg),
+				"diskEncryptionStatus":         llx.DictData(mqlEncStatus),
+				"failoverReplica":              llx.DictData(mqlFailoverReplica),
+				"gceZone":                      llx.StringData(instance.GceZone),
+				"instanceType":                 llx.StringData(instance.InstanceType),
+				"ipAddresses":                  llx.ArrayData(mqlIpAddresses, types.String),
+				"maintenanceVersion":           llx.StringData(instance.MaintenanceVersion),
+				"masterInstanceName":           llx.StringData(instance.MasterInstanceName),
+				"maxDiskSize":                  llx.IntData(instance.MaxDiskSize),
+				"name":                         llx.StringData(instance.Name),
+				"projectId":                    llx.StringData(projectId),
+				"region":                       llx.StringData(instance.Region),
+				"replicaNames":                 llx.ArrayData(convert.SliceAnyToInterface(instance.ReplicaNames), types.String),
+				"serviceAccountEmailAddress":   llx.StringData(instance.ServiceAccountEmailAddress),
+				"settings":                     llx.ResourceData(mqlSettings, "gcp.project.sqlService.instance.settings"),
+				"state":                        llx.StringData(instance.State),
+				"satisfiesPzi":                 llx.BoolData(instance.SatisfiesPzi),
+				"satisfiesPzs":                 llx.BoolData(instance.SatisfiesPzs),
+				"dnsName":                      llx.StringData(instance.DnsName),
+				"sqlNetworkArchitecture":       llx.StringData(instance.SqlNetworkArchitecture),
+				"suspensionReason":             llx.ArrayData(convert.SliceAnyToInterface(instance.SuspensionReason), types.String),
+				"switchTransactionLogsToCloudStorageEnabled": llx.BoolData(instance.SwitchTransactionLogsToCloudStorageEnabled),
+				"primaryDnsName":           llx.StringData(instance.PrimaryDnsName),
+				"writeEndpoint":            llx.StringData(instance.WriteEndpoint),
+				"pscServiceAttachmentLink": llx.StringData(instance.PscServiceAttachmentLink),
 			})
 			if err != nil {
-				return nil, err
+				return err
 			}
+			mqlInstance.(*mqlGcpProjectSqlServiceInstance).cacheSecondaryGceZone = instance.SecondaryGceZone
+			res = append(res, mqlInstance)
 		}
-
-		var mqlMaintenanceWindow plugin.Resource
-		if s.MaintenanceWindow != nil {
-			mqlMaintenanceWindow, err = CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings.maintenanceWindow", map[string]*llx.RawData{
-				"id":          llx.StringData(fmt.Sprintf("%s/settings/maintenanceWindow", instanceId)),
-				"day":         llx.IntData(s.MaintenanceWindow.Day),
-				"hour":        llx.IntData(s.MaintenanceWindow.Hour),
-				"updateTrack": llx.StringData(s.MaintenanceWindow.UpdateTrack),
-			})
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		var mqlPwdValidationPolicy plugin.Resource
-		if s.PasswordValidationPolicy != nil {
-			mqlPwdValidationPolicy, err = CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings.passwordValidationPolicy", map[string]*llx.RawData{
-				"id":                        llx.StringData(fmt.Sprintf("%s/settings/passwordValidationPolicy", instanceId)),
-				"complexity":                llx.StringData(s.PasswordValidationPolicy.Complexity),
-				"disallowUsernameSubstring": llx.BoolData(s.PasswordValidationPolicy.DisallowUsernameSubstring),
-				"enabledPasswordPolicy":     llx.BoolData(s.PasswordValidationPolicy.EnablePasswordPolicy),
-				"minLength":                 llx.IntData(s.PasswordValidationPolicy.MinLength),
-				"passwordChangeInterval":    llx.StringData(s.PasswordValidationPolicy.PasswordChangeInterval),
-				"reuseInterval":             llx.IntData(s.PasswordValidationPolicy.ReuseInterval),
-			})
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		type mqlSqlServerAuditConfig struct {
-			Bucket            string `json:"bucket"`
-			RetentionInterval string `json:"retentionInterval"`
-			UploadInterval    string `json:"uploadInterval"`
-		}
-		var mqlSqlServerAuditCfg map[string]any
-		if s.SqlServerAuditConfig != nil {
-			mqlSqlServerAuditCfg, err = convert.JsonToDict(mqlSqlServerAuditConfig{
-				Bucket:            s.SqlServerAuditConfig.Bucket,
-				RetentionInterval: s.SqlServerAuditConfig.RetentionInterval,
-				UploadInterval:    s.SqlServerAuditConfig.UploadInterval,
-			})
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		mqlSettings, err := CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings", map[string]*llx.RawData{
-			"activationPolicy":            llx.StringData(s.ActivationPolicy),
-			"activeDirectoryConfig":       llx.DictData(mqlADCfg),
-			"availabilityType":            llx.StringData(s.AvailabilityType),
-			"backupConfiguration":         llx.DictData(mqlBackupCfg),
-			"collation":                   llx.StringData(s.Collation),
-			"connectorEnforcement":        llx.StringData(s.ConnectorEnforcement),
-			"crashSafeReplicationEnabled": llx.BoolData(s.CrashSafeReplicationEnabled),
-			"databaseFlags":               llx.MapData(convert.MapToInterfaceMap(dbFlags), types.String),
-			"databaseReplicationEnabled":  llx.BoolData(s.DatabaseReplicationEnabled),
-			"dataDiskSizeGb":              llx.IntData(s.DataDiskSizeGb),
-			"dataDiskType":                llx.StringData(s.DataDiskType),
-			"deletionProtectionEnabled":   llx.BoolData(s.DeletionProtectionEnabled),
-			"denyMaintenancePeriods":      llx.ArrayData(mqlDenyMaintenancePeriods, types.Resource("gcp.project.sqlService.instance.settings.denyMaintenancePeriod")),
-			"insightsConfig":              llx.DictData(mqlInsightsConfig),
-			"instanceName":                llx.StringData(instance.Name),
-			"ipConfiguration":             llx.DictData(mqlIpCfg),
-			"locationPreference":          llx.DictData(mqlLocationP),
-			"maintenanceWindow":           llx.ResourceData(mqlMaintenanceWindow, "gcp.project.sqlService.instance.settings.maintenanceWindow"),
-			"passwordValidationPolicy":    llx.ResourceData(mqlPwdValidationPolicy, "gcp.project.sqlService.instance.settings.passwordValidationPolicy"),
-			"pricingPlan":                 llx.StringData(s.PricingPlan),
-			"projectId":                   llx.StringData(projectId),
-			"replicationType":             llx.StringData(s.ReplicationType),
-			"settingsVersion":             llx.IntData(s.SettingsVersion),
-			"sqlServerAuditConfig":        llx.DictData(mqlSqlServerAuditCfg),
-			"storageAutoResize":           llx.BoolDataPtr(s.StorageAutoResize),
-			"storageAutoResizeLimit":      llx.IntData(s.StorageAutoResizeLimit),
-			"tier":                        llx.StringData(s.Tier),
-			"timeZone":                    llx.StringData(s.TimeZone),
-			"userLabels":                  llx.MapData(convert.MapToInterfaceMap(s.UserLabels), types.String),
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		mqlInstance, err := CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance", map[string]*llx.RawData{
-			"availableMaintenanceVersions": llx.ArrayData(convert.SliceAnyToInterface(instance.AvailableMaintenanceVersions), types.String),
-			"backendType":                  llx.StringData(instance.BackendType),
-			"connectionName":               llx.StringData(instance.ConnectionName),
-			"created":                      llx.TimeDataPtr(parseTime(instance.CreateTime)),
-			"databaseInstalledVersion":     llx.StringData(instance.DatabaseInstalledVersion),
-			"databaseVersion":              llx.StringData(instance.DatabaseVersion),
-			"diskEncryptionConfiguration":  llx.DictData(mqlEncCfg),
-			"diskEncryptionStatus":         llx.DictData(mqlEncStatus),
-			"failoverReplica":              llx.DictData(mqlFailoverReplica),
-			"gceZone":                      llx.StringData(instance.GceZone),
-			"instanceType":                 llx.StringData(instance.InstanceType),
-			"ipAddresses":                  llx.ArrayData(mqlIpAddresses, types.String),
-			"maintenanceVersion":           llx.StringData(instance.MaintenanceVersion),
-			"masterInstanceName":           llx.StringData(instance.MasterInstanceName),
-			"maxDiskSize":                  llx.IntData(instance.MaxDiskSize),
-			"name":                         llx.StringData(instance.Name),
-			"projectId":                    llx.StringData(projectId),
-			"region":                       llx.StringData(instance.Region),
-			"replicaNames":                 llx.ArrayData(convert.SliceAnyToInterface(instance.ReplicaNames), types.String),
-			"serviceAccountEmailAddress":   llx.StringData(instance.ServiceAccountEmailAddress),
-			"settings":                     llx.ResourceData(mqlSettings, "gcp.project.sqlService.instance.settings"),
-			"state":                        llx.StringData(instance.State),
-			"satisfiesPzi":                 llx.BoolData(instance.SatisfiesPzi),
-			"satisfiesPzs":                 llx.BoolData(instance.SatisfiesPzs),
-			"dnsName":                      llx.StringData(instance.DnsName),
-			"sqlNetworkArchitecture":       llx.StringData(instance.SqlNetworkArchitecture),
-			"suspensionReason":             llx.ArrayData(convert.SliceAnyToInterface(instance.SuspensionReason), types.String),
-			"switchTransactionLogsToCloudStorageEnabled": llx.BoolData(instance.SwitchTransactionLogsToCloudStorageEnabled),
-			"primaryDnsName":           llx.StringData(instance.PrimaryDnsName),
-			"writeEndpoint":            llx.StringData(instance.WriteEndpoint),
-			"pscServiceAttachmentLink": llx.StringData(instance.PscServiceAttachmentLink),
-		})
-		if err != nil {
-			return nil, err
-		}
-		mqlInstance.(*mqlGcpProjectSqlServiceInstance).cacheSecondaryGceZone = instance.SecondaryGceZone
-		res = append(res, mqlInstance)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	return res, nil


### PR DESCRIPTION
## Summary

Fixes pagination bugs that silently drop data and reduces redundant API calls in the GCP provider.

### Bug Fixes (silent data loss)

**SQL `instances()` — now paginated**
- Was using `.Do()` which only returns the first page (~100 items). Now uses `.Pages()`.
- **Impact:** Projects with >100 SQL instances were silently missing results. Affects correctness, not call count.

**Logging `buckets()` — now paginated**
- Same issue — `.Do()` only returned the first page. Now uses `.Pages()`.
- **Impact:** Projects with many logging buckets across locations were silently missing results. Affects correctness, not call count.

### Performance Improvements

**Project `iamPolicy()` / `auditConfig()` — shared API call**
- Both methods independently called `Projects.GetIamPolicy()` for the same project. Now share a single call via `sync.Once`.
- **Calls saved:** 1 per project when both fields are accessed (common in security scans).
- **Mid-size project (1 project):** 1 call saved.
- **Org scan (50 projects):** 50 calls saved.

**BigQuery `tables()` / `models()` / `routines()` — shared client**
- Each method created its own `bigquery.NewClient()`, which involves OAuth token exchange and HTTP client setup. Now share a single client per dataset via Internal struct with `sync.Once`.
- **Clients saved:** 2 per dataset (3 methods share 1 client instead of each creating their own).
- **Mid-size project (20 datasets):** 40 client initializations eliminated.
- **Large project (100 datasets):** 200 client initializations eliminated.

### Estimated Total Savings (mid-size project)

| Scenario | Before | After | Saved |
|----------|--------|-------|-------|
| 1 project, both IAM fields accessed | 2 GetIamPolicy calls | 1 | 1 call |
| 50 projects (org scan), both IAM fields | 100 GetIamPolicy calls | 50 | 50 calls |
| 20 BigQuery datasets, all 3 methods accessed | 60 client inits | 20 | 40 client inits |
| SQL instances (>100) | Silently truncated | All returned | Correctness fix |
| Logging buckets (>50) | Silently truncated | All returned | Correctness fix |

The pagination fixes are the most critical — they fix silent data loss that could cause security policies to miss resources entirely.

## Test plan

- [ ] Build provider: `cd providers/gcp && go build ./...`
- [ ] Verify with a project that has SQL instances: `mql run gcp -c "gcp.project.sql.instances.length"`
- [ ] Verify logging buckets: `mql run gcp -c "gcp.project.logging.buckets.length"`
- [ ] Verify IAM policy and audit config both work: `mql run gcp -c "gcp.project { iamPolicy auditConfig }"`
- [ ] Verify BigQuery dataset methods: `mql run gcp -c "gcp.project.bigquery.datasets { tables models routines }"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)