### PR TITLE
🧹 hetzner: add unit tests for helpers and authentication

### DIFF
--- a/providers/hetzner/connection/authentication_test.go
+++ b/providers/hetzner/connection/authentication_test.go
@@ -1,0 +1,124 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
+)
+
+func TestGetToken(t *testing.T) {
+	t.Run("returns false when nothing is set", func(t *testing.T) {
+		t.Setenv(HCLOUD_TOKEN_VAR, "")
+		conf := &inventory.Config{Options: map[string]string{}}
+		got, ok := GetToken(conf)
+		assert.False(t, ok)
+		assert.Empty(t, got)
+	})
+
+	t.Run("falls back to env var", func(t *testing.T) {
+		t.Setenv(HCLOUD_TOKEN_VAR, "from-env")
+		conf := &inventory.Config{Options: map[string]string{}}
+		got, ok := GetToken(conf)
+		assert.True(t, ok)
+		assert.Equal(t, "from-env", got)
+	})
+
+	t.Run("flag option overrides env var", func(t *testing.T) {
+		t.Setenv(HCLOUD_TOKEN_VAR, "from-env")
+		conf := &inventory.Config{Options: map[string]string{OPTION_TOKEN: "from-flag"}}
+		got, ok := GetToken(conf)
+		assert.True(t, ok)
+		assert.Equal(t, "from-flag", got)
+	})
+
+	t.Run("password credential overrides env and flag", func(t *testing.T) {
+		t.Setenv(HCLOUD_TOKEN_VAR, "from-env")
+		conf := &inventory.Config{
+			Options:     map[string]string{OPTION_TOKEN: "from-flag"},
+			Credentials: []*vault.Credential{vault.NewPasswordCredential("", "from-cred")},
+		}
+		got, ok := GetToken(conf)
+		assert.True(t, ok)
+		assert.Equal(t, "from-cred", got)
+	})
+
+	t.Run("empty option value falls through to env", func(t *testing.T) {
+		t.Setenv(HCLOUD_TOKEN_VAR, "from-env")
+		conf := &inventory.Config{Options: map[string]string{OPTION_TOKEN: ""}}
+		got, ok := GetToken(conf)
+		assert.True(t, ok)
+		assert.Equal(t, "from-env", got)
+	})
+
+	t.Run("unsupported credential type is ignored", func(t *testing.T) {
+		t.Setenv(HCLOUD_TOKEN_VAR, "from-env")
+		conf := &inventory.Config{
+			Options: map[string]string{},
+			Credentials: []*vault.Credential{
+				{Type: vault.CredentialType_private_key, Secret: []byte("nope")},
+			},
+		}
+		got, ok := GetToken(conf)
+		assert.True(t, ok)
+		assert.Equal(t, "from-env", got)
+	})
+
+	t.Run("empty credential secret is skipped", func(t *testing.T) {
+		t.Setenv(HCLOUD_TOKEN_VAR, "from-env")
+		conf := &inventory.Config{
+			Options: map[string]string{},
+			Credentials: []*vault.Credential{
+				{Type: vault.CredentialType_password, Secret: nil},
+			},
+		}
+		got, ok := GetToken(conf)
+		assert.True(t, ok)
+		assert.Equal(t, "from-env", got)
+	})
+
+	t.Run("later credential wins over earlier", func(t *testing.T) {
+		t.Setenv(HCLOUD_TOKEN_VAR, "")
+		conf := &inventory.Config{
+			Options: map[string]string{},
+			Credentials: []*vault.Credential{
+				vault.NewPasswordCredential("", "first"),
+				vault.NewPasswordCredential("", "second"),
+			},
+		}
+		got, ok := GetToken(conf)
+		require.True(t, ok)
+		assert.Equal(t, "second", got)
+	})
+}
+
+func TestGetEndpoint(t *testing.T) {
+	t.Run("returns false when nothing is set", func(t *testing.T) {
+		t.Setenv(HCLOUD_ENDPOINT_VAR, "")
+		conf := &inventory.Config{Options: map[string]string{}}
+		got, ok := GetEndpoint(conf)
+		assert.False(t, ok)
+		assert.Empty(t, got)
+	})
+
+	t.Run("env value", func(t *testing.T) {
+		t.Setenv(HCLOUD_ENDPOINT_VAR, "https://api.example/")
+		conf := &inventory.Config{Options: map[string]string{}}
+		got, ok := GetEndpoint(conf)
+		assert.True(t, ok)
+		assert.Equal(t, "https://api.example/", got)
+	})
+
+	t.Run("flag option overrides env", func(t *testing.T) {
+		t.Setenv(HCLOUD_ENDPOINT_VAR, "https://api.example/")
+		conf := &inventory.Config{Options: map[string]string{OPTION_ENDPOINT: "https://override/"}}
+		got, ok := GetEndpoint(conf)
+		assert.True(t, ok)
+		assert.Equal(t, "https://override/", got)
+	})
+}

