### PR TITLE
✨ hetzner: expose public IP information on the server resource

### DIFF
--- a/providers/hetzner/resources/hetzner.lr
+++ b/providers/hetzner/resources/hetzner.lr
@@ -81,6 +81,18 @@ private hetzner.server @defaults("id name status") {
   primaryIpv4() hetzner.primaryIp
   // Primary IPv6 address (nullable)
   primaryIpv6() hetzner.primaryIp
+  // Public IPv4 address; empty when the server has no public IPv4
+  publicIpv4 string
+  // Whether the public IPv4 address is blocked by Hetzner abuse handling
+  publicIpv4Blocked bool
+  // Reverse DNS (PTR) record for the public IPv4 address
+  publicIpv4DnsPtr string
+  // Public IPv6 network in CIDR notation; empty when the server has no public IPv6
+  publicIpv6 string
+  // Whether the public IPv6 network is blocked by Hetzner abuse handling
+  publicIpv6Blocked bool
+  // Reverse DNS (PTR) records for addresses in the public IPv6 network (each dict: ip, dnsPtr)
+  publicIpv6DnsPtr []dict
   // Firewalls applied to the server
   firewalls() []hetzner.firewall
   // Load balancers attached to the server

--- a/providers/hetzner/resources/hetzner.lr.go
+++ b/providers/hetzner/resources/hetzner.lr.go
@@ -290,6 +290,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"hetzner.server.primaryIpv6": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerServer).GetPrimaryIpv6()).ToDataRes(types.Resource("hetzner.primaryIp"))
 	},
+	"hetzner.server.publicIpv4": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerServer).GetPublicIpv4()).ToDataRes(types.String)
+	},
+	"hetzner.server.publicIpv4Blocked": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerServer).GetPublicIpv4Blocked()).ToDataRes(types.Bool)
+	},
+	"hetzner.server.publicIpv4DnsPtr": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerServer).GetPublicIpv4DnsPtr()).ToDataRes(types.String)
+	},
+	"hetzner.server.publicIpv6": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerServer).GetPublicIpv6()).ToDataRes(types.String)
+	},
+	"hetzner.server.publicIpv6Blocked": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerServer).GetPublicIpv6Blocked()).ToDataRes(types.Bool)
+	},
+	"hetzner.server.publicIpv6DnsPtr": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerServer).GetPublicIpv6DnsPtr()).ToDataRes(types.Array(types.Dict))
+	},
 	"hetzner.server.firewalls": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerServer).GetFirewalls()).ToDataRes(types.Array(types.Resource("hetzner.firewall")))
 	},
