### PR TITLE
✨ cloudformation: typed outputs, resource policies, and parameter

### DIFF
--- a/providers/cloudformation/resources/cloudformation.go
+++ b/providers/cloudformation/resources/cloudformation.go
@@ -4,7 +4,9 @@
 package resources
 
 import (
+	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/ranger-rpc/codes"
@@ -53,4 +55,89 @@ func convertYamlToDict(valueNode *yaml.Node) (map[string]any, error) {
 	}
 
 	return convert.JsonToDict(dict)
+}
+
+// nodeToDict resolves the child node under `key` to a Go value suitable for
+// `llx.DictData`. Returns nil when the key is absent. The field stays `dict`
+// in the schema because CloudFormation values can be scalars (literal default,
+// intrinsic function evaluating to a string), lists, or full mapping bodies.
+func nodeToDict(parent *yaml.Node, key string) (any, error) {
+	_, val, err := gatherMapValue(parent, key)
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return convertYamlNodeToValue(val)
+}
+
+// nodeToInt extracts a YAML integer scalar at `key`, defaulting to 0 when
+// absent. Non-integer scalars return an error so callers see malformed input
+// rather than silently defaulting.
+func nodeToInt(parent *yaml.Node, key string) (int64, error) {
+	_, val, err := gatherMapValue(parent, key)
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return 0, nil
+		}
+		return 0, err
+	}
+	if val.Kind != yaml.ScalarNode {
+		return 0, fmt.Errorf("expected scalar for %s, got kind %v", key, val.Kind)
+	}
+	n, err := strconv.ParseInt(val.Value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid integer for %s: %w", key, err)
+	}
+	return n, nil
+}
+
+// nodeToDictList walks the sequence at `key` and returns each entry as a
+// dict (so heterogeneous strings/numbers/objects survive the round-trip).
+func nodeToDictList(parent *yaml.Node, key string) ([]any, error) {
+	_, val, err := gatherMapValue(parent, key)
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if val.Kind != yaml.SequenceNode {
+		return nil, fmt.Errorf("expected sequence for %s, got kind %v", key, val.Kind)
+	}
+	out := make([]any, 0, len(val.Content))
+	for _, item := range val.Content {
+		dict, err := convertYamlNodeToValue(item)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, dict)
+	}
+	return out, nil
+}
+
+// convertYamlNodeToValue handles a single YAML node — scalar, sequence, or
+// mapping — and returns the matching Go value, normalized for the llx dict
+// primitive (ints become float64, nested maps become map[string]any). The
+// round-trip through JSON mirrors what convert.JsonToDict does for maps but
+// also accepts scalars and lists at the top level.
+func convertYamlNodeToValue(n *yaml.Node) (any, error) {
+	data, err := yaml.Marshal(n)
+	if err != nil {
+		return nil, err
+	}
+	var v any
+	if err := yaml.Unmarshal(data, &v); err != nil {
+		return nil, err
+	}
+	jsonBytes, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var out any
+	if err := json.Unmarshal(jsonBytes, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }

--- a/providers/cloudformation/resources/cloudformation.lr
+++ b/providers/cloudformation/resources/cloudformation.lr
@@ -37,6 +37,14 @@ cloudformation.template @defaults("description") {
   outputs() []cloudformation.output
   // Supported resource types
   types() []string
+  // Parameter declarations as typed objects
+  //
+  // Iterate the `Parameters` section as `cloudformation.parameter` records
+  // exposing type, default, allowed values / patterns, length and value
+  // bounds, and the `NoEcho` flag — useful for policy that needs to reason
+  // about how a stack accepts input. Use `parameters` (the dict form) when
+  // you need a key-keyed view of the same data.
+  parameterList() []cloudformation.parameter
 }
 
 // AWS CloudFormation resource declaration
@@ -60,6 +68,37 @@ cloudformation.resource @defaults("name") {
   properties map[string]dict
   // Resource dependencies (DependsOn)
   dependsOn []string
+  // `DeletionPolicy` attribute
+  //
+  // One of `Delete`, `Retain`, `RetainExceptOnCreate`, or `Snapshot`. Empty
+  // when the attribute is not declared (CloudFormation then applies the
+  // `Delete` default). Stateful resources such as `AWS::RDS::DBInstance`
+  // or `AWS::S3::Bucket` typically require `Retain` to avoid accidental
+  // data loss on stack deletion.
+  deletionPolicy string
+  // `UpdateReplacePolicy` attribute
+  //
+  // One of `Delete`, `Retain`, `RetainExceptOnCreate`, or `Snapshot`. Empty
+  // when not declared. Controls what happens to the existing physical
+  // resource when an update forces replacement.
+  updateReplacePolicy string
+  // `CreationPolicy` attribute
+  //
+  // Nested object with `AutoScalingCreationPolicy` and `ResourceSignal`
+  // sub-sections used to wait for resource readiness before reporting
+  // CREATE_COMPLETE. Empty when not declared.
+  creationPolicy dict
+  // `UpdatePolicy` attribute
+  //
+  // Used by `AWS::AutoScaling::AutoScalingGroup`,
+  // `AWS::ElastiCache::ReplicationGroup`, `AWS::Lambda::Alias`, and a few
+  // others to control update behavior. Empty when not declared.
+  updatePolicy dict
+  // `Metadata` attribute
+  //
+  // Stores resource-specific metadata such as `AWS::CloudFormation::Init`
+  // or interface designer hints. Empty when not declared.
+  resourceMetadata dict
 }
 
 // AWS CloudFormation output
@@ -72,4 +111,70 @@ cloudformation.output @defaults("name") {
   name string
   // Output properties
   properties map[string]dict
+  // The `Value` expression
+  //
+  // Returned as a `dict` because the value may be a literal, a `Ref`, a
+  // `Fn::GetAtt`, or any other intrinsic-function call. Audits commonly
+  // pattern-match against the shape to detect outputs that leak resource
+  // ARNs or sensitive references.
+  value dict
+  // `Description` field from the Outputs entry
+  description string
+  // `Export.Name` value
+  //
+  // Empty when the output is not exported across stacks. Audits commonly
+  // forbid exporting sensitive resource ARNs (databases, KMS keys) so they
+  // can't be picked up by unrelated stacks.
+  exportName string
+  // `Condition` name that gates whether this output is produced
+  condition string
+}
+
+// AWS CloudFormation parameter declaration
+//
+// Examine a single entry from the `Parameters` section: type, default,
+// allowed-values / allowed-pattern constraints, length and value bounds,
+// the `NoEcho` flag, and any constraint description. This is the
+// primary surface for policies that enforce strong input typing, secret
+// masking (`NoEcho: true` for credential-shaped parameters), and bounded
+// inputs.
+cloudformation.parameter @defaults("name type") {
+  // Parameter name
+  name string
+  // Parameter type
+  //
+  // `String`, `Number`, `List<Number>`, `CommaDelimitedList`, or any of
+  // the AWS-specific parameter types (`AWS::EC2::KeyPair::KeyName`,
+  // `AWS::SSM::Parameter::Value<String>`, etc.).
+  type string
+  // `Default` value
+  //
+  // Returned as a `dict` because the value may be a string, number, or
+  // list depending on `type`. Empty when the parameter is required.
+  default dict
+  // `Description` text
+  description string
+  // `AllowedValues` constraint
+  //
+  // Heterogeneous list (strings, numbers) preserved as `dict`. Empty when
+  // the constraint is not set.
+  allowedValues []dict
+  // `AllowedPattern` regular expression (String parameters only)
+  allowedPattern string
+  // `NoEcho` flag
+  //
+  // When true, the parameter value is masked in stack events, the console,
+  // and the CLI. Required by most audit policies on parameters that hold
+  // passwords, API keys, or other credentials.
+  noEcho bool
+  // `MinLength` constraint (String parameters)
+  minLength int
+  // `MaxLength` constraint (String parameters)
+  maxLength int
+  // `MinValue` constraint (Number parameters)
+  minValue int
+  // `MaxValue` constraint (Number parameters)
+  maxValue int
+  // `ConstraintDescription` shown when validation fails
+  constraintDescription string
 }

--- a/providers/cloudformation/resources/cloudformation.lr.go
+++ b/providers/cloudformation/resources/cloudformation.lr.go
@@ -15,9 +15,10 @@ import (
 
 // The MQL type names exposed as public consts for ease of reference.
 const (
-	ResourceCloudformationTemplate string = "cloudformation.template"
-	ResourceCloudformationResource string = "cloudformation.resource"
-	ResourceCloudformationOutput   string = "cloudformation.output"
+	ResourceCloudformationTemplate  string = "cloudformation.template"
+	ResourceCloudformationResource  string = "cloudformation.resource"
+	ResourceCloudformationOutput    string = "cloudformation.output"
+	ResourceCloudformationParameter string = "cloudformation.parameter"
 )
 
 var resourceFactories map[string]plugin.ResourceFactory
@@ -35,6 +36,10 @@ func init() {
 		"cloudformation.output": {
 			// to override args, implement: initCloudformationOutput(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createCloudformationOutput,
+		},
+		"cloudformation.parameter": {
+			// to override args, implement: initCloudformationParameter(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createCloudformationParameter,
 		},
 	}
 }
@@ -143,6 +148,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"cloudformation.template.types": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudformationTemplate).GetTypes()).ToDataRes(types.Array(types.String))
 	},
