### PR TITLE
✨ Add R (CRAN) SBOM cataloger via renv.lock

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -108,6 +108,7 @@ cowlib
 cpe
 CPWn
 cpx
+cran
 crowdstrike
 cryptokey
 ctx
@@ -450,6 +451,7 @@ recaptcha
 regexmatchstatement
 regexpatternsetreferencestatement
 rehydration
+renv
 replicators
 resourcegroup
 resourcepolicy

--- a/providers/os/resources/languages/r/r.go
+++ b/providers/os/resources/languages/r/r.go
@@ -1,0 +1,29 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package r
+
+import (
+	"github.com/package-url/packageurl-go"
+	"go.mondoo.com/mql/v13/sbom"
+)
+
+// NewPackageUrl creates a CRAN package URL.
+// Format: pkg:cran/name@version
+func NewPackageUrl(name string, version string) string {
+	return packageurl.NewPackageURL(
+		"cran",
+		"",
+		name,
+		version,
+		nil,
+		"").String()
+}
+
+// NewEvidence creates a file evidence entry.
+func NewEvidence(path string) *sbom.Evidence {
+	return &sbom.Evidence{
+		Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
+		Value: path,
+	}
+}

--- a/providers/os/resources/languages/r/renvlock/renvlock.go
+++ b/providers/os/resources/languages/r/renvlock/renvlock.go
@@ -1,0 +1,98 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package renvlock
+
+import (
+	"encoding/json"
+	"io"
+	"slices"
+
+	"go.mondoo.com/mql/v13/providers/os/resources/languages"
+	rlang "go.mondoo.com/mql/v13/providers/os/resources/languages/r"
+	"go.mondoo.com/mql/v13/sbom"
+)
+
+// renvLockfile represents the structure of an renv.lock file.
+type renvLockfile struct {
+	R        renvR                  `json:"R"`
+	Packages map[string]renvPackage `json:"Packages"`
+}
+
+type renvR struct {
+	Version string `json:"Version"`
+}
+
+type renvPackage struct {
+	Package    string `json:"Package"`
+	Version    string `json:"Version"`
+	Source     string `json:"Source"`
+	Repository string `json:"Repository"`
+}
+
+// Extractor parses renv.lock files.
+type Extractor struct{}
+
+func (e *Extractor) Name() string {
+	return "R renv.lock Extractor"
+}
+
+func (e *Extractor) Parse(r io.Reader, filename string) (languages.Bom, error) {
+	var lockfile renvLockfile
+	if err := json.NewDecoder(r).Decode(&lockfile); err != nil {
+		return nil, err
+	}
+
+	bom := &renvBom{
+		transitive: make(languages.Packages, 0, len(lockfile.Packages)),
+	}
+
+	for _, pkg := range lockfile.Packages {
+		if pkg.Package == "" {
+			continue
+		}
+
+		bom.transitive = append(bom.transitive, &languages.Package{
+			Name:    pkg.Package,
+			Version: pkg.Version,
+			Purl:    rlang.NewPackageUrl(pkg.Package, pkg.Version),
+			EvidenceList: []*sbom.Evidence{
+				rlang.NewEvidence(filename),
+			},
+		})
+	}
+
+	slices.SortFunc(bom.transitive, func(a, b *languages.Package) int {
+		if a.Name != b.Name {
+			if a.Name < b.Name {
+				return -1
+			}
+			return 1
+		}
+		if a.Version < b.Version {
+			return -1
+		}
+		if a.Version > b.Version {
+			return 1
+		}
+		return 0
+	})
+
+	return bom, nil
+}
+
+type renvBom struct {
+	transitive languages.Packages
+}
+
+func (b *renvBom) Root() *languages.Package {
+	return nil
+}
+
+func (b *renvBom) Direct() languages.Packages {
+	return nil
+}
+
+func (b *renvBom) Transitive() languages.Packages {
+	return b.transitive
+}

