### PR TITLE
🐛 cloudflare: fix bugs surfaced by the audit pass

### DIFF
--- a/providers/cloudflare/resources/audit_logs.go
+++ b/providers/cloudflare/resources/audit_logs.go
@@ -17,44 +17,52 @@ func (c *mqlCloudflareAccountAuditLog) id() (string, error) {
 	return "cloudflare/account/auditLog/" + c.Id.Data, nil
 }
 
-// auditLogs returns the first page of audit log entries for the account
-// (most recent first). The Cloudflare API caps a page at 100 entries; callers
-// that need deeper history should filter by `when` or page through the API
-// outside MQL.
+// auditLogs returns audit log entries for the account (most recent first).
+// Cloudflare's audit log retention is bounded server-side; this walks every
+// page of results until the API reports no more pages.
 func (c *mqlCloudflareAccount) auditLogs() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
 
-	resp, err := conn.Cf.GetOrganizationAuditLogs(context.TODO(), c.Id.Data, cloudflare.AuditLogFilter{
+	results := []any{}
+	filter := cloudflare.AuditLogFilter{
 		PerPage:   100,
 		Direction: "desc",
-	})
-	if err != nil {
-		return nil, err
+		Page:      1,
 	}
-
-	results := []any{}
-	for i := range resp.Result {
-		entry := resp.Result[i]
-
-		res, err := NewResource(c.MqlRuntime, "cloudflare.account.auditLog", map[string]*llx.RawData{
-			"id":           llx.StringData(entry.ID),
-			"when":         llx.TimeData(entry.When),
-			"actorEmail":   llx.StringData(entry.Actor.Email),
-			"actorId":      llx.StringData(entry.Actor.ID),
-			"actorIp":      llx.StringData(entry.Actor.IP),
-			"actorType":    llx.StringData(entry.Actor.Type),
-			"actionType":   llx.StringData(entry.Action.Type),
-			"actionResult": llx.BoolData(entry.Action.Result),
-			"resourceId":   llx.StringData(entry.Resource.ID),
-			"resourceType": llx.StringData(entry.Resource.Type),
-			"ownerId":      llx.StringData(entry.Owner.ID),
-			"oldValue":     llx.DictData(anyMap(entry.OldValueJSON)),
-			"newValue":     llx.DictData(anyMap(entry.NewValueJSON)),
-		})
+	for {
+		resp, err := conn.Cf.GetOrganizationAuditLogs(context.TODO(), c.Id.Data, filter)
 		if err != nil {
 			return nil, err
 		}
-		results = append(results, res)
+
+		for i := range resp.Result {
+			entry := resp.Result[i]
+
+			res, err := NewResource(c.MqlRuntime, "cloudflare.account.auditLog", map[string]*llx.RawData{
+				"id":           llx.StringData(entry.ID),
+				"when":         llx.TimeData(entry.When),
+				"actorEmail":   llx.StringData(entry.Actor.Email),
+				"actorId":      llx.StringData(entry.Actor.ID),
+				"actorIp":      llx.StringData(entry.Actor.IP),
+				"actorType":    llx.StringData(entry.Actor.Type),
+				"actionType":   llx.StringData(entry.Action.Type),
+				"actionResult": llx.BoolData(entry.Action.Result),
+				"resourceId":   llx.StringData(entry.Resource.ID),
+				"resourceType": llx.StringData(entry.Resource.Type),
+				"ownerId":      llx.StringData(entry.Owner.ID),
+				"oldValue":     llx.DictData(anyMap(entry.OldValueJSON)),
+				"newValue":     llx.DictData(anyMap(entry.NewValueJSON)),
+			})
+			if err != nil {
+				return nil, err
+			}
+			results = append(results, res)
+		}
+
+		if !resp.ResultInfo.HasMorePages() {
+			break
+		}
+		filter.Page = resp.ResultInfo.Page + 1
 	}
 	return results, nil
 }

--- a/providers/cloudflare/resources/cloudflare.go
+++ b/providers/cloudflare/resources/cloudflare.go
@@ -4,6 +4,10 @@ package resources
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
 
 	"github.com/cloudflare/cloudflare-go"
 	"go.mondoo.com/mql/v13/llx"
@@ -11,6 +15,39 @@ import (
 	"go.mondoo.com/mql/v13/providers/cloudflare/connection"
 	"go.mondoo.com/mql/v13/types"
 )
+
+const defaultCloudflarePageSize = 50
+
+// paginateRaw walks pagination on a Cloudflare GET endpoint via the SDK's Raw
+// helper, which reuses the same HTTP client, retries, and authentication as
+// the typed SDK methods. Stops when the response omits result_info or
+// HasMorePages reports no further pages. handle is invoked once per page with
+// the raw `result` array bytes.
+//
+// This exists because many cloudflare-go v0 List* methods (devices, posture
+// rules, notifications, teams rules/lists/locations, DLP profiles, workers)
+// take no pagination parameters and silently return only the first page.
+func paginateRaw(ctx context.Context, cf *cloudflare.API, endpoint string, handle func(raw json.RawMessage) error) error {
+	page := 1
+	for {
+		sep := "?"
+		if strings.Contains(endpoint, "?") {
+			sep = "&"
+		}
+		uri := fmt.Sprintf("%s%spage=%d&per_page=%d", endpoint, sep, page, defaultCloudflarePageSize)
+		raw, err := cf.Raw(ctx, http.MethodGet, uri, nil, nil)
+		if err != nil {
+			return err
+		}
+		if err := handle(raw.Result); err != nil {
+			return err
+		}
+		if raw.ResultInfo == nil || !raw.ResultInfo.HasMorePages() {
+			return nil
+		}
+		page = raw.ResultInfo.Page + 1
+	}
+}
 
 func (r *mqlCloudflare) id() (string, error) {
 	return "cloudflare", nil
@@ -90,28 +127,26 @@ func (c *mqlCloudflare) accounts() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
 
 	var result []any
-	cursor := cloudflare.ResultInfo{}
+	params := cloudflare.AccountsListParams{}
 
 	for {
-		_accounts, info, err := conn.Cf.Accounts(context.Background(), cloudflare.AccountsListParams{
-			PaginationOptions: cloudflare.PaginationOptions{
-				Page:    cursor.Page,
-				PerPage: cursor.PerPage,
-			},
-		})
+		_accounts, info, err := conn.Cf.Accounts(context.Background(), params)
 		if err != nil {
 			return nil, err
 		}
 
-		cursor = info
-
 		for i := range _accounts {
 			acc := _accounts[i]
 
-			settings, err := NewResource(c.MqlRuntime, "cloudflare.account.settings", map[string]*llx.RawData{
-				"__id":             llx.StringData("cloudflare.account.settings@" + acc.ID),
-				"enforceTwoFactor": llx.BoolData(acc.Settings.EnforceTwoFactor),
-			})
+			settingsArgs := map[string]*llx.RawData{
+				"__id": llx.StringData("cloudflare.account.settings@" + acc.ID),
+			}
+			if acc.Settings != nil {
+				settingsArgs["enforceTwoFactor"] = llx.BoolData(acc.Settings.EnforceTwoFactor)
+			} else {
+				settingsArgs["enforceTwoFactor"] = llx.BoolData(false)
+			}
+			settings, err := NewResource(c.MqlRuntime, "cloudflare.account.settings", settingsArgs)
 			if err != nil {
 				return nil, err
 			}
@@ -130,9 +165,10 @@ func (c *mqlCloudflare) accounts() ([]any, error) {
 			result = append(result, res)
 		}
 
-		if !cursor.HasMorePages() {
+		if !info.HasMorePages() {
 			break
 		}
+		params.PaginationOptions.Page = info.Page + 1
 	}
 
 	return result, nil

--- a/providers/cloudflare/resources/cloudflare_test.go
+++ b/providers/cloudflare/resources/cloudflare_test.go
@@ -4,7 +4,10 @@
 package resources
 
 import (
+	"fmt"
 	"net/http"
+	"strconv"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -87,4 +90,69 @@ func TestAccounts(t *testing.T) {
 	assert.Equal(t, "9d4e6c8f0a2b1d3f5e7c9b1a8f6e4d2c", a2.Id.Data)
 	assert.Equal(t, "enterprise", a2.Type.Data)
 	assert.True(t, a2.Settings.Data.EnforceTwoFactor.Data)
+}
+
+// TestAccountsPagination guards against the infinite-loop bug where the
+// accounts cursor was never advanced and HasMorePages stayed true forever.
+// It also asserts every page is consumed (not just the first one).
+func TestAccountsPagination(t *testing.T) {
+	env := setupTestEnv(t)
+	root := newTestRoot(t, env)
+
+	const totalPages = 3
+	var calls int32
+
+	env.Mux.HandleFunc("/accounts", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		if page == 0 {
+			page = 1
+		}
+		// Distinct ids per page so we can tell if a page repeats (infinite loop).
+		body := fmt.Sprintf(`{
+			"success": true, "errors": [], "messages": [],
+			"result": [{"id": "acct-p%d", "name": "Account P%d", "type": "standard", "created_on": "2026-01-01T00:00:00Z"}],
+			"result_info": {"page": %d, "per_page": 1, "total_pages": %d, "count": 1, "total_count": %d}
+		}`, page, page, page, totalPages, totalPages)
+		jsonResponse(w, body)
+	})
+
+	// If pagination were broken the request handler would loop forever; cap
+	// the test with t.Deadline via a goroutine isn't necessary — the previous
+	// (buggy) code would re-request page=0 indefinitely. We assert that the
+	// handler is called exactly totalPages times.
+	result, err := root.accounts()
+	require.NoError(t, err)
+	require.Len(t, result, totalPages)
+	require.Equal(t, int32(totalPages), atomic.LoadInt32(&calls), "handler should be called once per page, no repeats")
+
+	ids := make([]string, len(result))
+	for i, r := range result {
+		ids[i] = r.(*mqlCloudflareAccount).Id.Data
+	}
+	assert.Equal(t, []string{"acct-p1", "acct-p2", "acct-p3"}, ids)
+}
+
+// TestAccountsNilSettings asserts that an account whose `settings` field is
+// missing from the API response does not panic. The previous code derefenced
+// acc.Settings.EnforceTwoFactor unconditionally.
+func TestAccountsNilSettings(t *testing.T) {
+	env := setupTestEnv(t)
+	root := newTestRoot(t, env)
+
+	env.Mux.HandleFunc("/accounts", func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, `{
+			"success": true, "errors": [], "messages": [],
+			"result": [{"id": "no-settings", "name": "No Settings", "type": "standard", "created_on": "2026-01-01T00:00:00Z"}],
+			"result_info": {"page": 1, "per_page": 20, "total_pages": 1, "count": 1, "total_count": 1}
+		}`)
+	})
+
+	result, err := root.accounts()
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	acc := result[0].(*mqlCloudflareAccount)
+	require.NotNil(t, acc.Settings.Data)
+	assert.False(t, acc.Settings.Data.EnforceTwoFactor.Data)
 }

--- a/providers/cloudflare/resources/devices.go
+++ b/providers/cloudflare/resources/devices.go
@@ -4,8 +4,11 @@ package resources
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"time"
 
+	"github.com/cloudflare/cloudflare-go"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers/cloudflare/connection"
 )
@@ -20,39 +23,42 @@ func (c *mqlCloudflareOneDevice) id() (string, error) {
 func (c *mqlCloudflareOne) devices() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
 
-	records, err := conn.Cf.ListTeamsDevices(context.TODO(), c.AccountID)
+	var result []any
+	err := paginateRaw(context.TODO(), conn.Cf, fmt.Sprintf("/accounts/%s/devices", c.AccountID), func(raw json.RawMessage) error {
+		var records []cloudflare.TeamsDeviceListItem
+		if err := json.Unmarshal(raw, &records); err != nil {
+			return err
+		}
+		for i := range records {
+			rec := records[i]
+			res, err := NewResource(c.MqlRuntime, "cloudflare.one.device", map[string]*llx.RawData{
+				"id":               llx.StringData(rec.ID),
+				"name":             llx.StringData(rec.Name),
+				"deviceType":       llx.StringData(rec.DeviceType),
+				"model":            llx.StringData(rec.Model),
+				"manufacturer":     llx.StringData(rec.Manufacturer),
+				"serialNumber":     llx.StringData(rec.SerialNumber),
+				"macAddress":       llx.StringData(rec.MacAddress),
+				"ip":               llx.StringData(rec.IP),
+				"osVersion":        llx.StringData(rec.OSVersion),
+				"osDistroName":     llx.StringData(rec.OSDistroName),
+				"osDistroRevision": llx.StringData(rec.OsDistroRevision),
+				"version":          llx.StringData(rec.Version),
+				"deleted":          llx.BoolData(rec.Deleted),
+				"created":          llx.TimeData(parseRFC3339(rec.Created)),
+				"updated":          llx.TimeData(parseRFC3339(rec.Updated)),
+				"lastSeen":         llx.TimeData(parseRFC3339(rec.LastSeen)),
+				"revokedAt":        llx.TimeData(parseRFC3339(rec.RevokedAt)),
+			})
+			if err != nil {
+				return err
+			}
+			result = append(result, res)
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
-	}
-
-	var result []any
-	for i := range records {
-		rec := records[i]
-
-		res, err := NewResource(c.MqlRuntime, "cloudflare.one.device", map[string]*llx.RawData{
-			"id":               llx.StringData(rec.ID),
-			"name":             llx.StringData(rec.Name),
-			"deviceType":       llx.StringData(rec.DeviceType),
-			"model":            llx.StringData(rec.Model),
-			"manufacturer":     llx.StringData(rec.Manufacturer),
-			"serialNumber":     llx.StringData(rec.SerialNumber),
-			"macAddress":       llx.StringData(rec.MacAddress),
-			"ip":               llx.StringData(rec.IP),
-			"osVersion":        llx.StringData(rec.OSVersion),
-			"osDistroName":     llx.StringData(rec.OSDistroName),
-			"osDistroRevision": llx.StringData(rec.OsDistroRevision),
-			"version":          llx.StringData(rec.Version),
-			"deleted":          llx.BoolData(rec.Deleted),
-			"created":          llx.TimeData(parseRFC3339(rec.Created)),
-			"updated":          llx.TimeData(parseRFC3339(rec.Updated)),
-			"lastSeen":         llx.TimeData(parseRFC3339(rec.LastSeen)),
-			"revokedAt":        llx.TimeData(parseRFC3339(rec.RevokedAt)),
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		result = append(result, res)
 	}
 
 	return result, nil
@@ -68,28 +74,31 @@ func (c *mqlCloudflareOneDevicePostureRule) id() (string, error) {
 func (c *mqlCloudflareOne) devicePostureRules() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
 
-	records, _, err := conn.Cf.DevicePostureRules(context.TODO(), c.AccountID)
+	var result []any
+	err := paginateRaw(context.TODO(), conn.Cf, fmt.Sprintf("/accounts/%s/devices/posture", c.AccountID), func(raw json.RawMessage) error {
+		var records []cloudflare.DevicePostureRule
+		if err := json.Unmarshal(raw, &records); err != nil {
+			return err
+		}
+		for i := range records {
+			rec := records[i]
+			res, err := NewResource(c.MqlRuntime, "cloudflare.one.devicePostureRule", map[string]*llx.RawData{
+				"id":          llx.StringData(rec.ID),
+				"name":        llx.StringData(rec.Name),
+				"type":        llx.StringData(rec.Type),
+				"description": llx.StringData(rec.Description),
+				"schedule":    llx.StringData(rec.Schedule),
+				"expiration":  llx.StringData(rec.Expiration),
+			})
+			if err != nil {
+				return err
+			}
+			result = append(result, res)
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
-	}
-
-	var result []any
-	for i := range records {
-		rec := records[i]
-
-		res, err := NewResource(c.MqlRuntime, "cloudflare.one.devicePostureRule", map[string]*llx.RawData{
-			"id":          llx.StringData(rec.ID),
-			"name":        llx.StringData(rec.Name),
-			"type":        llx.StringData(rec.Type),
-			"description": llx.StringData(rec.Description),
-			"schedule":    llx.StringData(rec.Schedule),
-			"expiration":  llx.StringData(rec.Expiration),
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		result = append(result, res)
 	}
 
 	return result, nil
@@ -105,26 +114,29 @@ func (c *mqlCloudflareOneDevicePostureIntegration) id() (string, error) {
 func (c *mqlCloudflareOne) devicePostureIntegrations() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
 
-	records, _, err := conn.Cf.DevicePostureIntegrations(context.TODO(), c.AccountID)
+	var result []any
+	err := paginateRaw(context.TODO(), conn.Cf, fmt.Sprintf("/accounts/%s/devices/posture/integration", c.AccountID), func(raw json.RawMessage) error {
+		var records []cloudflare.DevicePostureIntegration
+		if err := json.Unmarshal(raw, &records); err != nil {
+			return err
+		}
+		for i := range records {
+			rec := records[i]
+			res, err := NewResource(c.MqlRuntime, "cloudflare.one.devicePostureIntegration", map[string]*llx.RawData{
+				"id":       llx.StringData(rec.IntegrationID),
+				"name":     llx.StringData(rec.Name),
+				"type":     llx.StringData(rec.Type),
+				"interval": llx.StringData(rec.Interval),
+			})
+			if err != nil {
+				return err
+			}
+			result = append(result, res)
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
-	}
-
-	var result []any
-	for i := range records {
-		rec := records[i]
-
-		res, err := NewResource(c.MqlRuntime, "cloudflare.one.devicePostureIntegration", map[string]*llx.RawData{
-			"id":       llx.StringData(rec.IntegrationID),
-			"name":     llx.StringData(rec.Name),
-			"type":     llx.StringData(rec.Type),
-			"interval": llx.StringData(rec.Interval),
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		result = append(result, res)
 	}
 
 	return result, nil

--- a/providers/cloudflare/resources/devices_test.go
+++ b/providers/cloudflare/resources/devices_test.go
@@ -6,6 +6,8 @@ package resources
 import (
 	"fmt"
 	"net/http"
+	"strconv"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -78,4 +80,39 @@ func TestDevicePostureIntegrations(t *testing.T) {
 	assert.Equal(t, "CrowdStrike Integration", integ.Name.Data)
 	assert.Equal(t, "crowdstrike_s2s", integ.Type.Data)
 	assert.Equal(t, "10m", integ.Interval.Data)
+}
+
+// TestDevicesPagination asserts the new paginateRaw helper walks every page
+// for the Teams Devices endpoint (previously single-page only).
+func TestDevicesPagination(t *testing.T) {
+	env := setupTestEnv(t)
+	one := createTestOne(t, env)
+
+	const totalPages = 4
+	var calls int32
+
+	env.Mux.HandleFunc(fmt.Sprintf("/accounts/%s/devices", testAccountID), func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		if page == 0 {
+			page = 1
+		}
+		body := fmt.Sprintf(`{
+			"success": true, "errors": [], "messages": [],
+			"result": [{"id": "device-p%d", "name": "Device P%d", "device_type": "desktop", "model": "", "manufacturer": "", "serial_number": "", "mac_address": "", "ip": "", "os_version": "", "os_distro_name": "", "os_distro_revision": "", "version": "", "deleted": false, "created": "2024-01-01T00:00:00Z", "updated": "2024-01-01T00:00:00Z", "last_seen": "2024-01-01T00:00:00Z", "revoked_at": ""}],
+			"result_info": {"page": %d, "per_page": 1, "total_pages": %d, "count": 1, "total_count": %d}
+		}`, page, page, page, totalPages, totalPages)
+		jsonResponse(w, body)
+	})
+
+	result, err := one.devices()
+	require.NoError(t, err)
+	require.Len(t, result, totalPages)
+	require.Equal(t, int32(totalPages), atomic.LoadInt32(&calls))
+
+	ids := make([]string, len(result))
+	for i, r := range result {
+		ids[i] = r.(*mqlCloudflareOneDevice).Id.Data
+	}
+	assert.Equal(t, []string{"device-p1", "device-p2", "device-p3", "device-p4"}, ids)
 }

--- a/providers/cloudflare/resources/email_routing.go
+++ b/providers/cloudflare/resources/email_routing.go
@@ -184,9 +184,6 @@ func (c *mqlCloudflareZoneEmailRouting) resolveZoneName() (string, error) {
 }
 
 func (c *mqlCloudflareZoneEmailRouting) fetchSuggestedDNSRecords() ([]cloudflare.DNSRecord, error) {
-	if c.dnsFetched {
-		return c.dnsCache, nil
-	}
 	c.dnsLock.Lock()
 	defer c.dnsLock.Unlock()
 	if c.dnsFetched {

--- a/providers/cloudflare/resources/gateway.go
+++ b/providers/cloudflare/resources/gateway.go
@@ -4,6 +4,8 @@ package resources
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	"github.com/cloudflare/cloudflare-go"
 	"go.mondoo.com/mql/v13/llx"
@@ -21,41 +23,44 @@ func (c *mqlCloudflareOneGatewayRule) id() (string, error) {
 func (c *mqlCloudflareOne) gatewayRules() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
 
-	// TeamsRules does not support pagination in the SDK; it returns all rules.
-	records, err := conn.Cf.TeamsRules(context.TODO(), c.AccountID)
+	var result []any
+	err := paginateRaw(context.TODO(), conn.Cf, fmt.Sprintf("/accounts/%s/gateway/rules", c.AccountID), func(raw json.RawMessage) error {
+		var records []cloudflare.TeamsRule
+		if err := json.Unmarshal(raw, &records); err != nil {
+			return err
+		}
+		for i := range records {
+			rec := records[i]
+
+			filters := make([]any, len(rec.Filters))
+			for j, f := range rec.Filters {
+				filters[j] = string(f)
+			}
+
+			res, err := NewResource(c.MqlRuntime, "cloudflare.one.gatewayRule", map[string]*llx.RawData{
+				"id":            llx.StringData(rec.ID),
+				"name":          llx.StringData(rec.Name),
+				"description":   llx.StringData(rec.Description),
+				"action":        llx.StringData(string(rec.Action)),
+				"enabled":       llx.BoolData(rec.Enabled),
+				"precedence":    llx.IntData(int64(rec.Precedence)),
+				"traffic":       llx.StringData(rec.Traffic),
+				"identity":      llx.StringData(rec.Identity),
+				"devicePosture": llx.StringData(rec.DevicePosture),
+				"filters":       llx.ArrayData(filters, types.String),
+				"version":       llx.IntData(int64(rec.Version)),
+				"createdAt":     llx.TimeDataPtr(rec.CreatedAt),
+				"updatedAt":     llx.TimeDataPtr(rec.UpdatedAt),
+			})
+			if err != nil {
+				return err
+			}
+			result = append(result, res)
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
-	}
-
-	var result []any
-	for i := range records {
-		rec := records[i]
-
-		filters := make([]any, len(rec.Filters))
-		for j, f := range rec.Filters {
-			filters[j] = string(f)
-		}
-
-		res, err := NewResource(c.MqlRuntime, "cloudflare.one.gatewayRule", map[string]*llx.RawData{
-			"id":            llx.StringData(rec.ID),
-			"name":          llx.StringData(rec.Name),
-			"description":   llx.StringData(rec.Description),
-			"action":        llx.StringData(string(rec.Action)),
-			"enabled":       llx.BoolData(rec.Enabled),
-			"precedence":    llx.IntData(int64(rec.Precedence)),
-			"traffic":       llx.StringData(rec.Traffic),
-			"identity":      llx.StringData(rec.Identity),
-			"devicePosture": llx.StringData(rec.DevicePosture),
-			"filters":       llx.ArrayData(filters, types.String),
-			"version":       llx.IntData(int64(rec.Version)),
-			"createdAt":     llx.TimeDataPtr(rec.CreatedAt),
-			"updatedAt":     llx.TimeDataPtr(rec.UpdatedAt),
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		result = append(result, res)
 	}
 
 	return result, nil
@@ -71,32 +76,32 @@ func (c *mqlCloudflareOneList) id() (string, error) {
 func (c *mqlCloudflareOne) lists() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
 
-	records, _, err := conn.Cf.ListTeamsLists(context.TODO(), &cloudflare.ResourceContainer{
-		Identifier: c.AccountID,
-		Level:      cloudflare.AccountRouteLevel,
-	}, cloudflare.ListTeamListsParams{})
+	var result []any
+	err := paginateRaw(context.TODO(), conn.Cf, fmt.Sprintf("/accounts/%s/gateway/lists", c.AccountID), func(raw json.RawMessage) error {
+		var records []cloudflare.TeamsList
+		if err := json.Unmarshal(raw, &records); err != nil {
+			return err
+		}
+		for i := range records {
+			rec := records[i]
+			res, err := NewResource(c.MqlRuntime, "cloudflare.one.list", map[string]*llx.RawData{
+				"id":          llx.StringData(rec.ID),
+				"name":        llx.StringData(rec.Name),
+				"type":        llx.StringData(rec.Type),
+				"description": llx.StringData(rec.Description),
+				"count":       llx.IntData(int64(rec.Count)),
+				"createdAt":   llx.TimeDataPtr(rec.CreatedAt),
+				"updatedAt":   llx.TimeDataPtr(rec.UpdatedAt),
+			})
+			if err != nil {
+				return err
+			}
+			result = append(result, res)
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
-	}
-
-	var result []any
-	for i := range records {
-		rec := records[i]
-
-		res, err := NewResource(c.MqlRuntime, "cloudflare.one.list", map[string]*llx.RawData{
-			"id":          llx.StringData(rec.ID),
-			"name":        llx.StringData(rec.Name),
-			"type":        llx.StringData(rec.Type),
-			"description": llx.StringData(rec.Description),
-			"count":       llx.IntData(int64(rec.Count)),
-			"createdAt":   llx.TimeDataPtr(rec.CreatedAt),
-			"updatedAt":   llx.TimeDataPtr(rec.UpdatedAt),
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		result = append(result, res)
 	}
 
 	return result, nil
@@ -112,36 +117,40 @@ func (c *mqlCloudflareOneLocation) id() (string, error) {
 func (c *mqlCloudflareOne) locations() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
 
-	records, _, err := conn.Cf.TeamsLocations(context.TODO(), c.AccountID)
+	var result []any
+	err := paginateRaw(context.TODO(), conn.Cf, fmt.Sprintf("/accounts/%s/gateway/locations", c.AccountID), func(raw json.RawMessage) error {
+		var records []cloudflare.TeamsLocation
+		if err := json.Unmarshal(raw, &records); err != nil {
+			return err
+		}
+		for i := range records {
+			rec := records[i]
+
+			ecsSupport := false
+			if rec.ECSSupport != nil {
+				ecsSupport = *rec.ECSSupport
+			}
+
+			res, err := NewResource(c.MqlRuntime, "cloudflare.one.location", map[string]*llx.RawData{
+				"id":                    llx.StringData(rec.ID),
+				"name":                  llx.StringData(rec.Name),
+				"dohSubdomain":          llx.StringData(rec.Subdomain),
+				"ip":                    llx.StringData(rec.Ip),
+				"anonymizedLogsEnabled": llx.BoolData(rec.AnonymizedLogsEnabled),
+				"clientDefault":         llx.BoolData(rec.ClientDefault),
+				"ecsSupport":            llx.BoolData(ecsSupport),
+				"createdAt":             llx.TimeDataPtr(rec.CreatedAt),
+				"updatedAt":             llx.TimeDataPtr(rec.UpdatedAt),
+			})
+			if err != nil {
+				return err
+			}
+			result = append(result, res)
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
-	}
-
-	var result []any
-	for i := range records {
-		rec := records[i]
-
-		ecsSupport := false
-		if rec.ECSSupport != nil {
-			ecsSupport = *rec.ECSSupport
-		}
-
-		res, err := NewResource(c.MqlRuntime, "cloudflare.one.location", map[string]*llx.RawData{
-			"id":                    llx.StringData(rec.ID),
-			"name":                  llx.StringData(rec.Name),
-			"dohSubdomain":          llx.StringData(rec.Subdomain),
-			"ip":                    llx.StringData(rec.Ip),
-			"anonymizedLogsEnabled": llx.BoolData(rec.AnonymizedLogsEnabled),
-			"clientDefault":         llx.BoolData(rec.ClientDefault),
-			"ecsSupport":            llx.BoolData(ecsSupport),
-			"createdAt":             llx.TimeDataPtr(rec.CreatedAt),
-			"updatedAt":             llx.TimeDataPtr(rec.UpdatedAt),
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		result = append(result, res)
 	}
 
 	return result, nil
@@ -157,38 +166,39 @@ func (c *mqlCloudflareOneDlpProfile) id() (string, error) {
 func (c *mqlCloudflareOne) dlpProfiles() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
 
-	records, err := conn.Cf.ListDLPProfiles(context.TODO(), &cloudflare.ResourceContainer{
-		Identifier: c.AccountID,
-		Level:      cloudflare.AccountRouteLevel,
-	}, cloudflare.ListDLPProfilesParams{})
+	var result []any
+	err := paginateRaw(context.TODO(), conn.Cf, fmt.Sprintf("/accounts/%s/dlp/profiles", c.AccountID), func(raw json.RawMessage) error {
+		var records []cloudflare.DLPProfile
+		if err := json.Unmarshal(raw, &records); err != nil {
+			return err
+		}
+		for i := range records {
+			rec := records[i]
+
+			ocrEnabled := false
+			if rec.OCREnabled != nil {
+				ocrEnabled = *rec.OCREnabled
+			}
+
+			res, err := NewResource(c.MqlRuntime, "cloudflare.one.dlpProfile", map[string]*llx.RawData{
+				"id":                llx.StringData(rec.ID),
+				"name":              llx.StringData(rec.Name),
+				"type":              llx.StringData(rec.Type),
+				"description":       llx.StringData(rec.Description),
+				"allowedMatchCount": llx.IntData(int64(rec.AllowedMatchCount)),
+				"ocrEnabled":        llx.BoolData(ocrEnabled),
+				"createdAt":         llx.TimeDataPtr(rec.CreatedAt),
+				"updatedAt":         llx.TimeDataPtr(rec.UpdatedAt),
+			})
+			if err != nil {
+				return err
+			}
+			result = append(result, res)
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
-	}
-
-	var result []any
-	for i := range records {
-		rec := records[i]
-
-		ocrEnabled := false
-		if rec.OCREnabled != nil {
-			ocrEnabled = *rec.OCREnabled
-		}
-
-		res, err := NewResource(c.MqlRuntime, "cloudflare.one.dlpProfile", map[string]*llx.RawData{
-			"id":                llx.StringData(rec.ID),
-			"name":              llx.StringData(rec.Name),
-			"type":              llx.StringData(rec.Type),
-			"description":       llx.StringData(rec.Description),
-			"allowedMatchCount": llx.IntData(int64(rec.AllowedMatchCount)),
-			"ocrEnabled":        llx.BoolData(ocrEnabled),
-			"createdAt":         llx.TimeDataPtr(rec.CreatedAt),
-			"updatedAt":         llx.TimeDataPtr(rec.UpdatedAt),
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		result = append(result, res)
 	}
 
 	return result, nil

--- a/providers/cloudflare/resources/load_balancing.go
+++ b/providers/cloudflare/resources/load_balancing.go
@@ -57,17 +57,29 @@ func poolMapDict(m map[string][]string) map[string]any {
 func (c *mqlCloudflareZone) loadBalancers() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
 
-	lbs, err := conn.Cf.ListLoadBalancers(context.TODO(), &cloudflare.ResourceContainer{
-		Identifier: c.Id.Data,
-		Level:      cloudflare.ZoneRouteLevel,
-	}, cloudflare.ListLoadBalancerParams{})
-	if err != nil {
-		// Load balancing is a paid add-on; treat a missing subscription as "no
-		// load balancers" rather than failing the whole zone query.
-		if isLoadBalancingUnavailable(err) {
-			return []any{}, nil
+	const perPage = 50
+	var lbs []cloudflare.LoadBalancer
+	{
+		params := cloudflare.ListLoadBalancerParams{PaginationOptions: cloudflare.PaginationOptions{PerPage: perPage, Page: 1}}
+		for {
+			page, err := conn.Cf.ListLoadBalancers(context.TODO(), &cloudflare.ResourceContainer{
+				Identifier: c.Id.Data,
+				Level:      cloudflare.ZoneRouteLevel,
+			}, params)
+			if err != nil {
+				// Load balancing is a paid add-on; treat a missing subscription as "no
+				// load balancers" rather than failing the whole zone query.
+				if isLoadBalancingUnavailable(err) {
+					return []any{}, nil
+				}
+				return nil, err
+			}
+			lbs = append(lbs, page...)
+			if len(page) < perPage {
+				break
+			}
+			params.PaginationOptions.Page++
 		}
-		return nil, err
 	}
 	if len(lbs) == 0 {
 		return []any{}, nil
@@ -81,15 +93,25 @@ func (c *mqlCloudflareZone) loadBalancers() ([]any, error) {
 		// empty pool references are not mistaken for "no pools configured".
 		log.Warn().Msg("cloudflare> could not resolve the zone's account; load balancer pool references will be empty")
 	} else {
-		pools, err := conn.Cf.ListLoadBalancerPools(context.TODO(), &cloudflare.ResourceContainer{
-			Identifier: acc.Data.Id.Data,
-			Level:      cloudflare.AccountRouteLevel,
-		}, cloudflare.ListLoadBalancerPoolParams{})
-		if err != nil && !isLoadBalancingUnavailable(err) {
-			return nil, err
-		}
-		for i := range pools {
-			poolIndex[pools[i].ID] = pools[i]
+		params := cloudflare.ListLoadBalancerPoolParams{PaginationOptions: cloudflare.PaginationOptions{PerPage: perPage, Page: 1}}
+		for {
+			pools, err := conn.Cf.ListLoadBalancerPools(context.TODO(), &cloudflare.ResourceContainer{
+				Identifier: acc.Data.Id.Data,
+				Level:      cloudflare.AccountRouteLevel,
+			}, params)
+			if err != nil {
+				if isLoadBalancingUnavailable(err) {
+					break
+				}
+				return nil, err
+			}
+			for i := range pools {
+				poolIndex[pools[i].ID] = pools[i]
+			}
+			if len(pools) < perPage {
+				break
+			}
+			params.PaginationOptions.Page++
 		}
 	}
 

--- a/providers/cloudflare/resources/notifications.go
+++ b/providers/cloudflare/resources/notifications.go
@@ -4,8 +4,10 @@ package resources
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
-	"github.com/rs/zerolog/log"
+	"github.com/cloudflare/cloudflare-go"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers/cloudflare/connection"
 )
@@ -20,64 +22,57 @@ func (c *mqlCloudflareNotificationPolicy) id() (string, error) {
 func (c *mqlCloudflareAccount) notificationPolicies() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
 
-	resp, err := conn.Cf.ListNotificationPolicies(context.TODO(), c.Id.Data)
+	results := []any{}
+	err := paginateRaw(context.TODO(), conn.Cf, fmt.Sprintf("/accounts/%s/alerting/v3/policies", c.Id.Data), func(raw json.RawMessage) error {
+		var policies []cloudflare.NotificationPolicy
+		if err := json.Unmarshal(raw, &policies); err != nil {
+			return err
+		}
+		for i := range policies {
+			p := policies[i]
+
+			mechanisms := map[string]any{}
+			for name, integrations := range p.Mechanisms {
+				list := make([]any, 0, len(integrations))
+				for _, m := range integrations {
+					list = append(list, map[string]any{
+						"id":   m.ID,
+						"name": m.Name,
+					})
+				}
+				mechanisms[name] = list
+			}
+
+			filters := map[string]any{}
+			for k, v := range p.Filters {
+				vv := make([]any, 0, len(v))
+				for _, s := range v {
+					vv = append(vv, s)
+				}
+				filters[k] = vv
+			}
+
+			res, err := NewResource(c.MqlRuntime, "cloudflare.notificationPolicy", map[string]*llx.RawData{
+				"id":          llx.StringData(p.ID),
+				"name":        llx.StringData(p.Name),
+				"description": llx.StringData(p.Description),
+				"enabled":     llx.BoolData(p.Enabled),
+				"alertType":   llx.StringData(p.AlertType),
+				"mechanisms":  llx.DictData(mechanisms),
+				"conditions":  llx.DictData(anyMap(p.Conditions)),
+				"filters":     llx.DictData(filters),
+				"created":     llx.TimeData(p.Created),
+				"modified":    llx.TimeData(p.Modified),
+			})
+			if err != nil {
+				return err
+			}
+			results = append(results, res)
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
-	}
-
-	// The cloudflare-go v0.117.0 SDK does not expose pagination on
-	// ListNotificationPolicies, even though the underlying API does. If the
-	// response is truncated, warn so the operator knows the result set may
-	// be incomplete.
-	if resp.ResultInfo.HasMorePages() {
-		log.Warn().
-			Int("returned", len(resp.Result)).
-			Int("total", resp.ResultInfo.Total).
-			Str("account", c.Id.Data).
-			Msg("cloudflare> notification policies truncated; SDK does not support pagination on this endpoint")
-	}
-
-	results := []any{}
-	for i := range resp.Result {
-		p := resp.Result[i]
-
-		mechanisms := map[string]any{}
-		for name, integrations := range p.Mechanisms {
-			list := make([]any, 0, len(integrations))
-			for _, m := range integrations {
-				list = append(list, map[string]any{
-					"id":   m.ID,
-					"name": m.Name,
-				})
-			}
-			mechanisms[name] = list
-		}
-
-		filters := map[string]any{}
-		for k, v := range p.Filters {
-			vv := make([]any, 0, len(v))
-			for _, s := range v {
-				vv = append(vv, s)
-			}
-			filters[k] = vv
-		}
-
-		res, err := NewResource(c.MqlRuntime, "cloudflare.notificationPolicy", map[string]*llx.RawData{
-			"id":          llx.StringData(p.ID),
-			"name":        llx.StringData(p.Name),
-			"description": llx.StringData(p.Description),
-			"enabled":     llx.BoolData(p.Enabled),
-			"alertType":   llx.StringData(p.AlertType),
-			"mechanisms":  llx.DictData(mechanisms),
-			"conditions":  llx.DictData(anyMap(p.Conditions)),
-			"filters":     llx.DictData(filters),
-			"created":     llx.TimeData(p.Created),
-			"modified":    llx.TimeData(p.Modified),
-		})
-		if err != nil {
-			return nil, err
-		}
-		results = append(results, res)
 	}
 	return results, nil
 }

--- a/providers/cloudflare/resources/one.go
+++ b/providers/cloudflare/resources/one.go
@@ -173,9 +173,10 @@ func (c *mqlCloudflareOne) apps() ([]any, error) {
 					"allowedOrigins":   llx.ArrayData(convert.SliceAnyToInterface(headers.AllowedOrigins), types.String),
 					"maxAge":           llx.IntData(headers.MaxAge),
 				})
-				if err == nil {
-					resourceData["corsHeaders"] = llx.ResourceData(corsHeaders, corsHeaders.MqlName())
+				if err != nil {
+					return nil, err
 				}
+				resourceData["corsHeaders"] = llx.ResourceData(corsHeaders, corsHeaders.MqlName())
 			}
 
 			res, err := NewResource(c.MqlRuntime, "cloudflare.one.app", resourceData)

--- a/providers/cloudflare/resources/r2.go
+++ b/providers/cloudflare/resources/r2.go
@@ -41,9 +41,9 @@ func (c *mqlCloudflareZone) r2() (*mqlCloudflareR2, error) {
 type mqlCloudflareR2BucketInternal struct {
 	accountID string
 
-	publicAccessLock        sync.Mutex
-	publicAccessFetched     bool
+	publicAccessOnce        sync.Once
 	publicAccessAvailable   bool
+	publicAccessErr         error
 	cachePublicAccessOn     bool
 	cachePublicAccessDomain string
 }
@@ -129,54 +129,44 @@ func (c *mqlCloudflareR2) buckets() ([]any, error) {
 // caller lacks access to read it; in that case the calling computed method
 // should mark its field null.
 func (c *mqlCloudflareR2Bucket) fetchPublicAccess() (available, enabled bool, domain string, err error) {
-	if c.publicAccessFetched {
-		return c.publicAccessAvailable, c.cachePublicAccessOn, c.cachePublicAccessDomain, nil
-	}
-	c.publicAccessLock.Lock()
-	defer c.publicAccessLock.Unlock()
-	if c.publicAccessFetched {
-		return c.publicAccessAvailable, c.cachePublicAccessOn, c.cachePublicAccessDomain, nil
-	}
-
-	if c.accountID == "" {
-		c.publicAccessFetched = true
-		return false, false, "", nil
-	}
-
-	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
-	uri := fmt.Sprintf("/accounts/%s/r2/buckets/%s/domains/managed", c.accountID, c.GetName().Data)
-	raw, rerr := conn.Cf.Raw(context.TODO(), http.MethodGet, uri, nil, nil)
-	if rerr != nil {
-		var notFound *cloudflare.NotFoundError
-		var authN *cloudflare.AuthenticationError
-		var authZ *cloudflare.AuthorizationError
-		if errors.As(rerr, &notFound) || errors.As(rerr, &authN) || errors.As(rerr, &authZ) {
-			c.publicAccessFetched = true
-			return false, false, "", nil
+	c.publicAccessOnce.Do(func() {
+		if c.accountID == "" {
+			return
 		}
-		return false, false, "", rerr
-	}
 
-	// An empty result body means the managed-domain endpoint returned no data —
-	// treat that as "not available" rather than "available but disabled".
-	if len(raw.Result) == 0 {
-		c.publicAccessFetched = true
-		return false, false, "", nil
-	}
+		conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
+		uri := fmt.Sprintf("/accounts/%s/r2/buckets/%s/domains/managed", c.accountID, c.GetName().Data)
+		raw, rerr := conn.Cf.Raw(context.TODO(), http.MethodGet, uri, nil, nil)
+		if rerr != nil {
+			var notFound *cloudflare.NotFoundError
+			var authN *cloudflare.AuthenticationError
+			var authZ *cloudflare.AuthorizationError
+			if errors.As(rerr, &notFound) || errors.As(rerr, &authN) || errors.As(rerr, &authZ) {
+				return
+			}
+			c.publicAccessErr = rerr
+			return
+		}
 
-	var payload struct {
-		Enabled bool   `json:"enabled"`
-		Domain  string `json:"domain"`
-	}
-	if err := json.Unmarshal(raw.Result, &payload); err != nil {
-		return false, false, "", fmt.Errorf("failed to decode r2 managed-domain response: %w", err)
-	}
+		// Empty body → managed domain not available; not the same as available-but-disabled.
+		if len(raw.Result) == 0 {
+			return
+		}
 
-	c.publicAccessAvailable = true
-	c.cachePublicAccessOn = payload.Enabled
-	c.cachePublicAccessDomain = payload.Domain
-	c.publicAccessFetched = true
-	return c.publicAccessAvailable, c.cachePublicAccessOn, c.cachePublicAccessDomain, nil
+		var payload struct {
+			Enabled bool   `json:"enabled"`
+			Domain  string `json:"domain"`
+		}
+		if uerr := json.Unmarshal(raw.Result, &payload); uerr != nil {
+			c.publicAccessErr = fmt.Errorf("failed to decode r2 managed-domain response: %w", uerr)
+			return
+		}
+
+		c.publicAccessAvailable = true
+		c.cachePublicAccessOn = payload.Enabled
+		c.cachePublicAccessDomain = payload.Domain
+	})
+	return c.publicAccessAvailable, c.cachePublicAccessOn, c.cachePublicAccessDomain, c.publicAccessErr
 }
 
 func (c *mqlCloudflareR2Bucket) publicAccessEnabled() (bool, error) {

--- a/providers/cloudflare/resources/stream.go
+++ b/providers/cloudflare/resources/stream.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/cloudflare/cloudflare-go"
@@ -14,6 +13,20 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/cloudflare/connection"
 )
+
+// metaString returns the string value at key in a Cloudflare `meta` map, or ""
+// if the key is missing or the value is not a string. The Cloudflare stream
+// API allows arbitrary user-set keys here.
+func metaString(meta map[string]any, key string) string {
+	if meta == nil {
+		return ""
+	}
+	v, ok := meta[key].(string)
+	if !ok {
+		return ""
+	}
+	return v
+}
 
 func (c *mqlCloudflareStreamsLiveInput) id() (string, error) {
 	if c.Id.Error != nil {
@@ -40,44 +53,35 @@ func (c *mqlCloudflareAccount) liveInputs() ([]any, error) {
 func fetchLiveInputs(runtime *plugin.Runtime, account_id string) ([]any, error) {
 	conn := runtime.Connection.(*connection.CloudflareConnection)
 
-	req, _ := http.NewRequest(
-		"GET", fmt.Sprintf("%s/accounts/%s/stream/live_inputs", conn.Cf.BaseURL, account_id), nil,
+	raw, err := conn.Cf.Raw(
+		context.Background(),
+		http.MethodGet,
+		fmt.Sprintf("/accounts/%s/stream/live_inputs", account_id),
+		nil,
+		nil,
 	)
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", conn.Cf.APIToken))
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var results struct {
-		Result []struct {
-			Uid                      string         `json:"uid"`
-			Modified                 string         `json:"modified"`
-			Created                  string         `json:"created"`
-			DeleteRecordingAfterDays int            `json:"deleteRecordingAfterDays"`
-			Meta                     map[string]any `json:"meta"`
-		} `json:"result"`
-	}
-
-	bytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := json.Unmarshal(bytes, &results); err != nil {
-		return nil, err
+	var results []struct {
+		Uid                      string         `json:"uid"`
+		Modified                 string         `json:"modified"`
+		Created                  string         `json:"created"`
+		DeleteRecordingAfterDays int            `json:"deleteRecordingAfterDays"`
+		Meta                     map[string]any `json:"meta"`
+	}
+	if err := json.Unmarshal(raw.Result, &results); err != nil {
+		return nil, fmt.Errorf("cloudflare stream live_inputs: unmarshal: %w", err)
 	}
 
 	var res []any
-
-	for _, result := range results.Result {
+	for _, result := range results {
 		input, err := NewResource(runtime, "cloudflare.streams.liveInput", map[string]*llx.RawData{
 			"id":                       llx.StringData(result.Uid),
 			"uid":                      llx.StringData(result.Uid),
 			"deleteRecordingAfterDays": llx.IntData(result.DeleteRecordingAfterDays),
-			"name":                     llx.StringData(result.Meta["name"].(string)),
+			"name":                     llx.StringData(metaString(result.Meta, "name")),
 		})
 		if err != nil {
 			return nil, err
@@ -114,7 +118,7 @@ func fetchVideos(runtime *plugin.Runtime, account_id string) ([]any, error) {
 		res, err := NewResource(runtime, "cloudflare.streams.video", map[string]*llx.RawData{
 			"id":                    llx.StringData(video.UID),
 			"uid":                   llx.StringData(video.UID),
-			"name":                  llx.StringData(video.Meta["name"].(string)),
+			"name":                  llx.StringData(metaString(video.Meta, "name")),
 			"creator":               llx.StringData(video.Creator),
 			"duration":              llx.FloatData(video.Duration),
 			"height":                llx.IntData(video.Input.Height),

--- a/providers/cloudflare/resources/stream_test.go
+++ b/providers/cloudflare/resources/stream_test.go
@@ -1,0 +1,50 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStreamLiveInputsNilMeta exercises the previously panic-prone path where
+// `result.Meta["name"].(string)` would panic if `meta` was nil or the key was
+// missing or non-string. Cloudflare's stream API allows arbitrary user-set
+// metadata, so all three shapes are realistic.
+func TestStreamLiveInputsNilMeta(t *testing.T) {
+	env := setupTestEnv(t)
+	zone := createTestZone(t, env)
+
+	env.Mux.HandleFunc(fmt.Sprintf("/accounts/%s/stream/live_inputs", testAccountID), func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, `{
+			"success": true, "errors": [], "messages": [],
+			"result": [
+				{"uid": "input-1", "modified": "", "created": "", "deleteRecordingAfterDays": 30, "meta": null},
+				{"uid": "input-2", "deleteRecordingAfterDays": 0, "meta": {}},
+				{"uid": "input-3", "deleteRecordingAfterDays": 7, "meta": {"name": 12345}},
+				{"uid": "input-4", "deleteRecordingAfterDays": 1, "meta": {"name": "explicit-name"}}
+			]
+		}`)
+	})
+
+	result, err := zone.liveInputs()
+	require.NoError(t, err)
+	require.Len(t, result, 4)
+
+	got := make(map[string]string, len(result))
+	for _, r := range result {
+		li := r.(*mqlCloudflareStreamsLiveInput)
+		got[li.Uid.Data] = li.Name.Data
+	}
+
+	// Missing/null/non-string `name` all fall back to "" rather than panicking.
+	assert.Equal(t, "", got["input-1"])
+	assert.Equal(t, "", got["input-2"])
+	assert.Equal(t, "", got["input-3"])
+	assert.Equal(t, "explicit-name", got["input-4"])
+}

--- a/providers/cloudflare/resources/tunnels.go
+++ b/providers/cloudflare/resources/tunnels.go
@@ -125,6 +125,10 @@ func (c *mqlCloudflareTunnelRoute) id() (string, error) {
 	return fmt.Sprintf("tunnelRoute@%s@%s", c.Network.Data, c.TunnelId.Data), nil
 }
 
+func tunnelRouteID(network, tunnelID, vnetID string) string {
+	return fmt.Sprintf("tunnelRoute@%s@%s@%s", network, tunnelID, vnetID)
+}
+
 func (c *mqlCloudflareZone) tunnelRoutes() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
 	acc := c.GetAccount()
@@ -133,37 +137,45 @@ func (c *mqlCloudflareZone) tunnelRoutes() ([]any, error) {
 	}
 	accountID := acc.Data.GetId().Data
 
-	records, err := conn.Cf.ListTunnelRoutes(context.TODO(), &cloudflare.ResourceContainer{
-		Identifier: accountID,
-		Level:      cloudflare.AccountRouteLevel,
-	}, cloudflare.TunnelRoutesListParams{})
-	if err != nil {
-		return nil, err
+	const perPage = 50
+	params := cloudflare.TunnelRoutesListParams{
+		PaginationOptions: cloudflare.PaginationOptions{PerPage: perPage, Page: 1},
 	}
 
 	var result []any
-	for i := range records {
-		rec := records[i]
-
-		res, err := NewResource(c.MqlRuntime, "cloudflare.tunnel.route", map[string]*llx.RawData{
-			"network":    llx.StringData(rec.Network),
-			"tunnelId":   llx.StringData(rec.TunnelID),
-			"tunnelName": llx.StringData(rec.TunnelName),
-			"comment":    llx.StringData(rec.Comment),
-			"createdAt":  llx.TimeDataPtr(rec.CreatedAt),
-			"deletedAt":  llx.TimeDataPtr(rec.DeletedAt),
-		})
+	for {
+		records, err := conn.Cf.ListTunnelRoutes(context.TODO(), &cloudflare.ResourceContainer{
+			Identifier: accountID,
+			Level:      cloudflare.AccountRouteLevel,
+		}, params)
 		if err != nil {
 			return nil, err
 		}
 
-		mqlRoute := res.(*mqlCloudflareTunnelRoute)
-		mqlRoute.cacheVirtualNetworkID = rec.VirtualNetworkID
-		if err != nil {
-			return nil, err
+		for i := range records {
+			rec := records[i]
+
+			res, err := CreateResource(c.MqlRuntime, "cloudflare.tunnel.route", map[string]*llx.RawData{
+				"__id":       llx.StringData(tunnelRouteID(rec.Network, rec.TunnelID, rec.VirtualNetworkID)),
+				"network":    llx.StringData(rec.Network),
+				"tunnelId":   llx.StringData(rec.TunnelID),
+				"tunnelName": llx.StringData(rec.TunnelName),
+				"comment":    llx.StringData(rec.Comment),
+				"createdAt":  llx.TimeDataPtr(rec.CreatedAt),
+				"deletedAt":  llx.TimeDataPtr(rec.DeletedAt),
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			res.(*mqlCloudflareTunnelRoute).cacheVirtualNetworkID = rec.VirtualNetworkID
+			result = append(result, res)
 		}
 
-		result = append(result, res)
+		if len(records) < perPage {
+			break
+		}
+		params.PaginationOptions.Page++
 	}
 
 	return result, nil
@@ -184,31 +196,43 @@ func (c *mqlCloudflareZone) tunnelVirtualNetworks() ([]any, error) {
 	}
 	accountID := acc.Data.GetId().Data
 
-	records, err := conn.Cf.ListTunnelVirtualNetworks(context.TODO(), &cloudflare.ResourceContainer{
-		Identifier: accountID,
-		Level:      cloudflare.AccountRouteLevel,
-	}, cloudflare.TunnelVirtualNetworksListParams{})
-	if err != nil {
-		return nil, err
+	const perPage = 50
+	params := cloudflare.TunnelVirtualNetworksListParams{
+		PaginationOptions: cloudflare.PaginationOptions{PerPage: perPage, Page: 1},
 	}
 
 	var result []any
-	for i := range records {
-		rec := records[i]
-
-		res, err := NewResource(c.MqlRuntime, "cloudflare.tunnel.virtualNetwork", map[string]*llx.RawData{
-			"id":               llx.StringData(rec.ID),
-			"name":             llx.StringData(rec.Name),
-			"comment":          llx.StringData(rec.Comment),
-			"isDefaultNetwork": llx.BoolData(rec.IsDefaultNetwork),
-			"createdAt":        llx.TimeDataPtr(rec.CreatedAt),
-			"deletedAt":        llx.TimeDataPtr(rec.DeletedAt),
-		})
+	for {
+		records, err := conn.Cf.ListTunnelVirtualNetworks(context.TODO(), &cloudflare.ResourceContainer{
+			Identifier: accountID,
+			Level:      cloudflare.AccountRouteLevel,
+		}, params)
 		if err != nil {
 			return nil, err
 		}
 
-		result = append(result, res)
+		for i := range records {
+			rec := records[i]
+
+			res, err := NewResource(c.MqlRuntime, "cloudflare.tunnel.virtualNetwork", map[string]*llx.RawData{
+				"id":               llx.StringData(rec.ID),
+				"name":             llx.StringData(rec.Name),
+				"comment":          llx.StringData(rec.Comment),
+				"isDefaultNetwork": llx.BoolData(rec.IsDefaultNetwork),
+				"createdAt":        llx.TimeDataPtr(rec.CreatedAt),
+				"deletedAt":        llx.TimeDataPtr(rec.DeletedAt),
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			result = append(result, res)
+		}
+
+		if len(records) < perPage {
+			break
+		}
+		params.PaginationOptions.Page++
 	}
 
 	return result, nil

--- a/providers/cloudflare/resources/tunnels.go
+++ b/providers/cloudflare/resources/tunnels.go
@@ -122,7 +122,7 @@ func (c *mqlCloudflareTunnelRoute) id() (string, error) {
 	if c.TunnelId.Error != nil {
 		return "", c.TunnelId.Error
 	}
-	return fmt.Sprintf("tunnelRoute@%s@%s", c.Network.Data, c.TunnelId.Data), nil
+	return tunnelRouteID(c.Network.Data, c.TunnelId.Data, c.cacheVirtualNetworkID), nil
 }
 
 func tunnelRouteID(network, tunnelID, vnetID string) string {

--- a/providers/cloudflare/resources/tunnels_test.go
+++ b/providers/cloudflare/resources/tunnels_test.go
@@ -6,6 +6,8 @@ package resources
 import (
 	"fmt"
 	"net/http"
+	"strconv"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -87,4 +89,73 @@ func TestTunnelVirtualNetworks(t *testing.T) {
 	assert.Equal(t, "default-vnet", vnet.Name.Data)
 	assert.True(t, vnet.IsDefaultNetwork.Data)
 	assert.Equal(t, "Default virtual network", vnet.Comment.Data)
+}
+
+// TestTunnelRoutesVnetIDInCacheKey verifies that two routes advertising the
+// same network through the same tunnel from two different virtual networks
+// produce two distinct rows (rather than collapsing into one cached entry).
+// The previous __id `tunnelRoute@<network>@<tunnelId>` collided in this case.
+func TestTunnelRoutesVnetIDInCacheKey(t *testing.T) {
+	env := setupTestEnv(t)
+	zone := createTestZone(t, env)
+
+	env.Mux.HandleFunc(fmt.Sprintf("/accounts/%s/teamnet/routes", testAccountID), func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, `{
+			"success": true, "errors": [], "messages": [],
+			"result": [
+				{"network": "10.0.0.0/8", "tunnel_id": "tun-1", "tunnel_name": "t", "comment": "via vnet-a", "virtual_network_id": "vnet-a", "created_at": "2024-01-01T00:00:00Z"},
+				{"network": "10.0.0.0/8", "tunnel_id": "tun-1", "tunnel_name": "t", "comment": "via vnet-b", "virtual_network_id": "vnet-b", "created_at": "2024-01-01T00:00:00Z"}
+			]
+		}`)
+	})
+
+	result, err := zone.tunnelRoutes()
+	require.NoError(t, err)
+	require.Len(t, result, 2, "routes with distinct virtual_network_id must not collapse into one")
+
+	r1 := result[0].(*mqlCloudflareTunnelRoute)
+	r2 := result[1].(*mqlCloudflareTunnelRoute)
+
+	// Same (network, tunnelId) but distinct vnet IDs.
+	assert.Equal(t, r1.Network.Data, r2.Network.Data)
+	assert.Equal(t, r1.TunnelId.Data, r2.TunnelId.Data)
+	assert.NotEqual(t, r1.cacheVirtualNetworkID, r2.cacheVirtualNetworkID)
+	assert.NotEqual(t, r1.Comment.Data, r2.Comment.Data, "each row must keep its own data, not share with its collision peer")
+}
+
+// TestTunnelRoutesPagination guards against the previously single-page call
+// silently truncating large accounts. The handler returns full-size pages
+// (perPage=50) twice, then a short page, and we assert the loop consumed all
+// three pages and bumped page numbers monotonically.
+func TestTunnelRoutesPagination(t *testing.T) {
+	env := setupTestEnv(t)
+	zone := createTestZone(t, env)
+
+	const perPage = 50
+	var calls int32
+
+	env.Mux.HandleFunc(fmt.Sprintf("/accounts/%s/teamnet/routes", testAccountID), func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		if page == 0 {
+			page = 1
+		}
+		count := perPage
+		if page >= 3 {
+			count = 7 // short page → terminates loop
+		}
+		fmt.Fprint(w, `{"success": true, "errors": [], "messages": [], "result": [`)
+		for i := 0; i < count; i++ {
+			if i > 0 {
+				fmt.Fprint(w, ",")
+			}
+			fmt.Fprintf(w, `{"network": "10.%d.%d.0/24", "tunnel_id": "t-p%d-i%d", "tunnel_name": "t", "comment": "", "virtual_network_id": "v-p%d-i%d", "created_at": "2024-01-01T00:00:00Z"}`, page, i, page, i, page, i)
+		}
+		fmt.Fprint(w, `]}`)
+	})
+
+	result, err := zone.tunnelRoutes()
+	require.NoError(t, err)
+	require.Equal(t, perPage*2+7, len(result), "all three pages must be consumed")
+	require.Equal(t, int32(3), atomic.LoadInt32(&calls), "exactly three calls (page=1,2,3)")
 }

--- a/providers/cloudflare/resources/workers.go
+++ b/providers/cloudflare/resources/workers.go
@@ -4,7 +4,9 @@ package resources
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/cloudflare/cloudflare-go"
@@ -29,35 +31,28 @@ func (c *mqlCloudflareZone) workers() (*mqlCloudflareWorkers, error) {
 type mqlCloudflareWorkersInternal struct {
 	AccountID string
 
-	workerListLock sync.Mutex
-	workerListDone bool
+	workerListOnce sync.Once
 	workerList     []cloudflare.WorkerMetaData
 	workerListErr  error
 }
 
 // fetchWorkerList caches the per-account workers list so that workers() and
-// secrets() share a single ListWorkers API call.
+// secrets() share a single round-trip across the underlying API.
 func (c *mqlCloudflareWorkers) fetchWorkerList() ([]cloudflare.WorkerMetaData, error) {
-	if c.workerListDone {
-		return c.workerList, c.workerListErr
-	}
-	c.workerListLock.Lock()
-	defer c.workerListLock.Unlock()
-	if c.workerListDone {
-		return c.workerList, c.workerListErr
-	}
-
-	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
-	resp, _, err := conn.Cf.ListWorkers(context.TODO(), &cloudflare.ResourceContainer{
-		Identifier: c.mqlCloudflareWorkersInternal.AccountID,
-		Level:      cloudflare.AccountRouteLevel,
-	}, cloudflare.ListWorkersParams{})
-	if err != nil {
-		c.workerListErr = err
-	} else {
-		c.workerList = resp.WorkerList
-	}
-	c.workerListDone = true
+	c.workerListOnce.Do(func() {
+		conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
+		err := paginateRaw(context.TODO(), conn.Cf, fmt.Sprintf("/accounts/%s/workers/scripts", c.mqlCloudflareWorkersInternal.AccountID), func(raw json.RawMessage) error {
+			var batch []cloudflare.WorkerMetaData
+			if err := json.Unmarshal(raw, &batch); err != nil {
+				return err
+			}
+			c.workerList = append(c.workerList, batch...)
+			return nil
+		})
+		if err != nil {
+			c.workerListErr = err
+		}
+	})
 	return c.workerList, c.workerListErr
 }
 


### PR DESCRIPTION
## Summary

Cleans up the HIGH- and MEDIUM-severity findings from the cloudflare provider audit. The dominant pattern: the `cloudflare-go` v0.117.0 SDK is wildly inconsistent about pagination — some `List*` calls auto-paginate, several have `Page`/`PerPage` params but require the caller to loop, and many take no pagination params at all and silently return only the first page. The fixes split into three buckets.

### HIGH

- **`cloudflare.go: accounts()` infinite loop.** `cursor.Page` was fed back into the request unchanged; once `HasMorePages()` returned true the loop never advanced. Bump `info.Page + 1` per the `mtls.go` precedent.
- **`cloudflare.go: acc.Settings` nil deref.** `Account.Settings` is `*AccountSettings` and is not always populated in list responses; guarded.
- **`stream.go: fetchLiveInputs`** called `http.DefaultClient.Do` directly, swallowed the request error (`req, _ :=`), and never checked the HTTP status. A 401/403/500 parsed as an empty `result` and silently returned no records. Switched to `cf.Raw` which reuses SDK auth/retries and surfaces non-2xx as an error.
- **`stream.go: meta["name"]` panic.** Unchecked map-type-asserts on user-controlled `meta`; routed through a `metaString` helper.
- **`tunnels.go: route __id collision.** The cache key was `tunnelRoute@<network>@<tunnelId>` but the API allows the same network to be advertised through the same tunnel from multiple virtual networks. Two such routes collapsed into one cached row and `route.virtualNetwork` resolved to the wrong VNet. Include `virtual_network_id` in the cache key.
- **`tunnels.go`, `devices.go`: single-page truncation.** `ListTunnelRoutes`, `ListTunnelVirtualNetworks`, `ListTeamsDevices` all silently returned just one page. Paginated.

### MEDIUM

- New **`paginateRaw`** helper in `cloudflare.go` walks pagination on any GET endpoint via `cf.Raw` (so it reuses the same HTTP client, retries, and auth as the typed SDK methods). Used for the long list of `List*` calls whose SDK wrappers take no pagination params:
  - `workers.go` (`ListWorkers`)
  - `notifications.go` (`ListNotificationPolicies`)
  - `gateway.go` (`TeamsRules`, `ListTeamsLists`, `TeamsLocations`, `ListDLPProfiles`)
  - `devices.go` (`DevicePostureRules`, `DevicePostureIntegrations`)
- **`audit_logs.go`**: walk every page (`AuditLogFilter.Page`) instead of returning the first 100.
- **`load_balancing.go`**: paginate `ListLoadBalancers` and `ListLoadBalancerPools` (both `PaginationOptions`-aware, no `ResultInfo` → loop until short page).
- **DCL races** in `workers.go`, `r2.go`, `email_routing.go`: replaced with `sync.Once` (where the "do once" semantics fit) or always-lock (where the cache only stores success).
- **`one.go`**: stop swallowing the `corsHeaders` sub-resource creation error — propagate instead of producing a row with a nil header.

### Out of scope

- `StreamListVideos` uses cursor-based pagination via `After` timestamps; deferred — would need a different helper than `paginateRaw`.
- `waf.go` 1+N (one `GetRuleset` per ruleset) is unavoidable with the current schema; reshaping into a lazy `zone.ruleset.rules` sub-resource is a follow-up.

## Test plan

- [x] `go test ./resources/ -v` (all existing + new tests pass)
- [x] New regression tests:
  - `TestAccountsPagination` — loop terminates and consumes every page exactly once
  - `TestAccountsNilSettings` — missing `settings` in API response
  - `TestTunnelRoutesVnetIDInCacheKey` — two routes that differ only by `virtual_network_id` produce two distinct rows
  - `TestTunnelRoutesPagination` — multi-page route response walked
  - `TestDevicesPagination` — `paginateRaw` consumes every page
  - `TestStreamLiveInputsNilMeta` — nil / empty / non-string / present metadata
- [ ] Spot-check against a real Cloudflare account (recommended before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)