### PR TITLE
✨ aws: backfill aws.shield with subscription, protection, contact fields

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -5163,16 +5163,16 @@ private aws.shield.subscription @defaults("arn startTime") {
   startTime time
   // End time of the subscription
   endTime time
-  // Time period remaining in the subscription in days (truncated from seconds)
-  timeCommitmentInDays int
+  // DEPRECATED: use lengthInSeconds instead. Time period remaining in the subscription in days (truncated from seconds)
+  timeCommitmentInDays @maturity("deprecated") int
   // Length of the subscription period in seconds (raw value from TimeCommitmentInSeconds)
   lengthInSeconds int
-  // Whether auto-renew is enabled (ENABLED or DISABLED)
-  autoRenew string
+  // DEPRECATED: use autoRenewEnabled instead. Auto-renew status as a string enum (ENABLED or DISABLED)
+  autoRenew @maturity("deprecated") string
   // Whether auto-renew is enabled
   autoRenewEnabled bool
-  // Subscription limits (legacy per-type list of {Type, Max})
-  limits []dict
+  // DEPRECATED: use protectedResourceTypeLimits, maxProtectionGroups, and maxArbitraryPatternMembers instead. Legacy per-type list of {Type, Max} dicts
+  limits @maturity("deprecated") []dict
   // Per-protected-resource-type protection limits, keyed by resource type with the maximum protection count as the value
   protectedResourceTypeLimits map[string]int
   // Maximum number of protection groups allowed in the subscription
@@ -5195,8 +5195,8 @@ private aws.shield.protection @defaults("arn name resourceArn") {
   resourceArn string
   // Route 53 health check IDs associated with the protection
   healthCheckIds []string
-  // Application layer automatic response configuration (raw structure with status and action)
-  applicationLayerAutomaticResponseConfiguration dict
+  // DEPRECATED: use applicationLayerAutomaticResponseEnabled and applicationLayerAutomaticResponseAction instead. Raw structure with status and action
+  applicationLayerAutomaticResponseConfiguration @maturity("deprecated") dict
   // Whether automatic application-layer DDoS mitigation is enabled for the protection
   applicationLayerAutomaticResponseEnabled bool
   // WAF rule action used by automatic application-layer mitigation (BLOCK or COUNT; empty when not configured)

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -5165,10 +5165,20 @@ private aws.shield.subscription @defaults("arn startTime") {
   endTime time
   // Time period remaining in the subscription in days (truncated from seconds)
   timeCommitmentInDays int
+  // Length of the subscription period in seconds (raw value from TimeCommitmentInSeconds)
+  lengthInSeconds int
   // Whether auto-renew is enabled (ENABLED or DISABLED)
   autoRenew string
-  // Subscription limits
+  // Whether auto-renew is enabled
+  autoRenewEnabled bool
+  // Subscription limits (legacy per-type list of {Type, Max})
   limits []dict
+  // Per-protected-resource-type protection limits, keyed by resource type with the maximum protection count as the value
+  protectedResourceTypeLimits map[string]int
+  // Maximum number of protection groups allowed in the subscription
+  maxProtectionGroups int
+  // Maximum number of resource ARNs that can be specified for a single arbitrary-pattern protection group
+  maxArbitraryPatternMembers int
   // Proactive engagement status (ENABLED, DISABLED, or PENDING)
   proactiveEngagementStatus string
 }
@@ -5183,10 +5193,14 @@ private aws.shield.protection @defaults("arn name resourceArn") {
   name string
   // ARN of the protected resource
   resourceArn string
-  // Health check IDs associated with the protection
+  // Route 53 health check IDs associated with the protection
   healthCheckIds []string
-  // Application layer automatic response configuration
+  // Application layer automatic response configuration (raw structure with status and action)
   applicationLayerAutomaticResponseConfiguration dict
+  // Whether automatic application-layer DDoS mitigation is enabled for the protection
+  applicationLayerAutomaticResponseEnabled bool
+  // WAF rule action used by automatic application-layer mitigation (BLOCK or COUNT; empty when not configured)
+  applicationLayerAutomaticResponseAction string
 }
 
 // AWS Shield Advanced protection group

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -9837,11 +9837,26 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.shield.subscription.timeCommitmentInDays": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsShieldSubscription).GetTimeCommitmentInDays()).ToDataRes(types.Int)
 	},
+	"aws.shield.subscription.lengthInSeconds": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsShieldSubscription).GetLengthInSeconds()).ToDataRes(types.Int)
+	},
 	"aws.shield.subscription.autoRenew": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsShieldSubscription).GetAutoRenew()).ToDataRes(types.String)
 	},
