### PR TITLE
✨ surface internet-exposure fields on gcp resources

### DIFF
--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -1174,6 +1174,7 @@ func (g *mqlGcpProjectComputeService) snapshots() ([]any, error) {
 		for _, snapshot := range page.Items {
 			mqlSnapshpt, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.snapshot", map[string]*llx.RawData{
 				"id":                             llx.StringData(strconv.FormatUint(snapshot.Id, 10)),
+				"projectId":                      llx.StringData(projectId),
 				"name":                           llx.StringData(snapshot.Name),
 				"description":                    llx.StringData(snapshot.Description),
 				"architecture":                   llx.StringData(snapshot.Architecture),
@@ -3145,4 +3146,74 @@ func (g *mqlGcpProjectComputeService) storagePools() ([]any, error) {
 		return nil, err
 	}
 	return res, nil
+}
+
+func computeIamBindingsToResources(runtime *plugin.Runtime, idPrefix string, bindings []*compute.Binding) ([]any, error) {
+	res := make([]any, 0, len(bindings))
+	for i, b := range bindings {
+		mqlBinding, err := CreateResource(runtime, "gcp.resourcemanager.binding", map[string]*llx.RawData{
+			"id":      llx.StringData(idPrefix + "-" + strconv.Itoa(i)),
+			"role":    llx.StringData(b.Role),
+			"members": llx.ArrayData(convert.SliceAnyToInterface(b.Members), types.String),
+		})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlBinding)
+	}
+	return res, nil
+}
+
+func (g *mqlGcpProjectComputeServiceImage) iamPolicy() ([]any, error) {
+	if g.ProjectId.Error != nil {
+		return nil, g.ProjectId.Error
+	}
+	if g.Name.Error != nil {
+		return nil, g.Name.Error
+	}
+	projectId := g.ProjectId.Data
+	name := g.Name.Data
+
+	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
+	client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope, iam.CloudPlatformScope, compute.CloudPlatformScope)
+	if err != nil {
+		return nil, err
+	}
+	ctx := context.Background()
+	svc, err := compute.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		return nil, err
+	}
+	policy, err := svc.Images.GetIamPolicy(projectId, name).Context(ctx).Do()
+	if err != nil {
+		return nil, err
+	}
+	return computeIamBindingsToResources(g.MqlRuntime, name, policy.Bindings)
+}
+
+func (g *mqlGcpProjectComputeServiceSnapshot) iamPolicy() ([]any, error) {
+	if g.ProjectId.Error != nil {
+		return nil, g.ProjectId.Error
+	}
+	if g.Name.Error != nil {
+		return nil, g.Name.Error
+	}
+	projectId := g.ProjectId.Data
+	name := g.Name.Data
+
+	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
+	client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope, iam.CloudPlatformScope, compute.CloudPlatformScope)
+	if err != nil {
+		return nil, err
+	}
+	ctx := context.Background()
+	svc, err := compute.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		return nil, err
+	}
+	policy, err := svc.Snapshots.GetIamPolicy(projectId, name).Context(ctx).Do()
+	if err != nil {
+		return nil, err
+	}
+	return computeIamBindingsToResources(g.MqlRuntime, name, policy.Bindings)
 }

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -1065,6 +1065,8 @@ private gcp.project.computeService.attachedDisk {
 private gcp.project.computeService.snapshot @defaults("name") {
   // Unique identifier
   id string
+  // Project ID
+  projectId string
   // Name of the resource
   name string
   // Optional description
@@ -1109,6 +1111,8 @@ private gcp.project.computeService.snapshot @defaults("name") {
   sourceSnapshotSchedulePolicy string
   // ID of the snapshot schedule policy
   sourceSnapshotSchedulePolicyId string
+  // IAM policy bindings for this snapshot (includes allUsers / allAuthenticatedUsers grants when the snapshot is publicly shared)
+  iamPolicy() []gcp.resourcemanager.binding
 }
 
 // Google Cloud (GCP) Compute
@@ -1151,6 +1155,8 @@ private gcp.project.computeService.image @defaults("id name") {
   sourceImage() gcp.project.computeService.image
   // Source snapshot used to create this image
   sourceSnapshot() gcp.project.computeService.snapshot
+  // IAM policy bindings for this image (includes allUsers / allAuthenticatedUsers grants when the image is publicly shared)
+  iamPolicy() []gcp.resourcemanager.binding
 }
 
 // Google Cloud (GCP) Compute firewall
@@ -1883,6 +1889,20 @@ private gcp.project.sqlService.instance.settings.ipConfiguration {
   enablePrivatePathForGoogleCloudServices bool
   // Specifies how the server CA certificate is signed (GOOGLE_MANAGED_INTERNAL_CA, GOOGLE_MANAGED_CAS_CA)
   serverCaMode string
+  // Private Service Connect configuration
+  pscConfig gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig
+}
+
+// Google Cloud (GCP) SQL instance Private Service Connect configuration
+private gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig @defaults("pscEnabled") {
+  // Internal ID for this resource
+  id string
+  // Whether Private Service Connect is enabled on the instance
+  pscEnabled bool
+  // List of consumer projects that are allow-listed to create a PSC endpoint to the Cloud SQL instance
+  allowedConsumerProjects []string
+  // Whether auto-creation of PSC DNS records for the Cloud SQL instance is enabled
+  pscAutoConnections []dict
 }
 
 // Google Cloud (GCP) SQL instance settings maintenance window

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -71,6 +71,7 @@ const (
 	ResourceGcpProjectSqlServiceInstanceSettingsBackupconfiguration                    string = "gcp.project.sqlService.instance.settings.backupconfiguration"
 	ResourceGcpProjectSqlServiceInstanceSettingsDenyMaintenancePeriod                  string = "gcp.project.sqlService.instance.settings.denyMaintenancePeriod"
 	ResourceGcpProjectSqlServiceInstanceSettingsIpConfiguration                        string = "gcp.project.sqlService.instance.settings.ipConfiguration"
+	ResourceGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig               string = "gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig"
 	ResourceGcpProjectSqlServiceInstanceSettingsMaintenanceWindow                      string = "gcp.project.sqlService.instance.settings.maintenanceWindow"
 	ResourceGcpProjectSqlServiceInstanceSettingsPasswordValidationPolicy               string = "gcp.project.sqlService.instance.settings.passwordValidationPolicy"
 	ResourceGcpProjectBigqueryService                                                  string = "gcp.project.bigqueryService"
@@ -558,6 +559,10 @@ func init() {
 		"gcp.project.sqlService.instance.settings.ipConfiguration": {
 			// to override args, implement: initGcpProjectSqlServiceInstanceSettingsIpConfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createGcpProjectSqlServiceInstanceSettingsIpConfiguration,
+		},
+		"gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig": {
+			// to override args, implement: initGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig,
 		},
 		"gcp.project.sqlService.instance.settings.maintenanceWindow": {
 			// to override args, implement: initGcpProjectSqlServiceInstanceSettingsMaintenanceWindow(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -3049,6 +3054,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.snapshot.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSnapshot).GetId()).ToDataRes(types.String)
 	},
+	"gcp.project.computeService.snapshot.projectId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceSnapshot).GetProjectId()).ToDataRes(types.String)
+	},
 	"gcp.project.computeService.snapshot.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSnapshot).GetName()).ToDataRes(types.String)
 	},
@@ -3115,6 +3123,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.snapshot.sourceSnapshotSchedulePolicyId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSnapshot).GetSourceSnapshotSchedulePolicyId()).ToDataRes(types.String)
 	},
