### PR TITLE
🎉 aws-13.27.0, azure-13.13.0, gcp-13.17.0, os-13.17.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.26.2",
+	Version:         "13.27.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "azure",
 	ID:      "go.mondoo.com/cnquery/v9/providers/azure",
-	Version: "13.12.1",
+	Version: "13.13.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(azureinstancesnapshot.SnapshotConnectionType),

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.16.2",
+	Version: "13.17.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),

--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.16.9",
+	Version: "13.17.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
## Summary

Minor version bump for `aws`, `azure`, `gcp`, and `os` providers.

| Provider | From | To |
|----------|------|----|
| aws      | 13.26.2 | 13.27.0 |
| azure    | 13.12.1 | 13.13.0 |
| gcp      | 13.16.2 | 13.17.0 |
| os       | 13.16.9 | 13.17.0 |

## PRs in this release

### aws (since 13.26.2)

- #7943 — 🧹 Update deps for mql and providers 20260525
- #7919 — 🐛 fix bugs surfaced by provider-verification across aws/gcp/azure
- #7916 — 🧹 aws: regenerate permissions.json to pick up es:DescribeElasticsearchDomains
- #7902 — 🐛 aws: correctness, nil-handling, and pagination fixes from audit pass
- #7904 — ⚡ aws: N+1 and duplicate-call perf fixes from audit pass
- #7831 — ✨ aws: add App Runner support (services, connections, vpc connectors, observability, autoscaling)
- #7888 — 🐛 aws: cloudformation deep-dive fixes — lazy DescribeStackSet, nil-id skip, new fields
- #7882 — 🐛 aws: cloudformation fixes — DELETED stack sets, dict shape, eager tags, drift normalization
- #7769 — 🧹 remove the manual prefixed "Deprecation" from titles+desc for resources/fields
- #7864 — 🧹 Update deps for mql and providers 20260523
- #7834 — 🐛 fix 5 bugs found by /provider-verification on AWS + GCP
- #7795 — ✨ aws: expand cloudfront with response headers, OAC, cache/origin policies, KVS, key groups, FLE
- #7797 — ✨ aws: expand route53 with resolver, DNS firewall, traffic policies, CIDR collections, DNSSEC
- #7796 — ✨ aws: expand eventbridge with connections, API destinations, archives, replays, global endpoints
- #7815 — 🧹 Only supply repo names filter to AWS request when specified
- #7802 — ✨ aws: add CodePipeline and CodeArtifact support
- #7767 — ✨ Add filters for ECR repositories
- #7777 — ✨ aws: expand kms with grants, multi-region keys, custom key stores
- #7780 — ✨ aws: expand ssm with patch management, state manager, parameter store depth
- #7781 — ✨ aws: expand glue with data catalog, etl, schema registry, security configs
- #7778 — ✨ aws: expand network firewall with policies, rule groups, tls inspection, logging
- #7775 — ✨ aws: expand cloudwatch logs with data protection, filters, anomaly detectors, account policies
- #7776 — ✨ aws: expand cognito with threat protection, schema, recovery, and identity-pool roles
- #7779 — ✨ aws: expand bedrock with agents, knowledge bases, flows, eval/import/batch jobs
- #7742 — ✨ aws: expand iam, s3, rds, lambda, elb, and acm resources
- #7763 — 🧹 stricter rules for titles+description on resources/fields
- #7762 — ✨ aws: model VPC IPAM (ipam, scope, pool, pool.allocation)
- #7760 — 🧹 Update deps for mql and providers 20260521

### azure (since 13.12.1)

