### PR TITLE
🐛 k8s: fix nil-pointer panic on webhook configuration singular lookups

### DIFF
--- a/providers/k8s/resources/admission.go
+++ b/providers/k8s/resources/admission.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/k8s/connection/shared/resources"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -158,4 +159,14 @@ func (k *mqlK8sAdmissionValidatingwebhookconfiguration) webhooks() ([]any, error
 		return nil, err
 	}
 	return dict, nil
+}
+
+func (k *mqlK8sAdmissionValidatingwebhookconfiguration) id() (string, error) {
+	return k.Id.Data, nil
+}
+
+func initK8sAdmissionValidatingwebhookconfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	return initResource[*mqlK8sAdmissionValidatingwebhookconfiguration](runtime, args, func(k *mqlK8s) *plugin.TValue[[]any] {
+		return k.GetValidatingWebhookConfigurations()
+	})
 }

--- a/providers/k8s/resources/cross_references_test.go
+++ b/providers/k8s/resources/cross_references_test.go
@@ -761,3 +761,58 @@ func TestJobDefaults(t *testing.T) {
 	require.NoError(t, bl.Error)
 	assert.Equal(t, int64(6), bl.Data, "backoffLimit default must be the k8s API default of 6")
 }
+
+// -----------------------------------------------------------------------------
+// Webhook configuration singular-lookup regression.
+// Before the init functions were added, k8s.admission.{validating,mutating}-
+// webhookconfiguration(name: "X") returned a resource with obj=nil, so every
+// field that dereferenced k.obj panicked with nil pointer deref. This test
+// asserts the lookup actually populates obj and the fields are reachable.
+// -----------------------------------------------------------------------------
+
+func TestWebhookConfigurationSingularLookup(t *testing.T) {
+	runtime := loadCrossRefRuntime(t)
+
+	t.Run("ValidatingWebhookConfiguration", func(t *testing.T) {
+		obj, err := NewResource(runtime, "k8s.admission.validatingwebhookconfiguration", map[string]*llx.RawData{
+			"name": llx.StringData("regression-validator"),
+		})
+		require.NoError(t, err)
+		vwc := obj.(*mqlK8sAdmissionValidatingwebhookconfiguration)
+		require.NotNil(t, vwc, "lookup must return a populated resource, not nil")
+
+		// Each of these accessors used to panic when init was missing.
+		hooks := vwc.GetWebhooks()
+		require.NoError(t, hooks.Error)
+		assert.Len(t, hooks.Data, 1, "webhooks list must round-trip the single configured webhook")
+
+		labels := vwc.GetLabels()
+		require.NoError(t, labels.Error)
+		assert.Equal(t, "cross-references", labels.Data["test"])
+
+		manifest := vwc.GetManifest()
+		require.NoError(t, manifest.Error)
+		require.NotNil(t, manifest.Data)
+	})
+
+	t.Run("MutatingWebhookConfiguration", func(t *testing.T) {
+		obj, err := NewResource(runtime, "k8s.admission.mutatingwebhookconfiguration", map[string]*llx.RawData{
+			"name": llx.StringData("regression-mutator"),
+		})
+		require.NoError(t, err)
+		mwc := obj.(*mqlK8sAdmissionMutatingwebhookconfiguration)
+		require.NotNil(t, mwc)
+
+		hooks := mwc.GetWebhooks()
+		require.NoError(t, hooks.Error)
+		assert.Len(t, hooks.Data, 1)
+
+		labels := mwc.GetLabels()
+		require.NoError(t, labels.Error)
+		assert.Equal(t, "cross-references", labels.Data["test"])
+
+		manifest := mwc.GetManifest()
+		require.NoError(t, manifest.Error)
+		require.NotNil(t, manifest.Data)
+	})
+}

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -266,7 +266,7 @@ func init() {
 			Create: createK8sUserinfo,
 		},
 		"k8s.admission.validatingwebhookconfiguration": {
-			// to override args, implement: initK8sAdmissionValidatingwebhookconfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initK8sAdmissionValidatingwebhookconfiguration,
 			Create: createK8sAdmissionValidatingwebhookconfiguration,
 		},
 		"k8s.app": {
@@ -294,7 +294,7 @@ func init() {
 			Create: createK8sReferencegrant,
 		},
 		"k8s.admission.mutatingwebhookconfiguration": {
-			// to override args, implement: initK8sAdmissionMutatingwebhookconfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initK8sAdmissionMutatingwebhookconfiguration,
 			Create: createK8sAdmissionMutatingwebhookconfiguration,
 		},
 		"k8s.poddisruptionbudget": {
@@ -15417,7 +15417,12 @@ func createK8sAdmissionValidatingwebhookconfiguration(runtime *plugin.Runtime, a
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("k8s.admission.validatingwebhookconfiguration", res.__id)

--- a/providers/k8s/resources/mutatingwebhookconfiguration.go
+++ b/providers/k8s/resources/mutatingwebhookconfiguration.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,4 +63,10 @@ func (k *mqlK8sAdmissionMutatingwebhookconfiguration) labels() (map[string]any, 
 
 func (k *mqlK8sAdmissionMutatingwebhookconfiguration) webhooks() ([]any, error) {
 	return convert.JsonToDictSlice(k.obj.Webhooks)
+}
+
+func initK8sAdmissionMutatingwebhookconfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	return initResource[*mqlK8sAdmissionMutatingwebhookconfiguration](runtime, args, func(k *mqlK8s) *plugin.TValue[[]any] {
+		return k.GetMutatingWebhookConfigurations()
+	})
 }

--- a/providers/k8s/resources/testdata/cross_references.yaml
+++ b/providers/k8s/resources/testdata/cross_references.yaml
@@ -554,3 +554,46 @@ roleRef:
   kind: ClusterRole
   name: pod-reader
   apiGroup: rbac.authorization.k8s.io
+---
+# Webhook configurations — regression for the singular-lookup nil-pointer
+# panic. Looking these up via NewResource (the singular accessor) used to
+# skip the obj-populating list scan, so every field touching obj panicked.
+# Both resources now have init functions; the test asserts fields that
+# previously crashed (webhooks, manifest, labels) resolve cleanly.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: regression-validator
+  labels:
+    test: cross-references
+webhooks:
+  - name: validate.regression.test
+    clientConfig:
+      url: https://validator.regression.test/validate
+    rules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["configmaps"]
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Ignore
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: regression-mutator
+  labels:
+    test: cross-references
+webhooks:
+  - name: mutate.regression.test
+    clientConfig:
+      url: https://mutator.regression.test/mutate
+    rules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["pods"]
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Ignore


### PR DESCRIPTION
## Summary

Found while running every modeled k8s resource against a live minikube cluster.

\`k8s.admission.validatingwebhookconfiguration(name: \"X\")\` and \`k8s.admission.mutatingwebhookconfiguration(name: \"X\")\` panicked with \`invalid memory address or nil pointer dereference\` inside \`webhooks()\` (and any other field that dereferenced \`k.obj\` — \`labels\`/\`annotations\`/\`manifest\`).

## Root cause

Both resources have an \`Internal\` struct that caches a typed \`*admissionregistrationv1.ValidatingWebhookConfiguration\` (and the mutating equivalent) for accessor methods to read. The bulk lister sets \`obj\` after \`CreateResource\`, so the **list path** works:

\`\`\`mql
k8s.validatingWebhookConfigurations.where(name == \"X\") { webhooks.length }   # ok
\`\`\`

But \`NewResource(\"k8s.admission.validatingwebhookconfiguration\", {name})\` calls the generic \`createK8sAdmissionValidatingwebhookconfiguration\` with no init function, so the resource is returned with \`obj == nil\`. Every subsequent field that touches \`obj\` panics:

\`\`\`mql
k8s.admission.validatingwebhookconfiguration(name: \"X\") { webhooks }   # panic
\`\`\`

## Fix

Add \`initK8sAdmissionValidatingwebhookconfiguration\` and \`initK8sAdmissionMutatingwebhookconfiguration\`. Both use the standard cluster-scoped \`initResource[T]\` helper that looks up the resource by name in the cached list (populating \`obj\` as a side effect).

\`\`\`go
func initK8sAdmissionValidatingwebhookconfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
    return initResource[*mqlK8sAdmissionValidatingwebhookconfiguration](runtime, args, func(k *mqlK8s) *plugin.TValue[[]any] {
        return k.GetValidatingWebhookConfigurations()
    })
}
\`\`\`

\`mqlr generate\` picked up the new init functions automatically and wired them into the resource registration table (the \`k8s.lr.go\` diff is mechanical).

## Test plan

- [x] Reproduced the panic against minikube (full nil-pointer stack trace in \`webhooks()\` for both resources).
- [x] After fix, \`k8s.admission.validatingwebhookconfiguration(name: \"live-validator\") { name webhooks manifest.kind labels annotations }\` returns the full record without error.
- [x] Same for mutating webhook.
- [x] List path (\`k8s.validatingWebhookConfigurations.where(...)\`) continues to work.
- [x] \`go test ./providers/k8s/...\` — all green.

## How the rest of the provider looked

While I was here I also exercised every other modeled resource against the live cluster — Pod (typed fields + 2-hop deployment ref), workloads (Deployment/StatefulSet/DaemonSet/Job/CronJob with pods() + jobs()), Service (endpointSlices), Ingress (ingressClass ref), NetworkPolicy, RBAC (subject + roleRef + boundBy), PV/PVC/StorageClass triangle, HPA (scaleTargetDeployment ref), PodDisruptionBudget, ResourceQuota (hard/used), LimitRange, Node (providerID, podCIDRs, nodeInfo scalars, images, volumesInUse), Lease, APIService, Gateway API (GatewayClass/Gateway/HTTPRoute/GRPCRoute/ReferenceGrant), namespace accessors, Secret/ConfigMap usedBy, audit queries (under-replicated deployments, unused secrets, exposed services, privilege-escalation pods). Everything else worked correctly. The webhook init gap was the only real bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)