### PR TITLE
🐛 kustomize: init selector, discovery hardening, replacement race fix

### DIFF
--- a/providers/kustomize/connection/connection.go
+++ b/providers/kustomize/connection/connection.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
@@ -38,6 +39,10 @@ type KustomizationEntry struct {
 }
 
 func NewKustomizeConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*KustomizeConnection, error) {
+	if asset == nil || len(asset.Connections) == 0 {
+		return nil, errors.New("kustomize provider requires an asset with at least one connection")
+	}
+
 	conn := &KustomizeConnection{
 		Connection: plugin.NewConnection(id, asset),
 		Conf:       conf,
@@ -51,12 +56,15 @@ func NewKustomizeConnection(id uint32, asset *inventory.Asset, conf *inventory.C
 	}
 	conn.path = filepath.Clean(kustomizePath)
 
-	entries, err := loadKustomizations(kustomizePath)
+	// Discover from the cleaned path so entry.Path matches conn.path and
+	// downstream cache keys (kustomize.kustomization:<path>) are stable
+	// across "./foo" vs "./foo/" inputs.
+	entries, err := loadKustomizations(conn.path)
 	if err != nil {
 		return nil, err
 	}
 	if len(entries) == 0 {
-		return nil, errors.New("no kustomization.yaml found at " + kustomizePath)
+		return nil, errors.New("no kustomization.yaml found at " + conn.path)
 	}
 	conn.kustomizations = entries
 
@@ -84,6 +92,17 @@ var kustomizationFilenames = []string{
 	"kustomization.yaml",
 	"kustomization.yml",
 	"Kustomization",
+}
+
+// scanSkipDirs are subdir names that should not be scanned during
+// kustomization discovery. Hidden dirs (starting with `.`) are also
+// skipped — they're handled separately via the prefix check.
+var scanSkipDirs = map[string]struct{}{
+	"node_modules": {},
+	"vendor":       {},
+	"target":       {},
+	"dist":         {},
+	"build":        {},
 }
 
 // loadKustomizations finds and parses kustomization files from a path.
@@ -120,7 +139,18 @@ func loadKustomizations(kustomizePath string) ([]*KustomizationEntry, error) {
 		if !de.IsDir() {
 			continue
 		}
-		subPath := filepath.Join(kustomizePath, de.Name())
+		name := de.Name()
+		// Skip hidden dirs (.git, .terraform, .idea, etc.) and a
+		// short skip-list of well-known noise dirs. A misconfigured
+		// path on a repo root would otherwise spend file handles on
+		// directories that can't contain a kustomization.
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		if _, skip := scanSkipDirs[name]; skip {
+			continue
+		}
+		subPath := filepath.Join(kustomizePath, name)
 		entry, err := loadSingleKustomization(subPath)
 		if err == nil {
 			entries = append(entries, entry)
@@ -146,13 +176,13 @@ func loadSingleKustomization(dir string) (*KustomizationEntry, error) {
 			continue
 		}
 
-		var k types.Kustomization
+		k := &types.Kustomization{}
 		if err := k.Unmarshal(data); err != nil {
 			return nil, err
 		}
 		return &KustomizationEntry{
 			Path:          dir,
-			Kustomization: &k,
+			Kustomization: k,
 		}, nil
 	}
 

--- a/providers/kustomize/connection/connection_test.go
+++ b/providers/kustomize/connection/connection_test.go
@@ -5,10 +5,13 @@ package connection
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 )
 
 // A directory with a kustomization.yaml that fails YAML parsing used
@@ -37,4 +40,80 @@ func TestLoadKustomizations_BasicFixtureStillWorks(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, entries, 1)
 	assert.Equal(t, "../testdata/basic", entries[0].Path)
+}
+
+// NewKustomizeConnection used to deref asset.Connections[0] unconditionally;
+// passing a nil asset or one with no connections now produces a clear error
+// instead of a runtime panic.
+func TestNewKustomizeConnection_NilAssetRejected(t *testing.T) {
+	_, err := NewKustomizeConnection(0, nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one connection")
+}
+
+func TestNewKustomizeConnection_NoConnectionsRejected(t *testing.T) {
+	_, err := NewKustomizeConnection(0, &inventory.Asset{}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one connection")
+}
+
+// The cleaned-path discovery means entry.Path always matches conn.Path()
+// regardless of whether the caller passes "./foo", "./foo/", or "foo".
+func TestNewKustomizeConnection_PathIsCleaned(t *testing.T) {
+	cases := []string{
+		"../testdata/basic",
+		"../testdata/basic/",
+		"./../testdata/basic",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			conn, err := NewKustomizeConnection(0, &inventory.Asset{
+				Connections: []*inventory.Config{
+					{Options: map[string]string{"path": in}},
+				},
+			}, nil)
+			require.NoError(t, err)
+			require.Len(t, conn.Kustomizations(), 1)
+			// conn.Path() and the entry path should always agree —
+			// they're both derived from the same cleaned input.
+			assert.Equal(t, conn.Path(), conn.Kustomizations()[0].Path,
+				"entry.Path must equal conn.Path() to keep cache keys stable")
+		})
+	}
+}
+
+// Subdir scan must skip hidden dirs (.git, .terraform) and a short list of
+// well-known noise dirs (node_modules, vendor, …). A misconfigured path at
+// a repo root would otherwise spend file handles on dirs that can't
+// contain a kustomization.
+func TestLoadKustomizations_SkipsHiddenAndNoiseDirs(t *testing.T) {
+	tmp := t.TempDir()
+	// Put no kustomization in the root so we trigger the subdir scan.
+	require.NoError(t, os.MkdirAll(filepath.Join(tmp, ".git"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(tmp, "node_modules"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(tmp, "vendor"), 0o755))
+	// Put a malformed kustomization.yaml in each — if the scan visited
+	// them, the warn log would fire. We can't assert log output directly,
+	// but we can assert the scan returns cleanly (no entries) without
+	// inspecting these dirs.
+	bad := []byte("not: [valid: yaml")
+	for _, name := range []string{".git", "node_modules", "vendor"} {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(tmp, name, "kustomization.yaml"),
+			bad, 0o644))
+	}
+
+	// Add one legitimate subdir with a real kustomization so the scan
+	// has something to find — proves the skip-list only filters noise.
+	realDir := filepath.Join(tmp, "real")
+	require.NoError(t, os.MkdirAll(realDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(realDir, "kustomization.yaml"),
+		[]byte("apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\n"),
+		0o644))
+
+	entries, err := loadKustomizations(tmp)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "only the real subdir should be discovered")
+	assert.Equal(t, realDir, entries[0].Path)
 }

