### PR TITLE
✨ skills: add provider-verification skill

### DIFF
--- a/.claude/skills/provider-verification/SKILL.md
+++ b/.claude/skills/provider-verification/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: provider-verification
+description: >-
+  Verify mql provider resource/field changes against real cloud infrastructure.
+  Given a pull request or a commit range, this provisions Terraform infra in the
+  affected cloud(s), runs mql queries against every new or changed resource and
+  field, reports the hourly cost (pausing for approval above $2/hr), opens a fix
+  PR for any provider bugs it uncovers, and tears the infrastructure back down.
+  Use this whenever someone wants to test, verify, smoke-test, or "prove out" a
+  provider PR or a range of commits against live cloud APIs — e.g. "verify PR
+  #7701 works", "spin up infra to test the new GCP resources", "check the azure
+  changes against real infrastructure", "test resources changed between these
+  commits". Trigger it even when the user only says "test this PR" in the
+  context of an mql provider change.
+---
+
+# Provider Verification
+
+mql resources are thin wrappers over cloud APIs, so a `.lr` schema change is
+only really "done" once it has been run against a real cloud account. This
+skill automates that loop: figure out what changed, stand up just enough real
+infrastructure to exercise it, query it with `mql run`, and clean up.
+
+It exists because the failure modes that matter — a wrong location wildcard, a
+missing API view, an SDK that lags the service — are invisible to compile
+checks and unit tests. They only show up against live APIs.
+
+## Inputs
+
+One of:
+- **A pull request**: a number (`7701`) or URL. Diff comes from `gh pr diff`.
+- **A commit range**: `<base>..<head>` (e.g. `7bfc8787a..HEAD`). Diff comes from
+  `git diff`.
+
+Accept multiple PRs at once — verify them together in one infra spin-up.
+
+## Workflow
+
+Work through these steps in order. Track them with TodoWrite — the run is long
+and the teardown step must not be skipped.
+
+### 1. Extract what changed
+
+Run the bundled script — it parses the diff and lists every added/changed
+resource and field, grouped by provider:
+
+```bash
+python3 .claude/skills/provider-verification/extract_changes.py --pr 7701
+python3 .claude/skills/provider-verification/extract_changes.py --range A..B
+```
+
+It reports `.lr` schema changes (new resources, new fields) and flags the
+provider `.go` files that changed. A PR can touch a provider's code without
+touching its `.lr` (a pure bugfix); still verify those resources.
+
+Doc-comment-only `.lr` changes (a PR that just adds doc-comments to existing
+resources) do not need infrastructure — skip them, but say so in the report.
+
+### 2. Build the affected providers
+
+The merged PR code must be running locally. From the repo root:
+
+```bash
+make providers/build/<provider> && make providers/install/<provider>
+```
+
+Build every affected provider. If the PRs are **not** yet merged, check out the
+PR branch first. If verifying a commit range, check out the head commit.
+
+### 3. Check cloud auth
+
+For each affected cloud, confirm credentials before provisioning anything:
+`aws sts get-caller-identity`, `az account show`, `gcloud config get-value
+project`, `oci iam region list`. If a cloud is not authenticated, stop and tell
+the user — do not try to provision it.
+
+### 4. Generate Terraform
+
+Goal: the **cheapest** real resources that make each changed field return
+non-empty, non-error data. Smallest SKUs, smallest instances, free tiers where
+they exist.
+
+Read `references/cloud-notes.md` before writing any Terraform — it lists the
+per-cloud gotchas (SKUs that no longer exist, APIs that need a quota project,
+resources Terraform cannot create) that this process has already hit. It will
+save you a failed `apply`.
+
+Write Terraform into a scratch directory **outside the repo** (e.g.
+`~/dev/mql-verify-<timestamp>/<cloud>/`), one stack per cloud. When more than
+one cloud is involved, dispatch one subagent per cloud to write its stack in
+parallel — each agent writes the `.tf`, runs `terraform init/validate/plan`,
+and reports a per-resource hourly cost. Agents must not `apply`.
+
+Tag every resource with `project = mql-pr-verify` so leftovers are findable.
+
+### 5. Cost gate
+
+Sum the 1-hour cost across every cloud's `terraform plan`. Present a per-resource
+cost table and the total.
+
+- **Total ≤ $2/hour**: state the cost and proceed.
+- **Total > $2/hour**: STOP. Show the table and ask the user to approve before
+  applying. Do not apply until they say yes.
+
+### 6. Apply
+
+`terraform apply -auto-approve` per cloud — run them in parallel in the
+background; some resources are slow (see cloud-notes). Re-apply on transient
+failures. If a resource genuinely cannot be created, remove it from the stack,
+note it, and continue — one bad resource must not block the rest.
+
+### 7. Verify with `mql run`
+
+For **every** new or changed resource and field, run a query and confirm two
+things: it returns **no error**, and it returns **appropriate data**.
+
+```bash
+mql run <provider> -c "<resource> { <changed fields> }"
+```
+
+- A new field that resolves to `false`/`""`/`[]` is fine **if** that genuinely
+  reflects the resource's state (feature disabled, list empty). It is **not**
+  fine if the field should have data — that is a bug.
+- A query that errors, or `no data available` caused by an underlying API
+  error, is a bug. Capture the exact error.
+- Typed reference fields (`vpc()`, `kinesisStream()`, …) must resolve to the
+  referenced resource, not error.
+
+For resources Terraform cannot provision (ephemeral jobs, etc.), create them
+best-effort via the cloud CLI (see cloud-notes) so the accessor still gets
+exercised. If even that is impossible, verify the accessor resolves cleanly
+(empty, no error) and say so.
+
+### 8. Triage bugs
+
+A bug is any verification failure caused by **provider code**, including
+pre-existing bugs in code outside the PRs under test. For each:
+
+- **Has a clear, verifiable fix**: fix it (see step 9).
+- **No confident fix** (e.g. an SDK lagging a new API): do **not** guess a fix.
+  Record it in the report and offer to open a tracking GitHub issue.
+
+A failure caused by the cloud account (expired trial, missing quota, un-enabled
+API) is **not** a provider bug — report it as an environment limitation.
+
+### 9. Fix PR
+
+If there are bugs with verifiable fixes, open **one combined PR** for all of
+them, across every provider:
+
+1. Work in a worktree branched from `main`.
+2. Apply the fixes. Match existing patterns in the provider (see CLAUDE.md).
+3. `gofmt -w` changed files; rebuild the provider; **re-run the failing
+   queries against the still-live infrastructure** to confirm each fix works.
+4. Commit `*.permissions.json` if a fix changed it. No `.lr.versions` change
+   unless a fix adds a schema field.
+5. Commit (emoji-prefixed per CLAUDE.md — `🐛`), push, `gh pr create`.
+
+Verify fixes **before** teardown — the infrastructure is needed to prove them.
+
+### 10. Teardown — always
+
+Always destroy every stack at the end, even on failure, even when bugs were
+found (the fix PR was already verified in step 9). Run `terraform destroy` per
+cloud.
+
+Destroy is fragile — handle the known failure modes in cloud-notes (orphaned
+EFS mount targets blocking AWS subnets, OCI API circuit-breakers, resources
+Terraform dropped from state). Fall back to CLI deletion when `terraform
+destroy` cannot finish. Confirm nothing tagged `mql-pr-verify` remains.
+
+Note anything that genuinely cannot be deleted (e.g. an App Engine app) in the
+report — do not leave the user guessing.
+
+### 11. Report
+
+Always end with this structure:
+
+```
+# Verification report — <PRs / commit range>
+
+## Provisioned
+<per-cloud resource count + total $/hour for the run>
+
+## Results
+| PR / area | Resource / field | Result | Detail |
+(✅ pass / ⚠️ partial / ❌ bug, one row per changed resource or field group)
+
+## Bugs
+<each bug: file:line, the failing query, observed vs expected, and either
+"fixed in PR #NNNN" or "no verified fix — offer to open an issue">
+
+## Environment limitations
+<failures caused by the account, not the code>
+
+## Teardown
+<confirmation everything was destroyed; anything that could not be>
+```
+
+After the report, if there are unfixable bugs, offer to open a tracking issue.
+
+## Key rules
+
+- **Cost gate is $2/hour total.** Below it, proceed. Above it, pause for
+  approval. Always show the number.
+- **One combined fix PR** for all bugs, regardless of how many providers.
+- **Always tear down** — unconditionally, at the end.
+- **Cheapest infra that works.** This is a verification run, not a deployment.
+- **Honest reporting.** An empty result is a pass only when empty is correct;
+  otherwise it is a bug. Never claim a field works without seeing real data.
+
+## Reference
+
+- `references/cloud-notes.md` — per-cloud Terraform/CLI gotchas, slow resources,
+  and what cannot be provisioned or destroyed. Read it before steps 4, 6, 10.
+- `extract_changes.py` — diff → changed resources/fields, grouped by provider.

