### PR TITLE
✨ gcp/compute: add encryption-lineage and replication fields

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -149,6 +149,7 @@ cribl
 crowdstrike
 cryptokey
 Csec
+CSEK
 ctx
 customfield
 customfieldtypes

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -661,6 +661,20 @@ func newMqlComputeServiceInstance(projectId string, zone *mqlGcpProjectComputeSe
 		}
 	}
 
+	mqlInstanceEncryptionKey := customerEncryptionKeyToDict(instance.InstanceEncryptionKey)
+	mqlSourceMachineImageEncryptionKey := customerEncryptionKeyToDict(instance.SourceMachineImageEncryptionKey)
+
+	var mqlAdvancedMachineFeatures map[string]any
+	if instance.AdvancedMachineFeatures != nil {
+		mqlAdvancedMachineFeatures = map[string]any{
+			"enableNestedVirtualization": instance.AdvancedMachineFeatures.EnableNestedVirtualization,
+			"enableUefiNetworking":       instance.AdvancedMachineFeatures.EnableUefiNetworking,
+			"threadsPerCore":             instance.AdvancedMachineFeatures.ThreadsPerCore,
+			"visibleCoreCount":           instance.AdvancedMachineFeatures.VisibleCoreCount,
+			"performanceMonitoringUnit":  instance.AdvancedMachineFeatures.PerformanceMonitoringUnit,
+		}
+	}
+
 	reservationAffinity, err := convert.JsonToDict(instance.ReservationAffinity)
 	if err != nil {
 		return nil, err
@@ -764,6 +778,9 @@ func newMqlComputeServiceInstance(projectId string, zone *mqlGcpProjectComputeSe
 		"satisfiesPzi":                    llx.BoolData(instance.SatisfiesPzi),
 		"satisfiesPzs":                    llx.BoolData(instance.SatisfiesPzs),
 		"workloadIdentityConfig":          llx.DictData(mqlWorkloadIdentityConfig),
+		"instanceEncryptionKey":           llx.DictData(mqlInstanceEncryptionKey),
+		"sourceMachineImageEncryptionKey": llx.DictData(mqlSourceMachineImageEncryptionKey),
+		"advancedMachineFeatures":         llx.DictData(mqlAdvancedMachineFeatures),
 	})
 	if err != nil {
 		return nil, err
@@ -956,6 +973,22 @@ func (g *mqlGcpProjectComputeServiceDisk) storagePool() (*mqlGcpProjectComputeSe
 	return res.(*mqlGcpProjectComputeServiceStoragePool), nil
 }
 
+// customerEncryptionKeyToDict converts a Compute Engine CustomerEncryptionKey to a dict
+// shape: {kmsKeyName, kmsKeyServiceAccount, rawKey, rsaEncryptedKey, sha256}. Returns
+// nil when the key is nil so the field surfaces as null in MQL.
+func customerEncryptionKeyToDict(key *compute.CustomerEncryptionKey) map[string]any {
+	if key == nil {
+		return nil
+	}
+	return map[string]any{
+		"kmsKeyName":           key.KmsKeyName,
+		"kmsKeyServiceAccount": key.KmsKeyServiceAccount,
+		"rawKey":               key.RawKey,
+		"rsaEncryptedKey":      key.RsaEncryptedKey,
+		"sha256":               key.Sha256,
+	}
+}
+
 func (g *mqlGcpProjectComputeService) disks() ([]any, error) {
 	// when the service is not enabled, we return nil
 	if !g.GetEnabled().Data {
@@ -1016,45 +1049,69 @@ func (g *mqlGcpProjectComputeService) disks() ([]any, error) {
 					guestOsFeatures = append(guestOsFeatures, entry.Type)
 				}
 
-				var mqlDiskEnc map[string]any
-				if disk.DiskEncryptionKey != nil {
-					mqlDiskEnc = map[string]any{
-						"kmsKeyName":           disk.DiskEncryptionKey.KmsKeyName,
-						"kmsKeyServiceAccount": disk.DiskEncryptionKey.KmsKeyServiceAccount,
-						"rawKey":               disk.DiskEncryptionKey.RawKey,
-						"rsaEncryptedKey":      disk.DiskEncryptionKey.RsaEncryptedKey,
-						"sha256":               disk.DiskEncryptionKey.Sha256,
+				mqlDiskEnc := customerEncryptionKeyToDict(disk.DiskEncryptionKey)
+				mqlSourceImageEnc := customerEncryptionKeyToDict(disk.SourceImageEncryptionKey)
+				mqlSourceSnapshotEnc := customerEncryptionKeyToDict(disk.SourceSnapshotEncryptionKey)
+
+				var mqlAsyncPrimary map[string]any
+				if disk.AsyncPrimaryDisk != nil {
+					mqlAsyncPrimary = map[string]any{
+						"disk":                     disk.AsyncPrimaryDisk.Disk,
+						"consistencyGroupPolicy":   disk.AsyncPrimaryDisk.ConsistencyGroupPolicy,
+						"consistencyGroupPolicyId": disk.AsyncPrimaryDisk.ConsistencyGroupPolicyId,
+					}
+				}
+
+				var mqlAsyncSecondaries map[string]any
+				if len(disk.AsyncSecondaryDisks) > 0 {
+					mqlAsyncSecondaries = make(map[string]any, len(disk.AsyncSecondaryDisks))
+					for scope, entry := range disk.AsyncSecondaryDisks {
+						var inner map[string]any
+						if entry.AsyncReplicationDisk != nil {
+							inner = map[string]any{
+								"disk":                     entry.AsyncReplicationDisk.Disk,
+								"consistencyGroupPolicy":   entry.AsyncReplicationDisk.ConsistencyGroupPolicy,
+								"consistencyGroupPolicyId": entry.AsyncReplicationDisk.ConsistencyGroupPolicyId,
+							}
+						}
+						mqlAsyncSecondaries[scope] = map[string]any{
+							"asyncReplicationDisk": inner,
+						}
 					}
 				}
 
 				mqlDisk, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.disk", map[string]*llx.RawData{
-					"id":                        llx.StringData(strconv.FormatUint(disk.Id, 10)),
-					"name":                      llx.StringData(disk.Name),
-					"architecture":              llx.StringData(disk.Architecture),
-					"description":               llx.StringData(disk.Description),
-					"guestOsFeatures":           llx.ArrayData(convert.SliceAnyToInterface(guestOsFeatures), types.String),
-					"labels":                    llx.MapData(convert.MapToInterfaceMap(disk.Labels), types.String),
-					"lastAttachTimestamp":       llx.TimeDataPtr(parseTime(disk.LastAttachTimestamp)),
-					"lastDetachTimestamp":       llx.TimeDataPtr(parseTime(disk.LastDetachTimestamp)),
-					"locationHint":              llx.StringData(disk.LocationHint),
-					"licenses":                  llx.ArrayData(convert.SliceAnyToInterface(disk.Licenses), types.String),
-					"physicalBlockSizeBytes":    llx.IntData(disk.PhysicalBlockSizeBytes),
-					"provisionedIops":           llx.IntData(disk.ProvisionedIops),
-					"region":                    llx.StringData(RegionNameFromRegionUrl(disk.Region)),
-					"replicaZones":              llx.ArrayData(zoneNamesFromUrls(disk.ReplicaZones), types.String),
-					"resourcePolicies":          llx.ArrayData(convert.SliceAnyToInterface(disk.ResourcePolicies), types.String),
-					"satisfiesPzi":              llx.BoolData(disk.SatisfiesPzi),
-					"satisfiesPzs":              llx.BoolData(disk.SatisfiesPzs),
-					"sizeGb":                    llx.IntData(disk.SizeGb),
-					"status":                    llx.StringData(disk.Status),
-					"zone":                      llx.ResourceData(zone, "gcp.project.computeService.zone"),
-					"created":                   llx.TimeDataPtr(parseTime(disk.CreationTimestamp)),
-					"diskEncryptionKey":         llx.DictData(mqlDiskEnc),
-					"enableConfidentialCompute": llx.BoolData(disk.EnableConfidentialCompute),
-					"type":                      llx.StringData(disk.Type),
-					"users":                     llx.ArrayData(convert.SliceAnyToInterface(disk.Users), types.String),
-					"accessMode":                llx.StringData(disk.AccessMode),
-					"provisionedThroughput":     llx.IntData(disk.ProvisionedThroughput),
+					"id":                          llx.StringData(strconv.FormatUint(disk.Id, 10)),
+					"name":                        llx.StringData(disk.Name),
+					"architecture":                llx.StringData(disk.Architecture),
+					"description":                 llx.StringData(disk.Description),
+					"guestOsFeatures":             llx.ArrayData(convert.SliceAnyToInterface(guestOsFeatures), types.String),
+					"labels":                      llx.MapData(convert.MapToInterfaceMap(disk.Labels), types.String),
+					"lastAttachTimestamp":         llx.TimeDataPtr(parseTime(disk.LastAttachTimestamp)),
+					"lastDetachTimestamp":         llx.TimeDataPtr(parseTime(disk.LastDetachTimestamp)),
+					"locationHint":                llx.StringData(disk.LocationHint),
+					"licenses":                    llx.ArrayData(convert.SliceAnyToInterface(disk.Licenses), types.String),
+					"physicalBlockSizeBytes":      llx.IntData(disk.PhysicalBlockSizeBytes),
+					"provisionedIops":             llx.IntData(disk.ProvisionedIops),
+					"region":                      llx.StringData(RegionNameFromRegionUrl(disk.Region)),
+					"replicaZones":                llx.ArrayData(zoneNamesFromUrls(disk.ReplicaZones), types.String),
+					"resourcePolicies":            llx.ArrayData(convert.SliceAnyToInterface(disk.ResourcePolicies), types.String),
+					"satisfiesPzi":                llx.BoolData(disk.SatisfiesPzi),
+					"satisfiesPzs":                llx.BoolData(disk.SatisfiesPzs),
+					"sizeGb":                      llx.IntData(disk.SizeGb),
+					"status":                      llx.StringData(disk.Status),
+					"zone":                        llx.ResourceData(zone, "gcp.project.computeService.zone"),
+					"created":                     llx.TimeDataPtr(parseTime(disk.CreationTimestamp)),
+					"diskEncryptionKey":           llx.DictData(mqlDiskEnc),
+					"sourceImageEncryptionKey":    llx.DictData(mqlSourceImageEnc),
+					"sourceSnapshotEncryptionKey": llx.DictData(mqlSourceSnapshotEnc),
+					"asyncPrimaryDisk":            llx.DictData(mqlAsyncPrimary),
+					"asyncSecondaryDisks":         llx.DictData(mqlAsyncSecondaries),
+					"enableConfidentialCompute":   llx.BoolData(disk.EnableConfidentialCompute),
+					"type":                        llx.StringData(disk.Type),
+					"users":                       llx.ArrayData(convert.SliceAnyToInterface(disk.Users), types.String),
+					"accessMode":                  llx.StringData(disk.AccessMode),
+					"provisionedThroughput":       llx.IntData(disk.ProvisionedThroughput),
 				})
 				if err != nil {
 					return err
@@ -1779,6 +1836,8 @@ func (g *mqlGcpProjectComputeService) networks() ([]any, error) {
 				"peerings":                              llx.ArrayData(peerings, types.Dict),
 				"internalIpv6Range":                     llx.StringData(network.InternalIpv6Range),
 				"firewallPolicy":                        llx.StringData(network.FirewallPolicy),
+				"networkProfile":                        llx.StringData(network.NetworkProfile),
+				"ipv4Range":                             llx.StringData(network.IPv4Range),
 			})
 			if err != nil {
 				return err
@@ -2000,30 +2059,41 @@ func newMqlSubnetwork(projectId string, runtime *plugin.Runtime, subnetwork *com
 		}
 	}
 
+	secondaryIpRanges := make([]any, 0, len(subnetwork.GetSecondaryIpRanges()))
+	for _, r := range subnetwork.GetSecondaryIpRanges() {
+		secondaryIpRanges = append(secondaryIpRanges, map[string]any{
+			"rangeName":             r.GetRangeName(),
+			"ipCidrRange":           r.GetIpCidrRange(),
+			"reservedInternalRange": r.GetReservedInternalRange(),
+		})
+	}
+
 	args := map[string]*llx.RawData{
-		"id":                      llx.StringData(subnetId),
-		"projectId":               llx.StringData(projectId),
-		"name":                    llx.StringData(subnetwork.GetName()),
-		"description":             llx.StringData(subnetwork.GetDescription()),
-		"enableFlowLogs":          llx.BoolData(subnetwork.GetEnableFlowLogs()),
-		"externalIpv6Prefix":      llx.StringData(subnetwork.GetExternalIpv6Prefix()),
-		"fingerprint":             llx.StringData(subnetwork.GetFingerprint()),
-		"gatewayAddress":          llx.StringData(subnetwork.GetGatewayAddress()),
-		"internalIpv6Prefix":      llx.StringData(subnetwork.GetInternalIpv6Prefix()),
-		"ipCidrRange":             llx.StringData(subnetwork.GetIpCidrRange()),
-		"ipv6AccessType":          llx.StringData(subnetwork.GetIpv6AccessType()),
-		"ipv6CidrRange":           llx.StringData(subnetwork.GetIpv6CidrRange()),
-		"logConfig":               llx.ResourceData(mqlLogConfig, "gcp.project.computeService.subnetwork.logConfig"),
-		"privateIpGoogleAccess":   llx.BoolData(subnetwork.GetPrivateIpGoogleAccess()),
-		"privateIpv6GoogleAccess": llx.StringData(subnetwork.GetPrivateIpv6GoogleAccess()),
-		"purpose":                 llx.StringData(subnetwork.GetPurpose()),
-		"regionUrl":               llx.StringData(subnetwork.GetRegion()),
-		"role":                    llx.StringData(subnetwork.GetRole()),
-		"stackType":               llx.StringData(subnetwork.GetStackType()),
-		"state":                   llx.StringData(subnetwork.GetState()),
-		"created":                 llx.TimeDataPtr(parseTime(subnetwork.GetCreationTimestamp())),
-		"reservedInternalRange":   llx.StringData(subnetwork.GetReservedInternalRange()),
-		"networkUrl":              llx.StringData(subnetwork.GetNetwork()),
+		"id":                           llx.StringData(subnetId),
+		"projectId":                    llx.StringData(projectId),
+		"name":                         llx.StringData(subnetwork.GetName()),
+		"description":                  llx.StringData(subnetwork.GetDescription()),
+		"enableFlowLogs":               llx.BoolData(subnetwork.GetEnableFlowLogs()),
+		"externalIpv6Prefix":           llx.StringData(subnetwork.GetExternalIpv6Prefix()),
+		"fingerprint":                  llx.StringData(subnetwork.GetFingerprint()),
+		"gatewayAddress":               llx.StringData(subnetwork.GetGatewayAddress()),
+		"internalIpv6Prefix":           llx.StringData(subnetwork.GetInternalIpv6Prefix()),
+		"ipCidrRange":                  llx.StringData(subnetwork.GetIpCidrRange()),
+		"ipv6AccessType":               llx.StringData(subnetwork.GetIpv6AccessType()),
+		"ipv6CidrRange":                llx.StringData(subnetwork.GetIpv6CidrRange()),
+		"logConfig":                    llx.ResourceData(mqlLogConfig, "gcp.project.computeService.subnetwork.logConfig"),
+		"privateIpGoogleAccess":        llx.BoolData(subnetwork.GetPrivateIpGoogleAccess()),
+		"privateIpv6GoogleAccess":      llx.StringData(subnetwork.GetPrivateIpv6GoogleAccess()),
+		"purpose":                      llx.StringData(subnetwork.GetPurpose()),
+		"regionUrl":                    llx.StringData(subnetwork.GetRegion()),
+		"role":                         llx.StringData(subnetwork.GetRole()),
+		"stackType":                    llx.StringData(subnetwork.GetStackType()),
+		"state":                        llx.StringData(subnetwork.GetState()),
+		"created":                      llx.TimeDataPtr(parseTime(subnetwork.GetCreationTimestamp())),
+		"reservedInternalRange":        llx.StringData(subnetwork.GetReservedInternalRange()),
+		"networkUrl":                   llx.StringData(subnetwork.GetNetwork()),
+		"allowSubnetCidrRoutesOverlap": llx.BoolData(subnetwork.GetAllowSubnetCidrRoutesOverlap()),
+		"secondaryIpRanges":            llx.ArrayData(secondaryIpRanges, types.Dict),
 	}
 	if region != nil {
 		args["region"] = llx.ResourceData(region, "gcp.project.computeService.region")

--- a/providers/gcp/resources/compute_test.go
+++ b/providers/gcp/resources/compute_test.go
@@ -1,0 +1,45 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/compute/v1"
+)
+
+func TestCustomerEncryptionKeyToDict(t *testing.T) {
+	t.Run("nil input returns nil", func(t *testing.T) {
+		assert.Nil(t, customerEncryptionKeyToDict(nil))
+	})
+
+	t.Run("populated key maps every field", func(t *testing.T) {
+		got := customerEncryptionKeyToDict(&compute.CustomerEncryptionKey{
+			KmsKeyName:           "projects/p/locations/us/keyRings/r/cryptoKeys/k",
+			KmsKeyServiceAccount: "sa@p.iam.gserviceaccount.com",
+			RawKey:               "raw",
+			RsaEncryptedKey:      "rsa",
+			Sha256:               "deadbeef",
+		})
+		assert.Equal(t, map[string]any{
+			"kmsKeyName":           "projects/p/locations/us/keyRings/r/cryptoKeys/k",
+			"kmsKeyServiceAccount": "sa@p.iam.gserviceaccount.com",
+			"rawKey":               "raw",
+			"rsaEncryptedKey":      "rsa",
+			"sha256":               "deadbeef",
+		}, got)
+	})
+
+	t.Run("empty key still returns a map", func(t *testing.T) {
+		// A non-nil key with all-empty fields should still produce a dict
+		// (with empty-string values), so callers can distinguish "no key
+		// configured" (nil) from "key configured but raw value not returned"
+		// (populated dict with empty strings — common for KMS responses).
+		got := customerEncryptionKeyToDict(&compute.CustomerEncryptionKey{})
+		assert.NotNil(t, got)
+		assert.Equal(t, "", got["kmsKeyName"])
+		assert.Equal(t, "", got["sha256"])
+	})
+}

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -1829,10 +1829,10 @@ gcp.project.computeService.network @defaults("name") {
   networkProfile string
   // Legacy single-region IPv4 range for non-subnetted networks
   //
-  // Only present on legacy (pre-subnet-mode) networks. Subnet-mode
-  // VPC networks should leave this empty; a non-empty value flags
-  // a legacy network kept around for backward compatibility.
-  ipv4Range string
+  // Deprecated in favor of subnet-mode VPC networks. Only present on
+  // legacy (pre-subnet-mode) networks; a non-empty value flags a legacy
+  // network kept around for backward compatibility.
+  ipv4Range @maturity("deprecated") string
 }
 
 // Google Cloud VPC subnetwork

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -1346,6 +1346,32 @@ gcp.project.computeService.instance @defaults("name id") {
   satisfiesPzs bool
   // Workload identity configuration for the instance
   workloadIdentityConfig dict
+  // Customer-supplied or KMS-backed encryption key for instance suspend state and Local SSDs
+  //
+  // Examines the key material that protects suspended data and Local
+  // SSD storage attached to the instance: `kmsKeyName` for
+  // customer-managed KMS keys, `kmsKeyServiceAccount` for the service
+  // account used against the KMS key, `rawKey` / `rsaEncryptedKey` for
+  // customer-supplied encryption keys (CSEK), and `sha256` of the
+  // supplied key. Null when the instance has no instance-level
+  // encryption key configured (Google-managed encryption).
+  instanceEncryptionKey dict
+  // Encryption key used to decrypt the source machine image when the instance was created from one
+  //
+  // Same shape as `instanceEncryptionKey`: `kmsKeyName`,
+  // `kmsKeyServiceAccount`, `rawKey`, `rsaEncryptedKey`, `sha256`.
+  // Useful for tracking encryption lineage from the source machine
+  // image into the instance.
+  sourceMachineImageEncryptionKey dict
+  // Advanced machine features controlling BIOS-level behavior
+  //
+  // Surfaces options usually configured in a BIOS:
+  // `enableNestedVirtualization`, `enableUefiNetworking`,
+  // `threadsPerCore` (set to 1 to disable SMT), `visibleCoreCount`
+  // (number of physical cores exposed), and
+  // `performanceMonitoringUnit` (one of ARCHITECTURAL, ENHANCED,
+  // STANDARD, or PERFORMANCE_MONITORING_UNIT_UNSPECIFIED).
+  advancedMachineFeatures dict
   // VM Manager OS inventory of installed packages and operating system details
   inventory() gcp.project.computeService.instance.osInventory
   // VM Manager vulnerability report for the instance
@@ -1475,6 +1501,35 @@ private gcp.project.computeService.disk @defaults("name") {
   diskEncryptionKey dict
   // Customer-managed KMS key used for disk encryption (null when Google-managed or customer-supplied)
   kmsKey() gcp.project.kmsService.keyring.cryptokey
+  // Encryption key used to decrypt the source image when the disk was created from one
+  //
+  // Same shape as `diskEncryptionKey`: `kmsKeyName`,
+  // `kmsKeyServiceAccount`, `rawKey`, `rsaEncryptedKey`, `sha256`.
+  // Useful for auditing encryption lineage from the source image into
+  // the disk.
+  sourceImageEncryptionKey dict
+  // Encryption key used to decrypt the source snapshot when the disk was created from one
+  //
+  // Same shape as `diskEncryptionKey`: `kmsKeyName`,
+  // `kmsKeyServiceAccount`, `rawKey`, `rsaEncryptedKey`, `sha256`.
+  // Useful for auditing encryption lineage from the source snapshot
+  // into the disk.
+  sourceSnapshotEncryptionKey dict
+  // Primary of the async replication pair when this disk is a secondary
+  //
+  // Surfaces the replication primary for an asynchronously replicated
+  // disk: `disk` (the URL of the primary disk that replicates into
+  // this one), `consistencyGroupPolicy` (the disk consistency group
+  // policy URL when replication started as part of a group), and
+  // `consistencyGroupPolicyId`. Null when this disk is not an async
+  // replication secondary.
+  asyncPrimaryDisk dict
+  // Secondaries that this disk asynchronously replicates to, keyed by zone or region
+  //
+  // Map keyed by the destination scope (for example a zone URL); each
+  // value carries an `asyncReplicationDisk` entry with `disk`,
+  // `consistencyGroupPolicy`, and `consistencyGroupPolicyId`.
+  asyncSecondaryDisks dict
   // Whether the disk uses confidential compute mode encryption
   enableConfidentialCompute bool
   // URL of the disk type resource (e.g., pd-standard, pd-ssd, pd-balanced)
@@ -1770,6 +1825,14 @@ gcp.project.computeService.network @defaults("name") {
   internalIpv6Range string
   // URL of the firewall policy applied to this network
   firewallPolicy string
+  // URL of the network profile applied to this network
+  networkProfile string
+  // Legacy single-region IPv4 range for non-subnetted networks
+  //
+  // Only present on legacy (pre-subnet-mode) networks. Subnet-mode
+  // VPC networks should leave this empty; a non-empty value flags
+  // a legacy network kept around for backward compatibility.
+  ipv4Range string
 }
 
 // Google Cloud VPC subnetwork
@@ -1838,6 +1901,15 @@ gcp.project.computeService.subnetwork @defaults("name") {
   networkUrl @maturity("deprecated") string
   // Parent VPC network this subnetwork belongs to
   network() gcp.project.computeService.network
+  // Whether subnet CIDR routes are allowed to overlap with routes installed by other subnets
+  allowSubnetCidrRoutesOverlap bool
+  // Secondary IP ranges configured on the subnet for alias IP / IPv6 ranges
+  //
+  // Each entry carries `rangeName`, `ipCidrRange`, and
+  // `reservedInternalRange`. Secondary ranges are commonly used by GKE
+  // for Pods and Services and by other workloads that need additional
+  // alias IP allocations beyond the primary `ipCidrRange`.
+  secondaryIpRanges []dict
 }
 
 // Google Cloud (GCP) Compute VPC network partitioning log configuration

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -3595,6 +3595,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.instance.workloadIdentityConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetWorkloadIdentityConfig()).ToDataRes(types.Dict)
 	},
+	"gcp.project.computeService.instance.instanceEncryptionKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstance).GetInstanceEncryptionKey()).ToDataRes(types.Dict)
+	},
+	"gcp.project.computeService.instance.sourceMachineImageEncryptionKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstance).GetSourceMachineImageEncryptionKey()).ToDataRes(types.Dict)
+	},
+	"gcp.project.computeService.instance.advancedMachineFeatures": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstance).GetAdvancedMachineFeatures()).ToDataRes(types.Dict)
+	},
 	"gcp.project.computeService.instance.inventory": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetInventory()).ToDataRes(types.Resource("gcp.project.computeService.instance.osInventory"))
 	},
