### PR TITLE
✨ azure: surface VM imageReference, bootDiagnostics, and userData

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -255,6 +255,16 @@ azure.subscription.computeService.vm @defaults("name location properties.hardwar
   type string
   // VM properties
   properties dict
+  // VM image reference (marketplace publisher/offer/sku/version, or direct gallery image ID)
+  imageReference azure.subscription.computeService.vm.imageReference
+  // Whether boot diagnostics is enabled on the VM
+  bootDiagnosticsEnabled bool
+  // Boot diagnostics storage URI; empty when boot diagnostics writes to platform-managed storage
+  bootDiagnosticsStorageUri string
+  // Base64-encoded user data passed to the VM at provisioning time (cloud-init equivalent)
+  //
+  // Empty when user data is not set. Treat as sensitive — secrets and bootstrap credentials are sometimes embedded here.
+  userData string
   // VM extension
   extensions() []dict
   // Whether the Microsoft Defender for Endpoint (MDE) extension is installed on the VM
@@ -323,6 +333,35 @@ azure.subscription.computeService.vm @defaults("name location properties.hardwar
   patchMode string
   // Virtual Machine Scale Set that manages this VM, if any (resolved from managedBy)
   vmScaleSet() azure.subscription.computeService.vmScaleSet
+}
+
+// Azure VM image reference
+//
+// Examine the image a VM was deployed from. For marketplace images
+// the `publisher`, `offer`, `sku`, and `version` are populated. For
+// shared / community / direct gallery images, `imageId`,
+// `sharedGalleryImageId`, or `communityGalleryImageId` carries the
+// gallery resource path. `exactVersion` resolves the concrete version
+// when `version` was specified as `"latest"`. Audit queries typically
+// check `version != "latest"` to enforce pinning, or flag deployments
+// against unapproved publishers.
+private azure.subscription.computeService.vm.imageReference @defaults("publisher offer sku version") {
+  // Image publisher (marketplace images; empty for gallery images)
+  publisher string
+  // Image offer (marketplace images; empty for gallery images)
+  offer string
+  // Image SKU (marketplace images; empty for gallery images)
+  sku string
+  // Image version (marketplace or shared-gallery images); `"latest"` indicates the platform picks the newest at deploy time
+  version string
+  // Resolved concrete version when `version` was `"latest"` at deploy time; empty otherwise
+  exactVersion string
+  // Direct image resource ID (managed image or shared gallery); empty when deployed from a marketplace image
+  imageId string
+  // Shared-gallery image unique ID; empty when not deployed from a shared gallery
+  sharedGalleryImageId string
+  // Community-gallery image unique ID; empty when not deployed from a community gallery
+  communityGalleryImageId string
 }
 
 // Azure Arc-enabled server

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -23,6 +23,7 @@ const (
 	ResourceAzureSubscriptionResource                                                            string = "azure.subscription.resource"
 	ResourceAzureSubscriptionComputeService                                                      string = "azure.subscription.computeService"
 	ResourceAzureSubscriptionComputeServiceVm                                                    string = "azure.subscription.computeService.vm"
+	ResourceAzureSubscriptionComputeServiceVmImageReference                                      string = "azure.subscription.computeService.vm.imageReference"
 	ResourceAzureSubscriptionComputeServiceHybridMachine                                         string = "azure.subscription.computeService.hybridMachine"
 	ResourceAzureSubscriptionComputeServiceHybridMachineExtension                                string = "azure.subscription.computeService.hybridMachine.extension"
 	ResourceAzureSubscriptionComputeServiceDisk                                                  string = "azure.subscription.computeService.disk"
@@ -399,6 +400,10 @@ func init() {
 		"azure.subscription.computeService.vm": {
 			Init:   initAzureSubscriptionComputeServiceVm,
 			Create: createAzureSubscriptionComputeServiceVm,
+		},
+		"azure.subscription.computeService.vm.imageReference": {
+			// to override args, implement: initAzureSubscriptionComputeServiceVmImageReference(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAzureSubscriptionComputeServiceVmImageReference,
 		},
 		"azure.subscription.computeService.hybridMachine": {
 			Init:   initAzureSubscriptionComputeServiceHybridMachine,
@@ -2128,6 +2133,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.computeService.vm.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetProperties()).ToDataRes(types.Dict)
 	},
+	"azure.subscription.computeService.vm.imageReference": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetImageReference()).ToDataRes(types.Resource("azure.subscription.computeService.vm.imageReference"))
+	},
+	"azure.subscription.computeService.vm.bootDiagnosticsEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetBootDiagnosticsEnabled()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.computeService.vm.bootDiagnosticsStorageUri": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetBootDiagnosticsStorageUri()).ToDataRes(types.String)
+	},
+	"azure.subscription.computeService.vm.userData": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetUserData()).ToDataRes(types.String)
+	},
 	"azure.subscription.computeService.vm.extensions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetExtensions()).ToDataRes(types.Array(types.Dict))
 	},
