### PR TITLE
✨ gcp: type four dict-style fields + add GKE Windows node config

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -551,6 +551,7 @@ serde
 serviceconnection
 servicedesk
 serviceprincipals
+SEV
 Sflags
 sfn
 signin
@@ -620,6 +621,7 @@ trainingjob
 transitgateway
 transitives
 truststore
+TDX
 TValue
 Twt
 uami

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -604,6 +604,7 @@ tanium
 targetgroup
 tcpip
 tde
+TDX
 temurin
 tensorboard
 testutils
@@ -621,7 +622,6 @@ trainingjob
 transitgateway
 transitives
 truststore
-TDX
 TValue
 Twt
 uami

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -417,6 +417,25 @@ Think of it as: MQL (like SQL or even better GraphQL) → MQLC (compiler) → LL
 - Must be unique and stable (ARN, UUID, or composite key)
 - If `__id` is empty or duplicate, caching breaks and performance degrades
 
+**Hide synthetic `__id` values; don't expose them as `id` fields.** When a sub-resource's cache key is purely internal — a parent-qualified path like `<parentId>/confidentialCompute`, not something a user would ever query by — do NOT declare `id string` in the `.lr` block. Pass the cache key directly via the magic `"__id"` argument to `CreateResource`, and omit the `id()` Go method:
+
+```go
+// schema (.lr): no `id string` field declared
+private gcp.project.computeService.instance.confidentialCompute @defaults("enabled instanceType") {
+  enabled bool
+  instanceType string
+}
+
+// creator (.go): pass "__id" directly, no id() func needed
+mqlConfCompute, err := CreateResource(runtime, "gcp.project.computeService.instance.confidentialCompute", map[string]*llx.RawData{
+    "__id":         llx.StringData(fmt.Sprintf("%d/confidentialCompute", instance.Id)),
+    "enabled":      llx.BoolData(...),
+    "instanceType": llx.StringData(...),
+})
+```
+
+Reserve a public `id string` field for resources whose id carries user-meaningful information (an ARN, a GCP resource name, a stable cross-system key) — somewhere a user might write `.where(id == "...")`. Sub-resources whose id is `<parent>/<leaf>` synthetic should hide it. See `gcp.project.binaryAuthorizationControl.policy` for an existing example of this pattern.
+
 **Performance notes:**
 - Resource field access is lazy: fields are only fetched when needed
 - Cross-references should leverage caching to avoid redundant API calls

--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -410,6 +410,11 @@ func (g *mqlGcpProjectCloudRunService) services() ([]any, error) {
 					}
 
 					templateId := fmt.Sprintf("gcp.project.cloudRunService.service/%s/%s/revisionTemplate", projectId, s.Name)
