### PR TITLE
✨ GCP: surface public-access and key-hygiene scalars for CIS audits

### DIFF
--- a/providers/gcp/resources/apikeys.go
+++ b/providers/gcp/resources/apikeys.go
@@ -227,6 +227,29 @@ func (g *mqlGcpProjectApiKeyRestrictions) id() (string, error) {
 	return fmt.Sprintf("%s/restrictions", g.ParentResourcePath.Data), nil
 }
 
+func (g *mqlGcpProjectApiKeyRestrictions) unrestricted() (bool, error) {
+	if g.AndroidKeyRestrictions.Error != nil {
+		return false, g.AndroidKeyRestrictions.Error
+	}
+	if g.BrowserKeyRestrictions.Error != nil {
+		return false, g.BrowserKeyRestrictions.Error
+	}
+	if g.IosKeyRestrictions.Error != nil {
+		return false, g.IosKeyRestrictions.Error
+	}
+	if g.ServerKeyRestrictions.Error != nil {
+		return false, g.ServerKeyRestrictions.Error
+	}
+	if g.ApiTargets.Error != nil {
+		return false, g.ApiTargets.Error
+	}
+	return g.AndroidKeyRestrictions.Data == nil &&
+		g.BrowserKeyRestrictions.Data == nil &&
+		g.IosKeyRestrictions.Data == nil &&
+		g.ServerKeyRestrictions.Data == nil &&
+		len(g.ApiTargets.Data) == 0, nil
+}
+
 // Always bootstrap through the parent key. apiKeys() populates restrictions
 // via CreateResource (which bypasses Init), so any NewResource call here is
 // a top-level `gcp.project.apiKey.restrictions` query — partial args would

--- a/providers/gcp/resources/bigquery.go
+++ b/providers/gcp/resources/bigquery.go
@@ -214,6 +214,27 @@ func (g *mqlGcpProjectBigqueryServiceDataset) getClient() (*bigquery.Client, err
 	return g.client, g.clientErr
 }
 
