### PR TITLE
📄 os: insert blank // separator between resource description lines

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -27,6 +27,7 @@ extend asset {
 }
 
 // Operating system end-of-life status
+//
 // Check whether the platform has reached vendor end-of-support
 asset.eol @defaults("date") {
   // Documentation URL
@@ -48,6 +49,7 @@ private mondoo.eol {
 }
 
 // Asset vulnerability assessment
+//
 // Examine CVEs, advisories, and affected packages from the intelligence feed
 vulnmgmt {
   // List of all CVEs affecting the asset
@@ -109,6 +111,7 @@ private vuln.package @defaults("name version") {
 }
 
 // All platform and package advisories
+//
 // Examine vendor advisories with CVSS scores and severity counts
 platform.advisories {
   []audit.advisory
@@ -119,6 +122,7 @@ platform.advisories {
 }
 
 // All platform and package CVEs
+//
 // Examine known CVEs affecting the asset with CVSS scores and severity counts
 platform.cves {
   []audit.cve
@@ -175,6 +179,7 @@ private audit.cve {
 }
 
 // Hardware identity from SMBIOS / DMI
+//
 // Examine BIOS, system, baseboard, chassis, CPU, and Secure Boot details
 machine {}
 
@@ -255,6 +260,7 @@ machine.secureboot @defaults("enabled") {
 }
 
 // Operating system information
+//
 // Examine hostname, uptime, environment, and pending updates
 os {
   // Pretty hostname on macOS/Linux or device name on Windows
@@ -302,6 +308,7 @@ os.update @defaults("name")  {
 }
 
 // Generic operating system information common to all platforms
+//
 // Examine identity, environment, users, groups, and update state
 os.base {
   embed machine
@@ -327,12 +334,14 @@ os.base {
 }
 
 // Operating system information for Unix-like platforms
+//
 // Examine the cross-platform os.base attributes plus Unix-specific surfaces
 os.unix {
   embed os.base as base
 }
 
 // Operating system information for Linux platforms
+//
 // Examine firewall, fstab, AppArmor, and other Linux-only surfaces
 os.linux {
   embed os.unix as unix
@@ -354,6 +363,7 @@ os.linux {
 }
 
 // Operating system root certificate trust store
+//
 // Examine the certificates the OS trusts for TLS validation
 os.rootCertificates {
   []certificate(content)
@@ -363,6 +373,7 @@ os.rootCertificates {
 }
 
 // Results of running a command on the system
+//
 // Examine stdout, stderr, and exit code from arbitrary system commands
 command {
   init(command string)
@@ -377,6 +388,7 @@ command {
 }
 
 // Results of running a PowerShell script on the system
+//
 // Examine stdout, stderr, and exit code from arbitrary PowerShell scripts
 powershell {
   init(script string)
@@ -391,6 +403,7 @@ powershell {
 }
 
 // File on the system
+//
 // Examine path, contents, size, ownership, and POSIX permissions
 file @defaults("path size permissions.string") {
   init(path string)
@@ -465,6 +478,7 @@ private file.permissions @defaults("string") {
 }
 
 // File search and discovery namespace
+//
 // Use files.find to locate files by name, type, regex, or permissions
 files {}
 
@@ -488,6 +502,7 @@ files.find {
 }
 
 // Parse INI configuration files
+//
 // Examine sections and key-value pairs from any INI-formatted file
 parse.ini {
   init(path string, delimiter string)
@@ -504,6 +519,7 @@ parse.ini {
 }
 
 // Parse JSON files
+//
 // Examine the parsed structure of any JSON document on disk
 parse.json {
   init(path string)
@@ -516,6 +532,7 @@ parse.json {
 }
 
 // Parse XML files
+//
 // Examine the parsed structure of any XML document on disk
 parse.xml {
   init(path string)
@@ -528,6 +545,7 @@ parse.xml {
 }
 
 // Parse Apple property list (plist) files
+//
 // Examine the parsed structure of XML or binary plist files
 parse.plist {
   init(path string)
@@ -540,6 +558,7 @@ parse.plist {
 }
 
 // Parse YAML files
+//
 // Examine single- or multi-document YAML structures from disk
 parse.yaml {
   init(path string)
@@ -554,6 +573,7 @@ parse.yaml {
 }
 
 // Parse X.509 certificates from files
+//
 // Examine PEM-encoded certificate chains and bundles
 parse.certificates {
   []network.certificate(content, path)
@@ -567,6 +587,7 @@ parse.certificates {
 }
 
 // Parse OpenPGP keys from files
+//
 // Examine OpenPGP entities (keys, identities, subkeys) from key files
 parse.openpgp {
   []network.openpgp.entity(content)
@@ -578,6 +599,7 @@ parse.openpgp {
 }
 
 // User account on the system
+//
 // Examine UID, group, shell, home, SSH keys, and login state
 user @defaults("name uid gid") {
   // User ID
@@ -605,6 +627,7 @@ user @defaults("name uid gid") {
 }
 
 // Private key on disk
+//
 // Examine PEM data and whether the key is encrypted
 privatekey {
   // PEM data
@@ -618,12 +641,14 @@ privatekey {
 }
 
 // All user accounts configured on the system
+//
 // Iterate every user across the asset for filtering and aggregation
 users {
   []user
 }
 
 // SSH authorized_keys file
+//
 // Examine entries that grant key-based SSH login for a user
 authorizedkeys {
   []authorizedkeys.entry(file, content)
@@ -653,6 +678,7 @@ authorizedkeys.entry @defaults("key") {
 }
 
 // Group on the system
+//
 // Examine GID, name, and member users for a single group
 group @defaults("name gid") {
   init(id string)
@@ -667,12 +693,14 @@ group @defaults("name gid") {
 }
 
 // All groups configured on the system
+//
 // Iterate every group across the asset for filtering and aggregation
 groups {
   []group
 }
 
 // Installed package on the platform or OS
+//
 // Examine name, version, status, package URL, and origin metadata
 package @defaults("name version") {
   // May be initialized with the name only, in which case it will look up
@@ -725,12 +753,14 @@ private pkgFileInfo @defaults("path") {
 }
 
 // All packages installed on the system
+//
 // Iterate the full inventory across the asset's package manager(s)
 packages {
   []package
 }
 
 // PAM (pluggable authentication module) configuration
+//
 // Examine /etc/pam.d service entries with their type, control, and module
 pam.conf {
   init(path string)
@@ -761,10 +791,12 @@ private pam.conf.serviceEntry @defaults("service module") {
 }
 
 // OpenSSH server (sshd) namespace
+//
 // Use sshd.config to examine the effective server settings and match blocks
 sshd {}
 
 // OpenSSH server (sshd) configuration
+//
 // Examine ciphers, MACs, KEX algorithms, host keys, and Match blocks
 sshd.config {
   init(path? string)
@@ -811,6 +843,7 @@ private sshd.config.matchBlock @defaults("criteria") @context("file.context") {
 }
 
 // auditd (Linux Audit Daemon) global configuration
+//
 // Examine /etc/audit/auditd.conf parameters
 auditd.config {
   init(path? string)
@@ -821,6 +854,7 @@ auditd.config {
 }
 
 // auditd (Linux Audit Daemon) ruleset on disk
+//
 // Examine controls, file watches, and syscall rules from /etc/audit/audit.rules
 auditd.rules {
   // Path to folder to look up rules
@@ -889,6 +923,7 @@ private auditd.rule.syscall @defaults("action list") {
 }
 
 // Apache2 HTTP Server
+//
 // Examine server configuration and daemon version
 apache2 {
   // Apache2 version (e.g., "2.4.62")
@@ -896,6 +931,7 @@ apache2 {
 }
 
 // Apache2 HTTP Server configuration
+//
 // Examine directives, loaded modules, virtual hosts, and directory blocks
 apache2.conf {
   init(path? string)
@@ -961,6 +997,7 @@ private apache2.conf.directory @defaults("path") {
 }
 
 // Nginx HTTP Server
+//
 // Examine server configuration, daemon version, and compiled-in modules
 nginx {
   // Nginx version (e.g., "1.25.3")
@@ -970,6 +1007,7 @@ nginx {
 }
 
 // Nginx HTTP Server configuration
+//
 // Examine directives, server blocks, upstream pools, and listen addresses
 nginx.conf {
   init(path? string)
@@ -1034,6 +1072,7 @@ private nginx.conf.location @defaults("path") {
 }
 
 // systemd journald configuration
+//
 // Examine the [Journal] and other sections of journald.conf
 journald.config {
   init(path? string)
@@ -1062,6 +1101,7 @@ journald.config.section.param @defaults("name value") {
 }
 
 // Service on the system
+//
 // Examine install, enable, run state, type, and unit metadata
 service @defaults("name running enabled type") {
   init(name string)
@@ -1084,12 +1124,14 @@ service @defaults("name running enabled type") {
 }
 
 // All services configured on the system
+//
 // Iterate every service across the asset's init/service manager
 services {
   []service
 }
 
 // systemd timer unit
+//
 // Examine schedule, activation target, enable state, and run status
 systemd.timer @defaults("name enabled running") {
   init(name string)
@@ -1116,12 +1158,14 @@ systemd.timer @defaults("name enabled running") {
 }
 
 // All systemd timer units on the system
+//
 // Iterate every timer for filtering by schedule, target, or status
 systemd.timers {
   []systemd.timer
 }
 
 // systemd socket unit
+//
 // Examine listen addresses, activation target, and run state
 systemd.socket @defaults("name enabled running") {
   init(name string)
@@ -1148,12 +1192,14 @@ systemd.socket @defaults("name enabled running") {
 }
 
 // All systemd socket units on the system
+//
 // Iterate every socket-activated unit for listen-address and target audits
 systemd.sockets {
   []systemd.socket
 }
 
 // Running kernel and its modules
+//
 // Examine kernel info, sysctl parameters, loaded modules, and installed versions
 kernel @defaults("info") {
   // Active kernel information
@@ -1179,6 +1225,7 @@ kernel.module @defaults("name loaded") {
 }
 
 // Docker host
+//
 // Examine images and containers managed by the Docker daemon
 docker {
   // List all Docker images
@@ -1188,6 +1235,7 @@ docker {
 }
 
 // Dockerfile parser
+//
 // Examine instructions and per-stage FROM/RUN/COPY/ENV/EXPOSE/USER/HEALTHCHECK
 docker.file @defaults("file.path instructions.length stages.length") {
   init(path string)
@@ -1340,6 +1388,7 @@ private docker.file.workdir @defaults("path") {
 }
 
 // Single Docker image on the host
+//
 // Examine ID, tags, repo digests, size, and labels
 docker.image {
   // Image ID
@@ -1355,6 +1404,7 @@ docker.image {
 }
 
 // Single Docker container on the host
+//
 // Examine state, image, command, labels, and the container's embedded OS
 docker.container @defaults("names.first status"){
   embed os.linux as os
@@ -1379,6 +1429,7 @@ docker.container @defaults("names.first status"){
 }
 
 // containerd host
+//
 // Examine containers managed by the containerd runtime
 containerd {
   // List all containerd containers
@@ -1386,6 +1437,7 @@ containerd {
 }
 
 // Single containerd container
+//
 // Examine ID, image, status, namespace, and runtime
 containerd.container @defaults("id status") {
   // Container ID
@@ -1407,6 +1459,7 @@ containerd.container @defaults("id status") {
 }
 
 // IPv4 packet filter (iptables)
+//
 // Examine tables, chains, and default INPUT/OUTPUT/FORWARD policies
 iptables {
   // All tables (filter, nat, mangle, raw)
@@ -1426,6 +1479,7 @@ iptables {
 }
 
 // IPv6 packet filter (ip6tables)
+//
 // Examine tables, chains, and default INPUT/OUTPUT/FORWARD policies
 ip6tables {
   // All tables (filter, nat, mangle, raw)
@@ -1493,6 +1547,7 @@ iptables.entry {
 }
 
 // nftables firewall
+//
 // Examine tables, chains, rules, and named sets across all address families
 nftables @defaults("tables") {
   // nft version string (e.g., "1.0.2")
@@ -1590,6 +1645,7 @@ private nftables.set @defaults("family table name") {
 }
 
 // UFW (Uncomplicated Firewall) state and rules
+//
 // Examine status, default policies, configured rules, and application profiles
 ufw @defaults("status rules") {
   // Whether UFW is active ("active", "inactive", "not installed")
@@ -1645,6 +1701,7 @@ private ufw.application @defaults("name ports") {
 }
 
 // firewalld dynamic firewall manager (RHEL/CentOS/Fedora)
+//
 // Examine state, default zone, and per-zone services, ports, and rich rules
 firewalld @defaults("status defaultZone") {
   // Whether firewalld is running ("running", "not running", "not installed")
@@ -1707,6 +1764,7 @@ private firewalld.richrule @defaults("family rule") {
 }
 
 // fstab persistent mount table
+//
 // Examine mount entries with device, mount point, fstype, and options
 fstab @defaults("path") {
   init(path? string)
@@ -1733,6 +1791,7 @@ private fstab.entry @defaults("device mountpoint") {
 }
 
 // GRUB bootloader configuration
+//
 // Examine /etc/default/grub parameters, menu entries, and password protection
 grub.config @defaults("defaultsPath grubPath") {
   init(defaultsPath? string, grubPath? string)
@@ -1761,6 +1820,7 @@ private grub.config.entry @defaults("title") {
 }
 
 // FreeBSD rc.conf system configuration
+//
 // Examine variable assignments across rc.conf and rc.conf.local
 sysrc @defaults("files") {
   init(path? string)
@@ -1783,6 +1843,7 @@ private sysrc.entry @defaults("name value") {
 }
 
 // Single process on the system
+//
 // Examine PID, executable, command line, state, and runtime flags
 process @defaults("executable pid state") {
   init(pid int)
@@ -1799,12 +1860,14 @@ process @defaults("executable pid state") {
 }
 
 // All processes running on the system
+//
 // Iterate every process for filtering by executable, user, or state
 processes {
   []process
 }
 
 // Single TCP/UDP port on the system
+//
 // Examine address, state, attached process, and remote peer
 port @defaults("port protocol address process.executable") {
   // Protocol of this port
@@ -1828,6 +1891,7 @@ port @defaults("port protocol address process.executable") {
 }
 
 // All TCP/UDP ports on the system
+//
 // Iterate every port — including the listening() subset for exposure audits
 ports {
   []port
@@ -1836,6 +1900,7 @@ ports {
 }
 
 // Windows audit policies
+//
 // Examine inclusion and exclusion settings for every audit subcategory
 auditpol {
   []auditpol.entry
@@ -1858,6 +1923,7 @@ auditpol.entry  @defaults("subcategory inclusionsetting exclusionsetting") {
 }
 
 // Windows local security policy
+//
 // Examine system access, event audit, registry values, and privilege rights
 secpol {
   // System access
@@ -1871,6 +1937,7 @@ secpol {
 }
 
 // NTP daemon configuration
+//
 // Examine servers, restrict directives, fudge entries, and other settings
 ntp.conf {
   init(path string)
@@ -1889,6 +1956,7 @@ ntp.conf {
 }
 
 // rsyslog daemon configuration
+//
 // Examine effective settings across the main file and included fragments
 rsyslog.conf {
   init(path string)
@@ -1903,6 +1971,7 @@ rsyslog.conf {
 }
 
 // Shadow password suite (login.defs) configuration
+//
 // Examine password aging, UID/GID ranges, and login policy parameters
 logindefs {
   init(path string)
@@ -1915,6 +1984,7 @@ logindefs {
 }
 
 // PAM resource limits configuration (limits.conf)
+//
 // Examine soft/hard caps on processes, files, memory, and other resources
 limits {
   // List of files that make up the limits configuration
@@ -1940,6 +2010,7 @@ private limits.entry @defaults("domain item") {
 }
 
 // sudo authorization configuration
+//
 // Examine user specifications, defaults, and aliases across sudoers files
 sudoers @defaults("files") {
   init(path? string)
@@ -2012,6 +2083,7 @@ private sudoers.alias @defaults("type name") {
 }
 
 // Unix block devices (lsblk)
+//
 // Examine device names, filesystem types, labels, UUIDs, and mount points
 lsblk {
   []lsblk.entry
@@ -2032,6 +2104,7 @@ lsblk.entry {
 }
 
 // AppArmor mandatory access control
+//
 // Examine status, loaded profiles, and processes under confinement
 apparmor @defaults("profiles") {
   // AppArmor status output version
@@ -2063,6 +2136,7 @@ private apparmor.process @defaults("pid profile status") {
 }
 
 // SELinux mandatory access control
+//
 // Examine enforcement mode, policy type, booleans, and loaded modules
 selinux @defaults("mode") {
   // Whether SELinux is installed on the system
@@ -2098,6 +2172,7 @@ private selinux.module @defaults("name status") {
 }
 
 // Kernel module configuration (modprobe.d)
+//
 // Examine install, remove, blacklist, options, alias, and softdep directives
 modprobe @defaults("blacklists installs") {
   init(path? string)
@@ -2192,6 +2267,7 @@ private modprobe.softdep @defaults("module") {
 }
 
 // Unix mount table
+//
 // Iterate every mount point with device, fstype, options, and capacity
 mount {
   []mount.point
@@ -2219,6 +2295,7 @@ mount.point @defaults("device path fstype") {
 }
 
 // Shadow password file (/etc/shadow)
+//
 // Examine per-user password aging, expiration, and lock state
 shadow {
   []shadow.entry
@@ -2247,6 +2324,7 @@ shadow.entry {
 }
 
 // Yum/DNF package manager
+//
 // Examine yum variables and configured repositories
 yum {
   // Variables defined in Yum configuration files (/etc/yum.conf and all .repo files in the /etc/yum.repos.d/)
@@ -2283,6 +2361,7 @@ yum.repo {
 }
 
 // Windows registry key
+//
 // Examine items, child keys, and existence at a given registry path
 registrykey @defaults("path") {
   init(path string)
@@ -2316,6 +2395,7 @@ registrykey.property @defaults("path name") {
 }
 
 // OCI/Docker container image reference
+//
 // Examine fully-qualified name, tag/digest identifier, and source repository
 container.image @defaults("name") {
   // Image reference
@@ -2331,6 +2411,7 @@ container.image @defaults("name") {
 }
 
 // Container registry repository
+//
 // Examine registry, scheme, and full repository name for an image source
 container.repository {
   // Container registry repository name
@@ -2344,6 +2425,7 @@ container.repository {
 }
 
 // Kubernetes kubelet on this node
+//
 // Examine config-file parameters merged with the live process's CLI flags
 kubelet {
   // Kubelet config file
@@ -2355,6 +2437,7 @@ kubelet {
 }
 
 // Python package inventory
+//
 // Examine all installed packages plus the explicitly-installed top level
 python {
   init(path? string)
@@ -2400,6 +2483,7 @@ python.package @defaults("name version") {
 }
 
 // npm package inventory
+//
 // Examine the project root, direct dependencies, and full transitive tree
 npm.packages {
   []npm.package
@@ -2442,6 +2526,7 @@ npm.package @defaults("name version purl") {
 }
 
 // Go module inventory
+//
 // Examine the root module, direct dependencies, and full transitive tree
 go.packages {
   []go.package
@@ -2478,6 +2563,7 @@ go.package @defaults("name version purl") {
 }
 
 // Java package inventory (Maven, Gradle, JAR archives)
+//
 // Examine the root project, direct dependencies, and full transitive tree
 java.packages {
   []java.package
@@ -2514,6 +2600,7 @@ java.package @defaults("name version purl") {
 }
 
 // Rust/Cargo crate inventory
+//
 // Examine the root crate, direct dependencies, and full transitive tree
 rust.packages {
   []rust.package
@@ -2550,6 +2637,7 @@ rust.package @defaults("name version purl") {
 }
 
 // .NET / NuGet package inventory
+//
 // Examine the root project, direct dependencies, and full transitive tree
 dotnet.packages {
   []dotnet.package
@@ -2586,6 +2674,7 @@ dotnet.package @defaults("name version purl") {
 }
 
 // PHP / Composer package inventory
+//
 // Examine the root project, direct dependencies, and full transitive tree
 php.packages {
   []php.package
@@ -2622,6 +2711,7 @@ php.package @defaults("name version purl") {
 }
 
 // GitHub Actions workflow dependencies
+//
 // Examine action references (owner/repo@version) used across workflow files
 githubactions.packages {
   []githubactions.package
@@ -2650,6 +2740,7 @@ githubactions.package @defaults("name version purl") {
 }
 
 // Swift package inventory (SPM and CocoaPods)
+//
 // Examine all referenced packages with their resolved versions
 swift.packages {
   []swift.package
@@ -2680,6 +2771,7 @@ swift.package @defaults("name version purl") {
 }
 
 // Terraform provider inventory (SBOM cataloger)
+//
 // Examine provider versions pinned in .terraform.lock.hcl
 // Note: the terraform.* namespace is also used by the dedicated Terraform provider
 // for IaC resource scanning. These SBOM resources focus on provider version inventory
@@ -2713,6 +2805,7 @@ terraform.package @defaults("name version purl") {
 }
 
 // Homebrew package inventory (macOS and Linux)
+//
 // Examine installed formulae and casks with version, tap, and update status
 homebrew.packages {
   []homebrew.package
@@ -2755,6 +2848,7 @@ private homebrew.package @defaults("name version type") {
 }
 
 // Chocolatey package inventory (Windows)
+//
 // Examine installed packages with version, license, dependencies, and pin state
 chocolatey.packages {
   []chocolatey.package
@@ -2791,6 +2885,7 @@ private chocolatey.package @defaults("name version") {
 }
 
 // Jenkins plugin inventory
+//
 // Examine installed plugins with version and inter-plugin dependencies
 jenkins.packages {
   []jenkins.package
@@ -2823,6 +2918,7 @@ private jenkins.package @defaults("name version purl") {
 }
 
 // WordPress plugin inventory
+//
 // Examine installed plugins with version and WordPress compatibility ranges
 wordpress.packages {
   []wordpress.package
@@ -2857,6 +2953,7 @@ private wordpress.package @defaults("name version purl") {
 }
 
 // Ruby gem inventory
+//
 // Examine the root project, direct dependencies, and full transitive tree
 ruby.packages {
   []ruby.package
@@ -2893,6 +2990,7 @@ ruby.package @defaults("name version purl") {
 }
 
 // Dart/Flutter package inventory
+//
 // Examine the root project, direct dependencies, and full transitive tree
 dart.packages {
   []dart.package
@@ -2929,6 +3027,7 @@ dart.package @defaults("name version purl") {
 }
 
 // Haskell package inventory (Stack and Cabal)
+//
 // Examine all locked packages with their resolved versions
 haskell.packages {
   []haskell.package
@@ -2957,6 +3056,7 @@ haskell.package @defaults("name version purl") {
 }
 
 // Elixir Hex package inventory (mix.lock)
+//
 // Examine all locked Hex packages with their resolved versions
 elixir.packages {
   []elixir.package
@@ -2985,6 +3085,7 @@ elixir.package @defaults("name version purl") {
 }
 
 // Erlang Hex package inventory (rebar.lock)
+//
 // Examine all locked Hex packages with their resolved versions
 erlang.packages {
   []erlang.package
@@ -3013,6 +3114,7 @@ erlang.package @defaults("name version purl") {
 }
 
 // SWI-Prolog pack inventory
+//
 // Examine installed packs with their versions
 prolog.packages {
   []prolog.package
@@ -3041,6 +3143,7 @@ prolog.package @defaults("name version purl") {
 }
 
 // Conda package inventory
+//
 // Examine installed packages from conda-meta or environment.yml
 conda.packages {
   []conda.package
@@ -3069,6 +3172,7 @@ private conda.package @defaults("name version purl") {
 }
 
 // Julia package inventory (Manifest.toml)
+//
 // Examine all locked packages with their resolved versions
 julia.packages {
   []julia.package
@@ -3097,6 +3201,7 @@ private julia.package @defaults("name version purl") {
 }
 
 // R package inventory (renv.lock)
+//
 // Examine all locked packages with their resolved versions
 r.packages {
   []r.package
@@ -3125,6 +3230,7 @@ private r.package @defaults("name version purl") {
 }
 
 // Lua/LuaRocks package inventory
+//
 // Examine all installed rocks with their versions
 lua.packages {
   []lua.package
@@ -3153,6 +3259,7 @@ private lua.package @defaults("name version purl") {
 }
 
 // macOS-specific operating system surfaces
+//
 // Examine computer name, user defaults, account policies, and system extensions
 macos {
   // macOS computer name
@@ -3168,6 +3275,7 @@ macos {
 }
 
 // macOS hardware overview
+//
 // Examine chip type, model, memory, serial, and Activation Lock status
 macos.hardware @defaults("machineName chipType physicalMemory serialNumber") {
   // Activation Lock security feature
@@ -3197,6 +3305,7 @@ macos.hardware @defaults("machineName chipType physicalMemory serialNumber") {
 }
 
 // macOS application layer firewall — raw ALF preference values
+//
 // Prefer macos.firewall; this resource exposes the raw integer flags from ALF plist
 macos.alf {
   // Whether the firewall service allows downloaded software to receive incoming connections
@@ -3224,6 +3333,7 @@ macos.alf {
 }
 
 // macOS application layer firewall
+//
 // Examine enable state, stealth mode, signed-app policy, and per-app rules
 macos.firewall @defaults("enabled stealthEnabled") {
   // Whether the firewall is enabled
@@ -3261,6 +3371,7 @@ private macos.firewall.app @defaults("name state") {
 }
 
 // macOS FileVault full-disk encryption
+//
 // Examine enable state, encryption status, and configured recovery keys
 macos.filevault @defaults("enabled status") {
   // Whether FileVault is enabled
@@ -3276,6 +3387,7 @@ macos.filevault @defaults("enabled status") {
 }
 
 // macOS Gatekeeper application execution policy
+//
 // Examine whether assessments are enabled and the Gatekeeper status message
 macos.gatekeeper @defaults("enabled status") {
   // Whether Gatekeeper assessments are enabled
@@ -3285,6 +3397,7 @@ macos.gatekeeper @defaults("enabled status") {
 }
 
 // macOS System Integrity Protection (SIP)
+//
 // Examine whether SIP is enabled and the system status message
 macos.sip @defaults("enabled status") {
   // Whether System Integrity Protection is enabled
@@ -3294,6 +3407,7 @@ macos.sip @defaults("enabled status") {
 }
 
 // macOS Time Machine backup configuration
+//
 // Examine destinations, schedule, and exclusion preferences
 macos.timemachine {
   // macOS Time Machine preferences
@@ -3301,6 +3415,7 @@ macos.timemachine {
 }
 
 // macOS machine settings via the systemsetup CLI
+//
 // Examine date/time, sleep, remote login, power, and network-time configuration
 // Note: this resource requires at least admin privileges to run.
 macos.systemsetup {
@@ -3347,6 +3462,7 @@ macos.systemsetup {
 }
 
 // OpenBSM audit_control configuration (macOS and BSD)
+//
 // Examine audit flags, log retention, and policy parameters
 openBSMAudit @defaults("path") {
   init(path? string)
@@ -3383,6 +3499,7 @@ openBSMAudit @defaults("path") {
 }
 
 // Windows-specific operating system surfaces
+//
 // Examine computer info, hotfixes, and server / optional features
 windows {
   // A consolidated object of system and operating system properties
@@ -3424,6 +3541,7 @@ private macos.systemExtension @defaults("teamID identifier version state"){
 }
 
 // Safari browser (macOS only)
+//
 // Examine all installed Safari extensions across users
 safari {
   // All installed Safari extensions
@@ -3455,6 +3573,7 @@ private safari.extension @defaults("name version identifier") {
 }
 
 // macOS launchd job configurations
+//
 // Examine system, library, and user daemons / agents from their plist files
 launchd {
   // All launchd jobs from system and user directories
@@ -3562,6 +3681,7 @@ private windows.optionalFeature @defaults("name") {
 }
 
 // Windows Firewall (Advanced Security)
+//
 // Examine global settings, per-profile defaults, and individual firewall rules
 windows.firewall {
   // Global firewall settings
@@ -3654,6 +3774,7 @@ windows.firewall.rule {
 }
 
 // Windows BitLocker drive encryption
+//
 // Examine encryption, lock, and protection status across BitLocker volumes
 windows.bitlocker {
   // Windows BitLocker volumes
@@ -3686,6 +3807,7 @@ windows.bitlocker.volume {
 }
 
 // Windows registered security products
+//
 // Examine antivirus, anti-spyware, and firewall providers from Security Center
 windows.security {
   products() []windows.security.product
@@ -3710,6 +3832,7 @@ private windows.security.product {
 }
 
 // Windows Security Center health
+//
 // Examine firewall, antivirus, anti-spyware, Auto-Update, UAC, and IE settings
 windows.security.health {
   // Windows Firewall status and configuration
@@ -3729,6 +3852,7 @@ windows.security.health {
 }
 
 // Cloud-asset metadata
+//
 // Examine the cloud provider and exposed instance metadata
 cloud @defaults("provider") {
   // Cloud provider (e.g. aws, azure, gcp)
@@ -3752,6 +3876,7 @@ private cloudInstance @defaults("publicHostname privateHostname") {
 }
 
 // IP address (v4 or v6) with networking details
+//
 // Examine the address itself plus subnet, CIDR, broadcast, and gateway
 ipAddress @defaults("ip") {
   // Unique number that identifies a device on a network (e.g. 172.31.24.71 or 2001:0:2851:782c:869:1f7d:a331:f3e1)
@@ -3767,6 +3892,7 @@ ipAddress @defaults("ip") {
 }
 
 // Network configuration of this system
+//
 // Examine interfaces, routes, and detected IPv4 / IPv6 addresses
 network {
   // Network interfaces
@@ -3828,6 +3954,7 @@ private networkRoute @defaults("destination flags"){
 }
 
 // Chromium-family browsers (Chrome, Brave, Edge variants)
+//
 // Examine installed extensions and their content scripts across users and profiles
 chrome {
   // All installed Chrome extensions across all profiles and users
@@ -3907,6 +4034,7 @@ private chrome.extensionContentScript @defaults("script match") {
 }
 
 // Firefox-family browsers
+//
 // Examine installed addons across all users and profiles
 firefox {
   // All installed Firefox addons across all profiles and users
@@ -3960,6 +4088,7 @@ private firefox.addon @defaults("name version active browser") {
 }
 
 // USB device inventory (experimental)
+//
 // Examine attached USB devices with vendor, product, class, and serial
 usb {
   // List of USB devices
@@ -3995,6 +4124,7 @@ private usb.device @defaults("manufacturer name") {
 }
 
 // Crontab schedule on the system
+//
 // Examine cron entries from system, user, and /etc/cron.* sources
 crontab {
   // All cron entries from system and user crontabs
@@ -4026,6 +4156,7 @@ private crontab.entry @defaults("user command") {
 }
 
 // Visual Studio Code (and forks)
+//
 // Examine installed extensions across VS Code, Cursor, Windsurf, and similar editors
 vscode {
   // All installed VS Code extensions across all users
@@ -4059,6 +4190,7 @@ private vscode.extension @defaults("editor name version") {
 }
 
 // logrotate configuration
+//
 // Examine global directives and per-log rotation entries across logrotate.d
 logrotate {
   // List of configuration files (main + logrotate.d fragments)
@@ -4082,6 +4214,7 @@ private logrotate.entry @defaults("path") {
 }
 
 // Linux software RAID arrays (mdadm)
+//
 // Examine arrays with their RAID level, state, member devices, and resync progress
 mdadm @defaults("arrays") {
   // List of all discovered RAID arrays
@@ -4125,6 +4258,7 @@ private mdadm.device @defaults("name state") {
 }
 
 // ZFS storage pools and datasets
+//
 // Examine pool health and capacity, vdev topology, and dataset properties
 zfs @defaults("pools") {
   // ZFS version string
@@ -4234,6 +4368,7 @@ zfs.dataset @defaults("name type usedBytes") {
 }
 
 // Claude Code (Anthropic CLI agent) instance
+//
 // Examine account, plugins, skills, projects, and configured MCP servers
 // URL: https://claude.ai/code
 claude.code @defaults("configPath") @maturity("preview") {
@@ -4323,6 +4458,7 @@ private claude.code.mcpServer @defaults("name") @maturity("preview") {
 }
 
 // OpenAI Codex CLI instance
+//
 // Examine auth mode, plugins, skills, MCP servers, and OAuth connectors
 // URL: https://openai.com/index/introducing-codex/
 openai.codex @defaults("configPath") @maturity("preview") {
@@ -4410,6 +4546,7 @@ private openai.codex.connector @defaults("name") @maturity("preview") {
 }
 
 // Cursor editor (AI-powered) instance
+//
 // Examine MCP servers, global and project rules, and installed skills
 // URL: https://www.cursor.com/
 cursor @defaults("configPath") @maturity("preview") {
@@ -4467,6 +4604,7 @@ private cursor.skill @defaults("name") @maturity("preview") {
 }
 
 // GitHub Copilot CLI instance
+//
 // Examine authenticated accounts, MCP servers, and installed skills
 // URL: https://github.com/features/copilot
 github.copilot @defaults("configPath") @maturity("preview") {
@@ -4520,6 +4658,7 @@ private github.copilot.skill @defaults("name") @maturity("preview") {
 }
 
 // Goose AI agent (Block) instance
+//
 // Examine the active provider/model, telemetry, extensions, and skills
 // URL: https://block.github.io/goose/
 goose @defaults("configPath") @maturity("preview") {
@@ -4573,6 +4712,7 @@ private goose.skill @defaults("name") @maturity("preview") {
 }
 
 // Gemini CLI (Google) instance
+//
 // Examine auth type, settings, MCP servers, and installed skills
 // URL: https://github.com/google-gemini/gemini-cli
 gemini @defaults("configPath") @maturity("preview") {
@@ -4620,6 +4760,7 @@ private gemini.skill @defaults("name") @maturity("preview") {
 }
 
 // Windsurf editor (Codeium) instance
+//
 // Examine global rules / memories, MCP servers, and installed skills
 // URL: https://windsurf.com/
 windsurf @defaults("configPath") @maturity("preview") {
@@ -4675,6 +4816,7 @@ private windsurf.skill @defaults("name") @maturity("preview") {
 }
 
 // Zed editor instance
+//
 // Examine workspace settings and installed extensions
 // URL: https://zed.dev/
 zed @defaults("configPath") @maturity("preview") {
@@ -4688,6 +4830,7 @@ zed @defaults("configPath") @maturity("preview") {
 }
 
 // Roo Code editor instance
+//
 // Examine installed skills
 // URL: https://roocode.com/
 roo @defaults("configPath") @maturity("preview") {
@@ -4717,6 +4860,7 @@ private roo.skill @defaults("name") @maturity("preview") {
 }
 
 // Cline AI agent instance
+//
 // Examine installed skills
 // URL: https://cline.bot/
 cline @defaults("configPath") @maturity("preview") {
@@ -4746,6 +4890,7 @@ private cline.skill @defaults("name") @maturity("preview") {
 }
 
 // Kiro CLI (AWS) instance
+//
 // Examine installed skills
 // URL: https://kiro.dev/
 kiro @defaults("configPath") @maturity("preview") {
@@ -4775,6 +4920,7 @@ private kiro.skill @defaults("name") @maturity("preview") {
 }
 
 // Continue (open-source AI coding assistant) instance
+//
 // Examine installed skills
 // URL: https://continue.dev/
 continuedev @defaults("configPath") @maturity("preview") {
@@ -4804,6 +4950,7 @@ private continuedev.skill @defaults("name") @maturity("preview") {
 }
 
 // Trae AI assistant (ByteDance) instance
+//
 // Examine installed skills
 // URL: https://trae.ai/
 trae @defaults("configPath") @maturity("preview") {
@@ -4833,6 +4980,7 @@ private trae.skill @defaults("name") @maturity("preview") {
 }
 
 // OpenCode AI coding assistant instance
+//
 // Examine installed skills
 // URL: https://opencode.ai/
 opencode @defaults("configPath") @maturity("preview") {
@@ -4862,6 +5010,7 @@ private opencode.skill @defaults("name") @maturity("preview") {
 }
 
 // Pi AI agent instance
+//
 // Examine installed skills
 // URL: https://pi.dev/
 pi @defaults("configPath") @maturity("preview") {
@@ -4891,6 +5040,7 @@ private pi.skill @defaults("name") @maturity("preview") {
 }
 
 // Mistral Vibe (Mistral AI) instance
+//
 // Examine installed skills
 // URL: https://docs.mistral.ai/tools/vibe/
 mistral.vibe @defaults("configPath") @maturity("preview") {
@@ -4920,6 +5070,7 @@ private mistral.vibe.skill @defaults("name") @maturity("preview") {
 }
 
 // Antigravity (Google) instance
+//
 // Examine installed skills
 // URL: https://antigravity.google/
 antigravity @defaults("configPath") @maturity("preview") {
@@ -4949,6 +5100,7 @@ private antigravity.skill @defaults("name") @maturity("preview") {
 }
 
 // IBM Bob instance
+//
 // Examine installed skills
 // URL: https://www.ibm.com/products/bob
 ibm.bob @defaults("configPath") @maturity("preview") {
@@ -4978,6 +5130,7 @@ private ibm.bob.skill @defaults("name") @maturity("preview") {
 }
 
 // OpenClaw AI agent instance
+//
 // Examine installed skills
 // URL: https://openclaw.ai/
 openclaw @defaults("configPath") @maturity("preview") {
@@ -5007,6 +5160,7 @@ private openclaw.skill @defaults("name") @maturity("preview") {
 }
 
 // Snowflake Cortex Code instance
+//
 // Examine installed skills
 // URL: https://www.snowflake.com/en/product/features/cortex-code/
 snowflake.cortex @defaults("configPath") @maturity("preview") {
@@ -5036,6 +5190,7 @@ private snowflake.cortex.skill @defaults("name") @maturity("preview") {
 }
 
 // Junie (JetBrains AI agent) instance
+//
 // Examine installed skills
 // URL: https://www.jetbrains.com/junie/
 junie @defaults("configPath") @maturity("preview") {
@@ -5065,6 +5220,7 @@ private junie.skill @defaults("name") @maturity("preview") {
 }
 
 // Augment Code instance
+//
 // Examine installed skills
 // URL: https://www.augmentcode.com/
 augment @defaults("configPath") @maturity("preview") {
@@ -5094,6 +5250,7 @@ private augment.skill @defaults("name") @maturity("preview") {
 }
 
 // Warp AI terminal instance
+//
 // Examine installed skills
 // URL: https://www.warp.dev/
 warp @defaults("configPath") @maturity("preview") {
@@ -5123,6 +5280,7 @@ private warp.skill @defaults("name") @maturity("preview") {
 }
 
 // Kilo Code AI agent instance
+//
 // Examine installed skills
 // URL: https://kilocode.ai/
 kilocode @defaults("configPath") @maturity("preview") {
@@ -5152,6 +5310,7 @@ private kilocode.skill @defaults("name") @maturity("preview") {
 }
 
 // OpenHands AI agent instance (formerly OpenDevin)
+//
 // Examine installed skills
 // URL: https://www.all-hands.dev/
 openhands @defaults("configPath") @maturity("preview") {
@@ -5181,6 +5340,7 @@ private openhands.skill @defaults("name") @maturity("preview") {
 }
 
 // Qwen Code (Alibaba) instance
+//
 // Examine installed skills
 // URL: https://qwen.ai/qwencode
 qwen.code @defaults("configPath") @maturity("preview") {


### PR DESCRIPTION
## Summary
Follow-up to #7579. Splits each 2-line top-level resource doc-comment with an empty `//` between the identity line and the action-verb line, so the two sentences read as separate paragraphs:

```
// Apache2 HTTP Server
//
// Examine server configuration and daemon version
apache2 { ... }
```

For AI-assistant resources the separator goes before the `Examine` line only; the `URL:` line stays attached:

```
// Claude Code (Anthropic CLI agent) instance
//
// Examine account, plugins, skills, projects, and configured MCP servers
// URL: https://claude.ai/code
claude.code @defaults("configPath") @maturity("preview") { ... }
```

160 blank `//` lines added, all at column 0 (resource-level only — no field-level comments touched).

## Test plan
- [x] All 160 insertions are at column 0 (verified via diff)
- [x] `mqlr generate` runs clean — no `.lr.versions` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)