+					mqlVpcAccessCfg, err := mqlVpcAccessConfig(g.MqlRuntime, templateId+"/vpcAccess", s.Template.VpcAccess)
+					if err != nil {
+						log.Error().Err(err).Send()
+					}
+
 					mqlContainers, err := mqlContainers(g.MqlRuntime, s.Template.Containers, templateId)
 					if err != nil {
 						log.Error().Err(err).Send()
@@ -423,6 +428,7 @@ func (g *mqlGcpProjectCloudRunService) services() ([]any, error) {
 						"annotations":                   llx.MapData(convert.MapToInterfaceMap(s.Template.Annotations), types.String),
 						"scaling":                       llx.DictData(scalingCfg),
 						"vpcAccess":                     llx.DictData(vpcCfg),
+						"vpcAccessConfig":               llx.ResourceData(mqlVpcAccessCfg, "gcp.project.cloudRunService.vpcAccessConfig"),
 						"timeout":                       llx.TimeData(llx.DurationToTime((s.Template.Timeout.Seconds))),
 						"serviceAccountEmail":           llx.StringData(s.Template.ServiceAccount),
 						"containers":                    llx.ArrayData(mqlContainers, "gcp.project.cloudRunService.container"),
@@ -714,6 +720,13 @@ func (g *mqlGcpProjectCloudRunService) jobs() ([]any, error) {
 							return
 						}
 
+						taskTemplateId := fmt.Sprintf("%s/template", templateId)
+						mqlVpcAccessCfg, err := mqlVpcAccessConfig(g.MqlRuntime, taskTemplateId+"/vpcAccess", j.Template.Template.VpcAccess)
+						if err != nil {
+							log.Error().Err(err).Send()
+							return
+						}
+
 						mqlContainers, err := mqlContainers(g.MqlRuntime, j.Template.Template.Containers, templateId)
 						if err != nil {
 							log.Error().Err(err).Send()
@@ -721,9 +734,10 @@ func (g *mqlGcpProjectCloudRunService) jobs() ([]any, error) {
 						}
 
 						mqlTaskTemplate, err = CreateResource(g.MqlRuntime, "gcp.project.cloudRunService.job.executionTemplate.taskTemplate", map[string]*llx.RawData{
-							"id":                   llx.StringData(fmt.Sprintf("%s/template", templateId)),
+							"id":                   llx.StringData(taskTemplateId),
 							"projectId":            llx.StringData(projectId),
 							"vpcAccess":            llx.DictData(vpcAccess),
+							"vpcAccessConfig":      llx.ResourceData(mqlVpcAccessCfg, "gcp.project.cloudRunService.vpcAccessConfig"),
 							"timeout":              llx.TimeData(llx.DurationToTime((j.Template.Template.Timeout.Seconds))),
 							"serviceAccountEmail":  llx.StringData(j.Template.Template.ServiceAccount),
 							"containers":           llx.ArrayData(mqlContainers, types.Resource("gcp.project.cloudRunService.container")),
@@ -871,6 +885,38 @@ func mqlVpcAccess(vpcAccess *runpb.VpcAccess) (map[string]any, error) {
 	return convert.JsonToDict(mqlVpcAccess{
 		Connector: vpcAccess.Connector,
 		Egress:    vpcAccess.Egress.String(),
+	})
+}
+
+func (g *mqlGcpProjectCloudRunServiceVpcAccessConfig) id() (string, error) {
+	return g.Id.Data, g.Id.Error
+}
+
+// mqlVpcAccessConfig builds the typed gcp.project.cloudRunService.vpcAccessConfig
+// resource shared by Cloud Run service revisions and Cloud Run job task
+// templates. id should be a parent-qualified path so multiple instances of
+// this sub-resource (one per revision or task template) do not collide in the
+// runtime cache.
+func mqlVpcAccessConfig(runtime *plugin.Runtime, id string, vpcAccess *runpb.VpcAccess) (plugin.Resource, error) {
+	if vpcAccess == nil {
+		return nil, nil
+	}
+	interfaces := make([]any, 0, len(vpcAccess.NetworkInterfaces))
+	for _, ni := range vpcAccess.NetworkInterfaces {
+		if ni == nil {
+			continue
+		}
+		interfaces = append(interfaces, map[string]any{
+			"network":    ni.Network,
+			"subnetwork": ni.Subnetwork,
+			"tags":       convert.SliceAnyToInterface(ni.Tags),
+		})
+	}
+	return CreateResource(runtime, "gcp.project.cloudRunService.vpcAccessConfig", map[string]*llx.RawData{
+		"id":                llx.StringData(id),
+		"connector":         llx.StringData(vpcAccess.Connector),
+		"egress":            llx.StringData(vpcAccess.Egress.String()),
+		"networkInterfaces": llx.ArrayData(interfaces, types.Dict),
 	})
 }
 

--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -888,10 +888,6 @@ func mqlVpcAccess(vpcAccess *runpb.VpcAccess) (map[string]any, error) {
 	})
 }
 
-func (g *mqlGcpProjectCloudRunServiceVpcAccessConfig) id() (string, error) {
-	return g.Id.Data, g.Id.Error
-}
-
 // mqlVpcAccessConfig builds the typed gcp.project.cloudRunService.vpcAccessConfig
 // resource shared by Cloud Run service revisions and Cloud Run job task
 // templates. id should be a parent-qualified path so multiple instances of
@@ -913,7 +909,7 @@ func mqlVpcAccessConfig(runtime *plugin.Runtime, id string, vpcAccess *runpb.Vpc
 		})
 	}
 	return CreateResource(runtime, "gcp.project.cloudRunService.vpcAccessConfig", map[string]*llx.RawData{
-		"id":                llx.StringData(id),
+		"__id":              llx.StringData(id),
 		"connector":         llx.StringData(vpcAccess.Connector),
 		"egress":            llx.StringData(vpcAccess.Egress.String()),
 		"networkInterfaces": llx.ArrayData(interfaces, types.Dict),

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -368,6 +368,10 @@ func (g *mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig) id() (string
 	return g.Id.Data, g.Id.Error
 }
 
+func (g *mqlGcpProjectComputeServiceInstanceConfidentialCompute) id() (string, error) {
+	return g.Id.Data, g.Id.Error
+}
+
 func (g *mqlGcpProjectComputeServiceInstance) id() (string, error) {
 	if g.Id.Error != nil {
 		return "", g.Id.Error
@@ -619,12 +623,21 @@ func newMqlComputeServiceInstance(projectId string, zone *mqlGcpProjectComputeSe
 	}
 
 	var mqlConfCompute map[string]any
+	var mqlConfidentialCompute plugin.Resource
 	if instance.ConfidentialInstanceConfig != nil {
 		type mqlConfidentialInstanceConfig struct {
 			Enabled bool `json:"serviceEnabled,omitempty"`
 		}
 		mqlConfCompute, err = convert.JsonToDict(
 			mqlConfidentialInstanceConfig{Enabled: instance.ConfidentialInstanceConfig.EnableConfidentialCompute})
+		if err != nil {
+			return nil, err
+		}
+		mqlConfidentialCompute, err = CreateResource(runtime, "gcp.project.computeService.instance.confidentialCompute", map[string]*llx.RawData{
+			"id":           llx.StringData(fmt.Sprintf("%d/confidentialCompute", instance.Id)),
+			"enabled":      llx.BoolData(instance.ConfidentialInstanceConfig.EnableConfidentialCompute),
+			"instanceType": llx.StringData(instance.ConfidentialInstanceConfig.ConfidentialInstanceType),
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -641,6 +654,7 @@ func newMqlComputeServiceInstance(projectId string, zone *mqlGcpProjectComputeSe
 		"name":                            llx.StringData(instance.Name),
 		"description":                     llx.StringData(instance.Description),
 		"confidentialInstanceConfig":      llx.DictData(mqlConfCompute),
+		"confidentialCompute":             llx.ResourceData(mqlConfidentialCompute, "gcp.project.computeService.instance.confidentialCompute"),
 		"canIpForward":                    llx.BoolData(instance.CanIpForward),
 		"cpuPlatform":                     llx.StringData(instance.CpuPlatform),
 		"created":                         llx.TimeDataPtr(parseTime(instance.CreationTimestamp)),

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -368,10 +368,6 @@ func (g *mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig) id() (string
 	return g.Id.Data, g.Id.Error
 }
 
-func (g *mqlGcpProjectComputeServiceInstanceConfidentialCompute) id() (string, error) {
-	return g.Id.Data, g.Id.Error
-}
-
 func (g *mqlGcpProjectComputeServiceInstance) id() (string, error) {
 	if g.Id.Error != nil {
 		return "", g.Id.Error
@@ -634,7 +630,7 @@ func newMqlComputeServiceInstance(projectId string, zone *mqlGcpProjectComputeSe
 			return nil, err
 		}
 		mqlConfidentialCompute, err = CreateResource(runtime, "gcp.project.computeService.instance.confidentialCompute", map[string]*llx.RawData{
-			"id":           llx.StringData(fmt.Sprintf("%d/confidentialCompute", instance.Id)),
+			"__id":         llx.StringData(fmt.Sprintf("%d/confidentialCompute", instance.Id)),
 			"enabled":      llx.BoolData(instance.ConfidentialInstanceConfig.EnableConfidentialCompute),
 			"instanceType": llx.StringData(instance.ConfidentialInstanceConfig.ConfidentialInstanceType),
 		})

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -1215,8 +1215,10 @@ gcp.project.computeService.instance @defaults("name id") {
   name string
   // Optional description for this instance
   description string
-  // Confidential instance configuration
-  confidentialInstanceConfig dict
+  // DEPRECATED: use confidentialCompute for the typed sub-resource that exposes the same fields plus the confidential VM type
+  confidentialInstanceConfig @maturity("deprecated") dict
+  // Confidential Compute configuration for this instance
+  confidentialCompute gcp.project.computeService.instance.confidentialCompute
   // Whether the instance is allowed to send and receive packets with non-matching destination or source IPs
   canIpForward bool
   // CPU platform used by this instance
@@ -1349,6 +1351,24 @@ private gcp.project.computeService.instance.vulnerabilityReport @defaults("name 
   highestUpgradableCveSeverity string
   // Time the report was last refreshed
   updateTime time
+}
+
+// Google Cloud (GCP) Compute Engine confidential VM configuration
+//
+// Examine the Confidential Compute settings on a VM instance — whether
+// confidential compute is enabled and, when it is, the underlying
+// technology used (AMD SEV, AMD SEV-SNP, or Intel TDX). Confidential
+// VMs encrypt memory at the hardware level and are the GCP control
+// surface for workloads that require runtime memory isolation.
+private gcp.project.computeService.instance.confidentialCompute @defaults("enabled instanceType") {
+  // Internal ID for this resource
+  id string
+  // Whether confidential compute is enabled on this instance
+  enabled bool
+  // Confidential VM technology
+  //
+  // One of SEV, SEV_SNP, TDX, or CONFIDENTIAL_INSTANCE_TYPE_UNSPECIFIED. Empty when confidential compute is not enabled.
+  instanceType string
 }
 
 // Google Cloud (GCP) Compute Shielded Instance configuration
@@ -2421,8 +2441,10 @@ private gcp.project.sqlService.instance.settings {
   instanceName string
   // When the instance is activated
   activationPolicy string
-  // Entra ID (formerly Active Directory) configuration (relevant only for Cloud SQL for SQL Server)
-  activeDirectoryConfig dict
+  // DEPRECATED: use activeDirectory for the typed sub-resource that exposes domain, mode, and DNS servers
+  activeDirectoryConfig @maturity("deprecated") dict
+  // Entra ID (formerly Active Directory) configuration; relevant only for Cloud SQL for SQL Server
+  activeDirectory gcp.project.sqlService.instance.settings.activeDirectory
   // Availability type
   availabilityType string
   // Daily backup configuration for the instance
@@ -2473,6 +2495,30 @@ private gcp.project.sqlService.instance.settings {
   timeZone string
   // User-provided labels
   userLabels map[string]string
+}
+
+// Google Cloud (GCP) SQL instance Entra ID / Active Directory configuration
+//
+// Examine the Active Directory (now Entra ID) binding on a Cloud SQL
+// for SQL Server instance. `domain` is the FQDN the instance is joined
+// to; `mode` selects between Google-managed (`MANAGED_ACTIVE_DIRECTORY`)
+// and customer-managed (`CUSTOMER_MANAGED_ACTIVE_DIRECTORY`) directory
+// services; `dnsServers` lists the domain controller IPv4 addresses
+// used to bootstrap the join. A SQL Server instance with no AD binding
+// (or a binding to an unexpected domain) is the audit hot spot.
+private gcp.project.sqlService.instance.settings.activeDirectory @defaults("domain mode") {
+  // Internal ID for this resource
+  id string
+  // Fully-qualified Active Directory / Entra ID domain (e.g., corp.example.com); empty when no binding is configured
+  domain string
+  // Active Directory mode
+  //
+  // One of MANAGED_ACTIVE_DIRECTORY (Google-managed), CUSTOMER_MANAGED_ACTIVE_DIRECTORY, ACTIVE_DIRECTORY_MODE_UNSPECIFIED, or the deprecated SELF_MANAGED_ACTIVE_DIRECTORY.
+  mode string
+  // Domain controller IPv4 addresses used to bootstrap Active Directory; populated only for customer-managed AD
+  dnsServers []string
+  // Secret Manager resource name (`projects/{p}/secrets/{s}`) holding the administrator credential; populated only for customer-managed AD
+  adminCredentialSecretName string
 }
 
 // Google Cloud (GCP) SQL instance settings backup configuration
@@ -3454,6 +3500,8 @@ private gcp.project.gkeService.cluster.nodepool.config @defaults("machineType di
   shieldedInstanceConfig gcp.project.gkeService.cluster.nodepool.config.shieldedInstanceConfig
   // Parameters that can be configured on Linux nodes
   linuxNodeConfig gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig
+  // Parameters that can be configured on Windows nodes
+  windowsNodeConfig gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig
   // Node kubelet configs
   kubeletConfig gcp.project.gkeService.cluster.nodepool.config.kubeletConfig
   // The Customer Managed Encryption Key used to encrypt the boot disk attached to each node
@@ -3537,6 +3585,22 @@ private gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig @defaults
   id string
   // The Linux kernel parameters to apply to the nodes and all pods running on them
   sysctls map[string]string
+}
+
+// Google Kubernetes Engine (GKE) node pool parameters that can be configured on Windows nodes
+//
+// Examine the Windows-specific settings on a GKE node pool. Surfaces
+// the `osVersion` selecting which Windows Server LTSC image the pool
+// is pinned to (e.g., `LTSC2019`, `LTSC2022`). Auditors of mixed-OS
+// GKE clusters need this to verify that Windows nodes are running an
+// approved OS baseline.
+private gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig @defaults("osVersion") {
+  // Internal ID for this resource
+  id string
+  // Windows Server OS version pinned to this node pool
+  //
+  // One of OS_VERSION_UNSPECIFIED, OS_VERSION_LTSC2019, or OS_VERSION_LTSC2022.
+  osVersion string
 }
 
 // Google Kubernetes Engine (GKE) Node Pool kubelet configuration
@@ -5141,8 +5205,10 @@ private gcp.project.cloudRunService.service.revisionTemplate @defaults("name") {
   annotations map[string]string
   // Scaling settings
   scaling dict
-  // VPC access configuration
-  vpcAccess dict
+  // DEPRECATED: use vpcAccessConfig for the typed sub-resource (connector, egress, networkInterfaces)
+  vpcAccess @maturity("deprecated") dict
+  // VPC access configuration (Serverless VPC connector and egress policy)
+  vpcAccessConfig gcp.project.cloudRunService.vpcAccessConfig
   // Maximum allowed time for an instance to respond to a request
   timeout time
   // Email address of the IAM service account associated with the revision of the service
@@ -5205,6 +5271,32 @@ private gcp.project.cloudRunService.container.probe {
   httpGet dict
   // TCP socket probe configuration
   tcpSocket dict
+}
+
+// Google Cloud (GCP) Cloud Run VPC access configuration
+//
+// Examine how a Cloud Run revision or job task reaches private
+// networks. Surfaces the Serverless VPC `connector` (when traffic
+// flows through a connector), the direct-VPC `networkInterfaces`
+// (when the task is attached to a VPC subnet), and the `egress`
+// policy that decides which outbound traffic is sent through the
+// VPC: `PRIVATE_RANGES_ONLY` keeps RFC1918 traffic on the VPC and
+// sends public-IP traffic over the default internet path, while
+// `ALL_TRAFFIC` forces every egress packet through the VPC — the
+// stronger control for data-exfiltration audits.
+private gcp.project.cloudRunService.vpcAccessConfig @defaults("connector egress") {
+  // Internal ID for this resource
+  id string
+  // Serverless VPC Access connector (full resource name `projects/{p}/locations/{l}/connectors/{c}`); empty when direct-VPC `networkInterfaces` is used
+  connector string
+  // Outbound traffic routing through the VPC
+  //
+  // One of ALL_TRAFFIC (every packet egresses via the VPC), PRIVATE_RANGES_ONLY (only RFC1918 destinations), or VPC_EGRESS_UNSPECIFIED.
+  egress string
+  // Direct-VPC network interfaces the revision or task is attached to
+  //
+  // Each entry exposes `network` (the VPC network resource name), `subnetwork` (the subnet resource name), and `tags` (the network tags the workload presents). Populated when the workload uses direct VPC egress instead of a Serverless VPC Access connector.
+  networkInterfaces []dict
 }
 
 // Google Cloud (GCP) Run condition
@@ -5308,8 +5400,10 @@ private gcp.project.cloudRunService.job.executionTemplate.taskTemplate {
   id string
   // Project ID
   projectId string
-  // VPC access configuration
-  vpcAccess dict
+  // DEPRECATED: use vpcAccessConfig for the typed sub-resource (connector, egress, networkInterfaces)
+  vpcAccess @maturity("deprecated") dict
+  // VPC access configuration (Serverless VPC connector and egress policy)
+  vpcAccessConfig gcp.project.cloudRunService.vpcAccessConfig
   // Maximum allowed time for an instance to respond to a request
   timeout time
   // Email address of the IAM service account associated with the revision of the service

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -1361,8 +1361,6 @@ private gcp.project.computeService.instance.vulnerabilityReport @defaults("name 
 // VMs encrypt memory at the hardware level and are the GCP control
 // surface for workloads that require runtime memory isolation.
 private gcp.project.computeService.instance.confidentialCompute @defaults("enabled instanceType") {
-  // Internal ID for this resource
-  id string
   // Whether confidential compute is enabled on this instance
   enabled bool
   // Confidential VM technology
@@ -2507,8 +2505,6 @@ private gcp.project.sqlService.instance.settings {
 // used to bootstrap the join. A SQL Server instance with no AD binding
 // (or a binding to an unexpected domain) is the audit hot spot.
 private gcp.project.sqlService.instance.settings.activeDirectory @defaults("domain mode") {
-  // Internal ID for this resource
-  id string
   // Fully-qualified Active Directory / Entra ID domain (e.g., corp.example.com); empty when no binding is configured
   domain string
   // Active Directory mode
@@ -3595,8 +3591,6 @@ private gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig @defaults
 // GKE clusters need this to verify that Windows nodes are running an
 // approved OS baseline.
 private gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig @defaults("osVersion") {
-  // Internal ID for this resource
-  id string
   // Windows Server OS version pinned to this node pool
   //
   // One of OS_VERSION_UNSPECIFIED, OS_VERSION_LTSC2019, or OS_VERSION_LTSC2022.
@@ -5285,8 +5279,6 @@ private gcp.project.cloudRunService.container.probe {
 // `ALL_TRAFFIC` forces every egress packet through the VPC — the
 // stronger control for data-exfiltration audits.
 private gcp.project.cloudRunService.vpcAccessConfig @defaults("connector egress") {
-  // Internal ID for this resource
-  id string
   // Serverless VPC Access connector (full resource name `projects/{p}/locations/{l}/connectors/{c}`); empty when direct-VPC `networkInterfaces` is used
   connector string
   // Outbound traffic routing through the VPC

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -3587,9 +3587,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.instance.vulnerabilityReport.updateTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceVulnerabilityReport).GetUpdateTime()).ToDataRes(types.Time)
 	},
-	"gcp.project.computeService.instance.confidentialCompute.id": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceInstanceConfidentialCompute).GetId()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.instance.confidentialCompute.enabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceConfidentialCompute).GetEnabled()).ToDataRes(types.Bool)
 	},
@@ -4880,9 +4877,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.sqlService.instance.settings.userLabels": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettings).GetUserLabels()).ToDataRes(types.Map(types.String, types.String))
 	},
-	"gcp.project.sqlService.instance.settings.activeDirectory.id": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory).GetId()).ToDataRes(types.String)
-	},
 	"gcp.project.sqlService.instance.settings.activeDirectory.domain": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory).GetDomain()).ToDataRes(types.String)
 	},
@@ -6061,9 +6055,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig.sysctls": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig).GetSysctls()).ToDataRes(types.Map(types.String, types.String))
-	},
-	"gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig.id": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig).GetId()).ToDataRes(types.String)
 	},
 	"gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig.osVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig).GetOsVersion()).ToDataRes(types.String)
@@ -7750,9 +7741,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.cloudRunService.container.probe.tcpSocket": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceContainerProbe).GetTcpSocket()).ToDataRes(types.Dict)
-	},
-	"gcp.project.cloudRunService.vpcAccessConfig.id": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectCloudRunServiceVpcAccessConfig).GetId()).ToDataRes(types.String)
 	},
 	"gcp.project.cloudRunService.vpcAccessConfig.connector": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceVpcAccessConfig).GetConnector()).ToDataRes(types.String)
