### PR TITLE
✨ Add Swift SBOM cataloger (SPM + CocoaPods)

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -5,6 +5,7 @@ activedirectory
 ACTIVEMQ
 adr
 afero
+alamofire
 AJD
 advancedthreatprotection
 alloydb
@@ -35,6 +36,7 @@ AWSPENDING
 AWSPREVIOUS
 awsvpc
 Beixb
+bfc
 BXdl
 bwawxf
 backupconfiguration
@@ -48,6 +50,7 @@ BINPACK
 blackhole
 bytematchstatement
 cavium
+cbf
 cdn
 ceph
 certificatechains
@@ -60,6 +63,7 @@ claude
 clcerts
 cloudflare
 Clusterwide
+cocoapods
 codeql
 cmdline
 cmek
@@ -86,6 +90,7 @@ ddl
 ddos
 dedup
 dedupratio
+defc
 deliverychannel
 depsdev
 dfw
@@ -114,7 +119,9 @@ ERPCLOUD
 eventarc
 Exadata
 exo
+faa
 failback
+fce
 FEBLx
 fargate
 filestore
@@ -295,6 +302,7 @@ persistentvolume
 persistentvolumeclaim
 phpunit
 Pids
+podfile
 pipefail
 pki
 portgroup

--- a/docs/adr/010-cnspec-sbom-swift.md
+++ b/docs/adr/010-cnspec-sbom-swift.md
@@ -1,0 +1,145 @@
+# ADR: cnspec SBOM Cataloger for Swift
+
+**Status:** Proposed
+**Date:** 2026-04-17
+
+---
+
+## Context
+
+cnspec needs native SBOM cataloging for Swift packages to detect dependencies in both local and remote scanning contexts (SSH, containers). Swift is the primary language for Apple platform development (iOS, macOS, watchOS, tvOS), and increasingly used for server-side applications.
+
+The Swift ecosystem has two package managers:
+- **Swift Package Manager (SPM)**: Apple's official dependency manager, uses `Package.resolved` (JSON)
+- **CocoaPods**: Legacy dependency manager, uses `Podfile.lock` (custom YAML-like format)
+
+---
+
+## File Formats
+
+### Package.resolved (Swift Package Manager)
+
+SPM lock file with resolved dependency versions. Has two format versions.
+
+**Version 2 (current):**
+```json
+{
+  "pins": [
+    {
+      "identity": "alamofire",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/Alamofire/Alamofire.git",
+      "state": {
+        "revision": "f82c23a8a7ef8dc1a49a8bfc6a96883e0a4e5c07",
+        "version": "5.8.1"
+      }
+    }
+  ],
+  "version": 2
+}
+```
+
+**Version 1 (legacy):**
+```json
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Alamofire",
+        "repositoryURL": "https://github.com/Alamofire/Alamofire.git",
+        "state": {
+          "revision": "f82c23a8a7ef8dc1a49a8bfc6a96883e0a4e5c07",
+          "version": "5.8.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}
+```
+
+### Podfile.lock (CocoaPods)
+
+CocoaPods lock file listing resolved pod versions.
+
+```
+PODS:
+  - Alamofire (5.8.1)
+  - SwiftyJSON (5.0.1)
+  - Moya (15.0.3):
+    - Alamofire (~> 5.0)
+
+DEPENDENCIES:
+  - Alamofire (~> 5.8)
+  - SwiftyJSON (~> 5.0)
+  - Moya (~> 15.0)
+
+SPEC CHECKSUMS:
+  Alamofire: 3ca42e259f7c0c813defc2c0820d4fce16e97a5d
+  SwiftyJSON: 6faa0040f8b59dead0ee07436cbf76b73c08fd08
+  Moya: abc123def456
+
+PODFILE CHECKSUM: deadbeef12345678
+
+COCOAPODS: 1.14.3
+```
+
+---
+
+## Parsing Strategy
+
+### Package.resolved Parser
+1. Parse JSON via `encoding/json`
+2. Detect version field (1 or 2) for format handling
+3. V2: iterate `pins` array directly
+4. V1: iterate `object.pins` array
+5. Extract identity/package name, version, revision from each pin
+
+### Podfile.lock Parser
+1. Read line by line via `bufio.Scanner`
+2. Parse `PODS:` section for package names and resolved versions
+3. Format: `  - PackageName (version)` with optional sub-dependencies indented further
+4. Parse `SPEC CHECKSUMS:` section for integrity hashes
+
+### Error Handling
+- Unknown Package.resolved version: warn and attempt v2 format
+- Malformed entries: skip with debug log
+- Missing sections in Podfile.lock: skip gracefully
+
+---
+
+## Package Identification
+
+### PURL
+
+SPM: `pkg:swift/<name>@<version>`
+CocoaPods: `pkg:cocoapods/<name>@<version>`
+
+Examples:
+- `pkg:swift/alamofire@5.8.1`
+- `pkg:cocoapods/Alamofire@5.8.1`
+
+### CPE Generation
+Vendor and product are both the package name (Swift packages are uniquely named).
+
+---
+
+## Dev/Prod Classification
+
+Not available from either format — all dependencies are treated as production.
+
+---
+
+## Remote Scanning Considerations
+
+Both files are small text/JSON (< 100KB). No special handling needed. All reads through `afero.Fs`.
+
+Default search paths: project root directories, `/app`, `/usr/src/app`
+
+---
+
+## Verification Plan
+
+- Package.resolved: v1 and v2 format fixtures
+- Podfile.lock: pods with sub-dependencies, checksums
+- Interactive: `mql run os -c "swift.packages(path: '.') { list { name version purl } }"`

