### PR TITLE
🎉 os-13.13.0

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.12.0",
+	Version: "13.13.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### os (13.13.0)
- 🐛 expand apache2.conf variables from envvars (fixes #7173) (#7280)
- ✨ Add WordPress plugin SBOM cataloger (#7279)
- ✨ Add Jenkins plugin SBOM cataloger (#7278)
- ✨ Add Chocolatey package resource (#7271)
- ⭐ add Cursor editor resource to OS provider (#7204)