### PR TITLE
✨ GCP: 25 more security helpers across compute/SQL/GKE/storage/logging/secret/KMS

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -122,7 +122,6 @@ datastream
 DATAUSER
 DBFS
 DBRS
-DCV
 ddl
 ddos
 dedup
@@ -440,6 +439,7 @@ rai
 raidz
 ratebasedstatement
 rbcd
+Rdp
 recaptcha
 regexmatchstatement
 regexpatternsetreferencestatement
@@ -507,6 +507,7 @@ stepfunctions
 streamable
 stringx
 Stus
+subnetted
 subscriptionfilter
 superusers
 swi

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -3471,3 +3471,155 @@ func (g *mqlGcpProjectComputeServiceInstance) serialPortEnabled() (bool, error) 
 	}
 	return metadataBoolFlag(md.Data, "serial-port-enable"), nil
 }
+
+func (g *mqlGcpProjectComputeService) hasDefaultNetwork() (bool, error) {
+	networks := g.GetNetworks()
+	if networks.Error != nil {
+		return false, networks.Error
+	}
+	for _, raw := range networks.Data {
+		n, ok := raw.(*mqlGcpProjectComputeServiceNetwork)
+		if !ok || n == nil {
+			continue
+		}
+		name := n.GetName()
+		if name.Error != nil {
+			return false, name.Error
+		}
+		if name.Data == "default" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (g *mqlGcpProjectComputeServiceNetwork) legacy() (bool, error) {
+	if g.Mode.Error != nil {
+		return false, g.Mode.Error
+	}
+	return g.Mode.Data == "legacy", nil
+}
+
+func firewallSourceRangesContainPublic(ranges []any) bool {
+	for _, r := range ranges {
+		s, ok := r.(string)
+		if !ok {
+			continue
+		}
+		if s == "0.0.0.0/0" || s == "::/0" {
+			return true
+		}
+	}
+	return false
+}
+
+func allowedRulePermitsPort(rule map[string]any, port int) bool {
+	proto, _ := rule["ipProtocol"].(string)
+	if proto == "" {
+		proto, _ = rule["IPProtocol"].(string)
+	}
+	switch strings.ToLower(proto) {
+	case "tcp", "6", "all":
+	default:
+		return false
+	}
+	portsRaw, ok := rule["ports"].([]any)
+	if !ok || len(portsRaw) == 0 {
+		return true
+	}
+	for _, p := range portsRaw {
+		ps, ok := p.(string)
+		if !ok {
+			continue
+		}
+		if portMatches(ps, port) {
+			return true
+		}
+	}
+	return false
+}
+
+func portMatches(spec string, port int) bool {
+	if !strings.Contains(spec, "-") {
+		n, err := strconv.Atoi(spec)
+		if err != nil {
+			return false
+		}
+		return n == port
+	}
+	parts := strings.SplitN(spec, "-", 2)
+	low, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return false
+	}
+	high, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return false
+	}
+	return port >= low && port <= high
+}
+
+func (g *mqlGcpProjectComputeServiceFirewall) firewallOpenToInternetTcp(port int) (bool, error) {
+	if g.Disabled.Error != nil {
+		return false, g.Disabled.Error
+	}
+	if g.Disabled.Data {
+		return false, nil
+	}
+	if g.Direction.Error != nil {
+		return false, g.Direction.Error
+	}
+	if !strings.EqualFold(g.Direction.Data, "INGRESS") {
+		return false, nil
+	}
+	if g.SourceRanges.Error != nil {
+		return false, g.SourceRanges.Error
+	}
+	if !firewallSourceRangesContainPublic(g.SourceRanges.Data) {
+		return false, nil
+	}
+	if g.Allowed.Error != nil {
+		return false, g.Allowed.Error
+	}
+	for _, raw := range g.Allowed.Data {
+		rule, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if allowedRulePermitsPort(rule, port) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (g *mqlGcpProjectComputeServiceFirewall) allowsSshFromInternet() (bool, error) {
+	return g.firewallOpenToInternetTcp(22)
+}
+
+func (g *mqlGcpProjectComputeServiceFirewall) allowsRdpFromInternet() (bool, error) {
+	return g.firewallOpenToInternetTcp(3389)
+}
+
+func (g *mqlGcpProjectComputeServiceBackendService) cloudArmorEnabled() (bool, error) {
+	policy, err := g.securityPolicy()
+	if err != nil {
+		return false, err
+	}
+	return policy != nil, nil
+}
+
+func (g *mqlGcpProjectComputeServiceBackendService) iapEnabled() (bool, error) {
+	if g.Iap.Error != nil {
+		return false, g.Iap.Error
+	}
+	if g.Iap.Data == nil {
+		return false, nil
+	}
+	iapMap, ok := g.Iap.Data.(map[string]any)
+	if !ok {
+		return false, nil
+	}
+	enabled, _ := iapMap["enabled"].(bool)
+	return enabled, nil
+}

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -644,6 +644,8 @@ private gcp.project.computeService {
   firewalls() []gcp.project.computeService.firewall
   // Google Compute Engine VPC network in a project
   networks() []gcp.project.computeService.network
+  // Whether the project still has the auto-created `default` VPC network — true when a network named "default" exists
+  hasDefaultNetwork() bool
   // Logical partition of a VPC network
   subnetworks() []gcp.project.computeService.subnetwork
   // Cloud Routers in a project
@@ -1236,6 +1238,10 @@ private gcp.project.computeService.firewall @defaults("name") {
   sourceRanges []string
   // Whether this rule allows ingress traffic from the public internet (INGRESS, enabled, has allow rules, sourceRanges contains 0.0.0.0/0 or ::/0)
   openToInternet() bool
+  // Whether this rule permits SSH (tcp/22) from the public internet — narrower form of openToInternet for the SSH-specific port check
+  allowsSshFromInternet() bool
+  // Whether this rule permits RDP (tcp/3389) from the public internet — narrower form of openToInternet for the RDP-specific port check
+  allowsRdpFromInternet() bool
   // Source service accounts
   sourceServiceAccounts []string
   // Source tags
@@ -1262,6 +1268,8 @@ private gcp.project.computeService.firewall @defaults("name") {
 
 // Google Cloud (GCP) Compute VPC network resource
 gcp.project.computeService.network @defaults("name") {
+  // Whether the network is a legacy (single-region, non-subnetted) network — derived from mode == "legacy"
+  legacy() bool
   // Unique identifier
   id string
   // Project ID
@@ -1460,6 +1468,10 @@ private gcp.project.computeService.backendService @defaults("name") {
   securityPolicyUrl @maturity("deprecated") string
   // Cloud Armor security policy
   securityPolicy() gcp.project.computeService.securityPolicy
+  // Whether the backend service has a Cloud Armor security policy attached
+  cloudArmorEnabled() bool
+  // Whether Identity-Aware Proxy is enabled for the backend service (iap.enabled is true)
+  iapEnabled() bool
   // Client TLS policy and subject alternative names for the backend service
   securitySettings dict
   // Service binding URLs
@@ -1598,8 +1610,12 @@ private gcp.project.storageService.bucket @defaults("id") {
   metageneration int
   // Uniform bucket-level access configuration (enabled, lockedTime)
   uniformBucketLevelAccess dict
+  // Whether uniform bucket-level access is enabled — flat hoist of uniformBucketLevelAccess.enabled
+  uniformBucketLevelAccessEnabled() bool
   // Soft delete policy (retentionDurationSeconds, effectiveTime)
   softDeletePolicy dict
+  // Whether soft-delete is enabled — true when softDeletePolicy.retentionDurationSeconds > 0
+  softDeletePolicyEnabled() bool
   // Object retention mode (Enabled or empty)
   objectRetentionMode string
   // Automatic storage class management (enabled, toggleTime, terminalStorageClass)
@@ -1738,6 +1754,16 @@ private gcp.project.sqlService.instance @defaults("name") {
   replicaNames []string
   // Settings
   settings gcp.project.sqlService.instance.settings
+  // Whether the instance is reachable on a public IP — flat hoist of settings.ipConfiguration.ipv4Enabled
+  publicIpEnabled() bool
+  // Whether automated backups are enabled — flat hoist of settings.backupConfiguration.enabled
+  backupConfigurationEnabled() bool
+  // Whether point-in-time recovery is enabled — flat hoist of settings.backupConfiguration.pointInTimeRecoveryEnabled
+  pointInTimeRecoveryEnabled() bool
+  // Whether the instance has any built-in (non-IAM) database users
+  hasBuiltInUsers() bool
+  // Whether a built-in 'root' user exists (the most common SQL hardening finding)
+  localRootEnabled() bool
   // Service account email address
   serviceAccountEmailAddress string
   // Instance state
@@ -2398,8 +2424,12 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   description string
   // The logging service the cluster should use to write logs
   loggingService string
+  // Whether cluster logging is enabled (loggingService is set and not "none")
+  loggingEnabled() bool
   // The monitoring service the cluster should use to write metrics
   monitoringService string
+  // Whether cluster monitoring is enabled (monitoringService is set and not "none")
+  monitoringEnabled() bool
   // The name of the Google Compute Engine network to which the cluster is connected
   network string
   // The IP address range of the container pods in this cluster
@@ -2484,6 +2514,8 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   networkPolicy() gcp.project.gkeService.cluster.networkPolicy
   // The release channel that the cluster is subscribed to
   releaseChannel string
+  // Whether the cluster is on a managed release channel suitable for production (releaseChannel is "stable" or "regular"; excludes RAPID and unspecified)
+  releaseChannelManaged() bool
   // Whether Cloud TPU integration is enabled
   enableTpu bool
   // The number of nodes currently in the cluster
@@ -2771,6 +2803,10 @@ private gcp.project.gkeService.cluster.nodepool.config @defaults("machineType di
   serviceAccountEmail string
   // Google Cloud Platform Service Account to be used by the node VMs
   serviceAccount() gcp.project.iamService.serviceAccount
+  // Whether the node pool runs as the default Compute Engine service account (<projectNumber>-compute@developer.gserviceaccount.com or "default")
+  usesDefaultServiceAccount() bool
+  // Whether the node pool's service account is granted the broad cloud-platform OAuth scope
+  hasFullCloudPlatformScope() bool
   // The metadata key/value pairs assigned to instances in the cluster
   metadata map[string]string
   // The image type to use for this node
@@ -3131,6 +3167,8 @@ private gcp.project.kmsService.keyring.cryptokey @defaults("name purpose") {
   nextRotation time
   // Rotation period
   rotationPeriod time
+  // Whether automatic rotation is configured for this key (rotationPeriod is set)
+  rotationEnabled() bool
   // Template describing the settings for new crypto key versions
   versionTemplate dict
   // User-defined labels
@@ -3373,6 +3411,14 @@ private gcp.project.loggingservice.metric @defaults("description filter") {
   description string
   // Advanced log filter
   filter string
+  // Whether the filter matches IAM policy mutations (SetIamPolicy)
+  filtersIamChanges() bool
+  // Whether the filter matches audit-config mutations (auditConfigDelta on SetIamPolicy)
+  filtersAuditConfigChanges() bool
+  // Whether the filter matches compute route mutations (compute.routes.{insert,patch,delete})
+  filtersRouteChanges() bool
+  // Whether the filter matches compute firewall mutations (compute.firewalls.{insert,patch,delete})
+  filtersFirewallChanges() bool
   // Alert policies for this metric
   alertPolicies() []gcp.project.monitoringService.alertPolicy
 }
@@ -4494,6 +4540,8 @@ private gcp.project.secretmanagerService.secret @defaults("name createTime") {
   etag string
   // Rotation policy configuration
   rotation dict
+  // Whether rotation is configured (rotation.rotationPeriod or nextRotationTime is set)
+  rotationEnabled() bool
   // Version aliases mapping alias names to version numbers
   versionAliases map[string]int
   // Custom metadata annotations
@@ -4510,6 +4558,8 @@ private gcp.project.secretmanagerService.secret @defaults("name createTime") {
   versions() []gcp.project.secretmanagerService.secret.version
   // IAM policy for this secret
   iamPolicy() []gcp.resourcemanager.binding
+  // Whether the secret's IAM policy grants any role to allUsers or allAuthenticatedUsers
+  public() bool
 }
 
 // Google Cloud (GCP) Secret Manager secret version

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -2514,7 +2514,7 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   networkPolicy() gcp.project.gkeService.cluster.networkPolicy
   // The release channel that the cluster is subscribed to
   releaseChannel string
-  // Whether the cluster is on a managed release channel suitable for production (releaseChannel is "stable" or "regular"; excludes RAPID and unspecified)
+  // Whether the cluster is subscribed to a Google-managed release channel (rapid, regular, or stable). False for unspecified, which means upgrades are manual.
   releaseChannelManaged() bool
   // Whether Cloud TPU integration is enabled
   enableTpu bool

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -2603,6 +2603,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.networks": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeService).GetNetworks()).ToDataRes(types.Array(types.Resource("gcp.project.computeService.network")))
 	},
+	"gcp.project.computeService.hasDefaultNetwork": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeService).GetHasDefaultNetwork()).ToDataRes(types.Bool)
+	},
 	"gcp.project.computeService.subnetworks": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeService).GetSubnetworks()).ToDataRes(types.Array(types.Resource("gcp.project.computeService.subnetwork")))
 	},
@@ -3413,6 +3416,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.firewall.openToInternet": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceFirewall).GetOpenToInternet()).ToDataRes(types.Bool)
 	},
+	"gcp.project.computeService.firewall.allowsSshFromInternet": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceFirewall).GetAllowsSshFromInternet()).ToDataRes(types.Bool)
+	},
+	"gcp.project.computeService.firewall.allowsRdpFromInternet": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceFirewall).GetAllowsRdpFromInternet()).ToDataRes(types.Bool)
+	},
 	"gcp.project.computeService.firewall.sourceServiceAccounts": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceFirewall).GetSourceServiceAccounts()).ToDataRes(types.Array(types.String))
 	},
