### PR TITLE
✨ Add security-relevant aws.rds.dbinstance fields

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -7380,6 +7380,28 @@ aws.rds.dbinstance @defaults("id region engine engineVersion") {
   masterUserSecret dict
   // Whether the DB instance uses a customer-owned IP address (CoIP) for Outpost deployments
   customerOwnedIpEnabled bool
+  // IAM roles attached to the DB instance for accessing other AWS services (S3 import, Lambda, etc.)
+  associatedRoles() []aws.rds.dbinstance.associatedRole
+  // DB subnet group placement (VpcId, SubnetGroupStatus, Subnets, SupportedNetworkTypes)
+  dbSubnetGroup dict
+  // Active Directory domain memberships for the DB instance (Domain, Status, FQDN, IAMRoleName, OU, AuthSecretArn, DnsIps)
+  domainMemberships []dict
+  // Open mode for an Oracle read replica: "open-read-only" or "mounted"
+  replicaMode string
+  // Whether the DB instance is configured as Oracle multi-tenant CDB
+  multiTenant bool
+}
+
+// IAM role associated with an RDS DB instance for accessing other AWS services
+private aws.rds.dbinstance.associatedRole @defaults("featureName status") {
+  // ARN of the IAM role
+  roleArn string
+  // IAM role attached to the DB instance
+  iamRole() aws.iam.role
+  // Feature the role is associated with (e.g., s3Import, s3Export, Lambda)
+  featureName string
+  // Status of the role association (ACTIVE, PENDING, INVALID)
+  status string
 }
 
 // Amazon RDS pending maintenance action

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -354,6 +354,7 @@ const (
 	ResourceAwsRdsDbcluster                                                     string = "aws.rds.dbcluster"
 	ResourceAwsRdsSnapshot                                                      string = "aws.rds.snapshot"
 	ResourceAwsRdsDbinstance                                                    string = "aws.rds.dbinstance"
+	ResourceAwsRdsDbinstanceAssociatedRole                                      string = "aws.rds.dbinstance.associatedRole"
 	ResourceAwsRdsPendingMaintenanceAction                                      string = "aws.rds.pendingMaintenanceAction"
 	ResourceAwsRdsClusterParameterGroup                                         string = "aws.rds.clusterParameterGroup"
 	ResourceAwsRdsParameterGroup                                                string = "aws.rds.parameterGroup"
@@ -2002,6 +2003,10 @@ func init() {
 		"aws.rds.dbinstance": {
 			Init:   initAwsRdsDbinstance,
 			Create: createAwsRdsDbinstance,
+		},
+		"aws.rds.dbinstance.associatedRole": {
+			// to override args, implement: initAwsRdsDbinstanceAssociatedRole(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsRdsDbinstanceAssociatedRole,
 		},
 		"aws.rds.pendingMaintenanceAction": {
 			// to override args, implement: initAwsRdsPendingMaintenanceAction(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -12210,6 +12215,33 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.rds.dbinstance.customerOwnedIpEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsDbinstance).GetCustomerOwnedIpEnabled()).ToDataRes(types.Bool)
+	},
+	"aws.rds.dbinstance.associatedRoles": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetAssociatedRoles()).ToDataRes(types.Array(types.Resource("aws.rds.dbinstance.associatedRole")))
+	},
+	"aws.rds.dbinstance.dbSubnetGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetDbSubnetGroup()).ToDataRes(types.Dict)
+	},
+	"aws.rds.dbinstance.domainMemberships": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetDomainMemberships()).ToDataRes(types.Array(types.Dict))
+	},
+	"aws.rds.dbinstance.replicaMode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetReplicaMode()).ToDataRes(types.String)
+	},
+	"aws.rds.dbinstance.multiTenant": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstance).GetMultiTenant()).ToDataRes(types.Bool)
+	},
+	"aws.rds.dbinstance.associatedRole.roleArn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstanceAssociatedRole).GetRoleArn()).ToDataRes(types.String)
+	},
+	"aws.rds.dbinstance.associatedRole.iamRole": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstanceAssociatedRole).GetIamRole()).ToDataRes(types.Resource("aws.iam.role"))
+	},
+	"aws.rds.dbinstance.associatedRole.featureName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstanceAssociatedRole).GetFeatureName()).ToDataRes(types.String)
+	},
+	"aws.rds.dbinstance.associatedRole.status": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsDbinstanceAssociatedRole).GetStatus()).ToDataRes(types.String)
 	},
 	"aws.rds.pendingMaintenanceAction.resourceArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsPendingMaintenanceAction).GetResourceArn()).ToDataRes(types.String)
