### PR TITLE
🧹 close open vsphere connections on asset close

### DIFF
--- a/providers/vsphere/connection/connection.go
+++ b/providers/vsphere/connection/connection.go
@@ -12,6 +12,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
 
+	"github.com/rs/zerolog/log"
 	"github.com/vmware/govmomi"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 )
@@ -83,4 +84,12 @@ func (c *VsphereConnection) Asset() *inventory.Asset {
 
 func (c *VsphereConnection) Client() *govmomi.Client {
 	return c.client
+}
+
+func (c *VsphereConnection) Close() {
+	if c.client != nil {
+		if err := c.client.Logout(context.Background()); err != nil {
+			log.Error().Err(err).Msg("failed to logout from vSphere connection")
+		}
+	}
 }


### PR DESCRIPTION
Close the opened vsphere connection when we disconnect from the asset. This will make sure we don't leave idle connections after a vsphere scan is performed