@@ -3445,6 +3454,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.firewall.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceFirewall).GetNetwork()).ToDataRes(types.Resource("gcp.project.computeService.network"))
+	},
+	"gcp.project.computeService.network.legacy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceNetwork).GetLegacy()).ToDataRes(types.Bool)
 	},
 	"gcp.project.computeService.network.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceNetwork).GetId()).ToDataRes(types.String)
@@ -3719,6 +3731,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.backendService.securityPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceBackendService).GetSecurityPolicy()).ToDataRes(types.Resource("gcp.project.computeService.securityPolicy"))
 	},
+	"gcp.project.computeService.backendService.cloudArmorEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceBackendService).GetCloudArmorEnabled()).ToDataRes(types.Bool)
+	},
+	"gcp.project.computeService.backendService.iapEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceBackendService).GetIapEnabled()).ToDataRes(types.Bool)
+	},
 	"gcp.project.computeService.backendService.securitySettings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceBackendService).GetSecuritySettings()).ToDataRes(types.Dict)
 	},
@@ -3902,8 +3920,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.storageService.bucket.uniformBucketLevelAccess": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectStorageServiceBucket).GetUniformBucketLevelAccess()).ToDataRes(types.Dict)
 	},
+	"gcp.project.storageService.bucket.uniformBucketLevelAccessEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucket).GetUniformBucketLevelAccessEnabled()).ToDataRes(types.Bool)
+	},
 	"gcp.project.storageService.bucket.softDeletePolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectStorageServiceBucket).GetSoftDeletePolicy()).ToDataRes(types.Dict)
+	},
+	"gcp.project.storageService.bucket.softDeletePolicyEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucket).GetSoftDeletePolicyEnabled()).ToDataRes(types.Bool)
 	},
 	"gcp.project.storageService.bucket.objectRetentionMode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectStorageServiceBucket).GetObjectRetentionMode()).ToDataRes(types.String)
@@ -4039,6 +4063,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.sqlService.instance.settings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstance).GetSettings()).ToDataRes(types.Resource("gcp.project.sqlService.instance.settings"))
+	},
+	"gcp.project.sqlService.instance.publicIpEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstance).GetPublicIpEnabled()).ToDataRes(types.Bool)
+	},
+	"gcp.project.sqlService.instance.backupConfigurationEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstance).GetBackupConfigurationEnabled()).ToDataRes(types.Bool)
+	},
+	"gcp.project.sqlService.instance.pointInTimeRecoveryEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstance).GetPointInTimeRecoveryEnabled()).ToDataRes(types.Bool)
+	},
+	"gcp.project.sqlService.instance.hasBuiltInUsers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstance).GetHasBuiltInUsers()).ToDataRes(types.Bool)
+	},
+	"gcp.project.sqlService.instance.localRootEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstance).GetLocalRootEnabled()).ToDataRes(types.Bool)
 	},
 	"gcp.project.sqlService.instance.serviceAccountEmailAddress": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstance).GetServiceAccountEmailAddress()).ToDataRes(types.String)
@@ -4874,8 +4913,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.gkeService.cluster.loggingService": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetLoggingService()).ToDataRes(types.String)
 	},
+	"gcp.project.gkeService.cluster.loggingEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetLoggingEnabled()).ToDataRes(types.Bool)
+	},
 	"gcp.project.gkeService.cluster.monitoringService": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetMonitoringService()).ToDataRes(types.String)
+	},
+	"gcp.project.gkeService.cluster.monitoringEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetMonitoringEnabled()).ToDataRes(types.Bool)
 	},
 	"gcp.project.gkeService.cluster.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetNetwork()).ToDataRes(types.String)
@@ -5002,6 +5047,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.gkeService.cluster.releaseChannel": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetReleaseChannel()).ToDataRes(types.String)
+	},
+	"gcp.project.gkeService.cluster.releaseChannelManaged": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetReleaseChannelManaged()).ToDataRes(types.Bool)
 	},
 	"gcp.project.gkeService.cluster.enableTpu": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetEnableTpu()).ToDataRes(types.Bool)
@@ -5344,6 +5392,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.gkeService.cluster.nodepool.config.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfig).GetServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
+	},
+	"gcp.project.gkeService.cluster.nodepool.config.usesDefaultServiceAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfig).GetUsesDefaultServiceAccount()).ToDataRes(types.Bool)
+	},
+	"gcp.project.gkeService.cluster.nodepool.config.hasFullCloudPlatformScope": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfig).GetHasFullCloudPlatformScope()).ToDataRes(types.Bool)
 	},
 	"gcp.project.gkeService.cluster.nodepool.config.metadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfig).GetMetadata()).ToDataRes(types.Map(types.String, types.String))
@@ -5741,6 +5795,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.kmsService.keyring.cryptokey.rotationPeriod": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokey).GetRotationPeriod()).ToDataRes(types.Time)
 	},
