### PR TITLE
🐛 github: fix provider panic and field-resolution bugs

### DIFF
--- a/providers/github/resources/github.lr.go
+++ b/providers/github/resources/github.lr.go
@@ -102,11 +102,11 @@ func init() {
 			Create: createGithubOrganization,
 		},
 		"github.organization.samlConfig": {
-			// to override args, implement: initGithubOrganizationSamlConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initGithubOrganizationSamlConfig,
 			Create: createGithubOrganizationSamlConfig,
 		},
 		"github.organization.ipAllowList": {
-			// to override args, implement: initGithubOrganizationIpAllowList(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initGithubOrganizationIpAllowList,
 			Create: createGithubOrganizationIpAllowList,
 		},
 		"github.organization.ipAllowList.entry": {
@@ -126,7 +126,7 @@ func init() {
 			Create: createGithubOrganizationPersonalAccessToken,
 		},
 		"github.organization.auditLogStreamConfig": {
-			// to override args, implement: initGithubOrganizationAuditLogStreamConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initGithubOrganizationAuditLogStreamConfig,
 			Create: createGithubOrganizationAuditLogStreamConfig,
 		},
 		"github.repositoryFineGrainedPermission": {
@@ -174,7 +174,7 @@ func init() {
 			Create: createGithubPublicKey,
 		},
 		"github.repository.codeowners": {
-			// to override args, implement: initGithubRepositoryCodeowners(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initGithubRepositoryCodeowners,
 			Create: createGithubRepositoryCodeowners,
 		},
 		"github.codeowners.rule": {

--- a/providers/github/resources/github_org.go
+++ b/providers/github/resources/github_org.go
@@ -310,6 +310,8 @@ func (g *mqlGithubOrganization) owners() ([]any, error) {
 			"updatedAt":       llx.TimeDataPtr(githubTimestamp(member.UpdatedAt)),
 			"suspendedAt":     llx.TimeDataPtr(githubTimestamp(member.SuspendedAt)),
 			"company":         llx.StringDataPtr(member.Company),
+			"hireable":        llx.BoolData(member.GetHireable()),
+			"siteAdmin":       llx.BoolData(member.GetSiteAdmin()),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -298,13 +298,17 @@ func (g *mqlGithubRepository) license() (*mqlGithubLicense, error) {
 
 	repoLicense, _, err := conn.Client().Repositories.License(conn.Context(), ownerLogin, repoName)
 	if err != nil {
+		// A repository without a LICENSE file returns 404; that is a valid
+		// empty state, not an error.
 		if strings.Contains(err.Error(), "404") {
-			return nil, errors.New("not found")
+			g.License.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}
 
 	if repoLicense == nil || repoLicense.License == nil {
+		g.License.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 
@@ -571,7 +575,10 @@ func (g *mqlGithubRepository) defaultBranch() (*mqlGithubBranch, error) {
 
 	branch, _, err := conn.Client().Repositories.GetBranch(conn.Context(), ownerLogin, repoName, repoDefaultBranchName, 3)
 	if err != nil {
+		// An empty repository (or one without the named default branch) returns
+		// 404; that is a valid empty state, not an error.
 		if strings.Contains(err.Error(), "404") {
+			g.DefaultBranch.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil
 		}
 		return nil, err
@@ -878,6 +885,10 @@ func (g *mqlGithubRepository) commits() ([]any, error) {
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
 				return nil, nil
+			}
+			// An empty repository has no commits; the API reports this as a 409.
+			if strings.Contains(err.Error(), "Git Repository is empty") {
+				return []any{}, nil
 			}
 			return nil, err
 		}

--- a/providers/github/resources/github_security.go
+++ b/providers/github/resources/github_security.go
@@ -68,6 +68,82 @@ func doRawGraphQL(ctx context.Context, client *github.Client, query string, vars
 	return client.Do(req, v)
 }
 
+// The resources below are reachable both as a field of their parent
+// (github.repository / github.organization) and as a standalone dotted path
+// (e.g. `github.repository.codeowners`). The dotted form instantiates the
+// resource directly, bypassing the parent accessor that populates it. These
+// init functions delegate to the parent so a bare instantiation resolves to
+// the same fully-populated resource.
+
+func initGithubRepositoryCodeowners(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if _, ok := args["__id"]; ok {
+		return args, nil, nil
+	}
+	repo, err := NewResource(runtime, "github.repository", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+	codeowners := repo.(*mqlGithubRepository).GetCodeowners()
+	if codeowners.Error != nil {
+		return nil, nil, codeowners.Error
+	}
+	return args, codeowners.Data, nil
+}
+
+func initGithubOrganizationSamlConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if _, ok := args["__id"]; ok {
+		return args, nil, nil
+	}
+	org, err := NewResource(runtime, "github.organization", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+	samlConfig := org.(*mqlGithubOrganization).GetSamlConfig()
+	if samlConfig.Error != nil {
+		return nil, nil, samlConfig.Error
+	}
+	if samlConfig.Data == nil {
+		return nil, nil, errors.New("SAML SSO configuration is not available for this organization (requires GitHub Enterprise Cloud and admin access)")
+	}
+	return args, samlConfig.Data, nil
+}
+
+func initGithubOrganizationIpAllowList(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if _, ok := args["__id"]; ok {
+		return args, nil, nil
+	}
+	org, err := NewResource(runtime, "github.organization", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+	ipAllowList := org.(*mqlGithubOrganization).GetIpAllowList()
+	if ipAllowList.Error != nil {
+		return nil, nil, ipAllowList.Error
+	}
+	if ipAllowList.Data == nil {
+		return nil, nil, errors.New("IP allow list is not available for this organization (requires GitHub Enterprise Cloud and admin access)")
+	}
+	return args, ipAllowList.Data, nil
+}
+
+func initGithubOrganizationAuditLogStreamConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if _, ok := args["__id"]; ok {
+		return args, nil, nil
+	}
+	org, err := NewResource(runtime, "github.organization", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+	streamConfig := org.(*mqlGithubOrganization).GetAuditLogStreamConfig()
+	if streamConfig.Error != nil {
+		return nil, nil, streamConfig.Error
+	}
+	if streamConfig.Data == nil {
+		return nil, nil, errors.New("audit log streaming configuration is not available for this organization (requires GitHub Enterprise Cloud and admin access)")
+	}
+	return args, streamConfig.Data, nil
+}
+
 // ---------- SAML config (GraphQL) ----------
 
 func (g *mqlGithubOrganizationSamlConfig) id() (string, error) {


### PR DESCRIPTION
## Summary

A deep test of the github provider (every resource and field, against live infrastructure) surfaced five pre-existing bugs. All are fixed here.

## Bugs fixed

**1. Provider panic — `github.repository.defaultBranch`**
On a repo with no default branch (e.g. an empty repo), `defaultBranch()` returned `nil, nil` on a 404 without setting `StateIsNull`. The runtime then called `MqlID()` on a nil `*mqlGithubBranch` → nil-pointer dereference, panicking the provider. Now sets `StateIsNull` before returning.

**2. `cannot convert primitive with NO type information` — 4 resources unqueryable by dotted path**
`github.repository.codeowners`, `github.organization.samlConfig`, `.ipAllowList`, and `.auditLogStreamConfig` each have a fully-qualified resource name equal to `<parent>.<field>`. When queried as a dotted path, the MQL compiler instantiates the (private) resource directly, bypassing the parent accessor that fetches and populates it — leaving an empty husk whose every field errors. Added `init` functions that delegate to the parent resource so a bare instantiation resolves to the populated resource. The explicit block form (`github.repository { codeowners { … } }`) was already correct and is unchanged.

**3. `github.organization.owners` — `siteAdmin` / `hireable` errored**
`owners()` built each `github.user` via `CreateResource` with a partial field map that omitted `siteAdmin` and `hireable`. Added both.

**4. `github.repository.license` errored for repos with no LICENSE file**
A 404 (no license — very common) was turned into an error, so `license` reported "no data available" instead of `null`. Now returns `null`. Also fixed a latent nil-deref on the `repoLicense == nil` path (same class as #1).

**5. `github.repository.commits` errored on an empty repository**
GitHub reports an empty repo as a `409`; `commits()` propagated it as an error. Now returns an empty list.

## Verification

Built and installed the provider, then ran against live GitHub infrastructure:

| Query | Before | After |
|---|---|---|
| `defaultBranch` (empty repo) | provider panic | `null` |
| `commits.length` (empty repo) | "no data available" | `0` |
| `license` (no LICENSE file) | "no data available" | `null` |
| `github.repository.codeowners { … }` (dotted) | `cannot convert primitive…` | `{ exists: false, path: "", rules: [] }` |
| `owners { siteAdmin hireable }` | `cannot convert primitive…` | `false` / `false` |
| `github.organization.samlConfig` (dotted) | `cannot convert primitive…` | populated resource |
| `github.organization.ipAllowList` (dotted, non-Enterprise org) | `cannot convert primitive…` | clear error message |

`go vet`, `go test ./resources/... ./connection/...`, and `gofmt` all clean. No schema changes — `.lr.versions` and `*.json` unchanged; the only `*.lr.go` change is wiring the four new `init` functions into the resource factory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)