### PR TITLE
✨ Add GitHub Actions SBOM cataloger

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -60,6 +60,7 @@ claude
 clcerts
 cloudflare
 Clusterwide
+codeql
 cmdline
 cmek
 Cmk
@@ -138,6 +139,7 @@ gcs
 GENEVE
 geomatchstatement
 gistfile
+githubactions
 godo
 gopls
 gpc

--- a/docs/adr/009-cnspec-sbom-github-actions.md
+++ b/docs/adr/009-cnspec-sbom-github-actions.md
@@ -1,0 +1,99 @@
+# ADR: cnspec SBOM Cataloger for GitHub Actions
+
+**Status:** Proposed
+**Date:** 2026-04-17
+
+---
+
+## Context
+
+cnspec needs native SBOM cataloging for GitHub Actions to detect action dependencies in CI/CD workflows. GitHub Actions are a supply chain vector — pinning actions to specific commits or versions is a security best practice, and SBOM generation enables auditing which actions (and versions) a repository depends on.
+
+GitHub Actions workflows are defined in YAML files under `.github/workflows/`. Each `uses:` directive references an action by owner, repository, and ref (tag, branch, or commit SHA).
+
+---
+
+## File Formats
+
+### Workflow YAML Files
+
+Located at `.github/workflows/*.yml` (or `.yaml`).
+
+```yaml
+name: CI
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+      - uses: docker/build-push-action@v5.1.0
+      - uses: github/codeql-action/init@v3
+      - run: echo "not an action"
+```
+
+**Key fields:**
+- `jobs.<job>.steps[].uses`: Action reference in `owner/repo@ref` format
+- Nested actions: `owner/repo/path@ref` (e.g., `github/codeql-action/init@v3`)
+- Local actions: `./path/to/action` (skipped — not external dependencies)
+- Docker actions: `docker://image:tag` (skipped — separate ecosystem)
+
+---
+
+## Parsing Strategy
+
+1. Read YAML files via `afero.Fs` using `gopkg.in/yaml.v3` (already in go.mod)
+2. Walk the `jobs` map, iterate each job's `steps` array
+3. Extract `uses` field from each step
+4. Parse `uses` value into owner, repo, optional path, and ref
+5. Skip local actions (`./`) and Docker actions (`docker://`)
+6. Deduplicate by `owner/repo@ref`
+
+### Error Handling
+- Malformed YAML produces a warning and returns partial results
+- Steps without `uses` (e.g., `run:` steps) are silently skipped
+- Invalid `uses` format produces a debug log and is skipped
+
+---
+
+## Package Identification
+
+### PURL
+Format: `pkg:github/<owner>/<repo>@<ref>`
+
+Examples:
+- `pkg:github/actions/checkout@v4`
+- `pkg:github/docker/build-push-action@v5.1.0`
+
+For actions with sub-paths (e.g., `github/codeql-action/init@v3`), the PURL uses the repo only: `pkg:github/github/codeql-action@v3`
+
+### CPE Generation
+Not applicable for GitHub Actions — they don't map to CPE entries. CPEs will be empty.
+
+---
+
+## Dev/Prod Classification
+
+Not applicable — all referenced actions are production CI/CD dependencies.
+
+---
+
+## Remote Scanning Considerations
+
+YAML files are small (< 50KB typically). No special handling needed. All reads through `afero.Fs`.
+
+Default search path: `.github/workflows/`
+
+### Known Limitations
+
+- Only `.github/workflows/` is scanned by default. Composite actions in `.github/actions/` or reusable workflows in other directories are not discovered unless explicitly targeted via `githubactions.packages(path: ".github/actions")`
+- YAML files that are not workflow definitions (e.g., composite action metadata) are silently skipped (no `jobs` key)
+
+---
+
+## Verification Plan
+
+- Fixture-based tests with a multi-job workflow file
+- Edge cases: sub-path actions, Docker actions, local actions, reusable workflows
+- Interactive: `mql run os -c "githubactions.packages(path: '.') { list { name version purl } }"`

