### PR TITLE
🏃🏻‍♂️speed up goreleaser

### DIFF
--- a/.github/.goreleaser-edge.yml
+++ b/.github/.goreleaser-edge.yml
@@ -8,7 +8,7 @@ env:
   - CGO_ENABLED=0
 before:
   hooks:
-    - make providers
+    - make providers/proto
 builds:
   - id: linux
     main: ./apps/mql/mql.go
@@ -33,14 +33,14 @@ builds:
       - "-extldflags=-static"
       - -s -w -X go.mondoo.com/mql/v13.Version={{.Version}} -X go.mondoo.com/mql/v13.Build={{.ShortCommit}} -X go.mondoo.com/mql/v13.Date={{.Date}}
 checksum:
-  name_template: '{{ .ProjectName }}_v{{ .Version }}_SHA256SUMS'
+  name_template: "{{ .ProjectName }}_v{{ .Version }}_SHA256SUMS"
   algorithm: sha256
 release:
   disable: true
 changelog:
   disable: true
 dockers: # https://goreleaser.com/customization/docker/
-    # UBI containers
+  # UBI containers
   - use: buildx
     goos: linux
     goarch: amd64
@@ -125,7 +125,7 @@ dockers: # https://goreleaser.com/customization/docker/
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--target=root"
   # Rootless
-    # UBI containers
+  # UBI containers
   - use: buildx
     goos: linux
     goarch: amd64
@@ -208,8 +208,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--target=rootless"
-docker_manifests:  # https://goreleaser.com/customization/docker_manifest/
-    # UBI containers
+docker_manifests: # https://goreleaser.com/customization/docker_manifest/
+  # UBI containers
   - name_template: mondoo/{{ .ProjectName }}:edge-{{ .Version }}-ubi
     image_templates:
       - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-ubi-amd64
@@ -232,7 +232,7 @@ docker_manifests:  # https://goreleaser.com/customization/docker_manifest/
       - mondoo/{{ .ProjectName }}:edge-latest-armv6
       - mondoo/{{ .ProjectName }}:edge-latest-armv7
   # Rootless
-    # UBI containers
+  # UBI containers
   - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-rootless
     image_templates:
       - mondoo/{{ .ProjectName }}:edge-{{ .Version }}-ubi-amd64-rootless

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   group: goreleaser-edge
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   REGISTRY: docker.io

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ env:
   - CGO_ENABLED=0
 before:
   hooks:
-    - make providers
+    - make providers/proto
 builds:
   - id: linux
     main: ./apps/mql/mql.go
@@ -66,8 +66,7 @@ builds:
       post:
         - cmd: jsign --storetype TRUSTEDSIGNING --keystore {{ .Env.TSIGN_AZURE_ENDPOINT }} --storepass {{ .Env.TSIGN_ACCESS_TOKEN }} --alias {{ .Env.TSIGN_ACCOUNT_NAME }}/{{ .Env.TSIGN_CERT_PROFILE_NAME }} '{{ .Path }}'
 nfpms:
-  -
-    maintainer: Mondoo <hello@mondoo.com>
+  - maintainer: Mondoo <hello@mondoo.com>
     description: Cloud-Native Asset Inventory Framework
     homepage: https://mondoo.com/
     vendor: Mondoo, Inc
@@ -88,7 +87,7 @@ nfpms:
           - cnquery
     rpm:
       signature:
-        key_file: '{{ .Env.GPG_KEY_PATH }}'
+        key_file: "{{ .Env.GPG_KEY_PATH }}"
 archives:
   - id: releases
     format_overrides:
@@ -97,14 +96,14 @@ archives:
     files:
       - none*
 checksum:
-  name_template: '{{ .ProjectName }}_v{{ .Version }}_SHA256SUMS'
+  name_template: "{{ .ProjectName }}_v{{ .Version }}_SHA256SUMS"
   algorithm: sha256
 snapshot:
   version_template: "{{ .Tag }}-snapshot"
 changelog:
   use: github-native
 dockers: # https://goreleaser.com/customization/docker/
-    # UBI containers
+  # UBI containers
   - use: buildx
     goos: linux
     goarch: amd64
@@ -195,7 +194,7 @@ dockers: # https://goreleaser.com/customization/docker/
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--target=root"
   # Rootless
-    # UBI containers
+  # UBI containers
   - use: buildx
     goos: linux
     goarch: amd64
@@ -285,8 +284,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--target=rootless"
-docker_manifests:  # https://goreleaser.com/customization/docker_manifest/
-    # UBI containers
+docker_manifests: # https://goreleaser.com/customization/docker_manifest/
+  # UBI containers
   - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}-ubi
     image_templates:
       - mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64
@@ -319,7 +318,7 @@ docker_manifests:  # https://goreleaser.com/customization/docker_manifest/
       - mondoo/{{ .ProjectName }}:latest-armv6
       - mondoo/{{ .ProjectName }}:latest-armv7
   # Rootless
-    # UBI containers
+  # UBI containers
   - name_template: mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-rootless
     image_templates:
       - mondoo/{{ .ProjectName }}:{{ .Version }}-ubi-amd64-rootless
@@ -353,4 +352,4 @@ docker_manifests:  # https://goreleaser.com/customization/docker_manifest/
       - mondoo/{{ .ProjectName }}:latest-armv7-rootless
 release:
   replace_existing_artifacts: true
-  make_latest: "{{ if index .Env \"MAKE_LATEST\" }}{{ .Env.MAKE_LATEST }}{{ else }}false{{ end }}"
+  make_latest: '{{ if index .Env "MAKE_LATEST" }}{{ .Env.MAKE_LATEST }}{{ else }}false{{ end }}'


### PR DESCRIPTION
- cancel in-progress builds (we don't need to build edge for every commit)
- do not build all providers for each release, build only the proto

This should save plenty of time from CI