### PR TITLE
🐛 fix gcp cloudRun jobs listing + network lazy-load

### DIFF
--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -654,6 +654,14 @@ func (g *mqlGcpProjectCloudRunService) jobs() ([]any, error) {
 		return nil, g.Regions.Error
 	}
 	regions := g.Regions.Data
+	if len(regions) == 0 {
+		// regions data has not been fetched, we need to get it
+		r, err := g.regions()
+		if err != nil {
+			return nil, err
+		}
+		regions = r
+	}
 
 	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
 

--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -272,6 +272,14 @@ func (g *mqlGcpProjectCloudRunService) operations() ([]any, error) {
 		return nil, g.Regions.Error
 	}
 	regions := g.Regions.Data
+	if len(regions) == 0 {
+		// regions data has not been fetched, we need to get it
+		r, err := g.regions()
+		if err != nil {
+			return nil, err
+		}
+		regions = r
+	}
 
 	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
 

--- a/providers/gcp/resources/common.go
+++ b/providers/gcp/resources/common.go
@@ -204,7 +204,10 @@ func getNetworkByUrl(networkUrl string, runtime *plugin.Runtime) (*mqlGcpProject
 	parts := strings.Split(params, "/")
 	resId := resourceId{Project: parts[1], Region: parts[2], Name: parts[4]}
 
-	res, err := CreateResource(runtime, "gcp.project.computeService.network", map[string]*llx.RawData{
+	// Use NewResource so initGcpProjectComputeServiceNetwork runs and
+	// populates every field (scalars like autoCreateSubnetworks would
+	// otherwise surface as "no type information" when accessed).
+	res, err := NewResource(runtime, "gcp.project.computeService.network", map[string]*llx.RawData{
 		"name":      llx.StringData(resId.Name),
 		"projectId": llx.StringData(resId.Project),
 	})
@@ -229,7 +232,9 @@ func getSubnetworkByUrl(subnetUrl string, runtime *plugin.Runtime) (*mqlGcpProje
 	// regionUrl is the full URL up to and including the region segment
 	regionUrl := "https://www.googleapis.com/compute/v1/projects/" + resId.Project + "/regions/" + resId.Region
 
-	res, err := CreateResource(runtime, "gcp.project.computeService.subnetwork", map[string]*llx.RawData{
+	// Use NewResource so initGcpProjectComputeServiceSubnetwork runs and
+	// populates every field instead of leaving the resource partially set.
+	res, err := NewResource(runtime, "gcp.project.computeService.subnetwork", map[string]*llx.RawData{
 		"name":      llx.StringData(resId.Name),
 		"projectId": llx.StringData(resId.Project),
 		"regionUrl": llx.StringData(regionUrl),


### PR DESCRIPTION
Fixes two pre-existing bugs surfaced while verifying #7323 on a live project.

## Summary

- **#7324** — `gcp.project.cloudRunService.jobs` returned an empty list when queried directly (without first touching `.services`) even though jobs existed. The function read `g.Regions.Data` without the empty-fallback that `services()` has, so `wg.Add(0)` returned a nil slice immediately. Ported the same fallback so `jobs()` refreshes regions when the cache is cold.

- **#7325** — `getNetworkByUrl` / `getSubnetworkByUrl` in `common.go` created resources via `CreateResource` with only `{name, projectId}` (+`regionUrl`). This bypasses `init`, so the cache held a partial resource and any scalar-field access (e.g. `network.autoCreateSubnetworks`, `network.routingMode`) surfaced as _"cannot convert primitive with NO type information"_. Switched both helpers to `NewResource`, which triggers the existing `init` function and populates every field via the cache-or-fetch path.

## Verification

Live-tested against a terraform fixture (same one used for #7323 verification):

```text
# Before — jobs() empty
> gcp.project.cloudRunService.jobs.length
0

# After — jobs() lists the job and its IAM policy resolves
> gcp.project.cloudRunService.jobs { name region iamPolicy { role members } }
[
  0: {
    name: "mqlverify-job-ec66ce"
    region: "us-central1"
    iamPolicy: [ 0: { role: "roles/run.invoker", members: ["serviceAccount:..."] } ]
  }
]
```

```text
# Before — scalars on network() fail
> subnetworks.first { network.autoCreateSubnetworks network.routingMode }
  network.autoCreateSubnetworks: cannot convert primitive with NO type information
  network.routingMode: cannot convert primitive with NO type information

# After — both resolve
  network.autoCreateSubnetworks: false
  network.routingMode: "REGIONAL"
```

Unchanged behavior confirmed: `.networks.length`, `.subnetworks.length`, `.services.length` all return the same values as before.

## Test plan

- [x] `make providers/build/gcp` succeeds
- [x] `go test ./providers/gcp/resources/...` passes
- [x] `gofmt -w` clean
- [x] Live verification against a terraform-provisioned fixture on `tim-learning-project`
- [x] Sanity-checked that unrelated listings (networks, subnetworks, services) still work

Closes #7324, closes #7325.

🤖 Generated with [Claude Code](https://claude.com/claude-code)