### PR TITLE
🐛 dedupe colliding labels in block JSON output

### DIFF
--- a/llx/rawdata_json.go
+++ b/llx/rawdata_json.go
@@ -96,11 +96,22 @@ func refMapJSON(typ types.Type, data map[string]any, codeID string, bundle *Code
 	// What is the best explanation for why we do this?
 	keys = removeUnderscoreKeys(keys)
 
+	// Multiple entrypoints in a block can resolve to the same label (e.g.
+	// `package("a").installed` and `package("b").installed` both label as
+	// `package.installed`). Disambiguate so the resulting JSON has unique
+	// keys — downstream consumers reject duplicates when unmarshaling into
+	// proto map fields.
+	seen := make(map[string]int, len(keys))
 	last := len(keys) - 1
 	for i, k := range keys {
 		v := data[k]
-		label := label(k, bundle, true)
-		str, err := string2json(label)
+		base := label(k, bundle, true)
+		jsonKey := base
+		if n := seen[base]; n > 0 {
+			jsonKey = fmt.Sprintf("%s (%d)", base, n+1)
+		}
+		seen[base]++
+		str, err := string2json(jsonKey)
 		if err != nil {
 			return err
 		}

--- a/llx/rawdata_json_test.go
+++ b/llx/rawdata_json_test.go
@@ -73,3 +73,92 @@ func TestRawDataJson_Umlauts(t *testing.T) {
 	require.Equal(t, res.String(), "\"Systemintegrit\\ufffdt\"")
 	require.True(t, json.Valid(res.Bytes()))
 }
+
+// Two block entries can resolve to the same human-readable label (e.g.
+// `package("apparmor").installed` and `package("apparmor-utils").installed`
+// both label as `package.installed`). The JSON output must still parse — and
+// in particular must not contain duplicate map keys, which downstream
+// consumers reject when unmarshaling into proto map fields.
+func TestRawDataJson_refMapJSON_collidingLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		data   map[string]any
+	}{
+		{
+			name: "two colliding",
+			labels: map[string]string{
+				"sum-a": "package.installed",
+				"sum-b": "package.installed",
+			},
+			data: map[string]any{
+				"sum-a": BoolData(true),
+				"sum-b": BoolData(false),
+			},
+		},
+		{
+			name: "three colliding",
+			labels: map[string]string{
+				"sum-a": "package.installed",
+				"sum-b": "package.installed",
+				"sum-c": "package.installed",
+			},
+			data: map[string]any{
+				"sum-a": BoolData(true),
+				"sum-b": BoolData(false),
+				"sum-c": BoolData(true),
+			},
+		},
+		{
+			name: "mixed collisions and unique",
+			labels: map[string]string{
+				"sum-a": "package.installed",
+				"sum-b": "package.installed",
+				"sum-c": "asset.family",
+			},
+			data: map[string]any{
+				"sum-a": BoolData(true),
+				"sum-b": BoolData(false),
+				"sum-c": StringData("debian"),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := &CodeBundle{Labels: &Labels{Labels: tc.labels}}
+			var buf bytes.Buffer
+			require.NoError(t, refMapJSON(types.Block, tc.data, "", bundle, &buf))
+			require.True(t, json.Valid(buf.Bytes()), "output is not valid JSON: %s", buf.String())
+
+			// json.Unmarshal silently drops duplicate keys, so walk the raw
+			// token stream to assert all top-level keys are unique.
+			dec := json.NewDecoder(bytes.NewReader(buf.Bytes()))
+			seen := map[string]struct{}{}
+			var depth int
+			for {
+				tok, err := dec.Token()
+				if err != nil {
+					break
+				}
+				switch v := tok.(type) {
+				case json.Delim:
+					if v == '{' {
+						depth++
+					}
+					if v == '}' {
+						depth--
+					}
+				case string:
+					if depth == 1 && dec.More() {
+						if _, dup := seen[v]; dup {
+							t.Fatalf("duplicate JSON key %q in %s", v, buf.String())
+						}
+						seen[v] = struct{}{}
+					}
+				}
+			}
+			require.Equal(t, len(tc.data), len(seen), "every entry must be present in JSON: %s", buf.String())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fix `refMapJSON` to disambiguate JSON keys when multiple block entrypoints resolve to the same label.
- Two queries like `package(\"apparmor\").installed` and `package(\"apparmor-utils\").installed` both label as `package.installed`. The previous code wrote the label as the JSON key for each entry, producing JSON with duplicate keys (\`{\"package.installed\":...,\"package.installed\":...}\`). Strict JSON consumers (e.g. anything round-tripping through \`structpb\`/protojson, which rejects duplicate map keys in proto3) error out on this output.
- Repeated labels now get a `(n)` suffix on each subsequent occurrence so the resulting JSON has unique top-level keys while staying readable.

## Test plan

- [x] New test in `llx/rawdata_json_test.go` covering 2-way, 3-way, and mixed (collision + unique) cases — fails on `main` (duplicate keys), passes after the fix.
- [x] `go test ./llx/... ./cli/printer/...` — all green, no regressions.
- [x] `gofmt`, `go vet ./llx` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)