### PR TITLE
✨ GCP: project-level IAM and audit-log security helpers

### DIFF
--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -454,8 +454,14 @@ gcp.project @defaults("name number") {
   number() string
   // IAM policy
   iamPolicy() []gcp.resourcemanager.binding
+  // Whether the project's IAM policy grants any role to allUsers or allAuthenticatedUsers
+  hasPublicIamBinding() bool
+  // IAM bindings using primitive roles (roles/owner, roles/editor, roles/viewer); CIS recommends using predefined or custom roles instead
+  primitiveRoleBindings() []gcp.resourcemanager.binding
   // Audit logging configuration
   auditConfig() []gcp.resourcemanager.auditConfig
+  // Whether DATA_READ and DATA_WRITE audit logging is enabled for allServices with no exempted members (CIS 2.1)
+  dataAccessLoggingEnabled() bool
   // Organization policies
   orgPolicies() []gcp.orgPolicy
   // Available organization policy constraints

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -2342,8 +2342,17 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.iamPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProject).GetIamPolicy()).ToDataRes(types.Array(types.Resource("gcp.resourcemanager.binding")))
 	},
+	"gcp.project.hasPublicIamBinding": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProject).GetHasPublicIamBinding()).ToDataRes(types.Bool)
+	},
+	"gcp.project.primitiveRoleBindings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProject).GetPrimitiveRoleBindings()).ToDataRes(types.Array(types.Resource("gcp.resourcemanager.binding")))
+	},
 	"gcp.project.auditConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProject).GetAuditConfig()).ToDataRes(types.Array(types.Resource("gcp.resourcemanager.auditConfig")))
+	},
+	"gcp.project.dataAccessLoggingEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProject).GetDataAccessLoggingEnabled()).ToDataRes(types.Bool)
 	},
 	"gcp.project.orgPolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProject).GetOrgPolicies()).ToDataRes(types.Array(types.Resource("gcp.orgPolicy")))
