### PR TITLE
🧹 Bump packageurl-go to v0.1.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,8 +73,7 @@ require (
 	github.com/muesli/termenv v0.16.0
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/opencontainers/image-spec v1.1.1
-	// pin v0.1.3
-	github.com/package-url/packageurl-go v0.1.3
+	github.com/package-url/packageurl-go v0.1.5
 	github.com/pandatix/go-cvss v0.6.2
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pierrec/lz4/v4 v4.1.26

--- a/go.sum
+++ b/go.sum
@@ -759,8 +759,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/package-url/packageurl-go v0.1.3 h1:4juMED3hHiz0set3Vq3KeQ75KD1avthoXLtmE3I0PLs=
-github.com/package-url/packageurl-go v0.1.3/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
+github.com/package-url/packageurl-go v0.1.5 h1:O4efRXja2XQ5CtiiYiCZ22k/m7i5ugLiAghgcC+eDgk=
+github.com/package-url/packageurl-go v0.1.5/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
 github.com/pandatix/go-cvss v0.6.2 h1:TFiHlzUkT67s6UkelHmK6s1INKVUG7nlKYiWWDTITGI=
 github.com/pandatix/go-cvss v0.6.2/go.mod h1:jDXYlQBZrc8nvrMUVVvTG8PhmuShOnKrxP53nOFkt8Q=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -224,7 +224,7 @@ require (
 	github.com/olekukonko/tablewriter v1.1.4 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
-	github.com/package-url/packageurl-go v0.1.3 // indirect
+	github.com/package-url/packageurl-go v0.1.5 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pjbgf/sha1cd v0.5.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect

--- a/providers/azure/go.sum
+++ b/providers/azure/go.sum
@@ -807,8 +807,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/package-url/packageurl-go v0.1.3 h1:4juMED3hHiz0set3Vq3KeQ75KD1avthoXLtmE3I0PLs=
-github.com/package-url/packageurl-go v0.1.3/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
+github.com/package-url/packageurl-go v0.1.5 h1:O4efRXja2XQ5CtiiYiCZ22k/m7i5ugLiAghgcC+eDgk=
+github.com/package-url/packageurl-go v0.1.5/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
 github.com/pandatix/go-cvss v0.6.2 h1:TFiHlzUkT67s6UkelHmK6s1INKVUG7nlKYiWWDTITGI=
 github.com/pandatix/go-cvss v0.6.2/go.mod h1:jDXYlQBZrc8nvrMUVVvTG8PhmuShOnKrxP53nOFkt8Q=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/providers/gcp/go.mod
+++ b/providers/gcp/go.mod
@@ -105,7 +105,7 @@ require (
 	github.com/olekukonko/errors v1.2.0 // indirect
 	github.com/olekukonko/ll v0.1.8 // indirect
 	github.com/olekukonko/tablewriter v1.1.4 // indirect
-	github.com/package-url/packageurl-go v0.1.3 // indirect
+	github.com/package-url/packageurl-go v0.1.5 // indirect
 	github.com/pandatix/go-cvss v0.6.2 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect

--- a/providers/gcp/go.sum
+++ b/providers/gcp/go.sum
@@ -793,8 +793,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/package-url/packageurl-go v0.1.3 h1:4juMED3hHiz0set3Vq3KeQ75KD1avthoXLtmE3I0PLs=
-github.com/package-url/packageurl-go v0.1.3/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
+github.com/package-url/packageurl-go v0.1.5 h1:O4efRXja2XQ5CtiiYiCZ22k/m7i5ugLiAghgcC+eDgk=
+github.com/package-url/packageurl-go v0.1.5/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
 github.com/pandatix/go-cvss v0.6.2 h1:TFiHlzUkT67s6UkelHmK6s1INKVUG7nlKYiWWDTITGI=
 github.com/pandatix/go-cvss v0.6.2/go.mod h1:jDXYlQBZrc8nvrMUVVvTG8PhmuShOnKrxP53nOFkt8Q=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/providers/github/go.mod
+++ b/providers/github/go.mod
@@ -203,7 +203,7 @@ require (
 	github.com/olekukonko/tablewriter v1.1.4 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
-	github.com/package-url/packageurl-go v0.1.3 // indirect
+	github.com/package-url/packageurl-go v0.1.5 // indirect
 	github.com/pandatix/go-cvss v0.6.2 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pelletier/go-toml/v2 v2.3.0 // indirect

--- a/providers/github/go.sum
+++ b/providers/github/go.sum
@@ -741,8 +741,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/package-url/packageurl-go v0.1.3 h1:4juMED3hHiz0set3Vq3KeQ75KD1avthoXLtmE3I0PLs=
-github.com/package-url/packageurl-go v0.1.3/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
+github.com/package-url/packageurl-go v0.1.5 h1:O4efRXja2XQ5CtiiYiCZ22k/m7i5ugLiAghgcC+eDgk=
+github.com/package-url/packageurl-go v0.1.5/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
 github.com/pandatix/go-cvss v0.6.2 h1:TFiHlzUkT67s6UkelHmK6s1INKVUG7nlKYiWWDTITGI=
 github.com/pandatix/go-cvss v0.6.2/go.mod h1:jDXYlQBZrc8nvrMUVVvTG8PhmuShOnKrxP53nOFkt8Q=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/providers/google-workspace/go.mod
+++ b/providers/google-workspace/go.mod
@@ -198,7 +198,7 @@ require (
 	github.com/olekukonko/tablewriter v1.1.4 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
-	github.com/package-url/packageurl-go v0.1.3 // indirect
+	github.com/package-url/packageurl-go v0.1.5 // indirect
 	github.com/pandatix/go-cvss v0.6.2 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pelletier/go-toml/v2 v2.3.0 // indirect

--- a/providers/google-workspace/go.sum
+++ b/providers/google-workspace/go.sum
@@ -732,8 +732,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/package-url/packageurl-go v0.1.3 h1:4juMED3hHiz0set3Vq3KeQ75KD1avthoXLtmE3I0PLs=
-github.com/package-url/packageurl-go v0.1.3/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
+github.com/package-url/packageurl-go v0.1.5 h1:O4efRXja2XQ5CtiiYiCZ22k/m7i5ugLiAghgcC+eDgk=
+github.com/package-url/packageurl-go v0.1.5/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
 github.com/pandatix/go-cvss v0.6.2 h1:TFiHlzUkT67s6UkelHmK6s1INKVUG7nlKYiWWDTITGI=
 github.com/pandatix/go-cvss v0.6.2/go.mod h1:jDXYlQBZrc8nvrMUVVvTG8PhmuShOnKrxP53nOFkt8Q=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/providers/k8s/go.mod
+++ b/providers/k8s/go.mod
@@ -225,7 +225,7 @@ require (
 	github.com/olekukonko/tablewriter v1.1.4 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
-	github.com/package-url/packageurl-go v0.1.3 // indirect
+	github.com/package-url/packageurl-go v0.1.5 // indirect
 	github.com/pandatix/go-cvss v0.6.2 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pelletier/go-toml/v2 v2.3.0 // indirect

--- a/providers/k8s/go.sum
+++ b/providers/k8s/go.sum
@@ -774,8 +774,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/package-url/packageurl-go v0.1.3 h1:4juMED3hHiz0set3Vq3KeQ75KD1avthoXLtmE3I0PLs=
-github.com/package-url/packageurl-go v0.1.3/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
+github.com/package-url/packageurl-go v0.1.5 h1:O4efRXja2XQ5CtiiYiCZ22k/m7i5ugLiAghgcC+eDgk=
+github.com/package-url/packageurl-go v0.1.5/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
 github.com/pandatix/go-cvss v0.6.2 h1:TFiHlzUkT67s6UkelHmK6s1INKVUG7nlKYiWWDTITGI=
 github.com/pandatix/go-cvss v0.6.2/go.mod h1:jDXYlQBZrc8nvrMUVVvTG8PhmuShOnKrxP53nOFkt8Q=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/providers/os/resources/packages/apk_packages_test.go
+++ b/providers/os/resources/packages/apk_packages_test.go
@@ -42,7 +42,7 @@ func TestAlpineApkdbParser(t *testing.T) {
 		Arch:        "x86_64",
 		Description: "the musl c library (libc) implementation",
 		Origin:      "musl",
-		PUrl:        "pkg:apk/alpine/musl@1510953106%3A1.1.18-r2?arch=x86_64&distro=alpine-3.7.0&epoch=1510953106",
+		PUrl:        "pkg:apk/alpine/musl@1510953106:1.1.18-r2?arch=x86_64&distro=alpine-3.7.0&epoch=1510953106",
 		CPEs: []string{
 			"cpe:2.3:a:*:musl:1.1.18-r2:*:*:*:*:*:x86_64:*",
 			"cpe:2.3:a:*:musl:1.1.18:*:*:*:*:*:x86_64:*",
@@ -64,7 +64,7 @@ func TestAlpineApkdbParser(t *testing.T) {
 		Arch:        "x86_64",
 		Description: "libressl libcrypto library",
 		Origin:      "libressl",
-		PUrl:        "pkg:apk/alpine/libressl2.6-libcrypto@1510257703%3A2.6.3-r0?arch=x86_64&distro=alpine-3.7.0&epoch=1510257703",
+		PUrl:        "pkg:apk/alpine/libressl2.6-libcrypto@1510257703:2.6.3-r0?arch=x86_64&distro=alpine-3.7.0&epoch=1510257703",
 		CPEs: []string{
 			"cpe:2.3:a:*:libressl2.6-libcrypto:2.6.3-r0:*:*:*:*:*:x86_64:*",
 			"cpe:2.3:a:*:libressl2.6-libcrypto:2.6.3:*:*:*:*:*:x86_64:*",
@@ -86,7 +86,7 @@ func TestAlpineApkdbParser(t *testing.T) {
 		Arch:        "x86_64",
 		Description: "libressl libssl library",
 		Origin:      "libressl",
-		PUrl:        "pkg:apk/alpine/libressl2.6-libssl@1510257703%3A2.6.3-r0?arch=x86_64&distro=alpine-3.7.0&epoch=1510257703",
+		PUrl:        "pkg:apk/alpine/libressl2.6-libssl@1510257703:2.6.3-r0?arch=x86_64&distro=alpine-3.7.0&epoch=1510257703",
 		CPEs: []string{
 			"cpe:2.3:a:*:libressl2.6-libssl:2.6.3-r0:*:*:*:*:*:x86_64:*",
 			"cpe:2.3:a:*:libressl2.6-libssl:2.6.3:*:*:*:*:*:x86_64:*",
@@ -108,7 +108,7 @@ func TestAlpineApkdbParser(t *testing.T) {
 		Arch:        "x86_64",
 		Description: "Alpine Package Keeper - package manager for alpine",
 		Origin:      "apk-tools",
-		PUrl:        "pkg:apk/alpine/apk-tools@1515485577%3A2.8.2-r0?arch=x86_64&distro=alpine-3.7.0&epoch=1515485577",
+		PUrl:        "pkg:apk/alpine/apk-tools@1515485577:2.8.2-r0?arch=x86_64&distro=alpine-3.7.0&epoch=1515485577",
 		CPEs: []string{
 			"cpe:2.3:a:*:apk-tools:2.8.2-r0:*:*:*:*:*:x86_64:*",
 			"cpe:2.3:a:*:apk-tools:2.8.2:*:*:*:*:*:x86_64:*",
@@ -130,7 +130,7 @@ func TestAlpineApkdbParser(t *testing.T) {
 		Arch:        "x86_64",
 		Description: "Size optimized toolbox of many common UNIX utilities",
 		Origin:      "busybox",
-		PUrl:        "pkg:apk/alpine/busybox@1513075346%3A1.27.2-r7?arch=x86_64&distro=alpine-3.7.0&epoch=1513075346",
+		PUrl:        "pkg:apk/alpine/busybox@1513075346:1.27.2-r7?arch=x86_64&distro=alpine-3.7.0&epoch=1513075346",
 		CPEs: []string{
 			"cpe:2.3:a:*:busybox:1.27.2-r7:*:*:*:*:*:x86_64:*",
 			"cpe:2.3:a:*:busybox:1.27.2:*:*:*:*:*:x86_64:*",
@@ -152,7 +152,7 @@ func TestAlpineApkdbParser(t *testing.T) {
 		Arch:        "x86_64",
 		Description: "Alpine base dir structure and init scripts",
 		Origin:      "alpine-baselayout",
-		PUrl:        "pkg:apk/alpine/alpine-baselayout@1510075862%3A3.0.5-r2?arch=x86_64&distro=alpine-3.7.0&epoch=1510075862",
+		PUrl:        "pkg:apk/alpine/alpine-baselayout@1510075862:3.0.5-r2?arch=x86_64&distro=alpine-3.7.0&epoch=1510075862",
 		CPEs: []string{
 			"cpe:2.3:a:*:alpine-baselayout:3.0.5-r2:*:*:*:*:*:x86_64:*",
 			"cpe:2.3:a:*:alpine-baselayout:3.0.5:*:*:*:*:*:x86_64:*",

--- a/providers/os/resources/packages/dpkg_packages_test.go
+++ b/providers/os/resources/packages/dpkg_packages_test.go
@@ -73,7 +73,7 @@ The sfdisk utility is mostly for automation and scripting uses.`,
 The audit-libs package contains the dynamic libraries needed for
 applications to use the audit framework. It is used to monitor systems for
 security related events.`,
-		PUrl: "pkg:deb/ubuntu/libaudit1@1%3A2.4-1%2Bb1?arch=amd64&distro=ubuntu-18.04",
+		PUrl: "pkg:deb/ubuntu/libaudit1@1:2.4-1%2Bb1?arch=amd64&distro=ubuntu-18.04",
 		CPEs: []string{
 			"cpe:2.3:a:libaudit1:libaudit1:2.4-1\\+b1:*:*:*:*:*:amd64:*",
 			"cpe:2.3:a:libaudit1:libaudit1:2.4:*:*:*:*:*:amd64:*",

--- a/providers/os/resources/packages/rpm_packages_test.go
+++ b/providers/os/resources/packages/rpm_packages_test.go
@@ -106,7 +106,7 @@ func TestRedhat8Parser(t *testing.T) {
 		Epoch:       "1",
 		Arch:        "x86_64",
 		Description: "A general purpose cryptography library with TLS implementation",
-		PUrl:        "pkg:rpm/redhat/openssl-libs@1%3A1.1.1g-15.el8_3?arch=x86_64&distro=rhel-8.4&epoch=1",
+		PUrl:        "pkg:rpm/redhat/openssl-libs@1:1.1.1g-15.el8_3?arch=x86_64&distro=rhel-8.4&epoch=1",
 		CPEs: []string{
 			"cpe:2.3:a:red_hat\\,_inc.:openssl-libs:1.1.1g-15.el8_3:1:*:*:*:*:x86_64:*",
 			"cpe:2.3:a:red_hat\\,_inc.:openssl-libs:1.1.1g-15:1:*:*:*:*:x86_64:*",
@@ -130,7 +130,7 @@ func TestRedhat8Parser(t *testing.T) {
 		Epoch:       "1",
 		Arch:        "x86_64",
 		Description: "Libraries for accessing D-BUS",
-		PUrl:        "pkg:rpm/redhat/dbus-libs@1%3A1.12.8-12.el8_4.2?arch=x86_64&distro=rhel-8.4&epoch=1",
+		PUrl:        "pkg:rpm/redhat/dbus-libs@1:1.12.8-12.el8_4.2?arch=x86_64&distro=rhel-8.4&epoch=1",
 		CPEs: []string{
 			"cpe:2.3:a:red_hat\\,_inc.:dbus-libs:1.12.8-12.el8_4.2:1:*:*:*:*:x86_64:*",
 			"cpe:2.3:a:red_hat\\,_inc.:dbus-libs:1.12.8-12:1:*:*:*:*:x86_64:*",
@@ -416,7 +416,7 @@ func TestOracleParser(t *testing.T) {
 
 	p := Package{
 		Name: "ruby",
-		PUrl: "pkg:rpm/oraclelinux/ruby@3.1.7-146.module%2Bel9.5.0%2B90564%2B273a1edd?arch=x86_64&distro=oraclelinux-9&rpmmod=ruby%3A3.1%3A9050020250506050702%3A2e2f0e1c",
+		PUrl: "pkg:rpm/oraclelinux/ruby@3.1.7-146.module%2Bel9.5.0%2B90564%2B273a1edd?arch=x86_64&distro=oraclelinux-9&rpmmod=ruby:3.1:9050020250506050702:2e2f0e1c",
 	}
 	fPkg := findPkg(m, p.Name)
 	assert.Equal(t, p.PUrl, fPkg.PUrl)
@@ -455,7 +455,7 @@ func TestAlmaLinuxParser(t *testing.T) {
 
 	p := Package{
 		Name: "php-cli",
-		PUrl: "pkg:rpm/almalinux/php-cli@7.4.33-2.module_el8.10.0%2B3935%2B28808425?arch=aarch64&distro=almalinux-8.10&rpmmod=php%3A7.4%3A8100020241212065510%3Aeb0869e2",
+		PUrl: "pkg:rpm/almalinux/php-cli@7.4.33-2.module_el8.10.0%2B3935%2B28808425?arch=aarch64&distro=almalinux-8.10&rpmmod=php:7.4:8100020241212065510:eb0869e2",
 	}
 	fPkg := findPkg(m, p.Name)
 	assert.Equal(t, p.PUrl, fPkg.PUrl)
@@ -488,7 +488,7 @@ func TestRedHatModularParser(t *testing.T) {
 	// Verify modular package has rpmmod qualifier
 	p := Package{
 		Name: "php-cli",
-		PUrl: "pkg:rpm/redhat/php-cli@7.4.33-3.module%2Bel8.10.0%2B23902%2Bd3c8dd8f?arch=aarch64&distro=rhel-8.10&rpmmod=php%3A7.4%3A8100020260119075152%3Af7998665",
+		PUrl: "pkg:rpm/redhat/php-cli@7.4.33-3.module%2Bel8.10.0%2B23902%2Bd3c8dd8f?arch=aarch64&distro=rhel-8.10&rpmmod=php:7.4:8100020260119075152:f7998665",
 	}
 	fPkg := findPkg(m, p.Name)
 	assert.Equal(t, p.PUrl, fPkg.PUrl)


### PR DESCRIPTION
## Summary
- Bump `github.com/package-url/packageurl-go` from v0.1.3 to v0.1.5 across all modules
- Remove the version pin comment from root `go.mod`
- Update test expectations: colons (`:`) are no longer percent-encoded (`%3A`) in PURL output per the canonical purl spec

## Test plan
- [x] `go test ./providers/os/resources/packages/` passes
- [x] `go test ./providers/os/resources/purl/` passes
- [x] `go test ./sbom/generator/` passes
- [x] `go fmt` and `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)