### PR TITLE
✨ oci: typed refs for image, vault, securityGroups, topics, compartment

### DIFF
--- a/providers/oci/resources/oci.lr
+++ b/providers/oci/resources/oci.lr
@@ -435,8 +435,10 @@ private oci.compute.instance @defaults("name") {
   compartment oci.compartment
   // Fault domain for fault tolerance (e.g., FAULT-DOMAIN-1)
   faultDomain string
-  // Image OCID used to launch the instance
-  imageId string
+  // DEPRECATED: use image() instead
+  imageId @maturity("deprecated") string
+  // Image used to launch the instance
+  image() oci.compute.image
   // Dedicated VM host OCID if running on dedicated infrastructure
   dedicatedVmHostId string
   // Platform security configuration (Secure Boot, TPM, Measured Boot, memory encryption)
@@ -467,8 +469,10 @@ private oci.compute.vnic @defaults("name") {
   id string
   // VNIC display name
   name string
-  // Compartment OCID
-  compartmentID string
+  // DEPRECATED: use compartment() instead
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the VNIC
+  compartment() oci.compartment
   // Whether this is the primary VNIC
   isPrimary bool
   // Private IP address
@@ -481,8 +485,10 @@ private oci.compute.vnic @defaults("name") {
   hostnameLabel string
   // Subnet the VNIC is in
   subnet() oci.network.subnet
-  // Network Security Group OCIDs
-  nsgIds []string
+  // DEPRECATED: use securityGroups() instead
+  nsgIds @maturity("deprecated") []string
+  // Network Security Groups attached to the VNIC
+  securityGroups() []oci.network.networkSecurityGroup
   // Whether source/destination check is skipped
   skipSourceDestCheck bool
   // Lifecycle state (PROVISIONING, AVAILABLE, TERMINATING, TERMINATED)
@@ -527,8 +533,10 @@ private oci.compute.blockVolume @defaults("name") {
   id string
   // Block volume display name
   name string
-  // Compartment OCID containing the block volume
-  compartmentID string
+  // DEPRECATED: use compartment() instead
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the block volume
+  compartment() oci.compartment
   // Availability domain where the block volume is located
   availabilityDomain string
   // Size of the block volume in GBs
@@ -553,14 +561,18 @@ private oci.compute.bootVolume @defaults("name") {
   id string
   // Boot volume display name
   name string
-  // Compartment OCID containing the boot volume
-  compartmentID string
+  // DEPRECATED: use compartment() instead
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the boot volume
+  compartment() oci.compartment
   // Availability domain where the boot volume is located
   availabilityDomain string
   // Size of the boot volume in GBs
   sizeInGBs int
-  // Image OCID used to create the boot volume
-  imageId string
+  // DEPRECATED: use image() instead
+  imageId @maturity("deprecated") string
+  // Image used to create the boot volume
+  image() oci.compute.image
   // Boot volume lifecycle state (e.g., PROVISIONING, RESTORING, AVAILABLE, TERMINATING, TERMINATED, FAULTY)
   state string
   // KMS key for volume encryption
@@ -876,8 +888,10 @@ private oci.kms.vault @defaults("name") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  compartmentID string
+  // DEPRECATED: use compartment() instead
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the vault
+  compartment() oci.compartment
   // Vault type (DEFAULT, VIRTUAL_PRIVATE, EXTERNAL)
   vaultType string
   // Lifecycle state
@@ -898,10 +912,14 @@ private oci.kms.key @defaults("name") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  compartmentID string
-  // Parent vault OCID
-  vaultId string
+  // DEPRECATED: use compartment() instead
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the key
+  compartment() oci.compartment
+  // DEPRECATED: use vault() instead
+  vaultId @maturity("deprecated") string
+  // Parent vault containing the key
+  vault() oci.kms.vault
   // Key algorithm (AES, RSA, ECDSA)
   algorithm string
   // Protection mode (HSM, SOFTWARE, EXTERNAL)
@@ -924,10 +942,14 @@ private oci.kms.keyVersion @defaults("id") {
   id string
   // Master encryption key OCID
   keyId string
-  // Vault OCID
-  vaultId string
-  // Compartment OCID
-  compartmentID string
+  // DEPRECATED: use vault() instead
+  vaultId @maturity("deprecated") string
+  // Parent vault containing the key version
+  vault() oci.kms.vault
+  // DEPRECATED: use compartment() instead
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the key version
+  compartment() oci.compartment
   // Origin of the key material (INTERNAL, EXTERNAL)
   origin string
   // Lifecycle state
@@ -1074,8 +1096,10 @@ private oci.events.rule @defaults("name") {
   name string
   // Rule description
   description string
-  // Compartment OCID containing the rule
-  compartmentID string
+  // DEPRECATED: use compartment() instead
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the rule
+  compartment() oci.compartment
   // Event matching condition (JSON)
   condition string
   // Whether the rule is enabled
@@ -1243,8 +1267,10 @@ private oci.ons.topic @defaults("name") {
   name string
   // Topic description
   description string
-  // Compartment OCID containing the topic
-  compartmentID string
+  // DEPRECATED: use compartment() instead
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the topic
+  compartment() oci.compartment
   // Topic lifecycle state (e.g., ACTIVE, DELETING, CREATING)
   state string
   // Topic creation time
@@ -1298,8 +1324,10 @@ private oci.bastion.instance @defaults("name") {
   id string
   // Bastion display name
   name string
-  // Compartment OCID
-  compartmentID string
+  // DEPRECATED: use compartment() instead
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the bastion
+  compartment() oci.compartment
   // Bastion type (e.g., standard)
   bastionType string
   // Target VCN
@@ -1334,8 +1362,10 @@ private oci.monitoring.alarm @defaults("name") {
   id string
   // Alarm display name
   name string
-  // Compartment OCID
-  compartmentID string
+  // DEPRECATED: use compartment() instead
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the alarm
+  compartment() oci.compartment
   // Metric compartment OCID being monitored
   metricCompartmentId string
   // Metric namespace (e.g., oci_computeagent, oci_vcn)
@@ -1344,8 +1374,10 @@ private oci.monitoring.alarm @defaults("name") {
   query string
   // Alarm severity (CRITICAL, ERROR, WARNING, INFO)
   severity string
-  // List of notification destination OCIDs (ONS topics)
-  destinations []string
+  // DEPRECATED: use topics() instead
+  destinations @maturity("deprecated") []string
+  // Notification topics the alarm publishes to (resolved from destinations OCIDs)
+  topics() []oci.ons.topic
   // Whether the alarm is enabled
   isEnabled bool
   // Lifecycle state (e.g., ACTIVE, DELETING, DELETED)
@@ -1370,8 +1402,10 @@ private oci.vault.secret @defaults("name") {
   id string
   // Secret name
   name string
-  // Compartment OCID
-  compartmentID string
+  // DEPRECATED: use compartment() instead
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the secret
+  compartment() oci.compartment
   // Vault containing this secret
   kmsVault() oci.kms.vault
   // KMS key used for encryption
@@ -1995,10 +2029,14 @@ private oci.database.dbSystem @defaults("name") {
   kmsKey() oci.kms.key
   // Subnet the DB system is in
   subnet() oci.network.subnet
-  // Network Security Group OCIDs
-  nsgIds []string
-  // Backup network NSG OCIDs
-  backupNetworkNsgIds []string
+  // DEPRECATED: use securityGroups() instead
+  nsgIds @maturity("deprecated") []string
+  // Network Security Groups attached to the DB system
+  securityGroups() []oci.network.networkSecurityGroup
+  // DEPRECATED: use backupSecurityGroups() instead
+  backupNetworkNsgIds @maturity("deprecated") []string
+  // Network Security Groups attached to the backup network
+  backupSecurityGroups() []oci.network.networkSecurityGroup
   // Lifecycle state
   //
   // For example: PROVISIONING, AVAILABLE, UPDATING, TERMINATING, TERMINATED, FAILED, MIGRATED, MAINTENANCE_IN_PROGRESS, NEEDS_ATTENTION, UPGRADING.
@@ -2017,8 +2055,10 @@ private oci.database.autonomousDatabase @defaults("name") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  compartmentID string
+  // DEPRECATED: use compartment() instead
+  compartmentID @maturity("deprecated") string
+  // Compartment containing the autonomous database
+  compartment() oci.compartment
   // Database name
   dbName string
   // Database version
@@ -2057,8 +2097,10 @@ private oci.database.autonomousDatabase @defaults("name") {
   kmsVault() oci.kms.vault
   // Subnet for private endpoint
   subnet() oci.network.subnet
-  // Network Security Group OCIDs
-  nsgIds []string
+  // DEPRECATED: use securityGroups() instead
+  nsgIds @maturity("deprecated") []string
+  // Network Security Groups attached to the autonomous database
+  securityGroups() []oci.network.networkSecurityGroup
   // Private endpoint IP address
   privateEndpointIp string
   // Private endpoint label

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -1097,6 +1097,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.compute.instance.imageId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeInstance).GetImageId()).ToDataRes(types.String)
 	},
+	"oci.compute.instance.image": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciComputeInstance).GetImage()).ToDataRes(types.Resource("oci.compute.image"))
+	},
 	"oci.compute.instance.dedicatedVmHostId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeInstance).GetDedicatedVmHostId()).ToDataRes(types.String)
 	},
@@ -1139,6 +1142,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.compute.vnic.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeVnic).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.compute.vnic.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciComputeVnic).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.compute.vnic.isPrimary": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeVnic).GetIsPrimary()).ToDataRes(types.Bool)
 	},
@@ -1159,6 +1165,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.compute.vnic.nsgIds": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeVnic).GetNsgIds()).ToDataRes(types.Array(types.String))
+	},
+	"oci.compute.vnic.securityGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciComputeVnic).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("oci.network.networkSecurityGroup")))
 	},
 	"oci.compute.vnic.skipSourceDestCheck": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeVnic).GetSkipSourceDestCheck()).ToDataRes(types.Bool)
