### PR TITLE
✨ GCP: SA-key filters, weak TLS, weak DNSSEC algorithm helpers

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -454,6 +454,7 @@ roku
 rootdir
 rpo
 RRULE
+RSASHA
 RSASSA
 RSession
 rtl

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -2800,6 +2800,20 @@ func (g *mqlGcpProjectComputeServiceSecurityPolicy) rules() ([]any, error) {
 
 // SSL Policies
 
+func (g *mqlGcpProjectComputeServiceSslPolicy) weakTlsVersion() (bool, error) {
+	if g.MinTlsVersion.Error != nil {
+		return false, g.MinTlsVersion.Error
+	}
+	switch g.MinTlsVersion.Data {
+	case "TLS_1_0", "TLS_1_1":
+		return true, nil
+	}
+	if g.Profile.Error != nil {
+		return false, g.Profile.Error
+	}
+	return g.Profile.Data == "COMPATIBLE", nil
+}
+
 func (g *mqlGcpProjectComputeServiceSslPolicy) id() (string, error) {
 	return g.Id.Data, g.Id.Error
 }

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -2800,7 +2800,7 @@ func (g *mqlGcpProjectComputeServiceSecurityPolicy) rules() ([]any, error) {
 
 // SSL Policies
 
-func (g *mqlGcpProjectComputeServiceSslPolicy) weakTlsVersion() (bool, error) {
+func (g *mqlGcpProjectComputeServiceSslPolicy) weakTls() (bool, error) {
 	if g.MinTlsVersion.Error != nil {
 		return false, g.MinTlsVersion.Error
 	}

--- a/providers/gcp/resources/dns.go
+++ b/providers/gcp/resources/dns.go
@@ -355,10 +355,11 @@ func (g *mqlGcpProjectDnsServiceRecordset) id() (string, error) {
 }
 
 func (g *mqlGcpProjectDnsServiceManagedzone) dnsSecAlgorithmWeak() (bool, error) {
-	if g.DnssecEnabled.Error != nil {
-		return false, g.DnssecEnabled.Error
+	enabled := g.GetDnssecEnabled()
+	if enabled.Error != nil {
+		return false, enabled.Error
 	}
-	if !g.DnssecEnabled.Data {
+	if !enabled.Data {
 		return false, nil
 	}
 	cfg := g.GetDnssecConfig()
@@ -382,8 +383,8 @@ func (g *mqlGcpProjectDnsServiceManagedzone) dnsSecAlgorithmWeak() (bool, error)
 			continue
 		}
 		alg, _ := spec["algorithm"].(string)
-		switch alg {
-		case "rsasha1", "rsasha1-nsec3-sha1", "RSASHA1", "RSASHA1-NSEC3-SHA1":
+		switch strings.ToUpper(alg) {
+		case "RSASHA1", "RSASHA1-NSEC3-SHA1":
 			return true, nil
 		}
 	}

--- a/providers/gcp/resources/dns.go
+++ b/providers/gcp/resources/dns.go
@@ -354,6 +354,42 @@ func (g *mqlGcpProjectDnsServiceRecordset) id() (string, error) {
 	return "gcp.project.dnsService.recordset/" + projectId + "/" + id, nil
 }
 
+func (g *mqlGcpProjectDnsServiceManagedzone) dnsSecAlgorithmWeak() (bool, error) {
+	if g.DnssecEnabled.Error != nil {
+		return false, g.DnssecEnabled.Error
+	}
+	if !g.DnssecEnabled.Data {
+		return false, nil
+	}
+	cfg := g.GetDnssecConfig()
+	if cfg.Error != nil {
+		return false, cfg.Error
+	}
+	if cfg.Data == nil {
+		return false, nil
+	}
+	cfgMap, ok := cfg.Data.(map[string]any)
+	if !ok {
+		return false, nil
+	}
+	specs, ok := cfgMap["defaultKeySpecs"].([]any)
+	if !ok {
+		return false, nil
+	}
+	for _, raw := range specs {
+		spec, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		alg, _ := spec["algorithm"].(string)
+		switch alg {
+		case "rsasha1", "rsasha1-nsec3-sha1", "RSASHA1", "RSASHA1-NSEC3-SHA1":
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (g *mqlGcpProjectDnsServiceManagedzone) iamPolicy() ([]any, error) {
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -2300,6 +2300,8 @@ private gcp.project.dnsService.managedzone @defaults("name") {
   cloudLoggingEnabled bool
   // Whether DNSSEC is enabled
   dnssecEnabled bool
+  // Whether DNSSEC is enabled but uses a weak signing algorithm (RSASHA1 / RSASHA1-NSEC3-SHA1)
+  dnsSecAlgorithmWeak() bool
   // Authorized VPC networks and GKE clusters for a private zone (empty for public zones)
   privateVisibilityConfig dict
   // Cloud DNS record set in the zone
@@ -3409,6 +3411,10 @@ private gcp.project.iamService.serviceAccount @defaults("displayName name") {
   disabled bool
   // Service account keys
   keys() []gcp.project.iamService.serviceAccount.key
+  // Whether this service account has at least one user-managed (non-disabled) key
+  hasUserManagedKeys() bool
+  // User-managed keys that are not disabled (the SA-key audit hot spot)
+  activeUserManagedKeys() []gcp.project.iamService.serviceAccount.key
   // Timestamp when the service account was last used to authenticate (from Policy Intelligence)
   lastAuthenticatedTime() time
 }
@@ -5172,6 +5178,8 @@ private gcp.project.computeService.sslPolicy @defaults("name profile minTlsVersi
   profile string
   // Minimum TLS version (TLS_1_0, TLS_1_1, TLS_1_2)
   minTlsVersion string
+  // Whether the policy permits weak TLS: minTlsVersion is TLS_1_0/TLS_1_1, or profile is COMPATIBLE
+  weakTlsVersion() bool
   // Custom features enabled when profile is CUSTOM
   customFeatures []string
   // Features enabled in the SSL policy

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -5178,8 +5178,8 @@ private gcp.project.computeService.sslPolicy @defaults("name profile minTlsVersi
   profile string
   // Minimum TLS version (TLS_1_0, TLS_1_1, TLS_1_2)
   minTlsVersion string
-  // Whether the policy permits weak TLS: minTlsVersion is TLS_1_0/TLS_1_1, or profile is COMPATIBLE
-  weakTlsVersion() bool
+  // Whether the policy permits weak TLS — true when minTlsVersion is TLS_1_0/TLS_1_1 (version weakness) or profile is COMPATIBLE (cipher-suite weakness, even when minTlsVersion is TLS_1_2)
+  weakTls() bool
   // Custom features enabled when profile is CUSTOM
   customFeatures []string
   // Features enabled in the SSL policy

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -8276,8 +8276,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.sslPolicy.minTlsVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSslPolicy).GetMinTlsVersion()).ToDataRes(types.String)
 	},
-	"gcp.project.computeService.sslPolicy.weakTlsVersion": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceSslPolicy).GetWeakTlsVersion()).ToDataRes(types.Bool)
+	"gcp.project.computeService.sslPolicy.weakTls": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceSslPolicy).GetWeakTls()).ToDataRes(types.Bool)
 	},
 	"gcp.project.computeService.sslPolicy.customFeatures": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSslPolicy).GetCustomFeatures()).ToDataRes(types.Array(types.String))
@@ -21631,8 +21631,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceSslPolicy).MinTlsVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.sslPolicy.weakTlsVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceSslPolicy).WeakTlsVersion, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+	"gcp.project.computeService.sslPolicy.weakTls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceSslPolicy).WeakTls, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.sslPolicy.customFeatures": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -50029,7 +50029,7 @@ type mqlGcpProjectComputeServiceSslPolicy struct {
 	Description     plugin.TValue[string]
 	Profile         plugin.TValue[string]
 	MinTlsVersion   plugin.TValue[string]
-	WeakTlsVersion  plugin.TValue[bool]
+	WeakTls         plugin.TValue[bool]
 	CustomFeatures  plugin.TValue[[]any]
 	EnabledFeatures plugin.TValue[[]any]
 	RegionUrl       plugin.TValue[string]
@@ -50095,9 +50095,9 @@ func (c *mqlGcpProjectComputeServiceSslPolicy) GetMinTlsVersion() *plugin.TValue
 	return &c.MinTlsVersion
 }
 
-func (c *mqlGcpProjectComputeServiceSslPolicy) GetWeakTlsVersion() *plugin.TValue[bool] {
-	return plugin.GetOrCompute[bool](&c.WeakTlsVersion, func() (bool, error) {
-		return c.weakTlsVersion()
+func (c *mqlGcpProjectComputeServiceSslPolicy) GetWeakTls() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.WeakTls, func() (bool, error) {
+		return c.weakTls()
 	})
 }
 

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -4751,6 +4751,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.dnsService.managedzone.dnssecEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDnsServiceManagedzone).GetDnssecEnabled()).ToDataRes(types.Bool)
 	},
