### PR TITLE
✨ npm.package: surface description, author, license

### DIFF
--- a/providers/os/resources/languages/extractor.go
+++ b/providers/os/resources/languages/extractor.go
@@ -55,6 +55,12 @@ type Package struct {
 	Origin string `json:"origin,omitempty"`
 	// Package Vendor/Publisher
 	Vendor string `json:"vendor,omitempty"`
+	// Package Author — distinct from Vendor; some ecosystems
+	// (npm/python) only carry a free-form author string.
+	Author string `json:"author,omitempty"`
+	// Package License — SPDX expression where the source can provide
+	// one (npm package.json `license`, python METADATA `License`).
+	License string `json:"license,omitempty"`
 }
 
 // SortFn is a helper function for slices.SortFunc to sort a slice of Package

--- a/providers/os/resources/languages/javascript/packagejson/extractor.go
+++ b/providers/os/resources/languages/javascript/packagejson/extractor.go
@@ -46,12 +46,35 @@ func (p *packageJson) Root() *languages.Package {
 	root := &languages.Package{
 		Name:         p.Name,
 		Version:      p.Version,
+		Description:  p.Description,
+		Author:       p.authorName(),
+		License:      p.licenseExpression(),
 		Purl:         javascript.NewPackageUrl(p.Name, p.Version),
 		Cpes:         javascript.NewCpes(p.Name, p.Version),
 		EvidenceList: javascript.NewEvidenceList(p.evidence),
 	}
 
 	return root
+}
+
+// authorName surfaces only the name portion of package.json `author`,
+// matching the npm convention. Returns empty when author is omitted.
+func (p *packageJson) authorName() string {
+	if p.Author == nil {
+		return ""
+	}
+	return p.Author.Name
+}
+
+// licenseExpression returns the SPDX expression from package.json
+// `license`. Older packages may use the deprecated `licenses` array;
+// we don't support that here yet — surface empty in that case and add
+// it later if a real package hits it.
+func (p *packageJson) licenseExpression() string {
+	if p.License == nil {
+		return ""
+	}
+	return p.License.Value
 }
 
 func (p *packageJson) Direct() languages.Packages {

--- a/providers/os/resources/languages/javascript/packagejson/extractor_test.go
+++ b/providers/os/resources/languages/javascript/packagejson/extractor_test.go
@@ -5,6 +5,7 @@ package packagejson
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,6 +27,9 @@ func TestPackageJsonExtractor(t *testing.T) {
 	assert.Equal(t, &languages.Package{
 		Name:         "express",
 		Version:      "4.16.4",
+		Description:  "Fast, unopinionated, minimalist web framework",
+		Author:       "TJ Holowaychuk",
+		License:      "MIT",
 		Purl:         "pkg:npm/express@4.16.4",
 		Cpes:         []string{"cpe:2.3:a:express:express:4.16.4:*:*:*:*:*:*:*"},
 		EvidenceList: []*sbom.Evidence{{Type: sbom.EvidenceType_EVIDENCE_TYPE_FILE, Value: "path/package.json"}},
@@ -34,11 +38,15 @@ func TestPackageJsonExtractor(t *testing.T) {
 	list := info.Transitive()
 	assert.Equal(t, 31, len(list))
 
-	// ensure the package is in the list
+	// ensure the package is in the list — Find returns the root entry,
+	// which carries the package.json description/author/license.
 	p := list.Find("express")
 	assert.Equal(t, &languages.Package{
 		Name:         "express",
 		Version:      "4.16.4",
+		Description:  "Fast, unopinionated, minimalist web framework",
+		Author:       "TJ Holowaychuk",
+		License:      "MIT",
 		Purl:         "pkg:npm/express@4.16.4",
 		Cpes:         []string{"cpe:2.3:a:express:express:4.16.4:*:*:*:*:*:*:*"},
 		EvidenceList: []*sbom.Evidence{{Type: sbom.EvidenceType_EVIDENCE_TYPE_FILE, Value: "path/package.json"}},
@@ -61,4 +69,44 @@ func TestPackageJsonExtractor(t *testing.T) {
 		Cpes:         []string{"cpe:2.3:a:range-parser:range-parser:1.2.0:*:*:*:*:*:*:*"},
 		EvidenceList: []*sbom.Evidence{{Type: sbom.EvidenceType_EVIDENCE_TYPE_FILE, Value: "path/package.json"}},
 	}, p, "range-parser package is not as expected")
+}
+
+func TestPackageJsonExtractorAuthorForms(t *testing.T) {
+	// package.json supports two `author` shapes — string ("Name <email>")
+	// and object ({"name":..., "email":..., "url":...}). Both must
+	// surface as the bare name on languages.Package.Author.
+	cases := []struct {
+		name     string
+		raw      string
+		wantName string
+	}{
+		{
+			name:     "string with email and url",
+			raw:      `{"name":"x","version":"1","author":"Jane Doe <jane@example.com> (https://example.com)"}`,
+			wantName: "Jane Doe",
+		},
+		{
+			name:     "string with name only",
+			raw:      `{"name":"x","version":"1","author":"Jane Doe"}`,
+			wantName: "Jane Doe",
+		},
+		{
+			name:     "object form",
+			raw:      `{"name":"x","version":"1","author":{"name":"Jane Doe","email":"jane@example.com"}}`,
+			wantName: "Jane Doe",
+		},
+		{
+			name:     "missing author",
+			raw:      `{"name":"x","version":"1"}`,
+			wantName: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			info, err := (&Extractor{}).Parse(strings.NewReader(tc.raw), "p/package.json")
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantName, info.Root().Author)
+		})
+	}
 }

--- a/providers/os/resources/npm.go
+++ b/providers/os/resources/npm.go
@@ -521,12 +521,15 @@ func newNpmPackage(runtime *plugin.Runtime, pkg *languages.Package) (*mqlNpmPack
 		}
 	}
 	mqlPkg, err := CreateResource(runtime, "npm.package", map[string]*llx.RawData{
-		"id":      llx.StringData(pkg.Name + path),
-		"name":    llx.StringData(pkg.Name),
-		"version": llx.StringData(pkg.Version),
-		"purl":    llx.StringData(pkg.Purl),
-		"cpes":    llx.ArrayData(cpes, types.Resource("cpe")),
-		"files":   llx.ArrayData(mqlFiles, types.Resource("pkgFileInfo")),
+		"id":          llx.StringData(pkg.Name + path),
+		"name":        llx.StringData(pkg.Name),
+		"version":     llx.StringData(pkg.Version),
+		"purl":        llx.StringData(pkg.Purl),
+		"cpes":        llx.ArrayData(cpes, types.Resource("cpe")),
+		"files":       llx.ArrayData(mqlFiles, types.Resource("pkgFileInfo")),
+		"description": llx.StringData(pkg.Description),
+		"author":      llx.StringData(pkg.Author),
+		"license":     llx.StringData(pkg.License),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -2764,6 +2764,20 @@ npm.package @defaults("name version purl") {
   cpes() []core.cpe
   // Package files
   files() []pkgFileInfo
+  // Package description from package.json
+  description string
+  // Package author
+  //
+  // From package.json `author`. Accepts the SPDX-style string form
+  // ("Name <email>") and the object form ({"name":..., "email":...,
+  // "url":...}); only the name portion is surfaced.
+  author string
+  // Package license
+  //
+  // SPDX expression from package.json `license`. The deprecated
+  // `licenses` array is not yet supported — the field is empty in that
+  // case.
+  license string
 }
 
 // Go module inventory

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -4199,6 +4199,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"npm.package.files": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNpmPackage).GetFiles()).ToDataRes(types.Array(types.Resource("pkgFileInfo")))
 	},
+	"npm.package.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlNpmPackage).GetDescription()).ToDataRes(types.String)
+	},
+	"npm.package.author": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlNpmPackage).GetAuthor()).ToDataRes(types.String)
+	},
+	"npm.package.license": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlNpmPackage).GetLicense()).ToDataRes(types.String)
+	},
 	"go.packages.path": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGoPackages).GetPath()).ToDataRes(types.String)
 	},
