### PR TITLE
🐛 aws: cloudformation fixes — DELETED stack sets, dict shape, eager tags, drift normalization

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -20375,11 +20375,12 @@ private aws.lightsail.bucket @defaults("name arn") {
 // Use the CloudFormation namespace to enumerate infrastructure-as-code
 // deployments in the account. Iterate `stacks()` for every CloudFormation
 // stack across enabled regions (with its template-driven parameters,
-// outputs, capabilities, drift status, deletion-protection flag,
-// rollback configuration, and notification ARNs), and `stackSets()` for
-// stack sets that deploy a single template across multiple accounts and
-// regions in an organization (with their permission model, deployment
-// targets, and stack instances).
+// outputs, capabilities, drift status, deletion-protection flag, and
+// notification ARNs), and `stackSets()` for stack sets that deploy a
+// single template across multiple accounts and regions in an
+// organization (with their permission model, deployment targets, and
+// stack instances). Both ACTIVE and DELETED stack sets are returned;
+// filter with `where(status == "ACTIVE")` if you only want live ones.
 aws.cloudformation @defaults("stacks") {
   // List of CloudFormation stacks
   stacks() []aws.cloudformation.stack
@@ -20442,7 +20443,7 @@ private aws.cloudformation.stackSet @defaults("name status") {
   // Whether auto deployment is enabled
   autoDeploymentEnabled() bool
   // Tags for the stack set
-  tags() map[string]string
+  tags map[string]string
 }
 
 // Amazon Keyspaces (for Apache Cassandra)

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -155239,9 +155239,7 @@ func (c *mqlAwsCloudformationStackSet) GetAutoDeploymentEnabled() *plugin.TValue
 }
 
 func (c *mqlAwsCloudformationStackSet) GetTags() *plugin.TValue[map[string]any] {
-	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
-		return c.tags()
-	})
+	return &c.Tags
 }
 
 // mqlAwsKeyspaces for the aws.keyspaces resource

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -1123,7 +1123,7 @@ aws.cloudformation.stackSet.permissionModel 13.1.1
 aws.cloudformation.stackSet.region 13.1.1
 aws.cloudformation.stackSet.stackSetId 13.1.1
 aws.cloudformation.stackSet.status 13.1.1
-aws.cloudformation.stackSet.tags 13.1.1
+aws.cloudformation.stackSet.tags 13.26.3
 aws.cloudformation.stackSets 13.1.1
 aws.cloudformation.stacks 13.1.1
 aws.cloudfront 11.15.2

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.26.2",
-  "generated_at": "2026-05-21T20:50:50-07:00",
+  "generated_at": "2026-05-23T00:26:47-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindingsV2",

--- a/providers/aws/resources/aws_cloudformation.go
+++ b/providers/aws/resources/aws_cloudformation.go
@@ -5,7 +5,6 @@ package resources
 
 import (
 	"context"
-	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
@@ -13,7 +12,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/aws/connection"
 	"go.mondoo.com/mql/v13/types"
@@ -38,6 +36,61 @@ func (a *mqlAwsCloudformation) stacks() ([]any, error) {
 		}
 	}
 	return res, nil