+	"gcp.project.computeService.snapshot.iamPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceSnapshot).GetIamPolicy()).ToDataRes(types.Array(types.Resource("gcp.resourcemanager.binding")))
+	},
 	"gcp.project.computeService.image.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceImage).GetId()).ToDataRes(types.String)
 	},
@@ -3171,6 +3182,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.image.sourceSnapshot": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceImage).GetSourceSnapshot()).ToDataRes(types.Resource("gcp.project.computeService.snapshot"))
+	},
+	"gcp.project.computeService.image.iamPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceImage).GetIamPolicy()).ToDataRes(types.Array(types.Resource("gcp.resourcemanager.binding")))
 	},
 	"gcp.project.computeService.firewall.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceFirewall).GetId()).ToDataRes(types.String)
@@ -4089,6 +4103,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.sqlService.instance.settings.ipConfiguration.serverCaMode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).GetServerCaMode()).ToDataRes(types.String)
+	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).GetPscConfig()).ToDataRes(types.Resource("gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig"))
+	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig).GetId()).ToDataRes(types.String)
+	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig.pscEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig).GetPscEnabled()).ToDataRes(types.Bool)
+	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig.allowedConsumerProjects": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig).GetAllowedConsumerProjects()).ToDataRes(types.Array(types.String))
+	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig.pscAutoConnections": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig).GetPscAutoConnections()).ToDataRes(types.Array(types.Dict))
 	},
 	"gcp.project.sqlService.instance.settings.maintenanceWindow.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsMaintenanceWindow).GetId()).ToDataRes(types.String)
