### PR TITLE
✨ Firehose: typed encryption + source ref, lastUpdatedAt

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -12343,18 +12343,38 @@ private aws.kinesis.firehoseDeliveryStream @defaults("name status region") {
   status string
   // Type of the delivery stream (DirectPut or KinesisStreamAsSource)
   deliveryStreamType string
-  // Server-side encryption configuration
-  encryption dict
-  // Source configuration if the stream reads from a Kinesis data stream
-  source dict
+  // DEPRECATED: use serverSideEncryption instead
+  encryption @maturity("deprecated") dict
+  // Server-side encryption configuration for the delivery stream
+  serverSideEncryption() aws.kinesis.firehoseDeliveryStream.encryption
+  // DEPRECATED: use kinesisStream() and kinesisStreamArn instead
+  source @maturity("deprecated") dict
+  // Source Kinesis data stream when deliveryStreamType is KinesisStreamAsSource (null otherwise)
+  kinesisStream() aws.kinesis.stream
   // Destinations for the delivery stream
   destinations() []aws.kinesis.firehoseDeliveryStream.destination
   // Date and time the delivery stream was created
   createdAt time
+  // Date and time the delivery stream was last updated
+  lastUpdatedAt time
   // Region where the delivery stream exists
   region string
   // Tags for the delivery stream
   tags() map[string]string
+}
+
+// Server-side encryption configuration for a Firehose delivery stream
+private aws.kinesis.firehoseDeliveryStream.encryption @defaults("status keyType") {
+  // Encryption status: ENABLED, ENABLING, ENABLING_FAILED, DISABLED, DISABLING, DISABLING_FAILED
+  status string
+  // Key type: AWS_OWNED_CMK or CUSTOMER_MANAGED_CMK
+  keyType string
+  // KMS key used for encryption (null when keyType is AWS_OWNED_CMK)
+  kmsKey() aws.kms.key
+  // Failure type when status is ENABLING_FAILED or DISABLING_FAILED
+  failureType string
+  // Failure details when status is ENABLING_FAILED or DISABLING_FAILED
+  failureDetails string
 }
 
 // Amazon Kinesis Firehose delivery stream destination

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -12347,7 +12347,7 @@ private aws.kinesis.firehoseDeliveryStream @defaults("name status region") {
   encryption @maturity("deprecated") dict
   // Server-side encryption configuration for the delivery stream
   serverSideEncryption() aws.kinesis.firehoseDeliveryStream.encryption
-  // DEPRECATED: use kinesisStream() and kinesisStreamArn instead
+  // DEPRECATED: use kinesisStream() instead
   source @maturity("deprecated") dict
   // Source Kinesis data stream when deliveryStreamType is KinesisStreamAsSource (null otherwise)
   kinesisStream() aws.kinesis.stream

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -2783,7 +2783,7 @@ func init() {
 			Create: createAwsKinesis,
 		},
 		"aws.kinesis.stream": {
-			// to override args, implement: initAwsKinesisStream(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAwsKinesisStream,
 			Create: createAwsKinesisStream,
 		},
 		"aws.kinesis.streamConsumer": {

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -542,6 +542,7 @@ const (
 	ResourceAwsKinesisStream                                                    string = "aws.kinesis.stream"
 	ResourceAwsKinesisStreamConsumer                                            string = "aws.kinesis.streamConsumer"
 	ResourceAwsKinesisFirehoseDeliveryStream                                    string = "aws.kinesis.firehoseDeliveryStream"
+	ResourceAwsKinesisFirehoseDeliveryStreamEncryption                          string = "aws.kinesis.firehoseDeliveryStream.encryption"
 	ResourceAwsKinesisFirehoseDeliveryStreamDestination                         string = "aws.kinesis.firehoseDeliveryStream.destination"
 	ResourceAwsKinesisFirehoseDeliveryStreamCloudWatchLogging                   string = "aws.kinesis.firehoseDeliveryStream.cloudWatchLogging"
 	ResourceAwsKinesisFirehoseDeliveryStreamDestinationS3                       string = "aws.kinesis.firehoseDeliveryStream.destination.s3"
@@ -2792,6 +2793,10 @@ func init() {
 		"aws.kinesis.firehoseDeliveryStream": {
 			Init:   initAwsKinesisFirehoseDeliveryStream,
 			Create: createAwsKinesisFirehoseDeliveryStream,
+		},
+		"aws.kinesis.firehoseDeliveryStream.encryption": {
+			// to override args, implement: initAwsKinesisFirehoseDeliveryStreamEncryption(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsKinesisFirehoseDeliveryStreamEncryption,
 		},
 		"aws.kinesis.firehoseDeliveryStream.destination": {
 			// to override args, implement: initAwsKinesisFirehoseDeliveryStreamDestination(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -18671,8 +18676,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.kinesis.firehoseDeliveryStream.encryption": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsKinesisFirehoseDeliveryStream).GetEncryption()).ToDataRes(types.Dict)
 	},
+	"aws.kinesis.firehoseDeliveryStream.serverSideEncryption": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsKinesisFirehoseDeliveryStream).GetServerSideEncryption()).ToDataRes(types.Resource("aws.kinesis.firehoseDeliveryStream.encryption"))
+	},
 	"aws.kinesis.firehoseDeliveryStream.source": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsKinesisFirehoseDeliveryStream).GetSource()).ToDataRes(types.Dict)
