### PR TITLE
✨ package: add license field (rpm, dpkg, apk, pacman)

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -21,6 +21,7 @@ alpn
 ams
 antispam
 aof
+APKINDEX
 apm
 apparmor
 appsettings

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -909,6 +909,15 @@ package @defaults("name version") {
 
   // Package vendor
   vendor string
+
+  // Package license
+  //
+  // SPDX license expression (or upstream-reported license string).
+  // Eagerly populated where the package manager has it inline (rpm
+  // %{LICENSE}, apk APKINDEX, pacman desc); fetched on demand for dpkg
+  // (parses /usr/share/doc/<pkg>/copyright). Empty when no source
+  // exists (e.g. Windows registry DisplayName).
+  license() string
 }
 
 // File installed by a package

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -2471,6 +2471,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"package.vendor": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPackage).GetVendor()).ToDataRes(types.String)
 	},
+	"package.license": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPackage).GetLicense()).ToDataRes(types.String)
+	},
 	"pkgFileInfo.path": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPkgFileInfo).GetPath()).ToDataRes(types.String)
 	},
@@ -8171,6 +8174,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"package.vendor": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlPackage).Vendor, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"package.license": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPackage).License, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"pkgFileInfo.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -19306,6 +19313,7 @@ type mqlPackage struct {
 	Outdated    plugin.TValue[bool]
 	Files       plugin.TValue[[]any]
 	Vendor      plugin.TValue[string]
+	License     plugin.TValue[string]
 }
 
 // createPackage creates a new instance of this resource
@@ -19421,6 +19429,12 @@ func (c *mqlPackage) GetFiles() *plugin.TValue[[]any] {
 
 func (c *mqlPackage) GetVendor() *plugin.TValue[string] {
 	return &c.Vendor
+}
+
+func (c *mqlPackage) GetLicense() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.License, func() (string, error) {
+		return c.license()
+	})
 }
 
 // mqlPkgFileInfo for the pkgFileInfo resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -1375,6 +1375,7 @@ package.epoch 9.0.0
 package.files 10.2.0
 package.format 9.0.0
 package.installed 9.0.0
+package.license 13.16.10
 package.name 9.0.0
 package.origin 9.0.0
 package.outdated 9.0.0

--- a/providers/os/resources/packages.go
+++ b/providers/os/resources/packages.go
@@ -219,7 +219,7 @@ func (x *mqlPackages) list() ([]any, error) {
 			cpes = append(cpes, cpe)
 		}
 
-		pkg, err := CreateResource(x.MqlRuntime, "package", map[string]*llx.RawData{
+		pkgArgs := map[string]*llx.RawData{
 			"name":        llx.StringData(osPkg.Name),
 			"version":     llx.StringData(osPkg.Version),
 			"available":   llx.StringData(available),
@@ -233,8 +233,17 @@ func (x *mqlPackages) list() ([]any, error) {
 			"purl":        llx.StringData(osPkg.PUrl),
 			"cpes":        llx.ArrayData(cpes, types.Resource("cpe")),
 			"vendor":      llx.StringData(osPkg.Vendor),
-			"license":     llx.StringData(osPkg.License),
-		})
+		}
+		// Only eagerly set license when the backend populated it (rpm,
+		// apk, pacman). dpkg leaves it empty here so the lazy `license()`
+		// method on mqlPackage can fire and read
+		// /usr/share/doc/<pkg>/copyright on demand. Setting "" here
+		// would short-circuit the GetOrCompute wrapper and the lazy
+		// fallback would never run.
+		if osPkg.License != "" {
+			pkgArgs["license"] = llx.StringData(osPkg.License)
+		}
+		pkg, err := CreateResource(x.MqlRuntime, "package", pkgArgs)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/os/resources/packages.go
+++ b/providers/os/resources/packages.go
@@ -77,6 +77,7 @@ func initPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 	res.Origin.State = plugin.StateIsSet | plugin.StateIsNull
 	res.Status.State = plugin.StateIsSet | plugin.StateIsNull
 	res.Files.State = plugin.StateIsSet | plugin.StateIsNull
+	res.License.State = plugin.StateIsSet | plugin.StateIsNull
 	res.__id, _ = res.id()
 	return nil, res, nil
 }
