### PR TITLE
✨ vsphere: expose host lockdownMode, firewallEnabled, secureBootEnabled

### DIFF
--- a/providers/vsphere/resources/datacenter.go
+++ b/providers/vsphere/resources/datacenter.go
@@ -50,12 +50,17 @@ func newVsphereHostResources(vClient *resourceclient.Client, runtime *plugin.Run
 			}
 		}
 
+		lockdownMode, firewallEnabled, secureBootEnabled := hostHardeningArgs(hostInfo)
+
 		mqlHost, err := CreateResource(runtime, "vsphere.host", map[string]*llx.RawData{
-			"moid":          llx.StringData(h.Reference().Encode()),
-			"name":          llx.StringData(name),
-			"properties":    llx.DictData(props),
-			"inventoryPath": llx.StringData(h.InventoryPath),
-			"tags":          llx.ArrayData(convert.SliceAnyToInterface(tags), types.String),
+			"moid":              llx.StringData(h.Reference().Encode()),
+			"name":              llx.StringData(name),
+			"properties":        llx.DictData(props),
+			"inventoryPath":     llx.StringData(h.InventoryPath),
+			"tags":              llx.ArrayData(convert.SliceAnyToInterface(tags), types.String),
+			"lockdownMode":      llx.StringData(lockdownMode),
+			"firewallEnabled":   llx.BoolData(firewallEnabled),
+			"secureBootEnabled": llx.BoolData(secureBootEnabled),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/vsphere/resources/host.go
+++ b/providers/vsphere/resources/host.go
@@ -25,6 +25,27 @@ func (v *mqlVsphereHost) id() (string, error) {
 	return v.Moid.Data, nil
 }
 
+// hostHardeningArgs extracts a few audit-relevant scalar fields from mo.HostSystem.
+// firewallEnabled reflects whether the default policy blocks unsolicited incoming
+// traffic; the host firewall service itself is always running on ESXi.
+// secureBootEnabled is reported by HostCapability.UefiSecureBoot, which requires
+// vSphere 8.0.3+; on older hosts it's reported as false.
+func hostHardeningArgs(hostInfo *mo.HostSystem) (lockdownMode string, firewallEnabled bool, secureBootEnabled bool) {
+	if hostInfo == nil {
+		return "", false, false
+	}
+	if hostInfo.Config != nil {
+		lockdownMode = string(hostInfo.Config.LockdownMode)
+		if fw := hostInfo.Config.Firewall; fw != nil && fw.DefaultPolicy.IncomingBlocked != nil {
+			firewallEnabled = *fw.DefaultPolicy.IncomingBlocked
+		}
+	}
+	if hostInfo.Capability != nil && hostInfo.Capability.UefiSecureBoot != nil {
+		secureBootEnabled = *hostInfo.Capability.UefiSecureBoot
+	}
+	return
+}
+
 func initVsphereHost(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 0 {
 		return args, nil, nil
@@ -46,10 +67,15 @@ func initVsphereHost(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		name = hostInfo.Name
 	}
 
+	lockdownMode, firewallEnabled, secureBootEnabled := hostHardeningArgs(hostInfo)
+
 	args["moid"] = llx.StringData(h.Reference().Encode())
 	args["name"] = llx.StringData(name)
 	args["properties"] = llx.DictData(props)
 	args["inventoryPath"] = llx.StringData(h.InventoryPath)
+	args["lockdownMode"] = llx.StringData(lockdownMode)
+	args["firewallEnabled"] = llx.BoolData(firewallEnabled)
+	args["secureBootEnabled"] = llx.BoolData(secureBootEnabled)
 
 	return args, nil, nil
 }

--- a/providers/vsphere/resources/vsphere.go
+++ b/providers/vsphere/resources/vsphere.go
@@ -133,7 +133,7 @@ func esxiHostProperties(conn *connection.VsphereConnection) (*object.HostSystem,
 		// check if the connection was initialized with a specific host
 		identifier, err := conn.Identifier()
 		if err != nil || !connection.IsVsphereResourceID(identifier) {
-			return nil, nil, errors.New("esxi resource is only supported for esxi connections or vsphere vm connections")
+			return nil, nil, errors.New("singular host resource is ambiguous on a vCenter connection; use vsphere.datacenter.hosts or vsphere.cluster.hosts to enumerate, or connect directly to an ESXi host")
 		}
 
 		// extract type and inventory
@@ -143,7 +143,7 @@ func esxiHostProperties(conn *connection.VsphereConnection) (*object.HostSystem,
 		}
 
 		if moid.Type != "HostSystem" {
-			return nil, nil, errors.New("esxi resource is not supported for vsphere type " + moid.Type)
+			return nil, nil, errors.New("singular host resource is not supported for vsphere type " + moid.Type)
 		}
 
 		h, err = cl.HostByMoid(moid)

--- a/providers/vsphere/resources/vsphere.lr
+++ b/providers/vsphere/resources/vsphere.lr
@@ -170,6 +170,12 @@ private vsphere.host @defaults("moid name") {
   snmp() map[string]string
   //Host tags
   tags []string
+  // Lockdown mode (lockdownDisabled, lockdownNormal, lockdownStrict)
+  lockdownMode string
+  // Whether the host firewall blocks unsolicited incoming traffic by default (the host firewall service itself is always running on ESXi)
+  firewallEnabled bool
+  // Whether the host firmware reports UEFI Secure Boot was used during system boot (requires vSphere 8.0.3 or later)
+  secureBootEnabled bool
 }
 
 // vSphere VM resource

--- a/providers/vsphere/resources/vsphere.lr.go
+++ b/providers/vsphere/resources/vsphere.lr.go
@@ -396,6 +396,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"vsphere.host.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVsphereHost).GetTags()).ToDataRes(types.Array(types.String))
 	},
+	"vsphere.host.lockdownMode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereHost).GetLockdownMode()).ToDataRes(types.String)
+	},
+	"vsphere.host.firewallEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereHost).GetFirewallEnabled()).ToDataRes(types.Bool)
+	},
+	"vsphere.host.secureBootEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereHost).GetSecureBootEnabled()).ToDataRes(types.Bool)
+	},
 	"vsphere.vm.moid": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVsphereVm).GetMoid()).ToDataRes(types.String)
 	},
