### PR TITLE
🧹 github: bump go-github v85 → v86

### DIFF
--- a/providers/github/connection/connection.go
+++ b/providers/github/connection/connection.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/cockroachdb/errors"
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/mitchellh/hashstructure/v2"
 	"github.com/rs/zerolog"

--- a/providers/github/connection/connection_test.go
+++ b/providers/github/connection/connection_test.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"

--- a/providers/github/go.mod
+++ b/providers/github/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.18.0
 	github.com/cockroachdb/errors v1.13.0
 	github.com/gobwas/glob v0.2.3
-	github.com/google/go-github/v85 v85.0.0
+	github.com/google/go-github/v86 v86.0.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/rs/zerolog v1.35.1

--- a/providers/github/go.sum
+++ b/providers/github/go.sum
@@ -458,8 +458,8 @@ github.com/google/go-containerregistry v0.20.7 h1:24VGNpS0IwrOZ2ms2P1QE3Xa5X9p4p
 github.com/google/go-containerregistry v0.20.7/go.mod h1:Lx5LCZQjLH1QBaMPeGwsME9biPeo1lPx6lbGj/UmzgM=
 github.com/google/go-github/v84 v84.0.0 h1:I/0Xn5IuChMe8TdmI2bbim5nyhaRFJ7DEdzmD2w+yVA=
 github.com/google/go-github/v84 v84.0.0/go.mod h1:WwYL1z1ajRdlaPszjVu/47x1L0PXukJBn73xsiYrRRQ=
-github.com/google/go-github/v85 v85.0.0 h1:1+TLFX/akTFXK7o9Z9uAloQGufOn4ySa5DItUM1VWT4=
-github.com/google/go-github/v85 v85.0.0/go.mod h1:jYkBnqN+SzR2A2fGKYfbt6DEEQAyxeK0Q2XpPV9ZFsU=
+github.com/google/go-github/v86 v86.0.0 h1:S/6aANJhwRm8EQmGKVML3j41yq0h2BsTP8FnDkO7kcA=
+github.com/google/go-github/v86 v86.0.0/go.mod h1:zKv1l4SwDXNFMGByi2FWkq71KwSXqj/eQRZuqtmcot8=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/gobwas/glob"
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/logger"

--- a/providers/github/resources/git.go
+++ b/providers/github/resources/git.go
@@ -4,7 +4,7 @@
 package resources
 
 import (
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )

--- a/providers/github/resources/github.go
+++ b/providers/github/resources/github.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_actions_secrets.go
+++ b/providers/github/resources/github_actions_secrets.go
@@ -4,7 +4,7 @@
 package resources
 
 import (
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_audit.go
+++ b/providers/github/resources/github_audit.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"strings"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"

--- a/providers/github/resources/github_environments.go
+++ b/providers/github/resources/github_environments.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_org.go
+++ b/providers/github/resources/github_org.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/internal/workerpool"
 	"go.mondoo.com/mql/v13/llx"

--- a/providers/github/resources/github_package.go
+++ b/providers/github/resources/github_package.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/logger"

--- a/providers/github/resources/github_repo_test.go
+++ b/providers/github/resources/github_repo_test.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"testing"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/providers/github/resources/github_runners.go
+++ b/providers/github/resources/github_runners.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_runners_test.go
+++ b/providers/github/resources/github_runners_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/providers/github/resources/github_security.go
+++ b/providers/github/resources/github_security.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -47,11 +47,11 @@ func isAccessDeniedOrNotFound(err error) bool {
 // given relative URL and decodes the JSON body into v. Useful for endpoints not
 // yet covered by go-github helpers.
 func doRawJSON(ctx context.Context, client *github.Client, urlStr string, v any) (*github.Response, error) {
-	req, err := client.NewRequest(http.MethodGet, urlStr, nil)
+	req, err := client.NewRequest(ctx, http.MethodGet, urlStr, nil)
 	if err != nil {
 		return nil, err
 	}
-	return client.Do(ctx, req, v)
+	return client.Do(req, v)
 }
 
 // doRawGraphQL performs a POST against the GraphQL endpoint with the given
@@ -61,11 +61,11 @@ func doRawGraphQL(ctx context.Context, client *github.Client, query string, vars
 	if vars != nil {
 		body["variables"] = vars
 	}
-	req, err := client.NewRequest(http.MethodPost, "graphql", body)
+	req, err := client.NewRequest(ctx, http.MethodPost, "graphql", body)
 	if err != nil {
 		return nil, err
 	}
-	return client.Do(ctx, req, v)
+	return client.Do(req, v)
 }
 
 // ---------- SAML config (GraphQL) ----------

--- a/providers/github/resources/github_team.go
+++ b/providers/github/resources/github_team.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers/github/connection"
 )

--- a/providers/github/resources/github_user.go
+++ b/providers/github/resources/github_user.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/logger"

--- a/providers/github/resources/github_workflow.go
+++ b/providers/github/resources/github_workflow.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v86/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/github/connection"


### PR DESCRIPTION
## Summary

Bumps \`github.com/google/go-github\` from \`v85.0.0\` to \`v86.0.0\` in the github provider, with the 18 import paths rewritten from \`/v85\` to \`/v86\`.

## Breaking changes handled

Two API signature changes in v86 affect us, both in \`providers/github/resources/github_security.go\` (our \`doRawJSON\` / \`doRawGraphQL\` helpers used for GraphQL queries and a handful of REST endpoints not yet covered by go-github):

| API | v85 | v86 |
|---|---|---|
| \`client.NewRequest\` | \`(method, url, body)\` | \`(ctx, method, url, body, ...opts)\` — ctx stamped on the request |
| \`client.Do\` | \`(ctx, req, v)\` | \`(req, v)\` — ctx now carried by the request |

The \`ctx\` parameter is still threaded into our wrappers and forwarded to \`NewRequest\`, so call-site behavior is unchanged for everything that calls \`doRawJSON\` / \`doRawGraphQL\`.

The rest of the diff is the mechanical \`/v85\` → \`/v86\` import rewrite.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go vet ./...\` clean (one pre-existing warning in \`platform.go\` unrelated to this PR — proto-lock-copy in \`MessageState\`).
- [x] \`gotestsum ./...\` — 23 tests pass, 1 skipped (the pre-existing \`TestGithubNeedsFix\`).
- [x] \`make providers/build/github && make providers/install/github\` clean.
- [ ] Spot-check on an actual GitHub org against the GraphQL endpoints (SAML config + IP allow list, which is what \`doRaw*\` is used for).

🤖 Generated with [Claude Code](https://claude.com/claude-code)