### PR TITLE
✨ Add filters for ECR repositories.

### DIFF
--- a/providers/aws/connection/filters.go
+++ b/providers/aws/connection/filters.go
@@ -39,8 +39,11 @@ func DiscoveryFiltersFromOpts(opts map[string]string) DiscoveryFilters {
 			ExcludeInstanceIds: parseCsvSliceOpt(opts, "ec2:exclude:instance-ids"),
 		},
 		Ecr: EcrDiscoveryFilters{
-			Tags:        parseCsvSliceOpt(opts, "ecr:tags"),
-			ExcludeTags: parseCsvSliceOpt(opts, "ecr:exclude:tags"),
+			Tags:                   parseCsvSliceOpt(opts, "ecr:tags"),
+			ExcludeTags:            parseCsvSliceOpt(opts, "ecr:exclude:tags"),
+			PrivateRepositoryNames: parseCsvSliceOpt(opts, "ecr:private-repository-names"),
+			PublicRepositoryNames:  parseCsvSliceOpt(opts, "ecr:public-repository-names"),
+			Scope:                  parseStringOpt(opts, "ecr:scope"),
 		},
 		Ecs: EcsDiscoveryFilters{
 			OnlyRunningContainers: parseBoolOpt(opts, "ecs:only-running-containers", false),
@@ -135,9 +138,20 @@ func (f Ec2DiscoveryFilters) MatchesExcludeInstanceIds(instanceId *string) bool 
 	return instanceId != nil && slices.Contains(f.ExcludeInstanceIds, *instanceId)
 }
 
+// Values for EcrDiscoveryFilters.Scope. An empty Scope means both.
+const (
+	EcrScopePrivate = "private"
+	EcrScopePublic  = "public"
+)
+
 type EcrDiscoveryFilters struct {
-	Tags        []string
-	ExcludeTags []string
+	Tags                   []string
+	ExcludeTags            []string
+	PrivateRepositoryNames []string
+	PublicRepositoryNames  []string
+	// Scope restricts discovery to one registry visibility. Allowed values are
+	// EcrScopePrivate and EcrScopePublic; an empty string means both.
+	Scope string
 }
 
 func (f EcrDiscoveryFilters) IsFilteredOutByTags(imageTags []string) bool {
@@ -216,6 +230,16 @@ func parseMapOpt(opts map[string]string, keyPrefix string) map[string]string {
 		res[strings.TrimPrefix(k, keyPrefix)] = v
 	}
 	return res
+}
+
+// Given a map of options and a key, return the string value for that key.
+// Returns "" if the key is missing or its value is empty.
+// Example:
+// key = "ecr:scope"
+// opts = {"ecr:scope": "private"}
+// returns "private"
+func parseStringOpt(opts map[string]string, key string) string {
+	return opts[key]
 }
 
 // Given a map of options and a key, return a slice of strings

