### PR TITLE
🐛 jamf: fix bugs surfaced by the audit pass

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -98,6 +98,7 @@ CCN
 cdc
 cdn
 cdroms
+CENTRIFY
 ceph
 certificatechains
 certificatesigningrequest
@@ -506,6 +507,7 @@ onboot
 onbuild
 ondemand
 oneof
+ONELOGIN
 ontap
 opcplc
 openai

--- a/providers/jamf/connection/connection.go
+++ b/providers/jamf/connection/connection.go
@@ -49,8 +49,18 @@ func NewJamfConnection(id uint32, asset *inventory.Asset, conf *inventory.Config
 	}
 
 	// Validate that all necessary credentials are provided
-	if instanceDomain == "" || clientID == "" || clientSecret == "" {
-		return nil, errors.New("missing required Jamf credentials: instance_domain, client_id, client_secret")
+	var missing []string
+	if instanceDomain == "" {
+		missing = append(missing, "instance_domain")
+	}
+	if clientID == "" {
+		missing = append(missing, "client_id")
+	}
+	if clientSecret == "" {
+		missing = append(missing, "client_secret")
+	}
+	if len(missing) > 0 {
+		return nil, errors.New("missing required Jamf credentials: " + strings.Join(missing, ", "))
 	}
 
 	// Create the configuration container
@@ -68,7 +78,7 @@ func NewJamfConnection(id uint32, asset *inventory.Asset, conf *inventory.Config
 		return nil, err
 	}
 	conn.Client = client
-	log.Info().Msg("jamf> client initialized using BuildClient with ConfigContainer")
+	log.Debug().Msg("jamf> client initialized")
 
 	return conn, nil
 }

