### PR TITLE
⭐ expose Spanner, Firestore, and Bigtable as GCP platforms

### DIFF
--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -69,6 +69,9 @@ Examples with the GCP project configured:
 				resources.DiscoverApiKeys,
 				resources.DiscoverIamServiceAccounts,
 				resources.DiscoverAlloyDBClusters,
+				resources.DiscoverSpannerInstances,
+				resources.DiscoverFirestoreDatabases,
+				resources.DiscoverBigtableInstances,
 			},
 			Flags: []plugin.Flag{
 				{

--- a/providers/gcp/connection/platform.go
+++ b/providers/gcp/connection/platform.go
@@ -146,6 +146,12 @@ func GetTitleForPlatformName(name string) string {
 		return "GCP Dataproc Cluster"
 	case "gcp-alloydb-cluster":
 		return "GCP AlloyDB Cluster"
+	case "gcp-spanner-instance":
+		return "GCP Spanner Instance"
+	case "gcp-firestore-database":
+		return "GCP Firestore Database"
+	case "gcp-bigtable-instance":
+		return "GCP Bigtable Instance"
 	case "gcp-logging-bucket":
 		return "GCP Logging Bucket"
 	case "gcp-apikey":
@@ -261,6 +267,27 @@ func ResourceTechnologyUrl(service, project, region, objectType, name string) []
 			return []string{"gcp", project, "alloydb", region, "cluster"}
 		default:
 			return []string{"gcp", project, "alloydb", region, "other"}
+		}
+	case "spanner":
+		switch objectType {
+		case "instance":
+			return []string{"gcp", project, "spanner", region, "instance"}
+		default:
+			return []string{"gcp", project, "spanner", region, "other"}
+		}
+	case "firestore":
+		switch objectType {
+		case "database":
+			return []string{"gcp", project, "firestore", region, "database"}
+		default:
+			return []string{"gcp", project, "firestore", region, "other"}
+		}
+	case "bigtable":
+		switch objectType {
+		case "instance":
+			return []string{"gcp", project, "bigtable", region, "instance"}
+		default:
+			return []string{"gcp", project, "bigtable", region, "other"}
 		}
 	case "logging":
 		switch objectType {

--- a/providers/gcp/resources/bigtable.go
+++ b/providers/gcp/resources/bigtable.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/bigtable"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -51,6 +52,52 @@ func initGcpProjectBigtableService(runtime *plugin.Runtime, args map[string]*llx
 	return args, nil, nil
 }
 
+// initGcpProjectBigtableServiceInstance lets policies query a single Bigtable
+// instance directly (e.g. when cnspec scans a gcp-bigtable-instance asset).
+func initGcpProjectBigtableServiceInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+
+	if len(args) == 0 {
+		if args == nil {
+			args = make(map[string]*llx.RawData)
+		}
+		if ids := getAssetIdentifier(runtime); ids != nil {
+			args["name"] = llx.StringData(ids.name)
+			args["projectId"] = llx.StringData(ids.project)
+		} else {
+			return nil, nil, errors.New("no asset identifier found")
+		}
+	}
+
+	obj, err := CreateResource(runtime, "gcp.project.bigtableService", map[string]*llx.RawData{
+		"projectId": args["projectId"],
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	bigtableSvc := obj.(*mqlGcpProjectBigtableService)
+	instances := bigtableSvc.GetInstances()
+	if instances.Error != nil {
+		return nil, nil, instances.Error
+	}
+
+	nameVal := args["name"].Value.(string)
+	for _, i := range instances.Data {
+		instance := i.(*mqlGcpProjectBigtableServiceInstance)
+		// Bigtable instance name from the SDK is the short ID; it may also
+		// arrive as the full resource path projects/{project}/instances/{id}.
+		nameParts := strings.Split(instance.Name.Data, "/")
+		instanceName := nameParts[len(nameParts)-1]
+		if instanceName == nameVal {
+			return args, instance, nil
+		}
+	}
+
+	return nil, nil, fmt.Errorf("Bigtable instance %q not found", nameVal)
+}
+
 func (g *mqlGcpProjectBigtableService) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error
@@ -79,6 +126,10 @@ func (g *mqlGcpProjectBigtableService) instances() ([]any, error) {
 
 	instances, err := iac.Instances(ctx)
 	if err != nil {
+		if isGRPCSkippable(err) {
+			log.Warn().Err(err).Msg("could not list Bigtable instances")
+			return nil, nil
+		}
 		return nil, err
 	}
 
@@ -159,6 +210,10 @@ func (g *mqlGcpProjectBigtableServiceInstance) clusters() ([]any, error) {
 
 	clusters, err := iac.Clusters(ctx, instanceName)
 	if err != nil {
+		if isGRPCSkippable(err) {
+			log.Warn().Err(err).Msg("could not list Bigtable clusters")
+			return nil, nil
+		}
 		return nil, err
 	}
 
@@ -259,6 +314,10 @@ func (g *mqlGcpProjectBigtableServiceInstance) tables() ([]any, error) {
 
 	tableNames, err := ac.Tables(ctx)
 	if err != nil {
+		if isGRPCSkippable(err) {
+			log.Warn().Err(err).Msg("could not list Bigtable tables")
+			return nil, nil
+		}
 		return nil, err
 	}
 
@@ -266,6 +325,10 @@ func (g *mqlGcpProjectBigtableServiceInstance) tables() ([]any, error) {
 	for _, tableName := range tableNames {
 		tableInfo, err := ac.TableInfo(ctx, tableName)
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Str("table", tableName).Msg("could not read Bigtable table info")
+				continue
+			}
 			return nil, err
 		}
 
@@ -363,6 +426,10 @@ func (g *mqlGcpProjectBigtableServiceInstance) appProfiles() ([]any, error) {
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list Bigtable app profiles")
+				return nil, nil
+			}
 			return nil, err
 		}
 
@@ -440,6 +507,10 @@ func (g *mqlGcpProjectBigtableServiceInstance) backups() ([]any, error) {
 
 	clusters, err := iac.Clusters(ctx, instanceName)
 	if err != nil {
+		if isGRPCSkippable(err) {
+			log.Warn().Err(err).Msg("could not list Bigtable clusters for backup lookup")
+			return nil, nil
+		}
 		return nil, err
 	}
 
@@ -465,6 +536,10 @@ func (g *mqlGcpProjectBigtableServiceInstance) backups() ([]any, error) {
 				break
 			}
 			if err != nil {
+				if isGRPCSkippable(err) {
+					log.Warn().Err(err).Str("cluster", clusterID).Msg("could not list Bigtable backups")
+					break
+				}
 				return nil, err
 			}
 

--- a/providers/gcp/resources/discovery.go
+++ b/providers/gcp/resources/discovery.go
@@ -1189,6 +1189,9 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, 
 					Family:                []string{"google"},
 					TechnologyUrlSegments: connection.ResourceTechnologyUrl("firestore", gcpProject.Id.Data, location, "database", dbName),
 				},
+				// Firestore's adminpb.Database has Tags but no Labels field;
+				// emit an empty map for consistency with other GCP assets.
+				Labels:      map[string]string{},
 				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
 			})
 		}

--- a/providers/gcp/resources/discovery.go
+++ b/providers/gcp/resources/discovery.go
@@ -59,6 +59,9 @@ const (
 	DiscoverApiKeys                 = "apikeys"
 	DiscoverIamServiceAccounts      = "iam-service-accounts"
 	DiscoverAlloyDBClusters         = "alloydb-clusters"
+	DiscoverSpannerInstances        = "spanner-instances"
+	DiscoverFirestoreDatabases      = "firestore-databases"
+	DiscoverBigtableInstances       = "bigtable-instances"
 )
 
 // All includes every discovery target: Auto covers all of them for GCP.
@@ -95,6 +98,9 @@ var Auto = []string{
 	DiscoverApiKeys,
 	DiscoverIamServiceAccounts,
 	DiscoverAlloyDBClusters,
+	DiscoverSpannerInstances,
+	DiscoverFirestoreDatabases,
+	DiscoverBigtableInstances,
 }
 
 var AllAPIResources = []string{
@@ -125,6 +131,9 @@ var AllAPIResources = []string{
 	DiscoverApiKeys,
 	DiscoverIamServiceAccounts,
 	DiscoverAlloyDBClusters,
+	DiscoverSpannerInstances,
+	DiscoverFirestoreDatabases,
+	DiscoverBigtableInstances,
 }
 
 // List of all CloudSQL types, this will be used during discovery
@@ -1108,6 +1117,114 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, 
 					TechnologyUrlSegments: connection.ResourceTechnologyUrl("alloydb", gcpProject.Id.Data, location, "cluster", clusterName),
 				},
 				Labels:      mapStrInterfaceToMapStrStr(cluster.GetLabels().Data),
+				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+			})
+		}
+	}
+
+	if stringx.ContainsAnyOf(discoveryTargets, DiscoverSpannerInstances) {
+		spannerService := gcpProject.GetSpanner()
+		if spannerService.Error != nil {
+			return nil, spannerService.Error
+		}
+		instances := spannerService.Data.GetInstances()
+		if instances.Error != nil {
+			return nil, instances.Error
+		}
+		for i := range instances.Data {
+			instance := instances.Data[i].(*mqlGcpProjectSpannerServiceInstance)
+			// Spanner instance names are global within a project (no location
+			// segment); the regional placement is expressed by the instance's
+			// config. Use "global" here to match the platform-id scheme used
+			// by other non-regional resources (e.g. API keys, IAM).
+			instanceName := parseResourceName(instance.Name.Data)
+			location := "global"
+
+			assetList = append(assetList, &inventory.Asset{
+				PlatformIds: []string{
+					connection.NewResourcePlatformID("spanner", gcpProject.Id.Data, location, "instance", instanceName),
+				},
+				Name: instanceName,
+				Platform: &inventory.Platform{
+					Name:                  "gcp-spanner-instance",
+					Title:                 connection.GetTitleForPlatformName("gcp-spanner-instance"),
+					Runtime:               "gcp",
+					Kind:                  "gcp-object",
+					Family:                []string{"google"},
+					TechnologyUrlSegments: connection.ResourceTechnologyUrl("spanner", gcpProject.Id.Data, location, "instance", instanceName),
+				},
+				Labels:      mapStrInterfaceToMapStrStr(instance.GetLabels().Data),
+				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+			})
+		}
+	}
+
+	if stringx.ContainsAnyOf(discoveryTargets, DiscoverFirestoreDatabases) {
+		firestoreService := gcpProject.GetFirestore()
+		if firestoreService.Error != nil {
+			return nil, firestoreService.Error
+		}
+		databases := firestoreService.Data.GetDatabases()
+		if databases.Error != nil {
+			return nil, databases.Error
+		}
+		for i := range databases.Data {
+			database := databases.Data[i].(*mqlGcpProjectFirestoreServiceDatabase)
+			dbName := parseResourceName(database.Name.Data)
+			location := database.LocationId.Data
+			if location == "" {
+				location = "global"
+			}
+
+			assetList = append(assetList, &inventory.Asset{
+				PlatformIds: []string{
+					connection.NewResourcePlatformID("firestore", gcpProject.Id.Data, location, "database", dbName),
+				},
+				Name: dbName,
+				Platform: &inventory.Platform{
+					Name:                  "gcp-firestore-database",
+					Title:                 connection.GetTitleForPlatformName("gcp-firestore-database"),
+					Runtime:               "gcp",
+					Kind:                  "gcp-object",
+					Family:                []string{"google"},
+					TechnologyUrlSegments: connection.ResourceTechnologyUrl("firestore", gcpProject.Id.Data, location, "database", dbName),
+				},
+				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+			})
+		}
+	}
+
+	if stringx.ContainsAnyOf(discoveryTargets, DiscoverBigtableInstances) {
+		bigtableService := gcpProject.GetBigtable()
+		if bigtableService.Error != nil {
+			return nil, bigtableService.Error
+		}
+		instances := bigtableService.Data.GetInstances()
+		if instances.Error != nil {
+			return nil, instances.Error
+		}
+		for i := range instances.Data {
+			instance := instances.Data[i].(*mqlGcpProjectBigtableServiceInstance)
+			// Bigtable instances are themselves location-independent; their
+			// placement is per-cluster. Use "global" here to match the
+			// project-scoped platform-id scheme used by API keys and IAM.
+			instanceName := parseResourceName(instance.Name.Data)
+			location := "global"
+
+			assetList = append(assetList, &inventory.Asset{
+				PlatformIds: []string{
+					connection.NewResourcePlatformID("bigtable", gcpProject.Id.Data, location, "instance", instanceName),
+				},
+				Name: instanceName,
+				Platform: &inventory.Platform{
+					Name:                  "gcp-bigtable-instance",
+					Title:                 connection.GetTitleForPlatformName("gcp-bigtable-instance"),
+					Runtime:               "gcp",
+					Kind:                  "gcp-object",
+					Family:                []string{"google"},
+					TechnologyUrlSegments: connection.ResourceTechnologyUrl("bigtable", gcpProject.Id.Data, location, "instance", instanceName),
+				},
+				Labels:      mapStrInterfaceToMapStrStr(instance.GetLabels().Data),
 				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
 			})
 		}

--- a/providers/gcp/resources/discovery_test.go
+++ b/providers/gcp/resources/discovery_test.go
@@ -43,6 +43,9 @@ func TestAllResolvedResources(t *testing.T) {
 		DiscoverApiKeys,
 		DiscoverIamServiceAccounts,
 		DiscoverAlloyDBClusters,
+		DiscoverSpannerInstances,
+		DiscoverFirestoreDatabases,
+		DiscoverBigtableInstances,
 	}
 	require.ElementsMatch(t, expected, All)
 }
