### PR TITLE
✨ os/pam.module: typed per-module view with aggregated params for CIS audits

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -48,6 +48,7 @@ atapi
 atlassian
 auditlog
 Auths
+authtok
 autoaccept
 autoclass
 autoclose
@@ -234,6 +235,7 @@ EXACC
 exadata
 exo
 faa
+faillock
 fargate
 fastcgi
 favourited
@@ -607,6 +609,7 @@ PVCs
 pve
 PVEAPI
 pveproxy
+pwquality
 pyspark
 pythonshell
 pytorch

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -1591,16 +1591,25 @@ func TestCompiler_ResourceFieldGlob(t *testing.T) {
 			Type:    string(types.Array(types.Resource("file"))),
 			Binding: (2 << 32) | 1,
 		}, res.CodeV2.Blocks[1].Chunks[3])
+		assertFunction(t, "modules", &llx.Function{
+			Type:    string(types.Array(types.Resource("pam.module"))),
+			Binding: (2 << 32) | 1,
+		}, res.CodeV2.Blocks[1].Chunks[4])
 		assertFunction(t, "services", &llx.Function{
 			Type:    string(types.Map(types.String, types.Array(types.String))),
 			Binding: (2 << 32) | 1,
-		}, res.CodeV2.Blocks[1].Chunks[4])
+		}, res.CodeV2.Blocks[1].Chunks[5])
 		assertFunction(t, "{}", &llx.Function{
 			Type:    string(types.Array(types.Block)),
 			Binding: (2 << 32) | 4,
 			Args:    []*llx.Primitive{llx.FunctionPrimitive(3 << 32)},
-		}, res.CodeV2.Blocks[1].Chunks[5])
-		assert.Equal(t, []uint64{(2 << 32) | 2, (2 << 32) | 3, (2 << 32) | 6, (2 << 32) | 5},
+		}, res.CodeV2.Blocks[1].Chunks[6])
+		assertFunction(t, "{}", &llx.Function{
+			Type:    string(types.Array(types.Block)),
+			Binding: (2 << 32) | 5,
+			Args:    []*llx.Primitive{llx.FunctionPrimitive(4 << 32)},
+		}, res.CodeV2.Blocks[1].Chunks[7])
+		assert.Equal(t, []uint64{(2 << 32) | 2, (2 << 32) | 3, (2 << 32) | 7, (2 << 32) | 8, (2 << 32) | 6},
 			res.CodeV2.Blocks[1].Entrypoints)
 	})
 }

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -963,6 +963,8 @@ pam.conf {
   services(files) @maturity("deprecated") map[string][]string
   // List of services with parsed entries that are configured via PAM
   entries(files) map[string][]pam.conf.serviceEntry
+  // All PAM modules loaded across every service (deduplicated by name)
+  modules(entries) []pam.module
 }
 
 // A single entry within a PAM service configuration
@@ -979,6 +981,50 @@ private pam.conf.serviceEntry @defaults("service module") {
   module string
   // Configuration options for pam service entry
   options []string
+}
+
+// PAM module aggregated view
+//
+// Examine a single PAM module across every service that loads it. The
+// `params` dict merges `key=value` options from every line that uses
+// this module (last-write-wins per key) so audits like
+// `pam.module("pam_faillock").params["deny"]` work without iterating
+// `pam.conf.entries`. `enabled` is true when any service entry loads
+// the module with a non-skip control.
+//
+// Initialize by module name (e.g. `pam.module(name: "pam_faillock")`)
+// or iterate `pam.modules()` for every distinct module name seen
+// across the parsed PAM configuration.
+private pam.module @defaults("name enabled entries.length") {
+  init(name string)
+  // Module name as it appears after `<type> <control>`
+  //
+  // Examples: `pam_unix`, `pam_faillock`, `pam_pwquality`. The `.so`
+  // suffix and any leading path are stripped so lookups by short name
+  // work consistently.
+  name string
+  // All key=value options aggregated across every service entry that loads this module
+  //
+  // The same option key appearing on multiple lines is last-write-wins
+  // in source order (matching how PAM itself evaluates duplicate flags
+  // — the later line wins). Bare options (no `=`) are present in the
+  // map with an empty string value so `params["use_authtok"] != null`
+  // works as an existence check.
+  params map[string]string
+  // Whether the module is loaded by any service with a non-skip control
+  //
+  // True when at least one service entry references this module with a
+  // control of `required`, `requisite`, `sufficient`, `optional`, or a
+  // typed control with `default=ok` / `success=ok`. Always false when
+  // every reference is part of a stub or commented-out line.
+  enabled bool
+  // Every service entry that loads this module
+  //
+  // The full list across all `/etc/pam.d/*` files, in source order.
+  // Each entry carries its originating `service`, `lineNumber`,
+  // `pamType`, `control`, and raw `options` so callers can drill back
+  // into the underlying line if `params` aggregation isn't enough.
+  entries []pam.conf.serviceEntry
 }
 
 // OpenSSH server (sshd) namespace

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -68,6 +68,7 @@ const (
 	ResourcePackages                     string = "packages"
 	ResourcePamConf                      string = "pam.conf"
 	ResourcePamConfServiceEntry          string = "pam.conf.serviceEntry"
+	ResourcePamModule                    string = "pam.module"
 	ResourceSshd                         string = "sshd"
 	ResourceSshdConfig                   string = "sshd.config"
 	ResourceSshdConfigMatchBlock         string = "sshd.config.matchBlock"
@@ -585,6 +586,10 @@ func init() {
 		"pam.conf.serviceEntry": {
 			// to override args, implement: initPamConfServiceEntry(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createPamConfServiceEntry,
+		},
+		"pam.module": {
+			Init:   initPamModule,
+			Create: createPamModule,
 		},
 		"sshd": {
 			// to override args, implement: initSshd(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -2605,6 +2610,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"pam.conf.entries": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPamConf).GetEntries()).ToDataRes(types.Map(types.String, types.Array(types.Resource("pam.conf.serviceEntry"))))
 	},
+	"pam.conf.modules": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPamConf).GetModules()).ToDataRes(types.Array(types.Resource("pam.module")))
+	},
 	"pam.conf.serviceEntry.service": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPamConfServiceEntry).GetService()).ToDataRes(types.String)
 	},
