### PR TITLE
🎉 github-13.2.0

### DIFF
--- a/providers/github/config/config.go
+++ b/providers/github/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "github",
 	ID:              "go.mondoo.com/cnquery/v9/providers/github",
-	Version:         "13.1.0",
+	Version:         "13.2.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### github (13.2.0)
- 🧹 Update deps for mql and providers 20260428 (#7429)
- ✨ GitHub: add timestamps, user/label, PR review fields, runner ephemeral (#7426)
- ✨ GitHub: add Actions secrets and variables resources (#7422)