--- a/providers/jamf/connection/connection_test.go
+++ b/providers/jamf/connection/connection_test.go
@@ -19,6 +19,27 @@ func TestNewJamfConnection_MissingCredentials(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing required Jamf credentials")
+	// Error should enumerate every missing piece so the user knows what to
+	// provide, not just that "something" is missing.
+	assert.Contains(t, err.Error(), "instance_domain")
+	assert.Contains(t, err.Error(), "client_id")
+	assert.Contains(t, err.Error(), "client_secret")
+}
+
+func TestNewJamfConnection_MissingOnlyDomainNamesOnlyDomain(t *testing.T) {
+	cred := &vault.Credential{
+		Type:   vault.CredentialType_password,
+		User:   "client-id",
+		Secret: []byte("client-secret"),
+	}
+	_, err := NewJamfConnection(0, &inventory.Asset{}, &inventory.Config{
+		Options:     map[string]string{},
+		Credentials: []*vault.Credential{cred},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "instance_domain")
+	assert.NotContains(t, err.Error(), "client_id")
+	assert.NotContains(t, err.Error(), "client_secret")
 }
 
 func TestNewJamfConnection_MissingDomain(t *testing.T) {

--- a/providers/jamf/resources/computer_groups.go
+++ b/providers/jamf/resources/computer_groups.go
@@ -18,9 +18,6 @@ func (r *mqlJamf) computerGroups() ([]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	if groups == nil {
-		return nil, nil
-	}
 
 	var res []interface{}
 	for _, g := range groups.Results {

--- a/providers/jamf/resources/computer_inventory.go
+++ b/providers/jamf/resources/computer_inventory.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
@@ -39,6 +40,11 @@ var inventorySections = []string{
 	"LOCAL_USER_ACCOUNTS",
 }
 
+// inventoryPageSize is the per-request page size. The SDK defaults to 100;
+// Jamf Pro allows up to 2000. 500 cuts round-trip count 5x compared to the
+// default while keeping per-request payload size manageable.
+const inventoryPageSize = 500
+
 func (r *mqlJamf) computerInventory() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.JamfConnection)
 	client := conn.Client
@@ -49,12 +55,10 @@ func (r *mqlJamf) computerInventory() ([]interface{}, error) {
 	for _, s := range inventorySections {
 		params.Add("section", s)
 	}
+	params.Set("page-size", strconv.Itoa(inventoryPageSize))
 	inventory, err := client.GetComputersInventory(params)
 	if err != nil {
 		return nil, err
-	}
-	if inventory == nil {
-		return nil, nil
 	}
 
 	res := make([]interface{}, 0, len(inventory.Results))
@@ -112,14 +116,14 @@ func (c *mqlJamfComputer) localUserAccounts() ([]interface{}, error) {
 		return createLocalUserAccountResources(c.MqlRuntime, c.Id.Data, cached)
 	}
 
-	client := conn.Client
-	inventory, err := client.GetComputerInventoryByID(c.Id.Data)
+	// Fallback path: the computer was constructed outside of
+	// jamf.computerInventory (e.g. a recording replay). Populate the cache so
+	// repeat accesses don't re-fetch.
+	inventory, err := conn.Client.GetComputerInventoryByID(c.Id.Data)
 	if err != nil {
 		return nil, err
 	}
-	if inventory == nil {
-		return nil, nil
-	}
+	conn.CacheLocalUserAccounts(c.Id.Data, inventory.LocalUserAccounts)
 	return createLocalUserAccountResources(c.MqlRuntime, c.Id.Data, inventory.LocalUserAccounts)
 }
 

--- a/providers/jamf/resources/computer_inventory_count.go
+++ b/providers/jamf/resources/computer_inventory_count.go
@@ -7,13 +7,6 @@ import (
 	"go.mondoo.com/mql/v13/providers/jamf/connection"
 )
 
-// totalCountResponse decodes the first page of a Jamf paginated endpoint
-// when we only need the total. The Jamf Pro API returns `totalCount` in the
-// first response, so a single GET with page-size=1 is enough.
-type totalCountResponse struct {
-	TotalCount int `json:"totalCount"`
-}
-
 func (r *mqlJamf) computerInventoryCount() (int64, error) {
 	// If the full inventory was already fetched in this session, reuse it
 	// instead of issuing another HTTP call.
@@ -21,8 +14,14 @@ func (r *mqlJamf) computerInventoryCount() (int64, error) {
 		return int64(len(r.ComputerInventory.Data)), nil
 	}
 
+	// Bypass the SDK's GetComputersInventory because it always paginates
+	// through every record. We only want the total, which the Jamf Pro API
+	// reports in the first page. Endpoint:
+	// https://developer.jamf.com/jamf-pro/reference/get_v1-computers-inventory
 	conn := r.MqlRuntime.Connection.(*connection.JamfConnection)
-	var out totalCountResponse
+	var out struct {
+		TotalCount int `json:"totalCount"`
+	}
 	resp, err := conn.Client.HTTP.DoRequest("GET", "/api/v1/computers-inventory?page=0&page-size=1", nil, &out)
 	if err != nil {
 		return 0, err

--- a/providers/jamf/resources/computer_inventory_count.go
+++ b/providers/jamf/resources/computer_inventory_count.go
@@ -3,14 +3,32 @@
 
 package resources
 
+import (
+	"go.mondoo.com/mql/v13/providers/jamf/connection"
+)
+
+// totalCountResponse decodes the first page of a Jamf paginated endpoint
+// when we only need the total. The Jamf Pro API returns `totalCount` in the
+// first response, so a single GET with page-size=1 is enough.
+type totalCountResponse struct {
+	TotalCount int `json:"totalCount"`
+}
+
 func (r *mqlJamf) computerInventoryCount() (int64, error) {
-	// Derive the count from the cached inventory rather than issuing a
-	// second paginated fetch — the Jamf SDK paginates through every record
-	// regardless of the requested page-size, so a "count only" call would
-	// still load the full dataset.
-	inv := r.GetComputerInventory()
-	if inv.Error != nil {
-		return 0, inv.Error
+	// If the full inventory was already fetched in this session, reuse it
+	// instead of issuing another HTTP call.
+	if r.ComputerInventory.IsSet() && r.ComputerInventory.Error == nil {
+		return int64(len(r.ComputerInventory.Data)), nil
 	}
-	return int64(len(inv.Data)), nil
+
+	conn := r.MqlRuntime.Connection.(*connection.JamfConnection)
+	var out totalCountResponse
+	resp, err := conn.Client.HTTP.DoRequest("GET", "/api/v1/computers-inventory?page=0&page-size=1", nil, &out)
+	if err != nil {
+		return 0, err
+	}
+	if resp != nil && resp.Body != nil {
+		resp.Body.Close()
+	}
+	return int64(out.TotalCount), nil
 }

--- a/providers/jamf/resources/jamf.lr
+++ b/providers/jamf/resources/jamf.lr
@@ -212,9 +212,24 @@ private jamf.localUserAccount @defaults("username") {
 }
 
 // Single Sign-On (SSO) settings for Jamf Pro
-private jamf.ssoSettings @defaults("ssoEnabled") {
+//
+// Top-level fields apply regardless of which identity protocol is in use.
+// SAML-specific fields (sessionTimeout, idpUrl, idpProviderType,
+// userAttributeEnabled, userAttributeName, userMapping,
+// tokenExpirationDisabled, groupAttributeName, entityId) are null when the
+// tenant is configured for OIDC only. OIDC-specific fields
+// (oidcUserMapping, oidcJamfIdAuthenticationEnabled,
+// oidcUsernameAttributeClaimMapping) are null when the tenant is configured
+// for SAML only. Use `configurationType` to branch.
+private jamf.ssoSettings @defaults("ssoEnabled configurationType") {
   // Whether SSO is enabled
   ssoEnabled bool
+
+  // Active SSO configuration type
+  //
+  // One of SAML, OIDC, or OIDC_WITH_SAML. Tells you which set of
+  // protocol-specific fields on this resource will be populated.
+  configurationType string
 
   // Whether SSO is enabled for enrollment
   ssoForEnrollmentEnabled bool
@@ -222,41 +237,57 @@ private jamf.ssoSettings @defaults("ssoEnabled") {
   // Whether bypassing SSO is allowed
   ssoBypassAllowed bool
 
-  // Session timeout in minutes
+  // Session timeout in minutes (SAML only)
   sessionTimeout int
 
   // Whether SSO is enabled for macOS Self Service
   ssoForMacOsSelfServiceEnabled bool
 
-  // Whether token expiration is disabled
+  // Whether token expiration is disabled (SAML only)
   tokenExpirationDisabled bool
 
-  // Whether user attribute is enabled
+  // Whether the SAML user attribute is enabled
   userAttributeEnabled bool
 
-  // Name of the user attribute used
+  // Name of the SAML user attribute used
   userAttributeName string
 
-  // User mapping details
+  // SAML user mapping mode
+  //
+  // One of USERNAME or EMAIL. Null when configurationType is OIDC.
   userMapping string
 
   // Whether account-driven enrollment uses SSO
   enrollmentSsoForAccountDrivenEnrollmentEnabled bool
 
-  // Identity provider URL
+  // SAML identity provider URL
   idpUrl string
 
-  // Type of identity provider (e.g., Azure, Google)
+  // SAML identity provider type
+  //
+  // One of ADFS, OKTA, GOOGLE, SHIBBOLETH, ONELOGIN, PING, CENTRIFY, AZURE,
+  // or OTHER.
   idpProviderType string
 
   // Whether group enrollment access is enabled
   groupEnrollmentAccessEnabled bool
 
-  // Name of the group attribute used
+  // Name of the SAML group attribute used
   groupAttributeName string
 
-  // Entity ID for the SSO provider
+  // SAML entity ID for the SSO provider
   entityId string
+
+  // OIDC user mapping mode
+  //
+  // One of USERNAME or EMAIL. Null when configurationType is SAML.
+  oidcUserMapping string
+
+  // Whether Jamf ID authentication is enabled for OIDC
+  oidcJamfIdAuthenticationEnabled bool
+
+  // OIDC claim used as the username attribute
+  oidcUsernameAttributeClaimMapping string
 }
 
 // Jamf Pro user summary

--- a/providers/jamf/resources/jamf.lr.go
+++ b/providers/jamf/resources/jamf.lr.go
@@ -310,6 +310,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"jamf.ssoSettings.ssoEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlJamfSsoSettings).GetSsoEnabled()).ToDataRes(types.Bool)
 	},
+	"jamf.ssoSettings.configurationType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlJamfSsoSettings).GetConfigurationType()).ToDataRes(types.String)
+	},
 	"jamf.ssoSettings.ssoForEnrollmentEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlJamfSsoSettings).GetSsoForEnrollmentEnabled()).ToDataRes(types.Bool)
 	},
@@ -351,6 +354,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"jamf.ssoSettings.entityId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlJamfSsoSettings).GetEntityId()).ToDataRes(types.String)
+	},
+	"jamf.ssoSettings.oidcUserMapping": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlJamfSsoSettings).GetOidcUserMapping()).ToDataRes(types.String)
+	},
+	"jamf.ssoSettings.oidcJamfIdAuthenticationEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlJamfSsoSettings).GetOidcJamfIdAuthenticationEnabled()).ToDataRes(types.Bool)
+	},
+	"jamf.ssoSettings.oidcUsernameAttributeClaimMapping": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlJamfSsoSettings).GetOidcUsernameAttributeClaimMapping()).ToDataRes(types.String)
 	},
 	"jamf.user.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlJamfUser).GetId()).ToDataRes(types.Int)