@@ -79,6 +82,9 @@ func TestAutoResolvedResources(t *testing.T) {
 		DiscoverApiKeys,
 		DiscoverIamServiceAccounts,
 		DiscoverAlloyDBClusters,
+		DiscoverSpannerInstances,
+		DiscoverFirestoreDatabases,
+		DiscoverBigtableInstances,
 	}
 	require.ElementsMatch(t, expected, Auto)
 }

--- a/providers/gcp/resources/firestore.go
+++ b/providers/gcp/resources/firestore.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	firestoreadmin "cloud.google.com/go/firestore/apiv1/admin"
 	"cloud.google.com/go/firestore/apiv1/admin/adminpb"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
@@ -43,6 +45,52 @@ func initGcpProjectFirestoreService(runtime *plugin.Runtime, args map[string]*ll
 	return args, nil, nil
 }
 
+// initGcpProjectFirestoreServiceDatabase lets policies query a single Firestore
+// database directly (e.g. when cnspec scans a gcp-firestore-database asset).
+func initGcpProjectFirestoreServiceDatabase(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+
+	if len(args) == 0 {
+		if args == nil {
+			args = make(map[string]*llx.RawData)
+		}
+		if ids := getAssetIdentifier(runtime); ids != nil {
+			args["name"] = llx.StringData(ids.name)
+			args["projectId"] = llx.StringData(ids.project)
+		} else {
+			return nil, nil, errors.New("no asset identifier found")
+		}
+	}
+
+	obj, err := CreateResource(runtime, "gcp.project.firestoreService", map[string]*llx.RawData{
+		"projectId": args["projectId"],
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	firestoreSvc := obj.(*mqlGcpProjectFirestoreService)
+	databases := firestoreSvc.GetDatabases()
+	if databases.Error != nil {
+		return nil, nil, databases.Error
+	}
+
+	nameVal := args["name"].Value.(string)
+	for _, d := range databases.Data {
+		database := d.(*mqlGcpProjectFirestoreServiceDatabase)
+		// Firestore database name is a full resource path:
+		// projects/{project}/databases/{database}
+		nameParts := strings.Split(database.Name.Data, "/")
+		dbName := nameParts[len(nameParts)-1]
+		if dbName == nameVal {
+			return args, database, nil
+		}
+	}
+
+	return nil, nil, fmt.Errorf("Firestore database %q not found", nameVal)
+}
+
 func (g *mqlGcpProjectFirestoreService) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error
@@ -73,6 +121,10 @@ func (g *mqlGcpProjectFirestoreService) databases() ([]any, error) {
 		Parent: fmt.Sprintf("projects/%s", projectId),
 	})
 	if err != nil {
+		if isGRPCSkippable(err) {
+			log.Warn().Err(err).Msg("could not list Firestore databases")
+			return nil, nil
+		}
 		return nil, err
 	}
 
@@ -189,6 +241,10 @@ func (g *mqlGcpProjectFirestoreServiceDatabase) indexes() ([]any, error) {
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list Firestore indexes")
+				return nil, nil
+			}
 			return nil, err
 		}
 
