### PR TITLE
✨ Add Flatpak package manager support

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -180,6 +180,8 @@ fips
 firefox
 firestore
 firstname
+flathub
+flatpak
 FLEXGROUP
 FLEXVOL
 flink

--- a/providers/os/resources/packages/flatpak_packages.go
+++ b/providers/os/resources/packages/flatpak_packages.go
@@ -1,0 +1,269 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package packages
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+
+	packageurl "github.com/package-url/packageurl-go"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+)
+
+const (
+	FlatpakPkgFormat = "flatpak"
+)
+
+type FlatpakPkgManager struct {
+	conn     shared.Connection
+	platform *inventory.Platform
+}
+
+func (fpm *FlatpakPkgManager) Name() string {
+	return "Flatpak Package Manager"
+}
+
+func (fpm *FlatpakPkgManager) Format() string {
+	return FlatpakPkgFormat
+}
+
+func (fpm *FlatpakPkgManager) List() ([]Package, error) {
+	// Primary: flatpak CLI
+	if fpm.conn.Capabilities().Has(shared.Capability_RunCommand) {
+		pkgs, err := fpm.listFromCLI()
+		if err == nil {
+			return pkgs, nil
+		}
+		log.Debug().Err(err).Msg("mql[flatpak]> could not enumerate via CLI, falling back to filesystem")
+	}
+
+	// Fallback: parse /var/lib/flatpak/app/ directory
+	return fpm.listFromFS()
+}
+
+func (fpm *FlatpakPkgManager) listFromCLI() ([]Package, error) {
+	// --app excludes runtimes, --columns controls output fields
+	cmd, err := fpm.conn.RunCommand("flatpak list --app --columns=application,version,origin,arch")
+	if err != nil {
+		return nil, err
+	}
+	if cmd.ExitStatus != 0 {
+		return nil, fmt.Errorf("flatpak list failed with exit code %d", cmd.ExitStatus)
+	}
+
+	return ParseFlatpakList(cmd.Stdout)
+}
+
+// ParseFlatpakList parses the output of
+// `flatpak list --app --columns=application,version,origin,arch`.
+// Each line is tab-delimited: APPLICATION\tVERSION\tORIGIN\tARCH
+func ParseFlatpakList(r io.Reader) ([]Package, error) {
+	var pkgs []Package
+	scanner := bufio.NewScanner(r)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Split(line, "\t")
+		if len(fields) < 2 {
+			continue
+		}
+
+		appID := strings.TrimSpace(fields[0])
+		version := strings.TrimSpace(fields[1])
+		origin := ""
+		arch := ""
+		if len(fields) >= 3 {
+			origin = strings.TrimSpace(fields[2])
+		}
+		if len(fields) >= 4 {
+			arch = strings.TrimSpace(fields[3])
+		}
+
+		if appID == "" {
+			continue
+		}
+
+		pkgs = append(pkgs, Package{
+			Name:    appID,
+			Version: version,
+			Arch:    arch,
+			Format:  FlatpakPkgFormat,
+			Origin:  origin,
+			PUrl:    newFlatpakPurl(appID, version, origin),
+		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return pkgs, nil
+}
+
+func (fpm *FlatpakPkgManager) listFromFS() ([]Package, error) {
+	afs := &afero.Afero{Fs: fpm.conn.FileSystem()}
+
+	var pkgs []Package
+
+	// System-wide installations
+	sysPkgs, err := parseFlatpakDir(afs, "/var/lib/flatpak/app")
+	if err == nil {
+		pkgs = append(pkgs, sysPkgs...)
+	}
+
+	// Per-user installations (common home directories)
+	homeDirs := []string{"/home", "/root"}
+	for _, homeBase := range homeDirs {
+		entries, err := afs.ReadDir(homeBase)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			userAppDir := path.Join(homeBase, entry.Name(), ".local/share/flatpak/app")
+			userPkgs, err := parseFlatpakDir(afs, userAppDir)
+			if err == nil {
+				pkgs = append(pkgs, userPkgs...)
+			}
+		}
+	}
+
+	return pkgs, nil
+}
+
+// parseFlatpakDir enumerates Flatpak apps from the filesystem.
+// Structure: /var/lib/flatpak/app/APP_ID/ARCH/BRANCH/active/metadata
+func parseFlatpakDir(afs *afero.Afero, appDir string) ([]Package, error) {
+	apps, err := afs.ReadDir(appDir)
+	if err != nil {
+		return nil, fmt.Errorf("could not read flatpak app directory at %s: %w", appDir, err)
+	}
+
+	var pkgs []Package
+	for _, app := range apps {
+		if !app.IsDir() {
+			continue
+		}
+		appID := app.Name()
+
+		// path.Join (not filepath.Join) is intentional — these are always
+		// Linux filesystem paths, even when mql runs on a different OS.
+		archDir := path.Join(appDir, appID)
+		arches, err := afs.ReadDir(archDir)
+		if err != nil {
+			continue
+		}
+
+		for _, archEntry := range arches {
+			if !archEntry.IsDir() {
+				continue
+			}
+			arch := archEntry.Name()
+
+			branchDir := path.Join(archDir, arch)
+			branches, err := afs.ReadDir(branchDir)
+			if err != nil {
+				continue
+			}
+
+			for _, branchEntry := range branches {
+				if !branchEntry.IsDir() {
+					continue
+				}
+
+				// Read metadata from active deployment
+				metadataPath := path.Join(branchDir, branchEntry.Name(), "active", "metadata")
+				origin, version := parseFlatpakMetadata(afs, metadataPath)
+
+				pkgs = append(pkgs, Package{
+					Name:    appID,
+					Version: version,
+					Arch:    arch,
+					Format:  FlatpakPkgFormat,
+					Origin:  origin,
+					PUrl:    newFlatpakPurl(appID, version, origin),
+				})
+			}
+		}
+	}
+
+	return pkgs, nil
+}
+
+// parseFlatpakMetadata reads a Flatpak metadata file (INI-like format)
+// and extracts the origin and version. These are deploy-level keys that
+// Flatpak appends to the metadata file. Lines inside [Extension ...]
+// sections are skipped to avoid false matches.
+func parseFlatpakMetadata(afs *afero.Afero, metadataPath string) (string, string) {
+	f, err := afs.Open(metadataPath)
+	if err != nil {
+		return "", ""
+	}
+	defer f.Close()
+
+	var origin, version string
+	inExtension := false
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		// Track INI sections — skip [Extension ...] blocks
+		if len(line) > 0 && line[0] == '[' {
+			inExtension = strings.HasPrefix(line, "[Extension ")
+			continue
+		}
+
+		if inExtension {
+			continue
+		}
+
+		if strings.HasPrefix(line, "origin=") {
+			origin = strings.TrimPrefix(line, "origin=")
+		}
+		if strings.HasPrefix(line, "version=") {
+			version = strings.TrimPrefix(line, "version=")
+		}
+
+		if origin != "" && version != "" {
+			break
+		}
+	}
+	return origin, version
+}
+
+// newFlatpakPurl creates a PURL for a Flatpak application.
+// Format: pkg:flatpak/origin/app-id@version
+func newFlatpakPurl(appID, version, origin string) string {
+	if appID == "" {
+		return ""
+	}
+	return packageurl.NewPackageURL(
+		"flatpak",
+		origin,
+		appID,
+		version,
+		nil,
+		"",
+	).String()
+}
+
+func (fpm *FlatpakPkgManager) Available() (map[string]PackageUpdate, error) {
+	return map[string]PackageUpdate{}, nil
+}
+
+func (fpm *FlatpakPkgManager) Files(name string, version string, arch string) ([]FileRecord, error) {
+	return nil, nil
+}

