### PR TITLE
🧹 providers: fsync provider files before rename to prevent zeroed schema files

### DIFF
--- a/providers/providers.go
+++ b/providers/providers.go
@@ -617,10 +617,22 @@ func InstallIO(reader io.ReadCloser, conf InstallConf) ([]*Provider, error) {
 		if err != nil {
 			return err
 		}
-		defer writer.Close()
 
-		_, err = io.Copy(writer, reader)
-		return err
+		if _, err = io.Copy(writer, reader); err != nil {
+			writer.Close()
+			return err
+		}
+		// Flush the file's data to disk before it gets renamed into the
+		// providers directory. Without this, a crash between the rename and
+		// the kernel writing back the page cache can leave the renamed file
+		// pointing at unwritten (zeroed) blocks, which later panics schema
+		// loading with "invalid character '\x00'". Sync also surfaces
+		// writeback errors (e.g. ENOSPC) that Close() would silently drop.
+		if err = writer.Sync(); err != nil {
+			writer.Close()
+			return err
+		}
+		return writer.Close()
 	})
 	if err != nil {
 		return nil, err
@@ -678,6 +690,10 @@ func InstallIO(reader io.ReadCloser, conf InstallConf) ([]*Provider, error) {
 			return nil, err
 		}
 
+		// Flush the directory entries so the renames above are durable;
+		// otherwise a crash can leave the provider half-installed.
+		syncDir(dstPath)
+
 		providerDirs = append(providerDirs, dstPath)
 	}
 
@@ -714,6 +730,23 @@ func InstallIO(reader io.ReadCloser, conf InstallConf) ([]*Provider, error) {
 	LastProviderInstall = time.Now().Unix()
 
 	return res, nil
+}
+
+// syncDir flushes a directory's entries to disk so that renames into it
+// survive a crash. It is best-effort: directory fsync is not supported on
+// every platform (notably Windows), so failures are logged, not returned.
+// Even when the directory sync is skipped, the per-file Sync in InstallIO
+// still prevents the renamed file from pointing at zeroed blocks.
+func syncDir(path string) {
+	dir, err := os.Open(path)
+	if err != nil {
+		log.Warn().Err(err).Str("path", path).Msg("failed to open provider directory for sync")
+		return
+	}
+	defer dir.Close()
+	if err := dir.Sync(); err != nil {
+		log.Warn().Err(err).Str("path", path).Msg("failed to sync provider directory")
+	}
 }
 
 func walkTarXz(reader io.Reader, callback func(reader *tar.Reader, header *tar.Header) error) error {


### PR DESCRIPTION
## Problem

Clients have been reporting a startup panic:

```
panic: failed to embed schema for os: invalid character '\x00' looking for beginning of value
  ...
  providers.MustLoadSchema(...)        providers/providers.go:947
  providers.MustLoadSchemaFromFile(...) providers/providers.go:957
  providers.readProviderDir(...)        providers/providers.go:824
  providers.findProviders(...)
  providers.ListAll() / ListActive()
  cli/providers.AttachCLIs(...)
```

The file (`<provider>.resources.json`) is read successfully but fails to JSON-unmarshal because its **content is all NUL bytes** while its size is intact. A single corrupt provider file takes down the entire binary at startup — before any command can dispatch.

## Root cause

`InstallIO` unpacks provider files into a temp dir and `os.Rename`s them into place. `os.Rename` is atomic for the *directory entry*, but the install path never calls `fsync`:

- `io.Copy` writes the file data into the **page cache** only.
- `Close()` does **not** imply `fsync()`.
- The rename's metadata can become durable on disk *before* the file's data blocks are written back.

If the machine loses power / panics / the VM or container is hard-killed in that window, recovery replays the rename — the directory entry points at an inode with the correct **size** but **unwritten data blocks**, which the filesystem returns as zeros (well-known ext4 `delalloc` behavior; `auto_da_alloc` only helps when a rename *replaces* an existing file, not on a fresh install).

The same zeroed-file symptom also occurs **without a crash**: with delayed allocation, a writeback failure (`ENOSPC`, `EIO`, quota) happens *after* `Close()` returned success — and since nobody ever calls `fsync`, the application never sees the error. The kernel drops the dirty pages and the file reads back as zeros.

## Fix

Complete the durable-write recipe in `InstallIO` — *write temp → fsync file → close → rename → fsync dir*:

1. **Per-file `Sync()` before rename.** Each unpacked file is fsync'd before it's renamed into the providers directory, so a crash can no longer leave a renamed file pointing at zeroed blocks. As a bonus, `Sync()` surfaces writeback errors (e.g. `ENOSPC`) that `Close()` was silently swallowing — a failed install now aborts loudly instead of shipping a corrupt file.
2. **Directory `Sync()` after the renames.** New `syncDir` helper fsyncs the destination directory so the rename entries themselves are durable. It is best-effort (directory fsync isn't portable — notably Windows), so failures are logged, not returned. That degrades safely: even where the directory sync is skipped, step 1 still holds, so the worst case becomes "file missing after crash" (handled gracefully — provider skipped) rather than "file zeroed" (panic).

## Scope / non-goals

- The `MustLoadSchema` panic is **intentionally left in place** — it remains the correct loud signal for a genuinely corrupt file.
- This prevents *new* corruption; it cannot heal files already zeroed and baked into a CI cache, VM image, or container layer. Those still need the affected provider dir deleted and reinstalled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)