### PR TITLE
Add effective SSHD algorithm fields

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -980,6 +980,12 @@ sshd.config {
   macs(params) []string
   // Key exchange algorithms configured for this SSH server
   kexs(params) []string
+  // Effective ciphers reported by sshd -T
+  effectiveCiphers() []string
+  // Effective MACs reported by sshd -T
+  effectiveMacs() []string
+  // Effective key exchange algorithms reported by sshd -T
+  effectiveKexs() []string
   // Host keys configured for this SSH server
   hostkeys(params) []string
   // Host key algorithms configured for this SSH server

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -2528,6 +2528,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"sshd.config.kexs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlSshdConfig).GetKexs()).ToDataRes(types.Array(types.String))
 	},
+	"sshd.config.effectiveCiphers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSshdConfig).GetEffectiveCiphers()).ToDataRes(types.Array(types.String))
+	},
+	"sshd.config.effectiveMacs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSshdConfig).GetEffectiveMacs()).ToDataRes(types.Array(types.String))
+	},
+	"sshd.config.effectiveKexs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSshdConfig).GetEffectiveKexs()).ToDataRes(types.Array(types.String))
+	},
 	"sshd.config.hostkeys": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlSshdConfig).GetHostkeys()).ToDataRes(types.Array(types.String))
 	},
@@ -8262,6 +8271,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"sshd.config.kexs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlSshdConfig).Kexs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"sshd.config.effectiveCiphers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSshdConfig).EffectiveCiphers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"sshd.config.effectiveMacs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSshdConfig).EffectiveMacs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"sshd.config.effectiveKexs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSshdConfig).EffectiveKexs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"sshd.config.hostkeys": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -19739,6 +19760,9 @@ type mqlSshdConfig struct {
 	Ciphers           plugin.TValue[[]any]
 	Macs              plugin.TValue[[]any]
 	Kexs              plugin.TValue[[]any]
+	EffectiveCiphers  plugin.TValue[[]any]
+	EffectiveMacs     plugin.TValue[[]any]
+	EffectiveKexs     plugin.TValue[[]any]
 	Hostkeys          plugin.TValue[[]any]
 	Hostkeyalgorithms plugin.TValue[[]any]
 	PermitRootLogin   plugin.TValue[[]any]
@@ -19880,6 +19904,24 @@ func (c *mqlSshdConfig) GetKexs() *plugin.TValue[[]any] {
 		}
 
 		return c.kexs(vargParams.Data)
+	})
+}
+
+func (c *mqlSshdConfig) GetEffectiveCiphers() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectiveCiphers, func() ([]any, error) {
+		return c.effectiveCiphers()
+	})
+}
+
+func (c *mqlSshdConfig) GetEffectiveMacs() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectiveMacs, func() ([]any, error) {
+		return c.effectiveMacs()
+	})
+}
+
+func (c *mqlSshdConfig) GetEffectiveKexs() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectiveKexs, func() ([]any, error) {
+		return c.effectiveKexs()
 	})
 }
 

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -1667,6 +1667,9 @@ sshd 9.0.0
 sshd.config 9.0.0
 sshd.config.blocks 10.0.5
 sshd.config.ciphers 9.0.0
+sshd.config.effectiveCiphers 13.16.9
+sshd.config.effectiveKexs 13.16.9
+sshd.config.effectiveMacs 13.16.9
 sshd.config.file 9.0.0
 sshd.config.files 9.0.0
 sshd.config.hostkeyalgorithms 13.10.1

--- a/providers/os/resources/sshd.go
+++ b/providers/os/resources/sshd.go
@@ -6,6 +6,8 @@ package resources
 
 import (
 	"errors"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -21,7 +23,11 @@ import (
 )
 
 type mqlSshdConfigInternal struct {
-	lock sync.Mutex
+	lock                 sync.Mutex
+	effectiveLock        sync.Mutex
+	effectiveFetched     bool
+	effectiveParamsCache map[string]string
+	effectiveParamsErr   error
 }
 
 func initSshdConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -46,6 +52,8 @@ func initSshdConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 }
 
 const defaultSshdConfig = "/etc/ssh/sshd_config"
