### PR TITLE
✨ iptables: add tables() accessor for NAT/mangle/raw table support

### DIFF
--- a/providers/os/resources/iptables.go
+++ b/providers/os/resources/iptables.go
@@ -16,6 +16,7 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/v13/types"
 )
 
 // Stat represents a structured statistic entry.
@@ -41,6 +42,22 @@ type ChainResult struct {
 
 func (ie *mqlIptablesEntry) id() (string, error) {
 	return strconv.FormatInt(ie.LineNumber.Data, 10) + ie.Chain.Data, nil
+}
+
+type mqlIptablesTableInternal struct {
+	ipVersion string
+}
+
+type mqlIptablesChainInternal struct {
+	ipVersion string
+}
+
+func (t *mqlIptablesTable) id() (string, error) {
+	return t.ipVersion + "/" + t.Name.Data, nil
+}
+
+func (c *mqlIptablesChain) id() (string, error) {
+	return c.ipVersion + "/" + c.Table.Data + "/" + c.Name.Data, nil
 }
 
 // statToRawData converts a Stat into the llx data map for creating an iptables.entry resource.
@@ -78,6 +95,9 @@ type mqlIptablesInternal struct {
 	inputCache   chainCache
 	outputCache  chainCache
 	forwardCache chainCache
+	tablesOnce   sync.Once
+	tablesCache  []any
+	tablesErr    error
 }
 
 // mqlIp6tablesInternal caches chain results to avoid running the same
@@ -86,6 +106,9 @@ type mqlIp6tablesInternal struct {
 	inputCache   chainCache
 	outputCache  chainCache
 	forwardCache chainCache
+	tablesOnce   sync.Once
+	tablesCache  []any
+	tablesErr    error
 }
 
 // fetchChain runs an iptables/ip6tables command for a chain, parses the output,
@@ -119,6 +142,145 @@ func fetchChain(runtime *plugin.Runtime, conn shared.Connection, binary, chainNa
 		entries = append(entries, entry.(*mqlIptablesEntry))
 	}
 	return entries, result.Policy, nil
+}
+
+// iptablesTableNames lists the standard tables to query.
+var iptablesTableNames = []string{"filter", "nat", "mangle", "raw"}
+
+// fetchAllTables runs `iptables -t <table> -L -v -n -x --line-numbers` for each
+// table and returns MQL table resources containing chains and entries.
+func fetchAllTables(runtime *plugin.Runtime, conn shared.Connection, binary string, ipv6 bool) ([]any, error) {
+	ver := "ipv4"
+	if ipv6 {
+		ver = "ipv6"
+	}
+
+	var tables []any
+	for _, tableName := range iptablesTableNames {
+		// tableName comes from the compile-time iptablesTableNames constant.
+		cmd, err := conn.RunCommand(fmt.Sprintf("%s -t %s -L -v -n -x --line-numbers", binary, tableName))
+		if err != nil {
+			return nil, err
+		}
+		data, err := io.ReadAll(cmd.Stdout)
+		if err != nil {
+			return nil, err
+		}
+		if cmd.ExitStatus != 0 {
+			stderr, _ := io.ReadAll(cmd.Stderr)
+			errMsg := strings.TrimSpace(string(stderr))
+			// Table may not exist on this kernel (e.g., raw or mangle not loaded)
+			if strings.Contains(errMsg, "does not exist") ||
+				strings.Contains(errMsg, "No such file or directory") ||
+				strings.Contains(errMsg, "can't initialize") {
+				continue
+			}
+			return nil, fmt.Errorf("%s -t %s failed: %s", binary, tableName, errMsg)
+		}
+
+		chains, err := parseAllChains(runtime, string(data), tableName, ver, ipv6)
+		if err != nil {
+			return nil, err
+		}
+		if len(chains) == 0 {
+			continue
+		}
+
+		tableRes, err := CreateResource(runtime, "iptables.table", map[string]*llx.RawData{
+			"name":   llx.StringData(tableName),
+			"chains": llx.ArrayData(chains, types.Resource("iptables.chain")),
+		})
+		if err != nil {
+			return nil, err
+		}
+		tableRes.(*mqlIptablesTable).ipVersion = ver
+		tables = append(tables, tableRes)
+	}
+	return tables, nil
+}
+
+// parseAllChains parses the full output of `iptables -t <table> -L` which
+// contains multiple chain blocks separated by blank lines.
+func parseAllChains(runtime *plugin.Runtime, output, tableName, ipVersion string, ipv6 bool) ([]any, error) {
+	blocks := splitChainBlocks(output)
+	var chains []any
+
+	for _, block := range blocks {
+		lines := getLines(block)
+		if len(lines) < 2 {
+			continue
+		}
+
+		chainName := parseChainName(lines[0])
+		if chainName == "" {
+			continue
+		}
+
+		result, err := ParseChain(lines, ipv6)
+		if err != nil {
+			return nil, err
+		}
+
+		chainID := ipVersion + "/" + tableName + "/" + chainName
+		entries := make([]any, 0, len(result.Entries))
+		for _, stat := range result.Entries {
+			entry, err := CreateResource(runtime, "iptables.entry", statToRawData(stat, chainID))
+			if err != nil {
+				return nil, err
+			}
+			entries = append(entries, entry)
+		}
+
+		chainRes, err := CreateResource(runtime, "iptables.chain", map[string]*llx.RawData{
+			"table":  llx.StringData(tableName),
+			"name":   llx.StringData(chainName),
+			"policy": llx.StringData(result.Policy),
+			"rules":  llx.ArrayData(entries, types.Resource("iptables.entry")),
+		})
+		if err != nil {
+			return nil, err
+		}
+		chainRes.(*mqlIptablesChain).ipVersion = ipVersion
+		chains = append(chains, chainRes)
+	}
+	return chains, nil
+}
+
+// splitChainBlocks splits the output of `iptables -L` (all chains) into
+// individual chain blocks. Each block starts with "Chain ..." and is
+// separated by empty lines.
+func splitChainBlocks(output string) []string {
+	var blocks []string
+	var current []string
+
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(line, "Chain ") && len(current) > 0 {
+			blocks = append(blocks, strings.Join(current, "\n"))
+			current = nil
+		}
+		if line == "" && len(current) > 0 {
+			continue
+		}
+		if line != "" || len(current) > 0 {
+			current = append(current, line)
+		}
+	}
+	if len(current) > 0 {
+		blocks = append(blocks, strings.Join(current, "\n"))
+	}
+	return blocks
+}
+
+// reChainName matches "Chain CHAINNAME (...)" and extracts the chain name.
+var reChainName = regexp.MustCompile(`^Chain\s+(\S+)`)
+
+// parseChainName extracts the chain name from a chain header line.
+func parseChainName(line string) string {
+	m := reChainName.FindStringSubmatch(line)
+	if m == nil {
+		return ""
+	}
+	return m[1]
 }
 
 // --- iptables (IPv4) ---
