### PR TITLE
✨ azure: typed list scalars + provisioningState on NSG security rules

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -2170,12 +2170,22 @@ private azure.subscription.networkService.securityrule @defaults("id name") {
   sourceAddressPrefix string
   // Security rule destination address prefix (CIDR or *)
   destinationAddressPrefix string
+  // Security rule source port ranges (list form; empty when only `sourcePortRange` is set)
+  sourcePortRanges []string
+  // Security rule destination port ranges (raw list form preserving CIDR-style entries; empty when only `destinationPortRange` is set)
+  destinationPortRanges []string
+  // Security rule source address prefixes (list form; empty when only `sourceAddressPrefix` is set)
+  sourceAddressPrefixes []string
+  // Security rule destination address prefixes (list form; empty when only `destinationAddressPrefix` is set)
+  destinationAddressPrefixes []string
   // Application security groups the rule sources traffic from
   sourceApplicationSecurityGroups() []azure.subscription.networkService.appSecurityGroup
   // Application security groups the rule targets as destination
   destinationApplicationSecurityGroups() []azure.subscription.networkService.appSecurityGroup
   // Security rule description
   description string
+  // Provisioning state of the rule (e.g., "Succeeded", "Failed", "Updating")
+  provisioningState string
 }
 
 // Azure Network Watcher

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -4273,6 +4273,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.securityrule.destinationAddressPrefix": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).GetDestinationAddressPrefix()).ToDataRes(types.String)
 	},
+	"azure.subscription.networkService.securityrule.sourcePortRanges": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).GetSourcePortRanges()).ToDataRes(types.Array(types.String))
+	},
+	"azure.subscription.networkService.securityrule.destinationPortRanges": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).GetDestinationPortRanges()).ToDataRes(types.Array(types.String))
+	},
+	"azure.subscription.networkService.securityrule.sourceAddressPrefixes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).GetSourceAddressPrefixes()).ToDataRes(types.Array(types.String))
+	},
+	"azure.subscription.networkService.securityrule.destinationAddressPrefixes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).GetDestinationAddressPrefixes()).ToDataRes(types.Array(types.String))
+	},
 	"azure.subscription.networkService.securityrule.sourceApplicationSecurityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).GetSourceApplicationSecurityGroups()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.appSecurityGroup")))
 	},
@@ -4281,6 +4293,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.securityrule.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).GetDescription()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.securityrule.provisioningState": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).GetProvisioningState()).ToDataRes(types.String)
 	},
 	"azure.subscription.networkService.watcher.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceWatcher).GetId()).ToDataRes(types.String)
@@ -16197,6 +16212,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).DestinationAddressPrefix, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.networkService.securityrule.sourcePortRanges": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).SourcePortRanges, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.securityrule.destinationPortRanges": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).DestinationPortRanges, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.securityrule.sourceAddressPrefixes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).SourceAddressPrefixes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.securityrule.destinationAddressPrefixes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).DestinationAddressPrefixes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.networkService.securityrule.sourceApplicationSecurityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).SourceApplicationSecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -16207,6 +16238,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.securityrule.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.securityrule.provisioningState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceSecurityrule).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.watcher.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -36907,9 +36942,14 @@ type mqlAzureSubscriptionNetworkServiceSecurityrule struct {
 	SourcePortRange                      plugin.TValue[string]
 	SourceAddressPrefix                  plugin.TValue[string]
 	DestinationAddressPrefix             plugin.TValue[string]
+	SourcePortRanges                     plugin.TValue[[]any]
+	DestinationPortRanges                plugin.TValue[[]any]
+	SourceAddressPrefixes                plugin.TValue[[]any]
+	DestinationAddressPrefixes           plugin.TValue[[]any]
 	SourceApplicationSecurityGroups      plugin.TValue[[]any]
 	DestinationApplicationSecurityGroups plugin.TValue[[]any]
 	Description                          plugin.TValue[string]
+	ProvisioningState                    plugin.TValue[string]
 }
 
 // createAzureSubscriptionNetworkServiceSecurityrule creates a new instance of this resource
@@ -36997,6 +37037,22 @@ func (c *mqlAzureSubscriptionNetworkServiceSecurityrule) GetDestinationAddressPr
 	return &c.DestinationAddressPrefix
 }
 
