### PR TITLE
✨ github: add repository.vulnerabilityAlertsEnabled and privateVulnerabilityReportingEnabled

### DIFF
--- a/providers/github/resources/github.lr
+++ b/providers/github/resources/github.lr
@@ -638,6 +638,12 @@ github.repository @defaults("fullName") {
   secretScanningValidityChecksEnabled bool
   // Whether GitHub code security is enabled
   codeSecurityEnabled bool
+  // Whether Dependabot vulnerability alerts are enabled on the repository.
+  // Required for `dependabotSecurityUpdatesEnabled` to deliver auto-fix PRs.
+  vulnerabilityAlertsEnabled() bool
+  // Whether private vulnerability reporting is enabled on the repository.
+  // When true, security researchers can submit private advisories to maintainers.
+  privateVulnerabilityReportingEnabled() bool
   // Whether web-based commit signoff is required
   webCommitSignoffRequired bool
   // Repository rulesets

--- a/providers/github/resources/github.lr.go
+++ b/providers/github/resources/github.lr.go
@@ -1216,6 +1216,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"github.repository.codeSecurityEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubRepository).GetCodeSecurityEnabled()).ToDataRes(types.Bool)
 	},
+	"github.repository.vulnerabilityAlertsEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubRepository).GetVulnerabilityAlertsEnabled()).ToDataRes(types.Bool)
+	},
+	"github.repository.privateVulnerabilityReportingEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubRepository).GetPrivateVulnerabilityReportingEnabled()).ToDataRes(types.Bool)
+	},
 	"github.repository.webCommitSignoffRequired": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubRepository).GetWebCommitSignoffRequired()).ToDataRes(types.Bool)
 	},
