### PR TITLE
🐛 fix quota and apikeys issues on GCP

### DIFF
--- a/providers/gcp/connection/clients.go
+++ b/providers/gcp/connection/clients.go
@@ -55,9 +55,24 @@ func (c *GcpConnection) Client(scope ...string) (*http.Client, error) {
 	return defaultAuth(ctx, scope...)
 }
 
-// defaultAuth implements the
+// defaultAuth builds an HTTP client from Application Default Credentials.
+// It routes through transport.NewHTTPClient with option.WithCredentials so that
+// the quota project (from quota_project_id in the ADC JSON, or the
+// GOOGLE_CLOUD_QUOTA_PROJECT env var) is propagated as the X-Goog-User-Project
+// header. Going through googleoauth.DefaultClient skips that plumbing and
+// causes APIs that bill the caller (apikeys, serviceusage,
+// cloudresourcemanager) to fail with 403 against Google's default SDK project.
 func defaultAuth(ctx context.Context, scope ...string) (*http.Client, error) {
-	return googleoauth.DefaultClient(ctx, scope...)
+	creds, err := googleoauth.FindDefaultCredentials(ctx, scope...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to find google default credentials")
+	}
+
+	client, _, err := transport.NewHTTPClient(ctx, option.WithCredentials(creds))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create google http client")
+	}
+	return client, nil
 }
 
 // serviceAccountAuth implements

--- a/providers/gcp/resources/apikeys.go
+++ b/providers/gcp/resources/apikeys.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -31,6 +32,7 @@ func (g *mqlGcpProject) apiKeys() ([]any, error) {
 		return nil, err
 	}
 	if !serviceEnabled {
+		log.Debug().Str("service", service_apikeys).Str("project", projectId).Msg("gcp service is not enabled, skipping")
 		return nil, nil
 	}
 

--- a/providers/gcp/resources/apikeys.go
+++ b/providers/gcp/resources/apikeys.go
@@ -226,3 +226,45 @@ func (g *mqlGcpProjectApiKeyRestrictions) id() (string, error) {
 	}
 	return fmt.Sprintf("%s/restrictions", g.ParentResourcePath.Data), nil
 }
+
+// Always bootstrap through the parent key. apiKeys() populates restrictions
+// via CreateResource (which bypasses Init), so any NewResource call here is
+// a top-level `gcp.project.apiKey.restrictions` query — partial args would
+// pass through to Create and yield a bare stub whose fields all error with
+// "cannot convert primitive with NO type information".
+func initGcpProjectApiKeyRestrictions(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	ids := getAssetIdentifier(runtime)
+	if ids == nil {
+		return nil, nil, errors.New("no asset identifier found; gcp.project.apiKey.restrictions requires a gcp-apikey asset context")
+	}
+
+	obj, err := NewResource(runtime, "gcp.project.apiKey", map[string]*llx.RawData{
+		"id":        llx.StringData(ids.name),
+		"projectId": llx.StringData(ids.project),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	key := obj.(*mqlGcpProjectApiKey)
+	restrictions := key.GetRestrictions()
+	if restrictions.Error != nil {
+		return nil, nil, restrictions.Error
+	}
+	if restrictions.Data == nil {
+		// Key has no restrictions. Null out all fields so the Create fallthrough
+		// produces a resource whose TValues are StateIsNull|StateIsSet (via
+		// RawToTValue's nil path) instead of a bare stub. Matches the pattern
+		// in initGcpProjectIamServiceAccount.
+		if args == nil {
+			args = make(map[string]*llx.RawData)
+		}
+		args["parentResourcePath"] = llx.NilData
+		args["androidKeyRestrictions"] = llx.NilData
+		args["apiTargets"] = llx.NilData
+		args["browserKeyRestrictions"] = llx.NilData
+		args["iosKeyRestrictions"] = llx.NilData
+		args["serverKeyRestrictions"] = llx.NilData
+		return args, nil, nil
+	}
+	return args, restrictions.Data, nil
+}

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -792,7 +792,7 @@ func init() {
 			Create: createGcpProjectApiKey,
 		},
 		"gcp.project.apiKey.restrictions": {
-			// to override args, implement: initGcpProjectApiKeyRestrictions(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initGcpProjectApiKeyRestrictions,
 			Create: createGcpProjectApiKeyRestrictions,
 		},
 		"gcp.project.loggingservice": {

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
-  "version": "13.8.1",
-  "generated_at": "2026-04-17T22:09:06-07:00",
+  "version": "13.8.2",
+  "generated_at": "2026-04-20T09:42:55-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.customJobs.list",


### PR DESCRIPTION
## Quota

### Summary

Local runs against GCP with Application Default Credentials fail on caller-billed APIs (e.g. apikeys.googleapis.com) with a 403 against `consumer: projects/123456789123` — Google's default SDK project — because `googleoauth.DefaultClient` ignores `quota_project_id` in the ADC file and never sets `X-Goog-User-Project`, even after `gcloud auth application-default set-quota-project`. `defaultAuth` now routes through `transport.NewHTTPClient(option.WithCredentials(creds))`, which reads quota_project_id from the ADC JSON and propagates the header; `serviceAccountAuth` is untouched, so hosted SA/WIF scans stay on the exact same code path. Token source and scopes are preserved — `creds.TokenSource` from `FindDefaultCredentials` is the same token source `googleoauth.DefaultClient` extracts internally. Also added a `log.Debug` in `apikeys.go` when the API isn't enabled on the target project, matching the pattern in `iam.go/kms.go/logging.go` — previously it silently returned zero keys.

### Test plan

- `gcloud auth application-default set-quota-project <proj>` then run against a GCP project and confirm the 403 with consumer: `projects/123456789123` on `apikeys.googleapis.com` no longer appears
- Confirm hosted SA/WIF scans still succeed

---

## `apiKeys`

### Summary

When cnspec discovers GCP API keys as individual assets (`--discover apikeys`, platform `gcp-apikey`), a policy scoped to `asset.platform == 'gcp-apikey'` that reads `gcp.project.apiKey.restrictions` returns "cannot convert primitive with NO type information" on every sub-field — including the plain-string `parentResourcePath`, which is the tell that the sub-resource itself is uninitialized rather than any individual field being broken. Root cause: `gcp.project.apiKey.restrictions` is a first-class resource name, and MQL instantiates it directly via `NewResource` when queried at the top level; no `Init` was registered, so `NewResource` fell through to Create with empty args and produced a bare stub. The project-asset path (`gcp.project.apiKeys[0].restrictions`) works because it accesses the restrictions via the `GetRestrictions()` getter on an already-populated key — not via `NewResource`. Fix: register `initGcpProjectApiKeyRestrictions`, which bootstraps the parent key via `NewResource("gcp.project.apiKey", …)` (running `initGcpProjectApiKey` → `apiKeys()` → populated restrictions cache) and returns `key.GetRestrictions().Data`; on a non-apikey asset the init returns a clear "requires a gcp-apikey asset context" error instead of silently producing a broken resource.

### Test plan
  
- Against a GCP project with --discover apikeys, confirm `gcp.project.apiKey.restrictions { * }` on a `gcp-apikey` asset returns typed fields instead of "cannot convert primitive with NO type information" on every field
- Confirm `gcp.project.apiKeys[0].restrictions { * }` on a `gcp-project` asset still works (unchanged path)
- Confirm the Wabb API key hardening policy now evaluates against its intended `asset.platform == 'gcp-apikey'` scope