@@ -1217,6 +1226,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.compute.blockVolume.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeBlockVolume).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.compute.blockVolume.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciComputeBlockVolume).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.compute.blockVolume.availabilityDomain": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeBlockVolume).GetAvailabilityDomain()).ToDataRes(types.String)
 	},
@@ -1250,6 +1262,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.compute.bootVolume.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeBootVolume).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.compute.bootVolume.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciComputeBootVolume).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.compute.bootVolume.availabilityDomain": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeBootVolume).GetAvailabilityDomain()).ToDataRes(types.String)
 	},
@@ -1258,6 +1273,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.compute.bootVolume.imageId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeBootVolume).GetImageId()).ToDataRes(types.String)
+	},
+	"oci.compute.bootVolume.image": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciComputeBootVolume).GetImage()).ToDataRes(types.Resource("oci.compute.image"))
 	},
 	"oci.compute.bootVolume.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeBootVolume).GetState()).ToDataRes(types.String)
@@ -1619,6 +1637,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.kms.vault.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciKmsVault).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.kms.vault.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciKmsVault).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.kms.vault.vaultType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciKmsVault).GetVaultType()).ToDataRes(types.String)
 	},
@@ -1643,8 +1664,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.kms.key.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciKmsKey).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.kms.key.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciKmsKey).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.kms.key.vaultId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciKmsKey).GetVaultId()).ToDataRes(types.String)
+	},
+	"oci.kms.key.vault": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciKmsKey).GetVault()).ToDataRes(types.Resource("oci.kms.vault"))
 	},
 	"oci.kms.key.algorithm": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciKmsKey).GetAlgorithm()).ToDataRes(types.String)
@@ -1673,8 +1700,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.kms.keyVersion.vaultId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciKmsKeyVersion).GetVaultId()).ToDataRes(types.String)
 	},
+	"oci.kms.keyVersion.vault": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciKmsKeyVersion).GetVault()).ToDataRes(types.Resource("oci.kms.vault"))
+	},
 	"oci.kms.keyVersion.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciKmsKeyVersion).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.kms.keyVersion.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciKmsKeyVersion).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.kms.keyVersion.origin": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciKmsKeyVersion).GetOrigin()).ToDataRes(types.String)
@@ -1822,6 +1855,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.events.rule.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciEventsRule).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.events.rule.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciEventsRule).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.events.rule.condition": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciEventsRule).GetCondition()).ToDataRes(types.String)
@@ -2000,6 +2036,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.ons.topic.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOnsTopic).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.ons.topic.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciOnsTopic).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.ons.topic.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOnsTopic).GetState()).ToDataRes(types.String)
 	},
@@ -2042,6 +2081,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.bastion.instance.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciBastionInstance).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.bastion.instance.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciBastionInstance).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.bastion.instance.bastionType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciBastionInstance).GetBastionType()).ToDataRes(types.String)
 	},
@@ -2075,6 +2117,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.monitoring.alarm.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciMonitoringAlarm).GetCompartmentID()).ToDataRes(types.String)
 	},
+	"oci.monitoring.alarm.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciMonitoringAlarm).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
 	"oci.monitoring.alarm.metricCompartmentId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciMonitoringAlarm).GetMetricCompartmentId()).ToDataRes(types.String)
 	},
@@ -2089,6 +2134,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.monitoring.alarm.destinations": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciMonitoringAlarm).GetDestinations()).ToDataRes(types.Array(types.String))
+	},
+	"oci.monitoring.alarm.topics": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciMonitoringAlarm).GetTopics()).ToDataRes(types.Array(types.Resource("oci.ons.topic")))
 	},
 	"oci.monitoring.alarm.isEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciMonitoringAlarm).GetIsEnabled()).ToDataRes(types.Bool)
