### PR TITLE
✨ Add JavaScript lockfile parsers (pnpm, bun) + fix yarnlock evidence

### DIFF
--- a/providers/os/resources/languages/javascript/bunlock/extractor.go
+++ b/providers/os/resources/languages/javascript/bunlock/extractor.go
@@ -1,0 +1,134 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package bunlock
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages/javascript"
+)
+
+// stripJSONC removes trailing commas before } and ] to convert JSONC to
+// valid JSON. Bun.lock files use JSONC format (trailing commas allowed).
+func stripJSONC(data []byte) []byte {
+	out := make([]byte, 0, len(data))
+	inString := false
+	escape := false
+
+	for i := 0; i < len(data); i++ {
+		c := data[i]
+
+		if escape {
+			out = append(out, c)
+			escape = false
+			continue
+		}
+
+		if inString {
+			out = append(out, c)
+			if c == '\\' {
+				escape = true
+			} else if c == '"' {
+				inString = false
+			}
+			continue
+		}
+
+		switch c {
+		case '"':
+			out = append(out, c)
+			inString = true
+		case ',':
+			// Look ahead to see if the next non-whitespace is } or ].
+			// If so, this is a trailing comma — skip it.
+			trailing := false
+			for j := i + 1; j < len(data); j++ {
+				if data[j] == ' ' || data[j] == '\t' || data[j] == '\n' || data[j] == '\r' {
+					continue
+				}
+				if data[j] == '}' || data[j] == ']' {
+					trailing = true
+				}
+				break
+			}
+			if !trailing {
+				out = append(out, c)
+			}
+		default:
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+var (
+	_ languages.Extractor = (*Extractor)(nil)
+	_ languages.Bom       = (*bunLock)(nil)
+)
+
+// Extractor parses bun.lock files to extract npm package dependencies.
+type Extractor struct{}
+
+func (e *Extractor) Name() string {
+	return "bunlock"
+}
+
+func (e *Extractor) Parse(r io.Reader, filename string) (languages.Bom, error) {
+	// bun.lock uses JSONC format (allows trailing commas).
+	// Strip trailing commas before JSON decoding.
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	cleaned := stripJSONC(raw)
+
+	var lock bunLock
+	if err := json.Unmarshal(cleaned, &lock); err != nil {
+		return nil, err
+	}
+
+	if filename != "" {
+		lock.evidence = append(lock.evidence, filename)
+	}
+
+	return &lock, nil
+}
+
+// Root returns nil — bun.lock does not contain a root project entry in
+// the packages section.
+func (l *bunLock) Root() *languages.Package {
+	return nil
+}
+
+// Direct returns nil — bun.lock does not distinguish direct from transitive
+// within the packages map without cross-referencing workspaces.
+func (l *bunLock) Direct() languages.Packages {
+	return nil
+}
+
+// Transitive returns all packages listed in the lockfile.
+func (l *bunLock) Transitive() languages.Packages {
+	var packages languages.Packages
+
+	for key, raw := range l.Packages {
+		info, ok := parseBunPackageTuple(raw)
+		if !ok {
+			log.Warn().Str("key", key).Msg("cannot parse bun.lock package tuple")
+			continue
+		}
+
+		packages = append(packages, &languages.Package{
+			Name:         info.Name,
+			Version:      info.Version,
+			Purl:         javascript.NewPackageUrl(info.Name, info.Version),
+			Cpes:         javascript.NewCpes(info.Name, info.Version),
+			EvidenceList: javascript.NewEvidenceList(l.evidence),
+		})
+	}
+
+	return packages
+}

--- a/providers/os/resources/languages/javascript/bunlock/extractor.go
+++ b/providers/os/resources/languages/javascript/bunlock/extractor.go
@@ -30,9 +30,10 @@ func stripJSONC(data []byte) []byte {
 
 		if inString {
 			out = append(out, c)
-			if c == '\\' {
+			switch c {
+			case '\\':
 				escape = true
-			} else if c == '"' {
+			case '"':
 				inString = false
 			}
 			continue

--- a/providers/os/resources/languages/javascript/bunlock/extractor_test.go
+++ b/providers/os/resources/languages/javascript/bunlock/extractor_test.go
@@ -1,0 +1,97 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package bunlock
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSimple(t *testing.T) {
+	f, err := os.Open("testdata/simple.json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	e := &Extractor{}
+	bom, err := e.Parse(f, "testdata/simple.json")
+	require.NoError(t, err)
+
+	assert.Nil(t, bom.Root())
+	assert.Nil(t, bom.Direct())
+
+	pkgs := bom.Transitive()
+	assert.Len(t, pkgs, 3)
+
+	express := pkgs.Find("express")
+	require.NotNil(t, express)
+	assert.Equal(t, "4.18.2", express.Version)
+	assert.Equal(t, "pkg:npm/express@4.18.2", express.Purl)
+}
+
+func TestParseScoped(t *testing.T) {
+	f, err := os.Open("testdata/scoped.json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	e := &Extractor{}
+	bom, err := e.Parse(f, "testdata/scoped.json")
+	require.NoError(t, err)
+
+	pkgs := bom.Transitive()
+	assert.Len(t, pkgs, 3)
+
+	typesNode := pkgs.Find("@types/node")
+	require.NotNil(t, typesNode)
+	assert.Equal(t, "20.10.0", typesNode.Version)
+	assert.Equal(t, "pkg:npm/%40types/node@20.10.0", typesNode.Purl)
+}
+
+func TestParseBunNameVersion(t *testing.T) {
+	tests := []struct {
+		input   string
+		name    string
+		version string
+	}{
+		{"express@4.18.2", "express", "4.18.2"},
+		{"@types/node@20.10.0", "@types/node", "20.10.0"},
+		{"@babel/core@7.23.5", "@babel/core", "7.23.5"},
+		{"file:./local-pkg", "", ""},
+		{"noversion", "", ""},
+	}
+
+	for _, tt := range tests {
+		name, version := parseBunNameVersion(tt.input)
+		assert.Equal(t, tt.name, name, "input: %s", tt.input)
+		assert.Equal(t, tt.version, version, "input: %s", tt.input)
+	}
+}
+
+func TestStripJSONC(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"trailing comma in object", `{"a": 1,}`, `{"a": 1}`},
+		{"trailing comma in array", `[1, 2,]`, `[1, 2]`},
+		{"no trailing comma", `{"a": 1}`, `{"a": 1}`},
+		{"comma in string preserved", `{"a": "b,}"}`, `{"a": "b,}"}`},
+		{"nested trailing commas", `{"a": [1,], "b": 2,}`, `{"a": [1], "b": 2}`},
+		{"empty input", ``, ``},
+		{"escaped quote in string", `{"a": "b\"c,}"}`, `{"a": "b\"c,}"}`},
+	}
+
+	for _, tt := range tests {
+		got := string(stripJSONC([]byte(tt.input)))
+		assert.Equal(t, tt.want, got, tt.name)
+	}
+}
+
+func TestName(t *testing.T) {
+	e := &Extractor{}
+	assert.Equal(t, "bunlock", e.Name())
+}

--- a/providers/os/resources/languages/javascript/bunlock/parser.go
+++ b/providers/os/resources/languages/javascript/bunlock/parser.go
@@ -1,0 +1,66 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package bunlock
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// bunLock represents a parsed bun.lock file.
+type bunLock struct {
+	LockfileVersion int                        `json:"lockfileVersion"`
+	Packages        map[string]json.RawMessage `json:"packages"`
+
+	// evidence is a list of file paths where the bun.lock was found.
+	evidence []string `json:"-"`
+}
+
+// bunPackageInfo holds extracted name and version from a bun.lock package tuple.
+type bunPackageInfo struct {
+	Name    string
+	Version string
+}
+
+// parseBunPackageTuple extracts package info from a bun.lock tuple.
+// The first element of the tuple is a string in the format:
+//
+//	name@version or @scope/name@version
+func parseBunPackageTuple(raw json.RawMessage) (bunPackageInfo, bool) {
+	var tuple []json.RawMessage
+	if err := json.Unmarshal(raw, &tuple); err != nil || len(tuple) == 0 {
+		return bunPackageInfo{}, false
+	}
+
+	var nameVersion string
+	if err := json.Unmarshal(tuple[0], &nameVersion); err != nil {
+		return bunPackageInfo{}, false
+	}
+
+	name, version := parseBunNameVersion(nameVersion)
+	if name == "" || version == "" {
+		return bunPackageInfo{}, false
+	}
+
+	return bunPackageInfo{Name: name, Version: version}, true
+}
+
+// parseBunNameVersion splits a "name@version" string into name and version.
+// For scoped packages like "@scope/name@version", it finds the last @ that
+// separates the name from the version.
+func parseBunNameVersion(s string) (name, version string) {
+	// Skip file: dependencies.
+	if strings.HasPrefix(s, "file:") {
+		return "", ""
+	}
+
+	// For scoped packages (@scope/name@version), the first @ is part of the
+	// scope. Find the last @ which separates name from version.
+	idx := strings.LastIndex(s, "@")
+	if idx <= 0 {
+		return "", ""
+	}
+
+	return s[:idx], s[idx+1:]
+}

--- a/providers/os/resources/languages/javascript/bunlock/testdata/scoped.json
+++ b/providers/os/resources/languages/javascript/bunlock/testdata/scoped.json
@@ -1,0 +1,13 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "my-app"
+    }
+  },
+  "packages": {
+    "@types/node": ["@types/node@20.10.0", "", {}, "sha512-abc"],
+    "@babel/core": ["@babel/core@7.23.5", "", {}, "sha512-def"],
+    "express": ["express@4.18.2", "", {}, "sha512-ghi"]
+  }
+}

--- a/providers/os/resources/languages/javascript/bunlock/testdata/simple.json
+++ b/providers/os/resources/languages/javascript/bunlock/testdata/simple.json
@@ -1,0 +1,17 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "my-app",
+      "dependencies": {
+        "express": "^4.18.2",
+        "lodash": "^4.17.21",
+      },
+    },
+  },
+  "packages": {
+    "express": ["express@4.18.2", "", {}, "sha512-abc123"],
+    "lodash": ["lodash@4.17.21", "", {}, "sha512-def456"],
+    "accepts": ["accepts@1.3.8", "", {}, "sha512-ghi789"],
+  },
+}

