### PR TITLE
🧹 k8s: spelling — pre-existing → preexisting in PVC.selector doc

### DIFF
--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -1664,7 +1664,7 @@ private k8s.persistentvolumeclaim @defaults("namespace name phase capacity['stor
   volumeMode() string
   // Resource requirements (requests, limits keyed by resource name)
   resources() dict
-  // Label selector for pre-existing PVs eligible to satisfy the claim
+  // Label selector for preexisting PVs eligible to satisfy the claim
   selector() dict
   // Data source for populating the volume (snapshot, PVC, custom resource)
   dataSource() dict


### PR DESCRIPTION
Tiny fix-up to the PVC `selector` field doc added in #7872.

🤖 Generated with [Claude Code](https://claude.com/claude-code)