--- a/providers/os/resources/languages/swift/packageresolved/extractor.go
+++ b/providers/os/resources/languages/swift/packageresolved/extractor.go
@@ -1,0 +1,79 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package packageresolved
+
+import (
+	"encoding/json"
+	"io"
+
+	"go.mondoo.com/mql/v13/providers/os/resources/languages"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages/swift"
+)
+
+var (
+	_ languages.Extractor = (*Extractor)(nil)
+	_ languages.Bom       = (*packageResolved)(nil)
+)
+
+// Extractor parses Swift Package Manager Package.resolved files (v1 and v2).
+type Extractor struct{}
+
+func (e *Extractor) Name() string {
+	return "packageresolved"
+}
+
+func (e *Extractor) Parse(r io.Reader, filename string) (languages.Bom, error) {
+	var pr packageResolved
+
+	if filename != "" {
+		pr.evidence = append(pr.evidence, filename)
+	}
+
+	if err := json.NewDecoder(r).Decode(&pr); err != nil {
+		return nil, err
+	}
+
+	return &pr, nil
+}
+
+// Root returns nil — Package.resolved does not describe the root project.
+func (pr *packageResolved) Root() *languages.Package {
+	return nil
+}
+
+// Direct returns nil — Package.resolved does not distinguish direct from transitive.
+func (pr *packageResolved) Direct() languages.Packages {
+	return nil
+}
+
+// Transitive returns all resolved dependencies.
+func (pr *packageResolved) Transitive() languages.Packages {
+	var packages languages.Packages
+
+	if pr.Version >= 2 || (pr.Object == nil && len(pr.Pins) > 0) {
+		// V2 format: pins at top level
+		for _, p := range pr.Pins {
+			packages = append(packages, &languages.Package{
+				Name:         p.Identity,
+				Version:      p.State.Version,
+				Purl:         swift.NewSpmPackageUrl(p.Identity, p.State.Version),
+				Cpes:         swift.NewCpes(p.Identity, p.State.Version),
+				EvidenceList: swift.NewEvidenceList(pr.evidence),
+			})
+		}
+	} else if pr.Object != nil {
+		// V1 format: pins inside object
+		for _, p := range pr.Object.Pins {
+			packages = append(packages, &languages.Package{
+				Name:         p.Package,
+				Version:      p.State.Version,
+				Purl:         swift.NewSpmPackageUrl(p.Package, p.State.Version),
+				Cpes:         swift.NewCpes(p.Package, p.State.Version),
+				EvidenceList: swift.NewEvidenceList(pr.evidence),
+			})
+		}
+	}
+
+	return packages
+}

--- a/providers/os/resources/languages/swift/packageresolved/extractor_test.go
+++ b/providers/os/resources/languages/swift/packageresolved/extractor_test.go
@@ -1,0 +1,58 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package packageresolved
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/sbom"
+)
+
+func TestPackageResolvedV2(t *testing.T) {
+	f, err := os.Open("./testdata/v2.Package.resolved")
+	require.NoError(t, err)
+	defer f.Close()
+
+	info, err := (&Extractor{}).Parse(f, "Package.resolved")
+	require.NoError(t, err)
+
+	assert.Nil(t, info.Root())
+	assert.Nil(t, info.Direct())
+
+	transitive := info.Transitive()
+	assert.Equal(t, 3, len(transitive))
+
+	p := transitive.Find("alamofire")
+	require.NotNil(t, p)
+	assert.Equal(t, "5.8.1", p.Version)
+	assert.Equal(t, "pkg:swift/alamofire@5.8.1", p.Purl)
+	assert.Equal(t, []*sbom.Evidence{{Type: sbom.EvidenceType_EVIDENCE_TYPE_FILE, Value: "Package.resolved"}}, p.EvidenceList)
+
+	p = transitive.Find("swift-argument-parser")
+	require.NotNil(t, p)
+	assert.Equal(t, "1.2.3", p.Version)
+}
+
+func TestPackageResolvedV1(t *testing.T) {
+	f, err := os.Open("./testdata/v1.Package.resolved")
+	require.NoError(t, err)
+	defer f.Close()
+
+	info, err := (&Extractor{}).Parse(f, "Package.resolved")
+	require.NoError(t, err)
+
+	transitive := info.Transitive()
+	assert.Equal(t, 2, len(transitive))
+
+	p := transitive.Find("Alamofire")
+	require.NotNil(t, p)
+	assert.Equal(t, "5.8.1", p.Version)
+
+	p = transitive.Find("Kingfisher")
+	require.NotNil(t, p)
+	assert.Equal(t, "7.10.1", p.Version)
+}

