### PR TITLE
🎉 aws-13.25.0, gcp-13.15.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.24.0",
+	Version:         "13.25.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.14.1",
+	Version: "13.15.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### aws (13.25.0)
- ✨ aws: close cnspec runtime gaps (#7678 part 1) (#7685)
- ✨ aws: surface SG rule descriptions and typed prefix lists (#7677)

### gcp (13.15.0)
- 🐛 Fix DLP discoveryConfigs / connections / columnDataProfiles + Azure ASG name resolution (#7686)
- ✨ gcp: typed match fields on firewallPolicy.rule (#7681)
- ✨ gcp: complete Cloud DLP / Sensitive Data Protection coverage (#7672)