### PR TITLE
✨ k8s: type RBAC traversal, EndpointSlice service, ResourceQuota/LimitRange fields

### DIFF
--- a/providers/k8s/resources/clusterrole.go
+++ b/providers/k8s/resources/clusterrole.go
@@ -78,7 +78,7 @@ func (k *mqlK8sRbacClusterrole) annotations() (map[string]any, error) {
 }
 
 func (k *mqlK8sRbacClusterrole) labels() (map[string]any, error) {
-	return convert.MapToInterfaceMap(k.obj.GetAnnotations()), nil
+	return convert.MapToInterfaceMap(k.obj.GetLabels()), nil
 }
 
 func (k *mqlK8sRbacClusterrole) boundBy() ([]any, error) {

--- a/providers/k8s/resources/clusterrole.go
+++ b/providers/k8s/resources/clusterrole.go
@@ -80,3 +80,27 @@ func (k *mqlK8sRbacClusterrole) annotations() (map[string]any, error) {
 func (k *mqlK8sRbacClusterrole) labels() (map[string]any, error) {
 	return convert.MapToInterfaceMap(k.obj.GetAnnotations()), nil
 }
+
+func (k *mqlK8sRbacClusterrole) boundBy() ([]any, error) {
+	o, err := CreateResource(k.MqlRuntime, "k8s", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	crbs := o.(*mqlK8s).GetClusterrolebindings()
+	if crbs.Error != nil {
+		return nil, crbs.Error
+	}
+
+	roleName := k.Name.Data
+	out := []any{}
+	for i := range crbs.Data {
+		crb, ok := crbs.Data[i].(*mqlK8sRbacClusterrolebinding)
+		if !ok {
+			continue
+		}
+		if crb.obj.RoleRef.Name == roleName {
+			out = append(out, crb)
+		}
+	}
+	return out, nil
+}

--- a/providers/k8s/resources/clusterrolebinding.go
+++ b/providers/k8s/resources/clusterrolebinding.go
@@ -81,3 +81,23 @@ func (k *mqlK8sRbacClusterrolebinding) annotations() (map[string]any, error) {
 func (k *mqlK8sRbacClusterrolebinding) labels() (map[string]any, error) {
 	return convert.MapToInterfaceMap(k.obj.GetLabels()), nil
 }
+
+func (k *mqlK8sRbacClusterrolebinding) serviceAccounts() ([]any, error) {
+	// ClusterRoleBindings are cluster-scoped; ServiceAccount subjects must
+	// specify their own namespace (no fallback).
+	return resolveServiceAccountSubjects(k.MqlRuntime, k.obj.Subjects, "")
+}
+
+func (k *mqlK8sRbacClusterrolebinding) clusterRole() (*mqlK8sRbacClusterrole, error) {
+	if k.obj.RoleRef.Name == "" {
+		k.ClusterRole.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	r, err := NewResource(k.MqlRuntime, "k8s.rbac.clusterrole", map[string]*llx.RawData{
+		"name": llx.StringData(k.obj.RoleRef.Name),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.(*mqlK8sRbacClusterrole), nil
+}

--- a/providers/k8s/resources/cross_references_test.go
+++ b/providers/k8s/resources/cross_references_test.go
@@ -1,0 +1,749 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/k8s/connection/manifest"
+	"go.mondoo.com/mql/v13/utils/syncx"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const crossRefFixture = "testdata/cross_references.yaml"
+
+// loadCrossRefRuntime loads the cross-reference fixture and returns a runtime
+// wired against the resulting manifest connection. The connection is left
+// namespace-scopeless so cluster-wide queries traverse every fixture object.
+func loadCrossRefRuntime(t *testing.T) *plugin.Runtime {
+	t.Helper()
+	conn, err := manifest.NewConnection(0, &inventory.Asset{
+		Connections: []*inventory.Config{
+			{Options: map[string]string{}},
+		},
+	}, manifest.WithManifestFile(crossRefFixture))
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+	runtime.Connection = conn
+	return runtime
+}
+
+func mqlResourceNames(t *testing.T, items []any) []string {
+	t.Helper()
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		switch v := it.(type) {
+		case *mqlK8sPod:
+			out = append(out, v.Name.Data)
+		case *mqlK8sDeployment:
+			out = append(out, v.Name.Data)
+		case *mqlK8sStatefulset:
+			out = append(out, v.Name.Data)
+		case *mqlK8sDaemonset:
+			out = append(out, v.Name.Data)
+		case *mqlK8sReplicaset:
+			out = append(out, v.Name.Data)
+		case *mqlK8sJob:
+			out = append(out, v.Name.Data)
+		case *mqlK8sCronjob:
+			out = append(out, v.Name.Data)
+		case *mqlK8sService:
+			out = append(out, v.Name.Data)
+		case *mqlK8sEndpointslice:
+			out = append(out, v.Name.Data)
+		case *mqlK8sSecret:
+			out = append(out, v.Name.Data)
+		case *mqlK8sConfigmap:
+			out = append(out, v.Name.Data)
+		case *mqlK8sServiceaccount:
+			out = append(out, v.Name.Data)
+		case *mqlK8sRbacRole:
+			out = append(out, v.Name.Data)
+		case *mqlK8sRbacRolebinding:
+			out = append(out, v.Name.Data)
+		case *mqlK8sRbacClusterrole:
+			out = append(out, v.Name.Data)
+		case *mqlK8sRbacClusterrolebinding:
+			out = append(out, v.Name.Data)
+		default:
+			t.Fatalf("mqlResourceNames: unhandled type %T", v)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// -----------------------------------------------------------------------------
+// Pure-function tests for the multi-arm reference predicates.
+// These walk a constructed *corev1.Pod and don't need the MQL runtime.
+// -----------------------------------------------------------------------------
+
+func TestPodReferencesSecret(t *testing.T) {
+	// One pod that references "target" through every supported path, plus a
+	// no-match secret to assert false-positives aren't introduced.
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				{Name: "v-secret", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "target"}}},
+				{Name: "v-projected", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{
+					Sources: []corev1.VolumeProjection{
+						{Secret: &corev1.SecretProjection{LocalObjectReference: corev1.LocalObjectReference{Name: "target"}}},
+					},
+				}}},
+			},
+			ImagePullSecrets: []corev1.LocalObjectReference{{Name: "target"}},
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Env: []corev1.EnvVar{
+						{Name: "X", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "target"}, Key: "k",
+						}}},
+					},
+					EnvFrom: []corev1.EnvFromSource{
+						{SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "target"}}},
+					},
+				},
+			},
+			InitContainers: []corev1.Container{
+				{Name: "init", Env: []corev1.EnvVar{{Name: "Y", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "target"}, Key: "k",
+				}}}}},
+			},
+			EphemeralContainers: []corev1.EphemeralContainer{
+				{EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+					Name: "debug",
+					EnvFrom: []corev1.EnvFromSource{
+						{SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "target"}}},
+					},
+				}},
+			},
+		},
+	}
+	assert.True(t, podReferencesSecret(pod, "target"), "should detect target via any of the configured paths")
+	assert.False(t, podReferencesSecret(pod, "no-such-secret"), "must not false-positive on a name nothing references")
+
+	// Empty pod — no false-positive on the empty string.
+	assert.False(t, podReferencesSecret(&corev1.Pod{}, "anything"))
+	assert.False(t, podReferencesSecret(&corev1.Pod{}, ""))
+
+	// Per-path coverage: each branch should be the sole signal that flips the result.
+	t.Run("volume.secret only", func(t *testing.T) {
+		p := &corev1.Pod{Spec: corev1.PodSpec{Volumes: []corev1.Volume{
+			{Name: "v", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "s"}}},
+		}}}
+		assert.True(t, podReferencesSecret(p, "s"))
+		assert.False(t, podReferencesSecret(p, "other"))
+	})
+	t.Run("projected.secret only", func(t *testing.T) {
+		p := &corev1.Pod{Spec: corev1.PodSpec{Volumes: []corev1.Volume{
+			{Name: "v", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{
+				Sources: []corev1.VolumeProjection{{Secret: &corev1.SecretProjection{LocalObjectReference: corev1.LocalObjectReference{Name: "s"}}}},
+			}}},
+		}}}
+		assert.True(t, podReferencesSecret(p, "s"))
+	})
+	t.Run("imagePullSecrets only", func(t *testing.T) {
+		p := &corev1.Pod{Spec: corev1.PodSpec{ImagePullSecrets: []corev1.LocalObjectReference{{Name: "s"}}}}
+		assert.True(t, podReferencesSecret(p, "s"))
+	})
+	t.Run("container env only", func(t *testing.T) {
+		p := &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
+			{Env: []corev1.EnvVar{{ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "s"}}}}}},
+		}}}
+		assert.True(t, podReferencesSecret(p, "s"))
+	})
+	t.Run("init container envFrom only", func(t *testing.T) {
+		p := &corev1.Pod{Spec: corev1.PodSpec{InitContainers: []corev1.Container{
+			{EnvFrom: []corev1.EnvFromSource{{SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "s"}}}}},
+		}}}
+		assert.True(t, podReferencesSecret(p, "s"))
+	})
+	t.Run("ephemeral container only", func(t *testing.T) {
+		p := &corev1.Pod{Spec: corev1.PodSpec{EphemeralContainers: []corev1.EphemeralContainer{
+			{EphemeralContainerCommon: corev1.EphemeralContainerCommon{Env: []corev1.EnvVar{
+				{ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "s"}}}},
+			}}},
+		}}}
+		assert.True(t, podReferencesSecret(p, "s"))
+	})
+}
+
+func TestPodReferencesConfigMap(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				{Name: "v-cm", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "target"},
+				}}},
+				{Name: "v-projected", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{
+					Sources: []corev1.VolumeProjection{
+						{ConfigMap: &corev1.ConfigMapProjection{LocalObjectReference: corev1.LocalObjectReference{Name: "target"}}},
+					},
+				}}},
+			},
+			Containers: []corev1.Container{
+				{Env: []corev1.EnvVar{{ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "target"}},
+				}}}},
+				{EnvFrom: []corev1.EnvFromSource{{ConfigMapRef: &corev1.ConfigMapEnvSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "target"}}}}},
+			},
+		},
+	}
+	assert.True(t, podReferencesConfigMap(pod, "target"))
+	assert.False(t, podReferencesConfigMap(pod, "no-such-cm"))
+	// Secret references must not be confused for ConfigMap references.
+	secretOnly := &corev1.Pod{Spec: corev1.PodSpec{Volumes: []corev1.Volume{
+		{Name: "v", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "target"}}},
+	}}}
+	assert.False(t, podReferencesConfigMap(secretOnly, "target"),
+		"a secret named 'target' must not satisfy a configmap lookup")
+}
+
+// -----------------------------------------------------------------------------
+// Fixture-driven integration tests for cross-reference resolvers.
+// -----------------------------------------------------------------------------
+
+func TestPodOwnerRefs(t *testing.T) {
+	runtime := loadCrossRefRuntime(t)
+
+	t.Run("pod owned by ReplicaSet resolves replicaSet and 2-hop deployment", func(t *testing.T) {
+		obj, err := NewResource(runtime, "k8s.pod", map[string]*llx.RawData{
+			"name":      llx.StringData("api-7d4f-xyz"),
+			"namespace": llx.StringData("prod"),
+		})
+		require.NoError(t, err)
+		pod := obj.(*mqlK8sPod)
+
+		rs := pod.GetReplicaSet()
+		require.NoError(t, rs.Error)
+		require.NotNil(t, rs.Data)
+		assert.Equal(t, "api-7d4f", rs.Data.Name.Data)
+
+		dep := pod.GetDeployment()
+		require.NoError(t, dep.Error)
+		require.NotNil(t, dep.Data, "deployment should resolve via Pod → RS → Deployment ownerReferences")
+		assert.Equal(t, "api", dep.Data.Name.Data)
+
+		// Non-matching kinds must be null and have StateIsNull set.
+		assertNullOwner(t, pod.GetStatefulSet().State, pod.GetStatefulSet().Data == nil)
+		assertNullOwner(t, pod.GetDaemonSet().State, pod.GetDaemonSet().Data == nil)
+		assertNullOwner(t, pod.GetJob().State, pod.GetJob().Data == nil)
+	})
+
+	t.Run("pod owned by ReplicaSet with no Deployment owner has null deployment", func(t *testing.T) {
+		obj, err := NewResource(runtime, "k8s.pod", map[string]*llx.RawData{
+			"name":      llx.StringData("standalone-pod"),
+			"namespace": llx.StringData("prod"),
+		})
+		require.NoError(t, err)
+		pod := obj.(*mqlK8sPod)
+
+		rs := pod.GetReplicaSet()
+		require.NoError(t, rs.Error)
+		require.NotNil(t, rs.Data, "the orphan ReplicaSet should still resolve")
+		assert.Equal(t, "standalone-rs", rs.Data.Name.Data)
+
+		dep := pod.GetDeployment()
+		require.NoError(t, dep.Error)
+		assert.Nil(t, dep.Data, "ReplicaSet without a Deployment owner must surface as null deployment")
+		assert.True(t, dep.State&plugin.StateIsNull != 0, "expected StateIsNull on the null deployment")
+	})
+
+	t.Run("pod owned by StatefulSet", func(t *testing.T) {
+		obj, err := NewResource(runtime, "k8s.pod", map[string]*llx.RawData{
+			"name":      llx.StringData("db-0"),
+			"namespace": llx.StringData("prod"),
+		})
+		require.NoError(t, err)
+		pod := obj.(*mqlK8sPod)
+		ss := pod.GetStatefulSet()
+		require.NoError(t, ss.Error)
+		require.NotNil(t, ss.Data)
+		assert.Equal(t, "db", ss.Data.Name.Data)
+		assert.Nil(t, pod.GetReplicaSet().Data)
+		assert.Nil(t, pod.GetJob().Data)
+	})
+
+	t.Run("pod owned by DaemonSet", func(t *testing.T) {
+		obj, err := NewResource(runtime, "k8s.pod", map[string]*llx.RawData{
+			"name":      llx.StringData("fluentd-abc"),
+			"namespace": llx.StringData("kube-system"),
+		})
+		require.NoError(t, err)
+		pod := obj.(*mqlK8sPod)
+		ds := pod.GetDaemonSet()
+		require.NoError(t, ds.Error)
+		require.NotNil(t, ds.Data)
+		assert.Equal(t, "fluentd", ds.Data.Name.Data)
+	})
+
+	t.Run("pod owned by Job", func(t *testing.T) {
+		obj, err := NewResource(runtime, "k8s.pod", map[string]*llx.RawData{
+			"name":      llx.StringData("importer-pod"),
+			"namespace": llx.StringData("prod"),
+		})
+		require.NoError(t, err)
+		pod := obj.(*mqlK8sPod)
+		j := pod.GetJob()
+		require.NoError(t, j.Error)
+		require.NotNil(t, j.Data)
+		assert.Equal(t, "importer", j.Data.Name.Data)
+	})
+
+	t.Run("bare pod has all-null typed owner refs", func(t *testing.T) {
+		obj, err := NewResource(runtime, "k8s.pod", map[string]*llx.RawData{
+			"name":      llx.StringData("bare-pod"),
+			"namespace": llx.StringData("prod"),
+		})
+		require.NoError(t, err)
+		pod := obj.(*mqlK8sPod)
+		assert.Nil(t, pod.GetReplicaSet().Data)
+		assert.Nil(t, pod.GetStatefulSet().Data)
+		assert.Nil(t, pod.GetDaemonSet().Data)
+		assert.Nil(t, pod.GetJob().Data)
+		assert.Nil(t, pod.GetDeployment().Data)
+	})
+}
+
+func assertNullOwner(t *testing.T, state plugin.State, dataIsNil bool) {
+	t.Helper()
+	assert.True(t, dataIsNil, "expected data to be nil for non-matching owner kind")
+	assert.True(t, state&plugin.StateIsNull != 0, "expected StateIsNull bit on non-matching owner kind")
+}
+
+func TestWorkloadPodsSelector(t *testing.T) {
+	runtime := loadCrossRefRuntime(t)
+
+	t.Run("deployment with matchLabels selector", func(t *testing.T) {
+		obj, err := NewResource(runtime, "k8s.deployment", map[string]*llx.RawData{
+			"name":      llx.StringData("api"),
+			"namespace": llx.StringData("prod"),
+		})
+		require.NoError(t, err)
+		pods := obj.(*mqlK8sDeployment).GetPods()
+		require.NoError(t, pods.Error)
+		assert.Equal(t, []string{"api-7d4f-xyz"}, mqlResourceNames(t, pods.Data),
+			"deployment.pods must match the app=api selector and exclude pods in other namespaces or with different labels")
+	})
+
+	t.Run("statefulset with matchLabels selector", func(t *testing.T) {
+		obj, err := NewResource(runtime, "k8s.statefulset", map[string]*llx.RawData{
+			"name":      llx.StringData("db"),
+			"namespace": llx.StringData("prod"),
+		})
+		require.NoError(t, err)
+		pods := obj.(*mqlK8sStatefulset).GetPods()
+		require.NoError(t, pods.Error)
+		assert.Equal(t, []string{"db-0"}, mqlResourceNames(t, pods.Data))
+	})
+
+	t.Run("daemonset namespace scope", func(t *testing.T) {
+		obj, err := NewResource(runtime, "k8s.daemonset", map[string]*llx.RawData{
+			"name":      llx.StringData("fluentd"),
+			"namespace": llx.StringData("kube-system"),
+		})
+		require.NoError(t, err)
+		pods := obj.(*mqlK8sDaemonset).GetPods()
+		require.NoError(t, pods.Error)
+		assert.Equal(t, []string{"fluentd-abc"}, mqlResourceNames(t, pods.Data),
+			"daemonset.pods must scope to the daemonset's namespace even with matching labels elsewhere")
+	})
+
+	t.Run("job with matchExpressions selector", func(t *testing.T) {
+		// Exercises the matchExpressions code path in podsMatchingSelector.
+		obj, err := NewResource(runtime, "k8s.job", map[string]*llx.RawData{
+			"name":      llx.StringData("importer"),
+			"namespace": llx.StringData("prod"),
+		})
+		require.NoError(t, err)
+		pods := obj.(*mqlK8sJob).GetPods()
+		require.NoError(t, pods.Error)
+		assert.Equal(t, []string{"importer-pod"}, mqlResourceNames(t, pods.Data))
+	})
+}
+
+func TestPodsMatchingSelectorHelper(t *testing.T) {
+	runtime := loadCrossRefRuntime(t)
+
+	// nil selector returns an empty list rather than every pod.
+	out, err := podsMatchingSelector(runtime, nil, "prod")
+	require.NoError(t, err)
+	assert.Empty(t, out, "nil selector must not return any pods")
+
+	// Empty selector matches nothing-specific — k8s semantics treat it as "match all"
+	// for an actual selector object, but here we cover the nil-vs-empty distinction
+	// via the workload tests above. The pure helper test focuses on its contract.
+
+	// Mismatched namespace returns nothing even when labels would otherwise match.
+	sel := &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}}
+	out, err = podsMatchingSelector(runtime, sel, "nonexistent-ns")
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
+func TestCronJobActiveJobsAndJobs(t *testing.T) {
+	runtime := loadCrossRefRuntime(t)
+	obj, err := NewResource(runtime, "k8s.cronjob", map[string]*llx.RawData{
+		"name":      llx.StringData("weekly-cleanup"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	cj := obj.(*mqlK8sCronjob)
+
+	active := cj.GetActiveJobs()
+	require.NoError(t, active.Error)
+	assert.Equal(t, []string{"weekly-cleanup-active"}, mqlResourceNames(t, active.Data),
+		"activeJobs must resolve status.active ObjectReferences and exclude completed/unrelated jobs")
+
+	owned := cj.GetJobs()
+	require.NoError(t, owned.Error)
+	assert.Equal(t,
+		[]string{"weekly-cleanup-active", "weekly-cleanup-completed"},
+		mqlResourceNames(t, owned.Data),
+		"jobs must include every Job with an ownerReference UID matching the CronJob, regardless of status")
+}
+
+func TestServiceEndpointSlices(t *testing.T) {
+	runtime := loadCrossRefRuntime(t)
+	obj, err := NewResource(runtime, "k8s.service", map[string]*llx.RawData{
+		"name":      llx.StringData("api"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	slices := obj.(*mqlK8sService).GetEndpointSlices()
+	require.NoError(t, slices.Error)
+	assert.Equal(t, []string{"api-slice"}, mqlResourceNames(t, slices.Data),
+		"endpointSlices must filter on kubernetes.io/service-name + namespace and exclude orphan-slice")
+}
+
+func TestEndpointSliceService(t *testing.T) {
+	runtime := loadCrossRefRuntime(t)
+
+	t.Run("slice with service-name label resolves typed Service", func(t *testing.T) {
+		obj, err := NewResource(runtime, "k8s.endpointslice", map[string]*llx.RawData{
+			"name":      llx.StringData("api-slice"),
+			"namespace": llx.StringData("prod"),
+		})
+		require.NoError(t, err)
+		svc := obj.(*mqlK8sEndpointslice).GetService()
+		require.NoError(t, svc.Error)
+		require.NotNil(t, svc.Data)
+		assert.Equal(t, "api", svc.Data.Name.Data)
+	})
+
+	t.Run("slice without service-name label has null service", func(t *testing.T) {
+		obj, err := NewResource(runtime, "k8s.endpointslice", map[string]*llx.RawData{
+			"name":      llx.StringData("orphan-slice"),
+			"namespace": llx.StringData("prod"),
+		})
+		require.NoError(t, err)
+		svc := obj.(*mqlK8sEndpointslice).GetService()
+		require.NoError(t, svc.Error)
+		assert.Nil(t, svc.Data)
+		assert.True(t, svc.State&plugin.StateIsNull != 0)
+	})
+}
+
+func TestSecretUsedBy(t *testing.T) {
+	runtime := loadCrossRefRuntime(t)
+
+	t.Run("secret referenced from every path is used by exactly one pod", func(t *testing.T) {
+		obj, err := NewResource(runtime, "k8s.secret", map[string]*llx.RawData{
+			"name":      llx.StringData("db-creds"),
+			"namespace": llx.StringData("prod"),
+		})
+		require.NoError(t, err)
+		pods := obj.(*mqlK8sSecret).GetUsedBy()
+		require.NoError(t, pods.Error)
+		assert.Equal(t, []string{"api-7d4f-xyz"}, mqlResourceNames(t, pods.Data))
+	})
+
+	t.Run("imagePullSecret target only is still detected", func(t *testing.T) {
+		obj, err := NewResource(runtime, "k8s.secret", map[string]*llx.RawData{
+			"name":      llx.StringData("regcred"),
+			"namespace": llx.StringData("prod"),
+		})
+		require.NoError(t, err)
+		pods := obj.(*mqlK8sSecret).GetUsedBy()
+		require.NoError(t, pods.Error)
+		assert.Equal(t, []string{"api-7d4f-xyz"}, mqlResourceNames(t, pods.Data))
+	})
+
+	t.Run("orphan secret has empty usedBy", func(t *testing.T) {
+		obj, err := NewResource(runtime, "k8s.secret", map[string]*llx.RawData{
+			"name":      llx.StringData("orphan-secret"),
+			"namespace": llx.StringData("prod"),
+		})
+		require.NoError(t, err)
+		pods := obj.(*mqlK8sSecret).GetUsedBy()
+		require.NoError(t, pods.Error)
+		assert.Empty(t, pods.Data, "unused secrets must report an empty usedBy list")
+	})
+}
+
+func TestConfigMapUsedBy(t *testing.T) {
+	runtime := loadCrossRefRuntime(t)
+
+	t.Run("configmap referenced from volume+env+envFrom+init", func(t *testing.T) {
+		obj, err := NewResource(runtime, "k8s.configmap", map[string]*llx.RawData{
+			"name":      llx.StringData("app-config"),
+			"namespace": llx.StringData("prod"),
+		})
+		require.NoError(t, err)
+		pods := obj.(*mqlK8sConfigmap).GetUsedBy()
+		require.NoError(t, pods.Error)
+		assert.Equal(t, []string{"api-7d4f-xyz"}, mqlResourceNames(t, pods.Data))
+	})
+
+	t.Run("orphan configmap has empty usedBy", func(t *testing.T) {
+		obj, err := NewResource(runtime, "k8s.configmap", map[string]*llx.RawData{
+			"name":      llx.StringData("orphan-config"),
+			"namespace": llx.StringData("prod"),
+		})
+		require.NoError(t, err)
+		pods := obj.(*mqlK8sConfigmap).GetUsedBy()
+		require.NoError(t, pods.Error)
+		assert.Empty(t, pods.Data)
+	})
+}
+
+// -----------------------------------------------------------------------------
+// RBAC traversal: subject resolution + roleRef kind dispatch + boundBy reverse.
+// -----------------------------------------------------------------------------
+
+func TestResolveServiceAccountSubjects(t *testing.T) {
+	runtime := loadCrossRefRuntime(t)
+
+	t.Run("explicit subject namespace is used", func(t *testing.T) {
+		out, err := resolveServiceAccountSubjects(runtime, []rbacv1.Subject{
+			{Kind: "ServiceAccount", Name: "api-sa", Namespace: "prod"},
+		}, "")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"api-sa"}, mqlResourceNames(t, out))
+	})
+
+	t.Run("missing namespace falls back to binding namespace", func(t *testing.T) {
+		out, err := resolveServiceAccountSubjects(runtime, []rbacv1.Subject{
+			{Kind: "ServiceAccount", Name: "api-sa"}, // namespace omitted
+		}, "prod")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"api-sa"}, mqlResourceNames(t, out))
+	})
+
+	t.Run("non-ServiceAccount subjects are skipped", func(t *testing.T) {
+		out, err := resolveServiceAccountSubjects(runtime, []rbacv1.Subject{
+			{Kind: "User", Name: "alice@example.com"},
+			{Kind: "Group", Name: "devs"},
+			{Kind: "ServiceAccount", Name: "api-sa", Namespace: "prod"},
+		}, "")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"api-sa"}, mqlResourceNames(t, out),
+			"User and Group subjects must be filtered out")
+	})
+
+	t.Run("missing namespace and no fallback skips the subject", func(t *testing.T) {
+		out, err := resolveServiceAccountSubjects(runtime, []rbacv1.Subject{
+			{Kind: "ServiceAccount", Name: "api-sa"}, // no namespace, no fallback
+		}, "")
+		require.NoError(t, err)
+		assert.Empty(t, out, "ServiceAccount with neither explicit namespace nor fallback must be skipped, not error")
+	})
+}
+
+func TestRoleBindingResolvers(t *testing.T) {
+	runtime := loadCrossRefRuntime(t)
+
+	t.Run("RoleBinding referencing a Role", func(t *testing.T) {
+		obj, err := NewResource(runtime, "k8s.rbac.rolebinding", map[string]*llx.RawData{
+			"name":      llx.StringData("read-secrets"),
+			"namespace": llx.StringData("prod"),
+		})
+		require.NoError(t, err)
+		rb := obj.(*mqlK8sRbacRolebinding)
+
+		role := rb.GetRole()
+		require.NoError(t, role.Error)
+		require.NotNil(t, role.Data)
+		assert.Equal(t, "secret-reader", role.Data.Name.Data)
+
+		// roleRef.kind=Role implies clusterRole() is null.
+		cr := rb.GetClusterRole()
+		require.NoError(t, cr.Error)
+		assert.Nil(t, cr.Data)
+		assert.True(t, cr.State&plugin.StateIsNull != 0)
+
+		sas := rb.GetServiceAccounts()
+		require.NoError(t, sas.Error)
+		assert.Equal(t, []string{"api-sa"}, mqlResourceNames(t, sas.Data),
+			"subject without explicit namespace must fall back to the binding's namespace")
+	})
+
+	t.Run("RoleBinding referencing a ClusterRole", func(t *testing.T) {
+		obj, err := NewResource(runtime, "k8s.rbac.rolebinding", map[string]*llx.RawData{
+			"name":      llx.StringData("read-pods-in-prod"),
+			"namespace": llx.StringData("prod"),
+		})
+		require.NoError(t, err)
+		rb := obj.(*mqlK8sRbacRolebinding)
+
+		// Mutually exclusive: role() is null when roleRef points at a ClusterRole.
+		role := rb.GetRole()
+		require.NoError(t, role.Error)
+		assert.Nil(t, role.Data)
+		assert.True(t, role.State&plugin.StateIsNull != 0)
+
+		cr := rb.GetClusterRole()
+		require.NoError(t, cr.Error)
+		require.NotNil(t, cr.Data)
+		assert.Equal(t, "pod-reader", cr.Data.Name.Data)
+	})
+}
+
+func TestClusterRoleBindingResolvers(t *testing.T) {
+	runtime := loadCrossRefRuntime(t)
+	obj, err := NewResource(runtime, "k8s.rbac.clusterrolebinding", map[string]*llx.RawData{
+		"name": llx.StringData("read-pods-everywhere"),
+	})
+	require.NoError(t, err)
+	crb := obj.(*mqlK8sRbacClusterrolebinding)
+
+	cr := crb.GetClusterRole()
+	require.NoError(t, cr.Error)
+	require.NotNil(t, cr.Data)
+	assert.Equal(t, "pod-reader", cr.Data.Name.Data)
+
+	// User subject must be filtered out; only ServiceAccount remains.
+	sas := crb.GetServiceAccounts()
+	require.NoError(t, sas.Error)
+	assert.Equal(t, []string{"api-sa"}, mqlResourceNames(t, sas.Data))
+}
+
+func TestRoleBoundBy(t *testing.T) {
+	runtime := loadCrossRefRuntime(t)
+	obj, err := NewResource(runtime, "k8s.rbac.role", map[string]*llx.RawData{
+		"name":      llx.StringData("secret-reader"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	r := obj.(*mqlK8sRbacRole)
+	rbs := r.GetBoundBy()
+	require.NoError(t, rbs.Error)
+	assert.Equal(t, []string{"read-secrets"}, mqlResourceNames(t, rbs.Data),
+		"Role.boundBy must return only RoleBindings whose roleRef.kind=Role and name matches; "+
+			"read-pods-in-prod targets the same namespace but references a ClusterRole and must be excluded")
+}
+
+func TestClusterRoleBoundBy(t *testing.T) {
+	runtime := loadCrossRefRuntime(t)
+	obj, err := NewResource(runtime, "k8s.rbac.clusterrole", map[string]*llx.RawData{
+		"name": llx.StringData("pod-reader"),
+	})
+	require.NoError(t, err)
+	cr := obj.(*mqlK8sRbacClusterrole)
+	crbs := cr.GetBoundBy()
+	require.NoError(t, crbs.Error)
+	assert.Equal(t, []string{"read-pods-everywhere"}, mqlResourceNames(t, crbs.Data),
+		"ClusterRole.boundBy must only walk ClusterRoleBindings, not RoleBindings that also reference the role")
+}
+
+// -----------------------------------------------------------------------------
+// Namespace accessors (filterByNamespace helper, used by 21 accessors).
+// -----------------------------------------------------------------------------
+
+func TestNamespaceAccessors(t *testing.T) {
+	runtime := loadCrossRefRuntime(t)
+
+	prod, err := NewResource(runtime, "k8s.namespace", map[string]*llx.RawData{
+		"name": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	ns := prod.(*mqlK8sNamespace)
+
+	pods := ns.GetPods()
+	require.NoError(t, pods.Error)
+	prodPodNames := mqlResourceNames(t, pods.Data)
+	assert.ElementsMatch(t,
+		[]string{"api-7d4f-xyz", "bare-pod", "db-0", "importer-pod", "standalone-pod"},
+		prodPodNames,
+		"namespace.pods must include every Pod in 'prod' and exclude the kube-system one")
+	for _, name := range prodPodNames {
+		assert.NotEqual(t, "fluentd-abc", name, "kube-system pod must not appear in prod.pods")
+	}
+
+	secrets := ns.GetSecrets()
+	require.NoError(t, secrets.Error)
+	assert.ElementsMatch(t, []string{"db-creds", "orphan-secret", "regcred"}, mqlResourceNames(t, secrets.Data))
+
+	cfgs := ns.GetConfigmaps()
+	require.NoError(t, cfgs.Error)
+	assert.ElementsMatch(t, []string{"app-config", "orphan-config"}, mqlResourceNames(t, cfgs.Data))
+
+	deps := ns.GetDeployments()
+	require.NoError(t, deps.Error)
+	assert.Equal(t, []string{"api"}, mqlResourceNames(t, deps.Data))
+
+	cronjobs := ns.GetCronjobs()
+	require.NoError(t, cronjobs.Error)
+	assert.Equal(t, []string{"weekly-cleanup"}, mqlResourceNames(t, cronjobs.Data))
+
+	// kube-system must see the daemonset, not the prod resources.
+	kubeSys, err := NewResource(runtime, "k8s.namespace", map[string]*llx.RawData{
+		"name": llx.StringData("kube-system"),
+	})
+	require.NoError(t, err)
+	ksDS := kubeSys.(*mqlK8sNamespace).GetDaemonsets()
+	require.NoError(t, ksDS.Error)
+	assert.Equal(t, []string{"fluentd"}, mqlResourceNames(t, ksDS.Data))
+	ksPods := kubeSys.(*mqlK8sNamespace).GetPods()
+	require.NoError(t, ksPods.Error)
+	assert.Equal(t, []string{"fluentd-abc"}, mqlResourceNames(t, ksPods.Data))
+}
+
+// -----------------------------------------------------------------------------
+// Job/CronJob nullable defaults — the bot reviewer caught two of these on
+// the original PR (completions, completionMode), so these are sentinels.
+// -----------------------------------------------------------------------------
+
+func TestJobDefaults(t *testing.T) {
+	runtime := loadCrossRefRuntime(t)
+	obj, err := NewResource(runtime, "k8s.job", map[string]*llx.RawData{
+		"name":      llx.StringData("importer"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	j := obj.(*mqlK8sJob)
+
+	// completionMode unset in the fixture → must default to "NonIndexed", not "".
+	cm := j.GetCompletionMode()
+	require.NoError(t, cm.Error)
+	assert.Equal(t, "NonIndexed", cm.Data,
+		"completionMode default regressed if this is empty — k8s API default is NonIndexed")
+
+	// completions unset → must fall back to parallelism, not 0.
+	completions := j.GetCompletions()
+	require.NoError(t, completions.Error)
+	parallelism := j.GetParallelism()
+	require.NoError(t, parallelism.Error)
+	assert.Equal(t, parallelism.Data, completions.Data,
+		"completions default regressed if this is 0 — k8s API default is one completion per parallelism")
+
+	// backoffLimit unset → must default to 6, not 0.
+	bl := j.GetBackoffLimit()
+	require.NoError(t, bl.Error)
+	assert.Equal(t, int64(6), bl.Data, "backoffLimit default must be the k8s API default of 6")
+}

--- a/providers/k8s/resources/endpointslice.go
+++ b/providers/k8s/resources/endpointslice.go
@@ -74,3 +74,19 @@ func (k *mqlK8sEndpointslice) annotations() (map[string]any, error) {
 func (k *mqlK8sEndpointslice) labels() (map[string]any, error) {
 	return convert.MapToInterfaceMap(k.obj.GetLabels()), nil
 }
+
+func (k *mqlK8sEndpointslice) service() (*mqlK8sService, error) {
+	svcName := k.obj.Labels["kubernetes.io/service-name"]
+	if svcName == "" {
+		k.Service.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	r, err := NewResource(k.MqlRuntime, "k8s.service", map[string]*llx.RawData{
+		"name":      llx.StringData(svcName),
+		"namespace": llx.StringData(k.obj.Namespace),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.(*mqlK8sService), nil
+}

--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -1252,6 +1252,8 @@ private k8s.rbac.clusterrole @defaults("name created") {
   rules []dict
   // ClusterRole aggregation rule
   aggregationRule dict
+  // ClusterRoleBindings that reference this ClusterRole via roleRef
+  boundBy() []k8s.rbac.clusterrolebinding
 }
 
 // Kubernetes ClusterRoleBinding
@@ -1278,6 +1280,10 @@ private k8s.rbac.clusterrolebinding @defaults("name created") {
   subjects []dict
   // ClusterRole in the global namespace
   roleRef dict
+  // ServiceAccounts referenced as subjects (entries where kind == "ServiceAccount" resolved to typed resources)
+  serviceAccounts() []k8s.serviceaccount
+  // The ClusterRole granted by this binding (roleRef.name)
+  clusterRole() k8s.rbac.clusterrole
 }
 
 // Kubernetes Role
@@ -1304,6 +1310,8 @@ private k8s.rbac.role @defaults("name namespace") {
   manifest() dict
   // Role rules defining the permissions granted within this namespace
   rules []dict
+  // RoleBindings in this namespace that reference this Role via roleRef
+  boundBy() []k8s.rbac.rolebinding
 }
 
 // Kubernetes RoleBinding
@@ -1332,6 +1340,12 @@ private k8s.rbac.rolebinding @defaults("name namespace created") {
   subjects []dict
   // RoleRef can only reference a ClusterRole in the global namespace
   roleRef dict
+  // ServiceAccounts referenced as subjects (entries where kind == "ServiceAccount" resolved to typed resources)
+  serviceAccounts() []k8s.serviceaccount
+  // The Role granted by this binding (null when roleRef points to a ClusterRole)
+  role() k8s.rbac.role
+  // The ClusterRole granted by this binding (null when roleRef points to a Role)
+  clusterRole() k8s.rbac.clusterrole
 }
 
 // Kubernetes Network Policy
@@ -1596,6 +1610,14 @@ private k8s.resourcequota @defaults("namespace name created") {
   spec() dict
   // ResourceQuota status
   status() dict
+  // Hard limits enforced by the quota (resource name -> quantity string)
+  hard() map[string]string
+  // Current usage observed against the quota (resource name -> quantity string)
+  used() map[string]string
+  // Scopes to which the quota applies (e.g., Terminating, NotTerminating, BestEffort, NotBestEffort, PriorityClass, CrossNamespacePodAffinity)
+  scopes() []string
+  // Scope selector for fine-grained scope matching (operators on scope names)
+  scopeSelector() dict
 }
 
 // Kubernetes LimitRange
@@ -1622,6 +1644,8 @@ private k8s.limitrange @defaults("namespace name created") {
   manifest() dict
   // LimitRange spec
   spec() dict
+  // Limit items keyed by resource type (Container, Pod, PersistentVolumeClaim): default, defaultRequest, max, min, maxLimitRequestRatio
+  limits() []dict
 }
 
 // Kubernetes PersistentVolumeClaim
@@ -1708,6 +1732,8 @@ private k8s.endpointslice @defaults("namespace name addressType") {
   endpoints() []dict
   // List of network ports exposed by each endpoint
   ports() []dict
+  // The Service this slice backs (resolved from the kubernetes.io/service-name label)
+  service() k8s.service
 }
 
 // Kubernetes AdmissionReview

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -2053,6 +2053,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.rbac.clusterrole.aggregationRule": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacClusterrole).GetAggregationRule()).ToDataRes(types.Dict)
 	},
+	"k8s.rbac.clusterrole.boundBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRbacClusterrole).GetBoundBy()).ToDataRes(types.Array(types.Resource("k8s.rbac.clusterrolebinding")))
+	},
 	"k8s.rbac.clusterrolebinding.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacClusterrolebinding).GetId()).ToDataRes(types.String)
 	},
@@ -2086,6 +2089,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.rbac.clusterrolebinding.roleRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacClusterrolebinding).GetRoleRef()).ToDataRes(types.Dict)
 	},
+	"k8s.rbac.clusterrolebinding.serviceAccounts": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRbacClusterrolebinding).GetServiceAccounts()).ToDataRes(types.Array(types.Resource("k8s.serviceaccount")))
+	},
+	"k8s.rbac.clusterrolebinding.clusterRole": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRbacClusterrolebinding).GetClusterRole()).ToDataRes(types.Resource("k8s.rbac.clusterrole"))
+	},
 	"k8s.rbac.role.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacRole).GetId()).ToDataRes(types.String)
 	},
