### PR TITLE
✨ gcp/sql: add instance TLS, edition, and backup detail fields

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -210,6 +210,7 @@ emerg
 encryptors
 endpointslice
 eni
+entraid
 erlang
 ERPCLOUD
 ethertype
@@ -563,6 +564,7 @@ privsep
 processingjob
 proxmox
 PROXYV
+psa
 psc
 psr
 pti

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -2491,6 +2491,24 @@ private gcp.project.sqlService.instance @defaults("name") {
   currentDiskSize int
   // ETag for optimistic locking
   etag string
+  // DNS names for this instance (`{name, connectionType, dnsScope, recordManager}`)
+  //
+  // Each entry exposes the DNS name, its connection type
+  // (PUBLIC, PRIVATE_SERVICES_ACCESS, PRIVATE_SERVICE_CONNECT), DNS scope
+  // (INSTANCE, CLUSTER), and record manager
+  // (CUSTOMER, CLOUD_SQL_AUTOMATION).
+  dnsNames []dict
+  // Upcoming scheduled maintenance window (`{startTime, canDefer, canReschedule, scheduleDeadlineTime}`)
+  scheduledMaintenance dict
+  // Database versions available for upgrade (`{name, majorVersion, displayName}`)
+  upgradableDatabaseVersions []dict
+  // Primary/DR replica pairing for the instance (`{drReplica, failoverDrReplicaName, psaWriteEndpoint}`)
+  //
+  // Cross-region DR replication is an Enterprise Plus feature for MySQL
+  // and PostgreSQL. `drReplica` is true on the DR replica side;
+  // `failoverDrReplicaName` is set on the primary to designate the DR
+  // replica.
+  replicationCluster dict
 }
 
 // Google Cloud (GCP) SQL instance database
@@ -2690,6 +2708,24 @@ private gcp.project.sqlService.instance.settings {
   timeZone string
   // User-provided labels
   userLabels map[string]string
+  // Edition type of the Cloud SQL instance
+  //
+  // One of EDITION_UNSPECIFIED, ENTERPRISE, ENTERPRISE_PLUS, or DEVELOPER.
+  edition string
+  // Data cache configuration (`{dataCacheEnabled}`); applicable to Enterprise Plus
+  dataCacheConfig dict
+  // Microsoft Entra ID configuration for SQL Server (`{applicationId, tenantId}`)
+  entraidConfig dict
+  // Whether ExecuteSql API access is allowed
+  //
+  // One of DATA_API_ACCESS_UNSPECIFIED, DISALLOW_DATA_API, or ALLOW_DATA_API.
+  // When ALLOW_DATA_API is set on a private-IP instance, authorized users can
+  // reach it from the public internet via the ExecuteSql API.
+  dataApiAccess string
+  // Whether Vertex AI integration is enabled (MySQL and PostgreSQL only)
+  enableGoogleMlIntegration bool
+  // Whether Dataplex schema extraction is enabled
+  enableDataplexIntegration bool
 }
 
 // Google Cloud (GCP) SQL instance Entra ID / Active Directory configuration
@@ -2732,6 +2768,16 @@ private gcp.project.sqlService.instance.settings.backupconfiguration {
   startTime string
   // Number of days of transaction logs retained for point-in-time restore
   transactionLogRetentionDays int
+  // Backup tier managing the backups for this instance
+  //
+  // One of BACKUP_TIER_UNSPECIFIED, STANDARD (managed by Cloud SQL), or
+  // ENHANCED (managed by Google Cloud Backup and DR Service).
+  backupTier string
+  // Storage location of the transactional logs used for point-in-time recovery
+  //
+  // One of TRANSACTIONAL_LOG_STORAGE_STATE_UNSPECIFIED, DISK,
+  // SWITCHING_TO_CLOUD_STORAGE, SWITCHED_TO_CLOUD_STORAGE, or CLOUD_STORAGE.
+  transactionalLogStorageState string
 }
 
 // Google Cloud (GCP) SQL instance settings deny maintenance period
@@ -2768,8 +2814,21 @@ private gcp.project.sqlService.instance.settings.ipConfiguration {
   //
   // Controls connectivity to private IP instances from Google services, such as BigQuery.
   enablePrivatePathForGoogleCloudServices bool
-  // Specifies how the server CA certificate is signed (GOOGLE_MANAGED_INTERNAL_CA, GOOGLE_MANAGED_CAS_CA)
+  // Specifies how the server CA certificate is signed (GOOGLE_MANAGED_INTERNAL_CA, GOOGLE_MANAGED_CAS_CA, CUSTOMER_MANAGED_CAS_CA)
   serverCaMode string
+  // Resource name of the server CA pool when `serverCaMode` is `CUSTOMER_MANAGED_CAS_CA`
+  //
+  // Format: `projects/{PROJECT}/locations/{REGION}/caPools/{CA_POOL_ID}`.
+  serverCaPool string
+  // Custom Subject Alternative Names (SANs) presented on the instance server certificate
+  customSubjectAlternativeNames []string
+  // Server certificate auto-rotation mode
+  //
+  // Controls whether the server certificate is automatically rotated during
+  // Cloud SQL scheduled maintenance up to six months before it expires. Only
+  // settable when `serverCaMode` is `GOOGLE_MANAGED_CAS_CA` or
+  // `CUSTOMER_MANAGED_CAS_CA`.
+  serverCertificateRotationMode string
   // Private Service Connect configuration
   pscConfig gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig
 }

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -4753,6 +4753,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.sqlService.instance.etag": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstance).GetEtag()).ToDataRes(types.String)
 	},