@@ -10963,6 +10972,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"npm.package.files": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlNpmPackage).Files, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"npm.package.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlNpmPackage).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"npm.package.author": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlNpmPackage).Author, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"npm.package.license": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlNpmPackage).License, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"go.packages.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -29058,12 +29079,15 @@ type mqlNpmPackage struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlNpmPackageInternal it will be used here
-	Id      plugin.TValue[string]
-	Name    plugin.TValue[string]
-	Version plugin.TValue[string]
-	Purl    plugin.TValue[string]
-	Cpes    plugin.TValue[[]any]
-	Files   plugin.TValue[[]any]
+	Id          plugin.TValue[string]
+	Name        plugin.TValue[string]
+	Version     plugin.TValue[string]
+	Purl        plugin.TValue[string]
+	Cpes        plugin.TValue[[]any]
+	Files       plugin.TValue[[]any]
+	Description plugin.TValue[string]
+	Author      plugin.TValue[string]
+	License     plugin.TValue[string]
 }
 
 // createNpmPackage creates a new instance of this resource
@@ -29155,6 +29179,18 @@ func (c *mqlNpmPackage) GetFiles() *plugin.TValue[[]any] {
 
 		return c.files()
 	})
+}
+
+func (c *mqlNpmPackage) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlNpmPackage) GetAuthor() *plugin.TValue[string] {
+	return &c.Author
+}
+
+func (c *mqlNpmPackage) GetLicense() *plugin.TValue[string] {
+	return &c.License
 }
 
 // mqlGoPackages for the go.packages resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -1214,9 +1214,12 @@ nginx.conf.workerProcesses 13.14.1
 nginx.modules 13.14.1
 nginx.version 13.14.1
 npm.package 10.2.1