@@ -654,6 +666,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlJamfSsoSettings).SsoEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"jamf.ssoSettings.configurationType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlJamfSsoSettings).ConfigurationType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"jamf.ssoSettings.ssoForEnrollmentEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlJamfSsoSettings).SsoForEnrollmentEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -708,6 +724,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"jamf.ssoSettings.entityId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlJamfSsoSettings).EntityId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"jamf.ssoSettings.oidcUserMapping": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlJamfSsoSettings).OidcUserMapping, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"jamf.ssoSettings.oidcJamfIdAuthenticationEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlJamfSsoSettings).OidcJamfIdAuthenticationEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"jamf.ssoSettings.oidcUsernameAttributeClaimMapping": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlJamfSsoSettings).OidcUsernameAttributeClaimMapping, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"jamf.user.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1369,6 +1397,7 @@ type mqlJamfSsoSettings struct {
 	__id       string
 	// optional: if you define mqlJamfSsoSettingsInternal it will be used here
 	SsoEnabled                                     plugin.TValue[bool]
+	ConfigurationType                              plugin.TValue[string]
 	SsoForEnrollmentEnabled                        plugin.TValue[bool]
 	SsoBypassAllowed                               plugin.TValue[bool]
 	SessionTimeout                                 plugin.TValue[int64]
