### PR TITLE
🐛 kustomize: fix bugs surfaced by the audit pass

### DIFF
--- a/providers/kustomize/connection/connection.go
+++ b/providers/kustomize/connection/connection.go
@@ -8,11 +8,18 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
+
+// ErrNoKustomization is the sentinel returned by loadSingleKustomization
+// when the directory has none of the recognized kustomization filenames.
+// Callers use errors.Is to distinguish "look elsewhere" from a real
+// parse failure on a file that exists.
+var ErrNoKustomization = errors.New("no kustomization file found")
 
 var _ plugin.Connection = (*KustomizeConnection)(nil)
 
@@ -90,9 +97,16 @@ func loadKustomizations(kustomizePath string) ([]*KustomizationEntry, error) {
 		return nil, errors.New("kustomize path must be a directory: " + kustomizePath)
 	}
 
-	// Check if this directory has a kustomization file
-	if entry, err := loadSingleKustomization(kustomizePath); err == nil {
+	// Check if this directory has a kustomization file.
+	// "no kustomization file found" → fall through to subdir scan.
+	// Any other error (malformed YAML, unreadable file) is a real
+	// failure the caller should see, not silently swallow.
+	entry, err := loadSingleKustomization(kustomizePath)
+	if err == nil {
 		return []*KustomizationEntry{entry}, nil
+	}
+	if !errors.Is(err, ErrNoKustomization) {
+		return nil, err
 	}
 
 	// Otherwise scan subdirectories
@@ -107,8 +121,15 @@ func loadKustomizations(kustomizePath string) ([]*KustomizationEntry, error) {
 			continue
 		}
 		subPath := filepath.Join(kustomizePath, de.Name())
-		if entry, err := loadSingleKustomization(subPath); err == nil {
+		entry, err := loadSingleKustomization(subPath)
+		if err == nil {
 			entries = append(entries, entry)
+			continue
+		}
+		// Quiet skip when the subdir simply has no kustomization
+		// file; loud warning when a file exists but won't parse.
+		if !errors.Is(err, ErrNoKustomization) {
+			log.Warn().Err(err).Str("path", subPath).Msg("failed to load kustomization; skipping")
 		}
 	}
 
@@ -135,5 +156,5 @@ func loadSingleKustomization(dir string) (*KustomizationEntry, error) {
 		}, nil
 	}
 
-	return nil, errors.New("no kustomization file found in " + dir)
+	return nil, ErrNoKustomization
 }

--- a/providers/kustomize/connection/connection_test.go
+++ b/providers/kustomize/connection/connection_test.go
@@ -1,0 +1,40 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A directory with a kustomization.yaml that fails YAML parsing used
+// to be silently swallowed: loadKustomizations fell through to a
+// subdir scan, returned [], and the connection saw "no kustomization
+// found." Now the parse error propagates so the operator sees what's
+// actually wrong.
+func TestLoadKustomizations_MalformedRootPropagates(t *testing.T) {
+	_, err := loadKustomizations("../testdata/malformed")
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrNoKustomization),
+		"a parse error must not look like ErrNoKustomization (which only means \"no file here\")")
+}
+
+// Sanity check the sentinel: a directory with no kustomization
+// filename at any of the recognized names still produces ErrNoKustomization.
+func TestLoadSingleKustomization_NoFileReturnsSentinel(t *testing.T) {
+	_, err := loadSingleKustomization("../testdata/empty-dir")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNoKustomization))
+}
+
+// The basic fixture still loads (regression for the sentinel refactor).
+func TestLoadKustomizations_BasicFixtureStillWorks(t *testing.T) {
+	entries, err := loadKustomizations("../testdata/basic")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "../testdata/basic", entries[0].Path)
+}

--- a/providers/kustomize/provider/provider_test.go
+++ b/providers/kustomize/provider/provider_test.go
@@ -373,3 +373,48 @@ func TestStagingOverlay(t *testing.T) {
 	resNsResp := getData(t, srv, resp.Id, "kustomize.resource", resID, "namespace")
 	assert.Equal(t, "staging", string(resNsResp.Data.Value))
 }