@@ -34582,6 +34614,46 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.rds.dbinstance.customerOwnedIpEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsDbinstance).CustomerOwnedIpEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.associatedRoles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).AssociatedRoles, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.dbSubnetGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).DbSubnetGroup, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.domainMemberships": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).DomainMemberships, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.replicaMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).ReplicaMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.multiTenant": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstance).MultiTenant, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.associatedRole.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstanceAssociatedRole).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.rds.dbinstance.associatedRole.roleArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstanceAssociatedRole).RoleArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.associatedRole.iamRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstanceAssociatedRole).IamRole, ok = plugin.RawToTValue[*mqlAwsIamRole](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.associatedRole.featureName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstanceAssociatedRole).FeatureName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.dbinstance.associatedRole.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsDbinstanceAssociatedRole).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.rds.pendingMaintenanceAction.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -83842,6 +83914,11 @@ type mqlAwsRdsDbinstance struct {
 	ActivityStreamKmsKey               plugin.TValue[*mqlAwsKmsKey]
 	MasterUserSecret                   plugin.TValue[any]
 	CustomerOwnedIpEnabled             plugin.TValue[bool]
+	AssociatedRoles                    plugin.TValue[[]any]
+	DbSubnetGroup                      plugin.TValue[any]
+	DomainMemberships                  plugin.TValue[[]any]
+	ReplicaMode                        plugin.TValue[string]
+	MultiTenant                        plugin.TValue[bool]
 }
 
 // createAwsRdsDbinstance creates a new instance of this resource
@@ -84207,6 +84284,109 @@ func (c *mqlAwsRdsDbinstance) GetMasterUserSecret() *plugin.TValue[any] {
 
 func (c *mqlAwsRdsDbinstance) GetCustomerOwnedIpEnabled() *plugin.TValue[bool] {
 	return &c.CustomerOwnedIpEnabled
+}
+
+func (c *mqlAwsRdsDbinstance) GetAssociatedRoles() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AssociatedRoles, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds.dbinstance", c.__id, "associatedRoles")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.associatedRoles()
+	})
+}
+
+func (c *mqlAwsRdsDbinstance) GetDbSubnetGroup() *plugin.TValue[any] {
+	return &c.DbSubnetGroup
+}
+
+func (c *mqlAwsRdsDbinstance) GetDomainMemberships() *plugin.TValue[[]any] {
+	return &c.DomainMemberships
+}
+
+func (c *mqlAwsRdsDbinstance) GetReplicaMode() *plugin.TValue[string] {
+	return &c.ReplicaMode
+}
+
+func (c *mqlAwsRdsDbinstance) GetMultiTenant() *plugin.TValue[bool] {
+	return &c.MultiTenant
+}
+
+// mqlAwsRdsDbinstanceAssociatedRole for the aws.rds.dbinstance.associatedRole resource
+type mqlAwsRdsDbinstanceAssociatedRole struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAwsRdsDbinstanceAssociatedRoleInternal it will be used here
+	RoleArn     plugin.TValue[string]
+	IamRole     plugin.TValue[*mqlAwsIamRole]
+	FeatureName plugin.TValue[string]
+	Status      plugin.TValue[string]
+}
+
+// createAwsRdsDbinstanceAssociatedRole creates a new instance of this resource
+func createAwsRdsDbinstanceAssociatedRole(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsRdsDbinstanceAssociatedRole{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.rds.dbinstance.associatedRole", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsRdsDbinstanceAssociatedRole) MqlName() string {
+	return "aws.rds.dbinstance.associatedRole"
+}
+
+func (c *mqlAwsRdsDbinstanceAssociatedRole) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsRdsDbinstanceAssociatedRole) GetRoleArn() *plugin.TValue[string] {
+	return &c.RoleArn
+}
+
+func (c *mqlAwsRdsDbinstanceAssociatedRole) GetIamRole() *plugin.TValue[*mqlAwsIamRole] {
+	return plugin.GetOrCompute[*mqlAwsIamRole](&c.IamRole, func() (*mqlAwsIamRole, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.rds.dbinstance.associatedRole", c.__id, "iamRole")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsIamRole), nil
+			}
+		}
+
+		return c.iamRole()
+	})
+}
+
+func (c *mqlAwsRdsDbinstanceAssociatedRole) GetFeatureName() *plugin.TValue[string] {
+	return &c.FeatureName
+}
+
+func (c *mqlAwsRdsDbinstanceAssociatedRole) GetStatus() *plugin.TValue[string] {
+	return &c.Status
 }
 
 // mqlAwsRdsPendingMaintenanceAction for the aws.rds.pendingMaintenanceAction resource

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -4174,6 +4174,12 @@ aws.rds.dbinstance.activityStreamKmsKey 11.16.1
 aws.rds.dbinstance.activityStreamMode 11.15.2
 aws.rds.dbinstance.activityStreamStatus 11.15.2
 aws.rds.dbinstance.arn 11.15.2
