### PR TITLE
📄 providers: 2-line top-level resource descriptions (in progress)

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -129,6 +129,7 @@ datastream
 DATAUSER
 DBFS
 DBRS
+DCs
 ddl
 ddos
 dedup
@@ -202,6 +203,7 @@ gcfs
 gcs
 gelf
 GENEVE
+geocode
 geomatchstatement
 GHSA
 gistfile
@@ -505,6 +507,7 @@ selfservice
 sentinelone
 serde
 serviceconnection
+servicedesk
 serviceprincipals
 Sflags
 sfn

--- a/providers/activedirectory/resources/activedirectory.lr
+++ b/providers/activedirectory/resources/activedirectory.lr
@@ -5,6 +5,8 @@ option provider = "go.mondoo.com/mql/v13/providers/activedirectory"
 option go_package = "go.mondoo.com/mql/v13/providers/activedirectory/resources"
 
 // Active Directory Domain Services
+//
+// Examine the domain, its controllers, principals, GPOs, ADCS templates, trusts, password policy, and DC hardening signals
 activedirectory @defaults("domain functionalLevel") {
   // Domain DNS name (e.g., corp.example.com)
   domain string
@@ -74,7 +76,9 @@ activedirectory @defaults("domain functionalLevel") {
   ldapChannelBindingRequired() bool
 }
 
-// Active Directory Domain Controller
+// Active Directory domain controller
+//
+// Examine hostname, OS version, role flags (Global Catalog, RODC), site, and recent password / logon timestamps
 activedirectory.domainController @defaults("name operatingSystem") {
   // DNS hostname
   name string
@@ -96,7 +100,9 @@ activedirectory.domainController @defaults("name operatingSystem") {
   site string
 }
 
-// Active Directory default domain password policy
+// Active Directory default-domain password policy
+//
+// Examine length, age, history, complexity, lockout, and reversible-encryption settings applied to users without a fine-grained policy
 activedirectory.domainPasswordPolicy @defaults("minPasswordLength maxPasswordAge lockoutThreshold") {
   // Minimum password length
   minPasswordLength int
@@ -118,7 +124,9 @@ activedirectory.domainPasswordPolicy @defaults("minPasswordLength maxPasswordAge
   lockoutObservationWindow int
 }
 
-// Active Directory Fine-Grained Password Policy
+// Active Directory fine-grained password policy
+//
+// Examine per-PSO length, age, history, complexity, lockout overrides, precedence, and the principals it applies to
 activedirectory.fineGrainedPasswordPolicy @defaults("name precedence minPasswordLength") {
   // Policy name
   name string
@@ -147,6 +155,8 @@ activedirectory.fineGrainedPasswordPolicy @defaults("name precedence minPassword
 }
 
 // Active Directory user account
+//
+// Examine identity, UAC flags, group memberships, SPNs, delegation, password aging, and Kerberos / privilege risk indicators
 activedirectory.user @defaults("sAMAccountName displayName enabled") {
   // sAMAccountName (pre-Windows 2000 logon name)
   sAMAccountName string
@@ -219,6 +229,8 @@ activedirectory.user @defaults("sAMAccountName displayName enabled") {
 }
 
 // Active Directory group
+//
+// Examine name, type (security/distribution, scope), members, member count, privileged-group status, and OU placement
 activedirectory.group @defaults("sAMAccountName groupType") {
   // sAMAccountName
   sAMAccountName string
@@ -261,6 +273,8 @@ activedirectory.groupMember @defaults("name type") {
 }
 
 // Active Directory computer account
+//
+// Examine OS, UAC flags, delegation (unconstrained / constrained / RBCD), SPNs, LAPS state, password aging, and DC role
 activedirectory.computer @defaults("name operatingSystem enabled") {
   // sAMAccountName (includes trailing $)
   sAMAccountName string
@@ -316,7 +330,9 @@ activedirectory.computer @defaults("name operatingSystem enabled") {
   protocolTransition bool
 }
 
-// Active Directory Organizational Unit
+// Active Directory organizational unit
+//
+// Examine the OU's identity, GPO inheritance / linked GPOs, and creation timestamp
 activedirectory.ou @defaults("name") {
   // OU name
   name string
@@ -333,6 +349,8 @@ activedirectory.ou @defaults("name") {
 }
 
 // Active Directory Group Policy Object
+//
+// Examine the GPO's identity, status, SYSVOL path, link metadata, and version
 activedirectory.gpo @defaults("displayName") {
   // GPO GUID
   id string
@@ -369,6 +387,8 @@ activedirectory.gpoLink @defaults("target") {
 }
 
 // Active Directory domain trust
+//
+// Examine trust type, direction, transitivity, encryption (AES vs RC4), TGT delegation, SID filtering, and selective authentication
 activedirectory.trust @defaults("targetDomain trustType trustDirection") {
   // Target domain name
   targetDomain string
@@ -401,6 +421,8 @@ activedirectory.trust @defaults("targetDomain trustType trustDirection") {
 }
 
 // Active Directory Certificate Services template
+//
+// Examine EKUs, enrollment flags, manager approval, enrollment ACLs, and ESC1 / ESC2 / ESC3 / ESC4 / ESC9 / ESC13 vulnerability indicators
 activedirectory.certificateTemplate @defaults("name") {
   // Template common name
   name string
@@ -462,7 +484,9 @@ activedirectory.certificateTemplate @defaults("name") {
   isVulnerableESC13 bool
 }
 
-// Active Directory Certificate Authority (Enrollment Service)
+// Active Directory Certificate Services certificate authority
+//
+// Examine published templates, ManageCA / ManageCertificates ACLs (ESC7), HTTP enrollment endpoints (ESC8), and enrollment-agent restrictions
 activedirectory.certificateAuthority @defaults("name") {
   // CA name
   name string
@@ -488,7 +512,9 @@ activedirectory.certificateAuthority @defaults("name") {
   enrollmentAgentRestrictionsConfigured bool
 }
 
-// Active Directory PKI object under CN=Public Key Services for ESC5 analysis
+// Active Directory PKI object under CN=Public Key Services
+//
+// Examine object class and dangerous write-equivalent ACLs that enable ESC5 takeover of the AD CS environment
 activedirectory.pkiObject @defaults("name objectClass") {
   // Relative name of the PKI object
   name string
@@ -507,6 +533,8 @@ activedirectory.pkiObject @defaults("name objectClass") {
 }
 
 // Active Directory-integrated DNS zone
+//
+// Examine zone type and dynamic-update policy (open, secure-only, or disabled)
 activedirectory.dnsZone @defaults("name") {
   // Zone name
   name string
@@ -520,11 +548,9 @@ activedirectory.dnsZone @defaults("name") {
   secureOnly bool
 }
 
-// Dangerous ACL delegation found on a critical AD object.
-// These represent attack paths where a low-privilege principal holds
-// powerful rights (GenericAll, WriteDACL, WriteOwner, DCSync, etc.)
-// on sensitive objects like the domain head, AdminSDHolder, or
-// privileged group/DC computer accounts.
+// Dangerous ACL delegation on a critical AD object
+//
+// Examine attack paths where a low-privilege principal holds powerful rights (GenericAll, WriteDACL, WriteOwner, GenericWrite, DCSync, ForceChangePassword) on sensitive objects like the domain head, AdminSDHolder, or privileged group / DC accounts
 activedirectory.dangerousPermission @defaults("targetName rightType principalSID") {
   // DN of the AD object with the dangerous ACL
   targetDN string

--- a/providers/activedirectory/resources/activedirectory.lr
+++ b/providers/activedirectory/resources/activedirectory.lr
@@ -6,7 +6,19 @@ option go_package = "go.mondoo.com/mql/v13/providers/activedirectory/resources"
 
 // Active Directory Domain Services
 //
-// Examine the domain, its controllers, principals, GPOs, ADCS templates, trusts, password policy, and DC hardening signals
+// Top-level entry point for an Active Directory domain accessed over LDAP
+// against a domain controller. Exposes the domain's identity (DNS name,
+// NetBIOS name, distinguished name, SID, functional level, forest), the
+// principals (users, groups, computers), the OU and GPO topology, the
+// domain trusts, the default and fine-grained password policies, the
+// AD CS surface (certificate templates, certificate authorities, PKI
+// objects under CN=Public Key Services), DNS-integrated zones, and the
+// hardening signals auditors check on the contacted DC — LDAP signing,
+// LDAP channel binding, SMB signing, SMBv1 still accepted, SMB3 encryption,
+// SMB null / guest sessions, the highest negotiated SMB dialect — plus
+// metadata used by attack-path tooling (LAPS schema extension, machine-
+// account quota, AD Recycle Bin, schema version) and the dangerous-ACL
+// delegations across critical objects.
 activedirectory @defaults("domain functionalLevel") {
   // Domain DNS name (e.g., corp.example.com)
   domain string
@@ -78,7 +90,11 @@ activedirectory @defaults("domain functionalLevel") {
 
 // Active Directory domain controller
 //
-// Examine hostname, OS version, role flags (Global Catalog, RODC), site, and recent password / logon timestamps
+// Examine a single domain controller computer object: DNS hostname,
+// distinguished name, OS name and version, role flags (Global Catalog,
+// Read-Only DC), site placement, and the most recent password-set and
+// logon-timestamp values. Use it to inventory DCs, find unsupported OS
+// versions, and detect DCs that haven't replicated recently.
 activedirectory.domainController @defaults("name operatingSystem") {
   // DNS hostname
   name string
@@ -102,7 +118,13 @@ activedirectory.domainController @defaults("name operatingSystem") {
 
 // Active Directory default-domain password policy
 //
-// Examine length, age, history, complexity, lockout, and reversible-encryption settings applied to users without a fine-grained policy
+// Examine the password policy applied to every user that isn't covered
+// by a fine-grained policy: minimum / maximum password age, minimum
+// length, password-history depth, complexity-required flag, and the
+// reversible-encryption flag (which weakens password storage). Also
+// exposes the account-lockout configuration: threshold, duration, and
+// observation window. Auditors read this to verify the domain meets
+// password and lockout benchmarks.
 activedirectory.domainPasswordPolicy @defaults("minPasswordLength maxPasswordAge lockoutThreshold") {
   // Minimum password length
   minPasswordLength int
@@ -126,7 +148,14 @@ activedirectory.domainPasswordPolicy @defaults("minPasswordLength maxPasswordAge
 
 // Active Directory fine-grained password policy
 //
-// Examine per-PSO length, age, history, complexity, lockout overrides, precedence, and the principals it applies to
+// Examine a single Password Settings Object (PSO) that overrides the
+// default-domain password policy for a specific set of principals:
+// minimum / maximum age, minimum length, history depth, complexity-
+// required flag, reversible-encryption flag, and the lockout threshold
+// and duration. Each PSO carries a precedence (lower wins) and an
+// `appliesTo` list naming the users or groups it covers. Use it to
+// confirm that privileged groups are bound to a stronger PSO than the
+// default domain policy.
 activedirectory.fineGrainedPasswordPolicy @defaults("name precedence minPasswordLength") {
   // Policy name
   name string
@@ -156,7 +185,22 @@ activedirectory.fineGrainedPasswordPolicy @defaults("name precedence minPassword
 
 // Active Directory user account
 //
-// Examine identity, UAC flags, group memberships, SPNs, delegation, password aging, and Kerberos / privilege risk indicators
+// Examine a single user object: identity (sAMAccountName, UPN, display
+// name, distinguished name, SID), enabled state, lifecycle timestamps
+// (creation, password-last-set, last-logon, password age, days-since-
+// last-logon), group memberships, OU placement, email and description
+// fields, and SID history. The resource also surfaces the security-
+// relevant userAccountControl flags as named booleans (password never
+// expires, password not required, sensitive-and-cannot-be-delegated,
+// reversible-encryption, DES-only Kerberos, AS-REP-roastable via
+// pre-auth-not-required) plus the delegation surface (Service Principal
+// Names, Kerberoastable flag, constrained-delegation targets, GMSA
+// flag, Protected Users membership), the adminCount flag indicating
+// adminSDHolder protection, and convenience predicates for Domain
+// Admins / Enterprise Admins / Schema Admins / generic privileged-group
+// membership and stale-account state — the surface auditors use for
+// privilege reviews, Kerberos-attack-path analysis, and dormant-account
+// hygiene.
 activedirectory.user @defaults("sAMAccountName displayName enabled") {
   // sAMAccountName (pre-Windows 2000 logon name)
   sAMAccountName string
@@ -230,7 +274,14 @@ activedirectory.user @defaults("sAMAccountName displayName enabled") {
 
 // Active Directory group
 //
-// Examine name, type (security/distribution, scope), members, member count, privileged-group status, and OU placement
+// Examine a single group object: identity (sAMAccountName, distinguished
+// name, display name, SID), the human-readable groupType description
+// (Security vs Distribution, Global / Universal / DomainLocal scope) plus
+// the raw groupType bitmask, description, adminCount flag, OU placement,
+// and creation timestamp. Iterate `members()` for typed user / group /
+// computer references and use `memberCount()` for size-based rules; the
+// `isPrivileged` flag highlights built-in privileged groups that warrant
+// extra scrutiny in access reviews.
 activedirectory.group @defaults("sAMAccountName groupType") {
   // sAMAccountName
   sAMAccountName string
@@ -274,7 +325,17 @@ activedirectory.groupMember @defaults("name type") {
 
 // Active Directory computer account
 //
-// Examine OS, UAC flags, delegation (unconstrained / constrained / RBCD), SPNs, LAPS state, password aging, and DC role
+// Examine a single computer object: identity (sAMAccountName with the
+// trailing `$`, DNS hostname, distinguished name, SID), enabled state,
+// the OS name / version / service pack, lifecycle timestamps (created,
+// password-last-set, last-logon-timestamp, password age, days-since-
+// last-logon, stale flag), the raw userAccountControl bitmask plus
+// delegation surface (unconstrained delegation, constrained delegation
+// and its targets, resource-based constrained delegation, protocol
+// transition / TRUSTED_TO_AUTH_FOR_DELEGATION), the configured Service
+// Principal Names, LAPS deployment and password expiration, OU placement,
+// and whether the computer is a domain controller. Used for inventory,
+// stale-machine cleanup, and Kerberos-delegation attack-path reviews.
 activedirectory.computer @defaults("name operatingSystem enabled") {
   // sAMAccountName (includes trailing $)
   sAMAccountName string
@@ -332,7 +393,11 @@ activedirectory.computer @defaults("name operatingSystem enabled") {
 
 // Active Directory organizational unit
 //
-// Examine the OU's identity, GPO inheritance / linked GPOs, and creation timestamp
+// Examine a single OU: name, distinguished name, description, creation
+// timestamp, whether GPO inheritance is blocked, and the typed list of
+// linked GPOs in link order. OUs are the unit of policy delegation and
+// scoping, so they're the primary container audits walk to find where a
+// GPO actually applies and whether inheritance is being short-circuited.
 activedirectory.ou @defaults("name") {
   // OU name
   name string
@@ -350,7 +415,13 @@ activedirectory.ou @defaults("name") {
 
 // Active Directory Group Policy Object
 //
-// Examine the GPO's identity, status, SYSVOL path, link metadata, and version
+// Examine a single GPO: GUID and display name, distinguished name, GPO
+// status (enabled / disabled / user-side disabled / computer-side
+// disabled), SYSVOL file-system path containing the policy template,
+// version number, creation and last-modified timestamps, whether the
+// GPO is linked anywhere, and the per-link metadata (target OU/domain/
+// site, link order, enforced flag, enabled flag) showing exactly where
+// the policy applies.
 activedirectory.gpo @defaults("displayName") {
   // GPO GUID
   id string
@@ -388,7 +459,14 @@ activedirectory.gpoLink @defaults("target") {
 
 // Active Directory domain trust
 //
-// Examine trust type, direction, transitivity, encryption (AES vs RC4), TGT delegation, SID filtering, and selective authentication
+// Examine a single trust relationship from the source domain to a target
+// domain: trust type (External, Forest, ParentChild, CrossLink, MIT),
+// trust direction (Inbound / Outbound / Bidirectional), transitivity,
+// the cryptographic posture (AES vs weak RC4 encryption), TGT-delegation
+// flag, SID filtering and SID-history flags, selective-authentication
+// flag, the Azure-AD-trust marker, the raw trust-attributes bitmask, and
+// the trust creation timestamp. Used for forest-attack-path reviews and
+// confirming hardening of cross-domain authentication.
 activedirectory.trust @defaults("targetDomain trustType trustDirection") {
   // Target domain name
   targetDomain string
@@ -422,7 +500,19 @@ activedirectory.trust @defaults("targetDomain trustType trustDirection") {
 
 // Active Directory Certificate Services template
 //
-// Examine EKUs, enrollment flags, manager approval, enrollment ACLs, and ESC1 / ESC2 / ESC3 / ESC4 / ESC9 / ESC13 vulnerability indicators
+// Examine a single AD CS certificate template: identity (common name,
+// display name, distinguished name, OID, schema version), the validity
+// and renewal periods, whether the template is published on at least
+// one Enterprise CA, and the security-relevant configuration:
+// enrollee-supplies-subject (ESC1 indicator), the EKU set including
+// authentication / Any-Purpose / no-EKU markers, the manager-approval
+// requirement, authorized-signature count, the raw msPKI-Enrollment-Flag
+// and msPKI-Certificate-Name-Flag bitmasks, the issuance-policy OID
+// list, and the enrollment ACL with a low-privileged-enrollment marker.
+// Pre-computed boolean flags surface AD CS escalation risks (ESC1,
+// ESC2, ESC3, ESC4, ESC9 from no-security-extension, ESC13 via
+// privileged-group-linked issuance policy) so policies can fire
+// directly on those.
 activedirectory.certificateTemplate @defaults("name") {
   // Template common name
   name string
@@ -486,7 +576,15 @@ activedirectory.certificateTemplate @defaults("name") {
 
 // Active Directory Certificate Services certificate authority
 //
-// Examine published templates, ManageCA / ManageCertificates ACLs (ESC7), HTTP enrollment endpoints (ESC8), and enrollment-agent restrictions
+// Examine a single Enterprise CA's enrollment-service entry: identity,
+// distinguished name, the DNS hostname of the CA server, CA type
+// (Enterprise Root, Enterprise Subordinate, etc.), the CA certificate
+// expiration, and the templates published on this CA. Surfaces the
+// security-relevant ACLs and endpoints — whether any low-privileged
+// principal holds ManageCA or ManageCertificates rights (ESC7) along
+// with the principal list, whether the CA exposes HTTP (non-TLS)
+// enrollment endpoints (ESC8) along with the endpoint URLs, and
+// whether enrollment-agent restrictions are configured.
 activedirectory.certificateAuthority @defaults("name") {
   // CA name
   name string
@@ -514,7 +612,13 @@ activedirectory.certificateAuthority @defaults("name") {
 
 // Active Directory PKI object under CN=Public Key Services
 //
-// Examine object class and dangerous write-equivalent ACLs that enable ESC5 takeover of the AD CS environment
+// Examine a single PKI container or object below `CN=Public Key
+// Services,CN=Services,CN=Configuration` (NTAuthCertificates, AIA, the
+// Certificate Templates container, Enrollment Services, etc.): name,
+// distinguished name, primary object class, and its lifecycle
+// timestamps. The `isVulnerableESC5` flag and `dangerousAclPrincipals`
+// list highlight write-equivalent ACL grants on these objects, which
+// allow domain-wide AD CS takeover.
 activedirectory.pkiObject @defaults("name objectClass") {
   // Relative name of the PKI object
   name string
@@ -534,7 +638,12 @@ activedirectory.pkiObject @defaults("name objectClass") {
 
 // Active Directory-integrated DNS zone
 //
-// Examine zone type and dynamic-update policy (open, secure-only, or disabled)
+// Examine a DNS zone whose records are stored in AD itself: zone name,
+// distinguished name, zone type (forward / reverse / stub / etc.), and
+// the dynamic-update posture — whether dynamic updates are accepted at
+// all and whether the zone is restricted to secure-only updates. The
+// combination of these two flags is the standard "DNS hardening"
+// finding for AD-integrated zones.
 activedirectory.dnsZone @defaults("name") {
   // Zone name
   name string
@@ -550,7 +659,15 @@ activedirectory.dnsZone @defaults("name") {
 
 // Dangerous ACL delegation on a critical AD object
 //
-// Examine attack paths where a low-privilege principal holds powerful rights (GenericAll, WriteDACL, WriteOwner, GenericWrite, DCSync, ForceChangePassword) on sensitive objects like the domain head, AdminSDHolder, or privileged group / DC accounts
+// Examine a single attack-path finding where a low-privileged principal
+// holds rights — GenericAll, WriteDACL, WriteOwner, GenericWrite,
+// DCSync, ForceChangePassword — on a sensitive Active Directory object.
+// Each finding records the target distinguished name and friendly name,
+// the target category (domain head, AdminSDHolder, privileged group, DC
+// computer, user, or OU), the principal SID that received the grant,
+// the type of right granted, and the raw access mask. Iterating
+// `activedirectory.dangerousPermissions` surfaces the canonical AD
+// take-over primitives auditors check for.
 activedirectory.dangerousPermission @defaults("targetName rightType principalSID") {
   // DN of the AD object with the dangerous ACL
   targetDN string

--- a/providers/ansible/resources/ansible.lr
+++ b/providers/ansible/resources/ansible.lr
@@ -4,13 +4,24 @@
 option provider = "go.mondoo.com/mql/v13/providers/ansible"
 option go_package = "go.mondoo.com/mql/v13/providers/ansible/resources"
 
-// Ansible playbook configuration
+// Ansible playbook
+//
+// Entry point for static analysis of an Ansible playbook file. Exposes the
+// list of plays so audits can inspect what each play targets, what privileges
+// it escalates to, and which tasks and handlers it runs — without executing
+// the playbook against any inventory.
 ansible {
   // Plays defined in the playbook
   plays() []ansible.play
 }
 
-// Ansible play targeting hosts with tasks
+// Ansible play within a playbook
+//
+// Examine which hosts a play targets, which user it connects as, whether it
+// uses become / sudo (and to which user via which method), the fact-gathering
+// policy, the failure-handling strategy (max_fail_percentage, any_errors_fatal,
+// ignore_unreachable), and the variables, roles, tasks, and handlers it
+// declares.
 ansible.play @defaults("name") {
   // Play name displayed during execution
   name string
@@ -46,7 +57,12 @@ ansible.play @defaults("name") {
   handlers() []ansible.handler
 }
 
-// Ansible task within a play
+// Ansible task within a play or block
+//
+// Examine the module action and arguments, conditional execution (when /
+// failed_when / changed_when), task-level variables, registered output, the
+// handlers it notifies, any imported / included playbooks or task files, and
+// nested block / rescue tasks for error handling.
 ansible.task @defaults("name"){
   // Task name displayed during execution
   name string
@@ -79,6 +95,9 @@ ansible.task @defaults("name"){
 }
 
 // Ansible handler triggered by task notifications
+//
+// Examine the name a task references via `notify` and the module action the
+// handler runs once at the end of a play when notified.
 ansible.handler @defaults("name"){
   // Handler name (referenced in notify)
   name string

--- a/providers/arista/resources/arista.lr
+++ b/providers/arista/resources/arista.lr
@@ -5,6 +5,13 @@ option provider = "go.mondoo.com/cnquery/v9/providers/arista"
 option go_package = "go.mondoo.com/mql/v13/providers/arista/resources"
 
 // Arista EOS network operating system
+//
+// Top-level entry point for an Arista EOS device. Exposes system identity
+// (hostname, FQDN, software/hardware version), the data-plane and management
+// surfaces (interfaces, IP interfaces, switchports, VLANs, routes, BGP, MLAG,
+// ACLs), the management-plane services (SSH, telnet, SNMP, NTP), the AAA
+// stack, control-plane policing, and the local user / role / password-policy
+// hardening that auditors check against CIS / DISA STIG benchmarks.
 arista.eos {
   // System configuration key-value pairs
   systemConfig() map[string]string
@@ -56,13 +63,21 @@ arista.eos {
   portSecurity() []arista.eos.portSecurity
 }
 
-// Arista EOS system's operating configuration
+// Arista EOS running-config (full device configuration)
+//
+// Examine the raw running-config text emitted by `show running-config` for
+// pattern matching, line-oriented audits, or as a fall-through when a more
+// specific typed resource isn't available.
 arista.eos.runningConfig {
   // EOS running-config
   content() string
 }
 
-// Arista EOS system's operating configuration for a specific section
+// Section of the Arista EOS running-config
+//
+// Examine a single named section of the running-config (e.g., a specific
+// interface block or AAA section) when you need the raw text for one
+// configuration block rather than the whole device.
 arista.eos.runningConfig.section {
   // Section name
   name string
@@ -70,7 +85,12 @@ arista.eos.runningConfig.section {
   content() string
 }
 
-// Arista EOS local user
+// Arista EOS local user account
+//
+// Examine username, privilege level, assigned role, password / no-password
+// state and encoding, configured SSH key, and whether the account is locked
+// out. Useful for finding privilege-15 users, no-password accounts, weak
+// password encodings, and stale credentials.
 arista.eos.user @defaults("name privilege") {
   // The name of the user
   name string
@@ -100,7 +120,11 @@ private arista.eos.role @defaults("name default"){
   rules []dict
 }
 
-// Arista EOS SNMP information resource
+// Arista EOS SNMP daemon configuration
+//
+// Examine whether SNMP logging is enabled and which trap notifications the
+// device is configured to send. For SNMPv1/v2c community strings (a common
+// hardening finding) see arista.eos.snmpCommunities on the parent device.
 arista.eos.snmpSetting {
   // Whether SNMP logging is enabled
   enabled bool
@@ -109,6 +133,11 @@ arista.eos.snmpSetting {
 }
 
 // Arista EOS NTP configuration and authentication state
+//
+// Examine NTP service status, whether `ntp authenticate` is globally enabled,
+// and the configured NTP authentication keys including their hash algorithm
+// and trusted-key state — required for benchmarks that demand cryptographic
+// protection of time synchronization.
 arista.eos.ntp {
   // Status of NTP on the switch
   status string
@@ -172,13 +201,21 @@ private arista.eos.ipInterface @defaults("name") {
   mtu string
 }
 
-// Arista Spanning Tree Protocol (STP) resource
+// Arista EOS Spanning Tree Protocol (STP) configuration
+//
+// Examine the configured Multiple Spanning Tree Protocol (MST) instances,
+// each of which contains its own bridge / root bridge / regional root /
+// per-interface state.
 arista.eos.stp {
   // Multiple Spanning Tree Protocol (MST) instances
   mstInstances() []arista.eos.stp.mst
 }
 
-// Arista Multiple Spanning Tree Protocol (MSTP) resource instance
+// Arista EOS MST (Multiple Spanning Tree) instance
+//
+// Examine the protocol variant, bridge information (forward delay, MAC,
+// priority), the elected root and regional root bridges, and the interfaces
+// participating in this MST instance.
 arista.eos.stp.mst @defaults("instanceId name") {
   // MST instance number
   instanceId string
@@ -196,7 +233,11 @@ arista.eos.stp.mst @defaults("instanceId name") {
   interfaces []arista.eos.spt.mstInterface
 }
 
-// Multiple Spanning Tree Protocol (MSTP) information for a specified interface
+// Arista EOS MST per-interface state
+//
+// Examine the role, state, priority, cost, link type, and edge-port flag
+// for an interface in a specific MST instance, plus BPDU counters and
+// boundary / inconsistency features.
 arista.eos.spt.mstInterface @defaults("name") {
   id string
   // MST instance number
@@ -229,7 +270,10 @@ arista.eos.spt.mstInterface @defaults("name") {
   features() dict
 }
 
-// Arista EOS VLAN configuration
+// Arista EOS VLAN
+//
+// Examine VLAN ID, name, state (active vs suspend), associated trunk groups,
+// whether it is dynamically learned, and the interfaces assigned to it.
 arista.eos.vlan @defaults("id name") {
   // VLAN ID
   id string
@@ -245,7 +289,11 @@ arista.eos.vlan @defaults("id name") {
   interfaces() []string
 }
 
-// Arista EOS IP route entry
+// Arista EOS IP route
+//
+// Examine destination prefix, VRF, route source (connected, static, BGP,
+// OSPF, etc.), administrative distance / metric, hardware-programmed and
+// kernel-programmed flags, next hops, and whether the route is active.
 arista.eos.route @defaults("destination") {
   // Route destination prefix (e.g., "10.0.0.0/8")
   destination string
@@ -269,7 +317,11 @@ arista.eos.route @defaults("destination") {
   active() bool
 }
 
-// Arista EOS Layer 2 switchport configuration
+// Arista EOS Layer-2 switchport configuration
+//
+// Examine switchport mode (access vs trunk), the access VLAN, the trunk
+// native VLAN, the allowed VLAN list, and any trunk groups — useful for
+// finding misconfigured trunks or unexpected access-VLAN assignments.
 arista.eos.switchport @defaults("name mode") {
   // Interface name
   name string
@@ -286,6 +338,10 @@ arista.eos.switchport @defaults("name mode") {
 }
 
 // Arista EOS BGP configuration
+//
+// Examine whether BGP is enabled, the global AS number and router ID, and
+// the per-VRF BGP configurations including their peers, peer states, prefix
+// counts, and inbound / outbound route maps.
 arista.eos.bgp {
   // Whether BGP is enabled on this device
   enabled() bool
@@ -334,6 +390,10 @@ private arista.eos.bgp.peer @defaults("peerAddress") {
 }
 
 // Arista EOS MLAG (Multi-Chassis Link Aggregation) configuration
+//
+// Examine the MLAG domain ID, local interface used for MLAG control,
+// peer-switch IP, peer-link Port-Channel, administrative shutdown state,
+// and the Port-Channel interfaces that carry an MLAG ID.
 arista.eos.mlag {
   // MLAG domain ID
   domainId() string
@@ -358,6 +418,10 @@ private arista.eos.mlag.interface @defaults("name mlagId") {
 }
 
 // Arista EOS standard IP access control list
+//
+// Examine an ACL by name and iterate its ordered entries — sequence number,
+// permit / deny action, source address and prefix length, and per-rule
+// logging — for connectivity audits and ingress-filtering reviews.
 arista.eos.acl @defaults("name") {
   // ACL name
   name string
@@ -384,6 +448,11 @@ private arista.eos.acl.entry @defaults("sequenceNumber action") {
 }
 
 // Arista EOS hardware environment and inventory
+//
+// Examine power-supply units (state, capacity, output, fan/temperature
+// sensors), cooling fans (status, configured vs current speed), and the
+// hardware inventory of chassis, modules, and transceivers with their
+// serials and revisions.
 arista.eos.hardware {
   // Power supply units
   powerSupplies() []arista.eos.hardware.powerSupply
@@ -450,6 +519,12 @@ private arista.eos.hardware.inventoryItem @defaults("name description serialNumb
 }
 
 // Arista EOS AAA (Authentication, Authorization, Accounting) configuration
+//
+// Examine the configured method lists for login, enable, command/exec
+// authorization, and command/exec accounting, the configured TACACS+ and
+// RADIUS server hosts, and whether the default authentication list permits
+// local-only authentication (a common hardening finding in environments
+// that should require remote AAA).
 arista.eos.aaa {
   // Authentication login method lists (key = list name, e.g. "default")
   authenticationLogin map[string][]string
@@ -472,6 +547,11 @@ arista.eos.aaa {
 }
 
 // Arista EOS management SSH service configuration
+//
+// Examine SSH service enabled state, protocol version, idle timeout, server
+// port, authentication mode, configured cipher / KEX / MAC / hostkey
+// algorithms, and whether `fips restrictions` are applied — the surface
+// auditors check against SSH hardening benchmarks.
 arista.eos.sshSettings {
   // Whether the SSH service is enabled (no shutdown)
   enabled bool
@@ -512,6 +592,11 @@ private arista.eos.snmpCommunity @defaults("name access acl") {
 }
 
 // Arista EOS management telnet service
+//
+// Examine whether a `management telnet` block exists and is actually enabled,
+// the idle timeout, session limits (global and per-host), and any access-list
+// restricting connections. Telnet is a plaintext protocol; benchmarks
+// generally require it to be disabled.
 arista.eos.telnetService {
   // Whether a `management telnet` block exists in the running-config
   configured bool
@@ -528,6 +613,11 @@ arista.eos.telnetService {
 }
 
 // Arista EOS password policy and account-lockout configuration
+//
+// Examine lockout thresholds (failure count, observation window, lock
+// duration), whether no-password remote login is permitted, login event
+// logging, and the configured password-complexity rules (minimum length,
+// digits, uppercase, lowercase, special, repetitive, sequential characters).
 arista.eos.passwordPolicy {
   // Failures allowed before account lockout (0 = lockout not configured)
   lockoutFailure int
@@ -571,6 +661,12 @@ private arista.eos.ntpAuthKey @defaults("id hashAlgo trusted") {
 }
 
 // Arista EOS Control-Plane Policing (CoPP) configuration
+//
+// Examine whether a `control-plane` block is present, whether a service
+// policy is applied, and which IPv4 / IPv6 access-groups are bound to the
+// control plane (with typed references to the underlying ACL resources)
+// — control-plane policing is required for protection against
+// management-plane DoS.
 arista.eos.controlPlanePolicer {
   // Whether a `control-plane` block exists in the running-config
   configured bool

--- a/providers/arista/resources/arista.lr
+++ b/providers/arista/resources/arista.lr
@@ -65,9 +65,12 @@ arista.eos {
 
 // Arista EOS running-config (full device configuration)
 //
-// Examine the raw running-config text emitted by `show running-config` for
-// pattern matching, line-oriented audits, or as a fall-through when a more
-// specific typed resource isn't available.
+// Examine the full running-configuration text as emitted by
+// `show running-config`. `content` is the entire config as one string;
+// use it for pattern matching or line-oriented audits, or as a
+// fall-through when no more specific typed resource exists. To inspect
+// a single block of the configuration use
+// `arista.eos.runningConfig.section(name: "<header>")`.
 arista.eos.runningConfig {
   // EOS running-config
   content() string
@@ -75,9 +78,12 @@ arista.eos.runningConfig {
 
 // Section of the Arista EOS running-config
 //
-// Examine a single named section of the running-config (e.g., a specific
-// interface block or AAA section) when you need the raw text for one
-// configuration block rather than the whole device.
+// Examine a single named section of the running-config when you need the
+// raw text of one configuration block rather than the whole device. The
+// `name` field selects the section as it appears in the running-config —
+// for example `arista.eos.runningConfig.section(name: "interface Ethernet1")`
+// or `... section(name: "router bgp 65001")` — and `content` returns the
+// raw text of that block.
 arista.eos.runningConfig.section {
   // Section name
   name string
@@ -87,10 +93,12 @@ arista.eos.runningConfig.section {
 
 // Arista EOS local user account
 //
-// Examine username, privilege level, assigned role, password / no-password
-// state and encoding, configured SSH key, and whether the account is locked
-// out. Useful for finding privilege-15 users, no-password accounts, weak
-// password encodings, and stale credentials.
+// Examine a single user defined by `username ...` in the running-config:
+// login name, EOS privilege level, assigned role, the no-password and
+// password-encoding fields, the configured SSH key, and whether the
+// account is currently locked out — the input audits use to find
+// privilege-15 accounts, accounts with no password, weak secret
+// encodings, and stale credentials.
 arista.eos.user @defaults("name privilege") {
   // The name of the user
   name string
@@ -122,9 +130,9 @@ private arista.eos.role @defaults("name default"){
 
 // Arista EOS SNMP daemon configuration
 //
-// Examine whether SNMP logging is enabled and which trap notifications the
-// device is configured to send. For SNMPv1/v2c community strings (a common
-// hardening finding) see arista.eos.snmpCommunities on the parent device.
+// Examine whether SNMP logging is enabled and which trap notifications
+// the device is configured to send. For SNMPv1 / v2c community strings
+// — a common hardening finding — see `arista.eos.snmpCommunities`.
 arista.eos.snmpSetting {
   // Whether SNMP logging is enabled
   enabled bool
@@ -134,10 +142,11 @@ arista.eos.snmpSetting {
 
 // Arista EOS NTP configuration and authentication state
 //
-// Examine NTP service status, whether `ntp authenticate` is globally enabled,
-// and the configured NTP authentication keys including their hash algorithm
-// and trusted-key state — required for benchmarks that demand cryptographic
-// protection of time synchronization.
+// Examine the NTP service status, whether `ntp authenticate` is globally
+// enabled, and the configured NTP authentication keys via `authKeys()`
+// — each key's ID, hash algorithm, and `trusted` flag. The combination
+// is what benchmarks check when they require cryptographic protection
+// of time synchronization.
 arista.eos.ntp {
   // Status of NTP on the switch
   status string
@@ -203,9 +212,9 @@ private arista.eos.ipInterface @defaults("name") {
 
 // Arista EOS Spanning Tree Protocol (STP) configuration
 //
-// Examine the configured Multiple Spanning Tree Protocol (MST) instances,
-// each of which contains its own bridge / root bridge / regional root /
-// per-interface state.
+// Examine every configured Multiple Spanning Tree (MST) instance via
+// `mstInstances()`, each with its bridge / root-bridge / regional-root
+// state and per-interface participation.
 arista.eos.stp {
   // Multiple Spanning Tree Protocol (MST) instances
   mstInstances() []arista.eos.stp.mst
@@ -213,9 +222,10 @@ arista.eos.stp {
 
 // Arista EOS MST (Multiple Spanning Tree) instance
 //
-// Examine the protocol variant, bridge information (forward delay, MAC,
-// priority), the elected root and regional root bridges, and the interfaces
-// participating in this MST instance.
+// Examine a single MST instance by `instanceId`: the STP protocol
+// variant, the bridge information (forward delay, MAC, priority), the
+// elected root and regional-root bridges, and the interfaces
+// participating in this instance.
 arista.eos.stp.mst @defaults("instanceId name") {
   // MST instance number
   instanceId string
@@ -235,9 +245,10 @@ arista.eos.stp.mst @defaults("instanceId name") {
 
 // Arista EOS MST per-interface state
 //
-// Examine the role, state, priority, cost, link type, and edge-port flag
-// for an interface in a specific MST instance, plus BPDU counters and
-// boundary / inconsistency features.
+// Examine the per-interface state for one interface inside one MST
+// instance, identified by interface `name` and `mstInstanceId`: the
+// port role and state, priority, cost, link type, and edge-port flag,
+// plus BPDU counters and boundary / inconsistency features.
 arista.eos.spt.mstInterface @defaults("name") {
   id string
   // MST instance number
@@ -272,8 +283,9 @@ arista.eos.spt.mstInterface @defaults("name") {
 
 // Arista EOS VLAN
 //
-// Examine VLAN ID, name, state (active vs suspend), associated trunk groups,
-// whether it is dynamically learned, and the interfaces assigned to it.
+// Examine a single VLAN by its ID: the VLAN name, state (active vs
+// suspend), associated trunk groups, whether it was dynamically
+// learned, and the interfaces assigned to it.
 arista.eos.vlan @defaults("id name") {
   // VLAN ID
   id string
@@ -291,9 +303,12 @@ arista.eos.vlan @defaults("id name") {
 
 // Arista EOS IP route
 //
-// Examine destination prefix, VRF, route source (connected, static, BGP,
-// OSPF, etc.), administrative distance / metric, hardware-programmed and
-// kernel-programmed flags, next hops, and whether the route is active.
+// Examine a single entry in the IP routing table, identified by its
+// `destination` prefix (e.g., "10.0.0.0/8"): the VRF, source protocol
+// (connected, static, BGP, OSPF, …), administrative distance and
+// metric, hardware-programmed and kernel-programmed flags, the
+// next-hop list (interface + next-hop address), the route action, and
+// an `active()` flag indicating whether the route is currently in use.
 arista.eos.route @defaults("destination") {
   // Route destination prefix (e.g., "10.0.0.0/8")
   destination string
@@ -319,9 +334,11 @@ arista.eos.route @defaults("destination") {
 
 // Arista EOS Layer-2 switchport configuration
 //
-// Examine switchport mode (access vs trunk), the access VLAN, the trunk
-// native VLAN, the allowed VLAN list, and any trunk groups — useful for
-// finding misconfigured trunks or unexpected access-VLAN assignments.
+// Examine switchport state for one interface, identified by `name`
+// (e.g., "Ethernet1"): the switchport mode (access vs trunk), the
+// access VLAN, the trunk native VLAN, the allowed-VLAN list, and any
+// trunk groups — useful for finding misconfigured trunks or
+// unexpected access-VLAN assignments.
 arista.eos.switchport @defaults("name mode") {
   // Interface name
   name string
@@ -339,9 +356,10 @@ arista.eos.switchport @defaults("name mode") {
 
 // Arista EOS BGP configuration
 //
-// Examine whether BGP is enabled, the global AS number and router ID, and
-// the per-VRF BGP configurations including their peers, peer states, prefix
-// counts, and inbound / outbound route maps.
+// Examine whether BGP is enabled, the global AS number and router ID,
+// and the per-VRF BGP configurations via `vrfs()` — each VRF lists its
+// peers with their states, prefix counts, and inbound / outbound route
+// maps.
 arista.eos.bgp {
   // Whether BGP is enabled on this device
   enabled() bool
@@ -391,9 +409,10 @@ private arista.eos.bgp.peer @defaults("peerAddress") {
 
 // Arista EOS MLAG (Multi-Chassis Link Aggregation) configuration
 //
-// Examine the MLAG domain ID, local interface used for MLAG control,
-// peer-switch IP, peer-link Port-Channel, administrative shutdown state,
-// and the Port-Channel interfaces that carry an MLAG ID.
+// Examine the MLAG domain ID, the local interface used for MLAG
+// control (typically a VLAN interface), the peer-switch IP, the
+// peer-link Port-Channel, the administrative shutdown flag, and the
+// Port-Channel interfaces that carry an MLAG ID.
 arista.eos.mlag {
   // MLAG domain ID
   domainId() string
@@ -419,9 +438,11 @@ private arista.eos.mlag.interface @defaults("name mlagId") {
 
 // Arista EOS standard IP access control list
 //
-// Examine an ACL by name and iterate its ordered entries — sequence number,
-// permit / deny action, source address and prefix length, and per-rule
-// logging — for connectivity audits and ingress-filtering reviews.
+// Examine a single standard IP access control list by `name`: its type
+// (currently only "standard" is supported by the EOS SDK) and the
+// ordered entries — sequence number, permit / deny action, source
+// address and prefix length, and per-rule logging — used for
+// connectivity audits and ingress-filtering reviews.
 arista.eos.acl @defaults("name") {
   // ACL name
   name string
@@ -449,10 +470,11 @@ private arista.eos.acl.entry @defaults("sequenceNumber action") {
 
 // Arista EOS hardware environment and inventory
 //
-// Examine power-supply units (state, capacity, output, fan/temperature
-// sensors), cooling fans (status, configured vs current speed), and the
-// hardware inventory of chassis, modules, and transceivers with their
-// serials and revisions.
+// Examine the chassis hardware: `powerSupplies()` (each PSU's state,
+// capacity, output, embedded temperature sensors and fans), `fans()`
+// (each cooling fan's status and configured-vs-current speed), and
+// `inventory()` (every chassis / module / transceiver entry with its
+// serial number and hardware revision).
 arista.eos.hardware {
   // Power supply units
   powerSupplies() []arista.eos.hardware.powerSupply

--- a/providers/atlassian/resources/atlassian.lr
+++ b/providers/atlassian/resources/atlassian.lr
@@ -4,7 +4,12 @@
 option provider = "go.mondoo.com/cnquery/v9/providers/atlassian"
 option go_package = "go.mondoo.com/mql/v13/providers/atlassian/resources"
 
-// Atlassian SCIM (Cross-domain Identity Management) provisioning
+// Atlassian SCIM (System for Cross-domain Identity Management) directory
+//
+// Entry point for the SCIM provisioning surface — the source of record for
+// users and groups synced into Atlassian Cloud from an external IdP. Use it
+// to inventory provisioned identities and detect orphans, drift between the
+// IdP and Atlassian, or unexpected group membership.
 atlassian.scim {
   // Provisioned SCIM users
   users() []atlassian.scim.user
@@ -13,6 +18,10 @@ atlassian.scim {
 }
 
 // Atlassian SCIM provisioned user
+//
+// Examine the SCIM identifier, login name, display name, organization
+// membership, and job title for a user provisioned through the SCIM
+// directory.
 atlassian.scim.user @defaults("displayName") {
   // SCIM user ID
   id string
@@ -27,6 +36,9 @@ atlassian.scim.user @defaults("displayName") {
 }
 
 // Atlassian SCIM provisioned group
+//
+// Examine the SCIM group ID and name for a group provisioned through the
+// SCIM directory.
 atlassian.scim.group @defaults("name") {
   // SCIM group ID
   id string
@@ -35,6 +47,12 @@ atlassian.scim.group @defaults("name") {
 }
 
 // Atlassian Admin organization
+//
+// Top-level entry point for Atlassian Admin. Examine the org's identity and
+// type, the security and data-residency policies it enforces, the verified
+// domains it owns, and the users it manages — the surface auditors check
+// for org-wide identity controls (IP allowlists, data residency, verified
+// domains, managed accounts) and access reviews.
 atlassian.admin.organization @defaults("name") {
   // Organization ID
   id string
@@ -50,7 +68,12 @@ atlassian.admin.organization @defaults("name") {
   managedUsers() []atlassian.admin.organization.managedUser
 }
 
-// Atlassian managed user in an organization
+// Atlassian Admin managed user
+//
+// Examine a user managed by an Atlassian organization: account type
+// (atlassian / customer / app), email, status (active / inactive / closed),
+// last-active timestamp, and per-product access — the granularity needed
+// for managed-account access reviews and dormant-account cleanup.
 atlassian.admin.organization.managedUser @defaults("name") {
   // User ID
   id string
@@ -68,7 +91,12 @@ atlassian.admin.organization.managedUser @defaults("name") {
   productAccess []dict
 }
 
-// Atlassian organization policy
+// Atlassian Admin organization policy
+//
+// Examine an organization-level policy (e.g., IP allowlist, data residency)
+// — its identity, type, and enabled / disabled status — to verify the
+// policies an organization is supposed to enforce are actually present and
+// enabled.
 atlassian.admin.organization.policy @defaults("name") {
   // Policy ID
   id string
@@ -82,7 +110,11 @@ atlassian.admin.organization.policy @defaults("name") {
   status string
 }
 
-// Atlassian verified domain
+// Atlassian Admin verified domain
+//
+// Examine a verified email domain attached to an Atlassian organization —
+// its name and verification type — used to scope which user accounts the
+// organization controls.
 atlassian.admin.organization.domain @defaults("name") {
   // Domain ID
   id string
@@ -93,6 +125,12 @@ atlassian.admin.organization.domain @defaults("name") {
 }
 
 // Atlassian Jira instance
+//
+// Top-level entry point for a Jira Cloud / Server / Data Center instance.
+// Examine deployment metadata via serverInfos, all users / groups /
+// projects / issues, and the recent audit-log records — the surface
+// auditors check for least-privilege project permissions, dormant users,
+// and suspicious admin activity.
 atlassian.jira {
   // All Jira users
   users() []atlassian.jira.user
@@ -109,6 +147,11 @@ atlassian.jira {
 }
 
 // Jira audit log record
+//
+// Examine an entry from Jira's audit log: the audited action and category,
+// event source, the principal who triggered it, the originating IP, the
+// target object, and any recorded property changes — the input for
+// detecting privileged-action sequences and authentication anomalies.
 atlassian.jira.auditRecord @defaults("summary createdAt") {
   // Audit record ID
   id int
@@ -135,6 +178,11 @@ atlassian.jira.auditRecord @defaults("summary createdAt") {
 }
 
 // Jira issue (ticket)
+//
+// Examine the full state of a single issue: identity (key, summary,
+// description), workflow state and resolution, parent project, type,
+// priority, labels, the lifecycle timestamps (created, updated, resolved,
+// due), and the typed creator / assignee / reporter user references.
 atlassian.jira.issue @defaults("key summary status") {
   // Issue ID
   id string
@@ -175,6 +223,10 @@ atlassian.jira.issue @defaults("key summary status") {
 }
 
 // Jira server information
+//
+// Examine deployment metadata for the connected Jira instance: base URL,
+// build number, server title, and deployment type (Cloud / Server / Data
+// Center) — useful for version-driven branching in policies.
 atlassian.jira.serverInfo @defaults("serverTitle") {
   // Jira instance base URL
   baseUrl string
@@ -187,6 +239,10 @@ atlassian.jira.serverInfo @defaults("serverTitle") {
 }
 
 // Jira user account
+//
+// Examine an Atlassian account as it appears in Jira: account ID, display
+// name, account type (atlassian / app / customer), avatar, group memberships,
+// and the application roles the user is granted (e.g., jira-software-users).
 atlassian.jira.user @defaults("name") {
   // Atlassian account ID
   id string
@@ -203,6 +259,10 @@ atlassian.jira.user @defaults("name") {
 }
 
 // Jira application role
+//
+// Examine an application-role assignment: its key (e.g., jira-software,
+// jira-servicedesk) and display name. Application roles control which
+// Atlassian products a user is licensed to access.
 atlassian.jira.applicationRole @defaults("name") {
   // Role key
   id string
@@ -211,6 +271,11 @@ atlassian.jira.applicationRole @defaults("name") {
 }
 
 // Jira project
+//
+// Examine a project's identity (id, key, name, UUID, URL, email), its
+// privacy / archived / deleted state, custom properties, and the typed
+// permission scheme attached to it — the unit of access control for
+// project-level audits.
 atlassian.jira.project @defaults("name") {
   // Project ID
   id string
@@ -237,6 +302,10 @@ atlassian.jira.project @defaults("name") {
 }
 
 // Jira permission scheme
+//
+// Examine a permission scheme: identity, description, and the list of
+// permission grants it contains. Use it to verify that schemes attached to
+// projects only grant the permissions they should.
 atlassian.jira.permissionScheme @defaults("name") {
   // Permission scheme ID
   id int
@@ -248,7 +317,12 @@ atlassian.jira.permissionScheme @defaults("name") {
   grants() []atlassian.jira.permissionScheme.grant
 }
 
-// Individual permission grant within a permission scheme
+// Individual permission grant within a Jira permission scheme
+//
+// Examine the permission key being granted (e.g., CREATE_ISSUES,
+// ADMINISTER_PROJECTS), the holder type (user, group, projectRole,
+// applicationRole, anyone), and the holder parameter that selects who
+// receives it. The unit of grant-level project-permission audits.
 atlassian.jira.permissionScheme.grant @defaults("permission holderType") {
   // Grant ID (composite of scheme + grant id)
   id string
@@ -261,12 +335,19 @@ atlassian.jira.permissionScheme.grant @defaults("permission holderType") {
 }
 
 // Jira project custom property
+//
+// Examine the key of a custom property attached to a project — used by
+// Jira apps and integrations to attach scoped configuration to a project.
 atlassian.jira.project.property @defaults("id") {
   // Property key
   id string
 }
 
 // Jira user group
+//
+// Examine a user group used by Jira permission schemes and application
+// roles — its identity and name. Group membership drives most of Jira's
+// access control.
 atlassian.jira.group @defaults("name") {
   // Group ID
   id string
@@ -275,6 +356,11 @@ atlassian.jira.group @defaults("name") {
 }
 
 // Atlassian Confluence instance
+//
+// Top-level entry point for a Confluence Cloud / Server / Data Center
+// instance. Examine all users and all spaces — the surface auditors use
+// to find unprotected content (anonymous- or unlicensed-accessible spaces),
+// inappropriate space-level permissions, and page-level restrictions.
 atlassian.confluence {
   // All Confluence users
   users() []atlassian.confluence.user
@@ -283,6 +369,9 @@ atlassian.confluence {
 }
 
 // Confluence user account
+//
+// Examine an Atlassian account as it appears in Confluence: account ID,
+// display name, and account type (atlassian / app / customer).
 atlassian.confluence.user @defaults("name") {
   // Atlassian account ID
   id string
@@ -306,6 +395,12 @@ private atlassian.confluence.group @defaults("id name") {
 }
 
 // Confluence space
+//
+// Examine a single Confluence space: identity (key, name, id), type
+// (global / personal), status (current / archived), whether anonymous or
+// unlicensed users have any access, the raw permission entries, the typed
+// users and groups they reference, and the pages within the space —
+// everything needed for space-level access reviews.
 atlassian.confluence.space @defaults("name key type") {
   // Numeric space ID
   id int
@@ -332,6 +427,11 @@ atlassian.confluence.space @defaults("name key type") {
 }
 
 // Confluence page (content with type=page)
+//
+// Examine a single page: identity, status (current / trashed / draft), the
+// space it lives in, whether any explicit read or update restrictions are
+// applied, and the per-operation restriction set with its users and groups
+// — the unit of page-level access reviews.
 atlassian.confluence.page @defaults("title status") {
   // Content ID
   id string
@@ -350,6 +450,10 @@ atlassian.confluence.page @defaults("title status") {
 }
 
 // Per-operation restriction on a Confluence page
+//
+// Examine which Atlassian accounts and groups hold read or update access on
+// a page that has explicit restrictions configured, both as raw IDs / names
+// and as typed user / group references.
 atlassian.confluence.page.restriction @defaults("operation") {
   // Identifier of the restriction, unique per (page, operation) pair
   id string

--- a/providers/bicep/resources/bicep.lr
+++ b/providers/bicep/resources/bicep.lr
@@ -4,7 +4,13 @@
 option provider = "go.mondoo.com/mql/v13/providers/bicep"
 option go_package = "go.mondoo.com/mql/v13/providers/bicep/resources"
 
-// Bicep/ARM template analysis
+// Bicep / ARM template static analysis
+//
+// Top-level entry point for analyzing Azure Bicep source or compiled ARM
+// JSON. Exposes the Bicep source files (parameters, variables, resources,
+// modules, outputs) and, when available, the compiled ARM template — the
+// surface for IaC policy checks of Azure infrastructure-as-code without
+// deploying it.
 bicep {
   // All Bicep source files found
   files() []bicep.file
@@ -13,6 +19,11 @@ bicep {
 }
 
 // A Bicep source file
+//
+// Examine a single .bicep file: its target scope (resourceGroup,
+// subscription, managementGroup, tenant), declared parameters / variables /
+// resources / modules / outputs, and the raw file content for pattern
+// matching that the typed views can't express.
 bicep.file @defaults("path") {
   // File path
   path string
@@ -32,7 +43,12 @@ bicep.file @defaults("path") {
   content string
 }
 
-// A parameter declaration
+// Bicep parameter declaration
+//
+// Examine the name, type, default value, @description, @secure flag,
+// @allowed values, and the full raw decorator list — used to flag
+// missing @secure on credential-shaped parameters or unbounded @allowed
+// sets.
 bicep.parameter @defaults("name type") {
   // Parameter name
   name string
@@ -50,7 +66,11 @@ bicep.parameter @defaults("name type") {
   decorators []string
 }
 
-// A variable declaration
+// Bicep variable declaration
+//
+// Examine the variable name, the raw value expression, and any
+// @description decorator — useful for tracking how derived values flow
+// into resource bodies.
 bicep.variable @defaults("name") {
   // Variable name
   name string
@@ -61,6 +81,12 @@ bicep.variable @defaults("name") {
 }
 
 // A resource declaration in Bicep source
+//
+// Examine the symbolic name, Azure resource type and apiVersion, the
+// resolved name and location expressions, the full properties body, the
+// existing-resource flag, conditional-deployment expression, parent /
+// dependsOn relationships, and decorators — the surface IaC policies
+// match against to enforce Azure resource-shape rules.
 bicep.resource @defaults("type symbolicName") {
   // Symbolic name in the Bicep file
   symbolicName string
@@ -86,7 +112,12 @@ bicep.resource @defaults("type symbolicName") {
   decorators []string
 }
 
-// A module reference
+// A Bicep module reference
+//
+// Examine a `module` declaration: symbolic name, source path or registry
+// reference (br: / ts: flags break the source out by kind), scope, the
+// parameter values passed in, conditional-deployment expression,
+// description and decorators — the unit of cross-file Bicep composition.
 bicep.module @defaults("name source") {
   // Symbolic name
   name string
@@ -108,7 +139,11 @@ bicep.module @defaults("name source") {
   decorators []string
 }
 
-// An output declaration
+// A Bicep output declaration
+//
+// Examine an `output` statement: name, type, value expression, and
+// @description — useful for spotting outputs that leak secrets or
+// expose resource IDs unintentionally.
 bicep.output @defaults("name type") {
   // Output name
   name string
@@ -121,6 +156,12 @@ bicep.output @defaults("name type") {
 }
 
 // Compiled ARM template (from ARM JSON input)
+//
+// Examine the resolved schema URL, content version, parameters, variables,
+// resources, and outputs of an ARM template — the post-`bicep build`
+// view, where expressions have been resolved and resources are listed
+// flat. Use this for policy checks that need final values rather than
+// Bicep-level expressions.
 bicep.template @defaults("schema") {
   // ARM schema URL
   schema() string
@@ -137,6 +178,10 @@ bicep.template @defaults("schema") {
 }
 
 // A resource in the compiled ARM template
+//
+// Examine the resolved Azure resource type, apiVersion, name, location,
+// properties, dependsOn list, and the full ARM manifest for a single
+// resource — the form Azure Resource Manager actually deploys.
 bicep.template.resource @defaults("type name") {
   // Azure resource type
   type string

--- a/providers/bicep/resources/bicep.lr
+++ b/providers/bicep/resources/bicep.lr
@@ -4,7 +4,7 @@
 option provider = "go.mondoo.com/mql/v13/providers/bicep"
 option go_package = "go.mondoo.com/mql/v13/providers/bicep/resources"
 
-// Bicep / ARM template static analysis
+// Bicep / ARM template
 //
 // Top-level entry point for analyzing Azure Bicep source or compiled ARM
 // JSON. Exposes the Bicep source files (parameters, variables, resources,
@@ -18,7 +18,7 @@ bicep {
   template() bicep.template
 }
 
-// A Bicep source file
+// Bicep source file
 //
 // Examine a single .bicep file: its target scope (resourceGroup,
 // subscription, managementGroup, tenant), declared parameters / variables /
@@ -80,7 +80,7 @@ bicep.variable @defaults("name") {
   description string
 }
 
-// A resource declaration in Bicep source
+// Bicep resource declaration
 //
 // Examine the symbolic name, Azure resource type and apiVersion, the
 // resolved name and location expressions, the full properties body, the
@@ -112,7 +112,7 @@ bicep.resource @defaults("type symbolicName") {
   decorators []string
 }
 
-// A Bicep module reference
+// Bicep module reference
 //
 // Examine a `module` declaration: symbolic name, source path or registry
 // reference (br: / ts: flags break the source out by kind), scope, the
@@ -139,7 +139,7 @@ bicep.module @defaults("name source") {
   decorators []string
 }
 
-// A Bicep output declaration
+// Bicep output declaration
 //
 // Examine an `output` statement: name, type, value expression, and
 // @description — useful for spotting outputs that leak secrets or
@@ -177,7 +177,7 @@ bicep.template @defaults("schema") {
   outputs() map[string]dict
 }
 
-// A resource in the compiled ARM template
+// Resource in the compiled ARM template
 //
 // Examine the resolved Azure resource type, apiVersion, name, location,
 // properties, dependsOn list, and the full ARM manifest for a single

--- a/providers/cloudformation/resources/cloudformation.lr
+++ b/providers/cloudformation/resources/cloudformation.lr
@@ -4,7 +4,14 @@
 option provider = "go.mondoo.com/mql/v13/providers/cloudformation"
 option go_package = "go.mondoo.com/mql/v13/providers/cloudformation/resources"
 
-// AWS CloudFormation Template
+// AWS CloudFormation template
+//
+// Top-level entry point for static analysis of a CloudFormation template
+// (or SAM template via Transform). Exposes the template metadata
+// (AWSTemplateFormatVersion, Transform, Description), the parameter /
+// mapping / condition / rule / global / metadata sections, the declared
+// resources, the outputs, and the full set of resource types referenced
+// — the surface for IaC policy checks of AWS infrastructure-as-code.
 cloudformation.template @defaults("description") {
   // Template format version
   version string
@@ -32,7 +39,12 @@ cloudformation.template @defaults("description") {
   types() []string
 }
 
-// AWS CloudFormation Resource
+// AWS CloudFormation resource declaration
+//
+// Examine a single declared resource: logical name, AWS resource type,
+// condition, full properties body, attributes, dependsOn list, and the
+// documentation URL — the unit IaC policies match against to enforce
+// resource-shape rules (encryption, public access, tags, etc.).
 cloudformation.resource @defaults("name") {
   // Resource name
   name string
@@ -50,7 +62,11 @@ cloudformation.resource @defaults("name") {
   dependsOn []string
 }
 
-// AWS CloudFormation Output
+// AWS CloudFormation output
+//
+// Examine a single Outputs section entry: name and the properties body
+// (Value, Description, Export, Condition) — useful for spotting outputs
+// that leak resource ARNs, secrets, or sensitive state across stacks.
 cloudformation.output @defaults("name") {
   // Output name
   name string

--- a/providers/depsdev/resources/depsdev.lr
+++ b/providers/depsdev/resources/depsdev.lr
@@ -5,12 +5,22 @@ option provider = "go.mondoo.com/mql/v13/providers/depsdev"
 option go_package = "go.mondoo.com/mql/v13/providers/depsdev/resources"
 
 // deps.dev dependency analysis
+//
+// Top-level entry point for static analysis of a project's direct
+// dependencies via the deps.dev API. Currently exposes Go module
+// dependencies parsed from go.mod, each enriched with version history,
+// upstream project metadata, and OpenSSF Scorecard data.
 depsdev {
   // List of packages from go.mod direct dependencies
   packages() []depsdev.package
 }
 
-// deps.dev Go package information
+// deps.dev Go package metadata
+//
+// Examine a Go module's pinned version, the full version history with
+// publication dates and licenses, the latest published version and its
+// timestamp, and the typed link to the upstream source project — useful
+// for stale-dependency, lagging-patch, and license audits.
 depsdev.package @defaults("name currentVersion latestVersion latestPublished") {
   init(name string)
   // Go module path
@@ -39,7 +49,13 @@ private depsdev.packageVersion @defaults("version publishedAt") {
   licenses []string
 }
 
-// deps.dev source project (GitHub/GitLab repository)
+// deps.dev upstream source project (GitHub / GitLab repository)
+//
+// Examine the upstream repository associated with a package: identity,
+// description, homepage, license, archived state, social-proof signals
+// (stars, forks, open-issue count), and the OpenSSF Scorecard scores
+// — input for supply-chain risk policies (unmaintained / archived
+// dependencies, low-scorecard libraries).
 depsdev.project @defaults("id starsCount forksCount") {
   init(id string)
   // Project identifier (e.g. github.com/rs/zerolog)

--- a/providers/depsdev/resources/depsdev.lr
+++ b/providers/depsdev/resources/depsdev.lr
@@ -4,7 +4,7 @@
 option provider = "go.mondoo.com/mql/v13/providers/depsdev"
 option go_package = "go.mondoo.com/mql/v13/providers/depsdev/resources"
 
-// deps.dev dependency analysis
+// deps.dev dependency catalog
 //
 // Top-level entry point for static analysis of a project's direct
 // dependencies via the deps.dev API. Currently exposes Go module

--- a/providers/equinix/resources/equinix.lr
+++ b/providers/equinix/resources/equinix.lr
@@ -5,6 +5,10 @@ option provider = "go.mondoo.com/cnquery/v9/providers/equinix"
 option go_package = "go.mondoo.com/mql/v13/providers/equinix/resources"
 
 // Equinix Metal project
+//
+// Top-level entry point for an Equinix Metal project. Examine the project's
+// identity and lifecycle timestamps, the parent organization, the SSH keys
+// authorized for it, and the bare-metal devices provisioned within it.
 equinix.metal.project @defaults("name") {
   // Project ID
   id string
@@ -25,6 +29,10 @@ equinix.metal.project @defaults("name") {
 }
 
 // Equinix Metal organization
+//
+// Examine an Equinix Metal organization: identity, contact / billing /
+// address details, credit amount, lifecycle timestamps, and the users
+// who are members of it.
 equinix.metal.organization @defaults("name") {
   // Organization ID
   id string
@@ -91,6 +99,10 @@ private equinix.metal.user @defaults("email") {
 }
 
 // Equinix Metal SSH key
+//
+// Examine an SSH key authorized in Equinix Metal: identity, label, public-
+// key material in OpenSSH format, fingerprint, and lifecycle timestamps —
+// useful for finding shared / orphaned / weak keys across projects.
 equinix.metal.sshkey @defaults("label") {
   // ID of the SSH key
   id string
@@ -108,7 +120,12 @@ equinix.metal.sshkey @defaults("label") {
   url string
 }
 
-// Equinix Metal device
+// Equinix Metal bare-metal device
+//
+// Examine a single provisioned device: identity (id, short ID, URL,
+// hostname, description), current state, lifecycle timestamps, lock state,
+// billing cycle, whether it's a Spot instance, and the operating system
+// it's running.
 equinix.metal.device {
   // Device ID
   id string

--- a/providers/helm/resources/helm.lr
+++ b/providers/helm/resources/helm.lr
@@ -4,7 +4,7 @@
 option provider = "go.mondoo.com/mql/v13/providers/helm"
 option go_package = "go.mondoo.com/mql/v13/providers/helm/resources"
 
-// Helm chart static analysis
+// Helm chart catalog
 //
 // Top-level entry point for analyzing Helm charts. Exposes every parsed
 // chart along with its metadata, templates, rendered Kubernetes resources,
@@ -15,7 +15,7 @@ helm {
   charts() []helm.chart
 }
 
-// A Helm chart
+// Helm chart
 //
 // Examine a chart's Chart.yaml metadata (name, version, apiVersion, type,
 // appVersion, description, keywords, home, sources, icon, deprecated flag),
@@ -59,7 +59,7 @@ helm.chart @defaults("name version") {
   files() []helm.file
 }
 
-// A Helm chart dependency
+// Helm chart dependency
 //
 // Examine an entry from a chart's `dependencies:` list — name, version
 // constraint, repository, conditional-enable expression, tag groupings,
@@ -81,7 +81,7 @@ helm.dependency @defaults("name version") {
   alias string
 }
 
-// A Helm chart maintainer
+// Helm chart maintainer
 //
 // Examine a `maintainers:` entry from Chart.yaml — name, email, and
 // optional URL — useful for supply-chain ownership and contact audits.
@@ -94,7 +94,7 @@ helm.maintainer @defaults("name email") {
   url string
 }
 
-// A Helm template file
+// Helm template file
 //
 // Examine a single file under templates/: its path, the raw Go-template
 // source, the rendered YAML produced by applying the chart's values, the
@@ -114,7 +114,7 @@ helm.template @defaults("name") {
   directives() []helm.directive
 }
 
-// A Go-template directive in a Helm template
+// Go-template directive in a Helm template
 //
 // Examine a single directive (if, range, include, tpl, define, with,
 // block) — type, full expression, and source line — useful for
@@ -129,7 +129,7 @@ helm.directive @defaults("type expression") {
   line int
 }
 
-// A Kubernetes resource rendered from a Helm template
+// Kubernetes resource rendered from a Helm template
 //
 // Examine a Kubernetes manifest produced by rendering a chart with its
 // values: apiVersion, kind, name, namespace, labels, annotations, the full
@@ -154,7 +154,7 @@ helm.resource @defaults("kind name") {
   template() helm.template
 }
 
-// A file within a Helm chart
+// File within a Helm chart
 //
 // Examine a single file shipped with the chart by relative path and lazy
 // content — useful for inspecting NOTES.txt, README, LICENSE, or auxiliary

--- a/providers/helm/resources/helm.lr
+++ b/providers/helm/resources/helm.lr
@@ -4,13 +4,24 @@
 option provider = "go.mondoo.com/mql/v13/providers/helm"
 option go_package = "go.mondoo.com/mql/v13/providers/helm/resources"
 
-// Helm chart analysis
+// Helm chart static analysis
+//
+// Top-level entry point for analyzing Helm charts. Exposes every parsed
+// chart along with its metadata, templates, rendered Kubernetes resources,
+// dependencies, and bundled files — used to enforce policy on
+// Kubernetes manifests before they ever reach a cluster.
 helm {
   // List of all parsed Helm charts
   charts() []helm.chart
 }
 
 // A Helm chart
+//
+// Examine a chart's Chart.yaml metadata (name, version, apiVersion, type,
+// appVersion, description, keywords, home, sources, icon, deprecated flag),
+// its declared dependencies and maintainers, the Go template files, the
+// default values.yaml, every rendered Kubernetes resource, and the chart's
+// files on disk.
 helm.chart @defaults("name version") {
   // Chart name from Chart.yaml
   name string
@@ -49,6 +60,10 @@ helm.chart @defaults("name version") {
 }
 
 // A Helm chart dependency
+//
+// Examine an entry from a chart's `dependencies:` list — name, version
+// constraint, repository, conditional-enable expression, tag groupings,
+// the resolved enabled flag, and any alias.
 helm.dependency @defaults("name version") {
   // Dependency name
   name string
@@ -67,6 +82,9 @@ helm.dependency @defaults("name version") {
 }
 
 // A Helm chart maintainer
+//
+// Examine a `maintainers:` entry from Chart.yaml — name, email, and
+// optional URL — useful for supply-chain ownership and contact audits.
 helm.maintainer @defaults("name email") {
   // Maintainer name
   name string
@@ -77,6 +95,12 @@ helm.maintainer @defaults("name email") {
 }
 
 // A Helm template file
+//
+// Examine a single file under templates/: its path, the raw Go-template
+// source, the rendered YAML produced by applying the chart's values, the
+// Kubernetes resources that render produces, and the directives (if /
+// range / include / tpl / define / with / block) detected in the raw
+// source.
 helm.template @defaults("name") {
   // Template file name (e.g., templates/deployment.yaml)
   name string
@@ -90,7 +114,12 @@ helm.template @defaults("name") {
   directives() []helm.directive
 }
 
-// A Go template directive found in a raw template
+// A Go-template directive in a Helm template
+//
+// Examine a single directive (if, range, include, tpl, define, with,
+// block) — type, full expression, and source line — useful for
+// flagging dynamic constructs that policy can't reason about (e.g., `tpl`
+// of unbounded user input).
 helm.directive @defaults("type expression") {
   // Directive type (if, range, include, tpl, define, with, block)
   type string
@@ -100,7 +129,12 @@ helm.directive @defaults("type expression") {
   line int
 }
 
-// A Kubernetes resource defined in a Helm template
+// A Kubernetes resource rendered from a Helm template
+//
+// Examine a Kubernetes manifest produced by rendering a chart with its
+// values: apiVersion, kind, name, namespace, labels, annotations, the full
+// manifest dict, and the typed reference back to the template that
+// produced it.
 helm.resource @defaults("kind name") {
   // Kubernetes API version
   apiVersion string
@@ -120,7 +154,11 @@ helm.resource @defaults("kind name") {
   template() helm.template
 }
 
-// A file within the Helm chart
+// A file within a Helm chart
+//
+// Examine a single file shipped with the chart by relative path and lazy
+// content — useful for inspecting NOTES.txt, README, LICENSE, or auxiliary
+// scripts.
 helm.file @defaults("path") {
   // File path relative to chart root
   path string

--- a/providers/ipinfo/resources/ipinfo.lr
+++ b/providers/ipinfo/resources/ipinfo.lr
@@ -4,7 +4,13 @@
 option provider = "go.mondoo.com/cnquery/providers/ipinfo"
 option go_package = "go.mondoo.com/mql/v13/providers/ipinfo/resources"
 
-// IP information from ipinfo.io service
+// IP information from the ipinfo.io service
+//
+// Top-level entry point for IP lookups. Given an IP (or your own public
+// IP if none is supplied), examine the resolved hostname, geographic
+// location (city, region, country, EU flag, geocode coordinates, postal,
+// timezone), the owning organization (ASN + name), and whether the address
+// is in a special-use bogon range.
 ipinfo @defaults("returned_ip hostname city") {
   init(ip ip)
   // The IP address that was requested (empty if querying for your public IP)

--- a/providers/ipmi/resources/ipmi.lr
+++ b/providers/ipmi/resources/ipmi.lr
@@ -4,9 +4,12 @@
 option provider = "go.mondoo.com/cnquery/v9/providers/ipmi"
 option go_package = "go.mondoo.com/mql/v13/providers/ipmi/resources"
 
-// Intelligent Platform Management Interface (IPMI) resource
+// Intelligent Platform Management Interface (IPMI)
 //
-// Provides access to BIOS and UEFI configuration
+// Top-level entry point for an IPMI BMC connection. Examine the management
+// controller's device ID (firmware revision, IPMI version, manufacturer,
+// product ID) and its globally unique GUID — the identity an audit needs
+// to confirm out-of-band management firmware before checking chassis state.
 ipmi {
   // The hardware & firmware device ID
   deviceID() dict
@@ -14,7 +17,11 @@ ipmi {
   guid() string
 }
 
-// IPMI system chassis resource
+// IPMI system chassis
+//
+// Examine the high-level chassis status (power state, fault flags, intrusion
+// detection, drive / cooling fault, last power event) and the configured
+// system boot options for a server reachable via IPMI.
 ipmi.chassis {
   // High-level status of the system chassis and main power subsystem
   status() dict

--- a/providers/kustomize/resources/kustomize.lr
+++ b/providers/kustomize/resources/kustomize.lr
@@ -4,13 +4,25 @@
 option provider = "go.mondoo.com/mql/v13/providers/kustomize"
 option go_package = "go.mondoo.com/mql/v13/providers/kustomize/resources"
 
-// Kustomize overlay analysis
+// Kustomize overlay
+//
+// Top-level entry point for analyzing one or more `kustomization.yaml`
+// trees. Exposes every parsed kustomization with its transformer
+// configuration, generators, patches, image overrides, replacements, and
+// the rendered Kubernetes resources — used to enforce policy on
+// Kustomize-driven manifests before they reach a cluster.
 kustomize {
   // List of all parsed kustomizations
   kustomizations() []kustomize.kustomization
 }
 
-// A kustomization.yaml configuration
+// kustomization.yaml configuration
+//
+// Examine a single kustomization: directory path, apiVersion / kind, the
+// namespace / namePrefix / nameSuffix / commonLabels / commonAnnotations
+// transformers, the raw resource and component references, declared patches,
+// ConfigMap and Secret generators, image overrides, replacements, and the
+// final rendered Kubernetes resources after running `kustomize build`.
 kustomize.kustomization @defaults("path") {
   // Path to the kustomization directory
   path string
@@ -46,7 +58,12 @@ kustomize.kustomization @defaults("path") {
   replacements() []kustomize.replacement
 }
 
-// A patch definition (strategic merge or JSON patch)
+// Kustomize patch (strategic merge or JSON patch)
+//
+// Examine a patch's content (inline YAML or file path), its target
+// selector (group, version, kind, name, namespace, label selector,
+// annotation selector) — the unit Kustomize uses to mutate base
+// resources during rendering.
 kustomize.patch @defaults("path") {
   // Patch content (inline YAML or file content)
   content string
@@ -68,7 +85,12 @@ kustomize.patch @defaults("path") {
   targetAnnotationSelector string
 }
 
-// A ConfigMap or Secret generator
+// Kustomize ConfigMap or Secret generator
+//
+// Examine a generator declared in a kustomization: its type (configmap or
+// secret), the literal key=value pairs, included files, env-file sources,
+// merge behavior (create / replace / merge), and namespace — useful for
+// surfacing inline secrets or ConfigMap drift.
 kustomize.generator @defaults("name type") {
   // Generator name
   name string
@@ -86,7 +108,11 @@ kustomize.generator @defaults("name type") {
   namespace string
 }
 
-// An image override
+// Kustomize image override
+//
+// Examine an `images:` entry: the original image name, the optional
+// replacement name, and either a new tag or new digest — used to detect
+// non-pinned tags or unintended image swaps during overlay rendering.
 kustomize.image @defaults("name newTag") {
   // Original image name
   name string
@@ -98,7 +124,12 @@ kustomize.image @defaults("name newTag") {
   digest string
 }
 
-// A rendered Kubernetes resource from kustomize build
+// Rendered Kubernetes resource from `kustomize build`
+//
+// Examine a Kubernetes manifest produced by running Kustomize over the
+// overlay tree: apiVersion, kind, name, namespace, labels, annotations
+// (all post-transformation), and the full manifest dict. Use this to
+// enforce policy on the final manifest a cluster will see.
 kustomize.resource @defaults("kind name") {
   // Kubernetes API version
   apiVersion string

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -28,7 +28,11 @@ extend asset {
 
 // Operating system end-of-life status
 //
-// Check whether the platform has reached vendor end-of-support
+// Examine the End-of-Life metadata Mondoo publishes for the asset's
+// detected operating system or platform: the EoL date itself, a
+// product-page URL, and a documentation URL. Used by audits to flag
+// hosts whose vendor has stopped issuing security patches and to plan
+// migrations before unsupported software accumulates risk.
 asset.eol @defaults("date") {
   // Documentation URL
   docsUrl string
@@ -50,7 +54,14 @@ private mondoo.eol {
 
 // Asset vulnerability assessment
 //
-// Examine CVEs, advisories, and affected packages from the intelligence feed
+// Top-level entry point for vulnerability data Mondoo derives for an
+// asset by joining its installed-package inventory and platform identity
+// against the curated CVE / advisory feed. Exposes every CVE affecting
+// the asset, every vendor advisory that mentions one of those CVEs, the
+// affected packages with their currently-installed and patched-available
+// versions, the timestamp of the last assessment run, and the rolled-up
+// CVSS statistics — the surface used to score asset risk and to drive
+// patch-status policies.
 vulnmgmt {
   // List of all CVEs affecting the asset
   cves() []vuln.cve
@@ -110,9 +121,14 @@ private vuln.package @defaults("name version") {
   arch string
 }
 
-// All platform and package advisories
+// Platform and package advisories
 //
-// Examine vendor advisories with CVSS scores and severity counts
+// Examine the consolidated list of vendor advisories that affect the
+// asset, plus a worst-case CVSS roll-up across all of them and a
+// statistical breakdown by severity (total, critical, high, medium, low,
+// none, unknown). Use it to drive policies that require zero outstanding
+// critical-severity advisories or that compare an asset's advisory load
+// against a baseline.
 platform.advisories {
   []audit.advisory
   // Worst CVSS score for all advisories
@@ -121,9 +137,13 @@ platform.advisories {
   stats() dict
 }
 
-// All platform and package CVEs
+// Platform and package CVEs
 //
-// Examine known CVEs affecting the asset with CVSS scores and severity counts
+// Examine the full list of CVEs that affect the asset's installed
+// packages or platform, plus a worst-case CVSS roll-up across them and
+// a per-severity statistical breakdown (total, critical, high, medium,
+// low, none, unknown). Used to enforce ceilings on outstanding critical
+// or high-severity CVEs and to surface the most urgent fixes.
 platform.cves {
   []audit.cve
   // Worst CVSS score for all CVEs
@@ -180,7 +200,15 @@ private audit.cve {
 
 // Hardware identity from SMBIOS / DMI
 //
-// Examine BIOS, system, baseboard, chassis, CPU, and Secure Boot details
+// Top-level namespace for low-level hardware identity exposed by the
+// firmware. The sub-resources below — `machine.bios`, `machine.system`,
+// `machine.baseboard`, `machine.chassis`, `machine.cpu`, and
+// `machine.secureboot` — surface the SMBIOS / DMI tables (vendor /
+// version / release date for the BIOS, manufacturer / product / SKU /
+// UUID / serial for the system, baseboard and chassis identifiers, CPU
+// socket and core counts) plus the EFI Secure Boot posture read from
+// EFI variables on Linux. Used for inventory, warranty / supply-chain
+// reviews, and platform-firmware compliance.
 machine {}
 
 // SMBIOS BIOS information
@@ -261,7 +289,15 @@ machine.secureboot @defaults("enabled") {
 
 // Operating system information
 //
-// Examine hostname, uptime, environment, and pending updates
+// Top-level entry point for operating-system-level facts about the
+// asset. Examine the pretty hostname (or Windows device name), the
+// FQDN-style hostname, the system's machine ID, the hypervisor it's
+// running under (when virtualized), the running environment variables
+// and the resolved PATH list, the current uptime, the list of available
+// OS updates with their categories and severities, whether a reboot is
+// pending after recent installs, and the current system date / timezone.
+// Used as the cross-platform anchor that audits start from when they
+// need OS identity and patch state.
 os {
   // Pretty hostname on macOS/Linux or device name on Windows
   name() string
@@ -309,7 +345,13 @@ os.update @defaults("name")  {
 
 // Generic operating system information common to all platforms
 //
-// Examine identity, environment, users, groups, and update state
+// Cross-platform OS view that embeds `machine` (firmware / SMBIOS
+// hardware identity) and exposes the fields shared by every supported
+// platform: the pretty hostname (or Windows device name), the
+// FQDN-style hostname, environment variables and the resolved PATH
+// list, uptime, the available-OS-update list, the reboot-pending flag,
+// and the typed `users()` and `groups()` collections. `os.unix` and
+// `os.linux` extend this with platform-specific surfaces.
 os.base {
   embed machine
 
@@ -335,14 +377,24 @@ os.base {
 
 // Operating system information for Unix-like platforms
 //
-// Examine the cross-platform os.base attributes plus Unix-specific surfaces
+// Extends `os.base` for Unix-family operating systems (macOS, Linux,
+// FreeBSD, and similar). Aliases such as `os.base.user` / `os.base.group`
+// / `os.base.file` / `os.base.command` / `os.base.packages` route to
+// concrete Unix resources, and `os.unix.sshd` aliases to the system-wide
+// `sshd` resource so audits can express "examine sshd on the asset"
+// without knowing the exact platform.
 os.unix {
   embed os.base as base
 }
 
 // Operating system information for Linux platforms
 //
-// Examine firewall, fstab, AppArmor, and other Linux-only surfaces
+// Extends `os.unix` (and through it, `os.base`) with Linux-only
+// surfaces: the four supported packet-filter stacks (`iptables`,
+// `ip6tables`, `nftables`, `ufw`, `firewalld`), the `/etc/fstab` mount
+// table, and the AppArmor mandatory-access-control namespace. Use it
+// to write Linux-specific audits without reaching out to global
+// resource handles.
 os.linux {
   embed os.unix as unix
 
@@ -364,7 +416,14 @@ os.linux {
 
 // Operating system root certificate trust store
 //
-// Examine the certificates the OS trusts for TLS validation
+// Examine the X.509 root certificates that the asset's operating system
+// trusts for TLS validation, derived from the platform-appropriate
+// trust-store files (e.g. `/etc/ssl/certs/ca-certificates.crt` on
+// Debian, `/etc/pki/tls/certs/ca-bundle.crt` on RHEL, the macOS
+// SecTrust store, the Windows Root certificate store). The resource
+// lazily reads each trust-store file and exposes the parsed
+// `network.certificate` list so audits can pin specific issuers,
+// detect untrusted local additions, or count the trust-store size.
 os.rootCertificates {
   []certificate(content)
   // List of files that define these certificates
@@ -372,9 +431,15 @@ os.rootCertificates {
   content(files) []string
 }
 
-// Results of running a command on the system
+// Result of running a shell command on the system
 //
-// Examine stdout, stderr, and exit code from arbitrary system commands
+// Provides ad-hoc command execution as an MQL resource. Initialize it
+// with a shell command string; the resource lazily executes the command
+// through the connection (local exec, SSH, container exec, etc.) and
+// surfaces the captured `stdout`, `stderr`, and `exitcode`. Used as a
+// fall-back when there isn't a more specific typed resource for a
+// piece of system state, and for assertions on tool versions or
+// command-line probes.
 command {
   init(command string)
   // Raw contents of the command
@@ -387,9 +452,14 @@ command {
   exitcode(command) int
 }
 
-// Results of running a PowerShell script on the system
+// Result of running a PowerShell script on the system
 //
-// Examine stdout, stderr, and exit code from arbitrary PowerShell scripts
+// Provides ad-hoc PowerShell execution as an MQL resource. Initialize
+// it with a script string; the resource lazily executes the script via
+// PowerShell on the asset and surfaces the captured `stdout`, `stderr`,
+// and `exitcode`. Used as the Windows / cross-platform-PowerShell
+// counterpart to `command` for assertions that need PowerShell-only
+// surface area.
 powershell {
   init(script string)
   // Raw contents of the script
@@ -404,7 +474,15 @@ powershell {
 
 // File on the system
 //
-// Examine path, contents, size, ownership, and POSIX permissions
+// Examine a single file referenced by absolute path. Surfaces the path
+// itself, the basename and dirname, an `exists` flag, the lazily-loaded
+// `content` string, the file's size in bytes, an `empty` predicate, the
+// owning `user` and `group` as typed references, and a structured
+// `permissions` resource that explodes the POSIX mode into named user /
+// group / other read / write / execute bits, the SUID / SGID / sticky
+// bits, the `isFile` / `isDirectory` / `isSymlink` discriminators, and
+// a printed mode string. The unit of file-level audits and the building
+// block most config-file resources read through.
 file @defaults("path size permissions.string") {
   init(path string)
   // Location of the file on the system
@@ -479,7 +557,9 @@ private file.permissions @defaults("string") {
 
 // File search and discovery namespace
 //
-// Use files.find to locate files by name, type, regex, or permissions
+// Empty top-level namespace whose only purpose is to host
+// `files.find`. Used so audits can write `files.find(...) {...}` to
+// locate files on the asset rather than enumerating known paths.
 files {}
 
 // Find files on the system
@@ -600,7 +680,14 @@ parse.openpgp {
 
 // User account on the system
 //
-// Examine UID, group, shell, home, SSH keys, and login state
+// Examine a single local user account: numeric UID and primary GID
+// (Windows SID where applicable), name, home directory, configured
+// login shell, and an `enabled` flag. Surfaces the typed primary
+// `group` reference, the `authorizedkeys` resource that parses the
+// user's `~/.ssh/authorized_keys`, the SSH private keys discovered in
+// the user's home, and a `loggedIn` predicate that reflects whether
+// the user currently has an active session. Used for identity audits,
+// dormant-account hygiene, and SSH-key inventories.
 user @defaults("name uid gid") {
   // User ID
   uid int
@@ -628,7 +715,11 @@ user @defaults("name uid gid") {
 
 // Private key on disk
 //
-// Examine PEM data and whether the key is encrypted
+// Examine a PEM-encoded private key file: the typed `file` reference,
+// the raw PEM `pem` payload, and an `encrypted` flag indicating whether
+// the key uses a passphrase. Used to inventory SSH or service-account
+// keys discovered on the asset and to flag unencrypted private keys
+// stored in user home directories.
 privatekey {
   // PEM data
   pem string
@@ -642,14 +733,24 @@ privatekey {
 
 // All user accounts configured on the system
 //
-// Iterate every user across the asset for filtering and aggregation
+// Iterable collection of every local `user` on the asset. Use it as
+// the entry point for fleet-wide identity audits — e.g., asserting
+// that every account with UID < 1000 is enabled, that no account
+// shares another's home directory, or that no human user has the
+// shell set to `/bin/bash` outside an approved list.
 users {
   []user
 }
 
 // SSH authorized_keys file
 //
-// Examine entries that grant key-based SSH login for a user
+// Examine a single `authorized_keys` file: its path, the typed `file`
+// reference, the raw `content` string, and the parsed `[]entry` list
+// where each entry surfaces the line number, key type, key material,
+// label, and any `command=` / `from=` / `no-port-forwarding` SSH
+// options. Used to audit which keys actually grant SSH access to a
+// given user and to detect entries with no source / command
+// restrictions.
 authorizedkeys {
   []authorizedkeys.entry(file, content)
   init(path string)
@@ -679,7 +780,10 @@ authorizedkeys.entry @defaults("key") {
 
 // Group on the system
 //
-// Examine GID, name, and member users for a single group
+// Examine a single local group: numeric GID (or SID on Windows), group
+// name, and the typed `members()` list of users in the group. Used to
+// audit privileged-group membership (`sudo`, `wheel`, `docker`, `adm`,
+// etc.) and to confirm only expected accounts are present.
 group @defaults("name gid") {
   init(id string)
   // Group ID
@@ -694,14 +798,26 @@ group @defaults("name gid") {
 
 // All groups configured on the system
 //
-// Iterate every group across the asset for filtering and aggregation
+// Iterable collection of every local `group`. Use it as the entry
+// point for fleet-wide group-membership audits (every member of a
+// privileged group, no two groups sharing a GID, no human user in
+// `wheel` outside an approved list, etc.).
 groups {
   []group
 }
 
 // Installed package on the platform or OS
 //
-// Examine name, version, status, package URL, and origin metadata
+// Examine a single package known to the asset's native package
+// manager (rpm, deb, apk, pkg, msi, nuget, pacman, etc.). Surfaces
+// the package name, description, currently-installed `version`,
+// architecture, epoch, package format, install status, package URL,
+// the CPE list mapping the package to NVD identifiers, the package
+// origin, the latest `available` version known to the package
+// manager, the `installed` and `outdated` flags, the file
+// inventory the package contributed, and the package vendor.
+// The unit of asset-level package audits and the join key for
+// vulnerability correlation.
 package @defaults("name version") {
   // May be initialized with the name only, in which case it will look up
   // The package with the given name on the system.
@@ -754,7 +870,9 @@ private pkgFileInfo @defaults("path") {
 
 // All packages installed on the system
 //
-// Iterate the full inventory across the asset's package manager(s)
+// Iterable collection of every `package` known to the asset's native
+// package manager(s). Used as the entry point for fleet-wide patch
+// audits, banned-package checks, and inventory exports.
 packages {
   []package
 }


### PR DESCRIPTION
## Summary
Extends the OS-provider doc-comment pattern from #7579 / #7580 to other providers: every top-level resource gets a short identity title, a blank `//` separator, and a multi-paragraph "Examine ..." summary describing what auditors can query through it. Descriptions are written for the website-rendered resource docs, so depth and prose are favored over single-line brevity.

This PR is **a checkpoint, not the full sweep** — about a third of the providers are covered (small / medium ones plus a richer pass on the OS namespace roots and identity / package surfaces). Big providers (AWS, Azure, GCP, K8s, vSphere, MS365, Cloudflare, GitHub, etc.) and the remainder of OS sub-resources are still TODO.

### Format
```
// Apache2 HTTP Server
//
// Examine server configuration and daemon version. The configuration
// includes loaded modules, virtual hosts, and directory directives.
apache2 { ... }
```
- Line 1: simple, name-like identity (no leading articles, no "analysis" / "static analysis" verb-forms in the title).
- Single blank `//` separator between title and description.
- Multi-paragraph rich description of what's queryable through the resource. AI-assistant resources keep their existing `URL: …` line.

### Coverage in this PR
- **activedirectory** — 14 top-level resources, multi-paragraph rich pass (DC, password / fine-grained policies, user, group, computer, OU, GPO, trust, ADCS templates / CAs / PKI objects, DNS zone, dangerous ACL findings)
- **ansible** — playbook, play, task, handler
- **arista** — 21 EOS resources (running-config, users, AAA, SSH / telnet, SNMP, NTP, STP, VLANs, routes, switchports, BGP, MLAG, ACLs, hardware, password policy, CoPP)
- **atlassian** — SCIM, Admin organization (managed users, policies, domains), Jira (instance, audit log, issue, server info, user, application role, project, permission scheme + grants, group), Confluence (instance, user, space, page, page restrictions)
- **bicep** — Bicep / ARM root, source files, parameters, variables, resources, modules, outputs, compiled templates, template resources
- **cloudformation** — template, resource, output
- **depsdev** — root, package, project (with OpenSSF Scorecard context)
- **equinix** — Metal project, organization, SSH key, device
- **helm** — root, chart, dependency, maintainer, template, directive, rendered resource, file
- **ipinfo** — single root resource
- **ipmi** — root, chassis
- **kustomize** — root, kustomization, patch, generator, image, rendered resource
- **os (partial richer pass)** — asset.eol, vulnmgmt, platform.advisories, platform.cves, machine namespace, os / os.base / os.unix / os.linux / os.rootCertificates, command, powershell, file, files, user / users / group / groups, authorizedkeys, privatekey, package, packages

### Still TODO (separate PR)
- Rest of OS: services, firewalls (iptables / nftables / ufw / firewalld), apparmor / selinux / modprobe, mount / fstab / lsblk / mdadm / zfs, sshd.config, apache2 / nginx / kernel / docker / containerd, registrykey, every `*.packages` ecosystem, macOS / Windows / cloud / network / browsers / editors / AI-assistant configs.
- core, mondoo, nmap, opcua, network, vllm, tailscale, shodan, terraform, vcd, slack, google-workspace, grafana
- gitlab, github, ms365, okta, snowflake, datadog, digitalocean, hetzner, proxmox
- Big ones: vsphere, k8s, cloudflare, oci, gcp, azure, aws

## Test plan
- [x] `mqlr generate` runs clean against modified `.lr` files; no `.lr.versions` changes (descriptions don't bump versions)
- [x] All title lines are name-like (no "static analysis", no leading "A" article)
- [x] Exactly one blank `//` between title and description on every touched resource
- [x] No private resources or pure sub-row types touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)