### PR TITLE
✨ proxmox: polish pass — cert expiry, repo signing, kernel reboot, pool refs, backup targets

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -166,6 +166,7 @@ ddl
 ddos
 DEAUTHORIZED
 DEAUTHORIZING
+deb822
 dedup
 dedupratio
 defc
@@ -302,6 +303,7 @@ Iaa
 iana
 iap
 IBgt
+ibpb
 iccid
 identitycenter
 identitysource
@@ -361,6 +363,7 @@ kts
 kty
 kubenet
 kustomization
+kversion
 KVM
 labelmatchstatement
 Laravel
@@ -665,6 +668,7 @@ sqlimatchstatement
 sqlserver
 sriov
 srp
+ssbd
 SSHFP
 sshkeys
 ssis

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -98,11 +98,9 @@ ceph
 certificatechains
 certificatesmanagement
 cetypes
-cfs
 chabc
 chatgpt
 chokepoint
-cicustom
 cifs
 cipassword
 ciscocatalyst
@@ -137,8 +135,6 @@ cosmosdb
 costexplorer
 cowlib
 cpe
-cpulimit
-cpuunits
 CPWn
 cpx
 CRDR
@@ -363,7 +359,6 @@ kts
 kty
 kubenet
 kustomization
-kversion
 KVM
 labelmatchstatement
 Laravel
@@ -423,7 +418,6 @@ minfree
 MINIMALUSER
 Mirrorings
 mkey
-mknod
 mlag
 mls
 Mnfz
@@ -444,7 +438,6 @@ mychart
 myproject
 myvendor
 naflags
-nameserver
 natgateway
 nativead
 ndp
@@ -554,6 +547,7 @@ proxmox
 PROXYV
 psc
 psr
+pti
 PTn
 pubspec
 pushconfig
@@ -626,7 +620,6 @@ scm
 sdn
 sdp
 seabios
-searchdomain
 SECRETID
 secretmanager
 SECRETVALUE
@@ -655,7 +648,6 @@ slo
 smbv
 snaptime
 snat
-snippets
 SNOWSQL
 SNYK
 softdep
@@ -670,7 +662,6 @@ sriov
 srp
 ssbd
 SSHFP
-sshkeys
 ssis
 sslv
 Sspr
@@ -695,7 +686,6 @@ swi
 syd
 SYMANTEC
 symfony
-sys
 tacacs
 tailnets
 tailscale

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -162,7 +162,6 @@ ddl
 ddos
 DEAUTHORIZED
 DEAUTHORIZING
-deb822
 dedup
 dedupratio
 defc

--- a/providers/proxmox/connection/node.go
+++ b/providers/proxmox/connection/node.go
@@ -30,6 +30,9 @@ type NodeStatus struct {
 		Sockets int    `json:"sockets"`
 		Cores   int    `json:"cores"`
 		CPUs    int    `json:"cpus"`
+		// Flags is space-separated as returned by /proc/cpuinfo. Older
+		// PVE versions may omit the field entirely.
+		Flags string `json:"flags"`
 	} `json:"cpuinfo"`
 	CPU float64 `json:"cpu"`
 	// Memory
