### PR TITLE
🎉 os-13.18.0

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.17.0",
+	Version: "13.18.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### os (13.18.0)
- ✨ os: add luks resources for LUKS1 and LUKS2 volume audits (#7952)
- 🧹 macos.filevault/gatekeeper: extract parse helpers and add tests (#7954)
- ✨ os: add squid resource for full squid.conf inspection (#7926)
- ✨ os: add systemd.target, systemd.resolved, and systemd.timesyncd (#7929)
- ✨ os: add cgroups resource for cgroup v2 hierarchy and limits (#7930)
- ✨ os/pam.module: typed per-module view with aggregated params for CIS audits (#7939)
- ✨ os/kernel.module: expose blacklisted, installBypass, and disabled for CIS audits (#7938)
- ✨ os/rsyslog.conf: typed modules / inputs / actions / rules with source attribution (#7946)