### PR TITLE
🐛 DigitalOcean: drop near-constant connectionSsl/privateConnectionAvailable; rename hasNoFirewall

### DIFF
--- a/providers/digitalocean/resources/digitalocean.go
+++ b/providers/digitalocean/resources/digitalocean.go
@@ -282,31 +282,26 @@ func (r *mqlDigitalocean) databases() ([]interface{}, error) {
 			// Host/port are exposed separately for connectivity checks.
 			connHost := ""
 			connPort := int64(0)
-			connSsl := false
 			if db.Connection != nil {
 				connHost = db.Connection.Host
 				connPort = int64(db.Connection.Port)
-				connSsl = db.Connection.SSL
 			}
-			privateConnectionAvailable := db.PrivateConnection != nil
 
 			res, err := CreateResource(r.MqlRuntime, "digitalocean.database", map[string]*llx.RawData{
-				"id":                         llx.StringData(db.ID),
-				"name":                       llx.StringData(db.Name),
-				"engine":                     llx.StringData(db.EngineSlug),
-				"version":                    llx.StringData(db.VersionSlug),
-				"numNodes":                   llx.IntData(int64(db.NumNodes)),
-				"size":                       llx.StringData(db.SizeSlug),
-				"region":                     llx.StringData(db.RegionSlug),
-				"status":                     llx.StringData(db.Status),
-				"createdAt":                  llx.TimeData(db.CreatedAt),
-				"privateNetworkUuid":         llx.StringData(db.PrivateNetworkUUID),
-				"tags":                       llx.ArrayData(tags, "\x02"),
-				"maintenanceWindow":          llx.DictData(mw),
-				"connectionSsl":              llx.BoolData(connSsl),
-				"connectionHost":             llx.StringData(connHost),
-				"connectionPort":             llx.IntData(connPort),
-				"privateConnectionAvailable": llx.BoolData(privateConnectionAvailable),
+				"id":                 llx.StringData(db.ID),
+				"name":               llx.StringData(db.Name),
+				"engine":             llx.StringData(db.EngineSlug),
+				"version":            llx.StringData(db.VersionSlug),
+				"numNodes":           llx.IntData(int64(db.NumNodes)),
+				"size":               llx.StringData(db.SizeSlug),
+				"region":             llx.StringData(db.RegionSlug),
+				"status":             llx.StringData(db.Status),
+				"createdAt":          llx.TimeData(db.CreatedAt),
+				"privateNetworkUuid": llx.StringData(db.PrivateNetworkUUID),
+				"tags":               llx.ArrayData(tags, "\x02"),
+				"maintenanceWindow":  llx.DictData(mw),
+				"connectionHost":     llx.StringData(connHost),
+				"connectionPort":     llx.IntData(connPort),
 			})
 			if err != nil {
 				return nil, err

--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -108,8 +108,8 @@ digitalocean.droplet @defaults("id name status") {
   image dict
   // Firewalls covering this droplet (by id or matching tag)
   firewalls() []digitalocean.firewall
-  // Whether the droplet has a public IPv4 with no firewall attached at all (boolean: no firewall covers the droplet by ID or tag); for actual rule-level analysis, query `firewalls`
-  hasNoFirewall() bool
+  // True when no firewall is attached to the droplet (by id or tag); does not check inbound rule restrictiveness — for that, query `firewalls`
+  missingFirewall() bool
 }
 
 // DigitalOcean firewall

--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -274,8 +274,7 @@ digitalocean.volume @defaults("id name sizeGigabytes") {
   createdAt time
   // Tags
   tags []string
-  // Droplet IDs attached to
-  // Deprecated: use droplets() instead
+  // Deprecated: use droplets() instead. Droplet IDs attached to this volume
   dropletIds []int
   // Droplets this volume is attached to
   droplets() []digitalocean.droplet

--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -108,8 +108,8 @@ digitalocean.droplet @defaults("id name status") {
   image dict
   // Firewalls covering this droplet (by id or matching tag)
   firewalls() []digitalocean.firewall
-  // Whether the droplet has a public IPv4 not covered by any firewall
-  unprotectedPublicIp() bool
+  // Whether the droplet has a public IPv4 with no firewall attached at all (boolean: no firewall covers the droplet by ID or tag); for actual rule-level analysis, query `firewalls`
+  hasNoFirewall() bool
 }
 
 // DigitalOcean firewall
@@ -135,7 +135,7 @@ digitalocean.firewall @defaults("id name status") {
 }
 
 // DigitalOcean managed database cluster
-digitalocean.database @defaults("id name engine connectionSsl") {
+digitalocean.database @defaults("id name engine") {
   // Database cluster ID
   id string
   // Database cluster name
@@ -162,14 +162,10 @@ digitalocean.database @defaults("id name engine connectionSsl") {
   tags []string
   // Firewall rules (trusted sources)
   firewallRules() []dict
-  // Whether the public connection object reports SSL enabled (DigitalOcean managed databases always require TLS on public endpoints; this reflects the SDK's per-connection SSL flag, not a cluster-level enforcement policy)
-  connectionSsl bool
   // Public connection host
   connectionHost string
   // Public connection port
   connectionPort int
-  // Whether a private (VPC-only) connection endpoint is available
-  privateConnectionAvailable bool
   // Maintenance window
   maintenanceWindow dict
   // Database users
@@ -278,7 +274,8 @@ digitalocean.volume @defaults("id name sizeGigabytes") {
   createdAt time
   // Tags
   tags []string
-  // Deprecated: use droplets() instead. Droplet IDs attached to
+  // Droplet IDs attached to
+  // Deprecated: use droplets() instead
   dropletIds []int
   // Droplets this volume is attached to
   droplets() []digitalocean.droplet

--- a/providers/digitalocean/resources/digitalocean.lr.go
+++ b/providers/digitalocean/resources/digitalocean.lr.go
@@ -374,8 +374,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.droplet.firewalls": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDroplet).GetFirewalls()).ToDataRes(types.Array(types.Resource("digitalocean.firewall")))
 	},
-	"digitalocean.droplet.unprotectedPublicIp": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlDigitaloceanDroplet).GetUnprotectedPublicIp()).ToDataRes(types.Bool)
+	"digitalocean.droplet.hasNoFirewall": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanDroplet).GetHasNoFirewall()).ToDataRes(types.Bool)
 	},
 	"digitalocean.firewall.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanFirewall).GetId()).ToDataRes(types.String)
@@ -443,17 +443,11 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.database.firewallRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDatabase).GetFirewallRules()).ToDataRes(types.Array(types.Dict))
 	},