--- a/providers/os/resources/languages/javascript/pnpmlock/extractor.go
+++ b/providers/os/resources/languages/javascript/pnpmlock/extractor.go
@@ -1,0 +1,85 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package pnpmlock
+
+import (
+	"io"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages/javascript"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	_ languages.Extractor = (*Extractor)(nil)
+	_ languages.Bom       = (*pnpmLock)(nil)
+)
+
+// Extractor parses pnpm-lock.yaml files to extract npm package dependencies.
+type Extractor struct{}
+
+func (e *Extractor) Name() string {
+	return "pnpmlock"
+}
+
+func (e *Extractor) Parse(r io.Reader, filename string) (languages.Bom, error) {
+	var lock pnpmLock
+	if err := yaml.NewDecoder(r).Decode(&lock); err != nil {
+		return nil, err
+	}
+
+	if filename != "" {
+		lock.evidence = append(lock.evidence, filename)
+	}
+
+	return &lock, nil
+}
+
+// Root returns nil — pnpm-lock.yaml does not contain a root project entry.
+func (l *pnpmLock) Root() *languages.Package {
+	return nil
+}
+
+// Direct returns nil — pnpm-lock.yaml does not distinguish direct from transitive
+// without cross-referencing package.json.
+func (l *pnpmLock) Direct() languages.Packages {
+	return nil
+}
+
+// Transitive returns all packages listed in the lockfile.
+func (l *pnpmLock) Transitive() languages.Packages {
+	var packages languages.Packages
+	ver := l.lockfileVersionFloat()
+
+	for key, entry := range l.Packages {
+		name, version, ok := parsePnpmPackageKey(key, ver)
+
+		// Explicit Name/Version fields take precedence (used in v9, and
+		// in v5 for tarball/git packages with unparseable keys).
+		if entry.Name != "" {
+			name = entry.Name
+			ok = true
+		}
+		if entry.Version != "" {
+			version = entry.Version
+			ok = true
+		}
+
+		if !ok || name == "" || version == "" {
+			log.Warn().Str("key", key).Msg("cannot parse pnpm package key")
+			continue
+		}
+
+		packages = append(packages, &languages.Package{
+			Name:         name,
+			Version:      version,
+			Purl:         javascript.NewPackageUrl(name, version),
+			Cpes:         javascript.NewCpes(name, version),
+			EvidenceList: javascript.NewEvidenceList(l.evidence),
+		})
+	}
+
+	return packages
+}

