### PR TITLE
✨ os/macos.firewall: add managedByMDM for Configuration Profile detection

### DIFF
--- a/providers/os/resources/macos_firewall.go
+++ b/providers/os/resources/macos_firewall.go
@@ -268,6 +268,44 @@ func (m *mqlMacosFirewall) applications() ([]any, error) {
 	return apps, nil
 }
 
+// mdmFirewallPayloadType is the Configuration Profile payload type that
+// Apple defines for the application firewall. A profile carrying this
+// payload (typically delivered via MDM) declares enable state, stealth
+// mode, blocking behaviour, and per-app rules for the firewall.
+const mdmFirewallPayloadType = "com.apple.security.firewall"
+
+func (m *mqlMacosFirewall) managedByMDM() (bool, error) {
+	res, err := CreateResource(m.MqlRuntime, "macos.profiles", nil)
+	if err != nil {
+		return false, err
+	}
+	profiles := res.(*mqlMacosProfiles)
+	list := profiles.GetList()
+	if list.Error != nil {
+		return false, list.Error
+	}
+	for _, raw := range list.Data {
+		profile, ok := raw.(*mqlMacosProfile)
+		if !ok {
+			continue
+		}
+		payloads := profile.GetPayloads()
+		if payloads.Error != nil {
+			return false, payloads.Error
+		}
+		for _, p := range payloads.Data {
+			payload, ok := p.(*mqlMacosProfilePayload)
+			if !ok {
+				continue
+			}
+			if payload.GetType().Data == mdmFirewallPayloadType {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
 // id is required for the macos.firewall.app sub-resource
 func (m *mqlMacosFirewallApp) id() (string, error) {
 	return "macos.firewall.app/" + m.Name.Data, nil

--- a/providers/os/resources/macos_firewall.go
+++ b/providers/os/resources/macos_firewall.go
@@ -298,7 +298,11 @@ func (m *mqlMacosFirewall) managedByMDM() (bool, error) {
 			if !ok {
 				continue
 			}
-			if payload.GetType().Data == mdmFirewallPayloadType {
+			ptype := payload.GetType()
+			if ptype.Error != nil {
+				return false, ptype.Error
+			}
+			if ptype.Data == mdmFirewallPayloadType {
 				return true, nil
 			}
 		}

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -3979,6 +3979,14 @@ macos.firewall @defaults("enabled stealthEnabled") {
   explicitAuths() []string
   // Applications with explicit firewall rules
   applications() []macos.firewall.app
+  // Whether an installed Configuration Profile manages the firewall
+  //
+  // True when any installed profile carries a payload of type
+  // `com.apple.security.firewall`. Enumerating Configuration Profiles
+  // requires root, so on an unprivileged session the field surfaces
+  // the underlying `profiles list` error rather than silently
+  // returning `false`.
+  managedByMDM() bool
 }
 
 // macOS firewall per-application rule

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -5347,6 +5347,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"macos.firewall.applications": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMacosFirewall).GetApplications()).ToDataRes(types.Array(types.Resource("macos.firewall.app")))
 	},
+	"macos.firewall.managedByMDM": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMacosFirewall).GetManagedByMDM()).ToDataRes(types.Bool)
+	},
 	"macos.firewall.app.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMacosFirewallApp).GetName()).ToDataRes(types.String)
 	},
@@ -13212,6 +13215,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"macos.firewall.applications": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMacosFirewall).Applications, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"macos.firewall.managedByMDM": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMacosFirewall).ManagedByMDM, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"macos.firewall.app.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -35900,6 +35907,7 @@ type mqlMacosFirewall struct {
 	Exceptions              plugin.TValue[[]any]
 	ExplicitAuths           plugin.TValue[[]any]
 	Applications            plugin.TValue[[]any]
+	ManagedByMDM            plugin.TValue[bool]
 }
 
 // createMacosFirewall creates a new instance of this resource
@@ -36007,6 +36015,12 @@ func (c *mqlMacosFirewall) GetApplications() *plugin.TValue[[]any] {
 		}
 
 		return c.applications()
+	})
+}
+
+func (c *mqlMacosFirewall) GetManagedByMDM() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.ManagedByMDM, func() (bool, error) {
+		return c.managedByMDM()
 	})
 }
 

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -1092,6 +1092,7 @@ macos.firewall.exceptions 13.3.1
 macos.firewall.explicitAuths 13.3.1
 macos.firewall.loggingDetail 13.3.1
 macos.firewall.loggingEnabled 13.3.1
+macos.firewall.managedByMDM 13.16.10
 macos.firewall.stealthEnabled 13.3.1
 macos.firewall.version 13.3.1
 macos.gatekeeper 13.5.1


### PR DESCRIPTION
## Summary

- Adds `macos.firewall.managedByMDM` so audits can tell whether the application firewall is enforced by a Configuration Profile (typically MDM-delivered) versus only locally configured
- Implemented by scanning `macos.profiles.list` for a payload of type `com.apple.security.firewall`; surfaces the underlying `profiles list` error (e.g. \"requires root privileges\") instead of silently reporting `false`

## What this enables

```mql
# Firewall is policy-enforced
macos.firewall.managedByMDM

# Firewall is enabled AND policy-enforced
macos.firewall.enabled && macos.firewall.managedByMDM

# Firewall is enabled but NOT policy-enforced — locally-set, can be turned off
macos.firewall.enabled && !macos.firewall.managedByMDM
```

## Scope

Just the boolean. A follow-up could surface the declared payload as a typed `macos.firewall.payload` sub-resource so audits can assert drift between the MDM-declared policy (EnableFirewall, EnableStealthMode, BlockAllIncoming, …) and the observed ALF state. Out of scope here.

## Test plan

- [x] `make providers/mqlr` clean; `./mqlr generate` produced expected `GetManagedByMDM` accessor in `os.lr.go`
- [x] `go build ./...` in `providers/os` clean
- [x] `go test ./providers/os/resources/ -run "TestParseMacosProfiles|MacosFirewall"` passes
- [x] `os.lr.versions` updated to `macos.firewall.managedByMDM 13.16.10` (next patch after current 13.16.9)
- [ ] Interactive verification on a real macOS host with an MDM-managed firewall profile installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)