### PR TITLE
⚡ Azure: parallelize per-item Get calls in four hot paths

### DIFF
--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.5.0
+	golang.org/x/sync v0.20.0
 )
 
 require (
@@ -275,7 +276,6 @@ require (
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -468,12 +468,17 @@ func (a *mqlAzureSubscriptionComputeServiceVm) dataDisks() ([]any, error) {
 
 	dataDisks := properties.StorageProfile.DataDisks
 
-	// Fetch each attached disk in parallel. Azure has no batch get-by-id
-	// endpoint for disks, so concurrent per-disk Gets is the cheapest fix.
-	ctx := context.Background()
+	// Pre-validate all disks (parse IDs, build clients) before spawning any
+	// goroutines so that an early error can't leak in-flight workers.
+	type diskFetch struct {
+		client *compute.DisksClient
+		rg     string
+		name   string
+		index  int
+	}
+	clientsBySub := map[string]*compute.DisksClient{}
 	disks := make([]compute.Disk, len(dataDisks))
-	g, gctx := errgroup.WithContext(ctx)
-	g.SetLimit(10)
+	fetches := make([]diskFetch, 0, len(dataDisks))
 	for i, dd := range dataDisks {
 		if dd.ManagedDisk == nil || dd.ManagedDisk.ID == nil {
 			continue
@@ -486,20 +491,31 @@ func (a *mqlAzureSubscriptionComputeServiceVm) dataDisks() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
-		client, err := compute.NewDisksClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
-			ClientOptions: conn.ClientOptions(),
-		})
-		if err != nil {
-			return nil, err
+		client, ok := clientsBySub[resourceID.SubscriptionID]
+		if !ok {
+			client, err = compute.NewDisksClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
+				ClientOptions: conn.ClientOptions(),
+			})
+			if err != nil {
+				return nil, err
+			}
+			clientsBySub[resourceID.SubscriptionID] = client
 		}
-		i := i
-		rg := resourceID.ResourceGroup
+		fetches = append(fetches, diskFetch{client: client, rg: resourceID.ResourceGroup, name: diskName, index: i})
+	}
+
+	// Azure has no batch get-by-id endpoint for disks, so concurrent per-disk
+	// Gets in a bounded errgroup is the cheapest fix.
+	ctx := context.Background()
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(10)
+	for _, f := range fetches {
 		g.Go(func() error {
-			resp, err := client.Get(gctx, rg, diskName, &compute.DisksClientGetOptions{})
+			resp, err := f.client.Get(gctx, f.rg, f.name, &compute.DisksClientGetOptions{})
 			if err != nil {
 				return err
 			}
-			disks[i] = resp.Disk
+			disks[f.index] = resp.Disk
 			return nil
 		})
 	}
@@ -573,12 +589,15 @@ func (a *mqlAzureSubscriptionComputeServiceVm) publicIpAddresses() ([]any, error
 	if err != nil {
 		return nil, err
 	}
-	// Phase 1: fetch all NICs concurrently. Per-NIC Get is the only API
-	// option here (no batch endpoint), so a bounded errgroup is the cheapest
-	// fix that preserves semantics.
-	nics := make([]network.Interface, len(networkInterfaces.NetworkInterfaces))
-	g1, gctx1 := errgroup.WithContext(ctx)
-	g1.SetLimit(10)
+	// Phase 1: pre-validate NIC IDs, then fetch all NICs concurrently. Per-NIC
+	// Get is the only API option here (no batch endpoint), so a bounded
+	// errgroup is the cheapest fix that preserves semantics.
+	type nicFetch struct {
+		rg    string
+		name  string
+		index int
+	}
+	nicFetches := make([]nicFetch, 0, len(networkInterfaces.NetworkInterfaces))
 	for i, iface := range networkInterfaces.NetworkInterfaces {
 		if iface.ID == nil {
 			continue
@@ -591,14 +610,19 @@ func (a *mqlAzureSubscriptionComputeServiceVm) publicIpAddresses() ([]any, error
 		if err != nil {
 			return nil, err
 		}
-		i := i
-		rg := resource.ResourceGroup
+		nicFetches = append(nicFetches, nicFetch{rg: resource.ResourceGroup, name: name, index: i})
+	}
+
+	nics := make([]network.Interface, len(networkInterfaces.NetworkInterfaces))
+	g1, gctx1 := errgroup.WithContext(ctx)
+	g1.SetLimit(10)
+	for _, f := range nicFetches {
 		g1.Go(func() error {
-			resp, err := nicClient.Get(gctx1, rg, name, &network.InterfacesClientGetOptions{})
+			resp, err := nicClient.Get(gctx1, f.rg, f.name, &network.InterfacesClientGetOptions{})
 			if err != nil {
 				return err
 			}
-			nics[i] = resp.Interface
+			nics[f.index] = resp.Interface
 			return nil
 		})
 	}
@@ -637,8 +661,6 @@ func (a *mqlAzureSubscriptionComputeServiceVm) publicIpAddresses() ([]any, error
 	g2, gctx2 := errgroup.WithContext(ctx)
 	g2.SetLimit(10)
 	for i, f := range fetches {
-		i := i
-		f := f
 		g2.Go(func() error {
 			resp, err := ipClient.Get(gctx2, f.rg, f.name, &network.PublicIPAddressesClientGetOptions{})
 			if err != nil {

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -21,6 +21,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/azure/connection"
 	"go.mondoo.com/mql/v13/types"
+	"golang.org/x/sync/errgroup"
 )
 
 func (a *mqlAzureSubscriptionComputeService) id() (string, error) {
@@ -467,39 +468,54 @@ func (a *mqlAzureSubscriptionComputeServiceVm) dataDisks() ([]any, error) {
 
 	dataDisks := properties.StorageProfile.DataDisks
 
-	res := []any{}
-	for _, dd := range dataDisks {
+	// Fetch each attached disk in parallel. Azure has no batch get-by-id
+	// endpoint for disks, so concurrent per-disk Gets is the cheapest fix.
+	ctx := context.Background()
+	disks := make([]compute.Disk, len(dataDisks))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(10)
+	for i, dd := range dataDisks {
+		if dd.ManagedDisk == nil || dd.ManagedDisk.ID == nil {
+			continue
+		}
 		resourceID, err := ParseResourceID(*dd.ManagedDisk.ID)
 		if err != nil {
 			return nil, err
 		}
-
 		diskName, err := resourceID.Component("disks")
 		if err != nil {
 			return nil, err
 		}
-
-		ctx := context.Background()
-		if err != nil {
-			return nil, err
-		}
-
 		client, err := compute.NewDisksClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
 			ClientOptions: conn.ClientOptions(),
 		})
 		if err != nil {
 			return nil, err
 		}
-		disk, err := client.Get(ctx, resourceID.ResourceGroup, diskName, &compute.DisksClientGetOptions{})
+		i := i
+		rg := resourceID.ResourceGroup
+		g.Go(func() error {
+			resp, err := client.Get(gctx, rg, diskName, &compute.DisksClientGetOptions{})
+			if err != nil {
+				return err
+			}
+			disks[i] = resp.Disk
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	for _, disk := range disks {
+		if disk.ID == nil {
+			continue
+		}
+		mqlDisk, err := diskToMql(a.MqlRuntime, disk)
 		if err != nil {
 			return nil, err
 		}
-
-		mqlDisk, err := diskToMql(a.MqlRuntime, disk.Disk)
-		if err != nil {
-			return nil, err
-		}
-
 		res = append(res, mqlDisk)
 	}
 
@@ -557,45 +573,91 @@ func (a *mqlAzureSubscriptionComputeServiceVm) publicIpAddresses() ([]any, error
 	if err != nil {
 		return nil, err
 	}
-	for _, iface := range networkInterfaces.NetworkInterfaces {
+	// Phase 1: fetch all NICs concurrently. Per-NIC Get is the only API
+	// option here (no batch endpoint), so a bounded errgroup is the cheapest
+	// fix that preserves semantics.
+	nics := make([]network.Interface, len(networkInterfaces.NetworkInterfaces))
+	g1, gctx1 := errgroup.WithContext(ctx)
+	g1.SetLimit(10)
+	for i, iface := range networkInterfaces.NetworkInterfaces {
+		if iface.ID == nil {
+			continue
+		}
 		resource, err := ParseResourceID(*iface.ID)
 		if err != nil {
 			return nil, err
 		}
-
 		name, err := resource.Component("networkInterfaces")
 		if err != nil {
 			return nil, err
 		}
-		networkInterface, err := nicClient.Get(ctx, resource.ResourceGroup, name, &network.InterfacesClientGetOptions{})
+		i := i
+		rg := resource.ResourceGroup
+		g1.Go(func() error {
+			resp, err := nicClient.Get(gctx1, rg, name, &network.InterfacesClientGetOptions{})
+			if err != nil {
+				return err
+			}
+			nics[i] = resp.Interface
+			return nil
+		})
+	}
+	if err := g1.Wait(); err != nil {
+		return nil, err
+	}
+
+	// Phase 2: collect all public IP IDs across NICs, then fetch concurrently.
+	type ipFetch struct {
+		rg   string
+		name string
+	}
+	var fetches []ipFetch
+	for _, ni := range nics {
+		if ni.Properties == nil {
+			continue
+		}
+		for _, config := range ni.Properties.IPConfigurations {
+			if config.Properties == nil || config.Properties.PublicIPAddress == nil || config.Properties.PublicIPAddress.ID == nil {
+				continue
+			}
+			publicIPID := *config.Properties.PublicIPAddress.ID
+			publicIpResource, err := ParseResourceID(publicIPID)
+			if err != nil {
+				return nil, errors.New("invalid network information for resource " + publicIPID)
+			}
+			ipAddrName, err := publicIpResource.Component("publicIPAddresses")
+			if err != nil {
+				return nil, errors.New("invalid network information for resource " + publicIPID)
+			}
+			fetches = append(fetches, ipFetch{rg: publicIpResource.ResourceGroup, name: ipAddrName})
+		}
+	}
+
+	ipResults := make([]network.PublicIPAddress, len(fetches))
+	g2, gctx2 := errgroup.WithContext(ctx)
+	g2.SetLimit(10)
+	for i, f := range fetches {
+		i := i
+		f := f
+		g2.Go(func() error {
+			resp, err := ipClient.Get(gctx2, f.rg, f.name, &network.PublicIPAddressesClientGetOptions{})
+			if err != nil {
+				return err
+			}
+			ipResults[i] = resp.PublicIPAddress
+			return nil
+		})
+	}
+	if err := g2.Wait(); err != nil {
+		return nil, err
+	}
+
+	for _, ipAddress := range ipResults {
+		mqlIpAddress, err := azureIpToMql(a.MqlRuntime, ipAddress)
 		if err != nil {
 			return nil, err
 		}
-
-		for _, config := range networkInterface.Interface.Properties.IPConfigurations {
-			ip := config.Properties.PublicIPAddress
-			if ip != nil {
-				publicIPID := *ip.ID
-				publicIpResource, err := ParseResourceID(publicIPID)
-				if err != nil {
-					return nil, errors.New("invalid network information for resource " + publicIPID)
-				}
-
-				ipAddrName, err := publicIpResource.Component("publicIPAddresses")
-				if err != nil {
-					return nil, errors.New("invalid network information for resource " + publicIPID)
-				}
-				ipAddress, err := ipClient.Get(ctx, publicIpResource.ResourceGroup, ipAddrName, &network.PublicIPAddressesClientGetOptions{})
-				if err != nil {
-					return nil, err
-				}
-				mqlIpAddress, err := azureIpToMql(a.MqlRuntime, ipAddress.PublicIPAddress)
-				if err != nil {
-					return nil, err
-				}
-				res = append(res, mqlIpAddress)
-			}
-		}
+		res = append(res, mqlIpAddress)
 	}
 
 	return res, nil

--- a/providers/azure/resources/keyvault.go
+++ b/providers/azure/resources/keyvault.go
@@ -20,6 +20,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/azure/connection"
 	"go.mondoo.com/mql/v13/types"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -360,23 +361,45 @@ func (a *mqlAzureSubscriptionKeyVaultServiceVault) autorotation() ([]any, error)
 			return nil, err
 		}
 
+		// Resolve auto-rotation status concurrently. Azure Key Vault has no
+		// batch endpoint for rotation policies, so we fan out per-key
+		// GetKeyRotationPolicy calls within a bounded errgroup.
+		enabledByKid := make(map[string]bool, len(page.Value))
+		var mu sync.Mutex
+		g, gctx := errgroup.WithContext(ctx)
+		g.SetLimit(10)
 		for _, entry := range page.Value {
-			autoRotationEnabled := false
-
-			if entry.KID != nil {
-				keyID := string(*entry.KID)
-				kvid, err := parseKeyVaultId(keyID)
-				if err == nil && kvid.Type == "keys" {
-					policyResp, err := client.GetKeyRotationPolicy(ctx, kvid.Name, nil)
-					if err == nil && policyResp.LifetimeActions != nil {
-						for _, action := range policyResp.LifetimeActions {
-							if action.Action != nil && string(*action.Action.Type) == "Rotate" {
-								autoRotationEnabled = true
-								break
-							}
-						}
+			if entry.KID == nil {
+				continue
+			}
+			kid := string(*entry.KID)
+			kvid, err := parseKeyVaultId(kid)
+			if err != nil || kvid.Type != "keys" {
+				continue
+			}
+			keyName := kvid.Name
+			g.Go(func() error {
+				policyResp, err := client.GetKeyRotationPolicy(gctx, keyName, nil)
+				if err != nil || policyResp.LifetimeActions == nil {
+					return nil
+				}
+				for _, action := range policyResp.LifetimeActions {
+					if action.Action != nil && string(*action.Action.Type) == "Rotate" {
+						mu.Lock()
+						enabledByKid[kid] = true
+						mu.Unlock()
+						return nil
 					}
 				}
+				return nil
+			})
+		}
+		_ = g.Wait()
+
+		for _, entry := range page.Value {
+			autoRotationEnabled := false
+			if entry.KID != nil {
+				autoRotationEnabled = enabledByKid[string(*entry.KID)]
 			}
 
 			mqlAzure, err := CreateResource(a.MqlRuntime, "azure.subscription.keyVaultService.key.autorotation",

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -23,6 +23,7 @@ import (
 	"go.mondoo.com/mql/v13/providers/azure/connection"
 	"go.mondoo.com/mql/v13/types"
 	"go.mondoo.com/mql/v13/utils/stringx"
+	"golang.org/x/sync/errgroup"
 
 	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
 )
@@ -1899,10 +1900,21 @@ func (a *mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy) gateways()
 	}
 
 	gatewaysList := gateways.([]any)
-	res := []any{}
-	for _, g := range gatewaysList {
-		id := g.(map[string]any)["id"]
-		strId := id.(string)
+
+	// Fetch the referenced application gateways in parallel; there is no
+	// batch endpoint, so a bounded errgroup is the cheapest fix.
+	results := make([]network.ApplicationGateway, len(gatewaysList))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(10)
+	for i, gw := range gatewaysList {
+		idVal, ok := gw.(map[string]any)["id"]
+		if !ok {
+			continue
+		}
+		strId, ok := idVal.(string)
+		if !ok {
+			continue
+		}
 		azureId, err := ParseResourceID(strId)
 		if err != nil {
 			return nil, err
@@ -1911,11 +1923,27 @@ func (a *mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy) gateways()
 		if err != nil {
 			return nil, err
 		}
-		gateway, err := client.Get(ctx, azureId.ResourceGroup, gatewayName, &network.ApplicationGatewaysClientGetOptions{})
-		if err != nil {
-			return nil, err
+		i := i
+		rg := azureId.ResourceGroup
+		g.Go(func() error {
+			resp, err := client.Get(gctx, rg, gatewayName, &network.ApplicationGatewaysClientGetOptions{})
+			if err != nil {
+				return err
+			}
+			results[i] = resp.ApplicationGateway
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	for _, gw := range results {
+		if gw.ID == nil {
+			continue
 		}
-		mqlGateway, err := azureAppGatewayToMql(a.MqlRuntime, gateway.ApplicationGateway)
+		mqlGateway, err := azureAppGatewayToMql(a.MqlRuntime, gw)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -1901,11 +1901,14 @@ func (a *mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy) gateways()
 
 	gatewaysList := gateways.([]any)
 
-	// Fetch the referenced application gateways in parallel; there is no
-	// batch endpoint, so a bounded errgroup is the cheapest fix.
-	results := make([]network.ApplicationGateway, len(gatewaysList))
-	g, gctx := errgroup.WithContext(ctx)
-	g.SetLimit(10)
+	// Pre-validate all gateway IDs before launching any goroutines so that an
+	// early parse error can't leak in-flight workers.
+	type gwFetch struct {
+		rg    string
+		name  string
+		index int
+	}
+	fetches := make([]gwFetch, 0, len(gatewaysList))
 	for i, gw := range gatewaysList {
 		idVal, ok := gw.(map[string]any)["id"]
 		if !ok {
@@ -1923,14 +1926,21 @@ func (a *mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy) gateways()
 		if err != nil {
 			return nil, err
 		}
-		i := i
-		rg := azureId.ResourceGroup
+		fetches = append(fetches, gwFetch{rg: azureId.ResourceGroup, name: gatewayName, index: i})
+	}
+
+	// Fetch the referenced application gateways in parallel; there is no
+	// batch endpoint, so a bounded errgroup is the cheapest fix.
+	results := make([]network.ApplicationGateway, len(gatewaysList))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(10)
+	for _, f := range fetches {
 		g.Go(func() error {
-			resp, err := client.Get(gctx, rg, gatewayName, &network.ApplicationGatewaysClientGetOptions{})
+			resp, err := client.Get(gctx, f.rg, f.name, &network.ApplicationGatewaysClientGetOptions{})
 			if err != nil {
 				return err
 			}
-			results[i] = resp.ApplicationGateway
+			results[f.index] = resp.ApplicationGateway
 			return nil
 		})
 	}


### PR DESCRIPTION
## Summary

Output of a deep evaluation of the Azure provider for logic errors, nil handling, pagination, N+1 problems, and typos.

After verification, the Azure-specific findings reduce to **four N+1 patterns** in lazy-loaded resource methods. None of them have an Azure-side batch endpoint, so the cheapest correct fix is bounded-concurrency parallelization — same shape applied four times (`errgroup.SetLimit(10)`).

Result: each call collapses from O(N) sequential round-trips to ~O(N/10).

## Findings & fixes

### 1. `keyvault.go` `autorotation()` — per-key `GetKeyRotationPolicy`

The `KeyVaultServiceVault.autorotation()` method paginated through keys and, for each key, called `client.GetKeyRotationPolicy` serially. A vault with 200 keys cost 200 sequential round-trips before any resource was yielded.

**Fix:** Within each page, fan out `GetKeyRotationPolicy` calls concurrently into a `kid -> bool` map (bounded errgroup, limit 10). The subsequent `CreateResource` loop simply reads from the map. Errors are still tolerated (best-effort), matching the previous `if err == nil` swallow.

### 2. `compute.go` `dataDisks()` — per-disk `DisksClient.Get`

`VM.dataDisks()` looped over `properties.StorageProfile.DataDisks` and issued one `DisksClient.Get` per disk. A VM with N data disks cost N sequential round-trips.

**Fix:** Collect the disks to fetch, run `DisksClient.Get` concurrently, then map into MQL. Also adds a nil guard on `dd.ManagedDisk` / `dd.ManagedDisk.ID` (the SDK exposes both as pointers — a malformed VM-properties payload could have panicked the unchecked deref).

### 3. `compute.go` `publicIpAddresses()` — nested per-NIC + per-IP `Get` (most impactful)

This was a two-level N+1: for each NIC on a VM, `InterfacesClient.Get`; then for each IP config in that NIC, `PublicIPAddressesClient.Get`. Worst case for `M` NICs × `K` IP configs each, you paid `M + M·K` sequential round-trips.

**Fix:** Two phases, both parallelized:
1. Fetch all NICs concurrently into a `[]network.Interface`.
2. Walk every NIC's IP configs to collect public-IP fetch targets, then fetch all in parallel.

Also adds nil guards on `iface.ID`, `ni.Properties`, `config.Properties`, and `config.Properties.PublicIPAddress.ID` — the original code dereferenced through these without checking.

### 4. `network.go` `ApplicationFirewallPolicy.gateways()` — per-gateway `Get`

For each gateway ID listed in the policy's `applicationGateways` property, the code did `ApplicationGatewaysClient.Get` serially.

**Fix:** Same parallelization shape. Also replaces the panic-on-bad-input `id.(string)` cast with the comma-ok form (a malformed property payload would otherwise crash the resource).

## Audit findings that turned out to be false positives

For transparency:

- All `tags[*t.Key] = *t.Value` style sites in the Azure provider — already wrapped in `if t.Key != nil && t.Value != nil` guards.
- All `pager.More() / pager.NextPage()` paginated list operations — every site I traced consumes all pages, no early-break bugs.
- No `CreateResource`/`NewResource` resource-name typos found.

## Test plan

- [x] `go build ./...` in `providers/azure` clean.
- [x] `go vet ./...` in `providers/azure` clean.
- [x] `go test ./resources/...` in `providers/azure` passes.
- [x] `gofmt -w` on all changed files.
- [x] `go mod tidy` (errgroup promoted from indirect → direct).
- [ ] Manual verification on a real Azure tenant with VMs that have multiple data disks and NICs, and a vault with several keys (deferring to reviewer with a real Azure env).

## Related

- AWS provider got the same treatment for Lambda's `ListTags` N+1 in #7407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)