### PR TITLE
✨ vsphere: typed cross-references vm/host/datastore/cluster

### DIFF
--- a/providers/vsphere/resources/cross_refs.go
+++ b/providers/vsphere/resources/cross_refs.go
@@ -4,16 +4,18 @@
 package resources
 
 import (
+	"sync"
+
 	"github.com/vmware/govmomi/vim25/types"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
-// vsphereInventory walks vsphere.datacenters and indexes hosts/vms/datastores/
-// clusters by encoded moid for cross-reference resolution. The `vsphere`
-// resource and each datacenter's child list are cached by the runtime, so
-// repeated lookups across many resources only fan out the underlying SOAP
-// calls once.
+// vsphereInventory indexes hosts, VMs, datastores, and clusters by encoded
+// moid for cross-reference resolution. Built once per scan and cached on the
+// singleton vsphere resource (see mqlVsphereInternal), since a query like
+// `vsphere.vms { host datastores }` over N VMs would otherwise rebuild the
+// index 2N times.
 type vsphereInventory struct {
 	hosts      map[string]*mqlVsphereHost
 	vms        map[string]*mqlVsphereVm
@@ -21,12 +23,30 @@ type vsphereInventory struct {
 	clusters   map[string]*mqlVsphereCluster
 }
 
+// mqlVsphereInternal extends mqlVspherePermissionInternal (already declared in
+// vsphere.go); the codegen embeds both fields into the generated resource
+// struct. The sync.Once ensures the inventory index is built exactly once per
+// scan even when called concurrently from multiple cross-reference accessors.
+type mqlVsphereInternal struct {
+	inventoryOnce sync.Once
+	inventory     *vsphereInventory
+	inventoryErr  error
+}
+
 func loadVsphereInventory(runtime *plugin.Runtime) (*vsphereInventory, error) {
 	res, err := CreateResource(runtime, "vsphere", map[string]*llx.RawData{})
 	if err != nil {
 		return nil, err
 	}
-	dcs := res.(*mqlVsphere).GetDatacenters()
+	v := res.(*mqlVsphere)
+	v.inventoryOnce.Do(func() {
+		v.inventory, v.inventoryErr = buildVsphereInventory(v)
+	})
+	return v.inventory, v.inventoryErr
+}
+
+func buildVsphereInventory(v *mqlVsphere) (*vsphereInventory, error) {
+	dcs := v.GetDatacenters()
 	if dcs.Error != nil {
 		return nil, dcs.Error
 	}
@@ -38,29 +58,25 @@ func loadVsphereInventory(runtime *plugin.Runtime) (*vsphereInventory, error) {
 	}
 	for _, d := range dcs.Data {
 		dc := d.(*mqlVsphereDatacenter)
-		hosts := dc.GetHosts()
-		if hosts.Error == nil {
+		if hosts := dc.GetHosts(); hosts.Error == nil {
 			for _, h := range hosts.Data {
 				host := h.(*mqlVsphereHost)
 				inv.hosts[host.Moid.Data] = host
 			}
 		}
-		vms := dc.GetVms()
-		if vms.Error == nil {
+		if vms := dc.GetVms(); vms.Error == nil {
 			for _, vm := range vms.Data {
-				v := vm.(*mqlVsphereVm)
-				inv.vms[v.Moid.Data] = v
+				m := vm.(*mqlVsphereVm)
+				inv.vms[m.Moid.Data] = m
 			}
 		}
-		datastores := dc.GetDatastores()
-		if datastores.Error == nil {
+		if datastores := dc.GetDatastores(); datastores.Error == nil {
 			for _, ds := range datastores.Data {
-				d := ds.(*mqlVsphereDatastore)
-				inv.datastores[d.Moid.Data] = d
+				s := ds.(*mqlVsphereDatastore)
+				inv.datastores[s.Moid.Data] = s
 			}
 		}
-		clusters := dc.GetClusters()
-		if clusters.Error == nil {
+		if clusters := dc.GetClusters(); clusters.Error == nil {
 			for _, c := range clusters.Data {
 				cl := c.(*mqlVsphereCluster)
 				inv.clusters[cl.Moid.Data] = cl

--- a/providers/vsphere/resources/cross_refs.go
+++ b/providers/vsphere/resources/cross_refs.go
@@ -1,0 +1,199 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"github.com/vmware/govmomi/vim25/types"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// vsphereInventory walks vsphere.datacenters and indexes hosts/vms/datastores/
+// clusters by encoded moid for cross-reference resolution. The `vsphere`
+// resource and each datacenter's child list are cached by the runtime, so
+// repeated lookups across many resources only fan out the underlying SOAP
+// calls once.
+type vsphereInventory struct {
+	hosts      map[string]*mqlVsphereHost
+	vms        map[string]*mqlVsphereVm
+	datastores map[string]*mqlVsphereDatastore
+	clusters   map[string]*mqlVsphereCluster
+}
+
+func loadVsphereInventory(runtime *plugin.Runtime) (*vsphereInventory, error) {
+	res, err := CreateResource(runtime, "vsphere", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	dcs := res.(*mqlVsphere).GetDatacenters()
+	if dcs.Error != nil {
+		return nil, dcs.Error
+	}
+	inv := &vsphereInventory{
+		hosts:      map[string]*mqlVsphereHost{},
+		vms:        map[string]*mqlVsphereVm{},
+		datastores: map[string]*mqlVsphereDatastore{},
+		clusters:   map[string]*mqlVsphereCluster{},
+	}
+	for _, d := range dcs.Data {
+		dc := d.(*mqlVsphereDatacenter)
+		hosts := dc.GetHosts()
+		if hosts.Error == nil {
+			for _, h := range hosts.Data {
+				host := h.(*mqlVsphereHost)
+				inv.hosts[host.Moid.Data] = host
+			}
+		}
+		vms := dc.GetVms()
+		if vms.Error == nil {
+			for _, vm := range vms.Data {
+				v := vm.(*mqlVsphereVm)
+				inv.vms[v.Moid.Data] = v
+			}
+		}
+		datastores := dc.GetDatastores()
+		if datastores.Error == nil {
+			for _, ds := range datastores.Data {
+				d := ds.(*mqlVsphereDatastore)
+				inv.datastores[d.Moid.Data] = d
+			}
+		}
+		clusters := dc.GetClusters()
+		if clusters.Error == nil {
+			for _, c := range clusters.Data {
+				cl := c.(*mqlVsphereCluster)
+				inv.clusters[cl.Moid.Data] = cl
+			}
+		}
+	}
+	return inv, nil
+}
+
+// resolveHosts maps a slice of HostSystem refs to their MQL resources, dropping
+// refs that aren't in inventory (e.g. hosts the caller doesn't have read
+// access to).
+func (inv *vsphereInventory) resolveHosts(refs []types.ManagedObjectReference) []any {
+	out := make([]any, 0, len(refs))
+	for _, r := range refs {
+		if h, ok := inv.hosts[r.Encode()]; ok {
+			out = append(out, h)
+		}
+	}
+	return out
+}
+
+func (inv *vsphereInventory) resolveVms(refs []types.ManagedObjectReference) []any {
+	out := make([]any, 0, len(refs))
+	for _, r := range refs {
+		if v, ok := inv.vms[r.Encode()]; ok {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+func (inv *vsphereInventory) resolveDatastores(refs []types.ManagedObjectReference) []any {
+	out := make([]any, 0, len(refs))
+	for _, r := range refs {
+		if d, ok := inv.datastores[r.Encode()]; ok {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// host resolves the ESXi host the VM is currently running on against
+// vsphere.datacenters[].hosts. Null when the VM is unregistered or the host
+// isn't visible in inventory.
+func (v *mqlVsphereVm) host() (*mqlVsphereHost, error) {
+	if v.vm == nil || v.vm.Runtime.Host == nil {
+		v.Host.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	inv, err := loadVsphereInventory(v.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if h, ok := inv.hosts[v.vm.Runtime.Host.Encode()]; ok {
+		return h, nil
+	}
+	v.Host.State = plugin.StateIsNull | plugin.StateIsSet
+	return nil, nil
+}
+
+// datastores resolves the VM's backing datastores against
+// vsphere.datacenters[].datastores.
+func (v *mqlVsphereVm) datastores() ([]any, error) {
+	if v.vm == nil {
+		return []any{}, nil
+	}
+	inv, err := loadVsphereInventory(v.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	return inv.resolveDatastores(v.vm.Datastore), nil
+}
+
+// cluster resolves the host's parent cluster against
+// vsphere.datacenters[].clusters. Null for standalone hosts (whose parent is a
+// ComputeResource, not a ClusterComputeResource).
+func (v *mqlVsphereHost) cluster() (*mqlVsphereCluster, error) {
+	if v.host == nil || v.host.Parent == nil || v.host.Parent.Type != "ClusterComputeResource" {
+		v.Cluster.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	inv, err := loadVsphereInventory(v.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if c, ok := inv.clusters[v.host.Parent.Encode()]; ok {
+		return c, nil
+	}
+	v.Cluster.State = plugin.StateIsNull | plugin.StateIsSet
+	return nil, nil
+}
+
+// datastores resolves the host's mounted datastores against
+// vsphere.datacenters[].datastores.
+func (v *mqlVsphereHost) datastores() ([]any, error) {
+	if v.host == nil {
+		return []any{}, nil
+	}
+	inv, err := loadVsphereInventory(v.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	return inv.resolveDatastores(v.host.Datastore), nil
+}
+
+// hosts resolves the hosts that have this datastore mounted against
+// vsphere.datacenters[].hosts. Datastore.Host carries DatastoreHostMount; we
+// use its Key (the host moid).
+func (v *mqlVsphereDatastore) hosts() ([]any, error) {
+	if v.ds == nil {
+		return []any{}, nil
+	}
+	refs := make([]types.ManagedObjectReference, 0, len(v.ds.Host))
+	for _, h := range v.ds.Host {
+		refs = append(refs, h.Key)
+	}
+	inv, err := loadVsphereInventory(v.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	return inv.resolveHosts(refs), nil
+}
+
+// vms resolves the VMs whose files reside on this datastore against
+// vsphere.datacenters[].vms.
+func (v *mqlVsphereDatastore) vms() ([]any, error) {
+	if v.ds == nil {
+		return []any{}, nil
+	}
+	inv, err := loadVsphereInventory(v.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	return inv.resolveVms(v.ds.Vm), nil
+}

--- a/providers/vsphere/resources/datacenter.go
+++ b/providers/vsphere/resources/datacenter.go
@@ -21,6 +21,19 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// mqlVsphereClusterInternal caches the underlying ClusterComputeResource so
+// cross-reference accessors (e.g. cluster.hosts()) can avoid redundant fetches.
+type mqlVsphereClusterInternal struct {
+	cluster *mo.ClusterComputeResource
+}
+
+// mqlVsphereDatastoreInternal caches the Datastore mo so cross-reference
+// accessors (datastore.vms(), datastore.hosts()) can resolve typed refs from
+// already-fetched property data.
+type mqlVsphereDatastoreInternal struct {
+	ds *mo.Datastore
+}
+
 // countSnapshots returns the total snapshot count in a VM's snapshot tree
 // (including nested children). 0 if info is nil.
 func countSnapshots(info *vimtypes.VirtualMachineSnapshotInfo) int {
@@ -229,6 +242,7 @@ func (v *mqlVsphereDatacenter) clusters() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		mqlCluster.(*mqlVsphereCluster).cluster = moc
 
 		mqlClusters[i] = mqlCluster
 	}
@@ -549,7 +563,7 @@ func (v *mqlVsphereDatacenter) datastores() ([]any, error) {
 	g.SetLimit(discoveryConcurrency)
 	type stagedDs struct {
 		moid        string
-		summary     vimtypes.DatastoreSummary
+		props       *mo.Datastore
 		path        string
 		vmfsVersion string
 		ssd         bool
@@ -557,8 +571,10 @@ func (v *mqlVsphereDatacenter) datastores() ([]any, error) {
 	staged := make([]stagedDs, len(dsList))
 	for i, ds := range dsList {
 		g.Go(func() error {
+			// "vm" and "host" power the datastore.vms()/hosts() cross-references;
+			// they're cheap to include in the same property fetch.
 			var props mo.Datastore
-			if err := ds.Properties(gctx, ds.Reference(), []string{"summary", "info"}, &props); err != nil {
+			if err := ds.Properties(gctx, ds.Reference(), []string{"summary", "info", "vm", "host"}, &props); err != nil {
 				return err
 			}
 			vmfsVersion := ""
@@ -571,7 +587,7 @@ func (v *mqlVsphereDatacenter) datastores() ([]any, error) {
 			}
 			staged[i] = stagedDs{
 				moid:        ds.Reference().Encode(),
-				summary:     props.Summary,
+				props:       &props,
 				path:        ds.InventoryPath,
 				vmfsVersion: vmfsVersion,
 				ssd:         ssd,
@@ -585,20 +601,21 @@ func (v *mqlVsphereDatacenter) datastores() ([]any, error) {
 
 	for i, s := range staged {
 		multi := false
-		if s.summary.MultipleHostAccess != nil {
-			multi = *s.summary.MultipleHostAccess
+		summary := s.props.Summary
+		if summary.MultipleHostAccess != nil {
+			multi = *summary.MultipleHostAccess
 		}
 		mqlDs, err := CreateResource(v.MqlRuntime, "vsphere.datastore", map[string]*llx.RawData{
 			"moid":               llx.StringData(s.moid),
-			"name":               llx.StringData(s.summary.Name),
-			"type":               llx.StringData(s.summary.Type),
-			"capacity":           llx.IntData(s.summary.Capacity),
-			"freeSpace":          llx.IntData(s.summary.FreeSpace),
-			"uncommitted":        llx.IntData(s.summary.Uncommitted),
-			"accessible":         llx.BoolData(s.summary.Accessible),
+			"name":               llx.StringData(summary.Name),
+			"type":               llx.StringData(summary.Type),
+			"capacity":           llx.IntData(summary.Capacity),
+			"freeSpace":          llx.IntData(summary.FreeSpace),
+			"uncommitted":        llx.IntData(summary.Uncommitted),
+			"accessible":         llx.BoolData(summary.Accessible),
 			"multipleHostAccess": llx.BoolData(multi),
-			"maintenanceMode":    llx.StringData(s.summary.MaintenanceMode),
-			"url":                llx.StringData(s.summary.Url),
+			"maintenanceMode":    llx.StringData(summary.MaintenanceMode),
+			"url":                llx.StringData(summary.Url),
 			"inventoryPath":      llx.StringData(s.path),
 			"vmfsVersion":        llx.StringData(s.vmfsVersion),
 			"ssd":                llx.BoolData(s.ssd),
@@ -606,6 +623,7 @@ func (v *mqlVsphereDatacenter) datastores() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		mqlDs.(*mqlVsphereDatastore).ds = s.props
 		mqlDss[i] = mqlDs
 	}
 	return mqlDss, nil

--- a/providers/vsphere/resources/vsphere.lr
+++ b/providers/vsphere/resources/vsphere.lr
@@ -287,6 +287,10 @@ private vsphere.datastore @defaults("name type") {
   vmfsVersion string
   // Whether the underlying VMFS volume is on SSD (only set for VMFS; false for non-VMFS or unknown)
   ssd bool
+  // Hosts that have this datastore mounted, resolved against vsphere.datacenters[].hosts
+  hosts() []vsphere.host
+  // Virtual machines whose files are stored on this datastore, resolved against vsphere.datacenters[].vms
+  vms() []vsphere.vm
 }
 
 // vSphere cluster resource
@@ -369,6 +373,10 @@ private vsphere.host @defaults("moid name") {
   firewallRulesets() []esxi.firewallRuleset
   // iSCSI host bus adapters configured on the host (zero entries if iSCSI is not in use)
   iscsiAdapters() []esxi.iscsiAdapter
+  // Cluster the host belongs to, resolved against vsphere.datacenters[].clusters; null for standalone hosts
+  cluster() vsphere.cluster
+  // Datastores mounted on the host, resolved against vsphere.datacenters[].datastores
+  datastores() []vsphere.datastore
 }
 
 // ESXi firewall ruleset — one entry per network service (e.g., CIMHttpServer,
@@ -507,6 +515,10 @@ private vsphere.vm @defaults("moid name") {
   guestIpAddress string
   // Hostname reported by VMware Tools (only meaningful when Tools is running)
   guestHostname string
+  // ESXi host the VM is currently registered on, resolved against vsphere.datacenters[].hosts; null when the VM is unregistered or the host is missing from inventory
+  host() vsphere.host
+  // Datastores backing the VM's files, resolved against vsphere.datacenters[].datastores
+  datastores() []vsphere.datastore
 }
 
 // vSphere standard virtual switch

--- a/providers/vsphere/resources/vsphere.lr.go
+++ b/providers/vsphere/resources/vsphere.lr.go
@@ -2706,7 +2706,7 @@ func (c *mqlAuditCvss) GetVector() *plugin.TValue[string] {
 type mqlVsphere struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlVsphereInternal it will be used here
+	mqlVsphereInternal
 	About           plugin.TValue[any]
 	Licenses        plugin.TValue[[]any]
 	Datacenters     plugin.TValue[[]any]

--- a/providers/vsphere/resources/vsphere.lr.go
+++ b/providers/vsphere/resources/vsphere.lr.go
@@ -580,6 +580,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"vsphere.datastore.ssd": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVsphereDatastore).GetSsd()).ToDataRes(types.Bool)
 	},
+	"vsphere.datastore.hosts": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereDatastore).GetHosts()).ToDataRes(types.Array(types.Resource("vsphere.host")))
+	},
+	"vsphere.datastore.vms": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereDatastore).GetVms()).ToDataRes(types.Array(types.Resource("vsphere.vm")))
+	},
 	"vsphere.cluster.moid": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVsphereCluster).GetMoid()).ToDataRes(types.String)
 	},
@@ -690,6 +696,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"vsphere.host.iscsiAdapters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVsphereHost).GetIscsiAdapters()).ToDataRes(types.Array(types.Resource("esxi.iscsiAdapter")))
+	},
+	"vsphere.host.cluster": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereHost).GetCluster()).ToDataRes(types.Resource("vsphere.cluster"))
+	},
+	"vsphere.host.datastores": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereHost).GetDatastores()).ToDataRes(types.Array(types.Resource("vsphere.datastore")))
 	},
 	"esxi.firewallRuleset.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlEsxiFirewallRuleset).GetId()).ToDataRes(types.String)
@@ -861,6 +873,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"vsphere.vm.guestHostname": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVsphereVm).GetGuestHostname()).ToDataRes(types.String)
+	},
+	"vsphere.vm.host": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereVm).GetHost()).ToDataRes(types.Resource("vsphere.host"))
+	},
+	"vsphere.vm.datastores": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVsphereVm).GetDatastores()).ToDataRes(types.Array(types.Resource("vsphere.datastore")))
 	},
 	"vsphere.vswitch.standard.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVsphereVswitchStandard).GetName()).ToDataRes(types.String)
@@ -1525,6 +1543,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlVsphereDatastore).Ssd, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"vsphere.datastore.hosts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereDatastore).Hosts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"vsphere.datastore.vms": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereDatastore).Vms, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"vsphere.cluster.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlVsphereCluster).__id, ok = v.Value.(string)
 		return
@@ -1679,6 +1705,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"vsphere.host.iscsiAdapters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlVsphereHost).IscsiAdapters, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"vsphere.host.cluster": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHost).Cluster, ok = plugin.RawToTValue[*mqlVsphereCluster](v.Value, v.Error)
+		return
+	},
+	"vsphere.host.datastores": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereHost).Datastores, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"esxi.firewallRuleset.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1927,6 +1961,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"vsphere.vm.guestHostname": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlVsphereVm).GuestHostname, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"vsphere.vm.host": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereVm).Host, ok = plugin.RawToTValue[*mqlVsphereHost](v.Value, v.Error)
+		return
+	},
+	"vsphere.vm.datastores": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVsphereVm).Datastores, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"vsphere.vswitch.standard.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3562,7 +3604,7 @@ func (c *mqlVsphereResourcepool) GetMemoryShares() *plugin.TValue[int64] {
 type mqlVsphereDatastore struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlVsphereDatastoreInternal it will be used here
+	mqlVsphereDatastoreInternal
 	Moid               plugin.TValue[string]
 	Name               plugin.TValue[string]
 	Type               plugin.TValue[string]
@@ -3576,6 +3618,8 @@ type mqlVsphereDatastore struct {
 	InventoryPath      plugin.TValue[string]
 	VmfsVersion        plugin.TValue[string]
 	Ssd                plugin.TValue[bool]
+	Hosts              plugin.TValue[[]any]
+	Vms                plugin.TValue[[]any]
 }
 
 // createVsphereDatastore creates a new instance of this resource
@@ -3667,11 +3711,43 @@ func (c *mqlVsphereDatastore) GetSsd() *plugin.TValue[bool] {
 	return &c.Ssd
 }
 
+func (c *mqlVsphereDatastore) GetHosts() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Hosts, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("vsphere.datastore", c.__id, "hosts")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.hosts()
+	})
+}
+
+func (c *mqlVsphereDatastore) GetVms() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Vms, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("vsphere.datastore", c.__id, "vms")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.vms()
+	})
+}
+
 // mqlVsphereCluster for the vsphere.cluster resource
 type mqlVsphereCluster struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlVsphereClusterInternal it will be used here
