### PR TITLE
🎉 gcp-13.13.0

### DIFF
--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.12.1",
+	Version: "13.13.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### gcp (13.13.0)
- 🐛 GCP: fix shieldedInstanceConfig cache collision (#7489)
- ✨ GCP: 25 more security helpers across compute/SQL/GKE/storage/logging/secret/KMS (#7487)
- ✨ GCP: SA-key filters, weak TLS, weak DNSSEC algorithm helpers (#7486)
- ✨ GCP: typed kmsKey() across compute/BQ/Pub/Sub/Secret/Logging (#7481)
- ✨ GCP: GKE cluster + nodepool hardening helpers (CIS 5.x) (#7484)
- ✨ GCP: compute instance hardening helpers (CIS 4.x) (#7483)
- ✨ GCP: storage bucket retention-lock and access-log helpers (#7485)
- ✨ GCP: project-level IAM and audit-log security helpers (#7482)
- ✨ GCP: surface public-access and key-hygiene scalars for CIS audits (#7480)
- ✨ GCP: surface network exposure scalars for CIS-style audits (#7479)
- ✨ GCP: backfill DB typed kmsKey() accessors and Bigtable IAM (#7476)
- 🧹 mark deprecated .lr fields and resources with @maturity("deprecated") (#7467)
- ✨ GCP: surface stateInfo and typed backup files on redis cluster (#7460)
- ✨ GCP: bump SDKs and surface new resource fields (#7459)
- ✨ GCP: add bucket.public(), acl(), defaultObjectAcl() (#7458)
- 🧹 GCP: migrate pubsub provider to cloud.google.com/go/pubsub/v2 (#7456)
- Minor AWS docs fix + generate permissions (#7451)