@@ -2118,6 +2127,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.rbac.role.rules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacRole).GetRules()).ToDataRes(types.Array(types.Dict))
+	},
+	"k8s.rbac.role.boundBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRbacRole).GetBoundBy()).ToDataRes(types.Array(types.Resource("k8s.rbac.rolebinding")))
 	},
 	"k8s.rbac.rolebinding.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacRolebinding).GetId()).ToDataRes(types.String)
@@ -2154,6 +2166,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.rbac.rolebinding.roleRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sRbacRolebinding).GetRoleRef()).ToDataRes(types.Dict)
+	},
+	"k8s.rbac.rolebinding.serviceAccounts": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRbacRolebinding).GetServiceAccounts()).ToDataRes(types.Array(types.Resource("k8s.serviceaccount")))
+	},
+	"k8s.rbac.rolebinding.role": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRbacRolebinding).GetRole()).ToDataRes(types.Resource("k8s.rbac.role"))
+	},
+	"k8s.rbac.rolebinding.clusterRole": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRbacRolebinding).GetClusterRole()).ToDataRes(types.Resource("k8s.rbac.clusterrole"))
 	},
 	"k8s.networkpolicy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sNetworkpolicy).GetId()).ToDataRes(types.String)
@@ -2509,6 +2530,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.resourcequota.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sResourcequota).GetStatus()).ToDataRes(types.Dict)
 	},
