### PR TITLE
✨ azure: typed subnets and ASG refs on NSG / securityrule

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -2078,8 +2078,10 @@ private azure.subscription.networkService.securityGroup @defaults("id name locat
   etag string
   // Security group properties
   properties dict
-  // Security group interfaces
+  // Network interfaces this NSG is attached to
   interfaces() []azure.subscription.networkService.interface
+  // Subnets this NSG is attached to
+  subnets() []azure.subscription.networkService.subnet
   // Security group rules
   securityRules() []azure.subscription.networkService.securityrule
   // Security group default security rules
@@ -2112,6 +2114,10 @@ private azure.subscription.networkService.securityrule @defaults("id name") {
   sourceAddressPrefix string
   // Security rule destination address prefix (CIDR or *)
   destinationAddressPrefix string
+  // Application security groups the rule sources traffic from
+  sourceApplicationSecurityGroups() []azure.subscription.networkService.appSecurityGroup
+  // Application security groups the rule targets as destination
+  destinationApplicationSecurityGroups() []azure.subscription.networkService.appSecurityGroup
   // Security rule description
   description string
 }

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -522,7 +522,7 @@ func init() {
 			Create: createAzureSubscriptionNetworkServiceNatGateway,
 		},
 		"azure.subscription.networkService.subnet": {
-			// to override args, implement: initAzureSubscriptionNetworkServiceSubnet(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAzureSubscriptionNetworkServiceSubnet,
 			Create: createAzureSubscriptionNetworkServiceSubnet,
 		},
 		"azure.subscription.networkService.virtualNetwork": {
@@ -4026,6 +4026,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.securityGroup.interfaces": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityGroup).GetInterfaces()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.interface")))
 	},
+	"azure.subscription.networkService.securityGroup.subnets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityGroup).GetSubnets()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.subnet")))
+	},
 	"azure.subscription.networkService.securityGroup.securityRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityGroup).GetSecurityRules()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.securityrule")))
 	},
@@ -4067,6 +4070,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.securityrule.destinationAddressPrefix": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).GetDestinationAddressPrefix()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.securityrule.sourceApplicationSecurityGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).GetSourceApplicationSecurityGroups()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.appSecurityGroup")))
+	},
+	"azure.subscription.networkService.securityrule.destinationApplicationSecurityGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).GetDestinationApplicationSecurityGroups()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.appSecurityGroup")))
 	},
 	"azure.subscription.networkService.securityrule.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).GetDescription()).ToDataRes(types.String)
@@ -14942,6 +14951,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceSecurityGroup).Interfaces, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.networkService.securityGroup.subnets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceSecurityGroup).Subnets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.networkService.securityGroup.securityRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceSecurityGroup).SecurityRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -15000,6 +15013,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.securityrule.destinationAddressPrefix": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).DestinationAddressPrefix, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.securityrule.sourceApplicationSecurityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).SourceApplicationSecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.securityrule.destinationApplicationSecurityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).DestinationApplicationSecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.securityrule.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34022,6 +34043,7 @@ type mqlAzureSubscriptionNetworkServiceSecurityGroup struct {
 	Etag                 plugin.TValue[string]
 	Properties           plugin.TValue[any]
 	Interfaces           plugin.TValue[[]any]
+	Subnets              plugin.TValue[[]any]
 	SecurityRules        plugin.TValue[[]any]
 	DefaultSecurityRules plugin.TValue[[]any]
 }
@@ -34107,6 +34129,22 @@ func (c *mqlAzureSubscriptionNetworkServiceSecurityGroup) GetInterfaces() *plugi
 	})
 }
 
+func (c *mqlAzureSubscriptionNetworkServiceSecurityGroup) GetSubnets() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Subnets, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.securityGroup", c.__id, "subnets")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.subnets()
+	})
+}
+
 func (c *mqlAzureSubscriptionNetworkServiceSecurityGroup) GetSecurityRules() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.SecurityRules, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -34143,20 +34181,22 @@ func (c *mqlAzureSubscriptionNetworkServiceSecurityGroup) GetDefaultSecurityRule
 type mqlAzureSubscriptionNetworkServiceSecurityrule struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionNetworkServiceSecurityruleInternal it will be used here
