### PR TITLE
📄 gcp/azure/k8s/oci/digitalocean/hetzner: backfill resource doc-comments

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -99,6 +99,7 @@ Codeium
 codeowners
 codeql
 colo
+colocation
 compressratio
 computeagent
 continuedev
@@ -165,6 +166,7 @@ ERPCLOUD
 eula
 evc
 eventarc
+eventhubs
 evs
 Exadata
 exo
@@ -213,6 +215,7 @@ gpu
 grafana
 groupname
 gvnic
+GZRS
 hadoop
 HBFNV
 HCMCLOUD
@@ -227,6 +230,7 @@ hostedzone
 hostkeyalgorithms
 hostkeys
 hotlink
+HPC
 hpi
 hsts
 hvm
@@ -403,6 +407,7 @@ OSGi
 ospf
 ovmf
 owpjy
+Paa
 pacman
 pagerduty
 panos
@@ -506,7 +511,7 @@ skaffold
 slo
 smbv
 snaptime
-Snat
+snat
 SNYK
 softdep
 spdx
@@ -606,7 +611,6 @@ VMX
 vmxnet
 vnet
 vnic
-VPS
 vpus
 vrf
 vtpm
@@ -636,5 +640,6 @@ zfs
 zfspool
 zookeeper
 zpool
+ZRS
 zrt
 zstd

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -4,11 +4,34 @@
 option provider = "go.mondoo.com/cnquery/v9/providers/azure"
 option go_package = "go.mondoo.com/mql/v13/providers/azure/resources"
 
-// Azure resource
+// Microsoft Azure
+//
+// Use the Azure root namespace as the entry point for the Azure
+// provider. The active subscription is exposed as `azure.subscription`,
+// and every Azure service-specific accessor (Compute, Storage,
+// Network, Key Vault, Cosmos DB, Monitor, Defender for Cloud, AKS,
+// and so on) is reached through that subscription.
 azure {
 }
 
 // Azure subscription
