### PR TITLE
📄 vcd: clearer field comments in vcd.lr

### DIFF
--- a/providers/vcd/resources/vcd.lr
+++ b/providers/vcd/resources/vcd.lr
@@ -114,7 +114,7 @@ vcd.networkPool {
   name string
   // Whether the network pool is busy
   isBusy bool
-  // Type of network pool (0=Vlan backed network pool; 1=vNI backed network pool;2=Portgroup backed network pool)
+  // Type of network pool (0=VLAN-backed, 1=vNI-backed, 2=portgroup-backed)
   networkPoolType int
 }
 
@@ -248,7 +248,7 @@ vcd.vdc {
   id string
   // Name of the VDC
   name string
-  // Creation status of the VDC (0=creating, 1=ready, -1=error)
+  // Creation status of the VDC (-1=error, 0=creating, 1=ready)
   status int
   // Optional description
   description string
@@ -258,7 +258,7 @@ vcd.vdc {
   nicQuota int
   // Maximum number of network objects allowed (0=unlimited)
   networkQuota int
-  // Number of networks in use for/by this VDC
+  // Count of networks currently in use by this VDC
   usedNetworkCount int
   // Quota of VMs that can be created in this VDC
   vmQuota int


### PR DESCRIPTION
## Summary

Same kind of cleanup as #7534. Three small reword fixes on integer enum / dict descriptions:

- \`networkPoolType\` magic-number enum reformatted for readability ("0=VLAN-backed, 1=vNI-backed, 2=portgroup-backed").
- VDC creation \`status\` magic-number enum reordered ascending: \`-1=error, 0=creating, 1=ready\`.
- Replace ambiguous "in use for/by this VDC" phrasing on \`usedNetworkCount\` with "Count of networks currently in use".

## Test plan

- [x] \`./mqlr generate providers/vcd/resources/vcd.lr\` runs cleanly
- [x] No tracked generated files change

🤖 Generated with [Claude Code](https://claude.com/claude-code)