### PR TITLE
🟢 docker: switch remote-image test to mirror.gcr.io

### DIFF
--- a/providers/os/connection/docker/container_connection_test.go
+++ b/providers/os/connection/docker/container_connection_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker/client"
@@ -24,7 +25,6 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	containerimage "go.mondoo.com/mql/v13/providers/os/connection/container/image"
 	"go.mondoo.com/mql/v13/providers/os/connection/tar"
-	"go.mondoo.com/mql/v13/providers/os/id/containerid"
 )
 
 // resolveRemoteImage returns the digest the registry currently advertises for
@@ -39,14 +39,37 @@ func resolveRemoteImage(t *testing.T, imageRef string) string {
 	return desc.Digest.String()
 }
 
-// This test has an external dependency on the mirror.gcr.io registry.
-// mirror.gcr.io is Google's anonymous pull-through cache for Docker Hub, so it
-// avoids the docker-credential-gcloud helper that gcr.io triggers on CI runners.
+// Assertion strategy (read this before you "simplify" the assertions below):
+//
+// These tests exercise the remote-registry branch of NewContainerImageConnection
+// and verify it populates asset.Name and asset.PlatformIds in the format
+// `<repo>@<12-hex-short-digest>` and `//platformid.api.mondoo.app/runtime/docker/images/<64-hex-digest>`.
+//
+// Previously the expected digest was hardcoded, which made the test brittle
+// against `mirror.gcr.io` rebuilding the tag. The "obvious" fix is to recompute
+// the expected name with `containerid.ShortContainerImageID` /
+// `containerid.MondooContainerImageID` — but those are exactly the helpers the
+// production code uses, so doing that makes the assertions tautological: a
+// regression in either helper (wrong truncation length, prefix typo, stray
+// "sha256:") would be hidden because both sides would compute the same wrong
+// value. We deliberately stick to literal string composition and explicit
+// length checks here so that regressions in those helpers fail this test.
+//
+// The image digest is still fetched dynamically from the registry so the test
+// survives tag rebuilds.
+
+// TestAssetNameForRemoteImages depends on mirror.gcr.io. mirror.gcr.io is
+// Google's anonymous pull-through cache for Docker Hub, picked because it is
+// not bound to the docker-credential-gcloud helper that intermittently fails
+// on CI when the GHA OIDC token can't be refreshed.
 // To test this specific case, we cannot use a stored image, we need to call remote.Get
 func TestAssetNameForRemoteImages(t *testing.T) {
 	const imageRef = "mirror.gcr.io/library/busybox:1.36.1"
 	const imageRepo = "mirror.gcr.io/library/busybox"
 	imgDigest := resolveRemoteImage(t, imageRef)
+	digestHex := strings.TrimPrefix(imgDigest, "sha256:")
+	require.Len(t, digestHex, 64, "expected 64 hex chars after sha256: prefix, got %q", imgDigest)
+	shortDigest := digestHex[:12]
 
 	var err error
 	var conn *tar.Connection
@@ -73,18 +96,21 @@ func TestAssetNameForRemoteImages(t *testing.T) {
 	require.NotNil(t, conn)
 
 	assert.True(t, config.DelayDiscovery)
-	assert.Equal(t, imageRepo+"@"+containerid.ShortContainerImageID(imgDigest), asset.Name)
-	assert.Contains(t, asset.PlatformIds, containerid.MondooContainerImageID(imgDigest))
+	// Literal composition on purpose — see "Assertion strategy" comment above.
+	assert.Equal(t, imageRepo+"@"+shortDigest, asset.Name)
+	assert.Contains(t, asset.PlatformIds, "//platformid.api.mondoo.app/runtime/docker/images/"+digestHex)
 }
 
-// This test has an external dependency on the mirror.gcr.io registry.
-// mirror.gcr.io is Google's anonymous pull-through cache for Docker Hub, so it
-// avoids the docker-credential-gcloud helper that gcr.io triggers on CI runners.
+// TestAssetNameForRemoteImages_DisableDelayedDiscovery depends on mirror.gcr.io
+// for the same reason described on TestAssetNameForRemoteImages.
 // To test this specific case, we cannot use a stored image, we need to call remote.Get
 func TestAssetNameForRemoteImages_DisableDelayedDiscovery(t *testing.T) {
 	const imageRef = "mirror.gcr.io/library/busybox:1.36.1"
 	const imageRepo = "mirror.gcr.io/library/busybox"
 	imgDigest := resolveRemoteImage(t, imageRef)
+	digestHex := strings.TrimPrefix(imgDigest, "sha256:")
+	require.Len(t, digestHex, 64, "expected 64 hex chars after sha256: prefix, got %q", imgDigest)
+	shortDigest := digestHex[:12]
 
 	var err error
 	var conn *tar.Connection
@@ -114,8 +140,9 @@ func TestAssetNameForRemoteImages_DisableDelayedDiscovery(t *testing.T) {
 	require.NotNil(t, conn)
 
 	assert.False(t, config.DelayDiscovery)
-	assert.Equal(t, imageRepo+"@"+containerid.ShortContainerImageID(imgDigest), asset.Name)
-	assert.Contains(t, asset.PlatformIds, containerid.MondooContainerImageID(imgDigest))
+	// Literal composition on purpose — see "Assertion strategy" comment above.
+	assert.Equal(t, imageRepo+"@"+shortDigest, asset.Name)
+	assert.Contains(t, asset.PlatformIds, "//platformid.api.mondoo.app/runtime/docker/images/"+digestHex)
 }
 
 func fetchAndCreateImage(t *testing.T, ctx context.Context, dClient *client.Client, img string) container.CreateResponse {

--- a/providers/os/connection/docker/container_connection_test.go
+++ b/providers/os/connection/docker/container_connection_test.go
@@ -24,7 +24,9 @@ import (
 	"go.mondoo.com/mql/v13/providers/os/connection/tar"
 )
 
-// This test has an external dependency on the gcr.io registry
+// This test has an external dependency on the mirror.gcr.io registry.
+// mirror.gcr.io is Google's anonymous pull-through cache for Docker Hub, so it
+// avoids the docker-credential-gcloud helper that gcr.io triggers on CI runners.
 // To test this specific case, we cannot use a stored image, we need to call remote.Get
 func TestAssetNameForRemoteImages(t *testing.T) {
 	var err error
@@ -35,7 +37,7 @@ func TestAssetNameForRemoteImages(t *testing.T) {
 
 	config := &inventory.Config{
 		Type: "docker-image",
-		Host: "gcr.io/google-containers/busybox:1.27.2",
+		Host: "mirror.gcr.io/library/busybox:1.36.1",
 	}
 	asset = &inventory.Asset{
 		Connections: []*inventory.Config{config},
@@ -52,11 +54,13 @@ func TestAssetNameForRemoteImages(t *testing.T) {
 	require.NotNil(t, conn)
 
 	assert.True(t, config.DelayDiscovery)
-	assert.Equal(t, "gcr.io/google-containers/busybox@545e6a6310a2", asset.Name)
-	assert.Contains(t, asset.PlatformIds, "//platformid.api.mondoo.app/runtime/docker/images/545e6a6310a27636260920bc07b994a299b6708a1b26910cfefd335fdfb60d2b")
+	assert.Equal(t, "mirror.gcr.io/library/busybox@73aaf090f3d8", asset.Name)
+	assert.Contains(t, asset.PlatformIds, "//platformid.api.mondoo.app/runtime/docker/images/73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662")
 }
 
-// This test has an external dependency on the gcr.io registry
+// This test has an external dependency on the mirror.gcr.io registry.
+// mirror.gcr.io is Google's anonymous pull-through cache for Docker Hub, so it
+// avoids the docker-credential-gcloud helper that gcr.io triggers on CI runners.
 // To test this specific case, we cannot use a stored image, we need to call remote.Get
 func TestAssetNameForRemoteImages_DisableDelayedDiscovery(t *testing.T) {
 	var err error
@@ -67,7 +71,7 @@ func TestAssetNameForRemoteImages_DisableDelayedDiscovery(t *testing.T) {
 
 	config := &inventory.Config{
 		Type: "docker-image",
-		Host: "gcr.io/google-containers/busybox:1.27.2",
+		Host: "mirror.gcr.io/library/busybox:1.36.1",
 		Options: map[string]string{
 			plugin.DISABLE_DELAYED_DISCOVERY_OPTION: "true",
 		},
@@ -87,8 +91,8 @@ func TestAssetNameForRemoteImages_DisableDelayedDiscovery(t *testing.T) {
 	require.NotNil(t, conn)
 
 	assert.False(t, config.DelayDiscovery)
-	assert.Equal(t, "gcr.io/google-containers/busybox@545e6a6310a2", asset.Name)
-	assert.Contains(t, asset.PlatformIds, "//platformid.api.mondoo.app/runtime/docker/images/545e6a6310a27636260920bc07b994a299b6708a1b26910cfefd335fdfb60d2b")
+	assert.Equal(t, "mirror.gcr.io/library/busybox@73aaf090f3d8", asset.Name)
+	assert.Contains(t, asset.PlatformIds, "//platformid.api.mondoo.app/runtime/docker/images/73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662")
 }
 
 func fetchAndCreateImage(t *testing.T, ctx context.Context, dClient *client.Client, img string) container.CreateResponse {

--- a/providers/os/connection/docker/container_connection_test.go
+++ b/providers/os/connection/docker/container_connection_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/docker/docker/client"
@@ -16,61 +15,30 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
-	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/uuid"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	containerimage "go.mondoo.com/mql/v13/providers/os/connection/container/image"
 	"go.mondoo.com/mql/v13/providers/os/connection/tar"
 )
 
-// resolveRemoteImage returns the digest the registry currently advertises for
-// imageRef. Tests use this so assertions stay valid when the upstream tag is
-// rebuilt and the manifest digest changes.
-func resolveRemoteImage(t *testing.T, imageRef string) string {
-	t.Helper()
-	ref, err := name.ParseReference(imageRef)
-	require.NoError(t, err)
-	desc, err := containerimage.GetImageDescriptor(ref)
-	require.NoError(t, err)
-	return desc.Digest.String()
-}
+// The two TestAssetNameForRemoteImages* tests below use a tag reference
+// (mirror.gcr.io/library/busybox:1.36.1) rather than a digest reference, on
+// purpose: the goal is to exercise the tag→digest resolution path in
+// NewContainerImageConnection. The expected digest is hardcoded in the
+// assertions so a helper regression (wrong short-hash length, stray "sha256:"
+// prefix, etc.) would still be caught. If mirror.gcr.io ever rebuilds the
+// tag, update the hardcoded digest to match — this is preferable to a
+// dynamic lookup, which would make the assertions tautological against the
+// production helpers.
+// mirror.gcr.io is Google's anonymous pull-through cache for Docker Hub and
+// is not bound to docker-credential-gcloud, which made the previous gcr.io
+// fixture flake on CI.
 
-// Assertion strategy (read this before you "simplify" the assertions below):
-//
-// These tests exercise the remote-registry branch of NewContainerImageConnection
-// and verify it populates asset.Name and asset.PlatformIds in the format
-// `<repo>@<12-hex-short-digest>` and `//platformid.api.mondoo.app/runtime/docker/images/<64-hex-digest>`.
-//
-// Previously the expected digest was hardcoded, which made the test brittle
-// against `mirror.gcr.io` rebuilding the tag. The "obvious" fix is to recompute
-// the expected name with `containerid.ShortContainerImageID` /
-// `containerid.MondooContainerImageID` — but those are exactly the helpers the
-// production code uses, so doing that makes the assertions tautological: a
-// regression in either helper (wrong truncation length, prefix typo, stray
-// "sha256:") would be hidden because both sides would compute the same wrong
-// value. We deliberately stick to literal string composition and explicit
-// length checks here so that regressions in those helpers fail this test.
-//
-// The image digest is still fetched dynamically from the registry so the test
-// survives tag rebuilds.
-
-// TestAssetNameForRemoteImages depends on mirror.gcr.io. mirror.gcr.io is
-// Google's anonymous pull-through cache for Docker Hub, picked because it is
-// not bound to the docker-credential-gcloud helper that intermittently fails
-// on CI when the GHA OIDC token can't be refreshed.
 // To test this specific case, we cannot use a stored image, we need to call remote.Get
 func TestAssetNameForRemoteImages(t *testing.T) {
-	const imageRef = "mirror.gcr.io/library/busybox:1.36.1"
-	const imageRepo = "mirror.gcr.io/library/busybox"
-	imgDigest := resolveRemoteImage(t, imageRef)
-	digestHex := strings.TrimPrefix(imgDigest, "sha256:")
-	require.Len(t, digestHex, 64, "expected 64 hex chars after sha256: prefix, got %q", imgDigest)
-	shortDigest := digestHex[:12]
-
 	var err error
 	var conn *tar.Connection
 	var asset *inventory.Asset
@@ -79,7 +47,7 @@ func TestAssetNameForRemoteImages(t *testing.T) {
 
 	config := &inventory.Config{
 		Type: "docker-image",
-		Host: imageRef,
+		Host: "mirror.gcr.io/library/busybox:1.36.1",
 	}
 	asset = &inventory.Asset{
 		Connections: []*inventory.Config{config},
@@ -96,22 +64,12 @@ func TestAssetNameForRemoteImages(t *testing.T) {
 	require.NotNil(t, conn)
 
 	assert.True(t, config.DelayDiscovery)
-	// Literal composition on purpose — see "Assertion strategy" comment above.
-	assert.Equal(t, imageRepo+"@"+shortDigest, asset.Name)
-	assert.Contains(t, asset.PlatformIds, "//platformid.api.mondoo.app/runtime/docker/images/"+digestHex)
+	assert.Equal(t, "mirror.gcr.io/library/busybox@73aaf090f3d8", asset.Name)
+	assert.Contains(t, asset.PlatformIds, "//platformid.api.mondoo.app/runtime/docker/images/73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662")
 }
 
-// TestAssetNameForRemoteImages_DisableDelayedDiscovery depends on mirror.gcr.io
-// for the same reason described on TestAssetNameForRemoteImages.
 // To test this specific case, we cannot use a stored image, we need to call remote.Get
 func TestAssetNameForRemoteImages_DisableDelayedDiscovery(t *testing.T) {
-	const imageRef = "mirror.gcr.io/library/busybox:1.36.1"
-	const imageRepo = "mirror.gcr.io/library/busybox"
-	imgDigest := resolveRemoteImage(t, imageRef)
-	digestHex := strings.TrimPrefix(imgDigest, "sha256:")
-	require.Len(t, digestHex, 64, "expected 64 hex chars after sha256: prefix, got %q", imgDigest)
-	shortDigest := digestHex[:12]
-
 	var err error
 	var conn *tar.Connection
 	var asset *inventory.Asset
@@ -120,7 +78,7 @@ func TestAssetNameForRemoteImages_DisableDelayedDiscovery(t *testing.T) {
 
 	config := &inventory.Config{
 		Type: "docker-image",
-		Host: imageRef,
+		Host: "mirror.gcr.io/library/busybox:1.36.1",
 		Options: map[string]string{
 			plugin.DISABLE_DELAYED_DISCOVERY_OPTION: "true",
 		},
@@ -140,9 +98,8 @@ func TestAssetNameForRemoteImages_DisableDelayedDiscovery(t *testing.T) {
 	require.NotNil(t, conn)
 
 	assert.False(t, config.DelayDiscovery)
-	// Literal composition on purpose — see "Assertion strategy" comment above.
-	assert.Equal(t, imageRepo+"@"+shortDigest, asset.Name)
-	assert.Contains(t, asset.PlatformIds, "//platformid.api.mondoo.app/runtime/docker/images/"+digestHex)
+	assert.Equal(t, "mirror.gcr.io/library/busybox@73aaf090f3d8", asset.Name)
+	assert.Contains(t, asset.PlatformIds, "//platformid.api.mondoo.app/runtime/docker/images/73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662")
 }
 
 func fetchAndCreateImage(t *testing.T, ctx context.Context, dClient *client.Client, img string) container.CreateResponse {

--- a/providers/os/connection/docker/container_connection_test.go
+++ b/providers/os/connection/docker/container_connection_test.go
@@ -15,20 +15,39 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/uuid"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	containerimage "go.mondoo.com/mql/v13/providers/os/connection/container/image"
 	"go.mondoo.com/mql/v13/providers/os/connection/tar"
+	"go.mondoo.com/mql/v13/providers/os/id/containerid"
 )
+
+// resolveRemoteImage returns the digest the registry currently advertises for
+// imageRef. Tests use this so assertions stay valid when the upstream tag is
+// rebuilt and the manifest digest changes.
+func resolveRemoteImage(t *testing.T, imageRef string) string {
+	t.Helper()
+	ref, err := name.ParseReference(imageRef)
+	require.NoError(t, err)
+	desc, err := containerimage.GetImageDescriptor(ref)
+	require.NoError(t, err)
+	return desc.Digest.String()
+}
 
 // This test has an external dependency on the mirror.gcr.io registry.
 // mirror.gcr.io is Google's anonymous pull-through cache for Docker Hub, so it
 // avoids the docker-credential-gcloud helper that gcr.io triggers on CI runners.
 // To test this specific case, we cannot use a stored image, we need to call remote.Get
 func TestAssetNameForRemoteImages(t *testing.T) {
+	const imageRef = "mirror.gcr.io/library/busybox:1.36.1"
+	const imageRepo = "mirror.gcr.io/library/busybox"
+	imgDigest := resolveRemoteImage(t, imageRef)
+
 	var err error
 	var conn *tar.Connection
 	var asset *inventory.Asset
@@ -37,7 +56,7 @@ func TestAssetNameForRemoteImages(t *testing.T) {
 
 	config := &inventory.Config{
 		Type: "docker-image",
-		Host: "mirror.gcr.io/library/busybox:1.36.1",
+		Host: imageRef,
 	}
 	asset = &inventory.Asset{
 		Connections: []*inventory.Config{config},
@@ -54,8 +73,8 @@ func TestAssetNameForRemoteImages(t *testing.T) {
 	require.NotNil(t, conn)
 
 	assert.True(t, config.DelayDiscovery)
-	assert.Equal(t, "mirror.gcr.io/library/busybox@73aaf090f3d8", asset.Name)
-	assert.Contains(t, asset.PlatformIds, "//platformid.api.mondoo.app/runtime/docker/images/73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662")
+	assert.Equal(t, imageRepo+"@"+containerid.ShortContainerImageID(imgDigest), asset.Name)
+	assert.Contains(t, asset.PlatformIds, containerid.MondooContainerImageID(imgDigest))
 }
 
 // This test has an external dependency on the mirror.gcr.io registry.
@@ -63,6 +82,10 @@ func TestAssetNameForRemoteImages(t *testing.T) {
 // avoids the docker-credential-gcloud helper that gcr.io triggers on CI runners.
 // To test this specific case, we cannot use a stored image, we need to call remote.Get
 func TestAssetNameForRemoteImages_DisableDelayedDiscovery(t *testing.T) {
+	const imageRef = "mirror.gcr.io/library/busybox:1.36.1"
+	const imageRepo = "mirror.gcr.io/library/busybox"
+	imgDigest := resolveRemoteImage(t, imageRef)
+
 	var err error
 	var conn *tar.Connection
 	var asset *inventory.Asset
@@ -71,7 +94,7 @@ func TestAssetNameForRemoteImages_DisableDelayedDiscovery(t *testing.T) {
 
 	config := &inventory.Config{
 		Type: "docker-image",
-		Host: "mirror.gcr.io/library/busybox:1.36.1",
+		Host: imageRef,
 		Options: map[string]string{
 			plugin.DISABLE_DELAYED_DISCOVERY_OPTION: "true",
 		},
@@ -91,8 +114,8 @@ func TestAssetNameForRemoteImages_DisableDelayedDiscovery(t *testing.T) {
 	require.NotNil(t, conn)
 
 	assert.False(t, config.DelayDiscovery)
-	assert.Equal(t, "mirror.gcr.io/library/busybox@73aaf090f3d8", asset.Name)
-	assert.Contains(t, asset.PlatformIds, "//platformid.api.mondoo.app/runtime/docker/images/73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662")
+	assert.Equal(t, imageRepo+"@"+containerid.ShortContainerImageID(imgDigest), asset.Name)
+	assert.Contains(t, asset.PlatformIds, containerid.MondooContainerImageID(imgDigest))
 }
 
 func fetchAndCreateImage(t *testing.T, ctx context.Context, dClient *client.Client, img string) container.CreateResponse {


### PR DESCRIPTION
## Summary

- Switch the two `TestAssetNameForRemoteImages*` tests in `providers/os/connection/docker` from the (now deprecated) `gcr.io/google-containers/busybox:1.27.2` image to `mirror.gcr.io/library/busybox:1.36.1`.
- Updated the expected asset name and platformId digest to match the new image (manifest index digest `sha256:73aaf090f3d8…`).

## Why

These tests have been intermittently failing on CI — most recently on https://github.com/mondoohq/mql/actions/runs/26021241191/job/76485137450?pr=7730 (attempt 4 of the release run for #7730).

The failure mode is always the same:

```
error getting credentials - err: exit status 1, out: ``
ERROR: (gcloud.auth.docker-helper) There was a problem refreshing your current auth tokens:
('Unable to retrieve Identity Pool subject token',
 '{"source":"actions-run-service","statusCode":400,"errorMessage":"job is already completed"}')
```

Even though `gcr.io/google-containers/busybox` is a public image, Docker walks the credential helpers in `~/.docker/config.json` first. On GHA runners with `setup-gcloud`, `gcr.io` is bound to `docker-credential-gcloud`, which exchanges the GHA-supplied OIDC subject token for a Google access token via Workload Identity Federation. When that subject token expires mid-job and the refresh call lands at a bad moment, `actions-run-service` replies `400 — job is already completed` and the helper exits non-zero — aborting the pull regardless of the image being public.

`mirror.gcr.io` is Google's anonymous pull-through cache for Docker Hub and is **not** in the default `gcloud auth configure-docker` host list, so Docker goes straight to anonymous auth. As a side benefit, `gcr.io/google-containers/busybox` is marked deprecated upstream.

## Test plan

- [x] `go test -run 'TestAssetNameForRemoteImages' -v ./providers/os/connection/docker/...` passes locally
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)