### PR TITLE
🧹 Add concurrency groups with cancel-in-progress to CI workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,10 @@ on:
   schedule:
     - cron: "30 17 * * *"
 
+concurrency:
+  group: codeql-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,6 +7,10 @@
 name: 'Dependency Review'
 on: [pull_request]
 
+concurrency:
+  group: dependency-review-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,6 +9,7 @@ on: [pull_request]
 
 concurrency:
   group: dependency-review-${{ github.event.pull_request.number || github.ref }}
+  # Unconditional: this workflow only triggers on pull_request, never on main.
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -6,6 +6,10 @@ name: Link Checking
   push:
     branches: [main]
 
+concurrency:
+  group: link-check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/pr-extended-linting.yml
+++ b/.github/workflows/pr-extended-linting.yml
@@ -12,6 +12,7 @@ on:
 
 concurrency:
   group: pr-extended-linting-${{ github.event.pull_request.number || github.ref }}
+  # Unconditional: this workflow only triggers on pull_request, never on main.
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/pr-extended-linting.yml
+++ b/.github/workflows/pr-extended-linting.yml
@@ -10,6 +10,10 @@ on:
       - ".github/workflows/pr-extended-linting.yml"
       - ".github/workflows/reusable-lint-providers.yml"
 
+concurrency:
+  group: pr-extended-linting-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -11,6 +11,10 @@ on:
 env:
   PROTO_VERSION: "21.7"
 
+concurrency:
+  group: pr-test-generated-files-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -12,6 +12,10 @@ on:
       - ".github/workflows/reusable-lint-providers.yml"
       - "**.toml" # run tests when any recording changed
 
+concurrency:
+  group: pr-test-lint-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary
- Add `concurrency` with `cancel-in-progress` to 6 CI workflows that were missing it (`spell-check.yaml` already had it)
- Workflows triggered only on `pull_request` use `cancel-in-progress: true`
- Workflows that also trigger on `push` to main or `schedule` use `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}` so main branch runs always complete

| Workflow | `cancel-in-progress` | Reason |
|----------|---------------------|--------|
| `pr-test-lint.yml` | conditional | triggers on `push` (all branches) |
| `pr-test-generated-files.yaml` | conditional | triggers on `push` (all branches) |
| `link-check.yaml` | conditional | triggers on `pull_request` + `push: [main]` |
| `codeql.yml` | conditional | triggers on `push/PR: [main]` + `schedule` |
| `pr-extended-linting.yml` | `true` | PR-only |
| `dependency-review.yml` | `true` | PR-only |

## Test plan
- [ ] Verify workflows still trigger correctly on PRs
- [ ] Push a second commit to a PR quickly and confirm the first run is cancelled
- [ ] Verify main branch pushes are not cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)