### PR TITLE
✨ allow account-tag override for propagate-account-tags

### DIFF
--- a/providers/aws/connection/filters.go
+++ b/providers/aws/connection/filters.go
@@ -19,6 +19,11 @@ type DiscoveryFilters struct {
 	Ecs                  EcsDiscoveryFilters
 	General              GeneralDiscoveryFilters
 	PropagateAccountTags bool
+	// AccountTags, when non-empty, is used as the source of account-level tags
+	// for PropagateAccountTags instead of calling Organizations. Intended for
+	// callers that can fetch tags from a management-account context (member
+	// accounts can't reach Organizations APIs).
+	AccountTags map[string]string
 }
 
 func DiscoveryFiltersFromOpts(opts map[string]string) DiscoveryFilters {
@@ -43,6 +48,7 @@ func DiscoveryFiltersFromOpts(opts map[string]string) DiscoveryFilters {
 			DiscoverImages:        parseBoolOpt(opts, "ecs:discover-images", false),
 		},
 		PropagateAccountTags: parseBoolOpt(opts, "propagate-account-tags", false),
+		AccountTags:          parseMapOpt(opts, "account-tag:"),
 	}
 
 	// TODO: backward compatibility, remove in future versions

--- a/providers/aws/connection/filters_test.go
+++ b/providers/aws/connection/filters_test.go
@@ -253,6 +253,8 @@ func TestDiscoveryFiltersFromOpts(t *testing.T) {
 			"ecs:discover-instances":      "false",
 			// Account-level filters
 			"propagate-account-tags": "true",
+			"account-tag:Owner":      "team-a",
+			"account-tag:CostCenter": "cc-42",
 		}
 		expected := DiscoveryFilters{
 			General: GeneralDiscoveryFilters{
@@ -281,6 +283,10 @@ func TestDiscoveryFiltersFromOpts(t *testing.T) {
 				ExcludeTags: []string{"tag1", "tag2"},
 			},
 			PropagateAccountTags: true,
+			AccountTags: map[string]string{
+				"Owner":      "team-a",
+				"CostCenter": "cc-42",
+			},
 		}
 
 		actual := DiscoveryFiltersFromOpts(opts)
@@ -303,7 +309,8 @@ func TestDiscoveryFiltersFromOpts(t *testing.T) {
 				Tags:        []string{},
 				ExcludeTags: []string{},
 			},
-			Ecs: EcsDiscoveryFilters{},
+			Ecs:         EcsDiscoveryFilters{},
+			AccountTags: map[string]string{},
 		}
 		actual := DiscoveryFiltersFromOpts(map[string]string{})
 		require.Equal(t, expected, actual)
@@ -325,7 +332,8 @@ func TestDiscoveryFiltersFromOpts(t *testing.T) {
 				Tags:        []string{},
 				ExcludeTags: []string{},
 			},
-			Ecs: EcsDiscoveryFilters{},
+			Ecs:         EcsDiscoveryFilters{},
+			AccountTags: map[string]string{},
 		}
 		actual := DiscoveryFiltersFromOpts(nil)
 		require.Equal(t, expected, actual)

--- a/providers/aws/resources/discovery.go
+++ b/providers/aws/resources/discovery.go
@@ -133,7 +133,10 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 	}
 
 	if conn.Filters.PropagateAccountTags {
-		accountTags := fetchPrimaryAccountTags(awsAccount)
+		accountTags := conn.Filters.AccountTags
+		if len(accountTags) == 0 {
+			accountTags = fetchPrimaryAccountTags(awsAccount)
+		}
 		primaryAccountId := trimAwsAccountIdToJustId(awsAccount.Id.Data)
 		applyAccountTagsToAssets(in.Spec.Assets, accountTags, primaryAccountId)
 	}


### PR DESCRIPTION
## Summary

The `propagate-account-tags` feature currently sources tags from `Organizations:ListTagsForResource` under the connection's (possibly assumed-role) credentials. For cross-account scans this fails on **member** accounts because Organizations APIs only work from the management account or delegated admins — the call returns `AccessDeniedException` and tag propagation silently no-ops.

This PR adds an opt-in override: when `propagate-account-tags=true` **and** one or more `account-tag:<Key>=<Value>` filter entries are set, `Discover` uses the supplied tags directly and skips the Organizations API call. Callers that can fetch tags from a management-account context (e.g. an orchestrator running in the mgmt account) can pre-fetch and inject them without cnspec needing to assume into mgmt.

When `account-tag:*` is unset the behavior is unchanged — tags are fetched via `fetchPrimaryAccountTags` as before, preserving backward compatibility.

## Changes

- `providers/aws/connection/filters.go`: add `AccountTags map[string]string` on `DiscoveryFilters` and parse it from the `account-tag:` prefix.
- `providers/aws/resources/discovery.go`: prefer `conn.Filters.AccountTags` when non-empty; otherwise fall back to the existing Organizations call.
- `providers/aws/connection/filters_test.go`: extend `TestDiscoveryFiltersFromOpts` to cover the new key and empty/nil cases.

## Motivation

Hit in the serverless-scanner-aws cross-account scan path. Hub Lambda runs in the Organizations management account; the scanner EC2 also runs there, but cnspec assumes into the target role before discovery — so Organizations calls happen under the target member's creds and fail at the service layer, regardless of IAM. This PR lets the orchestrator fetch tags in the mgmt-account context and hand them to cnspec.

## Test plan

- [x] `go test ./providers/aws/connection/... -run TestDiscoveryFiltersFromOpts` passes.
- [x] `go build ./providers/aws/...` clean.
- [x] `go test ./providers/aws/resources/ -run "TestApplyAccountTagsToAssets|TestMergeAccountTagsIntoLabels|TestIsSiblingOrgAccountAsset"` passes.
- [ ] e2e: integrated with serverless-scanner-aws pre-fetch path (follow-up repo PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)