@@ -171,6 +333,14 @@ func (i *mqlIptables) forwardPolicy() (string, error) {
 	return i.forwardCache.policy, i.forwardCache.err
 }
 
+func (i *mqlIptables) tables() ([]any, error) {
+	i.tablesOnce.Do(func() {
+		conn := i.MqlRuntime.Connection.(shared.Connection)
+		i.tablesCache, i.tablesErr = fetchAllTables(i.MqlRuntime, conn, "iptables", false)
+	})
+	return i.tablesCache, i.tablesErr
+}
+
 // --- ip6tables (IPv6) ---
 
 func (i *mqlIp6tables) fetchInput() {
@@ -219,6 +389,14 @@ func (i *mqlIp6tables) outputPolicy() (string, error) {
 func (i *mqlIp6tables) forwardPolicy() (string, error) {
 	i.forwardCache.once.Do(i.fetchForward)
 	return i.forwardCache.policy, i.forwardCache.err
+}
+
+func (i *mqlIp6tables) tables() ([]any, error) {
+	i.tablesOnce.Do(func() {
+		conn := i.MqlRuntime.Connection.(shared.Connection)
+		i.tablesCache, i.tablesErr = fetchAllTables(i.MqlRuntime, conn, "ip6tables", true)
+	})
+	return i.tablesCache, i.tablesErr
 }
 
 // Credit to github.com/coreos/go-iptables for some of the parsing logic

--- a/providers/os/resources/iptables_test.go
+++ b/providers/os/resources/iptables_test.go
@@ -148,3 +148,98 @@ func TestParseChain(t *testing.T) {
 		assert.Equal(t, "::/0", result.Entries[0].Source)
 	})
 }
