### PR TITLE
🧹 Propagate ScanPackDir error in prolog cataloger

### DIFF
--- a/providers/os/resources/prolog.go
+++ b/providers/os/resources/prolog.go
@@ -59,7 +59,10 @@ func (r *mqlPrologPackages) gatherData() error {
 		path = "/usr/lib/swi-prolog/pack"
 	}
 
-	packs, _ := packpl.ScanPackDir(afs, path)
+	packs, err := packpl.ScanPackDir(afs, path)
+	if err != nil {
+		return err
+	}
 	pkgs := packpl.ToPackages(packs)
 	slices.SortFunc(pkgs, languages.SortFn)
 


### PR DESCRIPTION
## Summary

Follow-up to #7297 — propagate the error from `ScanPackDir` instead of silently discarding it with `_`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)