@@ -2107,6 +2155,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.vault.secret.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciVaultSecret).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.vault.secret.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciVaultSecret).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.vault.secret.kmsVault": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciVaultSecret).GetKmsVault()).ToDataRes(types.Resource("oci.kms.vault"))
@@ -2816,8 +2867,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.database.dbSystem.nsgIds": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseDbSystem).GetNsgIds()).ToDataRes(types.Array(types.String))
 	},
+	"oci.database.dbSystem.securityGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseDbSystem).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("oci.network.networkSecurityGroup")))
+	},
 	"oci.database.dbSystem.backupNetworkNsgIds": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseDbSystem).GetBackupNetworkNsgIds()).ToDataRes(types.Array(types.String))
+	},
+	"oci.database.dbSystem.backupSecurityGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseDbSystem).GetBackupSecurityGroups()).ToDataRes(types.Array(types.Resource("oci.network.networkSecurityGroup")))
 	},
 	"oci.database.dbSystem.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseDbSystem).GetState()).ToDataRes(types.String)
@@ -2839,6 +2896,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.database.autonomousDatabase.compartmentID": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabase).GetCompartmentID()).ToDataRes(types.String)
+	},
+	"oci.database.autonomousDatabase.compartment": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseAutonomousDatabase).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
 	"oci.database.autonomousDatabase.dbName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabase).GetDbName()).ToDataRes(types.String)
@@ -2899,6 +2959,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.database.autonomousDatabase.nsgIds": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabase).GetNsgIds()).ToDataRes(types.Array(types.String))
+	},
+	"oci.database.autonomousDatabase.securityGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseAutonomousDatabase).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("oci.network.networkSecurityGroup")))
 	},
 	"oci.database.autonomousDatabase.privateEndpointIp": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabase).GetPrivateEndpointIp()).ToDataRes(types.String)
@@ -4288,6 +4351,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciComputeInstance).ImageId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.compute.instance.image": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciComputeInstance).Image, ok = plugin.RawToTValue[*mqlOciComputeImage](v.Value, v.Error)
+		return
+	},
 	"oci.compute.instance.dedicatedVmHostId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciComputeInstance).DedicatedVmHostId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -4348,6 +4415,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciComputeVnic).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.compute.vnic.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciComputeVnic).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.compute.vnic.isPrimary": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciComputeVnic).IsPrimary, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -4374,6 +4445,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.compute.vnic.nsgIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciComputeVnic).NsgIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"oci.compute.vnic.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciComputeVnic).SecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"oci.compute.vnic.skipSourceDestCheck": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4460,6 +4535,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciComputeBlockVolume).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.compute.blockVolume.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciComputeBlockVolume).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.compute.blockVolume.availabilityDomain": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciComputeBlockVolume).AvailabilityDomain, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -4508,6 +4587,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciComputeBootVolume).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.compute.bootVolume.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciComputeBootVolume).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.compute.bootVolume.availabilityDomain": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciComputeBootVolume).AvailabilityDomain, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -4518,6 +4601,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.compute.bootVolume.imageId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciComputeBootVolume).ImageId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.compute.bootVolume.image": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciComputeBootVolume).Image, ok = plugin.RawToTValue[*mqlOciComputeImage](v.Value, v.Error)
 		return
 	},
 	"oci.compute.bootVolume.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5052,6 +5139,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciKmsVault).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.kms.vault.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciKmsVault).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.kms.vault.vaultType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciKmsVault).VaultType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5088,8 +5179,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciKmsKey).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.kms.key.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciKmsKey).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.kms.key.vaultId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciKmsKey).VaultId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.kms.key.vault": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciKmsKey).Vault, ok = plugin.RawToTValue[*mqlOciKmsVault](v.Value, v.Error)
 		return
 	},
 	"oci.kms.key.algorithm": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5132,8 +5231,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciKmsKeyVersion).VaultId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.kms.keyVersion.vault": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciKmsKeyVersion).Vault, ok = plugin.RawToTValue[*mqlOciKmsVault](v.Value, v.Error)
+		return
+	},
 	"oci.kms.keyVersion.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciKmsKeyVersion).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.kms.keyVersion.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciKmsKeyVersion).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.kms.keyVersion.origin": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5358,6 +5465,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.events.rule.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciEventsRule).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.events.rule.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciEventsRule).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.events.rule.condition": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5628,6 +5739,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciOnsTopic).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.ons.topic.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciOnsTopic).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.ons.topic.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciOnsTopic).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5700,6 +5815,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciBastionInstance).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.bastion.instance.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciBastionInstance).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.bastion.instance.bastionType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciBastionInstance).BastionType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5752,6 +5871,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciMonitoringAlarm).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.monitoring.alarm.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciMonitoringAlarm).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
 	"oci.monitoring.alarm.metricCompartmentId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciMonitoringAlarm).MetricCompartmentId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5770,6 +5893,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.monitoring.alarm.destinations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciMonitoringAlarm).Destinations, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"oci.monitoring.alarm.topics": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciMonitoringAlarm).Topics, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"oci.monitoring.alarm.isEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5802,6 +5929,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.vault.secret.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciVaultSecret).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.vault.secret.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciVaultSecret).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.vault.secret.kmsVault": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6844,8 +6975,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciDatabaseDbSystem).NsgIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"oci.database.dbSystem.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseDbSystem).SecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"oci.database.dbSystem.backupNetworkNsgIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDatabaseDbSystem).BackupNetworkNsgIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"oci.database.dbSystem.backupSecurityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseDbSystem).BackupSecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"oci.database.dbSystem.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6878,6 +7017,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.database.autonomousDatabase.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDatabaseAutonomousDatabase).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.database.autonomousDatabase.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseAutonomousDatabase).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
 	},
 	"oci.database.autonomousDatabase.dbName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6958,6 +7101,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.database.autonomousDatabase.nsgIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDatabaseAutonomousDatabase).NsgIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"oci.database.autonomousDatabase.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseAutonomousDatabase).SecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"oci.database.autonomousDatabase.privateEndpointIp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9837,6 +9984,7 @@ type mqlOciComputeInstance struct {
 	Compartment              plugin.TValue[*mqlOciCompartment]
 	FaultDomain              plugin.TValue[string]
 	ImageId                  plugin.TValue[string]
+	Image                    plugin.TValue[*mqlOciComputeImage]
 	DedicatedVmHostId        plugin.TValue[string]
 	PlatformConfig           plugin.TValue[any]
 	LaunchOptions            plugin.TValue[any]