+func (g *mqlGcpProjectBigqueryServiceDataset) public() (bool, error) {
+	access := g.GetAccess()
+	if access.Error != nil {
+		return false, access.Error
+	}
+	for _, raw := range access.Data {
+		entry, ok := raw.(*mqlGcpProjectBigqueryServiceDatasetAccessEntry)
+		if !ok || entry == nil {
+			continue
+		}
+		entity := entry.GetEntity()
+		if entity.Error != nil {
+			return false, entity.Error
+		}
+		if isPublicMember(entity.Data) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (g *mqlGcpProjectBigqueryServiceDataset) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error

--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -953,6 +953,20 @@ func mqlContainers(runtime *plugin.Runtime, containers []*runpb.Container, templ
 	return mqlContainers, nil
 }
 
+func (g *mqlGcpProjectCloudRunServiceService) publicInvocable() (bool, error) {
+	if g.Ingress.Error != nil {
+		return false, g.Ingress.Error
+	}
+	if g.Ingress.Data != "INGRESS_TRAFFIC_ALL" {
+		return false, nil
+	}
+	bindings := g.GetIamPolicy()
+	if bindings.Error != nil {
+		return false, bindings.Error
+	}
+	return iamPolicyHasPublicMember(bindings.Data)
+}
+
 func mqlVolumes(volumes []*runpb.Volume) []any {
 	mqlVolumes := make([]any, 0, len(volumes))
 	for _, v := range volumes {

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -3272,3 +3272,19 @@ func (g *mqlGcpProjectComputeServiceSnapshot) iamPolicy() ([]any, error) {
 	}
 	return computeIamBindingsToResources(g.MqlRuntime, name, policy.Bindings)
 }
+
+func (g *mqlGcpProjectComputeServiceSnapshot) public() (bool, error) {
+	bindings := g.GetIamPolicy()
+	if bindings.Error != nil {
+		return false, bindings.Error
+	}
+	return iamPolicyHasPublicMember(bindings.Data)
+}
+
+func (g *mqlGcpProjectComputeServiceImage) public() (bool, error) {
+	bindings := g.GetIamPolicy()
+	if bindings.Error != nil {
+		return false, bindings.Error
+	}
+	return iamPolicyHasPublicMember(bindings.Data)
+}

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -1144,6 +1144,8 @@ private gcp.project.computeService.snapshot @defaults("name") {
   sourceSnapshotSchedulePolicyId string
   // IAM policy bindings for this snapshot (includes allUsers / allAuthenticatedUsers grants when the snapshot is publicly shared)
   iamPolicy() []gcp.resourcemanager.binding
+  // Whether the snapshot's IAM policy grants any role to allUsers or allAuthenticatedUsers
+  public() bool
 }
 
 // Google Cloud (GCP) Compute
@@ -1188,6 +1190,8 @@ private gcp.project.computeService.image @defaults("id name") {
   sourceSnapshot() gcp.project.computeService.snapshot
   // IAM policy bindings for this image (includes allUsers / allAuthenticatedUsers grants when the image is publicly shared)
   iamPolicy() []gcp.resourcemanager.binding
+  // Whether the image's IAM policy grants any role to allUsers or allAuthenticatedUsers
+  public() bool
 }
 
 // Google Cloud (GCP) Compute firewall
@@ -2058,6 +2062,8 @@ private gcp.project.bigqueryService.dataset @defaults("id name") {
   kmsName string
   // Access permissions
   access []gcp.project.bigqueryService.dataset.accessEntry
+  // Whether any access entry grants the dataset to allUsers or allAuthenticatedUsers
+  public() bool
   // Default expiration time (in milliseconds) for tables in the dataset
   defaultTableExpirationMs int
   // Returns tables in the dataset
@@ -2895,6 +2901,8 @@ private gcp.project.pubsubService.topic @defaults("name") {
   config() gcp.project.pubsubService.topic.config
   // IAM policy for this topic
   iamPolicy() []gcp.resourcemanager.binding
+  // Whether the topic's IAM policy grants any role to allUsers or allAuthenticatedUsers
+  public() bool
 }
 
 // Google Cloud (GCP) Pub/Sub topic configuration
@@ -2951,6 +2959,8 @@ private gcp.project.pubsubService.subscription @defaults("name") {
   config() gcp.project.pubsubService.subscription.config
   // IAM policy for this subscription
   iamPolicy() []gcp.resourcemanager.binding
+  // Whether the subscription's IAM policy grants any role to allUsers or allAuthenticatedUsers
+  public() bool
 }
 
 // Google Cloud (GCP) Pub/Sub subscription configuration
@@ -3089,6 +3099,8 @@ private gcp.project.kmsService.keyring.cryptokey @defaults("name purpose") {
   versions() []gcp.project.kmsService.keyring.cryptokey.version
   // Crypto key IAM policy
   iamPolicy() []gcp.resourcemanager.binding
+  // Whether the key's IAM policy grants any role to allUsers or allAuthenticatedUsers
+  public() bool
 }
 
 // Google Cloud (GCP) KMS crypto key version
@@ -3223,6 +3235,8 @@ private gcp.project.apiKey.restrictions {
   iosKeyRestrictions dict
   // The IP addresses that are allowed to use the key
   serverKeyRestrictions dict
+  // Whether the API key has no restrictions configured (no app/IP/referrer/API target restriction). CIS flags unrestricted keys.
+  unrestricted() bool
 }
 
 // Google Cloud (GCP) Logging resources
@@ -3413,6 +3427,8 @@ private gcp.project.iamService.serviceAccount.key @defaults("name") {
   keyOrigin string
   // Key type
   keyType string
+  // Whether the key is user-managed (true when keyType == USER_MANAGED). User-managed keys are typically the audit hot spot.
+  userManaged bool
   // Whether the key is disabled
   disabled bool
 }
@@ -3962,6 +3978,8 @@ private gcp.project.cloudRunService.service @defaults("name") {
   etag string
   // IAM policy bindings for this Cloud Run service
   iamPolicy() []gcp.resourcemanager.binding
+  // Whether the service is reachable from the public internet: ingress allows all traffic AND IAM grants invoke to allUsers or allAuthenticatedUsers
+  publicInvocable() bool
 }
 
 // Google Cloud (GCP) Run service revision template

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -3287,6 +3287,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.snapshot.iamPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSnapshot).GetIamPolicy()).ToDataRes(types.Array(types.Resource("gcp.resourcemanager.binding")))
 	},
+	"gcp.project.computeService.snapshot.public": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceSnapshot).GetPublic()).ToDataRes(types.Bool)
+	},
 	"gcp.project.computeService.image.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceImage).GetId()).ToDataRes(types.String)
 	},
@@ -3346,6 +3349,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.image.iamPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceImage).GetIamPolicy()).ToDataRes(types.Array(types.Resource("gcp.resourcemanager.binding")))
+	},
+	"gcp.project.computeService.image.public": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceImage).GetPublic()).ToDataRes(types.Bool)
 	},
 	"gcp.project.computeService.firewall.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceFirewall).GetId()).ToDataRes(types.String)