+	"cloudformation.template.parameterList": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationTemplate).GetParameterList()).ToDataRes(types.Array(types.Resource("cloudformation.parameter")))
+	},
 	"cloudformation.resource.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudformationResource).GetName()).ToDataRes(types.String)
 	},
@@ -164,11 +172,74 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"cloudformation.resource.dependsOn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudformationResource).GetDependsOn()).ToDataRes(types.Array(types.String))
 	},
+	"cloudformation.resource.deletionPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationResource).GetDeletionPolicy()).ToDataRes(types.String)
+	},
+	"cloudformation.resource.updateReplacePolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationResource).GetUpdateReplacePolicy()).ToDataRes(types.String)
+	},
+	"cloudformation.resource.creationPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationResource).GetCreationPolicy()).ToDataRes(types.Dict)
+	},
+	"cloudformation.resource.updatePolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationResource).GetUpdatePolicy()).ToDataRes(types.Dict)
+	},
+	"cloudformation.resource.resourceMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationResource).GetResourceMetadata()).ToDataRes(types.Dict)
+	},
 	"cloudformation.output.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudformationOutput).GetName()).ToDataRes(types.String)
 	},
 	"cloudformation.output.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudformationOutput).GetProperties()).ToDataRes(types.Map(types.String, types.Dict))
