### PR TITLE
🐛 Fix CloudTrail cross-account scan errors for S3 and CloudWatch

### DIFF
--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
-  "version": "13.12.0",
-  "generated_at": "2026-04-13T09:58:50-07:00",
+  "version": "13.13.1",
+  "generated_at": "2026-04-15T11:18:18-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindingsV2",

--- a/providers/aws/resources/aws_cloudwatch.go
+++ b/providers/aws/resources/aws_cloudwatch.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	cloudwatchtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
@@ -680,6 +681,24 @@ func initAwsCloudwatchLoggroup(runtime *plugin.Runtime, args map[string]*llx.Raw
 			return args, logGroup, nil
 		}
 	}
+
+	// If the log group is in a different account (e.g., organizational trail referencing
+	// a log group in the management account), create a placeholder resource with basic
+	// info extracted from the ARN instead of failing.
+	conn := runtime.Connection.(*connection.AwsConnection)
+	if parsedArn, parseErr := arn.Parse(arnVal); parseErr == nil && parsedArn.AccountID != conn.AccountId() {
+		log.Warn().Str("arn", arnVal).Str("currentAccount", conn.AccountId()).Str("logGroupAccount", parsedArn.AccountID).Msg("cross-account CloudWatch log group reference")
+		region, groupName := parseLogGroupArn(arnVal)
+		args["name"] = llx.StringData(groupName)
+		args["region"] = llx.StringData(region)
+		args["retentionInDays"] = llx.IntData(0)
+		args["storedBytes"] = llx.IntData(0)
+		args["dataProtectionStatus"] = llx.StringData("")
+		args["deletionProtectionEnabled"] = llx.BoolData(false)
+		args["logGroupClass"] = llx.StringData("")
+		return args, nil, nil
+	}
+
 	return nil, nil, errors.New("cloudwatch log group does not exist")
 }
 

