### PR TITLE
🎉 aws-13.13.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.12.1",
+	Version:         "13.13.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### aws (13.13.0)
- 🐛 Fix VPC init failing when asset name is a tag instead of VPC ID (#7179)
- 🐛 aws-secret-manager-edgecases-enhancement (#6534)
- 🐛 Fix aws.iam.user.attachedPolicies setting nonexistent 'id' field on aws.iam.policy (#7182)
- ✨ Add SageMaker flexible instance group fields and new Slack user fields (#7180)