### PR TITLE
✨ azure: model Function App app settings and connection strings

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -22,6 +22,7 @@ antispam
 aof
 apm
 apparmor
+appsettings
 appslot
 armcontainerregistry
 armcontainerregistrytasks

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -6438,8 +6438,9 @@ private azure.subscription.functionsService.functionApp.appSetting @defaults("na
   // Whether the setting's value is a Key Vault reference
   // (i.e., starts with `@Microsoft.KeyVault(...)`)
   hasKeyVaultReference bool
-  // Whether the setting name suggests it carries a secret —
-  // matches /key|password|secret|token|conn(ection)?_?str/i
+  // Whether the setting name suggests it carries a secret. True when the
+  // name (case-insensitively) contains "key", "password", "secret",
+  // "token", or a connection-string identifier ending in `str`.
   isLikelySecret bool
   // Whether the setting is "sticky" on slot swaps (configured via the
   // app's slot-config-names list)

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -6439,7 +6439,7 @@ private azure.subscription.functionsService.functionApp.appSetting @defaults("na
   // (i.e., starts with `@Microsoft.KeyVault(...)`)
   hasKeyVaultReference bool
   // Whether the setting name suggests it carries a secret —
-  // matches /key|password|secret|token|connection/i
+  // matches /key|password|secret|token|conn(ection)?_?str/i
   isLikelySecret bool
   // Whether the setting is "sticky" on slot swaps (configured via the
   // app's slot-config-names list)

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -6412,6 +6412,40 @@ azure.subscription.functionsService.functionApp @defaults("id name location") {
   properties dict
   // Functions in this function app
   functions() []azure.subscription.functionsService.functionApp.function
+  // Application settings configured on the function app. Values are not
+  // returned — each entry exposes name, slot-stickiness, Key-Vault-reference
+  // detection, and a heuristic flag for secret-bearing names.
+  appSettings() []azure.subscription.functionsService.functionApp.appSetting
+  // Connection strings configured on the function app. Each entry has shape
+  // {name, type, hasKeyVaultReference, slotSetting}. Connection-string values
+  // are not returned.
+  connectionStrings() []dict
+}
+
+// Azure Function App application setting
+//
+// Examine a single application setting on a function app. Selectable by
+// composite id; surfaces whether the value resolves through Azure Key
+// Vault, whether the setting is sticky on slot swaps, and a heuristic
+// flag (`isLikelySecret`) for setting names that suggest secret content
+// — useful for "any plaintext secret-like setting that is not a Key
+// Vault reference" audits.
+private azure.subscription.functionsService.functionApp.appSetting @defaults("name hasKeyVaultReference isLikelySecret slotSetting") {
+  // Composite ID: <functionAppId>/config/appsettings/<name>
+  id string
+  // Setting name
+  name string
+  // Whether the setting's value is a Key Vault reference
+  // (i.e., starts with `@Microsoft.KeyVault(...)`)
+  hasKeyVaultReference bool
+  // Whether the setting name suggests it carries a secret —
+  // matches /key|password|secret|token|connection/i
+  isLikelySecret bool
+  // Whether the setting is "sticky" on slot swaps (configured via the
+  // app's slot-config-names list)
+  slotSetting bool
+  // Whether the setting has a non-empty value (the value itself is not exposed)
+  hasValue bool
 }
 
 // Azure Function within a Function App

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -279,6 +279,7 @@ const (
 	ResourceAzureSubscriptionRecoveryServicesServiceVaultProtectedItem                           string = "azure.subscription.recoveryServicesService.vault.protectedItem"
 	ResourceAzureSubscriptionFunctionsService                                                    string = "azure.subscription.functionsService"
 	ResourceAzureSubscriptionFunctionsServiceFunctionApp                                         string = "azure.subscription.functionsService.functionApp"
+	ResourceAzureSubscriptionFunctionsServiceFunctionAppAppSetting                               string = "azure.subscription.functionsService.functionApp.appSetting"
 	ResourceAzureSubscriptionFunctionsServiceFunctionAppFunction                                 string = "azure.subscription.functionsService.functionApp.function"
 	ResourceAzureSubscriptionServiceBusService                                                   string = "azure.subscription.serviceBusService"
 	ResourceAzureSubscriptionServiceBusServiceNamespace                                          string = "azure.subscription.serviceBusService.namespace"
@@ -1372,6 +1373,10 @@ func init() {
 		"azure.subscription.functionsService.functionApp": {
 			// to override args, implement: initAzureSubscriptionFunctionsServiceFunctionApp(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAzureSubscriptionFunctionsServiceFunctionApp,
+		},
+		"azure.subscription.functionsService.functionApp.appSetting": {
+			// to override args, implement: initAzureSubscriptionFunctionsServiceFunctionAppAppSetting(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAzureSubscriptionFunctionsServiceFunctionAppAppSetting,
 		},
 		"azure.subscription.functionsService.functionApp.function": {
 			// to override args, implement: initAzureSubscriptionFunctionsServiceFunctionAppFunction(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -9576,6 +9581,30 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.functionsService.functionApp.functions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).GetFunctions()).ToDataRes(types.Array(types.Resource("azure.subscription.functionsService.functionApp.function")))
+	},
+	"azure.subscription.functionsService.functionApp.appSettings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).GetAppSettings()).ToDataRes(types.Array(types.Resource("azure.subscription.functionsService.functionApp.appSetting")))
+	},
+	"azure.subscription.functionsService.functionApp.connectionStrings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).GetConnectionStrings()).ToDataRes(types.Array(types.Dict))
+	},
+	"azure.subscription.functionsService.functionApp.appSetting.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting).GetId()).ToDataRes(types.String)
+	},
+	"azure.subscription.functionsService.functionApp.appSetting.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting).GetName()).ToDataRes(types.String)
+	},
+	"azure.subscription.functionsService.functionApp.appSetting.hasKeyVaultReference": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting).GetHasKeyVaultReference()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.functionsService.functionApp.appSetting.isLikelySecret": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting).GetIsLikelySecret()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.functionsService.functionApp.appSetting.slotSetting": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting).GetSlotSetting()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.functionsService.functionApp.appSetting.hasValue": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting).GetHasValue()).ToDataRes(types.Bool)
 	},
 	"azure.subscription.functionsService.functionApp.function.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionAppFunction).GetId()).ToDataRes(types.String)
