### PR TITLE
✨ gcp: typed region/zone/serviceAccount refs across compute & serverless

### DIFF
--- a/providers/gcp/resources/cloud_functions.go
+++ b/providers/gcp/resources/cloud_functions.go
@@ -217,6 +217,29 @@ func (g *mqlGcpProjectCloudFunction) kmsKey() (*mqlGcpProjectKmsServiceKeyringCr
 	return res.(*mqlGcpProjectKmsServiceKeyringCryptokey), nil
 }
 
+func (g *mqlGcpProjectCloudFunction) serviceAccount() (*mqlGcpProjectIamServiceServiceAccount, error) {
+	if g.ServiceAccountEmail.Error != nil {
+		return nil, g.ServiceAccountEmail.Error
+	}
+	email := g.ServiceAccountEmail.Data
+	if email == "" {
+		g.ServiceAccount.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	if g.ProjectId.Error != nil {
+		return nil, g.ProjectId.Error
+	}
+	res, err := NewResource(g.MqlRuntime, "gcp.project.iamService.serviceAccount",
+		map[string]*llx.RawData{
+			"email":     llx.StringData(email),
+			"projectId": llx.StringData(g.ProjectId.Data),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectIamServiceServiceAccount), nil
+}
+
 func (g *mqlGcpProjectCloudFunction) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error

--- a/providers/gcp/resources/cloud_functions_v2.go
+++ b/providers/gcp/resources/cloud_functions_v2.go
@@ -79,7 +79,7 @@ func (g *mqlGcpProject) cloudFunctionsV2() ([]any, error) {
 			return nil, err
 		}
 
-		eventTrigger, err := fnV2EventTrigger(g.MqlRuntime, fn.Name, fn.EventTrigger)
+		eventTrigger, err := fnV2EventTrigger(g.MqlRuntime, fn.Name, projectId, fn.EventTrigger)
 		if err != nil {
 			return nil, err
 		}
@@ -276,7 +276,7 @@ func (g *mqlGcpProjectCloudFunctionV2ServiceConfig) iamServiceAccount() (*mqlGcp
 	return res.(*mqlGcpProjectIamServiceServiceAccount), nil
 }
 
-func fnV2EventTrigger(runtime *plugin.Runtime, parentName string, cfg *functionspb.EventTrigger) (*mqlGcpProjectCloudFunctionV2EventTrigger, error) {
+func fnV2EventTrigger(runtime *plugin.Runtime, parentName string, projectId string, cfg *functionspb.EventTrigger) (*mqlGcpProjectCloudFunctionV2EventTrigger, error) {
 	if cfg == nil {
 		return nil, nil
 	}
@@ -308,6 +308,7 @@ func fnV2EventTrigger(runtime *plugin.Runtime, parentName string, cfg *functions
 	// Populate Internal struct for cross-reference
 	et := res.(*mqlGcpProjectCloudFunctionV2EventTrigger)
 	et.cachePubsubTopic = cfg.PubsubTopic
+	et.cacheProjectId = projectId
 
 	return et, nil
 }
@@ -318,6 +319,27 @@ func (g *mqlGcpProjectCloudFunctionV2EventTrigger) id() (string, error) {
 
 type mqlGcpProjectCloudFunctionV2EventTriggerInternal struct {
 	cachePubsubTopic string
+	cacheProjectId   string
+}
+
+func (g *mqlGcpProjectCloudFunctionV2EventTrigger) serviceAccount() (*mqlGcpProjectIamServiceServiceAccount, error) {
+	if g.ServiceAccountEmail.Error != nil {
+		return nil, g.ServiceAccountEmail.Error
+	}
+	email := g.ServiceAccountEmail.Data
+	if email == "" {
+		g.ServiceAccount.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(g.MqlRuntime, "gcp.project.iamService.serviceAccount",
+		map[string]*llx.RawData{
+			"email":     llx.StringData(email),
+			"projectId": llx.StringData(g.cacheProjectId),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectIamServiceServiceAccount), nil
 }
 
 func (g *mqlGcpProjectCloudFunctionV2EventTrigger) topic() (*mqlGcpProjectPubsubServiceTopic, error) {

--- a/providers/gcp/resources/cloud_functions_v2_test.go
+++ b/providers/gcp/resources/cloud_functions_v2_test.go
@@ -29,7 +29,7 @@ func TestFnV2ServiceConfig(t *testing.T) {
 
 func TestFnV2EventTrigger(t *testing.T) {
 	t.Run("nil input returns nil", func(t *testing.T) {
-		result, err := fnV2EventTrigger(nil, "parent", nil)
+		result, err := fnV2EventTrigger(nil, "parent", "", nil)
 		require.NoError(t, err)
 		assert.Nil(t, result)
 	})

--- a/providers/gcp/resources/cloudbuild.go
+++ b/providers/gcp/resources/cloudbuild.go
@@ -107,7 +107,7 @@ func (g *mqlGcpProjectCloudBuildService) triggers() ([]any, error) {
 		}
 
 		// Build Pub/Sub config sub-resource
-		pubsubConfig, err := buildTriggerPubsubConfig(g.MqlRuntime, trigger.Name, trigger.GetPubsubConfig())
+		pubsubConfig, err := buildTriggerPubsubConfig(g.MqlRuntime, trigger.Name, projectId, trigger.GetPubsubConfig())
 		if err != nil {
 			return nil, err
 		}
@@ -246,7 +246,7 @@ func (g *mqlGcpProjectCloudBuildServiceTriggerGithubEventsConfig) id() (string, 
 	return g.Id.Data, nil
 }
 
-func buildTriggerPubsubConfig(runtime *plugin.Runtime, parentName string, cfg *cloudbuildpb.PubsubConfig) (*mqlGcpProjectCloudBuildServiceTriggerPubsubConfig, error) {
+func buildTriggerPubsubConfig(runtime *plugin.Runtime, parentName string, projectId string, cfg *cloudbuildpb.PubsubConfig) (*mqlGcpProjectCloudBuildServiceTriggerPubsubConfig, error) {
 	if cfg == nil {
 		return nil, nil
 	}
@@ -265,6 +265,7 @@ func buildTriggerPubsubConfig(runtime *plugin.Runtime, parentName string, cfg *c
 	// Populate Internal struct cache for cross-reference
 	pc := res.(*mqlGcpProjectCloudBuildServiceTriggerPubsubConfig)
 	pc.cacheTopic = cfg.Topic
+	pc.cacheProjectId = projectId
 
 	return pc, nil
 }
@@ -277,7 +278,8 @@ func (g *mqlGcpProjectCloudBuildServiceTriggerPubsubConfig) id() (string, error)
 }
 
 type mqlGcpProjectCloudBuildServiceTriggerPubsubConfigInternal struct {
-	cacheTopic string
+	cacheTopic     string
+	cacheProjectId string
 }
 
 func (g *mqlGcpProjectCloudBuildServiceTriggerPubsubConfig) pubsubTopic() (*mqlGcpProjectPubsubServiceTopic, error) {
@@ -293,6 +295,26 @@ func (g *mqlGcpProjectCloudBuildServiceTriggerPubsubConfig) pubsubTopic() (*mqlG
 		return nil, err
 	}
 	return res.(*mqlGcpProjectPubsubServiceTopic), nil
+}
+
+func (g *mqlGcpProjectCloudBuildServiceTriggerPubsubConfig) serviceAccount() (*mqlGcpProjectIamServiceServiceAccount, error) {
+	if g.ServiceAccountEmail.Error != nil {
+		return nil, g.ServiceAccountEmail.Error
+	}
+	email := g.ServiceAccountEmail.Data
+	if email == "" {
+		g.ServiceAccount.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	res, err := NewResource(g.MqlRuntime, "gcp.project.iamService.serviceAccount",
+		map[string]*llx.RawData{
+			"email":     llx.StringData(email),
+			"projectId": llx.StringData(g.cacheProjectId),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectIamServiceServiceAccount), nil
 }
 
 func buildTriggerWebhookConfig(runtime *plugin.Runtime, parentName string, cfg *cloudbuildpb.WebhookConfig) (*mqlGcpProjectCloudBuildServiceTriggerWebhookConfig, error) {

--- a/providers/gcp/resources/cloudbuild_test.go
+++ b/providers/gcp/resources/cloudbuild_test.go
@@ -21,7 +21,7 @@ func TestBuildTriggerGithubConfig(t *testing.T) {
 
 func TestBuildTriggerPubsubConfig(t *testing.T) {
 	t.Run("nil input returns nil", func(t *testing.T) {
-		result, err := buildTriggerPubsubConfig(nil, "parent", nil)
+		result, err := buildTriggerPubsubConfig(nil, "parent", "", nil)
 		require.NoError(t, err)
 		assert.Nil(t, result)
 	})

--- a/providers/gcp/resources/common.go
+++ b/providers/gcp/resources/common.go
@@ -287,3 +287,70 @@ func getDiskIdByUrl(diskUrl string) (*resourceId, error) {
 	parts := strings.Split(params, "/")
 	return &resourceId{Project: parts[1], Region: parts[3], Name: parts[5]}, nil
 }
+
+// parseProjectFromComputeUrl extracts the project id from a Compute self-link.
+// Returns "" when the URL doesn't match either compute self-link prefix.
+func parseProjectFromComputeUrl(url string) string {
+	params := strings.TrimPrefix(url, "https://www.googleapis.com/compute/v1/")
+	params = strings.TrimPrefix(params, "https://compute.googleapis.com/compute/v1/")
+	parts := strings.Split(params, "/")
+	if len(parts) < 2 || parts[0] != "projects" {
+		return ""
+	}
+	return parts[1]
+}
+
+// getRegionByUrl resolves the typed region resource matching a region URL.
+// Returns (nil, nil) for empty URLs (global resources). The init function on
+// `gcp.project.computeService.region` does the actual fetch — either via
+// `Regions.Get(projectId, name)` when the region isn't already in the
+// runtime cache, or by returning the cached entry if `regions()` was
+// previously listed on the same project.
+func getRegionByUrl(regionUrl string, runtime *plugin.Runtime) (*mqlGcpProjectComputeServiceRegion, error) {
+	if regionUrl == "" {
+		return nil, nil
+	}
+	regionName := RegionNameFromRegionUrl(regionUrl)
+	if regionName == "" {
+		return nil, fmt.Errorf("could not extract region name from %q", regionUrl)
+	}
+	projectId := parseProjectFromComputeUrl(regionUrl)
+	if projectId == "" {
+		return nil, fmt.Errorf("could not extract project id from region url %q", regionUrl)
+	}
+	res, err := NewResource(runtime, "gcp.project.computeService.region", map[string]*llx.RawData{
+		"name":      llx.StringData(regionName),
+		"projectId": llx.StringData(projectId),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectComputeServiceRegion), nil
+}
+
+// getZoneByUrl resolves the typed zone resource matching a zone URL.
+// Returns (nil, nil) for empty URLs (regional resources). Resolution goes
+// through the zone resource's init function (single `Zones.Get` call, or
+// runtime cache hit if `zones()` was previously listed).
+func getZoneByUrl(zoneUrl string, runtime *plugin.Runtime) (*mqlGcpProjectComputeServiceZone, error) {
+	if zoneUrl == "" {
+		return nil, nil
+	}
+	segments := strings.Split(zoneUrl, "/")
+	zoneName := segments[len(segments)-1]
+	if zoneName == "" {
+		return nil, fmt.Errorf("could not extract zone name from %q", zoneUrl)
+	}
+	projectId := parseProjectFromComputeUrl(zoneUrl)
+	if projectId == "" {
+		return nil, fmt.Errorf("could not extract project id from zone url %q", zoneUrl)
+	}
+	res, err := NewResource(runtime, "gcp.project.computeService.zone", map[string]*llx.RawData{
+		"name":      llx.StringData(zoneName),
+		"projectId": llx.StringData(projectId),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectComputeServiceZone), nil
+}

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -102,10 +102,94 @@ func initGcpProjectComputeServiceRegion(runtime *plugin.Runtime, args map[string
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
 
-	projectId := conn.ResourceID()
-	args["projectId"] = llx.StringData(projectId)
+	if pid, ok := args["projectId"]; !ok || pid == nil {
+		args["projectId"] = llx.StringData(conn.ResourceID())
+	}
 
-	return args, nil, nil
+	// When the caller passes a name, fetch the single region directly via
+	// Regions.Get rather than relying on a downstream regions() scan. This
+	// makes `NewResource("...region", {name, projectId})` cheap for typed
+	// references (e.g. instance.region()) when regions() has not been listed.
+	nameArg, hasName := args["name"]
+	if !hasName || nameArg == nil {
+		return args, nil, nil
+	}
+	name, ok := nameArg.Value.(string)
+	if !ok || name == "" {
+		return args, nil, nil
+	}
+	projectId := args["projectId"].Value.(string)
+
+	client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope, compute.ComputeReadonlyScope)
+	if err != nil {
+		return nil, nil, err
+	}
+	computeSvc, err := compute.NewService(context.Background(), option.WithHTTPClient(client))
+	if err != nil {
+		return nil, nil, err
+	}
+	region, err := computeSvc.Regions.Get(projectId, name).Do()
+	if err != nil {
+		return nil, nil, err
+	}
+	mqlRegion, err := newMqlRegion(runtime, region)
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, mqlRegion.(plugin.Resource), nil
+}
+
+func initGcpProjectComputeServiceZone(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+
+	conn, ok := runtime.Connection.(*connection.GcpConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
+	}
+
+	if pid, ok := args["projectId"]; !ok || pid == nil {
+		args["projectId"] = llx.StringData(conn.ResourceID())
+	}
+
+	nameArg, hasName := args["name"]
+	if !hasName || nameArg == nil {
+		return args, nil, nil
+	}
+	name, ok := nameArg.Value.(string)
+	if !ok || name == "" {
+		return args, nil, nil
+	}
+	projectId := args["projectId"].Value.(string)
+
+	client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope, compute.ComputeReadonlyScope)
+	if err != nil {
+		return nil, nil, err
+	}
+	computeSvc, err := compute.NewService(context.Background(), option.WithHTTPClient(client))
+	if err != nil {
+		return nil, nil, err
+	}
+	zone, err := computeSvc.Zones.Get(projectId, name).Do()
+	if err != nil {
+		return nil, nil, err
+	}
+	mqlZone, err := newMqlZone(runtime, zone)
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, mqlZone.(plugin.Resource), nil
+}
+
+func newMqlZone(runtime *plugin.Runtime, z *compute.Zone) (any, error) {
+	return CreateResource(runtime, "gcp.project.computeService.zone", map[string]*llx.RawData{
+		"id":          llx.StringData(strconv.FormatInt(int64(z.Id), 10)),
+		"name":        llx.StringData(z.Name),
+		"description": llx.StringData(z.Description),
+		"status":      llx.StringData(z.Status),
+		"created":     llx.TimeDataPtr(parseTime(z.CreationTimestamp)),
+	})
 }
 
 func (g *mqlGcpProjectComputeService) regions() ([]any, error) {
@@ -186,13 +270,7 @@ func (g *mqlGcpProjectComputeService) zones() ([]any, error) {
 	req := computeSvc.Zones.List(projectId)
 	if err := req.Pages(ctx, func(page *compute.ZoneList) error {
 		for _, zone := range page.Items {
-			mqlZone, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.zone", map[string]*llx.RawData{
-				"id":          llx.StringData(strconv.FormatInt(int64(zone.Id), 10)),
-				"name":        llx.StringData(zone.Name),
-				"description": llx.StringData(zone.Description),
-				"status":      llx.StringData(zone.Status),
-				"created":     llx.TimeDataPtr(parseTime(zone.CreationTimestamp)),
-			})
+			mqlZone, err := newMqlZone(g.MqlRuntime, zone)
 			if err != nil {
 				return err
 			}

--- a/providers/gcp/resources/compute_typed_refs.go
+++ b/providers/gcp/resources/compute_typed_refs.go
@@ -1,0 +1,333 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// region/zone typed accessors. The matching `regionUrl`/`zoneUrl` string
+// fields remain populated for now and are marked @maturity("deprecated") in
+// the .lr schema. New audits should use the typed accessors so they can
+// traverse the region or zone resource directly.
+
+func (g *mqlGcpProjectComputeServiceAddress) region() (*mqlGcpProjectComputeServiceRegion, error) {
+	if g.RegionUrl.Error != nil {
+		return nil, g.RegionUrl.Error
+	}
+	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		g.Region.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return r, nil
+}
+
+func (g *mqlGcpProjectComputeServiceForwardingRule) region() (*mqlGcpProjectComputeServiceRegion, error) {
+	if g.RegionUrl.Error != nil {
+		return nil, g.RegionUrl.Error
+	}
+	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		g.Region.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return r, nil
+}
+
+func (g *mqlGcpProjectComputeServiceBackendService) region() (*mqlGcpProjectComputeServiceRegion, error) {
+	if g.RegionUrl.Error != nil {
+		return nil, g.RegionUrl.Error
+	}
+	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		g.Region.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return r, nil
+}
+
+func (g *mqlGcpProjectComputeServiceSecurityPolicy) region() (*mqlGcpProjectComputeServiceRegion, error) {
+	if g.RegionUrl.Error != nil {
+		return nil, g.RegionUrl.Error
+	}
+	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		g.Region.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return r, nil
+}
+
+func (g *mqlGcpProjectComputeServiceSslPolicy) region() (*mqlGcpProjectComputeServiceRegion, error) {
+	if g.RegionUrl.Error != nil {
+		return nil, g.RegionUrl.Error
+	}
+	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		g.Region.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return r, nil
+}
+
+func (g *mqlGcpProjectComputeServiceSslCertificate) region() (*mqlGcpProjectComputeServiceRegion, error) {
+	if g.RegionUrl.Error != nil {
+		return nil, g.RegionUrl.Error
+	}
+	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		g.Region.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return r, nil
+}
+
+func (g *mqlGcpProjectComputeServiceVpnGateway) region() (*mqlGcpProjectComputeServiceRegion, error) {
+	if g.RegionUrl.Error != nil {
+		return nil, g.RegionUrl.Error
+	}
+	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		g.Region.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return r, nil
+}
+
+func (g *mqlGcpProjectComputeServiceVpnTunnel) region() (*mqlGcpProjectComputeServiceRegion, error) {
+	if g.RegionUrl.Error != nil {
+		return nil, g.RegionUrl.Error
+	}
+	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		g.Region.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return r, nil
+}
+
+func (g *mqlGcpProjectComputeServiceInstanceGroup) zone() (*mqlGcpProjectComputeServiceZone, error) {
+	if g.ZoneUrl.Error != nil {
+		return nil, g.ZoneUrl.Error
+	}
+	z, err := getZoneByUrl(g.ZoneUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if z == nil {
+		g.Zone.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return z, nil
+}
+
+func (g *mqlGcpProjectComputeServiceInstanceGroupManager) region() (*mqlGcpProjectComputeServiceRegion, error) {
+	if g.RegionUrl.Error != nil {
+		return nil, g.RegionUrl.Error
+	}
+	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		g.Region.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return r, nil
+}
+
+func (g *mqlGcpProjectComputeServiceInstanceGroupManager) zone() (*mqlGcpProjectComputeServiceZone, error) {
+	if g.ZoneUrl.Error != nil {
+		return nil, g.ZoneUrl.Error
+	}
+	z, err := getZoneByUrl(g.ZoneUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if z == nil {
+		g.Zone.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return z, nil
+}
+
+func (g *mqlGcpProjectComputeServiceFirewallPolicy) region() (*mqlGcpProjectComputeServiceRegion, error) {
+	if g.RegionUrl.Error != nil {
+		return nil, g.RegionUrl.Error
+	}
+	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		g.Region.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return r, nil
+}
+
+func (g *mqlGcpProjectComputeServiceHealthCheck) region() (*mqlGcpProjectComputeServiceRegion, error) {
+	if g.RegionUrl.Error != nil {
+		return nil, g.RegionUrl.Error
+	}
+	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		g.Region.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return r, nil
+}
+
+func (g *mqlGcpProjectComputeServiceUrlMap) region() (*mqlGcpProjectComputeServiceRegion, error) {
+	if g.RegionUrl.Error != nil {
+		return nil, g.RegionUrl.Error
+	}
+	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		g.Region.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return r, nil
+}
+
+func (g *mqlGcpProjectComputeServiceTargetHttpProxy) region() (*mqlGcpProjectComputeServiceRegion, error) {
+	if g.RegionUrl.Error != nil {
+		return nil, g.RegionUrl.Error
+	}
+	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		g.Region.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return r, nil
+}
+
+func (g *mqlGcpProjectComputeServiceTargetHttpsProxy) region() (*mqlGcpProjectComputeServiceRegion, error) {
+	if g.RegionUrl.Error != nil {
+		return nil, g.RegionUrl.Error
+	}
+	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		g.Region.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return r, nil
+}
+
+func (g *mqlGcpProjectComputeServiceServiceAttachment) region() (*mqlGcpProjectComputeServiceRegion, error) {
+	if g.RegionUrl.Error != nil {
+		return nil, g.RegionUrl.Error
+	}
+	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		g.Region.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return r, nil
+}
+
+func (g *mqlGcpProjectComputeServiceNetworkEndpointGroup) region() (*mqlGcpProjectComputeServiceRegion, error) {
+	if g.RegionUrl.Error != nil {
+		return nil, g.RegionUrl.Error
+	}
+	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		g.Region.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return r, nil
+}
+
+func (g *mqlGcpProjectComputeServiceNetworkEndpointGroup) zone() (*mqlGcpProjectComputeServiceZone, error) {
+	if g.ZoneUrl.Error != nil {
+		return nil, g.ZoneUrl.Error
+	}
+	z, err := getZoneByUrl(g.ZoneUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if z == nil {
+		g.Zone.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return z, nil
+}
+
+func (g *mqlGcpProjectComputeServiceInterconnectAttachment) region() (*mqlGcpProjectComputeServiceRegion, error) {
+	if g.RegionUrl.Error != nil {
+		return nil, g.RegionUrl.Error
+	}
+	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		g.Region.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return r, nil
+}
+
+func (g *mqlGcpProjectComputeServiceTargetTcpProxy) region() (*mqlGcpProjectComputeServiceRegion, error) {
+	if g.RegionUrl.Error != nil {
+		return nil, g.RegionUrl.Error
+	}
+	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		g.Region.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return r, nil
+}
+
+func (g *mqlGcpProjectComputeServicePacketMirroring) region() (*mqlGcpProjectComputeServiceRegion, error) {
+	if g.RegionUrl.Error != nil {
+		return nil, g.RegionUrl.Error
+	}
+	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		g.Region.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return r, nil
+}
+
+func (g *mqlGcpProjectComputeServiceTargetPool) region() (*mqlGcpProjectComputeServiceRegion, error) {
+	if g.RegionUrl.Error != nil {
+		return nil, g.RegionUrl.Error
+	}
+	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		g.Region.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return r, nil
+}

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -1028,8 +1028,8 @@ private gcp.project.computeService.address @defaults("name address addressType")
   name string
   // Labels applied to this resource
   labels map[string]string
-  // URL of the network in which to reserve the address
-  networkUrl string
+  // DEPRECATED: use network instead
+  networkUrl @maturity("deprecated") string
   // Network in which to reserve the address
   network() gcp.project.computeService.network
   // Network tier used for configuring this address
@@ -1038,12 +1038,14 @@ private gcp.project.computeService.address @defaults("name address addressType")
   prefixLength int
   // Address purpose
   purpose string
-  // Region URL
-  regionUrl string
+  // DEPRECATED: use region instead
+  regionUrl @maturity("deprecated") string
+  // Region where this address is reserved
+  region() gcp.project.computeService.region
   // Address status
   status string
-  // URL of the subnetwork in which to reserve the address
-  subnetworkUrl string
+  // DEPRECATED: use subnetwork instead
+  subnetworkUrl @maturity("deprecated") string
   // Subnetwork in which to reserve the address
   subnetwork() gcp.project.computeService.subnetwork
   // URLs of the resources that are using this address
@@ -1089,8 +1091,8 @@ private gcp.project.computeService.forwardingRule {
   metadataFilters []dict
   // Forwarding rule name
   name string
-  // URL of the network used for internal load balancing
-  networkUrl string
+  // DEPRECATED: use network instead
+  networkUrl @maturity("deprecated") string
   // Network used for internal load balancing
   network() gcp.project.computeService.network
   // Network tier used for configuring this load balancer
@@ -1101,16 +1103,18 @@ private gcp.project.computeService.forwardingRule {
   portRange string
   // Ports to forward
   ports []string
-  // Region URL
-  regionUrl string
+  // DEPRECATED: use region instead
+  regionUrl @maturity("deprecated") string
+  // Region the forwarding rule lives in (empty for global forwarding rules)
+  region() gcp.project.computeService.region
   // Service Directory resources with which to register this forwarding rule
   serviceDirectoryRegistrations []dict
   // Optional prefix to the service name for this forwarding rule
   serviceLabel string
   // Internal fully qualified service name for this forwarding rule
   serviceName string
-  // URL of the subnetwork to which the load balanced IP belongs
-  subnetworkUrl string
+  // DEPRECATED: use subnetwork instead
+  subnetworkUrl @maturity("deprecated") string
   // Subnetwork to which the load balanced IP belongs
   subnetwork() gcp.project.computeService.subnetwork
   // URL of the target resource to receive the matched traffic
@@ -1787,8 +1791,8 @@ gcp.project.computeService.subnetwork @defaults("name") {
   purpose string
   // GCP compute region this resource belongs to
   region() gcp.project.computeService.region
-  // Region URL
-  regionUrl string
+  // DEPRECATED: use region instead
+  regionUrl @maturity("deprecated") string
   // Role of subnetwork
   role string
   // Stack type for the subnet
@@ -1799,8 +1803,8 @@ gcp.project.computeService.subnetwork @defaults("name") {
   created time
   // The URL of the reserved internal range
   reservedInternalRange string
-  // URL of the parent VPC network this subnetwork belongs to
-  networkUrl string
+  // DEPRECATED: use network instead
+  networkUrl @maturity("deprecated") string
   // Parent VPC network this subnetwork belongs to
   network() gcp.project.computeService.network
 }
@@ -1921,8 +1925,10 @@ private gcp.project.computeService.backendService @defaults("name") {
   portName string
   // Protocol used for communication
   protocol string
-  // Region URL
-  regionUrl string
+  // DEPRECATED: use region instead
+  regionUrl @maturity("deprecated") string
+  // Region the backend service lives in (empty for global services)
+  region() gcp.project.computeService.region
   // DEPRECATED: Use securityPolicy instead
   securityPolicyUrl @maturity("deprecated") string
   // Cloud Armor security policy
@@ -4628,6 +4634,8 @@ private gcp.project.cloudFunction @defaults("name") {
   availableMemoryMb int
   // Email of the function's service account
   serviceAccountEmail string
+  // IAM service account used by the function
+  serviceAccount() gcp.project.iamService.serviceAccount
   // Update timestamp
   updated time
   // Version identifier of the cloud function
@@ -4783,6 +4791,8 @@ private gcp.project.cloudFunctionV2.eventTrigger @defaults("eventType") {
   topic() gcp.project.pubsubService.topic
   // Service account email for the trigger
   serviceAccountEmail string
+  // IAM service account used by the trigger
+  serviceAccount() gcp.project.iamService.serviceAccount
   // Retry policy (RETRY_POLICY_DO_NOT_RETRY, RETRY_POLICY_RETRY)
   retryPolicy string
   // Eventarc channel name
@@ -6645,8 +6655,10 @@ private gcp.project.computeService.securityPolicy @defaults("name type") {
   fingerprint string
   // User-defined fields for custom rule tuning
   userDefinedFields []dict
-  // URL of the region (empty for global policies)
-  regionUrl string
+  // DEPRECATED: use region instead
+  regionUrl @maturity("deprecated") string
+  // Region the policy lives in (empty for global policies)
+  region() gcp.project.computeService.region
   // Self-link URL
   selfLink string
   // Creation timestamp
@@ -6710,8 +6722,10 @@ private gcp.project.computeService.sslPolicy @defaults("name profile minTlsVersi
   customFeatures []string
   // Features enabled in the SSL policy
   enabledFeatures []string
-  // URL of the region (empty for global policies)
-  regionUrl string
+  // DEPRECATED: use region instead
+  regionUrl @maturity("deprecated") string
+  // Region the SSL policy lives in (empty for global policies)
+  region() gcp.project.computeService.region
   // Self-link URL
   selfLink string
   // Configuration warnings reported by the API for this resource
@@ -6741,8 +6755,10 @@ private gcp.project.computeService.sslCertificate @defaults("name type") {
   subjectAlternativeNames []string
   // Managed certificate configuration and status
   managed dict
-  // URL of the region (empty for global certificates)
-  regionUrl string
+  // DEPRECATED: use region instead
+  regionUrl @maturity("deprecated") string
+  // Region the certificate lives in (empty for global certificates)
+  region() gcp.project.computeService.region
   // Self-link URL
   selfLink string
   // Expiration time
@@ -6776,8 +6792,10 @@ private gcp.project.computeService.vpnGateway @defaults("name") {
   gatewayIpVersion string
   // Stack type for this VPN gateway (IPV4_ONLY, IPV4_IPV6, IPV6_ONLY)
   stackType string
-  // Region URL where the VPN gateway resides
-  regionUrl string
+  // DEPRECATED: use region instead
+  regionUrl @maturity("deprecated") string
+  // Region the VPN gateway lives in
+  region() gcp.project.computeService.region
   // VPN interfaces associated with this VPN gateway
   vpnInterfaces []dict
   // Resource manager tags bound to this VPN gateway
@@ -6823,8 +6841,10 @@ private gcp.project.computeService.vpnTunnel @defaults("name status") {
   peerGcpVpnGateway() gcp.project.computeService.vpnGateway
   // IP address of the peer VPN gateway
   peerIp string
-  // Region URL where the VPN tunnel resides
-  regionUrl string
+  // DEPRECATED: use region instead
+  regionUrl @maturity("deprecated") string
+  // Region the VPN tunnel lives in
+  region() gcp.project.computeService.region
   // DEPRECATED: Use router instead
   routerUrl @maturity("deprecated") string
   // Cloud Router resource for dynamic routing
@@ -7448,10 +7468,12 @@ private gcp.project.computeService.instanceGroup @defaults("name size") {
   name string
   // Human-readable description of the resource
   description string
-  // Zone URL
-  zoneUrl string
-  // Network URL
-  networkUrl string
+  // DEPRECATED: use zone instead
+  zoneUrl @maturity("deprecated") string
+  // Zone the instance group lives in
+  zone() gcp.project.computeService.zone
+  // DEPRECATED: use network instead
+  networkUrl @maturity("deprecated") string
   // Network resource
   network() gcp.project.computeService.network
   // Subnetwork resource
@@ -7484,10 +7506,14 @@ private gcp.project.computeService.instanceGroupManager @defaults("name targetSi
   name string
   // Human-readable description of the resource
   description string
-  // Zone URL (empty for regional)
-  zoneUrl string
-  // Region URL (empty for zonal)
-  regionUrl string
+  // DEPRECATED: use zone instead
+  zoneUrl @maturity("deprecated") string
+  // Zone the MIG lives in (empty for regional MIGs)
+  zone() gcp.project.computeService.zone
+  // DEPRECATED: use region instead
+  regionUrl @maturity("deprecated") string
+  // Region the MIG lives in (empty for zonal MIGs)
+  region() gcp.project.computeService.region
   // Instance template URL
   instanceTemplateUrl string
   // Target number of running instances
@@ -7536,8 +7562,10 @@ private gcp.project.computeService.firewallPolicy @defaults("name") {
   ruleTupleCount int
   // Creation timestamp
   created time
-  // Region URL (empty for global policies)
-  regionUrl string
+  // DEPRECATED: use region instead
+  regionUrl @maturity("deprecated") string
+  // Region the firewall policy lives in (empty for global policies)
+  region() gcp.project.computeService.region
   // Rules associated with this firewall policy
   rules() []gcp.project.computeService.firewallPolicy.rule
   // Associations of this policy with networks
@@ -8290,8 +8318,10 @@ private gcp.project.computeService.healthCheck @defaults("name type") {
   grpcHealthCheck dict
   // Whether to enable logging
   logConfig dict
-  // Region URL (empty for global health checks)
-  regionUrl string
+  // DEPRECATED: use region instead
+  regionUrl @maturity("deprecated") string
+  // Region the health check lives in (empty for global health checks)
+  region() gcp.project.computeService.region
 }
 
 // Google Cloud (GCP) Compute URL map
@@ -8321,8 +8351,10 @@ private gcp.project.computeService.urlMap @defaults("name") {
   created time
   // Server-defined URL for the resource
   selfLink string
-  // Region URL (empty for global URL maps)
-  regionUrl string
+  // DEPRECATED: use region instead
+  regionUrl @maturity("deprecated") string
+  // Region the URL map lives in (empty for global URL maps)
+  region() gcp.project.computeService.region
 }
 
 // Google Cloud (GCP) Compute target HTTP proxy
@@ -8339,8 +8371,8 @@ private gcp.project.computeService.targetHttpProxy @defaults("name") {
   name string
   // Human-readable description of the resource
   description string
-  // URL map URL
-  urlMapUrl string
+  // DEPRECATED: use urlMap instead
+  urlMapUrl @maturity("deprecated") string
   // URL map resource
   urlMap() gcp.project.computeService.urlMap
   // Creation timestamp
@@ -8349,8 +8381,10 @@ private gcp.project.computeService.targetHttpProxy @defaults("name") {
   selfLink string
   // Whether the proxy can be used by Cloud Armor
   proxyBind bool
-  // Region URL (empty for global proxies)
-  regionUrl string
+  // DEPRECATED: use region instead
+  regionUrl @maturity("deprecated") string
+  // Region the proxy lives in (empty for global proxies)
+  region() gcp.project.computeService.region
 }
 
 // Google Cloud (GCP) Compute target HTTPS proxy
@@ -8369,14 +8403,14 @@ private gcp.project.computeService.targetHttpsProxy @defaults("name") {
   name string
   // Human-readable description of the resource
   description string
-  // URL map URL
-  urlMapUrl string
+  // DEPRECATED: use urlMap instead
+  urlMapUrl @maturity("deprecated") string
   // URL map resource
   urlMap() gcp.project.computeService.urlMap
   // SSL certificate URLs
   sslCertificateUrls []string
-  // SSL policy URL
-  sslPolicyUrl string
+  // DEPRECATED: use sslPolicy instead
+  sslPolicyUrl @maturity("deprecated") string
   // SSL policy resource
   sslPolicy() gcp.project.computeService.sslPolicy
   // QUIC override setting (NONE, ENABLE, DISABLE)
@@ -8387,8 +8421,10 @@ private gcp.project.computeService.targetHttpsProxy @defaults("name") {
   selfLink string
   // Whether the proxy can be used by Cloud Armor
   proxyBind bool
-  // Region URL (empty for global proxies)
-  regionUrl string
+  // DEPRECATED: use region instead
+  regionUrl @maturity("deprecated") string
+  // Region the proxy lives in (empty for global proxies)
+  region() gcp.project.computeService.region
 }
 
 // Google Cloud (GCP) Compute network peering
@@ -8402,8 +8438,8 @@ private gcp.project.computeService.network.peering @defaults("name state") {
   id string
   // Name of the peering
   name string
-  // URL of the peer network
-  networkUrl string
+  // DEPRECATED: use network instead
+  networkUrl @maturity("deprecated") string
   // Network resource of the peer
   network() gcp.project.computeService.network
   // State of the peering (ACTIVE, INACTIVE)
@@ -8443,8 +8479,8 @@ private gcp.project.computeService.route @defaults("name destRange") {
   destRange string
   // Route priority (0-65535)
   priority int
-  // Network URL this route applies to
-  networkUrl string
+  // DEPRECATED: use network instead
+  networkUrl @maturity("deprecated") string
   // Network resource
   network() gcp.project.computeService.network
   // Next hop gateway URL
@@ -8513,8 +8549,10 @@ private gcp.project.computeService.serviceAttachment @defaults("name connectionP
   targetService string
   // Whether connection reconciliation is enabled
   reconcileConnections bool
-  // Region URL
-  regionUrl string
+  // DEPRECATED: use region instead
+  regionUrl @maturity("deprecated") string
+  // Region the service attachment lives in
+  region() gcp.project.computeService.region
   // Self-link URL
   selfLink string
   // Resource fingerprint used to detect concurrent modifications
@@ -8544,18 +8582,22 @@ private gcp.project.computeService.networkEndpointGroup @defaults("name networkE
   defaultPort int
   // Number of endpoints
   size int
-  // Network URL
-  networkUrl string
+  // DEPRECATED: use network instead
+  networkUrl @maturity("deprecated") string
   // Network resource
   network() gcp.project.computeService.network
-  // Subnetwork URL
-  subnetworkUrl string
+  // DEPRECATED: use subnetwork instead
+  subnetworkUrl @maturity("deprecated") string
   // Subnetwork resource
   subnetwork() gcp.project.computeService.subnetwork
-  // Zone URL
-  zoneUrl string
-  // Region URL
-  regionUrl string
+  // DEPRECATED: use zone instead
+  zoneUrl @maturity("deprecated") string
+  // Zone the NEG lives in (empty for regional NEGs)
+  zone() gcp.project.computeService.zone
+  // DEPRECATED: use region instead
+  regionUrl @maturity("deprecated") string
+  // Region the NEG lives in (empty for zonal NEGs)
+  region() gcp.project.computeService.region
   // Cloud Run configuration
   cloudRun dict
   // App Engine configuration
@@ -8691,8 +8733,10 @@ private gcp.project.computeService.interconnectAttachment @defaults("name type s
   partnerMetadata dict
   // Private interconnect info
   privateInterconnectInfo dict
-  // Region URL
-  regionUrl string
+  // DEPRECATED: use region instead
+  regionUrl @maturity("deprecated") string
+  // Region the attachment lives in
+  region() gcp.project.computeService.region
   // Self-link URL
   selfLink string
   // Dataplane version
@@ -8744,8 +8788,10 @@ private gcp.project.computeService.targetTcpProxy @defaults("name") {
   proxyBind bool
   // Backend service URL
   serviceUrl string
-  // Region URL (empty for global)
-  regionUrl string
+  // DEPRECATED: use region instead
+  regionUrl @maturity("deprecated") string
+  // Region the proxy lives in (empty for global proxies)
+  region() gcp.project.computeService.region
   // Self-link URL
   selfLink string
   // Creation timestamp
@@ -8771,8 +8817,8 @@ private gcp.project.computeService.targetSslProxy @defaults("name") {
   serviceUrl string
   // SSL certificate URLs
   sslCertificateUrls []string
-  // SSL policy URL
-  sslPolicyUrl string
+  // DEPRECATED: use sslPolicy instead
+  sslPolicyUrl @maturity("deprecated") string
   // SSL policy
   sslPolicy() gcp.project.computeService.sslPolicy
   // Certificate map URL
@@ -8808,8 +8854,10 @@ private gcp.project.computeService.packetMirroring @defaults("name enable") {
   mirroredResources dict
   // Filter configuration
   filter dict
-  // Region URL
-  regionUrl string
+  // DEPRECATED: use region instead
+  regionUrl @maturity("deprecated") string
+  // Region the packet mirroring policy lives in
+  region() gcp.project.computeService.region
   // Self-link URL
   selfLink string
   // Creation timestamp
@@ -8872,8 +8920,10 @@ private gcp.project.computeService.targetPool @defaults("name") {
   instanceUrls []string
   // Security policy URL
   securityPolicy string
-  // Region URL
-  regionUrl string
+  // DEPRECATED: use region instead
+  regionUrl @maturity("deprecated") string
+  // Region the target pool lives in
+  region() gcp.project.computeService.region
   // Self-link URL
   selfLink string
   // Creation timestamp
@@ -10668,8 +10718,8 @@ private gcp.project.idsService.endpoint @defaults("name severity state") {
   name string
   // Human-readable description of the resource
   description string
-  // Network URL
-  networkUrl string
+  // DEPRECATED: use network instead
+  networkUrl @maturity("deprecated") string
   // Network resource
   network() gcp.project.computeService.network
   // Endpoint forwarding rule URL
@@ -11219,6 +11269,8 @@ private gcp.project.cloudBuildService.trigger.pubsubConfig @defaults("topic stat
   subscription string
   // Service account email for Pub/Sub
   serviceAccountEmail string
+  // IAM service account used for Pub/Sub
+  serviceAccount() gcp.project.iamService.serviceAccount
   // Pub/Sub config state (OK, TOPIC_DELETED, SUBSCRIPTION_DELETED, SUBSCRIPTION_MISCONFIGURED)
   state string
 }

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -546,7 +546,7 @@ func init() {
 			Create: createGcpProjectComputeServiceRegion,
 		},
 		"gcp.project.computeService.zone": {
-			// to override args, implement: initGcpProjectComputeServiceZone(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initGcpProjectComputeServiceZone,
 			Create: createGcpProjectComputeServiceZone,
 		},
 		"gcp.project.computeService.machineType": {
@@ -3256,6 +3256,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.address.regionUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceAddress).GetRegionUrl()).ToDataRes(types.String)
 	},
+	"gcp.project.computeService.address.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceAddress).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
+	},
 	"gcp.project.computeService.address.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceAddress).GetStatus()).ToDataRes(types.String)
 	},
@@ -3330,6 +3333,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.forwardingRule.regionUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceForwardingRule).GetRegionUrl()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.forwardingRule.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceForwardingRule).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
 	},
 	"gcp.project.computeService.forwardingRule.serviceDirectoryRegistrations": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceForwardingRule).GetServiceDirectoryRegistrations()).ToDataRes(types.Array(types.Dict))
@@ -4266,6 +4272,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.backendService.regionUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceBackendService).GetRegionUrl()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.backendService.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceBackendService).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
 	},
 	"gcp.project.computeService.backendService.securityPolicyUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceBackendService).GetSecurityPolicyUrl()).ToDataRes(types.String)
@@ -7024,6 +7033,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.cloudFunction.serviceAccountEmail": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunction).GetServiceAccountEmail()).ToDataRes(types.String)
 	},
+	"gcp.project.cloudFunction.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudFunction).GetServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
+	},
 	"gcp.project.cloudFunction.updated": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunction).GetUpdated()).ToDataRes(types.Time)
 	},
@@ -7221,6 +7233,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.cloudFunctionV2.eventTrigger.serviceAccountEmail": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunctionV2EventTrigger).GetServiceAccountEmail()).ToDataRes(types.String)
+	},
+	"gcp.project.cloudFunctionV2.eventTrigger.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudFunctionV2EventTrigger).GetServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
 	},
 	"gcp.project.cloudFunctionV2.eventTrigger.retryPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunctionV2EventTrigger).GetRetryPolicy()).ToDataRes(types.String)
@@ -9163,6 +9178,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.securityPolicy.regionUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSecurityPolicy).GetRegionUrl()).ToDataRes(types.String)
 	},
+	"gcp.project.computeService.securityPolicy.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceSecurityPolicy).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
+	},
 	"gcp.project.computeService.securityPolicy.selfLink": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSecurityPolicy).GetSelfLink()).ToDataRes(types.String)
 	},
@@ -9232,6 +9250,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.sslPolicy.regionUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSslPolicy).GetRegionUrl()).ToDataRes(types.String)
 	},
+	"gcp.project.computeService.sslPolicy.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceSslPolicy).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
+	},
 	"gcp.project.computeService.sslPolicy.selfLink": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSslPolicy).GetSelfLink()).ToDataRes(types.String)
 	},
@@ -9261,6 +9282,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.sslCertificate.regionUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSslCertificate).GetRegionUrl()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.sslCertificate.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceSslCertificate).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
 	},
 	"gcp.project.computeService.sslCertificate.selfLink": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSslCertificate).GetSelfLink()).ToDataRes(types.String)
@@ -9297,6 +9321,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.vpnGateway.regionUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceVpnGateway).GetRegionUrl()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.vpnGateway.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceVpnGateway).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
 	},
 	"gcp.project.computeService.vpnGateway.vpnInterfaces": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceVpnGateway).GetVpnInterfaces()).ToDataRes(types.Array(types.Dict))
@@ -9351,6 +9378,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.vpnTunnel.regionUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceVpnTunnel).GetRegionUrl()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.vpnTunnel.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceVpnTunnel).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
 	},
 	"gcp.project.computeService.vpnTunnel.routerUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceVpnTunnel).GetRouterUrl()).ToDataRes(types.String)
@@ -9952,6 +9982,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.instanceGroup.zoneUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceGroup).GetZoneUrl()).ToDataRes(types.String)
 	},
+	"gcp.project.computeService.instanceGroup.zone": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstanceGroup).GetZone()).ToDataRes(types.Resource("gcp.project.computeService.zone"))
+	},
 	"gcp.project.computeService.instanceGroup.networkUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceGroup).GetNetworkUrl()).ToDataRes(types.String)
 	},