@@ -3702,6 +3711,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.disk.kmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceDisk).GetKmsKey()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
+	},
+	"gcp.project.computeService.disk.sourceImageEncryptionKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceDisk).GetSourceImageEncryptionKey()).ToDataRes(types.Dict)
+	},
+	"gcp.project.computeService.disk.sourceSnapshotEncryptionKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceDisk).GetSourceSnapshotEncryptionKey()).ToDataRes(types.Dict)
+	},
+	"gcp.project.computeService.disk.asyncPrimaryDisk": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceDisk).GetAsyncPrimaryDisk()).ToDataRes(types.Dict)
+	},
+	"gcp.project.computeService.disk.asyncSecondaryDisks": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceDisk).GetAsyncSecondaryDisks()).ToDataRes(types.Dict)
 	},
 	"gcp.project.computeService.disk.enableConfidentialCompute": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceDisk).GetEnableConfidentialCompute()).ToDataRes(types.Bool)
@@ -4060,6 +4081,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.network.firewallPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceNetwork).GetFirewallPolicy()).ToDataRes(types.String)
 	},
+	"gcp.project.computeService.network.networkProfile": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceNetwork).GetNetworkProfile()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.network.ipv4Range": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceNetwork).GetIpv4Range()).ToDataRes(types.String)
+	},
 	"gcp.project.computeService.subnetwork.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSubnetwork).GetId()).ToDataRes(types.String)
 	},