+	"k8s.resourcequota.hard": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sResourcequota).GetHard()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"k8s.resourcequota.used": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sResourcequota).GetUsed()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"k8s.resourcequota.scopes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sResourcequota).GetScopes()).ToDataRes(types.Array(types.String))
+	},
+	"k8s.resourcequota.scopeSelector": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sResourcequota).GetScopeSelector()).ToDataRes(types.Dict)
+	},
 	"k8s.limitrange.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sLimitrange).GetId()).ToDataRes(types.String)
 	},
@@ -2541,6 +2574,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.limitrange.spec": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sLimitrange).GetSpec()).ToDataRes(types.Dict)
+	},
+	"k8s.limitrange.limits": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sLimitrange).GetLimits()).ToDataRes(types.Array(types.Dict))
 	},
 	"k8s.persistentvolumeclaim.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPersistentvolumeclaim).GetId()).ToDataRes(types.String)
@@ -2658,6 +2694,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.endpointslice.ports": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sEndpointslice).GetPorts()).ToDataRes(types.Array(types.Dict))
+	},
+	"k8s.endpointslice.service": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sEndpointslice).GetService()).ToDataRes(types.Resource("k8s.service"))
 	},
 	"k8s.admissionreview.request": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sAdmissionreview).GetRequest()).ToDataRes(types.Resource("k8s.admissionrequest"))