@@ -240,6 +296,10 @@ func (g *mqlGcpProjectFirestoreServiceDatabase) backupSchedules() ([]any, error)
 		Parent: databaseName,
 	})
 	if err != nil {
+		if isGRPCSkippable(err) {
+			log.Warn().Err(err).Msg("could not list Firestore backup schedules")
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/providers/gcp/resources/firestore.go
+++ b/providers/gcp/resources/firestore.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
 	"go.mondoo.com/mql/v13/types"
 	"google.golang.org/api/iterator"
@@ -171,6 +172,7 @@ func (g *mqlGcpProjectFirestoreService) databases() ([]any, error) {
 			"appEngineIntegrationMode":      llx.StringData(db.AppEngineIntegrationMode.String()),
 			"pointInTimeRecoveryEnablement": llx.StringData(db.PointInTimeRecoveryEnablement.String()),
 			"deleteProtectionState":         llx.StringData(db.DeleteProtectionState.String()),
+			"tags":                          llx.MapData(convert.MapToInterfaceMap(db.Tags), types.String),
 			"cmekConfig":                    llx.DictData(cmekConfig),
 			"versionRetentionPeriod":        llx.StringData(versionRetentionPeriod),
 			"earliestVersionTime":           earliestVersionTime,

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -4333,6 +4333,8 @@ private gcp.project.firestoreService.database @defaults("name") {
   pointInTimeRecoveryEnablement string
   // Delete protection state
   deleteProtectionState string
+  // Resource Manager tag keys/values bound to this database
+  tags map[string]string
   // Customer-managed encryption key configuration
   cmekConfig dict
   // Version retention period

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -1032,7 +1032,7 @@ func init() {
 			Create: createGcpProjectFirestoreService,
 		},
 		"gcp.project.firestoreService.database": {
-			// to override args, implement: initGcpProjectFirestoreServiceDatabase(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initGcpProjectFirestoreServiceDatabase,
 			Create: createGcpProjectFirestoreServiceDatabase,
 		},
 		"gcp.project.firestoreService.database.index": {
@@ -1048,7 +1048,7 @@ func init() {
 			Create: createGcpProjectSpannerService,
 		},
 		"gcp.project.spannerService.instance": {
-			// to override args, implement: initGcpProjectSpannerServiceInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initGcpProjectSpannerServiceInstance,
 			Create: createGcpProjectSpannerServiceInstance,
 		},
 		"gcp.project.spannerService.instance.database": {
@@ -1080,7 +1080,7 @@ func init() {
 			Create: createGcpProjectBigtableService,
 		},
 		"gcp.project.bigtableService.instance": {
-			// to override args, implement: initGcpProjectBigtableServiceInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initGcpProjectBigtableServiceInstance,
 			Create: createGcpProjectBigtableServiceInstance,
 		},
 		"gcp.project.bigtableService.cluster": {
@@ -7070,6 +7070,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.firestoreService.database.deleteProtectionState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectFirestoreServiceDatabase).GetDeleteProtectionState()).ToDataRes(types.String)
+	},
+	"gcp.project.firestoreService.database.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectFirestoreServiceDatabase).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"gcp.project.firestoreService.database.cmekConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectFirestoreServiceDatabase).GetCmekConfig()).ToDataRes(types.Dict)
@@ -19137,6 +19140,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.firestoreService.database.deleteProtectionState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectFirestoreServiceDatabase).DeleteProtectionState, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.firestoreService.database.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectFirestoreServiceDatabase).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.firestoreService.database.cmekConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -44402,6 +44409,7 @@ type mqlGcpProjectFirestoreServiceDatabase struct {
 	AppEngineIntegrationMode      plugin.TValue[string]
 	PointInTimeRecoveryEnablement plugin.TValue[string]
 	DeleteProtectionState         plugin.TValue[string]
+	Tags                          plugin.TValue[map[string]any]
 	CmekConfig                    plugin.TValue[any]
 	VersionRetentionPeriod        plugin.TValue[string]
 	EarliestVersionTime           plugin.TValue[*time.Time]
@@ -44483,6 +44491,10 @@ func (c *mqlGcpProjectFirestoreServiceDatabase) GetPointInTimeRecoveryEnablement
 
 func (c *mqlGcpProjectFirestoreServiceDatabase) GetDeleteProtectionState() *plugin.TValue[string] {
 	return &c.DeleteProtectionState
+}
+
+func (c *mqlGcpProjectFirestoreServiceDatabase) GetTags() *plugin.TValue[map[string]any] {
+	return &c.Tags
 }
 
 func (c *mqlGcpProjectFirestoreServiceDatabase) GetCmekConfig() *plugin.TValue[any] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -2134,6 +2134,7 @@ gcp.project.firestoreService.database.locationId 11.3.1
 gcp.project.firestoreService.database.name 11.3.1
 gcp.project.firestoreService.database.pointInTimeRecoveryEnablement 11.3.1
 gcp.project.firestoreService.database.projectId 11.3.1
+gcp.project.firestoreService.database.tags 13.11.2
 gcp.project.firestoreService.database.type 11.3.1
 gcp.project.firestoreService.database.uid 11.3.1
 gcp.project.firestoreService.database.updatedAt 11.3.1

--- a/providers/gcp/resources/spanner.go
+++ b/providers/gcp/resources/spanner.go
@@ -8,11 +8,13 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	spannerdatabase "cloud.google.com/go/spanner/admin/database/apiv1"
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	spannerinstance "cloud.google.com/go/spanner/admin/instance/apiv1"
 	"cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -46,6 +48,54 @@ func initGcpProjectSpannerService(runtime *plugin.Runtime, args map[string]*llx.
 	}
 	args["projectId"] = llx.StringData(conn.ResourceID())
 	return args, nil, nil
