### PR TITLE
🧪 gcp: add uniqueness tests for sub-resource id formatters

### DIFF
--- a/providers/gcp/resources/eventarc.go
+++ b/providers/gcp/resources/eventarc.go
@@ -82,6 +82,14 @@ func (g *mqlGcpProjectEventarcServiceTrigger) id() (string, error) {
 	return g.Name.Data, g.Name.Error
 }
 
+// eventFilterID returns a cache-stable identifier for an Eventarc trigger
+// event filter. A trigger can declare multiple filters that share an
+// attribute key but match different values, so both must participate in
+// the id to avoid runtime-cache collisions.
+func eventFilterID(triggerName, attribute, value string) string {
+	return fmt.Sprintf("%s/eventFilters/%s/%s", triggerName, attribute, value)
+}
+
 func (g *mqlGcpProjectEventarcServiceTriggerEventFilter) id() (string, error) {
 	return g.Id.Data, g.Id.Error
 }
@@ -130,7 +138,7 @@ func (g *mqlGcpProjectEventarcService) triggers() ([]any, error) {
 		eventFilters := make([]any, 0, len(trigger.EventFilters))
 		for _, ef := range trigger.EventFilters {
 			mqlEF, err := CreateResource(g.MqlRuntime, "gcp.project.eventarcService.trigger.eventFilter", map[string]*llx.RawData{
-				"id":        llx.StringData(fmt.Sprintf("%s/eventFilters/%s/%s", trigger.Name, ef.Attribute, ef.Value)),
+				"id":        llx.StringData(eventFilterID(trigger.Name, ef.Attribute, ef.Value)),
 				"attribute": llx.StringData(ef.Attribute),
 				"value":     llx.StringData(ef.Value),
 				"operator":  llx.StringData(ef.Operator),

--- a/providers/gcp/resources/eventarc_test.go
+++ b/providers/gcp/resources/eventarc_test.go
@@ -1,0 +1,47 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventFilterID(t *testing.T) {
+	// Eventarc triggers can declare multiple filters sharing an attribute
+	// name but matching different values. Without the value in the id,
+	// siblings collide in the runtime cache and one wins.
+	cases := []struct {
+		name string
+		want string
+		got  string
+	}{
+		{
+			name: "happy path",
+			want: "trigger1/eventFilters/type/google.cloud.storage.object.v1.finalized",
+			got:  eventFilterID("trigger1", "type", "google.cloud.storage.object.v1.finalized"),
+		},
+		{
+			name: "same attribute, different value",
+			want: "trigger1/eventFilters/type/google.cloud.audit.log.v1.written",
+			got:  eventFilterID("trigger1", "type", "google.cloud.audit.log.v1.written"),
+		},
+		{
+			name: "different attribute, same value",
+			want: "trigger1/eventFilters/serviceName/storage.googleapis.com",
+			got:  eventFilterID("trigger1", "serviceName", "storage.googleapis.com"),
+		},
+	}
+	seen := make(map[string]string, len(cases))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.got)
+			if prev, exists := seen[tc.got]; exists {
+				t.Fatalf("id collision: %q produced by both %q and %q", tc.got, prev, tc.name)
+			}
+			seen[tc.got] = tc.name
+		})
+	}
+}

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -901,6 +901,14 @@ func createMqlNodePool(runtime *plugin.Runtime, np *containerpb.NodePool, cluste
 	return res, nil
 }
 