--- a/providers/os/resources/githubactions.go
+++ b/providers/os/resources/githubactions.go
@@ -1,0 +1,262 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages/githubactions/workflows"
+	"go.mondoo.com/mql/v13/types"
+)
+
+func initGithubactionsPackages(_ *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if x, ok := args["path"]; ok {
+		_, ok := x.Value.(string)
+		if !ok {
+			return nil, nil, errors.New("wrong type for 'path' in githubactions.packages initialization, it must be a string")
+		}
+	} else {
+		args["path"] = llx.StringData("")
+	}
+	return args, nil, nil
+}
+
+func (r *mqlGithubactionsPackages) id() (string, error) {
+	if r.Path.Data != "" {
+		return "githubactions.packages/" + r.Path.Data, nil
+	}
+	return "githubactions.packages", nil
+}
+
+type mqlGithubactionsPackagesInternal struct {
+	mutex   sync.Mutex
+	fetched bool
+}
+
+func (r *mqlGithubactionsPackages) gatherData() error {
+	if r.fetched {
+		return nil
+	}
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if r.fetched {
+		return nil
+	}
+
+	conn := r.MqlRuntime.Connection.(shared.Connection)
+	fs := conn.FileSystem()
+	afs := &afero.Afero{Fs: fs}
+
+	path := r.Path.Data
+
+	var allDeps []*languages.Package
+	var filePaths []string
+
+	if path != "" {
+		deps, files := collectGithubActionsPackages(afs, fs, path)
+		allDeps = append(allDeps, deps...)
+		filePaths = append(filePaths, files...)
+	} else {
+		// Search default location: .github/workflows/
+		deps, files := collectGithubActionsFromDir(afs, ".github/workflows")
+		allDeps = append(allDeps, deps...)
+		filePaths = append(filePaths, files...)
+	}
+
+	// Deduplicate and sort
+	allDeps = deduplicateGithubActionsPackages(allDeps)
+	slices.SortFunc(allDeps, languages.SortFn)
+
+	// Set list
+	allResources, err := newGithubActionsPackageList(r.MqlRuntime, allDeps)
+	if err != nil {
+		return err
+	}
+	r.List = plugin.TValue[[]any]{Data: allResources, State: plugin.StateIsSet}
+
+	// Set files
+	mqlFiles := []any{}
+	for _, p := range filePaths {
+		lf, err := CreateResource(r.MqlRuntime, "pkgFileInfo", map[string]*llx.RawData{
+			"path": llx.StringData(p),
+		})
+		if err != nil {
+			return err
+		}
+		mqlFiles = append(mqlFiles, lf)
+	}
+	r.Files = plugin.TValue[[]any]{Data: mqlFiles, State: plugin.StateIsSet}
+
+	r.fetched = true
+	return nil
+}
+
+func collectGithubActionsPackages(afs *afero.Afero, fs afero.Fs, path string) ([]*languages.Package, []string) {
+	isDir, err := afs.IsDir(path)
+	if err != nil {
+		log.Debug().Err(err).Str("path", path).Msg("could not check GitHub Actions path")
+		return nil, nil
+	}
+
+	if isDir {
+		return collectGithubActionsFromDir(afs, path)
+	}
+
+	return collectGithubActionsFromFile(afs, path)
+}
+
+func collectGithubActionsFromDir(afs *afero.Afero, dir string) ([]*languages.Package, []string) {
+	var allDeps []*languages.Package
+	var files []string
+
+	entries, err := afs.ReadDir(dir)
+	if err != nil {
+		log.Debug().Err(err).Str("path", dir).Msg("could not read GitHub Actions workflow directory")
+		return nil, nil
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !isWorkflowFile(name) {
+			continue
+		}
+		deps, f := collectGithubActionsFromFile(afs, filepath.Join(dir, name))
+		allDeps = append(allDeps, deps...)
+		files = append(files, f...)
+	}
+
+	return allDeps, files
+}
+
+func collectGithubActionsFromFile(afs *afero.Afero, path string) ([]*languages.Package, []string) {
+	f, err := afs.Open(path)
+	if err != nil {
+		log.Debug().Err(err).Str("path", path).Msg("could not open workflow file")
+		return nil, nil
+	}
+	defer f.Close()
+
+	extractor := &workflows.Extractor{}
+	bom, err := extractor.Parse(f, path)
+	if err != nil {
+		log.Debug().Err(err).Str("path", path).Msg("could not parse workflow file")
+		return nil, nil
+	}
+
+	return bom.Transitive(), []string{path}
+}
+
+func isWorkflowFile(name string) bool {
+	return strings.HasSuffix(name, ".yml") || strings.HasSuffix(name, ".yaml")
+}
+
+func deduplicateGithubActionsPackages(pkgs []*languages.Package) []*languages.Package {
+	seen := make(map[string]bool)
+	var result []*languages.Package
+	for _, pkg := range pkgs {
+		key := pkg.Name + "@" + pkg.Version
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		result = append(result, pkg)
+	}
+	return result
+}
+
+func (r *mqlGithubactionsPackages) list() ([]any, error) {
+	return nil, r.gatherData()
+}
+
+func (r *mqlGithubactionsPackages) files() ([]any, error) {
+	return nil, r.gatherData()
+}
+
+func newGithubActionsPackageList(runtime *plugin.Runtime, packages []*languages.Package) ([]any, error) {
+	resources := []any{}
+	for i := range packages {
+		pkg, err := newGithubActionsPackage(runtime, packages[i])
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, pkg)
+	}
+	return resources, nil
+}
+
+func newGithubActionsPackage(runtime *plugin.Runtime, pkg *languages.Package) (*mqlGithubactionsPackage, error) {
+	mqlFiles := []any{}
+	for i := range pkg.EvidenceList {
+		evidence := pkg.EvidenceList[i]
+		lf, err := CreateResource(runtime, "pkgFileInfo", map[string]*llx.RawData{
+			"path": llx.StringData(evidence.Value),
+		})
+		if err != nil {
+			return nil, err
+		}
+		mqlFiles = append(mqlFiles, lf)
+	}
+
+	path := ""
+	if len(mqlFiles) > 0 {
+		if fi, ok := mqlFiles[0].(*mqlPkgFileInfo); ok {
+			path = fi.Path.Data
+		}
+	}
+
+	mqlPkg, err := CreateResource(runtime, "githubactions.package", map[string]*llx.RawData{
+		"id":      llx.StringData(pkg.Name + "@" + pkg.Version + ":" + path),
+		"name":    llx.StringData(pkg.Name),
+		"version": llx.StringData(pkg.Version),
+		"purl":    llx.StringData(pkg.Purl),
+		"files":   llx.ArrayData(mqlFiles, types.Resource("pkgFileInfo")),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return mqlPkg.(*mqlGithubactionsPackage), nil
+}
+
+func (k *mqlGithubactionsPackage) id() (string, error) {
+	return k.Id.Data, nil
+}
+
+func (r *mqlGithubactionsPackage) name() (string, error) {
+	return "", r.populateData()
+}
+
+func (r *mqlGithubactionsPackage) version() (string, error) {
+	return "", r.populateData()
+}
+
+func (r *mqlGithubactionsPackage) purl() (string, error) {
+	return "", r.populateData()
+}
+
+func (r *mqlGithubactionsPackage) files() ([]any, error) {
+	return nil, r.populateData()
+}
+
+func (r *mqlGithubactionsPackage) populateData() error {
+	// githubactions.package instances are only created via newGithubActionsPackage,
+	// which pre-populates all fields at creation time.
+	r.Name = plugin.TValue[string]{State: plugin.StateIsSet | plugin.StateIsNull}
+	r.Version = plugin.TValue[string]{State: plugin.StateIsSet | plugin.StateIsNull}
+	r.Purl = plugin.TValue[string]{State: plugin.StateIsSet | plugin.StateIsNull}
+	r.Files = plugin.TValue[[]any]{State: plugin.StateIsSet | plugin.StateIsNull}
+	return nil
+}

--- a/providers/os/resources/languages/githubactions/githubactions.go
+++ b/providers/os/resources/languages/githubactions/githubactions.go
@@ -1,0 +1,95 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package githubactions
+
+import (
+	"strings"
+
+	"github.com/package-url/packageurl-go"
+	"go.mondoo.com/mql/v13/sbom"
+)
+
+// NewPackageUrl creates a GitHub Actions package URL.
+// See https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#github
+func NewPackageUrl(owner, repo, ref string) string {
+	return packageurl.NewPackageURL(
+		"github",
+		owner,
+		repo,
+		ref,
+		nil,
+		"").String()
+}
+
+// NewEvidenceList converts a list of file paths to evidence entries.
+func NewEvidenceList(evidence []string) []*sbom.Evidence {
+	evidenceList := make([]*sbom.Evidence, len(evidence))
+	for i, e := range evidence {
+		evidenceList[i] = &sbom.Evidence{
+			Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
+			Value: e,
+		}
+	}
+	return evidenceList
+}
+
+// ActionRef represents a parsed GitHub Actions `uses` reference.
+type ActionRef struct {
+	// Owner is the GitHub organization or user (e.g., "actions").
+	Owner string
+	// Repo is the repository name (e.g., "checkout").
+	Repo string
+	// Path is the optional sub-path within the repo (e.g., "init" in "github/codeql-action/init@v3").
+	Path string
+	// Ref is the version tag, branch, or commit SHA (e.g., "v4").
+	Ref string
+}
+
+// Name returns the display name as "owner/repo" (or "owner/repo/path" if path is set).
+func (a ActionRef) Name() string {
+	if a.Path != "" {
+		return a.Owner + "/" + a.Repo + "/" + a.Path
+	}
+	return a.Owner + "/" + a.Repo
+}
+
+// ParseUses parses a GitHub Actions `uses` directive into an ActionRef.
+// Returns nil for local actions (./), Docker actions (docker://), or invalid formats.
+func ParseUses(uses string) *ActionRef {
+	uses = strings.TrimSpace(uses)
+
+	// Skip local actions
+	if strings.HasPrefix(uses, "./") || strings.HasPrefix(uses, "../") {
+		return nil
+	}
+
+	// Skip Docker actions
+	if strings.HasPrefix(uses, "docker://") {
+		return nil
+	}
+
+	// Split on @ to get action and ref
+	action, ref, ok := strings.Cut(uses, "@")
+	if !ok || ref == "" {
+		return nil
+	}
+
+	// Split action into owner/repo[/path]
+	parts := strings.SplitN(action, "/", 3)
+	if len(parts) < 2 {
+		return nil
+	}
+
+	result := &ActionRef{
+		Owner: parts[0],
+		Repo:  parts[1],
+		Ref:   ref,
+	}
+
+	if len(parts) == 3 {
+		result.Path = parts[2]
+	}
+
+	return result
+}

--- a/providers/os/resources/languages/githubactions/githubactions_test.go
+++ b/providers/os/resources/languages/githubactions/githubactions_test.go
@@ -1,0 +1,54 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package githubactions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseUses(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected *ActionRef
+	}{
+		{"actions/checkout@v4", &ActionRef{Owner: "actions", Repo: "checkout", Ref: "v4"}},
+		{"docker/build-push-action@v5.1.0", &ActionRef{Owner: "docker", Repo: "build-push-action", Ref: "v5.1.0"}},
+		{"github/codeql-action/init@v3", &ActionRef{Owner: "github", Repo: "codeql-action", Path: "init", Ref: "v3"}},
+		{"actions/checkout@abc123def456", &ActionRef{Owner: "actions", Repo: "checkout", Ref: "abc123def456"}},
+		// Local actions — skip
+		{"./my-action", nil},
+		{"../shared/action", nil},
+		// Docker actions — skip
+		{"docker://alpine:3.18", nil},
+		// Invalid
+		{"actions/checkout", nil},
+		{"justarepo@v1", nil},
+		{"", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := ParseUses(tt.input)
+			if tt.expected == nil {
+				assert.Nil(t, result)
+			} else {
+				require.NotNil(t, result)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestActionRefName(t *testing.T) {
+	assert.Equal(t, "actions/checkout", ActionRef{Owner: "actions", Repo: "checkout", Ref: "v4"}.Name())
+	assert.Equal(t, "github/codeql-action/init", ActionRef{Owner: "github", Repo: "codeql-action", Path: "init", Ref: "v3"}.Name())
+}
+
+func TestNewPackageUrl(t *testing.T) {
+	assert.Equal(t, "pkg:github/actions/checkout@v4", NewPackageUrl("actions", "checkout", "v4"))
+	assert.Equal(t, "pkg:github/docker/build-push-action@v5.1.0", NewPackageUrl("docker", "build-push-action", "v5.1.0"))
+}

--- a/providers/os/resources/languages/githubactions/workflows/extractor.go
+++ b/providers/os/resources/languages/githubactions/workflows/extractor.go
@@ -1,0 +1,89 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package workflows
+
+import (
+	"io"
+
+	"github.com/rs/zerolog/log"
+	"gopkg.in/yaml.v3"
+
+	"go.mondoo.com/mql/v13/providers/os/resources/languages"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages/githubactions"
+)
+
+var (
+	_ languages.Extractor = (*Extractor)(nil)
+	_ languages.Bom       = (*workflow)(nil)
+)
+
+// Extractor parses GitHub Actions workflow YAML files.
+type Extractor struct{}
+
+func (e *Extractor) Name() string {
+	return "github-actions-workflow"
+}
+
+func (e *Extractor) Parse(r io.Reader, filename string) (languages.Bom, error) {
+	var wf workflow
+
+	if filename != "" {
+		wf.evidence = append(wf.evidence, filename)
+	}
+
+	if err := yaml.NewDecoder(r).Decode(&wf); err != nil {
+		return nil, err
+	}
+
+	if len(wf.Jobs) == 0 {
+		log.Debug().Str("file", filename).Msg("workflow has no jobs (may not be a workflow file)")
+	}
+
+	return &wf, nil
+}
+
+// Root returns nil — workflows don't have a root package.
+func (w *workflow) Root() *languages.Package {
+	return nil
+}
+
+// Direct returns nil — all actions are treated equally.
+func (w *workflow) Direct() languages.Packages {
+	return nil
+}
+
+// Transitive returns all unique action references found in the workflow.
+func (w *workflow) Transitive() languages.Packages {
+	seen := make(map[string]bool)
+	var packages languages.Packages
+
+	for _, job := range w.Jobs {
+		for _, step := range job.Steps {
+			if step.Uses == "" {
+				continue
+			}
+
+			ref := githubactions.ParseUses(step.Uses)
+			if ref == nil {
+				continue
+			}
+
+			// Deduplicate by full uses string (owner/repo@ref)
+			key := ref.Name() + "@" + ref.Ref
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+
+			packages = append(packages, &languages.Package{
+				Name:         ref.Name(),
+				Version:      ref.Ref,
+				Purl:         githubactions.NewPackageUrl(ref.Owner, ref.Repo, ref.Ref),
+				EvidenceList: githubactions.NewEvidenceList(w.evidence),
+			})
+		}
+	}
+
+	return packages
+}

--- a/providers/os/resources/languages/githubactions/workflows/extractor_test.go
+++ b/providers/os/resources/languages/githubactions/workflows/extractor_test.go
@@ -1,0 +1,55 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package workflows
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/sbom"
+)
+
+func TestWorkflowExtractor(t *testing.T) {
+	f, err := os.Open("./testdata/simple.yml")
+	require.NoError(t, err)
+	defer f.Close()
+
+	info, err := (&Extractor{}).Parse(f, ".github/workflows/ci.yml")
+	require.NoError(t, err)
+
+	assert.Nil(t, info.Root())
+	assert.Nil(t, info.Direct())
+
+	transitive := info.Transitive()
+	// actions/checkout@v4 (deduplicated), actions/setup-go@v5,
+	// docker/build-push-action@v5.1.0, github/codeql-action/init@v3,
+	// github/codeql-action/analyze@v3
+	// Local (./local-action) and Docker (docker://alpine) are excluded
+	assert.Equal(t, 5, len(transitive))
+
+	p := transitive.Find("actions/checkout")
+	require.NotNil(t, p)
+	assert.Equal(t, "v4", p.Version)
+	assert.Equal(t, "pkg:github/actions/checkout@v4", p.Purl)
+	assert.Equal(t, []*sbom.Evidence{{Type: sbom.EvidenceType_EVIDENCE_TYPE_FILE, Value: ".github/workflows/ci.yml"}}, p.EvidenceList)
+
+	p = transitive.Find("docker/build-push-action")
+	require.NotNil(t, p)
+	assert.Equal(t, "v5.1.0", p.Version)
+
+	// Sub-path action
+	p = transitive.Find("github/codeql-action/init")
+	require.NotNil(t, p)
+	assert.Equal(t, "v3", p.Version)
+	// PURL uses repo only (no sub-path)
+	assert.Equal(t, "pkg:github/github/codeql-action@v3", p.Purl)
+
+	// Local and Docker actions should be excluded
+	for _, pkg := range transitive {
+		assert.NotContains(t, pkg.Name, "local-action")
+		assert.NotContains(t, pkg.Name, "alpine")
+	}
+}

--- a/providers/os/resources/languages/githubactions/workflows/parser.go
+++ b/providers/os/resources/languages/githubactions/workflows/parser.go
@@ -1,0 +1,22 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package workflows
+
+// workflow represents the minimal structure of a GitHub Actions workflow YAML.
+type workflow struct {
+	Jobs map[string]job `yaml:"jobs"`
+
+	// evidence is a list of file paths where the workflow was found.
+	evidence []string `yaml:"-"`
+}
+
+// job represents a single job in a workflow.
+type job struct {
+	Steps []step `yaml:"steps"`
+}
+
+// step represents a single step in a job.
+type step struct {
+	Uses string `yaml:"uses"`
+}

--- a/providers/os/resources/languages/githubactions/workflows/testdata/simple.yml
+++ b/providers/os/resources/languages/githubactions/workflows/testdata/simple.yml
@@ -1,0 +1,20 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+      - name: Build
+        run: go build ./...
+      - uses: docker/build-push-action@v5.1.0
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/analyze@v3
+      - uses: ./local-action
+      - uses: docker://alpine:3.18

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -2401,6 +2401,33 @@ php.package @defaults("name version purl") {
   files() []pkgFileInfo
 }
 
+// GitHub Actions dependencies
+githubactions.packages {
+  []githubactions.package
+
+  init(path? string)
+
+  // Path to search for workflow files (directory or specific .yml file)
+  path string
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// GitHub Actions action reference
+githubactions.package @defaults("name version purl") {
+  // ID is the githubactions.package unique identifier
+  id string
+  // Name of the action (owner/repo or owner/repo/path)
+  name() string
+  // Version (tag, branch, or commit SHA)
+  version() string
+  // Package URL
+  purl() string
+  // Package files
+  files() []pkgFileInfo
+}
+
 // macOS specific resources
 macos {
   // macOS computer name

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -188,6 +188,8 @@ const (
 	ResourceDotnetPackage                string = "dotnet.package"
 	ResourcePhpPackages                  string = "php.packages"
 	ResourcePhpPackage                   string = "php.package"
+	ResourceGithubactionsPackages        string = "githubactions.packages"
+	ResourceGithubactionsPackage         string = "githubactions.package"
 	ResourceMacos                        string = "macos"
 	ResourceMacosHardware                string = "macos.hardware"
 	ResourceMacosAlf                     string = "macos.alf"
@@ -946,6 +948,14 @@ func init() {
 		"php.package": {
 			// to override args, implement: initPhpPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createPhpPackage,
+		},
+		"githubactions.packages": {
+			Init:   initGithubactionsPackages,
+			Create: createGithubactionsPackages,
+		},
+		"githubactions.package": {
+			// to override args, implement: initGithubactionsPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGithubactionsPackage,
 		},
 		"macos": {
 			// to override args, implement: initMacos(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -3749,6 +3759,30 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"php.package.files": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPhpPackage).GetFiles()).ToDataRes(types.Array(types.Resource("pkgFileInfo")))
+	},
+	"githubactions.packages.path": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubactionsPackages).GetPath()).ToDataRes(types.String)
+	},
+	"githubactions.packages.files": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubactionsPackages).GetFiles()).ToDataRes(types.Array(types.Resource("pkgFileInfo")))
+	},
+	"githubactions.packages.list": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubactionsPackages).GetList()).ToDataRes(types.Array(types.Resource("githubactions.package")))
+	},
+	"githubactions.package.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubactionsPackage).GetId()).ToDataRes(types.String)
+	},
+	"githubactions.package.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubactionsPackage).GetName()).ToDataRes(types.String)
+	},
+	"githubactions.package.version": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubactionsPackage).GetVersion()).ToDataRes(types.String)
+	},
+	"githubactions.package.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubactionsPackage).GetPurl()).ToDataRes(types.String)
+	},
+	"githubactions.package.files": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubactionsPackage).GetFiles()).ToDataRes(types.Array(types.Resource("pkgFileInfo")))
 	},
 	"macos.computerName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMacos).GetComputerName()).ToDataRes(types.String)