@@ -5587,6 +5626,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sRbacClusterrole).AggregationRule, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"k8s.rbac.clusterrole.boundBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRbacClusterrole).BoundBy, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"k8s.rbac.clusterrolebinding.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sRbacClusterrolebinding).__id, ok = v.Value.(string)
 		return
@@ -5635,6 +5678,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sRbacClusterrolebinding).RoleRef, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"k8s.rbac.clusterrolebinding.serviceAccounts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRbacClusterrolebinding).ServiceAccounts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.rbac.clusterrolebinding.clusterRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRbacClusterrolebinding).ClusterRole, ok = plugin.RawToTValue[*mqlK8sRbacClusterrole](v.Value, v.Error)
+		return
+	},
 	"k8s.rbac.role.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sRbacRole).__id, ok = v.Value.(string)
 		return
@@ -5681,6 +5732,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.rbac.role.rules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sRbacRole).Rules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.rbac.role.boundBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRbacRole).BoundBy, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.rbac.rolebinding.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5733,6 +5788,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.rbac.rolebinding.roleRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sRbacRolebinding).RoleRef, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"k8s.rbac.rolebinding.serviceAccounts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRbacRolebinding).ServiceAccounts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.rbac.rolebinding.role": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRbacRolebinding).Role, ok = plugin.RawToTValue[*mqlK8sRbacRole](v.Value, v.Error)
+		return
+	},
+	"k8s.rbac.rolebinding.clusterRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRbacRolebinding).ClusterRole, ok = plugin.RawToTValue[*mqlK8sRbacClusterrole](v.Value, v.Error)
 		return
 	},
 	"k8s.networkpolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6235,6 +6302,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sResourcequota).Status, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"k8s.resourcequota.hard": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sResourcequota).Hard, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"k8s.resourcequota.used": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sResourcequota).Used, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"k8s.resourcequota.scopes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sResourcequota).Scopes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.resourcequota.scopeSelector": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sResourcequota).ScopeSelector, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
 	"k8s.limitrange.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sLimitrange).__id, ok = v.Value.(string)
 		return