@@ -4436,6 +4442,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.bigqueryService.dataset.access": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigqueryServiceDataset).GetAccess()).ToDataRes(types.Array(types.Resource("gcp.project.bigqueryService.dataset.accessEntry")))
 	},
+	"gcp.project.bigqueryService.dataset.public": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBigqueryServiceDataset).GetPublic()).ToDataRes(types.Bool)
+	},
 	"gcp.project.bigqueryService.dataset.defaultTableExpirationMs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigqueryServiceDataset).GetDefaultTableExpirationMs()).ToDataRes(types.Int)
 	},
@@ -5453,6 +5462,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.pubsubService.topic.iamPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectPubsubServiceTopic).GetIamPolicy()).ToDataRes(types.Array(types.Resource("gcp.resourcemanager.binding")))
 	},
+	"gcp.project.pubsubService.topic.public": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectPubsubServiceTopic).GetPublic()).ToDataRes(types.Bool)
+	},
 	"gcp.project.pubsubService.topic.config.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectPubsubServiceTopicConfig).GetProjectId()).ToDataRes(types.String)
 	},
@@ -5512,6 +5524,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.pubsubService.subscription.iamPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectPubsubServiceSubscription).GetIamPolicy()).ToDataRes(types.Array(types.Resource("gcp.resourcemanager.binding")))
+	},
+	"gcp.project.pubsubService.subscription.public": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectPubsubServiceSubscription).GetPublic()).ToDataRes(types.Bool)
 	},
 	"gcp.project.pubsubService.subscription.config.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectPubsubServiceSubscriptionConfig).GetProjectId()).ToDataRes(types.String)
@@ -5678,6 +5693,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.kmsService.keyring.cryptokey.iamPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokey).GetIamPolicy()).ToDataRes(types.Array(types.Resource("gcp.resourcemanager.binding")))
 	},
+	"gcp.project.kmsService.keyring.cryptokey.public": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokey).GetPublic()).ToDataRes(types.Bool)
+	},
 	"gcp.project.kmsService.keyring.cryptokey.version.resourcePath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokeyVersion).GetResourcePath()).ToDataRes(types.String)
 	},
@@ -5830,6 +5848,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.apiKey.restrictions.serverKeyRestrictions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectApiKeyRestrictions).GetServerKeyRestrictions()).ToDataRes(types.Dict)
+	},
+	"gcp.project.apiKey.restrictions.unrestricted": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectApiKeyRestrictions).GetUnrestricted()).ToDataRes(types.Bool)
 	},
 	"gcp.project.loggingservice.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectLoggingservice).GetProjectId()).ToDataRes(types.String)
@@ -6049,6 +6070,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.iamService.serviceAccount.key.keyType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectIamServiceServiceAccountKey).GetKeyType()).ToDataRes(types.String)
+	},
+	"gcp.project.iamService.serviceAccount.key.userManaged": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectIamServiceServiceAccountKey).GetUserManaged()).ToDataRes(types.Bool)
 	},
 	"gcp.project.iamService.serviceAccount.key.disabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectIamServiceServiceAccountKey).GetDisabled()).ToDataRes(types.Bool)
@@ -6742,6 +6766,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.cloudRunService.service.iamPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceService).GetIamPolicy()).ToDataRes(types.Array(types.Resource("gcp.resourcemanager.binding")))
+	},
+	"gcp.project.cloudRunService.service.publicInvocable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudRunServiceService).GetPublicInvocable()).ToDataRes(types.Bool)
 	},
 	"gcp.project.cloudRunService.service.revisionTemplate.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceServiceRevisionTemplate).GetId()).ToDataRes(types.String)
@@ -14264,6 +14291,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceSnapshot).IamPolicy, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.snapshot.public": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceSnapshot).Public, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.image.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceImage).__id, ok = v.Value.(string)
 		return
@@ -14346,6 +14377,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.image.iamPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceImage).IamPolicy, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.image.public": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceImage).Public, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.firewall.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15916,6 +15951,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectBigqueryServiceDataset).Access, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.bigqueryService.dataset.public": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBigqueryServiceDataset).Public, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gcp.project.bigqueryService.dataset.defaultTableExpirationMs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectBigqueryServiceDataset).DefaultTableExpirationMs, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
@@ -17424,6 +17463,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectPubsubServiceTopic).IamPolicy, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.pubsubService.topic.public": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectPubsubServiceTopic).Public, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gcp.project.pubsubService.topic.config.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectPubsubServiceTopicConfig).__id, ok = v.Value.(string)
 		return