--- a/providers/kustomize/provider/provider_test.go
+++ b/providers/kustomize/provider/provider_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
@@ -417,4 +418,69 @@ func TestConnect_MalformedKustomizationSurfaces(t *testing.T) {
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "no kustomization.yaml found",
 		"a parse error must not be reported as 'no kustomization found'")
+}
+
+// initKustomizeKustomization lets users select a specific kustomization
+// by path (`kustomize.kustomization(path: "...")`) without first walking
+// `kustomize.kustomizations`. The resource it returns must have Internal
+// state populated so the field accessors (patches, images, replacements,
+// resources) work — previously they would nil-deref on a bare resource.
+func TestInitKustomizeKustomization_SelectorWorks(t *testing.T) {
+	srv, resp := newTestService("../testdata/multi-overlay")
+
+	createResp, err := srv.GetData(&plugin.DataReq{
+		Connection: resp.Id,
+		Resource:   "kustomize.kustomization",
+		Args: map[string]*llx.Primitive{
+			"path": llx.StringPrimitive("../testdata/multi-overlay/staging"),
+		},
+	})
+	require.NoError(t, err)
+	require.Empty(t, createResp.Error)
+	require.NotNil(t, createResp.Data)
+	kID := string(createResp.Data.Value)
+	require.NotEmpty(t, kID)
+
+	// The path field works (proves args were stamped).
+	pathResp := getData(t, srv, resp.Id, "kustomize.kustomization", kID, "path")
+	assert.Equal(t, "../testdata/multi-overlay/staging", string(pathResp.Data.Value))
+
+	// And — the regression we care about — a computed field that depends
+	// on Internal state (k.kustomization) resolves rather than panicking.
+	patchesResp := getData(t, srv, resp.Id, "kustomize.kustomization", kID, "patches")
+	require.NotNil(t, patchesResp.Data)
+
+	nsResp := getData(t, srv, resp.Id, "kustomize.kustomization", kID, "namespace")
+	assert.Equal(t, "staging", string(nsResp.Data.Value))
+}
+
+// A selector for a path the connection didn't load returns a bare resource
+// (matching the project's "bare resource is a valid empty state" rule);
+// computed field accessors then surface a clear error instead of panicking.
+func TestInitKustomizeKustomization_UnknownPathFieldsErrorCleanly(t *testing.T) {
+	srv, resp := newTestService("../testdata/basic")
+
+	createResp, err := srv.GetData(&plugin.DataReq{
+		Connection: resp.Id,
+		Resource:   "kustomize.kustomization",
+		Args: map[string]*llx.Primitive{
+			"path": llx.StringPrimitive("/does/not/exist"),
+		},
+	})
+	require.NoError(t, err)
+	require.Empty(t, createResp.Error)
+	kID := string(createResp.Data.Value)
+	require.NotEmpty(t, kID)
+
+	// Computed accessor that depends on Internal state should error
+	// (with a friendly message), not panic.
+	resp2, err := srv.GetData(&plugin.DataReq{
+		Connection: resp.Id,
+		Resource:   "kustomize.kustomization",
+		ResourceId: kID,
+		Field:      "patches",
+	})
+	require.NoError(t, err, "transport call must not fail")
+	assert.NotEmpty(t, resp2.Error, "unknown path should surface as a field error")
+	assert.Contains(t, resp2.Error, "no kustomization loaded")
 }

