### PR TITLE
✨ Add ALPM filesystem fallback for pacman package manager

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -13,6 +13,7 @@ afero
 AJD
 Akismet
 alamofire
+alpm
 alloydb
 alpn
 antispam
@@ -386,8 +387,9 @@ OSGi
 ospf
 OTP
 ovmf
-OVS
 owpjy
+OVS
+pacman
 pagerduty
 panos
 parallelquery

--- a/docs/adr/023-cnspec-sbom-alpm.md
+++ b/docs/adr/023-cnspec-sbom-alpm.md
@@ -1,0 +1,60 @@
+# ADR: mql ALPM (Arch Linux) SBOM Enhancement
+
+**Status:** Proposed
+**Date:** 2026-04-19
+
+---
+
+## Context
+
+The existing pacman package manager parser (`pacman -Q`) provides basic name+version extraction with PURL generation. For complete SBOM coverage, we need to also support filesystem-based parsing of `/var/lib/pacman/local/*/desc` files, which enables:
+
+1. **Offline/image scanning** without the `pacman` CLI
+2. **Richer metadata**: description, URL, architecture, dependencies
+3. **Dependency relationship extraction** for SBOM dependency graphs
+
+## Current State
+
+- `pacman -Q` parser: name, version, PURL (`pkg:alpm/arch/<name>@<version>`)
+- No filesystem fallback
+- No description, architecture, or dependency extraction
+
+## Enhancement
+
+### Filesystem fallback: `/var/lib/pacman/local/*/desc`
+
+The `desc` file uses a section-based format:
+
+```
+%NAME%
+zlib
+
+%VERSION%
+1:1.2.13-3
+
+%DESC%
+Compression library implementing the deflate compression method
+
+%URL%
+https://www.zlib.net/
+
+%ARCH%
+x86_64
+
+%DEPENDS%
+glibc
+```
+
+Sections are `%KEY%` followed by value lines until the next `%KEY%` or end of file.
+
+### Changes
+
+- Add `listFromFS()` method to `PacmanPkgManager` for filesystem-based parsing
+- Parse `desc` files for name, version, description, URL, arch
+- Use CLI primary, filesystem fallback (same pattern as Snap, Homebrew)
+- Populate `Description` and `Arch` fields on `Package` struct
+
+## Verification
+
+- Fixture-based tests with real desc files
+- Interactive: `mql run os -c "packages { list.where(format == 'pacman') { name version } }"`

--- a/providers/os/resources/packages/pacman_packages.go
+++ b/providers/os/resources/packages/pacman_packages.go
@@ -7,13 +7,16 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"path"
 	"regexp"