-	"digitalocean.database.connectionSsl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlDigitaloceanDatabase).GetConnectionSsl()).ToDataRes(types.Bool)
-	},
 	"digitalocean.database.connectionHost": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDatabase).GetConnectionHost()).ToDataRes(types.String)
 	},
 	"digitalocean.database.connectionPort": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDatabase).GetConnectionPort()).ToDataRes(types.Int)
-	},
-	"digitalocean.database.privateConnectionAvailable": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlDigitaloceanDatabase).GetPrivateConnectionAvailable()).ToDataRes(types.Bool)
 	},
 	"digitalocean.database.maintenanceWindow": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDatabase).GetMaintenanceWindow()).ToDataRes(types.Dict)
@@ -1201,8 +1195,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanDroplet).Firewalls, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"digitalocean.droplet.unprotectedPublicIp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlDigitaloceanDroplet).UnprotectedPublicIp, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+	"digitalocean.droplet.hasNoFirewall": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanDroplet).HasNoFirewall, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"digitalocean.firewall.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1301,20 +1295,12 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanDatabase).FirewallRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"digitalocean.database.connectionSsl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlDigitaloceanDatabase).ConnectionSsl, ok = plugin.RawToTValue[bool](v.Value, v.Error)
-		return
-	},
 	"digitalocean.database.connectionHost": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanDatabase).ConnectionHost, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"digitalocean.database.connectionPort": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanDatabase).ConnectionPort, ok = plugin.RawToTValue[int64](v.Value, v.Error)