@@ -9145,6 +9179,46 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"php.package.files": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlPhpPackage).Files, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"githubactions.packages.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubactionsPackages).__id, ok = v.Value.(string)
+		return
+	},
+	"githubactions.packages.path": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubactionsPackages).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"githubactions.packages.files": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubactionsPackages).Files, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"githubactions.packages.list": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubactionsPackages).List, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"githubactions.package.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubactionsPackage).__id, ok = v.Value.(string)
+		return
+	},
+	"githubactions.package.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubactionsPackage).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"githubactions.package.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubactionsPackage).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"githubactions.package.version": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubactionsPackage).Version, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"githubactions.package.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubactionsPackage).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"githubactions.package.files": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubactionsPackage).Files, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"macos.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -25405,6 +25479,176 @@ func (c *mqlPhpPackage) GetFiles() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Files, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
 			d, err := c.MqlRuntime.FieldResourceFromRecording("php.package", c.__id, "files")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.files()
+	})
+}
+
+// mqlGithubactionsPackages for the githubactions.packages resource
+type mqlGithubactionsPackages struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlGithubactionsPackagesInternal
+	Path  plugin.TValue[string]
+	Files plugin.TValue[[]any]
+	List  plugin.TValue[[]any]
+}
+
+// createGithubactionsPackages creates a new instance of this resource
+func createGithubactionsPackages(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGithubactionsPackages{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("githubactions.packages", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGithubactionsPackages) MqlName() string {
+	return "githubactions.packages"
+}
+
+func (c *mqlGithubactionsPackages) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGithubactionsPackages) GetPath() *plugin.TValue[string] {
+	return &c.Path
+}
+
+func (c *mqlGithubactionsPackages) GetFiles() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Files, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("githubactions.packages", c.__id, "files")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.files()
+	})
+}
+
+func (c *mqlGithubactionsPackages) GetList() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.List, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("githubactions.packages", c.__id, "list")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.list()
+	})
+}
+
+// mqlGithubactionsPackage for the githubactions.package resource
+type mqlGithubactionsPackage struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlGithubactionsPackageInternal it will be used here
+	Id      plugin.TValue[string]
+	Name    plugin.TValue[string]
+	Version plugin.TValue[string]
+	Purl    plugin.TValue[string]
+	Files   plugin.TValue[[]any]
+}
+
+// createGithubactionsPackage creates a new instance of this resource
+func createGithubactionsPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGithubactionsPackage{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("githubactions.package", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGithubactionsPackage) MqlName() string {
+	return "githubactions.package"
+}
+
+func (c *mqlGithubactionsPackage) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGithubactionsPackage) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlGithubactionsPackage) GetName() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Name, func() (string, error) {
+		return c.name()
+	})
+}
+
+func (c *mqlGithubactionsPackage) GetVersion() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Version, func() (string, error) {
+		return c.version()
+	})
+}
+
+func (c *mqlGithubactionsPackage) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
+	})
+}
+
+func (c *mqlGithubactionsPackage) GetFiles() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Files, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("githubactions.package", c.__id, "files")
 			if err != nil {
 				return nil, err
 			}

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -430,6 +430,16 @@ fstab.entry.fstype 11.3.5
 fstab.entry.mountpoint 11.3.5
 fstab.entry.options 11.3.5
 fstab.path 11.3.5
