### PR TITLE
✨ proxmox: cross-refs, cluster-options typed view, PBS encryption + HTTP-mocked tests

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -48,6 +48,7 @@ autoclass
 autoclose
 autocreate
 autoexpand
+autogen
 automattic
 autoprovision
 autoreplace

--- a/providers/proxmox/connection/api_test.go
+++ b/providers/proxmox/connection/api_test.go
@@ -1,0 +1,226 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"errors"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// APIError + IsAccessDeniedOrNotFound
+// ---------------------------------------------------------------------------
+
+func TestAPIError_StatusCodeRoundTrip(t *testing.T) {
+	f := newFakePVE(t)
+	f.errorRoute("/cluster/firewall/options", 403, "Permission check failed")
+	c := f.conn()
+
+	_, err := c.GetClusterFirewallOptions()
+	if err == nil {
+		t.Fatal("expected an error for a 403")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error %T is not an *APIError", err)
+	}
+	if apiErr.StatusCode != 403 {
+		t.Errorf("status = %d, want 403", apiErr.StatusCode)
+	}
+	if apiErr.Message != "Permission check failed" {
+		t.Errorf("message = %q, want %q", apiErr.Message, "Permission check failed")
+	}
+}
+
+func TestIsAccessDeniedOrNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil-err", nil, false},
+		{"plain-error", errors.New("network down"), false},
+		{"401", &APIError{StatusCode: 401}, true},
+		{"403", &APIError{StatusCode: 403}, true},
+		{"404", &APIError{StatusCode: 404}, true},
+		{"500-bubbles-up", &APIError{StatusCode: 500}, false},
+		{"502-bubbles-up", &APIError{StatusCode: 502}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsAccessDeniedOrNotFound(tt.err); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetStorages — PBS encryption parsing
+// ---------------------------------------------------------------------------
+
+func TestGetStorages_EncryptedAndPlain(t *testing.T) {
+	f := newFakePVE(t)
+	f.route("/storage", []map[string]any{
+		// PBS datastore configured with an encryption key
+		{
+			"storage":        "pbs-encrypted",
+			"type":           "pbs",
+			"content":        "backup",
+			"enabled":        1,
+			"shared":         1,
+			"total":          1_000_000_000,
+			"used":           500_000_000,
+			"avail":          500_000_000,
+			"used_fraction":  0.5,
+			"encryption-key": "autogen",
+		},
+		// Plain dir storage — no encryption-key field at all
+		{
+			"storage": "local",
+			"type":    "dir",
+			"content": "iso,vztmpl",
+			"path":    "/var/lib/vz",
+			"enabled": 1,
+			"shared":  0,
+		},
+	})
+
+	storages, err := f.conn().GetStorages()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(storages) != 2 {
+		t.Fatalf("expected 2 storages, got %d", len(storages))
+	}
+
+	pbs := storages[0]
+	if pbs.EncryptionKey != "autogen" {
+		t.Errorf("PBS storage EncryptionKey = %q, want %q", pbs.EncryptionKey, "autogen")
+	}
+	local := storages[1]
+	if local.EncryptionKey != "" {
+		t.Errorf("local storage EncryptionKey = %q, want empty", local.EncryptionKey)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetNodeContainers — regression for the Atoi VMID parsing
+// ---------------------------------------------------------------------------
+
+func TestGetNodeContainers_ValidVMIDs(t *testing.T) {
+	f := newFakePVE(t)
+	f.route("/nodes/pve1/lxc", []map[string]any{
+		{"vmid": "100", "name": "web", "status": "running", "maxmem": 512_000_000},
+		{"vmid": "201", "name": "db", "status": "stopped", "maxmem": 1_024_000_000},
+	})
+
+	cts, err := f.conn().GetNodeContainers("pve1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cts) != 2 {
+		t.Fatalf("expected 2 containers, got %d", len(cts))
+	}
+	if cts[0].VMID != 100 || cts[0].Name != "web" {
+		t.Errorf("container[0] = %+v, want VMID=100 Name=web", cts[0])
+	}
+	if cts[1].VMID != 201 {
+		t.Errorf("container[1].VMID = %d, want 201", cts[1].VMID)
+	}
+	if cts[0].Node != "pve1" {
+		t.Errorf("container[0].Node = %q, want pve1 (set by helper, not API)", cts[0].Node)
+	}
+}
+
+func TestGetNodeContainers_MalformedVMIDErrors(t *testing.T) {
+	f := newFakePVE(t)
+	f.route("/nodes/pve1/lxc", []map[string]any{
+		{"vmid": "not-a-number", "name": "broken"},
+	})
+
+	_, err := f.conn().GetNodeContainers("pve1")
+	if err == nil {
+		t.Fatal("expected an error for a non-numeric VMID; got nil")
+	}
+	// Don't pin the exact message — fmt.Errorf wraps the strconv error
+	// directly, so the test would break on every Go version bump. Check
+	// that the surrounding context (the bad value and node name) is in
+	// the wrapped message so operators can grep for it.
+	msg := err.Error()
+	if !contains(msg, `"not-a-number"`) || !contains(msg, "pve1") {
+		t.Errorf("error %q should mention the bad VMID and node name", msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetClusterFirewallOptions — dict semantics for the typed-options layer
+// ---------------------------------------------------------------------------
+
+func TestGetClusterFirewallOptions_ReturnsRawDict(t *testing.T) {
+	f := newFakePVE(t)
+	f.route("/cluster/firewall/options", map[string]any{
+		"enable":     1,
+		"policy_in":  "DROP",
+		"policy_out": "ACCEPT",
+	})
+
+	opts, err := f.conn().GetClusterFirewallOptions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, ok := opts["enable"].(float64); !ok || v != 1 {
+		t.Errorf("enable = %v (%T), want 1", opts["enable"], opts["enable"])
+	}
+	if opts["policy_in"] != "DROP" {
+		t.Errorf("policy_in = %v, want DROP", opts["policy_in"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetReplicationJobs — shape sanity, including int-typed `disable` field
+// ---------------------------------------------------------------------------
+
+func TestGetReplicationJobs_DisabledFlagAndRate(t *testing.T) {
+	f := newFakePVE(t)
+	f.route("/cluster/replication", []map[string]any{
+		{
+			"id":       "100-0",
+			"guest":    100,
+			"schedule": "*/30",
+			"source":   "pve1",
+			"target":   "pve2",
+			"type":     "local",
+			"disable":  1,
+			"rate":     50,
+		},
+	})
+
+	jobs, err := f.conn().GetReplicationJobs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+	j := jobs[0]
+	if j.Disable != 1 {
+		t.Errorf("Disable = %d, want 1", j.Disable)
+	}
+	if j.Rate != 50 {
+		t.Errorf("Rate = %d, want 50", j.Rate)
+	}
+	if j.VMID != 100 {
+		t.Errorf("VMID = %d, want 100", j.VMID)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/providers/proxmox/connection/storage.go
+++ b/providers/proxmox/connection/storage.go
@@ -20,6 +20,10 @@ type StorageInfo struct {
 	Used     int64   `json:"used"`
 	Avail    int64   `json:"avail"`
 	UsedFrac float64 `json:"used_fraction"`
+	// EncryptionKey carries the PBS encryption-key field. The value is
+	// either an explicit key fingerprint or the literal "autogen" when
+	// Proxmox manages the key. An empty string means encryption is off.
+	EncryptionKey string `json:"encryption-key"`
 }
 
 func (c *PveConnection) GetStorages() ([]StorageInfo, error) {

--- a/providers/proxmox/connection/testserver_test.go
+++ b/providers/proxmox/connection/testserver_test.go
@@ -1,0 +1,104 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// fakePVE spins up an httptest.Server that mimics the Proxmox API
+// envelope (`{"data": ...}`) and lets tests script per-path responses.
+// Use t.Cleanup to register Close, and call newConnection with the
+// server URL.
+type fakePVE struct {
+	t        *testing.T
+	server   *httptest.Server
+	routes   map[string]fakeRoute
+	requests []string // record of paths hit, for assertions
+}
+
+type fakeRoute struct {
+	status int
+	body   any    // marshaled into the `data` field of the envelope
+	raw    string // when set, returned verbatim instead of using `body`
+}
+
+func newFakePVE(t *testing.T) *fakePVE {
+	t.Helper()
+	f := &fakePVE{t: t, routes: map[string]fakeRoute{}}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Proxmox responses are always /api2/json/<path>; strip the prefix.
+		path := r.URL.Path
+		const prefix = "/api2/json"
+		if len(path) > len(prefix) && path[:len(prefix)] == prefix {
+			path = path[len(prefix):]
+		}
+		// Include the query string so tests can register routes like
+		// "/nodes/pve/disks/smart?disk=/dev/sda".
+		if r.URL.RawQuery != "" {
+			path += "?" + r.URL.RawQuery
+		}
+		f.requests = append(f.requests, path)
+		route, ok := f.routes[path]
+		if !ok {
+			http.Error(w, "no route", http.StatusNotFound)
+			return
+		}
+		if route.status >= 400 && route.body == nil && route.raw == "" {
+			http.Error(w, "forced error", route.status)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if route.status != 0 {
+			w.WriteHeader(route.status)
+		}
+		if route.raw != "" {
+			_, _ = w.Write([]byte(route.raw))
+			return
+		}
+		payload := map[string]any{"data": route.body}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+// route registers a successful response body for the given API path.
+// The body is wrapped in the Proxmox `{"data": ...}` envelope.
+func (f *fakePVE) route(path string, body any) {
+	f.routes[path] = fakeRoute{body: body}
+}
+
+// errorRoute registers a path that returns an HTTP error status with an
+// optional message in the envelope (mirroring how the real API reports
+// permission/not-found errors).
+func (f *fakePVE) errorRoute(path string, status int, message string) {
+	if message == "" {
+		f.routes[path] = fakeRoute{status: status}
+		return
+	}
+	f.routes[path] = fakeRoute{
+		status: status,
+		raw:    `{"data":null,"message":` + jsonQuote(message) + `}`,
+	}
+}
+
+// rawRoute lets a test bypass the envelope (useful for malformed JSON
+// regression tests).
+func (f *fakePVE) rawRoute(path string, status int, raw string) {
+	f.routes[path] = fakeRoute{status: status, raw: raw}
+}
+
+func (f *fakePVE) conn() *PveConnection {
+	// The token doesn't have to be valid; the fake server doesn't check.
+	return NewConnection(0, f.server.URL, "PVEAPIToken=root@pam!test=fake", true)
+}
+
+func jsonQuote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/providers/proxmox/resources/cluster.go
+++ b/providers/proxmox/resources/cluster.go
@@ -4,16 +4,39 @@
 package resources
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/proxmox/connection"
 )
 
+type mqlProxmoxClusterInternal struct {
+	optionsFetched bool
+	clusterOptions map[string]any
+	optionsErr     error
+	optionsLock    sync.Mutex
+}
+
 func clusterConn(r *mqlProxmoxCluster) *connection.PveConnection {
 	return r.MqlRuntime.Connection.(*connection.PveConnection)
+}
+
+func (r *mqlProxmoxCluster) ensureOptions() (map[string]any, error) {
+	if r.optionsFetched {
+		return r.clusterOptions, r.optionsErr
+	}
+	r.optionsLock.Lock()
+	defer r.optionsLock.Unlock()
+	if r.optionsFetched {
+		return r.clusterOptions, r.optionsErr
+	}
+	r.clusterOptions, r.optionsErr = clusterConn(r).GetClusterOptions()
+	r.optionsFetched = true
+	return r.clusterOptions, r.optionsErr
 }
 
 func (r *mqlProxmoxCluster) id() (string, error) {
@@ -79,8 +102,89 @@ func (r *mqlProxmoxCluster) haGroups() ([]any, error) {
 }
 
 func (r *mqlProxmoxCluster) options() (any, error) {
-	conn := clusterConn(r)
-	return conn.GetClusterOptions()
+	return r.ensureOptions()
+}
+
+// ---------------------------------------------------------------------------
+// Typed views over /cluster/options
+// ---------------------------------------------------------------------------
+
+// clusterOptionString reads a string-coerced value from cluster.options; if
+// the key isn't present or the fetch failed, returns "" with no error so an
+// audit can still proceed against partially-readable clusters.
+func (r *mqlProxmoxCluster) clusterOptionString(key string) (string, error) {
+	opts, err := r.ensureOptions()
+	if err != nil || opts == nil {
+		return "", err
+	}
+	v, ok := opts[key]
+	if !ok || v == nil {
+		return "", nil
+	}
+	return fmt.Sprintf("%v", v), nil
+}
+
+func (r *mqlProxmoxCluster) migrationPolicy() (string, error) {
+	// /cluster/options serializes the `migration` block as a comma-delimited
+	// string like `secure,network=10.0.0.0/24`. Split off the leading mode.
+	mig, err := r.clusterOptionString("migration")
+	if err != nil || mig == "" {
+		return "", err
+	}
+	if idx := strings.Index(mig, ","); idx >= 0 {
+		return mig[:idx], nil
+	}
+	return mig, nil
+}
+
+func (r *mqlProxmoxCluster) migrationNetwork() (string, error) {
+	mig, err := r.clusterOptionString("migration")
+	if err != nil || mig == "" {
+		return "", err
+	}
+	for _, part := range strings.Split(mig, ",") {
+		if kv := strings.SplitN(part, "=", 2); len(kv) == 2 && kv[0] == "network" {
+			return kv[1], nil
+		}
+	}
+	return "", nil
+}
+
+func (r *mqlProxmoxCluster) consoleViewer() (string, error) {
+	return r.clusterOptionString("console")
+}
+
+func (r *mqlProxmoxCluster) bandwidthLimits() (any, error) {
+	opts, err := r.ensureOptions()
+	if err != nil || opts == nil {
+		return map[string]any{}, err
+	}
+	raw, ok := opts["bwlimit"]
+	if !ok || raw == nil {
+		return map[string]any{}, nil
+	}
+	// `bwlimit` is serialized as a comma-delimited key=value string when
+	// the user sets multiple limits, e.g. `default=10000,restore=20000`.
+	// Convert it into a dict so MQL can index by operation name.
+	str, isStr := raw.(string)
+	if !isStr {
+		return raw, nil
+	}
+	out := map[string]any{}
+	for _, part := range strings.Split(str, ",") {
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		// values are KB/s as numeric strings; carry them as int64 when
+		// they parse, otherwise leave the raw string for audits to inspect.
+		if n, err := strconv.ParseInt(strings.TrimSpace(kv[1]), 10, 64); err == nil {
+			out[kv[0]] = n
+		} else {
+			out[kv[0]] = kv[1]
+		}
+	}
+	return out, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/providers/proxmox/resources/helpers.go
+++ b/providers/proxmox/resources/helpers.go
@@ -54,16 +54,18 @@ func storageInfoToResources(runtime *plugin.Runtime, storages []connection.Stora
 			usagePct = float64(s.Used) / float64(s.Total) * 100.0
 		}
 		res, err := CreateResource(runtime, "proxmox.storage", map[string]*llx.RawData{
-			"id":           llx.StringData(s.Storage),
-			"type":         llx.StringData(s.Type),
-			"content":      llx.StringData(s.Content),
-			"path":         llx.StringData(s.Path),
-			"enabled":      llx.BoolData(s.Enabled != 0),
-			"shared":       llx.BoolData(s.Shared != 0),
-			"total":        llx.IntData(s.Total),
-			"used":         llx.IntData(s.Used),
-			"available":    llx.IntData(s.Avail),
-			"usagePercent": llx.FloatData(usagePct),
+			"id":            llx.StringData(s.Storage),
+			"type":          llx.StringData(s.Type),
+			"content":       llx.StringData(s.Content),
+			"path":          llx.StringData(s.Path),
+			"enabled":       llx.BoolData(s.Enabled != 0),
+			"shared":        llx.BoolData(s.Shared != 0),
+			"total":         llx.IntData(s.Total),
+			"used":          llx.IntData(s.Used),
+			"available":     llx.IntData(s.Avail),
+			"usagePercent":  llx.FloatData(usagePct),
+			"encrypted":     llx.BoolData(s.EncryptionKey != ""),
+			"encryptionKey": llx.StringData(s.EncryptionKey),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/proxmox/resources/init.go
+++ b/providers/proxmox/resources/init.go
@@ -151,6 +151,8 @@ func initProxmoxStorage(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		args["used"] = llx.IntData(s.Used)
 		args["available"] = llx.IntData(s.Avail)
 		args["usagePercent"] = llx.FloatData(usagePct)
+		args["encrypted"] = llx.BoolData(s.EncryptionKey != "")
+		args["encryptionKey"] = llx.StringData(s.EncryptionKey)
 		return args, nil, nil
 	}
 	return args, nil, nil

--- a/providers/proxmox/resources/proxmox.lr
+++ b/providers/proxmox/resources/proxmox.lr
@@ -715,8 +715,8 @@ proxmox.user @defaults("id enable realm") {
   firstname string
   // Last name
   lastname string
-  // Groups the user belongs to
-  groups []string
+  // DEPRECATED: use `groupRefs` instead
+  groups @maturity("deprecated") []string
   // Resolved group memberships
   groupRefs() []proxmox.group
   // Authentication realm (pam, pve, ldap, ad)

--- a/providers/proxmox/resources/proxmox.lr
+++ b/providers/proxmox/resources/proxmox.lr
@@ -80,6 +80,26 @@ proxmox.cluster @defaults("name quorate") {
   aliases() []proxmox.firewall.alias
   // Cluster-level options
   options() dict
+  // Migration network policy
+  //
+  // `secure` tunnels through SSH; `insecure` exposes the storage stream
+  // on the chosen migration network. Empty when not configured; Proxmox
+  // defaults to `secure`.
+  migrationPolicy() string
+  // CIDR of the dedicated migration network
+  //
+  // Empty when migrations use the management network.
+  migrationNetwork() string
+  // Default VNC/SPICE console viewer
+  //
+  // One of `html5`, `vv`, or empty for the PVE default.
+  consoleViewer() string
+  // Default cluster-wide bandwidth limits
+  //
+  // Limits cover restore, migration, clone, and move operations. Keys
+  // mirror /cluster/options (`default`, `restore`, `migration`, etc.).
+  // Empty when no limits are set.
+  bandwidthLimits() dict
 }
 
 // Proxmox VE cluster HA resource
@@ -393,6 +413,8 @@ proxmox.vm.disk @defaults("id storage size") {
   iothread bool
   // Whether backup is enabled for this disk
   backup bool
+  // Resolved backing storage pool
+  storageRef() proxmox.storage
 }
 
 // Proxmox VE VM snapshot
@@ -463,6 +485,15 @@ proxmox.storage @defaults("id type enabled") {
   available int
   // Usage percentage
   usagePercent float
+  // Whether backups written to this storage are encrypted at rest
+  //
+  // True when the storage configuration carries an `encryption-key`
+  // (PBS-encrypted datastore). The key value itself is exposed via
+  // `encryptionKey` — it is either an explicit fingerprint or the
+  // literal `autogen` when Proxmox manages the key.
+  encrypted bool
+  // The raw `encryption-key` value from the storage config; empty when not configured
+  encryptionKey string
 }
 
 // Proxmox VE resource pool
@@ -686,6 +717,8 @@ proxmox.user @defaults("id enable realm") {
   lastname string
   // Groups the user belongs to
   groups []string
+  // Same as `groups`, resolved to typed group references for traversal
+  groupsTyped() []proxmox.group
   // Authentication realm (pam, pve, ldap, ad)
   realm string
   // Authentication realm type (pam, pve, ldap, ad, openid)
@@ -718,6 +751,8 @@ proxmox.token @defaults("id privsep") {
   expire int
   // Whether privilege separation is active
   privsep bool
+  // Resolved owner of this token (everything before the `!` in `id`)
+  owner() proxmox.user
 }
 
 // Proxmox VE access control role
@@ -1049,6 +1084,8 @@ proxmox.container.mountPoint @defaults("id storage mountPath size") {
   readonly bool
   // Whether POSIX ACLs are enabled on the mount
   aclEnabled bool
+  // Resolved backing storage pool
+  storageRef() proxmox.storage
 }
 
 // Proxmox VE scheduled backup job

--- a/providers/proxmox/resources/proxmox.lr
+++ b/providers/proxmox/resources/proxmox.lr
@@ -717,8 +717,8 @@ proxmox.user @defaults("id enable realm") {
   lastname string
   // Groups the user belongs to
   groups []string
-  // Same as `groups`, resolved to typed group references for traversal
-  groupsTyped() []proxmox.group
+  // Resolved group memberships
+  groupRefs() []proxmox.group
   // Authentication realm (pam, pve, ldap, ad)
   realm string
   // Authentication realm type (pam, pve, ldap, ad, openid)

--- a/providers/proxmox/resources/proxmox.lr.go
+++ b/providers/proxmox/resources/proxmox.lr.go
@@ -389,6 +389,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"proxmox.cluster.options": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxCluster).GetOptions()).ToDataRes(types.Dict)
 	},
+	"proxmox.cluster.migrationPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxCluster).GetMigrationPolicy()).ToDataRes(types.String)
+	},
+	"proxmox.cluster.migrationNetwork": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxCluster).GetMigrationNetwork()).ToDataRes(types.String)
+	},
+	"proxmox.cluster.consoleViewer": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxCluster).GetConsoleViewer()).ToDataRes(types.String)
+	},
+	"proxmox.cluster.bandwidthLimits": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxCluster).GetBandwidthLimits()).ToDataRes(types.Dict)
+	},
 	"proxmox.cluster.haResource.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxClusterHaResource).GetId()).ToDataRes(types.String)
 	},
@@ -668,6 +680,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"proxmox.vm.disk.backup": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxVmDisk).GetBackup()).ToDataRes(types.Bool)
 	},
+	"proxmox.vm.disk.storageRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxVmDisk).GetStorageRef()).ToDataRes(types.Resource("proxmox.storage"))
+	},
 	"proxmox.vm.snapshot.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxVmSnapshot).GetName()).ToDataRes(types.String)
 	},
@@ -727,6 +742,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"proxmox.storage.usagePercent": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxStorage).GetUsagePercent()).ToDataRes(types.Float)
+	},
+	"proxmox.storage.encrypted": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxStorage).GetEncrypted()).ToDataRes(types.Bool)
+	},
+	"proxmox.storage.encryptionKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxStorage).GetEncryptionKey()).ToDataRes(types.String)
 	},
 	"proxmox.pool.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxPool).GetId()).ToDataRes(types.String)