@@ -4134,6 +4161,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.subnetwork.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSubnetwork).GetNetwork()).ToDataRes(types.Resource("gcp.project.computeService.network"))
+	},
+	"gcp.project.computeService.subnetwork.allowSubnetCidrRoutesOverlap": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceSubnetwork).GetAllowSubnetCidrRoutesOverlap()).ToDataRes(types.Bool)
+	},
+	"gcp.project.computeService.subnetwork.secondaryIpRanges": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceSubnetwork).GetSecondaryIpRanges()).ToDataRes(types.Array(types.Dict))
 	},
 	"gcp.project.computeService.subnetwork.logConfig.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSubnetworkLogConfig).GetId()).ToDataRes(types.String)
@@ -16668,6 +16701,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceInstance).WorkloadIdentityConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.instance.instanceEncryptionKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstance).InstanceEncryptionKey, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.instance.sourceMachineImageEncryptionKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstance).SourceMachineImageEncryptionKey, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.instance.advancedMachineFeatures": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstance).AdvancedMachineFeatures, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.instance.inventory": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstance).Inventory, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceInstanceOsInventory](v.Value, v.Error)
 		return
@@ -16834,6 +16879,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.disk.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceDisk).KmsKey, ok = plugin.RawToTValue[*mqlGcpProjectKmsServiceKeyringCryptokey](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.disk.sourceImageEncryptionKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceDisk).SourceImageEncryptionKey, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.disk.sourceSnapshotEncryptionKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceDisk).SourceSnapshotEncryptionKey, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.disk.asyncPrimaryDisk": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceDisk).AsyncPrimaryDisk, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.disk.asyncSecondaryDisks": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceDisk).AsyncSecondaryDisks, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.disk.enableConfidentialCompute": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -17332,6 +17393,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceNetwork).FirewallPolicy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.network.networkProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceNetwork).NetworkProfile, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.network.ipv4Range": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceNetwork).Ipv4Range, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.subnetwork.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceSubnetwork).__id, ok = v.Value.(string)
 		return