@@ -9988,8 +10021,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.instanceGroupManager.zoneUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceGroupManager).GetZoneUrl()).ToDataRes(types.String)
 	},
+	"gcp.project.computeService.instanceGroupManager.zone": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstanceGroupManager).GetZone()).ToDataRes(types.Resource("gcp.project.computeService.zone"))
+	},
 	"gcp.project.computeService.instanceGroupManager.regionUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceGroupManager).GetRegionUrl()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.instanceGroupManager.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstanceGroupManager).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
 	},
 	"gcp.project.computeService.instanceGroupManager.instanceTemplateUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceGroupManager).GetInstanceTemplateUrl()).ToDataRes(types.String)
@@ -10047,6 +10086,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.firewallPolicy.regionUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceFirewallPolicy).GetRegionUrl()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.firewallPolicy.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceFirewallPolicy).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
 	},
 	"gcp.project.computeService.firewallPolicy.rules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceFirewallPolicy).GetRules()).ToDataRes(types.Array(types.Resource("gcp.project.computeService.firewallPolicy.rule")))
@@ -10771,6 +10813,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.healthCheck.regionUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceHealthCheck).GetRegionUrl()).ToDataRes(types.String)
 	},
+	"gcp.project.computeService.healthCheck.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceHealthCheck).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
+	},
 	"gcp.project.computeService.urlMap.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceUrlMap).GetId()).ToDataRes(types.String)
 	},