@@ -22368,6 +22397,42 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.functionsService.functionApp.functions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).Functions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.functionsService.functionApp.appSettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).AppSettings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.functionsService.functionApp.connectionStrings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).ConnectionStrings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.functionsService.functionApp.appSetting.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting).__id, ok = v.Value.(string)
+		return
+	},
+	"azure.subscription.functionsService.functionApp.appSetting.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.functionsService.functionApp.appSetting.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.functionsService.functionApp.appSetting.hasKeyVaultReference": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting).HasKeyVaultReference, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.functionsService.functionApp.appSetting.isLikelySecret": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting).IsLikelySecret, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.functionsService.functionApp.appSetting.slotSetting": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting).SlotSetting, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.functionsService.functionApp.appSetting.hasValue": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting).HasValue, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.functionsService.functionApp.function.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -52772,6 +52837,8 @@ type mqlAzureSubscriptionFunctionsServiceFunctionApp struct {
 	ManagedServiceIdentityId plugin.TValue[string]
 	Properties               plugin.TValue[any]
 	Functions                plugin.TValue[[]any]
+	AppSettings              plugin.TValue[[]any]
+	ConnectionStrings        plugin.TValue[[]any]
 }
 
 // createAzureSubscriptionFunctionsServiceFunctionApp creates a new instance of this resource
@@ -52873,6 +52940,102 @@ func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetFunctions() *plugin
 
 		return c.functions()
 	})
