### PR TITLE
📄 atlassian: clearer field comments in atlassian.lr

### DIFF
--- a/providers/atlassian/resources/atlassian.lr
+++ b/providers/atlassian/resources/atlassian.lr
@@ -339,7 +339,7 @@ atlassian.confluence.page @defaults("title status") {
   title string
   // Content status (current, trashed, draft)
   status string
-  // Content type (always "page")
+  // Confluence content type (page)
   type string
   // Key of the space the page lives in
   spaceKey string
@@ -351,7 +351,7 @@ atlassian.confluence.page @defaults("title status") {
 
 // Per-operation restriction on a Confluence page
 atlassian.confluence.page.restriction @defaults("operation") {
-  // Composite ID (page id + operation)
+  // Identifier of the restriction, unique per (page, operation) pair
   id string
   // Operation restricted (read, update)
   operation string


### PR DESCRIPTION
## Summary

Same kind of cleanup as #7534. Two small reword fixes on the Confluence page resource.

- \`// Content type (always "page")\` → "Confluence content type (page)" — drops the schema-constraint leak.
- \`// Composite ID (page id + operation)\` → "Identifier of the restriction, unique per (page, operation) pair" — drops the composition mechanism leak.

## Test plan

- [x] \`./mqlr generate providers/atlassian/resources/atlassian.lr\` runs cleanly
- [x] No tracked generated files change

🤖 Generated with [Claude Code](https://claude.com/claude-code)