### PR TITLE
✨ aws: surface SG rule descriptions and typed prefix lists

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -12559,10 +12559,16 @@ private aws.ec2.securitygroup.ippermission @defaults("id toPort fromPort ipProto
   ipProtocol string
   // IPv4 address ranges
   ipRanges []string
+  // IPv4 address ranges with per-range descriptions (each entry: {cidr, description})
+  ipRangeDetails []dict
   // IPv6 address ranges
   ipv6Ranges []string
+  // IPv6 address ranges with per-range descriptions (each entry: {cidr, description})
+  ipv6RangeDetails []dict
   // List of prefix IDs
   prefixListIds []dict
+  // Managed prefix lists this rule targets
+  prefixLists() []aws.ec2.managedPrefixList
   // List of user ID group pairs
   userIdGroupPairs []dict
 }

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -112635,7 +112635,7 @@ func (c *mqlAwsEc2TransitgatewayPeeringAttachment) GetStatusMessage() *plugin.TV
 type mqlAwsEc2ManagedPrefixList struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	mqlAwsEc2ManagedPrefixListInternal
+	// optional: if you define mqlAwsEc2ManagedPrefixListInternal it will be used here
 	Id            plugin.TValue[string]
 	Arn           plugin.TValue[string]
 	Name          plugin.TValue[string]

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -2677,7 +2677,7 @@ func init() {
 			Create: createAwsEc2TransitgatewayPeeringAttachment,
 		},
 		"aws.ec2.managedPrefixList": {
-			// to override args, implement: initAwsEc2ManagedPrefixList(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAwsEc2ManagedPrefixList,
 			Create: createAwsEc2ManagedPrefixList,
 		},
 		"aws.ec2.managedPrefixList.entry": {
@@ -18677,11 +18677,20 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.securitygroup.ippermission.ipRanges": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2SecuritygroupIppermission).GetIpRanges()).ToDataRes(types.Array(types.String))
 	},
+	"aws.ec2.securitygroup.ippermission.ipRangeDetails": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2SecuritygroupIppermission).GetIpRangeDetails()).ToDataRes(types.Array(types.Dict))
+	},
 	"aws.ec2.securitygroup.ippermission.ipv6Ranges": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2SecuritygroupIppermission).GetIpv6Ranges()).ToDataRes(types.Array(types.String))
 	},
+	"aws.ec2.securitygroup.ippermission.ipv6RangeDetails": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2SecuritygroupIppermission).GetIpv6RangeDetails()).ToDataRes(types.Array(types.Dict))
+	},
 	"aws.ec2.securitygroup.ippermission.prefixListIds": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2SecuritygroupIppermission).GetPrefixListIds()).ToDataRes(types.Array(types.Dict))
+	},
+	"aws.ec2.securitygroup.ippermission.prefixLists": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2SecuritygroupIppermission).GetPrefixLists()).ToDataRes(types.Array(types.Resource("aws.ec2.managedPrefixList")))
 	},
 	"aws.ec2.securitygroup.ippermission.userIdGroupPairs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2SecuritygroupIppermission).GetUserIdGroupPairs()).ToDataRes(types.Array(types.Dict))
@@ -48236,12 +48245,24 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2SecuritygroupIppermission).IpRanges, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.securitygroup.ippermission.ipRangeDetails": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2SecuritygroupIppermission).IpRangeDetails, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.securitygroup.ippermission.ipv6Ranges": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2SecuritygroupIppermission).Ipv6Ranges, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.securitygroup.ippermission.ipv6RangeDetails": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2SecuritygroupIppermission).Ipv6RangeDetails, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.securitygroup.ippermission.prefixListIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2SecuritygroupIppermission).PrefixListIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.securitygroup.ippermission.prefixLists": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2SecuritygroupIppermission).PrefixLists, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.securitygroup.ippermission.userIdGroupPairs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -116805,14 +116826,17 @@ func (c *mqlAwsEc2Securitygroup) GetIsAttachedToNetworkInterface() *plugin.TValu
 type mqlAwsEc2SecuritygroupIppermission struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsEc2SecuritygroupIppermissionInternal it will be used here
+	mqlAwsEc2SecuritygroupIppermissionInternal
 	Id               plugin.TValue[string]
 	FromPort         plugin.TValue[int64]
 	ToPort           plugin.TValue[int64]
 	IpProtocol       plugin.TValue[string]
 	IpRanges         plugin.TValue[[]any]
