### PR TITLE
🐛 mqlc: record [].join(...) chunk type as string, not the input array

### DIFF
--- a/llx/builtin_array.go
+++ b/llx/builtin_array.go
@@ -558,8 +558,8 @@ func arrayJoin(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawD
 	}
 
 	typHint := types.Any
-	if chunk.Type().IsArray() {
-		typHint = chunk.Type().Child()
+	if bind.Type.IsArray() {
+		typHint = bind.Type.Child()
 	}
 
 	var res strings.Builder

--- a/mqlc/builtin_array.go
+++ b/mqlc/builtin_array.go
@@ -582,7 +582,7 @@ func compileArrayJoin(c *compiler, typ types.Type, ref uint64, id string, call *
 		Call: llx.Chunk_FUNCTION,
 		Id:   id,
 		Function: &llx.Function{
-			Type:    string(typ),
+			Type:    string(types.String),
 			Binding: ref,
 			Args:    args,
 		},

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -903,6 +903,25 @@ func TestCompiler_Switch(t *testing.T) {
 // //   👋   ARRAYS and MAPS   🍹
 // //    =======================
 
+func TestCompiler_ArrayJoin(t *testing.T) {
+	// Regression: the join chunk's recorded output type must be string, not the
+	// input array type. Otherwise cnspec's policy executor (which reads the
+	// chunk type as the datapoint's expected type) tries to cast the runtime
+	// string result back into a []string and fails with "could not convert
+	// string to []string".
+	compileT(t, "[1,2,3].join('-')", func(res *llx.CodeBundle) {
+		joinChunk := res.CodeV2.Blocks[0].Chunks[1]
+		assert.Equal(t, "join", joinChunk.Id)
+		assert.Equal(t, string(types.String), joinChunk.Function.Type)
+	})
+
+	compileT(t, "['a','b'].join(',')", func(res *llx.CodeBundle) {
+		joinChunk := res.CodeV2.Blocks[0].Chunks[1]
+		assert.Equal(t, "join", joinChunk.Id)
+		assert.Equal(t, string(types.String), joinChunk.Function.Type)
+	})
+}
+
 func TestCompiler_ArrayEmptyWhere(t *testing.T) {
 	compileT(t, "[1,2,3].where()", func(res *llx.CodeBundle) {
 		assertPrimitive(t, &llx.Primitive{


### PR DESCRIPTION
## Summary

`compileArrayJoin` was setting the join chunk's `Function.Type` to the input array type (e.g. `[]string`) instead of the actual output type (`string`). Direct mql evaluation was unaffected because the runtime `arrayJoin` returns its own `RawData{Type: String, ...}`, but cnspec's policy resolver reads the chunk type via `DereferencedTypeV2` to register each datapoint's expected type. When `.join(...)` was the entrypoint of a data query, the executor saw `expectedType=[]string ≠ actualType=string` and routed the result through `CastResult([]string)`, which fed a Go string into `array2result` and failed with `could not convert string to []string`.

The bug only surfaced when `join` was itself the data-query entrypoint — in most policies it sits inside a comparison whose `Bool` is the actual datapoint, which is why it went unnoticed since the function was introduced in #6058.

Also switches the runtime's `typHint` lookup from `chunk.Type()` to `bind.Type` so regex/version/etc. element formatting still works once the chunk type is no longer the array.

## Test plan

- [x] New mqlc test asserts the join chunk's recorded type is `string`
- [ ] `make test/go/plain` passes
- [ ] Verify cnspec policy with `.join(...)` as a data-query entrypoint resolves cleanly end-to-end