+}
+
+func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetAppSettings() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AppSettings, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.functionsService.functionApp", c.__id, "appSettings")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.appSettings()
+	})
+}
+
+func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetConnectionStrings() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ConnectionStrings, func() ([]any, error) {
+		return c.connectionStrings()
+	})
+}
+
+// mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting for the azure.subscription.functionsService.functionApp.appSetting resource
+type mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAzureSubscriptionFunctionsServiceFunctionAppAppSettingInternal it will be used here
+	Id                   plugin.TValue[string]
+	Name                 plugin.TValue[string]
+	HasKeyVaultReference plugin.TValue[bool]
+	IsLikelySecret       plugin.TValue[bool]
+	SlotSetting          plugin.TValue[bool]
+	HasValue             plugin.TValue[bool]
+}
+
+// createAzureSubscriptionFunctionsServiceFunctionAppAppSetting creates a new instance of this resource
+func createAzureSubscriptionFunctionsServiceFunctionAppAppSetting(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("azure.subscription.functionsService.functionApp.appSetting", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting) MqlName() string {
+	return "azure.subscription.functionsService.functionApp.appSetting"
+}
+
+func (c *mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting) GetHasKeyVaultReference() *plugin.TValue[bool] {
+	return &c.HasKeyVaultReference
+}
+
+func (c *mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting) GetIsLikelySecret() *plugin.TValue[bool] {
+	return &c.IsLikelySecret
+}
+
+func (c *mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting) GetSlotSetting() *plugin.TValue[bool] {
+	return &c.SlotSetting
+}
+
+func (c *mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting) GetHasValue() *plugin.TValue[bool] {
+	return &c.HasValue
 }
 
 // mqlAzureSubscriptionFunctionsServiceFunctionAppFunction for the azure.subscription.functionsService.functionApp.function resource

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -1409,8 +1409,17 @@ azure.subscription.frontDoorService.subscriptionId 13.3.3
 azure.subscription.functions 13.3.3
 azure.subscription.functionsService 13.3.3
 azure.subscription.functionsService.functionApp 13.3.3
+azure.subscription.functionsService.functionApp.appSetting 13.10.2
+azure.subscription.functionsService.functionApp.appSetting.hasKeyVaultReference 13.10.2
+azure.subscription.functionsService.functionApp.appSetting.hasValue 13.10.2
+azure.subscription.functionsService.functionApp.appSetting.id 13.10.2
+azure.subscription.functionsService.functionApp.appSetting.isLikelySecret 13.10.2
+azure.subscription.functionsService.functionApp.appSetting.name 13.10.2
+azure.subscription.functionsService.functionApp.appSetting.slotSetting 13.10.2
+azure.subscription.functionsService.functionApp.appSettings 13.10.2
 azure.subscription.functionsService.functionApp.clientCertEnabled 13.3.3
 azure.subscription.functionsService.functionApp.clientCertMode 13.3.3
+azure.subscription.functionsService.functionApp.connectionStrings 13.10.2
 azure.subscription.functionsService.functionApp.defaultHostName 13.3.3
 azure.subscription.functionsService.functionApp.function 13.3.3
 azure.subscription.functionsService.functionApp.function.config 13.3.3

--- a/providers/azure/resources/functions_extras.go
+++ b/providers/azure/resources/functions_extras.go
@@ -25,7 +25,11 @@ func (a *mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting) id() (string
 // secretLikeNamePattern matches setting names that almost always carry secret
 // content. The match is case-insensitive and substring-based so suffix-style
 // names ("DB_PASSWORD") and word-style names ("StorageAccountKey") both hit.
-var secretLikeNamePattern = regexp.MustCompile(`(?i)key|password|secret|token|connection`)
+//
+// The connection-string sub-pattern only matches `conn(ection)?_?str*` rather
+// than bare `connection` so settings like `connectionRetryCount` or
+// `connectionTimeout` aren't flagged as secret-like.
+var secretLikeNamePattern = regexp.MustCompile(`(?i)key|password|secret|token|conn(?:ection)?_?str`)
 
 // isLikelySecretName classifies a setting name as "looks like it carries a
 // secret" using the regex above. Surfaced as the `isLikelySecret` field so
@@ -70,7 +74,7 @@ func (a *mqlAzureSubscriptionFunctionsServiceFunctionApp) appSettings() ([]any, 
 		return nil, err
 	}
 
-	stickyAppSettings := stickyAppSettingNames(ctx, client, rg, site)
+	stickyAppSettings, _ := stickySlotNames(ctx, client, rg, site)
 
 	res := []any{}
 	keys := sortedSettingKeys(settings.Properties)
@@ -98,44 +102,33 @@ func (a *mqlAzureSubscriptionFunctionsServiceFunctionApp) appSettings() ([]any, 
 	return res, nil
 }
 
-// stickyAppSettingNames fetches the slot-config-names resource and returns a
-// set of setting names that are pinned to the slot they were configured on
-// (i.e., they survive a slot swap). Empty set on permission errors so the
-// `slotSetting` field stays false rather than failing the broader query.
-func stickyAppSettingNames(ctx context.Context, client *web.WebAppsClient, rg, site string) map[string]bool {
-	out := map[string]bool{}
+// stickySlotNames fetches the slot-config-names resource once and returns the
+// (appSettings, connectionStrings) sets of names pinned to the slot they were
+// configured on (i.e., they survive a slot swap). Empty sets on permission
+// errors so the `slotSetting` field stays false rather than failing the
+// broader query.
+//
+// Returning both maps from a single call avoids a redundant ARM round-trip
+// when a query accesses both `appSettings` and `connectionStrings` on the
+// same function app.
+func stickySlotNames(ctx context.Context, client *web.WebAppsClient, rg, site string) (appSettings, connectionStrings map[string]bool) {
+	appSettings = map[string]bool{}
+	connectionStrings = map[string]bool{}
 	resp, err := client.ListSlotConfigurationNames(ctx, rg, site, nil)
-	if err != nil {
-		return out
-	}
-	if resp.Properties == nil {
-		return out
+	if err != nil || resp.Properties == nil {
+		return
 	}
 	for _, n := range resp.Properties.AppSettingNames {
 		if n != nil {
-			out[*n] = true
+			appSettings[*n] = true
 		}
-	}
-	return out
-}
-
-// stickyConnectionStringNames is the connection-string equivalent of
-// stickyAppSettingNames — slot-config-names tracks both lists separately.
-func stickyConnectionStringNames(ctx context.Context, client *web.WebAppsClient, rg, site string) map[string]bool {
-	out := map[string]bool{}
-	resp, err := client.ListSlotConfigurationNames(ctx, rg, site, nil)
-	if err != nil {
-		return out
-	}
-	if resp.Properties == nil {
-		return out
 	}
 	for _, n := range resp.Properties.ConnectionStringNames {
 		if n != nil {
-			out[*n] = true
+			connectionStrings[*n] = true
 		}
 	}
-	return out
+	return
 }
 
 func sortedSettingKeys(m map[string]*string) []string {
@@ -184,7 +177,7 @@ func (a *mqlAzureSubscriptionFunctionsServiceFunctionApp) connectionStrings() ([
 		return nil, err
 	}
 
-	stickyCS := stickyConnectionStringNames(ctx, client, rg, site)
+	_, stickyCS := stickySlotNames(ctx, client, rg, site)
 
 	res := []any{}
 	keys := sortedConnectionStringKeys(cs.Properties)

--- a/providers/azure/resources/functions_extras.go
+++ b/providers/azure/resources/functions_extras.go
@@ -1,0 +1,223 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	web "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v6"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers/azure/connection"
+)
+
+func (a *mqlAzureSubscriptionFunctionsServiceFunctionAppAppSetting) id() (string, error) {
+	return a.Id.Data, nil
+}
+
+// secretLikeNamePattern matches setting names that almost always carry secret
+// content. The match is case-insensitive and substring-based so suffix-style
+// names ("DB_PASSWORD") and word-style names ("StorageAccountKey") both hit.
+var secretLikeNamePattern = regexp.MustCompile(`(?i)key|password|secret|token|connection`)
+
+// isLikelySecretName classifies a setting name as "looks like it carries a
+// secret" using the regex above. Surfaced as the `isLikelySecret` field so
+// audit queries can ask "any setting that looks secret AND is not a Key Vault
+// reference" without re-implementing the regex in every policy.
+func isLikelySecretName(name string) bool {
+	return secretLikeNamePattern.MatchString(name)
+}
+
+// hasKeyVaultRefValue reports whether a Function App app-setting value resolves
+// through Azure Key Vault. Setting values that begin with `@Microsoft.KeyVault(`
+// are evaluated by App Service to a Key Vault secret at runtime.
+func hasKeyVaultRefValue(value string) bool {
+	return strings.HasPrefix(strings.TrimSpace(value), "@Microsoft.KeyVault(")
+}
+
+func (a *mqlAzureSubscriptionFunctionsServiceFunctionApp) appSettings() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+	parsed, err := ParseResourceID(a.Id.Data)
+	if err != nil {
+		return nil, err
+	}
+	site, err := parsed.Component("sites")
+	if err != nil {
+		return nil, err
+	}
+	rg := parsed.ResourceGroup
+
+	client, err := web.NewWebAppsClient(parsed.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	settings, err := client.ListApplicationSettings(ctx, rg, site, nil)
+	if err != nil {
+		if isFunctionAppForbiddenError(err) {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+
+	stickyAppSettings := stickyAppSettingNames(ctx, client, rg, site)
+
+	res := []any{}
+	keys := sortedSettingKeys(settings.Properties)
+	for _, name := range keys {
+		var value string
+		if v := settings.Properties[name]; v != nil {
+			value = *v
+		}
+		hasValue := value != ""
+		hasKV := hasKeyVaultRefValue(value)
+		mqlSetting, err := CreateResource(a.MqlRuntime, "azure.subscription.functionsService.functionApp.appSetting",
+			map[string]*llx.RawData{
+				"id":                   llx.StringData(a.Id.Data + "/config/appsettings/" + name),
+				"name":                 llx.StringData(name),
+				"hasKeyVaultReference": llx.BoolData(hasKV),
+				"isLikelySecret":       llx.BoolData(isLikelySecretName(name)),
+				"slotSetting":          llx.BoolData(stickyAppSettings[name]),
+				"hasValue":             llx.BoolData(hasValue),
+			})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlSetting)
+	}
+	return res, nil
+}
+
+// stickyAppSettingNames fetches the slot-config-names resource and returns a
+// set of setting names that are pinned to the slot they were configured on
+// (i.e., they survive a slot swap). Empty set on permission errors so the
+// `slotSetting` field stays false rather than failing the broader query.
+func stickyAppSettingNames(ctx context.Context, client *web.WebAppsClient, rg, site string) map[string]bool {
+	out := map[string]bool{}
+	resp, err := client.ListSlotConfigurationNames(ctx, rg, site, nil)
+	if err != nil {
+		return out
+	}
+	if resp.Properties == nil {
+		return out
+	}
+	for _, n := range resp.Properties.AppSettingNames {
+		if n != nil {
+			out[*n] = true
+		}
+	}
+	return out
+}
+
+// stickyConnectionStringNames is the connection-string equivalent of
+// stickyAppSettingNames — slot-config-names tracks both lists separately.
+func stickyConnectionStringNames(ctx context.Context, client *web.WebAppsClient, rg, site string) map[string]bool {
+	out := map[string]bool{}
+	resp, err := client.ListSlotConfigurationNames(ctx, rg, site, nil)
+	if err != nil {
+		return out
+	}
+	if resp.Properties == nil {
+		return out
+	}
+	for _, n := range resp.Properties.ConnectionStringNames {
+		if n != nil {
+			out[*n] = true
+		}
+	}
+	return out
+}
+
+func sortedSettingKeys(m map[string]*string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedConnectionStringKeys(m map[string]*web.ConnStringValueTypePair) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (a *mqlAzureSubscriptionFunctionsServiceFunctionApp) connectionStrings() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+	parsed, err := ParseResourceID(a.Id.Data)
+	if err != nil {
+		return nil, err
+	}
+	site, err := parsed.Component("sites")
+	if err != nil {
+		return nil, err
+	}
+	rg := parsed.ResourceGroup
+
+	client, err := web.NewWebAppsClient(parsed.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	cs, err := client.ListConnectionStrings(ctx, rg, site, nil)
+	if err != nil {
+		if isFunctionAppForbiddenError(err) {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+
+	stickyCS := stickyConnectionStringNames(ctx, client, rg, site)
+
+	res := []any{}
+	keys := sortedConnectionStringKeys(cs.Properties)
+	for _, name := range keys {
+		entry := cs.Properties[name]
+		var connType, value string
+		if entry != nil {
+			if entry.Type != nil {
+				connType = string(*entry.Type)
+			}
+			if entry.Value != nil {
+				value = *entry.Value
+			}
+		}
+		row := map[string]any{
+			"name":                 name,
+			"type":                 connType,
+			"hasKeyVaultReference": hasKeyVaultRefValue(value),
+			"slotSetting":          stickyCS[name],
+		}
+		res = append(res, row)
+	}
+	return res, nil
+}
+
+// isFunctionAppForbiddenError reports whether the err is the 403 we should
+// treat as "no settings visible" rather than fatal — the Function App's
+// app-settings/connection-strings endpoints require explicit permissions
+// (Microsoft.Web/sites/config/list/action) that the audit role may lack.
+func isFunctionAppForbiddenError(err error) bool {
+	var rerr *azcore.ResponseError
+	if errors.As(err, &rerr) {
+		return rerr.StatusCode == http.StatusForbidden
+	}
+	return false
+}

--- a/providers/azure/resources/functions_extras_test.go
+++ b/providers/azure/resources/functions_extras_test.go
@@ -1,0 +1,75 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsLikelySecretName(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"AzureWebJobsStorage", false},
+		{"FUNCTIONS_WORKER_RUNTIME", false},
+		{"WEBSITE_RUN_FROM_PACKAGE", false},
+		{"DB_PASSWORD", true},
+		{"db_password", true},
+		{"AzureWebJobsStorageKey", true},
+		{"StorageAccountKey", true},
+		{"ApiSecret", true},
+		{"my_token", true},
+		{"OAUTH_TOKEN", true},
+		{"DATABASE_CONNECTION", true},
+		{"ConnectionStrings:Default", true},
+		{"WEBSITE_INSTANCE_ID", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isLikelySecretName(tc.name))
+		})
+	}
+}
+
+func TestHasKeyVaultRefValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"empty", "", false},
+		{"plaintext", "abc123", false},
+		{"plain connection string", "Server=tcp:foo.database.windows.net", false},
+		{"key vault ref by secret uri", "@Microsoft.KeyVault(SecretUri=https://kv.vault.azure.net/secrets/x/abc)", true},
+		{"key vault ref by name+vault", "@Microsoft.KeyVault(VaultName=kv;SecretName=mySecret)", true},
+		{"with leading whitespace", "  @Microsoft.KeyVault(SecretUri=...)", true},
+		{"key vault wrong prefix not matched", "Microsoft.KeyVault(SecretUri=...)", false},
+		{"contains but doesn't start with", "fallback=@Microsoft.KeyVault(...)", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, hasKeyVaultRefValue(tc.value))
+		})
+	}
+}
+
+func TestSortedSettingKeys(t *testing.T) {
+	t.Run("empty map", func(t *testing.T) {
+		assert.Empty(t, sortedSettingKeys(nil))
+	})
+	t.Run("alphabetical order", func(t *testing.T) {
+		v1 := "x"
+		v2 := "y"
+		v3 := "z"
+		input := map[string]*string{
+			"zeta":  &v3,
+			"alpha": &v1,
+			"mu":    &v2,
+		}
+		assert.Equal(t, []string{"alpha", "mu", "zeta"}, sortedSettingKeys(input))
+	})
+}

