### PR TITLE
🐛 do not shadow global namespace with named vars in blocks

### DIFF
--- a/mqlc/builtin_map.go
+++ b/mqlc/builtin_map.go
@@ -66,6 +66,7 @@ func compileDictQuery(c *compiler, typ types.Type, ref uint64, id string, call *
 			ref: blockCompiler.Binding.ref,
 			typ: valueType,
 		})
+		blockCompiler.bindingIsExplicit = true
 	}
 
 	err := blockCompiler.compileExpressions([]*parser.Expression{arg.Value})
@@ -554,6 +555,7 @@ func compileMapWhere(c *compiler, typ types.Type, ref uint64, id string, call *p
 			ref: blockCompiler.Binding.ref,
 			typ: valueType,
 		})
+		blockCompiler.bindingIsExplicit = true
 	}
 
 	err := blockCompiler.compileExpressions([]*parser.Expression{arg.Value})

--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -155,6 +155,13 @@ type compiler struct {
 	//   file(xyz).content == _     is not
 	standalone bool
 
+	// bindingIsExplicit is true when the block's binding was given an explicit
+	// name by the caller, e.g. `xs.map(p: p.foo)`. In that case bare identifiers
+	// resolve against the global namespace (resources, builtins, vars) instead
+	// of against the bound resource's fields. The bound resource is only
+	// reachable through its explicit name (`p`) or through `_`.
+	bindingIsExplicit bool
+
 	// helps chaining of builtin calls like `if (..) else if (..) else ..`
 	prevID string
 
@@ -665,7 +672,14 @@ func (c *compiler) blockcompileOnResource(expressions []*parser.Expression, typ 
 			blockCompiler.standalone = false
 		},
 	}
+	// When the user supplies an explicit name (e.g. `.map(p: ...)`) the bound
+	// resource is reachable only through that name and through `_`. We also
+	// register `_` so the implicit-call form keeps working alongside the name.
 	blockCompiler.vars.add(bindingName, v)
+	if bindingName != "_" {
+		blockCompiler.vars.add("_", v)
+		blockCompiler.bindingIsExplicit = true
+	}
 	blockCompiler.Binding = &v
 
 	err := blockCompiler.compileExpressions(expressions)
@@ -1159,10 +1173,17 @@ func (c *compiler) compileIdentifier(id string, callBinding *variable, calls []*
 			return nil, types.Nil, errors.New("not sure how to handle implicit calls around `_`")
 		}
 
-		found, typ, err = c.compileBoundIdentifier(id, callBinding, call)
-		if found {
-			c.standalone = false
-			return restCalls, typ, err
+		// When the block has an explicit named binding (e.g. `.map(p: ...)`),
+		// bare identifiers do NOT shadow the global namespace with the bound
+		// resource's fields. The user must write `p.foo` or `_.foo` to reach a
+		// field of the binding. This avoids the trap where a process field
+		// (e.g. `command`) hides a same-named top-level resource.
+		if !c.bindingIsExplicit {
+			found, typ, err = c.compileBoundIdentifier(id, callBinding, call)
+			if found {
+				c.standalone = false
+				return restCalls, typ, err
+			}
 		}
 	} // end bound functions
 

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -2185,7 +2185,7 @@ func TestSuggestions(t *testing.T) {
 		{
 			// resource suggestions
 			"ssh",
-			[]string{"os.unix.sshd", "sshd", "sshd.config", "windows.security.health"},
+			[]string{"macos.sharing", "os.unix.sshd", "sshd", "sshd.config", "windows.security.health"},
 			errors.New("cannot find resource for identifier 'ssh'"),
 			nil,
 		},

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -971,6 +971,56 @@ func TestCompiler_ArrayWhereStatic(t *testing.T) {
 	})
 }
 
+// Named-binding blocks (e.g. `xs.map(p: ...)`) make the bound resource
+// reachable only through its name (`p`) or `_`. Bare identifiers inside the
+// block resolve against the global namespace — they do NOT shadow with the
+// bound resource's fields. This avoids the trap where a same-named field
+// (e.g. `process.command`) hides a top-level resource (e.g. `command`).
+func TestCompiler_NamedBindingScope(t *testing.T) {
+	// Bare `command` resolves to the top-level resource, not to
+	// `process.command`. Without the named-binding rule this fails with
+	// "cannot call field 'process.command' with arguments yet".
+	compileT(t, `processes.list.map(p: command("echo " + p.command))`, func(res *llx.CodeBundle) {
+		// The block body should invoke the global `command` resource. We don't
+		// pin the full chunk graph — just assert the call exists in some block.
+		found := false
+		for _, b := range res.CodeV2.Blocks {
+			for _, ch := range b.Chunks {
+				if ch.Id == "command" && ch.Call == llx.Chunk_FUNCTION {
+					found = true
+				}
+			}
+		}
+		assert.True(t, found, "expected a `command` resource call in compiled blocks")
+	})
+
+	// `_.command` still reaches the bound process's `command` field.
+	compileT(t, `processes.list.map(p: _.command)`, func(res *llx.CodeBundle) {
+		found := false
+		for _, b := range res.CodeV2.Blocks {
+			for _, ch := range b.Chunks {
+				if ch.Id == "command" && ch.Call == llx.Chunk_FUNCTION && ch.Function != nil && ch.Function.Type == string(types.String) {
+					found = true
+				}
+			}
+		}
+		assert.True(t, found, "expected the bound process.command field call in compiled blocks")
+	})
+
+	// Without a named binding the old shadowing rule still applies: bare
+	// `command` resolves to `process.command` (the field), not the global.
+	compileT(t, `processes.list.map(command)`, func(res *llx.CodeBundle) {
+		for _, b := range res.CodeV2.Blocks {
+			for _, ch := range b.Chunks {
+				if ch.Id == "command" && ch.Call == llx.Chunk_FUNCTION {
+					assert.Equal(t, string(types.String), ch.Function.Type,
+						"bare `command` inside an anonymous block should be the process.command string field, not the command resource")
+				}
+			}
+		}
+	})
+}
+
 func TestCompiler_ArrayContains(t *testing.T) {
 	compileT(t, "[1,2,3].contains(_ == 2)", func(res *llx.CodeBundle) {
 		assertPrimitive(t, &llx.Primitive{


### PR DESCRIPTION
This is a pretty bad oversight: We are currently shadowing the global namespace even when a binding variable has been defined. Usually we implicitly use `_` in blocks, which by default binds to the calling binding. So in e.g. a list of resources you deal with the resource. But when users explicitly rename that binding (ie: `.map(v: ...)`) then we shouldn't shadow the implicit namingspace anymore. Users defined a name (eg: `v` in this case), so it should give us control back to the global namespace. But it doesn't right now. I ran into it because it blocked one of my queries and in with this bug you can't solve it in MQL.

My personal example:

```
processes.where(command == /mysearch/).map(p: command('fix '+p.command)) 
```