+
+const sshdEffectiveConfigCommand = "sshd -T"
 
 func (s *mqlSshdConfig) id() (string, error) {
 	file := s.GetFile()
@@ -279,6 +287,113 @@ func (s *mqlSshdConfig) kexs(params map[string]any) ([]any, error) {
 	}
 
 	return parseConfigEntrySlice(rawkexs)
+}
+
+func parseEffectiveSshdConfig(input string) map[string]string {
+	res := map[string]string{}
+	lines := strings.Split(input, "\n")
+	for i := range lines {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+
+		key, value, ok := strings.Cut(line, " ")
+		key = strings.ToLower(strings.TrimSpace(key))
+		if !ok {
+			res[key] = ""
+			continue
+		}
+		res[key] = strings.TrimSpace(value)
+	}
+	return res
+}
+
+func (s *mqlSshdConfig) effectiveParams() (map[string]string, error) {
+	s.effectiveLock.Lock()
+	defer s.effectiveLock.Unlock()
+	if s.effectiveFetched {
+		return s.effectiveParamsCache, s.effectiveParamsErr
+	}
+	defer func() {
+		s.effectiveFetched = true
+	}()
+
+	conn, ok := s.MqlRuntime.Connection.(shared.Connection)
+	if !ok || !conn.Capabilities().Has(shared.Capability_RunCommand) {
+		s.effectiveParamsCache = map[string]string{}
+		return s.effectiveParamsCache, nil
+	}
+
+	command, err := s.effectiveConfigCommand()
+	if err != nil {
+		s.effectiveParamsErr = err
+		return nil, err
+	}
+
+	cmd, err := conn.RunCommand(command)
+	if err != nil {
+		s.effectiveParamsErr = err
+		return nil, err
+	}
+	if cmd.ExitStatus != 0 {
+		stderr, _ := io.ReadAll(cmd.Stderr)
+		err := fmt.Errorf("%s failed (exit %d): %s", command, cmd.ExitStatus, strings.TrimSpace(string(stderr)))
+		s.effectiveParamsErr = err
+		return nil, err
+	}
+
+	stdout, err := io.ReadAll(cmd.Stdout)
+	if err != nil {
+		s.effectiveParamsErr = err
+		return nil, err
+	}
+
+	s.effectiveParamsCache = parseEffectiveSshdConfig(string(stdout))
+	return s.effectiveParamsCache, nil
+}
+
+func (s *mqlSshdConfig) effectiveConfigCommand() (string, error) {
+	file := s.GetFile()
+	if file.Error != nil {
+		return "", file.Error
+	}
+	if file.Data == nil || file.Data.Path.Data == "" || file.Data.Path.Data == defaultSshdConfig {
+		return sshdEffectiveConfigCommand, nil
+	}
+	return sshdEffectiveConfigCommand + " -f " + shared.ShellEscape(file.Data.Path.Data), nil
+}
+
+func effectiveConfigEntrySlice(params map[string]string, key string) ([]any, error) {
+	raw, ok := params[key]
+	if !ok {
+		return nil, nil
+	}
+	return parseConfigEntrySlice(raw)
+}
+
+func (s *mqlSshdConfig) effectiveCiphers() ([]any, error) {
+	params, err := s.effectiveParams()
+	if err != nil {
+		return nil, err
+	}
+	return effectiveConfigEntrySlice(params, "ciphers")
+}
+
+func (s *mqlSshdConfig) effectiveMacs() ([]any, error) {
+	params, err := s.effectiveParams()
+	if err != nil {
+		return nil, err
+	}
+	return effectiveConfigEntrySlice(params, "macs")
+}
+
+func (s *mqlSshdConfig) effectiveKexs() ([]any, error) {
+	params, err := s.effectiveParams()
+	if err != nil {
+		return nil, err
+	}
+	return effectiveConfigEntrySlice(params, "kexalgorithms")
 }
 
 func (s *mqlSshdConfig) hostkeys(params map[string]any) ([]any, error) {

--- a/providers/os/resources/sshd_internal_test.go
+++ b/providers/os/resources/sshd_internal_test.go
@@ -1,0 +1,105 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/connection/mock"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+func TestSshdConfigEffectiveAlgorithms(t *testing.T) {
+	runtime := sshdEffectiveConfigMockRuntime(t, map[string]*mock.Command{
+		sshdEffectiveConfigCommand: {
+			Command: sshdEffectiveConfigCommand,
+			Stdout: `ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-ctr
+macs hmac-sha2-512-etm@openssh.com,hmac-sha2-256
+kexalgorithms sntrup761x25519-sha512,mlkem768x25519-sha256,curve25519-sha256
+`,
+			ExitStatus: 0,
+		},
+	})
+
+	raw, err := CreateResource(runtime, ResourceSshdConfig, nil)
+	require.NoError(t, err)
+
+	config := raw.(*mqlSshdConfig)
+	ciphers := config.GetEffectiveCiphers()
+	require.NoError(t, ciphers.Error)
+	assert.Equal(t, []any{"chacha20-poly1305@openssh.com", "aes256-gcm@openssh.com", "aes128-ctr"}, ciphers.Data)
+
+	macs := config.GetEffectiveMacs()
+	require.NoError(t, macs.Error)
+	assert.Equal(t, []any{"hmac-sha2-512-etm@openssh.com", "hmac-sha2-256"}, macs.Data)
+
+	kexs := config.GetEffectiveKexs()
+	require.NoError(t, kexs.Error)
+	assert.Equal(t, []any{"sntrup761x25519-sha512", "mlkem768x25519-sha256", "curve25519-sha256"}, kexs.Data)
+}
+
+func TestSshdConfigEffectiveAlgorithmsCustomPath(t *testing.T) {
+	command := sshdEffectiveConfigCommand + " -f '/tmp/sshd config'"
+	runtime := sshdEffectiveConfigMockRuntime(t, map[string]*mock.Command{
+		command: {
+			Command:    command,
+			Stdout:     "ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com\n",
+			ExitStatus: 0,
+		},
+	})
+
+	raw, err := NewResource(runtime, ResourceSshdConfig, map[string]*llx.RawData{
+		"path": llx.StringData("/tmp/sshd config"),
+	})
+	require.NoError(t, err)
+
+	config := raw.(*mqlSshdConfig)
+	ciphers := config.GetEffectiveCiphers()
+	require.NoError(t, ciphers.Error)
+	assert.Equal(t, []any{"aes256-gcm@openssh.com", "aes128-gcm@openssh.com"}, ciphers.Data)
+}
+
+func TestSshdConfigEffectiveAlgorithmsCommandFailure(t *testing.T) {
+	runtime := sshdEffectiveConfigMockRuntime(t, map[string]*mock.Command{
+		sshdEffectiveConfigCommand: {
+			Command:    sshdEffectiveConfigCommand,
+			Stderr:     "bad sshd configuration",
+			ExitStatus: 255,
+		},
+	})
+
+	raw, err := CreateResource(runtime, ResourceSshdConfig, nil)
+	require.NoError(t, err)
+
+	config := raw.(*mqlSshdConfig)
+	ciphers := config.GetEffectiveCiphers()
+	require.ErrorContains(t, ciphers.Error, "sshd -T failed (exit 255): bad sshd configuration")
+}
+
+func sshdEffectiveConfigMockRuntime(t *testing.T, commands map[string]*mock.Command) *plugin.Runtime {
+	t.Helper()
+
+	asset := &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:    "linux",
+			Family:  []string{"linux", "unix", "os"},
+			Version: "test",
+		},
+	}
+	conn, err := mock.New(0, asset, mock.WithData(&mock.TomlData{
+		Commands: commands,
+		Files:    map[string]*mock.MockFileData{},
+	}))
+	require.NoError(t, err)
+
+	return &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+}


### PR DESCRIPTION
## Summary
- add sshd.config effective algorithm fields backed by sshd -T
- support custom config paths via sshd -T -f with shell escaping
- add tests for parsing, custom path handling, and command failures

## Testing
- GOCACHE=/tmp/mql-gocache go test ./providers/os/resources