+	"gcp.project.kmsService.keyring.cryptokey.rotationEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokey).GetRotationEnabled()).ToDataRes(types.Bool)
+	},
 	"gcp.project.kmsService.keyring.cryptokey.versionTemplate": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokey).GetVersionTemplate()).ToDataRes(types.Dict)
 	},
@@ -6025,6 +6082,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.loggingservice.metric.filter": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectLoggingserviceMetric).GetFilter()).ToDataRes(types.String)
+	},
+	"gcp.project.loggingservice.metric.filtersIamChanges": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectLoggingserviceMetric).GetFiltersIamChanges()).ToDataRes(types.Bool)
+	},
+	"gcp.project.loggingservice.metric.filtersAuditConfigChanges": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectLoggingserviceMetric).GetFiltersAuditConfigChanges()).ToDataRes(types.Bool)
+	},
+	"gcp.project.loggingservice.metric.filtersRouteChanges": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectLoggingserviceMetric).GetFiltersRouteChanges()).ToDataRes(types.Bool)
+	},
+	"gcp.project.loggingservice.metric.filtersFirewallChanges": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectLoggingserviceMetric).GetFiltersFirewallChanges()).ToDataRes(types.Bool)
 	},
 	"gcp.project.loggingservice.metric.alertPolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectLoggingserviceMetric).GetAlertPolicies()).ToDataRes(types.Array(types.Resource("gcp.project.monitoringService.alertPolicy")))
@@ -7412,6 +7481,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.secretmanagerService.secret.rotation": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSecretmanagerServiceSecret).GetRotation()).ToDataRes(types.Dict)
 	},
+	"gcp.project.secretmanagerService.secret.rotationEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSecretmanagerServiceSecret).GetRotationEnabled()).ToDataRes(types.Bool)
+	},
 	"gcp.project.secretmanagerService.secret.versionAliases": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSecretmanagerServiceSecret).GetVersionAliases()).ToDataRes(types.Map(types.String, types.Int))
 	},
@@ -7435,6 +7507,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.secretmanagerService.secret.iamPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSecretmanagerServiceSecret).GetIamPolicy()).ToDataRes(types.Array(types.Resource("gcp.resourcemanager.binding")))
+	},
+	"gcp.project.secretmanagerService.secret.public": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSecretmanagerServiceSecret).GetPublic()).ToDataRes(types.Bool)
 	},
 	"gcp.project.secretmanagerService.secret.version.resourcePath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSecretmanagerServiceSecretVersion).GetResourcePath()).ToDataRes(types.String)
@@ -13422,6 +13497,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeService).Networks, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.hasDefaultNetwork": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeService).HasDefaultNetwork, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.subnetworks": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeService).Subnetworks, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -14554,6 +14633,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceFirewall).OpenToInternet, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.firewall.allowsSshFromInternet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceFirewall).AllowsSshFromInternet, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.firewall.allowsRdpFromInternet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceFirewall).AllowsRdpFromInternet, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.firewall.sourceServiceAccounts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceFirewall).SourceServiceAccounts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -14600,6 +14687,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.network.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceNetwork).__id, ok = v.Value.(string)
+		return
+	},
+	"gcp.project.computeService.network.legacy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceNetwork).Legacy, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.network.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -14982,6 +15073,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceBackendService).SecurityPolicy, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceSecurityPolicy](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.backendService.cloudArmorEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceBackendService).CloudArmorEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.backendService.iapEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceBackendService).IapEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.backendService.securitySettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceBackendService).SecuritySettings, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -15242,8 +15341,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectStorageServiceBucket).UniformBucketLevelAccess, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.storageService.bucket.uniformBucketLevelAccessEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucket).UniformBucketLevelAccessEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gcp.project.storageService.bucket.softDeletePolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectStorageServiceBucket).SoftDeletePolicy, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.storageService.bucket.softDeletePolicyEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucket).SoftDeletePolicyEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.storageService.bucket.objectRetentionMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15444,6 +15551,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.sqlService.instance.settings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstance).Settings, ok = plugin.RawToTValue[*mqlGcpProjectSqlServiceInstanceSettings](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.publicIpEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstance).PublicIpEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.backupConfigurationEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstance).BackupConfigurationEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.pointInTimeRecoveryEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstance).PointInTimeRecoveryEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.hasBuiltInUsers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstance).HasBuiltInUsers, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.localRootEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstance).LocalRootEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.sqlService.instance.serviceAccountEmailAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16662,8 +16789,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectGkeServiceCluster).LoggingService, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.gkeService.cluster.loggingEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).LoggingEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gcp.project.gkeService.cluster.monitoringService": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceCluster).MonitoringService, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.monitoringEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).MonitoringEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.gkeService.cluster.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16832,6 +16967,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.gkeService.cluster.releaseChannel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceCluster).ReleaseChannel, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.releaseChannelManaged": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).ReleaseChannelManaged, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.gkeService.cluster.enableTpu": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -17340,6 +17479,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.gkeService.cluster.nodepool.config.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceClusterNodepoolConfig).ServiceAccount, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.nodepool.config.usesDefaultServiceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceClusterNodepoolConfig).UsesDefaultServiceAccount, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.nodepool.config.hasFullCloudPlatformScope": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceClusterNodepoolConfig).HasFullCloudPlatformScope, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.gkeService.cluster.nodepool.config.metadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -17966,6 +18113,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectKmsServiceKeyringCryptokey).RotationPeriod, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"gcp.project.kmsService.keyring.cryptokey.rotationEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectKmsServiceKeyringCryptokey).RotationEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gcp.project.kmsService.keyring.cryptokey.versionTemplate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectKmsServiceKeyringCryptokey).VersionTemplate, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -18396,6 +18547,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.loggingservice.metric.filter": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectLoggingserviceMetric).Filter, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.loggingservice.metric.filtersIamChanges": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectLoggingserviceMetric).FiltersIamChanges, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.loggingservice.metric.filtersAuditConfigChanges": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectLoggingserviceMetric).FiltersAuditConfigChanges, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.loggingservice.metric.filtersRouteChanges": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectLoggingserviceMetric).FiltersRouteChanges, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.loggingservice.metric.filtersFirewallChanges": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectLoggingserviceMetric).FiltersFirewallChanges, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.loggingservice.metric.alertPolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20446,6 +20613,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectSecretmanagerServiceSecret).Rotation, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.secretmanagerService.secret.rotationEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSecretmanagerServiceSecret).RotationEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gcp.project.secretmanagerService.secret.versionAliases": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSecretmanagerServiceSecret).VersionAliases, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -20476,6 +20647,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.secretmanagerService.secret.iamPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSecretmanagerServiceSecret).IamPolicy, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.secretmanagerService.secret.public": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSecretmanagerServiceSecret).Public, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.secretmanagerService.secret.version.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -30782,6 +30957,7 @@ type mqlGcpProjectComputeService struct {
 	Images                   plugin.TValue[[]any]
 	Firewalls                plugin.TValue[[]any]
 	Networks                 plugin.TValue[[]any]
+	HasDefaultNetwork        plugin.TValue[bool]
 	Subnetworks              plugin.TValue[[]any]
 	Routers                  plugin.TValue[[]any]
 	MachineTypes             plugin.TValue[[]any]
@@ -30958,6 +31134,12 @@ func (c *mqlGcpProjectComputeService) GetNetworks() *plugin.TValue[[]any] {
 		}
 
 		return c.networks()
+	})
+}
+
+func (c *mqlGcpProjectComputeService) GetHasDefaultNetwork() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasDefaultNetwork, func() (bool, error) {
+		return c.hasDefaultNetwork()
 	})
 }
 
@@ -33409,6 +33591,8 @@ type mqlGcpProjectComputeServiceFirewall struct {
 	Disabled              plugin.TValue[bool]
 	SourceRanges          plugin.TValue[[]any]
 	OpenToInternet        plugin.TValue[bool]
+	AllowsSshFromInternet plugin.TValue[bool]
+	AllowsRdpFromInternet plugin.TValue[bool]
 	SourceServiceAccounts plugin.TValue[[]any]
 	SourceTags            plugin.TValue[[]any]
 	DestinationRanges     plugin.TValue[[]any]
@@ -33497,6 +33681,18 @@ func (c *mqlGcpProjectComputeServiceFirewall) GetOpenToInternet() *plugin.TValue
 	})
 }
 
+func (c *mqlGcpProjectComputeServiceFirewall) GetAllowsSshFromInternet() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.AllowsSshFromInternet, func() (bool, error) {
+		return c.allowsSshFromInternet()
+	})
+}
+
+func (c *mqlGcpProjectComputeServiceFirewall) GetAllowsRdpFromInternet() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.AllowsRdpFromInternet, func() (bool, error) {
+		return c.allowsRdpFromInternet()
+	})
+}
+
 func (c *mqlGcpProjectComputeServiceFirewall) GetSourceServiceAccounts() *plugin.TValue[[]any] {
 	return &c.SourceServiceAccounts
 }
@@ -33558,6 +33754,7 @@ type mqlGcpProjectComputeServiceNetwork struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlGcpProjectComputeServiceNetworkInternal
+	Legacy                                plugin.TValue[bool]
 	Id                                    plugin.TValue[string]
 	ProjectId                             plugin.TValue[string]
 	Name                                  plugin.TValue[string]