@@ -10804,6 +10849,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.urlMap.regionUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceUrlMap).GetRegionUrl()).ToDataRes(types.String)
 	},
+	"gcp.project.computeService.urlMap.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceUrlMap).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
+	},
 	"gcp.project.computeService.targetHttpProxy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetHttpProxy).GetId()).ToDataRes(types.String)
 	},
@@ -10833,6 +10881,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.targetHttpProxy.regionUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetHttpProxy).GetRegionUrl()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.targetHttpProxy.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceTargetHttpProxy).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
 	},
 	"gcp.project.computeService.targetHttpsProxy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).GetId()).ToDataRes(types.String)
@@ -10875,6 +10926,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.targetHttpsProxy.regionUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).GetRegionUrl()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.targetHttpsProxy.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
 	},
 	"gcp.project.computeService.network.peering.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceNetworkPeering).GetId()).ToDataRes(types.String)
@@ -11020,6 +11074,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.serviceAttachment.regionUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceServiceAttachment).GetRegionUrl()).ToDataRes(types.String)
 	},
+	"gcp.project.computeService.serviceAttachment.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceServiceAttachment).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
+	},
 	"gcp.project.computeService.serviceAttachment.selfLink": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceServiceAttachment).GetSelfLink()).ToDataRes(types.String)
 	},
