### PR TITLE
🐛 Fix BSD hostname detection fallbacks for vagrant connections

### DIFF
--- a/providers/os/id/hostname/hostname.go
+++ b/providers/os/id/hostname/hostname.go
@@ -60,14 +60,23 @@ func Hostname(conn shared.Connection, pf *inventory.Platform) (string, bool) {
 	}
 	log.Debug().Err(err).Msg("could not run `hostname` command")
 
-	// Fallback for BSD systems: use sysctl kern.hostname when the hostname command fails
-	// This handles cases where the hostname binary is missing or returns an error
+	// Fallback for BSD systems when the hostname command fails or returns empty
 	if isBSDWithoutDarwin(pf) {
+		// Try sysctl kern.hostname (handles missing hostname binary)
 		hostname, err := runCommand(conn, "sysctl -n kern.hostname")
 		if err == nil && hostname != "" {
 			return hostname, true
 		}
 		log.Debug().Err(err).Msg("could not detect hostname via `sysctl -n kern.hostname`")
+
+		// Try /etc/rc.conf which is the standard BSD hostname configuration file.
+		// This handles the case where the hostname is configured but not yet applied
+		// (e.g., fresh vagrant VMs that haven't been rebooted after provisioning).
+		hn, err := parseRcConfHostname(conn)
+		if err == nil && hn != "" {
+			return hn, true
+		}
+		log.Debug().Err(err).Msg("could not detect hostname from /etc/rc.conf")
 	}
 
 	// Fallback to for unix systems to /etc/hostname, since hostname command is not available on all systems
