### PR TITLE
🐛 fix cross-provider connection issues with k8s provider

### DIFF
--- a/providers-sdk/v1/plugin/service.go
+++ b/providers-sdk/v1/plugin/service.go
@@ -21,7 +21,7 @@ const DISABLE_DELAYED_DISCOVERY_OPTION = "disable-delayed-discovery"
 type Service struct {
 	runtimes         map[uint32]*Runtime
 	lastConnectionID uint32
-	runtimesLock     sync.Mutex
+	runtimesLock     sync.RWMutex
 
 	lastHeartbeat int64
 	heartbeatLock sync.Mutex
@@ -123,13 +123,13 @@ func (s *Service) deprecatedAddRuntime(createRuntime func(connId uint32) (*Runti
 // ^^
 
 func (s *Service) GetRuntime(id uint32) (*Runtime, error) {
-	s.runtimesLock.Lock()
-	defer s.runtimesLock.Unlock()
+	s.runtimesLock.RLock()
+	defer s.runtimesLock.RUnlock()
 	return s.doGetRuntime(id)
 }
 
-// doGetRuntime is a helper function to get a runtime by its ID. It MUST be called
-// with a lock on s.runtimesLock.
+// doGetRuntime is a helper function to get a runtime by its ID. The caller MUST
+// hold s.runtimesLock (read or write).
 func (s *Service) doGetRuntime(id uint32) (*Runtime, error) {
 	if runtime, ok := s.runtimes[id]; ok {
 		return runtime, nil
@@ -181,31 +181,58 @@ func (s *Service) GetData(req *DataReq) (*DataRes, error) {
 		}, nil
 	}
 
-	resource, ok := runtime.Resources.Get(req.Resource + "\x00" + req.ResourceId)
+	resourceKey := req.Resource + "\x00" + req.ResourceId
+	resource, ok := runtime.Resources.Get(resourceKey)
 	if !ok {
-		// Note: Since resources are internally always created, there are only very
-		// few cases where we arrive here:
-		// 1. The caller is wrong. Possibly a mixup with IDs
-		// 2. The resource was loaded from a recording, but the field is not
-		// in the recording. Thus the resource was never created inside the
-		// plugin. We will attempt to create the resource and see if the field
-		// can be computed.
-		if !runtime.HasRecording {
+		// The resource doesn't exist in this runtime. This can happen when:
+		// 1. The resource was loaded from a recording but the field is not in the
+		//    recording. We attempt to create the resource from the recording.
+		// 2. The resource was created via a different connection's runtime (e.g.,
+		//    cross-provider shared resources in K8s). We search sibling runtimes.
+		// 3. The caller is wrong (possibly a mixup with IDs).
+		if runtime.HasRecording {
+			args, err := runtime.ResourceFromRecording(req.Resource, req.ResourceId)
+			if err != nil {
+				return nil, errors.New("attempted to load resource '" + req.Resource + "' (id: " + req.ResourceId + ") from recording failed: " + err.Error())
+			}
+
+			resource, err = runtime.CreateResource(runtime, req.Resource, args)
+			if err != nil {
+				return nil, errors.New("attempted to create resource '" + req.Resource + "' (id: " + req.ResourceId + ") from recording failed: " + err.Error())
+			}
+		} else if resource, ok = s.findResourceInRuntimes(req.Connection, resourceKey); ok {
+			// Safe: shared resources that hit this path are fully resolved at creation
+			// time and don't lazy-load fields through MqlRuntime.
+			runtime.Resources.Set(resourceKey, resource)
+		} else {
 			return nil, errors.New("resource '" + req.Resource + "' (id: " + req.ResourceId + ") doesn't exist")
-		}
-
-		args, err := runtime.ResourceFromRecording(req.Resource, req.ResourceId)
-		if err != nil {
-			return nil, errors.New("attempted to load resource '" + req.Resource + "' (id: " + req.ResourceId + ") from recording failed: " + err.Error())
-		}
-
-		resource, err = runtime.CreateResource(runtime, req.Resource, args)
-		if err != nil {
-			return nil, errors.New("attempted to create resource '" + req.Resource + "' (id: " + req.ResourceId + ") from recording failed: " + err.Error())
 		}
 	}
 
 	return runtime.GetData(resource, req.Field, args), nil
+}
+
+// findResourceInRuntimes searches all runtimes for a resource by key. This
+// handles the case where a resource was created via one connection but is being
+// looked up from a different connection in the same provider (e.g., cross-provider
+// shared resources created via CreateSharedResource in K8s scans).
+//
+// The search is intentionally global (not scoped to parent/child lineage) because
+// the affected resources (container.image, certificates, cpe, tls, etc.) are
+// stateless and deterministic — same __id guarantees identical data regardless of
+// which connection created them.
+func (s *Service) findResourceInRuntimes(connID uint32, resourceKey string) (Resource, bool) {
+	s.runtimesLock.RLock()
+	defer s.runtimesLock.RUnlock()
+	for id, rt := range s.runtimes {
+		if id == connID {
+			continue
+		}
+		if res, ok := rt.Resources.Get(resourceKey); ok {
+			return res, true
+		}
+	}
+	return nil, false
 }
 
 func (s *Service) StoreData(req *StoreReq) (*StoreRes, error) {

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -391,6 +391,11 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 
 		switch conf.Type {
 		case shared.Type_Local.String(), "k8s": // FIXME: k8s is a temp workaround for cross-provider resources
+			if conf.Type == "k8s" {
+				// The parent connection lives in the k8s provider process, not here.
+				// Without this, AddRuntime would fail with "parent connection N not found".
+				conf.ParentConnectionId = 0
+			}
 			conn = local.NewConnection(connId, conf, asset)
 
 			fingerprint, p, err := id.IdentifyPlatform(conn, req, asset.Platform, asset.IdDetector)


### PR DESCRIPTION
## Summary

Fixes two errors that occur during K8s workload scans with cross-provider resources:

1. `parent connection 2 not found` — OS provider tried to find a K8s namespace parent in its own runtime:

```
2026-04-28T02:06:00 error: rpc error: code = Unknown desc = parent connection 2 not found
```

Fixing that uncovered:

2. `resource 'container.image' doesn't exist` — each K8s workload gets its own OS connection, but shared Resources references resources created via a sibling's connection:

```
error: rpc error: code = Unknown desc = resource 'container.image' (id: ghcr.io/mondoohq/mondoo-operator/cnspec@sha256:77d867...) doesn't exist
```

### Commit 1: Clear ParentConnectionId for cross-provider K8s connections

When the OS provider receives a `"k8s"` type connection (cross-provider call from K8s), it zeroes `ParentConnectionId` so `AddRuntime` doesn't look for a K8s namespace connection in the OS runtime map.

### Commit 2: Search sibling runtimes in GetData (findResourceInRuntimes)

When `GetData` can't find a resource in the requesting connection's runtime, it searches all runtimes in the same provider. Once found, the resource is cached in the requesting runtime for instant subsequent lookups.

**Why this is safe:**

- All cross-provider shared resources (`container.image`, `certificates`, `cpe`, `tls`, `socket`, `openpgp.entities`) are stateless and deterministic — their data depends only on the input (image ref, cert bytes, CPE string), not on which asset/connection created them. Same `__id` guarantees same data, so sharing across runtimes is always correct.
- `Resources` is backed by `sync.Map`; `findResourceInRuntimes` holds `runtimesLock` during search — no race conditions.
- Intra-provider `CreateSharedResource` calls already share a runtime via parent-child and never hit this path.

## Test plan

- [x] K8s scan produces 0 errors (was 90+ `container.image` errors and `parent connection` errors)
- [x] Scoring identical to unpatched baseline (1399 checks, 874 pass, 525 fail)
- [x] `go test ./providers-sdk/v1/plugin/` passes
