### PR TITLE
🎉 digitalocean-13.1.0

### DIFF
--- a/providers/digitalocean/config/config.go
+++ b/providers/digitalocean/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "digitalocean",
 	ID:              "go.mondoo.com/mql/providers/digitalocean",
-	Version:         "13.0.1",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### digitalocean (13.1.0)
- 🐛 DigitalOcean: drop near-constant connectionSsl/privateConnectionAvailable; rename hasNoFirewall (#7392)
- ✨ DigitalOcean: typed VPC/firewall/droplet refs + database TLS audit (#7382)