### PR TITLE
🐛 Fix VPC init failing when asset name is a tag

### DIFF
--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -2093,7 +2093,6 @@ func initAwsEc2Volume(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 
 	if len(args) == 0 {
 		if ids := getAssetIdentifier(runtime); ids != nil {
-			args["id"] = llx.StringData(ids.name)
 			args["arn"] = llx.StringData(ids.arn)
 		}
 	}

--- a/providers/aws/resources/aws_elasticache.go
+++ b/providers/aws/resources/aws_elasticache.go
@@ -385,7 +385,6 @@ func initAwsElasticacheCluster(runtime *plugin.Runtime, args map[string]*llx.Raw
 
 	if len(args) == 0 {
 		if ids := getAssetIdentifier(runtime); ids != nil {
-			args["cacheClusterId"] = llx.StringData(ids.name)
 			args["arn"] = llx.StringData(ids.arn)
 		}
 	}

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -1103,7 +1103,9 @@ func initAwsVpc(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[stri
 
 	if len(args) == 0 {
 		if ids := getAssetIdentifier(runtime); ids != nil {
-			args["id"] = llx.StringData(ids.name)
+			// Only use the ARN from asset identifiers. The asset name may be
+			// the VPC's "Name" tag (e.g. "my-vpc") rather than the VPC ID
+			// (e.g. "vpc-0abc123"), so it cannot be used as the "id" arg.
 			args["arn"] = llx.StringData(ids.arn)
 		}
 	}
@@ -1126,15 +1128,15 @@ func initAwsVpc(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[stri
 
 	var match func(vpc *mqlAwsVpc) bool
 
-	if args["id"] != nil {
-		idVal := args["id"].Value.(string)
-		match = func(vpc *mqlAwsVpc) bool {
-			return vpc.Id.Data == idVal
-		}
-	} else if args["arn"] != nil {
+	if args["arn"] != nil {
 		arnVal := args["arn"].Value.(string)
 		match = func(vpc *mqlAwsVpc) bool {
 			return vpc.Arn.Data == arnVal
+		}
+	} else if args["id"] != nil {
+		idVal := args["id"].Value.(string)
+		match = func(vpc *mqlAwsVpc) bool {
+			return vpc.Id.Data == idVal
 		}
 	}
 

--- a/providers/aws/resources/aws_vpc_init_test.go
+++ b/providers/aws/resources/aws_vpc_init_test.go
@@ -1,0 +1,165 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/aws/connection"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+// testAwsRuntime creates a runtime with an AwsConnection whose asset has
+// the given name and platform IDs.  It also pre-populates the resource
+// cache with an "aws" resource whose Vpcs list contains the supplied VPCs,
+// so initAwsVpc can resolve them without making real API calls.
+func testAwsRuntime(assetName string, platformIds []string, vpcs []*mqlAwsVpc) *plugin.Runtime {
+	asset := &inventory.Asset{
+		Name:        assetName,
+		PlatformIds: platformIds,
+		Connections: []*inventory.Config{{}},
+	}
+
+	conn := &connection.AwsConnection{
+		Connection: plugin.NewConnection(1, asset),
+		Conf: &inventory.Config{
+			Discover: &inventory.Discovery{},
+		},
+	}
+	conn.UpdateAsset(asset)
+
+	resources := &syncx.Map[plugin.Resource]{}
+	runtime := &plugin.Runtime{
+		Connection: conn,
+		Resources:  resources,
+	}
+
+	// Pre-populate the "aws" resource with VPCs already loaded.
+	awsRes := &mqlAws{MqlRuntime: runtime}
+	vpcList := make([]any, len(vpcs))
+	for i, v := range vpcs {
+		vpcList[i] = v
+	}
+	awsRes.Vpcs = plugin.TValue[[]any]{Data: vpcList, State: plugin.StateIsSet}
+	// Cache key: "aws" + \x00 + __id (empty)
+	resources.Set("aws\x00", awsRes)
+
+	return runtime
+}
+
+func TestInitAwsVpc(t *testing.T) {
+	const (
+		vpcId  = "vpc-0abc123def456"
+		vpcArn = "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-0abc123def456"
+		region = "us-east-1"
+	)
+
+	testVpc := &mqlAwsVpc{
+		Id:     plugin.TValue[string]{Data: vpcId, State: plugin.StateIsSet},
+		Arn:    plugin.TValue[string]{Data: vpcArn, State: plugin.StateIsSet},
+		Region: plugin.TValue[string]{Data: region, State: plugin.StateIsSet},
+	}
+
+	t.Run("resolves VPC by ARN when asset name is a tag (not VPC ID)", func(t *testing.T) {
+		// This is the bug scenario: during discovery, MqlObjectToAsset
+		// overrides the asset name with the VPC's "Name" tag.  The old
+		// code set args["id"] = ids.name (the tag), then tried to match
+		// against vpc.Id.Data (the real VPC ID) — which never matched.
+		tagName := "scottford-upgrade-eks-container-escape-demo-02c1-vpc"
+		runtime := testAwsRuntime(
+			tagName,
+			[]string{
+				"//platformid.api.mondoo.app/runtime/aws/accounts/123456789012/regions/us-east-1/vpcs/" + vpcId,
+				vpcArn,
+			},
+			[]*mqlAwsVpc{testVpc},
+		)
+
+		args := map[string]*llx.RawData{}
+		resultArgs, resource, err := initAwsVpc(runtime, args)
+		require.NoError(t, err)
+		require.NotNil(t, resource)
+
+		vpc := resource.(*mqlAwsVpc)
+		assert.Equal(t, vpcId, vpc.Id.Data)
+		assert.Equal(t, vpcArn, vpc.Arn.Data)
+		assert.Equal(t, vpcArn, resultArgs["arn"].Value.(string))
+	})
+
+	t.Run("resolves VPC by ARN when asset name matches VPC ID", func(t *testing.T) {
+		// When there's no "Name" tag, the asset name IS the VPC ID.
+		runtime := testAwsRuntime(
+			vpcId,
+			[]string{
+				"//platformid.api.mondoo.app/runtime/aws/accounts/123456789012/regions/us-east-1/vpcs/" + vpcId,
+				vpcArn,
+			},
+			[]*mqlAwsVpc{testVpc},
+		)
+
+		args := map[string]*llx.RawData{}
+		_, resource, err := initAwsVpc(runtime, args)
+		require.NoError(t, err)
+		require.NotNil(t, resource)
+
+		vpc := resource.(*mqlAwsVpc)
+		assert.Equal(t, vpcId, vpc.Id.Data)
+	})
+
+	t.Run("resolves VPC by explicit id arg", func(t *testing.T) {
+		runtime := testAwsRuntime("irrelevant", nil, []*mqlAwsVpc{testVpc})
+
+		args := map[string]*llx.RawData{
+			"id": llx.StringData(vpcId),
+		}
+		_, resource, err := initAwsVpc(runtime, args)
+		require.NoError(t, err)
+		require.NotNil(t, resource)
+
+		vpc := resource.(*mqlAwsVpc)
+		assert.Equal(t, vpcId, vpc.Id.Data)
+	})
+
+	t.Run("resolves VPC by explicit arn arg", func(t *testing.T) {
+		runtime := testAwsRuntime("irrelevant", nil, []*mqlAwsVpc{testVpc})
+
+		args := map[string]*llx.RawData{
+			"arn": llx.StringData(vpcArn),
+		}
+		_, resource, err := initAwsVpc(runtime, args)
+		require.NoError(t, err)
+		require.NotNil(t, resource)
+
+		vpc := resource.(*mqlAwsVpc)
+		assert.Equal(t, vpcArn, vpc.Arn.Data)
+	})
+
+	t.Run("returns error when VPC not found", func(t *testing.T) {
+		runtime := testAwsRuntime("irrelevant", nil, []*mqlAwsVpc{testVpc})
+
+		args := map[string]*llx.RawData{
+			"id": llx.StringData("vpc-doesnotexist"),
+		}
+		_, _, err := initAwsVpc(runtime, args)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "vpc does not exist")
+	})
+
+	t.Run("returns error when asset has no valid ARN in platform IDs", func(t *testing.T) {
+		// getAssetIdentifier returns a non-nil result with an empty arn
+		// when the asset has no "arn:aws:" platform ID. The empty-string
+		// arn won't match any VPC.
+		runtime := testAwsRuntime("some-vpc", []string{"not-an-arn"}, []*mqlAwsVpc{testVpc})
+
+		args := map[string]*llx.RawData{}
+		_, _, err := initAwsVpc(runtime, args)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "vpc does not exist")
+	})
+}


### PR DESCRIPTION
## Summary
- **Root cause**: During VPC asset discovery, `MqlObjectToAsset` overrides the asset name with the VPC's "Name" tag. `initAwsVpc` then used this tag-based name (e.g. `scottford-upgrade-eks-container-escape-demo-02c1-vpc`) as the VPC `id` arg and tried to match it against `vpc.Id.Data` (e.g. `vpc-0abc123`), which never matched — causing `"vpc does not exist"` errors for every VPC with a Name tag.
- **Fix**: Use only the ARN from asset identifiers (always correct) and match by ARN before ID. Applied the same cleanup to `initAwsEc2Volume` and `initAwsElasticacheCluster` which had the same incorrect `args["id"] = ids.name` pattern.
- **Tests**: Added unit tests for `initAwsVpc` covering the regression scenario, explicit id/arn lookups, and error cases.

## Test plan
- [x] Unit tests pass: `go test ./resources/ -run TestInitAwsVpc -v`
- [ ] Build and install provider: `make providers/build/aws && make providers/install/aws`
- [ ] Run `cnspec scan aws` and verify VPC assets resolve without `"vpc does not exist"` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)