--- a/providers/aws/connection/filters_test.go
+++ b/providers/aws/connection/filters_test.go
@@ -247,6 +247,12 @@ func TestDiscoveryFiltersFromOpts(t *testing.T) {
 			"ecr:tags": "tag1,tag2",
 			// EcrDiscoveryFilters.ExcludeTags
 			"ecr:exclude:tags": "tag1,tag2",
+			// EcrDiscoveryFilters.PrivateRepositoryNames
+			"ecr:private-repository-names": "priv1,priv2",
+			// EcrDiscoveryFilters.PublicRepositoryNames
+			"ecr:public-repository-names": "pub1,pub2",
+			// EcrDiscoveryFilters.Scope
+			"ecr:scope": "private",
 			// EcsDiscoveryFilters
 			"ecs:only-running-containers": "true",
 			"ecs:discover-images":         "T",
@@ -279,8 +285,11 @@ func TestDiscoveryFiltersFromOpts(t *testing.T) {
 				DiscoverInstances:     false,
 			},
 			Ecr: EcrDiscoveryFilters{
-				Tags:        []string{"tag1", "tag2"},
-				ExcludeTags: []string{"tag1", "tag2"},
+				Tags:                   []string{"tag1", "tag2"},
+				ExcludeTags:            []string{"tag1", "tag2"},
+				PrivateRepositoryNames: []string{"priv1", "priv2"},
+				PublicRepositoryNames:  []string{"pub1", "pub2"},
+				Scope:                  EcrScopePrivate,
 			},
 			PropagateAccountTags: true,
 			AccountTags: map[string]string{
@@ -306,8 +315,10 @@ func TestDiscoveryFiltersFromOpts(t *testing.T) {
 				ExcludeInstanceIds: []string{},
 			},
 			Ecr: EcrDiscoveryFilters{
-				Tags:        []string{},
-				ExcludeTags: []string{},
+				Tags:                   []string{},
+				ExcludeTags:            []string{},
+				PrivateRepositoryNames: []string{},
+				PublicRepositoryNames:  []string{},
 			},
 			Ecs:         EcsDiscoveryFilters{},
 			AccountTags: map[string]string{},
@@ -329,8 +340,10 @@ func TestDiscoveryFiltersFromOpts(t *testing.T) {
 				ExcludeInstanceIds: []string{},
 			},
 			Ecr: EcrDiscoveryFilters{
-				Tags:        []string{},
-				ExcludeTags: []string{},
+				Tags:                   []string{},
+				ExcludeTags:            []string{},
+				PrivateRepositoryNames: []string{},
+				PublicRepositoryNames:  []string{},
 			},
 			Ecs:         EcsDiscoveryFilters{},
 			AccountTags: map[string]string{},

--- a/providers/aws/provider/provider.go
+++ b/providers/aws/provider/provider.go
@@ -110,6 +110,9 @@ func parseFlagsToFiltersOpts(m map[string]*llx.Primitive) map[string]string {
 			// ecr filters
 			"ecr:tags",
 			"ecr:exclude:tags",
+			"ecr:private-repository-names",
+			"ecr:public-repository-names",
+			"ecr:scope",
 			// ecs filters
 			"ecs:only-running-containers",
 			"ecs:discover-instances",

--- a/providers/aws/resources/aws_ecr.go
+++ b/providers/aws/resources/aws_ecr.go
@@ -160,6 +160,8 @@ func (a *mqlAwsEcr) getPrivateRepositories(conn *connection.AwsConnection) []*jo
 			res := []any{}
 
 			paginator := ecr.NewDescribeRepositoriesPaginator(svc, &ecr.DescribeRepositoriesInput{
+				// AWS does not do partial results and returns an error if a single repository
+				// supplied in the filters is not found
 				RepositoryNames: conn.Filters.Ecr.PrivateRepositoryNames,
 			})
 			for paginator.HasMorePages() {
@@ -521,7 +523,9 @@ func (a *mqlAwsEcr) publicRepositories() ([]any, error) {
 	res := []any{}
 
 	paginator := ecrpublic.NewDescribeRepositoriesPaginator(svc, &ecrpublic.DescribeRepositoriesInput{
-		RegistryId:      aws.String(conn.AccountId()),
+		RegistryId: aws.String(conn.AccountId()),
+		// AWS does not do partial results and returns an error if a single repository
+		// supplied in the filters is not found
 		RepositoryNames: conn.Filters.Ecr.PublicRepositoryNames,
 	})
 	for paginator.HasMorePages() {

--- a/providers/aws/resources/aws_ecr.go
+++ b/providers/aws/resources/aws_ecr.go
@@ -125,6 +125,10 @@ func (a *mqlAwsEcr) images() ([]any, error) {
 func (a *mqlAwsEcr) privateRepositories() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
+	if conn.Filters.Ecr.Scope == connection.EcrScopePublic {
+		return []any{}, nil
+	}
+
 	res := []any{}
 	poolOfJobs := jobpool.CreatePool(a.getPrivateRepositories(conn), 5)
 	poolOfJobs.Run()
@@ -155,7 +159,9 @@ func (a *mqlAwsEcr) getPrivateRepositories(conn *connection.AwsConnection) []*jo
 			svc := conn.Ecr(region)
 			res := []any{}
 
-			paginator := ecr.NewDescribeRepositoriesPaginator(svc, &ecr.DescribeRepositoriesInput{})
+			paginator := ecr.NewDescribeRepositoriesPaginator(svc, &ecr.DescribeRepositoriesInput{
+				RepositoryNames: conn.Filters.Ecr.PrivateRepositoryNames,
+			})
 			for paginator.HasMorePages() {
 				repoResp, err := paginator.NextPage(ctx)
 				if err != nil {
@@ -507,10 +513,17 @@ func initAwsEcrImage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 func (a *mqlAwsEcr) publicRepositories() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
+	if conn.Filters.Ecr.Scope == connection.EcrScopePrivate {
+		return []any{}, nil
+	}
+
 	svc := conn.EcrPublic("us-east-1") // only supported for us-east-1
 	res := []any{}
 
-	paginator := ecrpublic.NewDescribeRepositoriesPaginator(svc, &ecrpublic.DescribeRepositoriesInput{RegistryId: aws.String(conn.AccountId())})
+	paginator := ecrpublic.NewDescribeRepositoriesPaginator(svc, &ecrpublic.DescribeRepositoriesInput{
+		RegistryId:      aws.String(conn.AccountId()),
+		RepositoryNames: conn.Filters.Ecr.PublicRepositoryNames,
+	})
 	for paginator.HasMorePages() {
 		repoResp, err := paginator.NextPage(context.TODO())
 		if err != nil {


### PR DESCRIPTION
#### In this PR
Added 3 filters:
- public repo names - `[]string`, the public repo names to consider
- private repo names - `[]string`, the private repo names to consider
- ecr scope - `string`, can be `public` or `private` (both if not specified)

Note: AWS does not do partial matching, so if a single repository name from the filters is not found, an error will be returned.