### PR TITLE
🎉 azure-13.9.0

### DIFF
--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "azure",
 	ID:      "go.mondoo.com/cnquery/v9/providers/azure",
-	Version: "13.8.1",
+	Version: "13.9.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(azureinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### azure (13.9.0)
- 🧹 Regenerate Azure permissions.json (#7477)
- ✨ Azure: backfill DB security fields (Cosmos RBAC/PEC/diagnostics, flexible-server gaps) (#7473)
- ✨ Azure: expand SQL security coverage (audit, BYOK, DDM, ledger, private link) (#7464)
- 🧹 mark deprecated .lr fields and resources with @maturity("deprecated") (#7467)
- ✨ Azure: bump armcompute to v8 + surface new compute fields (#7454)
- Minor AWS docs fix + generate permissions (#7451)
- 🧹 Drop redundant test error struct. (#7449)