@@ -11062,8 +11119,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.networkEndpointGroup.zoneUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).GetZoneUrl()).ToDataRes(types.String)
 	},
+	"gcp.project.computeService.networkEndpointGroup.zone": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).GetZone()).ToDataRes(types.Resource("gcp.project.computeService.zone"))
+	},
 	"gcp.project.computeService.networkEndpointGroup.regionUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).GetRegionUrl()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.networkEndpointGroup.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
 	},
 	"gcp.project.computeService.networkEndpointGroup.cloudRun": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).GetCloudRun()).ToDataRes(types.Dict)
@@ -11233,6 +11296,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.interconnectAttachment.regionUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInterconnectAttachment).GetRegionUrl()).ToDataRes(types.String)
 	},
+	"gcp.project.computeService.interconnectAttachment.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInterconnectAttachment).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
+	},
 	"gcp.project.computeService.interconnectAttachment.selfLink": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInterconnectAttachment).GetSelfLink()).ToDataRes(types.String)
 	},
@@ -11286,6 +11352,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.targetTcpProxy.regionUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetTcpProxy).GetRegionUrl()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.targetTcpProxy.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceTargetTcpProxy).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
 	},
 	"gcp.project.computeService.targetTcpProxy.selfLink": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetTcpProxy).GetSelfLink()).ToDataRes(types.String)
@@ -11356,6 +11425,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.packetMirroring.regionUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServicePacketMirroring).GetRegionUrl()).ToDataRes(types.String)
 	},
+	"gcp.project.computeService.packetMirroring.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServicePacketMirroring).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
+	},
 	"gcp.project.computeService.packetMirroring.selfLink": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServicePacketMirroring).GetSelfLink()).ToDataRes(types.String)
 	},
@@ -11424,6 +11496,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.targetPool.regionUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetPool).GetRegionUrl()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.targetPool.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceTargetPool).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
 	},
 	"gcp.project.computeService.targetPool.selfLink": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetPool).GetSelfLink()).ToDataRes(types.String)
@@ -13671,6 +13746,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.cloudBuildService.trigger.pubsubConfig.serviceAccountEmail": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudBuildServiceTriggerPubsubConfig).GetServiceAccountEmail()).ToDataRes(types.String)
+	},
+	"gcp.project.cloudBuildService.trigger.pubsubConfig.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudBuildServiceTriggerPubsubConfig).GetServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
 	},
 	"gcp.project.cloudBuildService.trigger.pubsubConfig.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudBuildServiceTriggerPubsubConfig).GetState()).ToDataRes(types.String)
