### PR TITLE
✨ GCP: GKE cluster + nodepool hardening helpers (CIS 5.x)

### DIFF
--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -2400,7 +2400,7 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   addonsConfig gcp.project.gkeService.cluster.addonsConfig
   // Configuration for the use of Kubernetes Service Accounts in GCP IAM policies
   workloadIdentityConfig dict
-  // Whether Workload Identity is enabled (workloadPool is set); CIS 5.2.2
+  // Whether Workload Identity is enabled (workloadPool is set)
   workloadIdentityEnabled bool
   // Configuration for cluster IP allocation
   ipAllocationPolicy gcp.project.gkeService.cluster.ipAllocationPolicy
@@ -2408,11 +2408,11 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   networkConfig gcp.project.gkeService.cluster.networkConfig
   // Binary authorization configuration
   binaryAuthorization dict
-  // Whether Binary Authorization is enabled for the cluster; CIS 5.10.5
+  // Whether Binary Authorization is enabled for the cluster (Enabled flag is true OR evaluationMode is anything other than DISABLED/UNSPECIFIED)
   binaryAuthorizationEnabled bool
   // Legacy ABAC authorization configuration
   legacyAbac dict
-  // Whether legacy ABAC is enabled (CIS 5.8.4 says it should not be)
+  // Whether the legacy ABAC authorizer is enabled on the cluster
   legacyAbacEnabled bool
   // Authentication information for accessing the master endpoint
   masterAuth dict
@@ -2436,7 +2436,7 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   databaseEncryptionKey() gcp.project.kmsService.keyring.cryptokey
   // Configuration for Shielded Nodes feature
   shieldedNodesConfig dict
-  // Whether Shielded Nodes is enabled cluster-wide; CIS 5.5.5
+  // Whether Shielded Nodes is enabled cluster-wide
   shieldedNodesEnabled bool
   // Configuration for the fine-grained cost management feature
   costManagementConfig dict
@@ -2648,9 +2648,9 @@ private gcp.project.gkeService.cluster.nodepool @defaults("name") {
   status string
   // Node management configuration
   management dict
-  // Whether nodes are automatically upgraded to the cluster master version; CIS 5.5.4
+  // Whether nodes are automatically upgraded to the cluster master version
   autoUpgrade bool
-  // Whether nodes are automatically repaired when unhealthy; CIS 5.5.3
+  // Whether nodes are automatically repaired when unhealthy
   autoRepair bool
   // Autoscaler configuration for this NodePool
   autoscaling gcp.project.gkeService.cluster.nodepool.autoscaling

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -2400,14 +2400,20 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   addonsConfig gcp.project.gkeService.cluster.addonsConfig
   // Configuration for the use of Kubernetes Service Accounts in GCP IAM policies
   workloadIdentityConfig dict
+  // Whether Workload Identity is enabled (workloadPool is set); CIS 5.2.2
+  workloadIdentityEnabled bool
   // Configuration for cluster IP allocation
   ipAllocationPolicy gcp.project.gkeService.cluster.ipAllocationPolicy
   // Configuration for cluster networking
   networkConfig gcp.project.gkeService.cluster.networkConfig
   // Binary authorization configuration
   binaryAuthorization dict
+  // Whether Binary Authorization is enabled for the cluster; CIS 5.10.5
+  binaryAuthorizationEnabled bool
   // Legacy ABAC authorization configuration
   legacyAbac dict
+  // Whether legacy ABAC is enabled (CIS 5.8.4 says it should not be)
+  legacyAbacEnabled bool
   // Authentication information for accessing the master endpoint
   masterAuth dict
   // Master authorized networks configuration
@@ -2430,6 +2436,8 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   databaseEncryptionKey() gcp.project.kmsService.keyring.cryptokey
   // Configuration for Shielded Nodes feature
   shieldedNodesConfig dict
+  // Whether Shielded Nodes is enabled cluster-wide; CIS 5.5.5
+  shieldedNodesEnabled bool
   // Configuration for the fine-grained cost management feature
   costManagementConfig dict
   // Configuration of Confidential Nodes
@@ -2640,6 +2648,10 @@ private gcp.project.gkeService.cluster.nodepool @defaults("name") {
   status string
   // Node management configuration
   management dict
+  // Whether nodes are automatically upgraded to the cluster master version; CIS 5.5.4
+  autoUpgrade bool
+  // Whether nodes are automatically repaired when unhealthy; CIS 5.5.3
+  autoRepair bool
   // Autoscaler configuration for this NodePool
   autoscaling gcp.project.gkeService.cluster.nodepool.autoscaling
   // Additional information about the current status of this node pool

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -4877,6 +4877,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.gkeService.cluster.workloadIdentityConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetWorkloadIdentityConfig()).ToDataRes(types.Dict)
 	},
