### PR TITLE
✨ Add Julia SBOM cataloger via Manifest.toml

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -220,6 +220,7 @@ jkl
 jpi
 jre
 jsonbody
+julia
 junie
 junos
 jupyter
@@ -457,6 +458,7 @@ timestream
 tokenauth
 tokenid
 tokio
+toml
 toplevel
 toport
 tpl

--- a/providers/os/resources/julia.go
+++ b/providers/os/resources/julia.go
@@ -24,7 +24,7 @@ var defaultJuliaPaths = []string{
 	"/app",
 	"/usr/src/app",
 	"/home/*/app",
-	"/home/*",
+	"/home/*/.julia/environments/v*",
 }
 
 func initJuliaPackages(_ *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/os/resources/julia.go
+++ b/providers/os/resources/julia.go
@@ -1,0 +1,236 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages/julia/manifest"
+	"go.mondoo.com/mql/v13/types"
+)
+
+var defaultJuliaPaths = []string{
+	"/app",
+	"/usr/src/app",
+	"/home/*/app",
+	"/home/*",
+}
+
+func initJuliaPackages(_ *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if x, ok := args["path"]; ok {
+		_, ok := x.Value.(string)
+		if !ok {
+			return nil, nil, errors.New("wrong type for 'path' in julia.packages initialization, it must be a string")
+		}
+	} else {
+		args["path"] = llx.StringData("")
+	}
+	return args, nil, nil
+}
+
+func (r *mqlJuliaPackages) id() (string, error) {
+	if r.Path.Data != "" {
+		return "julia.packages/" + r.Path.Data, nil
+	}
+	return "julia.packages", nil
+}
+
+type mqlJuliaPackagesInternal struct {
+	mutex   sync.Mutex
+	fetched bool
+}
+
+func (r *mqlJuliaPackages) gatherData() error {
+	if r.fetched {
+		return nil
+	}
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if r.fetched {
+		return nil
+	}
+
+	conn := r.MqlRuntime.Connection.(shared.Connection)
+	fs := conn.FileSystem()
+	afs := &afero.Afero{Fs: fs}
+
+	searchPath := r.Path.Data
+
+	var transitiveDeps []*languages.Package
+	var filePaths []string
+
+	if searchPath != "" {
+		t, f := collectJuliaPackages(afs, fs, searchPath)
+		transitiveDeps = append(transitiveDeps, t...)
+		filePaths = append(filePaths, f...)
+	} else {
+		for _, sp := range defaultJuliaPaths {
+			matches, err := afero.Glob(fs, sp)
+			if err != nil {
+				continue
+			}
+			if len(matches) == 0 {
+				if strings.ContainsAny(sp, "*?[") {
+					continue
+				}
+				matches = []string{sp}
+			}
+			for _, match := range matches {
+				t, f := collectJuliaPackages(afs, fs, match)
+				transitiveDeps = append(transitiveDeps, t...)
+				filePaths = append(filePaths, f...)
+			}
+		}
+	}
+
+	slices.SortFunc(transitiveDeps, languages.SortFn)
+
+	allResources, err := newJuliaPackageList(r.MqlRuntime, transitiveDeps)
+	if err != nil {
+		return err
+	}
+	r.List = plugin.TValue[[]any]{Data: allResources, State: plugin.StateIsSet}
+
+	mqlFiles := []any{}
+	for _, p := range filePaths {
+		lf, err := CreateResource(r.MqlRuntime, "pkgFileInfo", map[string]*llx.RawData{
+			"path": llx.StringData(p),
+		})
+		if err != nil {
+			return err
+		}
+		mqlFiles = append(mqlFiles, lf)
+	}
+	r.Files = plugin.TValue[[]any]{Data: mqlFiles, State: plugin.StateIsSet}
+
+	r.fetched = true
+	return nil
+}
+
+func collectJuliaPackages(afs *afero.Afero, fs afero.Fs, path string) ([]*languages.Package, []string) {
+	isDir, err := afs.IsDir(path)
+	if err != nil {
+		log.Debug().Err(err).Str("path", path).Msg("could not check Julia path")
+		return nil, nil
+	}
+
+	if isDir {
+		manifestPath := filepath.Join(path, "Manifest.toml")
+		if exists, _ := afs.Exists(manifestPath); exists {
+			return collectJuliaFromFile(afs, manifestPath)
+		}
+		return nil, nil
+	}
+
+	if strings.HasSuffix(path, "Manifest.toml") {
+		return collectJuliaFromFile(afs, path)
+	}
+
+	return nil, nil
+}
+
+func collectJuliaFromFile(afs *afero.Afero, path string) ([]*languages.Package, []string) {
+	f, err := afs.Open(path)
+	if err != nil {
+		log.Debug().Err(err).Str("path", path).Msg("could not open Julia Manifest.toml")
+		return nil, nil
+	}
+	defer f.Close()
+
+	extractor := &manifest.Extractor{}
+	bom, err := extractor.Parse(f, path)
+	if err != nil {
+		log.Debug().Err(err).Str("path", path).Msg("could not parse Julia Manifest.toml")
+		return nil, nil
+	}
+
+	return bom.Transitive(), []string{path}
+}
+
+func (r *mqlJuliaPackages) list() ([]any, error) {
+	return nil, r.gatherData()
+}
+
+func (r *mqlJuliaPackages) files() ([]any, error) {
+	return nil, r.gatherData()
+}
+
+func newJuliaPackageList(runtime *plugin.Runtime, packages []*languages.Package) ([]any, error) {
+	resources := []any{}
+	for i := range packages {
+		pkg, err := newJuliaPackage(runtime, packages[i])
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, pkg)
+	}
+	return resources, nil
+}
+
+func newJuliaPackage(runtime *plugin.Runtime, pkg *languages.Package) (*mqlJuliaPackage, error) {
+	mqlFiles := []any{}
+	for i := range pkg.EvidenceList {
+		evidence := pkg.EvidenceList[i]
+		lf, err := CreateResource(runtime, "pkgFileInfo", map[string]*llx.RawData{
+			"path": llx.StringData(evidence.Value),
+		})
+		if err != nil {
+			return nil, err
+		}
+		mqlFiles = append(mqlFiles, lf)
+	}
+
+	path := ""
+	if len(mqlFiles) > 0 {
+		if fi, ok := mqlFiles[0].(*mqlPkgFileInfo); ok {
+			path = fi.Path.Data
+		}
+	}
+
+	mqlPkg, err := CreateResource(runtime, "julia.package", map[string]*llx.RawData{
+		"id":      llx.StringData(pkg.Name + "@" + pkg.Version + ":" + path),
+		"name":    llx.StringData(pkg.Name),
+		"version": llx.StringData(pkg.Version),
+		"purl":    llx.StringData(pkg.Purl),
+		"files":   llx.ArrayData(mqlFiles, types.Resource("pkgFileInfo")),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return mqlPkg.(*mqlJuliaPackage), nil
+}
+
+func (k *mqlJuliaPackage) id() (string, error) {
+	return k.Id.Data, nil
+}
+
+func (r *mqlJuliaPackage) name() (string, error) {
+	return "", r.populateData()
+}
+
+func (r *mqlJuliaPackage) version() (string, error) {
+	return "", r.populateData()
+}
+
+func (r *mqlJuliaPackage) purl() (string, error) {
+	return "", r.populateData()
+}
+
+func (r *mqlJuliaPackage) files() ([]any, error) {
+	return nil, r.populateData()
+}
+
+func (r *mqlJuliaPackage) populateData() error {
+	return errors.New("julia.package can only be created via julia.packages")
+}

--- a/providers/os/resources/languages/julia/julia.go
+++ b/providers/os/resources/languages/julia/julia.go
@@ -1,0 +1,29 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package julia
+
+import (
+	"github.com/package-url/packageurl-go"
+	"go.mondoo.com/mql/v13/sbom"
+)
+
+// NewPackageUrl creates a Julia package URL.
+// Format: pkg:julia/name@version
+func NewPackageUrl(name string, version string) string {
+	return packageurl.NewPackageURL(
+		"julia",
+		"",
+		name,
+		version,
+		nil,
+		"").String()
+}
+
+// NewEvidence creates a file evidence entry.
+func NewEvidence(path string) *sbom.Evidence {
+	return &sbom.Evidence{
+		Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
+		Value: path,
+	}
+}

--- a/providers/os/resources/languages/julia/manifest/manifest.go
+++ b/providers/os/resources/languages/julia/manifest/manifest.go
@@ -1,0 +1,145 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package manifest
+
+import (
+	"io"
+
+	"github.com/BurntSushi/toml"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages"
+	julialang "go.mondoo.com/mql/v13/providers/os/resources/languages/julia"
+	"go.mondoo.com/mql/v13/sbom"
+)
+
+// Extractor parses Julia Manifest.toml files.
+type Extractor struct{}
+
+func (e *Extractor) Name() string {
+	return "Julia Manifest.toml Extractor"
+}
+
+func (e *Extractor) Parse(r io.Reader, filename string) (languages.Bom, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Try v2 format first (Julia >= 1.7), then v1
+	pkgs, err := parseManifestV2(data, filename)
+	if err != nil || len(pkgs) == 0 {
+		pkgs, err = parseManifestV1(data, filename)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &manifestBom{transitive: pkgs}, nil
+}
+
+// manifestV2 represents the Manifest.toml v2 format (Julia >= 1.7).
+// Structure:
+//
+//	julia_version = "1.9.0"
+//	manifest_format = "2.0"
+//	[deps]
+//	[deps.HTTP]
+//	  [[deps.HTTP]]
+//	  uuid = "..."
+//	  version = "1.10.1"
+type manifestV2 struct {
+	ManifestFormat string                         `toml:"manifest_format"`
+	Deps           map[string][]manifestV2Package `toml:"deps"`
+}
+
+type manifestV2Package struct {
+	UUID    string `toml:"uuid"`
+	Version string `toml:"version"`
+}
+
+func parseManifestV2(data []byte, filename string) (languages.Packages, error) {
+	var m manifestV2
+	if err := toml.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+
+	if m.ManifestFormat == "" || m.Deps == nil {
+		return nil, nil
+	}
+
+	var pkgs languages.Packages
+	for name, entries := range m.Deps {
+		for _, entry := range entries {
+			if entry.Version == "" {
+				continue
+			}
+			pkgs = append(pkgs, &languages.Package{
+				Name:    name,
+				Version: entry.Version,
+				Purl:    julialang.NewPackageUrl(name, entry.Version),
+				EvidenceList: []*sbom.Evidence{
+					julialang.NewEvidence(filename),
+				},
+			})
+		}
+	}
+
+	return pkgs, nil
+}
+
+// manifestV1 represents the Manifest.toml v1 format (Julia < 1.7).
+// Structure:
+//
+//	[[HTTP]]
+//	uuid = "..."
+//	version = "1.10.1"
+type manifestV1Package struct {
+	UUID    string `toml:"uuid"`
+	Version string `toml:"version"`
+}
+
+func parseManifestV1(data []byte, filename string) (languages.Packages, error) {
+	var raw map[string][]manifestV1Package
+	if err := toml.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+
+	var pkgs languages.Packages
+	for name, entries := range raw {
+		// Skip metadata keys
+		if name == "julia_version" || name == "manifest_format" {
+			continue
+		}
+		for _, entry := range entries {
+			if entry.Version == "" {
+				continue
+			}
+			pkgs = append(pkgs, &languages.Package{
+				Name:    name,
+				Version: entry.Version,
+				Purl:    julialang.NewPackageUrl(name, entry.Version),
+				EvidenceList: []*sbom.Evidence{
+					julialang.NewEvidence(filename),
+				},
+			})
+		}
+	}
+
+	return pkgs, nil
+}
+
+type manifestBom struct {
+	transitive languages.Packages
+}
+
+func (b *manifestBom) Root() *languages.Package {
+	return nil
+}
+
+func (b *manifestBom) Direct() languages.Packages {
+	return nil
+}
+
+func (b *manifestBom) Transitive() languages.Packages {
+	return b.transitive
+}

--- a/providers/os/resources/languages/julia/manifest/manifest.go
+++ b/providers/os/resources/languages/julia/manifest/manifest.go
@@ -4,6 +4,7 @@
 package manifest
 
 import (
+	"errors"
 	"io"
 
 	"github.com/BurntSushi/toml"
@@ -25,13 +26,15 @@ func (e *Extractor) Parse(r io.Reader, filename string) (languages.Bom, error) {
 		return nil, err
 	}
 
-	// Try v2 format first (Julia >= 1.7), then v1
-	pkgs, err := parseManifestV2(data, filename)
-	if err != nil || len(pkgs) == 0 {
-		pkgs, err = parseManifestV1(data, filename)
-		if err != nil {
-			return nil, err
-		}
+	// Try v2 format first (Julia >= 1.7), then fall back to v1
+	pkgs, errV2 := parseManifestV2(data, filename)
+	if errV2 == nil && len(pkgs) > 0 {
+		return &manifestBom{transitive: pkgs}, nil
+	}
+
+	pkgs, errV1 := parseManifestV1(data, filename)
+	if errV1 != nil {
+		return nil, errors.Join(errV2, errV1)
 	}
 
 	return &manifestBom{transitive: pkgs}, nil
@@ -106,7 +109,9 @@ func parseManifestV1(data []byte, filename string) (languages.Packages, error) {
 
 	var pkgs languages.Packages
 	for name, entries := range raw {
-		// Skip metadata keys
+		// Defensive guard: skip v2-only metadata keys. In practice these
+		// are scalar strings that would fail TOML unmarshalling into
+		// []manifestV1Package, but we guard against it explicitly.
 		if name == "julia_version" || name == "manifest_format" {
 			continue
 		}

--- a/providers/os/resources/languages/julia/manifest/manifest_test.go
+++ b/providers/os/resources/languages/julia/manifest/manifest_test.go
@@ -1,0 +1,62 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package manifest
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseManifestV2(t *testing.T) {
+	f, err := os.Open("testdata/Manifest_v2.toml")
+	require.NoError(t, err)
+	defer f.Close()
+
+	extractor := &Extractor{}
+	bom, err := extractor.Parse(f, "testdata/Manifest_v2.toml")
+	require.NoError(t, err)
+
+	pkgs := bom.Transitive()
+	require.Len(t, pkgs, 4)
+
+	byName := map[string]string{}
+	for _, p := range pkgs {
+		byName[p.Name] = p.Version
+	}
+
+	assert.Equal(t, "1.10.1", byName["HTTP"])
+	assert.Equal(t, "0.21.4", byName["JSON"])
+	assert.Equal(t, "1.6.1", byName["DataFrames"])
+	assert.Equal(t, "1.40.1", byName["Plots"])
+
+	http := pkgs.Find("HTTP")
+	require.NotNil(t, http)
+	assert.Equal(t, "pkg:julia/HTTP@1.10.1", http.Purl)
+	assert.Len(t, http.EvidenceList, 1)
+}
+
+func TestParseManifestV1(t *testing.T) {
+	f, err := os.Open("testdata/Manifest_v1.toml")
+	require.NoError(t, err)
+	defer f.Close()
+
+	extractor := &Extractor{}
+	bom, err := extractor.Parse(f, "testdata/Manifest_v1.toml")
+	require.NoError(t, err)
+
+	pkgs := bom.Transitive()
+	// Dates has no version, so should be skipped
+	require.Len(t, pkgs, 2)
+
+	byName := map[string]string{}
+	for _, p := range pkgs {
+		byName[p.Name] = p.Version
+	}
+
+	assert.Equal(t, "1.10.1", byName["HTTP"])
+	assert.Equal(t, "0.21.4", byName["JSON"])
+}

--- a/providers/os/resources/languages/julia/manifest/testdata/Manifest_v1.toml
+++ b/providers/os/resources/languages/julia/manifest/testdata/Manifest_v1.toml
@@ -1,0 +1,10 @@
+[[HTTP]]
+uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+version = "1.10.1"
+
+[[JSON]]
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.4"
+
+[[Dates]]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/providers/os/resources/languages/julia/manifest/testdata/Manifest_v2.toml
+++ b/providers/os/resources/languages/julia/manifest/testdata/Manifest_v2.toml
@@ -1,0 +1,20 @@
+julia_version = "1.9.0"
+manifest_format = "2.0"
+
+[deps]
+
+  [[deps.HTTP]]
+  uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+  version = "1.10.1"
+
+  [[deps.JSON]]
+  uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+  version = "0.21.4"
+
+  [[deps.DataFrames]]
+  uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+  version = "1.6.1"
+
+  [[deps.Plots]]
+  uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+  version = "1.40.1"

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -2850,6 +2850,33 @@ private conda.package @defaults("name version purl") {
   files() []pkgFileInfo
 }
 
+// Julia packages (Manifest.toml)
+julia.packages {
+  []julia.package
+
+  init(path? string)
+
+  // Path to search for Manifest.toml
+  path string
+
+  // Files used to determine the packages
+  files() []pkgFileInfo
+}
+
+// Julia package dependency
+private julia.package @defaults("name version purl") {
+  // ID is the julia.package unique identifier
+  id string
+  // Package name
+  name() string
+  // Package version
+  version() string
+  // Package URL
+  purl() string
+  // Package files
+  files() []pkgFileInfo
+}
+
 // macOS specific resources
 macos {
   // macOS computer name

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -217,6 +217,8 @@ const (
 	ResourcePrologPackage                string = "prolog.package"
 	ResourceCondaPackages                string = "conda.packages"
 	ResourceCondaPackage                 string = "conda.package"
+	ResourceJuliaPackages                string = "julia.packages"
+	ResourceJuliaPackage                 string = "julia.package"
 	ResourceMacos                        string = "macos"
 	ResourceMacosHardware                string = "macos.hardware"
 	ResourceMacosAlf                     string = "macos.alf"
@@ -1146,6 +1148,14 @@ func init() {
 		"conda.package": {
 			// to override args, implement: initCondaPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createCondaPackage,
+		},
+		"julia.packages": {
+			Init:   initJuliaPackages,
+			Create: createJuliaPackages,
+		},
+		"julia.package": {
+			// to override args, implement: initJuliaPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createJuliaPackage,
 		},
 		"macos": {
 			// to override args, implement: initMacos(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -4604,6 +4614,30 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"conda.package.files": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCondaPackage).GetFiles()).ToDataRes(types.Array(types.Resource("pkgFileInfo")))
+	},
+	"julia.packages.path": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlJuliaPackages).GetPath()).ToDataRes(types.String)
+	},
+	"julia.packages.files": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlJuliaPackages).GetFiles()).ToDataRes(types.Array(types.Resource("pkgFileInfo")))
+	},
+	"julia.packages.list": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlJuliaPackages).GetList()).ToDataRes(types.Array(types.Resource("julia.package")))
+	},
+	"julia.package.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlJuliaPackage).GetId()).ToDataRes(types.String)
+	},
+	"julia.package.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlJuliaPackage).GetName()).ToDataRes(types.String)
+	},
+	"julia.package.version": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlJuliaPackage).GetVersion()).ToDataRes(types.String)
+	},
+	"julia.package.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlJuliaPackage).GetPurl()).ToDataRes(types.String)
+	},
+	"julia.package.files": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlJuliaPackage).GetFiles()).ToDataRes(types.Array(types.Resource("pkgFileInfo")))
 	},
 	"macos.computerName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMacos).GetComputerName()).ToDataRes(types.String)
