### PR TITLE
🐛 Ensure ECR images from the same repository don't contain the same duplicate platform identifier.

### DIFF
--- a/providers/aws/resources/discovery.go
+++ b/providers/aws/resources/discovery.go
@@ -356,7 +356,7 @@ func discover(runtime *plugin.Runtime, awsAccount *mqlAwsAccount, target string,
 					name: l["Name"], labels: l,
 					awsObject: awsObject{
 						account: accountId, region: a.Region.Data, arn: a.Arn.Data,
-						id: a.Uri.Data, service: "ecr", objectType: "image",
+						id: a.Uri.Data + "/" + a.Digest.Data, service: "ecr", objectType: "image",
 					},
 				}, conn))
 		}


### PR DESCRIPTION
Noticed this when trying to discover/scan multiple images within the same ECR repository
<img width="201" height="514" alt="image" src="https://github.com/user-attachments/assets/fafabc39-0ef9-4414-8632-794aa526c553" />

which resulted in a single deduplicated asset
<img width="1480" height="162" alt="image" src="https://github.com/user-attachments/assets/ac9d534d-b8be-47fd-a30c-f5cbe3d175b1" />


The reason for this is that the `MondooObjectID` was being constructed via the repository URL which is the same for all images within the repository. The asset explorer would then look for platform id clashes and omit assets that had duplicates which in essence are all image assets except for the first one in the list.

This PR appends the image digest to the repository url which is aligned with how we construct the image host. This guarantees uniqueness across images sharing a repo.