### PR TITLE
🧹 Release aws, azure, gcp, oci providers (minor bump)

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.25.0",
+	Version:         "13.26.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "azure",
 	ID:      "go.mondoo.com/cnquery/v9/providers/azure",
-	Version: "13.11.2",
+	Version: "13.12.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(azureinstancesnapshot.SnapshotConnectionType),

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.15.0",
+	Version: "13.16.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),

--- a/providers/oci/config/config.go
+++ b/providers/oci/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "oci",
 	ID:              "go.mondoo.com/cnquery/v9/providers/oci",
-	Version:         "13.5.5",
+	Version:         "13.6.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
## Summary

Minor version bump on the four providers that received new resource and field coverage in recent PRs (#7674, #7680, #7684, #7686, #7694, #7696, #7701, #7703, #7704, #7705).

| Provider | Old | New |
|----------|-----|-----|
| aws | 13.25.0 | 13.26.0 |
| azure | 13.11.2 | 13.12.0 |
| gcp | 13.15.0 | 13.16.0 |
| oci | 13.5.5 | 13.6.0 |

Only `providers/<name>/config/config.go` `Version` fields change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)