+	mqlVsphereClusterInternal
 	Moid          plugin.TValue[string]
 	Name          plugin.TValue[string]
 	InventoryPath plugin.TValue[string]
@@ -3801,6 +3877,8 @@ type mqlVsphereHost struct {
 	NumCpuCores             plugin.TValue[int64]
 	FirewallRulesets        plugin.TValue[[]any]
 	IscsiAdapters           plugin.TValue[[]any]
+	Cluster                 plugin.TValue[*mqlVsphereCluster]
+	Datastores              plugin.TValue[[]any]
 }
 
 // createVsphereHost creates a new instance of this resource
@@ -4099,6 +4177,38 @@ func (c *mqlVsphereHost) GetIscsiAdapters() *plugin.TValue[[]any] {
 		}
 
 		return c.iscsiAdapters()
+	})
+}
+
+func (c *mqlVsphereHost) GetCluster() *plugin.TValue[*mqlVsphereCluster] {
+	return plugin.GetOrCompute[*mqlVsphereCluster](&c.Cluster, func() (*mqlVsphereCluster, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("vsphere.host", c.__id, "cluster")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlVsphereCluster), nil
+			}
+		}
+
+		return c.cluster()
+	})
+}
+
+func (c *mqlVsphereHost) GetDatastores() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Datastores, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("vsphere.host", c.__id, "datastores")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.datastores()
 	})
 }
 
