### PR TITLE
✨ hetzner: surface additional fields from the hcloud SDK

### DIFF
--- a/providers/hetzner/resources/hetzner.lr
+++ b/providers/hetzner/resources/hetzner.lr
@@ -95,6 +95,8 @@ private hetzner.server @defaults("id name status") {
   publicIpv6DnsPtr []dict
   // Firewalls applied to the server
   firewalls() []hetzner.firewall
+  // Firewalls applied to the server, with per-binding application status (applied, pending)
+  firewallBindings() []hetzner.server.firewallBinding
   // Load balancers attached to the server
   loadBalancers() []hetzner.loadBalancer
   // Backup window (e.g., "22-02"); empty if backups disabled
@@ -133,6 +135,18 @@ private hetzner.server.privateNet @defaults("ip macAddress") {
   aliasIps []string
   // MAC address of the network interface
   macAddress string
+}
+
+// Hetzner Cloud server firewall binding
+private hetzner.server.firewallBinding @defaults("status") {
+  // Parent server ID (composite key with firewallId)
+  serverId int
+  // Bound firewall ID (composite key)
+  firewallId int
+  // Hetzner Cloud firewall bound to the server
+  firewall() hetzner.firewall
+  // Application status (applied, pending)
+  status string
 }
 
 // Hetzner Cloud server type (VM size)
@@ -201,12 +215,16 @@ private hetzner.image @defaults("id name type") {
   osFlavor string
   // OS version
   osVersion string
+  // Architecture (x86, arm)
+  architecture string
   // Whether rapid deploy is supported
   rapidDeploy bool
   // Resource protection (delete)
   protection dict
   // Deprecation timestamp (nullable)
   deprecated time
+  // Deletion timestamp (nullable)
+  deleted time
   // User-defined labels for organizing the resource
   labels map[string]string
   // Bound server (nullable, for snapshots/backups)
@@ -276,6 +294,8 @@ private hetzner.network @defaults("id name ipRange") {
   routes []dict
   // Servers attached to this network
   servers() []hetzner.server
+  // Load balancers attached to this network
+  loadBalancers() []hetzner.loadBalancer
   // Whether routes are exposed to vSwitch
   exposeRoutesToVswitch bool
   // Resource protection (delete)
@@ -334,6 +354,8 @@ private hetzner.primaryIp @defaults("id ip type") {
   blocked bool
   // Datacenter the IP belongs to
   datacenter() hetzner.datacenter
+  // Location the IP belongs to
+  location() hetzner.location
   // Server the IP is assigned to (nullable)
   server() hetzner.server
   // Reverse DNS entries [{ip, dnsPtr}]
@@ -482,6 +504,8 @@ private hetzner.certificate @defaults("id name type") {
   type string
   // SHA256 fingerprint
   fingerprint string
+  // PEM-encoded certificate body
+  certificate string
   // Validity start
   notValidBefore time
   // Validity end

--- a/providers/hetzner/resources/hetzner.lr.go
+++ b/providers/hetzner/resources/hetzner.lr.go
@@ -19,6 +19,7 @@ const (
 	ResourceHetzner                       string = "hetzner"
 	ResourceHetznerServer                 string = "hetzner.server"
 	ResourceHetznerServerPrivateNet       string = "hetzner.server.privateNet"
+	ResourceHetznerServerFirewallBinding  string = "hetzner.server.firewallBinding"
 	ResourceHetznerServerType             string = "hetzner.serverType"
 	ResourceHetznerServerTypeLocation     string = "hetzner.serverType.location"
 	ResourceHetznerImage                  string = "hetzner.image"
@@ -55,6 +56,10 @@ func init() {
 		"hetzner.server.privateNet": {
 			// to override args, implement: initHetznerServerPrivateNet(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createHetznerServerPrivateNet,
+		},
+		"hetzner.server.firewallBinding": {
+			// to override args, implement: initHetznerServerFirewallBinding(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createHetznerServerFirewallBinding,
 		},
 		"hetzner.serverType": {
 			Init:   initHetznerServerType,
@@ -311,6 +316,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"hetzner.server.firewalls": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerServer).GetFirewalls()).ToDataRes(types.Array(types.Resource("hetzner.firewall")))
 	},
+	"hetzner.server.firewallBindings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerServer).GetFirewallBindings()).ToDataRes(types.Array(types.Resource("hetzner.server.firewallBinding")))
+	},
 	"hetzner.server.loadBalancers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerServer).GetLoadBalancers()).ToDataRes(types.Array(types.Resource("hetzner.loadBalancer")))
 	},
@@ -361,6 +369,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"hetzner.server.privateNet.macAddress": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerServerPrivateNet).GetMacAddress()).ToDataRes(types.String)
+	},
+	"hetzner.server.firewallBinding.serverId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerServerFirewallBinding).GetServerId()).ToDataRes(types.Int)
+	},
+	"hetzner.server.firewallBinding.firewallId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerServerFirewallBinding).GetFirewallId()).ToDataRes(types.Int)
+	},
+	"hetzner.server.firewallBinding.firewall": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerServerFirewallBinding).GetFirewall()).ToDataRes(types.Resource("hetzner.firewall"))
+	},
+	"hetzner.server.firewallBinding.status": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerServerFirewallBinding).GetStatus()).ToDataRes(types.String)
 	},
 	"hetzner.serverType.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerServerType).GetId()).ToDataRes(types.Int)
