### PR TITLE
🐛 k8s: resolve typed cross-refs to null on not-found instead of erroring

### DIFF
--- a/providers/k8s/resources/clusterrolebinding.go
+++ b/providers/k8s/resources/clusterrolebinding.go
@@ -97,6 +97,13 @@ func (k *mqlK8sRbacClusterrolebinding) clusterRole() (*mqlK8sRbacClusterrole, er
 		"name": llx.StringData(k.obj.RoleRef.Name),
 	})
 	if err != nil {
+		// A referenced ClusterRole can have been deleted while the
+		// ClusterRoleBinding remains. Resolve to null; surface other
+		// errors.
+		if errors.Is(err, ErrResourceNotFound) {
+			k.ClusterRole.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return r.(*mqlK8sRbacClusterrole), nil

--- a/providers/k8s/resources/horizontalpodautoscaler.go
+++ b/providers/k8s/resources/horizontalpodautoscaler.go
@@ -97,6 +97,12 @@ func (k *mqlK8sHorizontalpodautoscaler) scaleTargetDeployment() (*mqlK8sDeployme
 		"namespace": llx.StringData(k.obj.Namespace),
 	})
 	if err != nil {
+		// HPAs can survive their scale target mid-deletion. Resolve to
+		// null; surface other errors.
+		if errors.Is(err, ErrResourceNotFound) {
+			k.ScaleTargetDeployment.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return r.(*mqlK8sDeployment), nil
@@ -112,6 +118,10 @@ func (k *mqlK8sHorizontalpodautoscaler) scaleTargetStatefulSet() (*mqlK8sStatefu
 		"namespace": llx.StringData(k.obj.Namespace),
 	})
 	if err != nil {
+		if errors.Is(err, ErrResourceNotFound) {
+			k.ScaleTargetStatefulSet.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return r.(*mqlK8sStatefulset), nil
@@ -127,6 +137,10 @@ func (k *mqlK8sHorizontalpodautoscaler) scaleTargetReplicaSet() (*mqlK8sReplicas
 		"namespace": llx.StringData(k.obj.Namespace),
 	})
 	if err != nil {
+		if errors.Is(err, ErrResourceNotFound) {
+			k.ScaleTargetReplicaSet.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return r.(*mqlK8sReplicaset), nil

--- a/providers/k8s/resources/ingress.go
+++ b/providers/k8s/resources/ingress.go
@@ -143,6 +143,13 @@ func (k *mqlK8sIngress) ingressClass() (*mqlK8sIngressclass, error) {
 		"name": llx.StringData(*ing.Spec.IngressClassName),
 	})
 	if err != nil {
+		// IngressClass is cluster-scoped, so it isn't loaded when queried
+		// from a namespace-scoped asset, and a referenced IngressClass can
+		// genuinely have been deleted. Resolve to null; surface other errors.
+		if errors.Is(err, ErrResourceNotFound) {
+			k.IngressClass.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return ic.(*mqlK8sIngressclass), nil

--- a/providers/k8s/resources/node.go
+++ b/providers/k8s/resources/node.go
@@ -56,7 +56,11 @@ func initK8sNode(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 	x, found := k8s.nodesByName[name]
 	k8s.lock.Unlock()
 	if !found {
-		return nil, nil, errors.New("cannot find node " + name)
+		// Wrap ErrResourceNotFound so callers can distinguish "node was
+		// deleted" from a transient error via errors.Is — the existing
+		// pod.node() accessor relies on this to resolve to null instead
+		// of failing the query.
+		return nil, nil, fmt.Errorf("cannot find node %s: %w", name, ErrResourceNotFound)
 	}
 
 	return nil, x, nil

--- a/providers/k8s/resources/persistentvolume.go
+++ b/providers/k8s/resources/persistentvolume.go
@@ -106,6 +106,12 @@ func (k *mqlK8sPersistentvolume) storageClass() (*mqlK8sStorageclass, error) {
 		"name": llx.StringData(k.obj.Spec.StorageClassName),
 	})
 	if err != nil {
+		// A referenced StorageClass can have been deleted. Resolve to null;
+		// surface other errors.
+		if errors.Is(err, ErrResourceNotFound) {
+			k.StorageClass.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return r.(*mqlK8sStorageclass), nil
@@ -146,6 +152,13 @@ func (k *mqlK8sPersistentvolume) claim() (*mqlK8sPersistentvolumeclaim, error) {
 		"namespace": llx.StringData(k.obj.Spec.ClaimRef.Namespace),
 	})
 	if err != nil {
+		// A PV with Retain reclaim policy outlives its PVC, so the
+		// referenced PVC can already be gone. Resolve to null; surface
+		// other errors.
+		if errors.Is(err, ErrResourceNotFound) {
+			k.Claim.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return r.(*mqlK8sPersistentvolumeclaim), nil

--- a/providers/k8s/resources/persistentvolumeclaim.go
+++ b/providers/k8s/resources/persistentvolumeclaim.go
@@ -98,6 +98,13 @@ func (k *mqlK8sPersistentvolumeclaim) storageClass() (*mqlK8sStorageclass, error
 		"name": llx.StringData(*k.obj.Spec.StorageClassName),
 	})
 	if err != nil {
+		// StorageClass is cluster-scoped, so it isn't loaded when queried
+		// from a namespace-scoped asset, and a referenced StorageClass can
+		// genuinely have been deleted. Resolve to null; surface other errors.
+		if errors.Is(err, ErrResourceNotFound) {
+			k.StorageClass.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return r.(*mqlK8sStorageclass), nil
@@ -116,6 +123,13 @@ func (k *mqlK8sPersistentvolumeclaim) volume() (*mqlK8sPersistentvolume, error) 
 		"name": llx.StringData(k.obj.Spec.VolumeName),
 	})
 	if err != nil {
+		// PVs are cluster-scoped, so they aren't loaded when queried from a
+		// namespace-scoped asset, and the bound PV can legitimately be
+		// missing mid-deletion. Resolve to null; surface other errors.
+		if errors.Is(err, ErrResourceNotFound) {
+			k.Volume.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return r.(*mqlK8sPersistentvolume), nil

--- a/providers/k8s/resources/pod.go
+++ b/providers/k8s/resources/pod.go
@@ -182,10 +182,23 @@ func (k *mqlK8sPod) node() (*mqlK8sNode, error) {
 		return nil, err
 	}
 
+	// Unscheduled pods have no node assigned yet.
+	if podSpec.NodeName == "" {
+		k.Node.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
 	node, err := NewResource(k.MqlRuntime, "k8s.node", map[string]*llx.RawData{
 		"name": llx.StringData(podSpec.NodeName),
 	})
 	if err != nil {
+		// Nodes are cluster-scoped, so they aren't loaded when queried
+		// from a namespace-scoped asset, and a scheduled node can also be
+		// drained or removed. Resolve to null; surface other errors.
+		if errors.Is(err, ErrResourceNotFound) {
+			k.Node.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 
@@ -261,6 +274,13 @@ func (k *mqlK8sPod) priorityClass() (*mqlK8sPriorityclass, error) {
 		"name": llx.StringData(spec.PriorityClassName),
 	})
 	if err != nil {
+		// PriorityClass is cluster-scoped, so it isn't loaded when queried
+		// from a namespace-scoped asset, and a referenced PriorityClass
+		// may have been deleted. Resolve to null; surface other errors.
+		if errors.Is(err, ErrResourceNotFound) {
+			k.PriorityClass.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return pc.(*mqlK8sPriorityclass), nil
@@ -318,6 +338,12 @@ func (k *mqlK8sPod) serviceAccount() (*mqlK8sServiceaccount, error) {
 		"namespace": llx.StringData(pod.Namespace),
 	})
 	if err != nil {
+		// A referenced ServiceAccount may have been deleted. Resolve to
+		// null; surface other errors.
+		if errors.Is(err, ErrResourceNotFound) {
+			k.ServiceAccount.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return sa.(*mqlK8sServiceaccount), nil
@@ -622,6 +648,12 @@ func (k *mqlK8sPod) replicaSet() (*mqlK8sReplicaset, error) {
 		"namespace": llx.StringData(ns),
 	})
 	if err != nil {
+		// Pods can survive their owner mid-deletion or be re-parented to a
+		// new ReplicaSet. Resolve to null; surface other errors.
+		if errors.Is(err, ErrResourceNotFound) {
+			k.ReplicaSet.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return r.(*mqlK8sReplicaset), nil
@@ -638,6 +670,10 @@ func (k *mqlK8sPod) statefulSet() (*mqlK8sStatefulset, error) {
 		"namespace": llx.StringData(ns),
 	})
 	if err != nil {
+		if errors.Is(err, ErrResourceNotFound) {
+			k.StatefulSet.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return r.(*mqlK8sStatefulset), nil
@@ -654,6 +690,10 @@ func (k *mqlK8sPod) daemonSet() (*mqlK8sDaemonset, error) {
 		"namespace": llx.StringData(ns),
 	})
 	if err != nil {
+		if errors.Is(err, ErrResourceNotFound) {
+			k.DaemonSet.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return r.(*mqlK8sDaemonset), nil
@@ -670,6 +710,10 @@ func (k *mqlK8sPod) job() (*mqlK8sJob, error) {
 		"namespace": llx.StringData(ns),
 	})
 	if err != nil {
+		if errors.Is(err, ErrResourceNotFound) {
+			k.Job.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return r.(*mqlK8sJob), nil
@@ -693,6 +737,14 @@ func (k *mqlK8sPod) deployment() (*mqlK8sDeployment, error) {
 				"namespace": llx.StringData(rsTyped.Namespace),
 			})
 			if err != nil {
+				// A Deployment can be deleted while its ReplicaSet and
+				// pods are still mid-cleanup. Resolve to null; surface
+				// other errors (per PR #7884, type-assertion failures
+				// inside getReplicaSet() above still propagate).
+				if errors.Is(err, ErrResourceNotFound) {
+					k.Deployment.State = plugin.StateIsSet | plugin.StateIsNull
+					return nil, nil
+				}
 				return nil, err
 			}
 			return r.(*mqlK8sDeployment), nil

--- a/providers/k8s/resources/rolebinding.go
+++ b/providers/k8s/resources/rolebinding.go
@@ -97,6 +97,12 @@ func (k *mqlK8sRbacRolebinding) role() (*mqlK8sRbacRole, error) {
 		"namespace": llx.StringData(k.obj.Namespace),
 	})
 	if err != nil {
+		// A referenced Role can be deleted while the RoleBinding remains.
+		// Resolve to null; surface other errors.
+		if errors.Is(err, ErrResourceNotFound) {
+			k.Role.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return r.(*mqlK8sRbacRole), nil
@@ -111,6 +117,13 @@ func (k *mqlK8sRbacRolebinding) clusterRole() (*mqlK8sRbacClusterrole, error) {
 		"name": llx.StringData(k.obj.RoleRef.Name),
 	})
 	if err != nil {
+		// ClusterRole is cluster-scoped, so it isn't loaded when queried
+		// from a namespace-scoped asset, and a referenced ClusterRole can
+		// have been deleted. Resolve to null; surface other errors.
+		if errors.Is(err, ErrResourceNotFound) {
+			k.ClusterRole.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return r.(*mqlK8sRbacClusterrole), nil


### PR DESCRIPTION
## Summary

PR #7885 fixed this for `EndpointSlice.service()` — detect `ErrResourceNotFound` from `NewResource` and resolve to null instead of propagating the error verbatim. The same pattern was missing on every other typed cross-reference accessor in the provider, and several of them surfaced as hard query errors during live verification against a minikube cluster:

- `k8s.ingress.ingressClass` → \`not found\`
- `k8s.persistentvolumeclaim.storageClass` → \`not found\`
- `k8s.persistentvolumeclaim.volume` → \`not found\`
- `k8s.pod.node` → \`cannot find node minikube\`

In each case the underlying cross-referenced resource genuinely exists in the cluster, but isn't loaded in the current asset's scope: a namespace-scoped asset doesn't load cluster-scoped resources (IngressClass, StorageClass, PersistentVolume, Node, PriorityClass, ClusterRole). The same code path also fires when the target was deleted while the referrer remains (Retain-policy PVs surviving their PVC, RBAC bindings outliving their roles, orphaned pods losing their owner mid-cleanup), which is exactly the failure mode PR #7885's EndpointSlice fix was written for.

## Fix

Apply the same defensive pattern uniformly:

\`\`\`go
if err != nil {
    if errors.Is(err, ErrResourceNotFound) {
        k.X.State = plugin.StateIsSet | plugin.StateIsNull
        return nil, nil
    }
    return nil, err
}
\`\`\`

### Sites updated
- \`ingress.go\`: \`ingressClass()\`
- \`persistentvolumeclaim.go\`: \`storageClass()\`, \`volume()\`
- \`persistentvolume.go\`: \`storageClass()\`, \`claim()\`
- \`pod.go\`: \`node()\`, \`priorityClass()\`, \`serviceAccount()\`, \`replicaSet()\`, \`statefulSet()\`, \`daemonSet()\`, \`job()\`, \`deployment()\` (the inner \`NewResource\` only — the outer \`rs.getReplicaSet()\` type-assertion error still propagates per PR #7884)
- \`horizontalpodautoscaler.go\`: \`scaleTargetDeployment()\`, \`scaleTargetStatefulSet()\`, \`scaleTargetReplicaSet()\`
- \`rolebinding.go\`: \`role()\`, \`clusterRole()\`
- \`clusterrolebinding.go\`: \`clusterRole()\`
- \`pod.go: node()\` also gained an empty-name guard so an unscheduled pod resolves cleanly without going through the init at all

### Node init wrap

\`node.go: initK8sNode\` was the one init that returned a free-text \`"cannot find node X"\` error instead of \`ErrResourceNotFound\`, so the wrappers above could not catch it. Wrap with \`%w\` so it still reads \`"cannot find node minikube: not found"\` (the existing downstream text-match on \"not found\" stays intact) while \`errors.Is(err, ErrResourceNotFound)\` now succeeds.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./resources/...\` passes
- [x] Against live minikube from a namespace asset, the four previously-failing queries above now resolve to \`null\` with no error
- [x] From the cluster asset, the same accessors still resolve to the correct typed resource (\`ingressClass.name: \"live-test-class\"\`, \`storageClass.name: \"live-test-sc\"\`, \`volume.name: \"live-pv\"\`, \`node.name: \"minikube\"\`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)