### PR TITLE
providers/os: fall back to AppArmor kernel state

### DIFF
--- a/providers/os/resources/apparmor.go
+++ b/providers/os/resources/apparmor.go
@@ -4,18 +4,32 @@
 package resources
 
 import (
+	"bufio"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 
+	"github.com/spf13/afero"
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	processmgr "go.mondoo.com/mql/v13/providers/os/resources/processes"
 )
 
 type mqlApparmorInternal struct {
 	status  *apparmorStatus
 	fetched bool
 	lock    sync.Mutex
+}
+
+const apparmorProfilesPath = "/sys/kernel/security/apparmor/profiles"
+
+var apparmorJSONCommands = []string{
+	"apparmor_status --json",
+	"aa-status --json",
 }
 
 func (a *mqlApparmor) id() (string, error) {
@@ -45,25 +59,202 @@ func (a *mqlApparmor) fetchStatus() (*apparmorStatus, error) {
 		return a.status, nil
 	}
 
-	o, err := CreateResource(a.MqlRuntime, "command", map[string]*llx.RawData{
-		"command": llx.StringData("apparmor_status --json"),
-	})
+	status, err := a.fetchStatusFromJSON()
+	if err != nil {
+		status, kernelErr := a.fetchStatusFromKernel()
+		if kernelErr != nil {
+			return nil, fmt.Errorf("could not retrieve apparmor status via json or kernel interfaces: %w; fallback failed: %v", err, kernelErr)
+		}
+		a.status = status
+		a.fetched = true
+		return a.status, nil
+	}
+
+	a.status = status
+	a.fetched = true
+	return a.status, nil
+}
+
+func (a *mqlApparmor) fetchStatusFromJSON() (*apparmorStatus, error) {
+	var attempts []string
+
+	for _, command := range apparmorJSONCommands {
+		o, err := CreateResource(a.MqlRuntime, "command", map[string]*llx.RawData{
+			"command": llx.StringData(command),
+		})
+		if err != nil {
+			attempts = append(attempts, command+": "+err.Error())
+			continue
+		}
+
+		cmd := o.(*mqlCommand)
+		exit := cmd.GetExitcode()
+		if exit.Error != nil {
+			attempts = append(attempts, command+": "+exit.Error.Error())
+			continue
+		}
+		if exit.Data != 0 {
+			msg := strings.TrimSpace(cmd.Stderr.Data)
+			if msg == "" {
+				msg = "exit code " + strconv.FormatInt(exit.Data, 10)
+			}
+			attempts = append(attempts, command+": "+msg)
+			continue
+		}
+
+		var status apparmorStatus
+		if err := json.Unmarshal([]byte(cmd.Stdout.Data), &status); err != nil {
+			attempts = append(attempts, command+": "+err.Error())
+			continue
+		}
+
+		return &status, nil
+	}
+
+	if len(attempts) == 0 {
+		return nil, errors.New("could not retrieve apparmor status")
+	}
+	return nil, errors.New(strings.Join(attempts, "; "))
+}
+
+func (a *mqlApparmor) fetchStatusFromKernel() (*apparmorStatus, error) {
+	conn, ok := a.MqlRuntime.Connection.(shared.Connection)
+	if !ok {
+		return nil, errors.New("connection does not support filesystem access")
+	}
+
+	processManager, err := processmgr.ResolveManager(conn)
 	if err != nil {
 		return nil, err
 	}
-	cmd := o.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
-		return nil, errors.New("could not retrieve apparmor status: " + cmd.Stderr.Data)
-	}
 
