### PR TITLE
🧹 ci: scope provider regen and lint to changed providers

### DIFF
--- a/.github/workflows/pr-extended-linting.yml
+++ b/.github/workflows/pr-extended-linting.yml
@@ -20,6 +20,23 @@ permissions:
   pull-requests: read
 
 jobs:
+  detect-changed-providers:
+    runs-on: ubuntu-latest
+    outputs:
+      providers: ${{ steps.changed.outputs.providers }}
+      all: ${{ steps.changed.outputs.all }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Determine changed providers
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: bash scripts/changed-providers.sh
+
   golangci-lint:
     permissions:
       # allow read access to the content for analysis.
@@ -51,6 +68,8 @@ jobs:
           skip-cache: true
 
   golangci-lint-providers:
+    needs: detect-changed-providers
     uses: ./.github/workflows/reusable-lint-providers.yml
     with:
       only-new-issues: true
+      providers: ${{ needs.detect-changed-providers.outputs.all == 'true' && '' || needs.detect-changed-providers.outputs.providers }}

--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -58,6 +58,8 @@ jobs:
       - name: Determine changed providers
         id: changed
         env:
+          # Empty on push events (this workflow only triggers on push);
+          # scripts/changed-providers.sh falls back to merge-base with origin/main.
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: bash scripts/changed-providers.sh
 

--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV
@@ -53,12 +55,38 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ env.protoc-version }}
 
+      - name: Determine changed providers
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: bash scripts/changed-providers.sh
+
       - name: Check generated files
+        env:
+          ALL_PROVIDERS: ${{ steps.changed.outputs.all }}
+          CHANGED_PROVIDERS: ${{ steps.changed.outputs.providers }}
         run: |
+          set -euo pipefail
           protoc --version
           make prep
-          make mql/generate
-          SKIP_COMPILE=yes make providers/build
+          # Run all non-provider code generators (these are cheap relative to
+          # the per-provider work and may affect non-provider source files).
+          make clean/proto llx/generate shared/generate sbom/generate reporter/generate
+          # Provider plumbing that every provider relies on.
+          make providers/proto providers/config providers/lr
+          # Regenerate provider sources. Skip compile — we only need .lr.go,
+          # .lr.json, .resources.json to validate against the committed copies.
+          if [ "$ALL_PROVIDERS" = "true" ] || [ -z "$CHANGED_PROVIDERS" ]; then
+            echo "--> regenerating all providers"
+            SKIP_COMPILE=yes make providers/build
+          else
+            echo "--> regenerating changed providers: $CHANGED_PROVIDERS"
+            targets="providers/build/mock providers/build/core"
+            for p in $CHANGED_PROVIDERS; do
+              targets="$targets providers/build/$p"
+            done
+            SKIP_COMPILE=yes make $targets
+          fi
           git diff --exit-code *.go
           git diff --exit-code providers/**/*.lr.json
           git diff --exit-code providers/**/*.lr.go

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -34,6 +34,8 @@ jobs:
       - name: Determine changed providers
         id: changed
         env:
+          # Empty on push events (this workflow only triggers on push);
+          # scripts/changed-providers.sh falls back to merge-base with origin/main.
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: bash scripts/changed-providers.sh
 

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -20,6 +20,23 @@ permissions:
   contents: read
 
 jobs:
