### PR TITLE
🐛 azure: handle cosmos-serverless and aca-no-auth as "no data" not errors

### DIFF
--- a/providers/azure/resources/appcontainers.go
+++ b/providers/azure/resources/appcontainers.go
@@ -6,11 +6,13 @@ package resources
 import (
 	"context"
 	"errors"
+	"net/http"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	apps "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v3"
 	"go.mondoo.com/mql/v13/llx"
@@ -848,6 +850,15 @@ func (a *mqlAzureSubscriptionContainerAppServiceContainerApp) authConfigs() ([]a
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
+			// Container apps without auth configured surface as 404
+			// AuthConfigNotFound from the list endpoint, not as an empty
+			// page. Treat that as "no auth configs" rather than an error.
+			var rerr *azcore.ResponseError
+			if errors.As(err, &rerr) && rerr.StatusCode == http.StatusNotFound {
+				a.authConfigsCache = res
+				a.authConfigsFetched.Store(true)
+				return res, nil
+			}
 			return nil, err
 		}
 		for _, entry := range page.Value {

--- a/providers/azure/resources/appcontainers.go
+++ b/providers/azure/resources/appcontainers.go
@@ -852,9 +852,12 @@ func (a *mqlAzureSubscriptionContainerAppServiceContainerApp) authConfigs() ([]a
 		if err != nil {
 			// Container apps without auth configured surface as 404
 			// AuthConfigNotFound from the list endpoint, not as an empty
-			// page. Treat that as "no auth configs" rather than an error.
+			// page. Match the ErrorCode specifically so a 404 from a
+			// different cause (e.g. the container app was deleted
+			// mid-query, or a future API change) still surfaces as a
+			// real error.
 			var rerr *azcore.ResponseError
-			if errors.As(err, &rerr) && rerr.StatusCode == http.StatusNotFound {
+			if errors.As(err, &rerr) && rerr.StatusCode == http.StatusNotFound && rerr.ErrorCode == "AuthConfigNotFound" {
 				a.authConfigsCache = res
 				a.authConfigsFetched.Store(true)
 				return res, nil

--- a/providers/azure/resources/cosmosdb_extras.go
+++ b/providers/azure/resources/cosmosdb_extras.go
@@ -453,14 +453,23 @@ func isCosmosNotFoundError(err error) bool {
 // throughput row should render as zero/false rather than logging a warning
 // for every database and container on every query.
 //
-// The error code is the generic "BadRequest"; the distinguishing signal is
-// the substring "serverless accounts" in the body message.
+// Cosmos returns the generic ErrorCode "BadRequest" for this case, so the
+// distinguishing signal is the substring "serverless" in the response body
+// message. We inspect rerr.Error() (not the wrapping err.Error()) so the
+// match is scoped to the SDK response message rather than any outer
+// "failed to fetch ..." wrapper that callers may add.
 func isCosmosServerlessThroughputError(err error) bool {
 	var rerr *azcore.ResponseError
-	if errors.As(err, &rerr) && rerr.StatusCode == http.StatusBadRequest {
-		return strings.Contains(err.Error(), "serverless accounts")
+	if !errors.As(err, &rerr) || rerr.StatusCode != http.StatusBadRequest {
+		return false
 	}
-	return false
+	// ErrorCode, when present, is "BadRequest" — match it to confirm this is
+	// a structured ARM error rather than a generic transport 400, but don't
+	// require it (older SDK responses may leave ErrorCode empty).
+	if rerr.ErrorCode != "" && rerr.ErrorCode != "BadRequest" {
+		return false
+	}
+	return strings.Contains(rerr.Error(), "serverless")
 }
 
 // isCosmosForbiddenError mirrors the convention used elsewhere in this

--- a/providers/azure/resources/cosmosdb_extras.go
+++ b/providers/azure/resources/cosmosdb_extras.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -204,6 +205,11 @@ func fetchSqlDatabaseThroughput(ctx context.Context, dbClient *cosmos.SQLResourc
 		if isCosmosNotFoundError(err) {
 			return 0, 0, false, true
 		}
+		if isCosmosServerlessThroughputError(err) {
+			// Serverless accounts have no throughput offer — quietly return
+			// zeros rather than logging on every query.
+			return 0, 0, false, false
+		}
 		// Real failures (rate limits, network timeouts, 5xx) shouldn't read as
 		// "no offer" — log so operators can correlate empty-throughput rows
 		// with API errors. The default zero-value return is preserved so the
@@ -220,6 +226,9 @@ func fetchSqlContainerThroughput(ctx context.Context, dbClient *cosmos.SQLResour
 	if err != nil {
 		if isCosmosNotFoundError(err) {
 			return 0, 0, false, true
+		}
+		if isCosmosServerlessThroughputError(err) {
+			return 0, 0, false, false
 		}
 		log.Warn().Err(err).Str("account", accountName).Str("database", dbName).Str("container", containerName).
 			Msg("failed to fetch Cosmos DB SQL container throughput")
@@ -434,6 +443,22 @@ func isCosmosNotFoundError(err error) bool {
 	var rerr *azcore.ResponseError
 	if errors.As(err, &rerr) {
 		return rerr.StatusCode == http.StatusNotFound
+	}
+	return false
+}
+
+// isCosmosServerlessThroughputError reports whether err is the 400 BadRequest
+// Cosmos returns when you call the throughput endpoint on a serverless
+// account. Serverless accounts have no offer concept at all, so the
+// throughput row should render as zero/false rather than logging a warning
+// for every database and container on every query.
+//
+// The error code is the generic "BadRequest"; the distinguishing signal is
+// the substring "serverless accounts" in the body message.
+func isCosmosServerlessThroughputError(err error) bool {
+	var rerr *azcore.ResponseError
+	if errors.As(err, &rerr) && rerr.StatusCode == http.StatusBadRequest {
+		return strings.Contains(err.Error(), "serverless accounts")
 	}
 	return false
 }

--- a/providers/azure/resources/cosmosdb_extras_test.go
+++ b/providers/azure/resources/cosmosdb_extras_test.go
@@ -4,14 +4,44 @@
 package resources
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	cosmos "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v3"
 	"github.com/stretchr/testify/assert"
 )
+
+// newAzureResponseError builds an *azcore.ResponseError populated as the
+// azcore runtime would after parsing a real ARM JSON error body. The
+// RawResponse is fully populated (request, URL, body) so rerr.Error()
+// renders the same multi-line message that real callers see, including
+// the JSON body — that is what the substring match in
+// isCosmosServerlessThroughputError reads.
+func newAzureResponseError(statusCode int, errorCode, message string) *azcore.ResponseError {
+	body := fmt.Sprintf(`{"code":%q,"message":%q}`, errorCode, message)
+	reqURL, _ := url.Parse("https://example.documents.azure.com/dbs/x/throughputSettings/default")
+	resp := &http.Response{
+		StatusCode: statusCode,
+		Status:     fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+		Request: &http.Request{
+			Method: http.MethodGet,
+			URL:    reqURL,
+		},
+	}
+	return &azcore.ResponseError{
+		ErrorCode:   errorCode,
+		StatusCode:  statusCode,
+		RawResponse: resp,
+	}
+}
 
 func TestCosmosAccountResourceGroup(t *testing.T) {
 	tests := []struct {
@@ -107,6 +137,54 @@ func TestIsCosmosNotFoundError(t *testing.T) {
 	})
 	t.Run("403 not treated as not-found", func(t *testing.T) {
 		assert.False(t, isCosmosNotFoundError(&azcore.ResponseError{StatusCode: http.StatusForbidden}))
+	})
+}
+
+func TestIsCosmosServerlessThroughputError(t *testing.T) {
+	const serverlessMsg = "Reading or replacing offers is not supported for serverless accounts."
+
+	t.Run("nil error", func(t *testing.T) {
+		assert.False(t, isCosmosServerlessThroughputError(nil))
+	})
+	t.Run("non-azcore error", func(t *testing.T) {
+		assert.False(t, isCosmosServerlessThroughputError(errors.New("boom")))
+	})
+	t.Run("404 not treated as serverless", func(t *testing.T) {
+		err := newAzureResponseError(http.StatusNotFound, "NotFound", serverlessMsg)
+		assert.False(t, isCosmosServerlessThroughputError(err))
+	})
+	t.Run("400 with serverless message", func(t *testing.T) {
+		err := newAzureResponseError(http.StatusBadRequest, "BadRequest", serverlessMsg)
+		assert.True(t, isCosmosServerlessThroughputError(err))
+	})
+	t.Run("400 with empty ErrorCode still matches via body", func(t *testing.T) {
+		// Older SDK responses may not surface ErrorCode.
+		err := newAzureResponseError(http.StatusBadRequest, "", serverlessMsg)
+		assert.True(t, isCosmosServerlessThroughputError(err))
+	})
+	t.Run("400 with unrelated BadRequest message is not treated as serverless", func(t *testing.T) {
+		err := newAzureResponseError(http.StatusBadRequest, "BadRequest", "Invalid throughput value")
+		assert.False(t, isCosmosServerlessThroughputError(err))
+	})
+	t.Run("400 with specific ErrorCode unrelated to BadRequest is rejected", func(t *testing.T) {
+		err := newAzureResponseError(http.StatusBadRequest, "InvalidInput", serverlessMsg)
+		assert.False(t, isCosmosServerlessThroughputError(err))
+	})
+	t.Run("error wrapping does not pick up outer wrapper text", func(t *testing.T) {
+		// An outer wrapper that *does not* mention "serverless" must still
+		// match because we look at the unwrapped rerr.Error(), not err.Error().
+		rerr := newAzureResponseError(http.StatusBadRequest, "BadRequest", serverlessMsg)
+		wrapped := fmt.Errorf("failed to fetch Cosmos DB SQL database throughput: %w", rerr)
+		assert.True(t, isCosmosServerlessThroughputError(wrapped))
+	})
+	t.Run("wrapper substring alone is not enough", func(t *testing.T) {
+		// If the inner ResponseError body does not contain "serverless" but
+		// the outer wrapper happens to, we must reject — otherwise the check
+		// silently passes through any 400 simply because a caller mentioned
+		// the word in a wrapping message.
+		rerr := newAzureResponseError(http.StatusBadRequest, "BadRequest", "Invalid throughput value")
+		wrapped := fmt.Errorf("serverless probe failed: %w", rerr)
+		assert.False(t, isCosmosServerlessThroughputError(wrapped))
 	})
 }
 


### PR DESCRIPTION
## Summary

Two bugs uncovered while exercising the new Azure-provider resources from #7595, #7586, and #7616:

### `azure.subscription.cosmosDb.account.sqlDatabase{,.container}` throughput on serverless accounts

Cosmos serverless accounts have no offer concept at all. `GetSQLDatabaseThroughput` / `GetSQLContainerThroughput` return **400 BadRequest** with the message `Reading or replacing offers is not supported for serverless accounts.` (not 404 as the shared-throughput case does).

`fetchSqlDatabaseThroughput` and `fetchSqlContainerThroughput` recognized the 404 case but treated the 400 as a real failure and logged a warning. On every audit query that touched the cosmos namespace, every database and every container on every serverless account produced two warning lines:

```
! failed to fetch Cosmos DB SQL database throughput error="GET .../throughputSettings/default ... 400 Bad Request ... 'Reading or replacing offers is not supported for serverless accounts.'"
! failed to fetch Cosmos DB SQL container throughput error="GET .../throughputSettings/default ... 400 Bad Request ..."
```

Add `isCosmosServerlessThroughputError` that matches the serverless 400 by status + message substring and returns zero/false quietly, matching the documented zero-value semantics of the throughput fields.

### `azure.subscription.containerAppService.containerApp.authConfigs` returns the wrong shape when none configured

A container app with no auth configuration returns **404 `AuthConfigNotFound`** from `ContainerAppsAuthConfigsClient.NewListByContainerAppPager`'s first page, not an empty page. The provider's accessor propagated that 404 as a real error:

```
! failed: GET .../containerApps/<name>/authConfigs
RESPONSE 404: 404 Not Found
ERROR CODE: AuthConfigNotFound
```

Every query that touched `.authConfigs` on an unconfigured app surfaced the raw error string instead of the documented empty list. Special-case the 404 and cache an empty slice so subsequent calls don't refire.

## Test plan

Verified each fix against a real Terraform stack on `westus2` (Cosmos DB SQL serverless account + database + container; Container Apps Env + Container App with no auth config) using `mql` built from this branch:

**Before:**
```
mql> azure.subscription.cosmosDb.accounts.where(name == /mql/) { name sqlDatabases { manualThroughput containers { manualThroughput } } }
! failed to fetch Cosmos DB SQL container throughput ...serverless accounts...
! failed to fetch Cosmos DB SQL database throughput ...serverless accounts...
mql> azure.subscription.containerApp.containerApps.where(name == /mql/) { name authConfigs }
1 error occurred: * GET .../authConfigs RESPONSE 404: AuthConfigNotFound
```

**After:**
```
mql> azure.subscription.cosmosDb.accounts.where(name == /mql/) { name sqlDatabases { manualThroughput containers { manualThroughput } } }
  ✓ no warnings; manualThroughput = 0, autoscaleMaxThroughput = 0 (serverless == no offer)
mql> azure.subscription.containerApp.containerApps.where(name == /mql/) { name authConfigs }
  ✓ authConfigs: []
```

- [x] `gofmt -w` on the two changed files.

No `.lr` schema changes, no new fields — pure error-handling fixes — so `azure.lr.versions` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)