+	},
+	"cloudformation.output.value": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationOutput).GetValue()).ToDataRes(types.Dict)
+	},
+	"cloudformation.output.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationOutput).GetDescription()).ToDataRes(types.String)
+	},
+	"cloudformation.output.exportName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationOutput).GetExportName()).ToDataRes(types.String)
+	},
+	"cloudformation.output.condition": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationOutput).GetCondition()).ToDataRes(types.String)
+	},
+	"cloudformation.parameter.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationParameter).GetName()).ToDataRes(types.String)
+	},
+	"cloudformation.parameter.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationParameter).GetType()).ToDataRes(types.String)
+	},
+	"cloudformation.parameter.default": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationParameter).GetDefault()).ToDataRes(types.Dict)
+	},
+	"cloudformation.parameter.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationParameter).GetDescription()).ToDataRes(types.String)
+	},
+	"cloudformation.parameter.allowedValues": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationParameter).GetAllowedValues()).ToDataRes(types.Array(types.Dict))
+	},
+	"cloudformation.parameter.allowedPattern": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationParameter).GetAllowedPattern()).ToDataRes(types.String)
+	},
+	"cloudformation.parameter.noEcho": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationParameter).GetNoEcho()).ToDataRes(types.Bool)
+	},
+	"cloudformation.parameter.minLength": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationParameter).GetMinLength()).ToDataRes(types.Int)
+	},
+	"cloudformation.parameter.maxLength": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationParameter).GetMaxLength()).ToDataRes(types.Int)
+	},
+	"cloudformation.parameter.minValue": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationParameter).GetMinValue()).ToDataRes(types.Int)
+	},
+	"cloudformation.parameter.maxValue": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationParameter).GetMaxValue()).ToDataRes(types.Int)
+	},
+	"cloudformation.parameter.constraintDescription": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudformationParameter).GetConstraintDescription()).ToDataRes(types.String)
 	},
 }
 
@@ -234,6 +305,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlCloudformationTemplate).Types, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"cloudformation.template.parameterList": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationTemplate).ParameterList, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"cloudformation.resource.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlCloudformationResource).__id, ok = v.Value.(string)
 		return
@@ -266,6 +341,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlCloudformationResource).DependsOn, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"cloudformation.resource.deletionPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationResource).DeletionPolicy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"cloudformation.resource.updateReplacePolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationResource).UpdateReplacePolicy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"cloudformation.resource.creationPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationResource).CreationPolicy, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"cloudformation.resource.updatePolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationResource).UpdatePolicy, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"cloudformation.resource.resourceMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationResource).ResourceMetadata, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
 	"cloudformation.output.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlCloudformationOutput).__id, ok = v.Value.(string)
 		return
@@ -276,6 +371,74 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"cloudformation.output.properties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlCloudformationOutput).Properties, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"cloudformation.output.value": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationOutput).Value, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"cloudformation.output.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationOutput).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"cloudformation.output.exportName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationOutput).ExportName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"cloudformation.output.condition": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationOutput).Condition, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"cloudformation.parameter.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationParameter).__id, ok = v.Value.(string)
+		return
+	},
+	"cloudformation.parameter.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationParameter).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"cloudformation.parameter.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationParameter).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"cloudformation.parameter.default": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationParameter).Default, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"cloudformation.parameter.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationParameter).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"cloudformation.parameter.allowedValues": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationParameter).AllowedValues, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"cloudformation.parameter.allowedPattern": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationParameter).AllowedPattern, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"cloudformation.parameter.noEcho": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationParameter).NoEcho, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"cloudformation.parameter.minLength": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationParameter).MinLength, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"cloudformation.parameter.maxLength": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationParameter).MaxLength, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"cloudformation.parameter.minValue": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationParameter).MinValue, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"cloudformation.parameter.maxValue": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationParameter).MaxValue, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"cloudformation.parameter.constraintDescription": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudformationParameter).ConstraintDescription, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 }
@@ -307,18 +470,19 @@ type mqlCloudformationTemplate struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlCloudformationTemplateInternal it will be used here
-	Version     plugin.TValue[string]
-	Transform   plugin.TValue[[]any]
-	Description plugin.TValue[string]
-	Mappings    plugin.TValue[map[string]any]
-	Globals     plugin.TValue[map[string]any]
-	Parameters  plugin.TValue[map[string]any]
-	Metadata    plugin.TValue[map[string]any]
-	Conditions  plugin.TValue[map[string]any]
-	Rules       plugin.TValue[map[string]any]
-	Resources   plugin.TValue[[]any]
-	Outputs     plugin.TValue[[]any]
-	Types       plugin.TValue[[]any]
+	Version       plugin.TValue[string]
+	Transform     plugin.TValue[[]any]
+	Description   plugin.TValue[string]
+	Mappings      plugin.TValue[map[string]any]
+	Globals       plugin.TValue[map[string]any]
+	Parameters    plugin.TValue[map[string]any]
+	Metadata      plugin.TValue[map[string]any]
+	Conditions    plugin.TValue[map[string]any]
+	Rules         plugin.TValue[map[string]any]
+	Resources     plugin.TValue[[]any]
+	Outputs       plugin.TValue[[]any]
+	Types         plugin.TValue[[]any]
+	ParameterList plugin.TValue[[]any]
 }
 
 // createCloudformationTemplate creates a new instance of this resource
