### PR TITLE
🐛 ms365: paginate list endpoints and stop swallowing errors

### DIFF
--- a/providers/ms365/resources/applications.go
+++ b/providers/ms365/resources/applications.go
@@ -111,20 +111,52 @@ func newMqlMicrosoftApplication(runtime *plugin.Runtime, app models.Applicationa
 		secrets = append(secrets, secret)
 	}
 
+	// Each conversion is checked individually — the previous code threaded a
+	// single err variable through all of them and only inspected the last one,
+	// silently dropping any earlier failures.
 	info, err := convert.JsonToDict(newAppInformationUrl(app.GetInfo()))
+	if err != nil {
+		return nil, err
+	}
 	// https://learn.microsoft.com/en-us/entra/identity-platform/reference-microsoft-graph-app-manifest#api-attribute
 	apiInfo, err := convert.JsonToDict(newApiApplication(app.GetApi()))
+	if err != nil {
+		return nil, err
+	}
 	// https://learn.microsoft.com/en-us/entra/identity-platform/reference-microsoft-graph-app-manifest#web-attribute
 	webInfo, err := convert.JsonToDict(newWebApplication(app.GetWeb()))
+	if err != nil {
+		return nil, err
+	}
 	// https://learn.microsoft.com/en-us/entra/identity-platform/reference-microsoft-graph-app-manifest#spa-attribute
 	spaInfo, err := convert.JsonToDict(newSpaApplication(app.GetSpa()))
-
+	if err != nil {
+		return nil, err
+	}
 	certification, err := convert.JsonToDict(newCertificationable(app.GetCertification()))
+	if err != nil {
+		return nil, err
+	}
 	optionalClaims, err := convert.JsonToDict(newOptionalClaimsable(app.GetOptionalClaims()))
+	if err != nil {
+		return nil, err
+	}
 	servicePrincipalLockConfiguration, err := convert.JsonToDict(newServicePrincipalLockConfiguration(app.GetServicePrincipalLockConfiguration()))
+	if err != nil {
+		return nil, err
+	}
 	requestSignatureVerification, err := convert.JsonToDict(newRequestSignatureVerification(app.GetRequestSignatureVerification()))
+	if err != nil {
+		return nil, err
+	}
 	parentalControlSettings, err := convert.JsonToDict(newParentalControlSettings(app.GetParentalControlSettings()))
+	if err != nil {
+		return nil, err
+	}
 	publicClient, err := convert.JsonToDict(newPublicClientApplication(app.GetPublicClient()))