@@ -48,6 +51,15 @@ type NodeStatus struct {
 	PVEVer   string   `json:"pveversion"`
 	Uptime   int64    `json:"uptime"`
 	LoadAvg  []string `json:"loadavg"`
+	// BootInfo reports the running kernel image and what would boot
+	// on the next reboot. When the two differ a kernel package has
+	// been installed but the host hasn't picked it up yet.
+	BootInfo struct {
+		Mode          string `json:"mode"`
+		SecureBoot    int    `json:"secureboot"`
+		CurrentKernel string `json:"current-kernel"`
+		BootKernel    string `json:"boot-kernel"`
+	} `json:"boot-info"`
 }
 
 func (c *PveConnection) GetNodeStatus(node string) (*NodeStatus, error) {
@@ -209,6 +221,13 @@ type AptRepoInfo struct {
 			Components []string `json:"Components"`
 			Enabled    bool     `json:"Enabled"`
 			Comment    string   `json:"Comment"`
+			// PVE serializes Signed-By and the other deb822 options as an
+			// array of {Key, Values}. Older API versions and one-line
+			// sources don't return Options at all.
+			Options []struct {
+				Key    string   `json:"Key"`
+				Values []string `json:"Values"`
+			} `json:"Options"`
 		} `json:"repositories"`
 	} `json:"files"`
 	Infos []struct {

--- a/providers/proxmox/resources/backup.go
+++ b/providers/proxmox/resources/backup.go
@@ -18,6 +18,15 @@ type mqlProxmoxBackupJobInternal struct {
 	cfg           map[string]any
 	cfgErr        error
 	lock          sync.Mutex
+
+	// Target resolution hits /cluster/resources for both VMs and
+	// containers; cache the result so a query that reads both
+	// targetVms and targetContainers only pays the cost once.
+	targetsFetched bool
+	cachedVms      []any
+	cachedCts      []any
+	targetsErr     error
+	targetsLock    sync.Mutex
 }
 
 func (r *mqlProxmox) backupJobs() ([]any, error) {
@@ -103,8 +112,23 @@ func parseBackupVMIDs(raw string) []int64 {
 
 // resolveBackupTargets walks the cluster inventory once and returns the
 // VMs and containers selected by the job. `all` selects everything; a
-// non-empty `vmids` list selects only the matching guests.
+// non-empty `vmids` list selects only the matching guests. Results
+// are cached on the resource so the two accessors share one fetch.
 func (r *mqlProxmoxBackupJob) resolveBackupTargets() (vms, containers []any, err error) {
+	if r.targetsFetched {
+		return r.cachedVms, r.cachedCts, r.targetsErr
+	}
+	r.targetsLock.Lock()
+	defer r.targetsLock.Unlock()
+	if r.targetsFetched {
+		return r.cachedVms, r.cachedCts, r.targetsErr
+	}
+	r.cachedVms, r.cachedCts, r.targetsErr = r.resolveBackupTargetsUncached()
+	r.targetsFetched = true
+	return r.cachedVms, r.cachedCts, r.targetsErr
+}
+
+func (r *mqlProxmoxBackupJob) resolveBackupTargetsUncached() (vms, containers []any, err error) {
 	conn := r.MqlRuntime.Connection.(*connection.PveConnection)
 	all := r.All.Data
 	wanted := parseBackupVMIDs(r.Vmids.Data)

--- a/providers/proxmox/resources/backup.go
+++ b/providers/proxmox/resources/backup.go
@@ -4,6 +4,8 @@
 package resources
 
 import (
+	"strconv"
+	"strings"
 	"sync"
 
 	"go.mondoo.com/mql/v13/llx"
@@ -67,6 +69,117 @@ func (r *mqlProxmoxBackupJob) targetStorage() (*mqlProxmoxStorage, error) {
 		return nil, err
 	}
 	return res.(*mqlProxmoxStorage), nil
+}
+
+// parseBackupVMIDs splits a Proxmox `vmid` string into individual VMIDs.
+// The API accepts comma-separated lists (and tolerates whitespace).
+// Tokens that don't parse as integers are skipped — the API can also
+// accept "all" or ranges like "100-105" which we don't materialize as
+// targets here; ranges aren't surfaced by the listing endpoint at the
+// VM resource level.
+func parseBackupVMIDs(raw string) []int64 {
+	if raw == "" {
+		return nil
+	}
+	var out []int64
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" || part == "all" {
+			continue
+		}
+		// Skip ranges like "100-105" — not used in /cluster/backup output
+		// but defend against the future.
+		if strings.Contains(part, "-") {
+			continue
+		}
+		n, err := strconv.ParseInt(part, 10, 64)
+		if err != nil {
+			continue
+		}
+		out = append(out, n)
+	}
+	return out
+}
+
+// resolveBackupTargets walks the cluster inventory once and returns the
+// VMs and containers selected by the job. `all` selects everything; a
+// non-empty `vmids` list selects only the matching guests.
+func (r *mqlProxmoxBackupJob) resolveBackupTargets() (vms, containers []any, err error) {
+	conn := r.MqlRuntime.Connection.(*connection.PveConnection)
+	all := r.All.Data
+	wanted := parseBackupVMIDs(r.Vmids.Data)
+	if !all && len(wanted) == 0 {
+		// Pool-scoped jobs land here; surface empty lists so an audit
+		// can branch on `pool != ""` separately.
+		return nil, nil, nil
+	}
+	wantSet := make(map[int64]struct{}, len(wanted))
+	for _, id := range wanted {
+		wantSet[id] = struct{}{}
+	}
+
+	allVMs, vmErr := conn.GetAllVMs()
+	if vmErr == nil {
+		for _, vm := range allVMs {
+			if !all {
+				if _, ok := wantSet[int64(vm.VMID)]; !ok {
+					continue
+				}
+			}
+			ref, err := NewResource(r.MqlRuntime, "proxmox.vm", map[string]*llx.RawData{
+				"id": llx.IntData(int64(vm.VMID)),
+			})
+			if err != nil {
+				return nil, nil, err
+			}
+			vms = append(vms, ref)
+		}
+	}
+	allCT, ctErr := conn.GetAllContainers()
+	if ctErr == nil {
+		for _, ct := range allCT {
+			if !all {
+				if _, ok := wantSet[int64(ct.VMID)]; !ok {
+					continue
+				}
+			}
+			ref, err := NewResource(r.MqlRuntime, "proxmox.container", map[string]*llx.RawData{
+				"id": llx.IntData(int64(ct.VMID)),
+			})
+			if err != nil {
+				return nil, nil, err
+			}
+			containers = append(containers, ref)
+		}
+	}
+	// Only return the cluster-listing error when both lookups failed —
+	// a partial result is more useful for audits than a hard failure.
+	if vmErr != nil && ctErr != nil {
+		return nil, nil, vmErr
+	}
+	return vms, containers, nil
+}
+
+func (r *mqlProxmoxBackupJob) targetVms() ([]any, error) {
+	vms, _, err := r.resolveBackupTargets()
+	if err != nil {
+		return nil, err
+	}
+	if vms == nil {
+		return []any{}, nil
+	}
+	return vms, nil
+}
+
+func (r *mqlProxmoxBackupJob) targetContainers() ([]any, error) {
+	_, cts, err := r.resolveBackupTargets()
+	if err != nil {
+		return nil, err
+	}
+	if cts == nil {
+		return []any{}, nil
+	}
+	return cts, nil
 }
 
 func (r *mqlProxmoxBackupJob) config() (any, error) {

--- a/providers/proxmox/resources/backup_test.go
+++ b/providers/proxmox/resources/backup_test.go
@@ -1,0 +1,35 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseBackupVMIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []int64
+	}{
+		{"empty", "", nil},
+		{"single", "100", []int64{100}},
+		{"comma-separated", "100,101,200", []int64{100, 101, 200}},
+		{"whitespace-tolerated", " 100 , 101 , 200 ", []int64{100, 101, 200}},
+		{"all-skipped", "all", nil},
+		{"non-numeric-skipped", "garbage,100,more-garbage", []int64{100}},
+		{"range-skipped", "100-105", nil},
+		{"mixed-with-range", "100,200-205,300", []int64{100, 300}},
+		{"trailing-comma", "100,", []int64{100}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseBackupVMIDs(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseBackupVMIDs(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/providers/proxmox/resources/certificate.go
+++ b/providers/proxmox/resources/certificate.go
@@ -1,0 +1,22 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "time"
+
+// daysBetween returns the number of full 24-hour periods from `from` to
+// `to`, truncated toward zero. A 5-hour gap reports 0, a 25-hour gap
+// reports 1, and an already-expired certificate reports a negative
+// number so audits can write `daysUntilExpiry < 30` (warn) and
+// `daysUntilExpiry < 0` (already expired) against the same field.
+func daysBetween(from, to time.Time) int64 {
+	return int64(to.Sub(from) / (24 * time.Hour))
+}
+
+func (r *mqlProxmoxCertificate) daysUntilExpiry() (int64, error) {
+	if r.NotAfter.Data == nil {
+		return 0, nil
+	}
+	return daysBetween(time.Now(), *r.NotAfter.Data), nil
+}

--- a/providers/proxmox/resources/certificate_test.go
+++ b/providers/proxmox/resources/certificate_test.go
@@ -8,19 +8,16 @@ import (
 	"time"
 )
 
-// daysUntil mirrors the math used by mqlProxmoxCertificate.daysUntilExpiry.
-// Pinning it here pins the rounding direction without binding the test
-// to the wall clock.
-func daysUntil(t time.Time, now time.Time) int64 {
-	return int64(t.Sub(now) / (24 * time.Hour))
-}
-
-func TestCertificateDaysUntilExpiryRounding(t *testing.T) {
+// TestDaysBetween pins the rounding direction of the shared helper
+// behind mqlProxmoxCertificate.daysUntilExpiry. The test calls the
+// production helper directly so a drift in the formula is caught
+// here rather than going unnoticed.
+func TestDaysBetween(t *testing.T) {
 	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
 	tests := []struct {
-		name     string
-		notAfter time.Time
-		want     int64
+		name string
+		to   time.Time
+		want int64
 	}{
 		{"exactly-30-days", now.Add(30 * 24 * time.Hour), 30},
 		{"29-days-23-hours", now.Add(29*24*time.Hour + 23*time.Hour), 29},
@@ -32,9 +29,9 @@ func TestCertificateDaysUntilExpiryRounding(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := daysUntil(tt.notAfter, now)
+			got := daysBetween(now, tt.to)
 			if got != tt.want {
-				t.Errorf("daysUntil(%v) = %d, want %d", tt.notAfter, got, tt.want)
+				t.Errorf("daysBetween(now, %v) = %d, want %d", tt.to, got, tt.want)
 			}
 		})
 	}

--- a/providers/proxmox/resources/container.go
+++ b/providers/proxmox/resources/container.go
@@ -246,6 +246,21 @@ func (r *mqlProxmoxContainer) tags() ([]any, error) {
 	return result, nil
 }
 
+func (r *mqlProxmoxContainer) pool() (*mqlProxmoxPool, error) {
+	id := r.cfgStr("pool")
+	if id == "" {
+		r.Pool.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(r.MqlRuntime, "proxmox.pool", map[string]*llx.RawData{
+		"id": llx.StringData(id),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlProxmoxPool), nil
+}
+
 func (r *mqlProxmoxContainer) networks() ([]any, error) {
 	r.ensureConfig()
 	if r.configErr != nil {

--- a/providers/proxmox/resources/node.go
+++ b/providers/proxmox/resources/node.go
@@ -177,7 +177,6 @@ func (r *mqlProxmoxNode) secureBoot() (bool, error) {
 	return r.nodeStatus.BootInfo.SecureBoot == 1, nil
 }
 
-
 func (r *mqlProxmoxNode) networks() ([]any, error) {
 	conn := nodeConn(r)
 	ifaces, err := conn.GetNodeNetworks(r.Name.Data)

--- a/providers/proxmox/resources/node.go
+++ b/providers/proxmox/resources/node.go
@@ -177,16 +177,6 @@ func (r *mqlProxmoxNode) secureBoot() (bool, error) {
 	return r.nodeStatus.BootInfo.SecureBoot == 1, nil
 }
 
-func (r *mqlProxmoxCertificate) daysUntilExpiry() (int64, error) {
-	if r.NotAfter.Data == nil {
-		return 0, nil
-	}
-	// Integer-truncate toward zero so "5 hours from expiry" reports 0
-	// rather than 1 — the policy intent for `< 30 days` then triggers
-	// only when there's actually less than that left.
-	delta := r.NotAfter.Data.Sub(time.Now())
-	return int64(delta / (24 * time.Hour)), nil
-}
 
 func (r *mqlProxmoxNode) networks() ([]any, error) {
 	conn := nodeConn(r)

--- a/providers/proxmox/resources/node.go
+++ b/providers/proxmox/resources/node.go
@@ -137,6 +137,57 @@ func (r *mqlProxmoxNode) uptime() (int64, error) {
 	return r.nodeStatus.Uptime, nil
 }
 
+func (r *mqlProxmoxNode) cpuFlags() (string, error) {
+	r.ensureStatus()
+	if r.statusErr != nil {
+		return "", r.statusErr
+	}
+	return r.nodeStatus.CPUInfo.Flags, nil
+}
+
+func (r *mqlProxmoxNode) bootKernel() (string, error) {
+	r.ensureStatus()
+	if r.statusErr != nil {
+		return "", r.statusErr
+	}
+	return r.nodeStatus.BootInfo.BootKernel, nil
+}
+
+// pendingReboot returns true only when both kernels are known and
+// they disagree — older PVE versions don't populate boot-info at all
+// and we don't want them to false-positive every node.
+func (r *mqlProxmoxNode) pendingReboot() (bool, error) {
+	r.ensureStatus()
+	if r.statusErr != nil {
+		return false, r.statusErr
+	}
+	cur := r.nodeStatus.BootInfo.CurrentKernel
+	boot := r.nodeStatus.BootInfo.BootKernel
+	if cur == "" || boot == "" {
+		return false, nil
+	}
+	return cur != boot, nil
+}
+
+func (r *mqlProxmoxNode) secureBoot() (bool, error) {
+	r.ensureStatus()
+	if r.statusErr != nil {
+		return false, r.statusErr
+	}
+	return r.nodeStatus.BootInfo.SecureBoot == 1, nil
+}
+
+func (r *mqlProxmoxCertificate) daysUntilExpiry() (int64, error) {
+	if r.NotAfter.Data == nil {
+		return 0, nil
+	}
+	// Integer-truncate toward zero so "5 hours from expiry" reports 0
+	// rather than 1 — the policy intent for `< 30 days` then triggers
+	// only when there's actually less than that left.
+	delta := r.NotAfter.Data.Sub(time.Now())
+	return int64(delta / (24 * time.Hour)), nil
+}
+
 func (r *mqlProxmoxNode) networks() ([]any, error) {
 	conn := nodeConn(r)
 	ifaces, err := conn.GetNodeNetworks(r.Name.Data)
@@ -309,6 +360,15 @@ func (r *mqlProxmoxNode) repositories() ([]any, error) {
 			for _, c := range repo.Components {
 				components = append(components, c)
 			}
+			// Signed-By is one of several deb822 options the API returns
+			// as a {Key, Values} list; pull the first matching entry.
+			var signedBy string
+			for _, opt := range repo.Options {
+				if opt.Key == "Signed-By" && len(opt.Values) > 0 {
+					signedBy = opt.Values[0]
+					break
+				}
+			}
 			res, err := CreateResource(r.MqlRuntime, "proxmox.repository", map[string]*llx.RawData{
 				"__id":       llx.StringData("proxmox.repository/" + r.Name.Data + "/" + repoID),
 				"id":         llx.StringData(repoID),
@@ -319,6 +379,7 @@ func (r *mqlProxmoxNode) repositories() ([]any, error) {
 				"suites":     llx.ArrayData(suites, "\x02"),
 				"components": llx.ArrayData(components, "\x02"),
 				"fileType":   llx.StringData(file.FileType),
+				"signedBy":   llx.StringData(signedBy),
 			})
 			if err != nil {
 				return nil, err

--- a/providers/proxmox/resources/node_polish_test.go
+++ b/providers/proxmox/resources/node_polish_test.go
@@ -1,0 +1,41 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+)
+
+// daysUntil mirrors the math used by mqlProxmoxCertificate.daysUntilExpiry.
+// Pinning it here pins the rounding direction without binding the test
+// to the wall clock.
+func daysUntil(t time.Time, now time.Time) int64 {
+	return int64(t.Sub(now) / (24 * time.Hour))
+}
+
+func TestCertificateDaysUntilExpiryRounding(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name     string
+		notAfter time.Time
+		want     int64
+	}{
+		{"exactly-30-days", now.Add(30 * 24 * time.Hour), 30},
+		{"29-days-23-hours", now.Add(29*24*time.Hour + 23*time.Hour), 29},
+		{"29-days-25-hours", now.Add(29*24*time.Hour + 25*time.Hour), 30},
+		{"5-hours-from-expiry-rounds-to-zero", now.Add(5 * time.Hour), 0},
+		{"already-expired", now.Add(-72 * time.Hour), -3},
+		{"expired-by-an-hour", now.Add(-1 * time.Hour), 0},
+		{"expired-by-25-hours", now.Add(-25 * time.Hour), -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := daysUntil(tt.notAfter, now)
+			if got != tt.want {
+				t.Errorf("daysUntil(%v) = %d, want %d", tt.notAfter, got, tt.want)
+			}
+		})
+	}
+}

--- a/providers/proxmox/resources/proxmox.lr
+++ b/providers/proxmox/resources/proxmox.lr
@@ -165,6 +165,13 @@ proxmox.node @defaults("name status") {
   cpuCores int
   // Current CPU usage (fraction 0.0-1.0)
   cpuUsage float
+  // CPU feature flags reported by /proc/cpuinfo
+  //
+  // Space-separated when set, empty on older PVE versions that don't
+  // expose `cpuinfo.flags`. Use a `cpuFlags.contains(...)` query to
+  // detect microcode/vulnerability mitigations like `ibpb`, `ssbd`,
+  // `md_clear`, `pti`, etc.
+  cpuFlags() string
   // Total memory in bytes
   memTotal int
   // Used memory in bytes
@@ -184,6 +191,19 @@ proxmox.node @defaults("name status") {
   pveVersion string
   // Uptime in seconds
   uptime int
+  // Kernel image that would boot on next reboot
+  //
+  // When this differs from `kernelVersion` a kernel package has been
+  // installed but the host hasn't been rebooted to pick it up. Empty
+  // on older PVE versions that don't report `boot-info`.
+  bootKernel() string
+  // Whether a kernel upgrade is pending a reboot
+  //
+  // True when `kernelVersion` and `bootKernel` disagree. False when
+  // either value is empty so older PVE versions don't false-positive.
+  pendingReboot() bool
+  // UEFI Secure Boot status — true when enforcing, false when disabled or on BIOS-only platforms
+  secureBoot() bool
 
   // --- Network ---
 
@@ -340,6 +360,8 @@ proxmox.vm @defaults("id name status") {
   description() string
   // Tags assigned to the VM
   tags() []string
+  // Resource pool this VM belongs to; null when unassigned
+  pool() proxmox.pool
   // Acquired lock blocking other operations
   //
   // One of `backup`, `migrate`, `snapshot`, `rollback`, `clone`,
@@ -652,6 +674,13 @@ proxmox.certificate @defaults("subject notAfter") {
   san []string
   // Certificate subject
   subject string
+  // Days remaining until `notAfter`
+  //
+  // Computed as `notAfter` minus the time the value is read. Negative
+  // when the certificate has already expired, which makes
+  // `daysUntilExpiry < 30` / `< 0` a natural way to write expiry
+  // policies.
+  daysUntilExpiry() int
 }
 
 // Proxmox VE subscription
@@ -703,6 +732,12 @@ proxmox.repository @defaults("name enabled") {
   components []string
   // File type (sources.list, sources.list.d)
   fileType string
+  // Path to the keyring used to verify repository signatures
+  //
+  // Reads the `Signed-By` option on deb822-format entries (`.sources`).
+  // Empty when the entry doesn't declare one — older `.list` entries
+  // typically don't, and instead inherit the system trust store.
+  signedBy string
 }
 
 // Proxmox VE firewall rule
@@ -1054,6 +1089,8 @@ proxmox.container @defaults("id name status unprivileged") {
   description() string
   // Tags assigned to the container
   tags() []string
+  // Resource pool this container belongs to; null when unassigned
+  pool() proxmox.pool
   // Console mode
   //
   // One of `tty` (per-tty consoles, default), `console` (single
@@ -1214,6 +1251,15 @@ proxmox.backup.job @defaults("id schedule storage enabled") {
   nextRun int
   // Resolved target storage pool
   targetStorage() proxmox.storage
+  // VMs this job targets
+  //
+  // Resolved from `vmids` and `all` against the current cluster
+  // inventory. When `all` is true this returns every VM and `vmids`
+  // is ignored. Pool-scoped jobs (`pool` set, `vmids` empty) return
+  // an empty list — query `pool` for those instead.
+  targetVms() []proxmox.vm
+  // Containers this job targets, resolved the same way as `targetVms`
+  targetContainers() []proxmox.container
   // Full raw job configuration as returned by /cluster/backup/<id>
   config() dict
 }

--- a/providers/proxmox/resources/proxmox.lr
+++ b/providers/proxmox/resources/proxmox.lr
@@ -734,8 +734,8 @@ proxmox.repository @defaults("name enabled") {
   fileType string
   // Path to the keyring used to verify repository signatures
   //
-  // Reads the `Signed-By` option on deb822-format entries (`.sources`).
-  // Empty when the entry doesn't declare one — older `.list` entries
+  // Reads the `Signed-By` option from modern `.sources` entries. Empty
+  // when the entry doesn't declare one — older `.list` entries
   // typically don't, and instead inherit the system trust store.
   signedBy string
 }

--- a/providers/proxmox/resources/proxmox.lr.go
+++ b/providers/proxmox/resources/proxmox.lr.go
@@ -460,6 +460,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"proxmox.node.cpuUsage": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxNode).GetCpuUsage()).ToDataRes(types.Float)
 	},
+	"proxmox.node.cpuFlags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxNode).GetCpuFlags()).ToDataRes(types.String)
+	},
 	"proxmox.node.memTotal": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxNode).GetMemTotal()).ToDataRes(types.Int)
 	},
@@ -483,6 +486,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"proxmox.node.uptime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxNode).GetUptime()).ToDataRes(types.Int)
+	},
+	"proxmox.node.bootKernel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxNode).GetBootKernel()).ToDataRes(types.String)
+	},
+	"proxmox.node.pendingReboot": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxNode).GetPendingReboot()).ToDataRes(types.Bool)
+	},
+	"proxmox.node.secureBoot": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxNode).GetSecureBoot()).ToDataRes(types.Bool)
 	},
 	"proxmox.node.networks": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxNode).GetNetworks()).ToDataRes(types.Array(types.Resource("proxmox.network")))
@@ -621,6 +633,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"proxmox.vm.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxVm).GetTags()).ToDataRes(types.Array(types.String))
+	},
+	"proxmox.vm.pool": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxVm).GetPool()).ToDataRes(types.Resource("proxmox.pool"))
 	},
 	"proxmox.vm.lock": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxVm).GetLock()).ToDataRes(types.String)
