### PR TITLE
🎉 atlassian-13.2.0

### DIFF
--- a/providers/atlassian/config/config.go
+++ b/providers/atlassian/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "atlassian",
 	ID:      "go.mondoo.com/cnquery/v9/providers/atlassian",
-	Version: "13.1.0",
+	Version: "13.2.0",
 	ConnectionTypes: []string{
 		provider.DefaultConnectionType,
 		"jira",


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### atlassian (13.2.0)
- ✨ Atlassian: expand atlassian.jira.issue with audit-relevant fields (#7420)
- 🧹 Atlassian: migrate provider to go-atlassian/v2 (#7416)