+}
+
+func cfnTagsToMap(in []cf_types.Tag) map[string]any {
+	tags := make(map[string]any, len(in))
+	for _, t := range in {
+		if t.Key == nil {
+			continue
+		}
+		val := ""
+		if t.Value != nil {
+			val = *t.Value
+		}
+		tags[*t.Key] = val
+	}
+	return tags
+}
+
+// stackParameterToDict converts an SDK Parameter to a dict with lowercase
+// keys. ResolvedValue and UsePreviousValue are only emitted when present
+// since they're context-specific (SSM-resolved params and stack updates).
+func stackParameterToDict(p cf_types.Parameter) map[string]any {
+	d := map[string]any{
+		"key":   aws.ToString(p.ParameterKey),
+		"value": aws.ToString(p.ParameterValue),
+	}
+	if p.ResolvedValue != nil {
+		d["resolvedValue"] = *p.ResolvedValue
+	}
+	if p.UsePreviousValue != nil {
+		d["usePreviousValue"] = *p.UsePreviousValue
+	}
+	return d
+}
+
+func stackOutputToDict(o cf_types.Output) map[string]any {
+	d := map[string]any{
+		"key":   aws.ToString(o.OutputKey),
+		"value": aws.ToString(o.OutputValue),
+	}
+	if o.Description != nil {
+		d["description"] = *o.Description
+	}
+	if o.ExportName != nil {
+		d["exportName"] = *o.ExportName
+	}
+	return d
+}
+
+// normalizeDriftStatus maps the empty enum default to NOT_CHECKED so the
+// field always carries one of the four documented values.
+func normalizeDriftStatus(s string) string {
+	if s == "" {
+		return "NOT_CHECKED"
+	}
+	return s
 }
 
 func (a *mqlAwsCloudformation) getStacks(conn *connection.AwsConnection) []*jobpool.Job {
@@ -73,17 +126,6 @@ func (a *mqlAwsCloudformation) getStacks(conn *connection.AwsConnection) []*jobp
 				}
 
 				for _, stack := range resp.Stacks {
-					tags := make(map[string]any)
-					for _, t := range stack.Tags {
-						if t.Key != nil {
-							val := ""
-							if t.Value != nil {
-								val = *t.Value
-							}
-							tags[*t.Key] = val
-						}
-					}
-
 					capabilities := make([]any, len(stack.Capabilities))
 					for j, c := range stack.Capabilities {
 						capabilities[j] = string(c)
@@ -105,8 +147,8 @@ func (a *mqlAwsCloudformation) getStacks(conn *connection.AwsConnection) []*jobp
 							"description":                 llx.StringDataPtr(stack.Description),
 							"enableTerminationProtection": llx.BoolDataPtr(stack.EnableTerminationProtection),
 							"capabilities":                llx.ArrayData(capabilities, types.String),
-							"driftStatus":                 llx.StringData(driftStatus),
-							"tags":                        llx.MapData(tags, types.String),
+							"driftStatus":                 llx.StringData(normalizeDriftStatus(driftStatus)),
+							"tags":                        llx.MapData(cfnTagsToMap(stack.Tags), types.String),
 							"createdAt":                   llx.TimeDataPtr(stack.CreationTime),
 							"updatedAt":                   llx.TimeDataPtr(stack.LastUpdatedTime),
 						})