@@ -1000,6 +1018,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"hetzner.server.primaryIpv6": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerServer).PrimaryIpv6, ok = plugin.RawToTValue[*mqlHetznerPrimaryIp](v.Value, v.Error)
+		return
+	},
+	"hetzner.server.publicIpv4": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerServer).PublicIpv4, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"hetzner.server.publicIpv4Blocked": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerServer).PublicIpv4Blocked, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"hetzner.server.publicIpv4DnsPtr": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerServer).PublicIpv4DnsPtr, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"hetzner.server.publicIpv6": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerServer).PublicIpv6, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"hetzner.server.publicIpv6Blocked": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerServer).PublicIpv6Blocked, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"hetzner.server.publicIpv6DnsPtr": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerServer).PublicIpv6DnsPtr, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"hetzner.server.firewalls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2195,31 +2237,37 @@ type mqlHetznerServer struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlHetznerServerInternal
-	Id              plugin.TValue[int64]
-	Name            plugin.TValue[string]
-	Status          plugin.TValue[string]
-	Created         plugin.TValue[*time.Time]
-	ServerType      plugin.TValue[*mqlHetznerServerType]
-	Datacenter      plugin.TValue[*mqlHetznerDatacenter]
-	Location        plugin.TValue[*mqlHetznerLocation]
-	Image           plugin.TValue[*mqlHetznerImage]
-	PrivateNet      plugin.TValue[[]any]
-	Volumes         plugin.TValue[[]any]
-	FloatingIps     plugin.TValue[[]any]
-	PrimaryIpv4     plugin.TValue[*mqlHetznerPrimaryIp]
-	PrimaryIpv6     plugin.TValue[*mqlHetznerPrimaryIp]
-	Firewalls       plugin.TValue[[]any]
-	LoadBalancers   plugin.TValue[[]any]
-	BackupWindow    plugin.TValue[string]
-	RescueEnabled   plugin.TValue[bool]
-	Locked          plugin.TValue[bool]
-	IncludedTraffic plugin.TValue[int64]
-	OutgoingTraffic plugin.TValue[int64]
-	IngoingTraffic  plugin.TValue[int64]
-	PlacementGroup  plugin.TValue[*mqlHetznerPlacementGroup]
-	Iso             plugin.TValue[*mqlHetznerIso]
-	Labels          plugin.TValue[map[string]any]
-	Protection      plugin.TValue[any]
+	Id                plugin.TValue[int64]
+	Name              plugin.TValue[string]
+	Status            plugin.TValue[string]
+	Created           plugin.TValue[*time.Time]
+	ServerType        plugin.TValue[*mqlHetznerServerType]
+	Datacenter        plugin.TValue[*mqlHetznerDatacenter]
+	Location          plugin.TValue[*mqlHetznerLocation]
+	Image             plugin.TValue[*mqlHetznerImage]
+	PrivateNet        plugin.TValue[[]any]
+	Volumes           plugin.TValue[[]any]
+	FloatingIps       plugin.TValue[[]any]
+	PrimaryIpv4       plugin.TValue[*mqlHetznerPrimaryIp]
+	PrimaryIpv6       plugin.TValue[*mqlHetznerPrimaryIp]
+	PublicIpv4        plugin.TValue[string]
+	PublicIpv4Blocked plugin.TValue[bool]
+	PublicIpv4DnsPtr  plugin.TValue[string]
+	PublicIpv6        plugin.TValue[string]
+	PublicIpv6Blocked plugin.TValue[bool]
+	PublicIpv6DnsPtr  plugin.TValue[[]any]
+	Firewalls         plugin.TValue[[]any]
+	LoadBalancers     plugin.TValue[[]any]
+	BackupWindow      plugin.TValue[string]
+	RescueEnabled     plugin.TValue[bool]
+	Locked            plugin.TValue[bool]
+	IncludedTraffic   plugin.TValue[int64]
+	OutgoingTraffic   plugin.TValue[int64]
+	IngoingTraffic    plugin.TValue[int64]
+	PlacementGroup    plugin.TValue[*mqlHetznerPlacementGroup]
+	Iso               plugin.TValue[*mqlHetznerIso]
+	Labels            plugin.TValue[map[string]any]
+	Protection        plugin.TValue[any]
 }
 
 // createHetznerServer creates a new instance of this resource
@@ -2417,6 +2465,30 @@ func (c *mqlHetznerServer) GetPrimaryIpv6() *plugin.TValue[*mqlHetznerPrimaryIp]
 
 		return c.primaryIpv6()
 	})
