### PR TITLE
🐛 ipmi: fix bit-decoding bugs, nil-deref panic, and GUID round-trips

### DIFF
--- a/providers/ipmi/connection/client/decode.go
+++ b/providers/ipmi/connection/client/decode.go
@@ -1,0 +1,77 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package client
+
+// Pure bit decoders for IPMI response bytes, kept separate so they can be
+// unit tested without an IPMI transport. Bit layouts come from IPMI 2.0
+// §20.1 (Get Device ID), §28.2 (Get Chassis Status), and §28.13 (Get System
+// Boot Options).
+
+// decodeManufacturerID assembles the 20-bit IANA Enterprise Number: low 16
+// bits in id1, high 4 bits in the low nibble of id2.
+func decodeManufacturerID(id1 uint16, id2 uint8) OemVendorID {
+	return OemVendorID(uint32(id1) | (uint32(id2)&0x0F)<<16)
+}
+
+func decodePowerRestorePolicy(powerState uint8) string {
+	switch (powerState & 0x60) >> 5 {
+	case 0x0:
+		return "always-off"
+	case 0x1:
+		return "previous"
+	case 0x2:
+		return "always-on"
+	default:
+		return "unknown"
+	}
+}
+
+func decodeLastPowerEvent(b uint8) ChassisLastPowerEvent {
+	return ChassisLastPowerEvent{
+		AcFailed:  b&0x1 != 0,
+		Overload:  b&0x2 != 0,
+		Interlock: b&0x4 != 0,
+		Fault:     b&0x8 != 0,
+		Command:   b&0x10 != 0,
+	}
+}
+
+func decodeBIOSVerbosity(b uint8) string {
+	switch (b >> 5) & 0x3 {
+	case 0x0:
+		return "default"
+	case 0x1:
+		return "quiet"
+	case 0x2:
+		return "verbose"
+	default:
+		return "reserved"
+	}
+}
+
+func decodeConsoleRedirection(b uint8) string {
+	switch b & 0x3 {
+	case 0x0:
+		return "bios"
+	case 0x1:
+		return "skip"
+	case 0x2:
+		return "redirected"
+	default:
+		return "reserved"
+	}
+}
+
+func decodeBIOSMuxControlOverride(b uint8) string {
+	switch b & 0x3 {
+	case 0x0:
+		return "recommended"
+	case 0x1:
+		return "force-bmc"
+	case 0x2:
+		return "force-system"
+	default:
+		return "reserved"
+	}
+}