-		return
-	},
-	"digitalocean.database.privateConnectionAvailable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlDigitaloceanDatabase).PrivateConnectionAvailable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"digitalocean.database.maintenanceWindow": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2618,26 +2604,26 @@ type mqlDigitaloceanDroplet struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlDigitaloceanDropletInternal it will be used here
-	Id                  plugin.TValue[int64]
-	Name                plugin.TValue[string]
-	Memory              plugin.TValue[int64]
-	Vcpus               plugin.TValue[int64]
-	Disk                plugin.TValue[int64]
-	Region              plugin.TValue[string]
-	Size                plugin.TValue[string]
-	Status              plugin.TValue[string]
-	CreatedAt           plugin.TValue[*time.Time]
-	PublicIpv4          plugin.TValue[string]
-	PrivateIpv4         plugin.TValue[string]
-	Tags                plugin.TValue[[]any]
-	VpcUuid             plugin.TValue[string]
-	Vpc                 plugin.TValue[*mqlDigitaloceanVpc]
-	Features            plugin.TValue[[]any]
-	BackupsEnabled      plugin.TValue[bool]
-	MonitoringEnabled   plugin.TValue[bool]
-	Image               plugin.TValue[any]
-	Firewalls           plugin.TValue[[]any]
-	UnprotectedPublicIp plugin.TValue[bool]
+	Id                plugin.TValue[int64]
+	Name              plugin.TValue[string]
+	Memory            plugin.TValue[int64]
+	Vcpus             plugin.TValue[int64]
+	Disk              plugin.TValue[int64]
+	Region            plugin.TValue[string]
+	Size              plugin.TValue[string]
+	Status            plugin.TValue[string]
+	CreatedAt         plugin.TValue[*time.Time]
+	PublicIpv4        plugin.TValue[string]
+	PrivateIpv4       plugin.TValue[string]
+	Tags              plugin.TValue[[]any]
+	VpcUuid           plugin.TValue[string]
+	Vpc               plugin.TValue[*mqlDigitaloceanVpc]
+	Features          plugin.TValue[[]any]
+	BackupsEnabled    plugin.TValue[bool]
+	MonitoringEnabled plugin.TValue[bool]
+	Image             plugin.TValue[any]
+	Firewalls         plugin.TValue[[]any]
+	HasNoFirewall     plugin.TValue[bool]
 }
 
 // createDigitaloceanDroplet creates a new instance of this resource
@@ -2777,9 +2763,9 @@ func (c *mqlDigitaloceanDroplet) GetFirewalls() *plugin.TValue[[]any] {
 	})
 }
 
-func (c *mqlDigitaloceanDroplet) GetUnprotectedPublicIp() *plugin.TValue[bool] {
-	return plugin.GetOrCompute[bool](&c.UnprotectedPublicIp, func() (bool, error) {
-		return c.unprotectedPublicIp()
+func (c *mqlDigitaloceanDroplet) GetHasNoFirewall() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasNoFirewall, func() (bool, error) {
+		return c.hasNoFirewall()
 	})
 }
 
@@ -2889,27 +2875,25 @@ type mqlDigitaloceanDatabase struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlDigitaloceanDatabaseInternal it will be used here
-	Id                         plugin.TValue[string]
-	Name                       plugin.TValue[string]
-	Engine                     plugin.TValue[string]
-	Version                    plugin.TValue[string]
-	NumNodes                   plugin.TValue[int64]
-	Size                       plugin.TValue[string]
-	Region                     plugin.TValue[string]
-	Status                     plugin.TValue[string]
-	CreatedAt                  plugin.TValue[*time.Time]
-	PrivateNetworkUuid         plugin.TValue[string]
-	Vpc                        plugin.TValue[*mqlDigitaloceanVpc]
-	Tags                       plugin.TValue[[]any]
-	FirewallRules              plugin.TValue[[]any]
-	ConnectionSsl              plugin.TValue[bool]
-	ConnectionHost             plugin.TValue[string]
-	ConnectionPort             plugin.TValue[int64]
-	PrivateConnectionAvailable plugin.TValue[bool]
-	MaintenanceWindow          plugin.TValue[any]
-	Users                      plugin.TValue[[]any]
-	Replicas                   plugin.TValue[[]any]
-	Pools                      plugin.TValue[[]any]
+	Id                 plugin.TValue[string]
+	Name               plugin.TValue[string]
+	Engine             plugin.TValue[string]
+	Version            plugin.TValue[string]
+	NumNodes           plugin.TValue[int64]
+	Size               plugin.TValue[string]
+	Region             plugin.TValue[string]
+	Status             plugin.TValue[string]
+	CreatedAt          plugin.TValue[*time.Time]
+	PrivateNetworkUuid plugin.TValue[string]
+	Vpc                plugin.TValue[*mqlDigitaloceanVpc]
+	Tags               plugin.TValue[[]any]
+	FirewallRules      plugin.TValue[[]any]
+	ConnectionHost     plugin.TValue[string]
+	ConnectionPort     plugin.TValue[int64]
+	MaintenanceWindow  plugin.TValue[any]
+	Users              plugin.TValue[[]any]
+	Replicas           plugin.TValue[[]any]
+	Pools              plugin.TValue[[]any]
 }
 
 // createDigitaloceanDatabase creates a new instance of this resource
