### PR TITLE
✨ azure: VNet integration target + logging/auto-heal/websocket flags on App Service

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -3192,6 +3192,10 @@ azure.subscription.webService.appsite @defaults("id name location") {
   hostNameBindings() []azure.subscription.webService.appsite.hostNameBinding
   // Virtual network connections for the web app site
   virtualNetworkConnections() []azure.subscription.webService.appsite.virtualNetworkConnection
+  // ARM resource ID of the subnet the app is regionally VNet-integrated with; empty when no regional VNet integration is configured
+  virtualNetworkSubnetId string
+  // Subnet the app is regionally VNet-integrated with; null when no regional VNet integration is configured
+  virtualNetworkSubnet() azure.subscription.networkService.subnet
 }
 
 // Azure Web app site outbound VNet routing configuration
@@ -3342,6 +3346,14 @@ private azure.subscription.webService.appsiteconfig @defaults("id name") {
   scmIpSecurityRestrictions() []azure.subscription.webService.appsiteconfig.ipSecurityRestriction
   // Default action for IP security restrictions when no rule matches ("Allow" or "Deny")
   ipSecurityRestrictionsDefaultAction() string
+  // Whether WebSockets are enabled for the app
+  webSocketsEnabled bool
+  // Whether HTTP logging is enabled for the app
+  httpLoggingEnabled bool
+  // Whether detailed error logging is enabled
+  detailedErrorLoggingEnabled bool
+  // Whether auto-heal is enabled (the app is automatically restarted on certain conditions)
+  autoHealEnabled bool
 }
 
 // Azure AppSite config IP security restriction rule

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -5461,6 +5461,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.webService.appsite.virtualNetworkConnections": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetVirtualNetworkConnections()).ToDataRes(types.Array(types.Resource("azure.subscription.webService.appsite.virtualNetworkConnection")))
 	},
+	"azure.subscription.webService.appsite.virtualNetworkSubnetId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetVirtualNetworkSubnetId()).ToDataRes(types.String)
+	},
+	"azure.subscription.webService.appsite.virtualNetworkSubnet": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetVirtualNetworkSubnet()).ToDataRes(types.Resource("azure.subscription.networkService.subnet"))
+	},
 	"azure.subscription.webService.appsite.outboundVnetRouting.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsiteOutboundVnetRouting).GetId()).ToDataRes(types.String)
 	},
@@ -5643,6 +5649,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.webService.appsiteconfig.ipSecurityRestrictionsDefaultAction": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsiteconfig).GetIpSecurityRestrictionsDefaultAction()).ToDataRes(types.String)
+	},
+	"azure.subscription.webService.appsiteconfig.webSocketsEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsiteconfig).GetWebSocketsEnabled()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.webService.appsiteconfig.httpLoggingEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsiteconfig).GetHttpLoggingEnabled()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.webService.appsiteconfig.detailedErrorLoggingEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsiteconfig).GetDetailedErrorLoggingEnabled()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.webService.appsiteconfig.autoHealEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsiteconfig).GetAutoHealEnabled()).ToDataRes(types.Bool)
 	},
 	"azure.subscription.webService.appsiteconfig.ipSecurityRestriction.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsiteconfigIpSecurityRestriction).GetId()).ToDataRes(types.String)
@@ -17937,6 +17955,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionWebServiceAppsite).VirtualNetworkConnections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.webService.appsite.virtualNetworkSubnetId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsite).VirtualNetworkSubnetId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appsite.virtualNetworkSubnet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsite).VirtualNetworkSubnet, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceSubnet](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.webService.appsite.outboundVnetRouting.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebServiceAppsiteOutboundVnetRouting).__id, ok = v.Value.(string)
 		return
@@ -18207,6 +18233,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.webService.appsiteconfig.ipSecurityRestrictionsDefaultAction": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebServiceAppsiteconfig).IpSecurityRestrictionsDefaultAction, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appsiteconfig.webSocketsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsiteconfig).WebSocketsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appsiteconfig.httpLoggingEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsiteconfig).HttpLoggingEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appsiteconfig.detailedErrorLoggingEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsiteconfig).DetailedErrorLoggingEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appsiteconfig.autoHealEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsiteconfig).AutoHealEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.webService.appsiteconfig.ipSecurityRestriction.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -40855,6 +40897,8 @@ type mqlAzureSubscriptionWebServiceAppsite struct {
 	OutboundVnetRouting        plugin.TValue[*mqlAzureSubscriptionWebServiceAppsiteOutboundVnetRouting]
 	HostNameBindings           plugin.TValue[[]any]
 	VirtualNetworkConnections  plugin.TValue[[]any]
