### PR TITLE
🐛 Add check-latest to setup-go for self-hosted runners

### DIFF
--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
 
       - name: Install Protoc

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -82,6 +82,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
 
       - name: Install Protoc

--- a/.github/workflows/pr-extended-linting.yml
+++ b/.github/workflows/pr-extended-linting.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
       - name: Generate test files
         run: make test/generate

--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
 
       # We do not permit sudo on self-hosted runners

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
 
       - name: Check go mod
@@ -50,6 +51,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
 
       - run: make providers/build/core
@@ -84,6 +86,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
 
       - name: "Set up gcloud CLI"
@@ -121,6 +124,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
 
       - name: "Set up gcloud CLI"
@@ -153,6 +157,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
 
       - name: Run race detector on selected packages

--- a/.github/workflows/pr-test-windows.yml
+++ b/.github/workflows/pr-test-windows.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
 
       - name: Find packages with Windows-specific tests

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -129,6 +129,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
 
       - name: Install Protoc

--- a/.github/workflows/release-providers.yml
+++ b/.github/workflows/release-providers.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
 
       - name: Install Protoc

--- a/.github/workflows/reusable-lint-providers.yml
+++ b/.github/workflows/reusable-lint-providers.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
 
       - name: Install golangci-lint

--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ">=${{ env.golang-version }}"
+          check-latest: true
           cache: false
 
       - name: Update deps


### PR DESCRIPTION
## Summary

- Add `check-latest: true` to all `actions/setup-go` steps across 10 workflow files (14 occurrences total)
- Ensures self-hosted runners always fetch the newest Go patch release instead of using a stale cached version

## Details

Self-hosted runners cache the Go toolchain in a persistent tool cache directory. Without `check-latest: true`, `setup-go` uses the cached version even when a newer patch release is available that satisfies the version constraint (e.g., `>=1.23`). This can cause builds to use outdated Go versions with known bugs or security issues.

## Test plan

- [ ] Verify CI workflows pass on this PR
- [ ] Confirm setup-go step logs show "Checking latest match..." in workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)