@@ -33613,6 +33810,12 @@ func (c *mqlGcpProjectComputeServiceNetwork) MqlName() string {
 
 func (c *mqlGcpProjectComputeServiceNetwork) MqlID() string {
 	return c.__id
+}
+
+func (c *mqlGcpProjectComputeServiceNetwork) GetLegacy() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Legacy, func() (bool, error) {
+		return c.legacy()
+	})
 }
 
 func (c *mqlGcpProjectComputeServiceNetwork) GetId() *plugin.TValue[string] {
@@ -34125,6 +34328,8 @@ type mqlGcpProjectComputeServiceBackendService struct {
 	RegionUrl                plugin.TValue[string]
 	SecurityPolicyUrl        plugin.TValue[string]
 	SecurityPolicy           plugin.TValue[*mqlGcpProjectComputeServiceSecurityPolicy]
+	CloudArmorEnabled        plugin.TValue[bool]
+	IapEnabled               plugin.TValue[bool]
 	SecuritySettings         plugin.TValue[any]
 	ServiceBindingUrls       plugin.TValue[[]any]
 	SessionAffinity          plugin.TValue[string]
@@ -34317,6 +34522,18 @@ func (c *mqlGcpProjectComputeServiceBackendService) GetSecurityPolicy() *plugin.
 		}
 
 		return c.securityPolicy()
+	})
+}
+
+func (c *mqlGcpProjectComputeServiceBackendService) GetCloudArmorEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.CloudArmorEnabled, func() (bool, error) {
+		return c.cloudArmorEnabled()
+	})
+}
+
+func (c *mqlGcpProjectComputeServiceBackendService) GetIapEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IapEnabled, func() (bool, error) {
+		return c.iapEnabled()
 	})
 }
 
@@ -34641,37 +34858,39 @@ type mqlGcpProjectStorageServiceBucket struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlGcpProjectStorageServiceBucketInternal
-	Id                       plugin.TValue[string]
-	ProjectId                plugin.TValue[string]
-	Name                     plugin.TValue[string]
-	Labels                   plugin.TValue[map[string]any]
-	Location                 plugin.TValue[string]
-	LocationType             plugin.TValue[string]
-	ProjectNumber            plugin.TValue[string]
-	StorageClass             plugin.TValue[string]
-	Created                  plugin.TValue[*time.Time]
-	Updated                  plugin.TValue[*time.Time]
-	IamPolicy                plugin.TValue[[]any]
-	IamConfiguration         plugin.TValue[any]
-	RetentionPolicy          plugin.TValue[any]
-	RetentionPolicyLocked    plugin.TValue[bool]
-	LoggingEnabled           plugin.TValue[bool]
-	Encryption               plugin.TValue[any]
-	DefaultKmsKey            plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
-	Lifecycle                plugin.TValue[[]any]
-	DefaultEventBasedHold    plugin.TValue[bool]
-	Rpo                      plugin.TValue[string]
-	SatisfiesPZS             plugin.TValue[bool]
-	VersioningEnabled        plugin.TValue[bool]
-	PublicAccessPrevention   plugin.TValue[string]
-	Metageneration           plugin.TValue[int64]
-	UniformBucketLevelAccess plugin.TValue[any]
-	SoftDeletePolicy         plugin.TValue[any]
-	ObjectRetentionMode      plugin.TValue[string]
-	Autoclass                plugin.TValue[any]
-	Acl                      plugin.TValue[[]any]
-	DefaultObjectAcl         plugin.TValue[[]any]
-	Public                   plugin.TValue[bool]
+	Id                              plugin.TValue[string]
+	ProjectId                       plugin.TValue[string]
+	Name                            plugin.TValue[string]
+	Labels                          plugin.TValue[map[string]any]
+	Location                        plugin.TValue[string]
+	LocationType                    plugin.TValue[string]
+	ProjectNumber                   plugin.TValue[string]
+	StorageClass                    plugin.TValue[string]
+	Created                         plugin.TValue[*time.Time]
+	Updated                         plugin.TValue[*time.Time]
+	IamPolicy                       plugin.TValue[[]any]
+	IamConfiguration                plugin.TValue[any]
+	RetentionPolicy                 plugin.TValue[any]
+	RetentionPolicyLocked           plugin.TValue[bool]
+	LoggingEnabled                  plugin.TValue[bool]
+	Encryption                      plugin.TValue[any]
+	DefaultKmsKey                   plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
+	Lifecycle                       plugin.TValue[[]any]
+	DefaultEventBasedHold           plugin.TValue[bool]
+	Rpo                             plugin.TValue[string]
+	SatisfiesPZS                    plugin.TValue[bool]
+	VersioningEnabled               plugin.TValue[bool]
+	PublicAccessPrevention          plugin.TValue[string]
+	Metageneration                  plugin.TValue[int64]
+	UniformBucketLevelAccess        plugin.TValue[any]
+	UniformBucketLevelAccessEnabled plugin.TValue[bool]
+	SoftDeletePolicy                plugin.TValue[any]
+	SoftDeletePolicyEnabled         plugin.TValue[bool]
+	ObjectRetentionMode             plugin.TValue[string]
+	Autoclass                       plugin.TValue[any]
+	Acl                             plugin.TValue[[]any]
+	DefaultObjectAcl                plugin.TValue[[]any]
+	Public                          plugin.TValue[bool]
 }
 
 // createGcpProjectStorageServiceBucket creates a new instance of this resource
@@ -34835,8 +35054,20 @@ func (c *mqlGcpProjectStorageServiceBucket) GetUniformBucketLevelAccess() *plugi
 	return &c.UniformBucketLevelAccess
 }
 
