### PR TITLE
🎉 aws-13.13.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.12.0",
+	Version:         "13.13.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### aws (13.13.0)
- 🧹 Update deps for mql and providers 20260413 (#7171)
- Expand AWS provider: 10 services, 24 ARN→typed conversions, Step Functions, Batch, AppMesh (#7165)
- Expand 6 AWS services with security-focused resources (#7160)
- Expand EKS resources with typed references, insights, and addon versions (#7159)
- Expand Redshift, EMR, and ElastiCache resources (#7158)
- :star: Expand Security Hub with standards controls, findings, and insights (#7156)
- Expand CloudTrail, GuardDuty, and Config resources (#7155)