### PR TITLE
🎉 os-13.9.1

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.9.0",
+	Version: "13.9.1",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### os (13.9.1)
- 🐛 Return null resource for missing systemd sockets and timers (#7191)
- 🧹 Bump packageurl-go to v0.1.5 and fix test expectations (#7184)