### PR TITLE
📄 vsphere: drop typed-reference mechanism leak from role() comment

### DIFF
--- a/providers/vsphere/resources/vsphere.lr
+++ b/providers/vsphere/resources/vsphere.lr
@@ -114,7 +114,7 @@ private vsphere.permission @defaults("principal entityType entityMoid") {
   principal string
   // Whether the principal is a group (true) or a user (false)
   group bool
-  // RBAC role granted by this permission (typed reference; resolved lazily against vsphere.roles)
+  // RBAC role granted by this permission
   role() vsphere.role
   // Whether the permission propagates to children of the entity in the inventory hierarchy
   propagate bool


### PR DESCRIPTION
## Summary

Same kind of cleanup as #7534 — the comment on \`vsphere.permission.role()\` described the wiring (\`(typed reference; resolved lazily against vsphere.roles)\`) instead of what the field represents to a user. Trimmed.

## Test plan

- [x] \`./mqlr generate providers/vsphere/resources/vsphere.lr\` runs cleanly
- [x] No tracked generated files change

🤖 Generated with [Claude Code](https://claude.com/claude-code)