### PR TITLE
✨ Prevent dependency downgrades in mod-update

### DIFF
--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -43,9 +43,6 @@ jobs:
           version mod-update . --latest
           version mod-update providers/*/ --latest
           version mod-tidy providers/*/
-          # This is first updated and later downgraded by another dependency
-          # Unless this is fixed, bump it back up
-          go get github.com/google/go-containerregistry@v0.20.7
           version mod-tidy .
 
       - name: Prepare title and branch name

--- a/providers-sdk/v1/util/version/version.go
+++ b/providers-sdk/v1/util/version/version.go
@@ -31,6 +31,7 @@ import (
 	"go.mondoo.com/mql/v13/logger"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/semver"
 )
 
 var rootCmd = &cobra.Command{
@@ -141,6 +142,12 @@ func checkGoModUpdate(providerPath string, updateStrategy UpdateStrategy, ignore
 		return
 	}
 
+	// Save all dependency versions before updating so we can detect downgrades later.
+	beforeVersions := make(map[string]string, len(modFile.Require))
+	for _, req := range modFile.Require {
+		beforeVersions[req.Mod.Path] = req.Mod.Version
+	}
+
 	// Iterate through the require statements and update dependencies
 	for _, require := range modFile.Require {
 		// Skip indirect dependencies
@@ -224,7 +231,56 @@ func checkGoModUpdate(providerPath string, updateStrategy UpdateStrategy, ignore
 	// Run 'go mod tidy' to clean up the go.mod and go.sum files
 	goModTidy(providerPath)
 
+	// Detect and revert any dependency downgrades caused by ordering issues
+	// during sequential go get -u calls or go mod tidy.
+	revertDowngrades(providerPath, goModPath, beforeVersions)
+
 	log.Info().Msgf("All dependencies updated and cleaned up successfully.")
+}
+
+// revertDowngrades compares the current go.mod dependency versions against
+// the versions recorded before the update. Any dependency whose version
+// decreased is restored to its original version via "go get", followed by
+// a final "go mod tidy".
+func revertDowngrades(providerPath, goModPath string, beforeVersions map[string]string) {
+	modContent, err := os.ReadFile(goModPath)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read go.mod for downgrade check")
+		return
+	}
+
+	modFile, err := modfile.Parse("go.mod", modContent, nil)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to parse go.mod for downgrade check")
+		return
+	}
+
+	var reverted int
+	for _, req := range modFile.Require {
+		before, ok := beforeVersions[req.Mod.Path]
+		if !ok {
+			continue // new dependency, not a downgrade
+		}
+		if semver.Compare(before, req.Mod.Version) > 0 {
+			log.Warn().Str("package", req.Mod.Path).Str("before", before).Str("after", req.Mod.Version).
+				Msg("detected downgrade, reverting")
+
+			cmd := exec.Command("go", "get", req.Mod.Path+"@"+before)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			cmd.Dir = providerPath
+			if err := cmd.Run(); err != nil {
+				log.Error().Err(err).Str("package", req.Mod.Path).Msg("failed to revert downgrade")
+				continue
+			}
+			reverted++
+		}
+	}
+
+	if reverted > 0 {
+		log.Info().Int("count", reverted).Msg("reverted dependency downgrades, running go mod tidy")
+		goModTidy(providerPath)
+	}
 }
 
 func goModTidy(providerPath string) {

--- a/providers-sdk/v1/util/version/version.go
+++ b/providers-sdk/v1/util/version/version.go
@@ -232,27 +232,37 @@ func checkGoModUpdate(providerPath string, updateStrategy UpdateStrategy, ignore
 	goModTidy(providerPath)
 
 	// Detect and revert any dependency downgrades caused by ordering issues
-	// during sequential go get -u calls or go mod tidy.
-	revertDowngrades(providerPath, goModPath, beforeVersions)
+	// during sequential go get -u calls or go mod tidy. Loop because reverting
+	// one downgrade via go get can cause a different transitive dep to be
+	// downgraded.
+	const maxDowngradeFixPasses = 5
+	for pass := range maxDowngradeFixPasses {
+		reverted := revertDowngrades(providerPath, goModPath, beforeVersions)
+		if reverted == 0 {
+			break
+		}
+		log.Info().Int("pass", pass+1).Int("reverted", reverted).Msg("reverted dependency downgrades, running go mod tidy")
+		goModTidy(providerPath)
+	}
 
 	log.Info().Msgf("All dependencies updated and cleaned up successfully.")
 }
 
 // revertDowngrades compares the current go.mod dependency versions against
 // the versions recorded before the update. Any dependency whose version
-// decreased is restored to its original version via "go get", followed by
-// a final "go mod tidy".
-func revertDowngrades(providerPath, goModPath string, beforeVersions map[string]string) {
+// decreased is restored to its original version via "go get". It returns
+// the number of dependencies that were reverted.
+func revertDowngrades(providerPath, goModPath string, beforeVersions map[string]string) int {
 	modContent, err := os.ReadFile(goModPath)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to read go.mod for downgrade check")
-		return
+		return 0
 	}
 
 	modFile, err := modfile.Parse("go.mod", modContent, nil)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to parse go.mod for downgrade check")
-		return
+		return 0
 	}
 
 	var reverted int
@@ -277,10 +287,7 @@ func revertDowngrades(providerPath, goModPath string, beforeVersions map[string]
 		}
 	}
 
-	if reverted > 0 {
-		log.Info().Int("count", reverted).Msg("reverted dependency downgrades, running go mod tidy")
-		goModTidy(providerPath)
-	}
+	return reverted
 }
 
 func goModTidy(providerPath string) {


### PR DESCRIPTION
## Summary
- After `checkGoModUpdate` finishes updating all dependencies and running `go mod tidy`, it now compares the resulting versions against the pre-update snapshot
- Any dependency whose version decreased (detected via `semver.Compare`) is restored to its original version via `go get pkg@original-version`, followed by a final `go mod tidy`
- This prevents the recurring issue where sequential `go get -u` calls cause ordering-dependent downgrades (e.g., moby/buildkit v0.29.0 → v0.16.0, otelgrpc v0.63.0 → v0.54.0)

## Context
The automated `update-deps` workflow runs `go get -u dep@latest` for each direct dependency sequentially. When updating dep B, `go get -u` can resolve shared transitive dependencies to lower versions than what dep A (updated earlier) pulled in. The final `go mod tidy` can further lower versions. This has caused repeated manual fixups on deps update PRs (see #7309).

## Test plan
- [ ] Verify `go build ./providers-sdk/v1/util/version/` succeeds
- [ ] Run `version mod-update . --latest` locally and confirm no downgrades in the resulting go.mod
- [ ] Next automated deps update PR should not contain any downgrades

🤖 Generated with [Claude Code](https://claude.com/claude-code)