### PR TITLE
✨ Add mql discover command

### DIFF
--- a/apps/mql/cmd/discover.go
+++ b/apps/mql/cmd/discover.go
@@ -26,8 +26,6 @@ func init() {
 	_ = DiscoverCmd.Flags().String("inventory-file", "", "Set the path to the inventory file")
 	_ = DiscoverCmd.Flags().StringP("output-full", "o", "", "Write every discovered asset to this path. When empty, only the per-platform count summary is printed.")
 	_ = DiscoverCmd.Flags().StringP("output-format", "f", string(export.FormatJSON), "Format for --output-full: json (default), jsonl, or yaml.")
-	_ = DiscoverCmd.Flags().StringToString("annotations", nil, "Specify annotations for this run")
-	_ = DiscoverCmd.Flags().MarkHidden("annotations")
 }
 
 var DiscoverCmd = &cobra.Command{
@@ -36,7 +34,6 @@ var DiscoverCmd = &cobra.Command{
 	Long:  `Discover assets defined by an inventory file's discovery targets/filters or via CLI parameters. Prints a per-platform asset count to stdout. Pass --output-full <path> to additionally write every discovered asset to a file; pick the file format with --output-format json|jsonl|yaml (default json). No queries are executed.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		_ = viper.BindPFlag("inventory-file", cmd.Flags().Lookup("inventory-file"))
-		_ = viper.BindPFlag("annotations", cmd.Flags().Lookup("annotations"))
 	},
 	// initialized empty so cobra treats this as a runnable command in --help
 	Run: func(cmd *cobra.Command, args []string) {},
@@ -52,13 +49,7 @@ var DiscoverCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes
 		log.Fatal().Err(err).Msg("invalid --output-format")
 	}
 
-	annotations, _ := cmd.Flags().GetStringToString("annotations")
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-	cliRes.Asset.AddAnnotations(annotations)
-
-	in, err := inventoryloader.ParseOrUse(cliRes.Asset, viper.GetBool("insecure"), annotations)
+	in, err := inventoryloader.ParseOrUse(cliRes.Asset, viper.GetBool("insecure"), nil)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to resolve inventory")
 	}

--- a/apps/mql/cmd/discover.go
+++ b/apps/mql/cmd/discover.go
@@ -1,0 +1,131 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.mondoo.com/mql/v13/cli/inventoryloader"
+	"go.mondoo.com/mql/v13/discovery"
+	"go.mondoo.com/mql/v13/discovery/export"
+	"go.mondoo.com/mql/v13/providers"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func init() {
+	rootCmd.AddCommand(DiscoverCmd)
+
+	_ = DiscoverCmd.Flags().String("inventory-file", "", "Set the path to the inventory file")
+	_ = DiscoverCmd.Flags().StringP("output-full", "o", "", "Write every discovered asset to this path. When empty, only the per-platform count summary is printed.")
+	_ = DiscoverCmd.Flags().StringP("output-format", "f", string(export.FormatJSON), "Format for --output-full: json (default), jsonl, or yaml.")
+	_ = DiscoverCmd.Flags().StringToString("annotations", nil, "Specify annotations for this run")
+	_ = DiscoverCmd.Flags().MarkHidden("annotations")
+}
+
+var DiscoverCmd = &cobra.Command{
+	Use:   "discover",
+	Short: "Discover assets from an inventory file",
+	Long:  `Discover assets defined by an inventory file's discovery targets/filters. Prints a per-platform asset count to stdout. Pass --output-full <path> to additionally write every discovered asset to a file; pick the file format with --output-format json|jsonl|yaml (default json). No queries are executed.`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		_ = viper.BindPFlag("inventory-file", cmd.Flags().Lookup("inventory-file"))
+		_ = viper.BindPFlag("annotations", cmd.Flags().Lookup("annotations"))
+	},
+	// initialized empty so cobra treats this as a runnable command in --help
+	Run: func(cmd *cobra.Command, args []string) {},
+}
+
+var DiscoverCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes *plugin.ParseCLIRes) {
+	ctx := context.Background()
+
+	outPath, _ := cmd.Flags().GetString("output-full")
+	formatStr, _ := cmd.Flags().GetString("output-format")
+	format, err := export.ParseFormat(formatStr)
+	if err != nil {
+		log.Fatal().Err(err).Msg("invalid --output-format")
+	}
+
+	annotations, _ := cmd.Flags().GetStringToString("annotations")
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	cliRes.Asset.AddAnnotations(annotations)
+
+	in, err := inventoryloader.ParseOrUse(cliRes.Asset, viper.GetBool("insecure"), annotations)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to resolve inventory")
+	}
+
+	// Enable staged discovery so providers can split discovery into phases —
+	// same posture mql run uses, keeps memory bounded for large inventories.
+	for _, asset := range in.Spec.Assets {
+		for _, conn := range asset.Connections {
+			if conn.Options == nil {
+				conn.Options = map[string]string{}
+			}
+			conn.Options[plugin.OptionStagedDiscovery] = ""
+		}
+	}
+
+	explorer, err := discovery.NewAssetExplorer(ctx, discovery.AssetExplorerConfig{
+		Inventory: in,
+		Recording: runtime.Recording(),
+	})
+	if err != nil {
+		log.Fatal().Err(err).Msg("could not start discovery")
+	}
+	defer explorer.Shutdown()
+
+	// Recursively connect all first-level discovered children so deeper
+	// children are surfaced too. Without this, mql discover would only emit
+	// the inventory's roots plus their immediate children.
+	connectAll(explorer, explorer.Discovered())
+
+	assets := export.CollectExploredAssets(explorer)
+	printPlatformSummary(assets)
+
+	if outPath == "" {
+		return
+	}
+
+	f, err := os.Create(outPath)
+	if err != nil {
+		log.Fatal().Err(err).Str("path", outPath).Msg("failed to create output file")
+	}
+	defer f.Close()
+
+	if err := export.WriteAssets(f, assets, format); err != nil {
+		log.Fatal().Err(err).Msg("failed to write discovered assets")
+	}
+	log.Info().Str("path", outPath).Str("format", string(format)).Msg("discovered assets written")
+}
+
+// printPlatformSummary writes a per-platform asset count to stdout, sorted
+// alphabetically by platform name. Always runs, regardless of --output-full.
+func printPlatformSummary(assets []*inventory.Asset) {
+	counts := map[string]int{}
+	for _, a := range assets {
+		name := a.GetPlatform().GetName()
+		if name == "" {
+			name = "<unknown>"
+		}
+		counts[name]++
+	}
+	names := make([]string, 0, len(counts))
+	for name := range counts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	fmt.Println("Discovered assets:")
+	for _, name := range names {
+		fmt.Printf("%s: %d\n", name, counts[name])
+	}
+}

