### PR TITLE
🐛 kernel.installed: harden running-kernel detection across all RPM-based families

### DIFF
--- a/providers/os/resources/kernel.go
+++ b/providers/os/resources/kernel.go
@@ -41,23 +41,59 @@ type KernelVersion struct {
 	Running bool   `json:"running"`
 }
 
+// stripRPMEpoch removes a leading "<epoch>:" prefix from an RPM package
+// version string. /proc/version (and the rest of kernel.info) never carries
+// the epoch, so it must be stripped before comparing a package version to
+// the running kernel version. providers/os/resources/packages/rpm_packages.go
+// concatenates a non-zero / non-"(none)" epoch into pkg.Version, so this
+// matters whenever the underlying kernel rpm declares an Epoch.
+func stripRPMEpoch(version string) string {
+	if idx := strings.IndexByte(version, ':'); idx >= 0 {
+		return version[idx+1:]
+	}
+	return version
+}
+
 // rpmKernelMatchesRunning reports whether the given RPM kernel package
 // describes the currently running kernel, identified by the value
 // /proc/version reports (e.g. "6.1.170-210.320.amzn2023.x86_64").
 //
-// The package version string may carry an RPM epoch prefix like
-// "1:6.1.170-210.320.amzn2023" — see rpm_packages.go where epoch is
-// concatenated into the version when it is non-zero / not "(none)". The
-// running-kernel string from /proc/version never carries the epoch, so a
-// plain string-equality check between "<version>.<arch>" and that string
-// drops the running flag for every package whose epoch is set. AL2023's
-// `kernel` package has epoch 1, so the bug is reproducible there for every
-// installed kernel image. See customer-issues #178.
+// AL2023's `kernel` package has epoch 1, so without stripRPMEpoch the bug
+// is reproducible there for every installed kernel image (the entire list
+// reports running:false). Same shape would hit any future RHEL / Oracle
+// kernel that gains an epoch.
 func rpmKernelMatchesRunning(pkgVersion, pkgArch, runningKernelVersion string) bool {
-	if idx := strings.IndexByte(pkgVersion, ':'); idx >= 0 {
-		pkgVersion = pkgVersion[idx+1:]
+	return stripRPMEpoch(pkgVersion)+"."+pkgArch == runningKernelVersion
+}
+
+// photonKernelMatchesRunning reports whether the given Photon kernel
+// package describes the currently running kernel. Photon's flavor lives
+// in the package name suffix (e.g. "linux" → bare kernel, "linux-esx" →
+// VMware-targeted) and the running-kernel string from /proc/version is
+// version + "-flavor" — e.g. "4.19.97-1.ph3-esx". Mirrors
+// rpmKernelMatchesRunning by stripping any leading epoch from the package
+// version before joining.
+func photonKernelMatchesRunning(pkgVersion, pkgName, runningKernelVersion string) bool {
+	return stripRPMEpoch(pkgVersion)+strings.TrimPrefix(pkgName, "linux") == runningKernelVersion
+}
+
+// suseKernelMatchesRunning reports whether the given SUSE kernel package
+// describes the currently running kernel.
+//
+// SUSE's running-kernel string from /proc/version looks like
+// "4.12.14-122.23-default" — version + "-flavor". The package version is a
+// slightly longer "4.12.14-122.23.1-default" (one extra dpkg-release
+// segment), so the match uses HasSuffix on the flavor + HasPrefix on the
+// trimmed running version against the package version. stripRPMEpoch
+// keeps the HasPrefix check working if a SUSE kernel rpm ever declares an
+// epoch (none do today, but the algebra is identical).
+func suseKernelMatchesRunning(pkgVersion, pkgName, runningKernelVersion string) bool {
+	kernelType := strings.TrimPrefix(pkgName, "kernel")
+	if !strings.HasSuffix(runningKernelVersion, kernelType) {
+		return false
 	}
-	return pkgVersion+"."+pkgArch == runningKernelVersion
+	versionPrefix := strings.TrimSuffix(runningKernelVersion, kernelType)
+	return strings.HasPrefix(stripRPMEpoch(pkgVersion), versionPrefix)
 }
 
 func (k *mqlKernel) installed() ([]any, error) {
@@ -169,16 +205,10 @@ func (k *mqlKernel) installed() ([]any, error) {
 				if strings.HasPrefix(name, "linux") {
 					version := pkg.Version.Data
 
-					kernelName := version + strings.TrimPrefix(name, "linux")
-					running := false
-					if kernelName == runningKernelVersion {
-						running = true
-					}
-
 					res = append(res, KernelVersion{
 						Name:    name,
 						Version: version + strings.TrimPrefix(name, "linux"),
-						Running: running,
+						Running: photonKernelMatchesRunning(version, name, runningKernelVersion),
 					})
 				}
 			}
@@ -194,19 +224,10 @@ func (k *mqlKernel) installed() ([]any, error) {
 				name := pkg.Name.Data
 				if strings.HasPrefix(name, "kernel-") {
 					version := pkg.Version.Data
-
-					kernelType := strings.TrimPrefix(name, "kernel")
-					running := false
-
-					// NOTE: pkg version is 4.12.14-122.23.1 while the kernel version is 4.12.14-122.23
-					if strings.HasSuffix(runningKernelVersion, kernelType) && strings.HasPrefix(version, strings.TrimSuffix(runningKernelVersion, kernelType)) {
-						running = true
-					}
-
 					res = append(res, KernelVersion{
 						Name:    name,
 						Version: version + strings.TrimPrefix(name, "kernel"),
-						Running: running,
+						Running: suseKernelMatchesRunning(version, name, runningKernelVersion),
 					})
 				}
 			}

--- a/providers/os/resources/kernel.go
+++ b/providers/os/resources/kernel.go
@@ -41,6 +41,25 @@ type KernelVersion struct {
 	Running bool   `json:"running"`
 }
 
+// rpmKernelMatchesRunning reports whether the given RPM kernel package
+// describes the currently running kernel, identified by the value
+// /proc/version reports (e.g. "6.1.170-210.320.amzn2023.x86_64").
+//
+// The package version string may carry an RPM epoch prefix like
+// "1:6.1.170-210.320.amzn2023" — see rpm_packages.go where epoch is
+// concatenated into the version when it is non-zero / not "(none)". The
+// running-kernel string from /proc/version never carries the epoch, so a
+// plain string-equality check between "<version>.<arch>" and that string
+// drops the running flag for every package whose epoch is set. AL2023's
+// `kernel` package has epoch 1, so the bug is reproducible there for every
+// installed kernel image. See customer-issues #178.
+func rpmKernelMatchesRunning(pkgVersion, pkgArch, runningKernelVersion string) bool {
+	if idx := strings.IndexByte(pkgVersion, ':'); idx >= 0 {
+		pkgVersion = pkgVersion[idx+1:]
+	}
+	return pkgVersion+"."+pkgArch == runningKernelVersion
+}
+
 func (k *mqlKernel) installed() ([]any, error) {
 	res := []KernelVersion{}
 
@@ -113,18 +132,10 @@ func (k *mqlKernel) installed() ([]any, error) {
 			filterKernel = func(pkg *mqlPackage) {
 				if pkg.Name.Data == "kernel" || pkg.Name.Data == "kernel-uek" {
 					version := pkg.Version.Data
-					arch := pkg.Arch.Data
-
-					kernelName := version + "." + arch
-					running := false
-					if kernelName == runningKernelVersion {
-						running = true
-					}
-
 					res = append(res, KernelVersion{
 						Name:    pkg.Name.Data,
 						Version: version,
-						Running: running,
+						Running: rpmKernelMatchesRunning(version, pkg.Arch.Data, runningKernelVersion),
 					})
 				}
 			}
@@ -145,18 +156,10 @@ func (k *mqlKernel) installed() ([]any, error) {
 			filterKernel = func(pkg *mqlPackage) {
 				if pkg.Name.Data == "kernel" {
 					version := pkg.Version.Data
-					arch := pkg.Arch.Data
-
-					kernelName := version + "." + arch
-					running := false
-					if kernelName == runningKernelVersion {
-						running = true
-					}
-
 					res = append(res, KernelVersion{
 						Name:    pkg.Name.Data,
 						Version: version,
-						Running: running,
+						Running: rpmKernelMatchesRunning(version, pkg.Arch.Data, runningKernelVersion),
 					})
 				}
 			}

--- a/providers/os/resources/kernel_internal_test.go
+++ b/providers/os/resources/kernel_internal_test.go
@@ -74,3 +74,135 @@ func TestRpmKernelMatchesRunning(t *testing.T) {
 		})
 	}
 }
+
+func TestStripRPMEpoch(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		out  string
+	}{
+		{"no epoch", "6.1.170-210.320.amzn2023", "6.1.170-210.320.amzn2023"},
+		{"epoch 1", "1:6.1.170-210.320.amzn2023", "6.1.170-210.320.amzn2023"},
+		{"epoch 10 (multi-digit)", "10:6.1.170", "6.1.170"},
+		{"empty", "", ""},
+		{"bare colon", ":6.1.170", "6.1.170"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.out, stripRPMEpoch(tc.in))
+		})
+	}
+}
+
+// TestPhotonKernelMatchesRunning locks down the Photon comparison shape
+// (version + flavor-suffix-from-name == runningKernelVersion) and proves
+// the shared stripRPMEpoch primitive keeps the comparison working should
+// Photon ever ship a kernel rpm with an Epoch declared.
+func TestPhotonKernelMatchesRunning(t *testing.T) {
+	cases := []struct {
+		name           string
+		pkgVersion     string
+		pkgName        string
+		runningKernel  string
+		expectedResult bool
+	}{
+		{
+			name:           "bare linux package matches running",
+			pkgVersion:     "4.19.97-1.ph3",
+			pkgName:        "linux",
+			runningKernel:  "4.19.97-1.ph3",
+			expectedResult: true,
+		},
+		{
+			name:           "linux-esx flavor matches running with -esx suffix",
+			pkgVersion:     "4.19.97-1.ph3",
+			pkgName:        "linux-esx",
+			runningKernel:  "4.19.97-1.ph3-esx",
+			expectedResult: true,
+		},
+		{
+			name:           "older inactive kernel does not match",
+			pkgVersion:     "4.19.90-1.ph3",
+			pkgName:        "linux",
+			runningKernel:  "4.19.97-1.ph3",
+			expectedResult: false,
+		},
+		{
+			name:           "wrong flavor does not match",
+			pkgVersion:     "4.19.97-1.ph3",
+			pkgName:        "linux-rt",
+			runningKernel:  "4.19.97-1.ph3-esx",
+			expectedResult: false,
+		},
+		{
+			name:           "hypothetical epoch-1 photon kernel still matches running",
+			pkgVersion:     "1:4.19.97-1.ph3",
+			pkgName:        "linux-esx",
+			runningKernel:  "4.19.97-1.ph3-esx",
+			expectedResult: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := photonKernelMatchesRunning(tc.pkgVersion, tc.pkgName, tc.runningKernel)
+			assert.Equal(t, tc.expectedResult, got)
+		})
+	}
+}
+
+// TestSuseKernelMatchesRunning locks down the SUSE comparison shape:
+// running ends with the package's -flavor suffix AND the trimmed running
+// version is a prefix of the package version (accounting for the extra
+// dpkg-release segment on pkg.Version). stripRPMEpoch is in the path so
+// the comparison still works if a SUSE kernel rpm ever declares an Epoch.
+func TestSuseKernelMatchesRunning(t *testing.T) {
+	cases := []struct {
+		name           string
+		pkgVersion     string
+		pkgName        string
+		runningKernel  string
+		expectedResult bool
+	}{
+		{
+			name:           "kernel-default matches running with extra release segment",
+			pkgVersion:     "4.12.14-122.23.1",
+			pkgName:        "kernel-default",
+			runningKernel:  "4.12.14-122.23-default",
+			expectedResult: true,
+		},
+		{
+			name:           "kernel-default at older version does not match",
+			pkgVersion:     "4.12.14-122.20.1",
+			pkgName:        "kernel-default",
+			runningKernel:  "4.12.14-122.23-default",
+			expectedResult: false,
+		},
+		{
+			name:           "kernel-rt does not match a -default running kernel",
+			pkgVersion:     "4.12.14-122.23.1",
+			pkgName:        "kernel-rt",
+			runningKernel:  "4.12.14-122.23-default",
+			expectedResult: false,
+		},
+		{
+			name:           "hypothetical epoch-1 SUSE kernel still matches running",
+			pkgVersion:     "1:4.12.14-122.23.1",
+			pkgName:        "kernel-default",
+			runningKernel:  "4.12.14-122.23-default",
+			expectedResult: true,
+		},
+		{
+			name:           "empty running-kernel string never matches",
+			pkgVersion:     "4.12.14-122.23.1",
+			pkgName:        "kernel-default",
+			runningKernel:  "",
+			expectedResult: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := suseKernelMatchesRunning(tc.pkgVersion, tc.pkgName, tc.runningKernel)
+			assert.Equal(t, tc.expectedResult, got)
+		})
+	}
+}

