### PR TITLE
🐛 pin thrift to v0.22.0 in snowflake (32-bit build fix)

### DIFF
--- a/providers/snowflake/go.mod
+++ b/providers/snowflake/go.mod
@@ -2,6 +2,11 @@ module go.mondoo.com/mql/v13/providers/snowflake
 
 replace go.mondoo.com/mql/v13 => ../..
 
+// thrift v0.23.0 fails to build on 32-bit targets (linux/386, linux/arm/v7):
+// framed_transport.go:206 uses math.MaxUint32, which overflows int on 32-bit.
+// Drop this once the next upstream release ships the fix.
+replace github.com/apache/thrift => github.com/apache/thrift v0.22.0
+
 go 1.26.2
 
 require (

--- a/providers/snowflake/go.sum
+++ b/providers/snowflake/go.sum
@@ -87,8 +87,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/apache/arrow-go/v18 v18.6.0 h1:GX/Jyd3R7mCLiECAwY9FWbbaYblie2WXBSz4Sw8fNpM=
 github.com/apache/arrow-go/v18 v18.6.0/go.mod h1:gm3MiPpY82fLYK5VKPB3WoJbsiLVDfT7flD5/vHReKw=
-github.com/apache/thrift v0.23.0 h1:wKR6YnefQSEnxpEfmgTPuJibNG4bF0p2TK34tHLWi3s=
-github.com/apache/thrift v0.23.0/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=
+github.com/apache/thrift v0.22.0 h1:r7mTJdj51TMDe6RtcmNdQxgn9XcyfGDOzegMDRg47uc=
+github.com/apache/thrift v0.22.0/go.mod h1:1e7J/O1Ae6ZQMTYdy9xa3w9k+XHWPfRvdPyJeynQ+/g=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -498,8 +498,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/package-url/packageurl-go v0.1.6 h1:YO3p6u1XmCUliivUg/qWphaY8vI6hxSnnPv7Bfg3m5M=
-github.com/package-url/packageurl-go v0.1.6/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
+github.com/package-url/packageurl-go v0.1.5 h1:O4efRXja2XQ5CtiiYiCZ22k/m7i5ugLiAghgcC+eDgk=
+github.com/package-url/packageurl-go v0.1.5/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
 github.com/pandatix/go-cvss v0.6.2 h1:TFiHlzUkT67s6UkelHmK6s1INKVUG7nlKYiWWDTITGI=
 github.com/pandatix/go-cvss v0.6.2/go.mod h1:jDXYlQBZrc8nvrMUVVvTG8PhmuShOnKrxP53nOFkt8Q=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=


### PR DESCRIPTION
## Summary
- `apache/thrift v0.23.0` introduced `if size > math.MaxUint32` in `framed_transport.go:206`, which overflows `int` on 32-bit targets (`linux/386`, `linux/arm/v7`) and breaks the snowflake provider's release build.
- This re-applies the v0.22.0 pin (originally landed in #7439), but uses a `replace` directive so the pin survives the weekly deps-update job — the previous attempt was a plain require downgrade and got bumped back to v0.23.0 by the May 3 deps update.
- Both `gosnowflake` and `arrow-go` (the snowflake transitive importers) declare thrift `v0.22.0` already, so the replace is a no-op for them.

## Test plan
- [x] `GOOS=linux GOARCH=386 go build ./...` from `providers/snowflake` — succeeds (failed without pin)
- [x] `GOOS=linux GOARCH=arm GOARM=7 go build ./...` — succeeds
- [x] `GOOS=linux GOARCH=amd64 go build ./...` — still succeeds
- [x] `GOOS=darwin GOARCH=arm64 go build ./...` — still succeeds
- [x] `go mod tidy` clean

## Follow-up
Drop the `replace` directive once a thrift release > v0.23.0 ships with the math.MaxUint32 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)