### PR TITLE
🐛 aws: correctness, nil-handling, and pagination fixes from audit pass

### DIFF
--- a/providers/aws/resources/aws_cognito.go
+++ b/providers/aws/resources/aws_cognito.go
@@ -137,10 +137,13 @@ func (a *mqlAwsCognitoUserPool) fetchDescribeUserPool() (*cognitoidentityprovide
 		UserPoolId: &poolId,
 	})
 	if err != nil {
-		log.Warn().Str("userPoolId", poolId).Err(err).Msg("could not describe Cognito user pool")
-		a.descFetched = true
-		a.descData = nil
-		return nil, nil
+		if Is400AccessDeniedError(err) {
+			log.Warn().Str("userPoolId", poolId).Err(err).Msg("access denied describing Cognito user pool")
+			a.descFetched = true
+			a.descData = nil
+			return nil, nil
+		}
+		return nil, err
 	}
 
 	a.descFetched = true

--- a/providers/aws/resources/aws_config.go
+++ b/providers/aws/resources/aws_config.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/configservice"
@@ -518,7 +519,12 @@ func (a *mqlAwsConfigDeliverychannel) deliveryFrequency() (string, error) {
 }
 
 func (a *mqlAwsConfigDeliverychannel) getDeliveryStatus() (*cstypes.DeliveryChannelStatus, error) {
-	if a.cachedDeliveryStatus != nil {
+	if a.deliveryStatusFetched {
+		return a.cachedDeliveryStatus, nil
+	}
+	a.deliveryStatusLock.Lock()
+	defer a.deliveryStatusLock.Unlock()
+	if a.deliveryStatusFetched {
 		return a.cachedDeliveryStatus, nil
 	}
 
@@ -532,15 +538,16 @@ func (a *mqlAwsConfigDeliverychannel) getDeliveryStatus() (*cstypes.DeliveryChan
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
+			a.deliveryStatusFetched = true
 			return nil, nil
 		}
 		return nil, err
 	}
 	if len(resp.DeliveryChannelsStatus) > 0 {
 		a.cachedDeliveryStatus = &resp.DeliveryChannelsStatus[0]
-		return a.cachedDeliveryStatus, nil
 	}
-	return nil, nil
+	a.deliveryStatusFetched = true
+	return a.cachedDeliveryStatus, nil
 }
 
 func (a *mqlAwsConfigDeliverychannel) lastSuccessfulDeliveryTime() (*time.Time, error) {
@@ -579,6 +586,8 @@ func (a *mqlAwsConfigDeliverychannel) lastDeliveryStatus() (string, error) {
 type mqlAwsConfigDeliverychannelInternal struct {
 	cachedDeliveryStatus   *cstypes.DeliveryChannelStatus
 	cacheDeliveryFrequency string
+	deliveryStatusFetched  bool
+	deliveryStatusLock     sync.Mutex
 }
 
 func (a *mqlAwsConfigDeliverychannel) snsTopic() (*mqlAwsSnsTopic, error) {

--- a/providers/aws/resources/aws_controltower.go
+++ b/providers/aws/resources/aws_controltower.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -108,6 +109,9 @@ func (a *mqlAwsControltowerLandingZone) fetchDetail() (*controltower.GetLandingZ
 	})
 	if err != nil {
 		return nil, err
+	}
+	if resp == nil || resp.LandingZone == nil {
+		return nil, fmt.Errorf("get landing zone returned empty response for %q", arn)
 	}
 	a.fetched = true
 	a.detail = resp

--- a/providers/aws/resources/aws_efs.go
+++ b/providers/aws/resources/aws_efs.go
@@ -154,6 +154,9 @@ func initAwsEfsFilesystem(runtime *plugin.Runtime, args map[string]*llx.RawData)
 
 	efs := obj.(*mqlAwsEfs)
 	rawResources := efs.GetFilesystems()
+	if rawResources.Error != nil {
+		return nil, nil, rawResources.Error
+	}
 
 	arnVal := args["arn"].Value.(string)
 	for _, rawResource := range rawResources.Data {

--- a/providers/aws/resources/aws_guardduty.go
+++ b/providers/aws/resources/aws_guardduty.go
@@ -542,41 +542,43 @@ func (a *mqlAwsGuarddutyDetector) ipSets() ([]any, error) {
 	svc := conn.Guardduty(region)
 	ctx := context.Background()
 
-	resp, err := svc.ListIPSets(ctx, &guardduty.ListIPSetsInput{
+	res := []any{}
+	paginator := guardduty.NewListIPSetsPaginator(svc, &guardduty.ListIPSetsInput{
 		DetectorId: &detectorId,
 	})
-	if err != nil {
-		if Is400AccessDeniedError(err) {
-			return []any{}, nil
-		}
-		return nil, err
-	}
-
-	res := []any{}
-	for _, ipSetId := range resp.IpSetIds {
-		detail, err := svc.GetIPSet(ctx, &guardduty.GetIPSetInput{
-			DetectorId: &detectorId,
-			IpSetId:    &ipSetId,
-		})
+	for paginator.HasMorePages() {
+		resp, err := paginator.NextPage(ctx)
 		if err != nil {
-			log.Warn().Err(err).Str("ipSetId", ipSetId).Msg("could not get IP set details")
-			continue
-		}
-
-		mqlIpSet, err := CreateResource(a.MqlRuntime, "aws.guardduty.detector.ipSet",
-			map[string]*llx.RawData{
-				"__id":     llx.StringData(fmt.Sprintf("%s/ipSet/%s", detectorId, ipSetId)),
-				"id":       llx.StringData(ipSetId),
-				"name":     llx.StringDataPtr(detail.Name),
-				"format":   llx.StringData(string(detail.Format)),
-				"location": llx.StringDataPtr(detail.Location),
-				"status":   llx.StringData(string(detail.Status)),
-				"tags":     llx.MapData(convert.MapToInterfaceMap(detail.Tags), mqlTypes.String),
-			})
-		if err != nil {
+			if Is400AccessDeniedError(err) {
+				return []any{}, nil
+			}
 			return nil, err
 		}
-		res = append(res, mqlIpSet)
+		for _, ipSetId := range resp.IpSetIds {
+			detail, err := svc.GetIPSet(ctx, &guardduty.GetIPSetInput{
+				DetectorId: &detectorId,
+				IpSetId:    &ipSetId,
+			})
+			if err != nil {
+				log.Warn().Err(err).Str("ipSetId", ipSetId).Msg("could not get IP set details")
+				continue
+			}
+
+			mqlIpSet, err := CreateResource(a.MqlRuntime, "aws.guardduty.detector.ipSet",
+				map[string]*llx.RawData{
+					"__id":     llx.StringData(fmt.Sprintf("%s/ipSet/%s", detectorId, ipSetId)),
+					"id":       llx.StringData(ipSetId),
+					"name":     llx.StringDataPtr(detail.Name),
+					"format":   llx.StringData(string(detail.Format)),
+					"location": llx.StringDataPtr(detail.Location),
+					"status":   llx.StringData(string(detail.Status)),
+					"tags":     llx.MapData(convert.MapToInterfaceMap(detail.Tags), mqlTypes.String),
+				})
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlIpSet)
+		}
 	}
 	return res, nil
 }
@@ -588,41 +590,43 @@ func (a *mqlAwsGuarddutyDetector) threatIntelSets() ([]any, error) {
 	svc := conn.Guardduty(region)
 	ctx := context.Background()
 
-	resp, err := svc.ListThreatIntelSets(ctx, &guardduty.ListThreatIntelSetsInput{
+	res := []any{}
+	paginator := guardduty.NewListThreatIntelSetsPaginator(svc, &guardduty.ListThreatIntelSetsInput{
 		DetectorId: &detectorId,
 	})
-	if err != nil {
-		if Is400AccessDeniedError(err) {
-			return []any{}, nil
-		}
-		return nil, err
-	}
-
-	res := []any{}
-	for _, tiSetId := range resp.ThreatIntelSetIds {
-		detail, err := svc.GetThreatIntelSet(ctx, &guardduty.GetThreatIntelSetInput{
-			DetectorId:       &detectorId,
-			ThreatIntelSetId: &tiSetId,
-		})
+	for paginator.HasMorePages() {
+		resp, err := paginator.NextPage(ctx)
 		if err != nil {
-			log.Warn().Err(err).Str("threatIntelSetId", tiSetId).Msg("could not get threat intel set details")
-			continue
-		}
-
-		mqlTiSet, err := CreateResource(a.MqlRuntime, "aws.guardduty.detector.threatIntelSet",
-			map[string]*llx.RawData{
-				"__id":     llx.StringData(fmt.Sprintf("%s/threatIntelSet/%s", detectorId, tiSetId)),
-				"id":       llx.StringData(tiSetId),
-				"name":     llx.StringDataPtr(detail.Name),
-				"format":   llx.StringData(string(detail.Format)),
-				"location": llx.StringDataPtr(detail.Location),
-				"status":   llx.StringData(string(detail.Status)),
-				"tags":     llx.MapData(convert.MapToInterfaceMap(detail.Tags), mqlTypes.String),
-			})
-		if err != nil {
+			if Is400AccessDeniedError(err) {
+				return []any{}, nil
+			}
 			return nil, err
 		}
-		res = append(res, mqlTiSet)
+		for _, tiSetId := range resp.ThreatIntelSetIds {
+			detail, err := svc.GetThreatIntelSet(ctx, &guardduty.GetThreatIntelSetInput{
+				DetectorId:       &detectorId,
+				ThreatIntelSetId: &tiSetId,
+			})
+			if err != nil {
+				log.Warn().Err(err).Str("threatIntelSetId", tiSetId).Msg("could not get threat intel set details")
+				continue
+			}
+
+			mqlTiSet, err := CreateResource(a.MqlRuntime, "aws.guardduty.detector.threatIntelSet",
+				map[string]*llx.RawData{
+					"__id":     llx.StringData(fmt.Sprintf("%s/threatIntelSet/%s", detectorId, tiSetId)),
+					"id":       llx.StringData(tiSetId),
+					"name":     llx.StringDataPtr(detail.Name),
+					"format":   llx.StringData(string(detail.Format)),
+					"location": llx.StringDataPtr(detail.Location),
+					"status":   llx.StringData(string(detail.Status)),
+					"tags":     llx.MapData(convert.MapToInterfaceMap(detail.Tags), mqlTypes.String),
+				})
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlTiSet)
+		}
 	}
 	return res, nil
 }

--- a/providers/aws/resources/aws_guardduty.go
+++ b/providers/aws/resources/aws_guardduty.go
@@ -550,7 +550,7 @@ func (a *mqlAwsGuarddutyDetector) ipSets() ([]any, error) {
 		resp, err := paginator.NextPage(ctx)
 		if err != nil {
 			if Is400AccessDeniedError(err) {
-				return []any{}, nil
+				return res, nil
 			}
 			return nil, err
 		}
@@ -598,7 +598,7 @@ func (a *mqlAwsGuarddutyDetector) threatIntelSets() ([]any, error) {
 		resp, err := paginator.NextPage(ctx)
 		if err != nil {
 			if Is400AccessDeniedError(err) {
-				return []any{}, nil
+				return res, nil
 			}
 			return nil, err
 		}

--- a/providers/aws/resources/aws_neptune.go
+++ b/providers/aws/resources/aws_neptune.go
@@ -77,9 +77,6 @@ func (a *mqlAwsNeptune) getDbClusters(conn *connection.AwsConnection) []*jobpool
 					}
 					return nil, err
 				}
-				if len(cluster.DBClusters) == 0 {
-					return nil, nil
-				}
 				for _, cluster := range cluster.DBClusters {
 					mqlCluster, err := newMqlAwsNeptuneCluster(a.MqlRuntime, region, conn.AccountId(), cluster)
 					if err != nil {
@@ -244,9 +241,6 @@ func (a *mqlAwsNeptune) getDbInstances(conn *connection.AwsConnection) []*jobpoo
 						return res, nil
 					}
 					return nil, err
-				}
-				if len(cluster.DBInstances) == 0 {
-					return nil, nil
 				}
 				for _, instance := range cluster.DBInstances {
 					mqlNeptuneInstance, err := newMqlAwsNeptuneInstance(a.MqlRuntime, region, instance)

--- a/providers/aws/resources/aws_networkfirewall.go
+++ b/providers/aws/resources/aws_networkfirewall.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -166,8 +167,10 @@ func (a *mqlAwsNetworkfirewallFirewall) vpc() (*mqlAwsVpc, error) {
 		a.Vpc.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	vpcArn := fmt.Sprintf(vpcArnPattern, a.Region.Data, conn.AccountId(), *a.cacheVpcId)
 	mqlVpc, err := NewResource(a.MqlRuntime, "aws.vpc",
-		map[string]*llx.RawData{"id": llx.StringDataPtr(a.cacheVpcId)})
+		map[string]*llx.RawData{"arn": llx.StringData(vpcArn)})
 	if err != nil {
 		return nil, err
 	}

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -365,6 +365,10 @@ func (a *mqlAwsRds) getPendingMaintenanceActions(conn *connection.AwsConnection)
 			for paginator.HasMorePages() {
 				pendingMaintainanceList, err := paginator.NextPage(ctx)
 				if err != nil {
+					if Is400AccessDeniedError(err) {
+						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
+						return res, nil
+					}
 					return nil, err
 				}
 				for _, resp := range pendingMaintainanceList.PendingMaintenanceActions {

--- a/providers/aws/resources/aws_sqs.go
+++ b/providers/aws/resources/aws_sqs.go
@@ -228,7 +228,6 @@ func (a *mqlAwsSqsQueue) maxReceiveCount() (int64, error) {
 	if c == "" {
 		return 0, nil
 	}
-	log.Info().Msgf("redrive %v", c)
 	var r redrivePolicy
 	err = json.Unmarshal([]byte(c), &r)
 	if err != nil {

--- a/providers/aws/resources/aws_ssm.go
+++ b/providers/aws/resources/aws_ssm.go
@@ -101,7 +101,9 @@ func (a *mqlAwsSsm) getParameters(conn *connection.AwsConnection) []*jobpool.Job
 					if err != nil {
 						return nil, err
 					}
-					mqlParam.(*mqlAwsSsmParameter).parameterCache = param
+					mqlSsmParam := mqlParam.(*mqlAwsSsmParameter)
+					mqlSsmParam.parameterCache = param
+					mqlSsmParam.region = region
 					res = append(res, mqlParam)
 				}
 			}

--- a/providers/aws/resources/aws_ssm_documents.go
+++ b/providers/aws/resources/aws_ssm_documents.go
@@ -182,8 +182,9 @@ func (a *mqlAwsSsmDocument) content() (string, error) {
 		return "", err
 	}
 
+	a.Content = plugin.TValue[string]{Data: convert.ToValue(resp.Content), State: plugin.StateIsSet}
 	a.contentFetched = true
-	return convert.ToValue(resp.Content), nil
+	return a.Content.Data, nil
 }
 
 func (a *mqlAwsSsmDocument) permissions() ([]any, error) {

--- a/providers/aws/resources/aws_timestream.go
+++ b/providers/aws/resources/aws_timestream.go
@@ -85,9 +85,6 @@ func (a *mqlAwsTimestreamLiveanalytics) getDatabases(conn *connection.AwsConnect
 					}
 					return nil, err
 				}
-				if len(resp.Databases) == 0 {
-					return nil, nil
-				}
 				for _, database := range resp.Databases {
 					mqlCluster, err := CreateResource(a.MqlRuntime, "aws.timestream.liveanalytics.database",
 						map[string]*llx.RawData{
@@ -201,9 +198,6 @@ func (a *mqlAwsTimestreamLiveanalytics) getTables(conn *connection.AwsConnection
 						return res, nil
 					}
 					return nil, err
-				}
-				if len(resp.Tables) == 0 {
-					return nil, nil
 				}
 				for _, table := range resp.Tables {
 					magneticStoreProperties, _ := convert.JsonToDictSlice(table.MagneticStoreWriteProperties)

--- a/providers/aws/resources/aws_transfer.go
+++ b/providers/aws/resources/aws_transfer.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/service/transfer"
@@ -123,6 +124,9 @@ func (a *mqlAwsTransferServer) fetchDetail() (*transfer.DescribeServerOutput, er
 	})
 	if err != nil {
 		return nil, err
+	}
+	if resp == nil || resp.Server == nil {
+		return nil, fmt.Errorf("describe server returned empty response for %q", serverId)
 	}
 	a.fetched = true
 	a.descResp = resp

--- a/providers/aws/resources/aws_workspaces.go
+++ b/providers/aws/resources/aws_workspaces.go
@@ -145,6 +145,9 @@ func (a *mqlAwsWorkspacesDirectory) tags() (map[string]any, error) {
 		ResourceId: &a.DirectoryId.Data,
 	})
 	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	tags := make(map[string]any)
@@ -258,6 +261,9 @@ func (a *mqlAwsWorkspacesWorkspace) tags() (map[string]any, error) {
 		ResourceId: &a.WorkspaceId.Data,
 	})
 	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	tags := make(map[string]any)


### PR DESCRIPTION
## Summary

A second audit pass over the AWS provider surfaced a batch of correctness bugs that silently broke fields or accessors. None of these are individually large, but each one would show up as "field is empty / wrong / panics" in real queries.

**Silent failures and wrong-data bugs**
- `aws.ssm.parameter.kmsKey()` built the KMS ARN with an empty region segment because the parameter's \`region\` field on the Internal struct was declared but never assigned during listing. The resulting ARN (\`arn:aws:kms::acct:key/…\`) is invalid, so every parameter's KMS key reference resolved to an error.
- `aws.ssm.document.content()` set its cache flag but never wrote the fetched content to \`a.Content.Data\`, so the second call always returned \`""\`.
- `aws.neptune.*` and `aws.timestream.*` paginator loops did \`if len(page.X) == 0 { return nil, nil }\`, which exits the whole function on the first empty page — items on later pages were dropped.
- \`initAwsEfsFilesystem\` ranged over \`rawResources.Data\` without checking \`rawResources.Error\`, so a failed list surfaced as the generic "efs filesystem does not exist" instead of the real error.
- \`aws.sqs.queue.maxReceiveCount\` had a leftover \`log.Info().Msgf("redrive %v", c)\` that fired on every accessor call.

**Missing access-denied / error handling**
- \`aws.workspaces.directory.tags()\` and \`aws.workspaces.workspace.tags()\` surfaced any \`DescribeTags\` error to the caller. Added the standard \`Is400AccessDeniedError\` guard.
- \`aws.rds.allPendingMaintenanceActions\` paginator was missing the same guard that every other RDS paginator has.
- \`aws.cognito.userPool.fetchDescribeUserPool\` swallowed **all** errors as \`nil, nil\`, masking throttling and transient failures across 10+ accessors. Now only access-denied is swallowed; other errors propagate.

**Nil-pointer dereferences**
- \`aws.transfer.server\` and \`aws.controltower.landingZone\` accessors unconditionally dereferenced \`resp.Server\` / \`resp.LandingZone\`. Both \`fetchDetail\` helpers now guard against nil before caching.

**Concurrency / cache correctness**
- \`aws.config.deliverychannel.getDeliveryStatus()\` had no mutex; three concurrent field accessors racing on \`cachedDeliveryStatus\` would trip the race detector and double/triple the API calls. Added the standard \`fetched bool\` + \`sync.Mutex\` double-check pattern, also caching access-denied so we don't re-issue the call.

**VPC reference resolution**
- \`aws.networkfirewall.firewall.vpc()\` resolved the VPC by \`id\` rather than constructing the canonical ARN. Switched to the \`vpcArnPattern\`-based lookup that lambda, fsx, directoryservice, and the other typed-ref accessors use.

**Pagination gaps**
- \`aws.guardduty.detector.ipSets\` and \`threatIntelSets\` called \`ListIPSets\` / \`ListThreatIntelSets\` without pagination — default page size is 25, so larger accounts silently lost entries. Both now use \`NewListIPSetsPaginator\` / \`NewListThreatIntelSetsPaginator\`.

## Test plan

- [ ] \`go build ./...\` from \`providers/aws\` (passes locally)
- [ ] \`go vet ./resources/...\` (clean locally)
- [ ] \`mql run aws -c "aws.ssm.parameters { kmsKey }"\` resolves the KMS key (was an empty ARN before)
- [ ] \`mql run aws -c "aws.ssm.documents { content }"\` returns content on repeat queries (was \`""\` before)
- [ ] Spot-check workspaces tags in an account without \`workspaces:DescribeTags\` — no hard error
- [ ] Spot-check guardduty in an account with > 25 IP sets / threat-intel sets — all returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)