### PR TITLE
✨ GCP: surface network exposure scalars for CIS-style audits

### DIFF
--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -3191,6 +3191,61 @@ func (g *mqlGcpProjectComputeServiceImage) iamPolicy() ([]any, error) {
 	return computeIamBindingsToResources(g.MqlRuntime, name, policy.Bindings)
 }
 
+func (g *mqlGcpProjectComputeServiceInstance) hasPublicIp() (bool, error) {
+	nics := g.GetNetworkInterfaces()
+	if nics.Error != nil {
+		return false, nics.Error
+	}
+	for _, nic := range nics.Data {
+		nicMap, ok := nic.(map[string]any)
+		if !ok {
+			continue
+		}
+		accessConfigs, ok := nicMap["accessConfigs"].([]any)
+		if !ok {
+			continue
+		}
+		if len(accessConfigs) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (g *mqlGcpProjectComputeServiceFirewall) openToInternet() (bool, error) {
+	if g.Disabled.Error != nil {
+		return false, g.Disabled.Error
+	}
+	if g.Disabled.Data {
+		return false, nil
+	}
+	if g.Direction.Error != nil {
+		return false, g.Direction.Error
+	}
+	if !strings.EqualFold(g.Direction.Data, "INGRESS") {
+		return false, nil
+	}
+	if g.Allowed.Error != nil {
+		return false, g.Allowed.Error
+	}
+	if len(g.Allowed.Data) == 0 {
+		return false, nil
+	}
+	if g.SourceRanges.Error != nil {
+		return false, g.SourceRanges.Error
+	}
+	for _, r := range g.SourceRanges.Data {
+		s, ok := r.(string)
+		if !ok {
+			continue
+		}
+		if s == "0.0.0.0/0" || s == "::/0" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (g *mqlGcpProjectComputeServiceSnapshot) iamPolicy() ([]any, error) {
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -922,6 +922,8 @@ gcp.project.computeService.instance @defaults("name id") {
   minCpuPlatform string
   // Network configurations for the instance
   networkInterfaces []dict
+  // Whether the instance has at least one external IP attached via a network interface accessConfig
+  hasPublicIp() bool
   // Private IPv6 google access type for the VM
   privateIpv6GoogleAccess string
   // Reservations from which this instance can consume
@@ -1206,6 +1208,8 @@ private gcp.project.computeService.firewall @defaults("name") {
   disabled bool
   // Source ranges
   sourceRanges []string
+  // Whether this rule allows ingress traffic from the public internet (INGRESS, enabled, has allow rules, sourceRanges contains 0.0.0.0/0 or ::/0)
+  openToInternet() bool
   // Source service accounts
   sourceServiceAccounts []string
   // Source tags
@@ -1958,6 +1962,8 @@ private gcp.project.sqlService.instance.settings.ipConfiguration {
   allocatedIpRange string
   // List of external networks that are allowed to connect to the instance using the IP
   authorizedNetworks []dict
+  // Whether any authorized network entry uses 0.0.0.0/0 or ::/0 (public internet)
+  hasOpenAuthorizedNetworks() bool
   // Whether the instance is assigned a public IP address
   ipv4Enabled bool
   // Resource link for the VPC network from which the private IPs can access the Cloud SQL instance
@@ -2400,8 +2406,16 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   masterAuth dict
   // Master authorized networks configuration
   masterAuthorizedNetworksConfig dict
+  // Whether master authorized networks is enabled (restricts control plane access by source CIDR)
+  masterAuthorizedNetworksEnabled bool
   // Private cluster configuration
   privateClusterConfig dict
+  // Whether nodes have only private IPs (no public internet egress without NAT)
+  privateNodesEnabled bool
+  // Whether the cluster's control plane endpoint is private (no public master endpoint)
+  privateEndpointEnabled bool
+  // Whether the cluster's private control plane is reachable from any region (when private endpoint is enabled)
+  masterGlobalAccessEnabled bool
   // Etcd encryption configuration
   databaseEncryption dict
   // Etcd encryption state (ENCRYPTED, DECRYPTED)

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -2984,6 +2984,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.instance.networkInterfaces": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetNetworkInterfaces()).ToDataRes(types.Array(types.Dict))
 	},
+	"gcp.project.computeService.instance.hasPublicIp": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstance).GetHasPublicIp()).ToDataRes(types.Bool)
+	},
 	"gcp.project.computeService.instance.privateIpv6GoogleAccess": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetPrivateIpv6GoogleAccess()).ToDataRes(types.String)
 	},
@@ -3367,6 +3370,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.firewall.sourceRanges": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceFirewall).GetSourceRanges()).ToDataRes(types.Array(types.String))
+	},
+	"gcp.project.computeService.firewall.openToInternet": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceFirewall).GetOpenToInternet()).ToDataRes(types.Bool)
 	},
 	"gcp.project.computeService.firewall.sourceServiceAccounts": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceFirewall).GetSourceServiceAccounts()).ToDataRes(types.Array(types.String))
