### PR TITLE
✨ os: add macos.xprotect for anti-malware signature version + freshness

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -448,6 +448,7 @@ modelarmor
 modelfile
 mongodb
 Mpim
+mrt
 Mshv
 msk
 mtls
@@ -614,6 +615,7 @@ recrawl
 referencegrant
 regexmatchstatement
 regexpatternsetreferencestatement
+Remediator
 renv
 RESKEY
 resourcegroup
@@ -825,6 +827,7 @@ wwn
 Xff
 xks
 xlarge
+xprotect
 xssmatchstatement
 xts
 xxxxx

--- a/providers/os/resources/macos_xprotect.go
+++ b/providers/os/resources/macos_xprotect.go
@@ -1,0 +1,130 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"sync"
+	"time"
+
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/v13/providers/os/resources/plist"
+)
+
+// xprotectBundlePaths and mrtBundlePaths list the locations XProtect
+// and MRT can live in, in order of preference. Modern macOS keeps
+// them under /Library/Apple/System/...; older releases used the
+// traditional /System/Library/CoreServices/ path.
+var (
+	xprotectBundlePaths = []string{
+		"/Library/Apple/System/Library/CoreServices/XProtect.bundle",
+		"/System/Library/CoreServices/XProtect.bundle",
+	}
+	mrtBundlePaths = []string{
+		"/Library/Apple/System/Library/CoreServices/MRT.app",
+		"/System/Library/CoreServices/MRT.app",
+	}
+)
+
+type mqlMacosXprotectInternal struct {
+	lock    sync.Mutex
+	fetched bool
+	state   xprotectState
+}
+
+type xprotectState struct {
+	version     string
+	modified    *time.Time
+	mrtVersion  string
+	mrtModified *time.Time
+}
+
+func (x *mqlMacosXprotect) id() (string, error) {
+	return "macos.xprotect", nil
+}
+
+// fetchState locates XProtect.bundle and MRT.app, reads their
+// Info.plist files for `CFBundleShortVersionString`, and stats them
+// for modification time. A missing bundle leaves its fields at zero
+// (empty string + nil pointer), which the typed accessors translate
+// into MQL null/empty so audits fail soft on systems where Apple has
+// retired the relevant component.
+func (x *mqlMacosXprotect) fetchState() (xprotectState, error) {
+	if x.fetched {
+		return x.state, nil
+	}
+	x.lock.Lock()
+	defer x.lock.Unlock()
+	if x.fetched {
+		return x.state, nil
+	}
+
+	conn := x.MqlRuntime.Connection.(shared.Connection)
+
+	x.state.version, x.state.modified = readBundleVersionAndMtime(conn, xprotectBundlePaths)
+	x.state.mrtVersion, x.state.mrtModified = readBundleVersionAndMtime(conn, mrtBundlePaths)
+
+	x.fetched = true
+	return x.state, nil
+}
+
+func (x *mqlMacosXprotect) version() (string, error) {
+	s, err := x.fetchState()
+	return s.version, err
+}
+
+func (x *mqlMacosXprotect) modified() (*time.Time, error) {
+	s, err := x.fetchState()
+	return s.modified, err
+}
+
+func (x *mqlMacosXprotect) mrtVersion() (string, error) {
+	s, err := x.fetchState()
+	return s.mrtVersion, err
+}
+
+func (x *mqlMacosXprotect) mrtModified() (*time.Time, error) {
+	s, err := x.fetchState()
+	return s.mrtModified, err
+}
+
+// readBundleVersionAndMtime walks `bundlePaths` looking for the first
+// extant bundle, reads `Contents/Info.plist` for the version, and
+// returns the bundle's filesystem modification time. Missing bundles
+// (XProtect not installed on a non-Darwin host; MRT retired on macOS
+// 13+) return ("", nil) so callers can surface MQL null.
+func readBundleVersionAndMtime(conn shared.Connection, bundlePaths []string) (string, *time.Time) {
+	fs := conn.FileSystem()
+	for _, bundle := range bundlePaths {
+		info, err := fs.Stat(bundle)
+		if err != nil {
+			continue
+		}
+		mtime := info.ModTime()
+		version := readBundleVersion(conn, bundle+"/Contents/Info.plist")
+		return version, &mtime
+	}
+	return "", nil
+}
+
+// readBundleVersion reads CFBundleShortVersionString from an
+// Info.plist file. Missing file, unreadable plist, or absent key all
+// surface as an empty string — the bundle existed (the caller already
+// stat'd it) but its metadata is unreadable, which is unusual but
+// shouldn't crash the audit.
+func readBundleVersion(conn shared.Connection, infoPlistPath string) string {
+	f, err := conn.FileSystem().Open(infoPlistPath)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	data, err := plist.Decode(f)
+	if err != nil {
+		return ""
+	}
+	if v, ok := data["CFBundleShortVersionString"].(string); ok {
+		return v
+	}
+	return ""
+}

