### PR TITLE
🎉 digitalocean-13.4.0

### DIFF
--- a/providers/digitalocean/config/config.go
+++ b/providers/digitalocean/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "digitalocean",
 	ID:              "go.mondoo.com/mql/providers/digitalocean",
-	Version:         "13.3.0",
+	Version:         "13.4.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### digitalocean (13.4.0)
- ✨ digitalocean.account: expose team UUID and name (#7842)
- ✨ digitalocean.registry: tags, manifests, GC, subscription (#7843)