@@ -12971,8 +12980,20 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProject).IamPolicy, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.hasPublicIamBinding": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProject).HasPublicIamBinding, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.primitiveRoleBindings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProject).PrimitiveRoleBindings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.auditConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProject).AuditConfig, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.dataAccessLoggingEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProject).DataAccessLoggingEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.orgPolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -29261,70 +29282,73 @@ type mqlGcpProject struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlGcpProjectInternal
-	Id                     plugin.TValue[string]
-	Name                   plugin.TValue[string]
-	ParentId               plugin.TValue[string]
-	State                  plugin.TValue[string]
-	CreateTime             plugin.TValue[*time.Time]
-	Labels                 plugin.TValue[map[string]any]
-	DeleteTime             plugin.TValue[*time.Time]
-	Number                 plugin.TValue[string]
-	IamPolicy              plugin.TValue[[]any]
-	AuditConfig            plugin.TValue[[]any]
-	OrgPolicies            plugin.TValue[[]any]
-	OrgPolicyConstraints   plugin.TValue[[]any]
-	Services               plugin.TValue[[]any]
-	Recommendations        plugin.TValue[[]any]
-	Gke                    plugin.TValue[*mqlGcpProjectGkeService]
-	Compute                plugin.TValue[*mqlGcpProjectComputeService]
-	Pubsub                 plugin.TValue[*mqlGcpProjectPubsubService]
-	Kms                    plugin.TValue[*mqlGcpProjectKmsService]
-	EssentialContacts      plugin.TValue[[]any]
-	ApiKeys                plugin.TValue[[]any]
-	Logging                plugin.TValue[*mqlGcpProjectLoggingservice]
-	Sql                    plugin.TValue[*mqlGcpProjectSqlService]
-	Iam                    plugin.TValue[*mqlGcpProjectIamService]
-	CommonInstanceMetadata plugin.TValue[map[string]any]
-	Dns                    plugin.TValue[*mqlGcpProjectDnsService]
-	Bigquery               plugin.TValue[*mqlGcpProjectBigqueryService]
-	CloudFunctions         plugin.TValue[[]any]
-	CloudFunctionsV2       plugin.TValue[[]any]
-	Dataproc               plugin.TValue[*mqlGcpProjectDataprocService]
-	CloudRun               plugin.TValue[*mqlGcpProjectCloudRunService]
-	AccessApprovalSettings plugin.TValue[*mqlGcpAccessApprovalSettings]
-	Storage                plugin.TValue[*mqlGcpProjectStorageService]
-	Monitoring             plugin.TValue[*mqlGcpProjectMonitoringService]
-	BinaryAuthorization    plugin.TValue[*mqlGcpProjectBinaryAuthorizationControl]
-	Redis                  plugin.TValue[*mqlGcpProjectRedisService]
-	Secretmanager          plugin.TValue[*mqlGcpProjectSecretmanagerService]
-	Firestore              plugin.TValue[*mqlGcpProjectFirestoreService]
-	Spanner                plugin.TValue[*mqlGcpProjectSpannerService]
-	Bigtable               plugin.TValue[*mqlGcpProjectBigtableService]
-	Alloydb                plugin.TValue[*mqlGcpProjectAlloydbService]
-	CertificateAuthority   plugin.TValue[*mqlGcpProjectCertificateAuthorityService]
-	Filestore              plugin.TValue[*mqlGcpProjectFilestoreService]
-	CloudTasks             plugin.TValue[*mqlGcpProjectCloudTasksService]
-	CloudScheduler         plugin.TValue[*mqlGcpProjectCloudSchedulerService]
-	AppEngine              plugin.TValue[*mqlGcpProjectAppEngineService]
-	CloudDeploy            plugin.TValue[*mqlGcpProjectCloudDeployService]
-	Dataflow               plugin.TValue[*mqlGcpProjectDataflowService]
-	ArtifactRegistry       plugin.TValue[*mqlGcpProjectArtifactRegistryService]
-	Backupdr               plugin.TValue[*mqlGcpProjectBackupdrService]
-	Vertexai               plugin.TValue[*mqlGcpProjectVertexaiService]
-	ModelArmor             plugin.TValue[*mqlGcpProjectModelArmorService]
-	SccFindings            plugin.TValue[[]any]
-	Eventarc               plugin.TValue[*mqlGcpProjectEventarcService]
-	Dlp                    plugin.TValue[*mqlGcpProjectDlpService]
-	Batch                  plugin.TValue[*mqlGcpProjectBatchService]
-	Ids                    plugin.TValue[*mqlGcpProjectIdsService]
-	GkeBackup              plugin.TValue[*mqlGcpProjectGkeBackupService]
-	ContainerAnalysis      plugin.TValue[*mqlGcpProjectContainerAnalysisService]
-	CloudBuild             plugin.TValue[*mqlGcpProjectCloudBuildService]
-	Iap                    plugin.TValue[*mqlGcpProjectIapService]
-	SourceRepositories     plugin.TValue[*mqlGcpProjectSourceRepositoriesService]
-	Memcache               plugin.TValue[*mqlGcpProjectMemcacheService]
-	Datastream             plugin.TValue[*mqlGcpProjectDatastreamService]
-	Memorystore            plugin.TValue[*mqlGcpProjectMemorystoreService]
+	Id                       plugin.TValue[string]
+	Name                     plugin.TValue[string]
+	ParentId                 plugin.TValue[string]
+	State                    plugin.TValue[string]
+	CreateTime               plugin.TValue[*time.Time]
+	Labels                   plugin.TValue[map[string]any]
+	DeleteTime               plugin.TValue[*time.Time]
+	Number                   plugin.TValue[string]
+	IamPolicy                plugin.TValue[[]any]
+	HasPublicIamBinding      plugin.TValue[bool]
+	PrimitiveRoleBindings    plugin.TValue[[]any]
+	AuditConfig              plugin.TValue[[]any]
+	DataAccessLoggingEnabled plugin.TValue[bool]
+	OrgPolicies              plugin.TValue[[]any]
+	OrgPolicyConstraints     plugin.TValue[[]any]
+	Services                 plugin.TValue[[]any]
+	Recommendations          plugin.TValue[[]any]
+	Gke                      plugin.TValue[*mqlGcpProjectGkeService]
+	Compute                  plugin.TValue[*mqlGcpProjectComputeService]
+	Pubsub                   plugin.TValue[*mqlGcpProjectPubsubService]
+	Kms                      plugin.TValue[*mqlGcpProjectKmsService]
+	EssentialContacts        plugin.TValue[[]any]
+	ApiKeys                  plugin.TValue[[]any]
+	Logging                  plugin.TValue[*mqlGcpProjectLoggingservice]
+	Sql                      plugin.TValue[*mqlGcpProjectSqlService]
+	Iam                      plugin.TValue[*mqlGcpProjectIamService]
+	CommonInstanceMetadata   plugin.TValue[map[string]any]
+	Dns                      plugin.TValue[*mqlGcpProjectDnsService]
+	Bigquery                 plugin.TValue[*mqlGcpProjectBigqueryService]
+	CloudFunctions           plugin.TValue[[]any]
+	CloudFunctionsV2         plugin.TValue[[]any]
+	Dataproc                 plugin.TValue[*mqlGcpProjectDataprocService]
+	CloudRun                 plugin.TValue[*mqlGcpProjectCloudRunService]
+	AccessApprovalSettings   plugin.TValue[*mqlGcpAccessApprovalSettings]
+	Storage                  plugin.TValue[*mqlGcpProjectStorageService]
+	Monitoring               plugin.TValue[*mqlGcpProjectMonitoringService]
+	BinaryAuthorization      plugin.TValue[*mqlGcpProjectBinaryAuthorizationControl]
+	Redis                    plugin.TValue[*mqlGcpProjectRedisService]
+	Secretmanager            plugin.TValue[*mqlGcpProjectSecretmanagerService]
+	Firestore                plugin.TValue[*mqlGcpProjectFirestoreService]
+	Spanner                  plugin.TValue[*mqlGcpProjectSpannerService]
+	Bigtable                 plugin.TValue[*mqlGcpProjectBigtableService]
+	Alloydb                  plugin.TValue[*mqlGcpProjectAlloydbService]
+	CertificateAuthority     plugin.TValue[*mqlGcpProjectCertificateAuthorityService]
+	Filestore                plugin.TValue[*mqlGcpProjectFilestoreService]
+	CloudTasks               plugin.TValue[*mqlGcpProjectCloudTasksService]
+	CloudScheduler           plugin.TValue[*mqlGcpProjectCloudSchedulerService]
+	AppEngine                plugin.TValue[*mqlGcpProjectAppEngineService]
+	CloudDeploy              plugin.TValue[*mqlGcpProjectCloudDeployService]
+	Dataflow                 plugin.TValue[*mqlGcpProjectDataflowService]
+	ArtifactRegistry         plugin.TValue[*mqlGcpProjectArtifactRegistryService]
+	Backupdr                 plugin.TValue[*mqlGcpProjectBackupdrService]
+	Vertexai                 plugin.TValue[*mqlGcpProjectVertexaiService]
+	ModelArmor               plugin.TValue[*mqlGcpProjectModelArmorService]
+	SccFindings              plugin.TValue[[]any]
+	Eventarc                 plugin.TValue[*mqlGcpProjectEventarcService]
+	Dlp                      plugin.TValue[*mqlGcpProjectDlpService]
+	Batch                    plugin.TValue[*mqlGcpProjectBatchService]
+	Ids                      plugin.TValue[*mqlGcpProjectIdsService]
+	GkeBackup                plugin.TValue[*mqlGcpProjectGkeBackupService]
+	ContainerAnalysis        plugin.TValue[*mqlGcpProjectContainerAnalysisService]
+	CloudBuild               plugin.TValue[*mqlGcpProjectCloudBuildService]
+	Iap                      plugin.TValue[*mqlGcpProjectIapService]
+	SourceRepositories       plugin.TValue[*mqlGcpProjectSourceRepositoriesService]
+	Memcache                 plugin.TValue[*mqlGcpProjectMemcacheService]
+	Datastream               plugin.TValue[*mqlGcpProjectDatastreamService]
+	Memorystore              plugin.TValue[*mqlGcpProjectMemorystoreService]
 }
 
 // createGcpProject creates a new instance of this resource
