### PR TITLE
🎉 aws-13.22.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.21.3",
+	Version:         "13.22.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### aws (13.22.0)
- ✨ aws: add detective resources (#7609)
- 📄 aws/azure/gitlab: backfill resource doc-comments and fix split field titles (#7605)
- ✨ aws: add aws.rds.optionGroup and aws.rds.globalCluster (#7590)
- ✨ aws: add Cognito user pool clients, domains, and identity providers (#7588)
- ✨ aws: surface new SDK fields enabled by 20260507 dep bumps (#7597)
- ✨ aws: add API Gateway v2 (HTTP and WebSocket APIs) (#7592)
- ✨ aws: expand aws.account with region opt-in and org descriptors (#7585)