### PR TITLE
✨ vsphere: VM encryption posture + vTPM presence

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -582,6 +582,7 @@ vmfs
 vmhba
 VMID
 vmstate
+VMX
 vnet
 vnic
 vpus

--- a/providers/vsphere/resources/datacenter.go
+++ b/providers/vsphere/resources/datacenter.go
@@ -339,6 +339,8 @@ func (v *mqlVsphereDatacenter) vms() ([]any, error) {
 			vmwareToolsVersion                    string
 			guestIpAddress                        string
 			guestHostname                         string
+			encrypted, vtpmPresent                bool
+			encryptionKeyId                       string
 		)
 		if s.vmInfo != nil {
 			powerState = string(s.vmInfo.Runtime.PowerState)
@@ -371,6 +373,16 @@ func (v *mqlVsphereDatacenter) vms() ([]any, error) {
 				}
 				numCpu = int64(cfg.Hardware.NumCPU)
 				memoryMB = int64(cfg.Hardware.MemoryMB)
+				if cfg.KeyId != nil {
+					encrypted = true
+					encryptionKeyId = cfg.KeyId.KeyId
+				}
+				for _, dev := range cfg.Hardware.Device {
+					if _, ok := dev.(*vimtypes.VirtualTPM); ok {
+						vtpmPresent = true
+						break
+					}
+				}
 			}
 		}
 		mqlVm, err := CreateResource(v.MqlRuntime, "vsphere.vm", map[string]*llx.RawData{
@@ -382,6 +394,9 @@ func (v *mqlVsphereDatacenter) vms() ([]any, error) {
 			"bootFirmware":        llx.StringData(bootFirmware),
 			"secureBootEnabled":   llx.BoolData(secureBootEnabled),
 			"vbsEnabled":          llx.BoolData(vbsEnabled),
+			"encrypted":           llx.BoolData(encrypted),
+			"encryptionKeyId":     llx.StringData(encryptionKeyId),
+			"vtpmPresent":         llx.BoolData(vtpmPresent),
 			"numCpu":              llx.IntData(numCpu),
 			"memoryMB":            llx.IntData(memoryMB),
 			"cpuHotAddEnabled":    llx.BoolData(cpuHotAddEnabled),

--- a/providers/vsphere/resources/vm.go
+++ b/providers/vsphere/resources/vm.go
@@ -5,6 +5,8 @@ package resources
 
 import (
 	"github.com/vmware/govmomi/vim25/mo"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/vsphere/connection"
 	"go.mondoo.com/mql/v13/providers/vsphere/resources/resourceclient"
 )
@@ -32,4 +34,37 @@ func (v *mqlVsphereVm) advancedSettings() (map[string]any, error) {
 	}
 
 	return resourceclient.AdvancedSettings(vm)
+}
+
+// kmsCluster resolves the typed vsphere.kmsCluster providing this VM's
+// encryption key. Walks vsphere.kmsClusters (single SOAP call, cached) and
+// matches by clusterId; null when the VM isn't encrypted or its provider isn't
+// in the registered list.
+func (v *mqlVsphereVm) kmsCluster() (*mqlVsphereKmsCluster, error) {
+	if v.vm == nil || v.vm.Config == nil || v.vm.Config.KeyId == nil || v.vm.Config.KeyId.ProviderId == nil {
+		v.KmsCluster.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	providerId := v.vm.Config.KeyId.ProviderId.Id
+	if providerId == "" {
+		v.KmsCluster.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+
+	res, err := CreateResource(v.MqlRuntime, "vsphere", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	clusters := res.(*mqlVsphere).GetKmsClusters()
+	if clusters.Error != nil {
+		return nil, clusters.Error
+	}
+	for _, c := range clusters.Data {
+		cluster := c.(*mqlVsphereKmsCluster)
+		if cluster.ClusterId.Data == providerId {
+			return cluster, nil
+		}
+	}
+	v.KmsCluster.State = plugin.StateIsNull | plugin.StateIsSet
+	return nil, nil
 }

--- a/providers/vsphere/resources/vsphere.lr
+++ b/providers/vsphere/resources/vsphere.lr
@@ -475,6 +475,14 @@ private vsphere.vm @defaults("moid name") {
   secureBootEnabled bool
   // Whether Virtualization-Based Security (VBS) is enabled
   vbsEnabled bool
+  // Whether vSphere VM encryption is enabled on this VM (encrypts VMX, swap, and disks)
+  encrypted bool
+  // Encryption key ID (CryptoKeyId.KeyId) used to encrypt the VM; empty if not encrypted
+  encryptionKeyId string
+  // KMS cluster providing the encryption key, resolved lazily against vsphere.kmsClusters; null when the VM is not encrypted
+  kmsCluster() vsphere.kmsCluster
+  // Whether a virtual TPM 2.0 device is attached to the VM
+  vtpmPresent bool
   // Number of virtual CPUs configured
   numCpu int
   // Configured memory size in megabytes

--- a/providers/vsphere/resources/vsphere.lr.go
+++ b/providers/vsphere/resources/vsphere.lr.go
@@ -814,6 +814,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"vsphere.vm.vbsEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVsphereVm).GetVbsEnabled()).ToDataRes(types.Bool)
 	},
+	"vsphere.vm.encrypted": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereVm).GetEncrypted()).ToDataRes(types.Bool)
+	},
+	"vsphere.vm.encryptionKeyId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereVm).GetEncryptionKeyId()).ToDataRes(types.String)
+	},
+	"vsphere.vm.kmsCluster": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereVm).GetKmsCluster()).ToDataRes(types.Resource("vsphere.kmsCluster"))
+	},
+	"vsphere.vm.vtpmPresent": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereVm).GetVtpmPresent()).ToDataRes(types.Bool)
+	},
 	"vsphere.vm.numCpu": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVsphereVm).GetNumCpu()).ToDataRes(types.Int)
 	},
