### PR TITLE
🐛 Return null resource for missing systemd sockets and timers

### DIFF
--- a/providers/os/resources/systemd_units.go
+++ b/providers/os/resources/systemd_units.go
@@ -83,6 +83,9 @@ func missingSystemdTimerResource(runtime *plugin.Runtime, name string) plugin.Re
 	res.Enabled = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
 	res.Masked = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
 	res.Static = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	res.Activates.State = plugin.StateIsSet | plugin.StateIsNull
+	res.OnCalendar.State = plugin.StateIsSet | plugin.StateIsNull
+	res.Persistent = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
 	res.__id, _ = res.id()
 	return res
 }
@@ -231,6 +234,9 @@ func missingSystemdSocketResource(runtime *plugin.Runtime, name string) plugin.R
 	res.Enabled = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
 	res.Masked = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
 	res.Static = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	res.Activates.State = plugin.StateIsSet | plugin.StateIsNull
+	res.ListenAddresses.State = plugin.StateIsSet | plugin.StateIsNull
+	res.Accept = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
 	res.__id, _ = res.id()
 	return res
 }

--- a/providers/os/resources/systemd_units.go
+++ b/providers/os/resources/systemd_units.go
@@ -47,6 +47,9 @@ func initSystemdTimer(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 	mgr := services.ResolveSystemdTimerManager(conn)
 	timer, err := mgr.Get(name)
 	if err != nil {
+		if errors.Is(err, services.ErrServiceNotFound) {
+			return nil, missingSystemdTimerResource(runtime, name), nil
+		}
 		return nil, nil, err
 	}
 
@@ -68,6 +71,20 @@ func createSystemdTimerResource(runtime *plugin.Runtime, timer *services.Systemd
 		"running":     llx.BoolData(timer.Running),
 		"static":      llx.BoolData(timer.Static),
 	})
+}
+
+func missingSystemdTimerResource(runtime *plugin.Runtime, name string) plugin.Resource {
+	res := &mqlSystemdTimer{}
+	res.MqlRuntime = runtime
+	res.Name = plugin.TValue[string]{Data: name, State: plugin.StateIsSet}
+	res.Description.State = plugin.StateIsSet | plugin.StateIsNull
+	res.Installed = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	res.Running = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	res.Enabled = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	res.Masked = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	res.Static = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	res.__id, _ = res.id()
+	return res
 }
 
 func (t *mqlSystemdTimer) fetchProperties() (map[string]string, error) {
@@ -178,6 +195,9 @@ func initSystemdSocket(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	mgr := services.ResolveSystemdSocketManager(conn)
 	socket, err := mgr.Get(name)
 	if err != nil {
+		if errors.Is(err, services.ErrServiceNotFound) {
+			return nil, missingSystemdSocketResource(runtime, name), nil
+		}
 		return nil, nil, err
 	}
 
@@ -199,6 +219,20 @@ func createSystemdSocketResource(runtime *plugin.Runtime, socket *services.Syste
 		"running":     llx.BoolData(socket.Running),
 		"static":      llx.BoolData(socket.Static),
 	})
+}
+
+func missingSystemdSocketResource(runtime *plugin.Runtime, name string) plugin.Resource {
+	res := &mqlSystemdSocket{}
+	res.MqlRuntime = runtime
+	res.Name = plugin.TValue[string]{Data: name, State: plugin.StateIsSet}
+	res.Description.State = plugin.StateIsSet | plugin.StateIsNull
+	res.Installed = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	res.Running = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	res.Enabled = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	res.Masked = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	res.Static = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	res.__id, _ = res.id()
+	return res
 }
 
 func (s *mqlSystemdSocket) fetchProperties() (map[string]string, error) {

--- a/providers/os/resources/systemd_units.go
+++ b/providers/os/resources/systemd_units.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"errors"
+	"strings"
 	"sync"
 
 	"github.com/rs/zerolog/log"
@@ -73,10 +74,14 @@ func createSystemdTimerResource(runtime *plugin.Runtime, timer *services.Systemd
 	})
 }
 
