### PR TITLE
🧹 Cloudflare: deprecate fields that won't survive cloudflare-go v6 (#7385)

### DIFF
--- a/providers/cloudflare/resources/cloudflare.lr
+++ b/providers/cloudflare/resources/cloudflare.lr
@@ -43,8 +43,8 @@ private cloudflare.zone @defaults("name account.name") {
   account cloudflare.zone.account
 	// Zone owner
 	owner cloudflare.zone.owner
-	// Zone plan
-	plan cloudflare.zone.plan
+	// Zone plan. Deprecated and will be removed in the next major release.
+	plan @maturity("deprecated") cloudflare.zone.plan
 
 	// Zone security settings
 	settings() cloudflare.zone.settings
@@ -113,26 +113,27 @@ private cloudflare.zone.account @defaults("name") {
 	id string
 	// Account name
 	name string
-	// Account type
-	type string
-	// Account email
-	email string
+	// Account type. Deprecated and will be removed in the next major release.
+	type @maturity("deprecated") string
+	// Account email. Deprecated and will be removed in the next major release.
+	email @maturity("deprecated") string
 }
 
 // Cloudflare zone owner
 private cloudflare.zone.owner @defaults("name") {
 	// Owner identifier
 	id string
-	// Owner email
-	email string
+	// Owner email. Deprecated and will be removed in the next major release.
+	email @maturity("deprecated") string
 	// Owner name
 	name string
 	// Owner type
 	ownerType string
 }
 
-// Cloudflare zone plan
-private cloudflare.zone.plan @defaults("name") {
+// Cloudflare zone plan. Deprecated and will be removed in the next major
+// release.
+private cloudflare.zone.plan @defaults("name") @maturity("deprecated") {
 	// Plan identifier
 	id string
 	// Plan name


### PR DESCRIPTION
## Summary

Marks the cloudflare provider fields that won't be populated after the cloudflare-go v0 → v6 migration tracked in [#7385](https://github.com/mondoohq/mql/issues/7385). Shipping the deprecation now (ahead of the migration itself) gives users a heads-up so policies and queries can move off these fields **before** the next major release removes them.

The migration itself is on hold until next major.

## What's deprecated

| Field | Why |
|---|---|
| `cloudflare.zone.account.type` | Cloudflare's API no longer exposes it at the zone level |
| `cloudflare.zone.account.email` | Same — not in the zone-account response |
| `cloudflare.zone.owner.email` | Cloudflare's API doesn't expose owner email at the zone level |
| `cloudflare.zone.plan` (full sub-resource + the `plan` reference on `cloudflare.zone`) | Cloudflare deprecated this in their own SDK in favour of subscription endpoints |

User-facing comments are deliberately short and point at the next-major removal — no SDK internals.

## Diff

One-file change: `providers/cloudflare/resources/cloudflare.lr` — adds `@maturity("deprecated")` annotations and updates the field comments. Build + tests pick up the maturity automatically (visible in `cloudflare.resources.json` as `"maturity":"deprecated"`).

## Test plan
- [x] `./mqlr generate providers/cloudflare/resources/cloudflare.lr --dist providers/cloudflare/resources` clean — `.resources.json` carries `"maturity":"deprecated"` for the affected fields/resource
- [x] `make providers/build/cloudflare` clean
- [x] `go test ./providers/cloudflare/...` — all 48 tests still green (annotations don't change runtime behaviour)
- [x] No changes to `.lr.versions` (annotations don't add fields)
- [x] No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)