### PR TITLE
📄 dev docs: require comments on every .lr resource and field

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -310,6 +310,7 @@ logstream
 LONGTERM
 longtermretentionpolicy
 lsp
+lstrip
 lvm
 lvmthin
 MACSEC
@@ -462,6 +463,7 @@ ratebasedstatement
 rbcd
 rdm
 Rdp
+readlines
 recaptcha
 regexmatchstatement
 regexpatternsetreferencestatement
@@ -479,6 +481,7 @@ RRULE
 RSASHA
 RSASSA
 RSession
+rstrip
 rtl
 rtsp
 rulegroup
@@ -526,6 +529,7 @@ srp
 sslv
 Sspr
 stan
+startswith
 stdio
 stdlib
 stepfunctions

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -242,6 +242,67 @@ use (
 The more time we spend building providers, the more we learn how to do better in the future. Here we describe learnings
 that will help you get started with providers development.
 
+### Document every resource and field
+
+Every resource and field declared in a `.lr` schema **must** have a `//`-comment immediately above it. These comments
+are not just for code readers — the code generator emits them as the `title`/`desc` for each resource and field in the
+generated `*.resources.json`, which is what powers our user-facing docs and IDE autocomplete. A field with no comment
+ends up as an empty entry in the docs.
+
+Write the comment for someone who has never seen the provider's Go code:
+
+- **Describe what it represents, not how it's implemented.** "Static IP address reserved for a project" is useful;
+  "Returned by the Compute API" is not.
+- **Be specific.** A top-level provider resource is the worst place for a generic "X resource" comment, because that
+  string is the heading of the entire provider's docs. Name what the provider exposes — for example, "GitHub — entry
+  point for inspecting organizations, repositories, teams, users, packages, deploy keys, and security/governance
+  settings" beats a bare "GitHub resource".
+- **Match the SDK/API vocabulary** that someone reading docs would search for (e.g., "Amazon S3 bucket lifecycle rule",
+  not "lifecycle entry on the bucket").
+- **For deprecated fields**, prefix the comment with `DEPRECATED:` and name the replacement (see the `@maturity`
+  section in `CLAUDE.md`).
+
+```lr
+// Snowflake Data Cloud — entry point for inspecting accounts, users, roles, grants, databases,
+// warehouses, shares, and network/password/session policies
+snowflake {
+  // Role currently in use for this Snowflake session
+  currentRole() string
+}
+
+// Snowflake user account, including authentication and session settings
+snowflake.user @defaults("name") {
+  // User name
+  name string
+  // Email address
+  email string
+  // Whether the user has an RSA public key configured for key-pair authentication
+  hasRsaPublicKey bool
+}
+```
+
+A quick way to find resources across all providers that are missing comments:
+
+```bash
+python3 - <<'EOF'
+import glob, re
+skip = ('import ', 'option ', 'alias ', 'extend ', 'embed ')
+res_re = re.compile(r'^(private\s+)?[a-zA-Z][\w.]*\s*(@\w+\([^)]*\)\s*)*\{')
+for path in sorted(glob.glob('providers/*/resources/*.lr')):
+    with open(path) as f:
+        lines = f.readlines()
+    for i, line in enumerate(lines):
+        s = line.lstrip()
+        if any(s.startswith(p) for p in skip) or not res_re.match(s):
+            continue
+        j = i - 1
+        while j >= 0 and not lines[j].strip():
+            j -= 1
+        if j < 0 or not lines[j].strip().startswith('//'):
+            print(f'{path}:{i+1}: {line.rstrip()}')
+EOF
+```
+
 ### Referencing MQL resources
 
 Often we have a top-level MQL resource, which we want to reference in another top-level resource.


### PR DESCRIPTION
## Summary
Adds a **Document every resource and field** sub-section to the *Providers development best practices* section in `DEVELOPMENT.md`.

The point I want to land: `.lr` comments are not just for code readers — the generator emits them as the `title`/`desc` for each resource and field in the generated `*.resources.json`, which is what powers our user-facing docs and IDE autocomplete. So they need to be written for someone who has never seen the provider's Go code.

The new section calls out:
- Describe what something **represents**, not how it's implemented.
- A top-level provider resource is the *worst* place for a generic "X resource" comment — it ends up as the heading of the entire provider's docs. Name what the provider exposes (the recent #7571 / #7572 fixes use this pattern).
- Match SDK/API vocabulary users will search for.
- For deprecated fields, prefix the comment with `DEPRECATED:` and name the replacement (cross-references the existing `@maturity` guidance in `CLAUDE.md`).

Includes a short example and a python audit one-liner that lists every resource declaration missing a preceding comment, across all providers. (I tried writing this as awk but BSD awk on macOS doesn't tolerate `!~` against a string literal.)

## Test plan
- [x] Ran the included python audit script — output matches the per-provider gap list I worked from earlier today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)