### PR TITLE
🐛 gcp: fix sub-resource id collisions from audit pass

### DIFF
--- a/providers/gcp/resources/bigquery.go
+++ b/providers/gcp/resources/bigquery.go
@@ -124,7 +124,7 @@ func (g *mqlGcpProjectBigqueryService) datasets() ([]any, error) {
 		}
 
 		access := make([]any, 0, len(metadata.Access))
-		for i, a := range metadata.Access {
+		for _, a := range metadata.Access {
 			var viewRef any
 			if a.View != nil {
 				viewRef = map[string]any{
@@ -150,7 +150,7 @@ func (g *mqlGcpProjectBigqueryService) datasets() ([]any, error) {
 				}
 			}
 			mqlA, err := CreateResource(g.MqlRuntime, "gcp.project.bigqueryService.dataset.accessEntry", map[string]*llx.RawData{
-				"id":         llx.StringData(fmt.Sprintf("gcp.project.bigqueryService.dataset/%s/%s/accessEntry/%d", projectId, dataset.DatasetID, i)),
+				"id":         llx.StringData(fmt.Sprintf("gcp.project.bigqueryService.dataset/%s/%s/accessEntry/%s/%s/%s", projectId, dataset.DatasetID, a.Role, entityTypeToString(a.EntityType), a.Entity)),
 				"datasetId":  llx.StringData(dataset.DatasetID),
 				"role":       llx.StringData(string(a.Role)),
 				"entityType": llx.StringData(entityTypeToString(a.EntityType)),

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -1562,9 +1562,9 @@ func (g *mqlGcpProjectComputeServiceNetwork) networkPeerings() ([]any, error) {
 	}
 	networkId := g.Id.Data
 	res := make([]any, 0, len(g.cachePeerings))
-	for i, p := range g.cachePeerings {
+	for _, p := range g.cachePeerings {
 		mqlPeering, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.network.peering", map[string]*llx.RawData{
-			"id":                             llx.StringData(fmt.Sprintf("gcloud.compute.network/%s/peering/%d", networkId, i)),
+			"id":                             llx.StringData(fmt.Sprintf("gcloud.compute.network/%s/peering/%s", networkId, p.Name)),
 			"name":                           llx.StringData(p.Name),
 			"networkUrl":                     llx.StringData(p.Network),
 			"state":                          llx.StringData(p.State),
@@ -2295,9 +2295,9 @@ func (g *mqlGcpProjectComputeService) backendServices() ([]any, error) {
 		for _, b := range sb.BackendServices {
 			backendServiceId := strconv.FormatUint(b.Id, 10)
 			mqlBackends := make([]any, 0, len(b.Backends))
-			for i, backend := range b.Backends {
+			for _, backend := range b.Backends {
 				mqlBackend, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.backendService.backend", map[string]*llx.RawData{
-					"id":                        llx.StringData(fmt.Sprintf("gcp.project.computeService.backendService.backend/%s/%d", backendServiceId, i)),
+					"id":                        llx.StringData(fmt.Sprintf("gcp.project.computeService.backendService.backend/%s/%s", backendServiceId, backend.Group)),
 					"balancingMode":             llx.StringData(backend.BalancingMode),
 					"capacityScaler":            llx.FloatData(backend.CapacityScaler),
 					"description":               llx.StringData(backend.Description),

--- a/providers/gcp/resources/dataproc.go
+++ b/providers/gcp/resources/dataproc.go
@@ -495,9 +495,9 @@ func (g *mqlGcpProjectDataprocService) clusters() ([]any, error) {
 					}
 
 					mqlStatusHistory := make([]any, 0, len(c.StatusHistory))
-					for i, s := range c.StatusHistory {
+					for _, s := range c.StatusHistory {
 						mqlHistoryEntry, err := CreateResource(g.MqlRuntime, "gcp.project.dataprocService.cluster.status", map[string]*llx.RawData{
-							"id":       llx.StringData(fmt.Sprintf("%s/dataproc/%s/status/%d", projectId, c.ClusterName, i)),
+							"id":       llx.StringData(fmt.Sprintf("%s/dataproc/%s/status/%s", projectId, c.ClusterName, s.StateStartTime)),
 							"detail":   llx.StringData(s.Detail),
 							"state":    llx.StringData(s.State),
 							"started":  llx.TimeDataPtr(parseTime(s.StateStartTime)),

--- a/providers/gcp/resources/eventarc.go
+++ b/providers/gcp/resources/eventarc.go
@@ -130,7 +130,7 @@ func (g *mqlGcpProjectEventarcService) triggers() ([]any, error) {
 		eventFilters := make([]any, 0, len(trigger.EventFilters))
 		for _, ef := range trigger.EventFilters {
 			mqlEF, err := CreateResource(g.MqlRuntime, "gcp.project.eventarcService.trigger.eventFilter", map[string]*llx.RawData{
-				"id":        llx.StringData(fmt.Sprintf("%s/eventFilters/%s", trigger.Name, ef.Attribute)),
+				"id":        llx.StringData(fmt.Sprintf("%s/eventFilters/%s/%s", trigger.Name, ef.Attribute, ef.Value)),
 				"attribute": llx.StringData(ef.Attribute),
 				"value":     llx.StringData(ef.Value),
 				"operator":  llx.StringData(ef.Operator),

--- a/providers/gcp/resources/eventarc.go
+++ b/providers/gcp/resources/eventarc.go
@@ -128,9 +128,9 @@ func (g *mqlGcpProjectEventarcService) triggers() ([]any, error) {
 		}
 
 		eventFilters := make([]any, 0, len(trigger.EventFilters))
-		for i, ef := range trigger.EventFilters {
+		for _, ef := range trigger.EventFilters {
 			mqlEF, err := CreateResource(g.MqlRuntime, "gcp.project.eventarcService.trigger.eventFilter", map[string]*llx.RawData{
-				"id":        llx.StringData(fmt.Sprintf("%s/eventFilters/%d", trigger.Name, i)),
+				"id":        llx.StringData(fmt.Sprintf("%s/eventFilters/%s", trigger.Name, ef.Attribute)),
 				"attribute": llx.StringData(ef.Attribute),
 				"value":     llx.StringData(ef.Value),
 				"operator":  llx.StringData(ef.Operator),

--- a/providers/gcp/resources/filestore.go
+++ b/providers/gcp/resources/filestore.go
@@ -71,9 +71,9 @@ func (g *mqlGcpProjectFilestoreService) instances() ([]any, error) {
 		}
 
 		fileShares := make([]any, 0, len(instance.FileShares))
-		for i, fs := range instance.FileShares {
+		for _, fs := range instance.FileShares {
 			mqlFs, err := CreateResource(g.MqlRuntime, "gcp.project.filestoreService.instance.fileShare", map[string]*llx.RawData{
-				"id":         llx.StringData(fmt.Sprintf("%s/fileShares/%d", instance.Name, i)),
+				"id":         llx.StringData(fmt.Sprintf("%s/fileShares/%s", instance.Name, fs.Name)),
 				"name":       llx.StringData(fs.Name),
 				"capacityGb": llx.IntData(fs.CapacityGb),
 			})
@@ -84,13 +84,13 @@ func (g *mqlGcpProjectFilestoreService) instances() ([]any, error) {
 		}
 
 		networks := make([]any, 0, len(instance.Networks))
-		for i, net := range instance.Networks {
+		for _, net := range instance.Networks {
 			modes := make([]any, 0, len(net.Modes))
 			for _, m := range net.Modes {
 				modes = append(modes, m.String())
 			}
 			mqlNet, err := CreateResource(g.MqlRuntime, "gcp.project.filestoreService.instance.network", map[string]*llx.RawData{
-				"id":              llx.StringData(fmt.Sprintf("%s/networks/%d", instance.Name, i)),
+				"id":              llx.StringData(fmt.Sprintf("%s/networks/%s", instance.Name, net.Network)),
 				"network":         llx.StringData(net.Network),
 				"modes":           llx.ArrayData(modes, types.String),
 				"ipAddresses":     llx.ArrayData(convert.SliceAnyToInterface(net.IpAddresses), types.String),

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -917,9 +917,9 @@ func createMqlNodePoolConfig(runtime *plugin.Runtime, np *containerpb.NodePool, 
 	}
 
 	nodeTaints := make([]any, 0, len(cfg.Taints))
-	for i, taint := range cfg.Taints {
+	for _, taint := range cfg.Taints {
 		mqlNodeTaint, err := CreateResource(runtime, "gcp.project.gkeService.cluster.nodepool.config.nodeTaint", map[string]*llx.RawData{
-			"id":     llx.StringData(fmt.Sprintf("%s/taints/%d", nodePoolId, i)),
+			"id":     llx.StringData(fmt.Sprintf("%s/taints/%s", nodePoolId, taint.Key)),
 			"key":    llx.StringData(taint.Key),
 			"value":  llx.StringData(taint.Value),
 			"effect": llx.StringData(taint.Effect.String()),

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -919,7 +919,7 @@ func createMqlNodePoolConfig(runtime *plugin.Runtime, np *containerpb.NodePool, 
 	nodeTaints := make([]any, 0, len(cfg.Taints))
 	for _, taint := range cfg.Taints {
 		mqlNodeTaint, err := CreateResource(runtime, "gcp.project.gkeService.cluster.nodepool.config.nodeTaint", map[string]*llx.RawData{
-			"id":     llx.StringData(fmt.Sprintf("%s/taints/%s", nodePoolId, taint.Key)),
+			"id":     llx.StringData(fmt.Sprintf("%s/taints/%s/%s/%s", nodePoolId, taint.Key, taint.Value, taint.Effect.String())),
 			"key":    llx.StringData(taint.Key),
 			"value":  llx.StringData(taint.Value),
 			"effect": llx.StringData(taint.Effect.String()),

--- a/providers/gcp/resources/logging.go
+++ b/providers/gcp/resources/logging.go
@@ -108,9 +108,9 @@ func (g *mqlGcpProjectLoggingservice) buckets() ([]any, error) {
 			}
 
 			indexConfigs := make([]any, 0, len(bucket.IndexConfigs))
-			for i, cfg := range bucket.IndexConfigs {
+			for _, cfg := range bucket.IndexConfigs {
 				mqlIndexConfig, err := CreateResource(g.MqlRuntime, "gcp.project.loggingservice.bucket.indexConfigs", map[string]*llx.RawData{
-					"id":        llx.StringData(fmt.Sprintf("%s/indexConfigs/%d", bucket.Name, i)),
+					"id":        llx.StringData(fmt.Sprintf("%s/indexConfigs/%s", bucket.Name, cfg.FieldPath)),
 					"created":   llx.TimeDataPtr(parseTime(cfg.CreateTime)),
 					"fieldPath": llx.StringData(cfg.FieldPath),
 					"type":      llx.StringData(cfg.Type),

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -208,9 +208,9 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 			}
 
 			mqlIpAddresses := make([]any, 0, len(instance.IpAddresses))
-			for i, a := range instance.IpAddresses {
+			for _, a := range instance.IpAddresses {
 				mqlIpAddress, err := CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.ipMapping", map[string]*llx.RawData{
-					"id":           llx.StringData(fmt.Sprintf("%s/ipAddresses%d", instanceId, i)),
+					"id":           llx.StringData(fmt.Sprintf("%s/ipAddresses/%s", instanceId, a.Type)),
 					"ipAddress":    llx.StringData(a.IpAddress),
 					"timeToRetire": llx.TimeDataPtr(parseTime(a.TimeToRetire)),
 					"type":         llx.StringData(a.Type),
@@ -281,9 +281,9 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 			}
 
 			mqlDenyMaintenancePeriods := make([]any, 0, len(s.DenyMaintenancePeriods))
-			for i, p := range s.DenyMaintenancePeriods {
+			for _, p := range s.DenyMaintenancePeriods {
 				mqlPeriod, err := CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings.denyMaintenancePeriod", map[string]*llx.RawData{
-					"id":        llx.StringData(fmt.Sprintf("%s/settings/denyMaintenancePeriod%d", instanceId, i)),
+					"id":        llx.StringData(fmt.Sprintf("%s/settings/denyMaintenancePeriod/%s", instanceId, p.StartDate)),
 					"endDate":   llx.StringData(p.EndDate),
 					"startDate": llx.StringData(p.StartDate),
 					"time":      llx.StringData(p.Time),

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -210,7 +210,7 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 			mqlIpAddresses := make([]any, 0, len(instance.IpAddresses))
 			for _, a := range instance.IpAddresses {
 				mqlIpAddress, err := CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.ipMapping", map[string]*llx.RawData{
-					"id":           llx.StringData(fmt.Sprintf("%s/ipAddresses/%s", instanceId, a.Type)),
+					"id":           llx.StringData(fmt.Sprintf("%s/ipAddresses/%s/%s", instanceId, a.Type, a.IpAddress)),
 					"ipAddress":    llx.StringData(a.IpAddress),
 					"timeToRetire": llx.TimeDataPtr(parseTime(a.TimeToRetire)),
 					"type":         llx.StringData(a.Type),
@@ -283,7 +283,7 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 			mqlDenyMaintenancePeriods := make([]any, 0, len(s.DenyMaintenancePeriods))
 			for _, p := range s.DenyMaintenancePeriods {
 				mqlPeriod, err := CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings.denyMaintenancePeriod", map[string]*llx.RawData{
-					"id":        llx.StringData(fmt.Sprintf("%s/settings/denyMaintenancePeriod/%s", instanceId, p.StartDate)),
+					"id":        llx.StringData(fmt.Sprintf("%s/settings/denyMaintenancePeriod/%s/%s", instanceId, p.StartDate, p.EndDate)),
 					"endDate":   llx.StringData(p.EndDate),
 					"startDate": llx.StringData(p.StartDate),
 					"time":      llx.StringData(p.Time),


### PR DESCRIPTION
## Summary

Several sub-resource creators used a loop index (`%d`) or a malformed
format string for the `id` field. Because the runtime cache key is
`resourceName + "\x00" + __id`, non-unique IDs cause cache collisions —
later items overwrite earlier ones in shared queries, so users querying
multiple sibling sub-resources (e.g., a network's peerings, a Cloud SQL
instance's IPs, a Filestore instance's file shares) silently get
duplicates / lost rows.

Switched each to a stable, natural key from the API.

## Affected resources

| Resource | Old discriminator | New discriminator |
|---|---|---|
| `gcp.project.computeService.network.peering` | loop index | peering name |
| `gcp.project.computeService.backendService.backend` | loop index | backend group URL |
| `gcp.project.filestoreService.instance.fileShare` | loop index | file share name |
| `gcp.project.filestoreService.instance.network` | loop index | network URL |
| `gcp.project.bigqueryService.dataset.accessEntry` | loop index | role / entityType / entity |
| `gcp.project.loggingservice.bucket.indexConfigs` | loop index | field path |
| `gcp.project.eventarcService.trigger.eventFilter` | loop index | attribute |
| `gcp.project.gkeService.cluster.nodepool.config.nodeTaint` | loop index | taint key |
| `gcp.project.dataprocService.cluster.status` (history) | loop index | state start time |
| `gcp.project.sqlService.instance.ipMapping` | malformed `%s/ipAddresses%d` | `%s/ipAddresses/<type>` |
| `gcp.project.sqlService.instance.settings.denyMaintenancePeriod` | malformed `…denyMaintenancePeriod%d` | `…/denyMaintenancePeriod/<startDate>` |

The two `sql.go` entries had a second bug on top: a missing `/` in the
format string meant adjacent IDs (e.g. `…ipAddresses1` vs `…ipAddresses10`)
were textually adjacent.

## Companion PRs

Same audit-pass shape as the recent #7891 / #7892 / #7893 / #7894.
Separate PR will follow for the compute `AggregatedList` perf wins.

## Test plan

- [ ] `make providers/build/gcp && make providers/install/gcp`
- [ ] `cnspec shell gcp` against a project with a multi-peering network — confirm `gcp.project.computeService.networks[0].peerings { id, name }` returns one row per peering
- [ ] Same shape check for Filestore fileShares & networks on a multi-share instance
- [ ] BigQuery dataset accessEntries on a dataset with several grants
- [ ] Cloud SQL `ipAddresses` and `settings.denyMaintenancePeriods` on a configured instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)