### PR TITLE
🐛 k8s: fix two nil-handling bugs surfaced by the audit pass

### DIFF
--- a/providers/k8s/resources/admission.go
+++ b/providers/k8s/resources/admission.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/k8s/connection/shared/resources"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -34,6 +35,7 @@ func (k *mqlK8sAdmissionreview) request() (*mqlK8sAdmissionrequest, error) {
 		return nil, err
 	}
 	if len(result) == 0 {
+		k.Request.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 

--- a/providers/k8s/resources/pod.go
+++ b/providers/k8s/resources/pod.go
@@ -684,8 +684,7 @@ func (k *mqlK8sPod) deployment() (*mqlK8sDeployment, error) {
 	}
 	rsTyped, err := rs.getReplicaSet()
 	if err != nil {
-		k.Deployment.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
+		return nil, err
 	}
 	for _, o := range rsTyped.OwnerReferences {
 		if o.Kind == "Deployment" {


### PR DESCRIPTION
## Summary

Two genuine nil-handling bugs found while auditing the k8s provider for nil/logic/pagination/perf issues.

- **`admission.AdmissionReview.request()`** — when no admission review is present we returned `nil, nil` without setting `k.Request.State = StateIsSet | StateIsNull`. Per the codebase rule (`CLAUDE.md`: *"Never `return nil, nil` from a singular resource accessor without setting `StateIsNull` first"*), the runtime treats an unset state as "not yet computed" and can re-invoke the accessor or panic. Every other singular-pointer accessor in this provider follows the contract; this one didn't.
- **`pod.Pod.deployment()`** — `rs.getReplicaSet()` (in `replicaset.go`) only returns an error when the embedded `runtime.Object` fails to type-assert to `*appsv1.ReplicaSet`, i.e. a real data-integrity issue. The code swallowed that error and returned null, hiding the underlying bug. Propagate it instead.

## Test plan

- [x] `go build ./...` in `providers/k8s` (clean)
- [x] `go vet ./resources/...` (clean)
- [x] `gofmt -l` on modified files (no changes needed)
- [x] `go test ./resources/...` (passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)