### PR TITLE
🐛 Fix claude.code/openai.codex home dir detection and symlink handling

### DIFF
--- a/providers/os/resources/ai_coding_tools.go
+++ b/providers/os/resources/ai_coding_tools.go
@@ -166,8 +166,9 @@ func parseSkillMd(name, sourcePath, content string) skillInfo {
 	return info
 }
 
-// targetHomeDir resolves the first non-system user's home directory on the target
-// via the users resource, so it works for remote SSH/container connections.
+// targetHomeDir resolves a real user's home directory on the target.
+// It prefers a currently logged-in user (via loggedInUsers / "who"),
+// falling back to the first non-system user if no one is logged in.
 func targetHomeDir(runtime *plugin.Runtime) (string, error) {
 	usersResource, err := CreateResource(runtime, "users", map[string]*llx.RawData{})
 	if err != nil {
@@ -179,13 +180,27 @@ func targetHomeDir(runtime *plugin.Runtime) (string, error) {
 		return "", fmt.Errorf("cannot list users on target: %w", userList.Error)
 	}
 
+	conn := runtime.Connection.(shared.Connection)
+	loggedIn, _ := loggedInUsers(runtime, conn)
+
+	var fallback string
 	for _, u := range userList.Data {
 		user := u.(*mqlUser)
 		home := user.GetHome().Data
-		if home != "" && !isSystemHomeDir(home) {
+		if home == "" || isSystemHomeDir(home) {
+			continue
+		}
+		// Prefer a user that is currently logged in.
+		if loggedIn[user.GetName().Data] {
 			return home, nil
+		}
+		if fallback == "" {
+			fallback = home
 		}
 	}
 
+	if fallback != "" {
+		return fallback, nil
+	}
 	return "", fmt.Errorf("no valid user home directory found on target")
 }

--- a/providers/os/resources/ai_coding_tools.go
+++ b/providers/os/resources/ai_coding_tools.go
@@ -1,0 +1,191 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/afero"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"sigs.k8s.io/yaml"
+)
+
+// initConfigPath is a shared init helper for resources that resolve a
+// configPath from the target's home directory (e.g. claude.code, openai.codex).
+func initConfigPath(runtime *plugin.Runtime, args map[string]*llx.RawData, resourceName, defaultDir string) (map[string]*llx.RawData, plugin.Resource, error) {
+	if x, ok := args["configPath"]; ok {
+		path, ok := x.Value.(string)
+		if !ok {
+			return nil, nil, fmt.Errorf("wrong type for 'configPath' in %s initialization, it must be a string", resourceName)
+		}
+		if path == "" {
+			delete(args, "configPath")
+		}
+	}
+
+	if _, ok := args["configPath"]; !ok {
+		// Resolve the home directory from the target's user list, not the local host.
+		home, err := targetHomeDir(runtime)
+		if err != nil {
+			return nil, nil, err
+		}
+		args["configPath"] = llx.StringData(filepath.Join(home, defaultDir))
+	}
+
+	return args, nil, nil
+}
+
+// connectionAfs returns an afero.Afero wrapping the connection's filesystem.
+func connectionAfs(runtime *plugin.Runtime) *afero.Afero {
+	conn := runtime.Connection.(shared.Connection)
+	return &afero.Afero{Fs: conn.FileSystem()}
+}
+
+// listSubdirsAfero returns the names and full paths of subdirectories in dir,
+// following symlinks so that symlinked directories are included.
+func listSubdirsAfero(afs *afero.Afero, dir string) ([]subdirEntry, error) {
+	entries, err := afs.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []subdirEntry
+	for _, entry := range entries {
+		fullPath := filepath.Join(dir, entry.Name())
+		// Stat follows symlinks; ReadDir returns Lstat info where
+		// symlinked directories report IsDir()==false.
+		info, err := afs.Stat(fullPath)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		result = append(result, subdirEntry{name: entry.Name(), path: fullPath})
+	}
+	return result, nil
+}
+
+type subdirEntry struct {
+	name string
+	path string
+}
+
+// readJSONFileAfero reads and unmarshals a JSON file relative to a base directory
+// using the provided afero filesystem (which may be remote via SSH, container, etc.).
+func readJSONFileAfero(afs *afero.Afero, baseDir string, relPath string, v interface{}) error {
+	data, err := afs.ReadFile(filepath.Join(baseDir, relPath))
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, v)
+}
+
+// dirHasFilesAfero returns true if the directory contains at least one non-directory entry.
+func dirHasFilesAfero(afs *afero.Afero, dir string) bool {
+	entries, err := afs.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			return true
+		}
+	}
+	return false
+}
+
+// contentSHA256 returns the hex-encoded SHA-256 digest of s.
+func contentSHA256(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}
+
+// Skill parsing types and functions shared by claude.code and openai.codex.
+
+type skillInfo struct {
+	name         string
+	description  string
+	allowedTools []string
+	argumentHint string
+	source       string
+	content      string
+}
+
+type skillFrontmatter struct {
+	Name         string `json:"name" yaml:"name"`
+	Description  string `json:"description" yaml:"description"`
+	AllowedTools string `json:"allowed-tools" yaml:"allowed-tools"`
+	ArgumentHint string `json:"argument-hint" yaml:"argument-hint"`
+}
+
+func parseSkillMd(name, sourcePath, content string) skillInfo {
+	info := skillInfo{
+		name:    name,
+		source:  sourcePath,
+		content: content,
+	}
+
+	// Extract YAML frontmatter between --- delimiters
+	if !strings.HasPrefix(content, "---\n") {
+		return info
+	}
+
+	endIdx := strings.Index(content[4:], "\n---")
+	if endIdx == -1 {
+		return info
+	}
+
+	frontmatter := content[4 : 4+endIdx]
+	var fm skillFrontmatter
+	if err := yaml.Unmarshal([]byte(frontmatter), &fm); err != nil {
+		return info
+	}
+
+	if fm.Name != "" {
+		info.name = fm.Name
+	}
+	info.description = fm.Description
+	info.argumentHint = fm.ArgumentHint
+
+	// allowed-tools is a comma-separated string in both Claude Code and Codex SKILL.md files
+	if fm.AllowedTools != "" {
+		for _, tool := range strings.Split(fm.AllowedTools, ",") {
+			tool = strings.TrimSpace(tool)
+			if tool != "" {
+				info.allowedTools = append(info.allowedTools, tool)
+			}
+		}
+	}
+
+	return info
+}
+
+// targetHomeDir resolves the first non-system user's home directory on the target
+// via the users resource, so it works for remote SSH/container connections.
+func targetHomeDir(runtime *plugin.Runtime) (string, error) {
+	usersResource, err := CreateResource(runtime, "users", map[string]*llx.RawData{})
+	if err != nil {
+		return "", fmt.Errorf("cannot list users on target: %w", err)
+	}
+
+	userList := usersResource.(*mqlUsers).GetList()
+	if userList.Error != nil {
+		return "", fmt.Errorf("cannot list users on target: %w", userList.Error)
+	}
+
+	for _, u := range userList.Data {
+		user := u.(*mqlUser)
+		home := user.GetHome().Data
+		if home != "" && !isSystemHomeDir(home) {
+			return home, nil
+		}
+	}
+
+	return "", fmt.Errorf("no valid user home directory found on target")
+}

