### PR TITLE
✨ os: add BSD network interface support (FreeBSD, OpenBSD, NetBSD, DragonFly)

### DIFF
--- a/providers/os/id/networki/bsd_n.go
+++ b/providers/os/id/networki/bsd_n.go
@@ -1,0 +1,257 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package networki
+
+import (
+	"bufio"
+	"regexp"
+	"strings"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
+
+	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
+)
+
+// detectBSDInterfaces detects network interfaces on FreeBSD, NetBSD,
+// OpenBSD, and DragonFly. (Darwin/macOS uses detectDarwinInterfaces.)
+func (n *neti) detectBSDInterfaces() ([]Interface, error) {
+	detectors := []func() ([]Interface, error){
+		n.getBSDIfconfigInterfaces,
+		n.getBSDGatewayDetails,
+	}
+
+	var errs []error
+	interfaces := []Interface{}
+	for _, detectFn := range detectors {
+		detected, err := detectFn()
+		if err != nil {
+			log.Debug().Err(err).Msg("os.network.interface> unable to detect network interfaces")
+			errs = append(errs, err)
+			continue
+		}
+		interfaces = AddOrUpdateInterfaces(interfaces, detected)
+	}
+
+	if len(interfaces) == 0 {
+		return interfaces, errors.Join(errs...)
+	}
+	return interfaces, nil
+}
+
+// bsdIfconfigHeader matches the first line of an ifconfig stanza. NetBSD
+// prefixes the flags value with "0x"; the others use a bare hex/decimal
+// number. Both forms are accepted.
+var bsdIfconfigHeader = regexp.MustCompile(`^([a-zA-Z0-9._]+):\s+flags=(?:0x)?[0-9a-fA-F]+<([^>]*)>`)
+
+func (n *neti) getBSDIfconfigInterfaces() (interfaces []Interface, err error) {
+	output, err := n.RunCommand("ifconfig -a")
+	if err != nil {
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	var current *Interface
+	for scanner.Scan() {
+		raw := scanner.Text()
+		if raw == "" {
+			continue
+		}
+
+		if m := bsdIfconfigHeader.FindStringSubmatch(raw); len(m) > 0 {
+			if current != nil {
+				interfaces = append(interfaces, *current)
+			}
+			current = &Interface{
+				Name:    m[1],
+				Virtual: bsdVirtualByName(m[1]),
+			}
+			if m[2] != "" {
+				current.Flags = strings.Split(m[2], ",")
+			}
+			tokens := strings.Fields(raw)
+			for i, t := range tokens {
+				if t == "mtu" && i+1 < len(tokens) {
+					current.MTU = parseInt(tokens[i+1])
+				}
+			}
+			continue
+		}
+
+		if current == nil {
+			continue
+		}
+
+		line := strings.TrimSpace(raw)
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		switch fields[0] {
+		// MAC: "ether AA:..." (FreeBSD/DragonFly), "lladdr AA:..." (OpenBSD),
+		// "address: AA:..." (NetBSD)
+		case "ether", "lladdr", "address:":
+			current.SetMAC(fields[1])
+
+		case "inet":
+			// Two formats:
+			//   FreeBSD/OpenBSD/DragonFly: inet 1.2.3.4 netmask 0xffffff00 broadcast 1.2.3.255
+			//   NetBSD:                    inet 1.2.3.4/24 broadcast 1.2.3.255 flags 0x0
+			ipField := fields[1]
+			if slash := strings.Index(ipField, "/"); slash != -1 {
+				current.AddOrUpdateIP(NewIPv4WithPrefixLength(
+					ipField[:slash],
+					parseInt(ipField[slash+1:]),
+				))
+			} else if len(fields) >= 4 && fields[2] == "netmask" {
+				current.AddOrUpdateIP(NewIPv4WithMask(ipField, fields[3]))
+			} else if ip, ok := NewIPAddress(ipField); ok {
+				current.AddOrUpdateIP(ip)
+			}
+
+		case "inet6":
+			// FreeBSD/OpenBSD/DragonFly: inet6 fe80::1%em0 prefixlen 64 scopeid 0x1
+			// NetBSD:                    inet6 fe80::1%wm0/64 flags 0x0 scopeid 0x1
+			ipField := fields[1]
+			prefix := -1
+			if slash := strings.Index(ipField, "/"); slash != -1 {
+				prefix = parseInt(ipField[slash+1:])
+				ipField = ipField[:slash]
+			}
+			if pct := strings.Index(ipField, "%"); pct != -1 {
+				if pct < len(ipField) {
+					ipField = ipField[:pct]
+				}
+			}
+			if prefix < 0 {
+				for i, t := range fields {
+					if t == "prefixlen" && i+1 < len(fields) {
+						prefix = parseInt(fields[i+1])
+						break
+					}
+				}
+			}
+			if prefix >= 0 {
+				current.AddOrUpdateIP(NewIPv6WithPrefixLength(ipField, prefix))
+			} else if ip, ok := NewIPAddress(ipField); ok {
+				current.AddOrUpdateIP(ip)
+			}
+
+		case "status:":
+			switch fields[1] {
+			case "active":
+				current.Active = convert.ToPtr(true)
+			case "inactive", "no":
+				current.Active = convert.ToPtr(false)
+			}
+		}
+	}
+
+	if current != nil {
+		interfaces = append(interfaces, *current)
+	}
+
+	log.Debug().
+		Interface("interfaces", interfaces).
+		Str("detector", "cmd.ifconfig").
+		Msg("os.network.interfaces> discovered")
+	return interfaces, nil
+}
+
+// getBSDGatewayDetails extracts default-gateway info from `netstat -rn`.
+// netstat prints both the Internet (IPv4) and Internet6 sections in one
+// pass, so a single command covers both address families on all four
+// non-Darwin BSDs.
+func (n *neti) getBSDGatewayDetails() (interfaces []Interface, err error) {
+	output, err := n.RunCommand("netstat -rn")
+	if err != nil {
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		fields := strings.Fields(strings.TrimSpace(scanner.Text()))
+		if len(fields) < 4 || !isDefaultRoute(fields[0]) {
+			continue
+		}
+
+		gateway := fields[1]
+		// Strip "%ifname" zone suffix from link-local IPv6 gateways
+		if pct := strings.Index(gateway, "%"); pct != -1 {
+			gateway = gateway[:pct]
+		}
+
+		version := IPv4
+		if strings.Contains(gateway, ":") {
+			version = IPv6
+		}
+
+		// The Netif column position varies (Expire may or may not be
+		// populated), so pick the rightmost token that looks like an
+		// interface name.
+		netif := ""
+		for i := len(fields) - 1; i >= 2; i-- {
+			if isLikelyBSDIfname(fields[i]) {
+				netif = fields[i]
+				break
+			}
+		}
+		if netif == "" {
+			continue
+		}
+
+		gw := gateway
+		ver := version
+		interfaces = append(interfaces, Interface{
+			Name: netif,
+			enrichments: func(in *Interface) {
+				for i := range in.IPAddresses {
+					v, ok := in.IPAddresses[i].Version()
+					if !ok || v != ver {
+						continue
+					}
+					in.IPAddresses[i].Gateway = gw
+				}
+			},
+		})
+	}
+	return
+}
+
+// bsdIfnamePattern matches typical BSD interface names like em0, wm0,
+// vlan100, gif0, lo0, em0.5 (vlan sub-interface).
+var bsdIfnamePattern = regexp.MustCompile(`^[a-zA-Z]+\d+(\.\d+)?$`)
+
+func isLikelyBSDIfname(s string) bool {
+	return bsdIfnamePattern.MatchString(s)
+}
+
+// bsdVirtualByName flags interfaces as virtual based on common BSD
+// naming conventions. Only well-known virtual prefixes are reported as
+// true; everything else stays nil ("unknown") rather than asserting
+// physical, since BSD has no /sys/class/net to inspect.
+func bsdVirtualByName(name string) *bool {
+	prefixes := []string{
+		"tap", "tun",
+		"bridge", "vether", "veb",
+		"epair",
+		"vlan",
+		"gif",
+		"vxlan",
+		"wg",
+		"enc",
+		"pflog", "pfsync",
+		"vmnet",
+		"ipsec",
+		"ovpnc", "ovpns",
+		"carp",
+	}
+	for _, p := range prefixes {
+		if strings.HasPrefix(name, p) {
+			return convert.ToPtr(true)
+		}
+	}
+	return nil
+}

--- a/providers/os/id/networki/interfaces.go
+++ b/providers/os/id/networki/interfaces.go
@@ -37,6 +37,9 @@ func Interfaces(conn shared.Connection, pf *inventory.Platform) ([]Interface, er
 	if pf.IsFamily(inventory.FAMILY_DARWIN) {
 		return n.detectDarwinInterfaces()
 	}
+	if pf.IsFamily(inventory.FAMILY_BSD) {
+		return n.detectBSDInterfaces()
+	}
 	if pf.IsFamily(inventory.FAMILY_WINDOWS) && conn.Capabilities().Has(shared.Capability_File) {
 		return n.detectWindowsInterfaces()
 	}

--- a/providers/os/id/networki/interfaces_test.go
+++ b/providers/os/id/networki/interfaces_test.go
@@ -61,6 +61,177 @@ func TestInterfacesDarwin(t *testing.T) {
 	}
 }
 
+func TestInterfacesFreeBSD(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/freebsd.toml"))
+	require.NoError(t, err)
+	platform, ok := detector.DetectOS(conn)
+	require.True(t, ok)
+	assert.Equal(t, "freebsd", platform.Name)
+
+	interfaces, err := subject.Interfaces(conn, platform)
+	require.NoError(t, err)
+	assert.Len(t, interfaces, 2)
+
+	index := subject.FindInterface(interfaces, subject.Interface{Name: "em0"})
+	if assert.NotEqual(t, -1, index) {
+		em0 := interfaces[index]
+		assert.Equal(t, "em0", em0.Name)
+		assert.Equal(t, "08:00:27:6c:1a:0e", em0.MACAddress)
+		assert.Equal(t, "PCS Systemtechnik", em0.Vendor)
+		assert.Equal(t, 1500, em0.MTU)
+		if assert.NotNil(t, em0.Active) {
+			assert.True(t, *em0.Active)
+		}
+		assert.Nil(t, em0.Virtual)
+		assert.ElementsMatch(t,
+			[]string{"UP", "BROADCAST", "RUNNING", "SIMPLEX", "MULTICAST"},
+			em0.Flags,
+		)
+
+		i4 := em0.FindIP(net.ParseIP("192.168.1.50"))
+		if assert.NotEqual(t, -1, i4) {
+			ipv4 := em0.IPAddresses[i4]
+			assert.Equal(t, "192.168.1.50/24", ipv4.CIDR)
+			assert.Equal(t, "192.168.1.0/24", ipv4.Subnet)
+			assert.Equal(t, "192.168.1.255", ipv4.Broadcast)
+			assert.Equal(t, "192.168.1.1", ipv4.Gateway)
+		}
+		i6 := em0.FindIP(net.ParseIP("fe80::a00:27ff:fe6c:1a0e"))
+		if assert.NotEqual(t, -1, i6) {
+			ipv6 := em0.IPAddresses[i6]
+			assert.Equal(t, "fe80::a00:27ff:fe6c:1a0e/64", ipv6.CIDR)
+			assert.Equal(t, "fe80::/64", ipv6.Subnet)
+			assert.Equal(t, "fe80::1", ipv6.Gateway)
+		}
+	}
+}
+
+func TestInterfacesOpenBSD(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/openbsd.toml"))
+	require.NoError(t, err)
+	platform, ok := detector.DetectOS(conn)
+	require.True(t, ok)
+	assert.Equal(t, "openbsd", platform.Name)
+
+	interfaces, err := subject.Interfaces(conn, platform)
+	require.NoError(t, err)
+	assert.Len(t, interfaces, 2)
+
+	// OpenBSD uses "lladdr" instead of "ether" for MAC.
+	index := subject.FindInterface(interfaces, subject.Interface{Name: "em0"})
+	if assert.NotEqual(t, -1, index) {
+		em0 := interfaces[index]
+		assert.Equal(t, "em0", em0.Name)
+		assert.Equal(t, "08:00:27:6c:1a:0e", em0.MACAddress)
+		assert.Equal(t, 1500, em0.MTU)
+		if assert.NotNil(t, em0.Active) {
+			assert.True(t, *em0.Active)
+		}
+		assert.Nil(t, em0.Virtual)
+		assert.ElementsMatch(t,
+			[]string{"UP", "BROADCAST", "RUNNING", "SIMPLEX", "MULTICAST"},
+			em0.Flags,
+		)
+
+		i4 := em0.FindIP(net.ParseIP("192.168.1.51"))
+		if assert.NotEqual(t, -1, i4) {
+			ipv4 := em0.IPAddresses[i4]
+			assert.Equal(t, "192.168.1.51/24", ipv4.CIDR)
+			assert.Equal(t, "192.168.1.0/24", ipv4.Subnet)
+			assert.Equal(t, "192.168.1.255", ipv4.Broadcast)
+			assert.Equal(t, "192.168.1.1", ipv4.Gateway)
+		}
+		i6 := em0.FindIP(net.ParseIP("fe80::a00:27ff:fe6c:1a0e"))
+		if assert.NotEqual(t, -1, i6) {
+			ipv6 := em0.IPAddresses[i6]
+			assert.Equal(t, "fe80::a00:27ff:fe6c:1a0e/64", ipv6.CIDR)
+			assert.Equal(t, "fe80::1", ipv6.Gateway)
+		}
+	}
+}
+
+func TestInterfacesNetBSD(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/netbsd.toml"))
+	require.NoError(t, err)
+	platform, ok := detector.DetectOS(conn)
+	require.True(t, ok)
+	assert.Equal(t, "netbsd", platform.Name)
+
+	interfaces, err := subject.Interfaces(conn, platform)
+	require.NoError(t, err)
+	assert.Len(t, interfaces, 2)
+
+	// NetBSD has "0x" hex flag prefix, "address:" MAC keyword, and CIDR
+	// suffixes on inet/inet6 instead of separate netmask/prefixlen tokens.
+	index := subject.FindInterface(interfaces, subject.Interface{Name: "wm0"})
+	if assert.NotEqual(t, -1, index) {
+		wm0 := interfaces[index]
+		assert.Equal(t, "wm0", wm0.Name)
+		assert.Equal(t, "08:00:27:6c:1a:0e", wm0.MACAddress)
+		assert.Equal(t, 1500, wm0.MTU)
+		if assert.NotNil(t, wm0.Active) {
+			assert.True(t, *wm0.Active)
+		}
+		assert.Nil(t, wm0.Virtual)
+		assert.ElementsMatch(t,
+			[]string{"UP", "BROADCAST", "RUNNING", "SIMPLEX", "MULTICAST"},
+			wm0.Flags,
+		)
+
+		i4 := wm0.FindIP(net.ParseIP("192.168.1.52"))
+		if assert.NotEqual(t, -1, i4) {
+			ipv4 := wm0.IPAddresses[i4]
+			assert.Equal(t, "192.168.1.52/24", ipv4.CIDR)
+			assert.Equal(t, "192.168.1.0/24", ipv4.Subnet)
+			assert.Equal(t, "192.168.1.255", ipv4.Broadcast)
+			assert.Equal(t, "192.168.1.1", ipv4.Gateway)
+		}
+		i6 := wm0.FindIP(net.ParseIP("fe80::a00:27ff:fe6c:1a0e"))
+		if assert.NotEqual(t, -1, i6) {
+			ipv6 := wm0.IPAddresses[i6]
+			assert.Equal(t, "fe80::a00:27ff:fe6c:1a0e/64", ipv6.CIDR)
+			assert.Equal(t, "fe80::1", ipv6.Gateway)
+		}
+	}
+}
+
+func TestInterfacesDragonFlyBSD(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/dragonflybsd.toml"))
+	require.NoError(t, err)
+	platform, ok := detector.DetectOS(conn)
+	require.True(t, ok)
+	assert.Equal(t, "dragonflybsd", platform.Name)
+
+	interfaces, err := subject.Interfaces(conn, platform)
+	require.NoError(t, err)
+	assert.Len(t, interfaces, 2)
+
+	index := subject.FindInterface(interfaces, subject.Interface{Name: "em0"})
+	if assert.NotEqual(t, -1, index) {
+		em0 := interfaces[index]
+		assert.Equal(t, "em0", em0.Name)
+		assert.Equal(t, "08:00:27:6c:1a:0e", em0.MACAddress)
+		assert.Equal(t, 1500, em0.MTU)
+		if assert.NotNil(t, em0.Active) {
+			assert.True(t, *em0.Active)
+		}
+		assert.Nil(t, em0.Virtual)
+
+		i4 := em0.FindIP(net.ParseIP("192.168.1.53"))
+		if assert.NotEqual(t, -1, i4) {
+			ipv4 := em0.IPAddresses[i4]
+			assert.Equal(t, "192.168.1.53/24", ipv4.CIDR)
+			assert.Equal(t, "192.168.1.0/24", ipv4.Subnet)
+			assert.Equal(t, "192.168.1.1", ipv4.Gateway)
+		}
+		i6 := em0.FindIP(net.ParseIP("fe80::a00:27ff:fe6c:1a0e"))
+		if assert.NotEqual(t, -1, i6) {
+			ipv6 := em0.IPAddresses[i6]
+			assert.Equal(t, "fe80::1", ipv6.Gateway)
+		}
+	}
+}
+
 func TestInterfacesLinux(t *testing.T) {
 	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/linux_ip_addr_show_cmd.toml"))
 	require.NoError(t, err)

--- a/providers/os/id/networki/testdata/dragonflybsd.toml
+++ b/providers/os/id/networki/testdata/dragonflybsd.toml
@@ -1,0 +1,40 @@
+[commands."uname -s"]
+stdout = "DragonFly"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "5.8-RELEASE"
+
+[commands."ifconfig -a"]
+stdout = """
+em0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+	options=8<VLAN_MTU>
+	ether 08:00:27:6c:1a:0e
+	inet 192.168.1.53 netmask 0xffffff00 broadcast 192.168.1.255
+	inet6 fe80::a00:27ff:fe6c:1a0e%em0 prefixlen 64 scopeid 0x1
+	media: Ethernet autoselect (1000baseT <full-duplex>)
+	status: active
+lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
+	options=3<RXCSUM,TXCSUM>
+	inet6 ::1 prefixlen 128
+	inet6 fe80::1%lo0 prefixlen 64 scopeid 0x4
+	inet 127.0.0.1 netmask 0xff000000
+"""
+
+[commands."netstat -rn"]
+stdout = """
+Routing tables
+
+Internet:
+Destination        Gateway            Flags    Refs      Use  Mtu  Interface
+default            192.168.1.1        UGS         0        0 1500  em0
+127.0.0.1          127.0.0.1          UH          0        0 16384 lo0
+192.168.1.0/24     link#1             U           0        0 1500  em0
+
+Internet6:
+Destination                       Gateway                       Flags  Refs      Use  Mtu  Interface
+default                           fe80::1%em0                   UGS       0        0 1500  em0
+::1                               ::1                           UH        0        0 16384 lo0
+"""

--- a/providers/os/id/networki/testdata/freebsd.toml
+++ b/providers/os/id/networki/testdata/freebsd.toml
@@ -1,0 +1,44 @@
+[commands."uname -s"]
+stdout = "FreeBSD"
+
+[commands."uname -m"]
+stdout = "amd64"
+
+[commands."uname -r"]
+stdout = "14.3-RELEASE"
+
+[commands."ifconfig -a"]
+stdout = """
+em0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
+	options=4e527bb<RXCSUM,TXCSUM,VLAN_MTU,VLAN_HWTAGGING,JUMBO_MTU,VLAN_HWCSUM,TSO4,TSO6,LRO,WOL_MAGIC,VLAN_HWFILTER,VLAN_HWTSO,RXCSUM_IPV6,TXCSUM_IPV6,HWSTATS,MEXTPG>
+	ether 08:00:27:6c:1a:0e
+	inet 192.168.1.50 netmask 0xffffff00 broadcast 192.168.1.255
+	inet6 fe80::a00:27ff:fe6c:1a0e%em0 prefixlen 64 scopeid 0x1
+	media: Ethernet autoselect (1000baseT <full-duplex>)
+	status: active
+	nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>
+lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> metric 0 mtu 16384
+	options=680003<RXCSUM,TXCSUM,LINKSTATE,RXCSUM_IPV6,TXCSUM_IPV6>
+	inet6 ::1 prefixlen 128
+	inet6 fe80::1%lo0 prefixlen 64 scopeid 0x2
+	inet 127.0.0.1 netmask 0xff000000
+	groups: lo
+	nd6 options=21<PERFORMNUD,AUTO_LINKLOCAL>
+"""
+
+[commands."netstat -rn"]
+stdout = """
+Routing tables
+
+Internet:
+Destination        Gateway            Flags     Netif Expire
+default            192.168.1.1        UGS         em0
+127.0.0.1          link#2             UH          lo0
+192.168.1.0/24     link#1             U           em0
+
+Internet6:
+Destination                       Gateway                       Flags     Netif Expire
+::/96                             ::1                           UGRS        lo0
+default                           fe80::1%em0                   UGS         em0
+::1                               link#2                        UH          lo0
+"""

--- a/providers/os/id/networki/testdata/netbsd.toml
+++ b/providers/os/id/networki/testdata/netbsd.toml
@@ -1,0 +1,41 @@
+[commands."uname -s"]
+stdout = "NetBSD"
+
+[commands."uname -m"]
+stdout = "amd64"
+
+[commands."uname -r"]
+stdout = "8.0"
+
+[commands."ifconfig -a"]
+stdout = """
+wm0: flags=0x8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+	ec_capabilities=7<VLAN_MTU,VLAN_HWTAGGING,JUMBO_MTU>
+	ec_enabled=0
+	address: 08:00:27:6c:1a:0e
+	media: Ethernet autoselect (1000baseT full-duplex,master)
+	status: active
+	inet 192.168.1.52/24 broadcast 192.168.1.255 flags 0x0
+	inet6 fe80::a00:27ff:fe6c:1a0e%wm0/64 flags 0x0 scopeid 0x1
+lo0: flags=0x8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 33624
+	inet 127.0.0.1/8 flags 0x0
+	inet6 ::1/128 flags 0x20<NODAD>
+	inet6 fe80::1%lo0/64 flags 0x0 scopeid 0x2
+"""
+
+[commands."netstat -rn"]
+stdout = """
+Routing tables
+
+Internet:
+Destination        Gateway            Flags     Refs     Use    Mtu Interface
+default            192.168.1.1        UGS         -        -      -    wm0
+127/8              127.0.0.1          UGRS        -        -  33624    lo0
+127.0.0.1          127.0.0.1          UH          -        -  33624    lo0
+192.168.1.0/24     link#1             U           -        -      -    wm0
+
+Internet6:
+Destination                        Gateway                        Flags   Refs   Use   Mtu Interface
+default                            fe80::1%wm0                    UGS        -     -     -    wm0
+::1                                ::1                            UH         -     - 33624    lo0
+"""

--- a/providers/os/id/networki/testdata/openbsd.toml
+++ b/providers/os/id/networki/testdata/openbsd.toml
@@ -1,0 +1,43 @@
+[commands."uname -s"]
+stdout = "OpenBSD"
+
+[commands."uname -m"]
+stdout = "amd64"
+
+[commands."uname -r"]
+stdout = "7.8"
+
+[commands."ifconfig -a"]
+stdout = """
+em0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+	lladdr 08:00:27:6c:1a:0e
+	index 1 priority 0 llprio 3
+	groups: egress
+	media: Ethernet autoselect (1000baseT full-duplex)
+	status: active
+	inet 192.168.1.51 netmask 0xffffff00 broadcast 192.168.1.255
+	inet6 fe80::a00:27ff:fe6c:1a0e%em0 prefixlen 64 scopeid 0x1
+lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 32768
+	index 3 priority 0 llprio 3
+	groups: lo
+	inet6 ::1 prefixlen 128
+	inet6 fe80::1%lo0 prefixlen 64 scopeid 0x3
+	inet 127.0.0.1 netmask 0xff000000
+"""
+
+[commands."netstat -rn"]
+stdout = """
+Routing tables
+
+Internet:
+Destination        Gateway            Flags   Refs      Use   Mtu  Prio Iface
+default            192.168.1.1        UGS        1        0     -     8 em0
+127/8              127.0.0.1          UGRS       0        0 32768     8 lo0
+127.0.0.1          127.0.0.1          UH         1        0 32768     1 lo0
+192.168.1/24       192.168.1.51       UCn        1        0     -     4 em0
+
+Internet6:
+Destination                        Gateway                        Flags   Refs      Use   Mtu  Prio Iface
+default                            fe80::1%em0                    UGS        1        0     -     8 em0
+::1                                ::1                            UH         5        0 32768     1 lo0
+"""

--- a/providers/os/resources/networkinterface/interface.go
+++ b/providers/os/resources/networkinterface/interface.go
@@ -65,6 +65,12 @@ func (r *InterfaceResource) Interfaces() ([]Interface, error) {
 			conn: r.conn,
 		}
 		return handler.Interfaces()
+	} else if asset.Platform.IsFamily(inventory.FAMILY_BSD) && !asset.Platform.IsFamily(inventory.FAMILY_DARWIN) {
+		log.Debug().Msg("detected bsd platform")
+		handler := &BSDInterfaceHandler{
+			conn: r.conn,
+		}
+		return handler.Interfaces()
 	} else if asset.Platform.Name == "windows" {
 		log.Debug().Msg("detected windows platform")
 		handler := &WindowsInterfaceHandler{
@@ -299,6 +305,112 @@ func (i *MacOSInterfaceHandler) ParseMacOS(r io.Reader) ([]Interface, error) {
 		}
 
 	}
+	return interfaces, nil
+}
+
+type BSDInterfaceHandler struct {
+	conn shared.Connection
+}
+
+func (i *BSDInterfaceHandler) Interfaces() ([]Interface, error) {
+	cmd, err := i.conn.RunCommand("ifconfig -a")
+	if err != nil {
+		return nil, errors.Wrap(err, "could not fetch bsd network adapter")
+	}
+	return i.ParseBSD(cmd.Stdout)
+}
+
+// BSDIfconfigHeader matches the first line of an ifconfig stanza on
+// FreeBSD, OpenBSD, NetBSD, and DragonFly. Note that NetBSD prefixes
+// the flags value with "0x", which differs from the other three.
+var BSDIfconfigHeader = regexp.MustCompile(`^([a-zA-Z0-9._]+):\s+flags=(?:0x)?[0-9a-fA-F]+<([^>]*)>`)
+
+func (i *BSDInterfaceHandler) ParseBSD(r io.Reader) ([]Interface, error) {
+	interfaces := []Interface{}
+	ifIndex := -1
+	scanner := bufio.NewScanner(r)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		// New interface stanza
+		if m := BSDIfconfigHeader.FindStringSubmatch(line); len(m) > 0 {
+			var flags net.Flags
+			if m[2] != "" {
+				for _, f := range strings.Split(m[2], ",") {
+					switch strings.ToLower(f) {
+					case "up":
+						flags |= net.FlagUp
+					case "broadcast":
+						flags |= net.FlagBroadcast
+					case "multicast":
+						flags |= net.FlagMulticast
+					case "loopback":
+						flags |= net.FlagLoopback
+					case "pointopoint", "pointtopoint":
+						flags |= net.FlagPointToPoint
+					}
+				}
+			}
+
+			mtu := 0
+			tokens := strings.Fields(line)
+			for j, t := range tokens {
+				if t == "mtu" && j+1 < len(tokens) {
+					if v, err := strconv.Atoi(tokens[j+1]); err == nil {
+						mtu = v
+					}
+				}
+			}
+
+			ifIndex++
+			interfaces = append(interfaces, Interface{
+				Index: ifIndex + 1,
+				Name:  m[1],
+				MTU:   mtu,
+				Flags: flags,
+			})
+			continue
+		}
+
+		if ifIndex < 0 {
+			continue
+		}
+		cur := &interfaces[ifIndex]
+
+		trimmed := strings.TrimSpace(line)
+		fields := strings.Fields(trimmed)
+		if len(fields) < 2 {
+			continue
+		}
+
+		switch {
+		// MAC: "ether AA:..." (FreeBSD/DragonFly), "lladdr AA:..." (OpenBSD),
+		// "address: AA:..." (NetBSD)
+		case fields[0] == "ether", fields[0] == "lladdr", fields[0] == "address:":
+			if mac, err := net.ParseMAC(fields[1]); err == nil {
+				cur.HardwareAddr = mac
+			}
+
+		case fields[0] == "inet", fields[0] == "inet6":
+			addr := fields[1]
+			// strip CIDR suffix (NetBSD: "inet 1.2.3.4/24")
+			if k := strings.Index(addr, "/"); k != -1 {
+				addr = addr[:k]
+			}
+			// strip IPv6 link-local zone suffix (e.g. "fe80::1%em0")
+			if k := strings.Index(addr, "%"); k != -1 {
+				addr = addr[:k]
+			}
+			if ip := net.ParseIP(addr); ip != nil {
+				cur.Addrs = append(cur.Addrs, &ipAddr{IP: ip})
+			}
+		}
+	}
+
 	return interfaces, nil
 }
 

