### PR TITLE
🐛 cloudflare: read --token from Credentials to match digitalocean

### DIFF
--- a/providers/cloudflare/connection/connection.go
+++ b/providers/cloudflare/connection/connection.go
@@ -9,10 +9,7 @@ import (
 	"github.com/cloudflare/cloudflare-go"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-)
-
-const (
-	OPTION_API_TOKEN = "api-token"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
 )
 
 type CloudflareConnection struct {
@@ -30,13 +27,16 @@ func NewCloudflareConnection(id uint32, asset *inventory.Asset, conf *inventory.
 		asset:      asset,
 	}
 
-	// initialize your connection here
-	token := conf.Options[OPTION_API_TOKEN]
-	if token == "" {
-		token = os.Getenv("CLOUDFLARE_TOKEN")
-		if token == "" {
-			return nil, errors.New("a valid Cloudflare authentication is required, pass --token '<yourtoken>', set CLOUDFLARE_TOKEN environment variable")
+	token := os.Getenv("CLOUDFLARE_TOKEN")
+	if len(conf.Credentials) > 0 {
+		for _, cred := range conf.Credentials {
+			if cred.Type == vault.CredentialType_password {
+				token = string(cred.Secret)
+			}
 		}
+	}
+	if token == "" {
+		return nil, errors.New("a valid Cloudflare token is required (set CLOUDFLARE_TOKEN or use --token)")
 	}
 
 	api, err := cloudflare.NewWithAPIToken(token)

--- a/providers/cloudflare/provider/provider.go
+++ b/providers/cloudflare/provider/provider.go
@@ -5,11 +5,13 @@ package provider
 import (
 	"context"
 	"errors"
+	"os"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
 	"go.mondoo.com/mql/v13/providers/cloudflare/connection"
 	"go.mondoo.com/mql/v13/providers/cloudflare/resources"
 )
@@ -52,9 +54,15 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	}
 	conf.Discover = &inventory.Discovery{Targets: discoverTargets}
 
-	// token
-	if x, ok := flags["token"]; ok {
-		conf.Options[connection.OPTION_API_TOKEN] = string(x.GetValue())
+	token := ""
+	if x, ok := flags["token"]; ok && len(x.Value) != 0 {
+		token = string(x.Value)
+	}
+	if token == "" {
+		token = os.Getenv("CLOUDFLARE_TOKEN")
+	}
+	if token != "" {
+		conf.Credentials = append(conf.Credentials, vault.NewPasswordCredential("", token))
 	}
 
 	asset := inventory.Asset{


### PR DESCRIPTION
## Summary
- The cloudflare provider's `ParseCLI` was stashing `--token` in `conf.Options["api-token"]`, and `connection.go` only read from that same key.
- Hosted scan jobs from the Mondoo server send the token via `conf.Credentials` (vault-loaded password credential) — same shape used by digitalocean, hetzner, shodan. The cloudflare provider never saw it and scans failed with `a valid Cloudflare authentication is required`.
- This change mirrors `providers/digitalocean`: `ParseCLI` now appends the token to `conf.Credentials` via `vault.NewPasswordCredential` (with `CLOUDFLARE_TOKEN` env fallback), and `NewCloudflareConnection` reads the token by scanning `conf.Credentials` for a `CredentialType_password` entry.
- Drops `OPTION_API_TOKEN` constant (no external users in the repo).

## Test plan
- [x] `go build ./...` in `providers/cloudflare` is clean
- [x] `go test -vet=off ./...` in `providers/cloudflare` passes
- [ ] CLI scan: `cnspec scan cloudflare --token <token>` still works
- [ ] CLI scan: `CLOUDFLARE_TOKEN=<token> cnspec scan cloudflare` still works
- [ ] Hosted scan job triggered from the Mondoo server completes (Type_CLOUDFLARE → `cloudflareIntegrationToJob` → provider picks up the secret from `Credentials[0]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)