### PR TITLE
🐛 gcp: fix Composer/Healthcare location listing and App Engine version handlers

### DIFF
--- a/providers/gcp/resources/appengine.go
+++ b/providers/gcp/resources/appengine.go
@@ -151,7 +151,9 @@ func (g *mqlGcpProjectAppEngineServiceService) versions() ([]any, error) {
 
 	ctx := context.Background()
 	var res []any
-	req := svc.Apps.Services.Versions.List(projectId, serviceId)
+	// The FULL view is required for the response to include handlers,
+	// libraries, and other detail omitted by the default BASIC view.
+	req := svc.Apps.Services.Versions.List(projectId, serviceId).View("FULL")
 	if err := req.Pages(ctx, func(page *appengine.ListVersionsResponse) error {
 		for _, v := range page.Versions {
 			vpcConnector, err := appEngineConvertVpcConnector(v.VpcAccessConnector)

--- a/providers/gcp/resources/composer.go
+++ b/providers/gcp/resources/composer.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
@@ -119,11 +118,13 @@ func (g *mqlGcpProjectComposerService) environments() ([]any, error) {
 			return nil
 		}); err != nil {
 			if composerServiceDisabled(err) {
-				// The Cloud Composer API is not enabled for the project.
+				// The Cloud Composer API is not enabled for the project; it
+				// is disabled project-wide, so no other region would succeed.
 				return []any{}, nil
 			}
-			log.Debug().Err(err).Str("region", region.Name).Msg("gcp: could not list Cloud Composer environments")
-			continue
+			// Surface transient or server-side errors instead of silently
+			// dropping this region's environments from the result set.
+			return nil, err
 		}
 	}
 

--- a/providers/gcp/resources/composer.go
+++ b/providers/gcp/resources/composer.go
@@ -8,11 +8,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
 	"go.mondoo.com/mql/v13/types"
 	"google.golang.org/api/composer/v1"
+	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 )
@@ -70,44 +72,59 @@ func (g *mqlGcpProjectComposerService) environments() ([]any, error) {
 		return nil, err
 	}
 
-	var res []any
-	// Cloud Composer environments are regional; "-" lists across all locations.
-	parent := fmt.Sprintf("projects/%s/locations/-", projectId)
-	req := svc.Projects.Locations.Environments.List(parent)
-	if err := req.Pages(ctx, func(page *composer.ListEnvironmentsResponse) error {
-		for _, e := range page.Environments {
-			cfg, err := convert.JsonToDict(e.Config)
-			if err != nil {
-				return err
-			}
-
-			var imageVersion string
-			if e.Config != nil && e.Config.SoftwareConfig != nil {
-				imageVersion = e.Config.SoftwareConfig.ImageVersion
-			}
-
-			mqlEnv, err := CreateResource(g.MqlRuntime, "gcp.project.composerService.environment", map[string]*llx.RawData{
-				"projectId":    llx.StringData(projectId),
-				"name":         llx.StringData(e.Name),
-				"state":        llx.StringData(e.State),
-				"uuid":         llx.StringData(e.Uuid),
-				"createTime":   llx.TimeDataPtr(parseTime(e.CreateTime)),
-				"updateTime":   llx.TimeDataPtr(parseTime(e.UpdateTime)),
-				"labels":       llx.MapData(convert.MapToInterfaceMap(e.Labels), types.String),
-				"imageVersion": llx.StringData(imageVersion),
-				"config":       llx.DictData(cfg),
-			})
-			if err != nil {
-				return err
-			}
-			res = append(res, mqlEnv)
-		}
-		return nil
-	}); err != nil {
-		if composerServiceDisabled(err) {
-			return []any{}, nil
-		}
+	// Cloud Composer environments are regional and the environments.list API
+	// rejects the "-" location wildcard, so enumerate the project's regions
+	// and list environments in each.
+	computeSvc, err := compute.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
 		return nil, err
+	}
+	regions, err := computeSvc.Regions.List(projectId).Do()
+	if err != nil {
+		return nil, err
+	}
+
+	var res []any
+	for _, region := range regions.Items {
+		parent := fmt.Sprintf("projects/%s/locations/%s", projectId, region.Name)
+		req := svc.Projects.Locations.Environments.List(parent)
+		if err := req.Pages(ctx, func(page *composer.ListEnvironmentsResponse) error {
+			for _, e := range page.Environments {
+				cfg, err := convert.JsonToDict(e.Config)
+				if err != nil {
+					return err
+				}
+
+				var imageVersion string
+				if e.Config != nil && e.Config.SoftwareConfig != nil {
+					imageVersion = e.Config.SoftwareConfig.ImageVersion
+				}
+
+				mqlEnv, err := CreateResource(g.MqlRuntime, "gcp.project.composerService.environment", map[string]*llx.RawData{
+					"projectId":    llx.StringData(projectId),
+					"name":         llx.StringData(e.Name),
+					"state":        llx.StringData(e.State),
+					"uuid":         llx.StringData(e.Uuid),
+					"createTime":   llx.TimeDataPtr(parseTime(e.CreateTime)),
+					"updateTime":   llx.TimeDataPtr(parseTime(e.UpdateTime)),
+					"labels":       llx.MapData(convert.MapToInterfaceMap(e.Labels), types.String),
+					"imageVersion": llx.StringData(imageVersion),
+					"config":       llx.DictData(cfg),
+				})
+				if err != nil {
+					return err
+				}
+				res = append(res, mqlEnv)
+			}
+			return nil
+		}); err != nil {
+			if composerServiceDisabled(err) {
+				// The Cloud Composer API is not enabled for the project.
+				return []any{}, nil
+			}
+			log.Debug().Err(err).Str("region", region.Name).Msg("gcp: could not list Cloud Composer environments")
+			continue
+		}
 	}
 
 	return res, nil

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
   "version": "13.15.0",
-  "generated_at": "2026-05-16T09:49:14-07:00",
+  "generated_at": "2026-05-16T11:29:47-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.customJobs.list",
@@ -717,6 +717,12 @@
       "service": "compute",
       "action": "Regions.List",
       "source_file": "cloudrun.go"
+    },
+    {
+      "permission": "compute.regions.list",
+      "service": "compute",
+      "action": "Regions.List",
+      "source_file": "composer.go"
     },
     {
       "permission": "compute.regions.list",

--- a/providers/gcp/resources/healthcare.go
+++ b/providers/gcp/resources/healthcare.go
@@ -72,25 +72,37 @@ func (g *mqlGcpProjectHealthcareService) datasets() ([]any, error) {
 
 	ctx := context.Background()
 	var res []any
-	parent := fmt.Sprintf("projects/%s/locations/-", projectId)
-	req := svc.Projects.Locations.Datasets.List(parent)
-	if err := req.Pages(ctx, func(page *healthcare.ListDatasetsResponse) error {
-		for _, d := range page.Datasets {
-			encryptionSpec, err := healthcareConvertEncryptionSpec(d.EncryptionSpec)
-			if err != nil {
-				return err
-			}
+	// The datasets.list API rejects the "-" location wildcard, so enumerate
+	// the project's healthcare locations and list datasets in each.
+	if err := svc.Projects.Locations.List("projects/"+projectId).Pages(ctx, func(locPage *healthcare.ListLocationsResponse) error {
+		for _, loc := range locPage.Locations {
+			parent := fmt.Sprintf("projects/%s/locations/%s", projectId, loc.LocationId)
+			listErr := svc.Projects.Locations.Datasets.List(parent).Pages(ctx, func(page *healthcare.ListDatasetsResponse) error {
+				for _, d := range page.Datasets {
+					encryptionSpec, err := healthcareConvertEncryptionSpec(d.EncryptionSpec)
+					if err != nil {
+						return err
+					}
 
-			mqlDataset, err := CreateResource(g.MqlRuntime, "gcp.project.healthcareService.dataset", map[string]*llx.RawData{
-				"projectId":      llx.StringData(projectId),
-				"name":           llx.StringData(d.Name),
-				"timeZone":       llx.StringData(d.TimeZone),
-				"encryptionSpec": llx.DictData(encryptionSpec),
+					mqlDataset, err := CreateResource(g.MqlRuntime, "gcp.project.healthcareService.dataset", map[string]*llx.RawData{
+						"projectId":      llx.StringData(projectId),
+						"name":           llx.StringData(d.Name),
+						"timeZone":       llx.StringData(d.TimeZone),
+						"encryptionSpec": llx.DictData(encryptionSpec),
+					})
+					if err != nil {
+						return err
+					}
+					res = append(res, mqlDataset)
+				}
+				return nil
 			})
-			if err != nil {
-				return err
+			if listErr != nil {
+				if healthcareServiceUnavailable(listErr) {
+					continue
+				}
+				return listErr
 			}
-			res = append(res, mqlDataset)
 		}
 		return nil
 	}); err != nil {


### PR DESCRIPTION
## Summary

Three GCP resource accessors added/modified in recent PRs (#7703, #7705) returned **errors** or **empty data** when run against real GCP projects. Found while verifying those PRs against live infrastructure.

| Resource | Bug | Fix |
|----------|-----|-----|
| `gcp.project.composerService.environments()` | Listed with `projects/{p}/locations/-`; the Cloud Composer API rejects the `-` wildcard (`INVALID_ARGUMENT: Unexpected location: -`) — the accessor errored for **every** project | Enumerate Compute Engine regions, list environments per region (same pattern as the Cloud Run resource) |
| `gcp.project.healthcareService.datasets()` | Same `locations/-` bug; Cloud Healthcare API returns `400: location ID invalid` | Enumerate healthcare locations via `Projects.Locations.List`, list datasets per location (covers multi-region datasets too) |
| `gcp.project.appEngineService.version.handlers` | `Versions.List` uses the default `BASIC` view, which omits `handlers` — the field was always empty | Request the `FULL` view |

## Verification

Built the provider and ran each accessor against a live project with real infrastructure:

- **Composer** — `environments()` returns the environment (`state`, `imageVersion`, `labels`, …)
- **Healthcare** — `datasets()` returns the dataset plus its DICOM / FHIR (R4) / HL7v2 stores
- **App Engine** — `version.handlers` is now populated (URL handlers with `securityLevel`, `login`, `staticFiles`, …)

All three previously errored or returned empty.

## Notes

- No `.lr` schema change — pure accessor logic. No `.lr.versions` change.
- `gcp.permissions.json` regenerated: adds a `compute.regions.list` source-file entry for `composer.go` (the permission itself was already required by `cloudrun.go`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)