-
-	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
-	"go.mondoo.com/mql/v13/providers/os/resources/purl"
+	"strings"
 
 	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/v13/providers/os/resources/purl"
 )
 
 const (
@@ -57,12 +60,110 @@ func (ppm *PacmanPkgManager) Format() string {
 }
 
 func (ppm *PacmanPkgManager) List() ([]Package, error) {
-	cmd, err := ppm.conn.RunCommand("pacman -Q")
-	if err != nil {
-		return nil, fmt.Errorf("could not read pacman package list")
+	// Primary: pacman -Q CLI
+	if ppm.conn.Capabilities().Has(shared.Capability_RunCommand) {
+		cmd, err := ppm.conn.RunCommand("pacman -Q")
+		if err == nil && cmd.ExitStatus == 0 {
+			return ParsePacmanPackages(ppm.platform, cmd.Stdout), nil
+		}
+		log.Debug().Err(err).Msg("mql[pacman]> could not run pacman -Q, falling back to filesystem")
 	}
 
-	return ParsePacmanPackages(ppm.platform, cmd.Stdout), nil
+	// Fallback: parse /var/lib/pacman/local/*/desc files
+	return ppm.listFromFS()
+}
+
+func (ppm *PacmanPkgManager) listFromFS() ([]Package, error) {
+	afs := &afero.Afero{Fs: ppm.conn.FileSystem()}
+	return ParsePacmanDB(ppm.platform, afs, "/var/lib/pacman/local")
+}
+
+// ParsePacmanDB parses the pacman local database directory structure.
+// Each subdirectory contains a `desc` file with package metadata.
+func ParsePacmanDB(pf *inventory.Platform, afs *afero.Afero, dbPath string) ([]Package, error) {
+	entries, err := afs.ReadDir(dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not read pacman database at %s: %w", dbPath, err)
+	}
+
+	var pkgs []Package
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		// path.Join (not filepath.Join) is intentional — these are always
+		// Linux filesystem paths, even when mql runs on a different OS.
+		descPath := path.Join(dbPath, entry.Name(), "desc")
+		pkg, err := parsePacmanDesc(pf, afs, descPath)
+		if err != nil {
+			log.Debug().Err(err).Str("path", descPath).Msg("mql[pacman]> could not parse desc")
+			continue
+		}
+		if pkg != nil {
+			pkgs = append(pkgs, *pkg)
+		}
+	}
+
+	return pkgs, nil
+}
+
+// parsePacmanDesc parses a single pacman desc file.
+// The format uses %KEY% sections followed by values on subsequent lines.
+func parsePacmanDesc(pf *inventory.Platform, afs *afero.Afero, descPath string) (*Package, error) {
+	f, err := afs.Open(descPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	fields := parsePacmanDescSections(f)
+
+	name := fields["%NAME%"]
+	version := fields["%VERSION%"]
+	if name == "" {
+		return nil, nil
+	}
+
+	return &Package{
+		Name:        name,
+		Version:     version,
+		Arch:        fields["%ARCH%"],
+		Description: fields["%DESC%"],
+		Format:      PacmanPkgFormat,
+		PUrl:        purl.NewPackageURL(pf, purl.TypeAlpm, name, version).String(),
+	}, nil
+}
+
+// parsePacmanDescSections reads a desc file and returns a map of section key to value.
+func parsePacmanDescSections(r io.Reader) map[string]string {
+	fields := make(map[string]string)
+	scanner := bufio.NewScanner(r)
+	var currentKey string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Section header: %KEY% (at least 3 chars, exactly two % signs)
+		if len(line) >= 3 && line[0] == '%' && line[len(line)-1] == '%' && strings.Count(line, "%") == 2 {
+			currentKey = line
+			continue
+		}
+
+		// Empty line ends a section value
+		if line == "" {
+			currentKey = ""
+			continue
+		}
+
+		// Value line — only keep the first value line per section
+		// (multi-value sections like %DEPENDS% are not needed for SBOM)
+		if currentKey != "" && fields[currentKey] == "" {
+			fields[currentKey] = line
+		}
+	}
+
+	return fields
 }
 
 func (ppm *PacmanPkgManager) Available() (map[string]PackageUpdate, error) {

--- a/providers/os/resources/packages/pacman_packages_test.go
+++ b/providers/os/resources/packages/pacman_packages_test.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
-
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers/os/resources/packages"
 )
 
@@ -89,4 +90,46 @@ argon2 20190702-2`
 		Format:  packages.PacmanPkgFormat,
 	}
 	assert.Contains(t, m, p, "pkg detected")
+}
+
+func TestParsePacmanDB(t *testing.T) {
+	pf := &inventory.Platform{
+		Name:    "arch",
+		Version: "",
+		Arch:    "x86_64",
+		Family:  []string{"arch", "linux", "unix", "os"},
+		Labels: map[string]string{
+			"distro-id": "arch",
+		},
+	}
+
+	afs := &afero.Afero{Fs: afero.NewOsFs()}
+	pkgs, err := packages.ParsePacmanDB(pf, afs, "./testdata/pacman")
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(pkgs))
+
+	var zlib *packages.Package
+	for i := range pkgs {
+		if pkgs[i].Name == "zlib" {
+			zlib = &pkgs[i]
+			break
+		}
+	}
+	require.NotNil(t, zlib)
+	assert.Equal(t, "1:1.2.13-3", zlib.Version)
+	assert.Equal(t, "x86_64", zlib.Arch)
+	assert.Contains(t, zlib.Description, "Compression library")
+	assert.Equal(t, "pacman", zlib.Format)
+	assert.Contains(t, zlib.PUrl, "pkg:alpm/arch/zlib")
+
+	var openssl *packages.Package
+	for i := range pkgs {
+		if pkgs[i].Name == "openssl" {
+			openssl = &pkgs[i]
+			break
+		}
+	}
+	require.NotNil(t, openssl)
+	assert.Equal(t, "3.2.1-1", openssl.Version)
+	assert.Contains(t, openssl.Description, "Open Source toolkit")
 }

--- a/providers/os/resources/packages/testdata/pacman/glibc-2.39-1/desc
+++ b/providers/os/resources/packages/testdata/pacman/glibc-2.39-1/desc
@@ -1,0 +1,17 @@
+%NAME%
+glibc
+
+%VERSION%
+2.39-1
+
+%DESC%
+GNU C Library
+
+%URL%
+https://www.gnu.org/software/libc
+
+%ARCH%
+x86_64
+
+%SIZE%
+50000000

--- a/providers/os/resources/packages/testdata/pacman/openssl-3.2.1-1/desc
+++ b/providers/os/resources/packages/testdata/pacman/openssl-3.2.1-1/desc
@@ -1,0 +1,18 @@
+%NAME%
+openssl
+
+%VERSION%
+3.2.1-1
+
+%DESC%
+The Open Source toolkit for Secure Sockets Layer and Transport Layer Security
+
+%URL%
+https://www.openssl.org
+
+%ARCH%
+x86_64
+
+%DEPENDS%
+glibc
+zlib

--- a/providers/os/resources/packages/testdata/pacman/zlib-1.2.13-3/desc
+++ b/providers/os/resources/packages/testdata/pacman/zlib-1.2.13-3/desc
@@ -1,0 +1,35 @@
+%NAME%
+zlib
+
+%VERSION%
+1:1.2.13-3
+
+%BASE%
+zlib
+
+%DESC%
+Compression library implementing the deflate compression method found in gzip and PKZIP
+
+%URL%
+https://www.zlib.net/
+
+%ARCH%
+x86_64
+
+%BUILDDATE%
+1700000000
+
+%INSTALLDATE%
+1700100000
+
+%PACKAGER%
+Test Packager <packager@example.com>
+
+%SIZE%
+360448
+
+%DEPENDS%
+glibc
+
+%PROVIDES%
+libz.so=1-64


### PR DESCRIPTION
## Summary

Enhances the existing pacman package manager with a filesystem-based fallback that parses `/var/lib/pacman/local/*/desc` files. This enables SBOM generation for Arch Linux container images and offline scans where the `pacman` CLI is not available.

## Changes

### New: Filesystem fallback (`listFromFS`)

Parses the pacman local database directory structure:
```
/var/lib/pacman/local/
  zlib-1:1.2.13-3/desc
  glibc-2.39-1/desc
  openssl-3.2.1-1/desc
```

Each `desc` file uses a section-based format (`%KEY%` followed by value lines):
```
%NAME%
zlib

%VERSION%
1:1.2.13-3

%DESC%
Compression library

%ARCH%
x86_64
```

### Enhanced: Description and Arch fields

The filesystem fallback populates `Description` and `Arch` fields that are not available from the `pacman -Q` CLI output.

### Pattern: CLI primary, FS fallback

Same pattern used by Snap, Homebrew:
1. Try `pacman -Q` via `RunCommand` (fast, complete)
2. Fall back to filesystem parsing if CLI unavailable (offline/image scans)

## Test plan

- [x] Existing `pacman -Q` parser tests unchanged
- [x] New filesystem parser: 3 desc files (zlib with epoch, glibc, openssl)
- [x] Description and Arch extraction
- [x] PURL generation from desc files
- [x] golangci-lint clean
- [x] Full OS provider builds
- [ ] Interactive verification on Arch Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)