--- a/providers/ipmi/connection/client/decode_test.go
+++ b/providers/ipmi/connection/client/decode_test.go
@@ -1,0 +1,141 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodeManufacturerID(t *testing.T) {
+	tests := []struct {
+		name string
+		id1  uint16
+		id2  uint8
+		want OemVendorID
+	}{
+		{"Dell (674)", 674, 0x00, OemDell},
+		{"Supermicro (10876)", 10876, 0x00, OemSupermicro},
+		{"Intel (343)", 343, 0x00, OemIntel},
+		// 47488 = 0xB980 — fits in 16 bits, exercises ManufacturerID1 alone.
+		{"Supermicro 47488", 0xB980, 0x00, OemSupermicro47488},
+		// High-nibble bits: 0x10000 (65536) requires id2 bit 0 set.
+		{"high nibble bit 0", 0x0000, 0x01, OemVendorID(0x10000)},
+		// All 4 high-nibble bits set; high nibble of id2 must be ignored.
+		{"high nibble masked to low 4 bits", 0xFFFF, 0xFF, OemVendorID(0xFFFFF)},
+		{"zero", 0, 0, OemUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, decodeManufacturerID(tt.id1, tt.id2))
+		})
+	}
+}
+
+func TestDecodePowerRestorePolicy(t *testing.T) {
+	tests := []struct {
+		powerState uint8
+		want       string
+	}{
+		{0x00, "always-off"},
+		{0x20, "previous"},
+		{0x40, "always-on"},
+		{0x60, "unknown"},
+		// Other bits in the power state byte must not influence the decode.
+		{0xFF &^ 0x60, "always-off"},
+		{0xFF, "unknown"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, decodePowerRestorePolicy(tt.powerState),
+			"powerState=0x%02X", tt.powerState)
+	}
+}
+
+func TestDecodeLastPowerEvent(t *testing.T) {
+	// Regression test for the bug where Command shared Fault's mask (0x8).
+	t.Run("Fault and Command are distinct bits", func(t *testing.T) {
+		fault := decodeLastPowerEvent(0x08)
+		assert.True(t, fault.Fault)
+		assert.False(t, fault.Command)
+
+		cmd := decodeLastPowerEvent(0x10)
+		assert.False(t, cmd.Fault)
+		assert.True(t, cmd.Command)
+	})
+
+	t.Run("all bits set", func(t *testing.T) {
+		got := decodeLastPowerEvent(0x1F)
+		assert.Equal(t, ChassisLastPowerEvent{
+			AcFailed:  true,
+			Overload:  true,
+			Interlock: true,
+			Fault:     true,
+			Command:   true,
+		}, got)
+	})
+
+	t.Run("none set", func(t *testing.T) {
+		assert.Equal(t, ChassisLastPowerEvent{}, decodeLastPowerEvent(0x00))
+	})
+}
+
+func TestDecodeBIOSVerbosity(t *testing.T) {
+	// Regression test for the bug where `& 0x3 >> 5` was always 0, so the
+	// switch always landed on "default" regardless of input.
+	tests := []struct {
+		b    uint8
+		want string
+	}{
+		{0x00, "default"},
+		{0x20, "quiet"},    // bits 6:5 = 01
+		{0x40, "verbose"},  // bits 6:5 = 10
+		{0x60, "reserved"}, // bits 6:5 = 11
+		// Other bits must not affect the decode.
+		{0xFF, "reserved"},
+		{0x1F, "default"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, decodeBIOSVerbosity(tt.b), "b=0x%02X", tt.b)
+	}
+}
+
+func TestDecodeConsoleRedirection(t *testing.T) {
+	tests := []struct {
+		b    uint8
+		want string
+	}{
+		{0x00, "bios"},
+		{0x01, "skip"},
+		{0x02, "redirected"},
+		{0x03, "reserved"},
+		{0xFC, "bios"}, // high bits don't leak in
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, decodeConsoleRedirection(tt.b), "b=0x%02X", tt.b)
+	}
+}
+
+func TestDecodeBIOSMuxControlOverride(t *testing.T) {
+	tests := []struct {
+		b    uint8
+		want string
+	}{
+		{0x00, "recommended"},
+		{0x01, "force-bmc"},
+		{0x02, "force-system"},
+		{0x03, "reserved"},
+		{0xFC, "recommended"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, decodeBIOSMuxControlOverride(tt.b), "b=0x%02X", tt.b)
+	}
+}
+
+func TestOemVendorIDString(t *testing.T) {
+	// Regression test for the "NEEC" typo.
+	assert.Equal(t, "NEC", OemNEC.String())
+	assert.Equal(t, "Dell Inc", OemDell.String())
+	assert.Equal(t, "Unknown", OemVendorID(999999).String())
+}

--- a/providers/ipmi/connection/client/ipmi.go
+++ b/providers/ipmi/connection/client/ipmi.go
@@ -127,8 +127,7 @@ func (c *IpmiClient) DeviceID() (*DeviceID, error) {
 		return nil, err
 	}
 
