### PR TITLE
🐛 fix bugs surfaced by provider-verification across aws/gcp/azure

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -17123,31 +17123,31 @@ private aws.apprunner.service @defaults("serviceName status region") {
   // Time the service was last updated
   updatedAt time
   // Time the service was deleted (null when not deleted)
-  deletedAt time
+  deletedAt() time
   // Region where the service exists
   region string
   // Source deployed to the service
   //
   // Shape varies by source type. Image sources carry `imageRepository: {imageIdentifier, imageRepositoryType: "ECR"|"ECR_PUBLIC", imageConfiguration: {port, runtimeEnvironmentVariables, runtimeEnvironmentSecrets, startCommand}}`. Code sources carry `codeRepository: {repositoryUrl, sourceCodeVersion: {type, value}, sourceDirectory, codeConfiguration}`. The top level also carries `authenticationConfiguration: {connectionArn, accessRoleArn}` and `autoDeploymentsEnabled`.
-  sourceConfiguration dict
+  sourceConfiguration() dict
   // Number of CPU units reserved for each instance (e.g., "1024", "1 vCPU")
-  instanceCpu string
+  instanceCpu() string
   // Amount of memory reserved for each instance (e.g., "2048", "2 GB")
-  instanceMemory string
+  instanceMemory() string
   // IAM role the application code assumes when calling AWS APIs
   instanceRole() aws.iam.role
   // Health check configuration
   //
   // Shape: `{protocol: "TCP"|"HTTP", path, interval, timeout, healthyThreshold, unhealthyThreshold}`.
-  healthCheckConfiguration dict
+  healthCheckConfiguration() dict
   // Egress type for outbound traffic: DEFAULT (public internet) or VPC (through a VPC connector)
-  egressType string
+  egressType() string
   // VPC connector used for egress when egressType is VPC, null otherwise
   vpcConnector() aws.apprunner.vpcConnector
   // Whether the service is reachable from the public internet
-  isPubliclyAccessible bool
+  isPubliclyAccessible() bool
   // IP address type of the service: IPV4 or DUAL_STACK
-  ipAddressType string
+  ipAddressType() string
   // Observability configuration bound to the service when observability is enabled, null otherwise
   observabilityConfiguration() aws.apprunner.observabilityConfiguration
   // Auto scaling configuration revision bound to the service
@@ -17174,19 +17174,19 @@ private aws.apprunner.autoScalingConfiguration @defaults("name revision status r
   // Revision number unique within the configuration name
   revision int
   // Whether this revision is the latest one for the configuration name
-  latest bool
+  latest() bool
   // Current state of the revision: ACTIVE or INACTIVE
   status string
   // Time the revision was created
   createdAt time
   // Time the revision was deleted (null when not deleted)
-  deletedAt time
+  deletedAt() time
   // Maximum number of concurrent requests an instance processes before App Runner scales out
-  maxConcurrency int
+  maxConcurrency() int
   // Minimum number of instances kept provisioned for a service using this revision
-  minSize int
+  minSize() int
   // Maximum number of instances a service using this revision scales up to
-  maxSize int
+  maxSize() int
   // Whether at least one App Runner service references this revision
   hasAssociatedService bool
   // Region where the revision exists
@@ -17263,17 +17263,17 @@ private aws.apprunner.observabilityConfiguration @defaults("name revision status
   // Revision number unique within the configuration name
   revision int
   // Whether this revision is the latest one for the configuration name
-  latest bool
+  latest() bool
   // Current state of the revision: ACTIVE or INACTIVE
-  status string
+  status() string
   // Time the revision was created
-  createdAt time
+  createdAt() time
   // Time the revision was deleted (null when not deleted)
-  deletedAt time
+  deletedAt() time
   // Tracing implementation provider configured for the revision, empty when tracing is not enabled
   //
   // Currently the only supported value is AWSXRAY.
-  traceConfigurationVendor string
+  traceConfigurationVendor() string
   // Region where the revision exists
   region string
 }
@@ -17289,21 +17289,21 @@ private aws.apprunner.vpcIngressConnection @defaults("name status domainName reg
   // ARN of the VPC ingress connection
   arn string
   // Customer-provided VPC ingress connection name
-  name string
+  name() string
   // Current state of the ingress connection
   //
   // One of AVAILABLE, PENDING_CREATION, PENDING_UPDATE, PENDING_DELETION, FAILED_CREATION, FAILED_UPDATE, FAILED_DELETION, DELETED.
-  status string
+  status() string
   // Time the ingress connection was created
-  createdAt time
+  createdAt() time
   // Time the ingress connection was deleted (null when not deleted)
-  deletedAt time
+  deletedAt() time
   // Domain name customers resolve to reach the service through the ingress endpoint
-  domainName string
+  domainName() string
   // VPC endpoint configuration the ingress connection terminates on
   //
   // Shape: `{vpcId, vpcEndpointId}`.
-  ingressVpcConfiguration dict
+  ingressVpcConfiguration() dict
   // App Runner service the ingress connection fronts
   service() aws.apprunner.service
   // Region where the ingress connection exists
@@ -20808,7 +20808,7 @@ private aws.cloudformation.stackSet @defaults("name status") {
   // Time of the most recent drift detection operation, or null if drift detection has never been run
   lastDriftCheckTimestamp time
   // Whether non-conflicting stack set operations run concurrently
-  managedExecutionActive bool
+  managedExecutionActive() bool
   // Whether auto deployment is enabled
   autoDeploymentEnabled() bool
   // IAM role in the management account used to deploy stack instances (SELF_MANAGED stack sets)

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -141497,7 +141497,9 @@ func (c *mqlAwsApprunnerService) GetUpdatedAt() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlAwsApprunnerService) GetDeletedAt() *plugin.TValue[*time.Time] {
-	return &c.DeletedAt
+	return plugin.GetOrCompute[*time.Time](&c.DeletedAt, func() (*time.Time, error) {
+		return c.deletedAt()
+	})
 }
 
 func (c *mqlAwsApprunnerService) GetRegion() *plugin.TValue[string] {
@@ -141505,15 +141507,21 @@ func (c *mqlAwsApprunnerService) GetRegion() *plugin.TValue[string] {
 }
 
 func (c *mqlAwsApprunnerService) GetSourceConfiguration() *plugin.TValue[any] {
-	return &c.SourceConfiguration
+	return plugin.GetOrCompute[any](&c.SourceConfiguration, func() (any, error) {
+		return c.sourceConfiguration()
+	})
 }
 
 func (c *mqlAwsApprunnerService) GetInstanceCpu() *plugin.TValue[string] {
-	return &c.InstanceCpu
+	return plugin.GetOrCompute[string](&c.InstanceCpu, func() (string, error) {
+		return c.instanceCpu()
+	})
 }
 
 func (c *mqlAwsApprunnerService) GetInstanceMemory() *plugin.TValue[string] {
-	return &c.InstanceMemory
+	return plugin.GetOrCompute[string](&c.InstanceMemory, func() (string, error) {
+		return c.instanceMemory()
+	})
 }
 
 func (c *mqlAwsApprunnerService) GetInstanceRole() *plugin.TValue[*mqlAwsIamRole] {
@@ -141533,11 +141541,15 @@ func (c *mqlAwsApprunnerService) GetInstanceRole() *plugin.TValue[*mqlAwsIamRole
 }
 
 func (c *mqlAwsApprunnerService) GetHealthCheckConfiguration() *plugin.TValue[any] {
-	return &c.HealthCheckConfiguration
+	return plugin.GetOrCompute[any](&c.HealthCheckConfiguration, func() (any, error) {
+		return c.healthCheckConfiguration()
+	})
 }
 
 func (c *mqlAwsApprunnerService) GetEgressType() *plugin.TValue[string] {
-	return &c.EgressType
+	return plugin.GetOrCompute[string](&c.EgressType, func() (string, error) {
+		return c.egressType()
+	})
 }
 
 func (c *mqlAwsApprunnerService) GetVpcConnector() *plugin.TValue[*mqlAwsApprunnerVpcConnector] {
@@ -141557,11 +141569,15 @@ func (c *mqlAwsApprunnerService) GetVpcConnector() *plugin.TValue[*mqlAwsApprunn
 }
 
 func (c *mqlAwsApprunnerService) GetIsPubliclyAccessible() *plugin.TValue[bool] {
-	return &c.IsPubliclyAccessible
+	return plugin.GetOrCompute[bool](&c.IsPubliclyAccessible, func() (bool, error) {
+		return c.isPubliclyAccessible()
+	})
 }
 
 func (c *mqlAwsApprunnerService) GetIpAddressType() *plugin.TValue[string] {
-	return &c.IpAddressType
+	return plugin.GetOrCompute[string](&c.IpAddressType, func() (string, error) {
+		return c.ipAddressType()
+	})
 }
 
 func (c *mqlAwsApprunnerService) GetObservabilityConfiguration() *plugin.TValue[*mqlAwsApprunnerObservabilityConfiguration] {
@@ -141687,7 +141703,9 @@ func (c *mqlAwsApprunnerAutoScalingConfiguration) GetRevision() *plugin.TValue[i
 }
 
 func (c *mqlAwsApprunnerAutoScalingConfiguration) GetLatest() *plugin.TValue[bool] {
-	return &c.Latest
+	return plugin.GetOrCompute[bool](&c.Latest, func() (bool, error) {
+		return c.latest()
+	})
 }
 
 func (c *mqlAwsApprunnerAutoScalingConfiguration) GetStatus() *plugin.TValue[string] {
@@ -141699,19 +141717,27 @@ func (c *mqlAwsApprunnerAutoScalingConfiguration) GetCreatedAt() *plugin.TValue[
 }
 
 func (c *mqlAwsApprunnerAutoScalingConfiguration) GetDeletedAt() *plugin.TValue[*time.Time] {
-	return &c.DeletedAt
+	return plugin.GetOrCompute[*time.Time](&c.DeletedAt, func() (*time.Time, error) {
+		return c.deletedAt()
+	})
 }
 
 func (c *mqlAwsApprunnerAutoScalingConfiguration) GetMaxConcurrency() *plugin.TValue[int64] {
-	return &c.MaxConcurrency
+	return plugin.GetOrCompute[int64](&c.MaxConcurrency, func() (int64, error) {
+		return c.maxConcurrency()
+	})
 }
 
 func (c *mqlAwsApprunnerAutoScalingConfiguration) GetMinSize() *plugin.TValue[int64] {
-	return &c.MinSize
+	return plugin.GetOrCompute[int64](&c.MinSize, func() (int64, error) {
+		return c.minSize()
+	})
 }
 
 func (c *mqlAwsApprunnerAutoScalingConfiguration) GetMaxSize() *plugin.TValue[int64] {
-	return &c.MaxSize
+	return plugin.GetOrCompute[int64](&c.MaxSize, func() (int64, error) {
+		return c.maxSize()
+	})
 }
 
 func (c *mqlAwsApprunnerAutoScalingConfiguration) GetHasAssociatedService() *plugin.TValue[bool] {
@@ -141975,23 +142001,33 @@ func (c *mqlAwsApprunnerObservabilityConfiguration) GetRevision() *plugin.TValue
 }
 
 func (c *mqlAwsApprunnerObservabilityConfiguration) GetLatest() *plugin.TValue[bool] {
-	return &c.Latest
+	return plugin.GetOrCompute[bool](&c.Latest, func() (bool, error) {
+		return c.latest()
+	})
 }
 
 func (c *mqlAwsApprunnerObservabilityConfiguration) GetStatus() *plugin.TValue[string] {
-	return &c.Status
+	return plugin.GetOrCompute[string](&c.Status, func() (string, error) {
+		return c.status()
+	})
 }
 
 func (c *mqlAwsApprunnerObservabilityConfiguration) GetCreatedAt() *plugin.TValue[*time.Time] {
-	return &c.CreatedAt
+	return plugin.GetOrCompute[*time.Time](&c.CreatedAt, func() (*time.Time, error) {
+		return c.createdAt()
+	})
 }
 
 func (c *mqlAwsApprunnerObservabilityConfiguration) GetDeletedAt() *plugin.TValue[*time.Time] {
-	return &c.DeletedAt
+	return plugin.GetOrCompute[*time.Time](&c.DeletedAt, func() (*time.Time, error) {
+		return c.deletedAt()
+	})
 }
 
 func (c *mqlAwsApprunnerObservabilityConfiguration) GetTraceConfigurationVendor() *plugin.TValue[string] {
-	return &c.TraceConfigurationVendor
+	return plugin.GetOrCompute[string](&c.TraceConfigurationVendor, func() (string, error) {
+		return c.traceConfigurationVendor()
+	})
 }
 
 func (c *mqlAwsApprunnerObservabilityConfiguration) GetRegion() *plugin.TValue[string] {
@@ -142056,27 +142092,39 @@ func (c *mqlAwsApprunnerVpcIngressConnection) GetArn() *plugin.TValue[string] {
 }
 
 func (c *mqlAwsApprunnerVpcIngressConnection) GetName() *plugin.TValue[string] {
-	return &c.Name
+	return plugin.GetOrCompute[string](&c.Name, func() (string, error) {
+		return c.name()
+	})
 }
 
 func (c *mqlAwsApprunnerVpcIngressConnection) GetStatus() *plugin.TValue[string] {
-	return &c.Status
+	return plugin.GetOrCompute[string](&c.Status, func() (string, error) {
+		return c.status()
+	})
 }
 
 func (c *mqlAwsApprunnerVpcIngressConnection) GetCreatedAt() *plugin.TValue[*time.Time] {
-	return &c.CreatedAt
+	return plugin.GetOrCompute[*time.Time](&c.CreatedAt, func() (*time.Time, error) {
+		return c.createdAt()
+	})
 }
 
 func (c *mqlAwsApprunnerVpcIngressConnection) GetDeletedAt() *plugin.TValue[*time.Time] {
-	return &c.DeletedAt
+	return plugin.GetOrCompute[*time.Time](&c.DeletedAt, func() (*time.Time, error) {
+		return c.deletedAt()
+	})
 }
 
 func (c *mqlAwsApprunnerVpcIngressConnection) GetDomainName() *plugin.TValue[string] {
-	return &c.DomainName
+	return plugin.GetOrCompute[string](&c.DomainName, func() (string, error) {
+		return c.domainName()
+	})
 }
 
 func (c *mqlAwsApprunnerVpcIngressConnection) GetIngressVpcConfiguration() *plugin.TValue[any] {
-	return &c.IngressVpcConfiguration
+	return plugin.GetOrCompute[any](&c.IngressVpcConfiguration, func() (any, error) {
+		return c.ingressVpcConfiguration()
+	})
 }
 
 func (c *mqlAwsApprunnerVpcIngressConnection) GetService() *plugin.TValue[*mqlAwsApprunnerService] {
@@ -156706,7 +156754,9 @@ func (c *mqlAwsCloudformationStackSet) GetLastDriftCheckTimestamp() *plugin.TVal
 }
 
 func (c *mqlAwsCloudformationStackSet) GetManagedExecutionActive() *plugin.TValue[bool] {
-	return &c.ManagedExecutionActive
+	return plugin.GetOrCompute[bool](&c.ManagedExecutionActive, func() (bool, error) {
+		return c.managedExecutionActive()
+	})
 }
 
 func (c *mqlAwsCloudformationStackSet) GetAutoDeploymentEnabled() *plugin.TValue[bool] {

--- a/providers/aws/resources/aws_cloudformation.go
+++ b/providers/aws/resources/aws_cloudformation.go
@@ -326,7 +326,6 @@ func (a *mqlAwsCloudformation) getStackSets(conn *connection.AwsConnection) []*j
 								"permissionModel":         llx.StringData(string(ss.PermissionModel)),
 								"driftStatus":             llx.StringData(normalizeDriftStatus(string(ss.DriftStatus))),
 								"lastDriftCheckTimestamp": llx.TimeDataPtr(ss.LastDriftCheckTimestamp),
-								"managedExecutionActive":  llx.BoolData(managedExecutionActive(ss.ManagedExecution)),
 							})
 						if err != nil {
 							return nil, err
@@ -354,12 +353,13 @@ type mqlAwsCloudformationStackSetInternal struct {
 	cacheAutoDeployment *cf_types.AutoDeployment
 	cacheStatus         cf_types.StackSetStatus
 
-	detailsLock    sync.Mutex
-	detailsFetched bool
-	cacheTags      map[string]any
-	cacheAdminRole *string
-	cacheExecRole  *string
-	cacheOuIds     []string
+	detailsLock      sync.Mutex
+	detailsFetched   bool
+	cacheTags        map[string]any
+	cacheAdminRole   *string
+	cacheExecRole    *string
+	cacheOuIds       []string
+	cacheManagedExec *cf_types.ManagedExecution
 }
 
 func (a *mqlAwsCloudformationStackSet) autoDeploymentEnabled() (bool, error) {
@@ -409,9 +409,17 @@ func (a *mqlAwsCloudformationStackSet) fetchDetails() error {
 		a.cacheAdminRole = resp.StackSet.AdministrationRoleARN
 		a.cacheExecRole = resp.StackSet.ExecutionRoleName
 		a.cacheOuIds = resp.StackSet.OrganizationalUnitIds
+		a.cacheManagedExec = resp.StackSet.ManagedExecution
 	}
 	a.detailsFetched = true
 	return nil
+}
+
+func (a *mqlAwsCloudformationStackSet) managedExecutionActive() (bool, error) {
+	if err := a.fetchDetails(); err != nil {
+		return false, err
+	}
+	return managedExecutionActive(a.cacheManagedExec), nil
 }
 
 func (a *mqlAwsCloudformationStackSet) tags() (map[string]any, error) {

--- a/providers/azure/resources/armsecurity.go
+++ b/providers/azure/resources/armsecurity.go
@@ -66,7 +66,7 @@ func getPolicyAssignments(ctx context.Context, conn armSecurityConn) (PolicyAssi
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		return PolicyAssignments{}, errors.New("failed to fetch security contacts from " + urlPath + ": " + resp.Status)
+		return PolicyAssignments{}, errors.New("failed to fetch policy assignments from " + urlPath + ": " + resp.Status)
 	}
 
 	raw, err := io.ReadAll(resp.Body)
@@ -104,7 +104,7 @@ func getServerVulnAssessmentSettings(ctx context.Context, conn armSecurityConn) 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		return ServerVulnerabilityAssessmentsSettingsList{}, errors.New("failed to fetch security contacts from " + urlPath + ": " + resp.Status)
+		return ServerVulnerabilityAssessmentsSettingsList{}, errors.New("failed to fetch server vulnerability assessment settings from " + urlPath + ": " + resp.Status)
 	}
 
 	raw, err := io.ReadAll(resp.Body)

--- a/providers/gcp/resources/dataproc.go
+++ b/providers/gcp/resources/dataproc.go
@@ -78,6 +78,31 @@ func (g *mqlGcpProject) dataproc() (*mqlGcpProjectDataprocService, error) {
 	return res.(*mqlGcpProjectDataprocService), nil
 }
 
+// Direct construction (e.g. `gcp.project.dataprocService.regions`) bypasses
+// gcp.project.dataproc(), leaving projectId empty so regions() calls the
+// compute API with an empty project ID. Delegate to the parent project
+// accessor so projectId + enabled are both populated.
+func initGcpProjectDataprocService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if _, ok := args["projectId"]; ok {
+		return args, nil, nil
+	}
+	conn, ok := runtime.Connection.(*connection.GcpConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
+	}
+	proj, err := NewResource(runtime, "gcp.project", map[string]*llx.RawData{
+		"id": llx.StringData(conn.ResourceID()),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	svc, err := proj.(*mqlGcpProject).dataproc()
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, svc, nil
+}
+
 func (g *mqlGcpProjectDataprocService) regions() ([]any, error) {
 	// no check whether DataProc service is enabled here, this uses a different service
 	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)

--- a/providers/gcp/resources/filestore.go
+++ b/providers/gcp/resources/filestore.go
@@ -5,11 +5,13 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	filestore "cloud.google.com/go/filestore/apiv1"
 	"cloud.google.com/go/filestore/apiv1/filestorepb"
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
 	"go.mondoo.com/mql/v13/types"
@@ -28,6 +30,31 @@ func (g *mqlGcpProject) filestore() (*mqlGcpProjectFilestoreService, error) {
 		return nil, err
 	}
 	return res.(*mqlGcpProjectFilestoreService), nil
+}
+
+// Direct construction (e.g. `gcp.project.filestoreService.instances`) bypasses
+// gcp.project.filestore(), leaving projectId empty so instances() raises a
+// malformed RESOURCE_PROJECT_INVALID instead of returning the proper
+// SERVICE_DISABLED message. Delegate to the parent project accessor.
+func initGcpProjectFilestoreService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if _, ok := args["projectId"]; ok {
+		return args, nil, nil
+	}
+	conn, ok := runtime.Connection.(*connection.GcpConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
+	}
+	proj, err := NewResource(runtime, "gcp.project", map[string]*llx.RawData{
+		"id": llx.StringData(conn.ResourceID()),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	svc, err := proj.(*mqlGcpProject).filestore()
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, svc, nil
 }
 
 func (g *mqlGcpProjectFilestoreService) id() (string, error) {

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -954,7 +954,7 @@ func init() {
 			Create: createGcpProjectApiKeyRestrictions,
 		},
 		"gcp.project.loggingservice": {
-			// to override args, implement: initGcpProjectLoggingservice(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initGcpProjectLoggingservice,
 			Create: createGcpProjectLoggingservice,
 		},
 		"gcp.project.loggingservice.bucket": {
@@ -982,7 +982,7 @@ func init() {
 			Create: createGcpProjectLoggingserviceExclusion,
 		},
 		"gcp.project.iamService": {
-			// to override args, implement: initGcpProjectIamService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initGcpProjectIamService,
 			Create: createGcpProjectIamService,
 		},
 		"gcp.project.iamService.role": {
@@ -1030,7 +1030,7 @@ func init() {
 			Create: createGcpProjectCloudFunctionV2EventTrigger,
 		},
 		"gcp.project.dataprocService": {
-			// to override args, implement: initGcpProjectDataprocService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initGcpProjectDataprocService,
 			Create: createGcpProjectDataprocService,
 		},
 		"gcp.project.dataprocService.cluster": {
@@ -1406,7 +1406,7 @@ func init() {
 			Create: createGcpRetryConfig,
 		},
 		"gcp.project.filestoreService": {
-			// to override args, implement: initGcpProjectFilestoreService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initGcpProjectFilestoreService,
 			Create: createGcpProjectFilestoreService,
 		},
 		"gcp.project.filestoreService.instance": {

--- a/providers/gcp/resources/iam.go
+++ b/providers/gcp/resources/iam.go
@@ -82,6 +82,31 @@ func (g *mqlGcpProject) iam() (*mqlGcpProjectIamService, error) {
 	return svc, nil
 }
 
+// Direct construction (e.g. `gcp.project.iamService.serviceAccounts`) bypasses
+// gcp.project.iam(), so projectId stays empty and serviceEnabled stays false —
+// accessors then short-circuit and silently return empty. Delegate to the
+// parent project accessor so the resulting instance is fully initialized.
+func initGcpProjectIamService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if _, ok := args["projectId"]; ok {
+		return args, nil, nil
+	}
+	conn, ok := runtime.Connection.(*connection.GcpConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
+	}
+	proj, err := NewResource(runtime, "gcp.project", map[string]*llx.RawData{
+		"id": llx.StringData(conn.ResourceID()),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	svc, err := proj.(*mqlGcpProject).iam()
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, svc, nil
+}
+
 func (g *mqlGcpProjectIamServiceServiceAccount) id() (string, error) {
 	if g.UniqueId.Error != nil {
 		return "", g.UniqueId.Error

--- a/providers/gcp/resources/logging.go
+++ b/providers/gcp/resources/logging.go
@@ -61,6 +61,31 @@ func (g *mqlGcpProject) logging() (*mqlGcpProjectLoggingservice, error) {
 	return svc, nil
 }
 
+// Direct construction (e.g. `gcp.project.loggingservice.sinks`) bypasses
+// gcp.project.logging(), leaving projectId empty and serviceEnabled false —
+// accessors then short-circuit to empty silently. Delegate to the parent
+// project accessor so the resulting instance is fully initialized.
+func initGcpProjectLoggingservice(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if _, ok := args["projectId"]; ok {
+		return args, nil, nil
+	}
+	conn, ok := runtime.Connection.(*connection.GcpConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
+	}
+	proj, err := NewResource(runtime, "gcp.project", map[string]*llx.RawData{
+		"id": llx.StringData(conn.ResourceID()),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	svc, err := proj.(*mqlGcpProject).logging()
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, svc, nil
+}
+
 func (g *mqlGcpProjectLoggingservice) buckets() ([]any, error) {
 	if !g.serviceEnabled {
 		return nil, nil


### PR DESCRIPTION
## Summary

Three classes of bug found by running `/provider-verification` against `21f947e7e..main` with live AWS + GCP + Azure infrastructure:

### 1. `aws.apprunner` — 19 lazy fields broken (declaration/implementation mismatch)

Fields on `aws.apprunner.{service, autoScalingConfiguration, observabilityConfiguration, vpcIngressConnection}` were declared as plain data in `aws.lr` (`status string`, `egressType string`, …) but implemented as lazy methods in Go (`func (a *mqlAwsApprunnerService) egressType() (string, error)`). The codegen therefore emitted `GetEgressType()` accessors that returned an unset `TValue` with no type info; every read errored with:

> `cannot convert primitive with NO type information`

**Fix:** add `()` to the affected `.lr` declarations and regenerate. This wires the field through `plugin.GetOrCompute` so the lazy method actually runs.

### 2. `aws.cloudformation.stackSet.managedExecutionActive` — always `false`

The value was read from the `ListStackSets` summary, but that API never populates `ManagedExecution`; only `DescribeStackSet` does. So the field always resolved to `false` even when `Active: true`.

**Fix:** moved it onto the existing `fetchDetails()` lazy path alongside `administrationRole` / `executionRoleName` / `organizationalUnitIds`, which already round-trip through `DescribeStackSet`. Verified `mql-verify-ss` (TF `managed_execution { active = true }`) now reads as `true`.

### 3. `gcp` — dotted-subresource husk on 4 audit-touched services

Querying `gcp.project.{iamService,loggingservice,dataprocService,filestoreService}.<x>` directly (instead of via the `gcp.project.{iam,logging,dataproc,filestore}().<x>` accessor) bypassed the parent code that sets `projectId` and `serviceEnabled`. Symptoms:

- `iamService.serviceAccounts` returned `[]` even with real SAs (silent data loss)
- `loggingservice.{sinks,buckets}` returned `[]` even with `_Default` / `_Required` present (silent data loss)
- `dataprocService.regions` raised `RESOURCE_PROJECT_INVALID` (compute API called with empty project)
- `filestoreService.instances` returned a malformed error instead of clean `SERVICE_DISABLED`

**Fix:** added `initGcpProject<Service>` functions in each of the 4 files that detect the empty-args path and delegate to the parent project's accessor so the resulting instance is fully initialized. Pattern matches the existing `initGcpProjectPubsubService` / `initGcpProjectEventarcService` etc.

### 4. `azure.armsecurity` — copy-paste error messages

`getPolicyAssignments` and `getServerVulnAssessmentSettings` both reported `"failed to fetch security contacts"` on non-200 responses, leftover from the original security-contacts code these were copied from. Trivial text fix.

## Test plan

- [x] `make providers/build/{aws,gcp,azure}` + `make providers/install/{aws,gcp,azure}` succeed
- [x] AppRunner service / autoScalingConfiguration / observabilityConfiguration / vpcIngressConnection — every field listed now populates with real data
- [x] `aws.cloudformation.stackSet` `managedExecutionActive` returns `true` for a stack-set with TF-configured `managed_execution { active = true }`
- [x] `gcp.project.iamService.serviceAccounts` returns 2 SAs (was `[]`)
- [x] `gcp.project.loggingservice.sinks` returns `_Default` + `_Required` (was `[]`)
- [x] `gcp.project.dataprocService.regions.length` returns 43 (was `RESOURCE_PROJECT_INVALID`)
- [x] `gcp.project.filestoreService.instances` returns the clean `SERVICE_DISABLED` API message (was malformed error)
- [x] AppRunner typed refs (`kmsKey`, `vpcConnector`, `autoScalingConfiguration`) still resolve
- [x] `gofmt -w` on all touched Go files
- [x] No `.lr.versions` changes (no new fields)
- [x] `*.permissions.json` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)