### PR TITLE
🐛 hotpatch: refuse Pro / Home editions on client product-type

### DIFF
--- a/providers/os/detector/windows/hotpatch.go
+++ b/providers/os/detector/windows/hotpatch.go
@@ -47,18 +47,26 @@ func ParseWinRegistryClientHotpatch(r io.Reader) (bool, error) {
 	return hotpatch.AllowRebootlessUpdates == "1" && hotpatch.EnableVirtualizationBasedSecurity == "1", nil
 }
 
-// hotpatchSupported checks whether the given platform meets the minimum build
-// requirements for hotpatching:
+// hotpatchSupported checks whether the given platform meets the prerequisites
+// for hotpatching:
 //   - Windows Server 2022+ (build 20348+, product-type "2" or "3")
-//   - Windows 11 Enterprise 24H2+ (product-type "1"):
+//   - Windows 11 Enterprise / Education 24H2+ (product-type "1"):
 //   - x64 (AMD64/Intel): build 26100.2033+
 //   - arm64: build 26100.4929+
 //
-// Windows 11 client hotpatch requires architecture-specific minimum UBR
-// (Update Build Revision) values on build 26100. Without this check, devices
-// with AllowRebootlessUpdates set via policy but below the prerequisite build
-// would be falsely detected as hotpatch-enrolled.
-// See https://learn.microsoft.com/en-us/windows/client-management/hotpatch
+// Client hotpatch is license-gated, not just build-gated: the eligible SKUs
+// (Windows 11 Enterprise E3/E5, Education A3/A5, M365 F3, M365 Business Premium,
+// Windows 365 Enterprise) all activate Windows 11 Enterprise or Education on
+// the device. A Pro / Home / Pro Education box can never receive hotpatches
+// even when AllowRebootlessUpdates + VBS are set in the registry — a config
+// that can leak in via a misapplied GPO/Intune policy. Without the edition
+// guard we falsely tag those assets `hotpatch=true` and hotpatch-only KBs
+// surface as findings (real example: KB5089466 on a Win11 Pro AMD64 box).
+//
+// References:
+//   - https://learn.microsoft.com/en-us/intune/device-updates/windows/hotpatch (eligible license list, 2026-04-29)
+//   - https://learn.microsoft.com/en-us/windows/deployment/windows-autopatch/manage/windows-autopatch-hotpatch-updates (Autopatch eligibility, 2026-03-06)
+//   - https://learn.microsoft.com/en-us/windows/client-management/hotpatch (technical preconditions: build, UBR, VBS, ARM64 CHPE)
 func hotpatchSupported(pf *inventory.Platform) bool {
 	buildNumber, err := strconv.Atoi(pf.Version)
 	if err != nil {
@@ -70,6 +78,10 @@ func hotpatchSupported(pf *inventory.Platform) bool {
 	productType := pf.Labels["windows.mondoo.com/product-type"]
 	switch productType {
 	case "1": // Workstation (Windows client)
+		if !isHotpatchEligibleClientEdition(pf.Title) {
+			log.Debug().Str("title", pf.Title).Msg("windows client edition is not hotpatch-eligible")
+			return false
+		}
 		if buildNumber > 26100 {
 			return true
 		}
@@ -92,6 +104,29 @@ func hotpatchSupported(pf *inventory.Platform) bool {
 	default:
 		return false
 	}
+}
+
+// isHotpatchEligibleClientEdition reports whether `title` (the human-readable
+// Windows edition string from platform detection, e.g. "Windows 11 Enterprise"
+// or "Windows 11 Pro") corresponds to a SKU that can receive client hotpatches.
+//
+// Eligibility is license-gated per Microsoft Intune docs (2026-04-29) but every
+// eligible license activates Enterprise or Education on the device. The edition
+// string is the closest runtime signal we can read without inspecting tenant
+// licensing. Empty Title → refuse, since we can't tell what's running and
+// hotpatch is the failure-mode-with-false-positives direction.
+//
+// "Pro Education" is a distinct SKU in the Pro family (not Education A3/A5) so
+// it's rejected explicitly before the broader "education" substring match.
+func isHotpatchEligibleClientEdition(title string) bool {
+	t := strings.ToLower(title)
+	if t == "" {
+		return false
+	}
+	if strings.Contains(t, "pro education") {
+		return false
+	}
+	return strings.Contains(t, "enterprise") || strings.Contains(t, "education")
 }
 
 type WindowsHotpatch struct {

--- a/providers/os/detector/windows/hotpatch_test.go
+++ b/providers/os/detector/windows/hotpatch_test.go
@@ -123,6 +123,7 @@ func TestParseWinRegistryClientHotpatch(t *testing.T) {
 func TestHotpatchSupported(t *testing.T) {
 	t.Run("client amd64 build 26100 with sufficient UBR", func(t *testing.T) {
 		pf := &inventory.Platform{
+			Title:   "Windows 11 Enterprise",
 			Version: "26100",
 			Build:   "5000",
 			Arch:    "AMD64",
@@ -133,6 +134,7 @@ func TestHotpatchSupported(t *testing.T) {
 
 	t.Run("client amd64 build 26100 with exact minimum UBR", func(t *testing.T) {
 		pf := &inventory.Platform{
+			Title:   "Windows 11 Enterprise",
 			Version: "26100",
 			Build:   "2033",
 			Arch:    "AMD64",
@@ -143,6 +145,7 @@ func TestHotpatchSupported(t *testing.T) {
 
 	t.Run("client amd64 build 26100 with UBR below minimum", func(t *testing.T) {
 		pf := &inventory.Platform{
+			Title:   "Windows 11 Enterprise",
 			Version: "26100",
 			Build:   "2000",
 			Arch:    "AMD64",
@@ -153,6 +156,7 @@ func TestHotpatchSupported(t *testing.T) {
 
 	t.Run("client arm64 build 26100 with sufficient UBR", func(t *testing.T) {
 		pf := &inventory.Platform{
+			Title:   "Windows 11 Enterprise",
 			Version: "26100",
 			Build:   "5000",
 			Arch:    "ARM64",
@@ -163,6 +167,7 @@ func TestHotpatchSupported(t *testing.T) {
 
 	t.Run("client arm64 build 26100 with exact minimum UBR", func(t *testing.T) {
 		pf := &inventory.Platform{
+			Title:   "Windows 11 Enterprise",
 			Version: "26100",
 			Build:   "4929",
 			Arch:    "ARM64",
@@ -173,6 +178,7 @@ func TestHotpatchSupported(t *testing.T) {
 
 	t.Run("client arm64 build 26100 with UBR below arm64 minimum", func(t *testing.T) {
 		pf := &inventory.Platform{
+			Title:   "Windows 11 Enterprise",
 			Version: "26100",
 			Build:   "3775",
 			Arch:    "ARM64",
@@ -183,6 +189,7 @@ func TestHotpatchSupported(t *testing.T) {
 
 	t.Run("client build 26100 with empty UBR", func(t *testing.T) {
 		pf := &inventory.Platform{
+			Title:   "Windows 11 Enterprise",
 			Version: "26100",
 			Build:   "",
 			Labels:  map[string]string{"windows.mondoo.com/product-type": "1"},
@@ -192,6 +199,7 @@ func TestHotpatchSupported(t *testing.T) {
 
 	t.Run("client build above 26100 always supported", func(t *testing.T) {
 		pf := &inventory.Platform{
+			Title:   "Windows 11 Enterprise",
 			Version: "27000",
 			Build:   "100",
 			Labels:  map[string]string{"windows.mondoo.com/product-type": "1"},
@@ -201,6 +209,7 @@ func TestHotpatchSupported(t *testing.T) {
 
 	t.Run("client build 22000 not supported", func(t *testing.T) {
 		pf := &inventory.Platform{
+			Title:   "Windows 11 Enterprise",
 			Version: "22000",
 			Labels:  map[string]string{"windows.mondoo.com/product-type": "1"},
 		}
@@ -222,4 +231,126 @@ func TestHotpatchSupported(t *testing.T) {
 		}
 		assert.False(t, hotpatchSupported(pf))
 	})
+
+	// Edition guard: Pro / Home / Pro Education boxes can never receive
+	// hotpatches even when the build and UBR meet the prerequisites — no
+	// Microsoft license activates hotpatching while the OS reports as Pro
+	// or Home. KB Ranger flagged a real Win11 Pro AMD64 26200.8246 asset
+	// for KB5089466 because the registry signals were set but the edition
+	// makes it ineligible.
+
+	t.Run("client Pro 26200 with high UBR rejected by edition guard", func(t *testing.T) {
+		pf := &inventory.Platform{
+			Title:   "Windows 11 Pro",
+			Version: "26200",
+			Build:   "8246",
+			Arch:    "AMD64",
+			Labels:  map[string]string{"windows.mondoo.com/product-type": "1"},
+		}
+		assert.False(t, hotpatchSupported(pf))
+	})
+
+	t.Run("client Pro for Workstations rejected by edition guard", func(t *testing.T) {
+		pf := &inventory.Platform{
+			Title:   "Windows 11 Pro for Workstations",
+			Version: "27000",
+			Arch:    "AMD64",
+			Labels:  map[string]string{"windows.mondoo.com/product-type": "1"},
+		}
+		assert.False(t, hotpatchSupported(pf))
+	})
+
+	t.Run("client Home rejected by edition guard", func(t *testing.T) {
+		pf := &inventory.Platform{
+			Title:   "Windows 11 Home",
+			Version: "27000",
+			Arch:    "AMD64",
+			Labels:  map[string]string{"windows.mondoo.com/product-type": "1"},
+		}
+		assert.False(t, hotpatchSupported(pf))
+	})
+
+	t.Run("client Pro Education rejected by edition guard", func(t *testing.T) {
+		// Pro Education is in the Pro family (Win Edu A1 license), distinct
+		// from the Education A3/A5 SKUs that the hotpatch license list
+		// covers. Must be rejected before the broader "education" match.
+		pf := &inventory.Platform{
+			Title:   "Windows 11 Pro Education",
+			Version: "27000",
+			Arch:    "AMD64",
+			Labels:  map[string]string{"windows.mondoo.com/product-type": "1"},
+		}
+		assert.False(t, hotpatchSupported(pf))
+	})
+
+	t.Run("client Education accepted", func(t *testing.T) {
+		pf := &inventory.Platform{
+			Title:   "Windows 11 Education",
+			Version: "27000",
+			Arch:    "AMD64",
+			Labels:  map[string]string{"windows.mondoo.com/product-type": "1"},
+		}
+		assert.True(t, hotpatchSupported(pf))
+	})
+
+	t.Run("client IoT Enterprise accepted", func(t *testing.T) {
+		pf := &inventory.Platform{
+			Title:   "Windows 11 IoT Enterprise",
+			Version: "27000",
+			Arch:    "AMD64",
+			Labels:  map[string]string{"windows.mondoo.com/product-type": "1"},
+		}
+		assert.True(t, hotpatchSupported(pf))
+	})
+
+	t.Run("client Enterprise multi-session accepted", func(t *testing.T) {
+		// Cloud PC / Win365 Enterprise multi-session SKU is in the eligible
+		// license list and reports an "Enterprise multi-session" title.
+		pf := &inventory.Platform{
+			Title:   "Windows 11 Enterprise multi-session",
+			Version: "27000",
+			Arch:    "AMD64",
+			Labels:  map[string]string{"windows.mondoo.com/product-type": "1"},
+		}
+		assert.True(t, hotpatchSupported(pf))
+	})
+
+	t.Run("client empty title rejected", func(t *testing.T) {
+		// Missing Title means we can't tell what's running. Hotpatch eligibility
+		// must default to refuse — failing open here surfaces hotpatch-only
+		// KBs on every asset whose detection didn't fill Title.
+		pf := &inventory.Platform{
+			Title:   "",
+			Version: "27000",
+			Arch:    "AMD64",
+			Labels:  map[string]string{"windows.mondoo.com/product-type": "1"},
+		}
+		assert.False(t, hotpatchSupported(pf))
+	})
+}
+
+func TestIsHotpatchEligibleClientEdition(t *testing.T) {
+	cases := []struct {
+		title    string
+		eligible bool
+	}{
+		{"Windows 11 Enterprise", true},
+		{"Windows 11 Enterprise Evaluation", true},
+		{"Windows 11 Enterprise multi-session", true},
+		{"Windows 11 IoT Enterprise", true},
+		{"Windows 11 Education", true},
+		{"WINDOWS 11 ENTERPRISE", true}, // case-insensitive
+		{"Windows 11 Pro", false},
+		{"Windows 11 Pro for Workstations", false},
+		{"Windows 11 Pro Education", false}, // Pro family, not Education A3/A5
+		{"Windows 11 Home", false},
+		{"Windows 11 Home Single Language", false},
+		{"Windows 11 SE", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.title, func(t *testing.T) {
+			assert.Equal(t, tc.eligible, isHotpatchEligibleClientEdition(tc.title))
+		})
+	}
 }


### PR DESCRIPTION
## Summary

`hotpatchSupported` (Windows client branch) checked build + UBR + arch but not the OS **edition**. Combined with `powershellGetWindowsClientHotpatch` reading `AllowRebootlessUpdates` + VBS, a Pro or Home box where those registry keys happen to be set (a misapplied GPO/Intune policy is enough) was being tagged `windows.mondoo.com/hotpatch=true`. Downstream, the server-side filter then surfaced hotpatch-only KBs as findings on assets that can never actually receive them. Concrete recent example: **KB5089466** (May 2026 hotpatch) flagged on a Win11 Pro AMD64 26200.8246 asset.

## Microsoft's eligibility rule (license-gated, not just edition-gated)

Per the 2026-04-29 [Intune Hotpatch doc](https://learn.microsoft.com/en-us/intune/device-updates/windows/hotpatch), client hotpatching requires one of:

- Windows 11 Enterprise E3 / E5
- Windows 11 Education A3 / A5
- Microsoft 365 F3
- Microsoft 365 Business Premium
- Windows 365 Enterprise

Every entry in that list either IS an Enterprise/Education license outright or includes a Windows 11 Enterprise activation entitlement (M365 F3, M365 Business Premium, Win365 Enterprise all step the device's reported edition up to Enterprise on activation). A device whose runtime Title still says "Windows 11 Pro" hasn't activated any of those entitlements, so it can't be hotpatched in that state — independent of what the registry says.

The runtime edition string is the closest signal we can read without tenant-level license inspection.

## What changes

- `hotpatchSupported`: for product-type=1 (workstation) it now consults `isHotpatchEligibleClientEdition(pf.Title)` BEFORE the build/UBR/arch checks. Server-product-type behavior is unchanged.
- `isHotpatchEligibleClientEdition`: case-insensitive substring match on Title for "enterprise" or "education", with "pro education" explicitly rejected (it's in the Pro family with Win Edu A1 licensing, not the Education A3/A5 SKU). Empty Title → reject; failing-open here would re-introduce the false-positive class for any platform fingerprint that didn't fill Title.

## Test plan

- [x] `go test ./providers/os/detector/windows/ -run 'TestHotpatchSupported|TestIsHotpatchEligibleClientEdition' -count=1`: clean
- [x] `go vet` + `go fmt`: clean
- [x] Existing tests retrofitted with `Title: "Windows 11 Enterprise"` so the prior "supported" assertions still hold.
- [x] New cases: Pro / Pro for Workstations / Pro Education / Home / Home Single Language / SE / empty → false. Enterprise / Enterprise Evaluation / Enterprise multi-session / IoT Enterprise / Education → true.
- [ ] After merge: confirm next KB Ranger run no longer flags KB5089466 on the Win11 Pro AMD64 asset (`pc-office-002`).

## References

- [Use Hotpatch With Windows Quality Updates - Microsoft Intune](https://learn.microsoft.com/en-us/intune/device-updates/windows/hotpatch) (2026-04-29 — canonical eligible-license list)
- [Hotpatch updates - Windows Autopatch](https://learn.microsoft.com/en-us/windows/deployment/windows-autopatch/manage/windows-autopatch-hotpatch-updates) (2026-03-06)
- [Hotpatch for Windows clients - client management](https://learn.microsoft.com/en-us/windows/client-management/hotpatch) (technical preconditions: build, UBR, VBS, ARM64 CHPE)
- [Hotpatch for Windows client now available - Windows IT Pro Blog](https://techcommunity.microsoft.com/blog/Windows-ITPro-blog/hotpatch-for-windows-client-now-available/4399808)

🤖 Generated with [Claude Code](https://claude.com/claude-code)