### PR TITLE
✨ Add SWI-Prolog pack SBOM cataloger

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -265,6 +265,7 @@ messagestoragepolicy
 metageneration
 mfs
 mgroup
+mildner
 minfree
 MINIMALUSER
 Mirrorings
@@ -435,8 +436,10 @@ stdlib
 stdio
 stepfunctions
 streamable
+Stus
 stringx
 subscriptionfilter
+swi
 superusers
 switchports
 symfony

--- a/docs/adr/022-cnspec-sbom-prolog.md
+++ b/docs/adr/022-cnspec-sbom-prolog.md
@@ -1,0 +1,40 @@
+# ADR: mql SBOM Cataloger for SWI-Prolog Packs
+
+**Status:** Proposed
+**Date:** 2026-04-19
+
+---
+
+## Context
+
+cnspec needs native SBOM cataloging for SWI-Prolog packs to detect installed packages. SWI-Prolog uses a pack system where each pack contains a `pack.pl` file with metadata in Prolog term format.
+
+## File Format
+
+### pack.pl
+
+Simple Prolog term format with `key(value).` entries:
+
+```prolog
+name(mavis).
+version('1.0.5').
+title('Access Prolog packs from SICStus').
+author('Per Mildner', 'per.mildner@sics.se').
+home_url('https://github.com/example/mavis').
+download_url('https://example.com/mavis-1.0.5.zip').
+```
+
+Key fields: `name(...)` and `version(...)`.
+
+## Parsing Strategy
+
+Line-oriented regex matching `key('value')` or `key(value)` patterns. No full Prolog parser needed.
+
+## Package Identification
+
+- **PURL:** `pkg:swi-prolog/<name>@<version>`
+
+## Verification
+
+- Fixture-based tests with a pack.pl file
+- Interactive: `mql run os -c "prolog.packages(path: '/path/to/packs') { list { name version purl } }"`