@@ -156,17 +198,17 @@ func (a *mqlAwsCloudformationStack) iamRole() (*mqlAwsIamRole, error) {
 }
 
 func (a *mqlAwsCloudformationStack) parameters() ([]any, error) {
-	res, err := convert.JsonToDictSlice(a.cacheParameters)
-	if err != nil {
-		return nil, err
+	res := make([]any, 0, len(a.cacheParameters))
+	for _, p := range a.cacheParameters {
+		res = append(res, stackParameterToDict(p))
 	}
 	return res, nil
 }
 
 func (a *mqlAwsCloudformationStack) outputs() ([]any, error) {
-	res, err := convert.JsonToDictSlice(a.cacheOutputs)
-	if err != nil {
-		return nil, err
+	res := make([]any, 0, len(a.cacheOutputs))
+	for _, o := range a.cacheOutputs {
+		res = append(res, stackOutputToDict(o))
 	}
 	return res, nil
 }
@@ -204,6 +246,14 @@ func (a *mqlAwsCloudformation) stackSets() ([]any, error) {
 	return res, nil
 }
 
+// stackSetStatusesToEnumerate are the statuses we sweep. ListStackSets
+// defaults to ACTIVE only when Status is unset, so DELETED needs a
+// second explicit call.
+var stackSetStatusesToEnumerate = []cf_types.StackSetStatus{
+	cf_types.StackSetStatusActive,
+	cf_types.StackSetStatusDeleted,
+}
+
 func (a *mqlAwsCloudformation) getStackSets(conn *connection.AwsConnection) []*jobpool.Job {
 	tasks := make([]*jobpool.Job, 0)
 	regions, err := conn.Regions()
@@ -219,52 +269,74 @@ func (a *mqlAwsCloudformation) getStackSets(conn *connection.AwsConnection) []*j
 			ctx := context.Background()
 			res := []any{}
 
-			var nextToken *string
-			for {
-				resp, err := svc.ListStackSets(ctx, &cloudformation.ListStackSetsInput{
-					NextToken: nextToken,
-					Status:    cf_types.StackSetStatusActive,
-				})
-				if err != nil {
-					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
-						return res, nil
-					}
-					if IsServiceNotAvailableInRegionError(err) {
-						log.Warn().Str("region", region).Msg("CloudFormation is not available in region")
-						return res, nil
-					}
-					return nil, err
-				}
-
-				for _, ss := range resp.Summaries {
-					driftStatus := string(ss.DriftStatus)
-
-					mqlSs, err := CreateResource(a.MqlRuntime, "aws.cloudformation.stackSet",
-						map[string]*llx.RawData{
-							"__id":            llx.StringData(region + "/" + aws.ToString(ss.StackSetId)),
-							"stackSetId":      llx.StringDataPtr(ss.StackSetId),
-							"name":            llx.StringDataPtr(ss.StackSetName),
-							"region":          llx.StringData(region),
-							"status":          llx.StringData(string(ss.Status)),
-							"description":     llx.StringDataPtr(ss.Description),
-							"permissionModel": llx.StringData(string(ss.PermissionModel)),
-							"driftStatus":     llx.StringData(driftStatus),
-						})
+			for _, status := range stackSetStatusesToEnumerate {
+				var nextToken *string
+				for {
+					resp, err := svc.ListStackSets(ctx, &cloudformation.ListStackSetsInput{
+						NextToken: nextToken,
+						Status:    status,
+					})
 					if err != nil {
+						if Is400AccessDeniedError(err) {
+							log.Warn().Str("region", region).Msg("error accessing region for AWS API")
+							return res, nil
+						}
+						if IsServiceNotAvailableInRegionError(err) {
+							log.Warn().Str("region", region).Msg("CloudFormation is not available in region")
+							return res, nil
+						}
 						return nil, err
 					}
-					mqlSsRes := mqlSs.(*mqlAwsCloudformationStackSet)
-					mqlSsRes.cacheAutoDeployment = ss.AutoDeployment
-					mqlSsRes.cacheStackSetId = ss.StackSetId
-					mqlSsRes.cacheRegion = region
-					res = append(res, mqlSsRes)
-				}
 
-				if resp.NextToken == nil {
-					break
+					for _, ss := range resp.Summaries {
+						// Resolve tags inline by calling DescribeStackSet here
+						// rather than deferring to a lazy per-resource accessor.
+						// Tags are only fetchable via DescribeStackSet, and the
+						// previous lazy pattern produced an N-serial-call burst
+						// whenever a user queried `stackSets { tags }`. Inlining
+						// keeps the calls within the parallel region sweep so
+						// each region's tag lookups serialize among themselves
+						// but run concurrently across regions.
+						tags := map[string]any{}
+						if ss.Status == cf_types.StackSetStatusActive && ss.StackSetId != nil {
+							dresp, derr := svc.DescribeStackSet(ctx, &cloudformation.DescribeStackSetInput{
+								StackSetName: ss.StackSetId,
+							})
+							if derr != nil {
+								if !Is400AccessDeniedError(derr) && !IsServiceNotAvailableInRegionError(derr) {
+									return nil, derr
+								}
+								log.Debug().Str("region", region).Str("stackSet", aws.ToString(ss.StackSetId)).Msg("could not describe stack set for tags")
+							} else if dresp.StackSet != nil {
+								tags = cfnTagsToMap(dresp.StackSet.Tags)
+							}
+						}
+
+						mqlSs, err := CreateResource(a.MqlRuntime, "aws.cloudformation.stackSet",
+							map[string]*llx.RawData{
+								"__id":            llx.StringData(region + "/" + aws.ToString(ss.StackSetId)),
+								"stackSetId":      llx.StringDataPtr(ss.StackSetId),
+								"name":            llx.StringDataPtr(ss.StackSetName),
+								"region":          llx.StringData(region),
+								"status":          llx.StringData(string(ss.Status)),
+								"description":     llx.StringDataPtr(ss.Description),
+								"permissionModel": llx.StringData(string(ss.PermissionModel)),
+								"driftStatus":     llx.StringData(normalizeDriftStatus(string(ss.DriftStatus))),
+								"tags":            llx.MapData(tags, types.String),
+							})
+						if err != nil {
+							return nil, err
+						}
+						mqlSsRes := mqlSs.(*mqlAwsCloudformationStackSet)
+						mqlSsRes.cacheAutoDeployment = ss.AutoDeployment
+						res = append(res, mqlSsRes)
+					}
+
+					if resp.NextToken == nil {
+						break
+					}
+					nextToken = resp.NextToken
 				}
-				nextToken = resp.NextToken
 			}
 			return jobpool.JobResult(res), nil
 		}
@@ -275,11 +347,6 @@ func (a *mqlAwsCloudformation) getStackSets(conn *connection.AwsConnection) []*j
 
 type mqlAwsCloudformationStackSetInternal struct {
 	cacheAutoDeployment *cf_types.AutoDeployment
-	cacheStackSetId     *string
-	cacheRegion         string
-	cacheTags           map[string]any
-	tagsFetched         bool
-	tagsLock            sync.Mutex
 }
 
 func (a *mqlAwsCloudformationStackSet) autoDeploymentEnabled() (bool, error) {
@@ -288,58 +355,4 @@ func (a *mqlAwsCloudformationStackSet) autoDeploymentEnabled() (bool, error) {
 		return false, nil
 	}
 	return *a.cacheAutoDeployment.Enabled, nil
-}
-
-func (a *mqlAwsCloudformationStackSet) tags() (map[string]any, error) {
-	if a.tagsFetched {
-		return a.cacheTags, nil
-	}
-	a.tagsLock.Lock()
-	defer a.tagsLock.Unlock()
-	if a.tagsFetched {
-		return a.cacheTags, nil
-	}
-
-	if a.cacheStackSetId == nil {
-		a.cacheTags = map[string]any{}
-		a.tagsFetched = true
-		return a.cacheTags, nil
-	}
-
-	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	svc := conn.CloudFormation(a.cacheRegion)
-	ctx := context.Background()
-
-	resp, err := svc.DescribeStackSet(ctx, &cloudformation.DescribeStackSetInput{
-		StackSetName: a.cacheStackSetId,
-	})
-	if err != nil {
-		if Is400AccessDeniedError(err) {
-			a.cacheTags = map[string]any{}
-			a.tagsFetched = true
-			return a.cacheTags, nil
-		}
-		if IsServiceNotAvailableInRegionError(err) {
-			a.cacheTags = map[string]any{}
-			a.tagsFetched = true
-			return a.cacheTags, nil
-		}
-		return nil, err
-	}
-
-	tags := make(map[string]any)
-	if resp.StackSet != nil {
-		for _, t := range resp.StackSet.Tags {
-			if t.Key != nil {
-				val := ""
-				if t.Value != nil {
-					val = *t.Value
-				}
-				tags[*t.Key] = val
-			}
-		}
-	}
-	a.cacheTags = tags
-	a.tagsFetched = true
-	return tags, nil
 }

--- a/providers/aws/resources/aws_cloudformation_test.go
+++ b/providers/aws/resources/aws_cloudformation_test.go
@@ -1,0 +1,145 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cf_types "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeDriftStatus(t *testing.T) {
+	// Empty maps to NOT_CHECKED because the SDK enum's zero value carries
+	// no semantic meaning, but the field's contract promises one of four
+	// documented strings.
+	cases := []struct {
+		in, want string
+	}{
+		{"", "NOT_CHECKED"},
+		{"NOT_CHECKED", "NOT_CHECKED"},
+		{"DRIFTED", "DRIFTED"},
+		{"IN_SYNC", "IN_SYNC"},
+		{"UNKNOWN", "UNKNOWN"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, tc.want, normalizeDriftStatus(tc.in))
+		})
+	}
+}
+
+func TestCfnTagsToMap(t *testing.T) {
+	t.Run("empty input returns empty map (not nil)", func(t *testing.T) {
+		got := cfnTagsToMap(nil)
+		require.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("nil key entries are skipped", func(t *testing.T) {
+		// Nil keys can't be indexed and would panic on deref. Defensive
+		// skip — AWS shouldn't return them but we don't trust the wire.
+		got := cfnTagsToMap([]cf_types.Tag{
+			{Key: nil, Value: aws.String("v")},
+			{Key: aws.String("ok"), Value: aws.String("yes")},
+		})
+		assert.Equal(t, map[string]any{"ok": "yes"}, got)
+	})
+
+	t.Run("nil value becomes empty string", func(t *testing.T) {
+		got := cfnTagsToMap([]cf_types.Tag{
+			{Key: aws.String("k"), Value: nil},
+		})
+		assert.Equal(t, map[string]any{"k": ""}, got)
+	})
+}
+
+func TestStackParameterToDict(t *testing.T) {
+	t.Run("required fields only emits key/value", func(t *testing.T) {
+		got := stackParameterToDict(cf_types.Parameter{
+			ParameterKey:   aws.String("InstanceType"),
+			ParameterValue: aws.String("t3.micro"),
+		})
+		assert.Equal(t, map[string]any{
+			"key":   "InstanceType",
+			"value": "t3.micro",
+		}, got)
+	})
+
+	t.Run("uses lowercase mql-style keys, not SDK CamelCase", func(t *testing.T) {
+		// Regression: prior implementation round-tripped through
+		// json.Marshal on cf_types.Parameter, leaking SDK field names
+		// (ParameterKey/ParameterValue) to mql users.
+		got := stackParameterToDict(cf_types.Parameter{
+			ParameterKey:   aws.String("k"),
+			ParameterValue: aws.String("v"),
+		})
+		_, hasCamel := got["ParameterKey"]
+		assert.False(t, hasCamel, "must not surface SDK CamelCase")
+		assert.Contains(t, got, "key")
+		assert.Contains(t, got, "value")
+	})
+
+	t.Run("ResolvedValue only emitted when set", func(t *testing.T) {
+		without := stackParameterToDict(cf_types.Parameter{
+			ParameterKey:   aws.String("k"),
+			ParameterValue: aws.String("v"),
+		})
+		assert.NotContains(t, without, "resolvedValue")
+
+		with := stackParameterToDict(cf_types.Parameter{
+			ParameterKey:   aws.String("k"),
+			ParameterValue: aws.String("v"),
+			ResolvedValue:  aws.String("ssm-resolved"),
+		})
+		assert.Equal(t, "ssm-resolved", with["resolvedValue"])
+	})
+
+	t.Run("UsePreviousValue only emitted when set", func(t *testing.T) {
+		got := stackParameterToDict(cf_types.Parameter{
+			ParameterKey:     aws.String("k"),
+			ParameterValue:   aws.String("v"),
+			UsePreviousValue: aws.Bool(true),
+		})
+		assert.Equal(t, true, got["usePreviousValue"])
+	})
+
+	t.Run("nil key/value collapse to empty strings", func(t *testing.T) {
+		got := stackParameterToDict(cf_types.Parameter{})
+		assert.Equal(t, map[string]any{"key": "", "value": ""}, got)
+	})
+}
+
+func TestStackOutputToDict(t *testing.T) {
+	t.Run("required fields only emits key/value", func(t *testing.T) {
+		got := stackOutputToDict(cf_types.Output{
+			OutputKey:   aws.String("BucketName"),
+			OutputValue: aws.String("my-bucket"),
+		})
+		assert.Equal(t, map[string]any{
+			"key":   "BucketName",
+			"value": "my-bucket",
+		}, got)
+	})
+
+	t.Run("description and exportName emitted only when set", func(t *testing.T) {
+		full := stackOutputToDict(cf_types.Output{
+			OutputKey:   aws.String("k"),
+			OutputValue: aws.String("v"),
+			Description: aws.String("desc"),
+			ExportName:  aws.String("export"),
+		})
+		assert.Equal(t, "desc", full["description"])
+		assert.Equal(t, "export", full["exportName"])
+
+		minimal := stackOutputToDict(cf_types.Output{
+			OutputKey:   aws.String("k"),
+			OutputValue: aws.String("v"),
+		})
+		assert.NotContains(t, minimal, "description")
+		assert.NotContains(t, minimal, "exportName")
+	})
+}


### PR DESCRIPTION
## Summary

Follow-up to a deep-dive audit of `providers/aws/resources/aws_cloudformation.go`. Addresses the priority + performance issues surfaced:

- **DELETED stack sets are now returned.** `ListStackSets` defaults to ACTIVE-only when `Status` is unset; the previous hardcode silently dropped DELETED rows even though the schema doc advertised both. We now sweep both statuses.
- **`stack.parameters()` / `stack.outputs()` no longer leak SDK CamelCase.** The previous implementation round-tripped `[]cf_types.Parameter` through `JsonToDictSlice`, exposing fields as `ParameterKey` / `OutputKey` / `ResolvedValue` / `UsePreviousValue` etc. — inconsistent with the rest of mql. Replaced with explicit lowercase mql-style maps (`key`, `value`, `resolvedValue`, `usePreviousValue`, `description`, `exportName`), with the context-dependent fields only emitted when set.
- **`stackSet.tags` is eager now (perf).** Tags are only fetchable via `DescribeStackSet`. The prior lazy accessor produced an N-serial-call burst whenever a user queried `stackSets { tags }`. Folding the call into the parallel region sweep means tags serialize within a region but run concurrently across regions. The .lr field flips from `tags() map[string]string` to `tags map[string]string` and the sync/cache machinery on the Internal struct is gone.
- **`driftStatus` normalized.** Empty enum defaults from the SDK now map to `NOT_CHECKED`, so the field always carries one of the four documented values (`DRIFTED`, `IN_SYNC`, `NOT_CHECKED`, `UNKNOWN`). Applied to both stacks and stack sets.
- **Doc cleanup.** Dropped the unimplemented `rollback configuration` claim from the namespace description and added the ACTIVE+DELETED note.

Helpers (`cfnTagsToMap`, `stackParameterToDict`, `stackOutputToDict`, `normalizeDriftStatus`) are pure and exercised by new unit tests.

## Test plan

- [x] `gofmt -l` clean
- [x] `go build ./...` from `providers/aws`
- [x] `go vet ./...` from `providers/aws`
- [x] `go test ./resources/` — 14 new sub-tests pass, no regressions
- [x] `make providers/build/aws` — provider binary builds, permissions extractor still picks up `DescribeStackSet`
- [ ] Manual `mql shell aws -c "aws.cloudformation.stackSets { name status tags driftStatus }"` against an account with both ACTIVE and DELETED stack sets
- [ ] Manual `mql shell aws -c "aws.cloudformation.stacks { name parameters outputs driftStatus }"` to confirm new dict shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)