### PR TITLE
✨ os/kernel.module: expose blacklisted, installBypass, and disabled for CIS audits

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -316,6 +316,7 @@ horizontalpodautoscaler
 hostedzone
 hostkeyalgorithms
 hostpci
+hotplug
 hpi
 hsts
 httproute

--- a/providers/os/resources/kernel.go
+++ b/providers/os/resources/kernel.go
@@ -33,6 +33,13 @@ func initKernel(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[stri
 type mqlKernelInternal struct {
 	moduleByName map[string]*mqlKernelModule
 	lock         sync.Mutex
+
+	// modprobe-rule cache. Populated lazily on first access via
+	// loadModprobeRules so the modprobe.d walk happens once per query
+	// regardless of how many kernel.module accessors consult it.
+	modprobeOnce  sync.Once
+	modprobeRules map[string]modprobeRule
+	modprobeErr   error
 }
 
 type KernelVersion struct {

--- a/providers/os/resources/kernel_internal_test.go
+++ b/providers/os/resources/kernel_internal_test.go
@@ -9,6 +9,156 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestParseModprobeConfig locks down the modprobe.d parser used by the
+// kernel.module {blacklisted, installBypass, disabled} accessors. The
+// shapes here are taken from CIS Linux benchmarks (cramfs, usb-storage,
+// freevxfs, jffs2, hfs) and from the in-the-wild quirks the parser has
+// to tolerate — `exec /bin/false`, leading whitespace, comments mid-line,
+// and unrelated directives (alias, options, softdep) that must be ignored
+// without poisoning a sibling module's rule.
+func TestParseModprobeConfig(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    map[string]modprobeRule
+	}{
+		{
+			name:    "simple blacklist",
+			content: "blacklist cramfs\n",
+			want: map[string]modprobeRule{
+				"cramfs": {blacklisted: true},
+			},
+		},
+		{
+			name:    "install short-circuit to /bin/true",
+			content: "install usb-storage /bin/true\n",
+			want: map[string]modprobeRule{
+				"usb-storage": {installBypass: true},
+			},
+		},
+		{
+			name:    "install short-circuit to /bin/false",
+			content: "install usb-storage /bin/false\n",
+			want: map[string]modprobeRule{
+				"usb-storage": {installBypass: true},
+			},
+		},
+		{
+			name:    "install via exec wrapper to /bin/false",
+			content: "install usb-storage exec /bin/false\n",
+			want: map[string]modprobeRule{
+				"usb-storage": {installBypass: true},
+			},
+		},
+		{
+			name:    "install to real modprobe is not a bypass",
+			content: "install usb-storage /sbin/modprobe usb-storage-real\n",
+			want:    map[string]modprobeRule{},
+		},
+		{
+			name: "comments and blank lines are ignored",
+			content: `# CIS Linux Benchmark 1.1.1.1
+# Disable mounting of cramfs
+blacklist cramfs
+
+# Disable mounting of freevxfs
+
+blacklist freevxfs   # trailing comment
+`,
+			want: map[string]modprobeRule{
+				"cramfs":   {blacklisted: true},
+				"freevxfs": {blacklisted: true},
+			},
+		},
+		{
+			name: "multiple modules combine across lines",
+			content: `blacklist cramfs
+install usb-storage /bin/false
+blacklist freevxfs
+install jffs2 /bin/true
+`,
+			want: map[string]modprobeRule{
+				"cramfs":      {blacklisted: true},
+				"usb-storage": {installBypass: true},
+				"freevxfs":    {blacklisted: true},
+				"jffs2":       {installBypass: true},
+			},
+		},
+		{
+			name: "same module blacklisted and install-bypassed unions both flags",
+			content: `blacklist usb-storage
+install usb-storage /bin/false
+`,
+			want: map[string]modprobeRule{
+				"usb-storage": {blacklisted: true, installBypass: true},
+			},
+		},
+		{
+			name:    "leading whitespace, tabs, and mixed indentation tolerated",
+			content: "  blacklist cramfs\n\tinstall usb-storage\t/bin/false\n  \t blacklist  freevxfs \n",
+			want: map[string]modprobeRule{
+				"cramfs":      {blacklisted: true},
+				"usb-storage": {installBypass: true},
+				"freevxfs":    {blacklisted: true},
+			},
+		},
+		{
+			name: "alias / options / softdep / remove are ignored",
+			content: `alias net-pf-10 ipv6
+options ipv6 disable=1
+softdep nf_conntrack pre: nf_defrag_ipv4
+remove fuse /sbin/modprobe -r fuse
+blacklist cramfs
+`,
+			want: map[string]modprobeRule{
+				"cramfs": {blacklisted: true},
+			},
+		},
+		{
+			name:    "blacklist without a module name is dropped",
+			content: "blacklist\n",
+			want:    map[string]modprobeRule{},
+		},
+		{
+			name:    "install without a command is dropped",
+			content: "install usb-storage\n",
+			want:    map[string]modprobeRule{},
+		},
+		{
+			name:    "empty content yields empty map",
+			content: "",
+			want:    map[string]modprobeRule{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseModprobeConfig(tc.content)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestStripModprobeComment guards the modprobe-flavoured comment stripper
+// against drift toward rsyslog's quote-aware shape — modprobe has no
+// string literals, so `#` always introduces a comment.
+func TestStripModprobeComment(t *testing.T) {
+	cases := []struct {
+		in  string
+		out string
+	}{
+		{"blacklist cramfs", "blacklist cramfs"},
+		{"blacklist cramfs # comment", "blacklist cramfs "},
+		{"# entire line is a comment", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, tc.out, stripModprobeComment(tc.in))
+		})
+	}
+}
+
 // TestRpmKernelMatchesRunning is the unit-level reproducer for
 // customer-issues #178: AL2023's `kernel` rpm carries epoch 1, so
 // pkg.Version is "1:6.1.170-210.320.amzn2023" while /proc/version returns

--- a/providers/os/resources/kernel_modprobe.go
+++ b/providers/os/resources/kernel_modprobe.go
@@ -1,0 +1,248 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"strings"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/resources"
+)
+
+// modprobeRule captures the "module must not load" intent expressed by a
+// modprobe configuration file. It is the union of every directive observed
+// across every config path — i.e. if any file blacklists the module the
+// rule is blacklisted, and if any install rule short-circuits to
+// /bin/true or /bin/false the rule has installBypass set.
+type modprobeRule struct {
+	blacklisted   bool
+	installBypass bool
+}
+
+// modprobeSearchPaths is the search order used by libkmod when resolving
+// modprobe.d configuration. The first path that contains a given file name
+// wins for that file name, but for our union-of-intent semantics we just
+// walk every path that exists. Order is documented in modprobe.d(5).
+var modprobeSearchPaths = []string{
+	"/etc/modprobe.d",
+	"/run/modprobe.d",
+	"/usr/lib/modprobe.d",
+	"/lib/modprobe.d",
+}
+
+// installBypassBins are the executable paths whose presence as the command
+// of an `install <mod> ...` line means the load is short-circuited rather
+// than actually invoking modprobe / insmod. Both /bin/true and /bin/false
+// appear in CIS guidance and in the wild — admins use them interchangeably
+// (false is more semantically honest because it reports an error, true is
+// silent).
+var installBypassBins = map[string]bool{
+	"/bin/true":  true,
+	"/bin/false": true,
+}
+
+// parseModprobeConfig parses a single modprobe configuration blob and
+// returns the per-module rules it declares. Lines are interpreted per
+// modprobe.d(5):
+//
+//   - `#` introduces a comment to end-of-line.
+//   - `blacklist <name>` marks <name> as blacklisted.
+//   - `install <name> <cmd>...` records installBypass when <cmd> resolves
+//     to /bin/true or /bin/false. A leading `exec` is stripped because
+//     modprobe accepts `install foo exec /bin/false` and treats it the
+//     same as `install foo /bin/false`.
+//   - alias, options, softdep, remove and anything else are ignored — they
+//     don't express "must not load" intent.
+//
+// The same module can appear in multiple files; the returned rule is the
+// per-field OR across every occurrence.
+func parseModprobeConfig(content string) map[string]modprobeRule {
+	out := map[string]modprobeRule{}
+
+	for _, raw := range strings.Split(content, "\n") {
+		line := stripModprobeComment(raw)
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		switch fields[0] {
+		case "blacklist":
+			name := fields[1]
+			rule := out[name]
+			rule.blacklisted = true
+			out[name] = rule
+		case "install":
+			if len(fields) < 3 {
+				continue
+			}
+			name := fields[1]
+			// modprobe accepts an optional leading `exec` before the
+			// command — `install foo exec /bin/false` is equivalent to
+			// `install foo /bin/false`. Strip it so the bypass check
+			// always inspects the actual binary path.
+			cmd := fields[2]
+			if cmd == "exec" && len(fields) >= 4 {
+				cmd = fields[3]
+			}
+			if installBypassBins[cmd] {
+				rule := out[name]
+				rule.installBypass = true
+				out[name] = rule
+			}
+		}
+	}
+
+	return out
+}
+
+// stripModprobeComment removes everything from the first `#` to end-of-line.
+// modprobe's parser treats `#` as a comment introducer anywhere on a line
+// (there is no quoting in modprobe.d syntax).
+func stripModprobeComment(line string) string {
+	if i := strings.IndexByte(line, '#'); i >= 0 {
+		return line[:i]
+	}
+	return line
+}
+
+// loadModprobeRules walks modprobeSearchPaths for *.conf files, parses each,
+// and stores the merged per-module rule set on the kernel resource. Missing
+// directories are best-effort — they're a normal state on stripped-down
+// container images and stock minimal installs, and absent files just
+// contribute zero rules.
+//
+// Uses sync.Once with an explicit error capture so all three accessors
+// (blacklisted, installBypass, disabled) share a single walk per query.
+func (k *mqlKernel) loadModprobeRules() (map[string]modprobeRule, error) {
+	k.modprobeOnce.Do(func() {
+		rules := map[string]modprobeRule{}
+
+		for _, dir := range modprobeSearchPaths {
+			files, err := k.modprobeFilesIn(dir)
+			if err != nil {
+				// Treat any per-directory failure as "directory absent"
+				// for our purposes — modprobe itself silently ignores
+				// missing search paths.
+				continue
+			}
+
+			for _, f := range files {
+				mf, ok := f.(*mqlFile)
+				if !ok {
+					continue
+				}
+				path := mf.Path.Data
+				if !strings.HasSuffix(path, ".conf") {
+					continue
+				}
+
+				content := mf.GetContent()
+				if content.Error != nil {
+					if errors.Is(content.Error, resources.NotFoundError{}) {
+						continue
+					}
+					// Permission / IO errors on a single file shouldn't
+					// abort the whole walk — surface what we can.
+					continue
+				}
+
+				for name, rule := range parseModprobeConfig(content.Data) {
+					merged := rules[name]
+					if rule.blacklisted {
+						merged.blacklisted = true
+					}
+					if rule.installBypass {
+						merged.installBypass = true
+					}
+					rules[name] = merged
+				}
+			}
+		}
+
+		k.modprobeRules = rules
+	})
+
+	return k.modprobeRules, k.modprobeErr
+}
+
+// modprobeFilesIn lists every regular file in dir using files.find. The
+// directory's presence is checked up front so missing search paths are
+// silently skipped rather than producing a noisy error from files.find.
+func (k *mqlKernel) modprobeFilesIn(dir string) ([]any, error) {
+	dirFile, err := CreateResource(k.MqlRuntime, "file", map[string]*llx.RawData{
+		"path": llx.StringData(dir),
+	})
+	if err != nil {
+		return nil, err
+	}
+	exists := dirFile.(*mqlFile).GetExists()
+	if exists.Error != nil {
+		return nil, exists.Error
+	}
+	if !exists.Data {
+		return nil, nil
+	}
+
+	files, err := CreateResource(k.MqlRuntime, "files.find", map[string]*llx.RawData{
+		"from": llx.StringData(dir),
+		"type": llx.StringData("file"),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	list := files.(*mqlFilesFind).GetList()
+	if list.Error != nil {
+		return nil, list.Error
+	}
+	return list.Data, nil
+}
+
+// moduleRule resolves the parent kernel resource, triggers a one-shot
+// modprobe walk, and returns the rule for this module's name. A module
+// with no matching rule yields a zero-value modprobeRule (both fields
+// false), which is exactly what the accessors want.
+func (m *mqlKernelModule) moduleRule() (modprobeRule, error) {
+	obj, err := CreateResource(m.MqlRuntime, "kernel", map[string]*llx.RawData{})
+	if err != nil {
+		return modprobeRule{}, err
+	}
+	kernel := obj.(*mqlKernel)
+	rules, err := kernel.loadModprobeRules()
+	if err != nil {
+		return modprobeRule{}, err
+	}
+	return rules[m.Name.Data], nil
+}
+
+func (m *mqlKernelModule) blacklisted() (bool, error) {
+	rule, err := m.moduleRule()
+	if err != nil {
+		return false, err
+	}
+	return rule.blacklisted, nil
+}
+
+func (m *mqlKernelModule) installBypass() (bool, error) {
+	rule, err := m.moduleRule()
+	if err != nil {
+		return false, err
+	}
+	return rule.installBypass, nil
+}
+
+func (m *mqlKernelModule) disabled() (bool, error) {
+	rule, err := m.moduleRule()
+	if err != nil {
+		return false, err
+	}
+	return rule.blacklisted || rule.installBypass, nil
+}

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -1522,6 +1522,9 @@ kernel @defaults("info") {
 // whether it is currently `loaded`. Initialize by name (e.g.,
 // `kernel.module(name: "nf_conntrack")`) to check a specific module,
 // or iterate from `kernel.modules()` to audit the full loaded-module list.
+// Use `blacklisted`, `installBypass`, and `disabled` to express CIS-style
+// "module must not load" controls without falling back to raw modprobe.d
+// file parsing.
 kernel.module @defaults("name loaded") {
   init(name string)
 
@@ -1531,6 +1534,28 @@ kernel.module @defaults("name loaded") {
   size string
   // Whether the module is loaded
   loaded bool
+  // Whether the module is blacklisted in modprobe configuration
+  //
+  // True when any modprobe configuration file declares `blacklist <name>`.
+  // Blacklisted modules will not auto-load (e.g., from udev or hotplug
+  // events) but root can still force-load them with `modprobe --force`
+  // or by writing to `/sys/module/...`. CIS macOS/Linux benchmarks check
+  // for this to ensure unused filesystems/protocols stay off.
+  blacklisted() bool
+  // Whether the module's load is short-circuited to /bin/true or /bin/false
+  //
+  // True when any modprobe configuration file declares
+  // `install <name> /bin/false` (or `/bin/true`). This is stronger than
+  // blacklisting: even an explicit `modprobe <name>` is replaced with
+  // the no-op binary, so the module cannot be loaded without overriding
+  // the install rule.
+  installBypass() bool
+  // Whether the module is effectively disabled
+  //
+  // True when the module is either blacklisted or has an install
+  // short-circuit rule. Use this as the canonical "module will not load
+  // without explicit override" predicate.
+  disabled() bool
 }
 
 // Linux kernel boot command line

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -3148,6 +3148,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"kernel.module.loaded": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlKernelModule).GetLoaded()).ToDataRes(types.Bool)
 	},
+	"kernel.module.blacklisted": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlKernelModule).GetBlacklisted()).ToDataRes(types.Bool)
+	},
+	"kernel.module.installBypass": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlKernelModule).GetInstallBypass()).ToDataRes(types.Bool)
+	},
+	"kernel.module.disabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlKernelModule).GetDisabled()).ToDataRes(types.Bool)
+	},
 	"kernel.cmdline.raw": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlKernelCmdline).GetRaw()).ToDataRes(types.String)
 	},
