### PR TITLE
⭐ Expose networkInterfaceType on SageMaker HyperPod cluster resources

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2268,6 +2268,8 @@ private aws.sagemaker.clusterInstanceGroup @defaults("instanceGroupName instance
   instanceRequirements dict
   // Breakdown of instance types and counts within a flexible instance group
   instanceTypeDetails []aws.sagemaker.clusterInstanceGroup.instanceTypeDetail
+  // Network interface type for the instance group (e.g., efa, efa-only)
+  networkInterfaceType string
 }
 
 // Instance type detail within a flexible SageMaker HyperPod instance group
@@ -2298,6 +2300,8 @@ private aws.sagemaker.clusterNode @defaults("instanceId instanceGroupName instan
   privateDnsHostname string
   // Region where the node exists
   region string
+  // Network interface type for the node (e.g., efa, efa-only)
+  networkInterfaceType() string
 }
 
 // AWS SageMaker feature group

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -6092,6 +6092,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.sagemaker.clusterInstanceGroup.instanceTypeDetails": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSagemakerClusterInstanceGroup).GetInstanceTypeDetails()).ToDataRes(types.Array(types.Resource("aws.sagemaker.clusterInstanceGroup.instanceTypeDetail")))
 	},
+	"aws.sagemaker.clusterInstanceGroup.networkInterfaceType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSagemakerClusterInstanceGroup).GetNetworkInterfaceType()).ToDataRes(types.String)
+	},
 	"aws.sagemaker.clusterInstanceGroup.instanceTypeDetail.instanceType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSagemakerClusterInstanceGroupInstanceTypeDetail).GetInstanceType()).ToDataRes(types.String)
 	},
@@ -6124,6 +6127,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.sagemaker.clusterNode.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSagemakerClusterNode).GetRegion()).ToDataRes(types.String)
+	},
+	"aws.sagemaker.clusterNode.networkInterfaceType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSagemakerClusterNode).GetNetworkInterfaceType()).ToDataRes(types.String)
 	},
 	"aws.sagemaker.featureGroup.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSagemakerFeatureGroup).GetArn()).ToDataRes(types.String)
@@ -26041,6 +26047,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsSagemakerClusterInstanceGroup).InstanceTypeDetails, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.sagemaker.clusterInstanceGroup.networkInterfaceType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSagemakerClusterInstanceGroup).NetworkInterfaceType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.sagemaker.clusterInstanceGroup.instanceTypeDetail.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSagemakerClusterInstanceGroupInstanceTypeDetail).__id, ok = v.Value.(string)
 		return
@@ -26091,6 +26101,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.sagemaker.clusterNode.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSagemakerClusterNode).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.sagemaker.clusterNode.networkInterfaceType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSagemakerClusterNode).NetworkInterfaceType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.sagemaker.featureGroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -60746,6 +60760,7 @@ type mqlAwsSagemakerClusterInstanceGroup struct {
 	LifecycleConfig      plugin.TValue[any]
 	InstanceRequirements plugin.TValue[any]
 	InstanceTypeDetails  plugin.TValue[[]any]
+	NetworkInterfaceType plugin.TValue[string]
 }
 
 // createAwsSagemakerClusterInstanceGroup creates a new instance of this resource
@@ -60843,6 +60858,10 @@ func (c *mqlAwsSagemakerClusterInstanceGroup) GetInstanceTypeDetails() *plugin.T
 	return &c.InstanceTypeDetails
 }
 
