### PR TITLE
🧹 macos.filevault/gatekeeper: extract parse helpers and add tests

### DIFF
--- a/providers/os/resources/macos_filevault.go
+++ b/providers/os/resources/macos_filevault.go
@@ -38,17 +38,57 @@ func (m *mqlMacosFilevault) fetchStatus() (string, error) {
 		return "", errors.New("fdesetup status failed: " + cmd.GetStderr().Data)
 	}
 
-	// fdesetup status outputs lines like:
-	// "FileVault is On."
-	// "FileVault is Off."
-	// "Encryption in progress: Percent completed = 50.0"
-	// "Decryption in progress: Percent completed = 50.0"
-	output := strings.TrimSpace(cmd.GetStdout().Data)
-	lines := strings.SplitN(output, "\n", 2)
-
-	m.output = strings.TrimSpace(lines[0])
+	m.output = parseFdesetupStatus(cmd.GetStdout().Data)
 	m.fetched = true
 	return m.output, nil
+}
+
+// parseFdesetupStatus extracts the first non-empty line of `fdesetup status`
+// output, which is the status sentence we care about. fdesetup may print
+// additional lines (e.g. progress percentages, deferred-enablement notes);
+// callers only need the headline.
+//
+// Examples of the leading line:
+//
+//	"FileVault is On."
+//	"FileVault is Off."
+//	"Encryption in progress: Percent completed = 50.0"
+//	"Decryption in progress: Percent completed = 50.0"
+func parseFdesetupStatus(raw string) string {
+	for _, line := range strings.Split(raw, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+// isFilevaultEnabled returns true for the "on" and "encrypting" states.
+// Decryption-in-progress is treated as not enabled because the volume is
+// transitioning to plaintext.
+func isFilevaultEnabled(status string) bool {
+	return strings.Contains(status, "FileVault is On") ||
+		strings.Contains(status, "Encryption in progress")
+}
+
+// parseFdesetupList turns `fdesetup list` output into a list of usernames.
+// Each line is "username,UUID"; blanks are skipped.
+func parseFdesetupList(raw string) []any {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return []any{}
+	}
+	users := []any{}
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		name, _, _ := strings.Cut(line, ",")
+		users = append(users, name)
+	}
+	return users
 }
 
 func (m *mqlMacosFilevault) status() (string, error) {
@@ -60,9 +100,7 @@ func (m *mqlMacosFilevault) enabled() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-
-	return strings.Contains(status, "FileVault is On") ||
-		strings.Contains(status, "Encryption in progress"), nil
+	return isFilevaultEnabled(status), nil
 }
 
 func (m *mqlMacosFilevault) runFdesetup(subcmd string) (string, error) {
@@ -127,20 +165,5 @@ func (m *mqlMacosFilevault) users() ([]any, error) {
 		return nil, err
 	}
 
-	if output == "" {
-		return []any{}, nil
-	}
-
-	var users []any
-	for _, line := range strings.Split(output, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		// Each line is "username,UUID" — extract the username
-		parts := strings.SplitN(line, ",", 2)
-		users = append(users, parts[0])
-	}
-
-	return users, nil
+	return parseFdesetupList(output), nil
 }