+
+// A kustomization that references a non-existent file used to silently
+// produce zero resources (rendering error swallowed, []any{} returned).
+// That made audits like `.resources.length > 0` pass on broken
+// overlays. The accessor now surfaces the krusty error.
+func TestKustomizeResourcesPropagatesRenderError(t *testing.T) {
+	srv, resp := newTestService("../testdata/broken-render")
+
+	kustResp := getData(t, srv, resp.Id, "kustomize", "", "")
+	kustID := string(kustResp.Data.Value)
+	kustsResp := getData(t, srv, resp.Id, "kustomize", kustID, "kustomizations")
+	require.NotEmpty(t, kustsResp.Data.Array)
+	kID := string(kustsResp.Data.Array[0].Value)
+
+	// Use the lower-level call instead of getData so we can inspect Error.
+	resp2, err := srv.GetData(&plugin.DataReq{
+		Connection: resp.Id,
+		Resource:   "kustomize.kustomization",
+		ResourceId: kID,
+		Field:      "resources",
+	})
+	require.NoError(t, err, "transport-level call should not fail")
+	assert.NotEmpty(t, resp2.Error, "expected render failure to surface as a field error")
+}
+
+// A directory containing a kustomization.yaml that doesn't parse used
+// to fall through to a subdir scan and return "no kustomization found"
+// — masking the real problem. Now the connection refuses with the
+// parse error.
+func TestConnect_MalformedKustomizationSurfaces(t *testing.T) {
+	srv := Init()
+	_, err := srv.Connect(&plugin.ConnectReq{
+		Asset: &inventory.Asset{
+			Connections: []*inventory.Config{
+				{
+					Type:    DefaultConnectionType,
+					Options: map[string]string{"path": "../testdata/malformed"},
+				},
+			},
+		},
+	}, nil)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "no kustomization.yaml found",
+		"a parse error must not be reported as 'no kustomization found'")
+}

--- a/providers/kustomize/resources/kustomize.go
+++ b/providers/kustomize/resources/kustomize.go
@@ -39,6 +39,11 @@ type mqlKustomizeKustomizationInternal struct {
 	rendered      []map[string]any
 	renderedErr   error
 	renderedOnce  sync.Once
+	// stampOnce guards the post-construction write of kustomization
+	// and kustPath. CreateResource may return a cached instance for
+	// concurrent callers with the same __id; stampOnce ensures the
+	// stamp happens exactly once across those goroutines.
+	stampOnce sync.Once
 }
 
 func newMqlKustomization(runtime *plugin.Runtime, entry *connection.KustomizationEntry) (*mqlKustomizeKustomization, error) {
@@ -74,13 +79,13 @@ func newMqlKustomization(runtime *plugin.Runtime, entry *connection.Kustomizatio
 	}
 	mqlK := res.(*mqlKustomizeKustomization)
 	// CreateResource may return an already-cached instance when two
-	// callers ask for the same __id. Only stamp the Internal fields
-	// once so we don't overwrite a populated instance another caller
-	// is already using.
-	if mqlK.kustomization == nil {
+	// callers ask for the same __id; stampOnce keeps the write
+	// race-free under concurrent newMqlKustomization calls and
+	// happens-before any subsequent reader on the returned pointer.
+	mqlK.stampOnce.Do(func() {
 		mqlK.kustomization = k
 		mqlK.kustPath = entry.Path
-	}
+	})
 	return mqlK, nil
 }
 