@@ -923,6 +944,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"proxmox.user.groups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxUser).GetGroups()).ToDataRes(types.Array(types.String))
 	},
+	"proxmox.user.groupsTyped": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxUser).GetGroupsTyped()).ToDataRes(types.Array(types.Resource("proxmox.group")))
+	},
 	"proxmox.user.realm": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxUser).GetRealm()).ToDataRes(types.String)
 	},
@@ -949,6 +973,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"proxmox.token.privsep": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxToken).GetPrivsep()).ToDataRes(types.Bool)
+	},
+	"proxmox.token.owner": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxToken).GetOwner()).ToDataRes(types.Resource("proxmox.user"))
 	},
 	"proxmox.role.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxRole).GetId()).ToDataRes(types.String)
@@ -1237,6 +1264,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"proxmox.container.mountPoint.aclEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxContainerMountPoint).GetAclEnabled()).ToDataRes(types.Bool)
+	},
+	"proxmox.container.mountPoint.storageRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxContainerMountPoint).GetStorageRef()).ToDataRes(types.Resource("proxmox.storage"))
 	},
 	"proxmox.backup.job.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxBackupJob).GetId()).ToDataRes(types.String)
@@ -1675,6 +1705,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlProxmoxCluster).Options, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"proxmox.cluster.migrationPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxCluster).MigrationPolicy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"proxmox.cluster.migrationNetwork": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxCluster).MigrationNetwork, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"proxmox.cluster.consoleViewer": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxCluster).ConsoleViewer, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"proxmox.cluster.bandwidthLimits": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxCluster).BandwidthLimits, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
 	"proxmox.cluster.haResource.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlProxmoxClusterHaResource).__id, ok = v.Value.(string)
 		return
