### PR TITLE
🐛 ansible: fix bugs surfaced by the audit pass

### DIFF
--- a/providers/ansible/connection/connection.go
+++ b/providers/ansible/connection/connection.go
@@ -4,54 +4,62 @@
 package connection
 
 import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/ansible/play"
-	"io"
-	"os"
 )
 
 var _ plugin.Connection = (*AnsibleConnection)(nil)
 
 type AnsibleConnection struct {
 	plugin.Connection
-	Conf  *inventory.Config
-	asset *inventory.Asset
-	// Add custom connection fields here
+	Conf     *inventory.Config
+	asset    *inventory.Asset
 	path     string
 	playbook play.Playbook
 }
 
 func NewAnsibleConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*AnsibleConnection, error) {
-	conn := &AnsibleConnection{
-		Connection: plugin.NewConnection(id, asset),
-		Conf:       conf,
-		asset:      asset,
+	if asset == nil || len(asset.Connections) == 0 {
+		return nil, errors.New("ansible: no connection options for asset")
 	}
-
-	// initialize your connection here
 	cc := asset.Connections[0]
-	path := cc.Options["path"]
-	conn.path = path
+	path := ""
+	if cc.Options != nil {
+		path = cc.Options["path"]
+	}
+	if path == "" {
+		return nil, errors.New("ansible: no playbook path provided (set the `path` option)")
+	}
 
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ansible: cannot open playbook %q: %w", path, err)
 	}
 	defer f.Close()
 
 	data, err := io.ReadAll(f)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ansible: cannot read playbook %q: %w", path, err)
 	}
 
 	playbook, err := play.DecodePlaybook(data)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ansible: cannot decode playbook %q: %w", path, err)
 	}
-	conn.playbook = playbook
 
