### PR TITLE
✨ GCP: compute instance hardening helpers (CIS 4.x)

### DIFF
--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -3287,4 +3288,92 @@ func (g *mqlGcpProjectComputeServiceImage) public() (bool, error) {
 		return false, bindings.Error
 	}
 	return iamPolicyHasPublicMember(bindings.Data)
+}
+
+var defaultComputeServiceAccountRe = regexp.MustCompile(`^\d+-compute@developer\.gserviceaccount\.com$`)
+
+func (g *mqlGcpProjectComputeServiceInstance) usesDefaultServiceAccount() (bool, error) {
+	sas := g.GetServiceAccounts()
+	if sas.Error != nil {
+		return false, sas.Error
+	}
+	for _, raw := range sas.Data {
+		sa, ok := raw.(*mqlGcpProjectComputeServiceServiceaccount)
+		if !ok || sa == nil {
+			continue
+		}
+		email := sa.GetEmail()
+		if email.Error != nil {
+			return false, email.Error
+		}
+		if defaultComputeServiceAccountRe.MatchString(email.Data) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+const cloudPlatformOAuthScope = "https://www.googleapis.com/auth/cloud-platform"
+
+func (g *mqlGcpProjectComputeServiceInstance) hasFullCloudPlatformScope() (bool, error) {
+	sas := g.GetServiceAccounts()
+	if sas.Error != nil {
+		return false, sas.Error
+	}
+	for _, raw := range sas.Data {
+		sa, ok := raw.(*mqlGcpProjectComputeServiceServiceaccount)
+		if !ok || sa == nil {
+			continue
+		}
+		scopes := sa.GetScopes()
+		if scopes.Error != nil {
+			return false, scopes.Error
+		}
+		for _, s := range scopes.Data {
+			if str, ok := s.(string); ok && str == cloudPlatformOAuthScope {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func metadataBoolFlag(metadata map[string]any, key string) bool {
+	v, ok := metadata[key]
+	if !ok {
+		return false
+	}
+	s, ok := v.(string)
+	if !ok {
+		return false
+	}
+	switch strings.ToLower(s) {
+	case "true", "1":
+		return true
+	}
+	return false
+}
+
+func (g *mqlGcpProjectComputeServiceInstance) blockProjectSshKeysEnabled() (bool, error) {
+	md := g.GetMetadata()
+	if md.Error != nil {
+		return false, md.Error
+	}
+	return metadataBoolFlag(md.Data, "block-project-ssh-keys"), nil
+}
+
+func (g *mqlGcpProjectComputeServiceInstance) osLoginEnabled() (bool, error) {
+	md := g.GetMetadata()
+	if md.Error != nil {
+		return false, md.Error
+	}
+	return metadataBoolFlag(md.Data, "enable-oslogin"), nil
+}
+
+func (g *mqlGcpProjectComputeServiceInstance) serialPortEnabled() (bool, error) {
+	md := g.GetMetadata()
+	if md.Error != nil {
+		return false, md.Error
+	}
+	return metadataBoolFlag(md.Data, "serial-port-enable"), nil
 }

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -3367,7 +3367,31 @@ func (g *mqlGcpProjectComputeServiceInstance) osLoginEnabled() (bool, error) {
 	if md.Error != nil {
 		return false, md.Error
 	}
-	return metadataBoolFlag(md.Data, "enable-oslogin"), nil
+	if _, set := md.Data["enable-oslogin"]; set {
+		return metadataBoolFlag(md.Data, "enable-oslogin"), nil
+	}
+	if g.ProjectId.Error != nil {
+		return false, g.ProjectId.Error
+	}
+	projectId := g.ProjectId.Data
+	if projectId == "" {
+		return false, nil
+	}
+	projRes, err := NewResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+		"id": llx.StringData(projectId),
+	})
+	if err != nil {
+		return false, err
+	}
+	proj := projRes.(*mqlGcpProject)
+	projMd := proj.GetCommonInstanceMetadata()
+	if projMd.Error != nil {
+		return false, projMd.Error
+	}
+	if projMd.Data == nil {
+		return false, nil
+	}
+	return metadataBoolFlag(projMd.Data, "enable-oslogin"), nil
 }
 
 func (g *mqlGcpProjectComputeServiceInstance) serialPortEnabled() (bool, error) {

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -924,15 +924,15 @@ gcp.project.computeService.instance @defaults("name id") {
   networkInterfaces []dict
   // Whether the instance has at least one external IP attached via a network interface accessConfig
   hasPublicIp() bool
-  // Whether the instance runs as the default Compute Engine service account (<projectNumber>-compute@developer.gserviceaccount.com); CIS 4.1 advises a dedicated SA
+  // Whether the instance runs as the default Compute Engine service account (<projectNumber>-compute@developer.gserviceaccount.com)
   usesDefaultServiceAccount() bool
-  // Whether any attached service account has the broad cloud-platform OAuth scope; CIS 4.2 advises minimal scopes
+  // Whether any attached service account has the broad cloud-platform OAuth scope
   hasFullCloudPlatformScope() bool
-  // Whether instance metadata 'block-project-ssh-keys' is true; CIS 4.3
+  // Whether instance metadata 'block-project-ssh-keys' is true
   blockProjectSshKeysEnabled() bool
-  // Whether instance metadata 'enable-oslogin' is true; CIS 4.4. Does NOT yet fall back to project-level metadata.
+  // Whether OS Login is enabled on this instance — checks instance metadata 'enable-oslogin', then falls back to project commonInstanceMetadata when unset
   osLoginEnabled() bool
-  // Whether instance metadata 'serial-port-enable' is set to true (interactive serial console); CIS 4.5
+  // Whether instance metadata 'serial-port-enable' is set to true (interactive serial console)
   serialPortEnabled() bool
   // Private IPv6 google access type for the VM
   privateIpv6GoogleAccess string

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -924,6 +924,16 @@ gcp.project.computeService.instance @defaults("name id") {
   networkInterfaces []dict
   // Whether the instance has at least one external IP attached via a network interface accessConfig
   hasPublicIp() bool
+  // Whether the instance runs as the default Compute Engine service account (<projectNumber>-compute@developer.gserviceaccount.com); CIS 4.1 advises a dedicated SA
+  usesDefaultServiceAccount() bool
+  // Whether any attached service account has the broad cloud-platform OAuth scope; CIS 4.2 advises minimal scopes
+  hasFullCloudPlatformScope() bool
+  // Whether instance metadata 'block-project-ssh-keys' is true; CIS 4.3
+  blockProjectSshKeysEnabled() bool
+  // Whether instance metadata 'enable-oslogin' is true; CIS 4.4. Does NOT yet fall back to project-level metadata.
+  osLoginEnabled() bool
+  // Whether instance metadata 'serial-port-enable' is set to true (interactive serial console); CIS 4.5
+  serialPortEnabled() bool
   // Private IPv6 google access type for the VM
   privateIpv6GoogleAccess string
   // Reservations from which this instance can consume

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -2987,6 +2987,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.instance.hasPublicIp": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetHasPublicIp()).ToDataRes(types.Bool)
 	},
+	"gcp.project.computeService.instance.usesDefaultServiceAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstance).GetUsesDefaultServiceAccount()).ToDataRes(types.Bool)
+	},
+	"gcp.project.computeService.instance.hasFullCloudPlatformScope": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstance).GetHasFullCloudPlatformScope()).ToDataRes(types.Bool)
+	},
+	"gcp.project.computeService.instance.blockProjectSshKeysEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstance).GetBlockProjectSshKeysEnabled()).ToDataRes(types.Bool)
+	},
+	"gcp.project.computeService.instance.osLoginEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstance).GetOsLoginEnabled()).ToDataRes(types.Bool)
+	},
+	"gcp.project.computeService.instance.serialPortEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstance).GetSerialPortEnabled()).ToDataRes(types.Bool)
+	},
 	"gcp.project.computeService.instance.privateIpv6GoogleAccess": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetPrivateIpv6GoogleAccess()).ToDataRes(types.String)
 	},
