### PR TITLE
✨ vscode.extension: emit purl per package-url spec

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -9098,6 +9098,12 @@ private vscode.extension @defaults("editor name version") {
   vscodeVersion string
   // Extension categories
   categories []string
+  // Package URL
+  //
+  // Package URL identifying the extension in the form
+  // pkg:vscode-extension/<publisher>/<name>@<version>, per
+  // https://github.com/package-url/purl-spec/blob/main/types-doc/vscode-extension-definition.md
+  purl() string
 }
 
 // logrotate configuration

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -10319,6 +10319,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"vscode.extension.categories": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVscodeExtension).GetCategories()).ToDataRes(types.Array(types.String))
 	},
+	"vscode.extension.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVscodeExtension).GetPurl()).ToDataRes(types.String)
+	},
 	"logrotate.files": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlLogrotate).GetFiles()).ToDataRes(types.Array(types.Resource("file")))
 	},
@@ -23734,6 +23737,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"vscode.extension.categories": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlVscodeExtension).Categories, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"vscode.extension.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVscodeExtension).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"logrotate.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -62253,6 +62260,7 @@ type mqlVscodeExtension struct {
 	Path          plugin.TValue[string]
 	VscodeVersion plugin.TValue[string]
 	Categories    plugin.TValue[[]any]
+	Purl          plugin.TValue[string]
 }
 
 // createVscodeExtension creates a new instance of this resource
@@ -62330,6 +62338,12 @@ func (c *mqlVscodeExtension) GetVscodeVersion() *plugin.TValue[string] {
 
 func (c *mqlVscodeExtension) GetCategories() *plugin.TValue[[]any] {
 	return &c.Categories
+}
+
+func (c *mqlVscodeExtension) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
+	})
 }
 
 // mqlLogrotate for the logrotate resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -2714,6 +2714,7 @@ vscode.extension.identifier 11.4.86
 vscode.extension.name 11.4.86
 vscode.extension.path 11.4.86
 vscode.extension.publisher 11.4.86
+vscode.extension.purl 13.31.1
 vscode.extension.version 11.4.86
 vscode.extension.vscodeVersion 11.4.86
 vscode.extensions 11.4.86

--- a/providers/os/resources/vscode.go
+++ b/providers/os/resources/vscode.go
@@ -10,12 +10,29 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/package-url/packageurl-go"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
 	"go.mondoo.com/mql/v13/types"
 )