+	"gcp.project.sqlService.instance.dnsNames": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstance).GetDnsNames()).ToDataRes(types.Array(types.Dict))
+	},
+	"gcp.project.sqlService.instance.scheduledMaintenance": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstance).GetScheduledMaintenance()).ToDataRes(types.Dict)
+	},
+	"gcp.project.sqlService.instance.upgradableDatabaseVersions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstance).GetUpgradableDatabaseVersions()).ToDataRes(types.Array(types.Dict))
+	},
+	"gcp.project.sqlService.instance.replicationCluster": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstance).GetReplicationCluster()).ToDataRes(types.Dict)
+	},
 	"gcp.project.sqlService.instance.database.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceDatabase).GetProjectId()).ToDataRes(types.String)
 	},
@@ -4981,6 +4993,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.sqlService.instance.settings.userLabels": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettings).GetUserLabels()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"gcp.project.sqlService.instance.settings.edition": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettings).GetEdition()).ToDataRes(types.String)
+	},
+	"gcp.project.sqlService.instance.settings.dataCacheConfig": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettings).GetDataCacheConfig()).ToDataRes(types.Dict)
+	},
+	"gcp.project.sqlService.instance.settings.entraidConfig": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettings).GetEntraidConfig()).ToDataRes(types.Dict)
+	},
+	"gcp.project.sqlService.instance.settings.dataApiAccess": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettings).GetDataApiAccess()).ToDataRes(types.String)
+	},
+	"gcp.project.sqlService.instance.settings.enableGoogleMlIntegration": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettings).GetEnableGoogleMlIntegration()).ToDataRes(types.Bool)
+	},
+	"gcp.project.sqlService.instance.settings.enableDataplexIntegration": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettings).GetEnableDataplexIntegration()).ToDataRes(types.Bool)
+	},
 	"gcp.project.sqlService.instance.settings.activeDirectory.domain": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory).GetDomain()).ToDataRes(types.String)
 	},
@@ -5016,6 +5046,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.sqlService.instance.settings.backupconfiguration.transactionLogRetentionDays": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsBackupconfiguration).GetTransactionLogRetentionDays()).ToDataRes(types.Int)
+	},
+	"gcp.project.sqlService.instance.settings.backupconfiguration.backupTier": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsBackupconfiguration).GetBackupTier()).ToDataRes(types.String)
+	},
+	"gcp.project.sqlService.instance.settings.backupconfiguration.transactionalLogStorageState": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsBackupconfiguration).GetTransactionalLogStorageState()).ToDataRes(types.String)
 	},
 	"gcp.project.sqlService.instance.settings.denyMaintenancePeriod.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsDenyMaintenancePeriod).GetId()).ToDataRes(types.String)
@@ -5058,6 +5094,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.sqlService.instance.settings.ipConfiguration.serverCaMode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).GetServerCaMode()).ToDataRes(types.String)
+	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.serverCaPool": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).GetServerCaPool()).ToDataRes(types.String)
+	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.customSubjectAlternativeNames": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).GetCustomSubjectAlternativeNames()).ToDataRes(types.Array(types.String))
+	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.serverCertificateRotationMode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).GetServerCertificateRotationMode()).ToDataRes(types.String)
 	},
 	"gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).GetPscConfig()).ToDataRes(types.Resource("gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig"))
@@ -18341,6 +18386,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectSqlServiceInstance).Etag, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.sqlService.instance.dnsNames": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstance).DnsNames, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.scheduledMaintenance": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstance).ScheduledMaintenance, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.upgradableDatabaseVersions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstance).UpgradableDatabaseVersions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.replicationCluster": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstance).ReplicationCluster, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.sqlService.instance.database.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstanceDatabase).__id, ok = v.Value.(string)
 		return
@@ -18669,6 +18730,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectSqlServiceInstanceSettings).UserLabels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.sqlService.instance.settings.edition": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettings).Edition, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.dataCacheConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettings).DataCacheConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.entraidConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettings).EntraidConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.dataApiAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettings).DataApiAccess, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.enableGoogleMlIntegration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettings).EnableGoogleMlIntegration, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.enableDataplexIntegration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettings).EnableDataplexIntegration, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gcp.project.sqlService.instance.settings.activeDirectory.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory).__id, ok = v.Value.(string)
 		return
