### PR TITLE
🎉 azure-13.11.0

### DIFF
--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "azure",
 	ID:      "go.mondoo.com/cnquery/v9/providers/azure",
-	Version: "13.10.1",
+	Version: "13.11.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(azureinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### azure (13.11.0)
- 🐛 azure: handle cosmos-serverless and aca-no-auth as "no data" not errors (#7649)
- ✨ azure: model API Management services (#7635)
- ✨ azure: model Static Web Apps (#7637)
- ✨ azure: model AKS cluster node pools as a typed sub-resource (#7626)
- 🧹 azure: regenerate azure.permissions.json (#7634)
- ✨ azure: model storage account queues and tables (#7631)
- ✨ azure: model SQL Managed Instance and managed databases (#7632)
- ✨ azure: model Event Grid topics, system topics, and domains (#7633)
- 🐛 azure: fix VNG connection runtime fields, Logic App parameters, ACA env defaults (#7616)
- ✨ azure: add Local Network Gateway and enrich VPN Gateway connection (#7607)
- 📄 gcp/azure/k8s/oci/digitalocean/hetzner: backfill resource doc-comments (#7606)
- 📄 aws/azure/gitlab: backfill resource doc-comments and fix split field titles (#7605)
- 🧹 azure, gcp: regenerate permissions.json (#7604)
- ✨ azure: model Function App app settings and connection strings (#7594)
- ✨ azure: model Cosmos DB SQL databases and containers (#7595)
- ✨ azure: deepen storage account coverage (#7591)
- ✨ azure: model Logic Apps Consumption workflows (#7589)
- ✨ azure: deepen Data Factory coverage (#7593)
- ✨ azure: model Container Apps and Container Instances (#7586)