### PR TITLE
🎉 cloudflare-13.2.0

### DIFF
--- a/providers/cloudflare/config/config.go
+++ b/providers/cloudflare/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "cloudflare",
 	ID:              "go.mondoo.com/mql/v13/providers/cloudflare",
-	Version:         "13.1.0",
+	Version:         "13.2.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### cloudflare (13.2.0)
- 🐛 Cloudflare: move apiTokens to root; flatten r2 publicAccess; DMARC name filter; lazy zone name (#7393)
- ✨ Cloudflare: add DNSSEC, HSTS, R2 ACL, WAF, email routing, SSO (#7384)