+githubactions.package 13.10.1
+githubactions.package.files 13.10.1
+githubactions.package.id 13.10.1
+githubactions.package.name 13.10.1
+githubactions.package.purl 13.10.1
+githubactions.package.version 13.10.1
+githubactions.packages 13.10.1
+githubactions.packages.files 13.10.1
+githubactions.packages.list 13.10.1
+githubactions.packages.path 13.10.1
 go.package 13.10.1
 go.package.cpes 13.10.1
 go.package.files 13.10.1

--- a/sbom/generator/generator.go
+++ b/sbom/generator/generator.go
@@ -269,6 +269,24 @@ func GenerateBom(r *reporter.Report) []*sbom.Sbom {
 
 				bom.Packages = append(bom.Packages, bomPkg)
 			}
+
+			for _, pkg := range rb.GithubActionsPackages {
+				bomPkg := &sbom.Package{
+					Name:    pkg.Name,
+					Version: pkg.Version,
+					Purl:    pkg.Purl,
+					Type:    "github-action",
+				}
+
+				for _, filepath := range pkg.FilePaths {
+					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
+						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
+						Value: filepath,
+					})
+				}
+
+				bom.Packages = append(bom.Packages, bomPkg)
+			}
 		}
 		boms = append(boms, bom)
 	}