@@ -17434,6 +17503,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.subnetwork.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceSubnetwork).Network, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.subnetwork.allowSubnetCidrRoutesOverlap": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceSubnetwork).AllowSubnetCidrRoutesOverlap, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.subnetwork.secondaryIpRanges": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceSubnetwork).SecondaryIpRanges, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.subnetwork.logConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -38220,6 +38297,9 @@ type mqlGcpProjectComputeServiceInstance struct {
 	SatisfiesPzi                    plugin.TValue[bool]
 	SatisfiesPzs                    plugin.TValue[bool]
 	WorkloadIdentityConfig          plugin.TValue[any]
+	InstanceEncryptionKey           plugin.TValue[any]
+	SourceMachineImageEncryptionKey plugin.TValue[any]
+	AdvancedMachineFeatures         plugin.TValue[any]
 	Inventory                       plugin.TValue[*mqlGcpProjectComputeServiceInstanceOsInventory]
 	VulnerabilityReport             plugin.TValue[*mqlGcpProjectComputeServiceInstanceVulnerabilityReport]
 }
@@ -38487,6 +38567,18 @@ func (c *mqlGcpProjectComputeServiceInstance) GetSatisfiesPzs() *plugin.TValue[b
 
 func (c *mqlGcpProjectComputeServiceInstance) GetWorkloadIdentityConfig() *plugin.TValue[any] {
 	return &c.WorkloadIdentityConfig
+}
+
+func (c *mqlGcpProjectComputeServiceInstance) GetInstanceEncryptionKey() *plugin.TValue[any] {
+	return &c.InstanceEncryptionKey
+}
+
+func (c *mqlGcpProjectComputeServiceInstance) GetSourceMachineImageEncryptionKey() *plugin.TValue[any] {
+	return &c.SourceMachineImageEncryptionKey
+}
+
+func (c *mqlGcpProjectComputeServiceInstance) GetAdvancedMachineFeatures() *plugin.TValue[any] {
+	return &c.AdvancedMachineFeatures
 }
 
 func (c *mqlGcpProjectComputeServiceInstance) GetInventory() *plugin.TValue[*mqlGcpProjectComputeServiceInstanceOsInventory] {
@@ -38821,38 +38913,42 @@ type mqlGcpProjectComputeServiceDisk struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlGcpProjectComputeServiceDiskInternal
-	Id                        plugin.TValue[string]
-	Name                      plugin.TValue[string]
-	Architecture              plugin.TValue[string]
-	Description               plugin.TValue[string]
-	GuestOsFeatures           plugin.TValue[[]any]
-	Labels                    plugin.TValue[map[string]any]
-	LastAttachTimestamp       plugin.TValue[*time.Time]
-	LastDetachTimestamp       plugin.TValue[*time.Time]
-	Licenses                  plugin.TValue[[]any]
-	LocationHint              plugin.TValue[string]
-	PhysicalBlockSizeBytes    plugin.TValue[int64]
-	ProvisionedIops           plugin.TValue[int64]
-	SizeGb                    plugin.TValue[int64]
-	Status                    plugin.TValue[string]
-	Zone                      plugin.TValue[*mqlGcpProjectComputeServiceZone]
-	Created                   plugin.TValue[*time.Time]
-	DiskEncryptionKey         plugin.TValue[any]
-	KmsKey                    plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
-	EnableConfidentialCompute plugin.TValue[bool]
-	Type                      plugin.TValue[string]
-	Users                     plugin.TValue[[]any]
-	AccessMode                plugin.TValue[string]
-	SourceImage               plugin.TValue[*mqlGcpProjectComputeServiceImage]
-	SourceSnapshot            plugin.TValue[*mqlGcpProjectComputeServiceSnapshot]
-	ProvisionedThroughput     plugin.TValue[int64]
-	StoragePool               plugin.TValue[*mqlGcpProjectComputeServiceStoragePool]
-	Region                    plugin.TValue[string]
-	ReplicaZones              plugin.TValue[[]any]
-	ResourcePolicies          plugin.TValue[[]any]
-	SatisfiesPzi              plugin.TValue[bool]
-	SatisfiesPzs              plugin.TValue[bool]
-	SourceDisk                plugin.TValue[*mqlGcpProjectComputeServiceDisk]
+	Id                          plugin.TValue[string]
+	Name                        plugin.TValue[string]
+	Architecture                plugin.TValue[string]
+	Description                 plugin.TValue[string]
+	GuestOsFeatures             plugin.TValue[[]any]
+	Labels                      plugin.TValue[map[string]any]
+	LastAttachTimestamp         plugin.TValue[*time.Time]
+	LastDetachTimestamp         plugin.TValue[*time.Time]
+	Licenses                    plugin.TValue[[]any]
+	LocationHint                plugin.TValue[string]
+	PhysicalBlockSizeBytes      plugin.TValue[int64]
+	ProvisionedIops             plugin.TValue[int64]
+	SizeGb                      plugin.TValue[int64]
+	Status                      plugin.TValue[string]
+	Zone                        plugin.TValue[*mqlGcpProjectComputeServiceZone]
+	Created                     plugin.TValue[*time.Time]
+	DiskEncryptionKey           plugin.TValue[any]
+	KmsKey                      plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
+	SourceImageEncryptionKey    plugin.TValue[any]
+	SourceSnapshotEncryptionKey plugin.TValue[any]
+	AsyncPrimaryDisk            plugin.TValue[any]
+	AsyncSecondaryDisks         plugin.TValue[any]
+	EnableConfidentialCompute   plugin.TValue[bool]
+	Type                        plugin.TValue[string]
+	Users                       plugin.TValue[[]any]
+	AccessMode                  plugin.TValue[string]
+	SourceImage                 plugin.TValue[*mqlGcpProjectComputeServiceImage]
+	SourceSnapshot              plugin.TValue[*mqlGcpProjectComputeServiceSnapshot]
+	ProvisionedThroughput       plugin.TValue[int64]
+	StoragePool                 plugin.TValue[*mqlGcpProjectComputeServiceStoragePool]
+	Region                      plugin.TValue[string]
+	ReplicaZones                plugin.TValue[[]any]
+	ResourcePolicies            plugin.TValue[[]any]
+	SatisfiesPzi                plugin.TValue[bool]
+	SatisfiesPzs                plugin.TValue[bool]
+	SourceDisk                  plugin.TValue[*mqlGcpProjectComputeServiceDisk]
 }
 
 // createGcpProjectComputeServiceDisk creates a new instance of this resource
@@ -38974,6 +39070,22 @@ func (c *mqlGcpProjectComputeServiceDisk) GetKmsKey() *plugin.TValue[*mqlGcpProj
 
 		return c.kmsKey()
 	})
