### PR TITLE
📄 proxmox: clearer field comments in proxmox.lr

### DIFF
--- a/providers/proxmox/resources/proxmox.lr
+++ b/providers/proxmox/resources/proxmox.lr
@@ -66,7 +66,7 @@ proxmox.cluster.haResource @defaults("id type status") {
 proxmox.node @defaults("name status") {
   // Node hostname
   name string
-  // Current status (online, offline)
+  // Connectivity status of the node (online or offline)
   status string
   // Node IP address
   ip string
@@ -298,7 +298,7 @@ proxmox.storage @defaults("id type enabled") {
   id string
   // Storage type (dir, lvm, lvmthin, nfs, cifs, zfspool, ceph, etc.)
   type string
-  // Allowed content types (images, rootdir, vztmpl, backup, iso, snippets)
+  // Allowed content types as a comma-separated string (e.g., "images,rootdir,vztmpl,backup,iso,snippets")
   content string
   // Storage path (for local storage types)
   path string
@@ -422,7 +422,7 @@ proxmox.repository @defaults("name enabled") {
   name string
   // Whether the repository is enabled
   enabled bool
-  // Repository types (deb, deb-src)
+  // Repository types declared on the entry (e.g., deb, deb-src)
   types []string
   // Repository URIs
   uris []string


### PR DESCRIPTION
## Summary

Same kind of cleanup as #7534. Three small reword fixes:

- \`// Allowed content types (...)\` on \`proxmox.storage.content\` (a string field, not an enum) → clarify that the field is a comma-separated string.
- \`// Repository types (deb, deb-src)\` on \`proxmox.aptRepository.types\` → similar clarification.
- \`// Current status (online, offline)\` on \`proxmox.node.status\` → "Connectivity status of the node (online or offline)".

## Test plan

- [x] \`./mqlr generate providers/proxmox/resources/proxmox.lr\` runs cleanly
- [x] No tracked generated files change

🤖 Generated with [Claude Code](https://claude.com/claude-code)