### PR TITLE
🎉 atlassian-13.1.0

### DIFF
--- a/providers/atlassian/config/config.go
+++ b/providers/atlassian/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "atlassian",
 	ID:      "go.mondoo.com/cnquery/v9/providers/atlassian",
-	Version: "13.0.6",
+	Version: "13.1.0",
 	ConnectionTypes: []string{
 		provider.DefaultConnectionType,
 		"jira",


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### atlassian (13.1.0)
- ✨ Atlassian: add Jira permissions/audit, Confluence space/page perms (#7379)