@@ -3536,6 +3542,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"github.repository.codeSecurityEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGithubRepository).CodeSecurityEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"github.repository.vulnerabilityAlertsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubRepository).VulnerabilityAlertsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"github.repository.privateVulnerabilityReportingEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubRepository).PrivateVulnerabilityReportingEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"github.repository.webCommitSignoffRequired": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7535,84 +7549,86 @@ type mqlGithubRepository struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlGithubRepositoryInternal
-	Id                                  plugin.TValue[int64]
-	Name                                plugin.TValue[string]
-	FullName                            plugin.TValue[string]
-	Description                         plugin.TValue[string]
-	CloneUrl                            plugin.TValue[string]
-	SshUrl                              plugin.TValue[string]
-	Homepage                            plugin.TValue[string]
-	Topics                              plugin.TValue[[]any]
-	Language                            plugin.TValue[string]
-	WatchersCount                       plugin.TValue[int64]
-	ForksCount                          plugin.TValue[int64]
-	StargazersCount                     plugin.TValue[int64]
-	OpenIssuesCount                     plugin.TValue[int64]
-	CreatedAt                           plugin.TValue[*time.Time]
-	UpdatedAt                           plugin.TValue[*time.Time]
-	PushedAt                            plugin.TValue[*time.Time]
-	Archived                            plugin.TValue[bool]
-	Disabled                            plugin.TValue[bool]
-	Private                             plugin.TValue[bool]
-	IsFork                              plugin.TValue[bool]
-	Visibility                          plugin.TValue[string]
-	AllowAutoMerge                      plugin.TValue[bool]
-	AllowForking                        plugin.TValue[bool]
-	AllowMergeCommit                    plugin.TValue[bool]
-	AllowRebaseMerge                    plugin.TValue[bool]
-	AllowSquashMerge                    plugin.TValue[bool]
-	HasIssues                           plugin.TValue[bool]
-	HasProjects                         plugin.TValue[bool]
-	HasWiki                             plugin.TValue[bool]
-	HasPages                            plugin.TValue[bool]
-	HasDownloads                        plugin.TValue[bool]
-	HasDiscussions                      plugin.TValue[bool]
-	IsTemplate                          plugin.TValue[bool]
-	CustomProperties                    plugin.TValue[any]
-	OpenMergeRequests                   plugin.TValue[[]any]
-	ClosedMergeRequests                 plugin.TValue[[]any]
-	AllMergeRequests                    plugin.TValue[[]any]
-	Branches                            plugin.TValue[[]any]
-	DefaultBranchName                   plugin.TValue[string]
-	DefaultBranch                       plugin.TValue[*mqlGithubBranch]
-	Commits                             plugin.TValue[[]any]
-	Contributors                        plugin.TValue[[]any]
-	Collaborators                       plugin.TValue[[]any]
-	AdminCollaborators                  plugin.TValue[[]any]
-	Files                               plugin.TValue[[]any]
-	Releases                            plugin.TValue[[]any]
-	Owner                               plugin.TValue[*mqlGithubUser]
-	Webhooks                            plugin.TValue[[]any]
-	Workflows                           plugin.TValue[[]any]
-	Forks                               plugin.TValue[[]any]
-	Stargazers                          plugin.TValue[[]any]
-	OpenIssues                          plugin.TValue[[]any]
-	ClosedIssues                        plugin.TValue[[]any]
-	Milestones                          plugin.TValue[[]any]
-	License                             plugin.TValue[*mqlGithubLicense]
-	CodeOfConductFile                   plugin.TValue[*mqlGithubFile]
-	SupportFile                         plugin.TValue[*mqlGithubFile]
-	SecurityFile                        plugin.TValue[*mqlGithubFile]
-	DependabotAlerts                    plugin.TValue[[]any]
-	SecretScanningAlerts                plugin.TValue[[]any]
-	CodeScanningAlerts                  plugin.TValue[[]any]
-	Runners                             plugin.TValue[[]any]
-	Environments                        plugin.TValue[[]any]
-	Deployments                         plugin.TValue[[]any]
-	SpdxSbom                            plugin.TValue[*mqlGithubRepositorySbom]
-	AdvancedSecurityEnabled             plugin.TValue[bool]
-	SecretScanningEnabled               plugin.TValue[bool]
-	SecretScanningPushProtectionEnabled plugin.TValue[bool]
-	DependabotSecurityUpdatesEnabled    plugin.TValue[bool]
-	SecretScanningValidityChecksEnabled plugin.TValue[bool]
-	CodeSecurityEnabled                 plugin.TValue[bool]
-	WebCommitSignoffRequired            plugin.TValue[bool]
-	Rulesets                            plugin.TValue[[]any]
-	ActionsSettings                     plugin.TValue[*mqlGithubRepositoryActionsSettings]
-	DeployKeys                          plugin.TValue[[]any]
-	Codeowners                          plugin.TValue[*mqlGithubRepositoryCodeowners]
-	Secrets                             plugin.TValue[[]any]
-	Variables                           plugin.TValue[[]any]
+	Id                                   plugin.TValue[int64]
+	Name                                 plugin.TValue[string]
+	FullName                             plugin.TValue[string]
+	Description                          plugin.TValue[string]
+	CloneUrl                             plugin.TValue[string]
+	SshUrl                               plugin.TValue[string]
+	Homepage                             plugin.TValue[string]
+	Topics                               plugin.TValue[[]any]
+	Language                             plugin.TValue[string]
+	WatchersCount                        plugin.TValue[int64]
+	ForksCount                           plugin.TValue[int64]
+	StargazersCount                      plugin.TValue[int64]
+	OpenIssuesCount                      plugin.TValue[int64]
+	CreatedAt                            plugin.TValue[*time.Time]
+	UpdatedAt                            plugin.TValue[*time.Time]
+	PushedAt                             plugin.TValue[*time.Time]
+	Archived                             plugin.TValue[bool]
+	Disabled                             plugin.TValue[bool]
+	Private                              plugin.TValue[bool]
+	IsFork                               plugin.TValue[bool]
+	Visibility                           plugin.TValue[string]
+	AllowAutoMerge                       plugin.TValue[bool]
+	AllowForking                         plugin.TValue[bool]
+	AllowMergeCommit                     plugin.TValue[bool]
+	AllowRebaseMerge                     plugin.TValue[bool]
+	AllowSquashMerge                     plugin.TValue[bool]
+	HasIssues                            plugin.TValue[bool]
+	HasProjects                          plugin.TValue[bool]
+	HasWiki                              plugin.TValue[bool]
+	HasPages                             plugin.TValue[bool]
+	HasDownloads                         plugin.TValue[bool]
+	HasDiscussions                       plugin.TValue[bool]
+	IsTemplate                           plugin.TValue[bool]
+	CustomProperties                     plugin.TValue[any]
+	OpenMergeRequests                    plugin.TValue[[]any]
+	ClosedMergeRequests                  plugin.TValue[[]any]
+	AllMergeRequests                     plugin.TValue[[]any]
+	Branches                             plugin.TValue[[]any]
+	DefaultBranchName                    plugin.TValue[string]
+	DefaultBranch                        plugin.TValue[*mqlGithubBranch]
+	Commits                              plugin.TValue[[]any]
+	Contributors                         plugin.TValue[[]any]
+	Collaborators                        plugin.TValue[[]any]
+	AdminCollaborators                   plugin.TValue[[]any]
+	Files                                plugin.TValue[[]any]
+	Releases                             plugin.TValue[[]any]
+	Owner                                plugin.TValue[*mqlGithubUser]
+	Webhooks                             plugin.TValue[[]any]
+	Workflows                            plugin.TValue[[]any]
+	Forks                                plugin.TValue[[]any]
+	Stargazers                           plugin.TValue[[]any]
+	OpenIssues                           plugin.TValue[[]any]
+	ClosedIssues                         plugin.TValue[[]any]
+	Milestones                           plugin.TValue[[]any]
+	License                              plugin.TValue[*mqlGithubLicense]
+	CodeOfConductFile                    plugin.TValue[*mqlGithubFile]
+	SupportFile                          plugin.TValue[*mqlGithubFile]
+	SecurityFile                         plugin.TValue[*mqlGithubFile]
+	DependabotAlerts                     plugin.TValue[[]any]
+	SecretScanningAlerts                 plugin.TValue[[]any]
+	CodeScanningAlerts                   plugin.TValue[[]any]
+	Runners                              plugin.TValue[[]any]
+	Environments                         plugin.TValue[[]any]
+	Deployments                          plugin.TValue[[]any]
+	SpdxSbom                             plugin.TValue[*mqlGithubRepositorySbom]
+	AdvancedSecurityEnabled              plugin.TValue[bool]
+	SecretScanningEnabled                plugin.TValue[bool]
+	SecretScanningPushProtectionEnabled  plugin.TValue[bool]
+	DependabotSecurityUpdatesEnabled     plugin.TValue[bool]
+	SecretScanningValidityChecksEnabled  plugin.TValue[bool]
+	CodeSecurityEnabled                  plugin.TValue[bool]
+	VulnerabilityAlertsEnabled           plugin.TValue[bool]
+	PrivateVulnerabilityReportingEnabled plugin.TValue[bool]
+	WebCommitSignoffRequired             plugin.TValue[bool]
+	Rulesets                             plugin.TValue[[]any]
+	ActionsSettings                      plugin.TValue[*mqlGithubRepositoryActionsSettings]
+	DeployKeys                           plugin.TValue[[]any]
+	Codeowners                           plugin.TValue[*mqlGithubRepositoryCodeowners]
+	Secrets                              plugin.TValue[[]any]
+	Variables                            plugin.TValue[[]any]
 }
 
 // createGithubRepository creates a new instance of this resource
