### PR TITLE
Handle journald config drop-ins

### DIFF
--- a/providers/os/resources/journald.go
+++ b/providers/os/resources/journald.go
@@ -12,8 +12,10 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/spf13/afero"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
 	"go.mondoo.com/mql/v13/providers/os/resources/parsers"
 	"go.mondoo.com/mql/v13/types"
 	"go.mondoo.com/mql/v13/utils/multierr"
@@ -46,6 +48,12 @@ func initJournaldConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 
 const defaultJournaldConfig = "/etc/systemd/journald.conf"
 
+type journaldConfigSection struct {
+	name       string
+	params     map[string]string
+	paramOrder []string
+}
+
 func (s *mqlJournaldConfig) id() (string, error) {
 	file := s.GetFile()
 	if file.Error != nil {
@@ -74,20 +82,9 @@ func (s *mqlJournaldConfig) parse(file *mqlFile) error {
 		return errors.New("no base journald config file to read")
 	}
 
-	content, err := fileRequiredContent(file)
+	files, err := s.configFiles(file)
 	if err != nil {
 		return err
-	}
-
-	unit, err := parsers.ParseUnit(content)
-	if err != nil {
-		return fmt.Errorf("failed to parse journald config: %w", err)
-	}
-
-	if len(unit.Sections) == 0 {
-		s.Sections.Data = []any{}
-		s.Sections.State = plugin.StateIsSet
-		return nil
 	}
 
 	filePath := file.GetPath()
@@ -95,27 +92,40 @@ func (s *mqlJournaldConfig) parse(file *mqlFile) error {
 		return filePath.Error
 	}
 
+	sections := map[string]*journaldConfigSection{}
+	sectionOrder := []string{}
+
+	for _, configFile := range files {
+		content, err := fileRequiredContent(configFile)
+		if err != nil {
+			return err
+		}
+
+		unit, err := parsers.ParseUnit(content)
+		if err != nil {
+			return fmt.Errorf("failed to parse journald config: %w", err)
+		}
+
+		mergeJournaldConfig(unit, sections, &sectionOrder)
+	}
+
 	var errs multierr.Errors
 	sectionResources := []any{}
 
-	for i, unitSection := range unit.Sections {
-		sectionID := fmt.Sprintf("%s/%s/%d", filePath.Data, unitSection.Name, i)
+	for i, sectionName := range sectionOrder {
+		sectionData := sections[sectionName]
+		sectionID := fmt.Sprintf("%s/%s/%d", filePath.Data, sectionData.name, i)
 		paramResources := []any{}
 
-		for j, unitParam := range unitSection.Params {
-			val := unitParam.Value
-			if slices.Contains(journaldDowncaseKeywords, unitParam.Name) {
-				val = strings.ToLower(val)
-			}
-
-			paramID := fmt.Sprintf("%s/%s/%d", sectionID, unitParam.Name, j)
+		for j, paramName := range sectionData.paramOrder {
+			paramID := fmt.Sprintf("%s/%s/%d", sectionID, paramName, j)
 			param, err := CreateResource(s.MqlRuntime, ResourceJournaldConfigSectionParam, map[string]*llx.RawData{
 				"__id":  llx.StringData(paramID),
-				"name":  llx.StringData(unitParam.Name),
-				"value": llx.StringData(val),
+				"name":  llx.StringData(paramName),
+				"value": llx.StringData(sectionData.params[paramName]),
 			})
 			if err != nil {
-				errs.Add(fmt.Errorf("failed to create param resource for '%s' in section '%s': %w", unitParam.Name, unitSection.Name, err))
+				errs.Add(fmt.Errorf("failed to create param resource for '%s' in section '%s': %w", paramName, sectionData.name, err))
 				continue
 			}
 			paramResources = append(paramResources, param)
@@ -123,11 +133,11 @@ func (s *mqlJournaldConfig) parse(file *mqlFile) error {
 
 		section, err := CreateResource(s.MqlRuntime, ResourceJournaldConfigSection, map[string]*llx.RawData{
 			"__id":   llx.StringData(sectionID),
-			"name":   llx.StringData(unitSection.Name),
+			"name":   llx.StringData(sectionData.name),
 			"params": llx.ArrayData(paramResources, types.Resource(ResourceJournaldConfigSectionParam)),
 		})
 		if err != nil {
-			errs.Add(fmt.Errorf("failed to create section resource for '%s': %w", unitSection.Name, err))
+			errs.Add(fmt.Errorf("failed to create section resource for '%s': %w", sectionData.name, err))
 			continue
 		}
 
@@ -138,6 +148,60 @@ func (s *mqlJournaldConfig) parse(file *mqlFile) error {
 	s.Sections.State = plugin.StateIsSet
 	s.Sections.Error = errs.Deduplicate()
 	return s.Sections.Error
+}
+
+func (s *mqlJournaldConfig) configFiles(file *mqlFile) ([]*mqlFile, error) {
+	filePath := file.GetPath()
+	if filePath.Error != nil {
+		return nil, filePath.Error
+	}
+
+	files := []*mqlFile{file}
+	conn, ok := s.MqlRuntime.Connection.(shared.Connection)
+	if !ok {
+		return files, nil
+	}
+
+	matches, err := afero.Glob(conn.FileSystem(), filePath.Data+".d/*.conf")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, match := range matches {
+		dropinFile, err := newFile(s.MqlRuntime, match)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, dropinFile)
+	}
+
+	return files, nil
+}
+
+func mergeJournaldConfig(unit *parsers.Unit, sections map[string]*journaldConfigSection, sectionOrder *[]string) {
+	for _, unitSection := range unit.Sections {
+		sectionData, ok := sections[unitSection.Name]
+		if !ok {
+			sectionData = &journaldConfigSection{
+				name:   unitSection.Name,
+				params: map[string]string{},
+			}
+			sections[unitSection.Name] = sectionData
+			*sectionOrder = append(*sectionOrder, unitSection.Name)
+		}
+
+		for _, unitParam := range unitSection.Params {
+			val := unitParam.Value
+			if slices.Contains(journaldDowncaseKeywords, unitParam.Name) {
+				val = strings.ToLower(val)
+			}
+
+			if _, ok := sectionData.params[unitParam.Name]; !ok {
+				sectionData.paramOrder = append(sectionData.paramOrder, unitParam.Name)
+			}
+			sectionData.params[unitParam.Name] = val
+		}
+	}
 }
 
 // returns the sections of the journald config, eg [Journal], [Upload], etc

--- a/providers/os/resources/journald_internal_test.go
+++ b/providers/os/resources/journald_internal_test.go
@@ -1,0 +1,120 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/connection/mock"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+func TestJournaldConfigIncludesDropins(t *testing.T) {
+	runtime := journaldMockRuntime(t, map[string]*mock.MockFileData{
+		"/etc/systemd/journald.conf": {
+			StatData: mock.FileInfo{Mode: 0o644},
+			Content: `[Journal]
+Storage=persistent
+Compress=Yes
+ForwardToSyslog=no
+
+[Upload]
+URL=http://base.example.test
+`,
+		},
+		"/etc/systemd/journald.conf.d": {
+			StatData: mock.FileInfo{Mode: os.ModeDir | 0o755, IsDir: true},
+		},
+		"/etc/systemd/journald.conf.d/10-forward.conf": {
+			StatData: mock.FileInfo{Mode: 0o644},
+			Content: `[Journal]
+ForwardToSyslog=YES
+Compress=NO
+`,
+		},
+		"/etc/systemd/journald.conf.d/20-upload.conf": {
+			StatData: mock.FileInfo{Mode: 0o644},
+			Content: `[Upload]
+URL=https://dropin.example.test
+`,
+		},
+	})
+
+	raw, err := CreateResource(runtime, ResourceJournaldConfig, nil)
+	require.NoError(t, err)
+
+	config := raw.(*mqlJournaldConfig)
+	sections := config.GetSections()
+	require.NoError(t, sections.Error)
+
+	requireJournaldParam(t, sections.Data, "Journal", "Storage", "persistent")
+	requireJournaldParam(t, sections.Data, "Journal", "ForwardToSyslog", "yes")
+	requireJournaldParam(t, sections.Data, "Journal", "Compress", "no")
+	requireJournaldParam(t, sections.Data, "Upload", "URL", "https://dropin.example.test")
+
+	params := config.GetParams()
+	require.NoError(t, params.Error)
+	require.Equal(t, "yes", params.Data["ForwardToSyslog"])
+}
+
+func journaldMockRuntime(t *testing.T, files map[string]*mock.MockFileData) *plugin.Runtime {
+	t.Helper()
+
+	for path, file := range files {
+		file.Path = path
+	}
+
+	asset := &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:    "linux",
+			Family:  []string{"linux", "unix", "os"},
+			Version: "test",
+		},
+	}
+	conn, err := mock.New(0, asset, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{},
+		Files:    files,
+	}))
+	require.NoError(t, err)
+
+	return &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+}
+
+func requireJournaldParam(t *testing.T, sections []any, sectionName, paramName, expected string) {
+	t.Helper()
+
+	for _, sectionAny := range sections {
+		section := sectionAny.(*mqlJournaldConfigSection)
+		name := section.GetName()
+		require.NoError(t, name.Error)
+		if name.Data != sectionName {
+			continue
+		}
+
+		params := section.GetParams()
+		require.NoError(t, params.Error)
+		for _, paramAny := range params.Data {
+			param := paramAny.(*mqlJournaldConfigSectionParam)
+			name := param.GetName()
+			require.NoError(t, name.Error)
+			if name.Data != paramName {
+				continue
+			}
+
+			value := param.GetValue()
+			require.NoError(t, value.Error)
+			require.Equal(t, expected, value.Data)
+			return
+		}
+	}
+
+	require.Failf(t, "journald parameter not found", "%s.%s", sectionName, paramName)
+}


### PR DESCRIPTION
## Summary

- Include `journald.conf.d/*.conf` drop-ins when evaluating `journald.config`
- Merge repeated sections and parameters so later drop-ins override earlier values
- Add coverage for drop-in precedence and the deprecated `params` compatibility map

Fixes #7688

## Testing

```console
env GOCACHE=/tmp/mql-gocache go test ./providers/os/resources -run Journald -count=1
env GOCACHE=/tmp/mql-gocache go test ./providers/os/resources -count=1
/home/syl/go/bin/mql run local -c 'journald.config("/tmp/mql-journald-test/etc/systemd/journald.conf").sections.where(name == "Journal").first.params.where(name == "ForwardToSyslog").first.value == "yes"' --json
```