+}
+
+func (c *mqlGcpProjectComputeServiceDisk) GetSourceImageEncryptionKey() *plugin.TValue[any] {
+	return &c.SourceImageEncryptionKey
+}
+
+func (c *mqlGcpProjectComputeServiceDisk) GetSourceSnapshotEncryptionKey() *plugin.TValue[any] {
+	return &c.SourceSnapshotEncryptionKey
+}
+
+func (c *mqlGcpProjectComputeServiceDisk) GetAsyncPrimaryDisk() *plugin.TValue[any] {
+	return &c.AsyncPrimaryDisk
+}
+
+func (c *mqlGcpProjectComputeServiceDisk) GetAsyncSecondaryDisks() *plugin.TValue[any] {
+	return &c.AsyncSecondaryDisks
 }
 
 func (c *mqlGcpProjectComputeServiceDisk) GetEnableConfidentialCompute() *plugin.TValue[bool] {
@@ -39828,6 +39940,8 @@ type mqlGcpProjectComputeServiceNetwork struct {
 	Subnetworks                           plugin.TValue[[]any]
 	InternalIpv6Range                     plugin.TValue[string]
 	FirewallPolicy                        plugin.TValue[string]
+	NetworkProfile                        plugin.TValue[string]
+	Ipv4Range                             plugin.TValue[string]
 }
 
 // createGcpProjectComputeServiceNetwork creates a new instance of this resource
@@ -39969,36 +40083,46 @@ func (c *mqlGcpProjectComputeServiceNetwork) GetFirewallPolicy() *plugin.TValue[
 	return &c.FirewallPolicy
 }
 
+func (c *mqlGcpProjectComputeServiceNetwork) GetNetworkProfile() *plugin.TValue[string] {
+	return &c.NetworkProfile
+}
+
+func (c *mqlGcpProjectComputeServiceNetwork) GetIpv4Range() *plugin.TValue[string] {
+	return &c.Ipv4Range
+}
+
 // mqlGcpProjectComputeServiceSubnetwork for the gcp.project.computeService.subnetwork resource
 type mqlGcpProjectComputeServiceSubnetwork struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlGcpProjectComputeServiceSubnetworkInternal it will be used here
-	Id                      plugin.TValue[string]
-	ProjectId               plugin.TValue[string]
-	Name                    plugin.TValue[string]
-	Description             plugin.TValue[string]
-	EnableFlowLogs          plugin.TValue[bool]
-	ExternalIpv6Prefix      plugin.TValue[string]
-	Fingerprint             plugin.TValue[string]
-	GatewayAddress          plugin.TValue[string]
-	InternalIpv6Prefix      plugin.TValue[string]
-	IpCidrRange             plugin.TValue[string]
-	Ipv6AccessType          plugin.TValue[string]
-	Ipv6CidrRange           plugin.TValue[string]
-	LogConfig               plugin.TValue[*mqlGcpProjectComputeServiceSubnetworkLogConfig]
-	PrivateIpGoogleAccess   plugin.TValue[bool]
-	PrivateIpv6GoogleAccess plugin.TValue[string]
-	Purpose                 plugin.TValue[string]
-	Region                  plugin.TValue[*mqlGcpProjectComputeServiceRegion]
-	RegionUrl               plugin.TValue[string]
-	Role                    plugin.TValue[string]
-	StackType               plugin.TValue[string]
-	State                   plugin.TValue[string]
-	Created                 plugin.TValue[*time.Time]
-	ReservedInternalRange   plugin.TValue[string]
-	NetworkUrl              plugin.TValue[string]
-	Network                 plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
+	Id                           plugin.TValue[string]
+	ProjectId                    plugin.TValue[string]
+	Name                         plugin.TValue[string]
+	Description                  plugin.TValue[string]
+	EnableFlowLogs               plugin.TValue[bool]
+	ExternalIpv6Prefix           plugin.TValue[string]
+	Fingerprint                  plugin.TValue[string]
+	GatewayAddress               plugin.TValue[string]
+	InternalIpv6Prefix           plugin.TValue[string]
+	IpCidrRange                  plugin.TValue[string]
+	Ipv6AccessType               plugin.TValue[string]
+	Ipv6CidrRange                plugin.TValue[string]
+	LogConfig                    plugin.TValue[*mqlGcpProjectComputeServiceSubnetworkLogConfig]
+	PrivateIpGoogleAccess        plugin.TValue[bool]
+	PrivateIpv6GoogleAccess      plugin.TValue[string]
+	Purpose                      plugin.TValue[string]
+	Region                       plugin.TValue[*mqlGcpProjectComputeServiceRegion]
+	RegionUrl                    plugin.TValue[string]
+	Role                         plugin.TValue[string]
+	StackType                    plugin.TValue[string]
+	State                        plugin.TValue[string]
+	Created                      plugin.TValue[*time.Time]
+	ReservedInternalRange        plugin.TValue[string]
+	NetworkUrl                   plugin.TValue[string]
+	Network                      plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
+	AllowSubnetCidrRoutesOverlap plugin.TValue[bool]
+	SecondaryIpRanges            plugin.TValue[[]any]
 }
 
 // createGcpProjectComputeServiceSubnetwork creates a new instance of this resource
