### PR TITLE
🐛 windows: populate user.home from ProfileList registry hive

### DIFF
--- a/providers/os/resources/users/manager_test.go
+++ b/providers/os/resources/users/manager_test.go
@@ -102,9 +102,15 @@ func TestManagerWindows(t *testing.T) {
 	assert.Equal(t, "S-1-5-21-2356735557-1575748656-448136971-500", usr.ID)
 	assert.Equal(t, int64(-1), usr.Uid)
 	assert.Equal(t, int64(-1), usr.Gid)
-	assert.Equal(t, "", usr.Home)
+	assert.Equal(t, `C:\Users\chris`, usr.Home)
 	assert.Equal(t, "chris", usr.Name)
 	assert.Equal(t, "", usr.Shell)
+
+	// Accounts without a profile registry entry must surface as empty home,
+	// not as a fabricated C:\Users\<Name>. Downstream filters (vscode, firefox)
+	// rely on the empty value to skip them.
+	guest := findUser(userList, "S-1-5-21-2356735557-1575748656-448136971-501")
+	assert.Equal(t, "", guest.Home)
 
 	assert.Equal(t, 5, len(userList))
 }

--- a/providers/os/resources/users/ps1getlocalusers.go
+++ b/providers/os/resources/users/ps1getlocalusers.go
@@ -36,7 +36,30 @@ type WindowsLocalUser struct {
 	PasswordExpires        *string
 	PasswordLastSet        *string
 	LastLogon              *string
+
+	// On-disk profile path, joined from HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList.
+	// Empty for accounts that have never logged in (Guest, DefaultAccount, WDAGUtilityAccount, ...).
+	LocalPath string
 }
+
+// getLocalUsersScript enumerates local users and joins each with their on-disk
+// profile path. Profile paths come from the ProfileList registry hive — the same
+// data Win32_UserProfile exposes — to avoid WMI latency on hosts with many
+// cached profiles (RDS, Citrix). The output is a JSON array shaped like the
+// previous `Get-LocalUser | ConvertTo-Json` output, with an extra LocalPath field.
+const getLocalUsersScript = `
+$profiles = @{}
+Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList' -ErrorAction SilentlyContinue |
+    ForEach-Object {
+        $sid = Split-Path $_.Name -Leaf
+        $path = (Get-ItemProperty -LiteralPath $_.PSPath -ErrorAction SilentlyContinue).ProfileImagePath
+        if ($path) { $profiles[$sid] = $path }
+    }
+$out = foreach ($u in Get-LocalUser) {
+    $u | Add-Member -NotePropertyName LocalPath -NotePropertyValue $profiles[$u.SID.Value] -PassThru -Force
+}
+ConvertTo-Json -InputObject @($out) -Depth 4
+`
 
 func ParseWindowsLocalUsers(r io.Reader) ([]WindowsLocalUser, error) {
 	data, err := io.ReadAll(r)
@@ -71,8 +94,7 @@ func (s *WindowsUserManager) User(id string) (*User, error) {
 }
 
 func (s *WindowsUserManager) List() ([]*User, error) {
-	powershellCmd := "Get-LocalUser | ConvertTo-Json"
-	c, err := s.conn.RunCommand(powershell.Wrap(powershellCmd))
+	c, err := s.conn.RunCommand(powershell.Encode(getLocalUsersScript))
 	if err != nil {
 		return nil, err
 	}
@@ -96,6 +118,7 @@ func winToUser(g WindowsLocalUser) *User {
 		Uid:     -1, // TODO: not its suboptimal, but lets make sure to avoid runtime conflicts for now
 		Gid:     -1,
 		Name:    g.Name,
+		Home:    g.LocalPath,
 		Enabled: g.Enabled,
 	}
 }

--- a/providers/os/resources/users/ps1getlocalusers_test.go
+++ b/providers/os/resources/users/ps1getlocalusers_test.go
@@ -40,9 +40,13 @@ func TestWindowsLocalUsersParser(t *testing.T) {
 		PasswordExpires:        pointer("/Date(1590610319962)/"),
 		PasswordLastSet:        pointer("/Date(1586981519962)/"),
 		LastLogon:              pointer("/Date(1587041759064)/"),
+		LocalPath:              `C:\Users\chris`,
 	}
 	found := findWindowsUser(localUsers, "chris")
 	assert.EqualValues(t, expected, found)
+
+	guest := findWindowsUser(localUsers, "Guest")
+	assert.Equal(t, "", guest.LocalPath, "accounts without a profile registry entry have empty LocalPath")
 }
 
 func pointer(val string) *string {

--- a/providers/os/resources/users/testdata/windows.json
+++ b/providers/os/resources/users/testdata/windows.json
@@ -17,7 +17,8 @@
                   "Value":  "S-1-5-21-2356735557-1575748656-448136971-500"
               },
       "PrincipalSource":  1,