+aws.rds.dbinstance.associatedRole 13.14.2
+aws.rds.dbinstance.associatedRole.featureName 13.14.2
+aws.rds.dbinstance.associatedRole.iamRole 13.14.2
+aws.rds.dbinstance.associatedRole.roleArn 13.14.2
+aws.rds.dbinstance.associatedRole.status 13.14.2
+aws.rds.dbinstance.associatedRoles 13.14.2
 aws.rds.dbinstance.autoMinorVersionUpgrade 11.15.2
 aws.rds.dbinstance.availabilityZone 11.15.2
 aws.rds.dbinstance.backupRetentionPeriod 11.15.2
@@ -4187,9 +4193,11 @@ aws.rds.dbinstance.customerOwnedIpEnabled 11.16.1
 aws.rds.dbinstance.dbClusterIdentifier 11.15.2
 aws.rds.dbinstance.dbInstanceClass 11.15.2
 aws.rds.dbinstance.dbInstanceIdentifier 11.15.2
+aws.rds.dbinstance.dbSubnetGroup 13.14.2
 aws.rds.dbinstance.dbiResourceId 11.15.2
 aws.rds.dbinstance.dedicatedLogVolume 11.15.2
 aws.rds.dbinstance.deletionProtection 11.15.2
+aws.rds.dbinstance.domainMemberships 13.14.2
 aws.rds.dbinstance.enabledCloudwatchLogsExports 11.15.2
 aws.rds.dbinstance.endpoint 11.15.2
 aws.rds.dbinstance.engine 11.15.2
@@ -4206,6 +4214,7 @@ aws.rds.dbinstance.masterUsername 11.15.2
 aws.rds.dbinstance.maxAllocatedStorage 11.15.2
 aws.rds.dbinstance.monitoringInterval 11.15.2
 aws.rds.dbinstance.multiAZ 11.15.2
+aws.rds.dbinstance.multiTenant 13.14.2
 aws.rds.dbinstance.name 11.15.2
 aws.rds.dbinstance.networkType 11.15.2
 aws.rds.dbinstance.pendingMaintenanceActions 11.15.2
@@ -4217,6 +4226,7 @@ aws.rds.dbinstance.preferredBackupWindow 11.15.2
 aws.rds.dbinstance.preferredMaintenanceWindow 11.15.2
 aws.rds.dbinstance.publiclyAccessible 11.15.2
 aws.rds.dbinstance.region 11.15.2
+aws.rds.dbinstance.replicaMode 13.14.2
 aws.rds.dbinstance.securityGroups 11.15.2
 aws.rds.dbinstance.snapshots 11.15.2
 aws.rds.dbinstance.status 11.15.2

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -398,6 +398,7 @@ type mqlAwsRdsDbinstanceInternal struct {
 	cacheKmsKeyId                    *string
 	cachePerformanceInsightsKmsKeyId *string
 	cacheActivityStreamKmsKeyId      *string
+	cacheAssociatedRoles             []rds_types.DBInstanceRole
 	region                           string
 }
 
@@ -517,6 +518,15 @@ func newMqlAwsRdsInstance(runtime *plugin.Runtime, region string, accountID stri
 		certificateExpiration = dbInstance.CertificateDetails.ValidTill
 	}
 
