### PR TITLE
🐛 Fix aws.iam.user.attachedPolicies setting nonexistent 'id' field

### DIFF
--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -908,9 +908,7 @@ func (a *mqlAwsIamUser) attachedPolicies() ([]any, error) {
 
 		for _, attachedPolicy := range userAttachedPolicies.AttachedPolicies {
 			mqlAwsIamPolicy, err := CreateResource(a.MqlRuntime, ResourceAwsIamPolicy,
-				// this isn't correct for the id, this is the name. we need to remove "id" from the policy type.
-				// it is creating a conflict bc we cannot make it optional, as it then bumps up against the internal id
-				map[string]*llx.RawData{"arn": llx.StringDataPtr(attachedPolicy.PolicyArn), "id": llx.StringDataPtr(attachedPolicy.PolicyArn)})
+				map[string]*llx.RawData{"arn": llx.StringDataPtr(attachedPolicy.PolicyArn)})
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Summary
- `aws.iam.user.attachedPolicies()` was passing `"id"` as a field when creating `aws.iam.policy` resources, but that field doesn't exist — it was renamed to `policyId()` at some point and this call was never updated
- This caused: `error: [aws] cannot set 'id' in resource 'aws.iam.policy', field not found`
- The stale comment in the code confirmed this was a known issue
- The fix removes the `"id"` key, matching how `aws.iam.role.attachedPolicies()` and `aws.iam.group.attachedPolicies()` already work — they only pass `"arn"`, which is all the init function needs for lookup

## Why this is safe to remove
The `"id"` field was **already failing** every time — it never successfully set anything. The `aws.iam.policy` resource schema defines `arn string` (the `__id` key) and `policyId() string` (a computed/lazy field). There is no `id` field. The role and group versions of `attachedPolicies()` have been working correctly with just `"arn"` all along.

## Test plan
- [ ] `mql run aws -c "aws.iam.users { attachedPolicies }"` no longer errors
- [ ] `mql run aws -c "aws.iam.users { attachedPolicies { arn name policyId } }"` returns expected data
- [ ] Policy checks like "Ensure IAM users receive permissions only through groups" pass without the field error

🤖 Generated with [Claude Code](https://claude.com/claude-code)