-	Id                       plugin.TValue[string]
-	Name                     plugin.TValue[string]
-	Etag                     plugin.TValue[string]
-	Properties               plugin.TValue[any]
-	DestinationPortRange     plugin.TValue[[]any]
-	Direction                plugin.TValue[string]
-	Protocol                 plugin.TValue[string]
-	Access                   plugin.TValue[string]
-	Priority                 plugin.TValue[int64]
-	SourcePortRange          plugin.TValue[string]
-	SourceAddressPrefix      plugin.TValue[string]
-	DestinationAddressPrefix plugin.TValue[string]
-	Description              plugin.TValue[string]
+	mqlAzureSubscriptionNetworkServiceSecurityruleInternal
+	Id                                   plugin.TValue[string]
+	Name                                 plugin.TValue[string]
+	Etag                                 plugin.TValue[string]
+	Properties                           plugin.TValue[any]
+	DestinationPortRange                 plugin.TValue[[]any]
+	Direction                            plugin.TValue[string]
+	Protocol                             plugin.TValue[string]
+	Access                               plugin.TValue[string]
+	Priority                             plugin.TValue[int64]
+	SourcePortRange                      plugin.TValue[string]
+	SourceAddressPrefix                  plugin.TValue[string]
+	DestinationAddressPrefix             plugin.TValue[string]
+	SourceApplicationSecurityGroups      plugin.TValue[[]any]
+	DestinationApplicationSecurityGroups plugin.TValue[[]any]
+	Description                          plugin.TValue[string]
 }
 
 // createAzureSubscriptionNetworkServiceSecurityrule creates a new instance of this resource
@@ -34242,6 +34282,38 @@ func (c *mqlAzureSubscriptionNetworkServiceSecurityrule) GetSourceAddressPrefix(
 
 func (c *mqlAzureSubscriptionNetworkServiceSecurityrule) GetDestinationAddressPrefix() *plugin.TValue[string] {
 	return &c.DestinationAddressPrefix
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceSecurityrule) GetSourceApplicationSecurityGroups() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.SourceApplicationSecurityGroups, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.securityrule", c.__id, "sourceApplicationSecurityGroups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.sourceApplicationSecurityGroups()
+	})
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceSecurityrule) GetDestinationApplicationSecurityGroups() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.DestinationApplicationSecurityGroups, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.securityrule", c.__id, "destinationApplicationSecurityGroups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.destinationApplicationSecurityGroups()
+	})
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceSecurityrule) GetDescription() *plugin.TValue[string] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -2349,6 +2349,7 @@ azure.subscription.networkService.securityGroup.location 9.0.1
 azure.subscription.networkService.securityGroup.name 9.0.1
 azure.subscription.networkService.securityGroup.properties 9.0.1
 azure.subscription.networkService.securityGroup.securityRules 9.0.1
+azure.subscription.networkService.securityGroup.subnets 13.11.2
 azure.subscription.networkService.securityGroup.tags 9.0.1
 azure.subscription.networkService.securityGroup.type 9.0.1
 azure.subscription.networkService.securityGroups 9.0.1
@@ -2356,6 +2357,7 @@ azure.subscription.networkService.securityrule 9.0.1
 azure.subscription.networkService.securityrule.access 11.4.28
 azure.subscription.networkService.securityrule.description 11.4.28
 azure.subscription.networkService.securityrule.destinationAddressPrefix 11.4.28
+azure.subscription.networkService.securityrule.destinationApplicationSecurityGroups 13.11.2
 azure.subscription.networkService.securityrule.destinationPortRange 9.0.1
 azure.subscription.networkService.securityrule.direction 9.0.1
 azure.subscription.networkService.securityrule.etag 9.0.1
@@ -2365,6 +2367,7 @@ azure.subscription.networkService.securityrule.priority 11.4.28
 azure.subscription.networkService.securityrule.properties 9.0.1
 azure.subscription.networkService.securityrule.protocol 11.4.28
 azure.subscription.networkService.securityrule.sourceAddressPrefix 11.4.28