+func (c *mqlGcpProjectStorageServiceBucket) GetUniformBucketLevelAccessEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UniformBucketLevelAccessEnabled, func() (bool, error) {
+		return c.uniformBucketLevelAccessEnabled()
+	})
+}
+
 func (c *mqlGcpProjectStorageServiceBucket) GetSoftDeletePolicy() *plugin.TValue[any] {
 	return &c.SoftDeletePolicy
+}
+
+func (c *mqlGcpProjectStorageServiceBucket) GetSoftDeletePolicyEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.SoftDeletePolicyEnabled, func() (bool, error) {
+		return c.softDeletePolicyEnabled()
+	})
 }
 
 func (c *mqlGcpProjectStorageServiceBucket) GetObjectRetentionMode() *plugin.TValue[string] {
@@ -35155,6 +35386,11 @@ type mqlGcpProjectSqlServiceInstance struct {
 	Region                                     plugin.TValue[string]
 	ReplicaNames                               plugin.TValue[[]any]
 	Settings                                   plugin.TValue[*mqlGcpProjectSqlServiceInstanceSettings]
+	PublicIpEnabled                            plugin.TValue[bool]
+	BackupConfigurationEnabled                 plugin.TValue[bool]
+	PointInTimeRecoveryEnabled                 plugin.TValue[bool]
+	HasBuiltInUsers                            plugin.TValue[bool]
+	LocalRootEnabled                           plugin.TValue[bool]
 	ServiceAccountEmailAddress                 plugin.TValue[string]
 	State                                      plugin.TValue[string]
 	Databases                                  plugin.TValue[[]any]
@@ -35323,6 +35559,36 @@ func (c *mqlGcpProjectSqlServiceInstance) GetReplicaNames() *plugin.TValue[[]any
 
 func (c *mqlGcpProjectSqlServiceInstance) GetSettings() *plugin.TValue[*mqlGcpProjectSqlServiceInstanceSettings] {
 	return &c.Settings
+}
+
+func (c *mqlGcpProjectSqlServiceInstance) GetPublicIpEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.PublicIpEnabled, func() (bool, error) {
+		return c.publicIpEnabled()
+	})
+}
+
+func (c *mqlGcpProjectSqlServiceInstance) GetBackupConfigurationEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.BackupConfigurationEnabled, func() (bool, error) {
+		return c.backupConfigurationEnabled()
+	})
+}
+
+func (c *mqlGcpProjectSqlServiceInstance) GetPointInTimeRecoveryEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.PointInTimeRecoveryEnabled, func() (bool, error) {
+		return c.pointInTimeRecoveryEnabled()
+	})
+}
+
+func (c *mqlGcpProjectSqlServiceInstance) GetHasBuiltInUsers() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasBuiltInUsers, func() (bool, error) {
+		return c.hasBuiltInUsers()
+	})
+}
+
+func (c *mqlGcpProjectSqlServiceInstance) GetLocalRootEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.LocalRootEnabled, func() (bool, error) {
+		return c.localRootEnabled()
+	})
 }
 
 func (c *mqlGcpProjectSqlServiceInstance) GetServiceAccountEmailAddress() *plugin.TValue[string] {
@@ -38027,7 +38293,9 @@ type mqlGcpProjectGkeServiceCluster struct {
 	Name                            plugin.TValue[string]
 	Description                     plugin.TValue[string]
 	LoggingService                  plugin.TValue[string]
+	LoggingEnabled                  plugin.TValue[bool]
 	MonitoringService               plugin.TValue[string]
+	MonitoringEnabled               plugin.TValue[bool]
 	Network                         plugin.TValue[string]
 	ClusterIpv4Cidr                 plugin.TValue[string]
 	Subnetwork                      plugin.TValue[string]
@@ -38070,6 +38338,7 @@ type mqlGcpProjectGkeServiceCluster struct {
 	NetworkPolicyConfig             plugin.TValue[any]
 	NetworkPolicy                   plugin.TValue[*mqlGcpProjectGkeServiceClusterNetworkPolicy]
 	ReleaseChannel                  plugin.TValue[string]
+	ReleaseChannelManaged           plugin.TValue[bool]
 	EnableTpu                       plugin.TValue[bool]
 	CurrentNodeCount                plugin.TValue[int64]
 	SecurityPostureConfig           plugin.TValue[*mqlGcpProjectGkeServiceClusterSecurityPostureConfig]
@@ -38141,8 +38410,20 @@ func (c *mqlGcpProjectGkeServiceCluster) GetLoggingService() *plugin.TValue[stri
 	return &c.LoggingService
 }
 
+func (c *mqlGcpProjectGkeServiceCluster) GetLoggingEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.LoggingEnabled, func() (bool, error) {
+		return c.loggingEnabled()
+	})
+}
+
 func (c *mqlGcpProjectGkeServiceCluster) GetMonitoringService() *plugin.TValue[string] {
 	return &c.MonitoringService
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetMonitoringEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.MonitoringEnabled, func() (bool, error) {
+		return c.monitoringEnabled()
+	})
 }
 
 func (c *mqlGcpProjectGkeServiceCluster) GetNetwork() *plugin.TValue[string] {
@@ -38335,6 +38616,12 @@ func (c *mqlGcpProjectGkeServiceCluster) GetNetworkPolicy() *plugin.TValue[*mqlG
 
 func (c *mqlGcpProjectGkeServiceCluster) GetReleaseChannel() *plugin.TValue[string] {
 	return &c.ReleaseChannel
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetReleaseChannelManaged() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.ReleaseChannelManaged, func() (bool, error) {
+		return c.releaseChannelManaged()
+	})
 }
 
 func (c *mqlGcpProjectGkeServiceCluster) GetEnableTpu() *plugin.TValue[bool] {
@@ -39431,35 +39718,37 @@ type mqlGcpProjectGkeServiceClusterNodepoolConfig struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlGcpProjectGkeServiceClusterNodepoolConfigInternal it will be used here
-	Id                      plugin.TValue[string]
-	ProjectId               plugin.TValue[string]
-	MachineType             plugin.TValue[string]
-	DiskSizeGb              plugin.TValue[int64]
-	OauthScopes             plugin.TValue[[]any]
-	ServiceAccountEmail     plugin.TValue[string]
-	ServiceAccount          plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
-	Metadata                plugin.TValue[map[string]any]
-	ImageType               plugin.TValue[string]
-	Labels                  plugin.TValue[map[string]any]
-	LocalSsdCount           plugin.TValue[int64]
-	Tags                    plugin.TValue[[]any]
-	Preemptible             plugin.TValue[bool]
-	Accelerators            plugin.TValue[[]any]
-	DiskType                plugin.TValue[string]
-	MinCpuPlatform          plugin.TValue[string]
-	WorkloadMetadataMode    plugin.TValue[string]
-	Taints                  plugin.TValue[[]any]
-	SandboxConfig           plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigSandboxConfig]
-	ShieldedInstanceConfig  plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigShieldedInstanceConfig]
-	LinuxNodeConfig         plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig]
-	KubeletConfig           plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigKubeletConfig]
-	BootDiskKmsKey          plugin.TValue[string]
-	GcfsConfig              plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigGcfsConfig]
-	AdvancedMachineFeatures plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigAdvancedMachineFeatures]
-	GvnicConfig             plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigGvnicConfig]
-	Spot                    plugin.TValue[bool]
-	ConfidentialNodes       plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigConfidentialNodes]
-	GpuDirectConfig         plugin.TValue[any]
+	Id                        plugin.TValue[string]
+	ProjectId                 plugin.TValue[string]
+	MachineType               plugin.TValue[string]
+	DiskSizeGb                plugin.TValue[int64]
+	OauthScopes               plugin.TValue[[]any]
+	ServiceAccountEmail       plugin.TValue[string]
+	ServiceAccount            plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
+	UsesDefaultServiceAccount plugin.TValue[bool]
+	HasFullCloudPlatformScope plugin.TValue[bool]
+	Metadata                  plugin.TValue[map[string]any]
+	ImageType                 plugin.TValue[string]
+	Labels                    plugin.TValue[map[string]any]
+	LocalSsdCount             plugin.TValue[int64]
+	Tags                      plugin.TValue[[]any]
+	Preemptible               plugin.TValue[bool]
+	Accelerators              plugin.TValue[[]any]
+	DiskType                  plugin.TValue[string]
+	MinCpuPlatform            plugin.TValue[string]
+	WorkloadMetadataMode      plugin.TValue[string]
+	Taints                    plugin.TValue[[]any]
+	SandboxConfig             plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigSandboxConfig]
+	ShieldedInstanceConfig    plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigShieldedInstanceConfig]
+	LinuxNodeConfig           plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig]
+	KubeletConfig             plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigKubeletConfig]
+	BootDiskKmsKey            plugin.TValue[string]
+	GcfsConfig                plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigGcfsConfig]
+	AdvancedMachineFeatures   plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigAdvancedMachineFeatures]
+	GvnicConfig               plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigGvnicConfig]
+	Spot                      plugin.TValue[bool]
+	ConfidentialNodes         plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigConfidentialNodes]
+	GpuDirectConfig           plugin.TValue[any]
 }
 
 // createGcpProjectGkeServiceClusterNodepoolConfig creates a new instance of this resource
@@ -39536,6 +39825,18 @@ func (c *mqlGcpProjectGkeServiceClusterNodepoolConfig) GetServiceAccount() *plug
 		}
 
 		return c.serviceAccount()
+	})
+}
+
+func (c *mqlGcpProjectGkeServiceClusterNodepoolConfig) GetUsesDefaultServiceAccount() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UsesDefaultServiceAccount, func() (bool, error) {
+		return c.usesDefaultServiceAccount()
+	})
+}
+
+func (c *mqlGcpProjectGkeServiceClusterNodepoolConfig) GetHasFullCloudPlatformScope() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasFullCloudPlatformScope, func() (bool, error) {
+		return c.hasFullCloudPlatformScope()
 	})
 }
 
@@ -41328,6 +41629,7 @@ type mqlGcpProjectKmsServiceKeyringCryptokey struct {
 	Created                       plugin.TValue[*time.Time]
 	NextRotation                  plugin.TValue[*time.Time]
 	RotationPeriod                plugin.TValue[*time.Time]
+	RotationEnabled               plugin.TValue[bool]
 	VersionTemplate               plugin.TValue[any]
 	Labels                        plugin.TValue[map[string]any]
 	ImportOnly                    plugin.TValue[bool]
@@ -41402,6 +41704,12 @@ func (c *mqlGcpProjectKmsServiceKeyringCryptokey) GetNextRotation() *plugin.TVal
 
 func (c *mqlGcpProjectKmsServiceKeyringCryptokey) GetRotationPeriod() *plugin.TValue[*time.Time] {
 	return &c.RotationPeriod
+}
+
+func (c *mqlGcpProjectKmsServiceKeyringCryptokey) GetRotationEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.RotationEnabled, func() (bool, error) {
+		return c.rotationEnabled()
+	})
 }
 
 func (c *mqlGcpProjectKmsServiceKeyringCryptokey) GetVersionTemplate() *plugin.TValue[any] {
@@ -42483,11 +42791,15 @@ type mqlGcpProjectLoggingserviceMetric struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlGcpProjectLoggingserviceMetricInternal it will be used here
-	Id            plugin.TValue[string]
-	ProjectId     plugin.TValue[string]
-	Description   plugin.TValue[string]
-	Filter        plugin.TValue[string]
-	AlertPolicies plugin.TValue[[]any]
+	Id                        plugin.TValue[string]
+	ProjectId                 plugin.TValue[string]
+	Description               plugin.TValue[string]
+	Filter                    plugin.TValue[string]
+	FiltersIamChanges         plugin.TValue[bool]
+	FiltersAuditConfigChanges plugin.TValue[bool]
+	FiltersRouteChanges       plugin.TValue[bool]
+	FiltersFirewallChanges    plugin.TValue[bool]
+	AlertPolicies             plugin.TValue[[]any]
 }
 
 // createGcpProjectLoggingserviceMetric creates a new instance of this resource
@@ -42541,6 +42853,30 @@ func (c *mqlGcpProjectLoggingserviceMetric) GetDescription() *plugin.TValue[stri
 
 func (c *mqlGcpProjectLoggingserviceMetric) GetFilter() *plugin.TValue[string] {
 	return &c.Filter
+}
+
+func (c *mqlGcpProjectLoggingserviceMetric) GetFiltersIamChanges() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.FiltersIamChanges, func() (bool, error) {
+		return c.filtersIamChanges()
+	})
+}
+
+func (c *mqlGcpProjectLoggingserviceMetric) GetFiltersAuditConfigChanges() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.FiltersAuditConfigChanges, func() (bool, error) {
+		return c.filtersAuditConfigChanges()
+	})
+}
+
+func (c *mqlGcpProjectLoggingserviceMetric) GetFiltersRouteChanges() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.FiltersRouteChanges, func() (bool, error) {
+		return c.filtersRouteChanges()
+	})
+}
+
+func (c *mqlGcpProjectLoggingserviceMetric) GetFiltersFirewallChanges() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.FiltersFirewallChanges, func() (bool, error) {
+		return c.filtersFirewallChanges()
+	})
 }
 
 func (c *mqlGcpProjectLoggingserviceMetric) GetAlertPolicies() *plugin.TValue[[]any] {
@@ -47328,6 +47664,7 @@ type mqlGcpProjectSecretmanagerServiceSecret struct {
 	ExpireTime                plugin.TValue[*time.Time]
 	Etag                      plugin.TValue[string]
 	Rotation                  plugin.TValue[any]
+	RotationEnabled           plugin.TValue[bool]
 	VersionAliases            plugin.TValue[map[string]any]
 	Annotations               plugin.TValue[map[string]any]
 	VersionDestroyTtl         plugin.TValue[*time.Time]
@@ -47336,6 +47673,7 @@ type mqlGcpProjectSecretmanagerServiceSecret struct {
 	Tags                      plugin.TValue[map[string]any]
 	Versions                  plugin.TValue[[]any]
 	IamPolicy                 plugin.TValue[[]any]
+	Public                    plugin.TValue[bool]
 }
 
 // createGcpProjectSecretmanagerServiceSecret creates a new instance of this resource
@@ -47415,6 +47753,12 @@ func (c *mqlGcpProjectSecretmanagerServiceSecret) GetRotation() *plugin.TValue[a
 	return &c.Rotation
 }
 
+func (c *mqlGcpProjectSecretmanagerServiceSecret) GetRotationEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.RotationEnabled, func() (bool, error) {
+		return c.rotationEnabled()
+	})
+}
+
 func (c *mqlGcpProjectSecretmanagerServiceSecret) GetVersionAliases() *plugin.TValue[map[string]any] {
 	return &c.VersionAliases
 }