+// nodeTaintID returns a cache-stable identifier for a node-pool taint.
+// Kubernetes taints are uniquely identified by (key, value, effect); a node
+// pool can carry sibling taints sharing any one of those, so all three must
+// participate in the id to avoid runtime-cache collisions.
+func nodeTaintID(nodePoolId, key, value, effect string) string {
+	return fmt.Sprintf("%s/taints/%s/%s/%s", nodePoolId, key, value, effect)
+}
+
 func createMqlNodePoolConfig(runtime *plugin.Runtime, np *containerpb.NodePool, nodePoolId, projectId string) (plugin.Resource, error) {
 	cfg := np.Config
 	if cfg == nil {
@@ -919,7 +927,7 @@ func createMqlNodePoolConfig(runtime *plugin.Runtime, np *containerpb.NodePool, 
 	nodeTaints := make([]any, 0, len(cfg.Taints))
 	for _, taint := range cfg.Taints {
 		mqlNodeTaint, err := CreateResource(runtime, "gcp.project.gkeService.cluster.nodepool.config.nodeTaint", map[string]*llx.RawData{
-			"id":     llx.StringData(fmt.Sprintf("%s/taints/%s/%s/%s", nodePoolId, taint.Key, taint.Value, taint.Effect.String())),
+			"id":     llx.StringData(nodeTaintID(nodePoolId, taint.Key, taint.Value, taint.Effect.String())),
 			"key":    llx.StringData(taint.Key),
 			"value":  llx.StringData(taint.Value),
 			"effect": llx.StringData(taint.Effect.String()),

--- a/providers/gcp/resources/gke_test.go
+++ b/providers/gcp/resources/gke_test.go
@@ -11,6 +11,43 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNodeTaintID(t *testing.T) {
+	// Kubernetes taints are uniquely identified by (key, value, effect). A node
+	// pool may carry siblings that share any one or two of those — collisions
+	// here silently drop taints from the runtime cache.
+	cases := []struct {
+		name string
+		want string
+		got  string
+	}{
+		{
+			name: "happy path",
+			want: "pool1/taints/dedicated/team-a/NoSchedule",
+			got:  nodeTaintID("pool1", "dedicated", "team-a", "NoSchedule"),
+		},
+		{
+			name: "same key, different value",
+			want: "pool1/taints/dedicated/team-b/NoSchedule",
+			got:  nodeTaintID("pool1", "dedicated", "team-b", "NoSchedule"),
+		},
+		{
+			name: "same key & value, different effect",
+			want: "pool1/taints/dedicated/team-a/PreferNoSchedule",
+			got:  nodeTaintID("pool1", "dedicated", "team-a", "PreferNoSchedule"),
+		},
+	}
+	seen := make(map[string]string, len(cases))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.got)
+			if prev, exists := seen[tc.got]; exists {
+				t.Fatalf("id collision: %q produced by both %q and %q", tc.got, prev, tc.name)
+			}
+			seen[tc.got] = tc.name
+		})
+	}
+}
+
 func TestBuildGKENotificationConfig(t *testing.T) {
 	t.Run("nil input returns nil", func(t *testing.T) {
 		result, err := buildGKENotificationConfig(nil, "parent", nil)

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -96,6 +96,22 @@ func initGcpProjectSqlServiceInstance(runtime *plugin.Runtime, args map[string]*
 	return nil, nil, errors.New("SQL instance not found")
 }
 
+// sqlIPMappingID returns a cache-stable identifier for a Cloud SQL instance
+// IP address. A single instance can expose more than one IP of the same
+// Type (e.g., two PRIVATE IPs across distinct VPCs), so the address itself
+// must participate in the id to avoid runtime-cache collisions.
+func sqlIPMappingID(instanceId, ipType, ipAddress string) string {
+	return fmt.Sprintf("%s/ipAddresses/%s/%s", instanceId, ipType, ipAddress)
+}
+
+// sqlDenyMaintenancePeriodID returns a cache-stable identifier for a
+// Cloud SQL deny-maintenance period. Two periods can start on the same
+// date (e.g., recurring annual windows) but cover different end dates, so
+// both dates must participate in the id.
+func sqlDenyMaintenancePeriodID(instanceId, startDate, endDate string) string {
+	return fmt.Sprintf("%s/settings/denyMaintenancePeriod/%s/%s", instanceId, startDate, endDate)
+}
+
 func (g *mqlGcpProjectSqlService) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error
@@ -210,7 +226,7 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 			mqlIpAddresses := make([]any, 0, len(instance.IpAddresses))
 			for _, a := range instance.IpAddresses {
 				mqlIpAddress, err := CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.ipMapping", map[string]*llx.RawData{
-					"id":           llx.StringData(fmt.Sprintf("%s/ipAddresses/%s/%s", instanceId, a.Type, a.IpAddress)),
+					"id":           llx.StringData(sqlIPMappingID(instanceId, a.Type, a.IpAddress)),
 					"ipAddress":    llx.StringData(a.IpAddress),
 					"timeToRetire": llx.TimeDataPtr(parseTime(a.TimeToRetire)),
 					"type":         llx.StringData(a.Type),
@@ -283,7 +299,7 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 			mqlDenyMaintenancePeriods := make([]any, 0, len(s.DenyMaintenancePeriods))
 			for _, p := range s.DenyMaintenancePeriods {
 				mqlPeriod, err := CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings.denyMaintenancePeriod", map[string]*llx.RawData{
-					"id":        llx.StringData(fmt.Sprintf("%s/settings/denyMaintenancePeriod/%s/%s", instanceId, p.StartDate, p.EndDate)),
+					"id":        llx.StringData(sqlDenyMaintenancePeriodID(instanceId, p.StartDate, p.EndDate)),
 					"endDate":   llx.StringData(p.EndDate),
 					"startDate": llx.StringData(p.StartDate),
 					"time":      llx.StringData(p.Time),

--- a/providers/gcp/resources/sql_test.go
+++ b/providers/gcp/resources/sql_test.go
@@ -1,0 +1,83 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSQLIPMappingID(t *testing.T) {
+	// A Cloud SQL instance can expose more than one IP of the same Type
+	// (e.g., two PRIVATE IPs across distinct VPC networks). The address
+	// itself disambiguates them.
+	cases := []struct {
+		name string
+		want string
+		got  string
+	}{
+		{
+			name: "primary",
+			want: "inst1/ipAddresses/PRIMARY/34.10.20.30",
+			got:  sqlIPMappingID("inst1", "PRIMARY", "34.10.20.30"),
+		},
+		{
+			name: "first private",
+			want: "inst1/ipAddresses/PRIVATE/10.0.0.5",
+			got:  sqlIPMappingID("inst1", "PRIVATE", "10.0.0.5"),
+		},
+		{
+			name: "second private on different VPC",
+			want: "inst1/ipAddresses/PRIVATE/10.1.0.5",
+			got:  sqlIPMappingID("inst1", "PRIVATE", "10.1.0.5"),
+		},
+	}
+	seen := make(map[string]string, len(cases))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.got)
+			if prev, exists := seen[tc.got]; exists {
+				t.Fatalf("id collision: %q produced by both %q and %q", tc.got, prev, tc.name)
+			}
+			seen[tc.got] = tc.name
+		})
+	}
+}
+
+func TestSQLDenyMaintenancePeriodID(t *testing.T) {
+	// Two periods can begin on the same date (e.g., recurring annual
+	// freezes) but end on different ones; both must participate in the id.
+	cases := []struct {
+		name string
+		want string
+		got  string
+	}{
+		{
+			name: "single period",
+			want: "inst1/settings/denyMaintenancePeriod/2026-01-01/2026-01-07",
+			got:  sqlDenyMaintenancePeriodID("inst1", "2026-01-01", "2026-01-07"),
+		},
+		{
+			name: "same start, different end",
+			want: "inst1/settings/denyMaintenancePeriod/2026-01-01/2026-01-14",
+			got:  sqlDenyMaintenancePeriodID("inst1", "2026-01-01", "2026-01-14"),
+		},
+		{
+			name: "different start, same end",
+			want: "inst1/settings/denyMaintenancePeriod/2026-02-01/2026-01-14",
+			got:  sqlDenyMaintenancePeriodID("inst1", "2026-02-01", "2026-01-14"),
+		},
+	}
+	seen := make(map[string]string, len(cases))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.got)
+			if prev, exists := seen[tc.got]; exists {
+				t.Fatalf("id collision: %q produced by both %q and %q", tc.got, prev, tc.name)
+			}
+			seen[tc.got] = tc.name
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #7899. That PR fixed two rounds of cache collisions in sibling sub-resource ids — first loop-indexed ids, then ids where a single discriminator wasn't enough. This adds tests so the uniqueness invariant doesn't quietly regress again.

For each of the four high-risk formatters, extracts a small named helper and adds a table-driven test that runs plausible collision-prone inputs (same taint key with different values, two PRIVATE Cloud SQL IPs across VPCs, recurring annual deny-maintenance windows, etc.) and asserts the resulting ids are distinct.

## Helpers

Each lives next to its caller, so the format choice and the cache-key invariant are documented in one place:

| File | Helper |
|---|---|
| `gke.go` | `nodeTaintID(nodePoolId, key, value, effect)` |
| `eventarc.go` | `eventFilterID(triggerName, attribute, value)` |
| `sql.go` | `sqlIPMappingID(instanceId, ipType, ipAddress)` |
| `sql.go` | `sqlDenyMaintenancePeriodID(instanceId, startDate, endDate)` |

## Tests

- `gke_test.go` — extended with `TestNodeTaintID`
- `eventarc_test.go` — new; `TestEventFilterID`
- `sql_test.go` — new; `TestSQLIPMappingID`, `TestSQLDenyMaintenancePeriodID`

Each test uses a `seen` map to fail explicitly on any collision rather than relying on the assert chain alone.

## Test plan

- [x] `cd providers/gcp && go test ./resources/ -run 'TestNodeTaintID|TestEventFilterID|TestSQLIPMappingID|TestSQLDenyMaintenancePeriodID' -v` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)