### PR TITLE
📄 equinix: clearer field comments in equinix.lr

### DIFF
--- a/providers/equinix/resources/equinix.lr
+++ b/providers/equinix/resources/equinix.lr
@@ -16,11 +16,11 @@ equinix.metal.project @defaults("name") {
   createdAt time
   // When the project was last updated
   updatedAt time
-  // URL
+  // Equinix Metal API URL of the project
   url string
-  // SSH keys
+  // SSH keys associated with the project
   sshKeys() []equinix.metal.sshkey
-  // Devices
+  // Devices provisioned in the project
   devices() []equinix.metal.device
 }
 
@@ -50,7 +50,7 @@ equinix.metal.organization @defaults("name") {
   billingPhone string
   // Organization's credit amount
   creditAmount float
-  // URL
+  // Equinix Metal API URL of the organization
   url string
   // Users in the organization
  	users() []equinix.metal.user
@@ -86,7 +86,7 @@ private equinix.metal.user @defaults("email") {
   timezone string
   // User's phone number
   phoneNumber string
-  // URL
+  // Equinix Metal API URL of the user
   url string
 }
 
@@ -96,15 +96,15 @@ equinix.metal.sshkey @defaults("label") {
   id string
   // Label of the SSH key
   label string
-  // Key
+  // SSH public key material (OpenSSH authorized_keys format)
   key string
-  // Finger print
+  // Fingerprint of the SSH public key
   fingerPrint string
   // When the key was created
   createdAt time
   // When the key was last updated
   updatedAt time
-  // URL
+  // Equinix Metal API URL of the SSH key
   url string
 }
 


### PR DESCRIPTION
## Summary

Same kind of cleanup as #7534. The file had four `// URL` bare comments across project, organization, user, and SSH-key resources, plus a couple of minimal SSH-key field comments and a typoed `// Finger print`.

- Four `// URL` → describe each as the Equinix Metal API URL of the respective entity.
- `// Key` on equinix.metal.sshkey.key → describe it as SSH public-key material in OpenSSH authorized_keys format.
- `// Finger print` → `// Fingerprint of the SSH public key` (one word, matching field).
- `// SSH keys` and `// Devices` on equinix.metal.project → describe the relationship to the project.

## Test plan

- [x] `./mqlr generate providers/equinix/resources/equinix.lr` runs cleanly
- [x] No tracked generated files change

🤖 Generated with [Claude Code](https://claude.com/claude-code)