--- a/providers/os/resources/languages/javascript/pnpmlock/extractor_test.go
+++ b/providers/os/resources/languages/javascript/pnpmlock/extractor_test.go
@@ -1,0 +1,171 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package pnpmlock
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseV5(t *testing.T) {
+	f, err := os.Open("testdata/v5.yaml")
+	require.NoError(t, err)
+	defer f.Close()
+
+	e := &Extractor{}
+	bom, err := e.Parse(f, "testdata/v5.yaml")
+	require.NoError(t, err)
+
+	assert.Nil(t, bom.Root())
+	assert.Nil(t, bom.Direct())
+
+	pkgs := bom.Transitive()
+	assert.Len(t, pkgs, 4)
+
+	express := pkgs.Find("express")
+	require.NotNil(t, express)
+	assert.Equal(t, "4.18.2", express.Version)
+	assert.Equal(t, "pkg:npm/express@4.18.2", express.Purl)
+
+	typesNode := pkgs.Find("@types/node")
+	require.NotNil(t, typesNode)
+	assert.Equal(t, "20.10.0", typesNode.Version)
+	assert.Equal(t, "pkg:npm/%40types/node@20.10.0", typesNode.Purl)
+}
+
+func TestParseV9(t *testing.T) {
+	f, err := os.Open("testdata/v9.yaml")
+	require.NoError(t, err)
+	defer f.Close()
+
+	e := &Extractor{}
+	bom, err := e.Parse(f, "testdata/v9.yaml")
+	require.NoError(t, err)
+
+	pkgs := bom.Transitive()
+	assert.Len(t, pkgs, 4)
+
+	express := pkgs.Find("express")
+	require.NotNil(t, express)
+	assert.Equal(t, "4.18.2", express.Version)
+
+	typesNode := pkgs.Find("@types/node")
+	require.NotNil(t, typesNode)
+	assert.Equal(t, "20.10.0", typesNode.Version)
+}
+
+func TestParseV6(t *testing.T) {
+	f, err := os.Open("testdata/v6.yaml")
+	require.NoError(t, err)
+	defer f.Close()
+
+	e := &Extractor{}
+	bom, err := e.Parse(f, "testdata/v6.yaml")
+	require.NoError(t, err)
+
+	pkgs := bom.Transitive()
+	assert.Len(t, pkgs, 3)
+
+	scopedPkg := pkgs.Find("@scope/utils")
+	require.NotNil(t, scopedPkg)
+	assert.Equal(t, "2.0.0", scopedPkg.Version)
+}
+
+func TestParsePnpmV5Key(t *testing.T) {
+	tests := []struct {
+		key     string
+		name    string
+		version string
+		ok      bool
+	}{
+		{"/express/4.18.2", "express", "4.18.2", true},
+		{"/@types/node/20.10.0", "@types/node", "20.10.0", true},
+		{"/pkg/1.0.0_peer@2.0.0", "pkg", "1.0.0", true},
+		{"/pkg/1.0.0(react@18.0.0)", "pkg", "1.0.0", true},
+		{"", "", "", false},
+		{"/", "", "", false},
+	}
+
+	for _, tt := range tests {
+		name, ver, ok := parsePnpmV5Key(tt.key)
+		assert.Equal(t, tt.ok, ok, "key: %s", tt.key)
+		if ok {
+			assert.Equal(t, tt.name, name, "key: %s", tt.key)
+			assert.Equal(t, tt.version, ver, "key: %s", tt.key)
+		}
+	}
+}
+
+func TestParseAtSeparatedKey(t *testing.T) {
+	tests := []struct {
+		key     string
+		name    string
+		version string
+		ok      bool
+	}{
+		{"express@4.18.2", "express", "4.18.2", true},
+		{"@types/node@20.10.0", "@types/node", "20.10.0", true},
+		{"react-dom@18.2.0(react@18.2.0)", "react-dom", "18.2.0", true},
+		{"noversion", "", "", false},
+	}
+
+	for _, tt := range tests {
+		name, ver, ok := parseAtSeparatedKey(tt.key)
+		assert.Equal(t, tt.ok, ok, "key: %s", tt.key)
+		if ok {
+			assert.Equal(t, tt.name, name, "key: %s", tt.key)
+			assert.Equal(t, tt.version, ver, "key: %s", tt.key)
+		}
+	}
+}
+
+func TestParsePnpmV6Key(t *testing.T) {
+	tests := []struct {
+		key     string
+		name    string
+		version string
+		ok      bool
+	}{
+		{"/express@4.18.2", "express", "4.18.2", true},
+		{"/@scope/utils@2.0.0", "@scope/utils", "2.0.0", true},
+		{"/react-dom@18.2.0(react@18.2.0)", "react-dom", "18.2.0", true},
+		{"", "", "", false},
+		{"/", "", "", false},
+	}
+
+	for _, tt := range tests {
+		name, ver, ok := parsePnpmV6Key(tt.key)
+		assert.Equal(t, tt.ok, ok, "key: %s", tt.key)
+		if ok {
+			assert.Equal(t, tt.name, name, "key: %s", tt.key)
+			assert.Equal(t, tt.version, ver, "key: %s", tt.key)
+		}
+	}
+}
+
+func TestParseV5Tarball(t *testing.T) {
+	f, err := os.Open("testdata/v5-tarball.yaml")
+	require.NoError(t, err)
+	defer f.Close()
+
+	e := &Extractor{}
+	bom, err := e.Parse(f, "testdata/v5-tarball.yaml")
+	require.NoError(t, err)
+
+	pkgs := bom.Transitive()
+	assert.Len(t, pkgs, 2)
+
+	// Tarball/git package with explicit name/version fields and unparseable key.
+	scopedPkg := pkgs.Find("@my-scope/my-package")
+	require.NotNil(t, scopedPkg)
+	assert.Equal(t, "1.0.0", scopedPkg.Version)
+}
+
+func TestName(t *testing.T) {
+	e := &Extractor{}
+	assert.Equal(t, "pnpmlock", e.Name())
+}