@@ -9712,6 +9721,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"kernel.module.loaded": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlKernelModule).Loaded, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"kernel.module.blacklisted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlKernelModule).Blacklisted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"kernel.module.installBypass": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlKernelModule).InstallBypass, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"kernel.module.disabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlKernelModule).Disabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"kernel.cmdline.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -23994,9 +24015,12 @@ type mqlKernelModule struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlKernelModuleInternal it will be used here
-	Name   plugin.TValue[string]
-	Size   plugin.TValue[string]
-	Loaded plugin.TValue[bool]
+	Name          plugin.TValue[string]
+	Size          plugin.TValue[string]
+	Loaded        plugin.TValue[bool]
+	Blacklisted   plugin.TValue[bool]
+	InstallBypass plugin.TValue[bool]
+	Disabled      plugin.TValue[bool]
 }
 
 // createKernelModule creates a new instance of this resource
@@ -24046,6 +24070,24 @@ func (c *mqlKernelModule) GetSize() *plugin.TValue[string] {
 
 func (c *mqlKernelModule) GetLoaded() *plugin.TValue[bool] {
 	return &c.Loaded
+}
+
+func (c *mqlKernelModule) GetBlacklisted() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Blacklisted, func() (bool, error) {
+		return c.blacklisted()
+	})
+}
+
+func (c *mqlKernelModule) GetInstallBypass() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.InstallBypass, func() (bool, error) {
+		return c.installBypass()
+	})
+}
+
+func (c *mqlKernelModule) GetDisabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.Disabled, func() (bool, error) {
+		return c.disabled()
+	})
 }
 
 // mqlKernelCmdline for the kernel.cmdline resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -891,6 +891,9 @@ kernel.lockdown 13.16.10
 kernel.lockdown.enabled 13.16.10
 kernel.lockdown.mode 13.16.10
 kernel.module 9.0.0