@@ -17518,6 +17561,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.pubsubService.subscription.iamPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectPubsubServiceSubscription).IamPolicy, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.pubsubService.subscription.public": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectPubsubServiceSubscription).Public, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.pubsubService.subscription.config.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -17768,6 +17815,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectKmsServiceKeyringCryptokey).IamPolicy, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.kmsService.keyring.cryptokey.public": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectKmsServiceKeyringCryptokey).Public, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gcp.project.kmsService.keyring.cryptokey.version.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectKmsServiceKeyringCryptokeyVersion).__id, ok = v.Value.(string)
 		return
@@ -18002,6 +18053,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.apiKey.restrictions.serverKeyRestrictions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectApiKeyRestrictions).ServerKeyRestrictions, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.apiKey.restrictions.unrestricted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectApiKeyRestrictions).Unrestricted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.loggingservice.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -18338,6 +18393,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.iamService.serviceAccount.key.keyType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectIamServiceServiceAccountKey).KeyType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.iamService.serviceAccount.key.userManaged": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectIamServiceServiceAccountKey).UserManaged, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.iamService.serviceAccount.key.disabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -19350,6 +19409,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.cloudRunService.service.iamPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudRunServiceService).IamPolicy, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.cloudRunService.service.publicInvocable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudRunServiceService).PublicInvocable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.cloudRunService.service.revisionTemplate.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -32655,6 +32718,7 @@ type mqlGcpProjectComputeServiceSnapshot struct {
 	SourceSnapshotSchedulePolicy   plugin.TValue[string]
 	SourceSnapshotSchedulePolicyId plugin.TValue[string]
 	IamPolicy                      plugin.TValue[[]any]
+	Public                         plugin.TValue[bool]
 }
 
 // createGcpProjectComputeServiceSnapshot creates a new instance of this resource
@@ -32806,6 +32870,12 @@ func (c *mqlGcpProjectComputeServiceSnapshot) GetIamPolicy() *plugin.TValue[[]an
 	})
 }
 
+func (c *mqlGcpProjectComputeServiceSnapshot) GetPublic() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Public, func() (bool, error) {
+		return c.public()
+	})
+}
+
 // mqlGcpProjectComputeServiceImage for the gcp.project.computeService.image resource
 type mqlGcpProjectComputeServiceImage struct {
 	MqlRuntime *plugin.Runtime
@@ -32831,6 +32901,7 @@ type mqlGcpProjectComputeServiceImage struct {
 	SourceImage               plugin.TValue[*mqlGcpProjectComputeServiceImage]
 	SourceSnapshot            plugin.TValue[*mqlGcpProjectComputeServiceSnapshot]
 	IamPolicy                 plugin.TValue[[]any]
+	Public                    plugin.TValue[bool]
 }
 
 // createGcpProjectComputeServiceImage creates a new instance of this resource
@@ -32995,6 +33066,12 @@ func (c *mqlGcpProjectComputeServiceImage) GetIamPolicy() *plugin.TValue[[]any] 
 		}
 
 		return c.iamPolicy()
+	})
+}
+
+func (c *mqlGcpProjectComputeServiceImage) GetPublic() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Public, func() (bool, error) {
+		return c.public()
 	})
 }
 
@@ -36265,6 +36342,7 @@ type mqlGcpProjectBigqueryServiceDataset struct {
 	Tags                         plugin.TValue[map[string]any]
 	KmsName                      plugin.TValue[string]
 	Access                       plugin.TValue[[]any]
+	Public                       plugin.TValue[bool]
 	DefaultTableExpirationMs     plugin.TValue[int64]
 	Tables                       plugin.TValue[[]any]
 	Models                       plugin.TValue[[]any]
@@ -36355,6 +36433,12 @@ func (c *mqlGcpProjectBigqueryServiceDataset) GetKmsName() *plugin.TValue[string
 
 func (c *mqlGcpProjectBigqueryServiceDataset) GetAccess() *plugin.TValue[[]any] {
 	return &c.Access
+}
+
+func (c *mqlGcpProjectBigqueryServiceDataset) GetPublic() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Public, func() (bool, error) {
+		return c.public()
+	})
 }
 
 func (c *mqlGcpProjectBigqueryServiceDataset) GetDefaultTableExpirationMs() *plugin.TValue[int64] {
@@ -39890,6 +39974,7 @@ type mqlGcpProjectPubsubServiceTopic struct {
 	Name      plugin.TValue[string]
 	Config    plugin.TValue[*mqlGcpProjectPubsubServiceTopicConfig]
 	IamPolicy plugin.TValue[[]any]
+	Public    plugin.TValue[bool]
 }
 
 // createGcpProjectPubsubServiceTopic creates a new instance of this resource
@@ -39966,6 +40051,12 @@ func (c *mqlGcpProjectPubsubServiceTopic) GetIamPolicy() *plugin.TValue[[]any] {
 		}
 
 		return c.iamPolicy()
+	})
+}
+
+func (c *mqlGcpProjectPubsubServiceTopic) GetPublic() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Public, func() (bool, error) {
+		return c.public()
 	})
 }
 
