### PR TITLE
🎉 tailscale-13.2.0

### DIFF
--- a/providers/tailscale/config/config.go
+++ b/providers/tailscale/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "tailscale",
 	ID:              "go.mondoo.com/mql/v13/providers/tailscale",
-	Version:         "13.1.7",
+	Version:         "13.2.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### tailscale (13.2.0)
- ✨ tailscale: add authKey, webhook, and logstream resources (#7809)
- 🧹 stricter rules for titles+description on resources/fields (#7763)
- 🧹 Update deps for mql and providers 20260521 (#7760)