### PR TITLE
🧹 Improve provider scaffolding tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -526,7 +526,19 @@ Each provider follows a standard directory layout:
 - **`main.go`** - Provider binary entry point
 - **`gen/main.go`** - Generates CLI configuration JSON
 
-When adding a new provider, you must also register it in these files:
+### Creating a New Provider
+Use the scaffolding tool to generate the provider skeleton:
+```bash
+go run apps/provider-scaffold/provider-scaffold.go \
+  --path providers/your-provider \
+  --provider-id your-provider \
+  --provider-name "Your Provider"
+cd providers/your-provider && go mod tidy
+```
+The Go package path is derived automatically as `go.mondoo.com/mql/v13/providers/{provider-id}`.
+New providers use the ID scheme `go.mondoo.com/mql/providers/{provider-id}` (no version in the ID).
+
+After scaffolding, you must also register the provider in these files:
 - **`providers/defaults.go`** — Add a default entry (alphabetically) so the CLI discovers the provider before it's installed
 - **`README.md`** — Add a row to the provider table (alphabetically)
 - **`DEVELOPMENT.md`** — Add the provider path to the `go.work` provider list (alphabetically)

--- a/apps/provider-scaffold/README.md
+++ b/apps/provider-scaffold/README.md
@@ -18,7 +18,7 @@ cd providers/$PROVIDER && go mod tidy && cd ../..
 $EDITOR providers/$PROVIDER/resources/$PROVIDER.lr
 
 # Generate resource code
-make providers/lr && ./lr generate providers/$PROVIDER/resources/$PROVIDER.lr --dist providers/$PROVIDER/resources
+make providers/mqlr && ./mqlr generate providers/$PROVIDER/resources/$PROVIDER.lr --dist providers/$PROVIDER/resources
 
 # Build and install
 make providers/build/$PROVIDER && make providers/install/$PROVIDER

--- a/apps/provider-scaffold/README.md
+++ b/apps/provider-scaffold/README.md
@@ -1,23 +1,48 @@
 # Provider Scaffold
 
-This tool generates a new provider skeleton for a new provider.
-
-## Pre-requisites
-
-```shell
-go install apps/provider-scaffold/provider-scaffold.go
-```
+This tool generates a new provider skeleton and registers it in the build system.
 
 ## Usage
 
 ```shell
-provider-scaffold --path providers/your-provider --provider-id your-provider --provider-name "Your Provider" --go-package go.mondoo.com/mql/v13/providers/your-provider
+export PROVIDER=digitalocean
+export PROVIDER_NAME="DigitalOcean"
+
+go run apps/provider-scaffold/provider-scaffold.go \
+  --provider-id $PROVIDER \
+  --provider-name "$PROVIDER_NAME"
+
+cd providers/$PROVIDER && go mod tidy && cd ../..
+
+# Edit the resource schema
+$EDITOR providers/$PROVIDER/resources/$PROVIDER.lr
+
+# Generate resource code
+make providers/lr && ./lr generate providers/$PROVIDER/resources/$PROVIDER.lr --dist providers/$PROVIDER/resources
+
+# Build and install
+make providers/build/$PROVIDER && make providers/install/$PROVIDER
+
+# Test
+mql shell $PROVIDER
 ```
 
-Now you have a full provider skeleton in `providers/your-provider` that you can start to implement.
+The scaffold will:
+1. Generate the provider skeleton at `providers/$PROVIDER/`
+2. Add `$PROVIDER` to the `PROVIDERS` list in `Makefile`
+3. Add `./mql/providers/$PROVIDER` to the `go.work` block in `DEVELOPMENT.md`
 