+	"gcp.project.gkeService.cluster.workloadIdentityEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetWorkloadIdentityEnabled()).ToDataRes(types.Bool)
+	},
 	"gcp.project.gkeService.cluster.ipAllocationPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetIpAllocationPolicy()).ToDataRes(types.Resource("gcp.project.gkeService.cluster.ipAllocationPolicy"))
 	},
@@ -4886,8 +4889,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.gkeService.cluster.binaryAuthorization": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetBinaryAuthorization()).ToDataRes(types.Dict)
 	},
+	"gcp.project.gkeService.cluster.binaryAuthorizationEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetBinaryAuthorizationEnabled()).ToDataRes(types.Bool)
+	},
 	"gcp.project.gkeService.cluster.legacyAbac": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetLegacyAbac()).ToDataRes(types.Dict)
+	},
+	"gcp.project.gkeService.cluster.legacyAbacEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetLegacyAbacEnabled()).ToDataRes(types.Bool)
 	},
 	"gcp.project.gkeService.cluster.masterAuth": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetMasterAuth()).ToDataRes(types.Dict)
@@ -4921,6 +4930,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.gkeService.cluster.shieldedNodesConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetShieldedNodesConfig()).ToDataRes(types.Dict)
+	},
+	"gcp.project.gkeService.cluster.shieldedNodesEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetShieldedNodesEnabled()).ToDataRes(types.Bool)
 	},
 	"gcp.project.gkeService.cluster.costManagementConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetCostManagementConfig()).ToDataRes(types.Dict)
@@ -5188,6 +5200,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.gkeService.cluster.nodepool.management": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceClusterNodepool).GetManagement()).ToDataRes(types.Dict)
+	},
+	"gcp.project.gkeService.cluster.nodepool.autoUpgrade": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceClusterNodepool).GetAutoUpgrade()).ToDataRes(types.Bool)
+	},
+	"gcp.project.gkeService.cluster.nodepool.autoRepair": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceClusterNodepool).GetAutoRepair()).ToDataRes(types.Bool)
 	},
 	"gcp.project.gkeService.cluster.nodepool.autoscaling": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceClusterNodepool).GetAutoscaling()).ToDataRes(types.Resource("gcp.project.gkeService.cluster.nodepool.autoscaling"))
@@ -16579,6 +16597,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectGkeServiceCluster).WorkloadIdentityConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.gkeService.cluster.workloadIdentityEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).WorkloadIdentityEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gcp.project.gkeService.cluster.ipAllocationPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceCluster).IpAllocationPolicy, ok = plugin.RawToTValue[*mqlGcpProjectGkeServiceClusterIpAllocationPolicy](v.Value, v.Error)
 		return