@@ -2622,6 +2630,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"pam.conf.serviceEntry.options": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPamConfServiceEntry).GetOptions()).ToDataRes(types.Array(types.String))
+	},
+	"pam.module.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPamModule).GetName()).ToDataRes(types.String)
+	},
+	"pam.module.params": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPamModule).GetParams()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"pam.module.enabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPamModule).GetEnabled()).ToDataRes(types.Bool)
+	},
+	"pam.module.entries": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPamModule).GetEntries()).ToDataRes(types.Array(types.Resource("pam.conf.serviceEntry")))
 	},
 	"sshd.config.file": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlSshdConfig).GetFile()).ToDataRes(types.Resource("file"))
@@ -8858,6 +8878,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlPamConf).Entries, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"pam.conf.modules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPamConf).Modules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"pam.conf.serviceEntry.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlPamConfServiceEntry).__id, ok = v.Value.(string)
 		return
@@ -8884,6 +8908,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"pam.conf.serviceEntry.options": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlPamConfServiceEntry).Options, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"pam.module.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPamModule).__id, ok = v.Value.(string)
+		return
+	},
+	"pam.module.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPamModule).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"pam.module.params": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPamModule).Params, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"pam.module.enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPamModule).Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"pam.module.entries": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPamModule).Entries, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"sshd.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20986,6 +21030,7 @@ type mqlPamConf struct {
 	Content  plugin.TValue[string]
 	Services plugin.TValue[map[string]any]
 	Entries  plugin.TValue[map[string]any]
+	Modules  plugin.TValue[[]any]
 }
 
 // createPamConf creates a new instance of this resource
@@ -21084,6 +21129,27 @@ func (c *mqlPamConf) GetEntries() *plugin.TValue[map[string]any] {
 	})
 }
 