@@ -47480,6 +47824,12 @@ func (c *mqlGcpProjectSecretmanagerServiceSecret) GetIamPolicy() *plugin.TValue[
 		}
 
 		return c.iamPolicy()
+	})
+}
+
+func (c *mqlGcpProjectSecretmanagerServiceSecret) GetPublic() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Public, func() (bool, error) {
+		return c.public()
 	})
 }
 

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -1075,6 +1075,7 @@ gcp.project.computeService.backendService.cdnPolicy.serveWhileStale 9.0.0
 gcp.project.computeService.backendService.cdnPolicy.signedUrlCacheMaxAgeSec 9.0.0
 gcp.project.computeService.backendService.cdnPolicy.signedUrlKeyNames 9.0.0
 gcp.project.computeService.backendService.circuitBreakers 9.0.0
+gcp.project.computeService.backendService.cloudArmorEnabled 13.12.2
 gcp.project.computeService.backendService.compressionMode 9.0.0
 gcp.project.computeService.backendService.connectionDraining 9.0.0
 gcp.project.computeService.backendService.connectionTrackingPolicy 9.0.0
@@ -1089,6 +1090,7 @@ gcp.project.computeService.backendService.failoverPolicy 9.0.0
 gcp.project.computeService.backendService.fingerprint 13.1.2
 gcp.project.computeService.backendService.healthChecks 9.0.0
 gcp.project.computeService.backendService.iap 9.0.0
+gcp.project.computeService.backendService.iapEnabled 13.12.2
 gcp.project.computeService.backendService.id 9.0.0
 gcp.project.computeService.backendService.ipAddressSelectionPolicy 11.6.6
 gcp.project.computeService.backendService.loadBalancingScheme 9.0.0
@@ -1158,6 +1160,8 @@ gcp.project.computeService.externalVpnGateway.selfLink 13.6.1
 gcp.project.computeService.externalVpnGateways 13.6.1
 gcp.project.computeService.firewall 9.0.0
 gcp.project.computeService.firewall.allowed 9.0.0
+gcp.project.computeService.firewall.allowsRdpFromInternet 13.12.2
+gcp.project.computeService.firewall.allowsSshFromInternet 13.12.2
 gcp.project.computeService.firewall.created 9.0.0
 gcp.project.computeService.firewall.denied 9.0.0
 gcp.project.computeService.firewall.description 9.0.0
@@ -1238,6 +1242,7 @@ gcp.project.computeService.forwardingRule.subnetwork 9.0.0
 gcp.project.computeService.forwardingRule.subnetworkUrl 9.0.0
 gcp.project.computeService.forwardingRule.targetUrl 9.0.0
 gcp.project.computeService.forwardingRules 9.0.0
+gcp.project.computeService.hasDefaultNetwork 13.12.2
 gcp.project.computeService.healthCheck 11.6.6
 gcp.project.computeService.healthCheck.checkIntervalSec 11.6.6
 gcp.project.computeService.healthCheck.created 11.6.6
@@ -1457,6 +1462,7 @@ gcp.project.computeService.network.firewallPolicy 11.6.6
 gcp.project.computeService.network.gatewayIPv4 9.0.0
 gcp.project.computeService.network.id 9.0.0
 gcp.project.computeService.network.internalIpv6Range 11.6.6
+gcp.project.computeService.network.legacy 13.12.2
 gcp.project.computeService.network.mode 9.0.0
 gcp.project.computeService.network.mtu 9.0.0
 gcp.project.computeService.network.name 9.0.0
@@ -2363,6 +2369,7 @@ gcp.project.gkeService.cluster.legacyAbac 9.0.0
 gcp.project.gkeService.cluster.legacyAbacEnabled 13.12.2
 gcp.project.gkeService.cluster.location 9.0.0
 gcp.project.gkeService.cluster.locations 9.0.0
+gcp.project.gkeService.cluster.loggingEnabled 13.12.2
 gcp.project.gkeService.cluster.loggingService 9.0.0
 gcp.project.gkeService.cluster.maintenancePolicy 11.6.6
 gcp.project.gkeService.cluster.maintenancePolicy.dailyMaintenanceWindowDuration 11.6.6
@@ -2378,6 +2385,7 @@ gcp.project.gkeService.cluster.masterAuthorizedNetworksConfig 9.0.0
 gcp.project.gkeService.cluster.masterAuthorizedNetworksEnabled 13.12.2
 gcp.project.gkeService.cluster.masterGlobalAccessEnabled 13.12.2
 gcp.project.gkeService.cluster.meshCertificates 13.7.2
+gcp.project.gkeService.cluster.monitoringEnabled 13.12.2
 gcp.project.gkeService.cluster.monitoringService 9.0.0
 gcp.project.gkeService.cluster.name 9.0.0
 gcp.project.gkeService.cluster.network 9.0.0
@@ -2441,6 +2449,7 @@ gcp.project.gkeService.cluster.nodepool.config.gpuDirectConfig 13.6.1
 gcp.project.gkeService.cluster.nodepool.config.gvnicConfig 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.gvnicConfig.enabled 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.gvnicConfig.id 9.0.0
+gcp.project.gkeService.cluster.nodepool.config.hasFullCloudPlatformScope 13.12.2
 gcp.project.gkeService.cluster.nodepool.config.id 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.imageType 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.kubeletConfig 9.0.0
@@ -2476,6 +2485,7 @@ gcp.project.gkeService.cluster.nodepool.config.shieldedInstanceConfig.id 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.spot 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.tags 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.taints 9.0.0
+gcp.project.gkeService.cluster.nodepool.config.usesDefaultServiceAccount 13.12.2
 gcp.project.gkeService.cluster.nodepool.config.workloadMetadataMode 9.0.0
 gcp.project.gkeService.cluster.nodepool.etag 13.1.2
 gcp.project.gkeService.cluster.nodepool.id 9.0.0
@@ -2513,6 +2523,7 @@ gcp.project.gkeService.cluster.privateEndpointEnabled 13.12.2
 gcp.project.gkeService.cluster.privateNodesEnabled 13.12.2
 gcp.project.gkeService.cluster.projectId 9.0.0
 gcp.project.gkeService.cluster.releaseChannel 9.0.0
+gcp.project.gkeService.cluster.releaseChannelManaged 13.12.2
 gcp.project.gkeService.cluster.resourceLabels 9.0.0
 gcp.project.gkeService.cluster.securityPostureConfig 11.6.6
 gcp.project.gkeService.cluster.securityPostureConfig.id 11.6.6
@@ -2617,6 +2628,7 @@ gcp.project.kmsService.keyring.cryptokey.primary 9.0.0
 gcp.project.kmsService.keyring.cryptokey.public 13.12.2
 gcp.project.kmsService.keyring.cryptokey.purpose 9.0.0
 gcp.project.kmsService.keyring.cryptokey.resourcePath 9.0.0
+gcp.project.kmsService.keyring.cryptokey.rotationEnabled 13.12.2
 gcp.project.kmsService.keyring.cryptokey.rotationPeriod 9.0.0
 gcp.project.kmsService.keyring.cryptokey.version 9.0.0
 gcp.project.kmsService.keyring.cryptokey.version.algorithm 9.0.0
@@ -2705,6 +2717,10 @@ gcp.project.loggingservice.metric 9.0.0
 gcp.project.loggingservice.metric.alertPolicies 9.0.0
 gcp.project.loggingservice.metric.description 9.0.0
 gcp.project.loggingservice.metric.filter 9.0.0
+gcp.project.loggingservice.metric.filtersAuditConfigChanges 13.12.2
+gcp.project.loggingservice.metric.filtersFirewallChanges 13.12.2
+gcp.project.loggingservice.metric.filtersIamChanges 13.12.2
+gcp.project.loggingservice.metric.filtersRouteChanges 13.12.2
 gcp.project.loggingservice.metric.id 9.0.0
 gcp.project.loggingservice.metric.projectId 9.0.0
 gcp.project.loggingservice.metrics 9.0.0
@@ -3179,9 +3195,11 @@ gcp.project.secretmanagerService.secret.kmsKeys 13.12.2
 gcp.project.secretmanagerService.secret.labels 11.1.0
 gcp.project.secretmanagerService.secret.name 11.1.0
 gcp.project.secretmanagerService.secret.projectId 11.1.0
