### PR TITLE
🎉 gitlab-13.2.0

### DIFF
--- a/providers/gitlab/config/config.go
+++ b/providers/gitlab/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gitlab",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gitlab",
-	Version: "13.1.4",
+	Version: "13.2.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		provider.GitlabGroupConnection,


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### gitlab (13.2.0)
- 📄 aws/azure/gitlab: backfill resource doc-comments and fix split field titles (#7605)
- ✨ gitlab: expand gitlab.user with security and identity fields (#7600)