### PR TITLE
🐛 Fix section-separator comments bleeding into resource titles

### DIFF
--- a/providers-sdk/v1/mqlr/cmd/markdown.go
+++ b/providers-sdk/v1/mqlr/cmd/markdown.go
@@ -152,7 +152,7 @@ func (l *lrSchemaRenderer) renderToc(packName string, description string, resour
 
 	for i := range resources {
 		resource := resources[i]
-		rows = append(rows, []string{"[" + resource.ID + "](" + mdRef(resource.ID) + ")", strings.Join(sanitizeComments([]string{schema.Resources[resource.ID].Title}), " ")})
+		rows = append(rows, []string{"[" + resource.ID + "](" + mdRef(resource.ID) + ")", sanitizeMarkdownText(schema.Resources[resource.ID].Title)})
 	}
 
 	table := tablewriter.NewTable(builder,
@@ -206,7 +206,7 @@ func (l *lrSchemaRenderer) renderResourcePage(resource *lrcore.Resource, schema 
 	builder.WriteString("sidebar_label: " + resource.ID + "\n")
 	builder.WriteString("displayed_sidebar: MQL\n")
 
-	headerDesc := strings.Join(sanitizeComments([]string{schema.Resources[resource.ID].Title}), " ")
+	headerDesc := sanitizeMarkdownText(schema.Resources[resource.ID].Title)
 	if headerDesc != "" {
 		builder.WriteString("description: " + trimColon(headerDesc) + "\n")
 	}
@@ -223,7 +223,7 @@ func (l *lrSchemaRenderer) renderResourcePage(resource *lrcore.Resource, schema 
 
 	if schema.Resources[resource.ID].Title != "" {
 		builder.WriteString("**Description**\n\n")
-		builder.WriteString(strings.Join(sanitizeComments([]string{schema.Resources[resource.ID].Title}), "\n"))
+		builder.WriteString(sanitizeMarkdownText(schema.Resources[resource.ID].Title))
 		builder.WriteString("\n\n")
 	}
 
@@ -250,7 +250,7 @@ func (l *lrSchemaRenderer) renderResourcePage(resource *lrcore.Resource, schema 
 	}
 
 	basicFields := []*lrcore.BasicField{}
-	comments := [][]string{}
+	comments := [][]lrcore.CommentToken{}
 	for _, f := range resource.Body.Fields {
 		if f.BasicField != nil {
 			basicFields = append(basicFields, f.BasicField)
@@ -341,18 +341,19 @@ func renderLrType(t lrcore.Type, resourceHrefMap map[string]bool) string {
 	}
 }
 
-func sanitizeComments(comments []string) []string {
+func sanitizeMarkdownText(s string) string {
+	s = strings.TrimPrefix(s, "// ")
+	// Unescape pre-escaped pipes so all | are uniform, then re-escape them.
+	// Doing it in two passes avoids double-escaping (\\|).
+	s = strings.ReplaceAll(s, `\|`, `|`)
+	s = strings.ReplaceAll(s, `|`, `\|`)
+	return s
+}
+
+func sanitizeComments(comments []lrcore.CommentToken) []string {
 	sanitizedComments := []string{}
 	for _, c := range comments {
-		sanitized := strings.TrimPrefix(c, "// ")
-		// if the comment is pre-escaped, we unescape so that all | are uniform (unescaped)
-		// and get properly escaped in the next 'ReplaceAll'
-		// if we directly try to replace '|' with '\|' for pre-escaped comments
-		// it would look like '\\|' which would break the table.
-		sanitized = strings.ReplaceAll(sanitized, `\|`, `|`)
-		sanitized = strings.ReplaceAll(sanitized, `|`, `\|`)
-		sanitizedComments = append(sanitizedComments, sanitized)
+		sanitizedComments = append(sanitizedComments, sanitizeMarkdownText(c.Text))
 	}
-
 	return sanitizedComments
 }

--- a/providers-sdk/v1/mqlr/cmd/markdown_test.go
+++ b/providers-sdk/v1/mqlr/cmd/markdown_test.go
@@ -7,22 +7,23 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/mqlr/lrcore"
 )
 
 func TestSanitizeComments(t *testing.T) {
-	comments := []string{
-		"",
-		"// ",
-		"// normal comment",
-		"// normal comment | delimiter",
-		"// normal comment \\| pre-escaped delimiter",
+	comments := []lrcore.CommentToken{
+		{Text: ""},
+		{Text: "// "},
+		{Text: "// normal comment"},
+		{Text: "// normal comment | delimiter"},
+		{Text: `// normal comment \| pre-escaped delimiter`},
 	}
 	expected := []string{
 		"",
 		"",
 		"normal comment",
-		"normal comment \\| delimiter",
-		"normal comment \\| pre-escaped delimiter",
+		`normal comment \| delimiter`,
+		`normal comment \| pre-escaped delimiter`,
 	}
 
 	actual := sanitizeComments(comments)

--- a/providers-sdk/v1/mqlr/lrcore/lr.go
+++ b/providers-sdk/v1/mqlr/lrcore/lr.go
@@ -355,6 +355,9 @@ func Parse(input string) (*LR, error) {
 		}
 
 		if resource.Context != "" {
+			// Synthetic token: Pos is intentionally zero-value since this comment
+			// has no source location. Safe for lastCommentGroup (single-element
+			// slice short-circuits before Pos is read).
 			resource.Body.Fields = append(resource.Body.Fields, &Field{
 				Comments: []CommentToken{{Text: "# Contextual info, where this resource is located and defined"}},
 				BasicField: &BasicField{

--- a/providers-sdk/v1/mqlr/lrcore/lr.go
+++ b/providers-sdk/v1/mqlr/lrcore/lr.go
@@ -24,6 +24,13 @@ type Float float64
 // Bool for true/false
 type Bool bool
 
+// CommentToken captures a comment along with its source position,
+// enabling detection of blank-line gaps between comment groups.
+type CommentToken struct {
+	Pos  lexer.Position
+	Text string `@Comment` //nolint:govet // participle grammar tag
+}
+
 var CONTEXT_FIELD = "context"
 
 // Capture a Bool type for participle
@@ -55,11 +62,11 @@ type Alias struct {
 // LR are MQL resources parsed into an AST
 // nolint: govet
 type LR struct {
-	Comments  []string    `{ @Comment }`
-	Imports   []string    `{ "import" @String }`
-	Options   Map         `{ "option" @(Ident '=' String) }`
-	Aliases   []Alias     `{ "alias" @@ }`
-	Resources []*Resource `{ @@ }`
+	Comments  []CommentToken `{ @@ }`
+	Imports   []string       `{ "import" @String }`
+	Options   Map            `{ "option" @(Ident '=' String) }`
+	Aliases   []Alias        `{ "alias" @@ }`
+	Resources []*Resource    `{ @@ }`
 	imports   map[string]map[string]struct{}
 	packPaths map[string]string
 	aliases   map[string]*Resource
@@ -68,7 +75,7 @@ type LR struct {
 // Resource in LR
 // nolint: govet
 type Resource struct {
-	Comments    []string       `{ @Comment }`
+	Comments    []CommentToken `{ @@ }`
 	IsPrivate   bool           `@"private"?`
 	IsExtension bool           `@"extend"?`
 	ID          string         `@Ident { @'.' @Ident }`
@@ -137,10 +144,10 @@ type ResourceDef struct {
 // ResourceDef carrying the definition of the field
 // nolint: govet
 type Field struct {
-	Comments   []string    `{ @Comment }`
-	Init       *Init       `( @@ `
-	Embeddable *Embeddable `| @@`
-	BasicField *BasicField `| @@ )?`
+	Comments   []CommentToken `{ @@ }`
+	Init       *Init          `( @@ `
+	Embeddable *Embeddable    `| @@`
+	BasicField *BasicField    `| @@ )?`
 }
 
 // Init field definition
@@ -214,13 +221,13 @@ func (r *Resource) GetInitFields() []*Init {
 	return inits
 }
 
-func SanitizeComments(raw []string) []string {
+func SanitizeComments(raw []CommentToken) []CommentToken {
 	todoStart := -1
 	for i := range raw {
-		if raw[i] != "" {
-			raw[i] = strings.Trim(raw[i][2:], " \t\n")
+		if raw[i].Text != "" {
+			raw[i].Text = strings.Trim(raw[i].Text[2:], " \t\n")
 		}
-		if todoStart == -1 && strings.HasPrefix(raw[i], "TODO") {
+		if todoStart == -1 && strings.HasPrefix(raw[i].Text, "TODO") {
 			todoStart = i
 		}
 	}
@@ -230,14 +237,32 @@ func SanitizeComments(raw []string) []string {
 	return raw
 }
 
-func extractTitleAndDescription(raw []string) (string, string) {
+// lastCommentGroup returns only the final contiguous group of comments,
+// splitting on blank-line gaps (non-consecutive source lines). This prevents
+// section-separator comment blocks from bleeding into resource/field titles.
+func lastCommentGroup(comments []CommentToken) []CommentToken {
+	if len(comments) <= 1 {
+		return comments
+	}
+	lastGap := 0
+	for i := 1; i < len(comments); i++ {
+		if comments[i].Pos.Line != comments[i-1].Pos.Line+1 {
+			lastGap = i
+		}
+	}
+	return comments[lastGap:]
+}
+
+func extractTitleAndDescription(raw []CommentToken) (string, string) {
 	if len(raw) == 0 {
 		return "", ""
 	}
-	title, rest := raw[0], raw[1:]
-
+	title := raw[0].Text
+	rest := make([]string, len(raw)-1)
+	for i, c := range raw[1:] {
+		rest[i] = c.Text
+	}
 	desc := strings.Join(rest, " ")
-
 	return title, desc
 }
 
@@ -256,6 +281,7 @@ func Parse(input string) (*LR, error) {
 	for i := range res.Resources {
 		resource := res.Resources[i]
 		resource.Comments = SanitizeComments(resource.Comments)
+		resource.Comments = lastCommentGroup(resource.Comments)
 		resource.title, resource.desc = extractTitleAndDescription(resource.Comments)
 		resource.Comments = nil
 
@@ -330,7 +356,7 @@ func Parse(input string) (*LR, error) {
 
 		if resource.Context != "" {
 			resource.Body.Fields = append(resource.Body.Fields, &Field{
-				Comments: []string{"# Contextual info, where this resource is located and defined"},
+				Comments: []CommentToken{{Text: "# Contextual info, where this resource is located and defined"}},
 				BasicField: &BasicField{
 					ID:         CONTEXT_FIELD,
 					Args:       &FieldArgs{},

--- a/providers-sdk/v1/mqlr/lrcore/lr_test.go
+++ b/providers-sdk/v1/mqlr/lrcore/lr_test.go
@@ -122,21 +122,69 @@ func TestParse(t *testing.T) {
 		}
 		`)
 		assert.Equal(t, "name", res.Resources[0].ID)
-		// TODO: needs to be fixed
-		// assert.Equal(t, "resource-docs", res.Resources[0].title)
-		// assert.Equal(t, "with multiline", res.Resources[0].desc)
+		// Note: resource title/desc are empty because LR.Comments greedily
+		// captures all leading comments when there's no option/import before
+		// the first resource. In real .lr files, "option provider = ..." breaks
+		// the sequence so resource comments are attributed correctly.
 
-		f := []*Field{
-			{
-				BasicField: &BasicField{
-					ID:   "field",
-					Args: nil,
-					Type: Type{SimpleType: &SimpleType{"type"}},
-				},
-				Comments: []string{"// field docs..."},
-			},
-		}
-		assert.Equal(t, f, res.Resources[0].Body.Fields)
+		require.Len(t, res.Resources[0].Body.Fields, 1)
+		f := res.Resources[0].Body.Fields[0]
+		assert.Equal(t, &BasicField{
+			ID:   "field",
+			Args: nil,
+			Type: Type{SimpleType: &SimpleType{"type"}},
+		}, f.BasicField)
+		require.Len(t, f.Comments, 1)
+		assert.Equal(t, "// field docs...", f.Comments[0].Text)
+	})
+
+	t.Run("section separator comments don't bleed into resource title", func(t *testing.T) {
+		res := parse(t, `
+option provider = "test"
+
+// ============================================================
+// Section Header
+// ============================================================
+
+// Actual resource description
+name {
+	field type
+}
+`)
+		require.Len(t, res.Resources, 1)
+		assert.Equal(t, "name", res.Resources[0].ID)
+		assert.Equal(t, "Actual resource description", res.Resources[0].title)
+		assert.Equal(t, "", res.Resources[0].desc)
+	})
+
+	t.Run("multiple resources with section separators", func(t *testing.T) {
+		res := parse(t, `
+option provider = "test"
+
+// ============================================================
+// Section A
+// ============================================================
+
+// First resource
+first {
+	val type
+}
+
+// ============================================================
+// Section B
+// ============================================================
+
+// Second resource
+// with extra detail
+second {
+	val type
+}
+`)
+		require.Len(t, res.Resources, 2)
+		assert.Equal(t, "First resource", res.Resources[0].title)
+		assert.Equal(t, "", res.Resources[0].desc)
+		assert.Equal(t, "Second resource", res.Resources[1].title)
+		assert.Equal(t, "with extra detail", res.Resources[1].desc)
 	})
 
 	t.Run("resource with a list type", func(t *testing.T) {
@@ -302,26 +350,26 @@ func TestParse(t *testing.T) {
 		field map[string]int
 	}`)
 
-		fields := []*Field{
-			{
-				BasicField: &BasicField{
-					ID:   "field",
-					Type: Type{MapType: &MapType{Key: SimpleType{"string"}, Value: Type{SimpleType: &SimpleType{"int"}}}},
-				},
-			},
-			{
-				BasicField: &BasicField{
-					ID:   "context",
-					Type: Type{SimpleType: &SimpleType{"file.context"}},
-					Args: &FieldArgs{},
-				},
-				Comments: []string{"# Contextual info, where this resource is located and defined"},
-			},
-		}
 		require.NotEmpty(t, res.Resources)
 		assert.Equal(t, "sth", res.Resources[0].ID)
 		assert.Equal(t, "file.context", res.Resources[0].Context)
-		assert.Equal(t, fields, res.Resources[0].Body.Fields)
+
+		require.Len(t, res.Resources[0].Body.Fields, 2)
+
+		f0 := res.Resources[0].Body.Fields[0]
+		assert.Equal(t, &BasicField{
+			ID:   "field",
+			Type: Type{MapType: &MapType{Key: SimpleType{"string"}, Value: Type{SimpleType: &SimpleType{"int"}}}},
+		}, f0.BasicField)
+
+		f1 := res.Resources[0].Body.Fields[1]
+		assert.Equal(t, &BasicField{
+			ID:   "context",
+			Type: Type{SimpleType: &SimpleType{"file.context"}},
+			Args: &FieldArgs{},
+		}, f1.BasicField)
+		require.Len(t, f1.Comments, 1)
+		assert.Equal(t, "# Contextual info, where this resource is located and defined", f1.Comments[0].Text)
 	})
 }
 

--- a/providers-sdk/v1/mqlr/lrcore/schema.go
+++ b/providers-sdk/v1/mqlr/lrcore/schema.go
@@ -198,6 +198,7 @@ func resourceFields(r *Resource, ast *LR) (map[string]*resources.Field, error) {
 		}
 
 		f.Comments = SanitizeComments(f.Comments)
+		f.Comments = lastCommentGroup(f.Comments)
 		title, desc := extractTitleAndDescription(f.Comments)
 		fields[f.BasicField.ID] = &resources.Field{
 			Name:        f.BasicField.ID,


### PR DESCRIPTION
## Summary
- Section-separator comment blocks (e.g. `// ====...`) in `.lr` files were incorrectly merged into resource titles in `resources.json` because Go's `text/scanner` skips blank lines as whitespace, and participle's `{ @Comment }` rule greedily captured all consecutive comment tokens—even across blank lines
- Replaced `[]string` comment capture with `CommentToken` structs carrying `lexer.Position` (auto-injected by participle), then added `lastCommentGroup()` to detect line-number gaps and keep only the final contiguous comment block
- Before: `"title":"============================================================","desc":"Batch ============================================================ Google Cloud (GCP) Batch service"`
- After: `"title":"Google Cloud (GCP) Batch service","desc":""`

## Test plan
- [x] New unit tests: single section separator, multiple resources with section separators
- [x] All existing `lrcore` and `mqlr/cmd` tests pass
- [x] Regenerated `gcp.resources.json` — verified no `===` in any title/desc field
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)