@@ -16037,6 +16115,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceAddress).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.address.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceAddress).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.address.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceAddress).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -16139,6 +16221,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.forwardingRule.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceForwardingRule).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.forwardingRule.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceForwardingRule).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.forwardingRule.serviceDirectoryRegistrations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -17463,6 +17549,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.backendService.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceBackendService).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.backendService.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceBackendService).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.backendService.securityPolicyUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21537,6 +21627,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectCloudFunction).ServiceAccountEmail, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.cloudFunction.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudFunction).ServiceAccount, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
+		return
+	},
 	"gcp.project.cloudFunction.updated": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudFunction).Updated, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -21815,6 +21909,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.cloudFunctionV2.eventTrigger.serviceAccountEmail": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudFunctionV2EventTrigger).ServiceAccountEmail, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.cloudFunctionV2.eventTrigger.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudFunctionV2EventTrigger).ServiceAccount, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
 		return
 	},
 	"gcp.project.cloudFunctionV2.eventTrigger.retryPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -24669,6 +24767,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceSecurityPolicy).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.securityPolicy.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceSecurityPolicy).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.securityPolicy.selfLink": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceSecurityPolicy).SelfLink, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -24769,6 +24871,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceSslPolicy).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.sslPolicy.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceSslPolicy).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.sslPolicy.selfLink": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceSslPolicy).SelfLink, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -24811,6 +24917,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.sslCertificate.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceSslCertificate).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.sslCertificate.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceSslCertificate).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.sslCertificate.selfLink": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -24863,6 +24973,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.vpnGateway.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceVpnGateway).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.vpnGateway.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceVpnGateway).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.vpnGateway.vpnInterfaces": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -24939,6 +25053,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.vpnTunnel.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceVpnTunnel).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.vpnTunnel.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceVpnTunnel).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.vpnTunnel.routerUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -25817,6 +25935,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceInstanceGroup).ZoneUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.instanceGroup.zone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstanceGroup).Zone, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceZone](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.instanceGroup.networkUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstanceGroup).NetworkUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -25869,8 +25991,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceInstanceGroupManager).ZoneUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.instanceGroupManager.zone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstanceGroupManager).Zone, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceZone](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.instanceGroupManager.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstanceGroupManager).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.instanceGroupManager.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstanceGroupManager).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.instanceGroupManager.instanceTemplateUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -25951,6 +26081,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.firewallPolicy.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceFirewallPolicy).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.firewallPolicy.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceFirewallPolicy).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.firewallPolicy.rules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -27045,6 +27179,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceHealthCheck).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.healthCheck.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceHealthCheck).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.urlMap.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceUrlMap).__id, ok = v.Value.(string)
 		return
@@ -27093,6 +27231,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceUrlMap).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.urlMap.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceUrlMap).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.targetHttpProxy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceTargetHttpProxy).__id, ok = v.Value.(string)
 		return
@@ -27135,6 +27277,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.targetHttpProxy.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceTargetHttpProxy).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.targetHttpProxy.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceTargetHttpProxy).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.targetHttpsProxy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -27195,6 +27341,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.targetHttpsProxy.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.targetHttpsProxy.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.network.peering.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -27401,6 +27551,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceServiceAttachment).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.serviceAttachment.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceServiceAttachment).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.serviceAttachment.selfLink": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceServiceAttachment).SelfLink, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -27461,8 +27615,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).ZoneUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.networkEndpointGroup.zone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).Zone, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceZone](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.networkEndpointGroup.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.networkEndpointGroup.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.networkEndpointGroup.cloudRun": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -27697,6 +27859,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceInterconnectAttachment).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.interconnectAttachment.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInterconnectAttachment).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.interconnectAttachment.selfLink": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInterconnectAttachment).SelfLink, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -27775,6 +27941,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.targetTcpProxy.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceTargetTcpProxy).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.targetTcpProxy.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceTargetTcpProxy).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.targetTcpProxy.selfLink": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -27877,6 +28047,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServicePacketMirroring).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.packetMirroring.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServicePacketMirroring).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.packetMirroring.selfLink": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServicePacketMirroring).SelfLink, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -27975,6 +28149,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.targetPool.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceTargetPool).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.targetPool.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceTargetPool).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.targetPool.selfLink": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31315,6 +31493,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.cloudBuildService.trigger.pubsubConfig.serviceAccountEmail": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudBuildServiceTriggerPubsubConfig).ServiceAccountEmail, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.cloudBuildService.trigger.pubsubConfig.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudBuildServiceTriggerPubsubConfig).ServiceAccount, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
 		return
 	},
 	"gcp.project.cloudBuildService.trigger.pubsubConfig.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -37136,6 +37318,7 @@ type mqlGcpProjectComputeServiceAddress struct {
 	PrefixLength     plugin.TValue[int64]
 	Purpose          plugin.TValue[string]
 	RegionUrl        plugin.TValue[string]
+	Region           plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	Status           plugin.TValue[string]
 	SubnetworkUrl    plugin.TValue[string]
 	Subnetwork       plugin.TValue[*mqlGcpProjectComputeServiceSubnetwork]
@@ -37251,6 +37434,22 @@ func (c *mqlGcpProjectComputeServiceAddress) GetRegionUrl() *plugin.TValue[strin
 	return &c.RegionUrl
 }
 
+func (c *mqlGcpProjectComputeServiceAddress) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.address", c.__id, "region")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceRegion), nil
+			}
+		}
+
+		return c.region()
+	})
+}
+
 func (c *mqlGcpProjectComputeServiceAddress) GetStatus() *plugin.TValue[string] {
 	return &c.Status
 }
@@ -37305,6 +37504,7 @@ type mqlGcpProjectComputeServiceForwardingRule struct {
 	PortRange                     plugin.TValue[string]
 	Ports                         plugin.TValue[[]any]
 	RegionUrl                     plugin.TValue[string]
+	Region                        plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	ServiceDirectoryRegistrations plugin.TValue[[]any]
 	ServiceLabel                  plugin.TValue[string]
 	ServiceName                   plugin.TValue[string]
@@ -37449,6 +37649,22 @@ func (c *mqlGcpProjectComputeServiceForwardingRule) GetPorts() *plugin.TValue[[]
 
 func (c *mqlGcpProjectComputeServiceForwardingRule) GetRegionUrl() *plugin.TValue[string] {
 	return &c.RegionUrl
+}
+
+func (c *mqlGcpProjectComputeServiceForwardingRule) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.forwardingRule", c.__id, "region")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceRegion), nil
+			}
+		}
+
+		return c.region()
+	})
 }
 
 func (c *mqlGcpProjectComputeServiceForwardingRule) GetServiceDirectoryRegistrations() *plugin.TValue[[]any] {
@@ -39976,6 +40192,7 @@ type mqlGcpProjectComputeServiceBackendService struct {
 	PortName                 plugin.TValue[string]
 	Protocol                 plugin.TValue[string]
 	RegionUrl                plugin.TValue[string]
+	Region                   plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	SecurityPolicyUrl        plugin.TValue[string]
 	SecurityPolicy           plugin.TValue[*mqlGcpProjectComputeServiceSecurityPolicy]
 	CloudArmorEnabled        plugin.TValue[bool]
@@ -40153,6 +40370,22 @@ func (c *mqlGcpProjectComputeServiceBackendService) GetProtocol() *plugin.TValue
 
 func (c *mqlGcpProjectComputeServiceBackendService) GetRegionUrl() *plugin.TValue[string] {
 	return &c.RegionUrl
+}
+
+func (c *mqlGcpProjectComputeServiceBackendService) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.backendService", c.__id, "region")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceRegion), nil
+			}
+		}
+
+		return c.region()
+	})
 }
 
 func (c *mqlGcpProjectComputeServiceBackendService) GetSecurityPolicyUrl() *plugin.TValue[string] {
@@ -49842,6 +50075,7 @@ type mqlGcpProjectCloudFunction struct {
 	Timeout             plugin.TValue[*time.Time]
 	AvailableMemoryMb   plugin.TValue[int64]
 	ServiceAccountEmail plugin.TValue[string]
+	ServiceAccount      plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
 	Updated             plugin.TValue[*time.Time]
 	VersionId           plugin.TValue[int64]
 	Labels              plugin.TValue[map[string]any]
@@ -49959,6 +50193,22 @@ func (c *mqlGcpProjectCloudFunction) GetAvailableMemoryMb() *plugin.TValue[int64
 
 func (c *mqlGcpProjectCloudFunction) GetServiceAccountEmail() *plugin.TValue[string] {
 	return &c.ServiceAccountEmail
+}
+
+func (c *mqlGcpProjectCloudFunction) GetServiceAccount() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
+	return plugin.GetOrCompute[*mqlGcpProjectIamServiceServiceAccount](&c.ServiceAccount, func() (*mqlGcpProjectIamServiceServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.cloudFunction", c.__id, "serviceAccount")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectIamServiceServiceAccount), nil
+			}
+		}
+
+		return c.serviceAccount()
+	})
 }
 
 func (c *mqlGcpProjectCloudFunction) GetUpdated() *plugin.TValue[*time.Time] {
@@ -50412,6 +50662,7 @@ type mqlGcpProjectCloudFunctionV2EventTrigger struct {
 	PubsubTopic         plugin.TValue[string]
 	Topic               plugin.TValue[*mqlGcpProjectPubsubServiceTopic]
 	ServiceAccountEmail plugin.TValue[string]
+	ServiceAccount      plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
 	RetryPolicy         plugin.TValue[string]
 	Channel             plugin.TValue[string]
 }
@@ -50495,6 +50746,22 @@ func (c *mqlGcpProjectCloudFunctionV2EventTrigger) GetTopic() *plugin.TValue[*mq
 
 func (c *mqlGcpProjectCloudFunctionV2EventTrigger) GetServiceAccountEmail() *plugin.TValue[string] {
 	return &c.ServiceAccountEmail
+}
+
+func (c *mqlGcpProjectCloudFunctionV2EventTrigger) GetServiceAccount() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
+	return plugin.GetOrCompute[*mqlGcpProjectIamServiceServiceAccount](&c.ServiceAccount, func() (*mqlGcpProjectIamServiceServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.cloudFunctionV2.eventTrigger", c.__id, "serviceAccount")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectIamServiceServiceAccount), nil
+			}
+		}
+
+		return c.serviceAccount()
+	})
 }
 
 func (c *mqlGcpProjectCloudFunctionV2EventTrigger) GetRetryPolicy() *plugin.TValue[string] {
@@ -57122,6 +57389,7 @@ type mqlGcpProjectComputeServiceSecurityPolicy struct {
 	Fingerprint              plugin.TValue[string]
 	UserDefinedFields        plugin.TValue[[]any]
 	RegionUrl                plugin.TValue[string]
+	Region                   plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	SelfLink                 plugin.TValue[string]
 	CreatedAt                plugin.TValue[*time.Time]
 	Rules                    plugin.TValue[[]any]
@@ -57210,6 +57478,22 @@ func (c *mqlGcpProjectComputeServiceSecurityPolicy) GetUserDefinedFields() *plug
 
 func (c *mqlGcpProjectComputeServiceSecurityPolicy) GetRegionUrl() *plugin.TValue[string] {
 	return &c.RegionUrl
+}
+
+func (c *mqlGcpProjectComputeServiceSecurityPolicy) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.securityPolicy", c.__id, "region")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceRegion), nil
+			}
+		}
+
+		return c.region()
+	})
 }
 
 func (c *mqlGcpProjectComputeServiceSecurityPolicy) GetSelfLink() *plugin.TValue[string] {
@@ -57349,6 +57633,7 @@ type mqlGcpProjectComputeServiceSslPolicy struct {
 	CustomFeatures  plugin.TValue[[]any]
 	EnabledFeatures plugin.TValue[[]any]
 	RegionUrl       plugin.TValue[string]
+	Region          plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	SelfLink        plugin.TValue[string]
 	Warnings        plugin.TValue[[]any]
 	CreatedAt       plugin.TValue[*time.Time]
@@ -57429,6 +57714,22 @@ func (c *mqlGcpProjectComputeServiceSslPolicy) GetRegionUrl() *plugin.TValue[str
 	return &c.RegionUrl
 }
 
+func (c *mqlGcpProjectComputeServiceSslPolicy) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.sslPolicy", c.__id, "region")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceRegion), nil
+			}
+		}
+
+		return c.region()
+	})
+}
+
 func (c *mqlGcpProjectComputeServiceSslPolicy) GetSelfLink() *plugin.TValue[string] {
 	return &c.SelfLink
 }
@@ -57453,6 +57754,7 @@ type mqlGcpProjectComputeServiceSslCertificate struct {
 	SubjectAlternativeNames plugin.TValue[[]any]
 	Managed                 plugin.TValue[any]
 	RegionUrl               plugin.TValue[string]
+	Region                  plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	SelfLink                plugin.TValue[string]
 	ExpireTime              plugin.TValue[string]
 	CreatedAt               plugin.TValue[*time.Time]
@@ -57523,6 +57825,22 @@ func (c *mqlGcpProjectComputeServiceSslCertificate) GetRegionUrl() *plugin.TValu
 	return &c.RegionUrl
 }
 
+func (c *mqlGcpProjectComputeServiceSslCertificate) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.sslCertificate", c.__id, "region")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceRegion), nil
+			}
+		}
+
+		return c.region()
+	})
+}
+
 func (c *mqlGcpProjectComputeServiceSslCertificate) GetSelfLink() *plugin.TValue[string] {
 	return &c.SelfLink
 }