@@ -2071,6 +2117,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlProxmoxVmDisk).Backup, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"proxmox.vm.disk.storageRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxVmDisk).StorageRef, ok = plugin.RawToTValue[*mqlProxmoxStorage](v.Value, v.Error)
+		return
+	},
 	"proxmox.vm.snapshot.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlProxmoxVmSnapshot).__id, ok = v.Value.(string)
 		return
@@ -2161,6 +2211,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"proxmox.storage.usagePercent": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlProxmoxStorage).UsagePercent, ok = plugin.RawToTValue[float64](v.Value, v.Error)
+		return
+	},
+	"proxmox.storage.encrypted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxStorage).Encrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"proxmox.storage.encryptionKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxStorage).EncryptionKey, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"proxmox.pool.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2459,6 +2517,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlProxmoxUser).Groups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"proxmox.user.groupsTyped": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxUser).GroupsTyped, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"proxmox.user.realm": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlProxmoxUser).Realm, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -2497,6 +2559,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"proxmox.token.privsep": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlProxmoxToken).Privsep, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"proxmox.token.owner": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxToken).Owner, ok = plugin.RawToTValue[*mqlProxmoxUser](v.Value, v.Error)
 		return
 	},
 	"proxmox.role.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2925,6 +2991,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"proxmox.container.mountPoint.aclEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlProxmoxContainerMountPoint).AclEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"proxmox.container.mountPoint.storageRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxContainerMountPoint).StorageRef, ok = plugin.RawToTValue[*mqlProxmoxStorage](v.Value, v.Error)
 		return
 	},
 	"proxmox.backup.job.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3717,18 +3787,22 @@ func (c *mqlProxmox) GetSdnVnets() *plugin.TValue[[]any] {
 type mqlProxmoxCluster struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlProxmoxClusterInternal it will be used here
