### PR TITLE
✨ surface internet-exposure fields on azure resources

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -43,6 +43,7 @@ awslogs
 AWSPENDING
 AWSPREVIOUS
 awsvpc
+azurewebsites
 backupconfiguration
 backupdr
 backupsetting

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -1812,6 +1812,10 @@ azure.subscription.webService.appsite @defaults("id name location") {
   enabled bool
   // Current state of the app
   state string
+  // Default hostname assigned to the app (e.g., "my-app.azurewebsites.net")
+  defaultHostName string
+  // All enabled hostnames for the app, including custom domains
+  enabledHostNames []string
   // Deployment slots for the web app site
   slots() []azure.subscription.webService.appslot
   // App site configuration
@@ -4711,6 +4715,8 @@ azure.subscription.serviceBusService.namespace @defaults("id name location") {
   serviceBusEndpoint string
   // Whether local (SAS key) authentication is disabled
   disableLocalAuth bool
+  // Whether the namespace is zone-redundant
+  zoneRedundant bool
   // Queues in this namespace
   queues() []azure.subscription.serviceBusService.namespace.queue
   // Topics in this namespace
@@ -4825,6 +4831,10 @@ azure.subscription.eventHubService.namespace @defaults("id name location") {
   disableLocalAuth bool
   // Minimum TLS version (e.g., "1.0", "1.1", "1.2")
   minimumTlsVersion string
+  // Whether public network access is enabled ("Enabled", "Disabled", or "SecuredByPerimeter")
+  publicNetworkAccess string
+  // Whether the namespace is zone-redundant
+  zoneRedundant bool
   // Event Hubs in this namespace
   eventHubs() []azure.subscription.eventHubService.namespace.eventHub
 }

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -3490,6 +3490,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.webService.appsite.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetState()).ToDataRes(types.String)
 	},
+	"azure.subscription.webService.appsite.defaultHostName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetDefaultHostName()).ToDataRes(types.String)
+	},
+	"azure.subscription.webService.appsite.enabledHostNames": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetEnabledHostNames()).ToDataRes(types.Array(types.String))
+	},
 	"azure.subscription.webService.appsite.slots": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetSlots()).ToDataRes(types.Array(types.Resource("azure.subscription.webService.appslot")))
 	},
@@ -7051,6 +7057,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.serviceBusService.namespace.disableLocalAuth": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespace).GetDisableLocalAuth()).ToDataRes(types.Bool)
 	},
+	"azure.subscription.serviceBusService.namespace.zoneRedundant": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespace).GetZoneRedundant()).ToDataRes(types.Bool)
+	},
 	"azure.subscription.serviceBusService.namespace.queues": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespace).GetQueues()).ToDataRes(types.Array(types.Resource("azure.subscription.serviceBusService.namespace.queue")))
 	},
@@ -7188,6 +7197,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.eventHubService.namespace.minimumTlsVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionEventHubServiceNamespace).GetMinimumTlsVersion()).ToDataRes(types.String)
+	},
+	"azure.subscription.eventHubService.namespace.publicNetworkAccess": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionEventHubServiceNamespace).GetPublicNetworkAccess()).ToDataRes(types.String)
+	},
+	"azure.subscription.eventHubService.namespace.zoneRedundant": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionEventHubServiceNamespace).GetZoneRedundant()).ToDataRes(types.Bool)
 	},
 	"azure.subscription.eventHubService.namespace.eventHubs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionEventHubServiceNamespace).GetEventHubs()).ToDataRes(types.Array(types.Resource("azure.subscription.eventHubService.namespace.eventHub")))