+//
+// Examine an Azure subscription — the billing, identity, and policy
+// container that owns every Azure resource accessible to the provider.
+// Surfaces the subscription ID, tenant ID, display name, state,
+// authorization source, applied tags, the managing tenants, and the
+// `subscriptionsPolicies` block. Iterate `resourceGroups()` for the
+// resource-group containers and `resources()` for every resource in
+// the subscription. Service-specific entry points hang off the
+// subscription as accessor methods — `compute()`, `network()`,
+// `storage()`, `web()`, `sql()`, `mySql()`, `postgreSql()`,
+// `cosmosDb()`, `keyVault()`, `iam()` (Authorization), `monitor()`,
+// `cloudDefender()`, `aks()`, `advisor()`, `policy`, `iot()`,
+// `cache()`, `dataFactory()`, `synapse()`, `containerRegistry()`,
+// `recoveryServices()`, `functions()`, `serviceBus()`, `eventHub()`,
+// `dns()`, `frontDoor()`, `containerApp()`, `containerInstance()`,
+// `logic()`, `batch()`, and `databricks()` — letting you traverse from
+// a subscription into every modeled Azure service.
 azure.subscription @defaults ("name") {
   // Full resource identifier of the subscription
   id string
@@ -186,7 +209,17 @@ private azure.subscription.computeService {
   hybridMachines() []azure.subscription.computeService.hybridMachine
 }
 
-// Azure Compute virtual machine
+// Azure virtual machine
+//
+// Examine an Azure Compute Engine VM and the security-relevant
+// configuration around it. Surfaces the VM size, OS profile, storage
+// profile (OS and data disks), network profile and attached
+// `interfaces()`, identity assignments, applied tags, the
+// availability/zone/proximity-placement-group placement, the boot
+// diagnostics and security profile (TrustedLaunch / ConfidentialVM,
+// SecureBoot, vTPM), the `extensions()` installed on the VM, OS
+// patching state, and the deployed extensions for ASC, Defender, and
+// guest configuration.
 azure.subscription.computeService.vm @defaults("name location properties.hardwareProfile.vmSize properties.storageProfile.osDisk.osType") {
   // VM ID
   id string
@@ -266,7 +299,15 @@ azure.subscription.computeService.vm @defaults("name location properties.hardwar
   vmScaleSet() azure.subscription.computeService.vmScaleSet
 }
 
-// Azure Arc-enabled server (Microsoft.HybridCompute/machines)
+// Azure Arc-enabled server
+//
+// Examine an Azure Arc-enabled server (Microsoft.HybridCompute/machines)
+// — an on-premises or other-cloud machine projected into Azure for
+// management. Surfaces the agent status (Connected, Disconnected,
+// Expired), agent version, OS name and version, last status check,
+// machine identity, attached extensions, private link scope, and the
+// `cloudMetadata` describing the underlying environment when the
+// machine is hosted on AWS, GCP, VMware, or another cloud.
 azure.subscription.computeService.hybridMachine @defaults("name location osName osVersion status") {
   // ARM resource ID
   id string
@@ -362,7 +403,15 @@ private azure.subscription.computeService.hybridMachine.extension @defaults("nam
   instanceView dict
 }
 
-// Azure compute disk resource
+// Azure managed disk
+//
+// Examine an Azure managed disk attached to a VM, scale set, or
+// available for attachment. Surfaces the disk SKU and tier, OS type,
+// disk size and IOPS, the disk state (Unattached, Attached, Reserved,
+// ActiveSAS, ReadyToUpload, ActiveUpload), encryption settings
+// (platform-managed, customer-managed via diskEncryptionSet, or
+// double-encryption), network access policy, public network access,
+// the source from which the disk was created, and any attached VM.
 azure.subscription.computeService.disk @defaults("name location properties.osType properties.diskSizeGB properties.diskState") {
   // Disk resource ID
   id string
@@ -433,6 +482,15 @@ azure.subscription.computeService.disk @defaults("name location properties.osTyp
 }
 
 // Azure disk encryption set
+//
+// Examine a customer-managed key configuration that managed disks and
+// snapshots reference for envelope encryption. Surfaces the
+// `encryptionType` (EncryptionAtRestWithCustomerKey,
+// EncryptionAtRestWithPlatformAndCustomerKeys, or
+// ConfidentialVmEncryptedWithCustomerKey), the active and rotation-to
+// Key Vault key URLs, the system or user-assigned identity used to
+// access the vault, the auto-key-rotation flag, and the federated
+// client ID when one is configured.
 azure.subscription.computeService.diskEncryptionSet @defaults("name location encryptionType") {
   // Disk encryption set ID
   id string
@@ -460,7 +518,15 @@ azure.subscription.computeService.diskEncryptionSet @defaults("name location enc
   identity dict
 }
 
-// Azure disk access resource (private endpoint for managed disks)
+// Azure disk access resource
+//
+// Examine a private-endpoint configuration that managed disks and
+// snapshots can be exported and imported through. Surfaces the
+// `provisioningState`, the `extendedLocation` if the resource lives in
+// an Azure Edge Zone, and the time the access was created and last
+// modified. Disks reference a disk-access by ARM ID through their
+// `networkAccessPolicy` to keep export/import traffic off the public
+// internet.
 azure.subscription.computeService.diskAccess @defaults("name location") {
   // Disk access ID
   id string
@@ -481,6 +547,15 @@ azure.subscription.computeService.diskAccess @defaults("name location") {
 }
 
 // Azure managed disk snapshot
+//
+// Examine a point-in-time snapshot of an Azure managed disk. Surfaces
+// the snapshot SKU and tier, OS type, allocated and used size, the
+// `diskState`, the source resource the snapshot was created from, the
+// `incremental` flag (incremental vs full), encryption settings
+// (platform-managed, customer-managed via diskEncryptionSet, or
+// confidential-VM encryption), the network access policy, public
+// network access, and any active SAS export for downloading the
+// underlying VHD.
 azure.subscription.computeService.snapshot @defaults("name location diskSizeBytes diskState incremental") {
   // Snapshot ID
   id string
@@ -541,6 +616,15 @@ azure.subscription.computeService.snapshot @defaults("name location diskSizeByte
 }
 
 // Azure Virtual Machine Scale Set
+//
+// Examine a Virtual Machine Scale Set — the abstraction Azure uses to
+// deploy and manage a group of identical VMs. Surfaces the
+// `orchestrationMode` (Uniform or Flexible), the SKU and capacity, the
+// network and OS profiles applied to instances, upgrade policy
+// (Manual, Automatic, Rolling), automatic-OS-upgrade and rolling
+// upgrade policy, the spot priority and eviction settings, identity
+// assignments, the VM-extension profile, the platform-fault-domain
+// count, and the per-instance `instances()` currently provisioned.
 azure.subscription.computeService.vmScaleSet @defaults("name location orchestrationMode sku") {
   // VMSS ARM resource ID
   id string
@@ -598,7 +682,16 @@ azure.subscription.computeService.vmScaleSet @defaults("name location orchestrat
   extensions() []dict
 }
 
-// Azure Virtual Machine Scale Set virtual machine instance
+// Azure scale set VM instance
+//
+// Examine a single VM instance inside a Virtual Machine Scale Set.
+// Surfaces the per-instance ARM resource ID, the scale-set
+// `instanceId`, applied availability zones, the
+// `latestModelApplied` flag (whether the instance is on the current
+// scale-set model), the `modelDefinitionApplied` (whether the model is
+// the scale set's or customized), the Azure VM unique ID, instance
+// SKU, and the raw instance properties for fields not yet promoted to
+// typed accessors.
 azure.subscription.computeService.vmScaleSet.instance @defaults("name instanceId provisioningState") {
   // Instance ARM resource ID
   id string
@@ -628,7 +721,13 @@ azure.subscription.computeService.vmScaleSet.instance @defaults("name instanceId
   sku dict
 }
 
-// Azure Dedicated Host Group — single-tenant placement scope for dedicated hosts
+// Azure Dedicated Host Group
+//
+// Examine a single-tenant placement scope for Azure Dedicated Hosts.
+// Surfaces the platform-fault-domain count, the supported
+// availability zones, the `supportAutomaticPlacement` flag, and any
+// ultraSSD support exposed by the group. Use the `hosts()` collection
+// for the individual physical servers reserved through this group.
 azure.subscription.computeService.dedicatedHostGroup @defaults("name location platformFaultDomainCount") {
   // Dedicated host group ARM resource ID
   id string
@@ -656,7 +755,13 @@ azure.subscription.computeService.dedicatedHostGroup @defaults("name location pl
   hosts() []azure.subscription.computeService.dedicatedHost
 }
 
-// Azure Dedicated Host — physical server reserved for a single tenant
+// Azure Dedicated Host
+//
+// Examine a physical server reserved for a single tenant inside an
+// Azure Dedicated Host Group. Surfaces the SKU, fault domain, license
+// type, host's auto-replace-on-failure setting, the VMs currently
+// placed on the host, the `instanceView` reporting allocation status
+// and capacity, and the platform-fault-domain assignment.
 azure.subscription.computeService.dedicatedHost @defaults("name sku.name provisioningState") {
   // Dedicated host ARM resource ID
   id string
@@ -690,7 +795,13 @@ azure.subscription.computeService.dedicatedHost @defaults("name sku.name provisi
   instanceView dict
 }
 
-// Azure Proximity Placement Group — co-location scope for compute resources
+// Azure Proximity Placement Group
+//
+// Examine a co-location scope for Azure compute resources. Surfaces
+// the placement-group type (Standard or Ultra), the supported
+// availability zones, the colocation status, and the lists of VMs,
+// virtual-machine scale sets, and availability sets currently bound to
+// the group so they share low-latency network locality.
 azure.subscription.computeService.proximityPlacementGroup @defaults("name location proximityPlacementGroupType") {
   // Proximity placement group ARM resource ID
   id string
@@ -718,7 +829,15 @@ azure.subscription.computeService.proximityPlacementGroup @defaults("name locati
   availabilitySetIds []string
 }
 
-// Azure managed image — custom VM image stored as a single resource
+// Azure managed image
+//
+// Examine a custom VM image stored as a single Azure resource.
+// Surfaces the storage profile (OS disk and data disks), the
+// `hyperVGeneration` (V1 or V2), the source virtual machine the image
+// was generalized from, and the provisioning state. Compute Galleries
+// (`gallery()`) are the preferred mechanism for versioned image
+// distribution; managed images remain useful for single-resource
+// captures.
 azure.subscription.computeService.image @defaults("name location hyperVGeneration provisioningState") {
   // Image ARM resource ID
   id string
@@ -742,7 +861,14 @@ azure.subscription.computeService.image @defaults("name location hyperVGeneratio
   hyperVGeneration string
 }
 
-// Azure Compute Gallery (Shared Image Gallery) — versioned image distribution
+// Azure Compute Gallery
+//
+// Examine a Compute Gallery (formerly Shared Image Gallery) — the
+// versioned image-distribution scope inside a subscription. Surfaces
+// the gallery description, identifier, the
+// `sharingProfile` (private, community, or groups), the soft-delete
+// state, and the `images()` defined in the gallery so audits can
+// traverse from gallery to image definition to image version.
 azure.subscription.computeService.gallery @defaults("name location description") {
   // Gallery ARM resource ID
   id string
@@ -772,7 +898,14 @@ azure.subscription.computeService.gallery @defaults("name location description")
   images() []azure.subscription.computeService.gallery.image
 }
 
-// Azure Compute Gallery image definition — versioned VM image template
+// Azure Compute Gallery image definition
+//
+// Examine a versioned VM image definition inside a Compute Gallery.
+// Surfaces the OS type (Linux or Windows), OS state (Generalized vs
+// Specialized), `hyperVGeneration` (V1 or V2), architecture, supported
+// VM features, the publisher/offer/SKU identifiers, end-of-life date,
+// recommended VM configuration, and the `versions()` published under
+// the definition.
 azure.subscription.computeService.gallery.image @defaults("name osType osState hyperVGeneration") {
   // Image definition ARM resource ID
   id string
@@ -820,7 +953,14 @@ azure.subscription.computeService.gallery.image @defaults("name osType osState h
   versions() []azure.subscription.computeService.gallery.image.version
 }
 
-// Azure Compute Gallery image version — concrete versioned image
+// Azure Compute Gallery image version
+//
+// Examine a concrete versioned image inside a Compute Gallery image
+// definition. Surfaces the storage profile (OS disk image, data disk
+// images, and the source the version was created from), the
+// publishing-profile target regions and replication options, the
+// safety profile, end-of-life date, and the version's replication
+// status.
 azure.subscription.computeService.gallery.image.version @defaults("name location provisioningState") {
   // Image version ARM resource ID
   id string
@@ -857,6 +997,14 @@ private azure.subscription.batchService {
 }
 
 // Azure Batch account
+//
+// Examine an Azure Batch account — the resource-pool and job-scheduling
+// container for HPC and parallel workloads. Surfaces the account's
+// public network access state, the linked auto-storage account, the
+// poolAllocationMode (BatchService or UserSubscription), key vault
+// reference, encryption settings, network profile, the configured
+// node-communication mode, and the batch `pools()` deployed in the
+// account.
 azure.subscription.batchService.account @defaults("id name location") {
   // Batch account ID
   id string
@@ -913,6 +1061,13 @@ azure.subscription.batchService.account @defaults("id name location") {
 }
 
 // Azure Batch pool
+//
+// Examine a compute pool inside an Azure Batch account. Surfaces the
+// VM size and image, the deployment configuration (cloud-services or
+// VM-based), scale settings (fixed or auto), per-node start tasks,
+// network configuration, allocation state, target dedicated and
+// low-priority node counts, and the certificates and applications
+// installed on pool nodes.
 azure.subscription.batchService.account.pool @defaults("id name") {
   // Pool resource ID
   id string
@@ -955,6 +1110,14 @@ private azure.subscription.databricksService {
 }
 
 // Azure Databricks workspace
+//
+// Examine an Azure Databricks workspace — the analytics platform's
+// per-environment control plane. Surfaces the workspace SKU
+// (Standard, Premium, Trial), public network access state, the
+// managed resource group ID, the linked virtual network when VNet
+// injection is configured, the encryption settings (managed services
+// key and managed disks key), authorization settings, and the
+// `requiredNsgRules` posture used by the data plane.
 azure.subscription.databricksService.workspace @defaults("id name location publicNetworkAccess") {
   // Workspace ID
   id string
@@ -1050,7 +1213,15 @@ private azure.subscription.networkService {
   serviceEndpointPolicies() []azure.subscription.networkService.serviceEndpointPolicy
 }
 
-// Azure Virtual Network (VNet) gateway
+// Azure VPN/ExpressRoute gateway
+//
+// Examine a virtual network gateway used for VPN, ExpressRoute, or
+// LocalGateway connectivity. Surfaces the gateway type, VPN type
+// (RouteBased or PolicyBased), generation, SKU, IP configuration,
+// BGP settings (ASN, peering address), VPN client configuration
+// (address pool, root and revoked certificates, RADIUS server), the
+// active-active flag, and any associated VPN connections and
+// disaster-recovery settings.
 azure.subscription.networkService.virtualNetworkGateway @defaults("id name location") {
   // VNet gateway ID
   id string
@@ -1106,7 +1277,12 @@ azure.subscription.networkService.virtualNetworkGateway @defaults("id name locat
   vpnClientConfiguration dict
 }
 
-// Azure network application security group
+// Azure application security group
+//
+// Examine an application security group (ASG) — the logical grouping
+// used inside Network Security Group rules so traffic can be allowed
+// or denied based on application identity rather than IP. Surfaces
+// the resource GUID and the provisioning state of the group.
 azure.subscription.networkService.appSecurityGroup @defaults("id name location") {
   // Application security group ID
   id string
@@ -1124,7 +1300,15 @@ azure.subscription.networkService.appSecurityGroup @defaults("id name location")
   properties dict
 }
 
-// Azure network firewall
+// Azure Firewall
+//
+// Examine an Azure Firewall instance — the L4/L7 stateful service
+// firewall deployed at the network edge. Surfaces the firewall SKU
+// (Standard, Premium, or Basic), threat-intel mode, attached firewall
+// policy, IP configurations and management IP, application/network/NAT
+// rule collections, hub IP addresses for Secure Virtual Hub
+// deployments, the public IP and virtual hub linkage, and the
+// `additionalProperties` exposing autoscale and DNS settings.
 azure.subscription.networkService.firewall @defaults("id name location") {
   // Firewall ID
   id string
@@ -1216,7 +1400,14 @@ private azure.subscription.networkService.firewall.natRule @defaults("id name") 
   properties dict
 }
 
-// Azure network firewall policy
+// Azure Firewall policy
+//
+// Examine a reusable Azure Firewall policy — the rule-set parent that
+// firewall instances reference. Surfaces the policy SKU, threat-intel
+// mode and allow-list, DNS settings, intrusion detection settings,
+// TLS inspection certificate, the explicit-proxy configuration, the
+// child policy chain (`basePolicy`), and the rule collection groups
+// that hold the actual application/network/NAT rules.
 azure.subscription.networkService.firewallPolicy @defaults("id name location") {
   // Firewall policy ID
   id string
@@ -1273,6 +1464,12 @@ private azure.subscription.networkService.firewallPolicy.idpsBypassRule @default
 }
 
 // Azure DDoS protection plan
+//
+// Examine a DDoS Network Protection plan that virtual networks bind to
+// for enhanced volumetric and protocol DDoS mitigation. Surfaces the
+// plan resource GUID, the public IP addresses currently protected by
+// the plan, and the linked virtual networks subscribing to its
+// mitigation policies.
 azure.subscription.networkService.ddosProtectionPlan @defaults("name location") {
   // DDoS protection plan ID
   id string
@@ -1295,6 +1492,12 @@ azure.subscription.networkService.ddosProtectionPlan @defaults("name location") 
 }
 
 // Azure service endpoint policy
+//
+// Examine a service-endpoint policy that restricts which Azure service
+// resources can be reached from a subnet using service endpoints.
+// Surfaces the policy's service-endpoint-policy definitions (the
+// allowed Azure resource IDs), the contextual service alias, the
+// subnets the policy is applied to, and the resource GUID.
 azure.subscription.networkService.serviceEndpointPolicy @defaults("name location") {
   // Service endpoint policy ID
   id string
@@ -1399,6 +1602,12 @@ private azure.subscription.networkService.bgpSettings.ipConfigurationBgpPeeringA
 }
 
 // Azure NAT gateway
+//
+// Examine a NAT gateway that provides outbound SNAT for resources in
+// one or more subnets. Surfaces the SKU and zone placement, the
+// configured idle-timeout, the public IP addresses and prefixes
+// allocated for outbound translation, the subnets currently consuming
+// the gateway, and the resource GUID.
 azure.subscription.networkService.natGateway @defaults("id name location") {
   // NAT Gateway ID
   id string
@@ -1422,7 +1631,14 @@ azure.subscription.networkService.natGateway @defaults("id name location") {
   subnets() []azure.subscription.networkService.subnet
 }
 
-// Azure Virtual Network (VNet) subnet
+// Azure VNet subnet
+//
+// Examine a subnet inside an Azure Virtual Network. Surfaces the IPv4
+// and IPv6 address prefixes, the attached network security group and
+// route table, NAT gateway, service endpoints and service-endpoint
+// policies, delegations to PaaS services, the
+// `privateEndpointNetworkPolicies` and `privateLinkServiceNetworkPolicies`
+// flags, and the IP allocation method.
 azure.subscription.networkService.subnet @defaults("id name addressPrefix") {
   // Subnet ID
   id string
@@ -1448,7 +1664,14 @@ azure.subscription.networkService.subnet @defaults("id name addressPrefix") {
   ipConfigurations() []azure.subscription.networkService.virtualNetworkGateway.ipConfig
 }
 
-// Azure Virtual network (VNet)
+// Azure Virtual Network (VNet)
+//
+// Examine an Azure Virtual Network and its connectivity surface.
+// Surfaces the IPv4 and IPv6 address spaces, configured DNS servers,
+// the linked DDoS protection plan, encryption settings, BGP
+// communities, the `enableVmProtection` and `enableDdosProtection`
+// flags, the `subnets()` defined inside the VNet, and the
+// `peerings()` to other virtual networks.
 azure.subscription.networkService.virtualNetwork @defaults("id name location") {
   // Virtual Network ID
   id string
@@ -1486,7 +1709,15 @@ azure.subscription.networkService.virtualNetwork @defaults("id name location") {
   peerings() []azure.subscription.networkService.virtualNetwork.peering
 }
 
-// Azure Virtual Network (VNet) peering
+// Azure VNet peering
+//
+// Examine a peering between two Azure Virtual Networks. Surfaces the
+// peering state (Initiated, Connected, Disconnected), the remote
+// virtual network reference, allow-virtual-network-access /
+// allow-forwarded-traffic / allow-gateway-transit / use-remote-gateways
+// flags, the remote address space, the peering sync level (FullyInSync
+// vs LocalAndRemoteNotInSync), the `peeringSyncLevel`, and the
+// `doNotVerifyRemoteGateways` setting.
 azure.subscription.networkService.virtualNetwork.peering @defaults("id name peeringState") {
   // Peering resource ID
   id string
@@ -1523,6 +1754,15 @@ private azure.subscription.networkService.virtualNetwork.dhcpOptions {
 }
 
 // Azure Load Balancer
+//
+// Examine an Azure Load Balancer and the front-end / back-end
+// configuration that determines how traffic is distributed. Surfaces
+// the SKU (Basic, Standard, Gateway), tier (Regional or Global), the
+// `frontendIPConfigurations`, `backendAddressPools`,
+// `loadBalancingRules`, `inboundNatRules`, `inboundNatPools`,
+// `outboundRules`, and `probes`. The `extendedLocation`, attached
+// `virtualNetwork` for Standard private LBs, and the resource GUID
+// help correlate the LB to its surrounding network.
 azure.subscription.networkService.loadBalancer @defaults("id name location") {
   // Load Balancer ID
   id string
@@ -1665,6 +1905,14 @@ private azure.subscription.networkService.outboundRule @defaults("id name") {
 }
 
 // Azure network interface
+//
+// Examine an Azure network interface (NIC) attached to a VM, scale
+// set, or private endpoint. Surfaces the IP configurations (private
+// IP allocation, public IP, subnet binding), MAC address, the
+// associated network security group, accelerated-networking and
+// IP-forwarding flags, DNS settings, the NIC type (Standard,
+// Elastic), the migration phase, and the auxiliary mode/SKU when the
+// NIC is in an accelerated-connection configuration.
 azure.subscription.networkService.interface @defaults("name location properties.macAddress properties.nicType") {
   // Network interface ID
   id string
@@ -1849,6 +2097,15 @@ private azure.subscription.networkService.watcher.flowlog @defaults("name locati
 }
 
 // Azure Application Gateway
+//
+// Examine an Azure Application Gateway — the regional L7 load
+// balancer that fronts web workloads. Surfaces the SKU and tier
+// (Standard_v2, WAF_v2), TLS settings (frontend/backend TLS,
+// certificates, root certs), HTTP listeners, request-routing rules,
+// URL path maps, redirect configurations, backend address pools and
+// HTTP settings, autoscale configuration, the WAF mode and rule set
+// when the gateway is WAF-enabled, and the linked
+// `firewallPolicy()`.
 azure.subscription.networkService.applicationGateway @defaults("id name location") {
   // Application Gateway ID
   id string
@@ -1876,7 +2133,14 @@ azure.subscription.networkService.applicationGateway @defaults("id name location
   sslCipherSuites []string
 }
 
-// Azure Application Firewall Config
+// Azure Application Gateway WAF config
+//
+// Examine the legacy WAF configuration attached directly to an
+// Application Gateway (used by older v1 SKUs). Surfaces the WAF
+// `mode` (Detection / Prevention), the rule set type and version,
+// firewall mode flags, the `enabled` state, request-body limits, and
+// disabled rule groups. Newer deployments use a typed
+// `applicationFirewallPolicy` resource instead.
 azure.subscription.networkService.wafConfig @defaults("id name type") {
   // ID of the WAF configuration
   id string
@@ -1890,7 +2154,14 @@ azure.subscription.networkService.wafConfig @defaults("id name type") {
   properties dict
 }
 
-// Azure Application Firewall Policy (WAF)
+// Azure Web Application Firewall (WAF) policy
+//
+// Examine a reusable WAF policy that Application Gateway, Front Door,
+// or other PaaS endpoints reference for L7 protection. Surfaces the
+// `policySettings` (mode, request body limits, file upload limits,
+// state, log scrubbing), the `customRules` list, the `managedRules`
+// configuration (rule sets and per-rule overrides), and the resources
+// the policy is currently bound to.
 azure.subscription.networkService.applicationFirewallPolicy @defaults("id name location") {
   // Application firewall policy ID
   id string
@@ -2608,7 +2879,17 @@ private azure.subscription.webService.appRuntimeStack @defaults("preferredOs run
   endOfLifeDate time
 }
 
-// Azure Web app site
+// Azure App Service site
+//
+// Examine an App Service / Function App / Web App site. Surfaces the
+// app's runtime stack, SKU and App Service Plan binding, the
+// `siteConfig` (always-on, HTTP/2, TLS minimum version,
+// FTPS/HTTP-only state, IP restrictions, CORS), HTTPS-only flag,
+// client-cert and client-affinity settings, the configured custom
+// hostnames and SSL bindings, identity assignments, the deployed
+// `slots()`, app settings and connection strings, the linked storage
+// accounts, and the `webDiagnostics` (Application Insights / log
+// streaming) configuration.
 azure.subscription.webService.appsite @defaults("id name location") {
   // App site ID
   id string
@@ -3888,6 +4169,17 @@ private azure.subscription.cosmosDbService {
 }
 
 // Azure Cosmos DB account
+//
+// Examine a Cosmos DB account — the multi-model NoSQL service's
+// top-level resource. Surfaces the account `kind` (GlobalDocumentDB,
+// MongoDB, Parse), the API offering, default consistency policy,
+// configured locations and failover priorities, public network access,
+// network ACL bypass for Azure services, IP rules, virtual-network
+// rules, the encryption settings (key URI, identity used to access
+// Key Vault), local authentication state, the
+// `disableLocalAuth` flag, the
+// `analyticalStorageConfiguration`, backup policy, capabilities, and
+// the `sqlDatabases()` exposed by the account.
 azure.subscription.cosmosDbService.account @defaults("name kind location") {
   // Cosmos DB account ID
   id string
@@ -4084,6 +4376,13 @@ private azure.subscription.keyVaultService {
 }
 
 // Azure Managed HSM pool
+//
+// Examine a Managed HSM pool — the FIPS 140-2 Level 3 hardware
+// security module offering separate from regular Key Vaults. Surfaces
+// the pool SKU, `tenantId`, the `initialAdminObjectIds` granted local
+// HSM admin, the deployment status and provisioning state, public
+// network access, network ACLs, soft-delete and purge-protection
+// settings, and the public/private endpoint connection list.
 azure.subscription.keyVaultService.managedHsm @defaults("name location") {
   // Managed HSM ID
   id string
@@ -5151,7 +5450,19 @@ private azure.subscription.aksService {
   clusters() []azure.subscription.aksService.cluster
 }
 
-// Azure Kubernetes Service cluster
+// Azure Kubernetes Service (AKS) cluster
+//
+// Examine an AKS cluster's control-plane and managed-platform
+// configuration. Surfaces the Kubernetes version, DNS prefix, FQDN,
+// API server access profile (private cluster, authorized IP ranges),
+// network profile (network plugin, service/pod CIDR, load-balancer
+// SKU), identity (system-assigned or user-assigned, kubeletIdentity),
+// RBAC and Azure AD integration, OIDC issuer URL for workload
+// identity, the agent pool profiles, addon profiles (monitoring,
+// policy, ingress-app-routing), Azure Policy and Defender for Cloud
+// integration, image cleaner, cluster auto-upgrade channel, and the
+// security profile (workload identity, image integrity, defender,
+// node restriction, KMS encryption).
 azure.subscription.aksService.cluster @defaults("name location kubernetesVersion") {
   // ID of the AKS cluster
   id string
@@ -5448,6 +5759,15 @@ private azure.subscription.cacheService @defaults("subscriptionId") {
 }
 
 // Azure Cache for Redis instance
+//
+// Examine an Azure Cache for Redis instance. Surfaces the SKU and
+// tier (Basic, Standard, Premium, Enterprise), the Redis version,
+// host name and ports (SSL and non-SSL), the
+// `enableNonSslPort` flag, public network access, the configured
+// `redisConfiguration` (maxmemory policy, eviction, AOF/RDB
+// persistence), TLS minimum version, identity assignments, replicas
+// per master, shard count for clustered Premium tiers, and the
+// virtual-network or private-endpoint placement.
 azure.subscription.cacheService.redisInstance @defaults("id hostName") {
   // ID of the Redis cache
   id string
@@ -5559,7 +5879,15 @@ private azure.subscription.dataFactoryService {
   factories() []azure.subscription.dataFactoryService.factory
 }
 
-// Azure Data Factory instance
+// Azure Data Factory
+//
+// Examine an Azure Data Factory — the managed ETL/ELT and data
+// integration service. Surfaces the factory's identity assignments,
+// the linked Git repository configuration (Azure DevOps or GitHub
+// account, project, root folder, collaboration branch), public
+// network access, the `purviewConfiguration` for data-catalog
+// integration, encryption settings (customer-managed key reference),
+// global parameters, and the resource version.
 azure.subscription.dataFactoryService.factory @defaults("name location") {
   // Full resource ID
   id string
@@ -5713,6 +6041,14 @@ private azure.subscription.synapseService {
 }
 
 // Azure Synapse Analytics workspace
+//
+// Examine an Azure Synapse Analytics workspace. Surfaces the
+// workspace's default Data Lake Storage account, the SQL
+// administrator login, the managed virtual network configuration, the
+// public network access setting, customer-managed-key encryption
+// settings, identity assignments, the
+// `azureADOnlyAuthentication` flag, the workspace repository for Git
+// integration, and the configured trusted-service bypass list.
 azure.subscription.synapseService.workspace @defaults("name location") {
   // Full resource ID
   id string
@@ -5755,6 +6091,15 @@ private azure.subscription.containerRegistryService {
 }
 
 // Azure Container Registry
+//
+// Examine an Azure Container Registry — the managed Docker registry
+// service. Surfaces the SKU and tier (Basic, Standard, Premium), the
+// admin user state, public network access, the network rule set
+// (default action, IP rules, virtual-network rules), zone redundancy,
+// the encryption configuration and KMS reference, anonymous pull
+// access, data endpoint enabled state, the policies block (quarantine,
+// retention, trust, soft delete, export), and the configured
+// `webhooks()`, `replications()`, and `tasks()`.
 azure.subscription.containerRegistryService.registry @defaults("id name location skuName") {
   // Registry resource ID
   id string
@@ -6045,6 +6390,15 @@ private azure.subscription.containerRegistryService.registry.connectedRegistry @
 }
 
 // Azure Log Analytics workspace
+//
+// Examine a Log Analytics workspace — the underlying log/data store
+// for Azure Monitor, Microsoft Sentinel, and Defender for Cloud.
+// Surfaces the workspace SKU (PerGB2018, CapacityReservation, Free,
+// Standalone, etc.), retention period, daily-quota cap and reset
+// time, the public network access state for ingestion and query, the
+// linked Application Insights workspaces, the customer-managed-key
+// reference, identity assignments, and the `created`/`modified`
+// timestamps tying the workspace's lifecycle to its tenant.
 azure.subscription.monitorService.workspace @defaults("id name location skuName") {
   // Workspace resource ID
   id string
@@ -6263,6 +6617,12 @@ private azure.subscription.monitorService.workspace.nspConfiguration @defaults("
 }
 
 // Log Analytics QueryPack
+//
+// Examine a Log Analytics query pack — the share-and-version unit for
+// curated KQL queries. Surfaces the query-pack `queryPackId`, the
+// `provisioningState`, time created and modified, and the resource
+// tags applied. The queries inside the pack are accessed through the
+// per-pack collection accessor on the parent monitor service.
 azure.subscription.monitorService.queryPack @defaults("id name location queryPackId") {
   // QueryPack resource ID
   id string
@@ -6319,6 +6679,15 @@ private azure.subscription.recoveryServicesService {
 }
 
 // Azure Recovery Services vault
+//
+// Examine a Recovery Services vault — the storage container for Azure
+// Backup and Azure Site Recovery. Surfaces the vault SKU, the
+// soft-delete and immutability state, public network access, identity
+// assignments, the customer-managed-key encryption reference,
+// cross-region restore configuration, the `monitoringSettings` for
+// classic alerts and Azure Monitor alerts, the redundancy mode
+// (LRS, GRS, ZRS, GZRS), and the
+// `securitySettings` (multi-user authorization, soft delete).
 azure.subscription.recoveryServicesService.vault @defaults("id name location skuName") {
   // Vault resource ID
   id string
@@ -6471,6 +6840,16 @@ private azure.subscription.functionsService {
 }
 
 // Azure Function App
+//
+// Examine a Function App — the Azure-Functions-flavored App Service
+// site that runs serverless functions. Surfaces the runtime stack,
+// SKU, App Service Plan binding, the `siteConfig` (TLS minimum
+// version, FTPS state, IP restrictions, CORS, always-on,
+// HTTPS-only), HTTPS-only flag, identity assignments, public network
+// access, the configured custom hostnames and SSL bindings, the
+// `appSettings()` (with the runtime version, AzureWebJobsStorage,
+// FUNCTIONS_WORKER_RUNTIME, etc.), `connectionStrings()`, deployment
+// slots, and per-function metadata.
 azure.subscription.functionsService.functionApp @defaults("id name location") {
   // Function App resource ID
   id string
@@ -6560,6 +6939,15 @@ private azure.subscription.serviceBusService {
 }
 
 // Azure Service Bus namespace
+//
+// Examine a Service Bus namespace — the messaging entity scope that
+// owns queues, topics, and subscriptions. Surfaces the SKU and tier
+// (Basic, Standard, Premium), the messaging unit count (Premium
+// only), public network access, the `disableLocalAuth` flag,
+// minimum TLS version, identity assignments, the encryption settings
+// (customer-managed key reference), zone redundancy, and the
+// `queues()`, `topics()`, and `authorizationRules()` defined inside
+// the namespace.
 azure.subscription.serviceBusService.namespace @defaults("id name location") {
   // Namespace resource ID
   id string
@@ -6679,7 +7067,16 @@ private azure.subscription.eventHubService {
   namespaces() []azure.subscription.eventHubService.namespace
 }
 
-// Azure Event Hub namespace
+// Azure Event Hubs namespace
+//
+// Examine an Event Hubs namespace — the streaming-ingestion entity
+// scope that owns event hubs and consumer groups. Surfaces the SKU
+// and tier (Basic, Standard, Premium, Dedicated), the throughput
+// units configured, auto-inflate state, Kafka-enabled flag, the
+// `disableLocalAuth` toggle, minimum TLS version, public network
+// access, network rule sets, identity assignments, customer-managed-key
+// encryption settings, and the `eventhubs()` defined inside the
+// namespace.
 azure.subscription.eventHubService.namespace @defaults("id name location") {
   // Namespace resource ID
   id string
@@ -6760,6 +7157,13 @@ private azure.subscription.dnsService {
 }
 
 // Azure public DNS zone
+//
+// Examine an Azure DNS public zone. Surfaces the zone's
+// `numberOfRecordSets` and `maxNumberOfRecordSets` cap, the assigned
+// authoritative name servers, the registration virtual networks (when
+// the zone is private DNS in another product), and the `recordSets()`
+// hosted in the zone. Use `azure.subscription.dnsService.privateZone`
+// for Azure Private DNS zones.
 azure.subscription.dnsService.zone @defaults("id name") {
   // DNS zone resource ID
   id string
@@ -6795,7 +7199,14 @@ private azure.subscription.dnsService.zone.recordSet @defaults("id name type") {
   properties dict
 }
 
-// Azure private DNS zone
+// Azure Private DNS zone
+//
+// Examine an Azure Private DNS zone — a DNS zone resolved only from
+// linked virtual networks. Surfaces the `numberOfRecordSets` and the
+// `numberOfVirtualNetworkLinks` (with auto-registration counts), the
+// `provisioningState`, the maximum allowed record-set and
+// virtual-network-link counts, and the `recordSets()` hosted in the
+// zone.
 azure.subscription.dnsService.privateZone @defaults("id name") {
   // Private DNS zone resource ID
   id string
@@ -6842,6 +7253,16 @@ private azure.subscription.frontDoorService {
 }
 
 // Azure Front Door / CDN profile
+//
+// Examine an Azure Front Door (Standard / Premium) or classic CDN
+// profile. Surfaces the SKU and tier (Standard_AzureFrontDoor,
+// Premium_AzureFrontDoor, Standard_Microsoft, Standard_Verizon,
+// Premium_Verizon, Standard_Akamai, Standard_ChinaCdn), the resource
+// state, identity assignments, the `originResponseTimeoutSeconds`,
+// the `logScrubbing` configuration, and the `endpoints()`,
+// `originGroups()`, `customDomains()`, `secrets()`, `rulesets()`,
+// `routes()`, `securityPolicies()`, and `firewallPolicies()` defined
+// inside the profile.
 azure.subscription.frontDoorService.profile @defaults("id name location") {
   // Profile resource ID
   id string
@@ -7221,7 +7642,16 @@ private azure.subscription.containerAppService.containerApp.authConfig @defaults
   httpSettings dict
 }
 
-// Container Apps Job (run-to-completion)
+// Azure Container Apps Job
+//
+// Examine a Container Apps Job — the run-to-completion sibling of
+// Azure Container Apps. Surfaces the `triggerType` (Manual,
+// Schedule, or Event), the configuration block (replica timeout,
+// retry limit, parallelism, replica completion count, registries,
+// secrets, identity), the per-trigger schedule or event-trigger
+// configuration, the template (containers, init containers, volumes),
+// the linked managed environment, and the workload profile the job
+// runs on.
 azure.subscription.containerAppService.job @defaults("name location triggerType provisioningState") {
   // ARM resource ID
   id string

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -7070,7 +7070,7 @@ private azure.subscription.eventHubService {
 // Azure Event Hubs namespace
 //
 // Examine an Event Hubs namespace — the streaming-ingestion entity
-// scope that owns event hubs and consumer groups. Surfaces the SKU
+// scope that owns Event Hubs and consumer groups. Surfaces the SKU
 // and tier (Basic, Standard, Premium, Dedicated), the throughput
 // units configured, auto-inflate state, Kafka-enabled flag, the
 // `disableLocalAuth` toggle, minimum TLS version, public network

--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -4,7 +4,19 @@
 option provider = "go.mondoo.com/mql/providers/digitalocean"
 option go_package = "go.mondoo.com/mql/v13/providers/digitalocean/resources"
 
-// DigitalOcean cloud provider
+// DigitalOcean account
+//
+// Use the DigitalOcean namespace as the account-wide entry point for
+// the DigitalOcean provider. Iterate `droplets()` for VMs,
+// `firewalls()` for cloud-firewall rule sets, `databases()` for
+// managed databases, `volumes()` for block storage, `domains()` for
+// DigitalOcean-managed DNS, `loadBalancers()` for L4/L7 LBs,
+// `vpcs()` and `vpcPeerings()` for the network plane,
+// `kubernetesClusters()` for DOKS, `apps()` for App Platform
+// deployments, `cdnEndpoints()` for the CDN, `registryRepositories()`
+// for the container registry, `projects()` for the project grouping,
+// `sshKeys()`, `certificates()`, `reservedIPs()`, `tags()`,
+// `spacesKeys()`, `alertPolicies()`, and `uptimeChecks()`.
 digitalocean {
   // Droplets (virtual machines)
   droplets() []digitalocean.droplet
@@ -48,7 +60,13 @@ digitalocean {
   spacesKeys() []digitalocean.spacesKey
 }
 
-// DigitalOcean account information
+// DigitalOcean account
+//
+// Examine the DigitalOcean account the provider is authenticated
+// against. Surfaces the account UUID, primary email and email
+// verification status, account `status` (active, warning, locked) and
+// status message, and the per-resource limits the account is
+// permitted (`dropletLimit`, `floatingIpLimit`, `volumeLimit`).
 digitalocean.account @defaults("email status") {
   // Account email
   email string
@@ -68,7 +86,16 @@ digitalocean.account @defaults("email status") {
   statusMessage string
 }
 
-// DigitalOcean Droplet (virtual machine)
+// DigitalOcean Droplet
+//
+// Examine a DigitalOcean Droplet — the provider's cloud VM offering.
+// Surfaces the droplet `id`, region and size slug, allocated memory,
+// vCPUs and disk, the public/private IPv4 addresses, image details,
+// applied tags, attached `vpc()`, the enabled features list (e.g.,
+// monitoring, backups), backup and monitoring flags, the firewalls
+// covering the droplet (resolved by id or tag), and the
+// `missingFirewall()` predicate that flags droplets with no attached
+// firewall.
 digitalocean.droplet @defaults("id name status") {
   // Droplet ID
   id int
@@ -113,6 +140,13 @@ digitalocean.droplet @defaults("id name status") {
 }
 
 // DigitalOcean firewall
+//
+// Examine a DigitalOcean cloud-firewall rule set. Surfaces the firewall
+// status (waiting, succeeded, failed), the `inboundRules` and
+// `outboundRules` (each a dict describing protocol, ports, sources,
+// and destinations), the tags used to target droplets, and the
+// resolved `droplets()` covered by the firewall (by direct ID or
+// matching tag).
 digitalocean.firewall @defaults("id name status") {
   // Firewall ID
   id string
@@ -135,6 +169,14 @@ digitalocean.firewall @defaults("id name status") {
 }
 
 // DigitalOcean managed database cluster
+//
+// Examine a DigitalOcean managed database. Surfaces the engine (pg,
+// mysql, redis, mongodb, kafka, opensearch) and version, the cluster
+// size and node count, region, status, the
+// `privateNetworkUuid` and resolved `vpc()`, the public connection
+// host and port, the `firewallRules()` controlling trusted sources,
+// the maintenance window, and the typed children `users()`,
+// `replicas()`, and `pools()`.
 digitalocean.database @defaults("id name engine") {
   // Database cluster ID
   id string
@@ -220,7 +262,12 @@ private digitalocean.database.pool @defaults("name mode") {
   mode string
 }
 
-// DigitalOcean domain
+// DigitalOcean DNS domain
+//
+// Examine a DigitalOcean-managed DNS domain. Surfaces the zone TTL,
+// the raw `zoneFile` contents as DigitalOcean serves them, and the
+// `records()` defined under the domain (A, AAAA, CNAME, MX, TXT, NS,
+// SRV, CAA).
 digitalocean.domain @defaults("name") {
   // Domain name
   name string
@@ -255,6 +302,11 @@ private digitalocean.domain.record @defaults("type name data") {
 }
 
 // DigitalOcean block storage volume
+//
+// Examine a DigitalOcean block-storage volume. Surfaces the volume
+// size in GB, region, description, filesystem type and label, applied
+// tags, and the resolved `droplets()` the volume is currently attached
+// to.
 digitalocean.volume @defaults("id name sizeGigabytes") {
   // Volume ID
   id string
@@ -281,6 +333,15 @@ digitalocean.volume @defaults("id name sizeGigabytes") {
 }
 
 // DigitalOcean load balancer
+//
+// Examine a DigitalOcean load balancer. Surfaces the public IP, region
+// and lifecycle status, the routing algorithm
+// (round_robin or least_connections), the
+// `forwardingRules` list, the `healthCheck` configuration, sticky
+// session settings, the `redirectHttpToHttps`,
+// `enableProxyProtocol`, `enableBackendKeepalive`, and
+// `disableLetsEncryptDnsRecords` flags, the resolved `vpc()`, and the
+// `droplets()` currently attached as backends.
 digitalocean.loadBalancer @defaults("id name status") {
   // Load balancer ID
   id string
@@ -323,6 +384,13 @@ digitalocean.loadBalancer @defaults("id name status") {
 }
 
 // DigitalOcean VPC
+//
+// Examine a DigitalOcean Virtual Private Cloud. Surfaces the VPC's
+// description, IP range (CIDR), region slug, the `default` flag
+// (whether it is the region's default VPC), and the creation
+// timestamp. Droplets, databases, load balancers, and Kubernetes
+// clusters can be filtered or correlated by the VPC they are attached
+// to.
 digitalocean.vpc @defaults("id name region") {
   // VPC ID
   id string
@@ -341,6 +409,12 @@ digitalocean.vpc @defaults("id name region") {
 }
 
 // DigitalOcean VPC peering
+//
+// Examine a peering between two DigitalOcean VPCs. Surfaces the
+// `vpcIds` participating in the peering, the peering status, and the
+// creation timestamp. The peering allows resources in distinct VPCs
+// to reach each other over the private network without traversing the
+// public internet.
 digitalocean.vpcPeering @defaults("id name status") {
   // Peering ID
   id string
@@ -355,6 +429,13 @@ digitalocean.vpcPeering @defaults("id name status") {
 }
 
 // DigitalOcean Kubernetes cluster
+//
+// Examine a DOKS (DigitalOcean Kubernetes Service) cluster. Surfaces
+// the Kubernetes version, region, lifecycle status, the cluster and
+// service subnet CIDRs, the resolved `vpc()`, the auto-upgrade,
+// surge-upgrade, and HA control plane flags, the SSO posture
+// (`ssoEnabled`, `ssoRequired`, `ssoIssuerUrl`, `ssoClientId`), the
+// maintenance policy, and applied tags.
 digitalocean.kubernetes.cluster @defaults("id name version") {
   // Cluster ID
   id string
@@ -427,6 +508,12 @@ private digitalocean.kubernetes.nodePool @defaults("id name size") {
 }
 
 // DigitalOcean project
+//
+// Examine a DigitalOcean project — the resource grouping used to
+// organize droplets, databases, load balancers, and other resources.
+// Surfaces the project description, declared `purpose` and
+// `environment` (Development, Staging, Production), the `isDefault`
+// flag, and creation/update timestamps.
 digitalocean.project @defaults("id name environment") {
   // Project ID
   id string
@@ -447,6 +534,10 @@ digitalocean.project @defaults("id name environment") {
 }
 
 // DigitalOcean SSH key
+//
+// Examine an SSH key registered to the DigitalOcean account. Surfaces
+// the key name, fingerprint, and the full `publicKey` content as
+// stored by DigitalOcean.
 digitalocean.sshKey @defaults("id name") {
   // SSH key ID
   id int
@@ -459,6 +550,12 @@ digitalocean.sshKey @defaults("id name") {
 }
 
 // DigitalOcean TLS certificate
+//
+// Examine a TLS certificate held by DigitalOcean for use with load
+// balancers, CDN endpoints, or App Platform. Surfaces the certificate
+// type (custom or lets_encrypt), the issuance state (pending,
+// verified, error), the SHA-1 fingerprint, the DNS names covered, and
+// the `notAfter` expiration timestamp.
 digitalocean.certificate @defaults("id name state") {
   // Certificate ID
   id string
@@ -479,6 +576,12 @@ digitalocean.certificate @defaults("id name state") {
 }
 
 // DigitalOcean container registry
+//
+// Examine the DigitalOcean Container Registry attached to the
+// account. Surfaces the registry name, region slug, subscription
+// tier, current storage usage in bytes, and creation timestamp. The
+// `digitalocean.registryRepositories()` collection enumerates the
+// repositories hosted in the registry.
 digitalocean.registry @defaults("name region") {
   // Registry name
   name string
@@ -505,6 +608,12 @@ private digitalocean.registry.repository @defaults("name tagCount") {
 }
 
 // DigitalOcean reserved IP
+//
+// Examine a reserved IP — DigitalOcean's static public IPv4 that can
+// be reassigned between droplets. Surfaces the IP address, region
+// slug, owning project, the `locked` flag (in-flight assignment
+// state), and the `dropletId` the IP is currently routed to (zero
+// when unassigned).
 digitalocean.reservedIp @defaults("ip region") {
   // IP address
   ip string
@@ -519,6 +628,12 @@ digitalocean.reservedIp @defaults("ip region") {
 }
 
 // DigitalOcean App Platform application
+//
+// Examine an App Platform application — DigitalOcean's managed PaaS
+// for containers and static sites. Surfaces the app's live URL, the
+// `activeDeploymentStatus`, the full `spec` describing services,
+// jobs, workers, static sites, ingresses, environment variables, and
+// linked databases, and creation/update timestamps.
 digitalocean.app @defaults("id name") {
   // App ID
   id string
@@ -536,7 +651,13 @@ digitalocean.app @defaults("id name") {
   spec dict
 }
 
-// DigitalOcean monitoring alert policy
+// DigitalOcean alert policy
+//
+// Examine a DigitalOcean monitoring alert policy. Surfaces the alert
+// `type` (e.g., `v1/insights/droplet/cpu`), the
+// `compare` operator and `value` threshold, the evaluation `window`,
+// the `enabled` flag, the entities and tags the alert applies to, and
+// the email and Slack notification targets.
 digitalocean.alertPolicy @defaults("uuid type enabled") {
   // Alert policy UUID
   uuid string
@@ -563,6 +684,10 @@ digitalocean.alertPolicy @defaults("uuid type enabled") {
 }
 
 // DigitalOcean uptime check
+//
+// Examine a DigitalOcean uptime check. Surfaces the check `type`
+// (ping, http, https), the `target` URL or IP being probed, the list
+// of monitoring `regions` running the check, and the `enabled` flag.
 digitalocean.uptimeCheck @defaults("id name type") {
   // Check ID
   id string
@@ -579,6 +704,11 @@ digitalocean.uptimeCheck @defaults("id name type") {
 }
 
 // DigitalOcean CDN endpoint
+//
+// Examine a DigitalOcean CDN endpoint fronting a Spaces bucket.
+// Surfaces the origin Spaces endpoint, the public CDN endpoint URL,
+// the cache TTL, the bound TLS certificate ID, the custom domain when
+// configured, and the creation timestamp.
 digitalocean.cdn @defaults("id origin") {
   // CDN ID
   id string
@@ -597,6 +727,11 @@ digitalocean.cdn @defaults("id origin") {
 }
 
 // DigitalOcean tag
+//
+// Examine a DigitalOcean tag — the cross-resource label used to group
+// droplets, volumes, load balancers, databases, and reserved IPs.
+// Surfaces the tag name and the total count of resources currently
+// labelled with the tag.
 digitalocean.tag @defaults("name") {
   // Tag name
   name string
@@ -605,6 +740,12 @@ digitalocean.tag @defaults("name") {
 }
 
 // DigitalOcean Spaces access key
+//
+// Examine an access key for DigitalOcean Spaces — the S3-compatible
+// object storage. Surfaces the key name, access key ID, the
+// `grants` list (per-bucket permission bindings), and the creation
+// timestamp. The matching secret is only returned at creation time
+// and is not exposed here.
 digitalocean.spacesKey @defaults("name accessKey") {
   // Key name
   name string

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -31,7 +31,18 @@ alias gcp.memcache = gcp.project.memcacheService
 alias gcp.datastream = gcp.project.datastreamService
 alias gcp.memorystore = gcp.project.memorystoreService
 
-// Google Cloud (GCP) organization
+// Google Cloud organization
+//
+// Examine the Cloud Resource Manager organization that contains the
+// account's folders, projects, IAM policy, and Security Command Center
+// configuration. Surfaces the organization ID, name, lifecycle state,
+// the IAM `iamPolicy` and `auditConfig` bindings, the `orgPolicies`
+// applied across the org tree, the access-approval settings, and the
+// child `folders()` and `projects()`. The Security Command Center
+// accessors (`sccSources`, `sccFindings`, `sccNotificationConfigs`,
+// `sccMuteConfigs`, `sccBigQueryExports`, `sccOrganizationSettings`)
+// expose SCC posture across all sources, and `accessPolicies()` returns
+// the VPC Service Controls access policies bound to the org.
 gcp.organization @defaults("name") {
   // Organization ID
   id string
@@ -434,7 +445,25 @@ private gcp.projects {
   children() []gcp.project
 }
 
-// Google Cloud (GCP) project
+// Google Cloud project
+//
+// Examine a Google Cloud project — the resource container that owns
+// every Compute, Storage, IAM, GKE, BigQuery, Cloud SQL, and other
+// service-specific deployment in the account. Surfaces the project ID
+// and number, lifecycle state, labels, parent organization or folder,
+// the IAM policy and audit-log configuration (with the
+// `hasPublicIamBinding`, `primitiveRoleBindings`, and
+// `dataAccessLoggingEnabled` predicates that drive CIS controls 1.x and
+// 2.1), enabled `services()`, recommendations, the project's
+// `essentialContacts` and `apiKeys`, and the access-approval settings.
+// Service-specific entry points hang off the project as accessor
+// methods — `compute()`, `gke()`, `storage()`, `sql()`, `dns()`,
+// `bigquery()`, `iam()`, `kms()`, `pubsub()`, `cloudFunctions()`,
+// `cloudRun()`, `dataproc()`, `dataflow()`, `firestore()`,
+// `spanner()`, `bigtable()`, `alloydb()`, `redis()`,
+// `secretmanager()`, `binaryAuthorization()`, `monitoring()`,
+// `logging()`, and many others — letting you traverse from a single
+// project into every modeled service it uses.
 gcp.project @defaults("name number") {
   // Unique, user-assigned ID of the project
   id string
@@ -572,7 +601,15 @@ gcp.project @defaults("name number") {
   memorystore() gcp.project.memorystoreService
 }
 
-// Google Cloud (GCP) service
+// Google Cloud service API
+//
+// Examine a single Google Cloud service API (compute.googleapis.com,
+// iam.googleapis.com, etc.) and whether it is enabled for the parent
+// project. Surfaces the canonical service `name`, the `title` Google
+// uses for the service, the parent project, the service `state`, and
+// the `enabled` predicate that audits whether the API has been turned
+// on. The parent `gcp.project.services()` collection lists every
+// available and enabled service for a project.
 gcp.service @defaults("name") {
   // Project ID
   projectId string
@@ -588,7 +625,16 @@ gcp.service @defaults("name") {
   enabled() bool
 }
 
-// Google Cloud (GCP) recommendation and suggested action
+// Google Cloud recommendation
+//
+// Examine a single recommendation and the action Recommender suggests
+// taking. Surfaces the recommendation `id`, the `recommender` that
+// produced it (for example `google.compute.instance.IdleResourceRecommender`),
+// the recommendation `category` and `priority`, the proposed resource
+// changes in `content`, the `primaryImpact` and `additionalImpact`
+// projections (cost, security, performance, reliability, etc.), the
+// `lastRefreshTime`, and the lifecycle `state` reflecting whether the
+// recommendation is active, claimed, dismissed, or applied.
 gcp.recommendation {
   // ID of recommendation
   id string
@@ -886,7 +932,20 @@ private gcp.project.computeService.machineType @defaults("name") {
   zone gcp.project.computeService.zone
 }
 
-// Google Cloud (GCP) Compute instances
+// Google Cloud Compute Engine instance
+//
+// Examine a Compute Engine VM instance and the security-relevant
+// configuration around it. Surfaces the machine type and CPU platform,
+// the instance status and lifecycle, attached `disks` and
+// `networkInterfaces`, the boot image, applied `labels` and `metadata`,
+// the `serviceAccounts` bound to the instance, the
+// `shieldedInstanceConfig` (Secure Boot, vTPM, integrity monitoring),
+// the `confidentialInstanceConfig`, OS Config patch posture, and the
+// scheduling and reservation affinity settings. The CIS-aligned
+// predicates (`hasPublicIp`, `usesDefaultServiceAccount`,
+// `hasFullCloudPlatformScope`, `blockProjectSshKeysEnabled`,
+// `osLoginEnabled`, `serialPortEnabled`) collapse common posture
+// checks into a single boolean field per audit.
 gcp.project.computeService.instance @defaults("name id") {
   // Unique identifier for the instance
   id string
@@ -1266,7 +1325,14 @@ private gcp.project.computeService.firewall @defaults("name") {
   network() gcp.project.computeService.network
 }
 
-// Google Cloud (GCP) Compute VPC network resource
+// Google Cloud VPC network
+//
+// Examine a Compute Engine VPC network and the structural posture
+// around it. Surfaces the network `mode` (legacy, custom, or auto), the
+// `legacy` predicate, the `autoCreateSubnetworks` flag, the routing
+// mode, MTU, IPv6/ULA settings, the network-firewall enforcement order,
+// the attached firewall policy, peering configurations, and the
+// `subnetworks()` defined in the network.
 gcp.project.computeService.network @defaults("name") {
   // Whether the network is a legacy (single-region, non-subnetted) network — derived from mode == "legacy"
   legacy() bool
@@ -1308,7 +1374,17 @@ gcp.project.computeService.network @defaults("name") {
   firewallPolicy string
 }
 
-// Google Cloud (GCP) Compute VPC network partitioning
+// Google Cloud VPC subnetwork
+//
+// Examine a regional VPC subnetwork inside a Compute Engine network.
+// Surfaces the subnetwork's IPv4 and IPv6 CIDR ranges, the `purpose`
+// and `role` (private, regional-managed-proxy, internal-load-balancer,
+// global-managed-proxy, etc.), the `enableFlowLogs` flag and matching
+// `logConfig`, the `privateIpGoogleAccess` and
+// `privateIpv6GoogleAccess` settings that control reachability of
+// Google APIs from instances without external IPs, and typed
+// references to the parent `network()` and the `region()` the subnet
+// is bound to.
 gcp.project.computeService.subnetwork @defaults("name") {
   // Unique identifier
   id string
@@ -1636,8 +1712,7 @@ private gcp.project.storageService.bucket.lifecycleRule {
   condition gcp.project.storageService.bucket.lifecycleRuleCondition
 }
 
-// A lifecycle management rule, which is made of an action to take and
-// the condition(s) under which the action will be taken
+// Lifecycle management rule action and conditions
 private gcp.project.storageService.bucket.lifecycleRuleAction @defaults("type storageClass") {
   // Target storage class. Required iff the type of the action is SetStorageClass
   storageClass string

--- a/providers/hetzner/resources/hetzner.lr
+++ b/providers/hetzner/resources/hetzner.lr
@@ -5,6 +5,18 @@ option provider = "go.mondoo.com/mql/providers/hetzner"
 option go_package = "go.mondoo.com/mql/v13/providers/hetzner/resources"
 
 // Hetzner Cloud project
+//
+// Use the Hetzner Cloud namespace as the project-scoped entry point
+// for the Hetzner provider. Iterate `servers()` for cloud VMs (with
+// the matching `serverTypes()` and `images()`), `volumes()` for block
+// storage, `networks()` for project networks (Hetzner's VPC),
+// `floatingIps()` and `primaryIps()` for routable IPv4/IPv6,
+// `loadBalancers()` plus `loadBalancerTypes()` for the managed L4/L7
+// load balancers, `firewalls()` for stateful firewall rule sets,
+// `sshKeys()` for project SSH keys, `certificates()` for managed TLS
+// certs, `placementGroups()` for spread/anti-affinity placement,
+// `isos()` for boot ISOs, and `locations()`/`datacenters()` for the
+// regional and AZ-style topology.
 hetzner {
   // Cloud servers (virtual machines)
   servers() []hetzner.server

--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -8,6 +8,23 @@ option provider = "go.mondoo.com/cnquery/v9/providers/k8s"
 option go_package = "go.mondoo.com/mql/v13/providers/k8s/resources"
 
 // Kubernetes cluster
+//
+// Use the Kubernetes namespace as the cluster-wide handle for every
+// modeled API object. Read `serverVersion` for the control-plane
+// version and `apiResources()` for the list of resource types the
+// API server advertises. Iterate the workload accessors —
+// `namespaces()`, `nodes()`, `pods()`, `deployments()`, `daemonsets()`,
+// `statefulsets()`, `replicasets()`, `jobs()`, `cronjobs()`, and
+// `apps()` — for the running workload, and `services()`, `ingresses()`,
+// `endpointSlices()`, and `networkPolicies()` for the network plane.
+// `secrets()`, `configmaps()`, and `serviceaccounts()` cover identity
+// and configuration data; `clusterroles()`, `clusterrolebindings()`,
+// `roles()`, and `rolebindings()` cover the RBAC graph; `persistentVolumes()`,
+// `persistentVolumeClaims()`, and `storageClasses()` cover storage;
+// `priorityClasses()`, `horizontalPodAutoscalers()`, `resourceQuotas()`,
+// and `limitRanges()` cover scheduling and quota policy. Use
+// `validatingWebhookConfigurations()` for admission control and
+// `customresources()` for custom-resource instances.
 k8s {
   // Cluster version
   serverVersion() dict
@@ -1114,8 +1131,16 @@ private k8s.endpointslice @defaults("namespace name addressType") {
 }
 
 // Kubernetes AdmissionReview
+//
+// Examine an AdmissionReview that an admission controller is being
+// asked to evaluate. Use `request()` to read the embedded
+// `k8s.admissionrequest` — the operation, requesting user, target
+// namespace, the incoming object, and (for UPDATE/DELETE) the prior
+// object. This resource is populated when MQL is invoked from inside a
+// dynamic admission webhook so policies can decide whether to admit
+// the request.
 k8s.admissionreview {
-  // The requested admission
+  // Requested admission
   request() k8s.admissionrequest
 }
 

--- a/providers/oci/resources/oci.lr
+++ b/providers/oci/resources/oci.lr
@@ -4,7 +4,16 @@
 option provider = "go.mondoo.com/cnquery/v9/providers/oci"
 option go_package = "go.mondoo.com/mql/v13/providers/oci/resources"
 
-// Oracle Cloud Infrastructure (OCI) tenancy
+// Oracle Cloud Infrastructure (OCI)
+//
+// Use the Oracle Cloud Infrastructure namespace as the tenancy-scoped
+// entry point for the OCI provider. Iterate `regions()` for the
+// regions the tenancy is subscribed to (with the home-region flag and
+// subscription state) and `compartments()` for the OCI compartment
+// hierarchy. The active tenancy itself is exposed as `oci.tenancy`,
+// and service-specific entry points (`oci.identity`, `oci.compute`,
+// `oci.network`, `oci.objectStorage`, `oci.kms`, and so on) are
+// reached as siblings.
 oci {
   // Available regions
   regions() []oci.region
@@ -13,6 +22,11 @@ oci {
 }
 
 // Oracle Cloud Infrastructure (OCI) tenancy
+//
+// Examine the active OCI tenancy — the top-level identity and
+// resource container the provider is authenticated against. Surfaces
+// the tenancy OCID, display name and description, and the
+// `retentionPeriod` configured for audit-event retention.
 oci.tenancy @defaults("name") {
   // Tenancy OCID
   id string
@@ -50,7 +64,15 @@ private oci.compartment @defaults("id name") {
   state string
 }
 
-// Oracle Cloud Infrastructure (OCI) identity and access management
+// Oracle Cloud Infrastructure (OCI) Identity and Access Management
+//
+// Use the OCI Identity namespace to enumerate the tenancy's IAM
+// principals and access policies. Iterate `users()` for IAM users
+// (with their MFA state, login history, capabilities, API keys,
+// customer secret keys, auth tokens, MFA devices, and group
+// memberships), `groups()` for IAM groups and their members, and
+// `policies()` for the policy statements that grant groups access to
+// compartments and resources.
 oci.identity {
   // IAM users
   users() []oci.identity.user
@@ -204,7 +226,15 @@ private oci.identity.policy @defaults("name description") {
   definedTags map[string]map[string]string
 }
 
-// Oracle Cloud Infrastructure (OCI) Compute service
+// Oracle Cloud Infrastructure (OCI) Compute
+//
+// Use the OCI Compute namespace to enumerate compute and block-storage
+// primitives in the tenancy. Iterate `instances()` for compute VMs
+// and bare-metal instances (with their shape, image, networking,
+// metadata, and instance configuration), `images()` for OS and
+// custom images available for launch, `blockVolumes()` for managed
+// block storage volumes, and `bootVolumes()` for the boot-volume
+// counterparts attached to instances.
 oci.compute {
   // Compute instances
   instances() []oci.compute.instance
@@ -370,7 +400,15 @@ private oci.compute.bootVolume @defaults("name") {
   created time
 }
 
-// Oracle Cloud Infrastructure (OCI) Networking service
+// Oracle Cloud Infrastructure (OCI) Networking
+//
+// Use the OCI Networking namespace to enumerate the tenancy's network
+// topology. Iterate `vcns()` for Virtual Cloud Networks, `subnets()`
+// for the partitioned address ranges inside those VCNs,
+// `securityLists()` and `networkSecurityGroups()` for the L4 access
+// rules, `internetGateways()` for inbound/outbound IGW connectivity,
+// `natGateways()` for outbound-only NAT, and `routeTables()` for the
+// per-subnet routing decisions.
 oci.network {
   // Virtual Cloud Networks (VCNs)
   vcns() []oci.network.vcn
@@ -576,7 +614,13 @@ private oci.network.routeTable @defaults("name") {
   definedTags map[string]map[string]string
 }
 
-// Oracle Cloud Infrastructure (OCI) Logging service
+// Oracle Cloud Infrastructure (OCI) Logging
+//
+// Use the OCI Logging namespace to enumerate the tenancy's
+// service-emitted and custom logs. Iterate `logGroups()` for the log
+// groups across compartments — each group exposes its enabled
+// `logs()`, retention duration, source service and resource, and the
+// log category (read, write, or all) describing the events captured.
 oci.logging {
   // Log groups in the tenancy
   logGroups() []oci.logging.logGroup
@@ -630,7 +674,14 @@ private oci.logging.log @defaults("name") {
   timeLastModified time
 }
 
-// Oracle Cloud Infrastructure (OCI) Key Management service
+// Oracle Cloud Infrastructure (OCI) Key Management Service
+//
+// Use the OCI KMS namespace to enumerate the tenancy's encryption
+// vaults and customer-managed keys. Iterate `vaults()` for KMS vaults
+// (DEFAULT, VIRTUAL_PRIVATE, or EXTERNAL types) — each vault surfaces
+// its management endpoint and the `keys()` it holds, where each key
+// reports its algorithm, length, lifecycle state, rotation history,
+// and whether the key is software-protected or HSM-protected.
 oci.kms {
   // Key vaults in the tenancy
   vaults() []oci.kms.vault
@@ -702,7 +753,15 @@ private oci.kms.keyVersion @defaults("id") {
   timeOfDeletion time
 }
 
-// Oracle Cloud Infrastructure (OCI) Object Storage service
+// Oracle Cloud Infrastructure (OCI) Object Storage
+//
+// Use the OCI Object Storage namespace to enumerate the tenancy's
+// S3-compatible object stores. Read `namespace()` for the unique
+// per-tenancy Object Storage namespace, and iterate `buckets()` for
+// every bucket — each bucket surfaces its public access type, storage
+// tier, auto-tiering and versioning configuration, KMS encryption key,
+// retention rules for WORM/immutability, replication enablement, and
+// the approximate object count and total size.
 oci.objectStorage {
   // Object Storage namespace (unique per tenancy)
   namespace() string
@@ -774,7 +833,13 @@ private oci.objectStorage.retentionRule @defaults("name") {
   timeModified time
 }
 
-// Oracle Cloud Infrastructure (OCI) File Storage service
+// Oracle Cloud Infrastructure (OCI) File Storage
+//
+// Use the OCI File Storage namespace to enumerate the tenancy's
+// managed NFS file systems. Iterate `fileSystems()` for every file
+// system across availability domains — each entry surfaces the
+// metered byte usage, lifecycle state, KMS encryption key, and the
+// availability domain the file system is anchored to.
 oci.fileStorage {
   // File systems
   fileSystems() []oci.fileStorage.fileSystem
@@ -800,7 +865,13 @@ private oci.fileStorage.fileSystem @defaults("name") {
   created time
 }
 
-// Oracle Cloud Infrastructure (OCI) Events service
+// Oracle Cloud Infrastructure (OCI) Events
+//
+// Use the OCI Events namespace to enumerate the tenancy's
+// event-rule-based automation. Iterate `rules()` for every rule —
+// each rule surfaces the matching `condition` (JSON event filter), the
+// `actions` to perform (function, ONS topic, or stream targets), the
+// rule's enabled state, and the lifecycle state.
 oci.events {
   // Event rules
   rules() []oci.events.rule
@@ -828,7 +899,18 @@ private oci.events.rule @defaults("name") {
   created time
 }
 
-// Oracle Cloud Infrastructure (OCI) Cloud Guard threat detection and security monitoring
+// Oracle Cloud Infrastructure (OCI) Cloud Guard
+//
+// Use the OCI Cloud Guard namespace to enumerate the tenancy's
+// threat-detection and security-monitoring posture. Read `status()`
+// and `reportingRegion()` for whether Cloud Guard is enabled and
+// which region collects findings, and `selfManageResources()` for
+// whether Cloud Guard's resources are managed by the customer.
+// Iterate `targets()` for the compartments and resources Cloud Guard
+// monitors, `detectorRecipes()` for the curated detector rule sets,
+// `securityZones()` and `securityZoneRecipes()` for the
+// security-zone enforcement scopes, and `securityPolicies()` for the
+// individual policies that compose those recipes.
 oci.cloudGuard {
   // Whether Cloud Guard is enabled
   status() bool
@@ -950,7 +1032,13 @@ private oci.cloudGuard.securityPolicy @defaults("name category") {
   created time
 }
 
-// Oracle Cloud Infrastructure (OCI) Notifications (ONS) service
+// Oracle Cloud Infrastructure (OCI) Notifications
+//
+// Use the OCI Notifications (ONS) namespace to enumerate the
+// pub/sub messaging service used for alerts and event delivery.
+// Iterate `topics()` for every notification topic — each topic
+// surfaces its lifecycle state and the `subscriptions()` bound to
+// it (Email, HTTPS, Slack, PagerDuty, function, and so on).
 oci.ons {
   // Notification topics
   topics() []oci.ons.topic
@@ -990,13 +1078,24 @@ private oci.ons.subscription @defaults("id") {
   created time
 }
 
-// Oracle Cloud Infrastructure (OCI) Audit service
+// Oracle Cloud Infrastructure (OCI) Audit
+//
+// Use the OCI Audit namespace to inspect tenancy-wide audit log
+// configuration. Read `retentionPeriodDays()` for the number of days
+// audit events are retained before being purged.
 oci.audit {
   // Audit log retention period in days
   retentionPeriodDays() int
 }
 
-// Oracle Cloud Infrastructure (OCI) Bastion service
+// Oracle Cloud Infrastructure (OCI) Bastion
+//
+// Use the OCI Bastion namespace to enumerate the tenancy's bastion
+// instances — managed jump hosts that broker SSH access into private
+// subnets. Iterate `bastions()` for every bastion deployment — each
+// bastion surfaces the target VCN and subnet, allowed client CIDR
+// blocks, DNS proxy state, the maximum session TTL, and per-session
+// configuration.
 oci.bastion {
   // Bastion instances
   bastions() []oci.bastion.instance
@@ -1026,7 +1125,13 @@ private oci.bastion.instance @defaults("name") {
   timeUpdated time
 }
 
-// Oracle Cloud Infrastructure (OCI) Monitoring service
+// Oracle Cloud Infrastructure (OCI) Monitoring
+//
+// Use the OCI Monitoring namespace to enumerate the alarm definitions
+// emitting notifications to the tenancy. Iterate `alarms()` for every
+// alarm — each alarm surfaces the metric namespace, the Monitoring
+// Query Language (MQL) `query`, severity, the destination ONS topic
+// OCIDs, the enabled flag, and the alarm lifecycle state.
 oci.monitoring {
   // Monitoring alarm definitions
   alarms() []oci.monitoring.alarm
@@ -1056,7 +1161,13 @@ private oci.monitoring.alarm @defaults("name") {
   state string
 }
 
-// Oracle Cloud Infrastructure (OCI) Vault secrets service
+// Oracle Cloud Infrastructure (OCI) Vault
+//
+// Use the OCI Vault namespace to enumerate the tenancy's stored
+// secrets. Iterate `secrets()` for every secret — each entry surfaces
+// the parent KMS vault and key, lifecycle and rotation status,
+// scheduled and last rotation timestamps, the auto-generation flag,
+// the configured rotation interval, and the secret versions.
 oci.vault {
   // Secrets stored in vaults
   secrets() []oci.vault.secret
@@ -1120,7 +1231,14 @@ private oci.vault.secretVersion @defaults("versionNumber") {
   timeOfDeletion time
 }
 
-// Oracle Cloud Infrastructure (OCI) Load Balancer service
+// Oracle Cloud Infrastructure (OCI) Load Balancer
+//
+// Use the OCI Load Balancer namespace to enumerate the L7 (and L4)
+// load balancers in the tenancy. Iterate `loadBalancers()` for every
+// load balancer — each entry surfaces the shape (e.g., flexible,
+// 100Mbps, 400Mbps), private vs public flag, delete protection,
+// listeners (with their TLS protocols, cipher suites, and peer-cert
+// verification), backend sets and policies, and the lifecycle state.
 oci.loadBalancer {
   // Load balancers
   loadBalancers() []oci.loadBalancer.loadBalancer
@@ -1180,7 +1298,14 @@ private oci.loadBalancer.backendSet @defaults("name") {
   backendCount int
 }
 
-// Oracle Cloud Infrastructure (OCI) Network Firewall service
+// Oracle Cloud Infrastructure (OCI) Network Firewall
+//
+// Use the OCI Network Firewall namespace to enumerate the
+// next-generation firewall deployments in the tenancy. Iterate
+// `firewalls()` for the deployed firewall instances (with their
+// subnet placement, IPv4/IPv6 addresses, shape, and attached
+// `policy()`), and `policies()` for the reusable firewall policies
+// that drive the rule sets each firewall enforces.
 oci.networkFirewall {
   // Network firewalls
   firewalls() []oci.networkFirewall.firewall
@@ -1232,7 +1357,16 @@ private oci.networkFirewall.policy @defaults("name") {
   created time
 }
 
-// Oracle Cloud Infrastructure (OCI) Container Engine for Kubernetes (OKE)
+// Oracle Cloud Infrastructure (OCI) Container Engine for Kubernetes
+//
+// Use the OCI OKE namespace to enumerate the tenancy's managed
+// Kubernetes deployments. Iterate `clusters()` for every OKE cluster
+// — each cluster surfaces the Kubernetes version, cluster type
+// (BASIC_CLUSTER or ENHANCED_CLUSTER), the VCN it is deployed in, the
+// KMS key used for secret encryption, the public/private API endpoint
+// configuration, image-policy verification, the available upgrade
+// versions, the legacy Pod Security Policy admission setting, and the
+// `nodePools()` running workloads inside the cluster.
 oci.oke {
   // OKE clusters
   clusters() []oci.oke.cluster
@@ -1300,7 +1434,14 @@ private oci.oke.nodePool @defaults("name") {
   state string
 }
 
-// Oracle Cloud Infrastructure (OCI) Web Application Firewall service
+// Oracle Cloud Infrastructure (OCI) Web Application Firewall
+//
+// Use the OCI WAF namespace to enumerate the L7 web-application
+// firewall deployments in the tenancy. Iterate `firewalls()` for
+// every WAF instance (with the load balancer it fronts and the
+// attached `policy()`), and `policies()` for the reusable rule sets
+// that drive request-rate limiting, signature inspection, IP
+// allow/deny lists, and bot management.
 oci.waf {
   // Web Application Firewalls
   firewalls() []oci.waf.firewall
@@ -1352,7 +1493,15 @@ private oci.waf.policy @defaults("name") {
   definedTags map[string]map[string]string
 }
 
-// Oracle Cloud Infrastructure (OCI) Functions service
+// Oracle Cloud Infrastructure (OCI) Functions
+//
+// Use the OCI Functions namespace to enumerate the tenancy's
+// serverless functions. Iterate `applications()` for the function
+// applications (each scoping shape, subnet placement, NSGs,
+// environment configuration, syslog destination, and image-signature
+// verification), then traverse each application's `functions()` for
+// the per-function image, memory, timeout, invoke endpoint, and
+// tracing settings.
 oci.functions {
   // Function applications
   applications() []oci.functions.application
@@ -1432,7 +1581,14 @@ private oci.functions.function @defaults("name") {
   config() map[string]string
 }
 
-// Oracle Cloud Infrastructure (OCI) Container Instances service
+// Oracle Cloud Infrastructure (OCI) Container Instances
+//
+// Use the OCI Container Instances namespace to enumerate the
+// tenancy's serverless container deployments. Iterate `instances()`
+// for every container instance — each instance surfaces its shape,
+// CPU and memory allocation, fault domain, the containers running
+// inside the instance, restart policy, network placement (subnets
+// and NSGs), DNS configuration, and lifecycle state.
 oci.containerInstances {
   // Container instances
   instances() []oci.containerInstances.instance
@@ -1506,7 +1662,17 @@ private oci.containerInstances.container @defaults("name") {
   definedTags map[string]map[string]string
 }
 
-// Oracle Cloud Infrastructure (OCI) Database service
+// Oracle Cloud Infrastructure (OCI) Database
+//
+// Use the OCI Database namespace to enumerate the tenancy's database
+// deployments and their backups. Iterate `dbSystems()` for the
+// VM/BM-based DB systems (Oracle Database on virtual machines or
+// bare metal), `autonomousDatabases()` for serverless / dedicated
+// Autonomous Database instances, `backups()` for the manual and
+// automatic backups taken from VM/BM databases, and
+// `autonomousDatabaseBackups()` for backups belonging to autonomous
+// databases — each backup surfaces TDE/KMS encryption, retention,
+// destination type, and lifecycle state.
 oci.database {
   // Database systems (VM/BM)
   dbSystems() []oci.database.dbSystem
@@ -1716,7 +1882,16 @@ private oci.database.autonomousDatabase @defaults("name") {
   backups() []oci.database.autonomousDatabaseBackup
 }
 
-// Oracle Cloud Infrastructure (OCI) API Gateway service
+// Oracle Cloud Infrastructure (OCI) API Gateway
+//
+// Use the OCI API Gateway namespace to enumerate the tenancy's API
+// gateway deployments. Iterate `gateways()` for the regional gateway
+// appliances (with their endpoint type, IP-mode, hostname, response-
+// cache, attached subnet, and certificate bindings),
+// `deployments()` for the route configurations bound to those
+// gateways, and `certificates()` for the API-gateway-managed TLS
+// certs (distinct from the tenancy-wide
+// `oci.certificates.certificate` service).
 oci.apigateway {
   // API gateways in the tenancy
   gateways() []oci.apigateway.gateway
@@ -1836,7 +2011,16 @@ private oci.apigateway.certificate @defaults("name") {
   definedTags map[string]map[string]string
 }
 
-// Oracle Cloud Infrastructure (OCI) Certificates Management service
+// Oracle Cloud Infrastructure (OCI) Certificates Management
+//
+// Use the OCI Certificates namespace to enumerate the tenancy's
+// managed PKI material. Iterate `certificates()` for the managed
+// TLS certificates (each surfacing the issuer authority, subject and
+// SAN list, validity window, KMS-backed key spec, and configuration
+// origin — issued by an internal CA, externally managed, or
+// imported), `certificateAuthorities()` for the root and subordinate
+// CAs, and `caBundles()` for the trust bundles applications import
+// to validate peer certificates.
 oci.certificates {
   // Managed TLS certificates
   certificates() []oci.certificates.certificate
@@ -1946,7 +2130,14 @@ private oci.certificates.caBundle @defaults("name") {
   definedTags map[string]map[string]string
 }
 
-// Oracle Cloud Infrastructure (OCI) Cache (Redis/Valkey) service
+// Oracle Cloud Infrastructure (OCI) Cache
+//
+// Use the OCI Cache namespace to enumerate the tenancy's managed
+// in-memory cache deployments. Iterate `clusters()` for every cache
+// cluster — each cluster surfaces the engine (Redis or Valkey) and
+// version, node count and shape, the primary and replicas FQDNs and
+// endpoints, attached subnet, NSG bindings, lifecycle state, and
+// cluster mode.
 oci.redis {
   // OCI Cache clusters
   clusters() []oci.redis.cluster


### PR DESCRIPTION
## Summary
Follow-up to #7605: applies the same title/blank-`//`/description doc-comment format from the cloud resource development guide to every top-level resource that was missing it across the remaining providers.

- **GCP (7 resources)** — `gcp.organization`, `gcp.project`, `gcp.service`, `gcp.recommendation`, and the `gcp.project.computeService.{instance,network,subnetwork}` records. Also drops a leading "A" from `gcp.project.storageService.bucket.lifecycleRuleAction` to satisfy the no-leading-article style rule.
- **Azure (53 resources)** — the `azure` namespace root, `azure.subscription`, and every queryable record across compute, network, storage, batch, databricks, Cosmos DB, Key Vault HSM, AKS, cache, Data Factory, Synapse, container registry, monitor, recovery services, functions, service bus, event hubs, DNS, front door, and container apps.
- **k8s (2 resources)** — the `k8s` cluster root listing every workload, RBAC, networking, storage, scheduling, and admission accessor; and `k8s.admissionreview` for the dynamic-admission entry point.
- **OCI (26 resources)** — the `oci` root, `oci.tenancy`, and every service namespace (identity, compute, network, logging, kms, objectStorage, fileStorage, events, cloudGuard, ons, audit, bastion, monitoring, vault, loadBalancer, networkFirewall, oke, waf, functions, containerInstances, database, apigateway, certificates, redis). Titles spell out "Oracle Cloud Infrastructure (OCI)" so the docs site renders the full product name.
- **DigitalOcean (22 resources)** — the `digitalocean` namespace root and every queryable record across droplets, firewalls, databases, domains, volumes, load balancers, VPCs, peerings, Kubernetes, projects, SSH keys, certificates, registry, reserved IPs, App Platform, alert policies, uptime checks, CDN, tags, and Spaces keys.
- **Hetzner (1 resource)** — the `hetzner` namespace root listing every project-scoped accessor.

Each entry leads with `Use …` for namespace roots and `Examine …` for queryable records, and lists the accessors and predicates the resource exposes so the docs site has a substantive description for each.

## Test plan
- [ ] `make providers/build/<provider>` regenerates the `*.resources.json` for each touched provider with the new titles/descriptions
- [ ] `pnpm update-mql` in `mondoohq/docs` shows the new doc-comments in the schema JSON without title/description splits
- [ ] Docs site renders an `Examine …` / `Use …` description for every top-level resource page across these providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)