@@ -57549,6 +57867,7 @@ type mqlGcpProjectComputeServiceVpnGateway struct {
 	GatewayIpVersion    plugin.TValue[string]
 	StackType           plugin.TValue[string]
 	RegionUrl           plugin.TValue[string]
+	Region              plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	VpnInterfaces       plugin.TValue[[]any]
 	ResourceManagerTags plugin.TValue[map[string]any]
 }
@@ -57638,6 +57957,22 @@ func (c *mqlGcpProjectComputeServiceVpnGateway) GetRegionUrl() *plugin.TValue[st
 	return &c.RegionUrl
 }
 
+func (c *mqlGcpProjectComputeServiceVpnGateway) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.vpnGateway", c.__id, "region")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceRegion), nil
+			}
+		}
+
+		return c.region()
+	})
+}
+
 func (c *mqlGcpProjectComputeServiceVpnGateway) GetVpnInterfaces() *plugin.TValue[[]any] {
 	return &c.VpnInterfaces
 }
@@ -57667,6 +58002,7 @@ type mqlGcpProjectComputeServiceVpnTunnel struct {
 	PeerGcpVpnGateway            plugin.TValue[*mqlGcpProjectComputeServiceVpnGateway]
 	PeerIp                       plugin.TValue[string]
 	RegionUrl                    plugin.TValue[string]
+	Region                       plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	RouterUrl                    plugin.TValue[string]
 	Router                       plugin.TValue[*mqlGcpProjectComputeServiceRouter]
 	SharedSecretHash             plugin.TValue[string]
@@ -57801,6 +58137,22 @@ func (c *mqlGcpProjectComputeServiceVpnTunnel) GetPeerIp() *plugin.TValue[string
 
 func (c *mqlGcpProjectComputeServiceVpnTunnel) GetRegionUrl() *plugin.TValue[string] {
 	return &c.RegionUrl
+}
+
+func (c *mqlGcpProjectComputeServiceVpnTunnel) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.vpnTunnel", c.__id, "region")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceRegion), nil
+			}
+		}
+
+		return c.region()
+	})
 }
 
 func (c *mqlGcpProjectComputeServiceVpnTunnel) GetRouterUrl() *plugin.TValue[string] {
@@ -59739,6 +60091,7 @@ type mqlGcpProjectComputeServiceInstanceGroup struct {
 	Name        plugin.TValue[string]
 	Description plugin.TValue[string]
 	ZoneUrl     plugin.TValue[string]
+	Zone        plugin.TValue[*mqlGcpProjectComputeServiceZone]
 	NetworkUrl  plugin.TValue[string]
 	Network     plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	Subnetwork  plugin.TValue[*mqlGcpProjectComputeServiceSubnetwork]
@@ -59805,6 +60158,22 @@ func (c *mqlGcpProjectComputeServiceInstanceGroup) GetZoneUrl() *plugin.TValue[s
 	return &c.ZoneUrl
 }
 
+func (c *mqlGcpProjectComputeServiceInstanceGroup) GetZone() *plugin.TValue[*mqlGcpProjectComputeServiceZone] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceZone](&c.Zone, func() (*mqlGcpProjectComputeServiceZone, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.instanceGroup", c.__id, "zone")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceZone), nil
+			}
+		}
+
+		return c.zone()
+	})
+}
+
 func (c *mqlGcpProjectComputeServiceInstanceGroup) GetNetworkUrl() *plugin.TValue[string] {
 	return &c.NetworkUrl
 }
@@ -59867,7 +60236,9 @@ type mqlGcpProjectComputeServiceInstanceGroupManager struct {
 	Name                plugin.TValue[string]
 	Description         plugin.TValue[string]
 	ZoneUrl             plugin.TValue[string]
+	Zone                plugin.TValue[*mqlGcpProjectComputeServiceZone]
 	RegionUrl           plugin.TValue[string]
+	Region              plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	InstanceTemplateUrl plugin.TValue[string]
 	TargetSize          plugin.TValue[int64]
 	CurrentActions      plugin.TValue[any]
@@ -59937,8 +60308,40 @@ func (c *mqlGcpProjectComputeServiceInstanceGroupManager) GetZoneUrl() *plugin.T
 	return &c.ZoneUrl
 }
 
+func (c *mqlGcpProjectComputeServiceInstanceGroupManager) GetZone() *plugin.TValue[*mqlGcpProjectComputeServiceZone] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceZone](&c.Zone, func() (*mqlGcpProjectComputeServiceZone, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.instanceGroupManager", c.__id, "zone")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceZone), nil
+			}
+		}
+
+		return c.zone()
+	})
+}
+
 func (c *mqlGcpProjectComputeServiceInstanceGroupManager) GetRegionUrl() *plugin.TValue[string] {
 	return &c.RegionUrl
+}
+
+func (c *mqlGcpProjectComputeServiceInstanceGroupManager) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.instanceGroupManager", c.__id, "region")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceRegion), nil
+			}
+		}
+
+		return c.region()
+	})
 }
 
 func (c *mqlGcpProjectComputeServiceInstanceGroupManager) GetInstanceTemplateUrl() *plugin.TValue[string] {
@@ -59995,6 +60398,7 @@ type mqlGcpProjectComputeServiceFirewallPolicy struct {
 	RuleTupleCount plugin.TValue[int64]
 	Created        plugin.TValue[*time.Time]
 	RegionUrl      plugin.TValue[string]
+	Region         plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	Rules          plugin.TValue[[]any]
 	Associations   plugin.TValue[[]any]
 }
@@ -60070,6 +60474,22 @@ func (c *mqlGcpProjectComputeServiceFirewallPolicy) GetCreated() *plugin.TValue[
 
 func (c *mqlGcpProjectComputeServiceFirewallPolicy) GetRegionUrl() *plugin.TValue[string] {
 	return &c.RegionUrl
+}
+
+func (c *mqlGcpProjectComputeServiceFirewallPolicy) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.firewallPolicy", c.__id, "region")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceRegion), nil
+			}
+		}
+
+		return c.region()
+	})
 }
 
 func (c *mqlGcpProjectComputeServiceFirewallPolicy) GetRules() *plugin.TValue[[]any] {
@@ -62784,6 +63204,7 @@ type mqlGcpProjectComputeServiceHealthCheck struct {
 	GrpcHealthCheck    plugin.TValue[any]
 	LogConfig          plugin.TValue[any]
 	RegionUrl          plugin.TValue[string]
+	Region             plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 }
 
 // createGcpProjectComputeServiceHealthCheck creates a new instance of this resource
@@ -62899,6 +63320,22 @@ func (c *mqlGcpProjectComputeServiceHealthCheck) GetRegionUrl() *plugin.TValue[s
 	return &c.RegionUrl
 }
 
+func (c *mqlGcpProjectComputeServiceHealthCheck) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.healthCheck", c.__id, "region")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceRegion), nil
+			}
+		}
+
+		return c.region()
+	})
+}
+
 // mqlGcpProjectComputeServiceUrlMap for the gcp.project.computeService.urlMap resource
 type mqlGcpProjectComputeServiceUrlMap struct {
 	MqlRuntime *plugin.Runtime
@@ -62915,6 +63352,7 @@ type mqlGcpProjectComputeServiceUrlMap struct {
 	Created        plugin.TValue[*time.Time]
 	SelfLink       plugin.TValue[string]
 	RegionUrl      plugin.TValue[string]
+	Region         plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 }
 
 // createGcpProjectComputeServiceUrlMap creates a new instance of this resource
@@ -62998,6 +63436,22 @@ func (c *mqlGcpProjectComputeServiceUrlMap) GetRegionUrl() *plugin.TValue[string
 	return &c.RegionUrl
 }
 
+func (c *mqlGcpProjectComputeServiceUrlMap) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.urlMap", c.__id, "region")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceRegion), nil
+			}
+		}
+
+		return c.region()
+	})
+}
+
 // mqlGcpProjectComputeServiceTargetHttpProxy for the gcp.project.computeService.targetHttpProxy resource
 type mqlGcpProjectComputeServiceTargetHttpProxy struct {
 	MqlRuntime *plugin.Runtime
@@ -63013,6 +63467,7 @@ type mqlGcpProjectComputeServiceTargetHttpProxy struct {
 	SelfLink    plugin.TValue[string]
 	ProxyBind   plugin.TValue[bool]
 	RegionUrl   plugin.TValue[string]
+	Region      plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 }
 
 // createGcpProjectComputeServiceTargetHttpProxy creates a new instance of this resource
@@ -63104,6 +63559,22 @@ func (c *mqlGcpProjectComputeServiceTargetHttpProxy) GetRegionUrl() *plugin.TVal
 	return &c.RegionUrl
 }
 
+func (c *mqlGcpProjectComputeServiceTargetHttpProxy) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.targetHttpProxy", c.__id, "region")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceRegion), nil
+			}
+		}
+
+		return c.region()
+	})
+}
+
 // mqlGcpProjectComputeServiceTargetHttpsProxy for the gcp.project.computeService.targetHttpsProxy resource
 type mqlGcpProjectComputeServiceTargetHttpsProxy struct {
 	MqlRuntime *plugin.Runtime
@@ -63123,6 +63594,7 @@ type mqlGcpProjectComputeServiceTargetHttpsProxy struct {
 	SelfLink           plugin.TValue[string]
 	ProxyBind          plugin.TValue[bool]
 	RegionUrl          plugin.TValue[string]
+	Region             plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 }
 
 // createGcpProjectComputeServiceTargetHttpsProxy creates a new instance of this resource
@@ -63240,6 +63712,22 @@ func (c *mqlGcpProjectComputeServiceTargetHttpsProxy) GetProxyBind() *plugin.TVa
 
 func (c *mqlGcpProjectComputeServiceTargetHttpsProxy) GetRegionUrl() *plugin.TValue[string] {
 	return &c.RegionUrl
+}
+
+func (c *mqlGcpProjectComputeServiceTargetHttpsProxy) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.targetHttpsProxy", c.__id, "region")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceRegion), nil
+			}
+		}
+
+		return c.region()
+	})
 }
 
 // mqlGcpProjectComputeServiceNetworkPeering for the gcp.project.computeService.network.peering resource
@@ -63543,6 +64031,7 @@ type mqlGcpProjectComputeServiceServiceAttachment struct {
 	TargetService          plugin.TValue[string]
 	ReconcileConnections   plugin.TValue[bool]
 	RegionUrl              plugin.TValue[string]
+	Region                 plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	SelfLink               plugin.TValue[string]
 	Fingerprint            plugin.TValue[string]
 	Created                plugin.TValue[*time.Time]
@@ -63641,6 +64130,22 @@ func (c *mqlGcpProjectComputeServiceServiceAttachment) GetRegionUrl() *plugin.TV
 	return &c.RegionUrl
 }
 
+func (c *mqlGcpProjectComputeServiceServiceAttachment) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.serviceAttachment", c.__id, "region")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceRegion), nil
+			}
+		}
+
+		return c.region()
+	})
+}
+
 func (c *mqlGcpProjectComputeServiceServiceAttachment) GetSelfLink() *plugin.TValue[string] {
 	return &c.SelfLink
 }
@@ -63669,7 +64174,9 @@ type mqlGcpProjectComputeServiceNetworkEndpointGroup struct {
 	SubnetworkUrl       plugin.TValue[string]
 	Subnetwork          plugin.TValue[*mqlGcpProjectComputeServiceSubnetwork]
 	ZoneUrl             plugin.TValue[string]
+	Zone                plugin.TValue[*mqlGcpProjectComputeServiceZone]
 	RegionUrl           plugin.TValue[string]
+	Region              plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	CloudRun            plugin.TValue[any]
 	AppEngine           plugin.TValue[any]
 	CloudFunction       plugin.TValue[any]
@@ -63785,8 +64292,40 @@ func (c *mqlGcpProjectComputeServiceNetworkEndpointGroup) GetZoneUrl() *plugin.T
 	return &c.ZoneUrl
 }
 
+func (c *mqlGcpProjectComputeServiceNetworkEndpointGroup) GetZone() *plugin.TValue[*mqlGcpProjectComputeServiceZone] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceZone](&c.Zone, func() (*mqlGcpProjectComputeServiceZone, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.networkEndpointGroup", c.__id, "zone")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceZone), nil
+			}
+		}
+
+		return c.zone()
+	})
+}
+
 func (c *mqlGcpProjectComputeServiceNetworkEndpointGroup) GetRegionUrl() *plugin.TValue[string] {
 	return &c.RegionUrl
+}
+
+func (c *mqlGcpProjectComputeServiceNetworkEndpointGroup) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.networkEndpointGroup", c.__id, "region")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceRegion), nil
+			}
+		}
+
+		return c.region()
+	})
 }
 
 func (c *mqlGcpProjectComputeServiceNetworkEndpointGroup) GetCloudRun() *plugin.TValue[any] {
@@ -64022,6 +64561,7 @@ type mqlGcpProjectComputeServiceInterconnectAttachment struct {
 	PartnerMetadata           plugin.TValue[any]
 	PrivateInterconnectInfo   plugin.TValue[any]
 	RegionUrl                 plugin.TValue[string]
+	Region                    plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	SelfLink                  plugin.TValue[string]
 	DataplaneVersion          plugin.TValue[int64]
 	Created                   plugin.TValue[*time.Time]
@@ -64176,6 +64716,22 @@ func (c *mqlGcpProjectComputeServiceInterconnectAttachment) GetRegionUrl() *plug
 	return &c.RegionUrl
 }
 
+func (c *mqlGcpProjectComputeServiceInterconnectAttachment) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.interconnectAttachment", c.__id, "region")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceRegion), nil
+			}
+		}
+
+		return c.region()
+	})
+}
+
 func (c *mqlGcpProjectComputeServiceInterconnectAttachment) GetSelfLink() *plugin.TValue[string] {
 	return &c.SelfLink
 }
