### PR TITLE
✨ aws: backfill aws.detective member fields and datasource packages

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -4880,10 +4880,13 @@ private aws.macie.customDataIdentifier @defaults("id name") {
 // the account. Iterate `graphs()` for the per-region behavior graphs,
 // each of which exposes member accounts and the data-source packages
 // (Detective core, EKS audit logs, Security Hub findings) feeding the
-// graph.
+// graph. Iterate `organizationAdminAccounts()` to enumerate the accounts
+// designated as Detective administrators across the AWS organization.
 aws.detective {
   // List of Detective behavior graphs across regions
   graphs() []aws.detective.graph
+  // Detective administrator accounts delegated for the AWS organization
+  organizationAdminAccounts() []aws.detective.organizationAdminAccount
 }
 
 // Amazon Detective behavior graph
@@ -4930,6 +4933,24 @@ private aws.detective.graph.member @defaults("accountId status invitationType") 
   updatedAt time
   // Source of the membership: INVITATION, ORGANIZATION
   invitationType string
+  // Ingestion state for each data-source package, keyed by package name (DETECTIVE_CORE, EKS_AUDIT, ASFF_SECURITYHUB_FINDING). Values: STARTED, STOPPED, DISABLED
+  datasourcePackageIngestStates map[string]string
+  // Per-package data volume usage for the member, keyed by package name. Each entry contains volumeUsageInBytes and volumeUsageUpdateTime
+  volumeUsageByDatasourcePackage map[string]dict
+}
+
+// Amazon Detective organization administrator account
+private aws.detective.organizationAdminAccount @defaults("accountId region delegationTime") {
+  // AWS account ID of the Detective administrator account
+  accountId string
+  // ARN of the organization behavior graph the account administers
+  graphArn string
+  // Region the administrator delegation is registered in
+  region string
+  // Date and time when the administrator account was enabled
+  delegationTime time
+  // Behavior graph the administrator account owns
+  graph() aws.detective.graph
 }
 
 // AWS Security Hub

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -227,6 +227,7 @@ const (
 	ResourceAwsDetective                                                        string = "aws.detective"
 	ResourceAwsDetectiveGraph                                                   string = "aws.detective.graph"
 	ResourceAwsDetectiveGraphMember                                             string = "aws.detective.graph.member"
+	ResourceAwsDetectiveOrganizationAdminAccount                                string = "aws.detective.organizationAdminAccount"
 	ResourceAwsSecurityhub                                                      string = "aws.securityhub"
 	ResourceAwsSecurityhubHub                                                   string = "aws.securityhub.hub"
 	ResourceAwsSecurityhubStandardSubscription                                  string = "aws.securityhub.standardSubscription"
@@ -1603,6 +1604,10 @@ func init() {
 		"aws.detective.graph.member": {
 			// to override args, implement: initAwsDetectiveGraphMember(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsDetectiveGraphMember,
+		},
+		"aws.detective.organizationAdminAccount": {
+			// to override args, implement: initAwsDetectiveOrganizationAdminAccount(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsDetectiveOrganizationAdminAccount,
 		},
 		"aws.securityhub": {
 			// to override args, implement: initAwsSecurityhub(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -9531,6 +9536,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.detective.graphs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDetective).GetGraphs()).ToDataRes(types.Array(types.Resource("aws.detective.graph")))
 	},
+	"aws.detective.organizationAdminAccounts": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDetective).GetOrganizationAdminAccounts()).ToDataRes(types.Array(types.Resource("aws.detective.organizationAdminAccount")))
+	},
 	"aws.detective.graph.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDetectiveGraph).GetArn()).ToDataRes(types.String)
 	},
@@ -9578,6 +9586,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.detective.graph.member.invitationType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDetectiveGraphMember).GetInvitationType()).ToDataRes(types.String)
+	},
+	"aws.detective.graph.member.datasourcePackageIngestStates": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDetectiveGraphMember).GetDatasourcePackageIngestStates()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.detective.graph.member.volumeUsageByDatasourcePackage": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDetectiveGraphMember).GetVolumeUsageByDatasourcePackage()).ToDataRes(types.Map(types.String, types.Dict))
+	},
+	"aws.detective.organizationAdminAccount.accountId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDetectiveOrganizationAdminAccount).GetAccountId()).ToDataRes(types.String)
+	},
+	"aws.detective.organizationAdminAccount.graphArn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDetectiveOrganizationAdminAccount).GetGraphArn()).ToDataRes(types.String)
+	},
+	"aws.detective.organizationAdminAccount.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDetectiveOrganizationAdminAccount).GetRegion()).ToDataRes(types.String)
+	},
+	"aws.detective.organizationAdminAccount.delegationTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDetectiveOrganizationAdminAccount).GetDelegationTime()).ToDataRes(types.Time)
+	},
+	"aws.detective.organizationAdminAccount.graph": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDetectiveOrganizationAdminAccount).GetGraph()).ToDataRes(types.Resource("aws.detective.graph"))
 	},
 	"aws.securityhub.hubs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSecurityhub).GetHubs()).ToDataRes(types.Array(types.Resource("aws.securityhub.hub")))