-	Name            plugin.TValue[string]
-	Version         plugin.TValue[int64]
-	Quorate         plugin.TValue[bool]
-	NodeCount       plugin.TValue[int64]
-	HaResources     plugin.TValue[[]any]
-	HaGroups        plugin.TValue[[]any]
-	FirewallRules   plugin.TValue[[]any]
-	FirewallOptions plugin.TValue[*mqlProxmoxFirewallOptions]
-	Ipsets          plugin.TValue[[]any]
-	Aliases         plugin.TValue[[]any]
-	Options         plugin.TValue[any]
+	mqlProxmoxClusterInternal
+	Name             plugin.TValue[string]
+	Version          plugin.TValue[int64]
+	Quorate          plugin.TValue[bool]
+	NodeCount        plugin.TValue[int64]
+	HaResources      plugin.TValue[[]any]
+	HaGroups         plugin.TValue[[]any]
+	FirewallRules    plugin.TValue[[]any]
+	FirewallOptions  plugin.TValue[*mqlProxmoxFirewallOptions]
+	Ipsets           plugin.TValue[[]any]
+	Aliases          plugin.TValue[[]any]
+	Options          plugin.TValue[any]
+	MigrationPolicy  plugin.TValue[string]
+	MigrationNetwork plugin.TValue[string]
+	ConsoleViewer    plugin.TValue[string]
+	BandwidthLimits  plugin.TValue[any]
 }
 
 // createProxmoxCluster creates a new instance of this resource