@@ -13869,6 +13884,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.instance.hasPublicIp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstance).HasPublicIp, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.instance.usesDefaultServiceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstance).UsesDefaultServiceAccount, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.instance.hasFullCloudPlatformScope": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstance).HasFullCloudPlatformScope, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.instance.blockProjectSshKeysEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstance).BlockProjectSshKeysEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.instance.osLoginEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstance).OsLoginEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.instance.serialPortEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstance).SerialPortEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.instance.privateIpv6GoogleAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31941,6 +31976,11 @@ type mqlGcpProjectComputeServiceInstance struct {
 	MinCpuPlatform                  plugin.TValue[string]
 	NetworkInterfaces               plugin.TValue[[]any]
 	HasPublicIp                     plugin.TValue[bool]
+	UsesDefaultServiceAccount       plugin.TValue[bool]
+	HasFullCloudPlatformScope       plugin.TValue[bool]
+	BlockProjectSshKeysEnabled      plugin.TValue[bool]
+	OsLoginEnabled                  plugin.TValue[bool]
+	SerialPortEnabled               plugin.TValue[bool]
 	PrivateIpv6GoogleAccess         plugin.TValue[string]
 	ReservationAffinity             plugin.TValue[any]
 	ResourcePolicies                plugin.TValue[[]any]
