### PR TITLE
🐛 aws: fix aws.cloudfront.function.tags ARN format

### DIFF
--- a/providers/aws/resources/aws_cloudfront.go
+++ b/providers/aws/resources/aws_cloudfront.go
@@ -244,10 +244,12 @@ func (a *mqlAwsCloudfront) functions() ([]any, error) {
 			funct := functions.FunctionList.Items[i]
 			var stage, comment, runtime string
 			var lmTime, crTime *time.Time
+			var arn *string
 			if metadata := funct.FunctionMetadata; metadata != nil {
 				lmTime = metadata.LastModifiedTime
 				crTime = metadata.CreatedTime
 				stage = string(metadata.Stage)
+				arn = metadata.FunctionARN
 			}
 			if config := funct.FunctionConfig; config != nil {
 				comment = convert.ToValue(config.Comment)
@@ -262,7 +264,7 @@ func (a *mqlAwsCloudfront) functions() ([]any, error) {
 				"stage":            llx.StringData(stage),
 				"comment":          llx.StringData(comment),
 				"runtime":          llx.StringData(runtime),
-				"arn":              llx.StringData(fmt.Sprintf(cloudfrontFunctionPattern, "global", conn.AccountId(), convert.ToValue(funct.Name))),
+				"arn":              llx.StringDataPtr(arn),
 			}
 
 			mqlAwsCloudfrontDist, err := CreateResource(a.MqlRuntime, "aws.cloudfront.function", args)
@@ -382,8 +384,6 @@ func (a *mqlAwsCloudfrontAnycastIpList) tags() (map[string]any, error) {
 	}
 	return tags, nil
 }
-
-const cloudfrontFunctionPattern = "arn:aws:cloudfront:%s:%s::/functions/%s"
 
 func initAwsCloudfrontDistribution(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {

--- a/providers/aws/resources/aws_cloudfront.go
+++ b/providers/aws/resources/aws_cloudfront.go
@@ -251,6 +251,10 @@ func (a *mqlAwsCloudfront) functions() ([]any, error) {
 				stage = string(metadata.Stage)
 				arn = metadata.FunctionARN
 			}
+			if arn == nil {
+				constructed := fmt.Sprintf("arn:aws:cloudfront::%s:function/%s", conn.AccountId(), convert.ToValue(funct.Name))
+				arn = &constructed
+			}
 			if config := funct.FunctionConfig; config != nil {
 				comment = convert.ToValue(config.Comment)
 				runtime = string(config.Runtime)


### PR DESCRIPTION
## Summary

`aws.cloudfront.function.tags` (added in #7597) failed at runtime with:

```
operation error CloudFront: ListTagsForResource, https response error
StatusCode: 400, InvalidArgument: Invalid region (received: global, expected empty)
```

`aws_cloudfront.go` synthesized the function ARN as
`arn:aws:cloudfront:global:ACCOUNT::/functions/NAME`, but
`ListTagsForResource` only accepts the SDK-canonical
`arn:aws:cloudfront::ACCOUNT:function/NAME` format (no region segment, singular
`function`). The synthesized ARN was being stored in the resource and reused for
the tag lookup, which is what the API rejected.

The fix: use the ARN already returned by the SDK on
`FunctionMetadata.FunctionARN` instead of formatting one ourselves. That ARN is
in the format the tagging API accepts, so the synthesizing helper
(`cloudfrontFunctionPattern`) is also no longer needed and is removed.

## Test plan

Verified against a live tagged CloudFront function in account 177043759486:

```
mql run aws -c "aws.cloudfront.functions { name arn tags }"
```

Before:
\`\`\`
arn: "arn:aws:cloudfront:global:177043759486::/functions/mql7610-d0db30-fn"
tags: operation error CloudFront: ListTagsForResource, ... InvalidArgument: Invalid region (received: global, expected empty)
\`\`\`

After:
\`\`\`
arn: "arn:aws:cloudfront::177043759486:function/mql7610-d0db30-fn"
tags: { Environment: "test", mql-test: "true" }
\`\`\`

- [x] make providers/build/aws && make providers/install/aws clean
- [x] Live verification on a tagged CloudFront Function returns tags successfully
- [x] gofmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)