--- a/providers/os/resources/packages/flatpak_packages_test.go
+++ b/providers/os/resources/packages/flatpak_packages_test.go
@@ -1,0 +1,69 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package packages
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFlatpakList(t *testing.T) {
+	f, err := os.Open("testdata/flatpak_list.txt")
+	require.NoError(t, err)
+	defer f.Close()
+
+	pkgs, err := ParseFlatpakList(f)
+	require.NoError(t, err)
+	require.Len(t, pkgs, 5)
+
+	spotify := pkgs[0]
+	assert.Equal(t, "com.spotify.Client", spotify.Name)
+	assert.Equal(t, "1.2.31.564", spotify.Version)
+	assert.Equal(t, "flathub", spotify.Origin)
+	assert.Equal(t, "x86_64", spotify.Arch)
+	assert.Equal(t, "flatpak", spotify.Format)
+	assert.Contains(t, spotify.PUrl, "pkg:flatpak/flathub/com.spotify.Client@1.2.31.564")
+
+	firefox := pkgs[1]
+	assert.Equal(t, "org.mozilla.firefox", firefox.Name)
+	assert.Equal(t, "131.0", firefox.Version)
+}
+
+func TestParseFlatpakDir(t *testing.T) {
+	afs := &afero.Afero{Fs: afero.NewOsFs()}
+	pkgs, err := parseFlatpakDir(afs, "testdata/flatpak/app")
+	require.NoError(t, err)
+	require.Len(t, pkgs, 2)
+
+	byName := map[string]Package{}
+	for _, p := range pkgs {
+		byName[p.Name] = p
+	}
+
+	spotify := byName["com.spotify.Client"]
+	assert.Equal(t, "1.2.31.564", spotify.Version)
+	assert.Equal(t, "x86_64", spotify.Arch)
+	assert.Equal(t, "flathub", spotify.Origin)
+	assert.Equal(t, "flatpak", spotify.Format)
+	assert.Contains(t, spotify.PUrl, "pkg:flatpak/flathub/com.spotify.Client@1.2.31.564")
+
+	firefox := byName["org.mozilla.firefox"]
+	assert.Equal(t, "131.0", firefox.Version)
+	assert.Equal(t, "flathub", firefox.Origin)
+}
+
+func TestNewFlatpakPurl(t *testing.T) {
+	p := newFlatpakPurl("org.mozilla.firefox", "131.0", "flathub")
+	assert.Equal(t, "pkg:flatpak/flathub/org.mozilla.firefox@131.0", p)
+
+	p = newFlatpakPurl("com.spotify.Client", "1.2.31.564", "")
+	assert.Equal(t, "pkg:flatpak/com.spotify.Client@1.2.31.564", p)
+
+	p = newFlatpakPurl("", "1.0", "flathub")
+	assert.Equal(t, "", p)
+}