@@ -16442,10 +16430,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceInstanceConfidentialCompute).__id, ok = v.Value.(string)
 		return
 	},
-	"gcp.project.computeService.instance.confidentialCompute.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceInstanceConfidentialCompute).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.instance.confidentialCompute.enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstanceConfidentialCompute).Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -18278,10 +18262,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory).__id, ok = v.Value.(string)
 		return
 	},
-	"gcp.project.sqlService.instance.settings.activeDirectory.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.sqlService.instance.settings.activeDirectory.domain": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory).Domain, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -20012,10 +19992,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig).__id, ok = v.Value.(string)
-		return
-	},
-	"gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig.osVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -22536,10 +22512,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.cloudRunService.vpcAccessConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudRunServiceVpcAccessConfig).__id, ok = v.Value.(string)
-		return
-	},
-	"gcp.project.cloudRunService.vpcAccessConfig.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectCloudRunServiceVpcAccessConfig).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.cloudRunService.vpcAccessConfig.connector": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -37970,7 +37942,6 @@ type mqlGcpProjectComputeServiceInstanceConfidentialCompute struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlGcpProjectComputeServiceInstanceConfidentialComputeInternal it will be used here
-	Id           plugin.TValue[string]
 	Enabled      plugin.TValue[bool]
 	InstanceType plugin.TValue[string]
 }