-Next run `go mod tidy` to update the go.mod file.
-```shell
-cd providers/your-provider
-go mod tidy
-```
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--provider-id` | yes | | Provider identifier (e.g. `digitalocean`, `google-workspace`) |
+| `--provider-name` | yes | | Human-readable name (e.g. `"DigitalOcean"`) |
+| `--path` | no | `providers/{provider-id}` | Output directory |
+| `--force` | no | `false` | Overwrite existing directory |
+
+## Conventions
+
+- **Provider ID**: `go.mondoo.com/mql/providers/{provider-id}` (no version number)
+- **Go package**: `go.mondoo.com/mql/v13/providers/{provider-id}` (derived automatically)
+- **Go identifier**: Hyphen-separated IDs become CamelCase (e.g. `google-workspace` -> `GoogleWorkspaceConnection`)

--- a/apps/provider-scaffold/provider-scaffold.go
+++ b/apps/provider-scaffold/provider-scaffold.go
@@ -4,11 +4,14 @@
 package main
 
 import (
+	"bufio"
 	"embed"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
+	"sort"
 	"strings"
 	"text/template"
 	"unicode"
@@ -30,20 +33,16 @@ type config struct {
 
 func main() {
 	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
-	dir := flags.String("path", "", "path directory where you want to generate the files into")
-	providerID := flags.String("provider-id", "", "provider id")
-	providerName := flags.String("provider-name", "", "provider name")
-	goPackage := flags.String("go-package", "", "go package")
+	dir := flags.String("path", "", "path directory where you want to generate the files into (default: providers/{provider-id})")
+	providerID := flags.String("provider-id", "", "provider id (e.g. digitalocean)")
+	providerName := flags.String("provider-name", "", "provider display name (e.g. \"DigitalOcean\")")
+	force := flags.Bool("force", false, "overwrite existing provider directory")
 
 	if err := flags.Parse(os.Args); err != nil {
 		if err == pflag.ErrHelp {
 			os.Exit(0)
 		}
 		log.Fatal().Err(err).Msg("error: could not parse flags")
-	}
-
-	if *dir == "" {
-		log.Fatal().Msg("--path is required")
 	}
 
 	if *providerID == "" {
@@ -54,8 +53,18 @@ func main() {
 		log.Fatal().Msg("--provider-name is required")
 	}
 
-	if *goPackage == "" {
-		log.Fatal().Msg("--go-package is required")
+	// Derive path from provider ID if not specified.
+	if *dir == "" {
+		*dir = filepath.Join("providers", *providerID)
+	}
+
+	goPackage := "go.mondoo.com/mql/v13/providers/" + *providerID
+
+	// Overwrite protection: check if directory already has files.
+	if !*force {
+		if entries, err := os.ReadDir(*dir); err == nil && len(entries) > 0 {
+			log.Fatal().Str("path", *dir).Msg("directory already exists and is not empty; use --force to overwrite")
+		}
 	}
 
 	err := os.MkdirAll(*dir, os.ModePerm)
@@ -63,22 +72,56 @@ func main() {
 		log.Fatal().Err(err).Msg("could not ensure the provided directory exists")
 	}
 
-	err = generateProvider(config{
+	cfg := config{
 		Path:                *dir,
 		ProviderID:          *providerID,
 		ProviderName:        *providerName,
-		GoPackage:           *goPackage,
-		CamelcaseProviderID: capitalize(*providerID),
-	})
-	if err != nil {
+		GoPackage:           goPackage,
+		CamelcaseProviderID: toCamelCase(*providerID),
+	}
+
+	if err := generateProvider(cfg); err != nil {
 		log.Fatal().Err(err).Msg("could not generate provider files")
 	}
+
+	// Auto-register in Makefile and DEVELOPMENT.md.
+	if err := registerInMakefile(*providerID); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not update Makefile: %v\n", err)
+	}
+	if err := registerInDevelopmentMd(*providerID); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not update DEVELOPMENT.md: %v\n", err)
+	}
+
+	// Print next steps.
+	fmt.Println()
+	fmt.Printf("Provider scaffolded at %s\n", *dir)
+	fmt.Println()
+	fmt.Println("Next steps:")
+	fmt.Printf("  cd %s && go mod tidy\n", *dir)
+	fmt.Printf("  # Edit resources/%s.lr to define your resources\n", *providerID)
+	fmt.Println("  # Generate resource code:")
+	fmt.Printf("  make providers/lr && ./lr generate %s/resources/%s.lr --dist %s/resources\n", *dir, *providerID, *dir)
+	fmt.Println("  # Build and install:")
+	fmt.Printf("  make providers/build/%s && make providers/install/%s\n", *providerID, *providerID)
+	fmt.Println("  # Test:")
+	fmt.Printf("  mql shell %s\n", *providerID)
 }
 
-func capitalize(str string) string {
-	runes := []rune(str)
-	runes[0] = unicode.ToUpper(runes[0])
-	return string(runes)
+// toCamelCase converts a hyphen-separated provider ID to CamelCase for Go identifiers.
+//
+//	"digitalocean"    -> "Digitalocean"
+//	"google-workspace" -> "GoogleWorkspace"
+//	"my-cool-provider" -> "MyCoolProvider"
+func toCamelCase(s string) string {
+	parts := strings.Split(s, "-")
+	for i := range parts {
+		if len(parts[i]) > 0 {
+			runes := []rune(parts[i])
+			runes[0] = unicode.ToUpper(runes[0])
+			parts[i] = string(runes)
+		}
+	}
+	return strings.Join(parts, "")
 }
 
 func generateProvider(cfg config) error {
@@ -108,7 +151,7 @@ func generateProvider(cfg config) error {
 		}
 
 		destinationFile := filepath.Join(cfg.Path, path)
-		fmt.Println("Render file" + destinationFile)
+		fmt.Println("Render file " + destinationFile)
 
 		input, err := fs.ReadFile(templates, sourceFile)
 		if err != nil {
@@ -120,7 +163,7 @@ func generateProvider(cfg config) error {
 			return err
 		}
 
-		w, err := os.OpenFile(destinationFile, os.O_CREATE|os.O_WRONLY, 0o644)
+		w, err := os.OpenFile(destinationFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 		if err != nil {
 			fmt.Println("Error creating", destinationFile)
 			return err
@@ -134,4 +177,137 @@ func generateProvider(cfg config) error {
 
 		return nil
 	})
+}
+
+// registerInMakefile inserts the provider name alphabetically into the PROVIDERS list.
+func registerInMakefile(providerID string) error {
+	const filename = "Makefile"
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	lines := strings.Split(string(content), "\n")
+
+	// Find the PROVIDERS := \ block and collect entries.
+	startIdx := -1
+	endIdx := -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "PROVIDERS :=") {
+			startIdx = i
+		}
+		if startIdx >= 0 && i > startIdx {
+			// Lines in the block end with \, the last one doesn't.
+			if !strings.HasSuffix(trimmed, "\\") {
+				endIdx = i
+				break
+			}
+		}
+	}
+
+	if startIdx < 0 || endIdx < 0 {
+		return fmt.Errorf("could not find PROVIDERS block in %s", filename)
+	}
+
+	// Extract provider names from the block.
+	var providers []string
+	for i := startIdx + 1; i <= endIdx; i++ {
+		name := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(lines[i]), "\\"))
+		if name != "" {
+			providers = append(providers, name)
+		}
+	}
+
+	// Check if already registered.
+	if slices.Contains(providers, providerID) {
+		fmt.Printf("Makefile: %s already in PROVIDERS list\n", providerID)
+		return nil
+	}
+
+	providers = append(providers, providerID)
+	sort.Strings(providers)
+
+	// Rebuild the PROVIDERS block.
+	var newBlock []string
+	newBlock = append(newBlock, "PROVIDERS := \\")
+	for i, p := range providers {
+		if i < len(providers)-1 {
+			newBlock = append(newBlock, "\t"+p+" \\")
+		} else {
+			newBlock = append(newBlock, "\t"+p)
+		}
+	}
+
+	// Replace the old block.
+	var result []string
+	result = append(result, lines[:startIdx]...)
+	result = append(result, newBlock...)
+	result = append(result, lines[endIdx+1:]...)
+
+	fmt.Printf("Makefile: added %s to PROVIDERS list\n", providerID)
+	return os.WriteFile(filename, []byte(strings.Join(result, "\n")), 0o644)
+}
+
+// registerInDevelopmentMd inserts the provider path into the go.work use block.
+func registerInDevelopmentMd(providerID string) error {
+	const filename = "DEVELOPMENT.md"
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	entry := "./mql/providers/" + providerID
+
+	// Check if already present.
+	if strings.Contains(string(content), entry) {
+		fmt.Printf("DEVELOPMENT.md: %s already present\n", entry)
+		return nil
+	}
+
+	// Find the go.work use block and insert alphabetically.
+	lines := strings.Split(string(content), "\n")
+	scanner := bufio.NewScanner(strings.NewReader(string(content)))
+	_ = scanner
+
+	inserted := false
+	var result []string
+	inUseBlock := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "use (" {
+			inUseBlock = true
+			result = append(result, line)
+			continue
+		}
+
+		if inUseBlock && trimmed == ")" {
+			// End of use block -- if not inserted yet, add before closing.
+			if !inserted {
+				result = append(result, "   "+entry)
+				inserted = true
+			}
+			inUseBlock = false
+			result = append(result, line)
+			continue
+		}
+
+		if inUseBlock && strings.HasPrefix(trimmed, "./mql/providers/") {
+			// Insert before this line if our entry sorts before it.
+			if !inserted && entry < trimmed {
+				result = append(result, "   "+entry)
+				inserted = true
+			}
+		}
+
+		result = append(result, line)
+	}
+
+	if !inserted {
+		return fmt.Errorf("could not find insertion point in %s", filename)
+	}
+
+	fmt.Printf("DEVELOPMENT.md: added %s to go.work use block\n", entry)
+	return os.WriteFile(filename, []byte(strings.Join(result, "\n")), 0o644)
 }

--- a/apps/provider-scaffold/provider-scaffold.go
+++ b/apps/provider-scaffold/provider-scaffold.go
@@ -4,14 +4,12 @@
 package main
 
 import (
-	"bufio"
 	"embed"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strings"
 	"text/template"
 	"unicode"
@@ -100,7 +98,7 @@ func main() {
 	fmt.Printf("  cd %s && go mod tidy\n", *dir)
 	fmt.Printf("  # Edit resources/%s.lr to define your resources\n", *providerID)
 	fmt.Println("  # Generate resource code:")
-	fmt.Printf("  make providers/lr && ./lr generate %s/resources/%s.lr --dist %s/resources\n", *dir, *providerID, *dir)
+	fmt.Printf("  make providers/mqlr && ./mqlr generate %s/resources/%s.lr --dist %s/resources\n", *dir, *providerID, *dir)
 	fmt.Println("  # Build and install:")
 	fmt.Printf("  make providers/build/%s && make providers/install/%s\n", *providerID, *providerID)
 	fmt.Println("  # Test:")
@@ -225,8 +223,15 @@ func registerInMakefile(providerID string) error {
 		return nil
 	}
 
-	providers = append(providers, providerID)
-	sort.Strings(providers)
+	// Insert at sorted position, preserving existing order for other entries.
+	insertIdx := len(providers)
+	for i, p := range providers {
+		if providerID < p {
+			insertIdx = i
+			break
+		}
+	}
+	providers = slices.Insert(providers, insertIdx, providerID)
 
 	// Rebuild the PROVIDERS block.
 	var newBlock []string
@@ -267,9 +272,6 @@ func registerInDevelopmentMd(providerID string) error {
 
 	// Find the go.work use block and insert alphabetically.
 	lines := strings.Split(string(content), "\n")
-	scanner := bufio.NewScanner(strings.NewReader(string(content)))
-	_ = scanner
-
 	inserted := false
 	var result []string
 	inUseBlock := false

--- a/apps/provider-scaffold/provider-scaffold_test.go
+++ b/apps/provider-scaffold/provider-scaffold_test.go
@@ -4,20 +4,119 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
+func TestToCamelCase(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"digitalocean", "Digitalocean"},
+		{"google-workspace", "GoogleWorkspace"},
+		{"my-cool-provider", "MyCoolProvider"},
+		{"aws", "Aws"},
+		{"ms365", "Ms365"},
+	}
+	for _, tt := range tests {
+		got := toCamelCase(tt.input)
+		if got != tt.want {
+			t.Errorf("toCamelCase(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
 func TestGenerator(t *testing.T) {
+	dir := t.TempDir()
+
 	cfg := config{
-		Path:                "../../mql/providers/oci",
-		ProviderID:          "oci",
-		ProviderName:        "Oracle Cloud Infrastructure",
-		GoPackage:           "go.mondoo.com/mql/v13/providers/oci",
-		CamelcaseProviderID: "Oci",
+		Path:                dir,
+		ProviderID:          "test-provider",
+		ProviderName:        "Test Provider",
+		GoPackage:           "go.mondoo.com/mql/v13/providers/test-provider",
+		CamelcaseProviderID: toCamelCase("test-provider"),
 	}
 
 	err := generateProvider(cfg)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// Verify expected files exist.
+	expectedFiles := []string{
+		"main.go",
+		"go.mod",
+		"config/config.go",
+		"connection/connection.go",
+		"provider/provider.go",
+		"gen/main.go",
+		"resources/test-provider.go",
+		"resources/test-provider.lr",
+	}
+	for _, f := range expectedFiles {
+		path := filepath.Join(dir, f)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Errorf("expected file %s does not exist", f)
+		}
+	}
+
+	// Verify copyright headers on all Go files.
+	for _, f := range expectedFiles {
+		if !strings.HasSuffix(f, ".go") && !strings.HasSuffix(f, ".lr") {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(dir, f))
+		if err != nil {
+			t.Errorf("could not read %s: %v", f, err)
+			continue
+		}
+		if !strings.Contains(string(content), "Copyright Mondoo") {
+			t.Errorf("%s is missing copyright header", f)
+		}
+	}
+
+	// Verify provider ID uses new scheme.
+	configContent, err := os.ReadFile(filepath.Join(dir, "config/config.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(configContent), `"go.mondoo.com/mql/providers/test-provider"`) {
+		t.Error("config.go should use provider ID scheme go.mondoo.com/mql/providers/test-provider")
+	}
+
+	// Verify CamelCase in connection struct.
+	connContent, err := os.ReadFile(filepath.Join(dir, "connection/connection.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(connContent), "TestProviderConnection") {
+		t.Error("connection.go should use TestProviderConnection (CamelCase from test-provider)")
+	}
+
+	// Verify .lr has correct option directives.
+	lrContent, err := os.ReadFile(filepath.Join(dir, "resources/test-provider.lr"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(lrContent), `option provider = "go.mondoo.com/mql/providers/test-provider"`) {
+		t.Error(".lr should use provider ID scheme")
+	}
+	if !strings.Contains(string(lrContent), `option go_package = "go.mondoo.com/mql/v13/providers/test-provider/resources"`) {
+		t.Error(".lr should use v13 go_package")
+	}
+
+	// Verify platform ID is not hardcoded to OCI.
+	providerContent, err := os.ReadFile(filepath.Join(dir, "provider/provider.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(providerContent), "/oci/") {
+		t.Error("provider.go should not contain hardcoded /oci/ platform ID")
+	}
+	if !strings.Contains(string(providerContent), "/test-provider/") {
+		t.Error("provider.go should contain /test-provider/ in platform ID")
 	}
 }

--- a/apps/provider-scaffold/template/config/config.go.template
+++ b/apps/provider-scaffold/template/config/config.go.template
@@ -1,3 +1,6 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
 package config
 
 import (
@@ -7,8 +10,8 @@ import (
 
 var Config = plugin.Provider{
 	Name:            "{{ .ProviderID }}",
-	ID:              "{{ .GoPackage }}",
-	Version:         "10.0.0",
+	ID:              "go.mondoo.com/mql/providers/{{ .ProviderID }}",
+	Version:         "13.0.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/apps/provider-scaffold/template/connection/connection.go.template
+++ b/apps/provider-scaffold/template/connection/connection.go.template
@@ -1,3 +1,6 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
 package connection
 
 import (
@@ -31,4 +34,3 @@ func (c *{{ .CamelcaseProviderID }}Connection) Name() string {
 func (c *{{ .CamelcaseProviderID }}Connection) Asset() *inventory.Asset {
 	return c.asset
 }
-

--- a/apps/provider-scaffold/template/gen/main.go.template
+++ b/apps/provider-scaffold/template/gen/main.go.template
@@ -1,3 +1,6 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
 package main
 
 import (

--- a/apps/provider-scaffold/template/go.mod.template
+++ b/apps/provider-scaffold/template/go.mod.template
@@ -1,3 +1,5 @@
 module {{ .GoPackage }}
 
-go 1.22
+replace go.mondoo.com/mql/v13 => ../..
+
+go 1.25.8

--- a/apps/provider-scaffold/template/main.go.template
+++ b/apps/provider-scaffold/template/main.go.template
@@ -1,3 +1,6 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
 package main
 
 import (

--- a/apps/provider-scaffold/template/provider/provider.go.template
+++ b/apps/provider-scaffold/template/provider/provider.go.template
@@ -1,3 +1,6 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
 package provider
 
 import (
@@ -117,8 +120,8 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 }
 
 func (s *Service) detect(asset *inventory.Asset, conn *connection.{{ .CamelcaseProviderID }}Connection) error {
-  // TODO: adjust asset detection
-  asset.Id = conn.Conf.Type
+	// TODO: adjust asset detection
+	asset.Id = conn.Conf.Type
 	asset.Name = conn.Conf.Host
 
 	asset.Platform = &inventory.Platform{
@@ -129,7 +132,7 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.{{ .CamelcaseP
 	}
 
 	// TODO: Add platform IDs
-	asset.PlatformIds = []string{"//platformid.api.mondoo.app/runtime/oci/"}
+	asset.PlatformIds = []string{"//platformid.api.mondoo.app/runtime/{{ .ProviderID }}/"}
 	return nil
 }
 

--- a/apps/provider-scaffold/template/resources/providerid.go.template
+++ b/apps/provider-scaffold/template/resources/providerid.go.template
@@ -1,3 +1,6 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
 package resources
 
 func (r *mql{{ .CamelcaseProviderID }}) id() (string, error) {

--- a/apps/provider-scaffold/template/resources/providerid.lr.template
+++ b/apps/provider-scaffold/template/resources/providerid.lr.template
@@ -1,4 +1,7 @@
-option provider = "{{ .GoPackage }}"
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+option provider = "go.mondoo.com/mql/providers/{{ .ProviderID }}"
 option go_package = "{{ .GoPackage }}/resources"
 
 // {{ .ProviderName }}


### PR DESCRIPTION
## Summary
- Add copyright headers to all generated template files (CI `copywrite` check)
- Derive `--path` and `--go-package` automatically from `--provider-id` (fewer required flags)
- Fix CamelCase conversion for hyphenated provider IDs (`google-workspace` -> `GoogleWorkspace`)
- Use new provider ID scheme `go.mondoo.com/mql/providers/{id}` (no version, matching core provider)
- Auto-register provider in Makefile `PROVIDERS` list and DEVELOPMENT.md `go.work` block
- Add `--force` flag with overwrite protection for existing directories
- Fix hardcoded `/oci/` platform ID in provider.go template
- Update go.mod template with `replace` directive and current Go version
- Print next steps after scaffolding
- Update tests to use temp directory and verify output correctness
- Document scaffolding workflow in CLAUDE.md

## Before
```shell
provider-scaffold --path providers/your-provider \
  --provider-id your-provider \
  --provider-name "Your Provider" \
  --go-package go.mondoo.com/mql/v13/providers/your-provider
# Then manually: edit Makefile, edit DEVELOPMENT.md, remember to add copyright headers
```

## After
```shell
export PROVIDER=digitalocean
export PROVIDER_NAME="DigitalOcean"
go run apps/provider-scaffold/provider-scaffold.go \
  --provider-id $PROVIDER --provider-name "$PROVIDER_NAME"
# Makefile, DEVELOPMENT.md updated automatically. Copyright headers included. Next steps printed.
```

## Test plan
- [x] `go test ./apps/provider-scaffold/ -v` passes
- [x] `go vet ./apps/provider-scaffold/...` passes
- [x] End-to-end scaffold generates correct files with copyright headers
- [x] Overwrite protection works (errors without `--force`)
- [x] Makefile and DEVELOPMENT.md auto-registration works
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)