### PR TITLE
🐛 Capture provider stderr + version + uptime in crash errors

### DIFF
--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -314,6 +314,15 @@ func (c *coordinator) unsafeStartProvider(id string, update UpdateProvidersConfi
 		}
 	}
 
+	// crashLog tees the plugin subprocess's stderr to logger.LogOutputWriter
+	// (so terminal output is unchanged) while keeping the most recent lines
+	// in a ring buffer. handlePluginError reads from it on crash to surface
+	// the actual panic/fatal trace in the error sent to Sentry — without it,
+	// the only thing that reaches error tracking is the gRPC "Unavailable: EOF"
+	// rendering of the dropped connection. The buffer is shared across plugin
+	// restarts triggered by RestartableProvider.Reconnect().
+	crashLog := newCrashLogBuffer(logger.LogOutputWriter, defaultCrashLogLines)
+
 	connectFunc := func() (pp.ProviderPlugin, *plugin.Client, error) {
 		pluginCmd := exec.Command(provider.binPath(), []string{"run_as_plugin", "--log-level", zerolog.GlobalLevel().String()}...)
 
@@ -329,7 +338,7 @@ func (c *coordinator) unsafeStartProvider(id string, update UpdateProvidersConfi
 				plugin.ProtocolNetRPC, plugin.ProtocolGRPC,
 			},
 			Logger: pluginLogger,
-			Stderr: logger.LogOutputWriter,
+			Stderr: crashLog,
 		})
 
 		// Connect via RPC
@@ -361,6 +370,8 @@ func (c *coordinator) unsafeStartProvider(id string, update UpdateProvidersConfi
 	if err != nil {
 		return nil, err
 	}
+	res.Version = provider.Version
+	res.crashLog = crashLog
 	c.runningByID[res.ID] = res
 
 	return res, nil

--- a/providers/crashlog.go
+++ b/providers/crashlog.go
@@ -90,22 +90,30 @@ func (b *crashLogBuffer) appendLineLocked(line []byte) {
 
 // Snapshot returns a copy of the current buffer contents in chronological order.
 // Safe to call concurrently with Write.
+//
+// Any unterminated bytes still sitting in pending (a partial line that hasn't
+// seen a '\n' yet) are appended as a final line. This matters for crashes
+// where the subprocess is killed mid-write — the panic line that didn't get
+// to flush its newline is exactly what we want to surface.
 func (b *crashLogBuffer) Snapshot() []string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	var lines [][]byte
 	if b.full {
-		lines = make([][]byte, 0, len(b.ring))
+		lines = make([][]byte, 0, len(b.ring)+1)
 		lines = append(lines, b.ring[b.head:]...)
 		lines = append(lines, b.ring[:b.head]...)
 	} else {
 		lines = b.ring[:b.head]
 	}
 
-	out := make([]string, len(lines))
-	for i, l := range lines {
-		out[i] = string(l)
+	out := make([]string, 0, len(lines)+1)
+	for _, l := range lines {
+		out = append(out, string(l))
+	}
+	if b.pending.Len() > 0 {
+		out = append(out, b.pending.String())
 	}
 	return out
 }

--- a/providers/crashlog.go
+++ b/providers/crashlog.go
@@ -1,0 +1,141 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"sync"
+)
+
+// defaultCrashLogLines is the number of stderr lines we retain per provider.
+// 200 is enough to cover a typical Go panic stack trace (a goroutine + a few
+// runtime frames is usually <50 lines, and we want headroom for unrelated log
+// chatter that happened to land in the buffer right before the crash).
+const defaultCrashLogLines = 200
+
+// crashLogBuffer is an io.Writer that tees writes to an underlying writer
+// while keeping the most recent lines in a ring buffer. We use it to capture
+// a provider subprocess's stderr so that, on crash, we can surface the most
+// recent stderr (typically a Go runtime fatal or panic stack trace) in the
+// error attached to Runtime.CriticalErrors.
+//
+// hashicorp/go-plugin already writes the plugin's raw stderr to the configured
+// Stderr writer line-by-line before any hclog wrapping. We sit in front of
+// that path so the captured bytes are exactly what the plugin printed.
+type crashLogBuffer struct {
+	out io.Writer
+
+	mu      sync.Mutex
+	pending bytes.Buffer
+	ring    [][]byte
+	head    int
+	full    bool
+}
+
+func newCrashLogBuffer(out io.Writer, lines int) *crashLogBuffer {
+	if lines <= 0 {
+		lines = defaultCrashLogLines
+	}
+	return &crashLogBuffer{
+		out:  out,
+		ring: make([][]byte, lines),
+	}
+}
+
+func (b *crashLogBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	b.absorbLocked(p)
+	b.mu.Unlock()
+
+	if b.out != nil {
+		return b.out.Write(p)
+	}
+	return len(p), nil
+}
+
+// absorbLocked splits p on '\n' and appends each completed line to the ring.
+// Any trailing bytes (no '\n' yet) are kept in pending and prepended to the
+// next write.
+func (b *crashLogBuffer) absorbLocked(p []byte) {
+	for len(p) > 0 {
+		i := bytes.IndexByte(p, '\n')
+		if i < 0 {
+			b.pending.Write(p)
+			return
+		}
+		b.pending.Write(p[:i])
+		// drop a trailing '\r' so Windows-style line endings don't leak in
+		line := b.pending.Bytes()
+		if n := len(line); n > 0 && line[n-1] == '\r' {
+			line = line[:n-1]
+		}
+		b.appendLineLocked(line)
+		b.pending.Reset()
+		p = p[i+1:]
+	}
+}
+
+func (b *crashLogBuffer) appendLineLocked(line []byte) {
+	cp := make([]byte, len(line))
+	copy(cp, line)
+	b.ring[b.head] = cp
+	b.head = (b.head + 1) % len(b.ring)
+	if b.head == 0 {
+		b.full = true
+	}
+}
+
+// Snapshot returns a copy of the current buffer contents in chronological order.
+// Safe to call concurrently with Write.
+func (b *crashLogBuffer) Snapshot() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	var lines [][]byte
+	if b.full {
+		lines = make([][]byte, 0, len(b.ring))
+		lines = append(lines, b.ring[b.head:]...)
+		lines = append(lines, b.ring[:b.head]...)
+	} else {
+		lines = b.ring[:b.head]
+	}
+
+	out := make([]string, len(lines))
+	for i, l := range lines {
+		out[i] = string(l)
+	}
+	return out
+}
+
+// CrashTail returns the suffix of recent stderr lines that look like a Go
+// runtime fatal or panic stack trace. The detection mirrors hashicorp/go-plugin's
+// own panic detection (matching the same prefixes it uses) plus a few common
+// runtime markers. Returns nil if no panic-like marker was found.
+func (b *crashLogBuffer) CrashTail() []string {
+	lines := b.Snapshot()
+
+	// Walk forward, remember the last index where a panic/fatal marker started.
+	// If a provider has multiple recovered panics earlier that landed in stderr
+	// (e.g. via debug.PrintStack from inside recoverPanic), we want the most
+	// recent one — that's the unrecoverable fatal that actually killed the
+	// process.
+	start := -1
+	for i, raw := range lines {
+		l := strings.TrimSpace(raw)
+		switch {
+		case strings.HasPrefix(l, "panic:"),
+			strings.HasPrefix(l, "fatal error:"),
+			strings.HasPrefix(l, "runtime: "),
+			strings.HasPrefix(l, "SIG"),
+			strings.HasPrefix(l, "unexpected fault address"):
+			start = i
+		}
+	}
+	if start < 0 {
+		return nil
+	}
+	return lines[start:]
+}