@@ -64284,6 +64840,7 @@ type mqlGcpProjectComputeServiceTargetTcpProxy struct {
 	ProxyBind   plugin.TValue[bool]
 	ServiceUrl  plugin.TValue[string]
 	RegionUrl   plugin.TValue[string]
+	Region      plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	SelfLink    plugin.TValue[string]
 	Created     plugin.TValue[*time.Time]
 }
@@ -64351,6 +64908,22 @@ func (c *mqlGcpProjectComputeServiceTargetTcpProxy) GetServiceUrl() *plugin.TVal
 
 func (c *mqlGcpProjectComputeServiceTargetTcpProxy) GetRegionUrl() *plugin.TValue[string] {
 	return &c.RegionUrl
+}
+
+func (c *mqlGcpProjectComputeServiceTargetTcpProxy) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.targetTcpProxy", c.__id, "region")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceRegion), nil
+			}
+		}
+
+		return c.region()
+	})
 }
 
 func (c *mqlGcpProjectComputeServiceTargetTcpProxy) GetSelfLink() *plugin.TValue[string] {
@@ -64487,6 +65060,7 @@ type mqlGcpProjectComputeServicePacketMirroring struct {
 	MirroredResources plugin.TValue[any]
 	Filter            plugin.TValue[any]
 	RegionUrl         plugin.TValue[string]
+	Region            plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	SelfLink          plugin.TValue[string]
 	Created           plugin.TValue[*time.Time]
 }
@@ -64566,6 +65140,22 @@ func (c *mqlGcpProjectComputeServicePacketMirroring) GetFilter() *plugin.TValue[
 
 func (c *mqlGcpProjectComputeServicePacketMirroring) GetRegionUrl() *plugin.TValue[string] {
 	return &c.RegionUrl
+}
+
+func (c *mqlGcpProjectComputeServicePacketMirroring) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.packetMirroring", c.__id, "region")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceRegion), nil
+			}
+		}
+
+		return c.region()
+	})
 }
 
 func (c *mqlGcpProjectComputeServicePacketMirroring) GetSelfLink() *plugin.TValue[string] {
@@ -64690,6 +65280,7 @@ type mqlGcpProjectComputeServiceTargetPool struct {
 	InstanceUrls    plugin.TValue[[]any]
 	SecurityPolicy  plugin.TValue[string]
 	RegionUrl       plugin.TValue[string]
+	Region          plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	SelfLink        plugin.TValue[string]
 	Created         plugin.TValue[*time.Time]
 }
@@ -64769,6 +65360,22 @@ func (c *mqlGcpProjectComputeServiceTargetPool) GetSecurityPolicy() *plugin.TVal
 
 func (c *mqlGcpProjectComputeServiceTargetPool) GetRegionUrl() *plugin.TValue[string] {
 	return &c.RegionUrl
+}
+
+func (c *mqlGcpProjectComputeServiceTargetPool) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
+	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.targetPool", c.__id, "region")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectComputeServiceRegion), nil
+			}
+		}
+
+		return c.region()
+	})
 }
 
 func (c *mqlGcpProjectComputeServiceTargetPool) GetSelfLink() *plugin.TValue[string] {
@@ -72959,6 +73566,7 @@ type mqlGcpProjectCloudBuildServiceTriggerPubsubConfig struct {
 	PubsubTopic         plugin.TValue[*mqlGcpProjectPubsubServiceTopic]
 	Subscription        plugin.TValue[string]
 	ServiceAccountEmail plugin.TValue[string]
+	ServiceAccount      plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
 	State               plugin.TValue[string]
 }
 
@@ -73029,6 +73637,22 @@ func (c *mqlGcpProjectCloudBuildServiceTriggerPubsubConfig) GetSubscription() *p
 
 func (c *mqlGcpProjectCloudBuildServiceTriggerPubsubConfig) GetServiceAccountEmail() *plugin.TValue[string] {
 	return &c.ServiceAccountEmail
+}
+
+func (c *mqlGcpProjectCloudBuildServiceTriggerPubsubConfig) GetServiceAccount() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
+	return plugin.GetOrCompute[*mqlGcpProjectIamServiceServiceAccount](&c.ServiceAccount, func() (*mqlGcpProjectIamServiceServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.cloudBuildService.trigger.pubsubConfig", c.__id, "serviceAccount")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectIamServiceServiceAccount), nil
+			}
+		}
+
+		return c.serviceAccount()
+	})
 }
 
 func (c *mqlGcpProjectCloudBuildServiceTriggerPubsubConfig) GetState() *plugin.TValue[string] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -888,6 +888,7 @@ gcp.project.cloudBuildService.trigger.projectId 13.7.2
 gcp.project.cloudBuildService.trigger.pubsubConfig 13.7.2
 gcp.project.cloudBuildService.trigger.pubsubConfig.id 13.7.2
 gcp.project.cloudBuildService.trigger.pubsubConfig.pubsubTopic 13.7.2
+gcp.project.cloudBuildService.trigger.pubsubConfig.serviceAccount 13.16.3
 gcp.project.cloudBuildService.trigger.pubsubConfig.serviceAccountEmail 13.7.2
 gcp.project.cloudBuildService.trigger.pubsubConfig.state 13.7.2
 gcp.project.cloudBuildService.trigger.pubsubConfig.subscription 13.7.2
@@ -998,6 +999,7 @@ gcp.project.cloudFunction.projectId 9.0.0
 gcp.project.cloudFunction.runtime 9.0.0
 gcp.project.cloudFunction.secretEnvVars 9.0.0
 gcp.project.cloudFunction.secretVolumes 9.0.0
+gcp.project.cloudFunction.serviceAccount 13.16.3
 gcp.project.cloudFunction.serviceAccountEmail 9.0.0
 gcp.project.cloudFunction.sourceArchiveUrl 9.0.0
 gcp.project.cloudFunction.sourceRepository 9.0.0
@@ -1027,6 +1029,7 @@ gcp.project.cloudFunctionV2.eventTrigger.eventType 13.7.2
 gcp.project.cloudFunctionV2.eventTrigger.id 13.7.2
 gcp.project.cloudFunctionV2.eventTrigger.pubsubTopic 13.7.2
 gcp.project.cloudFunctionV2.eventTrigger.retryPolicy 13.7.2
+gcp.project.cloudFunctionV2.eventTrigger.serviceAccount 13.16.3
 gcp.project.cloudFunctionV2.eventTrigger.serviceAccountEmail 13.7.2
 gcp.project.cloudFunctionV2.eventTrigger.topic 13.7.2
 gcp.project.cloudFunctionV2.eventTrigger.trigger 13.7.2
@@ -1259,6 +1262,7 @@ gcp.project.computeService.address.networkTier 9.0.0
 gcp.project.computeService.address.networkUrl 9.0.0
 gcp.project.computeService.address.prefixLength 9.0.0
 gcp.project.computeService.address.purpose 9.0.0
+gcp.project.computeService.address.region 13.16.3
 gcp.project.computeService.address.regionUrl 9.0.0
 gcp.project.computeService.address.resourceUrls 9.0.0
 gcp.project.computeService.address.status 9.0.0
@@ -1355,6 +1359,7 @@ gcp.project.computeService.backendService.networkUrl 9.0.0
 gcp.project.computeService.backendService.port 11.6.6
 gcp.project.computeService.backendService.portName 9.0.0
 gcp.project.computeService.backendService.protocol 9.0.0
+gcp.project.computeService.backendService.region 13.16.3
 gcp.project.computeService.backendService.regionUrl 9.0.0
 gcp.project.computeService.backendService.securityPolicy 13.6.1
 gcp.project.computeService.backendService.securityPolicyUrl 9.0.0
@@ -1441,6 +1446,7 @@ gcp.project.computeService.firewallPolicy.displayName 11.6.6
 gcp.project.computeService.firewallPolicy.id 11.6.6
 gcp.project.computeService.firewallPolicy.name 11.6.6
 gcp.project.computeService.firewallPolicy.projectId 11.6.6
+gcp.project.computeService.firewallPolicy.region 13.16.3
 gcp.project.computeService.firewallPolicy.regionUrl 11.6.6
 gcp.project.computeService.firewallPolicy.rule 11.6.6
 gcp.project.computeService.firewallPolicy.rule.action 11.6.6
@@ -1491,6 +1497,7 @@ gcp.project.computeService.forwardingRule.noAutomateDnsZone 9.0.0
 gcp.project.computeService.forwardingRule.portRange 9.0.0
 gcp.project.computeService.forwardingRule.ports 9.0.0
 gcp.project.computeService.forwardingRule.pscConnectionStatus 11.6.6
+gcp.project.computeService.forwardingRule.region 13.16.3
 gcp.project.computeService.forwardingRule.regionUrl 9.0.0
 gcp.project.computeService.forwardingRule.serviceDirectoryRegistrations 9.0.0
 gcp.project.computeService.forwardingRule.serviceLabel 9.0.0
@@ -1514,6 +1521,7 @@ gcp.project.computeService.healthCheck.id 11.6.6
 gcp.project.computeService.healthCheck.logConfig 11.6.6
 gcp.project.computeService.healthCheck.name 11.6.6
 gcp.project.computeService.healthCheck.projectId 11.6.6
+gcp.project.computeService.healthCheck.region 13.16.3
 gcp.project.computeService.healthCheck.regionUrl 11.6.6
 gcp.project.computeService.healthCheck.selfLink 11.6.6
 gcp.project.computeService.healthCheck.sslHealthCheck 11.6.6
@@ -1627,6 +1635,7 @@ gcp.project.computeService.instanceGroup.projectId 11.6.6
 gcp.project.computeService.instanceGroup.selfLink 11.6.6
 gcp.project.computeService.instanceGroup.size 11.6.6
 gcp.project.computeService.instanceGroup.subnetwork 11.6.6
+gcp.project.computeService.instanceGroup.zone 13.16.3
 gcp.project.computeService.instanceGroup.zoneUrl 11.6.6
 gcp.project.computeService.instanceGroupManager 11.6.6
 gcp.project.computeService.instanceGroupManager.autoHealingPolicies 11.6.6
@@ -1639,11 +1648,13 @@ gcp.project.computeService.instanceGroupManager.instanceGroupUrl 11.6.6
 gcp.project.computeService.instanceGroupManager.instanceTemplateUrl 11.6.6
 gcp.project.computeService.instanceGroupManager.name 11.6.6
 gcp.project.computeService.instanceGroupManager.projectId 11.6.6
+gcp.project.computeService.instanceGroupManager.region 13.16.3
 gcp.project.computeService.instanceGroupManager.regionUrl 11.6.6
 gcp.project.computeService.instanceGroupManager.selfLink 11.6.6
 gcp.project.computeService.instanceGroupManager.statefulPolicy 11.6.6
 gcp.project.computeService.instanceGroupManager.status 11.6.6
 gcp.project.computeService.instanceGroupManager.targetSize 11.6.6
+gcp.project.computeService.instanceGroupManager.zone 13.16.3
 gcp.project.computeService.instanceGroupManager.zoneUrl 11.6.6
 gcp.project.computeService.instanceGroupManagers 11.6.6
 gcp.project.computeService.instanceGroups 11.6.6
@@ -1702,6 +1713,7 @@ gcp.project.computeService.interconnectAttachment.interconnectUrl 13.6.1
 gcp.project.computeService.interconnectAttachment.name 13.6.1
 gcp.project.computeService.interconnectAttachment.partnerMetadata 13.6.1
 gcp.project.computeService.interconnectAttachment.privateInterconnectInfo 13.6.1
+gcp.project.computeService.interconnectAttachment.region 13.16.3
 gcp.project.computeService.interconnectAttachment.regionUrl 13.6.1
 gcp.project.computeService.interconnectAttachment.router 13.6.1
 gcp.project.computeService.interconnectAttachment.routerUrl 13.6.1
@@ -1773,11 +1785,13 @@ gcp.project.computeService.networkEndpointGroup.networkEndpointType 13.6.1
 gcp.project.computeService.networkEndpointGroup.networkUrl 13.6.1
 gcp.project.computeService.networkEndpointGroup.pscData 13.6.1
 gcp.project.computeService.networkEndpointGroup.pscTargetService 13.6.1