@@ -9927,6 +10075,22 @@ func (c *mqlOciComputeInstance) GetImageId() *plugin.TValue[string] {
 	return &c.ImageId
 }
 
+func (c *mqlOciComputeInstance) GetImage() *plugin.TValue[*mqlOciComputeImage] {
+	return plugin.GetOrCompute[*mqlOciComputeImage](&c.Image, func() (*mqlOciComputeImage, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.compute.instance", c.__id, "image")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciComputeImage), nil
+			}
+		}
+
+		return c.image()
+	})
+}
+
 func (c *mqlOciComputeInstance) GetDedicatedVmHostId() *plugin.TValue[string] {
 	return &c.DedicatedVmHostId
 }
@@ -9991,6 +10155,7 @@ type mqlOciComputeVnic struct {
 	Id                  plugin.TValue[string]
 	Name                plugin.TValue[string]
 	CompartmentID       plugin.TValue[string]
+	Compartment         plugin.TValue[*mqlOciCompartment]
 	IsPrimary           plugin.TValue[bool]
 	PrivateIp           plugin.TValue[string]
 	PublicIp            plugin.TValue[string]
@@ -9998,6 +10163,7 @@ type mqlOciComputeVnic struct {
 	HostnameLabel       plugin.TValue[string]
 	Subnet              plugin.TValue[*mqlOciNetworkSubnet]
 	NsgIds              plugin.TValue[[]any]
+	SecurityGroups      plugin.TValue[[]any]
 	SkipSourceDestCheck plugin.TValue[bool]
 	State               plugin.TValue[string]
 	Created             plugin.TValue[*time.Time]
@@ -10054,6 +10220,22 @@ func (c *mqlOciComputeVnic) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
 }
 
+func (c *mqlOciComputeVnic) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.compute.vnic", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciComputeVnic) GetIsPrimary() *plugin.TValue[bool] {
 	return &c.IsPrimary
 }
@@ -10092,6 +10274,22 @@ func (c *mqlOciComputeVnic) GetSubnet() *plugin.TValue[*mqlOciNetworkSubnet] {
 
 func (c *mqlOciComputeVnic) GetNsgIds() *plugin.TValue[[]any] {
 	return &c.NsgIds
+}
+
+func (c *mqlOciComputeVnic) GetSecurityGroups() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.SecurityGroups, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.compute.vnic", c.__id, "securityGroups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.securityGroups()
+	})
 }
 
 func (c *mqlOciComputeVnic) GetSkipSourceDestCheck() *plugin.TValue[bool] {
@@ -10221,6 +10419,7 @@ type mqlOciComputeBlockVolume struct {
 	Id                 plugin.TValue[string]
 	Name               plugin.TValue[string]
 	CompartmentID      plugin.TValue[string]
+	Compartment        plugin.TValue[*mqlOciCompartment]
 	AvailabilityDomain plugin.TValue[string]
 	SizeInGBs          plugin.TValue[int64]
 	VpusPerGB          plugin.TValue[int64]
@@ -10280,6 +10479,22 @@ func (c *mqlOciComputeBlockVolume) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
 }
 
+func (c *mqlOciComputeBlockVolume) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.compute.blockVolume", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciComputeBlockVolume) GetAvailabilityDomain() *plugin.TValue[string] {
 	return &c.AvailabilityDomain
 }
@@ -10332,9 +10547,11 @@ type mqlOciComputeBootVolume struct {
 	Id                 plugin.TValue[string]
 	Name               plugin.TValue[string]
 	CompartmentID      plugin.TValue[string]
+	Compartment        plugin.TValue[*mqlOciCompartment]
 	AvailabilityDomain plugin.TValue[string]
 	SizeInGBs          plugin.TValue[int64]
 	ImageId            plugin.TValue[string]
+	Image              plugin.TValue[*mqlOciComputeImage]
 	State              plugin.TValue[string]
 	KmsKey             plugin.TValue[*mqlOciKmsKey]
 	Created            plugin.TValue[*time.Time]
@@ -10389,6 +10606,22 @@ func (c *mqlOciComputeBootVolume) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
 }
 
+func (c *mqlOciComputeBootVolume) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.compute.bootVolume", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciComputeBootVolume) GetAvailabilityDomain() *plugin.TValue[string] {
 	return &c.AvailabilityDomain
 }
@@ -10399,6 +10632,22 @@ func (c *mqlOciComputeBootVolume) GetSizeInGBs() *plugin.TValue[int64] {
 
 func (c *mqlOciComputeBootVolume) GetImageId() *plugin.TValue[string] {
 	return &c.ImageId
+}
+
+func (c *mqlOciComputeBootVolume) GetImage() *plugin.TValue[*mqlOciComputeImage] {
+	return plugin.GetOrCompute[*mqlOciComputeImage](&c.Image, func() (*mqlOciComputeImage, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.compute.bootVolume", c.__id, "image")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciComputeImage), nil
+			}
+		}
+
+		return c.image()
+	})
 }
 
 func (c *mqlOciComputeBootVolume) GetState() *plugin.TValue[string] {
@@ -11815,6 +12064,7 @@ type mqlOciKmsVault struct {
 	Id                 plugin.TValue[string]
 	Name               plugin.TValue[string]
 	CompartmentID      plugin.TValue[string]
+	Compartment        plugin.TValue[*mqlOciCompartment]
 	VaultType          plugin.TValue[string]
 	State              plugin.TValue[string]
 	ManagementEndpoint plugin.TValue[string]
@@ -11871,6 +12121,22 @@ func (c *mqlOciKmsVault) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
 }
 
+func (c *mqlOciKmsVault) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.kms.vault", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciKmsVault) GetVaultType() *plugin.TValue[string] {
 	return &c.VaultType
 }
@@ -11911,7 +12177,9 @@ type mqlOciKmsKey struct {
 	Id                    plugin.TValue[string]
 	Name                  plugin.TValue[string]
 	CompartmentID         plugin.TValue[string]
+	Compartment           plugin.TValue[*mqlOciCompartment]
 	VaultId               plugin.TValue[string]
+	Vault                 plugin.TValue[*mqlOciKmsVault]
 	Algorithm             plugin.TValue[string]
 	ProtectionMode        plugin.TValue[string]
 	State                 plugin.TValue[string]
@@ -11969,8 +12237,40 @@ func (c *mqlOciKmsKey) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
 }
 
+func (c *mqlOciKmsKey) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.kms.key", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciKmsKey) GetVaultId() *plugin.TValue[string] {
 	return &c.VaultId
