### PR TITLE
🎉 slack-13.1.0

### DIFF
--- a/providers/slack/config/config.go
+++ b/providers/slack/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "slack",
 	ID:              "go.mondoo.com/cnquery/v9/providers/slack",
-	Version:         "13.0.5",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### slack (13.1.0)
- ✨ Add additional Slack user profile fields (#7181)
- ✨ Add SageMaker flexible instance group fields and new Slack user fields (#7180)