@@ -3883,6 +3957,30 @@ func (c *mqlProxmoxCluster) GetAliases() *plugin.TValue[[]any] {
 func (c *mqlProxmoxCluster) GetOptions() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.Options, func() (any, error) {
 		return c.options()
+	})
+}
+
+func (c *mqlProxmoxCluster) GetMigrationPolicy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.MigrationPolicy, func() (string, error) {
+		return c.migrationPolicy()
+	})
+}
+
+func (c *mqlProxmoxCluster) GetMigrationNetwork() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.MigrationNetwork, func() (string, error) {
+		return c.migrationNetwork()
+	})
+}
+
+func (c *mqlProxmoxCluster) GetConsoleViewer() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ConsoleViewer, func() (string, error) {
+		return c.consoleViewer()
+	})
+}
+
+func (c *mqlProxmoxCluster) GetBandwidthLimits() *plugin.TValue[any] {
+	return plugin.GetOrCompute[any](&c.BandwidthLimits, func() (any, error) {
+		return c.bandwidthLimits()
 	})
 }
 
@@ -4883,13 +4981,14 @@ type mqlProxmoxVmDisk struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlProxmoxVmDiskInternal
-	Id       plugin.TValue[string]
-	Storage  plugin.TValue[string]
-	Size     plugin.TValue[int64]
-	Format   plugin.TValue[string]
-	Cache    plugin.TValue[string]
-	Iothread plugin.TValue[bool]
-	Backup   plugin.TValue[bool]
+	Id         plugin.TValue[string]
+	Storage    plugin.TValue[string]
+	Size       plugin.TValue[int64]
+	Format     plugin.TValue[string]
+	Cache      plugin.TValue[string]
+	Iothread   plugin.TValue[bool]
+	Backup     plugin.TValue[bool]
+	StorageRef plugin.TValue[*mqlProxmoxStorage]
 }
 
 // createProxmoxVmDisk creates a new instance of this resource