--- a/providers/os/resources/languages/prolog/packpl/scanner.go
+++ b/providers/os/resources/languages/prolog/packpl/scanner.go
@@ -1,0 +1,124 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package packpl
+
+import (
+	"bufio"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages/prolog"
+)
+
+// PrologPack represents a parsed SWI-Prolog pack.
+type PrologPack struct {
+	Name     string
+	Version  string
+	Title    string
+	FilePath string
+}
+
+// termPattern matches Prolog terms like name(value). or name('value').
+var termPattern = regexp.MustCompile(`^(\w+)\((?:'([^']*)'|(\w[^)]*?))\)\.`)
+
+// ScanPackDir scans a directory for SWI-Prolog packs.
+// Each subdirectory containing a pack.pl is treated as a pack.
+func ScanPackDir(afs *afero.Afero, dir string) ([]PrologPack, error) {
+	entries, err := afs.ReadDir(dir)
+	if err != nil {
+		log.Debug().Err(err).Str("path", dir).Msg("mql[prolog]> could not read packs directory")
+		return nil, nil
+	}
+
+	var packs []PrologPack
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		packPath := path.Join(dir, entry.Name(), "pack.pl")
+		if exists, _ := afs.Exists(packPath); !exists {
+			continue
+		}
+
+		pack, err := parsePackPl(afs, packPath)
+		if err != nil {
+			log.Debug().Err(err).Str("path", packPath).Msg("mql[prolog]> could not parse pack.pl")
+			continue
+		}
+		if pack != nil {
+			packs = append(packs, *pack)
+		}
+	}
+
+	return packs, nil
+}
+
+// parsePackPl reads a pack.pl file and extracts name and version.
+func parsePackPl(afs *afero.Afero, packPath string) (*PrologPack, error) {
+	f, err := afs.Open(packPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	pack := &PrologPack{FilePath: packPath}
+	scanner := bufio.NewScanner(f)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "%") {
+			continue
+		}
+
+		m := termPattern.FindStringSubmatch(line)
+		if len(m) < 3 {
+			continue
+		}
+
+		key := m[1]
+		// Value is either in group 2 (quoted) or group 3 (unquoted)
+		value := m[2]
+		if value == "" {
+			value = m[3]
+		}
+
+		switch key {
+		case "name":
+			pack.Name = value
+		case "version":
+			pack.Version = value
+		case "title":
+			pack.Title = value
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	if pack.Name == "" {
+		return nil, nil
+	}
+
+	return pack, nil
+}
+
+// ToPackages converts a list of PrologPacks to language packages.
+func ToPackages(packs []PrologPack) []*languages.Package {
+	var packages []*languages.Package
+	for _, p := range packs {
+		packages = append(packages, &languages.Package{
+			Name:         p.Name,
+			Version:      p.Version,
+			Purl:         prolog.NewPackageUrl(p.Name, p.Version),
+			EvidenceList: prolog.NewEvidenceList([]string{p.FilePath}),
+		})
+	}
+	return packages
+}

--- a/providers/os/resources/languages/prolog/packpl/scanner_test.go
+++ b/providers/os/resources/languages/prolog/packpl/scanner_test.go
@@ -1,0 +1,51 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package packpl
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanPackDir(t *testing.T) {
+	afs := &afero.Afero{Fs: afero.NewOsFs()}
+	packs, err := ScanPackDir(afs, "./testdata")
+	require.NoError(t, err)
+
+	// pack1 + pack2 = 2 packs; not-a-pack is skipped
+	assert.Equal(t, 2, len(packs))
+
+	var mavis, listUtil *PrologPack
+	for i := range packs {
+		switch packs[i].Name {
+		case "mavis":
+			mavis = &packs[i]
+		case "list_util":
+			listUtil = &packs[i]
+		}
+	}
+
+	require.NotNil(t, mavis)
+	assert.Equal(t, "mavis", mavis.Name)
+	assert.Equal(t, "1.0.5", mavis.Version)
+	assert.Equal(t, "Example Prolog pack", mavis.Title)
+
+	require.NotNil(t, listUtil)
+	assert.Equal(t, "list_util", listUtil.Name)
+	assert.Equal(t, "0.15.0", listUtil.Version)
+}
+
+func TestToPackages(t *testing.T) {
+	packs := []PrologPack{
+		{Name: "mavis", Version: "1.0.5", FilePath: "pack.pl"},
+	}
+	pkgs := ToPackages(packs)
+	assert.Equal(t, 1, len(pkgs))
+	assert.Equal(t, "mavis", pkgs[0].Name)
+	assert.Equal(t, "1.0.5", pkgs[0].Version)
+	assert.Equal(t, "pkg:swi-prolog/mavis@1.0.5", pkgs[0].Purl)
+}

--- a/providers/os/resources/languages/prolog/packpl/testdata/not-a-pack/readme.txt
+++ b/providers/os/resources/languages/prolog/packpl/testdata/not-a-pack/readme.txt
@@ -1,0 +1,1 @@
+Not a Prolog pack.

--- a/providers/os/resources/languages/prolog/packpl/testdata/pack1/pack.pl
+++ b/providers/os/resources/languages/prolog/packpl/testdata/pack1/pack.pl
@@ -1,0 +1,5 @@
+name(mavis).
+version('1.0.5').
+title('Example Prolog pack').
+author('Test Author', 'author@example.com').
+home_url('https://github.com/example/mavis').

--- a/providers/os/resources/languages/prolog/packpl/testdata/pack2/pack.pl
+++ b/providers/os/resources/languages/prolog/packpl/testdata/pack2/pack.pl
@@ -1,0 +1,4 @@
+name(list_util).
+version('0.15.0').
+title('List utilities').
+author('Michael Hendricks', 'michael@ndrix.org').

--- a/providers/os/resources/languages/prolog/prolog.go
+++ b/providers/os/resources/languages/prolog/prolog.go
@@ -1,0 +1,32 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package prolog
+
+import (
+	"github.com/package-url/packageurl-go"
+	"go.mondoo.com/mql/v13/sbom"
+)
+
+// NewPackageUrl creates a SWI-Prolog pack package URL.
+func NewPackageUrl(name string, version string) string {
+	return packageurl.NewPackageURL(
+		"swi-prolog",
+		"",
+		name,
+		version,
+		nil,
+		"").String()
+}
+
+// NewEvidenceList converts a list of file paths to evidence entries.
+func NewEvidenceList(evidence []string) []*sbom.Evidence {
+	evidenceList := make([]*sbom.Evidence, len(evidence))
+	for i, e := range evidence {
+		evidenceList[i] = &sbom.Evidence{
+			Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
+			Value: e,
+		}
+	}
+	return evidenceList
+}

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -2796,6 +2796,33 @@ erlang.package @defaults("name version purl") {
   files() []pkgFileInfo
 }
 
+// SWI-Prolog packs
+prolog.packages {
+  []prolog.package
+
+  init(path? string)
+
+  // Path to search for SWI-Prolog packs directory
+  path string
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// SWI-Prolog pack
+prolog.package @defaults("name version purl") {
+  // ID is the prolog.package unique identifier
+  id string
+  // Pack name
+  name() string
+  // Pack version
+  version() string
+  // Package URL
+  purl() string
+  // Package files
+  files() []pkgFileInfo
+}
+
 // macOS specific resources
 macos {
   // macOS computer name

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -213,6 +213,8 @@ const (
 	ResourceElixirPackage                string = "elixir.package"
 	ResourceErlangPackages               string = "erlang.packages"
 	ResourceErlangPackage                string = "erlang.package"
+	ResourcePrologPackages               string = "prolog.packages"
+	ResourcePrologPackage                string = "prolog.package"
 	ResourceMacos                        string = "macos"
 	ResourceMacosHardware                string = "macos.hardware"
 	ResourceMacosAlf                     string = "macos.alf"
@@ -1126,6 +1128,14 @@ func init() {
 		"erlang.package": {
 			// to override args, implement: initErlangPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createErlangPackage,
+		},
+		"prolog.packages": {
+			Init:   initPrologPackages,
+			Create: createPrologPackages,
+		},
+		"prolog.package": {
+			// to override args, implement: initPrologPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createPrologPackage,
 		},
 		"macos": {
 			// to override args, implement: initMacos(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -4536,6 +4546,30 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"erlang.package.files": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlErlangPackage).GetFiles()).ToDataRes(types.Array(types.Resource("pkgFileInfo")))
+	},
+	"prolog.packages.path": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPrologPackages).GetPath()).ToDataRes(types.String)
+	},
+	"prolog.packages.files": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPrologPackages).GetFiles()).ToDataRes(types.Array(types.Resource("pkgFileInfo")))
+	},
+	"prolog.packages.list": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPrologPackages).GetList()).ToDataRes(types.Array(types.Resource("prolog.package")))
+	},
+	"prolog.package.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPrologPackage).GetId()).ToDataRes(types.String)
+	},
+	"prolog.package.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPrologPackage).GetName()).ToDataRes(types.String)
+	},
+	"prolog.package.version": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPrologPackage).GetVersion()).ToDataRes(types.String)
+	},
+	"prolog.package.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPrologPackage).GetPurl()).ToDataRes(types.String)
+	},
+	"prolog.package.files": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPrologPackage).GetFiles()).ToDataRes(types.Array(types.Resource("pkgFileInfo")))
 	},
 	"macos.computerName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMacos).GetComputerName()).ToDataRes(types.String)