+	},
+	"aws.kinesis.firehoseDeliveryStream.kinesisStream": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsKinesisFirehoseDeliveryStream).GetKinesisStream()).ToDataRes(types.Resource("aws.kinesis.stream"))
 	},
 	"aws.kinesis.firehoseDeliveryStream.destinations": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsKinesisFirehoseDeliveryStream).GetDestinations()).ToDataRes(types.Array(types.Resource("aws.kinesis.firehoseDeliveryStream.destination")))
@@ -18680,11 +18691,29 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.kinesis.firehoseDeliveryStream.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsKinesisFirehoseDeliveryStream).GetCreatedAt()).ToDataRes(types.Time)
 	},
+	"aws.kinesis.firehoseDeliveryStream.lastUpdatedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsKinesisFirehoseDeliveryStream).GetLastUpdatedAt()).ToDataRes(types.Time)
+	},
 	"aws.kinesis.firehoseDeliveryStream.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsKinesisFirehoseDeliveryStream).GetRegion()).ToDataRes(types.String)
 	},
 	"aws.kinesis.firehoseDeliveryStream.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsKinesisFirehoseDeliveryStream).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.kinesis.firehoseDeliveryStream.encryption.status": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsKinesisFirehoseDeliveryStreamEncryption).GetStatus()).ToDataRes(types.String)
+	},
+	"aws.kinesis.firehoseDeliveryStream.encryption.keyType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsKinesisFirehoseDeliveryStreamEncryption).GetKeyType()).ToDataRes(types.String)
+	},
+	"aws.kinesis.firehoseDeliveryStream.encryption.kmsKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsKinesisFirehoseDeliveryStreamEncryption).GetKmsKey()).ToDataRes(types.Resource("aws.kms.key"))
+	},
+	"aws.kinesis.firehoseDeliveryStream.encryption.failureType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsKinesisFirehoseDeliveryStreamEncryption).GetFailureType()).ToDataRes(types.String)
+	},
+	"aws.kinesis.firehoseDeliveryStream.encryption.failureDetails": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsKinesisFirehoseDeliveryStreamEncryption).GetFailureDetails()).ToDataRes(types.String)
 	},
 	"aws.kinesis.firehoseDeliveryStream.destination.destinationId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsKinesisFirehoseDeliveryStreamDestination).GetDestinationId()).ToDataRes(types.String)
@@ -44984,8 +45013,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsKinesisFirehoseDeliveryStream).Encryption, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"aws.kinesis.firehoseDeliveryStream.serverSideEncryption": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsKinesisFirehoseDeliveryStream).ServerSideEncryption, ok = plugin.RawToTValue[*mqlAwsKinesisFirehoseDeliveryStreamEncryption](v.Value, v.Error)
+		return
+	},
 	"aws.kinesis.firehoseDeliveryStream.source": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsKinesisFirehoseDeliveryStream).Source, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"aws.kinesis.firehoseDeliveryStream.kinesisStream": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsKinesisFirehoseDeliveryStream).KinesisStream, ok = plugin.RawToTValue[*mqlAwsKinesisStream](v.Value, v.Error)
 		return
 	},
 	"aws.kinesis.firehoseDeliveryStream.destinations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -44996,12 +45033,40 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsKinesisFirehoseDeliveryStream).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"aws.kinesis.firehoseDeliveryStream.lastUpdatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsKinesisFirehoseDeliveryStream).LastUpdatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"aws.kinesis.firehoseDeliveryStream.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsKinesisFirehoseDeliveryStream).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.kinesis.firehoseDeliveryStream.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsKinesisFirehoseDeliveryStream).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.kinesis.firehoseDeliveryStream.encryption.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsKinesisFirehoseDeliveryStreamEncryption).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.kinesis.firehoseDeliveryStream.encryption.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsKinesisFirehoseDeliveryStreamEncryption).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.kinesis.firehoseDeliveryStream.encryption.keyType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsKinesisFirehoseDeliveryStreamEncryption).KeyType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.kinesis.firehoseDeliveryStream.encryption.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsKinesisFirehoseDeliveryStreamEncryption).KmsKey, ok = plugin.RawToTValue[*mqlAwsKmsKey](v.Value, v.Error)