+	IpRangeDetails   plugin.TValue[[]any]
 	Ipv6Ranges       plugin.TValue[[]any]
+	Ipv6RangeDetails plugin.TValue[[]any]
 	PrefixListIds    plugin.TValue[[]any]
+	PrefixLists      plugin.TValue[[]any]
 	UserIdGroupPairs plugin.TValue[[]any]
 }
 
@@ -116873,12 +116897,36 @@ func (c *mqlAwsEc2SecuritygroupIppermission) GetIpRanges() *plugin.TValue[[]any]
 	return &c.IpRanges
 }
 
+func (c *mqlAwsEc2SecuritygroupIppermission) GetIpRangeDetails() *plugin.TValue[[]any] {
+	return &c.IpRangeDetails
+}
+
 func (c *mqlAwsEc2SecuritygroupIppermission) GetIpv6Ranges() *plugin.TValue[[]any] {
 	return &c.Ipv6Ranges
 }
 
+func (c *mqlAwsEc2SecuritygroupIppermission) GetIpv6RangeDetails() *plugin.TValue[[]any] {
+	return &c.Ipv6RangeDetails
+}
+
 func (c *mqlAwsEc2SecuritygroupIppermission) GetPrefixListIds() *plugin.TValue[[]any] {
 	return &c.PrefixListIds
+}
+
+func (c *mqlAwsEc2SecuritygroupIppermission) GetPrefixLists() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PrefixLists, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2.securitygroup.ippermission", c.__id, "prefixLists")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.prefixLists()
+	})
 }
 
 func (c *mqlAwsEc2SecuritygroupIppermission) GetUserIdGroupPairs() *plugin.TValue[[]any] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -2463,9 +2463,12 @@ aws.ec2.securitygroup.ippermission 11.15.2
 aws.ec2.securitygroup.ippermission.fromPort 11.15.2
 aws.ec2.securitygroup.ippermission.id 11.15.2
 aws.ec2.securitygroup.ippermission.ipProtocol 11.15.2
+aws.ec2.securitygroup.ippermission.ipRangeDetails 13.23.2
 aws.ec2.securitygroup.ippermission.ipRanges 11.15.2
+aws.ec2.securitygroup.ippermission.ipv6RangeDetails 13.23.2
 aws.ec2.securitygroup.ippermission.ipv6Ranges 11.15.2
 aws.ec2.securitygroup.ippermission.prefixListIds 11.15.2
+aws.ec2.securitygroup.ippermission.prefixLists 13.23.2
 aws.ec2.securitygroup.ippermission.toPort 11.15.2
 aws.ec2.securitygroup.ippermission.userIdGroupPairs 11.15.2
 aws.ec2.securitygroup.isAttachedToNetworkInterface 11.15.2

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
-  "version": "13.21.3",
-  "generated_at": "2026-05-11T07:51:38+01:00",
+  "version": "13.23.1",
+  "generated_at": "2026-05-12T22:06:10+01:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindingsV2",

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -555,23 +555,41 @@ func (a *mqlAwsEc2Securitygroup) vpc() (*mqlAwsVpc, error) {
 	return nil, nil
 }
 