--- a/apps/mql/cmd/discover.go
+++ b/apps/mql/cmd/discover.go
@@ -32,8 +32,8 @@ func init() {
 
 var DiscoverCmd = &cobra.Command{
 	Use:   "discover",
-	Short: "Discover assets from an inventory file",
-	Long:  `Discover assets defined by an inventory file's discovery targets/filters. Prints a per-platform asset count to stdout. Pass --output-full <path> to additionally write every discovered asset to a file; pick the file format with --output-format json|jsonl|yaml (default json). No queries are executed.`,
+	Short: "Discover assets",
+	Long:  `Discover assets defined by an inventory file's discovery targets/filters or via CLI parameters. Prints a per-platform asset count to stdout. Pass --output-full <path> to additionally write every discovered asset to a file; pick the file format with --output-format json|jsonl|yaml (default json). No queries are executed.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		_ = viper.BindPFlag("inventory-file", cmd.Flags().Lookup("inventory-file"))
 		_ = viper.BindPFlag("annotations", cmd.Flags().Lookup("annotations"))

--- a/apps/mql/cmd/discover.go
+++ b/apps/mql/cmd/discover.go
@@ -56,12 +56,14 @@ var DiscoverCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes
 
 	// Enable staged discovery so providers can split discovery into phases —
 	// same posture mql run uses, keeps memory bounded for large inventories.
-	for _, asset := range in.Spec.Assets {
-		for _, conn := range asset.Connections {
-			if conn.Options == nil {
-				conn.Options = map[string]string{}
+	if in.Spec != nil {
+		for _, asset := range in.Spec.Assets {
+			for _, conn := range asset.Connections {
+				if conn.Options == nil {
+					conn.Options = map[string]string{}
+				}
+				conn.Options[plugin.OptionStagedDiscovery] = ""
 			}
-			conn.Options[plugin.OptionStagedDiscovery] = ""
 		}
 	}
 
@@ -90,10 +92,15 @@ var DiscoverCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes
 	if err != nil {
 		log.Fatal().Err(err).Str("path", outPath).Msg("failed to create output file")
 	}
-	defer f.Close()
 
 	if err := export.WriteAssets(f, assets, format); err != nil {
+		_ = f.Close()
 		log.Fatal().Err(err).Msg("failed to write discovered assets")
+	}
+	// Explicit close so a late writeback failure (NFS, full disk) surfaces
+	// before we log success. defer wouldn't run on the log.Fatal path above.
+	if err := f.Close(); err != nil {
+		log.Fatal().Err(err).Str("path", outPath).Msg("failed to close output file")
 	}
 	log.Info().Str("path", outPath).Str("format", string(format)).Msg("discovered assets written")
 }

--- a/apps/mql/cmd/discover.go
+++ b/apps/mql/cmd/discover.go
@@ -88,6 +88,11 @@ var DiscoverCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes
 		return
 	}
 
+	if len(assets) == 0 {
+		log.Info().Msg("no assets were discovered")
+		return
+	}
+
 	f, err := os.Create(outPath)
 	if err != nil {
 		log.Fatal().Err(err).Str("path", outPath).Msg("failed to create output file")
@@ -97,8 +102,6 @@ var DiscoverCmdRun = func(cmd *cobra.Command, runtime *providers.Runtime, cliRes
 		_ = f.Close()
 		log.Fatal().Err(err).Msg("failed to write discovered assets")
 	}
-	// Explicit close so a late writeback failure (NFS, full disk) surfaces
-	// before we log success. defer wouldn't run on the log.Fatal path above.
 	if err := f.Close(); err != nil {
 		log.Fatal().Err(err).Str("path", outPath).Msg("failed to close output file")
 	}

--- a/apps/mql/cmd/root.go
+++ b/apps/mql/cmd/root.go
@@ -50,6 +50,11 @@ func BuildRootCmd() (*cobra.Command, error) {
 			Run:     RunCmdRun,
 			Action:  "Run a query with ",
 		},
+		&cliproviders.Command{
+			Command: DiscoverCmd,
+			Run:     DiscoverCmdRun,
+			Action:  "Discover assets with ",
+		},
 	)
 	return rootCmd, err
 }

--- a/discovery/export/format.go
+++ b/discovery/export/format.go
@@ -77,8 +77,6 @@ func WriteAssets(w io.Writer, assets []*inventory.Asset, format Format) error {
 	if writeErr != nil {
 		return writeErr
 	}
-	// Flush explicitly so a buffered-write failure (disk full, broken
-	// pipe) surfaces as an error instead of a silently truncated file.
 	return bw.Flush()
 }
 

--- a/discovery/export/format.go
+++ b/discovery/export/format.go
@@ -1,0 +1,154 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package export
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/discovery"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"sigs.k8s.io/yaml"
+)
+
+// Format identifies the serialization format for discovered assets.
+type Format string
+
+const (
+	FormatYAML  Format = "yaml"  // inventory document containing the discovered assets
+	FormatJSON  Format = "json"  // inventory document containing the discovered assets
+	FormatJSONL Format = "jsonl" // one asset per line
+)
+
+// ParseFormat normalizes and validates s. Returns an error listing the
+// supported formats if s is unknown.
+func ParseFormat(s string) (Format, error) {
+	switch Format(strings.ToLower(s)) {
+	case FormatJSON:
+		return FormatJSON, nil
+	case FormatJSONL:
+		return FormatJSONL, nil
+	case FormatYAML:
+		return FormatYAML, nil
+	default:
+		return "", fmt.Errorf("unknown format %q (expected json, jsonl, yaml)", s)
+	}
+}
+
+var marshalOpts = protojson.MarshalOptions{UseProtoNames: true, EmitUnpopulated: false}
+
+// WriteAssets serializes assets into w using the requested format. Connection
+// credentials are stripped before encoding so the resulting file is safe to
+// share or commit.
+//
+// json/yaml emit a single Mondoo inventory document with the assets nested
+// under .spec.assets — the result is directly re-feedable to mql via
+// --inventory-file. jsonl emits one protojson-encoded asset per line.
+func WriteAssets(w io.Writer, assets []*inventory.Asset, format Format) error {
+	if len(assets) == 0 {
+		log.Warn().Msg("no discovered assets to write")
+		return nil
+	}
+
+	redacted := make([]*inventory.Asset, 0, len(assets))
+	for _, a := range assets {
+		redacted = append(redacted, RedactCredentials(a))
+	}
+
+	bw := bufio.NewWriter(w)
+	defer bw.Flush()
+
+	switch format {
+	case FormatJSONL:
+		return writeJSONL(bw, redacted)
+	case FormatJSON, FormatYAML:
+		return writeInventoryDoc(bw, redacted, format)
+	default:
+		return fmt.Errorf("unknown format %q", format)
+	}
+}
+
+func writeJSONL(bw *bufio.Writer, assets []*inventory.Asset) error {
+	written := 0
+	for _, a := range assets {
+		b, err := marshalOpts.Marshal(a)
+		if err != nil {
+			log.Warn().Err(err).Str("asset", a.GetName()).Msg("skipping asset")
+			continue
+		}
+		// Compact so each record fits on one line, even if protojson chose
+		// to insert whitespace.
+		var line bytes.Buffer
+		if err := json.Compact(&line, b); err != nil {
+			line.Reset()
+			line.Write(b)
+		}
+		if _, err := bw.Write(line.Bytes()); err != nil {
+			return err
+		}
+		if err := bw.WriteByte('\n'); err != nil {
+			return err
+		}
+		written++
+	}
+	log.Info().Int("count", written).Msg("discovery complete")
+	return nil
+}
+
+func writeInventoryDoc(bw *bufio.Writer, assets []*inventory.Asset, format Format) error {
+	inv := &inventory.Inventory{
+		Spec: &inventory.InventorySpec{Assets: assets},
+	}
+	data, err := marshalOpts.Marshal(inv)
+	if err != nil {
+		return err
+	}
+	if format == FormatYAML {
+		// sigs.k8s.io/yaml goes through JSON internally, so proto field
+		// names from protojson carry over unchanged.
+		data, err = yaml.JSONToYAML(data)
+		if err != nil {
+			return err
+		}
+	}
+	if _, err := bw.Write(data); err != nil {
+		return err
+	}
+	log.Info().Int("count", len(assets)).Msg("discovery complete")
+	return nil
+}
+
+// CollectExploredAssets returns Connected roots followed by any remaining
+// Discovered assets, in a stable pre-order traversal. Exposed so callers can
+// perform their own filtering before passing the slice to WriteAssets.
+func CollectExploredAssets(e *discovery.AssetExplorer) []*inventory.Asset {
+	var out []*inventory.Asset
+	for _, t := range e.Connected() {
+		out = append(out, t.Asset)
+	}
+	for _, t := range e.Discovered() {
+		out = append(out, t.Asset)
+	}
+	return out
+}
+
+// RedactCredentials clones the asset and nils out Connections[*].Credentials.
+// The original is untouched, so the explorer's tracked asset stays usable.
+func RedactCredentials(a *inventory.Asset) *inventory.Asset {
+	if a == nil {
+		return nil
+	}
+	clone := proto.Clone(a).(*inventory.Asset)
+	for _, c := range clone.Connections {
+		c.Credentials = nil
+	}
+	return clone
+}

--- a/discovery/export/format.go
+++ b/discovery/export/format.go
@@ -64,16 +64,22 @@ func WriteAssets(w io.Writer, assets []*inventory.Asset, format Format) error {
 	}
 
 	bw := bufio.NewWriter(w)
-	defer bw.Flush()
 
+	var writeErr error
 	switch format {
 	case FormatJSONL:
-		return writeJSONL(bw, redacted)
+		writeErr = writeJSONL(bw, redacted)
 	case FormatJSON, FormatYAML:
-		return writeInventoryDoc(bw, redacted, format)
+		writeErr = writeInventoryDoc(bw, redacted, format)
 	default:
 		return fmt.Errorf("unknown format %q", format)
 	}
+	if writeErr != nil {
+		return writeErr
+	}
+	// Flush explicitly so a buffered-write failure (disk full, broken
+	// pipe) surfaces as an error instead of a silently truncated file.
+	return bw.Flush()
 }
 
 func writeJSONL(bw *bufio.Writer, assets []*inventory.Asset) error {

--- a/test/commands/testdata/mql.ct
+++ b/test/commands/testdata/mql.ct
@@ -12,6 +12,7 @@ Usage:
 
 Available Commands:
   completion    Generate the autocompletion script for the specified shell
+  discover      Discover assets
   help          Help about any command
   login         Register with Mondoo Platform
   logout        Log out from Mondoo Platform


### PR DESCRIPTION
## Summary

Adds a new top-level `mql discover` subcommand that runs only asset discovery (no queries, no policies) and reports per-platform counts to stdout. Optionally writes every discovered asset to a file via `--output-full` in `json` (default), `jsonl`, or `yaml`.

Serialization helpers live in `discovery/export` so cnspec can wrap them directly when it grows its own discover flow — no copy/paste.

The `json`/`yaml` forms emit a Mondoo inventory document purely for convenience because it serves as a wrapper to the discovered assets. Credentials are stripped from every connection before serialization.

## Flags

| Flag | Default | Purpose |
|---|---|---|
| `--inventory-file` | — | Inventory YAML to load |
| `-o`, `--output-full` | `""` | Write full discovered assets to this path. Empty = summary only |
| `-f`, `--output-format` | `json` | `json` \| `jsonl` \| `yaml` |

Same provider subcommand surface as `mql run` / `mql shell` —`mql discover aws ...`, `mql discover k8s ...` etc. work uniformly.

## Examples

### 1. From an inventory file, JSON output

```yaml
# inv.yaml
spec:
  assets:
    - connections:
        - type: aws
          options:
            profile: my-profile
          discover:
            targets: [ecr-image-api]
            filter:
              ecr:scope: private
```

```
$ mql discover --inventory-file inv.yaml --output-full /tmp/assets.json

Discovered assets:
aws: 1
aws-ecr-image: 12
→ discovered assets written format=json path=/tmp/assets.json
```

### 2. Pure CLI — no inventory file

```
$ mql discover aws --profile my-profile --discover ecr-image-api --filters ecr:scope=private

Discovered assets:
aws: 1
aws-ecr-image: 12
```

or a simpler one:
```
$ mql discover local

Discovered assets:
macos: 1
```

Add `-o /tmp/out.yaml -f yaml` for a re-feedable YAML inventory; `-f jsonl` for one-asset-per-line streaming.

### 3. Summary only

Omit `--output-full` entirely and you just get the platform breakdown on stdout. Useful for a quick "what's in this account?" check.

## Test plan

- [ ] `make test/lint`
- [ ] `make test/go/plain`
- [x] Live run against an AWS account:
  - `--inventory-file` path with inventory containing discover targets and filters
  - CLI flags (`--discover`, `--filters`, `--profile`)
  - Default summary (no `--output-full`)
  - All three output formats — JSON parses as `{spec: {assets: [...]}}`, YAML round-trips through `--inventory-file`, JSONL is one asset per line
  - `ecr:scope=private`, `ecr:scope=public` filters honored
  - Credentials stripped from every connection in every format

🤖 Generated with [Claude Code](https://claude.com/claude-code)