@@ -13050,6 +13079,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceSnapshot).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.snapshot.projectId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceSnapshot).ProjectId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.snapshot.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceSnapshot).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -13138,6 +13171,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceSnapshot).SourceSnapshotSchedulePolicyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.snapshot.iamPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceSnapshot).IamPolicy, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.image.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceImage).__id, ok = v.Value.(string)
 		return
@@ -13216,6 +13253,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.image.sourceSnapshot": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceImage).SourceSnapshot, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceSnapshot](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.image.iamPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceImage).IamPolicy, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.firewall.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -14532,6 +14573,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.sqlService.instance.settings.ipConfiguration.serverCaMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).ServerCaMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).PscConfig, ok = plugin.RawToTValue[*mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig).__id, ok = v.Value.(string)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig.pscEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig).PscEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig.allowedConsumerProjects": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig).AllowedConsumerProjects, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig.pscAutoConnections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig).PscAutoConnections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.sqlService.instance.settings.maintenanceWindow.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -30047,6 +30112,7 @@ type mqlGcpProjectComputeServiceSnapshot struct {
 	__id       string
 	// optional: if you define mqlGcpProjectComputeServiceSnapshotInternal it will be used here
 	Id                             plugin.TValue[string]
+	ProjectId                      plugin.TValue[string]
 	Name                           plugin.TValue[string]
 	Description                    plugin.TValue[string]
 	Architecture                   plugin.TValue[string]
@@ -30069,6 +30135,7 @@ type mqlGcpProjectComputeServiceSnapshot struct {
 	SourceDisk                     plugin.TValue[string]
 	SourceSnapshotSchedulePolicy   plugin.TValue[string]
 	SourceSnapshotSchedulePolicyId plugin.TValue[string]
+	IamPolicy                      plugin.TValue[[]any]
 }
 
 // createGcpProjectComputeServiceSnapshot creates a new instance of this resource
@@ -30110,6 +30177,10 @@ func (c *mqlGcpProjectComputeServiceSnapshot) MqlID() string {
 
 func (c *mqlGcpProjectComputeServiceSnapshot) GetId() *plugin.TValue[string] {
 	return &c.Id
+}
+
+func (c *mqlGcpProjectComputeServiceSnapshot) GetProjectId() *plugin.TValue[string] {
+	return &c.ProjectId
 }
 
 func (c *mqlGcpProjectComputeServiceSnapshot) GetName() *plugin.TValue[string] {
@@ -30200,6 +30271,22 @@ func (c *mqlGcpProjectComputeServiceSnapshot) GetSourceSnapshotSchedulePolicyId(
 	return &c.SourceSnapshotSchedulePolicyId
 }
 
+func (c *mqlGcpProjectComputeServiceSnapshot) GetIamPolicy() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.IamPolicy, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.snapshot", c.__id, "iamPolicy")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.iamPolicy()
+	})
+}
+
 // mqlGcpProjectComputeServiceImage for the gcp.project.computeService.image resource
 type mqlGcpProjectComputeServiceImage struct {
 	MqlRuntime *plugin.Runtime
@@ -30224,6 +30311,7 @@ type mqlGcpProjectComputeServiceImage struct {
 	SourceDisk                plugin.TValue[*mqlGcpProjectComputeServiceDisk]
 	SourceImage               plugin.TValue[*mqlGcpProjectComputeServiceImage]
 	SourceSnapshot            plugin.TValue[*mqlGcpProjectComputeServiceSnapshot]
+	IamPolicy                 plugin.TValue[[]any]
 }
 
 // createGcpProjectComputeServiceImage creates a new instance of this resource
@@ -30372,6 +30460,22 @@ func (c *mqlGcpProjectComputeServiceImage) GetSourceSnapshot() *plugin.TValue[*m
 		}
 
 		return c.sourceSnapshot()
+	})
+}
+
+func (c *mqlGcpProjectComputeServiceImage) GetIamPolicy() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.IamPolicy, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.image", c.__id, "iamPolicy")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.iamPolicy()
 	})
 }
 