+azure.subscription.networkService.securityrule.sourceApplicationSecurityGroups 13.11.2
 azure.subscription.networkService.securityrule.sourcePortRange 11.4.28
 azure.subscription.networkService.serviceEndpointPolicies 13.3.3
 azure.subscription.networkService.serviceEndpointPolicy 13.3.3

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
-  "version": "13.10.1",
-  "generated_at": "2026-05-11T07:53:18+01:00",
+  "version": "13.11.1",
+  "generated_at": "2026-05-13T09:46:57+01:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",
@@ -765,13 +765,13 @@
     {
       "permission": "Microsoft.Network/localNetworkGateways/read",
       "service": "Microsoft.Network",
-      "action": "Get",
+      "action": "NewListPager",
       "source_file": "network.go"
     },
     {
       "permission": "Microsoft.Network/natGateways/read",
       "service": "Microsoft.Network",
-      "action": "Get",
+      "action": "NewListAllPager",
       "source_file": "network.go"
     },
     {
@@ -825,7 +825,7 @@
     {
       "permission": "Microsoft.Network/privateEndpoints/read",
       "service": "Microsoft.Network",
-      "action": "Get",
+      "action": "NewListBySubscriptionPager",
       "source_file": "network.go"
     },
     {
@@ -1257,7 +1257,7 @@
     {
       "permission": "Microsoft.Storage/storageAccounts/queueServices/queues/read",
       "service": "Microsoft.Storage",
-      "action": "Get",
+      "action": "NewListPager",
       "source_file": "storage_extras.go"
     },
     {
@@ -1299,7 +1299,7 @@
     {
       "permission": "Microsoft.Web/sites/read",
       "service": "Microsoft.Web",
-      "action": "NewListPager",
+      "action": "NewListFunctionsPager",
       "source_file": "functions.go"
     },
     {

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -1244,20 +1244,10 @@ func (a *mqlAzureSubscriptionNetworkService) applicationSecurityGroups() ([]any,
 			return nil, err
 		}
 		for _, asg := range page.Value {
-			props, err := convert.JsonToDict(asg.Properties)
-			if err != nil {
-				return nil, err
+			if asg == nil {
+				continue
 			}
-			mqlAppSecGroup, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.appSecurityGroup",
-				map[string]*llx.RawData{
-					"id":         llx.StringDataPtr(asg.ID),
-					"name":       llx.StringDataPtr(asg.Name),
-					"type":       llx.StringDataPtr(asg.Type),
-					"location":   llx.StringDataPtr(asg.Location),
-					"tags":       llx.MapData(convert.PtrMapStrToInterface(asg.Tags), types.String),
-					"etag":       llx.StringDataPtr(asg.Etag),
-					"properties": llx.DictData(props),
-				})
+			mqlAppSecGroup, err := azureAppSecurityGroupToMql(a.MqlRuntime, *asg)
 			if err != nil {
 				return nil, err
 			}
@@ -3211,6 +3201,53 @@ func azureNatGatewayToMql(runtime *plugin.Runtime, ng network.NatGateway) (*mqlA
 	return mqlNg.(*mqlAzureSubscriptionNetworkServiceNatGateway), nil
 }
 
+func initAzureSubscriptionNetworkServiceSubnet(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	if args["id"] == nil {
+		return args, nil, nil
+	}
+	id, ok := args["id"].Value.(string)
+	if !ok || id == "" {
+		return args, nil, nil
+	}
+
+	azureId, err := ParseResourceID(id)
+	if err != nil {
+		return args, nil, nil
+	}
+	vnName, err := azureId.Component("virtualNetworks")
+	if err != nil {
+		return args, nil, nil
+	}
+	subnetName, err := azureId.Component("subnets")
+	if err != nil {
+		return args, nil, nil
+	}
+
+	conn, ok := runtime.Connection.(*connection.AzureConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
+	}
+	client, err := network.NewSubnetsClient(azureId.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := client.Get(context.Background(), azureId.ResourceGroup, vnName, subnetName, &network.SubnetsClientGetOptions{})
+	if err != nil {
+		return args, nil, nil
+	}
+
+	mqlSubnet, err := azureSubnetToMql(runtime, resp.Subnet)
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, mqlSubnet, nil
+}
+
 func azureSubnetToMql(runtime *plugin.Runtime, subnet network.Subnet) (*mqlAzureSubscriptionNetworkServiceSubnet, error) {
 	props, err := convert.JsonToDict(subnet.Properties)
 	if err != nil {
@@ -3386,6 +3423,25 @@ func (a *mqlAzureSubscriptionNetworkServiceSecurityGroup) interfaces() ([]any, e
 	return res, nil
 }
 
+func (a *mqlAzureSubscriptionNetworkServiceSecurityGroup) subnets() ([]any, error) {
+	if a.cacheProperties == nil || a.cacheProperties.Subnets == nil {
+		return []any{}, nil
+	}
+	res := []any{}
+	for _, subnet := range a.cacheProperties.Subnets {
+		if subnet == nil || subnet.ID == nil {
+			continue
+		}
+		mqlSubnet, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.subnet",
+			map[string]*llx.RawData{"id": llx.StringDataPtr(subnet.ID)})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlSubnet)
+	}
+	return res, nil
+}
+
 func (a *mqlAzureSubscriptionNetworkServiceSecurityGroup) securityRules() ([]any, error) {
 	if a.cacheProperties == nil || a.cacheProperties.SecurityRules == nil {
 		return []any{}, nil
@@ -3499,7 +3555,63 @@ func azureSecurityRuleToMql(runtime *plugin.Runtime, secRule network.SecurityRul
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlAzureSubscriptionNetworkServiceSecurityrule), nil
+	mqlRule := res.(*mqlAzureSubscriptionNetworkServiceSecurityrule)
+	mqlRule.cacheProperties = secRule.Properties
+	return mqlRule, nil
+}
+
+type mqlAzureSubscriptionNetworkServiceSecurityruleInternal struct {
+	cacheProperties *network.SecurityRulePropertiesFormat
+}
+
+func azureAppSecurityGroupToMql(runtime *plugin.Runtime, asg network.ApplicationSecurityGroup) (*mqlAzureSubscriptionNetworkServiceAppSecurityGroup, error) {
+	props, err := convert.JsonToDict(asg.Properties)
+	if err != nil {
+		return nil, err
+	}
+	res, err := CreateResource(runtime, "azure.subscription.networkService.appSecurityGroup",
+		map[string]*llx.RawData{
+			"id":         llx.StringDataPtr(asg.ID),
+			"name":       llx.StringDataPtr(asg.Name),
+			"type":       llx.StringDataPtr(asg.Type),
+			"location":   llx.StringDataPtr(asg.Location),
+			"tags":       llx.MapData(convert.PtrMapStrToInterface(asg.Tags), types.String),
+			"etag":       llx.StringDataPtr(asg.Etag),
+			"properties": llx.DictData(props),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionNetworkServiceAppSecurityGroup), nil
+}
+
+func (a *mqlAzureSubscriptionNetworkServiceSecurityrule) sourceApplicationSecurityGroups() ([]any, error) {
+	if a.cacheProperties == nil {
+		return []any{}, nil
+	}
+	return azureAsgListToMql(a.MqlRuntime, a.cacheProperties.SourceApplicationSecurityGroups)
+}
+
+func (a *mqlAzureSubscriptionNetworkServiceSecurityrule) destinationApplicationSecurityGroups() ([]any, error) {
+	if a.cacheProperties == nil {
+		return []any{}, nil
+	}
+	return azureAsgListToMql(a.MqlRuntime, a.cacheProperties.DestinationApplicationSecurityGroups)
+}
+
+func azureAsgListToMql(runtime *plugin.Runtime, asgs []*network.ApplicationSecurityGroup) ([]any, error) {
+	res := []any{}
+	for _, asg := range asgs {
+		if asg == nil {
+			continue
+		}
+		mqlAsg, err := azureAppSecurityGroupToMql(runtime, *asg)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlAsg)
+	}
+	return res, nil
 }
 
 type AzureSecurityRulePortRange struct {


### PR DESCRIPTION
## Summary

Surface two pieces of NSG / security-rule data that today are only reachable via raw \`properties\` dict spelunking:

- **\`securityGroup.subnets()\`** — typed list of subnets the NSG is attached to. The NSG API only returns subnet IDs, so resolution goes through a new \`initAzureSubscriptionNetworkServiceSubnet\` that parses the resource ID and calls \`SubnetsClient.Get\` lazily. Untouched subnets cost nothing; touched ones get full data (\`name\`, \`addressPrefix\`, \`privateEndpointNetworkPolicies\`, etc).
- **\`securityrule.sourceApplicationSecurityGroups()\` / \`destinationApplicationSecurityGroups()\`** — typed references resolving to the existing \`appSecurityGroup\` resource, sourced from the cached SDK rule properties.

Also extracted a small \`azureAppSecurityGroupToMql\` helper so the existing collection path and the new rule-side path use one code path.

## Backwards compatibility

- The existing \`interfaces()\` accessor on the NSG keeps its name and behaviour. (Earlier draft introduced a \`networkInterfaces()\` synonym for cross-cloud naming parity, but dropped — the cost/benefit didn't justify the duplicate field.)
- \`properties dict\` continues to expose the raw payload exactly as before.
- New entries at \`13.11.2\` in \`azure.lr.versions\`.
- No new IAM permissions required — the permission set is unchanged.

## Test plan

Verified live against Lunalectric subscription:

- [x] \`nsg.subnets\` resolves end-to-end: \`name: \"Security-Team-subnet-orb7\"\`, \`addressPrefix: \"10.0.1.0/24\"\` populate via the new init function (vs the bare-ID stub returned by the NSG endpoint)
- [x] Rule ASG accessors compile and run cleanly (subscription happens to have no rules using ASG refs — the filter exercises the code path, returning empty as expected)
- [x] Existing \`interfaces()\` unchanged
- [x] Existing \`applicationSecurityGroups()\` collector unchanged after refactor to shared helper
- [x] \`make providers/build/azure\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)