-      "ObjectClass":  "User"
+      "ObjectClass":  "User",
+      "LocalPath":  "C:\\Users\\chris"
   },
   {
       "AccountExpires":  null,
@@ -37,7 +38,8 @@
                   "Value":  "S-1-5-21-2356735557-1575748656-448136971-503"
               },
       "PrincipalSource":  1,
-      "ObjectClass":  "User"
+      "ObjectClass":  "User",
+      "LocalPath":  null
   },
   {
       "AccountExpires":  null,
@@ -57,7 +59,8 @@
                   "Value":  "S-1-5-21-2356735557-1575748656-448136971-501"
               },
       "PrincipalSource":  1,
-      "ObjectClass":  "User"
+      "ObjectClass":  "User",
+      "LocalPath":  null
   },
   {
       "AccountExpires":  null,
@@ -77,7 +80,8 @@
                   "Value":  "S-1-5-21-2356735557-1575748656-448136971-1000"
               },
       "PrincipalSource":  1,
-      "ObjectClass":  "User"
+      "ObjectClass":  "User",
+      "LocalPath":  null
   },
   {
       "AccountExpires":  null,
@@ -97,6 +101,7 @@
                   "Value":  "S-1-5-21-2356735557-1575748656-448136971-504"
               },
       "PrincipalSource":  1,
-      "ObjectClass":  "User"
+      "ObjectClass":  "User",
+      "LocalPath":  null
   }
 ]

--- a/providers/os/resources/users/testdata/windows.toml
+++ b/providers/os/resources/users/testdata/windows.toml
@@ -1,4 +1,4 @@
-[commands."powershell -c \"Get-LocalUser | ConvertTo-Json\""]
+[commands."powershell.exe -NoProfile -EncodedCommand JABQAHIAbwBnAHIAZQBzAHMAUAByAGUAZgBlAHIAZQBuAGMAZQA9ACcAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQAnADsACgAkAHAAcgBvAGYAaQBsAGUAcwAgAD0AIABAAHsAfQAKAEcAZQB0AC0AQwBoAGkAbABkAEkAdABlAG0AIAAnAEgASwBMAE0AOgBcAFMATwBGAFQAVwBBAFIARQBcAE0AaQBjAHIAbwBzAG8AZgB0AFwAVwBpAG4AZABvAHcAcwAgAE4AVABcAEMAdQByAHIAZQBuAHQAVgBlAHIAcwBpAG8AbgBcAFAAcgBvAGYAaQBsAGUATABpAHMAdAAnACAALQBFAHIAcgBvAHIAQQBjAHQAaQBvAG4AIABTAGkAbABlAG4AdABsAHkAQwBvAG4AdABpAG4AdQBlACAAfAAKACAAIAAgACAARgBvAHIARQBhAGMAaAAtAE8AYgBqAGUAYwB0ACAAewAKACAAIAAgACAAIAAgACAAIAAkAHMAaQBkACAAPQAgAFMAcABsAGkAdAAtAFAAYQB0AGgAIAAkAF8ALgBOAGEAbQBlACAALQBMAGUAYQBmAAoAIAAgACAAIAAgACAAIAAgACQAcABhAHQAaAAgAD0AIAAoAEcAZQB0AC0ASQB0AGUAbQBQAHIAbwBwAGUAcgB0AHkAIAAtAEwAaQB0AGUAcgBhAGwAUABhAHQAaAAgACQAXwAuAFAAUwBQAGEAdABoACAALQBFAHIAcgBvAHIAQQBjAHQAaQBvAG4AIABTAGkAbABlAG4AdABsAHkAQwBvAG4AdABpAG4AdQBlACkALgBQAHIAbwBmAGkAbABlAEkAbQBhAGcAZQBQAGEAdABoAAoAIAAgACAAIAAgACAAIAAgAGkAZgAgACgAJABwAGEAdABoACkAIAB7ACAAJABwAHIAbwBmAGkAbABlAHMAWwAkAHMAaQBkAF0AIAA9ACAAJABwAGEAdABoACAAfQAKACAAIAAgACAAfQAKACQAbwB1AHQAIAA9ACAAZgBvAHIAZQBhAGMAaAAgACgAJAB1ACAAaQBuACAARwBlAHQALQBMAG8AYwBhAGwAVQBzAGUAcgApACAAewAKACAAIAAgACAAJAB1ACAAfAAgAEEAZABkAC0ATQBlAG0AYgBlAHIAIAAtAE4AbwB0AGUAUAByAG8AcABlAHIAdAB5AE4AYQBtAGUAIABMAG8AYwBhAGwAUABhAHQAaAAgAC0ATgBvAHQAZQBQAHIAbwBwAGUAcgB0AHkAVgBhAGwAdQBlACAAJABwAHIAbwBmAGkAbABlAHMAWwAkAHUALgBTAEkARAAuAFYAYQBsAHUAZQBdACAALQBQAGEAcwBzAFQAaAByAHUAIAAtAEYAbwByAGMAZQAKAH0ACgBDAG8AbgB2AGUAcgB0AFQAbwAtAEoAcwBvAG4AIAAtAEkAbgBwAHUAdABPAGIAagBlAGMAdAAgAEAAKAAkAG8AdQB0ACkAIAAtAEQAZQBwAHQAaAAgADQACgA="]
 stdout = """
 [
   {
@@ -19,7 +19,8 @@ stdout = """
                   "Value":  "S-1-5-21-2356735557-1575748656-448136971-500"
               },
       "PrincipalSource":  1,