+}
+
+func (c *mqlOciKmsKey) GetVault() *plugin.TValue[*mqlOciKmsVault] {
+	return plugin.GetOrCompute[*mqlOciKmsVault](&c.Vault, func() (*mqlOciKmsVault, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.kms.key", c.__id, "vault")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciKmsVault), nil
+			}
+		}
+
+		return c.vault()
+	})
 }
 
 func (c *mqlOciKmsKey) GetAlgorithm() *plugin.TValue[string] {
@@ -12017,7 +12317,9 @@ type mqlOciKmsKeyVersion struct {
 	Id             plugin.TValue[string]
 	KeyId          plugin.TValue[string]
 	VaultId        plugin.TValue[string]
+	Vault          plugin.TValue[*mqlOciKmsVault]
 	CompartmentID  plugin.TValue[string]
+	Compartment    plugin.TValue[*mqlOciCompartment]
 	Origin         plugin.TValue[string]
 	State          plugin.TValue[string]
 	IsAutoRotated  plugin.TValue[bool]
@@ -12074,8 +12376,40 @@ func (c *mqlOciKmsKeyVersion) GetVaultId() *plugin.TValue[string] {
 	return &c.VaultId
 }
 
+func (c *mqlOciKmsKeyVersion) GetVault() *plugin.TValue[*mqlOciKmsVault] {
+	return plugin.GetOrCompute[*mqlOciKmsVault](&c.Vault, func() (*mqlOciKmsVault, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.kms.keyVersion", c.__id, "vault")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciKmsVault), nil
+			}
+		}
+
+		return c.vault()
+	})
+}
+
 func (c *mqlOciKmsKeyVersion) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciKmsKeyVersion) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.kms.keyVersion", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciKmsKeyVersion) GetOrigin() *plugin.TValue[string] {
@@ -12661,6 +12995,7 @@ type mqlOciEventsRule struct {
 	Name          plugin.TValue[string]
 	Description   plugin.TValue[string]
 	CompartmentID plugin.TValue[string]
+	Compartment   plugin.TValue[*mqlOciCompartment]
 	Condition     plugin.TValue[string]
 	IsEnabled     plugin.TValue[bool]
 	State         plugin.TValue[string]
@@ -12719,6 +13054,22 @@ func (c *mqlOciEventsRule) GetDescription() *plugin.TValue[string] {
 
 func (c *mqlOciEventsRule) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciEventsRule) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.events.rule", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciEventsRule) GetCondition() *plugin.TValue[string] {
@@ -13412,6 +13763,7 @@ type mqlOciOnsTopic struct {
 	Name          plugin.TValue[string]
 	Description   plugin.TValue[string]
 	CompartmentID plugin.TValue[string]
+	Compartment   plugin.TValue[*mqlOciCompartment]
 	State         plugin.TValue[string]
 	Created       plugin.TValue[*time.Time]
 	Subscriptions plugin.TValue[[]any]
@@ -13468,6 +13820,22 @@ func (c *mqlOciOnsTopic) GetDescription() *plugin.TValue[string] {
 
 func (c *mqlOciOnsTopic) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciOnsTopic) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.ons.topic", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciOnsTopic) GetState() *plugin.TValue[string] {
@@ -13700,6 +14068,7 @@ type mqlOciBastionInstance struct {
 	Id             plugin.TValue[string]
 	Name           plugin.TValue[string]
 	CompartmentID  plugin.TValue[string]
+	Compartment    plugin.TValue[*mqlOciCompartment]
 	BastionType    plugin.TValue[string]
 	TargetVcn      plugin.TValue[*mqlOciNetworkVcn]
 	TargetSubnet   plugin.TValue[*mqlOciNetworkSubnet]
@@ -13756,6 +14125,22 @@ func (c *mqlOciBastionInstance) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciBastionInstance) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciBastionInstance) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.bastion.instance", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciBastionInstance) GetBastionType() *plugin.TValue[string] {
@@ -13879,11 +14264,13 @@ type mqlOciMonitoringAlarm struct {
 	Id                  plugin.TValue[string]
 	Name                plugin.TValue[string]
 	CompartmentID       plugin.TValue[string]
+	Compartment         plugin.TValue[*mqlOciCompartment]
 	MetricCompartmentId plugin.TValue[string]
 	Namespace           plugin.TValue[string]
 	Query               plugin.TValue[string]
 	Severity            plugin.TValue[string]
 	Destinations        plugin.TValue[[]any]
+	Topics              plugin.TValue[[]any]
 	IsEnabled           plugin.TValue[bool]
 	State               plugin.TValue[string]
 }
@@ -13937,6 +14324,22 @@ func (c *mqlOciMonitoringAlarm) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
 }
 
+func (c *mqlOciMonitoringAlarm) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.monitoring.alarm", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
+}
+
 func (c *mqlOciMonitoringAlarm) GetMetricCompartmentId() *plugin.TValue[string] {
 	return &c.MetricCompartmentId
 }