+		return
+	},
+	"aws.kinesis.firehoseDeliveryStream.encryption.failureType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsKinesisFirehoseDeliveryStreamEncryption).FailureType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.kinesis.firehoseDeliveryStream.encryption.failureDetails": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsKinesisFirehoseDeliveryStreamEncryption).FailureDetails, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.kinesis.firehoseDeliveryStream.destination.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -109497,16 +109562,19 @@ type mqlAwsKinesisFirehoseDeliveryStream struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAwsKinesisFirehoseDeliveryStreamInternal
-	Arn                plugin.TValue[string]
-	Name               plugin.TValue[string]
-	Status             plugin.TValue[string]
-	DeliveryStreamType plugin.TValue[string]
-	Encryption         plugin.TValue[any]
-	Source             plugin.TValue[any]
-	Destinations       plugin.TValue[[]any]
-	CreatedAt          plugin.TValue[*time.Time]
-	Region             plugin.TValue[string]
-	Tags               plugin.TValue[map[string]any]
+	Arn                  plugin.TValue[string]
+	Name                 plugin.TValue[string]
+	Status               plugin.TValue[string]
+	DeliveryStreamType   plugin.TValue[string]
+	Encryption           plugin.TValue[any]
+	ServerSideEncryption plugin.TValue[*mqlAwsKinesisFirehoseDeliveryStreamEncryption]
+	Source               plugin.TValue[any]
+	KinesisStream        plugin.TValue[*mqlAwsKinesisStream]
+	Destinations         plugin.TValue[[]any]
+	CreatedAt            plugin.TValue[*time.Time]
+	LastUpdatedAt        plugin.TValue[*time.Time]
+	Region               plugin.TValue[string]
+	Tags                 plugin.TValue[map[string]any]
 }
 
 // createAwsKinesisFirehoseDeliveryStream creates a new instance of this resource
@@ -109561,8 +109629,40 @@ func (c *mqlAwsKinesisFirehoseDeliveryStream) GetEncryption() *plugin.TValue[any
 	return &c.Encryption
 }
 