@@ -37986,12 +37957,7 @@ func createGcpProjectComputeServiceInstanceConfidentialCompute(runtime *plugin.R
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("gcp.project.computeService.instance.confidentialCompute", res.__id)
@@ -38010,10 +37976,6 @@ func (c *mqlGcpProjectComputeServiceInstanceConfidentialCompute) MqlName() strin
 
 func (c *mqlGcpProjectComputeServiceInstanceConfidentialCompute) MqlID() string {
 	return c.__id
-}
-
-func (c *mqlGcpProjectComputeServiceInstanceConfidentialCompute) GetId() *plugin.TValue[string] {
-	return &c.Id
 }
 
 func (c *mqlGcpProjectComputeServiceInstanceConfidentialCompute) GetEnabled() *plugin.TValue[bool] {
@@ -41774,7 +41736,6 @@ type mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlGcpProjectSqlServiceInstanceSettingsActiveDirectoryInternal it will be used here
-	Id                        plugin.TValue[string]
 	Domain                    plugin.TValue[string]
 	Mode                      plugin.TValue[string]
 	DnsServers                plugin.TValue[[]any]
@@ -41792,12 +41753,7 @@ func createGcpProjectSqlServiceInstanceSettingsActiveDirectory(runtime *plugin.R
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("gcp.project.sqlService.instance.settings.activeDirectory", res.__id)
@@ -41816,10 +41772,6 @@ func (c *mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory) MqlName() strin
 
 func (c *mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory) MqlID() string {
 	return c.__id
-}
-
-func (c *mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory) GetId() *plugin.TValue[string] {
-	return &c.Id
 }
 
 func (c *mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory) GetDomain() *plugin.TValue[string] {
@@ -45786,7 +45738,6 @@ type mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfigInternal it will be used here
-	Id        plugin.TValue[string]
 	OsVersion plugin.TValue[string]
 }
 
@@ -45801,12 +45752,7 @@ func createGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig(runtime *p
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig", res.__id)
@@ -45825,10 +45771,6 @@ func (c *mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig) MqlName(
 
 func (c *mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig) MqlID() string {
 	return c.__id
-}
-
-func (c *mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig) GetId() *plugin.TValue[string] {
-	return &c.Id
 }
 
 func (c *mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig) GetOsVersion() *plugin.TValue[string] {
@@ -52163,7 +52105,6 @@ type mqlGcpProjectCloudRunServiceVpcAccessConfig struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlGcpProjectCloudRunServiceVpcAccessConfigInternal it will be used here
-	Id                plugin.TValue[string]
 	Connector         plugin.TValue[string]
 	Egress            plugin.TValue[string]
 	NetworkInterfaces plugin.TValue[[]any]
@@ -52180,12 +52121,7 @@ func createGcpProjectCloudRunServiceVpcAccessConfig(runtime *plugin.Runtime, arg
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("gcp.project.cloudRunService.vpcAccessConfig", res.__id)
@@ -52204,10 +52140,6 @@ func (c *mqlGcpProjectCloudRunServiceVpcAccessConfig) MqlName() string {
 
 func (c *mqlGcpProjectCloudRunServiceVpcAccessConfig) MqlID() string {
 	return c.__id
-}
-
-func (c *mqlGcpProjectCloudRunServiceVpcAccessConfig) GetId() *plugin.TValue[string] {
-	return &c.Id
 }
 
 func (c *mqlGcpProjectCloudRunServiceVpcAccessConfig) GetConnector() *plugin.TValue[string] {

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -50,6 +50,7 @@ const (
 	ResourceGcpProjectComputeServiceInstance                                           string = "gcp.project.computeService.instance"
 	ResourceGcpProjectComputeServiceInstanceOsInventory                                string = "gcp.project.computeService.instance.osInventory"
 	ResourceGcpProjectComputeServiceInstanceVulnerabilityReport                        string = "gcp.project.computeService.instance.vulnerabilityReport"
+	ResourceGcpProjectComputeServiceInstanceConfidentialCompute                        string = "gcp.project.computeService.instance.confidentialCompute"
 	ResourceGcpProjectComputeServiceInstanceShieldedInstanceConfig                     string = "gcp.project.computeService.instance.shieldedInstanceConfig"
 	ResourceGcpProjectComputeServiceServiceaccount                                     string = "gcp.project.computeService.serviceaccount"
 	ResourceGcpProjectComputeServiceDisk                                               string = "gcp.project.computeService.disk"
@@ -77,6 +78,7 @@ const (
 	ResourceGcpProjectSqlServiceInstanceSslCert                                        string = "gcp.project.sqlService.instance.sslCert"
 	ResourceGcpProjectSqlServiceInstanceIpMapping                                      string = "gcp.project.sqlService.instance.ipMapping"
 	ResourceGcpProjectSqlServiceInstanceSettings                                       string = "gcp.project.sqlService.instance.settings"
+	ResourceGcpProjectSqlServiceInstanceSettingsActiveDirectory                        string = "gcp.project.sqlService.instance.settings.activeDirectory"
 	ResourceGcpProjectSqlServiceInstanceSettingsBackupconfiguration                    string = "gcp.project.sqlService.instance.settings.backupconfiguration"
 	ResourceGcpProjectSqlServiceInstanceSettingsDenyMaintenancePeriod                  string = "gcp.project.sqlService.instance.settings.denyMaintenancePeriod"
 	ResourceGcpProjectSqlServiceInstanceSettingsIpConfiguration                        string = "gcp.project.sqlService.instance.settings.ipConfiguration"
@@ -116,6 +118,7 @@ const (
 	ResourceGcpProjectGkeServiceClusterNodepoolConfigSandboxConfig                     string = "gcp.project.gkeService.cluster.nodepool.config.sandboxConfig"
 	ResourceGcpProjectGkeServiceClusterNodepoolConfigShieldedInstanceConfig            string = "gcp.project.gkeService.cluster.nodepool.config.shieldedInstanceConfig"
 	ResourceGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig                   string = "gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig"
+	ResourceGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig                 string = "gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig"
 	ResourceGcpProjectGkeServiceClusterNodepoolConfigKubeletConfig                     string = "gcp.project.gkeService.cluster.nodepool.config.kubeletConfig"
 	ResourceGcpProjectGkeServiceClusterNodepoolConfigGcfsConfig                        string = "gcp.project.gkeService.cluster.nodepool.config.gcfsConfig"
 	ResourceGcpProjectGkeServiceClusterNodepoolConfigAdvancedMachineFeatures           string = "gcp.project.gkeService.cluster.nodepool.config.advancedMachineFeatures"
@@ -183,6 +186,7 @@ const (
 	ResourceGcpProjectCloudRunServiceServiceRevisionTemplate                           string = "gcp.project.cloudRunService.service.revisionTemplate"
 	ResourceGcpProjectCloudRunServiceContainer                                         string = "gcp.project.cloudRunService.container"
 	ResourceGcpProjectCloudRunServiceContainerProbe                                    string = "gcp.project.cloudRunService.container.probe"
+	ResourceGcpProjectCloudRunServiceVpcAccessConfig                                   string = "gcp.project.cloudRunService.vpcAccessConfig"
 	ResourceGcpProjectCloudRunServiceCondition                                         string = "gcp.project.cloudRunService.condition"
 	ResourceGcpProjectCloudRunServiceJob                                               string = "gcp.project.cloudRunService.job"
 	ResourceGcpProjectCloudRunServiceJobExecutionTemplate                              string = "gcp.project.cloudRunService.job.executionTemplate"
@@ -557,6 +561,10 @@ func init() {
 			// to override args, implement: initGcpProjectComputeServiceInstanceVulnerabilityReport(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createGcpProjectComputeServiceInstanceVulnerabilityReport,
 		},
+		"gcp.project.computeService.instance.confidentialCompute": {
+			// to override args, implement: initGcpProjectComputeServiceInstanceConfidentialCompute(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGcpProjectComputeServiceInstanceConfidentialCompute,
+		},
 		"gcp.project.computeService.instance.shieldedInstanceConfig": {
 			// to override args, implement: initGcpProjectComputeServiceInstanceShieldedInstanceConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createGcpProjectComputeServiceInstanceShieldedInstanceConfig,
@@ -664,6 +672,10 @@ func init() {
 		"gcp.project.sqlService.instance.settings": {
 			// to override args, implement: initGcpProjectSqlServiceInstanceSettings(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createGcpProjectSqlServiceInstanceSettings,
+		},
+		"gcp.project.sqlService.instance.settings.activeDirectory": {
+			// to override args, implement: initGcpProjectSqlServiceInstanceSettingsActiveDirectory(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGcpProjectSqlServiceInstanceSettingsActiveDirectory,
 		},
 		"gcp.project.sqlService.instance.settings.backupconfiguration": {
 			// to override args, implement: initGcpProjectSqlServiceInstanceSettingsBackupconfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -820,6 +832,10 @@ func init() {
 		"gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig": {
 			// to override args, implement: initGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig,
+		},
+		"gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig": {
+			// to override args, implement: initGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig,
 		},
 		"gcp.project.gkeService.cluster.nodepool.config.kubeletConfig": {
 			// to override args, implement: initGcpProjectGkeServiceClusterNodepoolConfigKubeletConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -1088,6 +1104,10 @@ func init() {
 		"gcp.project.cloudRunService.container.probe": {
 			// to override args, implement: initGcpProjectCloudRunServiceContainerProbe(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createGcpProjectCloudRunServiceContainerProbe,
+		},
+		"gcp.project.cloudRunService.vpcAccessConfig": {
+			// to override args, implement: initGcpProjectCloudRunServiceVpcAccessConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGcpProjectCloudRunServiceVpcAccessConfig,
 		},
 		"gcp.project.cloudRunService.condition": {
 			// to override args, implement: initGcpProjectCloudRunServiceCondition(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -3399,6 +3419,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.instance.confidentialInstanceConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetConfidentialInstanceConfig()).ToDataRes(types.Dict)
 	},
+	"gcp.project.computeService.instance.confidentialCompute": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstance).GetConfidentialCompute()).ToDataRes(types.Resource("gcp.project.computeService.instance.confidentialCompute"))
+	},
 	"gcp.project.computeService.instance.canIpForward": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetCanIpForward()).ToDataRes(types.Bool)
 	},
@@ -3563,6 +3586,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.instance.vulnerabilityReport.updateTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceVulnerabilityReport).GetUpdateTime()).ToDataRes(types.Time)
+	},
+	"gcp.project.computeService.instance.confidentialCompute.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstanceConfidentialCompute).GetId()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.instance.confidentialCompute.enabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstanceConfidentialCompute).GetEnabled()).ToDataRes(types.Bool)
+	},
+	"gcp.project.computeService.instance.confidentialCompute.instanceType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstanceConfidentialCompute).GetInstanceType()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.instance.shieldedInstanceConfig.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig).GetId()).ToDataRes(types.String)
@@ -4770,6 +4802,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.sqlService.instance.settings.activeDirectoryConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettings).GetActiveDirectoryConfig()).ToDataRes(types.Dict)
 	},
+	"gcp.project.sqlService.instance.settings.activeDirectory": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettings).GetActiveDirectory()).ToDataRes(types.Resource("gcp.project.sqlService.instance.settings.activeDirectory"))
+	},
 	"gcp.project.sqlService.instance.settings.availabilityType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettings).GetAvailabilityType()).ToDataRes(types.String)
 	},
@@ -4844,6 +4879,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.sqlService.instance.settings.userLabels": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettings).GetUserLabels()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"gcp.project.sqlService.instance.settings.activeDirectory.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory).GetId()).ToDataRes(types.String)
+	},
+	"gcp.project.sqlService.instance.settings.activeDirectory.domain": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory).GetDomain()).ToDataRes(types.String)
+	},
+	"gcp.project.sqlService.instance.settings.activeDirectory.mode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory).GetMode()).ToDataRes(types.String)
+	},
+	"gcp.project.sqlService.instance.settings.activeDirectory.dnsServers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory).GetDnsServers()).ToDataRes(types.Array(types.String))
+	},
+	"gcp.project.sqlService.instance.settings.activeDirectory.adminCredentialSecretName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory).GetAdminCredentialSecretName()).ToDataRes(types.String)
 	},
 	"gcp.project.sqlService.instance.settings.backupconfiguration.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsBackupconfiguration).GetId()).ToDataRes(types.String)
