### PR TITLE
✨ aws: surface new SDK fields from #7578 dep bumps

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2310,6 +2310,8 @@ private aws.sagemaker.clusterInstanceGroup @defaults("instanceGroupName instance
   instanceTypeDetails []aws.sagemaker.clusterInstanceGroup.instanceTypeDetail
   // Network interface type for the instance group (e.g., efa, efa-only)
   networkInterfaceType string
+  // Image-version status for the group: LatestVersion or NewVersionAvailable
+  imageVersionStatus string
 }
 
 // Instance type detail within a flexible SageMaker HyperPod instance group
@@ -2342,6 +2344,8 @@ private aws.sagemaker.clusterNode @defaults("instanceId instanceGroupName instan
   region string
   // Network interface type for the node (e.g., efa, efa-only)
   networkInterfaceType() string
+  // Image-version status for the node: LatestVersion or NewVersionAvailable
+  imageVersionStatus string
 }
 
 // AWS SageMaker feature group
@@ -3984,6 +3988,10 @@ private aws.opensearch.domain @defaults("name engineVersion") {
   vpcId @maturity("deprecated") string
   // VPC associated with the domain
   vpc() aws.vpc
+  // Whether outbound traffic from the domain is routed through the customer
+  // VPC. When true, outbound traffic flows through the VPC; when false, it
+  // goes through the public internet. Always false for non-VPC domains.
+  vpcEgressEnabled bool
   // Whether HTTPS is required
   enforceHTTPS bool
   // TLS security policy
@@ -6719,6 +6727,8 @@ private aws.cloudfront.function @defaults("name status") {
   comment string
   // Runtime environment for the function
   runtime string
+  // Tags applied to the function
+  tags() map[string]string
 }
 
 // AWS CloudTrail

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -6482,6 +6482,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.sagemaker.clusterInstanceGroup.networkInterfaceType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSagemakerClusterInstanceGroup).GetNetworkInterfaceType()).ToDataRes(types.String)
 	},
+	"aws.sagemaker.clusterInstanceGroup.imageVersionStatus": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSagemakerClusterInstanceGroup).GetImageVersionStatus()).ToDataRes(types.String)
+	},
 	"aws.sagemaker.clusterInstanceGroup.instanceTypeDetail.instanceType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSagemakerClusterInstanceGroupInstanceTypeDetail).GetInstanceType()).ToDataRes(types.String)
 	},
@@ -6517,6 +6520,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.sagemaker.clusterNode.networkInterfaceType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSagemakerClusterNode).GetNetworkInterfaceType()).ToDataRes(types.String)
+	},
+	"aws.sagemaker.clusterNode.imageVersionStatus": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSagemakerClusterNode).GetImageVersionStatus()).ToDataRes(types.String)
 	},
 	"aws.sagemaker.featureGroup.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSagemakerFeatureGroup).GetArn()).ToDataRes(types.String)
@@ -8527,6 +8533,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.opensearch.domain.vpc": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOpensearchDomain).GetVpc()).ToDataRes(types.Resource("aws.vpc"))
+	},
+	"aws.opensearch.domain.vpcEgressEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOpensearchDomain).GetVpcEgressEnabled()).ToDataRes(types.Bool)
 	},
 	"aws.opensearch.domain.enforceHTTPS": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOpensearchDomain).GetEnforceHTTPS()).ToDataRes(types.Bool)
@@ -11749,6 +11758,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.cloudfront.function.runtime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudfrontFunction).GetRuntime()).ToDataRes(types.String)
+	},
+	"aws.cloudfront.function.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudfrontFunction).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"aws.cloudtrail.trails": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudtrail).GetTrails()).ToDataRes(types.Array(types.Resource("aws.cloudtrail.trail")))
@@ -28268,6 +28280,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsSagemakerClusterInstanceGroup).NetworkInterfaceType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.sagemaker.clusterInstanceGroup.imageVersionStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSagemakerClusterInstanceGroup).ImageVersionStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.sagemaker.clusterInstanceGroup.instanceTypeDetail.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSagemakerClusterInstanceGroupInstanceTypeDetail).__id, ok = v.Value.(string)
 		return