@@ -443,6 +463,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"hetzner.image.osVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerImage).GetOsVersion()).ToDataRes(types.String)
 	},
+	"hetzner.image.architecture": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerImage).GetArchitecture()).ToDataRes(types.String)
+	},
 	"hetzner.image.rapidDeploy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerImage).GetRapidDeploy()).ToDataRes(types.Bool)
 	},
@@ -451,6 +474,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"hetzner.image.deprecated": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerImage).GetDeprecated()).ToDataRes(types.Time)
+	},
+	"hetzner.image.deleted": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerImage).GetDeleted()).ToDataRes(types.Time)
 	},
 	"hetzner.image.labels": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerImage).GetLabels()).ToDataRes(types.Map(types.String, types.String))
@@ -533,6 +559,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"hetzner.network.servers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerNetwork).GetServers()).ToDataRes(types.Array(types.Resource("hetzner.server")))
 	},
+	"hetzner.network.loadBalancers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerNetwork).GetLoadBalancers()).ToDataRes(types.Array(types.Resource("hetzner.loadBalancer")))
+	},
 	"hetzner.network.exposeRoutesToVswitch": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerNetwork).GetExposeRoutesToVswitch()).ToDataRes(types.Bool)
 	},
@@ -604,6 +633,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"hetzner.primaryIp.datacenter": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerPrimaryIp).GetDatacenter()).ToDataRes(types.Resource("hetzner.datacenter"))
+	},
+	"hetzner.primaryIp.location": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerPrimaryIp).GetLocation()).ToDataRes(types.Resource("hetzner.location"))
 	},
 	"hetzner.primaryIp.server": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerPrimaryIp).GetServer()).ToDataRes(types.Resource("hetzner.server"))
@@ -778,6 +810,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"hetzner.certificate.fingerprint": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerCertificate).GetFingerprint()).ToDataRes(types.String)
+	},
+	"hetzner.certificate.certificate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerCertificate).GetCertificate()).ToDataRes(types.String)
 	},
 	"hetzner.certificate.notValidBefore": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerCertificate).GetNotValidBefore()).ToDataRes(types.Time)