@@ -4468,6 +4578,8 @@ type mqlVsphereVm struct {
 	VmwareToolsVersion  plugin.TValue[string]
 	GuestIpAddress      plugin.TValue[string]
 	GuestHostname       plugin.TValue[string]
+	Host                plugin.TValue[*mqlVsphereHost]
+	Datastores          plugin.TValue[[]any]
 }
 
 // createVsphereVm creates a new instance of this resource
@@ -4619,6 +4731,38 @@ func (c *mqlVsphereVm) GetGuestIpAddress() *plugin.TValue[string] {
 
 func (c *mqlVsphereVm) GetGuestHostname() *plugin.TValue[string] {
 	return &c.GuestHostname
+}
+
+func (c *mqlVsphereVm) GetHost() *plugin.TValue[*mqlVsphereHost] {
+	return plugin.GetOrCompute[*mqlVsphereHost](&c.Host, func() (*mqlVsphereHost, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("vsphere.vm", c.__id, "host")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlVsphereHost), nil
+			}
+		}
+
+		return c.host()
+	})
+}
+
+func (c *mqlVsphereVm) GetDatastores() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Datastores, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("vsphere.vm", c.__id, "datastores")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.datastores()
+	})
 }
 
 // mqlVsphereVswitchStandard for the vsphere.vswitch.standard resource

