### PR TITLE
Pin package-url/packageurl-go to v0.1.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/muesli/termenv v0.16.0
 	github.com/olekukonko/tablewriter v1.1.3
 	github.com/opencontainers/image-spec v1.1.1
+	// pin v0.1.3
 	github.com/package-url/packageurl-go v0.1.3
 	github.com/pandatix/go-cvss v0.6.2
 	github.com/patrickmn/go-cache v2.1.0+incompatible


### PR DESCRIPTION
## Summary
- Pin `package-url/packageurl-go` to v0.1.3 to prevent automated dep updates from bumping it
- v0.1.5 changes colon encoding behavior in PURLs (stops percent-encoding `:` to `%3A`), which breaks package URL tests

## Test plan
- [ ] CI passes (no code changes, just a comment pin)
- [ ] Verify dep update tooling respects the pin comment


🤖 Generated with [Claude Code](https://claude.com/claude-code)