--- a/providers/crashlog_test.go
+++ b/providers/crashlog_test.go
@@ -1,0 +1,128 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCrashLogBuffer_TeesToUnderlying(t *testing.T) {
+	var sink bytes.Buffer
+	b := newCrashLogBuffer(&sink, 10)
+
+	n, err := b.Write([]byte("hello\nworld\n"))
+	assert.NoError(t, err)
+	assert.Equal(t, 12, n)
+	assert.Equal(t, "hello\nworld\n", sink.String())
+}
+
+func TestCrashLogBuffer_NilUnderlyingIsAllowed(t *testing.T) {
+	b := newCrashLogBuffer(nil, 10)
+	n, err := b.Write([]byte("hi\n"))
+	assert.NoError(t, err)
+	assert.Equal(t, 3, n)
+	assert.Equal(t, []string{"hi"}, b.Snapshot())
+}
+
+func TestCrashLogBuffer_SplitsOnNewlines(t *testing.T) {
+	b := newCrashLogBuffer(io.Discard, 10)
+	_, _ = b.Write([]byte("one\ntwo\nthree\n"))
+	assert.Equal(t, []string{"one", "two", "three"}, b.Snapshot())
+}
+
+func TestCrashLogBuffer_HandlesPartialLinesAcrossWrites(t *testing.T) {
+	b := newCrashLogBuffer(io.Discard, 10)
+	_, _ = b.Write([]byte("partial "))
+	// not yet a complete line
+	assert.Empty(t, b.Snapshot())
+	_, _ = b.Write([]byte("line\nnext\n"))
+	assert.Equal(t, []string{"partial line", "next"}, b.Snapshot())
+}
+
+func TestCrashLogBuffer_StripsCRLF(t *testing.T) {
+	b := newCrashLogBuffer(io.Discard, 10)
+	_, _ = b.Write([]byte("windows\r\nstyle\r\n"))
+	assert.Equal(t, []string{"windows", "style"}, b.Snapshot())
+}
+
+func TestCrashLogBuffer_RingOverflowKeepsMostRecent(t *testing.T) {
+	b := newCrashLogBuffer(io.Discard, 3)
+	for _, l := range []string{"a", "b", "c", "d", "e"} {
+		_, _ = b.Write([]byte(l + "\n"))
+	}
+	assert.Equal(t, []string{"c", "d", "e"}, b.Snapshot())
+}
+
+func TestCrashLogBuffer_CrashTailFindsPanic(t *testing.T) {
+	b := newCrashLogBuffer(io.Discard, 50)
+	stderr := strings.Join([]string{
+		"2026-05-04T10:00:00Z INF starting up",
+		"2026-05-04T10:00:01Z DBG querying foo",
+		"panic: runtime error: invalid memory address or nil pointer dereference",
+		"[signal SIGSEGV: segmentation violation code=0x1 addr=0x0]",
+		"",
+		"goroutine 1 [running]:",
+		"main.main()",
+		"\t/src/main.go:42 +0x10",
+		"",
+	}, "\n") + "\n"
+	_, _ = b.Write([]byte(stderr))
+
+	tail := b.CrashTail()
+	assert.NotEmpty(t, tail)
+	assert.Equal(t, "panic: runtime error: invalid memory address or nil pointer dereference", tail[0])
+	// The DBG/INF lines from before the panic must not be included.
+	for _, l := range tail {
+		assert.NotContains(t, l, "starting up")
+	}
+}
+
+func TestCrashLogBuffer_CrashTailFindsFatalError(t *testing.T) {
+	b := newCrashLogBuffer(io.Discard, 50)
+	_, _ = b.Write([]byte("regular log\nfatal error: concurrent map writes\n\ngoroutine 17:\n"))
+	tail := b.CrashTail()
+	assert.Equal(t, []string{
+		"fatal error: concurrent map writes",
+		"",
+		"goroutine 17:",
+	}, tail)
+}
+
+func TestCrashLogBuffer_CrashTailReturnsNilWhenNoMarker(t *testing.T) {
+	b := newCrashLogBuffer(io.Discard, 10)
+	_, _ = b.Write([]byte("just some logs\nand more logs\n"))
+	assert.Nil(t, b.CrashTail())
+}
+
+func TestCrashLogBuffer_CrashTailPicksMostRecentPanic(t *testing.T) {
+	// Two panic markers in the buffer: we want the second (most recent) one,
+	// since that's the one that actually killed the process.
+	b := newCrashLogBuffer(io.Discard, 50)
+	_, _ = b.Write([]byte("panic: first\nrecovered\npanic: second fatal\ngoroutine 1:\n"))
+	tail := b.CrashTail()
+	assert.Equal(t, []string{"panic: second fatal", "goroutine 1:"}, tail)
+}
+
+func TestCrashLogBuffer_ConcurrentWrites(t *testing.T) {
+	b := newCrashLogBuffer(io.Discard, 1000)
+	var wg sync.WaitGroup
+	for i := range 10 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for range 50 {
+				_, _ = b.Write([]byte("line\n"))
+			}
+		}(i)
+	}
+	wg.Wait()
+	// We don't care about ordering, just that it didn't race or panic.
+	assert.Len(t, b.Snapshot(), 500)
+}

