### PR TITLE
⭐ Expand Safari extensions with enabled state and uid

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -2515,6 +2515,10 @@ private safari.extension @defaults("name version identifier") {
   containerAppPath string
   // Containing application name
   containerAppName string
+  // Whether the extension is enabled in Safari preferences
+  enabled bool
+  // UID of the user who owns this extension
+  uid int
 }
 
 // macOS launchd job configurations

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -3860,6 +3860,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"safari.extension.containerAppName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlSafariExtension).GetContainerAppName()).ToDataRes(types.String)
 	},
+	"safari.extension.enabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSafariExtension).GetEnabled()).ToDataRes(types.Bool)
+	},
+	"safari.extension.uid": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSafariExtension).GetUid()).ToDataRes(types.Int)
+	},
 	"launchd.jobs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlLaunchd).GetJobs()).ToDataRes(types.Array(types.Resource("launchd.job")))
 	},
@@ -9069,6 +9075,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"safari.extension.containerAppName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlSafariExtension).ContainerAppName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"safari.extension.enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSafariExtension).Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"safari.extension.uid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSafariExtension).Uid, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"launchd.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -24952,6 +24966,8 @@ type mqlSafariExtension struct {
 	Path             plugin.TValue[string]
 	ContainerAppPath plugin.TValue[string]
 	ContainerAppName plugin.TValue[string]
+	Enabled          plugin.TValue[bool]
+	Uid              plugin.TValue[int64]
 }
 
 // createSafariExtension creates a new instance of this resource