@@ -32090,6 +32130,36 @@ func (c *mqlGcpProjectComputeServiceInstance) GetNetworkInterfaces() *plugin.TVa
 func (c *mqlGcpProjectComputeServiceInstance) GetHasPublicIp() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.HasPublicIp, func() (bool, error) {
 		return c.hasPublicIp()
+	})
+}
+
+func (c *mqlGcpProjectComputeServiceInstance) GetUsesDefaultServiceAccount() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesDefaultServiceAccount, func() (bool, error) {
+		return c.usesDefaultServiceAccount()
+	})
+}
+
+func (c *mqlGcpProjectComputeServiceInstance) GetHasFullCloudPlatformScope() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasFullCloudPlatformScope, func() (bool, error) {
+		return c.hasFullCloudPlatformScope()
+	})
+}
+
+func (c *mqlGcpProjectComputeServiceInstance) GetBlockProjectSshKeysEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.BlockProjectSshKeysEnabled, func() (bool, error) {
+		return c.blockProjectSshKeysEnabled()
+	})
+}
+
+func (c *mqlGcpProjectComputeServiceInstance) GetOsLoginEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.OsLoginEnabled, func() (bool, error) {
+		return c.osLoginEnabled()
+	})
+}
+
+func (c *mqlGcpProjectComputeServiceInstance) GetSerialPortEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.SerialPortEnabled, func() (bool, error) {
+		return c.serialPortEnabled()
 	})
 }
 

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -1279,6 +1279,7 @@ gcp.project.computeService.image.status 9.0.0
 gcp.project.computeService.image.storageLocations 13.1.2
 gcp.project.computeService.images 9.0.0
 gcp.project.computeService.instance 9.0.0
+gcp.project.computeService.instance.blockProjectSshKeysEnabled 13.12.2
 gcp.project.computeService.instance.canIpForward 9.0.0
 gcp.project.computeService.instance.confidentialInstanceConfig 9.0.0
 gcp.project.computeService.instance.cpuPlatform 9.0.0
@@ -1292,6 +1293,7 @@ gcp.project.computeService.instance.enableSecureBoot 9.0.0
 gcp.project.computeService.instance.enableVtpm 9.0.0
 gcp.project.computeService.instance.fingerprint 9.0.0
 gcp.project.computeService.instance.guestAccelerators 9.0.0