--- a/providers/hetzner/go.mod
+++ b/providers/hetzner/go.mod
@@ -7,6 +7,7 @@ go 1.26.3
 require (
 	github.com/hetznercloud/hcloud-go/v2 v2.41.2
 	github.com/rs/zerolog v1.35.1
+	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.11.0
 )
 
@@ -53,6 +54,7 @@ require (
 	github.com/cockroachdb/redact v1.1.8 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dvsekhvalnov/jose2go v1.8.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.19.0 // indirect
@@ -109,6 +111,7 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
@@ -151,6 +154,7 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/providers/hetzner/resources/helpers_test.go
+++ b/providers/hetzner/resources/helpers_test.go
@@ -1,0 +1,255 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+func TestTranslateHcloudError(t *testing.T) {
+	t.Run("nil passes through", func(t *testing.T) {
+		assert.NoError(t, translateHcloudError(nil))
+	})
+
+	t.Run("unauthorized swallowed", func(t *testing.T) {
+		err := hcloud.Error{Code: hcloud.ErrorCodeUnauthorized, Message: "bad token"}
+		assert.NoError(t, translateHcloudError(err))
+	})
+
+	t.Run("forbidden swallowed", func(t *testing.T) {
+		err := hcloud.Error{Code: hcloud.ErrorCodeForbidden, Message: "no access"}
+		assert.NoError(t, translateHcloudError(err))
+	})
+
+	t.Run("not found swallowed", func(t *testing.T) {
+		err := hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "gone"}
+		assert.NoError(t, translateHcloudError(err))
+	})
+
+	t.Run("rate limit propagates", func(t *testing.T) {
+		err := hcloud.Error{Code: hcloud.ErrorCodeRateLimitExceeded, Message: "slow down"}
+		assert.Error(t, translateHcloudError(err))
+	})
+
+	t.Run("non-hcloud error propagates", func(t *testing.T) {
+		err := errors.New("network down")
+		assert.Equal(t, err, translateHcloudError(err))
+	})
+
+	t.Run("wrapped hcloud error", func(t *testing.T) {
+		// errors.As must unwrap through fmt.Errorf wrapping
+		inner := hcloud.Error{Code: hcloud.ErrorCodeUnauthorized}
+		wrapped := errors.Join(errors.New("context"), inner)
+		assert.NoError(t, translateHcloudError(wrapped))
+	})
+}
+
+func TestPaginate(t *testing.T) {
+	t.Run("single page no pagination meta breaks", func(t *testing.T) {
+		out, err := paginate(func(opts hcloud.ListOpts) ([]int, *hcloud.Response, error) {
+			return []int{1, 2, 3}, &hcloud.Response{}, nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []int{1, 2, 3}, out)
+	})
+
+	t.Run("walks multiple pages until NextPage is zero", func(t *testing.T) {
+		pages := []struct {
+			items []int
+			next  int
+		}{
+			{[]int{1, 2}, 2},
+			{[]int{3, 4}, 3},
+			{[]int{5}, 0},
+		}
+		idx := 0
+		var seenPages []int
+		out, err := paginate(func(opts hcloud.ListOpts) ([]int, *hcloud.Response, error) {
+			seenPages = append(seenPages, opts.Page)
+			p := pages[idx]
+			idx++
+			return p.items, &hcloud.Response{
+				Meta: hcloud.Meta{
+					Pagination: &hcloud.Pagination{NextPage: p.next},
+				},
+			}, nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []int{1, 2, 3, 4, 5}, out)
+		assert.Equal(t, []int{1, 2, 3}, seenPages)
+	})
+
+	t.Run("starts at page 1 with PerPage 50", func(t *testing.T) {
+		var seen hcloud.ListOpts
+		_, err := paginate(func(opts hcloud.ListOpts) ([]int, *hcloud.Response, error) {
+			seen = opts
+			return nil, &hcloud.Response{}, nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, seen.Page)
+		assert.Equal(t, 50, seen.PerPage)
+	})
+
+	t.Run("propagates non-permission errors", func(t *testing.T) {
+		want := errors.New("connection refused")
+		_, err := paginate(func(opts hcloud.ListOpts) ([]int, *hcloud.Response, error) {
+			return nil, nil, want
+		})
+		assert.ErrorIs(t, err, want)
+	})
+
+	t.Run("returns accumulated rows when an auth error appears mid-stream", func(t *testing.T) {
+		calls := 0
+		out, err := paginate(func(opts hcloud.ListOpts) ([]int, *hcloud.Response, error) {
+			calls++
+			if calls == 1 {
+				return []int{1, 2}, &hcloud.Response{
+					Meta: hcloud.Meta{Pagination: &hcloud.Pagination{NextPage: 2}},
+				}, nil
+			}
+			return nil, nil, hcloud.Error{Code: hcloud.ErrorCodeForbidden}
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []int{1, 2}, out)
+	})
+
+	t.Run("nil response terminates loop", func(t *testing.T) {
+		out, err := paginate(func(opts hcloud.ListOpts) ([]int, *hcloud.Response, error) {
+			return []int{7}, nil, nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []int{7}, out)
+	})
+}
+
+func TestLabelMap(t *testing.T) {
+	t.Run("nil yields empty map (never nil)", func(t *testing.T) {
+		got := labelMap(nil)
+		require.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("converts string values", func(t *testing.T) {
+		got := labelMap(map[string]string{"env": "prod", "team": "platform"})
+		assert.Equal(t, map[string]any{"env": "prod", "team": "platform"}, got)
+	})
+}
+
+func TestStringMapAny(t *testing.T) {
+	assert.Equal(t, map[string]any{}, stringMapAny(nil))
+	assert.Equal(t, map[string]any{"a": "1"}, stringMapAny(map[string]string{"a": "1"}))
+}
+
+func TestStringSlice(t *testing.T) {
+	assert.Equal(t, []any{}, stringSlice(nil))
+	assert.Equal(t, []any{"a", "b"}, stringSlice([]string{"a", "b"}))
+}
+
+func TestIpString(t *testing.T) {
+	assert.Equal(t, "", ipString(nil))
+	assert.Equal(t, "1.2.3.4", ipString(net.ParseIP("1.2.3.4")))
+}
+
+func TestIpNetString(t *testing.T) {
+	assert.Equal(t, "", ipNetString(nil))
+	_, ipnet, err := net.ParseCIDR("10.0.0.0/16")
+	require.NoError(t, err)
+	assert.Equal(t, "10.0.0.0/16", ipNetString(ipnet))
+}
+
+func TestTimePtr(t *testing.T) {
+	t.Run("zero time returns nil", func(t *testing.T) {
+		assert.Nil(t, timePtr(time.Time{}))
+	})
+	t.Run("non-zero returns pointer", func(t *testing.T) {
+		now := time.Now()
+		got := timePtr(now)
+		require.NotNil(t, got)
+		assert.True(t, now.Equal(*got))
+	})
+}
+
+func TestTimePtrUnix0(t *testing.T) {
+	t.Run("zero time returns nil", func(t *testing.T) {
+		assert.Nil(t, timePtrUnix0(time.Time{}))
+	})
+	t.Run("Unix(0,0) returns nil", func(t *testing.T) {
+		// hcloud's DeprecatableResource.UnavailableAfter() returns Unix(0,0)
+		// for non-deprecated resources; treat that as "unset".
+		assert.Nil(t, timePtrUnix0(time.Unix(0, 0)))
+	})
+	t.Run("real timestamp returns pointer", func(t *testing.T) {
+		ts := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		got := timePtrUnix0(ts)
+		require.NotNil(t, got)
+		assert.True(t, ts.Equal(*got))
+	})
+}
+
+func TestDnsPtrSliceFromMap(t *testing.T) {
+	t.Run("empty map yields non-nil empty slice", func(t *testing.T) {
+		got := dnsPtrSliceFromMap(nil)
+		require.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("entries become {ip, dnsPtr} dicts", func(t *testing.T) {
+		got := dnsPtrSliceFromMap(map[string]string{
+			"2001:db8::1": "host1.example.",
+		})
+		require.Len(t, got, 1)
+		entry, ok := got[0].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "2001:db8::1", entry["ip"])
+		assert.Equal(t, "host1.example.", entry["dnsPtr"])
+	})
+}
+
+func TestProtectionDict(t *testing.T) {
+	assert.Equal(t, map[string]any{"delete": true}, protectionDict(true))
+	assert.Equal(t, map[string]any{"delete": false}, protectionDict(false))
+}
+
+func TestProtectionDictRebuild(t *testing.T) {
+	assert.Equal(t, map[string]any{"delete": true, "rebuild": false},
+		protectionDictRebuild(true, false))
+}
+
+func TestIdArg(t *testing.T) {
+	t.Run("missing key returns false", func(t *testing.T) {
+		_, ok := idArg(map[string]*llx.RawData{}, "id")
+		assert.False(t, ok)
+	})
+
+	t.Run("nil value returns false", func(t *testing.T) {
+		_, ok := idArg(map[string]*llx.RawData{"id": nil}, "id")
+		assert.False(t, ok)
+	})
+
+	t.Run("wrong type returns false", func(t *testing.T) {
+		_, ok := idArg(map[string]*llx.RawData{"id": llx.StringData("123")}, "id")
+		assert.False(t, ok)
+	})
+
+	t.Run("int64 returns value", func(t *testing.T) {
+		got, ok := idArg(map[string]*llx.RawData{"id": llx.IntData(42)}, "id")
+		assert.True(t, ok)
+		assert.EqualValues(t, 42, got)
+	})
+}
+
+func TestNotFoundErr(t *testing.T) {
+	err := notFoundErr("server", 12345)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "server")
+	assert.Contains(t, err.Error(), "12345")
+}


### PR DESCRIPTION
## Summary

Adds unit tests for the pure, no-API-call surface of the Hetzner Cloud provider.

- `resources/helpers_test.go` exercises `translateHcloudError` (incl. wrapped hcloud errors), `paginate` (single/multi-page walking, PerPage=50 default, error propagation, the mid-stream auth-error swallow), the `time.Time`/IP/label/slice helpers, `dnsPtrSliceFromMap`, `protectionDict*`, `idArg`, and `notFoundErr`.
- `connection/authentication_test.go` covers `GetToken` / `GetEndpoint` precedence (credential > flag > env), empty-value fall-through, unsupported credential types, and the multi-credential last-wins behavior.
- `go.mod` promotes `github.com/stretchr/testify` to a direct dep (was already pulled transitively).

These came out of an audit pass on the provider. The audit also surfaced a handful of bugs (e.g. `time.Time` and Go `int` values being shoved into dicts where `dict2primitive` rejects them, dead-code `hetzner.certificate.servers()`, deprecated `Server.Datacenter` exposed as live) — those will be addressed in a follow-up PR.

## Test plan

- [x] `go test ./resources/... ./connection/...` passes (31 sub-tests)
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean