### PR TITLE
🐛 aws: fix lightsail instance ports/firewallRules []string conversion

### DIFF
--- a/providers/aws/resources/aws_lightsail.go
+++ b/providers/aws/resources/aws_lightsail.go
@@ -178,8 +178,8 @@ func (a *mqlAwsLightsailInstance) firewallRules() ([]any, error) {
 			"toPort":     int64(p.ToPort),
 			"protocol":   string(p.Protocol),
 			"accessType": string(p.AccessType),
-			"cidrs":      p.Cidrs,
-			"ipv6Cidrs":  p.Ipv6Cidrs,
+			"cidrs":      stringsToInterface(p.Cidrs),
+			"ipv6Cidrs":  stringsToInterface(p.Ipv6Cidrs),
 		}
 		if p.AccessFrom != nil {
 			rule["accessFrom"] = *p.AccessFrom
@@ -204,9 +204,9 @@ func (a *mqlAwsLightsailInstance) ports() ([]any, error) {
 			"protocol":        string(p.Protocol),
 			"accessType":      string(p.AccessType),
 			"accessDirection": string(p.AccessDirection),
-			"cidrs":           p.Cidrs,
-			"ipv6Cidrs":       p.Ipv6Cidrs,
-			"cidrListAliases": p.CidrListAliases,
+			"cidrs":           stringsToInterface(p.Cidrs),
+			"ipv6Cidrs":       stringsToInterface(p.Ipv6Cidrs),
+			"cidrListAliases": stringsToInterface(p.CidrListAliases),
 		}
 		if p.AccessFrom != nil {
 			entry["accessFrom"] = *p.AccessFrom


### PR DESCRIPTION
## Summary

- `aws.lightsail.instance.ports()` and `aws.lightsail.instance.firewallRules()` errored with `failed to convert dict to primitive, unsupported child type: []string` whenever they were selected, because they fed raw `[]string` slices (`Cidrs`, `Ipv6Cidrs`, `CidrListAliases`) into the dict map. The MQL dict serializer only accepts `[]any` for slice values.
- Wrap each slice with `stringsToInterface(...)` (the helper already used elsewhere in the provider) so the values land in the dict as `[]any` and the converter succeeds.

This was found while exercising the new fields added in #7641 against a real Lightsail instance with open firewall ports — but the bug also affected the pre-existing `firewallRules()` method.

## Test plan

- [x] Built provider, ran `cnspec run aws --region us-east-1 -c 'aws.lightsail.instances.where(name == "…") { ports firewallRules }'` against a Lightsail instance with two open TCP ports — both methods now return populated dict arrays (cidrs/ipv6Cidrs/cidrListAliases render as JSON arrays) instead of an error
- [ ] `make test/lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)