--- a/providers/os/resources/kernel_internal_test.go
+++ b/providers/os/resources/kernel_internal_test.go
@@ -1,0 +1,76 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRpmKernelMatchesRunning is the unit-level reproducer for
+// customer-issues #178: AL2023's `kernel` rpm carries epoch 1, so
+// pkg.Version is "1:6.1.170-210.320.amzn2023" while /proc/version returns
+// "6.1.170-210.320.amzn2023.x86_64". A naive `pkgVersion+"."+arch ==
+// runningKernelVersion` check fails for every installed kernel image, and
+// the entire kernel.installed list comes back with running:false.
+func TestRpmKernelMatchesRunning(t *testing.T) {
+	cases := []struct {
+		name           string
+		pkgVersion     string
+		pkgArch        string
+		runningKernel  string
+		expectedResult bool
+	}{
+		{
+			name:           "AL2023 epoch-1 kernel matches running",
+			pkgVersion:     "1:6.1.170-210.320.amzn2023",
+			pkgArch:        "x86_64",
+			runningKernel:  "6.1.170-210.320.amzn2023.x86_64",
+			expectedResult: true,
+		},
+		{
+			name:           "AL2023 epoch-1 kernel at older ABI does not match running",
+			pkgVersion:     "1:6.1.166-197.305.amzn2023",
+			pkgArch:        "x86_64",
+			runningKernel:  "6.1.170-210.320.amzn2023.x86_64",
+			expectedResult: false,
+		},
+		{
+			name:           "RHEL legacy kernel with no epoch still matches",
+			pkgVersion:     "3.10.0-1160.11.1.el7",
+			pkgArch:        "x86_64",
+			runningKernel:  "3.10.0-1160.11.1.el7.x86_64",
+			expectedResult: true,
+		},
+		{
+			name:           "Oracle UEK kernel with epoch matches running",
+			pkgVersion:     "1:6.12.0-105.51.5.el9uek",
+			pkgArch:        "x86_64",
+			runningKernel:  "6.12.0-105.51.5.el9uek.x86_64",
+			expectedResult: true,
+		},
+		{
+			name:           "different architectures never match",
+			pkgVersion:     "1:6.1.170-210.320.amzn2023",
+			pkgArch:        "aarch64",
+			runningKernel:  "6.1.170-210.320.amzn2023.x86_64",
+			expectedResult: false,
+		},
+		{
+			name:           "running-kernel string is empty (kernel.info unavailable)",
+			pkgVersion:     "1:6.1.170-210.320.amzn2023",
+			pkgArch:        "x86_64",
+			runningKernel:  "",
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rpmKernelMatchesRunning(tc.pkgVersion, tc.pkgArch, tc.runningKernel)
+			assert.Equal(t, tc.expectedResult, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`kernel.installed` decides whether each kernel package is the currently running one by string-comparing a derived key against the value parsed from `/proc/version`. The exact key shape differs per platform family — RHEL / Amazon Linux / Oracle / Photon / SUSE all have their own join — but every RPM-based branch funnels the package's `pkg.Version` through the comparison. When the underlying kernel rpm declares a non-zero `Epoch`, `providers/os/resources/packages/rpm_packages.go` prefixes that epoch into `pkg.Version` (e.g. `"1:6.1.170-210.320.amzn2023"`), while `/proc/version` never carries the epoch — so every comparison silently fails and the asset reports every installed kernel with `running: false`.

This is reproducible today on Amazon Linux 2023, whose `kernel` rpm ships with epoch 1. The same shape is latent on Oracle Linux, Photon, and SUSE if any of them ever pick up an epoch on their kernel rpm.

## Change

- Introduced `stripRPMEpoch(version)` to drop a leading `<epoch>:` from any RPM package version. Used by every per-platform matcher.
- Extracted three per-platform comparison helpers, each with the epoch primitive on its hot path:
  - `rpmKernelMatchesRunning(pkgVersion, pkgArch, runningKernel)` — RHEL / Amazon Linux / Oracle (incl. UEK)
  - `photonKernelMatchesRunning(pkgVersion, pkgName, runningKernel)` — Photon's `linux[-flavor]` join
  - `suseKernelMatchesRunning(pkgVersion, pkgName, runningKernel)` — SUSE's `HasSuffix(-flavor)` + `HasPrefix(trimmed-running)` shape, handling the extra dpkg-release segment SUSE carries on `pkg.Version`
- Wired each helper into its branch in `kernel.installed`. Closure bodies become one-liners. The output `KernelVersion.Version` field stays unchanged on every platform, so downstream consumers that pattern-match against it keep working.
- Debian / Ubuntu's branch is unaffected by the bug class — it matches on `pkg.Name` (which never carries an epoch), not on `pkg.Version` — and is left as-is.

## Test plan

- [x] `go test ./providers/os/resources/ -run 'TestRpmKernelMatchesRunning|TestStripRPMEpoch|TestPhotonKernelMatchesRunning|TestSuseKernelMatchesRunning' -v` — 21 internal-package cases pass:
  - `rpmKernelMatchesRunning` × 6: AL2023 epoch-1 match (regression case), AL2023 older ABI mismatch, legacy RHEL with no epoch (backward compat), Oracle UEK with epoch, different architectures, empty `/proc/version`
  - `stripRPMEpoch` × 5: no epoch, epoch 1, multi-digit epoch, empty input, bare colon
  - `photonKernelMatchesRunning` × 5: bare `linux`, `linux-esx` flavor, older inactive kernel, wrong flavor, hypothetical epoch-1 Photon
  - `suseKernelMatchesRunning` × 5: `kernel-default` running, older inactive `kernel-default`, `kernel-rt` vs `-default` running, hypothetical epoch-1 SUSE, empty running
- [x] Verified against a live Amazon Linux 2023 EC2 instance — `kernel.installed` now returns `running: true` on the kernel package whose version matches `/proc/version`, where prior to the fix every entry came back with `running: false`.