@@ -16591,8 +16613,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectGkeServiceCluster).BinaryAuthorization, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.gkeService.cluster.binaryAuthorizationEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).BinaryAuthorizationEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gcp.project.gkeService.cluster.legacyAbac": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceCluster).LegacyAbac, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.legacyAbacEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).LegacyAbacEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.gkeService.cluster.masterAuth": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16637,6 +16667,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.gkeService.cluster.shieldedNodesConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceCluster).ShieldedNodesConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.shieldedNodesEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).ShieldedNodesEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.gkeService.cluster.costManagementConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -17025,6 +17059,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.gkeService.cluster.nodepool.management": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceClusterNodepool).Management, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.nodepool.autoUpgrade": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceClusterNodepool).AutoUpgrade, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.nodepool.autoRepair": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceClusterNodepool).AutoRepair, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.gkeService.cluster.nodepool.autoscaling": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -37657,10 +37699,13 @@ type mqlGcpProjectGkeServiceCluster struct {
 	ExpirationTime                  plugin.TValue[*time.Time]
 	AddonsConfig                    plugin.TValue[*mqlGcpProjectGkeServiceClusterAddonsConfig]
 	WorkloadIdentityConfig          plugin.TValue[any]
+	WorkloadIdentityEnabled         plugin.TValue[bool]
 	IpAllocationPolicy              plugin.TValue[*mqlGcpProjectGkeServiceClusterIpAllocationPolicy]
 	NetworkConfig                   plugin.TValue[*mqlGcpProjectGkeServiceClusterNetworkConfig]
 	BinaryAuthorization             plugin.TValue[any]
+	BinaryAuthorizationEnabled      plugin.TValue[bool]
 	LegacyAbac                      plugin.TValue[any]
+	LegacyAbacEnabled               plugin.TValue[bool]
 	MasterAuth                      plugin.TValue[any]
 	MasterAuthorizedNetworksConfig  plugin.TValue[any]
 	MasterAuthorizedNetworksEnabled plugin.TValue[bool]
@@ -37672,6 +37717,7 @@ type mqlGcpProjectGkeServiceCluster struct {
 	DatabaseEncryptionState         plugin.TValue[string]
 	DatabaseEncryptionKey           plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 	ShieldedNodesConfig             plugin.TValue[any]
+	ShieldedNodesEnabled            plugin.TValue[bool]
 	CostManagementConfig            plugin.TValue[any]
 	ConfidentialNodesConfig         plugin.TValue[any]
 	IdentityServiceConfig           plugin.TValue[any]
@@ -37821,6 +37867,10 @@ func (c *mqlGcpProjectGkeServiceCluster) GetWorkloadIdentityConfig() *plugin.TVa
 	return &c.WorkloadIdentityConfig
 }
 
+func (c *mqlGcpProjectGkeServiceCluster) GetWorkloadIdentityEnabled() *plugin.TValue[bool] {
+	return &c.WorkloadIdentityEnabled
+}
+
 func (c *mqlGcpProjectGkeServiceCluster) GetIpAllocationPolicy() *plugin.TValue[*mqlGcpProjectGkeServiceClusterIpAllocationPolicy] {
 	return &c.IpAllocationPolicy
 }
@@ -37833,8 +37883,16 @@ func (c *mqlGcpProjectGkeServiceCluster) GetBinaryAuthorization() *plugin.TValue
 	return &c.BinaryAuthorization
 }
 