@@ -877,6 +892,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"proxmox.certificate.subject": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxCertificate).GetSubject()).ToDataRes(types.String)
 	},
+	"proxmox.certificate.daysUntilExpiry": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxCertificate).GetDaysUntilExpiry()).ToDataRes(types.Int)
+	},
 	"proxmox.subscription.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxSubscription).GetStatus()).ToDataRes(types.String)
 	},
@@ -921,6 +939,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"proxmox.repository.fileType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxRepository).GetFileType()).ToDataRes(types.String)
+	},
+	"proxmox.repository.signedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxRepository).GetSignedBy()).ToDataRes(types.String)
 	},
 	"proxmox.firewall.rule.pos": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxFirewallRule).GetPos()).ToDataRes(types.Int)
@@ -1228,6 +1249,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"proxmox.container.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxContainer).GetTags()).ToDataRes(types.Array(types.String))
 	},
+	"proxmox.container.pool": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxContainer).GetPool()).ToDataRes(types.Resource("proxmox.pool"))
+	},
 	"proxmox.container.cmode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxContainer).GetCmode()).ToDataRes(types.String)
 	},
@@ -1386,6 +1410,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"proxmox.backup.job.targetStorage": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxBackupJob).GetTargetStorage()).ToDataRes(types.Resource("proxmox.storage"))
+	},
+	"proxmox.backup.job.targetVms": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxBackupJob).GetTargetVms()).ToDataRes(types.Array(types.Resource("proxmox.vm")))
+	},
+	"proxmox.backup.job.targetContainers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxBackupJob).GetTargetContainers()).ToDataRes(types.Array(types.Resource("proxmox.container")))
 	},
 	"proxmox.backup.job.config": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxBackupJob).GetConfig()).ToDataRes(types.Dict)
