### PR TITLE
🎉 os-13.16.0

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.15.1",
+	Version: "13.16.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### os (13.16.0)
- ✨ Add Conan lockfile parser for C/C++ dependencies (#7474)
- ✨ Add JavaScript lockfile parsers (pnpm, bun) + fix yarnlock evidence (#7472)
- ✨ Add gems.locked support for Ruby dependency detection (#7475)
- ✨ Add Python lockfile parsers (poetry, uv, Pipfile, pdm) (#7471)
- ✨ iptables: add tables() accessor for NAT/mangle/raw table support (#7468)
- ✨ os: add BSD network interface support (FreeBSD, OpenBSD, NetBSD, DragonFly) (#7469)
- 🧹 mark deprecated .lr fields and resources with @maturity("deprecated") (#7467)
- ✨ Add Lua (LuaRocks) SBOM cataloger (#7306)
- ✨ Add R (CRAN) SBOM cataloger via renv.lock (#7305)
- ✨ Add Flatpak package manager support (#7303)
- ✨ Add Nix package manager support (#7304)
- ✨ Enhance Gentoo/Portage SBOM with PURL and filesystem fallback (#7301)
- ✨ Add ALPM filesystem fallback for pacman package manager (#7299)