### PR TITLE
:broom: Add junos provider to default providers

### DIFF
--- a/providers/defaults.go
+++ b/providers/defaults.go
@@ -245,6 +245,21 @@ var DefaultProviders Providers = map[string]*Provider{
 		},
 	},
 
+	"junos": {
+		Provider: &plugin.Provider{
+			Name:            "junos",
+			ID:              "go.mondoo.com/cnquery/providers/junos",
+			ConnectionTypes: []string{"junos"},
+			Connectors: []plugin.Connector{
+				{
+					Name:  "junos",
+					Use:   "junos",
+					Short: "a remote Junos OS device",
+				},
+			},
+		},
+	},
+
 	"k8s": {
 		Provider: &plugin.Provider{
 			Name:            "k8s",


### PR DESCRIPTION
## Summary
- Add the Juniper Junos OS provider to `DefaultProviders` in `providers/defaults.go`
- Ensures the junos provider is discoverable in air-gapped environments, matching the existing fortios, panos, and other enterprise providers

## Test plan
- [ ] Verify `go build ./providers/` compiles cleanly
- [ ] Confirm junos provider appears in `mql shell --help` output in air-gapped mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)