### PR TITLE
✨ os: typed parent refs on nftables.chain, .rule, .set

### DIFF
--- a/providers/os/resources/nftables.go
+++ b/providers/os/resources/nftables.go
@@ -259,6 +259,41 @@ func (s *mqlNftablesSet) id() (string, error) {
 	return s.Family.Data + "/" + s.Table.Data + "/" + s.Name.Data, nil
 }
 
+func (c *mqlNftablesChain) tableRef() (*mqlNftablesTable, error) {
+	return nftLookupTable(c.MqlRuntime, c.Family.Data, c.Table.Data)
+}
+
+func (r *mqlNftablesRule) tableRef() (*mqlNftablesTable, error) {
+	return nftLookupTable(r.MqlRuntime, r.Family.Data, r.Table.Data)
+}
+
+func (r *mqlNftablesRule) chainRef() (*mqlNftablesChain, error) {
+	raw, err := NewResource(r.MqlRuntime, "nftables.chain", map[string]*llx.RawData{
+		"family": llx.StringData(r.Family.Data),
+		"table":  llx.StringData(r.Table.Data),
+		"name":   llx.StringData(r.Chain.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return raw.(*mqlNftablesChain), nil
+}
+
+func (s *mqlNftablesSet) tableRef() (*mqlNftablesTable, error) {
+	return nftLookupTable(s.MqlRuntime, s.Family.Data, s.Table.Data)
+}
+
+func nftLookupTable(runtime *plugin.Runtime, family, name string) (*mqlNftablesTable, error) {
+	raw, err := NewResource(runtime, "nftables.table", map[string]*llx.RawData{
+		"family": llx.StringData(family),
+		"name":   llx.StringData(name),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return raw.(*mqlNftablesTable), nil
+}
+
 // fetchRuleset lazily fetches and caches the nft JSON ruleset.
 func (n *mqlNftables) fetchRuleset() (*nftRuleset, error) {
 	if n.fetched {

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -2563,8 +2563,10 @@ private nftables.table @defaults("family name") {
 private nftables.chain @defaults("family table name") {
   // Address family
   family string
-  // Table this chain belongs to
+  // Name of the table this chain belongs to
   table string
+  // Table this chain belongs to
+  tableRef() nftables.table
   // Chain name
   name string
   // Chain handle number
@@ -2587,10 +2589,14 @@ private nftables.chain @defaults("family table name") {
 private nftables.rule @defaults("family table chain handle") {
   // Address family
   family string
-  // Table this rule belongs to
+  // Name of the table this rule belongs to
   table string
-  // Chain this rule belongs to
+  // Table this rule belongs to
+  tableRef() nftables.table
+  // Name of the chain this rule belongs to
   chain string
+  // Chain this rule belongs to
+  chainRef() nftables.chain
   // Rule handle number
   handle int
   // Rule expressions as structured data
@@ -2603,8 +2609,10 @@ private nftables.rule @defaults("family table chain handle") {
 private nftables.set @defaults("family table name") {
   // Address family
   family string
-  // Table this set belongs to
+  // Name of the table this set belongs to
   table string
+  // Table this set belongs to
+  tableRef() nftables.table
   // Set name
   name string
   // Set handle number

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -4132,6 +4132,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"nftables.chain.table": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNftablesChain).GetTable()).ToDataRes(types.String)
 	},
+	"nftables.chain.tableRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlNftablesChain).GetTableRef()).ToDataRes(types.Resource("nftables.table"))
+	},
 	"nftables.chain.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNftablesChain).GetName()).ToDataRes(types.String)
 	},
@@ -4162,8 +4165,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"nftables.rule.table": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNftablesRule).GetTable()).ToDataRes(types.String)
 	},
+	"nftables.rule.tableRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlNftablesRule).GetTableRef()).ToDataRes(types.Resource("nftables.table"))
+	},
 	"nftables.rule.chain": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNftablesRule).GetChain()).ToDataRes(types.String)
+	},
+	"nftables.rule.chainRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlNftablesRule).GetChainRef()).ToDataRes(types.Resource("nftables.chain"))
 	},
 	"nftables.rule.handle": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNftablesRule).GetHandle()).ToDataRes(types.Int)