@@ -5928,6 +5978,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfig).GetLinuxNodeConfig()).ToDataRes(types.Resource("gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig"))
 	},
+	"gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfig).GetWindowsNodeConfig()).ToDataRes(types.Resource("gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig"))
+	},
 	"gcp.project.gkeService.cluster.nodepool.config.kubeletConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfig).GetKubeletConfig()).ToDataRes(types.Resource("gcp.project.gkeService.cluster.nodepool.config.kubeletConfig"))
 	},
@@ -6008,6 +6061,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig.sysctls": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig).GetSysctls()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig).GetId()).ToDataRes(types.String)
+	},
+	"gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig.osVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig).GetOsVersion()).ToDataRes(types.String)
 	},
 	"gcp.project.gkeService.cluster.nodepool.config.kubeletConfig.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceClusterNodepoolConfigKubeletConfig).GetId()).ToDataRes(types.String)
@@ -7608,6 +7667,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.cloudRunService.service.revisionTemplate.vpcAccess": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceServiceRevisionTemplate).GetVpcAccess()).ToDataRes(types.Dict)
 	},
+	"gcp.project.cloudRunService.service.revisionTemplate.vpcAccessConfig": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudRunServiceServiceRevisionTemplate).GetVpcAccessConfig()).ToDataRes(types.Resource("gcp.project.cloudRunService.vpcAccessConfig"))
+	},
 	"gcp.project.cloudRunService.service.revisionTemplate.timeout": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceServiceRevisionTemplate).GetTimeout()).ToDataRes(types.Time)
 	},
@@ -7688,6 +7750,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.cloudRunService.container.probe.tcpSocket": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceContainerProbe).GetTcpSocket()).ToDataRes(types.Dict)
+	},
+	"gcp.project.cloudRunService.vpcAccessConfig.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudRunServiceVpcAccessConfig).GetId()).ToDataRes(types.String)
+	},
+	"gcp.project.cloudRunService.vpcAccessConfig.connector": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudRunServiceVpcAccessConfig).GetConnector()).ToDataRes(types.String)
+	},
+	"gcp.project.cloudRunService.vpcAccessConfig.egress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudRunServiceVpcAccessConfig).GetEgress()).ToDataRes(types.String)
+	},
+	"gcp.project.cloudRunService.vpcAccessConfig.networkInterfaces": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudRunServiceVpcAccessConfig).GetNetworkInterfaces()).ToDataRes(types.Array(types.Dict))
 	},
 	"gcp.project.cloudRunService.condition.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceCondition).GetId()).ToDataRes(types.String)
@@ -7811,6 +7885,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.cloudRunService.job.executionTemplate.taskTemplate.vpcAccess": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate).GetVpcAccess()).ToDataRes(types.Dict)
+	},
+	"gcp.project.cloudRunService.job.executionTemplate.taskTemplate.vpcAccessConfig": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate).GetVpcAccessConfig()).ToDataRes(types.Resource("gcp.project.cloudRunService.vpcAccessConfig"))
 	},
 	"gcp.project.cloudRunService.job.executionTemplate.taskTemplate.timeout": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate).GetTimeout()).ToDataRes(types.Time)
@@ -16129,6 +16206,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceInstance).ConfidentialInstanceConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.instance.confidentialCompute": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstance).ConfidentialCompute, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceInstanceConfidentialCompute](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.instance.canIpForward": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstance).CanIpForward, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -16355,6 +16436,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.instance.vulnerabilityReport.updateTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstanceVulnerabilityReport).UpdateTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.instance.confidentialCompute.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstanceConfidentialCompute).__id, ok = v.Value.(string)
+		return
+	},
+	"gcp.project.computeService.instance.confidentialCompute.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstanceConfidentialCompute).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.instance.confidentialCompute.enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstanceConfidentialCompute).Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.instance.confidentialCompute.instanceType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstanceConfidentialCompute).InstanceType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.instance.shieldedInstanceConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -18073,6 +18170,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectSqlServiceInstanceSettings).ActiveDirectoryConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.sqlService.instance.settings.activeDirectory": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettings).ActiveDirectory, ok = plugin.RawToTValue[*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory](v.Value, v.Error)
+		return
+	},
 	"gcp.project.sqlService.instance.settings.availabilityType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstanceSettings).AvailabilityType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -18171,6 +18272,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.sqlService.instance.settings.userLabels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstanceSettings).UserLabels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.activeDirectory.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory).__id, ok = v.Value.(string)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.activeDirectory.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.activeDirectory.domain": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory).Domain, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.activeDirectory.mode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory).Mode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.activeDirectory.dnsServers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory).DnsServers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.activeDirectory.adminCredentialSecretName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory).AdminCredentialSecretName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.sqlService.instance.settings.backupconfiguration.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -19749,6 +19874,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectGkeServiceClusterNodepoolConfig).LinuxNodeConfig, ok = plugin.RawToTValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig](v.Value, v.Error)
 		return
 	},
+	"gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceClusterNodepoolConfig).WindowsNodeConfig, ok = plugin.RawToTValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig](v.Value, v.Error)
+		return
+	},
 	"gcp.project.gkeService.cluster.nodepool.config.kubeletConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceClusterNodepoolConfig).KubeletConfig, ok = plugin.RawToTValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigKubeletConfig](v.Value, v.Error)
 		return
@@ -19879,6 +20008,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig.sysctls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig).Sysctls, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig).__id, ok = v.Value.(string)
+		return
+	},
+	"gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig.osVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig).OsVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.gkeService.cluster.nodepool.config.kubeletConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -22273,6 +22414,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectCloudRunServiceServiceRevisionTemplate).VpcAccess, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.cloudRunService.service.revisionTemplate.vpcAccessConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudRunServiceServiceRevisionTemplate).VpcAccessConfig, ok = plugin.RawToTValue[*mqlGcpProjectCloudRunServiceVpcAccessConfig](v.Value, v.Error)
+		return
+	},
 	"gcp.project.cloudRunService.service.revisionTemplate.timeout": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudRunServiceServiceRevisionTemplate).Timeout, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -22387,6 +22532,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.cloudRunService.container.probe.tcpSocket": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudRunServiceContainerProbe).TcpSocket, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.cloudRunService.vpcAccessConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudRunServiceVpcAccessConfig).__id, ok = v.Value.(string)