--- a/providers/os/resources/packages/packages.go
+++ b/providers/os/resources/packages/packages.go
@@ -160,6 +160,23 @@ func ResolveSystemPkgManagers(conn shared.Connection) ([]OperatingSystemPkgManag
 		}
 	}
 
+	// Flatpak is cross-distro — check for its presence on any Linux platform.
+	if asset.Platform.IsFamily("linux") {
+		hasFlatpak := false
+		if _, err := conn.FileSystem().Stat("/var/lib/flatpak"); err == nil {
+			hasFlatpak = true
+		}
+		if !hasFlatpak && conn.Capabilities().Has(shared.Capability_RunCommand) {
+			cmd, err := conn.RunCommand("which flatpak")
+			if err == nil && cmd.ExitStatus == 0 {
+				hasFlatpak = true
+			}
+		}
+		if hasFlatpak {
+			pms = append(pms, &FlatpakPkgManager{conn: conn, platform: asset.Platform})
+		}
+	}
+
 	if len(pms) == 0 {
 		return nil, errors.New("could not detect suitable package manager for platform: " + asset.Platform.Name)
 	}

--- a/providers/os/resources/packages/testdata/flatpak/app/com.spotify.Client/x86_64/stable/active/metadata
+++ b/providers/os/resources/packages/testdata/flatpak/app/com.spotify.Client/x86_64/stable/active/metadata
@@ -1,0 +1,14 @@
+[Application]
+name=com.spotify.Client
+version=1.2.31.564
+runtime=org.freedesktop.Platform/x86_64/23.08
+sdk=org.freedesktop.Sdk/x86_64/23.08
+origin=flathub
+
+[Context]
+shared=ipc;network;
+sockets=x11;wayland;pulseaudio;
+
+[Extension com.spotify.Client.Locale]
+directory=share/runtime/locale
+autodelete=true

--- a/providers/os/resources/packages/testdata/flatpak/app/org.mozilla.firefox/x86_64/stable/active/metadata
+++ b/providers/os/resources/packages/testdata/flatpak/app/org.mozilla.firefox/x86_64/stable/active/metadata
@@ -1,0 +1,5 @@
+[Application]
+name=org.mozilla.firefox
+version=131.0
+runtime=org.freedesktop.Platform/x86_64/23.08
+origin=flathub

--- a/providers/os/resources/packages/testdata/flatpak_list.txt
+++ b/providers/os/resources/packages/testdata/flatpak_list.txt
@@ -1,0 +1,5 @@
+com.spotify.Client	1.2.31.564	flathub	x86_64
+org.mozilla.firefox	131.0	flathub	x86_64
+org.gimp.GIMP	2.10.38	flathub	x86_64
+org.libreoffice.LibreOffice	24.8.2	flathub	x86_64
+com.visualstudio.code	1.94.0	flathub	x86_64


### PR DESCRIPTION
## Summary

- Add `FlatpakPkgManager` that enumerates installed Flatpak applications on any Linux distribution
- **CLI primary**: `flatpak list --app --columns=application,version,origin,arch` (tab-delimited output)
- **Filesystem fallback**: Parse `/var/lib/flatpak/app/APP_ID/ARCH/BRANCH/active/metadata` for offline/image scanning
- **PURL**: `pkg:flatpak/origin/app-id@version` (e.g., `pkg:flatpak/flathub/org.mozilla.firefox@131.0`)
- **Auto-detection**: Registered on any Linux platform where `/var/lib/flatpak` exists (cross-distro)
- 3 unit tests covering CLI parsing, filesystem parsing, and PURL generation

### Example output

```
com.spotify.Client     1.2.31.564  pkg:flatpak/flathub/com.spotify.Client@1.2.31.564
org.mozilla.firefox    131.0       pkg:flatpak/flathub/org.mozilla.firefox@131.0
org.gimp.GIMP          2.10.38     pkg:flatpak/flathub/org.gimp.GIMP@2.10.38
```

## Test plan

- [x] CLI output parsing (tab-delimited, 4 columns)
- [x] Filesystem fallback (metadata INI parsing for origin + version)
- [x] PURL generation (with/without origin, empty app ID)
- [ ] Interactive test on a system with Flatpak installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)