+func (c *mqlAzureSubscriptionNetworkServiceSecurityrule) GetSourcePortRanges() *plugin.TValue[[]any] {
+	return &c.SourcePortRanges
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceSecurityrule) GetDestinationPortRanges() *plugin.TValue[[]any] {
+	return &c.DestinationPortRanges
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceSecurityrule) GetSourceAddressPrefixes() *plugin.TValue[[]any] {
+	return &c.SourceAddressPrefixes
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceSecurityrule) GetDestinationAddressPrefixes() *plugin.TValue[[]any] {
+	return &c.DestinationAddressPrefixes
+}
+
 func (c *mqlAzureSubscriptionNetworkServiceSecurityrule) GetSourceApplicationSecurityGroups() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.SourceApplicationSecurityGroups, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -37031,6 +37087,10 @@ func (c *mqlAzureSubscriptionNetworkServiceSecurityrule) GetDestinationApplicati
 
 func (c *mqlAzureSubscriptionNetworkServiceSecurityrule) GetDescription() *plugin.TValue[string] {
 	return &c.Description
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceSecurityrule) GetProvisioningState() *plugin.TValue[string] {
+	return &c.ProvisioningState
 }
 
 // mqlAzureSubscriptionNetworkServiceWatcher for the azure.subscription.networkService.watcher resource

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -2562,8 +2562,10 @@ azure.subscription.networkService.securityrule 9.0.1
 azure.subscription.networkService.securityrule.access 11.4.28
 azure.subscription.networkService.securityrule.description 11.4.28
 azure.subscription.networkService.securityrule.destinationAddressPrefix 11.4.28
+azure.subscription.networkService.securityrule.destinationAddressPrefixes 13.12.2
 azure.subscription.networkService.securityrule.destinationApplicationSecurityGroups 13.11.2
 azure.subscription.networkService.securityrule.destinationPortRange 9.0.1
+azure.subscription.networkService.securityrule.destinationPortRanges 13.12.2
 azure.subscription.networkService.securityrule.direction 9.0.1
 azure.subscription.networkService.securityrule.etag 9.0.1
 azure.subscription.networkService.securityrule.id 9.0.1
@@ -2571,9 +2573,12 @@ azure.subscription.networkService.securityrule.name 9.0.1
 azure.subscription.networkService.securityrule.priority 11.4.28
 azure.subscription.networkService.securityrule.properties 9.0.1
 azure.subscription.networkService.securityrule.protocol 11.4.28
+azure.subscription.networkService.securityrule.provisioningState 13.12.2
 azure.subscription.networkService.securityrule.sourceAddressPrefix 11.4.28
+azure.subscription.networkService.securityrule.sourceAddressPrefixes 13.12.2
 azure.subscription.networkService.securityrule.sourceApplicationSecurityGroups 13.11.2
 azure.subscription.networkService.securityrule.sourcePortRange 11.4.28
+azure.subscription.networkService.securityrule.sourcePortRanges 13.12.2
 azure.subscription.networkService.serviceEndpointPolicies 13.3.3
 azure.subscription.networkService.serviceEndpointPolicy 13.3.3
 azure.subscription.networkService.serviceEndpointPolicy.definition 13.3.3

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -3506,8 +3506,12 @@ func azureSecurityRuleToMql(runtime *plugin.Runtime, secRule network.SecurityRul
 		}
 	}
 
-	var direction, protocol, access, sourcePortRange, sourceAddressPrefix, destinationAddressPrefix, description *llx.RawData
+	var direction, protocol, access, sourcePortRange, sourceAddressPrefix, destinationAddressPrefix, description, provisioningState *llx.RawData
 	var priority *llx.RawData