@@ -40160,6 +40284,14 @@ func (c *mqlGcpProjectComputeServiceSubnetwork) GetNetwork() *plugin.TValue[*mql
 
 		return c.network()
 	})
+}
+
+func (c *mqlGcpProjectComputeServiceSubnetwork) GetAllowSubnetCidrRoutesOverlap() *plugin.TValue[bool] {
+	return &c.AllowSubnetCidrRoutesOverlap
+}
+
+func (c *mqlGcpProjectComputeServiceSubnetwork) GetSecondaryIpRanges() *plugin.TValue[[]any] {
+	return &c.SecondaryIpRanges
 }
 
 // mqlGcpProjectComputeServiceSubnetworkLogConfig for the gcp.project.computeService.subnetwork.logConfig resource

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -1373,6 +1373,8 @@ gcp.project.computeService.backendServices 9.0.0
 gcp.project.computeService.disk 9.0.0
 gcp.project.computeService.disk.accessMode 11.6.6
 gcp.project.computeService.disk.architecture 9.0.0
+gcp.project.computeService.disk.asyncPrimaryDisk 13.16.3
+gcp.project.computeService.disk.asyncSecondaryDisks 13.16.3
 gcp.project.computeService.disk.created 9.0.0
 gcp.project.computeService.disk.description 9.0.0
 gcp.project.computeService.disk.diskEncryptionKey 9.0.0