@@ -40202,6 +40293,7 @@ type mqlGcpProjectPubsubServiceSubscription struct {
 	Name      plugin.TValue[string]
 	Config    plugin.TValue[*mqlGcpProjectPubsubServiceSubscriptionConfig]
 	IamPolicy plugin.TValue[[]any]
+	Public    plugin.TValue[bool]
 }
 
 // createGcpProjectPubsubServiceSubscription creates a new instance of this resource
@@ -40278,6 +40370,12 @@ func (c *mqlGcpProjectPubsubServiceSubscription) GetIamPolicy() *plugin.TValue[[
 		}
 
 		return c.iamPolicy()
+	})
+}
+
+func (c *mqlGcpProjectPubsubServiceSubscription) GetPublic() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Public, func() (bool, error) {
+		return c.public()
 	})
 }
 
@@ -40803,6 +40901,7 @@ type mqlGcpProjectKmsServiceKeyringCryptokey struct {
 	KeyAccessJustificationsPolicy plugin.TValue[any]
 	Versions                      plugin.TValue[[]any]
 	IamPolicy                     plugin.TValue[[]any]
+	Public                        plugin.TValue[bool]
 }
 
 // createGcpProjectKmsServiceKeyringCryptokey creates a new instance of this resource
@@ -40923,6 +41022,12 @@ func (c *mqlGcpProjectKmsServiceKeyringCryptokey) GetIamPolicy() *plugin.TValue[
 		}
 
 		return c.iamPolicy()
+	})
+}
+
+func (c *mqlGcpProjectKmsServiceKeyringCryptokey) GetPublic() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Public, func() (bool, error) {
+		return c.public()
 	})
 }
 
@@ -41470,6 +41575,7 @@ type mqlGcpProjectApiKeyRestrictions struct {
 	BrowserKeyRestrictions plugin.TValue[any]
 	IosKeyRestrictions     plugin.TValue[any]
 	ServerKeyRestrictions  plugin.TValue[any]
+	Unrestricted           plugin.TValue[bool]
 }
 
 // createGcpProjectApiKeyRestrictions creates a new instance of this resource
@@ -41531,6 +41637,12 @@ func (c *mqlGcpProjectApiKeyRestrictions) GetIosKeyRestrictions() *plugin.TValue
 
 func (c *mqlGcpProjectApiKeyRestrictions) GetServerKeyRestrictions() *plugin.TValue[any] {
 	return &c.ServerKeyRestrictions
+}
+
+func (c *mqlGcpProjectApiKeyRestrictions) GetUnrestricted() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Unrestricted, func() (bool, error) {
+		return c.unrestricted()
+	})
 }
 
 // mqlGcpProjectLoggingservice for the gcp.project.loggingservice resource
@@ -42441,6 +42553,7 @@ type mqlGcpProjectIamServiceServiceAccountKey struct {
 	ValidBeforeTime plugin.TValue[*time.Time]
 	KeyOrigin       plugin.TValue[string]
 	KeyType         plugin.TValue[string]
+	UserManaged     plugin.TValue[bool]
 	Disabled        plugin.TValue[bool]
 }
 
