### PR TITLE
✨ vllm: add model inventory resource for AIBOM

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -378,6 +378,7 @@ kts
 kty
 kubenet
 kustomization
+KVCACHE
 KVM
 labelmatchstatement
 Laravel
@@ -692,6 +693,7 @@ sriov
 srp
 ssbd
 SSHFP
+sshleifer
 ssis
 sslv
 Sspr
@@ -769,6 +771,7 @@ vdev
 VDhir
 vdi
 vendored
+venv
 verifiedaccess
 vertexai
 Veth

--- a/providers/vllm/connection/connection.go
+++ b/providers/vllm/connection/connection.go
@@ -218,6 +218,38 @@ func (c *VllmConnection) Version(ctx context.Context) (string, error) {
 	return c.version, c.versionErr
 }
 
+type ModelCard struct {
+	ID          string `json:"id"`
+	Object      string `json:"object"`
+	Created     int64  `json:"created"`
+	OwnedBy     string `json:"owned_by"`
+	Root        string `json:"root"`
+	Parent      string `json:"parent"`
+	MaxModelLen int64  `json:"max_model_len"`
+}
+
+func (c *VllmConnection) Models(ctx context.Context) ([]ModelCard, error) {
+	resp, err := c.Request(ctx, http.MethodGet, "/v1/models", true, "")
+	if err != nil {
+		return nil, fmt.Errorf("vllm: failed to list models: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("vllm: /v1/models returned HTTP %d", resp.StatusCode)
+	}
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return nil, err
+	}
+	var parsed struct {
+		Data []ModelCard `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, fmt.Errorf("vllm: failed to parse /v1/models response: %w", err)
+	}
+	return parsed.Data, nil
+}
+
 func (c *VllmConnection) EndpointObservations(ctx context.Context) ([]EndpointObservation, error) {
 	c.endpointsOnce.Do(func() {
 		specs := DefaultEndpointSpecs()

--- a/providers/vllm/resources/vllm.go
+++ b/providers/vllm/resources/vllm.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -89,6 +90,41 @@ func (r *mqlVllm) version() (string, error) {
 		return "", nil
 	}
 	return version, nil
+}
+
+func (r *mqlVllm) models() ([]any, error) {
+	conn, err := vllmConnection(r.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+
+	cards, err := conn.Models(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]any, 0, len(cards))
+	for _, c := range cards {
+		mqlModel, err := CreateResource(r.MqlRuntime, "vllm.model", map[string]*llx.RawData{
+			"__id":        llx.StringData(conn.BaseURL() + "/model/" + c.ID),
+			"id":          llx.StringData(c.ID),
+			"root":        llx.StringData(c.Root),
+			"parent":      llx.StringData(c.Parent),
+			"maxModelLen": llx.IntData(c.MaxModelLen),
+			"created":     llx.TimeData(time.Unix(c.Created, 0)),
+			"ownedBy":     llx.StringData(c.OwnedBy),
+		})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlModel)
+	}
+
+	return res, nil
+}
+
+func (r *mqlVllmModel) id() (string, error) {
+	return r.Id.Data, nil
 }
 
 func (s *mqlVllmServer) id() (string, error) {

--- a/providers/vllm/resources/vllm.lr
+++ b/providers/vllm/resources/vllm.lr
@@ -6,11 +6,10 @@ option go_package = "go.mondoo.com/mql/v13/providers/vllm/resources"
 
 // vLLM inference server
 //
-// Examine the security posture of a remote vLLM HTTP inference server:
-// the server-level summary, the per-endpoint anonymous-access probe
-// results, the minimal metrics-exposure posture, and the reported
-// vLLM version. Used to find vLLM deployments that expose admin,
-// profiler, or metrics endpoints without authentication.
+// Examine the security posture and model inventory of a remote vLLM
+// HTTP inference server: the server-level summary, the per-endpoint
+// anonymous-access probe results, the minimal metrics-exposure posture,
+// the reported vLLM version, and the models loaded for serving.
 vllm {
   // Server-level HTTP posture summary
   server() vllm.server
@@ -20,6 +19,36 @@ vllm {
   metrics() vllm.metrics
   // vLLM server version, if the /version endpoint is observable
   version() string
+  // Models loaded for serving
+  models() []vllm.model
+}
+
+// vLLM served model
+//
+// Examine a model loaded for serving on the vLLM instance. The `id`
+// field is the model identifier as configured at launch (typically a
+// Hugging Face model path such as `meta-llama/Llama-3.1-8B-Instruct`).
+// The `root` field is the underlying model path, and `maxModelLen` is
+// the context window length in tokens configured for this deployment.
+vllm.model @defaults("id maxModelLen") {
+  // Model identifier
+  id string
+  // Underlying model path
+  //
+  // Typically the Hugging Face repository path or a local filesystem
+  // path. May differ from `id` when the model is served under an alias.
+  root string
+  // Parent model identifier
+  //
+  // Set for LoRA adapters to reference the base model they extend.
+  // Empty for base models.
+  parent string
+  // Maximum context window length in tokens
+  maxModelLen int
+  // Model creation timestamp as reported by the server
+  created time
+  // Entity that owns or manages the model
+  ownedBy string
 }
 
 // vLLM server-level HTTP posture

--- a/providers/vllm/resources/vllm.lr.go
+++ b/providers/vllm/resources/vllm.lr.go
@@ -7,6 +7,7 @@ package resources
 
 import (
 	"errors"
+	"time"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -16,6 +17,7 @@ import (
 // The MQL type names exposed as public consts for ease of reference.
 const (
 	ResourceVllm         string = "vllm"
+	ResourceVllmModel    string = "vllm.model"
 	ResourceVllmServer   string = "vllm.server"
 	ResourceVllmEndpoint string = "vllm.endpoint"
 	ResourceVllmMetrics  string = "vllm.metrics"
@@ -28,6 +30,10 @@ func init() {
 		"vllm": {
 			// to override args, implement: initVllm(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createVllm,
+		},
+		"vllm.model": {
+			// to override args, implement: initVllmModel(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createVllmModel,
 		},
 		"vllm.server": {
 			// to override args, implement: initVllmServer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -123,6 +129,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"vllm.version": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVllm).GetVersion()).ToDataRes(types.String)
+	},
+	"vllm.models": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVllm).GetModels()).ToDataRes(types.Array(types.Resource("vllm.model")))
+	},
+	"vllm.model.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVllmModel).GetId()).ToDataRes(types.String)
+	},
+	"vllm.model.root": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVllmModel).GetRoot()).ToDataRes(types.String)
+	},
+	"vllm.model.parent": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVllmModel).GetParent()).ToDataRes(types.String)
+	},
+	"vllm.model.maxModelLen": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVllmModel).GetMaxModelLen()).ToDataRes(types.Int)
+	},
+	"vllm.model.created": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVllmModel).GetCreated()).ToDataRes(types.Time)
+	},
+	"vllm.model.ownedBy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVllmModel).GetOwnedBy()).ToDataRes(types.String)
 	},
 	"vllm.server.baseUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVllmServer).GetBaseUrl()).ToDataRes(types.String)
@@ -229,6 +256,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"vllm.version": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlVllm).Version, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"vllm.models": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVllm).Models, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"vllm.model.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVllmModel).__id, ok = v.Value.(string)
+		return
+	},
+	"vllm.model.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVllmModel).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"vllm.model.root": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVllmModel).Root, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"vllm.model.parent": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVllmModel).Parent, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"vllm.model.maxModelLen": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVllmModel).MaxModelLen, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"vllm.model.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVllmModel).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"vllm.model.ownedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVllmModel).OwnedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"vllm.server.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -376,6 +435,7 @@ type mqlVllm struct {
 	Endpoints plugin.TValue[[]any]
 	Metrics   plugin.TValue[*mqlVllmMetrics]
 	Version   plugin.TValue[string]
+	Models    plugin.TValue[[]any]
 }
 
 // createVllm creates a new instance of this resource
@@ -467,6 +527,96 @@ func (c *mqlVllm) GetVersion() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Version, func() (string, error) {
 		return c.version()
 	})
+}
+
+func (c *mqlVllm) GetModels() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Models, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("vllm", c.__id, "models")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.models()
+	})
+}
+
+// mqlVllmModel for the vllm.model resource
+type mqlVllmModel struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlVllmModelInternal it will be used here
+	Id          plugin.TValue[string]
+	Root        plugin.TValue[string]
+	Parent      plugin.TValue[string]
+	MaxModelLen plugin.TValue[int64]
+	Created     plugin.TValue[*time.Time]
+	OwnedBy     plugin.TValue[string]
+}
+
+// createVllmModel creates a new instance of this resource
+func createVllmModel(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlVllmModel{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("vllm.model", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlVllmModel) MqlName() string {
+	return "vllm.model"
+}
+
+func (c *mqlVllmModel) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlVllmModel) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlVllmModel) GetRoot() *plugin.TValue[string] {
+	return &c.Root
+}
+
+func (c *mqlVllmModel) GetParent() *plugin.TValue[string] {
+	return &c.Parent
+}
+
+func (c *mqlVllmModel) GetMaxModelLen() *plugin.TValue[int64] {
+	return &c.MaxModelLen
+}
+
+func (c *mqlVllmModel) GetCreated() *plugin.TValue[*time.Time] {
+	return &c.Created
+}
+
+func (c *mqlVllmModel) GetOwnedBy() *plugin.TValue[string] {
+	return &c.OwnedBy
 }
 
 // mqlVllmServer for the vllm.server resource

--- a/providers/vllm/resources/vllm.lr.versions
+++ b/providers/vllm/resources/vllm.lr.versions
@@ -17,6 +17,14 @@ vllm.metrics 13.0.1
 vllm.metrics.loadEndpointExposed 13.0.1
 vllm.metrics.loadTrackingVisible 13.0.1
 vllm.metrics.prometheusExposed 13.0.1
+vllm.model 13.0.7
+vllm.model.created 13.0.7
+vllm.model.id 13.0.7
+vllm.model.maxModelLen 13.0.7
+vllm.model.ownedBy 13.0.7
+vllm.model.parent 13.0.7
+vllm.model.root 13.0.7
+vllm.models 13.0.7
 vllm.server 13.0.1
 vllm.server.baseUrl 13.0.1
 vllm.server.corsAllowsAnyOrigin 13.0.1

--- a/providers/vllm/testdata/README.md
+++ b/providers/vllm/testdata/README.md
@@ -1,0 +1,65 @@
+# vLLM Provider Testing
+
+Test the mql vLLM provider against a live vLLM inference server.
+
+## Setup (macOS, Apple Silicon)
+
+vLLM runs natively on macOS with CPU-only mode. Use Python 3.12 or 3.13 (3.14+ is not yet supported).
+
+### 1. Install vLLM
+
+```bash
+python3.12 -m venv /tmp/vllm-env
+/tmp/vllm-env/bin/pip install vllm
+```
+
+### 2. Start the server
+
+```bash
+VLLM_CPU_KVCACHE_SPACE=1 /tmp/vllm-env/bin/vllm serve sshleifer/tiny-gpt2 \
+  --host 0.0.0.0 --port 8000
+```
+
+The `sshleifer/tiny-gpt2` model is ~2 MB and loads in seconds. Wait for `Application startup complete.` in the output.
+
+### 3. Build and install the provider
+
+```bash
+make providers/build/vllm && make providers/install/vllm
+```
+
+### 4. Run the test suite
+
+```bash
+VLLM_IP=localhost ./providers/vllm/testdata/verify.sh
+```
+
+## Ad-hoc queries
+
+```bash
+mql run vllm http://localhost:8000 -c "vllm.server { baseUrl reachable version }"
+mql run vllm http://localhost:8000 -c "vllm.models { id root maxModelLen ownedBy }"
+mql run vllm http://localhost:8000 -c "vllm.endpoints { method path present anonymousAccessible }"
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `VLLM_IP` | `localhost` | IP or hostname of the vLLM server |
+| `VLLM_PORT` | `8000` | Port the vLLM server listens on |
+
+## Testing with a Remote Server
+
+Point the test suite at any reachable vLLM instance:
+
+```bash
+VLLM_IP=vllm.example.com VLLM_PORT=8000 ./providers/vllm/testdata/verify.sh
+```
+
+## Notes
+
+- vLLM on macOS uses CPU-only mode (no GPU required)
+- Python 3.12 or 3.13 is recommended; 3.14+ is not yet supported by vLLM
+- The `VLLM_CPU_KVCACHE_SPACE=1` env var limits KV cache to 1 GB of RAM
+- On Linux, vLLM requires a CUDA-capable GPU

--- a/providers/vllm/testdata/verify.sh
+++ b/providers/vllm/testdata/verify.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# Verify the mql vLLM provider against a live vLLM instance.
+#
+# Prerequisites:
+#   - mql installed with the vllm provider built and installed
+#   - A running vLLM server (see README.md for setup)
+#
+# Usage:
+#   VLLM_IP=localhost ./providers/vllm/testdata/verify.sh
+#   VLLM_IP=192.168.1.100 VLLM_PORT=8080 ./providers/vllm/testdata/verify.sh
+
+set -eo pipefail
+
+VLLM_IP="${VLLM_IP:-localhost}"
+VLLM_PORT="${VLLM_PORT:-8000}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+pass=0
+fail=0
+
+run_query() {
+  local desc="$1"
+  local query="$2"
+  local result
+  local exit_code=0
+  result=$(mql run vllm "http://${VLLM_IP}:${VLLM_PORT}" -c "$query" 2>&1) || exit_code=$?
+
+  local filtered
+  filtered=$(echo "$result" | grep -v "loaded configuration from")
+
+  if [ "$exit_code" -ne 0 ] || echo "$filtered" | grep -qi "error occurred\|panic\|unable to"; then
+    echo -e "${RED}FAIL${NC}: $desc"
+    echo "  Query: $query"
+    echo "$filtered" | head -5 | sed 's/^/  /'
+    fail=$((fail + 1))
+  else
+    echo -e "${GREEN}PASS${NC}: $desc"
+    pass=$((pass + 1))
+  fi
+}
+
+if ! command -v mql &>/dev/null; then
+  echo "Error: mql is not installed or not in PATH"
+  exit 1
+fi
+
+if ! curl -sf "http://${VLLM_IP}:${VLLM_PORT}/health" >/dev/null 2>&1; then
+  echo "Error: vLLM is not reachable at http://${VLLM_IP}:${VLLM_PORT}/health"
+  echo "See README.md for setup instructions."
+  exit 1
+fi
+
+echo -e "${CYAN}==>${NC} vLLM reachable at http://${VLLM_IP}:${VLLM_PORT}"
+echo ""
+echo "=== mql vLLM Provider Verification ==="
+echo ""
+
+# Server posture
+run_query "server summary" "vllm.server { baseUrl reachable version }"
+run_query "server TLS" "vllm.server { usesTls }"
+run_query "server CORS" "vllm.server { corsConfigured corsAllowsAnyOrigin }"
+run_query "server docs exposure" "vllm.server { docsExposed openapiExposed }"
+run_query "server metrics exposure" "vllm.server { metricsExposed loadEndpointExposed }"
+run_query "server dev endpoints" "vllm.server { devEndpointsExposed profilerEndpointsExposed tokenizerInfoExposed }"
+
+# Endpoints
+run_query "endpoint list" "vllm.endpoints { method path category present }"
+run_query "endpoint access" "vllm.endpoints { anonymousAccessible requiresAuth }"
+run_query "endpoint status codes" "vllm.endpoints { anonymousStatusCode }"
+
+# Metrics
+run_query "metrics posture" "vllm.metrics { prometheusExposed loadEndpointExposed loadTrackingVisible }"
+
+# Version
+run_query "vllm version" "vllm.version"
+
+# Models
+run_query "model list" "vllm.models { id root maxModelLen }"
+run_query "model details" "vllm.models { id ownedBy created parent }"
+run_query "model count" "vllm.models.length"
+
+echo ""
+echo "=== Results: ${pass} passed, ${fail} failed ==="
+
+if [ "$fail" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `vllm.model` resource with fields: `id`, `root`, `parent`, `maxModelLen`, `created`, `ownedBy`
- Add `vllm.models()` to the `vllm` resource for listing models loaded for serving
- Add `Models()` method to `VllmConnection` that calls `/v1/models` API
- vLLM extends the OpenAI `/v1/models` response with `max_model_len` and `root` (HF model path) — both captured

Example query:
```
mql run vllm http://localhost:8000 -c "vllm.models { id root maxModelLen ownedBy }"
```

## Test plan
- [ ] Build and install provider: `make providers/build/vllm && make providers/install/vllm`
- [ ] Query models on a running vLLM instance
- [ ] Verify existing security posture resources still work
- [ ] golangci-lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)