@@ -18723,6 +18808,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.sqlService.instance.settings.backupconfiguration.transactionLogRetentionDays": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstanceSettingsBackupconfiguration).TransactionLogRetentionDays, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.backupconfiguration.backupTier": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettingsBackupconfiguration).BackupTier, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.backupconfiguration.transactionalLogStorageState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettingsBackupconfiguration).TransactionalLogStorageState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.sqlService.instance.settings.denyMaintenancePeriod.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -18787,6 +18880,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.sqlService.instance.settings.ipConfiguration.serverCaMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).ServerCaMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.serverCaPool": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).ServerCaPool, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.customSubjectAlternativeNames": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).CustomSubjectAlternativeNames, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.settings.ipConfiguration.serverCertificateRotationMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).ServerCertificateRotationMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -41681,6 +41786,10 @@ type mqlGcpProjectSqlServiceInstance struct {
 	PscServiceAttachmentLink                   plugin.TValue[string]
 	CurrentDiskSize                            plugin.TValue[int64]
 	Etag                                       plugin.TValue[string]
+	DnsNames                                   plugin.TValue[[]any]
+	ScheduledMaintenance                       plugin.TValue[any]
+	UpgradableDatabaseVersions                 plugin.TValue[[]any]
+	ReplicationCluster                         plugin.TValue[any]
 }
 
 // createGcpProjectSqlServiceInstance creates a new instance of this resource
@@ -41996,6 +42105,22 @@ func (c *mqlGcpProjectSqlServiceInstance) GetCurrentDiskSize() *plugin.TValue[in
 
 func (c *mqlGcpProjectSqlServiceInstance) GetEtag() *plugin.TValue[string] {
 	return &c.Etag
+}
+
+func (c *mqlGcpProjectSqlServiceInstance) GetDnsNames() *plugin.TValue[[]any] {
+	return &c.DnsNames
+}
+
+func (c *mqlGcpProjectSqlServiceInstance) GetScheduledMaintenance() *plugin.TValue[any] {
+	return &c.ScheduledMaintenance
+}
+
+func (c *mqlGcpProjectSqlServiceInstance) GetUpgradableDatabaseVersions() *plugin.TValue[[]any] {
+	return &c.UpgradableDatabaseVersions
+}
+
+func (c *mqlGcpProjectSqlServiceInstance) GetReplicationCluster() *plugin.TValue[any] {
+	return &c.ReplicationCluster
 }
 
 // mqlGcpProjectSqlServiceInstanceDatabase for the gcp.project.sqlService.instance.database resource
@@ -42483,6 +42608,12 @@ type mqlGcpProjectSqlServiceInstanceSettings struct {
 	Tier                        plugin.TValue[string]
 	TimeZone                    plugin.TValue[string]
 	UserLabels                  plugin.TValue[map[string]any]
+	Edition                     plugin.TValue[string]
+	DataCacheConfig             plugin.TValue[any]
+	EntraidConfig               plugin.TValue[any]
+	DataApiAccess               plugin.TValue[string]
+	EnableGoogleMlIntegration   plugin.TValue[bool]
+	EnableDataplexIntegration   plugin.TValue[bool]
 }
 
 // createGcpProjectSqlServiceInstanceSettings creates a new instance of this resource
@@ -42642,6 +42773,30 @@ func (c *mqlGcpProjectSqlServiceInstanceSettings) GetUserLabels() *plugin.TValue
 	return &c.UserLabels
 }
 
+func (c *mqlGcpProjectSqlServiceInstanceSettings) GetEdition() *plugin.TValue[string] {
+	return &c.Edition
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettings) GetDataCacheConfig() *plugin.TValue[any] {
+	return &c.DataCacheConfig
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettings) GetEntraidConfig() *plugin.TValue[any] {
+	return &c.EntraidConfig
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettings) GetDataApiAccess() *plugin.TValue[string] {
+	return &c.DataApiAccess
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettings) GetEnableGoogleMlIntegration() *plugin.TValue[bool] {
+	return &c.EnableGoogleMlIntegration
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettings) GetEnableDataplexIntegration() *plugin.TValue[bool] {
+	return &c.EnableDataplexIntegration
+}
+
 // mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory for the gcp.project.sqlService.instance.settings.activeDirectory resource
 type mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory struct {
 	MqlRuntime *plugin.Runtime
@@ -42706,14 +42861,16 @@ type mqlGcpProjectSqlServiceInstanceSettingsBackupconfiguration struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlGcpProjectSqlServiceInstanceSettingsBackupconfigurationInternal it will be used here
-	Id                          plugin.TValue[string]
-	BackupRetentionSettings     plugin.TValue[any]
-	BinaryLogEnabled            plugin.TValue[bool]
-	Enabled                     plugin.TValue[bool]
-	Location                    plugin.TValue[string]
-	PointInTimeRecoveryEnabled  plugin.TValue[bool]
-	StartTime                   plugin.TValue[string]
-	TransactionLogRetentionDays plugin.TValue[int64]
+	Id                           plugin.TValue[string]
+	BackupRetentionSettings      plugin.TValue[any]
+	BinaryLogEnabled             plugin.TValue[bool]
+	Enabled                      plugin.TValue[bool]
+	Location                     plugin.TValue[string]
+	PointInTimeRecoveryEnabled   plugin.TValue[bool]
+	StartTime                    plugin.TValue[string]
+	TransactionLogRetentionDays  plugin.TValue[int64]
+	BackupTier                   plugin.TValue[string]
+	TransactionalLogStorageState plugin.TValue[string]
 }
 
 // createGcpProjectSqlServiceInstanceSettingsBackupconfiguration creates a new instance of this resource