+  detect-changed-providers:
+    runs-on: ubuntu-latest
+    outputs:
+      providers: ${{ steps.changed.outputs.providers }}
+      all: ${{ steps.changed.outputs.all }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Determine changed providers
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: bash scripts/changed-providers.sh
+
   # Check if there is any dirty change for go mod tidy
   go-mod:
     runs-on: ubuntu-latest
@@ -71,9 +88,11 @@ jobs:
           version: v2.10.1
 
   golangci-lint-providers:
+    needs: detect-changed-providers
     uses: ./.github/workflows/reusable-lint-providers.yml
     with:
       only-new-issues: false
+      providers: ${{ needs.detect-changed-providers.outputs.all == 'true' && '' || needs.detect-changed-providers.outputs.providers }}
 
   go-test:
     runs-on:

--- a/.github/workflows/reusable-lint-providers.yml
+++ b/.github/workflows/reusable-lint-providers.yml
@@ -7,6 +7,10 @@ on:
         description: 'Only report new issues (requires pull-requests: read permission at caller workflow level)'
         type: boolean
         default: false
+      providers:
+        description: 'Space-separated provider names (under providers/) to lint. Empty means all providers.'
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -33,10 +37,11 @@ jobs:
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@5d1e709b7be35cb2025444e19de266b056b7b7ee    #v2.10.1
 
-      - name: Run golangci-lint on all providers
+      - name: Run golangci-lint on providers
         env:
           ONLY_NEW_ISSUES: ${{ inputs.only-new-issues }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PROVIDERS_FILTER: ${{ inputs.providers }}
         run: |
           failed=""
           extra_args=""
@@ -44,11 +49,36 @@ jobs:
             git fetch origin "${BASE_SHA}" --depth=1
             extra_args="--new-from-rev=${BASE_SHA}"
           fi
-          for provider in providers/*/; do
-            # Skip providers without go.mod (they are part of the main module)
-            if [ ! -f "$provider/go.mod" ]; then
-              continue
-            fi
+
+          if [ -n "${PROVIDERS_FILTER}" ]; then
+            echo "=== Scoped lint: ${PROVIDERS_FILTER} ==="
+            providers=""
+            for name in ${PROVIDERS_FILTER}; do
+              dir="providers/${name}"
+              if [ ! -f "${dir}/go.mod" ]; then
+                # Providers without their own go.mod live in the main module
+                # and are linted by the root golangci-lint job.
+                echo "--- Skipping ${name}: no go.mod (linted via main module)"
+                continue
+              fi
+              providers="${providers} ${dir}/"
+            done
+          else
+            echo "=== Full lint: every provider with go.mod ==="
+            providers=""
+            for provider in providers/*/; do
+              if [ -f "${provider}/go.mod" ]; then
+                providers="${providers} ${provider}"
+              fi
+            done
+          fi
+
+          if [ -z "${providers}" ]; then
+            echo "No providers to lint."
+            exit 0
+          fi
+
+          for provider in ${providers}; do
             name=$(basename "$provider")
             echo "=== Linting provider: $name ==="
             if ! (cd "$provider" && golangci-lint run --timeout=30m $extra_args); then

--- a/scripts/changed-providers.sh
+++ b/scripts/changed-providers.sh
@@ -20,7 +20,10 @@ set -euo pipefail
 
 # Patterns whose change forces a full re-run across every provider.
 # Anything outside providers/<name>/ that providers depend on belongs here.
-FORCE_ALL_PATTERN='^(providers-sdk/|providers/core/|providers/builtin(_dev)?\.go$|providers/coordinator|providers/providers|providers/extensible_schema|providers/defaults|providers/crashlog|providers/logger|providers/mock|providers\.yaml$|Makefile$|scripts/changed-providers\.sh$|\.github/workflows/(pr-test-generated-files\.yaml|pr-test-lint\.yml|pr-extended-linting\.yml|reusable-lint-providers\.yml)$|go\.mod$|go\.sum$|[^/]+\.go$)'
+# Note: `providers/[^/]+\.go$` catches every .go file directly under providers/
+# (coordinator, runtime, registry, sbom, builtin*, etc.) — they're all shared
+# plumbing that every provider relies on.
+FORCE_ALL_PATTERN='^(providers-sdk/|providers/core/|providers/[^/]+\.go$|providers\.yaml$|Makefile$|\.github/env$|scripts/changed-providers\.sh$|\.github/workflows/(pr-test-generated-files\.yaml|pr-test-lint\.yml|pr-extended-linting\.yml|reusable-lint-providers\.yml)$|go\.mod$|go\.sum$|[^/]+\.go$)'
 
 base="${BASE_SHA:-}"
 if [ -z "$base" ]; then

--- a/scripts/changed-providers.sh
+++ b/scripts/changed-providers.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Emit the set of provider directories under providers/ that changed
+# relative to a base ref, or signal that ALL providers must be re-built
+# because a shared dependency (SDK, Makefile, root sources, CI config)
+# changed.
+#
+# Inputs (env):
+#   BASE_SHA      Optional. The ref to diff against. If unset, falls back
+#                 to `git merge-base HEAD origin/main`.
+#   GITHUB_OUTPUT Optional. When set, results are appended for GHA jobs.
+#
+# Outputs (GHA $GITHUB_OUTPUT, and stdout):
+#   all=true|false        — true when every provider must be processed
+#   providers="a b c"     — space-separated list (empty when all=true)
+
+set -euo pipefail
+
+# Patterns whose change forces a full re-run across every provider.
+# Anything outside providers/<name>/ that providers depend on belongs here.
+FORCE_ALL_PATTERN='^(providers-sdk/|providers/core/|providers/builtin(_dev)?\.go$|providers/coordinator|providers/providers|providers/extensible_schema|providers/defaults|providers/crashlog|providers/logger|providers/mock|providers\.yaml$|Makefile$|scripts/changed-providers\.sh$|\.github/workflows/(pr-test-generated-files\.yaml|pr-test-lint\.yml|pr-extended-linting\.yml|reusable-lint-providers\.yml)$|go\.mod$|go\.sum$|[^/]+\.go$)'
+
+base="${BASE_SHA:-}"
+if [ -z "$base" ]; then
+  git fetch origin main --depth=100 >/dev/null 2>&1 || true
+  base=$(git merge-base HEAD origin/main 2>/dev/null || true)
+fi
+
+emit() {
+  local all="$1"
+  local providers="$2"
+  echo "all=$all"
+  echo "providers=$providers"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+      echo "all=$all"
+      echo "providers=$providers"
+    } >> "$GITHUB_OUTPUT"
+  fi
+}
+
+if [ -z "$base" ]; then
+  echo "warn: no base ref available, falling back to all providers" >&2
+  emit "true" ""
+  exit 0
+fi
+
+# Make sure the base commit is reachable locally (shallow clones).
+git fetch origin "$base" --depth=1 >/dev/null 2>&1 || true
+
+changed_files=$(git diff --name-only "$base"...HEAD)
+
+if printf '%s\n' "$changed_files" | grep -qE "$FORCE_ALL_PATTERN"; then
+  emit "true" ""
+  exit 0
+fi
+
+# Pick up changed providers/<name>/... entries, filter to ones that still exist.
+changed=$(printf '%s\n' "$changed_files" \
+  | awk -F/ '/^providers\// && NF > 2 { print $2 }' \
+  | sort -u \
+  | while read -r name; do
+      [ -d "providers/$name" ] && echo "$name"
+    done \
+  | tr '\n' ' ' \
+  | sed 's/[[:space:]]*$//')
+
+emit "false" "$changed"

--- a/scripts/changed-providers.sh
+++ b/scripts/changed-providers.sh
@@ -50,6 +50,12 @@ fi
 # Make sure the base commit is reachable locally (shallow clones).
 git fetch origin "$base" --depth=1 >/dev/null 2>&1 || true
 
+# Triple-dot diff: changes introduced on HEAD relative to the merge-base
+# with `base`. On a push directly to main the merge-base resolves to HEAD,
+# producing no files and an empty providers list. The callers treat an
+# empty list as "lint/regen all" (see the `[ -z "$CHANGED_PROVIDERS" ]`
+# branch in pr-test-generated-files.yaml and the empty-input handling in
+# reusable-lint-providers.yml), so this fallback is intentional.
 changed_files=$(git diff --name-only "$base"...HEAD)
 
 if printf '%s\n' "$changed_files" | grep -qE "$FORCE_ALL_PATTERN"; then


### PR DESCRIPTION
## Summary

CI today does heavy work for providers that didn't change. On a PR that touches only `providers/os` (e.g. #7749 the CPE cleanup):

- `generated-files` runs `make mql/generate` + `SKIP_COMPILE=yes make providers/build`, which iterates LR codegen + CLI-json gen for **every** provider (~40). 29 min.
- `golangci-lint-providers` (called from both `pr-test-lint.yml` and `pr-extended-linting.yml`) loops `providers/*/` and lints all of them. ~3 min × 2.

Each provider has its own `go.mod` and no cross-provider Go imports, so processing them independently is safe.

This PR adds `scripts/changed-providers.sh`, which diffs against `merge-base HEAD origin/main` and emits either:
- `all=true` — when a shared dep changed (`providers-sdk/`, `providers/core/`, `Makefile`, `providers.yaml`, root `*.go`, `go.{mod,sum}`, the related workflows, or the script itself), or
- `providers="os k8s"` — the list of provider dirs that actually changed.

Wired into:
- **`pr-test-generated-files.yaml`**: regenerates only changed providers (or all, when forced). Also drops the redundant `make mql/generate` pass that was already building everything before the explicit `SKIP_COMPILE=yes make providers/build` ran again. The non-provider generators (`llx/`, `shared/`, `sbom/`, `reporter/`) still run unconditionally.
- **`reusable-lint-providers.yml`**: new optional `providers` input. Empty = old behavior. Non-empty = lint only those provider dirs that have their own `go.mod`.
- **`pr-test-lint.yml`** / **`pr-extended-linting.yml`**: add a `detect-changed-providers` job and pass its output to the providers lint workflow.

## Expected impact

For a single-provider PR:
- `generated-files`: ~29 min → a few minutes (LR codegen is the dominant cost and it now runs for 1 provider instead of 40).
- Each `golangci-lint-providers`: ~3 min → under a minute.

For PRs that touch `providers-sdk/`, `providers/core/`, the Makefile, or the workflows themselves, behavior is identical to today (all providers).

## Out of scope (explicitly not changed here)

- `go-test`'s `providers/build` dependency still builds all providers. Scoping that is riskier (`providers/test` and main-module tests both feed off it), so it's a separate change.
- The duplicate `golangci-lint` between `pr-test-lint.yml` and `pr-extended-linting.yml` is still there. That's Phase 1 from the audit and was deliberately skipped here.

## Test plan

- [ ] Push to a branch and verify `generated-files` reports a single provider when only that provider changed.
- [ ] Verify a touch to `providers-sdk/` triggers `all=true` and the full provider set is processed.
- [ ] Verify `golangci-lint-providers` skips providers without `go.mod` cleanly when scoped (they're linted via the root golangci-lint job).
- [ ] Verify behavior on push events without a PR (script falls back to `merge-base HEAD origin/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)