+	sourcePortRanges := []any{}
+	destinationPortRanges := []any{}
+	sourceAddressPrefixes := []any{}
+	destinationAddressPrefixes := []any{}
 	if secRule.Properties != nil {
 		direction = llx.StringDataPtr((*string)(secRule.Properties.Direction))
 		if secRule.Properties.Protocol != nil {
@@ -3525,6 +3529,27 @@ func azureSecurityRuleToMql(runtime *plugin.Runtime, secRule network.SecurityRul
 		sourceAddressPrefix = llx.StringDataPtr(secRule.Properties.SourceAddressPrefix)
 		destinationAddressPrefix = llx.StringDataPtr(secRule.Properties.DestinationAddressPrefix)
 		description = llx.StringDataPtr(secRule.Properties.Description)
+		provisioningState = llx.StringDataPtr((*string)(secRule.Properties.ProvisioningState))
+		for _, p := range secRule.Properties.SourcePortRanges {
+			if p != nil {
+				sourcePortRanges = append(sourcePortRanges, *p)
+			}
+		}
+		for _, p := range secRule.Properties.DestinationPortRanges {
+			if p != nil {
+				destinationPortRanges = append(destinationPortRanges, *p)
+			}
+		}
+		for _, p := range secRule.Properties.SourceAddressPrefixes {
+			if p != nil {
+				sourceAddressPrefixes = append(sourceAddressPrefixes, *p)
+			}
+		}
+		for _, p := range secRule.Properties.DestinationAddressPrefixes {
+			if p != nil {
+				destinationAddressPrefixes = append(destinationAddressPrefixes, *p)
+			}
+		}
 	} else {
 		direction = llx.StringData("")
 		protocol = llx.StringData("")
@@ -3534,23 +3559,29 @@ func azureSecurityRuleToMql(runtime *plugin.Runtime, secRule network.SecurityRul
 		sourceAddressPrefix = llx.StringData("")
 		destinationAddressPrefix = llx.StringData("")
 		description = llx.StringData("")
+		provisioningState = llx.StringData("")
 	}
 
 	res, err := CreateResource(runtime, "azure.subscription.networkService.securityrule",
 		map[string]*llx.RawData{
-			"id":                       llx.StringDataPtr(secRule.ID),
-			"name":                     llx.StringDataPtr(secRule.Name),
-			"etag":                     llx.StringDataPtr(secRule.Etag),
-			"direction":                direction,
-			"properties":               llx.DictData(properties),
-			"destinationPortRange":     llx.ArrayData(destinationPortRange, types.String),
-			"protocol":                 protocol,
-			"access":                   access,
-			"priority":                 priority,
-			"sourcePortRange":          sourcePortRange,
-			"sourceAddressPrefix":      sourceAddressPrefix,
-			"destinationAddressPrefix": destinationAddressPrefix,
-			"description":              description,
+			"id":                         llx.StringDataPtr(secRule.ID),
+			"name":                       llx.StringDataPtr(secRule.Name),
+			"etag":                       llx.StringDataPtr(secRule.Etag),
+			"direction":                  direction,
+			"properties":                 llx.DictData(properties),
+			"destinationPortRange":       llx.ArrayData(destinationPortRange, types.String),
+			"protocol":                   protocol,
+			"access":                     access,
+			"priority":                   priority,
+			"sourcePortRange":            sourcePortRange,
+			"sourceAddressPrefix":        sourceAddressPrefix,
+			"destinationAddressPrefix":   destinationAddressPrefix,
+			"sourcePortRanges":           llx.ArrayData(sourcePortRanges, types.String),
+			"destinationPortRanges":      llx.ArrayData(destinationPortRanges, types.String),
+			"sourceAddressPrefixes":      llx.ArrayData(sourceAddressPrefixes, types.String),
+			"destinationAddressPrefixes": llx.ArrayData(destinationAddressPrefixes, types.String),
+			"description":                description,
+			"provisioningState":          provisioningState,
 		})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Adds five strictly-additive fields to \`azure.subscription.networkService.securityrule\`:

| Field | SDK source |
|---|---|
| \`sourcePortRanges []string\` | \`SecurityRulePropertiesFormat.SourcePortRanges\` |
| \`destinationPortRanges []string\` | \`SecurityRulePropertiesFormat.DestinationPortRanges\` |
| \`sourceAddressPrefixes []string\` | \`SecurityRulePropertiesFormat.SourceAddressPrefixes\` |
| \`destinationAddressPrefixes []string\` | \`SecurityRulePropertiesFormat.DestinationAddressPrefixes\` |
| \`provisioningState string\` | \`SecurityRulePropertiesFormat.ProvisioningState\` |

The existing singular scalars (\`sourcePortRange\`, \`sourceAddressPrefix\`, …) and the catch-all \`properties dict\` are unchanged — no breaking changes.

### Why

Today, audits that need to match address prefix lists have to navigate \`properties.sourceAddressPrefixes\` etc., which is untyped and inconvenient. With these scalars, the audit pattern matches the existing pattern used for the singular forms:

\`\`\`
azure.subscription.networkSecurityGroups.securityRules.where(
  access == \"Allow\" && direction == \"Inbound\" &&
  (sourceAddressPrefix == \"*\" || sourceAddressPrefixes.any(_ == \"*\"))
)
\`\`\`

\`provisioningState\` makes it possible to filter out rules in a transient state.

### Versions

New \`.lr.versions\` entries at \`13.12.2\`.

## Test plan

- [x] \`mqlr generate\` clean
- [x] \`go build ./...\` / \`go vet ./...\` / \`go test ./resources/...\` pass
- [x] \`gofmt -l\` clean
- [x] \`azure.permissions.json\` unchanged (no new API calls)
- [ ] Manual: \`cnspec shell azure\` and run \`azure.subscription.networkSecurityGroups { securityRules { name sourcePortRanges destinationPortRanges sourceAddressPrefixes destinationAddressPrefixes provisioningState } }\` against an NSG with list-form rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)