@@ -175,6 +184,39 @@ func isLocalhostVariant(host string) bool {
 		lh == "localhost.localdomain" ||
 		lh == "ip6-localhost" ||
 		lh == "ip6-loopback"
+}
+
+// parseRcConfHostname reads the hostname from /etc/rc.conf, which is the standard
+// configuration file on BSD systems (FreeBSD, NetBSD, OpenBSD, DragonFlyBSD).
+// It looks for a line like: hostname="myhost.example.com"
+func parseRcConfHostname(conn shared.Connection) (string, error) {
+	afs := &afero.Afero{Fs: conn.FileSystem()}
+	ok, err := afs.Exists("/etc/rc.conf")
+	if err != nil || !ok {
+		return "", fmt.Errorf("could not find /etc/rc.conf")
+	}
+
+	content, err := afs.ReadFile("/etc/rc.conf")
+	if err != nil {
+		return "", err
+	}
+
+	for _, line := range strings.Split(string(content), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "hostname=") {
+			value := strings.TrimPrefix(line, "hostname=")
+			value = strings.Trim(value, `"'`)
+			value = strings.TrimSpace(value)
+			if value != "" {
+				return value, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no hostname found in /etc/rc.conf")
 }
 
 // isBSDWithoutDarwin returns true if the platform is a BSD system but not Darwin/macOS.

--- a/providers/os/id/hostname/hostname.go
+++ b/providers/os/id/hostname/hostname.go
@@ -60,6 +60,16 @@ func Hostname(conn shared.Connection, pf *inventory.Platform) (string, bool) {
 	}
 	log.Debug().Err(err).Msg("could not run `hostname` command")
 
+	// Fallback for BSD systems: use sysctl kern.hostname when the hostname command fails
+	// This handles cases where the hostname binary is missing or returns an error
+	if isBSDWithoutDarwin(pf) {
+		hostname, err := runCommand(conn, "sysctl -n kern.hostname")
+		if err == nil && hostname != "" {
+			return hostname, true
+		}
+		log.Debug().Err(err).Msg("could not detect hostname via `sysctl -n kern.hostname`")
+	}
+
 	// Fallback to for unix systems to /etc/hostname, since hostname command is not available on all systems
 	// This mechanism is also working for static analysis
 	if pf.IsFamily(inventory.FAMILY_LINUX) {

--- a/providers/os/id/hostname/hostname.go
+++ b/providers/os/id/hostname/hostname.go
@@ -69,14 +69,14 @@ func Hostname(conn shared.Connection, pf *inventory.Platform) (string, bool) {
 		}
 		log.Debug().Err(err).Msg("could not detect hostname via `sysctl -n kern.hostname`")
 
-		// Try /etc/rc.conf which is the standard BSD hostname configuration file.
+		// Try /etc/rc.conf (FreeBSD, NetBSD, DragonFlyBSD) or /etc/myname (OpenBSD).
 		// This handles the case where the hostname is configured but not yet applied
 		// (e.g., fresh vagrant VMs that haven't been rebooted after provisioning).
-		hn, err := parseRcConfHostname(conn)
+		hn, err := parseBSDHostnameConfig(conn)
 		if err == nil && hn != "" {
 			return hn, true
 		}
-		log.Debug().Err(err).Msg("could not detect hostname from /etc/rc.conf")
+		log.Debug().Err(err).Msg("could not detect hostname from BSD config files")
 	}
 
 	// Fallback to for unix systems to /etc/hostname, since hostname command is not available on all systems
@@ -186,37 +186,47 @@ func isLocalhostVariant(host string) bool {
 		lh == "ip6-loopback"
 }
 
-// parseRcConfHostname reads the hostname from /etc/rc.conf, which is the standard
-// configuration file on BSD systems (FreeBSD, NetBSD, OpenBSD, DragonFlyBSD).
-// It looks for a line like: hostname="myhost.example.com"
-func parseRcConfHostname(conn shared.Connection) (string, error) {
+// parseBSDHostnameConfig tries to read the hostname from BSD configuration files.
+// FreeBSD, NetBSD, and DragonFlyBSD use /etc/rc.conf (hostname="myhost.example.com").
+// OpenBSD uses /etc/myname (a single line containing the hostname).
+func parseBSDHostnameConfig(conn shared.Connection) (string, error) {
 	afs := &afero.Afero{Fs: conn.FileSystem()}
-	ok, err := afs.Exists("/etc/rc.conf")
-	if err != nil || !ok {
-		return "", fmt.Errorf("could not find /etc/rc.conf")
-	}
 
-	content, err := afs.ReadFile("/etc/rc.conf")
-	if err != nil {
-		return "", err
-	}
-
-	for _, line := range strings.Split(string(content), "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "#") {
-			continue
-		}
-		if strings.HasPrefix(line, "hostname=") {
-			value := strings.TrimPrefix(line, "hostname=")
-			value = strings.Trim(value, `"'`)
-			value = strings.TrimSpace(value)
-			if value != "" {
-				return value, nil
+	// Try /etc/myname first (OpenBSD)
+	if ok, err := afs.Exists("/etc/myname"); err == nil && ok {
+		content, err := afs.ReadFile("/etc/myname")
+		if err == nil {
+			hn := strings.TrimSpace(string(content))
+			if hn != "" {
+				return hn, nil
 			}
 		}
 	}
 
-	return "", fmt.Errorf("no hostname found in /etc/rc.conf")
+	// Try /etc/rc.conf (FreeBSD, NetBSD, DragonFlyBSD)
+	if ok, err := afs.Exists("/etc/rc.conf"); err == nil && ok {
+		content, err := afs.ReadFile("/etc/rc.conf")
+		if err != nil {
+			return "", err
+		}
+
+		for _, line := range strings.Split(string(content), "\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "#") {
+				continue
+			}
+			if strings.HasPrefix(line, "hostname=") {
+				value := strings.TrimPrefix(line, "hostname=")
+				value = strings.Trim(value, `"'`)
+				value = strings.TrimSpace(value)
+				if value != "" {
+					return value, nil
+				}
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no hostname found in BSD config files")
 }
 
 // isBSDWithoutDarwin returns true if the platform is a BSD system but not Darwin/macOS.

--- a/providers/os/id/hostname/hostname_test.go
+++ b/providers/os/id/hostname/hostname_test.go
@@ -145,3 +145,51 @@ func TestHostnameDragonFlyBSD(t *testing.T) {
 
 	assert.Equal(t, "dragonfly-server.local", hn)
 }
+
+func TestHostnameFreeBSDSysctlFallback(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/hostname_freebsd_sysctl_fallback.toml"))
+	require.NoError(t, err)
+	platform, ok := detector.DetectOS(conn)
+	require.True(t, ok)
+
+	hn, ok := hostname.Hostname(conn, platform)
+	require.True(t, ok)
+
+	assert.Equal(t, "freebsd-vagrant.local", hn)
+}
+
+func TestHostnameOpenBSDSysctlFallback(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/hostname_openbsd_sysctl_fallback.toml"))
+	require.NoError(t, err)
+	platform, ok := detector.DetectOS(conn)
+	require.True(t, ok)
+
+	hn, ok := hostname.Hostname(conn, platform)
+	require.True(t, ok)
+
+	assert.Equal(t, "openbsd-vagrant.local", hn)
+}
+
+func TestHostnameNetBSDSysctlFallback(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/hostname_netbsd_sysctl_fallback.toml"))
+	require.NoError(t, err)
+	platform, ok := detector.DetectOS(conn)
+	require.True(t, ok)
+
+	hn, ok := hostname.Hostname(conn, platform)
+	require.True(t, ok)
+
+	assert.Equal(t, "netbsd-vagrant.local", hn)
+}
+
+func TestHostnameDragonFlyBSDSysctlFallback(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/hostname_dragonflybsd_sysctl_fallback.toml"))
+	require.NoError(t, err)
+	platform, ok := detector.DetectOS(conn)
+	require.True(t, ok)
+
+	hn, ok := hostname.Hostname(conn, platform)
+	require.True(t, ok)
+
+	assert.Equal(t, "dragonfly-vagrant.local", hn)
+}

--- a/providers/os/id/hostname/hostname_test.go
+++ b/providers/os/id/hostname/hostname_test.go
@@ -158,6 +158,18 @@ func TestHostnameFreeBSDRcConfFallback(t *testing.T) {
 	assert.Equal(t, "freebsd-vagrant.local", hn)
 }
 
+func TestHostnameOpenBSDMynameFallback(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/hostname_openbsd_myname_fallback.toml"))
+	require.NoError(t, err)
+	platform, ok := detector.DetectOS(conn)
+	require.True(t, ok)
+
+	hn, ok := hostname.Hostname(conn, platform)
+	require.True(t, ok)
+
+	assert.Equal(t, "openbsd-vagrant.local", hn)
+}
+
 func TestHostnameFreeBSDSysctlFallback(t *testing.T) {
 	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/hostname_freebsd_sysctl_fallback.toml"))
 	require.NoError(t, err)

--- a/providers/os/id/hostname/hostname_test.go
+++ b/providers/os/id/hostname/hostname_test.go
@@ -146,6 +146,18 @@ func TestHostnameDragonFlyBSD(t *testing.T) {
 	assert.Equal(t, "dragonfly-server.local", hn)
 }
 
+func TestHostnameFreeBSDRcConfFallback(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/hostname_freebsd_rcconf_fallback.toml"))
+	require.NoError(t, err)
+	platform, ok := detector.DetectOS(conn)
+	require.True(t, ok)
+
+	hn, ok := hostname.Hostname(conn, platform)
+	require.True(t, ok)
+
+	assert.Equal(t, "freebsd-vagrant.local", hn)
+}
+
 func TestHostnameFreeBSDSysctlFallback(t *testing.T) {
 	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/hostname_freebsd_sysctl_fallback.toml"))
 	require.NoError(t, err)

--- a/providers/os/id/hostname/testdata/hostname_dragonflybsd_sysctl_fallback.toml
+++ b/providers/os/id/hostname/testdata/hostname_dragonflybsd_sysctl_fallback.toml
@@ -1,0 +1,14 @@
+[commands."uname -s"]
+stdout = "DragonFly"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "6.4-RELEASE"
+
+[commands."hostname"]
+exit_status = 1
+
+[commands."sysctl -n kern.hostname"]
+stdout = "dragonfly-vagrant.local"

--- a/providers/os/id/hostname/testdata/hostname_freebsd_rcconf_fallback.toml
+++ b/providers/os/id/hostname/testdata/hostname_freebsd_rcconf_fallback.toml
@@ -1,0 +1,21 @@
+[commands."uname -s"]
+stdout = "FreeBSD"
+
+[commands."uname -m"]
+stdout = "amd64"
+
+[commands."uname -r"]
+stdout = "14.0-RELEASE"
+
+[commands."hostname"]
+stdout = ""
+
+[commands."sysctl -n kern.hostname"]
+stdout = ""
+
+[files."/etc/rc.conf"]
+content = """
+# FreeBSD rc.conf
+hostname="freebsd-vagrant.local"
+sshd_enable="YES"
+"""

--- a/providers/os/id/hostname/testdata/hostname_freebsd_sysctl_fallback.toml
+++ b/providers/os/id/hostname/testdata/hostname_freebsd_sysctl_fallback.toml
@@ -1,0 +1,14 @@
+[commands."uname -s"]
+stdout = "FreeBSD"
+
+[commands."uname -m"]
+stdout = "amd64"
+
+[commands."uname -r"]
+stdout = "14.0-RELEASE"
+
+[commands."hostname"]
+exit_status = 1
+
+[commands."sysctl -n kern.hostname"]
+stdout = "freebsd-vagrant.local"

--- a/providers/os/id/hostname/testdata/hostname_netbsd_sysctl_fallback.toml
+++ b/providers/os/id/hostname/testdata/hostname_netbsd_sysctl_fallback.toml
@@ -1,0 +1,14 @@
+[commands."uname -s"]
+stdout = "NetBSD"
+
+[commands."uname -m"]
+stdout = "amd64"
+
+[commands."uname -r"]
+stdout = "10.0"
+
+[commands."hostname"]
+exit_status = 1
+
+[commands."sysctl -n kern.hostname"]
+stdout = "netbsd-vagrant.local"

--- a/providers/os/id/hostname/testdata/hostname_openbsd_myname_fallback.toml
+++ b/providers/os/id/hostname/testdata/hostname_openbsd_myname_fallback.toml
@@ -1,0 +1,17 @@
+[commands."uname -s"]
+stdout = "OpenBSD"
+
+[commands."uname -m"]
+stdout = "amd64"
+
+[commands."uname -r"]
+stdout = "7.4"
+
+[commands."hostname"]
+stdout = ""
+
+[commands."sysctl -n kern.hostname"]
+stdout = ""
+
+[files."/etc/myname"]
+content = "openbsd-vagrant.local"

--- a/providers/os/id/hostname/testdata/hostname_openbsd_sysctl_fallback.toml
+++ b/providers/os/id/hostname/testdata/hostname_openbsd_sysctl_fallback.toml
@@ -1,0 +1,14 @@
+[commands."uname -s"]
+stdout = "OpenBSD"
+
+[commands."uname -m"]
+stdout = "amd64"
+
+[commands."uname -r"]
+stdout = "7.4"
+
+[commands."hostname"]
+exit_status = 1
+
+[commands."sysctl -n kern.hostname"]
+stdout = "openbsd-vagrant.local"


### PR DESCRIPTION
## Summary
- Add `sysctl -n kern.hostname` fallback when `hostname` command fails on BSD systems (missing binary, non-zero exit)
- Add `/etc/rc.conf` hostname parsing fallback when both `hostname` and `sysctl` return empty (common on fresh vagrant VMs that haven't rebooted after provisioning)
- Covers FreeBSD, OpenBSD, NetBSD, and DragonFlyBSD

**Root cause:** Vagrant sets only `IdDetector_Hostname` for BSD VMs. When the hostname isn't configured (empty from both `hostname` and `sysctl`), no platform ID is generated, and discovery rejects the asset with "could not find an asset that we can connect to".

## Test plan
- [x] Unit tests for sysctl fallback on all 4 BSD variants
- [x] Unit test for `/etc/rc.conf` fallback (hostname + sysctl both empty)
- [x] Existing BSD hostname tests still pass (happy path)
- [ ] Manual: `mql shell vagrant default` against FreeBSD vagrant box

🤖 Generated with [Claude Code](https://claude.com/claude-code)