@@ -28322,6 +28338,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.sagemaker.clusterNode.networkInterfaceType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSagemakerClusterNode).NetworkInterfaceType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.sagemaker.clusterNode.imageVersionStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSagemakerClusterNode).ImageVersionStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.sagemaker.featureGroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31302,6 +31322,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.opensearch.domain.vpc": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsOpensearchDomain).Vpc, ok = plugin.RawToTValue[*mqlAwsVpc](v.Value, v.Error)
+		return
+	},
+	"aws.opensearch.domain.vpcEgressEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOpensearchDomain).VpcEgressEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.opensearch.domain.enforceHTTPS": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -36170,6 +36194,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.cloudfront.function.runtime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsCloudfrontFunction).Runtime, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.cloudfront.function.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudfrontFunction).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"aws.cloudtrail.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -65719,6 +65747,7 @@ type mqlAwsSagemakerClusterInstanceGroup struct {
 	InstanceRequirements plugin.TValue[any]
 	InstanceTypeDetails  plugin.TValue[[]any]
 	NetworkInterfaceType plugin.TValue[string]
+	ImageVersionStatus   plugin.TValue[string]
 }
 
 // createAwsSagemakerClusterInstanceGroup creates a new instance of this resource
@@ -65820,6 +65849,10 @@ func (c *mqlAwsSagemakerClusterInstanceGroup) GetNetworkInterfaceType() *plugin.
 	return &c.NetworkInterfaceType
 }
 
