### PR TITLE
🐛 Fix DLP discoveryConfigs / connections / columnDataProfiles + Azure ASG name resolution

### DIFF
--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -3569,10 +3569,20 @@ func azureAppSecurityGroupToMql(runtime *plugin.Runtime, asg network.Application
 	if err != nil {
 		return nil, err
 	}
+	// When the ASG is referenced from a security rule, the Azure API returns
+	// only the ARM resource ID. Recover the name from the ID's final segment
+	// so consumers don't see name=null on otherwise-valid typed references.
+	name := asg.Name
+	if (name == nil || *name == "") && asg.ID != nil {
+		if i := strings.LastIndex(*asg.ID, "/"); i >= 0 && i+1 < len(*asg.ID) {
+			n := (*asg.ID)[i+1:]
+			name = &n
+		}
+	}
 	res, err := CreateResource(runtime, "azure.subscription.networkService.appSecurityGroup",
 		map[string]*llx.RawData{
 			"id":         llx.StringDataPtr(asg.ID),
-			"name":       llx.StringDataPtr(asg.Name),
+			"name":       llx.StringDataPtr(name),
 			"type":       llx.StringDataPtr(asg.Type),
 			"location":   llx.StringDataPtr(asg.Location),
 			"tags":       llx.MapData(convert.PtrMapStrToInterface(asg.Tags), types.String),

--- a/providers/gcp/resources/dlp.go
+++ b/providers/gcp/resources/dlp.go
@@ -389,7 +389,17 @@ func (g *mqlGcpProjectDlpService) storedInfoTypes() ([]any, error) {
 // Helpers shared by new accessors
 // ---------------------------------------------------------------
 
+// dlpDataProfilesLocation is the location that data profile listings
+// (project / table / column / file-store) aggregate to. The DLP API
+// supports "global" for project-scope data profile listings.
 const dlpDataProfilesLocation = "global"
+
+// dlpRegionalListLocations is the set of locations the DLP API supports
+// for resources that cannot live in "global" at project scope —
+// DiscoveryConfig and Connection. We query the three multi-regions and
+// skip per-location errors so a project that has resources in only one
+// of them still returns useful data.
+var dlpRegionalListLocations = []string{"us", "eu", "asia"}
 
 func dlpProtoSliceToDict[T proto.Message](items []T) ([]any, error) {
 	res := make([]any, 0, len(items))
@@ -520,55 +530,56 @@ func (g *mqlGcpProjectDlpService) discoveryConfigs() ([]any, error) {
 	}
 	defer client.Close()
 
-	it := client.ListDiscoveryConfigs(ctx, &dlppb.ListDiscoveryConfigsRequest{
-		Parent: fmt.Sprintf("projects/%s/locations/%s", projectId, dlpDataProfilesLocation),
-	})
-
 	var res []any
-	for {
-		dc, err := it.Next()
-		if errors.Is(err, iterator.Done) {
-			break
-		}
-		if err != nil {
-			if isGRPCSkippable(err) {
-				log.Warn().Err(err).Msg("could not list DLP discovery configs")
-				return nil, nil
-			}
-			return nil, err
-		}
-
-		targets, err := dlpProtoSliceToDict(dc.Targets)
-		if err != nil {
-			return nil, err
-		}
-		errs, err := dlpProtoSliceToDict(dc.Errors)
-		if err != nil {
-			return nil, err
-		}
-		actions, err := dlpProtoSliceToDict(dc.Actions)
-		if err != nil {
-			return nil, err
-		}
-		orgConfig, _ := protoToDict(dc.OrgConfig)
-
-		mqlDc, err := CreateResource(g.MqlRuntime, "gcp.project.dlpService.discoveryConfig", map[string]*llx.RawData{
-			"name":             llx.StringData(dc.Name),
-			"displayName":      llx.StringData(dc.DisplayName),
-			"status":           llx.StringData(dc.Status.String()),
-			"targets":          llx.ArrayData(targets, types.Dict),
-			"errors":           llx.ArrayData(errs, types.Dict),
-			"inspectTemplates": llx.ArrayData(stringsToAnySlice(dc.InspectTemplates), types.String),
-			"actions":          llx.ArrayData(actions, types.Dict),
-			"orgConfig":        llx.DictData(orgConfig),
-			"lastRunTime":      llx.TimeDataPtr(timestampAsTimePtr(dc.LastRunTime)),
-			"created":          llx.TimeDataPtr(timestampAsTimePtr(dc.CreateTime)),
-			"updated":          llx.TimeDataPtr(timestampAsTimePtr(dc.UpdateTime)),
+	for _, loc := range dlpRegionalListLocations {
+		it := client.ListDiscoveryConfigs(ctx, &dlppb.ListDiscoveryConfigsRequest{
+			Parent: fmt.Sprintf("projects/%s/locations/%s", projectId, loc),
 		})
-		if err != nil {
-			return nil, err
+		for {
+			dc, err := it.Next()
+			if errors.Is(err, iterator.Done) {
+				break
+			}
+			if err != nil {
+				if isGRPCSkippable(err) {
+					log.Warn().Err(err).Str("location", loc).Msg("could not list DLP discovery configs")
+					break
+				}
+				return nil, err
+			}
+
+			targets, err := dlpProtoSliceToDict(dc.Targets)
+			if err != nil {
+				return nil, err
+			}
+			errs, err := dlpProtoSliceToDict(dc.Errors)
+			if err != nil {
+				return nil, err
+			}
+			actions, err := dlpProtoSliceToDict(dc.Actions)
+			if err != nil {
+				return nil, err
+			}
+			orgConfig, _ := protoToDict(dc.OrgConfig)
+
+			mqlDc, err := CreateResource(g.MqlRuntime, "gcp.project.dlpService.discoveryConfig", map[string]*llx.RawData{
+				"name":             llx.StringData(dc.Name),
+				"displayName":      llx.StringData(dc.DisplayName),
+				"status":           llx.StringData(dc.Status.String()),
+				"targets":          llx.ArrayData(targets, types.Dict),
+				"errors":           llx.ArrayData(errs, types.Dict),
+				"inspectTemplates": llx.ArrayData(stringsToAnySlice(dc.InspectTemplates), types.String),
+				"actions":          llx.ArrayData(actions, types.Dict),
+				"orgConfig":        llx.DictData(orgConfig),
+				"lastRunTime":      llx.TimeDataPtr(timestampAsTimePtr(dc.LastRunTime)),
+				"created":          llx.TimeDataPtr(timestampAsTimePtr(dc.CreateTime)),
+				"updated":          llx.TimeDataPtr(timestampAsTimePtr(dc.UpdateTime)),
+			})
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlDc)
 		}
-		res = append(res, mqlDc)
 	}
 
 	return res, nil
@@ -612,45 +623,46 @@ func (g *mqlGcpProjectDlpService) connections() ([]any, error) {
 	}
 	defer client.Close()
 
-	it := client.ListConnections(ctx, &dlppb.ListConnectionsRequest{
-		Parent: fmt.Sprintf("projects/%s/locations/%s", projectId, dlpDataProfilesLocation),
-	})
-
 	var res []any
-	for {
-		c, err := it.Next()
-		if errors.Is(err, iterator.Done) {
-			break
-		}
-		if err != nil {
-			if isGRPCSkippable(err) {
-				log.Warn().Err(err).Msg("could not list DLP connections")
-				return nil, nil
-			}
-			return nil, err
-		}
-
-		errs, err := dlpProtoSliceToDict(c.Errors)
-		if err != nil {
-			return nil, err
-		}
-		var properties any
-		switch p := c.Properties.(type) {
-		case *dlppb.Connection_CloudSql:
-			d, _ := protoToDict(p.CloudSql)
-			properties = map[string]any{"cloudSql": d}
-		}
-
-		mqlConn, err := CreateResource(g.MqlRuntime, "gcp.project.dlpService.connection", map[string]*llx.RawData{
-			"name":       llx.StringData(c.Name),
-			"state":      llx.StringData(c.State.String()),
-			"errors":     llx.ArrayData(errs, types.Dict),
-			"properties": llx.DictData(properties),
+	for _, loc := range dlpRegionalListLocations {
+		it := client.ListConnections(ctx, &dlppb.ListConnectionsRequest{
+			Parent: fmt.Sprintf("projects/%s/locations/%s", projectId, loc),
 		})
-		if err != nil {
-			return nil, err
+		for {
+			c, err := it.Next()
+			if errors.Is(err, iterator.Done) {
+				break
+			}
+			if err != nil {
+				if isGRPCSkippable(err) {
+					log.Warn().Err(err).Str("location", loc).Msg("could not list DLP connections")
+					break
+				}
+				return nil, err
+			}
+
+			errs, err := dlpProtoSliceToDict(c.Errors)
+			if err != nil {
+				return nil, err
+			}
+			var properties any
+			switch p := c.Properties.(type) {
+			case *dlppb.Connection_CloudSql:
+				d, _ := protoToDict(p.CloudSql)
+				properties = map[string]any{"cloudSql": d}
+			}
+
+			mqlConn, err := CreateResource(g.MqlRuntime, "gcp.project.dlpService.connection", map[string]*llx.RawData{
+				"name":       llx.StringData(c.Name),
+				"state":      llx.StringData(c.State.String()),
+				"errors":     llx.ArrayData(errs, types.Dict),
+				"properties": llx.DictData(properties),
+			})
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlConn)
 		}
-		res = append(res, mqlConn)
 	}
 
 	return res, nil
@@ -880,52 +892,74 @@ func (g *mqlGcpProjectDlpService) columnDataProfiles() ([]any, error) {
 	}
 	defer client.Close()
 
-	it := client.ListColumnDataProfiles(ctx, &dlppb.ListColumnDataProfilesRequest{
-		Parent: fmt.Sprintf("projects/%s/locations/%s", projectId, dlpDataProfilesLocation),
-	})
+	// ListColumnDataProfiles requires a filter with project_id, dataset_id,
+	// and table_id; there is no project-wide list. Iterate the project's
+	// table data profiles first and gather column profiles per-table.
+	parent := fmt.Sprintf("projects/%s/locations/%s", projectId, dlpDataProfilesLocation)
+	tableIt := client.ListTableDataProfiles(ctx, &dlppb.ListTableDataProfilesRequest{Parent: parent})
 
 	var res []any
 	for {
-		c, err := it.Next()
+		t, err := tableIt.Next()
 		if errors.Is(err, iterator.Done) {
 			break
 		}
 		if err != nil {
 			if isGRPCSkippable(err) {
-				log.Warn().Err(err).Msg("could not list DLP column data profiles")
+				log.Warn().Err(err).Msg("could not list DLP table data profiles for column profile enumeration")
 				return nil, nil
 			}
 			return nil, err
 		}
 
-		sensitivity, _ := protoToDict(c.SensitivityScore)
-		riskLevel, _ := protoToDict(c.DataRiskLevel)
-		columnInfoType, _ := protoToDict(c.ColumnInfoType)
-		otherMatches, err := dlpProtoSliceToDict(c.OtherMatches)
-		if err != nil {
-			return nil, err
-		}
-
-		mqlC, err := CreateResource(g.MqlRuntime, "gcp.project.dlpService.columnDataProfile", map[string]*llx.RawData{
-			"name":                 llx.StringData(c.Name),
-			"column":               llx.StringData(c.Column),
-			"datasetId":            llx.StringData(c.DatasetId),
-			"tableId":              llx.StringData(c.TableId),
-			"tableFullResource":    llx.StringData(c.TableFullResource),
-			"state":                llx.StringData(c.State.String()),
-			"sensitivityScore":     llx.DictData(sensitivity),
-			"dataRiskLevel":        llx.DictData(riskLevel),
-			"columnInfoType":       llx.DictData(columnInfoType),
-			"otherMatches":         llx.ArrayData(otherMatches, types.Dict),
-			"freeTextScore":        llx.FloatData(c.FreeTextScore),
-			"columnType":           llx.StringData(c.ColumnType.String()),
-			"policyState":          llx.StringData(c.PolicyState.String()),
-			"profileLastGenerated": llx.TimeDataPtr(timestampAsTimePtr(c.ProfileLastGenerated)),
+		filter := fmt.Sprintf("table_id=\"%s\" AND dataset_id=\"%s\" AND project_id=\"%s\"",
+			t.TableId, t.DatasetId, t.DatasetProjectId)
+		colIt := client.ListColumnDataProfiles(ctx, &dlppb.ListColumnDataProfilesRequest{
+			Parent: parent,
+			Filter: filter,
 		})
-		if err != nil {
-			return nil, err
+		for {
+			c, err := colIt.Next()
+			if errors.Is(err, iterator.Done) {
+				break
+			}
+			if err != nil {
+				if isGRPCSkippable(err) {
+					log.Warn().Err(err).Str("table", t.TableId).Msg("could not list DLP column data profiles")
+					break
+				}
+				return nil, err
+			}
+
+			sensitivity, _ := protoToDict(c.SensitivityScore)
+			riskLevel, _ := protoToDict(c.DataRiskLevel)
+			columnInfoType, _ := protoToDict(c.ColumnInfoType)
+			otherMatches, err := dlpProtoSliceToDict(c.OtherMatches)
+			if err != nil {
+				return nil, err
+			}
+
+			mqlC, err := CreateResource(g.MqlRuntime, "gcp.project.dlpService.columnDataProfile", map[string]*llx.RawData{
+				"name":                 llx.StringData(c.Name),
+				"column":               llx.StringData(c.Column),
+				"datasetId":            llx.StringData(c.DatasetId),
+				"tableId":              llx.StringData(c.TableId),
+				"tableFullResource":    llx.StringData(c.TableFullResource),
+				"state":                llx.StringData(c.State.String()),
+				"sensitivityScore":     llx.DictData(sensitivity),
+				"dataRiskLevel":        llx.DictData(riskLevel),
+				"columnInfoType":       llx.DictData(columnInfoType),
+				"otherMatches":         llx.ArrayData(otherMatches, types.Dict),
+				"freeTextScore":        llx.FloatData(c.FreeTextScore),
+				"columnType":           llx.StringData(c.ColumnType.String()),
+				"policyState":          llx.StringData(c.PolicyState.String()),
+				"profileLastGenerated": llx.TimeDataPtr(timestampAsTimePtr(c.ProfileLastGenerated)),
+			})
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlC)
 		}
-		res = append(res, mqlC)
 	}
 
 	return res, nil

--- a/providers/gcp/resources/dlp.go
+++ b/providers/gcp/resources/dlp.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	dlp "cloud.google.com/go/dlp/apiv2"
 	"cloud.google.com/go/dlp/apiv2/dlppb"
@@ -397,9 +398,29 @@ const dlpDataProfilesLocation = "global"
 // dlpRegionalListLocations is the set of locations the DLP API supports
 // for resources that cannot live in "global" at project scope —
 // DiscoveryConfig and Connection. We query the three multi-regions and
-// skip per-location errors so a project that has resources in only one
-// of them still returns useful data.
+// skip per-location errors so a project that has resources in any of
+// them still returns useful data.
+//
+// Limitation: DLP also supports ~40 single-region locations
+// (us-central1, europe-west1, asia-southeast1, ...). DiscoveryConfigs
+// and Connections pinned to a specific region (rather than the
+// containing multi-region) are *not* returned here. The DLP API does
+// not expose a `locations.list` for client SDKs, so iterating every
+// known region would multiply the listing cost by ~40x for every
+// query — an unacceptable trade-off when the vast majority of
+// customers use the multi-regions. If single-region coverage is
+// needed, expand this list or add a connection-level location
+// configuration.
 var dlpRegionalListLocations = []string{"us", "eu", "asia"}
+
+// dlpFilterEscape escapes characters that would break a double-quoted
+// DLP list-filter string. The DLP filter grammar treats `\"` as a
+// literal double quote inside a quoted value, so escaping `"` is enough
+// for the identifiers we interpolate (BigQuery project / dataset /
+// table IDs).
+func dlpFilterEscape(s string) string {
+	return strings.ReplaceAll(s, `"`, `\"`)
+}
 
 func dlpProtoSliceToDict[T proto.Message](items []T) ([]any, error) {
 	res := make([]any, 0, len(items))
@@ -895,6 +916,8 @@ func (g *mqlGcpProjectDlpService) columnDataProfiles() ([]any, error) {
 	// ListColumnDataProfiles requires a filter with project_id, dataset_id,
 	// and table_id; there is no project-wide list. Iterate the project's
 	// table data profiles first and gather column profiles per-table.
+	// This is O(tables) API calls — slow on projects with many profiled
+	// tables — but it is the only path the API exposes for this collection.
 	parent := fmt.Sprintf("projects/%s/locations/%s", projectId, dlpDataProfilesLocation)
 	tableIt := client.ListTableDataProfiles(ctx, &dlppb.ListTableDataProfilesRequest{Parent: parent})
 
@@ -912,8 +935,11 @@ func (g *mqlGcpProjectDlpService) columnDataProfiles() ([]any, error) {
 			return nil, err
 		}
 
-		filter := fmt.Sprintf("table_id=\"%s\" AND dataset_id=\"%s\" AND project_id=\"%s\"",
-			t.TableId, t.DatasetId, t.DatasetProjectId)
+		// Escape embedded double quotes so a BigQuery identifier containing
+		// a literal `"` (rare but legal in some characters) can't break out
+		// of the filter expression.
+		filter := fmt.Sprintf(`table_id="%s" AND dataset_id="%s" AND project_id="%s"`,
+			dlpFilterEscape(t.TableId), dlpFilterEscape(t.DatasetId), dlpFilterEscape(t.DatasetProjectId))
 		colIt := client.ListColumnDataProfiles(ctx, &dlppb.ListColumnDataProfilesRequest{
 			Parent: parent,
 			Filter: filter,


### PR DESCRIPTION
## Summary

Two fixes uncovered while interactively testing the recent `35a577..HEAD` provider PRs against live AWS / Azure / GCP / OCI test infrastructure.

### `🐛 gcp: fix DLP discoveryConfigs / connections / columnDataProfiles listings` (d06a1c07d)

- `discoveryConfigs` and `connections` were listed at `projects/{id}/locations/global`. The DLP API rejects project-scope discovery configs in `global` (terraform: *"All discovery configurations must be in the same non global location."*), so the call **silently returned empty for every project**. Iterate the `us` / `eu` / `asia` multi-regions and skip per-location errors so a project that has resources in any of them returns useful data.
- `columnDataProfiles` called `ListColumnDataProfiles` with no filter; the API requires `project_id` / `dataset_id` / `table_id` and rejected the call with `InvalidArgument: Filter must have at least project_id, dataset_id, and table_id set but none was set.` Iterate `tableDataProfiles` first and enumerate column profiles per-table using the proper filter string.

### `🐛 azure: derive ASG name from ID when security rule reference omits it` (cc094d531)

When a network security rule references an application security group, the Azure REST response returns only the ARM resource ID — not the name. Building the typed reference with `llx.StringDataPtr(asg.Name)` produced `name=null` on every otherwise-valid `sourceApplicationSecurityGroups` / `destinationApplicationSecurityGroups` entry. Recover the name from the ID's final segment.

## Test plan

- [x] `gcp.project.dlp.discoveryConfigs` returns the configured discovery config (verified against a test `locations/us` config)
- [x] `gcp.project.dlp.columnDataProfiles` returns 0 cleanly when no profiles exist (no more `InvalidArgument` crash)
- [x] `gcp.project.dlp.connections` returns 0 cleanly (was empty before fix anyway, but now uses the right parents)
- [x] `azure.subscription.network.securityGroups[*].securityRules[*].sourceApplicationSecurityGroups[*].name` returns the ASG name (was `null` before fix)
- [x] `azure.subscription.network.securityGroups[*].securityRules[*].destinationApplicationSecurityGroups[*].name` returns the ASG name
- [x] `make providers/build/gcp providers/install/gcp` clean
- [x] `make providers/build/azure providers/install/azure` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)