+func (c *mqlPamConf) GetModules() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Modules, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("pam.conf", c.__id, "modules")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		vargEntries := c.GetEntries()
+		if vargEntries.Error != nil {
+			return nil, vargEntries.Error
+		}
+
+		return c.modules(vargEntries.Data)
+	})
+}
+
 // mqlPamConfServiceEntry for the pam.conf.serviceEntry resource
 type mqlPamConfServiceEntry struct {
 	MqlRuntime *plugin.Runtime
@@ -21156,6 +21222,70 @@ func (c *mqlPamConfServiceEntry) GetModule() *plugin.TValue[string] {
 
 func (c *mqlPamConfServiceEntry) GetOptions() *plugin.TValue[[]any] {
 	return &c.Options
+}
+
+// mqlPamModule for the pam.module resource
+type mqlPamModule struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlPamModuleInternal it will be used here
+	Name    plugin.TValue[string]
+	Params  plugin.TValue[map[string]any]
+	Enabled plugin.TValue[bool]
+	Entries plugin.TValue[[]any]
+}
+
+// createPamModule creates a new instance of this resource
+func createPamModule(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlPamModule{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("pam.module", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlPamModule) MqlName() string {
+	return "pam.module"
+}
+
+func (c *mqlPamModule) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlPamModule) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlPamModule) GetParams() *plugin.TValue[map[string]any] {
+	return &c.Params
+}
+
+func (c *mqlPamModule) GetEnabled() *plugin.TValue[bool] {
+	return &c.Enabled
+}
+
+func (c *mqlPamModule) GetEntries() *plugin.TValue[[]any] {
+	return &c.Entries
 }
 
 // mqlSshd for the sshd resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -1583,6 +1583,7 @@ pam.conf 9.0.0
 pam.conf.content 9.0.0
 pam.conf.entries 9.0.0
 pam.conf.files 9.0.0
+pam.conf.modules 13.16.10
 pam.conf.serviceEntry 9.0.0
 pam.conf.serviceEntry.control 9.0.0
 pam.conf.serviceEntry.lineNumber 9.0.0
@@ -1591,6 +1592,11 @@ pam.conf.serviceEntry.options 9.0.0
 pam.conf.serviceEntry.pamType 9.0.0
 pam.conf.serviceEntry.service 9.0.0
 pam.conf.services 9.0.0
+pam.module 13.16.10
+pam.module.enabled 13.16.10
+pam.module.entries 13.16.10
+pam.module.name 13.16.10
+pam.module.params 13.16.10
 parse.certificates 9.0.1
 parse.certificates.content 9.0.1
 parse.certificates.file 9.0.1

--- a/providers/os/resources/pam.go
+++ b/providers/os/resources/pam.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"errors"
 	"io"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -173,6 +174,194 @@ func (s *mqlPamConf) services(files []any) (map[string]any, error) {
 	}
 
 	return services, nil
+}
+
+// canonicalizePamModuleName strips a leading path and `.so` suffix from a PAM
+// module reference so callers can look modules up by short name. Case is
+// preserved — PAM module names are conventionally lowercase, but we don't
+// fold them.
+func canonicalizePamModuleName(name string) string {
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		name = name[idx+1:]
+	}
+	name = strings.TrimSuffix(name, ".so")
+	return name
+}
+
+// aggregatePamParams merges `key=value` options from one or more service
+// entries into a single dict. Bare options without `=` are stored with an
+// empty string value so `params["use_authtok"] != null` works as an
+// existence check. Later occurrences of the same key overwrite earlier
+// ones, matching how PAM itself evaluates duplicate flags.
+func aggregatePamParams(optionLists ...[]any) map[string]any {
+	params := map[string]any{}
+	for _, opts := range optionLists {
+		for _, raw := range opts {
+			token, ok := raw.(string)
+			if !ok {
+				continue
+			}
+			if token == "" {
+				continue
+			}
+			if idx := strings.Index(token, "="); idx >= 0 {
+				key := strings.ToLower(token[:idx])
+				value := token[idx+1:]
+				params[key] = value
+			} else {
+				params[strings.ToLower(token)] = ""
+			}
+		}
+	}
+	return params
+}
+
+// isPamControlEnabled reports whether a PAM control directive counts as
+// "the module is loaded". Bracketed controls that explicitly route the
+// module to ignore/skip don't count.
+func isPamControlEnabled(control string) bool {
+	c := strings.TrimSpace(control)
+	if c == "" {
+		return false
+	}
+	// Bracketed controls: `[default=ignore]` / `[default=skip]` mean the
+	// module is referenced but its result is discarded — treat as not
+	// enabled. Any other bracketed form (e.g. `[success=1 default=bad]`,
+	// `[default=die]`) is a real load.
+	if strings.HasPrefix(c, "[") {
+		lower := strings.ToLower(c)
+		if strings.Contains(lower, "default=ignore") || strings.Contains(lower, "default=skip") {
+			return false
+		}
+		return true
+	}
+	// Bare controls: required, requisite, sufficient, optional,
+	// substack, include — all count as loaded.
+	return true
+}
+
+func initPamModule(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return args, nil, nil
+	}
+	name, ok := nameRaw.Value.(string)
+	if !ok {
+		return nil, nil, errors.New("wrong type for 'name', it must be a string")
+	}
+	name = canonicalizePamModuleName(name)
+
+	conf, err := CreateResource(runtime, "pam.conf", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+	pamConf := conf.(*mqlPamConf)
+
+	modules := pamConf.GetModules()
+	if modules.Error != nil {
+		return nil, nil, modules.Error
+	}
+
+	for _, m := range modules.Data {
+		mod, ok := m.(*mqlPamModule)
+		if !ok {
+			continue
+		}
+		if mod.Name.Data == name {
+			return nil, mod, nil
+		}
+	}
+
+	// Module is not referenced by any service — return an empty husk.
+	res, err := CreateResource(runtime, "pam.module", map[string]*llx.RawData{
+		"name":    llx.StringData(name),
+		"params":  llx.MapData(map[string]any{}, types.String),
+		"enabled": llx.BoolData(false),
+		"entries": llx.ArrayData([]any{}, types.Resource("pam.conf.serviceEntry")),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, res, nil
+}
+
+func (m *mqlPamModule) id() (string, error) {
+	return "pam.module/" + m.Name.Data, nil
+}
+
+func (s *mqlPamConf) modules(entries map[string]any) ([]any, error) {
+	// Collect entries grouped by canonical module name, preserving source
+	// order across files for last-write-wins option aggregation.
+	type moduleAgg struct {
+		name       string
+		entries    []any
+		optionSets [][]any
+		anyEnabled bool
+	}
+
+	byName := map[string]*moduleAgg{}
+	order := []string{}
+
+	// Iterate services in a stable order so the resulting []pam.module
+	// list is deterministic across calls.
+	serviceNames := make([]string, 0, len(entries))
+	for svc := range entries {
+		serviceNames = append(serviceNames, svc)
+	}
+	sort.Strings(serviceNames)
+
+	for _, svc := range serviceNames {
+		raw := entries[svc]
+		list, ok := raw.([]any)
+		if !ok {
+			continue
+		}
+		for _, e := range list {
+			entry, ok := e.(*mqlPamConfServiceEntry)
+			if !ok {
+				continue
+			}
+			rawModule := entry.Module.Data
+			if rawModule == "" {
+				// Skip @include lines and anything that doesn't reference
+				// a real module.
+				continue
+			}
+			name := canonicalizePamModuleName(rawModule)
+			agg, ok := byName[name]
+			if !ok {
+				agg = &moduleAgg{name: name}
+				byName[name] = agg
+				order = append(order, name)
+			}
+			agg.entries = append(agg.entries, entry)
+			agg.optionSets = append(agg.optionSets, entry.Options.Data)
+			if isPamControlEnabled(entry.Control.Data) {
+				agg.anyEnabled = true
+			}
+		}
+	}
+
+	out := make([]any, 0, len(order))
+	for _, name := range order {
+		agg := byName[name]
+		params := aggregatePamParams(agg.optionSets...)
+		res, err := CreateResource(s.MqlRuntime, "pam.module", map[string]*llx.RawData{
+			"name":    llx.StringData(agg.name),
+			"params":  llx.MapData(params, types.String),
+			"enabled": llx.BoolData(agg.anyEnabled),
+			"entries": llx.ArrayData(agg.entries, types.Resource("pam.conf.serviceEntry")),
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
+	}
+	return out, nil
 }
 
 func (s *mqlPamConf) entries(files []any) (map[string]any, error) {

--- a/providers/os/resources/pam_module_internal_test.go
+++ b/providers/os/resources/pam_module_internal_test.go
@@ -1,0 +1,115 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCanonicalizePamModuleName(t *testing.T) {
+	cases := []struct {
+		in       string
+		expected string
+	}{
+		{"pam_unix.so", "pam_unix"},
+		{"/lib/security/pam_faillock.so", "pam_faillock"},
+		{"pam_unix", "pam_unix"},
+		{"/lib64/security/pam_pwquality.so", "pam_pwquality"},
+		{"", ""},
+		{"pam_faillock", "pam_faillock"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, tc.expected, canonicalizePamModuleName(tc.in))
+		})
+	}
+}
+
+func TestAggregatePamParams(t *testing.T) {
+	t.Run("single entry simple key=value", func(t *testing.T) {
+		got := aggregatePamParams([]any{"deny=5"})
+		assert.Equal(t, map[string]any{"deny": "5"}, got)
+	})
+
+	t.Run("last-write-wins across entries", func(t *testing.T) {
+		got := aggregatePamParams(
+			[]any{"deny=3"},
+			[]any{"deny=5"},
+		)
+		assert.Equal(t, map[string]any{"deny": "5"}, got)
+	})
+
+	t.Run("bare option recorded as existence marker", func(t *testing.T) {
+		got := aggregatePamParams([]any{"use_authtok"})
+		assert.Equal(t, map[string]any{"use_authtok": ""}, got)
+	})
+
+	t.Run("mixed bare and key=value", func(t *testing.T) {
+		got := aggregatePamParams([]any{"use_authtok", "deny=5", "unlock_time=900"})
+		assert.Equal(t, map[string]any{
+			"use_authtok": "",
+			"deny":        "5",
+			"unlock_time": "900",
+		}, got)
+	})
+
+	t.Run("case-normalized keys", func(t *testing.T) {
+		got := aggregatePamParams([]any{"Deny=5"})
+		assert.Equal(t, map[string]any{"deny": "5"}, got)
+	})
+
+	t.Run("empty input produces empty map", func(t *testing.T) {
+		got := aggregatePamParams()
+		assert.Equal(t, map[string]any{}, got)
+	})
+
+	t.Run("value contains equals sign is preserved", func(t *testing.T) {
+		// Bracketed forms like `default=die` aren't options — they live in
+		// the control column — but if a value itself contains an `=`, we
+		// keep everything after the first `=` as the value.
+		got := aggregatePamParams([]any{"group=admin,wheel"})
+		assert.Equal(t, map[string]any{"group": "admin,wheel"}, got)
+	})
+
+	t.Run("multi-list aggregation in order", func(t *testing.T) {
+		got := aggregatePamParams(
+			[]any{"unlock_time=600", "deny=3"},
+			[]any{"deny=5", "even_deny_root"},
+		)
+		assert.Equal(t, map[string]any{
+			"unlock_time":    "600",
+			"deny":           "5",
+			"even_deny_root": "",
+		}, got)
+	})
+}
+
+func TestIsPamControlEnabled(t *testing.T) {
+	cases := []struct {
+		control  string
+		expected bool
+	}{
+		{"required", true},
+		{"requisite", true},
+		{"sufficient", true},
+		{"optional", true},
+		{"substack", true},
+		{"include", true},
+		{"[success=1 default=ignore]", false},
+		{"[default=ignore]", false},
+		{"[default=skip]", false},
+		{"[default=die]", true},
+		{"[success=ok default=bad]", true},
+		{"", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.control, func(t *testing.T) {
+			assert.Equal(t, tc.expected, isPamControlEnabled(tc.control))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds `pam.module(name)` and `pam.conf.modules` to the OS provider so CIS-style PAM audits can write a one-liner like:

```mql
pam.module("pam_faillock").params["deny"] <= 5
pam.module("pam_pwquality").params["minlen"] >= 14
pam.module("pam_unix").params["remember"] >= 5
```

instead of the ~15-line regex chain over `pam.conf.entries` that the CIS guides currently recommend.

The resource sits on top of the existing `providers/os/resources/pam/parser.go` — no re-parsing of `/etc/pam.d/*` files.

## What's new

- **`pam.module`** — keyed by canonical module name (`pam_unix.so`, `/lib/security/pam_faillock.so` → `pam_unix`, `pam_faillock`):
  - `name string` — canonical short name
  - `params map[string]string` — `key=value` options merged across every line that loads the module; later occurrences win (matching how PAM itself resolves duplicate flags); bare options (`use_authtok`) are present with `""` as an existence marker; keys are lowercased for stable lookups
  - `enabled bool` — true when at least one entry references the module with a non-skip control; bracketed `default=ignore` / `default=skip` excluded
  - `entries []pam.conf.serviceEntry` — every service entry that references this module, for callers that need to drill back into a specific line
- **`pam.conf.modules`** — `[]pam.module` containing every distinct module name seen across `/etc/pam.d/*`
- `pam.module(name: "...")` returns an empty husk (`enabled: false`, `params: {}`, `entries: []`) when nothing references the requested module, so audits that check "X is not configured" still work

## Behavior notes

- Module name canonicalization strips a leading path and trims `.so`; case is preserved
- `params` keys are lowercased (`Deny=5` → `{deny: "5"}`), values are not
- `enabled` rules: bare controls (`required`, `requisite`, `sufficient`, `optional`, `substack`, `include`) all count; bracketed forms count unless they explicitly route to `default=ignore` / `default=skip`

## Test plan

- [x] Unit tests for `canonicalizePamModuleName`, `aggregatePamParams`, and `isPamControlEnabled` cover the spec'd cases (path stripping, `.so` trim, last-write-wins, bare options, mixed input, case normalization, all the control variants)
- [x] `go test ./providers/os/resources/ -run "TestPam|TestResource_Pam|TestCanonicalizePamModuleName|TestAggregatePamParams|TestIsPamControlEnabled"` passes
- [x] `make providers/build/os` succeeds; `mqlr generate` is idempotent
- [ ] Integration test against a mock `/etc/pam.d/common-auth` is left as a TODO — `arch.json` has no PAM data and extending the mock is non-trivial; the helper-level unit tests give us the coverage we need for the aggregation/control logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)