@@ -42783,6 +42940,14 @@ func (c *mqlGcpProjectSqlServiceInstanceSettingsBackupconfiguration) GetStartTim
 
 func (c *mqlGcpProjectSqlServiceInstanceSettingsBackupconfiguration) GetTransactionLogRetentionDays() *plugin.TValue[int64] {
 	return &c.TransactionLogRetentionDays
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsBackupconfiguration) GetBackupTier() *plugin.TValue[string] {
+	return &c.BackupTier
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsBackupconfiguration) GetTransactionalLogStorageState() *plugin.TValue[string] {
+	return &c.TransactionalLogStorageState
 }
 
 // mqlGcpProjectSqlServiceInstanceSettingsDenyMaintenancePeriod for the gcp.project.sqlService.instance.settings.denyMaintenancePeriod resource
@@ -42864,6 +43029,9 @@ type mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration struct {
 	SslMode                                 plugin.TValue[string]
 	EnablePrivatePathForGoogleCloudServices plugin.TValue[bool]
 	ServerCaMode                            plugin.TValue[string]
+	ServerCaPool                            plugin.TValue[string]
+	CustomSubjectAlternativeNames           plugin.TValue[[]any]
+	ServerCertificateRotationMode           plugin.TValue[string]
 	PscConfig                               plugin.TValue[*mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig]
 }
 
