### PR TITLE
⚡ Parallelize AWS discovery targets

### DIFF
--- a/providers/aws/resources/discovery.go
+++ b/providers/aws/resources/discovery.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"slices"
+	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/rs/zerolog/log"
@@ -14,6 +15,11 @@ import (
 	"go.mondoo.com/mql/v13/providers/aws/connection"
 	"go.mondoo.com/mql/v13/utils/stringx"
 )
+
+// discoveryConcurrency is the number of discovery targets to process concurrently.
+// Each target internally uses a 5-worker job pool for per-region API calls,
+// so the total concurrent API calls is at most discoveryConcurrency * 5.
+const discoveryConcurrency = 5
 
 // Discovery Flags
 const (
@@ -123,14 +129,34 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 	awsAccount := res.(*mqlAwsAccount)
 
 	targets := getDiscoveryTargets(conn.Conf)
+
+	var (
+		wg     sync.WaitGroup
+		mu     sync.Mutex
+		assets = make([]*inventory.Asset, 0)
+	)
+	sem := make(chan struct{}, discoveryConcurrency)
+
 	for _, target := range targets {
-		list, err := discover(runtime, awsAccount, target, conn.Filters)
-		if err != nil {
-			log.Error().Err(err).Msg("error during discovery")
-			continue
-		}
-		in.Spec.Assets = append(in.Spec.Assets, list...)
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(t string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			list, err := discover(runtime, awsAccount, t, conn.Filters)
+			if err != nil {
+				log.Error().Err(err).Str("target", t).Msg("error during discovery")
+				return
+			}
+			mu.Lock()
+			assets = append(assets, list...)
+			mu.Unlock()
+		}(target)
 	}
+
+	wg.Wait()
+	in.Spec.Assets = assets
 	return in, nil
 }
 


### PR DESCRIPTION
## Summary

- Run up to 5 AWS discovery targets concurrently instead of sequentially
- In `auto` mode (26+ targets), this reduces wall-clock discovery time to roughly the duration of the 5 slowest targets rather than the sum of all
- A semaphore (`discoveryConcurrency = 5`) caps parallel targets; since each target's internal job pool uses 5 workers for per-region calls, peak concurrent API calls stays at a manageable 25
- Result collection is protected by a mutex; error logs now include the target name for better observability

## Background

AWS discovery iterates over 26+ resource types in `auto` mode (S3, EKS, RDS, VPCs, Lambda, KMS, etc.). Each type fans out across all enabled regions using a 5-worker job pool. Previously these 26 types ran sequentially — total discovery time was the **sum** of all individual discovery times. In a large account across many regions this easily takes minutes.

This change makes the outer target loop concurrent, so discovery time becomes roughly the **max** of the 5 slowest batches instead.

Note: the original PR also parallelized DynamoDB DescribeTable and EKS DescribeCluster calls during listing, but main has since refactored both to lazy loading via `fetchDetail()`, making those changes unnecessary.

## Test plan

- [ ] Build and install the AWS provider: `make providers/build/aws && make providers/install/aws`
- [ ] Run discovery against a real AWS account and confirm all expected asset types are discovered: `mql inventory aws --discover auto`
- [ ] Confirm no assets are missing compared to the sequential run
- [ ] Check logs show per-target error messages include the target name when a target fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)