--- a/providers/os/resources/networkinterface/interface.go
+++ b/providers/os/resources/networkinterface/interface.go
@@ -387,15 +387,15 @@ func (i *BSDInterfaceHandler) ParseBSD(r io.Reader) ([]Interface, error) {
 			continue
 		}
 
-		switch {
+		switch fields[0] {
 		// MAC: "ether AA:..." (FreeBSD/DragonFly), "lladdr AA:..." (OpenBSD),
 		// "address: AA:..." (NetBSD)
-		case fields[0] == "ether", fields[0] == "lladdr", fields[0] == "address:":
+		case "ether", "lladdr", "address:":
 			if mac, err := net.ParseMAC(fields[1]); err == nil {
 				cur.HardwareAddr = mac
 			}
 
-		case fields[0] == "inet", fields[0] == "inet6":
+		case "inet", "inet6":
 			addr := fields[1]
 			// strip CIDR suffix (NetBSD: "inet 1.2.3.4/24")
 			if k := strings.Index(addr, "/"); k != -1 {

--- a/providers/os/resources/networkinterface/interface_test.go
+++ b/providers/os/resources/networkinterface/interface_test.go
@@ -84,6 +84,38 @@ func TestMacOSRemoteInterface(t *testing.T) {
 	assert.Equal(t, "192.168.178.45", ip)
 }
 
+func TestBSDRemoteInterface(t *testing.T) {
+	mock, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:   "freebsd",
+			Family: []string{"bsd", "unix", "os"},
+		},
+	}, mock.WithPath("./testdata/freebsd.toml"))
+	require.NoError(t, err)
+
+	ifaces := networkinterface.New(mock)
+	list, err := ifaces.Interfaces()
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(list))
+
+	em0, err := ifaces.InterfaceByName("em0")
+	require.NoError(t, err)
+	assert.Equal(t, "em0", em0.Name)
+	assert.Equal(t, 1500, em0.MTU)
+	assert.Equal(t, "up|broadcast|multicast", em0.Flags.String())
+	assert.Equal(t, "08:00:27:6c:1a:0e", em0.HardwareAddr.String())
+	// inet 192.168.1.50 (netmask form) and inet6 fe80::...%em0 (with scope)
+	assert.Equal(t, 2, len(em0.Addrs))
+
+	lo0, err := ifaces.InterfaceByName("lo0")
+	require.NoError(t, err)
+	assert.Equal(t, "lo0", lo0.Name)
+	assert.Equal(t, 16384, lo0.MTU)
+	assert.Equal(t, "up|loopback|multicast", lo0.Flags.String())
+	assert.Equal(t, "", lo0.HardwareAddr.String())
+	assert.Equal(t, 3, len(lo0.Addrs))
+}
+
 func TestLinuxRemoteInterface(t *testing.T) {
 	mock, err := mock.New(0, &inventory.Asset{
 		Platform: &inventory.Platform{

--- a/providers/os/resources/networkinterface/testdata/freebsd.toml
+++ b/providers/os/resources/networkinterface/testdata/freebsd.toml
@@ -1,0 +1,24 @@
+[commands."uname -s"]
+stdout = "FreeBSD"
+
+[commands."uname -m"]
+stdout = "amd64"
+
+[commands."uname -r"]
+stdout = "14.3-RELEASE"
+
+[commands."ifconfig -a"]
+stdout = """
+em0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
+	options=4e527bb<RXCSUM,TXCSUM,VLAN_MTU>
+	ether 08:00:27:6c:1a:0e
+	inet 192.168.1.50 netmask 0xffffff00 broadcast 192.168.1.255
+	inet6 fe80::a00:27ff:fe6c:1a0e%em0 prefixlen 64 scopeid 0x1
+	media: Ethernet autoselect (1000baseT <full-duplex>)
+	status: active
+lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> metric 0 mtu 16384
+	inet6 ::1 prefixlen 128
+	inet6 fe80::1%lo0 prefixlen 64 scopeid 0x2
+	inet 127.0.0.1 netmask 0xff000000
+	groups: lo
+"""


### PR DESCRIPTION
Adds parity for the four non-Darwin BSDs in both layers of network
interface detection:

- providers/os/resources/networkinterface: new BSDInterfaceHandler that
  parses `ifconfig -a` and populates the net.Interface-shaped struct.
  Handles ether/lladdr/address: MAC keywords, both `netmask 0xMM` and
  `/N` IPv4 forms, and both `prefixlen N` and `/N` IPv6 forms with
  optional %scope suffix. Header regex tolerates NetBSD's `0x` flags
  prefix.

- providers/os/id/networki: new bsd_n.go with the rich detector. Runs
  ifconfig for fields, MTU, MAC/vendor, status (active/inactive),
  IPAddresses with subnet/CIDR/broadcast, and netstat -rn for default
  gateway enrichment (covers v4 and v6 in one pass). Virtual flag is
  derived from well-known BSD virtual prefixes (tap/tun/bridge/vlan/
  gif/vxlan/wg/enc/pflog/pfsync/epair/vether/carp/...).

Both dispatchers branch on FAMILY_BSD after the darwin check so macOS
still routes to its existing handler.

https://claude.ai/code/session_01UmjiHxZdqXFsQXiQm4H2v9