+	"gcp.project.dnsService.managedzone.dnsSecAlgorithmWeak": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectDnsServiceManagedzone).GetDnsSecAlgorithmWeak()).ToDataRes(types.Bool)
+	},
 	"gcp.project.dnsService.managedzone.privateVisibilityConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDnsServiceManagedzone).GetPrivateVisibilityConfig()).ToDataRes(types.Dict)
 	},
@@ -6049,6 +6052,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.iamService.serviceAccount.keys": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectIamServiceServiceAccount).GetKeys()).ToDataRes(types.Array(types.Resource("gcp.project.iamService.serviceAccount.key")))
+	},
+	"gcp.project.iamService.serviceAccount.hasUserManagedKeys": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectIamServiceServiceAccount).GetHasUserManagedKeys()).ToDataRes(types.Bool)
+	},
+	"gcp.project.iamService.serviceAccount.activeUserManagedKeys": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectIamServiceServiceAccount).GetActiveUserManagedKeys()).ToDataRes(types.Array(types.Resource("gcp.project.iamService.serviceAccount.key")))
 	},
 	"gcp.project.iamService.serviceAccount.lastAuthenticatedTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectIamServiceServiceAccount).GetLastAuthenticatedTime()).ToDataRes(types.Time)
@@ -8266,6 +8275,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.sslPolicy.minTlsVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSslPolicy).GetMinTlsVersion()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.sslPolicy.weakTlsVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceSslPolicy).GetWeakTlsVersion()).ToDataRes(types.Bool)
 	},
 	"gcp.project.computeService.sslPolicy.customFeatures": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSslPolicy).GetCustomFeatures()).ToDataRes(types.Array(types.String))
