### PR TITLE
✨ Add gcp-alloydb-cluster as a discoverable platform

### DIFF
--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -68,6 +68,7 @@ Examples with the GCP project configured:
 				resources.DiscoverLoggingBuckets,
 				resources.DiscoverApiKeys,
 				resources.DiscoverIamServiceAccounts,
+				resources.DiscoverAlloyDBClusters,
 			},
 			Flags: []plugin.Flag{
 				{

--- a/providers/gcp/connection/platform.go
+++ b/providers/gcp/connection/platform.go
@@ -144,6 +144,8 @@ func GetTitleForPlatformName(name string) string {
 		return "GCP Cloud Function"
 	case "gcp-dataproc-cluster":
 		return "GCP Dataproc Cluster"
+	case "gcp-alloydb-cluster":
+		return "GCP AlloyDB Cluster"
 	case "gcp-logging-bucket":
 		return "GCP Logging Bucket"
 	case "gcp-apikey":
@@ -252,6 +254,13 @@ func ResourceTechnologyUrl(service, project, region, objectType, name string) []
 			return []string{"gcp", project, "dataproc", region, "cluster"}
 		default:
 			return []string{"gcp", project, "dataproc", region, "other"}
+		}
+	case "alloydb":
+		switch objectType {
+		case "cluster":
+			return []string{"gcp", project, "alloydb", region, "cluster"}
+		default:
+			return []string{"gcp", project, "alloydb", region, "other"}
 		}
 	case "logging":
 		switch objectType {

--- a/providers/gcp/resources/alloydb.go
+++ b/providers/gcp/resources/alloydb.go
@@ -205,6 +205,54 @@ func parseAlloyDBClusterName(name string) *alloyDBClusterParts {
 	}
 }
 
+func initGcpProjectAlloydbServiceCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 3 {
+		return args, nil, nil
+	}
+
+	if len(args) == 0 {
+		if args == nil {
+			args = make(map[string]*llx.RawData)
+		}
+		if ids := getAssetIdentifier(runtime); ids != nil {
+			args["name"] = llx.StringData(ids.name)
+			args["location"] = llx.StringData(ids.region)
+			args["projectId"] = llx.StringData(ids.project)
+		} else {
+			return nil, nil, errors.New("no asset identifier found")
+		}
+	}
+
+	obj, err := CreateResource(runtime, "gcp.project.alloydbService", map[string]*llx.RawData{
+		"projectId": args["projectId"],
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	alloydbSvc := obj.(*mqlGcpProjectAlloydbService)
+	clusters := alloydbSvc.GetClusters()
+	if clusters.Error != nil {
+		return nil, nil, clusters.Error
+	}
+
+	nameVal := args["name"].Value.(string)
+	locationVal := ""
+	if args["location"] != nil {
+		locationVal = args["location"].Value.(string)
+	}
+	for _, c := range clusters.Data {
+		cluster := c.(*mqlGcpProjectAlloydbServiceCluster)
+		nameParts := strings.Split(cluster.Name.Data, "/")
+		clusterName := nameParts[len(nameParts)-1]
+
+		if clusterName == nameVal && (locationVal == "" || cluster.Location.Data == locationVal) {
+			return args, cluster, nil
+		}
+	}
+
+	return nil, nil, fmt.Errorf("AlloyDB cluster %q not found", nameVal)
+}
+
 func (g *mqlGcpProjectAlloydbServiceCluster) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error

--- a/providers/gcp/resources/discovery.go
+++ b/providers/gcp/resources/discovery.go
@@ -58,6 +58,7 @@ const (
 	DiscoverLoggingBuckets          = "logging-buckets"
 	DiscoverApiKeys                 = "apikeys"
 	DiscoverIamServiceAccounts      = "iam-service-accounts"
+	DiscoverAlloyDBClusters         = "alloydb-clusters"
 )
 
 // All includes every discovery target: Auto covers all of them for GCP.
@@ -93,6 +94,7 @@ var Auto = []string{
 	DiscoverLoggingBuckets,
 	DiscoverApiKeys,
 	DiscoverIamServiceAccounts,
+	DiscoverAlloyDBClusters,
 }
 
 var AllAPIResources = []string{
@@ -122,6 +124,7 @@ var AllAPIResources = []string{
 	DiscoverLoggingBuckets,
 	DiscoverApiKeys,
 	DiscoverIamServiceAccounts,
+	DiscoverAlloyDBClusters,
 }
 
 // List of all CloudSQL types, this will be used during discovery
@@ -1069,6 +1072,40 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, 
 					Kind:                  "gcp-object",
 					Family:                []string{"google"},
 					TechnologyUrlSegments: connection.ResourceTechnologyUrl("dataproc", gcpProject.Id.Data, location, "cluster", cluster.Name.Data),
+				},
+				Labels:      mapStrInterfaceToMapStrStr(cluster.GetLabels().Data),
+				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+			})
+		}
+	}
+
+	if stringx.ContainsAnyOf(discoveryTargets, DiscoverAlloyDBClusters) {
+		alloydbService := gcpProject.GetAlloydb()
+		if alloydbService.Error != nil {
+			return nil, alloydbService.Error
+		}
+		clusters := alloydbService.Data.GetClusters()
+		if clusters.Error != nil {
+			return nil, clusters.Error
+		}
+		for i := range clusters.Data {
+			cluster := clusters.Data[i].(*mqlGcpProjectAlloydbServiceCluster)
+			nameParts := strings.Split(cluster.Name.Data, "/")
+			clusterName := nameParts[len(nameParts)-1]
+			location := cluster.Location.Data
+
+			assetList = append(assetList, &inventory.Asset{
+				PlatformIds: []string{
+					connection.NewResourcePlatformID("alloydb", gcpProject.Id.Data, location, "cluster", clusterName),
+				},
+				Name: clusterName,
+				Platform: &inventory.Platform{
+					Name:                  "gcp-alloydb-cluster",
+					Title:                 connection.GetTitleForPlatformName("gcp-alloydb-cluster"),
+					Runtime:               "gcp",
+					Kind:                  "gcp-object",
+					Family:                []string{"google"},
+					TechnologyUrlSegments: connection.ResourceTechnologyUrl("alloydb", gcpProject.Id.Data, location, "cluster", clusterName),
 				},
 				Labels:      mapStrInterfaceToMapStrStr(cluster.GetLabels().Data),
 				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},

--- a/providers/gcp/resources/discovery_test.go
+++ b/providers/gcp/resources/discovery_test.go
@@ -42,6 +42,7 @@ func TestAllResolvedResources(t *testing.T) {
 		DiscoverLoggingBuckets,
 		DiscoverApiKeys,
 		DiscoverIamServiceAccounts,
+		DiscoverAlloyDBClusters,
 	}
 	require.ElementsMatch(t, expected, All)
 }
@@ -77,6 +78,7 @@ func TestAutoResolvedResources(t *testing.T) {
 		DiscoverLoggingBuckets,
 		DiscoverApiKeys,
 		DiscoverIamServiceAccounts,
+		DiscoverAlloyDBClusters,
 	}
 	require.ElementsMatch(t, expected, Auto)
 }

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -1084,7 +1084,7 @@ func init() {
 			Create: createGcpProjectAlloydbService,
 		},
 		"gcp.project.alloydbService.cluster": {
-			// to override args, implement: initGcpProjectAlloydbServiceCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initGcpProjectAlloydbServiceCluster,
 			Create: createGcpProjectAlloydbServiceCluster,
 		},
 		"gcp.project.alloydbService.instance": {

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
-  "version": "13.7.1",
-  "generated_at": "2026-04-14T21:28:47+03:00",
+  "version": "13.8.1",
+  "generated_at": "2026-04-17T22:09:06-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.customJobs.list",


### PR DESCRIPTION
## Summary
- Registers `gcp-alloydb-cluster` as a first-class discoverable platform so cnspec policies can assert on individual AlloyDB clusters (e.g., CMEK encryption, public IP) instead of running against the generic `gcp` project platform.
- Adds the `alloydb-clusters` discovery target (included in `Auto` and `AllAPIResources`) and mirrors the existing Dataproc/Memorystore discovery shape.
- Wires `gcp-alloydb-cluster` into `GetTitleForPlatformName()` and `ResourceTechnologyUrl()` in the connection package.

No `.lr` changes — `gcp.project.alloydbService.cluster` already exposes everything needed.

## Test plan
- [ ] `make providers/build/gcp && make providers/install/gcp`
- [ ] `cnspec shell gcp --discover alloydb-clusters -c "asset.platform"` in a project with AlloyDB clusters
- [ ] Confirm each discovered asset reports `asset.platform == "gcp-alloydb-cluster"` and has the expected technology URL segments

🤖 Generated with [Claude Code](https://claude.com/claude-code)