### PR TITLE
🐛 Add technology=virtualization branch to asset URL schema

### DIFF
--- a/providers/providers.go
+++ b/providers/providers.go
@@ -1007,6 +1007,15 @@ func LoadAssetUrlSchema() (*inventory.AssetUrlSchema, error) {
 		return nil, err
 	}
 
+	err = s.Add(&inventory.AssetUrlBranch{
+		PathSegments: []string{"technology=virtualization"},
+		Key:          "provider",
+		Title:        "Provider",
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	for _, provider := range providers {
 		for _, b := range provider.AssetUrlTrees {
 			if err := s.Add(b); err != nil {


### PR DESCRIPTION
## Summary
- The proxmox provider defines `AssetUrlTrees` with `technology=virtualization`, but `LoadAssetUrlSchema()` was missing this as a top-level branch
- This causes: `cannot find asset url branch for 'technology=virtualization'`
- Adds the missing `technology=virtualization` branch alongside the existing ones (saas, iac, network, directory-service)

## Test plan
- [ ] Existing asset URL schema tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)