### PR TITLE
🎉 aws-13.15.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.14.1",
+	Version:         "13.15.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### aws (13.15.0)
- ⭐ Expand AWS MSK (Kafka) for full security coverage (#7266)
- 🐛 Fix aws.ec2.networkinterface cache collapse and add firehose init (#7273)
- ✨ Add security-relevant aws.rds.dbinstance fields (#7269)
- ✨ Expand aws.rds and aws.appstream field coverage (#7268)
- ✨ Expand aws.autoscaling.group fields and bump AWS SDKs (#7267)
- 🐛 Extend region-unavailable handling to Phase 1-2 SageMaker lists (#7243)