### PR TITLE
🧹 Remove the extra ID field in the OCI load balancer resource

### DIFF
--- a/providers/oci/resources/loadbalancer.go
+++ b/providers/oci/resources/loadbalancer.go
@@ -145,7 +145,7 @@ func (o *mqlOciLoadBalancerLoadBalancer) listeners() ([]any, error) {
 		lbId := o.Id.Data
 		listenerId := lbId + "/listener/" + name
 		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.loadBalancer.listener", map[string]*llx.RawData{
-			"id":                       llx.StringData(listenerId),
+			"__id":                     llx.StringData(listenerId),
 			"name":                     llx.StringData(name),
 			"port":                     llx.IntDataPtr(listener.Port),
 			"protocol":                 llx.StringDataPtr(listener.Protocol),
@@ -173,7 +173,7 @@ func (o *mqlOciLoadBalancerLoadBalancer) backendSets() ([]any, error) {
 		lbId := o.Id.Data
 		bsId := lbId + "/backendSet/" + name
 		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.loadBalancer.backendSet", map[string]*llx.RawData{
-			"id":            llx.StringData(bsId),
+			"__id":          llx.StringData(bsId),
 			"name":          llx.StringData(name),
 			"policy":        llx.StringDataPtr(bs.Policy),
 			"healthChecker": llx.DictData(healthChecker),
@@ -188,9 +188,9 @@ func (o *mqlOciLoadBalancerLoadBalancer) backendSets() ([]any, error) {
 }
 
 func (o *mqlOciLoadBalancerListener) id() (string, error) {
-	return o.Id.Data, nil
+	return o.__id, nil
 }
 
 func (o *mqlOciLoadBalancerBackendSet) id() (string, error) {
-	return o.Id.Data, nil
+	return o.__id, nil
 }

--- a/providers/oci/resources/oci.lr
+++ b/providers/oci/resources/oci.lr
@@ -866,8 +866,6 @@ private oci.loadBalancer.loadBalancer @defaults("name") {
 
 // Oracle Cloud Infrastructure (OCI) load balancer listener
 private oci.loadBalancer.listener @defaults("name") {
-  // Listener identifier
-  id string
   // Listener name
   name string
   // Listener port
@@ -886,8 +884,6 @@ private oci.loadBalancer.listener @defaults("name") {
 
 // Oracle Cloud Infrastructure (OCI) load balancer backend set
 private oci.loadBalancer.backendSet @defaults("name") {
-  // Backend set identifier (same as name; OCI backend sets have no OCID)
-  id string
   // Backend set name
   name string
   // Load balancing policy (ROUND_ROBIN, LEAST_CONNECTIONS, IP_HASH)

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -1375,9 +1375,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.loadBalancer.loadBalancer.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerLoadBalancer).GetCreated()).ToDataRes(types.Time)
 	},
-	"oci.loadBalancer.listener.id": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciLoadBalancerListener).GetId()).ToDataRes(types.String)
-	},
 	"oci.loadBalancer.listener.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerListener).GetName()).ToDataRes(types.String)
 	},
@@ -1398,9 +1395,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.loadBalancer.listener.sslVerifyPeerCertificate": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerListener).GetSslVerifyPeerCertificate()).ToDataRes(types.Bool)
-	},
-	"oci.loadBalancer.backendSet.id": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciLoadBalancerBackendSet).GetId()).ToDataRes(types.String)
 	},
 	"oci.loadBalancer.backendSet.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerBackendSet).GetName()).ToDataRes(types.String)
@@ -3096,10 +3090,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciLoadBalancerListener).__id, ok = v.Value.(string)
 		return
 	},
-	"oci.loadBalancer.listener.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciLoadBalancerListener).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.loadBalancer.listener.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciLoadBalancerListener).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -3130,10 +3120,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.loadBalancer.backendSet.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciLoadBalancerBackendSet).__id, ok = v.Value.(string)
-		return
-	},
-	"oci.loadBalancer.backendSet.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciLoadBalancerBackendSet).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.loadBalancer.backendSet.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7769,7 +7755,6 @@ type mqlOciLoadBalancerListener struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlOciLoadBalancerListenerInternal it will be used here
-	Id                       plugin.TValue[string]
 	Name                     plugin.TValue[string]
 	Port                     plugin.TValue[int64]
 	Protocol                 plugin.TValue[string]
@@ -7816,10 +7801,6 @@ func (c *mqlOciLoadBalancerListener) MqlID() string {
 	return c.__id
 }
 
-func (c *mqlOciLoadBalancerListener) GetId() *plugin.TValue[string] {
-	return &c.Id
-}
-
 func (c *mqlOciLoadBalancerListener) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
@@ -7853,7 +7834,6 @@ type mqlOciLoadBalancerBackendSet struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlOciLoadBalancerBackendSetInternal it will be used here
-	Id            plugin.TValue[string]
 	Name          plugin.TValue[string]
 	Policy        plugin.TValue[string]
 	HealthChecker plugin.TValue[any]
@@ -7895,10 +7875,6 @@ func (c *mqlOciLoadBalancerBackendSet) MqlName() string {
 
 func (c *mqlOciLoadBalancerBackendSet) MqlID() string {
 	return c.__id
-}
-
-func (c *mqlOciLoadBalancerBackendSet) GetId() *plugin.TValue[string] {
-	return &c.Id
 }
 
 func (c *mqlOciLoadBalancerBackendSet) GetName() *plugin.TValue[string] {

--- a/providers/oci/resources/oci.lr.versions
+++ b/providers/oci/resources/oci.lr.versions
@@ -215,12 +215,10 @@ oci.loadBalancer 13.0.6
 oci.loadBalancer.backendSet 13.0.6
 oci.loadBalancer.backendSet.backendCount 13.0.6
 oci.loadBalancer.backendSet.healthChecker 13.0.6
-oci.loadBalancer.backendSet.id 13.0.6
 oci.loadBalancer.backendSet.name 13.0.6
 oci.loadBalancer.backendSet.policy 13.0.6
 oci.loadBalancer.listener 13.0.6
 oci.loadBalancer.listener.defaultBackendSetName 13.0.6
-oci.loadBalancer.listener.id 13.0.6
 oci.loadBalancer.listener.name 13.0.6
 oci.loadBalancer.listener.port 13.0.6
 oci.loadBalancer.listener.protocol 13.0.6


### PR DESCRIPTION
I thought this made it into the mega PR. There was no need for this ID field that is the same as the name. We just need it to be the __id under the hood for the resource.