+gcp.project.secretmanagerService.secret.public 13.12.2
 gcp.project.secretmanagerService.secret.replication 11.1.0
 gcp.project.secretmanagerService.secret.resourcePath 11.1.0
 gcp.project.secretmanagerService.secret.rotation 11.1.0
+gcp.project.secretmanagerService.secret.rotationEnabled 13.12.2
 gcp.project.secretmanagerService.secret.tags 13.12.2
 gcp.project.secretmanagerService.secret.topics 11.1.0
 gcp.project.secretmanagerService.secret.version 11.1.0
@@ -3350,6 +3368,7 @@ gcp.project.sqlService.backupRun.windowStartTime 13.11.2
 gcp.project.sqlService.instance 9.0.0
 gcp.project.sqlService.instance.availableMaintenanceVersions 9.0.0
 gcp.project.sqlService.instance.backendType 9.0.0
+gcp.project.sqlService.instance.backupConfigurationEnabled 13.12.2
 gcp.project.sqlService.instance.backupRuns 13.11.2
 gcp.project.sqlService.instance.connectionName 9.0.0
 gcp.project.sqlService.instance.created 9.0.0
@@ -3370,6 +3389,7 @@ gcp.project.sqlService.instance.dnsName 11.6.6
 gcp.project.sqlService.instance.etag 13.1.2
 gcp.project.sqlService.instance.failoverReplica 9.0.0
 gcp.project.sqlService.instance.gceZone 9.0.0
+gcp.project.sqlService.instance.hasBuiltInUsers 13.12.2
 gcp.project.sqlService.instance.instanceType 9.0.0
 gcp.project.sqlService.instance.ipAddresses 9.0.0
 gcp.project.sqlService.instance.ipMapping 9.0.0
@@ -3378,13 +3398,16 @@ gcp.project.sqlService.instance.ipMapping.ipAddress 9.0.0
 gcp.project.sqlService.instance.ipMapping.timeToRetire 9.0.0
 gcp.project.sqlService.instance.ipMapping.type 9.0.0
 gcp.project.sqlService.instance.kmsKey 13.12.2
+gcp.project.sqlService.instance.localRootEnabled 13.12.2
 gcp.project.sqlService.instance.maintenanceVersion 9.0.0
 gcp.project.sqlService.instance.masterInstanceName 9.0.0
 gcp.project.sqlService.instance.maxDiskSize 9.0.0
 gcp.project.sqlService.instance.name 9.0.0
+gcp.project.sqlService.instance.pointInTimeRecoveryEnabled 13.12.2
 gcp.project.sqlService.instance.primaryDnsName 11.6.6
 gcp.project.sqlService.instance.projectId 9.0.0
 gcp.project.sqlService.instance.pscServiceAttachmentLink 11.6.6
+gcp.project.sqlService.instance.publicIpEnabled 13.12.2
 gcp.project.sqlService.instance.region 9.0.0
 gcp.project.sqlService.instance.replicaConfiguration 13.7.2
 gcp.project.sqlService.instance.replicaNames 9.0.0
@@ -3541,8 +3564,10 @@ gcp.project.storageService.bucket.retentionPolicyLocked 13.12.2
 gcp.project.storageService.bucket.rpo 11.6.6
 gcp.project.storageService.bucket.satisfiesPZS 11.6.6
 gcp.project.storageService.bucket.softDeletePolicy 13.7.2
+gcp.project.storageService.bucket.softDeletePolicyEnabled 13.12.2
 gcp.project.storageService.bucket.storageClass 9.0.0
 gcp.project.storageService.bucket.uniformBucketLevelAccess 13.7.2
+gcp.project.storageService.bucket.uniformBucketLevelAccessEnabled 13.12.2
 gcp.project.storageService.bucket.updated 9.0.0
 gcp.project.storageService.bucket.versioningEnabled 11.6.6
 gcp.project.storageService.buckets 9.0.0

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -1235,3 +1235,54 @@ func (g *mqlGcpProjectGkeServiceClusterNotificationConfig) topic() (*mqlGcpProje
 	}
 	return res.(*mqlGcpProjectPubsubServiceTopic), nil
 }