@@ -33031,6 +33135,7 @@ type mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration struct {
 	SslMode                                 plugin.TValue[string]
 	EnablePrivatePathForGoogleCloudServices plugin.TValue[bool]
 	ServerCaMode                            plugin.TValue[string]
+	PscConfig                               plugin.TValue[*mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig]
 }
 
 // createGcpProjectSqlServiceInstanceSettingsIpConfiguration creates a new instance of this resource
@@ -33104,6 +33209,74 @@ func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetEnablePrivat
 
 func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetServerCaMode() *plugin.TValue[string] {
 	return &c.ServerCaMode
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetPscConfig() *plugin.TValue[*mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig] {
+	return &c.PscConfig
+}
+
+// mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig for the gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig resource
+type mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfigInternal it will be used here
+	Id                      plugin.TValue[string]
+	PscEnabled              plugin.TValue[bool]
+	AllowedConsumerProjects plugin.TValue[[]any]
+	PscAutoConnections      plugin.TValue[[]any]
+}
+
+// createGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig creates a new instance of this resource
+func createGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig) MqlName() string {
+	return "gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig"
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig) GetPscEnabled() *plugin.TValue[bool] {
+	return &c.PscEnabled
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig) GetAllowedConsumerProjects() *plugin.TValue[[]any] {
+	return &c.AllowedConsumerProjects
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig) GetPscAutoConnections() *plugin.TValue[[]any] {
+	return &c.PscAutoConnections
 }
 
 // mqlGcpProjectSqlServiceInstanceSettingsMaintenanceWindow for the gcp.project.sqlService.instance.settings.maintenanceWindow resource

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -1219,6 +1219,7 @@ gcp.project.computeService.image.description 9.0.0
 gcp.project.computeService.image.diskSizeGb 9.0.0
 gcp.project.computeService.image.enableConfidentialCompute 11.6.6
 gcp.project.computeService.image.family 9.0.0
+gcp.project.computeService.image.iamPolicy 13.10.1
 gcp.project.computeService.image.id 9.0.0
 gcp.project.computeService.image.labels 9.0.0
 gcp.project.computeService.image.licenses 9.0.0
@@ -1602,10 +1603,12 @@ gcp.project.computeService.snapshot.description 9.0.0
 gcp.project.computeService.snapshot.diskSizeGb 9.0.0
 gcp.project.computeService.snapshot.downloadBytes 9.0.0
 gcp.project.computeService.snapshot.enableConfidentialCompute 11.6.6
+gcp.project.computeService.snapshot.iamPolicy 13.10.1
 gcp.project.computeService.snapshot.id 9.0.0
 gcp.project.computeService.snapshot.labels 9.0.0
 gcp.project.computeService.snapshot.licenses 9.0.0
 gcp.project.computeService.snapshot.name 9.0.0
+gcp.project.computeService.snapshot.projectId 13.10.1
 gcp.project.computeService.snapshot.satisfiesPzi 11.6.6
 gcp.project.computeService.snapshot.satisfiesPzs 11.6.6
 gcp.project.computeService.snapshot.snapshotType 9.0.0
@@ -3067,6 +3070,11 @@ gcp.project.sqlService.instance.settings.ipConfiguration.enablePrivatePathForGoo
 gcp.project.sqlService.instance.settings.ipConfiguration.id 9.0.0
 gcp.project.sqlService.instance.settings.ipConfiguration.ipv4Enabled 9.0.0
 gcp.project.sqlService.instance.settings.ipConfiguration.privateNetwork 9.0.0
+gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig 13.10.1
+gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig.allowedConsumerProjects 13.10.1
+gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig.id 13.10.1
+gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig.pscAutoConnections 13.10.1
+gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig.pscEnabled 13.10.1
 gcp.project.sqlService.instance.settings.ipConfiguration.requireSsl 9.0.0
 gcp.project.sqlService.instance.settings.ipConfiguration.serverCaMode 13.2.3
 gcp.project.sqlService.instance.settings.ipConfiguration.sslMode 9.0.0

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -326,6 +326,25 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 					mqlAclEntries = append(mqlAclEntries, mqlAclEntry)
 				}
 
