### PR TITLE
🎉 bicep-13.1.0

### DIFF
--- a/providers/bicep/config/config.go
+++ b/providers/bicep/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "bicep",
 	ID:              "go.mondoo.com/mql/v13/providers/bicep",
-	Version:         "13.0.8",
+	Version:         "13.1.0",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### bicep (13.1.0)
- ✨ bicep: parameter bounds and resource tags (#7855)
- 🧹 Update deps for mql and providers 20260521 (#7760)