### PR TITLE
🐛 aws: fix dup rows and broken back-refs in newly added resources

### DIFF
--- a/providers/aws/resources/aws_cloudfront.go
+++ b/providers/aws/resources/aws_cloudfront.go
@@ -189,7 +189,14 @@ func (a *mqlAwsCloudfrontDistribution) logging() (*mqlAwsCloudfrontDistributionL
 }
 
 func (a *mqlAwsCloudfrontFunction) id() (string, error) {
-	return a.Arn.Data, nil
+	// ARN is the same for the DEVELOPMENT and LIVE versions of a function, so
+	// `ListFunctions` returns the same function twice on a published function.
+	// Composite the stage into the cache key so both versions surface as
+	// distinct rows instead of one silently overwriting the other.
+	if a.Stage.Data == "" {
+		return a.Arn.Data, nil
+	}
+	return a.Arn.Data + ":" + a.Stage.Data, nil
 }
 
 func (a *mqlAwsCloudfrontFunction) tags() (map[string]any, error) {

--- a/providers/aws/resources/aws_cognito.go
+++ b/providers/aws/resources/aws_cognito.go
@@ -488,13 +488,27 @@ func (a *mqlAwsCognitoUserPoolClient) id() (string, error) {
 	return a.UserPoolId.Data + "/" + a.ClientId.Data, nil
 }
 
-func (a *mqlAwsCognitoUserPoolClient) userPool() (*mqlAwsCognitoUserPool, error) {
-	mqlPool, err := NewResource(a.MqlRuntime, "aws.cognito.userPool",
-		map[string]*llx.RawData{"id": llx.StringData(a.UserPoolId.Data)})
+// resolveCognitoUserPool returns the lazy user-pool reference for a
+// sub-resource keyed by region+userPoolId. The user pool list creates
+// each pool with `__id = ARN`, so the NewResource call must pass the
+// same ARN — without it the lookup misses the cache and there's no init
+// to backfill the rest of the user-pool fields.
+func resolveCognitoUserPool(runtime *plugin.Runtime, region, userPoolId string) (*mqlAwsCognitoUserPool, error) {
+	conn := runtime.Connection.(*connection.AwsConnection)
+	poolArn := "arn:aws:cognito-idp:" + region + ":" + conn.AccountId() + ":userpool/" + userPoolId
+	mqlPool, err := NewResource(runtime, "aws.cognito.userPool",
+		map[string]*llx.RawData{
+			"__id": llx.StringData(poolArn),
+			"id":   llx.StringData(userPoolId),
+		})
 	if err != nil {
 		return nil, err
 	}
 	return mqlPool.(*mqlAwsCognitoUserPool), nil
+}
+
+func (a *mqlAwsCognitoUserPoolClient) userPool() (*mqlAwsCognitoUserPool, error) {
+	return resolveCognitoUserPool(a.MqlRuntime, a.Region.Data, a.UserPoolId.Data)
 }
 
 // User pool hosted UI domain
@@ -560,12 +574,7 @@ func (a *mqlAwsCognitoUserPoolDomain) id() (string, error) {
 }
 
 func (a *mqlAwsCognitoUserPoolDomain) userPool() (*mqlAwsCognitoUserPool, error) {
-	mqlPool, err := NewResource(a.MqlRuntime, "aws.cognito.userPool",
-		map[string]*llx.RawData{"id": llx.StringData(a.UserPoolId.Data)})
-	if err != nil {
-		return nil, err
-	}
-	return mqlPool.(*mqlAwsCognitoUserPool), nil
+	return resolveCognitoUserPool(a.MqlRuntime, a.Region.Data, a.UserPoolId.Data)
 }
 
 // User pool federated identity providers
@@ -634,10 +643,5 @@ func (a *mqlAwsCognitoUserPoolIdentityProvider) id() (string, error) {
 }
 
 func (a *mqlAwsCognitoUserPoolIdentityProvider) userPool() (*mqlAwsCognitoUserPool, error) {
-	mqlPool, err := NewResource(a.MqlRuntime, "aws.cognito.userPool",
-		map[string]*llx.RawData{"id": llx.StringData(a.UserPoolId.Data)})
-	if err != nil {
-		return nil, err
-	}
-	return mqlPool.(*mqlAwsCognitoUserPool), nil
+	return resolveCognitoUserPool(a.MqlRuntime, a.Region.Data, a.UserPoolId.Data)
 }

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -1706,6 +1706,7 @@ func (a *mqlAwsRdsDbinstance) optionGroups() ([]any, error) {
 	}
 
 	wanted := make(map[string]bool, len(a.cacheOptionGroupNames))
+	instanceRegion := a.Region.Data
 	for _, n := range a.cacheOptionGroupNames {
 		wanted[n] = true
 	}
@@ -1713,6 +1714,12 @@ func (a *mqlAwsRdsDbinstance) optionGroups() ([]any, error) {
 	res := []any{}
 	for _, raw := range rawResources.Data {
 		og := raw.(*mqlAwsRdsOptionGroup)
+		// Filter by region too — option groups with the same name exist in
+		// every region (default:mysql-8-0 etc.), so matching on name alone
+		// produces one entry per region the name appears in.
+		if og.Region.Data != instanceRegion {
+			continue
+		}
 		if wanted[og.OptionGroupName.Data] {
 			res = append(res, og)
 		}


### PR DESCRIPTION
## Summary

Three bug fixes uncovered while exercising the new resources and fields added across the recent run of aws-provider PRs (Cognito sub-resources #7588, RDS option groups + global cluster #7590, CloudFront function tags #7615).

### `aws.rds.dbinstance.optionGroups` — filter by instance region

The new computed accessor resolved option-groups by name only, so an instance attached to `default:mysql-8-0` in us-east-2 also matched the same-named default group in us-east-1 and us-west-2 — producing N duplicate rows for every default option-group attached to an instance.

Reproduce on any account before this fix:

```
mql> aws.rds.instances.where(id == \"acg-basic\") { id region optionGroups { optionGroupName region } }
aws.rds.instances.where: [
  0: {
    id: \"acg-basic\"
    region: \"us-east-2\"
    optionGroups: [
      0: { region: \"us-east-1\", optionGroupName: \"default:mysql-8-0\" }
      1: { region: \"us-east-2\", optionGroupName: \"default:mysql-8-0\" }
      2: { region: \"us-west-2\", optionGroupName: \"default:mysql-8-0\" }
    ]
  }
]
```

After: one row for the option-group in the instance's region.

### `aws.cloudfront.function` — composite \`__id\` with stage

CloudFront function ARNs are stage-less (\`arn:aws:cloudfront::ACCOUNT:function/NAME\` is identical for DEVELOPMENT and LIVE), but \`ListFunctions\` returns a published function twice — once per stage. With ARN as the resource \`__id\`, the second \`CreateResource\` call returned the cached DEVELOPMENT entry, so the list ended up with two pointers to the same DEVELOPMENT row and the LIVE data was silently dropped.

Before:
```
0: { stage: \"DEVELOPMENT\", arn: \"...:function/mqltest-vr\" }
1: { stage: \"DEVELOPMENT\", arn: \"...:function/mqltest-vr\" }   # should be LIVE
```

After: both stages surface as distinct rows with the correct `stage` value.

### `aws.cognito.userPoolClient/userPoolDomain/userPoolIdentityProvider.userPool()` — resolve via ARN

The user pool list creates each pool with \`__id = ARN\`. The new back-references on the three Cognito sub-resources called \`NewResource(\"aws.cognito.userPool\", {id: ...})\` — only the user-pool ID, not the ARN. With no init function defined for \`aws.cognito.userPool\`, the lookup missed the cache and the returned stub had no fields populated, surfacing as \`cannot convert primitive with NO type information\` on every field access.

Pulled the ARN-resolution logic into a small \`resolveCognitoUserPool\` helper so all three callsites stay in sync.

## Test plan

Verified each fix against a freshly-applied test stack (Terraform: CloudFront function, Cognito user pool + client + domain + OIDC IdP, RDS option groups + global cluster, etc.) on a real account in us-west-2 with mql built from this branch:

- [x] \`aws.rds.instances.where(...).optionGroups\` returns a single row per region-scoped option-group (verified on \`acg-basic\` which uses \`default:mysql-8-0\`).
- [x] \`aws.cloudfront.functions\` returns two distinct rows with \`stage: \"DEVELOPMENT\"\` and \`stage: \"LIVE\"\` for a published function.
- [x] \`aws.cognito.userPools[0].clients[0].userPool { id name arn }\` resolves to the populated user pool.
- [x] Same back-ref check on \`.domain.userPool\` and \`.identityProviders[0].userPool\` — both return the populated user pool.
- [x] \`gofmt -w\` on the three changed files.

No \`.lr\` schema changes, no new fields — pure implementation fixes — so \`aws.lr.versions\` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)