+		return
+	},
+	"gcp.project.cloudRunService.vpcAccessConfig.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudRunServiceVpcAccessConfig).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.cloudRunService.vpcAccessConfig.connector": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudRunServiceVpcAccessConfig).Connector, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.cloudRunService.vpcAccessConfig.egress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudRunServiceVpcAccessConfig).Egress, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.cloudRunService.vpcAccessConfig.networkInterfaces": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudRunServiceVpcAccessConfig).NetworkInterfaces, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.cloudRunService.condition.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -22567,6 +22732,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.cloudRunService.job.executionTemplate.taskTemplate.vpcAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate).VpcAccess, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.cloudRunService.job.executionTemplate.taskTemplate.vpcAccessConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate).VpcAccessConfig, ok = plugin.RawToTValue[*mqlGcpProjectCloudRunServiceVpcAccessConfig](v.Value, v.Error)
 		return
 	},
 	"gcp.project.cloudRunService.job.executionTemplate.taskTemplate.timeout": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -37321,6 +37490,7 @@ type mqlGcpProjectComputeServiceInstance struct {
 	Name                            plugin.TValue[string]
 	Description                     plugin.TValue[string]
 	ConfidentialInstanceConfig      plugin.TValue[any]
+	ConfidentialCompute             plugin.TValue[*mqlGcpProjectComputeServiceInstanceConfidentialCompute]
 	CanIpForward                    plugin.TValue[bool]
 	CpuPlatform                     plugin.TValue[string]
 	Created                         plugin.TValue[*time.Time]
@@ -37425,6 +37595,10 @@ func (c *mqlGcpProjectComputeServiceInstance) GetDescription() *plugin.TValue[st
 
 func (c *mqlGcpProjectComputeServiceInstance) GetConfidentialInstanceConfig() *plugin.TValue[any] {
 	return &c.ConfidentialInstanceConfig
+}
+
+func (c *mqlGcpProjectComputeServiceInstance) GetConfidentialCompute() *plugin.TValue[*mqlGcpProjectComputeServiceInstanceConfidentialCompute] {
+	return &c.ConfidentialCompute
 }
 
 func (c *mqlGcpProjectComputeServiceInstance) GetCanIpForward() *plugin.TValue[bool] {
@@ -37789,6 +37963,65 @@ func (c *mqlGcpProjectComputeServiceInstanceVulnerabilityReport) GetHighestUpgra
 
 func (c *mqlGcpProjectComputeServiceInstanceVulnerabilityReport) GetUpdateTime() *plugin.TValue[*time.Time] {
 	return &c.UpdateTime
+}
+
+// mqlGcpProjectComputeServiceInstanceConfidentialCompute for the gcp.project.computeService.instance.confidentialCompute resource
+type mqlGcpProjectComputeServiceInstanceConfidentialCompute struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlGcpProjectComputeServiceInstanceConfidentialComputeInternal it will be used here
+	Id           plugin.TValue[string]
+	Enabled      plugin.TValue[bool]
+	InstanceType plugin.TValue[string]
+}
+
+// createGcpProjectComputeServiceInstanceConfidentialCompute creates a new instance of this resource
+func createGcpProjectComputeServiceInstanceConfidentialCompute(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGcpProjectComputeServiceInstanceConfidentialCompute{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("gcp.project.computeService.instance.confidentialCompute", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGcpProjectComputeServiceInstanceConfidentialCompute) MqlName() string {
+	return "gcp.project.computeService.instance.confidentialCompute"
+}
+
+func (c *mqlGcpProjectComputeServiceInstanceConfidentialCompute) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGcpProjectComputeServiceInstanceConfidentialCompute) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlGcpProjectComputeServiceInstanceConfidentialCompute) GetEnabled() *plugin.TValue[bool] {
+	return &c.Enabled
+}
+
+func (c *mqlGcpProjectComputeServiceInstanceConfidentialCompute) GetInstanceType() *plugin.TValue[string] {
+	return &c.InstanceType
 }
 
 // mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig for the gcp.project.computeService.instance.shieldedInstanceConfig resource
@@ -41351,6 +41584,7 @@ type mqlGcpProjectSqlServiceInstanceSettings struct {
 	InstanceName                plugin.TValue[string]
 	ActivationPolicy            plugin.TValue[string]
 	ActiveDirectoryConfig       plugin.TValue[any]
+	ActiveDirectory             plugin.TValue[*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory]
 	AvailabilityType            plugin.TValue[string]
 	BackupConfiguration         plugin.TValue[*mqlGcpProjectSqlServiceInstanceSettingsBackupconfiguration]
 	Collation                   plugin.TValue[string]
@@ -41429,6 +41663,10 @@ func (c *mqlGcpProjectSqlServiceInstanceSettings) GetActivationPolicy() *plugin.
 
 func (c *mqlGcpProjectSqlServiceInstanceSettings) GetActiveDirectoryConfig() *plugin.TValue[any] {
 	return &c.ActiveDirectoryConfig
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettings) GetActiveDirectory() *plugin.TValue[*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory] {
+	return &c.ActiveDirectory
 }
 
 func (c *mqlGcpProjectSqlServiceInstanceSettings) GetAvailabilityType() *plugin.TValue[string] {
@@ -41529,6 +41767,75 @@ func (c *mqlGcpProjectSqlServiceInstanceSettings) GetTimeZone() *plugin.TValue[s
 
 func (c *mqlGcpProjectSqlServiceInstanceSettings) GetUserLabels() *plugin.TValue[map[string]any] {
 	return &c.UserLabels
+}
+
+// mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory for the gcp.project.sqlService.instance.settings.activeDirectory resource
+type mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlGcpProjectSqlServiceInstanceSettingsActiveDirectoryInternal it will be used here
+	Id                        plugin.TValue[string]
+	Domain                    plugin.TValue[string]
+	Mode                      plugin.TValue[string]
+	DnsServers                plugin.TValue[[]any]
+	AdminCredentialSecretName plugin.TValue[string]
+}
+
+// createGcpProjectSqlServiceInstanceSettingsActiveDirectory creates a new instance of this resource
+func createGcpProjectSqlServiceInstanceSettingsActiveDirectory(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("gcp.project.sqlService.instance.settings.activeDirectory", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory) MqlName() string {
+	return "gcp.project.sqlService.instance.settings.activeDirectory"
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory) GetDomain() *plugin.TValue[string] {
+	return &c.Domain
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory) GetMode() *plugin.TValue[string] {
+	return &c.Mode
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory) GetDnsServers() *plugin.TValue[[]any] {
+	return &c.DnsServers
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory) GetAdminCredentialSecretName() *plugin.TValue[string] {
+	return &c.AdminCredentialSecretName
 }
 
 // mqlGcpProjectSqlServiceInstanceSettingsBackupconfiguration for the gcp.project.sqlService.instance.settings.backupconfiguration resource
@@ -44923,6 +45230,7 @@ type mqlGcpProjectGkeServiceClusterNodepoolConfig struct {
 	SandboxConfig             plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigSandboxConfig]
 	ShieldedInstanceConfig    plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigShieldedInstanceConfig]
 	LinuxNodeConfig           plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig]
+	WindowsNodeConfig         plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig]
 	KubeletConfig             plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigKubeletConfig]
 	BootDiskKmsKey            plugin.TValue[string]
 	GcfsConfig                plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigGcfsConfig]
@@ -45076,6 +45384,10 @@ func (c *mqlGcpProjectGkeServiceClusterNodepoolConfig) GetShieldedInstanceConfig
 
 func (c *mqlGcpProjectGkeServiceClusterNodepoolConfig) GetLinuxNodeConfig() *plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig] {
 	return &c.LinuxNodeConfig
+}
+
+func (c *mqlGcpProjectGkeServiceClusterNodepoolConfig) GetWindowsNodeConfig() *plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig] {
+	return &c.WindowsNodeConfig
 }
 
 func (c *mqlGcpProjectGkeServiceClusterNodepoolConfig) GetKubeletConfig() *plugin.TValue[*mqlGcpProjectGkeServiceClusterNodepoolConfigKubeletConfig] {
@@ -45467,6 +45779,60 @@ func (c *mqlGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig) GetId() *p
 
 func (c *mqlGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig) GetSysctls() *plugin.TValue[map[string]any] {
 	return &c.Sysctls
+}
+
+// mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig for the gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig resource
+type mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfigInternal it will be used here
+	Id        plugin.TValue[string]
+	OsVersion plugin.TValue[string]
+}
+
+// createGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig creates a new instance of this resource
+func createGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig) MqlName() string {
+	return "gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig"
+}
+
+func (c *mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig) GetOsVersion() *plugin.TValue[string] {
+	return &c.OsVersion
 }
 
 // mqlGcpProjectGkeServiceClusterNodepoolConfigKubeletConfig for the gcp.project.gkeService.cluster.nodepool.config.kubeletConfig resource
@@ -51485,6 +51851,7 @@ type mqlGcpProjectCloudRunServiceServiceRevisionTemplate struct {
 	Annotations                   plugin.TValue[map[string]any]
 	Scaling                       plugin.TValue[any]
 	VpcAccess                     plugin.TValue[any]
+	VpcAccessConfig               plugin.TValue[*mqlGcpProjectCloudRunServiceVpcAccessConfig]
 	Timeout                       plugin.TValue[*time.Time]
 	ServiceAccountEmail           plugin.TValue[string]
 	ServiceAccount                plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
@@ -51558,6 +51925,10 @@ func (c *mqlGcpProjectCloudRunServiceServiceRevisionTemplate) GetScaling() *plug
 
 func (c *mqlGcpProjectCloudRunServiceServiceRevisionTemplate) GetVpcAccess() *plugin.TValue[any] {
 	return &c.VpcAccess
+}
+
+func (c *mqlGcpProjectCloudRunServiceServiceRevisionTemplate) GetVpcAccessConfig() *plugin.TValue[*mqlGcpProjectCloudRunServiceVpcAccessConfig] {
+	return &c.VpcAccessConfig
 }
 
 func (c *mqlGcpProjectCloudRunServiceServiceRevisionTemplate) GetTimeout() *plugin.TValue[*time.Time] {
@@ -51785,6 +52156,70 @@ func (c *mqlGcpProjectCloudRunServiceContainerProbe) GetHttpGet() *plugin.TValue
 
 func (c *mqlGcpProjectCloudRunServiceContainerProbe) GetTcpSocket() *plugin.TValue[any] {
 	return &c.TcpSocket
+}
+
+// mqlGcpProjectCloudRunServiceVpcAccessConfig for the gcp.project.cloudRunService.vpcAccessConfig resource
+type mqlGcpProjectCloudRunServiceVpcAccessConfig struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlGcpProjectCloudRunServiceVpcAccessConfigInternal it will be used here
+	Id                plugin.TValue[string]
+	Connector         plugin.TValue[string]
+	Egress            plugin.TValue[string]
+	NetworkInterfaces plugin.TValue[[]any]
+}
+
+// createGcpProjectCloudRunServiceVpcAccessConfig creates a new instance of this resource
+func createGcpProjectCloudRunServiceVpcAccessConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGcpProjectCloudRunServiceVpcAccessConfig{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("gcp.project.cloudRunService.vpcAccessConfig", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGcpProjectCloudRunServiceVpcAccessConfig) MqlName() string {
+	return "gcp.project.cloudRunService.vpcAccessConfig"
+}
+
+func (c *mqlGcpProjectCloudRunServiceVpcAccessConfig) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGcpProjectCloudRunServiceVpcAccessConfig) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlGcpProjectCloudRunServiceVpcAccessConfig) GetConnector() *plugin.TValue[string] {
+	return &c.Connector
+}
+
+func (c *mqlGcpProjectCloudRunServiceVpcAccessConfig) GetEgress() *plugin.TValue[string] {
+	return &c.Egress
+}
+
+func (c *mqlGcpProjectCloudRunServiceVpcAccessConfig) GetNetworkInterfaces() *plugin.TValue[[]any] {
+	return &c.NetworkInterfaces
 }
 
 // mqlGcpProjectCloudRunServiceCondition for the gcp.project.cloudRunService.condition resource
