### PR TITLE
🎉 gcp-13.11.0

### DIFF
--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.10.0",
+	Version: "13.11.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### gcp (13.11.0)
- 🟢 add missing gcp compute iam-policy permissions to validated list (#7336)
- ✨ surface internet-exposure fields on gcp resources (#7333)