### PR TITLE
🎉 azure-13.6.0

### DIFF
--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "azure",
 	ID:      "go.mondoo.com/cnquery/v9/providers/azure",
-	Version: "13.5.0",
+	Version: "13.6.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(azureinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### azure (13.6.0)
- 🐛 Azure: work around armnetwork TagMap unmarshal bug for effective NSG rules (#7373)
- ✨ Azure: expand security-scanning coverage across 14 services (#7372)
- 🧹 Bump Azure SDK majors and add update-azure-deps skill (#7371)
- ✨ Add fine-grained Azure discovery platforms (#7262)
- 🧹 update vendor deps for aws, azure, gcp, oci providers (#7346)