### PR TITLE
🎉 vsphere-13.0.6

### DIFF
--- a/providers/vsphere/config/config.go
+++ b/providers/vsphere/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vsphere",
 	ID:              "go.mondoo.com/cnquery/v9/providers/vsphere",
-	Version:         "13.0.5",
+	Version:         "13.0.6",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### vsphere (13.0.6)
- 🧹 close open vsphere connections on asset close (#7185)