@@ -11316,6 +11350,46 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"erlang.package.files": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlErlangPackage).Files, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"prolog.packages.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPrologPackages).__id, ok = v.Value.(string)
+		return
+	},
+	"prolog.packages.path": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPrologPackages).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"prolog.packages.files": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPrologPackages).Files, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"prolog.packages.list": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPrologPackages).List, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"prolog.package.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPrologPackage).__id, ok = v.Value.(string)
+		return
+	},
+	"prolog.package.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPrologPackage).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"prolog.package.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPrologPackage).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"prolog.package.version": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPrologPackage).Version, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"prolog.package.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPrologPackage).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"prolog.package.files": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPrologPackage).Files, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"macos.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31080,6 +31154,176 @@ func (c *mqlErlangPackage) GetFiles() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Files, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
 			d, err := c.MqlRuntime.FieldResourceFromRecording("erlang.package", c.__id, "files")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.files()
+	})
+}
+
+// mqlPrologPackages for the prolog.packages resource
+type mqlPrologPackages struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlPrologPackagesInternal
+	Path  plugin.TValue[string]
+	Files plugin.TValue[[]any]
+	List  plugin.TValue[[]any]
+}
+
+// createPrologPackages creates a new instance of this resource
+func createPrologPackages(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlPrologPackages{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("prolog.packages", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlPrologPackages) MqlName() string {
+	return "prolog.packages"
+}
+
+func (c *mqlPrologPackages) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlPrologPackages) GetPath() *plugin.TValue[string] {
+	return &c.Path
+}
+
+func (c *mqlPrologPackages) GetFiles() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Files, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("prolog.packages", c.__id, "files")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.files()
+	})
+}
+
+func (c *mqlPrologPackages) GetList() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.List, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("prolog.packages", c.__id, "list")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.list()
+	})
+}
+
+// mqlPrologPackage for the prolog.package resource
+type mqlPrologPackage struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlPrologPackageInternal it will be used here
+	Id      plugin.TValue[string]
+	Name    plugin.TValue[string]
+	Version plugin.TValue[string]
+	Purl    plugin.TValue[string]
+	Files   plugin.TValue[[]any]
+}
+
+// createPrologPackage creates a new instance of this resource
+func createPrologPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlPrologPackage{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("prolog.package", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlPrologPackage) MqlName() string {
+	return "prolog.package"
+}
+
+func (c *mqlPrologPackage) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlPrologPackage) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlPrologPackage) GetName() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Name, func() (string, error) {
+		return c.name()
+	})
+}
+
+func (c *mqlPrologPackage) GetVersion() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Version, func() (string, error) {
+		return c.version()
+	})
+}
+
+func (c *mqlPrologPackage) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
+	})
+}
+
+func (c *mqlPrologPackage) GetFiles() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Files, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("prolog.package", c.__id, "files")
 			if err != nil {
 				return nil, err
 			}

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -1423,6 +1423,16 @@ process.pid 9.0.1
 process.state 9.0.1
 processes 9.0.1
 processes.list 9.0.1
