### PR TITLE
✨ helm: kubeVersion and chart annotations

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -35,6 +35,7 @@ armcontainerregistry
 armcontainerregistrytasks
 armoperationalinsights
 arp
+artifacthub
 artifactregistry
 asdk
 ashburn

--- a/providers/helm/resources/helm.go
+++ b/providers/helm/resources/helm.go
@@ -51,7 +51,7 @@ func newMqlHelmChart(runtime *plugin.Runtime, c *chart.Chart) (*mqlHelmChart, er
 	keywords := convert.SliceAnyToInterface(meta.Keywords)
 	sources := convert.SliceAnyToInterface(meta.Sources)
 
-	res, err := CreateResource(runtime, "helm.chart", map[string]*llx.RawData{
+	args := map[string]*llx.RawData{
 		"__id":        llx.StringData("helm.chart:" + meta.Name + ":" + meta.Version),
 		"name":        llx.StringData(meta.Name),
 		"version":     llx.StringData(meta.Version),
@@ -64,7 +64,19 @@ func newMqlHelmChart(runtime *plugin.Runtime, c *chart.Chart) (*mqlHelmChart, er
 		"sources":     llx.ArrayData(sources, types.String),
 		"icon":        llx.StringData(meta.Icon),
 		"deprecated":  llx.BoolData(meta.Deprecated),
-	})
+		"kubeVersion": llx.StringData(meta.KubeVersion),
+	}
+	if meta.Annotations == nil {
+		args["annotations"] = llx.NilData
+	} else {
+		annotations := make(map[string]any, len(meta.Annotations))
+		for k, v := range meta.Annotations {
+			annotations[k] = v
+		}
+		args["annotations"] = llx.MapData(annotations, types.String)
+	}
+
+	res, err := CreateResource(runtime, "helm.chart", args)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/helm/resources/helm.lr
+++ b/providers/helm/resources/helm.lr
@@ -49,6 +49,19 @@ helm.chart @defaults("name version") {
   icon string
   // Whether the chart is deprecated
   deprecated bool
+  // SemVer constraint on the supported Kubernetes versions
+  //
+  // From `kubeVersion:` in Chart.yaml. Empty when unconstrained — audits
+  // commonly require every chart to pin a kubeVersion so it can be
+  // gated against a cluster's actual version (e.g. `>=1.27.0-0`).
+  kubeVersion string
+  // Chart-level annotations
+  //
+  // From `annotations:` in Chart.yaml. Used by Helm itself (for example
+  // `artifacthub.io/changes`, `artifacthub.io/license`,
+  // `helm.sh/chart-deprecation`) and by chart consumers for arbitrary
+  // metadata.
+  annotations map[string]string
   // Parsed templates
   templates() []helm.template
   // Default values from values.yaml

--- a/providers/helm/resources/helm.lr.go
+++ b/providers/helm/resources/helm.lr.go
@@ -174,6 +174,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"helm.chart.deprecated": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHelmChart).GetDeprecated()).ToDataRes(types.Bool)
 	},
+	"helm.chart.kubeVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHelmChart).GetKubeVersion()).ToDataRes(types.String)
+	},
+	"helm.chart.annotations": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHelmChart).GetAnnotations()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"helm.chart.templates": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHelmChart).GetTemplates()).ToDataRes(types.Array(types.Resource("helm.template")))
 	},
