### PR TITLE
🐛 firewalld: detect rich rule NOT inversion + allow zone lookup by name

### DIFF
--- a/providers/os/resources/firewalld.go
+++ b/providers/os/resources/firewalld.go
@@ -9,9 +9,50 @@ import (
 	"sync"
 
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
 	"go.mondoo.com/mql/v13/types"
 )
+
+// initFirewalldZone resolves `firewalld.zone("name")` lookups by name against
+// the zones exposed by the firewalld resource. When the resource is being
+// constructed from the firewalld.zones() accessor (i.e. all fields populated),
+// we fall through and let the default factory handle it.
+func initFirewalldZone(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) != 1 {
+		return args, nil, nil
+	}
+	nameArg, ok := args["name"]
+	if !ok {
+		return args, nil, nil
+	}
+	name, ok := nameArg.Value.(string)
+	if !ok || name == "" {
+		return args, nil, nil
+	}
+
+	o, err := CreateResource(runtime, "firewalld", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+	fw := o.(*mqlFirewalld)
+	zones := fw.GetZones()
+	if zones.Error != nil {
+		return nil, nil, zones.Error
+	}
+
+	for _, z := range zones.Data {
+		zone, ok := z.(*mqlFirewalldZone)
+		if !ok {
+			continue
+		}
+		if zone.Name.Data == name {
+			return nil, zone, nil
+		}
+	}
+
+	return nil, nil, fmt.Errorf("firewalld zone %q not found", name)
+}
 
 type mqlFirewalldInternal struct {
 	fetched      bool
@@ -126,11 +167,13 @@ func (f *mqlFirewalld) zones() ([]any, error) {
 		for _, rr := range z.richRules {
 			parsed := parseFirewalldRichRule(rr)
 			r, err := CreateResource(f.MqlRuntime, "firewalld.richrule", map[string]*llx.RawData{
-				"family":      llx.StringData(parsed.family),
-				"rule":        llx.StringData(rr),
-				"source":      llx.StringData(parsed.source),
-				"destination": llx.StringData(parsed.destination),
-				"action":      llx.StringData(parsed.action),
+				"family":              llx.StringData(parsed.family),
+				"rule":                llx.StringData(rr),
+				"source":              llx.StringData(parsed.source),
+				"sourceInverted":      llx.BoolData(parsed.sourceInverted),
+				"destination":         llx.StringData(parsed.destination),
+				"destinationInverted": llx.BoolData(parsed.destinationInverted),
+				"action":              llx.StringData(parsed.action),
 			})
 			if err != nil {
 				return nil, err
@@ -312,14 +355,17 @@ func splitNonEmpty(s string) []string {
 
 // parsedRichRule holds the parsed components of a firewalld rich rule.
 type parsedRichRule struct {
-	family      string
-	source      string
-	destination string
-	action      string
+	family              string
+	source              string
+	sourceInverted      bool
+	destination         string
+	destinationInverted bool
+	action              string
 }
 
 // parseFirewalldRichRule extracts structured fields from a rich rule string.
 // Example: `rule family="ipv4" source address="10.0.0.0/8" accept`
+// Example: `rule family="ipv4" source NOT address="127.0.0.1" destination NOT address="127.0.0.1" drop`
 func parseFirewalldRichRule(rule string) parsedRichRule {
 	var rr parsedRichRule
 
@@ -330,15 +376,26 @@ func parseFirewalldRichRule(rule string) parsedRichRule {
 		}
 	}
 
-	// Extract source address
-	if _, after, ok := strings.Cut(rule, `source address="`); ok {
+	// Extract source address — prefer the NOT-inverted form so `source NOT address="..."`
+	// isn't misread as a plain source match via a short-circuit on `address="..."`.
+	if _, after, ok := strings.Cut(rule, `source NOT address="`); ok {
+		if val, _, ok := strings.Cut(after, `"`); ok {
+			rr.source = val
+			rr.sourceInverted = true
+		}
+	} else if _, after, ok := strings.Cut(rule, `source address="`); ok {
 		if val, _, ok := strings.Cut(after, `"`); ok {
 			rr.source = val
 		}
 	}
 
-	// Extract destination address
-	if _, after, ok := strings.Cut(rule, `destination address="`); ok {
+	// Extract destination address (same NOT-first ordering as source)
+	if _, after, ok := strings.Cut(rule, `destination NOT address="`); ok {
+		if val, _, ok := strings.Cut(after, `"`); ok {
+			rr.destination = val
+			rr.destinationInverted = true
+		}
+	} else if _, after, ok := strings.Cut(rule, `destination address="`); ok {
 		if val, _, ok := strings.Cut(after, `"`); ok {
 			rr.destination = val
 		}

--- a/providers/os/resources/firewalld_test.go
+++ b/providers/os/resources/firewalld_test.go
@@ -160,6 +160,38 @@ func TestParseFirewalldRichRule(t *testing.T) {
 				action: "accept",
 			},
 		},
+		{
+			name:  "ipv4 anti-spoofing with destination NOT address",
+			input: `rule family="ipv4" source address="127.0.0.1" destination NOT address="127.0.0.1" drop`,
+			expected: parsedRichRule{
+				family:              "ipv4",
+				source:              "127.0.0.1",
+				destination:         "127.0.0.1",
+				destinationInverted: true,
+				action:              "drop",
+			},
+		},
+		{
+			name:  "ipv6 anti-spoofing with destination NOT address",
+			input: `rule family="ipv6" source address="::1" destination NOT address="::1" drop`,
+			expected: parsedRichRule{
+				family:              "ipv6",
+				source:              "::1",
+				destination:         "::1",
+				destinationInverted: true,
+				action:              "drop",
+			},
+		},
+		{
+			name:  "source NOT address inverted",
+			input: `rule family="ipv4" source NOT address="10.0.0.0/8" drop`,
+			expected: parsedRichRule{
+				family:         "ipv4",
+				source:         "10.0.0.0/8",
+				sourceInverted: true,
+				action:         "drop",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -1480,6 +1480,7 @@ firewalld @defaults("status defaultZone") {
 
 // firewalld zone configuration
 private firewalld.zone @defaults("name target") {
+  init(name? string)
   // Zone name (e.g., "public", "internal", "dmz")
   name string
   // Default target (default, ACCEPT, REJECT, DROP)
@@ -1518,8 +1519,12 @@ private firewalld.richrule @defaults("family rule") {
   rule string
   // Source address/subnet, empty if not specified
   source string
+  // True when the source address is negated (e.g., `source NOT address="..."`)
+  sourceInverted bool
   // Destination address/subnet, empty if not specified
   destination string
+  // True when the destination address is negated (e.g., `destination NOT address="..."`)
+  destinationInverted bool
   // Action (accept, reject, drop, mark), empty if not specified
   action string
 }

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -692,7 +692,7 @@ func init() {
 			Create: createFirewalld,
 		},
 		"firewalld.zone": {
-			// to override args, implement: initFirewalldZone(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initFirewalldZone,
 			Create: createFirewalldZone,
 		},
 		"firewalld.richrule": {
@@ -2856,8 +2856,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"firewalld.richrule.source": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlFirewalldRichrule).GetSource()).ToDataRes(types.String)
 	},
+	"firewalld.richrule.sourceInverted": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlFirewalldRichrule).GetSourceInverted()).ToDataRes(types.Bool)
+	},
 	"firewalld.richrule.destination": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlFirewalldRichrule).GetDestination()).ToDataRes(types.String)
+	},
+	"firewalld.richrule.destinationInverted": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlFirewalldRichrule).GetDestinationInverted()).ToDataRes(types.Bool)
 	},
 	"firewalld.richrule.action": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlFirewalldRichrule).GetAction()).ToDataRes(types.String)
@@ -7707,8 +7713,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlFirewalldRichrule).Source, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"firewalld.richrule.sourceInverted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlFirewalldRichrule).SourceInverted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"firewalld.richrule.destination": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlFirewalldRichrule).Destination, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"firewalld.richrule.destinationInverted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlFirewalldRichrule).DestinationInverted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"firewalld.richrule.action": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20023,11 +20037,13 @@ type mqlFirewalldRichrule struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlFirewalldRichruleInternal it will be used here
-	Family      plugin.TValue[string]
-	Rule        plugin.TValue[string]
-	Source      plugin.TValue[string]
-	Destination plugin.TValue[string]
-	Action      plugin.TValue[string]
+	Family              plugin.TValue[string]
+	Rule                plugin.TValue[string]
+	Source              plugin.TValue[string]
+	SourceInverted      plugin.TValue[bool]
+	Destination         plugin.TValue[string]
+	DestinationInverted plugin.TValue[bool]
+	Action              plugin.TValue[string]
 }
 
 // createFirewalldRichrule creates a new instance of this resource
@@ -20079,8 +20095,16 @@ func (c *mqlFirewalldRichrule) GetSource() *plugin.TValue[string] {
 	return &c.Source
 }
 
+func (c *mqlFirewalldRichrule) GetSourceInverted() *plugin.TValue[bool] {
+	return &c.SourceInverted
+}
+
 func (c *mqlFirewalldRichrule) GetDestination() *plugin.TValue[string] {
 	return &c.Destination
+}
+
+func (c *mqlFirewalldRichrule) GetDestinationInverted() *plugin.TValue[bool] {
+	return &c.DestinationInverted
 }
 
 func (c *mqlFirewalldRichrule) GetAction() *plugin.TValue[string] {

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -400,9 +400,11 @@ firewalld.defaultZone 13.2.9
 firewalld.richrule 13.2.9
 firewalld.richrule.action 13.2.9
 firewalld.richrule.destination 13.2.9
+firewalld.richrule.destinationInverted 13.10.1
 firewalld.richrule.family 13.2.9
 firewalld.richrule.rule 13.2.9
 firewalld.richrule.source 13.2.9
+firewalld.richrule.sourceInverted 13.10.1
 firewalld.status 13.2.9
 firewalld.zone 13.2.9
 firewalld.zone.active 13.2.9


### PR DESCRIPTION
## Summary

Two small improvements to the existing \`firewalld\` resource in the os provider.

**1. Bug fix — rich rule \`NOT\` inversion was silently dropped.**
The parser extracted \`source address=\"X\"\` and \`destination address=\"X\"\` but didn't distinguish them from the inverted forms \`source NOT address=\"X\"\` / \`destination NOT address=\"X\"\`. Anti-spoofing rules (which commonly use \`destination NOT address\`) were therefore indistinguishable from plain source/destination matches, making CIS-style anti-spoofing assertions impossible to write.

New fields on \`firewalld.richrule\`:
- \`sourceInverted bool\`
- \`destinationInverted bool\`

**2. New affordance — look up a zone by name.**
Added \`init(name? string)\` on \`firewalld.zone\` so you can write:

\`\`\`mql
firewalld.zone(\"public\").target == \"ACCEPT\"
\`\`\`

instead of:

\`\`\`mql
firewalld.zones.where(name == \"public\").first.target == \"ACCEPT\"
\`\`\`

This mirrors how CIS audits phrase the checks (\"get the zone bound to interface X and check its target\") and removes a round of shell-out-and-parse MQL that was being used in some policy content.

## Example — anti-spoofing check before/after

Before (shell-based):
\`\`\`mql
command(\"firewall-cmd --list-rich-rules\").stdout.contains(
  'rule family=\"ipv4\" source address=\"127.0.0.1\" destination NOT address=\"127.0.0.1\" drop'
)
\`\`\`

After (native, with the new fields):
\`\`\`mql
firewalld.zone(firewalld.defaultZone).richRules.any(
  family == \"ipv4\" && source == \"127.0.0.1\" &&
  destination == \"127.0.0.1\" && destinationInverted &&
  action == \"drop\"
)
\`\`\`

## Changes

- \`providers/os/resources/os.lr\` — added \`init(name? string)\` on \`firewalld.zone\`, added \`sourceInverted\` and \`destinationInverted\` on \`firewalld.richrule\`
- \`providers/os/resources/firewalld.go\` — implemented \`initFirewalldZone\`; fixed \`parseFirewalldRichRule\` to detect \`NOT\`-inverted source/destination; wired new fields into \`CreateResource\`
- \`providers/os/resources/firewalld_test.go\` — added cases for ipv4/ipv6 anti-spoofing and \`source NOT address\`
- \`providers/os/resources/os.lr.go\`, \`os.lr.versions\` — regenerated (new fields at \`13.10.1\`)

## Test plan

- [x] \`go test ./providers/os/resources/ -run Firewalld\` passes (including the new cases)
- [x] \`go test ./providers/os/resources/\` — no regressions
- [x] \`go vet\` clean on changed files; \`gofmt\` clean
- [x] Local rebuild + install of the os provider; \`mql run local -c 'firewalld.zone(\"public\")'\` returns the expected \"not found\" error on a host without firewalld (schema resolves, init fires)
- [x] \`firewalld.zones.any(richRules.any(destinationInverted && sourceInverted && source == \"x\"))\` compiles against the new schema
- [ ] Verify on a real RHEL/Alma/Rocky/SUSE host with firewalld running (CI coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)