### PR TITLE
🐛 guard against nil asset.Platform in CreateAssetResourceArgs

### DIFF
--- a/providers-sdk/v1/recording/asset_resource_args_test.go
+++ b/providers-sdk/v1/recording/asset_resource_args_test.go
@@ -103,6 +103,37 @@ func TestCreateAssetResourceArgs(t *testing.T) {
 		assert.Equal(t, types.Map(types.String, types.String), result["labels"].Type)
 	})
 
+	t.Run("nil platform does not panic", func(t *testing.T) {
+		asset := &inventory.Asset{
+			Name:        "no-platform-asset",
+			PlatformIds: []string{"platform-id-1"},
+			Labels:      map[string]string{"env": "prod"},
+			Platform:    nil,
+		}
+
+		result := CreateAssetResourceArgs(asset)
+		require.NotNil(t, result)
+
+		// Platform-derived fields should be their zero values.
+		assert.Equal(t, "", result["platform"].Value)
+		assert.Equal(t, "", result["kind"].Value)
+		assert.Equal(t, "", result["runtime"].Value)
+		assert.Equal(t, "", result["version"].Value)
+		assert.Equal(t, "", result["arch"].Value)
+		assert.Equal(t, "", result["title"].Value)
+		assert.Equal(t, "", result["build"].Value)
+
+		// Asset-level fields should still populate.
+		assert.Equal(t, "no-platform-asset", result["name"].Value)
+		ids := result["ids"].Value.([]any)
+		assert.Len(t, ids, 1)
+		assert.Equal(t, "platform-id-1", ids[0])
+
+		// Labels should contain the asset labels even without a platform.
+		labels := result["labels"].Value.(map[string]any)
+		assert.Equal(t, "prod", labels["env"])
+	})
+
 	t.Run("platform labels override asset labels for backwards compatibility", func(t *testing.T) {
 		asset := &inventory.Asset{
 			Name:   "override-test",

--- a/providers-sdk/v1/recording/recording.go
+++ b/providers-sdk/v1/recording/recording.go
@@ -458,24 +458,33 @@ func createResourceAsset(asset *inventory.Asset, id string) *Resource {
 }
 
 func CreateAssetResourceArgs(asset *inventory.Asset) map[string]*llx.RawData {
+	// Platform may be nil if the connecting provider hasn't populated it yet
+	// (e.g. the core provider's Connect runs before the connecting provider
+	// sets platform metadata). Fall back to a zero-value platform so we can
+	// still return the asset fields we do know.
+	platform := asset.Platform
+	if platform == nil {
+		platform = &inventory.Platform{}
+	}
+
 	// FIXME: remove in v12 (or later) vv
 	// we merge `asset.Labels` and `asset.Platform.Labels` for backwards compatibility
-	assetLabelsMergedV11Compat := mapx.Merge(asset.Platform.Labels, asset.Labels)
+	assetLabelsMergedV11Compat := mapx.Merge(platform.Labels, asset.Labels)
 	// ^^
 	args := map[string]*llx.RawData{
 		"ids":              llx.ArrayData(llx.TArr2Raw(asset.PlatformIds), types.String),
-		"platform":         llx.StringData(asset.Platform.Name),
+		"platform":         llx.StringData(platform.Name),
 		"name":             llx.StringData(asset.Name),
-		"kind":             llx.StringData(asset.Platform.Kind),
-		"runtime":          llx.StringData(asset.Platform.Runtime),
-		"version":          llx.StringData(asset.Platform.Version),
-		"arch":             llx.StringData(asset.Platform.Arch),
-		"title":            llx.StringData(asset.Platform.PrettyTitle()),
-		"family":           llx.ArrayData(llx.TArr2Raw(asset.Platform.Family), types.String),
-		"build":            llx.StringData(asset.Platform.Build),
+		"kind":             llx.StringData(platform.Kind),
+		"runtime":          llx.StringData(platform.Runtime),
+		"version":          llx.StringData(platform.Version),
+		"arch":             llx.StringData(platform.Arch),
+		"title":            llx.StringData(platform.PrettyTitle()),
+		"family":           llx.ArrayData(llx.TArr2Raw(platform.Family), types.String),
+		"build":            llx.StringData(platform.Build),
 		"annotations":      llx.MapData(llx.TMap2Raw(asset.Annotations), types.String),
 		"fqdn":             llx.StringData(asset.Fqdn),
-		"platformMetadata": llx.MapData(llx.TMap2Raw(asset.Platform.Metadata), types.String),
+		"platformMetadata": llx.MapData(llx.TMap2Raw(platform.Metadata), types.String),
 		// FIXME: remove in v12 (or later) vv
 		"labels": llx.MapData(llx.TMap2Raw(assetLabelsMergedV11Compat), types.String),
 		// ^^


### PR DESCRIPTION
## Summary
Any query that references the \`asset\` resource against a GCP connection crashes mql with a nil pointer dereference:

\`\`\`
panic: runtime error: invalid memory address or nil pointer dereference
...
go.mondoo.com/mql/v13/providers-sdk/v1/recording.CreateAssetResourceArgs
    providers-sdk/v1/recording/recording.go:463 +0x30
go.mondoo.com/mql/v13/providers/core/provider.(*Service).Connect
    providers/core/provider/provider.go:67 +0x8c
\`\`\`

The panic is at \`mapx.Merge(asset.Platform.Labels, asset.Labels)\` — \`asset.Platform\` is nil when the core provider's \`Connect\` runs before the connecting provider has populated platform metadata. \`CreateAssetResourceArgs\` then dereferences the nil pointer in 9 places (\`platform\`, \`kind\`, \`runtime\`, \`version\`, \`arch\`, \`title\`, \`family\`, \`build\`, \`platformMetadata\`, plus the \`Labels\` merge).

Reproduces today against any GCP project with:
\`\`\`
mql run gcp project <id> -c 'asset.name'
mql run gcp project <id> --discover alloydb-clusters -c 'asset.name'
\`\`\`
Found while verifying PRs #7356 / #7355 / #7351 — none of those PRs caused this, it's pre-existing.

## Fix
Fall back to a zero-value \`inventory.Platform\` when \`asset.Platform == nil\` so the asset-level fields we *do* know (\`name\`, \`ids\`, \`labels\`, \`annotations\`, \`fqdn\`) still populate and platform-derived fields return their empty zero values instead of panicking.

## Test plan
- [x] New unit test \`TestCreateAssetResourceArgs/nil_platform_does_not_panic\` covers the nil path; existing cases still pass.
- [x] Rebuilt mql locally (\`make mql/install\`) and confirmed \`mql run gcp project <id> -c 'asset.name'\` and \`mql run gcp project <id> -c 'asset { name platform kind runtime title }'\` both return data instead of panicking.
- [x] Confirmed discovery path (\`--discover alloydb-clusters\`) no longer panics.
- [x] \`go test ./providers-sdk/v1/recording/...\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)