### PR TITLE
🐛 proxmox: fix bugs surfaced by the audit pass

### DIFF
--- a/providers/proxmox/connection/api_test.go
+++ b/providers/proxmox/connection/api_test.go
@@ -155,6 +155,56 @@ func TestGetNodeContainers_MalformedVMIDErrors(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// GetNodeVMs — symmetric per-node fetch. Regression test against the
+// N+1 GetNodeVMs behavior (which used to hit /cluster/resources and
+// filter in memory).
+// ---------------------------------------------------------------------------
+
+func TestGetNodeVMs_HitsPerNodeEndpoint(t *testing.T) {
+	f := newFakePVE(t)
+	// Crucially, /cluster/resources is NOT registered. If GetNodeVMs ever
+	// regresses back to using GetAllVMs internally the test fails with a
+	// 404 instead of silently passing on a stale endpoint.
+	f.route("/nodes/pve1/qemu", []map[string]any{
+		{"vmid": "100", "name": "web", "status": "running", "maxmem": 2_000_000_000},
+		{"vmid": "201", "name": "db", "status": "stopped"},
+	})
+
+	vms, err := f.conn().GetNodeVMs("pve1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vms) != 2 {
+		t.Fatalf("expected 2 VMs, got %d", len(vms))
+	}
+	if vms[0].VMID != 100 || vms[0].Name != "web" || vms[0].Node != "pve1" {
+		t.Errorf("vm[0] = %+v, want VMID=100 Name=web Node=pve1", vms[0])
+	}
+	if vms[1].VMID != 201 {
+		t.Errorf("vm[1].VMID = %d, want 201", vms[1].VMID)
+	}
+	if vms[0].Type != "qemu" {
+		t.Errorf("vm[0].Type = %q, want qemu (filled in by helper)", vms[0].Type)
+	}
+}
+
+func TestGetNodeVMs_MalformedVMIDErrors(t *testing.T) {
+	f := newFakePVE(t)
+	f.route("/nodes/pve1/qemu", []map[string]any{
+		{"vmid": "garbage", "name": "broken"},
+	})
+
+	_, err := f.conn().GetNodeVMs("pve1")
+	if err == nil {
+		t.Fatal("expected an error for a non-numeric VMID; got nil")
+	}
+	msg := err.Error()
+	if !contains(msg, `"garbage"`) || !contains(msg, "pve1") {
+		t.Errorf("error %q should mention the bad VMID and node name", msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // GetClusterFirewallOptions — dict semantics for the typed-options layer
 // ---------------------------------------------------------------------------
 

--- a/providers/proxmox/connection/guest_agent.go
+++ b/providers/proxmox/connection/guest_agent.go
@@ -135,8 +135,11 @@ func (c *PveConnection) getAptUpdates(node string, vmid int) ([]UpdateInfo, erro
 }
 
 func (c *PveConnection) getDnfUpdates(node string, vmid int) ([]UpdateInfo, error) {
+	// `dnf check-update` exits 100 when updates are available, but
+	// QGAExec carries the exit code on the result struct rather than
+	// returning a Go error — so any non-nil err is a real failure.
 	result, err := c.QGAExec(node, vmid, []string{"dnf", "check-update", "--quiet"})
-	if err != nil && result == nil {
+	if err != nil {
 		return nil, fmt.Errorf("dnf check-update failed: %w", err)
 	}
 	return ParseDnfOutput(result.Stdout), nil

--- a/providers/proxmox/connection/vm.go
+++ b/providers/proxmox/connection/vm.go
@@ -3,7 +3,11 @@
 
 package connection
 
-import "fmt"
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+)
 
 // ---------------------------------------------------------------------------
 // VM listing
@@ -44,19 +48,65 @@ func (c *PveConnection) GetAllVMs() ([]VMInfo, error) {
 	return vms, nil
 }
 
-// GetNodeVMs returns VMs on a specific node.
+// nodeQemuEntry mirrors a /nodes/<node>/qemu row. VMIDs come back as
+// strings on this endpoint (unlike /cluster/resources, which uses
+// ints), so we unmarshal into an intermediate type and convert.
+type nodeQemuEntry struct {
+	VMID      string  `json:"vmid"`
+	Name      string  `json:"name"`
+	Status    string  `json:"status"`
+	CPU       float64 `json:"cpu"`
+	MaxCPU    int     `json:"cpus"`
+	Mem       int64   `json:"mem"`
+	MaxMem    int64   `json:"maxmem"`
+	Disk      int64   `json:"disk"`
+	MaxDisk   int64   `json:"maxdisk"`
+	DiskRead  int64   `json:"diskread"`
+	DiskWrite int64   `json:"diskwrite"`
+	NetIn     int64   `json:"netin"`
+	NetOut    int64   `json:"netout"`
+	Uptime    int64   `json:"uptime"`
+	Template  int     `json:"template"`
+	Tags      string  `json:"tags"`
+}
+
+// GetNodeVMs hits the per-node /nodes/<node>/qemu endpoint directly so
+// `proxmox.nodes { vms }` doesn't fan out into one full
+// cluster-resources fetch per node.
 func (c *PveConnection) GetNodeVMs(node string) ([]VMInfo, error) {
-	allVMs, err := c.GetAllVMs()
-	if err != nil {
-		return nil, err
+	var entries []nodeQemuEntry
+	path := fmt.Sprintf("/nodes/%s/qemu", url.PathEscape(node))
+	if err := c.apiGet(path, &entries); err != nil {
+		return nil, fmt.Errorf("failed to list VMs on node %s: %w", node, err)
 	}
-	var vms []VMInfo
-	for _, vm := range allVMs {
-		if vm.Node == node {
-			vms = append(vms, vm)
+	out := make([]VMInfo, 0, len(entries))
+	for _, e := range entries {
+		vmid, err := strconv.Atoi(e.VMID)
+		if err != nil {
+			return nil, fmt.Errorf("invalid VMID %q on node %s: %w", e.VMID, node, err)
 		}
+		out = append(out, VMInfo{
+			VMID:      vmid,
+			Name:      e.Name,
+			Node:      node,
+			Status:    e.Status,
+			Type:      "qemu",
+			CPU:       e.CPU,
+			MaxCPU:    e.MaxCPU,
+			Mem:       e.Mem,
+			MaxMem:    e.MaxMem,
+			Disk:      e.Disk,
+			MaxDisk:   e.MaxDisk,
+			DiskRead:  e.DiskRead,
+			DiskWrite: e.DiskWrite,
+			NetIn:     e.NetIn,
+			NetOut:    e.NetOut,
+			Uptime:    e.Uptime,
+			Template:  e.Template,
+			Tags:      e.Tags,
+		})
 	}
-	return vms, nil
+	return out, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/providers/proxmox/resources/access.go
+++ b/providers/proxmox/resources/access.go
@@ -12,6 +12,14 @@ import (
 	"go.mondoo.com/mql/v13/providers/proxmox/connection"
 )
 
+// mqlProxmoxUserInternal caches the inline token list from
+// /access/users?full=1 so `proxmox.users { tokens }` doesn't fan out
+// into a per-user /access/users/<id>/token fetch (N+1).
+type mqlProxmoxUserInternal struct {
+	cachedTokens    []any
+	cachedTokensSet bool
+}
+
 // ---------------------------------------------------------------------------
 // Groups
 // ---------------------------------------------------------------------------
@@ -158,10 +166,9 @@ func (r *mqlProxmoxAcl) token() (*mqlProxmoxToken, error) {
 // ---------------------------------------------------------------------------
 
 type mqlProxmoxRealmInternal struct {
-	configFetched bool
-	cfg           map[string]any
-	cfgErr        error
-	lock          sync.Mutex
+	configOnce sync.Once
+	cfg        map[string]any
+	cfgErr     error
 }
 
 func (r *mqlProxmox) realms() ([]any, error) {
@@ -207,17 +214,10 @@ func (r *mqlProxmoxRealm) id() (string, error) {
 }
 
 func (r *mqlProxmoxRealm) config() (any, error) {
-	if r.configFetched {
-		return r.cfg, r.cfgErr
-	}
-	r.lock.Lock()
-	defer r.lock.Unlock()
-	if r.configFetched {
-		return r.cfg, r.cfgErr
-	}
-	conn := r.MqlRuntime.Connection.(*connection.PveConnection)
-	r.cfg, r.cfgErr = conn.GetRealmConfig(r.Realm.Data)
-	r.configFetched = true
+	r.configOnce.Do(func() {
+		conn := r.MqlRuntime.Connection.(*connection.PveConnection)
+		r.cfg, r.cfgErr = conn.GetRealmConfig(r.Realm.Data)
+	})
 	return r.cfg, r.cfgErr
 }
 

--- a/providers/proxmox/resources/backup.go
+++ b/providers/proxmox/resources/backup.go
@@ -14,19 +14,17 @@ import (
 )
 
 type mqlProxmoxBackupJobInternal struct {
-	configFetched bool
-	cfg           map[string]any
-	cfgErr        error
-	lock          sync.Mutex
+	configOnce sync.Once
+	cfg        map[string]any
+	cfgErr     error
 
 	// Target resolution hits /cluster/resources for both VMs and
 	// containers; cache the result so a query that reads both
 	// targetVms and targetContainers only pays the cost once.
-	targetsFetched bool
-	cachedVms      []any
-	cachedCts      []any
-	targetsErr     error
-	targetsLock    sync.Mutex
+	targetsOnce sync.Once
+	cachedVms   []any
+	cachedCts   []any
+	targetsErr  error
 }
 
 func (r *mqlProxmox) backupJobs() ([]any, error) {
@@ -115,16 +113,9 @@ func parseBackupVMIDs(raw string) []int64 {
 // non-empty `vmids` list selects only the matching guests. Results
 // are cached on the resource so the two accessors share one fetch.
 func (r *mqlProxmoxBackupJob) resolveBackupTargets() (vms, containers []any, err error) {
-	if r.targetsFetched {
-		return r.cachedVms, r.cachedCts, r.targetsErr
-	}
-	r.targetsLock.Lock()
-	defer r.targetsLock.Unlock()
-	if r.targetsFetched {
-		return r.cachedVms, r.cachedCts, r.targetsErr
-	}
-	r.cachedVms, r.cachedCts, r.targetsErr = r.resolveBackupTargetsUncached()
-	r.targetsFetched = true
+	r.targetsOnce.Do(func() {
+		r.cachedVms, r.cachedCts, r.targetsErr = r.resolveBackupTargetsUncached()
+	})
 	return r.cachedVms, r.cachedCts, r.targetsErr
 }
 
@@ -207,16 +198,9 @@ func (r *mqlProxmoxBackupJob) targetContainers() ([]any, error) {
 }
 
 func (r *mqlProxmoxBackupJob) config() (any, error) {
-	if r.configFetched {
-		return r.cfg, r.cfgErr
-	}
-	r.lock.Lock()
-	defer r.lock.Unlock()
-	if r.configFetched {
-		return r.cfg, r.cfgErr
-	}
-	conn := r.MqlRuntime.Connection.(*connection.PveConnection)
-	r.cfg, r.cfgErr = conn.GetBackupJob(r.Id.Data)
-	r.configFetched = true
+	r.configOnce.Do(func() {
+		conn := r.MqlRuntime.Connection.(*connection.PveConnection)
+		r.cfg, r.cfgErr = conn.GetBackupJob(r.Id.Data)
+	})
 	return r.cfg, r.cfgErr
 }

--- a/providers/proxmox/resources/cluster.go
+++ b/providers/proxmox/resources/cluster.go
@@ -15,10 +15,9 @@ import (
 )
 
 type mqlProxmoxClusterInternal struct {
-	optionsFetched bool
+	optionsOnce    sync.Once
 	clusterOptions map[string]any
 	optionsErr     error
-	optionsLock    sync.Mutex
 }
 
 func clusterConn(r *mqlProxmoxCluster) *connection.PveConnection {
@@ -26,16 +25,9 @@ func clusterConn(r *mqlProxmoxCluster) *connection.PveConnection {
 }
 
 func (r *mqlProxmoxCluster) ensureOptions() (map[string]any, error) {
-	if r.optionsFetched {
-		return r.clusterOptions, r.optionsErr
-	}
-	r.optionsLock.Lock()
-	defer r.optionsLock.Unlock()
-	if r.optionsFetched {
-		return r.clusterOptions, r.optionsErr
-	}
-	r.clusterOptions, r.optionsErr = clusterConn(r).GetClusterOptions()
-	r.optionsFetched = true
+	r.optionsOnce.Do(func() {
+		r.clusterOptions, r.optionsErr = clusterConn(r).GetClusterOptions()
+	})
 	return r.clusterOptions, r.optionsErr
 }
 

--- a/providers/proxmox/resources/container.go
+++ b/providers/proxmox/resources/container.go
@@ -15,10 +15,9 @@ import (
 )
 
 type mqlProxmoxContainerInternal struct {
-	configFetched bool
-	ctConfig      map[string]any
-	configErr     error
-	lock          sync.Mutex
+	configOnce sync.Once
+	ctConfig   map[string]any
+	configErr  error
 }
 
 func ctConn(r *mqlProxmoxContainer) *connection.PveConnection {
@@ -77,16 +76,9 @@ func (r *mqlProxmoxNode) containers() ([]any, error) {
 }
 
 func (r *mqlProxmoxContainer) ensureConfig() {
-	if r.configFetched {
-		return
-	}
-	r.lock.Lock()
-	defer r.lock.Unlock()
-	if r.configFetched {
-		return
-	}
-	r.ctConfig, r.configErr = ctConn(r).GetContainerConfig(r.Node.Data, int(r.Id.Data))
-	r.configFetched = true
+	r.configOnce.Do(func() {
+		r.ctConfig, r.configErr = ctConn(r).GetContainerConfig(r.Node.Data, int(r.Id.Data))
+	})
 }
 
 func (r *mqlProxmoxContainer) cfgStr(key string) string {
@@ -268,7 +260,7 @@ func (r *mqlProxmoxContainer) networks() ([]any, error) {
 	}
 	var list []any
 	for key, val := range r.ctConfig {
-		if !strings.HasPrefix(key, "net") {
+		if !isNetSlotKey(key) {
 			continue
 		}
 		valStr := fmt.Sprintf("%v", val)

--- a/providers/proxmox/resources/disks.go
+++ b/providers/proxmox/resources/disks.go
@@ -16,11 +16,10 @@ import (
 // ---------------------------------------------------------------------------
 
 type mqlProxmoxNodeDiskInternal struct {
-	parentNode   string
-	smartFetched bool
-	smartData    *connection.DiskSMART
-	smartErr     error
-	lock         sync.Mutex
+	parentNode string
+	smartOnce  sync.Once
+	smartData  *connection.DiskSMART
+	smartErr   error
 }
 
 func (r *mqlProxmoxNode) disks() ([]any, error) {
@@ -59,17 +58,10 @@ func (r *mqlProxmoxNode) disks() ([]any, error) {
 }
 
 func (r *mqlProxmoxNodeDisk) ensureSMART() {
-	if r.smartFetched {
-		return
-	}
-	r.lock.Lock()
-	defer r.lock.Unlock()
-	if r.smartFetched {
-		return
-	}
-	conn := r.MqlRuntime.Connection.(*connection.PveConnection)
-	r.smartData, r.smartErr = conn.GetDiskSMART(r.parentNode, r.DevPath.Data)
-	r.smartFetched = true
+	r.smartOnce.Do(func() {
+		conn := r.MqlRuntime.Connection.(*connection.PveConnection)
+		r.smartData, r.smartErr = conn.GetDiskSMART(r.parentNode, r.DevPath.Data)
+	})
 }
 
 func (r *mqlProxmoxNodeDisk) smart() (*mqlProxmoxNodeDiskSmart, error) {
@@ -128,11 +120,10 @@ func (r *mqlProxmoxNodeDisk) smart() (*mqlProxmoxNodeDiskSmart, error) {
 // ---------------------------------------------------------------------------
 
 type mqlProxmoxZfsPoolInternal struct {
-	parentNode    string
-	detailFetched bool
-	detail        *connection.ZFSPoolDetail
-	detailErr     error
-	lock          sync.Mutex
+	parentNode string
+	detailOnce sync.Once
+	detail     *connection.ZFSPoolDetail
+	detailErr  error
 }
 
 func (r *mqlProxmoxNode) zfsPools() ([]any, error) {
@@ -164,17 +155,10 @@ func (r *mqlProxmoxNode) zfsPools() ([]any, error) {
 }
 
 func (r *mqlProxmoxZfsPool) ensureDetail() {
-	if r.detailFetched {
-		return
-	}
-	r.lock.Lock()
-	defer r.lock.Unlock()
-	if r.detailFetched {
-		return
-	}
-	conn := r.MqlRuntime.Connection.(*connection.PveConnection)
-	r.detail, r.detailErr = conn.GetZFSPoolDetail(r.parentNode, r.Name.Data)
-	r.detailFetched = true
+	r.detailOnce.Do(func() {
+		conn := r.MqlRuntime.Connection.(*connection.PveConnection)
+		r.detail, r.detailErr = conn.GetZFSPoolDetail(r.parentNode, r.Name.Data)
+	})
 }
 
 func (r *mqlProxmoxZfsPool) state() (string, error) {
@@ -246,14 +230,6 @@ func zfsChildToDict(c connection.ZFSPoolChild) map[string]any {
 // ---------------------------------------------------------------------------
 // LVM volume groups + thin pools
 // ---------------------------------------------------------------------------
-
-type mqlProxmoxLvmVolumeGroupInternal struct {
-	parentNode string
-}
-
-type mqlProxmoxLvmThinPoolInternal struct {
-	parentNode string
-}
 
 func (r *mqlProxmoxNode) volumeGroups() ([]any, error) {
 	conn := nodeConn(r)

--- a/providers/proxmox/resources/hardware.go
+++ b/providers/proxmox/resources/hardware.go
@@ -118,9 +118,12 @@ func (r *mqlProxmoxFirewallGroup) id() (string, error) {
 	return "proxmox.firewall.group/" + r.Name.Data, nil
 }
 
+func firewallGroupConn(r *mqlProxmoxFirewallGroup) *connection.PveConnection {
+	return r.MqlRuntime.Connection.(*connection.PveConnection)
+}
+
 func (r *mqlProxmoxFirewallGroup) rules() ([]any, error) {
-	conn := r.MqlRuntime.Connection.(*connection.PveConnection)
-	rules, err := conn.GetClusterFirewallGroupRules(r.Name.Data)
+	rules, err := firewallGroupConn(r).GetClusterFirewallGroupRules(r.Name.Data)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/proxmox/resources/helpers.go
+++ b/providers/proxmox/resources/helpers.go
@@ -190,6 +190,26 @@ func looksLikeMAC(s string) bool {
 	return len(s) == 17 && strings.Count(s, ":") == 5
 }
 
+// isNetSlotKey reports whether a VM/CT config key is one of the
+// `netN` interface slots. A naive `HasPrefix("net")` match would
+// also catch the `netin`/`netout` traffic counters returned by the
+// listing endpoint, so insist on a non-empty all-digit suffix.
+func isNetSlotKey(key string) bool {
+	if !strings.HasPrefix(key, "net") {
+		return false
+	}
+	rest := key[len("net"):]
+	if rest == "" {
+		return false
+	}
+	for _, c := range rest {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 // parseContainerNetworkConfig parses a Proxmox LXC network config value.
 // Format: name=eth0,bridge=vmbr0,firewall=1,gw=192.168.1.1,hwaddr=AA:..,
 //

--- a/providers/proxmox/resources/node.go
+++ b/providers/proxmox/resources/node.go
@@ -13,11 +13,10 @@ import (
 )
 
 type mqlProxmoxNodeInternal struct {
-	nodeName      string
-	statusFetched bool
-	nodeStatus    *connection.NodeStatus
-	statusErr     error
-	lock          sync.Mutex
+	nodeName   string
+	statusOnce sync.Once
+	nodeStatus *connection.NodeStatus
+	statusErr  error
 }
 
 func nodeConn(r *mqlProxmoxNode) *connection.PveConnection {
@@ -29,16 +28,9 @@ func (r *mqlProxmoxNode) id() (string, error) {
 }
 
 func (r *mqlProxmoxNode) ensureStatus() {
-	if r.statusFetched {
-		return
-	}
-	r.lock.Lock()
-	defer r.lock.Unlock()
-	if r.statusFetched {
-		return
-	}
-	r.nodeStatus, r.statusErr = nodeConn(r).GetNodeStatus(r.Name.Data)
-	r.statusFetched = true
+	r.statusOnce.Do(func() {
+		r.nodeStatus, r.statusErr = nodeConn(r).GetNodeStatus(r.Name.Data)
+	})
 }
 
 func (r *mqlProxmoxNode) cpuModel() (string, error) {
@@ -328,9 +320,10 @@ func (r *mqlProxmoxNode) repositories() ([]any, error) {
 		return nil, err
 	}
 	var list []any
-	idx := 0
 	for _, file := range repoInfo.Files {
-		for _, repo := range file.Repositories {
+		// idx is per-file so the resulting `<path>:<idx>` matches what
+		// the path string implies (the n-th entry inside that file).
+		for idx, repo := range file.Repositories {
 			repoID := fmt.Sprintf("%s:%d", file.Path, idx)
 			name := repo.Comment
 			if name == "" && len(repo.URIs) > 0 {
@@ -374,7 +367,6 @@ func (r *mqlProxmoxNode) repositories() ([]any, error) {
 				return nil, err
 			}
 			list = append(list, res)
-			idx++
 		}
 	}
 	return list, nil

--- a/providers/proxmox/resources/proxmox.go
+++ b/providers/proxmox/resources/proxmox.go
@@ -164,6 +164,26 @@ func (r *mqlProxmox) users() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		// The user-listing endpoint already returned every token for
+		// this user; cache them so tokens() doesn't refetch one
+		// /access/users/<id>/token per user.
+		mqlUser := res.(*mqlProxmoxUser)
+		tokens := make([]any, 0, len(u.Tokens))
+		for _, t := range u.Tokens {
+			fullID := u.UserID + "!" + t.TokenID
+			tok, err := CreateResource(r.MqlRuntime, "proxmox.token", map[string]*llx.RawData{
+				"id":      llx.StringData(fullID),
+				"comment": llx.StringData(t.Comment),
+				"expire":  llx.IntData(t.Expire),
+				"privsep": llx.BoolData(t.Privsep == 1),
+			})
+			if err != nil {
+				return nil, err
+			}
+			tokens = append(tokens, tok)
+		}
+		mqlUser.cachedTokens = tokens
+		mqlUser.cachedTokensSet = true
 		list[i] = res
 	}
 	return list, nil

--- a/providers/proxmox/resources/proxmox.lr.go
+++ b/providers/proxmox/resources/proxmox.lr.go
@@ -6788,7 +6788,7 @@ func (c *mqlProxmoxFirewallRule) GetGroup() *plugin.TValue[*mqlProxmoxFirewallGr
 type mqlProxmoxUser struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlProxmoxUserInternal it will be used here
+	mqlProxmoxUserInternal
 	Id             plugin.TValue[string]
 	Email          plugin.TValue[string]
 	Enable         plugin.TValue[bool]
@@ -8757,7 +8757,7 @@ func (c *mqlProxmoxZfsPool) GetChildren() *plugin.TValue[[]any] {
 type mqlProxmoxLvmVolumeGroup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	mqlProxmoxLvmVolumeGroupInternal
+	// optional: if you define mqlProxmoxLvmVolumeGroupInternal it will be used here
 	Name    plugin.TValue[string]
 	Size    plugin.TValue[int64]
 	Free    plugin.TValue[int64]
@@ -8816,7 +8816,7 @@ func (c *mqlProxmoxLvmVolumeGroup) GetLvCount() *plugin.TValue[int64] {
 type mqlProxmoxLvmThinPool struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	mqlProxmoxLvmThinPoolInternal
+	// optional: if you define mqlProxmoxLvmThinPoolInternal it will be used here
 	Name         plugin.TValue[string]
 	VolumeGroup  plugin.TValue[string]
 	Size         plugin.TValue[int64]

--- a/providers/proxmox/resources/replication.go
+++ b/providers/proxmox/resources/replication.go
@@ -15,10 +15,9 @@ import (
 // container() can return null for the wrong type without each one paging
 // through /cluster/resources independently.
 type mqlProxmoxReplicationJobInternal struct {
-	kindFetched bool
-	guestKind   string // "qemu", "lxc", or "" when the vmid isn't found
-	kindErr     error
-	lock        sync.Mutex
+	kindOnce  sync.Once
+	guestKind string // "qemu", "lxc", or "" when the vmid isn't found
+	kindErr   error
 }
 
 func (r *mqlProxmox) replicationJobs() ([]any, error) {
@@ -76,46 +75,35 @@ func replicationNodeRef(runtime *plugin.Runtime, name string, slot *plugin.TValu
 // the result to return the right typed resource and null for the other —
 // matching the .lr contract that only one of vm()/container() is set.
 func (r *mqlProxmoxReplicationJob) ensureGuestKind() (string, error) {
-	if r.kindFetched {
-		return r.guestKind, r.kindErr
-	}
-	r.lock.Lock()
-	defer r.lock.Unlock()
-	if r.kindFetched {
-		return r.guestKind, r.kindErr
-	}
-	conn := r.MqlRuntime.Connection.(*connection.PveConnection)
-	// Both /cluster/resources?type=vm and the dedicated GetAllContainers go
-	// through the same endpoint; one round-trip is enough.
-	vms, vmErr := conn.GetAllVMs()
-	if vmErr == nil {
-		for _, vm := range vms {
-			if int64(vm.VMID) == r.Vmid.Data {
-				r.guestKind = "qemu"
-				r.kindFetched = true
-				return r.guestKind, nil
+	r.kindOnce.Do(func() {
+		conn := r.MqlRuntime.Connection.(*connection.PveConnection)
+		vms, vmErr := conn.GetAllVMs()
+		if vmErr == nil {
+			for _, vm := range vms {
+				if int64(vm.VMID) == r.Vmid.Data {
+					r.guestKind = "qemu"
+					return
+				}
 			}
 		}
-	}
-	cts, ctErr := conn.GetAllContainers()
-	if ctErr == nil {
-		for _, ct := range cts {
-			if int64(ct.VMID) == r.Vmid.Data {
-				r.guestKind = "lxc"
-				r.kindFetched = true
-				return r.guestKind, nil
+		cts, ctErr := conn.GetAllContainers()
+		if ctErr == nil {
+			for _, ct := range cts {
+				if int64(ct.VMID) == r.Vmid.Data {
+					r.guestKind = "lxc"
+					return
+				}
 			}
 		}
-	}
-	// Both lookups returning empty is normal for a job pointing at a guest
-	// that's already been deleted — leave guestKind empty so both vm() and
-	// container() resolve to null.
-	if vmErr != nil {
-		r.kindErr = vmErr
-	} else if ctErr != nil {
-		r.kindErr = ctErr
-	}
-	r.kindFetched = true
+		// Treat "deleted guest" as the success path: only bubble the
+		// API errors up if BOTH lookups failed, because either listing
+		// returning cleanly is enough to authoritatively answer "not
+		// found." A transient VM-listing failure should not poison the
+		// answer when the container listing definitively said "not me."
+		if vmErr != nil && ctErr != nil {
+			r.kindErr = vmErr
+		}
+	})
 	return r.guestKind, r.kindErr
 }
 

--- a/providers/proxmox/resources/vm.go
+++ b/providers/proxmox/resources/vm.go
@@ -15,13 +15,12 @@ import (
 )
 
 type mqlProxmoxVmInternal struct {
-	configFetched bool
-	vmConfig      map[string]interface{}
-	configErr     error
-	osInfoFetched bool
-	osInfo        *connection.OsInfo
-	osInfoErr     error
-	cfgLock       sync.Mutex
+	configOnce sync.Once
+	vmConfig   map[string]interface{}
+	configErr  error
+	osInfoOnce sync.Once
+	osInfo     *connection.OsInfo
+	osInfoErr  error
 }
 
 func vmConn(r *mqlProxmoxVm) *connection.PveConnection {
@@ -33,16 +32,9 @@ func (r *mqlProxmoxVm) id() (string, error) {
 }
 
 func (r *mqlProxmoxVm) ensureConfig() {
-	if r.configFetched {
-		return
-	}
-	r.cfgLock.Lock()
-	defer r.cfgLock.Unlock()
-	if r.configFetched {
-		return
-	}
-	r.vmConfig, r.configErr = vmConn(r).GetVMConfig(r.Node.Data, int(r.Id.Data))
-	r.configFetched = true
+	r.configOnce.Do(func() {
+		r.vmConfig, r.configErr = vmConn(r).GetVMConfig(r.Node.Data, int(r.Id.Data))
+	})
 }
 
 func (r *mqlProxmoxVm) cfgStr(key string) string {
@@ -221,7 +213,7 @@ func (r *mqlProxmoxVm) networks() ([]any, error) {
 	}
 	var list []any
 	for key, val := range r.vmConfig {
-		if !strings.HasPrefix(key, "net") {
+		if !isNetSlotKey(key) {
 			continue
 		}
 		valStr := fmt.Sprintf("%v", val)
@@ -308,14 +300,9 @@ func (r *mqlProxmoxVm) updates() ([]any, error) {
 	}
 	conn := vmConn(r)
 	vmid := int(r.Id.Data)
-	if !r.osInfoFetched {
-		r.cfgLock.Lock()
-		defer r.cfgLock.Unlock()
-		if !r.osInfoFetched {
-			r.osInfo, r.osInfoErr = conn.GetOsInfo(r.Node.Data, vmid)
-			r.osInfoFetched = true
-		}
-	}
+	r.osInfoOnce.Do(func() {
+		r.osInfo, r.osInfoErr = conn.GetOsInfo(r.Node.Data, vmid)
+	})
 	if r.osInfoErr != nil {
 		if errors.Is(r.osInfoErr, connection.ErrQGANotRunning) {
 			return nil, fmt.Errorf("guest agent not reachable for VM %d", vmid)
@@ -345,7 +332,16 @@ func (r *mqlProxmoxVm) updates() ([]any, error) {
 }
 
 // --- User tokens ---
+//
+// When the user came from the cluster-wide listing the tokens are
+// already populated in cachedTokens (see proxmox.users()), so we
+// short-circuit. The per-user /access/users/<id>/token fetch is
+// reserved for the init path that resolves a single user by id
+// (e.g. an ACL grant pointing at a user we haven't enumerated).
 func (r *mqlProxmoxUser) tokens() ([]any, error) {
+	if r.cachedTokensSet {
+		return r.cachedTokens, nil
+	}
 	conn := r.MqlRuntime.Connection.(*connection.PveConnection)
 	tokens, err := conn.GetUserTokens(r.Id.Data)
 	if err != nil {

--- a/providers/proxmox/resources/vm.go
+++ b/providers/proxmox/resources/vm.go
@@ -338,6 +338,12 @@ func (r *mqlProxmoxVm) updates() ([]any, error) {
 // short-circuit. The per-user /access/users/<id>/token fetch is
 // reserved for the init path that resolves a single user by id
 // (e.g. an ACL grant pointing at a user we haven't enumerated).
+//
+// No sync.Once is needed for the cached-read path: cachedTokens and
+// cachedTokensSet are written synchronously inside proxmox.users()
+// before the resource is published to the runtime, so by the time
+// any caller can invoke tokens() the writes have happened-before in
+// the same goroutine that returned the resource list.
 func (r *mqlProxmoxUser) tokens() ([]any, error) {
 	if r.cachedTokensSet {
 		return r.cachedTokens, nil

--- a/providers/proxmox/resources/vm_parser_test.go
+++ b/providers/proxmox/resources/vm_parser_test.go
@@ -224,3 +224,34 @@ func TestLooksLikeMAC(t *testing.T) {
 		t.Error("expected false for empty string")
 	}
 }
+
+func TestIsNetSlotKey(t *testing.T) {
+	cases := map[string]bool{
+		// Valid slots — Proxmox accepts net0..net31 on VMs, fewer on
+		// containers, but the validator just checks the digit suffix.
+		"net0":  true,
+		"net1":  true,
+		"net12": true,
+		"net31": true,
+		// Critical regression cases: the listing endpoint exposes
+		// traffic counters with names that start with "net" but aren't
+		// configured interfaces.
+		"netin":  false,
+		"netout": false,
+		// Other near-matches that should not be treated as net slots.
+		"net":       false, // missing slot number
+		"netname":   false,
+		"network":   false,
+		"":          false,
+		"snet0":     false, // doesn't start with "net"
+		"netfoo":    false,
+		"net0extra": false,
+	}
+	for key, want := range cases {
+		t.Run(key, func(t *testing.T) {
+			if got := isNetSlotKey(key); got != want {
+				t.Errorf("isNetSlotKey(%q) = %v, want %v", key, got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Bugs found by a deep-dive review of the provider, focused on nil handling, logic errors, pagination, and performance.

### High-impact

- **`GetNodeVMs` N+1 — fixed.** Used to call `GetAllVMs` and filter, so `proxmox.nodes { vms }` made one `/cluster/resources` fetch per node. Now hits `/nodes/<n>/qemu` directly, the same way `GetNodeContainers` already did. A new HTTP-mocked test registers only the per-node endpoint, so any future fallback to `GetAllVMs` would surface as a 404 in CI.

- **User tokens N+1 — fixed.** `/access/users?full=1` already returns each user's tokens inline, but `tokens()` was fetching them again per user. The inline data is now cached on `mqlProxmoxUserInternal`; the init path (resolving a single user by id from ACL traversal) still does the on-demand fetch.

- **Double-checked locking → `sync.Once`.** Every `ensure*` helper across the provider (vm config, container config, disk SMART, ZFS pool detail, realm config, backup-job config + targets, replication guest-kind, cluster options, node status, VM OS-info) was using the classic Go DCL anti-pattern with a bare `bool` read outside the mutex — a data race per Go's memory model. In practice the symptom was an occasional duplicate fetch, but the race detector flagged it every time. Each one is now a one-liner `Once.Do(...)`.

- **`getDnfUpdates` dead nil-check.** The `err != nil && result == nil` guard was redundant (QGAExec never returns both non-nil result and non-nil error) and would have silently nil-derefed if the contract ever changed. Simplified to a plain `err != nil` check with a comment explaining how dnf exit code 100 is handled by the result struct.

### Medium

- **Dead LVM Internal structs.** `parentNode` on `mqlProxmoxLvmVolumeGroupInternal` and `mqlProxmoxLvmThinPoolInternal` is never written or read after the `__id` refactor. Both structs dropped.

- **Repository `idx` reset per file.** The counter was global across all source files, so the resulting `<path>:<idx>` cache key had a misleading shape. Now scoped per file via the loop variable.

- **`networks()` digit-suffix filter.** The bare `HasPrefix("net")` would also match `netin` / `netout` traffic counters. Replaced with a shared `isNetSlotKey` helper that insists on a digit suffix. Defensive against `/cluster/resources` fields ever leaking into per-VM/CT config.

- **`ensureGuestKind` error precedence.** Used to bubble a VM-listing failure even when the container lookup definitively answered "guest not here" — so a transient VM-API hiccup poisoned `container()` with an unrelated error. Now only bubbles if both lookups failed.

- **`firewallGroup` connection helper.** Added `firewallGroupConn()` to match the typed-helper pattern used everywhere else in the firewall code.

## Tests

- `TestGetNodeVMs_HitsPerNodeEndpoint` — pins the per-node endpoint by omitting `/cluster/resources` from the fixture
- `TestGetNodeVMs_MalformedVMIDErrors` — strconv.Atoi regression, symmetric with the existing container test
- `TestIsNetSlotKey` — covers the netin/netout regression case explicitly
- All existing tests still pass; `go test -race ./...` clean

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./...` and `go test -race ./...` both green
- [x] `make providers/build/proxmox` produces `dist/proxmox`
- [ ] Interactive smoke against a live Proxmox cluster:
  - `mql shell proxmox -c "proxmox.nodes { vms.length containers.length }"` — should be a fast, single round-trip per node
  - `mql shell proxmox -c "proxmox.users { id tokens.length }"` — should not fan out into per-user token fetches

🤖 Generated with [Claude Code](https://claude.com/claude-code)