@@ -4179,6 +4188,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"nftables.set.table": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNftablesSet).GetTable()).ToDataRes(types.String)
+	},
+	"nftables.set.tableRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlNftablesSet).GetTableRef()).ToDataRes(types.Resource("nftables.table"))
 	},
 	"nftables.set.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNftablesSet).GetName()).ToDataRes(types.String)
@@ -11744,6 +11756,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlNftablesChain).Table, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"nftables.chain.tableRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlNftablesChain).TableRef, ok = plugin.RawToTValue[*mqlNftablesTable](v.Value, v.Error)
+		return
+	},
 	"nftables.chain.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlNftablesChain).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -11788,8 +11804,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlNftablesRule).Table, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"nftables.rule.tableRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlNftablesRule).TableRef, ok = plugin.RawToTValue[*mqlNftablesTable](v.Value, v.Error)
+		return
+	},
 	"nftables.rule.chain": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlNftablesRule).Chain, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"nftables.rule.chainRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlNftablesRule).ChainRef, ok = plugin.RawToTValue[*mqlNftablesChain](v.Value, v.Error)
 		return
 	},
 	"nftables.rule.handle": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11814,6 +11838,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"nftables.set.table": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlNftablesSet).Table, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"nftables.set.tableRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlNftablesSet).TableRef, ok = plugin.RawToTValue[*mqlNftablesTable](v.Value, v.Error)
 		return
 	},
 	"nftables.set.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -29665,6 +29693,7 @@ type mqlNftablesChain struct {
 	// optional: if you define mqlNftablesChainInternal it will be used here
 	Family      plugin.TValue[string]
 	Table       plugin.TValue[string]
+	TableRef    plugin.TValue[*mqlNftablesTable]
 	Name        plugin.TValue[string]
 	Handle      plugin.TValue[int64]
 	Type        plugin.TValue[string]
@@ -29720,6 +29749,22 @@ func (c *mqlNftablesChain) GetTable() *plugin.TValue[string] {
 	return &c.Table
 }
 
+func (c *mqlNftablesChain) GetTableRef() *plugin.TValue[*mqlNftablesTable] {
+	return plugin.GetOrCompute[*mqlNftablesTable](&c.TableRef, func() (*mqlNftablesTable, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("nftables.chain", c.__id, "tableRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlNftablesTable), nil
+			}
+		}
+
+		return c.tableRef()
+	})
+}
+
 func (c *mqlNftablesChain) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
@@ -29757,12 +29802,14 @@ type mqlNftablesRule struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlNftablesRuleInternal it will be used here
-	Family  plugin.TValue[string]
-	Table   plugin.TValue[string]
-	Chain   plugin.TValue[string]
-	Handle  plugin.TValue[int64]
-	Expr    plugin.TValue[[]any]
-	Comment plugin.TValue[string]
+	Family   plugin.TValue[string]
+	Table    plugin.TValue[string]
+	TableRef plugin.TValue[*mqlNftablesTable]
+	Chain    plugin.TValue[string]
+	ChainRef plugin.TValue[*mqlNftablesChain]
+	Handle   plugin.TValue[int64]
+	Expr     plugin.TValue[[]any]
+	Comment  plugin.TValue[string]
 }
 
 // createNftablesRule creates a new instance of this resource
@@ -29810,8 +29857,40 @@ func (c *mqlNftablesRule) GetTable() *plugin.TValue[string] {
 	return &c.Table
 }
 