@@ -1866,6 +1896,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlProxmoxNode).CpuUsage, ok = plugin.RawToTValue[float64](v.Value, v.Error)
 		return
 	},
+	"proxmox.node.cpuFlags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxNode).CpuFlags, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"proxmox.node.memTotal": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlProxmoxNode).MemTotal, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
@@ -1896,6 +1930,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"proxmox.node.uptime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlProxmoxNode).Uptime, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"proxmox.node.bootKernel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxNode).BootKernel, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"proxmox.node.pendingReboot": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxNode).PendingReboot, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"proxmox.node.secureBoot": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxNode).SecureBoot, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"proxmox.node.networks": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2088,6 +2134,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"proxmox.vm.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlProxmoxVm).Tags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"proxmox.vm.pool": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxVm).Pool, ok = plugin.RawToTValue[*mqlProxmoxPool](v.Value, v.Error)
 		return
 	},
 	"proxmox.vm.lock": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2470,6 +2520,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlProxmoxCertificate).Subject, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"proxmox.certificate.daysUntilExpiry": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxCertificate).DaysUntilExpiry, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
 	"proxmox.subscription.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlProxmoxSubscription).__id, ok = v.Value.(string)
 		return
@@ -2536,6 +2590,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"proxmox.repository.fileType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlProxmoxRepository).FileType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"proxmox.repository.signedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxRepository).SignedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"proxmox.firewall.rule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2994,6 +3052,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlProxmoxContainer).Tags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"proxmox.container.pool": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxContainer).Pool, ok = plugin.RawToTValue[*mqlProxmoxPool](v.Value, v.Error)
+		return
+	},
 	"proxmox.container.cmode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlProxmoxContainer).Cmode, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -3216,6 +3278,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"proxmox.backup.job.targetStorage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlProxmoxBackupJob).TargetStorage, ok = plugin.RawToTValue[*mqlProxmoxStorage](v.Value, v.Error)
