### PR TITLE
🐛 Extend SageMaker region-unavailable handling to Phase 1-2 files

### DIFF
--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.14.1",
-  "generated_at": "2026-04-16T22:15:19-07:00",
+  "generated_at": "2026-04-17T08:01:17-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindingsV2",

--- a/providers/aws/resources/aws_sagemaker.go
+++ b/providers/aws/resources/aws_sagemaker.go
@@ -67,7 +67,7 @@ func (a *mqlAwsSagemaker) getEndpoints(conn *connection.AwsConnection) []*jobpoo
 			for paginator.HasMorePages() {
 				endpoints, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -167,7 +167,7 @@ func (a *mqlAwsSagemaker) getNotebookInstances(conn *connection.AwsConnection) [
 			for paginator.HasMorePages() {
 				notebookInstances, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -774,7 +774,7 @@ func (a *mqlAwsSagemaker) getModels(conn *connection.AwsConnection) []*jobpool.J
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -1030,7 +1030,7 @@ func (a *mqlAwsSagemaker) getTrainingJobs(conn *connection.AwsConnection) []*job
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -1392,7 +1392,7 @@ func (a *mqlAwsSagemaker) getProcessingJobs(conn *connection.AwsConnection) []*j
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -1610,7 +1610,7 @@ func (a *mqlAwsSagemaker) getPipelines(conn *connection.AwsConnection) []*jobpoo
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -1787,7 +1787,7 @@ func (a *mqlAwsSagemaker) getDomains(conn *connection.AwsConnection) []*jobpool.
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
 						return res, nil
 					}
@@ -2124,7 +2124,7 @@ func (a *mqlAwsSagemaker) getInferenceComponents(conn *connection.AwsConnection)
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS SageMaker inference components")
 						return res, nil
 					}
@@ -2294,7 +2294,7 @@ func (a *mqlAwsSagemaker) getClusters(conn *connection.AwsConnection) []*jobpool
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS SageMaker clusters")
 						return res, nil
 					}
@@ -2529,7 +2529,7 @@ func (a *mqlAwsSagemakerCluster) nodes() ([]any, error) {
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			if Is400AccessDeniedError(err) {
+			if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 				log.Warn().Str("cluster", clusterName).Msg("error accessing AWS SageMaker cluster nodes")
 				return res, nil
 			}
@@ -2646,7 +2646,7 @@ func (a *mqlAwsSagemaker) getFeatureGroups(conn *connection.AwsConnection) []*jo
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS SageMaker feature groups")
 						return res, nil
 					}
@@ -2889,7 +2889,7 @@ func (a *mqlAwsSagemaker) getModelPackages(conn *connection.AwsConnection) []*jo
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS SageMaker model packages")
 						return res, nil
 					}
@@ -3131,7 +3131,7 @@ func (a *mqlAwsSagemaker) getModelPackageGroups(conn *connection.AwsConnection) 
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS SageMaker model package groups")
 						return res, nil
 					}
@@ -3305,7 +3305,7 @@ func (a *mqlAwsSagemaker) getModelCards(conn *connection.AwsConnection) []*jobpo
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS SageMaker model cards")
 						return res, nil
 					}
@@ -3475,7 +3475,7 @@ func (a *mqlAwsSagemaker) getSpaces(conn *connection.AwsConnection) []*jobpool.J
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS SageMaker spaces")
 						return res, nil
 					}
@@ -3673,7 +3673,7 @@ func (a *mqlAwsSagemaker) getUserProfiles(conn *connection.AwsConnection) []*job
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS SageMaker user profiles")
 						return res, nil
 					}

--- a/providers/aws/resources/aws_sagemaker_monitoring.go
+++ b/providers/aws/resources/aws_sagemaker_monitoring.go
@@ -56,7 +56,7 @@ func (a *mqlAwsSagemaker) getEndpointConfigs(conn *connection.AwsConnection) []*
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS SageMaker endpoint configs")
 						return res, nil
 					}
@@ -389,7 +389,7 @@ func (a *mqlAwsSagemaker) getMonitoringSchedules(conn *connection.AwsConnection)
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS SageMaker monitoring schedules")
 						return res, nil
 					}
@@ -936,7 +936,7 @@ func (a *mqlAwsSagemaker) getDataQualityJobDefinitions(conn *connection.AwsConne
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS SageMaker data quality job definitions")
 						return res, nil
 					}
@@ -1148,7 +1148,7 @@ func (a *mqlAwsSagemaker) getModelQualityJobDefinitions(conn *connection.AwsConn
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS SageMaker model quality job definitions")
 						return res, nil
 					}
@@ -1360,7 +1360,7 @@ func (a *mqlAwsSagemaker) getModelBiasJobDefinitions(conn *connection.AwsConnect
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS SageMaker model bias job definitions")
 						return res, nil
 					}
@@ -1568,7 +1568,7 @@ func (a *mqlAwsSagemaker) getModelExplainabilityJobDefinitions(conn *connection.
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS SageMaker model explainability job definitions")
 						return res, nil
 					}


### PR DESCRIPTION
## Summary
- Mirror the fix from #7241 across \`aws_sagemaker.go\` and \`aws_sagemaker_monitoring.go\` (Phase 1-2). Every list loop that used to check \`Is400AccessDeniedError\` now also checks \`IsServiceNotAvailableInRegionError\`.
- Without this, DNS lookup failures (\"no such host\" for regional SageMaker endpoints) and \`UnknownOperationException\` errors bubble up and make the top-level query return \`no data available\` for the entire account — even though us-east-1 has resources.

## Repro

\`\`\`
$ mql run aws -c 'aws.sagemaker.endpoints { arn name status }'
operation error SageMaker: ListEndpoints: dial tcp: lookup api.sagemaker.ap-northeast-3.amazonaws.com: no such host
aws.sagemaker.endpoints: no data available
\`\`\`

After the fix, unreachable regions log a warning and are skipped, and the query returns the endpoints from reachable regions.

## Test plan
- [x] \`make providers/build/aws && make providers/install/aws\`
- [x] \`mql run aws -c 'aws.sagemaker.endpoints { arn name status }'\` returns results instead of \`no data available\`
- [x] Found while exercising the full SageMaker resource surface against a real AWS account

🤖 Generated with [Claude Code](https://claude.com/claude-code)