@@ -4955,6 +5054,22 @@ func (c *mqlProxmoxVmDisk) GetIothread() *plugin.TValue[bool] {
 
 func (c *mqlProxmoxVmDisk) GetBackup() *plugin.TValue[bool] {
 	return &c.Backup
+}
+
+func (c *mqlProxmoxVmDisk) GetStorageRef() *plugin.TValue[*mqlProxmoxStorage] {
+	return plugin.GetOrCompute[*mqlProxmoxStorage](&c.StorageRef, func() (*mqlProxmoxStorage, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("proxmox.vm.disk", c.__id, "storageRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlProxmoxStorage), nil
+			}
+		}
+
+		return c.storageRef()
+	})
 }
 
 // mqlProxmoxVmSnapshot for the proxmox.vm.snapshot resource
@@ -5100,16 +5215,18 @@ type mqlProxmoxStorage struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlProxmoxStorageInternal it will be used here
-	Id           plugin.TValue[string]
-	Type         plugin.TValue[string]
-	Content      plugin.TValue[string]
-	Path         plugin.TValue[string]
-	Enabled      plugin.TValue[bool]
-	Shared       plugin.TValue[bool]
-	Total        plugin.TValue[int64]
-	Used         plugin.TValue[int64]
-	Available    plugin.TValue[int64]
-	UsagePercent plugin.TValue[float64]
+	Id            plugin.TValue[string]
+	Type          plugin.TValue[string]
+	Content       plugin.TValue[string]
+	Path          plugin.TValue[string]
+	Enabled       plugin.TValue[bool]
+	Shared        plugin.TValue[bool]
+	Total         plugin.TValue[int64]
+	Used          plugin.TValue[int64]
+	Available     plugin.TValue[int64]
+	UsagePercent  plugin.TValue[float64]
+	Encrypted     plugin.TValue[bool]
+	EncryptionKey plugin.TValue[string]
 }
 
 // createProxmoxStorage creates a new instance of this resource
@@ -5187,6 +5304,14 @@ func (c *mqlProxmoxStorage) GetAvailable() *plugin.TValue[int64] {
 
 func (c *mqlProxmoxStorage) GetUsagePercent() *plugin.TValue[float64] {
 	return &c.UsagePercent
+}
+
+func (c *mqlProxmoxStorage) GetEncrypted() *plugin.TValue[bool] {
+	return &c.Encrypted
+}
+
+func (c *mqlProxmoxStorage) GetEncryptionKey() *plugin.TValue[string] {
+	return &c.EncryptionKey
 }
 
 // mqlProxmoxPool for the proxmox.pool resource
@@ -5843,6 +5968,7 @@ type mqlProxmoxUser struct {
 	Firstname      plugin.TValue[string]
 	Lastname       plugin.TValue[string]
 	Groups         plugin.TValue[[]any]
+	GroupsTyped    plugin.TValue[[]any]
 	Realm          plugin.TValue[string]
 	RealmType      plugin.TValue[string]
 	TfaLockedUntil plugin.TValue[int64]
@@ -5915,6 +6041,22 @@ func (c *mqlProxmoxUser) GetGroups() *plugin.TValue[[]any] {
 	return &c.Groups
 }
 
+func (c *mqlProxmoxUser) GetGroupsTyped() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.GroupsTyped, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("proxmox.user", c.__id, "groupsTyped")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.groupsTyped()
+	})
+}
+
 func (c *mqlProxmoxUser) GetRealm() *plugin.TValue[string] {
 	return &c.Realm
 }
@@ -5958,6 +6100,7 @@ type mqlProxmoxToken struct {
 	Comment plugin.TValue[string]
 	Expire  plugin.TValue[int64]
 	Privsep plugin.TValue[bool]
+	Owner   plugin.TValue[*mqlProxmoxUser]
 }
 
 // createProxmoxToken creates a new instance of this resource
@@ -6011,6 +6154,22 @@ func (c *mqlProxmoxToken) GetExpire() *plugin.TValue[int64] {
 
 func (c *mqlProxmoxToken) GetPrivsep() *plugin.TValue[bool] {
 	return &c.Privsep
+}
+
+func (c *mqlProxmoxToken) GetOwner() *plugin.TValue[*mqlProxmoxUser] {
+	return plugin.GetOrCompute[*mqlProxmoxUser](&c.Owner, func() (*mqlProxmoxUser, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("proxmox.token", c.__id, "owner")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlProxmoxUser), nil
+			}
+		}
+
+		return c.owner()
+	})
 }
 
 // mqlProxmoxRole for the proxmox.role resource
@@ -7082,6 +7241,7 @@ type mqlProxmoxContainerMountPoint struct {
 	Replicate  plugin.TValue[bool]
 	Readonly   plugin.TValue[bool]
 	AclEnabled plugin.TValue[bool]
+	StorageRef plugin.TValue[*mqlProxmoxStorage]
 }
 
 // createProxmoxContainerMountPoint creates a new instance of this resource
@@ -7151,6 +7311,22 @@ func (c *mqlProxmoxContainerMountPoint) GetReadonly() *plugin.TValue[bool] {
 
 func (c *mqlProxmoxContainerMountPoint) GetAclEnabled() *plugin.TValue[bool] {
 	return &c.AclEnabled
+}
+
+func (c *mqlProxmoxContainerMountPoint) GetStorageRef() *plugin.TValue[*mqlProxmoxStorage] {
+	return plugin.GetOrCompute[*mqlProxmoxStorage](&c.StorageRef, func() (*mqlProxmoxStorage, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("proxmox.container.mountPoint", c.__id, "storageRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlProxmoxStorage), nil
+			}
+		}
+
+		return c.storageRef()
+	})
 }
 
 // mqlProxmoxBackupJob for the proxmox.backup.job resource

