### PR TITLE
Handle effective journald config precedence

### DIFF
--- a/providers/os/resources/journald.go
+++ b/providers/os/resources/journald.go
@@ -8,7 +8,9 @@ package resources
 import (
 	"errors"
 	"fmt"
+	"path"
 	"slices"
+	"sort"
 	"strings"
 	"sync"
 
@@ -48,6 +50,13 @@ func initJournaldConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 
 const defaultJournaldConfig = "/etc/systemd/journald.conf"
 
+var journaldConfigSearchDirs = []string{
+	"/etc/systemd",
+	"/run/systemd",
+	"/usr/local/lib/systemd",
+	"/usr/lib/systemd",
+}
+
 type journaldConfigSection struct {
 	name       string
 	params     map[string]string
@@ -64,13 +73,23 @@ func (s *mqlJournaldConfig) id() (string, error) {
 }
 
 func (s *mqlJournaldConfig) file() (*mqlFile, error) {
-	f, err := CreateResource(s.MqlRuntime, "file", map[string]*llx.RawData{
-		"path": llx.StringData(defaultJournaldConfig),
-	})
-	if err != nil {
-		return nil, err
+	configPath := defaultJournaldConfig
+	conn, ok := s.MqlRuntime.Connection.(shared.Connection)
+	if ok {
+		for _, dir := range journaldConfigSearchDirs {
+			candidate := path.Join(dir, "journald.conf")
+			exists, err := afero.Exists(conn.FileSystem(), candidate)
+			if err != nil {
+				return nil, err
+			}
+			if exists {
+				configPath = candidate
+				break
+			}
+		}
 	}
-	return f.(*mqlFile), nil
+
+	return newFile(s.MqlRuntime, configPath)
 }
 
 // parses the journald config file and creates the resources
@@ -162,6 +181,14 @@ func (s *mqlJournaldConfig) configFiles(file *mqlFile) ([]*mqlFile, error) {
 		return files, nil
 	}
 
+	if isDefaultJournaldConfigPath(filePath.Data) {
+		dropinFiles, err := s.defaultConfigDropinFiles(conn.FileSystem())
+		if err != nil {
+			return nil, err
+		}
+		return append(files, dropinFiles...), nil
+	}
+
 	matches, err := afero.Glob(conn.FileSystem(), filePath.Data+".d/*.conf")
 	if err != nil {
 		return nil, err
@@ -169,6 +196,65 @@ func (s *mqlJournaldConfig) configFiles(file *mqlFile) ([]*mqlFile, error) {
 
 	for _, match := range matches {
 		dropinFile, err := newFile(s.MqlRuntime, match)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, dropinFile)
+	}
+
+	return files, nil
+}
+
+func isDefaultJournaldConfigPath(configPath string) bool {
+	for _, dir := range journaldConfigSearchDirs {
+		if configPath == path.Join(dir, "journald.conf") {
+			return true
+		}
+	}
+	return false
+}
+
+type journaldDropinFile struct {
+	basename string
+	path     string
+	priority int
+}
+
+func (s *mqlJournaldConfig) defaultConfigDropinFiles(fs afero.Fs) ([]*mqlFile, error) {
+	dropinsByName := map[string]journaldDropinFile{}
+
+	for priority, dir := range journaldConfigSearchDirs {
+		matches, err := afero.Glob(fs, path.Join(dir, "journald.conf.d", "*.conf"))
+		if err != nil {
+			return nil, err
+		}
+
+		for _, match := range matches {
+			name := path.Base(match)
+			selected, ok := dropinsByName[name]
+			if ok && selected.priority < priority {
+				continue
+			}
+			dropinsByName[name] = journaldDropinFile{
+				basename: name,
+				path:     match,
+				priority: priority,
+			}
+		}
+	}
+
+	dropins := make([]journaldDropinFile, 0, len(dropinsByName))
+	for _, dropin := range dropinsByName {
+		dropins = append(dropins, dropin)
+	}
+
+	sort.Slice(dropins, func(i, j int) bool {
+		return dropins[i].basename < dropins[j].basename
+	})
+
+	files := make([]*mqlFile, 0, len(dropins))
+	for _, dropin := range dropins {
+		dropinFile, err := newFile(s.MqlRuntime, dropin.path)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/os/resources/journald_internal_test.go
+++ b/providers/os/resources/journald_internal_test.go
@@ -62,6 +62,138 @@ URL=https://dropin.example.test
 	require.Equal(t, "yes", params.Data["ForwardToSyslog"])
 }
 
+func TestJournaldConfigUsesSystemdConfigSearchPath(t *testing.T) {
+	runtime := journaldMockRuntime(t, map[string]*mock.MockFileData{
+		"/usr/lib/systemd/journald.conf": {
+			StatData: mock.FileInfo{Mode: 0o644},
+			Content: `[Journal]
+Storage=auto
+`,
+		},
+		"/usr/lib/systemd/journald.conf.d": {
+			StatData: mock.FileInfo{Mode: os.ModeDir | 0o755, IsDir: true},
+		},
+		"/usr/lib/systemd/journald.conf.d/10-vendor.conf": {
+			StatData: mock.FileInfo{Mode: 0o644},
+			Content: `[Journal]
+ForwardToSyslog=YES
+Compress=YES
+`,
+		},
+		"/usr/local/lib/systemd/journald.conf.d": {
+			StatData: mock.FileInfo{Mode: os.ModeDir | 0o755, IsDir: true},
+		},
+		"/usr/local/lib/systemd/journald.conf.d/20-local-vendor.conf": {
+			StatData: mock.FileInfo{Mode: 0o644},
+			Content: `[Journal]
+Compress=NO
+`,
+		},
+		"/run/systemd/journald.conf.d": {
+			StatData: mock.FileInfo{Mode: os.ModeDir | 0o755, IsDir: true},
+		},
+		"/run/systemd/journald.conf.d/30-runtime.conf": {
+			StatData: mock.FileInfo{Mode: 0o644},
+			Content: `[Journal]
+Storage=volatile
+`,
+		},
+	})
+
+	raw, err := CreateResource(runtime, ResourceJournaldConfig, nil)
+	require.NoError(t, err)
+
+	config := raw.(*mqlJournaldConfig)
+	file := config.GetFile()
+	require.NoError(t, file.Error)
+	path := file.Data.GetPath()
+	require.NoError(t, path.Error)
+	require.Equal(t, "/usr/lib/systemd/journald.conf", path.Data)
+
+	sections := config.GetSections()
+	require.NoError(t, sections.Error)
+
+	requireJournaldParam(t, sections.Data, "Journal", "Storage", "volatile")
+	requireJournaldParam(t, sections.Data, "Journal", "ForwardToSyslog", "yes")
+	requireJournaldParam(t, sections.Data, "Journal", "Compress", "no")
+}
+
+func TestJournaldConfigDropinsUseSystemdFilenameOrdering(t *testing.T) {
+	runtime := journaldMockRuntime(t, map[string]*mock.MockFileData{
+		"/etc/systemd/journald.conf": {
+			StatData: mock.FileInfo{Mode: 0o644},
+			Content: `[Journal]
+ForwardToSyslog=yes
+`,
+		},
+		"/etc/systemd/journald.conf.d": {
+			StatData: mock.FileInfo{Mode: os.ModeDir | 0o755, IsDir: true},
+		},
+		"/etc/systemd/journald.conf.d/10-local.conf": {
+			StatData: mock.FileInfo{Mode: 0o644},
+			Content: `[Journal]
+ForwardToSyslog=no
+`,
+		},
+		"/usr/lib/systemd/journald.conf.d": {
+			StatData: mock.FileInfo{Mode: os.ModeDir | 0o755, IsDir: true},
+		},
+		"/usr/lib/systemd/journald.conf.d/90-vendor.conf": {
+			StatData: mock.FileInfo{Mode: 0o644},
+			Content: `[Journal]
+ForwardToSyslog=YES
+`,
+		},
+	})
+
+	raw, err := CreateResource(runtime, ResourceJournaldConfig, nil)
+	require.NoError(t, err)
+
+	config := raw.(*mqlJournaldConfig)
+	sections := config.GetSections()
+	require.NoError(t, sections.Error)
+
+	requireJournaldParam(t, sections.Data, "Journal", "ForwardToSyslog", "yes")
+}
+
+func TestJournaldConfigDropinsMaskSameFilenamesByDirectoryPriority(t *testing.T) {
+	runtime := journaldMockRuntime(t, map[string]*mock.MockFileData{
+		"/etc/systemd/journald.conf": {
+			StatData: mock.FileInfo{Mode: 0o644},
+			Content: `[Journal]
+Storage=auto
+`,
+		},
+		"/usr/lib/systemd/journald.conf.d": {
+			StatData: mock.FileInfo{Mode: os.ModeDir | 0o755, IsDir: true},
+		},
+		"/usr/lib/systemd/journald.conf.d/50-forward.conf": {
+			StatData: mock.FileInfo{Mode: 0o644},
+			Content: `[Journal]
+ForwardToSyslog=no
+`,
+		},
+		"/etc/systemd/journald.conf.d": {
+			StatData: mock.FileInfo{Mode: os.ModeDir | 0o755, IsDir: true},
+		},
+		"/etc/systemd/journald.conf.d/50-forward.conf": {
+			StatData: mock.FileInfo{Mode: 0o644},
+			Content: `[Journal]
+ForwardToSyslog=YES
+`,
+		},
+	})
+
+	raw, err := CreateResource(runtime, ResourceJournaldConfig, nil)
+	require.NoError(t, err)
+
+	config := raw.(*mqlJournaldConfig)
+	sections := config.GetSections()
+	require.NoError(t, sections.Error)
+
+	requireJournaldParam(t, sections.Data, "Journal", "ForwardToSyslog", "yes")
+}
+
 func journaldMockRuntime(t *testing.T, files map[string]*mock.MockFileData) *plugin.Runtime {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- teach `journald.config` to use the documented systemd journald config search path for the default config
- include vendor, local, and runtime `journald.conf.d` drop-ins when building effective sections and params
- preserve systemd ordering: main config first, drop-ins sorted by filename, and same-name drop-ins masked by higher-priority directories
- keep custom-path `journald.config("...")` behavior scoped to the provided file and sibling `.d` directory

Fixes #7727

## Verification

- `env GOCACHE=/tmp/mql-gocache go test ./providers/os/resources -run Journald -count=1`
- `env GOCACHE=/tmp/mql-gocache go test ./providers/os/resources -count=1`