### PR TITLE
🎉 arista-13.3.0

### DIFF
--- a/providers/arista/config/config.go
+++ b/providers/arista/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "arista",
 	ID:              "go.mondoo.com/cnquery/v9/providers/arista",
-	Version:         "13.2.6",
+	Version:         "13.3.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### arista (13.3.0)
- ✨ arista: add arista.eos.eapi service config + arista.eos.vrrp groups (#7808)
- 🧹 stricter rules for titles+description on resources/fields (#7763)
- 🧹 Update deps for mql and providers 20260521 (#7760)