-      "ObjectClass":  "User"
+      "ObjectClass":  "User",
+      "LocalPath":  "C:\\\\Users\\\\chris"
   },
   {
       "AccountExpires":  null,
@@ -39,7 +40,8 @@ stdout = """
                   "Value":  "S-1-5-21-2356735557-1575748656-448136971-503"
               },
       "PrincipalSource":  1,
-      "ObjectClass":  "User"
+      "ObjectClass":  "User",
+      "LocalPath":  null
   },
   {
       "AccountExpires":  null,
@@ -59,7 +61,8 @@ stdout = """
                   "Value":  "S-1-5-21-2356735557-1575748656-448136971-501"
               },
       "PrincipalSource":  1,
-      "ObjectClass":  "User"
+      "ObjectClass":  "User",
+      "LocalPath":  null
   },
   {
       "AccountExpires":  null,
@@ -79,7 +82,8 @@ stdout = """
                   "Value":  "S-1-5-21-2356735557-1575748656-448136971-1000"
               },
       "PrincipalSource":  1,
-      "ObjectClass":  "User"
+      "ObjectClass":  "User",
+      "LocalPath":  null
   },
   {
       "AccountExpires":  null,
@@ -99,7 +103,8 @@ stdout = """
                   "Value":  "S-1-5-21-2356735557-1575748656-448136971-504"
               },
       "PrincipalSource":  1,
-      "ObjectClass":  "User"
+      "ObjectClass":  "User",
+      "LocalPath":  null
   }
 ]
 """


### PR DESCRIPTION
## Summary

Fixes #7744. On Windows, `WindowsUserManager` populates each `User` from `Get-LocalUser | ConvertTo-Json`, which doesn't return a home directory — so `User.Home` was `""` for every Windows user. Downstream consumers (`vscode.extensions`, `firefox.profiles`, `ai_coding_tools`) filter empty homes as system accounts and silently returned `[]` on every Windows asset.

This PR resolves per-user profile paths from `HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList` — the same registry hive `Win32_UserProfile` is a façade for — joined to each local user by SID.

**Why the registry and not `Get-CimInstance Win32_UserProfile`:** WMI overhead is significant on hosts with many cached profiles (RDS, Citrix, Terminal Servers) — `Get-CimInstance Win32_UserProfile` can take seconds there. Native registry reads via the `HKLM:` PowerShell drive are sub-millisecond regardless of profile count. Same SID-keyed result set.

**No fabrication:** Accounts without a `ProfileList` entry (Guest, DefaultAccount, WDAGUtilityAccount before first logon) keep `home` empty rather than guessing `C:\Users\<Name>`. Downstream filters rely on the empty value to skip them, and a fabricated path would mislead policies that check "does this user have a profile."

**Out of scope** (filed separately if needed):
- Domain users with profiles on the machine — `Get-LocalUser` is local SAM only. The existing limitation is preserved.
- `User.Description` — also dropped on the floor today; trivial follow-up.

## Test plan

- [x] `go test ./providers/os/resources/users/...` — parser test and manager test both pass with the new fixture
- [x] `gofmt` and `go vet` clean on changed files
- [x] `go build ./...` clean under `providers/os/`
- [ ] Manual on a live Windows asset:
  ```
  mql shell <windows-asset>
  > users.where(name == "Administrator") { home }   # expect C:\Users\Administrator
  > users.where(name == "Guest") { home }           # expect ""
  > vscode.paths                                     # should list per-user .vscode/extensions if installed
  ```

## Notes for reviewers

- The TOML mock fixture (`testdata/windows.toml`) matches commands by literal string, so the new `[commands."powershell.exe -NoProfile -EncodedCommand <base64>"]` key contains the UTF-16-LE + base64 encoding of the script. Any future edit to `getLocalUsersScript` requires re-deriving that base64 (same pattern as `smbios/win.go` and `windows/security_products.go`).
- `manager_test.go` now also asserts that `Guest` (SID `-501`) has empty `Home`, locking in the no-fabrication rule against regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)