@@ -3015,20 +2999,12 @@ func (c *mqlDigitaloceanDatabase) GetFirewallRules() *plugin.TValue[[]any] {
 	})
 }
 
-func (c *mqlDigitaloceanDatabase) GetConnectionSsl() *plugin.TValue[bool] {
-	return &c.ConnectionSsl
-}
-
 func (c *mqlDigitaloceanDatabase) GetConnectionHost() *plugin.TValue[string] {
 	return &c.ConnectionHost
 }
 
 func (c *mqlDigitaloceanDatabase) GetConnectionPort() *plugin.TValue[int64] {
 	return &c.ConnectionPort
-}
-
-func (c *mqlDigitaloceanDatabase) GetPrivateConnectionAvailable() *plugin.TValue[bool] {
-	return &c.PrivateConnectionAvailable
 }
 
 func (c *mqlDigitaloceanDatabase) GetMaintenanceWindow() *plugin.TValue[any] {

--- a/providers/digitalocean/resources/digitalocean.lr.go
+++ b/providers/digitalocean/resources/digitalocean.lr.go
@@ -374,8 +374,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.droplet.firewalls": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDroplet).GetFirewalls()).ToDataRes(types.Array(types.Resource("digitalocean.firewall")))
 	},
-	"digitalocean.droplet.hasNoFirewall": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlDigitaloceanDroplet).GetHasNoFirewall()).ToDataRes(types.Bool)
+	"digitalocean.droplet.missingFirewall": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanDroplet).GetMissingFirewall()).ToDataRes(types.Bool)
 	},
 	"digitalocean.firewall.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanFirewall).GetId()).ToDataRes(types.String)
@@ -1195,8 +1195,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanDroplet).Firewalls, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"digitalocean.droplet.hasNoFirewall": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlDigitaloceanDroplet).HasNoFirewall, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+	"digitalocean.droplet.missingFirewall": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanDroplet).MissingFirewall, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"digitalocean.firewall.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2623,7 +2623,7 @@ type mqlDigitaloceanDroplet struct {
 	MonitoringEnabled plugin.TValue[bool]
 	Image             plugin.TValue[any]
 	Firewalls         plugin.TValue[[]any]
-	HasNoFirewall     plugin.TValue[bool]
+	MissingFirewall   plugin.TValue[bool]
 }
 
 // createDigitaloceanDroplet creates a new instance of this resource
@@ -2763,9 +2763,9 @@ func (c *mqlDigitaloceanDroplet) GetFirewalls() *plugin.TValue[[]any] {
 	})
 }
 