+				var mqlPscCfg plugin.Resource
+				if s.IpConfiguration.PscConfig != nil {
+					pscAutoConnections := make([]any, 0, len(s.IpConfiguration.PscConfig.PscAutoConnections))
+					for _, c := range s.IpConfiguration.PscConfig.PscAutoConnections {
+						if d, err := convert.JsonToDict(c); err == nil {
+							pscAutoConnections = append(pscAutoConnections, d)
+						}
+					}
+					mqlPscCfg, err = CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig", map[string]*llx.RawData{
+						"id":                      llx.StringData(fmt.Sprintf("%s/settings/ipConfiguration/pscConfig", instanceId)),
+						"pscEnabled":              llx.BoolData(s.IpConfiguration.PscConfig.PscEnabled),
+						"allowedConsumerProjects": llx.ArrayData(convert.SliceAnyToInterface(s.IpConfiguration.PscConfig.AllowedConsumerProjects), types.String),
+						"pscAutoConnections":      llx.ArrayData(pscAutoConnections, types.Dict),
+					})
+					if err != nil {
+						return err
+					}
+				}
+
 				mqlIpCfg, err = CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings.ipConfiguration", map[string]*llx.RawData{
 					"allocatedIpRange":                        llx.StringData(s.IpConfiguration.AllocatedIpRange),
 					"authorizedNetworks":                      llx.ArrayData(mqlAclEntries, types.Dict),
@@ -336,6 +355,7 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 					"requireSsl":     llx.BoolData(s.IpConfiguration.RequireSsl),
 					"sslMode":        llx.StringData(s.IpConfiguration.SslMode),
 					"serverCaMode":   llx.StringData(s.IpConfiguration.ServerCaMode),
+					"pscConfig":      llx.ResourceData(mqlPscCfg, "gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig"),
 				})
 				if err != nil {
 					return err
@@ -674,6 +694,10 @@ func (g *mqlGcpProjectSqlServiceInstanceSettingsDenyMaintenancePeriod) id() (str
 }
 
 func (g *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) id() (string, error) {
+	return g.Id.Data, g.Id.Error
+}
+
+func (g *mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig) id() (string, error) {
 	return g.Id.Data, g.Id.Error
 }
 


### PR DESCRIPTION
## Summary

Adds SDK-backed fields so users can query for "what is exposed to the internet?" on GCP without parsing dicts or joining on self-link URLs.

### Changes by resource

- **`gcp.project.computeService.image`** — `iamPolicy()` → `[]gcp.resourcemanager.binding`
- **`gcp.project.computeService.snapshot`** — `iamPolicy()` and `projectId` (prerequisite for the per-project IAM lookup)
- **`gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig`** — new typed sub-resource with `pscEnabled`, `allowedConsumerProjects`, `pscAutoConnections`

### Why

- Compute images and snapshots can be shared with `allUsers` / `allAuthenticatedUsers` by IAM. The existing schema surfaced no way to spot that without a manual `gcloud` call per resource.
- Cloud SQL exposure via Private Service Connect (PSC) was invisible until now — only the legacy `ipv4Enabled` / `privateNetwork` / `authorizedNetworks` fields were modeled.

### Example queries this enables

```
# Publicly shared compute images
gcp.project.computeService.images.where(
  iamPolicy.any(role, members) { members.contains("allUsers") || members.contains("allAuthenticatedUsers") }
) { name, family, licenses }

# Publicly shared snapshots
gcp.project.computeService.snapshots.where(
  iamPolicy.any(role, members) { members.contains("allUsers") || members.contains("allAuthenticatedUsers") }
) { name, sourceDisk }

# SQL instances with Private Service Connect enabled and the consumer projects that can reach them
gcp.project.sqlService.instances.where(settings.ipConfiguration.pscConfig.pscEnabled) {
  name, settings.ipConfiguration.pscConfig.allowedConsumerProjects
}
```

## Test plan

- [ ] `make providers/build/gcp && make providers/install/gcp`
- [ ] `cnspec shell gcp`, run the queries above against a sandbox project
- [ ] Confirm `iamPolicy()` on a publicly shared image includes `allUsers`
- [ ] Confirm `pscConfig.pscEnabled` is true on a PSC-configured Cloud SQL instance
- [ ] `go test ./providers/gcp/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)