@@ -25016,6 +25032,14 @@ func (c *mqlSafariExtension) GetContainerAppPath() *plugin.TValue[string] {
 
 func (c *mqlSafariExtension) GetContainerAppName() *plugin.TValue[string] {
 	return &c.ContainerAppName
+}
+
+func (c *mqlSafariExtension) GetEnabled() *plugin.TValue[bool] {
+	return &c.Enabled
+}
+
+func (c *mqlSafariExtension) GetUid() *plugin.TValue[int64] {
+	return &c.Uid
 }
 
 // mqlLaunchd for the launchd resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -1046,10 +1046,12 @@ safari.extension 11.4.86
 safari.extension.containerAppName 11.4.86
 safari.extension.containerAppPath 11.4.86
 safari.extension.description 11.4.86
+safari.extension.enabled 13.9.3
 safari.extension.extensionType 11.4.86
 safari.extension.identifier 11.4.86
 safari.extension.name 11.4.86
 safari.extension.path 11.4.86
+safari.extension.uid 13.9.3
 safari.extension.version 11.4.86
 safari.extensions 11.4.86
 secpol 9.0.1

--- a/providers/os/resources/safari.go
+++ b/providers/os/resources/safari.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
@@ -44,6 +45,45 @@ func (s *mqlSafari) extensions() ([]any, error) {
 	if _, err := afs.Stat("/usr/bin/pluginkit"); err != nil {
 		log.Warn().Msg("pluginkit command not found at /usr/bin/pluginkit, cannot enumerate Safari extensions")
 		return []any{}, nil
+	}
+
+	// Get users list for uid and per-user Extensions.plist
+	usersResource, err := CreateResource(s.MqlRuntime, "users", map[string]*llx.RawData{})
+	if err != nil {
+		log.Debug().Err(err).Msg("could not get users list")
+	}
+
+	// Build a map of enabled states from each user's Extensions.plist
+	enabledStates := make(map[string]bool)
+	uid := int64(0)
+	if usersResource != nil {
+		users := usersResource.(*mqlUsers)
+		userList := users.GetList()
+		if userList.Error == nil {
+			for _, u := range userList.Data {
+				user := u.(*mqlUser)
+				home := user.GetHome()
+				if home.Error != nil || home.Data == "" {
+					continue
+				}
+				// Only process macOS user homes
+				if !strings.HasPrefix(home.Data, "/Users/") || home.Data == "/Users/Shared" {
+					continue
+				}
+
+				// Get uid from the first valid user (pluginkit returns current user's extensions)
+				if uid == 0 {
+					if uidVal := user.GetUid(); uidVal.Error == nil {
+						uid = uidVal.Data
+					}
+				}
+
+				states := readSafariExtensionStates(&afero.Afero{Fs: afs}, home.Data)
+				for k, v := range states {
+					enabledStates[k] = v
+				}
+			}
+		}
 	}
 
 	seen := make(map[string]bool)
@@ -80,7 +120,7 @@ func (s *mqlSafari) extensions() ([]any, error) {
 				continue
 			}
 
-			ext, err := newSafariExtension(s.MqlRuntime, conn, path, extType)
+			ext, err := newSafariExtension(s.MqlRuntime, conn, path, extType, enabledStates, uid)
 			if err != nil {
 				// Skip extensions we can't parse
 				continue
@@ -92,7 +132,40 @@ func (s *mqlSafari) extensions() ([]any, error) {
 	return extensions, nil
 }
 
-func newSafariExtension(runtime *plugin.Runtime, conn shared.Connection, path string, extType string) (*mqlSafariExtension, error) {
+// readSafariExtensionStates reads Safari's Extensions.plist and returns a map of
+// bundle identifier to enabled state
+func readSafariExtensionStates(afs *afero.Afero, homeDir string) map[string]bool {
+	states := make(map[string]bool)
+
+	plistPath := filepath.Join(homeDir, "Library", "Safari", "Extensions", "Extensions.plist")
+	f, err := afs.Open(plistPath)
+	if err != nil {
+		return states
+	}
+	defer f.Close()
+
+	data, err := plist.Decode(f)
+	if err != nil {
+		log.Debug().Err(err).Str("path", plistPath).Msg("could not decode Safari Extensions.plist")
+		return states
+	}
+
+	// Extensions.plist contains a dict where keys are bundle identifiers
+	// and values are dicts with an "Enabled" boolean
+	for key, val := range data {
+		if extData, ok := val.(map[string]any); ok {
+			if enabled, ok := extData["Enabled"]; ok {
+				if b, ok := enabled.(bool); ok {
+					states[key] = b
+				}
+			}
+		}
+	}
+
+	return states
+}
+
+func newSafariExtension(runtime *plugin.Runtime, conn shared.Connection, path string, extType string, enabledStates map[string]bool, uid int64) (*mqlSafariExtension, error) {
 	afs := conn.FileSystem()
 
 	// Parse Info.plist from the extension bundle
@@ -132,6 +205,12 @@ func newSafariExtension(runtime *plugin.Runtime, conn shared.Connection, path st
 	// Derive extension type name from the pluginkit type
 	extensionTypeName := strings.TrimPrefix(extType, "com.apple.Safari.")
 
+	// Determine enabled state from Extensions.plist
+	enabled := true // default to true if not found in plist
+	if val, ok := enabledStates[identifier]; ok {
+		enabled = val
+	}
+
 	// Create the resource with a unique ID
 	ext, err := CreateResource(runtime, "safari.extension", map[string]*llx.RawData{
 		"__id":             llx.StringData(identifier + "|" + path),
@@ -143,6 +222,8 @@ func newSafariExtension(runtime *plugin.Runtime, conn shared.Connection, path st
 		"path":             llx.StringData(path),
 		"containerAppPath": llx.StringData(containerAppPath),
 		"containerAppName": llx.StringData(containerAppName),
+		"enabled":          llx.BoolData(enabled),
+		"uid":              llx.IntData(uid),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/os/resources/safari.go
+++ b/providers/os/resources/safari.go
@@ -53,35 +53,32 @@ func (s *mqlSafari) extensions() ([]any, error) {
 		log.Debug().Err(err).Msg("could not get users list")
 	}
 
-	// Build a map of enabled states from each user's Extensions.plist
+	// pluginkit returns extensions for the current user only, so we scope
+	// both uid and enabled state to the current user's home directory.
 	enabledStates := make(map[string]bool)
-	uid := int64(0)
+	uid := int64(-1)
 	if usersResource != nil {
 		users := usersResource.(*mqlUsers)
 		userList := users.GetList()
 		if userList.Error == nil {
+			// Find the current user (uid matching the process owner)
+			// Since pluginkit is per-user, we pick the first valid macOS user
+			// and read only their Extensions.plist for consistent uid/enabled pairing.
 			for _, u := range userList.Data {
 				user := u.(*mqlUser)
 				home := user.GetHome()
 				if home.Error != nil || home.Data == "" {
 					continue
 				}
-				// Only process macOS user homes
 				if !strings.HasPrefix(home.Data, "/Users/") || home.Data == "/Users/Shared" {
 					continue
 				}
 
-				// Get uid from the first valid user (pluginkit returns current user's extensions)
-				if uid == 0 {
-					if uidVal := user.GetUid(); uidVal.Error == nil {
-						uid = uidVal.Data
-					}
+				if uidVal := user.GetUid(); uidVal.Error == nil {
+					uid = uidVal.Data
 				}
-
-				states := readSafariExtensionStates(&afero.Afero{Fs: afs}, home.Data)
-				for k, v := range states {
-					enabledStates[k] = v
-				}
+				enabledStates = readSafariExtensionStates(&afero.Afero{Fs: afs}, home.Data)
+				break
 			}
 		}
 	}

--- a/providers/os/resources/safari_test.go
+++ b/providers/os/resources/safari_test.go
@@ -1,0 +1,70 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadSafariExtensionStates(t *testing.T) {
+	// Safari Extensions.plist is a binary plist, but for testing we use XML format
+	// which the plist library also supports
+	plistXML := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.agilebits.onepassword-safari</key>
+	<dict>
+		<key>Enabled</key>
+		<true/>
+	</dict>
+	<key>com.example.disabled-ext</key>
+	<dict>
+		<key>Enabled</key>
+		<false/>
+	</dict>
+	<key>com.example.no-enabled-key</key>
+	<dict>
+		<key>SomeOtherKey</key>
+		<string>value</string>
+	</dict>
+</dict>
+</plist>`
+
+	fs := afero.NewMemMapFs()
+	afs := &afero.Afero{Fs: fs}
+
+	homeDir := "/Users/testuser"
+	plistPath := homeDir + "/Library/Safari/Extensions/Extensions.plist"
+	require.NoError(t, fs.MkdirAll(homeDir+"/Library/Safari/Extensions", 0755))
+	require.NoError(t, afs.WriteFile(plistPath, []byte(plistXML), 0644))
+
+	states := readSafariExtensionStates(afs, homeDir)
+
+	// Enabled extension
+	enabled, ok := states["com.agilebits.onepassword-safari"]
+	assert.True(t, ok)
+	assert.True(t, enabled)
+
+	// Disabled extension
+	disabled, ok := states["com.example.disabled-ext"]
+	assert.True(t, ok)
+	assert.False(t, disabled)
+
+	// Extension without Enabled key should not be in map
+	_, ok = states["com.example.no-enabled-key"]
+	assert.False(t, ok)
+}
+
+func TestReadSafariExtensionStatesNonExistent(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	afs := &afero.Afero{Fs: fs}
+
+	states := readSafariExtensionStates(afs, "/nonexistent/user")
+	assert.Empty(t, states)
+}


### PR DESCRIPTION
## Summary

- Add `enabled` field to `safari.extension` by reading `~/Library/Safari/Extensions/Extensions.plist` and cross-referencing with pluginkit output by bundle identifier
- Add `uid` field for user attribution
- Defaults to `enabled: true` if the extension is not found in the plist (pluginkit returns it but plist may not reference it)

### Example queries

```mql
# Check for disabled Safari extensions
safari.extensions.where(enabled == false) { name identifier }

# List all Safari extensions with user info
safari.extensions { name identifier version enabled uid extensionType }
```

## Test plan

- [x] Unit tests: `go test ./providers/os/resources/ -run TestSafari` — Extensions.plist parsing (enabled/disabled/missing-key), non-existent plist handling
- [ ] Interactive: `cnquery run local -c "safari.extensions { name identifier enabled uid }"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)