### PR TITLE
Handle missing auditd rules directory without field errors

### DIFF
--- a/providers/os/resources/auditd.go
+++ b/providers/os/resources/auditd.go
@@ -157,6 +157,12 @@ func (s *mqlAuditdRules) path() (string, error) {
 	return defaultAuditdRules, nil
 }
 
+func (s *mqlAuditdRules) setEmptyRules() {
+	s.Controls = plugin.TValue[[]any]{Data: []any{}, State: plugin.StateIsSet}
+	s.Files = plugin.TValue[[]any]{Data: []any{}, State: plugin.StateIsSet}
+	s.Syscalls = plugin.TValue[[]any]{Data: []any{}, State: plugin.StateIsSet}
+}
+
 func (s *mqlAuditdRules) load(path string) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
@@ -166,6 +172,23 @@ func (s *mqlAuditdRules) load(path string) error {
 
 	if path == "" {
 		return errors.New("the path must be non-empty to parse auditd rules")
+	}
+
+	raw, err := CreateResource(s.MqlRuntime, "file", map[string]*llx.RawData{
+		"path": llx.StringData(path),
+	})
+	if err != nil {
+		return err
+	}
+	f := raw.(*mqlFile)
+	exists := f.GetExists()
+	if exists.Error != nil {
+		return exists.Error
+	}
+	if !exists.Data {
+		s.setEmptyRules()
+		s.loaded = true
+		return nil
 	}
 
 	files, err := getSortedPathFiles(s.MqlRuntime, path)

--- a/providers/os/resources/auditd_internal_test.go
+++ b/providers/os/resources/auditd_internal_test.go
@@ -1,0 +1,53 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/connection/mock"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+func newAuditdRulesTestRuntime(t *testing.T) *plugin.Runtime {
+	t.Helper()
+
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:    "oraclelinux",
+			Version: "8",
+			Family:  []string{"oraclelinux", "linux"},
+		},
+	})
+	require.NoError(t, err)
+
+	return &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+}
+
+func TestAuditdRulesMissingPathReturnsEmptyLists(t *testing.T) {
+	runtime := newAuditdRulesTestRuntime(t)
+	rules := &mqlAuditdRules{MqlRuntime: runtime}
+
+	controls := rules.GetControls()
+	require.NoError(t, controls.Error)
+	assert.Empty(t, controls.Data)
+	assert.Equal(t, plugin.StateIsSet, controls.State)
+
+	files := rules.GetFiles()
+	require.NoError(t, files.Error)
+	assert.Empty(t, files.Data)
+	assert.Equal(t, plugin.StateIsSet, files.State)
+
+	syscalls := rules.GetSyscalls()
+	require.NoError(t, syscalls.Error)
+	assert.Empty(t, syscalls.Data)
+	assert.Equal(t, plugin.StateIsSet, syscalls.State)
+}


### PR DESCRIPTION
## Summary
- treat a missing `/etc/audit/rules.d` path as an empty rule set instead of a hard resource error
- proactively cache empty `controls`, `files`, and `syscalls` results so policy queries evaluate cleanly
- add a focused resource-level test for the missing-path case

## Testing
- `GOCACHE=/tmp/go-build GOTMPDIR=/tmp/go-tmp go test ./providers/os/resources -run TestAuditd -count=1`
