### PR TITLE
🎉 digitalocean-13.3.0

### DIFF
--- a/providers/digitalocean/config/config.go
+++ b/providers/digitalocean/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "digitalocean",
 	ID:              "go.mondoo.com/mql/providers/digitalocean",
-	Version:         "13.2.0",
+	Version:         "13.3.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### digitalocean (13.3.0)
- ✨ digitalocean: Spaces bucket auditing + database backups & CA certificate (#7799)
- 🧹 stricter rules for titles+description on resources/fields (#7763)
- 🧹 Update deps for mql and providers 20260521 (#7760)