@@ -444,18 +608,39 @@ func (c *mqlCloudformationTemplate) GetTypes() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlCloudformationTemplate) GetParameterList() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ParameterList, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("cloudformation.template", c.__id, "parameterList")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.parameterList()
+	})
+}
+
 // mqlCloudformationResource for the cloudformation.resource resource
 type mqlCloudformationResource struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlCloudformationResourceInternal it will be used here
-	Name          plugin.TValue[string]
-	Type          plugin.TValue[string]
-	Condition     plugin.TValue[string]
-	Documentation plugin.TValue[string]
-	Attributes    plugin.TValue[map[string]any]
-	Properties    plugin.TValue[map[string]any]
-	DependsOn     plugin.TValue[[]any]
+	Name                plugin.TValue[string]
+	Type                plugin.TValue[string]
+	Condition           plugin.TValue[string]
+	Documentation       plugin.TValue[string]
+	Attributes          plugin.TValue[map[string]any]
+	Properties          plugin.TValue[map[string]any]
+	DependsOn           plugin.TValue[[]any]
+	DeletionPolicy      plugin.TValue[string]
+	UpdateReplacePolicy plugin.TValue[string]
+	CreationPolicy      plugin.TValue[any]
+	UpdatePolicy        plugin.TValue[any]
+	ResourceMetadata    plugin.TValue[any]
 }
 
 // createCloudformationResource creates a new instance of this resource
@@ -523,13 +708,37 @@ func (c *mqlCloudformationResource) GetDependsOn() *plugin.TValue[[]any] {
 	return &c.DependsOn
 }
 
+func (c *mqlCloudformationResource) GetDeletionPolicy() *plugin.TValue[string] {
+	return &c.DeletionPolicy
+}
+
+func (c *mqlCloudformationResource) GetUpdateReplacePolicy() *plugin.TValue[string] {
+	return &c.UpdateReplacePolicy
+}
+
+func (c *mqlCloudformationResource) GetCreationPolicy() *plugin.TValue[any] {
+	return &c.CreationPolicy
+}
+
+func (c *mqlCloudformationResource) GetUpdatePolicy() *plugin.TValue[any] {
+	return &c.UpdatePolicy
+}
+
+func (c *mqlCloudformationResource) GetResourceMetadata() *plugin.TValue[any] {
+	return &c.ResourceMetadata
+}
+
 // mqlCloudformationOutput for the cloudformation.output resource
 type mqlCloudformationOutput struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlCloudformationOutputInternal it will be used here
-	Name       plugin.TValue[string]
-	Properties plugin.TValue[map[string]any]
+	Name        plugin.TValue[string]
+	Properties  plugin.TValue[map[string]any]
+	Value       plugin.TValue[any]
+	Description plugin.TValue[string]
+	ExportName  plugin.TValue[string]
+	Condition   plugin.TValue[string]
 }
 
 // createCloudformationOutput creates a new instance of this resource
@@ -575,4 +784,124 @@ func (c *mqlCloudformationOutput) GetName() *plugin.TValue[string] {
 
 func (c *mqlCloudformationOutput) GetProperties() *plugin.TValue[map[string]any] {
 	return &c.Properties
+}
+
+func (c *mqlCloudformationOutput) GetValue() *plugin.TValue[any] {
+	return &c.Value
+}
+
+func (c *mqlCloudformationOutput) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlCloudformationOutput) GetExportName() *plugin.TValue[string] {
+	return &c.ExportName
+}
+
+func (c *mqlCloudformationOutput) GetCondition() *plugin.TValue[string] {
+	return &c.Condition
+}
+
+// mqlCloudformationParameter for the cloudformation.parameter resource
+type mqlCloudformationParameter struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlCloudformationParameterInternal it will be used here
+	Name                  plugin.TValue[string]
+	Type                  plugin.TValue[string]
+	Default               plugin.TValue[any]
+	Description           plugin.TValue[string]
+	AllowedValues         plugin.TValue[[]any]
+	AllowedPattern        plugin.TValue[string]
+	NoEcho                plugin.TValue[bool]
+	MinLength             plugin.TValue[int64]
+	MaxLength             plugin.TValue[int64]
+	MinValue              plugin.TValue[int64]
+	MaxValue              plugin.TValue[int64]
+	ConstraintDescription plugin.TValue[string]
+}
+
+// createCloudformationParameter creates a new instance of this resource
+func createCloudformationParameter(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlCloudformationParameter{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("cloudformation.parameter", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlCloudformationParameter) MqlName() string {
+	return "cloudformation.parameter"
+}
+
+func (c *mqlCloudformationParameter) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlCloudformationParameter) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlCloudformationParameter) GetType() *plugin.TValue[string] {
+	return &c.Type
+}
+
+func (c *mqlCloudformationParameter) GetDefault() *plugin.TValue[any] {
+	return &c.Default
+}
+
+func (c *mqlCloudformationParameter) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlCloudformationParameter) GetAllowedValues() *plugin.TValue[[]any] {
+	return &c.AllowedValues
+}
+
+func (c *mqlCloudformationParameter) GetAllowedPattern() *plugin.TValue[string] {
+	return &c.AllowedPattern
+}
+
+func (c *mqlCloudformationParameter) GetNoEcho() *plugin.TValue[bool] {
+	return &c.NoEcho
+}
+
+func (c *mqlCloudformationParameter) GetMinLength() *plugin.TValue[int64] {
+	return &c.MinLength
+}
+
+func (c *mqlCloudformationParameter) GetMaxLength() *plugin.TValue[int64] {
+	return &c.MaxLength
+}
+
+func (c *mqlCloudformationParameter) GetMinValue() *plugin.TValue[int64] {
+	return &c.MinValue
+}
+
+func (c *mqlCloudformationParameter) GetMaxValue() *plugin.TValue[int64] {
+	return &c.MaxValue
+}
+
+func (c *mqlCloudformationParameter) GetConstraintDescription() *plugin.TValue[string] {
+	return &c.ConstraintDescription
 }

