### PR TITLE
📄 providers: continue 2-line top-level resource description sweep

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -310,6 +310,7 @@ logon
 logpull
 logpush
 logstream
+lon
 LONGTERM
 longtermretentionpolicy
 lsp
@@ -570,6 +571,7 @@ toport
 totp
 tpl
 tpu
+traceroute
 trae
 trainingjob
 transitgateway

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,46 @@ The primary task in this repo is adding or modifying resources. Follow this life
 Resources are defined in `.lr` files (e.g., `providers/aws/resources/aws.lr`). This acts as the GraphQL-like schema.
 *   **Action**: Edit the `.lr` file to add new resources or fields.
 
+#### Resource doc-comment format
+
+Every top-level resource (anything users will query directly — including singular records like `aws.ec2.instance` and namespace roots like `aws`) must have a two-part doc-comment immediately above the `resource {` line:
+
+1. **Title.** A simple, technically correct one-line name for the item — a noun phrase, no leading article ("A" / "An"), no trailing verbs like "static analysis" or "configuration analysis". The title belongs to *what the resource is*, not what you do with it. Deprecated resources keep `DEPRECATED:` at the start of the title.
+2. **Single empty `//` line.**
+3. **Description.** Multi-line prose describing what's queryable through the resource — fields, sub-resources, derived predicates, the audits it enables. Lead with `Examine ...` (or `Iterate ...` for collection wrappers, `Use ...` for namespaces that exist mainly to host other resources). When the resource is keyed by a specific field, mention that field as the selection key with a concrete example. The description gets machine-parsed into the website-rendered resource docs, so favor depth and self-containment over single-line brevity.
+
+```
+// Apache2 HTTP Server
+//
+// Examine server configuration and daemon version. The configuration
+// includes loaded modules, virtual hosts, and directory directives.
+apache2 { ... }
+```
+
+Selection-keyed example:
+
+```
+// Section of the Arista EOS running-config
+//
+// Examine a single named section of the running-config when you need the
+// raw text of one configuration block rather than the whole device. The
+// `name` field selects the section as it appears in the running-config —
+// for example `arista.eos.runningConfig.section(name: "interface Ethernet1")`
+// or `... section(name: "router bgp 65001")` — and `content` returns the
+// raw text of that block.
+arista.eos.runningConfig.section { ... }
+```
+
+**Style rules:**
+- Title is a name-like noun phrase. No leading "A" / "An". No "static analysis" / "configuration analysis" verbs in the title. `DEPRECATED:` stays in the title for deprecated resources.
+- Exactly one blank `//` separator between title and description.
+- Don't reference the parent resource as a navigation hint ("read from the parent device as ...", "iterate from the parent ..."). Just describe what *this* resource examines.
+- Don't use developer jargon ("Singleton", "Top-level entry point" is OK if it adds meaning, otherwise drop it). Write user-facing prose.
+- Cross-reference sibling resources only when it genuinely helps the reader — e.g., pointing from a raw view (`apache2.conf`) at a richer typed view (`apache2.conf.module`).
+- Private resources and pure sub-row types (rows of a parent collection like `*.entry`) typically don't need the two-part form — a single-line comment is fine.
+
+Field-level comments (`// foo bar` above a field declaration) stay as one-line summaries, no blank `//` separator. The two-part form is for the *resource* doc-comment only.
+
 ### Step 2: Code Generation
 **Crucial:** You must generate Go interfaces after modifying `.lr` files.
 ```bash

--- a/providers/core/resources/core.lr
+++ b/providers/core/resources/core.lr
@@ -4,7 +4,13 @@
 option provider = "go.mondoo.com/mql/providers/core"
 option go_package = "go.mondoo.com/mql/v13/providers/core/resources"
 
-// Contextual information about MQL runtime and environment
+// MQL runtime and execution environment
+//
+// Examine the client running the current MQL evaluation: the client
+// version and build identifier, the architecture string, the
+// connection capabilities reported for the active connection, and the
+// `jobEnvironment` dict describing the context the agent is running
+// in (scheduled, interactive, CI, etc.).
 mondoo @defaults("version") {
   // Version of the client running on the asset
   version() string
@@ -18,7 +24,17 @@ mondoo @defaults("version") {
   capabilities() []string
 }
 
-// General asset information
+// Asset identity and platform metadata
+//
+// Examine the basic identity of the asset under evaluation. Surfaces the
+// human-readable name, the full set of asset identifiers, the platform
+// (e.g., redhat, windows, k8s-pod), the platform `kind` (api,
+// baremetal, virtualmachine, container, container-image, network), the
+// specific `runtime` (docker-container, podman-container,
+// aws-ec2-instance, …), the platform version, build, architecture, and
+// pretty `title`, the platform `family` list, the optional FQDN, the
+// per-platform metadata map, and any user-supplied `labels` or
+// `annotations`.
 asset @defaults("name platform version") {
   // Human readable name of the asset
   name string
@@ -50,7 +66,12 @@ asset @defaults("name platform version") {
   annotations map[string]string
 }
 
-// Information about the asset's platform's end of life
+// Asset platform end-of-life status
+//
+// Examine the End-of-Life metadata for the asset's detected platform:
+// the EoL date itself, a vendor product-page URL, and a documentation
+// URL. Used by audits to flag hosts running platforms whose vendor
+// has stopped issuing security patches.
 asset.eol @defaults("date") {
   // Documentation URL
   docsUrl string
@@ -60,7 +81,12 @@ asset.eol @defaults("date") {
   date time
 }
 
-// Date and time functions
+// Date and time helpers
+//
+// Examine helpers for time-aware MQL expressions. `now` returns the
+// current local time; `today` and `tomorrow` return midnight on those
+// days; `second`, `minute`, `hour`, and `day` are unit constants used
+// when computing durations.
 time {
   // The current time on the local system
   now() time
@@ -78,7 +104,12 @@ time {
   tomorrow() time
 }
 
-// Built-in regular expression functions
+// Built-in regular expressions
+//
+// Examine a library of pre-defined regex patterns for common formats:
+// IPv4 / IPv6 addresses, HTTP/HTTPS URLs, email addresses, MAC
+// addresses, hyphen-delimited UUIDs, emoji code points, semantic
+// version numbers, and credit card numbers.
 regex {
   // Matches IPv4 addresses
   ipv4() regex
@@ -100,14 +131,24 @@ regex {
   creditCard() regex
 }
 
-// Common parsers (json, ini, certs, and so on)
+// Common parsers
+//
+// Namespace for cross-cutting parsing helpers that apply to any
+// connection: `parse.date(value, format)` returns a typed `time`
+// from a string and an optional format, and `parse.duration(value)`
+// converts a duration string into a typed `time` interval.
 parse {
   // Built-in functions:
   // date(value, format) time
   // duration(value) time
 }
 
-// UUIDs based on RFC 4122 and DCE 1.1
+// UUID (RFC 4122 / DCE 1.1)
+//
+// Examine a parsed UUID. Initialize with
+// `uuid(value: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")` and inspect
+// the canonical string representation, the URN form
+// (`urn:uuid:...`), the version (1, 4, 5, …), and the variant.
 uuid @defaults("value") {
   init(value string)
   // Canonical string representation xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
@@ -120,7 +161,13 @@ uuid @defaults("value") {
   variant() string
 }
 
-// Common Platform Enumeration (CPE) identifiers
+// Common Platform Enumeration (CPE)
+//
+// Examine a parsed CPE identifier (NIST NVD's structured product
+// identifier). Initialize with `cpe(uri: "cpe:2.3:a:vendor:product:1.0:...")`
+// to break the CPE down into its part designation (a / h / o), vendor,
+// product, version, update, edition, language, software edition,
+// target software, target hardware, and miscellaneous fields.
 cpe @defaults("uri") {
   init(uri string)
   // URI binding of the CPE
@@ -149,7 +196,12 @@ cpe @defaults("uri") {
   other() string
 }
 
-// End of life information for a product
+// Product end-of-life lookup
+//
+// Examine the End-of-Life metadata for an arbitrary named product.
+// Each instance carries a product name and version and exposes a
+// typed `releaseCycle` resource with the matching release-cycle
+// information from Mondoo's product catalog.
 product {
   // Product name
   name string
@@ -181,7 +233,13 @@ private product.releaseCycleInformation {
   link string
 }
 
-// Unicode Text Classification
+// Unicode text classification
+//
+// Examine a Unicode-classified view of an input string. Initialize
+// with `unicode(input: "...")` and inspect the per-character
+// classification (each character's code point, category, and
+// description) and the per-category histogram showing how many
+// characters fall into each Unicode general category.
 unicode @maturity("preview") {
   init(input string)
   // Input text
@@ -220,7 +278,11 @@ private unicode.category @defaults("category count") {
   count int
 }
 
-// Experimental: Vulnerability Exchange information
+// Vulnerability Exchange information (experimental)
+//
+// Examine a single vulnerability identifier as published by an
+// upstream feed: the vulnerability `id` (e.g., CVE-2025-12345) and
+// the `source` registry that published it (NVD, GHSA, …).
 vulnerability.exchange @defaults("id source") {
   // Vulnerability ID, eg. CVE-2025-12345
   id string

--- a/providers/google-workspace/resources/google-workspace.lr
+++ b/providers/google-workspace/resources/google-workspace.lr
@@ -5,6 +5,15 @@ option provider = "go.mondoo.com/cnquery/v9/providers/google-workspace"
 option go_package = "go.mondoo.com/mql/v13/providers/google-workspace/resources"
 
 // Google Workspace organization
+//
+// Examine a Google Workspace customer organization: the organizational-
+// unit hierarchy, every user account and the user's tokens / OAuth
+// scopes, the groups (with members and security settings), the
+// registered domains and their verification state, the admin roles
+// and their privileges, the third-party OAuth-connected apps with
+// aggregated scopes, and the user calendars together with their ACL
+// rules — the surface auditors use for identity hygiene, sharing
+// reviews, and 2-step-verification enforcement checks.
 googleworkspace {
   // Organizational units in the account hierarchy
   orgUnits() []googleworkspace.orgUnit

--- a/providers/grafana/resources/grafana.lr
+++ b/providers/grafana/resources/grafana.lr
@@ -5,6 +5,15 @@ option provider = "go.mondoo.com/mql/v13/providers/grafana"
 option go_package = "go.mondoo.com/mql/v13/providers/grafana/resources"
 
 // Grafana
+//
+// Examine a Grafana instance via its HTTP API: organization details,
+// human users with their roles and MFA / external-auth status, service
+// accounts and their tokens, configured datasources, alerting contact
+// points, the notification-policy routing tree, legacy API keys, RBAC
+// roles, and SSO settings (with a focused view of SAML configuration).
+// The surface auditors use to find weak datasource credentials, missing
+// MFA, expired or broad-scope tokens, deprecated API keys, and
+// permissive SSO configuration.
 grafana {
   // Organization details
   organization() grafana.organization
@@ -29,6 +38,10 @@ grafana {
 }
 
 // Grafana organization
+//
+// Examine the connected Grafana organization's identity: its numeric
+// ID and display name. Grafana organizations scope users, datasources,
+// and most other resources.
 grafana.organization @defaults("id name") {
   // Organization ID
   id int
@@ -37,6 +50,15 @@ grafana.organization @defaults("id name") {
 }
 
 // Grafana organization user
+//
+// Examine a single human user: identity (user ID, org ID, email,
+// display name, login handle), the org-level role (Admin / Editor /
+// Viewer), `lastSeenAt` and a human-readable age, the auth-module
+// the user authenticates against (e.g., `oauth_google`, `ldap`,
+// `saml`, empty for password), the auth labels Grafana attaches,
+// and the convenience predicates `isExternal`, `isGrafanaAdmin`,
+// `isDisabled`, and `mfaEnabled`. RBAC permissions granted to this
+// user are surfaced as an action → scope list map.
 grafana.user @defaults("login role") {
   // User ID
   userId int
@@ -71,6 +93,11 @@ grafana.user @defaults("login role") {
 }
 
 // Grafana service account
+//
+// Examine a service account: numeric ID, parent org ID, name and
+// login, the assigned role (Admin / Editor / Viewer), the `disabled`
+// and `external` flags, and the typed list of tokens issued for this
+// service account.
 grafana.serviceAccount @defaults("id name role") {
   // Service account ID
   id int
@@ -91,6 +118,13 @@ grafana.serviceAccount @defaults("id name role") {
 }
 
 // Grafana service account token
+//
+// Examine a single token issued for a Grafana service account: token
+// ID, the parent service-account ID, the token name, creation
+// timestamp, expiration timestamp (zero when none is configured), a
+// `hasExpiration` predicate, the seconds remaining until expiration
+// (negative when expired), and an `isExpired` flag — used for token
+// hygiene audits and rotation policies.
 grafana.serviceAccountToken @defaults("id name") {
   // Token ID
   id int
@@ -111,6 +145,17 @@ grafana.serviceAccountToken @defaults("id name") {
 }
 
 // Grafana datasource
+//
+// Examine a configured datasource: identity (numeric ID, UID, org
+// ID, name, type — prometheus, loki, mysql, …), access mode and URL,
+// the default-datasource and read-only flags, basic-auth status with
+// the inline username, the database name and DB user, predicates for
+// inline plaintext passwords (`hasPassword`, `hasBasicAuthPassword`)
+// — both legacy / insecure indicators — the
+// `withCredentials` cookie-forwarding flag, the names of secret
+// fields stored encrypted, the non-secret JSON config dict, and the
+// derived TLS posture (`isHttps`, `tlsSkipVerify`, `tlsClientAuth`,
+// `oauthPassThru`).
 grafana.datasource @defaults("id name type") {
   // Datasource ID
   id int
@@ -159,6 +204,13 @@ grafana.datasource @defaults("id name type") {
 }
 
 // Grafana alerting contact point
+//
+// Examine a single alerting contact point: UID, name, type (email,
+// slack, webhook, pagerduty, …), the `disableResolveMessage` flag,
+// the (non-secret) settings dict, the URL configured on the contact
+// point (when applicable), and derived posture predicates —
+// `isHttps`, `tlsSkipVerify`, `hasHttpAuth` — used to flag contact
+// points that route alerts over plaintext or with unverified TLS.
 grafana.contactPoint @defaults("uid name type") {
   // Contact point UID
   uid string
@@ -180,8 +232,15 @@ grafana.contactPoint @defaults("uid name type") {
   hasHttpAuth() bool
 }
 
-// DEPRECATED: legacy Grafana API key (distinct from service account tokens). Use
-// service accounts and tokens for new integrations; api keys are deprecated.
+// DEPRECATED: legacy Grafana API key
+//
+// Legacy API keys are distinct from service-account tokens; use
+// service accounts and tokens for new integrations. Examine a single
+// legacy API key: numeric ID and parent org ID, key name, granted
+// role (Admin / Editor / Viewer), expiration timestamp (zero when
+// none is set) plus `hasExpiration` and `isExpired` predicates, and
+// the service-account ID this key was migrated to (zero when not
+// migrated).
 grafana.apiKey @defaults("name role") @maturity("deprecated") {
   // API key ID
   id int
@@ -201,7 +260,14 @@ grafana.apiKey @defaults("name role") @maturity("deprecated") {
   serviceAccountId int
 }
 
-// Grafana RBAC role (Enterprise/Cloud)
+// Grafana RBAC role (Enterprise / Cloud)
+//
+// Examine a single RBAC role: UID, name (e.g.,
+// `fixed:datasources:writer`), display name, description, group,
+// version number, the `global` (built-in) and `hidden` flags, the
+// permissions map (action → scope list), and `created` / `updated`
+// timestamps. Iterate `grafana.roles` to audit which roles grant
+// which actions across the organization.
 grafana.role @defaults("name displayName") {
   // Role UID
   uid string
@@ -228,6 +294,14 @@ grafana.role @defaults("name displayName") {
 }
 
 // Grafana SSO settings for a single identity provider
+//
+// Examine the SSO configuration for one identity provider (saml,
+// github, google, generic_oauth, azuread, gitlab, okta, …): the
+// provider name, configuration source (`system` vs `database`),
+// enabled flag, the (non-secret) settings dict (Grafana redacts
+// secrets), the `allowSignUp` flag, and a `hasDomainRestriction`
+// predicate indicating whether the provider restricts sign-in to a
+// configured allowed-domains / orgs list.
 grafana.ssoSettings @defaults("provider source") {
   // Provider name (e.g., saml, github, google, generic_oauth, azuread, gitlab, okta)
   provider string
@@ -243,8 +317,16 @@ grafana.ssoSettings @defaults("provider source") {
   hasDomainRestriction bool
 }
 
-// Grafana SAML SSO settings (Enterprise/Cloud). Convenience view of the saml
-// entry from grafana.ssoSettings with security-relevant fields surfaced.
+// Grafana SAML SSO settings (Enterprise / Cloud)
+//
+// Examine the security-relevant fields of the SAML SSO configuration
+// (a focused view of the `saml` entry from `grafana.ssoSettings`):
+// enabled flag, configuration source (`system` vs `database`), the
+// signature algorithm (e.g., rsa-sha256), whether SP-initiated
+// requests are signed, single-logout enabled flag, whether
+// IdP-initiated SSO is allowed, the auto-signup flag, the
+// allowed-organizations list, the `skipOrgRoleSync` flag, and the
+// raw provider settings dict (with secrets redacted by Grafana).
 grafana.samlSettings @defaults("enabled") {
   // Whether SAML SSO is enabled
   enabled bool
@@ -269,6 +351,10 @@ grafana.samlSettings @defaults("enabled") {
 }
 
 // Grafana notification policy tree
+//
+// Examine the alerting notification-policy tree: the default receiver,
+// the labels alerts are grouped by, and the nested routing rules
+// dispatching alerts to specific contact points.
 grafana.notificationPolicy {
   // Default receiver name
   receiver string

--- a/providers/mondoo/resources/mondoo.lr
+++ b/providers/mondoo/resources/mondoo.lr
@@ -8,12 +8,20 @@ option provider = "go.mondoo.com/mql/v13/providers/mondoo"
 option go_package = "go.mondoo.com/mql/v13/providers/mondoo/resources"
 
 // Mondoo Client
+//
+// Examine the Mondoo Resource Name (MRN) of the client (cnspec / cnquery /
+// the platform agent) executing the current scan — the identifier audits
+// can use to attribute findings back to a specific Mondoo client.
 mondoo.client @defaults("mrn") {
   // Client identifier
   mrn string
 }
 
 // Mondoo Organization
+//
+// Examine an organization in Mondoo Platform: its display name, its MRN
+// (Mondoo Resource Name), and the spaces it contains. Use it to walk
+// the organization → space → asset hierarchy from policy.
 mondoo.organization @defaults ("name mrn") {
   // Organization name
   name string
@@ -24,6 +32,10 @@ mondoo.organization @defaults ("name mrn") {
 }
 
 // Mondoo Space
+//
+// Examine a space in Mondoo Platform: its display name, its MRN, and the
+// assets that have been registered into it. Spaces are the unit of
+// access control and policy assignment in Mondoo.
 mondoo.space @defaults("name mrn") {
   // Space name
   name string

--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -4,7 +4,11 @@
 option provider = "go.mondoo.com/cnquery/v9/providers/network"
 option go_package = "go.mondoo.com/mql/v13/providers/network/resources"
 
-// Network socket: protocol, port, and target address
+// Network socket
+//
+// Examine an addressable network endpoint by `protocol`, `port`, and
+// `address`. Used as a building block for higher-level resources like
+// `tls` that need to know "what to talk to".
 socket @defaults("protocol port address") {
   // Transport protocol (e.g., tcp, udp)
   protocol string
@@ -15,9 +19,21 @@ socket @defaults("protocol port address") {
 }
 
 // HTTP endpoint
+//
+// Empty namespace for HTTP probing. Use `http.get(url: "https://...")`
+// to perform a GET against a URL and inspect the response status,
+// headers (parsed into typed sub-resources for HSTS, CSP, cookies,
+// etc.), and body.
 http {}
 
-// HTTP GET requests
+// HTTP GET request
+//
+// Examine the result of an HTTP GET against a URL. Initialize with
+// `http.get(rawUrl: "https://example.com", followRedirects: true)`.
+// Surfaces the parsed `url`, the `statusCode`, the HTTP `version`,
+// the response `body`, and a typed `header` sub-resource exposing
+// HSTS, CSP, X-Frame-Options, X-XSS-Protection, X-Content-Type-Options,
+// Referrer-Policy, Content-Type, and Set-Cookie semantics.
 http.get @defaults("url statusCode") {
   init(rawUrl string, followRedirects bool)
   // URL for this request
@@ -95,8 +111,14 @@ private http.header.setCookie @defaults("name value") {
   params map[string]string
 }
 
-// URL resource, generally represented as:
-// [scheme:][//[user[:password]@]host[:port]][/]path[?query][#fragment]
+// Parsed URL
+//
+// Examine a parsed URL, generally represented as
+// `[scheme:][//[user[:password]@]host[:port]][/]path[?query][#fragment]`.
+// Initialize with `url(raw: "https://user:pass@host:443/p?q=1#f")` and
+// inspect any of the parsed components individually: scheme, user /
+// password user-info pair, host, port, path, parsed query map, raw
+// query string, and fragment.
 url @defaults("string") {
   init(raw string)
   // The full URL as a string
@@ -121,7 +143,17 @@ url @defaults("string") {
   rawFragment string
 }
 
-// TLS/SSL connection inspection: versions, ciphers, and certificates served by the endpoint
+// TLS/SSL connection inspection
+//
+// Examine the TLS posture of a network endpoint. Initialize with
+// `tls(target: "host:port")` (an optional `domainName` enables SNI
+// testing). Surfaces every TLS / SSL version the endpoint accepts,
+// the cipher suites and extensions advertised, the version / cipher
+// / key-exchange group a modern client actually negotiates, and the
+// served certificate chain — both the SNI-aware chain and the
+// non-SNI fallback. The resource an audit uses to find weak protocol
+// versions, weak ciphers, expired certs, and missing OCSP / SCT
+// support.
 tls @defaults("socket domainName") {
   init(target string)
   // Socket of this connection
@@ -148,14 +180,30 @@ tls @defaults("socket domainName") {
   nonSniCertificates(socket, domainName) []certificate
 }
 
-// X.509 certificates resource
+// X.509 certificate bundle
+//
+// Examine a list of certificates parsed from PEM content. Use it to
+// iterate over a chain and apply per-certificate checks, or to
+// extract the underlying `pem` source.
 certificates {
   []certificate
   // PEM content
   pem string
 }
 
-// X.509 certificate resource
+// X.509 certificate
+//
+// Examine a single X.509 certificate parsed from PEM. Surfaces the
+// raw PEM, every SHA-1 / SHA-256 fingerprint, the serial number, the
+// subject and authority key identifiers, the parsed PKIX subject and
+// issuer distinguished names, version, validity window
+// (`notBefore`, `notAfter`, `expiresIn`), signature and signing
+// algorithm, the `isCA` flag, key usages and extended key usages, the
+// raw and SAN extensions, policy identifiers, CRL distribution points,
+// OCSP server and issuing-certificate URLs, the revoked / verified /
+// expired flags, public-key algorithm and bit length, the
+// `hasSCTs` flag (Certificate Transparency) and the maximum CA chain
+// path length.
 certificate @defaults("serial subject.commonName subject.dn") {
   // PEM content
   pem string
@@ -219,7 +267,13 @@ certificate @defaults("serial subject.commonName subject.dn") {
   maxPathLen() int
 }
 
-// X.509 certificate PKIX name
+// X.509 PKIX name
+//
+// Examine a parsed RFC 5280 distinguished name (DN) — the structured
+// form of a certificate's subject or issuer. Surfaces the canonical
+// DN string, common name, country, organization and organizational
+// unit, locality, province, street address, postal code, serial
+// number, and any extra named attributes.
 pkix.name @defaults("id dn commonName") {
   // Cache key derived from the distinguished name
   id string
@@ -246,7 +300,11 @@ pkix.name @defaults("id dn commonName") {
   extraNames map[string]string
 }
 
-// X.509 certificate PKIX extension
+// X.509 PKIX extension
+//
+// Examine a single extension carried by an X.509 certificate: its
+// OID identifier (e.g., 2.5.29.37 for extKeyUsage), the `critical`
+// flag, and the raw extension value.
 pkix.extension @defaults("id") {
   // Cache key derived from the extension identifier
   id string
@@ -345,6 +403,12 @@ private openpgp.signature {
 }
 
 // Domain name
+//
+// Examine a parsed FQDN. Initialize with `domainName(fqdn: "x.example.com")`.
+// Surfaces the FQDN itself, the effective TLD plus one (the
+// registrable domain), the TLD, an `tldIcannManaged` flag indicating
+// whether the TLD is in the ICANN-managed list, and the individual
+// dot-separated labels.
 domainName @defaults("fqdn") {
   init(fqdn string)
   // Fully qualified domain name (FQDN)
@@ -360,6 +424,11 @@ domainName @defaults("fqdn") {
 }
 
 // DNS resource
+//
+// Examine the DNS records published for a fully-qualified domain
+// name. Initialize with `dns(fqdn: "example.com")`. Surfaces every
+// resolved record, the MX record list, and a parsed view of any DKIM
+// public-key records discovered for the domain.
 dns @defaults("fqdn") {
   init(fqdn string)
   // Fully qualified domain name (FQDN)
@@ -375,6 +444,10 @@ dns @defaults("fqdn") {
 }
 
 // DNS record
+//
+// Examine a single resolved DNS record: name, type, class, TTL, and
+// the rdata payload (IP addresses, hostnames, or other values
+// depending on the record type).
 dns.record @defaults("name type") {
   // DNS name
   name string
@@ -389,6 +462,10 @@ dns.record @defaults("name type") {
 }
 
 // DNS MX record
+//
+// Examine a single MX record: the record name, the resolved target
+// `domainName`, and the `preference` value used to choose between
+// multiple MX records.
 dns.mxRecord @defaults("domainName") {
   // Record name
   name string
@@ -398,7 +475,13 @@ dns.mxRecord @defaults("domainName") {
   domainName string
 }
 
-// DKIM public key representation as defined in RFC 6376
+// DKIM public-key DNS record (RFC 6376)
+//
+// Examine a parsed DKIM TXT record: the raw DNS text, the selector
+// domain, the version, the acceptable hash algorithms, the key type,
+// the base64-encoded public-key data, the service-type restrictions,
+// the DKIM flags, free-form notes, and a `valid()` predicate that
+// validates the record and its public key.
 dns.dkimRecord @defaults("dnsTxt") {
   // DNS text representation
   dnsTxt string

--- a/providers/nmap/resources/nmap.lr
+++ b/providers/nmap/resources/nmap.lr
@@ -5,12 +5,22 @@ option provider = "go.mondoo.com/mql/v13/providers/nmap"
 option go_package = "go.mondoo.com/mql/v13/providers/nmap/resources"
 
 // Nmap network scanner
+//
+// Examine the local nmap installation that the provider invokes for
+// scans, including its version and build information (libraries it
+// was compiled with, supported nsock engines, target platform).
 nmap {
   // Nmap installation version and build info
   version() nmap.versionInformation
 }
 
 // Nmap network scan target
+//
+// Examine the result of running nmap against a `target` (IP address,
+// hostname, or CIDR range). Surfaces the discovered hosts and any
+// warnings or errors emitted during the scan. Initialize with the
+// target string, e.g., `nmap.network(target: "192.0.2.0/24")` or
+// `nmap.network(target: "example.com")`.
 nmap.network {
   init(target string)
   // Target IP address, hostname, or CIDR range
@@ -22,6 +32,12 @@ nmap.network {
 }
 
 // Nmap discovered host
+//
+// Examine a single host returned by an nmap scan, identified by its
+// hostname or IP address: state (up / down / unknown), all known IP
+// and MAC addresses, DNS hostnames, OS-detection result, network
+// distance and traceroute hops, scan-end timestamp, and the discovered
+// ports with their states (open / closed / filtered).
 nmap.host @defaults("name") {
  init(name string)
  // Hostname or IP address

--- a/providers/opcua/resources/opcua.lr
+++ b/providers/opcua/resources/opcua.lr
@@ -5,6 +5,11 @@ option provider = "go.mondoo.com/cnquery/v9/providers/opcua"
 option go_package = "go.mondoo.com/mql/v13/providers/opcua/resources"
 
 // OPC UA (Open Platform Communications Unified Architecture) server
+//
+// Examine the connected OPC UA server: every namespace it advertises,
+// the root node of its address space, and a flat list of every node
+// reachable in that address space. The starting point for industrial
+// control systems / OT audits expressed in MQL.
 opcua {
   // Namespaces
   namespaces() []opcua.namespace
@@ -15,6 +20,12 @@ opcua {
 }
 
 // OPC UA server information
+//
+// Examine the OPC UA server's identity and lifecycle: its server-status
+// node, build information (manufacturer, product, software version,
+// build date), the current time as reported by the server, the time
+// when the server started, and the server state (Running, Failed,
+// NoConfiguration, Suspended, Shutdown).
 opcua.server {
   // Reference to node
   node opcua.node

--- a/providers/shodan/resources/shodan.lr
+++ b/providers/shodan/resources/shodan.lr
@@ -5,9 +5,24 @@ option provider = "go.mondoo.com/mql/v13/providers/shodan"
 option go_package = "go.mondoo.com/mql/v13/providers/shodan/resources"
 
 // Shodan Search Engine
+//
+// Empty namespace for the Shodan provider. Use `shodan.host(ip: "...")`,
+// `shodan.domain(name: "...")`, `shodan.profile`, and `shodan.apiPlan`
+// to query host posture, domain DNS state, the connected Shodan
+// account, and the API plan limits.
 shodan {}
 
-// Shodan Search Engine host information
+// Shodan host information
+//
+// Examine what Shodan knows about a single internet-reachable host,
+// identified by `ip` (e.g., `shodan.host(ip: "1.2.3.4")`). Surfaces
+// reverse-DNS hostnames and ASN / ISP / organization ownership, the
+// open-port list and the per-banner service inventory, geolocation
+// (country, region, city, postal, lat/lon), Shodan's tag set with
+// derived predicates (`isCloud`, `isCdn`, `isVpn`, `isTor`, `isProxy`,
+// `isInfrastructure`), the `lastUpdate` timestamp, and the host-level
+// vulnerability list (with CVSS and severity per CVE) plus the
+// per-banner vulnerabilities through `services()`.
 shodan.host @defaults("ip") {
   init(ip string)
   // Host IP
@@ -191,7 +206,11 @@ private shodan.host.vulnerability @defaults("cve cvss severity") {
   references []string
 }
 
-// Shodan Search Engine domain information
+// Shodan domain information
+//
+// Examine what Shodan knows about a domain, identified by `name`
+// (e.g., `shodan.domain(name: "example.com")`): tags, the discovered
+// subdomain list, and the DNS NS records Shodan has seen.
 shodan.domain @defaults("name") {
   init(name string)
   // Domain name
@@ -219,6 +238,10 @@ private shodan.nsrecord @defaults("domain subdomain type") {
 }
 
 // Shodan Search Engine account
+//
+// Examine the Shodan account that the API key belongs to: display
+// name, whether it's a member account, the number of remaining search
+// credits, and the account creation timestamp.
 shodan.profile @defaults("displayName"){
   // Whether the account is a member
   member bool
@@ -231,6 +254,11 @@ shodan.profile @defaults("displayName"){
 }
 
 // Shodan Search Engine API plan information
+//
+// Examine the API plan attached to the connected account: plan name,
+// whether the plan is active (`unlocked`), the scan-credit total and
+// remaining count, the `telnet` permission, and the number of
+// monitored IPs allowed by the plan.
 shodan.apiPlan @defaults("plan"){
   // Number of scan credits
   scanCredits int

--- a/providers/slack/resources/slack.lr
+++ b/providers/slack/resources/slack.lr
@@ -4,7 +4,13 @@
 option provider = "go.mondoo.com/cnquery/v9/providers/slack"
 option go_package = "go.mondoo.com/mql/v13/providers/slack/resources"
 
-// Slack workspace and its resources (users, channels, user groups, access logs)
+// Slack workspace
+//
+// Examine a Slack workspace via the Web API: every login event in the
+// workspace access log (login activity, IP, user agent, ISP, geolocation)
+// and the user groups defined in the workspace. Pair with `slack.users`
+// for per-user identity / 2FA / role audits and `slack.conversations`
+// for channel sharing-and-membership reviews.
 slack {
   // Slack workspace access log entries (login activity)
   accessLogs() []slack.login
@@ -12,7 +18,11 @@ slack {
   userGroups() []slack.userGroup
 }
 
-// Slack conversations (channels, direct messages, and group messages)
+// Slack conversations
+//
+// Examine every conversation in the workspace — public channels,
+// private channels, and direct messages — together with split views
+// that return only the public, private, or direct-message subset.
 slack.conversations {
   []slack.conversation
   // List of private channels in a Slack team
@@ -24,6 +34,9 @@ slack.conversations {
 }
 
 // Slack team
+//
+// Examine the connected Slack team's identity: ID, name, domain
+// (the `<domain>.slack.com` host), and the workspace email domain.
 slack.team @defaults("id domain") {
   // ID of the team
   id string
@@ -35,7 +48,11 @@ slack.team @defaults("id domain") {
   emailDomain string
 }
 
-// Slack workspace users grouped by role (bots, members, admins, owners)
+// Slack workspace users
+//
+// Examine every user in the workspace, with role-filtered views for
+// `bots()`, `members()`, `admins()`, and `owners()`. The starting
+// point for 2FA, dormant-user, and admin-membership audits.
 slack.users {
   []slack.user
   // Bot users in the workspace
@@ -49,6 +66,16 @@ slack.users {
 }
 
 // Slack user
+//
+// Examine a single Slack user, identified by `id`. Surfaces username,
+// real name, profile dict, locale and timezone, presence (active /
+// away), the deactivated flag, the role flags
+// (`isAdmin`, `isOwner`, `isPrimaryOwner`, `isRestricted`,
+// `isUltraRestricted`, `isStranger`), bot-account markers (`isBot`,
+// `isAppUser`, `isConnectorBot`, `isWorkflowBot`, `isInvitedUser`),
+// the email-confirmed flag, two-factor enrollment (`has2FA`,
+// `twoFactorType`), and a typed link to the user's `enterpriseUser`
+// record on Slack Enterprise Grid.
 slack.user @defaults("id name") {
   // ID of the workspace user
   id string
@@ -109,6 +136,10 @@ slack.user @defaults("id name") {
 }
 
 // Slack Enterprise Grid user
+//
+// Examine the Enterprise-Grid record attached to a Slack user: the
+// enterprise user ID, the parent organization ID and name, and
+// whether the user is an admin or owner of the Enterprise Grid org.
 slack.enterpriseUser {
   // Enterprise user ID
    id string
@@ -122,7 +153,13 @@ slack.enterpriseUser {
    isOwner bool
 }
 
-// Slack user group (a group of workspace members addressable by handle)
+// Slack user group
+//
+// Examine a single user group — a group of workspace members
+// addressable by a `@handle`. Surfaces the handle, friendly name and
+// description, external-group flag, lifecycle timestamps with the
+// users that created / updated / deleted it, the member count, and
+// the typed members list.
 slack.userGroup @defaults("handle") {
   // Group ID
   id string
@@ -154,7 +191,14 @@ slack.userGroup @defaults("handle") {
   members() []slack.user
 }
 
-// Slack access log entry
+// Slack workspace access log entry
+//
+// Examine an access-log row that aggregates logins for one
+// (user, IP, user-agent) combination: the user ID and username,
+// the count of logins, the source IP and user agent, the best-guess
+// ISP, the IP-derived country and region, and the first / last
+// login timestamps. Used for impossible-travel and suspicious-IP
+// detection in workspace logins.
 slack.login @defaults("userID") {
   // User ID
   userID string
@@ -179,6 +223,15 @@ slack.login @defaults("userID") {
 }
 
 // Slack conversation
+//
+// Examine a single Slack conversation — a public or private channel,
+// direct message, or multi-party DM. Surfaces ID and name, the
+// creator and creation timestamp, locale, the topic and purpose
+// dicts, the lifecycle flags (`isArchived`, `isOpen`), the
+// channel-shape flags (`isPrivate`, `isIM`, `isMpim`, `isGroup`,
+// `isChannel`), the external-sharing flags (`isShared`,
+// `isExtShared`, `isPendingExtShared`, `isOrgShared`), the priority
+// score, and the typed member list.
 slack.conversation @defaults("id name") {
   // Conversation ID
   id string

--- a/providers/tailscale/resources/tailscale.lr
+++ b/providers/tailscale/resources/tailscale.lr
@@ -4,7 +4,14 @@
 option provider = "go.mondoo.com/mql/v13/providers/tailscale"
 option go_package = "go.mondoo.com/mql/v13/providers/tailscale/resources"
 
-// Tailscale organization
+// Tailscale tailnet
+//
+// Examine a Tailscale tailnet (organization): its name, the devices and
+// users it contains, the configured global DNS nameservers, the ACL
+// policy, and the tailnet-wide hardening flags — device-approval and
+// user-approval requirements, automatic-update enrollment, the auth-key
+// expiration window, network-flow logging, posture identity collection,
+// and which user role is allowed to join external tailnets.
 tailscale {
   // Tailnet organization name
   tailnet string
@@ -32,7 +39,17 @@ tailscale {
   aclPolicy() tailscale.aclPolicy
 }
 
-// A Tailscale device (sometimes referred to as node or machine)
+// Tailscale device (also called a node or machine)
+//
+// Examine a single device registered in the tailnet, identified by `id`:
+// hostname, operating system, MagicDNS name, the user that registered
+// it, ACL tags, all assigned Tailscale IP addresses (IPv4 and IPv6),
+// the Tailscale client version and update-availability flag, the
+// machine and node keys, tailnet-lock signing state, posture flags
+// (`blocksIncomingConnections`, `authorized`, `isExternal`,
+// `keyExpiryDisabled`), lifecycle timestamps (`createdAt`, `expiresAt`,
+// `lastSeenAt`), and the advertised vs enabled subnet routes (each
+// fetched per-device on demand).
 tailscale.device @defaults("id hostname os") {
   init(id? string)
   // Legacy identifier for a device
@@ -84,6 +101,15 @@ tailscale.device @defaults("id hostname os") {
 }
 
 // Tailscale user
+//
+// Examine a single user known to the tailnet, identified by `id`:
+// display name, login name, profile picture, the owning tailnet,
+// relation type (member vs shared), role (owner / admin / member /
+// etc.), status (active / idle / suspended / needs-approval /
+// over-billing-limit), the count of devices the user owns,
+// `createdAt` / `lastSeenAt` lifecycle timestamps, and a
+// `currentlyConnected` flag — used for access reviews and dormant /
+// suspended-account hygiene.
 tailscale.user @defaults("id displayName type") {
   init(id? string)
   // Unique identifier for the user
@@ -119,9 +145,15 @@ tailscale.user @defaults("id displayName type") {
 
 // Tailscale tailnet ACL (access control list) policy
 //
-// The ACL policy governs which users and devices can talk to which other users and
-// devices. The structured representation here is parsed from the tailnet's HuJSON
-// policy file (https://tailscale.com/kb/1018/acls).
+// Examine the tailnet's parsed HuJSON ACL policy
+// (https://tailscale.com/kb/1018/acls). The policy governs which
+// users and devices can reach which others, and the resource exposes
+// the ACL rules, named groups, host aliases, tag-owner assignments,
+// Tailscale SSH rules, embedded connectivity tests, per-node attribute
+// grants, exit-node and subnet-route auto-approvers, default and named
+// device-posture rules, the IPv4-disabled flag, the OneCGNATRoute
+// setting, the randomize-client-port flag, the policy `etag`, and the
+// raw HuJSON for fall-through pattern matching.
 tailscale.aclPolicy @defaults("tailnet") {
   // Tailnet name this ACL policy belongs to
   tailnet string

--- a/providers/terraform/resources/terraform.lr
+++ b/providers/terraform/resources/terraform.lr
@@ -4,7 +4,14 @@
 option provider = "go.mondoo.com/cnquery/v9/providers/terraform"
 option go_package = "go.mondoo.com/mql/v13/providers/terraform/resources"
 
-// Terraform configuration files
+// Terraform configuration
+//
+// Examine a directory of Terraform source: every parsed `.tf` and
+// `.tf.json` file, the `tfvars` and `tfvars.json` variable values,
+// the referenced modules, and the typed lists of provider, data
+// source, variable, and output blocks. Use it to write IaC policy
+// against the source representation of an infrastructure tree before
+// it has been planned or applied.
 terraform {
   // Access to individual files including .tf and .tf.json files
   files() []terraform.file
@@ -24,7 +31,12 @@ terraform {
   outputs() []terraform.block
 }
 
-// All blocks with the type resource
+// Terraform resource blocks
+//
+// Examine every `resource` block declared across the parsed
+// configuration. Initialize with `terraform.resources(resource: ...,
+// name: ...)` to filter by Terraform resource type and / or
+// resource name without iterating manually.
 terraform.resources {
   []terraform.block
   init(resource? any, name? any)
@@ -38,7 +50,11 @@ private terraform.file @defaults("path") {
   blocks() []terraform.block
 }
 
-// Position of the Terraform configuration block in the file
+// File position of a Terraform configuration block
+//
+// Examine the source location of an HCL block: file path, line and
+// column numbers, and byte offset. Used to point reviewers at the
+// exact location of a flagged block in the original file.
 terraform.fileposition {
   // File path to the Terraform configuration file
   path string
@@ -74,7 +90,13 @@ private terraform.block @defaults("type labels") {
   snippet string
 }
 
-// Terraform module block
+// Terraform module reference
+//
+// Examine a referenced module: a unique key identifying the module
+// instance, the source it was loaded from (registry, local path,
+// Git URL, …), the version constraint, the on-disk directory it was
+// expanded into, and the underlying HCL block including its
+// configuration arguments.
 terraform.module @defaults("key source") {
   // Unique identifier for the module
   key string
@@ -89,7 +111,12 @@ terraform.module @defaults("key source") {
   block() terraform.block
 }
 
-// Terraform settings
+// Terraform settings block
+//
+// Examine the contents of the `terraform { ... }` settings block: the
+// underlying HCL block, the parsed `required_providers` list (each
+// with its local name, source address, and version constraint), and
+// the configured `backend` block as a dict.
 terraform.settings {
   // The terraform { ... } block holding required_providers, backend, and version constraints
   block terraform.block
@@ -109,7 +136,13 @@ private terraform.settings.requiredProvider @defaults("name source version") {
   version string
 }
 
-// Terraform state
+// Terraform state file
+//
+// Examine a parsed Terraform state file (`terraform.tfstate` or the
+// `terraform show -json` output). Surfaces the state format version,
+// the Terraform version that wrote it, the declared output values,
+// the root module, a flat list of every module, and a flat list of
+// every managed and data resource captured in state.
 terraform.state {
   // Terraform state format version
   formatVersion string
@@ -125,7 +158,11 @@ terraform.state {
   resources() []terraform.state.resource
 }
 
-// Terraform state output values
+// Terraform state output value
+//
+// Examine a single declared output, identified by `identifier`: the
+// resolved value, its type definition, and a `sensitive` flag
+// indicating whether Terraform should redact the value in CLI output.
 terraform.state.output @defaults("identifier") {
   init(identifier string)
   // Output identifier
@@ -139,6 +176,11 @@ terraform.state.output @defaults("identifier") {
 }
 
 // Terraform state module
+//
+// Examine a single module captured in state, identified by its
+// absolute module `address`. Iterate `resources()` for the
+// infrastructure objects this module owns and `childModules()` to
+// walk into nested modules.
 terraform.state.module @defaults("address") {
   init(identifier string)
   // Module identifier address
@@ -150,6 +192,13 @@ terraform.state.module @defaults("address") {
 }
 
 // Terraform state resource
+//
+// Examine a single managed or data resource as captured in state:
+// absolute address, mode (managed vs data), Terraform resource type
+// and name, the responsible provider, the schema version of the
+// `values` payload, the attribute values themselves, the dependency
+// list, the `tainted` flag, and any `deposedKey`. Use it to write
+// policies that match the post-apply shape of infrastructure.
 terraform.state.resource @defaults("type name") {
   // Address is the absolute resource address
   address string
@@ -173,7 +222,13 @@ terraform.state.resource @defaults("type name") {
   deposedKey string
 }
 
-// Terraform plan
+// Terraform plan file
+//
+// Examine a parsed Terraform plan (`terraform show -json plan`).
+// Surfaces the plan's format version, the Terraform version that
+// produced it, the variables used to generate the plan, every
+// proposed resource change, and `applyable` / `errored` flags
+// indicating whether `terraform apply` is expected to succeed.
 terraform.plan {
   // Terraform plan format version
   formatVersion string
@@ -190,6 +245,10 @@ terraform.plan {
 }
 
 // Terraform plan configuration
+//
+// Examine the configuration section of a plan: the per-provider
+// configuration entries and the resource configuration belonging to
+// the root module — the shape Terraform was about to apply.
 terraform.plan.configuration {
   // Provider configuration
   providerConfig() []dict
@@ -198,6 +257,10 @@ terraform.plan.configuration {
 }
 
 // Terraform plan variable
+//
+// Examine a variable supplied to the plan: its name and the resolved
+// value (typed as a dict to preserve the original Terraform value
+// shape).
 terraform.plan.variable @defaults("name value") {
   // Variable name
   name string
@@ -206,6 +269,14 @@ terraform.plan.variable @defaults("name value") {
 }
 
 // Terraform plan resource change
+//
+// Examine a single proposed change in a plan: the absolute resource
+// address, any `previousAddress` (when the resource was moved), the
+// owning module address, mode (managed vs data), Terraform resource
+// type and name, the responsible provider, a `deposed` marker (set
+// when the change applies to a deposed object), the typed
+// `proposedChange` describing the actions and before / after values,
+// and the human-readable `actionReason`.
 terraform.plan.resourceChange @defaults("type name") {
   // Resource address
   address string
@@ -230,6 +301,13 @@ terraform.plan.resourceChange @defaults("type name") {
 }
 
 // Terraform plan proposed change
+//
+// Examine the actions Terraform will apply to a resource (create /
+// read / update / delete / no-op) along with the before / after
+// states, the per-attribute `afterUnknown` map, the
+// `beforeSensitive` / `afterSensitive` redaction flags, and the
+// `replacePaths` list identifying which attribute changes force a
+// replace.
 terraform.plan.proposedChange @defaults("actions after") {
   // Resource address
   address string

--- a/providers/vllm/resources/vllm.lr
+++ b/providers/vllm/resources/vllm.lr
@@ -5,6 +5,12 @@ option provider = "go.mondoo.com/mql/providers/vllm"
 option go_package = "go.mondoo.com/mql/v13/providers/vllm/resources"
 
 // vLLM inference server
+//
+// Examine the security posture of a remote vLLM HTTP inference server:
+// the server-level summary, the per-endpoint anonymous-access probe
+// results, the minimal metrics-exposure posture, and the reported
+// vLLM version. Used to find vLLM deployments that expose admin,
+// profiler, or metrics endpoints without authentication.
 vllm {
   // Server-level HTTP posture summary
   server() vllm.server
@@ -17,6 +23,13 @@ vllm {
 }
 
 // vLLM server-level HTTP posture
+//
+// Examine the server-wide HTTP exposure findings: the base URL the
+// connection probed, whether the server is reachable, the reported
+// vLLM version, whether the connection is over TLS, and whether
+// FastAPI docs / OpenAPI / Prometheus metrics / /load / tokenizer-info
+// / dev / profiler endpoints are anonymously exposed. Also surfaces
+// CORS posture (configured at all, accepts any origin).
 vllm.server @defaults("baseUrl reachable version") {
   // Base URL used by this connection
   baseUrl() string
@@ -47,6 +60,13 @@ vllm.server @defaults("baseUrl reachable version") {
 }
 
 // vLLM HTTP endpoint posture
+//
+// Examine the probe result for a single vLLM HTTP endpoint, identified
+// by `path` and `method` (e.g., `vllm.endpoint(path: "/v1/models",
+// method: "GET")`). Each probe records the endpoint category, whether
+// the route was observed at all, the anonymous and authenticated
+// status codes, whether anonymous traffic reached the route or got an
+// auth-like rejection, and human-readable notes from the probe.
 vllm.endpoint @defaults("method path category present anonymousAccessible requiresAuth") {
   init(path string, method string)
   // HTTP method used by the probe
@@ -70,6 +90,11 @@ vllm.endpoint @defaults("method path category present anonymousAccessible requir
 }
 
 // Minimal vLLM metrics exposure posture
+//
+// Examine whether the metrics-related endpoints are anonymously
+// reachable: the Prometheus `/metrics` endpoint, the `/load` endpoint,
+// and whether `/load` returns enough state to leak load-tracking
+// information.
 vllm.metrics @defaults("prometheusExposed loadEndpointExposed") {
   // Whether /metrics is anonymously exposed
   prometheusExposed() bool


### PR DESCRIPTION
## Summary
Follow-up to #7581 (now merged into main). Continues the per-provider doc-comment sweep, adds a CLAUDE.md section codifying the format, and applies the style fixes that came out of #7581 review feedback (no parent-device navigation, no "Singleton" jargon, name-only titles, mention selection key when relevant, DEPRECATED stays in titles).

### Format
```
// Apache2 HTTP Server
//
// Examine server configuration and daemon version. The configuration
// includes loaded modules, virtual hosts, and directory directives.
apache2 { ... }
```

### Coverage in this PR
- **CLAUDE.md** — new "Resource doc-comment format" subsection under "Step 1: Definition" documenting title / blank-line / description structure plus all the style rules (no leading "A", no "static analysis" titles, no parent-device navigation, DEPRECATED stays in titles, etc.).
- **mondoo** — client, organization, space
- **nmap** — root, network scan, host
- **opcua** — root, server
- **vllm** — root, server posture, endpoint, metrics
- **tailscale** — tailnet, device, user, ACL policy
- **google-workspace** — namespace root
- **shodan** — namespace, host, domain, profile, apiPlan
- **network** — socket, http, http.get, url, tls, certificates, certificate, pkix.name, pkix.extension, domainName, dns, dns.record, dns.mxRecord, dns.dkimRecord
- **core** — mondoo, asset, asset.eol, time, regex, parse, uuid, cpe, product, unicode, vulnerability.exchange
- **terraform** — namespace, resources, fileposition, module, settings, state and plan namespaces with their resource / output / module / change sub-types
- **slack** — workspace, conversations, team, users, user, enterpriseUser, userGroup, login, conversation
- **grafana** — root, organization, user, serviceAccount, serviceAccountToken, datasource, contactPoint, apiKey (DEPRECATED), role, ssoSettings, samlSettings, notificationPolicy

### Still TODO
Big providers (aws, azure, gcp, k8s, vsphere, cloudflare, ms365, oci) and remaining medium providers (datadog, hetzner, proxmox, snowflake, digitalocean, okta, gitlab, github, vcd) are not in this PR. They'll come in follow-ups using the format documented in CLAUDE.md.

## Test plan
- [x] `mqlr generate` runs clean against the modified `.lr` files; no `.lr.versions` changes (descriptions don't bump versions)
- [x] All title lines are name-like, no "static analysis" / leading "A" article
- [x] Exactly one blank `//` between title and description on every touched resource
- [x] No parent-device navigation in descriptions; selection guidance only where there's a key field
- [x] DEPRECATED kept in title for `grafana.apiKey`

🤖 Generated with [Claude Code](https://claude.com/claude-code)