+}
+
+func (c *mqlHetznerServer) GetPublicIpv4() *plugin.TValue[string] {
+	return &c.PublicIpv4
+}
+
+func (c *mqlHetznerServer) GetPublicIpv4Blocked() *plugin.TValue[bool] {
+	return &c.PublicIpv4Blocked
+}
+
+func (c *mqlHetznerServer) GetPublicIpv4DnsPtr() *plugin.TValue[string] {
+	return &c.PublicIpv4DnsPtr
+}
+
+func (c *mqlHetznerServer) GetPublicIpv6() *plugin.TValue[string] {
+	return &c.PublicIpv6
+}
+
+func (c *mqlHetznerServer) GetPublicIpv6Blocked() *plugin.TValue[bool] {
+	return &c.PublicIpv6Blocked
+}
+
+func (c *mqlHetznerServer) GetPublicIpv6DnsPtr() *plugin.TValue[[]any] {
+	return &c.PublicIpv6DnsPtr
 }
 
 func (c *mqlHetznerServer) GetFirewalls() *plugin.TValue[[]any] {

--- a/providers/hetzner/resources/hetzner.lr.versions
+++ b/providers/hetzner/resources/hetzner.lr.versions
@@ -196,6 +196,12 @@ hetzner.server.privateNet.network 13.0.1
 hetzner.server.privateNet.networkId 13.0.1
 hetzner.server.privateNet.serverId 13.0.1
 hetzner.server.protection 13.0.1
+hetzner.server.publicIpv4 13.0.6
+hetzner.server.publicIpv4Blocked 13.0.6
+hetzner.server.publicIpv4DnsPtr 13.0.6
+hetzner.server.publicIpv6 13.0.6
+hetzner.server.publicIpv6Blocked 13.0.6
+hetzner.server.publicIpv6DnsPtr 13.0.6
 hetzner.server.rescueEnabled 13.0.1
 hetzner.server.serverType 13.0.1
 hetzner.server.status 13.0.1

--- a/providers/hetzner/resources/hetzner_server.go
+++ b/providers/hetzner/resources/hetzner_server.go
@@ -52,20 +52,32 @@ func (h *mqlHetzner) servers() ([]any, error) {
 }
 
 func newMqlHetznerServer(runtime *plugin.Runtime, s *hcloud.Server) (*mqlHetznerServer, error) {
+	// Hetzner assigns a /64 to each server; prefer the network CIDR and fall
+	// back to the bare address when the network is not populated.
+	ipv6 := ipNetString(s.PublicNet.IPv6.Network)
+	if ipv6 == "" {
+		ipv6 = ipString(s.PublicNet.IPv6.IP)
+	}
 	res, err := CreateResource(runtime, "hetzner.server", map[string]*llx.RawData{
-		"__id":            llx.StringData(fmt.Sprintf("hetzner.server/%d", s.ID)),
-		"id":              llx.IntData(s.ID),
-		"name":            llx.StringData(s.Name),
-		"status":          llx.StringData(string(s.Status)),
-		"created":         llx.TimeDataPtr(timePtr(s.Created)),
-		"backupWindow":    llx.StringData(s.BackupWindow),
-		"rescueEnabled":   llx.BoolData(s.RescueEnabled),
-		"locked":          llx.BoolData(s.Locked),
-		"includedTraffic": llx.IntData(int64(s.IncludedTraffic)),
-		"outgoingTraffic": llx.IntData(int64(s.OutgoingTraffic)),
-		"ingoingTraffic":  llx.IntData(int64(s.IngoingTraffic)),
-		"labels":          labelData(s.Labels),
-		"protection":      llx.DictData(protectionDictRebuild(s.Protection.Delete, s.Protection.Rebuild)),
+		"__id":              llx.StringData(fmt.Sprintf("hetzner.server/%d", s.ID)),
+		"id":                llx.IntData(s.ID),
+		"name":              llx.StringData(s.Name),
+		"status":            llx.StringData(string(s.Status)),
+		"created":           llx.TimeDataPtr(timePtr(s.Created)),
+		"publicIpv4":        llx.StringData(ipString(s.PublicNet.IPv4.IP)),
+		"publicIpv4Blocked": llx.BoolData(s.PublicNet.IPv4.Blocked),
+		"publicIpv4DnsPtr":  llx.StringData(s.PublicNet.IPv4.DNSPtr),
+		"publicIpv6":        llx.StringData(ipv6),
+		"publicIpv6Blocked": llx.BoolData(s.PublicNet.IPv6.Blocked),
+		"publicIpv6DnsPtr":  dictArrayData(dnsPtrSliceFromMap(s.PublicNet.IPv6.DNSPtr)),
+		"backupWindow":      llx.StringData(s.BackupWindow),
+		"rescueEnabled":     llx.BoolData(s.RescueEnabled),
+		"locked":            llx.BoolData(s.Locked),
+		"includedTraffic":   llx.IntData(int64(s.IncludedTraffic)),
+		"outgoingTraffic":   llx.IntData(int64(s.OutgoingTraffic)),
+		"ingoingTraffic":    llx.IntData(int64(s.IngoingTraffic)),
+		"labels":            labelData(s.Labels),
+		"protection":        llx.DictData(protectionDictRebuild(s.Protection.Delete, s.Protection.Rebuild)),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What

`hetzner.server` previously only reached its IP details indirectly, through the lazy `primaryIpv4()` / `primaryIpv6()` typed references to `hetzner.primaryIp`. This surfaces the server's public network information directly on the resource as plain queryable fields.

### New fields on `hetzner.server`
| Field | Type | Source |
|---|---|---|
| `publicIpv4` | `string` | `PublicNet.IPv4.IP` |
| `publicIpv4Blocked` | `bool` | `PublicNet.IPv4.Blocked` — Hetzner abuse handling |
| `publicIpv4DnsPtr` | `string` | `PublicNet.IPv4.DNSPtr` — reverse DNS |
| `publicIpv6` | `string` | `PublicNet.IPv6.Network` CIDR (falls back to the bare address) |
| `publicIpv6Blocked` | `bool` | `PublicNet.IPv6.Blocked` |
| `publicIpv6DnsPtr` | `[]dict` | `PublicNet.IPv6.DNSPtr` — `{ip, dnsPtr}` pairs for the /64 |

All values come from the `Server.PublicNet` data already returned by the server list call — no extra API requests.

## Notes
- No breaking changes — purely additive. The existing `primaryIpv4()` / `primaryIpv6()` typed references are untouched.
- New `.lr.versions` entries are `13.0.6` (provider currently at `13.0.5`).

## Verification
Provider builds, `go vet`, and code generation are all clean; `go.mod` unchanged. **Live interactive verification was not run** — no `HCLOUD_TOKEN` is available in this environment. Recommend `mql shell hetzner` against a real project (`hetzner.servers { name publicIpv4 publicIpv4Blocked publicIpv6 }`) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)