@@ -4316,6 +4322,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.sqlService.instance.settings.ipConfiguration.authorizedNetworks": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).GetAuthorizedNetworks()).ToDataRes(types.Array(types.Dict))
 	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.hasOpenAuthorizedNetworks": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).GetHasOpenAuthorizedNetworks()).ToDataRes(types.Bool)
+	},
 	"gcp.project.sqlService.instance.settings.ipConfiguration.ipv4Enabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).GetIpv4Enabled()).ToDataRes(types.Bool)
 	},
@@ -4877,8 +4886,20 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.gkeService.cluster.masterAuthorizedNetworksConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetMasterAuthorizedNetworksConfig()).ToDataRes(types.Dict)
 	},
+	"gcp.project.gkeService.cluster.masterAuthorizedNetworksEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetMasterAuthorizedNetworksEnabled()).ToDataRes(types.Bool)
+	},
 	"gcp.project.gkeService.cluster.privateClusterConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetPrivateClusterConfig()).ToDataRes(types.Dict)
+	},
+	"gcp.project.gkeService.cluster.privateNodesEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetPrivateNodesEnabled()).ToDataRes(types.Bool)
+	},
+	"gcp.project.gkeService.cluster.privateEndpointEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetPrivateEndpointEnabled()).ToDataRes(types.Bool)
+	},
+	"gcp.project.gkeService.cluster.masterGlobalAccessEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetMasterGlobalAccessEnabled()).ToDataRes(types.Bool)
 	},
 	"gcp.project.gkeService.cluster.databaseEncryption": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetDatabaseEncryption()).ToDataRes(types.Dict)
@@ -13819,6 +13840,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceInstance).NetworkInterfaces, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.instance.hasPublicIp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstance).HasPublicIp, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.instance.privateIpv6GoogleAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstance).PrivateIpv6GoogleAccess, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -14357,6 +14382,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.firewall.sourceRanges": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceFirewall).SourceRanges, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.firewall.openToInternet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceFirewall).OpenToInternet, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.firewall.sourceServiceAccounts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15715,6 +15744,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).AuthorizedNetworks, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.hasOpenAuthorizedNetworks": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).HasOpenAuthorizedNetworks, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gcp.project.sqlService.instance.settings.ipConfiguration.ipv4Enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).Ipv4Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -16531,8 +16564,24 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectGkeServiceCluster).MasterAuthorizedNetworksConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.gkeService.cluster.masterAuthorizedNetworksEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).MasterAuthorizedNetworksEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gcp.project.gkeService.cluster.privateClusterConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceCluster).PrivateClusterConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.privateNodesEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).PrivateNodesEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.privateEndpointEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).PrivateEndpointEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.masterGlobalAccessEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).MasterGlobalAccessEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.gkeService.cluster.databaseEncryption": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31828,6 +31877,7 @@ type mqlGcpProjectComputeServiceInstance struct {
 	Metadata                        plugin.TValue[map[string]any]
 	MinCpuPlatform                  plugin.TValue[string]
 	NetworkInterfaces               plugin.TValue[[]any]
+	HasPublicIp                     plugin.TValue[bool]
 	PrivateIpv6GoogleAccess         plugin.TValue[string]
 	ReservationAffinity             plugin.TValue[any]
 	ResourcePolicies                plugin.TValue[[]any]