@@ -1383,6 +1412,9 @@ type mqlJamfSsoSettings struct {
 	GroupEnrollmentAccessEnabled                   plugin.TValue[bool]
 	GroupAttributeName                             plugin.TValue[string]
 	EntityId                                       plugin.TValue[string]
+	OidcUserMapping                                plugin.TValue[string]
+	OidcJamfIdAuthenticationEnabled                plugin.TValue[bool]
+	OidcUsernameAttributeClaimMapping              plugin.TValue[string]
 }
 
 // createJamfSsoSettings creates a new instance of this resource
@@ -1424,6 +1456,10 @@ func (c *mqlJamfSsoSettings) MqlID() string {
 
 func (c *mqlJamfSsoSettings) GetSsoEnabled() *plugin.TValue[bool] {
 	return &c.SsoEnabled
+}
+
+func (c *mqlJamfSsoSettings) GetConfigurationType() *plugin.TValue[string] {
+	return &c.ConfigurationType
 }
 
 func (c *mqlJamfSsoSettings) GetSsoForEnrollmentEnabled() *plugin.TValue[bool] {
@@ -1480,6 +1516,18 @@ func (c *mqlJamfSsoSettings) GetGroupAttributeName() *plugin.TValue[string] {
 
 func (c *mqlJamfSsoSettings) GetEntityId() *plugin.TValue[string] {
 	return &c.EntityId
+}
+
+func (c *mqlJamfSsoSettings) GetOidcUserMapping() *plugin.TValue[string] {
+	return &c.OidcUserMapping
+}
+
+func (c *mqlJamfSsoSettings) GetOidcJamfIdAuthenticationEnabled() *plugin.TValue[bool] {
+	return &c.OidcJamfIdAuthenticationEnabled
+}
+
+func (c *mqlJamfSsoSettings) GetOidcUsernameAttributeClaimMapping() *plugin.TValue[string] {
+	return &c.OidcUsernameAttributeClaimMapping
 }
 
 // mqlJamfUser for the jamf.user resource

--- a/providers/jamf/resources/jamf.lr.versions
+++ b/providers/jamf/resources/jamf.lr.versions
@@ -64,12 +64,16 @@ jamf.package.suppressUpdates 13.0.0
 jamf.packages 13.0.0
 jamf.sso 13.0.0
 jamf.ssoSettings 13.0.0
+jamf.ssoSettings.configurationType 13.0.2
 jamf.ssoSettings.enrollmentSsoForAccountDrivenEnrollmentEnabled 13.0.0
 jamf.ssoSettings.entityId 13.0.0
 jamf.ssoSettings.groupAttributeName 13.0.0
 jamf.ssoSettings.groupEnrollmentAccessEnabled 13.0.0
 jamf.ssoSettings.idpProviderType 13.0.0
 jamf.ssoSettings.idpUrl 13.0.0
+jamf.ssoSettings.oidcJamfIdAuthenticationEnabled 13.0.2
+jamf.ssoSettings.oidcUserMapping 13.0.2
+jamf.ssoSettings.oidcUsernameAttributeClaimMapping 13.0.2
 jamf.ssoSettings.sessionTimeout 13.0.0
 jamf.ssoSettings.ssoBypassAllowed 13.0.0
 jamf.ssoSettings.ssoEnabled 13.0.0

--- a/providers/jamf/resources/packages.go
+++ b/providers/jamf/resources/packages.go
@@ -18,9 +18,6 @@ func (r *mqlJamf) packages() ([]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	if inventory == nil {
-		return nil, nil
-	}
 
 	var res []interface{}
 	for _, c := range inventory.Results {

--- a/providers/jamf/resources/sso_settings.go
+++ b/providers/jamf/resources/sso_settings.go
@@ -6,7 +6,6 @@ package resources
 import (
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"go.mondoo.com/mql/v13/llx"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/jamf/connection"
 )
 
@@ -16,46 +15,68 @@ func (s *mqlJamfSsoSettings) id() (string, error) {
 
 func (r *mqlJamf) sso() (*mqlJamfSsoSettings, error) {
 	conn := r.MqlRuntime.Connection.(*connection.JamfConnection)
-	client := conn.Client
 
-	info, err := client.GetSsoSettings()
+	info, err := conn.Client.GetSsoSettings()
 	if err != nil {
 		return nil, err
 	}
-	if info == nil {
-		r.Sso = plugin.TValue[*mqlJamfSsoSettings]{State: plugin.StateIsSet | plugin.StateIsNull}
-		return nil, nil
-	}
 
-	// As of go-api-sdk-jamfpro v1.47.0, the SAML-specific settings moved from
-	// the flat ResourceSsoSettings struct into a nested, optional SamlSettings
-	// struct. It is nil when SSO is disabled or configured for OIDC only.
-	saml := jamfpro.SamlSettings{}
-	if info.SamlSettings != nil {
-		saml = *info.SamlSettings
+	res, err := CreateResource(r.MqlRuntime, "jamf.ssoSettings", ssoSettingsArgs(info))
+	if err != nil {
+		return nil, err
 	}
+	return res.(*mqlJamfSsoSettings), nil
+}
 
-	res, err := CreateResource(r.MqlRuntime, "jamf.ssoSettings", map[string]*llx.RawData{
+// ssoSettingsArgs builds the CreateResource argument map from the SDK
+// response. As of go-api-sdk-jamfpro v1.47.0, the protocol-specific
+// settings live in separate optional sub-structs: SamlSettings is nil when
+// the tenant is OIDC-only, OidcSettings is nil when SAML-only. Fields that
+// come from the absent sub-struct surface as null rather than as silently
+// zero-filled "0"/"false"/"".
+func ssoSettingsArgs(info *jamfpro.ResourceSsoSettings) map[string]*llx.RawData {
+	args := map[string]*llx.RawData{
 		"__id":                          llx.StringData("jamf.ssoSettings"),
 		"ssoEnabled":                    llx.BoolData(info.SsoEnabled),
+		"configurationType":             llx.StringData(info.ConfigurationType),
 		"ssoForEnrollmentEnabled":       llx.BoolData(info.SsoForEnrollmentEnabled),
 		"ssoBypassAllowed":              llx.BoolData(info.SsoBypassAllowed),
-		"sessionTimeout":                llx.IntData(saml.SessionTimeout),
 		"ssoForMacOsSelfServiceEnabled": llx.BoolData(info.SsoForMacOsSelfServiceEnabled),
-		"tokenExpirationDisabled":       llx.BoolData(saml.TokenExpirationDisabled),
-		"userAttributeEnabled":          llx.BoolData(saml.UserAttributeEnabled),
-		"userAttributeName":             llx.StringData(saml.UserAttributeName),
-		"userMapping":                   llx.StringData(saml.UserMapping),
 		"enrollmentSsoForAccountDrivenEnrollmentEnabled": llx.BoolData(info.EnrollmentSsoForAccountDrivenEnrollmentEnabled),
-		"idpUrl":                       llx.StringData(saml.IdpUrl),
-		"idpProviderType":              llx.StringData(saml.IdpProviderType),
-		"groupEnrollmentAccessEnabled": llx.BoolData(info.GroupEnrollmentAccessEnabled),
-		"groupAttributeName":           llx.StringData(saml.GroupAttributeName),
-		"entityId":                     llx.StringData(saml.EntityId),
-	})
-	if err != nil {
-		return nil, err
+		"groupEnrollmentAccessEnabled":                   llx.BoolData(info.GroupEnrollmentAccessEnabled),
 	}
 
-	return res.(*mqlJamfSsoSettings), nil
+	if saml := info.SamlSettings; saml != nil {
+		args["sessionTimeout"] = llx.IntData(saml.SessionTimeout)
+		args["tokenExpirationDisabled"] = llx.BoolData(saml.TokenExpirationDisabled)
+		args["userAttributeEnabled"] = llx.BoolData(saml.UserAttributeEnabled)
+		args["userAttributeName"] = llx.StringData(saml.UserAttributeName)
+		args["userMapping"] = llx.StringData(saml.UserMapping)
+		args["idpUrl"] = llx.StringData(saml.IdpUrl)
+		args["idpProviderType"] = llx.StringData(saml.IdpProviderType)
+		args["groupAttributeName"] = llx.StringData(saml.GroupAttributeName)
+		args["entityId"] = llx.StringData(saml.EntityId)
+	} else {
+		args["sessionTimeout"] = llx.IntDataPtr[int64](nil)
+		args["tokenExpirationDisabled"] = llx.BoolDataPtr(nil)
+		args["userAttributeEnabled"] = llx.BoolDataPtr(nil)
+		args["userAttributeName"] = llx.StringDataPtr(nil)
+		args["userMapping"] = llx.StringDataPtr(nil)
+		args["idpUrl"] = llx.StringDataPtr(nil)
+		args["idpProviderType"] = llx.StringDataPtr(nil)
+		args["groupAttributeName"] = llx.StringDataPtr(nil)
+		args["entityId"] = llx.StringDataPtr(nil)
+	}
+
+	if oidc := info.OidcSettings; oidc != nil {
+		args["oidcUserMapping"] = llx.StringData(oidc.UserMapping)
+		args["oidcJamfIdAuthenticationEnabled"] = llx.BoolDataPtr(oidc.JamfIdAuthenticationEnabled)
+		args["oidcUsernameAttributeClaimMapping"] = llx.StringData(oidc.UsernameAttributeClaimMapping)
+	} else {
+		args["oidcUserMapping"] = llx.StringDataPtr(nil)
+		args["oidcJamfIdAuthenticationEnabled"] = llx.BoolDataPtr(nil)
+		args["oidcUsernameAttributeClaimMapping"] = llx.StringDataPtr(nil)
+	}
+
+	return args
 }

--- a/providers/jamf/resources/sso_settings.go
+++ b/providers/jamf/resources/sso_settings.go
@@ -57,15 +57,15 @@ func ssoSettingsArgs(info *jamfpro.ResourceSsoSettings) map[string]*llx.RawData 
 		args["groupAttributeName"] = llx.StringData(saml.GroupAttributeName)
 		args["entityId"] = llx.StringData(saml.EntityId)
 	} else {
-		args["sessionTimeout"] = llx.IntDataPtr[int64](nil)
-		args["tokenExpirationDisabled"] = llx.BoolDataPtr(nil)
-		args["userAttributeEnabled"] = llx.BoolDataPtr(nil)
-		args["userAttributeName"] = llx.StringDataPtr(nil)
-		args["userMapping"] = llx.StringDataPtr(nil)
-		args["idpUrl"] = llx.StringDataPtr(nil)
-		args["idpProviderType"] = llx.StringDataPtr(nil)
-		args["groupAttributeName"] = llx.StringDataPtr(nil)
-		args["entityId"] = llx.StringDataPtr(nil)
+		args["sessionTimeout"] = llx.NilData
+		args["tokenExpirationDisabled"] = llx.NilData
+		args["userAttributeEnabled"] = llx.NilData
+		args["userAttributeName"] = llx.NilData
+		args["userMapping"] = llx.NilData
+		args["idpUrl"] = llx.NilData
+		args["idpProviderType"] = llx.NilData
+		args["groupAttributeName"] = llx.NilData
+		args["entityId"] = llx.NilData
 	}
 
 	if oidc := info.OidcSettings; oidc != nil {
@@ -73,9 +73,9 @@ func ssoSettingsArgs(info *jamfpro.ResourceSsoSettings) map[string]*llx.RawData 
 		args["oidcJamfIdAuthenticationEnabled"] = llx.BoolDataPtr(oidc.JamfIdAuthenticationEnabled)
 		args["oidcUsernameAttributeClaimMapping"] = llx.StringData(oidc.UsernameAttributeClaimMapping)
 	} else {
-		args["oidcUserMapping"] = llx.StringDataPtr(nil)
-		args["oidcJamfIdAuthenticationEnabled"] = llx.BoolDataPtr(nil)
-		args["oidcUsernameAttributeClaimMapping"] = llx.StringDataPtr(nil)
+		args["oidcUserMapping"] = llx.NilData
+		args["oidcJamfIdAuthenticationEnabled"] = llx.NilData
+		args["oidcUsernameAttributeClaimMapping"] = llx.NilData
 	}
 
 	return args

--- a/providers/jamf/resources/sso_settings_test.go
+++ b/providers/jamf/resources/sso_settings_test.go
@@ -1,0 +1,113 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/types"
+)
+
+// samlFields are populated from SamlSettings; they must be null when the
+// tenant has no SAML config.
+var samlFields = []string{
+	"sessionTimeout",
+	"tokenExpirationDisabled",
+	"userAttributeEnabled",
+	"userAttributeName",
+	"userMapping",
+	"idpUrl",
+	"idpProviderType",
+	"groupAttributeName",
+	"entityId",
+}
+
+// oidcFields are populated from OidcSettings; they must be null when the
+// tenant has no OIDC config.
+var oidcFields = []string{
+	"oidcUserMapping",
+	"oidcJamfIdAuthenticationEnabled",
+	"oidcUsernameAttributeClaimMapping",
+}
+
+func TestSsoSettingsArgs_OidcOnly_NullsOutSamlFields(t *testing.T) {
+	jamfId := true
+	info := &jamfpro.ResourceSsoSettings{
+		SsoEnabled:        true,
+		ConfigurationType: "OIDC",
+		SamlSettings:      nil,
+		OidcSettings: &jamfpro.OidcSettings{
+			UserMapping:                   "EMAIL",
+			JamfIdAuthenticationEnabled:   &jamfId,
+			UsernameAttributeClaimMapping: "preferred_username",
+		},
+	}
+
+	args := ssoSettingsArgs(info)
+
+	assert.Equal(t, "OIDC", args["configurationType"].Value, "configurationType must round-trip")
+	for _, f := range samlFields {
+		assert.Equal(t, types.Nil, args[f].Type,
+			"SAML-derived field %q must be null when SamlSettings is nil — otherwise an OIDC-only tenant looks like a SAML tenant with empty values", f)
+	}
+	assert.Equal(t, "EMAIL", args["oidcUserMapping"].Value)
+	assert.Equal(t, true, args["oidcJamfIdAuthenticationEnabled"].Value)
+	assert.Equal(t, "preferred_username", args["oidcUsernameAttributeClaimMapping"].Value)
+}
+
+func TestSsoSettingsArgs_SamlOnly_NullsOutOidcFields(t *testing.T) {
+	info := &jamfpro.ResourceSsoSettings{
+		SsoEnabled:        true,
+		ConfigurationType: "SAML",
+		OidcSettings:      nil,
+		SamlSettings: &jamfpro.SamlSettings{
+			SessionTimeout:          30,
+			TokenExpirationDisabled: false,
+			UserAttributeEnabled:    true,
+			UserAttributeName:       "uid",
+			UserMapping:             "USERNAME",
+			IdpUrl:                  "https://idp.example.com/saml",
+			IdpProviderType:         "OKTA",
+			GroupAttributeName:      "groups",
+			EntityId:                "jamf-pro",
+		},
+	}
+
+	args := ssoSettingsArgs(info)
+
+	assert.Equal(t, "SAML", args["configurationType"].Value)
+	assert.Equal(t, int64(30), args["sessionTimeout"].Value)
+	assert.Equal(t, "OKTA", args["idpProviderType"].Value)
+	assert.Equal(t, "jamf-pro", args["entityId"].Value)
+	for _, f := range oidcFields {
+		assert.Equal(t, types.Nil, args[f].Type,
+			"OIDC-derived field %q must be null when OidcSettings is nil", f)
+	}
+}
+
+func TestSsoSettingsArgs_BothPresent_PopulatesBoth(t *testing.T) {
+	info := &jamfpro.ResourceSsoSettings{
+		SsoEnabled:        true,
+		ConfigurationType: "OIDC_WITH_SAML",
+		SamlSettings: &jamfpro.SamlSettings{
+			IdpProviderType: "AZURE",
+		},
+		OidcSettings: &jamfpro.OidcSettings{
+			UserMapping: "USERNAME",
+		},
+	}
+
+	args := ssoSettingsArgs(info)
+
+	assert.Equal(t, "OIDC_WITH_SAML", args["configurationType"].Value)
+	assert.Equal(t, "AZURE", args["idpProviderType"].Value)
+	assert.Equal(t, "USERNAME", args["oidcUserMapping"].Value)
+}
+
+func TestSsoSettingsArgs_AlwaysSetsId(t *testing.T) {
+	args := ssoSettingsArgs(&jamfpro.ResourceSsoSettings{})
+	assert.Equal(t, "jamf.ssoSettings", args["__id"].Value)
+}

--- a/providers/jamf/resources/user_by_name.go
+++ b/providers/jamf/resources/user_by_name.go
@@ -27,16 +27,14 @@ func initJamfUserByName(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		return args, nil, nil
 	}
 	name := nameArg.Value.(string)
+	if name == "" {
+		return nil, nil, errors.New("jamf.userByName requires a non-empty name")
+	}
 
 	conn := runtime.Connection.(*connection.JamfConnection)
-	client := conn.Client
-
-	user, err := client.GetUserByName(name)
+	user, err := conn.Client.GetUserByName(name)
 	if err != nil {
 		return nil, nil, err
-	}
-	if user == nil {
-		return nil, nil, errors.New("jamf user not found: " + name)
 	}
 
 	args["__id"] = llx.StringData("jamf.userByName/" + user.Name)

--- a/providers/jamf/resources/user_by_name_test.go
+++ b/providers/jamf/resources/user_by_name_test.go
@@ -1,0 +1,44 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+func TestInitJamfUserByName_BareResourceIsEmptyState(t *testing.T) {
+	// No id, no name → not an error, just an empty resource.
+	args, res, err := initJamfUserByName(nil, map[string]*llx.RawData{})
+	require.NoError(t, err)
+	assert.Nil(t, res)
+	assert.NotNil(t, args)
+}
+
+func TestInitJamfUserByName_EmptyNameIsRejected(t *testing.T) {
+	// Empty string would call /users/name/ on the API, which the user almost
+	// certainly didn't mean. Reject early so we don't fan that out into a
+	// confusing HTTP error.
+	_, _, err := initJamfUserByName(nil, map[string]*llx.RawData{
+		"name": llx.StringData(""),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-empty name")
+}
+
+func TestInitJamfUserByName_IdAlreadyPresentSkipsAPI(t *testing.T) {
+	// runtime is nil — if the function tried to make an API call it would
+	// panic. The point is that pre-hydrated args take the fast path.
+	args := map[string]*llx.RawData{
+		"id":   llx.IntData(int64(42)),
+		"name": llx.StringData("jsmith"),
+	}
+	got, res, err := initJamfUserByName(nil, args)
+	require.NoError(t, err)
+	assert.Nil(t, res)
+	assert.Equal(t, args, got)
+}

--- a/providers/jamf/resources/users.go
+++ b/providers/jamf/resources/users.go
@@ -18,9 +18,6 @@ func (r *mqlJamf) users() ([]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	if users == nil {
-		return nil, nil
-	}
 
 	var res []interface{}
 	for _, u := range users.Users {


### PR DESCRIPTION
## Summary

Bug + perf fixes for the jamf provider, found during an audit.

- **`computerInventoryCount`** previously fetched every inventory record across every page just to call `len()`. A 50k-device fleet was ~500 round-trips and gigabytes of inventory data for a single integer. Now reads `totalCount` from a single `page=0&page-size=1` request.
- **`jamf.sso` was wrong on OIDC-only tenants.** As of `go-api-sdk-jamfpro@v1.47.0`, SAML settings live in an optional `SamlSettings` sub-struct that is `nil` when SSO is OIDC-only. The provider silently zero-filled the SAML fields, so a policy reading `jamf.sso.sessionTimeout < 30` would see `0` and conclude the timeout was too short — when really there was no SAML config at all. Now nulls out fields whose backing sub-struct is nil, exposes `configurationType` so policies can branch, and adds the three OIDC fields that were missing entirely.
- **Inventory pagination** now passes `page-size=500` (was SDK default 100) — 5x fewer round-trips when listing the fleet.
- **`localUserAccounts` lazy fallback** now populates the per-computer cache, so when the same `jamf.computer` is referenced twice it doesn't issue a second by-id call.
- Smaller cleanups: removed unreachable `if x == nil` checks after SDK calls (the SDK always returns `&value, nil` on success), rejected `jamf.userByName(name: "")` instead of letting it hit `/users/name/`, the missing-credentials error now names only the missing pieces, and demoted a per-connect log line from Info to Debug.

## Test plan

- [x] `go test ./providers/jamf/...` — all green, including new tests
- [x] New tests cover: SAML-only / OIDC-only / both-present null-handling in `ssoSettingsArgs`; empty-name guard in `initJamfUserByName`; per-credential missing-credentials error message
- [x] `make providers/build/jamf` succeeds
- [ ] Smoke test against a real Jamf Pro tenant (OIDC-only would be ideal — that's the path that previously returned wrong data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)