+func (c *mqlNftablesRule) GetTableRef() *plugin.TValue[*mqlNftablesTable] {
+	return plugin.GetOrCompute[*mqlNftablesTable](&c.TableRef, func() (*mqlNftablesTable, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("nftables.rule", c.__id, "tableRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlNftablesTable), nil
+			}
+		}
+
+		return c.tableRef()
+	})
+}
+
 func (c *mqlNftablesRule) GetChain() *plugin.TValue[string] {
 	return &c.Chain
+}
+
+func (c *mqlNftablesRule) GetChainRef() *plugin.TValue[*mqlNftablesChain] {
+	return plugin.GetOrCompute[*mqlNftablesChain](&c.ChainRef, func() (*mqlNftablesChain, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("nftables.rule", c.__id, "chainRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlNftablesChain), nil
+			}
+		}
+
+		return c.chainRef()
+	})
 }
 
 func (c *mqlNftablesRule) GetHandle() *plugin.TValue[int64] {
@@ -29833,6 +29912,7 @@ type mqlNftablesSet struct {
 	// optional: if you define mqlNftablesSetInternal it will be used here
 	Family    plugin.TValue[string]
 	Table     plugin.TValue[string]
+	TableRef  plugin.TValue[*mqlNftablesTable]
 	Name      plugin.TValue[string]
 	Handle    plugin.TValue[int64]
 	KeyType   plugin.TValue[string]
@@ -29886,6 +29966,22 @@ func (c *mqlNftablesSet) GetFamily() *plugin.TValue[string] {
 
 func (c *mqlNftablesSet) GetTable() *plugin.TValue[string] {
 	return &c.Table
+}
+
+func (c *mqlNftablesSet) GetTableRef() *plugin.TValue[*mqlNftablesTable] {
+	return plugin.GetOrCompute[*mqlNftablesTable](&c.TableRef, func() (*mqlNftablesTable, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("nftables.set", c.__id, "tableRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlNftablesTable), nil
+			}
+		}
+
+		return c.tableRef()
+	})
 }
 
 func (c *mqlNftablesSet) GetName() *plugin.TValue[string] {

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -1378,15 +1378,18 @@ nftables.chain.policy 11.8.14
 nftables.chain.prio 11.8.14
 nftables.chain.rules 11.8.14
 nftables.chain.table 11.8.14
+nftables.chain.tableRef 13.17.1
 nftables.chain.type 11.8.14
 nftables.chains 13.2.9
 nftables.rule 11.8.14
 nftables.rule.chain 11.8.14
+nftables.rule.chainRef 13.17.1
 nftables.rule.comment 11.8.14
 nftables.rule.expr 11.8.14
 nftables.rule.family 11.8.14
 nftables.rule.handle 11.8.14
 nftables.rule.table 11.8.14
+nftables.rule.tableRef 13.17.1
 nftables.rules 13.2.9
 nftables.set 13.2.9
 nftables.set.elements 13.2.9
@@ -1397,6 +1400,7 @@ nftables.set.isMap 13.2.9
 nftables.set.keyType 13.2.9
 nftables.set.name 13.2.9
 nftables.set.table 13.2.9
+nftables.set.tableRef 13.17.1
 nftables.set.timeout 13.2.9
 nftables.set.valueType 13.2.9
 nftables.sets 13.2.9


### PR DESCRIPTION
## Summary

Adds backwards-compatible cross-resource accessors so audits can traverse the nftables graph instead of carrying parent names around manually.

- `nftables.chain.tableRef -> nftables.table`
- `nftables.rule.tableRef  -> nftables.table`
- `nftables.rule.chainRef  -> nftables.chain`
- `nftables.set.tableRef   -> nftables.table`

The existing string fields (`table`, `chain`) are kept and re-described as the *name* of the parent, so prior queries continue to compile. New `.lr.versions` entries land at `13.18.1`.

### Why

Without typed refs, an auditor who has a `nftables.rule` cannot reach the policy of its base chain or the flags of its table without either re-fetching by name or hard-coding the parent context. The refs make queries like

```mql
nftables.rules.where(chainRef.policy == "accept" && chainRef.hook == "input")
```

natural — same shape as the typed refs in our cloud providers.

### Implementation

Each `*Ref` accessor calls `NewResource(...)` with just the parent's id fields. The runtime computes the same `__id` and returns the cached parent that `tables()` already populated when the user reached the rule/chain/set. No `init` is needed because every user-facing access path to chains/rules/sets transitively goes through `nftables.tables()` first.

## Test plan

- [ ] `make providers/build/os && make providers/install/os` succeeds
- [ ] Existing `TestParseNft*` / `TestNft*` unit tests pass (`go test ./providers/os/resources/`)
- [ ] On a Linux host with `nft` installed:
  - [ ] `mql run local -c "nftables.rules { chainRef.policy chainRef.hook tableRef.flags }"` returns data
  - [ ] `mql run local -c "nftables.chains.where(tableRef.family == \"inet\")"` filters correctly
  - [ ] Identity check: `nftables.tables[0] == nftables.chains[0].tableRef` when the chain is in the first table (i.e. the typed ref resolves to the cached parent, not a stub)
- [ ] Existing queries using the old string fields (`rule.table`, `rule.chain`, etc.) still compile and run