### PR TITLE
⚡ vsphere: batch vAPI tag lookups during host/VM discovery

### DIFF
--- a/providers/vsphere/resources/common.go
+++ b/providers/vsphere/resources/common.go
@@ -49,7 +49,7 @@ func BatchGetTags(ctx context.Context, refs []mo.Reference, client *vim25.Client
 	if err := restClient.Login(ctx, url.UserPassword(creds.User, string(creds.Secret))); err != nil {
 		return out
 	}
-	defer restClient.Logout(ctx)
+	defer func() { _ = restClient.Logout(ctx) }()
 
 	tagManager := tags.NewManager(restClient)
 
@@ -67,8 +67,11 @@ func BatchGetTags(ctx context.Context, refs []mo.Reference, client *vim25.Client
 			if !ok {
 				if cat, err := tagManager.GetCategory(ctx, tag.CategoryID); err == nil {
 					catName = cat.Name
+					categoryNames[tag.CategoryID] = catName
 				}
-				categoryNames[tag.CategoryID] = catName
+				// Don't cache failures: a transient GetCategory error shouldn't
+				// permanently suppress the category prefix for every other tag
+				// using that category in this batch.
 			}
 			if catName == "" {
 				strs = append(strs, tag.Name)

--- a/providers/vsphere/resources/common.go
+++ b/providers/vsphere/resources/common.go
@@ -11,7 +11,7 @@ import (
 	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vapi/tags"
 	"github.com/vmware/govmomi/vim25"
-	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vim25/mo"
 	vmwaretypes "github.com/vmware/govmomi/vim25/types"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
@@ -26,45 +26,57 @@ func extractTagKeys(tags []vmwaretypes.Tag) []string {
 	return tagKeys
 }
 
-// GetTags retrieves tags for a host system using the vSphere vAPI
-// If the vAPI is not available, it will return an empty array instead of an error.
-// This maintains backward compatibility with vSphere environments that don't use tags.
-func GetTags(ctx context.Context, ref types.ManagedObjectReference, client *vim25.Client, conf *inventory.Config) []string {
-	// Create vAPI REST client
-	restClient := rest.NewClient(client)
+// BatchGetTags fetches the attached vAPI tags for every reference in `refs`
+// using a single REST login and a single batched API call, caching category
+// lookups across the batch. The returned map is keyed by ref.Reference().Value
+// (the MOID) and holds tag strings formatted as "category:tag".
+//
+// On any error (login failure, missing credentials, vAPI unavailable) it
+// returns an empty map — callers should fall back to mo.ManagedEntity.Tag,
+// which preserves the previous "vAPI is best-effort" behavior.
+func BatchGetTags(ctx context.Context, refs []mo.Reference, client *vim25.Client, conf *inventory.Config) map[string][]string {
+	out := map[string][]string{}
+	if len(refs) == 0 {
+		return out
+	}
 
-	// Get credentials from connection config
 	creds, err := vault.GetPassword(conf.Credentials)
 	if err != nil {
-		return []string{}
+		return out
 	}
 
-	userInfo := url.UserPassword(creds.User, string(creds.Secret))
-	err = restClient.Login(ctx, userInfo)
-	if err != nil {
-		return []string{}
+	restClient := rest.NewClient(client)
+	if err := restClient.Login(ctx, url.UserPassword(creds.User, string(creds.Secret))); err != nil {
+		return out
 	}
+	defer restClient.Logout(ctx)
 
 	tagManager := tags.NewManager(restClient)
 
-	// Get attached tags for the host
-	attachedTags, err := tagManager.GetAttachedTags(ctx, ref)
+	attached, err := tagManager.GetAttachedTagsOnObjects(ctx, refs)
 	if err != nil {
-		return []string{}
+		return out
 	}
 
-	// Convert tags to string format: "category:tag"
-	tagStrings := make([]string, len(attachedTags))
-	for i, tag := range attachedTags {
-		// Get category information
-		category, err := tagManager.GetCategory(ctx, tag.CategoryID)
-		if err != nil {
-			// If we can't get category, just use tag name
-			tagStrings[i] = tag.Name
-			continue
+	categoryNames := map[string]string{}
+	for _, entry := range attached {
+		moid := entry.ObjectID.Reference().Value
+		strs := make([]string, 0, len(entry.Tags))
+		for _, tag := range entry.Tags {
+			catName, ok := categoryNames[tag.CategoryID]
+			if !ok {
+				if cat, err := tagManager.GetCategory(ctx, tag.CategoryID); err == nil {
+					catName = cat.Name
+				}
+				categoryNames[tag.CategoryID] = catName
+			}
+			if catName == "" {
+				strs = append(strs, tag.Name)
+			} else {
+				strs = append(strs, fmt.Sprintf("%s:%s", catName, tag.Name))
+			}
 		}
-		tagStrings[i] = fmt.Sprintf("%s:%s", category.Name, tag.Name)
+		out[moid] = strs
 	}
-
-	return tagStrings
+	return out
 }

--- a/providers/vsphere/resources/common.go
+++ b/providers/vsphere/resources/common.go
@@ -58,6 +58,28 @@ func BatchGetTags(ctx context.Context, refs []mo.Reference, client *vim25.Client
 		return out
 	}
 
+	return resolveAttachedTags(ctx, attached, func(ctx context.Context, id string) (string, error) {
+		cat, err := tagManager.GetCategory(ctx, id)
+		if err != nil {
+			return "", err
+		}
+		return cat.Name, nil
+	})
+}
+
+// categoryNameFetcher resolves a category ID to a name. Returning a non-nil
+// error tells resolveAttachedTags to skip the cache entry and try again the
+// next time the category is encountered in the batch.
+type categoryNameFetcher func(ctx context.Context, categoryID string) (string, error)
+
+// resolveAttachedTags formats the (object → tags) pairs from
+// GetAttachedTagsOnObjects into the moid → []string form callers want, looking
+// up category names via getCategory. Categories are fetched at most once per
+// successful lookup per call. A getCategory failure is NOT cached, so a
+// transient error doesn't permanently strip the category prefix from every
+// later tag using that category in the same batch.
+func resolveAttachedTags(ctx context.Context, attached []tags.AttachedTags, getCategory categoryNameFetcher) map[string][]string {
+	out := map[string][]string{}
 	categoryNames := map[string]string{}
 	for _, entry := range attached {
 		moid := entry.ObjectID.Reference().Value
@@ -65,13 +87,10 @@ func BatchGetTags(ctx context.Context, refs []mo.Reference, client *vim25.Client
 		for _, tag := range entry.Tags {
 			catName, ok := categoryNames[tag.CategoryID]
 			if !ok {
-				if cat, err := tagManager.GetCategory(ctx, tag.CategoryID); err == nil {
-					catName = cat.Name
+				if name, err := getCategory(ctx, tag.CategoryID); err == nil {
+					catName = name
 					categoryNames[tag.CategoryID] = catName
 				}
-				// Don't cache failures: a transient GetCategory error shouldn't
-				// permanently suppress the category prefix for every other tag
-				// using that category in this batch.
 			}
 			if catName == "" {
 				strs = append(strs, tag.Name)

--- a/providers/vsphere/resources/common_test.go
+++ b/providers/vsphere/resources/common_test.go
@@ -1,0 +1,93 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/govmomi/vapi/tags"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func attachedFor(moid string, tagPairs ...struct{ name, categoryID string }) tags.AttachedTags {
+	tagsList := make([]tags.Tag, len(tagPairs))
+	for i, p := range tagPairs {
+		tagsList[i] = tags.Tag{Name: p.name, CategoryID: p.categoryID}
+	}
+	return tags.AttachedTags{
+		ObjectID: types.ManagedObjectReference{Type: "VirtualMachine", Value: moid},
+		Tags:     tagsList,
+	}
+}
+
+func TestResolveAttachedTags_BasicAndCachedAcrossObjects(t *testing.T) {
+	calls := map[string]int{}
+	getCategory := func(_ context.Context, id string) (string, error) {
+		calls[id]++
+		return "env", nil
+	}
+
+	out := resolveAttachedTags(context.Background(), []tags.AttachedTags{
+		attachedFor("vm-1", struct{ name, categoryID string }{"prod", "cat-1"}),
+		attachedFor("vm-2", struct{ name, categoryID string }{"prod", "cat-1"}),
+	}, getCategory)
+
+	assert.Equal(t, []string{"env:prod"}, out["vm-1"])
+	assert.Equal(t, []string{"env:prod"}, out["vm-2"])
+	assert.Equal(t, 1, calls["cat-1"], "category should be fetched once across the batch")
+}
+
+func TestResolveAttachedTags_TransientFailureDoesNotPoisonCache(t *testing.T) {
+	calls := map[string]int{}
+	getCategory := func(_ context.Context, id string) (string, error) {
+		calls[id]++
+		// First call fails; subsequent calls succeed. This simulates a
+		// transient network blip that resolves before the next tag is
+		// processed.
+		if calls[id] == 1 {
+			return "", errors.New("transient")
+		}
+		return "env", nil
+	}
+
+	out := resolveAttachedTags(context.Background(), []tags.AttachedTags{
+		attachedFor("vm-1", struct{ name, categoryID string }{"prod", "cat-1"}),
+		attachedFor("vm-2", struct{ name, categoryID string }{"prod", "cat-1"}),
+	}, getCategory)
+
+	// vm-1 hit the failure: tag emitted without category prefix.
+	assert.Equal(t, []string{"prod"}, out["vm-1"])
+	// vm-2 retried (because failure wasn't cached) and got the prefix.
+	assert.Equal(t, []string{"env:prod"}, out["vm-2"])
+	assert.Equal(t, 2, calls["cat-1"], "transient failure should not be cached")
+}
+
+func TestResolveAttachedTags_PersistentFailureFallsBackToTagName(t *testing.T) {
+	getCategory := func(_ context.Context, _ string) (string, error) {
+		return "", errors.New("vAPI down")
+	}
+
+	out := resolveAttachedTags(context.Background(), []tags.AttachedTags{
+		attachedFor("vm-1", struct{ name, categoryID string }{"prod", "cat-1"}),
+	}, getCategory)
+
+	assert.Equal(t, []string{"prod"}, out["vm-1"])
+}
+
+func TestResolveAttachedTags_EmptyTagsYieldsEmptySlice(t *testing.T) {
+	getCategory := func(_ context.Context, _ string) (string, error) {
+		t.Fatal("getCategory should not be called when there are no tags")
+		return "", nil
+	}
+
+	out := resolveAttachedTags(context.Background(), []tags.AttachedTags{
+		attachedFor("vm-1"),
+	}, getCategory)
+
+	assert.Empty(t, out["vm-1"])
+	assert.Contains(t, out, "vm-1")
+}

--- a/providers/vsphere/resources/datacenter.go
+++ b/providers/vsphere/resources/datacenter.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -17,6 +18,15 @@ import (
 )
 
 func newVsphereHostResources(vClient *resourceclient.Client, runtime *plugin.Runtime, vhosts []*object.HostSystem) ([]any, error) {
+	conn := runtime.Connection.(*connection.VsphereConnection)
+	ctx := context.Background()
+
+	hostRefs := make([]mo.Reference, len(vhosts))
+	for i, h := range vhosts {
+		hostRefs[i] = h.Reference()
+	}
+	vapiTagsByMoid := BatchGetTags(ctx, hostRefs, vClient.Client.Client, conn.Conf)
+
 	mqlHosts := make([]any, len(vhosts))
 	for i, h := range vhosts {
 
@@ -34,19 +44,10 @@ func newVsphereHostResources(vClient *resourceclient.Client, runtime *plugin.Run
 		var tags []string
 		if hostInfo != nil {
 			name = hostInfo.Name
-			simpleTags := extractTagKeys(hostInfo.Tag)
-
-			// Get vAPI tags using the connection
-			conn := runtime.Connection.(*connection.VsphereConnection)
-			ctx := context.Background()
-
-			// Get vAPI tags using the connection config
-			vapiTags := GetTags(ctx, h.Reference(), vClient.Client.Client, conn.Conf)
-			// Use vAPI tags if available, otherwise use simple tags
-			if len(vapiTags) > 0 {
-				tags = vapiTags
+			if vapi := vapiTagsByMoid[h.Reference().Value]; len(vapi) > 0 {
+				tags = vapi
 			} else {
-				tags = simpleTags
+				tags = extractTagKeys(hostInfo.Tag)
 			}
 		}
 
@@ -186,6 +187,12 @@ func (v *mqlVsphereDatacenter) vms() ([]any, error) {
 		return nil, err
 	}
 
+	vmRefs := make([]mo.Reference, len(vms))
+	for i, vm := range vms {
+		vmRefs[i] = vm.Reference()
+	}
+	vapiTagsByMoid := BatchGetTags(context.Background(), vmRefs, vClient.Client.Client, conn.Conf)
+
 	mqlVms := make([]any, len(vms))
 	for i, vm := range vms {
 		vmInfo, err := resourceclient.VmInfo(vm)
@@ -193,7 +200,14 @@ func (v *mqlVsphereDatacenter) vms() ([]any, error) {
 			return nil, err
 		}
 
-		mqlVm, err := newMqlVm(v.MqlRuntime, vm, vmInfo)
+		var tags []string
+		if vapi := vapiTagsByMoid[vm.Reference().Value]; len(vapi) > 0 {
+			tags = vapi
+		} else if vmInfo != nil {
+			tags = extractTagKeys(vmInfo.Tag)
+		}
+
+		mqlVm, err := newMqlVm(v.MqlRuntime, vm, vmInfo, tags)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/vsphere/resources/datacenter.go
+++ b/providers/vsphere/resources/datacenter.go
@@ -41,14 +41,15 @@ func newVsphereHostResources(vClient *resourceclient.Client, runtime *plugin.Run
 		}
 
 		var name string
-		var tags []string
 		if hostInfo != nil {
 			name = hostInfo.Name
-			if vapi := vapiTagsByMoid[h.Reference().Value]; len(vapi) > 0 {
-				tags = vapi
-			} else {
-				tags = extractTagKeys(hostInfo.Tag)
-			}
+		}
+
+		var tags []string
+		if vapi := vapiTagsByMoid[h.Reference().Value]; len(vapi) > 0 {
+			tags = vapi
+		} else if hostInfo != nil {
+			tags = extractTagKeys(hostInfo.Tag)
 		}
 
 		lockdownMode, firewallIncomingBlocked, firewallOutgoingBlocked, secureBootEnabled := hostHardeningArgs(hostInfo)

--- a/providers/vsphere/resources/vm.go
+++ b/providers/vsphere/resources/vm.go
@@ -4,8 +4,6 @@
 package resources
 
 import (
-	"context"
-
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	"go.mondoo.com/mql/v13/llx"
@@ -16,32 +14,15 @@ import (
 	"go.mondoo.com/mql/v13/types"
 )
 
-func newMqlVm(runtime *plugin.Runtime, vm *object.VirtualMachine, vmInfo *mo.VirtualMachine) (*mqlVsphereVm, error) {
+func newMqlVm(runtime *plugin.Runtime, vm *object.VirtualMachine, vmInfo *mo.VirtualMachine, tags []string) (*mqlVsphereVm, error) {
 	props, err := resourceclient.VmProperties(vmInfo)
 	if err != nil {
 		return nil, err
 	}
 
 	var name string
-	var tags []string
 	if vmInfo != nil && vmInfo.Config != nil {
 		name = vmInfo.Config.Name
-		// Try both approaches for testing
-		simpleTags := extractTagKeys(vmInfo.Tag)
-
-		// Get vAPI tags using the connection
-		conn := runtime.Connection.(*connection.VsphereConnection)
-		vClient := resourceclient.New(conn.Client())
-		ctx := context.Background()
-
-		// Get vAPI tags using the connection config
-		vapiTags := GetTags(ctx, vm.Reference(), vClient.Client.Client, conn.Conf)
-		// Use vAPI tags if available, fallback to simple tags
-		if len(vapiTags) > 0 {
-			tags = vapiTags
-		} else {
-			tags = simpleTags
-		}
 	}
 
 	mqlVm, err := CreateResource(runtime, "vsphere.vm", map[string]*llx.RawData{


### PR DESCRIPTION
## Summary

Discovery used to do one vAPI session per asset:

- Every host enumerated by `vsphere.datacenter.hosts` triggered its own `rest.Client.Login` + `GetAttachedTags` + per-tag `GetCategory` round-trip.
- Same per VM via `vsphere.datacenter.vms`.

On a 100-host / 500-VM vCenter that's 600 logins per discovery — the dominant cost on tag-using estates and a meaningful cost even on tag-light ones (the login itself is the expensive part, not the tag retrieval).

This PR replaces the per-asset `GetTags` helper with **`BatchGetTags`**: one login, one `GetAttachedTagsOnObjects` call across all object refs, and a category-name cache keyed by category ID. Callers build a single `[]mo.Reference` and look results up by MOID inside the loop. `newMqlVm` now takes pre-fetched tags as a parameter rather than doing its own fetch.

Same fallback semantics: if vAPI login or the batch call errors, the helper returns an empty map and callers fall back to `mo.ManagedEntity.Tag` (the simple per-asset tag set), preserving the previous "vAPI is best-effort" contract.

## Validation

Live cluster: vSphere 8.0.2, 2 datacenters, 3 ESXi hosts, 27 VMs.

### Correctness

Output is byte-identical to the unfixed version:

| Query | Before | After |
|---|---|---|
| `vsphere.datacenters { hosts { name tags } }` | all hosts `tags: []` | identical |
| `vsphere.datacenters { vms { name tags } }` | only `vCenter` VM has `tags: [SYSTEM/COM.VMWARE.VIM.VC]`, rest empty | identical |

### Performance

3 cold runs of each query (full `mql run` startup → connect → discover → exit) on the live cluster, before/after the patch, same machine, same network conditions:

| Query | Before (median) | After (median) | Speedup |
|---|---|---|---|
| `vsphere.datacenters { hosts.length }` | **49.6 s** | **43.2 s** | 1.15× (-6.4 s) |
| `vsphere.datacenters { vms.length }` | **256.4 s** | **62.5 s** | **4.1× (-194 s)** |

Raw trials:

```
BEFORE (vsphere-13.0.11 from main):
  hosts: 49.59  45.84  49.65   (s)
  vms:   235.80 256.41 287.42  (s)

AFTER (this PR):
  hosts: 42.42  44.75  43.17   (s)
  vms:   62.18  62.55  63.20   (s)
```

The VM speedup is the headline number — **4 minutes → 1 minute on a 27-VM cluster** — because 27 logins collapse to 1. The host case is more modest (3 → 1 login) and the gain is limited to the few seconds of login overhead. At larger scale (100+ hosts, hundreds of VMs) both queries should improve linearly with asset count.

The remaining ~60s for VM discovery is dominated by per-VM `HostByInventoryPath` + `Properties(ctx, ref, nil, &props)` over-fetch — separate items in the discovery perf todo and the next things to tackle.

## Test plan

- [ ] `mql shell vsphere -- "vsphere.datacenters { hosts { name tags } vms { name tags } }"` against a vCenter with vAPI tags configured — confirm tag values still appear correctly.
- [ ] Same query against a vCenter without vAPI access (or with vAPI login failure) — confirm graceful fallback to `mo.ManagedEntity.Tag`.
- [ ] Stopwatch a discovery on a real estate; expect a noticeable drop on anything VM-heavy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)