### PR TITLE
🐛 Prevent panics on conversions for bare types & accessing kind on nil platform

### DIFF
--- a/discovery/delayed.go
+++ b/discovery/delayed.go
@@ -21,7 +21,7 @@ func HandleDelayedDiscovery(ctx context.Context, asset *inventory.Asset, runtime
 	}
 	asset = runtime.Provider.Connection.Asset
 	slices.Sort(asset.PlatformIds)
-	asset.KindString = asset.GetPlatform().Kind
+	asset.KindString = asset.GetPlatform().GetKind()
 
 	return asset, nil
 }

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -74,7 +74,7 @@ func prepareAsset(a *inventory.Asset, rootAsset *inventory.Asset, runtimeLabels 
 	a.ManagedBy = rootAsset.ManagedBy
 	a.TraceId = rootAsset.TraceId
 	if platform := a.GetPlatform(); platform != nil {
-		a.KindString = platform.Kind
+		a.KindString = platform.GetKind()
 	}
 	if a.Labels == nil {
 		a.Labels = map[string]string{}

--- a/llx/data_conversions.go
+++ b/llx/data_conversions.go
@@ -278,6 +278,9 @@ func array2result(value any, typ types.Type) (*Primitive, error) {
 	}
 	res := make([]*Primitive, len(arr))
 	ct := typ.Child()
+	if ct.NotSet() {
+		ct = types.Unset
+	}
 	var err error
 	for i := range arr {
 		res[i], err = raw2primitive(arr[i], ct)
@@ -323,6 +326,16 @@ func intmap2result(value any, typ types.Type) (*Primitive, error) {
 }
 
 func map2result(value any, typ types.Type) (*Primitive, error) {
+	if len(typ) < 2 {
+		switch value.(type) {
+		case map[string]any:
+			return stringmap2result(value, types.Map(types.String, types.Unset))
+		case map[int64]any:
+			return intmap2result(value, types.Map(types.Int, types.Unset))
+		default:
+			return nil, errors.New("cannot serialize map with unknown key type: " + typ.Label())
+		}
+	}
 	switch typ.Key() {
 	case types.String:
 		return stringmap2result(value, typ)
@@ -366,6 +379,10 @@ func raw2primitive(value any, typ types.Type) (*Primitive, error) {
 		default:
 			return NilPrimitive, nil
 		}
+	}
+
+	if typ.NotSet() {
+		return nil, errors.New("cannot serialize value of unknown type")
 	}
 
 	utyp := typ.Underlying()

--- a/llx/data_conversions_test.go
+++ b/llx/data_conversions_test.go
@@ -23,6 +23,34 @@ func TestVersion_Conversions(t *testing.T) {
 	})
 }
 
+func TestResultNotPanicsOnBareTypes(t *testing.T) {
+	t.Run("bare ArrayLike with elements", func(t *testing.T) {
+		rd := &llx.RawData{Type: types.ArrayLike, Value: []any{"hello"}}
+		require.NotPanics(t, func() { rd.Result() })
+	})
+
+	t.Run("bare ArrayLike empty", func(t *testing.T) {
+		rd := &llx.RawData{Type: types.ArrayLike, Value: []any{}}
+		require.NotPanics(t, func() { rd.Result() })
+	})
+
+	t.Run("bare MapLike with entries", func(t *testing.T) {
+		rd := &llx.RawData{Type: types.MapLike, Value: map[string]any{"k": "v"}}
+		require.NotPanics(t, func() { rd.Result() })
+	})
+
+	t.Run("Primitive round-trip with bare ArrayLike", func(t *testing.T) {
+		p := &llx.Primitive{
+			Type:  string(types.ArrayLike),
+			Array: []*llx.Primitive{llx.StringPrimitive("hello")},
+		}
+		require.NotPanics(t, func() {
+			raw := p.RawData()
+			raw.Result()
+		})
+	})
+}
+
 func TestResultRawConversions(t *testing.T) {
 	tests := []struct {
 		raw *llx.RawData

--- a/providers-sdk/v1/inventory/inventory.go
+++ b/providers-sdk/v1/inventory/inventory.go
@@ -330,10 +330,16 @@ func (p *Platform) Merge(pf *Platform) {
 }
 
 func (p *Platform) IsFamily(family string) bool {
+	if p == nil {
+		return false
+	}
 	return slices.Contains(p.Family, family)
 }
 
 func (p *Platform) PrettyTitle() string {
+	if p == nil {
+		return ""
+	}
 	prettyTitle := p.Title
 
 	// extend the title only for OS and k8s objects
@@ -365,7 +371,7 @@ func (p *Platform) PrettyTitle() string {
 			runtimeNiceName = "vSphere Virtual Machine"
 		}
 	} else {
-		runtimeKind := p.Kind
+		runtimeKind := p.GetKind()
 		switch runtimeKind {
 		case AssetKindBaremetal:
 			runtimeNiceName = "Bare metal system"

--- a/providers-sdk/v1/recording/recording.go
+++ b/providers-sdk/v1/recording/recording.go
@@ -460,22 +460,22 @@ func createResourceAsset(asset *inventory.Asset, id string) *Resource {
 func CreateAssetResourceArgs(asset *inventory.Asset) map[string]*llx.RawData {
 	// FIXME: remove in v12 (or later) vv
 	// we merge `asset.Labels` and `asset.Platform.Labels` for backwards compatibility
-	assetLabelsMergedV11Compat := mapx.Merge(asset.Platform.Labels, asset.Labels)
+	assetLabelsMergedV11Compat := mapx.Merge(asset.GetPlatform().GetLabels(), asset.Labels)
 	// ^^
 	args := map[string]*llx.RawData{
-		"ids":              llx.ArrayData(llx.TArr2Raw(asset.PlatformIds), types.String),
-		"platform":         llx.StringData(asset.Platform.Name),
+		"ids":              llx.ArrayData(llx.TArr2Raw(asset.GetPlatformIds()), types.String),
+		"platform":         llx.StringData(asset.GetPlatform().GetName()),
 		"name":             llx.StringData(asset.Name),
-		"kind":             llx.StringData(asset.Platform.Kind),
-		"runtime":          llx.StringData(asset.Platform.Runtime),
-		"version":          llx.StringData(asset.Platform.Version),
-		"arch":             llx.StringData(asset.Platform.Arch),
-		"title":            llx.StringData(asset.Platform.PrettyTitle()),
-		"family":           llx.ArrayData(llx.TArr2Raw(asset.Platform.Family), types.String),
-		"build":            llx.StringData(asset.Platform.Build),
+		"kind":             llx.StringData(asset.GetPlatform().GetKind()),
+		"runtime":          llx.StringData(asset.GetPlatform().GetRuntime()),
+		"version":          llx.StringData(asset.GetPlatform().GetVersion()),
+		"arch":             llx.StringData(asset.GetPlatform().GetArch()),
+		"title":            llx.StringData(asset.GetPlatform().PrettyTitle()),
+		"family":           llx.ArrayData(llx.TArr2Raw(asset.GetPlatform().GetFamily()), types.String),
+		"build":            llx.StringData(asset.GetPlatform().GetBuild()),
 		"annotations":      llx.MapData(llx.TMap2Raw(asset.Annotations), types.String),
 		"fqdn":             llx.StringData(asset.Fqdn),
-		"platformMetadata": llx.MapData(llx.TMap2Raw(asset.Platform.Metadata), types.String),
+		"platformMetadata": llx.MapData(llx.TMap2Raw(asset.GetPlatform().GetMetadata()), types.String),
 		// FIXME: remove in v12 (or later) vv
 		"labels": llx.MapData(llx.TMap2Raw(assetLabelsMergedV11Compat), types.String),
 		// ^^


### PR DESCRIPTION
### What's changed

#### 🐛 fix: prevent panics in result conversions for bare types

A Sentry trace showed `index out of range [0] with length 0` in `types.Type.Underlying()` during result serialization. The root cause: error-carrying `RawData` with no type information flows through aggregation functions like `arrayMapV2`, which produces bare `ArrayLike` (1-byte type with no child type encoded). When `RawData.Result()` tries to serialize this, `array2result` calls `typ.Child()` → empty string → `raw2primitive` calls `Underlying()` on it → panic.

Three guards added to `llx/data_conversions.go`:

- **`raw2primitive`**: when type is empty (`NotSet`), return an error instead of indexing into the empty string. `RawData.Result()` already handles conversion errors gracefully.
- **`array2result`**: when `typ.Child()` returns empty (bare `ArrayLike`), fall back to `types.Unset` which has a registered converter. Same pattern used by `arrayFlat`.
- **`map2result`**: when the type is too short to read the key byte (bare `MapLike`), infer the key type from the Go value via type-switch instead of panicking on `typ.Key()`.

Unit tests added for bare `ArrayLike` and `MapLike` in `RawData.Result()`.

#### 🐛 fix: ensure no nil-pointer-dereference by using protobuf getters instead of the field directly

`CreateAssetResourceArgs` and discovery code accessed `asset.Platform` fields directly, which panics when `Platform` is nil. Replaced with nil-safe protobuf getters (`asset.GetPlatform().GetName()`, etc.).

Added nil-receiver guards to `Platform.PrettyTitle()` and `Platform.IsFamily()` — these are hand-written methods (not proto-generated) called via `GetPlatform()` which returns nil when platform is unset.
