### PR TITLE
📄 network: add resource-level comment to openpgp.entities

### DIFF
--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -272,6 +272,7 @@ private pkix.sanExtension @defaults("dnsNames") {
 	uris []string
 }
 
+// List of OpenPGP entities parsed from a string
 private openpgp.entities {
   []openpgp.entity(content)
   content string


### PR DESCRIPTION
## Summary
- The `openpgp.entities` collection wrapper in `network.lr` was missing a description comment.
- Added one for consistency with sibling resources (`openpgp.entity`, `openpgp.publicKey`).
- Comment-only change.

## Test plan
- [x] `make providers/build/network` succeeds.
- [x] Re-audit script reports no remaining undocumented top-level resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)