@@ -42944,6 +43112,18 @@ func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetEnablePrivat
 
 func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetServerCaMode() *plugin.TValue[string] {
 	return &c.ServerCaMode
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetServerCaPool() *plugin.TValue[string] {
+	return &c.ServerCaPool
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetCustomSubjectAlternativeNames() *plugin.TValue[[]any] {
+	return &c.CustomSubjectAlternativeNames
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetServerCertificateRotationMode() *plugin.TValue[string] {
+	return &c.ServerCertificateRotationMode
 }
 
 func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetPscConfig() *plugin.TValue[*mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationPscConfig] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -4031,6 +4031,7 @@ gcp.project.sqlService.instance.databases 9.0.0
 gcp.project.sqlService.instance.diskEncryptionConfiguration 9.0.0
 gcp.project.sqlService.instance.diskEncryptionStatus 9.0.0
 gcp.project.sqlService.instance.dnsName 11.6.6
+gcp.project.sqlService.instance.dnsNames 13.16.3
 gcp.project.sqlService.instance.etag 13.1.2
 gcp.project.sqlService.instance.failoverReplica 9.0.0
 gcp.project.sqlService.instance.gceZone 9.0.0
@@ -4056,8 +4057,10 @@ gcp.project.sqlService.instance.publicIpEnabled 13.12.2
 gcp.project.sqlService.instance.region 9.0.0
 gcp.project.sqlService.instance.replicaConfiguration 13.7.2
 gcp.project.sqlService.instance.replicaNames 9.0.0
+gcp.project.sqlService.instance.replicationCluster 13.16.3
 gcp.project.sqlService.instance.satisfiesPzi 11.6.6
 gcp.project.sqlService.instance.satisfiesPzs 11.6.6
+gcp.project.sqlService.instance.scheduledMaintenance 13.16.3
 gcp.project.sqlService.instance.secondaryZone 11.6.6
 gcp.project.sqlService.instance.serviceAccountEmailAddress 9.0.0
 gcp.project.sqlService.instance.settings 9.0.0
@@ -4072,6 +4075,7 @@ gcp.project.sqlService.instance.settings.availabilityType 9.0.0
 gcp.project.sqlService.instance.settings.backupConfiguration 9.0.0
 gcp.project.sqlService.instance.settings.backupconfiguration 9.0.0
 gcp.project.sqlService.instance.settings.backupconfiguration.backupRetentionSettings 9.0.0
+gcp.project.sqlService.instance.settings.backupconfiguration.backupTier 13.16.3
 gcp.project.sqlService.instance.settings.backupconfiguration.binaryLogEnabled 9.0.0
 gcp.project.sqlService.instance.settings.backupconfiguration.enabled 9.0.0
 gcp.project.sqlService.instance.settings.backupconfiguration.id 9.0.0
@@ -4079,9 +4083,12 @@ gcp.project.sqlService.instance.settings.backupconfiguration.location 9.0.0
 gcp.project.sqlService.instance.settings.backupconfiguration.pointInTimeRecoveryEnabled 9.0.0
 gcp.project.sqlService.instance.settings.backupconfiguration.startTime 9.0.0
 gcp.project.sqlService.instance.settings.backupconfiguration.transactionLogRetentionDays 9.0.0
+gcp.project.sqlService.instance.settings.backupconfiguration.transactionalLogStorageState 13.16.3
 gcp.project.sqlService.instance.settings.collation 9.0.0
 gcp.project.sqlService.instance.settings.connectorEnforcement 9.0.0
 gcp.project.sqlService.instance.settings.crashSafeReplicationEnabled 9.0.0
+gcp.project.sqlService.instance.settings.dataApiAccess 13.16.3
+gcp.project.sqlService.instance.settings.dataCacheConfig 13.16.3
 gcp.project.sqlService.instance.settings.dataDiskSizeGb 9.0.0
 gcp.project.sqlService.instance.settings.dataDiskType 9.0.0
 gcp.project.sqlService.instance.settings.databaseFlags 9.0.0
@@ -4093,11 +4100,16 @@ gcp.project.sqlService.instance.settings.denyMaintenancePeriod.id 9.0.0
 gcp.project.sqlService.instance.settings.denyMaintenancePeriod.startDate 9.0.0
 gcp.project.sqlService.instance.settings.denyMaintenancePeriod.time 9.0.0
 gcp.project.sqlService.instance.settings.denyMaintenancePeriods 9.0.0
+gcp.project.sqlService.instance.settings.edition 13.16.3
+gcp.project.sqlService.instance.settings.enableDataplexIntegration 13.16.3
+gcp.project.sqlService.instance.settings.enableGoogleMlIntegration 13.16.3
+gcp.project.sqlService.instance.settings.entraidConfig 13.16.3
 gcp.project.sqlService.instance.settings.insightsConfig 9.0.0
 gcp.project.sqlService.instance.settings.instanceName 9.0.0
 gcp.project.sqlService.instance.settings.ipConfiguration 9.0.0
 gcp.project.sqlService.instance.settings.ipConfiguration.allocatedIpRange 9.0.0
 gcp.project.sqlService.instance.settings.ipConfiguration.authorizedNetworks 9.0.0
+gcp.project.sqlService.instance.settings.ipConfiguration.customSubjectAlternativeNames 13.16.3
 gcp.project.sqlService.instance.settings.ipConfiguration.enablePrivatePathForGoogleCloudServices 9.0.0
 gcp.project.sqlService.instance.settings.ipConfiguration.hasOpenAuthorizedNetworks 13.12.2
 gcp.project.sqlService.instance.settings.ipConfiguration.id 9.0.0
@@ -4110,6 +4122,8 @@ gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig.pscAutoConnec
 gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig.pscEnabled 13.10.1
 gcp.project.sqlService.instance.settings.ipConfiguration.requireSsl 9.0.0
 gcp.project.sqlService.instance.settings.ipConfiguration.serverCaMode 13.2.3
+gcp.project.sqlService.instance.settings.ipConfiguration.serverCaPool 13.16.3
+gcp.project.sqlService.instance.settings.ipConfiguration.serverCertificateRotationMode 13.16.3
 gcp.project.sqlService.instance.settings.ipConfiguration.sslMode 9.0.0
 gcp.project.sqlService.instance.settings.locationPreference 9.0.0
 gcp.project.sqlService.instance.settings.maintenanceWindow 9.0.0
@@ -4149,6 +4163,7 @@ gcp.project.sqlService.instance.sslCerts 13.7.2
 gcp.project.sqlService.instance.state 9.0.0
 gcp.project.sqlService.instance.suspensionReason 11.6.6
 gcp.project.sqlService.instance.switchTransactionLogsToCloudStorageEnabled 11.6.6
+gcp.project.sqlService.instance.upgradableDatabaseVersions 13.16.3
 gcp.project.sqlService.instance.user 13.7.2
 gcp.project.sqlService.instance.user.databaseRoles 13.7.2
 gcp.project.sqlService.instance.user.dualPasswordType 13.7.2

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -282,14 +282,16 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 				}
 
 				mqlBackupCfg, err = CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings.backupconfiguration", map[string]*llx.RawData{
-					"id":                          llx.StringData(fmt.Sprintf("%s/settings/backupConfiguration", instanceId)),
-					"backupRetentionSettings":     llx.DictData(mqlRetention),
-					"binaryLogEnabled":            llx.BoolData(s.BackupConfiguration.BinaryLogEnabled),
-					"enabled":                     llx.BoolData(s.BackupConfiguration.Enabled),
-					"location":                    llx.StringData(s.BackupConfiguration.Location),
-					"pointInTimeRecoveryEnabled":  llx.BoolData(s.BackupConfiguration.PointInTimeRecoveryEnabled),
-					"startTime":                   llx.StringData(s.BackupConfiguration.StartTime),
-					"transactionLogRetentionDays": llx.IntData(s.BackupConfiguration.TransactionLogRetentionDays),
+					"id":                           llx.StringData(fmt.Sprintf("%s/settings/backupConfiguration", instanceId)),
+					"backupRetentionSettings":      llx.DictData(mqlRetention),
+					"backupTier":                   llx.StringData(s.BackupConfiguration.BackupTier),
+					"binaryLogEnabled":             llx.BoolData(s.BackupConfiguration.BinaryLogEnabled),
+					"enabled":                      llx.BoolData(s.BackupConfiguration.Enabled),
+					"location":                     llx.StringData(s.BackupConfiguration.Location),
+					"pointInTimeRecoveryEnabled":   llx.BoolData(s.BackupConfiguration.PointInTimeRecoveryEnabled),
+					"startTime":                    llx.StringData(s.BackupConfiguration.StartTime),
+					"transactionLogRetentionDays":  llx.IntData(s.BackupConfiguration.TransactionLogRetentionDays),
+					"transactionalLogStorageState": llx.StringData(s.BackupConfiguration.TransactionalLogStorageState),
 				})
 				if err != nil {
 					return err
@@ -375,14 +377,17 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 				mqlIpCfg, err = CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings.ipConfiguration", map[string]*llx.RawData{
 					"allocatedIpRange":                        llx.StringData(s.IpConfiguration.AllocatedIpRange),
 					"authorizedNetworks":                      llx.ArrayData(mqlAclEntries, types.Dict),
+					"customSubjectAlternativeNames":           llx.ArrayData(convert.SliceAnyToInterface(s.IpConfiguration.CustomSubjectAlternativeNames), types.String),
 					"enablePrivatePathForGoogleCloudServices": llx.BoolData(s.IpConfiguration.EnablePrivatePathForGoogleCloudServices),
-					"id":             llx.StringData(fmt.Sprintf("%s/settings/ipConfiguration", instanceId)),
-					"ipv4Enabled":    llx.BoolData(s.IpConfiguration.Ipv4Enabled),
-					"privateNetwork": llx.StringData(s.IpConfiguration.PrivateNetwork),
-					"requireSsl":     llx.BoolData(s.IpConfiguration.RequireSsl),
-					"sslMode":        llx.StringData(s.IpConfiguration.SslMode),
-					"serverCaMode":   llx.StringData(s.IpConfiguration.ServerCaMode),
-					"pscConfig":      llx.ResourceData(mqlPscCfg, "gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig"),
+					"id":                            llx.StringData(fmt.Sprintf("%s/settings/ipConfiguration", instanceId)),
+					"ipv4Enabled":                   llx.BoolData(s.IpConfiguration.Ipv4Enabled),
+					"privateNetwork":                llx.StringData(s.IpConfiguration.PrivateNetwork),
+					"requireSsl":                    llx.BoolData(s.IpConfiguration.RequireSsl),
+					"sslMode":                       llx.StringData(s.IpConfiguration.SslMode),
+					"serverCaMode":                  llx.StringData(s.IpConfiguration.ServerCaMode),
+					"serverCaPool":                  llx.StringData(s.IpConfiguration.ServerCaPool),
+					"serverCertificateRotationMode": llx.StringData(s.IpConfiguration.ServerCertificateRotationMode),
+					"pscConfig":                     llx.ResourceData(mqlPscCfg, "gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig"),
 				})
 				if err != nil {
 					return err
@@ -452,6 +457,34 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 				}
 			}
 