@@ -8282,6 +8298,18 @@ func (c *mqlGithubRepository) GetSecretScanningValidityChecksEnabled() *plugin.T
 
 func (c *mqlGithubRepository) GetCodeSecurityEnabled() *plugin.TValue[bool] {
 	return &c.CodeSecurityEnabled
+}
+
+func (c *mqlGithubRepository) GetVulnerabilityAlertsEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.VulnerabilityAlertsEnabled, func() (bool, error) {
+		return c.vulnerabilityAlertsEnabled()
+	})
+}
+
+func (c *mqlGithubRepository) GetPrivateVulnerabilityReportingEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.PrivateVulnerabilityReportingEnabled, func() (bool, error) {
+		return c.privateVulnerabilityReportingEnabled()
+	})
 }
 
 func (c *mqlGithubRepository) GetWebCommitSignoffRequired() *plugin.TValue[bool] {

--- a/providers/github/resources/github.lr.versions
+++ b/providers/github/resources/github.lr.versions
@@ -547,6 +547,7 @@ github.repository.openIssuesCount 9.0.0
 github.repository.openMergeRequests 9.0.0
 github.repository.owner 9.0.0
 github.repository.private 9.0.0
+github.repository.privateVulnerabilityReportingEnabled 13.2.4
 github.repository.pushedAt 9.0.0
 github.repository.releases 9.0.0
 github.repository.rulesets 11.4.131
@@ -593,6 +594,7 @@ github.repository.topics 9.0.0
 github.repository.updatedAt 9.0.0
 github.repository.variables 13.1.1
 github.repository.visibility 9.0.0
+github.repository.vulnerabilityAlertsEnabled 13.2.4
 github.repository.watchersCount 9.0.0
 github.repository.webCommitSignoffRequired 11.4.131
 github.repository.webhooks 9.0.0

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -2666,3 +2666,35 @@ func (g *mqlGithubRepository) actionsSettings() (*mqlGithubRepositoryActionsSett
 	}
 	return res.(*mqlGithubRepositoryActionsSettings), nil
 }