+func (c *mqlAwsSagemakerClusterInstanceGroup) GetImageVersionStatus() *plugin.TValue[string] {
+	return &c.ImageVersionStatus
+}
+
 // mqlAwsSagemakerClusterInstanceGroupInstanceTypeDetail for the aws.sagemaker.clusterInstanceGroup.instanceTypeDetail resource
 type mqlAwsSagemakerClusterInstanceGroupInstanceTypeDetail struct {
 	MqlRuntime *plugin.Runtime
@@ -65893,6 +65926,7 @@ type mqlAwsSagemakerClusterNode struct {
 	PrivateDnsHostname   plugin.TValue[string]
 	Region               plugin.TValue[string]
 	NetworkInterfaceType plugin.TValue[string]
+	ImageVersionStatus   plugin.TValue[string]
 }
 
 // createAwsSagemakerClusterNode creates a new instance of this resource
@@ -65968,6 +66002,10 @@ func (c *mqlAwsSagemakerClusterNode) GetNetworkInterfaceType() *plugin.TValue[st
 	return plugin.GetOrCompute[string](&c.NetworkInterfaceType, func() (string, error) {
 		return c.networkInterfaceType()
 	})
+}
+
+func (c *mqlAwsSagemakerClusterNode) GetImageVersionStatus() *plugin.TValue[string] {
+	return &c.ImageVersionStatus
 }
 
 // mqlAwsSagemakerFeatureGroup for the aws.sagemaker.featureGroup resource
@@ -74015,6 +74053,7 @@ type mqlAwsOpensearchDomain struct {
 	EbsThroughput               plugin.TValue[int64]
 	VpcId                       plugin.TValue[string]
 	Vpc                         plugin.TValue[*mqlAwsVpc]
+	VpcEgressEnabled            plugin.TValue[bool]
 	EnforceHTTPS                plugin.TValue[bool]
 	TlsSecurityPolicy           plugin.TValue[string]
 	CustomEndpointEnabled       plugin.TValue[bool]
@@ -74211,6 +74250,10 @@ func (c *mqlAwsOpensearchDomain) GetVpc() *plugin.TValue[*mqlAwsVpc] {
 
 		return c.vpc()
 	})
+}
+
+func (c *mqlAwsOpensearchDomain) GetVpcEgressEnabled() *plugin.TValue[bool] {
+	return &c.VpcEgressEnabled
 }
 
 func (c *mqlAwsOpensearchDomain) GetEnforceHTTPS() *plugin.TValue[bool] {
@@ -87999,6 +88042,7 @@ type mqlAwsCloudfrontFunction struct {
 	Stage            plugin.TValue[string]
 	Comment          plugin.TValue[string]
 	Runtime          plugin.TValue[string]
+	Tags             plugin.TValue[map[string]any]
 }
 
 // createAwsCloudfrontFunction creates a new instance of this resource
@@ -88068,6 +88112,12 @@ func (c *mqlAwsCloudfrontFunction) GetComment() *plugin.TValue[string] {
 
 func (c *mqlAwsCloudfrontFunction) GetRuntime() *plugin.TValue[string] {
 	return &c.Runtime
+}
+
+func (c *mqlAwsCloudfrontFunction) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
 }
 
 // mqlAwsCloudtrail for the aws.cloudtrail resource

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -878,6 +878,7 @@ aws.cloudfront.function.name 11.15.2
 aws.cloudfront.function.runtime 11.15.2
 aws.cloudfront.function.stage 11.15.2
 aws.cloudfront.function.status 11.15.2
+aws.cloudfront.function.tags 13.21.4
 aws.cloudfront.functions 11.15.2
 aws.cloudfront.trustStore 13.20.1
 aws.cloudfront.trustStore.arn 13.20.1
@@ -4780,6 +4781,7 @@ aws.opensearch.domain.tags 11.15.2
 aws.opensearch.domain.tlsSecurityPolicy 11.15.2
 aws.opensearch.domain.upgradeProcessing 11.15.2
 aws.opensearch.domain.vpc 11.16.1
+aws.opensearch.domain.vpcEgressEnabled 13.21.4
 aws.opensearch.domain.vpcId 11.15.2
 aws.opensearch.domain.warmCount 11.15.2
 aws.opensearch.domain.warmEnabled 11.15.2
@@ -5533,6 +5535,7 @@ aws.sagemaker.cluster.vpc 13.12.0
 aws.sagemaker.clusterInstanceGroup 13.12.0
 aws.sagemaker.clusterInstanceGroup.currentCount 13.12.0
 aws.sagemaker.clusterInstanceGroup.iamRole 13.12.0
+aws.sagemaker.clusterInstanceGroup.imageVersionStatus 13.21.4
 aws.sagemaker.clusterInstanceGroup.instanceGroupName 13.12.0
 aws.sagemaker.clusterInstanceGroup.instanceRequirements 13.12.2
 aws.sagemaker.clusterInstanceGroup.instanceType 13.12.0
@@ -5548,6 +5551,7 @@ aws.sagemaker.clusterInstanceGroup.status 13.12.0
 aws.sagemaker.clusterInstanceGroup.targetCount 13.12.0
 aws.sagemaker.clusterInstanceGroup.threadsPerCore 13.12.0
 aws.sagemaker.clusterNode 13.12.0
+aws.sagemaker.clusterNode.imageVersionStatus 13.21.4
 aws.sagemaker.clusterNode.instanceGroupName 13.12.0
 aws.sagemaker.clusterNode.instanceId 13.12.0
 aws.sagemaker.clusterNode.instanceType 13.12.0

--- a/providers/aws/resources/aws_cloudfront.go
+++ b/providers/aws/resources/aws_cloudfront.go
@@ -192,6 +192,35 @@ func (a *mqlAwsCloudfrontFunction) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
+func (a *mqlAwsCloudfrontFunction) tags() (map[string]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Cloudfront("")
+	ctx := context.Background()
+
+	resp, err := svc.ListTagsForResource(ctx, &cloudfront.ListTagsForResourceInput{
+		Resource: &a.Arn.Data,
+	})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return map[string]any{}, nil
+		}
+		return nil, err
+	}
+	tags := make(map[string]any)
+	if resp.Tags != nil {
+		for _, tag := range resp.Tags.Items {
+			if tag.Key != nil {
+				val := ""
+				if tag.Value != nil {
+					val = *tag.Value
+				}
+				tags[*tag.Key] = val
+			}
+		}
+	}
+	return tags, nil
+}
+
 func (a *mqlAwsCloudfront) functions() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 

