### PR TITLE
:star: Add Slack user profile fields

### DIFF
--- a/providers/slack/resources/users.go
+++ b/providers/slack/resources/users.go
@@ -127,15 +127,19 @@ type userProfile struct {
 	RealNameNormalized    string     `json:"realNameNormalized"`
 	DisplayName           string     `json:"displayName"`
 	DisplayNameNormalized string     `json:"displayNameNormalized"`
+	Pronouns              string     `json:"pronouns,omitempty"`
 	Email                 string     `json:"email"`
 	Skype                 string     `json:"skype"`
 	Phone                 string     `json:"phone"`
 	Title                 string     `json:"title"`
 	BotID                 string     `json:"botId,omitempty"`
 	ApiAppID              string     `json:"apiAppId,omitempty"`
+	AlwaysActive          bool       `json:"alwaysActive"`
 	StatusText            string     `json:"statusText,omitempty"`
 	StatusEmoji           string     `json:"statusEmoji,omitempty"`
 	StatusExpiration      *time.Time `json:"statusExpiration"`
+	StartDate             string     `json:"startDate,omitempty"`
+	GuestInvitedBy        string     `json:"guestInvitedBy,omitempty"`
 	Team                  string     `json:"team"`
 }
 
@@ -149,15 +153,19 @@ func newUserProfile(u slack.UserProfile) userProfile {
 		RealNameNormalized:    u.RealNameNormalized,
 		DisplayName:           u.DisplayName,
 		DisplayNameNormalized: u.DisplayNameNormalized,
+		Pronouns:              u.Pronouns,
 		Email:                 u.Email,
 		Skype:                 u.Skype,
 		Phone:                 u.Phone,
 		Title:                 u.Title,
 		BotID:                 u.BotID,
 		ApiAppID:              u.ApiAppID,
+		AlwaysActive:          u.AlwaysActive,
 		StatusText:            u.StatusText,
 		StatusEmoji:           u.StatusEmoji,
 		StatusExpiration:      &statusExpiration,
+		StartDate:             u.StartDate,
+		GuestInvitedBy:        u.GuestInvitedBy,
 		Team:                  u.Team,
 	}
 }


### PR DESCRIPTION
## Summary
- Map four additional fields from the Slack `UserProfile` into the `profile` dict: `pronouns`, `alwaysActive`, `startDate`, and `guestInvitedBy`
- These fields are already returned by the `users.list` API response but were not being captured in the profile mapping
- No new API calls or scopes required

## Test plan
- [ ] Build the slack provider: `make providers/build/slack`
- [ ] Connect to a Slack workspace and verify the new fields appear in user profiles: `mql run slack -c "slack.users { profile }"`
- [ ] Confirm `guestInvitedBy` populates for guest users and `startDate` populates for users with a configured start date

🤖 Generated with [Claude Code](https://claude.com/claude-code)