+prolog.package 13.13.1
+prolog.package.files 13.13.1
+prolog.package.id 13.13.1
+prolog.package.name 13.13.1
+prolog.package.purl 13.13.1
+prolog.package.version 13.13.1
+prolog.packages 13.13.1
+prolog.packages.files 13.13.1
+prolog.packages.list 13.13.1
+prolog.packages.path 13.13.1
 python 9.0.1
 python.package 9.0.1
 python.package.author 9.0.1

--- a/providers/os/resources/prolog.go
+++ b/providers/os/resources/prolog.go
@@ -1,0 +1,150 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"slices"
+	"sync"
+
+	"github.com/spf13/afero"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages/prolog/packpl"
+	"go.mondoo.com/mql/v13/types"
+)
+
+func initPrologPackages(_ *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if x, ok := args["path"]; ok {
+		if _, ok := x.Value.(string); !ok {
+			return nil, nil, errors.New("wrong type for 'path' in prolog.packages initialization, it must be a string")
+		}
+	} else {
+		args["path"] = llx.StringData("")
+	}
+	return args, nil, nil
+}
+
+func (r *mqlPrologPackages) id() (string, error) {
+	if r.Path.Data != "" {
+		return "prolog.packages/" + r.Path.Data, nil
+	}
+	return "prolog.packages", nil
+}
+
+type mqlPrologPackagesInternal struct {
+	mutex   sync.Mutex
+	fetched bool
+}
+
+func (r *mqlPrologPackages) gatherData() error {
+	if r.fetched {
+		return nil
+	}
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if r.fetched {
+		return nil
+	}
+
+	conn := r.MqlRuntime.Connection.(shared.Connection)
+	afs := &afero.Afero{Fs: conn.FileSystem()}
+
+	path := r.Path.Data
+	if path == "" {
+		// SWI-Prolog default pack location
+		path = "/usr/lib/swi-prolog/pack"
+	}
+
+	packs, _ := packpl.ScanPackDir(afs, path)
+	pkgs := packpl.ToPackages(packs)
+	slices.SortFunc(pkgs, languages.SortFn)
+
+	allResources, err := newPrologPackageList(r.MqlRuntime, pkgs)
+	if err != nil {
+		return err
+	}
+	r.List = plugin.TValue[[]any]{Data: allResources, State: plugin.StateIsSet}
+
+	mqlFiles := []any{}
+	if len(packs) > 0 {
+		lf, err := CreateResource(r.MqlRuntime, "pkgFileInfo", map[string]*llx.RawData{
+			"path": llx.StringData(path),
+		})
+		if err != nil {
+			return err
+		}
+		mqlFiles = append(mqlFiles, lf)
+	}
+	r.Files = plugin.TValue[[]any]{Data: mqlFiles, State: plugin.StateIsSet}
+
+	r.fetched = true
+	return nil
+}
+
+func (r *mqlPrologPackages) list() ([]any, error) {
+	return nil, r.gatherData()
+}
+
+func (r *mqlPrologPackages) files() ([]any, error) {
+	return nil, r.gatherData()
+}
+
+func newPrologPackageList(runtime *plugin.Runtime, packages []*languages.Package) ([]any, error) {
+	resources := []any{}
+	for i := range packages {
+		pkg, err := newPrologPackage(runtime, packages[i])
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, pkg)
+	}
+	return resources, nil
+}
+
+func newPrologPackage(runtime *plugin.Runtime, pkg *languages.Package) (*mqlPrologPackage, error) {
+	mqlFiles := []any{}
+	for i := range pkg.EvidenceList {
+		lf, err := CreateResource(runtime, "pkgFileInfo", map[string]*llx.RawData{
+			"path": llx.StringData(pkg.EvidenceList[i].Value),
+		})
+		if err != nil {
+			return nil, err
+		}
+		mqlFiles = append(mqlFiles, lf)
+	}
+
+	path := ""
+	if len(mqlFiles) > 0 {
+		if fi, ok := mqlFiles[0].(*mqlPkgFileInfo); ok {
+			path = fi.Path.Data
+		}
+	}
+
+	mqlPkg, err := CreateResource(runtime, "prolog.package", map[string]*llx.RawData{
+		"id":      llx.StringData(pkg.Name + "@" + pkg.Version + ":" + path),
+		"name":    llx.StringData(pkg.Name),
+		"version": llx.StringData(pkg.Version),
+		"purl":    llx.StringData(pkg.Purl),
+		"files":   llx.ArrayData(mqlFiles, types.Resource("pkgFileInfo")),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return mqlPkg.(*mqlPrologPackage), nil
+}
+
+func (k *mqlPrologPackage) id() (string, error) {
+	return k.Id.Data, nil
+}
+
+func (r *mqlPrologPackage) name() (string, error)    { return "", r.populateData() }
+func (r *mqlPrologPackage) version() (string, error) { return "", r.populateData() }
+func (r *mqlPrologPackage) purl() (string, error)    { return "", r.populateData() }
+func (r *mqlPrologPackage) files() ([]any, error)    { return nil, r.populateData() }
+func (r *mqlPrologPackage) populateData() error {
+	return errors.New("prolog.package can only be created via prolog.packages")
+}

--- a/sbom/generator/generator.go
+++ b/sbom/generator/generator.go
@@ -460,6 +460,25 @@ func GenerateBom(r *reporter.Report) []*sbom.Sbom {
 
 				bom.Packages = append(bom.Packages, bomPkg)
 			}
+
+			for _, pkg := range rb.PrologPackages {
+				bomPkg := &sbom.Package{
+					Name:    pkg.Name,
+					Version: pkg.Version,
+					Purl:    pkg.Purl,
+					Cpes:    pkg.CPEs,
+					Type:    "swi-prolog",
+				}
+
+				for _, filepath := range pkg.FilePaths {
+					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
+						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
+						Value: filepath,
+					})
+				}
+
+				bom.Packages = append(bom.Packages, bomPkg)
+			}
 		}
 		boms = append(boms, bom)
 	}

