### PR TITLE
🎉 ms365-13.1.0

### DIFF
--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ms365",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ms365",
-	Version:         "13.0.12",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### ms365 (13.1.0)
- 🧹 Update deps for mql and providers 20260525 (#7943)
- 🧹 remove outdated cnquery docs (#7917)
- ⚡ ms365: cache PowerShell reports and drop redundant MFA fetch (#7912)
- 🐛 ms365: paginate list endpoints and stop swallowing errors (#7914)
- 🐛 ms365: fix logic errors surfaced by the audit pass (#7907)
- 🧹 remove the manual prefixed "Deprecation" from titles+desc for resources/fields (#7769)
- 🧹 Update deps for mql and providers 20260523 (#7864)
- ✨ ms365: expand Intune compliance/config/enrollment with platform-typed settings (#7805)
- 🧹 stricter rules for titles+description on resources/fields (#7763)
- 🧹 Update deps for mql and providers 20260521 (#7760)