### PR TITLE
⚡ Add double-check locking cache to aws.iam.user lazy-loaded fields

### DIFF
--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -56668,7 +56668,7 @@ func (c *mqlAwsIamUsercredentialreportentry) GetCreatedAt() *plugin.TValue[*time
 type mqlAwsIamUser struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsIamUserInternal it will be used here
+	mqlAwsIamUserInternal
 	Arn              plugin.TValue[string]
 	Id               plugin.TValue[string]
 	Name             plugin.TValue[string]

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -826,23 +827,23 @@ func initAwsIamUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 }
 
 type mqlAwsIamUserInternal struct {
-	accessKeysFetched bool
+	accessKeysFetched atomic.Bool
 	accessKeysCache   []any
 	accessKeysLock    sync.Mutex
 
-	policiesFetched bool
+	policiesFetched atomic.Bool
 	policiesCache   []any
 	policiesLock    sync.Mutex
 
-	attachedPoliciesFetched bool
+	attachedPoliciesFetched atomic.Bool
 	attachedPoliciesCache   []any
 	attachedPoliciesLock    sync.Mutex
 
-	groupsFetched bool
+	groupsFetched atomic.Bool
 	groupsCache   []any
 	groupsLock    sync.Mutex
 
-	loginProfileFetched bool
+	loginProfileFetched atomic.Bool
 	loginProfileCache   *mqlAwsIamLoginProfile
 	loginProfileLock    sync.Mutex
 }