@@ -52129,6 +52564,7 @@ type mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate struct {
 	Id                   plugin.TValue[string]
 	ProjectId            plugin.TValue[string]
 	VpcAccess            plugin.TValue[any]
+	VpcAccessConfig      plugin.TValue[*mqlGcpProjectCloudRunServiceVpcAccessConfig]
 	Timeout              plugin.TValue[*time.Time]
 	ServiceAccountEmail  plugin.TValue[string]
 	ServiceAccount       plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
@@ -52186,6 +52622,10 @@ func (c *mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate) GetProjec
 
 func (c *mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate) GetVpcAccess() *plugin.TValue[any] {
 	return &c.VpcAccess
+}
+
+func (c *mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate) GetVpcAccessConfig() *plugin.TValue[*mqlGcpProjectCloudRunServiceVpcAccessConfig] {
+	return &c.VpcAccessConfig
 }
 
 func (c *mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate) GetTimeout() *plugin.TValue[*time.Time] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -1167,7 +1167,6 @@ gcp.project.cloudRunService.services 9.0.0
 gcp.project.cloudRunService.vpcAccessConfig 13.16.3
 gcp.project.cloudRunService.vpcAccessConfig.connector 13.16.3
 gcp.project.cloudRunService.vpcAccessConfig.egress 13.16.3
-gcp.project.cloudRunService.vpcAccessConfig.id 13.16.3
 gcp.project.cloudRunService.vpcAccessConfig.networkInterfaces 13.16.3
 gcp.project.cloudScheduler 11.6.6
 gcp.project.cloudSchedulerService 11.6.6
@@ -1520,7 +1519,6 @@ gcp.project.computeService.instance.blockProjectSshKeysEnabled 13.12.2
 gcp.project.computeService.instance.canIpForward 9.0.0
 gcp.project.computeService.instance.confidentialCompute 13.16.3
 gcp.project.computeService.instance.confidentialCompute.enabled 13.16.3
-gcp.project.computeService.instance.confidentialCompute.id 13.16.3
 gcp.project.computeService.instance.confidentialCompute.instanceType 13.16.3
 gcp.project.computeService.instance.confidentialInstanceConfig 9.0.0
 gcp.project.computeService.instance.cpuPlatform 9.0.0
@@ -2837,7 +2835,6 @@ gcp.project.gkeService.cluster.nodepool.config.tags 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.taints 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.usesDefaultServiceAccount 13.12.2
 gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig 13.16.3
-gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig.id 13.16.3
 gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig.osVersion 13.16.3
 gcp.project.gkeService.cluster.nodepool.config.workloadMetadataMode 9.0.0
 gcp.project.gkeService.cluster.nodepool.etag 13.1.2
@@ -3982,7 +3979,6 @@ gcp.project.sqlService.instance.settings.activeDirectory 13.16.3
 gcp.project.sqlService.instance.settings.activeDirectory.adminCredentialSecretName 13.16.3
 gcp.project.sqlService.instance.settings.activeDirectory.dnsServers 13.16.3
 gcp.project.sqlService.instance.settings.activeDirectory.domain 13.16.3
-gcp.project.sqlService.instance.settings.activeDirectory.id 13.16.3
 gcp.project.sqlService.instance.settings.activeDirectory.mode 13.16.3
 gcp.project.sqlService.instance.settings.activeDirectoryConfig 9.0.0
 gcp.project.sqlService.instance.settings.availabilityType 9.0.0

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -1084,6 +1084,7 @@ gcp.project.cloudRunService.job.executionTemplate.taskTemplate.serviceAccountEma
 gcp.project.cloudRunService.job.executionTemplate.taskTemplate.timeout 9.0.0
 gcp.project.cloudRunService.job.executionTemplate.taskTemplate.volumes 9.0.0
 gcp.project.cloudRunService.job.executionTemplate.taskTemplate.vpcAccess 9.0.0
+gcp.project.cloudRunService.job.executionTemplate.taskTemplate.vpcAccessConfig 13.16.3
 gcp.project.cloudRunService.job.executionTemplate.template 9.0.0
 gcp.project.cloudRunService.job.expired 9.0.0
 gcp.project.cloudRunService.job.generation 9.0.0
@@ -1153,6 +1154,7 @@ gcp.project.cloudRunService.service.revisionTemplate.serviceAccountEmail 9.0.0
 gcp.project.cloudRunService.service.revisionTemplate.timeout 9.0.0
 gcp.project.cloudRunService.service.revisionTemplate.volumes 9.0.0
 gcp.project.cloudRunService.service.revisionTemplate.vpcAccess 9.0.0
+gcp.project.cloudRunService.service.revisionTemplate.vpcAccessConfig 13.16.3
 gcp.project.cloudRunService.service.satisfiesPzs 13.1.2
 gcp.project.cloudRunService.service.template 9.0.0
 gcp.project.cloudRunService.service.terminalCondition 9.0.0
@@ -1162,6 +1164,11 @@ gcp.project.cloudRunService.service.uid 13.1.2
 gcp.project.cloudRunService.service.updated 9.0.0
 gcp.project.cloudRunService.service.uri 9.0.0
 gcp.project.cloudRunService.services 9.0.0
+gcp.project.cloudRunService.vpcAccessConfig 13.16.3
+gcp.project.cloudRunService.vpcAccessConfig.connector 13.16.3
+gcp.project.cloudRunService.vpcAccessConfig.egress 13.16.3
+gcp.project.cloudRunService.vpcAccessConfig.id 13.16.3
+gcp.project.cloudRunService.vpcAccessConfig.networkInterfaces 13.16.3
 gcp.project.cloudScheduler 11.6.6
 gcp.project.cloudSchedulerService 11.6.6
 gcp.project.cloudSchedulerService.job 11.6.6
@@ -1511,6 +1518,10 @@ gcp.project.computeService.images 9.0.0
 gcp.project.computeService.instance 9.0.0
 gcp.project.computeService.instance.blockProjectSshKeysEnabled 13.12.2
 gcp.project.computeService.instance.canIpForward 9.0.0
+gcp.project.computeService.instance.confidentialCompute 13.16.3
+gcp.project.computeService.instance.confidentialCompute.enabled 13.16.3
+gcp.project.computeService.instance.confidentialCompute.id 13.16.3
+gcp.project.computeService.instance.confidentialCompute.instanceType 13.16.3
 gcp.project.computeService.instance.confidentialInstanceConfig 9.0.0
 gcp.project.computeService.instance.cpuPlatform 9.0.0
 gcp.project.computeService.instance.created 9.0.0
@@ -2825,6 +2836,9 @@ gcp.project.gkeService.cluster.nodepool.config.spot 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.tags 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.taints 9.0.0
 gcp.project.gkeService.cluster.nodepool.config.usesDefaultServiceAccount 13.12.2
+gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig 13.16.3
+gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig.id 13.16.3
+gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig.osVersion 13.16.3
 gcp.project.gkeService.cluster.nodepool.config.workloadMetadataMode 9.0.0
 gcp.project.gkeService.cluster.nodepool.etag 13.1.2
 gcp.project.gkeService.cluster.nodepool.id 9.0.0
@@ -3964,6 +3978,12 @@ gcp.project.sqlService.instance.secondaryZone 11.6.6
 gcp.project.sqlService.instance.serviceAccountEmailAddress 9.0.0
 gcp.project.sqlService.instance.settings 9.0.0
 gcp.project.sqlService.instance.settings.activationPolicy 9.0.0
+gcp.project.sqlService.instance.settings.activeDirectory 13.16.3
+gcp.project.sqlService.instance.settings.activeDirectory.adminCredentialSecretName 13.16.3
+gcp.project.sqlService.instance.settings.activeDirectory.dnsServers 13.16.3
+gcp.project.sqlService.instance.settings.activeDirectory.domain 13.16.3
+gcp.project.sqlService.instance.settings.activeDirectory.id 13.16.3
+gcp.project.sqlService.instance.settings.activeDirectory.mode 13.16.3
 gcp.project.sqlService.instance.settings.activeDirectoryConfig 9.0.0
 gcp.project.sqlService.instance.settings.availabilityType 9.0.0
 gcp.project.sqlService.instance.settings.backupConfiguration 9.0.0

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -190,6 +190,10 @@ func (g *mqlGcpProjectGkeServiceClusterNodepoolConfigShieldedInstanceConfig) id(
 	return g.Id.Data, g.Id.Error
 }
 
+func (g *mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig) id() (string, error) {
+	return g.Id.Data, g.Id.Error
+}
+
 func (g *mqlGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig) id() (string, error) {
 	return g.Id.Data, g.Id.Error
 }
@@ -964,6 +968,17 @@ func createMqlNodePoolConfig(runtime *plugin.Runtime, np *containerpb.NodePool, 
 		}
 	}
 
