### PR TITLE
✨ azure: model storage account queues and tables

### DIFF
--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -1544,6 +1544,8 @@ var azurePermissionOverrides = map[string]string{
 	"Microsoft.Storage/objectReplicationPolicies/read":  "Microsoft.Storage/storageAccounts/objectReplicationPolicies/read",
 	"Microsoft.Storage/inventoryPolicies/read":          "Microsoft.Storage/storageAccounts/inventoryPolicies/read",
 	"Microsoft.Storage/blobInventoryPolicies/read":      "Microsoft.Storage/storageAccounts/inventoryPolicies/read",
+	"Microsoft.Storage/queue/read":                      "Microsoft.Storage/storageAccounts/queueServices/queues/read",
+	"Microsoft.Storage/table/read":                      "Microsoft.Storage/storageAccounts/tableServices/tables/read",
 
 	// Data Factory: child resources are nested under factories/
 	"Microsoft.DataFactory/linkedServices/read":          "Microsoft.DataFactory/factories/linkedservices/read",

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -2544,7 +2544,7 @@ private azure.subscription.storageService.account @defaults("id name location") 
 }
 
 // Azure Storage account queue
-private azure.subscription.storageService.account.queue @defaults("id name approximateMessageCount") {
+private azure.subscription.storageService.account.queue @defaults("id name") {
   // Queue resource ID
   id string
   // Queue name

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -2513,6 +2513,10 @@ private azure.subscription.storageService.account @defaults("id name location") 
   publishMicrosoftEndpoints bool
   // Storage account containers
   containers() []azure.subscription.storageService.account.container
+  // Storage account queues
+  queues() []azure.subscription.storageService.account.queue
+  // Storage account tables
+  tables() []azure.subscription.storageService.account.table
   // Storage account queue properties
   queueProperties() azure.subscription.storageService.account.service.properties
   // Storage account table properties
@@ -2537,6 +2541,28 @@ private azure.subscription.storageService.account @defaults("id name location") 
   objectReplicationPolicies() []azure.subscription.storageService.account.objectReplicationPolicy
   // Blob inventory policy configured on the storage account, if any
   blobInventoryPolicy() azure.subscription.storageService.account.blobInventoryPolicy
+}
+
+// Azure Storage account queue
+private azure.subscription.storageService.account.queue @defaults("id name approximateMessageCount") {
+  // Queue resource ID
+  id string
+  // Queue name
+  name string
+  // Application-defined name/value pairs stored on the queue
+  metadata map[string]string
+  // Approximate number of messages in the queue (fetched on demand via Get)
+  approximateMessageCount() int
+}
+
+// Azure Storage account table
+private azure.subscription.storageService.account.table @defaults("id name") {
+  // Table resource ID
+  id string
+  // Table name
+  name string
+  // Stored access policies (SAS) on the table; each entry has id, permission, startTime, expiryTime
+  signedIdentifiers []dict
 }
 
 // Local user configured on a storage account for SFTP/SSH access

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -92,6 +92,8 @@ const (
 	ResourceAzureSubscriptionNetworkServiceRoute                                                 string = "azure.subscription.networkService.route"
 	ResourceAzureSubscriptionStorageService                                                      string = "azure.subscription.storageService"
 	ResourceAzureSubscriptionStorageServiceAccount                                               string = "azure.subscription.storageService.account"
+	ResourceAzureSubscriptionStorageServiceAccountQueue                                          string = "azure.subscription.storageService.account.queue"
+	ResourceAzureSubscriptionStorageServiceAccountTable                                          string = "azure.subscription.storageService.account.table"
 	ResourceAzureSubscriptionStorageServiceAccountLocalUser                                      string = "azure.subscription.storageService.account.localUser"
 	ResourceAzureSubscriptionStorageServiceAccountDataProtection                                 string = "azure.subscription.storageService.account.dataProtection"
 	ResourceAzureSubscriptionStorageServiceAccountFilePropertiesConfig                           string = "azure.subscription.storageService.account.filePropertiesConfig"
@@ -628,6 +630,14 @@ func init() {
 		"azure.subscription.storageService.account": {
 			Init:   initAzureSubscriptionStorageServiceAccount,
 			Create: createAzureSubscriptionStorageServiceAccount,
+		},
+		"azure.subscription.storageService.account.queue": {
+			// to override args, implement: initAzureSubscriptionStorageServiceAccountQueue(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAzureSubscriptionStorageServiceAccountQueue,
+		},
+		"azure.subscription.storageService.account.table": {
+			// to override args, implement: initAzureSubscriptionStorageServiceAccountTable(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAzureSubscriptionStorageServiceAccountTable,
 		},
 		"azure.subscription.storageService.account.localUser": {
 			// to override args, implement: initAzureSubscriptionStorageServiceAccountLocalUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -4497,6 +4507,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.storageService.account.containers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccount).GetContainers()).ToDataRes(types.Array(types.Resource("azure.subscription.storageService.account.container")))
 	},
+	"azure.subscription.storageService.account.queues": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccount).GetQueues()).ToDataRes(types.Array(types.Resource("azure.subscription.storageService.account.queue")))
+	},
+	"azure.subscription.storageService.account.tables": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccount).GetTables()).ToDataRes(types.Array(types.Resource("azure.subscription.storageService.account.table")))
+	},
 	"azure.subscription.storageService.account.queueProperties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccount).GetQueueProperties()).ToDataRes(types.Resource("azure.subscription.storageService.account.service.properties"))
 	},