@@ -16395,6 +16407,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectDnsServiceManagedzone).DnssecEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"gcp.project.dnsService.managedzone.dnsSecAlgorithmWeak": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectDnsServiceManagedzone).DnsSecAlgorithmWeak, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gcp.project.dnsService.managedzone.privateVisibilityConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectDnsServiceManagedzone).PrivateVisibilityConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -18361,6 +18377,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.iamService.serviceAccount.keys": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectIamServiceServiceAccount).Keys, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.iamService.serviceAccount.hasUserManagedKeys": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectIamServiceServiceAccount).HasUserManagedKeys, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.iamService.serviceAccount.activeUserManagedKeys": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectIamServiceServiceAccount).ActiveUserManagedKeys, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.iamService.serviceAccount.lastAuthenticatedTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21605,6 +21629,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.sslPolicy.minTlsVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceSslPolicy).MinTlsVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.sslPolicy.weakTlsVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceSslPolicy).WeakTlsVersion, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.sslPolicy.customFeatures": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -37263,6 +37291,7 @@ type mqlGcpProjectDnsServiceManagedzone struct {
 	Labels                  plugin.TValue[map[string]any]
 	CloudLoggingEnabled     plugin.TValue[bool]
 	DnssecEnabled           plugin.TValue[bool]
+	DnsSecAlgorithmWeak     plugin.TValue[bool]
 	PrivateVisibilityConfig plugin.TValue[any]
 	RecordSets              plugin.TValue[[]any]
 	IamPolicy               plugin.TValue[[]any]
@@ -37355,6 +37384,12 @@ func (c *mqlGcpProjectDnsServiceManagedzone) GetCloudLoggingEnabled() *plugin.TV
 
 func (c *mqlGcpProjectDnsServiceManagedzone) GetDnssecEnabled() *plugin.TValue[bool] {
 	return &c.DnssecEnabled
+}
+
+func (c *mqlGcpProjectDnsServiceManagedzone) GetDnsSecAlgorithmWeak() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.DnsSecAlgorithmWeak, func() (bool, error) {
+		return c.dnsSecAlgorithmWeak()
+	})
 }
 
 func (c *mqlGcpProjectDnsServiceManagedzone) GetPrivateVisibilityConfig() *plugin.TValue[any] {
@@ -42448,6 +42483,8 @@ type mqlGcpProjectIamServiceServiceAccount struct {
 	Oauth2ClientId        plugin.TValue[string]
 	Disabled              plugin.TValue[bool]
 	Keys                  plugin.TValue[[]any]
+	HasUserManagedKeys    plugin.TValue[bool]
+	ActiveUserManagedKeys plugin.TValue[[]any]
 	LastAuthenticatedTime plugin.TValue[*time.Time]
 }
 
@@ -42533,6 +42570,28 @@ func (c *mqlGcpProjectIamServiceServiceAccount) GetKeys() *plugin.TValue[[]any] 
 		}
 
 		return c.keys()
