### PR TITLE
🧹 proxmox: bump go-git to v5.19.1

### DIFF
--- a/providers/proxmox/go.mod
+++ b/providers/proxmox/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/getsentry/sentry-go v0.46.2 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.0 // indirect
-	github.com/go-git/go-git/v5 v5.19.0 // indirect
+	github.com/go-git/go-git/v5 v5.19.1 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.5 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/providers/proxmox/go.sum
+++ b/providers/proxmox/go.sum
@@ -215,8 +215,8 @@ github.com/go-git/go-billy/v5 v5.9.0 h1:jItGXszUDRtR/AlferWPTMN4j38BQ88XnXKbilmm
 github.com/go-git/go-billy/v5 v5.9.0/go.mod h1:jCnQMLj9eUgGU7+ludSTYoZL/GGmii14RxKFj7ROgHw=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.19.0 h1:+WkVUQZSy/F1Gb13udrMKjIM2PrzsNfDKFSfo5tkMtc=
-github.com/go-git/go-git/v5 v5.19.0/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
+github.com/go-git/go-git/v5 v5.19.1 h1:nX27AnaU43/K5bKktKwgBmR9lawoYVe1Ckg0rgzzN00=
+github.com/go-git/go-git/v5 v5.19.1/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
 github.com/go-jose/go-jose/v3 v3.0.5 h1:BLLJWbC4nMZOfuPVxoZIxeYsn6Nl2r1fITaJ78UQlVQ=
 github.com/go-jose/go-jose/v3 v3.0.5/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=


### PR DESCRIPTION
## Summary
- Bumps `github.com/go-git/go-git/v5` from `5.19.0` → `5.19.1` in `providers/proxmox/go.mod`
- Clears the two open dependabot alerts on the repo:
  - [#767](https://github.com/mondoohq/mql/security/dependabot/767) (moderate) — Crafted repositories may modify main and submodule `.git` directories
  - [#725](https://github.com/mondoohq/mql/security/dependabot/725) (low) — Improper single-quote escaping in the SSH transport
- Proxmox was the only provider still on `5.19.0`; every other go.mod already pins `5.19.1`, so this brings it in line.

## Test plan
- [x] `go mod tidy` is clean in `providers/proxmox`
- [x] `go build ./...` passes in `providers/proxmox`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)