### PR TITLE
🎉 github-13.3.0

### DIFF
--- a/providers/github/config/config.go
+++ b/providers/github/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "github",
 	ID:              "go.mondoo.com/cnquery/v9/providers/github",
-	Version:         "13.2.3",
+	Version:         "13.3.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### github (13.3.0)
- ✨ github: add repository.vulnerabilityAlertsEnabled and privateVulnerabilityReportingEnabled (#7598)
- ✨ github: add organization.outsideCollaborators (#7596)
- 🧹 github: bump go-github to v86 (#7599)