@@ -1397,7 +1399,9 @@ gcp.project.computeService.disk.satisfiesPzs 13.1.2
 gcp.project.computeService.disk.sizeGb 9.0.0
 gcp.project.computeService.disk.sourceDisk 13.1.2
 gcp.project.computeService.disk.sourceImage 11.6.6
+gcp.project.computeService.disk.sourceImageEncryptionKey 13.16.3
 gcp.project.computeService.disk.sourceSnapshot 11.6.6
+gcp.project.computeService.disk.sourceSnapshotEncryptionKey 13.16.3
 gcp.project.computeService.disk.status 9.0.0
 gcp.project.computeService.disk.storagePool 11.6.6
 gcp.project.computeService.disk.type 11.6.6
@@ -1556,6 +1560,7 @@ gcp.project.computeService.image.status 9.0.0
 gcp.project.computeService.image.storageLocations 13.1.2
 gcp.project.computeService.images 9.0.0
 gcp.project.computeService.instance 9.0.0
+gcp.project.computeService.instance.advancedMachineFeatures 13.16.3
 gcp.project.computeService.instance.blockProjectSshKeysEnabled 13.12.2
 gcp.project.computeService.instance.canIpForward 9.0.0
 gcp.project.computeService.instance.confidentialCompute 13.16.3
@@ -1577,6 +1582,7 @@ gcp.project.computeService.instance.hasFullCloudPlatformScope 13.12.2
 gcp.project.computeService.instance.hasPublicIp 13.12.2
 gcp.project.computeService.instance.hostname 9.0.0
 gcp.project.computeService.instance.id 9.0.0
+gcp.project.computeService.instance.instanceEncryptionKey 13.16.3
 gcp.project.computeService.instance.inventory 13.15.1
 gcp.project.computeService.instance.keyRevocationActionType 9.0.0
 gcp.project.computeService.instance.labels 9.0.0
@@ -1611,6 +1617,7 @@ gcp.project.computeService.instance.shieldedInstanceConfig.enableVtpm 11.6.3
 gcp.project.computeService.instance.shieldedInstanceConfig.id 11.6.3
 gcp.project.computeService.instance.shieldedInstanceIntegrityPolicy 13.7.2
 gcp.project.computeService.instance.sourceMachineImage 9.0.0
+gcp.project.computeService.instance.sourceMachineImageEncryptionKey 13.16.3
 gcp.project.computeService.instance.startRestricted 9.0.0
 gcp.project.computeService.instance.status 9.0.0
 gcp.project.computeService.instance.statusMessage 9.0.0
@@ -1747,12 +1754,14 @@ gcp.project.computeService.network.firewallPolicy 11.6.6
 gcp.project.computeService.network.gatewayIPv4 9.0.0
 gcp.project.computeService.network.id 9.0.0
 gcp.project.computeService.network.internalIpv6Range 11.6.6