--- a/providers/os/resources/languages/swift/packageresolved/parser.go
+++ b/providers/os/resources/languages/swift/packageresolved/parser.go
@@ -1,0 +1,43 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package packageresolved
+
+// packageResolved represents a parsed Package.resolved file (v1 or v2).
+type packageResolved struct {
+	// Version is the Package.resolved format version (1 or 2).
+	Version int `json:"version"`
+	// Pins is the list of resolved dependencies (v2 format).
+	Pins []pin `json:"pins"`
+	// Object wraps pins in v1 format.
+	Object *pinObject `json:"object"`
+
+	// evidence is a list of file paths where the Package.resolved was found.
+	evidence []string `json:"-"`
+}
+
+// pinObject is the v1 wrapper around pins.
+type pinObject struct {
+	Pins []pinV1 `json:"pins"`
+}
+
+// pin represents a single dependency in v2 format.
+type pin struct {
+	Identity string   `json:"identity"`
+	Kind     string   `json:"kind"`
+	Location string   `json:"location"`
+	State    pinState `json:"state"`
+}
+
+// pinV1 represents a single dependency in v1 format.
+type pinV1 struct {
+	Package       string   `json:"package"`
+	RepositoryURL string   `json:"repositoryURL"`
+	State         pinState `json:"state"`
+}
+
+// pinState contains the resolved version and revision.
+type pinState struct {
+	Revision string `json:"revision"`
+	Version  string `json:"version"`
+}

