### PR TITLE
🎉 os-13.15.0

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.14.0",
+	Version: "13.15.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### os (13.15.0)
- providers/os: fall back to AppArmor kernel state (#7360)
- Handle missing ntp and ini files without field errors (#7361)
- 🐛 handle missing auditd rules directory (#7358)
- Handle unavailable vulnmgmt data gracefully (#7349)
- ⭐ Add nginx resource with custom config parser (#7354)