### PR TITLE
🐛 Replace null byte separator with \x1e in recording package

### DIFF
--- a/providers-sdk/v1/recording/asset_recording.go
+++ b/providers-sdk/v1/recording/asset_recording.go
@@ -30,8 +30,8 @@ type Asset struct {
 	// the same behavior when reading/replaying recordings.
 	//
 	// The key is the resource name + request ID, e.g.
-	// "aws.ec2.instance\x00123": "i-1234567890abcdef0"
-	// "azure.subscription\x001": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+	// "aws.ec2.instance\x1e123": "i-1234567890abcdef0"
+	// "azure.subscription\x1e1": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 	IdsLookup map[string]string `json:"idsLookup,omitempty"`
 
 	connections map[string]*connection `json:"-"`
@@ -79,7 +79,7 @@ func (asset *Asset) finalize() {
 }
 
 func (asset *Asset) GetResource(name string, id string) (*Resource, bool) {
-	r, ok := asset.resources[name+"\x00"+id]
+	r, ok := asset.resources[name+keySep+id]
 	return r, ok
 }
 
@@ -88,7 +88,7 @@ func (asset *Asset) RefreshCache() {
 	asset.connections = make(map[string]*connection, len(asset.Connections))
 
 	for _, resource := range asset.Resources {
-		asset.resources[resource.Resource+"\x00"+resource.ID] = &resource
+		asset.resources[resource.Resource+keySep+resource.ID] = &resource
 	}
 
 	for _, conn := range asset.Connections {

--- a/providers-sdk/v1/recording/merge.go
+++ b/providers-sdk/v1/recording/merge.go
@@ -118,7 +118,7 @@ func mergeAssets(existing, incoming *Asset) {
 		existing.connections[k] = conn
 	}
 
-	// Merge resources (keyed by "Resource\x00ID").
+	// Merge resources (keyed by "Resource\x1eID").
 	for key, res := range incoming.resources {
 		if existingRes, ok := existing.resources[key]; ok {
 			mergeResourceFields(existingRes, res)

--- a/providers-sdk/v1/recording/merge_test.go
+++ b/providers-sdk/v1/recording/merge_test.go
@@ -64,14 +64,14 @@ func TestMerge_MatchByMRN(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, merged.Assets, 1)
 
-	// pkg\x001 should have both fields merged.
-	res, ok := merged.Assets[0].resources["pkg\x001"]
+	// pkg\x1e1 should have both fields merged.
+	res, ok := merged.Assets[0].resources["pkg\x1e1"]
 	require.True(t, ok)
 	assert.Equal(t, "curl", res.Fields["name"].Value)
 	assert.Equal(t, "7.88", res.Fields["version"].Value)
 
-	// pkg\x002 should exist from r2.
-	_, ok = merged.Assets[0].resources["pkg\x002"]
+	// pkg\x1e2 should exist from r2.
+	_, ok = merged.Assets[0].resources["pkg\x1e2"]
 	assert.True(t, ok)
 }
 
@@ -109,7 +109,7 @@ func TestMerge_MatchByPlatformID(t *testing.T) {
 	assert.ElementsMatch(t, []string{"pid-1", "pid-2", "pid-3"}, merged.Assets[0].Asset.PlatformIds)
 
 	// Resources should be merged.
-	res, ok := merged.Assets[0].resources["os\x00"]
+	res, ok := merged.Assets[0].resources["os\x1e"]
 	require.True(t, ok)
 	assert.Equal(t, "linux", res.Fields["name"].Value)
 	assert.Equal(t, "amd64", res.Fields["arch"].Value)
@@ -118,17 +118,17 @@ func TestMerge_MatchByPlatformID(t *testing.T) {
 func TestMerge_IdsLookup(t *testing.T) {
 	r1 := newMergeTestRecording(&Asset{
 		Asset:     &inventory.Asset{Mrn: "mrn://a", Platform: &inventory.Platform{}},
-		IdsLookup: map[string]string{"res\x00": "resolved-1"},
+		IdsLookup: map[string]string{"res\x1e": "resolved-1"},
 	})
 	r2 := newMergeTestRecording(&Asset{
 		Asset:     &inventory.Asset{Mrn: "mrn://a", Platform: &inventory.Platform{}},
-		IdsLookup: map[string]string{"res2\x00": "resolved-2"},
+		IdsLookup: map[string]string{"res2\x1e": "resolved-2"},
 	})
 
 	merged, err := Merge([]*recording{r1, r2}, MergeOpts{})
 	require.NoError(t, err)
-	assert.Equal(t, "resolved-1", merged.Assets[0].IdsLookup["res\x00"])
-	assert.Equal(t, "resolved-2", merged.Assets[0].IdsLookup["res2\x00"])
+	assert.Equal(t, "resolved-1", merged.Assets[0].IdsLookup["res\x1e"])
+	assert.Equal(t, "resolved-2", merged.Assets[0].IdsLookup["res2\x1e"])
 }
 
 func TestMerge_Connections(t *testing.T) {
@@ -166,7 +166,7 @@ func TestMerge_FieldConflictLastWins(t *testing.T) {
 
 	merged, err := Merge([]*recording{r1, r2}, MergeOpts{})
 	require.NoError(t, err)
-	res, ok := merged.Assets[0].resources["pkg\x001"]
+	res, ok := merged.Assets[0].resources["pkg\x1e1"]
 	require.True(t, ok)
 	assert.Equal(t, "2.0", res.Fields["version"].Value)
 }

--- a/providers-sdk/v1/recording/recording.go
+++ b/providers-sdk/v1/recording/recording.go
@@ -22,6 +22,11 @@ var _ llx.Recording = &recording{}
 
 const internalLookupId = "mql/internal-lookup-id"
 
+// keySep is the separator used to build composite map keys (e.g. resource + id).
+// We use the ASCII Record Separator (\x1e) instead of \x00 because Postgres
+// does not allow null bytes in text/JSON columns.
+const keySep = "\x1e"
+
 type recording struct {
 	Assets []*Asset `json:"assets"`
 	Path   string   `json:"-"`
@@ -399,17 +404,17 @@ func (r *recording) AddData(req llx.AddDataReq) {
 	}
 
 	if req.RequestResourceId != req.ResourceID {
-		asset.IdsLookup[req.Resource+"\x00"+req.RequestResourceId] = req.ResourceID
+		asset.IdsLookup[req.Resource+keySep+req.RequestResourceId] = req.ResourceID
 	}
 
-	obj, exist := asset.resources[req.Resource+"\x00"+req.ResourceID]
+	obj, exist := asset.resources[req.Resource+keySep+req.ResourceID]
 	if !exist {
 		obj = &Resource{
 			Resource: req.Resource,
 			ID:       req.ResourceID,
 			Fields:   map[string]*llx.RawData{},
 		}
-		asset.resources[req.Resource+"\x00"+req.ResourceID] = obj
+		asset.resources[req.Resource+keySep+req.ResourceID] = obj
 	}
 
 	if req.Field != "" {
@@ -424,7 +429,7 @@ func (r *recording) resolveResource(lookup llx.AssetRecordingLookup, resource st
 	}
 
 	// overwrite resourceId if there exists a lookup entry
-	if lookupId, ok := asset.IdsLookup[resource+"\x00"+id]; ok {
+	if lookupId, ok := asset.IdsLookup[resource+keySep+id]; ok {
 		id = lookupId
 	}
 
@@ -435,7 +440,7 @@ func (r *recording) resolveResource(lookup llx.AssetRecordingLookup, resource st
 		return assetResource, id, true
 	}
 
-	obj, exist := asset.resources[resource+"\x00"+id]
+	obj, exist := asset.resources[resource+keySep+id]
 	if !exist {
 		return nil, "", false
 	}
@@ -527,7 +532,7 @@ func (r *recording) GetAssetData(assetMrn string) (map[string]*llx.ResourceRecor
 	// we need to also store the id lookups as part of the resource recording
 	// so that they can be reused later when only reading the resource recording
 	for k, v := range cur.IdsLookup {
-		res[internalLookupId+"\x00"+k] = &llx.ResourceRecording{
+		res[internalLookupId+keySep+k] = &llx.ResourceRecording{
 			Resource: internalLookupId,
 			Id:       k,
 			Fields: map[string]*llx.Result{
@@ -560,7 +565,7 @@ func (r *recording) SetAssetRecording(id uint32, reco *Asset) {
 // This method makes sure the asset metadata is always included in the data
 // dump of a recording
 func ensureAssetMetadata(resources map[string]*Resource, asset *inventory.Asset) {
-	id := "asset\x00"
+	id := "asset" + keySep
 	existing, ok := resources[id]
 	if !ok {
 		existing = &Resource{

--- a/providers-sdk/v1/recording/recording.go
+++ b/providers-sdk/v1/recording/recording.go
@@ -318,7 +318,7 @@ func reconnectResource(v any, resource *Resource) (any, error) {
 
 	// TODO: Not sure yet if we need to check the recording for the reference.
 	// Unless it is used by the code, we may get away with it.
-	// if _, ok = asset.resources[name+"\x00"+id]; !ok {
+	// if _, ok = asset.resources[name+keySep+id]; !ok {
 	// 	return errors.New("cannot find resource '" + resource.Resource + "' (ID:" + resource.ID + ") in recording")
 	// }
 

--- a/providers-sdk/v1/recording/recording_test.go
+++ b/providers-sdk/v1/recording/recording_test.go
@@ -55,7 +55,7 @@ func TestAddAndGetData(t *testing.T) {
 		r.AddData(req)
 
 		// Verify the resource was created
-		resourceKey := "aws.ec2.instance\x00i-12345"
+		resourceKey := "aws.ec2.instance\x1ei-12345"
 		res, exists := r.Assets[0].resources[resourceKey]
 		assert.True(t, exists)
 		assert.Equal(t, "aws.ec2.instance", res.Resource)
@@ -100,7 +100,7 @@ func TestAddAndGetData(t *testing.T) {
 		r.AddData(req2)
 
 		// Verify both fields exist
-		resourceKey := "aws.ec2.instance\x00i-67890"
+		resourceKey := "aws.ec2.instance\x1ei-67890"
 		res, exists := r.Assets[0].resources[resourceKey]
 		assert.True(t, exists)
 		assert.Equal(t, 2, len(res.Fields))
@@ -131,7 +131,7 @@ func TestAddAndGetData(t *testing.T) {
 		}
 		r.AddData(req)
 
-		lookupKey := "aws.ec2.instance\x00"
+		lookupKey := "aws.ec2.instance\x1e"
 		actualID, exists := r.Assets[0].IdsLookup[lookupKey]
 		assert.True(t, exists)
 		assert.Equal(t, "arn:aws:ec2:us-east-1:123456789012:instance/i-abc123", actualID)
@@ -202,7 +202,7 @@ func TestAddAndGetData(t *testing.T) {
 		r.AddData(req)
 
 		// Verify resource exists but has no fields
-		resourceKey := "aws.ec2.instance\x00i-field-test"
+		resourceKey := "aws.ec2.instance\x1ei-field-test"
 		res, exists := r.Assets[0].resources[resourceKey]
 		assert.True(t, exists)
 		assert.Equal(t, "aws.ec2.instance", res.Resource)
@@ -253,7 +253,7 @@ func TestAddAndGetData(t *testing.T) {
 		r.AddData(req2)
 
 		// Verify the field was overwritten
-		resourceKey := "aws.ec2.instance\x00i-overwrite"
+		resourceKey := "aws.ec2.instance\x1ei-overwrite"
 		res, exists := r.Assets[0].resources[resourceKey]
 		assert.True(t, exists)
 		assert.Equal(t, 1, len(res.Fields))
@@ -302,15 +302,15 @@ func TestAddAndGetData(t *testing.T) {
 		// Verify all resources exist
 		assert.Equal(t, 3, len(r.Assets[0].resources))
 
-		res1, exists := r.Assets[0].resources["aws.ec2.instance\x00i-multi-1"]
+		res1, exists := r.Assets[0].resources["aws.ec2.instance\x1ei-multi-1"]
 		assert.True(t, exists)
 		assert.Equal(t, "instance-1", res1.Fields["name"].Value)
 
-		res2, exists := r.Assets[0].resources["aws.ec2.instance\x00i-multi-2"]
+		res2, exists := r.Assets[0].resources["aws.ec2.instance\x1ei-multi-2"]
 		assert.True(t, exists)
 		assert.Equal(t, "instance-2", res2.Fields["name"].Value)
 
-		res3, exists := r.Assets[0].resources["aws.s3.bucket\x00bucket-1"]
+		res3, exists := r.Assets[0].resources["aws.s3.bucket\x1ebucket-1"]
 		assert.True(t, exists)
 		assert.Equal(t, "my-bucket", res3.Fields["name"].Value)
 
@@ -447,7 +447,7 @@ func TestGetAssetData(t *testing.T) {
 		assert.True(t, ok)
 
 		// Verify the resource recording exists
-		resourceKey := "aws.ec2.instance\x00i-12345"
+		resourceKey := "aws.ec2.instance\x1ei-12345"
 		rec, exists := data[resourceKey]
 		assert.True(t, exists)
 		assert.Equal(t, "aws.ec2.instance", rec.Resource)
@@ -462,7 +462,7 @@ func TestGetAssetData(t *testing.T) {
 		assert.True(t, ok)
 
 		// Verify asset metadata is included
-		assetKey := "asset\x00"
+		assetKey := "asset\x1e"
 		rec, exists := data[assetKey]
 		assert.True(t, exists)
 		assert.Equal(t, "asset", rec.Resource)
@@ -492,11 +492,11 @@ func TestGetAssetData(t *testing.T) {
 		assert.True(t, ok)
 
 		// Verify the lookup entry is stored as an internal lookup resource
-		lookupKey := "mql/internal-lookup-id\x00aws.ec2.instance\x00"
+		lookupKey := "mql/internal-lookup-id\x1eaws.ec2.instance\x1e"
 		rec, exists := data[lookupKey]
 		assert.True(t, exists, "internal lookup resource should exist")
 		assert.Equal(t, "mql/internal-lookup-id", rec.Resource)
-		assert.Equal(t, "aws.ec2.instance\x00", rec.Id)
+		assert.Equal(t, "aws.ec2.instance\x1e", rec.Id)
 		assert.Equal(t, "arn:aws:ec2:us-east-1:123456789012:instance/i-abc123", string(rec.Fields["value"].Data.Value))
 	})
 
@@ -535,15 +535,15 @@ func TestGetAssetData(t *testing.T) {
 		// Verify all resources are included (3 resources + 1 asset metadata)
 		assert.Equal(t, 4, len(data))
 
-		rec1, exists := data["aws.ec2.instance\x00i-1"]
+		rec1, exists := data["aws.ec2.instance\x1ei-1"]
 		assert.True(t, exists)
 		assert.Equal(t, "instance-1", string(rec1.Fields["name"].Data.Value))
 
-		rec2, exists := data["aws.ec2.instance\x00i-2"]
+		rec2, exists := data["aws.ec2.instance\x1ei-2"]
 		assert.True(t, exists)
 		assert.Equal(t, "instance-2", string(rec2.Fields["name"].Data.Value))
 
-		rec3, exists := data["aws.s3.bucket\x00my-bucket"]
+		rec3, exists := data["aws.s3.bucket\x1emy-bucket"]
 		assert.True(t, exists)
 		assert.Equal(t, "bucket-name", string(rec3.Fields["name"].Data.Value))
 	})
@@ -572,7 +572,7 @@ func TestGetAssetData(t *testing.T) {
 		data, ok := r.GetAssetData("test-mrn")
 		assert.True(t, ok)
 
-		rec, exists := data["aws.ec2.instance\x00i-multi"]
+		rec, exists := data["aws.ec2.instance\x1ei-multi"]
 		assert.True(t, exists)
 		assert.Equal(t, 2, len(rec.Fields))
 		assert.Equal(t, "my-instance", string(rec.Fields["name"].Data.Value))

--- a/providers-sdk/v1/recording/upstream_recording.go
+++ b/providers-sdk/v1/recording/upstream_recording.go
@@ -111,7 +111,7 @@ func (n *Upstream) GetResource(_ llx.AssetRecordingLookup, resource string, id s
 	n.lock.Lock()
 	defer n.lock.Unlock()
 
-	cacheID := resource + "\x00" + id
+	cacheID := resource + keySep + id
 	if exist, ok := n.resourcesCache[cacheID]; ok {
 		return exist.fields, true
 	}


### PR DESCRIPTION
## Summary
- Postgres does not allow null bytes (`\x00`) in text/JSON columns, which breaks when recording data is stored upstream
- Replaced the composite map key separator with ASCII Record Separator (`\x1e`) throughout the recording package
- Added a `keySep` constant so the separator is defined in one place

## Test plan
- [x] All existing recording package tests pass (`go test ./providers-sdk/v1/recording/ -v`)
- [ ] Verify upstream recording storage works with Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)