+func (c *mqlGcpProjectGkeServiceCluster) GetBinaryAuthorizationEnabled() *plugin.TValue[bool] {
+	return &c.BinaryAuthorizationEnabled
+}
+
 func (c *mqlGcpProjectGkeServiceCluster) GetLegacyAbac() *plugin.TValue[any] {
 	return &c.LegacyAbac
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetLegacyAbacEnabled() *plugin.TValue[bool] {
+	return &c.LegacyAbacEnabled
 }
 
 func (c *mqlGcpProjectGkeServiceCluster) GetMasterAuth() *plugin.TValue[any] {
@@ -37891,6 +37949,10 @@ func (c *mqlGcpProjectGkeServiceCluster) GetDatabaseEncryptionKey() *plugin.TVal
 
 func (c *mqlGcpProjectGkeServiceCluster) GetShieldedNodesConfig() *plugin.TValue[any] {
 	return &c.ShieldedNodesConfig
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetShieldedNodesEnabled() *plugin.TValue[bool] {
+	return &c.ShieldedNodesEnabled
 }
 
 func (c *mqlGcpProjectGkeServiceCluster) GetCostManagementConfig() *plugin.TValue[any] {
@@ -38632,6 +38694,8 @@ type mqlGcpProjectGkeServiceClusterNodepool struct {
 	InstanceGroupManagers plugin.TValue[[]any]
 	Status                plugin.TValue[string]
 	Management            plugin.TValue[any]
+	AutoUpgrade           plugin.TValue[bool]
+	AutoRepair            plugin.TValue[bool]
 	Autoscaling           plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolAutoscaling]
 	StatusMessage         plugin.TValue[string]
 	PodIpv4CidrSize       plugin.TValue[int64]
@@ -38730,6 +38794,14 @@ func (c *mqlGcpProjectGkeServiceClusterNodepool) GetStatus() *plugin.TValue[stri
 
 func (c *mqlGcpProjectGkeServiceClusterNodepool) GetManagement() *plugin.TValue[any] {
 	return &c.Management
+}
+
+func (c *mqlGcpProjectGkeServiceClusterNodepool) GetAutoUpgrade() *plugin.TValue[bool] {
+	return &c.AutoUpgrade
+}
+
+func (c *mqlGcpProjectGkeServiceClusterNodepool) GetAutoRepair() *plugin.TValue[bool] {
+	return &c.AutoRepair
 }
 
 func (c *mqlGcpProjectGkeServiceClusterNodepool) GetAutoscaling() *plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolAutoscaling] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -2310,6 +2310,7 @@ gcp.project.gkeService.cluster.addonsConfig.networkPolicyConfig 9.0.0
 gcp.project.gkeService.cluster.addonsConfig.statefulHaConfig 9.0.0
 gcp.project.gkeService.cluster.autopilotEnabled 9.0.0
 gcp.project.gkeService.cluster.binaryAuthorization 9.0.0
+gcp.project.gkeService.cluster.binaryAuthorizationEnabled 13.12.2
 gcp.project.gkeService.cluster.clusterIpv4Cidr 9.0.0
 gcp.project.gkeService.cluster.confidentialNodesConfig 9.0.0
 gcp.project.gkeService.cluster.costManagementConfig 9.0.0
@@ -2345,6 +2346,7 @@ gcp.project.gkeService.cluster.ipAllocationPolicy.tpuIpv4CidrBlock 9.0.0
 gcp.project.gkeService.cluster.ipAllocationPolicy.useIpAliases 9.0.0
 gcp.project.gkeService.cluster.ipAllocationPolicy.useRoutes 9.0.0
 gcp.project.gkeService.cluster.legacyAbac 9.0.0
+gcp.project.gkeService.cluster.legacyAbacEnabled 13.12.2
 gcp.project.gkeService.cluster.location 9.0.0
 gcp.project.gkeService.cluster.locations 9.0.0
 gcp.project.gkeService.cluster.loggingService 9.0.0
@@ -2389,6 +2391,8 @@ gcp.project.gkeService.cluster.networkPolicyConfig 9.0.0
 gcp.project.gkeService.cluster.nodeIpv4CidrSize 13.1.2
 gcp.project.gkeService.cluster.nodePools 9.0.0
 gcp.project.gkeService.cluster.nodepool 9.0.0
+gcp.project.gkeService.cluster.nodepool.autoRepair 13.12.2
+gcp.project.gkeService.cluster.nodepool.autoUpgrade 13.12.2
 gcp.project.gkeService.cluster.nodepool.autoscaling 11.0.82
 gcp.project.gkeService.cluster.nodepool.autoscaling.autoprovisioned 11.0.82
 gcp.project.gkeService.cluster.nodepool.autoscaling.enabled 11.0.82
@@ -2502,10 +2506,12 @@ gcp.project.gkeService.cluster.securityPostureConfig.mode 11.6.6
 gcp.project.gkeService.cluster.securityPostureConfig.vulnerabilityMode 11.6.6
 gcp.project.gkeService.cluster.servicesIpv4Cidr 13.1.2
 gcp.project.gkeService.cluster.shieldedNodesConfig 9.0.0
+gcp.project.gkeService.cluster.shieldedNodesEnabled 13.12.2
 gcp.project.gkeService.cluster.status 9.0.0
 gcp.project.gkeService.cluster.subnetwork 9.0.0
 gcp.project.gkeService.cluster.tpuIpv4CidrBlock 13.1.2
 gcp.project.gkeService.cluster.workloadIdentityConfig 9.0.0
+gcp.project.gkeService.cluster.workloadIdentityEnabled 13.12.2
 gcp.project.gkeService.clusters 9.0.0
 gcp.project.gkeService.projectId 9.0.0
 gcp.project.iam 9.0.0

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -437,10 +437,12 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 		}
 
 		var workloadIdCfg map[string]any
+		var workloadIdentityEnabled bool
 		if c.WorkloadIdentityConfig != nil {
 			workloadIdCfg = map[string]any{
 				"workloadPool": c.WorkloadIdentityConfig.WorkloadPool,
 			}
+			workloadIdentityEnabled = c.WorkloadIdentityConfig.WorkloadPool != ""
 		}
 
 		var ipAllocPolicy plugin.Resource
@@ -509,18 +511,26 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 		}
 
 		var binAuth map[string]any
+		var binaryAuthorizationEnabled bool
 		if c.BinaryAuthorization != nil {
 			binAuth = map[string]any{
 				"enabled":        c.BinaryAuthorization.Enabled,
 				"evaluationMode": c.BinaryAuthorization.EvaluationMode.String(),
 			}
+			// CIS interpretation: Binary Auth is "enabled" when evaluationMode is anything
+			// other than DISABLED. The legacy boolean Enabled field is also honored.
+			mode := c.BinaryAuthorization.EvaluationMode
+			binaryAuthorizationEnabled = c.BinaryAuthorization.Enabled ||
+				(mode != containerpb.BinaryAuthorization_EVALUATION_MODE_UNSPECIFIED && mode != containerpb.BinaryAuthorization_DISABLED)
 		}
 
 		var legacyAbac map[string]any
+		var legacyAbacEnabled bool
 		if c.LegacyAbac != nil {
 			legacyAbac = map[string]any{
 				"enabled": c.LegacyAbac.Enabled,
 			}
+			legacyAbacEnabled = c.LegacyAbac.Enabled
 		}
 
 		var masterAuth map[string]any
@@ -595,10 +605,12 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 		}
 
 		var shieldedNodesConfig map[string]any
+		var shieldedNodesEnabled bool
 		if c.ShieldedNodes != nil {
 			shieldedNodesConfig = map[string]any{
 				"enabled": c.ShieldedNodes.Enabled,
 			}
+			shieldedNodesEnabled = c.ShieldedNodes.Enabled
 		}
 
 		var costManagementConfig map[string]any
@@ -725,10 +737,13 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 			"expirationTime":                  llx.TimeDataPtr(parseTime(c.ExpireTime)),
 			"addonsConfig":                    llx.ResourceData(addonsConfig, "gcp.project.gkeService.cluster.addonsConfig"),
 			"workloadIdentityConfig":          llx.DictData(workloadIdCfg),
+			"workloadIdentityEnabled":         llx.BoolData(workloadIdentityEnabled),
 			"ipAllocationPolicy":              llx.ResourceData(ipAllocPolicy, "gcp.project.gkeService.cluster.ipAllocationPolicy"),
 			"networkConfig":                   llx.ResourceData(networkConfig, "gcp.project.gkeService.cluster.networkConfig"),
 			"binaryAuthorization":             llx.DictData(binAuth),
+			"binaryAuthorizationEnabled":      llx.BoolData(binaryAuthorizationEnabled),
 			"legacyAbac":                      llx.DictData(legacyAbac),
+			"legacyAbacEnabled":               llx.BoolData(legacyAbacEnabled),
 			"masterAuth":                      llx.DictData(masterAuth),
 			"masterAuthorizedNetworksConfig":  llx.DictData(masterAuthorizedNetworksCfg),
 			"masterAuthorizedNetworksEnabled": llx.BoolData(masterAuthorizedNetworksEnabled),
@@ -739,6 +754,7 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 			"databaseEncryption":              llx.DictData(databaseEncryption),
 			"databaseEncryptionState":         llx.StringData(databaseEncryptionState),
 			"shieldedNodesConfig":             llx.DictData(shieldedNodesConfig),
+			"shieldedNodesEnabled":            llx.BoolData(shieldedNodesEnabled),
 			"costManagementConfig":            llx.DictData(costManagementConfig),
 			"confidentialNodesConfig":         llx.DictData(confidentialNodesConfig),
 			"identityServiceConfig":           llx.DictData(identityServiceConfig),
@@ -816,6 +832,7 @@ func createMqlNodePool(runtime *plugin.Runtime, np *containerpb.NodePool, cluste
 	}
 
 	var management map[string]any
+	var autoUpgrade, autoRepair bool
 	if np.Management != nil {
 		var upgradeOpts map[string]any
 		if np.Management.UpgradeOptions != nil {
@@ -824,6 +841,8 @@ func createMqlNodePool(runtime *plugin.Runtime, np *containerpb.NodePool, cluste
 				"description":          np.Management.UpgradeOptions.Description,
 			}
 		}
+		autoUpgrade = np.Management.AutoUpgrade
+		autoRepair = np.Management.AutoRepair
 		management = map[string]any{
 			"autoRepair":     np.Management.AutoRepair,
 			"autoUpgrade":    np.Management.AutoUpgrade,
@@ -865,6 +884,8 @@ func createMqlNodePool(runtime *plugin.Runtime, np *containerpb.NodePool, cluste
 		"instanceGroupUrls": llx.ArrayData(convert.SliceAnyToInterface(np.InstanceGroupUrls), types.String),
 		"status":            llx.StringData(np.Status.String()),
 		"management":        llx.DictData(management),
+		"autoUpgrade":       llx.BoolData(autoUpgrade),
+		"autoRepair":        llx.BoolData(autoRepair),
 		"autoscaling":       llx.ResourceData(mqlPoolAutoscaling, "gcp.project.gkeService.cluster.nodepool.autoscaling"),
 		"statusMessage":     llx.StringData(np.StatusMessage),
 		"podIpv4CidrSize":   llx.IntData(int64(np.PodIpv4CidrSize)),


### PR DESCRIPTION
## Summary

Hoists six booleans from existing GKE config dicts so audits can ask the CIS Benchmark §5 questions in one MQL traversal — no dict drill-down.

| New field | Source | CIS |
|---|---|---|
| \`cluster.workloadIdentityEnabled\` | \`workloadIdentityConfig.workloadPool != \"\"\` | 5.2.2 |
| \`cluster.binaryAuthorizationEnabled\` | \`Enabled OR evaluationMode ∉ {UNSPECIFIED, DISABLED}\` | 5.10.5 |
| \`cluster.legacyAbacEnabled\` | \`legacyAbac.enabled\` | 5.8.4 (should be false) |
| \`cluster.shieldedNodesEnabled\` | \`shieldedNodesConfig.enabled\` | 5.5.5 |
| \`nodepool.autoUpgrade\` | \`management.autoUpgrade\` | 5.5.4 |
| \`nodepool.autoRepair\` | \`management.autoRepair\` | 5.5.3 |

Existing dicts (\`workloadIdentityConfig\`, \`binaryAuthorization\`, \`legacyAbac\`, \`shieldedNodesConfig\`, \`management\`) untouched for full data access.

\`binaryAuthorizationEnabled\` honors both the legacy boolean and the newer \`evaluationMode\` enum, since real clusters can use either.

## Test plan
- [x] 6 new entries at 13.12.2 in gcp.lr.versions
- [x] gcp provider builds & installs; gofmt clean
- [x] --info: all 6 fields resolve as type=bool

🤖 Generated with [Claude Code](https://claude.com/claude-code)