--- a/providers/os/resources/languages/javascript/pnpmlock/parser.go
+++ b/providers/os/resources/languages/javascript/pnpmlock/parser.go
@@ -1,0 +1,144 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package pnpmlock
+
+import (
+	"fmt"
+	"strings"
+)
+
+// pnpmLock represents a parsed pnpm-lock.yaml file.
+type pnpmLock struct {
+	LockfileVersion any                         `yaml:"lockfileVersion"`
+	Packages        map[string]pnpmPackageEntry `yaml:"packages"`
+
+	// evidence is a list of file paths where the pnpm-lock.yaml was found.
+	evidence []string `yaml:"-"`
+}
+
+// pnpmPackageEntry represents a single entry in the packages map.
+type pnpmPackageEntry struct {
+	Resolution   pnpmResolution    `yaml:"resolution"`
+	Dependencies map[string]string `yaml:"dependencies"`
+	Dev          bool              `yaml:"dev"`
+	Name         string            `yaml:"name"`
+	Version      string            `yaml:"version"`
+}
+
+// pnpmResolution describes package resolution details.
+type pnpmResolution struct {
+	Integrity string `yaml:"integrity"`
+	Tarball   string `yaml:"tarball"`
+}
+
+// lockfileVersionFloat returns the lockfile version as a float64.
+func (l *pnpmLock) lockfileVersionFloat() float64 {
+	switch v := l.LockfileVersion.(type) {
+	case float64:
+		return v
+	case int:
+		return float64(v)
+	case string:
+		var f float64
+		if _, err := fmt.Sscanf(v, "%f", &f); err == nil {
+			return f
+		}
+	}
+	return 0
+}
+
+// parsePnpmPackageKey extracts the package name and version from a pnpm
+// packages map key. The format depends on the lockfile version:
+//
+//	v5:  /name/version or /@scope/name/version
+//	v6:  /name@version or /@scope/name@version
+//	v9:  name@version or @scope/name@version
+func parsePnpmPackageKey(key string, version float64) (name, ver string, ok bool) {
+	switch {
+	case version >= 9:
+		return parseAtSeparatedKey(key)
+	case version >= 6:
+		return parsePnpmV6Key(key)
+	default:
+		return parsePnpmV5Key(key)
+	}
+}
+
+// parseAtSeparatedKey parses keys in the format: name@version or @scope/name@version.
+// Used for both v6 (after stripping leading /) and v9 directly.
+func parseAtSeparatedKey(key string) (name, ver string, ok bool) {
+	// Strip parenthesized peer-dep suffixes before splitting, since they
+	// can contain @ characters (e.g. "react-dom@18.2.0(react@18.2.0)").
+	if idx := strings.IndexByte(key, '('); idx > 0 {
+		key = key[:idx]
+	}
+
+	// For scoped packages like @scope/name@1.0.0, we need to find the
+	// last @ that separates name from version (not the leading @).
+	atIdx := strings.LastIndex(key, "@")
+	if atIdx <= 0 {
+		return "", "", false
+	}
+
+	name = key[:atIdx]
+	ver = cleanVersionSuffix(key[atIdx+1:])
+	if name == "" || ver == "" {
+		return "", "", false
+	}
+	return name, ver, true
+}
+
+// parsePnpmV6Key parses v6 keys: /name@version or /@scope/name@version.
+func parsePnpmV6Key(key string) (name, ver string, ok bool) {
+	key = strings.TrimPrefix(key, "/")
+	if key == "" {
+		return "", "", false
+	}
+	return parseAtSeparatedKey(key)
+}
+
+// parsePnpmV5Key parses v5 keys: /name/version or /@scope/name/version.
+func parsePnpmV5Key(key string) (name, ver string, ok bool) {
+	key = strings.TrimPrefix(key, "/")
+	if key == "" {
+		return "", "", false
+	}
+
+	if strings.HasPrefix(key, "@") {
+		// @scope/name/version
+		parts := strings.SplitN(key, "/", 3)
+		if len(parts) < 3 {
+			return "", "", false
+		}
+		name = parts[0] + "/" + parts[1]
+		ver = parts[2]
+	} else {
+		// name/version
+		parts := strings.SplitN(key, "/", 2)
+		if len(parts) < 2 {
+			return "", "", false
+		}
+		name = parts[0]
+		ver = parts[1]
+	}
+
+	ver = cleanVersionSuffix(ver)
+	if name == "" || ver == "" {
+		return "", "", false
+	}
+	return name, ver, true
+}
+
+// cleanVersionSuffix strips peer dependency and parenthesized suffixes from version strings.
+func cleanVersionSuffix(ver string) string {
+	// Strip parenthesized suffixes first (e.g. "1.0.0(react@18.0.0)").
+	if idx := strings.IndexByte(ver, '('); idx > 0 {
+		ver = ver[:idx]
+	}
+	// Strip peer dependency suffix (e.g. "1.0.0_peer@2.0.0").
+	if idx := strings.IndexByte(ver, '_'); idx > 0 {
+		ver = ver[:idx]
+	}
+	return ver
+}

