### PR TITLE
✨ Add gems.locked support for Ruby dependency detection

### DIFF
--- a/providers/os/resources/ruby.go
+++ b/providers/os/resources/ruby.go
@@ -159,10 +159,12 @@ func collectRubyPackages(afs *afero.Afero, fs afero.Fs, path string) (*languages
 	}
 
 	if isDir {
-		// Prefer Gemfile.lock (resolved versions)
-		lockPath := filepath.Join(path, "Gemfile.lock")
-		if exists, _ := afs.Exists(lockPath); exists {
-			return collectFromGemfileLock(afs, lockPath)
+		// Prefer Gemfile.lock or gems.locked (resolved versions)
+		for _, lockName := range []string{"Gemfile.lock", "gems.locked"} {
+			lockPath := filepath.Join(path, lockName)
+			if exists, _ := afs.Exists(lockPath); exists {
+				return collectFromGemfileLock(afs, lockPath)
+			}
 		}
 
 		// Fall back to .gemspec files
@@ -178,7 +180,7 @@ func collectRubyPackages(afs *afero.Afero, fs afero.Fs, path string) (*languages
 		return nil, nil, nil, nil
 	}
 
-	if strings.HasSuffix(path, "Gemfile.lock") {
+	if strings.HasSuffix(path, "Gemfile.lock") || strings.HasSuffix(path, "gems.locked") {
 		return collectFromGemfileLock(afs, path)
 	}
 	if strings.HasSuffix(path, ".gemspec") {


### PR DESCRIPTION
## Summary

- Recognize `gems.locked` as an alternative Ruby lockfile name (same format as `Gemfile.lock`)
- Adds filename detection in both directory scanning and direct path handling in `ruby.go`

## Test plan

- [x] `go build ./providers/os/resources/...` compiles clean
- [x] Existing Gemfile.lock tests still pass
- [ ] Test with a project that uses `gems.locked` instead of `Gemfile.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)