### PR TITLE
🧹 Rename Alpine Package Manager to apk Package Manager

### DIFF
--- a/providers/os/resources/packages/apk_packages.go
+++ b/providers/os/resources/packages/apk_packages.go
@@ -139,7 +139,7 @@ type AlpinePkgManager struct {
 }
 
 func (apm *AlpinePkgManager) Name() string {
-	return "Alpine Package Manager"
+	return "apk Package Manager"
 }
 
 func (apm *AlpinePkgManager) Format() string {


### PR DESCRIPTION
## Summary

- Rename `"Alpine Package Manager"` to `"apk Package Manager"` since apk is used by both Alpine and Wolfi

One-line change in `providers/os/resources/packages/apk_packages.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)