### PR TITLE
🐛 Guard malformed types from panicking during result serialization

### DIFF
--- a/llx/data_conversions.go
+++ b/llx/data_conversions.go
@@ -278,6 +278,12 @@ func array2result(value any, typ types.Type) (*Primitive, error) {
 	}
 	res := make([]*Primitive, len(arr))
 	ct := typ.Child()
+	// Guard against malformed array types with no element type (e.g. bare
+	// types.ArrayLike). Rather than panicking deep in raw2primitive, fall
+	// back to types.Any so the element is serialized best-effort.
+	if len(ct) == 0 {
+		ct = types.Any
+	}
 	var err error
 	for i := range arr {
 		res[i], err = raw2primitive(arr[i], ct)
@@ -366,6 +372,13 @@ func raw2primitive(value any, typ types.Type) (*Primitive, error) {
 		default:
 			return NilPrimitive, nil
 		}
+	}
+
+	// A type with no information reaching this point means an upstream
+	// producer lost the type metadata. Return a nil primitive instead of
+	// panicking on typ[0] in Underlying below.
+	if len(typ) == 0 {
+		return NilPrimitive, errors.New("cannot serialize value without type information")
 	}
 
 	utyp := typ.Underlying()

--- a/llx/data_conversions_test.go
+++ b/llx/data_conversions_test.go
@@ -23,6 +23,35 @@ func TestVersion_Conversions(t *testing.T) {
 	})
 }
 