@@ -4532,6 +4548,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.storageService.account.blobInventoryPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccount).GetBlobInventoryPolicy()).ToDataRes(types.Resource("azure.subscription.storageService.account.blobInventoryPolicy"))
+	},
+	"azure.subscription.storageService.account.queue.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccountQueue).GetId()).ToDataRes(types.String)
+	},
+	"azure.subscription.storageService.account.queue.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccountQueue).GetName()).ToDataRes(types.String)
+	},
+	"azure.subscription.storageService.account.queue.metadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccountQueue).GetMetadata()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"azure.subscription.storageService.account.queue.approximateMessageCount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccountQueue).GetApproximateMessageCount()).ToDataRes(types.Int)
+	},
+	"azure.subscription.storageService.account.table.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccountTable).GetId()).ToDataRes(types.String)
+	},
+	"azure.subscription.storageService.account.table.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccountTable).GetName()).ToDataRes(types.String)
+	},
+	"azure.subscription.storageService.account.table.signedIdentifiers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccountTable).GetSignedIdentifiers()).ToDataRes(types.Array(types.Dict))
 	},
 	"azure.subscription.storageService.account.localUser.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountLocalUser).GetId()).ToDataRes(types.String)
@@ -15034,6 +15071,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionStorageServiceAccount).Containers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.storageService.account.queues": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccount).Queues, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.storageService.account.tables": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccount).Tables, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.storageService.account.queueProperties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionStorageServiceAccount).QueueProperties, ok = plugin.RawToTValue[*mqlAzureSubscriptionStorageServiceAccountServiceProperties](v.Value, v.Error)
 		return
@@ -15080,6 +15125,42 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.storageService.account.blobInventoryPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionStorageServiceAccount).BlobInventoryPolicy, ok = plugin.RawToTValue[*mqlAzureSubscriptionStorageServiceAccountBlobInventoryPolicy](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.storageService.account.queue.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountQueue).__id, ok = v.Value.(string)
+		return
+	},
+	"azure.subscription.storageService.account.queue.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountQueue).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.storageService.account.queue.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountQueue).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.storageService.account.queue.metadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountQueue).Metadata, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.storageService.account.queue.approximateMessageCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountQueue).ApproximateMessageCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.storageService.account.table.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountTable).__id, ok = v.Value.(string)
+		return
+	},
+	"azure.subscription.storageService.account.table.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountTable).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.storageService.account.table.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountTable).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.storageService.account.table.signedIdentifiers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountTable).SignedIdentifiers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.storageService.account.localUser.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33913,6 +33994,8 @@ type mqlAzureSubscriptionStorageServiceAccount struct {
 	PublishInternetEndpoints                         plugin.TValue[bool]
 	PublishMicrosoftEndpoints                        plugin.TValue[bool]
 	Containers                                       plugin.TValue[[]any]