+	"aws.shield.subscription.autoRenewEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsShieldSubscription).GetAutoRenewEnabled()).ToDataRes(types.Bool)
+	},
 	"aws.shield.subscription.limits": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsShieldSubscription).GetLimits()).ToDataRes(types.Array(types.Dict))
+	},
+	"aws.shield.subscription.protectedResourceTypeLimits": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsShieldSubscription).GetProtectedResourceTypeLimits()).ToDataRes(types.Map(types.String, types.Int))
+	},
+	"aws.shield.subscription.maxProtectionGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsShieldSubscription).GetMaxProtectionGroups()).ToDataRes(types.Int)
+	},
+	"aws.shield.subscription.maxArbitraryPatternMembers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsShieldSubscription).GetMaxArbitraryPatternMembers()).ToDataRes(types.Int)
 	},
 	"aws.shield.subscription.proactiveEngagementStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsShieldSubscription).GetProactiveEngagementStatus()).ToDataRes(types.String)
@@ -9863,6 +9878,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.shield.protection.applicationLayerAutomaticResponseConfiguration": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsShieldProtection).GetApplicationLayerAutomaticResponseConfiguration()).ToDataRes(types.Dict)
+	},
+	"aws.shield.protection.applicationLayerAutomaticResponseEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsShieldProtection).GetApplicationLayerAutomaticResponseEnabled()).ToDataRes(types.Bool)
+	},
+	"aws.shield.protection.applicationLayerAutomaticResponseAction": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsShieldProtection).GetApplicationLayerAutomaticResponseAction()).ToDataRes(types.String)
 	},
 	"aws.shield.protectionGroup.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsShieldProtectionGroup).GetId()).ToDataRes(types.String)
@@ -33708,12 +33729,32 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsShieldSubscription).TimeCommitmentInDays, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
+	"aws.shield.subscription.lengthInSeconds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsShieldSubscription).LengthInSeconds, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
 	"aws.shield.subscription.autoRenew": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsShieldSubscription).AutoRenew, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.shield.subscription.autoRenewEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsShieldSubscription).AutoRenewEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"aws.shield.subscription.limits": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsShieldSubscription).Limits, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.shield.subscription.protectedResourceTypeLimits": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsShieldSubscription).ProtectedResourceTypeLimits, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.shield.subscription.maxProtectionGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsShieldSubscription).MaxProtectionGroups, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.shield.subscription.maxArbitraryPatternMembers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsShieldSubscription).MaxArbitraryPatternMembers, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"aws.shield.subscription.proactiveEngagementStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33746,6 +33787,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.shield.protection.applicationLayerAutomaticResponseConfiguration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsShieldProtection).ApplicationLayerAutomaticResponseConfiguration, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"aws.shield.protection.applicationLayerAutomaticResponseEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsShieldProtection).ApplicationLayerAutomaticResponseEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.shield.protection.applicationLayerAutomaticResponseAction": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsShieldProtection).ApplicationLayerAutomaticResponseAction, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.shield.protectionGroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -80148,13 +80197,18 @@ type mqlAwsShieldSubscription struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAwsShieldSubscriptionInternal it will be used here
-	Arn                       plugin.TValue[string]
-	StartTime                 plugin.TValue[*time.Time]
-	EndTime                   plugin.TValue[*time.Time]
-	TimeCommitmentInDays      plugin.TValue[int64]
-	AutoRenew                 plugin.TValue[string]
-	Limits                    plugin.TValue[[]any]
-	ProactiveEngagementStatus plugin.TValue[string]
+	Arn                         plugin.TValue[string]
+	StartTime                   plugin.TValue[*time.Time]
+	EndTime                     plugin.TValue[*time.Time]
+	TimeCommitmentInDays        plugin.TValue[int64]
+	LengthInSeconds             plugin.TValue[int64]
+	AutoRenew                   plugin.TValue[string]
+	AutoRenewEnabled            plugin.TValue[bool]
+	Limits                      plugin.TValue[[]any]
+	ProtectedResourceTypeLimits plugin.TValue[map[string]any]
+	MaxProtectionGroups         plugin.TValue[int64]
+	MaxArbitraryPatternMembers  plugin.TValue[int64]
+	ProactiveEngagementStatus   plugin.TValue[string]
 }
 
 // createAwsShieldSubscription creates a new instance of this resource
@@ -80210,12 +80264,32 @@ func (c *mqlAwsShieldSubscription) GetTimeCommitmentInDays() *plugin.TValue[int6
 	return &c.TimeCommitmentInDays
 }
 
+func (c *mqlAwsShieldSubscription) GetLengthInSeconds() *plugin.TValue[int64] {
+	return &c.LengthInSeconds
+}
+
 func (c *mqlAwsShieldSubscription) GetAutoRenew() *plugin.TValue[string] {
 	return &c.AutoRenew
 }
 
