### PR TITLE
🐛 Gracefully handle SageMaker regions where service is unavailable

### DIFF
--- a/providers/aws/resources/aws_sagemaker_hub.go
+++ b/providers/aws/resources/aws_sagemaker_hub.go
@@ -97,7 +97,7 @@ func (a *mqlAwsSagemaker) getHubs(conn *connection.AwsConnection) []*jobpool.Job
 			for {
 				out, err := svc.ListHubs(ctx, &sagemaker.ListHubsInput{NextToken: nextToken})
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -236,7 +236,7 @@ func (a *mqlAwsSagemakerHub) contents() ([]any, error) {
 				NextToken:      nextToken,
 			})
 			if err != nil {
-				if Is400AccessDeniedError(err) {
+				if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 					return res, nil
 				}
 				return nil, err

--- a/providers/aws/resources/aws_sagemaker_infra.go
+++ b/providers/aws/resources/aws_sagemaker_infra.go
@@ -228,7 +228,7 @@ func (a *mqlAwsSagemaker) getApps(conn *connection.AwsConnection) []*jobpool.Job
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -543,7 +543,7 @@ func (a *mqlAwsSagemaker) getAppImageConfigs(conn *connection.AwsConnection) []*
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -718,7 +718,7 @@ func (a *mqlAwsSagemaker) getStudioLifecycleConfigs(conn *connection.AwsConnecti
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -840,7 +840,7 @@ func (a *mqlAwsSagemaker) getCodeRepositories(conn *connection.AwsConnection) []
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -1002,7 +1002,7 @@ func (a *mqlAwsSagemaker) getNotebookInstanceLifecycleConfigs(conn *connection.A
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -1124,7 +1124,7 @@ func (a *mqlAwsSagemaker) getImages(conn *connection.AwsConnection) []*jobpool.J
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -1247,7 +1247,7 @@ func (a *mqlAwsSagemakerImage) versions() ([]any, error) {
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			if Is400AccessDeniedError(err) {
+			if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 				return res, nil
 			}
 			return nil, err
@@ -1372,7 +1372,7 @@ func (a *mqlAwsSagemaker) getAlgorithms(conn *connection.AwsConnection) []*jobpo
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -1554,7 +1554,7 @@ func (a *mqlAwsSagemaker) getCompilationJobs(conn *connection.AwsConnection) []*
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}

--- a/providers/aws/resources/aws_sagemaker_labeling.go
+++ b/providers/aws/resources/aws_sagemaker_labeling.go
@@ -160,7 +160,7 @@ func (a *mqlAwsSagemaker) getLabelingJobs(conn *connection.AwsConnection) []*job
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -416,7 +416,7 @@ func (a *mqlAwsSagemaker) getWorkforces(conn *connection.AwsConnection) []*jobpo
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -569,7 +569,7 @@ func (a *mqlAwsSagemaker) getWorkteams(conn *connection.AwsConnection) []*jobpoo
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -712,7 +712,7 @@ func (a *mqlAwsSagemaker) getHumanTaskUis(conn *connection.AwsConnection) []*job
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -857,7 +857,7 @@ func (a *mqlAwsSagemaker) getFlowDefinitions(conn *connection.AwsConnection) []*
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}

--- a/providers/aws/resources/aws_sagemaker_lineage.go
+++ b/providers/aws/resources/aws_sagemaker_lineage.go
@@ -89,7 +89,7 @@ func (a *mqlAwsSagemaker) getArtifacts(conn *connection.AwsConnection) []*jobpoo
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -250,7 +250,7 @@ func (a *mqlAwsSagemaker) getActions(conn *connection.AwsConnection) []*jobpool.
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -421,7 +421,7 @@ func (a *mqlAwsSagemaker) getContexts(conn *connection.AwsConnection) []*jobpool
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -591,7 +591,7 @@ func (a *mqlAwsSagemaker) getAssociations(conn *connection.AwsConnection) []*job
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -663,7 +663,7 @@ func (a *mqlAwsSagemaker) getLineageGroups(conn *connection.AwsConnection) []*jo
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}

--- a/providers/aws/resources/aws_sagemaker_mlops.go
+++ b/providers/aws/resources/aws_sagemaker_mlops.go
@@ -142,7 +142,7 @@ func (a *mqlAwsSagemaker) getExperiments(conn *connection.AwsConnection) []*jobp
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -308,7 +308,7 @@ func (a *mqlAwsSagemaker) getTrials(conn *connection.AwsConnection) []*jobpool.J
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -532,7 +532,7 @@ func (a *mqlAwsSagemaker) getTrialComponents(conn *connection.AwsConnection) []*
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -788,7 +788,7 @@ func (a *mqlAwsSagemaker) getProjects(conn *connection.AwsConnection) []*jobpool
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -997,7 +997,7 @@ func (a *mqlAwsSagemaker) getHyperParameterTuningJobs(conn *connection.AwsConnec
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -1357,7 +1357,7 @@ func (a *mqlAwsSagemaker) getTransformJobs(conn *connection.AwsConnection) []*jo
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -1724,7 +1724,7 @@ func (a *mqlAwsSagemaker) getAutoMLJobs(conn *connection.AwsConnection) []*jobpo
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}


### PR DESCRIPTION
## Summary
- Add `IsServiceNotAvailableInRegionError(err)` alongside the existing `Is400AccessDeniedError(err)` checks in every SageMaker list/describe path across `aws_sagemaker_{hub,infra,labeling,lineage,mlops}.go`.
- Regions that don't offer a given SageMaker surface now log a warning and skip, matching the existing behavior for access-denied errors, instead of failing the whole query.

## Test plan
- [ ] `mql shell aws` against an account with regions where SageMaker is partially available (e.g. opt-in regions) and confirm listing resources (hubs, apps, images, labeling jobs, lineage artifacts, experiments, etc.) no longer errors out.
- [ ] `make providers/build/aws && make providers/install/aws`
- [ ] `make test/lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)