--- a/providers/os/resources/macos_xprotect_test.go
+++ b/providers/os/resources/macos_xprotect_test.go
@@ -1,0 +1,111 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.mondoo.com/mql/v13/providers/os/resources/plist"
+)
+
+// readBundleVersion delegates plist parsing to the helper in
+// providers/os/resources/plist; the tests below drive that helper
+// directly with the same XML shapes Apple emits in real Info.plist
+// files so we exercise the version-extraction logic without needing
+// a live macOS host.
+
+const xprotectInfoPlist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.apple.XProtect</string>
+    <key>CFBundleShortVersionString</key>
+    <string>2186</string>
+    <key>CFBundleVersion</key>
+    <string>2186</string>
+</dict>
+</plist>
+`
+
+func TestPlistDecode_ExtractsCFBundleShortVersionString(t *testing.T) {
+	data, err := plist.Decode(bytes.NewReader([]byte(xprotectInfoPlist)))
+	require.NoError(t, err)
+
+	v, ok := data["CFBundleShortVersionString"].(string)
+	require.True(t, ok, "CFBundleShortVersionString must decode as string")
+	assert.Equal(t, "2186", v)
+}
+
+func TestPlistDecode_MissingKeyTreatedAsAbsent(t *testing.T) {
+	// A bundle Info.plist without CFBundleShortVersionString — rare
+	// but possible for malformed/stub bundles. The reader must return
+	// an empty string, not crash.
+	const noVersion = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.apple.XProtect</string>
+</dict>
+</plist>
+`
+	data, err := plist.Decode(bytes.NewReader([]byte(noVersion)))
+	require.NoError(t, err)
+
+	v, _ := data["CFBundleShortVersionString"].(string)
+	assert.Equal(t, "", v, "missing key yields empty string")
+}
+
+func TestPlistDecode_WrongTypeForVersionTreatedAsAbsent(t *testing.T) {
+	// Defensive: if CFBundleShortVersionString is somehow an int
+	// (couldn't happen in a real Apple-shipped plist, but the
+	// extractor uses a type assertion), the result is "" rather
+	// than a panic.
+	const intVersion = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleShortVersionString</key>
+    <integer>2186</integer>
+</dict>
+</plist>
+`
+	data, err := plist.Decode(bytes.NewReader([]byte(intVersion)))
+	require.NoError(t, err)
+
+	_, ok := data["CFBundleShortVersionString"].(string)
+	assert.False(t, ok, "non-string typed value must not satisfy string assertion")
+}
+
+// Path lists are tiny, but assert their order anyway so changes are
+// visible — XProtect/MRT paths moved between macOS versions and
+// keeping the preferred (newer) path first matters for correctness on
+// hosts that have both legacy and modern locations.
+
+func TestXprotectBundlePaths_OrderingAndContents(t *testing.T) {
+	require.Len(t, xprotectBundlePaths, 2)
+	assert.Equal(t,
+		"/Library/Apple/System/Library/CoreServices/XProtect.bundle",
+		xprotectBundlePaths[0],
+		"modern path must be probed first")
+	assert.Equal(t,
+		"/System/Library/CoreServices/XProtect.bundle",
+		xprotectBundlePaths[1],
+		"legacy path is the fallback")
+}
+
+func TestMrtBundlePaths_OrderingAndContents(t *testing.T) {
+	require.Len(t, mrtBundlePaths, 2)
+	assert.Equal(t,
+		"/Library/Apple/System/Library/CoreServices/MRT.app",
+		mrtBundlePaths[0])
+	assert.Equal(t,
+		"/System/Library/CoreServices/MRT.app",
+		mrtBundlePaths[1])
+}

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -3956,16 +3956,16 @@ macos.sip @defaults("enabled status") {
 // XProtectRemediator.
 macos.xprotect @defaults("version modified") {
   // XProtect bundle version (CFBundleShortVersionString)
-  version string
+  version() string
   // Last modification time of the XProtect bundle
-  modified time
+  modified() time
   // MRT (Malware Removal Tool) bundle version
   //
   // Empty string when MRT.app is not installed (it was sunset in
   // macOS 13; its work is now performed by XProtectRemediator).
-  mrtVersion string
+  mrtVersion() string
   // Last modification time of MRT.app, null when MRT is not installed
-  mrtModified time
+  mrtModified() time
 }
 
 // macOS Time Machine backup configuration

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -3940,6 +3940,34 @@ macos.sip @defaults("enabled status") {
   status() string
 }
 
+// macOS XProtect anti-malware bundle
+//
+// Examine the version and last-modified timestamp of the XProtect
+// signature bundle (and, when present, the legacy Malware Removal
+// Tool). CIS macOS benchmarks expect XProtect signatures to be
+// current; checking `modified` against the auditor's freshness
+// threshold catches devices that have stopped receiving updates.
+//
+// XProtect.bundle lives at
+// `/Library/Apple/System/Library/CoreServices/XProtect.bundle` on
+// modern macOS (with `/System/Library/CoreServices/XProtect.bundle`
+// as the legacy fallback). `mrtVersion` and `mrtModified` are empty
+// or null on macOS 13+ where MRT has been retired in favor of
+// XProtectRemediator.
+macos.xprotect @defaults("version modified") {
+  // XProtect bundle version (CFBundleShortVersionString)
+  version string
+  // Last modification time of the XProtect bundle
+  modified time
+  // MRT (Malware Removal Tool) bundle version
+  //
+  // Empty string when MRT.app is not installed (it was sunset in
+  // macOS 13; its work is now performed by XProtectRemediator).
+  mrtVersion string
+  // Last modification time of MRT.app, null when MRT is not installed
+  mrtModified time
+}
+
 // macOS Time Machine backup configuration
 //
 // Examine destinations, schedule, and exclusion preferences

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -35146,19 +35146,27 @@ func (c *mqlMacosXprotect) MqlID() string {
 }
 
 func (c *mqlMacosXprotect) GetVersion() *plugin.TValue[string] {
-	return &c.Version
+	return plugin.GetOrCompute[string](&c.Version, func() (string, error) {
+		return c.version()
+	})
 }
 
 func (c *mqlMacosXprotect) GetModified() *plugin.TValue[*time.Time] {
-	return &c.Modified
+	return plugin.GetOrCompute[*time.Time](&c.Modified, func() (*time.Time, error) {
+		return c.modified()
+	})
 }
 
 func (c *mqlMacosXprotect) GetMrtVersion() *plugin.TValue[string] {
-	return &c.MrtVersion
+	return plugin.GetOrCompute[string](&c.MrtVersion, func() (string, error) {
+		return c.mrtVersion()
+	})
 }
 
 func (c *mqlMacosXprotect) GetMrtModified() *plugin.TValue[*time.Time] {
-	return &c.MrtModified
+	return plugin.GetOrCompute[*time.Time](&c.MrtModified, func() (*time.Time, error) {
+		return c.mrtModified()
+	})
 }
 
 // mqlMacosTimemachine for the macos.timemachine resource

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -242,6 +242,7 @@ const (
 	ResourceMacosFilevault               string = "macos.filevault"
 	ResourceMacosGatekeeper              string = "macos.gatekeeper"
 	ResourceMacosSip                     string = "macos.sip"
+	ResourceMacosXprotect                string = "macos.xprotect"
 	ResourceMacosTimemachine             string = "macos.timemachine"
 	ResourceMacosSystemsetup             string = "macos.systemsetup"
 	ResourceOpenBSMAudit                 string = "openBSMAudit"
@@ -1263,6 +1264,10 @@ func init() {
 		"macos.sip": {
 			// to override args, implement: initMacosSip(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMacosSip,
+		},
+		"macos.xprotect": {
+			// to override args, implement: initMacosXprotect(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createMacosXprotect,
 		},
 		"macos.timemachine": {
 			// to override args, implement: initMacosTimemachine(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -5247,6 +5252,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"macos.sip.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMacosSip).GetStatus()).ToDataRes(types.String)
+	},
+	"macos.xprotect.version": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosXprotect).GetVersion()).ToDataRes(types.String)
+	},
+	"macos.xprotect.modified": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosXprotect).GetModified()).ToDataRes(types.Time)
+	},
+	"macos.xprotect.mrtVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosXprotect).GetMrtVersion()).ToDataRes(types.String)
+	},
+	"macos.xprotect.mrtModified": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosXprotect).GetMrtModified()).ToDataRes(types.Time)
 	},
 	"macos.timemachine.preferences": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMacosTimemachine).GetPreferences()).ToDataRes(types.Dict)
@@ -12798,6 +12815,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"macos.sip.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMacosSip).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"macos.xprotect.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosXprotect).__id, ok = v.Value.(string)
+		return
+	},
+	"macos.xprotect.version": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosXprotect).Version, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"macos.xprotect.modified": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosXprotect).Modified, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"macos.xprotect.mrtVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosXprotect).MrtVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"macos.xprotect.mrtModified": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosXprotect).MrtModified, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"macos.timemachine.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -35058,6 +35095,70 @@ func (c *mqlMacosSip) GetStatus() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Status, func() (string, error) {
 		return c.status()
 	})
+}
+
+// mqlMacosXprotect for the macos.xprotect resource
+type mqlMacosXprotect struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlMacosXprotectInternal
+	Version     plugin.TValue[string]
+	Modified    plugin.TValue[*time.Time]
+	MrtVersion  plugin.TValue[string]
+	MrtModified plugin.TValue[*time.Time]
+}
+
+// createMacosXprotect creates a new instance of this resource
+func createMacosXprotect(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMacosXprotect{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("macos.xprotect", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMacosXprotect) MqlName() string {
+	return "macos.xprotect"
+}
+
+func (c *mqlMacosXprotect) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMacosXprotect) GetVersion() *plugin.TValue[string] {
+	return &c.Version
+}
+
+func (c *mqlMacosXprotect) GetModified() *plugin.TValue[*time.Time] {
+	return &c.Modified
+}
+
+func (c *mqlMacosXprotect) GetMrtVersion() *plugin.TValue[string] {
+	return &c.MrtVersion
+}
+
+func (c *mqlMacosXprotect) GetMrtModified() *plugin.TValue[*time.Time] {
+	return &c.MrtModified
 }
 
 // mqlMacosTimemachine for the macos.timemachine resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -1087,6 +1087,11 @@ macos.timemachine 9.0.1
 macos.timemachine.preferences 9.0.1
 macos.userHostPreferences 9.0.1
 macos.userPreferences 9.0.1
+macos.xprotect 13.16.10
+macos.xprotect.modified 13.16.10
+macos.xprotect.mrtModified 13.16.10
+macos.xprotect.mrtVersion 13.16.10
+macos.xprotect.version 13.16.10
 mdadm 13.1.2
 mdadm.array 13.1.2
 mdadm.array.activeDevices 13.1.2


### PR DESCRIPTION
## Summary

Adds `macos.xprotect` so auditors can verify XProtect anti-malware signatures are current. CIS macOS benchmarks check this on every framework — comparing `modified` against an auditor-defined freshness threshold (e.g. `< 14 days`) catches devices that have stopped receiving Apple's silent definition updates.

### Schema

```
macos.xprotect {
  version      string  // XProtect bundle CFBundleShortVersionString
  modified     time    // bundle filesystem mtime
  mrtVersion   string  // MRT.app CFBundleShortVersionString (empty on macOS 13+)
  mrtModified  time    // MRT.app mtime, null on macOS 13+
}
```

### Audit queries it unlocks

```mql
# XProtect updated within the last 14 days
macos.xprotect.modified > time.now - time.day * 14

# Minimum required signature version
macos.xprotect.version >= "2186"

# Modern macOS where MRT has been retired
macos.xprotect.mrtVersion == ""
```

### Implementation notes

- Probes `/Library/Apple/System/Library/CoreServices/` first (modern macOS) with `/System/Library/CoreServices/` as the legacy fallback. The newer path took over with the Catalina-era split-system-volume change.
- Version comes from `Contents/Info.plist`'s `CFBundleShortVersionString`; modification time comes from the bundle directory's filesystem mtime via the connection's `FileSystem().Stat()` — same pattern `macos.alf` uses, so SSH and container connections work the same as local.
- `mrtVersion` and `mrtModified` return `""` / `nil` when MRT.app isn't installed (macOS 13+ retired it in favor of XProtectRemediator) — fail-soft for that case so audits don't break on modern machines.
- Stat / parse errors fall through to the zero values rather than failing the whole query — XProtect simply not being present (e.g. on non-Darwin hosts) is the expected non-match case.

## Test plan

- [x] `go test -run "TestPlistDecode_|TestXprotectBundlePaths|TestMrtBundlePaths" ./providers/os/resources` — 5 tests pass
  - plist key extraction with a real-shape `Info.plist` (verifies `CFBundleShortVersionString == "2186"`)
  - missing key handled (empty string, no panic)
  - wrong-type value defensively rejected
  - bundle path lists in correct probe order (modern first, legacy fallback)
- [x] `go build ./providers/os/...` clean
- [x] `go vet ./providers/os/resources/` clean
- [x] `make providers/build/os` succeeds; generated `os.lr.go` includes the resource
- [ ] Interactive verification on a Mac: `mql shell <mac>` then `macos.xprotect { version modified mrtVersion mrtModified }`

---
_Generated by [Claude Code](https://claude.ai/code/session_01TACYfrt69YXJWScQbJbvUf)_