+gcp.project.computeService.networkEndpointGroup.region 13.16.3
 gcp.project.computeService.networkEndpointGroup.regionUrl 13.6.1
 gcp.project.computeService.networkEndpointGroup.selfLink 13.6.1
 gcp.project.computeService.networkEndpointGroup.size 13.6.1
 gcp.project.computeService.networkEndpointGroup.subnetwork 13.6.1
 gcp.project.computeService.networkEndpointGroup.subnetworkUrl 13.6.1
+gcp.project.computeService.networkEndpointGroup.zone 13.16.3
 gcp.project.computeService.networkEndpointGroup.zoneUrl 13.6.1
 gcp.project.computeService.networkEndpointGroups 13.6.1
 gcp.project.computeService.networks 9.0.0
@@ -1792,6 +1806,7 @@ gcp.project.computeService.packetMirroring.mirroredResources 13.6.1
 gcp.project.computeService.packetMirroring.name 13.6.1
 gcp.project.computeService.packetMirroring.network 13.6.1
 gcp.project.computeService.packetMirroring.priority 13.6.1
+gcp.project.computeService.packetMirroring.region 13.16.3
 gcp.project.computeService.packetMirroring.regionUrl 13.6.1
 gcp.project.computeService.packetMirroring.selfLink 13.6.1
 gcp.project.computeService.packetMirrorings 13.6.1
@@ -1888,6 +1903,7 @@ gcp.project.computeService.securityPolicy.id 11.5.1
 gcp.project.computeService.securityPolicy.labels 11.5.1
 gcp.project.computeService.securityPolicy.name 11.5.1
 gcp.project.computeService.securityPolicy.recaptchaOptionsConfig 11.5.1
+gcp.project.computeService.securityPolicy.region 13.16.3
 gcp.project.computeService.securityPolicy.regionUrl 11.5.1
 gcp.project.computeService.securityPolicy.rule 11.5.1
 gcp.project.computeService.securityPolicy.rule.action 11.5.1
@@ -1920,6 +1936,7 @@ gcp.project.computeService.serviceAttachment.name 13.6.1
 gcp.project.computeService.serviceAttachment.natSubnets 13.6.1
 gcp.project.computeService.serviceAttachment.producerForwardingRule 13.6.1
 gcp.project.computeService.serviceAttachment.reconcileConnections 13.6.1
+gcp.project.computeService.serviceAttachment.region 13.16.3
 gcp.project.computeService.serviceAttachment.regionUrl 13.6.1
 gcp.project.computeService.serviceAttachment.selfLink 13.6.1
 gcp.project.computeService.serviceAttachment.targetService 13.6.1
@@ -1963,6 +1980,7 @@ gcp.project.computeService.sslCertificate.expireTime 11.5.1
 gcp.project.computeService.sslCertificate.id 11.5.1
 gcp.project.computeService.sslCertificate.managed 11.5.1
 gcp.project.computeService.sslCertificate.name 11.5.1
+gcp.project.computeService.sslCertificate.region 13.16.3
 gcp.project.computeService.sslCertificate.regionUrl 11.5.1
 gcp.project.computeService.sslCertificate.selfLink 11.5.1
 gcp.project.computeService.sslCertificate.subjectAlternativeNames 11.5.1
@@ -1978,6 +1996,7 @@ gcp.project.computeService.sslPolicy.id 11.5.1
 gcp.project.computeService.sslPolicy.minTlsVersion 11.5.1
 gcp.project.computeService.sslPolicy.name 11.5.1
 gcp.project.computeService.sslPolicy.profile 11.5.1
+gcp.project.computeService.sslPolicy.region 13.16.3
 gcp.project.computeService.sslPolicy.regionUrl 11.5.1
 gcp.project.computeService.sslPolicy.selfLink 11.5.1
 gcp.project.computeService.sslPolicy.warnings 11.5.1
@@ -2039,6 +2058,7 @@ gcp.project.computeService.targetHttpProxy.id 11.6.6
 gcp.project.computeService.targetHttpProxy.name 11.6.6
 gcp.project.computeService.targetHttpProxy.projectId 11.6.6
 gcp.project.computeService.targetHttpProxy.proxyBind 11.6.6
+gcp.project.computeService.targetHttpProxy.region 13.16.3
 gcp.project.computeService.targetHttpProxy.regionUrl 11.6.6
 gcp.project.computeService.targetHttpProxy.selfLink 11.6.6
 gcp.project.computeService.targetHttpProxy.urlMap 11.6.6
@@ -2052,6 +2072,7 @@ gcp.project.computeService.targetHttpsProxy.name 11.6.6
 gcp.project.computeService.targetHttpsProxy.projectId 11.6.6
 gcp.project.computeService.targetHttpsProxy.proxyBind 11.6.6
 gcp.project.computeService.targetHttpsProxy.quicOverride 11.6.6
+gcp.project.computeService.targetHttpsProxy.region 13.16.3
 gcp.project.computeService.targetHttpsProxy.regionUrl 11.6.6
 gcp.project.computeService.targetHttpsProxy.selfLink 11.6.6
 gcp.project.computeService.targetHttpsProxy.sslCertificateUrls 11.6.6
@@ -2068,6 +2089,7 @@ gcp.project.computeService.targetPool.healthCheckUrls 13.6.1
 gcp.project.computeService.targetPool.id 13.6.1
 gcp.project.computeService.targetPool.instanceUrls 13.6.1
 gcp.project.computeService.targetPool.name 13.6.1
+gcp.project.computeService.targetPool.region 13.16.3
 gcp.project.computeService.targetPool.regionUrl 13.6.1
 gcp.project.computeService.targetPool.securityPolicy 13.6.1
 gcp.project.computeService.targetPool.selfLink 13.6.1
@@ -2094,6 +2116,7 @@ gcp.project.computeService.targetTcpProxy.id 13.6.1
 gcp.project.computeService.targetTcpProxy.name 13.6.1
 gcp.project.computeService.targetTcpProxy.proxyBind 13.6.1
 gcp.project.computeService.targetTcpProxy.proxyHeader 13.6.1
+gcp.project.computeService.targetTcpProxy.region 13.16.3
 gcp.project.computeService.targetTcpProxy.regionUrl 13.6.1
 gcp.project.computeService.targetTcpProxy.selfLink 13.6.1
 gcp.project.computeService.targetTcpProxy.serviceUrl 13.6.1
@@ -2106,6 +2129,7 @@ gcp.project.computeService.urlMap.id 11.6.6
 gcp.project.computeService.urlMap.name 11.6.6
 gcp.project.computeService.urlMap.pathMatchers 11.6.6
 gcp.project.computeService.urlMap.projectId 11.6.6
+gcp.project.computeService.urlMap.region 13.16.3
 gcp.project.computeService.urlMap.regionUrl 11.6.6
 gcp.project.computeService.urlMap.selfLink 11.6.6
 gcp.project.computeService.urlMap.tests 11.6.6
@@ -2118,6 +2142,7 @@ gcp.project.computeService.vpnGateway.id 11.6.6
 gcp.project.computeService.vpnGateway.labels 11.6.6
 gcp.project.computeService.vpnGateway.name 11.6.6
 gcp.project.computeService.vpnGateway.network 11.6.6
+gcp.project.computeService.vpnGateway.region 13.16.3
 gcp.project.computeService.vpnGateway.regionUrl 11.6.6
 gcp.project.computeService.vpnGateway.resourceManagerTags 13.5.0
 gcp.project.computeService.vpnGateway.stackType 11.6.6
@@ -2138,6 +2163,7 @@ gcp.project.computeService.vpnTunnel.peerExternalVpnGateway 13.6.1
 gcp.project.computeService.vpnTunnel.peerGcpGateway 11.6.6
 gcp.project.computeService.vpnTunnel.peerGcpVpnGateway 13.6.1
 gcp.project.computeService.vpnTunnel.peerIp 11.6.6
+gcp.project.computeService.vpnTunnel.region 13.16.3
 gcp.project.computeService.vpnTunnel.regionUrl 11.6.6
 gcp.project.computeService.vpnTunnel.remoteTrafficSelector 11.6.6
 gcp.project.computeService.vpnTunnel.resourceManagerTags 13.5.0

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
   "version": "13.16.2",
-  "generated_at": "2026-05-21T19:57:04-07:00",
+  "generated_at": "2026-05-22T08:27:51-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.customJobs.list",
@@ -90,6 +90,7 @@
     "compute.packetMirrorings.list",
     "compute.projects.get",
     "compute.publicAdvertisedPrefixes.list",
+    "compute.regions.get",
     "compute.regions.list",
     "compute.routers.list",
     "compute.routes.list",
@@ -757,6 +758,12 @@
       "source_file": "compute_networking.go"
     },
     {
+      "permission": "compute.regions.get",
+      "service": "compute",
+      "action": "Regions.Get",
+      "source_file": "compute.go"
+    },
+    {
       "permission": "compute.regions.list",
       "service": "compute",
       "action": "Regions.List",
@@ -886,6 +893,12 @@
       "permission": "compute.vpnTunnels.list",
       "service": "compute",
       "action": "VpnTunnels.AggregatedList",
+      "source_file": "compute.go"
+    },
+    {
+      "permission": "compute.zones.get",
+      "service": "compute",
+      "action": "Zones.Get",
       "source_file": "compute.go"
     },
     {

--- a/providers/gcp/resources/permissions_test.go
+++ b/providers/gcp/resources/permissions_test.go
@@ -104,6 +104,7 @@ var validatedGCPPermissions = []string{
 	"compute.packetMirrorings.list",
 	"compute.projects.get",
 	"compute.publicAdvertisedPrefixes.list",
+	"compute.regions.get",
 	"compute.regions.list",
 	"compute.routers.list",
 	"compute.routes.list",


### PR DESCRIPTION
## Summary

Adds typed accessors so audits can traverse from a GCP resource to its region, zone, or service-account identity instead of dealing with self-link URLs. The matching `*Url` and `*Email` raw-string fields are kept and marked `@maturity(\"deprecated\")` so existing audits keep working.

Pattern follows the existing precedent established by earlier compute refs (e.g. `vpnTunnel.router` / `routerUrl @maturity(\"deprecated\")`).

### Compute — new `region()`
address, forwardingRule, backendService, securityPolicy, sslPolicy, sslCertificate, vpnGateway, vpnTunnel, instanceGroupManager, firewallPolicy, healthCheck, urlMap, targetHttpProxy, targetHttpsProxy, targetTcpProxy, packetMirroring, targetPool, serviceAttachment, networkEndpointGroup, interconnectAttachment

### Compute — new `zone()`
instanceGroup, instanceGroupManager, networkEndpointGroup

### Deprecated raw `*Url` fields (typed accessor already existed)
- `networkUrl` / `subnetworkUrl` on address, forwardingRule, subnetwork, instanceGroup, network.peering, route, networkEndpointGroup, idsService.endpoint
- `urlMapUrl` on targetHttpProxy, targetHttpsProxy
- `sslPolicyUrl` on targetHttpsProxy, targetSslProxy

### Serverless — new `serviceAccount()`
- `gcp.project.cloudFunction` (v1)
- `gcp.project.cloudFunctionV2.eventTrigger`
- `gcp.project.cloudBuildService.trigger.pubsubConfig`

## How it works

- New helpers `getRegionByUrl` / `getZoneByUrl` in `common.go` parse the project id straight out of the self-link URL and resolve the typed resource by enumerating `gcpCompute.GetRegions()` / `GetZones()`. Empty URL (global resource) returns `(nil, nil)` and the field is marked `StateIsSet | StateIsNull`, same as the existing `network()` pattern.
- Compute typed accessors live in a new `compute_typed_refs.go` to keep the file diff per-resource small.
- The deprecated raw URL/email fields remain populated by the existing creator functions — only the schema-level marker changes — so any audit that still references them keeps returning the same value.

## Example

\`\`\`
gcp.project.computeService.subnetworks.first { region.name region.status region.quotas['IN_USE_ADDRESSES'] }
\`\`\`

returns:

\`\`\`
{
  region.name: \"africa-south1\"
  region.status: \"UP\"
  region.quotas[IN_USE_ADDRESSES]: 575
}
\`\`\`

## Test plan

- [x] \`./mqlr generate providers/gcp/resources/gcp.lr --dist providers/gcp/resources\` produces no unintended schema churn (only the 26 expected new \`.lr.versions\` entries at 13.16.3)
- [x] \`make providers/build/gcp && make providers/install/gcp\`
- [x] \`gofmt -l providers/gcp/resources/\` clean
- [x] \`go build ./...\` in the gcp provider clean
- [x] Live verification against an authenticated project: typed refs resolve (e.g. \`subnetwork.region.name\` → \`\"africa-south1\"\`) and traverse into the region's own fields (\`region.status\`, \`region.quotas[...]\`)
- [x] Deprecated raw fields still return values (no breakage for existing audits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)