### PR TITLE
🎉 k8s-13.1.0

### DIFF
--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "k8s",
 	ID:              "go.mondoo.com/cnquery/v9/providers/k8s",
-	Version:         "13.0.15",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### k8s (13.1.0)
- 🧹 Update deps for mql and providers 20260525 (#7943)
- 🐛 k8s: resolve typed cross-refs to null on not-found instead of erroring (#7918)
- 🐛 k8s: fix five logic errors surfaced by the audit pass (#7885)
- ⚡ k8s: drop eager JsonToDict marshals for fields with cheap lazy access (#7886)
- 🐛 k8s: fix two nil-handling bugs surfaced by the audit pass (#7884)
- 🐛 k8s: fix nil-pointer panic on webhook configuration singular lookups (#7879)
- 🧹 k8s: cover the deleted-SA branch of resolveServiceAccountSubjects (#7877)
- ✨ k8s: type RBAC traversal, EndpointSlice service, ResourceQuota/LimitRange fields (#7874)
- 🧹 k8s: spelling — pre-existing → preexisting in PVC.selector doc (#7873)
- ✨ k8s: type out HPA, Node, PV, PVC fields with cross-references (#7872)
- ✨ k8s: type Job/CronJob/NetworkPolicy/Ingress fields, add IngressClass resource (#7871)
- ✨ k8s: type out container probes, lifecycle, ports, sidecar, and status fields (#7869)
- ✨ k8s: type out workload rollout fields for Deployment, StatefulSet, DaemonSet, ReplicaSet (#7868)
- ✨ k8s: type out pod scheduling/security and service networking fields (#7867)
- 🧹 Update deps for mql and providers 20260523 (#7864)
- ✨ k8s: add MutatingWebhookConfiguration, PodDisruptionBudget, Lease, CertificateSigningRequest, APIService (#7863)
- ✨ k8s: add Gateway API resources (Gateway, GatewayClass, HTTPRoute, GRPCRoute, ReferenceGrant) (#7860)
- 🧹 Update deps for mql and providers 20260521 (#7760)