--- a/providers/os/resources/claude_code.go
+++ b/providers/os/resources/claude_code.go
@@ -4,7 +4,6 @@
 package resources
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,34 +16,13 @@ import (
 	"github.com/spf13/afero"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers/os/connection/shared"
 	"go.mondoo.com/mql/v13/types"
-	"sigs.k8s.io/yaml"
 )
 
 const defaultClaudeCodeConfigDir = ".claude"
 
 func initClaudeCode(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	if x, ok := args["configPath"]; ok {
-		path, ok := x.Value.(string)
-		if !ok {
-			return nil, nil, fmt.Errorf("wrong type for 'configPath' in claude.code initialization, it must be a string")
-		}
-		if path == "" {
-			delete(args, "configPath")
-		}
-	}
-
-	if _, ok := args["configPath"]; !ok {
-		// Resolve the home directory from the target's user list, not the local host.
-		home, err := targetHomeDir(runtime)
-		if err != nil {
-			return nil, nil, err
-		}
-		args["configPath"] = llx.StringData(filepath.Join(home, defaultClaudeCodeConfigDir))
-	}
-
-	return args, nil, nil
+	return initConfigPath(runtime, args, "claude.code", defaultClaudeCodeConfigDir)
 }
 
 // mqlClaudeCodeInternal caches the backup state for the lifetime of