@@ -31972,6 +32022,12 @@ func (c *mqlGcpProjectComputeServiceInstance) GetMinCpuPlatform() *plugin.TValue
 
 func (c *mqlGcpProjectComputeServiceInstance) GetNetworkInterfaces() *plugin.TValue[[]any] {
 	return &c.NetworkInterfaces
+}
+
+func (c *mqlGcpProjectComputeServiceInstance) GetHasPublicIp() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasPublicIp, func() (bool, error) {
+		return c.hasPublicIp()
+	})
 }
 
 func (c *mqlGcpProjectComputeServiceInstance) GetPrivateIpv6GoogleAccess() *plugin.TValue[string] {
@@ -32955,6 +33011,7 @@ type mqlGcpProjectComputeServiceFirewall struct {
 	Direction             plugin.TValue[string]
 	Disabled              plugin.TValue[bool]
 	SourceRanges          plugin.TValue[[]any]
+	OpenToInternet        plugin.TValue[bool]
 	SourceServiceAccounts plugin.TValue[[]any]
 	SourceTags            plugin.TValue[[]any]
 	DestinationRanges     plugin.TValue[[]any]
@@ -33035,6 +33092,12 @@ func (c *mqlGcpProjectComputeServiceFirewall) GetDisabled() *plugin.TValue[bool]
 
 func (c *mqlGcpProjectComputeServiceFirewall) GetSourceRanges() *plugin.TValue[[]any] {
 	return &c.SourceRanges
+}
+
+func (c *mqlGcpProjectComputeServiceFirewall) GetOpenToInternet() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.OpenToInternet, func() (bool, error) {
+		return c.openToInternet()
+	})
 }
 
 func (c *mqlGcpProjectComputeServiceFirewall) GetSourceServiceAccounts() *plugin.TValue[[]any] {
@@ -35786,6 +35849,7 @@ type mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration struct {
 	Id                                      plugin.TValue[string]
 	AllocatedIpRange                        plugin.TValue[string]
 	AuthorizedNetworks                      plugin.TValue[[]any]
+	HasOpenAuthorizedNetworks               plugin.TValue[bool]
 	Ipv4Enabled                             plugin.TValue[bool]
 	PrivateNetwork                          plugin.TValue[string]
 	RequireSsl                              plugin.TValue[bool]
@@ -35842,6 +35906,12 @@ func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetAllocatedIpR
 
 func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetAuthorizedNetworks() *plugin.TValue[[]any] {
 	return &c.AuthorizedNetworks
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetHasOpenAuthorizedNetworks() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasOpenAuthorizedNetworks, func() (bool, error) {
+		return c.hasOpenAuthorizedNetworks()
+	})
 }
 
 func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetIpv4Enabled() *plugin.TValue[bool] {
@@ -37480,58 +37550,62 @@ type mqlGcpProjectGkeServiceCluster struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlGcpProjectGkeServiceClusterInternal
-	ProjectId                      plugin.TValue[string]
-	Id                             plugin.TValue[string]
-	Name                           plugin.TValue[string]
-	Description                    plugin.TValue[string]
-	LoggingService                 plugin.TValue[string]
-	MonitoringService              plugin.TValue[string]
-	Network                        plugin.TValue[string]
-	ClusterIpv4Cidr                plugin.TValue[string]
-	Subnetwork                     plugin.TValue[string]
-	NodePools                      plugin.TValue[[]any]
-	Locations                      plugin.TValue[[]any]
-	EnableKubernetesAlpha          plugin.TValue[bool]
-	AutopilotEnabled               plugin.TValue[bool]
-	Location                       plugin.TValue[string]
-	Endpoint                       plugin.TValue[string]
-	InitialClusterVersion          plugin.TValue[string]
-	CurrentMasterVersion           plugin.TValue[string]
-	Status                         plugin.TValue[string]
-	ResourceLabels                 plugin.TValue[map[string]any]
-	Created                        plugin.TValue[*time.Time]
-	ExpirationTime                 plugin.TValue[*time.Time]
-	AddonsConfig                   plugin.TValue[*mqlGcpProjectGkeServiceClusterAddonsConfig]
-	WorkloadIdentityConfig         plugin.TValue[any]
-	IpAllocationPolicy             plugin.TValue[*mqlGcpProjectGkeServiceClusterIpAllocationPolicy]
-	NetworkConfig                  plugin.TValue[*mqlGcpProjectGkeServiceClusterNetworkConfig]
-	BinaryAuthorization            plugin.TValue[any]
-	LegacyAbac                     plugin.TValue[any]
-	MasterAuth                     plugin.TValue[any]
-	MasterAuthorizedNetworksConfig plugin.TValue[any]
-	PrivateClusterConfig           plugin.TValue[any]
-	DatabaseEncryption             plugin.TValue[any]
-	DatabaseEncryptionState        plugin.TValue[string]
-	DatabaseEncryptionKey          plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
-	ShieldedNodesConfig            plugin.TValue[any]
-	CostManagementConfig           plugin.TValue[any]
-	ConfidentialNodesConfig        plugin.TValue[any]
-	IdentityServiceConfig          plugin.TValue[any]
-	NetworkPolicyConfig            plugin.TValue[any]
-	NetworkPolicy                  plugin.TValue[*mqlGcpProjectGkeServiceClusterNetworkPolicy]
-	ReleaseChannel                 plugin.TValue[string]
-	EnableTpu                      plugin.TValue[bool]
-	CurrentNodeCount               plugin.TValue[int64]
-	SecurityPostureConfig          plugin.TValue[*mqlGcpProjectGkeServiceClusterSecurityPostureConfig]
-	MaintenancePolicy              plugin.TValue[*mqlGcpProjectGkeServiceClusterMaintenancePolicy]
-	MeshCertificates               plugin.TValue[any]
-	NotificationConfig             plugin.TValue[*mqlGcpProjectGkeServiceClusterNotificationConfig]
-	Etag                           plugin.TValue[string]
-	InitialNodeCount               plugin.TValue[int64]
-	ServicesIpv4Cidr               plugin.TValue[string]
-	NodeIpv4CidrSize               plugin.TValue[int64]
-	TpuIpv4CidrBlock               plugin.TValue[string]
-	EnabledK8sBetaApis             plugin.TValue[[]any]
+	ProjectId                       plugin.TValue[string]
+	Id                              plugin.TValue[string]
+	Name                            plugin.TValue[string]
+	Description                     plugin.TValue[string]
+	LoggingService                  plugin.TValue[string]
+	MonitoringService               plugin.TValue[string]
+	Network                         plugin.TValue[string]
+	ClusterIpv4Cidr                 plugin.TValue[string]
+	Subnetwork                      plugin.TValue[string]
+	NodePools                       plugin.TValue[[]any]
+	Locations                       plugin.TValue[[]any]
+	EnableKubernetesAlpha           plugin.TValue[bool]
+	AutopilotEnabled                plugin.TValue[bool]
+	Location                        plugin.TValue[string]
+	Endpoint                        plugin.TValue[string]
+	InitialClusterVersion           plugin.TValue[string]
+	CurrentMasterVersion            plugin.TValue[string]
+	Status                          plugin.TValue[string]
+	ResourceLabels                  plugin.TValue[map[string]any]
+	Created                         plugin.TValue[*time.Time]
+	ExpirationTime                  plugin.TValue[*time.Time]
+	AddonsConfig                    plugin.TValue[*mqlGcpProjectGkeServiceClusterAddonsConfig]
+	WorkloadIdentityConfig          plugin.TValue[any]
+	IpAllocationPolicy              plugin.TValue[*mqlGcpProjectGkeServiceClusterIpAllocationPolicy]
+	NetworkConfig                   plugin.TValue[*mqlGcpProjectGkeServiceClusterNetworkConfig]
+	BinaryAuthorization             plugin.TValue[any]
+	LegacyAbac                      plugin.TValue[any]
+	MasterAuth                      plugin.TValue[any]
+	MasterAuthorizedNetworksConfig  plugin.TValue[any]
+	MasterAuthorizedNetworksEnabled plugin.TValue[bool]
+	PrivateClusterConfig            plugin.TValue[any]
+	PrivateNodesEnabled             plugin.TValue[bool]
+	PrivateEndpointEnabled          plugin.TValue[bool]
+	MasterGlobalAccessEnabled       plugin.TValue[bool]
+	DatabaseEncryption              plugin.TValue[any]
+	DatabaseEncryptionState         plugin.TValue[string]
+	DatabaseEncryptionKey           plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
+	ShieldedNodesConfig             plugin.TValue[any]
+	CostManagementConfig            plugin.TValue[any]
+	ConfidentialNodesConfig         plugin.TValue[any]
+	IdentityServiceConfig           plugin.TValue[any]
+	NetworkPolicyConfig             plugin.TValue[any]
+	NetworkPolicy                   plugin.TValue[*mqlGcpProjectGkeServiceClusterNetworkPolicy]
+	ReleaseChannel                  plugin.TValue[string]
+	EnableTpu                       plugin.TValue[bool]
+	CurrentNodeCount                plugin.TValue[int64]
+	SecurityPostureConfig           plugin.TValue[*mqlGcpProjectGkeServiceClusterSecurityPostureConfig]
+	MaintenancePolicy               plugin.TValue[*mqlGcpProjectGkeServiceClusterMaintenancePolicy]
+	MeshCertificates                plugin.TValue[any]
+	NotificationConfig              plugin.TValue[*mqlGcpProjectGkeServiceClusterNotificationConfig]
+	Etag                            plugin.TValue[string]
+	InitialNodeCount                plugin.TValue[int64]
+	ServicesIpv4Cidr                plugin.TValue[string]
+	NodeIpv4CidrSize                plugin.TValue[int64]
+	TpuIpv4CidrBlock                plugin.TValue[string]
+	EnabledK8sBetaApis              plugin.TValue[[]any]
 }
 
 // createGcpProjectGkeServiceCluster creates a new instance of this resource
@@ -37687,8 +37761,24 @@ func (c *mqlGcpProjectGkeServiceCluster) GetMasterAuthorizedNetworksConfig() *pl
 	return &c.MasterAuthorizedNetworksConfig
 }
 
