### PR TITLE
🎉 vsphere-13.1.0

### DIFF
--- a/providers/vsphere/config/config.go
+++ b/providers/vsphere/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vsphere",
 	ID:              "go.mondoo.com/cnquery/v9/providers/vsphere",
-	Version:         "13.0.11",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### vsphere (13.1.0)
- ✨ vsphere: typed cross-references vm/host/datastore/cluster (#7526)
- ✨ vsphere: VM encryption posture + vTPM presence (#7525)
- ✨ vsphere: add host firewall, iSCSI, and KMS cluster resources (#7524)
- ✨ vsphere: add permission, folder, resourcepool, identitysource (#7521)
- ✨ vsphere: runtime/state typed fields on cluster, vm, portgroup, datastore (#7523)
- ✨ vsphere: typed scalar fields on host, vm, cluster, datastore (#7519)
- ⚡ vsphere: cache vAPI REST session on the connection (#7517)
- ✨ vsphere: add role, datastore, and host certificate resources (#7518)
- 🧹 vsphere: bump govmomi v0.47.1 → v0.53.1 (#7516)
- ⚡ vsphere: fan out per-asset property fetch during host/VM discovery (#7515)
- ⚡ vsphere: batch vAPI tag lookups during host/VM discovery (#7514)