### PR TITLE
Fix intermittent integration test failures (add -p 1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -724,10 +724,10 @@ test/go/plain-ci: prep/tools test/generate providers/build
 	gotestsum --junitfile report.xml --format pkgname -- -cover $(shell go list ./... | grep -v '/vendor/' | grep -v '/providers/' | grep -v '/test/')
 
 test/integration:
-	go test -cover $(shell go list ./... | grep '/test/')
+	go test -cover -p 1 $(shell go list ./... | grep '/test/')
 
 test/go-cli/plain-ci: prep/tools test/generate providers/build
-	gotestsum --junitfile report.xml --format pkgname -- -cover $(shell go list ./... | grep '/test/')
+	gotestsum --junitfile report.xml --format pkgname -- -cover -p 1 $(shell go list ./... | grep '/test/')
 
 .PHONY: test/lint/staticcheck
 test/lint/staticcheck:

--- a/test/commands/cli_test.go
+++ b/test/commands/cli_test.go
@@ -33,6 +33,8 @@ func setup() {
 	// install local provider
 	providerCmd := exec.Command("bash", "-c", "cd ../.. && make providers/build/os providers/install/os")
 	providerCmd.Env = test.BuildEnv()
+	providerCmd.Stdout = os.Stdout
+	providerCmd.Stderr = os.Stderr
 	if err := providerCmd.Run(); err != nil {
 		log.Fatalf("building os provider: %v", err)
 	}

--- a/test/providers/os_test.go
+++ b/test/providers/os_test.go
@@ -30,6 +30,8 @@ func setup() {
 	// install local provider
 	providerCmd := exec.Command("bash", "-c", "cd ../.. && make providers/build/os providers/install/os")
 	providerCmd.Env = test.BuildEnv()
+	providerCmd.Stdout = os.Stdout
+	providerCmd.Stderr = os.Stderr
 	if err := providerCmd.Run(); err != nil {
 		log.Fatalf("building os provider: %v", err)
 	}


### PR DESCRIPTION
## Summary
\`go test\` runs packages in parallel by default (up to GOMAXPROCS). Both \`test/commands\` and \`test/providers\` call \`make providers/build/os\` during setup, writing to the same shared directory (\`providers/os/dist/\`). Concurrent builds race on file writes, causing one to fail with \`"building os provider: exit status 2"\`.

The race also amplified a GOCOVERDIR issue: child Go processes spawned by make are not built with coverage instrumentation, so when GOCOVERDIR leaked through they failed with \`"program not built with -cover"\`. Previous fixes (PRs #6785, #6807) stripped GOCOVERDIR from child environments but couldn't fully prevent the issue under parallel execution.

### Changes
1. **Add \`-p 1\`** to \`test/integration\` and \`test/go-cli/plain-ci\` Makefile targets to force sequential package execution
2. **Pipe build output** from the provider build command so future failures produce visible diagnostics in CI logs

### Evidence of parallel execution causing failures
- Run [22827335389](https://github.com/mondoohq/mql/actions/runs/22827335389): \`test/commands\` OK, \`test/providers\` FAIL — both finish at same timestamp
- Run [22810219565](https://github.com/mondoohq/mql/actions/runs/22810219565): \`test/commands\` FAIL, \`test/providers\` OK — different package fails each time

## Test plan
- [ ] CI \`go-test-integration\` job passes consistently across multiple runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)