+	VirtualNetworkSubnetId     plugin.TValue[string]
+	VirtualNetworkSubnet       plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet]
 }
 
 // createAzureSubscriptionWebServiceAppsite creates a new instance of this resource
@@ -41167,6 +41211,26 @@ func (c *mqlAzureSubscriptionWebServiceAppsite) GetVirtualNetworkConnections() *
 		}
 
 		return c.virtualNetworkConnections()
+	})
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsite) GetVirtualNetworkSubnetId() *plugin.TValue[string] {
+	return &c.VirtualNetworkSubnetId
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsite) GetVirtualNetworkSubnet() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionNetworkServiceSubnet](&c.VirtualNetworkSubnet, func() (*mqlAzureSubscriptionNetworkServiceSubnet, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.appsite", c.__id, "virtualNetworkSubnet")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionNetworkServiceSubnet), nil
+			}
+		}
+
+		return c.virtualNetworkSubnet()
 	})
 }
 
@@ -41778,6 +41842,10 @@ type mqlAzureSubscriptionWebServiceAppsiteconfig struct {
 	IpSecurityRestrictions              plugin.TValue[[]any]
 	ScmIpSecurityRestrictions           plugin.TValue[[]any]
 	IpSecurityRestrictionsDefaultAction plugin.TValue[string]
+	WebSocketsEnabled                   plugin.TValue[bool]
+	HttpLoggingEnabled                  plugin.TValue[bool]
+	DetailedErrorLoggingEnabled         plugin.TValue[bool]
+	AutoHealEnabled                     plugin.TValue[bool]
 }
 
 // createAzureSubscriptionWebServiceAppsiteconfig creates a new instance of this resource
@@ -41901,6 +41969,22 @@ func (c *mqlAzureSubscriptionWebServiceAppsiteconfig) GetIpSecurityRestrictionsD
 	return plugin.GetOrCompute[string](&c.IpSecurityRestrictionsDefaultAction, func() (string, error) {
 		return c.ipSecurityRestrictionsDefaultAction()
 	})
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsiteconfig) GetWebSocketsEnabled() *plugin.TValue[bool] {
+	return &c.WebSocketsEnabled
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsiteconfig) GetHttpLoggingEnabled() *plugin.TValue[bool] {
+	return &c.HttpLoggingEnabled
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsiteconfig) GetDetailedErrorLoggingEnabled() *plugin.TValue[bool] {
+	return &c.DetailedErrorLoggingEnabled
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsiteconfig) GetAutoHealEnabled() *plugin.TValue[bool] {
+	return &c.AutoHealEnabled
 }
 
 // mqlAzureSubscriptionWebServiceAppsiteconfigIpSecurityRestriction for the azure.subscription.webService.appsiteconfig.ipSecurityRestriction resource

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -3774,6 +3774,8 @@ azure.subscription.webService.appsite.virtualNetworkConnection.name 11.4.32
 azure.subscription.webService.appsite.virtualNetworkConnection.resyncRequired 11.4.32
 azure.subscription.webService.appsite.virtualNetworkConnection.vnetResourceId 11.4.32
 azure.subscription.webService.appsite.virtualNetworkConnections 11.4.32
+azure.subscription.webService.appsite.virtualNetworkSubnet 13.12.2
+azure.subscription.webService.appsite.virtualNetworkSubnetId 13.12.2
 azure.subscription.webService.appsiteauthsettings 9.0.1
 azure.subscription.webService.appsiteauthsettings.id 9.0.1
 azure.subscription.webService.appsiteauthsettings.kind 9.0.1
@@ -3782,8 +3784,11 @@ azure.subscription.webService.appsiteauthsettings.properties 9.0.1
 azure.subscription.webService.appsiteauthsettings.type 9.0.1
 azure.subscription.webService.appsiteconfig 9.0.1
 azure.subscription.webService.appsiteconfig.alwaysOn 11.4.28