+}
+
+// initGcpProjectSpannerServiceInstance lets policies query a single Spanner
+// instance directly (e.g. when cnspec scans a gcp-spanner-instance asset).
+// It resolves the target instance from the asset identifier attached to the
+// connection and locates it within the project's instance list.
+func initGcpProjectSpannerServiceInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+
+	if len(args) == 0 {
+		if args == nil {
+			args = make(map[string]*llx.RawData)
+		}
+		if ids := getAssetIdentifier(runtime); ids != nil {
+			args["name"] = llx.StringData(ids.name)
+			args["projectId"] = llx.StringData(ids.project)
+		} else {
+			return nil, nil, errors.New("no asset identifier found")
+		}
+	}
+
+	obj, err := CreateResource(runtime, "gcp.project.spannerService", map[string]*llx.RawData{
+		"projectId": args["projectId"],
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	spannerSvc := obj.(*mqlGcpProjectSpannerService)
+	instances := spannerSvc.GetInstances()
+	if instances.Error != nil {
+		return nil, nil, instances.Error
+	}
+
+	nameVal := args["name"].Value.(string)
+	for _, i := range instances.Data {
+		instance := i.(*mqlGcpProjectSpannerServiceInstance)
+		// Spanner instance name is a full resource path:
+		// projects/{project}/instances/{instance}
+		nameParts := strings.Split(instance.Name.Data, "/")
+		instanceName := nameParts[len(nameParts)-1]
+		if instanceName == nameVal {
+			return args, instance, nil
+		}
+	}
+
+	return nil, nil, fmt.Errorf("Spanner instance %q not found", nameVal)
 }
 
 func (g *mqlGcpProjectSpannerService) id() (string, error) {
@@ -85,6 +135,10 @@ func (g *mqlGcpProjectSpannerService) instances() ([]any, error) {
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list Spanner instances")
+				return nil, nil
+			}
 			return nil, err
 		}
 
@@ -193,6 +247,10 @@ func (g *mqlGcpProjectSpannerServiceInstance) databases() ([]any, error) {
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list Spanner databases")
+				return nil, nil
+			}
 			return nil, err
 		}
 