--- a/providers/os/resources/languages/r/renvlock/renvlock_test.go
+++ b/providers/os/resources/languages/r/renvlock/renvlock_test.go
@@ -1,0 +1,44 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package renvlock
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRenvLock(t *testing.T) {
+	f, err := os.Open("testdata/renv.lock")
+	require.NoError(t, err)
+	defer f.Close()
+
+	extractor := &Extractor{}
+	bom, err := extractor.Parse(f, "testdata/renv.lock")
+	require.NoError(t, err)
+
+	pkgs := bom.Transitive()
+	require.Len(t, pkgs, 4)
+
+	byName := map[string]string{}
+	for _, p := range pkgs {
+		byName[p.Name] = p.Version
+	}
+
+	assert.Equal(t, "1.1.4", byName["dplyr"])
+	assert.Equal(t, "3.5.0", byName["ggplot2"])
+	assert.Equal(t, "1.3.1", byName["tidyr"])
+	assert.Equal(t, "1.5.1", byName["stringr"])
+
+	// Check PURL
+	dplyr := pkgs.Find("dplyr")
+	require.NotNil(t, dplyr)
+	assert.Equal(t, "pkg:cran/dplyr@1.1.4", dplyr.Purl)
+
+	// Check evidence
+	assert.Len(t, dplyr.EvidenceList, 1)
+	assert.Equal(t, "testdata/renv.lock", dplyr.EvidenceList[0].Value)
+}

--- a/providers/os/resources/languages/r/renvlock/testdata/renv.lock
+++ b/providers/os/resources/languages/r/renvlock/testdata/renv.lock
@@ -1,0 +1,37 @@
+{
+  "R": {
+    "Version": "4.3.2",
+    "Repositories": [
+      {
+        "Name": "CRAN",
+        "URL": "https://cloud.r-project.org"
+      }
+    ]
+  },
+  "Packages": {
+    "dplyr": {
+      "Package": "dplyr",
+      "Version": "1.1.4",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "ggplot2": {
+      "Package": "ggplot2",
+      "Version": "3.5.0",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "tidyr": {
+      "Package": "tidyr",
+      "Version": "1.3.1",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "stringr": {
+      "Package": "stringr",
+      "Version": "1.5.1",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    }
+  }
+}

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -2952,6 +2952,33 @@ private julia.package @defaults("name version purl") {
   files() []pkgFileInfo
 }
 
+// R packages (renv.lock)
+r.packages {
+  []r.package
+
+  init(path? string)
+
+  // Path to search for renv.lock
+  path string
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// R package dependency
+private r.package @defaults("name version purl") {
+  // ID is the r.package unique identifier
+  id string
+  // Package name
+  name() string
+  // Package version
+  version() string
+  // Package URL
+  purl() string
+  // Package files
+  files() []pkgFileInfo
+}
+
 // macOS specific resources
 macos {
   // macOS computer name

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -224,6 +224,8 @@ const (
 	ResourceCondaPackage                 string = "conda.package"
 	ResourceJuliaPackages                string = "julia.packages"
 	ResourceJuliaPackage                 string = "julia.package"
+	ResourceRPackages                    string = "r.packages"
+	ResourceRPackage                     string = "r.package"
 	ResourceMacos                        string = "macos"
 	ResourceMacosHardware                string = "macos.hardware"
 	ResourceMacosAlf                     string = "macos.alf"
@@ -1181,6 +1183,14 @@ func init() {
 		"julia.package": {
 			// to override args, implement: initJuliaPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createJuliaPackage,
+		},
+		"r.packages": {
+			Init:   initRPackages,
+			Create: createRPackages,
+		},
+		"r.package": {
+			// to override args, implement: initRPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createRPackage,
 		},
 		"macos": {
 			// to override args, implement: initMacos(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -4744,6 +4754,30 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"julia.package.files": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlJuliaPackage).GetFiles()).ToDataRes(types.Array(types.Resource("pkgFileInfo")))
+	},
+	"r.packages.path": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlRPackages).GetPath()).ToDataRes(types.String)
+	},
+	"r.packages.files": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlRPackages).GetFiles()).ToDataRes(types.Array(types.Resource("pkgFileInfo")))
+	},
+	"r.packages.list": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlRPackages).GetList()).ToDataRes(types.Array(types.Resource("r.package")))
+	},
+	"r.package.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlRPackage).GetId()).ToDataRes(types.String)
+	},
+	"r.package.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlRPackage).GetName()).ToDataRes(types.String)
+	},
+	"r.package.version": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlRPackage).GetVersion()).ToDataRes(types.String)
+	},
+	"r.package.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlRPackage).GetPurl()).ToDataRes(types.String)
+	},
+	"r.package.files": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlRPackage).GetFiles()).ToDataRes(types.Array(types.Resource("pkgFileInfo")))
 	},
 	"macos.computerName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMacos).GetComputerName()).ToDataRes(types.String)
