### PR TITLE
🐛 Tailscale: propagate ACL marshal errors; expose Postures map

### DIFF
--- a/providers/tailscale/resources/acl.go
+++ b/providers/tailscale/resources/acl.go
@@ -6,9 +6,9 @@ package resources
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 
-	"github.com/rs/zerolog/log"
 	tsclient "github.com/tailscale/tailscale-client-go/v2"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -47,18 +47,36 @@ func createTailscaleAclPolicyResource(runtime *plugin.Runtime, tailnet string, a
 		}
 	}
 
+	acls, err := structSliceToDictSlice(acl.ACLs)
+	if err != nil {
+		return nil, err
+	}
+	ssh, err := structSliceToDictSlice(acl.SSH)
+	if err != nil {
+		return nil, err
+	}
+	tests, err := structSliceToDictSlice(acl.Tests)
+	if err != nil {
+		return nil, err
+	}
+	nodeAttrs, err := structSliceToDictSlice(acl.NodeAttrs)
+	if err != nil {
+		return nil, err
+	}
+
 	return CreateResource(runtime, "tailscale.aclPolicy", map[string]*llx.RawData{
 		"tailnet":               llx.StringData(tailnet),
-		"acls":                  llx.ArrayData(structSliceToDictSlice(acl.ACLs), types.Dict),
+		"acls":                  llx.ArrayData(acls, types.Dict),
 		"groups":                llx.MapData(stringSliceMapToAny(acl.Groups), types.Array(types.String)),
 		"hosts":                 llx.MapData(stringMapToAny(acl.Hosts), types.String),
 		"tagOwners":             llx.MapData(stringSliceMapToAny(acl.TagOwners), types.Array(types.String)),
-		"ssh":                   llx.ArrayData(structSliceToDictSlice(acl.SSH), types.Dict),
-		"tests":                 llx.ArrayData(structSliceToDictSlice(acl.Tests), types.Dict),
-		"nodeAttrs":             llx.ArrayData(structSliceToDictSlice(acl.NodeAttrs), types.Dict),
+		"ssh":                   llx.ArrayData(ssh, types.Dict),
+		"tests":                 llx.ArrayData(tests, types.Dict),
+		"nodeAttrs":             llx.ArrayData(nodeAttrs, types.Dict),
 		"autoApproverExitNodes": llx.ArrayData(autoApproverExitNodes, types.String),
 		"autoApproverRoutes":    llx.MapData(autoApproverRoutes, types.Array(types.String)),
 		"defaultSourcePosture":  llx.ArrayData(stringSliceToAny(acl.DefaultSourcePosture), types.String),
+		"postures":              llx.MapData(stringSliceMapToAny(acl.Postures), types.Array(types.String)),
 		"disableIPv4":           llx.BoolData(acl.DisableIPv4),
 		"oneCGNATRoute":         llx.StringData(acl.OneCGNATRoute),
 		"randomizeClientPort":   llx.BoolData(acl.RandomizeClientPort),
@@ -67,6 +85,10 @@ func createTailscaleAclPolicyResource(runtime *plugin.Runtime, tailnet string, a
 }
 
 // raw lazily fetches the raw HuJSON representation of the policy.
+// Note: the `etag` field reflects the structured policy snapshot returned by
+// PolicyFile().Get() at resource creation, not this raw HuJSON fetch — the two
+// are independent API calls and may briefly diverge if the policy is edited
+// between them.
 func (a *mqlTailscaleAclPolicy) raw() (string, error) {
 	if a.rawFetched {
 		return a.rawValue, nil
@@ -89,26 +111,25 @@ func (a *mqlTailscaleAclPolicy) raw() (string, error) {
 // structSliceToDictSlice JSON-round-trips a slice of policy structs into a
 // slice of generic maps, suitable for use as MQL []dict. Field names match
 // the JSON tags on the Tailscale SDK types (e.g. "src", "dst", "ports",
-// "action", "proto", "users").
-func structSliceToDictSlice[T any](in []T) []any {
+// "action", "proto", "users"). Any conversion error is propagated so
+// security-sensitive policy entries are never silently dropped.
+func structSliceToDictSlice[T any](in []T) ([]any, error) {
 	if len(in) == 0 {
-		return []any{}
+		return []any{}, nil
 	}
 	out := make([]any, 0, len(in))
 	for i := range in {
 		b, err := json.Marshal(in[i])
 		if err != nil {
-			log.Warn().Err(err).Int("index", i).Msg("tailscale: failed to marshal policy entry; dropping")
-			continue
+			return nil, fmt.Errorf("tailscale: failed to marshal policy entry at index %d: %w", i, err)
 		}
 		var m map[string]any
 		if err := json.Unmarshal(b, &m); err != nil {
-			log.Warn().Err(err).Int("index", i).Msg("tailscale: failed to unmarshal policy entry; dropping")
-			continue
+			return nil, fmt.Errorf("tailscale: failed to unmarshal policy entry at index %d: %w", i, err)
 		}
 		out = append(out, m)
 	}
-	return out
+	return out, nil
 }
 
 func stringSliceMapToAny(in map[string][]string) map[string]any {

--- a/providers/tailscale/resources/tailscale.lr
+++ b/providers/tailscale/resources/tailscale.lr
@@ -77,9 +77,9 @@ tailscale.device @defaults("id hostname os") {
   expiresAt time
   // When device was last active on the tailnet
   lastSeenAt time
-  // Subnet routes that the device is advertising
+  // Subnet routes that the device is advertising (fetched per-device on demand)
   advertisedRoutes() []string
-  // Subnet routes that are enabled (allowed) for the device — the device's effective subnet scope
+  // Subnet routes that are enabled (allowed) for the device — the device's effective subnet scope (fetched per-device on demand)
   enabledRoutes() []string
 }
 
@@ -153,6 +153,8 @@ tailscale.aclPolicy @defaults("tailnet") {
   // a map, despite the JSON-style name. Empty when the experimental posture
   // feature is unused.
   defaultSourcePosture []string
+  // Named device posture rules referenced by name from src/defaultSrcPosture (rule name -> list of posture conditions)
+  postures map[string][]string
   // Whether IPv4 is disabled across the tailnet
   disableIPv4 bool
   // Setting that affects how Tailscale routes traffic on the 100.64.0.0/10 CGNAT range

--- a/providers/tailscale/resources/tailscale.lr.go
+++ b/providers/tailscale/resources/tailscale.lr.go
@@ -284,6 +284,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"tailscale.aclPolicy.defaultSourcePosture": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTailscaleAclPolicy).GetDefaultSourcePosture()).ToDataRes(types.Array(types.String))
 	},
+	"tailscale.aclPolicy.postures": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTailscaleAclPolicy).GetPostures()).ToDataRes(types.Map(types.String, types.Array(types.String)))
+	},
 	"tailscale.aclPolicy.disableIPv4": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTailscaleAclPolicy).GetDisableIPv4()).ToDataRes(types.Bool)
 	},
