### PR TITLE
🎉 gcp-13.12.0

### DIFF
--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.11.1",
+	Version: "13.12.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### gcp (13.12.0)
- ⭐ Close partial GCP coverage for Cloud SQL and BigQuery (#7356)
- ⭐ expose Spanner, Firestore, and Bigtable as GCP platforms (#7355)
- ⭐ expand GCP Spanner coverage with new fields, sub-resources, and IAM (#7351)
- 🧹 update vendor deps for aws, azure, gcp, oci providers (#7346)