### PR TITLE
chore: migrate create-github-app-token from app-id to client-id

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -188,9 +188,9 @@ jobs:
       # fetch a token for the mondoo-mergebot app
       - name: Generate token
         id: generate-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
+          client-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
           private-key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
       # automerge using bot token
       - name: Approve and merge a PR

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -236,9 +236,9 @@ jobs:
     steps:
       - name: Generate token
         id: generate-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
+          client-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
           private-key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
           owner: mondoohq
           repositories: |


### PR DESCRIPTION
## Summary
- Replace deprecated `app-id` input with `client-id` for `actions/create-github-app-token`
- Pin action to `v3.1.1` (`1b10c78c7865c340bc4f6099eb2f838309f1e8c3`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)