### PR TITLE
Return null file fields for missing files

### DIFF
--- a/cli/printer/printer_test.go
+++ b/cli/printer/printer_test.go
@@ -98,9 +98,7 @@ func TestPrinter(t *testing.T) {
 			"file('zzz') { content }",
 			"",
 			[]string{
-				"error: 1 error occurred:\n" +
-					"\t* file 'zzz' not found\n" +
-					"file: {\n  content: error: file 'zzz' not found\n}",
+				"file: {\n  content: null\n}",
 			},
 		},
 		{

--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -534,7 +534,7 @@ func TestMapRefLookup(t *testing.T) {
 	})
 }
 
-func TestArrayMapError(t *testing.T) {
+func TestArrayMapMissingFileContent(t *testing.T) {
 	x := testutils.InitTester(testutils.LinuxMock())
 	x.TestSimple(t, []testutils.SimpleTest{
 		{
@@ -542,7 +542,7 @@ func TestArrayMapError(t *testing.T) {
 				["a"].map(file(_).content)
 			`,
 			ResultIndex: 0,
-			Error:       "1 error occurred:\n\t* file 'a' not found\n",
+			Expectation: []any{nil},
 		},
 	})
 }

--- a/providers/os/resources/auditd.go
+++ b/providers/os/resources/auditd.go
@@ -76,12 +76,12 @@ func (s *mqlAuditdConfig) parse(file *mqlFile) error {
 		return errors.New("no base auditd config file to read")
 	}
 
-	content := file.GetContent()
-	if content.Error != nil {
-		return content.Error
+	content, err := fileRequiredContent(file)
+	if err != nil {
+		return err
 	}
 
-	ini := parsers.ParseIni(content.Data, "=")
+	ini := parsers.ParseIni(content, "=")
 
 	res := make(map[string]any, len(ini.Fields))
 	s.Params.Data = res

--- a/providers/os/resources/file.go
+++ b/providers/os/resources/file.go
@@ -44,6 +44,30 @@ func fileContentOrEmpty(file *mqlFile) (string, error) {
 	return content.Data, nil
 }
 
+func fileRequiredContent(file *mqlFile) (string, error) {
+	if file == nil {
+		return "", resources.NotFoundError{Resource: "file"}
+	}
+
+	exists := file.GetExists()
+	if exists.Error != nil {
+		return "", exists.Error
+	}
+	if !exists.Data {
+		return "", resources.NotFoundError{Resource: "file", ID: file.Path.Data}
+	}
+
+	content := file.GetContent()
+	if content.Error != nil {
+		return "", content.Error
+	}
+	if content.IsNull() {
+		return "", resources.NotFoundError{Resource: "file", ID: file.Path.Data}
+	}
+
+	return content.Data, nil
+}
+
 type mqlFileInternal struct {
 	statInfo *shared.FileInfoDetails
 }
@@ -54,7 +78,10 @@ func (s *mqlFile) id() (string, error) {
 
 func (s *mqlFile) content(path string, exists bool) (string, error) {
 	if !exists {
-		return "", resources.NotFoundError{Resource: "file", ID: path}
+		s.Content = plugin.TValue[string]{
+			State: plugin.StateIsSet | plugin.StateIsNull,
+		}
+		return "", nil
 	}
 
 	conn := s.MqlRuntime.Connection.(shared.Connection)
@@ -178,7 +205,13 @@ func (s *mqlFile) loadOwnership(path string) error {
 		return err
 	}
 	if !exists {
-		return os.ErrNotExist
+		s.User = plugin.TValue[*mqlUser]{
+			State: plugin.StateIsSet | plugin.StateIsNull,
+		}
+		s.Group = plugin.TValue[*mqlGroup]{
+			State: plugin.StateIsSet | plugin.StateIsNull,
+		}
+		return nil
 	}
 	if s.User.IsSet() && s.Group.IsSet() {
 		return nil
@@ -201,7 +234,10 @@ func (s *mqlFile) size(path string) (int64, error) {
 		return 0, err
 	}
 	if !exists {
-		return 0, os.ErrNotExist
+		s.Size = plugin.TValue[int64]{
+			State: plugin.StateIsSet | plugin.StateIsNull,
+		}
+		return 0, nil
 	}
 	return 0, nil
 }
@@ -212,7 +248,10 @@ func (s *mqlFile) permissions(path string) (*mqlFilePermissions, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, os.ErrNotExist
+		s.Permissions = plugin.TValue[*mqlFilePermissions]{
+			State: plugin.StateIsSet | plugin.StateIsNull,
+		}
+		return nil, nil
 	}
 	return nil, nil
 }

--- a/providers/os/resources/file_test.go
+++ b/providers/os/resources/file_test.go
@@ -6,7 +6,6 @@ package resources_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -51,8 +50,36 @@ func TestResource_File(t *testing.T) {
 }
 
 func TestResource_File_NotExist(t *testing.T) {
-	res := x.TestQuery(t, "file('Nope').content")
-	assert.EqualError(t, res[0].Data.Error, "file 'Nope' not found")
+	x.TestSimple(t, []testutils.SimpleTest{
+		{
+			Code:        "file('Nope').exists",
+			ResultIndex: 0, Expectation: false,
+		},
+		{
+			Code:        "file('Nope').content",
+			ResultIndex: 0, Expectation: nil,
+		},
+		{
+			Code:        "file('Nope').content == 'x'",
+			ResultIndex: 0, Expectation: nil,
+		},
+		{
+			Code:        "file('Nope').size > 0",
+			ResultIndex: 0, Expectation: nil,
+		},
+		{
+			Code:        "file('Nope').permissions.mode == 420",
+			ResultIndex: 0, Expectation: nil,
+		},
+		{
+			Code:        "file('Nope').user.name == 'root'",
+			ResultIndex: 0, Expectation: nil,
+		},
+		{
+			Code:        "file('Nope').group.name == 'root'",
+			ResultIndex: 0, Expectation: nil,
+		},
+	})
 }
 
 func TestResource_File_Permissions(t *testing.T) {

--- a/providers/os/resources/journald.go
+++ b/providers/os/resources/journald.go
@@ -74,12 +74,12 @@ func (s *mqlJournaldConfig) parse(file *mqlFile) error {
 		return errors.New("no base journald config file to read")
 	}
 
-	content := file.GetContent()
-	if content.Error != nil {
-		return content.Error
+	content, err := fileRequiredContent(file)
+	if err != nil {
+		return err
 	}
 
-	unit, err := parsers.ParseUnit(content.Data)
+	unit, err := parsers.ParseUnit(content)
 	if err != nil {
 		return fmt.Errorf("failed to parse journald config: %w", err)
 	}

--- a/providers/os/resources/kubelet_test.go
+++ b/providers/os/resources/kubelet_test.go
@@ -92,7 +92,7 @@ func TestResource_K8sKubeletAKS(t *testing.T) {
 	t.Run("kubelet configFile path", func(t *testing.T) {
 		res := x.TestQuery(t, "kubelet.configFile")
 		assert.NotEmpty(t, res)
-		assert.Error(t, res[0].Data.Error)
+		assert.NoError(t, res[0].Data.Error)
 	})
 
 	t.Run("kubelet configFile exists", func(t *testing.T) {

--- a/providers/os/resources/mql_test.go
+++ b/providers/os/resources/mql_test.go
@@ -634,13 +634,13 @@ func TestDict_Methods_OtherJson(t *testing.T) {
 	})
 }
 
-func TestArrayBlockError(t *testing.T) {
+func TestArrayBlockMissingFileContent(t *testing.T) {
 	x := testutils.InitTester(testutils.LinuxMock())
 	res := x.TestQuery(t, "users.list { file(_.name + 'doesnotexist').content }")
 	assert.NotEmpty(t, res)
 	queryResult := res[len(res)-1]
 	require.NotNil(t, queryResult)
-	require.Error(t, queryResult.Data.Error)
+	require.NoError(t, queryResult.Data.Error)
 }
 
 func TestBrokenQueryExecutionGH674(t *testing.T) {

--- a/providers/os/resources/sshd.go
+++ b/providers/os/resources/sshd.go
@@ -185,12 +185,12 @@ func (s *mqlSshdConfig) parse(file *mqlFile) error {
 			filesIdx[path] = file
 		}
 
-		fileContent := file.GetContent()
-		if fileContent.Error != nil {
-			return "", fileContent.Error
+		fileContent, err := fileRequiredContent(file)
+		if err != nil {
+			return "", err
 		}
 
-		return fileContent.Data + "\n", nil
+		return fileContent + "\n", nil
 	}
 
 	// Function to expand glob patterns


### PR DESCRIPTION
## Summary

Closes #7492.

Missing `file` fields now return null state instead of a hard `NotFoundError` for:

- `file.content`
- `file.size`
- `file.permissions`
- `file.user`
- `file.group`

This lets direct checks such as `file("/missing").content == "x"` fail cleanly instead of producing a policy error, and removes the need for noisy policy-side guard patterns like `["/path"].where(file(_).exists).all(...)`.

Higher-level resources that semantically require a backing config file still use strict missing-file behavior via `fileRequiredContent`, including `auditd.config`, `sshd.config`, and `journald.config`.

## Evidence

On `cnspec-enterprise-policies` `origin/main`, the missing-file workaround pattern is widespread:

- `701` `where(file(_).exists)` occurrences in `queries/*.mql.yaml`
- `433` literal file-list guard patterns such as `["/path"].where(file(_).exists)...`

Released runtime behavior returns a file-not-found error for direct missing-file content access. With this change and a locally built OS provider, the same query compiles and fails as an assertion with actual `_`.

## Testing

- `go test ./providers/os/resources -count=1`
- `go test ./exec -count=1`
- `go test ./mqlc -count=1`
- `git diff --check`
- `make providers/build/os`
- `PROVIDERS_PATH=/tmp/mql-provider-proof MONDOO_AUTO_UPDATE=false go run apps/mql/mql.go --auto-update=false run local -c "file('/tmp/definitely-not-present-codex-mql').content == 'x'"`

I also ran `go test ./providers/os/...`; it still fails on unrelated existing environment issues: missing generated snapshot mocks in `connection/device/linux`, Docker registry credential failures, and host-specific Docker/provider expectations.
