### PR TITLE
🐛 GCP: fix shieldedInstanceConfig cache collision (per-instance __id)

### DIFF
--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -364,6 +364,10 @@ func initGcpProjectComputeServiceInstance(runtime *plugin.Runtime, args map[stri
 	return nil, nil, errors.New("instance not found")
 }
 
+func (g *mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig) id() (string, error) {
+	return g.Id.Data, g.Id.Error
+}
+
 func (g *mqlGcpProjectComputeServiceInstance) id() (string, error) {
 	if g.Id.Error != nil {
 		return "", g.Id.Error

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -32670,7 +32670,12 @@ func createGcpProjectComputeServiceInstanceShieldedInstanceConfig(runtime *plugi
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("gcp.project.computeService.instance.shieldedInstanceConfig", res.__id)


### PR DESCRIPTION
## Summary

`mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig` had no `id()` method, so its `__id` stayed empty and every instance's `shieldedInstanceConfig` collided on the same cache entry. Querying the typed sub-resource on the **second** instance returned whatever value was cached for the **first** — i.e. all VMs reported the same shielded config.

This was discovered while testing GCP CIS-4.x compute instance hardening helpers (PR #7483) against a real fleet that included both a GKE node (secureBoot=false) and a hardened test VM (secureBoot=true). MQL returned `enableSecureBoot=false` for both, masking the hardened state of the test VM.

## Reproduction (before fix)

```
$ mql run gcp project tim-learning-project --discover none -c \
    "gcp.compute.instances { name shieldedInstanceConfig { enableSecureBoot } }"
gcp.compute.instances: [
  0: { name: "gke-node-...", shieldedInstanceConfig: { enableSecureBoot: false } }
  1: { name: "test-vm",      shieldedInstanceConfig: { enableSecureBoot: false } }   # WRONG
]

# Cross-check with the deprecated flat field on the parent:
$ mql run gcp project tim-learning-project --discover none -c \
    "gcp.compute.instances { name enableSecureBoot }"
gcp.compute.instances: [
  0: { name: "gke-node-...", enableSecureBoot: false }
  1: { name: "test-vm",      enableSecureBoot: true }    # correct via flat field
]
```

## Fix

Add `id() (string, error)` on the shielded-config struct so the generator wires `__id` to the per-instance id (`<instance.Id>/shieldedInstanceConfig`). Same pattern used elsewhere in `compute.go` (e.g. `mqlGcpProjectComputeServiceInstance.id()`).

After fix:

```
gcp.compute.instances: [
  0: { name: "gke-node-...", shieldedInstanceConfig: { enableSecureBoot: false } }
  1: { name: "test-vm",      shieldedInstanceConfig: { enableSecureBoot: true } }    # correct
]
```

## Test plan

- [x] Verified fix end-to-end against a live GCP project containing two VMs with different shielded configs (GKE node + hardened user VM)
- [x] `make providers/build/gcp && make providers/install/gcp` clean
- [x] `mqlr generate` regenerated `gcp.lr.go` cleanly
- [ ] Reviewers: spot-check that no existing audit policy depends on the broken (cache-collision) behavior — current behavior was wrong but uniform, so policies would have been alerting on an incorrect signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)