### PR TITLE
✨ Enhance Gentoo/Portage SBOM with PURL and filesystem fallback

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -16,6 +16,7 @@ alamofire
 alpm
 alloydb
 alpn
+antigravity
 antispam
 aof
 apm
@@ -31,6 +32,7 @@ ASGs
 aspnet
 atlassian
 auditlog
+augment
 Auths
 autoaccept
 autoclass
@@ -41,6 +43,7 @@ autoprovision
 autoreplace
 Autoscalers
 autotrim
+AVRO
 awsapps
 AWSCURRENT
 awsfirelens
@@ -112,9 +115,9 @@ customresources
 cwes
 cyclonedx
 dast
+databricks
 datadog
 datadoghq
-databricks
 datapath
 datasource
 datastream
@@ -123,6 +126,7 @@ DBFS
 DBRS
 ddl
 ddos
+dhcpcd
 dedup
 dedupratio
 defc
@@ -143,6 +147,7 @@ DRdf
 dsse
 Duf
 eas
+ebuild
 ecc
 Ecmp
 EDNS
@@ -258,8 +263,8 @@ julia
 junie
 junos
 jupyter
-jwks
 JVM
+jwks
 kerberoastable
 keymap
 keyspace
@@ -326,8 +331,8 @@ mongodb
 Mpim
 msk
 mtls
-multiplatform
 MULTIAZ
+multiplatform
 myapp
 mychart
 myproject
@@ -404,6 +409,7 @@ pipefail
 pki
 podfile
 Policer
+portage
 portgroup
 posix
 postgre
@@ -421,12 +427,14 @@ pubspec
 pushconfig
 pve
 PVEAPI
+PVR
 pyspark
 pzi
 pzs
 QAwr
 qcow
 QGA
+qlist
 querypack
 quorate
 qwen
@@ -444,12 +452,15 @@ resourcegroup
 resourcepolicy
 resourcequota
 richrule
+RODC
 roku
 rootdir
 rpo
 RRULE
+RSAES
 RSASSA
 RSession
+RStudio
 rtl
 rtsp
 rulegroup

--- a/docs/adr/025-cnspec-sbom-portage.md
+++ b/docs/adr/025-cnspec-sbom-portage.md
@@ -1,0 +1,69 @@
+# ADR: mql Portage (Gentoo) SBOM Enhancement
+
+**Status:** Proposed
+**Date:** 2026-04-19
+
+---
+
+## Context
+
+The existing Gentoo package manager parser (`qlist -Iv`) provides basic name+version extraction but lacks PURL generation and filesystem-based fallback. For complete SBOM coverage, we need:
+
+1. **PURL generation** using the `pkg:ebuild` type per the PURL specification
+2. **Filesystem fallback** for offline/image scanning via `/var/db/pkg/`
+3. **Richer metadata**: description from `/var/db/pkg/CATEGORY/NAME-VERSION/DESCRIPTION`
+
+## Current State
+
+- `qlist -Iv --format '%{CATEGORY}/%{PN}:%{PVR}'` parser: name (with category), version
+- No PURL generation
+- No filesystem fallback
+- No description extraction
+
+## Enhancement
+
+### PURL Generation
+
+Portage packages use the `ebuild` PURL type, which is defined in the PURL specification:
+
+```
+pkg:ebuild/net-misc/curl@8.4.0
+```
+
+The namespace is the Gentoo category (e.g., `net-misc`), and the name is the package name (e.g., `curl`).
+
+### Filesystem Fallback: `/var/db/pkg/`
+
+The Portage installed package database uses a directory structure:
+
+```
+/var/db/pkg/
+├── net-misc/
+│   ├── curl-8.4.0/
+│   │   ├── CATEGORY        → "net-misc"
+│   │   ├── PF              → "curl-8.4.0"
+│   │   ├── DESCRIPTION     → "A Client and Server ..."
+│   │   ├── EAPI            → "8"
+│   │   └── ...
+│   └── dhcpcd-10.0.5-r1/
+│       └── ...
+├── acct-group/
+│   └── audio-0-r2/
+│       └── ...
+```
+
+Each subdirectory under a category represents an installed package. The directory name encodes the package name and version (e.g., `curl-8.4.0`). The version is separated from the name by the last hyphen before a version-like segment (starting with a digit).
+
+### Changes
+
+- Add `TypeEbuild` PURL type
+- Add PURL generation to `ParseGentooPackages`
+- Add `listFromFS()` method with `/var/db/pkg/` fallback
+- Parse `DESCRIPTION` file for package description
+- Use CLI primary, filesystem fallback (same pattern as Homebrew, ALPM)
+- Pass platform to parser for PURL generation
+
+## Verification
+
+- Fixture-based tests with `qlist` output and `/var/db/pkg/` directory structure
+- Interactive: `mql run os -c "packages { list.where(format == 'gentoo') { name version purl } }"`