+func normalizeSystemdUnitLookupName(name string, suffix string) string {
+	return strings.TrimSuffix(name, suffix)
+}
+
 func missingSystemdTimerResource(runtime *plugin.Runtime, name string) plugin.Resource {
 	res := &mqlSystemdTimer{}
 	res.MqlRuntime = runtime
-	res.Name = plugin.TValue[string]{Data: name, State: plugin.StateIsSet}
+	res.Name = plugin.TValue[string]{Data: normalizeSystemdUnitLookupName(name, ".timer"), State: plugin.StateIsSet}
 	res.Description.State = plugin.StateIsSet | plugin.StateIsNull
 	res.Installed = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
 	res.Running = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
@@ -227,7 +232,7 @@ func createSystemdSocketResource(runtime *plugin.Runtime, socket *services.Syste
 func missingSystemdSocketResource(runtime *plugin.Runtime, name string) plugin.Resource {
 	res := &mqlSystemdSocket{}
 	res.MqlRuntime = runtime
-	res.Name = plugin.TValue[string]{Data: name, State: plugin.StateIsSet}
+	res.Name = plugin.TValue[string]{Data: normalizeSystemdUnitLookupName(name, ".socket"), State: plugin.StateIsSet}
 	res.Description.State = plugin.StateIsSet | plugin.StateIsNull
 	res.Installed = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
 	res.Running = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}

--- a/providers/os/resources/systemd_units_internal_test.go
+++ b/providers/os/resources/systemd_units_internal_test.go
@@ -1,0 +1,93 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/connection/mock"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+func newSystemdUnitsTestRuntime(t *testing.T, commands map[string]*mock.Command) *plugin.Runtime {
+	t.Helper()
+
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:    "ubuntu",
+			Version: "22.04",
+			Family:  []string{"ubuntu", "linux"},
+		},
+	}, mock.WithData(&mock.TomlData{Commands: commands}))
+	require.NoError(t, err)
+
+	return &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+}
+
+func TestInitSystemdTimerMissingResource(t *testing.T) {
+	runtime := newSystemdUnitsTestRuntime(t, map[string]*mock.Command{
+		"systemctl show --property=Id,LoadState,ActiveState,UnitFileState,Description missing.timer": {
+			Stdout: strings.Join([]string{
+				"Id=missing.timer",
+				"Description=missing.timer",
+				"LoadState=not-found",
+				"ActiveState=inactive",
+				"UnitFileState=",
+				"",
+			}, "\n"),
+		},
+	})
+
+	for _, input := range []string{"missing", "missing.timer"} {
+		t.Run(input, func(t *testing.T) {
+			_, res, err := initSystemdTimer(runtime, map[string]*llx.RawData{"name": llx.StringData(input)})
+			require.NoError(t, err)
+			require.NotNil(t, res)
+
+			timer := res.(*mqlSystemdTimer)
+			assert.Equal(t, "missing", timer.Name.Data)
+			assert.False(t, timer.Installed.Data)
+			assert.False(t, timer.Enabled.Data)
+			assert.False(t, timer.Running.Data)
+		})
+	}
+}
+
+func TestInitSystemdSocketMissingResource(t *testing.T) {
+	runtime := newSystemdUnitsTestRuntime(t, map[string]*mock.Command{
+		"systemctl show --property=Id,LoadState,ActiveState,UnitFileState,Description missing.socket": {
+			Stdout: strings.Join([]string{
+				"Id=missing.socket",
+				"Description=missing.socket",
+				"LoadState=not-found",
+				"ActiveState=inactive",
+				"UnitFileState=",
+				"",
+			}, "\n"),
+		},
+	})
+
+	for _, input := range []string{"missing", "missing.socket"} {
+		t.Run(input, func(t *testing.T) {
+			_, res, err := initSystemdSocket(runtime, map[string]*llx.RawData{"name": llx.StringData(input)})
+			require.NoError(t, err)
+			require.NotNil(t, res)
+
+			socket := res.(*mqlSystemdSocket)
+			assert.Equal(t, "missing", socket.Name.Data)
+			assert.False(t, socket.Installed.Data)
+			assert.False(t, socket.Enabled.Data)
+			assert.False(t, socket.Running.Data)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `systemd.socket()` and `systemd.timer()` now return a resource with `installed=false` when the unit doesn't exist, matching the existing `service()` behavior
- Previously these errored out, causing policy checks like `systemd.socket("rsh").enabled == false` to fail on systems where the socket isn't installed

Fixes https://github.com/mondoo-community/customer-issues/issues/139

Supersedes https://github.com/mondoohq/cnspec/pull/2373 — the policy workaround is no longer needed since the resource now handles missing units correctly.

## Test plan
- [ ] On a Linux system, verify `systemd.socket("nonexistent").enabled` returns `false` instead of erroring
- [ ] Verify `systemd.socket("nonexistent").installed` returns `false`
- [ ] Verify `systemd.timer("nonexistent").enabled` returns `false` instead of erroring
- [ ] Verify existing sockets/timers still resolve correctly
- [ ] Verify the cnspec CIS checks for rsh/rlogin/rexec/telnet/tftp sockets pass on systems without those sockets installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)