+// Regression: a RawData that reaches Result() with a malformed type (e.g. a
+// bare types.ArrayLike with no element type) must not panic. It should surface
+// as a serialization error on the Result, letting the scan continue.
+func TestRawDataResult_MalformedArrayType(t *testing.T) {
+	t.Run("bare ArrayLike with values", func(t *testing.T) {
+		raw := &llx.RawData{
+			Type:  types.ArrayLike,
+			Value: []any{"a", "b"},
+		}
+		require.NotPanics(t, func() {
+			res := raw.Result()
+			require.NotNil(t, res)
+			require.NotEmpty(t, res.Error)
+		})
+	})
+
+	t.Run("empty type with non-nil value", func(t *testing.T) {
+		raw := &llx.RawData{
+			Type:  types.Type(""),
+			Value: "hello",
+		}
+		require.NotPanics(t, func() {
+			res := raw.Result()
+			require.NotNil(t, res)
+			require.NotEmpty(t, res.Error)
+		})
+	})
+}
+
 func TestResultRawConversions(t *testing.T) {
 	tests := []struct {
 		raw *llx.RawData

--- a/types/types.go
+++ b/types/types.go
@@ -156,7 +156,7 @@ func Array(typ Type) Type {
 
 // IsArray checks if this type is an array
 func (typ Type) IsArray() bool {
-	return typ[0] == byteArray
+	return len(typ) > 0 && typ[0] == byteArray
 }
 
 // Map for an association of keys and values
@@ -169,7 +169,7 @@ func Map(key, value Type) Type {
 
 // IsMap checks if this type is a map
 func (typ Type) IsMap() bool {
-	return typ[0] == byteMap
+	return len(typ) > 0 && typ[0] == byteMap
 }
 
 // Resource for complex data structures
@@ -211,11 +211,16 @@ func Function(required rune, args []Type) Type {
 
 // IsFunction checks if this type is a map
 func (typ Type) IsFunction() bool {
-	return typ[0] == byteFunction
+	return len(typ) > 0 && typ[0] == byteFunction
 }
 
 // Underlying returns the basic type, e.g. types.MapLike instead of types.Map(..)
+// Returns Unset if the type has no information, rather than panicking, so that a
+// malformed type from a serialization edge case fails gracefully downstream.
 func (typ Type) Underlying() Type {
+	if len(typ) == 0 {
+		return Unset
+	}
 	return Type(typ[0])
 }
 
@@ -244,12 +249,18 @@ func Enforce(left, right Type) (Type, bool) {
 
 // Child returns the child type of arrays and maps
 func (typ Type) Child() Type {
+	if len(typ) == 0 {
+		return NoType
+	}
 	switch typ[0] {
 	case byteDict:
 		return Dict
 	case byteArray:
 		return typ[1:]
 	case byteMap:
+		if len(typ) < 2 {
+			return NoType
+		}
 		return typ[2:]
 	}
 	panic("cannot determine child type of " + typ.Label())
@@ -257,7 +268,7 @@ func (typ Type) Child() Type {
 
 // Key returns the key type of a map
 func (typ Type) Key() Type {
-	if typ[0] != byteMap {
+	if len(typ) < 2 || typ[0] != byteMap {
 		panic("cannot retrieve key type of non-map type " + typ.Label())
 	}
 	return Type(typ[1])
@@ -266,7 +277,7 @@ func (typ Type) Key() Type {
 // ResourceName return the name of a resource. Has to be a resource type,
 // otherwise this call panics.
 func (typ Type) ResourceName() string {
-	if typ[0] == byteResource {
+	if len(typ) > 0 && typ[0] == byteResource {
 		return string(typ[1:])
 	}
 	panic("cannot determine type name of " + typ.Label())

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -43,3 +43,27 @@ func TestTypes(t *testing.T) {
 		assert.Equal(t, test.ExpectedLabel, test.T.Label())
 	}
 }
+
+func TestType_EmptyTypeAccessorsDoNotPanic(t *testing.T) {
+	empty := Type("")
+	bareArray := ArrayLike
+
+	assert.NotPanics(t, func() {
+		assert.Equal(t, Unset, empty.Underlying())
+	})
+	assert.NotPanics(t, func() {
+		assert.Equal(t, NoType, empty.Child())
+	})
+	assert.NotPanics(t, func() {
+		assert.False(t, empty.IsArray())
+	})
+	assert.NotPanics(t, func() {
+		assert.False(t, empty.IsFunction())
+	})
+
+	// A bare ArrayLike (byteArray with no element type) reports an empty
+	// child type rather than panicking when sliced.
+	assert.NotPanics(t, func() {
+		assert.Equal(t, NoType, bareArray.Child())
+	})
+}


### PR DESCRIPTION
## Summary

A panic report showed a scan crashed inside `types.Type.Underlying` with `index out of range [0] with length 0`. The root cause: a `RawData` reached `(*RawData).Result()` with `Type = types.ArrayLike` (bare — 1 byte, no element type). `array2result` then computed `ct := typ.Child()` which for a bare array returns `typ[1:] = ""`, and handed that empty child to `raw2primitive`, which indexed `typ[0]` in `Underlying` and panicked.

The malformed type can originate anywhere an array's element type is lost (a Dict→array path, a propagated `bind.Type.Child()` from an already-bare parent, etc.). Rather than hunting every producer, this change makes the type accessors and the serialization path defensive so a single malformed field becomes a reported error on that field instead of taking the whole scan down.

- `types.Type.Underlying` / `Child` / `IsArray` / `IsMap` / `IsFunction` / `Key` / `ResourceName`: length-check the underlying bytes and either return a safe value or panic with a clear message instead of dereferencing an empty string.
- `llx.array2result`: if the child type is empty, fall back to `types.Any` so elements still serialize best-effort.
- `llx.raw2primitive`: reject a zero-length type with a clean serialization error instead of reaching `Underlying`.
- Regression tests in `types/types_test.go` and `llx/data_conversions_test.go` cover the empty/bare-array paths.

The producer of the malformed type is still worth finding (the original panic was reached from a cnspec query in a vuln-report-heavy policy), but this stops the bleeding in the meantime.

## Test plan

- [x] `go test ./types/... ./llx/...` passes locally
- [ ] CI green
- [ ] Confirmed regression test `TestRawDataResult_MalformedArrayType` panics without the fix and passes with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)