### PR TITLE
🎉 vsphere-13.2.0

### DIFF
--- a/providers/vsphere/config/config.go
+++ b/providers/vsphere/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vsphere",
 	ID:              "go.mondoo.com/cnquery/v9/providers/vsphere",
-	Version:         "13.1.0",
+	Version:         "13.2.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### vsphere (13.2.0)
- ⚡ vsphere: 10 perf + caching + defensive fixes (follow-up to #7564) (#7566)
- 🐛 vsphere: fix 8 correctness bugs (wrong fields, panics, swallowed errors) (#7564)
- 📄 vsphere: drop "(typed reference)" mechanism leak from role() comment (#7536)
- ✨ vsphere: standard vSwitch portgroups + vmnic / vmknic / vSwitch enrichment (#7533)
- ✨ vsphere: typed network policy resources + portGroup() cross-ref (#7532)
- ✨ vsphere.vm: cdroms, NICs, cpu/memory allocations, instance/bios UUID, template flag (#7531)
- ✨ vsphere.host: bootInfo, systemInfo, dnsConfig, ipRouteConfig (#7530)
- 🧹 vsphere: introduce vsphere.host.* and deprecate esxi.* equivalents (#7529)
- ✨ vsphere: VM snapshots and virtual disks (#7528)