@@ -290,6 +348,10 @@ func (g *mqlGcpProjectSpannerServiceInstanceDatabase) ddl() ([]any, error) {
 		Database: dbName,
 	})
 	if err != nil {
+		if isGRPCSkippable(err) {
+			log.Warn().Err(err).Msg("could not read Spanner database DDL")
+			return nil, nil
+		}
 		return nil, err
 	}
 
@@ -330,6 +392,10 @@ func (g *mqlGcpProjectSpannerServiceInstance) backups() ([]any, error) {
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list Spanner backups")
+				return nil, nil
+			}
 			return nil, err
 		}
 
@@ -446,6 +512,10 @@ func (g *mqlGcpProjectSpannerService) instanceConfigs() ([]any, error) {
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list Spanner instance configs")
+				return nil, nil
+			}
 			return nil, err
 		}
 
@@ -603,6 +673,10 @@ func (g *mqlGcpProjectSpannerServiceInstance) iamPolicy() ([]any, error) {
 
 	policy, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: instanceName})
 	if err != nil {
+		if isGRPCSkippable(err) {
+			log.Warn().Err(err).Msg("could not read Spanner instance IAM policy")
+			return nil, nil
+		}
 		return nil, err
 	}
 	return spannerIamPolicyBindings(g.MqlRuntime, instanceName, policy)
