### PR TITLE
🧹 AWS AppStream: add init functions for fleet/stack typed refs + cache stack list per fleet

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -12592,7 +12592,7 @@ private aws.appstream.application @defaults("name displayName enabled platforms 
   launchParameters string
   // Working directory for the application
   workingDirectory string
-  // Operating system platforms the application can run on (WINDOWS_SERVER_2016/2019/2022/2025, AMAZON_LINUX2, RHEL8, ROCKY_LINUX8, UBUNTU_PRO_2404)
+  // Operating system platforms the application can run on (WINDOWS, WINDOWS_SERVER_2016/2019/2022/2025, AMAZON_LINUX2, RHEL8, ROCKY_LINUX8, UBUNTU_PRO_2404)
   platforms []string
   // Instance families the application supports (e.g., GENERAL_PURPOSE, COMPUTE_OPTIMIZED, MEMORY_OPTIMIZED, GRAPHICS_DESIGN, GRAPHICS_PRO)
   instanceFamilies []string
@@ -12618,11 +12618,11 @@ private aws.appstream.image @defaults("name state platform visibility region") {
   description string
   // ARN of the image from which this image was created (null for AWS-supplied base images)
   baseImageArn string
-  // State of the image: PENDING, AVAILABLE, FAILED, COPYING, DELETING, CREATING, IMPORTING, or AVAILABLE_FOR_DCV
+  // State of the image: PENDING, AVAILABLE, FAILED, COPYING, DELETING, CREATING, IMPORTING, or VALIDATING
   state string
   // Visibility of the image: PUBLIC, PRIVATE, or SHARED
   visibility string
-  // Operating system platform: WINDOWS_SERVER_2016, WINDOWS_SERVER_2019, WINDOWS_SERVER_2022, WINDOWS_SERVER_2025, AMAZON_LINUX2, RHEL8, ROCKY_LINUX8, or UBUNTU_PRO_2404
+  // Operating system platform: WINDOWS, WINDOWS_SERVER_2016, WINDOWS_SERVER_2019, WINDOWS_SERVER_2022, WINDOWS_SERVER_2025, AMAZON_LINUX2, RHEL8, ROCKY_LINUX8, or UBUNTU_PRO_2404
   platform string
   // Name of the image builder that created the image (null for shared/copied/managed-update images)
   imageBuilderName string
@@ -12648,7 +12648,7 @@ private aws.appstream.user @defaults("userName status enabled region") {
   arn string
   // Email address of the user (also serves as the user's identifier within the user pool)
   userName string
-  // Authentication type: API, SAML, or USERPOOL
+  // Authentication type: API, SAML, USERPOOL, or AWS_AD
   authenticationType string
   // First (given) name of the user
   firstName string
@@ -12674,7 +12674,7 @@ private aws.appstream.session @defaults("id userId state fleetName stackName") {
   state string
   // Whether the user is currently connected: CONNECTED or NOT_CONNECTED
   connectionState string
-  // Authentication method used to start the session: API, SAML, or USERPOOL
+  // Authentication method used to start the session: API, SAML, USERPOOL, or AWS_AD
   authenticationType string
   // Name of the fleet the session is running on
   fleetName string

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -2919,7 +2919,7 @@ func init() {
 			Create: createAwsAppstream,
 		},
 		"aws.appstream.fleet": {
-			// to override args, implement: initAwsAppstreamFleet(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAwsAppstreamFleet,
 			Create: createAwsAppstreamFleet,
 		},
 		"aws.appstream.fleet.computeCapacityStatus": {
@@ -2927,7 +2927,7 @@ func init() {
 			Create: createAwsAppstreamFleetComputeCapacityStatus,
 		},
 		"aws.appstream.stack": {
-			// to override args, implement: initAwsAppstreamStack(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAwsAppstreamStack,
 			Create: createAwsAppstreamStack,
 		},
 		"aws.appstream.stack.contentRedirection": {

--- a/providers/aws/resources/aws_appstream.go
+++ b/providers/aws/resources/aws_appstream.go
@@ -6,9 +6,12 @@ package resources
 import (
 	"context"
 	"errors"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/appstream"
 	appstreamtypes "github.com/aws/aws-sdk-go-v2/service/appstream/types"
 	"github.com/rs/zerolog/log"
@@ -145,10 +148,47 @@ func newMqlAwsAppstreamFleet(runtime *plugin.Runtime, region string, fleet appst
 
 type mqlAwsAppstreamFleetInternal struct {
 	cacheComputeCapacityStatus *appstreamtypes.ComputeCapacityStatus
+
+	stackNamesLock    sync.Mutex
+	stackNamesFetched bool
+	stackNames        []string
 }
 
 func (a *mqlAwsAppstreamFleet) id() (string, error) {
 	return a.Arn.Data, nil
+}
+
+func initAwsAppstreamFleet(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	region, name, err := parseAppstreamRef(args, "fleet/")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	conn := runtime.Connection.(*connection.AwsConnection)
+	svc := conn.Appstream(region)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	resp, err := svc.DescribeFleets(ctx, &appstream.DescribeFleetsInput{
+		Names: []string{name},
+	})
+	if err != nil {
+		if isAppstreamRegionError(err) {
+			return args, nil, nil
+		}
+		return nil, nil, err
+	}
+	if len(resp.Fleets) == 0 {
+		return args, nil, nil
+	}
+
+	mqlFleet, err := newMqlAwsAppstreamFleet(runtime, region, resp.Fleets[0])
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, mqlFleet, nil
 }
 
 func (a *mqlAwsAppstreamFleet) iamRole() (*mqlAwsIamRole, error) {
@@ -323,6 +363,63 @@ type mqlAwsAppstreamStackInternal struct {
 
 func (a *mqlAwsAppstreamStack) id() (string, error) {
 	return a.Arn.Data, nil
+}
+
+func initAwsAppstreamStack(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	region, name, err := parseAppstreamRef(args, "stack/")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	conn := runtime.Connection.(*connection.AwsConnection)
+	svc := conn.Appstream(region)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	resp, err := svc.DescribeStacks(ctx, &appstream.DescribeStacksInput{
+		Names: []string{name},
+	})
+	if err != nil {
+		if isAppstreamRegionError(err) {
+			return args, nil, nil
+		}
+		return nil, nil, err
+	}
+	if len(resp.Stacks) == 0 {
+		return args, nil, nil
+	}
+
+	mqlStack, err := newMqlAwsAppstreamStack(runtime, region, resp.Stacks[0])
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, mqlStack, nil
+}
+
+// parseAppstreamRef extracts region + resource name from init args. Supports
+// {arn}, {name + region}, or both. resourcePrefix is "fleet/" or "stack/".
+func parseAppstreamRef(args map[string]*llx.RawData, resourcePrefix string) (string, string, error) {
+	var region, name string
+	if a := args["arn"]; a != nil {
+		parsed, err := arn.Parse(a.Value.(string))
+		if err != nil {
+			return "", "", err
+		}
+		region = parsed.Region
+		name = strings.TrimPrefix(parsed.Resource, resourcePrefix)
+	}
+	if r := args["region"]; r != nil {
+		region = r.Value.(string)
+	}
+	if n := args["name"]; n != nil {
+		name = n.Value.(string)
+	}
+	if region == "" || name == "" {
+		return "", "", errors.New("arn or (name + region) required to fetch aws appstream resource")
+	}
+	return region, name, nil
 }
 
 func (a *mqlAwsAppstreamStack) contentRedirection() (*mqlAwsAppstreamStackContentRedirection, error) {
@@ -693,7 +790,8 @@ func (a *mqlAwsAppstreamImage) id() (string, error) { return a.Arn.Data, nil }
 func (a *mqlAwsAppstreamImage) tags() (map[string]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	svc := conn.Appstream(a.Region.Data)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
 	resp, err := svc.ListTagsForResource(ctx, &appstream.ListTagsForResourceInput{
 		ResourceArn: aws.String(a.Arn.Data),
 	})
@@ -818,10 +916,19 @@ func (a *mqlAwsAppstreamStack) associatedFleets() ([]any, error) {
 	return res, nil
 }
 
-func (a *mqlAwsAppstreamFleet) associatedStacks() ([]any, error) {
+// listAssociatedStackNames returns (and caches) the names of stacks associated
+// with this fleet. Both associatedStacks() and sessions() walk the same set of
+// stacks, so we fetch ListAssociatedStacks once per fleet.
+func (a *mqlAwsAppstreamFleet) listAssociatedStackNames() ([]string, error) {
+	a.stackNamesLock.Lock()
+	defer a.stackNamesLock.Unlock()
+	if a.stackNamesFetched {
+		return a.stackNames, nil
+	}
+
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	svc := conn.Appstream(a.Region.Data)
-	res := []any{}
+	names := []string{}
 	var nextToken *string
 	fleetName := a.Name.Data
 	for {
@@ -833,23 +940,38 @@ func (a *mqlAwsAppstreamFleet) associatedStacks() ([]any, error) {
 		cancel()
 		if err != nil {
 			if isAppstreamRegionError(err) {
-				return res, nil
+				a.stackNamesFetched = true
+				a.stackNames = names
+				return names, nil
 			}
 			return nil, err
 		}
-		for _, stackName := range resp.Names {
-			stackArn := buildAppstreamStackArn(a.Region.Data, conn.AccountId(), stackName)
-			stack, err := NewResource(a.MqlRuntime, "aws.appstream.stack",
-				map[string]*llx.RawData{"arn": llx.StringData(stackArn)})
-			if err != nil {
-				return nil, err
-			}
-			res = append(res, stack)
-		}
+		names = append(names, resp.Names...)
 		if resp.NextToken == nil {
 			break
 		}
 		nextToken = resp.NextToken
+	}
+	a.stackNamesFetched = true
+	a.stackNames = names
+	return names, nil
+}
+
+func (a *mqlAwsAppstreamFleet) associatedStacks() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	names, err := a.listAssociatedStackNames()
+	if err != nil {
+		return nil, err
+	}
+	res := make([]any, 0, len(names))
+	for _, stackName := range names {
+		stackArn := buildAppstreamStackArn(a.Region.Data, conn.AccountId(), stackName)
+		stack, err := NewResource(a.MqlRuntime, "aws.appstream.stack",
+			map[string]*llx.RawData{"arn": llx.StringData(stackArn)})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, stack)
 	}
 	return res, nil
 }
@@ -935,77 +1057,63 @@ func (a *mqlAwsAppstreamFleet) sessions() ([]any, error) {
 	res := []any{}
 
 	// Walk each associated stack, then list active sessions for the (fleet, stack) pair.
-	var stackToken *string
+	// Stack names are cached on the fleet so associatedStacks() and sessions() share the same listing.
+	stackNames, err := a.listAssociatedStackNames()
+	if err != nil {
+		return nil, err
+	}
 	fleetName := a.Name.Data
-	for {
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-		stacks, err := svc.ListAssociatedStacks(ctx, &appstream.ListAssociatedStacksInput{
-			FleetName: aws.String(fleetName),
-			NextToken: stackToken,
-		})
-		cancel()
-		if err != nil {
-			if isAppstreamRegionError(err) {
-				return res, nil
-			}
-			return nil, err
-		}
-		for _, stackName := range stacks.Names {
-			var sessionToken *string
-			for {
-				ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-				sresp, err := svc.DescribeSessions(ctx, &appstream.DescribeSessionsInput{
-					FleetName: aws.String(fleetName),
-					StackName: aws.String(stackName),
-					NextToken: sessionToken,
-				})
-				cancel()
-				if err != nil {
-					if isAppstreamRegionError(err) {
-						break
-					}
-					return nil, err
-				}
-				for _, s := range sresp.Sessions {
-					sid := aws.ToString(s.Id)
-					synthArn := "arn:aws:appstream:" + a.Region.Data + ":" + conn.AccountId() + ":session/" + sid
-					var eniId, eniIp string
-					if s.NetworkAccessConfiguration != nil {
-						eniId = aws.ToString(s.NetworkAccessConfiguration.EniId)
-						eniIp = aws.ToString(s.NetworkAccessConfiguration.EniPrivateIpAddress)
-					}
-					resource, err := CreateResource(a.MqlRuntime, "aws.appstream.session",
-						map[string]*llx.RawData{
-							"__id":                llx.StringData(synthArn),
-							"id":                  llx.StringData(sid),
-							"userId":              llx.StringDataPtr(s.UserId),
-							"state":               llx.StringData(string(s.State)),
-							"connectionState":     llx.StringData(string(s.ConnectionState)),
-							"authenticationType":  llx.StringData(string(s.AuthenticationType)),
-							"fleetName":           llx.StringDataPtr(s.FleetName),
-							"stackName":           llx.StringDataPtr(s.StackName),
-							"instanceId":          llx.StringDataPtr(s.InstanceId),
-							"startTime":           llx.TimeDataPtr(s.StartTime),
-							"maxExpirationTime":   llx.TimeDataPtr(s.MaxExpirationTime),
-							"eniId":               llx.StringData(eniId),
-							"eniPrivateIpAddress": llx.StringData(eniIp),
-							"region":              llx.StringData(a.Region.Data),
-						})
-					if err != nil {
-						return nil, err
-					}
-					res = append(res, resource)
-				}
-				if sresp.NextToken == nil {
+	for _, stackName := range stackNames {
+		var sessionToken *string
+		for {
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			sresp, err := svc.DescribeSessions(ctx, &appstream.DescribeSessionsInput{
+				FleetName: aws.String(fleetName),
+				StackName: aws.String(stackName),
+				NextToken: sessionToken,
+			})
+			cancel()
+			if err != nil {
+				if isAppstreamRegionError(err) {
 					break
 				}
-				sessionToken = sresp.NextToken
+				return nil, err
 			}
+			for _, s := range sresp.Sessions {
+				sid := aws.ToString(s.Id)
+				synthArn := "arn:aws:appstream:" + a.Region.Data + ":" + conn.AccountId() + ":session/" + sid
+				var eniId, eniIp string
+				if s.NetworkAccessConfiguration != nil {
+					eniId = aws.ToString(s.NetworkAccessConfiguration.EniId)
+					eniIp = aws.ToString(s.NetworkAccessConfiguration.EniPrivateIpAddress)
+				}
+				resource, err := CreateResource(a.MqlRuntime, "aws.appstream.session",
+					map[string]*llx.RawData{
+						"__id":                llx.StringData(synthArn),
+						"id":                  llx.StringData(sid),
+						"userId":              llx.StringDataPtr(s.UserId),
+						"state":               llx.StringData(string(s.State)),
+						"connectionState":     llx.StringData(string(s.ConnectionState)),
+						"authenticationType":  llx.StringData(string(s.AuthenticationType)),
+						"fleetName":           llx.StringDataPtr(s.FleetName),
+						"stackName":           llx.StringDataPtr(s.StackName),
+						"instanceId":          llx.StringDataPtr(s.InstanceId),
+						"startTime":           llx.TimeDataPtr(s.StartTime),
+						"maxExpirationTime":   llx.TimeDataPtr(s.MaxExpirationTime),
+						"eniId":               llx.StringData(eniId),
+						"eniPrivateIpAddress": llx.StringData(eniIp),
+						"region":              llx.StringData(a.Region.Data),
+					})
+				if err != nil {
+					return nil, err
+				}
+				res = append(res, resource)
+			}
+			if sresp.NextToken == nil {
+				break
+			}
+			sessionToken = sresp.NextToken
 		}
-		if stacks.NextToken == nil {
-			break
-		}
-		stackToken = stacks.NextToken
 	}
 	return res, nil
 }

--- a/providers/aws/resources/aws_appstream.go
+++ b/providers/aws/resources/aws_appstream.go
@@ -403,7 +403,11 @@ func initAwsAppstreamStack(runtime *plugin.Runtime, args map[string]*llx.RawData
 func parseAppstreamRef(args map[string]*llx.RawData, resourcePrefix string) (string, string, error) {
 	var region, name string
 	if a := args["arn"]; a != nil {
-		parsed, err := arn.Parse(a.Value.(string))
+		s, ok := a.Value.(string)
+		if !ok {
+			return "", "", errors.New("aws appstream init: arn must be a string")
+		}
+		parsed, err := arn.Parse(s)
 		if err != nil {
 			return "", "", err
 		}
@@ -411,10 +415,14 @@ func parseAppstreamRef(args map[string]*llx.RawData, resourcePrefix string) (str
 		name = strings.TrimPrefix(parsed.Resource, resourcePrefix)
 	}
 	if r := args["region"]; r != nil {
-		region = r.Value.(string)
+		if s, ok := r.Value.(string); ok {
+			region = s
+		}
 	}
 	if n := args["name"]; n != nil {
-		name = n.Value.(string)
+		if s, ok := n.Value.(string); ok {
+			name = s
+		}
 	}
 	if region == "" || name == "" {
 		return "", "", errors.New("arn or (name + region) required to fetch aws appstream resource")
@@ -940,6 +948,7 @@ func (a *mqlAwsAppstreamFleet) listAssociatedStackNames() ([]string, error) {
 		cancel()
 		if err != nil {
 			if isAppstreamRegionError(err) {
+				log.Debug().Str("region", a.Region.Data).Str("fleet", fleetName).Int("partial", len(names)).Msg("error accessing region for AWS AppStream associated stacks API; caching partial result")
 				a.stackNamesFetched = true
 				a.stackNames = names
 				return names, nil


### PR DESCRIPTION
## Summary

Follow-up fixes for #7463 based on code review feedback.

- **Add `initAwsAppstreamFleet` / `initAwsAppstreamStack`** so the typed cross-references introduced in #7463 (`entitlement.stack`, `session.fleet`, `session.stack`, `fleet.associatedStacks`, `stack.associatedFleets`) populate full data via `DescribeFleets`/`DescribeStacks` on cache miss. Without an init function, `NewResource(... {"arn": ...})` produced stub resources with only `arn` set, so traversals like `aws.appstream.entitlements { stack.userSettings }` returned empty fields when the parent stack list hadn't been iterated first. Per CLAUDE.md Pattern B.

- **Cache the per-fleet `ListAssociatedStacks` result** on the fleet's Internal struct so `fleet.sessions()` and `fleet.associatedStacks()` share one walk instead of calling the API twice per fleet.

- **Add a 15s context timeout to `image.tags()`** for parity with the rest of the AppStream tag/list calls (which all wrap `context.WithTimeout`).

- **Fix `.lr` enum docs**:
  - `image.state`: replace `AVAILABLE_FOR_DCV` (not in the SDK) with `VALIDATING`
  - `image.platform` / `application.platforms`: add the legacy `WINDOWS` value to match the `fleet.platform` comment and the SDK enum
  - `user.authenticationType` / `session.authenticationType`: add `AWS_AD`

## Test plan

- [ ] `aws.appstream.entitlements { stack.userSettings }` populates stack fields without first listing `aws.appstream.stacks`
- [ ] `aws.appstream.fleets { sessions { fleet.name } }` resolves typed refs correctly (cache-hit path)
- [ ] `aws.appstream.fleets { sessions associatedStacks }` issues `ListAssociatedStacks` once per fleet (verify via debug logs)

