### PR TITLE
llx/builtin_array: nil-check leftArray in cmpArrayOne

### DIFF
--- a/llx/builtin_array.go
+++ b/llx/builtin_array.go
@@ -1092,8 +1092,11 @@ func cmpArrays(left *RawData, right *RawData, f func(any, any) bool) bool {
 }
 
 func cmpArrayOne(leftArray *RawData, right *RawData, f func(any, any) bool) bool {
-	l := leftArray.Value.([]any)
-	if len(l) != 1 {
+	if leftArray == nil || leftArray.Value == nil {
+		return false
+	}
+	l, ok := leftArray.Value.([]any)
+	if !ok || len(l) != 1 {
 		return false
 	}
 	return f(l[0], right.Value)


### PR DESCRIPTION
Closes #7258. `http` connection without scheme defaults the resp body to nil; `leftArray.Value.([]any)` then panics the shell.