### PR TITLE
🐛 expand apache2.conf variables from envvars (fixes #7173)

### DIFF
--- a/providers/os/resources/apache2.go
+++ b/providers/os/resources/apache2.go
@@ -274,7 +274,11 @@ func (s *mqlApache2Conf) id() (string, error) {
 	if file.Error != nil {
 		return "", file.Error
 	}
-
+	// When Apache isn't installed we leave File set+null; use a stable ID so
+	// the resource still caches cleanly instead of nil-dereferencing.
+	if file.Data == nil {
+		return "apache2.conf", nil
+	}
 	return file.Data.Path.Data, nil
 }
 
@@ -307,15 +311,11 @@ func (s *mqlApache2Conf) file() (*mqlFile, error) {
 		}
 	}
 
-	// No config file found; return the platform default so the resource still
-	// has a path but parse() will detect non-existence and return empty data.
-	f, err := CreateResource(s.MqlRuntime, "file", map[string]*llx.RawData{
-		"path": llx.StringData(preferred),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return f.(*mqlFile), nil
+	// No config file found anywhere — Apache likely isn't installed. Mark the
+	// field as set+null so downstream field accessors (params, modules, ...)
+	// return empty data instead of bubbling up "file does not exist" errors.
+	s.File.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 var reApacheGlob = regexp.MustCompile(`[*?\[]`)
@@ -529,13 +529,19 @@ func (s *mqlApache2Conf) loadEnvvars(fileContent func(string) (string, error)) m
 }
 
 // envvars returns the apache2.conf.envvars resource representing the parsed
-// envvars file. When the platform doesn't use one (or the file is missing),
-// the resource is returned with an empty params map so callers can still
-// introspect it.
+// envvars file. When the platform doesn't use one or the file is missing,
+// the field is marked set+null so the resource is cleanly absent rather than
+// rendering as an error or placeholder.
 func (s *mqlApache2Conf) envvars() (*mqlApache2ConfEnvvars, error) {
 	conn := s.MqlRuntime.Connection.(shared.Connection)
 	path := apacheEnvvarsPath(conn)
 	if path == "" {
+		s.Envvars.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	afs := &afero.Afero{Fs: conn.FileSystem()}
+	if ok, _ := afs.Exists(path); !ok {
 		s.Envvars.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -547,14 +553,11 @@ func (s *mqlApache2Conf) envvars() (*mqlApache2ConfEnvvars, error) {
 		return nil, err
 	}
 
-	afs := &afero.Afero{Fs: conn.FileSystem()}
 	params := map[string]any{}
-	if exists, _ := afs.Exists(path); exists {
-		content := f.(*mqlFile).GetContent()
-		if content.Error == nil {
-			for k, v := range apache2.ParseEnvvars(content.Data) {
-				params[k] = v
-			}
+	content := f.(*mqlFile).GetContent()
+	if content.Error == nil {
+		for k, v := range apache2.ParseEnvvars(content.Data) {
+			params[k] = v
 		}
 	}
 

--- a/providers/os/resources/apache2.go
+++ b/providers/os/resources/apache2.go
@@ -546,30 +546,82 @@ func (s *mqlApache2Conf) envvars() (*mqlApache2ConfEnvvars, error) {
 		return nil, nil
 	}
 
+	res, err := CreateResource(s.MqlRuntime, "apache2.conf.envvars", map[string]*llx.RawData{
+		"__id": llx.StringData("apache2.conf.envvars/" + path),
+		"path": llx.StringData(path),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlApache2ConfEnvvars), nil
+}
+
+// initApache2ConfEnvvars resolves the envvars file path from the platform
+// default when the resource is created directly (no arguments).
+func initApache2ConfEnvvars(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if x, ok := args["path"]; ok {
+		path, ok := x.Value.(string)
+		if !ok {
+			return nil, nil, errors.New("wrong type for 'path' in apache2.conf.envvars initialization, it must be a string")
+		}
+		f, err := CreateResource(runtime, "file", map[string]*llx.RawData{
+			"path": llx.StringData(path),
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		args["file"] = llx.ResourceData(f, "file")
+		delete(args, "path")
+	}
+	return args, nil, nil
+}
+
+func (s *mqlApache2ConfEnvvars) id() (string, error) {
+	file := s.GetFile()
+	if file.Error != nil {
+		return "", file.Error
+	}
+	if file.Data == nil {
+		return "apache2.conf.envvars", nil
+	}
+	return "apache2.conf.envvars/" + file.Data.Path.Data, nil
+}
+
+// file is the default getter: if the envvars resource was constructed without
+// an explicit file, resolve it from the host's platform.
+func (s *mqlApache2ConfEnvvars) file() (*mqlFile, error) {
+	conn := s.MqlRuntime.Connection.(shared.Connection)
+	path := apacheEnvvarsPath(conn)
+	if path == "" {
+		s.File.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
 	f, err := CreateResource(s.MqlRuntime, "file", map[string]*llx.RawData{
 		"path": llx.StringData(path),
 	})
 	if err != nil {
 		return nil, err
 	}
+	return f.(*mqlFile), nil
+}
 
-	params := map[string]any{}
-	content := f.(*mqlFile).GetContent()
-	if content.Error == nil {
-		for k, v := range apache2.ParseEnvvars(content.Data) {
-			params[k] = v
-		}
+// params reads the envvars file and returns the parsed assignments.
+func (s *mqlApache2ConfEnvvars) params(file *mqlFile) (map[string]any, error) {
+	if file == nil {
+		return map[string]any{}, nil
 	}
-
-	res, err := CreateResource(s.MqlRuntime, "apache2.conf.envvars", map[string]*llx.RawData{
-		"__id":   llx.StringData("apache2.conf.envvars/" + path),
-		"file":   llx.ResourceData(f, "file"),
-		"params": llx.MapData(params, types.String),
-	})
-	if err != nil {
-		return nil, err
+	if exists := file.GetExists(); exists.Error != nil || !exists.Data {
+		return map[string]any{}, nil
 	}
-	return res.(*mqlApache2ConfEnvvars), nil
+	content := file.GetContent()
+	if content.Error != nil {
+		return nil, content.Error
+	}
+	out := map[string]any{}
+	for k, v := range apache2.ParseEnvvars(content.Data) {
+		out[k] = v
+	}
+	return out, nil
 }
 
 func (s *mqlApache2Conf) listenAddresses(params map[string]any) ([]any, error) {

--- a/providers/os/resources/apache2.go
+++ b/providers/os/resources/apache2.go
@@ -182,6 +182,32 @@ var apacheServerRootByFamily = map[string]string{
 
 const defaultApacheServerRoot = "/etc/httpd"
 
+// apacheEnvvarsByFamily maps platform families/names to the shell-style
+// envvars file Apache sources at startup. On Debian/Ubuntu, /etc/apache2/envvars
+// defines APACHE_RUN_USER, APACHE_RUN_GROUP, etc. — values that directives
+// like `User ${APACHE_RUN_USER}` depend on.
+var apacheEnvvarsByFamily = map[string]string{
+	"debian": "/etc/apache2/envvars",
+}
+
+// apacheEnvvarsPath returns the path to the Apache envvars file for the asset's
+// platform, or "" if the platform doesn't use one.
+func apacheEnvvarsPath(conn shared.Connection) string {
+	asset := conn.Asset()
+	if asset == nil || asset.Platform == nil {
+		return ""
+	}
+	if p, ok := apacheEnvvarsByFamily[asset.Platform.Name]; ok {
+		return p
+	}
+	for _, family := range asset.Platform.Family {
+		if p, ok := apacheEnvvarsByFamily[family]; ok {
+			return p
+		}
+	}
+	return ""
+}
+
 // apacheServerRoot returns the ServerRoot directory for resolving relative
 // Include paths. Defaults based on platform.
 func apacheServerRoot(conn shared.Connection) string {
@@ -418,7 +444,11 @@ func (s *mqlApache2Conf) parse(file *mqlFile) error {
 		return s.expandGlob(pattern)
 	}
 
-	cfg, err := apache2.ParseWithGlob(file.Path.Data, fileContent, globExpand)
+	// Load platform envvars (e.g. Debian's /etc/apache2/envvars) so that
+	// directives like `User ${APACHE_RUN_USER}` are resolved.
+	envvars := s.loadEnvvars(fileContent)
+
+	cfg, err := apache2.ParseWithGlob(file.Path.Data, fileContent, globExpand, envvars)
 
 	if err != nil {
 		errState := plugin.TValue[map[string]any]{Error: err, State: plugin.StateIsSet | plugin.StateIsNull}
@@ -476,6 +506,67 @@ func (s *mqlApache2Conf) virtualHosts(file *mqlFile) ([]any, error) {
 
 func (s *mqlApache2Conf) directories(file *mqlFile) ([]any, error) {
 	return nil, s.parse(file)
+}
+
+// loadEnvvars reads the platform's Apache envvars file (if any) via the
+// provided fileContent function and returns the parsed assignments. A missing
+// file or parse failure returns an empty map — envvars are best-effort.
+func (s *mqlApache2Conf) loadEnvvars(fileContent func(string) (string, error)) map[string]string {
+	conn := s.MqlRuntime.Connection.(shared.Connection)
+	path := apacheEnvvarsPath(conn)
+	if path == "" {
+		return nil
+	}
+	afs := &afero.Afero{Fs: conn.FileSystem()}
+	if ok, _ := afs.Exists(path); !ok {
+		return nil
+	}
+	content, err := fileContent(path)
+	if err != nil {
+		return nil
+	}
+	return apache2.ParseEnvvars(content)
+}
+
+// envvars returns the apache2.conf.envvars resource representing the parsed
+// envvars file. When the platform doesn't use one (or the file is missing),
+// the resource is returned with an empty params map so callers can still
+// introspect it.
+func (s *mqlApache2Conf) envvars() (*mqlApache2ConfEnvvars, error) {
+	conn := s.MqlRuntime.Connection.(shared.Connection)
+	path := apacheEnvvarsPath(conn)
+	if path == "" {
+		s.Envvars.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	f, err := CreateResource(s.MqlRuntime, "file", map[string]*llx.RawData{
+		"path": llx.StringData(path),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	afs := &afero.Afero{Fs: conn.FileSystem()}
+	params := map[string]any{}
+	if exists, _ := afs.Exists(path); exists {
+		content := f.(*mqlFile).GetContent()
+		if content.Error == nil {
+			for k, v := range apache2.ParseEnvvars(content.Data) {
+				params[k] = v
+			}
+		}
+	}
+
+	res, err := CreateResource(s.MqlRuntime, "apache2.conf.envvars", map[string]*llx.RawData{
+		"__id":   llx.StringData("apache2.conf.envvars/" + path),
+		"file":   llx.ResourceData(f, "file"),
+		"params": llx.MapData(params, types.String),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlApache2ConfEnvvars), nil
 }
 
 func (s *mqlApache2Conf) listenAddresses(params map[string]any) ([]any, error) {

--- a/providers/os/resources/apache2/envvars.go
+++ b/providers/os/resources/apache2/envvars.go
@@ -1,0 +1,174 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package apache2
+
+import (
+	"strings"
+)
+
+// ParseEnvvars parses a Debian-style Apache envvars file (/etc/apache2/envvars).
+// It extracts simple `export KEY=value` and `KEY=value` assignments and expands
+// `$VAR` / `${VAR}` references within values. Shell control flow (if/for/fi)
+// is ignored — we only need the final exported values that Apache reads at
+// startup.
+func ParseEnvvars(content string) map[string]string {
+	vars := map[string]string{}
+	for _, raw := range strings.Split(content, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || line[0] == '#' {
+			continue
+		}
+
+		// Strip a trailing inline comment (outside of quotes)
+		line = stripInlineComment(line)
+		if line == "" {
+			continue
+		}
+
+		line = strings.TrimPrefix(line, "export ")
+		line = strings.TrimSpace(line)
+
+		eq := strings.IndexByte(line, '=')
+		if eq <= 0 {
+			continue
+		}
+
+		key := strings.TrimSpace(line[:eq])
+		if !isValidEnvKey(key) {
+			continue
+		}
+
+		value := strings.TrimSpace(line[eq+1:])
+		value = unquoteShellValue(value)
+		vars[key] = value
+	}
+
+	// Second pass: expand $VAR / ${VAR} references using the collected map.
+	for k, v := range vars {
+		vars[k] = expandShellVars(v, vars)
+	}
+	return vars
+}
+
+// isValidEnvKey reports whether s is a valid shell environment variable name
+// (letters, digits, underscores; cannot start with a digit).
+func isValidEnvKey(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, c := range s {
+		if c == '_' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') {
+			continue
+		}
+		if i > 0 && c >= '0' && c <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// unquoteShellValue strips a single pair of surrounding single or double
+// quotes from a shell value.
+func unquoteShellValue(v string) string {
+	if len(v) < 2 {
+		return v
+	}
+	first, last := v[0], v[len(v)-1]
+	if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+		return v[1 : len(v)-1]
+	}
+	return v
+}
+
+// expandShellVars expands $VAR and ${VAR} references in s using vars. Unknown
+// variables are replaced with the empty string, matching shell behavior.
+func expandShellVars(s string, vars map[string]string) string {
+	return expandVarsWith(s, func(name string) (string, bool) {
+		v, ok := vars[name]
+		return v, ok
+	}, true)
+}
+
+// expandApacheVars expands only `${VAR}` references (Apache does not honor
+// bare `$VAR`). Unresolved references are left as-is so the original text is
+// preserved when we can't resolve it.
+func expandApacheVars(s string, vars map[string]string) string {
+	if !strings.Contains(s, "${") || len(vars) == 0 {
+		return s
+	}
+	return expandVarsWith(s, func(name string) (string, bool) {
+		v, ok := vars[name]
+		return v, ok
+	}, false)
+}
+
+// expandVarsWith walks s and replaces variable references. When allowBare is
+// true, bare `$VAR` forms are also expanded (shell-style). Unresolved
+// `${VAR}` references are left literal so downstream tools can still see the
+// original text.
+func expandVarsWith(s string, lookup func(string) (string, bool), allowBare bool) string {
+	if !strings.ContainsRune(s, '$') {
+		return s
+	}
+
+	var b strings.Builder
+	b.Grow(len(s))
+
+	i := 0
+	for i < len(s) {
+		c := s[i]
+		if c != '$' || i+1 >= len(s) {
+			b.WriteByte(c)
+			i++
+			continue
+		}
+
+		// ${VAR}
+		if s[i+1] == '{' {
+			end := strings.IndexByte(s[i+2:], '}')
+			if end < 0 {
+				b.WriteByte(c)
+				i++
+				continue
+			}
+			name := s[i+2 : i+2+end]
+			if v, ok := lookup(name); ok {
+				b.WriteString(v)
+			} else {
+				// Keep the original reference so users can still see it.
+				b.WriteString(s[i : i+2+end+1])
+			}
+			i += 2 + end + 1
+			continue
+		}
+
+		// $VAR (bash-style, only when allowed)
+		if allowBare && isEnvNameStart(s[i+1]) {
+			j := i + 1
+			for j < len(s) && isEnvNameChar(s[j]) {
+				j++
+			}
+			name := s[i+1 : j]
+			if v, ok := lookup(name); ok {
+				b.WriteString(v)
+			}
+			// shell replaces unknown $VAR with empty string
+			i = j
+			continue
+		}
+
+		b.WriteByte(c)
+		i++
+	}
+	return b.String()
+}
+
+func isEnvNameStart(c byte) bool {
+	return c == '_' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+}
+
+func isEnvNameChar(c byte) bool {
+	return isEnvNameStart(c) || (c >= '0' && c <= '9')
+}

--- a/providers/os/resources/apache2/envvars.go
+++ b/providers/os/resources/apache2/envvars.go
@@ -44,9 +44,21 @@ func ParseEnvvars(content string) map[string]string {
 		vars[key] = value
 	}
 
-	// Second pass: expand $VAR / ${VAR} references using the collected map.
-	for k, v := range vars {
-		vars[k] = expandShellVars(v, vars)
+	// Expand $VAR / ${VAR} references using the collected map. Iterate to a
+	// fixed point so chained references (A=$B, B=$C) fully resolve regardless
+	// of map iteration order. Bounded by len(vars) to guard against cycles.
+	for i := 0; i <= len(vars); i++ {
+		changed := false
+		for k, v := range vars {
+			expanded := expandShellVars(v, vars)
+			if expanded != v {
+				vars[k] = expanded
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
 	}
 	return vars
 }

--- a/providers/os/resources/apache2/envvars_test.go
+++ b/providers/os/resources/apache2/envvars_test.go
@@ -1,0 +1,144 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package apache2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// debianEnvvars is a trimmed version of the envvars file shipped by Debian's
+// apache2 package. It includes the real shell control flow and exports so the
+// parser is exercised against realistic input.
+const debianEnvvars = `
+# envvars - default environment variables for apache2ctl
+
+unset HOME
+
+if [ "${APACHE_CONFDIR##/etc/apache2-}" != "${APACHE_CONFDIR}" ] ; then
+	SUFFIX="-${APACHE_CONFDIR##/etc/apache2-}"
+else
+	SUFFIX=
+fi
+
+export APACHE_RUN_USER=www-data
+export APACHE_RUN_GROUP=www-data
+
+export APACHE_PID_FILE=/var/run/apache2$SUFFIX/apache2.pid
+export APACHE_RUN_DIR=/var/run/apache2$SUFFIX
+export APACHE_LOCK_DIR=/var/lock/apache2$SUFFIX
+export APACHE_LOG_DIR=/var/log/apache2$SUFFIX
+
+export LANG=C
+export LANG
+
+# Quoted values
+export APACHE_ARGUMENTS="-DFOREGROUND"
+`
+
+func TestParseEnvvarsBasic(t *testing.T) {
+	vars := ParseEnvvars(debianEnvvars)
+	assert.Equal(t, "www-data", vars["APACHE_RUN_USER"])
+	assert.Equal(t, "www-data", vars["APACHE_RUN_GROUP"])
+	assert.Equal(t, "C", vars["LANG"])
+	// Unset SUFFIX expands to empty string (shell default for unknown vars).
+	assert.Equal(t, "/var/run/apache2/apache2.pid", vars["APACHE_PID_FILE"])
+	assert.Equal(t, "/var/log/apache2", vars["APACHE_LOG_DIR"])
+	// Quoted values keep their inner content without the quotes.
+	assert.Equal(t, "-DFOREGROUND", vars["APACHE_ARGUMENTS"])
+	// Shell control flow is not treated as an assignment.
+	assert.NotContains(t, vars, "if")
+	assert.NotContains(t, vars, "fi")
+}
+
+func TestParseEnvvarsIgnoresCommentsAndBlanks(t *testing.T) {
+	vars := ParseEnvvars(`
+# pure comment
+   # indented comment
+FOO=bar # trailing comment
+BAZ='qux'
+`)
+	assert.Equal(t, "bar", vars["FOO"])
+	assert.Equal(t, "qux", vars["BAZ"])
+}
+
+func TestParseEnvvarsReferencesOtherVars(t *testing.T) {
+	vars := ParseEnvvars(`
+export BASE=/opt/apache
+export LOG=${BASE}/log
+export PID=$BASE/apache.pid
+`)
+	assert.Equal(t, "/opt/apache", vars["BASE"])
+	assert.Equal(t, "/opt/apache/log", vars["LOG"])
+	assert.Equal(t, "/opt/apache/apache.pid", vars["PID"])
+}
+
+// TestParseWithGlobExpandsEnvvars is the regression test for
+// https://github.com/mondoohq/mql/issues/7173 — Debian's apache2.conf references
+// `${APACHE_RUN_USER}`, which must be resolved from envvars.
+func TestParseWithGlobExpandsEnvvars(t *testing.T) {
+	files := map[string]string{
+		"/etc/apache2/apache2.conf": `
+User ${APACHE_RUN_USER}
+Group ${APACHE_RUN_GROUP}
+ErrorLog ${APACHE_LOG_DIR}/error.log
+PidFile ${APACHE_PID_FILE}
+`,
+	}
+
+	fileContent := func(path string) (string, error) {
+		if c, ok := files[path]; ok {
+			return c, nil
+		}
+		return "", &fileNotFoundError{path: path}
+	}
+	globExpand := func(string) ([]string, error) { return nil, nil }
+
+	envvars := ParseEnvvars(`
+export APACHE_RUN_USER=www-data
+export APACHE_RUN_GROUP=www-data
+export APACHE_LOG_DIR=/var/log/apache2
+export APACHE_PID_FILE=/var/run/apache2/apache2.pid
+`)
+
+	cfg, err := ParseWithGlob("/etc/apache2/apache2.conf", fileContent, globExpand, envvars)
+	require.NoError(t, err)
+
+	assert.Equal(t, "www-data", cfg.Params["User"])
+	assert.Equal(t, "www-data", cfg.Params["Group"])
+	assert.Equal(t, "/var/log/apache2/error.log", cfg.Params["ErrorLog"])
+	assert.Equal(t, "/var/run/apache2/apache2.pid", cfg.Params["PidFile"])
+}
+
+func TestParseWithGlobUnresolvedVarsPreserved(t *testing.T) {
+	// When we can't resolve a variable, keep the original reference text so
+	// users can still see the problem instead of getting a silent empty value.
+	files := map[string]string{
+		"/etc/apache2/apache2.conf": `User ${APACHE_RUN_USER}`,
+	}
+	fileContent := func(path string) (string, error) { return files[path], nil }
+	globExpand := func(string) ([]string, error) { return nil, nil }
+
+	cfg, err := ParseWithGlob("/etc/apache2/apache2.conf", fileContent, globExpand, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "${APACHE_RUN_USER}", cfg.Params["User"])
+}
+
+func TestParseWithGlobApacheDefineDirective(t *testing.T) {
+	// Apache's own Define directive creates variables usable as ${NAME}.
+	files := map[string]string{
+		"/etc/apache2/apache2.conf": `
+Define SITE_ROOT /var/www/site
+DocumentRoot ${SITE_ROOT}
+`,
+	}
+	fileContent := func(path string) (string, error) { return files[path], nil }
+	globExpand := func(string) ([]string, error) { return nil, nil }
+
+	cfg, err := ParseWithGlob("/etc/apache2/apache2.conf", fileContent, globExpand, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "/var/www/site", cfg.Params["DocumentRoot"])
+}

--- a/providers/os/resources/apache2/envvars_test.go
+++ b/providers/os/resources/apache2/envvars_test.go
@@ -5,6 +5,7 @@ package apache2
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -76,6 +77,38 @@ export PID=$BASE/apache.pid
 	assert.Equal(t, "/opt/apache/apache.pid", vars["PID"])
 }
 
+// TestParseEnvvarsChainedReferences exercises the fixed-point expansion:
+// A depends on B depends on C, and map iteration order can visit them in any
+// sequence.
+func TestParseEnvvarsChainedReferences(t *testing.T) {
+	vars := ParseEnvvars(`
+export A=${B}/a
+export B=${C}/b
+export C=/root
+`)
+	assert.Equal(t, "/root", vars["C"])
+	assert.Equal(t, "/root/b", vars["B"])
+	assert.Equal(t, "/root/b/a", vars["A"])
+}
+
+// TestParseEnvvarsCyclicReferences ensures the fixed-point loop terminates
+// even when the input contains a reference cycle.
+func TestParseEnvvarsCyclicReferences(t *testing.T) {
+	done := make(chan map[string]string, 1)
+	go func() {
+		done <- ParseEnvvars(`
+export A=${B}
+export B=${A}
+`)
+	}()
+	select {
+	case <-done:
+		// ok — terminated
+	case <-time.After(2 * time.Second):
+		t.Fatal("ParseEnvvars did not terminate on a reference cycle")
+	}
+}
+
 // TestParseWithGlobExpandsEnvvars is the regression test for
 // https://github.com/mondoohq/mql/issues/7173 — Debian's apache2.conf references
 // `${APACHE_RUN_USER}`, which must be resolved from envvars.
@@ -125,6 +158,37 @@ func TestParseWithGlobUnresolvedVarsPreserved(t *testing.T) {
 	cfg, err := ParseWithGlob("/etc/apache2/apache2.conf", fileContent, globExpand, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "${APACHE_RUN_USER}", cfg.Params["User"])
+}
+
+func TestParseWithGlobExpandsInVirtualHost(t *testing.T) {
+	// ${VAR} references inside <VirtualHost> blocks must also be expanded,
+	// since Debian's default site configs rely on that (e.g. SSLCertificateFile
+	// ${APACHE_SSL_DIR}/cert.pem).
+	files := map[string]string{
+		"/etc/apache2/apache2.conf": `
+<VirtualHost *:443>
+    ServerName ${SITE_HOST}
+    DocumentRoot ${SITE_ROOT}
+    SSLEngine on
+</VirtualHost>
+`,
+	}
+	fileContent := func(path string) (string, error) { return files[path], nil }
+	globExpand := func(string) ([]string, error) { return nil, nil }
+
+	vars := map[string]string{
+		"SITE_HOST": "secure.example.com",
+		"SITE_ROOT": "/var/www/secure",
+	}
+
+	cfg, err := ParseWithGlob("/etc/apache2/apache2.conf", fileContent, globExpand, vars)
+	require.NoError(t, err)
+	require.Len(t, cfg.VHosts, 1)
+
+	vh := cfg.VHosts[0]
+	assert.Equal(t, "secure.example.com", vh.ServerName)
+	assert.Equal(t, "/var/www/secure", vh.DocumentRoot)
+	assert.Equal(t, "secure.example.com", vh.Params["ServerName"])
 }
 
 func TestParseWithGlobApacheDefineDirective(t *testing.T) {

--- a/providers/os/resources/apache2/parser.go
+++ b/providers/os/resources/apache2/parser.go
@@ -59,21 +59,31 @@ func Parse(content string) *Config {
 
 // ParseWithGlob parses Apache config files, recursively expanding Include and
 // IncludeOptional directives using the provided glob and file-content functions.
-func ParseWithGlob(rootPath string, fileContent fileContentFunc, globExpand globExpandFunc) (*Config, error) {
+// The optional vars map provides initial variable definitions (e.g. parsed from
+// Debian's /etc/apache2/envvars). `Define` directives encountered during
+// parsing extend this map, and `${VAR}` references in directive values are
+// substituted in-place.
+func ParseWithGlob(rootPath string, fileContent fileContentFunc, globExpand globExpandFunc, vars map[string]string) (*Config, error) {
 	content, err := fileContent(rootPath)
 	if err != nil {
 		return nil, err
+	}
+
+	// Copy the caller's map so we don't mutate it when handling Define.
+	working := make(map[string]string, len(vars))
+	for k, v := range vars {
+		working[k] = v
 	}
 
 	cfg := &Config{
 		Params: map[string]any{},
 	}
 
-	parseWithGlobRecursive(cfg, rootPath, content, fileContent, globExpand)
+	parseWithGlobRecursive(cfg, rootPath, content, fileContent, globExpand, working)
 	return cfg, nil
 }
 
-func parseWithGlobRecursive(cfg *Config, filePath, content string, fileContent fileContentFunc, globExpand globExpandFunc) {
+func parseWithGlobRecursive(cfg *Config, filePath, content string, fileContent fileContentFunc, globExpand globExpandFunc, vars map[string]string) {
 	lines := splitAndClean(content)
 	i := 0
 	for i < len(lines) {
@@ -82,15 +92,16 @@ func parseWithGlobRecursive(cfg *Config, filePath, content string, fileContent f
 		// Block directives: <VirtualHost>, <Directory>, etc.
 		if strings.HasPrefix(line, "<") {
 			blockTag, blockArg := parseBlockOpen(line)
+			blockArg = expandApacheVars(blockArg, vars)
 			blockLines, end := collectBlock(lines, i+1, blockTag)
 			i = end + 1
 
 			switch strings.ToLower(blockTag) {
 			case "virtualhost":
-				vh := parseVirtualHost(blockArg, blockLines)
+				vh := parseVirtualHost(blockArg, blockLines, vars)
 				cfg.VHosts = append(cfg.VHosts, vh)
 			case "directory", "directorymatch":
-				d := parseDirectory(blockArg, blockLines)
+				d := parseDirectory(blockArg, blockLines, vars)
 				cfg.Dirs = append(cfg.Dirs, d)
 			}
 			// Other block types (Location, Files, etc.) are silently skipped for now
@@ -103,18 +114,24 @@ func parseWithGlobRecursive(cfg *Config, filePath, content string, fileContent f
 			continue
 		}
 
+		value = expandApacheVars(value, vars)
 		keyLower := strings.ToLower(key)
 
 		switch keyLower {
 		case "include", "includeoptional":
 			cfg.Includes = append(cfg.Includes, value)
 			if globExpand != nil && fileContent != nil {
-				expandInclude(cfg, value, fileContent, globExpand, keyLower == "includeoptional")
+				expandInclude(cfg, value, fileContent, globExpand, keyLower == "includeoptional", vars)
 			}
 		case "loadmodule":
 			parts := strings.Fields(value)
 			if len(parts) >= 2 {
 				cfg.Modules = append(cfg.Modules, Module{Name: parts[0], Path: parts[1]})
+			}
+		case "define":
+			// `Define VAR value` adds an Apache-level variable usable as ${VAR}.
+			if name, val, ok := splitDefine(value); ok {
+				vars[name] = val
 			}
 		default:
 			setParam(cfg.Params, key, value)
@@ -124,7 +141,26 @@ func parseWithGlobRecursive(cfg *Config, filePath, content string, fileContent f
 	}
 }
 
-func expandInclude(cfg *Config, pattern string, fileContent fileContentFunc, globExpand globExpandFunc, optional bool) {
+// splitDefine splits a Define directive argument into name and value. When
+// only a name is given, the value is empty (Apache treats this as "defined").
+func splitDefine(s string) (string, string, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", "", false
+	}
+	idx := strings.IndexAny(s, " \t")
+	if idx < 0 {
+		return s, "", true
+	}
+	name := s[:idx]
+	val := strings.TrimSpace(s[idx+1:])
+	if len(val) >= 2 && val[0] == '"' && val[len(val)-1] == '"' {
+		val = val[1 : len(val)-1]
+	}
+	return name, val, true
+}
+
+func expandInclude(cfg *Config, pattern string, fileContent fileContentFunc, globExpand globExpandFunc, optional bool, vars map[string]string) {
 	paths, err := globExpand(pattern)
 	if err != nil {
 		if !optional {
@@ -141,7 +177,7 @@ func expandInclude(cfg *Config, pattern string, fileContent fileContentFunc, glo
 			}
 			continue
 		}
-		parseWithGlobRecursive(cfg, p, content, fileContent, globExpand)
+		parseWithGlobRecursive(cfg, p, content, fileContent, globExpand, vars)
 	}
 }
 
@@ -158,10 +194,10 @@ func parseLines(cfg *Config, lines []string, start int) {
 
 			switch strings.ToLower(blockTag) {
 			case "virtualhost":
-				vh := parseVirtualHost(blockArg, blockLines)
+				vh := parseVirtualHost(blockArg, blockLines, nil)
 				cfg.VHosts = append(cfg.VHosts, vh)
 			case "directory", "directorymatch":
-				d := parseDirectory(blockArg, blockLines)
+				d := parseDirectory(blockArg, blockLines, nil)
 				cfg.Dirs = append(cfg.Dirs, d)
 			}
 			continue
@@ -191,7 +227,7 @@ func parseLines(cfg *Config, lines []string, start int) {
 }
 
 // parseVirtualHost parses the lines inside a <VirtualHost> block.
-func parseVirtualHost(address string, lines []string) VirtualHost {
+func parseVirtualHost(address string, lines []string, vars map[string]string) VirtualHost {
 	vh := VirtualHost{
 		Address: address,
 		Params:  map[string]any{},
@@ -218,6 +254,7 @@ func parseVirtualHost(address string, lines []string) VirtualHost {
 			continue
 		}
 
+		value = expandApacheVars(value, vars)
 		setParam(vh.Params, key, value)
 
 		switch strings.ToLower(key) {
@@ -234,7 +271,7 @@ func parseVirtualHost(address string, lines []string) VirtualHost {
 }
 
 // parseDirectory parses the lines inside a <Directory> block.
-func parseDirectory(path string, lines []string) Directory {
+func parseDirectory(path string, lines []string, vars map[string]string) Directory {
 	d := Directory{
 		Path:   path,
 		Params: map[string]any{},
@@ -261,6 +298,7 @@ func parseDirectory(path string, lines []string) Directory {
 			continue
 		}
 
+		value = expandApacheVars(value, vars)
 		setParam(d.Params, key, value)
 
 		switch strings.ToLower(key) {

--- a/providers/os/resources/apache2/parser_test.go
+++ b/providers/os/resources/apache2/parser_test.go
@@ -245,7 +245,7 @@ ServerSignature Off
 		return nil, nil
 	}
 
-	cfg, err := ParseWithGlob("/etc/httpd/conf/httpd.conf", fileContent, globExpand)
+	cfg, err := ParseWithGlob("/etc/httpd/conf/httpd.conf", fileContent, globExpand, nil)
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -866,6 +866,16 @@ apache2.conf {
   virtualHosts(file) []apache2.conf.virtualHost
   // Directory blocks
   directories(file) []apache2.conf.directory
+  // Environment variables sourced by Apache at startup (e.g. Debian's /etc/apache2/envvars)
+  envvars() apache2.conf.envvars
+}
+
+// Apache2 environment variables (e.g. Debian's /etc/apache2/envvars)
+private apache2.conf.envvars @defaults("file.path") {
+  // File defining the environment variables
+  file file
+  // Parsed variable assignments (after shell expansion)
+  params map[string]string
 }
 
 // Apache2 loaded module

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -872,10 +872,11 @@ apache2.conf {
 
 // Apache2 environment variables (e.g. Debian's /etc/apache2/envvars)
 private apache2.conf.envvars @defaults("file.path") {
+  init(path? string)
   // File defining the environment variables
-  file file
+  file() file
   // Parsed variable assignments (after shell expansion)
-  params map[string]string
+  params(file) map[string]string
 }
 
 // Apache2 loaded module

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -529,7 +529,7 @@ func init() {
 			Create: createApache2Conf,
 		},
 		"apache2.conf.envvars": {
-			// to override args, implement: initApache2ConfEnvvars(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initApache2ConfEnvvars,
 			Create: createApache2ConfEnvvars,
 		},
 		"apache2.conf.module": {
@@ -17418,7 +17418,12 @@ func createApache2ConfEnvvars(runtime *plugin.Runtime, args map[string]*llx.RawD
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("apache2.conf.envvars", res.__id)
@@ -17440,11 +17445,30 @@ func (c *mqlApache2ConfEnvvars) MqlID() string {
 }
 
 func (c *mqlApache2ConfEnvvars) GetFile() *plugin.TValue[*mqlFile] {
-	return &c.File
+	return plugin.GetOrCompute[*mqlFile](&c.File, func() (*mqlFile, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("apache2.conf.envvars", c.__id, "file")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlFile), nil
+			}
+		}
+
+		return c.file()
+	})
 }
 
 func (c *mqlApache2ConfEnvvars) GetParams() *plugin.TValue[map[string]any] {
-	return &c.Params
+	return plugin.GetOrCompute[map[string]any](&c.Params, func() (map[string]any, error) {
+		vargFile := c.GetFile()
+		if vargFile.Error != nil {
+			return nil, vargFile.Error
+		}
+
+		return c.params(vargFile.Data)
+	})
 }
 
 // mqlApache2ConfModule for the apache2.conf.module resource

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -79,6 +79,7 @@ const (
 	ResourceAuditdRuleSyscall            string = "auditd.rule.syscall"
 	ResourceApache2                      string = "apache2"
 	ResourceApache2Conf                  string = "apache2.conf"
+	ResourceApache2ConfEnvvars           string = "apache2.conf.envvars"
 	ResourceApache2ConfModule            string = "apache2.conf.module"
 	ResourceApache2ConfVirtualHost       string = "apache2.conf.virtualHost"
 	ResourceApache2ConfDirectory         string = "apache2.conf.directory"
@@ -526,6 +527,10 @@ func init() {
 		"apache2.conf": {
 			Init:   initApache2Conf,
 			Create: createApache2Conf,
+		},
+		"apache2.conf.envvars": {
+			// to override args, implement: initApache2ConfEnvvars(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createApache2ConfEnvvars,
 		},
 		"apache2.conf.module": {
 			// to override args, implement: initApache2ConfModule(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -2227,6 +2232,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"apache2.conf.directories": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlApache2Conf).GetDirectories()).ToDataRes(types.Array(types.Resource("apache2.conf.directory")))
+	},
+	"apache2.conf.envvars": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlApache2Conf).GetEnvvars()).ToDataRes(types.Resource("apache2.conf.envvars"))
+	},
+	"apache2.conf.envvars.file": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlApache2ConfEnvvars).GetFile()).ToDataRes(types.Resource("file"))
+	},
+	"apache2.conf.envvars.params": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlApache2ConfEnvvars).GetParams()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"apache2.conf.module.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlApache2ConfModule).GetName()).ToDataRes(types.String)
@@ -6923,6 +6937,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"apache2.conf.directories": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlApache2Conf).Directories, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"apache2.conf.envvars": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlApache2Conf).Envvars, ok = plugin.RawToTValue[*mqlApache2ConfEnvvars](v.Value, v.Error)
+		return
+	},
+	"apache2.conf.envvars.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlApache2ConfEnvvars).__id, ok = v.Value.(string)
+		return
+	},
+	"apache2.conf.envvars.file": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlApache2ConfEnvvars).File, ok = plugin.RawToTValue[*mqlFile](v.Value, v.Error)
+		return
+	},
+	"apache2.conf.envvars.params": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlApache2ConfEnvvars).Params, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"apache2.conf.module.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -17190,6 +17220,7 @@ type mqlApache2Conf struct {
 	Modules         plugin.TValue[[]any]
 	VirtualHosts    plugin.TValue[[]any]
 	Directories     plugin.TValue[[]any]
+	Envvars         plugin.TValue[*mqlApache2ConfEnvvars]
 }
 
 // createApache2Conf creates a new instance of this resource
@@ -17349,6 +17380,71 @@ func (c *mqlApache2Conf) GetDirectories() *plugin.TValue[[]any] {
 
 		return c.directories(vargFile.Data)
 	})
+}
+
+func (c *mqlApache2Conf) GetEnvvars() *plugin.TValue[*mqlApache2ConfEnvvars] {
+	return plugin.GetOrCompute[*mqlApache2ConfEnvvars](&c.Envvars, func() (*mqlApache2ConfEnvvars, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("apache2.conf", c.__id, "envvars")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlApache2ConfEnvvars), nil
+			}
+		}
+
+		return c.envvars()
+	})
+}
+
+// mqlApache2ConfEnvvars for the apache2.conf.envvars resource
+type mqlApache2ConfEnvvars struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlApache2ConfEnvvarsInternal it will be used here
+	File   plugin.TValue[*mqlFile]
+	Params plugin.TValue[map[string]any]
+}
+
+// createApache2ConfEnvvars creates a new instance of this resource
+func createApache2ConfEnvvars(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlApache2ConfEnvvars{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("apache2.conf.envvars", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlApache2ConfEnvvars) MqlName() string {
+	return "apache2.conf.envvars"
+}
+
+func (c *mqlApache2ConfEnvvars) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlApache2ConfEnvvars) GetFile() *plugin.TValue[*mqlFile] {
+	return &c.File
+}
+
+func (c *mqlApache2ConfEnvvars) GetParams() *plugin.TValue[map[string]any] {
+	return &c.Params
 }
 
 // mqlApache2ConfModule for the apache2.conf.module resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -9,6 +9,9 @@ apache2.conf.directory.allowOverride 11.8.14
 apache2.conf.directory.options 11.8.14
 apache2.conf.directory.params 11.8.14
 apache2.conf.directory.path 11.8.14
+apache2.conf.envvars 13.12.1
+apache2.conf.envvars.file 13.12.1
+apache2.conf.envvars.params 13.12.1
 apache2.conf.file 11.8.14
 apache2.conf.files 11.8.14
 apache2.conf.listenAddresses 11.8.14


### PR DESCRIPTION
## Summary
- Parse Debian's `/etc/apache2/envvars` and expand `${VAR}` references in `apache2.conf` directive values, block args, and `Include` paths so `apache2.conf.params[\"User\"]` returns `www-data` instead of the literal `${APACHE_RUN_USER}`.
- Honor Apache's own `Define NAME value` directive as another source of variables.
- Add a new `apache2.conf.envvars` sub-resource (`file` + parsed `params`) so users can inspect the envvars the daemon actually picks up.

## Test plan
- [x] `go test ./providers/os/resources/apache2/...` — new tests cover envvars parsing, shell control-flow skipping, `${VAR}` / `$VAR` expansion, unresolved-variable preservation, the issue-7173 regression, and the `Define` directive.
- [ ] On a Debian host with apache2 installed: `mql run --command 'apache2.conf.params[\"User\"]'` returns `www-data`, and `mql run --command 'apache2.conf.envvars.params'` shows the parsed envvars.

Fixes #7173

🤖 Generated with [Claude Code](https://claude.com/claude-code)