### PR TITLE
🐛 detector: append "os" to Family in WindowsFamily.Resolve shortcut

### DIFF
--- a/providers/os/detector/detector.go
+++ b/providers/os/detector/detector.go
@@ -5,6 +5,7 @@ package detector
 
 import (
 	"runtime"
+	"slices"
 
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
@@ -15,6 +16,17 @@ func DetectOS(conn shared.Connection) (*inventory.Platform, bool) {
 	var ok bool
 	if conn.Type() == shared.Type_Local && runtime.GOOS == "windows" {
 		res, ok = WindowsFamily.Resolve(conn)
+		// WindowsFamily.Resolve stops one level short of the OperatingSystems
+		// wrapper, so the Family chain ends at "windows" instead of
+		// ["windows", "os"]. Downstream consumers treat `family` containing
+		// "os" as the "asset has installed software" marker; without this
+		// append, the local-Windows shortcut diverges from the equivalent
+		// OperatingSystems.Resolve path (which the rest of the cases — and
+		// the TestWindows* mocks — go through) and produces a different
+		// Family chain. Append "os" explicitly so the shortcut matches.
+		if ok && res != nil && !slices.Contains(res.Family, OperatingSystems.Name) {
+			res.Family = append(res.Family, OperatingSystems.Name)
+		}
 	} else {
 		res, ok = OperatingSystems.Resolve(conn)
 	}


### PR DESCRIPTION
## Summary

- `DetectOS` keeps its existing shortcut for local Windows connections (resolves `WindowsFamily` directly, skipping the no-op `unixFamily` detection branch).
- That shortcut stops one level short of the `OperatingSystems` wrapper and never appends `"os"` to the platform Family chain — production local-Windows scans produced `Family: ["windows"]` while existing `TestWindows*` cases use `OperatingSystems.Resolve(mockConn)` and assert `["windows", "os"]`, so the test suite never caught the production-only divergence.
- Downstream consumers treat `family` containing `"os"` as the "asset has installed software" marker, so the missing suffix caused scanned Windows assets to behave differently from Linux/macOS assets despite having populated package data.
- Fix: keep the shortcut, but after `WindowsFamily.Resolve` succeeds, explicitly append `OperatingSystems.Name` (`"os"`) to Family if it's not already there — matching what the full `OperatingSystems.Resolve` traversal would have produced.

## Test plan

- [x] `go build ./providers/os/detector/...`
- [x] `go test ./providers/os/detector/...` — existing `TestWindows*` assertions on `Family: ["windows", "os"]` still pass; the new branch is reached only on local-Windows connections, which the unit tests use mock connections for and exercise via `OperatingSystems.Resolve`
- [ ] Validate on a real local-Windows `cnspec scan` (the case that took the shortcut) and confirm `asset.platform.family` now ends in `"os"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)