+func (c *mqlAwsSagemakerClusterInstanceGroup) GetNetworkInterfaceType() *plugin.TValue[string] {
+	return &c.NetworkInterfaceType
+}
+
 // mqlAwsSagemakerClusterInstanceGroupInstanceTypeDetail for the aws.sagemaker.clusterInstanceGroup.instanceTypeDetail resource
 type mqlAwsSagemakerClusterInstanceGroupInstanceTypeDetail struct {
 	MqlRuntime *plugin.Runtime
@@ -60907,14 +60926,15 @@ type mqlAwsSagemakerClusterNode struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAwsSagemakerClusterNodeInternal
-	InstanceId         plugin.TValue[string]
-	InstanceGroupName  plugin.TValue[string]
-	InstanceType       plugin.TValue[string]
-	Status             plugin.TValue[string]
-	StatusMessage      plugin.TValue[string]
-	LaunchedAt         plugin.TValue[*time.Time]
-	PrivateDnsHostname plugin.TValue[string]
-	Region             plugin.TValue[string]
+	InstanceId           plugin.TValue[string]
+	InstanceGroupName    plugin.TValue[string]
+	InstanceType         plugin.TValue[string]
+	Status               plugin.TValue[string]
+	StatusMessage        plugin.TValue[string]
+	LaunchedAt           plugin.TValue[*time.Time]
+	PrivateDnsHostname   plugin.TValue[string]
+	Region               plugin.TValue[string]
+	NetworkInterfaceType plugin.TValue[string]
 }
 
 // createAwsSagemakerClusterNode creates a new instance of this resource
@@ -60984,6 +61004,12 @@ func (c *mqlAwsSagemakerClusterNode) GetPrivateDnsHostname() *plugin.TValue[stri
 
 func (c *mqlAwsSagemakerClusterNode) GetRegion() *plugin.TValue[string] {
 	return &c.Region
+}
+
+func (c *mqlAwsSagemakerClusterNode) GetNetworkInterfaceType() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.NetworkInterfaceType, func() (string, error) {
+		return c.networkInterfaceType()
+	})
 }
 
 // mqlAwsSagemakerFeatureGroup for the aws.sagemaker.featureGroup resource

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -4976,6 +4976,7 @@ aws.sagemaker.clusterInstanceGroup.instanceTypeDetail.instanceType 13.12.2
 aws.sagemaker.clusterInstanceGroup.instanceTypeDetail.threadsPerCore 13.12.2
 aws.sagemaker.clusterInstanceGroup.instanceTypeDetails 13.12.2
 aws.sagemaker.clusterInstanceGroup.lifecycleConfig 13.12.0
+aws.sagemaker.clusterInstanceGroup.networkInterfaceType 13.15.2
 aws.sagemaker.clusterInstanceGroup.region 13.12.0
 aws.sagemaker.clusterInstanceGroup.status 13.12.0
 aws.sagemaker.clusterInstanceGroup.targetCount 13.12.0
@@ -4985,6 +4986,7 @@ aws.sagemaker.clusterNode.instanceGroupName 13.12.0
 aws.sagemaker.clusterNode.instanceId 13.12.0
 aws.sagemaker.clusterNode.instanceType 13.12.0
 aws.sagemaker.clusterNode.launchedAt 13.12.0
+aws.sagemaker.clusterNode.networkInterfaceType 13.15.2
 aws.sagemaker.clusterNode.privateDnsHostname 13.12.0
 aws.sagemaker.clusterNode.region 13.12.0
 aws.sagemaker.clusterNode.status 13.12.0

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
-  "version": "13.14.1",
-  "generated_at": "2026-04-17T11:35:02-07:00",
+  "version": "13.15.1",
+  "generated_at": "2026-04-20T13:18:14-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindingsV2",
@@ -470,6 +470,7 @@
     "sagemaker:DescribeArtifact",
     "sagemaker:DescribeAutoMLJob",
     "sagemaker:DescribeCluster",
+    "sagemaker:DescribeClusterNode",
     "sagemaker:DescribeCodeRepository",
     "sagemaker:DescribeCompilationJob",
     "sagemaker:DescribeContext",
@@ -3549,6 +3550,12 @@
       "permission": "sagemaker:DescribeCluster",
       "service": "sagemaker",
       "action": "DescribeCluster",