@@ -66,8 +44,7 @@ func (r *mqlClaudeCode) configDir() string {
 
 // afs returns an afero.Afero wrapping the connection's filesystem.
 func (r *mqlClaudeCode) afs() *afero.Afero {
-	conn := r.MqlRuntime.Connection.(shared.Connection)
-	return &afero.Afero{Fs: conn.FileSystem()}
+	return connectionAfs(r.MqlRuntime)
 }
 
 func (r *mqlClaudeCode) email() (string, error) {
@@ -206,7 +183,7 @@ func (r *mqlClaudeCode) skills() ([]interface{}, error) {
 	afs := r.afs()
 	skillsDir := filepath.Join(r.configDir(), "skills")
 
-	entries, err := afs.ReadDir(skillsDir)
+	subdirs, err := listSubdirsAfero(afs, skillsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -215,18 +192,14 @@ func (r *mqlClaudeCode) skills() ([]interface{}, error) {
 	}
 
 	var result []interface{}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-
-		skillPath := filepath.Join(skillsDir, entry.Name(), "SKILL.md")
+	for _, dir := range subdirs {
+		skillPath := filepath.Join(dir.path, "SKILL.md")
 		data, err := afs.ReadFile(skillPath)
 		if err != nil {
 			continue
 		}
 
-		skill := parseSkillMd(entry.Name(), skillPath, string(data))
+		skill := parseSkillMd(dir.name, skillPath, string(data))
 
 		allowedToolsAny := make([]interface{}, len(skill.allowedTools))
 		for i, t := range skill.allowedTools {
@@ -234,7 +207,7 @@ func (r *mqlClaudeCode) skills() ([]interface{}, error) {
 		}
 
 		res, err := NewResource(r.MqlRuntime, "claude.code.skill", map[string]*llx.RawData{
-			"__id":         llx.StringData("claude.code.skill/" + entry.Name()),
+			"__id":         llx.StringData("claude.code.skill/" + dir.name),
 			"name":         llx.StringData(skill.name),
 			"description":  llx.StringData(skill.description),
 			"allowedTools": llx.ArrayData(allowedToolsAny, types.String),
@@ -331,15 +304,6 @@ type installedPluginEntry struct {
 	GitCommitSha string `json:"gitCommitSha"`
 }
 
-type skillInfo struct {
-	name         string
-	description  string
-	allowedTools []string
-	argumentHint string
-	source       string
-	content      string
-}
-
 type claudeBackupState struct {
 	OAuthAccount *oauthAccount          `json:"oauthAccount"`
 	Projects     map[string]interface{} `json:"projects"`
@@ -427,102 +391,6 @@ func findLatestBackupAfero(afs *afero.Afero, configDir string) (string, error) {
 	return latestBackup, nil
 }
 
-// readJSONFileAfero reads and unmarshals a JSON file relative to a base directory
-// using the provided afero filesystem (which may be remote via SSH, container, etc.).
-func readJSONFileAfero(afs *afero.Afero, baseDir string, relPath string, v interface{}) error {
-	data, err := afs.ReadFile(filepath.Join(baseDir, relPath))
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(data, v)
-}
-
-type skillFrontmatter struct {
-	Name         string `json:"name" yaml:"name"`
-	Description  string `json:"description" yaml:"description"`
-	AllowedTools string `json:"allowed-tools" yaml:"allowed-tools"`
-	ArgumentHint string `json:"argument-hint" yaml:"argument-hint"`
-}
-
-func parseSkillMd(name, sourcePath, content string) skillInfo {
-	info := skillInfo{
-		name:    name,
-		source:  sourcePath,
-		content: content,
-	}
-
-	// Extract YAML frontmatter between --- delimiters
-	if !strings.HasPrefix(content, "---\n") {
-		return info
-	}
-
-	endIdx := strings.Index(content[4:], "\n---")
-	if endIdx == -1 {
-		return info
-	}
-
-	frontmatter := content[4 : 4+endIdx]
-	var fm skillFrontmatter
-	if err := yaml.Unmarshal([]byte(frontmatter), &fm); err != nil {
-		return info
-	}
-
-	if fm.Name != "" {
-		info.name = fm.Name
-	}
-	info.description = fm.Description
-	info.argumentHint = fm.ArgumentHint
-
-	// allowed-tools is a comma-separated string in both Claude Code and Codex SKILL.md files
-	if fm.AllowedTools != "" {
-		for _, tool := range strings.Split(fm.AllowedTools, ",") {
-			tool = strings.TrimSpace(tool)
-			if tool != "" {
-				info.allowedTools = append(info.allowedTools, tool)
-			}
-		}
-	}
-
-	return info
-}
-
-func dirHasFilesAfero(afs *afero.Afero, dir string) bool {
-	entries, err := afs.ReadDir(dir)
-	if err != nil {
-		return false
-	}
-	for _, e := range entries {
-		if !e.IsDir() {
-			return true
-		}
-	}
-	return false
-}
-
-// targetHomeDir resolves the first non-system user's home directory on the target
-// via the users resource, so it works for remote SSH/container connections.
-func targetHomeDir(runtime *plugin.Runtime) (string, error) {
-	usersResource, err := CreateResource(runtime, "users", map[string]*llx.RawData{})
-	if err != nil {
-		return "", fmt.Errorf("cannot list users on target: %w", err)
-	}
-
-	userList := usersResource.(*mqlUsers).GetList()
-	if userList.Error != nil {
-		return "", fmt.Errorf("cannot list users on target: %w", userList.Error)
-	}
-
-	for _, u := range userList.Data {
-		user := u.(*mqlUser)
-		home := user.GetHome().Data
-		if home != "" && !invalidHomeDirs[home] {
-			return home, nil
-		}
-	}
-
-	return "", fmt.Errorf("no valid user home directory found on target")
-}
-
 // Stub ID methods for child resources (they use __id set during creation)
 
 func (r *mqlClaudeCodePlugin) id() (string, error) {
@@ -531,6 +399,10 @@ func (r *mqlClaudeCodePlugin) id() (string, error) {
 
 func (r *mqlClaudeCodeSkill) id() (string, error) {
 	return "claude.code.skill/" + r.Name.Data, nil
+}
+
+func (r *mqlClaudeCodeSkill) sha256() (string, error) {
+	return contentSHA256(r.Content.Data), nil
 }
 
 func (r *mqlClaudeCodeProject) id() (string, error) {

--- a/providers/os/resources/claude_code_test.go
+++ b/providers/os/resources/claude_code_test.go
@@ -235,12 +235,17 @@ func TestIsSystemHomeDir(t *testing.T) {
 	assert.True(t, isSystemHomeDir("/sbin/nologin"))
 	assert.True(t, isSystemHomeDir("/var/run/something"))
 
+	// Paths that look like root but aren't
+	assert.True(t, isSystemHomeDir("/rootfs"))
+	assert.True(t, isSystemHomeDir("/rootkit"))
+
 	// Real user home directories should NOT be flagged
 	assert.False(t, isSystemHomeDir("/Users/chris"))
 	assert.False(t, isSystemHomeDir("/Users/admin"))
 	assert.False(t, isSystemHomeDir("/home/chris"))
 	assert.False(t, isSystemHomeDir("/root"))
 	assert.False(t, isSystemHomeDir("/root/.config"))
+	assert.False(t, isSystemHomeDir("/usr/home/freebsd"))
 	assert.False(t, isSystemHomeDir(`C:\Users\chris`))
 }
 

--- a/providers/os/resources/claude_code_test.go
+++ b/providers/os/resources/claude_code_test.go
@@ -215,6 +215,35 @@ func TestFindLatestBackupAferoEmpty(t *testing.T) {
 	assert.Contains(t, err.Error(), "no backup files found")
 }
 
+func TestIsSystemHomeDir(t *testing.T) {
+	// Empty or missing
+	assert.True(t, isSystemHomeDir(""))
+
+	// macOS system accounts
+	assert.True(t, isSystemHomeDir("/var/db/astris"))
+	assert.True(t, isSystemHomeDir("/var/db/analyticsd"))
+	assert.True(t, isSystemHomeDir("/var/empty"))
+	assert.True(t, isSystemHomeDir("/var/virusmails"))
+	assert.True(t, isSystemHomeDir("/Library/WebServer"))
+	assert.True(t, isSystemHomeDir("/nonexistent"))
+	assert.True(t, isSystemHomeDir("/dev/null"))
+	assert.True(t, isSystemHomeDir("/"))
+
+	// Linux system accounts
+	assert.True(t, isSystemHomeDir("/usr/share"))
+	assert.True(t, isSystemHomeDir("/bin/false"))
+	assert.True(t, isSystemHomeDir("/sbin/nologin"))
+	assert.True(t, isSystemHomeDir("/var/run/something"))
+
+	// Real user home directories should NOT be flagged
+	assert.False(t, isSystemHomeDir("/Users/chris"))
+	assert.False(t, isSystemHomeDir("/Users/admin"))
+	assert.False(t, isSystemHomeDir("/home/chris"))
+	assert.False(t, isSystemHomeDir("/root"))
+	assert.False(t, isSystemHomeDir("/root/.config"))
+	assert.False(t, isSystemHomeDir(`C:\Users\chris`))
+}
+
 func TestClaudeConfigIntegration(t *testing.T) {
 	afs := testAfero()
 	dir := createTestClaudeConfig(t)

--- a/providers/os/resources/launchd.go
+++ b/providers/os/resources/launchd.go
@@ -106,7 +106,7 @@ func (l *mqlLaunchd) parseUserAgents(afs *afero.Afero) ([]any, error) {
 		}
 
 		// Skip system accounts with well-known non-user home directories
-		if invalidHomeDirs[home.Data] {
+		if isSystemHomeDir(home.Data) {
 			continue
 		}
 

--- a/providers/os/resources/openai_codex.go
+++ b/providers/os/resources/openai_codex.go
@@ -5,40 +5,19 @@ package resources
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/spf13/afero"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers/os/connection/shared"
 	"go.mondoo.com/mql/v13/types"
 )
 
 const defaultCodexConfigDir = ".codex"
 
 func initOpenaiCodex(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	if x, ok := args["configPath"]; ok {
-		path, ok := x.Value.(string)
-		if !ok {
-			return nil, nil, fmt.Errorf("wrong type for 'configPath' in openai.codex initialization, it must be a string")
-		}
-		if path == "" {
-			delete(args, "configPath")
-		}
-	}
-
-	if _, ok := args["configPath"]; !ok {
-		// Resolve the home directory from the target's user list, not the local host.
-		home, err := targetHomeDir(runtime)
-		if err != nil {
-			return nil, nil, err
-		}
-		args["configPath"] = llx.StringData(filepath.Join(home, defaultCodexConfigDir))
-	}
-
-	return args, nil, nil
+	return initConfigPath(runtime, args, "openai.codex", defaultCodexConfigDir)
 }
 
 func (r *mqlOpenaiCodex) id() (string, error) {
@@ -51,8 +30,7 @@ func (r *mqlOpenaiCodex) codexDir() string {
 
 // afs returns an afero.Afero wrapping the connection's filesystem.
 func (r *mqlOpenaiCodex) afs() *afero.Afero {
-	conn := r.MqlRuntime.Connection.(shared.Connection)
-	return &afero.Afero{Fs: conn.FileSystem()}
+	return connectionAfs(r.MqlRuntime)
 }
 
 func (r *mqlOpenaiCodex) authMode() (string, error) {
@@ -100,7 +78,7 @@ func (r *mqlOpenaiCodex) plugins() ([]interface{}, error) {
 	afs := r.afs()
 	pluginsDir := filepath.Join(r.codexDir(), ".tmp", "plugins", "plugins")
 
-	entries, err := afs.ReadDir(pluginsDir)
+	subdirs, err := listSubdirsAfero(afs, pluginsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -109,19 +87,12 @@ func (r *mqlOpenaiCodex) plugins() ([]interface{}, error) {
 	}
 
 	var result []interface{}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-
-		pluginName := entry.Name()
-		pluginDir := filepath.Join(pluginsDir, pluginName)
-
-		p := codexPluginInfo{name: pluginName}
+	for _, dir := range subdirs {
+		p := codexPluginInfo{name: dir.name}
 
 		// Read plugin.json
 		var pj codexPluginJSON
-		if err := readJSONFileAfero(afs, pluginDir, ".codex-plugin/plugin.json", &pj); err == nil {
+		if err := readJSONFileAfero(afs, dir.path, ".codex-plugin/plugin.json", &pj); err == nil {
 			p.version = pj.Version
 			p.description = pj.Description
 			if pj.Author != nil {
@@ -134,21 +105,19 @@ func (r *mqlOpenaiCodex) plugins() ([]interface{}, error) {
 		}
 
 		// Collect skill names from skills directory
-		skillsDir := filepath.Join(pluginDir, "skills")
-		if skillEntries, err := afs.ReadDir(skillsDir); err == nil {
-			for _, se := range skillEntries {
-				if se.IsDir() {
-					p.skillNames = append(p.skillNames, se.Name())
-				}
+		skillsDir := filepath.Join(dir.path, "skills")
+		if skillSubdirs, err := listSubdirsAfero(afs, skillsDir); err == nil {
+			for _, sd := range skillSubdirs {
+				p.skillNames = append(p.skillNames, sd.name)
 			}
 		}
 
 		// Check for MCP config
-		mcpExists, _ := afs.Exists(filepath.Join(pluginDir, ".mcp.json"))
+		mcpExists, _ := afs.Exists(filepath.Join(dir.path, ".mcp.json"))
 		p.hasMcp = mcpExists
 
 		// Check for hooks
-		hooksExists, _ := afs.Exists(filepath.Join(pluginDir, "hooks.json"))
+		hooksExists, _ := afs.Exists(filepath.Join(dir.path, "hooks.json"))
 		p.hasHooks = hooksExists
 
 		capAny := make([]interface{}, len(p.capabilities))
@@ -161,8 +130,8 @@ func (r *mqlOpenaiCodex) plugins() ([]interface{}, error) {
 		}
 
 		res, err := NewResource(r.MqlRuntime, "openai.codex.plugin", map[string]*llx.RawData{
-			"__id":         llx.StringData("openai.codex.plugin/" + pluginName),
-			"name":         llx.StringData(pluginName),
+			"__id":         llx.StringData("openai.codex.plugin/" + dir.name),
+			"name":         llx.StringData(dir.name),
 			"version":      llx.StringData(p.version),
 			"description":  llx.StringData(p.description),
 			"author":       llx.StringData(p.author),
@@ -186,17 +155,14 @@ func (r *mqlOpenaiCodex) skills() ([]interface{}, error) {
 
 	// Collect system skills
 	systemSkillsDir := filepath.Join(r.codexDir(), "skills", ".system")
-	if entries, err := afs.ReadDir(systemSkillsDir); err == nil {
-		for _, entry := range entries {
-			if !entry.IsDir() {
-				continue
-			}
-			skillPath := filepath.Join(systemSkillsDir, entry.Name(), "SKILL.md")
+	if subdirs, err := listSubdirsAfero(afs, systemSkillsDir); err == nil {
+		for _, dir := range subdirs {
+			skillPath := filepath.Join(dir.path, "SKILL.md")
 			data, err := afs.ReadFile(skillPath)
 			if err != nil {
 				continue
 			}
-			skill := parseSkillMd(entry.Name(), skillPath, string(data))
+			skill := parseSkillMd(dir.name, skillPath, string(data))
 			res, err := newCodexSkillResource(r.MqlRuntime, skill, "system")
 			if err != nil {
 				return nil, err
@@ -207,28 +173,21 @@ func (r *mqlOpenaiCodex) skills() ([]interface{}, error) {
 
 	// Collect plugin skills
 	pluginsDir := filepath.Join(r.codexDir(), ".tmp", "plugins", "plugins")
-	if pluginEntries, err := afs.ReadDir(pluginsDir); err == nil {
-		for _, pe := range pluginEntries {
-			if !pe.IsDir() {
-				continue
-			}
-			pluginName := pe.Name()
-			skillsDir := filepath.Join(pluginsDir, pluginName, "skills")
-			skillEntries, err := afs.ReadDir(skillsDir)
+	if pluginDirs, err := listSubdirsAfero(afs, pluginsDir); err == nil {
+		for _, pluginDir := range pluginDirs {
+			skillsDir := filepath.Join(pluginDir.path, "skills")
+			skillDirs, err := listSubdirsAfero(afs, skillsDir)
 			if err != nil {
 				continue
 			}
-			for _, se := range skillEntries {
-				if !se.IsDir() {
-					continue
-				}
-				skillPath := filepath.Join(skillsDir, se.Name(), "SKILL.md")
+			for _, skillDir := range skillDirs {
+				skillPath := filepath.Join(skillDir.path, "SKILL.md")
 				data, err := afs.ReadFile(skillPath)
 				if err != nil {
 					continue
 				}
-				skill := parseSkillMd(se.Name(), skillPath, string(data))
-				res, err := newCodexSkillResource(r.MqlRuntime, skill, pluginName)
+				skill := parseSkillMd(skillDir.name, skillPath, string(data))
+				res, err := newCodexSkillResource(r.MqlRuntime, skill, pluginDir.name)
 				if err != nil {
 					return nil, err
 				}
@@ -244,7 +203,7 @@ func (r *mqlOpenaiCodex) mcpServers() ([]interface{}, error) {
 	afs := r.afs()
 	pluginsDir := filepath.Join(r.codexDir(), ".tmp", "plugins", "plugins")
 
-	entries, err := afs.ReadDir(pluginsDir)
+	subdirs, err := listSubdirsAfero(afs, pluginsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -253,12 +212,8 @@ func (r *mqlOpenaiCodex) mcpServers() ([]interface{}, error) {
 	}
 
 	var result []interface{}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		pluginName := entry.Name()
-		mcpPath := filepath.Join(pluginsDir, pluginName, ".mcp.json")
+	for _, dir := range subdirs {
+		mcpPath := filepath.Join(dir.path, ".mcp.json")
 
 		var mcpConfig struct {
 			McpServers map[string]codexMcpServerEntry `json:"mcpServers"`
@@ -273,12 +228,12 @@ func (r *mqlOpenaiCodex) mcpServers() ([]interface{}, error) {
 
 		for name, srv := range mcpConfig.McpServers {
 			res, err := NewResource(r.MqlRuntime, "openai.codex.mcpServer", map[string]*llx.RawData{
-				"__id":   llx.StringData("openai.codex.mcpServer/" + pluginName + "/" + name),
+				"__id":   llx.StringData("openai.codex.mcpServer/" + dir.name + "/" + name),
 				"name":   llx.StringData(name),
 				"type":   llx.StringData(srv.Type),
 				"url":    llx.StringData(srv.URL),
 				"note":   llx.StringData(srv.Note),
-				"plugin": llx.StringData(pluginName),
+				"plugin": llx.StringData(dir.name),
 			})
 			if err != nil {
 				return nil, err
@@ -293,7 +248,7 @@ func (r *mqlOpenaiCodex) connectors() ([]interface{}, error) {
 	afs := r.afs()
 	pluginsDir := filepath.Join(r.codexDir(), ".tmp", "plugins", "plugins")
 
-	entries, err := afs.ReadDir(pluginsDir)
+	subdirs, err := listSubdirsAfero(afs, pluginsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -302,27 +257,22 @@ func (r *mqlOpenaiCodex) connectors() ([]interface{}, error) {
 	}
 
 	var result []interface{}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		pluginName := entry.Name()
-
+	for _, dir := range subdirs {
 		var appConfig struct {
 			Apps map[string]struct {
 				ID string `json:"id"`
 			} `json:"apps"`
 		}
-		if err := readJSONFileAfero(afs, filepath.Join(pluginsDir, pluginName), ".app.json", &appConfig); err != nil {
+		if err := readJSONFileAfero(afs, dir.path, ".app.json", &appConfig); err != nil {
 			continue
 		}
 
 		for connName, app := range appConfig.Apps {
 			res, err := NewResource(r.MqlRuntime, "openai.codex.connector", map[string]*llx.RawData{
-				"__id":   llx.StringData("openai.codex.connector/" + pluginName + "/" + connName),
+				"__id":   llx.StringData("openai.codex.connector/" + dir.name + "/" + connName),
 				"name":   llx.StringData(connName),
 				"id":     llx.StringData(app.ID),
-				"plugin": llx.StringData(pluginName),
+				"plugin": llx.StringData(dir.name),
 			})
 			if err != nil {
 				return nil, err
@@ -414,6 +364,10 @@ func (r *mqlOpenaiCodexPlugin) id() (string, error) {
 
 func (r *mqlOpenaiCodexSkill) id() (string, error) {
 	return "openai.codex.skill/" + r.Plugin.Data + "/" + r.Name.Data, nil
+}
+
+func (r *mqlOpenaiCodexSkill) sha256() (string, error) {
+	return contentSHA256(r.Content.Data), nil
 }
 
 func (r *mqlOpenaiCodexMcpServer) id() (string, error) {

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -3551,6 +3551,8 @@ private claude.code.skill @defaults("name") @maturity("preview") {
   source string
   // Full content of the skill definition
   content string
+  // SHA-256 hash of the skill content
+  sha256() string
 }
 
 // Claude Code project
@@ -3628,6 +3630,8 @@ private openai.codex.skill @defaults("name") @maturity("preview") {
   plugin string
   // Full content of the skill definition
   content string
+  // SHA-256 hash of the skill content
+  sha256() string
 }
 
 // OpenAI Codex MCP server

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -5083,6 +5083,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"claude.code.skill.content": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlClaudeCodeSkill).GetContent()).ToDataRes(types.String)
 	},
+	"claude.code.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlClaudeCodeSkill).GetSha256()).ToDataRes(types.String)
+	},
 	"claude.code.project.path": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlClaudeCodeProject).GetPath()).ToDataRes(types.String)
 	},
@@ -5166,6 +5169,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"openai.codex.skill.content": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenaiCodexSkill).GetContent()).ToDataRes(types.String)
+	},
+	"openai.codex.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenaiCodexSkill).GetSha256()).ToDataRes(types.String)
 	},
 	"openai.codex.mcpServer.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenaiCodexMcpServer).GetName()).ToDataRes(types.String)
@@ -11191,6 +11197,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlClaudeCodeSkill).Content, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"claude.code.skill.sha256": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlClaudeCodeSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"claude.code.project.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlClaudeCodeProject).__id, ok = v.Value.(string)
 		return
@@ -11321,6 +11331,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"openai.codex.skill.content": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenaiCodexSkill).Content, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"openai.codex.skill.sha256": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenaiCodexSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"openai.codex.mcpServer.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -30896,6 +30910,7 @@ type mqlClaudeCodeSkill struct {
 	ArgumentHint plugin.TValue[string]
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
+	Sha256       plugin.TValue[string]
 }
 
 // createClaudeCodeSkill creates a new instance of this resource
@@ -30957,6 +30972,12 @@ func (c *mqlClaudeCodeSkill) GetSource() *plugin.TValue[string] {
 
 func (c *mqlClaudeCodeSkill) GetContent() *plugin.TValue[string] {
 	return &c.Content
+}
+
+func (c *mqlClaudeCodeSkill) GetSha256() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
+		return c.sha256()
+	})
 }
 
 // mqlClaudeCodeProject for the claude.code.project resource
@@ -31316,6 +31337,7 @@ type mqlOpenaiCodexSkill struct {
 	Source      plugin.TValue[string]
 	Plugin      plugin.TValue[string]
 	Content     plugin.TValue[string]
+	Sha256      plugin.TValue[string]
 }
 
 // createOpenaiCodexSkill creates a new instance of this resource
@@ -31373,6 +31395,12 @@ func (c *mqlOpenaiCodexSkill) GetPlugin() *plugin.TValue[string] {
 
 func (c *mqlOpenaiCodexSkill) GetContent() *plugin.TValue[string] {
 	return &c.Content
+}
+
+func (c *mqlOpenaiCodexSkill) GetSha256() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
+		return c.sha256()
+	})
 }
 
 // mqlOpenaiCodexMcpServer for the openai.codex.mcpServer resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -178,6 +178,7 @@ claude.code.skill.argumentHint 13.8.2
 claude.code.skill.content 13.8.2
 claude.code.skill.description 13.8.2
 claude.code.skill.name 13.8.2
+claude.code.skill.sha256 13.10.1
 claude.code.skill.source 13.8.2
 claude.code.skills 13.8.2
 claude.code.subscription 13.8.2
@@ -936,6 +937,7 @@ openai.codex.skill.content 13.8.2
 openai.codex.skill.description 13.8.2
 openai.codex.skill.name 13.8.2
 openai.codex.skill.plugin 13.8.2
+openai.codex.skill.sha256 13.10.1
 openai.codex.skill.source 13.8.2
 openai.codex.skills 13.8.2
 openai.codex.version 13.8.2

--- a/providers/os/resources/vscode.go
+++ b/providers/os/resources/vscode.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
@@ -34,19 +35,28 @@ var vsCodeEditors = []vsCodeEditor{
 	{".kiro/extensions", "Kiro"},
 }
 
-// invalidHomeDirs contains home directories that should be skipped (system accounts)
-var invalidHomeDirs = map[string]bool{
-	"":                      true,
-	"/var/empty":            true,
-	"/nonexistent":          true,
-	"/dev/null":             true,
-	"/":                     true,
-	"/var":                  true,
-	"/usr":                  true,
-	"/bin":                  true,
-	"/sbin":                 true,
-	"C:\\Windows\\System32": true,
-	"C:\\Windows\\system32\\config\\systemprofile": true,
+// validHomePrefixes lists path prefixes where real user home directories live.
+// Anything outside these prefixes is treated as a system account.
+var validHomePrefixes = []string{
+	"/Users/", // macOS
+	"/home/",  // Linux
+	"/root",   // Linux root (exact match or /root/)
+	`C:\Users\`, // Windows
+}
+
+// isSystemHomeDir returns true if home looks like a system-account directory.
+// It uses an allowlist approach: only paths under known user-home prefixes
+// (e.g. /Users/, /home/, /root) are considered real users.
+func isSystemHomeDir(home string) bool {
+	if home == "" {
+		return true
+	}
+	for _, p := range validHomePrefixes {
+		if strings.HasPrefix(home, p) || home == strings.TrimSuffix(p, "/") {
+			return false
+		}
+	}
+	return true
 }
 
 // vscodePackageJSON represents the package.json structure for VS Code extensions
@@ -87,7 +97,7 @@ func (c *mqlVscode) paths() ([]any, error) {
 		user := u.(*mqlUser)
 		homeDir := user.GetHome().Data
 
-		if invalidHomeDirs[homeDir] {
+		if isSystemHomeDir(homeDir) {
 			continue
 		}
 
@@ -133,7 +143,7 @@ func (c *mqlVscode) extensions() ([]any, error) {
 		user := u.(*mqlUser)
 		homeDir := user.GetHome().Data
 
-		if invalidHomeDirs[homeDir] {
+		if isSystemHomeDir(homeDir) {
 			continue
 		}
 

--- a/providers/os/resources/vscode.go
+++ b/providers/os/resources/vscode.go
@@ -37,11 +37,14 @@ var vsCodeEditors = []vsCodeEditor{
 
 // validHomePrefixes lists path prefixes where real user home directories live.
 // Anything outside these prefixes is treated as a system account.
+// NOTE: Non-standard setups (FreeBSD /usr/home/, NixOS /persist/home/, custom
+// /opt/users/) may need additions here if those targets should be supported.
 var validHomePrefixes = []string{
-	"/Users/", // macOS
-	"/home/",  // Linux
-	"/root",   // Linux root (exact match or /root/)
-	`C:\Users\`, // Windows
+	"/Users/",     // macOS
+	"/home/",      // Linux, FreeBSD default
+	"/root/",      // Linux root
+	"/usr/home/",  // FreeBSD alternate
+	"C:\\Users\\", // Windows
 }
 
 // isSystemHomeDir returns true if home looks like a system-account directory.


### PR DESCRIPTION
## Summary
- **Fix default configPath** picking macOS system accounts (`/var/db/astris`, `/Library/WebServer`) instead of real user homes — switched `isSystemHomeDir` from a blocklist to an allowlist (`/Users/`, `/home/`, `/root`, `C:\Users\`)
- **Fix skills returning empty** when skill directories are symlinks (e.g. `agentation -> ../../.agents/skills/agentation`) — use `Stat` (follows symlinks) instead of `ReadDir`'s `Lstat`-based `IsDir`
- **Extract shared helpers** into `ai_coding_tools.go` to deduplicate claude.code and openai.codex resources (`initConfigPath`, `connectionAfs`, `listSubdirsAfero`, `parseSkillMd`, etc.)
- **Add `sha256()` computed field** to `claude.code.skill` and `openai.codex.skill` for on-demand content hashing

## Test plan
- [x] All existing unit tests pass (`go test ./providers/os/resources/`)
- [x] New `TestIsSystemHomeDir` covers macOS/Linux system accounts and real user homes
- [ ] Interactive: `mql shell` → `claude.code.skills` returns skills with correct default path
- [ ] Interactive: `claude.code.skills { sha256 }` returns hex SHA-256 hashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)