### PR TITLE
🎉 os-13.10.0

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.9.2",
+	Version: "13.10.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### os (13.10.0)
- ⭐ Expand Safari extensions with enabled state and uid (#7226)
- ⭐ Expand Firefox addons with permissions, creator, and new fields (#7225)
- ⭐ Expand Chrome extensions with Preferences parsing and new fields (#7224)