--- a/providers/kustomize/resources/kustomize.go
+++ b/providers/kustomize/resources/kustomize.go
@@ -5,7 +5,6 @@ package resources
 
 import (
 	"sync"
-	"sync/atomic"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -39,8 +38,7 @@ type mqlKustomizeKustomizationInternal struct {
 	kustPath      string
 	rendered      []map[string]any
 	renderedErr   error
-	lock          sync.Mutex
-	fetched       atomic.Bool
+	renderedOnce  sync.Once
 }
 
 func newMqlKustomization(runtime *plugin.Runtime, entry *connection.KustomizationEntry) (*mqlKustomizeKustomization, error) {
@@ -75,8 +73,14 @@ func newMqlKustomization(runtime *plugin.Runtime, entry *connection.Kustomizatio
 		return nil, err
 	}
 	mqlK := res.(*mqlKustomizeKustomization)
-	mqlK.kustomization = k
-	mqlK.kustPath = entry.Path
+	// CreateResource may return an already-cached instance when two
+	// callers ask for the same __id. Only stamp the Internal fields
+	// once so we don't overwrite a populated instance another caller
+	// is already using.
+	if mqlK.kustomization == nil {
+		mqlK.kustomization = k
+		mqlK.kustPath = entry.Path
+	}
 	return mqlK, nil
 }
 

--- a/providers/kustomize/resources/kustomize.lr.go
+++ b/providers/kustomize/resources/kustomize.lr.go
@@ -50,7 +50,7 @@ func init() {
 			Create: createKustomizeImage,
 		},
 		"kustomize.resource": {
-			Init:   initKustomizeResource,
+			// to override args, implement: initKustomizeResource(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createKustomizeResource,
 		},
 		"kustomize.replacement": {

--- a/providers/kustomize/resources/replacement.go
+++ b/providers/kustomize/resources/replacement.go
@@ -48,6 +48,11 @@ func newMqlKustomizeReplacement(runtime *plugin.Runtime, kustPath string, index 
 func (r *mqlKustomizeReplacement) targets() ([]any, error) {
 	var mqlTargets []any
 	for i, t := range r.replacementTargets {
+		// A bare `- ` list entry in the source YAML produces a nil
+		// element here; skip it before touching t.Select.
+		if t == nil {
+			continue
+		}
 		kind := ""
 		name := ""
 		if t.Select != nil {

--- a/providers/kustomize/resources/resource.go
+++ b/providers/kustomize/resources/resource.go
@@ -4,6 +4,9 @@
 package resources
 
 import (
+	"fmt"
+	"strconv"
+
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -17,13 +20,15 @@ import (
 func (k *mqlKustomizeKustomization) resources() ([]any, error) {
 	rendered, err := k.fetchRendered()
 	if err != nil {
-		log.Warn().Err(err).Str("path", k.kustPath).Msg("failed to render kustomize overlay, returning empty resources")
-		return []any{}, nil
+		// Propagate render failures so a broken overlay surfaces in
+		// audits rather than silently passing checks that count
+		// resources. Matches the helm.template.resources contract.
+		return nil, err
 	}
 
-	var allResources []any
-	for _, obj := range rendered {
-		mqlRes, err := newMqlKustomizeResource(k.MqlRuntime, k.kustPath, obj)
+	allResources := make([]any, 0, len(rendered))
+	for idx, obj := range rendered {
+		mqlRes, err := newMqlKustomizeResource(k.MqlRuntime, k.kustPath, idx, obj)
 		if err != nil {
 			log.Warn().Err(err).Msg("skipping rendered kustomize resource")
 			continue
@@ -34,46 +39,36 @@ func (k *mqlKustomizeKustomization) resources() ([]any, error) {
 }
 
 func (k *mqlKustomizeKustomization) fetchRendered() ([]map[string]any, error) {
-	if k.fetched.Load() {
-		return k.rendered, k.renderedErr
-	}
-	k.lock.Lock()
-	defer k.lock.Unlock()
-	if k.fetched.Load() {
-		return k.rendered, k.renderedErr
-	}
+	k.renderedOnce.Do(func() {
+		fSys := filesys.MakeFsOnDisk()
+		kustomizer := krusty.MakeKustomizer(krusty.MakeDefaultOptions())
 
-	fSys := filesys.MakeFsOnDisk()
-	kustomizer := krusty.MakeKustomizer(krusty.MakeDefaultOptions())
-
-	resMap, err := kustomizer.Run(fSys, k.kustPath)
-	if err != nil {
-		k.renderedErr = err
-		k.fetched.Store(true)
-		return nil, err
-	}
-
-	var resources []map[string]any
-	for _, res := range resMap.Resources() {
-		yamlBytes, err := res.AsYAML()
+		resMap, err := kustomizer.Run(fSys, k.kustPath)
 		if err != nil {
-			log.Warn().Err(err).Msg("skipping kustomize resource: failed to convert to YAML")
-			continue
+			k.renderedErr = err
+			return
 		}
-		var obj map[string]any
-		if err := yaml.Unmarshal(yamlBytes, &obj); err != nil {
-			log.Warn().Err(err).Msg("skipping kustomize resource: failed to unmarshal YAML")
-			continue
-		}
-		resources = append(resources, obj)
-	}
 
-	k.rendered = resources
-	k.fetched.Store(true)
-	return k.rendered, nil
+		resources := make([]map[string]any, 0, len(resMap.Resources()))
+		for _, res := range resMap.Resources() {
+			yamlBytes, err := res.AsYAML()
+			if err != nil {
+				log.Warn().Err(err).Msg("skipping kustomize resource: failed to convert to YAML")
+				continue
+			}
+			var obj map[string]any
+			if err := yaml.Unmarshal(yamlBytes, &obj); err != nil {
+				log.Warn().Err(err).Msg("skipping kustomize resource: failed to unmarshal YAML")
+				continue
+			}
+			resources = append(resources, obj)
+		}
+		k.rendered = resources
+	})
+	return k.rendered, k.renderedErr
 }
 
-func newMqlKustomizeResource(runtime *plugin.Runtime, kustPath string, obj map[string]any) (*mqlKustomizeResource, error) {
+func newMqlKustomizeResource(runtime *plugin.Runtime, kustPath string, idx int, obj map[string]any) (*mqlKustomizeResource, error) {
 	kind, _ := obj["kind"].(string)
 	apiVersion, _ := obj["apiVersion"].(string)
 	name := ""
@@ -92,25 +87,24 @@ func newMqlKustomizeResource(runtime *plugin.Runtime, kustPath string, obj map[s
 		}
 	}
 
-	labelsStr := make(map[string]any, len(labels))
-	for k, v := range labels {
-		if s, ok := v.(string); ok {
-			labelsStr[k] = s
-		}
-	}
-	annotationsStr := make(map[string]any, len(annotations))
-	for k, v := range annotations {
-		if s, ok := v.(string); ok {
-			annotationsStr[k] = s
-		}
-	}
+	// Kubernetes requires label and annotation values to be strings,
+	// but the YAML parser can hand us ints/bools/etc. when the
+	// manifest is non-compliant (e.g. an unquoted `replicas: 3` under
+	// labels). Coerce non-strings via fmt.Sprintf so audits can see
+	// the offending value rather than silently dropping it.
+	labelsStr := coerceStringMap(labels)
+	annotationsStr := coerceStringMap(annotations)
 
 	manifest, err := convert.JsonToDict(obj)
 	if err != nil {
 		return nil, err
 	}
 
-	id := "kustomize.resource:" + kustPath + ":" + apiVersion + ":" + kind + ":" + namespace + "/" + name
+	// idx makes the cache key unique even when two manifests in the
+	// same overlay share apiVersion+kind+namespace+name — possible for
+	// cluster-scoped resources without `name`, or for malformed
+	// overlays. Without it CreateResource silently dedupes them.
+	id := "kustomize.resource:" + kustPath + ":" + apiVersion + ":" + kind + ":" + namespace + "/" + name + ":" + strconv.Itoa(idx)
 
 	res, err := CreateResource(runtime, "kustomize.resource", map[string]*llx.RawData{
 		"__id":        llx.StringData(id),
@@ -128,6 +122,21 @@ func newMqlKustomizeResource(runtime *plugin.Runtime, kustPath string, obj map[s
 	return res.(*mqlKustomizeResource), nil
 }
 
-func initKustomizeResource(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	return args, nil, nil
+// coerceStringMap converts every value in src to a string, preserving
+// non-string entries that the YAML parser may have left as ints, bools,
+// or nested values. Empty input returns an empty (non-nil) map so
+// downstream MapData calls don't get a nil slot.
+func coerceStringMap(src map[string]any) map[string]any {
+	out := make(map[string]any, len(src))
+	for k, v := range src {
+		switch val := v.(type) {
+		case string:
+			out[k] = val
+		case nil:
+			out[k] = ""
+		default:
+			out[k] = fmt.Sprintf("%v", val)
+		}
+	}
+	return out
 }

--- a/providers/kustomize/resources/resource_test.go
+++ b/providers/kustomize/resources/resource_test.go
@@ -1,0 +1,46 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Kubernetes requires label/annotation values to be strings, but YAML
+// unmarshaling can hand us ints, bools, or nil when a manifest is
+// non-compliant. coerceStringMap preserves every value as a string
+// rather than silently dropping the non-string ones.
+func TestCoerceStringMap(t *testing.T) {
+	in := map[string]any{
+		"app":      "demo",
+		"replicas": 3,                // int from `replicas: 3`
+		"enabled":  true,             // bool
+		"none":     nil,              // nil
+		"f":        3.14,             // float
+		"nested":   map[string]int{}, // arbitrary, stringified
+	}
+	got := coerceStringMap(in)
+
+	assert.Equal(t, "demo", got["app"])
+	assert.Equal(t, "3", got["replicas"], "ints survive as decimal strings")
+	assert.Equal(t, "true", got["enabled"], "bools survive as 'true'/'false'")
+	assert.Equal(t, "", got["none"], "nil becomes empty string")
+	assert.Equal(t, "3.14", got["f"])
+	assert.Contains(t, got["nested"], "map", "fallback %v rendering for unknowns")
+	assert.Len(t, got, len(in), "no entries dropped")
+}
+
+func TestCoerceStringMap_EmptyInputReturnsNonNil(t *testing.T) {
+	got := coerceStringMap(nil)
+	assert.NotNil(t, got, "downstream MapData expects a non-nil map")
+	assert.Len(t, got, 0)
+}
+
+func TestCoerceStringMap_EmptyMap(t *testing.T) {
+	got := coerceStringMap(map[string]any{})
+	assert.NotNil(t, got)
+	assert.Len(t, got, 0)
+}

--- a/providers/kustomize/testdata/broken-render/kustomization.yaml
+++ b/providers/kustomize/testdata/broken-render/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # nonexistent.yaml does not exist; krusty.Run will fail. Used by
+  # TestKustomizeResourcesPropagatesRenderError.
+  - nonexistent.yaml

--- a/providers/kustomize/testdata/malformed/kustomization.yaml
+++ b/providers/kustomize/testdata/malformed/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  # Deliberately malformed: unclosed quote on the next line ensures
+  # k.Unmarshal fails. Used by TestLoadKustomizations_MalformedRoot.
+namespace: "broken


### PR DESCRIPTION
## Summary

Bugs found by a deep-dive review of the kustomize provider, focused on nil handling, logic errors, and concurrency. Same shape as the helm audit fix we just landed.

### High

- **`kustomize.replacement.targets` nil-guard.** A bare `- ` list entry in the source YAML can leave a `nil *TargetSelector` in the slice; the old loop dereferenced `t.Select` on it and crashed. Skip nil entries.

- **`kustomize.kustomization.resources` propagates render errors.** A broken overlay used to silently produce `[]` (rendering error swallowed) — making policies like `.resources.length > 0` pass on overlays that didn't render at all. Now returns the krusty error, matching `helm.template.resources`. Pinned with `TestKustomizeResourcesPropagatesRenderError`.

- **`loadKustomizations` distinguishes "no file" from "malformed file."** Introduced `ErrNoKustomization` sentinel; the old code used `if err == nil` and fell through to a subdir scan on any error, including parse failures on the root file. Subdir parse failures are now warn-logged (still skipped — one bad sibling shouldn't fail the whole scan).

- **`kustomize.resource` `__id` includes a per-render index.** Without it, two resources sharing `apiVersion+kind+namespace+name` (cluster-scoped without name, or malformed manifests) silently dedupe through the cache.

- **`fetchRendered` migrated to `sync.Once`.** Same `atomic.Bool` + `sync.Mutex` DCL anti-pattern we fixed in proxmox and helm — the bool was ordered, but the subsequent reads of `rendered`/`renderedErr` were not. `go test -race` is clean now.

- **`initKustomizeResource` removed.** Registered as a no-op Init hook that silently returned bare resources on cache miss. The generator regenerated cleanly without it.

### Medium

- **Non-string label/annotation values preserved via `coerceStringMap`.** The old `if s, ok := v.(string)` filter silently dropped anything the YAML parser handed us as `int`/`bool`/`nil`/etc. Now stringified via `fmt.Sprintf`. Unit tests cover int/bool/nil/float/fallback.

- **`newMqlKustomization` guards the post-construction Internal write.** `CreateResource` can return a cached instance; the unconditional `mqlK.kustomization = k` could clobber state another caller was already using. Only write when the field is still nil.

## Tests

- `TestCoerceStringMap` — int/bool/nil/float/nested all survive; empty/nil input returns a non-nil empty map
- `TestLoadKustomizations_MalformedRootPropagates` — fixture `testdata/malformed` has unparseable YAML; the load surfaces the parse error rather than fall through to a subdir scan
- `TestLoadSingleKustomization_NoFileReturnsSentinel` — pins the `ErrNoKustomization` shape
- `TestLoadKustomizations_BasicFixtureStillWorks` — regression for the sentinel refactor
- `TestKustomizeResourcesPropagatesRenderError` — fixture `testdata/broken-render` references a nonexistent file; the field error surfaces through `GetData`
- `TestConnect_MalformedKustomizationSurfaces` — connection-level pin that a malformed root produces a real error, not "no kustomization found"

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./...` and `go test -race ./...` both green
- [x] `make providers/build/kustomize` produces `dist/kustomize`
- [ ] Interactive smoke against a real overlay:
  - `mql shell kustomize --path ./testdata/multi-overlay -c "kustomize.kustomizations { path resources.length }"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)