### PR TITLE
✨ gcp/gke: pick up modern cluster fields & deprecate legacy equivalents

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -89,6 +89,7 @@ bumpable
 bwawxf
 BXdl
 bytematchstatement
+CADVISOR
 cafd
 cavium
 cbf
@@ -164,6 +165,7 @@ datasource
 datastream
 DATAUSER
 DBfor
+DCGM
 ddl
 ddos
 DEAUTHORIZED
@@ -341,6 +343,7 @@ JFi
 jira
 jkl
 jobnum
+JOBSET
 jpi
 jql
 jre

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -3112,12 +3112,19 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   name string
   // Optional description for the cluster
   description string
-  // The logging service the cluster should use to write logs
-  loggingService string
+  // Legacy logging service identifier
+  //
+  // Deprecated in favor of `loggingConfig`, which captures the per-component
+  // enable list (SYSTEM_COMPONENTS, WORKLOADS, APISERVER, SCHEDULER,
+  // CONTROLLER_MANAGER) used by modern GKE.
+  loggingService @maturity("deprecated") string
   // Whether cluster logging is enabled (loggingService is set and not "none")
   loggingEnabled() bool
-  // The monitoring service the cluster should use to write metrics
-  monitoringService string
+  // Legacy monitoring service identifier
+  //
+  // Deprecated in favor of `monitoringConfig`, which captures the per-component
+  // enable list plus the managed Prometheus configuration used by modern GKE.
+  monitoringService @maturity("deprecated") string
   // Whether cluster monitoring is enabled (monitoringService is set and not "none")
   monitoringEnabled() bool
   // The name of the Google Compute Engine network to which the cluster is connected
@@ -3160,28 +3167,133 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   ipAllocationPolicy gcp.project.gkeService.cluster.ipAllocationPolicy
   // Configuration for cluster networking
   networkConfig gcp.project.gkeService.cluster.networkConfig
-  // Binary authorization configuration
-  binaryAuthorization dict
-  // Whether Binary Authorization is enabled for the cluster (Enabled flag is true OR evaluationMode is anything other than DISABLED/UNSPECIFIED)
-  binaryAuthorizationEnabled bool
+  // Legacy binary authorization configuration dict
+  //
+  // Deprecated in favor of `binaryAuthorizationEvaluationMode`, which is the
+  // single field GKE now uses to drive Binary Authorization policy evaluation.
+  binaryAuthorization @maturity("deprecated") dict
+  // Whether Binary Authorization is enabled for the cluster
+  //
+  // Deprecated in favor of `binaryAuthorizationEvaluationMode`. True when the
+  // legacy boolean is set or `evaluationMode` is anything other than
+  // `DISABLED`/`UNSPECIFIED`.
+  binaryAuthorizationEnabled @maturity("deprecated") bool
+  // Binary Authorization policy evaluation mode
+  //
+  // One of `DISABLED`, `PROJECT_SINGLETON_POLICY_ENFORCE`, or `POLICY_BINDINGS`.
+  // Replaces the legacy boolean `binaryAuthorization.enabled` flag.
+  binaryAuthorizationEvaluationMode string
   // Legacy ABAC authorization configuration
   legacyAbac dict
   // Whether the legacy ABAC authorizer is enabled on the cluster
   legacyAbacEnabled bool
   // Authentication information for accessing the master endpoint
   masterAuth dict
-  // Master authorized networks configuration
-  masterAuthorizedNetworksConfig dict
-  // Whether master authorized networks is enabled (restricts control plane access by source CIDR)
-  masterAuthorizedNetworksEnabled bool
+  // Legacy master authorized networks configuration
+  //
+  // Deprecated in favor of
+  // `controlPlaneEndpointsConfig.ipEndpointsConfig.authorizedNetworksConfig`,
+  // which is the modern home for restricting control plane access by source
+  // CIDR.
+  masterAuthorizedNetworksConfig @maturity("deprecated") dict
+  // Whether master authorized networks is enabled
+  //
+  // Deprecated in favor of
+  // `controlPlaneEndpointsConfig.ipEndpointsConfig.authorizedNetworksConfig.enabled`.
+  masterAuthorizedNetworksEnabled @maturity("deprecated") bool
   // Private cluster configuration
   privateClusterConfig dict