+	Queues                                           plugin.TValue[[]any]
+	Tables                                           plugin.TValue[[]any]
 	QueueProperties                                  plugin.TValue[*mqlAzureSubscriptionStorageServiceAccountServiceProperties]
 	TableProperties                                  plugin.TValue[*mqlAzureSubscriptionStorageServiceAccountServiceProperties]
 	BlobProperties                                   plugin.TValue[*mqlAzureSubscriptionStorageServiceAccountServiceBlobProperties]
@@ -34186,6 +34269,38 @@ func (c *mqlAzureSubscriptionStorageServiceAccount) GetContainers() *plugin.TVal
 	})
 }
 
+func (c *mqlAzureSubscriptionStorageServiceAccount) GetQueues() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Queues, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.storageService.account", c.__id, "queues")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.queues()
+	})
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccount) GetTables() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Tables, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.storageService.account", c.__id, "tables")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.tables()
+	})
+}
+
 func (c *mqlAzureSubscriptionStorageServiceAccount) GetQueueProperties() *plugin.TValue[*mqlAzureSubscriptionStorageServiceAccountServiceProperties] {
 	return plugin.GetOrCompute[*mqlAzureSubscriptionStorageServiceAccountServiceProperties](&c.QueueProperties, func() (*mqlAzureSubscriptionStorageServiceAccountServiceProperties, error) {
 		if c.MqlRuntime.HasRecording {
@@ -34376,6 +34491,131 @@ func (c *mqlAzureSubscriptionStorageServiceAccount) GetBlobInventoryPolicy() *pl
 
 		return c.blobInventoryPolicy()
 	})
+}
+
+// mqlAzureSubscriptionStorageServiceAccountQueue for the azure.subscription.storageService.account.queue resource
+type mqlAzureSubscriptionStorageServiceAccountQueue struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlAzureSubscriptionStorageServiceAccountQueueInternal
+	Id                      plugin.TValue[string]
+	Name                    plugin.TValue[string]
+	Metadata                plugin.TValue[map[string]any]
+	ApproximateMessageCount plugin.TValue[int64]
+}
+
+// createAzureSubscriptionStorageServiceAccountQueue creates a new instance of this resource
+func createAzureSubscriptionStorageServiceAccountQueue(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAzureSubscriptionStorageServiceAccountQueue{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("azure.subscription.storageService.account.queue", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccountQueue) MqlName() string {
+	return "azure.subscription.storageService.account.queue"
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccountQueue) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccountQueue) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccountQueue) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccountQueue) GetMetadata() *plugin.TValue[map[string]any] {
+	return &c.Metadata
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccountQueue) GetApproximateMessageCount() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.ApproximateMessageCount, func() (int64, error) {
+		return c.approximateMessageCount()
+	})
+}
+
+// mqlAzureSubscriptionStorageServiceAccountTable for the azure.subscription.storageService.account.table resource
+type mqlAzureSubscriptionStorageServiceAccountTable struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAzureSubscriptionStorageServiceAccountTableInternal it will be used here
+	Id                plugin.TValue[string]
+	Name              plugin.TValue[string]
+	SignedIdentifiers plugin.TValue[[]any]
+}
+
+// createAzureSubscriptionStorageServiceAccountTable creates a new instance of this resource
+func createAzureSubscriptionStorageServiceAccountTable(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAzureSubscriptionStorageServiceAccountTable{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("azure.subscription.storageService.account.table", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccountTable) MqlName() string {
+	return "azure.subscription.storageService.account.table"
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccountTable) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccountTable) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccountTable) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccountTable) GetSignedIdentifiers() *plugin.TValue[[]any] {
+	return &c.SignedIdentifiers
 }
 
 // mqlAzureSubscriptionStorageServiceAccountLocalUser for the azure.subscription.storageService.account.localUser resource

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -3075,7 +3075,13 @@ azure.subscription.storageService.account.provisioningState 11.6.2
 azure.subscription.storageService.account.publicNetworkAccess 11.4.28
 azure.subscription.storageService.account.publishInternetEndpoints 13.10.2
 azure.subscription.storageService.account.publishMicrosoftEndpoints 13.10.2
+azure.subscription.storageService.account.queue 13.10.2
+azure.subscription.storageService.account.queue.approximateMessageCount 13.10.2
+azure.subscription.storageService.account.queue.id 13.10.2
+azure.subscription.storageService.account.queue.metadata 13.10.2
+azure.subscription.storageService.account.queue.name 13.10.2
 azure.subscription.storageService.account.queueProperties 9.0.1