@@ -1851,6 +1863,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"vsphere.vm.vbsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlVsphereVm).VbsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"vsphere.vm.encrypted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereVm).Encrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"vsphere.vm.encryptionKeyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereVm).EncryptionKeyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"vsphere.vm.kmsCluster": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereVm).KmsCluster, ok = plugin.RawToTValue[*mqlVsphereKmsCluster](v.Value, v.Error)
+		return
+	},
+	"vsphere.vm.vtpmPresent": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereVm).VtpmPresent, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"vsphere.vm.numCpu": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4424,6 +4452,10 @@ type mqlVsphereVm struct {
 	BootFirmware        plugin.TValue[string]
 	SecureBootEnabled   plugin.TValue[bool]
 	VbsEnabled          plugin.TValue[bool]
+	Encrypted           plugin.TValue[bool]
+	EncryptionKeyId     plugin.TValue[string]
+	KmsCluster          plugin.TValue[*mqlVsphereKmsCluster]
+	VtpmPresent         plugin.TValue[bool]
 	NumCpu              plugin.TValue[int64]
 	MemoryMB            plugin.TValue[int64]
 	CpuHotAddEnabled    plugin.TValue[bool]
@@ -4511,6 +4543,34 @@ func (c *mqlVsphereVm) GetSecureBootEnabled() *plugin.TValue[bool] {
 
 func (c *mqlVsphereVm) GetVbsEnabled() *plugin.TValue[bool] {
 	return &c.VbsEnabled
+}
+
+func (c *mqlVsphereVm) GetEncrypted() *plugin.TValue[bool] {
+	return &c.Encrypted
+}
+
+func (c *mqlVsphereVm) GetEncryptionKeyId() *plugin.TValue[string] {
+	return &c.EncryptionKeyId
+}
+
+func (c *mqlVsphereVm) GetKmsCluster() *plugin.TValue[*mqlVsphereKmsCluster] {
+	return plugin.GetOrCompute[*mqlVsphereKmsCluster](&c.KmsCluster, func() (*mqlVsphereKmsCluster, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("vsphere.vm", c.__id, "kmsCluster")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlVsphereKmsCluster), nil
+			}
+		}
+
+		return c.kmsCluster()
+	})
+}
+
+func (c *mqlVsphereVm) GetVtpmPresent() *plugin.TValue[bool] {
+	return &c.VtpmPresent
 }
 
 func (c *mqlVsphereVm) GetNumCpu() *plugin.TValue[int64] {

--- a/providers/vsphere/resources/vsphere.lr.versions
+++ b/providers/vsphere/resources/vsphere.lr.versions
@@ -217,9 +217,12 @@ vsphere.vm.annotation 13.0.12
 vsphere.vm.bootFirmware 13.0.12
 vsphere.vm.cpuHotAddEnabled 13.0.12
 vsphere.vm.createDate 13.0.12
+vsphere.vm.encrypted 13.0.12
+vsphere.vm.encryptionKeyId 13.0.12
 vsphere.vm.guestHostname 13.0.12
 vsphere.vm.guestIpAddress 13.0.12
 vsphere.vm.inventoryPath 9.0.0
+vsphere.vm.kmsCluster 13.0.12
 vsphere.vm.memoryHotAddEnabled 13.0.12
 vsphere.vm.memoryMB 13.0.12
 vsphere.vm.moid 9.0.0
@@ -233,6 +236,7 @@ vsphere.vm.tags 11.0.101
 vsphere.vm.vbsEnabled 13.0.12
 vsphere.vm.vmwareToolsRunning 13.0.12
 vsphere.vm.vmwareToolsVersion 13.0.12
+vsphere.vm.vtpmPresent 13.0.12
 vsphere.vmknic 9.0.0
 vsphere.vmknic.ipv4 9.0.0
 vsphere.vmknic.ipv6 9.0.0


### PR DESCRIPTION
## Summary

Closes the audit-loop on \`vsphere.kmsCluster\` from #7524 by exposing which VMs are actually encrypted and which KMS cluster is providing each VM's key.

New fields on \`vsphere.vm\`:
- \`encrypted bool\` — true when \`Config.KeyId\` is set
- \`encryptionKeyId string\` — the \`CryptoKeyId.KeyId\`
- \`kmsCluster() vsphere.kmsCluster\` — typed ref resolved against \`vsphere.kmsClusters\` by \`Config.KeyId.ProviderId.Id\`
- \`vtpmPresent bool\` — true when the VM hardware list contains a \`*VirtualTPM\` device

All four pull from data already loaded by the concurrent \`VmInfo\` fetch in \`datacenters.vms()\`. The typed \`kmsCluster()\` method walks the cached \`vsphere.kmsClusters\` list (single SOAP call, cached).

Versions tagged at \`13.0.12\` (provider released at \`13.0.11\`).

## Test plan

- [ ] On a vCenter with at least one encrypted VM: \`vsphere.vms.where(encrypted == true) { name encryptionKeyId kmsCluster.clusterId }\`
- [ ] On a vCenter with a vTPM-equipped VM: \`vsphere.vms.where(vtpmPresent == true) { name powerState }\`
- [ ] On a vCenter without VM encryption configured: \`vsphere.vms { encrypted vtpmPresent }\` returns all-false without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)