+func (c *mqlAwsShieldSubscription) GetAutoRenewEnabled() *plugin.TValue[bool] {
+	return &c.AutoRenewEnabled
+}
+
 func (c *mqlAwsShieldSubscription) GetLimits() *plugin.TValue[[]any] {
 	return &c.Limits
+}
+
+func (c *mqlAwsShieldSubscription) GetProtectedResourceTypeLimits() *plugin.TValue[map[string]any] {
+	return &c.ProtectedResourceTypeLimits
+}
+
+func (c *mqlAwsShieldSubscription) GetMaxProtectionGroups() *plugin.TValue[int64] {
+	return &c.MaxProtectionGroups
+}
+
+func (c *mqlAwsShieldSubscription) GetMaxArbitraryPatternMembers() *plugin.TValue[int64] {
+	return &c.MaxArbitraryPatternMembers
 }
 
 func (c *mqlAwsShieldSubscription) GetProactiveEngagementStatus() *plugin.TValue[string] {
@@ -80233,6 +80307,8 @@ type mqlAwsShieldProtection struct {
 	ResourceArn                                    plugin.TValue[string]
 	HealthCheckIds                                 plugin.TValue[[]any]
 	ApplicationLayerAutomaticResponseConfiguration plugin.TValue[any]
+	ApplicationLayerAutomaticResponseEnabled       plugin.TValue[bool]
+	ApplicationLayerAutomaticResponseAction        plugin.TValue[string]
 }
 
 // createAwsShieldProtection creates a new instance of this resource
@@ -80294,6 +80370,14 @@ func (c *mqlAwsShieldProtection) GetHealthCheckIds() *plugin.TValue[[]any] {
 
 func (c *mqlAwsShieldProtection) GetApplicationLayerAutomaticResponseConfiguration() *plugin.TValue[any] {
 	return &c.ApplicationLayerAutomaticResponseConfiguration
+}
+
+func (c *mqlAwsShieldProtection) GetApplicationLayerAutomaticResponseEnabled() *plugin.TValue[bool] {
+	return &c.ApplicationLayerAutomaticResponseEnabled
+}
+
+func (c *mqlAwsShieldProtection) GetApplicationLayerAutomaticResponseAction() *plugin.TValue[string] {
+	return &c.ApplicationLayerAutomaticResponseAction
 }
 
 // mqlAwsShieldProtectionGroup for the aws.shield.protectionGroup resource

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -6705,7 +6705,9 @@ aws.shield.emergencyContact.emailAddress 13.0.2
 aws.shield.emergencyContact.phoneNumber 13.0.2
 aws.shield.emergencyContacts 13.0.2
 aws.shield.protection 11.16.1
+aws.shield.protection.applicationLayerAutomaticResponseAction 13.21.4
 aws.shield.protection.applicationLayerAutomaticResponseConfiguration 11.16.1
+aws.shield.protection.applicationLayerAutomaticResponseEnabled 13.21.4
 aws.shield.protection.arn 11.16.1
 aws.shield.protection.healthCheckIds 11.16.1
 aws.shield.protection.id 11.16.1
@@ -6723,9 +6725,14 @@ aws.shield.protections 11.16.1
 aws.shield.subscription 11.16.1
 aws.shield.subscription.arn 11.16.1
 aws.shield.subscription.autoRenew 11.16.1
+aws.shield.subscription.autoRenewEnabled 13.21.4
 aws.shield.subscription.endTime 11.16.1
+aws.shield.subscription.lengthInSeconds 13.21.4
 aws.shield.subscription.limits 11.16.1
+aws.shield.subscription.maxArbitraryPatternMembers 13.21.4
+aws.shield.subscription.maxProtectionGroups 13.21.4
 aws.shield.subscription.proactiveEngagementStatus 11.16.1
+aws.shield.subscription.protectedResourceTypeLimits 13.21.4
 aws.shield.subscription.startTime 11.16.1
 aws.shield.subscription.timeCommitmentInDays 11.16.1
 aws.shield.subscriptionState 11.16.1

--- a/providers/aws/resources/aws_shield.go
+++ b/providers/aws/resources/aws_shield.go
@@ -14,6 +14,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/aws/connection"
+	"go.mondoo.com/mql/v13/types"
 )
 
 func (a *mqlAwsShield) id() (string, error) {
@@ -61,15 +62,43 @@ func (a *mqlAwsShield) subscription() (*mqlAwsShieldSubscription, error) {
 		log.Warn().Err(err).Msg("failed to convert shield subscription limits")
 	}
 
+	// Per-resource-type protection limits, keyed by resource type. The SDK
+	// returns these inside SubscriptionLimits.ProtectionLimits as a slice of
+	// {Type, Max} entries — flatten into a map for direct key-based queries.
+	protectedResourceTypeLimits := map[string]any{}
+	var maxProtectionGroups int64
+	var maxArbitraryPatternMembers int64
+	if sub.SubscriptionLimits != nil {
+		if pl := sub.SubscriptionLimits.ProtectionLimits; pl != nil {
+			for _, l := range pl.ProtectedResourceTypeLimits {
+				if l.Type == nil {
+					continue
+				}
+				protectedResourceTypeLimits[*l.Type] = l.Max
+			}
+		}
+		if pgl := sub.SubscriptionLimits.ProtectionGroupLimits; pgl != nil {
+			maxProtectionGroups = pgl.MaxProtectionGroups
+			if ptl := pgl.PatternTypeLimits; ptl != nil && ptl.ArbitraryPatternLimits != nil {
+				maxArbitraryPatternMembers = ptl.ArbitraryPatternLimits.MaxMembers
+			}
+		}
+	}
+
 	mqlSub, err := CreateResource(a.MqlRuntime, "aws.shield.subscription",
 		map[string]*llx.RawData{
-			"arn":                       llx.StringDataPtr(sub.SubscriptionArn),
-			"startTime":                 llx.TimeDataPtr(sub.StartTime),
-			"endTime":                   llx.TimeDataPtr(sub.EndTime),
-			"timeCommitmentInDays":      llx.IntData(sub.TimeCommitmentInSeconds / 86400),
-			"autoRenew":                 llx.StringData(string(sub.AutoRenew)),
-			"limits":                    llx.ArrayData(limits, "dict"),
-			"proactiveEngagementStatus": llx.StringData(string(sub.ProactiveEngagementStatus)),
+			"arn":                         llx.StringDataPtr(sub.SubscriptionArn),
+			"startTime":                   llx.TimeDataPtr(sub.StartTime),
+			"endTime":                     llx.TimeDataPtr(sub.EndTime),
+			"timeCommitmentInDays":        llx.IntData(sub.TimeCommitmentInSeconds / 86400),
+			"lengthInSeconds":             llx.IntData(sub.TimeCommitmentInSeconds),
+			"autoRenew":                   llx.StringData(string(sub.AutoRenew)),
+			"autoRenewEnabled":            llx.BoolData(sub.AutoRenew == shieldtypes.AutoRenewEnabled),
+			"limits":                      llx.ArrayData(limits, "dict"),
+			"protectedResourceTypeLimits": llx.MapData(protectedResourceTypeLimits, types.Int),
+			"maxProtectionGroups":         llx.IntData(maxProtectionGroups),
+			"maxArbitraryPatternMembers":  llx.IntData(maxArbitraryPatternMembers),
+			"proactiveEngagementStatus":   llx.StringData(string(sub.ProactiveEngagementStatus)),
 		})
 	if err != nil {
 		return nil, err
@@ -102,11 +131,22 @@ func (a *mqlAwsShield) protections() ([]any, error) {
 		}
 		for _, p := range page.Protections {
 			var appLayerConfig any
-			if p.ApplicationLayerAutomaticResponseConfiguration != nil {
+			appLayerEnabled := false
+			appLayerAction := ""
+			if cfg := p.ApplicationLayerAutomaticResponseConfiguration; cfg != nil {
 				var convErr error
-				appLayerConfig, convErr = convert.JsonToDict(p.ApplicationLayerAutomaticResponseConfiguration)
+				appLayerConfig, convErr = convert.JsonToDict(cfg)
 				if convErr != nil {
 					log.Warn().Err(convErr).Msg("failed to convert application layer automatic response configuration")
+				}
+				appLayerEnabled = cfg.Status == shieldtypes.ApplicationLayerAutomaticResponseStatusEnabled
+				if cfg.Action != nil {
+					switch {
+					case cfg.Action.Block != nil:
+						appLayerAction = "BLOCK"
+					case cfg.Action.Count != nil:
+						appLayerAction = "COUNT"
+					}
 				}
 			}
 			mqlProtection, err := CreateResource(a.MqlRuntime, "aws.shield.protection",
@@ -117,6 +157,8 @@ func (a *mqlAwsShield) protections() ([]any, error) {
 					"resourceArn":    llx.StringDataPtr(p.ResourceArn),
 					"healthCheckIds": llx.ArrayData(llx.TArr2Raw(p.HealthCheckIds), "string"),
 					"applicationLayerAutomaticResponseConfiguration": llx.DictData(appLayerConfig),
+					"applicationLayerAutomaticResponseEnabled":       llx.BoolData(appLayerEnabled),
+					"applicationLayerAutomaticResponseAction":        llx.StringData(appLayerAction),
 				})
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## Summary

Backfill `aws.shield` resources to expose AWS Shield Advanced fields the SDK already returns but mql wasn't modeling.

- **`aws.shield.subscription`** — added `lengthInSeconds` (raw `TimeCommitmentInSeconds`), `autoRenewEnabled` (boolean form of the existing `autoRenew` enum), and three flattened `SubscriptionLimits` fields: `protectedResourceTypeLimits` (`map[string]int`, keyed by AWS resource type), `maxProtectionGroups`, and `maxArbitraryPatternMembers`.
- **`aws.shield.protection`** — added `applicationLayerAutomaticResponseEnabled` (boolean form of the existing nested `Status` enum) and `applicationLayerAutomaticResponseAction` (`BLOCK` or `COUNT`, derived from the nested `Action.Block` / `Action.Count` discriminator). The original `applicationLayerAutomaticResponseConfiguration dict` is preserved for callers that need the raw structure.

No new sub-resources — limits flatten cleanly into the parent and don't carry stable IDs of their own. `healthCheckIds` stays as `[]string` since `aws.route53.healthCheck` doesn't currently have an init function that would let `NewResource(id: ...)` resolve a typed ref without expanding scope.

New `.lr.versions` entries are at `13.21.4` (next patch after the provider's current `13.21.3`). The `Version` in `providers/aws/config/config.go` is unchanged.

## Test plan

- [ ] `mql shell aws -c "aws.shield.subscription { lengthInSeconds autoRenewEnabled maxProtectionGroups maxArbitraryPatternMembers protectedResourceTypeLimits }"`
- [ ] `mql shell aws -c "aws.shield.protections { name applicationLayerAutomaticResponseEnabled applicationLayerAutomaticResponseAction }"`
- [ ] Account without Shield Advanced returns null subscription cleanly (no panic).
- [ ] Account without permissions surfaces `subscriptionState == "UNKNOWN"` and empty protections (existing access-denied paths preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)