@@ -11464,6 +11498,46 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"conda.package.files": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlCondaPackage).Files, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"julia.packages.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlJuliaPackages).__id, ok = v.Value.(string)
+		return
+	},
+	"julia.packages.path": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlJuliaPackages).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"julia.packages.files": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlJuliaPackages).Files, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"julia.packages.list": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlJuliaPackages).List, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"julia.package.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlJuliaPackage).__id, ok = v.Value.(string)
+		return
+	},
+	"julia.package.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlJuliaPackage).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"julia.package.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlJuliaPackage).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"julia.package.version": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlJuliaPackage).Version, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"julia.package.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlJuliaPackage).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"julia.package.files": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlJuliaPackage).Files, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"macos.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31568,6 +31642,176 @@ func (c *mqlCondaPackage) GetFiles() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Files, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
 			d, err := c.MqlRuntime.FieldResourceFromRecording("conda.package", c.__id, "files")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.files()
+	})
+}
+
+// mqlJuliaPackages for the julia.packages resource
+type mqlJuliaPackages struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlJuliaPackagesInternal
+	Path  plugin.TValue[string]
+	Files plugin.TValue[[]any]
+	List  plugin.TValue[[]any]
+}
+
+// createJuliaPackages creates a new instance of this resource
+func createJuliaPackages(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlJuliaPackages{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("julia.packages", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlJuliaPackages) MqlName() string {
+	return "julia.packages"
+}
+
+func (c *mqlJuliaPackages) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlJuliaPackages) GetPath() *plugin.TValue[string] {
+	return &c.Path
+}
+
+func (c *mqlJuliaPackages) GetFiles() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Files, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("julia.packages", c.__id, "files")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.files()
+	})
+}
+
+func (c *mqlJuliaPackages) GetList() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.List, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("julia.packages", c.__id, "list")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.list()
+	})
+}
+
+// mqlJuliaPackage for the julia.package resource
+type mqlJuliaPackage struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlJuliaPackageInternal it will be used here
+	Id      plugin.TValue[string]
+	Name    plugin.TValue[string]
+	Version plugin.TValue[string]
+	Purl    plugin.TValue[string]
+	Files   plugin.TValue[[]any]
+}
+
+// createJuliaPackage creates a new instance of this resource
+func createJuliaPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlJuliaPackage{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("julia.package", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlJuliaPackage) MqlName() string {
+	return "julia.package"
+}
+
+func (c *mqlJuliaPackage) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlJuliaPackage) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlJuliaPackage) GetName() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Name, func() (string, error) {
+		return c.name()
+	})
+}
+
+func (c *mqlJuliaPackage) GetVersion() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Version, func() (string, error) {
+		return c.version()
+	})
+}
+
+func (c *mqlJuliaPackage) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
+	})
+}
+
+func (c *mqlJuliaPackage) GetFiles() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Files, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("julia.package", c.__id, "files")
 			if err != nil {
 				return nil, err
 			}

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -773,6 +773,16 @@ journald.config.section.param.name 11.4.69
 journald.config.section.param.value 11.4.69
 journald.config.section.params 11.4.69
 journald.config.sections 11.4.51
