### PR TITLE
🐛 fix auditpol panic on non-CSV output

### DIFF
--- a/providers/os/resources/auditpol.go
+++ b/providers/os/resources/auditpol.go
@@ -24,6 +24,9 @@ func (p *mqlAuditpol) list() ([]any, error) {
 	if out.Error != nil {
 		return nil, fmt.Errorf("could not run auditpol: %w", out.Error)
 	}
+	if exit := cmd.GetExitcode(); exit.Data != 0 {
+		return nil, fmt.Errorf("could not run auditpol: %s", strings.TrimSpace(cmd.Stderr.Data))
+	}
 
 	entries, err := windows.ParseAuditpol(strings.NewReader(out.Data))
 	if err != nil {

--- a/providers/os/resources/windows/auditpol.go
+++ b/providers/os/resources/windows/auditpol.go
@@ -25,6 +25,10 @@ func ParseAuditpol(r io.Reader) ([]AuditpolEntry, error) {
 	res := []AuditpolEntry{}
 
 	csvReader := csv.NewReader(r)
+	// auditpol prints a plain-text error instead of CSV when it fails (e.g.
+	// non-admin shell). Tolerate variable-width rows so such output produces an
+	// empty result rather than poisoning FieldsPerRecord from the first record.
+	csvReader.FieldsPerRecord = -1
 	for {
 		record, err := csvReader.Read()
 		if err == io.EOF {
@@ -32,6 +36,10 @@ func ParseAuditpol(r io.Reader) ([]AuditpolEntry, error) {
 		}
 		if err != nil {
 			return nil, err
+		}
+
+		if len(record) < 6 {
+			continue
 		}
 
 		guid := strings.TrimSpace(record[3])

--- a/providers/os/resources/windows/auditpol_test.go
+++ b/providers/os/resources/windows/auditpol_test.go
@@ -4,6 +4,7 @@
 package windows_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,6 +36,24 @@ func TestParseAuditpol(t *testing.T) {
 	}
 	found := findPol(auditpol, "Kernel Object")
 	assert.Equal(t, expected, found)
+}
+
+// When auditpol fails (e.g. non-admin shell) it prints a human-readable error
+// instead of CSV. Previously the parser panicked with "index out of range [3]
+// with length 1" on such output.
+func TestParseAuditpol_NonCSVOutput(t *testing.T) {
+	cases := map[string]string{
+		"non-admin":         "The command must be run with administrator privileges\n",
+		"error code":        "ERROR 0x00000057 occurred: The parameter is incorrect.\n",
+		"empty":             "",
+		"malformed midline": "Machine Name,Policy Target,Subcategory,Subcategory GUID,Inclusion Setting,Exclusion Setting\nunexpected diagnostic line\nTest,System,Logon,{0CCE9215-69AE-11D9-BED3-505054503030},Success,\n",
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := windows.ParseAuditpol(strings.NewReader(in))
+			require.NoError(t, err)
+		})
+	}
 }
 
 func findPol(auditpol []windows.AuditpolEntry, subcategory string) *windows.AuditpolEntry {


### PR DESCRIPTION
## Summary
- When `auditpol /get /category:* /r` prints a plain-text error instead of CSV (e.g. a non-admin shell — the original trigger for this bug — or a localized failure banner), `csv.Reader` returned a 1-field record and `ParseAuditpol` panicked on `record[3]` with `index out of range [3] with length 1`.
- Parser now tolerates variable-width rows (`FieldsPerRecord = -1`) and skips records with fewer than 6 fields.
- Caller now checks the PowerShell exit code and returns stderr as an error, so a failed `auditpol` produces a clear diagnostic instead of a silent empty list. Matches the pattern used in `lsblk.go`.

## Test plan
- [x] `go test ./providers/os/resources/windows/... -run TestParseAuditpol` — new `TestParseAuditpol_NonCSVOutput` cases (non-admin message, `ERROR 0x…`, empty input, malformed midline row) reproduce the original panic without the fix and pass with it; existing `TestParseAuditpol` still passes.
- [ ] Manually run `mql run windows -c "auditpol.list"` on a Windows asset from a non-admin shell — should return an `auditpol` error (not a panic, not an empty list).