### PR TITLE
🎉 cloudflare-13.3.4

### DIFF
--- a/providers/cloudflare/config/config.go
+++ b/providers/cloudflare/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "cloudflare",
 	ID:              "go.mondoo.com/mql/v13/providers/cloudflare",
-	Version:         "13.3.3",
+	Version:         "13.3.4",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### cloudflare (13.3.4)
- 🐛 cloudflare: read --token from Credentials to match digitalocean (#7657)
- 🧹 Update deps for mql and providers 20260511 (#7650)