+npm.package.author 13.16.10
 npm.package.cpes 10.2.1
+npm.package.description 13.16.10
 npm.package.files 10.2.1
 npm.package.id 10.2.1
+npm.package.license 13.16.10
 npm.package.name 10.2.1
 npm.package.purl 10.2.1
 npm.package.version 10.2.1


### PR DESCRIPTION
## Summary

The \`packagejson\` parser already extracts \`description\`, \`author\`, and \`license\` from \`package.json\` — both string and object forms of author are handled. This PR wires those three fields through:

\`packageJson\` → \`languages.Package\` → \`mqlNpmPackage\` (MQL)

## What's added

Three new MQL fields on \`npm.package\`:

| Field | Source |
|---|---|
| \`description\` | package.json \`description\` |
| \`author\` | name portion of package.json \`author\` — accepts the SPDX-style \`\"Name <email> (url)\"\` string form and the \`{name, email, url}\` object form |
| \`license\` | SPDX expression from package.json \`license\` |

\`languages.Package\` gains \`Author string\` and \`License string\` alongside the existing \`Vendor\`/\`Description\`. Author and Vendor are intentionally separate concepts — some ecosystems carry only one or the other (npm has only \`author\`; dpkg has only Vendor).

## What's not in scope

- **Transitive deps**: \`Transitive()\` still emits bare \`(name, version)\` entries from the dep manifest. Surfacing description/author/license for transitive deps would require recursing into each dep's own \`package.json\` — that's what \`packagelockjson\` does, but it doesn't yet propagate these fields either. Separate follow-up.
- **Deprecated \`licenses\` array** (old packages): \`license\` is single-valued in the modern format. We surface empty when only \`licenses\` is present; can add later if a real package hits it.
- **Homepage**: explicitly out of scope.

Independent of #7813 and #7814 — touches only npm code paths.

## Test plan

- [x] \`go test ./providers/os/resources/languages/javascript/...\` — pass
- [x] \`go test ./providers/os/resources/packages/...\` — pass
- [x] \`go test ./providers/os/resources/reboot/...\` — pass
- [x] New \`TestPackageJsonExtractorAuthorForms\` covering string-form, object-form, and missing-author cases
- [x] \`golangci-lint run\` — 0 issues
- [x] \`gofmt\` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)