### PR TITLE
🧹 github: update go-github to v87

### DIFF
--- a/providers/github/connection/connection.go
+++ b/providers/github/connection/connection.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/cockroachdb/errors"
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v87/github"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/mitchellh/hashstructure/v2"
 	"github.com/rs/zerolog"
@@ -94,17 +94,7 @@ func NewGithubConnection(id uint32, asset *inventory.Asset) (*GithubConnection, 
 	}
 	connectionOpts := connectionOptionsFromConfigOptions(asset.Connections[0])
 
-	var client *github.Client
-	var err error
-	if connectionOpts.AppID != "" {
-		client, err = newGithubAppClient(connectionOpts)
-	} else {
-		client, err = newGithubTokenClient(connectionOpts)
-	}
-	if err != nil {
-		return nil, err
-	}
-
+	var clientOpts []github.ClientOptionsFunc
 	if connectionOpts.EnterpriseURL != "" {
 		parsedUrl, err := url.Parse(connectionOpts.EnterpriseURL)
 		if err != nil {
@@ -113,10 +103,18 @@ func NewGithubConnection(id uint32, asset *inventory.Asset) (*GithubConnection, 
 
 		baseUrl := parsedUrl.JoinPath("api/v3/")
 		uploadUrl := parsedUrl.JoinPath("api/uploads/")
-		client, err = client.WithEnterpriseURLs(baseUrl.String(), uploadUrl.String())
-		if err != nil {
-			return nil, err
-		}
+		clientOpts = append(clientOpts, github.WithEnterpriseURLs(baseUrl.String(), uploadUrl.String()))
+	}
+
+	var client *github.Client
+	var err error
+	if connectionOpts.AppID != "" {
+		client, err = newGithubAppClient(connectionOpts, clientOpts...)
+	} else {
+		client, err = newGithubTokenClient(connectionOpts, clientOpts...)
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	// set the context so github client can handle backoff
@@ -165,7 +163,7 @@ func (c *GithubConnection) Verify() error {
 	return nil
 }
 
-func newGithubAppClient(opts githubConnectionOptions) (*github.Client, error) {
+func newGithubAppClient(opts githubConnectionOptions, clientOpts ...github.ClientOptionsFunc) (*github.Client, error) {
 	if opts.AppID == "" {
 		return nil, errors.New("app-id is required for GitHub App authentication")
 	}
@@ -196,10 +194,11 @@ func newGithubAppClient(opts githubConnectionOptions) (*github.Client, error) {
 		return nil, errors.New("app-private-key is required for GitHub App authentication")
 	}
 
-	return github.NewClient(newGithubRetryableClient(&http.Client{Transport: itr})), nil
+	clientOpts = append(clientOpts, github.WithHTTPClient(newGithubRetryableClient(&http.Client{Transport: itr})))
+	return github.NewClient(clientOpts...)
 }
 
-func newGithubTokenClient(opts githubConnectionOptions) (*github.Client, error) {
+func newGithubTokenClient(opts githubConnectionOptions, clientOpts ...github.ClientOptionsFunc) (*github.Client, error) {
 	// if we still have no token, error out
 	if opts.Token == "" {
 		return nil, errors.New("a valid GitHub token is required, pass --token '<yourtoken>' or set GITHUB_TOKEN environment variable")
@@ -210,7 +209,8 @@ func newGithubTokenClient(opts githubConnectionOptions) (*github.Client, error) 
 		&oauth2.Token{AccessToken: opts.Token},
 	)
 	tc := oauth2.NewClient(ctx, ts)
-	return github.NewClient(newGithubRetryableClient(tc)), nil
+	clientOpts = append(clientOpts, github.WithHTTPClient(newGithubRetryableClient(tc)))
+	return github.NewClient(clientOpts...)
 }
 
 func newGithubRetryableClient(httpClient *http.Client) *http.Client {

--- a/providers/github/connection/connection_test.go
+++ b/providers/github/connection/connection_test.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v87/github"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"

--- a/providers/github/go.mod
+++ b/providers/github/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.18.0
 	github.com/cockroachdb/errors v1.13.0
 	github.com/gobwas/glob v0.2.3
-	github.com/google/go-github/v86 v86.0.0
+	github.com/google/go-github/v87 v87.0.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/rs/zerolog v1.35.1

--- a/providers/github/go.sum
+++ b/providers/github/go.sum
@@ -458,8 +458,8 @@ github.com/google/go-containerregistry v0.20.7 h1:24VGNpS0IwrOZ2ms2P1QE3Xa5X9p4p
 github.com/google/go-containerregistry v0.20.7/go.mod h1:Lx5LCZQjLH1QBaMPeGwsME9biPeo1lPx6lbGj/UmzgM=
 github.com/google/go-github/v84 v84.0.0 h1:I/0Xn5IuChMe8TdmI2bbim5nyhaRFJ7DEdzmD2w+yVA=
 github.com/google/go-github/v84 v84.0.0/go.mod h1:WwYL1z1ajRdlaPszjVu/47x1L0PXukJBn73xsiYrRRQ=
-github.com/google/go-github/v86 v86.0.0 h1:S/6aANJhwRm8EQmGKVML3j41yq0h2BsTP8FnDkO7kcA=
-github.com/google/go-github/v86 v86.0.0/go.mod h1:zKv1l4SwDXNFMGByi2FWkq71KwSXqj/eQRZuqtmcot8=
+github.com/google/go-github/v87 v87.0.0 h1:9Ck3dcOxWJyfsN8tzdah4YvmqB/7ZsstMglv/PkOsl0=
+github.com/google/go-github/v87 v87.0.0/go.mod h1:hGUoT5pwm/ck5uLL+wroSVQfg8mpe+buxllCcGV4VaM=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/gobwas/glob"
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v87/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/logger"

--- a/providers/github/resources/git.go
+++ b/providers/github/resources/git.go
@@ -4,7 +4,7 @@
 package resources
 
 import (
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v87/github"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )

--- a/providers/github/resources/github.go
+++ b/providers/github/resources/github.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v87/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_actions_secrets.go
+++ b/providers/github/resources/github_actions_secrets.go
@@ -4,7 +4,7 @@
 package resources
 
 import (
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v87/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_audit.go
+++ b/providers/github/resources/github_audit.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v87/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"

--- a/providers/github/resources/github_environments.go
+++ b/providers/github/resources/github_environments.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v87/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_org.go
+++ b/providers/github/resources/github_org.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v87/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/internal/workerpool"
 	"go.mondoo.com/mql/v13/llx"

--- a/providers/github/resources/github_package.go
+++ b/providers/github/resources/github_package.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v87/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v87/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/logger"

--- a/providers/github/resources/github_repo_test.go
+++ b/providers/github/resources/github_repo_test.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"testing"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v87/github"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/providers/github/resources/github_runners.go
+++ b/providers/github/resources/github_runners.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v87/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_runners_test.go
+++ b/providers/github/resources/github_runners_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v87/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,7 +23,7 @@ func newTestGithubClient(t *testing.T, server *httptest.Server) *github.Client {
 	t.Helper()
 	base, err := url.Parse(server.URL + "/")
 	require.NoError(t, err)
-	client, err := github.NewClient(nil).WithEnterpriseURLs(base.String(), base.String())
+	client, err := github.NewClient(github.WithEnterpriseURLs(base.String(), base.String()))
 	require.NoError(t, err)
 	return client
 }

--- a/providers/github/resources/github_security.go
+++ b/providers/github/resources/github_security.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v87/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_team.go
+++ b/providers/github/resources/github_team.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v87/github"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers/github/connection"
 )

--- a/providers/github/resources/github_user.go
+++ b/providers/github/resources/github_user.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v87/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/logger"

--- a/providers/github/resources/github_workflow.go
+++ b/providers/github/resources/github_workflow.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v87/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/github/connection"


### PR DESCRIPTION
## Summary

Bumps the GitHub provider's `google/go-github` dependency from **v86 → v87** (the current latest release).

## API changes handled

v87 reworked the client constructor:
- `github.NewClient()` now takes variadic `ClientOptionsFunc` and returns `(*Client, error)` — the retryable HTTP client is now wrapped in `github.WithHTTPClient(...)`.
- `Client.WithEnterpriseURLs(...)` moved from a `Client` method to a `ClientOptionsFunc`. `connection.go` now collects the enterprise-URL option up front and passes it into `newGithubAppClient`/`newGithubTokenClient` (both now accept `...github.ClientOptionsFunc`).
- The runners test helper switched to `github.NewClient(github.WithEnterpriseURLs(...))`.

The remaining 17 files are pure import-path updates (`/v86` → `/v87`).

Note: `go-github/v84` stays as an indirect dependency — it's pulled in by `ghinstallation/v2`, a separate major version, and is unaffected.

## Verification

- `go build ./...` — clean
- `go test ./connection/... ./resources/...` — pass
- Built/installed the provider and ran a live query (`github.organization` against `mondoohq`) — works against the real GitHub API
- No generated-file (`.lr.versions`, `*.json`) changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)