### PR TITLE
🎉 aws-13.22.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.21.3",
+	Version:         "13.22.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### aws (13.22.0)
- ✨ aws: backfill aws.drs source/recovery/job fields and add replicationConfigurationTemplate (#7623)
- ✨ aws: backfill aws.es.domain with VPC, encryption, log publishing, security options (#7620)
- ✨ aws: backfill aws.shield with subscription, protection, contact fields (#7617)
- ✨ aws: backfill aws.workdocs with folders, documents, and user fields (#7621)
- ✨ aws: backfill aws.dms with endpoints, replication tasks, subnet groups (#7624)
- ✨ aws: backfill aws.emr with steps, instance groups, security configs, cluster fields (#7622)
- ✨ aws: backfill aws.keyspaces with CDC, warm throughput, replicas, and metadata (#7618)
- ✨ aws: backfill aws.detective member fields and datasource packages (#7619)
- 🐛 aws: fix aws.cloudfront.function.tags ARN format (#7615)
- ✨ aws: add detective resources (#7609)
- 📄 aws/azure/gitlab: backfill resource doc-comments and fix split field titles (#7605)
- ✨ aws: add aws.rds.optionGroup and aws.rds.globalCluster (#7590)
- ✨ aws: add Cognito user pool clients, domains, and identity providers (#7588)
- ✨ aws: surface new SDK fields enabled by 20260507 dep bumps (#7597)
- ✨ aws: add API Gateway v2 (HTTP and WebSocket APIs) (#7592)
- ✨ aws: expand aws.account with region opt-in and org descriptors (#7585)