-  // Whether nodes have only private IPs (no public internet egress without NAT)
-  privateNodesEnabled bool
-  // Whether the cluster's control plane endpoint is private (no public master endpoint)
-  privateEndpointEnabled bool
-  // Whether the cluster's private control plane is reachable from any region (when private endpoint is enabled)
-  masterGlobalAccessEnabled bool
+  // Whether nodes have only private IPs
+  //
+  // Deprecated in favor of
+  // `controlPlaneEndpointsConfig.ipEndpointsConfig.enablePublicEndpoint`
+  // (which captures the modern equivalent inverted) and the broader private-node
+  // configuration on the cluster's node pool networking.
+  privateNodesEnabled @maturity("deprecated") bool
+  // Whether the cluster's control plane endpoint is private
+  //
+  // Deprecated in favor of
+  // `controlPlaneEndpointsConfig.ipEndpointsConfig.enablePublicEndpoint`
+  // (false means the public IP endpoint is disabled).
+  privateEndpointEnabled @maturity("deprecated") bool
+  // Whether the cluster's private control plane is reachable from any region
+  //
+  // Deprecated in favor of
+  // `controlPlaneEndpointsConfig.ipEndpointsConfig.enableGlobalAccess`.
+  masterGlobalAccessEnabled @maturity("deprecated") bool
+  // Control plane endpoints configuration
+  //
+  // Examine the modern, structured access-control configuration for the
+  // cluster's control plane — both DNS and IP endpoints. The
+  // `ipEndpointsConfig` sub-dict exposes the authorized-networks list,
+  // whether the public IP endpoint is enabled, and whether private endpoint
+  // global access is enabled. The `dnsEndpointConfig` sub-dict exposes the
+  // managed DNS endpoint URL and whether it is allowed. Replaces the legacy
+  // `masterAuthorizedNetworksConfig` and the access-related fields of
+  // `privateClusterConfig`.
+  controlPlaneEndpointsConfig dict
+  // Logging configuration
+  //
+  // Examine which logging components are enabled for the cluster. The
+  // `componentConfig.enableComponents` list contains members of
+  // `SYSTEM_COMPONENTS`, `WORKLOADS`, `APISERVER`, `SCHEDULER`, and
+  // `CONTROLLER_MANAGER`. Replaces the legacy `loggingService` string.
+  loggingConfig dict
+  // Monitoring configuration
+  //
+  // Examine which monitoring components are enabled for the cluster plus the
+  // managed Prometheus configuration. The `componentConfig.enableComponents`
+  // list contains members of `SYSTEM_COMPONENTS`, `APISERVER`, `SCHEDULER`,
+  // `CONTROLLER_MANAGER`, `STORAGE`, `HPA`, `POD`, `DAEMONSET`, `DEPLOYMENT`,
+  // `STATEFULSET`, `CADVISOR`, `KUBELET`, `DCGM`, and `JOBSET`. Replaces the
+  // legacy `monitoringService` string.
+  monitoringConfig dict
+  // Secret Manager configuration
+  //
+  // Configuration for the Secret Manager CSI driver — exposes whether the
+  // driver is `enabled` and the optional `rotationConfig` (enable flag plus
+  // rotation interval) used to refresh synced secrets.
+  secretManagerConfig dict
+  // User-managed keys configuration
+  //
+  // Customer-managed encryption-key (CMEK) references for cluster control
+  // plane storage and certificate authorities — cluster CA, etcd API CA,
+  // etcd peer CA, aggregation CA, service-account signing/verification keys,
+  // the control-plane disk encryption key, and the GKE-ops etcd backup
+  // encryption key.
+  userManagedKeysConfig dict
+  // Anonymous authentication configuration
+  //
+  // Controls whether anonymous access to non-health-check endpoints is
+  // permitted. `mode` is one of `LIMITED` (anonymous access restricted to the
+  // health-check endpoints) or `ENABLED` (anonymous access fully allowed).
+  anonymousAuthenticationConfig dict
+  // Fleet configuration
+  //
+  // Fleet membership information for the cluster — `project` (the fleet host
+  // project), `membership` (the full fleet membership resource name), and
+  // `preRegistered` (whether the cluster was registered through the fleet
+  // API).
+  fleet dict
+  // RBAC binding configuration
+  //
+  // Settings that govern which ClusterRoleBinding/RoleBinding subjects are
+  // permitted. `enableInsecureBindingSystemUnauthenticated` allows bindings
+  // to `system:anonymous` or `system:unauthenticated`;
+  // `enableInsecureBindingSystemAuthenticated` allows bindings to
+  // `system:authenticated`. Both default to disallowed.
+  rbacBindingConfig dict
+  // Status conditions
+  //
+  // Conditions that caused the current cluster state. Each entry has a
+  // `code`, a human-readable `message`, and a canonical `canonicalCode`
+  // (`google.rpc.Code` value). Provides more detail than the single `status`
+  // string.
+  conditions []dict
+  // Whether the cluster satisfies Physical Zone Isolation requirements
+  satisfiesPzi bool
+  // Whether the cluster satisfies Physical Zone Separation requirements
+  satisfiesPzs bool
   // Etcd encryption configuration
   databaseEncryption dict
   // Etcd encryption state (ENCRYPTED, DECRYPTED)

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -5560,6 +5560,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.gkeService.cluster.binaryAuthorizationEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetBinaryAuthorizationEnabled()).ToDataRes(types.Bool)
 	},
+	"gcp.project.gkeService.cluster.binaryAuthorizationEvaluationMode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetBinaryAuthorizationEvaluationMode()).ToDataRes(types.String)
+	},
 	"gcp.project.gkeService.cluster.legacyAbac": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetLegacyAbac()).ToDataRes(types.Dict)
 	},
@@ -5586,6 +5589,39 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.gkeService.cluster.masterGlobalAccessEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetMasterGlobalAccessEnabled()).ToDataRes(types.Bool)
+	},
+	"gcp.project.gkeService.cluster.controlPlaneEndpointsConfig": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetControlPlaneEndpointsConfig()).ToDataRes(types.Dict)
+	},
+	"gcp.project.gkeService.cluster.loggingConfig": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetLoggingConfig()).ToDataRes(types.Dict)
+	},
+	"gcp.project.gkeService.cluster.monitoringConfig": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetMonitoringConfig()).ToDataRes(types.Dict)
+	},
+	"gcp.project.gkeService.cluster.secretManagerConfig": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetSecretManagerConfig()).ToDataRes(types.Dict)
+	},
+	"gcp.project.gkeService.cluster.userManagedKeysConfig": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetUserManagedKeysConfig()).ToDataRes(types.Dict)
+	},
+	"gcp.project.gkeService.cluster.anonymousAuthenticationConfig": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetAnonymousAuthenticationConfig()).ToDataRes(types.Dict)
+	},
+	"gcp.project.gkeService.cluster.fleet": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetFleet()).ToDataRes(types.Dict)
+	},
+	"gcp.project.gkeService.cluster.rbacBindingConfig": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetRbacBindingConfig()).ToDataRes(types.Dict)
+	},
+	"gcp.project.gkeService.cluster.conditions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetConditions()).ToDataRes(types.Array(types.Dict))
+	},
+	"gcp.project.gkeService.cluster.satisfiesPzi": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetSatisfiesPzi()).ToDataRes(types.Bool)
+	},
+	"gcp.project.gkeService.cluster.satisfiesPzs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetSatisfiesPzs()).ToDataRes(types.Bool)
 	},
 	"gcp.project.gkeService.cluster.databaseEncryption": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetDatabaseEncryption()).ToDataRes(types.Dict)
