### PR TITLE
🐛 aws.lr: correct WAF fieldtomatch enum values in comments

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -672,13 +672,13 @@ private aws.waf.rule.statement.bytematchstatement @defaults("searchString") {
 
 // Component of an HTTP request that a WAF rule inspects (URI, headers, body, cookies, etc.)
 private aws.waf.rule.fieldtomatch @defaults("target") {
-  // Request component being inspected (e.g., METHOD, URI_PATH, QUERY_STRING, BODY, HEADERS)
+  // Inspected request component (one of: SingleHeader, SingleQueryArgument, allQueryArguments, Body, Cookies, HeaderOrder, JA3Fingerprint, Headers, JsonBody, QueryString, Method, UriPath)
   target string
   // Name of the rule this statement belongs to
   ruleName string
   // ID of the statement
   statementID string
-  // Whether to match the HTTP method: GET or POST
+  // Whether the rule inspects the HTTP method of the request
   method bool
   // Whether to match the URI path
   uriPath bool


### PR DESCRIPTION
## Summary

Follow-up to #7534. Two WAF `fieldtomatch` comments stated enum values that don't match what the resource actually emits.

- `target` field listed AWS API names (`METHOD`, `URI_PATH`, `QUERY_STRING`, `BODY`, `HEADERS`). The resource is populated by `createFieldToMatchResource` in `providers/aws/resources/aws_waf.go:794–937`, which writes CamelCase strings: `SingleHeader`, `SingleQueryArgument`, `Body`, `Cookies`, `HeaderOrder`, `JA3Fingerprint`, `Headers`, `JsonBody`, `QueryString`, `Method`, `UriPath`, plus the lowercase-first outlier `allQueryArguments`. Comment updated to match.
- `method bool` said "Whether to match the HTTP method: GET or POST". It's actually a boolean marker for whether the rule inspects the HTTP method at all (regardless of which method the request uses). Comment rewritten.

The other enum comments introduced in #7534 were spot-checked against `aws-sdk-go-v2/service/wafv2/types/enums.go` and `appmesh/types/enums.go` and are correct:
- `ForwardedIPPosition`: FIRST / LAST / ANY ✓
- `FallbackBehavior`: MATCH / NO_MATCH ✓
- `LabelMatchScope`: LABEL / NAMESPACE ✓
- `JsonMatchScope` / `MapMatchScope`: ALL / KEY / VALUE ✓
- `VirtualRouterStatusCode` / `RouteStatusCode`: ACTIVE / INACTIVE / DELETED ✓

The pre-existing lowercase-first inconsistency at `aws_waf.go:937` (`target = "allQueryArguments"` while every sibling uses CamelCase) is documented but not changed here — fixing it would alter user-visible data semantics for any audit checking `target == "allQueryArguments"`. Worth a separate cleanup if we want consistency.

## Test plan

- [x] `./mqlr generate providers/aws/resources/aws.lr` runs cleanly
- [x] No tracked generated files (`aws.lr.go`, `aws.lr.versions`, `aws.permissions.json`) change
- [ ] Spot-check the two field tooltips in `mql shell aws`

🤖 Generated with [Claude Code](https://claude.com/claude-code)