### PR TITLE
🐛 openstack: fix bugs surfaced by the audit pass

### DIFF
--- a/providers/openstack/connection/authentication.go
+++ b/providers/openstack/connection/authentication.go
@@ -70,9 +70,14 @@ func resolveAuth(conf *inventory.Config) (*authResult, error) {
 	}
 	authOpts.AllowReauth = true
 
+	// Fall back to the clouds.yaml region when the caller didn't supply
+	// --region. clientOpts.RegionName is just the explicit input; the
+	// resolved region from clouds.yaml lives on the Cloud record.
 	region := opts[OPTION_REGION]
 	if region == "" {
-		region = clientOpts.RegionName
+		if cloud, cerr := clientconfig.GetCloudFromYAML(clientOpts); cerr == nil && cloud != nil {
+			region = cloud.RegionName
+		}
 	}
 
 	return &authResult{authOpts: *authOpts, region: region}, nil

--- a/providers/openstack/connection/connection.go
+++ b/providers/openstack/connection/connection.go
@@ -47,13 +47,19 @@ type OpenstackConnection struct {
 	objectStorage *gophercloud.ServiceClient
 	dns           *gophercloud.ServiceClient
 
-	SGNameCacheLock sync.Mutex
+	// Name->ID caches for Nova-reported references that Neutron/Compute
+	// expose only by ID. sync.Once gives single-flight semantics: the
+	// first concurrent caller does the API work and every other caller
+	// blocks until that call completes. After it returns, the cache map
+	// is read without any lock — the previous lock-across-HTTP pattern
+	// serialized every reader for the entire round-trip.
+	SGNameCacheOnce sync.Once
 	SGNameCache     map[string]string
-	SGNameCacheDone bool
+	SGNameCacheErr  error
 
-	FlavorNameCacheLock sync.Mutex
+	FlavorNameCacheOnce sync.Once
 	FlavorNameCache     map[string]string
-	FlavorNameCacheDone bool
+	FlavorNameCacheErr  error
 }
 
 func NewOpenstackConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*OpenstackConnection, error) {

--- a/providers/openstack/connection/connection.go
+++ b/providers/openstack/connection/connection.go
@@ -48,18 +48,16 @@ type OpenstackConnection struct {
 	dns           *gophercloud.ServiceClient
 
 	// Name->ID caches for Nova-reported references that Neutron/Compute
-	// expose only by ID. sync.Once gives single-flight semantics: the
-	// first concurrent caller does the API work and every other caller
-	// blocks until that call completes. After it returns, the cache map
-	// is read without any lock — the previous lock-across-HTTP pattern
-	// serialized every reader for the entire round-trip.
-	SGNameCacheOnce sync.Once
+	// expose only by ID. A non-nil map is the "ready" signal so we don't
+	// need a separate flag; the lock single-flights the first fetch and
+	// concurrent callers wait. Real (non-translated) errors leave the
+	// map nil so the next call retries — a transient blip can't poison
+	// the cache for the connection's lifetime.
+	SGNameCacheLock sync.Mutex
 	SGNameCache     map[string]string
-	SGNameCacheErr  error
 
-	FlavorNameCacheOnce sync.Once
+	FlavorNameCacheLock sync.Mutex
 	FlavorNameCache     map[string]string
-	FlavorNameCacheErr  error
 }
 
 func NewOpenstackConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*OpenstackConnection, error) {

--- a/providers/openstack/resources/compute.go
+++ b/providers/openstack/resources/compute.go
@@ -47,12 +47,13 @@ func initOpenstackComputeServer(runtime *plugin.Runtime, args map[string]*llx.Ra
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetServers()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			s := raw.(*mqlOpenstackComputeServer)
-			if s.Id.Data == id {
-				return args, s, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		s := raw.(*mqlOpenstackComputeServer)
+		if s.Id.Data == id {
+			return args, s, nil
 		}
 	}
 	initSyntheticID("openstack.compute.server", "id", args)
@@ -306,34 +307,36 @@ func serverFlavorRef(raw map[string]any) (id, name string) {
 }
 
 // lookupFlavorIDByName resolves a flavor name to an id via a per-connection
-// cache populated lazily from a single flavors.ListDetail call.
+// cache populated lazily from a single flavors.ListDetail call. After the
+// once-only fetch, reads are lock-free.
 func lookupFlavorIDByName(c *connection.OpenstackConnection, name string) (string, error) {
-	c.FlavorNameCacheLock.Lock()
-	defer c.FlavorNameCacheLock.Unlock()
-
-	if !c.FlavorNameCacheDone {
+	c.FlavorNameCacheOnce.Do(func() {
 		client, err := c.ComputeClient()
 		if err != nil {
-			return "", err
+			c.FlavorNameCacheErr = err
+			return
 		}
 		pages, err := flavors.ListDetail(client, flavors.ListOpts{}).AllPages(ctx())
 		if err != nil {
 			if translateOpenstackError(err) == nil {
-				c.FlavorNameCacheDone = true
 				c.FlavorNameCache = map[string]string{}
-				return "", nil
+				return
 			}
-			return "", err
+			c.FlavorNameCacheErr = err
+			return
 		}
 		items, err := flavors.ExtractFlavors(pages)
 		if err != nil {
-			return "", err
+			c.FlavorNameCacheErr = err
+			return
 		}
 		c.FlavorNameCache = make(map[string]string, len(items))
 		for _, f := range items {
 			c.FlavorNameCache[f.Name] = f.ID
 		}
-		c.FlavorNameCacheDone = true
+	})
+	if c.FlavorNameCacheErr != nil {
+		return "", c.FlavorNameCacheErr
 	}
 	return c.FlavorNameCache[name], nil
 }
@@ -493,12 +496,13 @@ func initOpenstackComputeKeypair(runtime *plugin.Runtime, args map[string]*llx.R
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetKeypairs()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			k := raw.(*mqlOpenstackComputeKeypair)
-			if k.Name.Data == name {
-				return args, k, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		k := raw.(*mqlOpenstackComputeKeypair)
+		if k.Name.Data == name {
+			return args, k, nil
 		}
 	}
 	initSyntheticID("openstack.compute.keypair", "name", args)
@@ -557,12 +561,13 @@ func initOpenstackComputeServerGroup(runtime *plugin.Runtime, args map[string]*l
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetServerGroups()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			g := raw.(*mqlOpenstackComputeServerGroup)
-			if g.Id.Data == id {
-				return args, g, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		g := raw.(*mqlOpenstackComputeServerGroup)
+		if g.Id.Data == id {
+			return args, g, nil
 		}
 	}
 	initSyntheticID("openstack.compute.serverGroup", "id", args)
@@ -648,12 +653,13 @@ func initOpenstackComputeHypervisor(runtime *plugin.Runtime, args map[string]*ll
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetHypervisors()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			h := raw.(*mqlOpenstackComputeHypervisor)
-			if h.Id.Data == id {
-				return args, h, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		h := raw.(*mqlOpenstackComputeHypervisor)
+		if h.Id.Data == id {
+			return args, h, nil
 		}
 	}
 	initSyntheticID("openstack.compute.hypervisor", "id", args)
@@ -759,12 +765,13 @@ func initOpenstackComputeService(runtime *plugin.Runtime, args map[string]*llx.R
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetComputeServices()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			s := raw.(*mqlOpenstackComputeService)
-			if s.Id.Data == id {
-				return args, s, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		s := raw.(*mqlOpenstackComputeService)
+		if s.Id.Data == id {
+			return args, s, nil
 		}
 	}
 	initSyntheticID("openstack.compute.service", "id", args)
@@ -882,8 +889,7 @@ func (o *mqlOpenstack) computeLimits() (*mqlOpenstackComputeLimits, error) {
 	c := conn(o.MqlRuntime)
 	client, err := c.ComputeClient()
 	if err != nil {
-		o.ComputeLimits.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
+		return nil, err
 	}
 	lim, err := limits.Get(ctx(), client, nil).Extract()
 	if err != nil {

--- a/providers/openstack/resources/compute.go
+++ b/providers/openstack/resources/compute.go
@@ -888,6 +888,10 @@ func (o *mqlOpenstack) computeLimits() (*mqlOpenstackComputeLimits, error) {
 	c := conn(o.MqlRuntime)
 	client, err := c.ComputeClient()
 	if err != nil {
+		if serviceMissing(err) {
+			o.ComputeLimits.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	lim, err := limits.Get(ctx(), client, nil).Extract()

--- a/providers/openstack/resources/compute.go
+++ b/providers/openstack/resources/compute.go
@@ -307,36 +307,35 @@ func serverFlavorRef(raw map[string]any) (id, name string) {
 }
 
 // lookupFlavorIDByName resolves a flavor name to an id via a per-connection
-// cache populated lazily from a single flavors.ListDetail call. After the
-// once-only fetch, reads are lock-free.
+// cache populated lazily from a single flavors.ListDetail call. The lock
+// single-flights the first fetch; on success or auth-translated failure the
+// cache map is non-nil and subsequent callers fast-path. Real errors leave
+// the cache nil so the next call retries instead of inheriting a stale error.
 func lookupFlavorIDByName(c *connection.OpenstackConnection, name string) (string, error) {
-	c.FlavorNameCacheOnce.Do(func() {
-		client, err := c.ComputeClient()
-		if err != nil {
-			c.FlavorNameCacheErr = err
-			return
+	c.FlavorNameCacheLock.Lock()
+	defer c.FlavorNameCacheLock.Unlock()
+	if c.FlavorNameCache != nil {
+		return c.FlavorNameCache[name], nil
+	}
+	client, err := c.ComputeClient()
+	if err != nil {
+		return "", err
+	}
+	pages, err := flavors.ListDetail(client, flavors.ListOpts{}).AllPages(ctx())
+	if err != nil {
+		if translateOpenstackError(err) == nil {
+			c.FlavorNameCache = map[string]string{}
+			return "", nil
 		}
-		pages, err := flavors.ListDetail(client, flavors.ListOpts{}).AllPages(ctx())
-		if err != nil {
-			if translateOpenstackError(err) == nil {
-				c.FlavorNameCache = map[string]string{}
-				return
-			}
-			c.FlavorNameCacheErr = err
-			return
-		}
-		items, err := flavors.ExtractFlavors(pages)
-		if err != nil {
-			c.FlavorNameCacheErr = err
-			return
-		}
-		c.FlavorNameCache = make(map[string]string, len(items))
-		for _, f := range items {
-			c.FlavorNameCache[f.Name] = f.ID
-		}
-	})
-	if c.FlavorNameCacheErr != nil {
-		return "", c.FlavorNameCacheErr
+		return "", err
+	}
+	items, err := flavors.ExtractFlavors(pages)
+	if err != nil {
+		return "", err
+	}
+	c.FlavorNameCache = make(map[string]string, len(items))
+	for _, f := range items {
+		c.FlavorNameCache[f.Name] = f.ID
 	}
 	return c.FlavorNameCache[name], nil
 }

--- a/providers/openstack/resources/dns.go
+++ b/providers/openstack/resources/dns.go
@@ -26,12 +26,13 @@ func initOpenstackDnsZone(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetDnsZones()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			z := raw.(*mqlOpenstackDnsZone)
-			if z.Id.Data == id {
-				return args, z, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		z := raw.(*mqlOpenstackDnsZone)
+		if z.Id.Data == id {
+			return args, z, nil
 		}
 	}
 	initSyntheticID("openstack.dns.zone", "id", args)

--- a/providers/openstack/resources/firewall.go
+++ b/providers/openstack/resources/firewall.go
@@ -34,12 +34,13 @@ func initOpenstackFirewallGroup(runtime *plugin.Runtime, args map[string]*llx.Ra
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetFirewallGroups()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			g := raw.(*mqlOpenstackFirewallGroup)
-			if g.Id.Data == id {
-				return args, g, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		g := raw.(*mqlOpenstackFirewallGroup)
+		if g.Id.Data == id {
+			return args, g, nil
 		}
 	}
 	initSyntheticID("openstack.firewall.group", "id", args)
@@ -149,12 +150,13 @@ func initOpenstackFirewallPolicy(runtime *plugin.Runtime, args map[string]*llx.R
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetFirewallPolicies()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			p := raw.(*mqlOpenstackFirewallPolicy)
-			if p.Id.Data == id {
-				return args, p, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		p := raw.(*mqlOpenstackFirewallPolicy)
+		if p.Id.Data == id {
+			return args, p, nil
 		}
 	}
 	initSyntheticID("openstack.firewall.policy", "id", args)
@@ -206,9 +208,35 @@ func (r *mqlOpenstackFirewallPolicy) project() (*mqlOpenstackProject, error) {
 }
 
 func (r *mqlOpenstackFirewallPolicy) rules() ([]any, error) {
+	if len(r.cacheRuleIDs) == 0 {
+		return []any{}, nil
+	}
+
+	// Index the global rule list once. Without the index, each rule ID
+	// triggers a NewResource + init function that linearly scans the
+	// full rules list, producing O(N*M) per policy. The index folds that
+	// to O(N+M) total when openstack.firewallRules has been resolved.
+	root, err := CreateResource(r.MqlRuntime, "openstack", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	list := root.(*mqlOpenstack).GetFirewallRules()
+	var byID map[string]*mqlOpenstackFirewallRule
+	if list.Error == nil {
+		byID = make(map[string]*mqlOpenstackFirewallRule, len(list.Data))
+		for _, raw := range list.Data {
+			fr := raw.(*mqlOpenstackFirewallRule)
+			byID[fr.Id.Data] = fr
+		}
+	}
+
 	out := make([]any, 0, len(r.cacheRuleIDs))
 	for _, id := range r.cacheRuleIDs {
 		if id == "" {
+			continue
+		}
+		if fr, ok := byID[id]; ok {
+			out = append(out, fr)
 			continue
 		}
 		res, err := NewResource(r.MqlRuntime, "openstack.firewall.rule", map[string]*llx.RawData{"id": llx.StringData(id)})
@@ -241,12 +269,13 @@ func initOpenstackFirewallRule(runtime *plugin.Runtime, args map[string]*llx.Raw
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetFirewallRules()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			r := raw.(*mqlOpenstackFirewallRule)
-			if r.Id.Data == id {
-				return args, r, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		r := raw.(*mqlOpenstackFirewallRule)
+		if r.Id.Data == id {
+			return args, r, nil
 		}
 	}
 	initSyntheticID("openstack.firewall.rule", "id", args)

--- a/providers/openstack/resources/helpers.go
+++ b/providers/openstack/resources/helpers.go
@@ -74,6 +74,22 @@ func translateGetError(err error) error {
 	return err
 }
 
+// serviceMissing reports whether err indicates the service or endpoint is
+// absent from the Keystone catalog — the OpenStack way of saying "this
+// deployment doesn't run that service". Callers should treat this as "no
+// data" rather than a failure so a Cinder-less cloud can still query Nova.
+func serviceMissing(err error) bool {
+	if err == nil {
+		return false
+	}
+	var svc gophercloud.ErrServiceNotFound
+	if errors.As(err, &svc) {
+		return true
+	}
+	var ep gophercloud.ErrEndpointNotFound
+	return errors.As(err, &ep)
+}
+
 func stringSlice(in []string) []any {
 	out := make([]any, len(in))
 	for i, v := range in {

--- a/providers/openstack/resources/images.go
+++ b/providers/openstack/resources/images.go
@@ -30,12 +30,13 @@ func initOpenstackImage(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetImages()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			img := raw.(*mqlOpenstackImage)
-			if img.Id.Data == id {
-				return args, img, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		img := raw.(*mqlOpenstackImage)
+		if img.Id.Data == id {
+			return args, img, nil
 		}
 	}
 	initSyntheticID("openstack.image", "id", args)

--- a/providers/openstack/resources/keymanager.go
+++ b/providers/openstack/resources/keymanager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/keymanager/v1/containers"
 	"github.com/gophercloud/gophercloud/v2/openstack/keymanager/v1/orders"
 	"github.com/gophercloud/gophercloud/v2/openstack/keymanager/v1/secrets"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
@@ -46,12 +47,13 @@ func initOpenstackKeymanagerSecret(runtime *plugin.Runtime, args map[string]*llx
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetSecrets()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			s := raw.(*mqlOpenstackKeymanagerSecret)
-			if s.Id.Data == id {
-				return args, s, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		s := raw.(*mqlOpenstackKeymanagerSecret)
+		if s.Id.Data == id {
+			return args, s, nil
 		}
 	}
 	initSyntheticID("openstack.keymanager.secret", "id", args)
@@ -79,6 +81,10 @@ func (o *mqlOpenstack) secrets() ([]any, error) {
 	out := make([]any, 0, len(items))
 	for i := range items {
 		s := &items[i]
+		if barbicanRefID(s.SecretRef) == "" {
+			log.Warn().Str("secretRef", s.SecretRef).Msg("openstack: skipping Barbican secret with unresolvable ref")
+			continue
+		}
 		res, err := newMqlOpenstackKeymanagerSecret(o.MqlRuntime, s)
 		if err != nil {
 			return nil, err
@@ -151,12 +157,13 @@ func initOpenstackKeymanagerContainer(runtime *plugin.Runtime, args map[string]*
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetSecretContainers()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			c := raw.(*mqlOpenstackKeymanagerContainer)
-			if c.Id.Data == id {
-				return args, c, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		c := raw.(*mqlOpenstackKeymanagerContainer)
+		if c.Id.Data == id {
+			return args, c, nil
 		}
 	}
 	initSyntheticID("openstack.keymanager.container", "id", args)
@@ -185,6 +192,10 @@ func (o *mqlOpenstack) secretContainers() ([]any, error) {
 	for i := range items {
 		ct := &items[i]
 		id := barbicanRefID(ct.ContainerRef)
+		if id == "" {
+			log.Warn().Str("containerRef", ct.ContainerRef).Msg("openstack: skipping Barbican container with unresolvable ref")
+			continue
+		}
 		res, err := CreateResource(o.MqlRuntime, "openstack.keymanager.container", map[string]*llx.RawData{
 			"__id":         llx.StringData("openstack.keymanager.container/" + id),
 			"id":           llx.StringData(id),
@@ -326,12 +337,13 @@ func initOpenstackKeymanagerOrder(runtime *plugin.Runtime, args map[string]*llx.
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetSecretOrders()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			o := raw.(*mqlOpenstackKeymanagerOrder)
-			if o.Id.Data == id {
-				return args, o, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		o := raw.(*mqlOpenstackKeymanagerOrder)
+		if o.Id.Data == id {
+			return args, o, nil
 		}
 	}
 	initSyntheticID("openstack.keymanager.order", "id", args)
@@ -360,6 +372,10 @@ func (o *mqlOpenstack) secretOrders() ([]any, error) {
 	for i := range items {
 		ord := &items[i]
 		id := barbicanRefID(ord.OrderRef)
+		if id == "" {
+			log.Warn().Str("orderRef", ord.OrderRef).Msg("openstack: skipping Barbican order with unresolvable ref")
+			continue
+		}
 		res, err := CreateResource(o.MqlRuntime, "openstack.keymanager.order", map[string]*llx.RawData{
 			"__id":             llx.StringData("openstack.keymanager.order/" + id),
 			"id":               llx.StringData(id),

--- a/providers/openstack/resources/keystone.go
+++ b/providers/openstack/resources/keystone.go
@@ -35,12 +35,13 @@ func initOpenstackProject(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetProjects()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			p := raw.(*mqlOpenstackProject)
-			if p.Id.Data == id {
-				return args, p, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		p := raw.(*mqlOpenstackProject)
+		if p.Id.Data == id {
+			return args, p, nil
 		}
 	}
 	initSyntheticID("openstack.project", "id", args)
@@ -144,12 +145,13 @@ func initOpenstackUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetUsers()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			u := raw.(*mqlOpenstackUser)
-			if u.Id.Data == id {
-				return args, u, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		u := raw.(*mqlOpenstackUser)
+		if u.Id.Data == id {
+			return args, u, nil
 		}
 	}
 	initSyntheticID("openstack.user", "id", args)
@@ -176,25 +178,32 @@ func (o *mqlOpenstack) users() ([]any, error) {
 
 	out := make([]any, 0, len(items))
 	for i := range items {
-		u := &items[i]
-		res, err := CreateResource(o.MqlRuntime, "openstack.user", map[string]*llx.RawData{
-			"__id":                         llx.StringData("openstack.user/" + u.ID),
-			"id":                           llx.StringData(u.ID),
-			"name":                         llx.StringData(u.Name),
-			"enabled":                      llx.BoolData(u.Enabled),
-			"description":                  llx.StringData(u.Description),
-			"passwordExpiresAt":            llx.TimeDataPtr(timePtr(u.PasswordExpiresAt)),
-			"ignoreLockoutFailureAttempts": llx.BoolData(userOptionBool(u.Options, "ignore_lockout_failure_attempts")),
-		})
+		mqlUser, err := newMqlOpenstackUser(o.MqlRuntime, &items[i])
 		if err != nil {
 			return nil, err
 		}
-		mqlUser := res.(*mqlOpenstackUser)
-		mqlUser.cacheDomainID = u.DomainID
-		mqlUser.cacheDefaultProjectID = u.DefaultProjectID
 		out = append(out, mqlUser)
 	}
 	return out, nil
+}
+
+func newMqlOpenstackUser(runtime *plugin.Runtime, u *users.User) (*mqlOpenstackUser, error) {
+	res, err := CreateResource(runtime, "openstack.user", map[string]*llx.RawData{
+		"__id":                         llx.StringData("openstack.user/" + u.ID),
+		"id":                           llx.StringData(u.ID),
+		"name":                         llx.StringData(u.Name),
+		"enabled":                      llx.BoolData(u.Enabled),
+		"description":                  llx.StringData(u.Description),
+		"passwordExpiresAt":            llx.TimeDataPtr(timePtr(u.PasswordExpiresAt)),
+		"ignoreLockoutFailureAttempts": llx.BoolData(userOptionBool(u.Options, "ignore_lockout_failure_attempts")),
+	})
+	if err != nil {
+		return nil, err
+	}
+	mqlUser := res.(*mqlOpenstackUser)
+	mqlUser.cacheDomainID = u.DomainID
+	mqlUser.cacheDefaultProjectID = u.DefaultProjectID
+	return mqlUser, nil
 }
 
 func (r *mqlOpenstackUser) domain() (*mqlOpenstackDomain, error) {
@@ -246,27 +255,7 @@ func (r *mqlOpenstackUser) roles() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	seen := make(map[string]struct{}, len(items))
-	out := make([]any, 0, len(items))
-	for _, a := range items {
-		if a.Role.ID == "" {
-			continue
-		}
-		if _, dup := seen[a.Role.ID]; dup {
-			continue
-		}
-		seen[a.Role.ID] = struct{}{}
-		res, err := NewResource(r.MqlRuntime, "openstack.role", map[string]*llx.RawData{
-			"id":   llx.StringData(a.Role.ID),
-			"name": llx.StringData(a.Role.Name),
-		})
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, res)
-	}
-	return out, nil
+	return resolveAssignedRoles(r.MqlRuntime, items)
 }
 
 // ---- openstack.role ----
@@ -289,12 +278,13 @@ func initOpenstackRole(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetRoles()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			r := raw.(*mqlOpenstackRole)
-			if r.Id.Data == id {
-				return args, r, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		r := raw.(*mqlOpenstackRole)
+		if r.Id.Data == id {
+			return args, r, nil
 		}
 	}
 	initSyntheticID("openstack.role", "id", args)
@@ -368,12 +358,13 @@ func initOpenstackDomain(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetDomains()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			d := raw.(*mqlOpenstackDomain)
-			if d.Id.Data == id {
-				return args, d, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		d := raw.(*mqlOpenstackDomain)
+		if d.Id.Data == id {
+			return args, d, nil
 		}
 	}
 	initSyntheticID("openstack.domain", "id", args)
@@ -435,12 +426,13 @@ func initOpenstackGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetGroups()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			g := raw.(*mqlOpenstackGroup)
-			if g.Id.Data == id {
-				return args, g, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		g := raw.(*mqlOpenstackGroup)
+		if g.Id.Data == id {
+			return args, g, nil
 		}
 	}
 	initSyntheticID("openstack.group", "id", args)
@@ -474,21 +466,29 @@ func listKeystoneGroups(runtime *plugin.Runtime, opts groups.ListOpts) ([]any, e
 	}
 
 	out := make([]any, 0, len(items))
-	for _, g := range items {
-		res, err := CreateResource(runtime, "openstack.group", map[string]*llx.RawData{
-			"__id":        llx.StringData("openstack.group/" + g.ID),
-			"id":          llx.StringData(g.ID),
-			"name":        llx.StringData(g.Name),
-			"description": llx.StringData(g.Description),
-		})
+	for i := range items {
+		mqlGroup, err := newMqlOpenstackGroup(runtime, &items[i])
 		if err != nil {
 			return nil, err
 		}
-		mqlGroup := res.(*mqlOpenstackGroup)
-		mqlGroup.cacheDomainID = g.DomainID
 		out = append(out, mqlGroup)
 	}
 	return out, nil
+}
+
+func newMqlOpenstackGroup(runtime *plugin.Runtime, g *groups.Group) (*mqlOpenstackGroup, error) {
+	res, err := CreateResource(runtime, "openstack.group", map[string]*llx.RawData{
+		"__id":        llx.StringData("openstack.group/" + g.ID),
+		"id":          llx.StringData(g.ID),
+		"name":        llx.StringData(g.Name),
+		"description": llx.StringData(g.Description),
+	})
+	if err != nil {
+		return nil, err
+	}
+	mqlGroup := res.(*mqlOpenstackGroup)
+	mqlGroup.cacheDomainID = g.DomainID
+	return mqlGroup, nil
 }
 
 func (r *mqlOpenstackGroup) domain() (*mqlOpenstackDomain, error) {
@@ -524,14 +524,12 @@ func (r *mqlOpenstackGroup) users() ([]any, error) {
 	}
 
 	out := make([]any, 0, len(items))
-	for _, u := range items {
-		res, err := NewResource(r.MqlRuntime, "openstack.user", map[string]*llx.RawData{
-			"id": llx.StringData(u.ID),
-		})
+	for i := range items {
+		mqlUser, err := newMqlOpenstackUser(r.MqlRuntime, &items[i])
 		if err != nil {
 			return nil, err
 		}
-		out = append(out, res)
+		out = append(out, mqlUser)
 	}
 	return out, nil
 }
@@ -555,27 +553,7 @@ func (r *mqlOpenstackGroup) roles() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	seen := make(map[string]struct{}, len(items))
-	out := make([]any, 0, len(items))
-	for _, a := range items {
-		if a.Role.ID == "" {
-			continue
-		}
-		if _, dup := seen[a.Role.ID]; dup {
-			continue
-		}
-		seen[a.Role.ID] = struct{}{}
-		res, err := NewResource(r.MqlRuntime, "openstack.role", map[string]*llx.RawData{
-			"id":   llx.StringData(a.Role.ID),
-			"name": llx.StringData(a.Role.Name),
-		})
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, res)
-	}
-	return out, nil
+	return resolveAssignedRoles(r.MqlRuntime, items)
 }
 
 func (r *mqlOpenstackUser) groups() ([]any, error) {
@@ -597,9 +575,52 @@ func (r *mqlOpenstackUser) groups() ([]any, error) {
 	}
 
 	out := make([]any, 0, len(items))
-	for _, g := range items {
-		res, err := NewResource(r.MqlRuntime, "openstack.group", map[string]*llx.RawData{
-			"id": llx.StringData(g.ID),
+	for i := range items {
+		mqlGroup, err := newMqlOpenstackGroup(r.MqlRuntime, &items[i])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, mqlGroup)
+	}
+	return out, nil
+}
+
+// resolveAssignedRoles dedupes role assignments by role ID and, when the
+// caller has already triggered openstack.roles, resolves each role from the
+// cached list so the returned resources carry full data (name, domain).
+// ListAssignments returns only role IDs — accepting that as-is leaves a
+// blank `name` field on every assignment-derived role.
+func resolveAssignedRoles(runtime *plugin.Runtime, items []roles.RoleAssignment) ([]any, error) {
+	root, err := CreateResource(runtime, "openstack", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	list := root.(*mqlOpenstack).GetRoles()
+	var byID map[string]*mqlOpenstackRole
+	if list.Error == nil {
+		byID = make(map[string]*mqlOpenstackRole, len(list.Data))
+		for _, raw := range list.Data {
+			role := raw.(*mqlOpenstackRole)
+			byID[role.Id.Data] = role
+		}
+	}
+
+	seen := make(map[string]struct{}, len(items))
+	out := make([]any, 0, len(items))
+	for _, a := range items {
+		if a.Role.ID == "" {
+			continue
+		}
+		if _, dup := seen[a.Role.ID]; dup {
+			continue
+		}
+		seen[a.Role.ID] = struct{}{}
+		if role, ok := byID[a.Role.ID]; ok {
+			out = append(out, role)
+			continue
+		}
+		res, err := NewResource(runtime, "openstack.role", map[string]*llx.RawData{
+			"id": llx.StringData(a.Role.ID),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/openstack/resources/network.go
+++ b/providers/openstack/resources/network.go
@@ -752,12 +752,15 @@ func (o *mqlOpenstack) securityGroups() ([]any, error) {
 	// Prime the per-connection name->ID cache from this list call so that
 	// Nova security-group-by-name lookups (lookupSecurityGroupIDByName)
 	// reuse it instead of re-listing Neutron.
-	c.SGNameCacheOnce.Do(func() {
-		c.SGNameCache = make(map[string]string, len(items))
+	c.SGNameCacheLock.Lock()
+	if c.SGNameCache == nil {
+		cache := make(map[string]string, len(items))
 		for _, sg := range items {
-			c.SGNameCache[sg.Name] = sg.ID
+			cache[sg.Name] = sg.ID
 		}
-	})
+		c.SGNameCache = cache
+	}
+	c.SGNameCacheLock.Unlock()
 
 	out := make([]any, 0, len(items))
 	for i := range items {
@@ -856,32 +859,32 @@ func (r *mqlOpenstackSecurityGroupRule) remoteGroup() (*mqlOpenstackSecurityGrou
 
 // lookupSecurityGroupIDByName resolves a security-group name to an ID using a
 // per-connection cache. Nova reports server security groups by name, but
-// Neutron is the source of truth for IDs, so each connection lists groups once
-// and consults its cache thereafter. After the once-only fetch, reads are
-// lock-free.
+// Neutron is the source of truth for IDs, so each connection lists groups
+// once and consults its cache thereafter. The lock single-flights the first
+// fetch; on success or auth-translated failure the cache map is non-nil and
+// subsequent callers fast-path. Real errors leave the cache nil so the next
+// call retries instead of inheriting a stale error.
 func lookupSecurityGroupIDByName(c *connection.OpenstackConnection, client *gophercloud.ServiceClient, name string) (string, error) {
-	c.SGNameCacheOnce.Do(func() {
-		pages, err := groups.List(client, groups.ListOpts{}).AllPages(ctx())
-		if err != nil {
-			if translateOpenstackError(err) == nil {
-				c.SGNameCache = map[string]string{}
-				return
-			}
-			c.SGNameCacheErr = err
-			return
+	c.SGNameCacheLock.Lock()
+	defer c.SGNameCacheLock.Unlock()
+	if c.SGNameCache != nil {
+		return c.SGNameCache[name], nil
+	}
+	pages, err := groups.List(client, groups.ListOpts{}).AllPages(ctx())
+	if err != nil {
+		if translateOpenstackError(err) == nil {
+			c.SGNameCache = map[string]string{}
+			return "", nil
 		}
-		items, err := groups.ExtractGroups(pages)
-		if err != nil {
-			c.SGNameCacheErr = err
-			return
-		}
-		c.SGNameCache = make(map[string]string, len(items))
-		for _, sg := range items {
-			c.SGNameCache[sg.Name] = sg.ID
-		}
-	})
-	if c.SGNameCacheErr != nil {
-		return "", c.SGNameCacheErr
+		return "", err
+	}
+	items, err := groups.ExtractGroups(pages)
+	if err != nil {
+		return "", err
+	}
+	c.SGNameCache = make(map[string]string, len(items))
+	for _, sg := range items {
+		c.SGNameCache[sg.Name] = sg.ID
 	}
 	return c.SGNameCache[name], nil
 }

--- a/providers/openstack/resources/network.go
+++ b/providers/openstack/resources/network.go
@@ -177,12 +177,13 @@ func initOpenstackSubnet(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetSubnets()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			s := raw.(*mqlOpenstackSubnet)
-			if s.Id.Data == id {
-				return args, s, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		s := raw.(*mqlOpenstackSubnet)
+		if s.Id.Data == id {
+			return args, s, nil
 		}
 	}
 	initSyntheticID("openstack.subnet", "id", args)
@@ -311,12 +312,13 @@ func initOpenstackRouter(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetRouters()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			r := raw.(*mqlOpenstackRouter)
-			if r.Id.Data == id {
-				return args, r, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		r := raw.(*mqlOpenstackRouter)
+		if r.Id.Data == id {
+			return args, r, nil
 		}
 	}
 	initSyntheticID("openstack.router", "id", args)
@@ -438,12 +440,13 @@ func initOpenstackPort(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetPorts()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			p := raw.(*mqlOpenstackPort)
-			if p.Id.Data == id {
-				return args, p, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		p := raw.(*mqlOpenstackPort)
+		if p.Id.Data == id {
+			return args, p, nil
 		}
 	}
 	initSyntheticID("openstack.port", "id", args)
@@ -568,12 +571,13 @@ func initOpenstackFloatingIp(runtime *plugin.Runtime, args map[string]*llx.RawDa
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetFloatingIps()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			f := raw.(*mqlOpenstackFloatingIp)
-			if f.Id.Data == id {
-				return args, f, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		f := raw.(*mqlOpenstackFloatingIp)
+		if f.Id.Data == id {
+			return args, f, nil
 		}
 	}
 	initSyntheticID("openstack.floatingIp", "id", args)
@@ -683,15 +687,47 @@ func initOpenstackSecurityGroup(runtime *plugin.Runtime, args map[string]*llx.Ra
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetSecurityGroups()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			sg := raw.(*mqlOpenstackSecurityGroup)
-			if sg.Id.Data == id {
-				return args, sg, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		sg := raw.(*mqlOpenstackSecurityGroup)
+		if sg.Id.Data == id {
+			return args, sg, nil
 		}
 	}
-	initSyntheticID("openstack.securityGroup", "id", args)
+
+	// Cross-project rule references may point at a security group outside
+	// the locally listed set. Fall back to a direct Neutron Get so the
+	// caller observes real fields instead of a synthetic stub.
+	c := conn(runtime)
+	client, err := c.NetworkClient()
+	if err != nil {
+		initSyntheticID("openstack.securityGroup", "id", args)
+		return args, nil, nil
+	}
+	sg, err := groups.Get(ctx(), client, id).Extract()
+	if err != nil {
+		if translateGetError(err) == nil {
+			initSyntheticID("openstack.securityGroup", "id", args)
+			return args, nil, nil
+		}
+		return nil, nil, err
+	}
+	args["__id"] = llx.StringData("openstack.securityGroup/" + sg.ID)
+	args["id"] = llx.StringData(sg.ID)
+	args["name"] = llx.StringData(sg.Name)
+	args["description"] = llx.StringData(sg.Description)
+	args["stateful"] = llx.BoolData(sg.Stateful)
+	args["projectId"] = llx.StringData(sg.ProjectID)
+	args["tags"] = stringSliceData(sg.Tags)
+	args["createdAt"] = llx.TimeDataPtr(timePtr(sg.CreatedAt))
+	args["updatedAt"] = llx.TimeDataPtr(timePtr(sg.UpdatedAt))
+	ruleResources, err := buildSecurityGroupRules(runtime, sg)
+	if err != nil {
+		return nil, nil, err
+	}
+	args["rules"] = llx.ArrayData(ruleResources, types.Resource("openstack.securityGroup.rule"))
 	return args, nil, nil
 }
 
@@ -712,6 +748,16 @@ func (o *mqlOpenstack) securityGroups() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Prime the per-connection name->ID cache from this list call so that
+	// Nova security-group-by-name lookups (lookupSecurityGroupIDByName)
+	// reuse it instead of re-listing Neutron.
+	c.SGNameCacheOnce.Do(func() {
+		c.SGNameCache = make(map[string]string, len(items))
+		for _, sg := range items {
+			c.SGNameCache[sg.Name] = sg.ID
+		}
+	})
 
 	out := make([]any, 0, len(items))
 	for i := range items {
@@ -811,32 +857,32 @@ func (r *mqlOpenstackSecurityGroupRule) remoteGroup() (*mqlOpenstackSecurityGrou
 // lookupSecurityGroupIDByName resolves a security-group name to an ID using a
 // per-connection cache. Nova reports server security groups by name, but
 // Neutron is the source of truth for IDs, so each connection lists groups once
-// and consults its cache thereafter.
+// and consults its cache thereafter. After the once-only fetch, reads are
+// lock-free.
 func lookupSecurityGroupIDByName(c *connection.OpenstackConnection, client *gophercloud.ServiceClient, name string) (string, error) {
-	c.SGNameCacheLock.Lock()
-	defer c.SGNameCacheLock.Unlock()
-
-	if !c.SGNameCacheDone {
+	c.SGNameCacheOnce.Do(func() {
 		pages, err := groups.List(client, groups.ListOpts{}).AllPages(ctx())
 		if err != nil {
 			if translateOpenstackError(err) == nil {
-				c.SGNameCacheDone = true
 				c.SGNameCache = map[string]string{}
-				return "", nil
+				return
 			}
-			return "", err
+			c.SGNameCacheErr = err
+			return
 		}
 		items, err := groups.ExtractGroups(pages)
 		if err != nil {
-			return "", err
+			c.SGNameCacheErr = err
+			return
 		}
 		c.SGNameCache = make(map[string]string, len(items))
 		for _, sg := range items {
 			c.SGNameCache[sg.Name] = sg.ID
 		}
-		c.SGNameCacheDone = true
+	})
+	if c.SGNameCacheErr != nil {
+		return "", c.SGNameCacheErr
 	}
-
 	return c.SGNameCache[name], nil
 }
 

--- a/providers/openstack/resources/network.go
+++ b/providers/openstack/resources/network.go
@@ -751,7 +751,13 @@ func (o *mqlOpenstack) securityGroups() ([]any, error) {
 
 	// Prime the per-connection name->ID cache from this list call so that
 	// Nova security-group-by-name lookups (lookupSecurityGroupIDByName)
-	// reuse it instead of re-listing Neutron.
+	// reuse it instead of re-listing Neutron. First-writer-wins: whichever
+	// path populates the cache first (this accessor or
+	// lookupSecurityGroupIDByName) sets the canonical name->ID map for the
+	// connection's lifetime. Both paths list with default scope, so the
+	// result sets are equivalent; if scoping ever diverges, the second
+	// caller's data is silently ignored — at which point the cache should
+	// move into the lookup function itself.
 	c.SGNameCacheLock.Lock()
 	if c.SGNameCache == nil {
 		cache := make(map[string]string, len(items))
@@ -899,8 +905,11 @@ func (o *mqlOpenstack) networkQuotaSet() (*mqlOpenstackNetworkQuotaSet, error) {
 	c := conn(o.MqlRuntime)
 	client, err := c.NetworkClient()
 	if err != nil {
-		o.NetworkQuotaSet.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
+		if serviceMissing(err) {
+			o.NetworkQuotaSet.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		return nil, err
 	}
 	projectId := c.ProjectID()
 	q, err := neutronquotas.Get(ctx(), client, projectId).Extract()

--- a/providers/openstack/resources/network_extensions.go
+++ b/providers/openstack/resources/network_extensions.go
@@ -31,12 +31,13 @@ func initOpenstackSubnetPool(runtime *plugin.Runtime, args map[string]*llx.RawDa
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetSubnetPools()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			sp := raw.(*mqlOpenstackSubnetPool)
-			if sp.Id.Data == id {
-				return args, sp, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		sp := raw.(*mqlOpenstackSubnetPool)
+		if sp.Id.Data == id {
+			return args, sp, nil
 		}
 	}
 	initSyntheticID("openstack.subnetPool", "id", args)
@@ -116,12 +117,13 @@ func initOpenstackQosPolicy(runtime *plugin.Runtime, args map[string]*llx.RawDat
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetQosPolicies()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			q := raw.(*mqlOpenstackQosPolicy)
-			if q.Id.Data == id {
-				return args, q, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		q := raw.(*mqlOpenstackQosPolicy)
+		if q.Id.Data == id {
+			return args, q, nil
 		}
 	}
 	initSyntheticID("openstack.qosPolicy", "id", args)
@@ -205,12 +207,13 @@ func initOpenstackTrunk(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetTrunks()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			t := raw.(*mqlOpenstackTrunk)
-			if t.Id.Data == id {
-				return args, t, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		t := raw.(*mqlOpenstackTrunk)
+		if t.Id.Data == id {
+			return args, t, nil
 		}
 	}
 	initSyntheticID("openstack.trunk", "id", args)

--- a/providers/openstack/resources/octavia.go
+++ b/providers/openstack/resources/octavia.go
@@ -11,9 +11,9 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/loadbalancers"
 	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/monitors"
 	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/pools"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/types"
 )
 
 // barbicanRefIsContainer reports whether a Barbican ref URL points at a
@@ -62,7 +62,11 @@ func (r *mqlOpenstackOctaviaLoadBalancer) id() (string, error) {
 }
 
 func initOpenstackOctaviaLoadBalancer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	if len(args) >= 2 {
+	// Skip the per-ID Get when the caller already supplied populated
+	// fields. provisioningStatus is mandatory in every Octavia API
+	// response, so its presence reliably distinguishes a fully-populated
+	// resource from one created with just {__id, id}.
+	if _, ok := args["provisioningStatus"]; ok {
 		return args, nil, nil
 	}
 	id, ok := stringArg(args, "id")
@@ -277,12 +281,13 @@ func initOpenstackOctaviaListener(runtime *plugin.Runtime, args map[string]*llx.
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetListeners()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			l := raw.(*mqlOpenstackOctaviaListener)
-			if l.Id.Data == id {
-				return args, l, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		l := raw.(*mqlOpenstackOctaviaListener)
+		if l.Id.Data == id {
+			return args, l, nil
 		}
 	}
 	initSyntheticID("openstack.octavia.listener", "id", args)
@@ -340,6 +345,12 @@ func (o *mqlOpenstack) listeners() ([]any, error) {
 		mqlL.cacheProjectID = l.ProjectID
 		if len(l.Loadbalancers) > 0 {
 			mqlL.cacheLoadBalancerID = l.Loadbalancers[0].ID
+			if len(l.Loadbalancers) > 1 {
+				log.Warn().
+					Str("listenerId", l.ID).
+					Int("loadBalancerCount", len(l.Loadbalancers)).
+					Msg("openstack: listener references multiple load balancers; exposing only the first")
+			}
 		}
 		mqlL.cacheDefaultPoolID = l.DefaultPoolID
 		mqlL.cacheDefaultTlsContainerRef = l.DefaultTlsContainerRef
@@ -463,6 +474,7 @@ type mqlOpenstackOctaviaPoolInternal struct {
 	cacheCATlsContainerRef     string
 	cacheCRLContainerRef       string
 	cacheClientTlsContainerRef string
+	cacheMembers               []pools.Member
 }
 
 func (r *mqlOpenstackOctaviaPool) id() (string, error) {
@@ -479,12 +491,13 @@ func initOpenstackOctaviaPool(runtime *plugin.Runtime, args map[string]*llx.RawD
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetPools()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			p := raw.(*mqlOpenstackOctaviaPool)
-			if p.Id.Data == id {
-				return args, p, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		p := raw.(*mqlOpenstackOctaviaPool)
+		if p.Id.Data == id {
+			return args, p, nil
 		}
 	}
 	initSyntheticID("openstack.octavia.pool", "id", args)
@@ -512,10 +525,6 @@ func (o *mqlOpenstack) pools() ([]any, error) {
 	out := make([]any, 0, len(items))
 	for i := range items {
 		p := &items[i]
-		members, err := buildOctaviaMembers(o.MqlRuntime, p)
-		if err != nil {
-			return nil, err
-		}
 		res, err := CreateResource(o.MqlRuntime, "openstack.octavia.pool", map[string]*llx.RawData{
 			"__id":               llx.StringData("openstack.octavia.pool/" + p.ID),
 			"id":                 llx.StringData(p.ID),
@@ -533,7 +542,6 @@ func (o *mqlOpenstack) pools() ([]any, error) {
 			"tlsVersions":        stringSliceData(p.TLSVersions),
 			"alpnProtocols":      stringSliceData(p.ALPNProtocols),
 			"tags":               stringSliceData(p.Tags),
-			"members":            llx.ArrayData(members, types.Resource("openstack.octavia.member")),
 		})
 		if err != nil {
 			return nil, err
@@ -542,6 +550,12 @@ func (o *mqlOpenstack) pools() ([]any, error) {
 		mqlP.cacheProjectID = p.ProjectID
 		if len(p.Loadbalancers) > 0 {
 			mqlP.cacheLoadBalancerID = p.Loadbalancers[0].ID
+			if len(p.Loadbalancers) > 1 {
+				log.Warn().
+					Str("poolId", p.ID).
+					Int("loadBalancerCount", len(p.Loadbalancers)).
+					Msg("openstack: pool references multiple load balancers; exposing only the first")
+			}
 		}
 		mqlP.cacheListenerIDs = listenerIDsFromPoolListeners(p.Listeners)
 		mqlP.cacheHealthMonitorID = p.MonitorID
@@ -549,9 +563,14 @@ func (o *mqlOpenstack) pools() ([]any, error) {
 		mqlP.cacheCATlsContainerRef = p.CATLSContainerRef
 		mqlP.cacheCRLContainerRef = p.CRLContainerRef
 		mqlP.cacheClientTlsContainerRef = p.TLSContainerRef
+		mqlP.cacheMembers = p.Members
 		out = append(out, mqlP)
 	}
 	return out, nil
+}
+
+func (r *mqlOpenstackOctaviaPool) members() ([]any, error) {
+	return buildOctaviaMembers(r.MqlRuntime, r.cacheMembers)
 }
 
 func (r *mqlOpenstackOctaviaPool) project() (*mqlOpenstackProject, error) {
@@ -675,10 +694,10 @@ func (r *mqlOpenstackOctaviaMember) id() (string, error) {
 	return "openstack.octavia.member/" + r.Id.Data, nil
 }
 
-func buildOctaviaMembers(runtime *plugin.Runtime, p *pools.Pool) ([]any, error) {
-	out := make([]any, 0, len(p.Members))
-	for i := range p.Members {
-		m := &p.Members[i]
+func buildOctaviaMembers(runtime *plugin.Runtime, members []pools.Member) ([]any, error) {
+	out := make([]any, 0, len(members))
+	for i := range members {
+		m := &members[i]
 		res, err := CreateResource(runtime, "openstack.octavia.member", map[string]*llx.RawData{
 			"__id":               llx.StringData("openstack.octavia.member/" + m.ID),
 			"id":                 llx.StringData(m.ID),
@@ -757,12 +776,13 @@ func initOpenstackOctaviaHealthMonitor(runtime *plugin.Runtime, args map[string]
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetHealthMonitors()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			h := raw.(*mqlOpenstackOctaviaHealthMonitor)
-			if h.Id.Data == id {
-				return args, h, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		h := raw.(*mqlOpenstackOctaviaHealthMonitor)
+		if h.Id.Data == id {
+			return args, h, nil
 		}
 	}
 	initSyntheticID("openstack.octavia.healthMonitor", "id", args)
@@ -856,6 +876,7 @@ type mqlOpenstackOctaviaL7PolicyInternal struct {
 	cacheProjectID      string
 	cacheListenerID     string
 	cacheRedirectPoolID string
+	cacheRules          []l7policies.Rule
 }
 
 func (r *mqlOpenstackOctaviaL7Policy) id() (string, error) {
@@ -872,12 +893,13 @@ func initOpenstackOctaviaL7Policy(runtime *plugin.Runtime, args map[string]*llx.
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetL7Policies()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			p := raw.(*mqlOpenstackOctaviaL7Policy)
-			if p.Id.Data == id {
-				return args, p, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		p := raw.(*mqlOpenstackOctaviaL7Policy)
+		if p.Id.Data == id {
+			return args, p, nil
 		}
 	}
 	initSyntheticID("openstack.octavia.l7Policy", "id", args)
@@ -905,10 +927,6 @@ func (o *mqlOpenstack) l7Policies() ([]any, error) {
 	out := make([]any, 0, len(items))
 	for i := range items {
 		p := &items[i]
-		rules, err := buildOctaviaL7Rules(o.MqlRuntime, p)
-		if err != nil {
-			return nil, err
-		}
 		res, err := CreateResource(o.MqlRuntime, "openstack.octavia.l7Policy", map[string]*llx.RawData{
 			"__id":               llx.StringData("openstack.octavia.l7Policy/" + p.ID),
 			"id":                 llx.StringData(p.ID),
@@ -923,7 +941,6 @@ func (o *mqlOpenstack) l7Policies() ([]any, error) {
 			"provisioningStatus": llx.StringData(p.ProvisioningStatus),
 			"operatingStatus":    llx.StringData(p.OperatingStatus),
 			"tags":               stringSliceData(p.Tags),
-			"rules":              llx.ArrayData(rules, types.Resource("openstack.octavia.l7Rule")),
 		})
 		if err != nil {
 			return nil, err
@@ -932,9 +949,14 @@ func (o *mqlOpenstack) l7Policies() ([]any, error) {
 		mqlP.cacheProjectID = p.ProjectID
 		mqlP.cacheListenerID = p.ListenerID
 		mqlP.cacheRedirectPoolID = p.RedirectPoolID
+		mqlP.cacheRules = p.Rules
 		out = append(out, mqlP)
 	}
 	return out, nil
+}
+
+func (r *mqlOpenstackOctaviaL7Policy) rules() ([]any, error) {
+	return buildOctaviaL7Rules(r.MqlRuntime, r.Id.Data, r.cacheRules)
 }
 
 func (r *mqlOpenstackOctaviaL7Policy) project() (*mqlOpenstackProject, error) {
@@ -976,10 +998,10 @@ func (r *mqlOpenstackOctaviaL7Rule) id() (string, error) {
 	return "openstack.octavia.l7Rule/" + r.Id.Data, nil
 }
 
-func buildOctaviaL7Rules(runtime *plugin.Runtime, policy *l7policies.L7Policy) ([]any, error) {
-	out := make([]any, 0, len(policy.Rules))
-	for i := range policy.Rules {
-		rule := &policy.Rules[i]
+func buildOctaviaL7Rules(runtime *plugin.Runtime, policyID string, rules []l7policies.Rule) ([]any, error) {
+	out := make([]any, 0, len(rules))
+	for i := range rules {
+		rule := &rules[i]
 		res, err := CreateResource(runtime, "openstack.octavia.l7Rule", map[string]*llx.RawData{
 			"__id":               llx.StringData("openstack.octavia.l7Rule/" + rule.ID),
 			"id":                 llx.StringData(rule.ID),
@@ -998,7 +1020,7 @@ func buildOctaviaL7Rules(runtime *plugin.Runtime, policy *l7policies.L7Policy) (
 		}
 		mqlR := res.(*mqlOpenstackOctaviaL7Rule)
 		mqlR.cacheProjectID = rule.ProjectID
-		mqlR.cacheL7PolicyID = policy.ID
+		mqlR.cacheL7PolicyID = policyID
 		out = append(out, mqlR)
 	}
 	return out, nil

--- a/providers/openstack/resources/openstack.lr
+++ b/providers/openstack/resources/openstack.lr
@@ -960,7 +960,7 @@ private openstack.octavia.pool @defaults("id name lbAlgorithm protocol provision
   // Barbican container holding the client cert/key bundle for backend mTLS; null when not set
   clientTlsContainer() openstack.keymanager.container
   // Members in this pool
-  members []openstack.octavia.member
+  members() []openstack.octavia.member
 }
 
 // OpenStack Octavia pool member
@@ -1078,7 +1078,7 @@ private openstack.octavia.l7Policy @defaults("id name action position provisioni
   // Pool requests are redirected to when action is REDIRECT_TO_POOL; null otherwise
   redirectPool() openstack.octavia.pool
   // Match rules; the policy fires when ALL rules match
-  rules []openstack.octavia.l7Rule
+  rules() []openstack.octavia.l7Rule
 }
 
 // OpenStack Octavia L7 match rule

--- a/providers/openstack/resources/openstack.lr.go
+++ b/providers/openstack/resources/openstack.lr.go
@@ -10169,7 +10169,19 @@ func (c *mqlOpenstackOctaviaPool) GetClientTlsContainer() *plugin.TValue[*mqlOpe
 }
 
 func (c *mqlOpenstackOctaviaPool) GetMembers() *plugin.TValue[[]any] {
-	return &c.Members
+	return plugin.GetOrCompute[[]any](&c.Members, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.octavia.pool", c.__id, "members")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.members()
+	})
 }
 
 // mqlOpenstackOctaviaMember for the openstack.octavia.member resource
@@ -10657,7 +10669,19 @@ func (c *mqlOpenstackOctaviaL7Policy) GetRedirectPool() *plugin.TValue[*mqlOpens
 }
 
 func (c *mqlOpenstackOctaviaL7Policy) GetRules() *plugin.TValue[[]any] {
-	return &c.Rules
+	return plugin.GetOrCompute[[]any](&c.Rules, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.octavia.l7Policy", c.__id, "rules")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.rules()
+	})
 }
 
 // mqlOpenstackOctaviaL7Rule for the openstack.octavia.l7Rule resource

--- a/providers/openstack/resources/swift.go
+++ b/providers/openstack/resources/swift.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"strings"
+	"sync"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/objectstorage/v1/accounts"
@@ -67,6 +68,7 @@ func (o *mqlOpenstack) objectStorageAccount() (*mqlOpenstackObjectstorageAccount
 // ---- openstack.objectstorage.container ----
 
 type mqlOpenstackObjectstorageContainerInternal struct {
+	headerLock    sync.Mutex
 	headerFetched bool
 	headerErr     error
 	header        *containers.GetHeader
@@ -87,12 +89,13 @@ func initOpenstackObjectstorageContainer(runtime *plugin.Runtime, args map[strin
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetObjectStorageContainers()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			cc := raw.(*mqlOpenstackObjectstorageContainer)
-			if cc.Name.Data == name {
-				return args, cc, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		cc := raw.(*mqlOpenstackObjectstorageContainer)
+		if cc.Name.Data == name {
+			return args, cc, nil
 		}
 	}
 	initSyntheticID("openstack.objectstorage.container", "name", args)
@@ -134,6 +137,8 @@ func (o *mqlOpenstack) objectStorageContainers() ([]any, error) {
 }
 
 func (r *mqlOpenstackObjectstorageContainer) fetchHeader() (*containers.GetHeader, map[string]string, error) {
+	r.headerLock.Lock()
+	defer r.headerLock.Unlock()
 	if r.headerFetched {
 		return r.header, r.headerMeta, r.headerErr
 	}

--- a/providers/openstack/resources/volumes.go
+++ b/providers/openstack/resources/volumes.go
@@ -725,6 +725,10 @@ func (o *mqlOpenstack) blockStorageQuotaSet() (*mqlOpenstackBlockstorageQuotaSet
 	c := conn(o.MqlRuntime)
 	client, err := c.BlockStorageClient()
 	if err != nil {
+		if serviceMissing(err) {
+			o.BlockStorageQuotaSet.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	projectId := c.ProjectID()

--- a/providers/openstack/resources/volumes.go
+++ b/providers/openstack/resources/volumes.go
@@ -44,12 +44,13 @@ func initOpenstackBlockstorageVolume(runtime *plugin.Runtime, args map[string]*l
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetVolumes()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			v := raw.(*mqlOpenstackBlockstorageVolume)
-			if v.Id.Data == id {
-				return args, v, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		v := raw.(*mqlOpenstackBlockstorageVolume)
+		if v.Id.Data == id {
+			return args, v, nil
 		}
 	}
 	initSyntheticID("openstack.blockstorage.volume", "id", args)
@@ -315,12 +316,13 @@ func initOpenstackBlockstorageSnapshot(runtime *plugin.Runtime, args map[string]
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetSnapshots()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			s := raw.(*mqlOpenstackBlockstorageSnapshot)
-			if s.Id.Data == id {
-				return args, s, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		s := raw.(*mqlOpenstackBlockstorageSnapshot)
+		if s.Id.Data == id {
+			return args, s, nil
 		}
 	}
 	initSyntheticID("openstack.blockstorage.snapshot", "id", args)
@@ -438,12 +440,13 @@ func initOpenstackBlockstorageVolumeType(runtime *plugin.Runtime, args map[strin
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetVolumeTypes()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			vt := raw.(*mqlOpenstackBlockstorageVolumeType)
-			if vt.Id.Data == id {
-				return args, vt, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		vt := raw.(*mqlOpenstackBlockstorageVolumeType)
+		if vt.Id.Data == id {
+			return args, vt, nil
 		}
 	}
 	initSyntheticID("openstack.blockstorage.volumeType", "id", args)
@@ -598,12 +601,13 @@ func initOpenstackBlockstorageBackup(runtime *plugin.Runtime, args map[string]*l
 		return nil, nil, err
 	}
 	list := root.(*mqlOpenstack).GetBackups()
-	if list.Error == nil {
-		for _, raw := range list.Data {
-			b := raw.(*mqlOpenstackBlockstorageBackup)
-			if b.Id.Data == id {
-				return args, b, nil
-			}
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		b := raw.(*mqlOpenstackBlockstorageBackup)
+		if b.Id.Data == id {
+			return args, b, nil
 		}
 	}
 	initSyntheticID("openstack.blockstorage.backup", "id", args)
@@ -721,8 +725,7 @@ func (o *mqlOpenstack) blockStorageQuotaSet() (*mqlOpenstackBlockstorageQuotaSet
 	c := conn(o.MqlRuntime)
 	client, err := c.BlockStorageClient()
 	if err != nil {
-		o.BlockStorageQuotaSet.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
+		return nil, err
 	}
 	projectId := c.ProjectID()
 	q, err := quotasets.Get(ctx(), client, projectId).Extract()


### PR DESCRIPTION
## Summary

Outcome of a deep-dive review focused on nil handling, logic errors, pagination, and performance. Pagination was clean throughout; the rest had real issues.

### High-severity

- **Inverted error checks in `init` functions** (the biggest blast radius). Every init except `initOpenstackNetwork` wrote `if list.Error == nil { ... }` and fell through to `initSyntheticID` on failure, so an auth/extension/transient error produced a blank stub resource instead of surfacing the error. Fixed across ~20 init functions (network, network_extensions, firewall, octavia, keystone, compute, volumes, dns, images, keymanager, swift).
- **Octavia: `pool.members` and `l7Policy.rules` were stored fields, force-eagerly built** during the pools/L7-policies list — paid by every scan even when the field isn't queried. Converted to lazy computed methods backed by `cacheMembers`/`cacheRules`.
- **Locks held across blocking HTTP** in `lookupFlavorIDByName` and `lookupSecurityGroupIDByName`. Switched to `sync.Once` so cache reads after the first call are lock-free; `securityGroups()` now also primes the SG name cache so the two paths don't double-fetch.
- **Swift `fetchHeader` had no mutex** despite the double-check pattern — concurrent `public()` / `readACL()` could race. Added `sync.Mutex`.
- **`computeLimits` and `blockStorageQuotaSet` swallowed client-construction errors** as `StateIsNull`. Errors now propagate.
- **Multi-LB listener/pool truncation**: Octavia listener/pool `loadBalancer()` silently kept only `Loadbalancers[0]`. Now warn-logs when more than one is reported.
- **`barbicanRefID` empty → `__id` collision**: Barbican records whose ref URL doesn't yield a tail segment used to collide on `"openstack.keymanager.<type>/"`. Now skipped with a warning.

### Medium-severity

- **Cross-project security-group `remoteGroup`** stub: `initOpenstackSecurityGroup` now falls back to a direct Neutron `Get` when the rule references a group outside the local list, so `remoteGroup.name` resolves to real data instead of empty.
- **Keystone role-assignment names**: `user.roles` / `group.roles` resolved roles by ID only, leaving `name` blank when `openstack.roles` hadn't been queried. Now resolves via the cached global roles list when present.
- **`group.users` / `user.groups` discarded full record data**: replaced `NewResource(id only)` with full `newMqlOpenstackUser`/`newMqlOpenstackGroup` builders so the runtime cache is primed and downstream field accesses don't trigger a full Keystone list re-fetch.
- **Firewall policy `rules()` did O(N×M) lookup**: now builds a `map[id]rule` index from the global rules list once per call.
- **`initOpenstackOctaviaLoadBalancer` guard too loose**: `len(args) >= 2` skipped the per-ID `Get` even when only `{__id, id}` were present. Now checks `provisioningStatus` (always present on a populated LB).
- **Auth region fallback was dead code**: `clientOpts.RegionName` was always the same value as `opts[OPTION_REGION]`, so the clouds.yaml region never made it through. Now reads from `clientconfig.GetCloudFromYAML` when no explicit `--region` is supplied.

### Cleanly verified

- All `*.List(...)` calls in the provider already use `AllPages()` — pagination was clean before and remains so.
- `StateIsNull` compliance for singular resource accessors is clean across all files.
- `__id` namespacing pattern (`"openstack.<type>/" + id`) avoids cross-type cache collisions.

## Test plan

- [ ] `make providers/build/openstack && make providers/install/openstack`
- [ ] `cnspec shell openstack` and run common audit queries to confirm shape unchanged
- [ ] `openstack.octavia.loadBalancers { pools { members { address } } }` to verify lazy members still resolve
- [ ] `openstack.octavia.l7Policies { rules { ruleType } }` to verify lazy rules still resolve
- [ ] Query `openstack.user.roles { name }` on a setup with assigned roles — name should be populated
- [ ] Race detector: `go test -race ./providers/openstack/...` (already passes locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)