+
+func (g *mqlGcpProjectGkeServiceCluster) loggingEnabled() (bool, error) {
+	if g.LoggingService.Error != nil {
+		return false, g.LoggingService.Error
+	}
+	v := strings.ToLower(g.LoggingService.Data)
+	return v != "" && v != "none", nil
+}
+
+func (g *mqlGcpProjectGkeServiceCluster) monitoringEnabled() (bool, error) {
+	if g.MonitoringService.Error != nil {
+		return false, g.MonitoringService.Error
+	}
+	v := strings.ToLower(g.MonitoringService.Data)
+	return v != "" && v != "none", nil
+}
+
+func (g *mqlGcpProjectGkeServiceCluster) releaseChannelManaged() (bool, error) {
+	if g.ReleaseChannel.Error != nil {
+		return false, g.ReleaseChannel.Error
+	}
+	switch strings.ToLower(g.ReleaseChannel.Data) {
+	case "stable", "regular":
+		return true, nil
+	}
+	return false, nil
+}
+
+func (g *mqlGcpProjectGkeServiceClusterNodepoolConfig) usesDefaultServiceAccount() (bool, error) {
+	if g.ServiceAccountEmail.Error != nil {
+		return false, g.ServiceAccountEmail.Error
+	}
+	email := g.ServiceAccountEmail.Data
+	if email == "" || email == "default" {
+		return true, nil
+	}
+	return defaultComputeServiceAccountRe.MatchString(email), nil
+}
+
+func (g *mqlGcpProjectGkeServiceClusterNodepoolConfig) hasFullCloudPlatformScope() (bool, error) {
+	scopes := g.GetOauthScopes()
+	if scopes.Error != nil {
+		return false, scopes.Error
+	}
+	for _, s := range scopes.Data {
+		if str, ok := s.(string); ok && str == cloudPlatformOAuthScope {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -1257,7 +1257,7 @@ func (g *mqlGcpProjectGkeServiceCluster) releaseChannelManaged() (bool, error) {
 		return false, g.ReleaseChannel.Error
 	}
 	switch strings.ToLower(g.ReleaseChannel.Data) {
-	case "stable", "regular":
+	case "rapid", "regular", "stable":
 		return true, nil
 	}
 	return false, nil

--- a/providers/gcp/resources/kms.go
+++ b/providers/gcp/resources/kms.go
@@ -513,6 +513,14 @@ func (g *mqlGcpProjectKmsServiceKeyringCryptokey) versions() ([]any, error) {
 	return versions, nil
 }
 
+func (g *mqlGcpProjectKmsServiceKeyringCryptokey) rotationEnabled() (bool, error) {
+	v := g.GetRotationPeriod()
+	if v.Error != nil {
+		return false, v.Error
+	}
+	return v.Data != nil, nil
+}
+
 func (g *mqlGcpProjectKmsServiceKeyringCryptokey) public() (bool, error) {
 	bindings := g.GetIamPolicy()
 	if bindings.Error != nil {

--- a/providers/gcp/resources/logging.go
+++ b/providers/gcp/resources/logging.go
@@ -363,6 +363,35 @@ func (g *mqlGcpProjectLoggingserviceSink) storageBucket() (*mqlGcpProjectStorage
 	return nil, nil
 }
 
+func (g *mqlGcpProjectLoggingserviceMetric) filtersIamChanges() (bool, error) {
+	if g.Filter.Error != nil {
+		return false, g.Filter.Error
+	}
+	return strings.Contains(g.Filter.Data, "SetIamPolicy"), nil
+}
+
+func (g *mqlGcpProjectLoggingserviceMetric) filtersAuditConfigChanges() (bool, error) {
+	if g.Filter.Error != nil {
+		return false, g.Filter.Error
+	}
+	f := g.Filter.Data
+	return strings.Contains(f, "SetIamPolicy") && strings.Contains(f, "auditConfigDelta"), nil
+}
+
+func (g *mqlGcpProjectLoggingserviceMetric) filtersRouteChanges() (bool, error) {
+	if g.Filter.Error != nil {
+		return false, g.Filter.Error
+	}
+	return strings.Contains(g.Filter.Data, "compute.routes."), nil
+}
+
+func (g *mqlGcpProjectLoggingserviceMetric) filtersFirewallChanges() (bool, error) {
+	if g.Filter.Error != nil {
+		return false, g.Filter.Error
+	}
+	return strings.Contains(g.Filter.Data, "compute.firewalls."), nil
+}
+
 func (g *mqlGcpProjectLoggingserviceMetric) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error

--- a/providers/gcp/resources/secretmanager.go
+++ b/providers/gcp/resources/secretmanager.go
@@ -299,6 +299,35 @@ func (g *mqlGcpProjectSecretmanagerServiceSecretVersion) id() (string, error) {
 	return g.ResourcePath.Data, g.ResourcePath.Error
 }
 
+func (g *mqlGcpProjectSecretmanagerServiceSecret) rotationEnabled() (bool, error) {
+	v := g.GetRotation()
+	if v.Error != nil {
+		return false, v.Error
+	}
+	if v.Data == nil {
+		return false, nil
+	}
+	m, ok := v.Data.(map[string]any)
+	if !ok {
+		return false, nil
+	}
+	if period, _ := m["rotationPeriod"].(string); period != "" {
+		return true, nil
+	}
+	if next, _ := m["nextRotationTime"].(string); next != "" {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (g *mqlGcpProjectSecretmanagerServiceSecret) public() (bool, error) {
+	bindings := g.GetIamPolicy()
+	if bindings.Error != nil {
+		return false, bindings.Error
+	}
+	return iamPolicyHasPublicMember(bindings.Data)
+}
+
 func (g *mqlGcpProjectSecretmanagerServiceSecret) kmsKeys() ([]any, error) {
 	if g.CustomerManagedEncryption.Error != nil {
 		return nil, g.CustomerManagedEncryption.Error

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -1001,3 +1001,118 @@ func (g *mqlGcpProjectSqlServiceBackupRun) id() (string, error) {
 	}
 	return fmt.Sprintf("gcp.project/%s/sqlService.instance/%s/backupRun/%s", g.ProjectId.Data, g.InstanceName.Data, g.Id.Data), nil
 }
+
+func (g *mqlGcpProjectSqlServiceInstance) publicIpEnabled() (bool, error) {
+	settings := g.GetSettings()
+	if settings.Error != nil {
+		return false, settings.Error
+	}
+	if settings.Data == nil {
+		return false, nil
+	}
+	ip := settings.Data.GetIpConfiguration()
+	if ip.Error != nil {
+		return false, ip.Error
+	}
+	if ip.Data == nil {
+		return false, nil
+	}
+	enabled := ip.Data.GetIpv4Enabled()
+	if enabled.Error != nil {
+		return false, enabled.Error
+	}
+	return enabled.Data, nil
+}
+
+func (g *mqlGcpProjectSqlServiceInstance) backupConfigurationEnabled() (bool, error) {
+	settings := g.GetSettings()
+	if settings.Error != nil {
+		return false, settings.Error
+	}
+	if settings.Data == nil {
+		return false, nil
+	}
+	backup := settings.Data.GetBackupConfiguration()
+	if backup.Error != nil {
+		return false, backup.Error
+	}
+	if backup.Data == nil {
+		return false, nil
+	}
+	enabled := backup.Data.GetEnabled()
+	if enabled.Error != nil {
+		return false, enabled.Error
+	}
+	return enabled.Data, nil
+}
+
+func (g *mqlGcpProjectSqlServiceInstance) pointInTimeRecoveryEnabled() (bool, error) {
+	settings := g.GetSettings()
+	if settings.Error != nil {
+		return false, settings.Error
+	}
+	if settings.Data == nil {
+		return false, nil
+	}
+	backup := settings.Data.GetBackupConfiguration()
+	if backup.Error != nil {
+		return false, backup.Error
+	}
+	if backup.Data == nil {
+		return false, nil
+	}
+	pitr := backup.Data.GetPointInTimeRecoveryEnabled()
+	if pitr.Error != nil {
+		return false, pitr.Error
+	}
+	return pitr.Data, nil
+}
+
+func (g *mqlGcpProjectSqlServiceInstance) hasBuiltInUsers() (bool, error) {
+	users := g.GetUsers()
+	if users.Error != nil {
+		return false, users.Error
+	}
+	for _, raw := range users.Data {
+		u, ok := raw.(*mqlGcpProjectSqlServiceInstanceUser)
+		if !ok || u == nil {
+			continue
+		}
+		t := u.GetType()
+		if t.Error != nil {
+			return false, t.Error
+		}
+		if t.Data == "BUILT_IN" || t.Data == "" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (g *mqlGcpProjectSqlServiceInstance) localRootEnabled() (bool, error) {
+	users := g.GetUsers()
+	if users.Error != nil {
+		return false, users.Error
+	}
+	for _, raw := range users.Data {
+		u, ok := raw.(*mqlGcpProjectSqlServiceInstanceUser)
+		if !ok || u == nil {
+			continue
+		}
+		name := u.GetName()
+		if name.Error != nil {
+			return false, name.Error
+		}
+		if name.Data != "root" {
+			continue
+		}
+		t := u.GetType()
+		if t.Error != nil {
+			return false, t.Error
+		}
+		if t.Data == "BUILT_IN" || t.Data == "" {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/providers/gcp/resources/storage.go
+++ b/providers/gcp/resources/storage.go
@@ -552,3 +552,44 @@ func isPublicEntity(s string) bool {
 func anyPublicEntity(entities []string) bool {
 	return slices.ContainsFunc(entities, isPublicEntity)
 }
+
+func (g *mqlGcpProjectStorageServiceBucket) uniformBucketLevelAccessEnabled() (bool, error) {
+	v := g.GetUniformBucketLevelAccess()
+	if v.Error != nil {
+		return false, v.Error
+	}
+	if v.Data == nil {
+		return false, nil
+	}
+	m, ok := v.Data.(map[string]any)
+	if !ok {
+		return false, nil
+	}
+	enabled, _ := m["enabled"].(bool)
+	return enabled, nil
+}
+
+func (g *mqlGcpProjectStorageServiceBucket) softDeletePolicyEnabled() (bool, error) {
+	v := g.GetSoftDeletePolicy()
+	if v.Error != nil {
+		return false, v.Error
+	}
+	if v.Data == nil {
+		return false, nil
+	}
+	m, ok := v.Data.(map[string]any)
+	if !ok {
+		return false, nil
+	}
+	switch d := m["retentionDurationSeconds"].(type) {
+	case string:
+		return d != "" && d != "0" && d != "0s", nil
+	case float64:
+		return d > 0, nil
+	case int64:
+		return d > 0, nil
+	case int:
+		return d > 0, nil
+	}
+	return false, nil
+}


### PR DESCRIPTION
## Summary

Second batch of 25 derived security helpers on the GCP provider. Bundles items from the published next-25 roadmap into a single PR per the request to ship them all together.

### Network & exposure (compute)
| Field | Returns |
|---|---|
| `computeService.hasDefaultNetwork()` | true when the auto-created `default` VPC still exists |
| `computeService.network.legacy()` | flat hoist of `mode == "legacy"` |
| `computeService.firewall.allowsSshFromInternet()` | INGRESS + enabled + 0.0.0.0/0 source + allowed permits tcp/22 |
| `computeService.firewall.allowsRdpFromInternet()` | same, tcp/3389 |
| `computeService.backendService.cloudArmorEnabled()` | a `securityPolicy` is attached |
| `computeService.backendService.iapEnabled()` | `iap.enabled` is true |

### SQL hardening
| Field | Returns |
|---|---|
| `sqlService.instance.publicIpEnabled()` | flat hoist of `settings.ipConfiguration.ipv4Enabled` |
| `sqlService.instance.backupConfigurationEnabled()` | flat hoist |
| `sqlService.instance.pointInTimeRecoveryEnabled()` | flat hoist |
| `sqlService.instance.hasBuiltInUsers()` | any user with type=BUILT_IN exists |
| `sqlService.instance.localRootEnabled()` | a built-in `root` user exists |

### GKE additional
| Field | Returns |
|---|---|
| `gkeService.cluster.loggingEnabled()` | `loggingService` is set and not `"none"` |
| `gkeService.cluster.monitoringEnabled()` | same for `monitoringService` |
| `gkeService.cluster.releaseChannelManaged()` | channel is `stable` or `regular` |
| `gkeService.cluster.nodepool.config.usesDefaultServiceAccount()` | node SA email matches default Compute SA pattern (or is empty/`default`) |
| `gkeService.cluster.nodepool.config.hasFullCloudPlatformScope()` | node SA scopes include `cloud-platform` |

### Storage flat helpers
| Field | Returns |
|---|---|
| `storageService.bucket.uniformBucketLevelAccessEnabled()` | flat hoist of `iamConfiguration.uniformBucketLevelAccess.enabled` |
| `storageService.bucket.softDeletePolicyEnabled()` | `softDeletePolicy.retentionDurationSeconds > 0` |

### Audit-log metric filters
| Field | Returns |
|---|---|
| `loggingservice.metric.filtersIamChanges()` | filter contains `SetIamPolicy` |
| `loggingservice.metric.filtersAuditConfigChanges()` | filter has `SetIamPolicy` AND `auditConfigDelta` |
| `loggingservice.metric.filtersRouteChanges()` | filter contains `compute.routes.` |
| `loggingservice.metric.filtersFirewallChanges()` | filter contains `compute.firewalls.` |

### Secret Manager / KMS rotation
| Field | Returns |
|---|---|
| `secretmanagerService.secret.rotationEnabled()` | `rotation.rotationPeriod` or `nextRotationTime` is set |
| `secretmanagerService.secret.public()` | IAM has `allUsers`/`allAuthenticatedUsers` |
| `kmsService.keyring.cryptokey.rotationEnabled()` | `rotationPeriod` is set |

## Why one PR

Each item is a 1–10-line derived helper; collectively they round out the second wave of CIS-style audit predicates. Bundling avoids 6 round-trips of CI / review / merge for changes that share a theme and are individually trivial.

## Test plan
- [x] 25 new entries at 13.12.2 in gcp.lr.versions
- [x] gcp provider builds & installs; gofmt clean
- [x] `--info` confirms every new field resolves with `type=bool`
- [x] Live spot-checks against `tim-learning-project`:
  - `hasDefaultNetwork: true` (default VPC exists)
  - `firewalls.where(_.allowsSshFromInternet)` correctly returns `default-allow-ssh`; `allowsRdpFromInternet` returns `default-allow-rdp`
  - SQL `tim` instance: `publicIpEnabled=true, backupConfigurationEnabled=true, hasBuiltInUsers=true, localRootEnabled=false`
  - bucket `gcf-v2-sources`: `uniformBucketLevelAccessEnabled=true, softDeletePolicyEnabled=true`; dataproc temp/staging buckets: both false
  - KMS key `mql-test-key`: `rotationEnabled=false, rotationPeriod=null` (matches actual config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)