### PR TITLE
🎉 os-13.11.0

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.10.0",
+	Version: "13.11.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### os (13.11.0)
- fix: : `Ensure 'Deny access to this computer from the network' to include 'Guests, Local account'` doesn't use translated SIDs to fulfill checks (#7251)
- 🐛 Fix claude.code/openai.codex home dir detection and symlink handling (#7256)
- ✨ Add Terraform provider SBOM cataloger (#7255)
- ✨ Add Swift SBOM cataloger (SPM + CocoaPods) (#7250)
- ✨ Add GitHub Actions SBOM cataloger (#7245)
- 🐛 firewalld: detect rich rule NOT inversion + allow zone lookup by name (#7248)
- ✨ Add PHP/Composer SBOM cataloger (#7244)
- ✨ Add .NET/NuGet SBOM cataloger (#7240)
- ✨ Add Rust/Cargo SBOM cataloger (#7238)
- ✨ Add Java SBOM cataloger (#7237)
- ✨ Add Go module SBOM cataloger (#7236)