--- a/providers/azure/resources/functions_extras_test.go
+++ b/providers/azure/resources/functions_extras_test.go
@@ -24,7 +24,14 @@ func TestIsLikelySecretName(t *testing.T) {
 		{"ApiSecret", true},
 		{"my_token", true},
 		{"OAUTH_TOKEN", true},
-		{"DATABASE_CONNECTION", true},
+		// Bare "connection" should NOT be flagged — the pattern only fires
+		// on connection-string indicators ("connectionString", "connStr", etc).
+		{"DATABASE_CONNECTION", false},
+		{"connectionRetryCount", false},
+		{"connectionTimeout", false},
+		{"DefaultConnectionString", true},
+		{"AZURE_STORAGE_CONNECTION_STRING", true},
+		{"ConnStr", true},
 		{"ConnectionStrings:Default", true},
 		{"WEBSITE_INSTANCE_ID", false},
 	}


### PR DESCRIPTION
## Summary

Adds two new accessors on `azure.subscription.functionsService.functionApp`:

- **`appSettings`** — typed sub-resource per setting. Each entry exposes name, slot-stickiness, Key-Vault-reference detection, a heuristic `isLikelySecret` flag, and `hasValue` — but never the value itself.
- **`connectionStrings`** — `[]dict` with shape `{name, type, hasKeyVaultReference, slotSetting}`. Connection-string values are likewise not exposed.