--- a/sbom/generator/report_collection.go
+++ b/sbom/generator/report_collection.go
@@ -66,6 +66,7 @@ type BomFields struct {
 	HaskellPackages       []BomPackage      `json:"haskell.packages.list,omitempty"`
 	ElixirPackages        []BomPackage      `json:"elixir.packages.list,omitempty"`
 	ErlangPackages        []BomPackage      `json:"erlang.packages.list,omitempty"`
+	PrologPackages        []BomPackage      `json:"prolog.packages.list,omitempty"`
 	KernelInstalled       []KernelInstalled `json:"kernel.installed,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

Adds native SBOM cataloging for SWI-Prolog packs, enabling dependency detection from `pack.pl` files.

## New MQL Resources

### `prolog.packages`

Scans SWI-Prolog pack directories for installed packs.

```coffeescript
mql run os -c "prolog.packages(path: '/usr/lib/swi-prolog/pack') { list { name version purl } }"
```

### `prolog.package`

| Field | Type | Description |
|-------|------|-------------|
| `name` | `string` | Pack name |
| `version` | `string` | Pack version |
| `purl` | `string` | `pkg:swi-prolog/<name>@<version>` |
| `files` | `[]pkgFileInfo` | Evidence files |

## Parser

- Scans subdirectories for `pack.pl` files
- Regex-based extraction of Prolog term format: `name(value).` entries
- Handles both quoted (`'value'`) and unquoted (`value`) terms
- Extracts name, version, and title

## Test plan

- [x] Pack directory scan: 2 packs found, non-pack directory skipped
- [x] PURL generation
- [x] SBOM generator tests pass
- [x] golangci-lint extended clean
- [x] Full OS provider builds
- [ ] Interactive verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)