+func (c *mqlGcpProjectGkeServiceCluster) GetMasterAuthorizedNetworksEnabled() *plugin.TValue[bool] {
+	return &c.MasterAuthorizedNetworksEnabled
+}
+
 func (c *mqlGcpProjectGkeServiceCluster) GetPrivateClusterConfig() *plugin.TValue[any] {
 	return &c.PrivateClusterConfig
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetPrivateNodesEnabled() *plugin.TValue[bool] {
+	return &c.PrivateNodesEnabled
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetPrivateEndpointEnabled() *plugin.TValue[bool] {
+	return &c.PrivateEndpointEnabled
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetMasterGlobalAccessEnabled() *plugin.TValue[bool] {
+	return &c.MasterGlobalAccessEnabled
 }
 
 func (c *mqlGcpProjectGkeServiceCluster) GetDatabaseEncryption() *plugin.TValue[any] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -1162,6 +1162,7 @@ gcp.project.computeService.firewall.logConfig 13.7.2
 gcp.project.computeService.firewall.loggingEnabled 11.6.6
 gcp.project.computeService.firewall.name 9.0.0
 gcp.project.computeService.firewall.network 13.1.2
+gcp.project.computeService.firewall.openToInternet 13.12.2
 gcp.project.computeService.firewall.priority 9.0.0
 gcp.project.computeService.firewall.projectId 9.0.0
 gcp.project.computeService.firewall.sourceRanges 9.0.0
@@ -1287,6 +1288,7 @@ gcp.project.computeService.instance.enableSecureBoot 9.0.0
 gcp.project.computeService.instance.enableVtpm 9.0.0
 gcp.project.computeService.instance.fingerprint 9.0.0
 gcp.project.computeService.instance.guestAccelerators 9.0.0
+gcp.project.computeService.instance.hasPublicIp 13.12.2
 gcp.project.computeService.instance.hostname 9.0.0
 gcp.project.computeService.instance.id 9.0.0
 gcp.project.computeService.instance.keyRevocationActionType 9.0.0
@@ -2352,6 +2354,8 @@ gcp.project.gkeService.cluster.maintenancePolicy.recurringWindowStartTime 11.6.6
 gcp.project.gkeService.cluster.maintenancePolicy.resourceVersion 11.6.6
 gcp.project.gkeService.cluster.masterAuth 9.0.0
 gcp.project.gkeService.cluster.masterAuthorizedNetworksConfig 9.0.0
+gcp.project.gkeService.cluster.masterAuthorizedNetworksEnabled 13.12.2
+gcp.project.gkeService.cluster.masterGlobalAccessEnabled 13.12.2
 gcp.project.gkeService.cluster.meshCertificates 13.7.2
 gcp.project.gkeService.cluster.monitoringService 9.0.0
 gcp.project.gkeService.cluster.name 9.0.0
@@ -2482,6 +2486,8 @@ gcp.project.gkeService.cluster.notificationConfig.pubsubEnabled 13.7.2
 gcp.project.gkeService.cluster.notificationConfig.pubsubTopic 13.7.2
 gcp.project.gkeService.cluster.notificationConfig.topic 13.7.2
 gcp.project.gkeService.cluster.privateClusterConfig 9.0.0
+gcp.project.gkeService.cluster.privateEndpointEnabled 13.12.2
+gcp.project.gkeService.cluster.privateNodesEnabled 13.12.2
 gcp.project.gkeService.cluster.projectId 9.0.0
 gcp.project.gkeService.cluster.releaseChannel 9.0.0
 gcp.project.gkeService.cluster.resourceLabels 9.0.0
@@ -3384,6 +3390,7 @@ gcp.project.sqlService.instance.settings.ipConfiguration 9.0.0
 gcp.project.sqlService.instance.settings.ipConfiguration.allocatedIpRange 9.0.0
 gcp.project.sqlService.instance.settings.ipConfiguration.authorizedNetworks 9.0.0
 gcp.project.sqlService.instance.settings.ipConfiguration.enablePrivatePathForGoogleCloudServices 9.0.0
+gcp.project.sqlService.instance.settings.ipConfiguration.hasOpenAuthorizedNetworks 13.12.2
 gcp.project.sqlService.instance.settings.ipConfiguration.id 9.0.0
 gcp.project.sqlService.instance.settings.ipConfiguration.ipv4Enabled 9.0.0
 gcp.project.sqlService.instance.settings.ipConfiguration.privateNetwork 9.0.0

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -542,7 +542,9 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 		}
 
 		var masterAuthorizedNetworksCfg map[string]any
+		var masterAuthorizedNetworksEnabled bool
 		if c.MasterAuthorizedNetworksConfig != nil {
+			masterAuthorizedNetworksEnabled = c.MasterAuthorizedNetworksConfig.Enabled
 			cidrBlocks := make([]any, 0, len(c.MasterAuthorizedNetworksConfig.CidrBlocks))
 			for _, cidrBlock := range c.MasterAuthorizedNetworksConfig.CidrBlocks {
 				cidrBlocks = append(cidrBlocks, map[string]any{
@@ -557,9 +559,13 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 		}
 
 		var privateClusterCfg map[string]any
+		var privateNodesEnabled, privateEndpointEnabled, masterGlobalAccessEnabled bool
 		if c.PrivateClusterConfig != nil {
+			privateNodesEnabled = c.PrivateClusterConfig.EnablePrivateNodes
+			privateEndpointEnabled = c.PrivateClusterConfig.EnablePrivateEndpoint
 			var masterGlobalAccessCfg map[string]any
 			if c.PrivateClusterConfig.MasterGlobalAccessConfig != nil {
+				masterGlobalAccessEnabled = c.PrivateClusterConfig.MasterGlobalAccessConfig.Enabled
 				masterGlobalAccessCfg = map[string]any{
 					"enabled": c.PrivateClusterConfig.MasterGlobalAccessConfig.Enabled,
 				}
@@ -696,55 +702,59 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 		}
 
 		clusterArgs := map[string]*llx.RawData{
-			"projectId":                      llx.StringData(projectId),
-			"id":                             llx.StringData(c.Id),
-			"name":                           llx.StringData(c.Name),
-			"description":                    llx.StringData(c.Description),
-			"loggingService":                 llx.StringData(c.LoggingService),
-			"monitoringService":              llx.StringData(c.MonitoringService),
-			"network":                        llx.StringData(c.Network),
-			"clusterIpv4Cidr":                llx.StringData(c.ClusterIpv4Cidr),
-			"subnetwork":                     llx.StringData(c.Subnetwork),
-			"nodePools":                      llx.ArrayData(nodePools, types.Resource("gcp.project.gkeService.cluster.nodepool")),
-			"locations":                      llx.ArrayData(convert.SliceAnyToInterface(c.Locations), types.String),
-			"enableKubernetesAlpha":          llx.BoolData(c.EnableKubernetesAlpha),
-			"autopilotEnabled":               llx.BoolData(autopilotEnabled),
-			"location":                       llx.StringData(c.Location),
-			"endpoint":                       llx.StringData(c.Endpoint),
-			"initialClusterVersion":          llx.StringData(c.InitialClusterVersion),
-			"currentMasterVersion":           llx.StringData(c.CurrentMasterVersion),
-			"status":                         llx.StringData(c.Status.String()),
-			"resourceLabels":                 llx.MapData(convert.MapToInterfaceMap(c.ResourceLabels), types.String),
-			"created":                        llx.TimeDataPtr(parseTime(c.CreateTime)),
-			"expirationTime":                 llx.TimeDataPtr(parseTime(c.ExpireTime)),
-			"addonsConfig":                   llx.ResourceData(addonsConfig, "gcp.project.gkeService.cluster.addonsConfig"),
-			"workloadIdentityConfig":         llx.DictData(workloadIdCfg),
-			"ipAllocationPolicy":             llx.ResourceData(ipAllocPolicy, "gcp.project.gkeService.cluster.ipAllocationPolicy"),
-			"networkConfig":                  llx.ResourceData(networkConfig, "gcp.project.gkeService.cluster.networkConfig"),
-			"binaryAuthorization":            llx.DictData(binAuth),
-			"legacyAbac":                     llx.DictData(legacyAbac),
-			"masterAuth":                     llx.DictData(masterAuth),
-			"masterAuthorizedNetworksConfig": llx.DictData(masterAuthorizedNetworksCfg),
-			"privateClusterConfig":           llx.DictData(privateClusterCfg),
-			"databaseEncryption":             llx.DictData(databaseEncryption),
-			"databaseEncryptionState":        llx.StringData(databaseEncryptionState),
-			"shieldedNodesConfig":            llx.DictData(shieldedNodesConfig),
-			"costManagementConfig":           llx.DictData(costManagementConfig),
-			"confidentialNodesConfig":        llx.DictData(confidentialNodesConfig),
-			"identityServiceConfig":          llx.DictData(identityServiceConfig),
-			"networkPolicyConfig":            llx.DictData(networkPolicyConfig),
-			"releaseChannel":                 llx.StringData(strings.ToLower(c.ReleaseChannel.GetChannel().String())),
-			"enableTpu":                      llx.BoolData(c.EnableTpu),
-			"currentNodeCount":               llx.IntData(int64(c.CurrentNodeCount)),
-			"securityPostureConfig":          llx.ResourceData(secPostureConfig, "gcp.project.gkeService.cluster.securityPostureConfig"),
-			"maintenancePolicy":              llx.ResourceData(maintenancePolicy, "gcp.project.gkeService.cluster.maintenancePolicy"),
-			"etag":                           llx.StringData(c.Etag),
-			"initialNodeCount":               llx.IntData(int64(c.InitialNodeCount)),
-			"servicesIpv4Cidr":               llx.StringData(c.ServicesIpv4Cidr),
-			"nodeIpv4CidrSize":               llx.IntData(int64(c.NodeIpv4CidrSize)),
-			"tpuIpv4CidrBlock":               llx.StringData(c.TpuIpv4CidrBlock),
-			"enabledK8sBetaApis":             llx.ArrayData(enabledK8sBetaApis, types.String),
-			"meshCertificates":               llx.DictData(meshCertificates),
+			"projectId":                       llx.StringData(projectId),
+			"id":                              llx.StringData(c.Id),
+			"name":                            llx.StringData(c.Name),
+			"description":                     llx.StringData(c.Description),
+			"loggingService":                  llx.StringData(c.LoggingService),
+			"monitoringService":               llx.StringData(c.MonitoringService),
+			"network":                         llx.StringData(c.Network),
+			"clusterIpv4Cidr":                 llx.StringData(c.ClusterIpv4Cidr),
+			"subnetwork":                      llx.StringData(c.Subnetwork),
+			"nodePools":                       llx.ArrayData(nodePools, types.Resource("gcp.project.gkeService.cluster.nodepool")),
+			"locations":                       llx.ArrayData(convert.SliceAnyToInterface(c.Locations), types.String),
+			"enableKubernetesAlpha":           llx.BoolData(c.EnableKubernetesAlpha),
+			"autopilotEnabled":                llx.BoolData(autopilotEnabled),
+			"location":                        llx.StringData(c.Location),
+			"endpoint":                        llx.StringData(c.Endpoint),
+			"initialClusterVersion":           llx.StringData(c.InitialClusterVersion),
+			"currentMasterVersion":            llx.StringData(c.CurrentMasterVersion),
+			"status":                          llx.StringData(c.Status.String()),
+			"resourceLabels":                  llx.MapData(convert.MapToInterfaceMap(c.ResourceLabels), types.String),
+			"created":                         llx.TimeDataPtr(parseTime(c.CreateTime)),
+			"expirationTime":                  llx.TimeDataPtr(parseTime(c.ExpireTime)),
+			"addonsConfig":                    llx.ResourceData(addonsConfig, "gcp.project.gkeService.cluster.addonsConfig"),
+			"workloadIdentityConfig":          llx.DictData(workloadIdCfg),
+			"ipAllocationPolicy":              llx.ResourceData(ipAllocPolicy, "gcp.project.gkeService.cluster.ipAllocationPolicy"),
+			"networkConfig":                   llx.ResourceData(networkConfig, "gcp.project.gkeService.cluster.networkConfig"),
+			"binaryAuthorization":             llx.DictData(binAuth),
+			"legacyAbac":                      llx.DictData(legacyAbac),
+			"masterAuth":                      llx.DictData(masterAuth),
+			"masterAuthorizedNetworksConfig":  llx.DictData(masterAuthorizedNetworksCfg),
+			"masterAuthorizedNetworksEnabled": llx.BoolData(masterAuthorizedNetworksEnabled),
+			"privateClusterConfig":            llx.DictData(privateClusterCfg),
+			"privateNodesEnabled":             llx.BoolData(privateNodesEnabled),
+			"privateEndpointEnabled":          llx.BoolData(privateEndpointEnabled),
+			"masterGlobalAccessEnabled":       llx.BoolData(masterGlobalAccessEnabled),
+			"databaseEncryption":              llx.DictData(databaseEncryption),
+			"databaseEncryptionState":         llx.StringData(databaseEncryptionState),
+			"shieldedNodesConfig":             llx.DictData(shieldedNodesConfig),
+			"costManagementConfig":            llx.DictData(costManagementConfig),
+			"confidentialNodesConfig":         llx.DictData(confidentialNodesConfig),
+			"identityServiceConfig":           llx.DictData(identityServiceConfig),
+			"networkPolicyConfig":             llx.DictData(networkPolicyConfig),
+			"releaseChannel":                  llx.StringData(strings.ToLower(c.ReleaseChannel.GetChannel().String())),
+			"enableTpu":                       llx.BoolData(c.EnableTpu),
+			"currentNodeCount":                llx.IntData(int64(c.CurrentNodeCount)),
+			"securityPostureConfig":           llx.ResourceData(secPostureConfig, "gcp.project.gkeService.cluster.securityPostureConfig"),
+			"maintenancePolicy":               llx.ResourceData(maintenancePolicy, "gcp.project.gkeService.cluster.maintenancePolicy"),
+			"etag":                            llx.StringData(c.Etag),
+			"initialNodeCount":                llx.IntData(int64(c.InitialNodeCount)),
+			"servicesIpv4Cidr":                llx.StringData(c.ServicesIpv4Cidr),
+			"nodeIpv4CidrSize":                llx.IntData(int64(c.NodeIpv4CidrSize)),
+			"tpuIpv4CidrBlock":                llx.StringData(c.TpuIpv4CidrBlock),
+			"enabledK8sBetaApis":              llx.ArrayData(enabledK8sBetaApis, types.String),
+			"meshCertificates":                llx.DictData(meshCertificates),
 		}
 		if notificationConfig != nil {
 			clusterArgs["notificationConfig"] = llx.ResourceData(notificationConfig, "gcp.project.gkeService.cluster.notificationConfig")

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -715,6 +715,23 @@ func (g *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) id() (string, e
 	return g.Id.Data, g.Id.Error
 }
 
+func (g *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) hasOpenAuthorizedNetworks() (bool, error) {
+	if g.AuthorizedNetworks.Error != nil {
+		return false, g.AuthorizedNetworks.Error
+	}
+	for _, n := range g.AuthorizedNetworks.Data {
+		entry, ok := n.(map[string]any)
+		if !ok {
+			continue
+		}
+		value, _ := entry["value"].(string)
+		if value == "0.0.0.0/0" || value == "::/0" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (g *mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig) id() (string, error) {
 	return g.Id.Data, g.Id.Error
 }


### PR DESCRIPTION
## Summary

Adds 7 derived/hoisted fields on the GCP provider so common CIS-style "is this thing publicly exposed?" checks are one-liners instead of dict drill-downs.

| Resource | New field | Returns |
|---|---|---|
| `gcp.project.computeService.firewall` | `openToInternet() bool` | `true` when direction=INGRESS, not disabled, has allow rules, and sourceRanges contains `0.0.0.0/0` or `::/0` |
| `gcp.project.computeService.instance` | `hasPublicIp() bool` | `true` when any network interface has a non-empty accessConfigs list |
| `gcp.project.gkeService.cluster` | `privateNodesEnabled bool` | hoisted from `privateClusterConfig.enablePrivateNodes` |
| `gcp.project.gkeService.cluster` | `privateEndpointEnabled bool` | hoisted from `privateClusterConfig.enablePrivateEndpoint` |
| `gcp.project.gkeService.cluster` | `masterGlobalAccessEnabled bool` | hoisted from `privateClusterConfig.masterGlobalAccessConfig.enabled` |
| `gcp.project.gkeService.cluster` | `masterAuthorizedNetworksEnabled bool` | hoisted from `masterAuthorizedNetworksConfig.enabled` |
| `gcp.project.sqlService.instance.settings.ipConfiguration` | `hasOpenAuthorizedNetworks() bool` | `true` when any authorized network entry uses `0.0.0.0/0` or `::/0` |

The existing `privateClusterConfig` and `masterAuthorizedNetworksConfig` dicts are kept as-is for full-fidelity data access — these scalars just give clean accessors for the security-critical bits. All new entries land at provider version `13.12.2` in `gcp.lr.versions`.

### Why these specific fields

Each is a frequently-cited GCP CIS Benchmark / Security Health Analytics finding. Before this change, an audit query had to traverse nested dicts (`cluster.privateClusterConfig.enablePrivateNodes`) or evaluate list contents in MQL (`firewall.sourceRanges.contains("0.0.0.0/0")` plus and-logic for direction/enabled/allow). After this, queries read like the audit rule itself:

```mql
gcp.project.computeService.firewalls.where(_.openToInternet)
gcp.project.computeService.instances.where(_.hasPublicIp)
gcp.project.gkeService.clusters.all(_.privateNodesEnabled)
gcp.project.sqlService.instances.none(_.settings.ipConfiguration.hasOpenAuthorizedNetworks)
```

### Note on deprecated SDK fields

The four GKE scalars are derived from `PrivateClusterConfig` / `MasterAuthorizedNetworksConfig` proto fields that the container SDK has marked deprecated in favor of `ControlPlaneEndpointsConfig`. The existing dict-population code already reads these deprecated sources, so the new scalars match its behavior 1:1. Migrating the underlying source to `ControlPlaneEndpointsConfig` (and adding `EnablePublicEndpoint` semantics) is a separate follow-up.

## Test plan
- [x] `mqlr generate` produces 7 new entries at `13.12.2` in `gcp.lr.versions`
- [x] `make providers/build/gcp` succeeds; resource registry contains all 7 names
- [x] `make providers/install/gcp` and live query against `tim-learning-project`:
  - `firewalls { openToInternet }` returns `true` for default-allow-{icmp,rdp,ssh} (sourceRanges `0.0.0.0/0`) and `false` for default-allow-internal (`10.128.0.0/9`)
  - `sqlService.instances { settings.ipConfiguration.hasOpenAuthorizedNetworks }` returns `false` (no `0.0.0.0/0` configured)
  - `--info` confirms `hasPublicIp`, `privateNodesEnabled`, `privateEndpointEnabled`, `masterGlobalAccessEnabled`, `masterAuthorizedNetworksEnabled` resolve as `type=bool`
- [x] `gofmt` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)