### PR TITLE
🐛 Guard unchecked casts in azure getInstancesLabels

### DIFF
--- a/providers/azure/resources/discovery.go
+++ b/providers/azure/resources/discovery.go
@@ -505,31 +505,30 @@ func getInstancesLabels(vm *mqlAzureSubscriptionComputeServiceVm) (map[string]st
 		return nil, props.Error
 	}
 
-	propsDict := props.Data.(map[string]any)
-	osProfile, ok := propsDict["osProfile"]
-	if ok {
+	propsDict, ok := props.Data.(map[string]any)
+	if !ok {
+		propsDict = map[string]any{}
+	}
+	if osProfile, ok := propsDict["osProfile"]; ok {
 		if osProfileDict, ok := osProfile.(map[string]any); ok {
-			labels["azure.mondoo.com/computername"] = osProfileDict["computerName"].(string)
+			if computerName, ok := osProfileDict["computerName"].(string); ok {
+				labels["azure.mondoo.com/computername"] = computerName
+			}
 		}
 	}
-	storageProfile, ok := propsDict["storageProfile"]
-	if ok {
+	if storageProfile, ok := propsDict["storageProfile"]; ok {
 		if storageProfile, ok := storageProfile.(map[string]any); ok {
-			osDisk, ok := storageProfile["osDisk"]
-			if ok {
+			if osDisk, ok := storageProfile["osDisk"]; ok {
 				if osDisk, ok := osDisk.(map[string]any); ok {
-					if osType, ok := osDisk["osType"]; ok {
-						labels["azure.mondoo.com/ostype"] = osType.(string)
+					if osType, ok := osDisk["osType"].(string); ok {
+						labels["azure.mondoo.com/ostype"] = osType
 					}
 				}
 			}
 		}
 	}
-	vmId, ok := propsDict["vmId"]
-	if ok {
-		if casted, ok := vmId.(string); ok {
-			labels["mondoo.com/instance"] = casted
-		}
+	if vmId, ok := propsDict["vmId"].(string); ok {
+		labels["mondoo.com/instance"] = vmId
 	}
 
 	res, err := ParseResourceID(vm.Id.Data)

--- a/providers/azure/resources/discovery.go
+++ b/providers/azure/resources/discovery.go
@@ -511,8 +511,10 @@ func getInstancesLabels(vm *mqlAzureSubscriptionComputeServiceVm) (map[string]st
 	}
 	if osProfile, ok := propsDict["osProfile"]; ok {
 		if osProfileDict, ok := osProfile.(map[string]any); ok {
-			if computerName, ok := osProfileDict["computerName"].(string); ok {
-				labels["azure.mondoo.com/computername"] = computerName
+			if computerName, ok := osProfileDict["computerName"]; ok {
+				if name, ok := computerName.(string); ok {
+					labels["azure.mondoo.com/computername"] = name
+				}
 			}
 		}
 	}
@@ -520,15 +522,19 @@ func getInstancesLabels(vm *mqlAzureSubscriptionComputeServiceVm) (map[string]st
 		if storageProfile, ok := storageProfile.(map[string]any); ok {
 			if osDisk, ok := storageProfile["osDisk"]; ok {
 				if osDisk, ok := osDisk.(map[string]any); ok {
-					if osType, ok := osDisk["osType"].(string); ok {
-						labels["azure.mondoo.com/ostype"] = osType
+					if osType, ok := osDisk["osType"]; ok {
+						if t, ok := osType.(string); ok {
+							labels["azure.mondoo.com/ostype"] = t
+						}
 					}
 				}
 			}
 		}
 	}
-	if vmId, ok := propsDict["vmId"].(string); ok {
-		labels["mondoo.com/instance"] = vmId
+	if vmId, ok := propsDict["vmId"]; ok {
+		if id, ok := vmId.(string); ok {
+			labels["mondoo.com/instance"] = id
+		}
 	}
 
 	res, err := ParseResourceID(vm.Id.Data)

--- a/providers/azure/resources/discovery_test.go
+++ b/providers/azure/resources/discovery_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
 func TestAllResolvedResources(t *testing.T) {
@@ -114,3 +115,146 @@ func TestGetDiscoveryTargets(t *testing.T) {
 		})
 	}
 }
+
+func TestGetInstancesLabels(t *testing.T) {
+	const vmResourceID = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Compute/virtualMachines/my-vm"
+
+	newVM := func(props any) *mqlAzureSubscriptionComputeServiceVm {
+		return &mqlAzureSubscriptionComputeServiceVm{
+			Id:         plugin.TValue[string]{Data: vmResourceID, State: plugin.StateIsSet},
+			Properties: plugin.TValue[any]{Data: props, State: plugin.StateIsSet},
+		}
+	}
+
+	cases := []struct {
+		name string
+		vm   *mqlAzureSubscriptionComputeServiceVm
+		want map[string]string
+	}{
+		{
+			name: "happy path with all fields",
+			vm: newVM(map[string]any{
+				"vmId": "abc-123",
+				"osProfile": map[string]any{
+					"computerName": "host1",
+				},
+				"storageProfile": map[string]any{
+					"osDisk": map[string]any{
+						"osType": "Linux",
+					},
+				},
+			}),
+			want: map[string]string{
+				"azure.mondoo.com/computername":  "host1",
+				"azure.mondoo.com/ostype":        "Linux",
+				"azure.mondoo.com/resourcegroup": "my-rg",
+				"mondoo.com/instance":            "abc-123",
+			},
+		},
+		{
+			name: "properties not a map",
+			vm:   newVM("not-a-map"),
+			want: map[string]string{
+				"azure.mondoo.com/resourcegroup": "my-rg",
+			},
+		},
+		{
+			name: "properties nil",
+			vm:   newVM(nil),
+			want: map[string]string{
+				"azure.mondoo.com/resourcegroup": "my-rg",
+			},
+		},
+		{
+			name: "osProfile present but not a map",
+			vm: newVM(map[string]any{
+				"osProfile": "oops",
+			}),
+			want: map[string]string{
+				"azure.mondoo.com/resourcegroup": "my-rg",
+			},
+		},
+		{
+			name: "computerName missing",
+			vm: newVM(map[string]any{
+				"osProfile": map[string]any{},
+			}),
+			want: map[string]string{
+				"azure.mondoo.com/resourcegroup": "my-rg",
+			},
+		},
+		{
+			name: "computerName not a string",
+			vm: newVM(map[string]any{
+				"osProfile": map[string]any{
+					"computerName": 42,
+				},
+			}),
+			want: map[string]string{
+				"azure.mondoo.com/resourcegroup": "my-rg",
+			},
+		},
+		{
+			name: "storageProfile not a map",
+			vm: newVM(map[string]any{
+				"storageProfile": "nope",
+			}),
+			want: map[string]string{
+				"azure.mondoo.com/resourcegroup": "my-rg",
+			},
+		},
+		{
+			name: "osDisk not a map",
+			vm: newVM(map[string]any{
+				"storageProfile": map[string]any{
+					"osDisk": 7,
+				},
+			}),
+			want: map[string]string{
+				"azure.mondoo.com/resourcegroup": "my-rg",
+			},
+		},
+		{
+			name: "osType not a string",
+			vm: newVM(map[string]any{
+				"storageProfile": map[string]any{
+					"osDisk": map[string]any{
+						"osType": []string{"Linux"},
+					},
+				},
+			}),
+			want: map[string]string{
+				"azure.mondoo.com/resourcegroup": "my-rg",
+			},
+		},
+		{
+			name: "vmId not a string",
+			vm: newVM(map[string]any{
+				"vmId": 12345,
+			}),
+			want: map[string]string{
+				"azure.mondoo.com/resourcegroup": "my-rg",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := getInstancesLabels(tc.vm)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestGetInstancesLabels_PropertiesError(t *testing.T) {
+	vm := &mqlAzureSubscriptionComputeServiceVm{
+		Properties: plugin.TValue[any]{Error: assertErr("boom"), State: plugin.StateIsSet},
+	}
+	_, err := getInstancesLabels(vm)
+	require.Error(t, err)
+}
+
+type assertErr string
+
+func (e assertErr) Error() string { return string(e) }


### PR DESCRIPTION
## Summary
- `getInstancesLabels` in `providers/azure/resources/discovery.go` had three unguarded type assertions: `props.Data.(map[string]any)`, `osProfileDict["computerName"].(string)`, and `osType.(string)`. A VM with an unexpected property shape (or nil properties) would panic during discovery instead of just skipping those labels.
- Switched each cast to comma-ok; behavior is unchanged on the happy path, missing/wrong-shape data now silently drops the corresponding label.
- Added `TestGetInstancesLabels` covering the happy path plus every defensive branch (nil props, non-map props, missing/wrong-type osProfile/storageProfile/osDisk/osType/vmId), and a `TestGetInstancesLabels_PropertiesError` for the error path.

## Test plan
- [x] `GOWORK=off go test ./resources/ -run "TestGetInstancesLabels" -v` (all subtests pass)
- [ ] `make test/lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)