### PR TITLE
🎫 Add feature flag for token-response WIF token exchange

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -369,7 +369,8 @@ func (c *CommonOpts) GetServiceCredential() *upstream.ServiceAccountCredentials 
 		case AUTH_METHOD_WIF:
 			log.Info().Msg("using wif authentication method, generate temporary credentials")
 
-			serviceAccount, err := upstream.ExchangeExternalToken(c.UpstreamApiEndpoint(), c.Audience, c.IssuerURI, c.JWTToken)
+			tokenResponse := c.GetFeatures().IsActive(mql.ExchangeTokenForToken)
+			serviceAccount, err := upstream.ExchangeExternalToken(c.UpstreamApiEndpoint(), c.Audience, c.IssuerURI, c.JWTToken, tokenResponse)
 			if err != nil {
 				log.Error().Err(err).Msg("could not exchange external (wif) token")
 				return nil

--- a/feature_string.go
+++ b/feature_string.go
@@ -23,11 +23,12 @@ func _() {
 	_ = x[UploadResultsV2-13]
 	_ = x[AutoUpdateEngine-14]
 	_ = x[BiosUUIDAsID-15]
+	_ = x[ExchangeTokenForToken-16]
 }
 
-const _Feature_name = "MassQueriesPiperCodeBoolAssertionsK8sNodeDiscoveryMQLAssetContextErrorsAsFailuresStoreResourcesDataFineGrainedAssetsSerialNumberAsIDForceShellCompletionResourceContextFailIfNoEntryPointsUploadResultsV2AutoUpdateEngineBiosUUIDAsID"
+const _Feature_name = "MassQueriesPiperCodeBoolAssertionsK8sNodeDiscoveryMQLAssetContextErrorsAsFailuresStoreResourcesDataFineGrainedAssetsSerialNumberAsIDForceShellCompletionResourceContextFailIfNoEntryPointsUploadResultsV2AutoUpdateEngineBiosUUIDAsIDExchangeTokenForToken"
 
-var _Feature_index = [...]uint8{0, 11, 20, 34, 50, 65, 81, 99, 116, 132, 152, 167, 186, 201, 217, 229}
+var _Feature_index = [...]uint8{0, 11, 20, 34, 50, 65, 81, 99, 116, 132, 152, 167, 186, 201, 217, 229, 250}
 
 func (i Feature) String() string {
 	idx := int(i) - 1

--- a/features.go
+++ b/features.go
@@ -87,27 +87,33 @@ const (
 	// status: new
 	BiosUUIDAsID Feature = 15
 
+	// When exchanging an external identity token with upstream (WIF), request a bearer token response (response_type=TOKEN) in place of certificate-based service-account credentials.
+	// start:  v13.x
+	// status: new
+	ExchangeTokenForToken Feature = 16
+
 	// Placeholder to indicate how many feature flags exist. This number
 	// is changing with every new feature and cannot be used as a featureflag itself.
-	MAX_FEATURES byte = 16
+	MAX_FEATURES byte = 17
 )
 
 var FeaturesValue = map[string]Feature{
-	"MassQueries":          MassQueries,
-	"PiperCode":            PiperCode,
-	"BoolAssertions":       BoolAssertions,
-	"K8sNodeDiscovery":     K8sNodeDiscovery,
-	"MQLAssetContext":      MQLAssetContext,
-	"ErrorsAsFailures":     ErrorsAsFailures,
-	"StoreResourcesData":   StoreResourcesData,
-	"FineGrainedAssets":    FineGrainedAssets,
-	"SerialNumberAsID":     SerialNumberAsID,
-	"ForceShellCompletion": ForceShellCompletion,
-	"ResourceContext":      ResourceContext,
-	"FailIfNoEntryPoints":  FailIfNoEntryPoints,
-	"UploadResultsV2":      UploadResultsV2,
-	"AutoUpdateEngine":     AutoUpdateEngine,
-	"BiosUUIDAsID":         BiosUUIDAsID,
+	"MassQueries":           MassQueries,
+	"PiperCode":             PiperCode,
+	"BoolAssertions":        BoolAssertions,
+	"K8sNodeDiscovery":      K8sNodeDiscovery,
+	"MQLAssetContext":       MQLAssetContext,
+	"ErrorsAsFailures":      ErrorsAsFailures,
+	"StoreResourcesData":    StoreResourcesData,
+	"FineGrainedAssets":     FineGrainedAssets,
+	"SerialNumberAsID":      SerialNumberAsID,
+	"ForceShellCompletion":  ForceShellCompletion,
+	"ResourceContext":       ResourceContext,
+	"FailIfNoEntryPoints":   FailIfNoEntryPoints,
+	"UploadResultsV2":       UploadResultsV2,
+	"AutoUpdateEngine":      AutoUpdateEngine,
+	"BiosUUIDAsID":          BiosUUIDAsID,
+	"ExchangeTokenForToken": ExchangeTokenForToken,
 }
 
 // DefaultFeatures are a set of default flags that are active
@@ -124,4 +130,5 @@ var AvailableFeatures = Features{
 	byte(UploadResultsV2),
 	byte(AutoUpdateEngine),
 	byte(BiosUUIDAsID),
+	byte(ExchangeTokenForToken),
 }

--- a/features.yaml
+++ b/features.yaml
@@ -88,3 +88,8 @@ Features:
   idx: 15
   start: v13.x
   status: new
+- id: ExchangeTokenForToken
+  desc: "When exchanging an external identity token with upstream (WIF), request a bearer token response (response_type=TOKEN) in place of certificate-based service-account credentials."
+  idx: 16
+  start: v13.x
+  status: new

--- a/providers-sdk/v1/upstream/sts.go
+++ b/providers-sdk/v1/upstream/sts.go
@@ -58,7 +58,7 @@ func ExchangeSSHKey(apiEndpoint string, identityMrn string, resourceMrn string) 
 	}, nil
 }
 
