### PR TITLE
Add ApplyConfig to programmatically set viper config

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -225,6 +226,32 @@ func Read() (*Config, error) {
 	}
 
 	return &opts, nil
+}
+
+// ConfigToMap encodes a Config struct into a flat map, respecting mapstructure tags.
+func ConfigToMap(cfg *Config) (map[string]any, error) {
+	m := make(map[string]any)
+	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName: "mapstructure",
+		Result:  &m,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create config encoder")
+	}
+	if err := dec.Decode(cfg); err != nil {
+		return nil, errors.Wrap(err, "failed to encode config")
+	}
+	return m, nil
+}
+
+// ApplyConfig sets all values from the given Config into viper,
+// allowing programmatic configuration without a config file.
+func ApplyConfig(cfg *Config) error {
+	m, err := ConfigToMap(cfg)
+	if err != nil {
+		return err
+	}
+	return viper.MergeConfigMap(m)
 }
 
 type Config struct {

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -228,8 +228,8 @@ func Read() (*Config, error) {
 	return &opts, nil
 }
 
-// ConfigToMap encodes a Config struct into a flat map, respecting mapstructure tags.
-func ConfigToMap(cfg *Config) (map[string]any, error) {
+// configToMap encodes a Config struct into a flat map, respecting mapstructure tags.
+func configToMap(cfg *Config) (map[string]any, error) {
 	m := make(map[string]any)
 	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		TagName: "mapstructure",
@@ -247,7 +247,7 @@ func ConfigToMap(cfg *Config) (map[string]any, error) {
 // ApplyConfig sets all values from the given Config into viper,
 // allowing programmatic configuration without a config file.
 func ApplyConfig(cfg *Config) error {
-	m, err := ConfigToMap(cfg)
+	m, err := configToMap(cfg)
 	if err != nil {
 		return err
 	}

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -226,6 +226,74 @@ space_mrn: //captain.api.mondoo.app/spaces/musing-saha-952142
 		assert.Equal(t, "https://api.example.com", cfg.APIEndpoint)
 	})
 
+	t.Run("test ApplyConfig sets viper values from config", func(t *testing.T) {
+		viper.Reset()
+		viper.SetConfigType("yaml")
+		viper.SetOptions(viper.KeyDelimiter("\\"))
+
+		cfg := &Config{
+			CommonOpts: CommonOpts{
+				AgentMrn:          "//agents.api.mondoo.app/spaces/test/agents/abc",
+				ServiceAccountMrn: "//agents.api.mondoo.app/spaces/test/serviceaccounts/xyz",
+				APIEndpoint:       "https://custom.api.mondoo.com",
+				APIProxy:          "http://proxy:3128",
+				Features:          []string{"feature1", "feature2"},
+				Labels:            map[string]string{"env": "test"},
+				Annotations:       map[string]string{"team": "platform"},
+			},
+			Category:               "cicd",
+			AutoDetectCICDCategory: true,
+		}
+
+		err := ApplyConfig(cfg)
+		require.NoError(t, err)
+
+		assert.Equal(t, "//agents.api.mondoo.app/spaces/test/agents/abc", viper.GetString("agent_mrn"))
+		assert.Equal(t, "//agents.api.mondoo.app/spaces/test/serviceaccounts/xyz", viper.GetString("mrn"))
+		assert.Equal(t, "https://custom.api.mondoo.com", viper.GetString("api_endpoint"))
+		assert.Equal(t, "http://proxy:3128", viper.GetString("api_proxy"))
+		assert.Equal(t, []string{"feature1", "feature2"}, viper.GetStringSlice("features"))
+		assert.Equal(t, "cicd", viper.GetString("category"))
+		assert.Equal(t, true, viper.GetBool("detect-cicd"))
+
+		// Verify round-trip: ApplyConfig then Read should return equivalent config
+		readCfg, err := Read()
+		require.NoError(t, err)
+		assert.Equal(t, cfg.AgentMrn, readCfg.AgentMrn)
+		assert.Equal(t, cfg.ServiceAccountMrn, readCfg.ServiceAccountMrn)
+		assert.Equal(t, cfg.APIEndpoint, readCfg.APIEndpoint)
+		assert.Equal(t, cfg.APIProxy, readCfg.APIProxy)
+		assert.Equal(t, cfg.Features, readCfg.Features)
+		assert.Equal(t, cfg.Category, readCfg.Category)
+		assert.Equal(t, cfg.AutoDetectCICDCategory, readCfg.AutoDetectCICDCategory)
+		assert.Equal(t, cfg.Labels, readCfg.Labels)
+		assert.Equal(t, cfg.Annotations, readCfg.Annotations)
+	})
+
+	t.Run("test ConfigToMap produces correct keys", func(t *testing.T) {
+		cfg := &Config{
+			CommonOpts: CommonOpts{
+				AgentMrn:    "agent-123",
+				APIEndpoint: "https://api.example.com",
+				WIF: WIF{
+					Audience: "//captain.api.mondoo.app/spaces/test",
+				},
+			},
+			Category: "server",
+		}
+
+		m, err := ConfigToMap(cfg)
+		require.NoError(t, err)
+
+		// CommonOpts fields should be squashed to top level
+		assert.Equal(t, "agent-123", m["agent_mrn"])
+		assert.Equal(t, "https://api.example.com", m["api_endpoint"])
+		// WIF fields should also be squashed
+		assert.Equal(t, "//captain.api.mondoo.app/spaces/test", m["audience"])
+		// Config-level fields
+		assert.Equal(t, "server", m["category"])
+	})
+
 	t.Run("test config with annotations", func(t *testing.T) {
 		data := `
 agent_mrn: //agents.api.mondoo.app/spaces/musing-saha-952142/agents/1zDY7auR20SgrFfiGUT5qZWx6mE

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -270,7 +270,7 @@ space_mrn: //captain.api.mondoo.app/spaces/musing-saha-952142
 		assert.Equal(t, cfg.Annotations, readCfg.Annotations)
 	})
 
-	t.Run("test ConfigToMap produces correct keys", func(t *testing.T) {
+	t.Run("test configToMap produces correct keys", func(t *testing.T) {
 		cfg := &Config{
 			CommonOpts: CommonOpts{
 				AgentMrn:    "agent-123",
@@ -282,7 +282,7 @@ space_mrn: //captain.api.mondoo.app/spaces/musing-saha-952142
 			Category: "server",
 		}
 
-		m, err := ConfigToMap(cfg)
+		m, err := configToMap(cfg)
 		require.NoError(t, err)
 
 		// CommonOpts fields should be squashed to top level


### PR DESCRIPTION
## Summary
- Adds `ConfigToMap` function that encodes a `Config` struct into a flat `map[string]any` using mapstructure tags
- Adds `ApplyConfig` function that sets all values from a `Config` struct into viper via `MergeConfigMap`, enabling programmatic configuration without a config file
- Adds tests for both functions, including round-trip verification (`ApplyConfig` -> `Read`)

## Test plan
- [x] `go test ./cli/config/...` passes (new tests included)
- [x] `gofmt` applied to changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)