-	// 20 bits of are used for the vendor id
-	manufactor := OemVendorID(uint32(res.ManufacturerID1) + uint32(res.ManufacturerID2)&0x3<<8)
+	manufactor := decodeManufacturerID(res.ManufacturerID1, res.ManufacturerID2)
 	product := OemProductID(res.ProductID)
 
 	return &DeviceID{
@@ -203,36 +202,18 @@ func (c *IpmiClient) ChassisStatus() (*ChassisStatus, error) {
 		return nil, err
 	}
 
-	policy := ""
-	switch (res.PowerState & 0x60) >> 5 {
-	case 0x0:
-		policy = "always-off"
-	case 0x1:
-		policy = "previous"
-	case 0x2:
-		policy = "always-on"
-	default:
-		policy = "unknown"
-	}
-
 	return &ChassisStatus{
 		SystemPower:        res.PowerState&0x1 != 0,
 		PowerOverload:      res.PowerState&0x2 != 0,
 		PowerInterlock:     res.PowerState&0x4 != 0,
 		MainPowerFault:     res.PowerState&0x8 != 0,
 		PowerControlFault:  res.PowerState&0x10 != 0,
-		PowerRestorePolicy: policy,
-		LastPowerEvent: ChassisLastPowerEvent{
-			AcFailed:  res.LastPowerEvent&0x1 != 0,
-			Overload:  res.LastPowerEvent&0x2 != 0,
-			Interlock: res.LastPowerEvent&0x4 != 0,
-			Fault:     res.LastPowerEvent&0x8 != 0,
-			Command:   res.LastPowerEvent&0x8 != 0,
-		},
-		ChassisIntrusion:  res.State&0x1 != 0,
-		FrontPanelLockout: res.State&0x2 != 0,
-		DriveFault:        res.State&0x4 != 0,
-		CoolingFanFault:   res.State&0x8 != 0,
+		PowerRestorePolicy: decodePowerRestorePolicy(res.PowerState),
+		LastPowerEvent:     decodeLastPowerEvent(res.LastPowerEvent),
+		ChassisIntrusion:   res.State&0x1 != 0,
+		FrontPanelLockout:  res.State&0x2 != 0,
+		DriveFault:         res.State&0x4 != 0,
+		CoolingFanFault:    res.State&0x8 != 0,
 	}, nil
 }
 