@@ -11772,6 +11806,46 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"julia.package.files": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlJuliaPackage).Files, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"r.packages.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlRPackages).__id, ok = v.Value.(string)
+		return
+	},
+	"r.packages.path": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlRPackages).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"r.packages.files": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlRPackages).Files, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"r.packages.list": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlRPackages).List, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"r.package.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlRPackage).__id, ok = v.Value.(string)
+		return
+	},
+	"r.package.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlRPackage).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"r.package.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlRPackage).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"r.package.version": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlRPackage).Version, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"r.package.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlRPackage).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"r.package.files": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlRPackage).Files, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"macos.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -32504,6 +32578,176 @@ func (c *mqlJuliaPackage) GetFiles() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Files, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
 			d, err := c.MqlRuntime.FieldResourceFromRecording("julia.package", c.__id, "files")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.files()
+	})
+}
+
+// mqlRPackages for the r.packages resource
+type mqlRPackages struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlRPackagesInternal
+	Path  plugin.TValue[string]
+	Files plugin.TValue[[]any]
+	List  plugin.TValue[[]any]
+}
+
+// createRPackages creates a new instance of this resource
+func createRPackages(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlRPackages{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("r.packages", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlRPackages) MqlName() string {
+	return "r.packages"
+}
+
+func (c *mqlRPackages) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlRPackages) GetPath() *plugin.TValue[string] {
+	return &c.Path
+}
+
+func (c *mqlRPackages) GetFiles() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Files, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("r.packages", c.__id, "files")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.files()
+	})
+}
+
+func (c *mqlRPackages) GetList() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.List, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("r.packages", c.__id, "list")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.list()
+	})
+}
+
+// mqlRPackage for the r.package resource
+type mqlRPackage struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlRPackageInternal it will be used here
+	Id      plugin.TValue[string]
+	Name    plugin.TValue[string]
+	Version plugin.TValue[string]
+	Purl    plugin.TValue[string]
+	Files   plugin.TValue[[]any]
+}
+
+// createRPackage creates a new instance of this resource
+func createRPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlRPackage{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("r.package", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlRPackage) MqlName() string {
+	return "r.package"
+}
+
+func (c *mqlRPackage) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlRPackage) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlRPackage) GetName() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Name, func() (string, error) {
+		return c.name()
+	})
+}
+
+func (c *mqlRPackage) GetVersion() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Version, func() (string, error) {
+		return c.version()
+	})
+}
+
+func (c *mqlRPackage) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
+	})
+}
+
+func (c *mqlRPackage) GetFiles() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Files, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("r.package", c.__id, "files")
 			if err != nil {
 				return nil, err
 			}

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -1512,6 +1512,16 @@ qwen.code.skill.name 13.13.1
 qwen.code.skill.sha256 13.13.1
 qwen.code.skill.source 13.13.1
 qwen.code.skills 13.13.1
+r.package 13.15.2
+r.package.files 13.15.2
+r.package.id 13.15.2
+r.package.name 13.15.2
+r.package.purl 13.15.2
+r.package.version 13.15.2
+r.packages 13.15.2
+r.packages.files 13.15.2
+r.packages.list 13.15.2
+r.packages.path 13.15.2
 registrykey 9.0.1
 registrykey.children 9.0.1
 registrykey.exists 9.0.1