@@ -29426,6 +29450,28 @@ func (c *mqlGcpProject) GetIamPolicy() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlGcpProject) GetHasPublicIamBinding() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasPublicIamBinding, func() (bool, error) {
+		return c.hasPublicIamBinding()
+	})
+}
+
+func (c *mqlGcpProject) GetPrimitiveRoleBindings() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PrimitiveRoleBindings, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project", c.__id, "primitiveRoleBindings")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.primitiveRoleBindings()
+	})
+}
+
 func (c *mqlGcpProject) GetAuditConfig() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.AuditConfig, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -29439,6 +29485,12 @@ func (c *mqlGcpProject) GetAuditConfig() *plugin.TValue[[]any] {
 		}
 
 		return c.auditConfig()
+	})
+}
+
+func (c *mqlGcpProject) GetDataAccessLoggingEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.DataAccessLoggingEnabled, func() (bool, error) {
+		return c.dataAccessLoggingEnabled()
 	})
 }
 

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -1887,6 +1887,7 @@ gcp.project.containerAnalysisService.occurrence.vulnerability 13.6.1
 gcp.project.containerAnalysisService.occurrences 13.6.1
 gcp.project.containerAnalysisService.projectId 13.6.1
 gcp.project.createTime 9.0.0
+gcp.project.dataAccessLoggingEnabled 13.12.2
 gcp.project.dataflow 11.6.6
 gcp.project.dataflowService 11.6.6
 gcp.project.dataflowService.job 11.6.6
@@ -2508,6 +2509,7 @@ gcp.project.gkeService.cluster.tpuIpv4CidrBlock 13.1.2
 gcp.project.gkeService.cluster.workloadIdentityConfig 9.0.0
 gcp.project.gkeService.clusters 9.0.0
 gcp.project.gkeService.projectId 9.0.0
+gcp.project.hasPublicIamBinding 13.12.2
 gcp.project.iam 9.0.0
 gcp.project.iamPolicy 9.0.0
 gcp.project.iamService 9.0.0
