### PR TITLE
🐛 k8s: fix five logic errors surfaced by the audit pass

### DIFF
--- a/providers/k8s/resources/clusterrolebinding.go
+++ b/providers/k8s/resources/clusterrolebinding.go
@@ -89,7 +89,7 @@ func (k *mqlK8sRbacClusterrolebinding) serviceAccounts() ([]any, error) {
 }
 
 func (k *mqlK8sRbacClusterrolebinding) clusterRole() (*mqlK8sRbacClusterrole, error) {
-	if k.obj.RoleRef.Name == "" {
+	if k.obj.RoleRef.Kind != "ClusterRole" || k.obj.RoleRef.Name == "" {
 		k.ClusterRole.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}

--- a/providers/k8s/resources/common.go
+++ b/providers/k8s/resources/common.go
@@ -19,6 +19,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// ErrResourceNotFound is returned by the resource init helpers when a lookup
+// by id or name/namespace finds no match in the cluster snapshot. Callers can
+// distinguish this case from transient errors with errors.Is. The literal
+// "not found" message is also matched by cnspec, so don't change the text.
+var ErrResourceNotFound = errors.New("not found")
+
 func k8sProvider(t plugin.Connection) (shared.Connection, error) {
 	at, ok := t.(shared.Connection)
 	if !ok {
@@ -178,8 +184,8 @@ func initNamespacedResource[T K8sNamespacedObject](
 		}
 	}
 
-	// the error ResourceNotFound is checked by cnspec
-	return args, nil, errors.New("not found")
+	// the error message must stay "not found" — cnspec matches on this text
+	return args, nil, ErrResourceNotFound
 }
 
 func initResource[T K8sObject](
@@ -244,8 +250,8 @@ func initResource[T K8sObject](
 		}
 	}
 
-	// the error ResourceNotFound is checked by cnspec
-	return nil, nil, errors.New("not found")
+	// the error message must stay "not found" — cnspec matches on this text
+	return nil, nil, ErrResourceNotFound
 }
 
 // filterByNamespace returns the items from the k8s root accessor `all` whose

--- a/providers/k8s/resources/endpointslice.go
+++ b/providers/k8s/resources/endpointslice.go
@@ -86,6 +86,12 @@ func (k *mqlK8sEndpointslice) service() (*mqlK8sService, error) {
 		"namespace": llx.StringData(k.obj.Namespace),
 	})
 	if err != nil {
+		// EndpointSlices may outlive the Service they back (mid-deletion or
+		// hand-managed slices). Treat that as null, surface other errors.
+		if errors.Is(err, ErrResourceNotFound) {
+			k.Service.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return r.(*mqlK8sService), nil

--- a/providers/k8s/resources/horizontalpodautoscaler.go
+++ b/providers/k8s/resources/horizontalpodautoscaler.go
@@ -88,7 +88,7 @@ func (k *mqlK8sHorizontalpodautoscaler) scaleTargetName() (string, error) {
 }
 
 func (k *mqlK8sHorizontalpodautoscaler) scaleTargetDeployment() (*mqlK8sDeployment, error) {
-	if k.obj.Spec.ScaleTargetRef.Kind != "Deployment" {
+	if k.obj.Spec.ScaleTargetRef.Kind != "Deployment" || k.obj.Spec.ScaleTargetRef.Name == "" {
 		k.ScaleTargetDeployment.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -103,7 +103,7 @@ func (k *mqlK8sHorizontalpodautoscaler) scaleTargetDeployment() (*mqlK8sDeployme
 }
 
 func (k *mqlK8sHorizontalpodautoscaler) scaleTargetStatefulSet() (*mqlK8sStatefulset, error) {
-	if k.obj.Spec.ScaleTargetRef.Kind != "StatefulSet" {
+	if k.obj.Spec.ScaleTargetRef.Kind != "StatefulSet" || k.obj.Spec.ScaleTargetRef.Name == "" {
 		k.ScaleTargetStatefulSet.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -118,7 +118,7 @@ func (k *mqlK8sHorizontalpodautoscaler) scaleTargetStatefulSet() (*mqlK8sStatefu
 }
 
 func (k *mqlK8sHorizontalpodautoscaler) scaleTargetReplicaSet() (*mqlK8sReplicaset, error) {
-	if k.obj.Spec.ScaleTargetRef.Kind != "ReplicaSet" {
+	if k.obj.Spec.ScaleTargetRef.Kind != "ReplicaSet" || k.obj.Spec.ScaleTargetRef.Name == "" {
 		k.ScaleTargetReplicaSet.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}

--- a/providers/k8s/resources/node.go
+++ b/providers/k8s/resources/node.go
@@ -37,9 +37,11 @@ func initK8sNode(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 	}
 	k8s := k8sRaw.(*mqlK8s)
 
-	// Only list nodes if the cache is empty. GetNodes() populates nodesByName
-	// under k8s.lock, so guard the cold-cache check and the lookup with the
-	// same lock to avoid racing against a concurrent nodes() call.
+	// k8s.lock here only protects against reading a half-populated nodesByName
+	// while nodes() is mid-reset. It does NOT dedup concurrent GetNodes()
+	// calls — two cold initK8sNode goroutines can both see empty == true and
+	// both invoke GetNodes(); the MQL runtime's GetOrCompute handles that
+	// dedup so only one nodes() body actually runs.
 	k8s.lock.Lock()
 	empty := len(k8s.nodesByName) == 0
 	k8s.lock.Unlock()

--- a/providers/k8s/resources/node.go
+++ b/providers/k8s/resources/node.go
@@ -37,15 +37,22 @@ func initK8sNode(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 	}
 	k8s := k8sRaw.(*mqlK8s)
 
-	// Only list nodes if the cache is empty
-	if k8s.nodesByName == nil || len(k8s.nodesByName) == 0 {
+	// Only list nodes if the cache is empty. GetNodes() populates nodesByName
+	// under k8s.lock, so guard the cold-cache check and the lookup with the
+	// same lock to avoid racing against a concurrent nodes() call.
+	k8s.lock.Lock()
+	empty := len(k8s.nodesByName) == 0
+	k8s.lock.Unlock()
+	if empty {
 		list := k8s.GetNodes()
 		if list.Error != nil {
 			return nil, nil, list.Error
 		}
 	}
 
+	k8s.lock.Lock()
 	x, found := k8s.nodesByName[name]
+	k8s.lock.Unlock()
 	if !found {
 		return nil, nil, errors.New("cannot find node " + name)
 	}
@@ -54,7 +61,9 @@ func initK8sNode(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 }
 
 func (k *mqlK8s) nodes() ([]any, error) {
-	k.mqlK8sInternal.nodesByName = make(map[string]*mqlK8sNode)
+	k.lock.Lock()
+	k.nodesByName = make(map[string]*mqlK8sNode)
+	k.lock.Unlock()
 	return k8sResourceToMql(k.MqlRuntime, gvkString(corev1.SchemeGroupVersion.WithKind("nodes")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (any, error) {
 		ts := obj.GetCreationTimestamp()
 
@@ -95,7 +104,9 @@ func (k *mqlK8s) nodes() ([]any, error) {
 		}
 
 		r.(*mqlK8sNode).obj = n
-		k.mqlK8sInternal.nodesByName[obj.GetName()] = r.(*mqlK8sNode)
+		k.lock.Lock()
+		k.nodesByName[obj.GetName()] = r.(*mqlK8sNode)
+		k.lock.Unlock()
 
 		return r, nil
 	})

--- a/providers/k8s/resources/node.go
+++ b/providers/k8s/resources/node.go
@@ -61,9 +61,14 @@ func initK8sNode(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 }
 
 func (k *mqlK8s) nodes() ([]any, error) {
+	// Hold k.lock across the reset *and* the full population so a concurrent
+	// initK8sNode cannot observe a half-populated nodesByName map. The MQL
+	// runtime already deduplicates nodes() calls via the framework's TValue,
+	// so the only readers blocked behind this lock are the ones whose result
+	// depends on this evaluation finishing anyway.
 	k.lock.Lock()
+	defer k.lock.Unlock()
 	k.nodesByName = make(map[string]*mqlK8sNode)
-	k.lock.Unlock()
 	return k8sResourceToMql(k.MqlRuntime, gvkString(corev1.SchemeGroupVersion.WithKind("nodes")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (any, error) {
 		ts := obj.GetCreationTimestamp()
 
@@ -104,9 +109,8 @@ func (k *mqlK8s) nodes() ([]any, error) {
 		}
 
 		r.(*mqlK8sNode).obj = n
-		k.lock.Lock()
+		// k.lock is already held by the enclosing nodes() call.
 		k.nodesByName[obj.GetName()] = r.(*mqlK8sNode)
-		k.lock.Unlock()
 
 		return r, nil
 	})

--- a/providers/k8s/resources/rolebinding.go
+++ b/providers/k8s/resources/rolebinding.go
@@ -5,7 +5,6 @@ package resources
 
 import (
 	"errors"
-	"strings"
 	"sync"
 
 	"go.mondoo.com/mql/v13/llx"
@@ -143,7 +142,7 @@ func resolveServiceAccountSubjects(runtime *plugin.Runtime, subjects []rbacv1.Su
 			// Subject points at a SA that doesn't exist (e.g., deleted) — skip.
 			// Anything else (transient API error, etc.) must surface; otherwise
 			// a connectivity blip silently empties the subject list.
-			if strings.Contains(err.Error(), "not found") {
+			if errors.Is(err, ErrResourceNotFound) {
 				continue
 			}
 			return nil, err


### PR DESCRIPTION
## Summary

Five distinct logic errors found while auditing the k8s provider. All five are independent fixes; bundling them because they're small and the audit pass turned them up together.

- **`ClusterRoleBinding.clusterRole()`** only checked `RoleRef.Name`, not `RoleRef.Kind`. A statically-loaded CRB with `Kind: Role` would mis-resolve. Now matches the symmetric guard in `RoleBinding.clusterRole()`.
- **`HPA.scaleTarget{Deployment,StatefulSet,ReplicaSet}()`** guarded on `Kind` but not on an empty `Name`. A malformed HPA reaching the static-manifest path with `Kind` set and `Name` empty surfaced "not found" as a hard scan error instead of resolving to null.
- **`EndpointSlice.service()`** propagated the `NewResource` error directly. EndpointSlices may outlive the Service they back (mid-deletion or hand-managed slices). Detect `ErrResourceNotFound` and resolve to null; let other errors propagate.
- **`resolveServiceAccountSubjects`** was sniffing `err.Error()` with `strings.Contains(..., "not found")` to detect deleted SAs. Replaced with `errors.Is` against a new `ErrResourceNotFound` sentinel — an unrelated future error whose message happens to contain "not found" no longer gets silently swallowed.
- **Node `initK8sNode` / `nodes()`**: `nodesByName` was read by `initK8sNode` and written by `nodes()` without holding `mqlK8sInternal.lock`. Concurrent queries could race. Take the lock around the reads and the initialization/insert sites.

The sentinel error keeps its original `"not found"` `Error()` text — cnspec matches on that string downstream, so the user-visible message is unchanged.

## Test plan

- [x] \`go build ./...\` (clean)
- [x] \`go vet ./...\` (clean)
- [x] \`gofmt -l\` on modified files (no diffs)
- [x] \`go test -race ./resources/...\` (passes)
- [x] Existing \`cross_references_test.go\` deleted-SA test continues to pass — assertion text mentioning "not found" still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)