### PR TITLE
🐛 Fix aws.ec2.networkinterface cache collapse and add firehose stream init

### DIFF
--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -2725,7 +2725,7 @@ func init() {
 			Create: createAwsKinesisStreamConsumer,
 		},
 		"aws.kinesis.firehoseDeliveryStream": {
-			// to override args, implement: initAwsKinesisFirehoseDeliveryStream(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAwsKinesisFirehoseDeliveryStream,
 			Create: createAwsKinesisFirehoseDeliveryStream,
 		},
 		"aws.kinesis.firehoseDeliveryStream.destination": {

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -1486,6 +1486,7 @@ func initAwsEc2Networkinterface(runtime *plugin.Runtime, args map[string]*llx.Ra
 
 func buildNetworkInterfaceResource(runtime *plugin.Runtime, region string, eni ec2types.NetworkInterface) (map[string]*llx.RawData, plugin.Resource, error) {
 	args := map[string]*llx.RawData{
+		"__id":             llx.StringDataPtr(eni.NetworkInterfaceId),
 		"availabilityZone": llx.StringDataPtr(eni.AvailabilityZone),
 		"description":      llx.StringDataPtr(eni.Description),
 		"id":               llx.StringDataPtr(eni.NetworkInterfaceId),

--- a/providers/aws/resources/aws_kinesis.go
+++ b/providers/aws/resources/aws_kinesis.go
@@ -5,10 +5,12 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
 
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/firehose"
 	firehose_types "github.com/aws/aws-sdk-go-v2/service/firehose/types"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
@@ -483,6 +485,51 @@ func newMqlAwsKinesisFirehoseDeliveryStream(runtime *plugin.Runtime, region stri
 	mqlStream.cacheDestinations = stream.Destinations
 	mqlStream.cacheRegion = region
 	return mqlStream, nil
+}
+
+// initAwsKinesisFirehoseDeliveryStream allows typed refs (e.g. from
+// aws.msk.cluster.loggingInfo.firehose.deliveryStream) to resolve a stream
+// by arn. It fetches the delivery stream description and populates scalar
+// fields; access-denied falls back to an arn-only shell.
+func initAwsKinesisFirehoseDeliveryStream(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) >= 2 {
+		return args, nil, nil
+	}
+	if args["arn"] == nil {
+		return nil, nil, errors.New("arn required to fetch aws firehose delivery stream")
+	}
+	arnVal := args["arn"].Value.(string)
+	parsed, err := arn.Parse(arnVal)
+	if err != nil {
+		args["__id"] = llx.StringData(arnVal)
+		return args, nil, nil
+	}
+	// resource portion is "deliverystream/<name>"
+	name := strings.TrimPrefix(parsed.Resource, "deliverystream/")
+	if name == "" || name == parsed.Resource {
+		return nil, nil, fmt.Errorf("unexpected firehose arn format: %s", arnVal)
+	}
+	conn := runtime.Connection.(*connection.AwsConnection)
+	svc := conn.Firehose(parsed.Region)
+	out, err := svc.DescribeDeliveryStream(context.Background(), &firehose.DescribeDeliveryStreamInput{
+		DeliveryStreamName: &name,
+	})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			args["__id"] = llx.StringData(arnVal)
+			return args, nil, nil
+		}
+		return nil, nil, err
+	}
+	if out.DeliveryStreamDescription == nil {
+		args["__id"] = llx.StringData(arnVal)
+		return args, nil, nil
+	}
+	mqlStream, err := newMqlAwsKinesisFirehoseDeliveryStream(runtime, parsed.Region, out.DeliveryStreamDescription)
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, mqlStream, nil
 }
 
 func (a *mqlAwsKinesisFirehoseDeliveryStream) destinations() ([]any, error) {


### PR DESCRIPTION
## Summary

Two pre-existing typed-ref bugs surfaced while verifying the MSK expansion in #7266 against live infra:

- **`aws.ec2.networkinterface` cache collapse** — `buildNetworkInterfaceResource` never set `__id`, so every ENI resource shared the empty-string cache key. Multiple ENIs looked up in the same query collapsed into whichever one was first cached. Symptom: querying `aws.msk.cluster.nodes { attachedENIId networkInterface { id privateIpAddress } }` showed the correct per-broker `attachedENIId` scalar, but `networkInterface.id` and `privateIpAddress` were identical (first-fetched) across all brokers. Also affects `aws.vpc.endpoint.networkInterfaces`. Fix: set `__id` to the ENI id.
- **`aws.kinesis.firehoseDeliveryStream` missing init** — no `Init` registered, so typed refs by arn (e.g. `aws.msk.cluster.loggingInfo.firehose.deliveryStream`) returned an arn-only shell and field access errored with `cannot convert primitive with NO type information`. Fix: add `initAwsKinesisFirehoseDeliveryStream` that calls `DescribeDeliveryStream`; access-denied (cross-account) falls back to a shell.

## Test plan

- [x] `go build ./...` in `providers/aws`
- [x] `make providers/build/aws`
- [x] Verified against live MSK stack (same stack used for #7266 verification) before it was torn down: `aws.msk.clusters { nodes { attachedENIId networkInterface.id } }` now shows distinct ENI IDs per broker.
- [ ] Interactive smoke on a fresh account: `aws.vpc.endpoints { networkInterfaces { id privateIpAddress } }` should show distinct values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)