+			type mqlDataCacheCfg struct {
+				DataCacheEnabled bool `json:"dataCacheEnabled"`
+			}
+			var mqlDataCacheConfig map[string]any
+			if s.DataCacheConfig != nil {
+				mqlDataCacheConfig, err = convert.JsonToDict(mqlDataCacheCfg{
+					DataCacheEnabled: s.DataCacheConfig.DataCacheEnabled,
+				})
+				if err != nil {
+					return err
+				}
+			}
+
+			type mqlEntraIdCfg struct {
+				ApplicationId string `json:"applicationId"`
+				TenantId      string `json:"tenantId"`
+			}
+			var mqlEntraIdConfig map[string]any
+			if s.EntraidConfig != nil {
+				mqlEntraIdConfig, err = convert.JsonToDict(mqlEntraIdCfg{
+					ApplicationId: s.EntraidConfig.ApplicationId,
+					TenantId:      s.EntraidConfig.TenantId,
+				})
+				if err != nil {
+					return err
+				}
+			}
+
 			mqlSettings, err := CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings", map[string]*llx.RawData{
 				"activationPolicy":            llx.StringData(s.ActivationPolicy),
 				"activeDirectoryConfig":       llx.DictData(mqlADCfg),
@@ -483,6 +516,12 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 				"tier":                        llx.StringData(s.Tier),
 				"timeZone":                    llx.StringData(s.TimeZone),
 				"userLabels":                  llx.MapData(convert.MapToInterfaceMap(s.UserLabels), types.String),
