### PR TITLE
🎉 aws-13.19.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.18.0",
+	Version:         "13.19.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### aws (13.19.0)
- 🐛 AWS: fix tag/struct nil derefs and parallelize Lambda ListTags (#7407)
- ✨ Add aws.dsql and aws.neptuneAnalytics resources (#7413)
- ✨ AWS: surface kms key last-usage and opensearch JWT auth (#7414)
- ⚡ Add double-check locking cache to aws.iam.user lazy-loaded fields (#7187)