--- a/providers/proxmox/resources/proxmox.lr.go
+++ b/providers/proxmox/resources/proxmox.lr.go
@@ -944,8 +944,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"proxmox.user.groups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxUser).GetGroups()).ToDataRes(types.Array(types.String))
 	},
-	"proxmox.user.groupsTyped": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlProxmoxUser).GetGroupsTyped()).ToDataRes(types.Array(types.Resource("proxmox.group")))
+	"proxmox.user.groupRefs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxUser).GetGroupRefs()).ToDataRes(types.Array(types.Resource("proxmox.group")))
 	},
 	"proxmox.user.realm": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxUser).GetRealm()).ToDataRes(types.String)
@@ -2517,8 +2517,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlProxmoxUser).Groups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"proxmox.user.groupsTyped": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlProxmoxUser).GroupsTyped, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+	"proxmox.user.groupRefs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxUser).GroupRefs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"proxmox.user.realm": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5968,7 +5968,7 @@ type mqlProxmoxUser struct {
 	Firstname      plugin.TValue[string]
 	Lastname       plugin.TValue[string]
 	Groups         plugin.TValue[[]any]
-	GroupsTyped    plugin.TValue[[]any]
+	GroupRefs      plugin.TValue[[]any]
 	Realm          plugin.TValue[string]
 	RealmType      plugin.TValue[string]
 	TfaLockedUntil plugin.TValue[int64]
@@ -6041,10 +6041,10 @@ func (c *mqlProxmoxUser) GetGroups() *plugin.TValue[[]any] {
 	return &c.Groups
 }
 
-func (c *mqlProxmoxUser) GetGroupsTyped() *plugin.TValue[[]any] {
-	return plugin.GetOrCompute[[]any](&c.GroupsTyped, func() ([]any, error) {
+func (c *mqlProxmoxUser) GetGroupRefs() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.GroupRefs, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("proxmox.user", c.__id, "groupsTyped")
+			d, err := c.MqlRuntime.FieldResourceFromRecording("proxmox.user", c.__id, "groupRefs")
 			if err != nil {
 				return nil, err
 			}
@@ -6053,7 +6053,7 @@ func (c *mqlProxmoxUser) GetGroupsTyped() *plugin.TValue[[]any] {
 			}
 		}
 
-		return c.groupsTyped()
+		return c.groupRefs()
 	})
 }
 

--- a/providers/proxmox/resources/proxmox.lr.versions
+++ b/providers/proxmox/resources/proxmox.lr.versions
@@ -48,6 +48,8 @@ proxmox.certificate.san 0.1.1
 proxmox.certificate.subject 0.1.1
 proxmox.cluster 0.1.1
 proxmox.cluster.aliases 0.1.9
+proxmox.cluster.bandwidthLimits 0.1.9
+proxmox.cluster.consoleViewer 0.1.9
 proxmox.cluster.firewallOptions 0.1.9
 proxmox.cluster.firewallRules 0.1.1
 proxmox.cluster.haGroup 0.1.9
@@ -71,6 +73,8 @@ proxmox.cluster.haResource.type 0.1.1
 proxmox.cluster.haResource.vm 0.1.9
 proxmox.cluster.haResources 0.1.1
 proxmox.cluster.ipsets 0.1.9
+proxmox.cluster.migrationNetwork 0.1.9
+proxmox.cluster.migrationPolicy 0.1.9
 proxmox.cluster.name 0.1.1
 proxmox.cluster.nodeCount 0.1.1
 proxmox.cluster.options 0.1.1
@@ -103,6 +107,7 @@ proxmox.container.mountPoint.readonly 0.1.9
 proxmox.container.mountPoint.replicate 0.1.9
 proxmox.container.mountPoint.size 0.1.9
 proxmox.container.mountPoint.storage 0.1.9
+proxmox.container.mountPoint.storageRef 0.1.9
 proxmox.container.mountPoints 0.1.9
 proxmox.container.name 0.1.9
 proxmox.container.netin 0.1.9
@@ -345,6 +350,8 @@ proxmox.storage 0.1.1
 proxmox.storage.available 0.1.1
 proxmox.storage.content 0.1.1
 proxmox.storage.enabled 0.1.1
+proxmox.storage.encrypted 0.1.9
+proxmox.storage.encryptionKey 0.1.9
 proxmox.storage.id 0.1.1
 proxmox.storage.path 0.1.1
 proxmox.storage.shared 0.1.1
@@ -365,6 +372,7 @@ proxmox.token 0.1.1
 proxmox.token.comment 0.1.1
 proxmox.token.expire 0.1.1
 proxmox.token.id 0.1.1
+proxmox.token.owner 0.1.9
 proxmox.token.privsep 0.1.1
 proxmox.user 0.1.1
 proxmox.user.email 0.1.1
@@ -372,6 +380,7 @@ proxmox.user.enable 0.1.1
 proxmox.user.expire 0.1.1
 proxmox.user.firstname 0.1.1
 proxmox.user.groups 0.1.1
+proxmox.user.groupsTyped 0.1.9
 proxmox.user.id 0.1.1
 proxmox.user.lastname 0.1.1
 proxmox.user.realm 0.1.1
@@ -396,6 +405,7 @@ proxmox.vm.disk.id 0.1.1
 proxmox.vm.disk.iothread 0.1.1
 proxmox.vm.disk.size 0.1.1
 proxmox.vm.disk.storage 0.1.1
+proxmox.vm.disk.storageRef 0.1.9
 proxmox.vm.diskread 0.1.1
 proxmox.vm.disks 0.1.1
 proxmox.vm.diskwrite 0.1.1

--- a/providers/proxmox/resources/proxmox.lr.versions
+++ b/providers/proxmox/resources/proxmox.lr.versions
@@ -379,8 +379,8 @@ proxmox.user.email 0.1.1
 proxmox.user.enable 0.1.1
 proxmox.user.expire 0.1.1
 proxmox.user.firstname 0.1.1
+proxmox.user.groupRefs 0.1.9
 proxmox.user.groups 0.1.1
