### PR TITLE
✨ tailscale: accept OAuth client secret from credentials

### DIFF
--- a/providers/tailscale/config/config.go
+++ b/providers/tailscale/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "tailscale",
 	ID:              "go.mondoo.com/mql/v13/providers/tailscale",
-	Version:         "13.1.5",
+	Version:         "13.1.6",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/tailscale/connection/authentication.go
+++ b/providers/tailscale/connection/authentication.go
@@ -42,25 +42,12 @@ func GetToken(conf *inventory.Config) (string, bool) {
 	// env variable
 	token, set := getOptionValueFrom(conf.Options, TAILSCALE_API_KEY_VAR, OPTION_TOKEN)
 
-	// special case for tokens that are passed as credentials
-	if len(conf.Credentials) > 0 {
-		for _, cred := range conf.Credentials {
-			// support only for credentials of type password
-			if cred.Type != vault.CredentialType_password {
-				log.Warn().
-					Str("credential-type", cred.Type.String()).
-					Msg("unsupported credential type for Tailscale provider")
-				continue
-			}
-			// check if the password is empty
-			if len(cred.Secret) == 0 {
-				log.Warn().
-					Str("credential-type", cred.Type.String()).
-					Msg("empty credentials")
-				continue
-			}
-			// use it as the token
-			token = string(cred.Secret)
+	// special case for tokens that are passed as credentials. When an OAuth
+	// client id is configured the password credential is the client secret, not
+	// the API token, so we only fall back to credentials in token mode.
+	if _, oauth := getOptionValueFrom(conf.Options, TAILSCALE_OAUTH_CLIENT_ID_VAR, OPTION_CLIENT_ID); !oauth {
+		if cred, ok := firstPasswordCredential(conf); ok {
+			token = string(cred)
 			set = true
 		}
 	}
@@ -71,7 +58,41 @@ func GetClientID(conf *inventory.Config) (string, bool) {
 	return getOptionValueFrom(conf.Options, TAILSCALE_OAUTH_CLIENT_ID_VAR, OPTION_CLIENT_ID)
 }
 func GetClientSecret(conf *inventory.Config) (string, bool) {
-	return getOptionValueFrom(conf.Options, TAILSCALE_OAUTH_CLIENT_SECRET_VAR, OPTION_CLIENT_SECRET)
+	secret, set := getOptionValueFrom(conf.Options, TAILSCALE_OAUTH_CLIENT_SECRET_VAR, OPTION_CLIENT_SECRET)
+
+	// special case for OAuth client secrets that are passed as credentials. We
+	// only treat password credentials as the client secret when an OAuth client
+	// id is configured — otherwise the credential is the API token (see
+	// GetToken).
+	if _, oauth := getOptionValueFrom(conf.Options, TAILSCALE_OAUTH_CLIENT_ID_VAR, OPTION_CLIENT_ID); oauth {
+		if cred, ok := firstPasswordCredential(conf); ok {
+			secret = string(cred)
+			set = true
+		}
+	}
+
+	return secret, set
+}
+
+// firstPasswordCredential returns the secret bytes of the first non-empty
+// password credential in conf, or false if none is present.
+func firstPasswordCredential(conf *inventory.Config) ([]byte, bool) {
+	for _, cred := range conf.Credentials {
+		if cred.Type != vault.CredentialType_password {
+			log.Warn().
+				Str("credential-type", cred.Type.String()).
+				Msg("unsupported credential type for Tailscale provider")
+			continue
+		}
+		if len(cred.Secret) == 0 {
+			log.Warn().
+				Str("credential-type", cred.Type.String()).
+				Msg("empty credentials")
+			continue
+		}
+		return cred.Secret, true
+	}
+	return nil, false
 }
 func GetBaseURL(conf *inventory.Config) (string, bool) {
 	return getOptionValueFrom(conf.Options, TAILSCALE_BASE_URL_VAR, OPTION_BASE_URL)

--- a/providers/tailscale/connection/authentication_test.go
+++ b/providers/tailscale/connection/authentication_test.go
@@ -1,0 +1,98 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
+)
+
+func TestGetToken_FromOptions(t *testing.T) {
+	conf := &inventory.Config{
+		Options: map[string]string{OPTION_TOKEN: "api-token"},
+	}
+	token, ok := GetToken(conf)
+	assert.True(t, ok)
+	assert.Equal(t, "api-token", token)
+}
+
+func TestGetToken_FromPasswordCredential(t *testing.T) {
+	conf := &inventory.Config{
+		Credentials: []*vault.Credential{
+			{Type: vault.CredentialType_password, Secret: []byte("api-token")},
+		},
+	}
+	token, ok := GetToken(conf)
+	assert.True(t, ok)
+	assert.Equal(t, "api-token", token)
+}
+
+func TestGetToken_IgnoresCredentialInOAuthMode(t *testing.T) {
+	conf := &inventory.Config{
+		Options: map[string]string{OPTION_CLIENT_ID: "oauth-client-id"},
+		Credentials: []*vault.Credential{
+			{Type: vault.CredentialType_password, Secret: []byte("oauth-client-secret")},
+		},
+	}
+	token, ok := GetToken(conf)
+	assert.False(t, ok)
+	assert.Empty(t, token)
+}
+
+func TestGetClientSecret_FromOptions(t *testing.T) {
+	conf := &inventory.Config{
+		Options: map[string]string{
+			OPTION_CLIENT_ID:     "oauth-client-id",
+			OPTION_CLIENT_SECRET: "oauth-client-secret",
+		},
+	}
+	secret, ok := GetClientSecret(conf)
+	assert.True(t, ok)
+	assert.Equal(t, "oauth-client-secret", secret)
+}
+
+func TestGetClientSecret_FromPasswordCredentialInOAuthMode(t *testing.T) {
+	conf := &inventory.Config{
+		Options: map[string]string{OPTION_CLIENT_ID: "oauth-client-id"},
+		Credentials: []*vault.Credential{
+			{Type: vault.CredentialType_password, Secret: []byte("oauth-client-secret")},
+		},
+	}
+	secret, ok := GetClientSecret(conf)
+	assert.True(t, ok)
+	assert.Equal(t, "oauth-client-secret", secret)
+}
+
+func TestGetClientSecret_IgnoresCredentialWithoutClientID(t *testing.T) {
+	conf := &inventory.Config{
+		Credentials: []*vault.Credential{
+			{Type: vault.CredentialType_password, Secret: []byte("api-token")},
+		},
+	}
+	secret, ok := GetClientSecret(conf)
+	assert.False(t, ok)
+	assert.Empty(t, secret)
+}
+
+func TestAuthenticationMethod_OAuthFromCredentials(t *testing.T) {
+	conf := &inventory.Config{
+		Options: map[string]string{OPTION_CLIENT_ID: "oauth-client-id"},
+		Credentials: []*vault.Credential{
+			{Type: vault.CredentialType_password, Secret: []byte("oauth-client-secret")},
+		},
+	}
+	assert.Equal(t, OAuthMethod, AuthenticationMethod(conf))
+}
+
+func TestAuthenticationMethod_TokenFromCredential(t *testing.T) {
+	conf := &inventory.Config{
+		Credentials: []*vault.Credential{
+			{Type: vault.CredentialType_password, Secret: []byte("api-token")},
+		},
+	}
+	assert.Equal(t, TokenAuthMethod, AuthenticationMethod(conf))
+}

--- a/providers/tailscale/go.mod
+++ b/providers/tailscale/go.mod
@@ -7,6 +7,7 @@ go 1.26.2
 require (
 	github.com/cockroachdb/errors v1.13.0
 	github.com/rs/zerolog v1.35.1
+	github.com/stretchr/testify v1.11.1
 	github.com/tailscale/tailscale-client-go/v2 v2.0.0-20250129222324-74c8fc3cb4d7
 	go.mondoo.com/mql/v13 v13.9.0
 )
@@ -58,6 +59,7 @@ require (
 	github.com/cockroachdb/redact v1.1.8 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dvsekhvalnov/jose2go v1.8.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
@@ -115,6 +117,7 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
@@ -157,6 +160,7 @@ require (
 	google.golang.org/grpc v1.81.0 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )


### PR DESCRIPTION
## Summary

- The Tailscale provider already reads API tokens from password credentials on the inventory config, which lets the Mondoo platform integration keep the token in a vault and pass it via `cred.SecretId`. The OAuth client secret was limited to CLI flags / env vars, which blocked the platform integration from supporting OAuth without leaking the secret through plain connection options.
- `GetClientSecret` now also reads a password credential from the config when an OAuth client id is present in the options. The platform integration sets `client-id` alongside the credential, so the presence of `client-id` is the disambiguator.
- `GetToken` keeps its previous behaviour but only falls back to credentials when no OAuth `client-id` is configured, so the same credential isn't ambiguously interpreted as both a token and a client secret.
- Bumps tailscale provider version `13.1.5 → 13.1.6`.

Paired with the platform PR: https://github.com/mondoohq/server/pull/15675

## Test plan

- [x] `go test ./connection/ -count=1` (new `authentication_test.go` covers token-from-options, token-from-cred, OAuth-from-options, OAuth-secret-from-cred, and the disambiguation between the two modes)
- [ ] Run a token-mode scan via the platform: `cnspec scan tailscale --token <api-key>` — still works
- [ ] Run an OAuth-mode scan via the platform: integration with `client-id` + vault-stored client secret — provider authenticates via OAuth

🤖 Generated with [Claude Code](https://claude.com/claude-code)