### PR TITLE
🐛 azure: fix VNG connection runtime fields, Logic App parameters, ACA env defaults

### DIFF
--- a/providers/azure/resources/appcontainers.go
+++ b/providers/azure/resources/appcontainers.go
@@ -157,7 +157,10 @@ func acaManagedEnvironmentToMQL(runtime *plugin.Runtime, entry *apps.ManagedEnvi
 
 	var staticIp, defaultDomain, provisioningState, kind string
 	var zoneRedundant *bool
-	var internalLB *bool
+	// Default to false rather than leaving the pointer nil. An env without
+	// a VnetConfiguration has no internal LB by definition; returning null
+	// would break audits that check `internalLoadBalancerEnabled == false`.
+	internalLB := false
 	vnet := map[string]any{}
 	workloadProfiles := []any{}
 	peerAuth := map[string]any{}
@@ -187,7 +190,9 @@ func acaManagedEnvironmentToMQL(runtime *plugin.Runtime, entry *apps.ManagedEnvi
 				return nil, err
 			}
 			vnet = d
-			internalLB = props.VnetConfiguration.Internal
+			if props.VnetConfiguration.Internal != nil {
+				internalLB = *props.VnetConfiguration.Internal
+			}
 		}
 		if len(props.WorkloadProfiles) > 0 {
 			d, err := convert.JsonToDictSlice(props.WorkloadProfiles)
@@ -240,7 +245,7 @@ func acaManagedEnvironmentToMQL(runtime *plugin.Runtime, entry *apps.ManagedEnvi
 			"workloadProfiles":            llx.ArrayData(workloadProfiles, types.Dict),
 			"staticIp":                    llx.StringData(staticIp),
 			"defaultDomain":               llx.StringData(defaultDomain),
-			"internalLoadBalancerEnabled": llx.BoolDataPtr(internalLB),
+			"internalLoadBalancerEnabled": llx.BoolData(internalLB),
 			"zoneRedundant":               llx.BoolDataPtr(zoneRedundant),
 			"peerAuthentication":          llx.DictData(peerAuth),
 			"peerTrafficConfiguration":    llx.DictData(peerTraffic),

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -7602,7 +7602,7 @@ azure.subscription.containerAppService.containerApp @defaults("name location pro
   ingressExternal bool
   // Target port for ingress
   targetPort int
-  // Allowed transport ("auto", "http", "http2", "tcp")
+  // Allowed transport ("Auto", "Http", "Http2", "Tcp" — Azure SDK casing)
   transport string
   // Whether HTTPS-only is enforced (insecureAllowed == false)
   httpsOnly bool

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
   "version": "13.10.1",
-  "generated_at": "2026-05-08T10:57:12-07:00",
+  "generated_at": "2026-05-08T15:08:18-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.App/certificates/read",
@@ -659,7 +659,7 @@
     {
       "permission": "Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/read",
       "service": "Microsoft.Network",
-      "action": "NewListAllPager",
+      "action": "Get",
       "source_file": "network.go"
     },
     {
@@ -677,7 +677,7 @@
     {
       "permission": "Microsoft.Network/azureFirewalls/read",
       "service": "Microsoft.Network",
-      "action": "NewListAllPager",
+      "action": "Get",
       "source_file": "network.go"
     },
     {
@@ -689,7 +689,7 @@
     {
       "permission": "Microsoft.Network/connections/read",
       "service": "Microsoft.Network",
-      "action": "NewListPager",
+      "action": "Get",
       "source_file": "network.go"
     },
     {
@@ -731,7 +731,7 @@
     {
       "permission": "Microsoft.Network/natGateways/read",
       "service": "Microsoft.Network",
-      "action": "NewListAllPager",
+      "action": "Get",
       "source_file": "network.go"
     },
     {
@@ -863,7 +863,7 @@
     {
       "permission": "Microsoft.OperationalInsights/workspaces/read",
       "service": "Microsoft.OperationalInsights",
-      "action": "Get",
+      "action": "NewListNSPPager",
       "source_file": "loganalytics.go"
     },
     {

--- a/providers/azure/resources/logic.go
+++ b/providers/azure/resources/logic.go
@@ -148,7 +148,7 @@ func logicWorkflowToMQL(runtime *plugin.Runtime, entry *logic.Workflow) (plugin.
 				policyHasIpAllowList(ac.WorkflowManagement)
 		}
 
-		parameters, secureNames = workflowParametersToMQL(props.Parameters)
+		parameters, secureNames = workflowParametersToMQL(props.Definition, props.Parameters)
 		triggers, actions, connectionNames = workflowDefinitionToMQL(props.Definition)
 	}
 
@@ -248,42 +248,91 @@ var secureParameterTypes = map[string]bool{
 	string(logic.ParameterTypeSecureObject): true,
 }
 
-// workflowParametersToMQL flattens the SDK's WorkflowParameter map into a
-// stable-ordered slice of {name, type, hasDefaultValue, isSecure} entries
-// plus the names of secure-typed parameters. Stable order keeps query
-// output deterministic across runs.
-func workflowParametersToMQL(params map[string]*logic.WorkflowParameter) ([]any, []any) {
+// workflowParametersToMQL flattens parameter declarations from the workflow
+// definition into a stable-ordered slice of {name, type, hasDefaultValue,
+// isSecure} entries plus the names of secure-typed parameters. Stable order
+// keeps query output deterministic across runs.
+//
+// Parameter declarations live under `properties.definition.parameters` and
+// carry the type. The sibling `properties.parameters` map (passed as
+// runtimeValues) only holds the resolved runtime value for each declared
+// parameter — there is no type info there, and undeclared parameters never
+// appear. So the definition is the source of truth, with runtime values
+// folded in to populate `hasDefaultValue` when the declaration omits it.
+func workflowParametersToMQL(definition any, runtimeValues map[string]*logic.WorkflowParameter) ([]any, []any) {
 	out := []any{}
 	secure := []any{}
-	if len(params) == 0 {
+
+	// Parse declarations out of the definition map.
+	type decl struct {
+		paramType  string
+		hasDefault bool
+		isSecure   bool
+	}
+	decls := map[string]decl{}
+	if defMap, ok := definition.(map[string]any); ok {
+		if dp, ok := defMap["parameters"].(map[string]any); ok {
+			for name, raw := range dp {
+				d := decl{}
+				if entry, ok := raw.(map[string]any); ok {
+					if t, ok := entry["type"].(string); ok {
+						d.paramType = t
+						if secureParameterTypes[t] {
+							d.isSecure = true
+						}
+					}
+					if _, ok := entry["defaultValue"]; ok {
+						d.hasDefault = true
+					}
+				}
+				decls[name] = d
+			}
+		}
+	}
+
+	// Names: union of declarations and runtime values, sorted for determinism.
+	names := map[string]struct{}{}
+	for k := range decls {
+		names[k] = struct{}{}
+	}
+	for k := range runtimeValues {
+		names[k] = struct{}{}
+	}
+	if len(names) == 0 {
 		return out, secure
 	}
-	keys := make([]string, 0, len(params))
-	for k := range params {
+	keys := make([]string, 0, len(names))
+	for k := range names {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
+
 	for _, k := range keys {
-		p := params[k]
+		d, hasDecl := decls[k]
 		entry := map[string]any{
 			"name":            k,
-			"type":            "",
-			"hasDefaultValue": false,
-			"isSecure":        false,
+			"type":            d.paramType,
+			"hasDefaultValue": d.hasDefault,
+			"isSecure":        d.isSecure,
 		}
-		if p == nil {
-			out = append(out, entry)
-			continue
-		}
-		if p.Type != nil {
-			entry["type"] = string(*p.Type)
-			if secureParameterTypes[string(*p.Type)] {
-				entry["isSecure"] = true
-				secure = append(secure, k)
+		// Runtime overlay: if the runtime supplied a Value, mark the
+		// parameter as having one even if the declaration didn't.
+		if rv, ok := runtimeValues[k]; ok && rv != nil {
+			if rv.Value != nil {
+				entry["hasDefaultValue"] = true
+			}
+			// Runtime occasionally carries the type (older API shapes); fall
+			// back to it only when the declaration did not provide one.
+			if !hasDecl && rv.Type != nil {
+				t := string(*rv.Type)
+				entry["type"] = t
+				if secureParameterTypes[t] {
+					entry["isSecure"] = true
+				}
 			}
 		}
-		if p.Value != nil {
-			entry["hasDefaultValue"] = true
+		if entry["isSecure"].(bool) {
+			secure = append(secure, k)
 		}
 		out = append(out, entry)
 	}

--- a/providers/azure/resources/logic_test.go
+++ b/providers/azure/resources/logic_test.go
@@ -52,18 +52,19 @@ func TestPolicyHasIpAllowList(t *testing.T) {
 }
 
 func TestWorkflowParametersToMQL(t *testing.T) {
-	t.Run("empty map returns empty slices", func(t *testing.T) {
-		params, secure := workflowParametersToMQL(nil)
+	t.Run("nil definition returns empty slices", func(t *testing.T) {
+		params, secure := workflowParametersToMQL(nil, nil)
 		assert.Empty(t, params)
 		assert.Empty(t, secure)
 	})
 
 	t.Run("plain string parameter without default", func(t *testing.T) {
-		typ := logic.ParameterTypeString
-		input := map[string]*logic.WorkflowParameter{
-			"region": {Type: &typ},
+		def := map[string]any{
+			"parameters": map[string]any{
+				"region": map[string]any{"type": "String"},
+			},
 		}
-		params, secure := workflowParametersToMQL(input)
+		params, secure := workflowParametersToMQL(def, nil)
 		assert.Len(t, params, 1)
 		entry := params[0].(map[string]any)
 		assert.Equal(t, "region", entry["name"])
@@ -74,11 +75,12 @@ func TestWorkflowParametersToMQL(t *testing.T) {
 	})
 
 	t.Run("secure-string parameter with default value", func(t *testing.T) {
-		typ := logic.ParameterTypeSecureString
-		input := map[string]*logic.WorkflowParameter{
-			"apiKey": {Type: &typ, Value: "redacted"},
+		def := map[string]any{
+			"parameters": map[string]any{
+				"apiKey": map[string]any{"type": "SecureString", "defaultValue": "redacted"},
+			},
 		}
-		params, secure := workflowParametersToMQL(input)
+		params, secure := workflowParametersToMQL(def, nil)
 		assert.Len(t, params, 1)
 		entry := params[0].(map[string]any)
 		assert.Equal(t, "apiKey", entry["name"])
@@ -89,20 +91,23 @@ func TestWorkflowParametersToMQL(t *testing.T) {
 	})
 
 	t.Run("secure-object also flagged as secure", func(t *testing.T) {
-		typ := logic.ParameterTypeSecureObject
-		input := map[string]*logic.WorkflowParameter{
-			"creds": {Type: &typ},
+		def := map[string]any{
+			"parameters": map[string]any{
+				"creds": map[string]any{"type": "SecureObject"},
+			},
 		}
-		params, secure := workflowParametersToMQL(input)
+		params, secure := workflowParametersToMQL(def, nil)
 		assert.Equal(t, true, params[0].(map[string]any)["isSecure"])
 		assert.Equal(t, []any{"creds"}, secure)
 	})
 
-	t.Run("nil parameter value yields default entry", func(t *testing.T) {
-		input := map[string]*logic.WorkflowParameter{
-			"empty": nil,
+	t.Run("declaration without type yields blank type", func(t *testing.T) {
+		def := map[string]any{
+			"parameters": map[string]any{
+				"empty": map[string]any{},
+			},
 		}
-		params, _ := workflowParametersToMQL(input)
+		params, _ := workflowParametersToMQL(def, nil)
 		entry := params[0].(map[string]any)
 		assert.Equal(t, "empty", entry["name"])
 		assert.Equal(t, "", entry["type"])
@@ -110,19 +115,51 @@ func TestWorkflowParametersToMQL(t *testing.T) {
 	})
 
 	t.Run("output is sorted by name", func(t *testing.T) {
-		typ := logic.ParameterTypeString
-		input := map[string]*logic.WorkflowParameter{
-			"zeta":  {Type: &typ},
-			"alpha": {Type: &typ},
-			"mu":    {Type: &typ},
+		def := map[string]any{
+			"parameters": map[string]any{
+				"zeta":  map[string]any{"type": "String"},
+				"alpha": map[string]any{"type": "String"},
+				"mu":    map[string]any{"type": "String"},
+			},
 		}
-		params, _ := workflowParametersToMQL(input)
+		params, _ := workflowParametersToMQL(def, nil)
 		got := []string{
 			params[0].(map[string]any)["name"].(string),
 			params[1].(map[string]any)["name"].(string),
 			params[2].(map[string]any)["name"].(string),
 		}
 		assert.Equal(t, []string{"alpha", "mu", "zeta"}, got)
+	})
+
+	t.Run("runtime values supply default flag when declaration lacks it", func(t *testing.T) {
+		def := map[string]any{
+			"parameters": map[string]any{
+				"$connections": map[string]any{"type": "Object"},
+			},
+		}
+		runtime := map[string]*logic.WorkflowParameter{
+			"$connections": {Value: map[string]any{"some": "value"}},
+		}
+		params, _ := workflowParametersToMQL(def, runtime)
+		entry := params[0].(map[string]any)
+		assert.Equal(t, "$connections", entry["name"])
+		assert.Equal(t, "Object", entry["type"])
+		assert.Equal(t, true, entry["hasDefaultValue"])
+	})
+
+	t.Run("runtime-only entry (no declaration) still appears", func(t *testing.T) {
+		typ := logic.ParameterTypeSecureString
+		runtime := map[string]*logic.WorkflowParameter{
+			"legacyKey": {Type: &typ, Value: "x"},
+		}
+		params, secure := workflowParametersToMQL(nil, runtime)
+		assert.Len(t, params, 1)
+		entry := params[0].(map[string]any)
+		assert.Equal(t, "legacyKey", entry["name"])
+		assert.Equal(t, "SecureString", entry["type"])
+		assert.Equal(t, true, entry["hasDefaultValue"])
+		assert.Equal(t, true, entry["isSecure"])
+		assert.Equal(t, []any{"legacyKey"}, secure)
 	})
 }
 

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -2427,38 +2427,48 @@ func (a *mqlAzureSubscriptionNetworkServiceVirtualNetworkGateway) connections() 
 			if !stringx.Contains(filter, id) {
 				continue
 			}
-			props, err := convert.JsonToDict(c.Properties)
+			// LIST omits runtime fields like connectionStatus, ingressBytesTransferred,
+			// and egressBytesTransferred — they only land in GET responses. Fetch
+			// the full record so audits like `connections.where(connectionStatus == "NotConnected")`
+			// see real values rather than nulls. Connections-per-gateway is typically
+			// small (1–5) so the extra N+1 GETs are bounded.
+			full, err := client.Get(ctx, azureId.ResourceGroup, *c.Name, &network.VirtualNetworkGatewayConnectionsClientGetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			cn := full.VirtualNetworkGatewayConnection
+			props, err := convert.JsonToDict(cn.Properties)
 			if err != nil {
 				return nil, err
 			}
 			args := map[string]*llx.RawData{
-				"id":         llx.StringDataPtr(c.ID),
-				"type":       llx.StringDataPtr(c.Type),
-				"name":       llx.StringDataPtr(c.Name),
-				"etag":       llx.StringDataPtr(c.Etag),
-				"location":   llx.StringDataPtr(c.Location),
+				"id":         llx.StringDataPtr(cn.ID),
+				"type":       llx.StringDataPtr(cn.Type),
+				"name":       llx.StringDataPtr(cn.Name),
+				"etag":       llx.StringDataPtr(cn.Etag),
+				"location":   llx.StringDataPtr(cn.Location),
 				"properties": llx.DictData(props),
 			}
-			if c.Properties != nil {
-				args["connectionType"] = llx.StringDataPtr((*string)(c.Properties.ConnectionType))
-				args["connectionStatus"] = llx.StringDataPtr((*string)(c.Properties.ConnectionStatus))
-				args["connectionMode"] = llx.StringDataPtr((*string)(c.Properties.ConnectionMode))
-				args["connectionProtocol"] = llx.StringDataPtr((*string)(c.Properties.ConnectionProtocol))
-				args["provisioningState"] = llx.StringDataPtr((*string)(c.Properties.ProvisioningState))
-				args["enableBgp"] = llx.BoolDataPtr(c.Properties.EnableBgp)
-				args["usePolicyBasedTrafficSelectors"] = llx.BoolDataPtr(c.Properties.UsePolicyBasedTrafficSelectors)
-				args["useLocalAzureIpAddress"] = llx.BoolDataPtr(c.Properties.UseLocalAzureIPAddress)
-				args["dpdTimeoutSeconds"] = llx.IntDataDefault(c.Properties.DpdTimeoutSeconds, 0)
-				args["routingWeight"] = llx.IntDataDefault(c.Properties.RoutingWeight, 0)
-				args["ingressBytesTransferred"] = llx.IntDataDefault(c.Properties.IngressBytesTransferred, 0)
-				args["egressBytesTransferred"] = llx.IntDataDefault(c.Properties.EgressBytesTransferred, 0)
+			if cn.Properties != nil {
+				args["connectionType"] = llx.StringDataPtr((*string)(cn.Properties.ConnectionType))
+				args["connectionStatus"] = llx.StringDataPtr((*string)(cn.Properties.ConnectionStatus))
+				args["connectionMode"] = llx.StringDataPtr((*string)(cn.Properties.ConnectionMode))
+				args["connectionProtocol"] = llx.StringDataPtr((*string)(cn.Properties.ConnectionProtocol))
+				args["provisioningState"] = llx.StringDataPtr((*string)(cn.Properties.ProvisioningState))
+				args["enableBgp"] = llx.BoolDataPtr(cn.Properties.EnableBgp)
+				args["usePolicyBasedTrafficSelectors"] = llx.BoolDataPtr(cn.Properties.UsePolicyBasedTrafficSelectors)
+				args["useLocalAzureIpAddress"] = llx.BoolDataPtr(cn.Properties.UseLocalAzureIPAddress)
+				args["dpdTimeoutSeconds"] = llx.IntDataDefault(cn.Properties.DpdTimeoutSeconds, 0)
+				args["routingWeight"] = llx.IntDataDefault(cn.Properties.RoutingWeight, 0)
+				args["ingressBytesTransferred"] = llx.IntDataDefault(cn.Properties.IngressBytesTransferred, 0)
+				args["egressBytesTransferred"] = llx.IntDataDefault(cn.Properties.EgressBytesTransferred, 0)
 			}
 			mqlConnection, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.virtualNetworkGateway.connection", args)
 			if err != nil {
 				return nil, err
 			}
 			mqlConn := mqlConnection.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection)
-			mqlConn.cacheProperties = c.Properties
+			mqlConn.cacheProperties = cn.Properties
 			res = append(res, mqlConn)
 
 		}

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -2427,12 +2427,25 @@ func (a *mqlAzureSubscriptionNetworkServiceVirtualNetworkGateway) connections() 
 			if !stringx.Contains(filter, id) {
 				continue
 			}
+			if c.ID == nil || c.Name == nil {
+				continue
+			}
 			// LIST omits runtime fields like connectionStatus, ingressBytesTransferred,
 			// and egressBytesTransferred — they only land in GET responses. Fetch
 			// the full record so audits like `connections.where(connectionStatus == "NotConnected")`
 			// see real values rather than nulls. Connections-per-gateway is typically
 			// small (1–5) so the extra N+1 GETs are bounded.
-			full, err := client.Get(ctx, azureId.ResourceGroup, *c.Name, &network.VirtualNetworkGatewayConnectionsClientGetOptions{})
+			//
+			// Resolve the connection's own resource group from its ARM id rather
+			// than reusing the gateway's. While the ListPager is scoped to the
+			// gateway's RG, a Vnet2Vnet connection can reference a peer gateway
+			// that lives elsewhere, and parsing the connection's id keeps the
+			// GET correct regardless of any future cross-RG list semantics.
+			connId, err := ParseResourceID(*c.ID)
+			if err != nil {
+				return nil, err
+			}
+			full, err := client.Get(ctx, connId.ResourceGroup, *c.Name, &network.VirtualNetworkGatewayConnectionsClientGetOptions{})
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Summary

Three bugs found while live-testing the azure 13.11.0 PR set (#7611) against deployed Azure resources — a S2S VPN gateway with a real `LocalNetworkGateway` peer, a Consumption Logic App with a SecureString parameter, and a Container Apps managed environment without VNet integration.

### 1. VNG connection runtime fields always nil/0 (#7607 follow-up)

`virtualNetworkGateway.connections()` calls `NewListPager` on `VirtualNetworkGatewayConnectionsClient`, but the ARM **LIST** response omits the data-plane fields:
- `connectionStatus`
- `ingressBytesTransferred`
- `egressBytesTransferred`

Only **GET** returns them. So the audit query in #7607's own description silently never matched anything:

```mql
azure.subscription.networkService.virtualNetworkGateways.where(
  connections.any(_.connectionStatus == "NotConnected")
)
```

**Fix:** GET each connection that survives the gateway-id filter. The N+1 is bounded — typical S2S deployments have 1–5 connections per gateway.

**Verification (against live infra):**
```
connections: [
  0: {
    connectionStatus: "NotConnected"     # ← was null
    connectionType: "IPsec"
    ingressBytesTransferred: 0
    egressBytesTransferred: 0
    dpdTimeoutSeconds: 45
  }
]
```

### 2. Logic App `parameters` reads the wrong source (#7589 follow-up)

`workflowParametersToMQL` was passed `properties.parameters` — the runtime value map. ARM's runtime map only contains entries that have an explicit value, has no type info, and never sees declarations that lack a runtime value.

A workflow declaring three params (`$connections`, `publicLabel: String`, `secretToken: SecureString`) only surfaced **one row** — `$connections` — with empty `type`. The audit query in #7589's own description therefore never matched:

```mql
parameters.where(_["isSecure"] == true && _["hasDefaultValue"] == true)
```

**Fix:** parse declarations from `properties.definition.parameters` (where the `type` lives) and overlay runtime values on top so `hasDefaultValue` is accurate when the declaration omits a default but the runtime supplies one. Tests updated; new case added for runtime-only entries (legacy API shape).

**Verification (against live infra):**
```
parameters: [
  0: { name: "$connections",  type: "Object",       hasDefaultValue: true,  isSecure: false }
  1: { name: "publicLabel",   type: "String",       hasDefaultValue: true,  isSecure: false }
  2: { name: "secretToken",   type: "SecureString", hasDefaultValue: true,  isSecure: true  }
]
secureParameterNames: ["secretToken"]
```

### 3. ACA managed env `internalLoadBalancerEnabled` returns null (#7586 follow-up)

When `VnetConfiguration` is absent, `internalLB *bool` stayed nil and `llx.BoolDataPtr(nil)` rendered as null. Schema declares `internalLoadBalancerEnabled bool`, so the spot-check from #7586's test plan (`internalLoadBalancerEnabled == false`) never matched.

**Fix:** default to `false` and only override when the SDK provides a value. Use `llx.BoolData` instead of `llx.BoolDataPtr`.

### 4. Schema doc fix: ACA `transport` casing (#7586 follow-up)

The doc said the `transport` enum is `"auto", "http", "http2", "tcp"` but Azure's `IngressTransportMethod` enum returns `"Auto", "Http", "Http2", "Tcp"`. Audits like `transport == "auto"` silently never matched. Updated the doc to reflect the SDK casing — same pattern as `provisioningState` and other Azure enum fields elsewhere in this file.

## Test plan

- [x] `make providers/build/azure` (clean)
- [x] `gofmt -w` clean
- [x] `go test ./providers/azure/resources/ -run "TestWorkflowParametersToMQL|TestPolicyHasIpAllowList|TestParseDefinitionMap|TestWorkflowDefinitionToMQL|TestAccessPolicyToDict"` — passes
- [x] Live verification against an Azure subscription with all four resource types deployed (VNG+LNG+S2S connection, Consumption Logic App with `SecureString` parameter, Container Apps managed env without VNet)
- [ ] Reviewer: confirm no regression on existing audits that rely on the previous null/missing values

🤖 Generated with [Claude Code](https://claude.com/claude-code)