+gcp.project.computeService.instance.hasFullCloudPlatformScope 13.12.2
 gcp.project.computeService.instance.hasPublicIp 13.12.2
 gcp.project.computeService.instance.hostname 9.0.0
 gcp.project.computeService.instance.id 9.0.0
@@ -1305,6 +1307,7 @@ gcp.project.computeService.instance.metadata 9.0.0
 gcp.project.computeService.instance.minCpuPlatform 9.0.0
 gcp.project.computeService.instance.name 9.0.0
 gcp.project.computeService.instance.networkInterfaces 9.0.0
+gcp.project.computeService.instance.osLoginEnabled 13.12.2
 gcp.project.computeService.instance.physicalHostResourceStatus 9.0.0
 gcp.project.computeService.instance.privateIpv6GoogleAccess 9.0.0
 gcp.project.computeService.instance.projectId 9.0.0
@@ -1313,6 +1316,7 @@ gcp.project.computeService.instance.resourcePolicies 9.0.0
 gcp.project.computeService.instance.satisfiesPzi 11.6.6
 gcp.project.computeService.instance.satisfiesPzs 11.6.6
 gcp.project.computeService.instance.scheduling 9.0.0
+gcp.project.computeService.instance.serialPortEnabled 13.12.2
 gcp.project.computeService.instance.serviceAccounts 9.0.0
 gcp.project.computeService.instance.shieldedInstanceConfig 11.6.3
 gcp.project.computeService.instance.shieldedInstanceConfig.enableIntegrityMonitoring 11.6.3
@@ -1326,6 +1330,7 @@ gcp.project.computeService.instance.status 9.0.0
 gcp.project.computeService.instance.statusMessage 9.0.0
 gcp.project.computeService.instance.tags 9.0.0
 gcp.project.computeService.instance.totalEgressBandwidthTier 9.0.0
+gcp.project.computeService.instance.usesDefaultServiceAccount 13.12.2
 gcp.project.computeService.instance.workloadIdentityConfig 13.5.0
 gcp.project.computeService.instance.zone 9.0.0
 gcp.project.computeService.instanceGroup 11.6.6


### PR DESCRIPTION
## Summary

Adds five derived helpers on \`gcp.project.computeService.instance\` mapping to GCP CIS Benchmark §4 (Virtual Machines).

| New field | Source | CIS |
|---|---|---|
| \`usesDefaultServiceAccount() bool\` | SA email regex \`^\\d+-compute@developer\\.gserviceaccount\\.com$\` | 4.1 |
| \`hasFullCloudPlatformScope() bool\` | any SA has \`https://www.googleapis.com/auth/cloud-platform\` | 4.2 |
| \`blockProjectSshKeysEnabled() bool\` | metadata \`block-project-ssh-keys\` ∈ {true,1} | 4.3 |
| \`osLoginEnabled() bool\` | metadata \`enable-oslogin\` ∈ {true,1} | 4.4 |
| \`serialPortEnabled() bool\` | metadata \`serial-port-enable\` ∈ {true,1} | 4.5 |

## Caveat — osLoginEnabled

Currently checks instance metadata only. \`enable-oslogin\` can also be set at the project level via \`commonInstanceMetadata\` and inherited by instances; that fallback is **not** included here. A query that wants project-level coverage today can do:

\`\`\`mql
instance.osLoginEnabled || project.commonInstanceMetadata["enable-oslogin"] == "TRUE"
\`\`\`

A follow-up can fold the project fallback into the instance method once we decide whether to make it implicit.

## Test plan
- [x] 5 new entries at 13.12.2 in gcp.lr.versions
- [x] gcp provider builds & installs; gofmt clean
- [x] --info: all 5 fields resolve as type=bool

🤖 Generated with [Claude Code](https://claude.com/claude-code)