### PR TITLE
📄 gcp: add resource-level comments for GKE autoscaling and Binary Authorization

### DIFF
--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -2744,6 +2744,7 @@ private gcp.project.gkeService.cluster.nodepool.upgradeSettings @defaults("strat
   blueGreenSettings dict
 }
 
+// Google Kubernetes Engine (GKE) node pool autoscaling configuration
 private gcp.project.gkeService.cluster.nodepool.autoscaling @defaults( "enabled" ) {
   // Is autoscaling enabled for this node pool.
   enabled bool
@@ -4461,6 +4462,7 @@ private gcp.project.monitoringService.service.slo @defaults("name displayName go
   userLabels map[string]string
 }
 
+// Google Cloud (GCP) Binary Authorization
 private gcp.project.binaryAuthorizationControl {
   // The policy for container image binary authorization
   policy gcp.project.binaryAuthorizationControl.policy
@@ -4468,6 +4470,7 @@ private gcp.project.binaryAuthorizationControl {
   attestors() []gcp.project.binaryAuthorizationControl.attestor
 }
 
+// Google Cloud (GCP) Binary Authorization policy
 private gcp.project.binaryAuthorizationControl.policy {
   // The resource name
   name string
@@ -4489,6 +4492,7 @@ private gcp.project.binaryAuthorizationControl.policy {
   updated time
 }
 
+// Google Cloud (GCP) Binary Authorization admission rule
 private gcp.project.binaryAuthorizationControl.admissionRule {
   // How this admission rule will be evaluated
   evaluationMode string


### PR DESCRIPTION
## Summary
Four resources in `gcp.lr` were missing description comments:
- `gcp.project.gkeService.cluster.nodepool.autoscaling`
- `gcp.project.binaryAuthorizationControl`
- `gcp.project.binaryAuthorizationControl.policy`
- `gcp.project.binaryAuthorizationControl.admissionRule`

Added comments matching the style of sibling GKE / Binary Authorization resources.

Comment-only change — no version bumps, no shape changes.

## Test plan
- [x] `make providers/build/gcp` succeeds.
- [x] Re-audit script reports no remaining undocumented top-level resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)