### PR TITLE
🐛 Fix containsAll mutating its input argument slice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,6 +385,21 @@ When navigating the codebase, these are the critical types you'll encounter:
 - **`providers.Coordinator`** - Manages provider lifecycle and spawning
 - **`providers.Runtime`** - Active provider management per asset
 
+### LLX Builtin Function Invariants
+When implementing or modifying builtin functions in `llx/` (e.g., array/dict operations):
+- **Never mutate slices or maps obtained from `arg.Value` or `bind.Value`.** These reference shared runtime data — the runtime caches resolved values and may return the same `RawData` pointer to multiple callers. Mutating them corrupts the original value for any subsequent use. Always copy before modifying:
+  ```go
+  // WRONG: mutates the argument's backing array in-place
+  filters := arg.Value.([]any)
+  filters = append(filters[0:j], filters[j+1:]...)  // destroys arg.Value for future callers
+
+  // CORRECT: copy first, then mutate the copy
+  argFilters := arg.Value.([]any)
+  filters := make([]any, len(argFilters))
+  copy(filters, argFilters)
+  filters = append(filters[0:j], filters[j+1:]...)  // safe — original untouched
+  ```
+
 ## 6. Development Workflow Patterns
 
 The primary workflow for provider changes is the "Local Provider Debugging" pattern in Section 4. For resource-only changes, follow Steps 1-4 in Section 2.

--- a/llx/builtin_array.go
+++ b/llx/builtin_array.go
@@ -932,7 +932,9 @@ func arrayContainsAll(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64)
 	}
 
 	org := bind.Value.([]any)
-	filters := arg.Value.([]any)
+	argFilters := arg.Value.([]any)
+	filters := make([]any, len(argFilters))
+	copy(filters, argFilters)
 
 	for i := range org {
 		for j := range filters {

--- a/llx/builtin_map.go
+++ b/llx/builtin_map.go
@@ -1291,11 +1291,13 @@ func dictContainsAll(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) 
 		return &RawData{Type: bind.Type, Error: errors.New("cannot compute difference of lists, argument is not a list")}, 0, nil
 	}
 
-	filters, ok := arg.Value.([]any)
+	argFilters, ok := arg.Value.([]any)
 	if !ok {
 		return &RawData{Type: bind.Type, Error: errors.New("tried to call function with a non-array, please make sure the argument is an array")}, 0, nil
 		// filters = []any{arg.Value}
 	}
+	filters := make([]any, len(argFilters))
+	copy(filters, argFilters)
 
 	for i := range org {
 		for j := range filters {

--- a/providers/core/resources/mql_test.go
+++ b/providers/core/resources/mql_test.go
@@ -717,6 +717,10 @@ func TestArray(t *testing.T) {
 			Expectation: []any{int64(3)},
 		},
 		{
+			Code:        "a = [1,2]; [1,2,3].containsAll(a); [1,2,4].containsAll(a)",
+			ResultIndex: 2, Expectation: []any(nil),
+		},
+		{
 			Code:        "[2,1,2,2].containsNone([1])",
 			Expectation: []any{int64(1)},
 		},


### PR DESCRIPTION
## Summary
- `arrayContainsAll` and `dictContainsAll` extracted the filters slice from `arg.Value` as a reference, then mutated it in-place via `append(filters[0:j], filters[j+1:]...)` to remove matched elements
- This destroyed the original argument data, so any subsequent call reusing the same variable saw corrupted values (e.g. `["ftruncate","ftruncate","ftruncate","ftruncate"]` instead of empty)
- Fix: copy the filters slice before mutating it in both `arrayContainsAll` (`llx/builtin_array.go`) and `dictContainsAll` (`llx/builtin_map.go`)

## Test plan
- [x] Added regression test that calls `containsAll` twice with the same variable argument
- [x] All existing `TestArray` tests pass
- [ ] Verify interactively with the original repro query

🤖 Generated with [Claude Code](https://claude.com/claude-code)