### PR TITLE
🧹 Gitignore is too strict when ignoring mql binaries.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
 /lr
-mql
+/mql
 mqlr
 dist
 alpine-container.tar
 centos-container.tar
-./mql
 test/commands/mql
+test/providers/mql
 file1
 id_rsa
 id_rsa.pub


### PR DESCRIPTION
Having just `mql` ignores any dir that has `mql` in it, so for example adding a file like `apps/mql/cmd/file.go` was ignored. Existing files in such directories were not being ignored because they were staged beforehand. If new directories with an `mql` binary are created, they can be ignored explicitly.