@@ -880,6 +889,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"vsphere.host.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlVsphereHost).Tags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"vsphere.host.lockdownMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHost).LockdownMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"vsphere.host.firewallEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHost).FirewallEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"vsphere.host.secureBootEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHost).SecureBootEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"vsphere.vm.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2028,6 +2049,9 @@ type mqlVsphereHost struct {
 	Ntp               plugin.TValue[*mqlEsxiNtpconfig]
 	Snmp              plugin.TValue[map[string]any]
 	Tags              plugin.TValue[[]any]
+	LockdownMode      plugin.TValue[string]
+	FirewallEnabled   plugin.TValue[bool]
+	SecureBootEnabled plugin.TValue[bool]
 }
 
 // createVsphereHost creates a new instance of this resource
@@ -2247,6 +2271,18 @@ func (c *mqlVsphereHost) GetSnmp() *plugin.TValue[map[string]any] {
 
 func (c *mqlVsphereHost) GetTags() *plugin.TValue[[]any] {
 	return &c.Tags
+}
+
+func (c *mqlVsphereHost) GetLockdownMode() *plugin.TValue[string] {
+	return &c.LockdownMode
+}
+
+func (c *mqlVsphereHost) GetFirewallEnabled() *plugin.TValue[bool] {
+	return &c.FirewallEnabled
+}
+
+func (c *mqlVsphereHost) GetSecureBootEnabled() *plugin.TValue[bool] {
+	return &c.SecureBootEnabled
 }
 
 // mqlVsphereVm for the vsphere.vm resource

--- a/providers/vsphere/resources/vsphere.lr.versions
+++ b/providers/vsphere/resources/vsphere.lr.versions
@@ -70,13 +70,16 @@ vsphere.host.acceptanceLevel 9.0.0
 vsphere.host.adapters 9.0.0
 vsphere.host.advancedSettings 9.0.0
 vsphere.host.distributedSwitch 9.0.0
+vsphere.host.firewallEnabled 13.0.10
 vsphere.host.inventoryPath 9.0.0
 vsphere.host.kernelModules 9.0.0
+vsphere.host.lockdownMode 13.0.10
 vsphere.host.moid 9.0.0
 vsphere.host.name 9.0.0
 vsphere.host.ntp 9.0.0
 vsphere.host.packages 9.0.0
 vsphere.host.properties 9.0.0
+vsphere.host.secureBootEnabled 13.0.10
 vsphere.host.services 9.0.0
 vsphere.host.snmp 9.0.0
 vsphere.host.standardSwitch 9.0.0


### PR DESCRIPTION
## Summary

- Adds three hardening scalars to `vsphere.host` so audits can assert on host posture without traversing the `properties` dict:
  - `lockdownMode string` — `HostSystem.Config.LockdownMode` (`lockdownDisabled` / `lockdownNormal` / `lockdownStrict`).
  - `firewallEnabled bool` — `HostSystem.Config.Firewall.DefaultPolicy.IncomingBlocked`. The host firewall service itself is always running on ESXi; this field reflects default-deny posture, which is the CIS-relevant signal.
  - `secureBootEnabled bool` — `HostSystem.Capability.UefiSecureBoot` (vSphere 8.0.3+; older hosts report `false`).
- Reworks the misleading error that fired when calling `vsphere.host` (singular) on a vCenter connection. The old message claimed an "esxi resource" couldn't be resolved; the new one names the actual resource and points users at `vsphere.datacenter.hosts` / `vsphere.cluster.hosts`.

Both creation paths (`initVsphereHost` and `newVsphereHostResources`) populate the new fields via a small `hostHardeningArgs` helper that nil-guards `Config`, `Firewall`, and `Capability`.

New `.lr.versions` entries are at `13.0.10`.

## Test plan

- [ ] `mql shell vsphere -- "vsphere.datacenter.hosts { name lockdownMode firewallEnabled secureBootEnabled }"` against a vCenter connection — verify all three fields populate.
- [ ] `mql shell vsphere -- "vsphere.host { lockdownMode firewallEnabled secureBootEnabled }"` against a direct ESXi connection — verify singular accessor still works and fields populate.
- [ ] `mql shell vsphere -- "vsphere.host"` against a vCenter (no host scope) — verify the new error message names `vsphere.host` and points to `vsphere.datacenter.hosts` / `vsphere.cluster.hosts`.
- [ ] Spot-check `secureBootEnabled` on a pre-8.0.3 host reports `false` rather than erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)