### PR TITLE
⚡ ci: matrix providers/test across one runner per provider

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -104,14 +104,90 @@ jobs:
       - name: Test mql
         run: make test/go/plain-ci
 
-      - name: Test Providers
-        run: make providers/test
-
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success() || failure() # run this step even if previous step failed
         with:
           name: test-results
           path: "*.xml"
+
+  go-test-providers:
+    runs-on:
+      group: Default
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        provider:
+          - core
+          - network
+          - os
+          - activedirectory
+          - ansible
+          - arista
+          - atlassian
+          - aws
+          - azure
+          - bicep
+          - cloudflare
+          - cloudformation
+          - depsdev
+          - equinix
+          - gcp
+          - github
+          - gitlab
+          - google-workspace
+          - grafana
+          - helm
+          - ipinfo
+          - ipmi
+          - k8s
+          - kustomize
+          - mondoo
+          - ms365
+          - nmap
+          - oci
+          - okta
+          - opcua
+          - shodan
+          - slack
+          - snowflake
+          - tailscale
+          - terraform
+          - vcd
+          - vllm
+          - vsphere
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Import environment variables from file
+        run: cat ".github/env" >> $GITHUB_ENV
+
+      - name: Install Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ">=${{ env.golang-version }}"
+          check-latest: true
+          cache: false
+
+      - name: Install gotestsum and mockgen
+        run: |
+          go install gotest.tools/gotestsum@latest
+          go install go.uber.org/mock/mockgen@latest
+
+      - name: Generate provider mocks
+        run: make test/generate
+
+      - name: Test provider
+        env:
+          PROVIDER: ${{ matrix.provider }}
+        run: make "providers/test/$PROVIDER"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: success() || failure()
+        with:
+          name: test-results-provider-${{ matrix.provider }}
+          path: report_*.xml
 
   go-test-integration:
     runs-on:
@@ -169,7 +245,7 @@ jobs:
 
   go-auto-approve:
     runs-on: ubuntu-latest
-    needs: [golangci-lint, golangci-lint-providers, go-test, go-test-integration, go-mod]
+    needs: [golangci-lint, golangci-lint-providers, go-test, go-test-providers, go-test-integration, go-mod]
     # For now, we only auto approve and merge provider release PRs created by mondoo-tools.
     # We use github.actor (the authenticated GitHub user who pushed) instead of
     # github.event.commits[0].author.username (the git commit author) because git commit

--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,21 @@ providers/permissions:
 	@go run providers-sdk/v1/util/permissions/permissions.go providers/gcp
 	@go run providers-sdk/v1/util/permissions/permissions.go providers/azure
 
+# Test a single provider — the entry point CI matrix jobs invoke per-provider.
+# Explicit rules for the providers that share the root go.mod; the pattern
+# rule below covers everything that has its own go.mod.
+providers/test/core:
+	@$(call testProvider, providers/core)
+
+providers/test/network:
+	@$(call testProvider, providers/network)
+
+providers/test/os:
+	@$(call testProvider, providers/os)
+
+providers/test/%:
+	@$(call testGoModProvider, providers/$*)
+
 providers/test:
 	@$(call testProvider, providers/core)
 	@$(call testProvider, providers/network)


### PR DESCRIPTION
## Summary

- Splits the sequential `make providers/test` step (≈7 min wall-clock for 38 providers, run as part of the `go-test` job) into a **parallel matrix job** with one runner per provider. Wall-clock for the provider tests drops to the time of the slowest provider — well under 2 min in practice.
- Adds new `providers/test/<name>` make targets so a single provider can be tested in isolation. Explicit rules cover the shared-`go.mod` providers (`core`, `network`, `os`); a pattern rule covers everything else. The existing `providers/test` target is left untouched for local use.
- Adds a `go-test-providers` matrix job in `pr-test-lint.yml` that covers the same 38 providers the existing `providers/test` target runs. Per-provider artifacts are suffixed with the provider name to avoid v4 `upload-artifact` collisions.
- Removes the `Test Providers` step from `go-test`. `go-test` keeps testing mql core via `make test/go/plain-ci`. The new matrix job is added to `go-auto-approve`'s `needs[]`.

## Why

The existing `go-test` job currently runs (data from a recent green main run, job 74934202840):

| Step | Wall-clock |
|---|---|
| `make test/go/plain-ci` (build all 41 providers + test mql core) | 5m 47s |
| `make providers/test` (test 38 providers serially) | **6m 54s** |

The 38 providers are independent Go modules with no inter-dependencies — perfect for a matrix. Trading one runner-slot for ~5 minutes of wall-clock time is a clear win, especially since fan-out is bounded (38 short jobs, each finishing well inside the runner pool's typical concurrency).

## Test plan

- [x] `make providers/test/core` (testProvider style, shared `go.mod`) — passes locally, runs the same packages as the existing rule.
- [x] `make providers/test/aws` (testGoModProvider style, own `go.mod`) — passes locally; `cd providers/aws && gotestsum ...` resolves correctly.
- [x] `make providers/test` (existing top-level target) — `make -n` confirms it's unchanged.
- [x] YAML lints clean.
- [ ] CI run: confirm all 38 matrix jobs succeed and report per-provider artifacts.
- [ ] Confirm `go-auto-approve` blocks until all matrix legs report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)