@@ -42503,6 +42616,10 @@ func (c *mqlGcpProjectIamServiceServiceAccountKey) GetKeyOrigin() *plugin.TValue
 
 func (c *mqlGcpProjectIamServiceServiceAccountKey) GetKeyType() *plugin.TValue[string] {
 	return &c.KeyType
+}
+
+func (c *mqlGcpProjectIamServiceServiceAccountKey) GetUserManaged() *plugin.TValue[bool] {
+	return &c.UserManaged
 }
 
 func (c *mqlGcpProjectIamServiceServiceAccountKey) GetDisabled() *plugin.TValue[bool] {
@@ -44592,6 +44709,7 @@ type mqlGcpProjectCloudRunServiceService struct {
 	Uid                   plugin.TValue[string]
 	Etag                  plugin.TValue[string]
 	IamPolicy             plugin.TValue[[]any]
+	PublicInvocable       plugin.TValue[bool]
 }
 
 // createGcpProjectCloudRunServiceService creates a new instance of this resource
@@ -44772,6 +44890,12 @@ func (c *mqlGcpProjectCloudRunServiceService) GetIamPolicy() *plugin.TValue[[]an
 		}
 
 		return c.iamPolicy()
+	})
+}
+
+func (c *mqlGcpProjectCloudRunServiceService) GetPublicInvocable() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.PublicInvocable, func() (bool, error) {
+		return c.publicInvocable()
 	})
 }
 

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -205,6 +205,7 @@ gcp.project.apiKey.restrictions.browserKeyRestrictions 9.0.0
 gcp.project.apiKey.restrictions.iosKeyRestrictions 9.0.0
 gcp.project.apiKey.restrictions.parentResourcePath 9.0.0
 gcp.project.apiKey.restrictions.serverKeyRestrictions 9.0.0
+gcp.project.apiKey.restrictions.unrestricted 13.12.2
 gcp.project.apiKey.updated 9.0.0
 gcp.project.apiKeys 9.0.0
 gcp.project.appEngine 11.6.6
@@ -429,6 +430,7 @@ gcp.project.bigqueryService.dataset.models 9.0.0
 gcp.project.bigqueryService.dataset.modified 9.0.0
 gcp.project.bigqueryService.dataset.name 9.0.0
 gcp.project.bigqueryService.dataset.projectId 9.0.0
+gcp.project.bigqueryService.dataset.public 13.12.2
 gcp.project.bigqueryService.dataset.routines 9.0.0
 gcp.project.bigqueryService.dataset.storageBillingModel 13.1.2
 gcp.project.bigqueryService.dataset.tables 9.0.0
@@ -930,6 +932,7 @@ gcp.project.cloudRunService.service.launchStage 9.0.0
 gcp.project.cloudRunService.service.name 9.0.0
 gcp.project.cloudRunService.service.observedGeneration 9.0.0
 gcp.project.cloudRunService.service.projectId 9.0.0
+gcp.project.cloudRunService.service.publicInvocable 13.12.2
 gcp.project.cloudRunService.service.reconciling 9.0.0
 gcp.project.cloudRunService.service.region 9.0.0
 gcp.project.cloudRunService.service.revisionTemplate 9.0.0
@@ -1266,6 +1269,7 @@ gcp.project.computeService.image.labels 9.0.0
 gcp.project.computeService.image.licenses 9.0.0
 gcp.project.computeService.image.name 9.0.0
 gcp.project.computeService.image.projectId 9.0.0
+gcp.project.computeService.image.public 13.12.2
 gcp.project.computeService.image.satisfiesPzi 11.6.6
 gcp.project.computeService.image.satisfiesPzs 11.6.6
 gcp.project.computeService.image.sourceDisk 13.1.2
@@ -1651,6 +1655,7 @@ gcp.project.computeService.snapshot.labels 9.0.0
 gcp.project.computeService.snapshot.licenses 9.0.0
 gcp.project.computeService.snapshot.name 9.0.0
 gcp.project.computeService.snapshot.projectId 13.10.1
+gcp.project.computeService.snapshot.public 13.12.2
 gcp.project.computeService.snapshot.satisfiesPzi 11.6.6
 gcp.project.computeService.snapshot.satisfiesPzs 11.6.6
 gcp.project.computeService.snapshot.snapshotType 9.0.0
@@ -2527,6 +2532,7 @@ gcp.project.iamService.serviceAccount.key.keyAlgorithm 9.0.0
 gcp.project.iamService.serviceAccount.key.keyOrigin 9.0.0
 gcp.project.iamService.serviceAccount.key.keyType 9.0.0
 gcp.project.iamService.serviceAccount.key.name 9.0.0
+gcp.project.iamService.serviceAccount.key.userManaged 13.12.2
 gcp.project.iamService.serviceAccount.key.validAfterTime 9.0.0
 gcp.project.iamService.serviceAccount.key.validBeforeTime 9.0.0
 gcp.project.iamService.serviceAccount.keys 9.0.0