--- a/.claude/skills/provider-verification/SKILL.md
+++ b/.claude/skills/provider-verification/SKILL.md
@@ -106,8 +106,11 @@ cost table and the total.
 
 `terraform apply -auto-approve` per cloud — run them in parallel in the
 background; some resources are slow (see cloud-notes). Re-apply on transient
-failures. If a resource genuinely cannot be created, remove it from the stack,
-note it, and continue — one bad resource must not block the rest.
+failures, but cap it at **2–3 attempts** — a failure that survives that many
+re-applies is not transient. Treat it as a blocker or an environment
+limitation and stop retrying. If a resource genuinely cannot be created,
+remove it from the stack, note it, and continue — one bad resource must not
+block the rest.
 
 ### 7. Verify with `mql run`
 
@@ -134,7 +137,7 @@ exercised. If even that is impossible, verify the accessor resolves cleanly
 ### 8. Triage bugs
 
 A bug is any verification failure caused by **provider code**, including
-pre-existing bugs in code outside the PRs under test. For each:
+preexisting bugs in code outside the PRs under test. For each:
 
 - **Has a clear, verifiable fix**: fix it (see step 9).
 - **No confident fix** (e.g. an SDK lagging a new API): do **not** guess a fix.

--- a/.claude/skills/provider-verification/extract_changes.py
+++ b/.claude/skills/provider-verification/extract_changes.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+"""Extract changed mql provider resources and fields from a PR or commit range.
+
+Parses the unified diff of a pull request (via `gh pr diff`) or a commit range
+(via `git diff`) and reports, grouped by provider:
+
+  * `.lr` schema changes  - added/modified resource blocks and fields, which is
+                            what needs real infrastructure to verify;
+  * provider `.go` files  - changed implementation files (a PR can change
+                            behaviour without touching the `.lr` schema).
+
+This is the deterministic first step of the provider-verification skill: it
+turns a diff into a concrete checklist of what to provision and query.
+
+Usage:
+    extract_changes.py --pr 7701
+    extract_changes.py --pr 7701 --pr 7705        # several PRs at once
+    extract_changes.py --range 7bfc8787a..HEAD
+    extract_changes.py --json                     # machine-readable output
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections import defaultdict
+
+# A diff file header: "diff --git a/<path> b/<path>".
+FILE_RE = re.compile(r"^diff --git a/(\S+) b/(\S+)")
+# A hunk header; the trailing text is the enclosing context (often the resource).
+HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@(.*)$")
+# Path of a provider resource file: providers/<provider>/resources/<file>.
+PROVIDER_PATH_RE = re.compile(r"providers/([^/]+)/resources/")
+# A resource declaration line, e.g. "oci.dataSafe {" or
+# "private azure.x.y @defaults(\"...\") {". Resource names are dotted idents.
+RESOURCE_RE = re.compile(r"^(?:private\s+)?([a-zA-Z][\w.]*)\b.*\{\s*$")
+# The enclosing resource named in a hunk's "@@ ... @@" context line. git
+# truncates that line, so unlike RESOURCE_RE this does not require a "{".
+CONTEXT_RE = re.compile(r"^(?:private\s+)?([a-zA-Z][\w.]+)")
+# A field declaration line: "name type", "name() type", "name @maturity(..) t".
+FIELD_RE = re.compile(r"^([a-zA-Z]\w*)(\(\))?\s+\S")
+
+
+def run(cmd: list[str]) -> str:
+    """Run a command and return stdout, exiting with its stderr on failure."""
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        sys.exit(f"command failed: {' '.join(cmd)}\n{result.stderr.strip()}")
+    return result.stdout
+
+
+def get_diff(prs: list[str], commit_range: str | None) -> str:
+    """Collect the combined unified diff for the given PRs and/or range."""
+    chunks: list[str] = []
+    for pr in prs:
+        chunks.append(run(["gh", "pr", "diff", pr, "--repo", "mondoohq/mql"]))
+    if commit_range:
+        chunks.append(run(["git", "diff", commit_range]))
+    return "\n".join(chunks)
+
+
+def is_lr_schema(path: str) -> bool:
+    """True for a `.lr` schema file (not generated `.lr.go` / `.lr.versions`)."""
+    return path.endswith(".lr")
+
+
+def is_provider_go(path: str) -> bool:
+    """True for a hand-written provider `.go` file (not generated `.lr.go`)."""
+    return (
+        path.endswith(".go")
+        and not path.endswith(".lr.go")
+        and "/resources/" in path
+        and not path.endswith("_test.go")
+    )
+
+
+def parse(diff: str) -> dict:
+    """Walk the diff and bucket schema/code changes by provider."""
+    # provider -> {"resources": {name: [fields]}, "go_files": set, "lr_files": set}
+    out: dict[str, dict] = defaultdict(
+        lambda: {"resources": defaultdict(list), "go_files": set(), "lr_files": set()}
+    )
+
+    path = provider = None
+    in_lr = False
+    current_resource = None
+
+    for line in diff.splitlines():
+        header = FILE_RE.match(line)
+        if header:
+            path = header.group(2)
+            m = PROVIDER_PATH_RE.search(path)
+            provider = m.group(1) if m else None
+            in_lr = bool(provider) and is_lr_schema(path)
+            current_resource = None
+            if provider and is_provider_go(path):
+                out[provider]["go_files"].add(path)
+            if in_lr:
+                out[provider]["lr_files"].add(path)
+            continue
+
+        if not in_lr or provider is None:
+            continue
+
+        hunk = HUNK_RE.match(line)
+        if hunk:
+            # The context after "@@" names the enclosing resource - this is how
+            # fields added to an *existing* resource get attributed (the
+            # resource's own header line is unchanged, so it never appears as
+            # an added line).
+            ctx = CONTEXT_RE.match(hunk.group(1).strip())
+            current_resource = ctx.group(1) if ctx else None
+            continue
+
+        # Only added lines (new schema). Skip the "+++" file marker.
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        body = line[1:].strip()
+        if not body or body.startswith("//") or body in ("{", "}"):
+            continue
+
+        res = RESOURCE_RE.match(body)
+        if res:
+            current_resource = res.group(1)
+            # Record the resource even if no new fields follow (new resource).
+            out[provider]["resources"].setdefault(current_resource, [])
+            continue
+
+        field = FIELD_RE.match(body)
+        if field and current_resource:
+            name = field.group(1) + (field.group(2) or "")
+            fields = out[provider]["resources"][current_resource]
+            if name not in fields:
+                fields.append(name)
+
+    return out
+
+
+def to_plain(parsed: dict) -> dict:
+    """Convert defaultdicts/sets into plain JSON-serialisable structures."""
+    return {
+        provider: {
+            "resources": {r: f for r, f in data["resources"].items()},
+            "go_files": sorted(data["go_files"]),
+            "lr_files": sorted(data["lr_files"]),
+        }
+        for provider, data in sorted(parsed.items())
+    }
+
+
+def render(parsed: dict) -> str:
+    """Render a human-readable checklist of what to verify."""
+    if not parsed:
+        return "No provider resource changes found in the diff."
+    lines: list[str] = []
+    for provider, data in parsed.items():
+        lines.append(f"## {provider}")
+        if data["resources"]:
+            lines.append("  .lr schema changes:")
+            for resource, fields in sorted(data["resources"].items()):
+                if fields:
+                    lines.append(f"    - {resource}: {', '.join(fields)}")
+                else:
+                    lines.append(f"    - {resource} (new resource / no new fields)")
+        else:
+            lines.append("  .lr schema changes: none (code-only change)")
+        if data["go_files"]:
+            lines.append("  changed provider .go files:")
+            for f in data["go_files"]:
+                lines.append(f"    - {f}")
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--pr", action="append", default=[], metavar="N",
+                    help="pull request number or URL (repeatable)")
+    ap.add_argument("--range", dest="commit_range", metavar="A..B",
+                    help="commit range, e.g. 7bfc8787a..HEAD")
+    ap.add_argument("--json", action="store_true", help="emit JSON")
+    args = ap.parse_args()
+
+    if not args.pr and not args.commit_range:
+        ap.error("provide --pr and/or --range")
+
+    parsed = to_plain(parse(get_diff(args.pr, args.commit_range)))
+    if args.json:
+        print(json.dumps(parsed, indent=2))
+    else:
+        print(render(parsed))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/provider-verification/extract_changes.py
+++ b/.claude/skills/provider-verification/extract_changes.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import shlex
 import subprocess
 import sys
 from collections import defaultdict
@@ -47,20 +48,39 @@ FIELD_RE = re.compile(r"^([a-zA-Z]\w*)(\(\))?\s+\S")
 
 
 def run(cmd: list[str]) -> str:
-    """Run a command and return stdout, exiting with its stderr on failure."""
+    """Run a command and return stdout, raising RuntimeError on failure."""
     result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:
-        sys.exit(f"command failed: {' '.join(cmd)}\n{result.stderr.strip()}")
+        raise RuntimeError(
+            f"command failed: {shlex.join(cmd)}\n{result.stderr.strip()}"
+        )
     return result.stdout
 
 
 def get_diff(prs: list[str], commit_range: str | None) -> str:
-    """Collect the combined unified diff for the given PRs and/or range."""
+    """Collect the combined unified diff for the given PRs and/or range.
+
+    A failure on one input (a missing PR, say) is reported to stderr and the
+    remaining inputs are still processed — verifying three PRs should not be
+    aborted by a typo in the fourth. The run only aborts if *nothing* was
+    retrieved.
+    """
     chunks: list[str] = []
-    for pr in prs:
-        chunks.append(run(["gh", "pr", "diff", pr, "--repo", "mondoohq/mql"]))
+    failures: list[str] = []
+    sources = [(["gh", "pr", "diff", pr, "--repo", "mondoohq/mql"], f"PR {pr}")
+               for pr in prs]
     if commit_range:
-        chunks.append(run(["git", "diff", commit_range]))
+        sources.append((["git", "diff", commit_range], f"range {commit_range}"))
+
+    for cmd, label in sources:
+        try:
+            chunks.append(run(cmd))
+        except RuntimeError as err:
+            failures.append(f"{label}: {err}")
+            print(f"warning: skipping {label} — {err}", file=sys.stderr)
+
+    if not chunks:
+        sys.exit("no diffs could be retrieved:\n" + "\n".join(failures))
     return "\n".join(chunks)
 
 
@@ -117,8 +137,15 @@ def parse(diff: str) -> dict:
             current_resource = ctx.group(1) if ctx else None
             continue
 
-        # Only added lines (new schema). Skip the "+++" file marker.
-        if not line.startswith("+") or line.startswith("+++"):
+        # Consider added lines ("+", new schema) and unchanged context lines
+        # (" "). Context lines never record a field, but their resource
+        # headers update the current resource: when a hunk adds fields right
+        # after an existing resource's "{" line, that header is unchanged
+        # context, and the stale "@@" context would otherwise misattribute the
+        # fields to the *previous* resource.
+        added = line.startswith("+") and not line.startswith("+++")
+        context = line.startswith(" ")
+        if not (added or context):
             continue
         body = line[1:].strip()
         if not body or body.startswith("//") or body in ("{", "}"):
@@ -127,10 +154,13 @@ def parse(diff: str) -> dict:
         res = RESOURCE_RE.match(body)
         if res:
             current_resource = res.group(1)
-            # Record the resource even if no new fields follow (new resource).
-            out[provider]["resources"].setdefault(current_resource, [])
+            if added:
+                # A new resource block - record it even if no fields follow.
+                out[provider]["resources"].setdefault(current_resource, [])
             continue
 
+        if not added:
+            continue  # context lines only reposition current_resource
         field = FIELD_RE.match(body)
         if field and current_resource:
             name = field.group(1) + (field.group(2) or "")

--- a/.claude/skills/provider-verification/references/cloud-notes.md
+++ b/.claude/skills/provider-verification/references/cloud-notes.md
@@ -1,0 +1,140 @@
+# Cloud provisioning notes
+
+Per-cloud gotchas learned from real verification runs. Read the relevant
+section before generating Terraform (step 4), applying (step 6), and
+tearing down (step 10). These are the things that turn a clean `plan` into a
+failed `apply`.
+
+## Table of contents
+
+- [General](#general)
+- [AWS](#aws)
+- [Azure](#azure)
+- [GCP](#gcp)
+- [OCI](#oci)
+- [Resources Terraform cannot provision](#resources-terraform-cannot-provision)
+- [Teardown failure modes](#teardown-failure-modes)
+
+## General
+
+- Pick the smallest SKU / instance / tier that still makes the field populate.
+  Free tiers exist on most clouds — use them.
+- The sandbox blocks the Terraform registry and most cloud APIs. `terraform`
+  and cloud CLIs generally need the command sandbox disabled.
+- A field resolving to `false`/`""`/`[]` is a valid pass only when that
+  reflects reality. If a field *should* hold data and doesn't, it is a bug —
+  often the provider listing with the wrong scope or API view.
+- Slow resources dominate wall time. Apply every cloud in parallel in the
+  background.
+
+## AWS
+
+- **Region**: Aurora DSQL and Bedrock advanced-prompt-optimization are limited
+  to a few regions (`us-east-1`, `us-east-2`, `us-west-2`). Default to
+  `us-west-2`.
+- **ES / OpenSearch domains**: smallest is `t3.small.search`, 1 node, ~10 GiB
+  gp3. ~10–15 min to become active.
+- **CloudFront distributions**: ~15 min to deploy and ~15 min to delete.
+- **SageMaker domain**: needs a VPC + subnet + execution IAM role.
+- **CloudFront viewer mTLS**: set `viewer_mtls_config` on the distribution
+  referencing a `aws_cloudfront_trust_store` (CA bundle uploaded to S3).
+- Tag with `Project = mql-pr-verify`.
+
+## Azure
+
+- **VPN Gateway**: non-AZ `VpnGw1`..`VpnGw5` SKUs can no longer be created —
+  use the `VpnGw1AZ` (etc.) AZ SKUs. An AZ VPN gateway also requires a
+  **zone-redundant Standard public IP** (`zones = ["1","2","3"]`). The Basic
+  SKU does not support custom IPsec policies. Provisioning takes ~30–45 min.
+- **Function App**: the classic Consumption plan (`Y1`) is rejected on quota-
+  limited subscriptions ("additional quota … Total VMs: 0"). Use the **Flex
+  Consumption** plan: `azurerm_service_plan` SKU `FC1` +
+  `azurerm_function_app_flex_consumption` (needs a storage container). Note the
+  flex-consumption resource has **no `key_vault_reference_identity_id`
+  argument** — set `keyVaultReferenceIdentity` post-apply with
+  `az functionapp update --set keyVaultReferenceIdentity=<uami-id>`.
+- **Cognitive Services**: use `kind = "CognitiveServices"` (multi-service, SKU
+  `S0`). `kind = "OpenAI"` needs special subscription approval — avoid it.
+- **AI Search**: cheapest paid SKU is `basic` (~$0.10/hr). `free` is limited to
+  one per subscription.
+- Put everything in one resource group; tag `project = mql-pr-verify`.
+
+## GCP
+
+- **Provider block**: set `billing_project` and `user_project_override = true`.
+  Some APIs (DLP/Sensitive Data Protection) reject ADC user credentials without
+  a quota project. Also run
+  `gcloud auth application-default set-quota-project <project>`.
+- **Enable APIs explicitly** with `google_project_service` and `depends_on`
+  them — composer, dlp, healthcare, apigateway, workstations, etc.
+- **Cloud Composer**: ~25–40 min to create, ~20 min to destroy, ~$0.40–0.55/hr
+  — the dominant cost. Composer 3 web server memory must be **≥ 2 GB**.
+- **Workstation cluster**: ~20 min to create, ~15 min to destroy. The cluster
+  itself is free; only running workstations cost.
+- **DLP connections** must be in `AVAILABLE` state at creation — they need a
+  live Cloud SQL instance and valid credentials. A placeholder instance is
+  rejected. The Terraform `google` provider has no DLP connection resource.
+- **Legacy Notebooks** (`google_notebooks_instance`, user-managed) can no
+  longer be created — GCP rejects with "deprecated". The accessor still
+  resolves to an empty list.
+- App Engine runtimes go end-of-support — use a current runtime
+  (`python312`, not `python39`).
+
+## OCI
+
+- **Compartment scope**: the OCI provider lists *network* resources (VCN,
+  security lists, NSGs) only in the **tenancy root compartment**. Put network
+  and compute resources for those checks in the root compartment, not a
+  sub-compartment. Data Safe resources *are* scanned subtree-wide, so they can
+  live in a sub-compartment.
+- **Always Free tier**: Autonomous DB (`is_free_tier = true`) and
+  `VM.Standard.E2.1.Micro` compute are $0 — use them.
+- **Data Safe target databases** require a non-expired account promotion.
+  On an Always-Free-only tenancy, `CreateTargetDatabase` fails with
+  `405 … promotion is expired` — an account limit, not a bug.
+- Auth: the Terraform `oci` provider reads `~/.oci/config`; set
+  `config_file_profile = "DEFAULT"`.
+
+## Resources Terraform cannot provision
+
+Some resources have no Terraform resource, or are ephemeral. Create them
+best-effort via the cloud CLI after `apply`, then verify the accessor:
+
+- **AWS Bedrock advanced-prompt-optimization job** — ephemeral batch job.
+  `aws bedrock create-advanced-prompt-optimization-job`. The input JSONL is
+  undocumented: each entry needs `version`, `templateId`, `promptTemplate`,
+  and `evaluationSamples` with `inputVariables` as `[{var: value}]`. Use a
+  model the account can actually invoke (an inference-profile id such as
+  `us.amazon.nova-lite-v1:0`).
+- **AWS DSQL CDC stream** — `aws dsql create-stream` with
+  `--ordering UNORDERED` and a Kinesis stream + IAM role created in Terraform.
+- **GCP DLP connection** — `gcloud dlp` may be unavailable; POST to
+  `https://dlp.googleapis.com/v2/projects/<p>/locations/us/connections`. Needs
+  a live Cloud SQL instance to reach `AVAILABLE`.
+
+If a resource cannot be created even by CLI, verify the accessor resolves
+cleanly (empty list, no error) and record the limitation.
+
+## Teardown failure modes
+
+`terraform destroy` frequently cannot finish on its own. Known cases:
+
+- **AWS subnet stuck on `DependencyViolation`**: a deleted SageMaker domain
+  leaves an EFS filesystem + mount-target ENI in the subnet. Find it with
+  `aws ec2 describe-network-interfaces --filters Name=subnet-id,Values=<id>`,
+  then `aws efs delete-mount-target` → wait → `aws efs delete-file-system`,
+  then re-run `terraform destroy`.
+- **OCI security list "in use" / API circuit-breaker open**: repeated retries
+  trip the OCI VirtualNetwork circuit breaker. Delete the OCI resources
+  directly with the CLI in dependency order — subnet → security list → route
+  table → internet gateway → VCN → compartment — using
+  `--wait-for-state TERMINATED`.
+- **OCI state drift**: Terraform may drop a resource from state while it still
+  exists in OCI (e.g. a subnet). Check the cloud directly, not just
+  `terraform state list`.
+- **GCP App Engine app**: once created it can never be deleted (only by
+  deleting the whole project). `terraform destroy` fails on the default
+  service. `terraform state rm` the App Engine resources and delete the rest;
+  report the App Engine app as a permanent leftover (it costs ~$0 idle).
+
+After teardown, confirm nothing tagged `mql-pr-verify` remains in any account.

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -633,6 +633,7 @@ transitives
 truststore
 TValue
 Twt
+uami
 udid
 uefi
 UNAVAIL
@@ -696,6 +697,7 @@ workdir
 Workflowapp
 WORKSPACESUSER
 workspacesweb
+worktree
 writeback
 Xff
 xlarge


### PR DESCRIPTION
## Summary

Adds a project skill, **`provider-verification`**, that verifies mql provider resource/field changes against real cloud infrastructure.

mql resources are thin wrappers over cloud APIs, so a `.lr` schema change is only really proven once it has been run against a live account. Compile checks and unit tests miss the failure modes that matter — a wrong location wildcard, a missing API view, an SDK lagging the service. This skill automates the provision → query → tear-down loop.

Given a **pull request** or a **commit range**, the skill:

1. Extracts the changed `.lr` resources/fields and provider `.go` files — via the bundled `extract_changes.py` diff parser.
2. Builds the affected providers and checks cloud auth.
3. Generates the cheapest Terraform that exercises each changed field (one stack per cloud, parallel subagents).
4. Reports the hourly cost and **pauses for approval above $2/hr**.
5. Applies, then runs `mql run` against every new/changed resource and field — confirming no errors and appropriate data.
6. Opens **one combined fix PR** for any provider bugs found, including pre-existing ones; bugs without a verified fix are reported with an offer to file a tracking issue.
7. **Always tears the infrastructure back down.**

## Contents

| File | Purpose |
|------|---------|
| `SKILL.md` | The 11-step workflow, cost-gate / bug-handling / teardown rules, report template |
| `references/cloud-notes.md` | Per-cloud Terraform & CLI gotchas, slow resources, resources Terraform can't provision, and teardown failure modes — learned from real verification runs |
| `extract_changes.py` | Deterministic diff parser: PR/commit-range → changed resources & fields, grouped by provider |

`extract_changes.py` was tested against merged PRs (#7680, #7701, #7705) and extracts the changed resources/fields accurately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)