@@ -1048,6 +1083,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlHetznerServer).Firewalls, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"hetzner.server.firewallBindings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerServer).FirewallBindings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"hetzner.server.loadBalancers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerServer).LoadBalancers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -1118,6 +1157,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"hetzner.server.privateNet.macAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerServerPrivateNet).MacAddress, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"hetzner.server.firewallBinding.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerServerFirewallBinding).__id, ok = v.Value.(string)
+		return
+	},
+	"hetzner.server.firewallBinding.serverId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerServerFirewallBinding).ServerId, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"hetzner.server.firewallBinding.firewallId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerServerFirewallBinding).FirewallId, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"hetzner.server.firewallBinding.firewall": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerServerFirewallBinding).Firewall, ok = plugin.RawToTValue[*mqlHetznerFirewall](v.Value, v.Error)
+		return
+	},
+	"hetzner.server.firewallBinding.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerServerFirewallBinding).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"hetzner.serverType.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1240,6 +1299,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlHetznerImage).OsVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"hetzner.image.architecture": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerImage).Architecture, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"hetzner.image.rapidDeploy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerImage).RapidDeploy, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -1250,6 +1313,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"hetzner.image.deprecated": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerImage).Deprecated, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"hetzner.image.deleted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerImage).Deleted, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"hetzner.image.labels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1372,6 +1439,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlHetznerNetwork).Servers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"hetzner.network.loadBalancers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerNetwork).LoadBalancers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"hetzner.network.exposeRoutesToVswitch": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerNetwork).ExposeRoutesToVswitch, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -1474,6 +1545,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"hetzner.primaryIp.datacenter": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerPrimaryIp).Datacenter, ok = plugin.RawToTValue[*mqlHetznerDatacenter](v.Value, v.Error)
+		return
+	},
+	"hetzner.primaryIp.location": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerPrimaryIp).Location, ok = plugin.RawToTValue[*mqlHetznerLocation](v.Value, v.Error)
 		return
 	},
 	"hetzner.primaryIp.server": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1734,6 +1809,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"hetzner.certificate.fingerprint": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerCertificate).Fingerprint, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"hetzner.certificate.certificate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerCertificate).Certificate, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"hetzner.certificate.notValidBefore": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2257,6 +2336,7 @@ type mqlHetznerServer struct {
 	PublicIpv6Blocked plugin.TValue[bool]
 	PublicIpv6DnsPtr  plugin.TValue[[]any]
 	Firewalls         plugin.TValue[[]any]
+	FirewallBindings  plugin.TValue[[]any]
 	LoadBalancers     plugin.TValue[[]any]
 	BackupWindow      plugin.TValue[string]
 	RescueEnabled     plugin.TValue[bool]
@@ -2507,6 +2587,22 @@ func (c *mqlHetznerServer) GetFirewalls() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlHetznerServer) GetFirewallBindings() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.FirewallBindings, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("hetzner.server", c.__id, "firewallBindings")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.firewallBindings()
+	})
+}
+
 func (c *mqlHetznerServer) GetLoadBalancers() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.LoadBalancers, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -2671,6 +2767,82 @@ func (c *mqlHetznerServerPrivateNet) GetAliasIps() *plugin.TValue[[]any] {
 
 func (c *mqlHetznerServerPrivateNet) GetMacAddress() *plugin.TValue[string] {
 	return &c.MacAddress
+}
+
+// mqlHetznerServerFirewallBinding for the hetzner.server.firewallBinding resource
+type mqlHetznerServerFirewallBinding struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlHetznerServerFirewallBindingInternal it will be used here
+	ServerId   plugin.TValue[int64]
+	FirewallId plugin.TValue[int64]
+	Firewall   plugin.TValue[*mqlHetznerFirewall]
+	Status     plugin.TValue[string]
+}
+
+// createHetznerServerFirewallBinding creates a new instance of this resource
+func createHetznerServerFirewallBinding(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlHetznerServerFirewallBinding{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("hetzner.server.firewallBinding", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlHetznerServerFirewallBinding) MqlName() string {
+	return "hetzner.server.firewallBinding"
+}
+
+func (c *mqlHetznerServerFirewallBinding) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlHetznerServerFirewallBinding) GetServerId() *plugin.TValue[int64] {
+	return &c.ServerId
+}
+
+func (c *mqlHetznerServerFirewallBinding) GetFirewallId() *plugin.TValue[int64] {
+	return &c.FirewallId
+}
+
+func (c *mqlHetznerServerFirewallBinding) GetFirewall() *plugin.TValue[*mqlHetznerFirewall] {
+	return plugin.GetOrCompute[*mqlHetznerFirewall](&c.Firewall, func() (*mqlHetznerFirewall, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("hetzner.server.firewallBinding", c.__id, "firewall")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlHetznerFirewall), nil
+			}
+		}
+
+		return c.firewall()
+	})
+}
+
+func (c *mqlHetznerServerFirewallBinding) GetStatus() *plugin.TValue[string] {
+	return &c.Status
 }
 
 // mqlHetznerServerType for the hetzner.serverType resource
