### PR TITLE
🎉 aws-13.21.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.20.0",
+	Version:         "13.21.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### aws (13.21.0)
- 🧹 AWS AppStream: add init functions for fleet/stack typed refs + cache stack list per fleet (#7478)
- 🧹 mark deprecated .lr fields and resources with @maturity("deprecated") (#7467)
- ✨ AWS: expand AppStream (applications, images, users, sessions, entitlements) (#7463)
- ✨ AWS: expand API Gateway with authorizers, API keys, usage plans, VPC links, request validators (#7462)
- ✨ Expand AWS provider: Identity Center apps, WorkSpaces Web family, CloudFront trust stores, Transfer connectors/web apps/workflows (#7455)
- Minor AWS docs fix + generate permissions (#7451)