### PR TITLE
📄 core: clearer field comments in core.lr

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -200,6 +200,7 @@ gcs
 gelf
 GENEVE
 geomatchstatement
+GHSA
 gistfile
 githubactions
 godo

--- a/providers/core/resources/core.lr
+++ b/providers/core/resources/core.lr
@@ -100,8 +100,11 @@ regex {
   creditCard() regex
 }
 
-// Common parsers (json, ini, certs, and so on). Also exposes parser functions: date(value, format) time, duration(value) time.
+// Common parsers (json, ini, certs, and so on)
 parse {
+  // Built-in functions:
+  // date(value, format) time
+  // duration(value) time
 }
 
 // UUIDs based on RFC 4122 and DCE 1.1

--- a/providers/core/resources/core.lr
+++ b/providers/core/resources/core.lr
@@ -8,11 +8,11 @@ option go_package = "go.mondoo.com/mql/v13/providers/core/resources"
 mondoo @defaults("version") {
   // Version of the client running on the asset
   version() string
-  // Build of the client (e.g., production, development)
+  // Build identifier of the client (e.g., production, development, or commit hash)
   build() string
   // Architecture of this client (e.g., linux-amd64)
   arch() string
-  // Agent execution environment
+  // Environment context the agent is running in (e.g., scheduled, interactive, CI)
   jobEnvironment() dict
   // Connection capabilities
   capabilities() []string
@@ -26,11 +26,9 @@ asset @defaults("name platform version") {
   ids []string
   // Platform for this asset (redhat, windows, k8s-pod)
   platform string
-  // Kind of platform, for example:
-  // api, baremetal, virtualmachine, container, container-image, network, ...
+  // High-level platform category (e.g., api, baremetal, virtualmachine, container, container-image, network)
   kind string
-  // Runtime is the specific kind of the platform. Examples include:
-  // docker-container, podman-container, aws-ec2-instance, ...
+  // Specific runtime the asset is operating in (e.g., docker-container, podman-container, aws-ec2-instance)
   runtime string
   // Version of the platform
   version string
@@ -44,7 +42,7 @@ asset @defaults("name platform version") {
   fqdn string
   // Build version of the platform (optional)
   build string
-  // Platform Metadata (e.g. key values from /etc/os/release)
+  // Platform metadata such as distribution and release details
   platformMetadata map[string]string
   // Optional platform information
   labels map[string]string
@@ -102,11 +100,8 @@ regex {
   creditCard() regex
 }
 
-// Common parsers (json, ini, certs, and so on)
+// Common parsers (json, ini, certs, and so on). Also exposes parser functions: date(value, format) time, duration(value) time.
 parse {
-  // Built-in functions:
-  // date(value, format) time
-  // duration(value) time
 }
 
 // UUIDs based on RFC 4122 and DCE 1.1
@@ -114,7 +109,7 @@ uuid @defaults("value") {
   init(value string)
   // Canonical string representation xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   value string
-  // URN returns the RFC 2141 URN form of uuid
+  // RFC 2141 URN form of the UUID (e.g., urn:uuid:xxxxxxxx-...)
   urn() string
   // Version of UUID
   version() int
@@ -127,7 +122,7 @@ cpe @defaults("uri") {
   init(uri string)
   // URI binding of the CPE
   uri string
-  // Part of the CPE
+  // CPE part designation: a (application), h (hardware), or o (operating system)
   part() string
   // Vendor of the CPE
   vendor() string
@@ -147,7 +142,7 @@ cpe @defaults("uri") {
   targetSw() string
   // Target hardware of the CPE
   targetHw() string
-  // Additional CPE attributes not covered by other fields
+  // Miscellaneous CPE attributes not covered by the standard fields
   other() string
 }
 
@@ -163,7 +158,7 @@ product {
 
 // End of life information for a product release
 private product.releaseCycleInformation {
-  // Release name
+  // Name identifier of the release cycle
   name string
   // Release cycle
   cycle string
@@ -226,6 +221,6 @@ private unicode.category @defaults("category count") {
 vulnerability.exchange @defaults("id source") {
   // Vulnerability ID, eg. CVE-2025-12345
   id string
-  // Vulnerability source
-  source string  
+  // Source/registry that published the vulnerability record (e.g., NVD, GHSA)
+  source string
 }


### PR DESCRIPTION
## Summary

Same kind of cleanup as #7534 for the universal core resources. Ten fixes:

- \`mondoo.build\` / \`.jobEnvironment\`: bare comments → describe values.
- \`asset.kind\` / \`.runtime\`: collapse multi-line "Kind of platform, for example: ..." into a single descriptive sentence each.
- \`asset.platformMetadata\`: drop the \`/etc/os/release\` implementation hint.
- \`parse\`: move \`date()\` / \`duration()\` function listing into the resource doc instead of an empty body.
- \`uuid.urn()\`: drop the "URN returns ..." Go-style preamble.
- \`cpe.part\` / \`.other\`: bare nouns → describe.
- \`product.releaseCycleInformation.name\`: bare "Release name" → describe.
- \`vulnerability.exchange.source\`: bare → name example sources (NVD, GHSA).

## Test plan

- [x] \`./mqlr generate providers/core/resources/core.lr\` runs cleanly
- [x] No tracked generated files change

🤖 Generated with [Claude Code](https://claude.com/claude-code)