+func (c *mqlAwsKinesisFirehoseDeliveryStream) GetServerSideEncryption() *plugin.TValue[*mqlAwsKinesisFirehoseDeliveryStreamEncryption] {
+	return plugin.GetOrCompute[*mqlAwsKinesisFirehoseDeliveryStreamEncryption](&c.ServerSideEncryption, func() (*mqlAwsKinesisFirehoseDeliveryStreamEncryption, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.kinesis.firehoseDeliveryStream", c.__id, "serverSideEncryption")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsKinesisFirehoseDeliveryStreamEncryption), nil
+			}
+		}
+
+		return c.serverSideEncryption()
+	})
+}
+
 func (c *mqlAwsKinesisFirehoseDeliveryStream) GetSource() *plugin.TValue[any] {
 	return &c.Source
+}
+
+func (c *mqlAwsKinesisFirehoseDeliveryStream) GetKinesisStream() *plugin.TValue[*mqlAwsKinesisStream] {
+	return plugin.GetOrCompute[*mqlAwsKinesisStream](&c.KinesisStream, func() (*mqlAwsKinesisStream, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.kinesis.firehoseDeliveryStream", c.__id, "kinesisStream")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsKinesisStream), nil
+			}
+		}
+
+		return c.kinesisStream()
+	})
 }
 
 func (c *mqlAwsKinesisFirehoseDeliveryStream) GetDestinations() *plugin.TValue[[]any] {
@@ -109585,6 +109685,10 @@ func (c *mqlAwsKinesisFirehoseDeliveryStream) GetCreatedAt() *plugin.TValue[*tim
 	return &c.CreatedAt
 }
 
+func (c *mqlAwsKinesisFirehoseDeliveryStream) GetLastUpdatedAt() *plugin.TValue[*time.Time] {
+	return &c.LastUpdatedAt
+}
+
 func (c *mqlAwsKinesisFirehoseDeliveryStream) GetRegion() *plugin.TValue[string] {
 	return &c.Region
 }
@@ -109593,6 +109697,82 @@ func (c *mqlAwsKinesisFirehoseDeliveryStream) GetTags() *plugin.TValue[map[strin
 	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
 		return c.tags()
 	})
+}
+
+// mqlAwsKinesisFirehoseDeliveryStreamEncryption for the aws.kinesis.firehoseDeliveryStream.encryption resource
+type mqlAwsKinesisFirehoseDeliveryStreamEncryption struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlAwsKinesisFirehoseDeliveryStreamEncryptionInternal
+	Status         plugin.TValue[string]
+	KeyType        plugin.TValue[string]
+	KmsKey         plugin.TValue[*mqlAwsKmsKey]
+	FailureType    plugin.TValue[string]
+	FailureDetails plugin.TValue[string]
+}
+
+// createAwsKinesisFirehoseDeliveryStreamEncryption creates a new instance of this resource
+func createAwsKinesisFirehoseDeliveryStreamEncryption(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsKinesisFirehoseDeliveryStreamEncryption{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.kinesis.firehoseDeliveryStream.encryption", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsKinesisFirehoseDeliveryStreamEncryption) MqlName() string {
+	return "aws.kinesis.firehoseDeliveryStream.encryption"
+}
+
+func (c *mqlAwsKinesisFirehoseDeliveryStreamEncryption) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsKinesisFirehoseDeliveryStreamEncryption) GetStatus() *plugin.TValue[string] {
+	return &c.Status
+}
+
+func (c *mqlAwsKinesisFirehoseDeliveryStreamEncryption) GetKeyType() *plugin.TValue[string] {
+	return &c.KeyType
+}
+
+func (c *mqlAwsKinesisFirehoseDeliveryStreamEncryption) GetKmsKey() *plugin.TValue[*mqlAwsKmsKey] {
+	return plugin.GetOrCompute[*mqlAwsKmsKey](&c.KmsKey, func() (*mqlAwsKmsKey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.kinesis.firehoseDeliveryStream.encryption", c.__id, "kmsKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsKmsKey), nil
+			}
+		}
+
+		return c.kmsKey()
+	})
+}
+
+func (c *mqlAwsKinesisFirehoseDeliveryStreamEncryption) GetFailureType() *plugin.TValue[string] {
+	return &c.FailureType
+}
+
+func (c *mqlAwsKinesisFirehoseDeliveryStreamEncryption) GetFailureDetails() *plugin.TValue[string] {
+	return &c.FailureDetails
 }
 
 // mqlAwsKinesisFirehoseDeliveryStreamDestination for the aws.kinesis.firehoseDeliveryStream.destination resource

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -3528,8 +3528,16 @@ aws.kinesis.firehoseDeliveryStream.destination.splunk.s3BackupMode 13.0.2
 aws.kinesis.firehoseDeliveryStream.destination.type 13.0.2
 aws.kinesis.firehoseDeliveryStream.destinations 11.16.1
 aws.kinesis.firehoseDeliveryStream.encryption 11.16.1
+aws.kinesis.firehoseDeliveryStream.encryption.failureDetails 13.19.2
+aws.kinesis.firehoseDeliveryStream.encryption.failureType 13.19.2
+aws.kinesis.firehoseDeliveryStream.encryption.keyType 13.19.2
+aws.kinesis.firehoseDeliveryStream.encryption.kmsKey 13.19.2
+aws.kinesis.firehoseDeliveryStream.encryption.status 13.19.2
+aws.kinesis.firehoseDeliveryStream.kinesisStream 13.19.2
+aws.kinesis.firehoseDeliveryStream.lastUpdatedAt 13.19.2
 aws.kinesis.firehoseDeliveryStream.name 11.16.1
 aws.kinesis.firehoseDeliveryStream.region 11.16.1