--- a/providers/os/resources/r.go
+++ b/providers/os/resources/r.go
@@ -1,0 +1,235 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages/r/renvlock"
+	"go.mondoo.com/mql/v13/types"
+)
+
+var defaultRPaths = []string{
+	"/app",
+	"/usr/src/app",
+	"/home/*/app",
+	"/home/*",
+}
+
+func initRPackages(_ *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if x, ok := args["path"]; ok {
+		_, ok := x.Value.(string)
+		if !ok {
+			return nil, nil, errors.New("wrong type for 'path' in r.packages initialization, it must be a string")
+		}
+	} else {
+		args["path"] = llx.StringData("")
+	}
+	return args, nil, nil
+}
+
+func (r *mqlRPackages) id() (string, error) {
+	if r.Path.Data != "" {
+		return "r.packages/" + r.Path.Data, nil
+	}
+	return "r.packages", nil
+}
+
+type mqlRPackagesInternal struct {
+	mutex   sync.Mutex
+	fetched bool
+}
+
+func (r *mqlRPackages) gatherData() error {
+	if r.fetched {
+		return nil
+	}
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if r.fetched {
+		return nil
+	}
+
+	conn := r.MqlRuntime.Connection.(shared.Connection)
+	fs := conn.FileSystem()
+	afs := &afero.Afero{Fs: fs}
+
+	searchPath := r.Path.Data
+
+	var transitiveDeps []*languages.Package
+	var filePaths []string
+
+	if searchPath != "" {
+		t, f := collectRPackages(afs, fs, searchPath)
+		transitiveDeps = append(transitiveDeps, t...)
+		filePaths = append(filePaths, f...)
+	} else {
+		for _, sp := range defaultRPaths {
+			matches, err := afero.Glob(fs, sp)
+			if err != nil {
+				continue
+			}
+			if len(matches) == 0 {
+				if strings.ContainsAny(sp, "*?[") {
+					continue
+				}
+				matches = []string{sp}
+			}
+			for _, match := range matches {
+				t, f := collectRPackages(afs, fs, match)
+				transitiveDeps = append(transitiveDeps, t...)
+				filePaths = append(filePaths, f...)
+			}
+		}
+	}
+
+	slices.SortFunc(transitiveDeps, languages.SortFn)
+
+	allResources, err := newRPackageList(r.MqlRuntime, transitiveDeps)
+	if err != nil {
+		return err
+	}
+	r.List = plugin.TValue[[]any]{Data: allResources, State: plugin.StateIsSet}
+
+	mqlFiles := []any{}
+	for _, p := range filePaths {
+		lf, err := CreateResource(r.MqlRuntime, "pkgFileInfo", map[string]*llx.RawData{
+			"path": llx.StringData(p),
+		})
+		if err != nil {
+			return err
+		}
+		mqlFiles = append(mqlFiles, lf)
+	}
+	r.Files = plugin.TValue[[]any]{Data: mqlFiles, State: plugin.StateIsSet}
+
+	r.fetched = true
+	return nil
+}
+
+func collectRPackages(afs *afero.Afero, fs afero.Fs, path string) ([]*languages.Package, []string) {
+	isDir, err := afs.IsDir(path)
+	if err != nil {
+		log.Debug().Err(err).Str("path", path).Msg("could not check R path")
+		return nil, nil
+	}
+
+	if isDir {
+		renvPath := filepath.Join(path, "renv.lock")
+		if exists, _ := afs.Exists(renvPath); exists {
+			return collectRFromFile(afs, renvPath, &renvlock.Extractor{})
+		}
+		return nil, nil
+	}
+
+	if strings.HasSuffix(path, "renv.lock") {
+		return collectRFromFile(afs, path, &renvlock.Extractor{})
+	}
+
+	return nil, nil
+}
+
+func collectRFromFile(afs *afero.Afero, path string, extractor languages.Extractor) ([]*languages.Package, []string) {
+	f, err := afs.Open(path)
+	if err != nil {
+		log.Debug().Err(err).Str("path", path).Msg("could not open R file")
+		return nil, nil
+	}
+	defer f.Close()
+
+	bom, err := extractor.Parse(f, path)
+	if err != nil {
+		log.Debug().Err(err).Str("path", path).Msg("could not parse R file")
+		return nil, nil
+	}
+
+	return bom.Transitive(), []string{path}
+}
+
+func (r *mqlRPackages) list() ([]any, error) {
+	return nil, r.gatherData()
+}
+
+func (r *mqlRPackages) files() ([]any, error) {
+	return nil, r.gatherData()
+}
+
+func newRPackageList(runtime *plugin.Runtime, packages []*languages.Package) ([]any, error) {
+	resources := []any{}
+	for i := range packages {
+		pkg, err := newRPackage(runtime, packages[i])
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, pkg)
+	}
+	return resources, nil
+}
+
+func newRPackage(runtime *plugin.Runtime, pkg *languages.Package) (*mqlRPackage, error) {
+	mqlFiles := []any{}
+	for i := range pkg.EvidenceList {
+		evidence := pkg.EvidenceList[i]
+		lf, err := CreateResource(runtime, "pkgFileInfo", map[string]*llx.RawData{
+			"path": llx.StringData(evidence.Value),
+		})
+		if err != nil {
+			return nil, err
+		}
+		mqlFiles = append(mqlFiles, lf)
+	}
+
+	path := ""
+	if len(mqlFiles) > 0 {
+		if fi, ok := mqlFiles[0].(*mqlPkgFileInfo); ok {
+			path = fi.Path.Data
+		}
+	}
+
+	mqlPkg, err := CreateResource(runtime, "r.package", map[string]*llx.RawData{
+		"id":      llx.StringData(pkg.Name + "@" + pkg.Version + ":" + path),
+		"name":    llx.StringData(pkg.Name),
+		"version": llx.StringData(pkg.Version),
+		"purl":    llx.StringData(pkg.Purl),
+		"files":   llx.ArrayData(mqlFiles, types.Resource("pkgFileInfo")),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return mqlPkg.(*mqlRPackage), nil
+}
+
+func (k *mqlRPackage) id() (string, error) {
+	return k.Id.Data, nil
+}
+
+func (r *mqlRPackage) name() (string, error) {
+	return "", r.populateData()
+}
+
+func (r *mqlRPackage) version() (string, error) {
+	return "", r.populateData()
+}
+
+func (r *mqlRPackage) purl() (string, error) {
+	return "", r.populateData()
+}
+
+func (r *mqlRPackage) files() ([]any, error) {
+	return nil, r.populateData()
+}
+
+func (r *mqlRPackage) populateData() error {
+	return errors.New("r.package can only be created via r.packages")
+}

--- a/sbom/generator/generator.go
+++ b/sbom/generator/generator.go
@@ -517,6 +517,25 @@ func GenerateBom(r *reporter.Report) []*sbom.Sbom {
 
 				bom.Packages = append(bom.Packages, bomPkg)
 			}
+
+			for _, pkg := range rb.RPackages {
+				bomPkg := &sbom.Package{
+					Name:    pkg.Name,
+					Version: pkg.Version,
+					Purl:    pkg.Purl,
+					Cpes:    pkg.CPEs,
+					Type:    "cran",
+				}
+
+				for _, filepath := range pkg.FilePaths {
+					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
+						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
+						Value: filepath,
+					})
+				}
+
+				bom.Packages = append(bom.Packages, bomPkg)
+			}
 		}
 		boms = append(boms, bom)
 	}