+		return
+	},
+	"proxmox.backup.job.targetVms": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxBackupJob).TargetVms, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"proxmox.backup.job.targetContainers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxBackupJob).TargetContainers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"proxmox.backup.job.config": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4280,6 +4350,7 @@ type mqlProxmoxNode struct {
 	CpuSockets      plugin.TValue[int64]
 	CpuCores        plugin.TValue[int64]
 	CpuUsage        plugin.TValue[float64]
+	CpuFlags        plugin.TValue[string]
 	MemTotal        plugin.TValue[int64]
 	MemUsed         plugin.TValue[int64]
 	MemFree         plugin.TValue[int64]
@@ -4288,6 +4359,9 @@ type mqlProxmoxNode struct {
 	KernelVersion   plugin.TValue[string]
 	PveVersion      plugin.TValue[string]
 	Uptime          plugin.TValue[int64]
+	BootKernel      plugin.TValue[string]
+	PendingReboot   plugin.TValue[bool]
+	SecureBoot      plugin.TValue[bool]
 	Networks        plugin.TValue[[]any]
 	Dns             plugin.TValue[*mqlProxmoxDns]
 	Services        plugin.TValue[[]any]
@@ -4372,6 +4446,12 @@ func (c *mqlProxmoxNode) GetCpuUsage() *plugin.TValue[float64] {
 	return &c.CpuUsage
 }
 
+func (c *mqlProxmoxNode) GetCpuFlags() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.CpuFlags, func() (string, error) {
+		return c.cpuFlags()
+	})
+}
+
 func (c *mqlProxmoxNode) GetMemTotal() *plugin.TValue[int64] {
 	return &c.MemTotal
 }
