### PR TITLE
🐛 ms365: make conditionalAccess.namedLocations a computed field

### DIFF
--- a/providers/ms365/resources/conditional-access.go
+++ b/providers/ms365/resources/conditional-access.go
@@ -15,6 +15,18 @@ import (
 	"go.mondoo.com/mql/v13/types"
 )
 
+// namedLocations exposes the tenant's named-location container, which holds
+// the IP-based and country-based named locations.
+func (a *mqlMicrosoftConditionalAccess) namedLocations() (*mqlMicrosoftConditionalAccessNamedLocations, error) {
+	resource, err := CreateResource(a.MqlRuntime, "microsoft.conditionalAccess.namedLocations", map[string]*llx.RawData{
+		"__id": llx.StringData("microsoft.conditionalAccess.namedLocations"),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resource.(*mqlMicrosoftConditionalAccessNamedLocations), nil
+}
+
 func (a *mqlMicrosoftConditionalAccessNamedLocations) ipLocations() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)
 	graphClient, err := conn.GraphClient()

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -438,7 +438,7 @@ private microsoft.user.licenseDetail.servicePlanInfo @defaults("appliesTo provis
 // `authenticationMethodsPolicy` (tenant-wide allowed authentication methods).
 microsoft.conditionalAccess {
   // Named locations container
-  namedLocations microsoft.conditionalAccess.namedLocations
+  namedLocations() microsoft.conditionalAccess.namedLocations
   // Policies collection
   policies() []microsoft.conditionalAccess.policy
   // Tenant-wide authentication methods policy

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -9515,7 +9515,19 @@ func (c *mqlMicrosoftConditionalAccess) MqlID() string {
 }
 
 func (c *mqlMicrosoftConditionalAccess) GetNamedLocations() *plugin.TValue[*mqlMicrosoftConditionalAccessNamedLocations] {
-	return &c.NamedLocations
+	return plugin.GetOrCompute[*mqlMicrosoftConditionalAccessNamedLocations](&c.NamedLocations, func() (*mqlMicrosoftConditionalAccessNamedLocations, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft.conditionalAccess", c.__id, "namedLocations")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlMicrosoftConditionalAccessNamedLocations), nil
+			}
+		}
+
+		return c.namedLocations()
+	})
 }
 
 func (c *mqlMicrosoftConditionalAccess) GetPolicies() *plugin.TValue[[]any] {


### PR DESCRIPTION
## Bug

`microsoft.conditionalAccess.namedLocations` was declared as a **plain** resource-typed field:

```
microsoft.conditionalAccess {
  namedLocations microsoft.conditionalAccess.namedLocations   // plain field
  ...
}
```

A plain resource field only has a value if something sets it when the parent resource is created. But `microsoft.conditionalAccess` is a namespace root — it is created bare, with no backing API data — so `namedLocations` is **never populated**. Querying it failed:

```
microsoft.conditionalAccess { namedLocations }
# => namedLocations: cannot convert primitive with NO type information
```

This also made the entire `namedLocations` container — and its `ipLocations` / `countryLocations` — unreachable.

## Fix

Make `namedLocations` a **computed** field (`namedLocations()`) with an accessor that creates the container resource on demand — the same pattern the other namespace-style resources in this provider already use (`identityAndSignIn`, `microsoft.security`, etc.). The `namedLocations` container itself only holds the computed `ipLocations()` / `countryLocations()` accessors, so it just needs to be instantiable.

## Verification

Built and installed the provider, tested against a live tenant:

```
microsoft.conditionalAccess { namedLocations }
# => namedLocations: microsoft.conditionalAccess.namedLocations   ✓ (was: error)

microsoft.conditionalAccess.namedLocations { ipLocations.length countryLocations.length }
# => ipLocations.length: 0, countryLocations.length: 0           ✓ resolves as a query subject too
```

`go build ./...`, `go test ./resources/`, and codegen are all clean. No `.lr.versions` change — the field name is unchanged, only plain → computed.

## Context

Found during an exhaustive resource-by-resource sweep of the ms365 provider. Three other resources hit the same `cannot convert primitive with NO type information` symptom (`conditionalAccess.authenticationMethodsPolicy`, `conditionalAccess.authenticationMethodConfiguration`, `identitySecurityDefaultsEnforcementPolicy`) — but those have **correct provider accessors** and fail only when used as a query *subject*. That is a separate MQL-core issue tracked in #7712, not a provider bug, and is intentionally **not** addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)