@@ -2920,6 +2922,7 @@ gcp.project.number 9.0.0
 gcp.project.orgPolicies 11.5.1
 gcp.project.orgPolicyConstraints 13.6.1
 gcp.project.parentId 9.0.0
+gcp.project.primitiveRoleBindings 13.12.2
 gcp.project.pubsub 9.0.0
 gcp.project.pubsubService 9.0.0
 gcp.project.pubsubService.projectId 9.0.0

--- a/providers/gcp/resources/project.go
+++ b/providers/gcp/resources/project.go
@@ -174,6 +174,89 @@ func (g *mqlGcpProject) iamPolicy() ([]any, error) {
 	return res, nil
 }
 
+func (g *mqlGcpProject) hasPublicIamBinding() (bool, error) {
+	bindings := g.GetIamPolicy()
+	if bindings.Error != nil {
+		return false, bindings.Error
+	}
+	return iamPolicyHasPublicMember(bindings.Data)
+}
+
+func (g *mqlGcpProject) primitiveRoleBindings() ([]any, error) {
+	bindings := g.GetIamPolicy()
+	if bindings.Error != nil {
+		return nil, bindings.Error
+	}
+	res := make([]any, 0)
+	for _, raw := range bindings.Data {
+		b, ok := raw.(*mqlGcpResourcemanagerBinding)
+		if !ok || b == nil {
+			continue
+		}
+		role := b.GetRole()
+		if role.Error != nil {
+			return nil, role.Error
+		}
+		switch role.Data {
+		case "roles/owner", "roles/editor", "roles/viewer":
+			res = append(res, b)
+		}
+	}
+	return res, nil
+}
+
+func (g *mqlGcpProject) dataAccessLoggingEnabled() (bool, error) {
+	configs := g.GetAuditConfig()
+	if configs.Error != nil {
+		return false, configs.Error
+	}
+	for _, raw := range configs.Data {
+		cfg, ok := raw.(*mqlGcpResourcemanagerAuditConfig)
+		if !ok || cfg == nil {
+			continue
+		}
+		service := cfg.GetService()
+		if service.Error != nil {
+			return false, service.Error
+		}
+		if service.Data != "allServices" {
+			continue
+		}
+		logConfigs := cfg.GetAuditLogConfigs()
+		if logConfigs.Error != nil {
+			return false, logConfigs.Error
+		}
+		var hasDataRead, hasDataWrite bool
+		for _, lcRaw := range logConfigs.Data {
+			lc, ok := lcRaw.(*mqlGcpResourcemanagerAuditConfigLogConfig)
+			if !ok || lc == nil {
+				continue
+			}
+			logType := lc.GetLogType()
+			if logType.Error != nil {
+				return false, logType.Error
+			}
+			exempted := lc.GetExemptedMembers()
+			if exempted.Error != nil {
+				return false, exempted.Error
+			}
+			if len(exempted.Data) > 0 {
+				continue
+			}
+			switch logType.Data {
+			case "DATA_READ":
+				hasDataRead = true
+			case "DATA_WRITE":
+				hasDataWrite = true
+			}
+		}
+		if hasDataRead && hasDataWrite {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (g *mqlGcpProject) auditConfig() ([]any, error) {
 	if g.Id.Error != nil {
 		return nil, g.Id.Error


### PR DESCRIPTION
## Summary

Adds three derived helpers on \`gcp.project\` so common project-wide audit checks become one-liners.

| New field | Returns |
|---|---|
| \`hasPublicIamBinding() bool\` | true when project IAM grants any role to \`allUsers\`/\`allAuthenticatedUsers\` |
| \`primitiveRoleBindings() []binding\` | bindings using \`roles/owner\`, \`roles/editor\`, or \`roles/viewer\` |
| \`dataAccessLoggingEnabled() bool\` | true when DATA_READ + DATA_WRITE are enabled for \`allServices\` with no exempted members |

Maps to CIS 1.x (IAM) and 2.1 (audit logging) controls.

## Why

Today the same checks require traversing \`iamPolicy()\` and \`auditConfig()\` and inspecting per-binding/per-log-config detail. Now:

\`\`\`mql
gcp.projects.none(_.hasPublicIamBinding)
gcp.projects.all(_.primitiveRoleBindings.length == 0)
gcp.projects.all(_.dataAccessLoggingEnabled)
\`\`\`

\`hasPublicIamBinding\` reuses the shared \`iamPolicyHasPublicMember\` helper from PR #7480.

## Test plan
- [x] Live query against tim-learning-project: \`hasPublicIamBinding=false\`, \`primitiveRoleBindings\` returns 2 bindings (roles/owner with 1 member, roles/editor with 3 — a real CIS 1.4 finding), \`dataAccessLoggingEnabled=false\` (matches the project's actual audit config)
- [x] gcp provider builds & installs; gofmt clean
- [x] 3 new entries at 13.12.2 in gcp.lr.versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)