@@ -6281,6 +6364,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.limitrange.spec": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sLimitrange).Spec, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"k8s.limitrange.limits": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sLimitrange).Limits, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.persistentvolumeclaim.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6445,6 +6532,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.endpointslice.ports": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sEndpointslice).Ports, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.endpointslice.service": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sEndpointslice).Service, ok = plugin.RawToTValue[*mqlK8sService](v.Value, v.Error)
 		return
 	},
 	"k8s.admissionreview.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12988,6 +13079,7 @@ type mqlK8sRbacClusterrole struct {
 	Manifest        plugin.TValue[any]
 	Rules           plugin.TValue[[]any]
 	AggregationRule plugin.TValue[any]
+	BoundBy         plugin.TValue[[]any]
 }
 
 // createK8sRbacClusterrole creates a new instance of this resource
@@ -13077,6 +13169,22 @@ func (c *mqlK8sRbacClusterrole) GetAggregationRule() *plugin.TValue[any] {
 	return &c.AggregationRule
 }
 
+func (c *mqlK8sRbacClusterrole) GetBoundBy() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.BoundBy, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.rbac.clusterrole", c.__id, "boundBy")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.boundBy()
+	})
+}
+
 // mqlK8sRbacClusterrolebinding for the k8s.rbac.clusterrolebinding resource
 type mqlK8sRbacClusterrolebinding struct {
 	MqlRuntime *plugin.Runtime
@@ -13093,6 +13201,8 @@ type mqlK8sRbacClusterrolebinding struct {
 	Manifest        plugin.TValue[any]
 	Subjects        plugin.TValue[[]any]
 	RoleRef         plugin.TValue[any]
+	ServiceAccounts plugin.TValue[[]any]
+	ClusterRole     plugin.TValue[*mqlK8sRbacClusterrole]
 }
 
 // createK8sRbacClusterrolebinding creates a new instance of this resource
@@ -13182,6 +13292,38 @@ func (c *mqlK8sRbacClusterrolebinding) GetRoleRef() *plugin.TValue[any] {
 	return &c.RoleRef
 }
 
+func (c *mqlK8sRbacClusterrolebinding) GetServiceAccounts() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ServiceAccounts, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.rbac.clusterrolebinding", c.__id, "serviceAccounts")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.serviceAccounts()
+	})
+}
+
+func (c *mqlK8sRbacClusterrolebinding) GetClusterRole() *plugin.TValue[*mqlK8sRbacClusterrole] {
+	return plugin.GetOrCompute[*mqlK8sRbacClusterrole](&c.ClusterRole, func() (*mqlK8sRbacClusterrole, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.rbac.clusterrolebinding", c.__id, "clusterRole")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sRbacClusterrole), nil
+			}
+		}
+
+		return c.clusterRole()
+	})
+}
+
 // mqlK8sRbacRole for the k8s.rbac.role resource
 type mqlK8sRbacRole struct {
 	MqlRuntime *plugin.Runtime
@@ -13198,6 +13340,7 @@ type mqlK8sRbacRole struct {
 	Created         plugin.TValue[*time.Time]
 	Manifest        plugin.TValue[any]
 	Rules           plugin.TValue[[]any]
+	BoundBy         plugin.TValue[[]any]
 }
 
 // createK8sRbacRole creates a new instance of this resource
@@ -13287,6 +13430,22 @@ func (c *mqlK8sRbacRole) GetRules() *plugin.TValue[[]any] {
 	return &c.Rules
 }
 
+func (c *mqlK8sRbacRole) GetBoundBy() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.BoundBy, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.rbac.role", c.__id, "boundBy")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.boundBy()
+	})
+}
+
 // mqlK8sRbacRolebinding for the k8s.rbac.rolebinding resource
 type mqlK8sRbacRolebinding struct {
 	MqlRuntime *plugin.Runtime
@@ -13304,6 +13463,9 @@ type mqlK8sRbacRolebinding struct {
 	Manifest        plugin.TValue[any]
 	Subjects        plugin.TValue[[]any]
 	RoleRef         plugin.TValue[any]
+	ServiceAccounts plugin.TValue[[]any]
+	Role            plugin.TValue[*mqlK8sRbacRole]
+	ClusterRole     plugin.TValue[*mqlK8sRbacClusterrole]
 }
 
 // createK8sRbacRolebinding creates a new instance of this resource
@@ -13395,6 +13557,54 @@ func (c *mqlK8sRbacRolebinding) GetSubjects() *plugin.TValue[[]any] {
 
 func (c *mqlK8sRbacRolebinding) GetRoleRef() *plugin.TValue[any] {
 	return &c.RoleRef
+}
+
+func (c *mqlK8sRbacRolebinding) GetServiceAccounts() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ServiceAccounts, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.rbac.rolebinding", c.__id, "serviceAccounts")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.serviceAccounts()
+	})
+}
+
+func (c *mqlK8sRbacRolebinding) GetRole() *plugin.TValue[*mqlK8sRbacRole] {
+	return plugin.GetOrCompute[*mqlK8sRbacRole](&c.Role, func() (*mqlK8sRbacRole, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.rbac.rolebinding", c.__id, "role")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sRbacRole), nil
+			}
+		}
+
+		return c.role()
+	})
+}
+
+func (c *mqlK8sRbacRolebinding) GetClusterRole() *plugin.TValue[*mqlK8sRbacClusterrole] {
+	return plugin.GetOrCompute[*mqlK8sRbacClusterrole](&c.ClusterRole, func() (*mqlK8sRbacClusterrole, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.rbac.rolebinding", c.__id, "clusterRole")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sRbacClusterrole), nil
+			}
+		}
+
+		return c.clusterRole()
+	})
 }
 
 // mqlK8sNetworkpolicy for the k8s.networkpolicy resource