--- a/providers/os/resources/languages/swift/packageresolved/testdata/v1.Package.resolved
+++ b/providers/os/resources/languages/swift/packageresolved/testdata/v1.Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Alamofire",
+        "repositoryURL": "https://github.com/Alamofire/Alamofire.git",
+        "state": {
+          "branch": null,
+          "revision": "f82c23a8a7ef8dc1a49a8bfc6a96883e0a4e5c07",
+          "version": "5.8.1"
+        }
+      },
+      {
+        "package": "Kingfisher",
+        "repositoryURL": "https://github.com/onevcat/Kingfisher.git",
+        "state": {
+          "branch": null,
+          "revision": "abc123",
+          "version": "7.10.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/providers/os/resources/languages/swift/packageresolved/testdata/v2.Package.resolved
+++ b/providers/os/resources/languages/swift/packageresolved/testdata/v2.Package.resolved
@@ -1,0 +1,32 @@
+{
+  "pins": [
+    {
+      "identity": "alamofire",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/Alamofire/Alamofire.git",
+      "state": {
+        "revision": "f82c23a8a7ef8dc1a49a8bfc6a96883e0a4e5c07",
+        "version": "5.8.1"
+      }
+    },
+    {
+      "identity": "swiftyjson",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/SwiftyJSON/SwiftyJSON.git",
+      "state": {
+        "revision": "b3dcd7dbd0d488e1a7077cb33b00f2083e382f07",
+        "version": "5.0.1"
+      }
+    },
+    {
+      "identity": "swift-argument-parser",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-argument-parser.git",
+      "state": {
+        "revision": "46989693916f56d1186bd59ac15f7c28e29e340e",
+        "version": "1.2.3"
+      }
+    }
+  ],
+  "version": 2
+}

--- a/providers/os/resources/languages/swift/podfilelock/extractor.go
+++ b/providers/os/resources/languages/swift/podfilelock/extractor.go
@@ -1,0 +1,137 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package podfilelock
+
+import (
+	"bufio"
+	"io"
+	"strings"
+
+	"go.mondoo.com/mql/v13/providers/os/resources/languages"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages/swift"
+)
+
+var (
+	_ languages.Extractor = (*Extractor)(nil)
+	_ languages.Bom       = (*podfileLock)(nil)
+)
+
+// Extractor parses CocoaPods Podfile.lock files.
+type Extractor struct{}
+
+func (e *Extractor) Name() string {
+	return "podfilelock"
+}
+
+func (e *Extractor) Parse(r io.Reader, filename string) (languages.Bom, error) {
+	pl, err := parsePodfileLock(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if filename != "" {
+		pl.evidence = append(pl.evidence, filename)
+	}
+
+	return pl, nil
+}
+
+// parsePodfileLock reads a Podfile.lock and extracts pod names and versions
+// from the PODS: section.
+func parsePodfileLock(r io.Reader) (*podfileLock, error) {
+	pl := &podfileLock{}
+	scanner := bufio.NewScanner(r)
+	inPods := false
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Detect section headers
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "PODS:" {
+			inPods = true
+			continue
+		}
+
+		// Any other section header ends PODS
+		if !strings.HasPrefix(line, " ") && strings.HasSuffix(trimmed, ":") && trimmed != "PODS:" {
+			inPods = false
+			continue
+		}
+
+		if !inPods {
+			continue
+		}
+
+		// Pod entries are "  - Name (version)" (2-space indent)
+		// Sub-dependencies are "    - Name (constraint)" (4+ space indent)
+		// We only want top-level pods (2-space indent with "  - ")
+		if !strings.HasPrefix(line, "  - ") {
+			continue
+		}
+		// Skip sub-dependencies (indented more than 2 spaces after "  - ")
+		if strings.HasPrefix(line, "    ") {
+			continue
+		}
+
+		entry := parsePodEntry(strings.TrimPrefix(line, "  - "))
+		if entry.Name != "" {
+			pl.Pods = append(pl.Pods, entry)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return pl, nil
+}
+
+// parsePodEntry parses "Name (version)" or "Name (version):" from a PODS line.
+func parsePodEntry(s string) podEntry {
+	s = strings.TrimSpace(s)
+
+	// Remove trailing colon (pods with sub-dependencies)
+	s = strings.TrimSuffix(s, ":")
+
+	// Find "(version)"
+	openParen := strings.LastIndex(s, "(")
+	closeParen := strings.LastIndex(s, ")")
+	if openParen == -1 || closeParen == -1 || closeParen <= openParen {
+		return podEntry{}
+	}
+
+	name := strings.TrimSpace(s[:openParen])
+	version := s[openParen+1 : closeParen]
+
+	return podEntry{
+		Name:    name,
+		Version: version,
+	}
+}
+
+// Root returns nil — Podfile.lock does not describe the root project.
+func (pl *podfileLock) Root() *languages.Package {
+	return nil
+}
+
+// Direct returns nil — Podfile.lock does not distinguish direct from transitive in the PODS section.
+func (pl *podfileLock) Direct() languages.Packages {
+	return nil
+}
+
+// Transitive returns all resolved pods.
+func (pl *podfileLock) Transitive() languages.Packages {
+	var packages languages.Packages
+	for _, pod := range pl.Pods {
+		packages = append(packages, &languages.Package{
+			Name:         pod.Name,
+			Version:      pod.Version,
+			Purl:         swift.NewCocoapodsPackageUrl(pod.Name, pod.Version),
+			Cpes:         swift.NewCpes(pod.Name, pod.Version),
+			EvidenceList: swift.NewEvidenceList(pl.evidence),
+		})
+	}
+	return packages
+}

--- a/providers/os/resources/languages/swift/podfilelock/extractor_test.go
+++ b/providers/os/resources/languages/swift/podfilelock/extractor_test.go
@@ -1,0 +1,47 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package podfilelock
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/sbom"
+)
+
+func TestPodfileLockExtractor(t *testing.T) {
+	f, err := os.Open("./testdata/simple.Podfile.lock")
+	require.NoError(t, err)
+	defer f.Close()
+
+	info, err := (&Extractor{}).Parse(f, "Podfile.lock")
+	require.NoError(t, err)
+
+	assert.Nil(t, info.Root())
+	assert.Nil(t, info.Direct())
+
+	transitive := info.Transitive()
+	// Alamofire, SwiftyJSON, Moya, Moya/Core (4 top-level pods)
+	assert.Equal(t, 4, len(transitive))
+
+	p := transitive.Find("Alamofire")
+	require.NotNil(t, p)
+	assert.Equal(t, "5.8.1", p.Version)
+	assert.Equal(t, "pkg:cocoapods/Alamofire@5.8.1", p.Purl)
+	assert.Equal(t, []*sbom.Evidence{{Type: sbom.EvidenceType_EVIDENCE_TYPE_FILE, Value: "Podfile.lock"}}, p.EvidenceList)
+
+	p = transitive.Find("Moya")
+	require.NotNil(t, p)
+	assert.Equal(t, "15.0.3", p.Version)
+
+	p = transitive.Find("Moya/Core")
+	require.NotNil(t, p)
+	assert.Equal(t, "15.0.3", p.Version)
+
+	p = transitive.Find("SwiftyJSON")
+	require.NotNil(t, p)
+	assert.Equal(t, "5.0.1", p.Version)
+}

--- a/providers/os/resources/languages/swift/podfilelock/parser.go
+++ b/providers/os/resources/languages/swift/podfilelock/parser.go
@@ -1,0 +1,19 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package podfilelock
+
+// podfileLock represents a parsed Podfile.lock file.
+type podfileLock struct {
+	// Pods is the list of resolved pods with versions.
+	Pods []podEntry
+
+	// evidence is a list of file paths where the Podfile.lock was found.
+	evidence []string
+}
+
+// podEntry represents a single pod with its resolved version.
+type podEntry struct {
+	Name    string
+	Version string
+}

--- a/providers/os/resources/languages/swift/podfilelock/testdata/simple.Podfile.lock
+++ b/providers/os/resources/languages/swift/podfilelock/testdata/simple.Podfile.lock
@@ -1,0 +1,22 @@
+PODS:
+  - Alamofire (5.8.1)
+  - SwiftyJSON (5.0.1)
+  - Moya (15.0.3):
+    - Alamofire (~> 5.0)
+    - Moya/Core (= 15.0.3)
+  - Moya/Core (15.0.3):
+    - Alamofire (~> 5.0)
+
+DEPENDENCIES:
+  - Alamofire (~> 5.8)
+  - SwiftyJSON (~> 5.0)
+  - Moya (~> 15.0)
+
+SPEC CHECKSUMS:
+  Alamofire: 3ca42e259f7c0c813defc2c0820d4fce16e97a5d
+  SwiftyJSON: 6faa0040f8b59dead0ee07436cbf76b73c08fd08
+  Moya: abc123def456
+
+PODFILE CHECKSUM: deadbeef12345678
+
+COCOAPODS: 1.14.3

--- a/providers/os/resources/languages/swift/swift.go
+++ b/providers/os/resources/languages/swift/swift.go
@@ -1,0 +1,57 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package swift
+
+import (
+	"github.com/package-url/packageurl-go"
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/providers/os/resources/cpe"
+	"go.mondoo.com/mql/v13/sbom"
+)
+
+// NewSpmPackageUrl creates a Swift Package Manager package URL.
+func NewSpmPackageUrl(name string, version string) string {
+	return packageurl.NewPackageURL(
+		"swift",
+		"",
+		name,
+		version,
+		nil,
+		"").String()
+}
+
+// NewCocoapodsPackageUrl creates a CocoaPods package URL.
+func NewCocoapodsPackageUrl(name string, version string) string {
+	return packageurl.NewPackageURL(
+		"cocoapods",
+		"",
+		name,
+		version,
+		nil,
+		"").String()
+}
+
+// NewCpes creates CPE entries for a Swift package.
+func NewCpes(name string, version string) []string {
+	cpes := []string{}
+	cpeEntries, err := cpe.NewPackage2Cpe(name, name, version, "", "")
+	if err != nil {
+		log.Warn().Str("name", name).Str("version", version).Err(err).Msg("failed to create cpe for Swift package")
+	} else if len(cpeEntries) > 0 {
+		cpes = append(cpes, cpeEntries...)
+	}
+	return cpes
+}
+
+// NewEvidenceList converts a list of file paths to evidence entries.
+func NewEvidenceList(evidence []string) []*sbom.Evidence {
+	evidenceList := make([]*sbom.Evidence, len(evidence))
+	for i, e := range evidence {
+		evidenceList[i] = &sbom.Evidence{
+			Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
+			Value: e,
+		}
+	}
+	return evidenceList
+}

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -2433,6 +2433,35 @@ githubactions.package @defaults("name version purl") {
   files() []pkgFileInfo
 }
 
+// Swift packages (SPM and CocoaPods)
+swift.packages {
+  []swift.package
+
+  init(path? string)
+
+  // Path to search for Swift package files
+  path string
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// Swift package dependency
+swift.package @defaults("name version purl") {
+  // ID is the swift.package unique identifier
+  id string
+  // Name of the package
+  name() string
+  // Version of the package
+  version() string
+  // Package URL
+  purl() string
+  // Common Platform Enumeration (CPE) for the package
+  cpes() []core.cpe
+  // Package files
+  files() []pkgFileInfo
+}
+
 // macOS specific resources
 macos {
   // macOS computer name

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -190,6 +190,8 @@ const (
 	ResourcePhpPackage                   string = "php.package"
 	ResourceGithubactionsPackages        string = "githubactions.packages"
 	ResourceGithubactionsPackage         string = "githubactions.package"
+	ResourceSwiftPackages                string = "swift.packages"
+	ResourceSwiftPackage                 string = "swift.package"
 	ResourceMacos                        string = "macos"
 	ResourceMacosHardware                string = "macos.hardware"
 	ResourceMacosAlf                     string = "macos.alf"
@@ -956,6 +958,14 @@ func init() {
 		"githubactions.package": {
 			// to override args, implement: initGithubactionsPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createGithubactionsPackage,
+		},
+		"swift.packages": {
+			Init:   initSwiftPackages,
+			Create: createSwiftPackages,
+		},
+		"swift.package": {
+			// to override args, implement: initSwiftPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createSwiftPackage,
 		},
 		"macos": {
 			// to override args, implement: initMacos(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -3789,6 +3799,33 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"githubactions.package.files": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubactionsPackage).GetFiles()).ToDataRes(types.Array(types.Resource("pkgFileInfo")))
+	},
+	"swift.packages.path": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSwiftPackages).GetPath()).ToDataRes(types.String)
+	},
+	"swift.packages.files": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSwiftPackages).GetFiles()).ToDataRes(types.Array(types.Resource("pkgFileInfo")))
+	},
+	"swift.packages.list": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSwiftPackages).GetList()).ToDataRes(types.Array(types.Resource("swift.package")))
+	},
+	"swift.package.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSwiftPackage).GetId()).ToDataRes(types.String)
+	},
+	"swift.package.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSwiftPackage).GetName()).ToDataRes(types.String)
+	},
+	"swift.package.version": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSwiftPackage).GetVersion()).ToDataRes(types.String)
+	},
+	"swift.package.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSwiftPackage).GetPurl()).ToDataRes(types.String)
+	},
+	"swift.package.cpes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSwiftPackage).GetCpes()).ToDataRes(types.Array(types.Resource("cpe")))
+	},
+	"swift.package.files": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSwiftPackage).GetFiles()).ToDataRes(types.Array(types.Resource("pkgFileInfo")))
 	},
 	"macos.computerName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMacos).GetComputerName()).ToDataRes(types.String)
