### PR TITLE
🧹 GCP: remove auto fallback from getDiscoveryTargets

### DIFF
--- a/providers/gcp/resources/discovery.go
+++ b/providers/gcp/resources/discovery.go
@@ -142,26 +142,21 @@ var AllCloudSQLTypes = []string{DiscoverCloudSQLPostgreSQL, DiscoverCloudSQLSQLS
 func getDiscoveryTargets(config *inventory.Config) []string {
 	targets := config.Discover.Targets
 
-	if len(targets) == 0 {
-		return Auto
-	}
-
 	if stringx.ContainsAnyOf(targets, DiscoveryAll) {
 		// return all discovery targets
 		return All
 	}
-	if stringx.ContainsAnyOf(targets, DiscoveryAuto) {
-		for i, target := range targets {
-			if target == DiscoveryAuto {
-				// remove the auto keyword
-				targets = slices.Delete(targets, i, i+1)
-			}
+
+	res := []string{}
+	for _, target := range targets {
+		switch target {
+		case DiscoveryAuto:
+			res = append(res, Auto...)
+		default:
+			res = append(res, target)
 		}
-		// add in the required discovery targets
-		return append(targets, Auto...)
 	}
-	// random assortment of targets
-	return targets
+	return stringx.DedupStringArray(res)
 }
 
 func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {

--- a/providers/gcp/resources/discovery_test.go
+++ b/providers/gcp/resources/discovery_test.go
@@ -96,9 +96,9 @@ func TestGetDiscoveryTargets(t *testing.T) {
 		want    []string
 	}{
 		{
-			name:    "empty defaults to Auto",
+			name:    "empty returns nothing",
 			targets: []string{},
-			want:    Auto,
+			want:    []string{},
 		},
 		{
 			name:    "all",
@@ -116,9 +116,14 @@ func TestGetDiscoveryTargets(t *testing.T) {
 			want:    Auto,
 		},
 		{
-			name:    "auto with extras",
+			name:    "auto with extras already in auto",
 			targets: []string{"auto", "cloud-dns-zones", "compute-images"},
-			want:    append(slices.Clone(Auto), DiscoverCloudDNSZones, DiscoveryComputeImages),
+			want:    Auto,
+		},
+		{
+			name:    "auto with unique extras",
+			targets: []string{"auto", "some-custom-target"},
+			want:    append(slices.Clone(Auto), "some-custom-target"),
 		},
 		{
 			name:    "explicit targets",


### PR DESCRIPTION
## Summary
- Remove the implicit `Auto` fallback in `getDiscoveryTargets` when discovery targets are empty — `ParseCLI` already sets `"auto"` as the default, so the fallback was redundant and inconsistent with AWS/Azure
- Rewrite `getDiscoveryTargets` to use a switch-based expansion loop with `DedupStringArray`, matching the AWS pattern
- Update tests to reflect the new behavior (empty targets → empty result, dedup of auto extras)

```sh
mql shell gcp project <id> --discover projects --verbose
```

did not work before. it was ignoring it and instead doing a full project discovery, this PR fixes it so the discovery flags are respected

## Test plan
- [x] `GOWORK=off go test ./resources/ -run TestGetDiscoveryTargets -v` — all 7 cases pass
- [x] `GOWORK=off go test ./resources/ -run 'TestAllResolved|TestAutoResolved' -v` — pass
- [ ] Verify no regression in GCP discovery with `mql shell gcp project <id>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)