@@ -13955,6 +14358,22 @@ func (c *mqlOciMonitoringAlarm) GetSeverity() *plugin.TValue[string] {
 
 func (c *mqlOciMonitoringAlarm) GetDestinations() *plugin.TValue[[]any] {
 	return &c.Destinations
+}
+
+func (c *mqlOciMonitoringAlarm) GetTopics() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Topics, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.monitoring.alarm", c.__id, "topics")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.topics()
+	})
 }
 
 func (c *mqlOciMonitoringAlarm) GetIsEnabled() *plugin.TValue[bool] {
@@ -14034,6 +14453,7 @@ type mqlOciVaultSecret struct {
 	Id                         plugin.TValue[string]
 	Name                       plugin.TValue[string]
 	CompartmentID              plugin.TValue[string]
+	Compartment                plugin.TValue[*mqlOciCompartment]
 	KmsVault                   plugin.TValue[*mqlOciKmsVault]
 	KmsKey                     plugin.TValue[*mqlOciKmsKey]
 	Description                plugin.TValue[string]
@@ -14096,6 +14516,22 @@ func (c *mqlOciVaultSecret) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciVaultSecret) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciVaultSecret) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.vault.secret", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciVaultSecret) GetKmsVault() *plugin.TValue[*mqlOciKmsVault] {
@@ -16650,7 +17086,9 @@ type mqlOciDatabaseDbSystem struct {
 	KmsKey               plugin.TValue[*mqlOciKmsKey]
 	Subnet               plugin.TValue[*mqlOciNetworkSubnet]
 	NsgIds               plugin.TValue[[]any]
+	SecurityGroups       plugin.TValue[[]any]
 	BackupNetworkNsgIds  plugin.TValue[[]any]
+	BackupSecurityGroups plugin.TValue[[]any]
 	State                plugin.TValue[string]
 	Created              plugin.TValue[*time.Time]
 	FreeformTags         plugin.TValue[map[string]any]
@@ -16786,8 +17224,40 @@ func (c *mqlOciDatabaseDbSystem) GetNsgIds() *plugin.TValue[[]any] {
 	return &c.NsgIds
 }
 
+func (c *mqlOciDatabaseDbSystem) GetSecurityGroups() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.SecurityGroups, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.database.dbSystem", c.__id, "securityGroups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.securityGroups()
+	})
+}
+
 func (c *mqlOciDatabaseDbSystem) GetBackupNetworkNsgIds() *plugin.TValue[[]any] {
 	return &c.BackupNetworkNsgIds
+}
+
+func (c *mqlOciDatabaseDbSystem) GetBackupSecurityGroups() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.BackupSecurityGroups, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.database.dbSystem", c.__id, "backupSecurityGroups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.backupSecurityGroups()
+	})
 }
 
 func (c *mqlOciDatabaseDbSystem) GetState() *plugin.TValue[string] {
@@ -16814,6 +17284,7 @@ type mqlOciDatabaseAutonomousDatabase struct {
 	Id                       plugin.TValue[string]
 	Name                     plugin.TValue[string]
 	CompartmentID            plugin.TValue[string]
+	Compartment              plugin.TValue[*mqlOciCompartment]
 	DbName                   plugin.TValue[string]
 	DbVersion                plugin.TValue[string]
 	DbWorkload               plugin.TValue[string]
@@ -16834,6 +17305,7 @@ type mqlOciDatabaseAutonomousDatabase struct {
 	KmsVault                 plugin.TValue[*mqlOciKmsVault]
 	Subnet                   plugin.TValue[*mqlOciNetworkSubnet]
 	NsgIds                   plugin.TValue[[]any]
+	SecurityGroups           plugin.TValue[[]any]
 	PrivateEndpointIp        plugin.TValue[string]
 	PrivateEndpointLabel     plugin.TValue[string]
 	ConnectionUrls           plugin.TValue[any]
@@ -16891,6 +17363,22 @@ func (c *mqlOciDatabaseAutonomousDatabase) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciDatabaseAutonomousDatabase) GetCompartmentID() *plugin.TValue[string] {
 	return &c.CompartmentID
+}
+
+func (c *mqlOciDatabaseAutonomousDatabase) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
+	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.database.autonomousDatabase", c.__id, "compartment")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciCompartment), nil
+			}
+		}
+
+		return c.compartment()
+	})
 }
 
 func (c *mqlOciDatabaseAutonomousDatabase) GetDbName() *plugin.TValue[string] {
@@ -17007,6 +17495,22 @@ func (c *mqlOciDatabaseAutonomousDatabase) GetSubnet() *plugin.TValue[*mqlOciNet
 
 func (c *mqlOciDatabaseAutonomousDatabase) GetNsgIds() *plugin.TValue[[]any] {
 	return &c.NsgIds
+}
+
+func (c *mqlOciDatabaseAutonomousDatabase) GetSecurityGroups() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.SecurityGroups, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.database.autonomousDatabase", c.__id, "securityGroups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.securityGroups()
+	})
 }
 
 func (c *mqlOciDatabaseAutonomousDatabase) GetPrivateEndpointIp() *plugin.TValue[string] {

--- a/providers/oci/resources/oci.lr.versions
+++ b/providers/oci/resources/oci.lr.versions
@@ -64,6 +64,7 @@ oci.bastion 13.0.6
 oci.bastion.bastions 13.0.6
 oci.bastion.instance 13.0.6
 oci.bastion.instance.bastionType 13.0.6
+oci.bastion.instance.compartment 13.6.2
 oci.bastion.instance.compartmentID 13.0.6
 oci.bastion.instance.created 13.0.6
 oci.bastion.instance.dnsProxyStatus 13.0.6
@@ -189,6 +190,7 @@ oci.compartments 9.0.0
 oci.compute 9.0.0
 oci.compute.blockVolume 13.0.6
 oci.compute.blockVolume.availabilityDomain 13.0.6
+oci.compute.blockVolume.compartment 13.6.2
 oci.compute.blockVolume.compartmentID 13.0.6
 oci.compute.blockVolume.created 13.0.6
 oci.compute.blockVolume.id 13.0.6
@@ -202,9 +204,11 @@ oci.compute.blockVolume.vpusPerGB 13.0.6
 oci.compute.blockVolumes 13.0.6
 oci.compute.bootVolume 13.0.6
 oci.compute.bootVolume.availabilityDomain 13.0.6
+oci.compute.bootVolume.compartment 13.6.2
 oci.compute.bootVolume.compartmentID 13.0.6
 oci.compute.bootVolume.created 13.0.6
 oci.compute.bootVolume.id 13.0.6
+oci.compute.bootVolume.image 13.6.2
 oci.compute.bootVolume.imageId 13.0.6
 oci.compute.bootVolume.kmsKey 13.0.6
 oci.compute.bootVolume.name 13.0.6
@@ -233,6 +237,7 @@ oci.compute.instance.definedTags 11.1.0
 oci.compute.instance.faultDomain 11.1.0
 oci.compute.instance.freeformTags 11.1.0
 oci.compute.instance.id 9.0.0
+oci.compute.instance.image 13.6.2
 oci.compute.instance.imageId 11.1.0
 oci.compute.instance.instanceOptions 13.0.6
 oci.compute.instance.launchOptions 13.0.6
@@ -248,6 +253,7 @@ oci.compute.instance.timeMaintenanceRebootDue 13.0.6
 oci.compute.instance.vnics 13.1.1
 oci.compute.instances 9.0.0
 oci.compute.vnic 13.1.1
+oci.compute.vnic.compartment 13.6.2
 oci.compute.vnic.compartmentID 13.1.1
 oci.compute.vnic.created 13.1.1
 oci.compute.vnic.definedTags 13.1.1
@@ -260,6 +266,7 @@ oci.compute.vnic.name 13.1.1
 oci.compute.vnic.nsgIds 13.1.1
 oci.compute.vnic.privateIp 13.1.1
 oci.compute.vnic.publicIp 13.1.1
+oci.compute.vnic.securityGroups 13.6.2
 oci.compute.vnic.skipSourceDestCheck 13.1.1
 oci.compute.vnic.state 13.1.1
 oci.compute.vnic.subnet 13.1.1
@@ -399,6 +406,7 @@ oci.dataSafe.userAssessments 13.5.5
 oci.database 13.1.1
 oci.database.autonomousDatabase 13.1.1
 oci.database.autonomousDatabase.backups 13.4.1
+oci.database.autonomousDatabase.compartment 13.6.2
 oci.database.autonomousDatabase.compartmentID 13.1.1
 oci.database.autonomousDatabase.connectionUrls 13.3.1
 oci.database.autonomousDatabase.cpuCoreCount 13.1.1
@@ -426,6 +434,7 @@ oci.database.autonomousDatabase.openMode 13.1.1
 oci.database.autonomousDatabase.permissionLevel 13.1.1
 oci.database.autonomousDatabase.privateEndpointIp 13.1.1
 oci.database.autonomousDatabase.privateEndpointLabel 13.1.1
+oci.database.autonomousDatabase.securityGroups 13.6.2
 oci.database.autonomousDatabase.state 13.1.1
 oci.database.autonomousDatabase.subnet 13.1.1
 oci.database.autonomousDatabase.whitelistedIps 13.1.1
@@ -475,6 +484,7 @@ oci.database.backups 13.4.1
 oci.database.dbSystem 13.1.1
 oci.database.dbSystem.availabilityDomain 13.1.1
 oci.database.dbSystem.backupNetworkNsgIds 13.1.1
+oci.database.dbSystem.backupSecurityGroups 13.6.2
 oci.database.dbSystem.compartmentID 13.1.1
 oci.database.dbSystem.cpuCoreCount 13.1.1
 oci.database.dbSystem.created 13.1.1
@@ -491,6 +501,7 @@ oci.database.dbSystem.licenseModel 13.1.1
 oci.database.dbSystem.name 13.1.1
 oci.database.dbSystem.nodeCount 13.1.1
 oci.database.dbSystem.nsgIds 13.1.1
+oci.database.dbSystem.securityGroups 13.6.2
 oci.database.dbSystem.shape 13.1.1
 oci.database.dbSystem.state 13.1.1
 oci.database.dbSystem.subnet 13.1.1
@@ -499,6 +510,7 @@ oci.database.dbSystems 13.1.1
 oci.events 13.0.6
 oci.events.rule 13.0.6
 oci.events.rule.actions 13.0.6
+oci.events.rule.compartment 13.6.2
 oci.events.rule.compartmentID 13.0.6
 oci.events.rule.condition 13.0.6
 oci.events.rule.created 13.0.6
@@ -702,6 +714,7 @@ oci.identity.users 9.0.0
 oci.kms 13.0.6
 oci.kms.key 13.0.6
 oci.kms.key.algorithm 13.0.6
+oci.kms.key.compartment 13.6.2
 oci.kms.key.compartmentID 13.0.6
 oci.kms.key.created 13.0.6
 oci.kms.key.id 13.0.6
@@ -710,8 +723,10 @@ oci.kms.key.keyVersions 13.1.1
 oci.kms.key.name 13.0.6
 oci.kms.key.protectionMode 13.0.6
 oci.kms.key.state 13.0.6
+oci.kms.key.vault 13.6.2
 oci.kms.key.vaultId 13.0.6
 oci.kms.keyVersion 13.1.1
+oci.kms.keyVersion.compartment 13.6.2
 oci.kms.keyVersion.compartmentID 13.1.1
 oci.kms.keyVersion.created 13.1.1
 oci.kms.keyVersion.id 13.1.1
@@ -720,8 +735,10 @@ oci.kms.keyVersion.keyId 13.1.1
 oci.kms.keyVersion.origin 13.1.1
 oci.kms.keyVersion.state 13.1.1
 oci.kms.keyVersion.timeOfDeletion 13.1.1
+oci.kms.keyVersion.vault 13.6.2
 oci.kms.keyVersion.vaultId 13.1.1
 oci.kms.vault 13.0.6
+oci.kms.vault.compartment 13.6.2
 oci.kms.vault.compartmentID 13.0.6
 oci.kms.vault.created 13.0.6
 oci.kms.vault.id 13.0.6
@@ -783,6 +800,7 @@ oci.logging.logGroup.state 13.0.6
 oci.logging.logGroups 13.0.6
 oci.monitoring 13.0.6
 oci.monitoring.alarm 13.0.6
+oci.monitoring.alarm.compartment 13.6.2
 oci.monitoring.alarm.compartmentID 13.0.6
 oci.monitoring.alarm.destinations 13.0.6
 oci.monitoring.alarm.id 13.0.6
@@ -793,6 +811,7 @@ oci.monitoring.alarm.namespace 13.0.6
 oci.monitoring.alarm.query 13.0.6
 oci.monitoring.alarm.severity 13.0.6
 oci.monitoring.alarm.state 13.0.6
+oci.monitoring.alarm.topics 13.6.2
 oci.monitoring.alarms 13.0.6
 oci.network 9.0.0
 oci.network.internetGateway 13.1.1
@@ -990,6 +1009,7 @@ oci.ons.subscription.protocol 13.0.6
 oci.ons.subscription.state 13.0.6
 oci.ons.subscription.topic 13.0.6
 oci.ons.topic 13.0.6
+oci.ons.topic.compartment 13.6.2
 oci.ons.topic.compartmentID 13.0.6
 oci.ons.topic.created 13.0.6
 oci.ons.topic.description 13.0.6
@@ -1035,6 +1055,7 @@ oci.tenancy.name 9.0.0
 oci.tenancy.retentionPeriod 9.0.0
 oci.vault 13.0.6
 oci.vault.secret 13.0.6
+oci.vault.secret.compartment 13.6.2
 oci.vault.secret.compartmentID 13.0.6
 oci.vault.secret.created 13.0.6
 oci.vault.secret.description 13.0.6

--- a/providers/oci/resources/typed_refs.go
+++ b/providers/oci/resources/typed_refs.go
@@ -1,0 +1,191 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// resolveOciImage resolves a typed image resource from an image OCID. Returns
+// (nil, nil) and marks the field as null when the OCID is empty.
+func resolveOciImage(runtime *plugin.Runtime, id string, field *plugin.TValue[*mqlOciComputeImage]) (*mqlOciComputeImage, error) {
+	if id == "" {
+		field.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(runtime, "oci.compute.image", map[string]*llx.RawData{
+		"id": llx.StringData(id),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOciComputeImage), nil
+}
+
+// resolveOciVault resolves a typed vault resource from a vault OCID. Returns
+// (nil, nil) and marks the field as null when the OCID is empty.
+func resolveOciVault(runtime *plugin.Runtime, id string, field *plugin.TValue[*mqlOciKmsVault]) (*mqlOciKmsVault, error) {
+	if id == "" {
+		field.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(runtime, "oci.kms.vault", map[string]*llx.RawData{
+		"id": llx.StringData(id),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOciKmsVault), nil
+}
+
+// resolveOciSecurityGroups resolves a list of typed network security group
+// resources from a list of NSG OCIDs. Empty list returns ([], nil).
+func resolveOciSecurityGroups(runtime *plugin.Runtime, ids []any) ([]any, error) {
+	out := make([]any, 0, len(ids))
+	for _, raw := range ids {
+		id, ok := raw.(string)
+		if !ok || id == "" {
+			continue
+		}
+		res, err := NewResource(runtime, "oci.network.networkSecurityGroup", map[string]*llx.RawData{
+			"id": llx.StringData(id),
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}
+
+// resolveOciTopics resolves a list of typed ONS topic resources from a list of
+// topic OCIDs. Non-topic OCIDs (alarms can target other destination types in
+// the future) are skipped silently.
+func resolveOciTopics(runtime *plugin.Runtime, ids []any) ([]any, error) {
+	out := make([]any, 0, len(ids))
+	for _, raw := range ids {
+		id, ok := raw.(string)
+		if !ok || id == "" {
+			continue
+		}
+		res, err := NewResource(runtime, "oci.ons.topic", map[string]*llx.RawData{
+			"id": llx.StringData(id),
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}
+
+// ----- compute -----
+
+func (o *mqlOciComputeInstance) image() (*mqlOciComputeImage, error) {
+	return resolveOciImage(o.MqlRuntime, o.ImageId.Data, &o.Image)
+}
+
+func (o *mqlOciComputeBootVolume) image() (*mqlOciComputeImage, error) {
+	return resolveOciImage(o.MqlRuntime, o.ImageId.Data, &o.Image)
+}
+
+func (o *mqlOciComputeBootVolume) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciComputeBlockVolume) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciComputeVnic) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciComputeVnic) securityGroups() ([]any, error) {
+	if o.NsgIds.Error != nil {
+		return nil, o.NsgIds.Error
+	}
+	return resolveOciSecurityGroups(o.MqlRuntime, o.NsgIds.Data)
+}
+
+// ----- kms -----
+
+func (o *mqlOciKmsVault) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciKmsKey) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciKmsKey) vault() (*mqlOciKmsVault, error) {
+	return resolveOciVault(o.MqlRuntime, o.VaultId.Data, &o.Vault)
+}
+
+func (o *mqlOciKmsKeyVersion) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciKmsKeyVersion) vault() (*mqlOciKmsVault, error) {
+	return resolveOciVault(o.MqlRuntime, o.VaultId.Data, &o.Vault)
+}
+
+// ----- events / ons / monitoring -----
+
+func (o *mqlOciEventsRule) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciOnsTopic) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciMonitoringAlarm) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciMonitoringAlarm) topics() ([]any, error) {
+	if o.Destinations.Error != nil {
+		return nil, o.Destinations.Error
+	}
+	return resolveOciTopics(o.MqlRuntime, o.Destinations.Data)
+}
+
+// ----- bastion / vault.secret -----
+
+func (o *mqlOciBastionInstance) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciVaultSecret) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+// ----- database -----
+
+func (o *mqlOciDatabaseDbSystem) securityGroups() ([]any, error) {
+	if o.NsgIds.Error != nil {
+		return nil, o.NsgIds.Error
+	}
+	return resolveOciSecurityGroups(o.MqlRuntime, o.NsgIds.Data)
+}
+
+func (o *mqlOciDatabaseDbSystem) backupSecurityGroups() ([]any, error) {
+	if o.BackupNetworkNsgIds.Error != nil {
+		return nil, o.BackupNetworkNsgIds.Error
+	}
+	return resolveOciSecurityGroups(o.MqlRuntime, o.BackupNetworkNsgIds.Data)
+}
+
+func (o *mqlOciDatabaseAutonomousDatabase) compartment() (*mqlOciCompartment, error) {
+	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+}
+
+func (o *mqlOciDatabaseAutonomousDatabase) securityGroups() ([]any, error) {
+	if o.NsgIds.Error != nil {
+		return nil, o.NsgIds.Error
+	}
+	return resolveOciSecurityGroups(o.MqlRuntime, o.NsgIds.Data)
+}


### PR DESCRIPTION
## Summary

Add typed accessors so audits can traverse from an OCI resource to its image, vault, network security groups, ONS topics, and compartment instead of dealing with raw OCID strings. The matching raw-OCID fields are kept and marked \`@maturity(\"deprecated\")\` so existing audits keep working — fully backwards-compatible.

## What changed

**Typed refs added** (each deprecates its raw-OCID counterpart):

- \`compute.instance.image()\` ← \`imageId\`
- \`compute.bootVolume.image()\` ← \`imageId\`
- \`compute.vnic.securityGroups()\` ← \`nsgIds\`
- \`database.dbSystem.securityGroups()\` / \`backupSecurityGroups()\` ← \`nsgIds\` / \`backupNetworkNsgIds\`
- \`database.autonomousDatabase.securityGroups()\` ← \`nsgIds\`
- \`kms.key.vault()\` and \`kms.keyVersion.vault()\` ← \`vaultId\`
- \`monitoring.alarm.topics()\` ← \`destinations\`

**Compartment backfill** — typed \`compartment()\` + deprecate \`compartmentID\` on:
- \`compute.vnic\`, \`compute.blockVolume\`, \`compute.bootVolume\`
- \`kms.vault\`, \`kms.key\`, \`kms.keyVersion\`
- \`events.rule\`, \`ons.topic\`, \`monitoring.alarm\`
- \`bastion.instance\`, \`vault.secret\`
- \`database.autonomousDatabase\`

## How it works

- All implementations live in a new \`providers/oci/resources/typed_refs.go\` to keep per-resource files clean.
- Four shared resolver helpers cover the new accessors: \`resolveOciImage\`, \`resolveOciVault\`, \`resolveOciSecurityGroups\`, \`resolveOciTopics\`. Compartment lookups reuse the pre-existing \`resolveOciCompartment\`.
- Each helper returns \`(nil, nil)\` and marks the field as \`StateIsSet | StateIsNull\` when the OCID is empty (or skips empty entries in list resolvers).
- 21 new \`.lr.versions\` entries at \`13.6.2\` (provider currently 13.6.1).
- No version bump to \`config.go\` per project convention.

## Backwards compatibility

All deprecations use \`@maturity(\"deprecated\")\` on the existing field. The field is still populated by the creator function — nothing the runtime does was changed. Existing audits that reference \`compartmentID\`, \`vaultId\`, \`nsgIds\`, \`imageId\`, or \`destinations\` will continue to return the same OCIDs. New audits should use the typed accessor.

## Example

\`\`\`
oci.kms.vaults.first { name compartmentID compartment.name }
\`\`\`

returns:

\`\`\`
{
  compartmentID: \"ocid1.tenancy.oc1..aaaaaaaath4...\"
  name: \"mql-test-vault\"
  compartment.name: \"tsmith84\"
}
\`\`\`

## Test plan

- [x] \`./mqlr generate providers/oci/resources/oci.lr --dist providers/oci/resources\` produces only the 21 expected new entries at \`13.6.2\`
- [x] \`make providers/build/oci && make providers/install/oci\`
- [x] \`gofmt -l providers/oci/resources/\` clean
- [x] \`go build ./...\` in the oci provider clean
- [x] \`go test ./resources/...\` passes
- [x] Live verification against an authenticated tenancy: \`oci.kms.vaults.first.compartment.name\` resolves to the compartment name; deprecated \`compartmentID\` still returns the OCID

🤖 Generated with [Claude Code](https://claude.com/claude-code)