### PR TITLE
🐛 Azure: work around armnetwork TagMap unmarshal bug for effective NSG rules

### DIFF
--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -324,14 +324,15 @@ func (a *mqlAzureSubscriptionNetworkServiceInterface) effectiveSecurityRules() (
 	}
 	defer httpResp.Body.Close()
 
-	// 202 Accepted → poll the Location/Azure-AsyncOperation header until the result is ready.
+	// 202 Accepted → poll the Location header until the result is ready. We don't
+	// fall back to Azure-AsyncOperation: that endpoint returns a status envelope
+	// (`{"status": "InProgress"|"Succeeded"|"Failed"}`), not the effective-rules
+	// payload, so a 200 from it would just be the loop exiting onto the wrong body.
 	for httpResp.StatusCode == http.StatusAccepted {
 		loc := httpResp.Header.Get("Location")
 		if loc == "" {
-			loc = httpResp.Header.Get("Azure-AsyncOperation")
-		}
-		if loc == "" {
-			break
+			io.Copy(io.Discard, httpResp.Body)
+			return nil, fmt.Errorf("effective NSG list returned 202 without a Location header")
 		}
 		// Sleep a beat then poll.
 		select {
@@ -375,23 +376,14 @@ func (a *mqlAzureSubscriptionNetworkServiceInterface) effectiveSecurityRules() (
 
 	var res []any
 	for _, ensg := range payload.Value {
-		res = append(res, ensg.EffectiveSecurityRules...)
+		for _, rule := range ensg.EffectiveSecurityRules {
+			if rule == nil {
+				continue
+			}
+			res = append(res, rule)
+		}
 	}
 	return res, nil
-}
-
-// isNicEffectiveRulesUnavailableErr returns true when Azure rejects an effective-rules
-// lookup because the NIC is detached, the VM is stopped/deallocated, or RBAC denies it.
-func isNicEffectiveRulesUnavailableErr(err error) bool {
-	var respErr *azcore.ResponseError
-	if !errors.As(err, &respErr) {
-		return false
-	}
-	switch respErr.StatusCode {
-	case http.StatusBadRequest, http.StatusNotFound, http.StatusForbidden:
-		return true
-	}
-	return false
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceWatcher) flowLogs() ([]any, error) {

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -5,14 +5,17 @@ package resources
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -293,43 +296,86 @@ func (a *mqlAzureSubscriptionNetworkServiceInterface) effectiveSecurityRules() (
 		return nil, err
 	}
 
-	client, err := network.NewInterfacesClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
+	// armnetwork v9 misshapes EffectiveNetworkSecurityGroup.TagMap (declared *string,
+	// API returns object), so SDK unmarshalling fails. Use REST directly and pluck
+	// the effectiveSecurityRules out as raw JSON.
+	tok, err := conn.Token().GetToken(ctx, policy.TokenRequestOptions{
+		Scopes: []string{"https://management.azure.com/.default"},
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	poller, err := client.BeginListEffectiveNetworkSecurityGroups(ctx, resourceID.ResourceGroup, nicName, nil)
+	url := fmt.Sprintf(
+		"https://management.azure.com/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkInterfaces/%s/effectiveNetworkSecurityGroups?api-version=2024-05-01",
+		resourceID.SubscriptionID, resourceID.ResourceGroup, nicName,
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
 	if err != nil {
-		if isNicEffectiveRulesUnavailableErr(err) {
-			log.Warn().Str("nic", nicName).Err(err).Msg("effective security rules unavailable for NIC")
-			return []any{}, nil
-		}
 		return nil, err
 	}
-	resp, err := poller.PollUntilDone(ctx, nil)
+	req.Header.Set("Authorization", "Bearer "+tok.Token)
+	req.Header.Set("Accept", "application/json")
+
+	httpClient := &http.Client{Timeout: 60 * time.Second}
+	httpResp, err := httpClient.Do(req)
 	if err != nil {
-		if isNicEffectiveRulesUnavailableErr(err) {
-			log.Warn().Str("nic", nicName).Err(err).Msg("effective security rules unavailable for NIC")
-			return []any{}, nil
+		return nil, err
+	}
+	defer httpResp.Body.Close()
+
+	// 202 Accepted → poll the Location/Azure-AsyncOperation header until the result is ready.
+	for httpResp.StatusCode == http.StatusAccepted {
+		loc := httpResp.Header.Get("Location")
+		if loc == "" {
+			loc = httpResp.Header.Get("Azure-AsyncOperation")
 		}
+		if loc == "" {
+			break
+		}
+		// Sleep a beat then poll.
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+		pollReq, perr := http.NewRequestWithContext(ctx, http.MethodGet, loc, nil)
+		if perr != nil {
+			return nil, perr
+		}
+		pollReq.Header.Set("Authorization", "Bearer "+tok.Token)
+		pollReq.Header.Set("Accept", "application/json")
+		newResp, perr := httpClient.Do(pollReq)
+		if perr != nil {
+			return nil, perr
+		}
+		httpResp.Body.Close()
+		httpResp = newResp
+	}
+
+	if httpResp.StatusCode == http.StatusBadRequest ||
+		httpResp.StatusCode == http.StatusNotFound ||
+		httpResp.StatusCode == http.StatusForbidden {
+		log.Warn().Str("nic", nicName).Int("status", httpResp.StatusCode).Msg("effective security rules unavailable for NIC")
+		return []any{}, nil
+	}
+	if httpResp.StatusCode >= 400 {
+		body, _ := io.ReadAll(httpResp.Body)
+		return nil, fmt.Errorf("effective NSG list returned %d: %s", httpResp.StatusCode, string(body))
+	}
+
+	var payload struct {
+		Value []struct {
+			EffectiveSecurityRules []any `json:"effectiveSecurityRules"`
+		} `json:"value"`
+	}
+	if err := json.NewDecoder(httpResp.Body).Decode(&payload); err != nil {
 		return nil, err
 	}
 
 	var res []any
-	for _, ensg := range resp.Value {
-		if ensg == nil {
-			continue
-		}
-		for _, rule := range ensg.EffectiveSecurityRules {
-			if rule == nil {
-				continue
-			}
-			if d, err := convert.JsonToDict(rule); err == nil {
-				res = append(res, d)
-			}
-		}
+	for _, ensg := range payload.Value {
+		res = append(res, ensg.EffectiveSecurityRules...)
 	}
 	return res, nil
 }


### PR DESCRIPTION
## Summary

`armnetwork@v9.0.0` declares `EffectiveNetworkSecurityGroup.TagMap` as `*string`, but the underlying ARM API returns it as a JSON object. Any call to `InterfacesClient.BeginListEffectiveNetworkSecurityGroups` therefore fails to unmarshal:

```
unmarshalling type *armnetwork.EffectiveNetworkSecurityGroup:
struct field TagMap: json: cannot unmarshal object into Go value of type string
```

This breaks the new `interface.effectiveSecurityRules()` method shipped in #7372 (which auditors use to see the *merged* NSG/ASG/subnet rule set actually applied to a NIC).

## Fix

Bypass the SDK for this one call. Issue the POST directly via REST, follow the `Location` / `Azure-AsyncOperation` redirect for the long-poll, and pull `effectiveSecurityRules` out of the raw JSON. The shape we already cared about (the security-rule entries themselves) round-trips fine — the only field the SDK chokes on is the surrounding wrapper.

Existing graceful-degrade behavior is preserved: 400/403/404 responses (detached NIC, RBAC denial, stopped/deallocated VM) still return an empty slice with a `log.Warn`, same as the prior implementation.

## Verified

```
$ mql run azure --subscription <id> -c \
  'azure.subscription.network.interfaces.where(name == "<nic>")
   { effectiveSecurityRules.length effectiveSecurityRules.first }'
azure.subscription.network.interfaces.where: [
  0: {
    effectiveSecurityRules.first: {
      access: "Allow"
      direction: "Inbound"
      destinationPortRange: "22-22"
      name: "securityRules/AllowSSHFromAzure"
      priority: 100.000000
      protocol: "Tcp"
      sourceAddressPrefix: "AzureCloud"
      ...
    }
    effectiveSecurityRules.length: 7
  }
]
```

The 7 rules cover the explicit NIC/subnet rules plus Azure's default deny/allow set.

## Test plan

- [x] `make providers/build/azure` succeeds
- [x] Spot-checked against a real NIC with both an NSG-on-subnet and a custom security rule — merged rule list returns
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)