### PR TITLE
🐛 improve (shadowed) resource errors

### DIFF
--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -960,7 +960,7 @@ func (c *compiler) compileBoundIdentifierWithMqlCtx(id string, binding *variable
 			c.Stats.CallField(resource.Name, fieldinfo)
 
 			if call != nil && len(call.Function) > 0 && !fieldinfo.IsImplicitResource {
-				return true, types.Nil, errors.New("cannot call resource field with arguments yet")
+				return true, types.Nil, errors.New("cannot call field '" + resource.Name + "." + id + "' with arguments yet (it is a field, not a resource)")
 			}
 
 			// this only happens when we call a field of a bridging resource,


### PR DESCRIPTION
I ran into this trying to call the shadowed `command` resource inside of a block call. Within this map of process resources, `command` maps to `process.command` instead of the global `command`. Thing is: I didn't know that and the error was not helpful. Now the error at least becomes informative.