@@ -33244,6 +33273,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsDetective).Graphs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.detective.organizationAdminAccounts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDetective).OrganizationAdminAccounts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.detective.graph.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsDetectiveGraph).__id, ok = v.Value.(string)
 		return
@@ -33314,6 +33347,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.detective.graph.member.invitationType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsDetectiveGraphMember).InvitationType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.detective.graph.member.datasourcePackageIngestStates": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDetectiveGraphMember).DatasourcePackageIngestStates, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.detective.graph.member.volumeUsageByDatasourcePackage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDetectiveGraphMember).VolumeUsageByDatasourcePackage, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.detective.organizationAdminAccount.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDetectiveOrganizationAdminAccount).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.detective.organizationAdminAccount.accountId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDetectiveOrganizationAdminAccount).AccountId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.detective.organizationAdminAccount.graphArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDetectiveOrganizationAdminAccount).GraphArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.detective.organizationAdminAccount.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDetectiveOrganizationAdminAccount).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.detective.organizationAdminAccount.delegationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDetectiveOrganizationAdminAccount).DelegationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.detective.organizationAdminAccount.graph": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDetectiveOrganizationAdminAccount).Graph, ok = plugin.RawToTValue[*mqlAwsDetectiveGraph](v.Value, v.Error)
 		return
 	},
 	"aws.securityhub.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -78835,7 +78900,8 @@ type mqlAwsDetective struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAwsDetectiveInternal it will be used here
-	Graphs plugin.TValue[[]any]
+	Graphs                    plugin.TValue[[]any]
+	OrganizationAdminAccounts plugin.TValue[[]any]
 }
 
 // createAwsDetective creates a new instance of this resource
@@ -78888,6 +78954,22 @@ func (c *mqlAwsDetective) GetGraphs() *plugin.TValue[[]any] {
 		}
 
 		return c.graphs()
+	})
+}
+
+func (c *mqlAwsDetective) GetOrganizationAdminAccounts() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.OrganizationAdminAccounts, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.detective", c.__id, "organizationAdminAccounts")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.organizationAdminAccounts()
 	})
 }
 
@@ -78986,16 +79068,18 @@ type mqlAwsDetectiveGraphMember struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAwsDetectiveGraphMemberInternal it will be used here
-	GraphArn        plugin.TValue[string]
-	Region          plugin.TValue[string]
-	AccountId       plugin.TValue[string]
-	Email           plugin.TValue[string]
-	AdministratorId plugin.TValue[string]
-	Status          plugin.TValue[string]
-	DisabledReason  plugin.TValue[string]
-	InvitedAt       plugin.TValue[*time.Time]
-	UpdatedAt       plugin.TValue[*time.Time]
-	InvitationType  plugin.TValue[string]
+	GraphArn                       plugin.TValue[string]
+	Region                         plugin.TValue[string]
+	AccountId                      plugin.TValue[string]
+	Email                          plugin.TValue[string]
+	AdministratorId                plugin.TValue[string]
+	Status                         plugin.TValue[string]
+	DisabledReason                 plugin.TValue[string]
+	InvitedAt                      plugin.TValue[*time.Time]
+	UpdatedAt                      plugin.TValue[*time.Time]
+	InvitationType                 plugin.TValue[string]
+	DatasourcePackageIngestStates  plugin.TValue[map[string]any]
+	VolumeUsageByDatasourcePackage plugin.TValue[map[string]any]
 }
 
 // createAwsDetectiveGraphMember creates a new instance of this resource