--- a/providers/os/resources/languages/javascript/pnpmlock/testdata/v5-tarball.yaml
+++ b/providers/os/resources/languages/javascript/pnpmlock/testdata/v5-tarball.yaml
@@ -7,5 +7,5 @@ packages:
 
   github.com/my-org/my-package/267087deadbeef:
     name: '@my-scope/my-package'
-    version: 1.0.0
+    version: '1.0.0'
     resolution: {tarball: https://codeload.github.com/my-org/my-package/tar.gz/267087deadbeef}

--- a/providers/os/resources/languages/javascript/pnpmlock/testdata/v5-tarball.yaml
+++ b/providers/os/resources/languages/javascript/pnpmlock/testdata/v5-tarball.yaml
@@ -1,0 +1,11 @@
+lockfileVersion: '5.4'
+
+packages:
+
+  /express/4.18.2:
+    resolution: {integrity: sha512-abc123}
+
+  github.com/my-org/my-package/267087deadbeef:
+    name: '@my-scope/my-package'
+    version: 1.0.0
+    resolution: {tarball: https://codeload.github.com/my-org/my-package/tar.gz/267087deadbeef}

--- a/providers/os/resources/languages/javascript/pnpmlock/testdata/v5.yaml
+++ b/providers/os/resources/languages/javascript/pnpmlock/testdata/v5.yaml
@@ -1,0 +1,20 @@
+lockfileVersion: '5.4'
+
+packages:
+
+  /express/4.18.2:
+    resolution: {integrity: sha512-abc123}
+    dependencies:
+      accepts: 1.3.8
+      body-parser: 1.20.1
+
+  /accepts/1.3.8:
+    resolution: {integrity: sha512-def456}
+    dev: false
+
+  /body-parser/1.20.1:
+    resolution: {integrity: sha512-ghi789}
+
+  /@types/node/20.10.0:
+    resolution: {integrity: sha512-jkl012}
+    dev: true

--- a/providers/os/resources/languages/javascript/pnpmlock/testdata/v6.yaml
+++ b/providers/os/resources/languages/javascript/pnpmlock/testdata/v6.yaml
@@ -1,0 +1,14 @@
+lockfileVersion: '6.0'
+
+packages:
+
+  /express@4.18.2:
+    resolution: {integrity: sha512-abc123}
+    dependencies:
+      accepts: 1.3.8
+
+  /accepts@1.3.8:
+    resolution: {integrity: sha512-def456}
+
+  /@scope/utils@2.0.0:
+    resolution: {integrity: sha512-mno345}

--- a/providers/os/resources/languages/javascript/pnpmlock/testdata/v9.yaml
+++ b/providers/os/resources/languages/javascript/pnpmlock/testdata/v9.yaml
@@ -1,0 +1,19 @@
+lockfileVersion: 9
+
+packages:
+
+  express@4.18.2:
+    resolution: {integrity: sha512-abc123}
+    dependencies:
+      accepts: 1.3.8
+      body-parser: 1.20.1
+
+  accepts@1.3.8:
+    resolution: {integrity: sha512-def456}
+
+  body-parser@1.20.1:
+    resolution: {integrity: sha512-ghi789}
+
+  '@types/node@20.10.0':
+    resolution: {integrity: sha512-jkl012}
+    dev: true

--- a/providers/os/resources/languages/javascript/yarnlock/extractor.go
+++ b/providers/os/resources/languages/javascript/yarnlock/extractor.go
@@ -15,9 +15,15 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// yarnLockBom wraps a parsed yarnLock with file evidence.
+type yarnLockBom struct {
+	packages yarnLock
+	evidence []string
+}
+
 var (
 	_ languages.Extractor = (*Extractor)(nil)
-	_ languages.Bom       = (*yarnLock)(nil)
+	_ languages.Bom       = (*yarnLockBom)(nil)
 )
 
 type Extractor struct{}
@@ -45,40 +51,47 @@ func (p *Extractor) Parse(r io.Reader, filename string) (languages.Bom, error) {
 		return nil, err
 	}
 
-	var yarnLock yarnLock
+	var lock yarnLock
 
-	err := yaml.Unmarshal(b.Bytes(), &yarnLock)
+	err := yaml.Unmarshal(b.Bytes(), &lock)
 	if err != nil {
 		return nil, err
 	}
 
-	return &yarnLock, nil
+	var result yarnLockBom
+	result.packages = lock
+	if filename != "" {
+		result.evidence = append(result.evidence, filename)
+	}
+
+	return &result, nil
 }
 
-func (p *yarnLock) Root() *languages.Package {
+func (p *yarnLockBom) Root() *languages.Package {
 	// we don't have a root package in yarn.lock
 	return nil
 }
 
-func (p *yarnLock) Direct() languages.Packages {
+func (p *yarnLockBom) Direct() languages.Packages {
 	return nil
 }
 
-func (p *yarnLock) Transitive() languages.Packages {
+func (p *yarnLockBom) Transitive() languages.Packages {
 	var transitive languages.Packages
 
 	// add all dependencies
-	for k, v := range *p {
+	for k, v := range p.packages {
 		name, _, err := parseYarnPackageName(k)
 		if err != nil {
 			log.Error().Str("name", name).Msg("cannot parse yarn package name")
 			continue
 		}
 		transitive = append(transitive, &languages.Package{
-			Name:    name,
-			Version: v.Version,
-			Purl:    javascript.NewPackageUrl(name, v.Version),
-			Cpes:    javascript.NewCpes(name, v.Version),
+			Name:         name,
+			Version:      v.Version,
+			Purl:         javascript.NewPackageUrl(name, v.Version),
+			Cpes:         javascript.NewCpes(name, v.Version),
+			EvidenceList: javascript.NewEvidenceList(p.evidence),
 		})
 	}
 

--- a/providers/os/resources/languages/javascript/yarnlock/extractor_test.go
+++ b/providers/os/resources/languages/javascript/yarnlock/extractor_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers/os/resources/languages"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages/javascript"
 )
 
 func TestYarnLockExtractor(t *testing.T) {
@@ -23,19 +24,23 @@ func TestYarnLockExtractor(t *testing.T) {
 	list := info.Transitive()
 	assert.Equal(t, 99, len(list))
 
+	evidence := javascript.NewEvidenceList([]string{"/path/to/yarn.lock"})
+
 	p := list.Find("has")
 	assert.Equal(t, &languages.Package{
-		Name:    "has",
-		Version: "1.0.3",
-		Purl:    "pkg:npm/has@1.0.3",
-		Cpes:    []string{"cpe:2.3:a:has:has:1.0.3:*:*:*:*:*:*:*"},
+		Name:         "has",
+		Version:      "1.0.3",
+		Purl:         "pkg:npm/has@1.0.3",
+		Cpes:         []string{"cpe:2.3:a:has:has:1.0.3:*:*:*:*:*:*:*"},
+		EvidenceList: evidence,
 	}, p)
 
 	p = list.Find("iconv-lite")
 	assert.Equal(t, &languages.Package{
-		Name:    "iconv-lite",
-		Version: "0.4.24",
-		Purl:    "pkg:npm/iconv-lite@0.4.24",
-		Cpes:    []string{"cpe:2.3:a:iconv-lite:iconv-lite:0.4.24:*:*:*:*:*:*:*"},
+		Name:         "iconv-lite",
+		Version:      "0.4.24",
+		Purl:         "pkg:npm/iconv-lite@0.4.24",
+		Cpes:         []string{"cpe:2.3:a:iconv-lite:iconv-lite:0.4.24:*:*:*:*:*:*:*"},
+		EvidenceList: evidence,
 	}, p)
 }

--- a/providers/os/resources/npm.go
+++ b/providers/os/resources/npm.go
@@ -26,6 +26,7 @@ import (
 	"go.mondoo.com/mql/v13/providers/os/resources/languages/javascript/packagejson"
 	"go.mondoo.com/mql/v13/providers/os/resources/languages/javascript/packagelockjson"
 	"go.mondoo.com/mql/v13/providers/os/resources/languages/javascript/pnpmlock"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages/javascript/yarnlock"
 	"go.mondoo.com/mql/v13/types"
 )
 
@@ -204,14 +205,16 @@ func hasLockfile(runtime *plugin.Runtime, fs afero.Fs, path string) bool {
 
 	searchPaths := []string{}
 	if isDir {
-		// check if there is a package-lock.json, pnpm-lock.yaml, bun.lock, or package.json file
+		// check if there is a lockfile
 		searchPaths = append(searchPaths,
 			filepath.Join(path, "/package-lock.json"),
 			filepath.Join(path, "/pnpm-lock.yaml"),
+			filepath.Join(path, "/yarn.lock"),
 			filepath.Join(path, "/bun.lock"),
 		)
 	} else if strings.HasSuffix(path, "package-lock.json") ||
 		strings.HasSuffix(path, "pnpm-lock.yaml") ||
+		strings.HasSuffix(path, "yarn.lock") ||
 		strings.HasSuffix(path, "bun.lock") {
 		searchPaths = append(searchPaths, path)
 	}
@@ -241,12 +244,15 @@ func collectNpmPackages(runtime *plugin.Runtime, fs afero.Fs, path string) (lang
 		searchPaths = append(searchPaths,
 			filepath.Join(path, "/package-lock.json"),
 			filepath.Join(path, "/pnpm-lock.yaml"),
+			filepath.Join(path, "/yarn.lock"),
 			filepath.Join(path, "/bun.lock"),
 			filepath.Join(path, "/package.json"),
 		)
 	} else if strings.HasSuffix(path, "package-lock.json") {
 		searchPaths = append(searchPaths, path)
 	} else if strings.HasSuffix(path, "pnpm-lock.yaml") {
+		searchPaths = append(searchPaths, path)
+	} else if strings.HasSuffix(path, "yarn.lock") {
 		searchPaths = append(searchPaths, path)
 	} else if strings.HasSuffix(path, "bun.lock") {
 		searchPaths = append(searchPaths, path)
@@ -264,7 +270,7 @@ func collectNpmPackages(runtime *plugin.Runtime, fs afero.Fs, path string) (lang
 	}
 
 	if len(filteredSearchPath) == 0 {
-		return nil, fmt.Errorf("path %s is not a package.json or package-lock.json file", path)
+		return nil, fmt.Errorf("path %s is not a supported JavaScript lockfile or package.json", path)
 	}
 
 	// technically we should only have one file, this logic will always pick the first one
@@ -285,6 +291,8 @@ func collectNpmPackages(runtime *plugin.Runtime, fs afero.Fs, path string) (lang
 			extractor = &packagelockjson.Extractor{}
 		} else if strings.HasSuffix(searchPath, "pnpm-lock.yaml") {
 			extractor = &pnpmlock.Extractor{}
+		} else if strings.HasSuffix(searchPath, "yarn.lock") {
+			extractor = &yarnlock.Extractor{}
 		} else if strings.HasSuffix(searchPath, "bun.lock") {
 			extractor = &bunlock.Extractor{}
 		} else if strings.HasSuffix(searchPath, "package.json") {

--- a/providers/os/resources/npm.go
+++ b/providers/os/resources/npm.go
@@ -22,8 +22,10 @@ import (
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
 	"go.mondoo.com/mql/v13/providers/os/fsutil"
 	"go.mondoo.com/mql/v13/providers/os/resources/languages"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages/javascript/bunlock"
 	"go.mondoo.com/mql/v13/providers/os/resources/languages/javascript/packagejson"
 	"go.mondoo.com/mql/v13/providers/os/resources/languages/javascript/packagelockjson"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages/javascript/pnpmlock"
 	"go.mondoo.com/mql/v13/types"
 )
 
@@ -202,9 +204,15 @@ func hasLockfile(runtime *plugin.Runtime, fs afero.Fs, path string) bool {
 
 	searchPaths := []string{}
 	if isDir {
-		// check if there is a package-lock.json or package.json file
-		searchPaths = append(searchPaths, filepath.Join(path, "/package-lock.json"))
-	} else if strings.HasSuffix(path, "package-lock.json") {
+		// check if there is a package-lock.json, pnpm-lock.yaml, bun.lock, or package.json file
+		searchPaths = append(searchPaths,
+			filepath.Join(path, "/package-lock.json"),
+			filepath.Join(path, "/pnpm-lock.yaml"),
+			filepath.Join(path, "/bun.lock"),
+		)
+	} else if strings.HasSuffix(path, "package-lock.json") ||
+		strings.HasSuffix(path, "pnpm-lock.yaml") ||
+		strings.HasSuffix(path, "bun.lock") {
 		searchPaths = append(searchPaths, path)
 	}
 
@@ -229,9 +237,18 @@ func collectNpmPackages(runtime *plugin.Runtime, fs afero.Fs, path string) (lang
 
 	searchPaths := []string{}
 	if isDir {
-		// check if there is a package-lock.json or package.json file
-		searchPaths = append(searchPaths, filepath.Join(path, "/package-lock.json"), filepath.Join(path, "/package.json"))
+		// check if there is a lockfile or package.json file
+		searchPaths = append(searchPaths,
+			filepath.Join(path, "/package-lock.json"),
+			filepath.Join(path, "/pnpm-lock.yaml"),
+			filepath.Join(path, "/bun.lock"),
+			filepath.Join(path, "/package.json"),
+		)
 	} else if strings.HasSuffix(path, "package-lock.json") {
+		searchPaths = append(searchPaths, path)
+	} else if strings.HasSuffix(path, "pnpm-lock.yaml") {
+		searchPaths = append(searchPaths, path)
+	} else if strings.HasSuffix(path, "bun.lock") {
 		searchPaths = append(searchPaths, path)
 	} else if strings.HasSuffix(path, "package.json") {
 		searchPaths = append(searchPaths, path)
@@ -266,6 +283,10 @@ func collectNpmPackages(runtime *plugin.Runtime, fs afero.Fs, path string) (lang
 
 		if strings.HasSuffix(searchPath, "package-lock.json") {
 			extractor = &packagelockjson.Extractor{}
+		} else if strings.HasSuffix(searchPath, "pnpm-lock.yaml") {
+			extractor = &pnpmlock.Extractor{}
+		} else if strings.HasSuffix(searchPath, "bun.lock") {
+			extractor = &bunlock.Extractor{}
 		} else if strings.HasSuffix(searchPath, "package.json") {
 			extractor = &packagejson.Extractor{}
 		}


### PR DESCRIPTION
## Summary

- Add **pnpm-lock.yaml** parser (YAML) with support for v5, v6, and v9 key formats including scoped packages, peer dependency suffixes, and tarball/git references
- Add **bun.lock** parser (JSONC) with trailing comma handling via `stripJSONC` preprocessor
- Wire both parsers into `npm.go` so they're discovered alongside `package-lock.json`
- Fix pre-existing bug in yarnlock parser where `EvidenceList` was not populated

No interdependencies with the other lockfile parser PRs.

## Test plan

- [x] `go test ./providers/os/resources/languages/javascript/pnpmlock/...` (v5, v6, v9, tarball fixtures)
- [x] `go test ./providers/os/resources/languages/javascript/bunlock/...` (JSONC edge cases, scoped packages)
- [x] `go test ./providers/os/resources/languages/javascript/yarnlock/...` (evidence fix verified)
- [x] `go build ./providers/os/resources/...` (npm.go wiring compiles)
- [ ] Build and install os provider, test with real pnpm/bun projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)