### PR TITLE
🎉 aws-13.23.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.22.0",
+	Version:         "13.23.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### aws (13.23.0)
- 🐛 aws: populate codebuild project scalar fields from iterator (#7665)
- 🐛 aws: fix lightsail instance ports/firewallRules []string conversion (#7664)
- ✨ aws: backfill aws.elasticbeanstalk.application and environment fields (#7639)
- ✨ aws: backfill aws.networkfirewall firewall/policy/ruleGroup fields (#7645)
- ✨ aws: backfill aws.mq.broker fields and add configuration resource (#7642)
- ✨ aws: backfill aws.appmesh resources with listener/backend fields and add virtualGateway (#7643)
- ✨ aws: backfill aws.lightsail instance/db/lb fields and add disk resource (#7641)
- ✨ aws: backfill aws.codebuild.project with VPC/logs/cache/env fields and add reportGroup (#7640)
- ✨ aws: backfill aws.sfn.stateMachine fields and add stateMachineVersion (#7644)
- 🧹 Update deps for mql and providers 20260511 (#7650)