### PR TITLE
🎉 azure-13.8.0

### DIFF
--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "azure",
 	ID:      "go.mondoo.com/cnquery/v9/providers/azure",
-	Version: "13.7.0",
+	Version: "13.8.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(azureinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### azure (13.8.0)
- 🧹 Update deps for mql and providers 20260428 (#7429)
- ✨ Azure: add hosts, proximity groups, images, galleries, vm.networkInterfaces (#7427)
- ✨ Azure: add managed disk snapshot, VMSS, and disk.diskEncryptionSet refs (#7421)