@@ -2585,6 +2591,7 @@ gcp.project.kmsService.keyring.cryptokey.labels 9.0.0
 gcp.project.kmsService.keyring.cryptokey.name 9.0.0
 gcp.project.kmsService.keyring.cryptokey.nextRotation 9.0.0
 gcp.project.kmsService.keyring.cryptokey.primary 9.0.0
+gcp.project.kmsService.keyring.cryptokey.public 13.12.2
 gcp.project.kmsService.keyring.cryptokey.purpose 9.0.0
 gcp.project.kmsService.keyring.cryptokey.resourcePath 9.0.0
 gcp.project.kmsService.keyring.cryptokey.rotationPeriod 9.0.0
@@ -2956,6 +2963,7 @@ gcp.project.pubsubService.subscription.config.topicMessageRetentionDuration 11.6
 gcp.project.pubsubService.subscription.iamPolicy 11.0.146
 gcp.project.pubsubService.subscription.name 9.0.0
 gcp.project.pubsubService.subscription.projectId 9.0.0
+gcp.project.pubsubService.subscription.public 13.12.2
 gcp.project.pubsubService.subscriptions 9.0.0
 gcp.project.pubsubService.topic 9.0.0
 gcp.project.pubsubService.topic.config 9.0.0
@@ -2979,6 +2987,7 @@ gcp.project.pubsubService.topic.config.topicName 9.0.0
 gcp.project.pubsubService.topic.iamPolicy 11.0.146
 gcp.project.pubsubService.topic.name 9.0.0
 gcp.project.pubsubService.topic.projectId 9.0.0
+gcp.project.pubsubService.topic.public 13.12.2
 gcp.project.pubsubService.topics 9.0.0
 gcp.project.recommendations 9.0.0
 gcp.project.redis 11.0.79

