### PR TITLE
Trigger docs MQL resources update on provider release

### DIFF
--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -243,6 +243,7 @@ jobs:
           owner: mondoohq
           repositories: |
             releasr
+            docs
 
       - name: Trigger Reindex of releases.mondoo.com
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
@@ -252,4 +253,15 @@ jobs:
           event-type: reindex
           client-payload: '{
             "apps": "providers"
+            }'
+
+      - name: Trigger MQL resources update in mondoohq/docs
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          repository: "mondoohq/docs"
+          event-type: update-mql-resources
+          client-payload: '{
+              "mql_sha": "${{ github.sha }}",
+              "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }'


### PR DESCRIPTION
## Summary

- After all providers are built and indexed in the `provider-index` job, fire a `repository_dispatch` event at `mondoohq/docs` so the docs site can regenerate `mql-schema/` and `lib/mql-url-redirects.json` automatically.
- Expands the existing mergebot app token to include `docs` so the same step that already dispatches to `mondoohq/releasr` can also reach `mondoohq/docs`.
- The docs workflow ([mondoohq/docs#1356](https://github.com/mondoohq/docs/pull/1356)) regenerates from `main` of both source repos. The `client_payload` carries `mql_sha` and `run_url` as metadata so the auto-opened docs PR can link back to the release commit that triggered it.

## Why

Today the docs MQL regen workflow is `workflow_dispatch`-only — someone has to remember to run it after each provider release. This wires up the dispatch automatically so docs stays in sync without manual intervention.

A matching dispatch will be added in `mondoohq/mql-enterprise-providers` so both source repos trigger docs regen.

## Test plan

- [ ] Trigger `Build & Release Providers` via the Actions UI with `skip_publish=false` against a branch with a real version bump
- [ ] Confirm `provider-index` runs, both the existing releasr dispatch AND the new docs dispatch fire
- [ ] Confirm the docs `update-mql-resources` workflow runs and either opens a regen PR or correctly reports no changes
- [ ] Negative: trigger with `skip_publish=true` and confirm `provider-index` is skipped and no docs dispatch fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)