### PR TITLE
🎉 grafana-13.0.2

### DIFF
--- a/providers/grafana/config/config.go
+++ b/providers/grafana/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "grafana",
 	ID:              "go.mondoo.com/mql/v13/providers/grafana",
-	Version:         "13.0.1",
+	Version:         "13.0.2",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### grafana (13.0.2)
- 🐛 fix(grafana): add init functions for sub-resources accessed directly (#7141)
- 🧹 Update deps for mql and providers 20260408 (#7132)
- 🧹 Update deps for mql and providers 20260406 (#7122)