+julia.package 13.13.1
+julia.package.files 13.13.1
+julia.package.id 13.13.1
+julia.package.name 13.13.1
+julia.package.purl 13.13.1
+julia.package.version 13.13.1
+julia.packages 13.13.1
+julia.packages.files 13.13.1
+julia.packages.list 13.13.1
+julia.packages.path 13.13.1
 junie 13.13.1
 junie.configPath 13.13.1
 junie.skill 13.13.1

--- a/sbom/generator/generator.go
+++ b/sbom/generator/generator.go
@@ -480,6 +480,25 @@ func GenerateBom(r *reporter.Report) []*sbom.Sbom {
 				bom.Packages = append(bom.Packages, bomPkg)
 			}
 
+			for _, pkg := range rb.JuliaPackages {
+				bomPkg := &sbom.Package{
+					Name:    pkg.Name,
+					Version: pkg.Version,
+					Purl:    pkg.Purl,
+					Cpes:    pkg.CPEs,
+					Type:    "julia",
+				}
+
+				for _, filepath := range pkg.FilePaths {
+					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
+						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
+						Value: filepath,
+					})
+				}
+
+				bom.Packages = append(bom.Packages, bomPkg)
+			}
+
 			for _, pkg := range rb.CondaPackages {
 				bomPkg := &sbom.Package{
 					Name:    pkg.Name,

--- a/sbom/generator/report_collection.go
+++ b/sbom/generator/report_collection.go
@@ -67,6 +67,7 @@ type BomFields struct {
 	ElixirPackages        []BomPackage      `json:"elixir.packages.list,omitempty"`
 	ErlangPackages        []BomPackage      `json:"erlang.packages.list,omitempty"`
 	PrologPackages        []BomPackage      `json:"prolog.packages.list,omitempty"`
+	JuliaPackages         []BomPackage      `json:"julia.packages.list,omitempty"`
 	CondaPackages         []BomPackage      `json:"conda.packages.list,omitempty"`
 	KernelInstalled       []KernelInstalled `json:"kernel.installed,omitempty"`
 }


### PR DESCRIPTION
## Summary

- Add `julia.packages` and `julia.package` MQL resources for Julia package dependency tracking
- Parses `Manifest.toml` — Julia's project lockfile
- **Supports both formats**:
  - v1 (Julia < 1.7): flat `[[PackageName]]` sections
  - v2 (Julia >= 1.7): nested `[deps.PackageName]` with `manifest_format = "2.0"`
- **PURL**: `pkg:julia/name@version` (e.g., `pkg:julia/HTTP@1.10.1`)
- Searches default paths, supports explicit path via `julia.packages(path: "...")`
- SBOM generator integration with `julia` package type
- Packages without a version (stdlib deps like `Dates`) are skipped

### Usage

```bash
mql run os -c "julia.packages { list { name version purl } }"
mql run os -c "julia.packages(path: '/home/user/project') { list { name version } }"
```

## Test plan

- [x] v2 Manifest.toml parsing (4 packages: HTTP, JSON, DataFrames, Plots)
- [x] v1 Manifest.toml parsing (2 packages, 1 skipped for missing version)
- [x] PURL generation (`pkg:julia/HTTP@1.10.1`)
- [x] Evidence tracking
- [ ] Interactive test with Julia project

🤖 Generated with [Claude Code](https://claude.com/claude-code)