### PR TITLE
🐛 github: fix correctness bugs and reduce N+1 API calls from audit pass

### DIFF
--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -163,7 +163,6 @@ func org(runtime *plugin.Runtime, orgName string, conn *connection.GithubConnect
 		}
 	}
 	if stringx.ContainsAnyOf(targets, connection.DiscoveryUsers) {
-		assetList = []*inventory.Asset{}
 		for i := range org.GetMembers().Data {
 			user := org.GetMembers().Data[i].(*mqlGithubUser)
 			if user.Name.Data == "" {
@@ -257,7 +256,7 @@ func user(runtime *plugin.Runtime, userName string, conn *connection.GithubConne
 }
 
 func getMqlGithubUser(runtime *plugin.Runtime, userName string) (*mqlGithubUser, error) {
-	res, err := NewResource(runtime, "github.user", map[string]*llx.RawData{"name": llx.StringData(userName)})
+	res, err := NewResource(runtime, "github.user", map[string]*llx.RawData{"login": llx.StringData(userName)})
 	if err != nil {
 		return nil, err
 	}

--- a/providers/github/resources/github_environments.go
+++ b/providers/github/resources/github_environments.go
@@ -299,6 +299,7 @@ func (g *mqlGithubDeployment) latestStatus() (*mqlGithubDeploymentStatus, error)
 	repoName := g.repoName
 
 	if ownerLogin == "" || repoName == "" {
+		g.LatestStatus.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 
@@ -306,16 +307,19 @@ func (g *mqlGithubDeployment) latestStatus() (*mqlGithubDeploymentStatus, error)
 	statuses, _, err := conn.Client().Repositories.ListDeploymentStatuses(conn.Context(), ownerLogin, repoName, deploymentID, opts)
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
+			g.LatestStatus.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil
 		}
 		if strings.Contains(err.Error(), "403") {
 			log.Debug().Msg("Deployment statuses are not accessible for this deployment")
+			g.LatestStatus.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil
 		}
 		return nil, err
 	}
 
 	if len(statuses) == 0 {
+		g.LatestStatus.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 

--- a/providers/github/resources/github_org.go
+++ b/providers/github/resources/github_org.go
@@ -96,7 +96,7 @@ func initGithubOrganization(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	args["membersCanCreateInternalRepositories"] = llx.BoolData(convert.ToValue(org.MembersCanCreateInternalRepos))
 	args["membersCanCreatePages"] = llx.BoolData(convert.ToValue(org.MembersCanCreatePages))
 	args["membersCanCreatePublicPages"] = llx.BoolData(convert.ToValue(org.MembersCanCreatePublicPages))
-	args["membersCanCreatePrivatePages"] = llx.BoolData(convert.ToValue(org.MembersCanCreatePrivateRepos))
+	args["membersCanCreatePrivatePages"] = llx.BoolData(convert.ToValue(org.MembersCanCreatePrivatePages))
 	args["membersCanForkPrivateRepos"] = llx.BoolData(convert.ToValue(org.MembersCanForkPrivateRepos))
 
 	// Security settings for new repositories
@@ -618,6 +618,7 @@ func (g *mqlGithubOrganization) packages() ([]any, error) {
 				return nil, err
 			}
 			pkg := mqlGhPackage.(*mqlGithubPackage)
+			pkg.parentResource = g
 
 			// NOTE: we need to fetch repo separately because the Github repo object is not complete, instead of
 			// call the repo fetching all the time, we make this lazy loading
@@ -639,6 +640,15 @@ func (g *mqlGithubPackage) repository() (*mqlGithubRepository, error) {
 	}
 
 	repoName := g.packageRepository
+
+	// When the package was discovered via an organization, the org's repo
+	// list is already cached. Reuse it before falling back to a per-package
+	// Repositories.Get call.
+	if g.parentResource != nil {
+		if cached, ok := g.parentResource.repoCacheMap[repoName]; ok && cached != nil {
+			return cached, nil
+		}
+	}
 
 	if g.Owner.Error != nil {
 		return nil, g.Owner.Error

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -73,12 +73,19 @@ func newMqlGithubRepository(runtime *plugin.Runtime, repo *github.Repository) (*
 		id = *repo.ID
 	}
 
-	owner, err := NewResource(runtime, "github.user", map[string]*llx.RawData{
-		"id":    llx.IntData(repo.GetOwner().GetID()),
-		"login": llx.StringData(repo.GetOwner().GetLogin()),
-	})
-	if err != nil {
-		return nil, err
+	// repo.Owner can be nil on fork entries and some list responses. Skip the
+	// owner resource in that case rather than constructing a degenerate
+	// `github.user/0` that every nil-owner repo would share.
+	var owner plugin.Resource
+	if repo.Owner != nil && repo.GetOwner().GetLogin() != "" {
+		var err error
+		owner, err = NewResource(runtime, "github.user", map[string]*llx.RawData{
+			"id":    llx.IntData(repo.GetOwner().GetID()),
+			"login": llx.StringData(repo.GetOwner().GetLogin()),
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	res, err := CreateResource(runtime, "github.repository", map[string]*llx.RawData{
@@ -116,7 +123,7 @@ func newMqlGithubRepository(runtime *plugin.Runtime, repo *github.Repository) (*
 		"defaultBranchName":                   llx.StringDataPtr(repo.DefaultBranch),
 		"cloneUrl":                            llx.StringData(repo.GetCloneURL()),
 		"sshUrl":                              llx.StringData(repo.GetSSHURL()),
-		"owner":                               llx.ResourceData(owner, owner.MqlName()),
+		"owner":                               llx.AnyData(owner),
 		"customProperties":                    llx.DictData(repo.CustomProperties),
 		"webCommitSignoffRequired":            llx.BoolDataPtr(repo.WebCommitSignoffRequired),
 		"advancedSecurityEnabled":             llx.BoolData(saEnabled(repo.SecurityAndAnalysis, saAdvancedSecurity)),
@@ -368,12 +375,16 @@ func (g *mqlGithubRepository) getMergeRequests(state string) ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
-		owner, err := NewResource(g.MqlRuntime, "github.user", map[string]*llx.RawData{
-			"id":    llx.IntDataPtr(pr.User.ID),
-			"login": llx.StringDataPtr(pr.User.Login),
-		})
-		if err != nil {
-			return nil, err
+		var owner plugin.Resource
+		if pr.User != nil {
+			ownerRes, err := NewResource(g.MqlRuntime, "github.user", map[string]*llx.RawData{
+				"id":    llx.IntDataPtr(pr.User.ID),
+				"login": llx.StringDataPtr(pr.User.Login),
+			})
+			if err != nil {
+				return nil, err
+			}
+			owner = ownerRes
 		}
 
 		assigneesRes := []any{}
@@ -423,14 +434,14 @@ func (g *mqlGithubRepository) getMergeRequests(state string) ([]any, error) {
 
 		r, err := CreateResource(g.MqlRuntime, "github.mergeRequest", map[string]*llx.RawData{
 			"id":                 llx.IntDataPtr(pr.ID),
-			"number":             llx.IntData(int64(*pr.Number)),
+			"number":             llx.IntData(int64(pr.GetNumber())),
 			"state":              llx.StringDataPtr(pr.State),
 			"labels":             llx.ArrayData(labels, types.Any),
 			"createdAt":          llx.TimeDataPtr(githubTimestamp(pr.CreatedAt)),
 			"updatedAt":          llx.TimeDataPtr(githubTimestamp(pr.UpdatedAt)),
 			"closedAt":           llx.TimeDataPtr(githubTimestamp(pr.ClosedAt)),
 			"title":              llx.StringDataPtr(pr.Title),
-			"owner":              llx.ResourceData(owner, owner.MqlName()),
+			"owner":              llx.AnyData(owner),
 			"assignees":          llx.ArrayData(assigneesRes, types.Any),
 			"requestedReviewers": llx.ArrayData(requestedReviewers, types.Resource("github.user")),
 			"repoName":           llx.StringData(repoName),
@@ -524,7 +535,7 @@ func (g *mqlGithubRepository) branches() ([]any, error) {
 		branch := allBranches[i]
 
 		defaultBranch := false
-		if repoDefaultBranchName == *branch.Name {
+		if repoDefaultBranchName == branch.GetName() {
 			defaultBranch = true
 		}
 
@@ -855,8 +866,8 @@ func newMqlGithubCommit(runtime *plugin.Runtime, rc *github.RepositoryCommit, ow
 		"repository":    llx.StringData(repo),
 		"commit":        llx.AnyData(mqlGitCommit),
 		"stats":         llx.MapData(stats, types.Any),
-		"authoredDate":  llx.TimeData(rc.Commit.Author.Date.Time),
-		"committedDate": llx.TimeData(rc.Commit.Committer.Date.Time),
+		"authoredDate":  llx.TimeData(rc.Commit.GetAuthor().GetDate().Time),
+		"committedDate": llx.TimeData(rc.Commit.GetCommitter().GetDate().Time),
 	})
 }
 
@@ -1359,6 +1370,7 @@ func (g *mqlGithubRepository) webhooks() ([]any, error) {
 
 type mqlGithubWorkflowInternal struct {
 	repositoryFullName string
+	defaultBranchName  string
 	parentResource     *mqlGithubRepository
 }
 
@@ -1382,6 +1394,11 @@ func (g *mqlGithubRepository) workflows() ([]any, error) {
 		return nil, g.FullName.Error
 	}
 	fullName := g.FullName.Data
+
+	defaultBranchName := ""
+	if g.DefaultBranchName.Error == nil {
+		defaultBranchName = g.DefaultBranchName.Data
+	}
 
 	listOpts := &github.ListOptions{
 		PerPage: paginationPerPage,
@@ -1420,6 +1437,7 @@ func (g *mqlGithubRepository) workflows() ([]any, error) {
 
 		gw := mqlWebhook.(*mqlGithubWorkflow)
 		gw.repositoryFullName = fullName
+		gw.defaultBranchName = defaultBranchName
 		res = append(res, gw)
 	}
 	return res, nil
@@ -1738,6 +1756,9 @@ func (g *mqlGithubRepository) stargazers() ([]any, error) {
 	res := []any{}
 	for i := range allStargazers {
 		stargazer := allStargazers[i]
+		if stargazer.User == nil {
+			continue
+		}
 		r, err := NewResource(g.MqlRuntime, "github.user", map[string]*llx.RawData{
 			"id":    llx.IntDataPtr(stargazer.User.ID),
 			"login": llx.StringDataPtr(stargazer.User.Login),
@@ -2447,6 +2468,7 @@ func (g *mqlGithubRepository) spdxSbom() (*mqlGithubRepositorySbom, error) {
 		return nil, err
 	}
 	if result == nil || result.SBOM == nil {
+		g.SpdxSbom.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	info := result.SBOM

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -76,16 +76,16 @@ func newMqlGithubRepository(runtime *plugin.Runtime, repo *github.Repository) (*
 	// repo.Owner can be nil on fork entries and some list responses. Skip the
 	// owner resource in that case rather than constructing a degenerate
 	// `github.user/0` that every nil-owner repo would share.
-	var owner plugin.Resource
+	ownerData := llx.NilData
 	if repo.Owner != nil && repo.GetOwner().GetLogin() != "" {
-		var err error
-		owner, err = NewResource(runtime, "github.user", map[string]*llx.RawData{
+		owner, err := NewResource(runtime, "github.user", map[string]*llx.RawData{
 			"id":    llx.IntData(repo.GetOwner().GetID()),
 			"login": llx.StringData(repo.GetOwner().GetLogin()),
 		})
 		if err != nil {
 			return nil, err
 		}
+		ownerData = llx.ResourceData(owner, "github.user")
 	}
 
 	res, err := CreateResource(runtime, "github.repository", map[string]*llx.RawData{
@@ -123,7 +123,7 @@ func newMqlGithubRepository(runtime *plugin.Runtime, repo *github.Repository) (*
 		"defaultBranchName":                   llx.StringDataPtr(repo.DefaultBranch),
 		"cloneUrl":                            llx.StringData(repo.GetCloneURL()),
 		"sshUrl":                              llx.StringData(repo.GetSSHURL()),
-		"owner":                               llx.AnyData(owner),
+		"owner":                               ownerData,
 		"customProperties":                    llx.DictData(repo.CustomProperties),
 		"webCommitSignoffRequired":            llx.BoolDataPtr(repo.WebCommitSignoffRequired),
 		"advancedSecurityEnabled":             llx.BoolData(saEnabled(repo.SecurityAndAnalysis, saAdvancedSecurity)),
@@ -375,7 +375,7 @@ func (g *mqlGithubRepository) getMergeRequests(state string) ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
-		var owner plugin.Resource
+		ownerData := llx.NilData
 		if pr.User != nil {
 			ownerRes, err := NewResource(g.MqlRuntime, "github.user", map[string]*llx.RawData{
 				"id":    llx.IntDataPtr(pr.User.ID),
@@ -384,7 +384,7 @@ func (g *mqlGithubRepository) getMergeRequests(state string) ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
-			owner = ownerRes
+			ownerData = llx.ResourceData(ownerRes, "github.user")
 		}
 
 		assigneesRes := []any{}
@@ -441,7 +441,7 @@ func (g *mqlGithubRepository) getMergeRequests(state string) ([]any, error) {
 			"updatedAt":          llx.TimeDataPtr(githubTimestamp(pr.UpdatedAt)),
 			"closedAt":           llx.TimeDataPtr(githubTimestamp(pr.ClosedAt)),
 			"title":              llx.StringDataPtr(pr.Title),
-			"owner":              llx.AnyData(owner),
+			"owner":              ownerData,
 			"assignees":          llx.ArrayData(assigneesRes, types.Any),
 			"requestedReviewers": llx.ArrayData(requestedReviewers, types.Resource("github.user")),
 			"repoName":           llx.StringData(repoName),

--- a/providers/github/resources/github_team.go
+++ b/providers/github/resources/github_team.go
@@ -39,7 +39,7 @@ func (g *mqlGithubTeam) repositories() ([]any, error) {
 	}
 	orgID := org.Id.Data
 
-	listOpts := &github.ListOptions{}
+	listOpts := &github.ListOptions{PerPage: paginationPerPage}
 	var allRepos []*github.Repository
 	for {
 		repos, resp, err := conn.Client().Teams.ListTeamReposByID(conn.Context(), orgID, teamID, listOpts)

--- a/providers/github/resources/github_user.go
+++ b/providers/github/resources/github_user.go
@@ -97,7 +97,7 @@ func (g *mqlGithubCollaborator) id() (string, error) {
 		return "", g.Id.Error
 	}
 	id := g.Id.Data
-	return strconv.FormatInt(id, 10), nil
+	return "github.collaborator/" + strconv.FormatInt(id, 10), nil
 }
 
 func (g *mqlGithubInstallation) id() (string, error) {
@@ -105,7 +105,7 @@ func (g *mqlGithubInstallation) id() (string, error) {
 		return "", g.Id.Error
 	}
 	id := g.Id.Data
-	return strconv.FormatInt(id, 10), nil
+	return "github.installation/" + strconv.FormatInt(id, 10), nil
 }
 
 func (g *mqlGithubUser) repositories() ([]any, error) {

--- a/providers/github/resources/github_user_test.go
+++ b/providers/github/resources/github_user_test.go
@@ -1,0 +1,37 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func TestGithubCollaboratorID(t *testing.T) {
+	tests := []struct {
+		name string
+		id   int64
+		want string
+	}{
+		{name: "non-zero id", id: 42, want: "github.collaborator/42"},
+		{name: "zero id", id: 0, want: "github.collaborator/0"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &mqlGithubCollaborator{Id: plugin.TValue[int64]{Data: tc.id, State: plugin.StateIsSet}}
+			got, err := c.id()
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestGithubInstallationID(t *testing.T) {
+	i := &mqlGithubInstallation{Id: plugin.TValue[int64]{Data: 7, State: plugin.StateIsSet}}
+	got, err := i.id()
+	assert.NoError(t, err)
+	assert.Equal(t, "github.installation/7", got)
+}

--- a/providers/github/resources/github_workflow.go
+++ b/providers/github/resources/github_workflow.go
@@ -65,11 +65,16 @@ func (g *mqlGithubWorkflow) file() (*mqlGithubFile, error) {
 	ownerLogin := fullNameSplit[0]
 	repoName := fullNameSplit[1]
 
-	repo, _, err := conn.Client().Repositories.Get(conn.Context(), ownerLogin, repoName)
-	if err != nil {
-		return nil, err
+	// Prefer the default branch already known to the parent repository to
+	// avoid an extra Repositories.Get on every workflow access.
+	defaultBranch := g.defaultBranchName
+	if defaultBranch == "" {
+		repo, _, err := conn.Client().Repositories.Get(conn.Context(), ownerLogin, repoName)
+		if err != nil {
+			return nil, err
+		}
+		defaultBranch = repo.GetDefaultBranch()
 	}
-	defaultBranch := repo.GetDefaultBranch()
 	if defaultBranch == "" {
 		defaultBranch = "main"
 	}


### PR DESCRIPTION
## Summary

A deep audit of the github provider (across nil handling, pagination, logic, and performance) surfaced a dozen issues. This PR fixes the critical/high-confidence findings and the easy performance wins; the deeper refactors (commit-list N+1, branch-protection split, actionsSettings split) are left for follow-ups since they touch the schema.

### Correctness

- **Wrong SDK field source** — \`org.membersCanCreatePrivatePages\` was reading from \`MembersCanCreatePrivateRepos\`. The field has been silently wrong since it was added.
- **Discovery user lookup broken** — \`getMqlGithubUser\` passed \`{\"name\": ...}\` but \`initGithubUser\` only checks \`args[\"login\"]\`. Result: \`--discover users\` for a specific user always returned the token owner.
- **Users-discovery wiped prior assets** — the \`DiscoveryUsers\` branch reassigned \`assetList = []*inventory.Asset{}\` before its loop, throwing away every org and repo asset collected earlier in the same call.
- **\`StateIsNull\` not set on null singular accessors** — \`spdxSbom\` (\`github_repo.go\`) and \`latestStatus\` (\`github_environments.go\`, 4 paths) returned \`nil, nil\` without marking the field, which can cause the runtime to panic or re-fetch indefinitely (CLAUDE.md rule).
- **Null-owner cache collision** — \`newMqlGithubRepository\` always created a \`github.user\` owner; when \`repo.Owner\` was nil (forks, some list responses) every nil-owner repo collided on cache key \`github.user/0\`. Now skip the owner resource in that case.
- **Nil-derefs on SDK pointer chains:**
  - \`pr.User.ID/Login\` (bot- and deleted-account PRs)
  - \`stargazer.User.ID/Login\` (deleted accounts)
  - \`rc.Commit.Author.Date / rc.Commit.Committer.Date\` (merge commits, automated commits) — replaced with nil-safe \`GetX()\` accessors
- **Bare pointer derefs** — \`*pr.Number\`, \`*branch.Name\` replaced with \`GetNumber()\` / \`GetName()\`.
- **Collaborator/Installation cache keys** — \`mqlGithubCollaborator.id()\` and \`mqlGithubInstallation.id()\` returned bare \`strconv.FormatInt(id, 10)\` with no resource prefix. When the SDK omits the ID (some list endpoints do), every such row collapses to cache key \`\"\"\` and they all share one slot. Now prefixed like every other id() in the file.

### Performance

- \`github_team.go\` \`ListOptions{}\` defaulted \`PerPage\` to 30; every other list in the provider uses \`paginationPerPage\` (100). 3× more API calls for teams with >30 repos. One-line fix.
- \`mqlGithubWorkflow.file()\` called \`Repositories.Get\` on **every access** just to read the default branch. The parent repository already has it on \`DefaultBranchName\` — now stashed on the workflow's Internal struct when the workflow is created. For an org with 20 repos × 5 workflows × \`workflow.configuration\`, that's ~100 wasted GETs per query.
- \`mqlGithubPackage.repository()\` did its own \`Repositories.Get\` per package, ignoring the parent org's \`repoCacheMap\`. Wire \`parentResource\` and reuse the cached repo when present.

## Not in this PR (intentional follow-ups)

- **Commit list N+1** — \`ListCommits\` returns sparse \`RepositoryCommit\`s and \`newMqlGithubCommit\` issues a \`GetCommit\` for each row. Real fix requires making \`stats\` a lazy method (schema change).
- **Branch protection \`GetSignaturesProtectedBranch\` split** — adds a 2nd unconditional API call per protected branch; splitting requires a new \`.lr\` field.
- **\`actionsSettings\` couples two API calls** — same shape.
- These are real wins but deserve their own PRs since they touch \`.lr\` and the versions file.

## Test plan

- [x] \`go build ./...\` clean in \`providers/github\`
- [x] \`go test ./...\` clean (existing tests + new \`TestGithubCollaboratorID\` / \`TestGithubInstallationID\`)
- [x] \`gofmt -l\` clean
- [ ] Interactive: \`mql shell github\` against a real org/user and exercise \`github.organization.repositories\`, \`.packages.repository\`, \`.repositories.workflows[0].file\`, \`.repositories.stargazers\`, \`.repositories.openMergeRequests\`. Particularly worth poking at a fork-heavy account to catch the null-owner case, and an org with bot-authored PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)