--- a/providers/aws/resources/aws_cloudwatch.go
+++ b/providers/aws/resources/aws_cloudwatch.go
@@ -689,10 +689,13 @@ func initAwsCloudwatchLoggroup(runtime *plugin.Runtime, args map[string]*llx.Raw
 	if parsedArn, parseErr := arn.Parse(arnVal); parseErr == nil && parsedArn.AccountID != conn.AccountId() {
 		log.Warn().Str("arn", arnVal).Str("currentAccount", conn.AccountId()).Str("logGroupAccount", parsedArn.AccountID).Msg("cross-account CloudWatch log group reference")
 		region, groupName := parseLogGroupArn(arnVal)
+		if region == "" || groupName == "" {
+			return nil, nil, errors.New("cloudwatch log group does not exist")
+		}
 		args["name"] = llx.StringData(groupName)
 		args["region"] = llx.StringData(region)
-		args["retentionInDays"] = llx.IntData(0)
-		args["storedBytes"] = llx.IntData(0)
+		args["retentionInDays"] = llx.IntData(-1)
+		args["storedBytes"] = llx.IntData(-1)
 		args["dataProtectionStatus"] = llx.StringData("")
 		args["deletionProtectionEnabled"] = llx.BoolData(false)
 		args["logGroupClass"] = llx.StringData("")

--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -308,6 +308,11 @@ func (a *mqlAwsS3Bucket) tags() (map[string]any, error) {
 }
 
 func (a *mqlAwsS3Bucket) location() (string, error) {
+	// Placeholder buckets (e.g., cross-account references) can't be queried for location
+	if !a.Exists.Data {
+		return "", nil
+	}
+
 	bucketname := a.Name.Data
 
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
@@ -393,6 +398,10 @@ func (a *mqlAwsS3Bucket) acl() ([]any, error) {
 }
 
 func (a *mqlAwsS3Bucket) fetchPublicAccessBlock() (*s3types.PublicAccessBlockConfiguration, error) {
+	// Placeholder buckets (e.g., cross-account references) can't be queried
+	if !a.Exists.Data {
+		return nil, nil
+	}
 	a.publicAccessOnce.Do(func() {
 		bucketname := a.Name.Data
 		location := a.Location.Data
@@ -450,6 +459,10 @@ const (
 )
 
 func (a *mqlAwsS3Bucket) public() (bool, error) {
+	// Placeholder buckets (e.g., cross-account references) can't be queried
+	if !a.Exists.Data {
+		return false, nil
+	}
 	var (
 		bucketname = a.Name.Data
 		location   = a.Location.Data
@@ -572,6 +585,10 @@ func (a *mqlAwsS3Bucket) cors() ([]any, error) {
 }
 
 func (a *mqlAwsS3Bucket) logging() (map[string]any, error) {
+	// Placeholder buckets (e.g., cross-account references) can't be queried
+	if !a.Exists.Data {
+		return nil, nil
+	}
 	bucketname := a.Name.Data
 	bucketlocation := a.Location.Data
 

--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -233,6 +233,11 @@ func (a *mqlAwsS3Bucket) id() (string, error) {
 }
 
 func (a *mqlAwsS3Bucket) policy() (*mqlAwsS3BucketPolicy, error) {
+	// Placeholder buckets (e.g., cross-account references) can't be queried
+	if !a.Exists.Data {
+		a.Policy.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
 	bucketname := a.Name.Data
@@ -277,6 +282,10 @@ func (a *mqlAwsS3Bucket) policy() (*mqlAwsS3BucketPolicy, error) {
 }
 
 func (a *mqlAwsS3Bucket) tags() (map[string]any, error) {
+	// Placeholder buckets (e.g., cross-account references) can't be queried
+	if !a.Exists.Data {
+		return nil, nil
+	}
 	bucketname := a.Name.Data
 	location := a.Location.Data
 
@@ -337,6 +346,10 @@ func (a *mqlAwsS3Bucket) location() (string, error) {
 }
 
 func (a *mqlAwsS3Bucket) gatherAcl() (*s3.GetBucketAclOutput, error) {
+	// Placeholder buckets (e.g., cross-account references) can't be queried
+	if !a.Exists.Data {
+		return nil, nil
+	}
 	a.aclOnce.Do(func() {
 		bucketname := a.Name.Data
 		location := a.Location.Data
@@ -545,6 +558,10 @@ func (a *mqlAwsS3Bucket) public() (bool, error) {
 }
 
 func (a *mqlAwsS3Bucket) cors() ([]any, error) {
+	// Placeholder buckets (e.g., cross-account references) can't be queried
+	if !a.Exists.Data {
+		return nil, nil
+	}
 	bucketname := a.Name.Data
 	location := a.Location.Data
 
@@ -625,6 +642,10 @@ func (a *mqlAwsS3Bucket) logging() (map[string]any, error) {
 }
 
 func (a *mqlAwsS3Bucket) versioning() (map[string]any, error) {
+	// Placeholder buckets (e.g., cross-account references) can't be queried
+	if !a.Exists.Data {
+		return nil, nil
+	}
 	bucketname := a.Name.Data
 	location := a.Location.Data
 
@@ -672,6 +693,10 @@ type mqlAwsS3BucketInternal struct {
 }
 
 func (a *mqlAwsS3Bucket) fetchReplicationConfig() (*s3types.ReplicationConfiguration, error) {
+	// Placeholder buckets (e.g., cross-account references) can't be queried
+	if !a.Exists.Data {
+		return nil, nil
+	}
 	a.replicationOnce.Do(func() {
 		bucketname := a.Name.Data
 		region := a.Location.Data
@@ -695,6 +720,10 @@ func (a *mqlAwsS3Bucket) fetchReplicationConfig() (*s3types.ReplicationConfigura
 }
 
 func (a *mqlAwsS3Bucket) fetchEncryptionConfig() (*s3types.ServerSideEncryptionConfiguration, error) {
+	// Placeholder buckets (e.g., cross-account references) can't be queried
+	if !a.Exists.Data {
+		return nil, nil
+	}
 	a.encryptionOnce.Do(func() {
 		bucketname := a.Name.Data
 		region := a.Location.Data
@@ -869,6 +898,10 @@ func (a *mqlAwsS3BucketMetricsConfiguration) id() (string, error) {
 }
 
 func (a *mqlAwsS3Bucket) metricsConfigurations() ([]any, error) {
+	// Placeholder buckets (e.g., cross-account references) can't be queried
+	if !a.Exists.Data {
+		return nil, nil
+	}
 	bucketName := a.Name.Data
 	region := a.Location.Data
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
@@ -916,6 +949,10 @@ func (a *mqlAwsS3Bucket) metricsConfigurations() ([]any, error) {
 }
 
 func (a *mqlAwsS3Bucket) fetchObjectLockConfig() (*s3types.ObjectLockConfiguration, error) {
+	// Placeholder buckets (e.g., cross-account references) can't be queried
+	if !a.Exists.Data {
+		return nil, nil
+	}
 	a.objectLockOnce.Do(func() {
 		bucketname := a.Name.Data
 		region := a.Location.Data
@@ -977,6 +1014,11 @@ func (a *mqlAwsS3Bucket) staticWebsiteHosting() (map[string]any, error) {
 }
 
 func (a *mqlAwsS3Bucket) website() (*mqlAwsS3BucketWebsiteConfiguration, error) {
+	// Placeholder buckets (e.g., cross-account references) can't be queried
+	if !a.Exists.Data {
+		a.Website.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
 	bucketname := a.Name.Data
 	region := a.Location.Data
 
@@ -1132,6 +1174,10 @@ func (a *mqlAwsS3Bucket) fetchLifecycleConfig() ([]s3types.LifecycleRule, error)
 }
 
 func (a *mqlAwsS3Bucket) lifecycleRules() ([]any, error) {
+	// Placeholder buckets (e.g., cross-account references) can't be queried
+	if !a.Exists.Data {
+		return nil, nil
+	}
 	bucketArn := a.Arn.Data
 
 	rules, err := a.fetchLifecycleConfig()
@@ -1221,6 +1267,10 @@ func (a *mqlAwsS3BucketLifecycleRule) id() (string, error) {
 }
 
 func (a *mqlAwsS3Bucket) notificationConfiguration() (any, error) {
+	// Placeholder buckets (e.g., cross-account references) can't be queried
+	if !a.Exists.Data {
+		return nil, nil
+	}
 	bucketname := a.Name.Data
 	region := a.Location.Data
 
@@ -1271,6 +1321,10 @@ func (a *mqlAwsS3Bucket) notificationConfiguration() (any, error) {
 }
 
 func (a *mqlAwsS3Bucket) ownershipControls() (string, error) {
+	// Placeholder buckets (e.g., cross-account references) can't be queried
+	if !a.Exists.Data {
+		return "", nil
+	}
 	bucketname := a.Name.Data
 	region := a.Location.Data
 


### PR DESCRIPTION
## Summary
- When scanning organizational CloudTrail trails from a member account (`--discover cloudtrail-trails`), cross-account references to S3 buckets and CloudWatch log groups caused errors because those resources live in the management account and can't be discovered/accessed from the member account.
- **CloudWatch log group**: `initAwsCloudwatchLoggroup` now detects cross-account ARNs and creates a placeholder resource with fields extracted from the ARN (name, region, etc.) instead of returning `"cloudwatch log group does not exist"`. This follows the same pattern used for cross-account KMS keys.
- **S3 bucket**: Added `exists` guards to `location()`, `logging()`, `fetchPublicAccessBlock()`, and `public()` so they return nil/empty gracefully for placeholder buckets (`exists=false`) instead of attempting S3 API calls that fail with `PermanentRedirect` due to unknown region.

## Test plan
- [x] Build the AWS provider: `make providers/build/aws && make providers/install/aws`
- [x] Scan an organizational CloudTrail trail from a member account: `cnspec scan aws --discover cloudtrail-trails`
- [x] Verify no `PermanentRedirect` errors for S3 bucket operations
- [x] Verify no `"cloudwatch log group does not exist"` errors
- [x] Verify the cross-account CloudWatch log group warning appears in logs
- [x] Verify `aws.cloudtrail.trail.logGroup != empty` check passes for trails with log groups configured
- [x] Run existing tests: `go test ./providers/aws/resources/ -run "TestParseLogGroupArn|TestS3"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)