+gcp.project.computeService.network.ipv4Range 13.16.3
 gcp.project.computeService.network.legacy 13.12.2
 gcp.project.computeService.network.mode 9.0.0
 gcp.project.computeService.network.mtu 9.0.0
 gcp.project.computeService.network.name 9.0.0
 gcp.project.computeService.network.networkFirewallPolicyEnforcementOrder 9.0.0
 gcp.project.computeService.network.networkPeerings 11.6.6
+gcp.project.computeService.network.networkProfile 13.16.3
 gcp.project.computeService.network.peering 11.6.6
 gcp.project.computeService.network.peering.autoCreateRoutes 11.6.6
 gcp.project.computeService.network.peering.exchangeSubnetRoutes 11.6.6
@@ -2018,6 +2027,7 @@ gcp.project.computeService.storagePool.storagePoolType 11.6.6
 gcp.project.computeService.storagePool.zone 11.6.6
 gcp.project.computeService.storagePools 11.6.6
 gcp.project.computeService.subnetwork 9.0.0
+gcp.project.computeService.subnetwork.allowSubnetCidrRoutesOverlap 13.16.3
 gcp.project.computeService.subnetwork.created 9.0.0
 gcp.project.computeService.subnetwork.description 9.0.0
 gcp.project.computeService.subnetwork.enableFlowLogs 9.0.0
@@ -2048,6 +2058,7 @@ gcp.project.computeService.subnetwork.region 9.0.0
 gcp.project.computeService.subnetwork.regionUrl 9.0.0
 gcp.project.computeService.subnetwork.reservedInternalRange 11.6.6
 gcp.project.computeService.subnetwork.role 9.0.0
+gcp.project.computeService.subnetwork.secondaryIpRanges 13.16.3
 gcp.project.computeService.subnetwork.stackType 9.0.0
 gcp.project.computeService.subnetwork.state 9.0.0
 gcp.project.computeService.subnetworks 9.0.0

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
   "version": "13.16.2",
-  "generated_at": "2026-05-22T08:27:51-07:00",
+  "generated_at": "2026-05-23T17:10:11-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.customJobs.list",
@@ -628,7 +628,7 @@
     {
       "permission": "compute.disks.list",
       "service": "compute",
-      "action": "Disks.List",
+      "action": "Disks.AggregatedList",
       "source_file": "compute.go"
     },
     {
@@ -694,7 +694,7 @@
     {
       "permission": "compute.instances.list",
       "service": "compute",
-      "action": "Instances.List",
+      "action": "Instances.AggregatedList",
       "source_file": "compute.go"
     },
     {
@@ -718,7 +718,7 @@
     {
       "permission": "compute.machineTypes.list",
       "service": "compute",
-      "action": "MachineTypes.List",
+      "action": "MachineTypes.AggregatedList",
       "source_file": "compute.go"
     },
     {
@@ -790,7 +790,7 @@
     {
       "permission": "compute.routers.list",
       "service": "compute",
-      "action": "Routers.List",
+      "action": "Routers.AggregatedList",
       "source_file": "compute.go"
     },
     {


### PR DESCRIPTION
## Summary

Surfaces previously unmodeled fields from the Compute Engine REST API on the instance, disk, network, and subnetwork resources. The new fields cover encryption-key lineage (KMS / CSEK metadata at instance, disk, and source levels), async disk replication, advanced machine BIOS-level features, secondary subnet IP ranges, and the legacy-network `ipv4Range` flag.

## Fields added

| Resource | New field | Type | Source |
|---|---|---|---|
| `gcp.project.computeService.instance` | `instanceEncryptionKey` | `dict` | `Instance.InstanceEncryptionKey` |
| `gcp.project.computeService.instance` | `sourceMachineImageEncryptionKey` | `dict` | `Instance.SourceMachineImageEncryptionKey` |
| `gcp.project.computeService.instance` | `advancedMachineFeatures` | `dict` | `Instance.AdvancedMachineFeatures` |
| `gcp.project.computeService.disk` | `sourceImageEncryptionKey` | `dict` | `Disk.SourceImageEncryptionKey` |
| `gcp.project.computeService.disk` | `sourceSnapshotEncryptionKey` | `dict` | `Disk.SourceSnapshotEncryptionKey` |
| `gcp.project.computeService.disk` | `asyncPrimaryDisk` | `dict` | `Disk.AsyncPrimaryDisk` |
| `gcp.project.computeService.disk` | `asyncSecondaryDisks` | `dict` | `Disk.AsyncSecondaryDisks` |
| `gcp.project.computeService.network` | `networkProfile` | `string` | `Network.NetworkProfile` |
| `gcp.project.computeService.network` | `ipv4Range` | `string` | `Network.IPv4Range` |
| `gcp.project.computeService.subnetwork` | `allowSubnetCidrRoutesOverlap` | `bool` | `Subnetwork.AllowSubnetCidrRoutesOverlap` |
| `gcp.project.computeService.subnetwork` | `secondaryIpRanges` | `[]dict` | `Subnetwork.SecondaryIpRanges` |

A shared `customerEncryptionKeyToDict` helper keeps the `{kmsKeyName, kmsKeyServiceAccount, rawKey, rsaEncryptedKey, sha256}` shape consistent across the three new instance/disk encryption-key fields and the pre-existing `diskEncryptionKey`.

## Notes

- `secondaryIpRanges` exposes `{rangeName, ipCidrRange, reservedInternalRange}`. The protobuf `SubnetworkSecondaryRange` in the SDK version we compile against does not have an `ipv6AccessType` accessor, so that field is intentionally omitted from the dict shape.
- `gcp.permissions.json` carries a small drift fix (`Disks.List` → `Disks.AggregatedList` action description) that landed with the recent AggregatedList migration but had not been regenerated.

## Test plan

- [ ] `make providers/build/gcp && make providers/install/gcp`
- [ ] `mql run gcp -c "gcp.compute.instances { name, instanceEncryptionKey, sourceMachineImageEncryptionKey, advancedMachineFeatures }"`
- [ ] `mql run gcp -c "gcp.project.computeService.disks { name, sourceImageEncryptionKey, sourceSnapshotEncryptionKey, asyncPrimaryDisk, asyncSecondaryDisks }"`
- [ ] `mql run gcp -c "gcp.project.computeService.networks { name, networkProfile, ipv4Range }"` — confirm legacy networks show `ipv4Range`
- [ ] `mql run gcp -c "gcp.project.computeService.subnetworks { name, allowSubnetCidrRoutesOverlap, secondaryIpRanges }"` — confirm GKE subnets surface Pod/Service ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)