@@ -79073,6 +79157,90 @@ func (c *mqlAwsDetectiveGraphMember) GetUpdatedAt() *plugin.TValue[*time.Time] {
 
 func (c *mqlAwsDetectiveGraphMember) GetInvitationType() *plugin.TValue[string] {
 	return &c.InvitationType
+}
+
+func (c *mqlAwsDetectiveGraphMember) GetDatasourcePackageIngestStates() *plugin.TValue[map[string]any] {
+	return &c.DatasourcePackageIngestStates
+}
+
+func (c *mqlAwsDetectiveGraphMember) GetVolumeUsageByDatasourcePackage() *plugin.TValue[map[string]any] {
+	return &c.VolumeUsageByDatasourcePackage
+}
+
+// mqlAwsDetectiveOrganizationAdminAccount for the aws.detective.organizationAdminAccount resource
+type mqlAwsDetectiveOrganizationAdminAccount struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAwsDetectiveOrganizationAdminAccountInternal it will be used here
+	AccountId      plugin.TValue[string]
+	GraphArn       plugin.TValue[string]
+	Region         plugin.TValue[string]
+	DelegationTime plugin.TValue[*time.Time]
+	Graph          plugin.TValue[*mqlAwsDetectiveGraph]
+}
+
+// createAwsDetectiveOrganizationAdminAccount creates a new instance of this resource
+func createAwsDetectiveOrganizationAdminAccount(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsDetectiveOrganizationAdminAccount{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.detective.organizationAdminAccount", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsDetectiveOrganizationAdminAccount) MqlName() string {
+	return "aws.detective.organizationAdminAccount"
+}
+
+func (c *mqlAwsDetectiveOrganizationAdminAccount) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsDetectiveOrganizationAdminAccount) GetAccountId() *plugin.TValue[string] {
+	return &c.AccountId
+}
+
+func (c *mqlAwsDetectiveOrganizationAdminAccount) GetGraphArn() *plugin.TValue[string] {
+	return &c.GraphArn
+}
+
+func (c *mqlAwsDetectiveOrganizationAdminAccount) GetRegion() *plugin.TValue[string] {
+	return &c.Region
+}
+
+func (c *mqlAwsDetectiveOrganizationAdminAccount) GetDelegationTime() *plugin.TValue[*time.Time] {
+	return &c.DelegationTime
+}
+
+func (c *mqlAwsDetectiveOrganizationAdminAccount) GetGraph() *plugin.TValue[*mqlAwsDetectiveGraph] {
+	return plugin.GetOrCompute[*mqlAwsDetectiveGraph](&c.Graph, func() (*mqlAwsDetectiveGraph, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.detective.organizationAdminAccount", c.__id, "graph")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsDetectiveGraph), nil
+			}
+		}
+
+		return c.graph()
+	})
 }
 
 // mqlAwsSecurityhub for the aws.securityhub resource

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -1416,6 +1416,7 @@ aws.detective.graph.datasourcePackages 13.21.4
 aws.detective.graph.member 13.21.4
 aws.detective.graph.member.accountId 13.21.4
 aws.detective.graph.member.administratorId 13.21.4
+aws.detective.graph.member.datasourcePackageIngestStates 13.21.4
 aws.detective.graph.member.disabledReason 13.21.4
 aws.detective.graph.member.email 13.21.4
 aws.detective.graph.member.graphArn 13.21.4
@@ -1424,10 +1425,18 @@ aws.detective.graph.member.invitedAt 13.21.4
 aws.detective.graph.member.region 13.21.4
 aws.detective.graph.member.status 13.21.4
 aws.detective.graph.member.updatedAt 13.21.4
+aws.detective.graph.member.volumeUsageByDatasourcePackage 13.21.4
 aws.detective.graph.members 13.21.4
 aws.detective.graph.region 13.21.4
 aws.detective.graph.tags 13.21.4
 aws.detective.graphs 13.21.4
+aws.detective.organizationAdminAccount 13.21.4
+aws.detective.organizationAdminAccount.accountId 13.21.4
+aws.detective.organizationAdminAccount.delegationTime 13.21.4
+aws.detective.organizationAdminAccount.graph 13.21.4
+aws.detective.organizationAdminAccount.graphArn 13.21.4
+aws.detective.organizationAdminAccount.region 13.21.4
+aws.detective.organizationAdminAccounts 13.21.4
 aws.directoryservice 11.15.6
 aws.directoryservice.connectSettings 11.15.6
 aws.directoryservice.connectSettings.availabilityZones 11.15.6

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.21.3",
-  "generated_at": "2026-05-08T10:57:12-07:00",
+  "generated_at": "2026-05-09T16:54:12-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindingsV2",
@@ -128,6 +128,7 @@
     "detective:ListDatasourcePackages",
     "detective:ListGraphs",
     "detective:ListMembers",