@@ -4402,6 +4482,24 @@ func (c *mqlProxmoxNode) GetPveVersion() *plugin.TValue[string] {
 
 func (c *mqlProxmoxNode) GetUptime() *plugin.TValue[int64] {
 	return &c.Uptime
+}
+
+func (c *mqlProxmoxNode) GetBootKernel() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.BootKernel, func() (string, error) {
+		return c.bootKernel()
+	})
+}
+
+func (c *mqlProxmoxNode) GetPendingReboot() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.PendingReboot, func() (bool, error) {
+		return c.pendingReboot()
+	})
+}
+
+func (c *mqlProxmoxNode) GetSecureBoot() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.SecureBoot, func() (bool, error) {
+		return c.secureBoot()
+	})
 }
 
 func (c *mqlProxmoxNode) GetNetworks() *plugin.TValue[[]any] {
@@ -4753,6 +4851,7 @@ type mqlProxmoxVm struct {
 	Protection      plugin.TValue[bool]
 	Description     plugin.TValue[string]
 	Tags            plugin.TValue[[]any]
+	Pool            plugin.TValue[*mqlProxmoxPool]
 	Lock            plugin.TValue[string]
 	Hookscript      plugin.TValue[string]
 	Args            plugin.TValue[string]
@@ -4926,6 +5025,22 @@ func (c *mqlProxmoxVm) GetDescription() *plugin.TValue[string] {
 func (c *mqlProxmoxVm) GetTags() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Tags, func() ([]any, error) {
 		return c.tags()
+	})
+}
+
+func (c *mqlProxmoxVm) GetPool() *plugin.TValue[*mqlProxmoxPool] {
+	return plugin.GetOrCompute[*mqlProxmoxPool](&c.Pool, func() (*mqlProxmoxPool, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("proxmox.vm", c.__id, "pool")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlProxmoxPool), nil
+			}
+		}
+
+		return c.pool()
 	})
 }
 
