### PR TITLE
🎉 aws-13.14.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.13.3",
+	Version:         "13.14.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### aws (13.14.0)
- ⭐ Add SageMaker hub resources: JumpStart hubs and hub content (#7235)
- ⭐ Add SageMaker lineage resources: artifacts, actions, contexts, associations, lineageGroups (#7234)
- :star: Add SageMaker labeling resources: Ground Truth jobs, workforces, A2I flows (#7232)
- :star: Add SageMaker infrastructure resources: apps, images, code repos, algorithms (#7229)
- ✨ Propagate AWS account tags to discovered assets (#7214)
- :star: Add SageMaker MLOps resources: experiments, tuning, transforms, AutoML (#7228)
- :star: Add SageMaker endpoint configs and monitoring resources (#7227)
- :star: Enrich existing SageMaker resources with deeper field coverage (#7222)