+	dbSubnetGroupDict, err := convert.JsonToDict(dbInstance.DBSubnetGroup)
+	if err != nil {
+		return nil, err
+	}
+	domainMemberships, err := convert.JsonToDictSlice(dbInstance.DomainMemberships)
+	if err != nil {
+		return nil, err
+	}
+
 	resource, err := CreateResource(runtime, ResourceAwsRdsDbinstance,
 		map[string]*llx.RawData{
 			"arn":                                llx.StringDataPtr(dbInstance.DBInstanceArn),
@@ -569,6 +579,10 @@ func newMqlAwsRdsInstance(runtime *plugin.Runtime, region string, accountID stri
 			"storageThroughput":                  llx.IntDataDefault(dbInstance.StorageThroughput, 0),
 			"masterUserSecret":                   llx.DictData(masterUserSecretToDict(dbInstance.MasterUserSecret)),
 			"customerOwnedIpEnabled":             llx.BoolDataPtr(dbInstance.CustomerOwnedIpEnabled),
+			"dbSubnetGroup":                      llx.DictData(dbSubnetGroupDict),
+			"domainMemberships":                  llx.ArrayData(domainMemberships, types.Dict),
+			"replicaMode":                        llx.StringData(string(dbInstance.ReplicaMode)),
+			"multiTenant":                        llx.BoolDataPtr(dbInstance.MultiTenant),
 		})
 	if err != nil {
 		return nil, err
@@ -579,8 +593,44 @@ func newMqlAwsRdsInstance(runtime *plugin.Runtime, region string, accountID stri
 	mqlDBInstance.cacheKmsKeyId = dbInstance.KmsKeyId
 	mqlDBInstance.cachePerformanceInsightsKmsKeyId = dbInstance.PerformanceInsightsKMSKeyId
 	mqlDBInstance.cacheActivityStreamKmsKeyId = dbInstance.ActivityStreamKmsKeyId
+	mqlDBInstance.cacheAssociatedRoles = dbInstance.AssociatedRoles
 	mqlDBInstance.setSecurityGroupArns(sgsArn)
 	return mqlDBInstance, nil
+}
+
+func (a *mqlAwsRdsDbinstance) associatedRoles() ([]any, error) {
+	res := make([]any, 0, len(a.cacheAssociatedRoles))
+	instanceArn := a.Arn.Data
+	for _, role := range a.cacheAssociatedRoles {
+		roleArn := convert.ToValue(role.RoleArn)
+		featureName := convert.ToValue(role.FeatureName)
+		mqlRole, err := CreateResource(a.MqlRuntime, ResourceAwsRdsDbinstanceAssociatedRole,
+			map[string]*llx.RawData{
+				"__id":        llx.StringData(fmt.Sprintf("%s/role/%s/feature/%s", instanceArn, roleArn, featureName)),
+				"roleArn":     llx.StringData(roleArn),
+				"featureName": llx.StringData(featureName),
+				"status":      llx.StringDataPtr(role.Status),
+			})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlRole)
+	}
+	return res, nil
+}
+
+func (a *mqlAwsRdsDbinstanceAssociatedRole) iamRole() (*mqlAwsIamRole, error) {
+	arn := a.RoleArn.Data
+	if arn == "" {
+		a.IamRole.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	mqlRole, err := NewResource(a.MqlRuntime, ResourceAwsIamRole,
+		map[string]*llx.RawData{"arn": llx.StringData(arn)})
+	if err != nil {
+		return nil, err
+	}
+	return mqlRole.(*mqlAwsIamRole), nil
 }
 
 func initAwsRdsDbcluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/aws/resources/aws_rds_test.go
+++ b/providers/aws/resources/aws_rds_test.go
@@ -76,3 +76,102 @@ func TestRdsClusterDbClusterParameterGroup(t *testing.T) {
 		assert.True(t, c.DbClusterParameterGroup.IsSet())
 	})
 }