@@ -5796,15 +5911,16 @@ type mqlProxmoxCertificate struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlProxmoxCertificateInternal it will be used here
-	Filename      plugin.TValue[string]
-	Fingerprint   plugin.TValue[string]
-	Issuer        plugin.TValue[string]
-	NotAfter      plugin.TValue[*time.Time]
-	NotBefore     plugin.TValue[*time.Time]
-	PublicKeyBits plugin.TValue[int64]
-	PublicKeyType plugin.TValue[string]
-	San           plugin.TValue[[]any]
-	Subject       plugin.TValue[string]
+	Filename        plugin.TValue[string]
+	Fingerprint     plugin.TValue[string]
+	Issuer          plugin.TValue[string]
+	NotAfter        plugin.TValue[*time.Time]
+	NotBefore       plugin.TValue[*time.Time]
+	PublicKeyBits   plugin.TValue[int64]
+	PublicKeyType   plugin.TValue[string]
+	San             plugin.TValue[[]any]
+	Subject         plugin.TValue[string]
+	DaysUntilExpiry plugin.TValue[int64]
 }
 
 // createProxmoxCertificate creates a new instance of this resource
@@ -5873,6 +5989,12 @@ func (c *mqlProxmoxCertificate) GetSan() *plugin.TValue[[]any] {
 
 func (c *mqlProxmoxCertificate) GetSubject() *plugin.TValue[string] {
 	return &c.Subject
+}
+
+func (c *mqlProxmoxCertificate) GetDaysUntilExpiry() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.DaysUntilExpiry, func() (int64, error) {
+		return c.daysUntilExpiry()
+	})
 }
 
 // mqlProxmoxSubscription for the proxmox.subscription resource
@@ -5962,6 +6084,7 @@ type mqlProxmoxRepository struct {
 	Suites     plugin.TValue[[]any]
 	Components plugin.TValue[[]any]
 	FileType   plugin.TValue[string]
+	SignedBy   plugin.TValue[string]
 }
 
 // createProxmoxRepository creates a new instance of this resource
@@ -6026,6 +6149,10 @@ func (c *mqlProxmoxRepository) GetComponents() *plugin.TValue[[]any] {
 
 func (c *mqlProxmoxRepository) GetFileType() *plugin.TValue[string] {
 	return &c.FileType
+}
+
+func (c *mqlProxmoxRepository) GetSignedBy() *plugin.TValue[string] {
+	return &c.SignedBy
 }
 
 // mqlProxmoxFirewallRule for the proxmox.firewall.rule resource
@@ -7019,6 +7146,7 @@ type mqlProxmoxContainer struct {
 	Onboot          plugin.TValue[bool]
 	Description     plugin.TValue[string]
 	Tags            plugin.TValue[[]any]
+	Pool            plugin.TValue[*mqlProxmoxPool]
 	Cmode           plugin.TValue[string]
 	Swap            plugin.TValue[int64]
 	CpuLimit        plugin.TValue[float64]
@@ -7187,6 +7315,22 @@ func (c *mqlProxmoxContainer) GetDescription() *plugin.TValue[string] {
 func (c *mqlProxmoxContainer) GetTags() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Tags, func() ([]any, error) {
 		return c.tags()
+	})
+}
+
+func (c *mqlProxmoxContainer) GetPool() *plugin.TValue[*mqlProxmoxPool] {
+	return plugin.GetOrCompute[*mqlProxmoxPool](&c.Pool, func() (*mqlProxmoxPool, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("proxmox.container", c.__id, "pool")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlProxmoxPool), nil
+			}
+		}
+
+		return c.pool()
 	})
 }
 
@@ -7554,6 +7698,8 @@ type mqlProxmoxBackupJob struct {
 	Protected        plugin.TValue[bool]
 	NextRun          plugin.TValue[int64]
 	TargetStorage    plugin.TValue[*mqlProxmoxStorage]
+	TargetVms        plugin.TValue[[]any]
+	TargetContainers plugin.TValue[[]any]
 	Config           plugin.TValue[any]
 }
 
@@ -7683,6 +7829,38 @@ func (c *mqlProxmoxBackupJob) GetTargetStorage() *plugin.TValue[*mqlProxmoxStora
 		}
 
 		return c.targetStorage()
+	})
+}
+
+func (c *mqlProxmoxBackupJob) GetTargetVms() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.TargetVms, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("proxmox.backup.job", c.__id, "targetVms")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.targetVms()
+	})
+}
+
+func (c *mqlProxmoxBackupJob) GetTargetContainers() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.TargetContainers, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("proxmox.backup.job", c.__id, "targetContainers")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.targetContainers()
 	})
 }
 

--- a/providers/proxmox/resources/proxmox.lr.versions
+++ b/providers/proxmox/resources/proxmox.lr.versions
@@ -33,10 +33,13 @@ proxmox.backup.job.protected 0.1.9
 proxmox.backup.job.prune 0.1.9
 proxmox.backup.job.schedule 0.1.9
 proxmox.backup.job.storage 0.1.9
+proxmox.backup.job.targetContainers 0.1.9
 proxmox.backup.job.targetStorage 0.1.9
+proxmox.backup.job.targetVms 0.1.9
 proxmox.backup.job.vmids 0.1.9
 proxmox.backupJobs 0.1.9
 proxmox.certificate 0.1.1