@@ -276,44 +257,6 @@ func (c *IpmiClient) ChassisSystemBootOptions() (*ChassisSystemBootOptions, erro
 	if err != nil {
 		return nil, err
 	}
-	bootDevice := res.BootDeviceSelector()
-
-	consoleRedirection := ""
-	switch res.Data[2] & 0x3 {
-	case 0x0:
-		consoleRedirection = "bios"
-	case 0x1:
-		consoleRedirection = "skip"
-	case 0x2:
-		consoleRedirection = "redirected"
-	default:
-		consoleRedirection = "reserved"
-	}
-
-	biosVerbosity := ""
-	switch res.Data[2] & 0x3 >> 5 {
-	case 0x0:
-		biosVerbosity = "default"
-	case 0x1:
-		biosVerbosity = "quiet"
-	case 0x2:
-		biosVerbosity = "verbose"
-	default:
-		biosVerbosity = "reserved"
-	}
-
-	biosMuxControlOverride := ""
-	switch res.Data[3] & 0x3 {
-	case 0x0:
-		biosMuxControlOverride = "recommended"
-	case 0x1:
-		biosMuxControlOverride = "force-bmc"
-	case 0x2:
-		biosMuxControlOverride = "force-system"
-	default:
-		biosMuxControlOverride = "reserved"
-	}
-
 	return &ChassisSystemBootOptions{
 		ParameterVersion:       int64(res.Version),
 		ParameterValidUnlocked: res.Param&0x80 == 0,
@@ -321,18 +264,18 @@ func (c *IpmiClient) ChassisSystemBootOptions() (*ChassisSystemBootOptions, erro
 			BootFlagsValid:         res.Data[0]&0x80 != 0,
 			ApplyToNextBootOnly:    res.Data[0]&0x40 == 0,
 			LegacyBootType:         res.Data[0]&0x20 == 0,
-			BootDeviceSelector:     bootDevice.String(),
+			BootDeviceSelector:     res.BootDeviceSelector().String(),
 			CmosClear:              res.Data[1]&0x80 != 0,
 			LockKeyboard:           res.Data[1]&0x40 != 0,
 			ScreenBlank:            res.Data[1]&0x2 != 0,
 			LockOutResetButton:     res.Data[1]&0x1 != 0,
-			ConsoleRedirection:     consoleRedirection,
+			ConsoleRedirection:     decodeConsoleRedirection(res.Data[2]),
 			LockOutSleepButton:     res.Data[2]&0x4 != 0,
 			UserPasswordBypass:     res.Data[2]&0x8 != 0,
 			ForceProgressEventTrap: res.Data[2]&0x10 != 0,
-			BIOSVerbosity:          biosVerbosity,
+			BIOSVerbosity:          decodeBIOSVerbosity(res.Data[2]),
 			LockOutPowerButton:     res.Data[2]&0x80 != 0,
-			BIOSMuxControlOverride: biosMuxControlOverride,
+			BIOSMuxControlOverride: decodeBIOSMuxControlOverride(res.Data[3]),
 			BIOSSharedModeOverride: res.Data[3]&0x8 != 0,
 		},
 	}, nil

--- a/providers/ipmi/connection/client/oem_vendor.go
+++ b/providers/ipmi/connection/client/oem_vendor.go
@@ -65,7 +65,7 @@ var oemStrings = map[OemVendorID]string{
 	OemNokia:                "Nokia",
 	OemBull:                 "Bull Company",
 	OemHitachi116:           "Hitachi",
-	OemNEC:                  "NEEC",
+	OemNEC:                  "NEC",
 	OemToshiba:              "Toshiba",
 	OemIntel:                "Intel Corporation",
 	OemTatung:               "Tatung",

--- a/providers/ipmi/connection/connection.go
+++ b/providers/ipmi/connection/connection.go
@@ -6,7 +6,6 @@ package connection
 import (
 	"errors"
 
-	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
@@ -77,20 +76,24 @@ func (c *IpmiConnection) Client() *impi_client.IpmiClient {
 	return c.client
 }
 
-func (c *IpmiConnection) Identifier() string {
-	return "//platformid.api.mondoo.app/runtime/ipmi/deviceid/" + c.Guid()
+func (c *IpmiConnection) Identifier() (string, error) {
+	guid, err := c.Guid()
+	if err != nil {
+		return "", err
+	}
+	return "//platformid.api.mondoo.app/runtime/ipmi/deviceid/" + guid, nil
 }
 
-func (c *IpmiConnection) Guid() string {
+func (c *IpmiConnection) Guid() (string, error) {
 	if c.guid != "" {
-		return c.guid
+		return c.guid, nil
 	}
 
 	resp, err := c.client.DeviceGUID()
 	if err != nil {
-		log.Error().Err(err).Msg("could not retrieve Ipmi GUID")
+		return "", err
 	}
 
 	c.guid = resp.GUID
-	return c.guid
+	return c.guid, nil
 }

--- a/providers/ipmi/go.mod
+++ b/providers/ipmi/go.mod
@@ -5,7 +5,6 @@ replace go.mondoo.com/mql/v13 => ../..
 go 1.26.3
 
 require (
-	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.11.1
 	github.com/vmware/goipmi v0.0.0-20181114221114-2333cd82d702
 	go.mondoo.com/mql/v13 v13.11.0
@@ -120,6 +119,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
+	github.com/rs/zerolog v1.35.1 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/segmentio/fasthash v1.0.3 // indirect
 	github.com/segmentio/ksuid v1.0.4 // indirect

--- a/providers/ipmi/provider/provider.go
+++ b/providers/ipmi/provider/provider.go
@@ -161,11 +161,20 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.IpmiConnection
 		TechnologyUrlSegments: []string{"network", "ipmi"},
 	}
 
-	// TODO: consider using the ipmi vendor id and product id
-	if asset.Name == "" {
-		asset.Name = "IPMI device " + conn.Guid()
+	identifier, err := conn.Identifier()
+	if err != nil {
+		return err
 	}
 
-	asset.PlatformIds = []string{conn.Identifier()}
+	// TODO: consider using the ipmi vendor id and product id
+	if asset.Name == "" {
+		guid, err := conn.Guid()
+		if err != nil {
+			return err
+		}
+		asset.Name = "IPMI device " + guid
+	}
+
+	asset.PlatformIds = []string{identifier}
 	return nil
 }

--- a/providers/ipmi/resources/ipmi.go
+++ b/providers/ipmi/resources/ipmi.go
@@ -14,13 +14,7 @@ func (r *mqlIpmi) id() (string, error) {
 
 func (r *mqlIpmi) guid() (string, error) {
 	conn := r.MqlRuntime.Connection.(*connection.IpmiConnection)
-	client := conn.Client()
-
-	resp, err := client.DeviceGUID()
-	if err != nil {
-		return "", err
-	}
-	return resp.GUID, nil
+	return conn.Guid()
 }
 
 func (r *mqlIpmi) deviceID() (map[string]any, error) {


### PR DESCRIPTION
## Summary

Audit pass on the ipmi provider. Six fixes plus unit tests for the bit
decoders.

### Bugs

- **Nil-deref panic in `connection.Guid()`.** On any `DeviceGUID` transport
  error, `resp` was nil but the next line did `c.guid = resp.GUID` — provider
  crashed instead of failing the scan. Worse, the silent-error path used to
  build the platform ID as
  `…/runtime/ipmi/deviceid/` (empty suffix), so every BMC that hit a transient
  error deduped into a single asset. Changed `Guid` and `Identifier` to return
  `(string, error)` and propagated through `detect()`.
- **`LastPowerEvent.Command` copy-pasted Fault's mask.** Both used `0x8`, so
  `command` mirrored `fault`. Now uses `0x10` per IPMI 2.0 §28.2.
- **`BIOSVerbosity` always returned `"default"`.** The expression
  `res.Data[2] & 0x3 >> 5` evaluates left-to-right (Go shift/and at the same
  precedence) — mask to 2 bits, then shift right by 5 — identically zero.
  Fixed to `(res.Data[2] >> 5) & 0x3`.
- **Manufacturer ID decoded with wrong shift and mask.** Was
  `id1 + (id2 & 0x3) << 8`; should be `id1 | (id2 & 0x0F) << 16` per IPMI 2.0
  §20.1. The high 4 bits of the 20-bit IANA Enterprise Number landed at
  positions 8–9 instead of 16–19, which is why most non-Dell vendors rendered
  as `Unknown`.
- **`OemNEC` rendered as "NEEC"** — typo fix.

### Performance

- `mqlIpmi.guid()` called `client.DeviceGUID()` directly, bypassing the
  per-connection cache and producing a third round-trip on every scan. Now
  goes through `conn.Guid()`.

### Tests

Bit decoders moved into `decode.go` so they can be exercised without an IPMI
transport. `decode_test.go` adds regression tests for each of the bugs above
(`Fault` vs `Command` distinction, `BIOSVerbosity` switching, manufacturer ID
high-nibble assembly, `NEC` rendering, etc.). The existing
`debugtest`-gated integration test in `ipmi_test.go` is untouched.

## Test plan

- [x] `go build ./...` from `providers/ipmi/`
- [x] `go test ./...` from `providers/ipmi/` (decoder tests pass)
- [x] `gofmt -l providers/ipmi/` clean
- [x] `go mod tidy` (zerolog demoted to indirect since the logger import is
      no longer needed)
- [ ] Manual smoke test against a real BMC if one's available