### PR TITLE
🎉 openstack-13.1.0

### DIFF
--- a/providers/openstack/config/config.go
+++ b/providers/openstack/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "openstack",
 	ID:              "go.mondoo.com/mql/providers/openstack",
-	Version:         "13.0.0",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### openstack (13.1.0)
- 🧹 Update deps for mql and providers 20260511 (#7650)
- ✨ openstack: broad provider expansion — Swift, Designate, Keystone groups+app creds, Nova depth, Cinder backups+types, Glance members, Barbican ACLs, quotas (#7638)