+kernel.module.blacklisted 13.16.10
+kernel.module.disabled 13.16.10
+kernel.module.installBypass 13.16.10
 kernel.module.loaded 9.0.0
 kernel.module.name 9.0.0
 kernel.module.size 9.0.0


### PR DESCRIPTION
## Summary

Adds three computed booleans to `kernel.module` so CIS-style "must not load" controls can be expressed natively — replacing the regex-over-`command` patterns auditors had to write against `/bin/(true|false)`.

- `blacklisted` — true when any modprobe.d file declares `blacklist <name>`. Stops auto-load (udev/hotplug), but root can still `modprobe --force`.
- `installBypass` — true when any modprobe.d file declares `install <name> /bin/true` (or `/bin/false`, optionally via `exec`). Stronger than blacklisting: even an explicit `modprobe <name>` is replaced by the no-op binary.
- `disabled` — canonical "module will not load without explicit override" predicate; equals `blacklisted || installBypass`.

Audits can now say:

```mql
kernel.module("cramfs").disabled
kernel.module("usb-storage").installBypass && kernel.module("usb-storage").loaded == false
```

## Implementation notes

- Walks the libkmod search order — `/etc/modprobe.d`, `/run/modprobe.d`, `/usr/lib/modprobe.d`, `/lib/modprobe.d` — for `*.conf` files. Missing directories are silently ignored, matching modprobe's own behaviour and keeping things working on minimal container images.
- The walked-rule set is cached on the parent `kernel` resource via `sync.Once`, so all three accessors share a single pass regardless of how many modules are queried.
- Parser is a pure `parseModprobeConfig(string) map[string]modprobeRule` so it's unit-testable without provider mocks.
- Schema-only version bump for the three new fields in `os.lr.versions` (`13.16.10`); no provider `Version` change.

## Test plan

- [x] `go test ./providers/os/resources/ -run "TestParseModprobeConfig|TestStripModprobeComment|TestResource_KernelModules" -count=1` — all pass
- [x] `make providers/build/os` — clean build
- [x] `go vet ./providers/os/resources/...` — clean
- [ ] Integration test against `LinuxMock` (`arch.json` + `files.find` recording) intentionally deferred — non-trivial to extend the fixture and out of scope for this change.
- [ ] Smoke against a real Linux host: `mql shell <host>` then `kernel.module("cramfs").{blacklisted, installBypass, disabled}` on a CIS-hardened image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)