### PR TITLE
🎉 jamf-13.0.2, kustomize-13.0.9, ipmi-13.0.13, grafana-13.1.7, digitalocean-13.4.1, cloudflare-13.5.1, atlassian-13.3.1, openstack-13.1.3, helm-13.0.9, ansible-13.0.13, proxmox-0.1.9

### DIFF
--- a/providers/ansible/config/config.go
+++ b/providers/ansible/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ansible",
 	ID:              "go.mondoo.com/mql/v13/providers/ansible",
-	Version:         "13.0.12",
+	Version:         "13.0.13",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/atlassian/config/config.go
+++ b/providers/atlassian/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "atlassian",
 	ID:      "go.mondoo.com/cnquery/v9/providers/atlassian",
-	Version: "13.3.0",
+	Version: "13.3.1",
 	ConnectionTypes: []string{
 		provider.DefaultConnectionType,
 		"jira",

--- a/providers/cloudflare/config/config.go
+++ b/providers/cloudflare/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "cloudflare",
 	ID:              "go.mondoo.com/mql/v13/providers/cloudflare",
-	Version:         "13.5.0",
+	Version:         "13.5.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/digitalocean/config/config.go
+++ b/providers/digitalocean/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "digitalocean",
 	ID:              "go.mondoo.com/mql/providers/digitalocean",
-	Version:         "13.4.0",
+	Version:         "13.4.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/grafana/config/config.go
+++ b/providers/grafana/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "grafana",
 	ID:              "go.mondoo.com/mql/v13/providers/grafana",
-	Version:         "13.1.6",
+	Version:         "13.1.7",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/helm/config/config.go
+++ b/providers/helm/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "helm",
 	ID:              "go.mondoo.com/mql/v13/providers/helm",
-	Version:         "13.0.8",
+	Version:         "13.0.9",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{

--- a/providers/ipmi/config/config.go
+++ b/providers/ipmi/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ipmi",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ipmi",
-	Version:         "13.0.12",
+	Version:         "13.0.13",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/jamf/config/config.go
+++ b/providers/jamf/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "jamf",
 	ID:              "go.mondoo.com/mql/providers/jamf",
-	Version:         "13.0.1",
+	Version:         "13.0.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/kustomize/config/config.go
+++ b/providers/kustomize/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "kustomize",
 	ID:              "go.mondoo.com/mql/v13/providers/kustomize",
-	Version:         "13.0.8",
+	Version:         "13.0.9",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{

--- a/providers/openstack/config/config.go
+++ b/providers/openstack/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "openstack",
 	ID:              "go.mondoo.com/mql/providers/openstack",
-	Version:         "13.1.2",
+	Version:         "13.1.3",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/proxmox/config/config.go
+++ b/providers/proxmox/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "proxmox",
 	ID:              "go.mondoo.com/mql/v13/providers/proxmox",
-	Version:         "0.1.8",
+	Version:         "0.1.9",
 	ConnectionTypes: []string{"proxmox"},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.