+				"edition":                     llx.StringData(s.Edition),
+				"dataCacheConfig":             llx.DictData(mqlDataCacheConfig),
+				"entraidConfig":               llx.DictData(mqlEntraIdConfig),
+				"dataApiAccess":               llx.StringData(s.DataApiAccess),
+				"enableGoogleMlIntegration":   llx.BoolData(s.EnableGoogleMlIntegration),
+				"enableDataplexIntegration":   llx.BoolData(s.EnableDataplexIntegration),
 			})
 			if err != nil {
 				return err
@@ -491,6 +530,86 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 			replicaConfigDict, err := convert.JsonToDict(instance.ReplicaConfiguration)
 			if err != nil {
 				return err
+			}
+
+			type mqlDnsNameMapping struct {
+				Name           string `json:"name"`
+				ConnectionType string `json:"connectionType"`
+				DnsScope       string `json:"dnsScope"`
+				RecordManager  string `json:"recordManager"`
+			}
+			mqlDnsNames := make([]any, 0, len(instance.DnsNames))
+			for _, d := range instance.DnsNames {
+				if d == nil {
+					continue
+				}
+				entry, err := convert.JsonToDict(mqlDnsNameMapping{
+					Name:           d.Name,
+					ConnectionType: d.ConnectionType,
+					DnsScope:       d.DnsScope,
+					RecordManager:  d.RecordManager,
+				})
+				if err != nil {
+					return err
+				}
+				mqlDnsNames = append(mqlDnsNames, entry)
+			}
+
+			type mqlScheduledMaintenance struct {
+				StartTime            string `json:"startTime,omitempty"`
+				CanDefer             bool   `json:"canDefer"`
+				CanReschedule        bool   `json:"canReschedule"`
+				ScheduleDeadlineTime string `json:"scheduleDeadlineTime,omitempty"`
+			}
+			var mqlScheduledMaint map[string]any
+			if instance.ScheduledMaintenance != nil {
+				mqlScheduledMaint, err = convert.JsonToDict(mqlScheduledMaintenance{
+					StartTime:            instance.ScheduledMaintenance.StartTime,
+					CanDefer:             instance.ScheduledMaintenance.CanDefer,
+					CanReschedule:        instance.ScheduledMaintenance.CanReschedule,
+					ScheduleDeadlineTime: instance.ScheduledMaintenance.ScheduleDeadlineTime,
+				})
+				if err != nil {
+					return err
+				}
+			}
+
+			type mqlAvailableDbVersion struct {
+				Name         string `json:"name"`
+				MajorVersion string `json:"majorVersion"`
+				DisplayName  string `json:"displayName"`
+			}
+			mqlUpgradableVersions := make([]any, 0, len(instance.UpgradableDatabaseVersions))
+			for _, v := range instance.UpgradableDatabaseVersions {
+				if v == nil {
+					continue
+				}
+				entry, err := convert.JsonToDict(mqlAvailableDbVersion{
+					Name:         v.Name,
+					MajorVersion: v.MajorVersion,
+					DisplayName:  v.DisplayName,
+				})
+				if err != nil {
+					return err
+				}
+				mqlUpgradableVersions = append(mqlUpgradableVersions, entry)
+			}
+
+			type mqlReplicationCluster struct {
+				DrReplica             bool   `json:"drReplica"`
+				FailoverDrReplicaName string `json:"failoverDrReplicaName,omitempty"`
+				PsaWriteEndpoint      string `json:"psaWriteEndpoint,omitempty"`
+			}
+			var mqlReplicationClusterDict map[string]any
+			if instance.ReplicationCluster != nil {
+				mqlReplicationClusterDict, err = convert.JsonToDict(mqlReplicationCluster{
+					DrReplica:             instance.ReplicationCluster.DrReplica,
+					FailoverDrReplicaName: instance.ReplicationCluster.FailoverDrReplicaName,
+					PsaWriteEndpoint:      instance.ReplicationCluster.PsaWriteEndpoint,
+				})
+				if err != nil {
+					return err
+				}
 			}
 
 			mqlInstance, err := CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance", map[string]*llx.RawData{
@@ -522,12 +641,16 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 				"sqlNetworkArchitecture":       llx.StringData(instance.SqlNetworkArchitecture),
 				"suspensionReason":             llx.ArrayData(convert.SliceAnyToInterface(instance.SuspensionReason), types.String),
 				"switchTransactionLogsToCloudStorageEnabled": llx.BoolData(instance.SwitchTransactionLogsToCloudStorageEnabled),
-				"primaryDnsName":           llx.StringData(instance.PrimaryDnsName),
-				"writeEndpoint":            llx.StringData(instance.WriteEndpoint),
-				"pscServiceAttachmentLink": llx.StringData(instance.PscServiceAttachmentLink),
-				"currentDiskSize":          llx.IntData(instance.CurrentDiskSize),
-				"etag":                     llx.StringData(instance.Etag),
-				"replicaConfiguration":     llx.DictData(replicaConfigDict),
+				"primaryDnsName":             llx.StringData(instance.PrimaryDnsName),
+				"writeEndpoint":              llx.StringData(instance.WriteEndpoint),
+				"pscServiceAttachmentLink":   llx.StringData(instance.PscServiceAttachmentLink),
+				"currentDiskSize":            llx.IntData(instance.CurrentDiskSize),
+				"etag":                       llx.StringData(instance.Etag),
+				"replicaConfiguration":       llx.DictData(replicaConfigDict),
+				"dnsNames":                   llx.ArrayData(mqlDnsNames, types.Dict),
+				"scheduledMaintenance":       llx.DictData(mqlScheduledMaint),
+				"upgradableDatabaseVersions": llx.ArrayData(mqlUpgradableVersions, types.Dict),
+				"replicationCluster":         llx.DictData(mqlReplicationClusterDict),
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
## Summary

Extends `gcp.project.sqlService.instance` with security/TLS, edition, data integration, backup tier, and replication/maintenance fields surfaced by the Cloud SQL Admin API (`google.golang.org/api/sqladmin/v1`).

### IP configuration (TLS / CAS)
- `customSubjectAlternativeNames` — custom SANs presented on the instance server certificate
- `serverCertificateRotationMode` — auto-rotation policy for the server cert
- `serverCaPool` — customer-managed CA pool when `serverCaMode` is `CUSTOMER_MANAGED_CAS_CA`

### Backup configuration
- `backupTier` — `STANDARD` vs `ENHANCED` (Google Cloud Backup and DR Service)
- `transactionalLogStorageState` — `DISK`, `CLOUD_STORAGE`, or transitional states

### Settings
- `edition` — `ENTERPRISE` / `ENTERPRISE_PLUS` / `DEVELOPER`
- `dataCacheConfig` — `{dataCacheEnabled}` (Enterprise Plus data cache)
- `entraidConfig` — `{applicationId, tenantId}` (SQL Server Entra ID auth)
- `dataApiAccess` — `ALLOW_DATA_API` / `DISALLOW_DATA_API`
- `enableGoogleMlIntegration` — Vertex AI integration toggle
- `enableDataplexIntegration` — Dataplex schema extraction toggle

### `DatabaseInstance` level
- `dnsNames` — list of DNS names beyond `dnsName`, with connection type, scope, and record manager
- `scheduledMaintenance` — `{startTime, canDefer, canReschedule, scheduleDeadlineTime}`
- `upgradableDatabaseVersions` — list of upgrade-eligible versions (`{name, majorVersion, displayName}`)
- `replicationCluster` — primary/DR replica pairing (`{drReplica, failoverDrReplicaName, psaWriteEndpoint}`)

All small struct-shaped fields are exposed as `dict` / `[]dict` (no clear ID and no nested typed references — flattening would lose grouping). `.lr.versions` entries land at `13.16.3` (one past current provider version `13.16.2` in `providers/gcp/config/config.go`).

Note: the task description referenced `sqladmin/v1beta4`; the GCP provider compiles against `sqladmin/v1`. All listed fields exist in the v1 SDK pinned in `providers/gcp/go.mod` (`google.golang.org/api v0.280.0`); none had to be skipped. The SDK calls the SQL Server Entra ID struct `EntraidConfig` (lowercase `id`), reflected in the field name.

## Test plan

- [ ] `make providers/build/gcp && make providers/install/gcp`
- [ ] `mql shell gcp` against a project with a Cloud SQL instance and run:
  - `gcp.project.sqlService.instances { name settings.edition settings.dataApiAccess settings.enableGoogleMlIntegration settings.enableDataplexIntegration }`
  - `gcp.project.sqlService.instances { name settings.ipConfiguration { sslMode serverCaMode serverCaPool serverCertificateRotationMode customSubjectAlternativeNames } }`
  - `gcp.project.sqlService.instances { name settings.backupConfiguration { enabled backupTier transactionalLogStorageState } }`
  - `gcp.project.sqlService.instances { name dnsNames scheduledMaintenance upgradableDatabaseVersions replicationCluster }`
  - `gcp.project.sqlService.instances { name settings.dataCacheConfig settings.entraidConfig }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)