### PR TITLE
🐛 google-workspace: fix bugs surfaced by the audit pass

### DIFF
--- a/providers/google-workspace/resources/calendars.go
+++ b/providers/google-workspace/resources/calendars.go
@@ -15,30 +15,41 @@ func (g *mqlGoogleworkspace) calendars() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	res := []any{}
 	calendars, err := calendarService.CalendarList.List().Do()
 	if err != nil {
 		return nil, err
 	}
-	res := make([]any, 0, len(calendars.Items))
-	for _, c := range calendars.Items {
-		r, err := CreateResource(g.MqlRuntime, "googleworkspace.calendar", map[string]*llx.RawData{
-			"__id":            llx.StringData(c.Id),
-			"id":              llx.StringData(c.Id),
-			"summary":         llx.StringData(c.Summary),
-			"summaryOverride": llx.StringData(c.SummaryOverride),
-			"primary":         llx.BoolData(c.Primary),
-			"accessRole":      llx.StringData(c.AccessRole),
-			"description":     llx.StringData(c.Description),
-			"timeZone":        llx.StringData(c.TimeZone),
-			"location":        llx.StringData(c.Location),
-			"hidden":          llx.BoolData(c.Hidden),
-			"deleted":         llx.BoolData(c.Deleted),
-			"selected":        llx.BoolData(c.Selected),
-		})
+	for {
+		for _, c := range calendars.Items {
+			r, err := CreateResource(g.MqlRuntime, "googleworkspace.calendar", map[string]*llx.RawData{
+				"__id":            llx.StringData(c.Id),
+				"id":              llx.StringData(c.Id),
+				"summary":         llx.StringData(c.Summary),
+				"summaryOverride": llx.StringData(c.SummaryOverride),
+				"primary":         llx.BoolData(c.Primary),
+				"accessRole":      llx.StringData(c.AccessRole),
+				"description":     llx.StringData(c.Description),
+				"timeZone":        llx.StringData(c.TimeZone),
+				"location":        llx.StringData(c.Location),
+				"hidden":          llx.BoolData(c.Hidden),
+				"deleted":         llx.BoolData(c.Deleted),
+				"selected":        llx.BoolData(c.Selected),
+			})
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, r)
+		}
+
+		if calendars.NextPageToken == "" {
+			break
+		}
+		calendars, err = calendarService.CalendarList.List().PageToken(calendars.NextPageToken).Do()
 		if err != nil {
 			return nil, err
 		}
-		res = append(res, r)
 	}
 	return res, nil
 }
@@ -49,32 +60,47 @@ func (g *mqlGoogleworkspaceCalendar) acl() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	res := []any{}
 	acls, err := calendarService.Acl.List(g.__id).Do()
 	if err != nil {
 		return nil, err
 	}
+	for {
+		for _, a := range acls.Items {
+			var scopeType, scopeValue string
+			if a.Scope != nil {
+				scopeType = a.Scope.Type
+				scopeValue = a.Scope.Value
+			}
+			scope, err := CreateResource(g.MqlRuntime, "googleworkspace.calendar.aclRule.scope", map[string]*llx.RawData{
+				"__id":  llx.StringData(a.Id + scopeType + scopeValue),
+				"type":  llx.StringData(scopeType),
+				"value": llx.StringData(scopeValue),
+			})
+			if err != nil {
+				return nil, err
+			}
 
-	res := make([]any, 0, len(acls.Items))
-	for _, a := range acls.Items {
-		scope, err := CreateResource(g.MqlRuntime, "googleworkspace.calendar.aclRule.scope", map[string]*llx.RawData{
-			"__id":  llx.StringData(a.Id + a.Scope.Type + a.Scope.Value),
-			"type":  llx.StringData(a.Scope.Type),
-			"value": llx.StringData(a.Scope.Value),
-		})
+			r, err := CreateResource(g.MqlRuntime, "googleworkspace.calendar.aclRule", map[string]*llx.RawData{
+				"__id":  llx.StringData(a.Id),
+				"id":    llx.StringData(a.Id),
+				"role":  llx.StringData(a.Role),
+				"scope": llx.ResourceData(scope, "googleworkspace.calendar.aclRule.scope"),
+			})
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, r)
+		}
+
+		if acls.NextPageToken == "" {
+			break
+		}
+		acls, err = calendarService.Acl.List(g.__id).PageToken(acls.NextPageToken).Do()
 		if err != nil {
 			return nil, err
 		}
-
-		r, err := CreateResource(g.MqlRuntime, "googleworkspace.calendar.aclRule", map[string]*llx.RawData{
-			"__id":  llx.StringData(a.Id),
-			"id":    llx.StringData(a.Id),
-			"role":  llx.StringData(a.Role),
-			"scope": llx.ResourceData(scope, "googleworkspace.calendar.aclRule.scope"),
-		})
-		if err != nil {
-			return nil, err
-		}
-		res = append(res, r)
 	}
 	return res, nil
 }