@@ -9233,6 +9270,50 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"githubactions.package.files": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGithubactionsPackage).Files, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"swift.packages.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSwiftPackages).__id, ok = v.Value.(string)
+		return
+	},
+	"swift.packages.path": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSwiftPackages).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"swift.packages.files": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSwiftPackages).Files, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"swift.packages.list": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSwiftPackages).List, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"swift.package.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSwiftPackage).__id, ok = v.Value.(string)
+		return
+	},
+	"swift.package.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSwiftPackage).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"swift.package.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSwiftPackage).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"swift.package.version": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSwiftPackage).Version, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"swift.package.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSwiftPackage).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"swift.package.cpes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSwiftPackage).Cpes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"swift.package.files": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSwiftPackage).Files, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"macos.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -25673,6 +25754,193 @@ func (c *mqlGithubactionsPackage) GetFiles() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Files, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
 			d, err := c.MqlRuntime.FieldResourceFromRecording("githubactions.package", c.__id, "files")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.files()
+	})
+}
+
+// mqlSwiftPackages for the swift.packages resource
+type mqlSwiftPackages struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlSwiftPackagesInternal
+	Path  plugin.TValue[string]
+	Files plugin.TValue[[]any]
+	List  plugin.TValue[[]any]
+}
+
+// createSwiftPackages creates a new instance of this resource
+func createSwiftPackages(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlSwiftPackages{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("swift.packages", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlSwiftPackages) MqlName() string {
+	return "swift.packages"
+}
+
+func (c *mqlSwiftPackages) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlSwiftPackages) GetPath() *plugin.TValue[string] {
+	return &c.Path
+}
+
+func (c *mqlSwiftPackages) GetFiles() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Files, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("swift.packages", c.__id, "files")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.files()
+	})
+}
+
+func (c *mqlSwiftPackages) GetList() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.List, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("swift.packages", c.__id, "list")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.list()
+	})
+}
+
+// mqlSwiftPackage for the swift.package resource
+type mqlSwiftPackage struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlSwiftPackageInternal it will be used here
+	Id      plugin.TValue[string]
+	Name    plugin.TValue[string]
+	Version plugin.TValue[string]
+	Purl    plugin.TValue[string]
+	Cpes    plugin.TValue[[]any]
+	Files   plugin.TValue[[]any]
+}
+
+// createSwiftPackage creates a new instance of this resource
+func createSwiftPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlSwiftPackage{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("swift.package", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlSwiftPackage) MqlName() string {
+	return "swift.package"
+}
+
+func (c *mqlSwiftPackage) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlSwiftPackage) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlSwiftPackage) GetName() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Name, func() (string, error) {
+		return c.name()
+	})
+}
+
+func (c *mqlSwiftPackage) GetVersion() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Version, func() (string, error) {
+		return c.version()
+	})
+}
+
+func (c *mqlSwiftPackage) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
+	})
+}
+
+func (c *mqlSwiftPackage) GetCpes() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Cpes, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("swift.package", c.__id, "cpes")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.cpes()
+	})
+}
+
+func (c *mqlSwiftPackage) GetFiles() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Files, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("swift.package", c.__id, "files")
 			if err != nil {
 				return nil, err
 			}

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -1255,6 +1255,17 @@ sudoers.userSpec.runasUsers 11.7.0
 sudoers.userSpec.tags 11.7.0
 sudoers.userSpec.users 11.7.0
 sudoers.userSpecs 11.7.0