+    "detective:ListOrganizationAdminAccounts",
     "detective:ListTagsForResource",
     "dms:DescribeReplicationInstances",
     "docdbelastic:ListClusterSnapshots",
@@ -1457,6 +1458,12 @@
       "permission": "detective:ListMembers",
       "service": "detective",
       "action": "ListMembers",
+      "source_file": "aws_detective.go"
+    },
+    {
+      "permission": "detective:ListOrganizationAdminAccounts",
+      "service": "detective",
+      "action": "ListOrganizationAdminAccounts",
       "source_file": "aws_detective.go"
     },
     {

--- a/providers/aws/resources/aws_detective.go
+++ b/providers/aws/resources/aws_detective.go
@@ -8,13 +8,14 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/detective"
-	"github.com/aws/aws-sdk-go-v2/service/detective/types"
+	detectivetypes "github.com/aws/aws-sdk-go-v2/service/detective/types"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/aws/connection"
+	"go.mondoo.com/mql/v13/types"
 )
 
 func (a *mqlAwsDetective) id() (string, error) {
@@ -135,22 +136,42 @@ func (a *mqlAwsDetectiveGraph) members() ([]any, error) {
 	return res, nil
 }
 
-func newMqlAwsDetectiveGraphMember(runtime *plugin.Runtime, region string, m types.MemberDetail) (plugin.Resource, error) {
+func newMqlAwsDetectiveGraphMember(runtime *plugin.Runtime, region string, m detectivetypes.MemberDetail) (plugin.Resource, error) {
 	graphArn := convert.ToValue(m.GraphArn)
 	accountId := convert.ToValue(m.AccountId)
+
+	ingestStates := make(map[string]any, len(m.DatasourcePackageIngestStates))
+	for pkg, state := range m.DatasourcePackageIngestStates {
+		ingestStates[string(pkg)] = string(state)
+	}
+
+	volumeUsage := make(map[string]any, len(m.VolumeUsageByDatasourcePackage))
+	for pkg, info := range m.VolumeUsageByDatasourcePackage {
+		entry := map[string]any{}
+		if info.VolumeUsageInBytes != nil {
+			entry["volumeUsageInBytes"] = *info.VolumeUsageInBytes
+		}
+		if info.VolumeUsageUpdateTime != nil {
+			entry["volumeUsageUpdateTime"] = *info.VolumeUsageUpdateTime
+		}
+		volumeUsage[string(pkg)] = entry
+	}
+
 	return CreateResource(runtime, "aws.detective.graph.member",
 		map[string]*llx.RawData{
-			"__id":            llx.StringData(fmt.Sprintf("%s/member/%s", graphArn, accountId)),
-			"graphArn":        llx.StringDataPtr(m.GraphArn),
-			"region":          llx.StringData(region),
-			"accountId":       llx.StringDataPtr(m.AccountId),
-			"email":           llx.StringDataPtr(m.EmailAddress),
-			"administratorId": llx.StringDataPtr(m.AdministratorId),
-			"status":          llx.StringData(string(m.Status)),
-			"disabledReason":  llx.StringData(string(m.DisabledReason)),
-			"invitedAt":       llx.TimeDataPtr(m.InvitedTime),
-			"updatedAt":       llx.TimeDataPtr(m.UpdatedTime),
-			"invitationType":  llx.StringData(string(m.InvitationType)),
+			"__id":                           llx.StringData(fmt.Sprintf("%s/member/%s", graphArn, accountId)),
+			"graphArn":                       llx.StringDataPtr(m.GraphArn),
+			"region":                         llx.StringData(region),
+			"accountId":                      llx.StringDataPtr(m.AccountId),
+			"email":                          llx.StringDataPtr(m.EmailAddress),
+			"administratorId":                llx.StringDataPtr(m.AdministratorId),
+			"status":                         llx.StringData(string(m.Status)),
+			"disabledReason":                 llx.StringData(string(m.DisabledReason)),
+			"invitedAt":                      llx.TimeDataPtr(m.InvitedTime),
+			"updatedAt":                      llx.TimeDataPtr(m.UpdatedTime),
+			"invitationType":                 llx.StringData(string(m.InvitationType)),
+			"datasourcePackageIngestStates":  llx.MapData(ingestStates, types.String),
+			"volumeUsageByDatasourcePackage": llx.MapData(volumeUsage, types.Dict),
 		})
 }
 
@@ -206,4 +227,97 @@ func (a *mqlAwsDetectiveGraph) tags() (map[string]any, error) {
 		return nil, err
 	}
 	return convert.MapToInterfaceMap(resp.Tags), nil
+}
+
+func (a *mqlAwsDetective) organizationAdminAccounts() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+
+	res := []any{}
+	poolOfJobs := jobpool.CreatePool(a.getOrganizationAdminAccounts(conn), 5)
+	poolOfJobs.Run()
+
+	if poolOfJobs.HasErrors() {
+		return nil, poolOfJobs.GetErrors()
+	}
+	for i := range poolOfJobs.Jobs {
+		if poolOfJobs.Jobs[i].Result != nil {
+			res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
+		}
+	}
+	return res, nil
+}
+
+func (a *mqlAwsDetective) getOrganizationAdminAccounts(conn *connection.AwsConnection) []*jobpool.Job {
+	tasks := make([]*jobpool.Job, 0)
+	regions, err := conn.Regions()
+	if err != nil {
+		return []*jobpool.Job{{Err: err}}
+	}
+
+	for _, region := range regions {
+		f := func() (jobpool.JobResult, error) {
+			svc := conn.Detective(region)
+			ctx := context.Background()
+			res := []any{}
+
+			var nextToken *string
+			for {
+				resp, err := svc.ListOrganizationAdminAccounts(ctx, &detective.ListOrganizationAdminAccountsInput{NextToken: nextToken})
+				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", region).Msg("error accessing region for AWS Detective administrators")
+						return res, nil
+					}
+					if IsServiceNotAvailableInRegionError(err) {
+						log.Debug().Str("region", region).Msg("AWS Detective is not available in region")
+						return res, nil
+					}
+					return nil, err
+				}
+
+				for _, admin := range resp.Administrators {
+					accountId := convert.ToValue(admin.AccountId)
+					graphArn := convert.ToValue(admin.GraphArn)
+					mqlAdmin, err := CreateResource(a.MqlRuntime, "aws.detective.organizationAdminAccount",
+						map[string]*llx.RawData{
+							"__id":           llx.StringData(fmt.Sprintf("%s/%s/%s", region, graphArn, accountId)),
+							"accountId":      llx.StringDataPtr(admin.AccountId),
+							"graphArn":       llx.StringDataPtr(admin.GraphArn),
+							"region":         llx.StringData(region),
+							"delegationTime": llx.TimeDataPtr(admin.DelegationTime),
+						})
+					if err != nil {
+						return nil, err
+					}
+					res = append(res, mqlAdmin)
+				}
+
+				if resp.NextToken == nil || *resp.NextToken == "" {
+					break
+				}
+				nextToken = resp.NextToken
+			}
+			return jobpool.JobResult(res), nil
+		}
+		tasks = append(tasks, jobpool.NewJob(f))
+	}
+	return tasks
+}
+
+func (a *mqlAwsDetectiveOrganizationAdminAccount) graph() (*mqlAwsDetectiveGraph, error) {
+	graphArn := a.GraphArn.Data
+	if graphArn == "" {
+		a.Graph.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	mqlGraph, err := NewResource(a.MqlRuntime, "aws.detective.graph",
+		map[string]*llx.RawData{
+			"__id":   llx.StringData(graphArn),
+			"arn":    llx.StringData(graphArn),
+			"region": llx.StringData(a.Region.Data),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return mqlGraph.(*mqlAwsDetectiveGraph), nil
 }


### PR DESCRIPTION
## Summary

- Add `datasourcePackageIngestStates` and `volumeUsageByDatasourcePackage` to `aws.detective.graph.member`, exposing per-package ingest state and volume usage that AWS already returns from `ListMembers`.
- Add `aws.detective.organizationAdminAccount` (with `accountId`, `graphArn`, `region`, `delegationTime`, and a typed `graph()` cross-ref) and surface it as `aws.detective.organizationAdminAccounts()` on the namespace.
- Skip the deprecated `MemberDetail` fields (`MasterId`, `PercentOfGraphUtilization*`, `VolumeUsageInBytes`, `VolumeUsageUpdatedTime`) — the per-package map replaces them.

## Test plan

- [ ] `make providers/build/aws && make providers/install/aws`
- [ ] `mql run aws -c "aws.detective.graphs { members { accountId datasourcePackageIngestStates volumeUsageByDatasourcePackage } }"`
- [ ] `mql run aws -c "aws.detective.organizationAdminAccounts { accountId region delegationTime graph.arn }"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)