### PR TITLE
🐛 Add concurrency group to goreleaser edge workflow

### DIFF
--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -12,6 +12,10 @@ on:
         default: false
         type: boolean
 
+concurrency:
+  group: goreleaser-edge
+  cancel-in-progress: false
+
 env:
   REGISTRY: docker.io
 


### PR DESCRIPTION
## Summary
- Adds a `concurrency` group to the goreleaser edge workflow to serialize builds
- Prevents race condition where concurrent pushes to `main` overwrite each other's arch-specific Docker tags, causing manifest verification failures
- Uses `cancel-in-progress: false` so every commit still gets a full build

## Context
On 2026-04-16, two provider releases (`oci-13.2.0` and `os-13.10.0`) merged ~40 seconds apart. Both triggered concurrent edge builds that pushed to the same `edge-latest-*` tags simultaneously. Each build invalidated the other's recorded digests, causing both to fail with `manifest verification failed for digest` after exhausting retries.

Failed runs:
- https://github.com/mondoohq/mql/actions/runs/24525441468 (oci-13.2.0, 1h32m)
- https://github.com/mondoohq/mql/actions/runs/24525471432 (os-13.10.0, 42m)

## Test plan
- [ ] Verify workflow YAML is valid
- [ ] Next time two commits land on main in quick succession, confirm the second build queues instead of racing

🤖 Generated with [Claude Code](https://claude.com/claude-code)