### PR TITLE
🐛 ARN-only init tolerance for cloudwatch.loggroup and ecs.taskDefinition

### DIFF
--- a/providers/aws/resources/aws_cloudwatch.go
+++ b/providers/aws/resources/aws_cloudwatch.go
@@ -673,11 +673,16 @@ func initAwsCloudwatchLoggroup(runtime *plugin.Runtime, args map[string]*llx.Raw
 	}
 
 	arnVal := args["arn"].Value.(string)
+	// CloudWatch's DescribeLogGroups returns ARNs with a trailing ":*" suffix;
+	// other AWS services (e.g. EventBridge Pipes LogConfiguration) return the
+	// bare ARN without it. Compare both with and without the suffix so init
+	// resolves correctly regardless of which form the caller passes.
+	arnNoStar := strings.TrimSuffix(arnVal, ":*")
 	for _, rawResource := range rawResources.Data {
 		logGroup := rawResource.(*mqlAwsCloudwatchLoggroup)
 		mqlLgArn := logGroup.Arn.Data
 
-		if mqlLgArn == arnVal {
+		if mqlLgArn == arnVal || strings.TrimSuffix(mqlLgArn, ":*") == arnNoStar {
 			return args, logGroup, nil
 		}
 	}

--- a/providers/aws/resources/aws_ecs.go
+++ b/providers/aws/resources/aws_ecs.go
@@ -1272,10 +1272,22 @@ func (a *mqlAwsEcsTaskDefinition) fetchDetail() error {
 	}
 
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	svc := conn.Ecs(a.Region.Data)
+	arnVal := a.Arn.Data
+
+	// When the resource is initialised with only an ARN (e.g. from a typed-ref
+	// accessor in another resource), Region.Data is empty. Fall back to the
+	// region encoded in the ARN so DescribeTaskDefinition has a valid endpoint.
+	region := a.Region.Data
+	if region == "" {
+		if parsed, err := arn.Parse(arnVal); err == nil {
+			region = parsed.Region
+			a.Region = plugin.TValue[string]{Data: region, State: plugin.StateIsSet}
+		}
+	}
+
+	svc := conn.Ecs(region)
 	ctx := context.Background()
 
-	arnVal := a.Arn.Data
 	describeResp, err := svc.DescribeTaskDefinition(ctx, &ecsservice.DescribeTaskDefinitionInput{
 		TaskDefinition: &arnVal,
 	})


### PR DESCRIPTION
## Summary

Two pre-existing init bugs in resources that other resources resolve via typed-ref ARN. Both surfaced when exercising the EventBridge Pipes (#7443, merged) and EventBridge Scheduler (#7444, in review) PRs against a live AWS account.

### `aws.cloudwatch.loggroup`

`initAwsCloudwatchLoggroup` compared incoming ARNs by exact equality against cached log-group ARNs.

CloudWatch's `DescribeLogGroups` returns ARNs **with** a trailing `:*` suffix:
```
arn:aws:logs:us-east-1:123:log-group:/aws/pipes/foo:*
```

Other AWS services (EventBridge Pipes' `LogConfiguration.CloudwatchLogsLogDestination.LogGroupArn` in particular) return the **bare** ARN without it:
```
arn:aws:logs:us-east-1:123:log-group:/aws/pipes/foo
```

Init silently failed to match — every typed-ref access from a Pipe to its CloudWatch log group returned `cloudwatch log group does not exist`.

**Fix:** compare both with and without the suffix.

### `aws.ecs.taskDefinition`

`fetchDetail()` called `conn.Ecs(a.Region.Data)`, but `Region.Data` is empty when the resource is initialised by ARN (no init function for taskDefinition). The empty region caused `DescribeTaskDefinition` to use a bogus default endpoint and AWS returned `Invalid Region in ARN`.

**Fix:** when `Region.Data` is empty, parse the region out of the ARN and use that.

## Verification

Reproduced both bugs by querying the new accessors from PRs #7443 and #7444 against a live AWS account:
- `aws.eventbridge.pipes { logConfiguration.cloudwatchLogs.logGroup.name }` — now resolves
- `aws.eventbridge.schedules { target.ecsParameters.taskDefinition.family }` — now resolves

Both fixes are minimal and isolated. No schema changes, no new permissions, no new dependencies.

## Test plan

- [ ] `make providers/build/aws && make providers/install/aws`
- [ ] Existing test suite still passes
- [ ] Spot-check a typed-ref query that crosses into one of these resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)