+azure.subscription.storageService.account.queues 13.10.2
 azure.subscription.storageService.account.requireInfrastructureEncryption 13.5.1
 azure.subscription.storageService.account.routingChoice 13.10.2
 azure.subscription.storageService.account.sasExpirationAction 13.5.1
@@ -3112,7 +3118,12 @@ azure.subscription.storageService.account.serviceKeyTypes 13.5.1
 azure.subscription.storageService.account.sku 9.0.1
 azure.subscription.storageService.account.statusOfPrimary 11.6.2
 azure.subscription.storageService.account.statusOfSecondary 11.6.2
+azure.subscription.storageService.account.table 13.10.2
+azure.subscription.storageService.account.table.id 13.10.2
+azure.subscription.storageService.account.table.name 13.10.2
+azure.subscription.storageService.account.table.signedIdentifiers 13.10.2
 azure.subscription.storageService.account.tableProperties 9.0.1
+azure.subscription.storageService.account.tables 13.10.2
 azure.subscription.storageService.account.tags 9.0.1
 azure.subscription.storageService.account.type 9.0.1
 azure.subscription.storageService.accounts 9.0.1

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
   "version": "13.10.1",
-  "generated_at": "2026-05-08T15:08:18-07:00",
+  "generated_at": "2026-05-09T16:54:12-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.App/certificates/read",
@@ -168,7 +168,9 @@
     "Microsoft.Storage/storageAccounts/managementPolicies/read",
     "Microsoft.Storage/storageAccounts/objectReplicationPolicies/read",
     "Microsoft.Storage/storageAccounts/privateEndpointConnections/read",
+    "Microsoft.Storage/storageAccounts/queueServices/queues/read",
     "Microsoft.Storage/storageAccounts/read",
+    "Microsoft.Storage/storageAccounts/tableServices/tables/read",
     "Microsoft.Synapse/workspaces/read",
     "Microsoft.Web/certificates/read",
     "Microsoft.Web/hostingEnvironments/read",
