### PR TITLE
🧹 provider-scaffold: set Runtime on Platform info template

### DIFF
--- a/apps/provider-scaffold/README.md
+++ b/apps/provider-scaffold/README.md
@@ -46,3 +46,4 @@ The scaffold will:
 - **Provider ID**: `go.mondoo.com/mql/providers/{provider-id}` (no version number)
 - **Go package**: `go.mondoo.com/mql/v13/providers/{provider-id}` (derived automatically)
 - **Go identifier**: Hyphen-separated IDs become CamelCase (e.g. `google-workspace` -> `GoogleWorkspaceConnection`)
+- **Platform `Runtime`**: When you customize `asset.Platform` in `provider/provider.go`, keep `Runtime` set to the provider ID (the scaffold does this for you). Downstream consumers — most notably the mondoohq/server asset atlas — classify assets by matching on `Runtime`. Omitting it causes real assets to fall through to "Unrecognized Assets" in the Mondoo UI. Every other cloud provider (AWS, Azure, GCP, OCI, Proxmox, Hetzner, Tailscale, vSphere) follows this convention.

--- a/apps/provider-scaffold/template/provider/provider.go.template
+++ b/apps/provider-scaffold/template/provider/provider.go.template
@@ -125,10 +125,11 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.{{ .CamelcaseP
 	asset.Name = conn.Conf.Host
 
 	asset.Platform = &inventory.Platform{
-		Name:   "{{ .ProviderID }}",
-		Family: []string{"{{ .ProviderID }}"},
-		Kind:   "api",
-		Title:  "{{ .ProviderName }}",
+		Name:    "{{ .ProviderID }}",
+		Family:  []string{"{{ .ProviderID }}"},
+		Kind:    "api",
+		Runtime: "{{ .ProviderID }}",
+		Title:   "{{ .ProviderName }}",
 	}
 
 	// TODO: Add platform IDs


### PR DESCRIPTION
## Summary
- Every cloud provider in this repo (AWS, Azure, GCP, OCI, Proxmox, Hetzner, Tailscale, vSphere) sets `Runtime` on its `inventory.Platform` to the provider ID. Downstream consumers — most notably the mondoohq/server asset atlas (`policy/registry_*.go`) — classify assets by matching on `Runtime`.
- The scaffold template at `apps/provider-scaffold/template/provider/provider.go.template` was omitting this field, so new providers generated from it (e.g. DigitalOcean) reported assets that fell through to "Unrecognized Assets" in the Mondoo UI. See #7659 for the DigitalOcean spot-fix.
- This PR fixes the template so future scaffolded providers get `Runtime` by default, and adds a note to the scaffold README so anyone customizing the platform block by hand knows to preserve it.

## Test plan
- [ ] `go test ./apps/provider-scaffold/...` succeeds
- [ ] Scaffold a throwaway provider via `go run apps/provider-scaffold/provider-scaffold.go --provider-id testprov --provider-name "TestProv"` and confirm the generated `provider/provider.go` includes `Runtime: "testprov"` in the `inventory.Platform` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)