### PR TITLE
Fix DNS resolution errors in ElastiCache discovery

### DIFF
--- a/providers/aws/resources/aws_elasticache.go
+++ b/providers/aws/resources/aws_elasticache.go
@@ -67,6 +67,10 @@ func (a *mqlAwsElasticache) getCacheClusters(conn *connection.AwsConnection) []*
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
+					if IsServiceNotAvailableInRegionError(err) {
+						log.Debug().Str("region", region).Msg("elasticache service not available in region")
+						return res, nil
+					}
 					return nil, err
 				}
 				for _, cluster := range clusters.CacheClusters {
@@ -203,6 +207,10 @@ func (a *mqlAwsElasticache) getServerlessCaches(conn *connection.AwsConnection) 
 				if err != nil {
 					if Is400AccessDeniedError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
+						return res, nil
+					}
+					if IsServiceNotAvailableInRegionError(err) {
+						log.Debug().Str("region", region).Msg("elasticache service not available in region")
 						return res, nil
 					}
 					return nil, err


### PR DESCRIPTION
## Summary
- Handle `IsServiceNotAvailableInRegionError` in ElastiCache `getCacheClusters` and `getServerlessCaches` methods
- When ElastiCache endpoints fail DNS resolution (e.g., in unsupported regions), the error is now gracefully logged and skipped instead of failing the entire discovery

## Test plan
- [ ] Build and install AWS provider, run `mql run aws -c "aws.elasticache.clusters"` against an account with regions where ElastiCache DNS fails
- [ ] Verify clusters from supported regions are still returned
- [ ] Verify no error is thrown for unsupported regions

🤖 Generated with [Claude Code](https://claude.com/claude-code)