-proxmox.user.groupsTyped 0.1.9
 proxmox.user.id 0.1.1
 proxmox.user.lastname 0.1.1
 proxmox.user.realm 0.1.1

--- a/providers/proxmox/resources/xrefs.go
+++ b/providers/proxmox/resources/xrefs.go
@@ -60,10 +60,10 @@ func (r *mqlProxmoxToken) owner() (*mqlProxmoxUser, error) {
 }
 
 // ---------------------------------------------------------------------------
-// user → groupsTyped
+// user → groupRefs
 // ---------------------------------------------------------------------------
 
-func (r *mqlProxmoxUser) groupsTyped() ([]any, error) {
+func (r *mqlProxmoxUser) groupRefs() ([]any, error) {
 	out := make([]any, 0, len(r.Groups.Data))
 	for _, raw := range r.Groups.Data {
 		g, ok := raw.(string)

--- a/providers/proxmox/resources/xrefs.go
+++ b/providers/proxmox/resources/xrefs.go
@@ -1,0 +1,82 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// ---------------------------------------------------------------------------
+// vm.disk / container.mountPoint → storage
+// ---------------------------------------------------------------------------
+
+func (r *mqlProxmoxVmDisk) storageRef() (*mqlProxmoxStorage, error) {
+	return resolveStorageRef(r.MqlRuntime, r.Storage.Data, &r.StorageRef)
+}
+
+func (r *mqlProxmoxContainerMountPoint) storageRef() (*mqlProxmoxStorage, error) {
+	return resolveStorageRef(r.MqlRuntime, r.Storage.Data, &r.StorageRef)
+}
+
+func resolveStorageRef(runtime *plugin.Runtime, storageID string, slot *plugin.TValue[*mqlProxmoxStorage]) (*mqlProxmoxStorage, error) {
+	if storageID == "" {
+		slot.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(runtime, "proxmox.storage", map[string]*llx.RawData{
+		"id": llx.StringData(storageID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlProxmoxStorage), nil
+}
+
+// ---------------------------------------------------------------------------
+// token → owner user
+// ---------------------------------------------------------------------------
+
+func (r *mqlProxmoxToken) owner() (*mqlProxmoxUser, error) {
+	// Token id shape is `user@realm!tokenid`. Anything else is a token
+	// the API would have refused to create, so treat unparseable ids as
+	// "no resolvable owner" rather than failing the whole query.
+	bang := strings.LastIndex(r.Id.Data, "!")
+	if bang <= 0 {
+		r.Owner.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	ownerID := r.Id.Data[:bang]
+	res, err := NewResource(r.MqlRuntime, "proxmox.user", map[string]*llx.RawData{
+		"id": llx.StringData(ownerID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlProxmoxUser), nil
+}
+
+// ---------------------------------------------------------------------------
+// user → groupsTyped
+// ---------------------------------------------------------------------------
+
+func (r *mqlProxmoxUser) groupsTyped() ([]any, error) {
+	out := make([]any, 0, len(r.Groups.Data))
+	for _, raw := range r.Groups.Data {
+		g, ok := raw.(string)
+		if !ok || g == "" {
+			continue
+		}
+		res, err := NewResource(r.MqlRuntime, "proxmox.group", map[string]*llx.RawData{
+			"id": llx.StringData(g),
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}


### PR DESCRIPTION
## Summary

Three small audit-ergonomics improvements plus the start of an HTTP-mocked test layer for the connection package.

**Cross-references** — fields that today hold identifier strings now have a typed sibling for traversal:
- `proxmox.vm.disk.storageRef()` and `proxmox.container.mountPoint.storageRef()` → `proxmox.storage`
- `proxmox.token.owner()` → `proxmox.user` (parses the owner out of `user@realm!tokenid`)
- `proxmox.user.groupsRefs()` → `[]proxmox.group` (keeps the existing `groups []string` field intact)

**Cluster options typed view** — lazy accessors over `/cluster/options` so audits don't have to grep the dict:
- `migrationPolicy()` / `migrationNetwork()` (parsed from the `migration` serialized line)
- `consoleViewer()` (`html5`, `vv`, or empty for PVE default)
- `bandwidthLimits()` (parsed from the `bwlimit` `key=value,...` list into a per-operation dict)
- `options()` itself is now cached via a new `mqlProxmoxClusterInternal` so all five accessors share a single API call.

**PBS encryption** — `proxmox.storage` now exposes:
- `encrypted bool` — true when the storage config carries an `encryption-key`
- `encryptionKey string` — raw value (typically `"autogen"` or a fingerprint)

**HTTP-mocked unit tests** — new harness in `connection/testserver_test.go` spins up an `httptest.Server` that mimics the PVE `/api2/json` envelope. `connection/api_test.go` covers:
- `APIError` captures the HTTP status code through `apiGet`
- `IsAccessDeniedOrNotFound` over 401/403/404 vs other failures
- `GetStorages` — encryption-key parsing for PBS vs plain dir storage
- `GetNodeContainers` — valid + malformed VMID parsing (regression for the prior `fmt.Sscanf` bug)
- `GetClusterFirewallOptions` — raw dict round-trip
- `GetReplicationJobs` — disable / rate / VMID shape

`.lr.versions` entries land at `0.1.9` (next patch after the provider's current `0.1.8`).

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./...` passes; the new connection-layer tests all green
- [x] `make providers/build/proxmox` produces `dist/proxmox`
- [ ] Interactive smoke against a live Proxmox cluster:
  - `mql shell proxmox -c "proxmox.vms { name disks { storage storageRef.encrypted } }"`
  - `mql shell proxmox -c "proxmox.users { id tokens { id owner.id privsep } }"`
  - `mql shell proxmox -c "proxmox.users { id groupsTyped.id }"`
  - `mql shell proxmox -c "proxmox.cluster { migrationPolicy migrationNetwork consoleViewer bandwidthLimits }"`
  - `mql shell proxmox -c "proxmox.storages.where(type == 'pbs') { id encrypted encryptionKey }"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)