@@ -419,7 +421,7 @@
     {
       "permission": "Microsoft.ContainerRegistry/registries/credentialSets/read",
       "service": "Microsoft.ContainerRegistry",
-      "action": "Get",
+      "action": "NewListPager",
       "source_file": "containerregistry.go"
     },
     {
@@ -569,7 +571,7 @@
     {
       "permission": "Microsoft.DocumentDB/sQLResources/read",
       "service": "Microsoft.DocumentDB",
-      "action": "NewListSQLRoleDefinitionsPager",
+      "action": "NewListSQLRoleAssignmentsPager",
       "source_file": "cosmosdb.go"
     },
     {
@@ -665,7 +667,7 @@
     {
       "permission": "Microsoft.Network/applicationGateways/read",
       "service": "Microsoft.Network",
-      "action": "Get",
+      "action": "NewListAllPager",
       "source_file": "network.go"
     },
     {
@@ -677,7 +679,7 @@
     {
       "permission": "Microsoft.Network/azureFirewalls/read",
       "service": "Microsoft.Network",
-      "action": "Get",
+      "action": "NewListAllPager",
       "source_file": "network.go"
     },
     {
@@ -731,7 +733,7 @@
     {
       "permission": "Microsoft.Network/natGateways/read",
       "service": "Microsoft.Network",
-      "action": "Get",
+      "action": "NewListAllPager",
       "source_file": "network.go"
     },
     {
@@ -785,13 +787,13 @@
     {
       "permission": "Microsoft.Network/privateEndpoints/read",
       "service": "Microsoft.Network",
-      "action": "NewListBySubscriptionPager",
+      "action": "Get",
       "source_file": "network.go"
     },
     {
       "permission": "Microsoft.Network/privateLinkServices/read",
       "service": "Microsoft.Network",
-      "action": "NewListBySubscriptionPager",
+      "action": "Get",
       "source_file": "network.go"
     },
     {
@@ -827,7 +829,7 @@
     {
       "permission": "Microsoft.Network/virtualNetworks/read",
       "service": "Microsoft.Network",
-      "action": "NewListAllPager",
+      "action": "Get",
       "source_file": "network.go"
     },
     {
@@ -863,7 +865,7 @@
     {
       "permission": "Microsoft.OperationalInsights/workspaces/read",
       "service": "Microsoft.OperationalInsights",
-      "action": "NewListNSPPager",
+      "action": "Get",
       "source_file": "loganalytics.go"
     },
     {
@@ -899,7 +901,7 @@
     {
       "permission": "Microsoft.RecoveryServices/vaults/read",
       "service": "Microsoft.RecoveryServices",
-      "action": "NewListBySubscriptionIDPager",
+      "action": "Get",
       "source_file": "recoveryservices.go"
     },
     {
@@ -1151,7 +1153,7 @@
     {
       "permission": "Microsoft.Storage/storageAccounts/blobServices/containers/read",
       "service": "Microsoft.Storage",
-      "action": "Get",
+      "action": "NewListPager",
       "source_file": "storage.go"
     },
     {
@@ -1197,10 +1199,22 @@
       "source_file": "storage_extras.go"
     },
     {
+      "permission": "Microsoft.Storage/storageAccounts/queueServices/queues/read",
+      "service": "Microsoft.Storage",
+      "action": "NewListPager",
+      "source_file": "storage_extras.go"
+    },
+    {
       "permission": "Microsoft.Storage/storageAccounts/read",
       "service": "Microsoft.Storage",
       "action": "NewListPager",
       "source_file": "storage.go"
+    },
+    {
+      "permission": "Microsoft.Storage/storageAccounts/tableServices/tables/read",
+      "service": "Microsoft.Storage",
+      "action": "NewListPager",
+      "source_file": "storage_extras.go"
     },
     {
       "permission": "Microsoft.Synapse/workspaces/read",
@@ -1229,7 +1243,7 @@
     {
       "permission": "Microsoft.Web/sites/read",
       "service": "Microsoft.Web",
-      "action": "NewListPager",
+      "action": "NewListFunctionsPager",
       "source_file": "functions.go"
     },
     {

--- a/providers/azure/resources/storage_extras.go
+++ b/providers/azure/resources/storage_extras.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -444,4 +445,184 @@ func isInventoryPolicyNotFoundError(err error) bool {
 		return rerr.StatusCode == 404
 	}
 	return false
+}
+
+func (a *mqlAzureSubscriptionStorageServiceAccountQueue) id() (string, error) {
+	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionStorageServiceAccountTable) id() (string, error) {
+	return a.Id.Data, nil
+}
+
+type mqlAzureSubscriptionStorageServiceAccountQueueInternal struct {
+	cacheAccountId string
+	countFetched   bool
+	count          int64
+	countLock      sync.Mutex
+}
+
+func (a *mqlAzureSubscriptionStorageServiceAccount) queues() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+	parsed, err := ParseResourceID(a.Id.Data)
+	if err != nil {
+		return nil, err
+	}
+	rg, accountName, err := storageAccountResourceGroup(a.Id.Data)
+	if err != nil {
+		return nil, err
+	}
+	client, err := storage.NewQueueClient(parsed.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	res := []any{}
+	pager := client.NewListPager(rg, accountName, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			if isFeatureNotSupportedForAccountError(err) {
+				a.Queues.State = plugin.StateIsNull | plugin.StateIsSet
+				return nil, nil
+			}
+			return nil, err
+		}
+		for _, q := range page.Value {
+			if q == nil {
+				continue
+			}
+			metadata := map[string]any{}
+			if q.QueueProperties != nil {
+				for k, v := range q.QueueProperties.Metadata {
+					if v != nil {
+						metadata[k] = *v
+					}
+				}
+			}
+			mqlQueue, err := CreateResource(a.MqlRuntime, "azure.subscription.storageService.account.queue",
+				map[string]*llx.RawData{
+					"id":       llx.StringDataPtr(q.ID),
+					"name":     llx.StringDataPtr(q.Name),
+					"metadata": llx.MapData(metadata, types.String),
+				})
+			if err != nil {
+				return nil, err
+			}
+			mqlQ := mqlQueue.(*mqlAzureSubscriptionStorageServiceAccountQueue)
+			mqlQ.cacheAccountId = a.Id.Data
+			res = append(res, mqlQ)
+		}
+	}
+	return res, nil
+}
+
+func (a *mqlAzureSubscriptionStorageServiceAccountQueue) approximateMessageCount() (int64, error) {
+	if a.countFetched {
+		return a.count, nil
+	}
+	a.countLock.Lock()
+	defer a.countLock.Unlock()
+	if a.countFetched {
+		return a.count, nil
+	}
+
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+	parsed, err := ParseResourceID(a.cacheAccountId)
+	if err != nil {
+		return 0, err
+	}
+	rg, accountName, err := storageAccountResourceGroup(a.cacheAccountId)
+	if err != nil {
+		return 0, err
+	}
+	client, err := storage.NewQueueClient(parsed.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return 0, err
+	}
+	resp, err := client.Get(ctx, rg, accountName, a.Name.Data, nil)
+	if err != nil {
+		return 0, err
+	}
+	if resp.QueueProperties != nil && resp.QueueProperties.ApproximateMessageCount != nil {
+		a.count = int64(*resp.QueueProperties.ApproximateMessageCount)
+	}
+	a.countFetched = true
+	return a.count, nil
+}
+
+func (a *mqlAzureSubscriptionStorageServiceAccount) tables() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+	parsed, err := ParseResourceID(a.Id.Data)
+	if err != nil {
+		return nil, err
+	}
+	rg, accountName, err := storageAccountResourceGroup(a.Id.Data)
+	if err != nil {
+		return nil, err
+	}
+	client, err := storage.NewTableClient(parsed.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	res := []any{}
+	pager := client.NewListPager(rg, accountName, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			if isFeatureNotSupportedForAccountError(err) {
+				a.Tables.State = plugin.StateIsNull | plugin.StateIsSet
+				return nil, nil
+			}
+			return nil, err
+		}
+		for _, t := range page.Value {
+			if t == nil {
+				continue
+			}
+			signedIdentifiers := []any{}
+			if t.TableProperties != nil {
+				for _, si := range t.TableProperties.SignedIdentifiers {
+					if si == nil {
+						continue
+					}
+					entry := map[string]any{}
+					if si.ID != nil {
+						entry["id"] = *si.ID
+					}
+					if si.AccessPolicy != nil {
+						if si.AccessPolicy.Permission != nil {
+							entry["permission"] = *si.AccessPolicy.Permission
+						}
+						if si.AccessPolicy.StartTime != nil {
+							entry["startTime"] = si.AccessPolicy.StartTime.Format(time.RFC3339)
+						}
+						if si.AccessPolicy.ExpiryTime != nil {
+							entry["expiryTime"] = si.AccessPolicy.ExpiryTime.Format(time.RFC3339)
+						}
+					}
+					signedIdentifiers = append(signedIdentifiers, entry)
+				}
+			}
+			mqlTable, err := CreateResource(a.MqlRuntime, "azure.subscription.storageService.account.table",
+				map[string]*llx.RawData{
+					"id":                llx.StringDataPtr(t.ID),
+					"name":              llx.StringDataPtr(t.Name),
+					"signedIdentifiers": llx.ArrayData(signedIdentifiers, types.Dict),
+				})
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlTable)
+		}
+	}
+	return res, nil
 }


### PR DESCRIPTION
## Summary

- New typed sub-resources `azure.subscription.storageService.account.queue` and `.table`, mirroring the existing `containers` / `fileShares` pattern. Adds `queues()` and `tables()` accessors on the storage account.
- **Queue:** `id`, `name`, `metadata`, lazy `approximateMessageCount()` (the list endpoint omits the count, so it's fetched via Get on demand and cached with double-check locking).
- **Table:** `id`, `name`, `signedIdentifiers []dict` (id, permission, startTime, expiryTime) so SAS access-policy audits work.
- Both gracefully handle `FeatureNotSupportedForAccount` (e.g., BlockBlobStorage, FileStorage accounts) by setting the field null instead of erroring.
- Adds canonical permission mappings for `QueueClient` / `TableClient` so the scanner emits `Microsoft.Storage/storageAccounts/queueServices/queues/read` and `Microsoft.Storage/storageAccounts/tableServices/tables/read` (rather than the short `Microsoft.Storage/queue/read` form).

## Test plan
- [x] Built and installed the provider
- [x] Live-tested against a real StorageV2 account: created a test queue + table via az CLI, confirmed `queues` returned the queue with `approximateMessageCount: 0` and `tables` returned the table; cleaned up
- [x] Verified `FeatureNotSupportedForAccount` path on accounts that don't support queues/tables — returns null
- [x] gofmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)