--- a/providers/kustomize/resources/kustomize.go
+++ b/providers/kustomize/resources/kustomize.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"errors"
 	"sync"
 
 	"go.mondoo.com/mql/v13/llx"
@@ -47,6 +48,9 @@ type mqlKustomizeKustomizationInternal struct {
 }
 
 func newMqlKustomization(runtime *plugin.Runtime, entry *connection.KustomizationEntry) (*mqlKustomizeKustomization, error) {
+	if entry == nil || entry.Kustomization == nil {
+		return nil, errors.New("kustomize: entry has no parsed kustomization")
+	}
 	k := entry.Kustomization
 
 	commonLabels := make(map[string]any, len(k.CommonLabels))
@@ -89,14 +93,82 @@ func newMqlKustomization(runtime *plugin.Runtime, entry *connection.Kustomizatio
 	return mqlK, nil
 }
 
+// initKustomizeKustomization handles selector-style lookups
+// (`kustomize.kustomization(path: "...")`). It locates the matching entry
+// on the connection and routes through newMqlKustomization so Internal
+// state stays populated — without this, field accessors would nil-deref
+// on a bare resource constructed only from the `path` arg.
+//
+// Returning `args, nil, nil` for an unknown / empty path matches the
+// "bare resource is a valid empty state" convention used elsewhere in
+// this repo; callers see a resource that satisfies the type but yields
+// errors from the accessors.
+func initKustomizeKustomization(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) == 0 {
+		return args, nil, nil
+	}
+	pathArg, ok := args["path"]
+	if !ok || pathArg == nil {
+		return args, nil, nil
+	}
+	path, _ := pathArg.Value.(string)
+	if path == "" {
+		return args, nil, nil
+	}
+
+	conn, ok := runtime.Connection.(*connection.KustomizeConnection)
+	if !ok {
+		return args, nil, nil
+	}
+	for _, entry := range conn.Kustomizations() {
+		if entry.Path == path {
+			mqlK, err := newMqlKustomization(runtime, entry)
+			if err != nil {
+				return nil, nil, err
+			}
+			return args, mqlK, nil
+		}
+	}
+	return args, nil, nil
+}
+
 func (k *mqlKustomizeKustomization) id() (string, error) {
 	return "kustomize.kustomization:" + k.Path.Data, nil
 }
 