-func (c *mqlDigitaloceanDroplet) GetHasNoFirewall() *plugin.TValue[bool] {
-	return plugin.GetOrCompute[bool](&c.HasNoFirewall, func() (bool, error) {
-		return c.hasNoFirewall()
+func (c *mqlDigitaloceanDroplet) GetMissingFirewall() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.MissingFirewall, func() (bool, error) {
+		return c.missingFirewall()
 	})
 }
 

--- a/providers/digitalocean/resources/digitalocean.lr.versions
+++ b/providers/digitalocean/resources/digitalocean.lr.versions
@@ -55,7 +55,6 @@ digitalocean.certificates 13.0.1
 digitalocean.database 13.0.1
 digitalocean.database.connectionHost 13.0.2
 digitalocean.database.connectionPort 13.0.2
-digitalocean.database.connectionSsl 13.0.2
 digitalocean.database.createdAt 13.0.1
 digitalocean.database.engine 13.0.1
 digitalocean.database.firewallRules 13.0.1
@@ -71,7 +70,6 @@ digitalocean.database.pool.name 13.0.1
 digitalocean.database.pool.size 13.0.1
 digitalocean.database.pool.user 13.0.1
 digitalocean.database.pools 13.0.1
-digitalocean.database.privateConnectionAvailable 13.0.2
 digitalocean.database.privateNetworkUuid 13.0.1
 digitalocean.database.region 13.0.1
 digitalocean.database.replica 13.0.1
@@ -116,6 +114,7 @@ digitalocean.droplet.createdAt 13.0.1
 digitalocean.droplet.disk 13.0.1
 digitalocean.droplet.features 13.0.1
 digitalocean.droplet.firewalls 13.0.2
+digitalocean.droplet.hasNoFirewall 13.0.2
 digitalocean.droplet.id 13.0.1
 digitalocean.droplet.image 13.0.1
 digitalocean.droplet.memory 13.0.1
@@ -127,7 +126,6 @@ digitalocean.droplet.region 13.0.1
 digitalocean.droplet.size 13.0.1
 digitalocean.droplet.status 13.0.1
 digitalocean.droplet.tags 13.0.1
-digitalocean.droplet.unprotectedPublicIp 13.0.2
 digitalocean.droplet.vcpus 13.0.1
 digitalocean.droplet.vpc 13.0.2
 digitalocean.droplet.vpcUuid 13.0.1

--- a/providers/digitalocean/resources/digitalocean.lr.versions
+++ b/providers/digitalocean/resources/digitalocean.lr.versions
@@ -114,10 +114,10 @@ digitalocean.droplet.createdAt 13.0.1
 digitalocean.droplet.disk 13.0.1
 digitalocean.droplet.features 13.0.1
 digitalocean.droplet.firewalls 13.0.2
-digitalocean.droplet.hasNoFirewall 13.0.2
 digitalocean.droplet.id 13.0.1
 digitalocean.droplet.image 13.0.1
 digitalocean.droplet.memory 13.0.1
+digitalocean.droplet.missingFirewall 13.0.2
 digitalocean.droplet.monitoringEnabled 13.0.1
 digitalocean.droplet.name 13.0.1
 digitalocean.droplet.privateIpv4 13.0.1

--- a/providers/digitalocean/resources/digitalocean_security.go
+++ b/providers/digitalocean/resources/digitalocean_security.go
@@ -117,7 +117,7 @@ func (r *mqlDigitaloceanDroplet) firewalls() ([]any, error) {
 	return out, nil
 }
 
-func (r *mqlDigitaloceanDroplet) unprotectedPublicIp() (bool, error) {
+func (r *mqlDigitaloceanDroplet) hasNoFirewall() (bool, error) {
 	if r.PublicIpv4.Data == "" {
 		return false, nil
 	}

--- a/providers/digitalocean/resources/digitalocean_security.go
+++ b/providers/digitalocean/resources/digitalocean_security.go
@@ -117,7 +117,7 @@ func (r *mqlDigitaloceanDroplet) firewalls() ([]any, error) {
 	return out, nil
 }
 
-func (r *mqlDigitaloceanDroplet) hasNoFirewall() (bool, error) {
+func (r *mqlDigitaloceanDroplet) missingFirewall() (bool, error) {
 	if r.PublicIpv4.Data == "" {
 		return false, nil
 	}


### PR DESCRIPTION
## Summary

Follow-up fixes from review of #7382 (already merged).

- Remove `database.connectionSsl` (constant `true` on managed DBs — zero audit signal).
- Remove `database.privateConnectionAvailable` (nearly always `true` — same).
- Rename `droplet.unprotectedPublicIp` → `droplet.hasNoFirewall` to honestly describe what's checked (firewall attachment, not rule restrictiveness).
- Mark `volume.dropletIds` deprecated alongside the typed `droplets()` getter.

## Test plan
- [x] `go build ./...` clean in `providers/digitalocean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)