+
+func TestSplitChainBlocks(t *testing.T) {
+	t.Run("single chain", func(t *testing.T) {
+		output := "Chain INPUT (policy ACCEPT 0 packets, 0 bytes)\nnum      pkts      bytes target     prot opt in     out     source               destination\n"
+		blocks := splitChainBlocks(output)
+		require.Len(t, blocks, 1)
+		assert.Contains(t, blocks[0], "Chain INPUT")
+	})
+
+	t.Run("multiple chains with blank line separators", func(t *testing.T) {
+		output := `Chain PREROUTING (policy ACCEPT 5 packets, 260 bytes)
+num      pkts      bytes target     prot opt in     out     source               destination
+1           5      260 DNAT       tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:80 to:192.168.1.100:8080
+
+Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
+num      pkts      bytes target     prot opt in     out     source               destination
+
+Chain OUTPUT (policy ACCEPT 3 packets, 148 bytes)
+num      pkts      bytes target     prot opt in     out     source               destination
+
+Chain POSTROUTING (policy ACCEPT 3 packets, 148 bytes)
+num      pkts      bytes target     prot opt in     out     source               destination
+1          10      600 MASQUERADE  all  --  *      eth0    192.168.1.0/24       0.0.0.0/0
+`
+		blocks := splitChainBlocks(output)
+		require.Len(t, blocks, 4)
+		assert.Contains(t, blocks[0], "Chain PREROUTING")
+		assert.Contains(t, blocks[0], "DNAT")
+		assert.Contains(t, blocks[1], "Chain INPUT")
+		assert.Contains(t, blocks[2], "Chain OUTPUT")
+		assert.Contains(t, blocks[3], "Chain POSTROUTING")
+		assert.Contains(t, blocks[3], "MASQUERADE")
+	})
+
+	t.Run("empty output", func(t *testing.T) {
+		blocks := splitChainBlocks("")
+		assert.Empty(t, blocks)
+	})
+}
+
+func TestParseChainName(t *testing.T) {
+	assert.Equal(t, "INPUT", parseChainName("Chain INPUT (policy DROP 0 packets, 0 bytes)"))
+	assert.Equal(t, "FORWARD", parseChainName("Chain FORWARD (policy ACCEPT)"))
+	assert.Equal(t, "DOCKER", parseChainName("Chain DOCKER (1 references)"))
+	assert.Equal(t, "PREROUTING", parseChainName("Chain PREROUTING (policy ACCEPT 5 packets, 260 bytes)"))
+	assert.Equal(t, "POSTROUTING", parseChainName("Chain POSTROUTING (policy ACCEPT 0 packets, 0 bytes)"))
+	assert.Equal(t, "", parseChainName(""))
+	assert.Equal(t, "", parseChainName("not a chain header"))
+}
+
+func TestSplitChainBlocks_NATTable(t *testing.T) {
+	output := `Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
+num      pkts      bytes target     prot opt in     out     source               destination
+1           0        0 DNAT       tcp  --  eth0   *       0.0.0.0/0            0.0.0.0/0            tcp dpt:80 to:10.0.0.5:8080
+2           0        0 DNAT       tcp  --  eth0   *       0.0.0.0/0            0.0.0.0/0            tcp dpt:443 to:10.0.0.5:8443
+
+Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
+num      pkts      bytes target     prot opt in     out     source               destination
+
+Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
+num      pkts      bytes target     prot opt in     out     source               destination
+
+Chain POSTROUTING (policy ACCEPT 0 packets, 0 bytes)
+num      pkts      bytes target     prot opt in     out     source               destination
+1           0        0 MASQUERADE  all  --  *      eth0    10.0.0.0/24          0.0.0.0/0
+2           0        0 SNAT       all  --  *      eth1    192.168.1.0/24       0.0.0.0/0            to:203.0.113.5
+`
+
+	blocks := splitChainBlocks(output)
+	require.Len(t, blocks, 4)
+
+	// Verify PREROUTING has DNAT rules
+	preLines := getLines(blocks[0])
+	result, err := ParseChain(preLines, false)
+	require.NoError(t, err)
+	assert.Equal(t, "ACCEPT", result.Policy)
+	require.Len(t, result.Entries, 2)
+	assert.Equal(t, "DNAT", result.Entries[0].Target)
+	assert.Equal(t, "eth0", result.Entries[0].Input)
+	assert.Contains(t, result.Entries[0].Options, "tcp dpt:80 to:10.0.0.5:8080")
+	assert.Equal(t, "DNAT", result.Entries[1].Target)
+	assert.Contains(t, result.Entries[1].Options, "tcp dpt:443")
+
+	// Verify POSTROUTING has MASQUERADE and SNAT
+	postLines := getLines(blocks[3])
+	result, err = ParseChain(postLines, false)
+	require.NoError(t, err)
+	assert.Equal(t, "ACCEPT", result.Policy)
+	require.Len(t, result.Entries, 2)
+	assert.Equal(t, "MASQUERADE", result.Entries[0].Target)
+	assert.Equal(t, "10.0.0.0/24", result.Entries[0].Source)
+	assert.Equal(t, "SNAT", result.Entries[1].Target)
+	assert.Equal(t, "192.168.1.0/24", result.Entries[1].Source)
+	assert.Contains(t, result.Entries[1].Options, "to:203.0.113.5")
+}

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -1346,11 +1346,13 @@ containerd.container @defaults("id status") {
 
 // IPv4 tables
 iptables {
-  // IPv4 input chain entries
+  // All tables (filter, nat, mangle, raw)
+  tables() []iptables.table
+  // IPv4 input chain entries (filter table)
   input() []iptables.entry
-  // IPv4 output chain entries
+  // IPv4 output chain entries (filter table)
   output() []iptables.entry
-  // IPv4 forward chain entries
+  // IPv4 forward chain entries (filter table)
   forward() []iptables.entry
   // Default policy for the INPUT chain (e.g., ACCEPT, DROP)
   inputPolicy() string
@@ -1362,11 +1364,13 @@ iptables {
 
 // IPv6 tables
 ip6tables {
-  // IPv6 input chain entries
+  // All tables (filter, nat, mangle, raw)
+  tables() []iptables.table
+  // IPv6 input chain entries (filter table)
   input() []iptables.entry
-  // IPv6 output chain entries
+  // IPv6 output chain entries (filter table)
   output() []iptables.entry
-  // IPv6 forward chain entries
+  // IPv6 forward chain entries (filter table)
   forward() []iptables.entry
   // Default policy for the INPUT chain (e.g., ACCEPT, DROP)
   inputPolicy() string
@@ -1374,6 +1378,26 @@ ip6tables {
   forwardPolicy() string
   // Default policy for the OUTPUT chain (e.g., ACCEPT, DROP)
   outputPolicy() string
+}
+
+// iptables table (filter, nat, mangle, raw)
+private iptables.table @defaults("name") {
+  // Table name (filter, nat, mangle, raw)
+  name string
+  // Chains in this table
+  chains []iptables.chain
+}
+
+// iptables chain within a table
+private iptables.chain @defaults("table name policy") {
+  // Table this chain belongs to (filter, nat, mangle, raw)
+  table string
+  // Chain name (INPUT, OUTPUT, FORWARD, PREROUTING, POSTROUTING, or user-defined)
+  name string
+  // Default policy (ACCEPT, DROP, REJECT) - empty for user-defined chains
+  policy string
+  // Rules in this chain
+  rules []iptables.entry
 }
 
 // Individual iptables entry
@@ -1396,11 +1420,11 @@ iptables.entry {
   out string
   // Source address field that tells the receiver where the packet came from
   source string
-  //The destination IP address of the traffic, subnet of the traffic, or anywhere
+  // The destination IP address of the traffic, subnet of the traffic, or anywhere
   destination string
   // Optional settings within the header such as internet timestamps, SACK, or record route options
   options string
-  // Input or output, which is used to create the ID
+  // Chain and table identifier used for the resource ID
   chain string
 }
 

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -120,6 +120,8 @@ const (
 	ResourceContainerdContainer          string = "containerd.container"
 	ResourceIptables                     string = "iptables"
 	ResourceIp6tables                    string = "ip6tables"
+	ResourceIptablesTable                string = "iptables.table"
+	ResourceIptablesChain                string = "iptables.chain"
 	ResourceIptablesEntry                string = "iptables.entry"
 	ResourceNftables                     string = "nftables"
 	ResourceNftablesTable                string = "nftables.table"
@@ -769,6 +771,14 @@ func init() {
 		"ip6tables": {
 			// to override args, implement: initIp6tables(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createIp6tables,
+		},
+		"iptables.table": {
+			// to override args, implement: initIptablesTable(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createIptablesTable,
+		},
+		"iptables.chain": {
+			// to override args, implement: initIptablesChain(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createIptablesChain,
 		},
 		"iptables.entry": {
 			// to override args, implement: initIptablesEntry(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -3112,6 +3122,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"containerd.container.snapshotter": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlContainerdContainer).GetSnapshotter()).ToDataRes(types.String)
 	},
+	"iptables.tables": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlIptables).GetTables()).ToDataRes(types.Array(types.Resource("iptables.table")))
+	},
 	"iptables.input": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlIptables).GetInput()).ToDataRes(types.Array(types.Resource("iptables.entry")))
 	},