+
+func TestRdsDbInstanceActivityStreamKmsKey(t *testing.T) {
+	t.Run("nil key ID sets null state", func(t *testing.T) {
+		db := &mqlAwsRdsDbinstance{}
+		result, err := db.activityStreamKmsKey()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, db.ActivityStreamKmsKey.IsNull())
+		assert.True(t, db.ActivityStreamKmsKey.IsSet())
+	})
+}
+
+func TestRdsClusterKmsKey(t *testing.T) {
+	t.Run("nil key ID sets null state", func(t *testing.T) {
+		c := &mqlAwsRdsDbcluster{}
+		result, err := c.kmsKey()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, c.KmsKey.IsNull())
+		assert.True(t, c.KmsKey.IsSet())
+	})
+}
+
+func TestRdsClusterActivityStreamKmsKey(t *testing.T) {
+	t.Run("nil key ID sets null state", func(t *testing.T) {
+		c := &mqlAwsRdsDbcluster{}
+		result, err := c.activityStreamKmsKey()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, c.ActivityStreamKmsKey.IsNull())
+		assert.True(t, c.ActivityStreamKmsKey.IsSet())
+	})
+}
+
+func TestRdsSnapshotKmsKey(t *testing.T) {
+	t.Run("nil key ID sets null state", func(t *testing.T) {
+		s := &mqlAwsRdsSnapshot{}
+		result, err := s.kmsKey()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, s.KmsKey.IsNull())
+		assert.True(t, s.KmsKey.IsSet())
+	})
+}
+
+func TestRdsBackupSettingKmsKey(t *testing.T) {
+	t.Run("nil key ID sets null state", func(t *testing.T) {
+		b := &mqlAwsRdsBackupsetting{}
+		result, err := b.kmsKey()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, b.KmsKey.IsNull())
+		assert.True(t, b.KmsKey.IsSet())
+	})
+}
+
+func TestRdsProxyVpc(t *testing.T) {
+	t.Run("nil VPC ID sets null state", func(t *testing.T) {
+		p := &mqlAwsRdsProxy{}
+		result, err := p.vpc()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, p.Vpc.IsNull())
+		assert.True(t, p.Vpc.IsSet())
+	})
+}
+
+func TestRdsProxyIamRole(t *testing.T) {
+	t.Run("nil role ARN sets null state", func(t *testing.T) {
+		p := &mqlAwsRdsProxy{}
+		result, err := p.iamRole()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, p.IamRole.IsNull())
+		assert.True(t, p.IamRole.IsSet())
+	})
+}
+
+func TestRdsEventSubscriptionSnsTopic(t *testing.T) {
+	t.Run("empty SNS topic ARN sets null state", func(t *testing.T) {
+		e := &mqlAwsRdsEventSubscription{}
+		result, err := e.snsTopic()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, e.SnsTopic.IsNull())
+		assert.True(t, e.SnsTopic.IsSet())
+	})
+}
+
+func TestRdsDbInstanceAssociatedRoleIamRole(t *testing.T) {
+	t.Run("empty role ARN sets null state", func(t *testing.T) {
+		r := &mqlAwsRdsDbinstanceAssociatedRole{}
+		result, err := r.iamRole()
+		require.NoError(t, err)
+		require.Nil(t, result)
+		assert.True(t, r.IamRole.IsNull())
+		assert.True(t, r.IamRole.IsSet())
+	})
+}


### PR DESCRIPTION
## Summary

Adds 5 security-relevant fields to `aws.rds.dbinstance` plus a new `aws.rds.dbinstance.associatedRole` sub-resource:

| Field | Purpose |
|---|---|
| `associatedRoles() []aws.rds.dbinstance.associatedRole` | IAM roles attached to the DB (s3Import, s3Export, Lambda, etc.) with typed `iamRole()` ref. Enables "what can my DBs do on my behalf?" audits. |
| `dbSubnetGroup dict` | VpcId, SubnetGroupStatus, Subnets, SupportedNetworkTypes — network isolation audits. |
| `domainMemberships []dict` | Active Directory join state for SQL Server / Oracle Windows auth. |
| `replicaMode string` | Oracle replica open mode (`open-read-only` / `mounted`). |
| `multiTenant bool` | Oracle multi-tenant CDB indicator. |

## Tests

- **New**: 1 nil-state test for `associatedRole.iamRole()`.
- **Backfill**: 8 nil-state tests for existing typed-ref methods that lacked coverage:
  - `dbinstance.activityStreamKmsKey`
  - `dbcluster.kmsKey`, `dbcluster.activityStreamKmsKey`
  - `snapshot.kmsKey`, `backupSetting.kmsKey`
  - `proxy.vpc`, `proxy.iamRole`
  - `eventSubscription.snsTopic`

The "return nil, nil without setting StateIsNull" footgun (per CLAUDE.md) is now fully covered for RDS typed refs. This brings the RDS test count from 4 → 14.

`.lr.versions` entries use 13.14.2 per the repo convention; provider `Version` in `config.go` left for the release flow.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./providers/aws/resources/` passes (14 RDS tests + existing suite)
- [x] Live verification on a real DB instance: `dbSubnetGroup` populated with VpcId + Subnets, `associatedRoles` (empty here, structurally correct), `domainMemberships` (empty), `replicaMode` ("" for non-Oracle), `multiTenant` (null for non-Oracle).
- [x] Compile-checked typed traversal `associatedRoles { iamRole { name } }` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)