### PR TITLE
🏃🏻‍♂️ build provider arch in parallel

### DIFF
--- a/scripts/provider_bundler.sh
+++ b/scripts/provider_bundler.sh
@@ -56,6 +56,7 @@ echo "  - Generate the resource versions..."
 ${REPOROOT}/lr versions ${PROVIDER_PATH}/resources/${PROVIDER_NAME}.lr
 
 build_bundle(){
+  set -eo pipefail
   local GOOS=$1
   local GOARCH=$2
   local GOARM=${3:-}
@@ -98,11 +99,6 @@ build_bundle(){
     ${TAR_FLAGS} --use-compress-program='xz -9v' \
     -C ${ARCH_DIST} ${PROVIDER_EXECUTABLE} \
     -C ${PROVIDER_DIST} ${PROVIDER_NAME}.json ${PROVIDER_NAME}.resources.json
-
-  if [ $? -ne 0 ]; then
-    echo "Failed to build the ${PROVIDER_NAME} provider for ${GOOS}/${GOARCH}."
-    return 1
-  fi
 
   # Clean up the arch-specific directory
   rm -rf "$ARCH_DIST"


### PR DESCRIPTION
This change allows us to build the different architectures for our providers in parallel. This should tremendously cut down on build time. Our runners are more than capable of handling such parallelism given their size.

Here's an example build with these changes: https://github.com/mondoohq/mql/actions/runs/22944965583
Here's a build with the existing approach: https://github.com/mondoohq/mql/actions/runs/22916497418

Some comparison for build time for a few randomly picked providers

| **Provider** | **Current** | **New** |
|--------------|-------------|---------|
| gcp          | 16min       | 7min    |
| azure        | 18min       | 7min    |
| snowflake    | 9min        | 3min    |
| github       | 4min        | 2min    |
| okta         | 3min        | 1min    |
| aws          | 30min       | 19min   |
| ms365    | 41min   | 20min |

Total runtime for building 27 providers with the old approach: **3h 30min**
Total runtime for building 31 providers with the new approach: **1h 35min**