@@ -19411,6 +19447,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectGkeServiceCluster).BinaryAuthorizationEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"gcp.project.gkeService.cluster.binaryAuthorizationEvaluationMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).BinaryAuthorizationEvaluationMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.project.gkeService.cluster.legacyAbac": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceCluster).LegacyAbac, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -19445,6 +19485,50 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.gkeService.cluster.masterGlobalAccessEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceCluster).MasterGlobalAccessEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.controlPlaneEndpointsConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).ControlPlaneEndpointsConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.loggingConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).LoggingConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.monitoringConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).MonitoringConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.secretManagerConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).SecretManagerConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.userManagedKeysConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).UserManagedKeysConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.anonymousAuthenticationConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).AnonymousAuthenticationConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.fleet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).Fleet, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.rbacBindingConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).RbacBindingConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.conditions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).Conditions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.satisfiesPzi": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).SatisfiesPzi, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.satisfiesPzs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).SatisfiesPzs, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.gkeService.cluster.databaseEncryption": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -44269,69 +44353,81 @@ type mqlGcpProjectGkeServiceCluster struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlGcpProjectGkeServiceClusterInternal
-	ProjectId                       plugin.TValue[string]
-	Id                              plugin.TValue[string]
-	Name                            plugin.TValue[string]
-	Description                     plugin.TValue[string]
-	LoggingService                  plugin.TValue[string]
-	LoggingEnabled                  plugin.TValue[bool]
-	MonitoringService               plugin.TValue[string]
-	MonitoringEnabled               plugin.TValue[bool]
-	Network                         plugin.TValue[string]
-	ClusterIpv4Cidr                 plugin.TValue[string]
-	Subnetwork                      plugin.TValue[string]
-	NodePools                       plugin.TValue[[]any]
-	Locations                       plugin.TValue[[]any]
-	EnableKubernetesAlpha           plugin.TValue[bool]
-	AutopilotEnabled                plugin.TValue[bool]
-	Location                        plugin.TValue[string]
-	Endpoint                        plugin.TValue[string]
-	InitialClusterVersion           plugin.TValue[string]
-	CurrentMasterVersion            plugin.TValue[string]
-	Status                          plugin.TValue[string]
-	ResourceLabels                  plugin.TValue[map[string]any]
-	Created                         plugin.TValue[*time.Time]
-	ExpirationTime                  plugin.TValue[*time.Time]
-	AddonsConfig                    plugin.TValue[*mqlGcpProjectGkeServiceClusterAddonsConfig]
-	WorkloadIdentityConfig          plugin.TValue[any]
-	WorkloadIdentityEnabled         plugin.TValue[bool]
-	IpAllocationPolicy              plugin.TValue[*mqlGcpProjectGkeServiceClusterIpAllocationPolicy]
-	NetworkConfig                   plugin.TValue[*mqlGcpProjectGkeServiceClusterNetworkConfig]
-	BinaryAuthorization             plugin.TValue[any]
-	BinaryAuthorizationEnabled      plugin.TValue[bool]
-	LegacyAbac                      plugin.TValue[any]
-	LegacyAbacEnabled               plugin.TValue[bool]
-	MasterAuth                      plugin.TValue[any]
-	MasterAuthorizedNetworksConfig  plugin.TValue[any]
-	MasterAuthorizedNetworksEnabled plugin.TValue[bool]
-	PrivateClusterConfig            plugin.TValue[any]
-	PrivateNodesEnabled             plugin.TValue[bool]
-	PrivateEndpointEnabled          plugin.TValue[bool]
-	MasterGlobalAccessEnabled       plugin.TValue[bool]
-	DatabaseEncryption              plugin.TValue[any]
-	DatabaseEncryptionState         plugin.TValue[string]
-	DatabaseEncryptionKey           plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
-	ShieldedNodesConfig             plugin.TValue[any]
-	ShieldedNodesEnabled            plugin.TValue[bool]
-	CostManagementConfig            plugin.TValue[any]
-	ConfidentialNodesConfig         plugin.TValue[any]
-	IdentityServiceConfig           plugin.TValue[any]
-	NetworkPolicyConfig             plugin.TValue[any]
-	NetworkPolicy                   plugin.TValue[*mqlGcpProjectGkeServiceClusterNetworkPolicy]
-	ReleaseChannel                  plugin.TValue[string]
-	ReleaseChannelManaged           plugin.TValue[bool]
-	EnableTpu                       plugin.TValue[bool]
-	CurrentNodeCount                plugin.TValue[int64]
-	SecurityPostureConfig           plugin.TValue[*mqlGcpProjectGkeServiceClusterSecurityPostureConfig]
-	MaintenancePolicy               plugin.TValue[*mqlGcpProjectGkeServiceClusterMaintenancePolicy]
-	MeshCertificates                plugin.TValue[any]
-	NotificationConfig              plugin.TValue[*mqlGcpProjectGkeServiceClusterNotificationConfig]
-	Etag                            plugin.TValue[string]
-	InitialNodeCount                plugin.TValue[int64]
-	ServicesIpv4Cidr                plugin.TValue[string]
-	NodeIpv4CidrSize                plugin.TValue[int64]
-	TpuIpv4CidrBlock                plugin.TValue[string]
-	EnabledK8sBetaApis              plugin.TValue[[]any]
+	ProjectId                         plugin.TValue[string]
+	Id                                plugin.TValue[string]
+	Name                              plugin.TValue[string]
+	Description                       plugin.TValue[string]
+	LoggingService                    plugin.TValue[string]
+	LoggingEnabled                    plugin.TValue[bool]
+	MonitoringService                 plugin.TValue[string]
+	MonitoringEnabled                 plugin.TValue[bool]
+	Network                           plugin.TValue[string]
+	ClusterIpv4Cidr                   plugin.TValue[string]
+	Subnetwork                        plugin.TValue[string]
+	NodePools                         plugin.TValue[[]any]
+	Locations                         plugin.TValue[[]any]
+	EnableKubernetesAlpha             plugin.TValue[bool]
+	AutopilotEnabled                  plugin.TValue[bool]
+	Location                          plugin.TValue[string]
+	Endpoint                          plugin.TValue[string]
+	InitialClusterVersion             plugin.TValue[string]
+	CurrentMasterVersion              plugin.TValue[string]
+	Status                            plugin.TValue[string]
+	ResourceLabels                    plugin.TValue[map[string]any]
+	Created                           plugin.TValue[*time.Time]
+	ExpirationTime                    plugin.TValue[*time.Time]
+	AddonsConfig                      plugin.TValue[*mqlGcpProjectGkeServiceClusterAddonsConfig]
+	WorkloadIdentityConfig            plugin.TValue[any]
+	WorkloadIdentityEnabled           plugin.TValue[bool]
+	IpAllocationPolicy                plugin.TValue[*mqlGcpProjectGkeServiceClusterIpAllocationPolicy]
+	NetworkConfig                     plugin.TValue[*mqlGcpProjectGkeServiceClusterNetworkConfig]
+	BinaryAuthorization               plugin.TValue[any]
+	BinaryAuthorizationEnabled        plugin.TValue[bool]
+	BinaryAuthorizationEvaluationMode plugin.TValue[string]
+	LegacyAbac                        plugin.TValue[any]
+	LegacyAbacEnabled                 plugin.TValue[bool]
+	MasterAuth                        plugin.TValue[any]
+	MasterAuthorizedNetworksConfig    plugin.TValue[any]
+	MasterAuthorizedNetworksEnabled   plugin.TValue[bool]
+	PrivateClusterConfig              plugin.TValue[any]
+	PrivateNodesEnabled               plugin.TValue[bool]
+	PrivateEndpointEnabled            plugin.TValue[bool]
+	MasterGlobalAccessEnabled         plugin.TValue[bool]
+	ControlPlaneEndpointsConfig       plugin.TValue[any]
+	LoggingConfig                     plugin.TValue[any]
+	MonitoringConfig                  plugin.TValue[any]
+	SecretManagerConfig               plugin.TValue[any]
+	UserManagedKeysConfig             plugin.TValue[any]
+	AnonymousAuthenticationConfig     plugin.TValue[any]
+	Fleet                             plugin.TValue[any]
+	RbacBindingConfig                 plugin.TValue[any]
+	Conditions                        plugin.TValue[[]any]
+	SatisfiesPzi                      plugin.TValue[bool]
+	SatisfiesPzs                      plugin.TValue[bool]
+	DatabaseEncryption                plugin.TValue[any]
+	DatabaseEncryptionState           plugin.TValue[string]
+	DatabaseEncryptionKey             plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
+	ShieldedNodesConfig               plugin.TValue[any]
+	ShieldedNodesEnabled              plugin.TValue[bool]
+	CostManagementConfig              plugin.TValue[any]
+	ConfidentialNodesConfig           plugin.TValue[any]
+	IdentityServiceConfig             plugin.TValue[any]
+	NetworkPolicyConfig               plugin.TValue[any]
+	NetworkPolicy                     plugin.TValue[*mqlGcpProjectGkeServiceClusterNetworkPolicy]
+	ReleaseChannel                    plugin.TValue[string]
+	ReleaseChannelManaged             plugin.TValue[bool]
+	EnableTpu                         plugin.TValue[bool]
+	CurrentNodeCount                  plugin.TValue[int64]
+	SecurityPostureConfig             plugin.TValue[*mqlGcpProjectGkeServiceClusterSecurityPostureConfig]
+	MaintenancePolicy                 plugin.TValue[*mqlGcpProjectGkeServiceClusterMaintenancePolicy]
+	MeshCertificates                  plugin.TValue[any]
+	NotificationConfig                plugin.TValue[*mqlGcpProjectGkeServiceClusterNotificationConfig]
+	Etag                              plugin.TValue[string]
+	InitialNodeCount                  plugin.TValue[int64]
+	ServicesIpv4Cidr                  plugin.TValue[string]
+	NodeIpv4CidrSize                  plugin.TValue[int64]
+	TpuIpv4CidrBlock                  plugin.TValue[string]
+	EnabledK8sBetaApis                plugin.TValue[[]any]
 }
 
 // createGcpProjectGkeServiceCluster creates a new instance of this resource