+	var mqlWindowsNodeCfg plugin.Resource
+	if cfg.WindowsNodeConfig != nil {
+		mqlWindowsNodeCfg, err = CreateResource(runtime, "gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig", map[string]*llx.RawData{
+			"id":        llx.StringData(fmt.Sprintf("%s/windowsNodeConfig", nodePoolId)),
+			"osVersion": llx.StringData(cfg.WindowsNodeConfig.OsVersion.String()),
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	var mqlKubeletCfg plugin.Resource
 	if cfg.KubeletConfig != nil {
 		mqlKubeletCfg, err = CreateResource(runtime, "gcp.project.gkeService.cluster.nodepool.config.kubeletConfig", map[string]*llx.RawData{
@@ -1054,6 +1069,7 @@ func createMqlNodePoolConfig(runtime *plugin.Runtime, np *containerpb.NodePool, 
 		"sandboxConfig":           llx.ResourceData(mqlSandboxCfg, "gcp.project.gkeService.cluster.nodepool.config.sandboxConfig"),
 		"shieldedInstanceConfig":  llx.ResourceData(mqlShieldedInstanceCfg, "gcp.project.gkeService.cluster.nodepool.config.shieldedInstanceConfig"),
 		"linuxNodeConfig":         llx.ResourceData(mqlLinuxNodeCfg, " gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig"),
+		"windowsNodeConfig":       llx.ResourceData(mqlWindowsNodeCfg, "gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig"),
 		"kubeletConfig":           llx.ResourceData(mqlKubeletCfg, "gcp.project.gkeService.cluster.nodepool.config.kubeletConfig"),
 		"bootDiskKmsKey":          llx.StringData(cfg.BootDiskKmsKey),
 		"gcfsConfig":              llx.ResourceData(mqlGcfsCfg, "gcp.project.gkeService.cluster.nodepool.config.gcfsConfig"),

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -190,10 +190,6 @@ func (g *mqlGcpProjectGkeServiceClusterNodepoolConfigShieldedInstanceConfig) id(
 	return g.Id.Data, g.Id.Error
 }
 
-func (g *mqlGcpProjectGkeServiceClusterNodepoolConfigWindowsNodeConfig) id() (string, error) {
-	return g.Id.Data, g.Id.Error
-}
-
 func (g *mqlGcpProjectGkeServiceClusterNodepoolConfigLinuxNodeConfig) id() (string, error) {
 	return g.Id.Data, g.Id.Error
 }
@@ -971,7 +967,7 @@ func createMqlNodePoolConfig(runtime *plugin.Runtime, np *containerpb.NodePool, 
 	var mqlWindowsNodeCfg plugin.Resource
 	if cfg.WindowsNodeConfig != nil {
 		mqlWindowsNodeCfg, err = CreateResource(runtime, "gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig", map[string]*llx.RawData{
-			"id":        llx.StringData(fmt.Sprintf("%s/windowsNodeConfig", nodePoolId)),
+			"__id":      llx.StringData(fmt.Sprintf("%s/windowsNodeConfig", nodePoolId)),
 			"osVersion": llx.StringData(cfg.WindowsNodeConfig.OsVersion.String()),
 		})
 		if err != nil {

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -231,9 +231,20 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 				Domain string `json:"domain,omitempty"`
 			}
 			var mqlADCfg map[string]any
+			var mqlActiveDirectory plugin.Resource
 			if s.ActiveDirectoryConfig != nil {
 				mqlADCfg, err = convert.JsonToDict(mqlActiveDirectoryCfg{
 					Domain: s.ActiveDirectoryConfig.Domain,
+				})
+				if err != nil {
+					return err
+				}
+				mqlActiveDirectory, err = CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings.activeDirectory", map[string]*llx.RawData{
+					"id":                        llx.StringData(fmt.Sprintf("%s/settings/activeDirectory", instanceId)),
+					"domain":                    llx.StringData(s.ActiveDirectoryConfig.Domain),
+					"mode":                      llx.StringData(s.ActiveDirectoryConfig.Mode),
+					"dnsServers":                llx.ArrayData(convert.SliceAnyToInterface(s.ActiveDirectoryConfig.DnsServers), types.String),
+					"adminCredentialSecretName": llx.StringData(s.ActiveDirectoryConfig.AdminCredentialSecretName),
 				})
 				if err != nil {
 					return err
@@ -428,6 +439,7 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 			mqlSettings, err := CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings", map[string]*llx.RawData{
 				"activationPolicy":            llx.StringData(s.ActivationPolicy),
 				"activeDirectoryConfig":       llx.DictData(mqlADCfg),
+				"activeDirectory":             llx.ResourceData(mqlActiveDirectory, "gcp.project.sqlService.instance.settings.activeDirectory"),
 				"availabilityType":            llx.StringData(s.AvailabilityType),
 				"backupConfiguration":         llx.DictData(mqlBackupCfg),
 				"collation":                   llx.StringData(s.Collation),
@@ -704,6 +716,10 @@ func (g *mqlGcpProjectSqlServiceInstanceSettings) id() (string, error) {
 }
 
 func (g *mqlGcpProjectSqlServiceInstanceSettingsBackupconfiguration) id() (string, error) {
+	return g.Id.Data, g.Id.Error
+}
+
+func (g *mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory) id() (string, error) {
 	return g.Id.Data, g.Id.Error
 }
 

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -240,7 +240,7 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 					return err
 				}
 				mqlActiveDirectory, err = CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings.activeDirectory", map[string]*llx.RawData{
-					"id":                        llx.StringData(fmt.Sprintf("%s/settings/activeDirectory", instanceId)),
+					"__id":                      llx.StringData(fmt.Sprintf("%s/settings/activeDirectory", instanceId)),
 					"domain":                    llx.StringData(s.ActiveDirectoryConfig.Domain),
 					"mode":                      llx.StringData(s.ActiveDirectoryConfig.Mode),
 					"dnsServers":                llx.ArrayData(convert.SliceAnyToInterface(s.ActiveDirectoryConfig.DnsServers), types.String),
@@ -716,10 +716,6 @@ func (g *mqlGcpProjectSqlServiceInstanceSettings) id() (string, error) {
 }
 
 func (g *mqlGcpProjectSqlServiceInstanceSettingsBackupconfiguration) id() (string, error) {
-	return g.Id.Data, g.Id.Error
-}
-
-func (g *mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory) id() (string, error) {
 	return g.Id.Data, g.Id.Error
 }
 


### PR DESCRIPTION
## Summary

Expand depth on four existing resources, no breaking changes. Three are **dict → typed sub-resource** refactors that keep the existing field as `@maturity(\"deprecated\")` alongside the new typed accessor; one is purely additive.

### Resources / fields added

- **`gcp.project.computeService.instance.confidentialCompute`** (new typed sub-resource) exposes `enabled` and `instanceType` (`SEV` / `SEV_SNP` / `TDX`). The original `confidentialInstanceConfig dict` stays as a deprecated alias so existing dict-style queries keep working. Closes the asymmetry with the already-typed `shieldedInstanceConfig`.
- **`gcp.project.cloudRunService.vpcAccessConfig`** (new shared typed sub-resource) exposes `connector`, `egress` (`ALL_TRAFFIC` / `PRIVATE_RANGES_ONLY`), and direct-VPC `networkInterfaces`. Referenced from both `service.revisionTemplate` and `job.executionTemplate.taskTemplate`. Old `vpcAccess dict` kept deprecated on both parents. `egress` is the data-exfiltration-prevention control auditors care about.
- **`gcp.project.sqlService.instance.settings.activeDirectory`** (new typed sub-resource) exposes `domain`, `mode`, `dnsServers`, `adminCredentialSecretName` for Cloud SQL for SQL Server Entra ID / AD binding audits. Old `activeDirectoryConfig dict` kept deprecated.
- **`gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig`** (new typed sub-resource) exposes `osVersion` (`LTSC2019` / `LTSC2022`). Mirrors the existing `linuxNodeConfig` for Windows GKE node pools. Purely additive — no deprecation needed.

### Backwards compatibility

The three `dict` → `typed` refactors keep both names — old field stays exactly where it is, just annotated `@maturity(\"deprecated\")`. No existing query breaks. New typed alternatives are added under new field names (`confidentialCompute`, `vpcAccessConfig`, `activeDirectory`) so the old field path stays intact.

### What was dropped from the original list

Two items from the gap analysis were removed after SDK verification:
- `AttachedDisk.sourceImageEncryptionKey` — only exists on `AttachedDiskInitializeParams`, which is documented as `[Input Only]` and isn't populated at read time.
- `Instance.secondaryBootDisk` — doesn't exist in `cloud.google.com/go/compute@v1.63.0` or the REST `compute/v1` SDK. Looks to have been hallucinated.

### Notes

- `.lr.versions` entries at `13.16.3`. No `config/config.go` version bump.
- `gcp.permissions.json` unchanged (no new API calls).
- No new SDK dependencies.

## Test plan

- [x] `make providers/build/gcp` clean; permissions JSON unchanged
- [x] `go test ./providers/gcp/resources/...` passes (includes `TestGCPPermissionsMatchValidatedList`)
- [ ] Interactive smoke against live projects:
  ```
  cnspec shell gcp
  > gcp.project.computeService.instances { confidentialCompute { enabled instanceType } }
  > gcp.project.cloudRunService.services { template.vpcAccessConfig { connector egress networkInterfaces } }
  > gcp.project.sqlService.instances { settings.activeDirectory { domain mode dnsServers } }
  > gcp.project.gkeService.clusters { nodePools.list { config.windowsNodeConfig { osVersion } } }
  ```
  Each returns null fields when the corresponding feature isn't configured on the resource — that's expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)