+
+// newVscodeExtensionPurl builds a vscode-extension PURL per the purl-spec
+// definition at:
+//
+//	https://github.com/package-url/purl-spec/blob/main/types-doc/vscode-extension-definition.md
+//
+// Format: pkg:vscode-extension/<publisher>/<name>@<version>
+// Empty publisher / name / version yields an empty string — callers that
+// pass incomplete extension metadata get no PURL rather than a malformed one.
+func newVscodeExtensionPurl(publisher, name, version string) string {
+	if publisher == "" || name == "" {
+		return ""
+	}
+	return packageurl.NewPackageURL("vscode-extension", publisher, name, version, nil, "").String()
+}
 
 // vsCodeEditor represents a VS Code-based editor with its extension directory
 type vsCodeEditor struct {
@@ -218,6 +235,7 @@ func (c *mqlVscode) extensions() ([]any, error) {
 					"path":          llx.StringData(extPath),
 					"vscodeVersion": llx.StringData(pkgJSON.Engines.VSCode),
 					"categories":    llx.ArrayData(categories, types.String),
+					"purl":          llx.StringData(newVscodeExtensionPurl(pkgJSON.Publisher, pkgJSON.Name, pkgJSON.Version)),
 				})
 				if err != nil {
 					log.Debug().Err(err).Str("extension", identifier).Msg("failed to create VS Code extension resource")
@@ -233,6 +251,16 @@ func (c *mqlVscode) extensions() ([]any, error) {
 
 func (e *mqlVscodeExtension) id() (string, error) {
 	return e.Identifier.Data + "|" + e.Path.Data, nil
+}
+
+// purl is populated eagerly in the vscode.extensions() enumerator from
+// the extension's package.json publisher/name/version. The stub satisfies
+// the generated lazy-init contract; if for any reason a caller constructs
+// a vscode.extension without going through the enumerator (e.g. tests),
+// returning the empty string keeps the field non-nil rather than panicking.
+func (e *mqlVscodeExtension) purl() (string, error) {
+	e.Purl = plugin.TValue[string]{State: plugin.StateIsSet, Data: newVscodeExtensionPurl(e.Publisher.Data, e.Name.Data, e.Version.Data)}
+	return e.Purl.Data, nil
 }
 
 // readVSCodePackageJSON reads and parses a VS Code extension package.json file

--- a/providers/os/resources/vscode_test.go
+++ b/providers/os/resources/vscode_test.go
@@ -1,0 +1,63 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewVscodeExtensionPurl(t *testing.T) {
+	cases := []struct {
+		name      string
+		publisher string
+		extName   string
+		version   string
+		want      string
+	}{
+		{
+			name:      "Roo Code (real marketplace extension)",
+			publisher: "RooVeterinaryInc",
+			extName:   "roo-cline",
+			version:   "3.34.7",
+			want:      "pkg:vscode-extension/RooVeterinaryInc/roo-cline@3.34.7",
+		},
+		{
+			name:      "Microsoft Python (well-known prebuilt extension)",
+			publisher: "ms-python",
+			extName:   "python",
+			version:   "2026.6.0",
+			want:      "pkg:vscode-extension/ms-python/python@2026.6.0",
+		},
+		{
+			name:      "version omitted (unknown / dev build)",
+			publisher: "golang",
+			extName:   "go",
+			version:   "",
+			want:      "pkg:vscode-extension/golang/go",
+		},
+		{
+			name:      "empty publisher (incomplete metadata) yields empty PURL",
+			publisher: "",
+			extName:   "go",
+			version:   "0.50.0",
+			want:      "",
+		},
+		{
+			name:      "empty name (incomplete metadata) yields empty PURL",
+			publisher: "golang",
+			extName:   "",
+			version:   "0.50.0",
+			want:      "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := newVscodeExtensionPurl(tc.publisher, tc.extName, tc.version)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Adds a `purl` field to the `vscode.extension` resource so installed VS Code extensions (and Cursor / Windsurf / Kiro / VSCodium / Antigravity / Positron extensions, which the resource also enumerates) flow through PURL-based downstream tooling — MVD catalog routing for CVE matching, SBOM generation, vuln matching.

## Format

Follows the canonical package-url spec at [`types-doc/vscode-extension-definition.md`](https://github.com/package-url/purl-spec/blob/main/types-doc/vscode-extension-definition.md):

```
pkg:vscode-extension/<publisher>/<name>@<version>
```

Examples produced by the new field:

```
pkg:vscode-extension/RooVeterinaryInc/roo-cline@3.34.7
pkg:vscode-extension/ms-python/python@2026.6.0
pkg:vscode-extension/golang/go@0.50.0
```

## Implementation notes

- **Eager population.** The `extensions()` enumerator already reads the extension's `package.json` publisher/name/version, so the PURL is computed at resource construction time. The lazy-init stub is provided for the rare case where a `vscode.extension` is constructed outside the enumerator (e.g. tests).
- **Defensive on incomplete metadata.** If either publisher or name is empty, the helper returns an empty string rather than building a malformed PURL (which would round-trip incorrectly through `packageurl-go`'s parser).
- **No new dependencies.** Uses `packageurl-go` which is already vendored.

## Test plan

- [x] `TestNewVscodeExtensionPurl` — 5 cases covering Roo Code, Microsoft Python (real marketplace extensions), missing version, and the two incomplete-metadata edge cases.
- [x] `go build ./providers/os/...` clean
- [x] `go vet ./providers/os/resources/` clean
- [x] `./lr go providers/os/resources/os.lr --dist providers/os/dist` regenerated `os.lr.go` cleanly with the new `Purl plugin.TValue[string]` field and the generated `GetPurl()` getter

## Downstream / motivation

Server-side catalog routing currently can't match vulnerabilities against VS Code extensions because there's no PURL to key against — even though the extension data is fully available via `vscode.extensions.where(...)`. This change closes that gap so the existing PURL-based MVD pipeline picks up extension findings without further plumbing.

The first downstream consumer is the Roo Code product catalog entry (which has 11 CVEs in MITRE under `RooCodeInc/Roo-Code`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)