-	var status apparmorStatus
-	if err := json.Unmarshal([]byte(cmd.Stdout.Data), &status); err != nil {
+	procs, err := processManager.List()
+	if err != nil {
 		return nil, err
 	}
 
-	a.status = &status
-	a.fetched = true
-	return a.status, nil
+	status := &apparmorStatus{
+		Profiles:  readApparmorProfilesFromFS(conn.FileSystem()),
+		Processes: readApparmorProcessesFromFS(conn.FileSystem(), procs),
+	}
+
+	profilesAvailable, err := afero.Exists(conn.FileSystem(), apparmorProfilesPath)
+	if err != nil {
+		return nil, err
+	}
+	if !profilesAvailable && len(status.Processes) == 0 {
+		return nil, errors.New("AppArmor kernel interfaces unavailable")
+	}
+
+	return status, nil
+}
+
+func readApparmorProfilesFromFS(fs afero.Fs) map[string]string {
+	f, err := fs.Open(apparmorProfilesPath)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	profiles := map[string]string{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		name, mode, ok := parseApparmorProfileLine(scanner.Text())
+		if ok {
+			profiles[name] = mode
+		}
+	}
+	return profiles
+}
+
+func readApparmorProcessesFromFS(fs afero.Fs, procs []*processmgr.OSProcess) map[string][]apparmorProcInfo {
+	processes := map[string][]apparmorProcInfo{}
+	for _, proc := range procs {
+		profile, status, ok := readApparmorCurrentForProcess(fs, proc.Pid)
+		if !ok {
+			continue
+		}
+
+		executable := apparmorProcessExecutable(proc)
+
+		processes[executable] = append(processes[executable], apparmorProcInfo{
+			Profile: profile,
+			PID:     strconv.FormatInt(proc.Pid, 10),
+			Status:  status,
+		})
+	}
+	return processes
+}
+
+func readApparmorCurrentForProcess(fs afero.Fs, pid int64) (profile string, status string, ok bool) {
+	pidStr := strconv.FormatInt(pid, 10)
+	paths := []string{
+		filepath.Join("/proc", pidStr, "attr/apparmor/current"),
+		filepath.Join("/proc", pidStr, "attr/current"),
+	}
+
+	for _, path := range paths {
+		data, err := afero.ReadFile(fs, path)
+		if err != nil {
+			continue
+		}
+
+		profile, status, ok = parseApparmorCurrentLabel(string(data))
+		if ok {
+			return profile, status, true
+		}
+	}
+
+	return "", "", false
+}
+
+func apparmorProcessExecutable(proc *processmgr.OSProcess) string {
+	if proc.Command != "" {
+		fields := strings.Fields(proc.Command)
+		if len(fields) > 0 && strings.Contains(fields[0], "/") {
+			return fields[0]
+		}
+	}
+
+	if proc.Executable != "" {
+		return proc.Executable
+	}
+	if proc.Command != "" {
+		return proc.Command
+	}
+	return strconv.FormatInt(proc.Pid, 10)
+}
+
+func parseApparmorProfileLine(line string) (name string, mode string, ok bool) {
+	return parseApparmorModeLine(line)
+}
+
+func parseApparmorCurrentLabel(content string) (profile string, status string, ok bool) {
+	line := strings.TrimSpace(strings.TrimRight(content, "\x00"))
+	if line == "unconfined" {
+		return "unconfined", "unconfined", true
+	}
+	return parseApparmorModeLine(line)
+}
+
+func parseApparmorModeLine(line string) (name string, mode string, ok bool) {
+	line = strings.TrimSpace(line)
+	if line == "" || !strings.HasSuffix(line, ")") {
+		return "", "", false
+	}
+
+	idx := strings.LastIndex(line, " (")
+	if idx <= 0 {
+		return "", "", false
+	}
+
+	name = strings.TrimSpace(line[:idx])
+	mode = strings.TrimSpace(line[idx+2 : len(line)-1])
+	if name == "" || mode == "" {
+		return "", "", false
+	}
+
+	return name, mode, true
 }
 
 func (a *mqlApparmor) version() (string, error) {

--- a/providers/os/resources/apparmor.go
+++ b/providers/os/resources/apparmor.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"path/filepath"
+	"path"
 	"strconv"
 	"strings"
 	"sync"
@@ -189,8 +189,8 @@ func readApparmorProcessesFromFS(fs afero.Fs, procs []*processmgr.OSProcess) map
 func readApparmorCurrentForProcess(fs afero.Fs, pid int64) (profile string, status string, ok bool) {
 	pidStr := strconv.FormatInt(pid, 10)
 	paths := []string{
-		filepath.Join("/proc", pidStr, "attr/apparmor/current"),
-		filepath.Join("/proc", pidStr, "attr/current"),
+		path.Join("/proc", pidStr, "attr/apparmor/current"),
+		path.Join("/proc", pidStr, "attr/current"),
 	}
 
 	for _, path := range paths {

--- a/providers/os/resources/apparmor_test.go
+++ b/providers/os/resources/apparmor_test.go
@@ -7,8 +7,10 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	processmgr "go.mondoo.com/mql/v13/providers/os/resources/processes"
 )
 
 const testApparmorJSON = `{"version": "2", "profiles": {"/usr/bin/man": "enforce", "/usr/lib/NetworkManager/nm-dhcp-client.action": "enforce", "/usr/lib/connman/scripts/dhclient-script": "enforce", "/usr/sbin/chronyd": "enforce", "/usr/{lib/NetworkManager,libexec}/nm-dhcp-helper": "enforce", "/{,usr/}sbin/dhclient": "enforce", "docker-default": "enforce", "libvirtd": "enforce", "libvirtd//qemu_bridge_helper": "enforce", "lsb_release": "enforce", "man_filter": "enforce", "man_groff": "enforce", "nvidia_modprobe": "enforce", "nvidia_modprobe//kmod": "enforce", "virt-aa-helper": "enforce", "Xorg": "complain", "plasmashell": "complain", "plasmashell//QtWebEngineProcess": "complain", "sbuild": "complain", "sbuild-abort": "complain", "sbuild-adduser": "complain", "sbuild-apt": "complain", "sbuild-checkpackages": "complain", "sbuild-clean": "complain", "sbuild-createchroot": "complain", "sbuild-destroychroot": "complain", "sbuild-distupgrade": "complain", "sbuild-hold": "complain", "sbuild-shell": "complain", "sbuild-unhold": "complain", "sbuild-update": "complain", "sbuild-upgrade": "complain", "transmission-cli": "complain", "transmission-daemon": "complain", "transmission-gtk": "complain", "transmission-qt": "complain", "unix-chkpwd": "complain", "unprivileged_userns": "complain", "1password": "unconfined", "Discord": "unconfined", "MongoDB Compass": "unconfined", "QtWebEngineProcess": "unconfined", "balena-etcher": "unconfined", "brave": "unconfined", "buildah": "unconfined", "busybox": "unconfined", "cam": "unconfined", "ch-checkns": "unconfined", "ch-run": "unconfined", "chrome": "unconfined", "chromium": "unconfined", "crun": "unconfined", "devhelp": "unconfined", "element-desktop": "unconfined", "epiphany": "unconfined", "evolution": "unconfined", "firefox": "unconfined", "flatpak": "unconfined", "foliate": "unconfined", "geary": "unconfined", "github-desktop": "unconfined", "goldendict": "unconfined", "ipa_verify": "unconfined", "kchmviewer": "unconfined", "keybase": "unconfined", "lc-compliance": "unconfined", "libcamerify": "unconfined", "linux-sandbox": "unconfined", "loupe": "unconfined", "lxc-attach": "unconfined", "lxc-create": "unconfined", "lxc-destroy": "unconfined", "lxc-execute": "unconfined", "lxc-stop": "unconfined", "lxc-unshare": "unconfined", "lxc-usernsexec": "unconfined", "mmdebstrap": "unconfined", "msedge": "unconfined", "nautilus": "unconfined", "notepadqq": "unconfined", "obsidian": "unconfined", "opam": "unconfined", "opera": "unconfined", "pageedit": "unconfined", "polypane": "unconfined", "privacybrowser": "unconfined", "qcam": "unconfined", "qmapshack": "unconfined", "qutebrowser": "unconfined", "rootlesskit": "unconfined", "rpm": "unconfined", "rssguard": "unconfined", "runc": "unconfined", "scide": "unconfined", "signal-desktop": "unconfined", "slack": "unconfined", "slirp4netns": "unconfined", "steam": "unconfined", "stress-ng": "unconfined", "surfshark": "unconfined", "systemd-coredump": "unconfined", "toybox": "unconfined", "trinity": "unconfined", "tup": "unconfined", "tuxedo-control-center": "unconfined", "userbindmount": "unconfined", "uwsgi-core": "unconfined", "vdens": "unconfined", "virtiofsd": "unconfined", "vivaldi-bin": "unconfined", "vpnns": "unconfined", "vscode": "unconfined", "wike": "unconfined", "wpcom": "unconfined"}, "processes": {"/portainer": [{"profile": "docker-default", "pid": "1607926", "status": "enforce"}], "/usr/sbin/chronyd": [{"profile": "/usr/sbin/chronyd", "pid": "1858", "status": "enforce"}, {"profile": "/usr/sbin/chronyd", "pid": "1861", "status": "enforce"}]}}`
@@ -46,4 +48,106 @@ func TestParseApparmorStatusEmpty(t *testing.T) {
 	assert.Equal(t, "2", status.Version)
 	assert.Empty(t, status.Profiles)
 	assert.Empty(t, status.Processes)
+}
+
+func TestParseApparmorProfileLine(t *testing.T) {
+	name, mode, ok := parseApparmorProfileLine("/usr/sbin/chronyd (enforce)")
+	require.True(t, ok)
+	assert.Equal(t, "/usr/sbin/chronyd", name)
+	assert.Equal(t, "enforce", mode)
+
+	name, mode, ok = parseApparmorProfileLine("MongoDB Compass (unconfined)")
+	require.True(t, ok)
+	assert.Equal(t, "MongoDB Compass", name)
+	assert.Equal(t, "unconfined", mode)
+
+	_, _, ok = parseApparmorProfileLine("apparmor module is loaded.")
+	assert.False(t, ok)
+}
+
+func TestParseApparmorCurrentLabel(t *testing.T) {
+	profile, status, ok := parseApparmorCurrentLabel("/usr/sbin/chronyd (complain)\n")
+	require.True(t, ok)
+	assert.Equal(t, "/usr/sbin/chronyd", profile)
+	assert.Equal(t, "complain", status)
+
+	profile, status, ok = parseApparmorCurrentLabel("unconfined\n")
+	require.True(t, ok)
+	assert.Equal(t, "unconfined", profile)
+	assert.Equal(t, "unconfined", status)
+
+	profile, status, ok = parseApparmorCurrentLabel("MongoDB Compass (unconfined)\x00")
+	require.True(t, ok)
+	assert.Equal(t, "MongoDB Compass", profile)
+	assert.Equal(t, "unconfined", status)
+}
+
+func TestReadApparmorProfilesFromFS(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	err := fs.MkdirAll("/sys/kernel/security/apparmor", 0o755)
+	require.NoError(t, err)
+	err = afero.WriteFile(fs, apparmorProfilesPath, []byte(""+
+		"/usr/sbin/chronyd (enforce)\n"+
+		"MongoDB Compass (unconfined)\n"+
+		"/usr/sbin/dnsmasq (complain)\n"), 0o444)
+	require.NoError(t, err)
+
+	profiles := readApparmorProfilesFromFS(fs)
+	require.Len(t, profiles, 3)
+	assert.Equal(t, "enforce", profiles["/usr/sbin/chronyd"])
+	assert.Equal(t, "unconfined", profiles["MongoDB Compass"])
+	assert.Equal(t, "complain", profiles["/usr/sbin/dnsmasq"])
+}
+
+func TestReadApparmorProcessesFromFS(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	require.NoError(t, fs.MkdirAll("/proc/1/attr/apparmor", 0o755))
+	require.NoError(t, fs.MkdirAll("/proc/2/attr/apparmor", 0o755))
+	require.NoError(t, fs.MkdirAll("/proc/3/attr", 0o755))
+
+	require.NoError(t, afero.WriteFile(fs, "/proc/1/attr/apparmor/current", []byte("/usr/sbin/chronyd (complain)\n"), 0o444))
+	require.NoError(t, afero.WriteFile(fs, "/proc/2/attr/apparmor/current", []byte("unconfined\n"), 0o444))
+	require.NoError(t, afero.WriteFile(fs, "/proc/3/attr/current", []byte("docker-default (enforce)\n"), 0o444))
+
+	procs := []*processmgr.OSProcess{
+		{Pid: 1, Executable: "/usr/sbin/chronyd"},
+		{Pid: 2, Executable: "/usr/bin/firefox"},
+		{Pid: 3, Executable: "/portainer"},
+		{Pid: 4, Executable: "/usr/bin/ignored"},
+	}
+
+	processes := readApparmorProcessesFromFS(fs, procs)
+	require.Len(t, processes, 3)
+
+	chronyd := processes["/usr/sbin/chronyd"]
+	require.Len(t, chronyd, 1)
+	assert.Equal(t, "complain", chronyd[0].Status)
+	assert.Equal(t, "/usr/sbin/chronyd", chronyd[0].Profile)
+
+	firefox := processes["/usr/bin/firefox"]
+	require.Len(t, firefox, 1)
+	assert.Equal(t, "unconfined", firefox[0].Status)
+	assert.Equal(t, "unconfined", firefox[0].Profile)
+
+	portainer := processes["/portainer"]
+	require.Len(t, portainer, 1)
+	assert.Equal(t, "enforce", portainer[0].Status)
+	assert.Equal(t, "docker-default", portainer[0].Profile)
+}
+
+func TestApparmorProcessExecutable(t *testing.T) {
+	assert.Equal(t, "/usr/sbin/chronyd", apparmorProcessExecutable(&processmgr.OSProcess{
+		Pid:        1,
+		Executable: "chronyd",
+		Command:    "/usr/sbin/chronyd -d",
+	}))
+
+	assert.Equal(t, "dockerd", apparmorProcessExecutable(&processmgr.OSProcess{
+		Pid:        2,
+		Executable: "dockerd",
+		Command:    "dockerd --debug",
+	}))
+
+	assert.Equal(t, "3", apparmorProcessExecutable(&processmgr.OSProcess{Pid: 3}))
 }

--- a/providers/os/resources/parse.go
+++ b/providers/os/resources/parse.go
@@ -146,42 +146,45 @@ func parseJSONContent(content string) (any, error) {
 
 func sanitizeJSONStructuralNoise(content string) (string, bool) {
 	var (
-		builder strings.Builder
-		stack   []byte
-		changed bool
-		lastSig byte
+		out        = make([]byte, 0, len(content))
+		stack      []byte
+		changed    bool
+		lastSig    byte
+		lastSigPos = -1
 	)
-
-	builder.Grow(len(content))
 
 	inString := false
 	escaped := false
 
-	recomputeLastSig := func() {
-		lastSig = 0
-		out := builder.String()
-		for i := len(out) - 1; i >= 0; i-- {
-			switch out[i] {
-			case ' ', '\t', '\n', '\r':
-				continue
-			default:
-				lastSig = out[i]
-				return
-			}
-		}
+	setLastSig := func(ch byte) {
+		lastSig = ch
+		lastSigPos = len(out) - 1
 	}
 
 	trimTrailingComma := func() {
-		out := builder.String()
 		end := len(out)
 		for end > 0 {
 			switch out[end-1] {
 			case ' ', '\t', '\n', '\r':
 				end--
 			case ',':
-				builder.Reset()
-				builder.WriteString(out[:end-1])
-				recomputeLastSig()
+				commaPos := lastSigPos
+				if commaPos < 0 || commaPos >= len(out) {
+					commaPos = end - 1
+				}
+				out = out[:commaPos]
+				lastSig = 0
+				lastSigPos = -1
+				for i := commaPos - 1; i >= 0; i-- {
+					switch out[i] {
+					case ' ', '\t', '\n', '\r':
+						continue
+					default:
+						lastSig = out[i]
+						lastSigPos = i
+						return
+					}
+				}
 				return
 			default:
 				return
@@ -192,7 +195,7 @@ func sanitizeJSONStructuralNoise(content string) (string, bool) {
 	for i := 0; i < len(content); i++ {
 		ch := content[i]
 		if inString {
-			builder.WriteByte(ch)
+			out = append(out, ch)
 			if escaped {
 				escaped = false
 				continue
@@ -202,7 +205,7 @@ func sanitizeJSONStructuralNoise(content string) (string, bool) {
 				escaped = true
 			case '"':
 				inString = false
-				lastSig = '"'
+				setLastSig(ch)
 			}
 			continue
 		}
@@ -210,21 +213,21 @@ func sanitizeJSONStructuralNoise(content string) (string, bool) {
 		switch ch {
 		case '"':
 			inString = true
-			builder.WriteByte(ch)
+			out = append(out, ch)
 		case ' ', '\t', '\n', '\r':
-			builder.WriteByte(ch)
+			out = append(out, ch)
 		case '{', '[':
 			stack = append(stack, ch)
-			builder.WriteByte(ch)
-			lastSig = ch
+			out = append(out, ch)
+			setLastSig(ch)
 		case ',':
 			next := nextSignificantJSONByte(content, i+1)
 			if lastSig == '{' || lastSig == '[' || lastSig == ',' || lastSig == ':' || next == '}' || next == ']' {
 				changed = true
 				continue
 			}
-			builder.WriteByte(ch)
-			lastSig = ch
+			out = append(out, ch)
+			setLastSig(ch)
 		case '}':
 			if len(stack) == 0 {
 				changed = true
@@ -239,8 +242,8 @@ func sanitizeJSONStructuralNoise(content string) (string, bool) {
 				changed = true
 			}
 			stack = stack[:len(stack)-1]
-			builder.WriteByte(ch)
-			lastSig = ch
+			out = append(out, ch)
+			setLastSig(ch)
 		case ']':
 			if len(stack) == 0 {
 				changed = true
@@ -255,15 +258,15 @@ func sanitizeJSONStructuralNoise(content string) (string, bool) {
 				changed = true
 			}
 			stack = stack[:len(stack)-1]
-			builder.WriteByte(ch)
-			lastSig = ch
+			out = append(out, ch)
+			setLastSig(ch)
 		default:
-			builder.WriteByte(ch)
-			lastSig = ch
+			out = append(out, ch)
+			setLastSig(ch)
 		}
 	}
 
-	return builder.String(), changed
+	return string(out), changed
 }
 
 func nextSignificantJSONByte(content string, start int) byte {

--- a/providers/os/resources/parse.go
+++ b/providers/os/resources/parse.go
@@ -125,11 +125,157 @@ func (s *mqlParseJson) params(content string) (any, error) {
 		return nil, nil
 	}
 
+	return parseJSONContent(content)
+}
+
+func parseJSONContent(content string) (any, error) {
 	var res any
 	if err := json.Unmarshal([]byte(content), &res); err != nil {
-		return nil, err
+		sanitized, changed := sanitizeJSONStructuralNoise(content)
+		if !changed {
+			return nil, err
+		}
+
+		if sanitizeErr := json.Unmarshal([]byte(sanitized), &res); sanitizeErr != nil {
+			return nil, fmt.Errorf("failed to parse JSON: %w; sanitized parse failed: %v", err, sanitizeErr)
+		}
+		return res, nil
 	}
 	return res, nil
+}
+
+func sanitizeJSONStructuralNoise(content string) (string, bool) {
+	var (
+		builder strings.Builder
+		stack   []byte
+		changed bool
+		lastSig byte
+	)
+
+	builder.Grow(len(content))
+
+	inString := false
+	escaped := false
+
+	recomputeLastSig := func() {
+		lastSig = 0
+		out := builder.String()
+		for i := len(out) - 1; i >= 0; i-- {
+			switch out[i] {
+			case ' ', '\t', '\n', '\r':
+				continue
+			default:
+				lastSig = out[i]
+				return
+			}
+		}
+	}
+
+	trimTrailingComma := func() {
+		out := builder.String()
+		end := len(out)
+		for end > 0 {
+			switch out[end-1] {
+			case ' ', '\t', '\n', '\r':
+				end--
+			case ',':
+				builder.Reset()
+				builder.WriteString(out[:end-1])
+				recomputeLastSig()
+				return
+			default:
+				return
+			}
+		}
+	}
+
+	for i := 0; i < len(content); i++ {
+		ch := content[i]
+		if inString {
+			builder.WriteByte(ch)
+			if escaped {
+				escaped = false
+				continue
+			}
+			switch ch {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+				lastSig = '"'
+			}
+			continue
+		}
+
+		switch ch {
+		case '"':
+			inString = true
+			builder.WriteByte(ch)
+		case ' ', '\t', '\n', '\r':
+			builder.WriteByte(ch)
+		case '{', '[':
+			stack = append(stack, ch)
+			builder.WriteByte(ch)
+			lastSig = ch
+		case ',':
+			next := nextSignificantJSONByte(content, i+1)
+			if lastSig == '{' || lastSig == '[' || lastSig == ',' || lastSig == ':' || next == '}' || next == ']' {
+				changed = true
+				continue
+			}
+			builder.WriteByte(ch)
+			lastSig = ch
+		case '}':
+			if len(stack) == 0 {
+				changed = true
+				continue
+			}
+			if stack[len(stack)-1] == '[' {
+				changed = true
+				continue
+			}
+			if lastSig == ',' {
+				trimTrailingComma()
+				changed = true
+			}
+			stack = stack[:len(stack)-1]
+			builder.WriteByte(ch)
+			lastSig = ch
+		case ']':
+			if len(stack) == 0 {
+				changed = true
+				continue
+			}
+			if stack[len(stack)-1] == '{' {
+				changed = true
+				continue
+			}
+			if lastSig == ',' {
+				trimTrailingComma()
+				changed = true
+			}
+			stack = stack[:len(stack)-1]
+			builder.WriteByte(ch)
+			lastSig = ch
+		default:
+			builder.WriteByte(ch)
+			lastSig = ch
+		}
+	}
+
+	return builder.String(), changed
+}
+
+func nextSignificantJSONByte(content string, start int) byte {
+	for i := start; i < len(content); i++ {
+		switch content[i] {
+		case ' ', '\t', '\n', '\r':
+			continue
+		default:
+			return content[i]
+		}
+	}
+	return 0
 }
 
 func initParseXml(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/os/resources/parse_internal_test.go
+++ b/providers/os/resources/parse_internal_test.go
@@ -1,0 +1,38 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseJsonParamsRepairsMalformedApparmorOutput(t *testing.T) {
+	content := `{"version": "1", "profiles": {, "/usr/bin/man": "complain"}, "processes": {], "/usr/sbin/chronyd": [{"profile": "/usr/sbin/chronyd", "pid": "339", "status": "unconfined"}]}}`
+
+	res, err := (&mqlParseJson{}).params(content)
+	require.NoError(t, err)
+
+	params := res.(map[string]any)
+	assert.Equal(t, "1", params["version"])
+
+	profiles := params["profiles"].(map[string]any)
+	assert.Equal(t, "complain", profiles["/usr/bin/man"])
+
+	processes := params["processes"].(map[string]any)
+	chronyd := processes["/usr/sbin/chronyd"].([]any)
+	require.Len(t, chronyd, 1)
+
+	proc := chronyd[0].(map[string]any)
+	assert.Equal(t, "/usr/sbin/chronyd", proc["profile"])
+	assert.Equal(t, "339", proc["pid"])
+	assert.Equal(t, "unconfined", proc["status"])
+}
+
+func TestParseJsonParamsRejectsUnrepairableJSON(t *testing.T) {
+	_, err := (&mqlParseJson{}).params(`{"version": nope}`)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

- keep `apparmor_status --json` and `aa-status --json` as the fast path
- fall back to AppArmor kernel interfaces when JSON is unavailable or invalid
- repair malformed JSON separator noise in `parse.json` for buggy command output
- add focused tests for profile parsing, process confinement parsing, executable selection, and malformed JSON recovery

## Verification

- `GOCACHE=/tmp/go-cache go test ./providers/os/resources -run 'TestParseJson|TestParseJsonParamsRepairsMalformedApparmorOutput|TestParseJsonParamsRejectsUnrepairableJSON|TestParseApparmorStatus|TestParseApparmorProfileLine|TestParseApparmorCurrentLabel|TestReadApparmorProfilesFromFS|TestReadApparmorProcessesFromFS|TestApparmorProcessExecutable'`

Closes #7359
Closes #1619