@@ -629,6 +703,10 @@ func (g *mqlGcpProjectSpannerServiceInstanceDatabase) iamPolicy() ([]any, error)
 
 	policy, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: dbName})
 	if err != nil {
+		if isGRPCSkippable(err) {
+			log.Warn().Err(err).Msg("could not read Spanner database IAM policy")
+			return nil, nil
+		}
 		return nil, err
 	}
 	return spannerIamPolicyBindings(g.MqlRuntime, dbName, policy)
@@ -672,6 +750,10 @@ func (g *mqlGcpProjectSpannerServiceInstanceDatabase) databaseRoles() ([]any, er
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list Spanner database roles")
+				return nil, nil
+			}
 			return nil, err
 		}
 		mqlRole, err := CreateResource(g.MqlRuntime, "gcp.project.spannerService.instance.database.role", map[string]*llx.RawData{
@@ -741,6 +823,10 @@ func (g *mqlGcpProjectSpannerServiceInstance) backupSchedules() ([]any, error) {
 				break
 			}
 			if err != nil {
+				if isGRPCSkippable(err) {
+					log.Warn().Err(err).Str("database", dbName).Msg("could not list Spanner backup schedules")
+					break
+				}
 				return nil, err
 			}
 
@@ -834,6 +920,10 @@ func (g *mqlGcpProjectSpannerServiceInstance) instancePartitions() ([]any, error
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list Spanner instance partitions")
+				return nil, nil
+			}
 			return nil, err
 		}
 


### PR DESCRIPTION
Adds three new sub-service platforms so cnspec can target these databases directly (gcp-spanner-instance, gcp-firestore-database, gcp-bigtable-instance), matching how AlloyDB, Cloud SQL, BigQuery, and Memorystore are already exposed. Each platform gets a discovery target, a title, a ResourceTechnologyUrl mapping, and a singular init function so policies can query the scanned instance directly through the existing gcp.spanner / gcp.firestore / gcp.bigtable aliases.

All list/iterator and IAM-policy calls in spanner.go, firestore.go, and bigtable.go are now wrapped with isGRPCSkippable so a disabled API or missing permission logs a warning instead of aborting the scan — same fix that #7343 applied to AlloyDB, extended to cover the ten call sites added by #7351's expanded Spanner coverage.