+// resolveEntry returns the parsed kustomization, repopulating Internal
+// state from the connection when needed (e.g., when the resource was
+// constructed without going through newMqlKustomization). Each accessor
+// calls this first instead of dereferencing k.kustomization directly.
+func (k *mqlKustomizeKustomization) resolveEntry() (*kustomizeTypes.Kustomization, string, error) {
+	if k.kustomization != nil {
+		return k.kustomization, k.kustPath, nil
+	}
+	conn, ok := k.MqlRuntime.Connection.(*connection.KustomizeConnection)
+	if !ok {
+		return nil, "", errors.New("kustomize: connection is not a KustomizeConnection")
+	}
+	path := k.Path.Data
+	for _, entry := range conn.Kustomizations() {
+		if entry.Path == path {
+			k.stampOnce.Do(func() {
+				k.kustomization = entry.Kustomization
+				k.kustPath = entry.Path
+			})
+			return k.kustomization, k.kustPath, nil
+		}
+	}
+	return nil, "", errors.New("kustomize: no kustomization loaded for path " + path)
+}
+
 func (k *mqlKustomizeKustomization) patches() ([]any, error) {
+	kust, kustPath, err := k.resolveEntry()
+	if err != nil {
+		return nil, err
+	}
 	var mqlPatches []any
-	for i, p := range k.kustomization.Patches {
-		mqlP, err := newMqlKustomizePatch(k.MqlRuntime, k.kustPath, i, &p)
+	for i, p := range kust.Patches {
+		mqlP, err := newMqlKustomizePatch(k.MqlRuntime, kustPath, i, &p)
 		if err != nil {
 			return nil, err
 		}
@@ -106,17 +178,29 @@ func (k *mqlKustomizeKustomization) patches() ([]any, error) {
 }
 
 func (k *mqlKustomizeKustomization) configMapGenerators() ([]any, error) {
-	return newMqlConfigMapGenerators(k.MqlRuntime, k.kustPath, k.kustomization.ConfigMapGenerator)
+	kust, kustPath, err := k.resolveEntry()
+	if err != nil {
+		return nil, err
+	}
+	return newMqlConfigMapGenerators(k.MqlRuntime, kustPath, kust.ConfigMapGenerator)
 }
 
 func (k *mqlKustomizeKustomization) secretGenerators() ([]any, error) {
-	return newMqlSecretGenerators(k.MqlRuntime, k.kustPath, k.kustomization.SecretGenerator)
+	kust, kustPath, err := k.resolveEntry()
+	if err != nil {
+		return nil, err
+	}
+	return newMqlSecretGenerators(k.MqlRuntime, kustPath, kust.SecretGenerator)
 }
 
 func (k *mqlKustomizeKustomization) images() ([]any, error) {
+	kust, kustPath, err := k.resolveEntry()
+	if err != nil {
+		return nil, err
+	}
 	var mqlImages []any
-	for _, img := range k.kustomization.Images {
-		mqlImg, err := newMqlKustomizeImage(k.MqlRuntime, k.kustPath, img)
+	for _, img := range kust.Images {
+		mqlImg, err := newMqlKustomizeImage(k.MqlRuntime, kustPath, img)
 		if err != nil {
 			return nil, err
 		}
@@ -126,9 +210,13 @@ func (k *mqlKustomizeKustomization) images() ([]any, error) {
 }
 
 func (k *mqlKustomizeKustomization) replacements() ([]any, error) {
+	kust, kustPath, err := k.resolveEntry()
+	if err != nil {
+		return nil, err
+	}
 	var mqlReplacements []any
-	for i, r := range k.kustomization.Replacements {
-		mqlR, err := newMqlKustomizeReplacement(k.MqlRuntime, k.kustPath, i, &r)
+	for i, r := range kust.Replacements {
+		mqlR, err := newMqlKustomizeReplacement(k.MqlRuntime, kustPath, i, &r)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/kustomize/resources/kustomize.lr.go
+++ b/providers/kustomize/resources/kustomize.lr.go
@@ -34,7 +34,7 @@ func init() {
 			Create: createKustomize,
 		},
 		"kustomize.kustomization": {
-			// to override args, implement: initKustomizeKustomization(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initKustomizeKustomization,
 			Create: createKustomizeKustomization,
 		},
 		"kustomize.patch": {

--- a/providers/kustomize/resources/replacement.go
+++ b/providers/kustomize/resources/replacement.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"strconv"
+	"sync"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -14,6 +15,11 @@ import (
 type mqlKustomizeReplacementInternal struct {
 	replacementTargets []*kustomizeTypes.TargetSelector
 	kustPath           string
+	// stampOnce guards the post-construction Internal-field write.
+	// CreateResource can return a cached instance to concurrent callers
+	// with the same __id; stampOnce keeps the write race-free under those
+	// goroutines and matches the pattern in newMqlKustomization.
+	stampOnce sync.Once
 }
 
 func newMqlKustomizeReplacement(runtime *plugin.Runtime, kustPath string, index int, r *kustomizeTypes.ReplacementField) (*mqlKustomizeReplacement, error) {
@@ -40,8 +46,10 @@ func newMqlKustomizeReplacement(runtime *plugin.Runtime, kustPath string, index 
 	}
 
 	mqlR := res.(*mqlKustomizeReplacement)
-	mqlR.kustPath = kustPath
-	mqlR.replacementTargets = r.Targets
+	mqlR.stampOnce.Do(func() {
+		mqlR.kustPath = kustPath
+		mqlR.replacementTargets = r.Targets
+	})
 	return mqlR, nil
 }
 

--- a/providers/kustomize/resources/resource.go
+++ b/providers/kustomize/resources/resource.go
@@ -39,6 +39,12 @@ func (k *mqlKustomizeKustomization) resources() ([]any, error) {
 }
 
 func (k *mqlKustomizeKustomization) fetchRendered() ([]map[string]any, error) {
+	// Trigger the same lazy-resolve path as the other accessors so the
+	// rendered fetch works on resources constructed via init (no Internal
+	// state set yet).
+	if _, _, err := k.resolveEntry(); err != nil {
+		return nil, err
+	}
 	k.renderedOnce.Do(func() {
 		fSys := filesys.MakeFsOnDisk()
 		kustomizer := krusty.MakeKustomizer(krusty.MakeDefaultOptions())


### PR DESCRIPTION
## Summary

Deeper follow-up to the kustomize audit (#7878). That PR caught the obvious nil-derefs; this PR addresses a few correctness and robustness gaps that surfaced on a re-read.

- **`kustomize.kustomization(path: …)` works as a selector.** Added `initKustomizeKustomization` + a lazy `resolveEntry` helper so the computed fields (`patches`, `images`, `replacements`, `resources`, `configMapGenerators`, `secretGenerators`) repopulate Internal state from the connection on demand. Previously, any path that produced a bare resource (selector lookup, or any future reconstitution path) would nil-deref on `k.kustomization.Patches`.
- **`replacement.go` write race.** `newMqlKustomizeReplacement` did a post-`CreateResource` Internal-field write without the `sync.Once` guard that `newMqlKustomization` already uses for the same situation. Adding `stampOnce` makes the two consistent and removes the race-detector flag under concurrent callers with the same `__id`.
- **Path-cleaning stability.** `loadKustomizations` is now called with `conn.path` (the cleaned form) instead of the raw option value, so `entry.Path` matches `conn.Path()` for `./foo`, `./foo/`, and `foo` — keeping the `kustomize.kustomization:<path>` cache key stable.
- **Skip-list on subdir discovery.** Hidden dirs (`.git`, `.terraform`, …) and a short list of well-known noise dirs (`node_modules`, `vendor`, `target`, `dist`, `build`) are skipped during the one-level subdir scan. A user who mis-points the provider at a repo root no longer spends file handles on dirs that can't contain a kustomization.
- **`NewKustomizeConnection` nil-asset guard.** Used to deref `asset.Connections[0]` unconditionally; now returns a clear error for `nil` asset / empty `Connections`.

Deferred to a follow-up (out of scope here): the triple-materialization in `fetchRendered` (`resMap` → `map[string]any` → `dict`), a `kustomizer.Run` timeout for overlays that pull remote bases, and parallel rendering across multiple kustomizations.

## Test plan

- [x] `go test -race -count=1 ./...` in `providers/kustomize` (all packages green)
- [x] New tests cover: init selector + computed-field roundtrip, init for unknown path surfaces a clean field error, path cleaning across `./foo` / `./foo/` / `foo`, skip-list against `.git` / `node_modules` / `vendor`, nil-asset and empty-Connections guards
- [ ] Smoke: \`make providers/build/kustomize && make providers/install/kustomize\` then \`mql shell kustomize ./<some-overlay>\` (left to the reviewer; CI exercises the build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)