--- a/providers/aws/resources/aws_opensearch.go
+++ b/providers/aws/resources/aws_opensearch.go
@@ -185,12 +185,14 @@ func newMqlAwsOpensearchDomain(runtime *plugin.Runtime, region string, accountID
 	sgArns := []string{}
 	subnetIds := []string{}
 	var vpcId string
+	var vpcEgressEnabled bool
 	if domain.VPCOptions != nil {
 		for _, sgId := range domain.VPCOptions.SecurityGroupIds {
 			sgArns = append(sgArns, NewSecurityGroupArn(region, accountID, sgId))
 		}
 		subnetIds = domain.VPCOptions.SubnetIds
 		vpcId = convert.ToValue(domain.VPCOptions.VPCId)
+		vpcEgressEnabled = convert.ToValue(domain.VPCOptions.EgressEnabled)
 	}
 
 	// Get endpoint
@@ -367,6 +369,7 @@ func newMqlAwsOpensearchDomain(runtime *plugin.Runtime, region string, accountID
 			"ebsIops":                     llx.IntData(ebsIops),
 			"ebsThroughput":               llx.IntData(ebsThroughput),
 			"vpcId":                       llx.StringData(vpcId),
+			"vpcEgressEnabled":            llx.BoolData(vpcEgressEnabled),
 			"enforceHTTPS":                llx.BoolData(enforceHTTPS),
 			"tlsSecurityPolicy":           llx.StringData(tlsSecurityPolicy),
 			"customEndpointEnabled":       llx.BoolData(customEndpointEnabled),

--- a/providers/aws/resources/aws_sagemaker.go
+++ b/providers/aws/resources/aws_sagemaker.go
@@ -2464,6 +2464,7 @@ func (a *mqlAwsSagemakerCluster) instanceGroups() ([]any, error) {
 				"instanceRequirements": llx.DictData(instanceRequirements),
 				"instanceTypeDetails":  llx.ArrayData(instanceTypeDetails, types.Resource("aws.sagemaker.clusterInstanceGroup.instanceTypeDetail")),
 				"networkInterfaceType": llx.StringData(networkInterfaceType),
+				"imageVersionStatus":   llx.StringData(string(ig.ImageVersionStatus)),
 			})
 		if err != nil {
 			return nil, err
@@ -2557,6 +2558,7 @@ func (a *mqlAwsSagemakerCluster) nodes() ([]any, error) {
 					"launchedAt":         llx.TimeDataPtr(node.LaunchTime),
 					"privateDnsHostname": llx.StringDataPtr(node.PrivateDnsHostname),
 					"region":             llx.StringData(a.Region.Data),
+					"imageVersionStatus": llx.StringData(string(node.ImageVersionStatus)),
 				})
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## Summary

Three additive fields enabled by the AWS SDK bumps that landed via #7578 (\`20260507\` deps update):

- **\`aws.opensearch.domain.vpcEgressEnabled\`** (opensearch SDK v1.68.0) — whether outbound traffic from the domain is routed through the customer VPC vs. the public internet. New auditable network-posture signal alongside the existing \`vpc()\` typed ref.
- **\`aws.cloudfront.function.tags\`** (cloudfront SDK v1.63.0) — tags applied to a function. CloudFront Functions gained tagging support in this SDK release. Implemented as a lazy method via \`ListTagsForResource\`.
- **\`aws.sagemaker.clusterInstanceGroup.imageVersionStatus\`** + **\`aws.sagemaker.clusterNode.imageVersionStatus\`** (sagemaker SDK v1.246.0) — HyperPod instance groups and nodes now report whether they are on the latest image version (\`LatestVersion\` / \`NewVersionAvailable\`).

The corresponding SDK packages are already on the matching versions in \`providers/aws/go.mod\` after #7578, so this PR doesn't carry any dep bumps. New entries land at \`aws.lr.versions\` 13.21.4 — fully BC.

## Test plan

- [x] \`make providers/build/aws && make providers/install/aws\` clean; \`aws.permissions.json\` regenerates (cloudfront tags adds no new IAM permission since the existing \`cloudfront:ListTagsForResource\` covers it).
- [x] \`mql run aws -c \"aws.opensearch.domains.length\"\` / \`aws.cloudfront.functions.length\` / \`aws.sagemaker.clusters.length\` return 0 cleanly on an account with none of those resources.
- [x] \`gofmt\` and \`go vet\` clean.
- [ ] Spot-check on an account that actually has a VPC OpenSearch domain (egress on/off), a tagged CloudFront Function, and a HyperPod cluster (mixed image-version state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)