+swift.package 13.10.1
+swift.package.cpes 13.10.1
+swift.package.files 13.10.1
+swift.package.id 13.10.1
+swift.package.name 13.10.1
+swift.package.purl 13.10.1
+swift.package.version 13.10.1
+swift.packages 13.10.1
+swift.packages.files 13.10.1
+swift.packages.list 13.10.1
+swift.packages.path 13.10.1
 sysrc 13.2.6
 sysrc.content 13.2.6
 sysrc.entries 13.2.6

--- a/providers/os/resources/swift.go
+++ b/providers/os/resources/swift.go
@@ -1,0 +1,307 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages/swift/packageresolved"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages/swift/podfilelock"
+	"go.mondoo.com/mql/v13/types"
+)
+
+// defaultSwiftPaths are searched for Swift package files.
+// Only top-level files in these directories are scanned.
+var defaultSwiftPaths = []string{
+	"/app",
+	"/usr/src/app",
+	"/home/*/app",
+}
+
+func initSwiftPackages(_ *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if x, ok := args["path"]; ok {
+		_, ok := x.Value.(string)
+		if !ok {
+			return nil, nil, errors.New("wrong type for 'path' in swift.packages initialization, it must be a string")
+		}
+	} else {
+		args["path"] = llx.StringData("")
+	}
+	return args, nil, nil
+}
+
+func (r *mqlSwiftPackages) id() (string, error) {
+	if r.Path.Data != "" {
+		return "swift.packages/" + r.Path.Data, nil
+	}
+	return "swift.packages", nil
+}
+
+type mqlSwiftPackagesInternal struct {
+	mutex   sync.Mutex
+	fetched bool
+}
+
+func (r *mqlSwiftPackages) gatherData() error {
+	if r.fetched {
+		return nil
+	}
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if r.fetched {
+		return nil
+	}
+
+	conn := r.MqlRuntime.Connection.(shared.Connection)
+	fs := conn.FileSystem()
+	afs := &afero.Afero{Fs: fs}
+
+	path := r.Path.Data
+
+	var allDeps []*languages.Package
+	var filePaths []string
+
+	if path != "" {
+		deps, files := collectSwiftPackages(afs, path)
+		allDeps = append(allDeps, deps...)
+		filePaths = append(filePaths, files...)
+	} else {
+		for _, searchPath := range defaultSwiftPaths {
+			// Expand glob wildcards in search paths (e.g., /home/*/app)
+			matches, err := afero.Glob(fs, searchPath)
+			if err != nil {
+				// Skip paths with invalid glob patterns
+				continue
+			}
+			if len(matches) == 0 {
+				// Only fall back to literal path for non-glob paths (avoid
+				// unnecessary stat calls for glob patterns with no matches)
+				if strings.ContainsAny(searchPath, "*?[") {
+					continue
+				}
+				matches = []string{searchPath}
+			}
+			for _, match := range matches {
+				deps, files := collectSwiftFromDir(afs, match)
+				allDeps = append(allDeps, deps...)
+				filePaths = append(filePaths, files...)
+			}
+		}
+	}
+
+	// Deduplicate and sort
+	allDeps = deduplicateSwiftPackages(allDeps)
+	slices.SortFunc(allDeps, languages.SortFn)
+
+	// Set list
+	allResources, err := newSwiftPackageList(r.MqlRuntime, allDeps)
+	if err != nil {
+		return err
+	}
+	r.List = plugin.TValue[[]any]{Data: allResources, State: plugin.StateIsSet}
+
+	// Set files
+	mqlFiles := []any{}
+	for _, p := range filePaths {
+		lf, err := CreateResource(r.MqlRuntime, "pkgFileInfo", map[string]*llx.RawData{
+			"path": llx.StringData(p),
+		})
+		if err != nil {
+			return err
+		}
+		mqlFiles = append(mqlFiles, lf)
+	}
+	r.Files = plugin.TValue[[]any]{Data: mqlFiles, State: plugin.StateIsSet}
+
+	r.fetched = true
+	return nil
+}
+
+func collectSwiftPackages(afs *afero.Afero, path string) ([]*languages.Package, []string) {
+	isDir, err := afs.IsDir(path)
+	if err != nil {
+		log.Debug().Err(err).Str("path", path).Msg("could not check Swift path")
+		return nil, nil
+	}
+
+	if isDir {
+		return collectSwiftFromDir(afs, path)
+	}
+
+	return collectSwiftFromFile(afs, path)
+}
+
+func collectSwiftFromDir(afs *afero.Afero, dir string) ([]*languages.Package, []string) {
+	var allDeps []*languages.Package
+	var files []string
+
+	// Check Package.resolved
+	resolvedPath := filepath.Join(dir, "Package.resolved")
+	if exists, _ := afs.Exists(resolvedPath); exists {
+		deps, f := collectSwiftFromFile(afs, resolvedPath)
+		allDeps = append(allDeps, deps...)
+		files = append(files, f...)
+	}
+
+	// Check Podfile.lock
+	podPath := filepath.Join(dir, "Podfile.lock")
+	if exists, _ := afs.Exists(podPath); exists {
+		deps, f := collectSwiftFromFile(afs, podPath)
+		allDeps = append(allDeps, deps...)
+		files = append(files, f...)
+	}
+
+	return allDeps, files
+}
+
+func collectSwiftFromFile(afs *afero.Afero, path string) ([]*languages.Package, []string) {
+	f, err := afs.Open(path)
+	if err != nil {
+		log.Debug().Err(err).Str("path", path).Msg("could not open Swift file")
+		return nil, nil
+	}
+	defer f.Close()
+
+	var extractor languages.Extractor
+	switch {
+	case strings.HasSuffix(path, "Package.resolved"):
+		extractor = &packageresolved.Extractor{}
+	case strings.HasSuffix(path, "Podfile.lock"):
+		extractor = &podfilelock.Extractor{}
+	default:
+		return nil, nil
+	}
+
+	bom, err := extractor.Parse(f, path)
+	if err != nil {
+		log.Debug().Err(err).Str("path", path).Msg("could not parse Swift file")
+		return nil, nil
+	}
+
+	return bom.Transitive(), []string{path}
+}
+
+func deduplicateSwiftPackages(pkgs []*languages.Package) []*languages.Package {
+	seen := make(map[string]bool)
+	var result []*languages.Package
+	for _, pkg := range pkgs {
+		key := pkg.Name + "@" + pkg.Version
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		result = append(result, pkg)
+	}
+	return result
+}
+
+func (r *mqlSwiftPackages) list() ([]any, error) {
+	return nil, r.gatherData()
+}
+
+func (r *mqlSwiftPackages) files() ([]any, error) {
+	return nil, r.gatherData()
+}
+
+func newSwiftPackageList(runtime *plugin.Runtime, packages []*languages.Package) ([]any, error) {
+	resources := []any{}
+	for i := range packages {
+		pkg, err := newSwiftPackage(runtime, packages[i])
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, pkg)
+	}
+	return resources, nil
+}
+
+func newSwiftPackage(runtime *plugin.Runtime, pkg *languages.Package) (*mqlSwiftPackage, error) {
+	cpes := []any{}
+	for i := range pkg.Cpes {
+		cpe, err := runtime.CreateSharedResource("cpe", map[string]*llx.RawData{
+			"uri": llx.StringData(pkg.Cpes[i]),
+		})
+		if err != nil {
+			return nil, err
+		}
+		cpes = append(cpes, cpe)
+	}
+
+	mqlFiles := []any{}
+	for i := range pkg.EvidenceList {
+		evidence := pkg.EvidenceList[i]
+		lf, err := CreateResource(runtime, "pkgFileInfo", map[string]*llx.RawData{
+			"path": llx.StringData(evidence.Value),
+		})
+		if err != nil {
+			return nil, err
+		}
+		mqlFiles = append(mqlFiles, lf)
+	}
+
+	path := ""
+	if len(mqlFiles) > 0 {
+		if fi, ok := mqlFiles[0].(*mqlPkgFileInfo); ok {
+			path = fi.Path.Data
+		}
+	}
+
+	mqlPkg, err := CreateResource(runtime, "swift.package", map[string]*llx.RawData{
+		"id":      llx.StringData(pkg.Name + "@" + pkg.Version + ":" + path),
+		"name":    llx.StringData(pkg.Name),
+		"version": llx.StringData(pkg.Version),
+		"purl":    llx.StringData(pkg.Purl),
+		"cpes":    llx.ArrayData(cpes, types.Resource("cpe")),
+		"files":   llx.ArrayData(mqlFiles, types.Resource("pkgFileInfo")),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return mqlPkg.(*mqlSwiftPackage), nil
+}
+
+func (k *mqlSwiftPackage) id() (string, error) {
+	return k.Id.Data, nil
+}
+
+func (r *mqlSwiftPackage) name() (string, error) {
+	return "", r.populateData()
+}
+
+func (r *mqlSwiftPackage) version() (string, error) {
+	return "", r.populateData()
+}
+
+func (r *mqlSwiftPackage) purl() (string, error) {
+	return "", r.populateData()
+}
+
+func (r *mqlSwiftPackage) cpes() ([]any, error) {
+	return nil, r.populateData()
+}
+
+func (r *mqlSwiftPackage) files() ([]any, error) {
+	return nil, r.populateData()
+}
+
+func (r *mqlSwiftPackage) populateData() error {
+	// swift.package instances are only created via newSwiftPackage, which pre-populates
+	// all fields at creation time.
+	r.Name = plugin.TValue[string]{State: plugin.StateIsSet | plugin.StateIsNull}
+	r.Version = plugin.TValue[string]{State: plugin.StateIsSet | plugin.StateIsNull}
+	r.Purl = plugin.TValue[string]{State: plugin.StateIsSet | plugin.StateIsNull}
+	r.Cpes = plugin.TValue[[]any]{State: plugin.StateIsSet | plugin.StateIsNull}
+	r.Files = plugin.TValue[[]any]{State: plugin.StateIsSet | plugin.StateIsNull}
+	return nil
+}

--- a/sbom/generator/generator.go
+++ b/sbom/generator/generator.go
@@ -287,6 +287,29 @@ func GenerateBom(r *reporter.Report) []*sbom.Sbom {
 
 				bom.Packages = append(bom.Packages, bomPkg)
 			}
+
+			for _, pkg := range rb.SwiftPackages {
+				pkgType := "swift"
+				if strings.HasPrefix(pkg.Purl, "pkg:cocoapods/") {
+					pkgType = "cocoapods"
+				}
+				bomPkg := &sbom.Package{
+					Name:    pkg.Name,
+					Version: pkg.Version,
+					Purl:    pkg.Purl,
+					Cpes:    pkg.CPEs,
+					Type:    pkgType,
+				}
+
+				for _, filepath := range pkg.FilePaths {
+					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
+						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
+						Value: filepath,
+					})
+				}
+
+				bom.Packages = append(bom.Packages, bomPkg)
+			}
 		}
 		boms = append(boms, bom)
 	}