+
+func (g *mqlGithubRepository) vulnerabilityAlertsEnabled() (bool, error) {
+	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return false, err
+	}
+	enabled, _, err := conn.Client().Repositories.GetVulnerabilityAlerts(conn.Context(), ownerLogin, repoName)
+	if err != nil {
+		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "403") {
+			return false, nil
+		}
+		return false, err
+	}
+	return enabled, nil
+}
+
+func (g *mqlGithubRepository) privateVulnerabilityReportingEnabled() (bool, error) {
+	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return false, err
+	}
+	enabled, _, err := conn.Client().Repositories.IsPrivateReportingEnabled(conn.Context(), ownerLogin, repoName)
+	if err != nil {
+		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "403") {
+			return false, nil
+		}
+		return false, err
+	}
+	return enabled, nil
+}

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"path"
 	"strconv"
 	"strings"
@@ -2667,6 +2668,18 @@ func (g *mqlGithubRepository) actionsSettings() (*mqlGithubRepositoryActionsSett
 	return res.(*mqlGithubRepositoryActionsSettings), nil
 }
 
+// githubResponseStatus returns the HTTP status code of a go-github error, or
+// 0 when err is not an *github.ErrorResponse. Used to classify 404 (feature
+// does not apply) versus 403 (no permission) without brittle substring
+// matching on err.Error().
+func githubResponseStatus(err error) int {
+	var ghErr *github.ErrorResponse
+	if errors.As(err, &ghErr) && ghErr.Response != nil {
+		return ghErr.Response.StatusCode
+	}
+	return 0
+}
+
 func (g *mqlGithubRepository) vulnerabilityAlertsEnabled() (bool, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 	ownerLogin, repoName, err := repoOwnerAndName(g)
@@ -2675,16 +2688,17 @@ func (g *mqlGithubRepository) vulnerabilityAlertsEnabled() (bool, error) {
 	}
 	enabled, _, err := conn.Client().Repositories.GetVulnerabilityAlerts(conn.Context(), ownerLogin, repoName)
 	if err != nil {
-		// 404: feature does not apply to this repo (e.g., disabled at the
-		// org level on archived repos). Surface as `false` cleanly.
-		if strings.Contains(err.Error(), "404") {
+		switch githubResponseStatus(err) {
+		case http.StatusNotFound:
+			// Feature does not apply to this repo (e.g., archived repos
+			// where the setting is disabled at the org level). Surface
+			// as `false` cleanly.
 			return false, nil
-		}
-		// 403: caller lacks permission to read the setting. Returning
-		// `false` here would falsely report "alerts disabled", so we log a
-		// warning to surface the unreliable result and still return false
-		// so the rest of the audit row renders.
-		if strings.Contains(err.Error(), "403") {
+		case http.StatusForbidden:
+			// Caller lacks permission to read the setting. Returning
+			// `false` would falsely report "alerts disabled", so we log
+			// a warning to surface the unreliable result and still
+			// return false so the rest of the audit row renders.
 			log.Warn().Err(err).Str("owner", ownerLogin).Str("repo", repoName).
 				Msg("permission denied reading vulnerability-alerts setting; reporting as disabled")
 			return false, nil
@@ -2702,10 +2716,10 @@ func (g *mqlGithubRepository) privateVulnerabilityReportingEnabled() (bool, erro
 	}
 	enabled, _, err := conn.Client().Repositories.IsPrivateReportingEnabled(conn.Context(), ownerLogin, repoName)
 	if err != nil {
-		if strings.Contains(err.Error(), "404") {
+		switch githubResponseStatus(err) {
+		case http.StatusNotFound:
 			return false, nil
-		}
-		if strings.Contains(err.Error(), "403") {
+		case http.StatusForbidden:
 			log.Warn().Err(err).Str("owner", ownerLogin).Str("repo", repoName).
 				Msg("permission denied reading private-vulnerability-reporting setting; reporting as disabled")
 			return false, nil

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -2675,7 +2675,18 @@ func (g *mqlGithubRepository) vulnerabilityAlertsEnabled() (bool, error) {
 	}
 	enabled, _, err := conn.Client().Repositories.GetVulnerabilityAlerts(conn.Context(), ownerLogin, repoName)
 	if err != nil {
-		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "403") {
+		// 404: feature does not apply to this repo (e.g., disabled at the
+		// org level on archived repos). Surface as `false` cleanly.
+		if strings.Contains(err.Error(), "404") {
+			return false, nil
+		}
+		// 403: caller lacks permission to read the setting. Returning
+		// `false` here would falsely report "alerts disabled", so we log a
+		// warning to surface the unreliable result and still return false
+		// so the rest of the audit row renders.
+		if strings.Contains(err.Error(), "403") {
+			log.Warn().Err(err).Str("owner", ownerLogin).Str("repo", repoName).
+				Msg("permission denied reading vulnerability-alerts setting; reporting as disabled")
 			return false, nil
 		}
 		return false, err
@@ -2691,7 +2702,12 @@ func (g *mqlGithubRepository) privateVulnerabilityReportingEnabled() (bool, erro
 	}
 	enabled, _, err := conn.Client().Repositories.IsPrivateReportingEnabled(conn.Context(), ownerLogin, repoName)
 	if err != nil {
-		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "403") {
+		if strings.Contains(err.Error(), "404") {
+			return false, nil
+		}
+		if strings.Contains(err.Error(), "403") {
+			log.Warn().Err(err).Str("owner", ownerLogin).Str("repo", repoName).
+				Msg("permission denied reading private-vulnerability-reporting setting; reporting as disabled")
 			return false, nil
 		}
 		return false, err


### PR DESCRIPTION
## Summary

Two new lazy boolean accessors on `github.repository`, complementing the existing `security_and_analysis` block (advancedSecurityEnabled, secretScanningEnabled, secretScanningPushProtectionEnabled, dependabotSecurityUpdatesEnabled, secretScanningValidityChecksEnabled, codeSecurityEnabled):

- **`vulnerabilityAlertsEnabled`** — `Repositories.GetVulnerabilityAlerts`. This is the master Dependabot-alerts toggle. Required for `dependabotSecurityUpdatesEnabled = true` to actually deliver auto-fix PRs (a repo with security updates on but alerts off is misconfigured).
- **`privateVulnerabilityReportingEnabled`** — `Repositories.IsPrivateReportingEnabled`. When true, security researchers can submit private advisories to maintainers. Common audit ask for any repo with a public-facing surface.

## Audit angles unlocked

```mql
# Repos with security updates on but alerts off — misconfigured
github.organization.repositories
  .where(dependabotSecurityUpdatesEnabled == true)
  .where(vulnerabilityAlertsEnabled == false)

# Public repos without private vulnerability reporting
github.organization.repositories
  .where(visibility == "public")
  .where(privateVulnerabilityReportingEnabled == false)

# Coverage rollup — repos with neither alerts nor private reporting
github.organization.repositories
  .where(vulnerabilityAlertsEnabled == false)
  .where(privateVulnerabilityReportingEnabled == false)
```

## Design notes

- Both fields are lazy (computed accessors) because they require separate API calls per repo. The 5 existing security fields are populated from the repo `security_and_analysis` block which comes "free" with the repo list/get response.
- 403/404 → false rather than fatal. Mirrors the existing pattern across the github provider for endpoints that not all tokens have permission to read.
- `secretScanningNonProviderPatterns` from the GitHub REST API is intentionally **not** added — go-github v85's `SecurityAndAnalysis` type doesn't yet expose it. Follow-up when the SDK catches up.

## Test plan

- [ ] `make providers/build/github` succeeds (verified locally)
- [ ] `gofmt -w` clean (verified locally)
- [ ] `mql shell github` against an organization with at least one repo
- [ ] Spot-check: a repo with Dependabot alerts disabled reports `vulnerabilityAlertsEnabled == false`
- [ ] Spot-check: a public repo with private vulnerability reporting on reports `privateVulnerabilityReportingEnabled == true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)