@@ -10756,6 +10771,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.webService.appsite.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebServiceAppsite).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appsite.defaultHostName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsite).DefaultHostName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appsite.enabledHostNames": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsite).EnabledHostNames, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.webService.appsite.slots": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16042,6 +16065,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionServiceBusServiceNamespace).DisableLocalAuth, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.serviceBusService.namespace.zoneRedundant": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionServiceBusServiceNamespace).ZoneRedundant, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.serviceBusService.namespace.queues": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionServiceBusServiceNamespace).Queues, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -16244,6 +16271,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.eventHubService.namespace.minimumTlsVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionEventHubServiceNamespace).MinimumTlsVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.eventHubService.namespace.publicNetworkAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionEventHubServiceNamespace).PublicNetworkAccess, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.eventHubService.namespace.zoneRedundant": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionEventHubServiceNamespace).ZoneRedundant, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.eventHubService.namespace.eventHubs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -25058,6 +25093,8 @@ type mqlAzureSubscriptionWebServiceAppsite struct {
 	ClientCertMode             plugin.TValue[string]
 	Enabled                    plugin.TValue[bool]
 	State                      plugin.TValue[string]
+	DefaultHostName            plugin.TValue[string]
+	EnabledHostNames           plugin.TValue[[]any]
 	Slots                      plugin.TValue[[]any]
 	Configuration              plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteconfig]
 	AuthenticationSettings     plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteauthsettings]