--- a/sbom/generator/report_collection.go
+++ b/sbom/generator/report_collection.go
@@ -57,6 +57,7 @@ type BomFields struct {
 	DotnetPackages        []BomPackage      `json:"dotnet.packages.list,omitempty"`
 	PhpPackages           []BomPackage      `json:"php.packages.list,omitempty"`
 	GithubActionsPackages []BomPackage      `json:"githubactions.packages.list,omitempty"`
+	SwiftPackages         []BomPackage      `json:"swift.packages.list,omitempty"`
 	KernelInstalled       []KernelInstalled `json:"kernel.installed,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

Adds native SBOM cataloging for Swift packages, supporting both **Swift Package Manager** (Package.resolved) and **CocoaPods** (Podfile.lock) across all scanning contexts — local, SSH, and containers.

## New MQL Resources

### `swift.packages`

Discovers Swift dependencies from both package managers. Checks for `Package.resolved` and `Podfile.lock` in the target directory.

```coffeescript
mql run os -c "swift.packages(path: '.') { list { name version purl } }"
```

### `swift.package`

| Field | Type | Description |
|-------|------|-------------|
| `name` | `string` | Package name (e.g., `alamofire`, `Alamofire`) |
| `version` | `string` | Version (e.g., `5.8.1`) |
| `purl` | `string` | `pkg:swift/<name>@<version>` or `pkg:cocoapods/<name>@<version>` |
| `cpes` | `[]core.cpe` | CPE entries |
| `files` | `[]pkgFileInfo` | Evidence files |

## Parsers

### Package.resolved (Swift Package Manager)
- Supports **v1** and **v2** JSON formats
- V2: `pins` array at top level with `identity`, `state.version`
- V1: `object.pins` array with `package`, `state.version`

### Podfile.lock (CocoaPods)
- Custom line-oriented parser for `PODS:` section
- Extracts top-level pod names and versions (`  - Name (version)`)
- Skips sub-dependency lines (deeper indentation)
- Handles pods with sub-specs (e.g., `Moya/Core (15.0.3)`)

## Usage Examples

```coffeescript
# All Swift dependencies
mql run os -c "swift.packages(path: '.') { list { name version purl } }"

# Policy: ensure no outdated Alamofire
swift.packages.list.none(name == "alamofire" && version == /^4\./)

# Remote scan
mql run ssh user@host -c "swift.packages(path: '/app') { list { name version } }"
```

## Test plan

- [x] Package.resolved v2: 3 pins, PURL generation
- [x] Package.resolved v1: 2 pins, legacy format
- [x] Podfile.lock: 4 top-level pods (incl. sub-specs), sub-deps excluded
- [x] SBOM generator tests pass
- [x] `golangci-lint` extended clean
- [x] `gofmt` clean
- [x] Full OS provider builds
- [ ] Interactive verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)