### PR TITLE
⚡ vsphere: fan out per-asset property fetch during host/VM discovery

### DIFF
--- a/providers/vsphere/go.mod
+++ b/providers/vsphere/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/vmware/govmomi v0.47.1
 	go.mondoo.com/mondoo-go v0.0.0-20260430122853-c770cea4fd7f
 	go.mondoo.com/mql/v13 v13.8.0
+	golang.org/x/sync v0.20.0
 )
 
 require (
@@ -150,7 +151,6 @@ require (
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/providers/vsphere/resources/datacenter.go
+++ b/providers/vsphere/resources/datacenter.go
@@ -15,7 +15,27 @@ import (
 	"go.mondoo.com/mql/v13/providers/vsphere/connection"
 	"go.mondoo.com/mql/v13/providers/vsphere/resources/resourceclient"
 	"go.mondoo.com/mql/v13/types"
+	"golang.org/x/sync/errgroup"
 )
+
+// discoveryConcurrency caps the number of concurrent per-asset SOAP calls we
+// fan out during host/VM enumeration. Higher = lower wall-clock for a single
+// discovery, but vCenter rate-limits concurrent sessions and the gain
+// flattens past ~16 workers.
+const discoveryConcurrency = 16
+
+// stagedHost holds the per-host data fetched in the concurrent stage of
+// newVsphereHostResources, before the sequential CreateResource pass.
+type stagedHost struct {
+	hostInfo                *mo.HostSystem
+	props                   map[string]any
+	name                    string
+	tags                    []string
+	lockdownMode            string
+	firewallIncomingBlocked bool
+	firewallOutgoingBlocked bool
+	secureBootEnabled       bool
+}
 
 func newVsphereHostResources(vClient *resourceclient.Client, runtime *plugin.Runtime, vhosts []*object.HostSystem) ([]any, error) {
 	conn := runtime.Connection.(*connection.VsphereConnection)
@@ -27,52 +47,63 @@ func newVsphereHostResources(vClient *resourceclient.Client, runtime *plugin.Run
 	}
 	vapiTagsByMoid := BatchGetTags(ctx, hostRefs, vClient.Client.Client, conn.Conf)
 
-	mqlHosts := make([]any, len(vhosts))
+	// Stage 1 — concurrent fetch of per-host data (SOAP + JSON marshaling).
+	// CreateResource is held back to stage 2 because it touches the runtime
+	// resource cache, which we keep single-threaded.
+	staged := make([]stagedHost, len(vhosts))
+	g, _ := errgroup.WithContext(ctx)
+	g.SetLimit(discoveryConcurrency)
 	for i, h := range vhosts {
+		i, h := i, h
+		g.Go(func() error {
+			hostInfo, err := resourceclient.HostInfo(h)
+			if err != nil {
+				return err
+			}
+			props, err := resourceclient.HostProperties(hostInfo)
+			if err != nil {
+				return err
+			}
 
-		hostInfo, err := resourceclient.HostInfo(h)
-		if err != nil {
-			return nil, err
-		}
+			s := stagedHost{hostInfo: hostInfo, props: props}
+			if hostInfo != nil {
+				s.name = hostInfo.Name
+			}
+			if vapi := vapiTagsByMoid[h.Reference().Value]; len(vapi) > 0 {
+				s.tags = vapi
+			} else if hostInfo != nil {
+				s.tags = extractTagKeys(hostInfo.Tag)
+			}
+			s.lockdownMode, s.firewallIncomingBlocked, s.firewallOutgoingBlocked, s.secureBootEnabled = hostHardeningArgs(hostInfo)
+			staged[i] = s
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
 
-		props, err := resourceclient.HostProperties(hostInfo)
-		if err != nil {
-			return nil, err
-		}
-
-		var name string
-		if hostInfo != nil {
-			name = hostInfo.Name
-		}
-
-		var tags []string
-		if vapi := vapiTagsByMoid[h.Reference().Value]; len(vapi) > 0 {
-			tags = vapi
-		} else if hostInfo != nil {
-			tags = extractTagKeys(hostInfo.Tag)
-		}
-
-		lockdownMode, firewallIncomingBlocked, firewallOutgoingBlocked, secureBootEnabled := hostHardeningArgs(hostInfo)
-
+	// Stage 2 — sequential CreateResource pass.
+	mqlHosts := make([]any, len(vhosts))
+	for i, s := range staged {
+		h := vhosts[i]
 		mqlHost, err := CreateResource(runtime, "vsphere.host", map[string]*llx.RawData{
 			"moid":                    llx.StringData(h.Reference().Encode()),
-			"name":                    llx.StringData(name),
-			"properties":              llx.DictData(props),
+			"name":                    llx.StringData(s.name),
+			"properties":              llx.DictData(s.props),
 			"inventoryPath":           llx.StringData(h.InventoryPath),
-			"tags":                    llx.ArrayData(convert.SliceAnyToInterface(tags), types.String),
-			"lockdownMode":            llx.StringData(lockdownMode),
-			"firewallIncomingBlocked": llx.BoolData(firewallIncomingBlocked),
-			"firewallOutgoingBlocked": llx.BoolData(firewallOutgoingBlocked),
-			"secureBootEnabled":       llx.BoolData(secureBootEnabled),
+			"tags":                    llx.ArrayData(convert.SliceAnyToInterface(s.tags), types.String),
+			"lockdownMode":            llx.StringData(s.lockdownMode),
+			"firewallIncomingBlocked": llx.BoolData(s.firewallIncomingBlocked),
+			"firewallOutgoingBlocked": llx.BoolData(s.firewallOutgoingBlocked),
+			"secureBootEnabled":       llx.BoolData(s.secureBootEnabled),
 		})
 		if err != nil {
 			return nil, err
 		}
-		mqlHost.(*mqlVsphereHost).host = hostInfo
-
+		mqlHost.(*mqlVsphereHost).host = s.hostInfo
 		mqlHosts[i] = mqlHost
 	}
-
 	return mqlHosts, nil
 }
 
@@ -188,34 +219,69 @@ func (v *mqlVsphereDatacenter) vms() ([]any, error) {
 		return nil, err
 	}
 
+	ctx := context.Background()
 	vmRefs := make([]mo.Reference, len(vms))
 	for i, vm := range vms {
 		vmRefs[i] = vm.Reference()
 	}
-	vapiTagsByMoid := BatchGetTags(context.Background(), vmRefs, vClient.Client.Client, conn.Conf)
+	vapiTagsByMoid := BatchGetTags(ctx, vmRefs, vClient.Client.Client, conn.Conf)
 
-	mqlVms := make([]any, len(vms))
+	// Stage 1 — concurrent VmInfo + VmProperties for each VM.
+	type stagedVm struct {
+		vmInfo *mo.VirtualMachine
+		props  map[string]any
+		tags   []string
+	}
+	staged := make([]stagedVm, len(vms))
+	g, _ := errgroup.WithContext(ctx)
+	g.SetLimit(discoveryConcurrency)
 	for i, vm := range vms {
-		vmInfo, err := resourceclient.VmInfo(vm)
-		if err != nil {
-			return nil, err
-		}
+		i, vm := i, vm
+		g.Go(func() error {
+			vmInfo, err := resourceclient.VmInfo(vm)
+			if err != nil {
+				return err
+			}
+			props, err := resourceclient.VmProperties(vmInfo)
+			if err != nil {
+				return err
+			}
 
-		var tags []string
-		if vapi := vapiTagsByMoid[vm.Reference().Value]; len(vapi) > 0 {
-			tags = vapi
-		} else if vmInfo != nil {
-			tags = extractTagKeys(vmInfo.Tag)
-		}
-
-		mqlVm, err := newMqlVm(v.MqlRuntime, vm, vmInfo, tags)
-		if err != nil {
-			return nil, err
-		}
-
-		mqlVms[i] = mqlVm
+			s := stagedVm{vmInfo: vmInfo, props: props}
+			if vapi := vapiTagsByMoid[vm.Reference().Value]; len(vapi) > 0 {
+				s.tags = vapi
+			} else if vmInfo != nil {
+				s.tags = extractTagKeys(vmInfo.Tag)
+			}
+			staged[i] = s
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 
+	// Stage 2 — sequential CreateResource pass.
+	mqlVms := make([]any, len(vms))
+	for i, s := range staged {
+		vm := vms[i]
+		var name string
+		if s.vmInfo != nil && s.vmInfo.Config != nil {
+			name = s.vmInfo.Config.Name
+		}
+		mqlVm, err := CreateResource(v.MqlRuntime, "vsphere.vm", map[string]*llx.RawData{
+			"moid":          llx.StringData(vm.Reference().Encode()),
+			"name":          llx.StringData(name),
+			"properties":    llx.DictData(s.props),
+			"inventoryPath": llx.StringData(vm.InventoryPath),
+			"tags":          llx.ArrayData(convert.SliceAnyToInterface(s.tags), types.String),
+		})
+		if err != nil {
+			return nil, err
+		}
+		mqlVm.(*mqlVsphereVm).vm = s.vmInfo
+		mqlVms[i] = mqlVm
+	}
 	return mqlVms, nil
 }
 

--- a/providers/vsphere/resources/datacenter.go
+++ b/providers/vsphere/resources/datacenter.go
@@ -51,12 +51,11 @@ func newVsphereHostResources(vClient *resourceclient.Client, runtime *plugin.Run
 	// CreateResource is held back to stage 2 because it touches the runtime
 	// resource cache, which we keep single-threaded.
 	staged := make([]stagedHost, len(vhosts))
-	g, _ := errgroup.WithContext(ctx)
+	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(discoveryConcurrency)
 	for i, h := range vhosts {
-		i, h := i, h
 		g.Go(func() error {
-			hostInfo, err := resourceclient.HostInfo(h)
+			hostInfo, err := resourceclient.HostInfo(gctx, h)
 			if err != nil {
 				return err
 			}
@@ -233,12 +232,11 @@ func (v *mqlVsphereDatacenter) vms() ([]any, error) {
 		tags   []string
 	}
 	staged := make([]stagedVm, len(vms))
-	g, _ := errgroup.WithContext(ctx)
+	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(discoveryConcurrency)
 	for i, vm := range vms {
-		i, vm := i, vm
 		g.Go(func() error {
-			vmInfo, err := resourceclient.VmInfo(vm)
+			vmInfo, err := resourceclient.VmInfo(gctx, vm)
 			if err != nil {
 				return err
 			}

--- a/providers/vsphere/resources/resourceclient/host.go
+++ b/providers/vsphere/resources/resourceclient/host.go
@@ -17,8 +17,8 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
-func HostInfo(host *object.HostSystem) (*mo.HostSystem, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), DefaultAPITimeout)
+func HostInfo(ctx context.Context, host *object.HostSystem) (*mo.HostSystem, error) {
+	ctx, cancel := context.WithTimeout(ctx, DefaultAPITimeout)
 	defer cancel()
 	var props mo.HostSystem
 	if err := host.Properties(ctx, host.Reference(), nil, &props); err != nil {

--- a/providers/vsphere/resources/resourceclient/vm.go
+++ b/providers/vsphere/resources/resourceclient/vm.go
@@ -14,8 +14,8 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
-func VmInfo(vm *object.VirtualMachine) (*mo.VirtualMachine, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), DefaultAPITimeout)
+func VmInfo(ctx context.Context, vm *object.VirtualMachine) (*mo.VirtualMachine, error) {
+	ctx, cancel := context.WithTimeout(ctx, DefaultAPITimeout)
 	defer cancel()
 	var props mo.VirtualMachine
 	if err := vm.Properties(ctx, vm.Reference(), nil, &props); err != nil {
@@ -29,7 +29,7 @@ func VmProperties(vm *mo.VirtualMachine) (map[string]any, error) {
 }
 
 func AdvancedSettings(vm *object.VirtualMachine) (map[string]any, error) {
-	vmInfo, err := VmInfo(vm)
+	vmInfo, err := VmInfo(context.Background(), vm)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/vsphere/resources/vm.go
+++ b/providers/vsphere/resources/vm.go
@@ -4,41 +4,10 @@
 package resources
 
 import (
-	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
-	"go.mondoo.com/mql/v13/llx"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/vsphere/connection"
 	"go.mondoo.com/mql/v13/providers/vsphere/resources/resourceclient"
-	"go.mondoo.com/mql/v13/types"
 )
-
-func newMqlVm(runtime *plugin.Runtime, vm *object.VirtualMachine, vmInfo *mo.VirtualMachine, tags []string) (*mqlVsphereVm, error) {
-	props, err := resourceclient.VmProperties(vmInfo)
-	if err != nil {
-		return nil, err
-	}
-
-	var name string
-	if vmInfo != nil && vmInfo.Config != nil {
-		name = vmInfo.Config.Name
-	}
-
-	mqlVm, err := CreateResource(runtime, "vsphere.vm", map[string]*llx.RawData{
-		"moid":          llx.StringData(vm.Reference().Encode()),
-		"name":          llx.StringData(name),
-		"properties":    llx.DictData(props),
-		"inventoryPath": llx.StringData(vm.InventoryPath),
-		"tags":          llx.ArrayData(convert.SliceAnyToInterface(tags), types.String),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	mqlVm.(*mqlVsphereVm).vm = vmInfo
-	return mqlVm.(*mqlVsphereVm), nil
-}
 
 type mqlVsphereVmInternal struct {
 	vm *mo.VirtualMachine

--- a/providers/vsphere/resources/vsphere.go
+++ b/providers/vsphere/resources/vsphere.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -153,7 +154,7 @@ func esxiHostProperties(conn *connection.VsphereConnection) (*object.HostSystem,
 	}
 
 	// todo sync with GetHosts
-	hostInfo, err := resourceclient.HostInfo(h)
+	hostInfo, err := resourceclient.HostInfo(context.Background(), h)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Summary

Host- and VM-enumeration loops in `newVsphereHostResources` and `(v *mqlVsphereDatacenter) vms()` previously did per-asset SOAP round trips (`HostInfo` / `VmInfo`, each ~50–100ms) **one at a time**. This replaces both loops with a two-stage pattern:

1. **Concurrent stage** — fan out the SOAP fetches and CPU-bound `PropertiesToDict` marshalling via `golang.org/x/sync/errgroup` with a 16-worker cap. Each goroutine writes into its own slot in a pre-sized staging slice, so no synchronization is needed.
2. **Sequential stage** — iterate the staged data and call `CreateResource`. The runtime resource cache is touched on the main goroutine only, sidestepping any concerns about its thread-safety contract.

`newMqlVm` becomes orphaned and is removed; its body is inlined into the staging+create loop in `vms()` since the staging struct already holds everything `CreateResource` needs.

## Honest framing on perf benefit

This change does the right thing architecturally but **doesn't move the wall-clock needle on a small estate** — and I want that to be clear up front.

Wall-clock against the same 3-host / 27-VM lab cluster used for the previous two perf PRs:

| | Before (sequential) | After (concurrent) |
|---|---|---|
| `vsphere.datacenters { hosts.length }` | ~44.5s median | ~46.7s median (within noise) |
| `vsphere.datacenters { vms.length }` | ~63.0s median | ~59.4s median (~5% faster) |

The fan-out itself works fine. Phase-level instrumentation during development showed the actual per-VM fetch step on 21 VMs dropping from ~1s sequential to ~230ms concurrent — a real ~4× speedup on that step. But on a small cluster, that step is no longer the bottleneck; most of the wall-clock comes from:

- vAPI session login (~1.6s, fixed cost per `vms()` call after the previous batch-tag PR)
- vCenter inventory listing (~540ms)
- mql discovery framework invoking `vms()` once per discovered asset (vCenter + each ESXi host) — so on this cluster, `vms()` runs **8× per single `mql run`** rather than once

The 8× repeat is the next thing to investigate — separately filed as a follow-up. Concurrency at the per-asset level is still net-positive: it doesn't slow anything down, and on a 100-host or 500-VM estate (where the old serial pattern paid the SOAP round-trip cost N times in series) the savings will scale linearly. The 16-worker cap stays friendly to vCenter's session limits.

## Test plan

- [ ] Sanity: `mql shell vsphere -- "vsphere.datacenters { hosts { name } vms { name } }"` returns the same hosts/VMs as before. Verified locally on the lab cluster.
- [ ] Larger cluster (100+ hosts or 500+ VMs) — expect a meaningful drop on `vsphere.datacenters { hosts.length }` and `vsphere.datacenters { vms.length }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)