--- a/providers/cloudformation/resources/cloudformation.lr.versions
+++ b/providers/cloudformation/resources/cloudformation.lr.versions
@@ -2,16 +2,38 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 cloudformation.output 11.0.0
+cloudformation.output.condition 13.0.13
+cloudformation.output.description 13.0.13
+cloudformation.output.exportName 13.0.13
 cloudformation.output.name 11.0.0
 cloudformation.output.properties 11.0.0
+cloudformation.output.value 13.0.13
+cloudformation.parameter 13.0.13
+cloudformation.parameter.allowedPattern 13.0.13
+cloudformation.parameter.allowedValues 13.0.13
+cloudformation.parameter.constraintDescription 13.0.13
+cloudformation.parameter.default 13.0.13
+cloudformation.parameter.description 13.0.13
+cloudformation.parameter.maxLength 13.0.13
+cloudformation.parameter.maxValue 13.0.13
+cloudformation.parameter.minLength 13.0.13
+cloudformation.parameter.minValue 13.0.13
+cloudformation.parameter.name 13.0.13
+cloudformation.parameter.noEcho 13.0.13
+cloudformation.parameter.type 13.0.13
 cloudformation.resource 11.0.0
 cloudformation.resource.attributes 11.0.0
 cloudformation.resource.condition 11.0.0
+cloudformation.resource.creationPolicy 13.0.13
+cloudformation.resource.deletionPolicy 13.0.13
 cloudformation.resource.dependsOn 13.0.1
 cloudformation.resource.documentation 11.0.0
 cloudformation.resource.name 11.0.0
 cloudformation.resource.properties 11.0.0
+cloudformation.resource.resourceMetadata 13.0.13
 cloudformation.resource.type 11.0.0
+cloudformation.resource.updatePolicy 13.0.13
+cloudformation.resource.updateReplacePolicy 13.0.13
 cloudformation.template 11.0.0
 cloudformation.template.conditions 11.0.0
 cloudformation.template.description 11.0.0
@@ -19,6 +41,7 @@ cloudformation.template.globals 11.0.0
 cloudformation.template.mappings 11.0.0
 cloudformation.template.metadata 11.0.0
 cloudformation.template.outputs 11.0.0
+cloudformation.template.parameterList 13.0.13
 cloudformation.template.parameters 11.0.0
 cloudformation.template.resources 11.0.0
 cloudformation.template.rules 13.0.1

--- a/providers/cloudformation/resources/cloudformation_test.go
+++ b/providers/cloudformation/resources/cloudformation_test.go
@@ -242,4 +242,103 @@ func TestCloudformationResources(t *testing.T) {
 
 		assert.Equal(t, []any{"MyMacro", "AWS::Serverless"}, tpl.Transform.Data)
 	})
+
+	t.Run("cloudformation resource policies + metadata", func(t *testing.T) {
+		tpl, err := loadTemplate("../testdata/policies.yaml")
+		require.NoError(t, err)
+
+		res := tpl.GetResources()
+		require.NoError(t, res.Error)
+
+		byName := map[string]*mqlCloudformationResource{}
+		for _, r := range res.Data {
+			rr := r.(*mqlCloudformationResource)
+			byName[rr.Name.Data] = rr
+		}
+
+		bucket := byName["RetainedBucket"]
+		require.NotNil(t, bucket)
+		assert.Equal(t, "Retain", bucket.DeletionPolicy.Data)
+		assert.Equal(t, "Retain", bucket.UpdateReplacePolicy.Data)
+		require.NotNil(t, bucket.ResourceMetadata.Data)
+		require.NotEmpty(t, bucket.ResourceMetadata.Data)
+
+		asg := byName["ASG"]
+		require.NotNil(t, asg)
+		require.NotNil(t, asg.CreationPolicy.Data)
+		cp := asg.CreationPolicy.Data.(map[string]any)
+		require.Contains(t, cp, "ResourceSignal")
+		require.NotNil(t, asg.UpdatePolicy.Data)
+		up := asg.UpdatePolicy.Data.(map[string]any)
+		require.Contains(t, up, "AutoScalingRollingUpdate")
+
+		// Resources without policies expose empty strings / nil dicts so
+		// queries can distinguish "explicit Delete" from "unset".
+		assert.Equal(t, "", asg.DeletionPolicy.Data)
+		assert.Equal(t, "", asg.UpdateReplacePolicy.Data)
+	})
+
+	t.Run("cloudformation typed outputs", func(t *testing.T) {
+		tpl, err := loadTemplate("../testdata/policies.yaml")
+		require.NoError(t, err)
+
+		res := tpl.GetOutputs()
+		require.NoError(t, res.Error)
+
+		byName := map[string]*mqlCloudformationOutput{}
+		for _, o := range res.Data {
+			oo := o.(*mqlCloudformationOutput)
+			byName[oo.Name.Data] = oo
+		}
+
+		bucket := byName["BucketArn"]
+		require.NotNil(t, bucket)
+		assert.Equal(t, "ARN of the retained bucket", bucket.Description.Data)
+		assert.Equal(t, "my-stack-BucketArn", bucket.ExportName.Data)
+		assert.Equal(t, "", bucket.Condition.Data)
+		require.NotNil(t, bucket.Value.Data)
+
+		port := byName["DBPortValue"]
+		require.NotNil(t, port)
+		assert.Equal(t, "HasDB", port.Condition.Data)
+		assert.Equal(t, "", port.ExportName.Data)
+	})
+
+	t.Run("cloudformation typed parameters", func(t *testing.T) {
+		tpl, err := loadTemplate("../testdata/policies.yaml")
+		require.NoError(t, err)
+
+		res := tpl.GetParameterList()
+		require.NoError(t, res.Error)
+		require.Equal(t, 3, len(res.Data))
+
+		byName := map[string]*mqlCloudformationParameter{}
+		for _, p := range res.Data {
+			pp := p.(*mqlCloudformationParameter)
+			byName[pp.Name.Data] = pp
+		}
+
+		pw := byName["DBPassword"]
+		require.NotNil(t, pw)
+		assert.Equal(t, "String", pw.Type.Data)
+		assert.True(t, pw.NoEcho.Data)
+		assert.Equal(t, int64(8), pw.MinLength.Data)
+		assert.Equal(t, int64(41), pw.MaxLength.Data)
+		assert.Equal(t, "^[a-zA-Z0-9]*$", pw.AllowedPattern.Data)
+		assert.Equal(t, "Must contain only alphanumeric characters.", pw.ConstraintDescription.Data)
+
+		port := byName["DBPort"]
+		require.NotNil(t, port)
+		assert.Equal(t, "Number", port.Type.Data)
+		assert.False(t, port.NoEcho.Data)
+		assert.Equal(t, int64(1150), port.MinValue.Data)
+		assert.Equal(t, int64(65535), port.MaxValue.Data)
+		// Numeric defaults arrive as float64 because the dict primitive uses
+		// JSON-style numeric typing.
+		require.Equal(t, float64(3306), port.Default.Data)
+
+		env := byName["Environment"]
+		require.NotNil(t, env)
+		require.Equal(t, []any{"production", "staging", "dev"}, env.AllowedValues.Data)
+	})
 }