+	})
+}
+
+func (c *mqlGcpProjectIamServiceServiceAccount) GetHasUserManagedKeys() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasUserManagedKeys, func() (bool, error) {
+		return c.hasUserManagedKeys()
+	})
+}
+
+func (c *mqlGcpProjectIamServiceServiceAccount) GetActiveUserManagedKeys() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ActiveUserManagedKeys, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.iamService.serviceAccount", c.__id, "activeUserManagedKeys")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.activeUserManagedKeys()
 	})
 }
 
@@ -49970,6 +50029,7 @@ type mqlGcpProjectComputeServiceSslPolicy struct {
 	Description     plugin.TValue[string]
 	Profile         plugin.TValue[string]
 	MinTlsVersion   plugin.TValue[string]
+	WeakTlsVersion  plugin.TValue[bool]
 	CustomFeatures  plugin.TValue[[]any]
 	EnabledFeatures plugin.TValue[[]any]
 	RegionUrl       plugin.TValue[string]
@@ -50033,6 +50093,12 @@ func (c *mqlGcpProjectComputeServiceSslPolicy) GetProfile() *plugin.TValue[strin
 
 func (c *mqlGcpProjectComputeServiceSslPolicy) GetMinTlsVersion() *plugin.TValue[string] {
 	return &c.MinTlsVersion
+}
+
+func (c *mqlGcpProjectComputeServiceSslPolicy) GetWeakTlsVersion() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.WeakTlsVersion, func() (bool, error) {
+		return c.weakTlsVersion()
+	})
 }
 
 func (c *mqlGcpProjectComputeServiceSslPolicy) GetCustomFeatures() *plugin.TValue[[]any] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -1692,6 +1692,7 @@ gcp.project.computeService.sslPolicy.profile 11.5.1
 gcp.project.computeService.sslPolicy.regionUrl 11.5.1
 gcp.project.computeService.sslPolicy.selfLink 11.5.1
 gcp.project.computeService.sslPolicy.warnings 11.5.1
+gcp.project.computeService.sslPolicy.weakTlsVersion 13.12.2
 gcp.project.computeService.storagePool 11.6.6
 gcp.project.computeService.storagePool.capacityProvisioningType 11.6.6
 gcp.project.computeService.storagePool.created 11.6.6
@@ -2127,6 +2128,7 @@ gcp.project.dnsService.managedzone.cloudLoggingEnabled 11.6.6
 gcp.project.dnsService.managedzone.created 9.0.0
 gcp.project.dnsService.managedzone.description 9.0.0
 gcp.project.dnsService.managedzone.dnsName 9.0.0
+gcp.project.dnsService.managedzone.dnsSecAlgorithmWeak 13.12.2
 gcp.project.dnsService.managedzone.dnssecConfig 9.0.0
 gcp.project.dnsService.managedzone.dnssecEnabled 13.1.2
 gcp.project.dnsService.managedzone.iamPolicy 13.9.1
@@ -2522,10 +2524,12 @@ gcp.project.iamService.role.stage 11.6.6
 gcp.project.iamService.role.title 11.6.6
 gcp.project.iamService.roles 11.6.6
 gcp.project.iamService.serviceAccount 9.0.0
