### PR TITLE
🐛 OCI: guard nil tenant.HomeRegionKey in object-storage namespace

### DIFF
--- a/providers/oci/resources/buckets.go
+++ b/providers/oci/resources/buckets.go
@@ -30,6 +30,9 @@ func (o *mqlOciObjectStorage) namespace() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if tenant.HomeRegionKey == nil {
+		return "", errors.New("tenancy has no home region configured")
+	}
 
 	region := *tenant.HomeRegionKey
 	client, err := conn.ObjectStorageClient(region)


### PR DESCRIPTION
## Summary

Output of a deep evaluation of the OCI provider for logic errors, nil handling, pagination, N+1 problems, and typos.

After verification, the audit produced **one confirmed bug**.

## Finding & fix

### `oci/resources/buckets.go:34` — un-guarded `*tenant.HomeRegionKey`

**What was wrong:** `mqlOciObjectStorage.namespace()` did `region := *tenant.HomeRegionKey` after only checking the error from `conn.Tenant(ctx)`. The OCI SDK exposes `HomeRegionKey` as `*string`, so a tenancy returned without one would have panicked.

**Consistency note:** Every other site in the OCI provider that touches `tenant.HomeRegionKey` already nil-checks the field before deref:

- `oci/resources/audit.go:28-29` — `if tenancy.HomeRegionKey != nil { region = *tenancy.HomeRegionKey }`
- `oci/resources/cloudguard.go:46-52` — explicit early-return on nil
- `oci/resources/oci.go:122-126` — explicit early-return on nil

`buckets.go:34` was the lone un-guarded site.

**Fix:** Match the pattern: return a typed error if `tenant.HomeRegionKey` is nil before dereferencing.

## Audit findings that turned out to be false positives

For transparency:

- All `*pointer` derefs in tag/property maps elsewhere in the OCI provider — already wrapped in `if x != nil` guards.
- All paginated list operations — `OpcNextPage` is correctly threaded back into the next request in every enumerator I checked.
- No N+1 patterns in top-level enumerators (the existing per-region jobpool model already amortizes the most expensive lookups; comments in `compute.go:252` already acknowledge known per-instance details fetches).
- No `CreateResource`/`NewResource` typos.

## Test plan

- [x] `go build ./...` in `providers/oci` clean.
- [x] `go test ./resources/...` in `providers/oci` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)