+aws.kinesis.firehoseDeliveryStream.serverSideEncryption 13.19.2
 aws.kinesis.firehoseDeliveryStream.source 11.16.1
 aws.kinesis.firehoseDeliveryStream.status 11.16.1
 aws.kinesis.firehoseDeliveryStream.tags 11.16.1

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
-  "version": "13.19.0",
-  "generated_at": "2026-04-28T08:46:40-07:00",
+  "version": "13.19.1",
+  "generated_at": "2026-04-28T17:00:02-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindingsV2",

--- a/providers/aws/resources/aws_kinesis.go
+++ b/providers/aws/resources/aws_kinesis.go
@@ -86,6 +86,56 @@ func (a *mqlAwsKinesis) getStreams(conn *connection.AwsConnection) []*jobpool.Jo
 	return tasks
 }
 
+// initAwsKinesisStream allows typed refs (e.g. from
+// aws.kinesis.firehoseDeliveryStream.kinesisStream or
+// aws.kinesis.streamConsumer.stream) to resolve a stream by ARN. Without it
+// NewResource would yield a shell with no fields populated. Falls back to an
+// arn-only shell on access-denied or describe failure.
+func initAwsKinesisStream(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) >= 2 {
+		return args, nil, nil
+	}
+	if args["arn"] == nil {
+		return nil, nil, errors.New("arn required to fetch aws kinesis stream")
+	}
+	arnVal := args["arn"].Value.(string)
+	parsed, err := arn.Parse(arnVal)
+	if err != nil {
+		args["__id"] = llx.StringData(arnVal)
+		return args, nil, nil
+	}
+	// resource portion is "stream/<name>"
+	name := strings.TrimPrefix(parsed.Resource, "stream/")
+	if name == "" || name == parsed.Resource {
+		return nil, nil, fmt.Errorf("unexpected kinesis stream arn format: %s", arnVal)
+	}
+	conn := runtime.Connection.(*connection.AwsConnection)
+	svc := conn.Kinesis(parsed.Region)
+	out, err := svc.DescribeStreamSummary(context.Background(), &kinesis.DescribeStreamSummaryInput{
+		StreamARN: &arnVal,
+	})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			args["__id"] = llx.StringData(arnVal)
+			return args, nil, nil
+		}
+		return nil, nil, err
+	}
+	if out.StreamDescriptionSummary == nil {
+		args["__id"] = llx.StringData(arnVal)
+		return args, nil, nil
+	}
+	desc := out.StreamDescriptionSummary
+	args["__id"] = llx.StringData(arnVal)
+	args["arn"] = llx.StringData(arnVal)
+	args["name"] = llx.StringDataPtr(desc.StreamName)
+	args["status"] = llx.StringData(string(desc.StreamStatus))
+	args["streamModeDetails"] = llx.NilData
+	args["createdAt"] = llx.TimeDataPtr(desc.StreamCreationTimestamp)
+	args["region"] = llx.StringData(parsed.Region)
+	return args, nil, nil
+}
+
 func newMqlAwsKinesisStream(runtime *plugin.Runtime, region string, summary *kinesis_types.StreamSummary) (*mqlAwsKinesisStream, error) {
 	// Use fields available from ListStreams StreamSummary
 	streamModeDetails, err := convert.JsonToDict(summary.StreamModeDetails)

--- a/providers/aws/resources/aws_kinesis.go
+++ b/providers/aws/resources/aws_kinesis.go
@@ -454,8 +454,10 @@ func (a *mqlAwsKinesis) getFirehoseDeliveryStreams(conn *connection.AwsConnectio
 }
 
 type mqlAwsKinesisFirehoseDeliveryStreamInternal struct {
-	cacheDestinations []firehose_types.DestinationDescription
-	cacheRegion       string
+	cacheDestinations     []firehose_types.DestinationDescription
+	cacheRegion           string
+	cacheEncryption       *firehose_types.DeliveryStreamEncryptionConfiguration
+	cacheKinesisStreamArn string
 }
 
 func newMqlAwsKinesisFirehoseDeliveryStream(runtime *plugin.Runtime, region string, stream *firehose_types.DeliveryStreamDescription) (*mqlAwsKinesisFirehoseDeliveryStream, error) {
@@ -469,6 +471,12 @@ func newMqlAwsKinesisFirehoseDeliveryStream(runtime *plugin.Runtime, region stri
 		return nil, err
 	}
 
+	kinesisStreamArn := ""
+	if stream.Source != nil && stream.Source.KinesisStreamSourceDescription != nil &&
+		stream.Source.KinesisStreamSourceDescription.KinesisStreamARN != nil {
+		kinesisStreamArn = *stream.Source.KinesisStreamSourceDescription.KinesisStreamARN
+	}
+
 	resource, err := CreateResource(runtime, "aws.kinesis.firehoseDeliveryStream",
 		map[string]*llx.RawData{
 			"__id":               llx.StringDataPtr(stream.DeliveryStreamARN),
@@ -479,6 +487,7 @@ func newMqlAwsKinesisFirehoseDeliveryStream(runtime *plugin.Runtime, region stri
 			"encryption":         llx.DictData(encryption),
 			"source":             llx.DictData(source),
 			"createdAt":          llx.TimeDataPtr(stream.CreateTimestamp),
+			"lastUpdatedAt":      llx.TimeDataPtr(stream.LastUpdateTimestamp),
 			"region":             llx.StringData(region),
 		})
 	if err != nil {
@@ -487,7 +496,70 @@ func newMqlAwsKinesisFirehoseDeliveryStream(runtime *plugin.Runtime, region stri
 	mqlStream := resource.(*mqlAwsKinesisFirehoseDeliveryStream)
 	mqlStream.cacheDestinations = stream.Destinations
 	mqlStream.cacheRegion = region
+	mqlStream.cacheEncryption = stream.DeliveryStreamEncryptionConfiguration
+	mqlStream.cacheKinesisStreamArn = kinesisStreamArn
 	return mqlStream, nil
+}
+
+func (a *mqlAwsKinesisFirehoseDeliveryStream) serverSideEncryption() (*mqlAwsKinesisFirehoseDeliveryStreamEncryption, error) {
+	enc := a.cacheEncryption
+	if enc == nil {
+		a.ServerSideEncryption.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	failureType := ""
+	failureDetails := ""
+	if enc.FailureDescription != nil {
+		failureType = string(enc.FailureDescription.Type)
+		failureDetails = convert.ToValue(enc.FailureDescription.Details)
+	}
+	encId := a.Arn.Data + "/encryption"
+	res, err := CreateResource(a.MqlRuntime, "aws.kinesis.firehoseDeliveryStream.encryption",
+		map[string]*llx.RawData{
+			"__id":           llx.StringData(encId),
+			"status":         llx.StringData(string(enc.Status)),
+			"keyType":        llx.StringData(string(enc.KeyType)),
+			"failureType":    llx.StringData(failureType),
+			"failureDetails": llx.StringData(failureDetails),
+		})
+	if err != nil {
+		return nil, err
+	}
+	mqlEnc := res.(*mqlAwsKinesisFirehoseDeliveryStreamEncryption)
+	mqlEnc.cacheKmsKeyArn = enc.KeyARN
+	return mqlEnc, nil
+}
+
+type mqlAwsKinesisFirehoseDeliveryStreamEncryptionInternal struct {
+	cacheKmsKeyArn *string
+}
+
+func (a *mqlAwsKinesisFirehoseDeliveryStreamEncryption) kmsKey() (*mqlAwsKmsKey, error) {
+	if a.cacheKmsKeyArn == nil || *a.cacheKmsKeyArn == "" {
+		a.KmsKey.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	mqlKey, err := NewResource(a.MqlRuntime, ResourceAwsKmsKey, map[string]*llx.RawData{
+		"arn": llx.StringDataPtr(a.cacheKmsKeyArn),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return mqlKey.(*mqlAwsKmsKey), nil
+}
+
+func (a *mqlAwsKinesisFirehoseDeliveryStream) kinesisStream() (*mqlAwsKinesisStream, error) {
+	if a.cacheKinesisStreamArn == "" {
+		a.KinesisStream.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	mqlStream, err := NewResource(a.MqlRuntime, "aws.kinesis.stream", map[string]*llx.RawData{
+		"arn": llx.StringData(a.cacheKinesisStreamArn),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return mqlStream.(*mqlAwsKinesisStream), nil
 }
 
 // initAwsKinesisFirehoseDeliveryStream allows typed refs (e.g. from

--- a/providers/aws/resources/aws_kinesis.go
+++ b/providers/aws/resources/aws_kinesis.go
@@ -104,9 +104,8 @@ func initAwsKinesisStream(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		args["__id"] = llx.StringData(arnVal)
 		return args, nil, nil
 	}
-	// resource portion is "stream/<name>"
-	name := strings.TrimPrefix(parsed.Resource, "stream/")
-	if name == "" || name == parsed.Resource {
+	// resource portion must be "stream/<name>"
+	if !strings.HasPrefix(parsed.Resource, "stream/") || parsed.Resource == "stream/" {
 		return nil, nil, fmt.Errorf("unexpected kinesis stream arn format: %s", arnVal)
 	}
 	conn := runtime.Connection.(*connection.AwsConnection)


### PR DESCRIPTION
## Summary

Replaces the dict-only `encryption` and `source` fields on `aws.kinesis.firehoseDeliveryStream` with typed sub-resources so audits can traverse them without dict navigation.

- **New `aws.kinesis.firehoseDeliveryStream.encryption` sub-resource** (exposed via `serverSideEncryption()`)
  - `status` — `ENABLED` / `ENABLING` / `ENABLING_FAILED` / `DISABLED` / `DISABLING` / `DISABLING_FAILED`
  - `keyType` — `AWS_OWNED_CMK` or `CUSTOMER_MANAGED_CMK`
  - `kmsKey()` — typed `aws.kms.key`, null when `keyType` is `AWS_OWNED_CMK`
  - `failureType`, `failureDetails` — populated when status is `ENABLING_FAILED` / `DISABLING_FAILED`
- **New `kinesisStream() aws.kinesis.stream`** on the parent — null unless `deliveryStreamType` is `KinesisStreamAsSource`
- **New `lastUpdatedAt time`** field
- The old `encryption dict` and `source dict` fields stay populated for backward-compat, marked `@maturity("deprecated")` with `DEPRECATED:` doc prefix per CLAUDE.md convention
- **New `initAwsKinesisStream`** so typed kinesis-stream refs (used by `firehose.kinesisStream()` and the existing `streamConsumer.stream()`) resolve to a populated resource via `DescribeStreamSummary` rather than a shell with only `arn` set

`.lr.versions` entries land at `13.19.2`. No new permissions required (already calls `firehose:DescribeDeliveryStream`).

## Verification — live AWS account, 12/12 MQL queries pass

Stood up a real test stack in `us-east-1`:
- 1 Firehose stream with `CUSTOMER_MANAGED_CMK` encryption + `extended_s3` destination
- 1 Firehose stream with `KinesisStreamAsSource` (no encryption) + `extended_s3` destination
- 1 source Kinesis data stream
- 1 KMS CMK
- 1 S3 bucket + IAM role (firehose write policy)

Ran 12 MQL queries via `mql --auto-update=false run aws --filters regions=us-east-1 -j -c "<query>"`:

```
================================================================
PASS=12 FAIL=0 TOTAL=12
```

Highlights:

| # | Query (abbreviated) | Result |
|---|---|---|
| 1 | `aws.kinesis.firehoseDeliveryStreams.length` | `2` |
| 2 | `{ name status deliveryStreamType }` | Both streams `ACTIVE`, types `DirectPut` and `KinesisStreamAsSource` |
| 3 | `{ createdAt lastUpdatedAt }` | Times populated; `lastUpdatedAt` null for fresh-created streams (SDK behavior, expected) |
| 4–5 | Deprecated `encryption` / `source` dicts | Still populated for back-compat |
| 6 | `serverSideEncryption { status keyType failureType failureDetails }` | `ENABLED`/`CUSTOMER_MANAGED_CMK` for the CMK stream; `null` (set+null) for the unencrypted stream |
| 7 | `serverSideEncryption { kmsKey { id arn } }` | KMS key resolves correctly to the CMK |
| 8 | `kinesisStream` on `DirectPut` stream | `null` (correct) |
| 9 | `kinesisStream { name status }` on `KinesisStreamAsSource` | Resolves to the source stream with `name=mqlfh-…-source`, `status=ACTIVE` — confirms `initAwsKinesisStream` works |
| 10 | `tags` | All custom tags returned |
| 11 | `destinations { type s3 { bucketArn compressionFormat prefix } }` | Existing typed destination model still works |
| 12 | `serverSideEncryption.kmsKey.keyManager` cross-traversal | Returns `"CUSTOMER"` |

All 10 terraform resources destroyed cleanly afterwards, state list empty.

## Test plan (for the merge reviewer)

- [ ] `make providers/build/aws && make providers/install/aws`
- [ ] Spot-check the queries above against any account that has Firehose streams; both encrypted and unencrypted variants are useful, plus a `KinesisStreamAsSource` for the typed-ref check
- [ ] `make test/lint` and `make test/go/plain` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)