@@ -2875,22 +3047,24 @@ type mqlHetznerImage struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlHetznerImageInternal
-	Id          plugin.TValue[int64]
-	Type        plugin.TValue[string]
-	Status      plugin.TValue[string]
-	Name        plugin.TValue[string]
-	Description plugin.TValue[string]
-	ImageSize   plugin.TValue[float64]
-	DiskSize    plugin.TValue[float64]
-	Created     plugin.TValue[*time.Time]
-	OsFlavor    plugin.TValue[string]
-	OsVersion   plugin.TValue[string]
-	RapidDeploy plugin.TValue[bool]
-	Protection  plugin.TValue[any]
-	Deprecated  plugin.TValue[*time.Time]
-	Labels      plugin.TValue[map[string]any]
-	BoundServer plugin.TValue[*mqlHetznerServer]
-	CreatedFrom plugin.TValue[*mqlHetznerServer]
+	Id           plugin.TValue[int64]
+	Type         plugin.TValue[string]
+	Status       plugin.TValue[string]
+	Name         plugin.TValue[string]
+	Description  plugin.TValue[string]
+	ImageSize    plugin.TValue[float64]
+	DiskSize     plugin.TValue[float64]
+	Created      plugin.TValue[*time.Time]
+	OsFlavor     plugin.TValue[string]
+	OsVersion    plugin.TValue[string]
+	Architecture plugin.TValue[string]
+	RapidDeploy  plugin.TValue[bool]
+	Protection   plugin.TValue[any]
+	Deprecated   plugin.TValue[*time.Time]
+	Deleted      plugin.TValue[*time.Time]
+	Labels       plugin.TValue[map[string]any]
+	BoundServer  plugin.TValue[*mqlHetznerServer]
+	CreatedFrom  plugin.TValue[*mqlHetznerServer]
 }
 
 // createHetznerImage creates a new instance of this resource
@@ -2970,6 +3144,10 @@ func (c *mqlHetznerImage) GetOsVersion() *plugin.TValue[string] {
 	return &c.OsVersion
 }
 
+func (c *mqlHetznerImage) GetArchitecture() *plugin.TValue[string] {
+	return &c.Architecture
+}
+
 func (c *mqlHetznerImage) GetRapidDeploy() *plugin.TValue[bool] {
 	return &c.RapidDeploy
 }
@@ -2980,6 +3158,10 @@ func (c *mqlHetznerImage) GetProtection() *plugin.TValue[any] {
 
 func (c *mqlHetznerImage) GetDeprecated() *plugin.TValue[*time.Time] {
 	return &c.Deprecated
+}
+
+func (c *mqlHetznerImage) GetDeleted() *plugin.TValue[*time.Time] {
+	return &c.Deleted
 }
 
 func (c *mqlHetznerImage) GetLabels() *plugin.TValue[map[string]any] {
@@ -3227,6 +3409,7 @@ type mqlHetznerNetwork struct {
 	Subnets               plugin.TValue[[]any]
 	Routes                plugin.TValue[[]any]
 	Servers               plugin.TValue[[]any]
+	LoadBalancers         plugin.TValue[[]any]
 	ExposeRoutesToVswitch plugin.TValue[bool]
 	Protection            plugin.TValue[any]
 	Labels                plugin.TValue[map[string]any]
@@ -3306,6 +3489,22 @@ func (c *mqlHetznerNetwork) GetServers() *plugin.TValue[[]any] {
 		}
 
 		return c.servers()
+	})
+}
+
+func (c *mqlHetznerNetwork) GetLoadBalancers() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.LoadBalancers, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("hetzner.network", c.__id, "loadBalancers")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.loadBalancers()
 	})
 }
 
@@ -3463,6 +3662,7 @@ type mqlHetznerPrimaryIp struct {
 	AutoDelete   plugin.TValue[bool]
 	Blocked      plugin.TValue[bool]
 	Datacenter   plugin.TValue[*mqlHetznerDatacenter]
+	Location     plugin.TValue[*mqlHetznerLocation]
 	Server       plugin.TValue[*mqlHetznerServer]
 	DnsPtr       plugin.TValue[[]any]
 	Protection   plugin.TValue[any]
@@ -3552,6 +3752,22 @@ func (c *mqlHetznerPrimaryIp) GetDatacenter() *plugin.TValue[*mqlHetznerDatacent
 		}
 
 		return c.datacenter()
+	})
+}
+
+func (c *mqlHetznerPrimaryIp) GetLocation() *plugin.TValue[*mqlHetznerLocation] {
+	return plugin.GetOrCompute[*mqlHetznerLocation](&c.Location, func() (*mqlHetznerLocation, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("hetzner.primaryIp", c.__id, "location")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlHetznerLocation), nil
+			}
+		}
+
+		return c.location()
 	})
 }
 