-func ExchangeExternalToken(apiEndpoint, audience, issuerURI, jwtToken string) (*ServiceAccountCredentials, error) {
+func ExchangeExternalToken(apiEndpoint, audience, issuerURI, jwtToken string, tokenResponse bool) (*ServiceAccountCredentials, error) {
 	if jwtToken == "" {
 		// Try to fetch the token from an environment variable
 		jwtToken = os.Getenv("JWT_TOKEN")
@@ -93,6 +93,9 @@ func ExchangeExternalToken(apiEndpoint, audience, issuerURI, jwtToken string) (*
 		IssuerUri: issuerURI,
 		JwtToken:  jwtToken,
 	}
+	if tokenResponse {
+		request.ResponseType = "TOKEN"
+	}
 	resp, err := stsClient.ExchangeExternalToken(context.Background(), request)
 	if err != nil {
 		return nil, err
@@ -102,6 +105,25 @@ func ExchangeExternalToken(apiEndpoint, audience, issuerURI, jwtToken string) (*
 	credBytes, err := base64.StdEncoding.DecodeString(resp.Base64Credential)
 	if err != nil {
 		return nil, err
+	}
+
+	if tokenResponse {
+		var tokenCreds struct {
+			Mrn         string `json:"mrn"`
+			SpaceMrn    string `json:"space_mrn"`
+			Token       string `json:"token"`
+			ApiEndpoint string `json:"api_endpoint"`
+		}
+		if err := json.Unmarshal(credBytes, &tokenCreds); err != nil {
+			return nil, err
+		}
+		return &ServiceAccountCredentials{
+			Mrn:         tokenCreds.Mrn,
+			ParentMrn:   tokenCreds.SpaceMrn,
+			ScopeMrn:    tokenCreds.SpaceMrn,
+			Token:       tokenCreds.Token,
+			ApiEndpoint: tokenCreds.ApiEndpoint,
+		}, nil
 	}
 
 	// First unmarshal to a temporary structure to handle the field name mismatch

--- a/providers-sdk/v1/upstream/upstream.pb.go
+++ b/providers-sdk/v1/upstream/upstream.pb.go
@@ -898,7 +898,10 @@ type ExchangeExternalTokenRequest struct {
 	// Audience for the service account
 	Audience string `protobuf:"bytes,2,opt,name=audience,proto3" json:"audience,omitempty"`
 	// Token provided by the external identity provider to exchange
-	JwtToken      string `protobuf:"bytes,3,opt,name=jwt_token,json=jwtToken,proto3" json:"jwt_token,omitempty"`
+	JwtToken string `protobuf:"bytes,3,opt,name=jwt_token,json=jwtToken,proto3" json:"jwt_token,omitempty"`
+	// Optional. When set to "TOKEN", the server returns a short-lived bearer
+	// token inside base64_credential instead of service-account credentials.
+	ResponseType  string `protobuf:"bytes,4,opt,name=response_type,json=responseType,proto3" json:"response_type,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -950,6 +953,13 @@ func (x *ExchangeExternalTokenRequest) GetAudience() string {
 func (x *ExchangeExternalTokenRequest) GetJwtToken() string {
 	if x != nil {
 		return x.JwtToken
+	}
+	return ""
+}
+
+func (x *ExchangeExternalTokenRequest) GetResponseType() string {
+	if x != nil {
+		return x.ResponseType
 	}
 	return ""
 }
@@ -1075,12 +1085,13 @@ const file_upstream_proto_rawDesc = "" +
 	"\fSshSignature\x12\x10\n" +
 	"\x03alg\x18\x01 \x01(\tR\x03alg\x12\x10\n" +
 	"\x03kid\x18\x02 \x01(\tR\x03kid\x12\x10\n" +
-	"\x03sig\x18\x03 \x01(\tR\x03sig\"v\n" +
+	"\x03sig\x18\x03 \x01(\tR\x03sig\"\x9b\x01\n" +
 	"\x1cExchangeExternalTokenRequest\x12\x1d\n" +
 	"\n" +
 	"issuer_uri\x18\x01 \x01(\tR\tissuerUri\x12\x1a\n" +
 	"\baudience\x18\x02 \x01(\tR\baudience\x12\x1b\n" +
-	"\tjwt_token\x18\x03 \x01(\tR\bjwtToken\"L\n" +
+	"\tjwt_token\x18\x03 \x01(\tR\bjwtToken\x12#\n" +
+	"\rresponse_type\x18\x04 \x01(\tR\fresponseType\"L\n" +
 	"\x1dExchangeExternalTokenResponse\x12+\n" +
 	"\x11base64_credential\x18\x01 \x01(\tR\x10base64Credential2\x86\x03\n" +
 	"\fAgentManager\x12x\n" +

--- a/providers-sdk/v1/upstream/upstream.proto
+++ b/providers-sdk/v1/upstream/upstream.proto
@@ -135,6 +135,9 @@ message ExchangeExternalTokenRequest {
   string audience = 2;
   // Token provided by the external identity provider to exchange
   string jwt_token = 3;
+  // Optional. When set to "TOKEN", the server returns a short-lived bearer
+  // token inside base64_credential instead of service-account credentials.
+  string response_type = 4;
 }
 
 message ExchangeExternalTokenResponse {

--- a/providers-sdk/v1/upstream/upstream_vtproto.pb.go
+++ b/providers-sdk/v1/upstream/upstream_vtproto.pb.go
@@ -307,6 +307,7 @@ func (m *ExchangeExternalTokenRequest) CloneVT() *ExchangeExternalTokenRequest {
 	r.IssuerUri = m.IssuerUri
 	r.Audience = m.Audience
 	r.JwtToken = m.JwtToken
+	r.ResponseType = m.ResponseType
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -1171,6 +1172,13 @@ func (m *ExchangeExternalTokenRequest) MarshalToSizedBufferVT(dAtA []byte) (int,
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.ResponseType) > 0 {
+		i -= len(m.ResponseType)
+		copy(dAtA[i:], m.ResponseType)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ResponseType)))
+		i--
+		dAtA[i] = 0x22
+	}
 	if len(m.JwtToken) > 0 {
 		i -= len(m.JwtToken)
 		copy(dAtA[i:], m.JwtToken)
@@ -1571,6 +1579,10 @@ func (m *ExchangeExternalTokenRequest) SizeVT() (n int) {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	l = len(m.JwtToken)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.ResponseType)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
@@ -3939,6 +3951,38 @@ func (m *ExchangeExternalTokenRequest) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.JwtToken = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ResponseType", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ResponseType = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex


### PR DESCRIPTION
## Summary
- Adds the `ExchangeTokenForToken` feature flag. When enabled, the WIF external token exchange sends `response_type=TOKEN` in the `ExchangeExternalTokenRequest`.
- Decodes the resulting bearer-token payload into `ServiceAccountCredentials.Token`, which the existing `statictoken` ranger plugin path consumes for authentication.
- No change to the default path — without the flag set, the exchange continues to return certificate-based service-account credentials exactly as before.

## Test plan
- [ ] `go generate ./...` + proto regen produce no unexpected diffs
- [ ] `make test/lint`
- [ ] `go test ./providers-sdk/v1/upstream/...`
- [ ] WIF config without the flag: upstream call still succeeds and authenticates via certificate
- [ ] WIF config with `features: [ExchangeTokenForToken]`: request carries `response_type=TOKEN`, client receives a bearer token, and subsequent upstream calls authenticate via `Authorization: Bearer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)