@@ -855,12 +856,12 @@ func (a *mqlAwsIamUser) id() (string, error) {
 }
 
 func (a *mqlAwsIamUser) accessKeys() ([]any, error) {
-	if a.accessKeysFetched {
+	if a.accessKeysFetched.Load() {
 		return a.accessKeysCache, nil
 	}
 	a.accessKeysLock.Lock()
 	defer a.accessKeysLock.Unlock()
-	if a.accessKeysFetched {
+	if a.accessKeysFetched.Load() {
 		return a.accessKeysCache, nil
 	}
 
@@ -889,17 +890,17 @@ func (a *mqlAwsIamUser) accessKeys() ([]any, error) {
 	}
 
 	a.accessKeysCache = res
-	a.accessKeysFetched = true
+	a.accessKeysFetched.Store(true)
 	return res, nil
 }
 
 func (a *mqlAwsIamUser) policies() ([]any, error) {
-	if a.policiesFetched {
+	if a.policiesFetched.Load() {
 		return a.policiesCache, nil
 	}
 	a.policiesLock.Lock()
 	defer a.policiesLock.Unlock()
-	if a.policiesFetched {
+	if a.policiesFetched.Load() {
 		return a.policiesCache, nil
 	}
 
@@ -927,17 +928,17 @@ func (a *mqlAwsIamUser) policies() ([]any, error) {
 	}
 
 	a.policiesCache = res
-	a.policiesFetched = true
+	a.policiesFetched.Store(true)
 	return res, nil
 }
 
 func (a *mqlAwsIamUser) attachedPolicies() ([]any, error) {
-	if a.attachedPoliciesFetched {
+	if a.attachedPoliciesFetched.Load() {
 		return a.attachedPoliciesCache, nil
 	}
 	a.attachedPoliciesLock.Lock()
 	defer a.attachedPoliciesLock.Unlock()
-	if a.attachedPoliciesFetched {
+	if a.attachedPoliciesFetched.Load() {
 		return a.attachedPoliciesCache, nil
 	}
 
@@ -971,26 +972,26 @@ func (a *mqlAwsIamUser) attachedPolicies() ([]any, error) {
 	}
 
 	a.attachedPoliciesCache = res
-	a.attachedPoliciesFetched = true
+	a.attachedPoliciesFetched.Store(true)
 	return res, nil
 }
 
 type mqlAwsIamPolicyInternal struct {
 	cachePolicy     *iamtypes.Policy
-	policyFetched   bool
+	policyFetched   atomic.Bool
 	policyLock      sync.Mutex
 	cachedVersions  []iamtypes.PolicyVersion
-	versionsFetched bool
+	versionsFetched atomic.Bool
 	versionsLock    sync.Mutex
 }
 
 func (a *mqlAwsIamPolicy) loadPolicy(arn string) (*iamtypes.Policy, error) {
-	if a.policyFetched {
+	if a.policyFetched.Load() {
 		return a.cachePolicy, nil
 	}
 	a.policyLock.Lock()
 	defer a.policyLock.Unlock()
-	if a.policyFetched {
+	if a.policyFetched.Load() {
 		return a.cachePolicy, nil
 	}
 
@@ -1005,7 +1006,7 @@ func (a *mqlAwsIamPolicy) loadPolicy(arn string) (*iamtypes.Policy, error) {
 	}
 
 	a.cachePolicy = policy.Policy
-	a.policyFetched = true
+	a.policyFetched.Store(true)
 	return policy.Policy, nil
 }
 
@@ -1213,12 +1214,12 @@ func (a *mqlAwsIamPolicy) attachedGroups() ([]any, error) {
 // fetchPolicyVersions fetches and caches ListPolicyVersions with double-check locking.
 // Shared between defaultVersion() and versions().
 func (a *mqlAwsIamPolicy) fetchPolicyVersions() ([]iamtypes.PolicyVersion, error) {
-	if a.versionsFetched {
+	if a.versionsFetched.Load() {
 		return a.cachedVersions, nil
 	}
 	a.versionsLock.Lock()
 	defer a.versionsLock.Unlock()
-	if a.versionsFetched {
+	if a.versionsFetched.Load() {
 		return a.cachedVersions, nil
 	}
 
@@ -1233,7 +1234,7 @@ func (a *mqlAwsIamPolicy) fetchPolicyVersions() ([]iamtypes.PolicyVersion, error
 	}
 
 	a.cachedVersions = resp.Versions
-	a.versionsFetched = true
+	a.versionsFetched.Store(true)
 	return a.cachedVersions, nil
 }
 
@@ -1615,12 +1616,12 @@ func (a *mqlAwsIamGroup) inlinePolicies() ([]any, error) {
 }
 
 func (a *mqlAwsIamUser) groups() ([]any, error) {
-	if a.groupsFetched {
+	if a.groupsFetched.Load() {
 		return a.groupsCache, nil
 	}
 	a.groupsLock.Lock()
 	defer a.groupsLock.Unlock()
-	if a.groupsFetched {
+	if a.groupsFetched.Load() {
 		return a.groupsCache, nil
 	}
 
@@ -1648,12 +1649,12 @@ func (a *mqlAwsIamUser) groups() ([]any, error) {
 	}
 
 	a.groupsCache = res
-	a.groupsFetched = true
+	a.groupsFetched.Store(true)
 	return res, nil
 }
 
 func (a *mqlAwsIamUser) loginProfile() (*mqlAwsIamLoginProfile, error) {
-	if a.loginProfileFetched {
+	if a.loginProfileFetched.Load() {
 		if a.loginProfileCache == nil {
 			a.LoginProfile.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil
@@ -1662,7 +1663,7 @@ func (a *mqlAwsIamUser) loginProfile() (*mqlAwsIamLoginProfile, error) {
 	}
 	a.loginProfileLock.Lock()
 	defer a.loginProfileLock.Unlock()
-	if a.loginProfileFetched {
+	if a.loginProfileFetched.Load() {
 		if a.loginProfileCache == nil {
 			a.LoginProfile.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil
@@ -1683,7 +1684,7 @@ func (a *mqlAwsIamUser) loginProfile() (*mqlAwsIamLoginProfile, error) {
 	var ae smithy.APIError
 	if errors.As(err, &ae) {
 		if ae.ErrorCode() == "NoSuchEntity" {
-			a.loginProfileFetched = true
+			a.loginProfileFetched.Store(true)
 			a.LoginProfile.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil
 		}
@@ -1705,7 +1706,7 @@ func (a *mqlAwsIamUser) loginProfile() (*mqlAwsIamLoginProfile, error) {
 		return nil, err
 	}
 	a.loginProfileCache = o.(*mqlAwsIamLoginProfile)
-	a.loginProfileFetched = true
+	a.loginProfileFetched.Store(true)
 	return a.loginProfileCache, nil
 }
 

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -825,6 +825,28 @@ func initAwsIamUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 	return args, nil, nil
 }
 
+type mqlAwsIamUserInternal struct {
+	accessKeysFetched bool
+	accessKeysCache   []any
+	accessKeysLock    sync.Mutex
+
+	policiesFetched bool
+	policiesCache   []any
+	policiesLock    sync.Mutex
+
+	attachedPoliciesFetched bool
+	attachedPoliciesCache   []any
+	attachedPoliciesLock    sync.Mutex
+
+	groupsFetched bool
+	groupsCache   []any
+	groupsLock    sync.Mutex
+
+	loginProfileFetched bool
+	loginProfileCache   *mqlAwsIamLoginProfile
+	loginProfileLock    sync.Mutex
+}
+
 func (a *mqlAwsIamUser) id() (string, error) {
 	if a.Arn.Error != nil {
 		return "", a.Arn.Error
@@ -833,6 +855,15 @@ func (a *mqlAwsIamUser) id() (string, error) {
 }
 
 func (a *mqlAwsIamUser) accessKeys() ([]any, error) {
+	if a.accessKeysFetched {
+		return a.accessKeysCache, nil
+	}
+	a.accessKeysLock.Lock()
+	defer a.accessKeysLock.Unlock()
+	if a.accessKeysFetched {
+		return a.accessKeysCache, nil
+	}
+
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
 	svc := conn.Iam("")
@@ -857,10 +888,21 @@ func (a *mqlAwsIamUser) accessKeys() ([]any, error) {
 		res = append(res, metadata)
 	}
 
+	a.accessKeysCache = res
+	a.accessKeysFetched = true
 	return res, nil
 }
 
 func (a *mqlAwsIamUser) policies() ([]any, error) {
+	if a.policiesFetched {
+		return a.policiesCache, nil
+	}
+	a.policiesLock.Lock()
+	defer a.policiesLock.Unlock()
+	if a.policiesFetched {
+		return a.policiesCache, nil
+	}
+
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
 	svc := conn.Iam("")
@@ -884,10 +926,21 @@ func (a *mqlAwsIamUser) policies() ([]any, error) {
 		}
 	}
 
+	a.policiesCache = res
+	a.policiesFetched = true
 	return res, nil
 }
 
 func (a *mqlAwsIamUser) attachedPolicies() ([]any, error) {
+	if a.attachedPoliciesFetched {
+		return a.attachedPoliciesCache, nil
+	}
+	a.attachedPoliciesLock.Lock()
+	defer a.attachedPoliciesLock.Unlock()
+	if a.attachedPoliciesFetched {
+		return a.attachedPoliciesCache, nil
+	}
+
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
 	svc := conn.Iam("")
@@ -917,6 +970,8 @@ func (a *mqlAwsIamUser) attachedPolicies() ([]any, error) {
 		}
 	}
 
+	a.attachedPoliciesCache = res
+	a.attachedPoliciesFetched = true
 	return res, nil
 }
 
@@ -1560,6 +1615,15 @@ func (a *mqlAwsIamGroup) inlinePolicies() ([]any, error) {
 }
 
 func (a *mqlAwsIamUser) groups() ([]any, error) {
+	if a.groupsFetched {
+		return a.groupsCache, nil
+	}
+	a.groupsLock.Lock()
+	defer a.groupsLock.Unlock()
+	if a.groupsFetched {
+		return a.groupsCache, nil
+	}
+
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
 	svc := conn.Iam("")
@@ -1583,10 +1647,29 @@ func (a *mqlAwsIamUser) groups() ([]any, error) {
 		}
 	}
 
+	a.groupsCache = res
+	a.groupsFetched = true
 	return res, nil
 }
 
 func (a *mqlAwsIamUser) loginProfile() (*mqlAwsIamLoginProfile, error) {
+	if a.loginProfileFetched {
+		if a.loginProfileCache == nil {
+			a.LoginProfile.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		return a.loginProfileCache, nil
+	}
+	a.loginProfileLock.Lock()
+	defer a.loginProfileLock.Unlock()
+	if a.loginProfileFetched {
+		if a.loginProfileCache == nil {
+			a.LoginProfile.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		return a.loginProfileCache, nil
+	}
+
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
 	svc := conn.Iam("")
@@ -1600,6 +1683,7 @@ func (a *mqlAwsIamUser) loginProfile() (*mqlAwsIamLoginProfile, error) {
 	var ae smithy.APIError
 	if errors.As(err, &ae) {
 		if ae.ErrorCode() == "NoSuchEntity" {
+			a.loginProfileFetched = true
 			a.LoginProfile.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil
 		}
@@ -1620,7 +1704,9 @@ func (a *mqlAwsIamUser) loginProfile() (*mqlAwsIamLoginProfile, error) {
 	if err != nil {
 		return nil, err
 	}
-	return o.(*mqlAwsIamLoginProfile), nil
+	a.loginProfileCache = o.(*mqlAwsIamLoginProfile)
+	a.loginProfileFetched = true
+	return a.loginProfileCache, nil
 }
 
 func (a *mqlAwsIamLoginProfile) init() (string, error) {


### PR DESCRIPTION
## Summary
- Adds `mqlAwsIamUserInternal` struct with double-check locking caches for all 5 lazy-loaded fields on `aws.iam.user`: `accessKeys`, `policies`, `attachedPolicies`, `groups`, and `loginProfile`
- Prevents redundant IAM API calls when the same field is accessed multiple times on a user resource
- Follows the same caching pattern already used by `mqlAwsIamPolicy`, `mqlAwsIamSamlProvider`, and `mqlAwsIamOidcProvider`

## Performance impact

Each of the 5 lazy-loaded fields on `aws.iam.user` makes a separate IAM API call (`ListAccessKeys`, `ListUserPolicies`, `ListAttachedUserPolicies`, `ListGroupsForUser`, `GetLoginProfile`). When multiple queries or policy checks access the same field on the same user, the API call is repeated without caching.

In practice, these fields are accessed across multiple query sources during a scan:

| Field | Asset Overview | Security Policy | Incident Response | Total accesses per user |
|---|---|---|---|---|
| `accessKeys` | `accessKeys.length` | `accessKeys.flat.where(...)` | `accessKeys` | 3 |
| `policies` | `policies.length` | `policies == empty` | `policies` | 3 |
| `attachedPolicies` | `attachedPolicies.length` | `attachedPolicies == empty` | `attachedPolicies` | 3 |
| `groups` | `groups` | — | `groups` | 2 |
| `loginProfile` | `loginProfile != null` | — | `loginProfile` | 2 |

Sources:
- **Asset overview**: `server/policy/bundles-internal/asset-overview.mql.yaml` — accesses all 5 fields per IAM user asset
- **AWS security policy**: `cnspec/content/mondoo-aws-security.mql.yaml` — checks `accessKeys`, `policies`, and `attachedPolicies`
- **Incident response pack**: `cnspec/content/querypacks/mondoo-aws-incident-response.mql.yaml` — accesses all 5 fields in a single block

**For a medium AWS account (~50 IAM users), running asset overview + security policy + incident response:**

| | Without cache | With cache | Saved |
|---|---|---|---|
| `ListAccessKeys` | 150 calls (50 × 3) | 50 calls (50 × 1) | **100 calls** |
| `ListUserPolicies` | 150 calls (50 × 3) | 50 calls (50 × 1) | **100 calls** |
| `ListAttachedUserPolicies` | 150 calls (50 × 3) | 50 calls (50 × 1) | **100 calls** |
| `ListGroupsForUser` | 100 calls (50 × 2) | 50 calls (50 × 1) | **50 calls** |
| `GetLoginProfile` | 100 calls (50 × 2) | 50 calls (50 × 1) | **50 calls** |
| **Total** | **650 calls** | **250 calls** | **400 calls saved (62% reduction)** |

## Test plan
- [ ] Build and install the AWS provider (`make providers/build/aws && make providers/install/aws`)
- [ ] Run `mql run aws -c "aws.iam.users { accessKeys policies attachedPolicies groups loginProfile }"` and verify fields resolve correctly
- [ ] Verify users with no login profile still return null (NoSuchEntity handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)