### PR TITLE
🐛 Fix nil pointer dereferences in Azure provider

### DIFF
--- a/providers/azure/resources/advisor.go
+++ b/providers/azure/resources/advisor.go
@@ -64,20 +64,22 @@ func (a *mqlAzureSubscriptionAdvisorService) recommendations() ([]any, error) {
 				return nil, err
 			}
 			args := map[string]*llx.RawData{
-				"id":                   llx.StringDataPtr(r.ID),
-				"name":                 llx.StringDataPtr(r.Name),
-				"type":                 llx.StringDataPtr(r.Type),
-				"category":             llx.StringDataPtr((*string)(r.Properties.Category)),
-				"impact":               llx.StringDataPtr((*string)(r.Properties.Impact)),
-				"risk":                 llx.StringDataPtr((*string)(r.Properties.Risk)),
-				"properties":           llx.DictData(props),
-				"impactedResourceType": llx.StringDataPtr(r.Properties.ImpactedField),
-				"impactedResource":     llx.StringDataPtr(r.Properties.ImpactedValue),
+				"id":         llx.StringDataPtr(r.ID),
+				"name":       llx.StringDataPtr(r.Name),
+				"type":       llx.StringDataPtr(r.Type),
+				"properties": llx.DictData(props),
 			}
-			if r.Properties.ShortDescription != nil {
-				// the 'Description' field in the API response is always empty, use the short description instead
-				args["description"] = llx.StringDataPtr(r.Properties.ShortDescription.Problem)
-				args["remediation"] = llx.StringDataPtr(r.Properties.ShortDescription.Solution)
+			if r.Properties != nil {
+				args["category"] = llx.StringDataPtr((*string)(r.Properties.Category))
+				args["impact"] = llx.StringDataPtr((*string)(r.Properties.Impact))
+				args["risk"] = llx.StringDataPtr((*string)(r.Properties.Risk))
+				args["impactedResourceType"] = llx.StringDataPtr(r.Properties.ImpactedField)
+				args["impactedResource"] = llx.StringDataPtr(r.Properties.ImpactedValue)
+				if r.Properties.ShortDescription != nil {
+					// the 'Description' field in the API response is always empty, use the short description instead
+					args["description"] = llx.StringDataPtr(r.Properties.ShortDescription.Problem)
+					args["remediation"] = llx.StringDataPtr(r.Properties.ShortDescription.Solution)
+				}
 			}
 			mqlRecomm, err := CreateResource(a.MqlRuntime, "azure.subscription.advisorService.recommendation", args)
 			if err != nil {

--- a/providers/azure/resources/aks.go
+++ b/providers/azure/resources/aks.go
@@ -90,6 +90,13 @@ func (a *mqlAzureSubscriptionAksServiceClusterAutoUpgradeProfile) id() (string, 
 	return a.Id.Data, nil
 }
 
+func aksPowerState(entry *clusters.ManagedCluster) *llx.RawData {
+	if entry.Properties != nil && entry.Properties.PowerState != nil {
+		return llx.StringDataPtr((*string)(entry.Properties.PowerState.Code))
+	}
+	return llx.NilData
+}
+
 func (a *mqlAzureSubscriptionAksService) clusters() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	ctx := context.Background()
@@ -211,7 +218,7 @@ func (a *mqlAzureSubscriptionAksService) clusters() ([]any, error) {
 				}
 				aadRes, err := CreateResource(a.MqlRuntime, "azure.subscription.aksService.cluster.aadProfile",
 					map[string]*llx.RawData{
-						"id":                  llx.StringData(*entry.ID + "/aadProfile"),
+						"id":                  llx.StringData(convert.ToValue(entry.ID) + "/aadProfile"),
 						"managed":             llx.BoolDataPtr(aadP.Managed),
 						"enableAzureRBAC":     llx.BoolDataPtr(aadP.EnableAzureRBAC),
 						"adminGroupObjectIDs": llx.ArrayData(adminGroupObjectIDs, types.String),
@@ -228,7 +235,7 @@ func (a *mqlAzureSubscriptionAksService) clusters() ([]any, error) {
 				aup := entry.Properties.AutoUpgradeProfile
 				autoUpgradeRes, err := CreateResource(a.MqlRuntime, "azure.subscription.aksService.cluster.autoUpgradeProfile",
 					map[string]*llx.RawData{
-						"id":                   llx.StringData(*entry.ID + "/autoUpgradeProfile"),
+						"id":                   llx.StringData(convert.ToValue(entry.ID) + "/autoUpgradeProfile"),
 						"upgradeChannel":       llx.StringDataPtr((*string)(aup.UpgradeChannel)),
 						"nodeOSUpgradeChannel": llx.StringDataPtr((*string)(aup.NodeOSUpgradeChannel)),
 					})
@@ -247,7 +254,7 @@ func (a *mqlAzureSubscriptionAksService) clusters() ([]any, error) {
 					"provisioningState":              llx.StringDataPtr(entry.Properties.ProvisioningState),
 					"createdAt":                      llx.TimeDataPtr(createdAt),
 					"nodeResourceGroup":              llx.StringDataPtr(entry.Properties.NodeResourceGroup),
-					"powerState":                     llx.StringDataPtr((*string)(entry.Properties.PowerState.Code)),
+					"powerState":                     aksPowerState(entry),
 					"tags":                           llx.MapData(convert.PtrMapStrToInterface(entry.Tags), types.String),
 					"rbacEnabled":                    llx.BoolDataPtr(entry.Properties.EnableRBAC),
 					"dnsPrefix":                      llx.StringDataPtr(entry.Properties.DNSPrefix),

--- a/providers/azure/resources/cloud_defender.go
+++ b/providers/azure/resources/cloud_defender.go
@@ -456,8 +456,10 @@ func (a *mqlAzureSubscriptionCloudDefenderService) monitoringAgentAutoProvision(
 	if err != nil {
 		return false, err
 	}
-	autoProvision := *setting.Properties.AutoProvision
-	return autoProvision == security.AutoProvisionOn, nil
+	if setting.Properties == nil || setting.Properties.AutoProvision == nil {
+		return false, nil
+	}
+	return *setting.Properties.AutoProvision == security.AutoProvisionOn, nil
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) defenderForContainers() (any, error) {
@@ -522,19 +524,21 @@ func (a *mqlAzureSubscriptionCloudDefenderService) defenderForContainers() (any,
 	}
 
 	enabled := false
-	if containersPricing.Properties.PricingTier != nil {
+	if containersPricing.Properties != nil && containersPricing.Properties.PricingTier != nil {
 		enabled = *containersPricing.Properties.PricingTier == security.PricingTierStandard
 	}
 	extensions := []extension{}
-	for _, ext := range containersPricing.Properties.Extensions {
-		if ext.IsEnabled == nil || ext.Name == nil {
-			continue
+	if containersPricing.Properties != nil {
+		for _, ext := range containersPricing.Properties.Extensions {
+			if ext.IsEnabled == nil || ext.Name == nil {
+				continue
+			}
+			e := false
+			if *ext.IsEnabled == security.IsEnabledTrue {
+				e = true
+			}
+			extensions = append(extensions, extension{Name: *ext.Name, IsEnabled: e})
 		}
-		e := false
-		if *ext.IsEnabled == security.IsEnabledTrue {
-			e = true
-		}
-		extensions = append(extensions, extension{Name: *ext.Name, IsEnabled: e})
 	}
 
 	def := defenderForContainers{

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -526,9 +526,15 @@ func (a *mqlAzureSubscriptionComputeServiceVm) publicIpAddresses() ([]any, error
 			return nil, err
 		}
 
+		if networkInterface.Interface.Properties == nil {
+			continue
+		}
 		for _, config := range networkInterface.Interface.Properties.IPConfigurations {
+			if config.Properties == nil {
+				continue
+			}
 			ip := config.Properties.PublicIPAddress
-			if ip != nil {
+			if ip != nil && ip.ID != nil {
 				publicIPID := *ip.ID
 				publicIpResource, err := ParseResourceID(publicIPID)
 				if err != nil {

--- a/providers/azure/resources/iam.go
+++ b/providers/azure/resources/iam.go
@@ -71,28 +71,34 @@ func (a *mqlAzureSubscriptionAuthorizationService) roles() ([]any, error) {
 			return nil, err
 		}
 		for _, roleDef := range page.Value {
-			roleType := convert.ToValue(roleDef.Properties.RoleType)
+			var roleType string
 			scopes := []any{}
-			for _, s := range roleDef.Properties.AssignableScopes {
-				if s != nil {
-					scopes = append(scopes, *s)
-				}
-			}
 			permissions := []any{}
-			for idx, p := range roleDef.Properties.Permissions {
-				id := fmt.Sprintf("%s/azure.subscription.authorizationService.roleDefinition.permission/%d", *roleDef.ID, idx)
-				permission, err := newMqlRolePermission(a.MqlRuntime, id, p)
-				if err != nil {
-					return nil, err
+			var roleName, description *string
+			if roleDef.Properties != nil {
+				roleType = convert.ToValue(roleDef.Properties.RoleType)
+				roleName = roleDef.Properties.RoleName
+				description = roleDef.Properties.Description
+				for _, s := range roleDef.Properties.AssignableScopes {
+					if s != nil {
+						scopes = append(scopes, *s)
+					}
 				}
-				permissions = append(permissions, permission)
+				for idx, p := range roleDef.Properties.Permissions {
+					id := fmt.Sprintf("%s/azure.subscription.authorizationService.roleDefinition.permission/%d", convert.ToValue(roleDef.ID), idx)
+					permission, err := newMqlRolePermission(a.MqlRuntime, id, p)
+					if err != nil {
+						return nil, err
+					}
+					permissions = append(permissions, permission)
+				}
 			}
 			mqlRoleDefinition, err := CreateResource(a.MqlRuntime, "azure.subscription.authorizationService.roleDefinition",
 				map[string]*llx.RawData{
 					"__id":        llx.StringDataPtr(roleDef.ID),
 					"id":          llx.StringDataPtr(roleDef.ID),
-					"name":        llx.StringDataPtr(roleDef.Properties.RoleName),
-					"description": llx.StringDataPtr(roleDef.Properties.Description),
+					"name":        llx.StringDataPtr(roleName),
+					"description": llx.StringDataPtr(description),
 					"type":        llx.StringData(roleType),
 					"scopes":      llx.ArrayData(scopes, types.String),
 					"permissions": llx.ArrayData(permissions, types.ResourceLike),

--- a/providers/azure/resources/monitor.go
+++ b/providers/azure/resources/monitor.go
@@ -242,30 +242,34 @@ func (a *mqlAzureSubscriptionMonitorServiceActivityLog) alerts() ([]any, error) 
 			actions := []mqlAlertAction{}
 			conditions := []mqlAlertCondition{}
 
-			for _, act := range entry.Properties.Actions.ActionGroups {
-				mqlAction := mqlAlertAction{
-					ActionGroupId:     convert.ToValue(act.ActionGroupID),
-					WebhookProperties: convert.PtrMapStrToStr(act.WebhookProperties),
-				}
-				actions = append(actions, mqlAction)
-			}
-			for _, cond := range entry.Properties.Condition.AllOf {
-				anyOf := []mqlAlertLeafCondition{}
-				for _, leaf := range cond.AnyOf {
-					mqlAnyOfLeaf := mqlAlertLeafCondition{
-						FieldName:   convert.ToValue(leaf.Field),
-						Equals:      convert.ToValue(leaf.Equals),
-						ContainsAny: convert.SliceStrPtrToStr(leaf.ContainsAny),
+			if entry.Properties != nil && entry.Properties.Actions != nil {
+				for _, act := range entry.Properties.Actions.ActionGroups {
+					mqlAction := mqlAlertAction{
+						ActionGroupId:     convert.ToValue(act.ActionGroupID),
+						WebhookProperties: convert.PtrMapStrToStr(act.WebhookProperties),
 					}
-					anyOf = append(anyOf, mqlAnyOfLeaf)
+					actions = append(actions, mqlAction)
 				}
-				mqlCondition := mqlAlertCondition{
-					FieldName:   convert.ToValue(cond.Field),
-					Equals:      convert.ToValue(cond.Equals),
-					ContainsAny: convert.SliceStrPtrToStr(cond.ContainsAny),
-					AnyOf:       anyOf,
+			}
+			if entry.Properties != nil && entry.Properties.Condition != nil {
+				for _, cond := range entry.Properties.Condition.AllOf {
+					anyOf := []mqlAlertLeafCondition{}
+					for _, leaf := range cond.AnyOf {
+						mqlAnyOfLeaf := mqlAlertLeafCondition{
+							FieldName:   convert.ToValue(leaf.Field),
+							Equals:      convert.ToValue(leaf.Equals),
+							ContainsAny: convert.SliceStrPtrToStr(leaf.ContainsAny),
+						}
+						anyOf = append(anyOf, mqlAnyOfLeaf)
+					}
+					mqlCondition := mqlAlertCondition{
+						FieldName:   convert.ToValue(cond.Field),
+						Equals:      convert.ToValue(cond.Equals),
+						ContainsAny: convert.SliceStrPtrToStr(cond.ContainsAny),
+						AnyOf:       anyOf,
+					}
+					conditions = append(conditions, mqlCondition)
 				}
-				conditions = append(conditions, mqlCondition)
 			}
 
 			actionsDict := []any{}

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -297,43 +297,50 @@ func (a *mqlAzureSubscriptionNetworkServiceWatcher) flowLogs() ([]any, error) {
 			WorkspaceRegion     string `json:"workspaceRegion"`
 		}
 		for _, flowLog := range page.Value {
-			retentionPolicy := mqlRetentionPolicy{
-				Enabled:       convert.ToValue(flowLog.Properties.RetentionPolicy.Enabled),
-				RetentionDays: int(convert.ToValue(flowLog.Properties.RetentionPolicy.Days)),
+			retentionPolicy := mqlRetentionPolicy{}
+			if flowLog.Properties != nil && flowLog.Properties.RetentionPolicy != nil {
+				retentionPolicy.Enabled = convert.ToValue(flowLog.Properties.RetentionPolicy.Enabled)
+				retentionPolicy.RetentionDays = int(convert.ToValue(flowLog.Properties.RetentionPolicy.Days))
 			}
 			retentionPolicyDict, err := convert.JsonToDict(retentionPolicy)
 			if err != nil {
 				return nil, err
 			}
-			flowLogAnalytics := mqlFlowLogAnalytics{
-				Enabled:             convert.ToValue(flowLog.Properties.FlowAnalyticsConfiguration.NetworkWatcherFlowAnalyticsConfiguration.Enabled),
-				AnalyticsInterval:   int(convert.ToValue(flowLog.Properties.FlowAnalyticsConfiguration.NetworkWatcherFlowAnalyticsConfiguration.TrafficAnalyticsInterval)),
-				WorkspaceRegion:     convert.ToValue(flowLog.Properties.FlowAnalyticsConfiguration.NetworkWatcherFlowAnalyticsConfiguration.WorkspaceRegion),
-				WorkspaceResourceId: convert.ToValue(flowLog.Properties.FlowAnalyticsConfiguration.NetworkWatcherFlowAnalyticsConfiguration.WorkspaceResourceID),
-				WorkspaceId:         convert.ToValue(flowLog.Properties.FlowAnalyticsConfiguration.NetworkWatcherFlowAnalyticsConfiguration.WorkspaceID),
+			flowLogAnalytics := mqlFlowLogAnalytics{}
+			if flowLog.Properties != nil && flowLog.Properties.FlowAnalyticsConfiguration != nil && flowLog.Properties.FlowAnalyticsConfiguration.NetworkWatcherFlowAnalyticsConfiguration != nil {
+				nwfac := flowLog.Properties.FlowAnalyticsConfiguration.NetworkWatcherFlowAnalyticsConfiguration
+				flowLogAnalytics.Enabled = convert.ToValue(nwfac.Enabled)
+				flowLogAnalytics.AnalyticsInterval = int(convert.ToValue(nwfac.TrafficAnalyticsInterval))
+				flowLogAnalytics.WorkspaceRegion = convert.ToValue(nwfac.WorkspaceRegion)
+				flowLogAnalytics.WorkspaceResourceId = convert.ToValue(nwfac.WorkspaceResourceID)
+				flowLogAnalytics.WorkspaceId = convert.ToValue(nwfac.WorkspaceID)
 			}
 			flowLogAnalyticsDict, err := convert.JsonToDict(flowLogAnalytics)
 			if err != nil {
 				return nil, err
 			}
-			mqlFlowLog, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.watcher.flowlog",
-				map[string]*llx.RawData{
-					"id":                 llx.StringDataPtr(flowLog.ID),
-					"name":               llx.StringDataPtr(flowLog.Name),
-					"location":           llx.StringDataPtr(flowLog.Location),
-					"tags":               llx.MapData(convert.PtrMapStrToInterface(flowLog.Tags), types.String),
-					"type":               llx.StringDataPtr(flowLog.Type),
-					"etag":               llx.StringDataPtr(flowLog.Etag),
-					"retentionPolicy":    llx.DictData(retentionPolicyDict),
-					"format":             llx.StringDataPtr((*string)(flowLog.Properties.Format.Type)),
-					"version":            llx.IntDataDefault(flowLog.Properties.Format.Version, 0),
-					"enabled":            llx.BoolDataPtr(flowLog.Properties.Enabled),
-					"storageAccountId":   llx.StringDataPtr(flowLog.Properties.StorageID),
-					"targetResourceId":   llx.StringDataPtr(flowLog.Properties.TargetResourceID),
-					"targetResourceGuid": llx.StringDataPtr(flowLog.Properties.TargetResourceGUID),
-					"provisioningState":  llx.StringDataPtr((*string)(flowLog.Properties.ProvisioningState)),
-					"analytics":          llx.DictData(flowLogAnalyticsDict),
-				})
+			args := map[string]*llx.RawData{
+				"id":              llx.StringDataPtr(flowLog.ID),
+				"name":            llx.StringDataPtr(flowLog.Name),
+				"location":        llx.StringDataPtr(flowLog.Location),
+				"tags":            llx.MapData(convert.PtrMapStrToInterface(flowLog.Tags), types.String),
+				"type":            llx.StringDataPtr(flowLog.Type),
+				"etag":            llx.StringDataPtr(flowLog.Etag),
+				"retentionPolicy": llx.DictData(retentionPolicyDict),
+				"analytics":       llx.DictData(flowLogAnalyticsDict),
+			}
+			if flowLog.Properties != nil {
+				args["enabled"] = llx.BoolDataPtr(flowLog.Properties.Enabled)
+				args["storageAccountId"] = llx.StringDataPtr(flowLog.Properties.StorageID)
+				args["targetResourceId"] = llx.StringDataPtr(flowLog.Properties.TargetResourceID)
+				args["targetResourceGuid"] = llx.StringDataPtr(flowLog.Properties.TargetResourceGUID)
+				args["provisioningState"] = llx.StringDataPtr((*string)(flowLog.Properties.ProvisioningState))
+				if flowLog.Properties.Format != nil {
+					args["format"] = llx.StringDataPtr((*string)(flowLog.Properties.Format.Type))
+					args["version"] = llx.IntDataDefault(flowLog.Properties.Format.Version, 0)
+				}
+			}
+			mqlFlowLog, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.watcher.flowlog", args)
 			if err != nil {
 				return nil, err
 			}
@@ -1087,30 +1094,34 @@ func (a *mqlAzureSubscriptionNetworkService) virtualNetworkGateways() ([]any, er
 					return nil, err
 				}
 				bgpPeeringAddresses := []any{}
-				bgpSettingsId := *vng.ID + "/bgpSettings"
-				for i, bpa := range vng.Properties.BgpSettings.BgpPeeringAddresses {
-					bpaId := fmt.Sprintf("%s/%s/%d", bgpSettingsId, "bgpPeeringAddresses", i)
-					mqlBpa, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.bgpSettings.ipConfigurationBgpPeeringAddress",
-						map[string]*llx.RawData{
-							"id":                    llx.StringData(bpaId),
-							"customBgpIpAddresses":  llx.ArrayData(convert.SliceStrPtrToInterface(bpa.CustomBgpIPAddresses), types.String),
-							"defaultBgpIpAddresses": llx.ArrayData(convert.SliceStrPtrToInterface(bpa.DefaultBgpIPAddresses), types.String),
-							"tunnelIpAddresses":     llx.ArrayData(convert.SliceStrPtrToInterface(bpa.TunnelIPAddresses), types.String),
-							"ipConfigurationId":     llx.StringDataPtr(bpa.IPConfigurationID),
-						})
-					if err != nil {
-						return nil, err
+				bgpSettingsId := convert.ToValue(vng.ID) + "/bgpSettings"
+				if vng.Properties != nil && vng.Properties.BgpSettings != nil {
+					for i, bpa := range vng.Properties.BgpSettings.BgpPeeringAddresses {
+						bpaId := fmt.Sprintf("%s/%s/%d", bgpSettingsId, "bgpPeeringAddresses", i)
+						mqlBpa, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.bgpSettings.ipConfigurationBgpPeeringAddress",
+							map[string]*llx.RawData{
+								"id":                    llx.StringData(bpaId),
+								"customBgpIpAddresses":  llx.ArrayData(convert.SliceStrPtrToInterface(bpa.CustomBgpIPAddresses), types.String),
+								"defaultBgpIpAddresses": llx.ArrayData(convert.SliceStrPtrToInterface(bpa.DefaultBgpIPAddresses), types.String),
+								"tunnelIpAddresses":     llx.ArrayData(convert.SliceStrPtrToInterface(bpa.TunnelIPAddresses), types.String),
+								"ipConfigurationId":     llx.StringDataPtr(bpa.IPConfigurationID),
+							})
+						if err != nil {
+							return nil, err
+						}
+						bgpPeeringAddresses = append(bgpPeeringAddresses, mqlBpa)
 					}
-					bgpPeeringAddresses = append(bgpPeeringAddresses, mqlBpa)
 				}
-				bgpSettings, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.bgpSettings",
-					map[string]*llx.RawData{
-						"id":                        llx.StringData(bgpSettingsId),
-						"asn":                       llx.IntDataPtr(vng.Properties.BgpSettings.Asn),
-						"bgpPeeringAddress":         llx.StringDataPtr(vng.Properties.BgpSettings.BgpPeeringAddress),
-						"peerWeight":                llx.IntDataDefault(vng.Properties.BgpSettings.PeerWeight, 0),
-						"bgpPeeringAddressesConfig": llx.ArrayData(bgpPeeringAddresses, types.ResourceLike),
-					})
+				bgpSettingsArgs := map[string]*llx.RawData{
+					"id":                        llx.StringData(bgpSettingsId),
+					"bgpPeeringAddressesConfig": llx.ArrayData(bgpPeeringAddresses, types.ResourceLike),
+				}
+				if vng.Properties != nil && vng.Properties.BgpSettings != nil {
+					bgpSettingsArgs["asn"] = llx.IntDataPtr(vng.Properties.BgpSettings.Asn)
+					bgpSettingsArgs["bgpPeeringAddress"] = llx.StringDataPtr(vng.Properties.BgpSettings.BgpPeeringAddress)
+					bgpSettingsArgs["peerWeight"] = llx.IntDataDefault(vng.Properties.BgpSettings.PeerWeight, 0)
+				}
+				bgpSettings, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.bgpSettings", bgpSettingsArgs)
 				if err != nil {
 					return nil, err
 				}
@@ -1144,7 +1155,7 @@ func (a *mqlAzureSubscriptionNetworkService) virtualNetworkGateways() ([]any, er
 						"name":             llx.StringDataPtr(ipc.Name),
 						"etag":             llx.StringDataPtr(ipc.Etag),
 						"properties":       llx.DictData(props),
-						"privateIpAddress": llx.StringDataPtr(ipc.Properties.PrivateIPAddress),
+						"privateIpAddress": ipcPrivateIP(ipc.Properties),
 					})
 					if err != nil {
 						return nil, err
@@ -1152,36 +1163,40 @@ func (a *mqlAzureSubscriptionNetworkService) virtualNetworkGateways() ([]any, er
 					ipConfigs = append(ipConfigs, mqlIpc)
 				}
 				args := map[string]*llx.RawData{
-					"id":                              llx.StringDataPtr(vng.ID),
-					"name":                            llx.StringDataPtr(vng.Name),
-					"type":                            llx.StringDataPtr(vng.Type),
-					"location":                        llx.StringDataPtr(vng.Location),
-					"tags":                            llx.MapData(convert.PtrMapStrToInterface(vng.Tags), types.String),
-					"etag":                            llx.StringDataPtr(vng.Etag),
-					"active":                          llx.BoolDataPtr(vng.Properties.Active),
-					"enableBgp":                       llx.BoolDataPtr(vng.Properties.EnableBgp),
-					"enableBgpRouteTranslationForNat": llx.BoolDataPtr(vng.Properties.EnableBgpRouteTranslationForNat),
-					"enableDNSForwarding":             llx.BoolDataPtr(vng.Properties.EnableDNSForwarding),
-					"enablePrivateIPAddress":          llx.BoolDataPtr(vng.Properties.EnablePrivateIPAddress),
-					"disableIPSecReplayProtection":    llx.BoolDataPtr(vng.Properties.DisableIPSecReplayProtection),
-					"inboundDNSForwardingEndpoint":    llx.StringDataPtr(vng.Properties.InboundDNSForwardingEndpoint),
-					"skuName":                         llx.StringDataPtr((*string)(vng.Properties.SKU.Name)),
-					"skuCapacity":                     llx.IntDataDefault(vng.Properties.SKU.Capacity, 0),
-					"provisioningState":               llx.StringDataPtr((*string)(vng.Properties.ProvisioningState)),
-					"properties":                      llx.DictData(props),
-					"vpnType":                         llx.StringDataPtr((*string)(vng.Properties.VPNType)),
-					"vpnGatewayGeneration":            llx.StringDataPtr((*string)(vng.Properties.VPNGatewayGeneration)),
-					"bgpSettings":                     llx.ResourceData(bgpSettings, "bgpSettings"),
-					"ipConfigurations":                llx.ArrayData(ipConfigs, types.ResourceLike),
-					"gatewayType":                     llx.StringDataPtr((*string)(vng.Properties.GatewayType)),
-					"natRules":                        llx.ArrayData(natRules, types.ResourceLike),
+					"id":               llx.StringDataPtr(vng.ID),
+					"name":             llx.StringDataPtr(vng.Name),
+					"type":             llx.StringDataPtr(vng.Type),
+					"location":         llx.StringDataPtr(vng.Location),
+					"tags":             llx.MapData(convert.PtrMapStrToInterface(vng.Tags), types.String),
+					"etag":             llx.StringDataPtr(vng.Etag),
+					"properties":       llx.DictData(props),
+					"bgpSettings":      llx.ResourceData(bgpSettings, "bgpSettings"),
+					"ipConfigurations": llx.ArrayData(ipConfigs, types.ResourceLike),
+					"natRules":         llx.ArrayData(natRules, types.ResourceLike),
 				}
-				if vng.Properties.CustomRoutes != nil {
+				if vng.Properties != nil {
+					args["active"] = llx.BoolDataPtr(vng.Properties.Active)
+					args["enableBgp"] = llx.BoolDataPtr(vng.Properties.EnableBgp)
+					args["enableBgpRouteTranslationForNat"] = llx.BoolDataPtr(vng.Properties.EnableBgpRouteTranslationForNat)
+					args["enableDNSForwarding"] = llx.BoolDataPtr(vng.Properties.EnableDNSForwarding)
+					args["enablePrivateIPAddress"] = llx.BoolDataPtr(vng.Properties.EnablePrivateIPAddress)
+					args["disableIPSecReplayProtection"] = llx.BoolDataPtr(vng.Properties.DisableIPSecReplayProtection)
+					args["inboundDNSForwardingEndpoint"] = llx.StringDataPtr(vng.Properties.InboundDNSForwardingEndpoint)
+					args["provisioningState"] = llx.StringDataPtr((*string)(vng.Properties.ProvisioningState))
+					args["vpnType"] = llx.StringDataPtr((*string)(vng.Properties.VPNType))
+					args["vpnGatewayGeneration"] = llx.StringDataPtr((*string)(vng.Properties.VPNGatewayGeneration))
+					args["gatewayType"] = llx.StringDataPtr((*string)(vng.Properties.GatewayType))
+					if vng.Properties.SKU != nil {
+						args["skuName"] = llx.StringDataPtr((*string)(vng.Properties.SKU.Name))
+						args["skuCapacity"] = llx.IntDataDefault(vng.Properties.SKU.Capacity, 0)
+					}
+				}
+				if vng.Properties != nil && vng.Properties.CustomRoutes != nil {
 					args["addressPrefixes"] = llx.ArrayData(convert.SliceStrPtrToInterface(vng.Properties.CustomRoutes.AddressPrefixes), types.String)
 				} else {
 					args["addressPrefixes"] = llx.ArrayData([]any{}, types.String)
 				}
-				if vng.Properties.VPNClientConfiguration != nil {
+				if vng.Properties != nil && vng.Properties.VPNClientConfiguration != nil {
 					vpnClientDict, err := convert.JsonToDict(vng.Properties.VPNClientConfiguration)
 					if err != nil {
 						return nil, err
@@ -2160,6 +2175,13 @@ func azureAppGatewayToMql(runtime *plugin.Runtime, ag network.ApplicationGateway
 	return mqlAg.(*mqlAzureSubscriptionNetworkServiceApplicationGateway), nil
 }
 
+func ipcPrivateIP(props *network.VirtualNetworkGatewayIPConfigurationPropertiesFormat) *llx.RawData {
+	if props != nil {
+		return llx.StringDataPtr(props.PrivateIPAddress)
+	}
+	return llx.NilData
+}
+
 func azureFirewallToMql(runtime *plugin.Runtime, fw network.AzureFirewall) (*mqlAzureSubscriptionNetworkServiceFirewall, error) {
 	applicationRules := []any{}
 	natRules := []any{}
@@ -2169,74 +2191,82 @@ func azureFirewallToMql(runtime *plugin.Runtime, fw network.AzureFirewall) (*mql
 	if err != nil {
 		return nil, err
 	}
-	for _, ipConfig := range fw.Properties.IPConfigurations {
-		props, err := convert.JsonToDict(ipConfig.Properties)
-		if err != nil {
-			return nil, err
+	if fw.Properties != nil {
+		for _, ipConfig := range fw.Properties.IPConfigurations {
+			ipProps, err := convert.JsonToDict(ipConfig.Properties)
+			if err != nil {
+				return nil, err
+			}
+			var privateIP *llx.RawData = llx.NilData
+			if ipConfig.Properties != nil {
+				privateIP = llx.StringDataPtr(ipConfig.Properties.PrivateIPAddress)
+			}
+			mqlIpConfig, err := CreateResource(runtime, "azure.subscription.networkService.firewall.ipConfig",
+				map[string]*llx.RawData{
+					"id":               llx.StringDataPtr(ipConfig.ID),
+					"name":             llx.StringDataPtr(ipConfig.Name),
+					"etag":             llx.StringDataPtr(ipConfig.Etag),
+					"privateIpAddress": privateIP,
+					"properties":       llx.DictData(ipProps),
+				})
+			if err != nil {
+				return nil, err
+			}
+			ipConfigs = append(ipConfigs, mqlIpConfig)
 		}
-		mqlIpConfig, err := CreateResource(runtime, "azure.subscription.networkService.firewall.ipConfig",
-			map[string]*llx.RawData{
-				"id":               llx.StringDataPtr(ipConfig.ID),
-				"name":             llx.StringDataPtr(ipConfig.Name),
-				"etag":             llx.StringDataPtr(ipConfig.Etag),
-				"privateIpAddress": llx.StringDataPtr(ipConfig.Properties.PrivateIPAddress),
-				"properties":       llx.DictData(props),
-			})
-		if err != nil {
-			return nil, err
-		}
-		ipConfigs = append(ipConfigs, mqlIpConfig)
 	}
-	for _, natRule := range fw.Properties.NatRuleCollections {
-		props, err := convert.JsonToDict(natRule.Properties)
-		if err != nil {
-			return nil, err
+	if fw.Properties != nil {
+		for _, natRule := range fw.Properties.NatRuleCollections {
+			props, err := convert.JsonToDict(natRule.Properties)
+			if err != nil {
+				return nil, err
+			}
+			mqlNatRule, err := CreateResource(runtime, "azure.subscription.networkService.firewall.natRule",
+				map[string]*llx.RawData{
+					"id":         llx.StringDataPtr(natRule.ID),
+					"name":       llx.StringDataPtr(natRule.Name),
+					"etag":       llx.StringDataPtr(natRule.Etag),
+					"properties": llx.DictData(props),
+				})
+			if err != nil {
+				return nil, err
+			}
+			natRules = append(natRules, mqlNatRule)
 		}
-		mqlNatRule, err := CreateResource(runtime, "azure.subscription.networkService.firewall.natRule",
-			map[string]*llx.RawData{
-				"id":         llx.StringDataPtr(natRule.ID),
-				"name":       llx.StringDataPtr(natRule.Name),
-				"etag":       llx.StringDataPtr(natRule.Etag),
-				"properties": llx.DictData(props),
-			})
-		if err != nil {
-			return nil, err
+		for _, networkRule := range fw.Properties.NetworkRuleCollections {
+			props, err := convert.JsonToDict(networkRule.Properties)
+			if err != nil {
+				return nil, err
+			}
+			mqlNetworkRule, err := CreateResource(runtime, "azure.subscription.networkService.firewall.networkRule",
+				map[string]*llx.RawData{
+					"id":         llx.StringDataPtr(networkRule.ID),
+					"name":       llx.StringDataPtr(networkRule.Name),
+					"etag":       llx.StringDataPtr(networkRule.Etag),
+					"properties": llx.DictData(props),
+				})
+			if err != nil {
+				return nil, err
+			}
+			networkRules = append(networkRules, mqlNetworkRule)
 		}
-		natRules = append(natRules, mqlNatRule)
-	}
-	for _, networkRule := range fw.Properties.NetworkRuleCollections {
-		props, err := convert.JsonToDict(networkRule.Properties)
-		if err != nil {
-			return nil, err
+		for _, appRule := range fw.Properties.ApplicationRuleCollections {
+			props, err := convert.JsonToDict(appRule.Properties)
+			if err != nil {
+				return nil, err
+			}
+			mqlAppRule, err := CreateResource(runtime, "azure.subscription.networkService.firewall.applicationRule",
+				map[string]*llx.RawData{
+					"id":         llx.StringDataPtr(appRule.ID),
+					"name":       llx.StringDataPtr(appRule.Name),
+					"etag":       llx.StringDataPtr(appRule.Etag),
+					"properties": llx.DictData(props),
+				})
+			if err != nil {
+				return nil, err
+			}
+			applicationRules = append(applicationRules, mqlAppRule)
 		}
-		mqlNetworkRule, err := CreateResource(runtime, "azure.subscription.networkService.firewall.networkRule",
-			map[string]*llx.RawData{
-				"id":         llx.StringDataPtr(networkRule.ID),
-				"name":       llx.StringDataPtr(networkRule.Name),
-				"etag":       llx.StringDataPtr(networkRule.Etag),
-				"properties": llx.DictData(props),
-			})
-		if err != nil {
-			return nil, err
-		}
-		networkRules = append(networkRules, mqlNetworkRule)
-	}
-	for _, appRule := range fw.Properties.ApplicationRuleCollections {
-		props, err := convert.JsonToDict(appRule.Properties)
-		if err != nil {
-			return nil, err
-		}
-		mqlAppRule, err := CreateResource(runtime, "azure.subscription.networkService.firewall.applicationRule",
-			map[string]*llx.RawData{
-				"id":         llx.StringDataPtr(appRule.ID),
-				"name":       llx.StringDataPtr(appRule.Name),
-				"etag":       llx.StringDataPtr(appRule.Etag),
-				"properties": llx.DictData(props),
-			})
-		if err != nil {
-			return nil, err
-		}
-		applicationRules = append(applicationRules, mqlAppRule)
 	}
 	args := map[string]*llx.RawData{
 		"id":                llx.StringDataPtr(fw.ID),

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -2269,40 +2269,50 @@ func azureFirewallToMql(runtime *plugin.Runtime, fw network.AzureFirewall) (*mql
 		}
 	}
 	args := map[string]*llx.RawData{
-		"id":                llx.StringDataPtr(fw.ID),
-		"name":              llx.StringDataPtr(fw.Name),
-		"type":              llx.StringDataPtr(fw.Type),
-		"location":          llx.StringDataPtr(fw.Location),
-		"tags":              llx.MapData(convert.PtrMapStrToInterface(fw.Tags), types.String),
-		"etag":              llx.StringDataPtr(fw.Etag),
-		"properties":        llx.DictData(props),
-		"skuTier":           llx.StringDataPtr((*string)(fw.Properties.SKU.Tier)),
-		"skuName":           llx.StringDataPtr((*string)(fw.Properties.SKU.Name)),
-		"provisioningState": llx.StringDataPtr((*string)(fw.Properties.ProvisioningState)),
-		"threatIntelMode":   llx.StringDataPtr((*string)(fw.Properties.ThreatIntelMode)),
-		"natRules":          llx.ArrayData(natRules, types.ResourceLike),
-		"applicationRules":  llx.ArrayData(applicationRules, types.ResourceLike),
-		"networkRules":      llx.ArrayData(networkRules, types.ResourceLike),
-		"ipConfigurations":  llx.ArrayData(ipConfigs, types.ResourceLike),
+		"id":               llx.StringDataPtr(fw.ID),
+		"name":             llx.StringDataPtr(fw.Name),
+		"type":             llx.StringDataPtr(fw.Type),
+		"location":         llx.StringDataPtr(fw.Location),
+		"tags":             llx.MapData(convert.PtrMapStrToInterface(fw.Tags), types.String),
+		"etag":             llx.StringDataPtr(fw.Etag),
+		"properties":       llx.DictData(props),
+		"natRules":         llx.ArrayData(natRules, types.ResourceLike),
+		"applicationRules": llx.ArrayData(applicationRules, types.ResourceLike),
+		"networkRules":     llx.ArrayData(networkRules, types.ResourceLike),
+		"ipConfigurations": llx.ArrayData(ipConfigs, types.ResourceLike),
 	}
-	if fw.Properties.ManagementIPConfiguration != nil {
-		ipConfig := fw.Properties.ManagementIPConfiguration
-		props, err := convert.JsonToDict(ipConfig.Properties)
-		if err != nil {
-			return nil, err
+	if fw.Properties != nil {
+		args["provisioningState"] = llx.StringDataPtr((*string)(fw.Properties.ProvisioningState))
+		args["threatIntelMode"] = llx.StringDataPtr((*string)(fw.Properties.ThreatIntelMode))
+		if fw.Properties.SKU != nil {
+			args["skuTier"] = llx.StringDataPtr((*string)(fw.Properties.SKU.Tier))
+			args["skuName"] = llx.StringDataPtr((*string)(fw.Properties.SKU.Name))
 		}
-		mqlIpConfig, err := CreateResource(runtime, "azure.subscription.networkService.firewall.ipConfig",
-			map[string]*llx.RawData{
-				"id":               llx.StringDataPtr(ipConfig.ID),
-				"name":             llx.StringDataPtr(ipConfig.Name),
-				"etag":             llx.StringDataPtr(ipConfig.Etag),
-				"privateIpAddress": llx.StringDataPtr(ipConfig.Properties.PrivateIPAddress),
-				"properties":       llx.DictData(props),
-			})
-		if err != nil {
-			return nil, err
+		if fw.Properties.ManagementIPConfiguration != nil {
+			ipConfig := fw.Properties.ManagementIPConfiguration
+			mgmtProps, err := convert.JsonToDict(ipConfig.Properties)
+			if err != nil {
+				return nil, err
+			}
+			var privateIP *llx.RawData = llx.NilData
+			if ipConfig.Properties != nil {
+				privateIP = llx.StringDataPtr(ipConfig.Properties.PrivateIPAddress)
+			}
+			mqlIpConfig, err := CreateResource(runtime, "azure.subscription.networkService.firewall.ipConfig",
+				map[string]*llx.RawData{
+					"id":               llx.StringDataPtr(ipConfig.ID),
+					"name":             llx.StringDataPtr(ipConfig.Name),
+					"etag":             llx.StringDataPtr(ipConfig.Etag),
+					"privateIpAddress": privateIP,
+					"properties":       llx.DictData(mgmtProps),
+				})
+			if err != nil {
+				return nil, err
+			}
+			args["managementIpConfiguration"] = llx.ResourceData(mqlIpConfig, "managementIpConfiguration")
+		} else {
+			args["managementIpConfiguration"] = llx.NilData
 		}
-		args["managementIpConfiguration"] = llx.ResourceData(mqlIpConfig, "managementIpConfiguration")
 	} else {
 		args["managementIpConfiguration"] = llx.NilData
 	}

--- a/providers/azure/resources/sql.go
+++ b/providers/azure/resources/sql.go
@@ -160,29 +160,33 @@ func (a *mqlAzureSubscriptionSqlServiceServer) databases() ([]any, error) {
 		}
 		for _, entry := range page.Value {
 			args := map[string]*llx.RawData{
-				"id":               llx.StringDataPtr(entry.ID),
-				"name":             llx.StringDataPtr(entry.Name),
-				"type":             llx.StringDataPtr(entry.Type),
-				"collation":        llx.StringDataPtr(entry.Properties.Collation),
-				"creationDate":     llx.TimeDataPtr(entry.Properties.CreationDate),
-				"databaseId":       llx.StringDataPtr(entry.Properties.DatabaseID),
-				"createMode":       llx.StringDataPtr((*string)(entry.Properties.CreateMode)),
-				"sourceDatabaseId": llx.StringDataPtr(entry.Properties.SourceDatabaseID),
-				"recoveryServicesRecoveryPointResourceId": llx.StringDataPtr(entry.Properties.RecoveryServicesRecoveryPointID),
-				"edition":                       llx.StringDataPtr(entry.SKU.Tier),
-				"maxSizeBytes":                  llx.IntDataDefault(entry.Properties.MaxSizeBytes, 0),
-				"requestedServiceObjectiveName": llx.StringDataPtr(entry.Properties.RequestedServiceObjectiveName),
-				"serviceLevelObjective":         llx.StringDataPtr(entry.Properties.CurrentServiceObjectiveName),
-				"status":                        llx.StringDataPtr((*string)(entry.Properties.Status)),
-				"elasticPoolName":               llx.StringDataPtr(entry.Properties.ElasticPoolID),
-				"defaultSecondaryLocation":      llx.StringDataPtr(entry.Properties.DefaultSecondaryLocation),
-				"failoverGroupId":               llx.StringDataPtr(entry.Properties.FailoverGroupID),
-				"readScale":                     llx.StringDataPtr((*string)(entry.Properties.ReadScale)),
-				"sampleName":                    llx.StringDataPtr((*string)(entry.Properties.SampleName)),
-				"zoneRedundant":                 llx.BoolDataPtr(entry.Properties.ZoneRedundant),
-				"earliestRestoreDate":           llx.TimeDataPtr(entry.Properties.EarliestRestoreDate),
-				"sourceDatabaseDeletionDate":    llx.TimeDataPtr(entry.Properties.SourceDatabaseDeletionDate),
-				"restorePointInTime":            llx.TimeDataPtr(entry.Properties.RestorePointInTime),
+				"id":   llx.StringDataPtr(entry.ID),
+				"name": llx.StringDataPtr(entry.Name),
+				"type": llx.StringDataPtr(entry.Type),
+			}
+			if entry.SKU != nil {
+				args["edition"] = llx.StringDataPtr(entry.SKU.Tier)
+			}
+			if entry.Properties != nil {
+				args["collation"] = llx.StringDataPtr(entry.Properties.Collation)
+				args["creationDate"] = llx.TimeDataPtr(entry.Properties.CreationDate)
+				args["databaseId"] = llx.StringDataPtr(entry.Properties.DatabaseID)
+				args["createMode"] = llx.StringDataPtr((*string)(entry.Properties.CreateMode))
+				args["sourceDatabaseId"] = llx.StringDataPtr(entry.Properties.SourceDatabaseID)
+				args["recoveryServicesRecoveryPointResourceId"] = llx.StringDataPtr(entry.Properties.RecoveryServicesRecoveryPointID)
+				args["maxSizeBytes"] = llx.IntDataDefault(entry.Properties.MaxSizeBytes, 0)
+				args["requestedServiceObjectiveName"] = llx.StringDataPtr(entry.Properties.RequestedServiceObjectiveName)
+				args["serviceLevelObjective"] = llx.StringDataPtr(entry.Properties.CurrentServiceObjectiveName)
+				args["status"] = llx.StringDataPtr((*string)(entry.Properties.Status))
+				args["elasticPoolName"] = llx.StringDataPtr(entry.Properties.ElasticPoolID)
+				args["defaultSecondaryLocation"] = llx.StringDataPtr(entry.Properties.DefaultSecondaryLocation)
+				args["failoverGroupId"] = llx.StringDataPtr(entry.Properties.FailoverGroupID)
+				args["readScale"] = llx.StringDataPtr((*string)(entry.Properties.ReadScale))
+				args["sampleName"] = llx.StringDataPtr((*string)(entry.Properties.SampleName))
+				args["zoneRedundant"] = llx.BoolDataPtr(entry.Properties.ZoneRedundant)
+				args["earliestRestoreDate"] = llx.TimeDataPtr(entry.Properties.EarliestRestoreDate)
+				args["sourceDatabaseDeletionDate"] = llx.TimeDataPtr(entry.Properties.SourceDatabaseDeletionDate)
+				args["restorePointInTime"] = llx.TimeDataPtr(entry.Properties.RestorePointInTime)
 			}
 
 			mqlAzureDatabase, err := CreateResource(a.MqlRuntime, "azure.subscription.sqlService.database", args)
@@ -510,18 +514,22 @@ func (a *mqlAzureSubscriptionSqlServiceServer) vulnerabilityAssessmentSettings()
 	if err != nil {
 		return nil, err
 	}
-	res, err := CreateResource(a.MqlRuntime, "azure.subscription.sqlService.server.vulnerabilityassessmentsettings",
-		map[string]*llx.RawData{
-			"id":                      llx.StringDataPtr(vaSettings.ID),
-			"name":                    llx.StringDataPtr(vaSettings.Name),
-			"type":                    llx.StringDataPtr(vaSettings.Type),
-			"storageContainerPath":    llx.StringDataPtr(vaSettings.Properties.StorageContainerPath),
-			"storageAccountAccessKey": llx.StringDataPtr(vaSettings.Properties.StorageAccountAccessKey),
-			"storageContainerSasKey":  llx.StringDataPtr(vaSettings.Properties.StorageContainerSasKey),
-			"recurringScanEnabled":    llx.BoolDataPtr(vaSettings.Properties.RecurringScans.IsEnabled),
-			"recurringScanEmails":     llx.ArrayData(llx.TArr2Raw(convert.ToListFromPtrs(vaSettings.Properties.RecurringScans.Emails)), types.String),
-			"mailSubscriptionAdmins":  llx.BoolDataPtr(vaSettings.Properties.RecurringScans.EmailSubscriptionAdmins),
-		})
+	args := map[string]*llx.RawData{
+		"id":   llx.StringDataPtr(vaSettings.ID),
+		"name": llx.StringDataPtr(vaSettings.Name),
+		"type": llx.StringDataPtr(vaSettings.Type),
+	}
+	if vaSettings.Properties != nil {
+		args["storageContainerPath"] = llx.StringDataPtr(vaSettings.Properties.StorageContainerPath)
+		args["storageAccountAccessKey"] = llx.StringDataPtr(vaSettings.Properties.StorageAccountAccessKey)
+		args["storageContainerSasKey"] = llx.StringDataPtr(vaSettings.Properties.StorageContainerSasKey)
+		if vaSettings.Properties.RecurringScans != nil {
+			args["recurringScanEnabled"] = llx.BoolDataPtr(vaSettings.Properties.RecurringScans.IsEnabled)
+			args["recurringScanEmails"] = llx.ArrayData(llx.TArr2Raw(convert.ToListFromPtrs(vaSettings.Properties.RecurringScans.Emails)), types.String)
+			args["mailSubscriptionAdmins"] = llx.BoolDataPtr(vaSettings.Properties.RecurringScans.EmailSubscriptionAdmins)
+		}
+	}
+	res, err := CreateResource(a.MqlRuntime, "azure.subscription.sqlService.server.vulnerabilityassessmentsettings", args)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Add nil checks for Azure SDK pointer-typed `Properties` fields across 8 resource files to prevent panics when API responses contain nil values
- Guards added for nested pointer chains like `entry.Properties.PowerState.Code`, `vng.Properties.BgpSettings.BgpPeeringAddresses`, `flowLog.Properties.RetentionPolicy`, etc.
- Fixes crash points in: advisor, AKS, cloud defender, compute, IAM, monitor, network (flow logs, VPN gateways, firewalls), and SQL resources

## Test plan
- [ ] `go build ./...` passes in `providers/azure/` (verified locally)
- [ ] `go vet ./...` passes in `providers/azure/` (verified locally)
- [ ] Run `mql shell azure` and query affected resources: `azure.subscription.advisor.recommendations`, `azure.subscription.aksService.clusters`, `azure.subscription.cloudDefender.monitoringAgentAutoProvision`, `azure.subscription.networkService.virtualNetworkGateways`, `azure.subscription.networkService.watchers { flowLogs }`, `azure.subscription.sqlService.databases`
- [ ] Verify no regressions in existing Azure provider tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)