### PR TITLE
🎉 gcp-13.7.0

### DIFF
--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.6.0",
+	Version: "13.7.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### gcp (13.7.0)
- 🧹 Update deps for mql and providers 20260413 (#7171)
- Expand 8 GCP services with 17 new resources using existing SDK deps (#7168)
- Add 12 GCP Compute networking resources with typed cross-references (#7166)