### PR TITLE
🐛 keep queries in shell history even if they don't work

### DIFF
--- a/cli/shell/model.go
+++ b/cli/shell/model.go
@@ -549,7 +549,7 @@ func (m *shellModel) executeQuery(input string) (tea.Model, tea.Cmd) {
 
 	// Query is complete (or has error) - execute it
 	cleanCommand := m.query
-	if code != nil {
+	if code != nil && code.Source != "" {
 		cleanCommand = code.Source
 	}
 


### PR DESCRIPTION
Whenever I'm experimenting and if I fail to enter something correctly, it just disappears and I have to type it all in again. This fixes it