--- a/providers/os/resources/packages/gentoo_packages.go
+++ b/providers/os/resources/packages/gentoo_packages.go
@@ -5,23 +5,28 @@ package packages
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
+	"path"
 	"strings"
+	"unicode"
 
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/v13/providers/os/resources/purl"
 )
 
 const (
 	GentooPkgFormat = "gentoo"
 )
 
-type GentooPackage struct {
-	Name    string
-	Version string
-}
-
-func ParseGentooPackages(r io.Reader) ([]Package, error) {
+// ParseGentooPackages parses the output of
+// `qlist -Iv --format '%{CATEGORY}/%{PN}:%{PVR}'`.
+// Format: CATEGORY/NAME:VERSION (e.g., "net-misc/curl:8.4.0")
+func ParseGentooPackages(pf *inventory.Platform, r io.Reader) ([]Package, error) {
 	pkgs := []Package{}
 
 	scanner := bufio.NewScanner(r)
@@ -37,13 +42,14 @@ func ParseGentooPackages(r io.Reader) ([]Package, error) {
 			continue
 		}
 
-		name := strings.TrimSpace(parts[0])
+		categoryName := strings.TrimSpace(parts[0])
 		version := strings.TrimSpace(parts[1])
 
 		pkgs = append(pkgs, Package{
-			Name:    name,
+			Name:    categoryName,
 			Version: version,
 			Format:  GentooPkgFormat,
+			PUrl:    newEbuildPurl(pf, categoryName, version),
 		})
 	}
 
@@ -54,8 +60,28 @@ func ParseGentooPackages(r io.Reader) ([]Package, error) {
 	return pkgs, nil
 }
 
+// newEbuildPurl creates a PURL for a Gentoo ebuild package.
+// Format: pkg:ebuild/CATEGORY/NAME@VERSION
+func newEbuildPurl(pf *inventory.Platform, categoryName, version string) string {
+	category, name := splitCategoryName(categoryName)
+	return purl.NewPackageURL(pf, purl.TypeEbuild, name, version,
+		purl.WithNamespace(category),
+	).String()
+}
+
+// splitCategoryName splits "category/name" into its parts.
+func splitCategoryName(categoryName string) (string, string) {
+	idx := strings.LastIndex(categoryName, "/")
+	if idx < 0 {
+		return "", categoryName
+	}
+	return categoryName[:idx], categoryName[idx+1:]
+}
+
+// Gentoo
 type GentooPkgManager struct {
-	conn shared.Connection
+	conn     shared.Connection
+	platform *inventory.Platform
 }
 
 func (f *GentooPkgManager) Name() string {
@@ -67,19 +93,117 @@ func (f *GentooPkgManager) Format() string {
 }
 
 func (f *GentooPkgManager) List() ([]Package, error) {
-	cmd, err := f.conn.RunCommand("qlist -Iv --format '%{CATEGORY}/%{PN}:%{PVR}'")
-	if err != nil {
-		return nil, fmt.Errorf("could not read gentoo package list from qlist")
+	// Primary: qlist CLI
+	if f.conn.Capabilities().Has(shared.Capability_RunCommand) {
+		cmd, err := f.conn.RunCommand("qlist -Iv --format '%{CATEGORY}/%{PN}:%{PVR}'")
+		if err != nil {
+			log.Debug().Err(err).Msg("mql[gentoo]> could not run qlist, falling back to filesystem")
+		} else if cmd.ExitStatus != 0 {
+			log.Debug().Int("exitStatus", cmd.ExitStatus).Msg("mql[gentoo]> qlist returned non-zero, falling back to filesystem")
+		} else {
+			return ParseGentooPackages(f.platform, cmd.Stdout)
+		}
 	}
 
-	return ParseGentooPackages(cmd.Stdout)
+	// Fallback: parse /var/db/pkg/ directory structure
+	return f.listFromFS()
+}
+
+func (f *GentooPkgManager) listFromFS() ([]Package, error) {
+	fs := f.conn.FileSystem()
+	if fs == nil {
+		return nil, errors.New("gentoo package manager requires either command execution or filesystem access")
+	}
+	afs := &afero.Afero{Fs: fs}
+	return ParsePortageDB(f.platform, afs, "/var/db/pkg")
+}
+
+// ParsePortageDB parses the Portage installed package database directory.
+// Structure: /var/db/pkg/CATEGORY/NAME-VERSION/
+func ParsePortageDB(pf *inventory.Platform, afs *afero.Afero, dbPath string) ([]Package, error) {
+	categories, err := afs.ReadDir(dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not read portage database at %s: %w", dbPath, err)
+	}
+
+	var pkgs []Package
+	for _, cat := range categories {
+		if !cat.IsDir() {
+			continue
+		}
+		category := cat.Name()
+
+		// path.Join (not filepath.Join) is intentional — these are always
+		// Linux filesystem paths, even when mql runs on a different OS.
+		catPath := path.Join(dbPath, category)
+		entries, err := afs.ReadDir(catPath)
+		if err != nil {
+			log.Debug().Err(err).Str("path", catPath).Msg("mql[gentoo]> could not read category")
+			continue
+		}
+
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+
+			name, version := splitPortageDirName(entry.Name())
+			if name == "" || version == "" {
+				continue
+			}
+
+			fullName := category + "/" + name
+
+			// Try to read description
+			descPath := path.Join(catPath, entry.Name(), "DESCRIPTION")
+			description := readFileContent(afs, descPath)
+
+			pkgs = append(pkgs, Package{
+				Name:        fullName,
+				Version:     version,
+				Description: description,
+				Format:      GentooPkgFormat,
+				PUrl:        newEbuildPurl(pf, fullName, version),
+			})
+		}
+	}
+
+	return pkgs, nil
+}
+
+// splitPortageDirName splits a directory name like "curl-8.4.0" or
+// "dhcpcd-10.0.5-r1" into (name, version). The version starts at the last
+// hyphen that is followed by a digit.
+func splitPortageDirName(dirName string) (string, string) {
+	// Walk backwards to find the last hyphen followed by a digit
+	for i := len(dirName) - 1; i > 0; i-- {
+		if dirName[i] == '-' && i+1 < len(dirName) && unicode.IsDigit(rune(dirName[i+1])) {
+			return dirName[:i], dirName[i+1:]
+		}
+	}
+	return dirName, ""
+}
+
+// readFileContent reads the first line of a file, returning empty string on error.
+func readFileContent(afs *afero.Afero, path string) string {
+	f, err := afs.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	if scanner.Scan() {
+		return strings.TrimSpace(scanner.Text())
+	}
+	return ""
 }
 
 func (f *GentooPkgManager) Available() (map[string]PackageUpdate, error) {
 	return map[string]PackageUpdate{}, nil
 }
 
-func (mpm *GentooPkgManager) Files(name string, version string, arch string) ([]FileRecord, error) {
+func (f *GentooPkgManager) Files(name string, version string, arch string) ([]FileRecord, error) {
 	// not yet implemented
 	return nil, nil
 }

--- a/providers/os/resources/packages/gentoo_packages_test.go
+++ b/providers/os/resources/packages/gentoo_packages_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,15 +15,90 @@ import (
 func TestParseGentooPackages(t *testing.T) {
 	f, err := os.Open("testdata/gentoo_qlist.txt")
 	require.NoError(t, err)
+	defer f.Close()
 
-	m, err := ParseGentooPackages(f)
-	require.Nil(t, err)
+	m, err := ParseGentooPackages(nil, f)
+	require.NoError(t, err)
 	assert.Equal(t, 13, len(m), "detected the right amount of packages")
 
-	p := Package{
-		Name:    "net-misc/curl",
-		Version: "8.4.0",
-		Format:  "gentoo",
+	p := m[10] // net-misc/curl:8.4.0
+	assert.Equal(t, "net-misc/curl", p.Name)
+	assert.Equal(t, "8.4.0", p.Version)
+	assert.Equal(t, "gentoo", p.Format)
+	assert.Contains(t, p.PUrl, "pkg:ebuild/net-misc/curl@8.4.0")
+}
+
+func TestParseGentooPackagesRevision(t *testing.T) {
+	f, err := os.Open("testdata/gentoo_qlist.txt")
+	require.NoError(t, err)
+	defer f.Close()
+
+	m, err := ParseGentooPackages(nil, f)
+	require.NoError(t, err)
+
+	// net-misc/dhcpcd:10.0.5-r1
+	p := m[11]
+	assert.Equal(t, "net-misc/dhcpcd", p.Name)
+	assert.Equal(t, "10.0.5-r1", p.Version)
+	assert.Contains(t, p.PUrl, "pkg:ebuild/net-misc/dhcpcd@10.0.5-r1")
+}
+
+func TestParsePortageDB(t *testing.T) {
+	afs := &afero.Afero{Fs: afero.NewOsFs()}
+	pkgs, err := ParsePortageDB(nil, afs, "testdata/portage")
+	require.NoError(t, err)
+	require.Len(t, pkgs, 3)
+
+	// Sort order depends on OS readdir — find by name
+	byName := map[string]Package{}
+	for _, p := range pkgs {
+		byName[p.Name] = p
 	}
-	assert.Contains(t, m, p)
+
+	curl := byName["net-misc/curl"]
+	assert.Equal(t, "8.4.0", curl.Version)
+	assert.Equal(t, "gentoo", curl.Format)
+	assert.Contains(t, curl.PUrl, "pkg:ebuild/net-misc/curl@8.4.0")
+	assert.Contains(t, curl.Description, "Client and Server")
+
+	dhcpcd := byName["net-misc/dhcpcd"]
+	assert.Equal(t, "10.0.5-r1", dhcpcd.Version)
+	assert.Contains(t, dhcpcd.Description, "DHCP client")
+
+	audio := byName["acct-group/audio"]
+	assert.Equal(t, "0-r2", audio.Version)
+}
+
+func TestSplitPortageDirName(t *testing.T) {
+	tests := []struct {
+		input   string
+		name    string
+		version string
+	}{
+		{"curl-8.4.0", "curl", "8.4.0"},
+		{"dhcpcd-10.0.5-r1", "dhcpcd", "10.0.5-r1"},
+		{"audio-0-r2", "audio", "0-r2"},
+		{"libmnl-1.0.5", "libmnl", "1.0.5"},
+		{"nghttp2-1.57.0", "nghttp2", "1.57.0"},
+		{"iputils-20221126-r1", "iputils", "20221126-r1"},
+	}
+	for _, tt := range tests {
+		name, version := splitPortageDirName(tt.input)
+		assert.Equal(t, tt.name, name, "splitPortageDirName(%q) name", tt.input)
+		assert.Equal(t, tt.version, version, "splitPortageDirName(%q) version", tt.input)
+	}
+}
+
+func TestSplitCategoryName(t *testing.T) {
+	cat, name := splitCategoryName("net-misc/curl")
+	assert.Equal(t, "net-misc", cat)
+	assert.Equal(t, "curl", name)
+
+	cat, name = splitCategoryName("acct-group/audio")
+	assert.Equal(t, "acct-group", cat)
+	assert.Equal(t, "audio", name)
+
+	cat, name = splitCategoryName("nocat")
+	assert.Equal(t, "", cat)
+	assert.Equal(t, "nocat", name)
 }

--- a/providers/os/resources/packages/packages.go
+++ b/providers/os/resources/packages/packages.go
@@ -140,7 +140,7 @@ func ResolveSystemPkgManagers(conn shared.Connection) ([]OperatingSystemPkgManag
 	case asset.Platform.Name == "aix":
 		pms = append(pms, &AixPkgManager{conn: conn, platform: asset.Platform})
 	case asset.Platform.Name == "gentoo":
-		pms = append(pms, &GentooPkgManager{conn: conn})
+		pms = append(pms, &GentooPkgManager{conn: conn, platform: asset.Platform})
 	case asset.Platform.IsFamily("linux"):
 		// no clear package manager for linux platform found
 		// most likely we land here if we have a yocto-based system

--- a/providers/os/resources/packages/testdata/portage/acct-group/audio-0-r2/DESCRIPTION
+++ b/providers/os/resources/packages/testdata/portage/acct-group/audio-0-r2/DESCRIPTION
@@ -1,0 +1,1 @@
+System group: audio

--- a/providers/os/resources/packages/testdata/portage/net-misc/curl-8.4.0/DESCRIPTION
+++ b/providers/os/resources/packages/testdata/portage/net-misc/curl-8.4.0/DESCRIPTION
@@ -1,0 +1,1 @@
+A Client and Server library supporting the Gopher, HTTP, HTTPS, FTP and FTPS protocols

--- a/providers/os/resources/packages/testdata/portage/net-misc/dhcpcd-10.0.5-r1/DESCRIPTION
+++ b/providers/os/resources/packages/testdata/portage/net-misc/dhcpcd-10.0.5-r1/DESCRIPTION
@@ -1,0 +1,1 @@
+A fully featured, yet light weight RFC2131 compliant DHCP client

--- a/providers/os/resources/purl/purl_types.go
+++ b/providers/os/resources/purl/purl_types.go
@@ -27,6 +27,7 @@ var (
 	TypeApk     = Type(packageurl.TypeApk)
 	TypeDebian  = Type(packageurl.TypeDebian)
 	TypeAlpm    = Type(packageurl.TypeAlpm)
+	TypeEbuild  = Type(packageurl.TypeEbuild)
 	TypeRPM     = Type(packageurl.TypeRPM)
 
 	KnownTypes = map[Type]struct{}{
@@ -38,6 +39,7 @@ var (
 		TypeApk:         {},
 		TypeDebian:      {},
 		TypeAlpm:        {},
+		TypeEbuild:      {},
 		TypeRPM:         {},
 	}
 )


### PR DESCRIPTION
## Summary

- Add `pkg:ebuild` PURL type for Gentoo packages (per PURL specification)
- Generate PURLs for all Gentoo packages: `pkg:ebuild/category/name@version`
- Add filesystem fallback via `/var/db/pkg/` for offline image scanning (same pattern as Homebrew, ALPM)
- Parse `DESCRIPTION` files from Portage database for richer SBOM metadata
- CLI primary (`qlist`) + filesystem fallback pattern

### Changes

| File | Change |
|------|--------|
| `providers/os/resources/packages/gentoo_packages.go` | Add PURL generation, filesystem fallback via `ParsePortageDB`, `splitPortageDirName` version extraction |
| `providers/os/resources/packages/packages.go` | Pass platform to `GentooPkgManager` for PURL generation |
| `providers/os/resources/purl/purl_types.go` | Add `TypeEbuild` PURL type |
| `providers/os/resources/packages/gentoo_packages_test.go` | 5 tests: CLI parsing, revision handling, filesystem parsing, dir name splitting, category splitting |
| `docs/adr/025-cnspec-sbom-portage.md` | ADR documenting the enhancement |

### Example

```
pkg:ebuild/net-misc/curl@8.4.0
pkg:ebuild/net-misc/dhcpcd@10.0.5-r1
pkg:ebuild/acct-group/audio@0-r2
```

## Test plan

- [x] Unit tests pass for qlist parsing with PURL generation
- [x] Revision versions (e.g., `10.0.5-r1`) handled correctly
- [x] Filesystem fallback parses `/var/db/pkg/` directory structure
- [x] DESCRIPTION files parsed for package descriptions
- [x] `splitPortageDirName` correctly splits name-version for all patterns
- [ ] Interactive test on Gentoo: `mql run os -c "packages { list.where(format == 'gentoo') { name version purl } }"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)