+type mqlAwsEc2SecuritygroupIppermissionInternal struct {
+	cachePrefixListIds []ec2types.PrefixListId
+	cacheRegion        string
+	cacheAccountId     string
+}
+
 func (a *mqlAwsEc2Securitygroup) ipPermissions() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	accountId := conn.AccountId()
 	mqlIpPermissions := []any{}
 	for p, permission := range a.cacheIpPerms {
 		ipRanges := []any{}
+		ipRangeDetails := []any{}
 		for r := range permission.IpRanges {
 			iprange := permission.IpRanges[r]
 			if iprange.CidrIp != nil {
 				ipRanges = append(ipRanges, *iprange.CidrIp)
 			}
+			ipRangeDetails = append(ipRangeDetails, map[string]any{
+				"cidr":        convert.ToValue(iprange.CidrIp),
+				"description": convert.ToValue(iprange.Description),
+			})
 		}
 
 		ipv6Ranges := []any{}
+		ipv6RangeDetails := []any{}
 		for r := range permission.Ipv6Ranges {
 			iprange := permission.Ipv6Ranges[r]
 			if iprange.CidrIpv6 != nil {
 				ipv6Ranges = append(ipv6Ranges, *iprange.CidrIpv6)
 			}
+			ipv6RangeDetails = append(ipv6RangeDetails, map[string]any{
+				"cidr":        convert.ToValue(iprange.CidrIpv6),
+				"description": convert.ToValue(iprange.Description),
+			})
 		}
 		prefixListIds, err := convert.JsonToDictSlice(permission.PrefixListIds)
 		if err != nil {
@@ -588,13 +606,19 @@ func (a *mqlAwsEc2Securitygroup) ipPermissions() ([]any, error) {
 				"toPort":           llx.IntDataDefault(permission.ToPort, -1),
 				"ipProtocol":       llx.StringDataPtr(permission.IpProtocol),
 				"ipRanges":         llx.ArrayData(ipRanges, types.Any),
+				"ipRangeDetails":   llx.ArrayData(ipRangeDetails, types.Any),
 				"ipv6Ranges":       llx.ArrayData(ipv6Ranges, types.Any),
+				"ipv6RangeDetails": llx.ArrayData(ipv6RangeDetails, types.Any),
 				"prefixListIds":    llx.ArrayData(prefixListIds, types.Any),
 				"userIdGroupPairs": llx.ArrayData(userIdGroupPairs, types.Any),
 			})
 		if err != nil {
 			return nil, err
 		}
+		mqlPerm := mqlSecurityGroupIpPermission.(*mqlAwsEc2SecuritygroupIppermission)
+		mqlPerm.cachePrefixListIds = permission.PrefixListIds
+		mqlPerm.cacheRegion = a.region
+		mqlPerm.cacheAccountId = accountId
 
 		mqlIpPermissions = append(mqlIpPermissions, mqlSecurityGroupIpPermission)
 	}
@@ -602,24 +626,36 @@ func (a *mqlAwsEc2Securitygroup) ipPermissions() ([]any, error) {
 }
 
 func (a *mqlAwsEc2Securitygroup) ipPermissionsEgress() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	accountId := conn.AccountId()
 	mqlIpPermissionsEgress := []any{}
 	for p := range a.cacheIpPermsEgress {
 		permission := a.cacheIpPermsEgress[p]
 
 		ipRanges := []any{}
+		ipRangeDetails := []any{}
 		for r := range permission.IpRanges {
 			iprange := permission.IpRanges[r]
 			if iprange.CidrIp != nil {
 				ipRanges = append(ipRanges, *iprange.CidrIp)
 			}
+			ipRangeDetails = append(ipRangeDetails, map[string]any{
+				"cidr":        convert.ToValue(iprange.CidrIp),
+				"description": convert.ToValue(iprange.Description),
+			})
 		}
 
 		ipv6Ranges := []any{}
+		ipv6RangeDetails := []any{}
 		for r := range permission.Ipv6Ranges {
 			iprange := permission.Ipv6Ranges[r]
 			if iprange.CidrIpv6 != nil {
 				ipv6Ranges = append(ipv6Ranges, *iprange.CidrIpv6)
 			}
+			ipv6RangeDetails = append(ipv6RangeDetails, map[string]any{
+				"cidr":        convert.ToValue(iprange.CidrIpv6),
+				"description": convert.ToValue(iprange.Description),
+			})
 		}
 		prefixListIds, err := convert.JsonToDictSlice(permission.PrefixListIds)
 		if err != nil {
@@ -636,17 +672,40 @@ func (a *mqlAwsEc2Securitygroup) ipPermissionsEgress() ([]any, error) {
 				"toPort":           llx.IntDataDefault(permission.ToPort, -1),
 				"ipProtocol":       llx.StringDataPtr(permission.IpProtocol),
 				"ipRanges":         llx.ArrayData(ipRanges, types.Any),
+				"ipRangeDetails":   llx.ArrayData(ipRangeDetails, types.Any),
 				"ipv6Ranges":       llx.ArrayData(ipv6Ranges, types.Any),
+				"ipv6RangeDetails": llx.ArrayData(ipv6RangeDetails, types.Any),
 				"prefixListIds":    llx.ArrayData(prefixListIds, types.Any),
 				"userIdGroupPairs": llx.ArrayData(userIdGroupPairs, types.Any),
 			})
 		if err != nil {
 			return nil, err
 		}
+		mqlPerm := mqlSecurityGroupIpPermission.(*mqlAwsEc2SecuritygroupIppermission)
+		mqlPerm.cachePrefixListIds = permission.PrefixListIds
+		mqlPerm.cacheRegion = a.region
+		mqlPerm.cacheAccountId = accountId
 
 		mqlIpPermissionsEgress = append(mqlIpPermissionsEgress, mqlSecurityGroupIpPermission)
 	}
 	return mqlIpPermissionsEgress, nil
