### PR TITLE
:broom: Downgrade DAX region warning to debug

### DIFF
--- a/providers/aws/resources/aws_dax.go
+++ b/providers/aws/resources/aws_dax.go
@@ -60,7 +60,7 @@ func (a *mqlAwsDynamodb) getDaxClusters(conn *connection.AwsConnection) []*jobpo
 				})
 				if err != nil {
 					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) || isDaxAccessDeniedError(err) {
-						log.Warn().Str("region", region).Msg("error accessing region for AWS DAX API")
+						log.Debug().Str("region", region).Msg("skipping DAX: service not available or access denied in region")
 						return res, nil
 					}
 					return nil, err


### PR DESCRIPTION
## Summary
- Demote DAX region access log from `Warn` to `Debug` — DAX is only available in [~15 AWS regions](https://docs.aws.amazon.com/general/latest/gr/ddb.html), so these messages are expected noise for most accounts
- Clarify the message from "error accessing region" to "skipping DAX: service not available or access denied in region"

## Test plan
- [ ] Run `mql run aws -c "aws.dynamodb.daxClusters"` against an account with multiple regions and verify no warnings appear at default log level
- [ ] Run with `--log-level debug` and verify the messages still appear for unsupported regions

🤖 Generated with [Claude Code](https://claude.com/claude-code)