### PR TITLE
🎉 oci-13.2.0

### DIFF
--- a/providers/oci/config/config.go
+++ b/providers/oci/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "oci",
 	ID:              "go.mondoo.com/cnquery/v9/providers/oci",
-	Version:         "13.1.0",
+	Version:         "13.2.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### oci (13.2.0)
- ⭐ Add OCI Functions and Container Instances resources (#7220)
- ⭐ Expand OCI provider with new resources and fields (#7219)