@@ -553,6 +556,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"tailscale.aclPolicy.defaultSourcePosture": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlTailscaleAclPolicy).DefaultSourcePosture, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"tailscale.aclPolicy.postures": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTailscaleAclPolicy).Postures, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"tailscale.aclPolicy.disableIPv4": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1033,6 +1040,7 @@ type mqlTailscaleAclPolicy struct {
 	AutoApproverExitNodes plugin.TValue[[]any]
 	AutoApproverRoutes    plugin.TValue[map[string]any]
 	DefaultSourcePosture  plugin.TValue[[]any]
+	Postures              plugin.TValue[map[string]any]
 	DisableIPv4           plugin.TValue[bool]
 	OneCGNATRoute         plugin.TValue[string]
 	RandomizeClientPort   plugin.TValue[bool]
@@ -1119,6 +1127,10 @@ func (c *mqlTailscaleAclPolicy) GetAutoApproverRoutes() *plugin.TValue[map[strin
 
 func (c *mqlTailscaleAclPolicy) GetDefaultSourcePosture() *plugin.TValue[[]any] {
 	return &c.DefaultSourcePosture
+}
+
+func (c *mqlTailscaleAclPolicy) GetPostures() *plugin.TValue[map[string]any] {
+	return &c.Postures
 }
 
 func (c *mqlTailscaleAclPolicy) GetDisableIPv4() *plugin.TValue[bool] {

--- a/providers/tailscale/resources/tailscale.lr.versions
+++ b/providers/tailscale/resources/tailscale.lr.versions
@@ -13,6 +13,7 @@ tailscale.aclPolicy.groups 13.0.7
 tailscale.aclPolicy.hosts 13.0.7
 tailscale.aclPolicy.nodeAttrs 13.0.7
 tailscale.aclPolicy.oneCGNATRoute 13.0.7
+tailscale.aclPolicy.postures 13.0.7
 tailscale.aclPolicy.randomizeClientPort 13.0.7
 tailscale.aclPolicy.raw 13.0.7
 tailscale.aclPolicy.ssh 13.0.7


### PR DESCRIPTION
## Summary

Follow-up fixes from review of #7376 (already merged).

- **acl.go**: `structSliceToDictSlice` now returns `([]any, error)` — previously it silently dropped ACL rules on JSON marshal/unmarshal errors via `continue`, which is dangerous for security audits.
- **tailscale.lr**: add `postures map[string][]string` to `aclPolicy`. The SDK exposes both `DefaultSourcePosture` (already surfaced) and `Postures` (named posture rule definitions). Without `Postures`, queries can't resolve what a `defaultSourcePosture` name actually checks.
- **acl.go**: documented that `etag` reflects the structured-snapshot fetch and may briefly diverge from the raw HuJSON fetch.

## Test plan
- [x] `go build ./...` clean in `providers/tailscale`
- [x] `gofmt -w` clean
- [ ] Live verification against a tailnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)