### PR TITLE
🐛 vsphere: fix per-host data leak in adapters/vmknics/services/etc

### DIFF
--- a/providers/vsphere/resources/host.go
+++ b/providers/vsphere/resources/host.go
@@ -110,8 +110,10 @@ func (v *mqlVsphereHost) standardSwitch() ([]any, error) {
 
 	mqlVswitches := make([]any, len(vswitches))
 	for i, s := range vswitches {
+		name := s["Name"].(string)
 		mqlVswitch, err := CreateResource(v.MqlRuntime, "vsphere.vswitch.standard", map[string]*llx.RawData{
-			"name":       llx.StringData(s["Name"].(string)),
+			"__id":       llx.StringData(esxiClient.InventoryPath + "/" + name),
+			"name":       llx.StringData(name),
 			"properties": llx.DictData(s),
 		})
 		if err != nil {
@@ -142,8 +144,10 @@ func (v *mqlVsphereHost) distributedSwitch() ([]any, error) {
 
 	mqlVswitches := make([]any, len(vswitches))
 	for i, s := range vswitches {
+		name := s["Name"].(string)
 		mqlVswitch, err := CreateResource(v.MqlRuntime, "vsphere.vswitch.dvs", map[string]*llx.RawData{
-			"name":       llx.StringData(s["Name"].(string)),
+			"__id":       llx.StringData(esxiClient.InventoryPath + "/" + name),
+			"name":       llx.StringData(name),
 			"properties": llx.DictData(s),
 		})
 		if err != nil {
@@ -189,6 +193,7 @@ func (v *mqlVsphereHost) adapters() ([]any, error) {
 		pParams := pauseParams[nicName]
 
 		mqlAdapter, err := CreateResource(v.MqlRuntime, "vsphere.vmnic", map[string]*llx.RawData{
+			"__id":        llx.StringData(esxiClient.InventoryPath + "/" + nicName),
 			"name":        llx.StringData(nicName),
 			"properties":  llx.DictData(a),
 			"pauseParams": llx.DictData(pParams),
@@ -244,8 +249,10 @@ func (v *mqlVsphereHost) vmknics() ([]any, error) {
 	mqlVmknics := make([]any, len(vmknics))
 	for i := range vmknics {
 		entry := vmknics[i]
+		nicName := entry.Properties["Name"].(string)
 		mqlVswitch, err := CreateResource(v.MqlRuntime, "vsphere.vmknic", map[string]*llx.RawData{
-			"name":       llx.StringData(entry.Properties["Name"].(string)),
+			"__id":       llx.StringData(esxiClient.InventoryPath + "/" + nicName),
+			"name":       llx.StringData(nicName),
 			"properties": llx.DictData(entry.Properties),
 			"ipv4":       llx.ArrayData(entry.Ipv4, types.Dict),
 			"ipv6":       llx.ArrayData(entry.Ipv6, types.Dict),
@@ -330,6 +337,7 @@ func (v *mqlVsphereHost) kernelModules() ([]any, error) {
 	mqlModules := make([]any, len(modules))
 	for i, m := range modules {
 		mqlModule, err := CreateResource(v.MqlRuntime, "esxi.kernelmodule", map[string]*llx.RawData{
+			"__id":                 llx.StringData(esxiClient.InventoryPath + "/" + m.Module),
 			"name":                 llx.StringData(m.Module),
 			"modulefile":           llx.StringData(m.ModuleFile),
 			"version":              llx.StringData(m.Version),
@@ -388,6 +396,7 @@ func (v *mqlVsphereHost) services() ([]any, error) {
 	mqlServices := make([]any, len(services))
 	for i, s := range services {
 		mqlService, err := CreateResource(v.MqlRuntime, "esxi.service", map[string]*llx.RawData{
+			"__id":     llx.StringData(path + "/" + s.Key),
 			"key":      llx.StringData(s.Key),
 			"label":    llx.StringData(s.Label),
 			"required": llx.BoolData(s.Required),
@@ -427,6 +436,7 @@ func (v *mqlVsphereHost) timezone() (*mqlEsxiTimezone, error) {
 	}
 
 	mqlTimezone, err := CreateResource(v.MqlRuntime, "esxi.timezone", map[string]*llx.RawData{
+		"__id":        llx.StringData(path + "/" + datetimeinfo.TimeZone.Key),
 		"key":         llx.StringData(datetimeinfo.TimeZone.Key),
 		"name":        llx.StringData(datetimeinfo.TimeZone.Name),
 		"offset":      llx.IntData(int64(datetimeinfo.TimeZone.GmtOffset)),
@@ -435,7 +445,6 @@ func (v *mqlVsphereHost) timezone() (*mqlEsxiTimezone, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	return mqlTimezone.(*mqlEsxiTimezone), nil
 }
 


### PR DESCRIPTION
## Summary

Resources created from per-host esxcli accessors used non-host-unique `__id`s (the NIC name, service key, etc.). Since the runtime cache key is `resourceName + "\x00" + __id`, host B's `vmnic0` collided with host A's `vmnic0` and the cache returned host A's instance for all subsequent lookups — so all hosts appeared to share host A's MACs / IPs / etc.

Affected resources:
- `vsphere.vmnic`
- `vsphere.vmknic`
- `vsphere.vswitch.standard`
- `vsphere.vswitch.dvs`
- `esxi.kernelmodule`
- `esxi.service`
- `esxi.timezone`

(`esxi.vib` and `esxi.ntpconfig` were already safe — `vib.id` is globally unique, and `ntpconfig.id` was already prefixed with the host inventory path.)

## Symptom

On a 3-host cluster, querying:

```
vsphere.datacenters { hosts { vmknics { name ipv4 } } }
```

returned **host A's vmk0 IP for all three hosts**, even though the underlying esxcli call was correctly fetching distinct data per host. The bug was upstream in the runtime cache, not in the SOAP/esxcli layer.

## Fix

Pass an explicit `__id` arg to each `CreateResource` call, prefixed with the host's inventory path (e.g. `<host_inventory_path>/<nic_name>`). The factory uses the explicit `__id` when provided and falls back to `id()` otherwise — so no schema change, no Internal struct shuffling, no .lr.versions churn. Just args.

The previous attempt to put `hostInventoryPath` in an Internal struct didn't fix this because the field was set *after* `CreateResource` returned, but `id()` runs *during* `CreateResource` (when the field is still empty). The `__id`-arg approach sidesteps that ordering entirely.

## Test plan

Validated against a live vSphere 8.0.2 cluster (2 datacenters, 3 ESXi hosts). Cross-checked the corrected esxcli output against `mo.HostSystem.Config.Network.Pnic` from vCenter:

| Host | vmnic0 MAC (vCenter) | vmnic0 MAC (esxcli pre-fix) | vmnic0 MAC (esxcli post-fix) |
|---|---|---|---|
| 192.168.5.23 | `00:0c:29:77:7e:9f` | `00:0c:29:77:7e:9f` | `00:0c:29:77:7e:9f` ✓ |
| 192.168.5.22 | `00:0c:29:1d:3f:94` | `00:0c:29:77:7e:9f` ✗ | `00:0c:29:1d:3f:94` ✓ |
| 192.168.5.21 | `00:0c:29:dd:3d:72` | `00:0c:29:77:7e:9f` ✗ | `00:0c:29:dd:3d:72` ✓ |

Same pattern for vmknic IPv4 addresses.

- [ ] `mql shell vsphere -- "vsphere.datacenters { hosts { name vmknics { name ipv4 properties.MACAddress } adapters { name properties.MACAddress } } }"` against a multi-host vCenter — confirm each host's data is distinct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)