### PR TITLE
🎉 oci-13.7.0

### DIFF
--- a/providers/oci/config/config.go
+++ b/providers/oci/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "oci",
 	ID:              "go.mondoo.com/cnquery/v9/providers/oci",
-	Version:         "13.6.1",
+	Version:         "13.7.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### oci (13.7.0)
- ✨ oci: typed refs for image, vault, securityGroups, topics, compartment (#7801)
- 🧹 stricter rules for titles+description on resources/fields (#7763)
- 🧹 Update deps for mql and providers 20260521 (#7760)