--- a/sbom/generator/report_collection.go
+++ b/sbom/generator/report_collection.go
@@ -47,16 +47,17 @@ type KernelInstalled struct {
 }
 
 type BomFields struct {
-	Asset           *BomAsset         `json:"asset,omitempty"`
-	Packages        []BomPackage      `json:"packages.list,omitempty"`
-	PythonPackages  []BomPackage      `json:"python.packages,omitempty"`
-	NpmPackages     []BomPackage      `json:"npm.packages.list,omitempty"`
-	GoPackages      []BomPackage      `json:"go.packages.list,omitempty"`
-	JavaPackages    []BomPackage      `json:"java.packages.list,omitempty"`
-	RustPackages    []BomPackage      `json:"rust.packages.list,omitempty"`
-	DotnetPackages  []BomPackage      `json:"dotnet.packages.list,omitempty"`
-	PhpPackages     []BomPackage      `json:"php.packages.list,omitempty"`
-	KernelInstalled []KernelInstalled `json:"kernel.installed,omitempty"`
+	Asset                 *BomAsset         `json:"asset,omitempty"`
+	Packages              []BomPackage      `json:"packages.list,omitempty"`
+	PythonPackages        []BomPackage      `json:"python.packages,omitempty"`
+	NpmPackages           []BomPackage      `json:"npm.packages.list,omitempty"`
+	GoPackages            []BomPackage      `json:"go.packages.list,omitempty"`
+	JavaPackages          []BomPackage      `json:"java.packages.list,omitempty"`
+	RustPackages          []BomPackage      `json:"rust.packages.list,omitempty"`
+	DotnetPackages        []BomPackage      `json:"dotnet.packages.list,omitempty"`
+	PhpPackages           []BomPackage      `json:"php.packages.list,omitempty"`
+	GithubActionsPackages []BomPackage      `json:"githubactions.packages.list,omitempty"`
+	KernelInstalled       []KernelInstalled `json:"kernel.installed,omitempty"`
 }
 
 func (b *BomFields) ToJSON() ([]byte, error) {


### PR DESCRIPTION
## Summary

Adds native SBOM cataloging for GitHub Actions workflow dependencies, enabling detection of action references from `.github/workflows/*.yml` files. This is a supply chain security feature — auditing which actions (and versions) a repository depends on.

## New MQL Resources

### `githubactions.packages`

Discovers action dependencies from workflow YAML files.

```coffeescript
# Scan a repository
mql run os -c "githubactions.packages(path: '.') { list { name version purl } }"

# Scan a specific workflow
mql run os -c "githubactions.packages(path: '.github/workflows/ci.yml') { list { name version } }"
```

### `githubactions.package`

| Field | Type | Description |
|-------|------|-------------|
| `name` | `string` | owner/repo or owner/repo/path (e.g., `actions/checkout`) |
| `version` | `string` | Tag, branch, or commit SHA (e.g., `v4`) |
| `purl` | `string` | Package URL (`pkg:github/actions/checkout@v4`) |
| `files` | `[]pkgFileInfo` | Workflow files where the action was found |

## Parser

- Extracts `uses:` directives from all jobs and steps
- Parses `owner/repo@ref` format with sub-path support (e.g., `github/codeql-action/init@v3`)
- Deduplicates across jobs (same action used in multiple jobs counted once)
- Skips local actions (`./`) and Docker actions (`docker://`)

## Usage Examples

```coffeescript
# List all action dependencies
mql run os -c "githubactions.packages { list { name version purl } }"

# Policy: ensure actions are pinned to SHA, not tags
githubactions.packages.list.all(version == /^[a-f0-9]{40}$/)

# Policy: no deprecated actions
githubactions.packages.list.none(name == "actions/deprecated-action")

# Remote scan
mql run ssh user@host -c "githubactions.packages(path: '/repo') { list { name version } }"
```

## Test plan

- [x] Workflow YAML parser: 5 unique actions from multi-job fixture
- [x] ParseUses: standard, sub-path, commit SHA, local/Docker exclusion
- [x] PURL generation tests
- [x] Deduplication (same action in multiple jobs)
- [x] SBOM generator tests pass
- [x] `golangci-lint` extended clean
- [x] `gofmt` clean
- [x] Full OS provider builds
- [ ] Interactive: `mql run os -c "githubactions.packages { list { name version purl } }"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)