### PR TITLE
✨ Pin goreleaser edge to v2.15.3 and add auto-update workflow

### DIFF
--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -67,7 +67,8 @@ jobs:
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
           distribution: goreleaser
-          version: latest
+          # auto-update: source=github-releases repo=goreleaser/goreleaser updates=minor
+          version: v2.15.3
           args: release -f .github/.goreleaser-edge.yml --clean --timeout 120m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-pinned-versions.yml
+++ b/.github/workflows/update-pinned-versions.yml
@@ -1,0 +1,18 @@
+name: Update pinned versions
+
+on:
+  schedule:
+    - cron: "22 8 * * 1" # every monday
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update-versions:
+    uses: mondoohq/actions/.github/workflows/update-pinned-versions.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+    secrets:
+      ssh-key: ${{ secrets.CNQUERY_DEPLOY_KEY_PRIV }}

--- a/.github/workflows/update-pinned-versions.yml
+++ b/.github/workflows/update-pinned-versions.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   update-versions:
-    uses: mondoohq/actions/.github/workflows/update-pinned-versions.yml@main
+    uses: mondoohq/actions/.github/workflows/update-pinned-versions.yml@c09ff90232c442d736990f184a438a844bec4cb1 # main
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- Pin edge workflow goreleaser from `latest` to `v2.15.3` to prevent supply-chain risk from unpinned tool versions
- Add `# auto-update: source=github-releases repo=goreleaser/goreleaser updates=minor` annotation so version bumps are detected automatically (skips major bumps)
- Add `update-pinned-versions.yml` caller workflow (runs weekly) that references the reusable workflow in mondoohq/actions

**Note:** The stable workflow (`goreleaser.yml`) stays pinned at `v2.5.1` without an auto-update annotation due to the RPM signing bug with `rpm 4.17.0` on Ubuntu 22.04 runners.

## How it works
1. Annotate any version string in a workflow file:
   ```yaml
   # auto-update: source=github-releases repo=goreleaser/goreleaser updates=minor
   version: v2.15.3
   ```
2. The weekly workflow scans for these annotations, checks for newer releases, and opens a PR
3. `updates=minor` means only minor and patch bumps are proposed (major bumps are skipped)

## Dependencies
- mondoohq/actions#137 (merged)

## Test plan
- [ ] Verify edge workflow still builds containers successfully with v2.15.3
- [ ] Manually trigger `Update pinned versions` workflow to validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)