+	if err != nil {
+		return nil, err
+	}
 	requiredResourceAccess, err := convert.JsonToDictSlice(newRequiredResourceAccessList(app.GetRequiredResourceAccess()))
 	if err != nil {
 		return nil, err
@@ -368,10 +400,14 @@ func (a *mqlMicrosoftApplication) owners() ([]any, error) {
 	if err != nil {
 		return nil, transformError(err)
 	}
+	owners, err := iterate[models.DirectoryObjectable](ctx, resp, graphClient.GetAdapter(), models.CreateDirectoryObjectCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
 
 	res := []any{}
-	for i := range resp.GetValue() {
-		ownerId := resp.GetValue()[i].GetId()
+	for _, owner := range owners {
+		ownerId := owner.GetId()
 		if ownerId == nil {
 			continue
 		}

--- a/providers/ms365/resources/conditional-access.go
+++ b/providers/ms365/resources/conditional-access.go
@@ -35,13 +35,17 @@ func (a *mqlMicrosoftConditionalAccessNamedLocations) ipLocations() ([]any, erro
 	}
 
 	ctx := context.Background()
-	namedLocations, err := graphClient.Identity().ConditionalAccess().NamedLocations().Get(ctx, nil)
+	resp, err := graphClient.Identity().ConditionalAccess().NamedLocations().Get(ctx, nil)
 	if err != nil {
 		return nil, transformError(err)
 	}
+	namedLocations, err := iterate[models.NamedLocationable](ctx, resp, graphClient.GetAdapter(), models.CreateNamedLocationCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
 
 	var locationDetails []any
-	for _, location := range namedLocations.GetValue() {
+	for _, location := range namedLocations {
 		if ipLocation, ok := location.(*models.IpNamedLocation); ok {
 			displayName := ipLocation.GetDisplayName()
 			isTrusted := ipLocation.GetIsTrusted()
@@ -88,13 +92,17 @@ func (a *mqlMicrosoftConditionalAccessNamedLocations) countryLocations() ([]any,
 	}
 
 	ctx := context.Background()
-	namedLocations, err := graphClient.Identity().ConditionalAccess().NamedLocations().Get(ctx, nil)
+	resp, err := graphClient.Identity().ConditionalAccess().NamedLocations().Get(ctx, nil)
 	if err != nil {
 		return nil, transformError(err)
 	}
+	namedLocations, err := iterate[models.NamedLocationable](ctx, resp, graphClient.GetAdapter(), models.CreateNamedLocationCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
 
 	var locationDetails []any
-	for _, location := range namedLocations.GetValue() {
+	for _, location := range namedLocations {
 		if countryLocation, ok := location.(*models.CountryNamedLocation); ok {
 			displayName := countryLocation.GetDisplayName()
 			countryLookupMethod := countryLocation.GetCountryLookupMethod()
@@ -151,13 +159,17 @@ func (a *mqlMicrosoftConditionalAccess) policies() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	policies, err := graphClient.Identity().ConditionalAccess().Policies().Get(ctx, nil)
+	resp, err := graphClient.Identity().ConditionalAccess().Policies().Get(ctx, nil)
 	if err != nil {
 		return nil, transformError(err)
 	}
+	policies, err := iterate[models.ConditionalAccessPolicyable](ctx, resp, graphClient.GetAdapter(), models.CreateConditionalAccessPolicyCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
 
 	var policyDetails []any
-	for _, policy := range policies.GetValue() {
+	for _, policy := range policies {
 		id := policy.GetId()
 		displayName := policy.GetDisplayName()
 

--- a/providers/ms365/resources/devicemanagement.go
+++ b/providers/ms365/resources/devicemanagement.go
@@ -41,30 +41,9 @@ func (a *mqlMicrosoftDevicemanagement) managedDevices() ([]any, error) {
 	if err != nil {
 		return nil, transformError(err)
 	}
-
-	var allDevices []models.ManagedDeviceable
-
-	// Add first page results
-	if resp.GetValue() != nil {
-		allDevices = append(allDevices, resp.GetValue()...)
-	}
-
-	// Handle pagination
-	for resp.GetOdataNextLink() != nil {
-		nextLink := *resp.GetOdataNextLink()
-
-		// Create request from next link
-		nextResp, err := graphClient.DeviceManagement().ManagedDevices().WithUrl(nextLink).Get(ctx, nil)
-		if err != nil {
-			return nil, err
-		}
-
-		// Add results from this page
-		if nextResp.GetValue() != nil {
-			allDevices = append(allDevices, nextResp.GetValue()...)
-		}
-
-		resp = nextResp
+	allDevices, err := iterate[models.ManagedDeviceable](ctx, resp, graphClient.GetAdapter(), models.CreateManagedDeviceCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
 	}
 
 	res := []any{}
@@ -179,8 +158,12 @@ func (a *mqlMicrosoftDevicemanagement) deviceConfigurations() ([]any, error) {
 		return nil, transformError(err)
 	}
 
+	configurations, err := iterate[models.DeviceConfigurationable](ctx, resp, graphClient.GetAdapter(), models.CreateDeviceConfigurationCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
+
 	res := []any{}
-	configurations := resp.GetValue()
 	for _, configuration := range configurations {
 		properties := getConfigurationProperties(configuration)
 		policyAssignments := []any{}
@@ -224,7 +207,7 @@ func (a *mqlMicrosoftDevicemanagement) deviceEnrollmentConfigurations() ([]any, 
 	}
 
 	ctx := context.Background()
-	deviceEnrollmentConfigurations, err := graphClient.DeviceManagement().DeviceEnrollmentConfigurations().Get(ctx, &devicemanagement.DeviceEnrollmentConfigurationsRequestBuilderGetRequestConfiguration{
+	resp, err := graphClient.DeviceManagement().DeviceEnrollmentConfigurations().Get(ctx, &devicemanagement.DeviceEnrollmentConfigurationsRequestBuilderGetRequestConfiguration{
 		QueryParameters: &devicemanagement.DeviceEnrollmentConfigurationsRequestBuilderGetQueryParameters{
 			Expand: []string{"assignments"},
 		},
@@ -232,8 +215,11 @@ func (a *mqlMicrosoftDevicemanagement) deviceEnrollmentConfigurations() ([]any, 
 	if err != nil {
 		return nil, transformError(err)
 	}
+	configs, err := iterate[models.DeviceEnrollmentConfigurationable](ctx, resp, graphClient.GetAdapter(), models.CreateDeviceEnrollmentConfigurationCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
 
-	configs := deviceEnrollmentConfigurations.GetValue()
 	res := []any{}
 	for _, config := range configs {
 		policyAssignments := []any{}
@@ -288,8 +274,11 @@ func (a *mqlMicrosoftDevicemanagement) deviceCompliancePolicies() ([]any, error)
 	if err != nil {
 		return nil, transformError(err)
 	}
+	compliancePolicies, err := iterate[models.DeviceCompliancePolicyable](ctx, resp, graphClient.GetAdapter(), models.CreateDeviceCompliancePolicyCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
 
-	compliancePolicies := resp.GetValue()
 	res := []any{}
 	for _, compliancePolicy := range compliancePolicies {
 		assignments, err := convert.JsonToDictSlice(newDeviceCompliancePolicyAssignments(compliancePolicy.GetAssignments()))

--- a/providers/ms365/resources/domains.go
+++ b/providers/ms365/resources/domains.go
@@ -32,10 +32,13 @@ func (a *mqlMicrosoft) domains() ([]any, error) {
 	if err != nil {
 		return nil, transformError(err)
 	}
+	allDomains, err := iterate[models.Domainable](ctx, resp, graphClient.GetAdapter(), models.CreateDomainCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
 
 	res := []any{}
-	domains := resp.GetValue()
-	for _, domain := range domains {
+	for _, domain := range allDomains {
 		supportedServices := []any{}
 		for _, service := range domain.GetSupportedServices() {
 			supportedServices = append(supportedServices, service)
@@ -76,9 +79,12 @@ func (a *mqlMicrosoftDomain) serviceConfigurationRecords() ([]any, error) {
 	if err != nil {
 		return nil, transformError(err)
 	}
+	records, err := iterate[models.DomainDnsRecordable](ctx, resp, graphClient.GetAdapter(), models.CreateDomainDnsRecordCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
 
 	res := []any{}
-	records := resp.GetValue()
 	for _, record := range records {
 		properties := getDomainsDnsRecordProperties(record)
 		mqlResource, err := CreateResource(a.MqlRuntime, "microsoft.domaindnsrecord",

--- a/providers/ms365/resources/groups.go
+++ b/providers/ms365/resources/groups.go
@@ -48,9 +48,13 @@ func (a *mqlMicrosoftGroup) members() ([]any, error) {
 	if err != nil {
 		return nil, transformError(err)
 	}
+	members, err := iterate[models.DirectoryObjectable](ctx, resp, graphClient.GetAdapter(), models.CreateDirectoryObjectCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
 
 	res := []any{}
-	for _, member := range resp.GetValue() {
+	for _, member := range members {
 		memberId := member.GetId()
 		if memberId == nil {
 			continue
@@ -174,9 +178,13 @@ func (a *mqlMicrosoftGroup) owners() ([]any, error) {
 	if err != nil {
 		return nil, transformError(err)
 	}
+	allOwners, err := iterate[models.DirectoryObjectable](ctx, ownersResp, graphClient.GetAdapter(), models.CreateDirectoryObjectCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
 
 	var owners []any
-	for _, owner := range ownersResp.GetValue() {
+	for _, owner := range allOwners {
 		if owner.GetId() == nil {
 			continue
 		}

--- a/providers/ms365/resources/identity_and_access.go
+++ b/providers/ms365/resources/identity_and_access.go
@@ -127,17 +127,21 @@ func listRoleManagementPolicies(runtime *plugin.Runtime, requestFilter string, c
 		QueryParameters: requestParameters,
 	}
 
-	policies, err := graphClient.Policies().RoleManagementPolicies().Get(context.Background(), configuration)
+	ctx := context.Background()
+	resp, err := graphClient.Policies().RoleManagementPolicies().Get(ctx, configuration)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve role management policies with filter '%s': %w", requestFilter, err)
 	}
-
-	var policyResources []any
-	if policies == nil {
+	if resp == nil {
 		return nil, nil
 	}
+	policies, err := iterate[models.UnifiedRoleManagementPolicyable](ctx, resp, graphClient.GetAdapter(), models.CreateUnifiedRoleManagementPolicyCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
 
-	for _, policy := range policies.GetValue() {
+	var policyResources []any
+	for _, policy := range policies {
 		if policy.GetId() != nil && policy.GetDisplayName() != nil {
 			policyResource, err := createPolicy(runtime, policy)
 			if err != nil {
@@ -301,17 +305,21 @@ func (a *mqlMicrosoftIdentityAndAccess) roleEligibilityScheduleInstances() ([]an
 		return nil, err
 	}
 
-	roleEligibilityScheduleInstances, err := graphClient.RoleManagement().Directory().RoleEligibilityScheduleInstances().Get(context.Background(), nil)
+	ctx := context.Background()
+	resp, err := graphClient.RoleManagement().Directory().RoleEligibilityScheduleInstances().Get(ctx, nil)
 	if err != nil {
 		return nil, transformError(err)
 	}
-
-	if roleEligibilityScheduleInstances == nil {
+	if resp == nil {
 		return nil, nil
+	}
+	roleEligibilityScheduleInstances, err := iterate[models.UnifiedRoleEligibilityScheduleInstanceable](ctx, resp, graphClient.GetAdapter(), models.CreateUnifiedRoleEligibilityScheduleInstanceCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
 	}
 
 	var instances []any
-	for _, inst := range roleEligibilityScheduleInstances.GetValue() {
+	for _, inst := range roleEligibilityScheduleInstances {
 		if inst.GetId() == nil {
 			continue
 		}
@@ -452,21 +460,25 @@ func (a *mqlMicrosoftIdentityAndAccessAccessReviews) list() ([]any, error) {
 		}
 	}
 
-	definitions, err := graphClient.
+	ctx := context.Background()
+	resp, err := graphClient.
 		IdentityGovernance().
 		AccessReviews().
 		Definitions().
-		Get(context.Background(), configuration)
+		Get(ctx, configuration)
 	if err != nil {
 		return nil, transformError(err)
 	}
-
-	if definitions == nil {
+	if resp == nil {
 		return nil, nil
+	}
+	definitions, err := iterate[models.AccessReviewScheduleDefinitionable](ctx, resp, graphClient.GetAdapter(), models.CreateAccessReviewScheduleDefinitionCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
 	}
 
 	var accessReviewResources []any
-	for _, accessReviewSchedule := range definitions.GetValue() {
+	for _, accessReviewSchedule := range definitions {
 		if accessReviewSchedule.GetId() != nil {
 			reviewResource, err := newMqlAccessReviewDefinition(a.MqlRuntime, accessReviewSchedule)
 			if err != nil {

--- a/providers/ms365/resources/policies.go
+++ b/providers/ms365/resources/policies.go
@@ -62,7 +62,11 @@ func (a *mqlMicrosoftPolicies) permissionGrantPolicies() ([]any, error) {
 	if err != nil {
 		return nil, transformError(err)
 	}
-	return convert.JsonToDictSlice(newPermissionGrantPolicies(resp.GetValue()))
+	grantPolicies, err := iterate[models.PermissionGrantPolicyable](ctx, resp, graphClient.GetAdapter(), models.CreatePermissionGrantPolicyCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
+	return convert.JsonToDictSlice(newPermissionGrantPolicies(grantPolicies))
 }
 
 // https://learn.microsoft.com/en-us/graph/api/groupsetting-get?view=graph-rest-1.0&tabs=http
@@ -76,13 +80,17 @@ func (a *mqlMicrosoftPolicies) consentPolicySettings() (any, error) {
 
 	ctx := context.Background()
 
-	groupSettings, err := graphClient.GroupSettings().Get(ctx, nil)
+	resp, err := graphClient.GroupSettings().Get(ctx, nil)
 	if err != nil {
 		return nil, transformError(err)
 	}
+	groupSettings, err := iterate[models.GroupSettingable](ctx, resp, graphClient.GetAdapter(), models.CreateGroupSettingCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
 
 	actualSettingsMap := make(map[string]map[string]any)
-	for _, setting := range groupSettings.GetValue() {
+	for _, setting := range groupSettings {
 		displayName := setting.GetDisplayName()
 		if displayName != nil {
 			if _, exists := actualSettingsMap[*displayName]; !exists {
@@ -137,9 +145,13 @@ func (a *mqlMicrosoftPolicies) activityBasedTimeoutPolicies() ([]any, error) {
 	if err != nil {
 		return nil, transformError(err)
 	}
+	timeoutPolicies, err := iterate[models.ActivityBasedTimeoutPolicyable](ctx, resp, graphClient.GetAdapter(), models.CreateActivityBasedTimeoutPolicyCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
 
 	var activityBasedTimeoutPolicies []any
-	for _, policy := range resp.GetValue() {
+	for _, policy := range timeoutPolicies {
 		mqlPolicy, err := CreateResource(a.MqlRuntime, "microsoft.policies.activityBasedTimeoutPolicy",
 			map[string]*llx.RawData{
 				"__id":                  llx.StringDataPtr(policy.GetId()),
@@ -451,37 +463,42 @@ func (a *mqlMicrosoftCrossTenantAccessPolicyDefault) getCrossTenantAccessPolicy(
 				"inboundAllowed":  llx.BoolDataPtr(consentSettings.GetInboundAllowed()),
 				"outboundAllowed": llx.BoolDataPtr(consentSettings.GetOutboundAllowed()),
 			})
-		if err == nil {
-			a.cachedAutomaticUserConsentSettings = consentResource.(*mqlMicrosoftCrossTenantAccessPolicyDefaultAutomaticUserConsentSettings)
+		if err != nil {
+			return errHandler(err)
 		}
+		a.cachedAutomaticUserConsentSettings = consentResource.(*mqlMicrosoftCrossTenantAccessPolicyDefaultAutomaticUserConsentSettings)
 	}
 
 	if policy.GetB2bCollaborationInbound() != nil {
 		b2bResource, err := newB2BSetting(a.MqlRuntime, policy.GetB2bCollaborationInbound(), a.__id+"-b2bCollaborationInbound")
-		if err == nil {
-			a.cachedB2bCollaborationInbound = b2bResource
+		if err != nil {
+			return errHandler(err)
 		}
+		a.cachedB2bCollaborationInbound = b2bResource
 	}
 
 	if policy.GetB2bCollaborationOutbound() != nil {
 		b2bResource, err := newB2BSetting(a.MqlRuntime, policy.GetB2bCollaborationOutbound(), a.__id+"-b2bCollaborationOutbound")
-		if err == nil {
-			a.cachedB2bCollaborationOutbound = b2bResource
+		if err != nil {
+			return errHandler(err)
 		}
+		a.cachedB2bCollaborationOutbound = b2bResource
 	}
 
 	if policy.GetB2bDirectConnectInbound() != nil {
 		b2bResource, err := newB2BSetting(a.MqlRuntime, policy.GetB2bDirectConnectInbound(), a.__id+"-b2bDirectConnectInbound")
-		if err == nil {
-			a.cachedB2bDirectConnectInbound = b2bResource
+		if err != nil {
+			return errHandler(err)
 		}
+		a.cachedB2bDirectConnectInbound = b2bResource
 	}
 
 	if policy.GetB2bDirectConnectOutbound() != nil {
 		b2bResource, err := newB2BSetting(a.MqlRuntime, policy.GetB2bDirectConnectOutbound(), a.__id+"-b2bDirectConnectOutbound")
-		if err == nil {
-			a.cachedB2bDirectConnectOutbound = b2bResource
+		if err != nil {
+			return errHandler(err)
 		}
+		a.cachedB2bDirectConnectOutbound = b2bResource
 	}
 
 	if policy.GetInvitationRedemptionIdentityProviderConfiguration() != nil {
@@ -501,9 +518,10 @@ func (a *mqlMicrosoftCrossTenantAccessPolicyDefault) getCrossTenantAccessPolicy(
 				"fallbackIdentityProvider":               llx.StringData(fallbackProvider),
 				"primaryIdentityProviderPrecedenceOrder": llx.ArrayData(precedenceOrder, types.String),
 			})
-		if err == nil {
-			a.cachedInvitationRedemptionIdentityProviderConfiguration = invResource.(*mqlMicrosoftCrossTenantAccessPolicyDefaultInvitationRedemptionIdentityProviderConfiguration)
+		if err != nil {
+			return errHandler(err)
 		}
+		a.cachedInvitationRedemptionIdentityProviderConfiguration = invResource.(*mqlMicrosoftCrossTenantAccessPolicyDefaultInvitationRedemptionIdentityProviderConfiguration)
 	}
 
 	if policy.GetInboundTrust() != nil {
@@ -515,16 +533,18 @@ func (a *mqlMicrosoftCrossTenantAccessPolicyDefault) getCrossTenantAccessPolicy(
 				"isCompliantDeviceAccepted":           llx.BoolDataPtr(inboundTrustValue.GetIsCompliantDeviceAccepted()),
 				"isHybridAzureADJoinedDeviceAccepted": llx.BoolDataPtr(inboundTrustValue.GetIsHybridAzureADJoinedDeviceAccepted()),
 			})
-		if err == nil {
-			a.cachedInboundTrust = inboundTrustResource.(*mqlMicrosoftCrossTenantAccessPolicyDefaultInboundTrust)
+		if err != nil {
+			return errHandler(err)
 		}
+		a.cachedInboundTrust = inboundTrustResource.(*mqlMicrosoftCrossTenantAccessPolicyDefaultInboundTrust)
 	}
 
 	if policy.GetTenantRestrictions() != nil {
 		b2bResource, err := newB2BSetting(a.MqlRuntime, policy.GetTenantRestrictions(), a.__id+"-tenantRestrictions")
-		if err == nil {
-			a.cachedTenantRestrictions = b2bResource
+		if err != nil {
+			return errHandler(err)
 		}
+		a.cachedTenantRestrictions = b2bResource
 	}
 
 	return nil

--- a/providers/ms365/resources/rolemanagement.go
+++ b/providers/ms365/resources/rolemanagement.go
@@ -9,6 +9,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 
 	abstractions "github.com/microsoft/kiota-abstractions-go"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/rolemanagement"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
@@ -76,9 +77,12 @@ func (a *mqlMicrosoftRoles) list() ([]any, error) {
 	if err != nil {
 		return nil, transformError(err)
 	}
+	roles, err := iterate[models.UnifiedRoleDefinitionable](ctx, resp, graphClient.GetAdapter(), models.CreateUnifiedRoleDefinitionCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
 
 	res := []any{}
-	roles := resp.GetValue()
 	for _, role := range roles {
 		rolePermissions, err := convert.JsonToDictSlice(newUnifiedRolePermissions(role.GetRolePermissions()))
 		if err != nil {
@@ -161,8 +165,11 @@ func (a *mqlMicrosoftRolemanagementRoledefinition) assignments() ([]any, error) 
 	if err != nil {
 		return nil, transformError(err)
 	}
+	roleAssignments, err := iterate[models.UnifiedRoleAssignmentable](ctx, resp, graphClient.GetAdapter(), models.CreateUnifiedRoleAssignmentCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
 
-	roleAssignments := resp.GetValue()
 	res := []any{}
 	for _, roleAssignment := range roleAssignments {
 		principal, err := convert.JsonToDict(newDirectoryPrincipal(roleAssignment.GetPrincipal()))

--- a/providers/ms365/resources/security_riskyusers.go
+++ b/providers/ms365/resources/security_riskyusers.go
@@ -32,9 +32,12 @@ func (a *mqlMicrosoftSecurity) riskyUsers() ([]any, error) {
 	if err != nil {
 		return nil, transformError(err)
 	}
+	users, err := iterate[models.RiskyUserable](ctx, resp, graphClient.GetAdapter(), models.CreateRiskyUserCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
 
 	res := []any{}
-	users := resp.GetValue()
 	for i := range users {
 		riskyUser := users[i]
 		mqlResource, err := newMqlMicrosoftRiskyUser(a.MqlRuntime, riskyUser)

--- a/providers/ms365/resources/security_securescores.go
+++ b/providers/ms365/resources/security_securescores.go
@@ -104,9 +104,12 @@ func (a *mqlMicrosoftSecurity) secureScores() ([]any, error) {
 	if err != nil {
 		return nil, transformError(err)
 	}
+	scores, err := iterate[models.SecureScoreable](ctx, resp, graphClient.GetAdapter(), models.CreateSecureScoreCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
 
 	res := []any{}
-	scores := resp.GetValue()
 	for i := range scores {
 		score := scores[i]
 		mqlResource, err := newMqlMicrosoftSecureScore(a.MqlRuntime, score)

--- a/providers/ms365/resources/serviceprincipals.go
+++ b/providers/ms365/resources/serviceprincipals.go
@@ -477,13 +477,16 @@ func (a *mqlMicrosoftServiceprincipal) permissions() ([]any, error) {
 	if err != nil {
 		return nil, transformError(err)
 	}
+	appRolesAssignments, err := iterate[models.AppRoleAssignmentable](ctx, grantedApplicationRolesResp, graphClient.GetAdapter(), models.CreateAppRoleAssignmentCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
 
 	list := []any{}
 	// track which app roles are granted, keyed by resourceSpId/roleId, and the
 	// display name of each resource service principal the application touches
 	grantedRoleKeys := map[string]bool{}
 	resourceSpNames := map[string]string{}
-	appRolesAssignments := grantedApplicationRolesResp.GetValue()
 	for _, roleAssignment := range appRolesAssignments {
 		assignmentID := roleAssignment.GetId()
 		spId := roleAssignment.GetResourceId()  // id of the service account
@@ -545,7 +548,13 @@ func (a *mqlMicrosoftServiceprincipal) permissions() ([]any, error) {
 	}
 
 	oauthResp, err := graphClient.ServicePrincipals().ByServicePrincipalId(servicePrincipalId).Oauth2PermissionGrants().Get(ctx, &serviceprincipals.ItemOauth2PermissionGrantsRequestBuilderGetRequestConfiguration{})
-	delegatedRolesAssignments := oauthResp.GetValue()
+	if err != nil {
+		return nil, transformError(err)
+	}
+	delegatedRolesAssignments, err := iterate[models.OAuth2PermissionGrantable](ctx, oauthResp, graphClient.GetAdapter(), models.CreateOAuth2PermissionGrantCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
 	for _, roleAssignment := range delegatedRolesAssignments {
 
 		spId := roleAssignment.GetResourceId() // id of the service account

--- a/providers/ms365/resources/settings.go
+++ b/providers/ms365/resources/settings.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/groupsettings"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/ms365/connection"
@@ -21,11 +22,15 @@ func (a *mqlMicrosoft) settings() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	settings, err := graphClient.GroupSettings().Get(ctx, &groupsettings.GroupSettingsRequestBuilderGetRequestConfiguration{})
+	resp, err := graphClient.GroupSettings().Get(ctx, &groupsettings.GroupSettingsRequestBuilderGetRequestConfiguration{})
 	if err != nil {
 		return nil, transformError(err)
 	}
-	return convert.JsonToDictSlice(newSettings(settings.GetValue()))
+	settings, err := iterate[models.GroupSettingable](ctx, resp, graphClient.GetAdapter(), models.CreateGroupSettingCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
+	return convert.JsonToDictSlice(newSettings(settings))
 }
 
 func (a *mqlMicrosoft) groupSettings() ([]any, error) {
@@ -36,13 +41,17 @@ func (a *mqlMicrosoft) groupSettings() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	settings, err := graphClient.GroupSettings().Get(ctx, &groupsettings.GroupSettingsRequestBuilderGetRequestConfiguration{})
+	resp, err := graphClient.GroupSettings().Get(ctx, &groupsettings.GroupSettingsRequestBuilderGetRequestConfiguration{})
 	if err != nil {
 		return nil, transformError(err)
 	}
+	settings, err := iterate[models.GroupSettingable](ctx, resp, graphClient.GetAdapter(), models.CreateGroupSettingCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
 
 	settingsList := []any{}
-	for _, setting := range settings.GetValue() {
+	for _, setting := range settings {
 		settingValues := make([]any, 0, len(setting.GetValues()))
 
 		for _, val := range setting.GetValues() {

--- a/providers/ms365/resources/tenant.go
+++ b/providers/ms365/resources/tenant.go
@@ -59,9 +59,12 @@ func (a *mqlMicrosoft) organizations() ([]any, error) {
 	if err != nil {
 		return nil, transformError(err)
 	}
+	orgs, err := iterate[models.Organizationable](ctx, resp, graphClient.GetAdapter(), models.CreateOrganizationCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
 
 	res := []any{}
-	orgs := resp.GetValue()
 	for i := range orgs {
 		org := orgs[i]
 		mqlResource, err := newMicrosoftTenant(a.MqlRuntime, org)
@@ -169,13 +172,18 @@ func (a *mqlMicrosoftTenant) subscriptions() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := graphClient.Directory().Subscriptions().Get(context.Background(), &directory.SubscriptionsRequestBuilderGetRequestConfiguration{})
+	ctx := context.Background()
+	resp, err := graphClient.Directory().Subscriptions().Get(ctx, &directory.SubscriptionsRequestBuilderGetRequestConfiguration{})
 	if err != nil {
 		return nil, transformError(err)
 	}
+	subs, err := iterate[models.CompanySubscriptionable](ctx, resp, graphClient.GetAdapter(), models.CreateCompanySubscriptionCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return nil, err
+	}
 
 	res := []any{}
-	for _, sub := range resp.GetValue() {
+	for _, sub := range subs {
 		res = append(res, newCompanySubscription(sub))
 	}
 
@@ -193,11 +201,15 @@ func (a *mqlMicrosoft) tenantDomainName() (string, error) {
 	if err != nil {
 		return "", transformError(err)
 	}
+	orgs, err := iterate[models.Organizationable](ctx, resp, graphClient.GetAdapter(), models.CreateOrganizationCollectionResponseFromDiscriminatorValue)
+	if err != nil {
+		return "", err
+	}
 	tenantDomainName := ""
 
-	for _, org := range resp.GetValue() {
+	for _, org := range orgs {
 		for _, d := range org.GetVerifiedDomains() {
-			if *d.GetIsInitial() {
+			if d.GetIsInitial() != nil && *d.GetIsInitial() && d.GetName() != nil {
 				tenantDomainName = *d.GetName()
 			}
 		}


### PR DESCRIPTION
## Summary

Third of three PRs landing fixes from a ms365-provider audit pass. This one cleans up **silent data dropping** — Graph API list endpoints whose response was truncated after the first page, plus a couple of error returns that the code was throwing away.

The provider already has an `iterate()` helper at `resources/iterator.go` that uses `msgraphgocore.PageIterator` to follow `@odata.nextLink`. The sites below were calling `resp.GetValue()` once and stopping there. On any tenant with more than one Graph page worth of items, each query silently returned a truncated result.

### Pagination added

- **`microsoft.group`**: `members`, `owners`
- **`microsoft.application`**: `owners`
- **`microsoft.serviceprincipal`**: `appRoleAssignments` and `oauth2PermissionGrants` (the oauth grants call also wasn't checking its `err` return, so any failure went straight into `nil.GetValue` and panicked)
- **`microsoft.conditionalAccess`**: `namedLocations` (ip + country), `policies`
- **`microsoft.identityAndAccess`**: `roleManagementPolicies`, `roleEligibilityScheduleInstances`, `accessReviews.definitions`
- **`microsoft.roles`**: `roleDefinitions` and per-role `assignments`
- **`microsoft.policies`**: `permissionGrantPolicies`, the `consentPolicySettings` backing groupSettings call, `activityBasedTimeoutPolicies`
- **`microsoft` tenant-level**: `organizations`, `subscriptions`, and the organization list backing `tenantDomainName` (also added missing nil guards for `*d.GetIsInitial()` / `*d.GetName()` that lived in the same loop)
- **`microsoft.settings` / `microsoft.groupSettings`**: both
- **`microsoft.security`**: `riskyUsers`, `secureScores`
- **`microsoft.devicemanagement`**: `managedDevices` (replaced a hand-rolled nextLink loop), `deviceConfigurations`, `deviceEnrollmentConfigurations`, `deviceCompliancePolicies`
- **`microsoft.domain`**: `domains` list and per-domain `serviceConfigurationRecords`

### Error swallowing fixed

- **`newMqlMicrosoftApplication`** (`applications.go`): a chain of `x, err := convert.JsonToDict(...)` calls threaded a single `err` through ten conversions and only inspected the last one. Each call now checks its own `err`.
- **`getCrossTenantAccessPolicy`** (`policies.go`): every sub-resource construction was `if err == nil { cache = ... }`, which silently discarded the failure and then returned the (nil) cached value through accessors that return `*X`. Each now routes the error through the existing `errHandler` so it lands on `a.fetchErr` and surfaces to callers.

### Notes on test coverage

This is a mechanical sweep: `resp, _ := X().Y().Get(...); for _, v := range resp.GetValue()` → `resp, _ := X().Y().Get(...); items, _ := iterate[T](...); for _, v := range items`. The behavior change is observable only against a live tenant with more than one page of results, which the provider has no harness for. I didn't add tests here for the same reason PR #7912 didn't. PR #7907 has the new tests (sharepoint tenant parsing and `newAdminConsentRequestPolicy` nil-safety).

## Test plan

- [ ] `make providers/build/ms365 && make providers/install/ms365`
- [ ] On a tenant with >100 users, `microsoft.groups[0].members.length` returns the full count
- [ ] On a tenant with several Intune compliance policies, `microsoft.devicemanagement.deviceCompliancePolicies.length` doesn't cap at 25
- [ ] `microsoft.security.riskyUsers.length` returns more than 20 entries on a tenant that has them
- [ ] `microsoft.policies.crossTenantAccessPolicy.default { automaticUserConsentSettings }` propagates a real error instead of returning silently null when CreateResource fails
- [ ] `microsoft.applications` query still works (the convert.JsonToDict cascade has the same successful path, just now reports earlier failures)

## Stack

Stacks on #7907 and #7912. The hunks touched here don't overlap with those PRs, so it can land independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)