+azure.subscription.webService.appsiteconfig.autoHealEnabled 13.12.2
+azure.subscription.webService.appsiteconfig.detailedErrorLoggingEnabled 13.12.2
 azure.subscription.webService.appsiteconfig.ftpsState 11.4.28
 azure.subscription.webService.appsiteconfig.http20Enabled 11.4.28
+azure.subscription.webService.appsiteconfig.httpLoggingEnabled 13.12.2
 azure.subscription.webService.appsiteconfig.id 9.0.1
 azure.subscription.webService.appsiteconfig.ipSecurityRestriction 13.1.8
 azure.subscription.webService.appsiteconfig.ipSecurityRestriction.action 13.1.8
@@ -3807,6 +3812,7 @@ azure.subscription.webService.appsiteconfig.remoteDebuggingEnabled 11.4.28
 azure.subscription.webService.appsiteconfig.scmIpSecurityRestrictions 13.1.8
 azure.subscription.webService.appsiteconfig.scmMinTlsVersion 13.1.8
 azure.subscription.webService.appsiteconfig.type 9.0.1
+azure.subscription.webService.appsiteconfig.webSocketsEnabled 13.12.2
 azure.subscription.webService.appslot 11.3.85
 azure.subscription.webService.appslot.applicationSettings 11.3.85
 azure.subscription.webService.appslot.authenticationSettings 11.3.85