--- a/providers/os/resources/macos_filevault_test.go
+++ b/providers/os/resources/macos_filevault_test.go
@@ -1,0 +1,173 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// macos.filevault delegates command execution to the MQL runtime, but the
+// interesting logic — picking the right line of `fdesetup status`, deciding
+// what counts as "enabled", and turning `fdesetup list` into a slice of
+// usernames — lives in pure helpers. The tests below drive those helpers
+// with the exact strings macOS emits, so we can verify behavior without a
+// live host.
+
+func TestParseFdesetupStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "filevault on",
+			raw:  "FileVault is On.\n",
+			want: "FileVault is On.",
+		},
+		{
+			name: "filevault off",
+			raw:  "FileVault is Off.\n",
+			want: "FileVault is Off.",
+		},
+		{
+			name: "encryption in progress, multiple lines",
+			// fdesetup follows the headline with a progress line during
+			// active encryption; the headline alone is what we want.
+			raw:  "Encryption in progress: Percent completed = 50.0\nFileVault master keychain appears to be installed.",
+			want: "Encryption in progress: Percent completed = 50.0",
+		},
+		{
+			name: "decryption in progress",
+			raw:  "Decryption in progress: Percent completed = 25.0",
+			want: "Decryption in progress: Percent completed = 25.0",
+		},
+		{
+			name: "leading whitespace and blank line",
+			// Defensive: don't return an empty first line.
+			raw:  "\n   \nFileVault is On.\n",
+			want: "FileVault is On.",
+		},
+		{
+			name: "empty output",
+			raw:  "",
+			want: "",
+		},
+		{
+			name: "whitespace only",
+			raw:  "   \n\t\n",
+			want: "",
+		},
+		{
+			name: "trailing whitespace trimmed",
+			raw:  "FileVault is On.   \r\n",
+			want: "FileVault is On.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseFdesetupStatus(tt.raw))
+		})
+	}
+}
+
+func TestIsFilevaultEnabled(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+		want   bool
+	}{
+		{
+			name:   "on",
+			status: "FileVault is On.",
+			want:   true,
+		},
+		{
+			name:   "off",
+			status: "FileVault is Off.",
+			want:   false,
+		},
+		{
+			name:   "encryption in progress counts as enabled",
+			status: "Encryption in progress: Percent completed = 50.0",
+			want:   true,
+		},
+		{
+			// Decryption means the disk is on its way to plaintext — not enabled.
+			name:   "decryption in progress is not enabled",
+			status: "Decryption in progress: Percent completed = 75.0",
+			want:   false,
+		},
+		{
+			name:   "empty",
+			status: "",
+			want:   false,
+		},
+		{
+			// Don't get fooled by substrings that don't actually announce status.
+			name:   "unrelated text",
+			status: "FileVault master keychain appears to be installed.",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isFilevaultEnabled(tt.status))
+		})
+	}
+}
+
+func TestParseFdesetupList(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []any
+	}{
+		{
+			name: "single user",
+			raw:  "alice,85632A00-1234-5678-ABCD-123456789ABC",
+			want: []any{"alice"},
+		},
+		{
+			name: "multiple users",
+			raw:  "alice,85632A00-1234-5678-ABCD-123456789ABC\nbob,95632A00-1234-5678-ABCD-123456789ABC",
+			want: []any{"alice", "bob"},
+		},
+		{
+			name: "empty input yields empty slice (not nil)",
+			raw:  "",
+			want: []any{},
+		},
+		{
+			name: "whitespace only yields empty slice",
+			raw:  "   \n\n",
+			want: []any{},
+		},
+		{
+			name: "trailing newline ignored",
+			raw:  "alice,UUID-A\nbob,UUID-B\n",
+			want: []any{"alice", "bob"},
+		},
+		{
+			// Belt-and-braces: missing UUID shouldn't crash; we still want the name.
+			name: "line without comma falls back to whole line",
+			raw:  "alice",
+			want: []any{"alice"},
+		},
+		{
+			name: "blank lines between users are skipped",
+			raw:  "alice,UUID-A\n\nbob,UUID-B\n",
+			want: []any{"alice", "bob"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseFdesetupList(tt.raw))
+		})
+	}
+}

--- a/providers/os/resources/macos_gatekeeper.go
+++ b/providers/os/resources/macos_gatekeeper.go
@@ -38,12 +38,30 @@ func (m *mqlMacosGatekeeper) fetchStatus() (string, error) {
 		return "", errors.New("spctl --status failed: " + cmd.GetStderr().Data)
 	}
 
-	// spctl --status outputs:
-	// "assessments enabled" (Gatekeeper on)
-	// "assessments disabled" (Gatekeeper off)
-	m.output = strings.TrimSpace(cmd.GetStdout().Data)
+	m.output = parseSpctlStatus(cmd.GetStdout().Data)
 	m.fetched = true
 	return m.output, nil