+}
+
+func (a *mqlAwsEc2SecuritygroupIppermission) prefixLists() ([]any, error) {
+	res := []any{}
+	for _, pl := range a.cachePrefixListIds {
+		if pl.PrefixListId == nil {
+			continue
+		}
+		plArn := fmt.Sprintf("arn:aws:ec2:%s:%s:prefix-list/%s", a.cacheRegion, a.cacheAccountId, *pl.PrefixListId)
+		mqlPL, err := NewResource(a.MqlRuntime, ResourceAwsEc2ManagedPrefixList,
+			map[string]*llx.RawData{"arn": llx.StringData(plArn)})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlPL)
+	}
+	return res, nil
 }
 
 func (a *mqlAwsEc2) keypairs() ([]any, error) {

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -561,36 +561,45 @@ type mqlAwsEc2SecuritygroupIppermissionInternal struct {
 	cacheAccountId     string
 }
 
+func buildIpRangeDetails(ranges []ec2types.IpRange) ([]any, []any) {
+	ipRanges := []any{}
+	ipRangeDetails := []any{}
+	for r := range ranges {
+		iprange := ranges[r]
+		if iprange.CidrIp != nil {
+			ipRanges = append(ipRanges, *iprange.CidrIp)
+		}
+		ipRangeDetails = append(ipRangeDetails, map[string]any{
+			"cidr":        convert.ToValue(iprange.CidrIp),
+			"description": convert.ToValue(iprange.Description),
+		})
+	}
+	return ipRanges, ipRangeDetails
+}
+
+func buildIpv6RangeDetails(ranges []ec2types.Ipv6Range) ([]any, []any) {
+	ipv6Ranges := []any{}
+	ipv6RangeDetails := []any{}
+	for r := range ranges {
+		iprange := ranges[r]
+		if iprange.CidrIpv6 != nil {
+			ipv6Ranges = append(ipv6Ranges, *iprange.CidrIpv6)
+		}
+		ipv6RangeDetails = append(ipv6RangeDetails, map[string]any{
+			"cidr":        convert.ToValue(iprange.CidrIpv6),
+			"description": convert.ToValue(iprange.Description),
+		})
+	}
+	return ipv6Ranges, ipv6RangeDetails
+}
+
 func (a *mqlAwsEc2Securitygroup) ipPermissions() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	accountId := conn.AccountId()
 	mqlIpPermissions := []any{}
 	for p, permission := range a.cacheIpPerms {
-		ipRanges := []any{}
-		ipRangeDetails := []any{}
-		for r := range permission.IpRanges {
-			iprange := permission.IpRanges[r]
-			if iprange.CidrIp != nil {
-				ipRanges = append(ipRanges, *iprange.CidrIp)
-			}
-			ipRangeDetails = append(ipRangeDetails, map[string]any{
-				"cidr":        convert.ToValue(iprange.CidrIp),
-				"description": convert.ToValue(iprange.Description),
-			})
-		}
-
-		ipv6Ranges := []any{}
-		ipv6RangeDetails := []any{}
-		for r := range permission.Ipv6Ranges {
-			iprange := permission.Ipv6Ranges[r]
-			if iprange.CidrIpv6 != nil {
-				ipv6Ranges = append(ipv6Ranges, *iprange.CidrIpv6)
-			}
-			ipv6RangeDetails = append(ipv6RangeDetails, map[string]any{
-				"cidr":        convert.ToValue(iprange.CidrIpv6),
-				"description": convert.ToValue(iprange.Description),
-			})
-		}
+		ipRanges, ipRangeDetails := buildIpRangeDetails(permission.IpRanges)
+		ipv6Ranges, ipv6RangeDetails := buildIpv6RangeDetails(permission.Ipv6Ranges)
 		prefixListIds, err := convert.JsonToDictSlice(permission.PrefixListIds)
 		if err != nil {
 			return nil, err
@@ -631,32 +640,8 @@ func (a *mqlAwsEc2Securitygroup) ipPermissionsEgress() ([]any, error) {
 	mqlIpPermissionsEgress := []any{}
 	for p := range a.cacheIpPermsEgress {
 		permission := a.cacheIpPermsEgress[p]
-
-		ipRanges := []any{}
-		ipRangeDetails := []any{}
-		for r := range permission.IpRanges {
-			iprange := permission.IpRanges[r]
-			if iprange.CidrIp != nil {
-				ipRanges = append(ipRanges, *iprange.CidrIp)
-			}
-			ipRangeDetails = append(ipRangeDetails, map[string]any{
-				"cidr":        convert.ToValue(iprange.CidrIp),
-				"description": convert.ToValue(iprange.Description),
-			})
-		}
-
-		ipv6Ranges := []any{}
-		ipv6RangeDetails := []any{}
-		for r := range permission.Ipv6Ranges {
-			iprange := permission.Ipv6Ranges[r]
-			if iprange.CidrIpv6 != nil {
-				ipv6Ranges = append(ipv6Ranges, *iprange.CidrIpv6)
-			}
-			ipv6RangeDetails = append(ipv6RangeDetails, map[string]any{
-				"cidr":        convert.ToValue(iprange.CidrIpv6),
-				"description": convert.ToValue(iprange.Description),
-			})
-		}
+		ipRanges, ipRangeDetails := buildIpRangeDetails(permission.IpRanges)
+		ipv6Ranges, ipv6RangeDetails := buildIpv6RangeDetails(permission.Ipv6Ranges)
 		prefixListIds, err := convert.JsonToDictSlice(permission.PrefixListIds)
 		if err != nil {
 			return nil, err

--- a/providers/aws/resources/aws_ec2_prefixlist.go
+++ b/providers/aws/resources/aws_ec2_prefixlist.go
@@ -26,10 +26,6 @@ func (a *mqlAwsEc2ManagedPrefixListEntry) id() (string, error) {
 	return a.Cidr.Data, nil
 }
 
-type mqlAwsEc2ManagedPrefixListInternal struct {
-	region string
-}
-
 func initAwsEc2ManagedPrefixList(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
@@ -53,6 +49,10 @@ func initAwsEc2ManagedPrefixList(runtime *plugin.Runtime, args map[string]*llx.R
 		return args, nil, nil
 	}
 	plId := parts[len(parts)-1]
+
+	args["id"] = llx.StringData(plId)
+	args["arn"] = llx.StringData(arnVal)
+	args["region"] = llx.StringData(region)
 
 	conn := runtime.Connection.(*connection.AwsConnection)
 	svc := conn.Ec2(region)
@@ -81,9 +81,7 @@ func initAwsEc2ManagedPrefixList(runtime *plugin.Runtime, args map[string]*llx.R
 	}
 
 	args["id"] = llx.StringData(convert.ToValue(pl.PrefixListId))
-	args["arn"] = llx.StringData(arnVal)
 	args["name"] = llx.StringData(convert.ToValue(pl.PrefixListName))
-	args["region"] = llx.StringData(region)
 	args["state"] = llx.StringData(string(pl.State))
 	args["addressFamily"] = llx.StringData(convert.ToValue(pl.AddressFamily))
 	args["maxEntries"] = llx.IntData(maxEntries)
@@ -164,7 +162,6 @@ func (a *mqlAwsEc2) getManagedPrefixLists(conn *connection.AwsConnection) []*job
 					if err != nil {
 						return nil, err
 					}
-					mqlPl.(*mqlAwsEc2ManagedPrefixList).region = region
 					res = append(res, mqlPl)
 				}
 			}

--- a/providers/aws/resources/aws_ec2_prefixlist.go
+++ b/providers/aws/resources/aws_ec2_prefixlist.go
@@ -6,10 +6,12 @@ package resources
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/aws/connection"
@@ -26,6 +28,69 @@ func (a *mqlAwsEc2ManagedPrefixListEntry) id() (string, error) {
 
 type mqlAwsEc2ManagedPrefixListInternal struct {
 	region string
+}
+
+func initAwsEc2ManagedPrefixList(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+
+	arnRaw, hasArn := args["arn"]
+	if !hasArn || arnRaw == nil || arnRaw.Value == nil {
+		return args, nil, nil
+	}
+	arnVal, ok := arnRaw.Value.(string)
+	if !ok || arnVal == "" {
+		return args, nil, nil
+	}
+
+	region, err := GetRegionFromArn(arnVal)
+	if err != nil {
+		return args, nil, nil
+	}
+	parts := strings.Split(arnVal, "/")
+	if len(parts) < 2 {
+		return args, nil, nil
+	}
+	plId := parts[len(parts)-1]
+
+	conn := runtime.Connection.(*connection.AwsConnection)
+	svc := conn.Ec2(region)
+	ctx := context.Background()
+	resp, err := svc.DescribeManagedPrefixLists(ctx, &ec2.DescribeManagedPrefixListsInput{
+		PrefixListIds: []string{plId},
+	})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return args, nil, nil
+		}
+		return nil, nil, err
+	}
+	if len(resp.PrefixLists) == 0 {
+		return args, nil, nil
+	}
+	pl := resp.PrefixLists[0]
+
+	var version int64
+	if pl.Version != nil {
+		version = *pl.Version
+	}
+	var maxEntries int64
+	if pl.MaxEntries != nil {
+		maxEntries = int64(*pl.MaxEntries)
+	}
+
+	args["id"] = llx.StringData(convert.ToValue(pl.PrefixListId))
+	args["arn"] = llx.StringData(arnVal)
+	args["name"] = llx.StringData(convert.ToValue(pl.PrefixListName))
+	args["region"] = llx.StringData(region)
+	args["state"] = llx.StringData(string(pl.State))
+	args["addressFamily"] = llx.StringData(convert.ToValue(pl.AddressFamily))
+	args["maxEntries"] = llx.IntData(maxEntries)
+	args["version"] = llx.IntData(version)
+	args["ownerId"] = llx.StringData(convert.ToValue(pl.OwnerId))
+	args["tags"] = llx.MapData(toInterfaceMap(ec2TagsToMap(pl.Tags)), types.String)
+	return args, nil, nil
 }
 
 func (a *mqlAwsEc2) managedPrefixLists() ([]any, error) {
@@ -112,7 +177,7 @@ func (a *mqlAwsEc2) getManagedPrefixLists(conn *connection.AwsConnection) []*job
 
 func (a *mqlAwsEc2ManagedPrefixList) entries() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	svc := conn.Ec2(a.region)
+	svc := conn.Ec2(a.Region.Data)
 	ctx := context.Background()
 
 	plId := a.Id.Data


### PR DESCRIPTION
## Summary

Three additive fields on `aws.ec2.securitygroup.ippermission` so audits can reach data we currently drop or only expose as raw dicts:

- **`ipRangeDetails []dict`** and **`ipv6RangeDetails []dict`** — parallel to the existing `ipRanges` / `ipv6Ranges`, but each entry is `{cidr, description}`. AWS returns a per-CIDR description (e.g. "SSH from office") that today we discard at [aws_ec2.go:562](providers/aws/resources/aws_ec2.go#L562); these fields surface it.
- **`prefixLists() []aws.ec2.managedPrefixList`** — typed reference resolving `PrefixListIds` against the existing managed-prefix-list resource. Unlocks traversal like `sg.ipPermissions.prefixLists.entries.cidr`.

A new `initAwsEc2ManagedPrefixList` resolves a managed prefix list by ARN via `DescribeManagedPrefixLists` (region parsed from the ARN) so the typed ref above works even when the user hasn't pre-enumerated the full collection. `entries()` switched to read the schema-level `Region` field, so init-created instances work too.

## Backwards compatibility

- No existing fields change shape or semantics. `ipRanges`, `ipv6Ranges`, and `prefixListIds` keep their current types and values.
- The synthetic `ippermission.id` (`groupId-index[-egress]`) is intentionally **unchanged** in this PR — switching to real `sgr-…` IDs is a separate body of work because it requires a different data source (`DescribeSecurityGroupRules`) and a new IAM permission.
- No new IAM permissions required for this PR — `ec2:DescribeManagedPrefixLists` was already in `aws.permissions.json`.
- New entries live at `13.23.2` in `aws.lr.versions`.

## Test plan

Verified live against AWS account `177043759486`:

- [x] `ipRangeDetails` returns `[{cidr, description}]` — confirmed with a rule whose description is `"SSH"`
- [x] `prefixLists()` resolves AWS-managed `pl-45a6432c` (`com.amazonaws.firewall.regional-prod-only`) end-to-end: id, name, addressFamily, and `entries.length=9` populated lazily via the new `initAwsEc2ManagedPrefixList`
- [x] Existing fields (`ipRanges`, `ipv6Ranges`, `prefixListIds`) unchanged in shape and values
- [x] `make providers/build/aws` clean; `gofmt -l` silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)