@@ -94,6 +95,22 @@ func (p *mqlPackage) outdated() (bool, error) {
 
 func (p *mqlPackage) origin() (string, error) {
 	return "", nil
+}
+
+// license is the lazy fallback for package managers that don't surface
+// license inline. Used today for dpkg, which keeps license metadata in
+// the per-package copyright file rather than in /var/lib/dpkg/status.
+// Other managers populate License eagerly during list() and never reach
+// this method (see plugin.GetOrCompute wrapper in the generated code).
+func (p *mqlPackage) license() (string, error) {
+	if p.Format.Data != packages.DpkgPkgFormat || p.Name.Data == "" {
+		return "", nil
+	}
+	conn, ok := p.MqlRuntime.Connection.(shared.Connection)
+	if !ok {
+		return "", nil
+	}
+	return packages.ParseDpkgCopyrightLicense(conn.FileSystem(), p.Name.Data), nil
 }
 
 func (p *mqlPackage) files() ([]any, error) {
@@ -216,6 +233,7 @@ func (x *mqlPackages) list() ([]any, error) {
 			"purl":        llx.StringData(osPkg.PUrl),
 			"cpes":        llx.ArrayData(cpes, types.Resource("cpe")),
 			"vendor":      llx.StringData(osPkg.Vendor),
+			"license":     llx.StringData(osPkg.License),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/os/resources/packages/apk_packages.go
+++ b/providers/os/resources/packages/apk_packages.go
@@ -105,6 +105,8 @@ func ParseApkDbPackages(pf *inventory.Platform, input io.Reader) []Package {
 			pkg.Origin = m[2] // origin
 		case "T":
 			pkg.Description = m[2] // description
+		case "L":
+			pkg.License = m[2] // license (SPDX expression)
 		}
 	}
 

--- a/providers/os/resources/packages/apk_packages_test.go
+++ b/providers/os/resources/packages/apk_packages_test.go
@@ -41,6 +41,7 @@ func TestAlpineApkdbParser(t *testing.T) {
 		Epoch:       "1510953106",
 		Arch:        "x86_64",
 		Description: "the musl c library (libc) implementation",
+		License:     "MIT",
 		Origin:      "musl",
 		PUrl:        "pkg:apk/alpine/musl@1510953106:1.1.18-r2?arch=x86_64&distro=alpine-3.7.0&epoch=1510953106",
 		CPEs: []string{
@@ -58,6 +59,7 @@ func TestAlpineApkdbParser(t *testing.T) {
 
 	p = Package{
 		Name:        "libressl2.6-libcrypto",
+		License:     "custom",
 		Version:     "1510257703:2.6.3-r0",
 		Epoch:       "1510257703",
 		Arch:        "x86_64",
@@ -79,6 +81,7 @@ func TestAlpineApkdbParser(t *testing.T) {
 
 	p = Package{
 		Name:        "libressl2.6-libssl",
+		License:     "custom",
 		Version:     "1510257703:2.6.3-r0",
 		Epoch:       "1510257703",
 		Arch:        "x86_64",
@@ -100,6 +103,7 @@ func TestAlpineApkdbParser(t *testing.T) {
 
 	p = Package{
 		Name:        "apk-tools",
+		License:     "GPL2",
 		Version:     "1515485577:2.8.2-r0",
 		Epoch:       "1515485577",
 		Arch:        "x86_64",
@@ -121,6 +125,7 @@ func TestAlpineApkdbParser(t *testing.T) {
 
 	p = Package{
 		Name:        "busybox",
+		License:     "GPL2",
 		Version:     "1513075346:1.27.2-r7",
 		Epoch:       "1513075346",
 		Arch:        "x86_64",
@@ -142,6 +147,7 @@ func TestAlpineApkdbParser(t *testing.T) {
 
 	p = Package{
 		Name:        "alpine-baselayout",
+		License:     "GPL2",
 		Version:     "1510075862:3.0.5-r2",
 		Epoch:       "1510075862",
 		Arch:        "x86_64",

--- a/providers/os/resources/packages/dpkg_packages.go
+++ b/providers/os/resources/packages/dpkg_packages.go
@@ -101,6 +101,49 @@ func ParseDpkgPackages(pf *inventory.Platform, input io.Reader) ([]Package, erro
 	return pkgs, nil
 }
 
+// ParseDpkgCopyrightLicense reads the per-package DEP-5 copyright file at
+// /usr/share/doc/<pkg>/copyright and returns the first top-level
+// `License:` value. Returns the empty string when the file is missing,
+// not DEP-5, or the License field is absent. Called lazily from the
+// `license()` method on the `package` resource — only when MQL actually
+// asks for the license, so we don't pay the per-package read cost on
+// every `packages` enumeration.
+//
+// DEP-5 reference: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+// In practice many older packages use free-form copyright files where
+// the License: field is absent; we return empty rather than guessing.
+func ParseDpkgCopyrightLicense(fs afero.Fs, pkgName string) string {
+	if fs == nil || pkgName == "" {
+		return ""
+	}
+	path := "/usr/share/doc/" + pkgName + "/copyright"
+	f, err := fs.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// We only care about the first top-level `License:` field — the
+		// summary one at file header. Per-paragraph `License:` lines
+		// (after a blank line) are file-specific and not the overall
+		// package license; bail at the first blank line.
+		if line == "" {
+			break
+		}
+		if strings.HasPrefix(line, "License:") {
+			val := strings.TrimSpace(strings.TrimPrefix(line, "License:"))
+			// DEP-5 allows multi-line license bodies indented under the
+			// short name; the short name is on the same line as
+			// `License:`. Return just that short name.
+			return val
+		}
+	}
+	return ""
+}
+
 var DPKG_UPDATE_REGEX = regexp.MustCompile(`^Inst\s([a-zA-Z0-9.\-_]+)\s\[([a-zA-Z0-9.\-\+]+)\]\s\(([a-zA-Z0-9.\-\+]+)\s*(.*)\)(.*)$`)
 
 func ParseDpkgUpdates(input io.Reader) (map[string]PackageUpdate, error) {

--- a/providers/os/resources/packages/dpkg_packages.go
+++ b/providers/os/resources/packages/dpkg_packages.go
@@ -102,16 +102,24 @@ func ParseDpkgPackages(pf *inventory.Platform, input io.Reader) ([]Package, erro
 }
 
 // ParseDpkgCopyrightLicense reads the per-package DEP-5 copyright file at
-// /usr/share/doc/<pkg>/copyright and returns the first top-level
-// `License:` value. Returns the empty string when the file is missing,
-// not DEP-5, or the License field is absent. Called lazily from the
-// `license()` method on the `package` resource — only when MQL actually
-// asks for the license, so we don't pay the per-package read cost on
-// every `packages` enumeration.
+// /usr/share/doc/<pkg>/copyright and returns the first `License:` value
+// found anywhere in the file. Returns the empty string when the file is
+// missing, not DEP-5, or no License field is present. Called lazily
+// from the `license()` method on the `package` resource — only when
+// MQL actually asks for the license, so we don't pay the per-package
+// read cost on every `packages` enumeration.
 //
 // DEP-5 reference: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-// In practice many older packages use free-form copyright files where
-// the License: field is absent; we return empty rather than guessing.
+// A top-level `License:` is rare in practice; most Ubuntu/Debian
+// packages carry their license expression in the first `Files: *`
+// paragraph (after the header's blank line). We scan the whole file
+// and take the first `License:` regardless of paragraph — that yields
+// the package's primary license for typical DEP-5 files and the only
+// license present for single-paragraph ones.
+//
+// Many older packages use free-form copyright files with no `License:`
+// field at all (just a `See /usr/share/common-licenses/X` pointer);
+// those return empty rather than us guessing.
 func ParseDpkgCopyrightLicense(fs afero.Fs, pkgName string) string {
 	if fs == nil || pkgName == "" {
 		return ""
@@ -126,19 +134,12 @@ func ParseDpkgCopyrightLicense(fs afero.Fs, pkgName string) string {
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := scanner.Text()
-		// We only care about the first top-level `License:` field — the
-		// summary one at file header. Per-paragraph `License:` lines
-		// (after a blank line) are file-specific and not the overall
-		// package license; bail at the first blank line.
-		if line == "" {
-			break
-		}
+		// DEP-5 allows multi-line license bodies indented under the
+		// short name; the short name is on the same line as
+		// `License:`. We only return that short name. Lines beginning
+		// with whitespace are continuation/body and are skipped.
 		if strings.HasPrefix(line, "License:") {
-			val := strings.TrimSpace(strings.TrimPrefix(line, "License:"))
-			// DEP-5 allows multi-line license bodies indented under the
-			// short name; the short name is on the same line as
-			// `License:`. Return just that short name.
-			return val
+			return strings.TrimSpace(strings.TrimPrefix(line, "License:"))
 		}
 	}
 	return ""

--- a/providers/os/resources/packages/dpkg_packages_test.go
+++ b/providers/os/resources/packages/dpkg_packages_test.go
@@ -6,6 +6,7 @@ package packages
 import (
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
@@ -172,4 +173,32 @@ func TestDpkgUpdateParser(t *testing.T) {
 	assert.Equal(t, "ncurses-bin", update.Name, "pkg name detected")
 	assert.Equal(t, "6.1-1ubuntu1", update.Version, "pkg version detected")
 	assert.Equal(t, "6.1-1ubuntu1.18.04", update.Available, "pkg available version detected")
+}
+
+func TestParseDpkgCopyrightLicense(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	// DEP-5 copyright file with a top-level License: field.
+	const dep5 = `Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: bash
+Source: https://www.gnu.org/software/bash/
+License: GPL-3+
+
+Files: *
+Copyright: 1989-2022 Free Software Foundation, Inc.
+License: GPL-3+
+`
+	require.NoError(t, afero.WriteFile(fs, "/usr/share/doc/bash/copyright", []byte(dep5), 0o644))
+
+	// Free-form copyright file (older packages) with no top-level License: header.
+	const freeform = `This package was debianized by John Doe <john@example.org>.
+See /usr/share/common-licenses/GPL-2 for the full license text.
+`
+	require.NoError(t, afero.WriteFile(fs, "/usr/share/doc/legacy/copyright", []byte(freeform), 0o644))
+
+	assert.Equal(t, "GPL-3+", ParseDpkgCopyrightLicense(fs, "bash"))
+	assert.Equal(t, "", ParseDpkgCopyrightLicense(fs, "legacy"))
+	assert.Equal(t, "", ParseDpkgCopyrightLicense(fs, "missing"))
+	assert.Equal(t, "", ParseDpkgCopyrightLicense(fs, ""))
+	assert.Equal(t, "", ParseDpkgCopyrightLicense(nil, "bash"))
 }

--- a/providers/os/resources/packages/dpkg_packages_test.go
+++ b/providers/os/resources/packages/dpkg_packages_test.go
@@ -178,25 +178,38 @@ func TestDpkgUpdateParser(t *testing.T) {
 func TestParseDpkgCopyrightLicense(t *testing.T) {
 	fs := afero.NewMemMapFs()
 
-	// DEP-5 copyright file with a top-level License: field.
-	const dep5 = `Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+	// DEP-5 copyright with header License: (rare but valid).
+	const headerOnly = `Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: bash
 Source: https://www.gnu.org/software/bash/
 License: GPL-3+
+`
+	require.NoError(t, afero.WriteFile(fs, "/usr/share/doc/bash/copyright", []byte(headerOnly), 0o644))
+
+	// DEP-5 with License: only in the first Files: paragraph — the
+	// common case for Debian/Ubuntu packages like apt and base-files.
+	const filesParagraph = `Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: apt
+Source: https://salsa.debian.org/apt-team/apt
 
 Files: *
-Copyright: 1989-2022 Free Software Foundation, Inc.
-License: GPL-3+
+Copyright: 1997, 1998, 1999, Jason Gilmore <jgg@debian.org>
+License: GPL-2+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License...
 `
-	require.NoError(t, afero.WriteFile(fs, "/usr/share/doc/bash/copyright", []byte(dep5), 0o644))
+	require.NoError(t, afero.WriteFile(fs, "/usr/share/doc/apt/copyright", []byte(filesParagraph), 0o644))
 
-	// Free-form copyright file (older packages) with no top-level License: header.
+	// Free-form copyright (older packages) with no License: field at
+	// all — just a pointer to common-licenses.
 	const freeform = `This package was debianized by John Doe <john@example.org>.
 See /usr/share/common-licenses/GPL-2 for the full license text.
 `
 	require.NoError(t, afero.WriteFile(fs, "/usr/share/doc/legacy/copyright", []byte(freeform), 0o644))
 
 	assert.Equal(t, "GPL-3+", ParseDpkgCopyrightLicense(fs, "bash"))
+	assert.Equal(t, "GPL-2+", ParseDpkgCopyrightLicense(fs, "apt"),
+		"License: in the first Files: paragraph (typical Ubuntu/Debian shape) must be surfaced")
 	assert.Equal(t, "", ParseDpkgCopyrightLicense(fs, "legacy"))
 	assert.Equal(t, "", ParseDpkgCopyrightLicense(fs, "missing"))
 	assert.Equal(t, "", ParseDpkgCopyrightLicense(fs, ""))

--- a/providers/os/resources/packages/packages.go
+++ b/providers/os/resources/packages/packages.go
@@ -48,6 +48,11 @@ type Package struct {
 
 	// This is used for the CPE generation and exposed via MQL
 	Vendor string `json:"vendor,omitempty"`
+
+	// SPDX license expression or upstream-reported license string.
+	// Empty when the backend has no source for it (e.g. Windows
+	// registry — DisplayName has no license field).
+	License string `json:"license,omitempty"`
 }
 
 type FileRecord struct {

--- a/providers/os/resources/packages/pacman_packages.go
+++ b/providers/os/resources/packages/pacman_packages.go
@@ -130,8 +130,14 @@ func parsePacmanDesc(pf *inventory.Platform, afs *afero.Afero, descPath string) 
 		Version:     version,
 		Arch:        fields["%ARCH%"],
 		Description: fields["%DESC%"],
-		Format:      PacmanPkgFormat,
-		PUrl:        purl.NewPackageURL(pf, purl.TypeAlpm, name, version).String(),
+		// Pacman desc files carry %LICENSE% as a multi-line block, one
+		// SPDX identifier per line; parsePacmanDescSections keeps only
+		// the first which is correct for most packages. The fast
+		// `pacman -Q` path doesn't surface license at all; that gap is
+		// expected and gets filled in only when the FS fallback runs.
+		License: fields["%LICENSE%"],
+		Format:  PacmanPkgFormat,
+		PUrl:    purl.NewPackageURL(pf, purl.TypeAlpm, name, version).String(),
 	}, nil
 }
 

--- a/providers/os/resources/packages/pacman_packages_test.go
+++ b/providers/os/resources/packages/pacman_packages_test.go
@@ -121,6 +121,7 @@ func TestParsePacmanDB(t *testing.T) {
 	assert.Contains(t, zlib.Description, "Compression library")
 	assert.Equal(t, "pacman", zlib.Format)
 	assert.Contains(t, zlib.PUrl, "pkg:alpm/arch/zlib")
+	assert.Equal(t, "custom:Zlib", zlib.License)
 
 	var openssl *packages.Package
 	for i := range pkgs {
@@ -132,4 +133,5 @@ func TestParsePacmanDB(t *testing.T) {
 	require.NotNil(t, openssl)
 	assert.Equal(t, "3.2.1-1", openssl.Version)
 	assert.Contains(t, openssl.Description, "Open Source toolkit")
+	assert.Equal(t, "Apache-2.0", openssl.License)
 }

--- a/providers/os/resources/packages/rpm_packages.go
+++ b/providers/os/resources/packages/rpm_packages.go
@@ -30,11 +30,11 @@ const (
 	RpmPkgFormat = "rpm"
 )
 
-var RPM_REGEX = regexp.MustCompile(`^([\w-+]*)\s(\d*|\(none\)):([\w\d-+.:]+)\s([\w\d]*|\(none\))__([\w\d\s,/<>:\.|\(none\)]+?)__(.*?)(?:__(.+))?$`)
+var RPM_REGEX = regexp.MustCompile(`^([\w-+]*)\s(\d*|\(none\)):([\w\d-+.:]+)\s([\w\d]*|\(none\))__([\w\d\s,/<>:\.|\(none\)]+?)__(.*?)__(.*?)(?:__(.+))?$`)
 
 // ParseRpmPackages parses output from:
 // %{MODULARITYLABEL} is only added on supported systems
-// rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{MODULARITYLABEL}\n'
+// rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}__%{MODULARITYLABEL}\n'
 func ParseRpmPackages(pf *inventory.Platform, input io.Reader) []Package {
 	pkgs := []Package{}
 	scanner := bufio.NewScanner(input)
@@ -62,12 +62,19 @@ func ParseRpmPackages(pf *inventory.Platform, input io.Reader) []Package {
 
 			vendor := cleanupVendorName(m[5])
 
-			modularity := ""
-			if len(m) > 6 {
-				modularity = m[7]
+			license := m[7]
+			// "(none)" is the rpm-format sentinel for missing fields;
+			// surface it as empty so we never ship "(none)" as a license.
+			if license == "(none)" {
+				license = ""
 			}
 
-			pkg := newRpmPackage(pf, name, version, arch, epoch, vendor, m[6], modularity)
+			modularity := ""
+			if len(m) > 8 {
+				modularity = m[8]
+			}
+
+			pkg := newRpmPackage(pf, name, version, arch, epoch, vendor, m[6], license, modularity)
 			pkg.FilesAvailable = PkgFilesAsync // when we use commands we need to fetch the files async
 			pkgs = append(pkgs, pkg)
 
@@ -76,7 +83,7 @@ func ParseRpmPackages(pf *inventory.Platform, input io.Reader) []Package {
 	return pkgs
 }
 
-func newRpmPackage(pf *inventory.Platform, name, version, arch, epoch, vendor, description, modularity string) Package {
+func newRpmPackage(pf *inventory.Platform, name, version, arch, epoch, vendor, description, license, modularity string) Package {
 	// NOTE that we do not have the vendor of the package itself, we could try to parse it from the vendor
 	// but that will also not be reliable. We may incorporate the cpe dictionary in the future but that would
 	// increase the binary.
@@ -106,6 +113,7 @@ func newRpmPackage(pf *inventory.Platform, name, version, arch, epoch, vendor, d
 		Format:      RpmPkgFormat,
 		CPEs:        cpes,
 		Vendor:      vendor,
+		License:     license,
 		PUrl: purl.NewPackageURL(pf, purl.TypeRPM, name, version,
 			purl.WithArch(arch),
 			purl.WithEpoch(epoch),
@@ -200,14 +208,14 @@ func (rpm *RpmPkgManager) queryFormat() string {
 	// this format should work everywhere
 	// fall-back to epoch instead of epochnum for 6 ish platforms, latest 6 platforms also support epochnum, but we
 	// save 1 call by not detecting the available keyword via rpm --querytags
-	format := "%{NAME} %{EPOCH}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}" + modularity + "\\n"
+	format := "%{NAME} %{EPOCH}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}" + modularity + "\\n"
 
 	// ATTENTION: EPOCHNUM is only available since later version of rpm in RedHat 6 and Suse 12
 	// we can only expect if for rhel 7+, therefore we need to run an extra test
 	// be aware that this method is also used for non-redhat systems like suse
 	i, err := strconv.ParseInt(rpm.platform.Version, 0, 32)
 	if err == nil && (rpm.platform.Name == "centos" || rpm.platform.Name == "redhat") && i >= 7 {
-		format = "%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}" + modularity + "\\n"
+		format = "%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}" + modularity + "\\n"
 	}
 
 	return format
@@ -312,7 +320,7 @@ func (rpm *RpmPkgManager) staticList() ([]Package, error) {
 			version = version + "-" + pkg.Release
 		}
 
-		rpmPkg := newRpmPackage(rpm.platform, pkg.Name, version, pkg.Arch, epoch, cleanupVendorName(pkg.Vendor), pkg.Summary, pkg.Modularitylabel)
+		rpmPkg := newRpmPackage(rpm.platform, pkg.Name, version, pkg.Arch, epoch, cleanupVendorName(pkg.Vendor), pkg.Summary, pkg.License, pkg.Modularitylabel)
 
 		rpmPkg.FilesAvailable = PkgFilesIncluded
 		rpmPkg.Files = []FileRecord{

--- a/providers/os/resources/packages/rpm_packages_test.go
+++ b/providers/os/resources/packages/rpm_packages_test.go
@@ -31,7 +31,7 @@ func TestRedhat8Parser(t *testing.T) {
 		},
 	}
 
-	c, err := mock.RunCommand("rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}\\n'")
+	c, err := mock.RunCommand("rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}\\n'")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,6 +43,7 @@ func TestRedhat8Parser(t *testing.T) {
 		Name:        "ncurses-base",
 		Version:     "6.1-7.20180224.el8",
 		Vendor:      "Red Hat, Inc.",
+		License:     "GPLv3+",
 		Arch:        "noarch",
 		Description: "Descriptions of common terminals",
 		PUrl:        "pkg:rpm/redhat/ncurses-base@6.1-7.20180224.el8?arch=noarch&distro=rhel-8.4",
@@ -59,6 +60,7 @@ func TestRedhat8Parser(t *testing.T) {
 		Name:        "libstdc++",
 		Version:     "8.4.1-1.el8",
 		Vendor:      "Red Hat, Inc.",
+		License:     "GPLv3+",
 		Arch:        "x86_64",
 		Description: "GNU Standard C++ Library",
 		PUrl:        "pkg:rpm/redhat/libstdc%2B%2B@8.4.1-1.el8?arch=x86_64&distro=rhel-8.4",
@@ -75,6 +77,7 @@ func TestRedhat8Parser(t *testing.T) {
 		Name:        "iptables-libs",
 		Version:     "1.8.4-17.el8_4.1",
 		Vendor:      "Red Hat, Inc.",
+		License:     "GPLv3+",
 		Arch:        "x86_64",
 		Description: "iptables libraries",
 		PUrl:        "pkg:rpm/redhat/iptables-libs@1.8.4-17.el8_4.1?arch=x86_64&distro=rhel-8.4",
@@ -91,6 +94,7 @@ func TestRedhat8Parser(t *testing.T) {
 		Name:        "openssl-libs",
 		Version:     "1:1.1.1g-15.el8_3",
 		Vendor:      "Red Hat, Inc.",
+		License:     "GPLv3+",
 		Epoch:       "1",
 		Arch:        "x86_64",
 		Description: "A general purpose cryptography library with TLS implementation",
@@ -109,6 +113,7 @@ func TestRedhat8Parser(t *testing.T) {
 		Name:        "dbus-libs",
 		Version:     "1:1.12.8-12.el8_4.2",
 		Vendor:      "Red Hat, Inc.",
+		License:     "GPLv3+",
 		Epoch:       "1",
 		Arch:        "x86_64",
 		Description: "Libraries for accessing D-BUS",
@@ -144,6 +149,7 @@ func TestRedhat8Parser(t *testing.T) {
 		Name:        "which",
 		Version:     "2.21-12.el8",
 		Vendor:      "Red Hat, Inc.",
+		License:     "GPLv3+",
 		Epoch:       "",
 		Arch:        "x86_64",
 		Description: "Displays where a particular program in your path is located",
@@ -180,6 +186,7 @@ func TestPhoton4ImageParser(t *testing.T) {
 			Release: "6.ph4",
 			Arch:    "x86_64",
 			Vendor:  "VMware, Inc.",
+			License: "GPLv3+",
 			Summary: "Ncurses Libraries",
 		},
 		{
@@ -189,6 +196,7 @@ func TestPhoton4ImageParser(t *testing.T) {
 			Release: "4.ph4",
 			Arch:    "x86_64",
 			Vendor:  "VMware, Inc.",
+			License: "GPLv3+",
 			Summary: "Bourne-Again SHell",
 		},
 		{
@@ -198,13 +206,14 @@ func TestPhoton4ImageParser(t *testing.T) {
 			Release: "4.ph4",
 			Arch:    "x86_64",
 			Vendor:  "VMware, Inc.",
+			License: "GPLv3+",
 			Summary: "sqlite3 library",
 		},
 	}
 
 	var packageList bytes.Buffer
 	for _, pkg := range pkgList {
-		fmt.Fprintf(&packageList, "%s %d:%s-%s %s__%s__%s\n", pkg.Name, pkg.EpochNum(), pkg.Version, pkg.Release, pkg.Arch, pkg.Vendor, pkg.Summary)
+		fmt.Fprintf(&packageList, "%s %d:%s-%s %s__%s__%s__%s\n", pkg.Name, pkg.EpochNum(), pkg.Version, pkg.Release, pkg.Arch, pkg.Vendor, pkg.Summary, pkg.License)
 	}
 
 	pf := &inventory.Platform{
@@ -224,6 +233,7 @@ func TestPhoton4ImageParser(t *testing.T) {
 		Name:        "ncurses-libs",
 		Version:     "6.2-6.ph4",
 		Vendor:      "VMware, Inc.",
+		License:     "GPLv3+",
 		Arch:        "x86_64",
 		Description: "Ncurses Libraries",
 		PUrl:        "pkg:rpm/photon%20os/ncurses-libs@6.2-6.ph4?arch=x86_64&distro=photon-4.0",
@@ -240,6 +250,7 @@ func TestPhoton4ImageParser(t *testing.T) {
 		Name:        "bash",
 		Version:     "5.0-4.ph4",
 		Vendor:      "VMware, Inc.",
+		License:     "GPLv3+",
 		Arch:        "x86_64",
 		Description: "Bourne-Again SHell",
 		PUrl:        "pkg:rpm/photon%20os/bash@5.0-4.ph4?arch=x86_64&distro=photon-4.0",
@@ -256,6 +267,7 @@ func TestPhoton4ImageParser(t *testing.T) {
 		Name:        "sqlite-libs",
 		Version:     "3.38.5-4.ph4",
 		Vendor:      "VMware, Inc.",
+		License:     "GPLv3+",
 		Arch:        "x86_64",
 		Description: "sqlite3 library",
 		PUrl:        "pkg:rpm/photon%20os/sqlite-libs@3.38.5-4.ph4?arch=x86_64&distro=photon-4.0",
@@ -280,13 +292,14 @@ func TestSuSEParser(t *testing.T) {
 			Release: "150000.4.6.1",
 			Arch:    "x86_64",
 			Vendor:  "SUSE LLC <https://www.suse.com/>",
+			License: "GPLv3+",
 			Summary: "Print lines matching a pattern",
 		},
 	}
 
 	var packageList bytes.Buffer
 	for _, pkg := range pkgList {
-		fmt.Fprintf(&packageList, "%s %d:%s-%s %s__%s__%s\n", pkg.Name, pkg.EpochNum(), pkg.Version, pkg.Release, pkg.Arch, pkg.Vendor, pkg.Summary)
+		fmt.Fprintf(&packageList, "%s %d:%s-%s %s__%s__%s__%s\n", pkg.Name, pkg.EpochNum(), pkg.Version, pkg.Release, pkg.Arch, pkg.Vendor, pkg.Summary, pkg.License)
 	}
 
 	pf := &inventory.Platform{
@@ -307,6 +320,7 @@ func TestSuSEParser(t *testing.T) {
 		Version: "3.1-150000.4.6.1",
 		// Note that the tag <https://suse.com/> has been removed.
 		Vendor:      "SUSE LLC",
+		License:     "GPLv3+",
 		Arch:        "x86_64",
 		Description: "Print lines matching a pattern",
 		PUrl:        "pkg:rpm/suse/grep@3.1-150000.4.6.1?arch=x86_64&distro=suse-15.6",
@@ -366,7 +380,7 @@ func TestOracleParser(t *testing.T) {
 		},
 	}
 
-	c, err := mock.RunCommand("rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{MODULARITYLABEL}\\n'")
+	c, err := mock.RunCommand("rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}__%{MODULARITYLABEL}\\n'")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -405,7 +419,7 @@ func TestAlmaLinuxParser(t *testing.T) {
 		},
 	}
 
-	c, err := mock.RunCommand("rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{MODULARITYLABEL}\\n'")
+	c, err := mock.RunCommand("rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}__%{MODULARITYLABEL}\\n'")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -437,7 +451,7 @@ func TestRedHatModularParser(t *testing.T) {
 		},
 	}
 
-	c, err := mock.RunCommand("rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{MODULARITYLABEL}\\n'")
+	c, err := mock.RunCommand("rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}__%{MODULARITYLABEL}\\n'")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/os/resources/packages/testdata/packages_almalinux.toml
+++ b/providers/os/resources/packages/testdata/packages_almalinux.toml
@@ -4,12 +4,12 @@ stdout="/usr/bin/rpm"
 [commands."rpm -E '%{_dbpath}'"]
 stdout="/var/lib/rpm"
 
-[commands."rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{MODULARITYLABEL}\\n'"]
+[commands."rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}__%{MODULARITYLABEL}\\n'"]
 stdout="""
-php-xml 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__A module for PHP applications which use XML__php:7.4:8100020241212065510:eb0869e2
-php-mbstring 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__A module for PHP applications which need multi-byte string handling__php:7.4:8100020241212065510:eb0869e2
-php-common 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__Common files for PHP__php:7.4:8100020241212065510:eb0869e2
-php-cli 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__Command-line interface for PHP__php:7.4:8100020241212065510:eb0869e2
-php-fpm 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__PHP FastCGI Process Manager__php:7.4:8100020241212065510:eb0869e2
-php-json 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__JavaScript Object Notation extension for PHP__php:7.4:8100020241212065510:eb0869e2
+php-xml 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__A module for PHP applications which use XML__GPLv3+__php:7.4:8100020241212065510:eb0869e2
+php-mbstring 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__A module for PHP applications which need multi-byte string handling__GPLv3+__php:7.4:8100020241212065510:eb0869e2
+php-common 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__Common files for PHP__GPLv3+__php:7.4:8100020241212065510:eb0869e2
+php-cli 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__Command-line interface for PHP__GPLv3+__php:7.4:8100020241212065510:eb0869e2
+php-fpm 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__PHP FastCGI Process Manager__GPLv3+__php:7.4:8100020241212065510:eb0869e2
+php-json 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__JavaScript Object Notation extension for PHP__GPLv3+__php:7.4:8100020241212065510:eb0869e2
 """

--- a/providers/os/resources/packages/testdata/packages_oracle.toml
+++ b/providers/os/resources/packages/testdata/packages_oracle.toml
@@ -4,10 +4,10 @@ stdout="/usr/bin/rpm"
 [commands."rpm -E '%{_dbpath}'"]
 stdout="/var/lib/rpm"
 
-[commands."rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{MODULARITYLABEL}\\n'"]
+[commands."rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}__%{MODULARITYLABEL}\\n'"]
 stdout="""
-adcli 0:0.9.2-1.el9 x86_64__Oracle America__Active Directory enrollment__(none)
-at 0:3.1.23-12.el9_6 x86_64__Oracle America__Job spooling tools__(none)
-ruby 0:3.1.7-146.module+el9.5.0+90564+273a1edd x86_64__Oracle America__An interpreter of object-oriented scripting language__ruby:3.1:9050020250506050702:2e2f0e1c
-ruby-default-gems 0:3.1.7-146.module+el9.5.0+90564+273a1edd noarch__Oracle America__Default gems which are part of Ruby StdLib__ruby:3.1:9050020250506050702:2e2f0e1c
+adcli 0:0.9.2-1.el9 x86_64__Oracle America__Active Directory enrollment__GPLv3+__(none)
+at 0:3.1.23-12.el9_6 x86_64__Oracle America__Job spooling tools__GPLv3+__(none)
+ruby 0:3.1.7-146.module+el9.5.0+90564+273a1edd x86_64__Oracle America__An interpreter of object-oriented scripting language__GPLv3+__ruby:3.1:9050020250506050702:2e2f0e1c
+ruby-default-gems 0:3.1.7-146.module+el9.5.0+90564+273a1edd noarch__Oracle America__Default gems which are part of Ruby StdLib__GPLv3+__ruby:3.1:9050020250506050702:2e2f0e1c
 """

--- a/providers/os/resources/packages/testdata/packages_redhat8.toml
+++ b/providers/os/resources/packages/testdata/packages_redhat8.toml
@@ -4,200 +4,200 @@ stdout="/usr/bin/rpm"
 [commands."rpm -E '%{_dbpath}'"]
 stdout="/var/lib/rpm/rpmdb.sqlite"
 
-[commands."rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}\\n'"]
+[commands."rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}\\n'"]
 stdout="""
-tzdata 0:2021c-1.el8 noarch__Red Hat, Inc.__Timezone data
-python3-pip-wheel 0:9.0.3-19.el8 noarch__Red Hat, Inc.__The pip wheel
-redhat-release 0:8.4-0.6.el8 x86_64__Red Hat, Inc.__Red Hat Enterprise Linux release file
-filesystem 0:3.8-3.el8 x86_64__Red Hat, Inc.__The basic directory layout for a Linux system
-publicsuffix-list-dafsa 0:20180723-1.el8 noarch__Red Hat, Inc.__Cross-vendor public domain suffix database in DAFSA form
-pcre2 0:10.32-2.el8 x86_64__Red Hat, Inc.__Perl-compatible regular expression library
-ncurses-libs 0:6.1-7.20180224.el8 x86_64__Red Hat, Inc.__Ncurses libraries
-glibc-common 0:2.28-151.el8 x86_64__Red Hat, Inc.__Common binaries and locale data for glibc
-bash 0:4.4.20-1.el8_4 x86_64__Red Hat, Inc.__The GNU Bourne Again shell
-zlib 0:1.2.11-17.el8 x86_64__Red Hat, Inc.__The compression and decompression library
-bzip2-libs 0:1.0.6-26.el8 x86_64__Red Hat, Inc.__Libraries for applications using bzip2
-libxml2 0:2.9.7-9.el8_4.2 x86_64__Red Hat, Inc.__Library providing XML and HTML support
-libcap 0:2.26-4.el8 x86_64__Red Hat, Inc.__Library for getting and setting POSIX.1e capabilities
-libzstd 0:1.4.4-1.el8 x86_64__Red Hat, Inc.__Zstd shared library
-elfutils-libelf 0:0.182-3.el8 x86_64__Red Hat, Inc.__Library to read and write ELF files
-expat 0:2.2.5-4.el8 x86_64__Red Hat, Inc.__An XML parser library
-libcom_err 0:1.45.6-1.el8 x86_64__Red Hat, Inc.__Common error description library
-libuuid 0:2.32.1-27.el8 x86_64__Red Hat, Inc.__Universally unique ID library
-gmp 1:6.1.2-10.el8 x86_64__Red Hat, Inc.__A GNU arbitrary precision library
-libacl 0:2.2.53-1.el8 x86_64__Red Hat, Inc.__Dynamic library for access control list support
-libblkid 0:2.32.1-27.el8 x86_64__Red Hat, Inc.__Block device ID library
-sed 0:4.5-2.el8 x86_64__Red Hat, Inc.__A GNU stream text editor
-libstdc++ 0:8.4.1-1.el8 x86_64__Red Hat, Inc.__GNU Standard C++ Library
-p11-kit 0:0.23.22-1.el8 x86_64__Red Hat, Inc.__Library for loading and sharing PKCS#11 modules
-libunistring 0:0.9.9-3.el8 x86_64__Red Hat, Inc.__GNU Unicode string library
-libgcrypt 0:1.8.5-4.el8 x86_64__Red Hat, Inc.__A general-purpose cryptography library
-libcap-ng 0:0.7.9-5.el8 x86_64__Red Hat, Inc.__An alternate posix capabilities library
-libnl3 0:3.5.0-1.el8 x86_64__Red Hat, Inc.__Convenience library for kernel netlink sockets
-libassuan 0:2.5.1-3.el8 x86_64__Red Hat, Inc.__GnuPG IPC library
-keyutils-libs 0:1.5.10-6.el8 x86_64__Red Hat, Inc.__Key utilities library
-p11-kit-trust 0:0.23.22-1.el8 x86_64__Red Hat, Inc.__System trust module from p11-kit
-grep 0:3.1-6.el8 x86_64__Red Hat, Inc.__Pattern matching utilities
-dbus-libs 1:1.12.8-12.el8_4.2 x86_64__Red Hat, Inc.__Libraries for accessing D-BUS
-dbus-tools 1:1.12.8-12.el8_4.2 x86_64__Red Hat, Inc.__D-BUS Tools and Utilities
-gdbm 1:1.18-1.el8 x86_64__Red Hat, Inc.__A GNU set of database routines which use extensible hashing
-shadow-utils 2:4.6-12.el8 x86_64__Red Hat, Inc.__Utilities for managing accounts and shadow password files
-libpsl 0:0.20.2-6.el8 x86_64__Red Hat, Inc.__C library for the Publix Suffix List
-gzip 0:1.9-12.el8 x86_64__Red Hat, Inc.__The GNU data compression program
-cracklib-dicts 0:2.9.6-15.el8 x86_64__Red Hat, Inc.__The standard CrackLib dictionaries
-mpfr 0:3.1.6-1.el8 x86_64__Red Hat, Inc.__A C library for multiple-precision floating-point computations
-libcomps 0:0.1.11-5.el8 x86_64__Red Hat, Inc.__Comps XML file manipulation library
-brotli 0:1.0.6-3.el8 x86_64__Red Hat, Inc.__Lossless compression algorithm
-libnghttp2 0:1.33.0-3.el8_2.1 x86_64__Red Hat, Inc.__A library implementing the HTTP/2 protocol
-libsigsegv 0:2.11-5.el8 x86_64__Red Hat, Inc.__Library for handling page faults in user mode
-libverto 0:0.3.0-5.el8 x86_64__Red Hat, Inc.__Main loop abstraction library
-libtirpc 0:1.1.4-4.el8 x86_64__Red Hat, Inc.__Transport Independent RPC Library
-openssl-libs 1:1.1.1g-15.el8_3 x86_64__Red Hat, Inc.__A general purpose cryptography library with TLS implementation
-crypto-policies-scripts 0:20210209-1.gitbfb6bed.el8_3 noarch__Red Hat, Inc.__Tool to switch between crypto policies
-platform-python 0:3.6.8-39.el8_4 x86_64__Red Hat, Inc.__Internal interpreter of the Python programming language
-libdb 0:5.3.28-42.el8_4 x86_64__Red Hat, Inc.__The Berkeley DB database library for C
-pam 0:1.3.1-14.el8 x86_64__Red Hat, Inc.__An extensible library which provides authentication for applications
-util-linux 0:2.32.1-27.el8 x86_64__Red Hat, Inc.__A collection of basic system utilities
-gnutls 0:3.6.14-8.el8_3 x86_64__Red Hat, Inc.__A TLS protocol implementation
-json-glib 0:1.4.4-1.el8 x86_64__Red Hat, Inc.__Library for JavaScript Object Notation format
-python3-iniparse 0:0.4-31.el8 noarch__Red Hat, Inc.__Python Module for Accessing and Modifying Configuration Data in INI files
-dbus-glib 0:0.110-2.el8 x86_64__Red Hat, Inc.__GLib bindings for D-Bus
-gobject-introspection 0:1.56.1-1.el8 x86_64__Red Hat, Inc.__Introspection system for GObject-based libraries
-cyrus-sasl-lib 0:2.1.27-5.el8 x86_64__Red Hat, Inc.__Shared libraries needed by applications which use Cyrus SASL
-libuser 0:0.62-23.el8 x86_64__Red Hat, Inc.__A user and group account administration library
-usermode 0:1.113-1.el8 x86_64__Red Hat, Inc.__Tools for certain user account management tasks
-python3-ethtool 0:0.14-3.el8 x86_64__Red Hat, Inc.__Python module to interface with ethtool
-python3-libxml2 0:2.9.7-9.el8_4.2 x86_64__Red Hat, Inc.__Python 3 bindings for the libxml2 library
-python3-chardet 0:3.0.4-7.el8 noarch__Red Hat, Inc.__Character encoding auto-detection in Python 3
-python3-idna 0:2.5-5.el8 noarch__Red Hat, Inc.__Internationalized Domain Names in Applications (IDNA)
-python3-pysocks 0:1.6.8-3.el8 noarch__Red Hat, Inc.__A Python SOCKS client module
-python3-requests 0:2.20.0-2.1.el8_1 noarch__Red Hat, Inc.__HTTP library, written in Python, for human beings
-libarchive 0:3.3.3-1.el8 x86_64__Red Hat, Inc.__A library for handling streaming archive formats
-ima-evm-utils 0:1.3.2-12.el8 x86_64__Red Hat, Inc.__IMA/EVM support utilities
-npth 0:1.5-4.el8 x86_64__Red Hat, Inc.__The New GNU Portable Threads library
-gpgme 0:1.13.1-7.el8 x86_64__Red Hat, Inc.__GnuPG Made Easy - high level crypto API
-pciutils-libs 0:3.7.0-1.el8 x86_64__Red Hat, Inc.__Linux PCI library
-virt-what 0:1.18-9.el8_4 x86_64__Red Hat, Inc.__Detect if we are running in a virtual machine
-libssh 0:0.9.4-2.el8 x86_64__Red Hat, Inc.__A library implementing the SSH protocol
-librepo 0:1.12.0-3.el8 x86_64__Red Hat, Inc.__Repodata downloading library
-curl 0:7.61.1-18.el8_4.2 x86_64__Red Hat, Inc.__A utility for getting files from remote servers (FTP, HTTP, and others)
-rpm-libs 0:4.14.3-14.el8_4 x86_64__Red Hat, Inc.__Libraries for manipulating RPM packages
-libsolv 0:0.7.16-3.el8_4 x86_64__Red Hat, Inc.__Package dependency solver
-python3-libdnf 0:0.55.0-7.el8 x86_64__Red Hat, Inc.__Python 3 bindings for the libdnf library.
-libreport-filesystem 0:2.9.5-15.el8 x86_64__Red Hat, Inc.__Filesystem layout for libreport
-hwdata 0:0.314-8.8.el8 noarch__Red Hat, Inc.__Hardware identification and configuration data
-rdma-core 0:32.0-4.el8 x86_64__Red Hat, Inc.__RDMA core userspace libraries and daemons
-libpcap 14:1.9.1-5.el8 x86_64__Red Hat, Inc.__A system-independent interface for user-level packet capture
-dbus-common 1:1.12.8-12.el8_4.2 noarch__Red Hat, Inc.__D-BUS message bus configuration
-device-mapper 8:1.02.175-5.el8 x86_64__Red Hat, Inc.__Device mapper utility
-cryptsetup-libs 0:2.3.3-4.el8 x86_64__Red Hat, Inc.__Cryptsetup shared library
-elfutils-libs 0:0.182-3.el8 x86_64__Red Hat, Inc.__Libraries to handle compiled objects
-systemd 0:239-45.el8_4.3 x86_64__Red Hat, Inc.__System and Service Manager
-rpm-build-libs 0:4.14.3-14.el8_4 x86_64__Red Hat, Inc.__Libraries for building and signing RPM packages
-python3-dnf 0:4.4.2-11.el8 noarch__Red Hat, Inc.__Python 3 interface to DNF
-python3-dnf-plugins-core 0:4.0.18-4.el8 noarch__Red Hat, Inc.__Core Plugins for DNF
-python3-subscription-manager-rhsm 0:1.28.13-4.el8_4 x86_64__Red Hat, Inc.__A Python library to communicate with a Red Hat Unified Entitlement Platform
-yum 0:4.4.2-11.el8 noarch__Red Hat, Inc.__Package manager
-tar 2:1.30-5.el8 x86_64__Red Hat, Inc.__A GNU file archiving program
-findutils 1:4.6.0-20.el8 x86_64__Red Hat, Inc.__The GNU versions of find utilities (find and xargs)
-rootfiles 0:8.1-22.el8 noarch__Red Hat, Inc.__The basic required files for the root user's directory
-gpg-pubkey 0:d4082792-5b32db75 (none)__(none)__gpg(Red Hat, Inc. (auxiliary key) <security@redhat.com>)
-libgcc 0:8.4.1-1.el8 x86_64__Red Hat, Inc.__GCC version 8 shared support library
-python3-setuptools-wheel 0:39.2.0-6.el8 noarch__Red Hat, Inc.__The setuptools wheel
-subscription-manager-rhsm-certificates 0:1.28.13-4.el8_4 x86_64__Red Hat, Inc.__Certificates required to communicate with a Red Hat Unified Entitlement Platform
-setup 0:2.12.2-6.el8 noarch__Red Hat, Inc.__A set of system configuration and setup files
-basesystem 0:11-5.el8 noarch__Red Hat, Inc.__The skeleton package which defines a simple Red Hat Enterprise Linux system
-ncurses-base 0:6.1-7.20180224.el8 noarch__Red Hat, Inc.__Descriptions of common terminals
-libselinux 0:2.9-5.el8 x86_64__Red Hat, Inc.__SELinux library and simple utilities
-glibc-minimal-langpack 0:2.28-151.el8 x86_64__Red Hat, Inc.__Minimal language packs for glibc.
-glibc 0:2.28-151.el8 x86_64__Red Hat, Inc.__The GNU libc libraries
-libsepol 0:2.9-2.el8 x86_64__Red Hat, Inc.__SELinux binary policy manipulation library
-xz-libs 0:5.2.4-3.el8 x86_64__Red Hat, Inc.__Libraries for decoding LZMA compression
-libgpg-error 0:1.31-1.el8 x86_64__Red Hat, Inc.__Library for error values used by GnuPG components
-info 0:6.5-6.el8 x86_64__Red Hat, Inc.__A stand-alone TTY-based reader for GNU texinfo documentation
-libxcrypt 0:4.1.1-4.el8 x86_64__Red Hat, Inc.__Extended crypt library for DES, MD5, Blowfish and others
-popt 0:1.18-1.el8 x86_64__Red Hat, Inc.__C library for parsing command line parameters
-sqlite-libs 0:3.26.0-13.el8 x86_64__Red Hat, Inc.__Shared library for the sqlite3 embeddable SQL database engine.
-json-c 0:0.13.1-0.4.el8 x86_64__Red Hat, Inc.__JSON implementation in C
-libffi 0:3.1-22.el8 x86_64__Red Hat, Inc.__A portable foreign function interface library
-readline 0:7.0-10.el8 x86_64__Red Hat, Inc.__A library for editing typed command lines
-libattr 0:2.4.48-3.el8 x86_64__Red Hat, Inc.__Dynamic library for extended attribute support
-coreutils-single 0:8.30-8.el8 x86_64__Red Hat, Inc.__coreutils multicall binary
-libmount 0:2.32.1-27.el8 x86_64__Red Hat, Inc.__Device mounting library
-libsmartcols 0:2.32.1-27.el8 x86_64__Red Hat, Inc.__Formatting library for ls-like programs.
-lua-libs 0:5.3.4-11.el8 x86_64__Red Hat, Inc.__Libraries for lua
-chkconfig 0:1.13-2.el8 x86_64__Red Hat, Inc.__A system tool for maintaining the /etc/rc*.d hierarchy
-libidn2 0:2.2.0-1.el8 x86_64__Red Hat, Inc.__Library to support IDNA2008 internationalized domain names
-file-libs 0:5.33-16.el8_3.1 x86_64__Red Hat, Inc.__Libraries for applications using libmagic
-audit-libs 0:3.0-0.17.20191104git1c2f876.el8 x86_64__Red Hat, Inc.__Dynamic library for libaudit
-lz4-libs 0:1.8.3-3.el8_4 x86_64__Red Hat, Inc.__Libaries for lz4
-gdbm-libs 1:1.18-1.el8 x86_64__Red Hat, Inc.__Libraries files for gdbm
-libtasn1 0:4.13-3.el8 x86_64__Red Hat, Inc.__The ASN.1 library used in GNUTLS
-pcre 0:8.42-4.el8 x86_64__Red Hat, Inc.__Perl-compatible regular expression library
-systemd-libs 0:239-45.el8_4.3 x86_64__Red Hat, Inc.__systemd libraries
-ca-certificates 0:2021.2.50-80.0.el8_4 noarch__Red Hat, Inc.__The Mozilla CA root certificate bundle
-libusbx 0:1.0.23-4.el8 x86_64__Red Hat, Inc.__Library for accessing USB devices
-libsemanage 0:2.9-6.el8 x86_64__Red Hat, Inc.__SELinux binary policy manipulation library
-libutempter 0:1.1.6-14.el8 x86_64__Red Hat, Inc.__A privileged helper for utmp/wtmp updates
-libfdisk 0:2.32.1-27.el8 x86_64__Red Hat, Inc.__Partitioning library for fdisk-like programs.
-cracklib 0:2.9.6-15.el8 x86_64__Red Hat, Inc.__A password-checking library
-acl 0:2.2.53-1.el8 x86_64__Red Hat, Inc.__Access control list utilities
-nettle 0:3.4.1-4.el8_3 x86_64__Red Hat, Inc.__A low-level cryptographic library
-libksba 0:1.3.5-7.el8 x86_64__Red Hat, Inc.__CMS and X.509 library
-dmidecode 1:3.2-8.el8 x86_64__Red Hat, Inc.__Tool to analyse BIOS DMI data
-libseccomp 0:2.5.1-1.el8 x86_64__Red Hat, Inc.__Enhanced seccomp library
-gawk 0:4.2.1-2.el8 x86_64__Red Hat, Inc.__The GNU version of the AWK text processing utility
-libnsl2 0:1.2.0-2.20180605git4a062cf.el8 x86_64__Red Hat, Inc.__Public client interface library for NIS(YP) and NIS+
-krb5-libs 0:1.18.2-8.3.el8_4 x86_64__Red Hat, Inc.__The non-admin shared libraries used by Kerberos 5
-crypto-policies 0:20210209-1.gitbfb6bed.el8_3 noarch__Red Hat, Inc.__System-wide crypto policies
-platform-python-setuptools 0:39.2.0-6.el8 noarch__Red Hat, Inc.__Easily build and distribute Python 3 packages
-python3-libs 0:3.6.8-39.el8_4 x86_64__Red Hat, Inc.__Python runtime libraries
-libpwquality 0:1.4.4-3.el8 x86_64__Red Hat, Inc.__A library for password generation and password quality checking
-python3-six 0:1.11.0-8.el8 noarch__Red Hat, Inc.__Python 2 and 3 compatibility utilities
-python3-dateutil 1:2.6.1-6.el8 noarch__Red Hat, Inc.__Powerful extensions to the standard datetime module
-glib2 0:2.56.4-10.el8_4.1 x86_64__Red Hat, Inc.__A library of handy utility functions
-librhsm 0:0.0.3-4.el8 x86_64__Red Hat, Inc.__Red Hat Subscription Manager library
-kmod-libs 0:25-17.el8 x86_64__Red Hat, Inc.__Libraries to handle kernel module loading and unloading
-python3-dbus 0:1.2.4-15.el8 x86_64__Red Hat, Inc.__D-Bus bindings for python3
-python3-gobject-base 0:3.28.3-2.el8 x86_64__Red Hat, Inc.__Python 3 bindings for GObject Introspection base package
-openldap 0:2.4.46-17.el8_4 x86_64__Red Hat, Inc.__LDAP support libraries
-passwd 0:0.80-3.el8 x86_64__Red Hat, Inc.__An utility for setting or changing passwords using PAM
-libdb-utils 0:5.3.28-42.el8_4 x86_64__Red Hat, Inc.__Command line tools for managing Berkeley DB databases
-python3-libcomps 0:0.1.11-5.el8 x86_64__Red Hat, Inc.__Python 3 bindings for libcomps library
-python3-dmidecode 0:3.12.2-15.el8 x86_64__Red Hat, Inc.__Python 3 module to access DMI data
-python3-decorator 0:4.2.1-2.el8 noarch__Red Hat, Inc.__Module to simplify usage of decorators in python3
-python3-inotify 0:0.9.6-13.el8 noarch__Red Hat, Inc.__Monitor filesystem events with Python under Linux
-python3-urllib3 0:1.24.2-5.el8 noarch__Red Hat, Inc.__Python3 HTTP library with thread-safe connection pooling and file post
-python3-syspurpose 0:1.28.13-4.el8_4 x86_64__Red Hat, Inc.__A commandline utility for declaring system syspurpose
-tpm2-tss 0:2.3.2-3.el8 x86_64__Red Hat, Inc.__TPM2.0 Software Stack
-libyaml 0:0.1.7-5.el8 x86_64__Red Hat, Inc.__YAML 1.1 parser and emitter written in C
-gnupg2 0:2.2.20-2.el8 x86_64__Red Hat, Inc.__Utility for secure communication and data storage
-python3-gpg 0:1.13.1-7.el8 x86_64__Red Hat, Inc.__gpgme bindings for Python 3
-which 0:2.21-12.el8 x86_64__Red Hat, Inc.__Displays where a particular program in your path is located
-libssh-config 0:0.9.4-2.el8 noarch__Red Hat, Inc.__Configuration files for libssh
-libcurl 0:7.61.1-18.el8_4.2 x86_64__Red Hat, Inc.__A library for getting files from web servers
-python3-librepo 0:1.12.0-3.el8 x86_64__Red Hat, Inc.__Python 3 bindings for the librepo library
-rpm 0:4.14.3-14.el8_4 x86_64__Red Hat, Inc.__The RPM package management system
-libmodulemd 0:2.9.4-2.el8 x86_64__Red Hat, Inc.__Module metadata manipulation library
-libdnf 0:0.55.0-7.el8 x86_64__Red Hat, Inc.__Library providing simplified C and Python API to libsolv
-python3-hawkey 0:0.55.0-7.el8 x86_64__Red Hat, Inc.__Python 3 bindings for the hawkey library
-dnf-data 0:4.4.2-11.el8 noarch__Red Hat, Inc.__Common data and configuration files for DNF
-pciutils 0:3.7.0-1.el8 x86_64__Red Hat, Inc.__PCI bus related utilities
-libibverbs 0:32.0-4.el8 x86_64__Red Hat, Inc.__A library and drivers for direct userspace use of RDMA (InfiniBand/iWARP/RoCE) hardware
-iptables-libs 0:1.8.4-17.el8_4.1 x86_64__Red Hat, Inc.__iptables libraries
-dbus-daemon 1:1.12.8-12.el8_4.2 x86_64__Red Hat, Inc.__D-BUS message bus
-device-mapper-libs 8:1.02.175-5.el8 x86_64__Red Hat, Inc.__Device-mapper shared library
-elfutils-default-yama-scope 0:0.182-3.el8 noarch__Red Hat, Inc.__Default yama attach scope sysctl setting
-systemd-pam 0:239-45.el8_4.3 x86_64__Red Hat, Inc.__systemd PAM module
-dbus 1:1.12.8-12.el8_4.2 x86_64__Red Hat, Inc.__D-BUS message bus
-python3-rpm 0:4.14.3-14.el8_4 x86_64__Red Hat, Inc.__Python 3 bindings for apps which will manipulate RPM packages
-dnf 0:4.4.2-11.el8 noarch__Red Hat, Inc.__Package manager
-dnf-plugin-subscription-manager 0:1.28.13-4.el8_4 x86_64__Red Hat, Inc.__Subscription Manager plugins for DNF
-subscription-manager 0:1.28.13-4.el8_4 x86_64__Red Hat, Inc.__Tools and libraries for subscription and repository management
-gdb-gdbserver 0:8.2-15.el8 x86_64__Red Hat, Inc.__A standalone server for GDB (the GNU source-level debugger)
-vim-minimal 2:8.0.1763-15.el8 x86_64__Red Hat, Inc.__A minimal version of the VIM editor
-langpacks-en 0:1.0-12.el8 noarch__Red Hat, Inc.__English langpacks meta-package
-gpg-pubkey 0:fd431d51-4ae0493b (none)__(none)__gpg(Red Hat, Inc. (release key 2) <security@redhat.com>)
+tzdata 0:2021c-1.el8 noarch__Red Hat, Inc.__Timezone data__GPLv3+
+python3-pip-wheel 0:9.0.3-19.el8 noarch__Red Hat, Inc.__The pip wheel__GPLv3+
+redhat-release 0:8.4-0.6.el8 x86_64__Red Hat, Inc.__Red Hat Enterprise Linux release file__GPLv3+
+filesystem 0:3.8-3.el8 x86_64__Red Hat, Inc.__The basic directory layout for a Linux system__GPLv3+
+publicsuffix-list-dafsa 0:20180723-1.el8 noarch__Red Hat, Inc.__Cross-vendor public domain suffix database in DAFSA form__GPLv3+
+pcre2 0:10.32-2.el8 x86_64__Red Hat, Inc.__Perl-compatible regular expression library__GPLv3+
+ncurses-libs 0:6.1-7.20180224.el8 x86_64__Red Hat, Inc.__Ncurses libraries__GPLv3+
+glibc-common 0:2.28-151.el8 x86_64__Red Hat, Inc.__Common binaries and locale data for glibc__GPLv3+
+bash 0:4.4.20-1.el8_4 x86_64__Red Hat, Inc.__The GNU Bourne Again shell__GPLv3+
+zlib 0:1.2.11-17.el8 x86_64__Red Hat, Inc.__The compression and decompression library__GPLv3+
+bzip2-libs 0:1.0.6-26.el8 x86_64__Red Hat, Inc.__Libraries for applications using bzip2__GPLv3+
+libxml2 0:2.9.7-9.el8_4.2 x86_64__Red Hat, Inc.__Library providing XML and HTML support__GPLv3+
+libcap 0:2.26-4.el8 x86_64__Red Hat, Inc.__Library for getting and setting POSIX.1e capabilities__GPLv3+
+libzstd 0:1.4.4-1.el8 x86_64__Red Hat, Inc.__Zstd shared library__GPLv3+
+elfutils-libelf 0:0.182-3.el8 x86_64__Red Hat, Inc.__Library to read and write ELF files__GPLv3+
+expat 0:2.2.5-4.el8 x86_64__Red Hat, Inc.__An XML parser library__GPLv3+
+libcom_err 0:1.45.6-1.el8 x86_64__Red Hat, Inc.__Common error description library__GPLv3+
+libuuid 0:2.32.1-27.el8 x86_64__Red Hat, Inc.__Universally unique ID library__GPLv3+
+gmp 1:6.1.2-10.el8 x86_64__Red Hat, Inc.__A GNU arbitrary precision library__GPLv3+
+libacl 0:2.2.53-1.el8 x86_64__Red Hat, Inc.__Dynamic library for access control list support__GPLv3+
+libblkid 0:2.32.1-27.el8 x86_64__Red Hat, Inc.__Block device ID library__GPLv3+
+sed 0:4.5-2.el8 x86_64__Red Hat, Inc.__A GNU stream text editor__GPLv3+
+libstdc++ 0:8.4.1-1.el8 x86_64__Red Hat, Inc.__GNU Standard C++ Library__GPLv3+
+p11-kit 0:0.23.22-1.el8 x86_64__Red Hat, Inc.__Library for loading and sharing PKCS#11 modules__GPLv3+
+libunistring 0:0.9.9-3.el8 x86_64__Red Hat, Inc.__GNU Unicode string library__GPLv3+
+libgcrypt 0:1.8.5-4.el8 x86_64__Red Hat, Inc.__A general-purpose cryptography library__GPLv3+
+libcap-ng 0:0.7.9-5.el8 x86_64__Red Hat, Inc.__An alternate posix capabilities library__GPLv3+
+libnl3 0:3.5.0-1.el8 x86_64__Red Hat, Inc.__Convenience library for kernel netlink sockets__GPLv3+
+libassuan 0:2.5.1-3.el8 x86_64__Red Hat, Inc.__GnuPG IPC library__GPLv3+
+keyutils-libs 0:1.5.10-6.el8 x86_64__Red Hat, Inc.__Key utilities library__GPLv3+
+p11-kit-trust 0:0.23.22-1.el8 x86_64__Red Hat, Inc.__System trust module from p11-kit__GPLv3+
+grep 0:3.1-6.el8 x86_64__Red Hat, Inc.__Pattern matching utilities__GPLv3+
+dbus-libs 1:1.12.8-12.el8_4.2 x86_64__Red Hat, Inc.__Libraries for accessing D-BUS__GPLv3+
+dbus-tools 1:1.12.8-12.el8_4.2 x86_64__Red Hat, Inc.__D-BUS Tools and Utilities__GPLv3+
+gdbm 1:1.18-1.el8 x86_64__Red Hat, Inc.__A GNU set of database routines which use extensible hashing__GPLv3+
+shadow-utils 2:4.6-12.el8 x86_64__Red Hat, Inc.__Utilities for managing accounts and shadow password files__GPLv3+
+libpsl 0:0.20.2-6.el8 x86_64__Red Hat, Inc.__C library for the Publix Suffix List__GPLv3+
+gzip 0:1.9-12.el8 x86_64__Red Hat, Inc.__The GNU data compression program__GPLv3+
+cracklib-dicts 0:2.9.6-15.el8 x86_64__Red Hat, Inc.__The standard CrackLib dictionaries__GPLv3+
+mpfr 0:3.1.6-1.el8 x86_64__Red Hat, Inc.__A C library for multiple-precision floating-point computations__GPLv3+
+libcomps 0:0.1.11-5.el8 x86_64__Red Hat, Inc.__Comps XML file manipulation library__GPLv3+
+brotli 0:1.0.6-3.el8 x86_64__Red Hat, Inc.__Lossless compression algorithm__GPLv3+
+libnghttp2 0:1.33.0-3.el8_2.1 x86_64__Red Hat, Inc.__A library implementing the HTTP/2 protocol__GPLv3+
+libsigsegv 0:2.11-5.el8 x86_64__Red Hat, Inc.__Library for handling page faults in user mode__GPLv3+
+libverto 0:0.3.0-5.el8 x86_64__Red Hat, Inc.__Main loop abstraction library__GPLv3+
+libtirpc 0:1.1.4-4.el8 x86_64__Red Hat, Inc.__Transport Independent RPC Library__GPLv3+
+openssl-libs 1:1.1.1g-15.el8_3 x86_64__Red Hat, Inc.__A general purpose cryptography library with TLS implementation__GPLv3+
+crypto-policies-scripts 0:20210209-1.gitbfb6bed.el8_3 noarch__Red Hat, Inc.__Tool to switch between crypto policies__GPLv3+
+platform-python 0:3.6.8-39.el8_4 x86_64__Red Hat, Inc.__Internal interpreter of the Python programming language__GPLv3+
+libdb 0:5.3.28-42.el8_4 x86_64__Red Hat, Inc.__The Berkeley DB database library for C__GPLv3+
+pam 0:1.3.1-14.el8 x86_64__Red Hat, Inc.__An extensible library which provides authentication for applications__GPLv3+
+util-linux 0:2.32.1-27.el8 x86_64__Red Hat, Inc.__A collection of basic system utilities__GPLv3+
+gnutls 0:3.6.14-8.el8_3 x86_64__Red Hat, Inc.__A TLS protocol implementation__GPLv3+
+json-glib 0:1.4.4-1.el8 x86_64__Red Hat, Inc.__Library for JavaScript Object Notation format__GPLv3+
+python3-iniparse 0:0.4-31.el8 noarch__Red Hat, Inc.__Python Module for Accessing and Modifying Configuration Data in INI files__GPLv3+
+dbus-glib 0:0.110-2.el8 x86_64__Red Hat, Inc.__GLib bindings for D-Bus__GPLv3+
+gobject-introspection 0:1.56.1-1.el8 x86_64__Red Hat, Inc.__Introspection system for GObject-based libraries__GPLv3+
+cyrus-sasl-lib 0:2.1.27-5.el8 x86_64__Red Hat, Inc.__Shared libraries needed by applications which use Cyrus SASL__GPLv3+
+libuser 0:0.62-23.el8 x86_64__Red Hat, Inc.__A user and group account administration library__GPLv3+
+usermode 0:1.113-1.el8 x86_64__Red Hat, Inc.__Tools for certain user account management tasks__GPLv3+
+python3-ethtool 0:0.14-3.el8 x86_64__Red Hat, Inc.__Python module to interface with ethtool__GPLv3+
+python3-libxml2 0:2.9.7-9.el8_4.2 x86_64__Red Hat, Inc.__Python 3 bindings for the libxml2 library__GPLv3+
+python3-chardet 0:3.0.4-7.el8 noarch__Red Hat, Inc.__Character encoding auto-detection in Python 3__GPLv3+
+python3-idna 0:2.5-5.el8 noarch__Red Hat, Inc.__Internationalized Domain Names in Applications (IDNA)__GPLv3+
+python3-pysocks 0:1.6.8-3.el8 noarch__Red Hat, Inc.__A Python SOCKS client module__GPLv3+
+python3-requests 0:2.20.0-2.1.el8_1 noarch__Red Hat, Inc.__HTTP library, written in Python, for human beings__GPLv3+
+libarchive 0:3.3.3-1.el8 x86_64__Red Hat, Inc.__A library for handling streaming archive formats__GPLv3+
+ima-evm-utils 0:1.3.2-12.el8 x86_64__Red Hat, Inc.__IMA/EVM support utilities__GPLv3+
+npth 0:1.5-4.el8 x86_64__Red Hat, Inc.__The New GNU Portable Threads library__GPLv3+
+gpgme 0:1.13.1-7.el8 x86_64__Red Hat, Inc.__GnuPG Made Easy - high level crypto API__GPLv3+
+pciutils-libs 0:3.7.0-1.el8 x86_64__Red Hat, Inc.__Linux PCI library__GPLv3+
+virt-what 0:1.18-9.el8_4 x86_64__Red Hat, Inc.__Detect if we are running in a virtual machine__GPLv3+
+libssh 0:0.9.4-2.el8 x86_64__Red Hat, Inc.__A library implementing the SSH protocol__GPLv3+
+librepo 0:1.12.0-3.el8 x86_64__Red Hat, Inc.__Repodata downloading library__GPLv3+
+curl 0:7.61.1-18.el8_4.2 x86_64__Red Hat, Inc.__A utility for getting files from remote servers (FTP, HTTP, and others)__GPLv3+
+rpm-libs 0:4.14.3-14.el8_4 x86_64__Red Hat, Inc.__Libraries for manipulating RPM packages__GPLv3+
+libsolv 0:0.7.16-3.el8_4 x86_64__Red Hat, Inc.__Package dependency solver__GPLv3+
+python3-libdnf 0:0.55.0-7.el8 x86_64__Red Hat, Inc.__Python 3 bindings for the libdnf library.__GPLv3+
+libreport-filesystem 0:2.9.5-15.el8 x86_64__Red Hat, Inc.__Filesystem layout for libreport__GPLv3+
+hwdata 0:0.314-8.8.el8 noarch__Red Hat, Inc.__Hardware identification and configuration data__GPLv3+
+rdma-core 0:32.0-4.el8 x86_64__Red Hat, Inc.__RDMA core userspace libraries and daemons__GPLv3+
+libpcap 14:1.9.1-5.el8 x86_64__Red Hat, Inc.__A system-independent interface for user-level packet capture__GPLv3+
+dbus-common 1:1.12.8-12.el8_4.2 noarch__Red Hat, Inc.__D-BUS message bus configuration__GPLv3+
+device-mapper 8:1.02.175-5.el8 x86_64__Red Hat, Inc.__Device mapper utility__GPLv3+
+cryptsetup-libs 0:2.3.3-4.el8 x86_64__Red Hat, Inc.__Cryptsetup shared library__GPLv3+
+elfutils-libs 0:0.182-3.el8 x86_64__Red Hat, Inc.__Libraries to handle compiled objects__GPLv3+
+systemd 0:239-45.el8_4.3 x86_64__Red Hat, Inc.__System and Service Manager__GPLv3+
+rpm-build-libs 0:4.14.3-14.el8_4 x86_64__Red Hat, Inc.__Libraries for building and signing RPM packages__GPLv3+
+python3-dnf 0:4.4.2-11.el8 noarch__Red Hat, Inc.__Python 3 interface to DNF__GPLv3+
+python3-dnf-plugins-core 0:4.0.18-4.el8 noarch__Red Hat, Inc.__Core Plugins for DNF__GPLv3+
+python3-subscription-manager-rhsm 0:1.28.13-4.el8_4 x86_64__Red Hat, Inc.__A Python library to communicate with a Red Hat Unified Entitlement Platform__GPLv3+
+yum 0:4.4.2-11.el8 noarch__Red Hat, Inc.__Package manager__GPLv3+
+tar 2:1.30-5.el8 x86_64__Red Hat, Inc.__A GNU file archiving program__GPLv3+
+findutils 1:4.6.0-20.el8 x86_64__Red Hat, Inc.__The GNU versions of find utilities (find and xargs)__GPLv3+
+rootfiles 0:8.1-22.el8 noarch__Red Hat, Inc.__The basic required files for the root user's directory__GPLv3+
+gpg-pubkey 0:d4082792-5b32db75 (none)__(none)__gpg(Red Hat, Inc. (auxiliary key) <security@redhat.com>)__(none)
+libgcc 0:8.4.1-1.el8 x86_64__Red Hat, Inc.__GCC version 8 shared support library__GPLv3+
+python3-setuptools-wheel 0:39.2.0-6.el8 noarch__Red Hat, Inc.__The setuptools wheel__GPLv3+
+subscription-manager-rhsm-certificates 0:1.28.13-4.el8_4 x86_64__Red Hat, Inc.__Certificates required to communicate with a Red Hat Unified Entitlement Platform__GPLv3+
+setup 0:2.12.2-6.el8 noarch__Red Hat, Inc.__A set of system configuration and setup files__GPLv3+
+basesystem 0:11-5.el8 noarch__Red Hat, Inc.__The skeleton package which defines a simple Red Hat Enterprise Linux system__GPLv3+
+ncurses-base 0:6.1-7.20180224.el8 noarch__Red Hat, Inc.__Descriptions of common terminals__GPLv3+
+libselinux 0:2.9-5.el8 x86_64__Red Hat, Inc.__SELinux library and simple utilities__GPLv3+
+glibc-minimal-langpack 0:2.28-151.el8 x86_64__Red Hat, Inc.__Minimal language packs for glibc.__GPLv3+
+glibc 0:2.28-151.el8 x86_64__Red Hat, Inc.__The GNU libc libraries__GPLv3+
+libsepol 0:2.9-2.el8 x86_64__Red Hat, Inc.__SELinux binary policy manipulation library__GPLv3+
+xz-libs 0:5.2.4-3.el8 x86_64__Red Hat, Inc.__Libraries for decoding LZMA compression__GPLv3+
+libgpg-error 0:1.31-1.el8 x86_64__Red Hat, Inc.__Library for error values used by GnuPG components__GPLv3+
+info 0:6.5-6.el8 x86_64__Red Hat, Inc.__A stand-alone TTY-based reader for GNU texinfo documentation__GPLv3+
+libxcrypt 0:4.1.1-4.el8 x86_64__Red Hat, Inc.__Extended crypt library for DES, MD5, Blowfish and others__GPLv3+
+popt 0:1.18-1.el8 x86_64__Red Hat, Inc.__C library for parsing command line parameters__GPLv3+
+sqlite-libs 0:3.26.0-13.el8 x86_64__Red Hat, Inc.__Shared library for the sqlite3 embeddable SQL database engine.__GPLv3+
+json-c 0:0.13.1-0.4.el8 x86_64__Red Hat, Inc.__JSON implementation in C__GPLv3+
+libffi 0:3.1-22.el8 x86_64__Red Hat, Inc.__A portable foreign function interface library__GPLv3+
+readline 0:7.0-10.el8 x86_64__Red Hat, Inc.__A library for editing typed command lines__GPLv3+
+libattr 0:2.4.48-3.el8 x86_64__Red Hat, Inc.__Dynamic library for extended attribute support__GPLv3+
+coreutils-single 0:8.30-8.el8 x86_64__Red Hat, Inc.__coreutils multicall binary__GPLv3+
+libmount 0:2.32.1-27.el8 x86_64__Red Hat, Inc.__Device mounting library__GPLv3+
+libsmartcols 0:2.32.1-27.el8 x86_64__Red Hat, Inc.__Formatting library for ls-like programs.__GPLv3+
+lua-libs 0:5.3.4-11.el8 x86_64__Red Hat, Inc.__Libraries for lua__GPLv3+
+chkconfig 0:1.13-2.el8 x86_64__Red Hat, Inc.__A system tool for maintaining the /etc/rc*.d hierarchy__GPLv3+
+libidn2 0:2.2.0-1.el8 x86_64__Red Hat, Inc.__Library to support IDNA2008 internationalized domain names__GPLv3+
+file-libs 0:5.33-16.el8_3.1 x86_64__Red Hat, Inc.__Libraries for applications using libmagic__GPLv3+
+audit-libs 0:3.0-0.17.20191104git1c2f876.el8 x86_64__Red Hat, Inc.__Dynamic library for libaudit__GPLv3+
+lz4-libs 0:1.8.3-3.el8_4 x86_64__Red Hat, Inc.__Libaries for lz4__GPLv3+
+gdbm-libs 1:1.18-1.el8 x86_64__Red Hat, Inc.__Libraries files for gdbm__GPLv3+
+libtasn1 0:4.13-3.el8 x86_64__Red Hat, Inc.__The ASN.1 library used in GNUTLS__GPLv3+
+pcre 0:8.42-4.el8 x86_64__Red Hat, Inc.__Perl-compatible regular expression library__GPLv3+
+systemd-libs 0:239-45.el8_4.3 x86_64__Red Hat, Inc.__systemd libraries__GPLv3+
+ca-certificates 0:2021.2.50-80.0.el8_4 noarch__Red Hat, Inc.__The Mozilla CA root certificate bundle__GPLv3+
+libusbx 0:1.0.23-4.el8 x86_64__Red Hat, Inc.__Library for accessing USB devices__GPLv3+
+libsemanage 0:2.9-6.el8 x86_64__Red Hat, Inc.__SELinux binary policy manipulation library__GPLv3+
+libutempter 0:1.1.6-14.el8 x86_64__Red Hat, Inc.__A privileged helper for utmp/wtmp updates__GPLv3+
+libfdisk 0:2.32.1-27.el8 x86_64__Red Hat, Inc.__Partitioning library for fdisk-like programs.__GPLv3+
+cracklib 0:2.9.6-15.el8 x86_64__Red Hat, Inc.__A password-checking library__GPLv3+
+acl 0:2.2.53-1.el8 x86_64__Red Hat, Inc.__Access control list utilities__GPLv3+
+nettle 0:3.4.1-4.el8_3 x86_64__Red Hat, Inc.__A low-level cryptographic library__GPLv3+
+libksba 0:1.3.5-7.el8 x86_64__Red Hat, Inc.__CMS and X.509 library__GPLv3+
+dmidecode 1:3.2-8.el8 x86_64__Red Hat, Inc.__Tool to analyse BIOS DMI data__GPLv3+
+libseccomp 0:2.5.1-1.el8 x86_64__Red Hat, Inc.__Enhanced seccomp library__GPLv3+
+gawk 0:4.2.1-2.el8 x86_64__Red Hat, Inc.__The GNU version of the AWK text processing utility__GPLv3+
+libnsl2 0:1.2.0-2.20180605git4a062cf.el8 x86_64__Red Hat, Inc.__Public client interface library for NIS(YP) and NIS+__GPLv3+
+krb5-libs 0:1.18.2-8.3.el8_4 x86_64__Red Hat, Inc.__The non-admin shared libraries used by Kerberos 5__GPLv3+
+crypto-policies 0:20210209-1.gitbfb6bed.el8_3 noarch__Red Hat, Inc.__System-wide crypto policies__GPLv3+
+platform-python-setuptools 0:39.2.0-6.el8 noarch__Red Hat, Inc.__Easily build and distribute Python 3 packages__GPLv3+
+python3-libs 0:3.6.8-39.el8_4 x86_64__Red Hat, Inc.__Python runtime libraries__GPLv3+
+libpwquality 0:1.4.4-3.el8 x86_64__Red Hat, Inc.__A library for password generation and password quality checking__GPLv3+
+python3-six 0:1.11.0-8.el8 noarch__Red Hat, Inc.__Python 2 and 3 compatibility utilities__GPLv3+
+python3-dateutil 1:2.6.1-6.el8 noarch__Red Hat, Inc.__Powerful extensions to the standard datetime module__GPLv3+
+glib2 0:2.56.4-10.el8_4.1 x86_64__Red Hat, Inc.__A library of handy utility functions__GPLv3+
+librhsm 0:0.0.3-4.el8 x86_64__Red Hat, Inc.__Red Hat Subscription Manager library__GPLv3+
+kmod-libs 0:25-17.el8 x86_64__Red Hat, Inc.__Libraries to handle kernel module loading and unloading__GPLv3+
+python3-dbus 0:1.2.4-15.el8 x86_64__Red Hat, Inc.__D-Bus bindings for python3__GPLv3+
+python3-gobject-base 0:3.28.3-2.el8 x86_64__Red Hat, Inc.__Python 3 bindings for GObject Introspection base package__GPLv3+
+openldap 0:2.4.46-17.el8_4 x86_64__Red Hat, Inc.__LDAP support libraries__GPLv3+
+passwd 0:0.80-3.el8 x86_64__Red Hat, Inc.__An utility for setting or changing passwords using PAM__GPLv3+
+libdb-utils 0:5.3.28-42.el8_4 x86_64__Red Hat, Inc.__Command line tools for managing Berkeley DB databases__GPLv3+
+python3-libcomps 0:0.1.11-5.el8 x86_64__Red Hat, Inc.__Python 3 bindings for libcomps library__GPLv3+
+python3-dmidecode 0:3.12.2-15.el8 x86_64__Red Hat, Inc.__Python 3 module to access DMI data__GPLv3+
+python3-decorator 0:4.2.1-2.el8 noarch__Red Hat, Inc.__Module to simplify usage of decorators in python3__GPLv3+
+python3-inotify 0:0.9.6-13.el8 noarch__Red Hat, Inc.__Monitor filesystem events with Python under Linux__GPLv3+
+python3-urllib3 0:1.24.2-5.el8 noarch__Red Hat, Inc.__Python3 HTTP library with thread-safe connection pooling and file post__GPLv3+
+python3-syspurpose 0:1.28.13-4.el8_4 x86_64__Red Hat, Inc.__A commandline utility for declaring system syspurpose__GPLv3+
+tpm2-tss 0:2.3.2-3.el8 x86_64__Red Hat, Inc.__TPM2.0 Software Stack__GPLv3+
+libyaml 0:0.1.7-5.el8 x86_64__Red Hat, Inc.__YAML 1.1 parser and emitter written in C__GPLv3+
+gnupg2 0:2.2.20-2.el8 x86_64__Red Hat, Inc.__Utility for secure communication and data storage__GPLv3+
+python3-gpg 0:1.13.1-7.el8 x86_64__Red Hat, Inc.__gpgme bindings for Python 3__GPLv3+
+which 0:2.21-12.el8 x86_64__Red Hat, Inc.__Displays where a particular program in your path is located__GPLv3+
+libssh-config 0:0.9.4-2.el8 noarch__Red Hat, Inc.__Configuration files for libssh__GPLv3+
+libcurl 0:7.61.1-18.el8_4.2 x86_64__Red Hat, Inc.__A library for getting files from web servers__GPLv3+
+python3-librepo 0:1.12.0-3.el8 x86_64__Red Hat, Inc.__Python 3 bindings for the librepo library__GPLv3+
+rpm 0:4.14.3-14.el8_4 x86_64__Red Hat, Inc.__The RPM package management system__GPLv3+
+libmodulemd 0:2.9.4-2.el8 x86_64__Red Hat, Inc.__Module metadata manipulation library__GPLv3+
+libdnf 0:0.55.0-7.el8 x86_64__Red Hat, Inc.__Library providing simplified C and Python API to libsolv__GPLv3+
+python3-hawkey 0:0.55.0-7.el8 x86_64__Red Hat, Inc.__Python 3 bindings for the hawkey library__GPLv3+
+dnf-data 0:4.4.2-11.el8 noarch__Red Hat, Inc.__Common data and configuration files for DNF__GPLv3+
+pciutils 0:3.7.0-1.el8 x86_64__Red Hat, Inc.__PCI bus related utilities__GPLv3+
+libibverbs 0:32.0-4.el8 x86_64__Red Hat, Inc.__A library and drivers for direct userspace use of RDMA (InfiniBand/iWARP/RoCE) hardware__GPLv3+
+iptables-libs 0:1.8.4-17.el8_4.1 x86_64__Red Hat, Inc.__iptables libraries__GPLv3+
+dbus-daemon 1:1.12.8-12.el8_4.2 x86_64__Red Hat, Inc.__D-BUS message bus__GPLv3+
+device-mapper-libs 8:1.02.175-5.el8 x86_64__Red Hat, Inc.__Device-mapper shared library__GPLv3+
+elfutils-default-yama-scope 0:0.182-3.el8 noarch__Red Hat, Inc.__Default yama attach scope sysctl setting__GPLv3+
+systemd-pam 0:239-45.el8_4.3 x86_64__Red Hat, Inc.__systemd PAM module__GPLv3+
+dbus 1:1.12.8-12.el8_4.2 x86_64__Red Hat, Inc.__D-BUS message bus__GPLv3+
+python3-rpm 0:4.14.3-14.el8_4 x86_64__Red Hat, Inc.__Python 3 bindings for apps which will manipulate RPM packages__GPLv3+
+dnf 0:4.4.2-11.el8 noarch__Red Hat, Inc.__Package manager__GPLv3+
+dnf-plugin-subscription-manager 0:1.28.13-4.el8_4 x86_64__Red Hat, Inc.__Subscription Manager plugins for DNF__GPLv3+
+subscription-manager 0:1.28.13-4.el8_4 x86_64__Red Hat, Inc.__Tools and libraries for subscription and repository management__GPLv3+
+gdb-gdbserver 0:8.2-15.el8 x86_64__Red Hat, Inc.__A standalone server for GDB (the GNU source-level debugger)__GPLv3+
+vim-minimal 2:8.0.1763-15.el8 x86_64__Red Hat, Inc.__A minimal version of the VIM editor__GPLv3+
+langpacks-en 0:1.0-12.el8 noarch__Red Hat, Inc.__English langpacks meta-package__GPLv3+
+gpg-pubkey 0:fd431d51-4ae0493b (none)__(none)__gpg(Red Hat, Inc. (release key 2) <security@redhat.com>)__(none)
 """
 
 [commands."rpm -ql which"]

--- a/providers/os/resources/packages/testdata/packages_redhat8_modular.toml
+++ b/providers/os/resources/packages/testdata/packages_redhat8_modular.toml
@@ -4,10 +4,10 @@ stdout="/usr/bin/rpm"
 [commands."rpm -E '%{_dbpath}'"]
 stdout="/var/lib/rpm"
 
-[commands."rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{MODULARITYLABEL}\\n'"]
+[commands."rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}__%{MODULARITYLABEL}\\n'"]
 stdout="""
-tzdata 0:2021c-1.el8 noarch__Red Hat, Inc.__Timezone data__(none)
-bash 0:4.4.20-1.el8_4 x86_64__Red Hat, Inc.__The GNU Bourne Again shell__(none)
-php-common 0:7.4.33-3.module+el8.10.0+23902+d3c8dd8f aarch64__Red Hat, Inc.__Common files for PHP__php:7.4:8100020260119075152:f7998665
-php-cli 0:7.4.33-3.module+el8.10.0+23902+d3c8dd8f aarch64__Red Hat, Inc.__Command-line interface for PHP__php:7.4:8100020260119075152:f7998665
+tzdata 0:2021c-1.el8 noarch__Red Hat, Inc.__Timezone data__GPLv3+__(none)
+bash 0:4.4.20-1.el8_4 x86_64__Red Hat, Inc.__The GNU Bourne Again shell__GPLv3+__(none)
+php-common 0:7.4.33-3.module+el8.10.0+23902+d3c8dd8f aarch64__Red Hat, Inc.__Common files for PHP__GPLv3+__php:7.4:8100020260119075152:f7998665
+php-cli 0:7.4.33-3.module+el8.10.0+23902+d3c8dd8f aarch64__Red Hat, Inc.__Command-line interface for PHP__GPLv3+__php:7.4:8100020260119075152:f7998665
 """

--- a/providers/os/resources/packages/testdata/pacman/openssl-3.2.1-1/desc
+++ b/providers/os/resources/packages/testdata/pacman/openssl-3.2.1-1/desc
@@ -16,3 +16,6 @@ x86_64
 %DEPENDS%
 glibc
 zlib
+
+%LICENSE%
+Apache-2.0

--- a/providers/os/resources/packages/testdata/pacman/zlib-1.2.13-3/desc
+++ b/providers/os/resources/packages/testdata/pacman/zlib-1.2.13-3/desc
@@ -33,3 +33,6 @@ glibc
 
 %PROVIDES%
 libz.so=1-64
+
+%LICENSE%
+custom:Zlib

--- a/providers/os/resources/reboot/rhel.go
+++ b/providers/os/resources/reboot/rhel.go
@@ -30,7 +30,7 @@ func (s *RpmNewestKernel) RebootPending() (bool, error) {
 	}
 
 	// get installed kernel version
-	installedKernelCmd, err := s.conn.RunCommand("rpm -q kernel --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}\n'")
+	installedKernelCmd, err := s.conn.RunCommand("rpm -q kernel --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}\n'")
 	if err != nil {
 		return false, err
 	}

--- a/providers/os/resources/reboot/testdata/redhat_kernel_reboot.toml
+++ b/providers/os/resources/reboot/testdata/redhat_kernel_reboot.toml
@@ -1,8 +1,8 @@
-[commands."rpm -q kernel --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}\n'"]
+[commands."rpm -q kernel --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}\n'"]
 stdout = """
-kernel 0:4.18.0-80.el8 x86_64__Red Hat, Inc.__The Linux kernel
-kernel 0:4.18.0-80.4.2.el8_0 x86_64__Red Hat, Inc.__The Linux kernel
-kernel 0:4.18.0-80.11.2.el8_0 x86_64__Red Hat, Inc.__The Linux kernel
+kernel 0:4.18.0-80.el8 x86_64__Red Hat, Inc.__The Linux kernel__GPLv2
+kernel 0:4.18.0-80.4.2.el8_0 x86_64__Red Hat, Inc.__The Linux kernel__GPLv2
+kernel 0:4.18.0-80.11.2.el8_0 x86_64__Red Hat, Inc.__The Linux kernel__GPLv2
 """
 
 [commands."uname -r"]


### PR DESCRIPTION
## Summary

Adds \`license() string\` to the generic \`package\` resource so software inventory consumers can expose the SPDX license expression alongside vendor/description/cpes.

Part of a series unlocking richer SBOM data for the platform's software API. Follow-ups in this series: \`package.installDate\`, \`npm.package\` description/author/license, \`sbom.Package\` proto fields.

## Per-backend coverage

| backend | source | mode |
|---|---|---|
| **rpm** | \`%{LICENSE}\` rpm queryformat (runtime); \`pkg.License\` from go-rpmdb (static) | eager |
| **dpkg** | \`/usr/share/doc/<pkg>/copyright\` first DEP-5 \`License:\` field | **lazy** |
| **apk** | \`L:\` field of APKINDEX | eager |
| **pacman** | \`%LICENSE%\` block of per-package \`desc\` (FS-fallback path) | eager |
| Windows registry | n/a — no License field on \`HKLM\\...\\Uninstall\` | empty |
| macOS | n/a | empty |

\`license()\` is a computed method, not a plain field, so the dpkg lazy fallback fires only when MQL actually asks for license — no per-package copyright reads on plain \`packages\` enumerations. The eager backends populate via \`CreateResource\` and short-circuit the method body.

## RPM regex extension

\`RPM_REGEX\` gains a new capture group between \`SUMMARY\` and the optional \`MODULARITYLABEL\` segment. The reboot detector in \`providers/os/resources/reboot/rhel.go\` reuses \`ParseRpmPackages\` and was updated to emit the new queryformat.

## Test plan

- [x] \`go test ./providers/os/resources/packages/...\` — all pass
- [x] \`go test ./providers/os/...\` — all pass (the \`device/linux\` build failure also reproduces on \`main\` — pre-existing, unrelated)
- [x] \`golangci-lint run\` — 0 issues
- [x] \`gofmt\` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)