@@ -14376,6 +14586,10 @@ type mqlK8sResourcequota struct {
 	Manifest        plugin.TValue[any]
 	Spec            plugin.TValue[any]
 	Status          plugin.TValue[any]
+	Hard            plugin.TValue[map[string]any]
+	Used            plugin.TValue[map[string]any]
+	Scopes          plugin.TValue[[]any]
+	ScopeSelector   plugin.TValue[any]
 }
 
 // createK8sResourcequota creates a new instance of this resource
@@ -14473,6 +14687,30 @@ func (c *mqlK8sResourcequota) GetStatus() *plugin.TValue[any] {
 	})
 }
 
+func (c *mqlK8sResourcequota) GetHard() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Hard, func() (map[string]any, error) {
+		return c.hard()
+	})
+}
+
+func (c *mqlK8sResourcequota) GetUsed() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Used, func() (map[string]any, error) {
+		return c.used()
+	})
+}
+
+func (c *mqlK8sResourcequota) GetScopes() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Scopes, func() ([]any, error) {
+		return c.scopes()
+	})
+}
+
+func (c *mqlK8sResourcequota) GetScopeSelector() *plugin.TValue[any] {
+	return plugin.GetOrCompute[any](&c.ScopeSelector, func() (any, error) {
+		return c.scopeSelector()
+	})
+}
+
 // mqlK8sLimitrange for the k8s.limitrange resource
 type mqlK8sLimitrange struct {
 	MqlRuntime *plugin.Runtime
@@ -14489,6 +14727,7 @@ type mqlK8sLimitrange struct {
 	Created         plugin.TValue[*time.Time]
 	Manifest        plugin.TValue[any]
 	Spec            plugin.TValue[any]
+	Limits          plugin.TValue[[]any]
 }
 
 // createK8sLimitrange creates a new instance of this resource
@@ -14577,6 +14816,12 @@ func (c *mqlK8sLimitrange) GetManifest() *plugin.TValue[any] {
 func (c *mqlK8sLimitrange) GetSpec() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.Spec, func() (any, error) {
 		return c.spec()
+	})
+}
+
+func (c *mqlK8sLimitrange) GetLimits() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Limits, func() ([]any, error) {
+		return c.limits()
 	})
 }
 
@@ -14830,6 +15075,7 @@ type mqlK8sEndpointslice struct {
 	AddressType     plugin.TValue[string]
 	Endpoints       plugin.TValue[[]any]
 	Ports           plugin.TValue[[]any]
+	Service         plugin.TValue[*mqlK8sService]
 }
 
 // createK8sEndpointslice creates a new instance of this resource
@@ -14928,6 +15174,22 @@ func (c *mqlK8sEndpointslice) GetEndpoints() *plugin.TValue[[]any] {
 func (c *mqlK8sEndpointslice) GetPorts() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Ports, func() ([]any, error) {
 		return c.ports()
+	})
+}
+
+func (c *mqlK8sEndpointslice) GetService() *plugin.TValue[*mqlK8sService] {
+	return plugin.GetOrCompute[*mqlK8sService](&c.Service, func() (*mqlK8sService, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.endpointslice", c.__id, "service")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sService), nil
+			}
+		}
+
+		return c.service()
 	})
 }
 

--- a/providers/k8s/resources/k8s.lr.versions
+++ b/providers/k8s/resources/k8s.lr.versions
@@ -261,6 +261,7 @@ k8s.endpointslice.name 11.1.139
 k8s.endpointslice.namespace 11.1.139
 k8s.endpointslice.ports 11.1.139
 k8s.endpointslice.resourceVersion 11.1.139
+k8s.endpointslice.service 13.0.16
 k8s.endpointslice.uid 11.1.139
 k8s.ephemeralContainer 9.0.0
 k8s.ephemeralContainer.args 9.0.0
@@ -526,6 +527,7 @@ k8s.limitrange.created 11.1.139
 k8s.limitrange.id 11.1.139
 k8s.limitrange.kind 11.1.139
 k8s.limitrange.labels 11.1.139
+k8s.limitrange.limits 13.0.16
 k8s.limitrange.manifest 11.1.139
 k8s.limitrange.name 11.1.139
 k8s.limitrange.namespace 11.1.139
@@ -787,6 +789,7 @@ k8s.priorityclass.value 11.1.139
 k8s.rbac.clusterrole 9.0.0
 k8s.rbac.clusterrole.aggregationRule 9.0.0
 k8s.rbac.clusterrole.annotations 9.0.0
+k8s.rbac.clusterrole.boundBy 13.0.16
 k8s.rbac.clusterrole.created 9.0.0
 k8s.rbac.clusterrole.id 9.0.0
 k8s.rbac.clusterrole.kind 9.0.0
@@ -798,6 +801,7 @@ k8s.rbac.clusterrole.rules 9.0.0
 k8s.rbac.clusterrole.uid 9.0.0
 k8s.rbac.clusterrolebinding 9.0.0
 k8s.rbac.clusterrolebinding.annotations 9.0.0
+k8s.rbac.clusterrolebinding.clusterRole 13.0.16
 k8s.rbac.clusterrolebinding.created 9.0.0
 k8s.rbac.clusterrolebinding.id 9.0.0
 k8s.rbac.clusterrolebinding.kind 9.0.0
@@ -806,10 +810,12 @@ k8s.rbac.clusterrolebinding.manifest 9.0.0
 k8s.rbac.clusterrolebinding.name 9.0.0
 k8s.rbac.clusterrolebinding.resourceVersion 9.0.0
 k8s.rbac.clusterrolebinding.roleRef 9.0.0
+k8s.rbac.clusterrolebinding.serviceAccounts 13.0.16
 k8s.rbac.clusterrolebinding.subjects 9.0.0
 k8s.rbac.clusterrolebinding.uid 9.0.0
 k8s.rbac.role 9.0.0
 k8s.rbac.role.annotations 9.0.0
+k8s.rbac.role.boundBy 13.0.16
 k8s.rbac.role.created 9.0.0
 k8s.rbac.role.id 9.0.0
 k8s.rbac.role.kind 9.0.0
@@ -822,6 +828,7 @@ k8s.rbac.role.rules 9.0.0
 k8s.rbac.role.uid 9.0.0
 k8s.rbac.rolebinding 9.0.0
 k8s.rbac.rolebinding.annotations 9.0.0
+k8s.rbac.rolebinding.clusterRole 13.0.16
 k8s.rbac.rolebinding.created 9.0.0
 k8s.rbac.rolebinding.id 9.0.0
 k8s.rbac.rolebinding.kind 9.0.0
@@ -830,7 +837,9 @@ k8s.rbac.rolebinding.manifest 9.0.0
 k8s.rbac.rolebinding.name 9.0.0
 k8s.rbac.rolebinding.namespace 9.0.0
 k8s.rbac.rolebinding.resourceVersion 9.0.0
+k8s.rbac.rolebinding.role 13.0.16
 k8s.rbac.rolebinding.roleRef 9.0.0
+k8s.rbac.rolebinding.serviceAccounts 13.0.16
 k8s.rbac.rolebinding.subjects 9.0.0
 k8s.rbac.rolebinding.uid 9.0.0
 k8s.referenceGrants 13.0.16
@@ -876,6 +885,7 @@ k8s.resourceQuotas 11.1.139
 k8s.resourcequota 11.1.139
 k8s.resourcequota.annotations 11.1.139
 k8s.resourcequota.created 11.1.139
+k8s.resourcequota.hard 13.0.16
 k8s.resourcequota.id 11.1.139
 k8s.resourcequota.kind 11.1.139
 k8s.resourcequota.labels 11.1.139
@@ -883,9 +893,12 @@ k8s.resourcequota.manifest 11.1.139
 k8s.resourcequota.name 11.1.139
 k8s.resourcequota.namespace 11.1.139
 k8s.resourcequota.resourceVersion 11.1.139
