### PR TITLE
🎉 vsphere-13.0.11

### DIFF
--- a/providers/vsphere/config/config.go
+++ b/providers/vsphere/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vsphere",
 	ID:              "go.mondoo.com/cnquery/v9/providers/vsphere",
-	Version:         "13.0.10",
+	Version:         "13.0.11",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### vsphere (13.0.11)
- 🐛 vsphere: fix per-host data leak in adapters/vmknics/services/etc (#7512)
- 🧹 vsphere: bump govmomi v0.46.3 → v0.47.1 (#7511)
- 🐛 vsphere: rename firewallEnabled to firewallIncomingBlocked + add outgoing (#7510)
- ✨ vsphere: expose host lockdownMode, firewallEnabled, secureBootEnabled (#7509)