--- a/providers/gcp/resources/iam.go
+++ b/providers/gcp/resources/iam.go
@@ -278,13 +278,15 @@ func (g *mqlGcpProjectIamServiceServiceAccount) keys() ([]any, error) {
 	}
 	mqlKeys := make([]any, 0, len(resp.Keys))
 	for _, k := range resp.Keys {
+		keyType := k.KeyType.String()
 		mqlKey, err := CreateResource(g.MqlRuntime, "gcp.project.iamService.serviceAccount.key", map[string]*llx.RawData{
 			"name":            llx.StringData(k.Name),
 			"keyAlgorithm":    llx.StringData(k.KeyAlgorithm.String()),
 			"validAfterTime":  llx.TimeDataPtr(timestampAsTimePtr(k.ValidAfterTime)),
 			"validBeforeTime": llx.TimeDataPtr(timestampAsTimePtr(k.ValidBeforeTime)),
 			"keyOrigin":       llx.StringData(k.KeyOrigin.String()),
-			"keyType":         llx.StringData(k.KeyType.String()),
+			"keyType":         llx.StringData(keyType),
+			"userManaged":     llx.BoolData(keyType == "USER_MANAGED"),
 			"disabled":        llx.BoolData(k.Disabled),
 		})
 		if err != nil {

--- a/providers/gcp/resources/iam_public.go
+++ b/providers/gcp/resources/iam_public.go
@@ -1,0 +1,35 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+const (
+	publicMemberAllUsers              = "allUsers"
+	publicMemberAllAuthenticatedUsers = "allAuthenticatedUsers"
+)
+
+func isPublicMember(s string) bool {
+	return s == publicMemberAllUsers || s == publicMemberAllAuthenticatedUsers
+}
+
+// iamPolicyHasPublicMember returns true when any binding member is allUsers
+// or allAuthenticatedUsers. The input is the .Data of an iamPolicy() TValue —
+// each element is expected to be a *mqlGcpResourcemanagerBinding.
+func iamPolicyHasPublicMember(bindings []any) (bool, error) {
+	for _, raw := range bindings {
+		binding, ok := raw.(*mqlGcpResourcemanagerBinding)
+		if !ok || binding == nil {
+			continue
+		}
+		members := binding.GetMembers()
+		if members.Error != nil {
+			return false, members.Error
+		}
+		for _, m := range members.Data {
+			if s, ok := m.(string); ok && isPublicMember(s) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}

--- a/providers/gcp/resources/kms.go
+++ b/providers/gcp/resources/kms.go
@@ -513,6 +513,14 @@ func (g *mqlGcpProjectKmsServiceKeyringCryptokey) versions() ([]any, error) {
 	return versions, nil
 }
 
+func (g *mqlGcpProjectKmsServiceKeyringCryptokey) public() (bool, error) {
+	bindings := g.GetIamPolicy()
+	if bindings.Error != nil {
+		return false, bindings.Error
+	}
+	return iamPolicyHasPublicMember(bindings.Data)
+}
+
 func (g *mqlGcpProjectKmsServiceKeyringCryptokey) iamPolicy() ([]any, error) {
 	if g.ResourcePath.Error != nil {
 		return nil, g.ResourcePath.Error

--- a/providers/gcp/resources/pubsub.go
+++ b/providers/gcp/resources/pubsub.go
@@ -995,3 +995,19 @@ func (g *mqlGcpProjectPubsubServiceTopicConfigSchemaSettings) schemaResource() (
 	}
 	return res.(*mqlGcpProjectPubsubServiceSchema), nil
 }
+
+func (g *mqlGcpProjectPubsubServiceTopic) public() (bool, error) {
+	bindings := g.GetIamPolicy()
+	if bindings.Error != nil {
+		return false, bindings.Error
+	}
+	return iamPolicyHasPublicMember(bindings.Data)
+}
+
+func (g *mqlGcpProjectPubsubServiceSubscription) public() (bool, error) {
+	bindings := g.GetIamPolicy()
+	if bindings.Error != nil {
+		return false, bindings.Error
+	}
+	return iamPolicyHasPublicMember(bindings.Data)
+}


### PR DESCRIPTION
## Summary

Adds 9 derived/hoisted fields on the GCP provider so the most-cited GCP CIS Benchmark findings become one-liners.

| Resource | New field | Semantics |
|---|---|---|
| `gcp.project.computeService.snapshot` | `public() bool` | IAM grants any role to `allUsers`/`allAuthenticatedUsers` |
| `gcp.project.computeService.image` | `public() bool` | same |
| `gcp.project.kmsService.keyring.cryptokey` | `public() bool` | same; CIS-flagged hot spot |
| `gcp.project.pubsubService.topic` | `public() bool` | same |
| `gcp.project.pubsubService.subscription` | `public() bool` | same |
| `gcp.project.bigqueryService.dataset` | `public() bool` | any `accessEntries` entity is `allUsers` or `allAuthenticatedUsers` |
| `gcp.project.cloudRunService.service` | `publicInvocable() bool` | `ingress == INGRESS_TRAFFIC_ALL` AND IAM grants invoke to `allUsers`/`allAuthenticatedUsers` |
| `gcp.project.apiKey.restrictions` | `unrestricted() bool` | no app/IP/referrer/API target restriction is configured |
| `gcp.project.iamService.serviceAccount.key` | `userManaged bool` | `keyType == "USER_MANAGED"` — the SA-key audit hot spot |

A new `iamPolicyHasPublicMember` helper (in `iam_public.go`) keeps the binding-scan logic in one place across compute/KMS/Pub/Sub/Cloud Run.

### Why these specific fields

These map directly to the most-frequent GCP audit findings: publicly shared snapshots/images, KMS keys with `allUsers`, world-readable BigQuery datasets, public Pub/Sub, internet-reachable Cloud Run, unrestricted API keys, and user-managed SA keys. Audit queries now read like the rule itself:

```mql
gcp.projects.all(_.computeService.snapshots.none(_.public))
gcp.projects.all(_.kmsService.keyrings.all(_.cryptokeys.none(_.public)))
gcp.projects.all(_.bigqueryService.datasets.none(_.public))
gcp.projects.all(_.cloudRun.services.none(_.publicInvocable))
gcp.projects.all(_.apiKeys.none(_.restrictions.unrestricted))
gcp.projects.all(_.iamService.serviceAccounts.all(_.keys.none(_.userManaged && !_.disabled)))
```

The existing `gcp.project.storageService.bucket.public` is left unchanged (its semantics already include ACL + PAP short-circuit).

## Test plan
- [x] `mqlr generate` produces 9 new entries at `13.12.2` in `gcp.lr.versions`
- [x] `make providers/build/gcp` succeeds; `make providers/install/gcp` installs
- [x] `gofmt` clean on changed files
- [x] `--info` confirms each new field resolves as `type=bool`
- [x] Live verification against `tim-learning-project`:
  - 2 KMS keys → `cryptokey.public: false` (correct — neither is shared with allUsers)
  - 4 Pub/Sub container-analysis topics → `topic.public: false`
  - Other resource types not present in the test project, but schema parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)