@@ -3130,6 +3143,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"iptables.outputPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlIptables).GetOutputPolicy()).ToDataRes(types.String)
 	},
+	"ip6tables.tables": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlIp6tables).GetTables()).ToDataRes(types.Array(types.Resource("iptables.table")))
+	},
 	"ip6tables.input": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlIp6tables).GetInput()).ToDataRes(types.Array(types.Resource("iptables.entry")))
 	},
@@ -3147,6 +3163,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"ip6tables.outputPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlIp6tables).GetOutputPolicy()).ToDataRes(types.String)
+	},
+	"iptables.table.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlIptablesTable).GetName()).ToDataRes(types.String)
+	},
+	"iptables.table.chains": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlIptablesTable).GetChains()).ToDataRes(types.Array(types.Resource("iptables.chain")))
+	},
+	"iptables.chain.table": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlIptablesChain).GetTable()).ToDataRes(types.String)
+	},
+	"iptables.chain.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlIptablesChain).GetName()).ToDataRes(types.String)
+	},
+	"iptables.chain.policy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlIptablesChain).GetPolicy()).ToDataRes(types.String)
+	},
+	"iptables.chain.rules": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlIptablesChain).GetRules()).ToDataRes(types.Array(types.Resource("iptables.entry")))
 	},
 	"iptables.entry.lineNumber": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlIptablesEntry).GetLineNumber()).ToDataRes(types.Int)