+}
+
+// parseSpctlStatus normalizes `spctl --status` output. The command prints a
+// single line such as "assessments enabled" or "assessments disabled"; trim
+// and use the first non-empty line so trailing newlines or stray banner
+// lines don't trip up downstream matchers.
+func parseSpctlStatus(raw string) string {
+	for _, line := range strings.Split(raw, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+// isGatekeeperEnabled returns true only for the exact "assessments enabled"
+// marker. parseSpctlStatus has already trimmed and picked one line, so an
+// exact match is safer than a substring check against future spctl output.
+func isGatekeeperEnabled(status string) bool {
+	return status == "assessments enabled"
 }
 
 func (m *mqlMacosGatekeeper) status() (string, error) {
@@ -55,6 +73,5 @@ func (m *mqlMacosGatekeeper) enabled() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-
-	return strings.Contains(status, "assessments enabled"), nil
+	return isGatekeeperEnabled(status), nil
 }

--- a/providers/os/resources/macos_gatekeeper_test.go
+++ b/providers/os/resources/macos_gatekeeper_test.go
@@ -1,0 +1,106 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// macos.gatekeeper drives `spctl --status` through the MQL runtime, but the
+// status normalization and enabled-state decision are pure string ops. The
+// tests below pin those helpers against the exact phrases macOS emits.
+
+func TestParseSpctlStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "enabled with trailing newline",
+			raw:  "assessments enabled\n",
+			want: "assessments enabled",
+		},
+		{
+			name: "disabled with trailing newline",
+			raw:  "assessments disabled\n",
+			want: "assessments disabled",
+		},
+		{
+			name: "no trailing newline",
+			raw:  "assessments enabled",
+			want: "assessments enabled",
+		},
+		{
+			name: "leading whitespace and CRLF",
+			raw:  "   assessments enabled\r\n",
+			want: "assessments enabled",
+		},
+		{
+			name: "blank lines before status are skipped",
+			raw:  "\n\nassessments enabled\n",
+			want: "assessments enabled",
+		},
+		{
+			name: "empty output",
+			raw:  "",
+			want: "",
+		},
+		{
+			name: "whitespace only",
+			raw:  "\n  \t\n",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseSpctlStatus(tt.raw))
+		})
+	}
+}
+
+func TestIsGatekeeperEnabled(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+		want   bool
+	}{
+		{
+			name:   "enabled",
+			status: "assessments enabled",
+			want:   true,
+		},
+		{
+			name:   "disabled",
+			status: "assessments disabled",
+			want:   false,
+		},
+		{
+			name:   "empty",
+			status: "",
+			want:   false,
+		},
+		{
+			// Make sure we don't match partial words — defends against future
+			// spctl wording changes that might add prefixes or suffixes.
+			name:   "extra suffix is not enabled",
+			status: "assessments enabled (kernel)",
+			want:   false,
+		},
+		{
+			name:   "extra prefix is not enabled",
+			status: "global: assessments enabled",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isGatekeeperEnabled(tt.status))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Extract the line-picking and enabled-state logic in `macos.filevault` and `macos.gatekeeper` into pure helpers so they can be tested without a live macOS host.
- Add unit tests for both: 21 subtests for filevault (status parsing, enabled state, user list), 12 for gatekeeper (status parsing, enabled match).
- Tighten the gatekeeper enabled check to an exact comparison against the trimmed status line. Future spctl wording such as ``\"assessments enabled (kernel)\"`` won't silently pass.

The MQL resource methods are still thin wrappers around the runtime ``command`` resource — only the parsing/decision logic moved into helpers.

## Test plan

- [x] ``go test ./providers/os/resources/ -run 'TestParseFdesetup|TestIsFilevault|TestParseSpctl|TestIsGatekeeper'`` — 33 subtests pass
- [x] ``go vet ./providers/os/resources/`` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)