@@ -2226,6 +2243,30 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.computeService.vm.vmScaleSet": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetVmScaleSet()).ToDataRes(types.Resource("azure.subscription.computeService.vmScaleSet"))
+	},
+	"azure.subscription.computeService.vm.imageReference.publisher": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVmImageReference).GetPublisher()).ToDataRes(types.String)
+	},
+	"azure.subscription.computeService.vm.imageReference.offer": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVmImageReference).GetOffer()).ToDataRes(types.String)
+	},
+	"azure.subscription.computeService.vm.imageReference.sku": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVmImageReference).GetSku()).ToDataRes(types.String)
+	},
+	"azure.subscription.computeService.vm.imageReference.version": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVmImageReference).GetVersion()).ToDataRes(types.String)
+	},
+	"azure.subscription.computeService.vm.imageReference.exactVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVmImageReference).GetExactVersion()).ToDataRes(types.String)
+	},
+	"azure.subscription.computeService.vm.imageReference.imageId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVmImageReference).GetImageId()).ToDataRes(types.String)
+	},
+	"azure.subscription.computeService.vm.imageReference.sharedGalleryImageId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVmImageReference).GetSharedGalleryImageId()).ToDataRes(types.String)
+	},
+	"azure.subscription.computeService.vm.imageReference.communityGalleryImageId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceVmImageReference).GetCommunityGalleryImageId()).ToDataRes(types.String)
 	},
 	"azure.subscription.computeService.hybridMachine.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceHybridMachine).GetId()).ToDataRes(types.String)
@@ -13216,6 +13257,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionComputeServiceVm).Properties, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.computeService.vm.imageReference": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVm).ImageReference, ok = plugin.RawToTValue[*mqlAzureSubscriptionComputeServiceVmImageReference](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.vm.bootDiagnosticsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVm).BootDiagnosticsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.vm.bootDiagnosticsStorageUri": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVm).BootDiagnosticsStorageUri, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.vm.userData": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVm).UserData, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.computeService.vm.extensions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceVm).Extensions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -13346,6 +13403,42 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.computeService.vm.vmScaleSet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceVm).VmScaleSet, ok = plugin.RawToTValue[*mqlAzureSubscriptionComputeServiceVmScaleSet](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.vm.imageReference.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVmImageReference).__id, ok = v.Value.(string)
+		return
+	},
+	"azure.subscription.computeService.vm.imageReference.publisher": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVmImageReference).Publisher, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.vm.imageReference.offer": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVmImageReference).Offer, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.vm.imageReference.sku": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVmImageReference).Sku, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.vm.imageReference.version": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVmImageReference).Version, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.vm.imageReference.exactVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVmImageReference).ExactVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.vm.imageReference.imageId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVmImageReference).ImageId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.vm.imageReference.sharedGalleryImageId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVmImageReference).SharedGalleryImageId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.vm.imageReference.communityGalleryImageId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceVmImageReference).CommunityGalleryImageId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.computeService.hybridMachine.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -30139,6 +30232,10 @@ type mqlAzureSubscriptionComputeServiceVm struct {
 	Tags                          plugin.TValue[map[string]any]
 	Type                          plugin.TValue[string]
 	Properties                    plugin.TValue[any]
+	ImageReference                plugin.TValue[*mqlAzureSubscriptionComputeServiceVmImageReference]
+	BootDiagnosticsEnabled        plugin.TValue[bool]
+	BootDiagnosticsStorageUri     plugin.TValue[string]
+	UserData                      plugin.TValue[string]
 	Extensions                    plugin.TValue[[]any]
 	MdeInstalled                  plugin.TValue[bool]
 	AmaInstalled                  plugin.TValue[bool]
