### PR TITLE
Fix Windows client hotpatch detection false positives

### DIFF
--- a/providers/os/detector/windows/hotpatch.go
+++ b/providers/os/detector/windows/hotpatch.go
@@ -50,7 +50,15 @@ func ParseWinRegistryClientHotpatch(r io.Reader) (bool, error) {
 // hotpatchSupported checks whether the given platform meets the minimum build
 // requirements for hotpatching:
 //   - Windows Server 2022+ (build 20348+, product-type "2" or "3")
-//   - Windows 11 Enterprise 24H2+ (build 26100+, product-type "1")
+//   - Windows 11 Enterprise 24H2+ (product-type "1"):
+//   - x64 (AMD64/Intel): build 26100.2033+
+//   - arm64: build 26100.4929+
+//
+// Windows 11 client hotpatch requires architecture-specific minimum UBR
+// (Update Build Revision) values on build 26100. Without this check, devices
+// with AllowRebootlessUpdates set via policy but below the prerequisite build
+// would be falsely detected as hotpatch-enrolled.
+// See https://learn.microsoft.com/en-us/windows/client-management/hotpatch
 func hotpatchSupported(pf *inventory.Platform) bool {
 	buildNumber, err := strconv.Atoi(pf.Version)
 	if err != nil {
@@ -62,7 +70,23 @@ func hotpatchSupported(pf *inventory.Platform) bool {
 	productType := pf.Labels["windows.mondoo.com/product-type"]
 	switch productType {
 	case "1": // Workstation (Windows client)
-		return buildNumber >= 26100
+		if buildNumber > 26100 {
+			return true
+		}
+		if buildNumber < 26100 {
+			return false
+		}
+		ubr, err := strconv.Atoi(pf.Build)
+		if err != nil {
+			log.Error().Err(err).Msg("could not parse windows UBR")
+			return false
+		}
+		log.Debug().Int("ubr", ubr).Str("arch", pf.Arch).Msg("parsed windows UBR for client hotpatch check")
+		minUBR := 2033
+		if strings.EqualFold(pf.Arch, "arm64") {
+			minUBR = 4929
+		}
+		return ubr >= minUBR
 	case "2", "3": // Domain Controller or Server
 		return buildNumber >= 20348
 	default:

--- a/providers/os/detector/windows/hotpatch_test.go
+++ b/providers/os/detector/windows/hotpatch_test.go
@@ -121,9 +121,79 @@ func TestParseWinRegistryClientHotpatch(t *testing.T) {
 }
 
 func TestHotpatchSupported(t *testing.T) {
-	t.Run("client build 26100 supported", func(t *testing.T) {
+	t.Run("client amd64 build 26100 with sufficient UBR", func(t *testing.T) {
 		pf := &inventory.Platform{
 			Version: "26100",
+			Build:   "5000",
+			Arch:    "AMD64",
+			Labels:  map[string]string{"windows.mondoo.com/product-type": "1"},
+		}
+		assert.True(t, hotpatchSupported(pf))
+	})
+
+	t.Run("client amd64 build 26100 with exact minimum UBR", func(t *testing.T) {
+		pf := &inventory.Platform{
+			Version: "26100",
+			Build:   "2033",
+			Arch:    "AMD64",
+			Labels:  map[string]string{"windows.mondoo.com/product-type": "1"},
+		}
+		assert.True(t, hotpatchSupported(pf))
+	})
+
+	t.Run("client amd64 build 26100 with UBR below minimum", func(t *testing.T) {
+		pf := &inventory.Platform{
+			Version: "26100",
+			Build:   "2000",
+			Arch:    "AMD64",
+			Labels:  map[string]string{"windows.mondoo.com/product-type": "1"},
+		}
+		assert.False(t, hotpatchSupported(pf))
+	})
+
+	t.Run("client arm64 build 26100 with sufficient UBR", func(t *testing.T) {
+		pf := &inventory.Platform{
+			Version: "26100",
+			Build:   "5000",
+			Arch:    "ARM64",
+			Labels:  map[string]string{"windows.mondoo.com/product-type": "1"},
+		}
+		assert.True(t, hotpatchSupported(pf))
+	})
+
+	t.Run("client arm64 build 26100 with exact minimum UBR", func(t *testing.T) {
+		pf := &inventory.Platform{
+			Version: "26100",
+			Build:   "4929",
+			Arch:    "ARM64",
+			Labels:  map[string]string{"windows.mondoo.com/product-type": "1"},
+		}
+		assert.True(t, hotpatchSupported(pf))
+	})
+
+	t.Run("client arm64 build 26100 with UBR below arm64 minimum", func(t *testing.T) {
+		pf := &inventory.Platform{
+			Version: "26100",
+			Build:   "3775",
+			Arch:    "ARM64",
+			Labels:  map[string]string{"windows.mondoo.com/product-type": "1"},
+		}
+		assert.False(t, hotpatchSupported(pf))
+	})
+
+	t.Run("client build 26100 with empty UBR", func(t *testing.T) {
+		pf := &inventory.Platform{
+			Version: "26100",
+			Build:   "",
+			Labels:  map[string]string{"windows.mondoo.com/product-type": "1"},
+		}
+		assert.False(t, hotpatchSupported(pf))
+	})
+
+	t.Run("client build above 26100 always supported", func(t *testing.T) {
+		pf := &inventory.Platform{
+			Version: "27000",
+			Build:   "100",
 			Labels:  map[string]string{"windows.mondoo.com/product-type": "1"},
 		}
 		assert.True(t, hotpatchSupported(pf))


### PR DESCRIPTION
## Summary
- Add architecture-specific UBR (Update Build Revision) checks for Windows 11 client hotpatch detection
- Previously, any build 26100+ was considered hotpatch-capable, but devices with `AllowRebootlessUpdates` set via policy could be falsely detected when their UBR was below the minimum prerequisite
- Minimum UBR requirements on build 26100: x64 (AMD64/Intel) >= 2033, arm64 >= 4929

## Test plan
- [x] Unit tests for both architectures at/above/below UBR thresholds
- [x] Integration test with mock Windows 11 24H2 hotpatch-enabled device
- [x] Verified non-hotpatch Windows 11 24H2 test still reports `hotpatch=false`
- [ ] Manual verification on a Windows 11 Enterprise 24H2 device

🤖 Generated with [Claude Code](https://claude.com/claude-code)