--- a/sbom/generator/report_collection.go
+++ b/sbom/generator/report_collection.go
@@ -69,6 +69,7 @@ type BomFields struct {
 	PrologPackages        []BomPackage      `json:"prolog.packages.list,omitempty"`
 	JuliaPackages         []BomPackage      `json:"julia.packages.list,omitempty"`
 	CondaPackages         []BomPackage      `json:"conda.packages.list,omitempty"`
+	RPackages             []BomPackage      `json:"r.packages.list,omitempty"`
 	KernelInstalled       []KernelInstalled `json:"kernel.installed,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

- Add `r.packages` and `r.package` MQL resources for R package dependency tracking
- Parses `renv.lock` (R project lockfile, JSON format) to extract package names and versions
- **PURL**: `pkg:cran/name@version` (e.g., `pkg:cran/dplyr@1.1.4`)
- Searches default paths (`/app`, `/usr/src/app`, `/home/*/app`, `/home/*`)
- Supports explicit path: `r.packages(path: "/path/to/project")`
- SBOM generator integration with `cran` package type

### New files

| File | Purpose |
|------|---------|
| `providers/os/resources/r.go` | MQL resource wiring (init, gatherData, list, files) |
| `providers/os/resources/languages/r/r.go` | PURL + evidence helpers |
| `providers/os/resources/languages/r/renvlock/renvlock.go` | renv.lock JSON parser |
| `providers/os/resources/languages/r/renvlock/renvlock_test.go` | Unit test with fixture |

### Usage

```bash
mql run os -c "r.packages { list { name version purl } }"
mql run os -c "r.packages(path: '/home/analyst/project') { list { name version } }"
```

## Test plan

- [x] renv.lock parsing with 4 packages (dplyr, ggplot2, tidyr, stringr)
- [x] PURL generation (`pkg:cran/dplyr@1.1.4`)
- [x] Evidence tracking (lockfile path)
- [ ] Interactive test with R project containing renv.lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)