@@ -44495,6 +44591,10 @@ func (c *mqlGcpProjectGkeServiceCluster) GetBinaryAuthorizationEnabled() *plugin
 	return &c.BinaryAuthorizationEnabled
 }
 
+func (c *mqlGcpProjectGkeServiceCluster) GetBinaryAuthorizationEvaluationMode() *plugin.TValue[string] {
+	return &c.BinaryAuthorizationEvaluationMode
+}
+
 func (c *mqlGcpProjectGkeServiceCluster) GetLegacyAbac() *plugin.TValue[any] {
 	return &c.LegacyAbac
 }
@@ -44529,6 +44629,50 @@ func (c *mqlGcpProjectGkeServiceCluster) GetPrivateEndpointEnabled() *plugin.TVa
 
 func (c *mqlGcpProjectGkeServiceCluster) GetMasterGlobalAccessEnabled() *plugin.TValue[bool] {
 	return &c.MasterGlobalAccessEnabled
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetControlPlaneEndpointsConfig() *plugin.TValue[any] {
+	return &c.ControlPlaneEndpointsConfig
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetLoggingConfig() *plugin.TValue[any] {
+	return &c.LoggingConfig
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetMonitoringConfig() *plugin.TValue[any] {
+	return &c.MonitoringConfig
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetSecretManagerConfig() *plugin.TValue[any] {
+	return &c.SecretManagerConfig
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetUserManagedKeysConfig() *plugin.TValue[any] {
+	return &c.UserManagedKeysConfig
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetAnonymousAuthenticationConfig() *plugin.TValue[any] {
+	return &c.AnonymousAuthenticationConfig
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetFleet() *plugin.TValue[any] {
+	return &c.Fleet
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetRbacBindingConfig() *plugin.TValue[any] {
+	return &c.RbacBindingConfig
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetConditions() *plugin.TValue[[]any] {
+	return &c.Conditions
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetSatisfiesPzi() *plugin.TValue[bool] {
+	return &c.SatisfiesPzi
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetSatisfiesPzs() *plugin.TValue[bool] {
+	return &c.SatisfiesPzs
 }
 
 func (c *mqlGcpProjectGkeServiceCluster) GetDatabaseEncryption() *plugin.TValue[any] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -2734,11 +2734,15 @@ gcp.project.gkeService.cluster.addonsConfig.id 9.0.0
 gcp.project.gkeService.cluster.addonsConfig.kubernetesDashboard 9.0.0
 gcp.project.gkeService.cluster.addonsConfig.networkPolicyConfig 9.0.0
 gcp.project.gkeService.cluster.addonsConfig.statefulHaConfig 9.0.0
+gcp.project.gkeService.cluster.anonymousAuthenticationConfig 13.16.3
 gcp.project.gkeService.cluster.autopilotEnabled 9.0.0
 gcp.project.gkeService.cluster.binaryAuthorization 9.0.0
 gcp.project.gkeService.cluster.binaryAuthorizationEnabled 13.12.2
+gcp.project.gkeService.cluster.binaryAuthorizationEvaluationMode 13.16.3
 gcp.project.gkeService.cluster.clusterIpv4Cidr 9.0.0
+gcp.project.gkeService.cluster.conditions 13.16.3
 gcp.project.gkeService.cluster.confidentialNodesConfig 9.0.0
+gcp.project.gkeService.cluster.controlPlaneEndpointsConfig 13.16.3
 gcp.project.gkeService.cluster.costManagementConfig 9.0.0
 gcp.project.gkeService.cluster.created 9.0.0
 gcp.project.gkeService.cluster.currentMasterVersion 9.0.0
@@ -2753,6 +2757,7 @@ gcp.project.gkeService.cluster.enabledK8sBetaApis 13.1.2
 gcp.project.gkeService.cluster.endpoint 9.0.0
 gcp.project.gkeService.cluster.etag 13.1.2
 gcp.project.gkeService.cluster.expirationTime 9.0.0
+gcp.project.gkeService.cluster.fleet 13.16.3
 gcp.project.gkeService.cluster.id 9.0.0
 gcp.project.gkeService.cluster.identityServiceConfig 9.0.0
 gcp.project.gkeService.cluster.initialClusterVersion 9.0.0
@@ -2775,6 +2780,7 @@ gcp.project.gkeService.cluster.legacyAbac 9.0.0
 gcp.project.gkeService.cluster.legacyAbacEnabled 13.12.2
 gcp.project.gkeService.cluster.location 9.0.0
 gcp.project.gkeService.cluster.locations 9.0.0
+gcp.project.gkeService.cluster.loggingConfig 13.16.3
 gcp.project.gkeService.cluster.loggingEnabled 13.12.2
 gcp.project.gkeService.cluster.loggingService 9.0.0
 gcp.project.gkeService.cluster.maintenancePolicy 11.6.6
@@ -2791,6 +2797,7 @@ gcp.project.gkeService.cluster.masterAuthorizedNetworksConfig 9.0.0
 gcp.project.gkeService.cluster.masterAuthorizedNetworksEnabled 13.12.2
 gcp.project.gkeService.cluster.masterGlobalAccessEnabled 13.12.2
 gcp.project.gkeService.cluster.meshCertificates 13.7.2
+gcp.project.gkeService.cluster.monitoringConfig 13.16.3
 gcp.project.gkeService.cluster.monitoringEnabled 13.12.2
 gcp.project.gkeService.cluster.monitoringService 9.0.0
 gcp.project.gkeService.cluster.name 9.0.0
@@ -2930,9 +2937,13 @@ gcp.project.gkeService.cluster.privateClusterConfig 9.0.0
 gcp.project.gkeService.cluster.privateEndpointEnabled 13.12.2
 gcp.project.gkeService.cluster.privateNodesEnabled 13.12.2
 gcp.project.gkeService.cluster.projectId 9.0.0
+gcp.project.gkeService.cluster.rbacBindingConfig 13.16.3
 gcp.project.gkeService.cluster.releaseChannel 9.0.0
 gcp.project.gkeService.cluster.releaseChannelManaged 13.12.2
 gcp.project.gkeService.cluster.resourceLabels 9.0.0
+gcp.project.gkeService.cluster.satisfiesPzi 13.16.3
+gcp.project.gkeService.cluster.satisfiesPzs 13.16.3
+gcp.project.gkeService.cluster.secretManagerConfig 13.16.3
 gcp.project.gkeService.cluster.securityPostureConfig 11.6.6
 gcp.project.gkeService.cluster.securityPostureConfig.id 11.6.6
 gcp.project.gkeService.cluster.securityPostureConfig.mode 11.6.6
@@ -2943,6 +2954,7 @@ gcp.project.gkeService.cluster.shieldedNodesEnabled 13.12.2
 gcp.project.gkeService.cluster.status 9.0.0
 gcp.project.gkeService.cluster.subnetwork 9.0.0
 gcp.project.gkeService.cluster.tpuIpv4CidrBlock 13.1.2
+gcp.project.gkeService.cluster.userManagedKeysConfig 13.16.3
 gcp.project.gkeService.cluster.workloadIdentityConfig 9.0.0
 gcp.project.gkeService.cluster.workloadIdentityEnabled 13.12.2
 gcp.project.gkeService.clusters 9.0.0

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -512,6 +512,7 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 
 		var binAuth map[string]any
 		var binaryAuthorizationEnabled bool
+		var binaryAuthorizationEvaluationMode string
 		if c.BinaryAuthorization != nil {
 			binAuth = map[string]any{
 				"enabled":        c.BinaryAuthorization.Enabled,
@@ -522,6 +523,7 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 			mode := c.BinaryAuthorization.EvaluationMode
 			binaryAuthorizationEnabled = c.BinaryAuthorization.Enabled ||
 				(mode != containerpb.BinaryAuthorization_EVALUATION_MODE_UNSPECIFIED && mode != containerpb.BinaryAuthorization_DISABLED)
+			binaryAuthorizationEvaluationMode = mode.String()
 		}
 
 		var legacyAbac map[string]any
@@ -708,69 +710,132 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 			return nil, err
 		}
 
+		controlPlaneEndpointsConfig, err := protoToDict(c.ControlPlaneEndpointsConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		loggingConfig, err := protoToDict(c.LoggingConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		monitoringConfig, err := protoToDict(c.MonitoringConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		secretManagerConfig, err := protoToDict(c.SecretManagerConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		userManagedKeysConfig, err := protoToDict(c.UserManagedKeysConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		anonymousAuthenticationConfig, err := protoToDict(c.AnonymousAuthenticationConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		fleet, err := protoToDict(c.Fleet)
+		if err != nil {
+			return nil, err
+		}
+
+		rbacBindingConfig, err := protoToDict(c.RbacBindingConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		conditions := make([]any, 0, len(c.Conditions))
+		for _, cond := range c.Conditions {
+			condDict, err := protoToDict(cond)
+			if err != nil {
+				return nil, err
+			}
+			if condDict != nil {
+				conditions = append(conditions, condDict)
+			}
+		}
+
 		notificationConfig, err := buildGKENotificationConfig(g.MqlRuntime, c.Name, c.NotificationConfig)
 		if err != nil {
 			return nil, err
 		}
 
 		clusterArgs := map[string]*llx.RawData{
-			"projectId":                       llx.StringData(projectId),
-			"id":                              llx.StringData(c.Id),
-			"name":                            llx.StringData(c.Name),
-			"description":                     llx.StringData(c.Description),
-			"loggingService":                  llx.StringData(c.LoggingService),
-			"monitoringService":               llx.StringData(c.MonitoringService),
-			"network":                         llx.StringData(c.Network),
-			"clusterIpv4Cidr":                 llx.StringData(c.ClusterIpv4Cidr),
-			"subnetwork":                      llx.StringData(c.Subnetwork),
-			"nodePools":                       llx.ArrayData(nodePools, types.Resource("gcp.project.gkeService.cluster.nodepool")),
-			"locations":                       llx.ArrayData(convert.SliceAnyToInterface(c.Locations), types.String),
-			"enableKubernetesAlpha":           llx.BoolData(c.EnableKubernetesAlpha),
-			"autopilotEnabled":                llx.BoolData(autopilotEnabled),
-			"location":                        llx.StringData(c.Location),
-			"endpoint":                        llx.StringData(c.Endpoint),
-			"initialClusterVersion":           llx.StringData(c.InitialClusterVersion),
-			"currentMasterVersion":            llx.StringData(c.CurrentMasterVersion),
-			"status":                          llx.StringData(c.Status.String()),
-			"resourceLabels":                  llx.MapData(convert.MapToInterfaceMap(c.ResourceLabels), types.String),
-			"created":                         llx.TimeDataPtr(parseTime(c.CreateTime)),
-			"expirationTime":                  llx.TimeDataPtr(parseTime(c.ExpireTime)),
-			"addonsConfig":                    llx.ResourceData(addonsConfig, "gcp.project.gkeService.cluster.addonsConfig"),
-			"workloadIdentityConfig":          llx.DictData(workloadIdCfg),
-			"workloadIdentityEnabled":         llx.BoolData(workloadIdentityEnabled),
-			"ipAllocationPolicy":              llx.ResourceData(ipAllocPolicy, "gcp.project.gkeService.cluster.ipAllocationPolicy"),
-			"networkConfig":                   llx.ResourceData(networkConfig, "gcp.project.gkeService.cluster.networkConfig"),
-			"binaryAuthorization":             llx.DictData(binAuth),
-			"binaryAuthorizationEnabled":      llx.BoolData(binaryAuthorizationEnabled),
-			"legacyAbac":                      llx.DictData(legacyAbac),
-			"legacyAbacEnabled":               llx.BoolData(legacyAbacEnabled),
-			"masterAuth":                      llx.DictData(masterAuth),
-			"masterAuthorizedNetworksConfig":  llx.DictData(masterAuthorizedNetworksCfg),
-			"masterAuthorizedNetworksEnabled": llx.BoolData(masterAuthorizedNetworksEnabled),
-			"privateClusterConfig":            llx.DictData(privateClusterCfg),
-			"privateNodesEnabled":             llx.BoolData(privateNodesEnabled),
-			"privateEndpointEnabled":          llx.BoolData(privateEndpointEnabled),
-			"masterGlobalAccessEnabled":       llx.BoolData(masterGlobalAccessEnabled),
-			"databaseEncryption":              llx.DictData(databaseEncryption),
-			"databaseEncryptionState":         llx.StringData(databaseEncryptionState),
-			"shieldedNodesConfig":             llx.DictData(shieldedNodesConfig),
-			"shieldedNodesEnabled":            llx.BoolData(shieldedNodesEnabled),
-			"costManagementConfig":            llx.DictData(costManagementConfig),
-			"confidentialNodesConfig":         llx.DictData(confidentialNodesConfig),
-			"identityServiceConfig":           llx.DictData(identityServiceConfig),
-			"networkPolicyConfig":             llx.DictData(networkPolicyConfig),
-			"releaseChannel":                  llx.StringData(strings.ToLower(c.ReleaseChannel.GetChannel().String())),
-			"enableTpu":                       llx.BoolData(c.EnableTpu),
-			"currentNodeCount":                llx.IntData(int64(c.CurrentNodeCount)),
-			"securityPostureConfig":           llx.ResourceData(secPostureConfig, "gcp.project.gkeService.cluster.securityPostureConfig"),
-			"maintenancePolicy":               llx.ResourceData(maintenancePolicy, "gcp.project.gkeService.cluster.maintenancePolicy"),
-			"etag":                            llx.StringData(c.Etag),
-			"initialNodeCount":                llx.IntData(int64(c.InitialNodeCount)),
-			"servicesIpv4Cidr":                llx.StringData(c.ServicesIpv4Cidr),
-			"nodeIpv4CidrSize":                llx.IntData(int64(c.NodeIpv4CidrSize)),
-			"tpuIpv4CidrBlock":                llx.StringData(c.TpuIpv4CidrBlock),
-			"enabledK8sBetaApis":              llx.ArrayData(enabledK8sBetaApis, types.String),
-			"meshCertificates":                llx.DictData(meshCertificates),
+			"projectId":                         llx.StringData(projectId),
+			"id":                                llx.StringData(c.Id),
+			"name":                              llx.StringData(c.Name),
+			"description":                       llx.StringData(c.Description),
+			"loggingService":                    llx.StringData(c.LoggingService),
+			"monitoringService":                 llx.StringData(c.MonitoringService),
+			"network":                           llx.StringData(c.Network),
+			"clusterIpv4Cidr":                   llx.StringData(c.ClusterIpv4Cidr),
+			"subnetwork":                        llx.StringData(c.Subnetwork),
+			"nodePools":                         llx.ArrayData(nodePools, types.Resource("gcp.project.gkeService.cluster.nodepool")),
+			"locations":                         llx.ArrayData(convert.SliceAnyToInterface(c.Locations), types.String),
+			"enableKubernetesAlpha":             llx.BoolData(c.EnableKubernetesAlpha),
+			"autopilotEnabled":                  llx.BoolData(autopilotEnabled),
+			"location":                          llx.StringData(c.Location),
+			"endpoint":                          llx.StringData(c.Endpoint),
+			"initialClusterVersion":             llx.StringData(c.InitialClusterVersion),
+			"currentMasterVersion":              llx.StringData(c.CurrentMasterVersion),
+			"status":                            llx.StringData(c.Status.String()),
+			"resourceLabels":                    llx.MapData(convert.MapToInterfaceMap(c.ResourceLabels), types.String),
+			"created":                           llx.TimeDataPtr(parseTime(c.CreateTime)),
+			"expirationTime":                    llx.TimeDataPtr(parseTime(c.ExpireTime)),
+			"addonsConfig":                      llx.ResourceData(addonsConfig, "gcp.project.gkeService.cluster.addonsConfig"),
+			"workloadIdentityConfig":            llx.DictData(workloadIdCfg),
+			"workloadIdentityEnabled":           llx.BoolData(workloadIdentityEnabled),
+			"ipAllocationPolicy":                llx.ResourceData(ipAllocPolicy, "gcp.project.gkeService.cluster.ipAllocationPolicy"),
+			"networkConfig":                     llx.ResourceData(networkConfig, "gcp.project.gkeService.cluster.networkConfig"),
+			"binaryAuthorization":               llx.DictData(binAuth),
+			"binaryAuthorizationEnabled":        llx.BoolData(binaryAuthorizationEnabled),
+			"binaryAuthorizationEvaluationMode": llx.StringData(binaryAuthorizationEvaluationMode),
+			"legacyAbac":                        llx.DictData(legacyAbac),
+			"legacyAbacEnabled":                 llx.BoolData(legacyAbacEnabled),
+			"masterAuth":                        llx.DictData(masterAuth),
+			"masterAuthorizedNetworksConfig":    llx.DictData(masterAuthorizedNetworksCfg),
+			"masterAuthorizedNetworksEnabled":   llx.BoolData(masterAuthorizedNetworksEnabled),
+			"privateClusterConfig":              llx.DictData(privateClusterCfg),
+			"privateNodesEnabled":               llx.BoolData(privateNodesEnabled),
+			"privateEndpointEnabled":            llx.BoolData(privateEndpointEnabled),
+			"masterGlobalAccessEnabled":         llx.BoolData(masterGlobalAccessEnabled),
+			"databaseEncryption":                llx.DictData(databaseEncryption),
+			"databaseEncryptionState":           llx.StringData(databaseEncryptionState),
+			"shieldedNodesConfig":               llx.DictData(shieldedNodesConfig),
+			"shieldedNodesEnabled":              llx.BoolData(shieldedNodesEnabled),
+			"costManagementConfig":              llx.DictData(costManagementConfig),
+			"confidentialNodesConfig":           llx.DictData(confidentialNodesConfig),
+			"identityServiceConfig":             llx.DictData(identityServiceConfig),
+			"networkPolicyConfig":               llx.DictData(networkPolicyConfig),
+			"releaseChannel":                    llx.StringData(strings.ToLower(c.ReleaseChannel.GetChannel().String())),
+			"enableTpu":                         llx.BoolData(c.EnableTpu),
+			"currentNodeCount":                  llx.IntData(int64(c.CurrentNodeCount)),
+			"securityPostureConfig":             llx.ResourceData(secPostureConfig, "gcp.project.gkeService.cluster.securityPostureConfig"),
+			"maintenancePolicy":                 llx.ResourceData(maintenancePolicy, "gcp.project.gkeService.cluster.maintenancePolicy"),
+			"etag":                              llx.StringData(c.Etag),
+			"initialNodeCount":                  llx.IntData(int64(c.InitialNodeCount)),
+			"servicesIpv4Cidr":                  llx.StringData(c.ServicesIpv4Cidr),
+			"nodeIpv4CidrSize":                  llx.IntData(int64(c.NodeIpv4CidrSize)),
+			"tpuIpv4CidrBlock":                  llx.StringData(c.TpuIpv4CidrBlock),
+			"enabledK8sBetaApis":                llx.ArrayData(enabledK8sBetaApis, types.String),
+			"meshCertificates":                  llx.DictData(meshCertificates),
+			"controlPlaneEndpointsConfig":       llx.DictData(controlPlaneEndpointsConfig),
+			"loggingConfig":                     llx.DictData(loggingConfig),
+			"monitoringConfig":                  llx.DictData(monitoringConfig),
+			"secretManagerConfig":               llx.DictData(secretManagerConfig),
+			"userManagedKeysConfig":             llx.DictData(userManagedKeysConfig),
+			"anonymousAuthenticationConfig":     llx.DictData(anonymousAuthenticationConfig),
+			"fleet":                             llx.DictData(fleet),
+			"rbacBindingConfig":                 llx.DictData(rbacBindingConfig),
+			"conditions":                        llx.ArrayData(conditions, types.Dict),
+			"satisfiesPzi":                      llx.BoolDataPtr(c.SatisfiesPzi),
+			"satisfiesPzs":                      llx.BoolDataPtr(c.SatisfiesPzs),
 		}
 		if notificationConfig != nil {
 			clusterArgs["notificationConfig"] = llx.ResourceData(notificationConfig, "gcp.project.gkeService.cluster.notificationConfig")


### PR DESCRIPTION
## Summary

Expose the modern fields the GKE `container/apiv1` SDK now points to on
`gcp.project.gkeService.cluster`, and mark the older shapes deprecated
(without removing them) so new audits target the right things.

### Fields added (all at `13.16.3`)

| Field | Type | Replaces / notes |
| --- | --- | --- |
| `controlPlaneEndpointsConfig` | `dict` | Modern access-control config — DNS endpoint, IP endpoints, authorized networks, public-endpoint flag, global-access flag. Supersedes `masterAuthorizedNetworksConfig` and the access-related fields of `privateClusterConfig`. |
| `loggingConfig` | `dict` | Per-component enable list (`SYSTEM_COMPONENTS`, `WORKLOADS`, `APISERVER`, `SCHEDULER`, `CONTROLLER_MANAGER`). Supersedes `loggingService`. |
| `monitoringConfig` | `dict` | Per-component enable list plus managed Prometheus config. Supersedes `monitoringService`. |
| `binaryAuthorizationEvaluationMode` | `string` | `DISABLED` / `PROJECT_SINGLETON_POLICY_ENFORCE` / `POLICY_BINDINGS`. Supersedes the boolean `binaryAuthorization.enabled`. |
| `secretManagerConfig` | `dict` | `{enabled, rotationConfig}` for the Secret Manager CSI driver. |
| `userManagedKeysConfig` | `dict` | CMEK refs for control-plane storage and CAs. |
| `anonymousAuthenticationConfig` | `dict` | `{mode}` — `LIMITED` / `ENABLED`. |
| `fleet` | `dict` | `{project, membership, preRegistered}`. |
| `rbacBindingConfig` | `dict` | `{enableInsecureBindingSystemUnauthenticated, enableInsecureBindingSystemAuthenticated}`. |
| `conditions` | `[]dict` | Status conditions: `{code, message, canonicalCode}` — more detail than the single `status` string. |
| `satisfiesPzi` | `bool` | Physical Zone Isolation compliance flag. |
| `satisfiesPzs` | `bool` | Physical Zone Separation compliance flag. |

### Fields newly marked `@maturity("deprecated")`

The SDK marks each of these `Deprecated:`. Descriptions were rewritten to lead with `Deprecated in favor of …` per the CLAUDE.md rule. Fields stay queryable; `.lr.versions` entries unchanged.

- `loggingService` → `loggingConfig`
- `monitoringService` → `monitoringConfig`
- `binaryAuthorization` → `binaryAuthorizationEvaluationMode`
- `binaryAuthorizationEnabled` → `binaryAuthorizationEvaluationMode`
- `masterAuthorizedNetworksConfig` → `controlPlaneEndpointsConfig.ipEndpointsConfig.authorizedNetworksConfig`
- `masterAuthorizedNetworksEnabled` → `controlPlaneEndpointsConfig.ipEndpointsConfig.authorizedNetworksConfig.enabled`
- `privateNodesEnabled` / `privateEndpointEnabled` → `controlPlaneEndpointsConfig.ipEndpointsConfig.enablePublicEndpoint`
- `masterGlobalAccessEnabled` → `controlPlaneEndpointsConfig.ipEndpointsConfig.enableGlobalAccess`

No new GCP API calls are made — all data comes from the existing `ListClusters` response — so `gcp.permissions.json` is unchanged.

## Test plan

- [ ] `make providers/build/gcp && make providers/install/gcp`
- [ ] `cnspec shell gcp` against a real project and check the new fields:
  - [ ] `gcp.project.gkeService.clusters { name controlPlaneEndpointsConfig loggingConfig monitoringConfig binaryAuthorizationEvaluationMode }`
  - [ ] `gcp.project.gkeService.clusters { name secretManagerConfig userManagedKeysConfig anonymousAuthenticationConfig fleet rbacBindingConfig }`
  - [ ] `gcp.project.gkeService.clusters { name conditions satisfiesPzi satisfiesPzs }`
- [ ] Confirm deprecated fields still return their old values for existing policies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)