### PR TITLE
⚡ k8s: drop eager JsonToDict marshals for fields with cheap lazy access

### DIFF
--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -215,7 +215,7 @@ private k8s.node @defaults("name labels['kubernetes.io/arch'] labels['kubernetes
   // Kubernetes object creation timestamp
   created time
   // Node configuration information
-  nodeInfo dict
+  nodeInfo() dict
   // Kubelet port
   kubeletPort int
   // Node taints for pod scheduling
@@ -225,9 +225,9 @@ private k8s.node @defaults("name labels['kubernetes.io/arch'] labels['kubernetes
   // Node network addresses (e.g., InternalIP, ExternalIP, Hostname)
   addresses() []k8s.nodeAddress
   // Total resources available on the node (e.g., cpu, memory, pods)
-  capacity dict
+  capacity() dict
   // Resources available for scheduling pods on the node
-  allocatable dict
+  allocatable() dict
   // Cloud-provider node identifier (e.g., aws:///us-east-1a/i-0123456789abcdef0)
   providerID() string
   // Whether the node is marked as unschedulable (cordoned)

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -8794,7 +8794,9 @@ func (c *mqlK8sNode) GetCreated() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlK8sNode) GetNodeInfo() *plugin.TValue[any] {
-	return &c.NodeInfo
+	return plugin.GetOrCompute[any](&c.NodeInfo, func() (any, error) {
+		return c.nodeInfo()
+	})
 }
 
 func (c *mqlK8sNode) GetKubeletPort() *plugin.TValue[int64] {
@@ -8850,11 +8852,15 @@ func (c *mqlK8sNode) GetAddresses() *plugin.TValue[[]any] {
 }
 
 func (c *mqlK8sNode) GetCapacity() *plugin.TValue[any] {
-	return &c.Capacity
+	return plugin.GetOrCompute[any](&c.Capacity, func() (any, error) {
+		return c.capacity()
+	})
 }
 
 func (c *mqlK8sNode) GetAllocatable() *plugin.TValue[any] {
-	return &c.Allocatable
+	return plugin.GetOrCompute[any](&c.Allocatable, func() (any, error) {
+		return c.allocatable()
+	})
 }
 
 func (c *mqlK8sNode) GetProviderID() *plugin.TValue[string] {

--- a/providers/k8s/resources/networkpolicy.go
+++ b/providers/k8s/resources/networkpolicy.go
@@ -29,11 +29,6 @@ func (k *mqlK8s) networkPolicies() ([]any, error) {
 			return nil, errors.New("not a k8s networkpolicy")
 		}
 
-		spec, err := convert.JsonToDict(networkPolicy.Spec)
-		if err != nil {
-			return nil, err
-		}
-
 		r, err := CreateResource(k.MqlRuntime, "k8s.networkpolicy", map[string]*llx.RawData{
 			"id":              llx.StringData(objIdFromK8sObj(obj, objT)),
 			"uid":             llx.StringData(string(obj.GetUID())),
@@ -42,7 +37,6 @@ func (k *mqlK8s) networkPolicies() ([]any, error) {
 			"namespace":       llx.StringData(obj.GetNamespace()),
 			"kind":            llx.StringData(objT.GetKind()),
 			"created":         llx.TimeData(ts.Time),
-			"spec":            llx.DictData(spec),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/k8s/resources/node.go
+++ b/providers/k8s/resources/node.go
@@ -63,21 +63,6 @@ func (k *mqlK8s) nodes() ([]any, error) {
 			return nil, errors.New("not a k8s node")
 		}
 
-		nodeInfo, err := convert.JsonToDict(n.Status.NodeInfo)
-		if err != nil {
-			return nil, err
-		}
-
-		capacity, err := convert.JsonToDict(n.Status.Capacity)
-		if err != nil {
-			return nil, err
-		}
-
-		allocatable, err := convert.JsonToDict(n.Status.Allocatable)
-		if err != nil {
-			return nil, err
-		}
-
 		r, err := CreateResource(k.MqlRuntime, "k8s.node", map[string]*llx.RawData{
 			"id":              llx.StringData(objIdFromK8sObj(obj, objT)),
 			"uid":             llx.StringData(string(obj.GetUID())),
@@ -85,10 +70,7 @@ func (k *mqlK8s) nodes() ([]any, error) {
 			"name":            llx.StringData(obj.GetName()),
 			"kind":            llx.StringData(objT.GetKind()),
 			"created":         llx.TimeData(ts.Time),
-			"nodeInfo":        llx.DictData(nodeInfo),
 			"kubeletPort":     llx.IntData(n.Status.DaemonEndpoints.KubeletEndpoint.Port),
-			"capacity":        llx.DictData(capacity),
-			"allocatable":     llx.DictData(allocatable),
 		})
 		if err != nil {
 			return nil, err
@@ -111,6 +93,18 @@ func (k *mqlK8sNode) annotations() (map[string]any, error) {
 
 func (k *mqlK8sNode) labels() (map[string]any, error) {
 	return convert.MapToInterfaceMap(k.obj.GetLabels()), nil
+}
+
+func (k *mqlK8sNode) nodeInfo() (map[string]any, error) {
+	return convert.JsonToDict(k.obj.Status.NodeInfo)
+}
+
+func (k *mqlK8sNode) capacity() (map[string]any, error) {
+	return convert.JsonToDict(k.obj.Status.Capacity)
+}
+
+func (k *mqlK8sNode) allocatable() (map[string]any, error) {
+	return convert.JsonToDict(k.obj.Status.Allocatable)
 }
 
 func (k *mqlK8sNode) taints() ([]any, error) {


### PR DESCRIPTION
## Summary

Two list-time hot spots in the k8s provider were doing redundant JSON marshals on every resource at discovery time, even when the field was never queried. Both fixes are pure deletions of eager work; the user-facing schema is unchanged.

- **\`NetworkPolicy.spec\`** — the creator eagerly built the spec dict and passed it as a \`CreateResource\` arg, while a lazy \`spec()\` Go method existed in parallel. Once the eager arg sets the field state to "resolved", the framework never invokes the lazy method — so the lazy implementation was dead code and every NetworkPolicy paid the marshal cost. Drop the eager arg; the existing \`spec()\` method now runs on first access.
- **\`Node.nodeInfo\` / \`capacity\` / \`allocatable\`** — each was marshaled per node at list time. None are typically queried in a name/labels scan but every node paid for all three. Schema-flip the three fields to computed (\`foo() dict\`), add the Go methods, drop the eager args from the \`nodes()\` creator, and regenerate.

### Why no version bump in \`.lr.versions\`

The fields' name and type are unchanged; only the implementation strategy (stored → computed) flipped. From a query's perspective \`k8s.node.nodeInfo\` returns the same dict it always did. The regenerator left \`.lr.versions\` untouched, which matches the intent.

## Impact

On a name/labels-only query of a 100-node cluster: 300 fewer \`JsonToDict\` marshals at list time (3 fields × 100 nodes). For NetworkPolicy: 1 fewer marshal per NetworkPolicy.

## Test plan

- [x] \`./mqlr generate providers/k8s/resources/k8s.lr --dist providers/k8s/resources\` clean
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`gofmt -l\` no diffs
- [x] \`go test ./resources/...\` passes

## Out of scope (separate PRs)

Other eager-marshal sites found in the same audit pass — \`container.go\` (probe/resource dicts × pods × containers), \`role.go\`/\`clusterrole.go\` \`boundBy()\` (full-list scan per role), \`ingress.go\` \`getTLS\` (per-namespace secret map rebuilt per call), \`rolebinding.go\` \`resolveServiceAccountSubjects\` (per-subject linear SA scan). These all need new index data structures or schema migrations on hotter resources, so handling them separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)