### PR TITLE
🎉 gcp-13.8.1

### DIFF
--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.8.0",
+	Version: "13.8.1",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### gcp (13.8.1)
- 🐛 Fix logic bugs in GCP compute, storage, and DNS resources (#6943)
- 🧹 Bump github.com/moby/buildkit v0.16.0 → v0.29.0 (#7249)