### PR TITLE
📄 github: add resource-level comment to top-level github namespace

### DIFF
--- a/providers/github/resources/github.lr
+++ b/providers/github/resources/github.lr
@@ -4,7 +4,7 @@
 option provider = "go.mondoo.com/cnquery/v9/providers/github"
 option go_package = "go.mondoo.com/mql/v13/providers/github/resources"
 
-// GitHub resource
+// GitHub — entry point for inspecting organizations, repositories, teams, users, packages, deploy keys, and security/governance settings
 private github {}
 
 // Git commit

--- a/providers/github/resources/github.lr
+++ b/providers/github/resources/github.lr
@@ -4,6 +4,7 @@
 option provider = "go.mondoo.com/cnquery/v9/providers/github"
 option go_package = "go.mondoo.com/mql/v13/providers/github/resources"
 
+// GitHub resource
 private github {}
 
 // Git commit


### PR DESCRIPTION
## Summary
- The top-level `github` namespace resource in `providers/github/resources/github.lr` was missing a description comment.
- Added one for consistency with other providers (e.g., `aws`, `azure`).
- Comment-only change — no version bumps, no shape changes.

## Test plan
- [x] `make providers/build/github` succeeds.
- [x] Re-audit script reports no remaining undocumented top-level resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)