### PR TITLE
:bug: MQL: cannot add arrays to null

### DIFF
--- a/llx/builtin_array.go
+++ b/llx/builtin_array.go
@@ -232,7 +232,7 @@ func _arrayWhereV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64, in
 	arg1 := chunk.Function.Args[1]
 	if types.Type(arg1.Type).Underlying() != types.FunctionLike {
 		right := arg1.RawData().Value
-		var res []any
+		res := make([]any, 0)
 		for i := range list {
 			left := list[i]
 			if left == right {
@@ -302,7 +302,7 @@ func arrayWhereNotV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) 
 }
 
 func _arraySample(array []any, cnt int64) []any {
-	var res []any
+	res := make([]any, 0)
 	// Note: we still go through the list, even if more items are requested than the list contains.
 	// In that case we only return what we have, but in random order.
 	for i := 0; i < int(cnt) && len(array) > 0; i++ {
@@ -476,7 +476,7 @@ func flatten(v any) []any {
 		return []any{v}
 	}
 
-	var res []any
+	res := make([]any, 0)
 	for i := range list {
 		res = append(res, flatten(list[i])...)
 	}
@@ -829,7 +829,7 @@ func arrayDifferenceV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64
 	org := bind.Value.([]any)
 	filters := arg.Value.([]any)
 
-	var res []any
+	res := make([]any, 0)
 	var skip bool
 	for i := range org {
 		skip = false
@@ -985,7 +985,7 @@ func arrayContainsNone(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64
 	org := bind.Value.([]any)
 	filters := arg.Value.([]any)
 
-	var res []any
+	res := make([]any, 0)
 	for i := range org {
 		for j := range filters {
 			if equalFunc(org[i], filters[j]) {

--- a/llx/builtin_array.go
+++ b/llx/builtin_array.go
@@ -494,7 +494,7 @@ func arrayFlat(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawD
 		return &RawData{Type: bind.Type, Error: errors.New("incorrect type, no array data found")}, 0, nil
 	}
 
-	var res []any
+	res := make([]any, 0)
 	for i := range list {
 		res = append(res, flatten(list[i])...)
 	}

--- a/llx/builtin_array_test.go
+++ b/llx/builtin_array_test.go
@@ -21,3 +21,25 @@ func TestArrayFlat(t *testing.T) {
 		require.Equal(t, ArrayData([]any{}, types.Any), res)
 	})
 }
+
+// Ensure internal array helpers return empty slices (not nil) so that downstream
+// operations like array concatenation do not hit "cannot add arrays to null".
+func TestArrayHelpers_EmptyNotNil(t *testing.T) {
+	t.Run("flatten of empty array returns empty slice", func(t *testing.T) {
+		res := flatten([]any{})
+		require.NotNil(t, res)
+		require.Equal(t, []any{}, res)
+	})
+
+	t.Run("_arraySample with zero count returns empty slice", func(t *testing.T) {
+		res := _arraySample([]any{1, 2, 3}, 0)
+		require.NotNil(t, res)
+		require.Equal(t, []any{}, res)
+	})
+
+	t.Run("_arraySample with empty array returns empty slice", func(t *testing.T) {
+		res := _arraySample([]any{}, 5)
+		require.NotNil(t, res)
+		require.Equal(t, []any{}, res)
+	})
+}

--- a/llx/builtin_array_test.go
+++ b/llx/builtin_array_test.go
@@ -18,6 +18,6 @@ func TestArrayFlat(t *testing.T) {
 		}, nil, 0)
 		require.NoError(t, err)
 		require.Equal(t, uint64(0), ref)
-		require.Equal(t, ArrayData(nil, types.Any), res)
+		require.Equal(t, ArrayData([]any{}, types.Any), res)
 	})
 }

--- a/llx/builtin_map.go
+++ b/llx/builtin_map.go
@@ -1207,7 +1207,7 @@ func dictFlat(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawDa
 		return &RawData{Type: bind.Type, Error: errors.New("incorrect type, no array data found")}, 0, nil
 	}
 
-	var res []any
+	res := make([]any, 0)
 	for i := range list {
 		res = append(res, flatten(list[i])...)
 	}
@@ -1246,7 +1246,7 @@ func dictDifferenceV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64)
 		return &RawData{Type: bind.Type, Error: errors.New("tried to call function with a non-array, please make sure the argument is an array")}, 0, nil
 	}
 
-	var res []any
+	res := make([]any, 0)
 	var skip bool
 	for i := range org {
 		skip = false
@@ -1345,7 +1345,7 @@ func dictContainsNone(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64)
 		// filters = []any{arg.Value}
 	}
 
-	var res []any
+	res := make([]any, 0)
 	var skip bool
 	for i := range org {
 		skip = true

--- a/providers/core/resources/mql_test.go
+++ b/providers/core/resources/mql_test.go
@@ -698,7 +698,7 @@ func TestArray(t *testing.T) {
 		},
 		{
 			Code:        "[2,1,2,1].containsOnly([1,2])",
-			ResultIndex: 0, Expectation: []any(nil),
+			ResultIndex: 0, Expectation: []any{},
 		},
 		{
 			Code:        "a = [1]; [2,1,2,1].containsOnly(a)",
@@ -722,7 +722,7 @@ func TestArray(t *testing.T) {
 		},
 		{
 			Code:        "[2,1,2,1].containsNone([3,4])",
-			ResultIndex: 0, Expectation: []any(nil),
+			ResultIndex: 0, Expectation: []any{},
 		},
 		{
 			Code:        "a = [1]; [2,1,2,1].containsNone(a)",
@@ -739,6 +739,21 @@ func TestArray(t *testing.T) {
 		{
 			Code:        "[3,1,3,4,2] - [3,4,5]",
 			Expectation: []any{int64(1), int64(2)},
+		},
+		// Regression: array-valued builtins must return empty, not null, when no
+		// items remain, so downstream concatenation does not fail with
+		// "cannot add arrays to null".
+		{
+			Code:        "[1,2,3].where(99) + [9]",
+			Expectation: []any{int64(9)},
+		},
+		{
+			Code:        "[1,2,3].sample(0) + [9]",
+			Expectation: []any{int64(9)},
+		},
+		{
+			Code:        "[].flat + [9]",
+			Expectation: []any{int64(9)},
 		},
 	})
 


### PR DESCRIPTION
Fixed 'cannot add arrays to null' on default Debian 13 (no UFW). Root cause: arrayFlat in mql/llx/builtin_array.go returned null (nil Value) for empty array input instead of an empty array, because `var res []any` stays nil when no elements are appended. Fix 1 (mql): changed to `res := make([]any, 0)` so flat on empty input returns [] not null; updated test. Fix 2 (cnspec-enterprise-policies): removed the ufwPaths = [non-existent-file].where().map().flat computation and allPaths = ufwPaths + paths concatenation from all 34 affected checks in queries/debian-13.mql.yaml and all 35 in policies/cis-debian-linux-13.mql.yaml, replacing allPaths.where(...) with paths.where(...). All 35 reported failing checks (1.3.1.4, 1.5.1-1.5.10, 3.3.1.1-3.3.1.18, 3.3.2.1-3.3.2.8) now use null-safe MQL. MQL compiler validated all updated queries as compilable.