--- a/providers/cloudformation/resources/cloudformation_test.go
+++ b/providers/cloudformation/resources/cloudformation_test.go
@@ -304,6 +304,27 @@ func TestCloudformationResources(t *testing.T) {
 		assert.Equal(t, "", port.ExportName.Data)
 	})
 
+	t.Run("cloudformation empty template guard", func(t *testing.T) {
+		// A file with only comments parses successfully but the cft library
+		// hands us a Template whose Node.Content is empty. Every lazy accessor
+		// (resources, outputs, parameterList, etc.) must short-circuit instead
+		// of dereferencing Content[0].
+		tpl, err := loadTemplate("../testdata/empty.yaml")
+		require.NoError(t, err)
+
+		res := tpl.GetResources()
+		require.NoError(t, res.Error)
+		assert.Empty(t, res.Data)
+
+		outs := tpl.GetOutputs()
+		require.NoError(t, outs.Error)
+		assert.Empty(t, outs.Data)
+
+		params := tpl.GetParameterList()
+		require.NoError(t, params.Error)
+		assert.Empty(t, params.Data)
+	})
+
 	t.Run("cloudformation typed parameters", func(t *testing.T) {
 		tpl, err := loadTemplate("../testdata/policies.yaml")
 		require.NoError(t, err)

--- a/providers/cloudformation/resources/template.go
+++ b/providers/cloudformation/resources/template.go
@@ -120,6 +120,9 @@ func (x *mqlCloudformationResource) id() (string, error) {
 func (r *mqlCloudformationTemplate) resources() ([]any, error) {
 	conn := r.MqlRuntime.Connection.(*connection.CloudformationConnection)
 	template := conn.CftTemplate()
+	if template.Node == nil || len(template.Node.Content) == 0 {
+		return nil, nil
+	}
 	_, resources, err := gatherMapValue(template.Node.Content[0], string(cft.Resources))
 	if err != nil && status.Code(err) == codes.NotFound {
 		return nil, nil
@@ -241,6 +244,9 @@ func (x *mqlCloudformationParameter) id() (string, error) {
 func (r *mqlCloudformationTemplate) outputs() ([]any, error) {
 	conn := r.MqlRuntime.Connection.(*connection.CloudformationConnection)
 	template := conn.CftTemplate()
+	if template.Node == nil || len(template.Node.Content) == 0 {
+		return nil, nil
+	}
 
 	_, outputs, err := gatherMapValue(template.Node.Content[0], string(cft.Outputs))
 	if err != nil && status.Code(err) == codes.NotFound {

--- a/providers/cloudformation/resources/template.go
+++ b/providers/cloudformation/resources/template.go
@@ -27,6 +27,12 @@ func initCloudformationTemplate(runtime *plugin.Runtime, args map[string]*llx.Ra
 	args["description"] = llx.StringData("")
 	args["transform"] = llx.NilData
 
+	// cft.Template.GetSection dereferences Node.Content[0] without a guard, so
+	// short-circuit on a degenerate template (empty file, comments only).
+	if template.Node == nil || len(template.Node.Content) == 0 {
+		return args, nil, nil
+	}
+
 	version, err := template.GetSection(cft.AWSTemplateFormatVersion)
 	if err == nil {
 		args["version"] = llx.StringData(version.Value)

--- a/providers/cloudformation/resources/template.go
+++ b/providers/cloudformation/resources/template.go
@@ -180,14 +180,44 @@ func (r *mqlCloudformationTemplate) resources() ([]any, error) {
 			}
 		}
 
+		deletionPolicy := ""
+		_, val, err = gatherMapValue(valueNode, "DeletionPolicy")
+		if err == nil {
+			deletionPolicy = val.Value
+		}
+
+		updateReplacePolicy := ""
+		_, val, err = gatherMapValue(valueNode, "UpdateReplacePolicy")
+		if err == nil {
+			updateReplacePolicy = val.Value
+		}
+
+		creationPolicy, err := nodeToDict(valueNode, "CreationPolicy")
+		if err != nil {
+			return nil, err
+		}
+		updatePolicy, err := nodeToDict(valueNode, "UpdatePolicy")
+		if err != nil {
+			return nil, err
+		}
+		resourceMetadata, err := nodeToDict(valueNode, "Metadata")
+		if err != nil {
+			return nil, err
+		}
+
 		pkg, err := CreateResource(r.MqlRuntime, "cloudformation.resource", map[string]*llx.RawData{
-			"name":          llx.StringData(keyNode.Value),
-			"type":          llx.StringData(resourceType),
-			"condition":     llx.StringData(resourceCondition),
-			"documentation": llx.StringData(resourceDocumentation),
-			"attributes":    llx.MapData(attrs, types.Dict),
-			"properties":    llx.MapData(props, types.Dict),
-			"dependsOn":     llx.ArrayData(dependsOn, types.String),
+			"name":                llx.StringData(keyNode.Value),
+			"type":                llx.StringData(resourceType),
+			"condition":           llx.StringData(resourceCondition),
+			"documentation":       llx.StringData(resourceDocumentation),
+			"attributes":          llx.MapData(attrs, types.Dict),
+			"properties":          llx.MapData(props, types.Dict),
+			"dependsOn":           llx.ArrayData(dependsOn, types.String),
+			"deletionPolicy":      llx.StringData(deletionPolicy),
+			"updateReplacePolicy": llx.StringData(updateReplacePolicy),
+			"creationPolicy":      llx.DictData(creationPolicy),
+			"updatePolicy":        llx.DictData(updatePolicy),
+			"resourceMetadata":    llx.DictData(resourceMetadata),
 		})
 		if err != nil {
 			return nil, err
@@ -201,6 +231,10 @@ func (r *mqlCloudformationTemplate) resources() ([]any, error) {
 }
 
 func (x *mqlCloudformationOutput) id() (string, error) {
+	return x.Name.Data, nil
+}
+
+func (x *mqlCloudformationParameter) id() (string, error) {
 	return x.Name.Data, nil
 }
 
@@ -225,9 +259,35 @@ func (r *mqlCloudformationTemplate) outputs() ([]any, error) {
 			return nil, err
 		}
 
+		value, err := nodeToDict(valueNode, "Value")
+		if err != nil {
+			return nil, err
+		}
+
+		description := ""
+		if _, n, err := gatherMapValue(valueNode, "Description"); err == nil {
+			description = n.Value
+		}
+
+		condition := ""
+		if _, n, err := gatherMapValue(valueNode, "Condition"); err == nil {
+			condition = n.Value
+		}
+
+		exportName := ""
+		if _, exportNode, err := gatherMapValue(valueNode, "Export"); err == nil {
+			if _, n, err := gatherMapValue(exportNode, "Name"); err == nil {
+				exportName = n.Value
+			}
+		}
+
 		pkg, err := CreateResource(r.MqlRuntime, "cloudformation.output", map[string]*llx.RawData{
-			"name":       llx.StringData(keyNode.Value),
-			"properties": llx.DictData(dict),
+			"name":        llx.StringData(keyNode.Value),
+			"properties":  llx.DictData(dict),
+			"value":       llx.DictData(value),
+			"description": llx.StringData(description),
+			"exportName":  llx.StringData(exportName),
+			"condition":   llx.StringData(condition),
 		})
 		if err != nil {
 			return nil, err
@@ -235,6 +295,101 @@ func (r *mqlCloudformationTemplate) outputs() ([]any, error) {
 
 		s := pkg.(*mqlCloudformationOutput)
 		result = append(result, s)
+	}
+
+	return result, nil
+}
+
+func (r *mqlCloudformationTemplate) parameterList() ([]any, error) {
+	conn := r.MqlRuntime.Connection.(*connection.CloudformationConnection)
+	template := conn.CftTemplate()
+
+	if template.Node == nil || len(template.Node.Content) == 0 {
+		return nil, nil
+	}
+	_, params, err := gatherMapValue(template.Node.Content[0], string(cft.Parameters))
+	if err != nil && status.Code(err) == codes.NotFound {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	result := make([]any, 0)
+	for i := 0; i < len(params.Content); i += 2 {
+		keyNode := params.Content[i]
+		valueNode := params.Content[i+1]
+
+		paramType := ""
+		if _, n, err := gatherMapValue(valueNode, "Type"); err == nil {
+			paramType = n.Value
+		}
+
+		description := ""
+		if _, n, err := gatherMapValue(valueNode, "Description"); err == nil {
+			description = n.Value
+		}
+
+		allowedPattern := ""
+		if _, n, err := gatherMapValue(valueNode, "AllowedPattern"); err == nil {
+			allowedPattern = n.Value
+		}
+
+		constraintDescription := ""
+		if _, n, err := gatherMapValue(valueNode, "ConstraintDescription"); err == nil {
+			constraintDescription = n.Value
+		}
+
+		noEcho := false
+		if _, n, err := gatherMapValue(valueNode, "NoEcho"); err == nil {
+			noEcho = n.Value == "true" || n.Value == "True" || n.Value == "TRUE"
+		}
+
+		minLength, err := nodeToInt(valueNode, "MinLength")
+		if err != nil {
+			return nil, err
+		}
+		maxLength, err := nodeToInt(valueNode, "MaxLength")
+		if err != nil {
+			return nil, err
+		}
+		minValue, err := nodeToInt(valueNode, "MinValue")
+		if err != nil {
+			return nil, err
+		}
+		maxValue, err := nodeToInt(valueNode, "MaxValue")
+		if err != nil {
+			return nil, err
+		}
+
+		defaultDict, err := nodeToDict(valueNode, "Default")
+		if err != nil {
+			return nil, err
+		}
+
+		allowedValues, err := nodeToDictList(valueNode, "AllowedValues")
+		if err != nil {
+			return nil, err
+		}
+
+		pkg, err := CreateResource(r.MqlRuntime, "cloudformation.parameter", map[string]*llx.RawData{
+			"__id":                  llx.StringData(keyNode.Value),
+			"name":                  llx.StringData(keyNode.Value),
+			"type":                  llx.StringData(paramType),
+			"default":               llx.DictData(defaultDict),
+			"description":           llx.StringData(description),
+			"allowedValues":         llx.ArrayData(allowedValues, types.Dict),
+			"allowedPattern":        llx.StringData(allowedPattern),
+			"noEcho":                llx.BoolData(noEcho),
+			"minLength":             llx.IntData(minLength),
+			"maxLength":             llx.IntData(maxLength),
+			"minValue":              llx.IntData(minValue),
+			"maxValue":              llx.IntData(maxValue),
+			"constraintDescription": llx.StringData(constraintDescription),
+		})
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, pkg)
 	}
 
 	return result, nil

--- a/providers/cloudformation/testdata/empty.yaml
+++ b/providers/cloudformation/testdata/empty.yaml
@@ -1,0 +1,1 @@
+# empty cloudformation template

--- a/providers/cloudformation/testdata/policies.yaml
+++ b/providers/cloudformation/testdata/policies.yaml
@@ -1,0 +1,58 @@
+Parameters:
+  DBPassword:
+    NoEcho: true
+    Description: The database admin account password
+    Type: String
+    MinLength: 8
+    MaxLength: 41
+    AllowedPattern: ^[a-zA-Z0-9]*$
+    ConstraintDescription: Must contain only alphanumeric characters.
+  DBPort:
+    Default: 3306
+    Description: TCP/IP port for the database
+    Type: Number
+    MinValue: 1150
+    MaxValue: 65535
+  Environment:
+    Type: String
+    Default: production
+    AllowedValues:
+      - production
+      - staging
+      - dev
+Resources:
+  RetainedBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks: [E3001]
+    Properties:
+      BucketName: my-retained-bucket
+  ASG:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    CreationPolicy:
+      AutoScalingCreationPolicy:
+        MinSuccessfulInstancesPercent: 80
+      ResourceSignal:
+        Count: 3
+        Timeout: PT10M
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MinInstancesInService: 1
+        MaxBatchSize: 1
+        PauseTime: PT5M
+    Properties:
+      MinSize: 1
+      MaxSize: 5
+Outputs:
+  BucketArn:
+    Description: ARN of the retained bucket
+    Value: !GetAtt RetainedBucket.Arn
+    Export:
+      Name: my-stack-BucketArn
+  DBPortValue:
+    Value: !Ref DBPort
+    Condition: HasDB


### PR DESCRIPTION
## Summary
- Expands the cloudformation provider so audits can reach the fields they need without parsing raw `properties` dicts.
- `cloudformation.output` gains typed `value`, `description`, `exportName` (from `Export.Name`), and `condition`. Supports policies like "no Outputs export sensitive resource ARNs across stack boundaries".
- `cloudformation.resource` gains typed `deletionPolicy`, `updateReplacePolicy`, `creationPolicy`, `updatePolicy`, and `resourceMetadata`. Empty / nil when the attribute is not declared so policies can distinguish "explicit Delete" from "unset".
- New `cloudformation.parameter` sub-resource with `type`, `default`, `description`, `allowedValues`, `allowedPattern`, `noEcho`, `minLength` / `maxLength` / `minValue` / `maxValue`, and `constraintDescription` — exposed via `cloudformation.template.parameterList()`. The dict-shaped `parameters()` accessor stays for backward compatibility.
- Shared YAML→Go helper `convertYamlNodeToValue` round-trips through JSON so values normalize to the llx dict primitive (ints as float64) for scalars, lists, and maps alike.

## Test plan
- [x] `go test ./resources/...` from `providers/cloudformation` — passes. Existing subtests are unchanged; three new subtests (`cloudformation resource policies + metadata`, `cloudformation typed outputs`, `cloudformation typed parameters`) cover each new field against a new `testdata/policies.yaml` fixture.
- [x] Built and installed the provider; interactively ran the equivalent MQL query against `testdata/policies.yaml` — all new fields return the expected values, including `deletionPolicy: "Retain"`, the `creationPolicy.ResourceSignal` nested dict, output `exportName`, parameter `noEcho`, bounds, and `allowedValues`.
- [x] `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)