### PR TITLE
✨ gcp/bigquery: add dataset externalDatasetReference field

### DIFF
--- a/providers/gcp/resources/bigquery.go
+++ b/providers/gcp/resources/bigquery.go
@@ -123,6 +123,14 @@ func (g *mqlGcpProjectBigqueryService) datasets() ([]any, error) {
 			kmsName = metadata.DefaultEncryptionConfig.KMSKeyName
 		}
 
+		var externalDatasetReference any
+		if metadata.ExternalDatasetReference != nil {
+			externalDatasetReference = map[string]any{
+				"externalSource": metadata.ExternalDatasetReference.ExternalSource,
+				"connection":     metadata.ExternalDatasetReference.Connection,
+			}
+		}
+
 		access := make([]any, 0, len(metadata.Access))
 		for _, a := range metadata.Access {
 			var viewRef any
@@ -183,6 +191,7 @@ func (g *mqlGcpProjectBigqueryService) datasets() ([]any, error) {
 			"defaultCollation":             llx.StringData(metadata.DefaultCollation),
 			"defaultPartitionExpirationMs": llx.IntData(metadata.DefaultPartitionExpiration.Milliseconds()),
 			"isCaseInsensitive":            llx.BoolData(metadata.IsCaseInsensitive),
+			"externalDatasetReference":     llx.DictData(externalDatasetReference),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -2750,6 +2750,15 @@ private gcp.project.bigqueryService.dataset @defaults("id name") {
   defaultPartitionExpirationMs int
   // Whether field names are treated as case insensitive
   isCaseInsensitive bool
+  // External source backing this dataset
+  //
+  // For externally defined datasets (for example BigLake or Iceberg
+  // tables federated through AWS Glue), this dict has two keys:
+  // `externalSource` is the URI of the upstream system that backs the
+  // dataset, and `connection` is the Cloud connection used to reach it
+  // in the form `projects/{project_id}/locations/{location_id}/connections/{connection_id}`.
+  // Null for datasets stored natively in BigQuery.
+  externalDatasetReference dict
 }
 
 // Google Cloud (GCP) BigQuery dataset access entry

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -5122,6 +5122,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.bigqueryService.dataset.isCaseInsensitive": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigqueryServiceDataset).GetIsCaseInsensitive()).ToDataRes(types.Bool)
 	},
+	"gcp.project.bigqueryService.dataset.externalDatasetReference": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBigqueryServiceDataset).GetExternalDatasetReference()).ToDataRes(types.Dict)
+	},
 	"gcp.project.bigqueryService.dataset.accessEntry.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigqueryServiceDatasetAccessEntry).GetId()).ToDataRes(types.String)
 	},
@@ -18777,6 +18780,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.bigqueryService.dataset.isCaseInsensitive": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectBigqueryServiceDataset).IsCaseInsensitive, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.bigqueryService.dataset.externalDatasetReference": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBigqueryServiceDataset).ExternalDatasetReference, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.bigqueryService.dataset.accessEntry.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -42913,6 +42920,7 @@ type mqlGcpProjectBigqueryServiceDataset struct {
 	DefaultCollation             plugin.TValue[string]
 	DefaultPartitionExpirationMs plugin.TValue[int64]
 	IsCaseInsensitive            plugin.TValue[bool]
+	ExternalDatasetReference     plugin.TValue[any]
 }
 
 // createGcpProjectBigqueryServiceDataset creates a new instance of this resource
@@ -43088,6 +43096,10 @@ func (c *mqlGcpProjectBigqueryServiceDataset) GetDefaultPartitionExpirationMs() 
 
 func (c *mqlGcpProjectBigqueryServiceDataset) GetIsCaseInsensitive() *plugin.TValue[bool] {
 	return &c.IsCaseInsensitive
+}
+
+func (c *mqlGcpProjectBigqueryServiceDataset) GetExternalDatasetReference() *plugin.TValue[any] {
+	return &c.ExternalDatasetReference
 }
 
 // mqlGcpProjectBigqueryServiceDatasetAccessEntry for the gcp.project.bigqueryService.dataset.accessEntry resource

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -551,6 +551,7 @@ gcp.project.bigqueryService.dataset.defaultCollation 13.1.2
 gcp.project.bigqueryService.dataset.defaultPartitionExpirationMs 13.1.2
 gcp.project.bigqueryService.dataset.defaultTableExpirationMs 11.6.6
 gcp.project.bigqueryService.dataset.description 9.0.0
+gcp.project.bigqueryService.dataset.externalDatasetReference 13.16.3
 gcp.project.bigqueryService.dataset.id 9.0.0
 gcp.project.bigqueryService.dataset.isCaseInsensitive 13.1.2
 gcp.project.bigqueryService.dataset.kmsKey 13.12.2


### PR DESCRIPTION
## Summary

Adds the `externalDatasetReference` dict field to `gcp.project.bigqueryService.dataset`. The dict exposes `externalSource` (the URI of the upstream system that backs the dataset) and `connection` (the Cloud connection used to reach it), surfaced from `DatasetMetadata.ExternalDatasetReference` in the `cloud.google.com/go/bigquery` client. The value is null for datasets stored natively in BigQuery.

This lets data-governance audits assert on whether a BigQuery dataset is backed by an external source — BigLake, Iceberg via AWS Glue, or any other federated source — and which Cloud connection it routes through.

## Test plan

- [ ] `cnspec shell gcp` against a project that has both native and externally backed datasets
- [ ] `gcp.project.bigqueryService.datasets { name externalDatasetReference }` shows the dict populated for federated datasets and null for native ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)