### PR TITLE
🎉 digitalocean-13.1.5

### DIFF
--- a/providers/digitalocean/config/config.go
+++ b/providers/digitalocean/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "digitalocean",
 	ID:              "go.mondoo.com/mql/providers/digitalocean",
-	Version:         "13.1.4",
+	Version:         "13.1.5",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### digitalocean (13.1.5)
- 🐛 digitalocean: set Runtime on platform info (#7659)
- 🧹 Update deps for mql and providers 20260511 (#7650)
- 📄 gcp/azure/k8s/oci/digitalocean/hetzner: backfill resource doc-comments (#7606)