--- a/providers/azure/resources/web.go
+++ b/providers/azure/resources/web.go
@@ -114,6 +114,7 @@ func createWebAppResourceFromSite(runtime *plugin.Runtime, resourceType string, 
 		args["sshEnabled"] = llx.BoolDataPtr(site.Properties.SSHEnabled)
 		args["keyVaultReferenceIdentity"] = llx.StringDataPtr(site.Properties.KeyVaultReferenceIdentity)
 		args["publicNetworkAccess"] = llx.StringDataPtr(site.Properties.PublicNetworkAccess)
+		args["virtualNetworkSubnetId"] = llx.StringDataPtr(site.Properties.VirtualNetworkSubnetID)
 		if site.Properties.IPMode != nil {
 			args["ipMode"] = llx.StringData(string(*site.Properties.IPMode))
 		}
@@ -517,6 +518,7 @@ func (a *mqlAzureSubscriptionWebService) apps() ([]any, error) {
 				args["state"] = llx.StringDataPtr(entry.Properties.State)
 				args["sshEnabled"] = llx.BoolDataPtr(entry.Properties.SSHEnabled)
 				args["publicNetworkAccess"] = llx.StringDataPtr(entry.Properties.PublicNetworkAccess)
+				args["virtualNetworkSubnetId"] = llx.StringDataPtr(entry.Properties.VirtualNetworkSubnetID)
 				if entry.Properties.IPMode != nil {
 					args["ipMode"] = llx.StringData(string(*entry.Properties.IPMode))
 				}
@@ -668,6 +670,19 @@ func (a *mqlAzureSubscriptionWebService) availableRuntimes() ([]any, error) {
 	return res, nil
 }
 
+func (a *mqlAzureSubscriptionWebServiceAppsite) virtualNetworkSubnet() (*mqlAzureSubscriptionNetworkServiceSubnet, error) {
+	if a.VirtualNetworkSubnetId.Data == "" {
+		a.VirtualNetworkSubnet.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.subnet",
+		map[string]*llx.RawData{"id": llx.StringData(a.VirtualNetworkSubnetId.Data)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionNetworkServiceSubnet), nil
+}
+
 func (a *mqlAzureSubscriptionWebServiceAppsite) configuration() (*mqlAzureSubscriptionWebServiceAppsiteconfig, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	return webAppSiteConfigToMql(a.MqlRuntime, conn, a.Id.Data)
@@ -725,6 +740,10 @@ func webAppSiteConfigToMql(runtime *plugin.Runtime, conn *connection.AzureConnec
 		args["remoteDebuggingEnabled"] = llx.BoolDataPtr(entry.Properties.RemoteDebuggingEnabled)
 		args["http20Enabled"] = llx.BoolDataPtr(entry.Properties.Http20Enabled)
 		args["alwaysOn"] = llx.BoolDataPtr(entry.Properties.AlwaysOn)
+		args["webSocketsEnabled"] = llx.BoolDataPtr(entry.Properties.WebSocketsEnabled)
+		args["httpLoggingEnabled"] = llx.BoolDataPtr(entry.Properties.HTTPLoggingEnabled)
+		args["detailedErrorLoggingEnabled"] = llx.BoolDataPtr(entry.Properties.DetailedErrorLoggingEnabled)
+		args["autoHealEnabled"] = llx.BoolDataPtr(entry.Properties.AutoHealEnabled)
 		if entry.Properties.MinTLSCipherSuite != nil {
 			args["minTlsCipherSuite"] = llx.StringData(string(*entry.Properties.MinTLSCipherSuite))
 		}
@@ -1164,6 +1183,10 @@ func (a *mqlAzureSubscriptionWebServiceAppslot) configuration() (*mqlAzureSubscr
 		args["remoteDebuggingEnabled"] = llx.BoolDataPtr(configuration.Properties.RemoteDebuggingEnabled)
 		args["http20Enabled"] = llx.BoolDataPtr(configuration.Properties.Http20Enabled)
 		args["alwaysOn"] = llx.BoolDataPtr(configuration.Properties.AlwaysOn)
+		args["webSocketsEnabled"] = llx.BoolDataPtr(configuration.Properties.WebSocketsEnabled)
+		args["httpLoggingEnabled"] = llx.BoolDataPtr(configuration.Properties.HTTPLoggingEnabled)
+		args["detailedErrorLoggingEnabled"] = llx.BoolDataPtr(configuration.Properties.DetailedErrorLoggingEnabled)
+		args["autoHealEnabled"] = llx.BoolDataPtr(configuration.Properties.AutoHealEnabled)
 		if configuration.Properties.ScmMinTLSVersion != nil {
 			args["scmMinTlsVersion"] = llx.StringData(string(*configuration.Properties.ScmMinTLSVersion))
 		}


### PR DESCRIPTION
## Summary

Strictly-additive fields on \`webService.appsite\` and \`webService.appsiteconfig\`, all derived from the existing API responses (no new permissions, no new calls):

| Addition | Source |
|---|---|
| \`appsite.virtualNetworkSubnetId string\` | \`SiteProperties.VirtualNetworkSubnetID\` |
| \`appsite.virtualNetworkSubnet() subnet\` | Typed ref via existing subnet init; \`null\` when no regional VNet integration is configured |
| \`appsiteconfig.webSocketsEnabled bool\` | \`SiteConfig.WebSocketsEnabled\` |
| \`appsiteconfig.httpLoggingEnabled bool\` | \`SiteConfig.HTTPLoggingEnabled\` |
| \`appsiteconfig.detailedErrorLoggingEnabled bool\` | \`SiteConfig.DetailedErrorLoggingEnabled\` |
| \`appsiteconfig.autoHealEnabled bool\` | \`SiteConfig.AutoHealEnabled\` |

Both the appsite-level fields (populated in two existing paths — single-fetch and list-fetch) and the appsiteconfig-level flags (populated in both the appsite and appslot configuration fetchers) are wired up. Existing fields and the \`properties dict\` are unchanged.

### Why

\`\`\`
azure.subscription.web.apps.where(virtualNetworkSubnet == null)
azure.subscription.web.apps.where(configuration.httpLoggingEnabled == false)
azure.subscription.web.apps.where(configuration.webSocketsEnabled && !configuration.alwaysOn)
\`\`\`

### Versions

New \`.lr.versions\` entries at \`13.12.2\`. \`azure.permissions.json\` unchanged.

## Test plan

- [x] \`mqlr generate\` clean
- [x] \`go build ./...\` / \`go vet ./...\` / \`go test ./resources/...\` pass
- [x] \`gofmt -l\` clean
- [ ] Manual: \`cnspec shell azure\` and run
  - \`azure.subscription.web.apps { name virtualNetworkSubnetId virtualNetworkSubnet { name } }\` against a VNet-integrated app
  - \`azure.subscription.web.apps.first.configuration { webSocketsEnabled httpLoggingEnabled detailedErrorLoggingEnabled autoHealEnabled }\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)