### PR TITLE
📄 cloudflare: add resource-level comment to cloudflare.streams

### DIFF
--- a/providers/cloudflare/resources/cloudflare.lr
+++ b/providers/cloudflare/resources/cloudflare.lr
@@ -324,6 +324,7 @@ private cloudflare.account.settings {
 	enforceTwoFactor bool
 }
 
+// Cloudflare Stream namespace (live inputs and videos)
 private cloudflare.streams {}
 
 // Cloudflare live input (stream)


### PR DESCRIPTION
## Summary
- The `cloudflare.streams` namespace in `cloudflare.lr` was missing a description comment.
- It's the parent of `cloudflare.streams.liveInput` and `cloudflare.streams.video`.
- Added one for consistency with sibling namespaces.

## Test plan
- [x] `make providers/build/cloudflare` succeeds.
- [x] Re-audit script reports no remaining undocumented top-level resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)