@@ -344,6 +350,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"helm.chart.deprecated": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHelmChart).Deprecated, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"helm.chart.kubeVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHelmChart).KubeVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"helm.chart.annotations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHelmChart).Annotations, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"helm.chart.templates": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -601,6 +615,8 @@ type mqlHelmChart struct {
 	Sources      plugin.TValue[[]any]
 	Icon         plugin.TValue[string]
 	Deprecated   plugin.TValue[bool]
+	KubeVersion  plugin.TValue[string]
+	Annotations  plugin.TValue[map[string]any]
 	Templates    plugin.TValue[[]any]
 	Values       plugin.TValue[any]
 	Resources    plugin.TValue[[]any]
@@ -718,6 +734,14 @@ func (c *mqlHelmChart) GetIcon() *plugin.TValue[string] {
 
 func (c *mqlHelmChart) GetDeprecated() *plugin.TValue[bool] {
 	return &c.Deprecated
+}
+
+func (c *mqlHelmChart) GetKubeVersion() *plugin.TValue[string] {
+	return &c.KubeVersion
+}
+
+func (c *mqlHelmChart) GetAnnotations() *plugin.TValue[map[string]any] {
+	return &c.Annotations
 }
 
 func (c *mqlHelmChart) GetTemplates() *plugin.TValue[[]any] {

--- a/providers/helm/resources/helm.lr.versions
+++ b/providers/helm/resources/helm.lr.versions
@@ -3,6 +3,7 @@
 
 helm 13.0.0
 helm.chart 13.0.0
+helm.chart.annotations 13.0.9
 helm.chart.apiVersion 13.0.0
 helm.chart.appVersion 13.0.0
 helm.chart.dependencies 13.0.0
@@ -12,6 +13,7 @@ helm.chart.files 13.0.0
 helm.chart.home 13.0.0
 helm.chart.icon 13.0.0
 helm.chart.keywords 13.0.0
+helm.chart.kubeVersion 13.0.9
 helm.chart.maintainers 13.0.0
 helm.chart.name 13.0.0
 helm.chart.resources 13.0.0

--- a/providers/helm/resources/helm_test.go
+++ b/providers/helm/resources/helm_test.go
@@ -1,0 +1,49 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/chart"
+)
+
+func TestNewMqlHelmChart_KubeVersionAndAnnotations(t *testing.T) {
+	t.Run("populated fields surface verbatim", func(t *testing.T) {
+		c := &chart.Chart{Metadata: &chart.Metadata{
+			Name:        "mychart",
+			Version:     "1.2.3",
+			KubeVersion: ">=1.27.0-0",
+			Annotations: map[string]string{
+				"artifacthub.io/license": "Apache-2.0",
+				"artifacthub.io/changes": "Initial release",
+			},
+		}}
+
+		mqlChart, err := newMqlHelmChart(newTestRuntime(), c)
+		require.NoError(t, err)
+		assert.Equal(t, ">=1.27.0-0", mqlChart.KubeVersion.Data)
+		assert.Equal(t, map[string]any{
+			"artifacthub.io/license": "Apache-2.0",
+			"artifacthub.io/changes": "Initial release",
+		}, mqlChart.Annotations.Data)
+	})
+
+	t.Run("missing fields stay empty / nil", func(t *testing.T) {
+		c := &chart.Chart{Metadata: &chart.Metadata{
+			Name:    "mychart",
+			Version: "1.2.3",
+		}}
+
+		mqlChart, err := newMqlHelmChart(newTestRuntime(), c)
+		require.NoError(t, err)
+		assert.Equal(t, "", mqlChart.KubeVersion.Data)
+		// A chart without `annotations:` parses to nil; the resource layer
+		// passes NilData so audits can distinguish "no annotations" from
+		// "explicitly empty annotations".
+		assert.Nil(t, mqlChart.Annotations.Data)
+	})
+}


### PR DESCRIPTION
## Summary
- Surfaces the two remaining `chart.Metadata` fields the Helm loader already returns but the schema didn't expose:
- `helm.chart.kubeVersion` — Helm's `kubeVersion:` SemVer constraint that gates which Kubernetes versions a chart supports (e.g. `>=1.27.0-0`). Audits commonly require every chart to pin a constraint so it can be checked against the target cluster.
- `helm.chart.annotations` — the chart-level `annotations:` block. Used by Helm (`artifacthub.io/changes`, `helm.sh/chart-deprecation`, etc.) and by chart consumers for arbitrary metadata.
- Missing-annotations is `null`, not `{}`, matching the bicep tags pattern so audits can distinguish "no annotations" from "explicitly empty".

## Test plan
- [x] `go test ./resources/...` from `providers/helm` — passes. New `TestNewMqlHelmChart_KubeVersionAndAnnotations` covers both populated and missing cases (asserts `kubeVersion: ""` and `annotations == nil` for the missing case).
- [x] Built and installed; interactively queried a Chart.yaml with `kubeVersion: ">=1.27.0-0"` and two artifacthub annotations — both render correctly.
- [x] `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)