### PR TITLE
✨ os: add windows-ad-sid platform ID detector

### DIFF
--- a/providers/os/id/ids/ids.go
+++ b/providers/os/id/ids/ids.go
@@ -10,6 +10,7 @@ const (
 	IdDetector_BiosUUID     = "bios-uuid"
 	IdDetector_CloudDetect  = "cloud-detect"
 	IdDetector_AwsEcs       = "aws-ecs"
+	IdDetector_WindowsADSID = "windows-ad-sid"
 
 	// IdDetector_PlatformID = "transport-platform-id" // TODO: how does this work?
 )

--- a/providers/os/id/platform.go
+++ b/providers/os/id/platform.go
@@ -22,6 +22,7 @@ import (
 	"go.mondoo.com/mql/v13/providers/os/id/ids"
 	"go.mondoo.com/mql/v13/providers/os/id/machineid"
 	"go.mondoo.com/mql/v13/providers/os/id/serialnumber"
+	"go.mondoo.com/mql/v13/providers/os/id/windowsadsid"
 )
 
 type PlatformFingerprint struct {
@@ -220,6 +221,17 @@ func gatherPlatformInfo(conn shared.Connection, pf *inventory.Platform, idDetect
 		uuid, err := biosuuid.BiosUUID(conn, pf)
 		if err == nil && len(uuid) > 0 {
 			identifier = "//platformid.api.mondoo.app/bios-uuid/" + uuid
+			return &platformInfo{
+				IDs:                []string{identifier},
+				Name:               "",
+				RelatedPlatformIDs: []string{},
+			}, nil
+		}
+		return &platformInfo{}, nil
+	case ids.IdDetector_WindowsADSID:
+		sid, err := windowsadsid.WindowsADSID(conn, pf)
+		if err == nil && len(sid) > 0 {
+			identifier = "//platformid.api.mondoo.app/windows-ad-sid/" + sid
 			return &platformInfo{
 				IDs:                []string{identifier},
 				Name:               "",

--- a/providers/os/id/platform.go
+++ b/providers/os/id/platform.go
@@ -230,7 +230,10 @@ func gatherPlatformInfo(conn shared.Connection, pf *inventory.Platform, idDetect
 		return &platformInfo{}, nil
 	case ids.IdDetector_WindowsADSID:
 		sid, err := windowsadsid.WindowsADSID(conn, pf)
-		if err == nil && len(sid) > 0 {
+		if err != nil {
+			return nil, err
+		}
+		if len(sid) > 0 {
 			identifier = "//platformid.api.mondoo.app/windows-ad-sid/" + sid
 			return &platformInfo{
 				IDs:                []string{identifier},

--- a/providers/os/id/windowsadsid/windowsadsid.go
+++ b/providers/os/id/windowsadsid/windowsadsid.go
@@ -1,0 +1,80 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package windowsadsid
+
+import (
+	"io"
+	"regexp"
+	"strings"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/v13/providers/os/resources/powershell"
+)
+
+// adSidScript resolves the AD computer object's SID for the current Windows host.
+//
+// It deliberately uses Win32_ComputerSystem.Domain (set by the host's domain join
+// state) rather than $env:USERDOMAIN, because the cnspec service runs as
+// LocalSystem and $env:USERDOMAIN can be unset or report the local computer name
+// in that context. The PartOfDomain check short-circuits non-domain-joined hosts
+// (workgroup, standalone) so the detector returns an empty string instead of
+// translating a name that does not resolve and raising an exception.
+const adSidScript = `
+$ErrorActionPreference = 'SilentlyContinue'
+$sys = Get-CimInstance Win32_ComputerSystem
+if ($null -eq $sys -or -not $sys.PartOfDomain) { return }
+$account = $sys.Domain + '\' + $env:COMPUTERNAME + '$'
+try {
+  (New-Object System.Security.Principal.NTAccount($account)).Translate([System.Security.Principal.SecurityIdentifier]).Value
+} catch {
+  return
+}
+`
+
+// sidPattern validates a SID of the form S-R-I-S[-S...] (uppercase, dash separated).
+// AD computer SIDs are typically S-1-5-21-<sub1>-<sub2>-<sub3>-<RID>.
+var sidPattern = regexp.MustCompile(`^S-\d+-\d+(?:-\d+)+$`)
+
+// WindowsADSID returns the AD computer object SID for a domain-joined Windows host.
+// Returns ("", nil) on non-Windows platforms, on workgroup/standalone Windows
+// hosts, or when the SID cannot be resolved — the detector is best-effort and
+// callers should fall through to other detectors when the result is empty.
+func WindowsADSID(conn shared.Connection, pf *inventory.Platform) (string, error) {
+	if pf == nil || !pf.IsFamily(inventory.FAMILY_WINDOWS) {
+		return "", nil
+	}
+
+	cmd, err := conn.RunCommand(powershell.Encode(adSidScript))
+	if err != nil {
+		return "", err
+	}
+
+	if cmd.ExitStatus != 0 {
+		// non-zero exit is treated as "not detected"; cnspec falls through to other detectors.
+		return "", nil
+	}
+
+	data, err := io.ReadAll(cmd.Stdout)
+	if err != nil {
+		return "", err
+	}
+
+	return parseSIDOutput(string(data)), nil
+}
+
+// parseSIDOutput trims whitespace from the PowerShell stdout and validates that
+// the result is a SID. Returns the SID on success or an empty string when the
+// output is empty, only whitespace, or not a SID (e.g. an error message that
+// reached stdout). Exposed for tests.
+func parseSIDOutput(out string) string {
+	sid := strings.TrimSpace(out)
+	if sid == "" {
+		return ""
+	}
+	if !sidPattern.MatchString(sid) {
+		return ""
+	}
+	return sid
+}

--- a/providers/os/id/windowsadsid/windowsadsid_test.go
+++ b/providers/os/id/windowsadsid/windowsadsid_test.go
@@ -120,14 +120,14 @@ func (c *stubConn) RunCommand(command string) (*shared.Command, error) {
 	}, nil
 }
 
-func (c *stubConn) ID() uint32                                  { return 1 }
-func (c *stubConn) ParentID() uint32                            { return 0 }
-func (c *stubConn) Name() string                                { return "stub" }
-func (c *stubConn) Type() shared.ConnectionType                 { return shared.Type_Local }
-func (c *stubConn) Asset() *inventory.Asset                     { return &inventory.Asset{} }
-func (c *stubConn) UpdateAsset(asset *inventory.Asset)          {}
-func (c *stubConn) Capabilities() shared.Capabilities           { return shared.Capability_RunCommand }
-func (c *stubConn) FileSystem() afero.Fs                        { return afero.NewMemMapFs() }
+func (c *stubConn) ID() uint32                         { return 1 }
+func (c *stubConn) ParentID() uint32                   { return 0 }
+func (c *stubConn) Name() string                       { return "stub" }
+func (c *stubConn) Type() shared.ConnectionType        { return shared.Type_Local }
+func (c *stubConn) Asset() *inventory.Asset            { return &inventory.Asset{} }
+func (c *stubConn) UpdateAsset(asset *inventory.Asset) {}
+func (c *stubConn) Capabilities() shared.Capabilities  { return shared.Capability_RunCommand }
+func (c *stubConn) FileSystem() afero.Fs               { return afero.NewMemMapFs() }
 func (c *stubConn) FileInfo(path string) (shared.FileInfoDetails, error) {
 	return shared.FileInfoDetails{}, nil
 }

--- a/providers/os/id/windowsadsid/windowsadsid_test.go
+++ b/providers/os/id/windowsadsid/windowsadsid_test.go
@@ -1,0 +1,140 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package windowsadsid
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+)
+
+func TestParseSIDOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"valid SID", "S-1-5-21-1004336348-1177238915-682003330-1014", "S-1-5-21-1004336348-1177238915-682003330-1014"},
+		{"trailing newline", "S-1-5-21-1004336348-1177238915-682003330-1014\r\n", "S-1-5-21-1004336348-1177238915-682003330-1014"},
+		{"leading and trailing whitespace", "  S-1-5-21-1-2-3-1001  ", "S-1-5-21-1-2-3-1001"},
+		{"empty", "", ""},
+		{"whitespace only", "  \r\n  ", ""},
+		{"PowerShell exception text", "Exception calling \"Translate\" with \"1\" argument(s): \"Some or all identity references could not be translated.\"", ""},
+		{"missing S prefix", "1-5-21-1-2-3-1001", ""},
+		{"too few subauthorities", "S-1", ""},
+		{"non-numeric component", "S-1-5-21-foo-bar-baz-1001", ""},
+		{"trailing dash", "S-1-5-21-1-2-3-", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseSIDOutput(tt.in)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestWindowsADSID_NonWindowsPlatform(t *testing.T) {
+	conn := newStubConn(t, "", 0)
+	pf := &inventory.Platform{Name: "ubuntu", Family: []string{"linux", "unix"}}
+
+	sid, err := WindowsADSID(conn, pf)
+	require.NoError(t, err)
+	assert.Empty(t, sid)
+	assert.Zero(t, conn.callCount, "non-windows platforms must not run a command")
+}
+
+func TestWindowsADSID_NilPlatform(t *testing.T) {
+	conn := newStubConn(t, "", 0)
+	sid, err := WindowsADSID(conn, nil)
+	require.NoError(t, err)
+	assert.Empty(t, sid)
+}
+
+func TestWindowsADSID_DomainJoinedHostReturnsSID(t *testing.T) {
+	conn := newStubConn(t, "S-1-5-21-1004336348-1177238915-682003330-1014\r\n", 0)
+	pf := &inventory.Platform{Name: "windows", Family: []string{"windows"}}
+
+	sid, err := WindowsADSID(conn, pf)
+	require.NoError(t, err)
+	assert.Equal(t, "S-1-5-21-1004336348-1177238915-682003330-1014", sid)
+	assert.Equal(t, 1, conn.callCount)
+}
+
+func TestWindowsADSID_WorkgroupHostReturnsEmpty(t *testing.T) {
+	// The PartOfDomain check in the PowerShell script exits early with no output
+	// on workgroup/standalone hosts.
+	conn := newStubConn(t, "", 0)
+	pf := &inventory.Platform{Name: "windows", Family: []string{"windows"}}
+
+	sid, err := WindowsADSID(conn, pf)
+	require.NoError(t, err)
+	assert.Empty(t, sid)
+}
+
+func TestWindowsADSID_NonZeroExitReturnsEmpty(t *testing.T) {
+	conn := newStubConn(t, "powershell error", 1)
+	pf := &inventory.Platform{Name: "windows", Family: []string{"windows"}}
+
+	sid, err := WindowsADSID(conn, pf)
+	require.NoError(t, err)
+	assert.Empty(t, sid)
+}
+
+func TestWindowsADSID_GarbledOutputReturnsEmpty(t *testing.T) {
+	// guards against PowerShell exception text reaching stdout via misconfigured
+	// ErrorActionPreference or pipeline output.
+	conn := newStubConn(t, "Exception calling \"Translate\"...", 0)
+	pf := &inventory.Platform{Name: "windows", Family: []string{"windows"}}
+
+	sid, err := WindowsADSID(conn, pf)
+	require.NoError(t, err)
+	assert.Empty(t, sid)
+}
+
+// stubConn is a minimal shared.Connection that returns a canned stdout/exit
+// status for any command, recording how many times RunCommand was invoked.
+type stubConn struct {
+	t         *testing.T
+	stdout    string
+	exitCode  int
+	callCount int
+}
+
+func newStubConn(t *testing.T, stdout string, exitCode int) *stubConn {
+	return &stubConn{t: t, stdout: stdout, exitCode: exitCode}
+}
+
+func (c *stubConn) RunCommand(command string) (*shared.Command, error) {
+	c.callCount++
+	return &shared.Command{
+		Command:    command,
+		Stdout:     bytes.NewBufferString(c.stdout),
+		Stderr:     bytes.NewBuffer(nil),
+		ExitStatus: c.exitCode,
+	}, nil
+}
+
+func (c *stubConn) ID() uint32                                  { return 1 }
+func (c *stubConn) ParentID() uint32                            { return 0 }
+func (c *stubConn) Name() string                                { return "stub" }
+func (c *stubConn) Type() shared.ConnectionType                 { return shared.Type_Local }
+func (c *stubConn) Asset() *inventory.Asset                     { return &inventory.Asset{} }
+func (c *stubConn) UpdateAsset(asset *inventory.Asset)          {}
+func (c *stubConn) Capabilities() shared.Capabilities           { return shared.Capability_RunCommand }
+func (c *stubConn) FileSystem() afero.Fs                        { return afero.NewMemMapFs() }
+func (c *stubConn) FileInfo(path string) (shared.FileInfoDetails, error) {
+	return shared.FileInfoDetails{}, nil
+}
+
+// Asserts that stubConn implements the shared.Connection interface.
+var _ shared.Connection = (*stubConn)(nil)
+
+// Silence unused-import warning for plugin when iface changes upstream.
+var _ = plugin.Connection(nil)

--- a/providers/os/id/windowsadsid/windowsadsid_test.go
+++ b/providers/os/id/windowsadsid/windowsadsid_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
 )
 
@@ -135,6 +134,3 @@ func (c *stubConn) FileInfo(path string) (shared.FileInfoDetails, error) {
 
 // Asserts that stubConn implements the shared.Connection interface.
 var _ shared.Connection = (*stubConn)(nil)
-
-// Silence unused-import warning for plugin when iface changes upstream.
-var _ = plugin.Connection(nil)


### PR DESCRIPTION
Resolves the AD computer object's SID for domain-joined Windows hosts and emits //platformid.api.mondoo.app/windows-ad-sid/<SID> as the platform ID. Fills the gap for Windows fleets cloned from a template that was not sysprepped /generalize: SMBIOS UUIDs collide across all clones, but each domain-join mints a unique AD computer SID, so this detector disambiguates them.

The detector runs a base64-encoded PowerShell script that checks PartOfDomain first (so workgroup/standalone hosts return an empty string, not an error), then translates Domain\COMPUTERNAME$ via NTAccount.Translate. Output is validated against a strict SID regex before being accepted so PowerShell exception text leaking into stdout is rejected. Non-Windows / nil platform takes a fast-path that returns empty without running a command.

Opt-in via id_detector: [windows-ad-sid] in the inventory or the --id-detector flag.