### PR TITLE
🧹 gcp: regenerate permissions.json with correct action name

### DIFF
--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
   "version": "13.16.2",
-  "generated_at": "2026-05-21T15:23:44-07:00",
+  "generated_at": "2026-05-21T19:57:04-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.customJobs.list",
@@ -1496,7 +1496,7 @@
     {
       "permission": "resourcemanager.projects.list",
       "service": "resourcemanager",
-      "action": "Projects.List",
+      "action": "Projects.Search",
       "source_file": "project.go",
       "scope": "org"
     },


### PR DESCRIPTION
## Summary
- Regenerate `providers/gcp/resources/gcp.permissions.json` so the `resourcemanager.projects.list` entry shows `Projects.Search` (matching the actual call site in `project.go`) instead of the stale `Projects.List`.

## Test plan
- [ ] `make providers/build/gcp` produces no further diff in `gcp.permissions.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)