--- a/providers/vsphere/resources/vsphere.lr.versions
+++ b/providers/vsphere/resources/vsphere.lr.versions
@@ -111,6 +111,7 @@ vsphere.datastore 13.0.12
 vsphere.datastore.accessible 13.0.12
 vsphere.datastore.capacity 13.0.12
 vsphere.datastore.freeSpace 13.0.12
+vsphere.datastore.hosts 13.0.12
 vsphere.datastore.inventoryPath 13.0.12
 vsphere.datastore.maintenanceMode 13.0.12
 vsphere.datastore.moid 13.0.12
@@ -121,6 +122,7 @@ vsphere.datastore.type 13.0.12
 vsphere.datastore.uncommitted 13.0.12
 vsphere.datastore.url 13.0.12
 vsphere.datastore.vmfsVersion 13.0.12
+vsphere.datastore.vms 13.0.12
 vsphere.folder 13.0.12
 vsphere.folder.childCount 13.0.12
 vsphere.folder.childTypes 13.0.12
@@ -133,7 +135,9 @@ vsphere.host.acceptanceLevel 9.0.0
 vsphere.host.adapters 9.0.0
 vsphere.host.advancedSettings 9.0.0
 vsphere.host.certificate 13.0.12
+vsphere.host.cluster 13.0.12
 vsphere.host.cpuMhz 13.0.12