- #7943 — 🧹 Update deps for mql and providers 20260525
- #7919 — 🐛 fix bugs surfaced by provider-verification across aws/gcp/azure
- #7900 — 🐛 azure: fix nil-deref panics and a cache-key collision from audit pass
- #7769 — 🧹 remove the manual prefixed "Deprecation" from titles+desc for resources/fields
- #7864 — 🧹 Update deps for mql and providers 20260523
- #7834 — 🐛 fix 5 bugs found by /provider-verification on AWS + GCP
- #7793 — ✨ azure: expand networking with Traffic Manager, Virtual WAN, ExpressRoute, Network Watcher depth
- #7790 — ✨ azure: typed NSG ref + DNS settings on network interface
- #7788 — ✨ azure: typed listeners + sslCertificates on Application Gateway
- #7785 — ✨ azure: surface VM imageReference, bootDiagnostics, and userData
- #7784 — ✨ azure: typed networkRules() on Service Bus + Event Hubs namespaces
- #7787 — ✨ azure: surface VNet integration target + logging/auto-heal/websocket flags on App Service
- #7782 — ✨ azure: typed list scalars + provisioningState on NSG security rules
- #7783 — ✨ azure: subnet NSG/routeTable typed refs + serviceEndpoint + delegation sub-resources
- #7773 — ✨ azure: model Sentinel, Defender for AI, and VM endpoint-agent presence
- #7771 — ✨ azure: model new fields & RAI resources from storage v4 / cogsvc v3 / appconfig v3
- #7770 — 🧹 azure: bump armappconfiguration v3, armcognitiveservices v3, armstorage v4
- #7763 — 🧹 stricter rules for titles+description on resources/fields
- #7741 — ✨ azure: model Cosmos DB MongoDB vCore and PostgreSQL clusters
- #7760 — 🧹 Update deps for mql and providers 20260521

### gcp (since 13.16.2)

- #7943 — 🧹 Update deps for mql and providers 20260525
- #7919 — 🐛 fix bugs surfaced by provider-verification across aws/gcp/azure
- #7910 — ✨ gcp/sql: add instance TLS, edition, and backup detail fields
- #7911 — ✨ gcp/compute: add encryption-lineage and replication fields
- #7909 — ✨ gcp/gke: pick up modern cluster fields & deprecate legacy equivalents
- #7913 — 🧪 gcp: add uniqueness tests for sub-resource id formatters
- #7906 — ✨ gcp/pubsub: add topic security and ingestion fields
- #7905 — ✨ gcp/bigquery: add dataset externalDatasetReference field
- #7908 — ✨ gcp/storage: add bucket security and operational fields
- #7901 — ⚡ gcp: use Compute AggregatedList for instances, disks, machineTypes, routers
- #7899 — 🐛 gcp: fix sub-resource id collisions from audit pass
- #7769 — 🧹 remove the manual prefixed "Deprecation" from titles+desc for resources/fields
- #7864 — 🧹 Update deps for mql and providers 20260523
- #7834 — 🐛 fix 5 bugs found by /provider-verification on AWS + GCP
- #7794 — ✨ gcp: typed region/zone/serviceAccount refs across compute & serverless
- #7789 — 🧹 gcp: regenerate permissions.json with correct action name
- #7786 — ✨ gcp: type four dict-style fields + add GKE Windows node config
- #7774 — ✨ gcp: folder IAM/audit, org+folder logging sinks, SA key lastAuthenticatedTime
- #7772 — ✨ gcp: model org-level IAM roles, folder org policies, KMS EKM connections + import jobs

### os (since 13.16.9)

- #7933 — ✨ os: add macos.softwareupdate for update policy and pending updates
- #7768 — ✨ os: add ai.models resource for local AI model cache detection
- #7932 — ✨ os: add macos.mdm and macos.profiles for MDM enrollment + Configuration Profiles
- #7936 — ✨ os: add macos.sharing for the System Settings Sharing panel
- #7931 — ✨ os: add kernel hardening fields — cmdline, taint, lockdown, aslr
- #7937 — ✨ os/rsyslog.conf: follow \$IncludeConfig and include(file="…") directives
- #7928 — ✨ os: add lvm resource for physical/volume groups/logical volumes
- #7934 — ✨ os: add macos.xprotect for anti-malware signature version + freshness
- #7880 — ✨ os: expand apache2 + nginx surface for TLS, hardening, and listen/upstream/location detail
- #7769 — 🧹 remove the manual prefixed "Deprecation" from titles+desc for resources/fields
- #7838 — ✨ docker.file: STOPSIGNAL, ONBUILD, parser directives, and RUN/ADD/COPY flag audits
- #7818 — 🧹 rpm: switch queryformat delimiter from __ to ASCII RS
- #7816 — ✨ npm.package: surface description, author, license
- #7814 — ✨ package: add installDate (rpm + Windows registry)
- #7822 — ✨ Improve error handling in parseYarnPackageName function and add tests for invalid inputs
- #7813 — ✨ package: add license field (rpm, dpkg, apk, pacman)

## Test plan

- [ ] CI green
- [ ] Release workflow picks up the new versions