Both accessors lazy-load via the WebApps client; permission failures are treated as empty list rather than fatal so an over-scoped audit role still works on the rest of the schema.

## Audit angles unlocked

```mql
# Function App settings that look like secrets but are NOT Key Vault references
azure.subscription.functions.functionApps {
  name appSettings.where(isLikelySecret == true && hasKeyVaultReference == false) {
    name slotSetting
  }
}

# Function Apps with any non-KV connection string
azure.subscription.functions.functionApps
  .where(connectionStrings.any(_["hasKeyVaultReference"] == false))

# Slot-sticky settings (these stay put on a slot swap)
azure.subscription.functions.functionApps {
  name appSettings.where(slotSetting) { name }
}

# Function Apps that don't reference Key Vault at all (cleanup candidate)
azure.subscription.functions.functionApps
  .where(appSettings.all(_["hasKeyVaultReference"] == false))
```

## Design notes

- **Sub-resource bar** — `appSetting` uses a composite ARM-id (`<appId>/config/appsettings/<name>`) which mirrors the AWS ECS `containerDefinition.environmentVariable` precedent in this codebase: stable name within parent, real audit story per row.
- **Connection strings as `[]dict`** — the per-row shape is small and homogeneous; no per-row sub-resource queries beyond what a dict supports.
- **No values exposed** — `hasValue` and `hasKeyVaultReference` are the only signals about content. The actual value is intentionally dropped at parse time so the resource never returns secrets in query output, even when ARM does.
- **Heuristic `isLikelySecret`** — case-insensitive substring match on `key|password|secret|token|connection`. The list errs on the side of false positives (e.g., `WEBSITE_INSTANCE_ID` → false; `DB_PASSWORD` → true; `ConnectionStrings:Default` → true). Makes "any plaintext secret-like setting" a one-line query rather than a 5-line filter chain.
- **403 → empty** — `ListApplicationSettings` / `ListConnectionStrings` / `ListSlotConfigurationNames` are POST `list/action` endpoints that require explicit `Microsoft.Web/sites/config/list/Action` permission. We surface a 403 as an empty list so the rest of the audit still works on apps the caller can read.
- **Stable ordering** — settings and connection strings are sorted by name so query output is deterministic across runs (the SDK's `map[string]*string` shape doesn't preserve insertion order).

## Tests

```
go test ./providers/azure/resources/ -run "TestIsLikelySecretName|TestHasKeyVaultRefValue|TestSortedSettingKeys"
```

Covers the secret-name heuristic across realistic Function App setting names (`AzureWebJobsStorage`, `WEBSITE_RUN_FROM_PACKAGE`, `DB_PASSWORD`, `OAUTH_TOKEN`, etc.), the Key-Vault-reference value detector across edge cases (leading whitespace, wrong-prefix substring, etc.), and the deterministic ordering helper.

## Test plan

- [ ] `make providers/build/azure` succeeds (verified locally)
- [ ] `gofmt -w` clean (verified locally)
- [ ] `go test ./providers/azure/resources/...` passes (verified locally)
- [ ] `mql shell azure` against a real subscription with at least one Function App
- [ ] Spot-check: a Function App with `AzureWebJobsStorage` reports `isLikelySecret == true`
- [ ] Spot-check: a setting whose value starts with `@Microsoft.KeyVault(SecretUri=...)` reports `hasKeyVaultReference == true`
- [ ] Spot-check: a slot-sticky setting reports `slotSetting == true`
- [ ] Spot-check: a setting's value is never exposed in any output

🤖 Generated with [Claude Code](https://claude.com/claude-code)