@@ -25171,6 +25208,14 @@ func (c *mqlAzureSubscriptionWebServiceAppsite) GetEnabled() *plugin.TValue[bool
 
 func (c *mqlAzureSubscriptionWebServiceAppsite) GetState() *plugin.TValue[string] {
 	return &c.State
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsite) GetDefaultHostName() *plugin.TValue[string] {
+	return &c.DefaultHostName
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsite) GetEnabledHostNames() *plugin.TValue[[]any] {
+	return &c.EnabledHostNames
 }
 
 func (c *mqlAzureSubscriptionWebServiceAppsite) GetSlots() *plugin.TValue[[]any] {
@@ -38727,6 +38772,7 @@ type mqlAzureSubscriptionServiceBusServiceNamespace struct {
 	Status             plugin.TValue[string]
 	ServiceBusEndpoint plugin.TValue[string]
 	DisableLocalAuth   plugin.TValue[bool]
+	ZoneRedundant      plugin.TValue[bool]
 	Queues             plugin.TValue[[]any]
 	Topics             plugin.TValue[[]any]
 }
@@ -38798,6 +38844,10 @@ func (c *mqlAzureSubscriptionServiceBusServiceNamespace) GetServiceBusEndpoint()
 
 func (c *mqlAzureSubscriptionServiceBusServiceNamespace) GetDisableLocalAuth() *plugin.TValue[bool] {
 	return &c.DisableLocalAuth
+}
+
+func (c *mqlAzureSubscriptionServiceBusServiceNamespace) GetZoneRedundant() *plugin.TValue[bool] {
+	return &c.ZoneRedundant
 }
 
 func (c *mqlAzureSubscriptionServiceBusServiceNamespace) GetQueues() *plugin.TValue[[]any] {
@@ -39213,6 +39263,8 @@ type mqlAzureSubscriptionEventHubServiceNamespace struct {
 	KafkaEnabled           plugin.TValue[bool]
 	DisableLocalAuth       plugin.TValue[bool]
 	MinimumTlsVersion      plugin.TValue[string]
+	PublicNetworkAccess    plugin.TValue[string]
+	ZoneRedundant          plugin.TValue[bool]
 	EventHubs              plugin.TValue[[]any]
 }
 
@@ -39295,6 +39347,14 @@ func (c *mqlAzureSubscriptionEventHubServiceNamespace) GetDisableLocalAuth() *pl
 
 func (c *mqlAzureSubscriptionEventHubServiceNamespace) GetMinimumTlsVersion() *plugin.TValue[string] {
 	return &c.MinimumTlsVersion
+}
+
+func (c *mqlAzureSubscriptionEventHubServiceNamespace) GetPublicNetworkAccess() *plugin.TValue[string] {
+	return &c.PublicNetworkAccess
+}
+
+func (c *mqlAzureSubscriptionEventHubServiceNamespace) GetZoneRedundant() *plugin.TValue[bool] {
+	return &c.ZoneRedundant
 }
 
 func (c *mqlAzureSubscriptionEventHubServiceNamespace) GetEventHubs() *plugin.TValue[[]any] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -766,9 +766,11 @@ azure.subscription.eventHubService.namespace.location 13.3.3
 azure.subscription.eventHubService.namespace.maximumThroughputUnits 13.3.3
 azure.subscription.eventHubService.namespace.minimumTlsVersion 13.3.3
 azure.subscription.eventHubService.namespace.name 13.3.3
+azure.subscription.eventHubService.namespace.publicNetworkAccess 13.4.3
 azure.subscription.eventHubService.namespace.sku 13.3.3
 azure.subscription.eventHubService.namespace.status 13.3.3
 azure.subscription.eventHubService.namespace.tags 13.3.3
+azure.subscription.eventHubService.namespace.zoneRedundant 13.4.3
 azure.subscription.eventHubService.namespaces 13.3.3
 azure.subscription.eventHubService.subscriptionId 13.3.3
 azure.subscription.frontDoor 13.3.3
@@ -1774,6 +1776,7 @@ azure.subscription.serviceBusService.namespace.topic.subscriptionCount 13.3.3
 azure.subscription.serviceBusService.namespace.topic.subscriptions 13.3.3
 azure.subscription.serviceBusService.namespace.topic.supportOrdering 13.3.3
 azure.subscription.serviceBusService.namespace.topics 13.3.3
+azure.subscription.serviceBusService.namespace.zoneRedundant 13.4.3
 azure.subscription.serviceBusService.namespaces 13.3.3
 azure.subscription.serviceBusService.subscriptionId 13.3.3
 azure.subscription.sql 9.0.0
@@ -2107,8 +2110,10 @@ azure.subscription.webService.appsite.clientCertEnabled 11.4.28
 azure.subscription.webService.appsite.clientCertMode 11.4.28
 azure.subscription.webService.appsite.configuration 9.0.1
 azure.subscription.webService.appsite.connectionSettings 9.0.1
+azure.subscription.webService.appsite.defaultHostName 13.4.3
 azure.subscription.webService.appsite.diagnosticSettings 11.3.0
 azure.subscription.webService.appsite.enabled 11.4.28
+azure.subscription.webService.appsite.enabledHostNames 13.4.3
 azure.subscription.webService.appsite.endToEndEncryptionEnabled 11.4.28
 azure.subscription.webService.appsite.ftp 11.3.31
 azure.subscription.webService.appsite.functions 11.3.3

--- a/providers/azure/resources/eventhub.go
+++ b/providers/azure/resources/eventhub.go
@@ -77,9 +77,9 @@ func (a *mqlAzureSubscriptionEventHubService) namespaces() ([]any, error) {
 			}
 
 			var status string
-			var isAutoInflateEnabled, kafkaEnabled, disableLocalAuth bool
+			var isAutoInflateEnabled, kafkaEnabled, disableLocalAuth, zoneRedundant bool
 			var maximumThroughputUnits int64
-			var minimumTlsVersion string
+			var minimumTlsVersion, publicNetworkAccess string
 			if ns.Properties != nil {
 				if ns.Properties.Status != nil {
 					status = *ns.Properties.Status
@@ -99,6 +99,12 @@ func (a *mqlAzureSubscriptionEventHubService) namespaces() ([]any, error) {
 				if ns.Properties.MinimumTLSVersion != nil {
 					minimumTlsVersion = string(*ns.Properties.MinimumTLSVersion)
 				}
+				if ns.Properties.PublicNetworkAccess != nil {
+					publicNetworkAccess = string(*ns.Properties.PublicNetworkAccess)
+				}
+				if ns.Properties.ZoneRedundant != nil {
+					zoneRedundant = *ns.Properties.ZoneRedundant
+				}
 			}
 
 			mqlNs, err := CreateResource(a.MqlRuntime, "azure.subscription.eventHubService.namespace", map[string]*llx.RawData{
@@ -113,6 +119,8 @@ func (a *mqlAzureSubscriptionEventHubService) namespaces() ([]any, error) {
 				"kafkaEnabled":           llx.BoolData(kafkaEnabled),
 				"disableLocalAuth":       llx.BoolData(disableLocalAuth),
 				"minimumTlsVersion":      llx.StringData(minimumTlsVersion),
+				"publicNetworkAccess":    llx.StringData(publicNetworkAccess),
+				"zoneRedundant":          llx.BoolData(zoneRedundant),
 			})
 			if err != nil {
 				return nil, err

--- a/providers/azure/resources/servicebus.go
+++ b/providers/azure/resources/servicebus.go
@@ -81,7 +81,7 @@ func (a *mqlAzureSubscriptionServiceBusService) namespaces() ([]any, error) {
 			}
 
 			var status, serviceBusEndpoint string
-			var disableLocalAuth bool
+			var disableLocalAuth, zoneRedundant bool
 			if ns.Properties != nil {
 				if ns.Properties.Status != nil {
 					status = *ns.Properties.Status
@@ -91,6 +91,9 @@ func (a *mqlAzureSubscriptionServiceBusService) namespaces() ([]any, error) {
 				}
 				if ns.Properties.DisableLocalAuth != nil {
 					disableLocalAuth = *ns.Properties.DisableLocalAuth
+				}
+				if ns.Properties.ZoneRedundant != nil {
+					zoneRedundant = *ns.Properties.ZoneRedundant
 				}
 			}
 
@@ -103,6 +106,7 @@ func (a *mqlAzureSubscriptionServiceBusService) namespaces() ([]any, error) {
 				"status":             llx.StringData(status),
 				"serviceBusEndpoint": llx.StringData(serviceBusEndpoint),
 				"disableLocalAuth":   llx.BoolData(disableLocalAuth),
+				"zoneRedundant":      llx.BoolData(zoneRedundant),
 			})
 			if err != nil {
 				return nil, err

--- a/providers/azure/resources/web.go
+++ b/providers/azure/resources/web.go
@@ -108,6 +108,8 @@ func createWebAppResourceFromSite(runtime *plugin.Runtime, resourceType string, 
 		}
 		args["enabled"] = llx.BoolDataPtr(site.Properties.Enabled)
 		args["state"] = llx.StringDataPtr(site.Properties.State)
+		args["defaultHostName"] = llx.StringDataPtr(site.Properties.DefaultHostName)
+		args["enabledHostNames"] = llx.ArrayData(convert.SliceStrPtrToInterface(site.Properties.EnabledHostNames), types.String)
 		args["endToEndEncryptionEnabled"] = llx.BoolDataPtr(site.Properties.EndToEndEncryptionEnabled)
 		args["sshEnabled"] = llx.BoolDataPtr(site.Properties.SSHEnabled)
 		args["publicNetworkAccess"] = llx.StringDataPtr(site.Properties.PublicNetworkAccess)


### PR DESCRIPTION
## Summary

Adds SDK-backed fields on Azure resources that already model most security controls but lacked the final exposure signals.

### Changes by resource

- **`azure.subscription.eventHubService.namespace`** — `publicNetworkAccess`, `zoneRedundant`
- **`azure.subscription.serviceBusService.namespace`** — `zoneRedundant` *(the Service Bus SDK v1.2.0 does not surface `publicNetworkAccess` on `SBNamespaceProperties`; it only exposes it through the separate `NetworkRuleSet` API call, so I deferred it rather than forcing an extra per-namespace round-trip)*
- **`azure.subscription.webService.appsite`** — `defaultHostName`, `enabledHostNames` — the auto-generated `*.azurewebsites.net` hostname and the full list of bound hostnames

### Example queries this enables

```
# Event Hub namespaces still accepting public traffic
azure.subscription.eventHubService.namespaces.where(publicNetworkAccess == "Enabled") { name, location }

# Web apps with a public default hostname (i.e., the auto-assigned azurewebsites.net URL is live)
azure.subscription.webService.apps.where(publicNetworkAccess == "Enabled") { name, defaultHostName, enabledHostNames }
```

## Test plan

- [ ] `make providers/build/azure && make providers/install/azure`
- [ ] `cnspec shell azure`, run queries above against a sandbox subscription
- [ ] Confirm `defaultHostName` matches the `*.azurewebsites.net` URL in the portal
- [ ] `go test ./providers/azure/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)