+proxmox.certificate.daysUntilExpiry 0.1.9
 proxmox.certificate.filename 0.1.1
 proxmox.certificate.fingerprint 0.1.1
 proxmox.certificate.issuer 0.1.1
@@ -131,6 +134,7 @@ proxmox.container.networks 0.1.9
 proxmox.container.node 0.1.9
 proxmox.container.onboot 0.1.9
 proxmox.container.osType 0.1.9
+proxmox.container.pool 0.1.9
 proxmox.container.protection 0.1.9
 proxmox.container.rawLxc 0.1.9
 proxmox.container.searchDomain 0.1.9
@@ -220,9 +224,11 @@ proxmox.network.method 0.1.1
 proxmox.network.netmask 0.1.1
 proxmox.network.type 0.1.1
 proxmox.node 0.1.1
+proxmox.node.bootKernel 0.1.9
 proxmox.node.certificates 0.1.1
 proxmox.node.containers 0.1.9
 proxmox.node.cpuCores 0.1.1
+proxmox.node.cpuFlags 0.1.9
 proxmox.node.cpuModel 0.1.1
 proxmox.node.cpuSockets 0.1.1
 proxmox.node.cpuUsage 0.1.1
@@ -255,8 +261,10 @@ proxmox.node.memTotal 0.1.1
 proxmox.node.memUsed 0.1.1
 proxmox.node.name 0.1.1
 proxmox.node.networks 0.1.1
+proxmox.node.pendingReboot 0.1.9
 proxmox.node.pveVersion 0.1.1
 proxmox.node.repositories 0.1.1
+proxmox.node.secureBoot 0.1.9
 proxmox.node.services 0.1.1
 proxmox.node.status 0.1.1
 proxmox.node.storages 0.1.1
@@ -310,6 +318,7 @@ proxmox.repository.enabled 0.1.1
 proxmox.repository.fileType 0.1.1
 proxmox.repository.id 0.1.1
 proxmox.repository.name 0.1.1
+proxmox.repository.signedBy 0.1.9
 proxmox.repository.suites 0.1.1
 proxmox.repository.types 0.1.1
 proxmox.repository.uris 0.1.1
@@ -445,6 +454,7 @@ proxmox.vm.network.tag 0.1.1
 proxmox.vm.networks 0.1.1
 proxmox.vm.node 0.1.1
 proxmox.vm.osType 0.1.1
+proxmox.vm.pool 0.1.9
 proxmox.vm.protection 0.1.1
 proxmox.vm.searchDomain 0.1.9
 proxmox.vm.serialPort 0.1.9

--- a/providers/proxmox/resources/vm.go
+++ b/providers/proxmox/resources/vm.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/proxmox/connection"
 )
 
@@ -196,6 +197,21 @@ func (r *mqlProxmoxVm) tags() ([]any, error) {
 		result[i] = p
 	}
 	return result, nil
+}
+
+func (r *mqlProxmoxVm) pool() (*mqlProxmoxPool, error) {
+	id := r.cfgStr("pool")
+	if id == "" {
+		r.Pool.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(r.MqlRuntime, "proxmox.pool", map[string]*llx.RawData{
+		"id": llx.StringData(id),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlProxmoxPool), nil
 }
 
 func (r *mqlProxmoxVm) networks() ([]any, error) {


### PR DESCRIPTION
## Summary

Five small additions across several existing resources — each closes a specific audit gap that wasn't worth its own PR.

- **`proxmox.certificate.daysUntilExpiry`** — integer days from `notAfter`, integer-truncated toward zero so a cert with 5 hours left reports `0` (not `1`). Negative when already expired, so `< 30` and `< 0` both work for expiry policies.
- **`proxmox.repository.signedBy`** — surfaces the `Signed-By` keyring path from the deb822 options array. Lets audits distinguish enterprise-keyring vs no-subscription-keyring repos at a glance.
- **`proxmox.node.cpuFlags` / `bootKernel` / `pendingReboot` / `secureBoot`** — pulled from `/nodes/<n>/status`. `pendingReboot` is true only when both `current-kernel` and `boot-kernel` are reported and disagree, so older PVE versions don't false-positive every node.
- **`proxmox.vm.pool` / `proxmox.container.pool`** — typed `proxmox.pool` reference from the guest's `pool` config key. Null when unassigned.
- **`proxmox.backup.job.targetVms` / `targetContainers`** — resolves the comma-separated `vmids` (or `all`) against the current cluster inventory and returns typed lists. Pool-scoped jobs return empty — query `pool` for those.

`.lr.versions` entries land at `0.1.9` (next patch after the provider's current `0.1.8`).

## Tests

- `TestParseBackupVMIDs` — single VMID, comma list, whitespace tolerance, `all`, non-numeric and range tokens skipped, mixed input, trailing comma
- `TestCertificateDaysUntilExpiryRounding` — pins the integer-toward-zero rounding direction across the boundary cases (exactly 30 days, 29d23h, 29d25h, 5h from expiry, already expired)

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./...` passes
- [x] `make providers/build/proxmox` produces `dist/proxmox`
- [ ] Interactive smoke against a live Proxmox cluster:
  - `mql shell proxmox -c "proxmox.nodes { certificates.where(daysUntilExpiry < 30) }"`
  - `mql shell proxmox -c "proxmox.nodes { repositories { name signedBy enabled } }"`
  - `mql shell proxmox -c "proxmox.nodes { name kernelVersion bootKernel pendingReboot secureBoot }"`
  - `mql shell proxmox -c "proxmox.vms { id name pool.id }"`
  - `mql shell proxmox -c "proxmox.backupJobs { id targetVms.length targetContainers.length }"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)