+vsphere.host.datastores 13.0.12
 vsphere.host.distributedSwitch 9.0.0
 vsphere.host.firewallIncomingBlocked 13.0.11
 vsphere.host.firewallOutgoingBlocked 13.0.11
@@ -217,10 +221,12 @@ vsphere.vm.annotation 13.0.12
 vsphere.vm.bootFirmware 13.0.12
 vsphere.vm.cpuHotAddEnabled 13.0.12
 vsphere.vm.createDate 13.0.12
+vsphere.vm.datastores 13.0.12
 vsphere.vm.encrypted 13.0.12
 vsphere.vm.encryptionKeyId 13.0.12
 vsphere.vm.guestHostname 13.0.12
 vsphere.vm.guestIpAddress 13.0.12
+vsphere.vm.host 13.0.12
 vsphere.vm.inventoryPath 9.0.0
 vsphere.vm.kmsCluster 13.0.12
 vsphere.vm.memoryHotAddEnabled 13.0.12


### PR DESCRIPTION
## Summary

Six typed accessors so MQL can traverse the vSphere inventory graph without manual moid lookups:

| From | Method | Returns |
|------|--------|---------|
| \`vsphere.vm\` | \`host()\` | \`vsphere.host\` |
| \`vsphere.vm\` | \`datastores()\` | \`[]vsphere.datastore\` |
| \`vsphere.host\` | \`cluster()\` | \`vsphere.cluster\` |
| \`vsphere.host\` | \`datastores()\` | \`[]vsphere.datastore\` |
| \`vsphere.datastore\` | \`vms()\` | \`[]vsphere.vm\` |
| \`vsphere.datastore\` | \`hosts()\` | \`[]vsphere.host\` |

## Implementation

Lookup is centralized in \`cross_refs.go\`. \`loadVsphereInventory\` walks \`vsphere.datacenters[].{hosts,vms,datastores,clusters}\` once and indexes by encoded moid; the typed accessors resolve refs through the index. Both the \`vsphere\` resource and each datacenter's child list are runtime-cached, so calling \`host()\` across many VMs only fans out the discovery work once.

- VM and host accessors use already-cached \`mo.VirtualMachine\` / \`mo.HostSystem\` data — zero new SOAP calls.
- Cluster and datastore now cache their mo objects in Internal structs; the datastore property fetch grows by two columns (\`vm\`, \`host\`) — same call, slightly larger payload.
- \`host.cluster()\` returns null for standalone hosts (Parent.Type != \`ClusterComputeResource\`).
- Refs that aren't visible in inventory (e.g. hosts the caller can't read) are dropped rather than surfaced as nil.

Versions tagged at \`13.0.12\` (provider released at \`13.0.11\`).

## Follow-ups deferred from the #7521 roadmap

- \`vsphere.vm.networks()\` — needs a \`vsphere.network\` (or portgroup) modeling decision
- \`vsphere.host.datacenter()\`, \`vsphere.cluster.datacenter()\` — requires datacenter moid caching on each child
- \`vsphere.cluster.resourcePools()\`
- \`vsphere.folder.parent()\`, \`vsphere.folder.children()\`
- \`vsphere.resourcepool.parent()\`, \`vsphere.resourcepool.vms()\`
- \`vsphere.permission.entity()\` — polymorphic, needs a different shape

## Test plan

- [ ] \`vsphere.vms { name host.name datastores.length }\` returns the registered host and datastore count for each VM.
- [ ] \`vsphere.hosts.where(cluster.name == "<lab cluster>") { name }\` returns only hosts in that cluster; standalone hosts (if any) appear with a null cluster.
- [ ] \`vsphere.datastores.where(vms.length > 0) { name vms.length hosts.length }\` returns matching VM and host fan-out.
- [ ] \`vsphere.vms.first { datastores { name } }\` resolves typed datastores for a single VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)