### PR TITLE
🐛 Fix 78 incorrect Azure RBAC permissions in auto-generated manifest

### DIFF
--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -1417,10 +1417,12 @@ var azurePermissionOverrides = map[string]string{
 	"Microsoft.DBforMySQL/databases/read":      "Microsoft.DBforMySQL/servers/databases/read",
 	"Microsoft.DBforMySQL/firewallRules/read":  "Microsoft.DBforMySQL/servers/firewallRules/read",
 
-	// PostgreSQL: sub-resources need servers/ parent path
-	"Microsoft.DBforPostgreSQL/configurations/read": "Microsoft.DBforPostgreSQL/servers/configurations/read",
-	"Microsoft.DBforPostgreSQL/databases/read":      "Microsoft.DBforPostgreSQL/servers/databases/read",
-	"Microsoft.DBforPostgreSQL/firewallRules/read":  "Microsoft.DBforPostgreSQL/servers/firewallRules/read",
+	// PostgreSQL: sub-resources need servers/ parent path; threat protection
+	// settings only exist on flexibleServers/
+	"Microsoft.DBforPostgreSQL/configurations/read":                   "Microsoft.DBforPostgreSQL/servers/configurations/read",
+	"Microsoft.DBforPostgreSQL/databases/read":                        "Microsoft.DBforPostgreSQL/servers/databases/read",
+	"Microsoft.DBforPostgreSQL/firewallRules/read":                    "Microsoft.DBforPostgreSQL/servers/firewallRules/read",
+	"Microsoft.DBforPostgreSQL/advancedThreatProtectionSettings/read": "Microsoft.DBforPostgreSQL/flexibleServers/advancedThreatProtectionSettings/read",
 
 	// Network: client names don't match ARM resource types
 	"Microsoft.Network/interfaces/read":                       "Microsoft.Network/networkInterfaces/read",
@@ -1467,10 +1469,13 @@ var azurePermissionOverrides = map[string]string{
 	"Microsoft.Cdn/aFDOrigins/read":       "Microsoft.Cdn/profiles/origingroups/origins/read",
 
 	// ContainerRegistry: sub-resources need registries/ parent path
-	"Microsoft.ContainerRegistry/replications/read": "Microsoft.ContainerRegistry/registries/replications/read",
-	"Microsoft.ContainerRegistry/scopeMaps/read":    "Microsoft.ContainerRegistry/registries/scopeMaps/read",
-	"Microsoft.ContainerRegistry/tokens/read":       "Microsoft.ContainerRegistry/registries/tokens/read",
-	"Microsoft.ContainerRegistry/webhooks/read":     "Microsoft.ContainerRegistry/registries/webhooks/read",
+	"Microsoft.ContainerRegistry/cacheRules/read":          "Microsoft.ContainerRegistry/registries/cacheRules/read",
+	"Microsoft.ContainerRegistry/connectedRegistries/read": "Microsoft.ContainerRegistry/registries/connectedRegistries/read",
+	"Microsoft.ContainerRegistry/credentialSets/read":      "Microsoft.ContainerRegistry/registries/credentialSets/read",
+	"Microsoft.ContainerRegistry/replications/read":        "Microsoft.ContainerRegistry/registries/replications/read",
+	"Microsoft.ContainerRegistry/scopeMaps/read":           "Microsoft.ContainerRegistry/registries/scopeMaps/read",
+	"Microsoft.ContainerRegistry/tokens/read":              "Microsoft.ContainerRegistry/registries/tokens/read",
+	"Microsoft.ContainerRegistry/webhooks/read":            "Microsoft.ContainerRegistry/registries/webhooks/read",
 
 	// DNS: Azure DNS lives under Microsoft.Network, not Microsoft.Dns
 	"Microsoft.Dns/recordSets/read": "Microsoft.Network/dnszones/recordsets/read",
@@ -1480,16 +1485,21 @@ var azurePermissionOverrides = map[string]string{
 	"Microsoft.Privatedns/privateZones/read":        "Microsoft.Network/privateDnsZones/read",
 	"Microsoft.Privatedns/virtualNetworkLinks/read": "Microsoft.Network/privateDnsZones/virtualNetworkLinks/read",
 
-	// EventHub: sub-resources need namespaces/ (or namespaces/eventHubs/) parent path
-	"Microsoft.EventHub/consumerGroups/read": "Microsoft.EventHub/namespaces/eventHubs/consumergroups/read",
+	// EventHub: sub-resources need namespaces/ (or namespaces/eventhubs/) parent path
+	"Microsoft.EventHub/consumerGroups/read": "Microsoft.EventHub/namespaces/eventhubs/consumergroups/read",
 	"Microsoft.EventHub/eventHubs/read":      "Microsoft.EventHub/namespaces/eventhubs/read",
 
 	// Network: SDK calls Application Gateway WAF, which has a longer ARM type name
 	"Microsoft.Network/webApplicationFirewallPolicies/read": "Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/read",
 
-	// OperationalInsights: sub-resources need workspaces/ parent path
+	// OperationalInsights: sub-resources need workspaces/ parent path;
+	// queryPacks is the standalone resource and uses lowercase querypacks;
+	// log queries map to workspaces/savedSearches
 	"Microsoft.OperationalInsights/dataExports/read":    "Microsoft.OperationalInsights/workspaces/dataexports/read",
 	"Microsoft.OperationalInsights/linkedServices/read": "Microsoft.OperationalInsights/workspaces/linkedservices/read",
+	"Microsoft.OperationalInsights/queries/read":        "Microsoft.OperationalInsights/workspaces/savedSearches/read",
+	"Microsoft.OperationalInsights/queryPacks/read":     "Microsoft.OperationalInsights/querypacks/read",
+	"Microsoft.OperationalInsights/tables/read":         "Microsoft.OperationalInsights/workspaces/tables/read",
 
 	// RecoveryServices: backup sub-resources need Vaults/ parent path; backupResourceVaultConfigs
 	// is the SDK client name but the ARM operation is called backupconfig
@@ -1505,9 +1515,17 @@ var azurePermissionOverrides = map[string]string{
 	"Microsoft.ServiceBus/topics/read":        "Microsoft.ServiceBus/namespaces/topics/read",
 	"Microsoft.ServiceBus/subscriptions/read": "Microsoft.ServiceBus/namespaces/topics/subscriptions/read",
 
-	// Storage: encryption/management policy sub-resources need storageAccounts/ parent path
+	// Storage: encryption/management policy and local user sub-resources need
+	// storageAccounts/ parent path
 	"Microsoft.Storage/encryptionScopes/read":   "Microsoft.Storage/storageAccounts/encryptionScopes/read",
+	"Microsoft.Storage/localUsers/read":         "Microsoft.Storage/storageAccounts/localUsers/read",
 	"Microsoft.Storage/managementPolicies/read": "Microsoft.Storage/storageAccounts/managementPolicies/read",
+
+	// CDN: AFD routes are nested under profiles/afdendpoints/
+	"Microsoft.Cdn/routes/read": "Microsoft.Cdn/profiles/afdendpoints/routes/read",
+
+	// Network: privateDnsZoneGroups are nested under privateEndpoints/
+	"Microsoft.Network/privateDNSZoneGroups/read": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups/read",
 }
 
 // azurePermission constructs the RBAC permission string.

--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -1382,6 +1382,8 @@ var azureServiceToARMMap = map[string]string{
 	"batch":                 "Microsoft.Batch",
 	"databricks":            "Microsoft.Databricks",
 	"synapse":               "Microsoft.Synapse",
+	"operationalinsights":   "Microsoft.OperationalInsights",
+	"recoveryservices":      "Microsoft.RecoveryServices",
 }
 
 func azureServiceToARM(service string) string {
@@ -1421,33 +1423,33 @@ var azurePermissionOverrides = map[string]string{
 	"Microsoft.DBforPostgreSQL/firewallRules/read":  "Microsoft.DBforPostgreSQL/servers/firewallRules/read",
 
 	// Network: client names don't match ARM resource types
-	"Microsoft.Network/interfaces/read":                        "Microsoft.Network/networkInterfaces/read",
-	"Microsoft.Network/securityGroups/read":                    "Microsoft.Network/networkSecurityGroups/read",
-	"Microsoft.Network/subnets/read":                           "Microsoft.Network/virtualNetworks/subnets/read",
-	"Microsoft.Network/flowLogs/read":                          "Microsoft.Network/networkWatchers/flowLogs/read",
-	"Microsoft.Network/watchers/read":                          "Microsoft.Network/networkWatchers/read",
-	"Microsoft.Network/virtualNetworkPeerings/read":            "Microsoft.Network/virtualNetworks/virtualNetworkPeerings/read",
-	"Microsoft.Network/virtualNetworkGatewayConnections/read":  "Microsoft.Network/connections/read",
+	"Microsoft.Network/interfaces/read":                       "Microsoft.Network/networkInterfaces/read",
+	"Microsoft.Network/securityGroups/read":                   "Microsoft.Network/networkSecurityGroups/read",
+	"Microsoft.Network/subnets/read":                          "Microsoft.Network/virtualNetworks/subnets/read",
+	"Microsoft.Network/flowLogs/read":                         "Microsoft.Network/networkWatchers/flowLogs/read",
+	"Microsoft.Network/watchers/read":                         "Microsoft.Network/networkWatchers/read",
+	"Microsoft.Network/virtualNetworkPeerings/read":           "Microsoft.Network/virtualNetworks/virtualNetworkPeerings/read",
+	"Microsoft.Network/virtualNetworkGatewayConnections/read": "Microsoft.Network/connections/read",
 
 	// SQL: sub-resources need servers/ or servers/databases/ parent paths
-	"Microsoft.Sql/databases/read":                              "Microsoft.Sql/servers/databases/read",
-	"Microsoft.Sql/firewallRules/read":                          "Microsoft.Sql/servers/firewallRules/read",
-	"Microsoft.Sql/virtualNetworkRules/read":                    "Microsoft.Sql/servers/virtualNetworkRules/read",
-	"Microsoft.Sql/encryptionProtectors/read":                   "Microsoft.Sql/servers/encryptionProtector/read",
-	"Microsoft.Sql/backupShortTermRetentionPolicies/read":       "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/read",
-	"Microsoft.Sql/longTermRetentionPolicies/read":              "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/read",
-	"Microsoft.Sql/transparentDataEncryptions/read":             "Microsoft.Sql/servers/databases/transparentDataEncryption/read",
+	"Microsoft.Sql/databases/read":                                "Microsoft.Sql/servers/databases/read",
+	"Microsoft.Sql/firewallRules/read":                            "Microsoft.Sql/servers/firewallRules/read",
+	"Microsoft.Sql/virtualNetworkRules/read":                      "Microsoft.Sql/servers/virtualNetworkRules/read",
+	"Microsoft.Sql/encryptionProtectors/read":                     "Microsoft.Sql/servers/encryptionProtector/read",
+	"Microsoft.Sql/backupShortTermRetentionPolicies/read":         "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/read",
+	"Microsoft.Sql/longTermRetentionPolicies/read":                "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/read",
+	"Microsoft.Sql/transparentDataEncryptions/read":               "Microsoft.Sql/servers/databases/transparentDataEncryption/read",
 	"Microsoft.Sql/databaseAdvancedThreatProtectionSettings/read": "Microsoft.Sql/servers/databases/advancedThreatProtectionSettings/read",
-	"Microsoft.Sql/databaseBlobAuditingPolicies/read":           "Microsoft.Sql/servers/databases/auditingSettings/read",
-	"Microsoft.Sql/databaseSecurityAlertPolicies/read":          "Microsoft.Sql/servers/databases/securityAlertPolicies/read",
-	"Microsoft.Sql/databaseUsages/read":                         "Microsoft.Sql/servers/databases/usages/read",
-	"Microsoft.Sql/serverAdvancedThreatProtectionSettings/read": "Microsoft.Sql/servers/advancedThreatProtectionSettings/read",
-	"Microsoft.Sql/serverAzureADAdministrators/read":            "Microsoft.Sql/servers/administrators/read",
-	"Microsoft.Sql/serverAzureADOnlyAuthentications/read":       "Microsoft.Sql/servers/azureADOnlyAuthentications/read",
-	"Microsoft.Sql/serverBlobAuditingPolicies/read":             "Microsoft.Sql/servers/auditingSettings/read",
-	"Microsoft.Sql/serverConnectionPolicies/read":               "Microsoft.Sql/servers/connectionPolicies/read",
-	"Microsoft.Sql/serverSecurityAlertPolicies/read":            "Microsoft.Sql/servers/securityAlertPolicies/read",
-	"Microsoft.Sql/serverVulnerabilityAssessments/read":         "Microsoft.Sql/servers/vulnerabilityAssessments/read",
+	"Microsoft.Sql/databaseBlobAuditingPolicies/read":             "Microsoft.Sql/servers/databases/auditingSettings/read",
+	"Microsoft.Sql/databaseSecurityAlertPolicies/read":            "Microsoft.Sql/servers/databases/securityAlertPolicies/read",
+	"Microsoft.Sql/databaseUsages/read":                           "Microsoft.Sql/servers/databases/usages/read",
+	"Microsoft.Sql/serverAdvancedThreatProtectionSettings/read":   "Microsoft.Sql/servers/advancedThreatProtectionSettings/read",
+	"Microsoft.Sql/serverAzureADAdministrators/read":              "Microsoft.Sql/servers/administrators/read",
+	"Microsoft.Sql/serverAzureADOnlyAuthentications/read":         "Microsoft.Sql/servers/azureADOnlyAuthentications/read",
+	"Microsoft.Sql/serverBlobAuditingPolicies/read":               "Microsoft.Sql/servers/auditingSettings/read",
+	"Microsoft.Sql/serverConnectionPolicies/read":                 "Microsoft.Sql/servers/connectionPolicies/read",
+	"Microsoft.Sql/serverSecurityAlertPolicies/read":              "Microsoft.Sql/servers/securityAlertPolicies/read",
+	"Microsoft.Sql/serverVulnerabilityAssessments/read":           "Microsoft.Sql/servers/vulnerabilityAssessments/read",
 
 	// Storage: client names don't match ARM resource types
 	"Microsoft.Storage/accounts/read":       "Microsoft.Storage/storageAccounts/read",
@@ -1457,6 +1459,55 @@ var azurePermissionOverrides = map[string]string{
 	"Microsoft.Web/environments/read": "Microsoft.Web/hostingEnvironments/read",
 	"Microsoft.Web/plans/read":        "Microsoft.Web/serverfarms/read",
 	"Microsoft.Web/webApps/read":      "Microsoft.Web/sites/read",
+
+	// CDN: Azure Front Door SDK clients omit the profiles/ parent path
+	"Microsoft.Cdn/aFDCustomDomains/read": "Microsoft.Cdn/profiles/customdomains/read",
+	"Microsoft.Cdn/aFDEndpoints/read":     "Microsoft.Cdn/profiles/afdendpoints/read",
+	"Microsoft.Cdn/aFDOriginGroups/read":  "Microsoft.Cdn/profiles/origingroups/read",
+	"Microsoft.Cdn/aFDOrigins/read":       "Microsoft.Cdn/profiles/origingroups/origins/read",
+
+	// ContainerRegistry: sub-resources need registries/ parent path
+	"Microsoft.ContainerRegistry/replications/read": "Microsoft.ContainerRegistry/registries/replications/read",
+	"Microsoft.ContainerRegistry/scopeMaps/read":    "Microsoft.ContainerRegistry/registries/scopeMaps/read",
+	"Microsoft.ContainerRegistry/tokens/read":       "Microsoft.ContainerRegistry/registries/tokens/read",
+	"Microsoft.ContainerRegistry/webhooks/read":     "Microsoft.ContainerRegistry/registries/webhooks/read",
+
+	// DNS: Azure DNS lives under Microsoft.Network, not Microsoft.Dns
+	"Microsoft.Dns/recordSets/read": "Microsoft.Network/dnszones/recordsets/read",
+	"Microsoft.Dns/zones/read":      "Microsoft.Network/dnszones/read",
+
+	// Private DNS: lives under Microsoft.Network/privateDnsZones, not Microsoft.Privatedns
+	"Microsoft.Privatedns/privateZones/read":        "Microsoft.Network/privateDnsZones/read",
+	"Microsoft.Privatedns/virtualNetworkLinks/read": "Microsoft.Network/privateDnsZones/virtualNetworkLinks/read",
+
+	// EventHub: sub-resources need namespaces/ (or namespaces/eventHubs/) parent path
+	"Microsoft.EventHub/consumerGroups/read": "Microsoft.EventHub/namespaces/eventHubs/consumergroups/read",
+	"Microsoft.EventHub/eventHubs/read":      "Microsoft.EventHub/namespaces/eventhubs/read",
+
+	// Network: SDK calls Application Gateway WAF, which has a longer ARM type name
+	"Microsoft.Network/webApplicationFirewallPolicies/read": "Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/read",
+
+	// OperationalInsights: sub-resources need workspaces/ parent path
+	"Microsoft.OperationalInsights/dataExports/read":    "Microsoft.OperationalInsights/workspaces/dataexports/read",
+	"Microsoft.OperationalInsights/linkedServices/read": "Microsoft.OperationalInsights/workspaces/linkedservices/read",
+
+	// RecoveryServices: backup sub-resources need Vaults/ parent path; backupResourceVaultConfigs
+	// is the SDK client name but the ARM operation is called backupconfig
+	"Microsoft.RecoveryServices/backupPolicies/read":             "Microsoft.RecoveryServices/Vaults/backupPolicies/read",
+	"Microsoft.RecoveryServices/backupProtectedItems/read":       "Microsoft.RecoveryServices/Vaults/backupProtectedItems/read",
+	"Microsoft.RecoveryServices/backupResourceVaultConfigs/read": "Microsoft.RecoveryServices/Vaults/backupconfig/read",
+
+	// Resources: resource groups are nested under subscriptions/
+	"Microsoft.Resources/resourceGroups/read": "Microsoft.Resources/subscriptions/resourceGroups/read",
+
+	// ServiceBus: sub-resources need namespaces/ parent path; subscriptions are nested under topics
+	"Microsoft.ServiceBus/queues/read":        "Microsoft.ServiceBus/namespaces/queues/read",
+	"Microsoft.ServiceBus/topics/read":        "Microsoft.ServiceBus/namespaces/topics/read",
+	"Microsoft.ServiceBus/subscriptions/read": "Microsoft.ServiceBus/namespaces/topics/subscriptions/read",
+
+	// Storage: encryption/management policy sub-resources need storageAccounts/ parent path
+	"Microsoft.Storage/encryptionScopes/read":   "Microsoft.Storage/storageAccounts/encryptionScopes/read",
+	"Microsoft.Storage/managementPolicies/read": "Microsoft.Storage/storageAccounts/managementPolicies/read",
 }
 
 // azurePermission constructs the RBAC permission string.

--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -1377,6 +1377,11 @@ var azureServiceToARMMap = map[string]string{
 	"logic":                 "Microsoft.Logic",
 	"msi":                   "Microsoft.ManagedIdentity",
 	"frontdoor":             "Microsoft.Network",
+	"datafactory":           "Microsoft.DataFactory",
+	"cosmosforpostgresql":   "Microsoft.DBforPostgreSQL",
+	"batch":                 "Microsoft.Batch",
+	"databricks":            "Microsoft.Databricks",
+	"synapse":               "Microsoft.Synapse",
 }
 
 func azureServiceToARM(service string) string {
@@ -1390,11 +1395,81 @@ func azureServiceToARM(service string) string {
 	return "Microsoft." + strings.ToUpper(service[:1]) + service[1:]
 }
 
+// azurePermissionOverrides maps generated permission strings to the correct
+// Azure RBAC permission. Many Azure SDK client names don't include parent
+// resource paths (e.g., servers/) or use different names than the ARM API.
+var azurePermissionOverrides = map[string]string{
+	// Batch: client names don't match ARM resource types
+	"Microsoft.Batch/account/read": "Microsoft.Batch/batchAccounts/read",
+	"Microsoft.Batch/pool/read":    "Microsoft.Batch/batchAccounts/pools/read",
+
+	// Cache (Redis): sub-resources need redis/ parent path
+	"Microsoft.Cache/firewallRules/read":  "Microsoft.Cache/redis/firewallRules/read",
+	"Microsoft.Cache/patchSchedules/read": "Microsoft.Cache/redis/patchSchedules/read",
+
+	// Cosmos DB for PostgreSQL: SDK package maps to different ARM resource type
+	"Microsoft.DBforPostgreSQL/clusters/read": "Microsoft.DBforPostgreSQL/serverGroupsv2/read",
+
+	// MySQL: sub-resources need servers/ parent path
+	"Microsoft.DBforMySQL/configurations/read": "Microsoft.DBforMySQL/servers/configurations/read",
+	"Microsoft.DBforMySQL/databases/read":      "Microsoft.DBforMySQL/servers/databases/read",
+	"Microsoft.DBforMySQL/firewallRules/read":  "Microsoft.DBforMySQL/servers/firewallRules/read",
+
+	// PostgreSQL: sub-resources need servers/ parent path
+	"Microsoft.DBforPostgreSQL/configurations/read": "Microsoft.DBforPostgreSQL/servers/configurations/read",
+	"Microsoft.DBforPostgreSQL/databases/read":      "Microsoft.DBforPostgreSQL/servers/databases/read",
+	"Microsoft.DBforPostgreSQL/firewallRules/read":  "Microsoft.DBforPostgreSQL/servers/firewallRules/read",
+
+	// Network: client names don't match ARM resource types
+	"Microsoft.Network/interfaces/read":                        "Microsoft.Network/networkInterfaces/read",
+	"Microsoft.Network/securityGroups/read":                    "Microsoft.Network/networkSecurityGroups/read",
+	"Microsoft.Network/subnets/read":                           "Microsoft.Network/virtualNetworks/subnets/read",
+	"Microsoft.Network/flowLogs/read":                          "Microsoft.Network/networkWatchers/flowLogs/read",
+	"Microsoft.Network/watchers/read":                          "Microsoft.Network/networkWatchers/read",
+	"Microsoft.Network/virtualNetworkPeerings/read":            "Microsoft.Network/virtualNetworks/virtualNetworkPeerings/read",
+	"Microsoft.Network/virtualNetworkGatewayConnections/read":  "Microsoft.Network/connections/read",
+
+	// SQL: sub-resources need servers/ or servers/databases/ parent paths
+	"Microsoft.Sql/databases/read":                              "Microsoft.Sql/servers/databases/read",
+	"Microsoft.Sql/firewallRules/read":                          "Microsoft.Sql/servers/firewallRules/read",
+	"Microsoft.Sql/virtualNetworkRules/read":                    "Microsoft.Sql/servers/virtualNetworkRules/read",
+	"Microsoft.Sql/encryptionProtectors/read":                   "Microsoft.Sql/servers/encryptionProtector/read",
+	"Microsoft.Sql/backupShortTermRetentionPolicies/read":       "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/read",
+	"Microsoft.Sql/longTermRetentionPolicies/read":              "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/read",
+	"Microsoft.Sql/transparentDataEncryptions/read":             "Microsoft.Sql/servers/databases/transparentDataEncryption/read",
+	"Microsoft.Sql/databaseAdvancedThreatProtectionSettings/read": "Microsoft.Sql/servers/databases/advancedThreatProtectionSettings/read",
+	"Microsoft.Sql/databaseBlobAuditingPolicies/read":           "Microsoft.Sql/servers/databases/auditingSettings/read",
+	"Microsoft.Sql/databaseSecurityAlertPolicies/read":          "Microsoft.Sql/servers/databases/securityAlertPolicies/read",
+	"Microsoft.Sql/databaseUsages/read":                         "Microsoft.Sql/servers/databases/usages/read",
+	"Microsoft.Sql/serverAdvancedThreatProtectionSettings/read": "Microsoft.Sql/servers/advancedThreatProtectionSettings/read",
+	"Microsoft.Sql/serverAzureADAdministrators/read":            "Microsoft.Sql/servers/administrators/read",
+	"Microsoft.Sql/serverAzureADOnlyAuthentications/read":       "Microsoft.Sql/servers/azureADOnlyAuthentications/read",
+	"Microsoft.Sql/serverBlobAuditingPolicies/read":             "Microsoft.Sql/servers/auditingSettings/read",
+	"Microsoft.Sql/serverConnectionPolicies/read":               "Microsoft.Sql/servers/connectionPolicies/read",
+	"Microsoft.Sql/serverSecurityAlertPolicies/read":            "Microsoft.Sql/servers/securityAlertPolicies/read",
+	"Microsoft.Sql/serverVulnerabilityAssessments/read":         "Microsoft.Sql/servers/vulnerabilityAssessments/read",
+
+	// Storage: client names don't match ARM resource types
+	"Microsoft.Storage/accounts/read":       "Microsoft.Storage/storageAccounts/read",
+	"Microsoft.Storage/blobContainers/read": "Microsoft.Storage/storageAccounts/blobServices/containers/read",
+
+	// Web: client names don't match ARM resource types
+	"Microsoft.Web/environments/read": "Microsoft.Web/hostingEnvironments/read",
+	"Microsoft.Web/plans/read":        "Microsoft.Web/serverfarms/read",
+	"Microsoft.Web/webApps/read":      "Microsoft.Web/sites/read",
+}
+
 // azurePermission constructs the RBAC permission string.
 func azurePermission(armProvider, resourceType string) string {
 	// Convert PascalCase to camelCase for the resource type
 	rt := pascalToCamelCase(resourceType)
-	return armProvider + "/" + rt + "/read"
+	perm := armProvider + "/" + rt + "/read"
+
+	// Check for overrides where SDK names don't match ARM resource types
+	if override, ok := azurePermissionOverrides[perm]; ok {
+		return override
+	}
+	return perm
 }
 
 func pascalToCamelCase(s string) string {

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,47 +1,40 @@
 {
   "provider": "azure",
   "version": "13.5.0",
-  "generated_at": "2026-04-25T15:50:37-07:00",
+  "generated_at": "2026-04-24T22:26:35-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
-    "Microsoft.Authorization/classicAdministrators/read",
-    "Microsoft.Authorization/denyAssignments/read",
     "Microsoft.Authorization/roleAssignments/read",
     "Microsoft.Authorization/roleDefinitions/read",
-    "Microsoft.Batch/account/read",
-    "Microsoft.Batch/pool/read",
-    "Microsoft.Cache/firewallRules/read",
-    "Microsoft.Cache/patchSchedules/read",
+    "Microsoft.Batch/batchAccounts/pools/read",
+    "Microsoft.Batch/batchAccounts/read",
+    "Microsoft.Cache/redis/firewallRules/read",
+    "Microsoft.Cache/redis/patchSchedules/read",
     "Microsoft.Cdn/aFDCustomDomains/read",
     "Microsoft.Cdn/aFDEndpoints/read",
     "Microsoft.Cdn/aFDOriginGroups/read",
     "Microsoft.Cdn/aFDOrigins/read",
     "Microsoft.Cdn/profiles/read",
-    "Microsoft.Cdn/routes/read",
     "Microsoft.Compute/diskAccesses/read",
     "Microsoft.Compute/diskEncryptionSets/read",
     "Microsoft.Compute/disks/read",
     "Microsoft.Compute/virtualMachines/read",
-    "Microsoft.ContainerRegistry/cacheRules/read",
-    "Microsoft.ContainerRegistry/connectedRegistries/read",
-    "Microsoft.ContainerRegistry/credentialSets/read",
     "Microsoft.ContainerRegistry/replications/read",
     "Microsoft.ContainerRegistry/scopeMaps/read",
     "Microsoft.ContainerRegistry/tokens/read",
     "Microsoft.ContainerRegistry/webhooks/read",
     "Microsoft.ContainerService/managedClusters/read",
-    "Microsoft.Cosmosforpostgresql/clusters/read",
-    "Microsoft.DBforMySQL/configurations/read",
-    "Microsoft.DBforMySQL/databases/read",
-    "Microsoft.DBforMySQL/firewallRules/read",
+    "Microsoft.DBforMySQL/servers/configurations/read",
+    "Microsoft.DBforMySQL/servers/databases/read",
+    "Microsoft.DBforMySQL/servers/firewallRules/read",
     "Microsoft.DBforMySQL/servers/read",
-    "Microsoft.DBforPostgreSQL/advancedThreatProtectionSettings/read",
-    "Microsoft.DBforPostgreSQL/configurations/read",
-    "Microsoft.DBforPostgreSQL/databases/read",
-    "Microsoft.DBforPostgreSQL/firewallRules/read",
+    "Microsoft.DBforPostgreSQL/serverGroupsv2/read",
+    "Microsoft.DBforPostgreSQL/servers/configurations/read",
+    "Microsoft.DBforPostgreSQL/servers/databases/read",
+    "Microsoft.DBforPostgreSQL/servers/firewallRules/read",
     "Microsoft.DBforPostgreSQL/servers/read",
+    "Microsoft.DataFactory/factories/read",
     "Microsoft.Databricks/workspaces/read",
-    "Microsoft.Datafactory/factories/read",
     "Microsoft.Dns/recordSets/read",
     "Microsoft.Dns/zones/read",
     "Microsoft.DocumentDB/databaseAccounts/read",
@@ -59,30 +52,26 @@
     "Microsoft.Network/applicationSecurityGroups/read",
     "Microsoft.Network/azureFirewalls/read",
     "Microsoft.Network/bastionHosts/read",
+    "Microsoft.Network/connections/read",
     "Microsoft.Network/ddosProtectionPlans/read",
     "Microsoft.Network/firewallPolicies/read",
-    "Microsoft.Network/flowLogs/read",
-    "Microsoft.Network/interfaces/read",
     "Microsoft.Network/loadBalancers/read",
     "Microsoft.Network/natGateways/read",
-    "Microsoft.Network/privateDNSZoneGroups/read",
+    "Microsoft.Network/networkInterfaces/read",
+    "Microsoft.Network/networkSecurityGroups/read",
+    "Microsoft.Network/networkWatchers/flowLogs/read",
+    "Microsoft.Network/networkWatchers/read",
     "Microsoft.Network/privateEndpoints/read",
     "Microsoft.Network/publicIPAddresses/read",
     "Microsoft.Network/routeTables/read",
-    "Microsoft.Network/securityGroups/read",
     "Microsoft.Network/serviceEndpointPolicies/read",
-    "Microsoft.Network/subnets/read",
-    "Microsoft.Network/virtualNetworkGatewayConnections/read",
     "Microsoft.Network/virtualNetworkGateways/read",
-    "Microsoft.Network/virtualNetworkPeerings/read",
     "Microsoft.Network/virtualNetworks/read",
-    "Microsoft.Network/watchers/read",
+    "Microsoft.Network/virtualNetworks/subnets/read",
+    "Microsoft.Network/virtualNetworks/virtualNetworkPeerings/read",
     "Microsoft.Network/webApplicationFirewallPolicies/read",
     "Microsoft.Operationalinsights/dataExports/read",
     "Microsoft.Operationalinsights/linkedServices/read",
-    "Microsoft.Operationalinsights/queries/read",
-    "Microsoft.Operationalinsights/queryPacks/read",
-    "Microsoft.Operationalinsights/tables/read",
     "Microsoft.Operationalinsights/workspaces/read",
     "Microsoft.Privatedns/privateZones/read",
     "Microsoft.Privatedns/virtualNetworkLinks/read",
@@ -98,35 +87,34 @@
     "Microsoft.ServiceBus/queues/read",
     "Microsoft.ServiceBus/subscriptions/read",
     "Microsoft.ServiceBus/topics/read",
-    "Microsoft.Sql/backupShortTermRetentionPolicies/read",
-    "Microsoft.Sql/databaseAdvancedThreatProtectionSettings/read",
-    "Microsoft.Sql/databaseBlobAuditingPolicies/read",
-    "Microsoft.Sql/databaseSecurityAlertPolicies/read",
-    "Microsoft.Sql/databaseUsages/read",
-    "Microsoft.Sql/databases/read",
-    "Microsoft.Sql/encryptionProtectors/read",
-    "Microsoft.Sql/firewallRules/read",
-    "Microsoft.Sql/longTermRetentionPolicies/read",
-    "Microsoft.Sql/serverAdvancedThreatProtectionSettings/read",
-    "Microsoft.Sql/serverAzureADAdministrators/read",
-    "Microsoft.Sql/serverAzureADOnlyAuthentications/read",
-    "Microsoft.Sql/serverBlobAuditingPolicies/read",
-    "Microsoft.Sql/serverConnectionPolicies/read",
-    "Microsoft.Sql/serverSecurityAlertPolicies/read",
-    "Microsoft.Sql/serverVulnerabilityAssessments/read",
+    "Microsoft.Sql/servers/administrators/read",
+    "Microsoft.Sql/servers/advancedThreatProtectionSettings/read",
+    "Microsoft.Sql/servers/auditingSettings/read",
+    "Microsoft.Sql/servers/azureADOnlyAuthentications/read",
+    "Microsoft.Sql/servers/connectionPolicies/read",
+    "Microsoft.Sql/servers/databases/advancedThreatProtectionSettings/read",
+    "Microsoft.Sql/servers/databases/auditingSettings/read",
+    "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/read",
+    "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/read",
+    "Microsoft.Sql/servers/databases/read",
+    "Microsoft.Sql/servers/databases/securityAlertPolicies/read",
+    "Microsoft.Sql/servers/databases/transparentDataEncryption/read",
+    "Microsoft.Sql/servers/databases/usages/read",
+    "Microsoft.Sql/servers/encryptionProtector/read",
+    "Microsoft.Sql/servers/firewallRules/read",
     "Microsoft.Sql/servers/read",
-    "Microsoft.Sql/transparentDataEncryptions/read",
-    "Microsoft.Sql/virtualNetworkRules/read",
-    "Microsoft.Storage/accounts/read",
-    "Microsoft.Storage/blobContainers/read",
+    "Microsoft.Sql/servers/securityAlertPolicies/read",
+    "Microsoft.Sql/servers/virtualNetworkRules/read",
+    "Microsoft.Sql/servers/vulnerabilityAssessments/read",
     "Microsoft.Storage/encryptionScopes/read",
-    "Microsoft.Storage/localUsers/read",
     "Microsoft.Storage/managementPolicies/read",
+    "Microsoft.Storage/storageAccounts/blobServices/containers/read",
+    "Microsoft.Storage/storageAccounts/read",
     "Microsoft.Synapse/workspaces/read",
     "Microsoft.Web/certificates/read",
-    "Microsoft.Web/environments/read",
-    "Microsoft.Web/plans/read",
-    "Microsoft.Web/webApps/read"
+    "Microsoft.Web/hostingEnvironments/read",
+    "Microsoft.Web/serverfarms/read",
+    "Microsoft.Web/sites/read"
   ],
   "details": [
     {
@@ -134,18 +122,6 @@
       "service": "Microsoft.Advisor",
       "action": "NewListPager",
       "source_file": "advisor.go"
-    },
-    {
-      "permission": "Microsoft.Authorization/classicAdministrators/read",
-      "service": "Microsoft.Authorization",
-      "action": "NewListPager",
-      "source_file": "iam.go"
-    },
-    {
-      "permission": "Microsoft.Authorization/denyAssignments/read",
-      "service": "Microsoft.Authorization",
-      "action": "NewListPager",
-      "source_file": "iam.go"
     },
     {
       "permission": "Microsoft.Authorization/roleAssignments/read",
@@ -160,25 +136,25 @@
       "source_file": "iam.go"
     },
     {
-      "permission": "Microsoft.Batch/account/read",
-      "service": "Microsoft.Batch",
-      "action": "NewListPager",
-      "source_file": "batch.go"
-    },
-    {
-      "permission": "Microsoft.Batch/pool/read",
+      "permission": "Microsoft.Batch/batchAccounts/pools/read",
       "service": "Microsoft.Batch",
       "action": "NewListByBatchAccountPager",
       "source_file": "batch.go"
     },
     {
-      "permission": "Microsoft.Cache/firewallRules/read",
+      "permission": "Microsoft.Batch/batchAccounts/read",
+      "service": "Microsoft.Batch",
+      "action": "NewListPager",
+      "source_file": "batch.go"
+    },
+    {
+      "permission": "Microsoft.Cache/redis/firewallRules/read",
       "service": "Microsoft.Cache",
       "action": "NewListPager",
       "source_file": "redis.go"
     },
     {
-      "permission": "Microsoft.Cache/patchSchedules/read",
+      "permission": "Microsoft.Cache/redis/patchSchedules/read",
       "service": "Microsoft.Cache",
       "action": "NewListByRedisResourcePager",
       "source_file": "redis.go"
@@ -214,12 +190,6 @@
       "source_file": "frontdoor.go"
     },
     {
-      "permission": "Microsoft.Cdn/routes/read",
-      "service": "Microsoft.Cdn",
-      "action": "NewListByEndpointPager",
-      "source_file": "frontdoor.go"
-    },
-    {
       "permission": "Microsoft.Compute/diskAccesses/read",
       "service": "Microsoft.Compute",
       "action": "NewListPager",
@@ -234,7 +204,7 @@
     {
       "permission": "Microsoft.Compute/disks/read",
       "service": "Microsoft.Compute",
-      "action": "NewListPager",
+      "action": "Get",
       "source_file": "compute.go"
     },
     {
@@ -242,24 +212,6 @@
       "service": "Microsoft.Compute",
       "action": "NewListAllPager",
       "source_file": "compute.go"
-    },
-    {
-      "permission": "Microsoft.ContainerRegistry/cacheRules/read",
-      "service": "Microsoft.ContainerRegistry",
-      "action": "NewListPager",
-      "source_file": "containerregistry.go"
-    },
-    {
-      "permission": "Microsoft.ContainerRegistry/connectedRegistries/read",
-      "service": "Microsoft.ContainerRegistry",
-      "action": "NewListPager",
-      "source_file": "containerregistry.go"
-    },
-    {
-      "permission": "Microsoft.ContainerRegistry/credentialSets/read",
-      "service": "Microsoft.ContainerRegistry",
-      "action": "NewListPager",
-      "source_file": "containerregistry.go"
     },
     {
       "permission": "Microsoft.ContainerRegistry/replications/read",
@@ -270,7 +222,7 @@
     {
       "permission": "Microsoft.ContainerRegistry/scopeMaps/read",
       "service": "Microsoft.ContainerRegistry",
-      "action": "NewListPager",
+      "action": "Get",
       "source_file": "containerregistry.go"
     },
     {
@@ -292,25 +244,19 @@
       "source_file": "aks.go"
     },
     {
-      "permission": "Microsoft.Cosmosforpostgresql/clusters/read",
-      "service": "Microsoft.Cosmosforpostgresql",
-      "action": "NewListPager",
-      "source_file": "cosmosdb.go"
-    },
-    {
-      "permission": "Microsoft.DBforMySQL/configurations/read",
-      "service": "Microsoft.DBforMySQL",
-      "action": "Get",
-      "source_file": "mysql.go"
-    },
-    {
-      "permission": "Microsoft.DBforMySQL/databases/read",
+      "permission": "Microsoft.DBforMySQL/servers/configurations/read",
       "service": "Microsoft.DBforMySQL",
       "action": "NewListByServerPager",
       "source_file": "mysql.go"
     },
     {
-      "permission": "Microsoft.DBforMySQL/firewallRules/read",
+      "permission": "Microsoft.DBforMySQL/servers/databases/read",
+      "service": "Microsoft.DBforMySQL",
+      "action": "NewListByServerPager",
+      "source_file": "mysql.go"
+    },
+    {
+      "permission": "Microsoft.DBforMySQL/servers/firewallRules/read",
       "service": "Microsoft.DBforMySQL",
       "action": "NewListByServerPager",
       "source_file": "mysql.go"
@@ -322,25 +268,25 @@
       "source_file": "mysql.go"
     },
     {
-      "permission": "Microsoft.DBforPostgreSQL/advancedThreatProtectionSettings/read",
+      "permission": "Microsoft.DBforPostgreSQL/serverGroupsv2/read",
       "service": "Microsoft.DBforPostgreSQL",
-      "action": "Get",
-      "source_file": "postgresql.go"
+      "action": "NewListPager",
+      "source_file": "cosmosdb.go"
     },
     {
-      "permission": "Microsoft.DBforPostgreSQL/configurations/read",
-      "service": "Microsoft.DBforPostgreSQL",
-      "action": "NewListByServerPager",
-      "source_file": "postgresql.go"
-    },
-    {
-      "permission": "Microsoft.DBforPostgreSQL/databases/read",
+      "permission": "Microsoft.DBforPostgreSQL/servers/configurations/read",
       "service": "Microsoft.DBforPostgreSQL",
       "action": "NewListByServerPager",
       "source_file": "postgresql.go"
     },
     {
-      "permission": "Microsoft.DBforPostgreSQL/firewallRules/read",
+      "permission": "Microsoft.DBforPostgreSQL/servers/databases/read",
+      "service": "Microsoft.DBforPostgreSQL",
+      "action": "NewListByServerPager",
+      "source_file": "postgresql.go"
+    },
+    {
+      "permission": "Microsoft.DBforPostgreSQL/servers/firewallRules/read",
       "service": "Microsoft.DBforPostgreSQL",
       "action": "NewListByServerPager",
       "source_file": "postgresql.go"
@@ -348,20 +294,20 @@
     {
       "permission": "Microsoft.DBforPostgreSQL/servers/read",
       "service": "Microsoft.DBforPostgreSQL",
-      "action": "NewListBySubscriptionPager",
+      "action": "NewListPager",
       "source_file": "postgresql.go"
+    },
+    {
+      "permission": "Microsoft.DataFactory/factories/read",
+      "service": "Microsoft.DataFactory",
+      "action": "NewListPager",
+      "source_file": "datafactory.go"
     },
     {
       "permission": "Microsoft.Databricks/workspaces/read",
       "service": "Microsoft.Databricks",
       "action": "NewListBySubscriptionPager",
       "source_file": "databricks.go"
-    },
-    {
-      "permission": "Microsoft.Datafactory/factories/read",
-      "service": "Microsoft.Datafactory",
-      "action": "NewListPager",
-      "source_file": "datafactory.go"
     },
     {
       "permission": "Microsoft.Dns/recordSets/read",
@@ -432,7 +378,7 @@
     {
       "permission": "Microsoft.KeyVault/vaults/read",
       "service": "Microsoft.KeyVault",
-      "action": "NewListPager",
+      "action": "Get",
       "source_file": "keyvault.go"
     },
     {
@@ -444,7 +390,7 @@
     {
       "permission": "Microsoft.Network/applicationGateways/read",
       "service": "Microsoft.Network",
-      "action": "Get",
+      "action": "NewListAllPager",
       "source_file": "network.go"
     },
     {
@@ -456,11 +402,17 @@
     {
       "permission": "Microsoft.Network/azureFirewalls/read",
       "service": "Microsoft.Network",
-      "action": "Get",
+      "action": "NewListAllPager",
       "source_file": "network.go"
     },
     {
       "permission": "Microsoft.Network/bastionHosts/read",
+      "service": "Microsoft.Network",
+      "action": "NewListPager",
+      "source_file": "network.go"
+    },
+    {
+      "permission": "Microsoft.Network/connections/read",
       "service": "Microsoft.Network",
       "action": "NewListPager",
       "source_file": "network.go"
@@ -478,24 +430,6 @@
       "source_file": "network.go"
     },
     {
-      "permission": "Microsoft.Network/flowLogs/read",
-      "service": "Microsoft.Network",
-      "action": "NewListPager",
-      "source_file": "network.go"
-    },
-    {
-      "permission": "Microsoft.Network/interfaces/read",
-      "service": "Microsoft.Network",
-      "action": "Get",
-      "source_file": "compute.go"
-    },
-    {
-      "permission": "Microsoft.Network/interfaces/read",
-      "service": "Microsoft.Network",
-      "action": "NewListAllPager",
-      "source_file": "network.go"
-    },
-    {
       "permission": "Microsoft.Network/loadBalancers/read",
       "service": "Microsoft.Network",
       "action": "NewListAllPager",
@@ -508,9 +442,33 @@
       "source_file": "network.go"
     },
     {
-      "permission": "Microsoft.Network/privateDNSZoneGroups/read",
+      "permission": "Microsoft.Network/networkInterfaces/read",
+      "service": "Microsoft.Network",
+      "action": "Get",
+      "source_file": "compute.go"
+    },
+    {
+      "permission": "Microsoft.Network/networkInterfaces/read",
+      "service": "Microsoft.Network",
+      "action": "NewListAllPager",
+      "source_file": "network.go"
+    },
+    {
+      "permission": "Microsoft.Network/networkSecurityGroups/read",
+      "service": "Microsoft.Network",
+      "action": "NewListAllPager",
+      "source_file": "network.go"
+    },
+    {
+      "permission": "Microsoft.Network/networkWatchers/flowLogs/read",
       "service": "Microsoft.Network",
       "action": "NewListPager",
+      "source_file": "network.go"
+    },
+    {
+      "permission": "Microsoft.Network/networkWatchers/read",
+      "service": "Microsoft.Network",
+      "action": "NewListAllPager",
       "source_file": "network.go"
     },
     {
@@ -538,25 +496,7 @@
       "source_file": "network.go"
     },
     {
-      "permission": "Microsoft.Network/securityGroups/read",
-      "service": "Microsoft.Network",
-      "action": "NewListAllPager",
-      "source_file": "network.go"
-    },
-    {
       "permission": "Microsoft.Network/serviceEndpointPolicies/read",
-      "service": "Microsoft.Network",
-      "action": "NewListPager",
-      "source_file": "network.go"
-    },
-    {
-      "permission": "Microsoft.Network/subnets/read",
-      "service": "Microsoft.Network",
-      "action": "Get",
-      "source_file": "network.go"
-    },
-    {
-      "permission": "Microsoft.Network/virtualNetworkGatewayConnections/read",
       "service": "Microsoft.Network",
       "action": "NewListPager",
       "source_file": "network.go"
@@ -568,27 +508,27 @@
       "source_file": "network.go"
     },
     {
-      "permission": "Microsoft.Network/virtualNetworkPeerings/read",
+      "permission": "Microsoft.Network/virtualNetworks/read",
+      "service": "Microsoft.Network",
+      "action": "Get",
+      "source_file": "network.go"
+    },
+    {
+      "permission": "Microsoft.Network/virtualNetworks/subnets/read",
+      "service": "Microsoft.Network",
+      "action": "Get",
+      "source_file": "network.go"
+    },
+    {
+      "permission": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings/read",
       "service": "Microsoft.Network",
       "action": "NewListPager",
       "source_file": "network.go"
     },
     {
-      "permission": "Microsoft.Network/virtualNetworks/read",
-      "service": "Microsoft.Network",
-      "action": "NewListAllPager",
-      "source_file": "network.go"
-    },
-    {
-      "permission": "Microsoft.Network/watchers/read",
-      "service": "Microsoft.Network",
-      "action": "NewListAllPager",
-      "source_file": "network.go"
-    },
-    {
       "permission": "Microsoft.Network/webApplicationFirewallPolicies/read",
       "service": "Microsoft.Network",
-      "action": "Get",
+      "action": "NewListAllPager",
       "source_file": "network.go"
     },
     {
@@ -599,24 +539,6 @@
     },
     {
       "permission": "Microsoft.Operationalinsights/linkedServices/read",
-      "service": "Microsoft.Operationalinsights",
-      "action": "NewListByWorkspacePager",
-      "source_file": "loganalytics.go"
-    },
-    {
-      "permission": "Microsoft.Operationalinsights/queries/read",
-      "service": "Microsoft.Operationalinsights",
-      "action": "NewListPager",
-      "source_file": "loganalytics.go"
-    },
-    {
-      "permission": "Microsoft.Operationalinsights/queryPacks/read",
-      "service": "Microsoft.Operationalinsights",
-      "action": "NewListPager",
-      "source_file": "loganalytics.go"
-    },
-    {
-      "permission": "Microsoft.Operationalinsights/tables/read",
       "service": "Microsoft.Operationalinsights",
       "action": "NewListByWorkspacePager",
       "source_file": "loganalytics.go"
@@ -724,99 +646,93 @@
       "source_file": "servicebus.go"
     },
     {
-      "permission": "Microsoft.Sql/backupShortTermRetentionPolicies/read",
+      "permission": "Microsoft.Sql/servers/administrators/read",
+      "service": "Microsoft.Sql",
+      "action": "NewListByServerPager",
+      "source_file": "sql.go"
+    },
+    {
+      "permission": "Microsoft.Sql/servers/advancedThreatProtectionSettings/read",
       "service": "Microsoft.Sql",
       "action": "Get",
       "source_file": "sql.go"
     },
     {
-      "permission": "Microsoft.Sql/databaseAdvancedThreatProtectionSettings/read",
+      "permission": "Microsoft.Sql/servers/auditingSettings/read",
       "service": "Microsoft.Sql",
       "action": "Get",
       "source_file": "sql.go"
     },
     {
-      "permission": "Microsoft.Sql/databaseBlobAuditingPolicies/read",
+      "permission": "Microsoft.Sql/servers/azureADOnlyAuthentications/read",
       "service": "Microsoft.Sql",
       "action": "Get",
       "source_file": "sql.go"
     },
     {
-      "permission": "Microsoft.Sql/databaseSecurityAlertPolicies/read",
+      "permission": "Microsoft.Sql/servers/connectionPolicies/read",
       "service": "Microsoft.Sql",
       "action": "Get",
       "source_file": "sql.go"
     },
     {
-      "permission": "Microsoft.Sql/databaseUsages/read",
+      "permission": "Microsoft.Sql/servers/databases/advancedThreatProtectionSettings/read",
+      "service": "Microsoft.Sql",
+      "action": "Get",
+      "source_file": "sql.go"
+    },
+    {
+      "permission": "Microsoft.Sql/servers/databases/auditingSettings/read",
+      "service": "Microsoft.Sql",
+      "action": "Get",
+      "source_file": "sql.go"
+    },
+    {
+      "permission": "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies/read",
+      "service": "Microsoft.Sql",
+      "action": "Get",
+      "source_file": "sql.go"
+    },
+    {
+      "permission": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies/read",
+      "service": "Microsoft.Sql",
+      "action": "Get",
+      "source_file": "sql.go"
+    },
+    {
+      "permission": "Microsoft.Sql/servers/databases/read",
+      "service": "Microsoft.Sql",
+      "action": "NewListByServerPager",
+      "source_file": "sql.go"
+    },
+    {
+      "permission": "Microsoft.Sql/servers/databases/securityAlertPolicies/read",
+      "service": "Microsoft.Sql",
+      "action": "Get",
+      "source_file": "sql.go"
+    },
+    {
+      "permission": "Microsoft.Sql/servers/databases/transparentDataEncryption/read",
+      "service": "Microsoft.Sql",
+      "action": "Get",
+      "source_file": "sql.go"
+    },
+    {
+      "permission": "Microsoft.Sql/servers/databases/usages/read",
       "service": "Microsoft.Sql",
       "action": "NewListByDatabasePager",
       "source_file": "sql.go"
     },
     {
-      "permission": "Microsoft.Sql/databases/read",
+      "permission": "Microsoft.Sql/servers/encryptionProtector/read",
+      "service": "Microsoft.Sql",
+      "action": "Get",
+      "source_file": "sql.go"
+    },
+    {
+      "permission": "Microsoft.Sql/servers/firewallRules/read",
       "service": "Microsoft.Sql",
       "action": "NewListByServerPager",
-      "source_file": "sql.go"
-    },
-    {
-      "permission": "Microsoft.Sql/encryptionProtectors/read",
-      "service": "Microsoft.Sql",
-      "action": "Get",
-      "source_file": "sql.go"
-    },
-    {
-      "permission": "Microsoft.Sql/firewallRules/read",
-      "service": "Microsoft.Sql",
-      "action": "NewListByServerPager",
-      "source_file": "sql.go"
-    },
-    {
-      "permission": "Microsoft.Sql/longTermRetentionPolicies/read",
-      "service": "Microsoft.Sql",
-      "action": "Get",
-      "source_file": "sql.go"
-    },
-    {
-      "permission": "Microsoft.Sql/serverAdvancedThreatProtectionSettings/read",
-      "service": "Microsoft.Sql",
-      "action": "Get",
-      "source_file": "sql.go"
-    },
-    {
-      "permission": "Microsoft.Sql/serverAzureADAdministrators/read",
-      "service": "Microsoft.Sql",
-      "action": "NewListByServerPager",
-      "source_file": "sql.go"
-    },
-    {
-      "permission": "Microsoft.Sql/serverAzureADOnlyAuthentications/read",
-      "service": "Microsoft.Sql",
-      "action": "Get",
-      "source_file": "sql.go"
-    },
-    {
-      "permission": "Microsoft.Sql/serverBlobAuditingPolicies/read",
-      "service": "Microsoft.Sql",
-      "action": "Get",
-      "source_file": "sql.go"
-    },
-    {
-      "permission": "Microsoft.Sql/serverConnectionPolicies/read",
-      "service": "Microsoft.Sql",
-      "action": "Get",
-      "source_file": "sql.go"
-    },
-    {
-      "permission": "Microsoft.Sql/serverSecurityAlertPolicies/read",
-      "service": "Microsoft.Sql",
-      "action": "Get",
-      "source_file": "sql.go"
-    },
-    {
-      "permission": "Microsoft.Sql/serverVulnerabilityAssessments/read",
-      "service": "Microsoft.Sql",
-      "action": "Get",
       "source_file": "sql.go"
     },
     {
@@ -826,28 +742,22 @@
       "source_file": "sql.go"
     },
     {
-      "permission": "Microsoft.Sql/transparentDataEncryptions/read",
+      "permission": "Microsoft.Sql/servers/securityAlertPolicies/read",
       "service": "Microsoft.Sql",
       "action": "Get",
       "source_file": "sql.go"
     },
     {
-      "permission": "Microsoft.Sql/virtualNetworkRules/read",
+      "permission": "Microsoft.Sql/servers/virtualNetworkRules/read",
       "service": "Microsoft.Sql",
       "action": "NewListByServerPager",
       "source_file": "sql.go"
     },
     {
-      "permission": "Microsoft.Storage/accounts/read",
-      "service": "Microsoft.Storage",
-      "action": "NewListPager",
-      "source_file": "storage.go"
-    },
-    {
-      "permission": "Microsoft.Storage/blobContainers/read",
-      "service": "Microsoft.Storage",
+      "permission": "Microsoft.Sql/servers/vulnerabilityAssessments/read",
+      "service": "Microsoft.Sql",
       "action": "Get",
-      "source_file": "storage.go"
+      "source_file": "sql.go"
     },
     {
       "permission": "Microsoft.Storage/encryptionScopes/read",
@@ -856,15 +766,21 @@
       "source_file": "storage.go"
     },
     {
-      "permission": "Microsoft.Storage/localUsers/read",
+      "permission": "Microsoft.Storage/managementPolicies/read",
+      "service": "Microsoft.Storage",
+      "action": "Get",
+      "source_file": "storage.go"
+    },
+    {
+      "permission": "Microsoft.Storage/storageAccounts/blobServices/containers/read",
       "service": "Microsoft.Storage",
       "action": "NewListPager",
       "source_file": "storage.go"
     },
     {
-      "permission": "Microsoft.Storage/managementPolicies/read",
+      "permission": "Microsoft.Storage/storageAccounts/read",
       "service": "Microsoft.Storage",
-      "action": "Get",
+      "action": "NewListPager",
       "source_file": "storage.go"
     },
     {
@@ -880,25 +796,25 @@
       "source_file": "web.go"
     },
     {
-      "permission": "Microsoft.Web/environments/read",
+      "permission": "Microsoft.Web/hostingEnvironments/read",
       "service": "Microsoft.Web",
       "action": "NewListPager",
       "source_file": "web.go"
     },
     {
-      "permission": "Microsoft.Web/plans/read",
+      "permission": "Microsoft.Web/serverfarms/read",
       "service": "Microsoft.Web",
       "action": "NewListPager",
       "source_file": "web.go"
     },
     {
-      "permission": "Microsoft.Web/webApps/read",
+      "permission": "Microsoft.Web/sites/read",
       "service": "Microsoft.Web",
       "action": "NewListFunctionsPager",
       "source_file": "functions.go"
     },
     {
-      "permission": "Microsoft.Web/webApps/read",
+      "permission": "Microsoft.Web/sites/read",
       "service": "Microsoft.Web",
       "action": "NewListSlotsPager",
       "source_file": "web.go"

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,33 +1,40 @@
 {
   "provider": "azure",
   "version": "13.5.0",
-  "generated_at": "2026-04-24T22:26:35-07:00",
+  "generated_at": "2026-04-27T09:18:23-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
+    "Microsoft.Authorization/classicAdministrators/read",
+    "Microsoft.Authorization/denyAssignments/read",
     "Microsoft.Authorization/roleAssignments/read",
     "Microsoft.Authorization/roleDefinitions/read",
     "Microsoft.Batch/batchAccounts/pools/read",
     "Microsoft.Batch/batchAccounts/read",
     "Microsoft.Cache/redis/firewallRules/read",
     "Microsoft.Cache/redis/patchSchedules/read",
-    "Microsoft.Cdn/aFDCustomDomains/read",
-    "Microsoft.Cdn/aFDEndpoints/read",
-    "Microsoft.Cdn/aFDOriginGroups/read",
-    "Microsoft.Cdn/aFDOrigins/read",
+    "Microsoft.Cdn/profiles/afdendpoints/read",
+    "Microsoft.Cdn/profiles/customdomains/read",
+    "Microsoft.Cdn/profiles/origingroups/origins/read",
+    "Microsoft.Cdn/profiles/origingroups/read",
     "Microsoft.Cdn/profiles/read",
+    "Microsoft.Cdn/routes/read",
     "Microsoft.Compute/diskAccesses/read",
     "Microsoft.Compute/diskEncryptionSets/read",
     "Microsoft.Compute/disks/read",
     "Microsoft.Compute/virtualMachines/read",
-    "Microsoft.ContainerRegistry/replications/read",
-    "Microsoft.ContainerRegistry/scopeMaps/read",
-    "Microsoft.ContainerRegistry/tokens/read",
-    "Microsoft.ContainerRegistry/webhooks/read",
+    "Microsoft.ContainerRegistry/cacheRules/read",
+    "Microsoft.ContainerRegistry/connectedRegistries/read",
+    "Microsoft.ContainerRegistry/credentialSets/read",
+    "Microsoft.ContainerRegistry/registries/replications/read",
+    "Microsoft.ContainerRegistry/registries/scopeMaps/read",
+    "Microsoft.ContainerRegistry/registries/tokens/read",
+    "Microsoft.ContainerRegistry/registries/webhooks/read",
     "Microsoft.ContainerService/managedClusters/read",
     "Microsoft.DBforMySQL/servers/configurations/read",
     "Microsoft.DBforMySQL/servers/databases/read",
     "Microsoft.DBforMySQL/servers/firewallRules/read",
     "Microsoft.DBforMySQL/servers/read",
+    "Microsoft.DBforPostgreSQL/advancedThreatProtectionSettings/read",
     "Microsoft.DBforPostgreSQL/serverGroupsv2/read",
     "Microsoft.DBforPostgreSQL/servers/configurations/read",
     "Microsoft.DBforPostgreSQL/servers/databases/read",
@@ -35,11 +42,9 @@
     "Microsoft.DBforPostgreSQL/servers/read",
     "Microsoft.DataFactory/factories/read",
     "Microsoft.Databricks/workspaces/read",
-    "Microsoft.Dns/recordSets/read",
-    "Microsoft.Dns/zones/read",
     "Microsoft.DocumentDB/databaseAccounts/read",
-    "Microsoft.EventHub/consumerGroups/read",
-    "Microsoft.EventHub/eventHubs/read",
+    "Microsoft.EventHub/namespaces/eventHubs/consumergroups/read",
+    "Microsoft.EventHub/namespaces/eventhubs/read",
     "Microsoft.EventHub/namespaces/read",
     "Microsoft.Insights/activityLogAlerts/read",
     "Microsoft.Insights/components/read",
@@ -48,12 +53,15 @@
     "Microsoft.KeyVault/managedHsms/read",
     "Microsoft.KeyVault/vaults/read",
     "Microsoft.ManagedIdentity/userAssignedIdentities/read",
+    "Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/read",
     "Microsoft.Network/applicationGateways/read",
     "Microsoft.Network/applicationSecurityGroups/read",
     "Microsoft.Network/azureFirewalls/read",
     "Microsoft.Network/bastionHosts/read",
     "Microsoft.Network/connections/read",
     "Microsoft.Network/ddosProtectionPlans/read",
+    "Microsoft.Network/dnszones/read",
+    "Microsoft.Network/dnszones/recordsets/read",
     "Microsoft.Network/firewallPolicies/read",
     "Microsoft.Network/loadBalancers/read",
     "Microsoft.Network/natGateways/read",
@@ -61,6 +69,9 @@
     "Microsoft.Network/networkSecurityGroups/read",
     "Microsoft.Network/networkWatchers/flowLogs/read",
     "Microsoft.Network/networkWatchers/read",
+    "Microsoft.Network/privateDNSZoneGroups/read",
+    "Microsoft.Network/privateDnsZones/read",
+    "Microsoft.Network/privateDnsZones/virtualNetworkLinks/read",
     "Microsoft.Network/privateEndpoints/read",
     "Microsoft.Network/publicIPAddresses/read",
     "Microsoft.Network/routeTables/read",
@@ -69,24 +80,24 @@
     "Microsoft.Network/virtualNetworks/read",
     "Microsoft.Network/virtualNetworks/subnets/read",
     "Microsoft.Network/virtualNetworks/virtualNetworkPeerings/read",
-    "Microsoft.Network/webApplicationFirewallPolicies/read",
-    "Microsoft.Operationalinsights/dataExports/read",
-    "Microsoft.Operationalinsights/linkedServices/read",
-    "Microsoft.Operationalinsights/workspaces/read",
-    "Microsoft.Privatedns/privateZones/read",
-    "Microsoft.Privatedns/virtualNetworkLinks/read",
-    "Microsoft.Recoveryservices/backupPolicies/read",
-    "Microsoft.Recoveryservices/backupProtectedItems/read",
-    "Microsoft.Recoveryservices/backupResourceVaultConfigs/read",
-    "Microsoft.Recoveryservices/vaults/read",
-    "Microsoft.Resources/resourceGroups/read",
+    "Microsoft.OperationalInsights/queries/read",
+    "Microsoft.OperationalInsights/queryPacks/read",
+    "Microsoft.OperationalInsights/tables/read",
+    "Microsoft.OperationalInsights/workspaces/dataexports/read",
+    "Microsoft.OperationalInsights/workspaces/linkedservices/read",
+    "Microsoft.OperationalInsights/workspaces/read",
+    "Microsoft.RecoveryServices/Vaults/backupPolicies/read",
+    "Microsoft.RecoveryServices/Vaults/backupProtectedItems/read",
+    "Microsoft.RecoveryServices/Vaults/backupconfig/read",
+    "Microsoft.RecoveryServices/vaults/read",
     "Microsoft.Resources/resources/read",
     "Microsoft.Resources/subscriptions/read",
+    "Microsoft.Resources/subscriptions/resourceGroups/read",
     "Microsoft.Security/autoProvisioningSettings/read",
+    "Microsoft.ServiceBus/namespaces/queues/read",
     "Microsoft.ServiceBus/namespaces/read",
-    "Microsoft.ServiceBus/queues/read",
-    "Microsoft.ServiceBus/subscriptions/read",
-    "Microsoft.ServiceBus/topics/read",
+    "Microsoft.ServiceBus/namespaces/topics/read",
+    "Microsoft.ServiceBus/namespaces/topics/subscriptions/read",
     "Microsoft.Sql/servers/administrators/read",
     "Microsoft.Sql/servers/advancedThreatProtectionSettings/read",
     "Microsoft.Sql/servers/auditingSettings/read",
@@ -106,9 +117,10 @@
     "Microsoft.Sql/servers/securityAlertPolicies/read",
     "Microsoft.Sql/servers/virtualNetworkRules/read",
     "Microsoft.Sql/servers/vulnerabilityAssessments/read",
-    "Microsoft.Storage/encryptionScopes/read",
-    "Microsoft.Storage/managementPolicies/read",
+    "Microsoft.Storage/localUsers/read",
     "Microsoft.Storage/storageAccounts/blobServices/containers/read",
+    "Microsoft.Storage/storageAccounts/encryptionScopes/read",
+    "Microsoft.Storage/storageAccounts/managementPolicies/read",
     "Microsoft.Storage/storageAccounts/read",
     "Microsoft.Synapse/workspaces/read",
     "Microsoft.Web/certificates/read",
@@ -122,6 +134,18 @@
       "service": "Microsoft.Advisor",
       "action": "NewListPager",
       "source_file": "advisor.go"
+    },
+    {
+      "permission": "Microsoft.Authorization/classicAdministrators/read",
+      "service": "Microsoft.Authorization",
+      "action": "NewListPager",
+      "source_file": "iam.go"
+    },
+    {
+      "permission": "Microsoft.Authorization/denyAssignments/read",
+      "service": "Microsoft.Authorization",
+      "action": "NewListPager",
+      "source_file": "iam.go"
     },
     {
       "permission": "Microsoft.Authorization/roleAssignments/read",
@@ -160,33 +184,39 @@
       "source_file": "redis.go"
     },
     {
-      "permission": "Microsoft.Cdn/aFDCustomDomains/read",
+      "permission": "Microsoft.Cdn/profiles/afdendpoints/read",
       "service": "Microsoft.Cdn",
       "action": "NewListByProfilePager",
       "source_file": "frontdoor.go"
     },
     {
-      "permission": "Microsoft.Cdn/aFDEndpoints/read",
+      "permission": "Microsoft.Cdn/profiles/customdomains/read",
       "service": "Microsoft.Cdn",
       "action": "NewListByProfilePager",
       "source_file": "frontdoor.go"
     },
     {
-      "permission": "Microsoft.Cdn/aFDOriginGroups/read",
-      "service": "Microsoft.Cdn",
-      "action": "NewListByProfilePager",
-      "source_file": "frontdoor.go"
-    },
-    {
-      "permission": "Microsoft.Cdn/aFDOrigins/read",
+      "permission": "Microsoft.Cdn/profiles/origingroups/origins/read",
       "service": "Microsoft.Cdn",
       "action": "NewListByOriginGroupPager",
+      "source_file": "frontdoor.go"
+    },
+    {
+      "permission": "Microsoft.Cdn/profiles/origingroups/read",
+      "service": "Microsoft.Cdn",
+      "action": "NewListByProfilePager",
       "source_file": "frontdoor.go"
     },
     {
       "permission": "Microsoft.Cdn/profiles/read",
       "service": "Microsoft.Cdn",
       "action": "NewListPager",
+      "source_file": "frontdoor.go"
+    },
+    {
+      "permission": "Microsoft.Cdn/routes/read",
+      "service": "Microsoft.Cdn",
+      "action": "NewListByEndpointPager",
       "source_file": "frontdoor.go"
     },
     {
@@ -204,7 +234,7 @@
     {
       "permission": "Microsoft.Compute/disks/read",
       "service": "Microsoft.Compute",
-      "action": "Get",
+      "action": "NewListPager",
       "source_file": "compute.go"
     },
     {
@@ -214,25 +244,43 @@
       "source_file": "compute.go"
     },
     {
-      "permission": "Microsoft.ContainerRegistry/replications/read",
+      "permission": "Microsoft.ContainerRegistry/cacheRules/read",
       "service": "Microsoft.ContainerRegistry",
       "action": "NewListPager",
       "source_file": "containerregistry.go"
     },
     {
-      "permission": "Microsoft.ContainerRegistry/scopeMaps/read",
-      "service": "Microsoft.ContainerRegistry",
-      "action": "Get",
-      "source_file": "containerregistry.go"
-    },
-    {
-      "permission": "Microsoft.ContainerRegistry/tokens/read",
+      "permission": "Microsoft.ContainerRegistry/connectedRegistries/read",
       "service": "Microsoft.ContainerRegistry",
       "action": "NewListPager",
       "source_file": "containerregistry.go"
     },
     {
-      "permission": "Microsoft.ContainerRegistry/webhooks/read",
+      "permission": "Microsoft.ContainerRegistry/credentialSets/read",
+      "service": "Microsoft.ContainerRegistry",
+      "action": "NewListPager",
+      "source_file": "containerregistry.go"
+    },
+    {
+      "permission": "Microsoft.ContainerRegistry/registries/replications/read",
+      "service": "Microsoft.ContainerRegistry",
+      "action": "NewListPager",
+      "source_file": "containerregistry.go"
+    },
+    {
+      "permission": "Microsoft.ContainerRegistry/registries/scopeMaps/read",
+      "service": "Microsoft.ContainerRegistry",
+      "action": "NewListPager",
+      "source_file": "containerregistry.go"
+    },
+    {
+      "permission": "Microsoft.ContainerRegistry/registries/tokens/read",
+      "service": "Microsoft.ContainerRegistry",
+      "action": "NewListPager",
+      "source_file": "containerregistry.go"
+    },
+    {
+      "permission": "Microsoft.ContainerRegistry/registries/webhooks/read",
       "service": "Microsoft.ContainerRegistry",
       "action": "NewListPager",
       "source_file": "containerregistry.go"
@@ -266,6 +314,12 @@
       "service": "Microsoft.DBforMySQL",
       "action": "NewListPager",
       "source_file": "mysql.go"
+    },
+    {
+      "permission": "Microsoft.DBforPostgreSQL/advancedThreatProtectionSettings/read",
+      "service": "Microsoft.DBforPostgreSQL",
+      "action": "Get",
+      "source_file": "postgresql.go"
     },
     {
       "permission": "Microsoft.DBforPostgreSQL/serverGroupsv2/read",
@@ -310,31 +364,19 @@
       "source_file": "databricks.go"
     },
     {
-      "permission": "Microsoft.Dns/recordSets/read",
-      "service": "Microsoft.Dns",
-      "action": "NewListByDNSZonePager",
-      "source_file": "dns.go"
-    },
-    {
-      "permission": "Microsoft.Dns/zones/read",
-      "service": "Microsoft.Dns",
-      "action": "NewListPager",
-      "source_file": "dns.go"
-    },
-    {
       "permission": "Microsoft.DocumentDB/databaseAccounts/read",
       "service": "Microsoft.DocumentDB",
       "action": "NewListPager",
       "source_file": "cosmosdb.go"
     },
     {
-      "permission": "Microsoft.EventHub/consumerGroups/read",
+      "permission": "Microsoft.EventHub/namespaces/eventHubs/consumergroups/read",
       "service": "Microsoft.EventHub",
       "action": "NewListByEventHubPager",
       "source_file": "eventhub.go"
     },
     {
-      "permission": "Microsoft.EventHub/eventHubs/read",
+      "permission": "Microsoft.EventHub/namespaces/eventhubs/read",
       "service": "Microsoft.EventHub",
       "action": "NewListByNamespacePager",
       "source_file": "eventhub.go"
@@ -388,6 +430,12 @@
       "source_file": "iam.go"
     },
     {
+      "permission": "Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/read",
+      "service": "Microsoft.Network",
+      "action": "NewListAllPager",
+      "source_file": "network.go"
+    },
+    {
       "permission": "Microsoft.Network/applicationGateways/read",
       "service": "Microsoft.Network",
       "action": "NewListAllPager",
@@ -402,7 +450,7 @@
     {
       "permission": "Microsoft.Network/azureFirewalls/read",
       "service": "Microsoft.Network",
-      "action": "NewListAllPager",
+      "action": "Get",
       "source_file": "network.go"
     },
     {
@@ -424,6 +472,18 @@
       "source_file": "network.go"
     },
     {
+      "permission": "Microsoft.Network/dnszones/read",
+      "service": "Microsoft.Dns",
+      "action": "NewListPager",
+      "source_file": "dns.go"
+    },
+    {
+      "permission": "Microsoft.Network/dnszones/recordsets/read",
+      "service": "Microsoft.Dns",
+      "action": "NewListByDNSZonePager",
+      "source_file": "dns.go"
+    },
+    {
       "permission": "Microsoft.Network/firewallPolicies/read",
       "service": "Microsoft.Network",
       "action": "Get",
@@ -438,7 +498,7 @@
     {
       "permission": "Microsoft.Network/natGateways/read",
       "service": "Microsoft.Network",
-      "action": "Get",
+      "action": "NewListAllPager",
       "source_file": "network.go"
     },
     {
@@ -470,6 +530,24 @@
       "service": "Microsoft.Network",
       "action": "NewListAllPager",
       "source_file": "network.go"
+    },
+    {
+      "permission": "Microsoft.Network/privateDNSZoneGroups/read",
+      "service": "Microsoft.Network",
+      "action": "NewListPager",
+      "source_file": "network.go"
+    },
+    {
+      "permission": "Microsoft.Network/privateDnsZones/read",
+      "service": "Microsoft.Privatedns",
+      "action": "NewListPager",
+      "source_file": "dns.go"
+    },
+    {
+      "permission": "Microsoft.Network/privateDnsZones/virtualNetworkLinks/read",
+      "service": "Microsoft.Privatedns",
+      "action": "NewListPager",
+      "source_file": "dns.go"
     },
     {
       "permission": "Microsoft.Network/privateEndpoints/read",
@@ -526,70 +604,64 @@
       "source_file": "network.go"
     },
     {
-      "permission": "Microsoft.Network/webApplicationFirewallPolicies/read",
-      "service": "Microsoft.Network",
-      "action": "NewListAllPager",
-      "source_file": "network.go"
+      "permission": "Microsoft.OperationalInsights/queries/read",
+      "service": "Microsoft.OperationalInsights",
+      "action": "NewListPager",
+      "source_file": "loganalytics.go"
     },
     {
-      "permission": "Microsoft.Operationalinsights/dataExports/read",
-      "service": "Microsoft.Operationalinsights",
+      "permission": "Microsoft.OperationalInsights/queryPacks/read",
+      "service": "Microsoft.OperationalInsights",
+      "action": "NewListPager",
+      "source_file": "loganalytics.go"
+    },
+    {
+      "permission": "Microsoft.OperationalInsights/tables/read",
+      "service": "Microsoft.OperationalInsights",
       "action": "NewListByWorkspacePager",
       "source_file": "loganalytics.go"
     },
     {
-      "permission": "Microsoft.Operationalinsights/linkedServices/read",
-      "service": "Microsoft.Operationalinsights",
+      "permission": "Microsoft.OperationalInsights/workspaces/dataexports/read",
+      "service": "Microsoft.OperationalInsights",
       "action": "NewListByWorkspacePager",
       "source_file": "loganalytics.go"
     },
     {
-      "permission": "Microsoft.Operationalinsights/workspaces/read",
-      "service": "Microsoft.Operationalinsights",
+      "permission": "Microsoft.OperationalInsights/workspaces/linkedservices/read",
+      "service": "Microsoft.OperationalInsights",
+      "action": "NewListByWorkspacePager",
+      "source_file": "loganalytics.go"
+    },
+    {
+      "permission": "Microsoft.OperationalInsights/workspaces/read",
+      "service": "Microsoft.OperationalInsights",
       "action": "Get",
       "source_file": "loganalytics.go"
     },
     {
-      "permission": "Microsoft.Privatedns/privateZones/read",
-      "service": "Microsoft.Privatedns",
-      "action": "NewListPager",
-      "source_file": "dns.go"
-    },
-    {
-      "permission": "Microsoft.Privatedns/virtualNetworkLinks/read",
-      "service": "Microsoft.Privatedns",
-      "action": "NewListPager",
-      "source_file": "dns.go"
-    },
-    {
-      "permission": "Microsoft.Recoveryservices/backupPolicies/read",
-      "service": "Microsoft.Recoveryservices",
+      "permission": "Microsoft.RecoveryServices/Vaults/backupPolicies/read",
+      "service": "Microsoft.RecoveryServices",
       "action": "NewListPager",
       "source_file": "recoveryservices.go"
     },
     {
-      "permission": "Microsoft.Recoveryservices/backupProtectedItems/read",
-      "service": "Microsoft.Recoveryservices",
+      "permission": "Microsoft.RecoveryServices/Vaults/backupProtectedItems/read",
+      "service": "Microsoft.RecoveryServices",
       "action": "NewListPager",
       "source_file": "recoveryservices.go"
     },
     {
-      "permission": "Microsoft.Recoveryservices/backupResourceVaultConfigs/read",
-      "service": "Microsoft.Recoveryservices",
+      "permission": "Microsoft.RecoveryServices/Vaults/backupconfig/read",
+      "service": "Microsoft.RecoveryServices",
       "action": "Get",
       "source_file": "recoveryservices.go"
     },
     {
-      "permission": "Microsoft.Recoveryservices/vaults/read",
-      "service": "Microsoft.Recoveryservices",
+      "permission": "Microsoft.RecoveryServices/vaults/read",
+      "service": "Microsoft.RecoveryServices",
       "action": "NewListBySubscriptionIDPager",
       "source_file": "recoveryservices.go"
-    },
-    {
-      "permission": "Microsoft.Resources/resourceGroups/read",
-      "service": "Microsoft.Resources",
-      "action": "NewListPager",
-      "source_file": "resource_groups.go"
     },
     {
       "permission": "Microsoft.Resources/resources/read",
@@ -616,10 +688,22 @@
       "source_file": "subscription.go"
     },
     {
+      "permission": "Microsoft.Resources/subscriptions/resourceGroups/read",
+      "service": "Microsoft.Resources",
+      "action": "NewListPager",
+      "source_file": "resource_groups.go"
+    },
+    {
       "permission": "Microsoft.Security/autoProvisioningSettings/read",
       "service": "Microsoft.Security",
       "action": "Get",
       "source_file": "cloud_defender.go"
+    },
+    {
+      "permission": "Microsoft.ServiceBus/namespaces/queues/read",
+      "service": "Microsoft.ServiceBus",
+      "action": "NewListByNamespacePager",
+      "source_file": "servicebus.go"
     },
     {
       "permission": "Microsoft.ServiceBus/namespaces/read",
@@ -628,21 +712,15 @@
       "source_file": "servicebus.go"
     },
     {
-      "permission": "Microsoft.ServiceBus/queues/read",
+      "permission": "Microsoft.ServiceBus/namespaces/topics/read",
       "service": "Microsoft.ServiceBus",
       "action": "NewListByNamespacePager",
       "source_file": "servicebus.go"
     },
     {
-      "permission": "Microsoft.ServiceBus/subscriptions/read",
+      "permission": "Microsoft.ServiceBus/namespaces/topics/subscriptions/read",
       "service": "Microsoft.ServiceBus",
       "action": "NewListByTopicPager",
-      "source_file": "servicebus.go"
-    },
-    {
-      "permission": "Microsoft.ServiceBus/topics/read",
-      "service": "Microsoft.ServiceBus",
-      "action": "NewListByNamespacePager",
       "source_file": "servicebus.go"
     },
     {
@@ -760,21 +838,27 @@
       "source_file": "sql.go"
     },
     {
-      "permission": "Microsoft.Storage/encryptionScopes/read",
+      "permission": "Microsoft.Storage/localUsers/read",
       "service": "Microsoft.Storage",
       "action": "NewListPager",
-      "source_file": "storage.go"
-    },
-    {
-      "permission": "Microsoft.Storage/managementPolicies/read",
-      "service": "Microsoft.Storage",
-      "action": "Get",
       "source_file": "storage.go"
     },
     {
       "permission": "Microsoft.Storage/storageAccounts/blobServices/containers/read",
       "service": "Microsoft.Storage",
       "action": "NewListPager",
+      "source_file": "storage.go"
+    },
+    {
+      "permission": "Microsoft.Storage/storageAccounts/encryptionScopes/read",
+      "service": "Microsoft.Storage",
+      "action": "NewListPager",
+      "source_file": "storage.go"
+    },
+    {
+      "permission": "Microsoft.Storage/storageAccounts/managementPolicies/read",
+      "service": "Microsoft.Storage",
+      "action": "Get",
       "source_file": "storage.go"
     },
     {

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
   "version": "13.5.0",
-  "generated_at": "2026-04-27T09:18:23-07:00",
+  "generated_at": "2026-04-27T09:19:49-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Authorization/classicAdministrators/read",
@@ -13,18 +13,18 @@
     "Microsoft.Cache/redis/firewallRules/read",
     "Microsoft.Cache/redis/patchSchedules/read",
     "Microsoft.Cdn/profiles/afdendpoints/read",
+    "Microsoft.Cdn/profiles/afdendpoints/routes/read",
     "Microsoft.Cdn/profiles/customdomains/read",
     "Microsoft.Cdn/profiles/origingroups/origins/read",
     "Microsoft.Cdn/profiles/origingroups/read",
     "Microsoft.Cdn/profiles/read",
-    "Microsoft.Cdn/routes/read",
     "Microsoft.Compute/diskAccesses/read",
     "Microsoft.Compute/diskEncryptionSets/read",
     "Microsoft.Compute/disks/read",
     "Microsoft.Compute/virtualMachines/read",
-    "Microsoft.ContainerRegistry/cacheRules/read",
-    "Microsoft.ContainerRegistry/connectedRegistries/read",
-    "Microsoft.ContainerRegistry/credentialSets/read",
+    "Microsoft.ContainerRegistry/registries/cacheRules/read",
+    "Microsoft.ContainerRegistry/registries/connectedRegistries/read",
+    "Microsoft.ContainerRegistry/registries/credentialSets/read",
     "Microsoft.ContainerRegistry/registries/replications/read",
     "Microsoft.ContainerRegistry/registries/scopeMaps/read",
     "Microsoft.ContainerRegistry/registries/tokens/read",
@@ -34,7 +34,7 @@
     "Microsoft.DBforMySQL/servers/databases/read",
     "Microsoft.DBforMySQL/servers/firewallRules/read",
     "Microsoft.DBforMySQL/servers/read",
-    "Microsoft.DBforPostgreSQL/advancedThreatProtectionSettings/read",
+    "Microsoft.DBforPostgreSQL/flexibleServers/advancedThreatProtectionSettings/read",
     "Microsoft.DBforPostgreSQL/serverGroupsv2/read",
     "Microsoft.DBforPostgreSQL/servers/configurations/read",
     "Microsoft.DBforPostgreSQL/servers/databases/read",
@@ -43,7 +43,7 @@
     "Microsoft.DataFactory/factories/read",
     "Microsoft.Databricks/workspaces/read",
     "Microsoft.DocumentDB/databaseAccounts/read",
-    "Microsoft.EventHub/namespaces/eventHubs/consumergroups/read",
+    "Microsoft.EventHub/namespaces/eventhubs/consumergroups/read",
     "Microsoft.EventHub/namespaces/eventhubs/read",
     "Microsoft.EventHub/namespaces/read",
     "Microsoft.Insights/activityLogAlerts/read",
@@ -69,9 +69,9 @@
     "Microsoft.Network/networkSecurityGroups/read",
     "Microsoft.Network/networkWatchers/flowLogs/read",
     "Microsoft.Network/networkWatchers/read",
-    "Microsoft.Network/privateDNSZoneGroups/read",
     "Microsoft.Network/privateDnsZones/read",
     "Microsoft.Network/privateDnsZones/virtualNetworkLinks/read",
+    "Microsoft.Network/privateEndpoints/privateDnsZoneGroups/read",
     "Microsoft.Network/privateEndpoints/read",
     "Microsoft.Network/publicIPAddresses/read",
     "Microsoft.Network/routeTables/read",
@@ -80,12 +80,12 @@
     "Microsoft.Network/virtualNetworks/read",
     "Microsoft.Network/virtualNetworks/subnets/read",
     "Microsoft.Network/virtualNetworks/virtualNetworkPeerings/read",
-    "Microsoft.OperationalInsights/queries/read",
-    "Microsoft.OperationalInsights/queryPacks/read",
-    "Microsoft.OperationalInsights/tables/read",
+    "Microsoft.OperationalInsights/querypacks/read",
     "Microsoft.OperationalInsights/workspaces/dataexports/read",
     "Microsoft.OperationalInsights/workspaces/linkedservices/read",
     "Microsoft.OperationalInsights/workspaces/read",
+    "Microsoft.OperationalInsights/workspaces/savedSearches/read",
+    "Microsoft.OperationalInsights/workspaces/tables/read",
     "Microsoft.RecoveryServices/Vaults/backupPolicies/read",
     "Microsoft.RecoveryServices/Vaults/backupProtectedItems/read",
     "Microsoft.RecoveryServices/Vaults/backupconfig/read",
@@ -117,9 +117,9 @@
     "Microsoft.Sql/servers/securityAlertPolicies/read",
     "Microsoft.Sql/servers/virtualNetworkRules/read",
     "Microsoft.Sql/servers/vulnerabilityAssessments/read",
-    "Microsoft.Storage/localUsers/read",
     "Microsoft.Storage/storageAccounts/blobServices/containers/read",
     "Microsoft.Storage/storageAccounts/encryptionScopes/read",
+    "Microsoft.Storage/storageAccounts/localUsers/read",
     "Microsoft.Storage/storageAccounts/managementPolicies/read",
     "Microsoft.Storage/storageAccounts/read",
     "Microsoft.Synapse/workspaces/read",
@@ -190,6 +190,12 @@
       "source_file": "frontdoor.go"
     },
     {
+      "permission": "Microsoft.Cdn/profiles/afdendpoints/routes/read",
+      "service": "Microsoft.Cdn",
+      "action": "NewListByEndpointPager",
+      "source_file": "frontdoor.go"
+    },
+    {
       "permission": "Microsoft.Cdn/profiles/customdomains/read",
       "service": "Microsoft.Cdn",
       "action": "NewListByProfilePager",
@@ -211,12 +217,6 @@
       "permission": "Microsoft.Cdn/profiles/read",
       "service": "Microsoft.Cdn",
       "action": "NewListPager",
-      "source_file": "frontdoor.go"
-    },
-    {
-      "permission": "Microsoft.Cdn/routes/read",
-      "service": "Microsoft.Cdn",
-      "action": "NewListByEndpointPager",
       "source_file": "frontdoor.go"
     },
     {
@@ -244,19 +244,19 @@
       "source_file": "compute.go"
     },
     {
-      "permission": "Microsoft.ContainerRegistry/cacheRules/read",
+      "permission": "Microsoft.ContainerRegistry/registries/cacheRules/read",
       "service": "Microsoft.ContainerRegistry",
       "action": "NewListPager",
       "source_file": "containerregistry.go"
     },
     {
-      "permission": "Microsoft.ContainerRegistry/connectedRegistries/read",
+      "permission": "Microsoft.ContainerRegistry/registries/connectedRegistries/read",
       "service": "Microsoft.ContainerRegistry",
       "action": "NewListPager",
       "source_file": "containerregistry.go"
     },
     {
-      "permission": "Microsoft.ContainerRegistry/credentialSets/read",
+      "permission": "Microsoft.ContainerRegistry/registries/credentialSets/read",
       "service": "Microsoft.ContainerRegistry",
       "action": "NewListPager",
       "source_file": "containerregistry.go"
@@ -316,7 +316,7 @@
       "source_file": "mysql.go"
     },
     {
-      "permission": "Microsoft.DBforPostgreSQL/advancedThreatProtectionSettings/read",
+      "permission": "Microsoft.DBforPostgreSQL/flexibleServers/advancedThreatProtectionSettings/read",
       "service": "Microsoft.DBforPostgreSQL",
       "action": "Get",
       "source_file": "postgresql.go"
@@ -370,7 +370,7 @@
       "source_file": "cosmosdb.go"
     },
     {
-      "permission": "Microsoft.EventHub/namespaces/eventHubs/consumergroups/read",
+      "permission": "Microsoft.EventHub/namespaces/eventhubs/consumergroups/read",
       "service": "Microsoft.EventHub",
       "action": "NewListByEventHubPager",
       "source_file": "eventhub.go"
@@ -532,12 +532,6 @@
       "source_file": "network.go"
     },
     {
-      "permission": "Microsoft.Network/privateDNSZoneGroups/read",
-      "service": "Microsoft.Network",
-      "action": "NewListPager",
-      "source_file": "network.go"
-    },
-    {
       "permission": "Microsoft.Network/privateDnsZones/read",
       "service": "Microsoft.Privatedns",
       "action": "NewListPager",
@@ -548,6 +542,12 @@
       "service": "Microsoft.Privatedns",
       "action": "NewListPager",
       "source_file": "dns.go"
+    },
+    {
+      "permission": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups/read",
+      "service": "Microsoft.Network",
+      "action": "NewListPager",
+      "source_file": "network.go"
     },
     {
       "permission": "Microsoft.Network/privateEndpoints/read",
@@ -588,7 +588,7 @@
     {
       "permission": "Microsoft.Network/virtualNetworks/read",
       "service": "Microsoft.Network",
-      "action": "Get",
+      "action": "NewListAllPager",
       "source_file": "network.go"
     },
     {
@@ -604,21 +604,9 @@
       "source_file": "network.go"
     },
     {
-      "permission": "Microsoft.OperationalInsights/queries/read",
+      "permission": "Microsoft.OperationalInsights/querypacks/read",
       "service": "Microsoft.OperationalInsights",
       "action": "NewListPager",
-      "source_file": "loganalytics.go"
-    },
-    {
-      "permission": "Microsoft.OperationalInsights/queryPacks/read",
-      "service": "Microsoft.OperationalInsights",
-      "action": "NewListPager",
-      "source_file": "loganalytics.go"
-    },
-    {
-      "permission": "Microsoft.OperationalInsights/tables/read",
-      "service": "Microsoft.OperationalInsights",
-      "action": "NewListByWorkspacePager",
       "source_file": "loganalytics.go"
     },
     {
@@ -637,6 +625,18 @@
       "permission": "Microsoft.OperationalInsights/workspaces/read",
       "service": "Microsoft.OperationalInsights",
       "action": "Get",
+      "source_file": "loganalytics.go"
+    },
+    {
+      "permission": "Microsoft.OperationalInsights/workspaces/savedSearches/read",
+      "service": "Microsoft.OperationalInsights",
+      "action": "NewListPager",
+      "source_file": "loganalytics.go"
+    },
+    {
+      "permission": "Microsoft.OperationalInsights/workspaces/tables/read",
+      "service": "Microsoft.OperationalInsights",
+      "action": "NewListByWorkspacePager",
       "source_file": "loganalytics.go"
     },
     {
@@ -838,12 +838,6 @@
       "source_file": "sql.go"
     },
     {
-      "permission": "Microsoft.Storage/localUsers/read",
-      "service": "Microsoft.Storage",
-      "action": "NewListPager",
-      "source_file": "storage.go"
-    },
-    {
       "permission": "Microsoft.Storage/storageAccounts/blobServices/containers/read",
       "service": "Microsoft.Storage",
       "action": "NewListPager",
@@ -851,6 +845,12 @@
     },
     {
       "permission": "Microsoft.Storage/storageAccounts/encryptionScopes/read",
+      "service": "Microsoft.Storage",
+      "action": "NewListPager",
+      "source_file": "storage.go"
+    },
+    {
+      "permission": "Microsoft.Storage/storageAccounts/localUsers/read",
       "service": "Microsoft.Storage",
       "action": "NewListPager",
       "source_file": "storage.go"


### PR DESCRIPTION
## Summary

Fixed the Azure permission extraction generator (`providers-sdk/v1/util/permissions/permissions.go`) to produce correct RBAC permission strings. **78 permissions were invalid** across three rounds of fixes:

- Missing parent resource paths (e.g. SDK calls `firewallRules` but ARM expects `redis/firewallRules` or `servers/firewallRules`)
- Wrong resource type names (e.g. SDK calls `interfaces` but ARM expects `networkInterfaces`)
- Wrong ARM provider names (e.g. `Microsoft.Datafactory` should be `Microsoft.DataFactory`)
- Wrong casing for resource types nested inside parents
- Sub-resources only available under one of multiple parent variants (e.g. `flexibleServers/` vs legacy `servers/`)

Every entry in the regenerated `azure.permissions.json` was cross-checked against the [Azure RBAC permissions reference](https://learn.microsoft.com/en-us/azure/role-based-access-control/permissions/) and built-in role JSONs.

## What changed

A single override map (`azurePermissionOverrides`) in the permissions generator translates SDK-derived strings to canonical RBAC permission names. New ARM-provider mappings (`datafactory`, `cosmosforpostgresql`, `batch`, `databricks`, `synapse`) were also added to `azureServiceToARMMap`.

### Round 1 — initial 42 fixes (commit 1)

| Category | Examples |
|---|---|
| ARM provider names | `Microsoft.Datafactory` → `Microsoft.DataFactory`, `Microsoft.Cosmosforpostgresql` → `Microsoft.DBforPostgreSQL` |
| Missing `servers/` parent (SQL/MySQL/PostgreSQL) | `Microsoft.Sql/databases/read` → `Microsoft.Sql/servers/databases/read`, similar for `firewallRules`, `virtualNetworkRules`, `encryptionProtector`, `auditingSettings`, etc. (~22 entries) |
| Missing `redis/` parent (Cache) | `Microsoft.Cache/firewallRules/read` → `Microsoft.Cache/redis/firewallRules/read` |
| Wrong type names (Network) | `Microsoft.Network/interfaces` → `networkInterfaces`, `securityGroups` → `networkSecurityGroups`, `flowLogs` → `networkWatchers/flowLogs`, `subnets` → `virtualNetworks/subnets` |
| Wrong type names (Storage / Web / Batch) | `Microsoft.Storage/accounts` → `storageAccounts`, `Microsoft.Web/webApps` → `sites`, `Microsoft.Web/plans` → `serverfarms`, `Microsoft.Batch/account` → `batchAccounts` |

### Round 2 — 25 more fixes across 11 providers (commit 2)

Covers CDN AFD types (`Microsoft.Cdn/aFDCustomDomains` → `profiles/customdomains`, etc.), ContainerRegistry sub-resources (`replications`, `scopeMaps`, `tokens`, `webhooks` need `registries/` parent), DNS namespaces (`Microsoft.Dns/zones` actually lives under `Microsoft.Network/dnszones`), Private DNS (`Microsoft.Privatedns` → `Microsoft.Network/privateDnsZones`), EventHub sub-resources, OperationalInsights `dataExports`/`linkedServices` under `workspaces/`, RecoveryServices backup types, the WAF policy long type name, ServiceBus sub-resources, and resource group nesting.

### Round 3 — 11 more fixes (commit 3, this push)

Identified by re-validating every entry in the regenerated manifest against the Microsoft RBAC docs:

| Before (invalid) | After (correct) |
|---|---|
| `Microsoft.ContainerRegistry/cacheRules/read` | `Microsoft.ContainerRegistry/registries/cacheRules/read` |
| `Microsoft.ContainerRegistry/connectedRegistries/read` | `Microsoft.ContainerRegistry/registries/connectedRegistries/read` |
| `Microsoft.ContainerRegistry/credentialSets/read` | `Microsoft.ContainerRegistry/registries/credentialSets/read` |
| `Microsoft.DBforPostgreSQL/advancedThreatProtectionSettings/read` | `Microsoft.DBforPostgreSQL/flexibleServers/advancedThreatProtectionSettings/read` |
| `Microsoft.OperationalInsights/queries/read` | `Microsoft.OperationalInsights/workspaces/savedSearches/read` |
| `Microsoft.OperationalInsights/queryPacks/read` | `Microsoft.OperationalInsights/querypacks/read` |
| `Microsoft.OperationalInsights/tables/read` | `Microsoft.OperationalInsights/workspaces/tables/read` |
| `Microsoft.Storage/localUsers/read` | `Microsoft.Storage/storageAccounts/localUsers/read` |
| `Microsoft.Cdn/routes/read` | `Microsoft.Cdn/profiles/afdendpoints/routes/read` |
| `Microsoft.Network/privateDNSZoneGroups/read` | `Microsoft.Network/privateEndpoints/privateDnsZoneGroups/read` |
| `Microsoft.EventHub/namespaces/eventHubs/consumergroups/read` | `Microsoft.EventHub/namespaces/eventhubs/consumergroups/read` (lowercase, matches the sibling `eventhubs/read` entry) |

## Test plan

- [x] Verified each corrected permission against the Microsoft RBAC permissions reference docs and built-in role JSONs.
- [x] `go build ./...` and `go vet ./...` clean for both the permissions generator and the azure provider.
- [x] Regeneration is idempotent: a second run of `go run providers-sdk/v1/util/permissions/permissions.go providers/azure` produces no diff (only `generated_at` would change, and the generator skip-writes that case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)