### PR TITLE
🎉 aws-13.11.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.10.0",
+	Version:         "13.11.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
## Summary

Bump AWS provider version from 13.10.0 to 13.11.0.

### PRs included since aws-13.8.0

- ⭐ Add Bedrock, Control Tower, Security Lake, Verified Access, Private CA resources (#7136)
- ⭐ Add new security-relevant fields from SDK bumps (#7134)
- 🧹 Update deps for mql and providers 20260408 (#7132)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>