-	return conn, nil
+	return &AnsibleConnection{
+		Connection: plugin.NewConnection(id, asset),
+		Conf:       conf,
+		asset:      asset,
+		path:       path,
+		playbook:   playbook,
+	}, nil
 }
 
 func (c *AnsibleConnection) Name() string {

--- a/providers/ansible/connection/connection_test.go
+++ b/providers/ansible/connection/connection_test.go
@@ -1,0 +1,88 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestNewAnsibleConnection_Errors(t *testing.T) {
+	t.Run("nil asset", func(t *testing.T) {
+		_, err := NewAnsibleConnection(0, nil, &inventory.Config{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no connection options")
+	})
+
+	t.Run("no connections", func(t *testing.T) {
+		_, err := NewAnsibleConnection(0, &inventory.Asset{}, &inventory.Config{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no connection options")
+	})
+
+	t.Run("nil options", func(t *testing.T) {
+		asset := &inventory.Asset{Connections: []*inventory.Config{{}}}
+		_, err := NewAnsibleConnection(0, asset, &inventory.Config{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no playbook path")
+	})
+
+	t.Run("empty path", func(t *testing.T) {
+		asset := &inventory.Asset{Connections: []*inventory.Config{{
+			Options: map[string]string{"path": ""},
+		}}}
+		_, err := NewAnsibleConnection(0, asset, &inventory.Config{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no playbook path")
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		asset := &inventory.Asset{Connections: []*inventory.Config{{
+			Options: map[string]string{"path": "/no/such/playbook.yml"},
+		}}}
+		_, err := NewAnsibleConnection(0, asset, &inventory.Config{})
+		require.Error(t, err)
+		// error should wrap the path so users can debug typos
+		assert.Contains(t, err.Error(), "/no/such/playbook.yml")
+	})
+
+	t.Run("malformed yaml", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "broken.yml")
+		// `- name:` followed by a key without a value is fine; use a clearly
+		// invalid YAML structure (unclosed mapping with a tab + quote).
+		require.NoError(t, os.WriteFile(path, []byte("---\n- name: x\n  hosts: [unterminated"), 0o600))
+
+		asset := &inventory.Asset{Connections: []*inventory.Config{{
+			Options: map[string]string{"path": path},
+		}}}
+		_, err := NewAnsibleConnection(0, asset, &inventory.Config{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decode playbook")
+		assert.Contains(t, err.Error(), path)
+	})
+}
+
+func TestNewAnsibleConnection_Success(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "playbook.yml")
+	require.NoError(t, os.WriteFile(path, []byte("---\n- hosts: webservers\n  tasks:\n    - name: ping\n      ping:\n"), 0o600))
+
+	asset := &inventory.Asset{Connections: []*inventory.Config{{
+		Options: map[string]string{"path": path},
+	}}}
+	conn, err := NewAnsibleConnection(42, asset, &inventory.Config{})
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	assert.Equal(t, "ansible", conn.Name())
+	require.Len(t, conn.Playbook(), 1)
+	assert.Equal(t, "webservers", conn.Playbook()[0].Hosts)
+	require.Len(t, conn.Playbook()[0].Tasks, 1)
+	assert.Equal(t, "ping", conn.Playbook()[0].Tasks[0].Name)
+}

--- a/providers/ansible/provider/provider.go
+++ b/providers/ansible/provider/provider.go
@@ -89,13 +89,7 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	asset := req.Asset
 	conf := asset.Connections[0]
 	runtime, err := s.AddRuntime(conf, func(connId uint32) (*plugin.Runtime, error) {
-		var conn *connection.AnsibleConnection
-		var err error
-
-		switch conf.Type {
-		default:
-			conn, err = connection.NewAnsibleConnection(connId, asset, conf)
-		}
+		conn, err := connection.NewAnsibleConnection(connId, asset, conf)
 		if err != nil {
 			return nil, err
 		}
@@ -128,8 +122,6 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 
 func (s *Service) detect(asset *inventory.Asset, conn *connection.AnsibleConnection) error {
 	asset.Id = conn.Conf.Type
-	asset.Name = conn.Conf.Host
-
 	asset.Platform = &inventory.Platform{
 		Name:                  "ansible-playbook",
 		Family:                []string{"ansible"},
@@ -139,18 +131,21 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.AnsibleConnect
 	}
 
 	projectPath, ok := asset.Connections[0].Options["path"]
-	if ok {
-		absPath, _ := filepath.Abs(projectPath)
-		h := sha256.New()
-		h.Write([]byte(absPath))
-		hash := hex.EncodeToString(h.Sum(nil))
-		platformID := "//platformid.api.mondoo.app/runtime/ansible/hash/" + hash
-		asset.Connections[0].PlatformId = platformID
-		asset.PlatformIds = []string{platformID}
-		asset.Name = "Ansible Playbook Static Analysis " + parseNameFromPath(projectPath)
+	if !ok || projectPath == "" {
+		asset.Name = conn.Conf.Host
 		return nil
 	}
 
+	absPath, err := filepath.Abs(projectPath)
+	if err != nil {
+		absPath = projectPath
+	}
+	h := sha256.New()
+	h.Write([]byte(absPath))
+	platformID := "//platformid.api.mondoo.app/runtime/ansible/hash/" + hex.EncodeToString(h.Sum(nil))
+	asset.Connections[0].PlatformId = platformID
+	asset.PlatformIds = []string{platformID}
+	asset.Name = "Ansible Playbook Static Analysis " + parseNameFromPath(projectPath)
 	return nil
 }
 

--- a/providers/ansible/resources/ansible.go
+++ b/providers/ansible/resources/ansible.go
@@ -22,46 +22,42 @@ func (r *mqlAnsible) plays() ([]any, error) {
 	conn := r.MqlRuntime.Connection.(*connection.AnsibleConnection)
 	playbook := conn.Playbook()
 
-	var plays []any
-	for _, play := range playbook {
-
-		p, err := newMqlAnsiblePlay(r.MqlRuntime, play)
+	plays := make([]any, 0, len(playbook))
+	for i, p := range playbook {
+		mqlPlay, err := newMqlAnsiblePlay(r.MqlRuntime, "play["+strconv.Itoa(i)+"]", p)
 		if err != nil {
 			return nil, err
 		}
-		plays = append(plays, p)
+		plays = append(plays, mqlPlay)
 	}
 	return plays, nil
 }
 
-func newMqlAnsiblePlay(runtime *plugin.Runtime, play *play.Play) (*mqlAnsiblePlay, error) {
-	varsDict, err := convert.JsonToDict(play.Vars)
-	if err != nil {
-		return nil, err
-	}
-
+func newMqlAnsiblePlay(runtime *plugin.Runtime, id string, p *play.Play) (*mqlAnsiblePlay, error) {
 	res, err := CreateResource(runtime, "ansible.play", map[string]*llx.RawData{
-		"name":              llx.StringData(play.Name),
-		"hosts":             llx.DictData(play.Hosts),
-		"remoteUser":        llx.StringData(play.RemoteUser),
-		"become":            llx.BoolData(play.Become),
-		"becomeUser":        llx.StringData(play.BecomeUser),
-		"becomeMethod":      llx.StringData(play.BecomeMethod),
-		"becomeFlags":       llx.StringData(play.BecomeFlags),
-		"strategy":          llx.StringData(play.Strategy),
-		"maxFailPercentage": llx.IntData(play.MaxFailPercentage),
-		"ignoreUnreachable": llx.BoolData(play.IgnoreUnreachable),
-		"anyErrorsFatal":    llx.BoolData(play.AnyErrorsFatal),
-		"gatherFacts":       llx.StringData(play.GatherFacts),
-		"vars":              llx.DictData(varsDict),
-		"tags":              llx.ArrayData(convert.SliceAnyToInterface(play.Tags), types.String),
-		"roles":             llx.ArrayData(convert.SliceAnyToInterface(play.Roles), types.String),
+		"__id":              llx.StringData(id),
+		"name":              llx.StringData(p.Name),
+		"hosts":             llx.DictData(p.Hosts),
+		"remoteUser":        llx.StringData(p.RemoteUser),
+		"become":            llx.BoolData(p.Become),
+		"becomeUser":        llx.StringData(p.BecomeUser),
+		"becomeMethod":      llx.StringData(p.BecomeMethod),
+		"becomeFlags":       llx.StringData(p.BecomeFlags),
+		"serial":            llx.DictData(p.Serial),
+		"strategy":          llx.StringData(p.Strategy),
+		"maxFailPercentage": llx.IntData(p.MaxFailPercentage),
+		"ignoreUnreachable": llx.BoolData(p.IgnoreUnreachable),
+		"anyErrorsFatal":    llx.BoolData(p.AnyErrorsFatal),
+		"gatherFacts":       llx.StringData(p.GatherFacts),
+		"vars":              llx.MapData(p.Vars, types.Dict),
+		"tags":              llx.ArrayData(convert.SliceAnyToInterface(p.Tags), types.String),
+		"roles":             llx.ArrayData(convert.SliceAnyToInterface(p.Roles), types.String),
 	})
 	if err != nil {
 		return nil, err
 	}
 	mqlPlay := res.(*mqlAnsiblePlay)
-	mqlPlay.play = play
+	mqlPlay.play = p
 	return mqlPlay, nil
 }
 
@@ -69,70 +65,41 @@ type mqlAnsiblePlayInternal struct {
 	play *play.Play
 }
 
-func (r *mqlAnsiblePlay) id() (string, error) {
-	return r.Name.Data, nil
-}
-
-func newMqlAnsibleHandler(runtime *plugin.Runtime, id string, task *play.Handler) (*mqlAnsibleHandler, error) {
-	dict, err := convert.JsonToDict(task.Action)
-	if err != nil {
-		return nil, err
-	}
-
+func newMqlAnsibleHandler(runtime *plugin.Runtime, id string, handler *play.Handler) (*mqlAnsibleHandler, error) {
 	res, err := CreateResource(runtime, "ansible.handler", map[string]*llx.RawData{
 		"__id":   llx.StringData(id),
-		"name":   llx.StringData(task.Name),
-		"action": llx.DictData(dict),
+		"name":   llx.StringData(handler.Name),
+		"action": llx.DictData(toAny(handler.Action)),
 	})
 	if err != nil {
 		return nil, err
 	}
-	mqlHandler := res.(*mqlAnsibleHandler)
-	return mqlHandler, nil
+	return res.(*mqlAnsibleHandler), nil
 }
 
-func newMqlAnsibleHandlers(runtime *plugin.Runtime, idPrefix string, handler []*play.Handler) ([]any, error) {
-	var mqlTasks []any
-	for i, t := range handler {
-		id := idPrefix + strconv.Itoa(i)
-		if t.Name != "" {
-			id = t.Name
-		}
-
-		t, err := newMqlAnsibleHandler(runtime, id, t)
+func newMqlAnsibleHandlers(runtime *plugin.Runtime, parentID string, handlers []*play.Handler) ([]any, error) {
+	mqlHandlers := make([]any, 0, len(handlers))
+	for i, h := range handlers {
+		id := parentID + "/handlers[" + strconv.Itoa(i) + "]"
+		mqlHandler, err := newMqlAnsibleHandler(runtime, id, h)
 		if err != nil {
 			return nil, err
 		}
-		mqlTasks = append(mqlTasks, t)
+		mqlHandlers = append(mqlHandlers, mqlHandler)
 	}
-	return mqlTasks, nil
+	return mqlHandlers, nil
 }
 
 func (r *mqlAnsiblePlay) handlers() ([]any, error) {
-	return newMqlAnsibleHandlers(r.MqlRuntime, "handlers", r.play.Handlers)
+	return newMqlAnsibleHandlers(r.MqlRuntime, r.MqlID(), r.play.Handlers)
 }
 
 func newMqlAnsibleTask(runtime *plugin.Runtime, id string, task *play.Task) (*mqlAnsibleTask, error) {
-	actionDict, err := convert.JsonToDict(task.Action)
-	if err != nil {
-		return nil, err
-	}
-
-	varDict, err := convert.JsonToDict(task.Vars)
-	if err != nil {
-		return nil, err
-	}
-
-	loopControlDict, err := convert.JsonToDict(task.LoopControl)
-	if err != nil {
-		return nil, err
-	}
-
 	res, err := CreateResource(runtime, "ansible.task", map[string]*llx.RawData{
 		"__id":            llx.StringData(id),
 		"name":            llx.StringData(task.Name),
-		"action":          llx.DictData(actionDict),
-		"vars":            llx.DictData(varDict),
+		"action":          llx.DictData(toAny(task.Action)),
+		"vars":            llx.MapData(task.Vars, types.Dict),
 		"tags":            llx.ArrayData(convert.SliceAnyToInterface(task.Tags), types.String),
 		"register":        llx.StringData(task.Register),
 		"when":            llx.StringData(task.When),
@@ -140,7 +107,7 @@ func newMqlAnsibleTask(runtime *plugin.Runtime, id string, task *play.Task) (*mq
 		"changedWhen":     llx.StringData(task.ChangedWhen),
 		"notify":          llx.ArrayData(convert.SliceAnyToInterface(task.Notify), types.String),
 		"loop":            llx.DictData(task.Loop),
-		"loopControl":     llx.DictData(loopControlDict),
+		"loopControl":     llx.DictData(toAny(task.LoopControl)),
 		"importPlaybook":  llx.StringData(task.ImportPlaybook),
 		"includePlaybook": llx.StringData(task.IncludePlaybook),
 		"importTasks":     llx.StringData(task.ImportTasks),
@@ -154,19 +121,15 @@ func newMqlAnsibleTask(runtime *plugin.Runtime, id string, task *play.Task) (*mq
 	return mqlTask, nil
 }
 
-func newMqlAnsibleTasks(runtime *plugin.Runtime, idPrefix string, tasks []*play.Task) ([]any, error) {
-	var mqlTasks []any
+func newMqlAnsibleTasks(runtime *plugin.Runtime, parentID, group string, tasks []*play.Task) ([]any, error) {
+	mqlTasks := make([]any, 0, len(tasks))
 	for i, t := range tasks {
-		id := idPrefix + strconv.Itoa(i)
-		if t.Name != "" {
-			id = t.Name
-		}
-
-		t, err := newMqlAnsibleTask(runtime, id, t)
+		id := parentID + "/" + group + "[" + strconv.Itoa(i) + "]"
+		mqlTask, err := newMqlAnsibleTask(runtime, id, t)
 		if err != nil {
 			return nil, err
 		}
-		mqlTasks = append(mqlTasks, t)
+		mqlTasks = append(mqlTasks, mqlTask)
 	}
 	return mqlTasks, nil
 }
@@ -176,25 +139,35 @@ type mqlAnsibleTaskInternal struct {
 }
 
 func (r *mqlAnsiblePlay) preTasks() ([]any, error) {
-	return newMqlAnsibleTasks(r.MqlRuntime, "preTasks", r.play.PreTasks)
+	return newMqlAnsibleTasks(r.MqlRuntime, r.MqlID(), "preTasks", r.play.PreTasks)
 }
 
 func (r *mqlAnsiblePlay) tasks() ([]any, error) {
-	return newMqlAnsibleTasks(r.MqlRuntime, "tasks", r.play.Tasks)
+	return newMqlAnsibleTasks(r.MqlRuntime, r.MqlID(), "tasks", r.play.Tasks)
 }
 
 func (r *mqlAnsiblePlay) postTasks() ([]any, error) {
-	return newMqlAnsibleTasks(r.MqlRuntime, "postTasks", r.play.PostTasks)
+	return newMqlAnsibleTasks(r.MqlRuntime, r.MqlID(), "postTasks", r.play.PostTasks)
 }
 
 func (r *mqlAnsibleTask) block() ([]any, error) {
-	return newMqlAnsibleTasks(r.MqlRuntime, "block", r.task.Block)
+	return newMqlAnsibleTasks(r.MqlRuntime, r.MqlID(), "block", r.task.Block)
 }
 
 func (r *mqlAnsibleTask) rescue() ([]any, error) {
-	return newMqlAnsibleTasks(r.MqlRuntime, "rescue", r.task.Rescue)
+	return newMqlAnsibleTasks(r.MqlRuntime, r.MqlID(), "rescue", r.task.Rescue)
 }
 
 func (r *mqlAnsibleTask) always() ([]any, error) {
-	return newMqlAnsibleTasks(r.MqlRuntime, "always", r.task.Always)
+	return newMqlAnsibleTasks(r.MqlRuntime, r.MqlID(), "always", r.task.Always)
+}
+
+// toAny converts a typed map to an untyped `any` for llx.DictData. Passing the
+// typed map directly would box the map type into the interface, which the dict
+// runtime cannot iterate the same way as map[string]any.
+func toAny(m map[string]any) any {
+	if m == nil {
+		return nil
+	}
+	return m
 }

--- a/providers/ansible/resources/ansible.lr
+++ b/providers/ansible/resources/ansible.lr
@@ -37,6 +37,12 @@ ansible.play @defaults("name") {
   becomeMethod string
   // Additional flags for become method
   becomeFlags string
+  // Batch size for the play
+  //
+  // Value supplied to the `serial:` keyword. Limits how many hosts run the
+  // play at once. Can be an integer (for example `3`), a percentage string
+  // (for example `"30%"`), or a list mixing both for rolling batches.
+  serial dict
   // Strategy
   strategy string
   // Max percentage of failed hosts before aborting

--- a/providers/ansible/resources/ansible.lr.go
+++ b/providers/ansible/resources/ansible.lr.go
@@ -136,6 +136,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"ansible.play.becomeFlags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAnsiblePlay).GetBecomeFlags()).ToDataRes(types.String)
 	},
+	"ansible.play.serial": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAnsiblePlay).GetSerial()).ToDataRes(types.Dict)
+	},
 	"ansible.play.strategy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAnsiblePlay).GetStrategy()).ToDataRes(types.String)
 	},
@@ -282,6 +285,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"ansible.play.becomeFlags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAnsiblePlay).BecomeFlags, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"ansible.play.serial": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAnsiblePlay).Serial, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"ansible.play.strategy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -517,6 +524,7 @@ type mqlAnsiblePlay struct {
 	BecomeUser        plugin.TValue[string]
 	BecomeMethod      plugin.TValue[string]
 	BecomeFlags       plugin.TValue[string]
+	Serial            plugin.TValue[any]
 	Strategy          plugin.TValue[string]
 	MaxFailPercentage plugin.TValue[int64]
 	IgnoreUnreachable plugin.TValue[bool]
@@ -542,12 +550,7 @@ func createAnsiblePlay(runtime *plugin.Runtime, args map[string]*llx.RawData) (p
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("ansible.play", res.__id)
@@ -594,6 +597,10 @@ func (c *mqlAnsiblePlay) GetBecomeMethod() *plugin.TValue[string] {
 
 func (c *mqlAnsiblePlay) GetBecomeFlags() *plugin.TValue[string] {
 	return &c.BecomeFlags
+}
+
+func (c *mqlAnsiblePlay) GetSerial() *plugin.TValue[any] {
+	return &c.Serial
 }
 
 func (c *mqlAnsiblePlay) GetStrategy() *plugin.TValue[string] {

--- a/providers/ansible/resources/ansible.lr.versions
+++ b/providers/ansible/resources/ansible.lr.versions
@@ -21,6 +21,7 @@ ansible.play.postTasks 13.0.13
 ansible.play.preTasks 13.0.13
 ansible.play.remoteUser 10.0.0
 ansible.play.roles 10.0.0
+ansible.play.serial 13.0.13
 ansible.play.strategy 10.0.0
 ansible.play.tags 13.0.13
 ansible.play.tasks 10.0.0

--- a/providers/ansible/resources/ansible_test.go
+++ b/providers/ansible/resources/ansible_test.go
@@ -1,0 +1,241 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/ansible/connection"
+)
+
+func newTestRuntime(t *testing.T, yaml string) *plugin.Runtime {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "playbook.yml")
+	require.NoError(t, os.WriteFile(path, []byte(yaml), 0o600))
+	asset := &inventory.Asset{Connections: []*inventory.Config{{
+		Options: map[string]string{"path": path},
+	}}}
+	conn, err := connection.NewAnsibleConnection(1, asset, &inventory.Config{})
+	require.NoError(t, err)
+	return plugin.NewRuntime(conn, nil, false, CreateResource, NewResource, GetData, SetData, nil)
+}
+
+// Two plays with identical names used to collide on `__id = name`, causing the
+// second play's MQL resource to silently reuse the first's state.
+func TestPlayIDsUnique_SameName(t *testing.T) {
+	rt := newTestRuntime(t, `---
+- name: same
+  hosts: a
+  tasks:
+    - name: do-thing
+      ping:
+- name: same
+  hosts: b
+  tasks:
+    - name: do-thing
+      ping:
+`)
+	a := &mqlAnsible{MqlRuntime: rt}
+	plays, err := a.plays()
+	require.NoError(t, err)
+	require.Len(t, plays, 2)
+
+	p0 := plays[0].(*mqlAnsiblePlay)
+	p1 := plays[1].(*mqlAnsiblePlay)
+	assert.NotEqual(t, p0.MqlID(), p1.MqlID(), "two plays with same name must have distinct __ids")
+	assert.Equal(t, "play[0]", p0.MqlID())
+	assert.Equal(t, "play[1]", p1.MqlID())
+
+	// hosts must come from the correct play
+	assert.Equal(t, "a", p0.Hosts.Data)
+	assert.Equal(t, "b", p1.Hosts.Data)
+}
+
+// Two unnamed plays used to both get `__id = ""` and collide.
+func TestPlayIDsUnique_Unnamed(t *testing.T) {
+	rt := newTestRuntime(t, `---
+- hosts: a
+  tasks:
+    - ping:
+- hosts: b
+  tasks:
+    - ping:
+`)
+	a := &mqlAnsible{MqlRuntime: rt}
+	plays, err := a.plays()
+	require.NoError(t, err)
+	require.Len(t, plays, 2)
+	p0 := plays[0].(*mqlAnsiblePlay)
+	p1 := plays[1].(*mqlAnsiblePlay)
+	assert.NotEqual(t, p0.MqlID(), p1.MqlID())
+	assert.Equal(t, "a", p0.Hosts.Data)
+	assert.Equal(t, "b", p1.Hosts.Data)
+}
+
+// Same-named tasks across plays used to collide because the id prefix was
+// global ("tasks") and a non-empty name replaced the prefix entirely.
+func TestTaskIDsUnique_SameNameAcrossPlays(t *testing.T) {
+	rt := newTestRuntime(t, `---
+- name: play-a
+  hosts: a
+  tasks:
+    - name: do-thing
+      ping:
+- name: play-b
+  hosts: b
+  tasks:
+    - name: do-thing
+      ping:
+`)
+	a := &mqlAnsible{MqlRuntime: rt}
+	plays, err := a.plays()
+	require.NoError(t, err)
+	require.Len(t, plays, 2)
+
+	tasks0, err := plays[0].(*mqlAnsiblePlay).tasks()
+	require.NoError(t, err)
+	tasks1, err := plays[1].(*mqlAnsiblePlay).tasks()
+	require.NoError(t, err)
+	require.Len(t, tasks0, 1)
+	require.Len(t, tasks1, 1)
+
+	t0 := tasks0[0].(*mqlAnsibleTask)
+	t1 := tasks1[0].(*mqlAnsibleTask)
+	assert.NotEqual(t, t0.MqlID(), t1.MqlID(), "same-named tasks in different plays must have distinct __ids")
+	// task ids must be nested under the parent play id
+	assert.Contains(t, t0.MqlID(), "play[0]")
+	assert.Contains(t, t1.MqlID(), "play[1]")
+	// and the internal task pointers must match their respective parents
+	assert.NotSame(t, t0.task, t1.task)
+}
+
+// Task group prefixes (preTasks, tasks, postTasks) used to share id space across
+// plays — also recursive groups (block/rescue/always) used to be flat.
+func TestTaskIDsUnique_NestedGroups(t *testing.T) {
+	rt := newTestRuntime(t, `---
+- name: only
+  hosts: a
+  pre_tasks:
+    - name: setup
+      ping:
+  tasks:
+    - name: setup
+      block:
+        - name: setup
+          ping:
+        - name: setup
+          ping:
+      rescue:
+        - name: setup
+          ping:
+      always:
+        - name: setup
+          ping:
+  post_tasks:
+    - name: setup
+      ping:
+  handlers:
+    - name: setup
+      ping:
+`)
+	a := &mqlAnsible{MqlRuntime: rt}
+	plays, err := a.plays()
+	require.NoError(t, err)
+	require.Len(t, plays, 1)
+
+	p := plays[0].(*mqlAnsiblePlay)
+	pre, err := p.preTasks()
+	require.NoError(t, err)
+	tasks, err := p.tasks()
+	require.NoError(t, err)
+	post, err := p.postTasks()
+	require.NoError(t, err)
+	handlers, err := p.handlers()
+	require.NoError(t, err)
+
+	require.Len(t, pre, 1)
+	require.Len(t, tasks, 1)
+	require.Len(t, post, 1)
+	require.Len(t, handlers, 1)
+
+	tasksParent := tasks[0].(*mqlAnsibleTask)
+	block, err := tasksParent.block()
+	require.NoError(t, err)
+	rescue, err := tasksParent.rescue()
+	require.NoError(t, err)
+	always, err := tasksParent.always()
+	require.NoError(t, err)
+	require.Len(t, block, 2)
+	require.Len(t, rescue, 1)
+	require.Len(t, always, 1)
+
+	// Every id observed in this play must be globally unique even though every
+	// task is named "setup".
+	ids := map[string]string{}
+	collect := func(label, id string) {
+		t.Helper()
+		if prev, ok := ids[id]; ok {
+			t.Fatalf("id collision: %q used by %s and %s", id, prev, label)
+		}
+		ids[id] = label
+	}
+	collect("play", p.MqlID())
+	collect("preTasks[0]", pre[0].(*mqlAnsibleTask).MqlID())
+	collect("tasks[0]", tasksParent.MqlID())
+	collect("postTasks[0]", post[0].(*mqlAnsibleTask).MqlID())
+	collect("handlers[0]", handlers[0].(*mqlAnsibleHandler).MqlID())
+	collect("block[0]", block[0].(*mqlAnsibleTask).MqlID())
+	collect("block[1]", block[1].(*mqlAnsibleTask).MqlID())
+	collect("rescue[0]", rescue[0].(*mqlAnsibleTask).MqlID())
+	collect("always[0]", always[0].(*mqlAnsibleTask).MqlID())
+}
+
+// Calling a child accessor twice on the same play must return resources whose
+// MqlIDs match — proving the cache works correctly with the new id scheme.
+func TestTaskIDsStable_AcrossCalls(t *testing.T) {
+	rt := newTestRuntime(t, `---
+- name: p
+  hosts: a
+  tasks:
+    - name: t
+      ping:
+`)
+	a := &mqlAnsible{MqlRuntime: rt}
+	plays, err := a.plays()
+	require.NoError(t, err)
+	require.Len(t, plays, 1)
+	p := plays[0].(*mqlAnsiblePlay)
+
+	first, err := p.tasks()
+	require.NoError(t, err)
+	second, err := p.tasks()
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	require.Len(t, second, 1)
+	assert.Same(t, first[0], second[0], "repeated tasks() calls must return the cached resource")
+}
+
+// Serial was parsed by the YAML decoder but never exposed. Make sure the field
+// is now populated on the MQL resource.
+func TestSerialIsExposed(t *testing.T) {
+	rt := newTestRuntime(t, `---
+- name: p
+  hosts: a
+  serial: 3
+  tasks:
+    - ping:
+`)
+	a := &mqlAnsible{MqlRuntime: rt}
+	plays, err := a.plays()
+	require.NoError(t, err)
+	require.Len(t, plays, 1)
+	assert.Equal(t, 3, plays[0].(*mqlAnsiblePlay).Serial.Data)
+}


### PR DESCRIPTION
## Summary

Deep-dive review of the `ansible` provider turned up a class of resource-identity bugs, a perf hotspot, and some dead code. This PR fixes them and adds tests.

### Logic / correctness
- **`__id` collisions.** `mqlAnsiblePlay.id()` returned `r.Name.Data`, so two plays with the same name — or both unnamed — mapped to the same MQL resource. The `tasks() / preTasks() / postTasks() / block() / rescue() / always() / handlers()` helpers used a global prefix (`"tasks"`, `"block"`, …) and replaced it entirely with the task name when present, so same-named tasks across plays also collided. On a collision, `CreateResource` returned the previously cached resource and the post-call `mqlPlay.play = play` overwrote the cached internal pointer — leaving public fields from creation #1 and internal `play` from creation #2.
- **Fix:** ids are now hierarchical and index-derived (`play[i]`, `play[i]/tasks[j]`, `play[i]/tasks[j]/block[k]`, `play[i]/handlers[j]`), passed explicitly via `"__id"`. Dropped `mqlAnsiblePlay.id()`. The post-`CreateResource` internal-pointer assignment is now safe because the same id always maps to the same logical resource.

### Performance
- Dropped `convert.JsonToDict` for `vars`, `action`, `loopControl`. `yaml.v3` already produces `map[string]any`, so the JSON marshal+unmarshal round-trip per task/handler/play is gone. `vars` switched from `DictData(map[string]any)` to the more accurate `MapData(..., types.Dict)`.
- Pre-allocated result slices.

### Robustness
- `NewAnsibleConnection` now validates `asset`, `Connections[0]`, `Options`, and `path != ""` with clear errors. File-open, read, and YAML-decode errors are wrapped with the path.

### Cleanup
- `provider/provider.go`: removed the single-arm `switch`, removed the dead `asset.Name = conn.Conf.Host` pre-write in `detect()`, handle `filepath.Abs` error.

### New field
- Exposed `ansible.play.serial` (`dict`) — parsed by the YAML decoder but never surfaced. Added at `13.0.13` in `.lr.versions`.

### Tests
- `connection_test.go`: nil asset, missing connection, nil options, empty path, missing file, malformed YAML, happy path.
- `ansible_test.go`: same-named plays distinct, unnamed plays distinct, same-named tasks across plays distinct, nine same-named tasks across nested groups all distinct, repeat-call cache stability, `Serial` exposure.

## Test plan

- [ ] `go test ./providers/ansible/...` passes
- [ ] `make providers/build/ansible` builds cleanly
- [ ] Smoke: `cnspec shell ansible <some playbook>` — `ansible.playbook.plays { name, hosts, serial }` and traversal into `tasks { name }` / `block { name }` returns correct, distinct resources on a multi-play file

🤖 Generated with [Claude Code](https://claude.com/claude-code)