@@ -9218,6 +9252,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlIptables).__id, ok = v.Value.(string)
 		return
 	},
+	"iptables.tables": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlIptables).Tables, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"iptables.input": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlIptables).Input, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -9246,6 +9284,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlIp6tables).__id, ok = v.Value.(string)
 		return
 	},
+	"ip6tables.tables": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlIp6tables).Tables, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"ip6tables.input": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlIp6tables).Input, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -9268,6 +9310,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"ip6tables.outputPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlIp6tables).OutputPolicy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"iptables.table.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlIptablesTable).__id, ok = v.Value.(string)
+		return
+	},
+	"iptables.table.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlIptablesTable).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"iptables.table.chains": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlIptablesTable).Chains, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"iptables.chain.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlIptablesChain).__id, ok = v.Value.(string)
+		return
+	},
+	"iptables.chain.table": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlIptablesChain).Table, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"iptables.chain.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlIptablesChain).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"iptables.chain.policy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlIptablesChain).Policy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"iptables.chain.rules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlIptablesChain).Rules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"iptables.entry.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -23344,6 +23418,7 @@ type mqlIptables struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlIptablesInternal
+	Tables        plugin.TValue[[]any]
 	Input         plugin.TValue[[]any]
 	Output        plugin.TValue[[]any]
 	Forward       plugin.TValue[[]any]
@@ -23382,6 +23457,22 @@ func (c *mqlIptables) MqlName() string {
 
 func (c *mqlIptables) MqlID() string {
 	return c.__id
+}
+
+func (c *mqlIptables) GetTables() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Tables, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("iptables", c.__id, "tables")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.tables()
+	})
 }
 
 func (c *mqlIptables) GetInput() *plugin.TValue[[]any] {
@@ -23455,6 +23546,7 @@ type mqlIp6tables struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlIp6tablesInternal
+	Tables        plugin.TValue[[]any]
 	Input         plugin.TValue[[]any]
 	Output        plugin.TValue[[]any]
 	Forward       plugin.TValue[[]any]
@@ -23493,6 +23585,22 @@ func (c *mqlIp6tables) MqlName() string {
 
 func (c *mqlIp6tables) MqlID() string {
 	return c.__id
+}
+
+func (c *mqlIp6tables) GetTables() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Tables, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("ip6tables", c.__id, "tables")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.tables()
+	})
 }
 
 func (c *mqlIp6tables) GetInput() *plugin.TValue[[]any] {
@@ -23559,6 +23667,124 @@ func (c *mqlIp6tables) GetOutputPolicy() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.OutputPolicy, func() (string, error) {
 		return c.outputPolicy()
 	})
