### PR TITLE
🎉 gcp-13.14.0

### DIFF
--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.13.3",
+	Version: "13.14.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### gcp (13.14.0)
- ✨ gcp: add Workload Identity Federation pools and providers (#7608)
- 📄 gcp/azure/k8s/oci/digitalocean/hetzner: backfill resource doc-comments (#7606)
- 🧹 azure, gcp: regenerate permissions.json (#7604)