--- a/providers/google-workspace/resources/connected_apps.go
+++ b/providers/google-workspace/resources/connected_apps.go
@@ -57,16 +57,13 @@ func (g *mqlGoogleworkspace) connectedApps() ([]any, error) {
 			}
 			cApp.name = tk.DisplayText.Data
 
-			// merge scopes
+			// merge scopes (dedup once at the end to avoid O(n²) churn)
 			if tk.Scopes.Error != nil {
 				return nil, tk.Scopes.Error
 			}
-			scopes := tk.Scopes.Data
-			stringScopes := []string{}
-			for _, scope := range scopes {
-				stringScopes = append(stringScopes, scope.(string))
+			for _, scope := range tk.Scopes.Data {
+				cApp.scopes = append(cApp.scopes, scope.(string))
 			}
-			cApp.scopes = stringx.DedupStringArray(append(cApp.scopes, stringScopes...))
 
 			cApp.tokens = append(cApp.tokens, tk)
 			cApp.users = append(cApp.users, usr)
@@ -77,37 +74,29 @@ func (g *mqlGoogleworkspace) connectedApps() ([]any, error) {
 
 	// group token by client id
 	runtime := g.MqlRuntime
-	res := make([]any, len(connectedApps))
-	i := 0
-	for k := range connectedApps {
-		connectedApp := connectedApps[k]
-
+	res := make([]any, 0, len(connectedApps))
+	for _, connectedApp := range connectedApps {
 		mqlUsers := make([]any, len(connectedApp.users))
-		if connectedApp.users != nil && len(connectedApp.users) > 0 {
-			for i := range connectedApp.users {
-				mqlUsers[i] = connectedApp.users[i]
-			}
+		for i := range connectedApp.users {
+			mqlUsers[i] = connectedApp.users[i]
 		}
 
 		mqlTokens := make([]any, len(connectedApp.tokens))
-		if connectedApp.tokens != nil && len(connectedApp.tokens) > 0 {
-			for i := range connectedApp.tokens {
-				mqlTokens[i] = connectedApp.tokens[i]
-			}
+		for i := range connectedApp.tokens {
+			mqlTokens[i] = connectedApp.tokens[i]
 		}
 
 		mqlApp, err := CreateResource(runtime, "googleworkspace.connectedApp", map[string]*llx.RawData{
 			"clientId": llx.StringData(connectedApp.clientID),
 			"name":     llx.StringData(connectedApp.name),
-			"scopes":   llx.ArrayData(convert.SliceAnyToInterface[string](connectedApp.scopes), types.Any),
+			"scopes":   llx.ArrayData(convert.SliceAnyToInterface[string](stringx.DedupStringArray(connectedApp.scopes)), types.Any),
 			"users":    llx.ArrayData(mqlUsers, types.Any),
 			"tokens":   llx.ArrayData(mqlTokens, types.Any),
 		})
 		if err != nil {
 			return nil, err
 		}
-		res[i] = mqlApp
-		i++
+		res = append(res, mqlApp)
 	}
 
 	return res, nil

--- a/providers/google-workspace/resources/endpoints_test.go
+++ b/providers/google-workspace/resources/endpoints_test.go
@@ -1,0 +1,65 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	cloudidentity "google.golang.org/api/cloudidentity/v1"
+)
+
+func TestParseRFC3339(t *testing.T) {
+	require.Nil(t, parseRFC3339(""))
+	require.Nil(t, parseRFC3339("not a date"))
+
+	got := parseRFC3339("2024-07-29T15:04:05Z")
+	require.NotNil(t, got)
+	require.Equal(t, "2024-07-29T15:04:05Z", got.UTC().Format("2006-01-02T15:04:05Z"))
+}
+
+func TestParseEndpointAdditionalSignals(t *testing.T) {
+	// nil attrs is safe
+	got := parseEndpointAdditionalSignals(nil)
+	require.Nil(t, got.AvInstalled)
+	require.Nil(t, got.AvEnabled)
+	require.Nil(t, got.IsOsNativeFirewallEnabled)
+	require.Nil(t, got.IsSecureBootEnabled)
+	require.Equal(t, "", got.WindowsDomainName)
+
+	// empty additional signals is safe
+	got = parseEndpointAdditionalSignals(&cloudidentity.GoogleAppsCloudidentityDevicesV1EndpointVerificationSpecificAttributes{})
+	require.Nil(t, got.AvInstalled)
+
+	// malformed payload collapses to defaults, no panic
+	got = parseEndpointAdditionalSignals(&cloudidentity.GoogleAppsCloudidentityDevicesV1EndpointVerificationSpecificAttributes{
+		AdditionalSignals: []byte("not-json"),
+	})
+	require.Nil(t, got.AvInstalled)
+	require.Equal(t, "", got.WindowsDomainName)
+
+	// fully populated payload
+	got = parseEndpointAdditionalSignals(&cloudidentity.GoogleAppsCloudidentityDevicesV1EndpointVerificationSpecificAttributes{
+		AdditionalSignals: []byte(`{"av_installed":true,"av_enabled":false,"is_os_native_firewall_enabled":true,"is_secure_boot_enabled":false,"windows_domain_name":"CORP"}`),
+	})
+	require.NotNil(t, got.AvInstalled)
+	require.True(t, *got.AvInstalled)
+	require.NotNil(t, got.AvEnabled)
+	require.False(t, *got.AvEnabled)
+	require.NotNil(t, got.IsOsNativeFirewallEnabled)
+	require.True(t, *got.IsOsNativeFirewallEnabled)
+	require.NotNil(t, got.IsSecureBootEnabled)
+	require.False(t, *got.IsSecureBootEnabled)
+	require.Equal(t, "CORP", got.WindowsDomainName)
+
+	// partial payload leaves missing booleans as nil (not false)
+	got = parseEndpointAdditionalSignals(&cloudidentity.GoogleAppsCloudidentityDevicesV1EndpointVerificationSpecificAttributes{
+		AdditionalSignals: []byte(`{"av_installed":true,"windows_domain_name":"WORKGROUP"}`),
+	})
+	require.NotNil(t, got.AvInstalled)
+	require.True(t, *got.AvInstalled)
+	require.Nil(t, got.AvEnabled, "device did not report av_enabled, should stay nil")
+	require.Nil(t, got.IsSecureBootEnabled)
+	require.Equal(t, "WORKGROUP", got.WindowsDomainName)
+}

--- a/providers/google-workspace/resources/google-workspace.go
+++ b/providers/google-workspace/resources/google-workspace.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"sync"
 
 	"go.mondoo.com/mql/v13/providers/google-workspace/connection"
 	directory "google.golang.org/api/admin/directory/v1"
@@ -14,6 +15,35 @@ import (
 	"google.golang.org/api/groupssettings/v1"
 	"google.golang.org/api/option"
 )
+
+type mqlGoogleworkspaceInternal struct {
+	usersByEmailOnce sync.Once
+	usersByEmail     map[string]*mqlGoogleworkspaceUser
+	usersByEmailErr  error
+}
+
+func (g *mqlGoogleworkspace) userByEmail(email string) (*mqlGoogleworkspaceUser, error) {
+	g.usersByEmailOnce.Do(func() {
+		if g.Users.Error != nil {
+			g.usersByEmailErr = g.Users.Error
+			return
+		}
+		m := make(map[string]*mqlGoogleworkspaceUser, len(g.Users.Data))
+		for _, u := range g.Users.Data {
+			user := u.(*mqlGoogleworkspaceUser)
+			if user.PrimaryEmail.Error != nil {
+				g.usersByEmailErr = user.PrimaryEmail.Error
+				return
+			}
+			m[user.PrimaryEmail.Data] = user
+		}
+		g.usersByEmail = m
+	})
+	if g.usersByEmailErr != nil {
+		return nil, g.usersByEmailErr
+	}
+	return g.usersByEmail[email], nil
+}
 
 func (r *mqlGoogleworkspace) id() (string, error) {
 	return "google-workspace", nil

--- a/providers/google-workspace/resources/google-workspace.lr.go
+++ b/providers/google-workspace/resources/google-workspace.lr.go
@@ -1942,7 +1942,7 @@ func SetAllData(resource plugin.Resource, args map[string]*llx.RawData) error {
 type mqlGoogleworkspace struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGoogleworkspaceInternal it will be used here
+	mqlGoogleworkspaceInternal
 	OrgUnits      plugin.TValue[[]any]
 	Users         plugin.TValue[[]any]
 	Domains       plugin.TValue[[]any]

--- a/providers/google-workspace/resources/group.go
+++ b/providers/google-workspace/resources/group.go
@@ -27,7 +27,7 @@ func (g *mqlGoogleworkspace) groups() ([]any, error) {
 	}
 
 	res := []any{}
-	groups, err := directoryService.Groups.List().Customer(conn.CustomerID()).Do()
+	groups, err := directoryService.Groups.List().Customer(conn.CustomerID()).MaxResults(200).Do()
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (g *mqlGoogleworkspace) groups() ([]any, error) {
 			break
 		}
 
-		groups, err = directoryService.Groups.List().Customer(conn.CustomerID()).PageToken(groups.NextPageToken).Do()
+		groups, err = directoryService.Groups.List().Customer(conn.CustomerID()).MaxResults(200).PageToken(groups.NextPageToken).Do()
 		if err != nil {
 			return nil, err
 		}
@@ -90,7 +90,7 @@ func (g *mqlGoogleworkspaceGroup) members() ([]any, error) {
 
 	res := []any{}
 
-	members, err := directoryService.Members.List(id).Do()
+	members, err := directoryService.Members.List(id).MaxResults(200).Do()
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (g *mqlGoogleworkspaceGroup) members() ([]any, error) {
 			break
 		}
 
-		members, err = directoryService.Members.List(id).PageToken(members.NextPageToken).Do()
+		members, err = directoryService.Members.List(id).MaxResults(200).PageToken(members.NextPageToken).Do()
 		if err != nil {
 			return nil, err
 		}
@@ -143,6 +143,7 @@ func (g *mqlGoogleworkspaceMember) user() (*mqlGoogleworkspaceUser, error) {
 	typ := g.Type.Data
 
 	if strings.ToLower(typ) != "user" {
+		g.User.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 
@@ -152,22 +153,15 @@ func (g *mqlGoogleworkspaceMember) user() (*mqlGoogleworkspaceUser, error) {
 	}
 	gws := obj.(*mqlGoogleworkspace)
 
-	if gws.Users.Error != nil {
-		return nil, gws.Users.Error
+	user, err := gws.userByEmail(email)
+	if err != nil {
+		return nil, err
 	}
-	users := gws.Users.Data
-
-	for i := range users {
-		user := users[i].(*mqlGoogleworkspaceUser)
-		if user.PrimaryEmail.Error != nil {
-			return nil, user.PrimaryEmail.Error
-		}
-		primaryEmail := user.PrimaryEmail.Data
-		if primaryEmail == email {
-			return user, nil
-		}
+	if user == nil {
+		g.User.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
 	}
-	return nil, nil
+	return user, nil
 }
 
 func (g *mqlGoogleworkspaceGroup) settings() (any, error) {

--- a/providers/google-workspace/resources/reports.go
+++ b/providers/google-workspace/resources/reports.go
@@ -138,8 +138,13 @@ func newMqlGoogleWorkspaceReportActivity(runtime *plugin.Runtime, entry *reports
 		return nil, err
 	}
 
+	var uniqueQualifier int64
+	if entry.Id != nil {
+		uniqueQualifier = entry.Id.UniqueQualifier
+	}
+
 	return CreateResource(runtime, "googleworkspace.report.activity", map[string]*llx.RawData{
-		"id":          llx.IntData(entry.Id.UniqueQualifier),
+		"id":          llx.IntData(uniqueQualifier),
 		"ipAddress":   llx.StringData(entry.IpAddress),
 		"ownerDomain": llx.StringData(entry.OwnerDomain),
 		"actor":       llx.MapData(actor, types.Any),
@@ -158,35 +163,33 @@ func (g *mqlGoogleworkspaceReportUsers) list() ([]any, error) {
 		return nil, err
 	}
 
-	res := []any{}
 	date := time.Now()
 	expectedErr := "googleapi: Error 400: Data for dates later than"
 
 	usageReports, err := fetchReportUsage(g.MqlRuntime, reportsService, conn.CustomerID(), date.Format(time.DateOnly))
-	// we expect this error if there is no data for the current day, so we continue
+	// we expect this error if there is no data for the current day, so we fall through to past-day retries
 	if err != nil && !strings.HasPrefix(err.Error(), expectedErr) {
 		return nil, err
 	}
-
-	if len(usageReports) == 0 {
-		// try and fetch usage for each of the past 7 days
-		attempts := 7
-		for attempts > 0 {
-			date = date.Add(-24 * time.Hour)
-			reports, err := fetchReportUsage(g.MqlRuntime, reportsService, conn.CustomerID(), date.Format(time.DateOnly))
-			// we expect this error if there is no data for the current day, so we continue
-			if err != nil && !strings.HasPrefix(err.Error(), expectedErr) {
-				return nil, err
-			}
-			if len(reports) > 0 {
-				res = append(res, reports...)
-				break
-			}
-			attempts--
-		}
+	if len(usageReports) > 0 {
+		return usageReports, nil
 	}
 
-	return res, nil
+	// try and fetch usage for each of the past 7 days
+	attempts := 7
+	for attempts > 0 {
+		date = date.Add(-24 * time.Hour)
+		usageReports, err = fetchReportUsage(g.MqlRuntime, reportsService, conn.CustomerID(), date.Format(time.DateOnly))
+		if err != nil && !strings.HasPrefix(err.Error(), expectedErr) {
+			return nil, err
+		}
+		if len(usageReports) > 0 {
+			return usageReports, nil
+		}
+		attempts--
+	}
+
+	return []any{}, nil
 }
 
 func fetchReportUsage(runtime *plugin.Runtime, service *reports.Service, customerId, date string) ([]any, error) {
@@ -196,25 +199,22 @@ func fetchReportUsage(runtime *plugin.Runtime, service *reports.Service, custome
 	if err != nil {
 		return nil, err
 	}
-	for _, u := range usageReports.UsageReports {
-		r, err := newMqlGoogleWorkspaceUsageReport(runtime, u)
-		if err != nil {
-			return nil, err
-		}
-		res = append(res, r)
-	}
-
-	for usageReports != nil && usageReports.NextPageToken != "" {
-		usageReports, err := service.UserUsageReport.Get("all", date).CustomerId(customerId).PageToken(usageReports.NextPageToken).Do()
-		if err != nil {
-			return nil, err
-		}
+	for {
 		for _, u := range usageReports.UsageReports {
 			r, err := newMqlGoogleWorkspaceUsageReport(runtime, u)
 			if err != nil {
 				return nil, err
 			}
 			res = append(res, r)
+		}
+
+		if usageReports.NextPageToken == "" {
+			break
+		}
+
+		usageReports, err = service.UserUsageReport.Get("all", date).CustomerId(customerId).PageToken(usageReports.NextPageToken).Do()
+		if err != nil {
+			return nil, err
 		}
 	}
 	return res, nil
@@ -249,12 +249,21 @@ func newMqlGoogleWorkspaceUsageReport(runtime *plugin.Runtime, entry *reports.Us
 		return nil, err
 	}
 
+	var customerId, entityId, profileId, entityType, userEmail string
+	if entry.Entity != nil {
+		customerId = entry.Entity.CustomerId
+		entityId = entry.Entity.EntityId
+		profileId = entry.Entity.ProfileId
+		entityType = entry.Entity.Type
+		userEmail = entry.Entity.UserEmail
+	}
+
 	report, err := CreateResource(runtime, "googleworkspace.report.usage", map[string]*llx.RawData{
-		"customerId": llx.StringData(entry.Entity.CustomerId),
-		"entityId":   llx.StringData(entry.Entity.EntityId),
-		"profileId":  llx.StringData(entry.Entity.ProfileId),
-		"type":       llx.StringData(entry.Entity.Type),
-		"userEmail":  llx.StringData(entry.Entity.UserEmail),
+		"customerId": llx.StringData(customerId),
+		"entityId":   llx.StringData(entityId),
+		"profileId":  llx.StringData(profileId),
+		"type":       llx.StringData(entityType),
+		"userEmail":  llx.StringData(userEmail),
 		"date":       llx.TimeDataPtr(date),
 		"parameters": llx.ArrayData(parameters, types.Any),
 		"account":    llx.MapData(accountUsage, types.Any),

--- a/providers/google-workspace/resources/reports_test.go
+++ b/providers/google-workspace/resources/reports_test.go
@@ -1,0 +1,97 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	reports "google.golang.org/api/admin/reports/v1"
+)
+
+func TestParseUserReports(t *testing.T) {
+	params := []*reports.UsageReportParameters{
+		{Name: "accounts:is_disabled", BoolValue: true},
+		{Name: "accounts:is_super_admin", BoolValue: true},
+		{Name: "accounts:is_2sv_enrolled", BoolValue: true},
+		{Name: "accounts:is_2sv_enforced", BoolValue: false},
+		{Name: "accounts:password_length_compliance", StringValue: "COMPLIANT"},
+		{Name: "accounts:password_strength", StringValue: "STRONG"},
+		{Name: "accounts:is_less_secure_apps_access_allowed", BoolValue: false},
+		{Name: "accounts:admin_set_name", StringValue: "admin"},
+		{Name: "accounts:num_authorized_apps", IntValue: 5},
+		{Name: "accounts:num_security_keys", IntValue: 2},
+		{Name: "accounts:gmail_used_quota_in_mb", IntValue: 100},
+		{Name: "accounts:drive_used_quota_in_mb", IntValue: 200},
+		{Name: "accounts:used_quota_in_mb", IntValue: 350},
+		{Name: "gplus_photos_used_quota_in_mb", IntValue: 50},
+		{Name: "gmail:num_emails_exchanged", IntValue: 1000},
+		{Name: "gmail:num_emails_sent", IntValue: 400},
+		{Name: "gmail:num_emails_received", IntValue: 600},
+		{Name: "gmail:last_imap_time", DatetimeValue: "2024-07-29T15:04:05Z"},
+		{Name: "gmail:last_webmail_time", DatetimeValue: "2024-07-30T09:00:00Z"},
+		{Name: "docs:num_owned_items_edited", IntValue: 10},
+		{Name: "docs:num_owned_items_viewed", IntValue: 25},
+		{Name: "drive:last_active_usage_time", DatetimeValue: "2024-07-28T12:00:00Z"},
+	}
+
+	r := parseUserReports(params)
+	require.NotNil(t, r)
+
+	// account fields shared with security
+	require.True(t, r.Account.IsDisabled)
+	require.True(t, r.Security.IsDisabled)
+	require.True(t, r.Account.IsSuperAdmin)
+	require.True(t, r.Security.IsSuperAdmin)
+	require.True(t, r.Account.IsS2svEnrolled)
+	require.True(t, r.Security.IsS2svEnrolled)
+	require.Equal(t, "COMPLIANT", r.Account.PasswordLengthCompliance)
+	require.Equal(t, "COMPLIANT", r.Security.PasswordLengthCompliance)
+	require.Equal(t, "admin", r.Account.AdminSetName)
+
+	// security-only fields
+	require.Equal(t, int64(5), r.Security.NumAuthorizedApps)
+	require.Equal(t, int64(2), r.Security.NumSecurityKeys)
+
+	// usage shared between account + appUsage
+	require.Equal(t, int64(100), r.Account.GmailUsedQuotaInMb)
+	require.Equal(t, int64(100), r.AppUsage.GmailUsedQuotaInMb)
+	require.Equal(t, int64(200), r.Account.DriveUsedQuotaInMb)
+	require.Equal(t, int64(350), r.Account.UsedQuotaInMb)
+	require.Equal(t, int64(350), r.AppUsage.UsedQuotaInMb)
+	require.Equal(t, int64(50), r.AppUsage.GPlusPhotosUsedQuotaInMb)
+
+	// gmail / docs counters land on appUsage only
+	require.Equal(t, int64(1000), r.AppUsage.NumEmailsExchanged)
+	require.Equal(t, int64(400), r.AppUsage.NumEmailSent)
+	require.Equal(t, int64(600), r.AppUsage.NumEmailsReceived)
+	require.Equal(t, int64(10), r.AppUsage.NumOwnedItemsEdited)
+	require.Equal(t, int64(25), r.AppUsage.NumOwnedItemsViewed)
+
+	// timestamps parse to non-nil pointers
+	require.NotNil(t, r.AppUsage.LastImapTime)
+	require.NotNil(t, r.AppUsage.LastWebmailTime)
+	require.NotNil(t, r.AppUsage.DriveLastActiveUsageTime)
+}
+
+func TestParseUserReports_EmptyAndUnknownParams(t *testing.T) {
+	// no params at all
+	r := parseUserReports(nil)
+	require.NotNil(t, r)
+	require.False(t, r.Account.IsDisabled)
+	require.Equal(t, "", r.Account.AdminSetName)
+
+	// unknown param names are ignored
+	r = parseUserReports([]*reports.UsageReportParameters{
+		{Name: "unknown:param", IntValue: 99},
+	})
+	require.NotNil(t, r)
+	require.Equal(t, int64(0), r.AppUsage.NumEmailSent)
+
+	// malformed datetime leaves the pointer nil
+	r = parseUserReports([]*reports.UsageReportParameters{
+		{Name: "gmail:last_imap_time", DatetimeValue: "not a date"},
+	})
+	require.Nil(t, r.AppUsage.LastImapTime)
+}

--- a/providers/google-workspace/resources/role.go
+++ b/providers/google-workspace/resources/role.go
@@ -22,24 +22,24 @@ func (g *mqlGoogleworkspace) roles() ([]any, error) {
 	}
 
 	res := []any{}
-	groups, err := directoryService.Roles.List(conn.CustomerID()).Do()
+	roles, err := directoryService.Roles.List(conn.CustomerID()).MaxResults(100).Do()
 	if err != nil {
 		return nil, err
 	}
 	for {
-		for i := range groups.Items {
-			r, err := newMqlGoogleWorkspaceRole(g.MqlRuntime, groups.Items[i])
+		for i := range roles.Items {
+			r, err := newMqlGoogleWorkspaceRole(g.MqlRuntime, roles.Items[i])
 			if err != nil {
 				return nil, err
 			}
 			res = append(res, r)
 		}
 
-		if groups.NextPageToken == "" {
+		if roles.NextPageToken == "" {
 			break
 		}
 
-		groups, err = directoryService.Roles.List(conn.CustomerID()).PageToken(groups.NextPageToken).Do()
+		roles, err = directoryService.Roles.List(conn.CustomerID()).MaxResults(100).PageToken(roles.NextPageToken).Do()
 		if err != nil {
 			return nil, err
 		}

--- a/providers/google-workspace/resources/users.go
+++ b/providers/google-workspace/resources/users.go
@@ -32,7 +32,7 @@ func (g *mqlGoogleworkspace) users() ([]any, error) {
 
 	res := []any{}
 
-	users, err := directoryService.Users.List().Customer(conn.CustomerID()).Do()
+	users, err := directoryService.Users.List().Customer(conn.CustomerID()).MaxResults(500).Do()
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func (g *mqlGoogleworkspace) users() ([]any, error) {
 			break
 		}
 
-		users, err = directoryService.Users.List().Customer(conn.CustomerID()).PageToken(users.NextPageToken).Do()
+		users, err = directoryService.Users.List().Customer(conn.CustomerID()).MaxResults(500).PageToken(users.NextPageToken).Do()
 		if err != nil {
 			return nil, err
 		}
@@ -110,11 +110,18 @@ func newMqlGoogleWorkspaceUser(runtime *plugin.Runtime, entry *directory.User) (
 	}
 	customSchemas := customSchemasToDict(entry.CustomSchemas)
 
+	var familyName, givenName, fullName string
+	if entry.Name != nil {
+		familyName = entry.Name.FamilyName
+		givenName = entry.Name.GivenName
+		fullName = entry.Name.FullName
+	}
+
 	return CreateResource(runtime, "googleworkspace.user", map[string]*llx.RawData{
 		"id":                         llx.StringData(entry.Id),
-		"familyName":                 llx.StringData(entry.Name.FamilyName),
-		"givenName":                  llx.StringData(entry.Name.GivenName),
-		"fullName":                   llx.StringData(entry.Name.FullName),
+		"familyName":                 llx.StringData(familyName),
+		"givenName":                  llx.StringData(givenName),
+		"fullName":                   llx.StringData(fullName),
 		"primaryEmail":               llx.StringData(entry.PrimaryEmail),
 		"recoveryEmail":              llx.StringData(entry.RecoveryEmail),
 		"recoveryPhone":              llx.StringData(entry.RecoveryPhone),

--- a/providers/google-workspace/resources/users_test.go
+++ b/providers/google-workspace/resources/users_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/api/googleapi"
 )
 
 func TestShouldCheckEarlierDateForReport(t *testing.T) {
@@ -22,4 +23,54 @@ func TestShouldCheckEarlierDateForReport(t *testing.T) {
 
 	err = errors.New("Error 400: Data for dates later than 2024-07-26 is not yet available. Please check back later, invalid")
 	require.True(t, shouldCheckEarlierDateForReport(err))
+}
+
+func TestParseInt64(t *testing.T) {
+	require.Equal(t, int64(0), parseInt64(""))
+	require.Equal(t, int64(0), parseInt64("not a number"))
+	require.Equal(t, int64(42), parseInt64("42"))
+	require.Equal(t, int64(-7), parseInt64("-7"))
+	require.Equal(t, int64(9223372036854775807), parseInt64("9223372036854775807"))
+	// overflow falls back to zero
+	require.Equal(t, int64(0), parseInt64("99999999999999999999"))
+}
+
+func TestCustomSchemasToDict(t *testing.T) {
+	require.Nil(t, customSchemasToDict(nil))
+	require.Nil(t, customSchemasToDict(map[string]googleapi.RawMessage{}))
+
+	in := map[string]googleapi.RawMessage{
+		"badge":   googleapi.RawMessage(`{"color":"blue","tier":3}`),
+		"broken":  googleapi.RawMessage(`not-json`),
+		"empty":   googleapi.RawMessage(`{}`),
+		"nested":  googleapi.RawMessage(`{"team":{"name":"core"}}`),
+		"numeric": googleapi.RawMessage(`{"score":42}`),
+	}
+	got := customSchemasToDict(in)
+	require.Len(t, got, 4, "broken entry should be skipped, all others kept")
+	require.Equal(t, map[string]any{"color": "blue", "tier": float64(3)}, got["badge"])
+	require.Equal(t, map[string]any{}, got["empty"])
+	require.Equal(t, map[string]any{"team": map[string]any{"name": "core"}}, got["nested"])
+	require.Equal(t, map[string]any{"score": float64(42)}, got["numeric"])
+	require.NotContains(t, got, "broken")
+}
+
+func TestUnmarshalUserMultiValue(t *testing.T) {
+	type entry struct {
+		Address string `json:"address"`
+	}
+
+	// nil collapses to empty
+	require.Nil(t, unmarshalUserMultiValue[entry](nil))
+
+	// list response shape
+	listShape := []any{
+		map[string]any{"address": "a@b.com"},
+		map[string]any{"address": "c@d.com"},
+	}
+	got := unmarshalUserMultiValue[entry](listShape)
+	require.Equal(t, []entry{{Address: "a@b.com"}, {Address: "c@d.com"}}, got)
+
+	// non-list payload (e.g. single-entry create shape) does not panic; returns nil
+	require.Nil(t, unmarshalUserMultiValue[entry](map[string]any{"address": "x@y.com"}))
 }


### PR DESCRIPTION
## Summary

Audit pass on `providers/google-workspace/resources/`. Caught two silent-correctness bugs in the reports flow, four panic-on-nil-SDK-pointer cases, two missing pagination loops, and a few performance papercuts.

### Critical correctness
- **`report.users.list()` was discarding today's results.** When the first fetch succeeded, `usageReports` was never appended to `res` — the function returned `[]any{}` and only ever populated through the 7-day-retry fallback. Restructured so today's results return directly.
- **`fetchReportUsage` pagination was an infinite loop bug.** The inner `usageReports, err := service.UserUsageReport.Get(...).PageToken(usageReports.NextPageToken).Do()` used `:=`, shadowing the outer variable. The outer `NextPageToken` never changed and the loop spun forever once a second page existed. Rewrote with a single accumulator and `=`.
- **`member.user()` returned bare `return nil, nil`** on non-user members and on email-not-found, violating the CLAUDE.md rule that singular resource accessors must set `StateIsSet|StateIsNull` first. Per CLAUDE.md this can panic or cause re-fetch loops.

### Nil-pointer panic guards
SDK uses `*UserName`, `*ActivityId`, `*UsageReportEntity`, `*AclRuleScope` — guarded all four (one site each in `users.go`, `reports.go` x2, `calendars.go`).

### Pagination
- `calendar.list` and `calendar.acl` only fetched page 1. Both SDK types have `NextPageToken`. Now paginate.

### Performance
- Bumped page sizes to API maxima — Users 500, Groups 200, Members 200, Roles 100 (5x fewer round trips for Users on large customers).
- `member.user()` was O(N) linear scan per invocation. Added `mqlGoogleworkspaceInternal` with a `sync.Once`-protected `email→user` map (regenerated `.lr.go` to embed). Now O(1) per lookup.
- `connectedApps` was running `stringx.DedupStringArray(append(...))` per token — O(n²) churn. Now appends raw and dedups once at materialization.

### Not fixed in this pass
- Eager `convert.JsonToDict` in `report.activity` and `report.usage` constructors (same pattern as #7886). Wants `.lr` field→method conversion — separate PR.
- `reports.drive()` / `reports.admin()` pull the full Activities retention window unconditionally. Wants a resource-shape decision (expose a time-window selector).

## Test plan
- [x] `go test ./resources/...` — all pass
- [x] `gofmt -l` clean
- [x] `golangci-lint run` — 0 issues
- [x] `make providers/build/google-workspace` succeeds
- [x] New tests: `parseInt64`, `customSchemasToDict`, `unmarshalUserMultiValue`, `parseRFC3339`, `parseEndpointAdditionalSignals`, `parseUserReports` (happy + empty/unknown/malformed)
- [ ] Manual smoke against a real workspace (queries: `googleworkspace.calendars`, `googleworkspace.groups[*].members[*].user`, `googleworkspace.report.users`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)