@@ -4213,6 +4429,7 @@ type mqlHetznerCertificate struct {
 	Name           plugin.TValue[string]
 	Type           plugin.TValue[string]
 	Fingerprint    plugin.TValue[string]
+	Certificate    plugin.TValue[string]
 	NotValidBefore plugin.TValue[*time.Time]
 	NotValidAfter  plugin.TValue[*time.Time]
 	DomainNames    plugin.TValue[[]any]
@@ -4274,6 +4491,10 @@ func (c *mqlHetznerCertificate) GetType() *plugin.TValue[string] {
 
 func (c *mqlHetznerCertificate) GetFingerprint() *plugin.TValue[string] {
 	return &c.Fingerprint
+}
+
+func (c *mqlHetznerCertificate) GetCertificate() *plugin.TValue[string] {
+	return &c.Certificate
 }
 
 func (c *mqlHetznerCertificate) GetNotValidBefore() *plugin.TValue[*time.Time] {

--- a/providers/hetzner/resources/hetzner.lr.versions
+++ b/providers/hetzner/resources/hetzner.lr.versions
@@ -3,6 +3,7 @@
 
 hetzner 13.0.1
 hetzner.certificate 13.0.1
+hetzner.certificate.certificate 13.1.2
 hetzner.certificate.created 13.0.1
 hetzner.certificate.domainNames 13.0.1
 hetzner.certificate.fingerprint 13.0.1
@@ -49,9 +50,11 @@ hetzner.floatingIp.server 13.0.1
 hetzner.floatingIp.type 13.0.1
 hetzner.floatingIps 13.0.1
 hetzner.image 13.0.1
+hetzner.image.architecture 13.1.2
 hetzner.image.boundServer 13.0.1
 hetzner.image.created 13.0.1
 hetzner.image.createdFrom 13.0.1
+hetzner.image.deleted 13.1.2
 hetzner.image.deprecated 13.0.1
 hetzner.image.description 13.0.1
 hetzner.image.diskSize 13.0.1
@@ -138,6 +141,7 @@ hetzner.network.exposeRoutesToVswitch 13.0.1
 hetzner.network.id 13.0.1
 hetzner.network.ipRange 13.0.1
 hetzner.network.labels 13.0.1
+hetzner.network.loadBalancers 13.1.2
 hetzner.network.name 13.0.1
 hetzner.network.protection 13.0.1
 hetzner.network.routes 13.0.1
@@ -163,6 +167,7 @@ hetzner.primaryIp.dnsPtr 13.0.1
 hetzner.primaryIp.id 13.0.1
 hetzner.primaryIp.ip 13.0.1
 hetzner.primaryIp.labels 13.0.1
+hetzner.primaryIp.location 13.1.2
 hetzner.primaryIp.name 13.0.1
 hetzner.primaryIp.protection 13.0.1
 hetzner.primaryIp.server 13.0.1
@@ -172,6 +177,12 @@ hetzner.server 13.0.1
 hetzner.server.backupWindow 13.0.1
 hetzner.server.created 13.0.1
 hetzner.server.datacenter 13.0.1
+hetzner.server.firewallBinding 13.1.2
+hetzner.server.firewallBinding.firewall 13.1.2
+hetzner.server.firewallBinding.firewallId 13.1.2
+hetzner.server.firewallBinding.serverId 13.1.2
+hetzner.server.firewallBinding.status 13.1.2
+hetzner.server.firewallBindings 13.1.2
 hetzner.server.firewalls 13.0.1
 hetzner.server.floatingIps 13.0.1
 hetzner.server.id 13.0.1

--- a/providers/hetzner/resources/hetzner_certificate.go
+++ b/providers/hetzner/resources/hetzner_certificate.go
@@ -64,6 +64,7 @@ func newMqlHetznerCertificate(runtime *plugin.Runtime, cert *hcloud.Certificate)
 		"name":           llx.StringData(cert.Name),
 		"type":           llx.StringData(string(cert.Type)),
 		"fingerprint":    llx.StringData(cert.Fingerprint),
+		"certificate":    llx.StringData(cert.Certificate),
 		"notValidBefore": llx.TimeDataPtr(timePtr(cert.NotValidBefore)),
 		"notValidAfter":  llx.TimeDataPtr(timePtr(cert.NotValidAfter)),
 		"domainNames":    stringArrayData(cert.DomainNames),

--- a/providers/hetzner/resources/hetzner_image.go
+++ b/providers/hetzner/resources/hetzner_image.go
@@ -41,21 +41,23 @@ func (h *mqlHetzner) images() ([]any, error) {
 
 func newMqlHetznerImage(runtime *plugin.Runtime, img *hcloud.Image) (*mqlHetznerImage, error) {
 	res, err := CreateResource(runtime, "hetzner.image", map[string]*llx.RawData{
-		"__id":        llx.StringData(fmt.Sprintf("hetzner.image/%d", img.ID)),
-		"id":          llx.IntData(img.ID),
-		"type":        llx.StringData(string(img.Type)),
-		"status":      llx.StringData(string(img.Status)),
-		"name":        llx.StringData(img.Name),
-		"description": llx.StringData(img.Description),
-		"imageSize":   llx.FloatData(float64(img.ImageSize)),
-		"diskSize":    llx.FloatData(float64(img.DiskSize)),
-		"created":     llx.TimeDataPtr(timePtr(img.Created)),
-		"osFlavor":    llx.StringData(img.OSFlavor),
-		"osVersion":   llx.StringData(img.OSVersion),
-		"rapidDeploy": llx.BoolData(img.RapidDeploy),
-		"protection":  llx.DictData(protectionDict(img.Protection.Delete)),
-		"deprecated":  llx.TimeDataPtr(timePtr(img.Deprecated)),
-		"labels":      labelData(img.Labels),
+		"__id":         llx.StringData(fmt.Sprintf("hetzner.image/%d", img.ID)),
+		"id":           llx.IntData(img.ID),
+		"type":         llx.StringData(string(img.Type)),
+		"status":       llx.StringData(string(img.Status)),
+		"name":         llx.StringData(img.Name),
+		"description":  llx.StringData(img.Description),
+		"imageSize":    llx.FloatData(float64(img.ImageSize)),
+		"diskSize":     llx.FloatData(float64(img.DiskSize)),
+		"created":      llx.TimeDataPtr(timePtr(img.Created)),
+		"osFlavor":     llx.StringData(img.OSFlavor),
+		"osVersion":    llx.StringData(img.OSVersion),
+		"architecture": llx.StringData(string(img.Architecture)),
+		"rapidDeploy":  llx.BoolData(img.RapidDeploy),
+		"protection":   llx.DictData(protectionDict(img.Protection.Delete)),
+		"deprecated":   llx.TimeDataPtr(timePtr(img.Deprecated)),
+		"deleted":      llx.TimeDataPtr(timePtr(img.Deleted)),
+		"labels":       labelData(img.Labels),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/hetzner/resources/hetzner_network.go
+++ b/providers/hetzner/resources/hetzner_network.go
@@ -12,7 +12,8 @@ import (
 )
 
 type mqlHetznerNetworkInternal struct {
-	cacheServers []*hcloud.Server
+	cacheServers       []*hcloud.Server
+	cacheLoadBalancers []*hcloud.LoadBalancer
 }
 
 func (r *mqlHetznerNetwork) id() (string, error) {
@@ -73,6 +74,7 @@ func newMqlHetznerNetwork(runtime *plugin.Runtime, n *hcloud.Network) (*mqlHetzn
 	}
 	m := res.(*mqlHetznerNetwork)
 	m.cacheServers = n.Servers
+	m.cacheLoadBalancers = n.LoadBalancers
 	return m, nil
 }
 
@@ -99,6 +101,20 @@ func (m *mqlHetznerNetwork) servers() ([]any, error) {
 		// Use NewResource so an init-by-id can fully resolve them on demand.
 		ref, err := NewResource(m.MqlRuntime, "hetzner.server", map[string]*llx.RawData{
 			"id": llx.IntData(s.ID),
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, ref)
+	}
+	return out, nil
+}
+
+func (m *mqlHetznerNetwork) loadBalancers() ([]any, error) {
+	out := make([]any, 0, len(m.cacheLoadBalancers))
+	for _, lb := range m.cacheLoadBalancers {
+		ref, err := NewResource(m.MqlRuntime, "hetzner.loadBalancer", map[string]*llx.RawData{
+			"id": llx.IntData(lb.ID),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/hetzner/resources/hetzner_primaryip.go
+++ b/providers/hetzner/resources/hetzner_primaryip.go
@@ -13,6 +13,7 @@ import (
 
 type mqlHetznerPrimaryIpInternal struct {
 	cacheDatacenter *hcloud.Datacenter
+	cacheLocation   *hcloud.Location
 	cacheServerID   int64
 }
 
@@ -64,6 +65,7 @@ func newMqlHetznerPrimaryIp(runtime *plugin.Runtime, p *hcloud.PrimaryIP) (*mqlH
 	}
 	m := res.(*mqlHetznerPrimaryIp)
 	m.cacheDatacenter = p.Datacenter
+	m.cacheLocation = p.Location
 	if p.AssigneeType == "server" {
 		m.cacheServerID = p.AssigneeID
 	}
@@ -89,6 +91,16 @@ func initHetznerPrimaryIp(runtime *plugin.Runtime, args map[string]*llx.RawData)
 func (m *mqlHetznerPrimaryIp) datacenter() (*mqlHetznerDatacenter, error) {
 	return resolveTypedResource(&m.Datacenter, m.cacheDatacenter, func(dc *hcloud.Datacenter) (*mqlHetznerDatacenter, error) {
 		return newMqlHetznerDatacenter(m.MqlRuntime, dc)
+	})
+}
+
+func (m *mqlHetznerPrimaryIp) location() (*mqlHetznerLocation, error) {
+	loc := m.cacheLocation
+	if loc == nil && m.cacheDatacenter != nil {
+		loc = m.cacheDatacenter.Location
+	}
+	return resolveTypedResource(&m.Location, loc, func(l *hcloud.Location) (*mqlHetznerLocation, error) {
+		return newMqlHetznerLocation(m.MqlRuntime, l)
 	})
 }
 

--- a/providers/hetzner/resources/hetzner_server.go
+++ b/providers/hetzner/resources/hetzner_server.go
@@ -24,7 +24,7 @@ type mqlHetznerServerInternal struct {
 	cachePlacementGroup *hcloud.PlacementGroup
 	cacheISO            *hcloud.ISO
 	cachePrivateNet     []hcloud.ServerPrivateNet
-	cacheFirewallIDs    []int64
+	cacheFirewalls      []*hcloud.ServerFirewallStatus
 	cacheLoadBalancers  []*hcloud.LoadBalancer
 }
 
@@ -94,9 +94,7 @@ func newMqlHetznerServer(runtime *plugin.Runtime, s *hcloud.Server) (*mqlHetzner
 	m.cachePlacementGroup = s.PlacementGroup
 	m.cacheISO = s.ISO
 	m.cachePrivateNet = s.PrivateNet
-	for _, fw := range s.PublicNet.Firewalls {
-		m.cacheFirewallIDs = append(m.cacheFirewallIDs, fw.Firewall.ID)
-	}
+	m.cacheFirewalls = s.PublicNet.Firewalls
 	m.cacheLoadBalancers = s.LoadBalancers
 	return m, nil
 }
@@ -175,15 +173,27 @@ func (m *mqlHetznerServer) floatingIps() ([]any, error) {
 }
 
 func (m *mqlHetznerServer) firewalls() ([]any, error) {
-	out := make([]any, 0, len(m.cacheFirewallIDs))
-	for _, id := range m.cacheFirewallIDs {
+	out := make([]any, 0, len(m.cacheFirewalls))
+	for _, fw := range m.cacheFirewalls {
 		ref, err := NewResource(m.MqlRuntime, "hetzner.firewall", map[string]*llx.RawData{
-			"id": llx.IntData(id),
+			"id": llx.IntData(fw.Firewall.ID),
 		})
 		if err != nil {
 			return nil, err
 		}
 		out = append(out, ref)
+	}
+	return out, nil
+}
+
+func (m *mqlHetznerServer) firewallBindings() ([]any, error) {
+	out := make([]any, 0, len(m.cacheFirewalls))
+	for _, fw := range m.cacheFirewalls {
+		res, err := newMqlHetznerServerFirewallBinding(m.MqlRuntime, m.Id.Data, fw)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
 	}
 	return out, nil
 }
@@ -289,4 +299,37 @@ func (m *mqlHetznerServerPrivateNet) network() (*mqlHetznerNetwork, error) {
 		return nil, err
 	}
 	return ref.(*mqlHetznerNetwork), nil
+}
+
+// --- server.firewallBinding sub-resource ---
+
+func (r *mqlHetznerServerFirewallBinding) id() (string, error) {
+	return fmt.Sprintf("hetzner.server.firewallBinding/%d/%d", r.ServerId.Data, r.FirewallId.Data), nil
+}
+
+func newMqlHetznerServerFirewallBinding(runtime *plugin.Runtime, serverID int64, fw *hcloud.ServerFirewallStatus) (*mqlHetznerServerFirewallBinding, error) {
+	res, err := CreateResource(runtime, "hetzner.server.firewallBinding", map[string]*llx.RawData{
+		"__id":       llx.StringData(fmt.Sprintf("hetzner.server.firewallBinding/%d/%d", serverID, fw.Firewall.ID)),
+		"serverId":   llx.IntData(serverID),
+		"firewallId": llx.IntData(fw.Firewall.ID),
+		"status":     llx.StringData(string(fw.Status)),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlHetznerServerFirewallBinding), nil
+}
+
+func (m *mqlHetznerServerFirewallBinding) firewall() (*mqlHetznerFirewall, error) {
+	if m.FirewallId.Data == 0 {
+		m.Firewall.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	ref, err := NewResource(m.MqlRuntime, "hetzner.firewall", map[string]*llx.RawData{
+		"id": llx.IntData(m.FirewallId.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ref.(*mqlHetznerFirewall), nil
 }


### PR DESCRIPTION
## Summary

The hcloud-go SDK returns several fields per resource that we weren't surfacing. This PR exposes them as queryable schema — all changes are additive, no breaking changes.

- **`hetzner.certificate.certificate`** — PEM-encoded certificate body. Lets users audit key algorithm, key size, signature algorithm, issuer CN, and SAN expansion vs `domainNames`.
- **`hetzner.image.architecture`** and **`hetzner.image.deleted`** — architecture matters for fleet-standardization; `deleted` flags images that vanished out from under bound servers.
- **`hetzner.network.loadBalancers()`** — accessor for LBs attached to a network. Already populated by the SDK; previously dropped.
- **`hetzner.primaryIp.location()`** — the hcloud `PrimaryIP.Datacenter` field is deprecated and will be removed after 2026-07-01 per the SDK; adding `location()` now (matching the pattern already in `hetzner.server`) keeps queries working past that date.
- **`hetzner.server.firewallBindings()`** + new **`hetzner.server.firewallBinding`** sub-resource — preserves the per-binding `Status` (`applied` / `pending`) from `ServerFirewallStatus`. Today we drop the status and cache just firewall IDs, so a "pending" firewall on a server (rule change not yet propagated) is invisible. The existing `firewalls()` accessor is kept for backward compatibility.

All new `.lr.versions` entries land at `13.1.2` (next patch after the current provider version `13.1.1`). The provider's `Version` itself is not bumped per the repo release flow.

## Test plan

- [ ] `make providers/build/hetzner && make providers/install/hetzner`
- [ ] `mql shell hetzner` — confirm the new fields populate:
  - `hetzner.certificates { name certificate notValidAfter }`
  - `hetzner.images.where(type == "snapshot") { id name architecture deleted }`
  - `hetzner.networks { name loadBalancers.length }`
  - `hetzner.primaryIps { id location.name }`
  - `hetzner.servers { name firewallBindings { firewall.name status } }`
- [ ] Verify a server with a freshly-attached firewall reports `status == "pending"` until propagation completes, then `applied`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)