### PR TITLE
🐛 add shebang to gcp validate_permissions.py

### DIFF
--- a/providers/gcp/resources/validate_permissions.py
+++ b/providers/gcp/resources/validate_permissions.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 


### PR DESCRIPTION
## Summary
- Add `#!/usr/bin/env python3` shebang to `providers/gcp/resources/validate_permissions.py` so the script can be executed directly. Without it, the shell parsed the docstring and `import` lines as commands.
- File mode is now `755` (executable).

## Test plan
- [ ] `./providers/gcp/resources/validate_permissions.py --help` runs without shell parse errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)