### PR TITLE
✨ digitalocean.account: expose team UUID and name

### DIFF
--- a/providers/digitalocean/resources/digitalocean.go
+++ b/providers/digitalocean/resources/digitalocean.go
@@ -36,6 +36,13 @@ func initDigitaloceanAccount(runtime *plugin.Runtime, args map[string]*llx.RawDa
 	args["emailVerified"] = llx.BoolData(acct.EmailVerified)
 	args["status"] = llx.StringData(acct.Status)
 	args["statusMessage"] = llx.StringData(acct.StatusMessage)
+	teamUuid, teamName := "", ""
+	if acct.Team != nil {
+		teamUuid = acct.Team.UUID
+		teamName = acct.Team.Name
+	}
+	args["teamUuid"] = llx.StringData(teamUuid)
+	args["teamName"] = llx.StringData(teamName)
 	return args, nil, nil
 }
 

--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -94,6 +94,10 @@ digitalocean.account @defaults("email status") {
   status string
   // Status message
   statusMessage string
+  // UUID of the team that owns this account; empty when the API token is not scoped to a team
+  teamUuid string
+  // Display name of the team that owns this account; empty when the API token is not scoped to a team
+  teamName string
 }
 
 // DigitalOcean Droplet

--- a/providers/digitalocean/resources/digitalocean.lr.go
+++ b/providers/digitalocean/resources/digitalocean.lr.go
@@ -359,6 +359,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.account.statusMessage": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanAccount).GetStatusMessage()).ToDataRes(types.String)
 	},
+	"digitalocean.account.teamUuid": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanAccount).GetTeamUuid()).ToDataRes(types.String)
+	},
+	"digitalocean.account.teamName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanAccount).GetTeamName()).ToDataRes(types.String)
+	},
 	"digitalocean.droplet.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDroplet).GetId()).ToDataRes(types.Int)
 	},
@@ -1390,6 +1396,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.account.statusMessage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanAccount).StatusMessage, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.account.teamUuid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanAccount).TeamUuid, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.account.teamName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanAccount).TeamName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"digitalocean.droplet.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3189,6 +3203,8 @@ type mqlDigitaloceanAccount struct {
 	EmailVerified   plugin.TValue[bool]
 	Status          plugin.TValue[string]
 	StatusMessage   plugin.TValue[string]
+	TeamUuid        plugin.TValue[string]
+	TeamName        plugin.TValue[string]
 }
 
 // createDigitaloceanAccount creates a new instance of this resource
@@ -3258,6 +3274,14 @@ func (c *mqlDigitaloceanAccount) GetStatus() *plugin.TValue[string] {
 
 func (c *mqlDigitaloceanAccount) GetStatusMessage() *plugin.TValue[string] {
 	return &c.StatusMessage
+}
+
+func (c *mqlDigitaloceanAccount) GetTeamUuid() *plugin.TValue[string] {
+	return &c.TeamUuid
+}
+
+func (c *mqlDigitaloceanAccount) GetTeamName() *plugin.TValue[string] {
+	return &c.TeamName
 }
 
 // mqlDigitaloceanDroplet for the digitalocean.droplet resource

--- a/providers/digitalocean/resources/digitalocean.lr.versions
+++ b/providers/digitalocean/resources/digitalocean.lr.versions
@@ -9,6 +9,8 @@ digitalocean.account.emailVerified 13.0.1
 digitalocean.account.floatingIpLimit 13.0.1
 digitalocean.account.status 13.0.1
 digitalocean.account.statusMessage 13.0.1
+digitalocean.account.teamName 13.3.1
+digitalocean.account.teamUuid 13.3.1
 digitalocean.account.uuid 13.0.1
 digitalocean.account.volumeLimit 13.0.1
 digitalocean.alertPolicies 13.0.1


### PR DESCRIPTION
## Summary
- Add `teamUuid` and `teamName` to `digitalocean.account`, sourced from godo's `account.Team` field.
- Empty strings when the API token is not scoped to a team.

## Why
Account-level audits need to attribute findings to the owning team. This is the entire team-related surface godo exposes (`account.TeamInfo` is just `{UUID, Name}`) — there is no team-member, API-token, or OAuth-app listing in the SDK, so this is the realistic "expose team" change.

## Test plan
- [ ] `cnspec shell digitalocean -c "digitalocean.account { teamUuid teamName }"` against a team-scoped token returns the team UUID and display name
- [ ] Same query against a non-team token returns empty strings (does not error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)