### PR TITLE
🎉 oci-13.5.0

### DIFF
--- a/providers/oci/config/config.go
+++ b/providers/oci/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "oci",
 	ID:              "go.mondoo.com/cnquery/v9/providers/oci",
-	Version:         "13.4.0",
+	Version:         "13.5.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### oci (13.5.0)
- 🧹 Update deps for mql and providers 20260428 (#7429)
- 🐛 OCI: guard nil tenant.HomeRegionKey in object-storage namespace (#7408)
- ⭐ Expand OCI provider with flow logs, DB backups, API Gateway, and Certificates (#7353)
- 🧹 update vendor deps for aws, azure, gcp, oci providers (#7346)