+gcp.project.iamService.serviceAccount.activeUserManagedKeys 13.12.2
 gcp.project.iamService.serviceAccount.description 9.0.0
 gcp.project.iamService.serviceAccount.disabled 9.0.0
 gcp.project.iamService.serviceAccount.displayName 9.0.0
 gcp.project.iamService.serviceAccount.email 9.0.0
+gcp.project.iamService.serviceAccount.hasUserManagedKeys 13.12.2
 gcp.project.iamService.serviceAccount.key 9.0.0
 gcp.project.iamService.serviceAccount.key.disabled 9.0.0
 gcp.project.iamService.serviceAccount.key.keyAlgorithm 9.0.0

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -1692,7 +1692,7 @@ gcp.project.computeService.sslPolicy.profile 11.5.1
 gcp.project.computeService.sslPolicy.regionUrl 11.5.1
 gcp.project.computeService.sslPolicy.selfLink 11.5.1
 gcp.project.computeService.sslPolicy.warnings 11.5.1
-gcp.project.computeService.sslPolicy.weakTlsVersion 13.12.2
+gcp.project.computeService.sslPolicy.weakTls 13.12.2
 gcp.project.computeService.storagePool 11.6.6
 gcp.project.computeService.storagePool.capacityProvisioningType 11.6.6
 gcp.project.computeService.storagePool.created 11.6.6

--- a/providers/gcp/resources/iam.go
+++ b/providers/gcp/resources/iam.go
@@ -307,6 +307,44 @@ type lastAuthActivity struct {
 	LastAuthenticatedTime string `json:"lastAuthenticatedTime"`
 }
 
+func (g *mqlGcpProjectIamServiceServiceAccount) hasUserManagedKeys() (bool, error) {
+	keys, err := g.activeUserManagedKeys()
+	if err != nil {
+		return false, err
+	}
+	return len(keys) > 0, nil
+}
+
+func (g *mqlGcpProjectIamServiceServiceAccount) activeUserManagedKeys() ([]any, error) {
+	keys := g.GetKeys()
+	if keys.Error != nil {
+		return nil, keys.Error
+	}
+	res := make([]any, 0)
+	for _, raw := range keys.Data {
+		key, ok := raw.(*mqlGcpProjectIamServiceServiceAccountKey)
+		if !ok || key == nil {
+			continue
+		}
+		userManaged := key.GetUserManaged()
+		if userManaged.Error != nil {
+			return nil, userManaged.Error
+		}
+		if !userManaged.Data {
+			continue
+		}
+		disabled := key.GetDisabled()
+		if disabled.Error != nil {
+			return nil, disabled.Error
+		}
+		if disabled.Data {
+			continue
+		}
+		res = append(res, key)
+	}
+	return res, nil
+}
+
 func (g *mqlGcpProjectIamServiceServiceAccount) lastAuthenticatedTime() (*time.Time, error) {
 	// If the SA wasn't found at init time, UniqueId is null; skip the call.
 	if g.UniqueId.IsNull() {


### PR DESCRIPTION
## Summary

Final PR in the GCP security-helper roadmap. Four derived helpers across three categories:

**Service-account key hygiene**
- \`iamService.serviceAccount.hasUserManagedKeys() bool\`
- \`iamService.serviceAccount.activeUserManagedKeys() []key\` — filters \`keys\` to \`userManaged && !disabled\` (the audit hot spot)

**TLS**
- \`computeService.sslPolicy.weakTlsVersion() bool\` — \`minTlsVersion ∈ {TLS_1_0, TLS_1_1}\` or \`profile == COMPATIBLE\`

**DNS**
- \`dnsService.managedzone.dnsSecAlgorithmWeak() bool\` — DNSSEC enabled AND any defaultKeySpec uses \`RSASHA1\` / \`RSASHA1-NSEC3-SHA1\`

Builds on \`userManaged bool\` shipped in PR #7480.

## Test plan
- [x] 4 new entries at 13.12.2 in gcp.lr.versions
- [x] gcp provider builds & installs; gofmt clean
- [x] --info: all 4 fields resolve with the right types

🤖 Generated with [Claude Code](https://claude.com/claude-code)