### PR TITLE
🎉 cloudflare-13.3.0

### DIFF
--- a/providers/cloudflare/config/config.go
+++ b/providers/cloudflare/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "cloudflare",
 	ID:              "go.mondoo.com/mql/v13/providers/cloudflare",
-	Version:         "13.2.0",
+	Version:         "13.3.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### cloudflare (13.3.0)
- 🧹 Update deps for mql and providers 20260428 (#7429)
- 🧹 Cloudflare: deprecate fields that won't survive cloudflare-go v6 (#7385) (#7425)
- 🧹 Cloudflare: Tier 2 tests (DNS, DNSSEC, settings, certs, rate limits, IdPs) (#7423)
- 🧹 Cloudflare: tests + fix account.settings aliasing bug (#7419)