+}
+
+// mqlIptablesTable for the iptables.table resource
+type mqlIptablesTable struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlIptablesTableInternal
+	Name   plugin.TValue[string]
+	Chains plugin.TValue[[]any]
+}
+
+// createIptablesTable creates a new instance of this resource
+func createIptablesTable(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlIptablesTable{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("iptables.table", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlIptablesTable) MqlName() string {
+	return "iptables.table"
+}
+
+func (c *mqlIptablesTable) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlIptablesTable) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlIptablesTable) GetChains() *plugin.TValue[[]any] {
+	return &c.Chains
+}
+
+// mqlIptablesChain for the iptables.chain resource
+type mqlIptablesChain struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlIptablesChainInternal
+	Table  plugin.TValue[string]
+	Name   plugin.TValue[string]
+	Policy plugin.TValue[string]
+	Rules  plugin.TValue[[]any]
+}
+
+// createIptablesChain creates a new instance of this resource
+func createIptablesChain(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlIptablesChain{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("iptables.chain", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlIptablesChain) MqlName() string {
+	return "iptables.chain"
+}
+
+func (c *mqlIptablesChain) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlIptablesChain) GetTable() *plugin.TValue[string] {
+	return &c.Table
+}
+
+func (c *mqlIptablesChain) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlIptablesChain) GetPolicy() *plugin.TValue[string] {
+	return &c.Policy
+}
+
+func (c *mqlIptablesChain) GetRules() *plugin.TValue[[]any] {
+	return &c.Rules
 }
 
 // mqlIptablesEntry for the iptables.entry resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -712,6 +712,7 @@ ip6tables.input 9.0.0
 ip6tables.inputPolicy 13.2.9
 ip6tables.output 9.0.0
 ip6tables.outputPolicy 13.2.9
+ip6tables.tables 13.15.2
 ipAddress 11.3.42
 ipAddress.broadcast 11.3.42
 ipAddress.cidr 11.3.42
@@ -719,6 +720,11 @@ ipAddress.gateway 11.3.42
 ipAddress.ip 11.3.42
 ipAddress.subnet 11.3.42
 iptables 9.0.0
+iptables.chain 13.15.2
+iptables.chain.name 13.15.2
+iptables.chain.policy 13.15.2
+iptables.chain.rules 13.15.2
+iptables.chain.table 13.15.2
 iptables.entry 9.0.0
 iptables.entry.bytes 9.0.0
 iptables.entry.chain 9.0.0
@@ -738,6 +744,10 @@ iptables.input 9.0.0
 iptables.inputPolicy 13.2.9
 iptables.output 9.0.0
 iptables.outputPolicy 13.2.9
+iptables.table 13.15.2
+iptables.table.chains 13.15.2
+iptables.table.name 13.15.2
+iptables.tables 13.15.2
 java.package 13.10.1
 java.package.cpes 13.10.1
 java.package.files 13.10.1


### PR DESCRIPTION
## Summary

- Add `iptables.table` and `iptables.chain` private resources that model the full iptables table/chain hierarchy (filter, nat, mangle, raw)
- Add `tables()` computed method to both `iptables` and `ip6tables` resources, enabling queries like `iptables.tables { name chains { name policy rules } }`
- Enables querying NAT rules (DNAT, SNAT, MASQUERADE), mangle rules, and raw table entries that were previously inaccessible
- Existing `input()`, `output()`, `forward()`, and `*Policy()` accessors remain unchanged for full backwards compatibility

### New resources

| Resource | Fields |
|---|---|
| `iptables.table` | `name`, `chains` |
| `iptables.chain` | `table`, `name`, `policy`, `rules` |

### Example queries

```mql
# List all tables and their chains
iptables.tables { name chains { name policy } }

# Find NAT DNAT rules
iptables.tables.where(name == "nat") { chains.where(name == "PREROUTING") { rules { target options } } }

# Check MASQUERADE rules in POSTROUTING
iptables.tables.where(name == "nat") { chains.where(name == "POSTROUTING") { rules.where(target == "MASQUERADE") { source destination } } }
```

## Test plan

- [x] All existing iptables tests pass (TestParseStat, TestParseChainPolicy, TestParseChain)
- [x] New unit tests pass: TestSplitChainBlocks (single/multiple/empty), TestParseChainName, TestSplitChainBlocks_NATTable (full NAT table with DNAT, SNAT, MASQUERADE rules)
- [x] `go vet ./resources/` passes clean
- [x] Code generation produces correct types (mqlIptablesTable, mqlIptablesChain)
- [ ] Interactive test: `mql shell local -c "iptables.tables { name chains { name policy rules } }"` on a Linux host with iptables

https://claude.ai/code/session_01Xkt6Si7it3hGyqbQKQHEBi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xkt6Si7it3hGyqbQKQHEBi)_