### PR TITLE
✨ github: add organization.outsideCollaborators

### DIFF
--- a/providers/github/resources/github.lr
+++ b/providers/github/resources/github.lr
@@ -141,6 +141,9 @@ github.organization @defaults("login name") {
   owners() []github.user
   // List of users that are part of the members group
   members() []github.user
+  // List of outside collaborators — users who have access to one or more
+  // repositories in the organization but are not members of the organization
+  outsideCollaborators() []github.user
   // List of users that are part of the teams group
   teams() []github.team
   // List of repositories

--- a/providers/github/resources/github.lr.go
+++ b/providers/github/resources/github.lr.go
@@ -568,6 +568,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"github.organization.members": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubOrganization).GetMembers()).ToDataRes(types.Array(types.Resource("github.user")))
 	},
+	"github.organization.outsideCollaborators": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubOrganization).GetOutsideCollaborators()).ToDataRes(types.Array(types.Resource("github.user")))
+	},
 	"github.organization.teams": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubOrganization).GetTeams()).ToDataRes(types.Array(types.Resource("github.team")))
 	},
@@ -2605,6 +2608,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"github.organization.members": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGithubOrganization).Members, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"github.organization.outsideCollaborators": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubOrganization).OutsideCollaborators, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"github.organization.teams": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5495,6 +5502,7 @@ type mqlGithubOrganization struct {
 	ReadersCanCreateDiscussions                    plugin.TValue[bool]
 	Owners                                         plugin.TValue[[]any]
 	Members                                        plugin.TValue[[]any]
+	OutsideCollaborators                           plugin.TValue[[]any]
 	Teams                                          plugin.TValue[[]any]
 	Repositories                                   plugin.TValue[[]any]
 	Installations                                  plugin.TValue[[]any]
@@ -5765,6 +5773,22 @@ func (c *mqlGithubOrganization) GetMembers() *plugin.TValue[[]any] {
 		}
 
 		return c.members()
+	})
+}
+
+func (c *mqlGithubOrganization) GetOutsideCollaborators() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.OutsideCollaborators, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("github.organization", c.__id, "outsideCollaborators")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.outsideCollaborators()
 	})
 }
 

--- a/providers/github/resources/github.lr.versions
+++ b/providers/github/resources/github.lr.versions
@@ -397,6 +397,7 @@ github.organization.oauthApp.scopes 13.0.8
 github.organization.oauthApp.tokenLastEight 13.0.8
 github.organization.oauthApp.user 13.0.8
 github.organization.oauthApps 13.0.8
+github.organization.outsideCollaborators 13.2.4
 github.organization.ownedPrivateRepos 9.0.0
 github.organization.owners 9.0.0
 github.organization.packages 9.0.0

--- a/providers/github/resources/github_org.go
+++ b/providers/github/resources/github_org.go
@@ -215,6 +215,47 @@ func (g *mqlGithubOrganization) members() ([]any, error) {
 	return res, nil
 }
 
+func (g *mqlGithubOrganization) outsideCollaborators() ([]any, error) {
+	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
+	if g.Login.Error != nil {
+		return nil, g.Login.Error
+	}
+	orgLogin := g.Login.Data
+
+	listOpts := &github.ListOutsideCollaboratorsOptions{
+		ListOptions: github.ListOptions{PerPage: paginationPerPage},
+	}
+	var allUsers []*github.User
+	for {
+		users, resp, err := conn.Client().Organizations.ListOutsideCollaborators(conn.Context(), orgLogin, listOpts)
+		if err != nil {
+			if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "403") {
+				return nil, nil
+			}
+			return nil, err
+		}
+		allUsers = append(allUsers, users...)
+		if resp.NextPage == 0 {
+			break
+		}
+		listOpts.Page = resp.NextPage
+	}
+
+	res := []any{}
+	for i := range allUsers {
+		u := allUsers[i]
+		r, err := NewResource(g.MqlRuntime, "github.user", map[string]*llx.RawData{
+			"id":    llx.IntDataDefault(u.ID, 0),
+			"login": llx.StringDataPtr(u.Login),
+		})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, r)
+	}
+	return res, nil
+}
+
 func (g *mqlGithubOrganization) owners() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 


### PR DESCRIPTION
## Summary

Adds `organization.outsideCollaborators []github.user` — users who have access to one or more repositories in the organization but are not members of the organization. Previously unreachable from MQL; the closest signal was `membersCanInviteOutsideCollaborators` which only governs whether *new* outside collaborators can be added.

## Audit angles unlocked

```mql
# Outside collaborators on private orgs (often ex-employees with stale access)
github.organization.outsideCollaborators { login name email company }

# Outside collaborators count threshold
github.organization.outsideCollaborators.length

# Cross-reference with repo collaborators to find which repos each is on
github.organization {
  login outsideCollaborators { login }
  repositories { fullName collaborators { login } }
}
```

## Design notes

- Mirrors the existing `members()` / `owners()` accessors in `github_org.go` — same pagination loop, same 404/403-as-empty handling.
- Returns the typed `github.user` resource (same as `members`); the user fields the GitHub API returns at list time are `id` and `login`, with the rest hydrated lazily by the existing `github.user` init.
- 403 is treated as empty: `ListOutsideCollaborators` requires the caller to be an org owner, so an audit running with a less-privileged token gets `[]` rather than a fatal error.

## Test plan

- [ ] `make providers/build/github` succeeds (verified locally)
- [ ] `gofmt -w` clean (verified locally)
- [ ] `mql shell github` against an organization with at least one outside collaborator
- [ ] Spot-check: `github.organization.outsideCollaborators` returns the expected list
- [ ] Spot-check: a token without owner privileges returns `[]` rather than an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)