+      "source_file": "aws_sagemaker.go"
+    },
+    {
+      "permission": "sagemaker:DescribeClusterNode",
+      "service": "sagemaker",
+      "action": "DescribeClusterNode",
       "source_file": "aws_sagemaker.go"
     },
     {

--- a/providers/aws/resources/aws_sagemaker.go
+++ b/providers/aws/resources/aws_sagemaker.go
@@ -2448,6 +2448,10 @@ func (a *mqlAwsSagemakerCluster) instanceGroups() ([]any, error) {
 			itdRes.cacheParentGroupID = a.Region.Data + "/" + a.Name.Data + "/" + igName
 			instanceTypeDetails = append(instanceTypeDetails, mqlITD)
 		}
+		var networkInterfaceType string
+		if ig.NetworkInterface != nil {
+			networkInterfaceType = string(ig.NetworkInterface.InterfaceType)
+		}
 		mqlIG, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerClusterInstanceGroup,
 			map[string]*llx.RawData{
 				"instanceGroupName":    llx.StringDataPtr(ig.InstanceGroupName),
@@ -2459,6 +2463,7 @@ func (a *mqlAwsSagemakerCluster) instanceGroups() ([]any, error) {
 				"threadsPerCore":       llx.IntData(threadsPerCore),
 				"instanceRequirements": llx.DictData(instanceRequirements),
 				"instanceTypeDetails":  llx.ArrayData(instanceTypeDetails, types.Resource("aws.sagemaker.clusterInstanceGroup.instanceTypeDetail")),
+				"networkInterfaceType": llx.StringData(networkInterfaceType),
 			})
 		if err != nil {
 			return nil, err
@@ -2604,6 +2609,52 @@ func (a *mqlAwsSagemakerClusterInstanceGroupInstanceTypeDetail) id() (string, er
 
 type mqlAwsSagemakerClusterNodeInternal struct {
 	cacheClusterName string
+	fetched          bool
+	fetchLock        sync.Mutex
+	cacheDescribe    *sagemakerTypes.ClusterNodeDetails
+}
+
+func (a *mqlAwsSagemakerClusterNode) fetchDetails() (*sagemakerTypes.ClusterNodeDetails, error) {
+	if a.fetched {
+		return a.cacheDescribe, nil
+	}
+	a.fetchLock.Lock()
+	defer a.fetchLock.Unlock()
+	if a.fetched {
+		return a.cacheDescribe, nil
+	}
+
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Sagemaker(a.Region.Data)
+	ctx := context.Background()
+	clusterName := a.cacheClusterName
+	nodeId := a.InstanceId.Data
+
+	resp, err := svc.DescribeClusterNode(ctx, &sagemaker.DescribeClusterNodeInput{
+		ClusterName: &clusterName,
+		NodeId:      &nodeId,
+	})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			a.fetched = true
+			return nil, nil
+		}
+		return nil, err
+	}
+	a.cacheDescribe = resp.NodeDetails
+	a.fetched = true
+	return a.cacheDescribe, nil
+}
+
+func (a *mqlAwsSagemakerClusterNode) networkInterfaceType() (string, error) {
+	details, err := a.fetchDetails()
+	if err != nil {
+		return "", err
+	}
+	if details == nil || details.NetworkInterface == nil {
+		return "", nil
+	}
+	return string(details.NetworkInterface.InterfaceType), nil
 }
 
 func (a *mqlAwsSagemakerClusterNode) id() (string, error) {


### PR DESCRIPTION
## Summary
- Adds `networkInterfaceType` to `aws.sagemaker.clusterInstanceGroup` (populated eagerly from existing `DescribeCluster` response — no extra API cost)
- Adds `networkInterfaceType()` to `aws.sagemaker.clusterNode` as a computed method that lazy-loads via `DescribeClusterNode` only when queried
- Surfaces the EFA / EFA-only interface configuration added in AWS SDK sagemaker v1.241.0 (bumped in #7309)

Note: `ClusterLifeCycleConfig.OnInitComplete` (also added in v1.241.0) already flows through our existing `lifecycleConfig() dict` automatically — no schema change needed.

## Test plan
- [ ] `make providers/build/aws && make providers/install/aws`
- [ ] On an account with an active HyperPod cluster: `cnspec shell aws` then `aws.sagemaker.clusters { instanceGroups { instanceGroupName networkInterfaceType } nodes { instanceId networkInterfaceType } }`
- [ ] Confirm `sagemaker:DescribeClusterNode` permission addition in `aws.permissions.json` is picked up by downstream IAM policy generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)