--- a/providers/crashlog_test.go
+++ b/providers/crashlog_test.go
@@ -40,8 +40,9 @@ func TestCrashLogBuffer_SplitsOnNewlines(t *testing.T) {
 func TestCrashLogBuffer_HandlesPartialLinesAcrossWrites(t *testing.T) {
 	b := newCrashLogBuffer(io.Discard, 10)
 	_, _ = b.Write([]byte("partial "))
-	// not yet a complete line
-	assert.Empty(t, b.Snapshot())
+	// Snapshot surfaces the unterminated pending bytes too — see the
+	// SIGKILL-mid-write rationale on Snapshot itself.
+	assert.Equal(t, []string{"partial "}, b.Snapshot())
 	_, _ = b.Write([]byte("line\nnext\n"))
 	assert.Equal(t, []string{"partial line", "next"}, b.Snapshot())
 }
@@ -108,6 +109,35 @@ func TestCrashLogBuffer_CrashTailPicksMostRecentPanic(t *testing.T) {
 	_, _ = b.Write([]byte("panic: first\nrecovered\npanic: second fatal\ngoroutine 1:\n"))
 	tail := b.CrashTail()
 	assert.Equal(t, []string{"panic: second fatal", "goroutine 1:"}, tail)
+}
+
+func TestCrashLogBuffer_SnapshotIncludesUnterminatedPending(t *testing.T) {
+	// Simulates the SIGKILL/OOM-mid-write case: the subprocess writes a
+	// panic line but is killed before emitting the trailing '\n'. Snapshot
+	// must still surface that partial line — it's the most actionable byte.
+	b := newCrashLogBuffer(io.Discard, 10)
+	_, _ = b.Write([]byte("setup ok\npanic: about to die"))
+
+	snap := b.Snapshot()
+	assert.Equal(t, []string{"setup ok", "panic: about to die"}, snap)
+}
+
+func TestCrashLogBuffer_CrashTailFindsPanicInPending(t *testing.T) {
+	b := newCrashLogBuffer(io.Discard, 10)
+	_, _ = b.Write([]byte("normal log\npanic: nil deref"))
+
+	tail := b.CrashTail()
+	assert.Equal(t, []string{"panic: nil deref"}, tail)
+}
+
+func TestCrashLogBuffer_PendingDoesNotReappearAfterFlush(t *testing.T) {
+	// Once a complete line is flushed to the ring, subsequent Snapshots
+	// must not double-count it via the pending path.
+	b := newCrashLogBuffer(io.Discard, 10)
+	_, _ = b.Write([]byte("partial"))
+	_, _ = b.Write([]byte(" rest\n"))
+	assert.Equal(t, []string{"partial rest"}, b.Snapshot())
+	assert.Equal(t, []string{"partial rest"}, b.Snapshot())
 }
 
 func TestCrashLogBuffer_ConcurrentWrites(t *testing.T) {

--- a/providers/crashlog_test.go
+++ b/providers/crashlog_test.go
@@ -85,6 +85,21 @@ func TestCrashLogBuffer_CrashTailFindsPanic(t *testing.T) {
 	}
 }
 
+func TestCrashLogBuffer_CrashTailFindsRuntimeDiagnostic(t *testing.T) {
+	// "runtime: " (with trailing space) is the prefix Go's runtime uses for
+	// its own diagnostic prints — distinct from "panic: runtime error: ..."
+	// (which is one line starting with "panic:"). Examples from the wild:
+	// "runtime: out of memory: cannot allocate ..."
+	// "runtime: program exceeds 10000-thread limit"
+	// We capture these because they sometimes appear WITHOUT a following
+	// "fatal error:" line (e.g. when the subprocess is killed mid-write),
+	// and they're the only signal we get.
+	b := newCrashLogBuffer(io.Discard, 50)
+	_, _ = b.Write([]byte("regular log\nruntime: out of memory: cannot allocate 16384-byte block\n"))
+	tail := b.CrashTail()
+	assert.Equal(t, []string{"runtime: out of memory: cannot allocate 16384-byte block"}, tail)
+}
+
 func TestCrashLogBuffer_CrashTailFindsFatalError(t *testing.T) {
 	b := newCrashLogBuffer(io.Discard, 50)
 	_, _ = b.Write([]byte("regular log\nfatal error: concurrent map writes\n\ngoroutine 17:\n"))

--- a/providers/running_provider.go
+++ b/providers/running_provider.go
@@ -275,16 +275,30 @@ func (r *RestartableProvider) StoreData(req *pp.StoreReq) (*pp.StoreRes, error) 
 var _ pp.ProviderPlugin = &RestartableProvider{}
 
 type RunningProvider struct {
-	Name   string
-	ID     string
-	Plugin pp.ProviderPlugin
-	Schema resources.ResourcesSchema
+	Name    string
+	ID      string
+	Version string
+	Plugin  pp.ProviderPlugin
+	Schema  resources.ResourcesSchema
 
 	// isClosed is true for any provider that is not running anymore,
 	// either via shutdown or via crash
 	isClosed bool
 	// isShutdown is only used once during provider shutdown
 	isShutdown bool
+	// heartbeatFailed is set when a heartbeat probe fails and triggers
+	// Shutdown(). It distinguishes "we proactively closed the connection
+	// because the plugin stopped responding" from "the plugin process
+	// crashed on its own" — both surface as gRPC Unavailable downstream.
+	heartbeatFailed bool
+	// startedAt records when SupervisedRunningProvider returned; used to
+	// report uptime in crash messages so we can tell quick startup crashes
+	// apart from after-N-minutes failures.
+	startedAt time.Time
+	// crashLog captures the plugin subprocess's stderr in a ring buffer so
+	// we can include the most recent stderr (typically a runtime fatal or
+	// panic stack trace) in the error attached to Runtime.CriticalErrors.
+	crashLog *crashLogBuffer
 	// provider errors which are evaluated and printed during shutdown of the provider
 	err          error
 	lock         sync.Mutex
@@ -298,10 +312,11 @@ func SupervisedRunningProvider(name string, id string, plugin pp.ProviderPlugin,
 	hbCtx, hbCancelFunc := context.WithCancel(context.Background())
 
 	rp := &RunningProvider{
-		Name:     name,
-		ID:       id,
-		Schema:   schema,
-		isClosed: false,
+		Name:      name,
+		ID:        id,
+		Schema:    schema,
+		isClosed:  false,
+		startedAt: time.Now(),
 		Plugin: &RestartableProvider{
 			plugin:          plugin,
 			client:          client,
@@ -324,6 +339,9 @@ func SupervisedRunningProvider(name string, id string, plugin pp.ProviderPlugin,
 func (p *RunningProvider) heartbeat(ctx context.Context, cancelFunc context.CancelFunc) error {
 	if err := p.doOneHeartbeat(p.interval + p.gracePeriod); err != nil {
 		log.Error().Err(err).Str("plugin", p.Name).Msg("error in plugin heartbeat")
+		p.shutdownLock.Lock()
+		p.heartbeatFailed = true
+		p.shutdownLock.Unlock()
 		if err := p.Shutdown(); err != nil {
 			log.Error().Err(err).Str("plugin", p.Name).Msg("error in plugin shutdown")
 		}
@@ -336,6 +354,9 @@ func (p *RunningProvider) heartbeat(ctx context.Context, cancelFunc context.Canc
 		for !p.isCloseOrShutdown() {
 			if err := p.doOneHeartbeat(p.interval + p.gracePeriod); err != nil {
 				log.Error().Err(err).Str("plugin", p.Name).Msg("error in plugin heartbeat")
+				p.shutdownLock.Lock()
+				p.heartbeatFailed = true
+				p.shutdownLock.Unlock()
 				if err := p.Shutdown(); err != nil {
 					log.Error().Err(err).Str("plugin", p.Name).Msg("error in plugin shutdown")
 				}
@@ -456,4 +477,54 @@ func (p *RunningProvider) KillClient() {
 			c.Kill()
 		}
 	}
+}
+
+// hasExited reports whether the underlying plugin subprocess has exited.
+// Returns false if we have no client handle (e.g. for builtin providers).
+func (p *RunningProvider) hasExited() bool {
+	if rp, ok := p.Plugin.(*RestartableProvider); ok {
+		c := rp.Client()
+		if c != nil {
+			return c.Exited()
+		}
+	}
+	return false
+}
+
+// uptime reports how long the provider has been running. Zero if startedAt
+// was never set (e.g. for builtin providers constructed directly).
+func (p *RunningProvider) uptime() time.Duration {
+	if p.startedAt.IsZero() {
+		return 0
+	}
+	return time.Since(p.startedAt)
+}
+
+// crashTail returns the most recent stderr lines that look like a Go runtime
+// fatal or panic stack trace, or nil if no panic-like marker was captured.
+func (p *RunningProvider) crashTail() []string {
+	if p.crashLog == nil {
+		return nil
+	}
+	return p.crashLog.CrashTail()
+}
+
+// stderrSnapshot returns the full ring-buffer contents of recent plugin stderr.
+// Used as a fallback when crashTail returns nothing — for OS-level kills
+// (SIGKILL by OOM, etc.) the process may not write anything panic-shaped before
+// dying, but earlier debug logs can still hint at what was happening.
+func (p *RunningProvider) stderrSnapshot() []string {
+	if p.crashLog == nil {
+		return nil
+	}
+	return p.crashLog.Snapshot()
+}
+
+// hadHeartbeatFailure reports whether this provider was Shutdown by the
+// heartbeat watcher rather than dying on its own. Used to distinguish "plugin
+// stopped responding to heartbeats" from "plugin process crashed."
+func (p *RunningProvider) hadHeartbeatFailure() bool {
+	p.shutdownLock.Lock()
+	defer p.shutdownLock.Unlock()
+	return p.heartbeatFailed
 }

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -604,8 +604,23 @@ func buildCrashDiagnostics(p *RunningProvider) string {
 	// panic-shaped: the lines just before death can still hint at the
 	// resource being processed when it happened.
 	if tail := p.crashTail(); len(tail) > 0 {
+		// Cap to keep error messages bounded — a panic with hundreds of
+		// blocked goroutines could otherwise produce a multi-MB string and
+		// bloat Sentry events. Take from the start: Go runtime fatals print
+		// the panicking goroutine first, so the most actionable frames are
+		// at the beginning. The other goroutines' stacks rarely add value
+		// beyond the panicking one's.
+		const maxTail = 80
+		truncated := false
+		if len(tail) > maxTail {
+			tail = tail[:maxTail]
+			truncated = true
+		}
 		sb.WriteString("\nplugin stderr (panic/fatal trace):\n")
 		sb.WriteString(strings.Join(tail, "\n"))
+		if truncated {
+			sb.WriteString("\n... (trace truncated)")
+		}
 	} else if snap := p.stderrSnapshot(); len(snap) > 0 {
 		const maxFallback = 30
 		if len(snap) > maxFallback {

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -5,6 +5,7 @@ package providers
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -528,7 +529,8 @@ func (r *Runtime) handlePluginError(err error, provider *ConnectedProvider, reso
 		// Transport-level errors (e.g. "dial tcp" connection failures) don't
 		// carry a gRPC status code. Record them as critical so they reach
 		// error reporting (Sentry) via runtime.CriticalErrors().
-		transportErr := errors.New("the '" + provider.Instance.Name + "' provider connection failed" + ctx + ": " + err.Error())
+		base := "the '" + provider.Instance.Name + "' provider connection failed" + ctx + ": " + err.Error()
+		transportErr := errors.New(base + buildCrashDiagnostics(provider.Instance))
 		r.addCriticalError(transportErr)
 		return false, transportErr
 	}
@@ -549,11 +551,73 @@ func (r *Runtime) handlePluginError(err error, provider *ConnectedProvider, reso
 		// Happens when the plugin crashes or the gRPC connection drops.
 		// TODO: try to restart the plugin and reset its connections
 		provider.Instance.isClosed = true
-		provider.Instance.err = errors.New("the '" + provider.Instance.Name + "' provider crashed" + ctx + ": " + err.Error())
+		base := "the '" + provider.Instance.Name + "' provider crashed" + ctx + ": " + err.Error()
+		provider.Instance.err = errors.New(base + buildCrashDiagnostics(provider.Instance))
 		r.addCriticalError(provider.Instance.err)
 		return false, provider.Instance.err
 	}
 	return false, err
+}
+
+// buildCrashDiagnostics returns a multi-line suffix to append to a crash error
+// with whatever extra context we have about the dead/dying provider:
+// version, uptime, whether the subprocess actually exited, whether the
+// shutdown was triggered by a heartbeat probe, and the most recent stderr
+// (panic/fatal trace if one was captured).
+//
+// Returns "" when there's nothing useful to report, so the message stays
+// compact for cases where the optional context is unavailable (mostly tests
+// and builtin providers).
+func buildCrashDiagnostics(p *RunningProvider) string {
+	if p == nil {
+		return ""
+	}
+
+	var meta []string
+	if v := strings.TrimSpace(p.Version); v != "" {
+		meta = append(meta, "version="+v)
+	}
+	if up := p.uptime(); up > 0 {
+		meta = append(meta, "uptime="+up.Round(time.Millisecond).String())
+	}
+	if p.hasExited() {
+		meta = append(meta, "subprocess=exited")
+	} else if p.startedAt.IsZero() {
+		// builtin/in-process — no subprocess to report on
+	} else {
+		meta = append(meta, "subprocess=running")
+	}
+	if p.hadHeartbeatFailure() {
+		meta = append(meta, "trigger=heartbeat-timeout")
+	}
+
+	var sb strings.Builder
+	if len(meta) > 0 {
+		sb.WriteString("\n[")
+		sb.WriteString(strings.Join(meta, " "))
+		sb.WriteString("]")
+	}
+
+	// Prefer a panic/fatal tail when one was captured — it points at the line
+	// of provider code that died. Fall back to a tail of recent stderr for
+	// OS-level kills (OOM, SIGKILL) that exit before writing anything
+	// panic-shaped: the lines just before death can still hint at the
+	// resource being processed when it happened.
+	if tail := p.crashTail(); len(tail) > 0 {
+		sb.WriteString("\nplugin stderr (panic/fatal trace):\n")
+		sb.WriteString(strings.Join(tail, "\n"))
+	} else if snap := p.stderrSnapshot(); len(snap) > 0 {
+		const maxFallback = 30
+		if len(snap) > maxFallback {
+			snap = snap[len(snap)-maxFallback:]
+		}
+		sb.WriteString("\nplugin stderr (last ")
+		sb.WriteString(strconv.Itoa(len(snap)))
+		sb.WriteString(" lines):\n")
+		sb.WriteString(strings.Join(snap, "\n"))
+	}
+
+	return sb.String()
 }
 
 type providerCallbacks struct {

--- a/providers/runtime_test.go
+++ b/providers/runtime_test.go
@@ -5,7 +5,9 @@ package providers
 
 import (
 	"errors"
+	"io"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -469,10 +471,127 @@ func TestRuntime_CriticalErrors_MultiplePanics(t *testing.T) {
 		Instance: &RunningProvider{Name: "aws"},
 	}
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		panicErr := status.Error(codes.Internal, "panic in provider aws: error")
 		r.handlePluginError(panicErr, provider, "", "") // nolint:errcheck
 	}
 
 	assert.Len(t, r.CriticalErrors(), 3)
+}
+
+func TestRuntime_HandlePluginError_CrashIncludesVersionAndUptime(t *testing.T) {
+	r := &Runtime{}
+	instance := &RunningProvider{
+		Name:      "os",
+		Version:   "13.5.0",
+		startedAt: time.Now().Add(-3 * time.Second),
+	}
+	provider := &ConnectedProvider{Instance: instance}
+
+	crashErr := status.Error(codes.Unavailable, "error reading from server: EOF")
+	_, err := r.handlePluginError(crashErr, provider, "npm.packages", "list")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "version=13.5.0")
+	assert.Contains(t, err.Error(), "uptime=")
+	// uptime=3s (approximately) — just confirm it's a duration string
+	assert.Contains(t, err.Error(), "subprocess=running")
+}
+
+func TestRuntime_HandlePluginError_CrashIncludesPanicTail(t *testing.T) {
+	r := &Runtime{}
+	buf := newCrashLogBuffer(io.Discard, 100)
+	_, _ = buf.Write([]byte("2026-05-04 starting up\n"))
+	_, _ = buf.Write([]byte("panic: runtime error: invalid memory address\n"))
+	_, _ = buf.Write([]byte("[signal SIGSEGV]\n"))
+	_, _ = buf.Write([]byte("goroutine 1:\n"))
+	_, _ = buf.Write([]byte("\tpkg.Func()\n"))
+
+	instance := &RunningProvider{
+		Name:     "os",
+		Version:  "13.5.0",
+		crashLog: buf,
+	}
+	provider := &ConnectedProvider{Instance: instance}
+
+	crashErr := status.Error(codes.Unavailable, "error reading from server: EOF")
+	_, err := r.handlePluginError(crashErr, provider, "npm.packages", "list")
+
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "plugin stderr (panic/fatal trace):")
+	assert.Contains(t, msg, "panic: runtime error: invalid memory address")
+	assert.Contains(t, msg, "goroutine 1:")
+	// The pre-panic startup line must not be in the panic-trace section.
+	tailIdx := mustIndex(t, msg, "plugin stderr (panic/fatal trace):")
+	assert.NotContains(t, msg[tailIdx:], "starting up")
+}
+
+func TestRuntime_HandlePluginError_CrashFallsBackToRecentStderr(t *testing.T) {
+	// No panic marker — we should still surface recent stderr lines so the
+	// caller has something to look at (e.g. for OOM-killed subprocesses that
+	// die without writing a panic trace).
+	r := &Runtime{}
+	buf := newCrashLogBuffer(io.Discard, 100)
+	_, _ = buf.Write([]byte("2026-05-04 querying /var/lib\n"))
+	_, _ = buf.Write([]byte("2026-05-04 found 1024 entries\n"))
+
+	instance := &RunningProvider{
+		Name:     "os",
+		crashLog: buf,
+	}
+	provider := &ConnectedProvider{Instance: instance}
+
+	crashErr := status.Error(codes.Unavailable, "error reading from server: EOF")
+	_, err := r.handlePluginError(crashErr, provider, "files.find", "list")
+
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "plugin stderr (last 2 lines):")
+	assert.Contains(t, msg, "querying /var/lib")
+	assert.Contains(t, msg, "found 1024 entries")
+}
+
+func TestRuntime_HandlePluginError_CrashIncludesHeartbeatTrigger(t *testing.T) {
+	r := &Runtime{}
+	instance := &RunningProvider{
+		Name:            "os",
+		heartbeatFailed: true,
+	}
+	provider := &ConnectedProvider{Instance: instance}
+
+	crashErr := status.Error(codes.Unavailable, "error reading from server: EOF")
+	_, err := r.handlePluginError(crashErr, provider, "windows", "optionalFeatures")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trigger=heartbeat-timeout")
+}
+
+func TestRuntime_HandlePluginError_CrashWithoutContextStaysCompact(t *testing.T) {
+	// A bare RunningProvider (no version, no startedAt, no buffer) should not
+	// produce extra noise — the message is just the original crash text.
+	r := &Runtime{}
+	provider := &ConnectedProvider{
+		Instance: &RunningProvider{Name: "aws"},
+	}
+
+	crashErr := status.Error(codes.Unavailable, "connection lost")
+	_, err := r.handlePluginError(crashErr, provider, "", "")
+
+	require.Error(t, err)
+	msg := err.Error()
+	assert.NotContains(t, msg, "version=")
+	assert.NotContains(t, msg, "uptime=")
+	assert.NotContains(t, msg, "plugin stderr")
+}
+
+func mustIndex(t *testing.T, s, sub string) int {
+	t.Helper()
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	t.Fatalf("substring %q not found in %q", sub, s)
+	return -1
 }

--- a/providers/runtime_test.go
+++ b/providers/runtime_test.go
@@ -6,6 +6,7 @@ package providers
 import (
 	"errors"
 	"io"
+	"strconv"
 	"testing"
 	"time"
 
@@ -565,6 +566,33 @@ func TestRuntime_HandlePluginError_CrashIncludesHeartbeatTrigger(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "trigger=heartbeat-timeout")
+}
+
+func TestRuntime_HandlePluginError_CrashTailIsTruncated(t *testing.T) {
+	// A panic that produces hundreds of stack frames (e.g. with a large
+	// runtime goroutine dump) must not balloon the error string. Verify
+	// the cap kicks in and a truncation marker is appended.
+	r := &Runtime{}
+	buf := newCrashLogBuffer(io.Discard, 500)
+	_, _ = buf.Write([]byte("panic: too much\n"))
+	for i := range 300 {
+		_, _ = buf.Write([]byte(strconv.Itoa(i) + " frame\n"))
+	}
+
+	instance := &RunningProvider{Name: "os", crashLog: buf}
+	provider := &ConnectedProvider{Instance: instance}
+
+	crashErr := status.Error(codes.Unavailable, "EOF")
+	_, err := r.handlePluginError(crashErr, provider, "x", "y")
+
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "panic: too much")
+	assert.Contains(t, msg, "(trace truncated)")
+	// Frame 0..79 should be present (cap is 80, including the panic line
+	// that's 79 frames). Frame 200 should not.
+	assert.Contains(t, msg, "0 frame")
+	assert.NotContains(t, msg, "200 frame")
 }
 
 func TestRuntime_HandlePluginError_CrashWithoutContextStaysCompact(t *testing.T) {


### PR DESCRIPTION
## Summary

When a provider subprocess dies, the only thing currently surfaced via `Runtime.CriticalErrors()` (and onward to Sentry) is the gRPC framing of the dropped connection:

> the 'os' provider crashed (resource=npm.packages, field=list): rpc error: code = Unavailable desc = error reading from server: EOF

That gives no hint at the actual cause. The plugin's panic/fatal trace is written to its stderr and tee'd to `logger.LogOutputWriter` (the local terminal), but in agent / scanner contexts nobody reads stderr, so reports like the recent `MONDOO-2D…` batch are unactionable — we can't tell whether they're nil derefs, OOM kills, concurrent map writes, heartbeat timeouts, or something else.

## Changes

- **`providers/crashlog.go`** — line-aware ring buffer (200 lines) that tees writes to an underlying `io.Writer`. Has a `CrashTail()` helper that returns the suffix from the most recent `panic:` / `fatal error:` / `runtime: ` / `SIG…` / `unexpected fault address` marker.
- **`providers/coordinator.go`** — wraps `logger.LogOutputWriter` with the ring buffer per provider before passing to `plugin.NewClient(Stderr: …)`. Buffer is shared across `RestartableProvider.Reconnect()` restarts.
- **`providers/running_provider.go`** — adds `Version`, `startedAt`, `crashLog`, and `heartbeatFailed` fields on `RunningProvider`, plus accessors. Marks `heartbeatFailed = true` before the heartbeat watcher Shuts the plugin down.
- **`providers/runtime.go`** — `handlePluginError` now appends a diagnostics suffix on crash + transport error:
  ```
  [version=13.5.0 uptime=42s subprocess=exited]
  plugin stderr (panic/fatal trace):
  panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: …]
  goroutine 17 [running]:
  …
  ```
  Falls back to the last 30 raw stderr lines if no panic marker was captured (covers SIGKILL/OOM cases that exit without writing a trace). Adds `trigger=heartbeat-timeout` so heartbeat-driven shutdowns don't masquerade as plugin crashes.

When no diagnostic info is available (mostly tests, builtin providers), the message stays exactly as before — no extra noise.

## Test plan

- [x] `go test ./providers/ -count=1 -race` — passes (incl. 11 new ring buffer tests + 5 new diagnostic enrichment tests)
- [x] `golangci-lint run ./providers/...` — clean
- [x] `gofmt -l` — clean
- [x] `go build ./...` — clean
- [ ] Spot check on a real run: build & install os provider, force a panic in `npm.packages.list`, confirm Sentry-bound message includes the trace
- [ ] Downstream cnspec consumes `CriticalErrors()` — no API change here, just longer error strings; verify they fit Sentry's message field

🤖 Generated with [Claude Code](https://claude.com/claude-code)