@@ -30249,6 +30346,22 @@ func (c *mqlAzureSubscriptionComputeServiceVm) GetType() *plugin.TValue[string] 
 
 func (c *mqlAzureSubscriptionComputeServiceVm) GetProperties() *plugin.TValue[any] {
 	return &c.Properties
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVm) GetImageReference() *plugin.TValue[*mqlAzureSubscriptionComputeServiceVmImageReference] {
+	return &c.ImageReference
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVm) GetBootDiagnosticsEnabled() *plugin.TValue[bool] {
+	return &c.BootDiagnosticsEnabled
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVm) GetBootDiagnosticsStorageUri() *plugin.TValue[string] {
+	return &c.BootDiagnosticsStorageUri
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVm) GetUserData() *plugin.TValue[string] {
+	return &c.UserData
 }
 
 func (c *mqlAzureSubscriptionComputeServiceVm) GetExtensions() *plugin.TValue[[]any] {
@@ -30451,6 +30564,85 @@ func (c *mqlAzureSubscriptionComputeServiceVm) GetVmScaleSet() *plugin.TValue[*m
 
 		return c.vmScaleSet()
 	})
+}
+
+// mqlAzureSubscriptionComputeServiceVmImageReference for the azure.subscription.computeService.vm.imageReference resource
+type mqlAzureSubscriptionComputeServiceVmImageReference struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAzureSubscriptionComputeServiceVmImageReferenceInternal it will be used here
+	Publisher               plugin.TValue[string]
+	Offer                   plugin.TValue[string]
+	Sku                     plugin.TValue[string]
+	Version                 plugin.TValue[string]
+	ExactVersion            plugin.TValue[string]
+	ImageId                 plugin.TValue[string]
+	SharedGalleryImageId    plugin.TValue[string]
+	CommunityGalleryImageId plugin.TValue[string]
+}
+
+// createAzureSubscriptionComputeServiceVmImageReference creates a new instance of this resource
+func createAzureSubscriptionComputeServiceVmImageReference(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAzureSubscriptionComputeServiceVmImageReference{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("azure.subscription.computeService.vm.imageReference", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVmImageReference) MqlName() string {
+	return "azure.subscription.computeService.vm.imageReference"
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVmImageReference) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVmImageReference) GetPublisher() *plugin.TValue[string] {
+	return &c.Publisher
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVmImageReference) GetOffer() *plugin.TValue[string] {
+	return &c.Offer
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVmImageReference) GetSku() *plugin.TValue[string] {
+	return &c.Sku
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVmImageReference) GetVersion() *plugin.TValue[string] {
+	return &c.Version
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVmImageReference) GetExactVersion() *plugin.TValue[string] {
+	return &c.ExactVersion
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVmImageReference) GetImageId() *plugin.TValue[string] {
+	return &c.ImageId
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVmImageReference) GetSharedGalleryImageId() *plugin.TValue[string] {
+	return &c.SharedGalleryImageId
+}
+
+func (c *mqlAzureSubscriptionComputeServiceVmImageReference) GetCommunityGalleryImageId() *plugin.TValue[string] {
+	return &c.CommunityGalleryImageId
 }
 
 // mqlAzureSubscriptionComputeServiceHybridMachine for the azure.subscription.computeService.hybridMachine resource

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -934,6 +934,8 @@ azure.subscription.computeService.subscriptionId 9.0.1
 azure.subscription.computeService.vm 9.0.1
 azure.subscription.computeService.vm.adminUsername 11.6.1
 azure.subscription.computeService.vm.amaInstalled 13.12.2
+azure.subscription.computeService.vm.bootDiagnosticsEnabled 13.12.2
+azure.subscription.computeService.vm.bootDiagnosticsStorageUri 13.12.2
 azure.subscription.computeService.vm.computerName 11.6.1
 azure.subscription.computeService.vm.dataDisks 9.0.1
 azure.subscription.computeService.vm.dependencyAgentInstalled 13.12.2
@@ -943,6 +945,15 @@ azure.subscription.computeService.vm.encryptionAtHost 11.4.28
 azure.subscription.computeService.vm.extensions 9.0.1
 azure.subscription.computeService.vm.fipsEncryptionEnabled 13.8.2
 azure.subscription.computeService.vm.id 9.0.1
+azure.subscription.computeService.vm.imageReference 13.12.2
+azure.subscription.computeService.vm.imageReference.communityGalleryImageId 13.12.2
+azure.subscription.computeService.vm.imageReference.exactVersion 13.12.2
+azure.subscription.computeService.vm.imageReference.imageId 13.12.2
+azure.subscription.computeService.vm.imageReference.offer 13.12.2
+azure.subscription.computeService.vm.imageReference.publisher 13.12.2
+azure.subscription.computeService.vm.imageReference.sharedGalleryImageId 13.12.2
+azure.subscription.computeService.vm.imageReference.sku 13.12.2
+azure.subscription.computeService.vm.imageReference.version 13.12.2
 azure.subscription.computeService.vm.isRunning 9.0.1
 azure.subscription.computeService.vm.licenseType 11.6.1
 azure.subscription.computeService.vm.location 9.0.1
@@ -970,6 +981,7 @@ azure.subscription.computeService.vm.systemData 13.8.2
 azure.subscription.computeService.vm.tags 9.0.1
 azure.subscription.computeService.vm.timeCreated 11.6.2
 azure.subscription.computeService.vm.type 9.0.1
+azure.subscription.computeService.vm.userData 13.12.2
 azure.subscription.computeService.vm.vmId 11.6.2
 azure.subscription.computeService.vm.vmScaleSet 13.7.1
 azure.subscription.computeService.vm.vtpmEnabled 11.4.28

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -187,6 +187,32 @@ func (a *mqlAzureSubscriptionComputeService) vms() ([]any, error) {
 				normalized := strings.ToLower(*vm.ID)
 				id = &normalized
 			}
+
+			var bootDiagnosticsEnabled bool
+			var bootDiagnosticsStorageUri, userData string
+			if vm.Properties != nil {
+				if dp := vm.Properties.DiagnosticsProfile; dp != nil && dp.BootDiagnostics != nil {
+					if dp.BootDiagnostics.Enabled != nil {
+						bootDiagnosticsEnabled = *dp.BootDiagnostics.Enabled
+					}
+					if dp.BootDiagnostics.StorageURI != nil {
+						bootDiagnosticsStorageUri = *dp.BootDiagnostics.StorageURI
+					}
+				}
+				if vm.Properties.UserData != nil {
+					userData = *vm.Properties.UserData
+				}
+			}
+
+			vmIDStr := ""
+			if vm.ID != nil {
+				vmIDStr = *vm.ID
+			}
+			mqlImageRef, err := vmImageReferenceToMql(a.MqlRuntime, vmIDStr, vm.Properties)
+			if err != nil {
+				return nil, err
+			}
+
 			mqlAzureVm, err := CreateResource(a.MqlRuntime, "azure.subscription.computeService.vm",
 				map[string]*llx.RawData{
 					"id":                            llx.StringDataPtr(id),
@@ -219,6 +245,10 @@ func (a *mqlAzureSubscriptionComputeService) vms() ([]any, error) {
 					"provisionVMAgent":              llx.BoolDataPtr(provisionVMAgent),
 					"enableAutomaticUpdates":        llx.BoolDataPtr(enableAutomaticUpdates),
 					"patchMode":                     llx.StringData(patchMode),
+					"imageReference":                llx.ResourceData(mqlImageRef, "imageReference"),
+					"bootDiagnosticsEnabled":        llx.BoolData(bootDiagnosticsEnabled),
+					"bootDiagnosticsStorageUri":     llx.StringData(bootDiagnosticsStorageUri),
+					"userData":                      llx.StringData(userData),
 				})
 			if err != nil {
 				return nil, err
@@ -1423,4 +1453,62 @@ func (a *mqlAzureSubscriptionComputeServiceDisk) diskEncryptionSet() (*mqlAzureS
 		return nil, err
 	}
 	return res.(*mqlAzureSubscriptionComputeServiceDiskEncryptionSet), nil
+}
+
+func vmImageReferenceToMql(runtime *plugin.Runtime, vmID string, props *compute.VirtualMachineProperties) (*mqlAzureSubscriptionComputeServiceVmImageReference, error) {
+	var ref *compute.ImageReference
+	if props != nil && props.StorageProfile != nil {
+		ref = props.StorageProfile.ImageReference
+	}
+	publisher := ""
+	offer := ""
+	sku := ""
+	version := ""
+	exactVersion := ""
+	imageId := ""
+	sharedGalleryId := ""
+	communityGalleryId := ""
+	if ref != nil {
+		if ref.Publisher != nil {
+			publisher = *ref.Publisher
+		}
+		if ref.Offer != nil {
+			offer = *ref.Offer
+		}
+		if ref.SKU != nil {
+			sku = *ref.SKU
+		}
+		if ref.Version != nil {
+			version = *ref.Version
+		}
+		if ref.ExactVersion != nil {
+			exactVersion = *ref.ExactVersion
+		}
+		if ref.ID != nil {
+			imageId = *ref.ID
+		}
+		if ref.SharedGalleryImageID != nil {
+			sharedGalleryId = *ref.SharedGalleryImageID
+		}
+		if ref.CommunityGalleryImageID != nil {
+			communityGalleryId = *ref.CommunityGalleryImageID
+		}
+	}
+	id := vmID + "/imageReference"
+	res, err := CreateResource(runtime, "azure.subscription.computeService.vm.imageReference",
+		map[string]*llx.RawData{
+			"__id":                    llx.StringData(id),
+			"publisher":               llx.StringData(publisher),
+			"offer":                   llx.StringData(offer),
+			"sku":                     llx.StringData(sku),
+			"version":                 llx.StringData(version),
+			"exactVersion":            llx.StringData(exactVersion),
+			"imageId":                 llx.StringData(imageId),
+			"sharedGalleryImageId":    llx.StringData(sharedGalleryId),
+			"communityGalleryImageId": llx.StringData(communityGalleryId),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionComputeServiceVmImageReference), nil
 }

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -208,6 +208,9 @@ func (a *mqlAzureSubscriptionComputeService) vms() ([]any, error) {
 			if vm.ID != nil {
 				vmIDStr = *vm.ID
 			}
+			// vmImageReferenceToMql is nil-safe on vm.Properties — always returns a
+			// resource (fields default to empty strings when the VM has no storage
+			// profile / image reference).
 			mqlImageRef, err := vmImageReferenceToMql(a.MqlRuntime, vmIDStr, vm.Properties)
 			if err != nil {
 				return nil, err
@@ -245,7 +248,7 @@ func (a *mqlAzureSubscriptionComputeService) vms() ([]any, error) {
 					"provisionVMAgent":              llx.BoolDataPtr(provisionVMAgent),
 					"enableAutomaticUpdates":        llx.BoolDataPtr(enableAutomaticUpdates),
 					"patchMode":                     llx.StringData(patchMode),
-					"imageReference":                llx.ResourceData(mqlImageRef, "imageReference"),
+					"imageReference":                llx.ResourceData(mqlImageRef, mqlImageRef.MqlName()),
 					"bootDiagnosticsEnabled":        llx.BoolData(bootDiagnosticsEnabled),
 					"bootDiagnosticsStorageUri":     llx.StringData(bootDiagnosticsStorageUri),
 					"userData":                      llx.StringData(userData),


### PR DESCRIPTION
## Summary

Three strictly-additive fields on \`computeService.vm\`, all derived from the existing VM payload (no new API call):

| Addition | Source | Why |
|---|---|---|
| \`imageReference\` sub-resource (\`publisher\`, \`offer\`, \`sku\`, \`version\`, \`exactVersion\`, \`imageId\`, \`sharedGalleryImageId\`, \`communityGalleryImageId\`) | \`Properties.StorageProfile.ImageReference\` | Pin-the-image audits; flag \`version == \"latest\"\`; flag unapproved publishers |
| \`bootDiagnosticsEnabled bool\` + \`bootDiagnosticsStorageUri string\` | \`Properties.DiagnosticsProfile.BootDiagnostics\` | Flag boot diag disabled or pointing at a non-managed storage account |
| \`userData string\` | \`Properties.UserData\` | Base64 cloud-init payload — secrets are sometimes embedded here, worth surfacing as a top-level field for audit |

The existing \`properties dict\` is unchanged — strictly additive.

### Why

\`\`\`
azure.subscription.compute.vms.where(imageReference.version == \"latest\")
azure.subscription.compute.vms.where(!bootDiagnosticsEnabled)
azure.subscription.compute.vms.where(userData.length > 0)
\`\`\`

### Versions

New \`.lr.versions\` entries at \`13.12.2\`. \`azure.permissions.json\` unchanged (data already in the listVirtualMachines response).

## Test plan

- [x] \`mqlr generate\` clean
- [x] \`go build ./...\` / \`go vet ./...\` / \`go test ./resources/...\` pass
- [x] \`gofmt -l\` clean
- [ ] Manual: \`cnspec shell azure\` and run \`azure.subscription.compute.vms { name imageReference { publisher offer sku version exactVersion } bootDiagnosticsEnabled bootDiagnosticsStorageUri userData }\` against marketplace + shared-gallery VMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)