### PR TITLE
🐛 digitalocean: set Runtime on platform info

### DIFF
--- a/providers/digitalocean/provider/provider.go
+++ b/providers/digitalocean/provider/provider.go
@@ -128,10 +128,11 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.DigitaloceanCo
 	asset.Name = "DigitalOcean Account"
 
 	asset.Platform = &inventory.Platform{
-		Name:   "digitalocean",
-		Family: []string{"digitalocean"},
-		Kind:   "api",
-		Title:  "DigitalOcean",
+		Name:    "digitalocean",
+		Family:  []string{"digitalocean"},
+		Kind:    "api",
+		Runtime: "digitalocean",
+		Title:   "DigitalOcean",
 	}
 
 	platformId := "//platformid.api.mondoo.app/runtime/digitalocean"


### PR DESCRIPTION
## Summary
- The DigitalOcean provider was missing `Runtime: "digitalocean"` on its `inventory.Platform`. Every other cloud provider (AWS, Azure, GCP, OCI, Proxmox, Hetzner, Tailscale, vSphere) sets `Runtime` to its short name.
- Downstream consumers (e.g. the mondoohq/server asset atlas in `policy/registry_misc.go`) match assets on `Runtime`. Without this field, real DigitalOcean assets reported by cnspec were classified as "Unrecognized Assets" in the Mondoo UI.
- One-line fix to bring DO into line with the rest of the providers.

## Test plan
- [ ] `go build ./providers/digitalocean/...` succeeds
- [ ] `go vet ./providers/digitalocean/...` succeeds
- [ ] Scan a DigitalOcean account with a build that includes this change and confirm the asset reports with `runtime=digitalocean`
- [ ] Confirm the asset shows under the DigitalOcean group in the Mondoo UI (not "Unrecognized Assets")

🤖 Generated with [Claude Code](https://claude.com/claude-code)