### PR TITLE
🐛 skip disabled AlloyDB API during GCP discovery

### DIFF
--- a/providers/gcp/resources/alloydb.go
+++ b/providers/gcp/resources/alloydb.go
@@ -11,6 +11,7 @@ import (
 
 	alloydb "cloud.google.com/go/alloydb/apiv1"
 	"cloud.google.com/go/alloydb/apiv1/alloydbpb"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -82,6 +83,10 @@ func (g *mqlGcpProjectAlloydbService) clusters() ([]any, error) {
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list AlloyDB clusters")
+				return nil, nil
+			}
 			return nil, err
 		}
 
@@ -297,6 +302,10 @@ func (g *mqlGcpProjectAlloydbServiceCluster) instances() ([]any, error) {
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list AlloyDB instances")
+				return nil, nil
+			}
 			return nil, err
 		}
 
@@ -437,6 +446,10 @@ func (g *mqlGcpProjectAlloydbServiceCluster) backups() ([]any, error) {
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list AlloyDB backups")
+				return nil, nil
+			}
 			return nil, err
 		}
 


### PR DESCRIPTION
## Summary
- `cnspec scan gcp project <id>` aborted with `PermissionDenied: AlloyDB API has not been used in project …` whenever the AlloyDB API wasn't enabled, because `alloydb.clusters` / `instances` / `backups` returned the raw gRPC error and `discovery.go` kills the scan on any target error.
- AlloyDB was the one service in the default `Auto` discovery set that skipped the established graceful-degradation pattern — every other service uses either `isServiceEnabled()` (`bigquery`, `cloudrun`, `dataproc`, `logging`, `pubsub`, …) or `isGRPCSkippable()` at the iterator (`backupdr`, `batch`, `cloudbuild`, `container_analysis`, `dlp`, `eventarc`, `gke_backup`, `ids`).
- Adopt the `isGRPCSkippable` pattern (matches `backupdr.go`) at the three `ListX` iterators in `alloydb.go` so disabled APIs, missing permissions, and NotFound locations log a warning and return an empty list instead of failing the whole scan.

## Test plan
- [ ] `cnspec scan gcp project <project-without-alloydb-api-enabled>` completes successfully and emits a warning for AlloyDB instead of aborting.
- [ ] `mql run gcp project <id> -c "gcp.project.alloydb.clusters"` returns `[]` (with a log warning) when AlloyDB API is disabled.
- [ ] Scanning a project where AlloyDB IS enabled still lists clusters/instances/backups as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)