+k8s.resourcequota.scopeSelector 13.0.16
+k8s.resourcequota.scopes 13.0.16
 k8s.resourcequota.spec 11.1.139
 k8s.resourcequota.status 11.1.139
 k8s.resourcequota.uid 11.1.139
+k8s.resourcequota.used 13.0.16
 k8s.rolebindings 9.0.0
 k8s.roles 9.0.0
 k8s.secret 9.0.0

--- a/providers/k8s/resources/limitrange.go
+++ b/providers/k8s/resources/limitrange.go
@@ -69,3 +69,7 @@ func (k *mqlK8sLimitrange) annotations() (map[string]any, error) {
 func (k *mqlK8sLimitrange) labels() (map[string]any, error) {
 	return convert.MapToInterfaceMap(k.obj.GetLabels()), nil
 }
+
+func (k *mqlK8sLimitrange) limits() ([]any, error) {
+	return convert.JsonToDictSlice(k.obj.Spec.Limits)
+}

--- a/providers/k8s/resources/resourcequota.go
+++ b/providers/k8s/resources/resourcequota.go
@@ -73,3 +73,31 @@ func (k *mqlK8sResourcequota) annotations() (map[string]any, error) {
 func (k *mqlK8sResourcequota) labels() (map[string]any, error) {
 	return convert.MapToInterfaceMap(k.obj.GetLabels()), nil
 }
+
+func (k *mqlK8sResourcequota) hard() (map[string]any, error) {
+	out := make(map[string]any, len(k.obj.Spec.Hard))
+	for name, qty := range k.obj.Spec.Hard {
+		out[string(name)] = qty.String()
+	}
+	return out, nil
+}
+
+func (k *mqlK8sResourcequota) used() (map[string]any, error) {
+	out := make(map[string]any, len(k.obj.Status.Used))
+	for name, qty := range k.obj.Status.Used {
+		out[string(name)] = qty.String()
+	}
+	return out, nil
+}
+
+func (k *mqlK8sResourcequota) scopes() ([]any, error) {
+	out := make([]any, len(k.obj.Spec.Scopes))
+	for i, s := range k.obj.Spec.Scopes {
+		out[i] = string(s)
+	}
+	return out, nil
+}
+
+func (k *mqlK8sResourcequota) scopeSelector() (map[string]any, error) {
+	return convert.JsonToDict(k.obj.Spec.ScopeSelector)
+}

--- a/providers/k8s/resources/role.go
+++ b/providers/k8s/resources/role.go
@@ -76,3 +76,31 @@ func (k *mqlK8sRbacRole) annotations() (map[string]any, error) {
 func (k *mqlK8sRbacRole) labels() (map[string]any, error) {
 	return convert.MapToInterfaceMap(k.obj.GetLabels()), nil
 }
+
+func (k *mqlK8sRbacRole) boundBy() ([]any, error) {
+	o, err := CreateResource(k.MqlRuntime, "k8s", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	rbs := o.(*mqlK8s).GetRolebindings()
+	if rbs.Error != nil {
+		return nil, rbs.Error
+	}
+
+	roleName := k.Name.Data
+	namespace := k.Namespace.Data
+	out := []any{}
+	for i := range rbs.Data {
+		rb, ok := rbs.Data[i].(*mqlK8sRbacRolebinding)
+		if !ok {
+			continue
+		}
+		if rb.Namespace.Data != namespace {
+			continue
+		}
+		if rb.obj.RoleRef.Kind == "Role" && rb.obj.RoleRef.Name == roleName {
+			out = append(out, rb)
+		}
+	}
+	return out, nil
+}

--- a/providers/k8s/resources/rolebinding.go
+++ b/providers/k8s/resources/rolebinding.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"errors"
+	"strings"
 	"sync"
 
 	"go.mondoo.com/mql/v13/llx"
@@ -140,7 +141,12 @@ func resolveServiceAccountSubjects(runtime *plugin.Runtime, subjects []rbacv1.Su
 		})
 		if err != nil {
 			// Subject points at a SA that doesn't exist (e.g., deleted) — skip.
-			continue
+			// Anything else (transient API error, etc.) must surface; otherwise
+			// a connectivity blip silently empties the subject list.
+			if strings.Contains(err.Error(), "not found") {
+				continue
+			}
+			return nil, err
 		}
 		out = append(out, r)
 	}

--- a/providers/k8s/resources/rolebinding.go
+++ b/providers/k8s/resources/rolebinding.go
@@ -82,3 +82,67 @@ func (k *mqlK8sRbacRolebinding) annotations() (map[string]any, error) {
 func (k *mqlK8sRbacRolebinding) labels() (map[string]any, error) {
 	return convert.MapToInterfaceMap(k.obj.GetLabels()), nil
 }
+
+func (k *mqlK8sRbacRolebinding) serviceAccounts() ([]any, error) {
+	return resolveServiceAccountSubjects(k.MqlRuntime, k.obj.Subjects, k.obj.Namespace)
+}
+
+func (k *mqlK8sRbacRolebinding) role() (*mqlK8sRbacRole, error) {
+	if k.obj.RoleRef.Kind != "Role" || k.obj.RoleRef.Name == "" {
+		k.Role.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	r, err := NewResource(k.MqlRuntime, "k8s.rbac.role", map[string]*llx.RawData{
+		"name":      llx.StringData(k.obj.RoleRef.Name),
+		"namespace": llx.StringData(k.obj.Namespace),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.(*mqlK8sRbacRole), nil
+}
+
+func (k *mqlK8sRbacRolebinding) clusterRole() (*mqlK8sRbacClusterrole, error) {
+	if k.obj.RoleRef.Kind != "ClusterRole" || k.obj.RoleRef.Name == "" {
+		k.ClusterRole.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	r, err := NewResource(k.MqlRuntime, "k8s.rbac.clusterrole", map[string]*llx.RawData{
+		"name": llx.StringData(k.obj.RoleRef.Name),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.(*mqlK8sRbacClusterrole), nil
+}
+
+// resolveServiceAccountSubjects resolves the ServiceAccount entries in an RBAC
+// subjects list to typed k8s.serviceaccount resources. Subjects with kinds
+// other than "ServiceAccount" are skipped. A subject's namespace falls back to
+// the binding's namespace when omitted (matches kube-apiserver behavior for
+// RoleBindings).
+func resolveServiceAccountSubjects(runtime *plugin.Runtime, subjects []rbacv1.Subject, fallbackNamespace string) ([]any, error) {
+	out := []any{}
+	for _, s := range subjects {
+		if s.Kind != "ServiceAccount" {
+			continue
+		}
+		ns := s.Namespace
+		if ns == "" {
+			ns = fallbackNamespace
+		}
+		if ns == "" || s.Name == "" {
+			continue
+		}
+		r, err := NewResource(runtime, "k8s.serviceaccount", map[string]*llx.RawData{
+			"name":      llx.StringData(s.Name),
+			"namespace": llx.StringData(ns),
+		})
+		if err != nil {
+			// Subject points at a SA that doesn't exist (e.g., deleted) — skip.
+			continue
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}

--- a/providers/k8s/resources/testdata/cross_references.yaml
+++ b/providers/k8s/resources/testdata/cross_references.yaml
@@ -1,0 +1,556 @@
+# Comprehensive fixture for cross-reference resolver tests:
+#   - Pod owner refs (replicaSet, statefulSet, daemonSet, job, deployment 2-hop)
+#   - Workload pods() via spec.selector (matchLabels + matchExpressions)
+#   - CronJob activeJobs (UID match) + jobs (ownerReference UID filter)
+#   - Service ↔ EndpointSlice (kubernetes.io/service-name label)
+#   - Secret + ConfigMap usedBy (volumes, projected, env, envFrom, imagePullSecrets,
+#     init + ephemeral containers)
+#   - RBAC subjects → ServiceAccount, roleRef → Role/ClusterRole, boundBy reverse lookup
+#   - filterByNamespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prod
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-system
+---
+# ServiceAccount referenced by RBAC bindings and as a pod imagePullSecret target
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: api-sa
+  namespace: prod
+---
+# Secret referenced from every supported path (so usedBy must find one pod)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-creds
+  namespace: prod
+type: Opaque
+data:
+  password: c2VjcmV0
+---
+# Unused secret — secret.usedBy.length == 0 should select this
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orphan-secret
+  namespace: prod
+type: Opaque
+data:
+  key: dmFsdWU=
+---
+# Image-pull secret target — referenced via spec.imagePullSecrets
+apiVersion: v1
+kind: Secret
+metadata:
+  name: regcred
+  namespace: prod
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: e30=
+---
+# ConfigMap referenced from volume, env, envFrom, init container, ephemeral container
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+  namespace: prod
+data:
+  LOG_LEVEL: info
+---
+# Unused ConfigMap
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orphan-config
+  namespace: prod
+data:
+  unused: "true"
+---
+# Deployment → ReplicaSet → Pod ownership chain (for pod.deployment 2-hop)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: prod
+  uid: dep-uid-api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+        - name: api
+          image: nginx:1.27
+---
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: api-7d4f
+  namespace: prod
+  uid: rs-uid-api
+  ownerReferences:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: api
+      uid: dep-uid-api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+        - name: api
+          image: nginx:1.27
+---
+# An orphan ReplicaSet with no Deployment owner — verifies pod.deployment() returns null
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: standalone-rs
+  namespace: prod
+  uid: rs-uid-standalone
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: standalone
+  template:
+    metadata:
+      labels:
+        app: standalone
+    spec:
+      containers:
+        - name: app
+          image: busybox
+---
+# Pod owned by the api ReplicaSet — tests pod.replicaSet + pod.deployment 2-hop
+apiVersion: v1
+kind: Pod
+metadata:
+  name: api-7d4f-xyz
+  namespace: prod
+  labels:
+    app: api
+  ownerReferences:
+    - apiVersion: apps/v1
+      kind: ReplicaSet
+      name: api-7d4f
+      uid: rs-uid-api
+spec:
+  serviceAccountName: api-sa
+  imagePullSecrets:
+    - name: regcred
+  initContainers:
+    - name: migrate
+      image: migrate:1.0
+      env:
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: db-creds
+              key: password
+      envFrom:
+        - configMapRef:
+            name: app-config
+  containers:
+    - name: api
+      image: nginx:1.27
+      env:
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: db-creds
+              key: password
+      envFrom:
+        - secretRef:
+            name: db-creds
+        - configMapRef:
+            name: app-config
+      volumeMounts:
+        - name: creds-vol
+          mountPath: /etc/creds
+        - name: config-vol
+          mountPath: /etc/config
+        - name: projected-vol
+          mountPath: /etc/projected
+  ephemeralContainers:
+    - name: debugger
+      image: busybox
+      env:
+        - name: SECRET_PEEK
+          valueFrom:
+            secretKeyRef:
+              name: db-creds
+              key: password
+  volumes:
+    - name: creds-vol
+      secret:
+        secretName: db-creds
+    - name: config-vol
+      configMap:
+        name: app-config
+    - name: projected-vol
+      projected:
+        sources:
+          - secret:
+              name: db-creds
+          - configMap:
+              name: app-config
+status:
+  phase: Running
+---
+# Pod owned by the orphan ReplicaSet — pod.deployment must be null even though replicaSet is set
+apiVersion: v1
+kind: Pod
+metadata:
+  name: standalone-pod
+  namespace: prod
+  labels:
+    app: standalone
+  ownerReferences:
+    - apiVersion: apps/v1
+      kind: ReplicaSet
+      name: standalone-rs
+      uid: rs-uid-standalone
+spec:
+  containers:
+    - name: app
+      image: busybox
+status:
+  phase: Running
+---
+# Pod with no owner refs — every typed owner accessor should return null
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bare-pod
+  namespace: prod
+  labels:
+    app: bare
+spec:
+  containers:
+    - name: app
+      image: busybox
+status:
+  phase: Running
+---
+# StatefulSet + owned Pod — tests pod.statefulSet
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: db
+  namespace: prod
+  uid: ss-uid-db
+spec:
+  replicas: 1
+  serviceName: db
+  selector:
+    matchLabels:
+      app: db
+  template:
+    metadata:
+      labels:
+        app: db
+    spec:
+      containers:
+        - name: db
+          image: postgres:16
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: db-0
+  namespace: prod
+  labels:
+    app: db
+  ownerReferences:
+    - apiVersion: apps/v1
+      kind: StatefulSet
+      name: db
+      uid: ss-uid-db
+spec:
+  containers:
+    - name: db
+      image: postgres:16
+status:
+  phase: Running
+---
+# DaemonSet + owned Pod in a different namespace — tests pod.daemonSet + namespace filter on pods()
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluentd
+  namespace: kube-system
+  uid: ds-uid-fluentd
+spec:
+  selector:
+    matchLabels:
+      app: fluentd
+  template:
+    metadata:
+      labels:
+        app: fluentd
+    spec:
+      containers:
+        - name: fluentd
+          image: fluent/fluentd:v1.16
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fluentd-abc
+  namespace: kube-system
+  labels:
+    app: fluentd
+  ownerReferences:
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      name: fluentd
+      uid: ds-uid-fluentd
+spec:
+  containers:
+    - name: fluentd
+      image: fluent/fluentd:v1.16
+status:
+  phase: Running
+---
+# Job-with-matchExpressions selector — exercises the matchExpressions path in podsMatchingSelector
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: importer
+  namespace: prod
+  uid: job-uid-importer
+spec:
+  selector:
+    matchExpressions:
+      - key: job-name
+        operator: In
+        values: [importer]
+  template:
+    metadata:
+      labels:
+        job-name: importer
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: importer
+          image: importer:1.0
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: importer-pod
+  namespace: prod
+  labels:
+    job-name: importer
+  ownerReferences:
+    - apiVersion: batch/v1
+      kind: Job
+      name: importer
+      uid: job-uid-importer
+spec:
+  containers:
+    - name: importer
+      image: importer:1.0
+status:
+  phase: Succeeded
+---
+# CronJob with status.active referencing one of its owned Jobs
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: weekly-cleanup
+  namespace: prod
+  uid: cj-uid-cleanup
+spec:
+  schedule: "0 2 * * 0"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: cleanup
+              image: cleanup:1.0
+status:
+  active:
+    - kind: Job
+      name: weekly-cleanup-active
+      namespace: prod
+      uid: job-uid-active
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: weekly-cleanup-active
+  namespace: prod
+  uid: job-uid-active
+  ownerReferences:
+    - apiVersion: batch/v1
+      kind: CronJob
+      name: weekly-cleanup
+      uid: cj-uid-cleanup
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: cleanup
+          image: cleanup:1.0
+status:
+  active: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: weekly-cleanup-completed
+  namespace: prod
+  uid: job-uid-completed
+  ownerReferences:
+    - apiVersion: batch/v1
+      kind: CronJob
+      name: weekly-cleanup
+      uid: cj-uid-cleanup
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: cleanup
+          image: cleanup:1.0
+status:
+  succeeded: 1
+---
+# Unrelated job — must NOT appear in cronjob.jobs() (no ownerReference back to the CronJob)
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: unrelated-job
+  namespace: prod
+  uid: job-uid-unrelated
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: x
+          image: busybox
+---
+# Service + EndpointSlice tied via kubernetes.io/service-name label
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  namespace: prod
+spec:
+  selector:
+    app: api
+  ports:
+    - port: 80
+---
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: api-slice
+  namespace: prod
+  labels:
+    kubernetes.io/service-name: api
+addressType: IPv4
+endpoints:
+  - addresses: ["10.0.0.5"]
+ports:
+  - port: 8080
+---
+# EndpointSlice without the service-name label — service() must be null
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: orphan-slice
+  namespace: prod
+addressType: IPv4
+endpoints: []
+ports: []
+---
+# RBAC: ClusterRole granted via ClusterRoleBinding to api-sa (cross-namespace SA subject)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pod-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: read-pods-everywhere
+subjects:
+  - kind: ServiceAccount
+    name: api-sa
+    namespace: prod
+  - kind: User
+    name: alice@example.com
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: pod-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+# RBAC: Role granted via RoleBinding (roleRef.kind=Role)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secret-reader
+  namespace: prod
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: read-secrets
+  namespace: prod
+subjects:
+  - kind: ServiceAccount
+    name: api-sa
+    # namespace omitted on purpose — must fall back to the binding's namespace
+roleRef:
+  kind: Role
+  name: secret-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+# RBAC: RoleBinding that references a ClusterRole instead of a Role
+# Exercises roleBinding.role()=null + roleBinding.clusterRole()=pod-reader
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: read-pods-in-prod
+  namespace: prod
+subjects:
+  - kind: Group
+    name: devs
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: pod-reader
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Summary

Closes the typed-traversal gap on the remaining audit-critical resources. RBAC gets the typed graph it always needed; EndpointSlice gets its back-reference to Service; ResourceQuota and LimitRange get the queryable fields needed for capacity audits.

### RBAC

- **\`rolebinding.serviceAccounts()\`** and **\`clusterrolebinding.serviceAccounts()\`** — resolve subjects with \`kind == "ServiceAccount"\` to typed \`k8s.serviceaccount\` resources. Subject namespace falls back to the RoleBinding's namespace when omitted (matches kube-apiserver behavior).
- **\`rolebinding.role()\`** / **\`rolebinding.clusterRole()\`** — typed refs based on \`roleRef.kind\`; the unused one is null.
- **\`clusterrolebinding.clusterRole()\`** — typed ref (ClusterRoleBindings can only reference ClusterRoles).
- **\`role.boundBy()\`** / **\`clusterrole.boundBy()\`** — reverse lookup. Returns the bindings that reference this role via roleRef. Unlocks the classic query \`k8s.clusterroles.where(name == "cluster-admin").boundBy\`.

### EndpointSlice

- **\`service()\`** — typed ref via the \`kubernetes.io/service-name\` label. Completes the bidirectional Service ↔ EndpointSlice traversal (\`service.endpointSlices\` was already shipped in #7867).

### ResourceQuota

- \`hard\`, \`used\` (\`map[string]string\` keyed by resource name, quantity-string values), \`scopes\`, \`scopeSelector\`. Enables \`k8s.resourceQuotas.where(used["cpu"] != hard["cpu"])\`.

### LimitRange

- \`limits\` (\`[]dict\` per type — Container, Pod, PersistentVolumeClaim — with \`default\`/\`defaultRequest\`/\`max\`/\`min\`/\`maxLimitRequestRatio\`).

## Design notes

- All fields computed (lazy), matching the established pattern.
- Subject resolution skips entries with unknown SAs (returns the resolved subset rather than erroring) — same forgiveness model used by \`secret.usedBy()\`.
- No new sub-resources — \`scopeSelector\`, \`limits\`, RBAC \`rules\` stay as \`dict\`/\`[]dict\` per the bar.

## Test plan

- [x] \`go test ./providers/k8s/...\` — all green
- [x] Manifest fixture covering a ClusterRoleBinding with mixed ServiceAccount + User subjects, a RoleBinding referencing a Role (vs ClusterRole), an EndpointSlice with the service-name label, and a ResourceQuota with both hard + used set
- [x] Traversal queries: \`clusterrolebinding.serviceAccounts.namespace\`, \`rolebinding.clusterRole == null\` (correct; it points at a Role), \`role.boundBy.name\`, \`endpointslice.service.namespace\` — all traverse correctly
- [x] Audit queries: \`k8s.clusterroles.where(boundBy.any(name == "read-pods-everywhere"))\` and \`k8s.resourceQuotas.where(used["cpu"] != hard["cpu"])\` both return expected results
- [ ] Live-cluster verify (Docker not available locally; the live path uses the same code paths exercised in manifest mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)