### PR TITLE
🧹 Revert "rpm: switch queryformat delimiter from __ to ASCII RS (#7818)"

### DIFF
--- a/providers/os/resources/packages/rpm_packages.go
+++ b/providers/os/resources/packages/rpm_packages.go
@@ -31,20 +31,11 @@ const (
 	RpmPkgFormat = "rpm"
 )
 
-// RPM_REGEX uses the ASCII Record Separator (RS, 0x1E) as the field
-// delimiter between the arch and the remaining columns. RS is in the
-// C0 control range and cannot appear in any rpm header tag (rpm rejects
-// non-printable characters in NAME / VENDOR / SUMMARY / LICENSE /
-// MODULARITYLABEL), so it's safe to split on without escaping. The
-// previous `__` separator was a latent risk because a summary or
-// license containing two literal underscores would have been
-// mis-parsed; switching to RS removes that class of failure.
-var RPM_REGEX = regexp.MustCompile(`^([\w-+]*)\s(\d*|\(none\)):([\w\d-+.:]+)\s([\w\d]*|\(none\))\x1e([^\x1e]+?)\x1e([^\x1e]*)\x1e([^\x1e]*)\x1e(\d+|\(none\))(?:\x1e(.+))?$`)
+var RPM_REGEX = regexp.MustCompile(`^([\w-+]*)\s(\d*|\(none\)):([\w\d-+.:]+)\s([\w\d]*|\(none\))__([\w\d\s,/<>:\.|\(none\)]+?)__(.*?)__(.*?)__(\d+|\(none\))(?:__(.+))?$`)
 
 // ParseRpmPackages parses output from:
 // %{MODULARITYLABEL} is only added on supported systems
-// rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}\036%{VENDOR}\036%{SUMMARY}\036%{LICENSE}\036%{INSTALLTIME}\036%{MODULARITYLABEL}\n'
-// (`\036` is the octal escape for ASCII RS that rpm queryformat accepts.)
+// rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}__%{INSTALLTIME}__%{MODULARITYLABEL}\n'
 func ParseRpmPackages(pf *inventory.Platform, input io.Reader) []Package {
 	pkgs := []Package{}
 	scanner := bufio.NewScanner(input)
@@ -227,25 +218,19 @@ func (rpm *RpmPkgManager) queryFormat() string {
 	modularity := ""
 	// Not all rpm based distros support modules, only query when applicable, otherwise we get an error
 	if modularitySupportedByPlatform(rpm.platform) {
-		modularity = `\036%{MODULARITYLABEL}`
+		modularity = "__%{MODULARITYLABEL}"
 	}
 	// this format should work everywhere
 	// fall-back to epoch instead of epochnum for 6 ish platforms, latest 6 platforms also support epochnum, but we
 	// save 1 call by not detecting the available keyword via rpm --querytags
-	//
-	// `\036` is the octal escape for ASCII Record Separator (0x1E).
-	// rpm queryformat passes C-style escape sequences through to the
-	// emitted output; using RS as the field delimiter avoids the
-	// ambiguity that the previous `__` separator had with package
-	// summaries / licenses that happen to contain two underscores.
-	format := `%{NAME} %{EPOCH}:%{VERSION}-%{RELEASE} %{ARCH}\036%{VENDOR}\036%{SUMMARY}\036%{LICENSE}\036%{INSTALLTIME}` + modularity + `\n`
+	format := "%{NAME} %{EPOCH}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}__%{INSTALLTIME}" + modularity + "\\n"
 
 	// ATTENTION: EPOCHNUM is only available since later version of rpm in RedHat 6 and Suse 12
 	// we can only expect if for rhel 7+, therefore we need to run an extra test
 	// be aware that this method is also used for non-redhat systems like suse
 	i, err := strconv.ParseInt(rpm.platform.Version, 0, 32)
 	if err == nil && (rpm.platform.Name == "centos" || rpm.platform.Name == "redhat") && i >= 7 {
-		format = `%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}\036%{VENDOR}\036%{SUMMARY}\036%{LICENSE}\036%{INSTALLTIME}` + modularity + `\n`
+		format = "%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}__%{INSTALLTIME}" + modularity + "\\n"
 	}
 
 	return format

--- a/providers/os/resources/packages/rpm_packages_test.go
+++ b/providers/os/resources/packages/rpm_packages_test.go
@@ -32,7 +32,7 @@ func TestRedhat8Parser(t *testing.T) {
 		},
 	}
 
-	c, err := mock.RunCommand("rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}\\036%{VENDOR}\\036%{SUMMARY}\\036%{LICENSE}\\036%{INSTALLTIME}\\n'")
+	c, err := mock.RunCommand("rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}__%{INSTALLTIME}\\n'")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +223,7 @@ func TestPhoton4ImageParser(t *testing.T) {
 
 	var packageList bytes.Buffer
 	for _, pkg := range pkgList {
-		fmt.Fprintf(&packageList, "%s %d:%s-%s %s\x1e%s\x1e%s\x1e%s\x1e%d\n", pkg.Name, pkg.EpochNum(), pkg.Version, pkg.Release, pkg.Arch, pkg.Vendor, pkg.Summary, pkg.License, pkg.InstallTime)
+		fmt.Fprintf(&packageList, "%s %d:%s-%s %s__%s__%s__%s__%d\n", pkg.Name, pkg.EpochNum(), pkg.Version, pkg.Release, pkg.Arch, pkg.Vendor, pkg.Summary, pkg.License, pkg.InstallTime)
 	}
 
 	pf := &inventory.Platform{
@@ -313,7 +313,7 @@ func TestSuSEParser(t *testing.T) {
 
 	var packageList bytes.Buffer
 	for _, pkg := range pkgList {
-		fmt.Fprintf(&packageList, "%s %d:%s-%s %s\x1e%s\x1e%s\x1e%s\x1e%d\n", pkg.Name, pkg.EpochNum(), pkg.Version, pkg.Release, pkg.Arch, pkg.Vendor, pkg.Summary, pkg.License, pkg.InstallTime)
+		fmt.Fprintf(&packageList, "%s %d:%s-%s %s__%s__%s__%s__%d\n", pkg.Name, pkg.EpochNum(), pkg.Version, pkg.Release, pkg.Arch, pkg.Vendor, pkg.Summary, pkg.License, pkg.InstallTime)
 	}
 
 	pf := &inventory.Platform{
@@ -395,7 +395,7 @@ func TestOracleParser(t *testing.T) {
 		},
 	}
 
-	c, err := mock.RunCommand("rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}\\036%{VENDOR}\\036%{SUMMARY}\\036%{LICENSE}\\036%{INSTALLTIME}\\036%{MODULARITYLABEL}\\n'")
+	c, err := mock.RunCommand("rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}__%{INSTALLTIME}__%{MODULARITYLABEL}\\n'")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -434,7 +434,7 @@ func TestAlmaLinuxParser(t *testing.T) {
 		},
 	}
 
-	c, err := mock.RunCommand("rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}\\036%{VENDOR}\\036%{SUMMARY}\\036%{LICENSE}\\036%{INSTALLTIME}\\036%{MODULARITYLABEL}\\n'")
+	c, err := mock.RunCommand("rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}__%{INSTALLTIME}__%{MODULARITYLABEL}\\n'")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -466,7 +466,7 @@ func TestRedHatModularParser(t *testing.T) {
 		},
 	}
 
-	c, err := mock.RunCommand("rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}\\036%{VENDOR}\\036%{SUMMARY}\\036%{LICENSE}\\036%{INSTALLTIME}\\036%{MODULARITYLABEL}\\n'")
+	c, err := mock.RunCommand("rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}__%{INSTALLTIME}__%{MODULARITYLABEL}\\n'")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/os/resources/packages/testdata/packages_almalinux.toml
+++ b/providers/os/resources/packages/testdata/packages_almalinux.toml
@@ -4,12 +4,12 @@ stdout="/usr/bin/rpm"
 [commands."rpm -E '%{_dbpath}'"]
 stdout="/var/lib/rpm"
 
-[commands."rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}\\036%{VENDOR}\\036%{SUMMARY}\\036%{LICENSE}\\036%{INSTALLTIME}\\036%{MODULARITYLABEL}\\n'"]
+[commands."rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}__%{INSTALLTIME}__%{MODULARITYLABEL}\\n'"]
 stdout="""
-php-xml 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64\u001EAlmaLinux\u001EA module for PHP applications which use XML\u001EGPLv3+\u001E1704067200\u001Ephp:7.4:8100020241212065510:eb0869e2
-php-mbstring 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64\u001EAlmaLinux\u001EA module for PHP applications which need multi-byte string handling\u001EGPLv3+\u001E1704067200\u001Ephp:7.4:8100020241212065510:eb0869e2
-php-common 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64\u001EAlmaLinux\u001ECommon files for PHP\u001EGPLv3+\u001E1704067200\u001Ephp:7.4:8100020241212065510:eb0869e2
-php-cli 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64\u001EAlmaLinux\u001ECommand-line interface for PHP\u001EGPLv3+\u001E1704067200\u001Ephp:7.4:8100020241212065510:eb0869e2
-php-fpm 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64\u001EAlmaLinux\u001EPHP FastCGI Process Manager\u001EGPLv3+\u001E1704067200\u001Ephp:7.4:8100020241212065510:eb0869e2
-php-json 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64\u001EAlmaLinux\u001EJavaScript Object Notation extension for PHP\u001EGPLv3+\u001E1704067200\u001Ephp:7.4:8100020241212065510:eb0869e2
+php-xml 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__A module for PHP applications which use XML__GPLv3+__1704067200__php:7.4:8100020241212065510:eb0869e2
+php-mbstring 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__A module for PHP applications which need multi-byte string handling__GPLv3+__1704067200__php:7.4:8100020241212065510:eb0869e2
+php-common 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__Common files for PHP__GPLv3+__1704067200__php:7.4:8100020241212065510:eb0869e2
+php-cli 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__Command-line interface for PHP__GPLv3+__1704067200__php:7.4:8100020241212065510:eb0869e2
+php-fpm 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__PHP FastCGI Process Manager__GPLv3+__1704067200__php:7.4:8100020241212065510:eb0869e2
+php-json 0:7.4.33-2.module_el8.10.0+3935+28808425 aarch64__AlmaLinux__JavaScript Object Notation extension for PHP__GPLv3+__1704067200__php:7.4:8100020241212065510:eb0869e2
 """

--- a/providers/os/resources/packages/testdata/packages_oracle.toml
+++ b/providers/os/resources/packages/testdata/packages_oracle.toml
@@ -4,10 +4,10 @@ stdout="/usr/bin/rpm"
 [commands."rpm -E '%{_dbpath}'"]
 stdout="/var/lib/rpm"
 
-[commands."rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}\\036%{VENDOR}\\036%{SUMMARY}\\036%{LICENSE}\\036%{INSTALLTIME}\\036%{MODULARITYLABEL}\\n'"]
+[commands."rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}__%{INSTALLTIME}__%{MODULARITYLABEL}\\n'"]
 stdout="""
-adcli 0:0.9.2-1.el9 x86_64\u001EOracle America\u001EActive Directory enrollment\u001EGPLv3+\u001E1704067200\u001E(none)
-at 0:3.1.23-12.el9_6 x86_64\u001EOracle America\u001EJob spooling tools\u001EGPLv3+\u001E1704067200\u001E(none)
-ruby 0:3.1.7-146.module+el9.5.0+90564+273a1edd x86_64\u001EOracle America\u001EAn interpreter of object-oriented scripting language\u001EGPLv3+\u001E1704067200\u001Eruby:3.1:9050020250506050702:2e2f0e1c
-ruby-default-gems 0:3.1.7-146.module+el9.5.0+90564+273a1edd noarch\u001EOracle America\u001EDefault gems which are part of Ruby StdLib\u001EGPLv3+\u001E1704067200\u001Eruby:3.1:9050020250506050702:2e2f0e1c
+adcli 0:0.9.2-1.el9 x86_64__Oracle America__Active Directory enrollment__GPLv3+__1704067200__(none)
+at 0:3.1.23-12.el9_6 x86_64__Oracle America__Job spooling tools__GPLv3+__1704067200__(none)
+ruby 0:3.1.7-146.module+el9.5.0+90564+273a1edd x86_64__Oracle America__An interpreter of object-oriented scripting language__GPLv3+__1704067200__ruby:3.1:9050020250506050702:2e2f0e1c
+ruby-default-gems 0:3.1.7-146.module+el9.5.0+90564+273a1edd noarch__Oracle America__Default gems which are part of Ruby StdLib__GPLv3+__1704067200__ruby:3.1:9050020250506050702:2e2f0e1c
 """

--- a/providers/os/resources/packages/testdata/packages_redhat8.toml
+++ b/providers/os/resources/packages/testdata/packages_redhat8.toml
@@ -4,200 +4,200 @@ stdout="/usr/bin/rpm"
 [commands."rpm -E '%{_dbpath}'"]
 stdout="/var/lib/rpm/rpmdb.sqlite"
 
-[commands."rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}\\036%{VENDOR}\\036%{SUMMARY}\\036%{LICENSE}\\036%{INSTALLTIME}\\n'"]
+[commands."rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}__%{INSTALLTIME}\\n'"]
 stdout="""
-tzdata 0:2021c-1.el8 noarch\u001ERed Hat, Inc.\u001ETimezone data\u001EGPLv3+\u001E1704067200
-python3-pip-wheel 0:9.0.3-19.el8 noarch\u001ERed Hat, Inc.\u001EThe pip wheel\u001EGPLv3+\u001E1704067200
-redhat-release 0:8.4-0.6.el8 x86_64\u001ERed Hat, Inc.\u001ERed Hat Enterprise Linux release file\u001EGPLv3+\u001E1704067200
-filesystem 0:3.8-3.el8 x86_64\u001ERed Hat, Inc.\u001EThe basic directory layout for a Linux system\u001EGPLv3+\u001E1704067200
-publicsuffix-list-dafsa 0:20180723-1.el8 noarch\u001ERed Hat, Inc.\u001ECross-vendor public domain suffix database in DAFSA form\u001EGPLv3+\u001E1704067200
-pcre2 0:10.32-2.el8 x86_64\u001ERed Hat, Inc.\u001EPerl-compatible regular expression library\u001EGPLv3+\u001E1704067200
-ncurses-libs 0:6.1-7.20180224.el8 x86_64\u001ERed Hat, Inc.\u001ENcurses libraries\u001EGPLv3+\u001E1704067200
-glibc-common 0:2.28-151.el8 x86_64\u001ERed Hat, Inc.\u001ECommon binaries and locale data for glibc\u001EGPLv3+\u001E1704067200
-bash 0:4.4.20-1.el8_4 x86_64\u001ERed Hat, Inc.\u001EThe GNU Bourne Again shell\u001EGPLv3+\u001E1704067200
-zlib 0:1.2.11-17.el8 x86_64\u001ERed Hat, Inc.\u001EThe compression and decompression library\u001EGPLv3+\u001E1704067200
-bzip2-libs 0:1.0.6-26.el8 x86_64\u001ERed Hat, Inc.\u001ELibraries for applications using bzip2\u001EGPLv3+\u001E1704067200
-libxml2 0:2.9.7-9.el8_4.2 x86_64\u001ERed Hat, Inc.\u001ELibrary providing XML and HTML support\u001EGPLv3+\u001E1704067200
-libcap 0:2.26-4.el8 x86_64\u001ERed Hat, Inc.\u001ELibrary for getting and setting POSIX.1e capabilities\u001EGPLv3+\u001E1704067200
-libzstd 0:1.4.4-1.el8 x86_64\u001ERed Hat, Inc.\u001EZstd shared library\u001EGPLv3+\u001E1704067200
-elfutils-libelf 0:0.182-3.el8 x86_64\u001ERed Hat, Inc.\u001ELibrary to read and write ELF files\u001EGPLv3+\u001E1704067200
-expat 0:2.2.5-4.el8 x86_64\u001ERed Hat, Inc.\u001EAn XML parser library\u001EGPLv3+\u001E1704067200
-libcom_err 0:1.45.6-1.el8 x86_64\u001ERed Hat, Inc.\u001ECommon error description library\u001EGPLv3+\u001E1704067200
-libuuid 0:2.32.1-27.el8 x86_64\u001ERed Hat, Inc.\u001EUniversally unique ID library\u001EGPLv3+\u001E1704067200
-gmp 1:6.1.2-10.el8 x86_64\u001ERed Hat, Inc.\u001EA GNU arbitrary precision library\u001EGPLv3+\u001E1704067200
-libacl 0:2.2.53-1.el8 x86_64\u001ERed Hat, Inc.\u001EDynamic library for access control list support\u001EGPLv3+\u001E1704067200
-libblkid 0:2.32.1-27.el8 x86_64\u001ERed Hat, Inc.\u001EBlock device ID library\u001EGPLv3+\u001E1704067200
-sed 0:4.5-2.el8 x86_64\u001ERed Hat, Inc.\u001EA GNU stream text editor\u001EGPLv3+\u001E1704067200
-libstdc++ 0:8.4.1-1.el8 x86_64\u001ERed Hat, Inc.\u001EGNU Standard C++ Library\u001EGPLv3+\u001E1704067200
-p11-kit 0:0.23.22-1.el8 x86_64\u001ERed Hat, Inc.\u001ELibrary for loading and sharing PKCS#11 modules\u001EGPLv3+\u001E1704067200
-libunistring 0:0.9.9-3.el8 x86_64\u001ERed Hat, Inc.\u001EGNU Unicode string library\u001EGPLv3+\u001E1704067200
-libgcrypt 0:1.8.5-4.el8 x86_64\u001ERed Hat, Inc.\u001EA general-purpose cryptography library\u001EGPLv3+\u001E1704067200
-libcap-ng 0:0.7.9-5.el8 x86_64\u001ERed Hat, Inc.\u001EAn alternate posix capabilities library\u001EGPLv3+\u001E1704067200
-libnl3 0:3.5.0-1.el8 x86_64\u001ERed Hat, Inc.\u001EConvenience library for kernel netlink sockets\u001EGPLv3+\u001E1704067200
-libassuan 0:2.5.1-3.el8 x86_64\u001ERed Hat, Inc.\u001EGnuPG IPC library\u001EGPLv3+\u001E1704067200
-keyutils-libs 0:1.5.10-6.el8 x86_64\u001ERed Hat, Inc.\u001EKey utilities library\u001EGPLv3+\u001E1704067200
-p11-kit-trust 0:0.23.22-1.el8 x86_64\u001ERed Hat, Inc.\u001ESystem trust module from p11-kit\u001EGPLv3+\u001E1704067200
-grep 0:3.1-6.el8 x86_64\u001ERed Hat, Inc.\u001EPattern matching utilities\u001EGPLv3+\u001E1704067200
-dbus-libs 1:1.12.8-12.el8_4.2 x86_64\u001ERed Hat, Inc.\u001ELibraries for accessing D-BUS\u001EGPLv3+\u001E1704067200
-dbus-tools 1:1.12.8-12.el8_4.2 x86_64\u001ERed Hat, Inc.\u001ED-BUS Tools and Utilities\u001EGPLv3+\u001E1704067200
-gdbm 1:1.18-1.el8 x86_64\u001ERed Hat, Inc.\u001EA GNU set of database routines which use extensible hashing\u001EGPLv3+\u001E1704067200
-shadow-utils 2:4.6-12.el8 x86_64\u001ERed Hat, Inc.\u001EUtilities for managing accounts and shadow password files\u001EGPLv3+\u001E1704067200
-libpsl 0:0.20.2-6.el8 x86_64\u001ERed Hat, Inc.\u001EC library for the Publix Suffix List\u001EGPLv3+\u001E1704067200
-gzip 0:1.9-12.el8 x86_64\u001ERed Hat, Inc.\u001EThe GNU data compression program\u001EGPLv3+\u001E1704067200
-cracklib-dicts 0:2.9.6-15.el8 x86_64\u001ERed Hat, Inc.\u001EThe standard CrackLib dictionaries\u001EGPLv3+\u001E1704067200
-mpfr 0:3.1.6-1.el8 x86_64\u001ERed Hat, Inc.\u001EA C library for multiple-precision floating-point computations\u001EGPLv3+\u001E1704067200
-libcomps 0:0.1.11-5.el8 x86_64\u001ERed Hat, Inc.\u001EComps XML file manipulation library\u001EGPLv3+\u001E1704067200
-brotli 0:1.0.6-3.el8 x86_64\u001ERed Hat, Inc.\u001ELossless compression algorithm\u001EGPLv3+\u001E1704067200
-libnghttp2 0:1.33.0-3.el8_2.1 x86_64\u001ERed Hat, Inc.\u001EA library implementing the HTTP/2 protocol\u001EGPLv3+\u001E1704067200
-libsigsegv 0:2.11-5.el8 x86_64\u001ERed Hat, Inc.\u001ELibrary for handling page faults in user mode\u001EGPLv3+\u001E1704067200
-libverto 0:0.3.0-5.el8 x86_64\u001ERed Hat, Inc.\u001EMain loop abstraction library\u001EGPLv3+\u001E1704067200
-libtirpc 0:1.1.4-4.el8 x86_64\u001ERed Hat, Inc.\u001ETransport Independent RPC Library\u001EGPLv3+\u001E1704067200
-openssl-libs 1:1.1.1g-15.el8_3 x86_64\u001ERed Hat, Inc.\u001EA general purpose cryptography library with TLS implementation\u001EGPLv3+\u001E1704067200
-crypto-policies-scripts 0:20210209-1.gitbfb6bed.el8_3 noarch\u001ERed Hat, Inc.\u001ETool to switch between crypto policies\u001EGPLv3+\u001E1704067200
-platform-python 0:3.6.8-39.el8_4 x86_64\u001ERed Hat, Inc.\u001EInternal interpreter of the Python programming language\u001EGPLv3+\u001E1704067200
-libdb 0:5.3.28-42.el8_4 x86_64\u001ERed Hat, Inc.\u001EThe Berkeley DB database library for C\u001EGPLv3+\u001E1704067200
-pam 0:1.3.1-14.el8 x86_64\u001ERed Hat, Inc.\u001EAn extensible library which provides authentication for applications\u001EGPLv3+\u001E1704067200
-util-linux 0:2.32.1-27.el8 x86_64\u001ERed Hat, Inc.\u001EA collection of basic system utilities\u001EGPLv3+\u001E1704067200
-gnutls 0:3.6.14-8.el8_3 x86_64\u001ERed Hat, Inc.\u001EA TLS protocol implementation\u001EGPLv3+\u001E1704067200
-json-glib 0:1.4.4-1.el8 x86_64\u001ERed Hat, Inc.\u001ELibrary for JavaScript Object Notation format\u001EGPLv3+\u001E1704067200
-python3-iniparse 0:0.4-31.el8 noarch\u001ERed Hat, Inc.\u001EPython Module for Accessing and Modifying Configuration Data in INI files\u001EGPLv3+\u001E1704067200
-dbus-glib 0:0.110-2.el8 x86_64\u001ERed Hat, Inc.\u001EGLib bindings for D-Bus\u001EGPLv3+\u001E1704067200
-gobject-introspection 0:1.56.1-1.el8 x86_64\u001ERed Hat, Inc.\u001EIntrospection system for GObject-based libraries\u001EGPLv3+\u001E1704067200
-cyrus-sasl-lib 0:2.1.27-5.el8 x86_64\u001ERed Hat, Inc.\u001EShared libraries needed by applications which use Cyrus SASL\u001EGPLv3+\u001E1704067200
-libuser 0:0.62-23.el8 x86_64\u001ERed Hat, Inc.\u001EA user and group account administration library\u001EGPLv3+\u001E1704067200
-usermode 0:1.113-1.el8 x86_64\u001ERed Hat, Inc.\u001ETools for certain user account management tasks\u001EGPLv3+\u001E1704067200
-python3-ethtool 0:0.14-3.el8 x86_64\u001ERed Hat, Inc.\u001EPython module to interface with ethtool\u001EGPLv3+\u001E1704067200
-python3-libxml2 0:2.9.7-9.el8_4.2 x86_64\u001ERed Hat, Inc.\u001EPython 3 bindings for the libxml2 library\u001EGPLv3+\u001E1704067200
-python3-chardet 0:3.0.4-7.el8 noarch\u001ERed Hat, Inc.\u001ECharacter encoding auto-detection in Python 3\u001EGPLv3+\u001E1704067200
-python3-idna 0:2.5-5.el8 noarch\u001ERed Hat, Inc.\u001EInternationalized Domain Names in Applications (IDNA)\u001EGPLv3+\u001E1704067200
-python3-pysocks 0:1.6.8-3.el8 noarch\u001ERed Hat, Inc.\u001EA Python SOCKS client module\u001EGPLv3+\u001E1704067200
-python3-requests 0:2.20.0-2.1.el8_1 noarch\u001ERed Hat, Inc.\u001EHTTP library, written in Python, for human beings\u001EGPLv3+\u001E1704067200
-libarchive 0:3.3.3-1.el8 x86_64\u001ERed Hat, Inc.\u001EA library for handling streaming archive formats\u001EGPLv3+\u001E1704067200
-ima-evm-utils 0:1.3.2-12.el8 x86_64\u001ERed Hat, Inc.\u001EIMA/EVM support utilities\u001EGPLv3+\u001E1704067200
-npth 0:1.5-4.el8 x86_64\u001ERed Hat, Inc.\u001EThe New GNU Portable Threads library\u001EGPLv3+\u001E1704067200
-gpgme 0:1.13.1-7.el8 x86_64\u001ERed Hat, Inc.\u001EGnuPG Made Easy - high level crypto API\u001EGPLv3+\u001E1704067200
-pciutils-libs 0:3.7.0-1.el8 x86_64\u001ERed Hat, Inc.\u001ELinux PCI library\u001EGPLv3+\u001E1704067200
-virt-what 0:1.18-9.el8_4 x86_64\u001ERed Hat, Inc.\u001EDetect if we are running in a virtual machine\u001EGPLv3+\u001E1704067200
-libssh 0:0.9.4-2.el8 x86_64\u001ERed Hat, Inc.\u001EA library implementing the SSH protocol\u001EGPLv3+\u001E1704067200
-librepo 0:1.12.0-3.el8 x86_64\u001ERed Hat, Inc.\u001ERepodata downloading library\u001EGPLv3+\u001E1704067200
-curl 0:7.61.1-18.el8_4.2 x86_64\u001ERed Hat, Inc.\u001EA utility for getting files from remote servers (FTP, HTTP, and others)\u001EGPLv3+\u001E1704067200
-rpm-libs 0:4.14.3-14.el8_4 x86_64\u001ERed Hat, Inc.\u001ELibraries for manipulating RPM packages\u001EGPLv3+\u001E1704067200
-libsolv 0:0.7.16-3.el8_4 x86_64\u001ERed Hat, Inc.\u001EPackage dependency solver\u001EGPLv3+\u001E1704067200
-python3-libdnf 0:0.55.0-7.el8 x86_64\u001ERed Hat, Inc.\u001EPython 3 bindings for the libdnf library.\u001EGPLv3+\u001E1704067200
-libreport-filesystem 0:2.9.5-15.el8 x86_64\u001ERed Hat, Inc.\u001EFilesystem layout for libreport\u001EGPLv3+\u001E1704067200
-hwdata 0:0.314-8.8.el8 noarch\u001ERed Hat, Inc.\u001EHardware identification and configuration data\u001EGPLv3+\u001E1704067200
-rdma-core 0:32.0-4.el8 x86_64\u001ERed Hat, Inc.\u001ERDMA core userspace libraries and daemons\u001EGPLv3+\u001E1704067200
-libpcap 14:1.9.1-5.el8 x86_64\u001ERed Hat, Inc.\u001EA system-independent interface for user-level packet capture\u001EGPLv3+\u001E1704067200
-dbus-common 1:1.12.8-12.el8_4.2 noarch\u001ERed Hat, Inc.\u001ED-BUS message bus configuration\u001EGPLv3+\u001E1704067200
-device-mapper 8:1.02.175-5.el8 x86_64\u001ERed Hat, Inc.\u001EDevice mapper utility\u001EGPLv3+\u001E1704067200
-cryptsetup-libs 0:2.3.3-4.el8 x86_64\u001ERed Hat, Inc.\u001ECryptsetup shared library\u001EGPLv3+\u001E1704067200
-elfutils-libs 0:0.182-3.el8 x86_64\u001ERed Hat, Inc.\u001ELibraries to handle compiled objects\u001EGPLv3+\u001E1704067200
-systemd 0:239-45.el8_4.3 x86_64\u001ERed Hat, Inc.\u001ESystem and Service Manager\u001EGPLv3+\u001E1704067200
-rpm-build-libs 0:4.14.3-14.el8_4 x86_64\u001ERed Hat, Inc.\u001ELibraries for building and signing RPM packages\u001EGPLv3+\u001E1704067200
-python3-dnf 0:4.4.2-11.el8 noarch\u001ERed Hat, Inc.\u001EPython 3 interface to DNF\u001EGPLv3+\u001E1704067200
-python3-dnf-plugins-core 0:4.0.18-4.el8 noarch\u001ERed Hat, Inc.\u001ECore Plugins for DNF\u001EGPLv3+\u001E1704067200
-python3-subscription-manager-rhsm 0:1.28.13-4.el8_4 x86_64\u001ERed Hat, Inc.\u001EA Python library to communicate with a Red Hat Unified Entitlement Platform\u001EGPLv3+\u001E1704067200
-yum 0:4.4.2-11.el8 noarch\u001ERed Hat, Inc.\u001EPackage manager\u001EGPLv3+\u001E1704067200
-tar 2:1.30-5.el8 x86_64\u001ERed Hat, Inc.\u001EA GNU file archiving program\u001EGPLv3+\u001E1704067200
-findutils 1:4.6.0-20.el8 x86_64\u001ERed Hat, Inc.\u001EThe GNU versions of find utilities (find and xargs)\u001EGPLv3+\u001E1704067200
-rootfiles 0:8.1-22.el8 noarch\u001ERed Hat, Inc.\u001EThe basic required files for the root user's directory\u001EGPLv3+\u001E1704067200
-gpg-pubkey 0:d4082792-5b32db75 (none)\u001E(none)\u001Egpg(Red Hat, Inc. (auxiliary key) <security@redhat.com>)\u001E(none)\u001E(none)
-libgcc 0:8.4.1-1.el8 x86_64\u001ERed Hat, Inc.\u001EGCC version 8 shared support library\u001EGPLv3+\u001E1704067200
-python3-setuptools-wheel 0:39.2.0-6.el8 noarch\u001ERed Hat, Inc.\u001EThe setuptools wheel\u001EGPLv3+\u001E1704067200
-subscription-manager-rhsm-certificates 0:1.28.13-4.el8_4 x86_64\u001ERed Hat, Inc.\u001ECertificates required to communicate with a Red Hat Unified Entitlement Platform\u001EGPLv3+\u001E1704067200
-setup 0:2.12.2-6.el8 noarch\u001ERed Hat, Inc.\u001EA set of system configuration and setup files\u001EGPLv3+\u001E1704067200
-basesystem 0:11-5.el8 noarch\u001ERed Hat, Inc.\u001EThe skeleton package which defines a simple Red Hat Enterprise Linux system\u001EGPLv3+\u001E1704067200
-ncurses-base 0:6.1-7.20180224.el8 noarch\u001ERed Hat, Inc.\u001EDescriptions of common terminals\u001EGPLv3+\u001E1704067200
-libselinux 0:2.9-5.el8 x86_64\u001ERed Hat, Inc.\u001ESELinux library and simple utilities\u001EGPLv3+\u001E1704067200
-glibc-minimal-langpack 0:2.28-151.el8 x86_64\u001ERed Hat, Inc.\u001EMinimal language packs for glibc.\u001EGPLv3+\u001E1704067200
-glibc 0:2.28-151.el8 x86_64\u001ERed Hat, Inc.\u001EThe GNU libc libraries\u001EGPLv3+\u001E1704067200
-libsepol 0:2.9-2.el8 x86_64\u001ERed Hat, Inc.\u001ESELinux binary policy manipulation library\u001EGPLv3+\u001E1704067200
-xz-libs 0:5.2.4-3.el8 x86_64\u001ERed Hat, Inc.\u001ELibraries for decoding LZMA compression\u001EGPLv3+\u001E1704067200
-libgpg-error 0:1.31-1.el8 x86_64\u001ERed Hat, Inc.\u001ELibrary for error values used by GnuPG components\u001EGPLv3+\u001E1704067200
-info 0:6.5-6.el8 x86_64\u001ERed Hat, Inc.\u001EA stand-alone TTY-based reader for GNU texinfo documentation\u001EGPLv3+\u001E1704067200
-libxcrypt 0:4.1.1-4.el8 x86_64\u001ERed Hat, Inc.\u001EExtended crypt library for DES, MD5, Blowfish and others\u001EGPLv3+\u001E1704067200
-popt 0:1.18-1.el8 x86_64\u001ERed Hat, Inc.\u001EC library for parsing command line parameters\u001EGPLv3+\u001E1704067200
-sqlite-libs 0:3.26.0-13.el8 x86_64\u001ERed Hat, Inc.\u001EShared library for the sqlite3 embeddable SQL database engine.\u001EGPLv3+\u001E1704067200
-json-c 0:0.13.1-0.4.el8 x86_64\u001ERed Hat, Inc.\u001EJSON implementation in C\u001EGPLv3+\u001E1704067200
-libffi 0:3.1-22.el8 x86_64\u001ERed Hat, Inc.\u001EA portable foreign function interface library\u001EGPLv3+\u001E1704067200
-readline 0:7.0-10.el8 x86_64\u001ERed Hat, Inc.\u001EA library for editing typed command lines\u001EGPLv3+\u001E1704067200
-libattr 0:2.4.48-3.el8 x86_64\u001ERed Hat, Inc.\u001EDynamic library for extended attribute support\u001EGPLv3+\u001E1704067200
-coreutils-single 0:8.30-8.el8 x86_64\u001ERed Hat, Inc.\u001Ecoreutils multicall binary\u001EGPLv3+\u001E1704067200
-libmount 0:2.32.1-27.el8 x86_64\u001ERed Hat, Inc.\u001EDevice mounting library\u001EGPLv3+\u001E1704067200
-libsmartcols 0:2.32.1-27.el8 x86_64\u001ERed Hat, Inc.\u001EFormatting library for ls-like programs.\u001EGPLv3+\u001E1704067200
-lua-libs 0:5.3.4-11.el8 x86_64\u001ERed Hat, Inc.\u001ELibraries for lua\u001EGPLv3+\u001E1704067200
-chkconfig 0:1.13-2.el8 x86_64\u001ERed Hat, Inc.\u001EA system tool for maintaining the /etc/rc*.d hierarchy\u001EGPLv3+\u001E1704067200
-libidn2 0:2.2.0-1.el8 x86_64\u001ERed Hat, Inc.\u001ELibrary to support IDNA2008 internationalized domain names\u001EGPLv3+\u001E1704067200
-file-libs 0:5.33-16.el8_3.1 x86_64\u001ERed Hat, Inc.\u001ELibraries for applications using libmagic\u001EGPLv3+\u001E1704067200
-audit-libs 0:3.0-0.17.20191104git1c2f876.el8 x86_64\u001ERed Hat, Inc.\u001EDynamic library for libaudit\u001EGPLv3+\u001E1704067200
-lz4-libs 0:1.8.3-3.el8_4 x86_64\u001ERed Hat, Inc.\u001ELibaries for lz4\u001EGPLv3+\u001E1704067200
-gdbm-libs 1:1.18-1.el8 x86_64\u001ERed Hat, Inc.\u001ELibraries files for gdbm\u001EGPLv3+\u001E1704067200
-libtasn1 0:4.13-3.el8 x86_64\u001ERed Hat, Inc.\u001EThe ASN.1 library used in GNUTLS\u001EGPLv3+\u001E1704067200
-pcre 0:8.42-4.el8 x86_64\u001ERed Hat, Inc.\u001EPerl-compatible regular expression library\u001EGPLv3+\u001E1704067200
-systemd-libs 0:239-45.el8_4.3 x86_64\u001ERed Hat, Inc.\u001Esystemd libraries\u001EGPLv3+\u001E1704067200
-ca-certificates 0:2021.2.50-80.0.el8_4 noarch\u001ERed Hat, Inc.\u001EThe Mozilla CA root certificate bundle\u001EGPLv3+\u001E1704067200
-libusbx 0:1.0.23-4.el8 x86_64\u001ERed Hat, Inc.\u001ELibrary for accessing USB devices\u001EGPLv3+\u001E1704067200
-libsemanage 0:2.9-6.el8 x86_64\u001ERed Hat, Inc.\u001ESELinux binary policy manipulation library\u001EGPLv3+\u001E1704067200
-libutempter 0:1.1.6-14.el8 x86_64\u001ERed Hat, Inc.\u001EA privileged helper for utmp/wtmp updates\u001EGPLv3+\u001E1704067200
-libfdisk 0:2.32.1-27.el8 x86_64\u001ERed Hat, Inc.\u001EPartitioning library for fdisk-like programs.\u001EGPLv3+\u001E1704067200
-cracklib 0:2.9.6-15.el8 x86_64\u001ERed Hat, Inc.\u001EA password-checking library\u001EGPLv3+\u001E1704067200
-acl 0:2.2.53-1.el8 x86_64\u001ERed Hat, Inc.\u001EAccess control list utilities\u001EGPLv3+\u001E1704067200
-nettle 0:3.4.1-4.el8_3 x86_64\u001ERed Hat, Inc.\u001EA low-level cryptographic library\u001EGPLv3+\u001E1704067200
-libksba 0:1.3.5-7.el8 x86_64\u001ERed Hat, Inc.\u001ECMS and X.509 library\u001EGPLv3+\u001E1704067200
-dmidecode 1:3.2-8.el8 x86_64\u001ERed Hat, Inc.\u001ETool to analyse BIOS DMI data\u001EGPLv3+\u001E1704067200
-libseccomp 0:2.5.1-1.el8 x86_64\u001ERed Hat, Inc.\u001EEnhanced seccomp library\u001EGPLv3+\u001E1704067200
-gawk 0:4.2.1-2.el8 x86_64\u001ERed Hat, Inc.\u001EThe GNU version of the AWK text processing utility\u001EGPLv3+\u001E1704067200
-libnsl2 0:1.2.0-2.20180605git4a062cf.el8 x86_64\u001ERed Hat, Inc.\u001EPublic client interface library for NIS(YP) and NIS+\u001EGPLv3+\u001E1704067200
-krb5-libs 0:1.18.2-8.3.el8_4 x86_64\u001ERed Hat, Inc.\u001EThe non-admin shared libraries used by Kerberos 5\u001EGPLv3+\u001E1704067200
-crypto-policies 0:20210209-1.gitbfb6bed.el8_3 noarch\u001ERed Hat, Inc.\u001ESystem-wide crypto policies\u001EGPLv3+\u001E1704067200
-platform-python-setuptools 0:39.2.0-6.el8 noarch\u001ERed Hat, Inc.\u001EEasily build and distribute Python 3 packages\u001EGPLv3+\u001E1704067200
-python3-libs 0:3.6.8-39.el8_4 x86_64\u001ERed Hat, Inc.\u001EPython runtime libraries\u001EGPLv3+\u001E1704067200
-libpwquality 0:1.4.4-3.el8 x86_64\u001ERed Hat, Inc.\u001EA library for password generation and password quality checking\u001EGPLv3+\u001E1704067200
-python3-six 0:1.11.0-8.el8 noarch\u001ERed Hat, Inc.\u001EPython 2 and 3 compatibility utilities\u001EGPLv3+\u001E1704067200
-python3-dateutil 1:2.6.1-6.el8 noarch\u001ERed Hat, Inc.\u001EPowerful extensions to the standard datetime module\u001EGPLv3+\u001E1704067200
-glib2 0:2.56.4-10.el8_4.1 x86_64\u001ERed Hat, Inc.\u001EA library of handy utility functions\u001EGPLv3+\u001E1704067200
-librhsm 0:0.0.3-4.el8 x86_64\u001ERed Hat, Inc.\u001ERed Hat Subscription Manager library\u001EGPLv3+\u001E1704067200
-kmod-libs 0:25-17.el8 x86_64\u001ERed Hat, Inc.\u001ELibraries to handle kernel module loading and unloading\u001EGPLv3+\u001E1704067200
-python3-dbus 0:1.2.4-15.el8 x86_64\u001ERed Hat, Inc.\u001ED-Bus bindings for python3\u001EGPLv3+\u001E1704067200
-python3-gobject-base 0:3.28.3-2.el8 x86_64\u001ERed Hat, Inc.\u001EPython 3 bindings for GObject Introspection base package\u001EGPLv3+\u001E1704067200
-openldap 0:2.4.46-17.el8_4 x86_64\u001ERed Hat, Inc.\u001ELDAP support libraries\u001EGPLv3+\u001E1704067200
-passwd 0:0.80-3.el8 x86_64\u001ERed Hat, Inc.\u001EAn utility for setting or changing passwords using PAM\u001EGPLv3+\u001E1704067200
-libdb-utils 0:5.3.28-42.el8_4 x86_64\u001ERed Hat, Inc.\u001ECommand line tools for managing Berkeley DB databases\u001EGPLv3+\u001E1704067200
-python3-libcomps 0:0.1.11-5.el8 x86_64\u001ERed Hat, Inc.\u001EPython 3 bindings for libcomps library\u001EGPLv3+\u001E1704067200
-python3-dmidecode 0:3.12.2-15.el8 x86_64\u001ERed Hat, Inc.\u001EPython 3 module to access DMI data\u001EGPLv3+\u001E1704067200
-python3-decorator 0:4.2.1-2.el8 noarch\u001ERed Hat, Inc.\u001EModule to simplify usage of decorators in python3\u001EGPLv3+\u001E1704067200
-python3-inotify 0:0.9.6-13.el8 noarch\u001ERed Hat, Inc.\u001EMonitor filesystem events with Python under Linux\u001EGPLv3+\u001E1704067200
-python3-urllib3 0:1.24.2-5.el8 noarch\u001ERed Hat, Inc.\u001EPython3 HTTP library with thread-safe connection pooling and file post\u001EGPLv3+\u001E1704067200
-python3-syspurpose 0:1.28.13-4.el8_4 x86_64\u001ERed Hat, Inc.\u001EA commandline utility for declaring system syspurpose\u001EGPLv3+\u001E1704067200
-tpm2-tss 0:2.3.2-3.el8 x86_64\u001ERed Hat, Inc.\u001ETPM2.0 Software Stack\u001EGPLv3+\u001E1704067200
-libyaml 0:0.1.7-5.el8 x86_64\u001ERed Hat, Inc.\u001EYAML 1.1 parser and emitter written in C\u001EGPLv3+\u001E1704067200
-gnupg2 0:2.2.20-2.el8 x86_64\u001ERed Hat, Inc.\u001EUtility for secure communication and data storage\u001EGPLv3+\u001E1704067200
-python3-gpg 0:1.13.1-7.el8 x86_64\u001ERed Hat, Inc.\u001Egpgme bindings for Python 3\u001EGPLv3+\u001E1704067200
-which 0:2.21-12.el8 x86_64\u001ERed Hat, Inc.\u001EDisplays where a particular program in your path is located\u001EGPLv3+\u001E1704067200
-libssh-config 0:0.9.4-2.el8 noarch\u001ERed Hat, Inc.\u001EConfiguration files for libssh\u001EGPLv3+\u001E1704067200
-libcurl 0:7.61.1-18.el8_4.2 x86_64\u001ERed Hat, Inc.\u001EA library for getting files from web servers\u001EGPLv3+\u001E1704067200
-python3-librepo 0:1.12.0-3.el8 x86_64\u001ERed Hat, Inc.\u001EPython 3 bindings for the librepo library\u001EGPLv3+\u001E1704067200
-rpm 0:4.14.3-14.el8_4 x86_64\u001ERed Hat, Inc.\u001EThe RPM package management system\u001EGPLv3+\u001E1704067200
-libmodulemd 0:2.9.4-2.el8 x86_64\u001ERed Hat, Inc.\u001EModule metadata manipulation library\u001EGPLv3+\u001E1704067200
-libdnf 0:0.55.0-7.el8 x86_64\u001ERed Hat, Inc.\u001ELibrary providing simplified C and Python API to libsolv\u001EGPLv3+\u001E1704067200
-python3-hawkey 0:0.55.0-7.el8 x86_64\u001ERed Hat, Inc.\u001EPython 3 bindings for the hawkey library\u001EGPLv3+\u001E1704067200
-dnf-data 0:4.4.2-11.el8 noarch\u001ERed Hat, Inc.\u001ECommon data and configuration files for DNF\u001EGPLv3+\u001E1704067200
-pciutils 0:3.7.0-1.el8 x86_64\u001ERed Hat, Inc.\u001EPCI bus related utilities\u001EGPLv3+\u001E1704067200
-libibverbs 0:32.0-4.el8 x86_64\u001ERed Hat, Inc.\u001EA library and drivers for direct userspace use of RDMA (InfiniBand/iWARP/RoCE) hardware\u001EGPLv3+\u001E1704067200
-iptables-libs 0:1.8.4-17.el8_4.1 x86_64\u001ERed Hat, Inc.\u001Eiptables libraries\u001EGPLv3+\u001E1704067200
-dbus-daemon 1:1.12.8-12.el8_4.2 x86_64\u001ERed Hat, Inc.\u001ED-BUS message bus\u001EGPLv3+\u001E1704067200
-device-mapper-libs 8:1.02.175-5.el8 x86_64\u001ERed Hat, Inc.\u001EDevice-mapper shared library\u001EGPLv3+\u001E1704067200
-elfutils-default-yama-scope 0:0.182-3.el8 noarch\u001ERed Hat, Inc.\u001EDefault yama attach scope sysctl setting\u001EGPLv3+\u001E1704067200
-systemd-pam 0:239-45.el8_4.3 x86_64\u001ERed Hat, Inc.\u001Esystemd PAM module\u001EGPLv3+\u001E1704067200
-dbus 1:1.12.8-12.el8_4.2 x86_64\u001ERed Hat, Inc.\u001ED-BUS message bus\u001EGPLv3+\u001E1704067200
-python3-rpm 0:4.14.3-14.el8_4 x86_64\u001ERed Hat, Inc.\u001EPython 3 bindings for apps which will manipulate RPM packages\u001EGPLv3+\u001E1704067200
-dnf 0:4.4.2-11.el8 noarch\u001ERed Hat, Inc.\u001EPackage manager\u001EGPLv3+\u001E1704067200
-dnf-plugin-subscription-manager 0:1.28.13-4.el8_4 x86_64\u001ERed Hat, Inc.\u001ESubscription Manager plugins for DNF\u001EGPLv3+\u001E1704067200
-subscription-manager 0:1.28.13-4.el8_4 x86_64\u001ERed Hat, Inc.\u001ETools and libraries for subscription and repository management\u001EGPLv3+\u001E1704067200
-gdb-gdbserver 0:8.2-15.el8 x86_64\u001ERed Hat, Inc.\u001EA standalone server for GDB (the GNU source-level debugger)\u001EGPLv3+\u001E1704067200
-vim-minimal 2:8.0.1763-15.el8 x86_64\u001ERed Hat, Inc.\u001EA minimal version of the VIM editor\u001EGPLv3+\u001E1704067200
-langpacks-en 0:1.0-12.el8 noarch\u001ERed Hat, Inc.\u001EEnglish langpacks meta-package\u001EGPLv3+\u001E1704067200
-gpg-pubkey 0:fd431d51-4ae0493b (none)\u001E(none)\u001Egpg(Red Hat, Inc. (release key 2) <security@redhat.com>)\u001E(none)\u001E(none)
+tzdata 0:2021c-1.el8 noarch__Red Hat, Inc.__Timezone data__GPLv3+__1704067200
+python3-pip-wheel 0:9.0.3-19.el8 noarch__Red Hat, Inc.__The pip wheel__GPLv3+__1704067200
+redhat-release 0:8.4-0.6.el8 x86_64__Red Hat, Inc.__Red Hat Enterprise Linux release file__GPLv3+__1704067200
+filesystem 0:3.8-3.el8 x86_64__Red Hat, Inc.__The basic directory layout for a Linux system__GPLv3+__1704067200
+publicsuffix-list-dafsa 0:20180723-1.el8 noarch__Red Hat, Inc.__Cross-vendor public domain suffix database in DAFSA form__GPLv3+__1704067200
+pcre2 0:10.32-2.el8 x86_64__Red Hat, Inc.__Perl-compatible regular expression library__GPLv3+__1704067200
+ncurses-libs 0:6.1-7.20180224.el8 x86_64__Red Hat, Inc.__Ncurses libraries__GPLv3+__1704067200
+glibc-common 0:2.28-151.el8 x86_64__Red Hat, Inc.__Common binaries and locale data for glibc__GPLv3+__1704067200
+bash 0:4.4.20-1.el8_4 x86_64__Red Hat, Inc.__The GNU Bourne Again shell__GPLv3+__1704067200
+zlib 0:1.2.11-17.el8 x86_64__Red Hat, Inc.__The compression and decompression library__GPLv3+__1704067200
+bzip2-libs 0:1.0.6-26.el8 x86_64__Red Hat, Inc.__Libraries for applications using bzip2__GPLv3+__1704067200
+libxml2 0:2.9.7-9.el8_4.2 x86_64__Red Hat, Inc.__Library providing XML and HTML support__GPLv3+__1704067200
+libcap 0:2.26-4.el8 x86_64__Red Hat, Inc.__Library for getting and setting POSIX.1e capabilities__GPLv3+__1704067200
+libzstd 0:1.4.4-1.el8 x86_64__Red Hat, Inc.__Zstd shared library__GPLv3+__1704067200
+elfutils-libelf 0:0.182-3.el8 x86_64__Red Hat, Inc.__Library to read and write ELF files__GPLv3+__1704067200
+expat 0:2.2.5-4.el8 x86_64__Red Hat, Inc.__An XML parser library__GPLv3+__1704067200
+libcom_err 0:1.45.6-1.el8 x86_64__Red Hat, Inc.__Common error description library__GPLv3+__1704067200
+libuuid 0:2.32.1-27.el8 x86_64__Red Hat, Inc.__Universally unique ID library__GPLv3+__1704067200
+gmp 1:6.1.2-10.el8 x86_64__Red Hat, Inc.__A GNU arbitrary precision library__GPLv3+__1704067200
+libacl 0:2.2.53-1.el8 x86_64__Red Hat, Inc.__Dynamic library for access control list support__GPLv3+__1704067200
+libblkid 0:2.32.1-27.el8 x86_64__Red Hat, Inc.__Block device ID library__GPLv3+__1704067200
+sed 0:4.5-2.el8 x86_64__Red Hat, Inc.__A GNU stream text editor__GPLv3+__1704067200
+libstdc++ 0:8.4.1-1.el8 x86_64__Red Hat, Inc.__GNU Standard C++ Library__GPLv3+__1704067200
+p11-kit 0:0.23.22-1.el8 x86_64__Red Hat, Inc.__Library for loading and sharing PKCS#11 modules__GPLv3+__1704067200
+libunistring 0:0.9.9-3.el8 x86_64__Red Hat, Inc.__GNU Unicode string library__GPLv3+__1704067200
+libgcrypt 0:1.8.5-4.el8 x86_64__Red Hat, Inc.__A general-purpose cryptography library__GPLv3+__1704067200
+libcap-ng 0:0.7.9-5.el8 x86_64__Red Hat, Inc.__An alternate posix capabilities library__GPLv3+__1704067200
+libnl3 0:3.5.0-1.el8 x86_64__Red Hat, Inc.__Convenience library for kernel netlink sockets__GPLv3+__1704067200
+libassuan 0:2.5.1-3.el8 x86_64__Red Hat, Inc.__GnuPG IPC library__GPLv3+__1704067200
+keyutils-libs 0:1.5.10-6.el8 x86_64__Red Hat, Inc.__Key utilities library__GPLv3+__1704067200
+p11-kit-trust 0:0.23.22-1.el8 x86_64__Red Hat, Inc.__System trust module from p11-kit__GPLv3+__1704067200
+grep 0:3.1-6.el8 x86_64__Red Hat, Inc.__Pattern matching utilities__GPLv3+__1704067200
+dbus-libs 1:1.12.8-12.el8_4.2 x86_64__Red Hat, Inc.__Libraries for accessing D-BUS__GPLv3+__1704067200
+dbus-tools 1:1.12.8-12.el8_4.2 x86_64__Red Hat, Inc.__D-BUS Tools and Utilities__GPLv3+__1704067200
+gdbm 1:1.18-1.el8 x86_64__Red Hat, Inc.__A GNU set of database routines which use extensible hashing__GPLv3+__1704067200
+shadow-utils 2:4.6-12.el8 x86_64__Red Hat, Inc.__Utilities for managing accounts and shadow password files__GPLv3+__1704067200
+libpsl 0:0.20.2-6.el8 x86_64__Red Hat, Inc.__C library for the Publix Suffix List__GPLv3+__1704067200
+gzip 0:1.9-12.el8 x86_64__Red Hat, Inc.__The GNU data compression program__GPLv3+__1704067200
+cracklib-dicts 0:2.9.6-15.el8 x86_64__Red Hat, Inc.__The standard CrackLib dictionaries__GPLv3+__1704067200
+mpfr 0:3.1.6-1.el8 x86_64__Red Hat, Inc.__A C library for multiple-precision floating-point computations__GPLv3+__1704067200
+libcomps 0:0.1.11-5.el8 x86_64__Red Hat, Inc.__Comps XML file manipulation library__GPLv3+__1704067200
+brotli 0:1.0.6-3.el8 x86_64__Red Hat, Inc.__Lossless compression algorithm__GPLv3+__1704067200
+libnghttp2 0:1.33.0-3.el8_2.1 x86_64__Red Hat, Inc.__A library implementing the HTTP/2 protocol__GPLv3+__1704067200
+libsigsegv 0:2.11-5.el8 x86_64__Red Hat, Inc.__Library for handling page faults in user mode__GPLv3+__1704067200
+libverto 0:0.3.0-5.el8 x86_64__Red Hat, Inc.__Main loop abstraction library__GPLv3+__1704067200
+libtirpc 0:1.1.4-4.el8 x86_64__Red Hat, Inc.__Transport Independent RPC Library__GPLv3+__1704067200
+openssl-libs 1:1.1.1g-15.el8_3 x86_64__Red Hat, Inc.__A general purpose cryptography library with TLS implementation__GPLv3+__1704067200
+crypto-policies-scripts 0:20210209-1.gitbfb6bed.el8_3 noarch__Red Hat, Inc.__Tool to switch between crypto policies__GPLv3+__1704067200
+platform-python 0:3.6.8-39.el8_4 x86_64__Red Hat, Inc.__Internal interpreter of the Python programming language__GPLv3+__1704067200
+libdb 0:5.3.28-42.el8_4 x86_64__Red Hat, Inc.__The Berkeley DB database library for C__GPLv3+__1704067200
+pam 0:1.3.1-14.el8 x86_64__Red Hat, Inc.__An extensible library which provides authentication for applications__GPLv3+__1704067200
+util-linux 0:2.32.1-27.el8 x86_64__Red Hat, Inc.__A collection of basic system utilities__GPLv3+__1704067200
+gnutls 0:3.6.14-8.el8_3 x86_64__Red Hat, Inc.__A TLS protocol implementation__GPLv3+__1704067200
+json-glib 0:1.4.4-1.el8 x86_64__Red Hat, Inc.__Library for JavaScript Object Notation format__GPLv3+__1704067200
+python3-iniparse 0:0.4-31.el8 noarch__Red Hat, Inc.__Python Module for Accessing and Modifying Configuration Data in INI files__GPLv3+__1704067200
+dbus-glib 0:0.110-2.el8 x86_64__Red Hat, Inc.__GLib bindings for D-Bus__GPLv3+__1704067200
+gobject-introspection 0:1.56.1-1.el8 x86_64__Red Hat, Inc.__Introspection system for GObject-based libraries__GPLv3+__1704067200
+cyrus-sasl-lib 0:2.1.27-5.el8 x86_64__Red Hat, Inc.__Shared libraries needed by applications which use Cyrus SASL__GPLv3+__1704067200
+libuser 0:0.62-23.el8 x86_64__Red Hat, Inc.__A user and group account administration library__GPLv3+__1704067200
+usermode 0:1.113-1.el8 x86_64__Red Hat, Inc.__Tools for certain user account management tasks__GPLv3+__1704067200
+python3-ethtool 0:0.14-3.el8 x86_64__Red Hat, Inc.__Python module to interface with ethtool__GPLv3+__1704067200
+python3-libxml2 0:2.9.7-9.el8_4.2 x86_64__Red Hat, Inc.__Python 3 bindings for the libxml2 library__GPLv3+__1704067200
+python3-chardet 0:3.0.4-7.el8 noarch__Red Hat, Inc.__Character encoding auto-detection in Python 3__GPLv3+__1704067200
+python3-idna 0:2.5-5.el8 noarch__Red Hat, Inc.__Internationalized Domain Names in Applications (IDNA)__GPLv3+__1704067200
+python3-pysocks 0:1.6.8-3.el8 noarch__Red Hat, Inc.__A Python SOCKS client module__GPLv3+__1704067200
+python3-requests 0:2.20.0-2.1.el8_1 noarch__Red Hat, Inc.__HTTP library, written in Python, for human beings__GPLv3+__1704067200
+libarchive 0:3.3.3-1.el8 x86_64__Red Hat, Inc.__A library for handling streaming archive formats__GPLv3+__1704067200
+ima-evm-utils 0:1.3.2-12.el8 x86_64__Red Hat, Inc.__IMA/EVM support utilities__GPLv3+__1704067200
+npth 0:1.5-4.el8 x86_64__Red Hat, Inc.__The New GNU Portable Threads library__GPLv3+__1704067200
+gpgme 0:1.13.1-7.el8 x86_64__Red Hat, Inc.__GnuPG Made Easy - high level crypto API__GPLv3+__1704067200
+pciutils-libs 0:3.7.0-1.el8 x86_64__Red Hat, Inc.__Linux PCI library__GPLv3+__1704067200
+virt-what 0:1.18-9.el8_4 x86_64__Red Hat, Inc.__Detect if we are running in a virtual machine__GPLv3+__1704067200
+libssh 0:0.9.4-2.el8 x86_64__Red Hat, Inc.__A library implementing the SSH protocol__GPLv3+__1704067200
+librepo 0:1.12.0-3.el8 x86_64__Red Hat, Inc.__Repodata downloading library__GPLv3+__1704067200
+curl 0:7.61.1-18.el8_4.2 x86_64__Red Hat, Inc.__A utility for getting files from remote servers (FTP, HTTP, and others)__GPLv3+__1704067200
+rpm-libs 0:4.14.3-14.el8_4 x86_64__Red Hat, Inc.__Libraries for manipulating RPM packages__GPLv3+__1704067200
+libsolv 0:0.7.16-3.el8_4 x86_64__Red Hat, Inc.__Package dependency solver__GPLv3+__1704067200
+python3-libdnf 0:0.55.0-7.el8 x86_64__Red Hat, Inc.__Python 3 bindings for the libdnf library.__GPLv3+__1704067200
+libreport-filesystem 0:2.9.5-15.el8 x86_64__Red Hat, Inc.__Filesystem layout for libreport__GPLv3+__1704067200
+hwdata 0:0.314-8.8.el8 noarch__Red Hat, Inc.__Hardware identification and configuration data__GPLv3+__1704067200
+rdma-core 0:32.0-4.el8 x86_64__Red Hat, Inc.__RDMA core userspace libraries and daemons__GPLv3+__1704067200
+libpcap 14:1.9.1-5.el8 x86_64__Red Hat, Inc.__A system-independent interface for user-level packet capture__GPLv3+__1704067200
+dbus-common 1:1.12.8-12.el8_4.2 noarch__Red Hat, Inc.__D-BUS message bus configuration__GPLv3+__1704067200
+device-mapper 8:1.02.175-5.el8 x86_64__Red Hat, Inc.__Device mapper utility__GPLv3+__1704067200
+cryptsetup-libs 0:2.3.3-4.el8 x86_64__Red Hat, Inc.__Cryptsetup shared library__GPLv3+__1704067200
+elfutils-libs 0:0.182-3.el8 x86_64__Red Hat, Inc.__Libraries to handle compiled objects__GPLv3+__1704067200
+systemd 0:239-45.el8_4.3 x86_64__Red Hat, Inc.__System and Service Manager__GPLv3+__1704067200
+rpm-build-libs 0:4.14.3-14.el8_4 x86_64__Red Hat, Inc.__Libraries for building and signing RPM packages__GPLv3+__1704067200
+python3-dnf 0:4.4.2-11.el8 noarch__Red Hat, Inc.__Python 3 interface to DNF__GPLv3+__1704067200
+python3-dnf-plugins-core 0:4.0.18-4.el8 noarch__Red Hat, Inc.__Core Plugins for DNF__GPLv3+__1704067200
+python3-subscription-manager-rhsm 0:1.28.13-4.el8_4 x86_64__Red Hat, Inc.__A Python library to communicate with a Red Hat Unified Entitlement Platform__GPLv3+__1704067200
+yum 0:4.4.2-11.el8 noarch__Red Hat, Inc.__Package manager__GPLv3+__1704067200
+tar 2:1.30-5.el8 x86_64__Red Hat, Inc.__A GNU file archiving program__GPLv3+__1704067200
+findutils 1:4.6.0-20.el8 x86_64__Red Hat, Inc.__The GNU versions of find utilities (find and xargs)__GPLv3+__1704067200
+rootfiles 0:8.1-22.el8 noarch__Red Hat, Inc.__The basic required files for the root user's directory__GPLv3+__1704067200
+gpg-pubkey 0:d4082792-5b32db75 (none)__(none)__gpg(Red Hat, Inc. (auxiliary key) <security@redhat.com>)__(none)__(none)
+libgcc 0:8.4.1-1.el8 x86_64__Red Hat, Inc.__GCC version 8 shared support library__GPLv3+__1704067200
+python3-setuptools-wheel 0:39.2.0-6.el8 noarch__Red Hat, Inc.__The setuptools wheel__GPLv3+__1704067200
+subscription-manager-rhsm-certificates 0:1.28.13-4.el8_4 x86_64__Red Hat, Inc.__Certificates required to communicate with a Red Hat Unified Entitlement Platform__GPLv3+__1704067200
+setup 0:2.12.2-6.el8 noarch__Red Hat, Inc.__A set of system configuration and setup files__GPLv3+__1704067200
+basesystem 0:11-5.el8 noarch__Red Hat, Inc.__The skeleton package which defines a simple Red Hat Enterprise Linux system__GPLv3+__1704067200
+ncurses-base 0:6.1-7.20180224.el8 noarch__Red Hat, Inc.__Descriptions of common terminals__GPLv3+__1704067200
+libselinux 0:2.9-5.el8 x86_64__Red Hat, Inc.__SELinux library and simple utilities__GPLv3+__1704067200
+glibc-minimal-langpack 0:2.28-151.el8 x86_64__Red Hat, Inc.__Minimal language packs for glibc.__GPLv3+__1704067200
+glibc 0:2.28-151.el8 x86_64__Red Hat, Inc.__The GNU libc libraries__GPLv3+__1704067200
+libsepol 0:2.9-2.el8 x86_64__Red Hat, Inc.__SELinux binary policy manipulation library__GPLv3+__1704067200
+xz-libs 0:5.2.4-3.el8 x86_64__Red Hat, Inc.__Libraries for decoding LZMA compression__GPLv3+__1704067200
+libgpg-error 0:1.31-1.el8 x86_64__Red Hat, Inc.__Library for error values used by GnuPG components__GPLv3+__1704067200
+info 0:6.5-6.el8 x86_64__Red Hat, Inc.__A stand-alone TTY-based reader for GNU texinfo documentation__GPLv3+__1704067200
+libxcrypt 0:4.1.1-4.el8 x86_64__Red Hat, Inc.__Extended crypt library for DES, MD5, Blowfish and others__GPLv3+__1704067200
+popt 0:1.18-1.el8 x86_64__Red Hat, Inc.__C library for parsing command line parameters__GPLv3+__1704067200
+sqlite-libs 0:3.26.0-13.el8 x86_64__Red Hat, Inc.__Shared library for the sqlite3 embeddable SQL database engine.__GPLv3+__1704067200
+json-c 0:0.13.1-0.4.el8 x86_64__Red Hat, Inc.__JSON implementation in C__GPLv3+__1704067200
+libffi 0:3.1-22.el8 x86_64__Red Hat, Inc.__A portable foreign function interface library__GPLv3+__1704067200
+readline 0:7.0-10.el8 x86_64__Red Hat, Inc.__A library for editing typed command lines__GPLv3+__1704067200
+libattr 0:2.4.48-3.el8 x86_64__Red Hat, Inc.__Dynamic library for extended attribute support__GPLv3+__1704067200
+coreutils-single 0:8.30-8.el8 x86_64__Red Hat, Inc.__coreutils multicall binary__GPLv3+__1704067200
+libmount 0:2.32.1-27.el8 x86_64__Red Hat, Inc.__Device mounting library__GPLv3+__1704067200
+libsmartcols 0:2.32.1-27.el8 x86_64__Red Hat, Inc.__Formatting library for ls-like programs.__GPLv3+__1704067200
+lua-libs 0:5.3.4-11.el8 x86_64__Red Hat, Inc.__Libraries for lua__GPLv3+__1704067200
+chkconfig 0:1.13-2.el8 x86_64__Red Hat, Inc.__A system tool for maintaining the /etc/rc*.d hierarchy__GPLv3+__1704067200
+libidn2 0:2.2.0-1.el8 x86_64__Red Hat, Inc.__Library to support IDNA2008 internationalized domain names__GPLv3+__1704067200
+file-libs 0:5.33-16.el8_3.1 x86_64__Red Hat, Inc.__Libraries for applications using libmagic__GPLv3+__1704067200
+audit-libs 0:3.0-0.17.20191104git1c2f876.el8 x86_64__Red Hat, Inc.__Dynamic library for libaudit__GPLv3+__1704067200
+lz4-libs 0:1.8.3-3.el8_4 x86_64__Red Hat, Inc.__Libaries for lz4__GPLv3+__1704067200
+gdbm-libs 1:1.18-1.el8 x86_64__Red Hat, Inc.__Libraries files for gdbm__GPLv3+__1704067200
+libtasn1 0:4.13-3.el8 x86_64__Red Hat, Inc.__The ASN.1 library used in GNUTLS__GPLv3+__1704067200
+pcre 0:8.42-4.el8 x86_64__Red Hat, Inc.__Perl-compatible regular expression library__GPLv3+__1704067200
+systemd-libs 0:239-45.el8_4.3 x86_64__Red Hat, Inc.__systemd libraries__GPLv3+__1704067200
+ca-certificates 0:2021.2.50-80.0.el8_4 noarch__Red Hat, Inc.__The Mozilla CA root certificate bundle__GPLv3+__1704067200
+libusbx 0:1.0.23-4.el8 x86_64__Red Hat, Inc.__Library for accessing USB devices__GPLv3+__1704067200
+libsemanage 0:2.9-6.el8 x86_64__Red Hat, Inc.__SELinux binary policy manipulation library__GPLv3+__1704067200
+libutempter 0:1.1.6-14.el8 x86_64__Red Hat, Inc.__A privileged helper for utmp/wtmp updates__GPLv3+__1704067200
+libfdisk 0:2.32.1-27.el8 x86_64__Red Hat, Inc.__Partitioning library for fdisk-like programs.__GPLv3+__1704067200
+cracklib 0:2.9.6-15.el8 x86_64__Red Hat, Inc.__A password-checking library__GPLv3+__1704067200
+acl 0:2.2.53-1.el8 x86_64__Red Hat, Inc.__Access control list utilities__GPLv3+__1704067200
+nettle 0:3.4.1-4.el8_3 x86_64__Red Hat, Inc.__A low-level cryptographic library__GPLv3+__1704067200
+libksba 0:1.3.5-7.el8 x86_64__Red Hat, Inc.__CMS and X.509 library__GPLv3+__1704067200
+dmidecode 1:3.2-8.el8 x86_64__Red Hat, Inc.__Tool to analyse BIOS DMI data__GPLv3+__1704067200
+libseccomp 0:2.5.1-1.el8 x86_64__Red Hat, Inc.__Enhanced seccomp library__GPLv3+__1704067200
+gawk 0:4.2.1-2.el8 x86_64__Red Hat, Inc.__The GNU version of the AWK text processing utility__GPLv3+__1704067200
+libnsl2 0:1.2.0-2.20180605git4a062cf.el8 x86_64__Red Hat, Inc.__Public client interface library for NIS(YP) and NIS+__GPLv3+__1704067200
+krb5-libs 0:1.18.2-8.3.el8_4 x86_64__Red Hat, Inc.__The non-admin shared libraries used by Kerberos 5__GPLv3+__1704067200
+crypto-policies 0:20210209-1.gitbfb6bed.el8_3 noarch__Red Hat, Inc.__System-wide crypto policies__GPLv3+__1704067200
+platform-python-setuptools 0:39.2.0-6.el8 noarch__Red Hat, Inc.__Easily build and distribute Python 3 packages__GPLv3+__1704067200
+python3-libs 0:3.6.8-39.el8_4 x86_64__Red Hat, Inc.__Python runtime libraries__GPLv3+__1704067200
+libpwquality 0:1.4.4-3.el8 x86_64__Red Hat, Inc.__A library for password generation and password quality checking__GPLv3+__1704067200
+python3-six 0:1.11.0-8.el8 noarch__Red Hat, Inc.__Python 2 and 3 compatibility utilities__GPLv3+__1704067200
+python3-dateutil 1:2.6.1-6.el8 noarch__Red Hat, Inc.__Powerful extensions to the standard datetime module__GPLv3+__1704067200
+glib2 0:2.56.4-10.el8_4.1 x86_64__Red Hat, Inc.__A library of handy utility functions__GPLv3+__1704067200
+librhsm 0:0.0.3-4.el8 x86_64__Red Hat, Inc.__Red Hat Subscription Manager library__GPLv3+__1704067200
+kmod-libs 0:25-17.el8 x86_64__Red Hat, Inc.__Libraries to handle kernel module loading and unloading__GPLv3+__1704067200
+python3-dbus 0:1.2.4-15.el8 x86_64__Red Hat, Inc.__D-Bus bindings for python3__GPLv3+__1704067200
+python3-gobject-base 0:3.28.3-2.el8 x86_64__Red Hat, Inc.__Python 3 bindings for GObject Introspection base package__GPLv3+__1704067200
+openldap 0:2.4.46-17.el8_4 x86_64__Red Hat, Inc.__LDAP support libraries__GPLv3+__1704067200
+passwd 0:0.80-3.el8 x86_64__Red Hat, Inc.__An utility for setting or changing passwords using PAM__GPLv3+__1704067200
+libdb-utils 0:5.3.28-42.el8_4 x86_64__Red Hat, Inc.__Command line tools for managing Berkeley DB databases__GPLv3+__1704067200
+python3-libcomps 0:0.1.11-5.el8 x86_64__Red Hat, Inc.__Python 3 bindings for libcomps library__GPLv3+__1704067200
+python3-dmidecode 0:3.12.2-15.el8 x86_64__Red Hat, Inc.__Python 3 module to access DMI data__GPLv3+__1704067200
+python3-decorator 0:4.2.1-2.el8 noarch__Red Hat, Inc.__Module to simplify usage of decorators in python3__GPLv3+__1704067200
+python3-inotify 0:0.9.6-13.el8 noarch__Red Hat, Inc.__Monitor filesystem events with Python under Linux__GPLv3+__1704067200
+python3-urllib3 0:1.24.2-5.el8 noarch__Red Hat, Inc.__Python3 HTTP library with thread-safe connection pooling and file post__GPLv3+__1704067200
+python3-syspurpose 0:1.28.13-4.el8_4 x86_64__Red Hat, Inc.__A commandline utility for declaring system syspurpose__GPLv3+__1704067200
+tpm2-tss 0:2.3.2-3.el8 x86_64__Red Hat, Inc.__TPM2.0 Software Stack__GPLv3+__1704067200
+libyaml 0:0.1.7-5.el8 x86_64__Red Hat, Inc.__YAML 1.1 parser and emitter written in C__GPLv3+__1704067200
+gnupg2 0:2.2.20-2.el8 x86_64__Red Hat, Inc.__Utility for secure communication and data storage__GPLv3+__1704067200
+python3-gpg 0:1.13.1-7.el8 x86_64__Red Hat, Inc.__gpgme bindings for Python 3__GPLv3+__1704067200
+which 0:2.21-12.el8 x86_64__Red Hat, Inc.__Displays where a particular program in your path is located__GPLv3+__1704067200
+libssh-config 0:0.9.4-2.el8 noarch__Red Hat, Inc.__Configuration files for libssh__GPLv3+__1704067200
+libcurl 0:7.61.1-18.el8_4.2 x86_64__Red Hat, Inc.__A library for getting files from web servers__GPLv3+__1704067200
+python3-librepo 0:1.12.0-3.el8 x86_64__Red Hat, Inc.__Python 3 bindings for the librepo library__GPLv3+__1704067200
+rpm 0:4.14.3-14.el8_4 x86_64__Red Hat, Inc.__The RPM package management system__GPLv3+__1704067200
+libmodulemd 0:2.9.4-2.el8 x86_64__Red Hat, Inc.__Module metadata manipulation library__GPLv3+__1704067200
+libdnf 0:0.55.0-7.el8 x86_64__Red Hat, Inc.__Library providing simplified C and Python API to libsolv__GPLv3+__1704067200
+python3-hawkey 0:0.55.0-7.el8 x86_64__Red Hat, Inc.__Python 3 bindings for the hawkey library__GPLv3+__1704067200
+dnf-data 0:4.4.2-11.el8 noarch__Red Hat, Inc.__Common data and configuration files for DNF__GPLv3+__1704067200
+pciutils 0:3.7.0-1.el8 x86_64__Red Hat, Inc.__PCI bus related utilities__GPLv3+__1704067200
+libibverbs 0:32.0-4.el8 x86_64__Red Hat, Inc.__A library and drivers for direct userspace use of RDMA (InfiniBand/iWARP/RoCE) hardware__GPLv3+__1704067200
+iptables-libs 0:1.8.4-17.el8_4.1 x86_64__Red Hat, Inc.__iptables libraries__GPLv3+__1704067200
+dbus-daemon 1:1.12.8-12.el8_4.2 x86_64__Red Hat, Inc.__D-BUS message bus__GPLv3+__1704067200
+device-mapper-libs 8:1.02.175-5.el8 x86_64__Red Hat, Inc.__Device-mapper shared library__GPLv3+__1704067200
+elfutils-default-yama-scope 0:0.182-3.el8 noarch__Red Hat, Inc.__Default yama attach scope sysctl setting__GPLv3+__1704067200
+systemd-pam 0:239-45.el8_4.3 x86_64__Red Hat, Inc.__systemd PAM module__GPLv3+__1704067200
+dbus 1:1.12.8-12.el8_4.2 x86_64__Red Hat, Inc.__D-BUS message bus__GPLv3+__1704067200
+python3-rpm 0:4.14.3-14.el8_4 x86_64__Red Hat, Inc.__Python 3 bindings for apps which will manipulate RPM packages__GPLv3+__1704067200
+dnf 0:4.4.2-11.el8 noarch__Red Hat, Inc.__Package manager__GPLv3+__1704067200
+dnf-plugin-subscription-manager 0:1.28.13-4.el8_4 x86_64__Red Hat, Inc.__Subscription Manager plugins for DNF__GPLv3+__1704067200
+subscription-manager 0:1.28.13-4.el8_4 x86_64__Red Hat, Inc.__Tools and libraries for subscription and repository management__GPLv3+__1704067200
+gdb-gdbserver 0:8.2-15.el8 x86_64__Red Hat, Inc.__A standalone server for GDB (the GNU source-level debugger)__GPLv3+__1704067200
+vim-minimal 2:8.0.1763-15.el8 x86_64__Red Hat, Inc.__A minimal version of the VIM editor__GPLv3+__1704067200
+langpacks-en 0:1.0-12.el8 noarch__Red Hat, Inc.__English langpacks meta-package__GPLv3+__1704067200
+gpg-pubkey 0:fd431d51-4ae0493b (none)__(none)__gpg(Red Hat, Inc. (release key 2) <security@redhat.com>)__(none)__(none)
 """
 
 [commands."rpm -ql which"]

--- a/providers/os/resources/packages/testdata/packages_redhat8_modular.toml
+++ b/providers/os/resources/packages/testdata/packages_redhat8_modular.toml
@@ -4,10 +4,10 @@ stdout="/usr/bin/rpm"
 [commands."rpm -E '%{_dbpath}'"]
 stdout="/var/lib/rpm"
 
-[commands."rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}\\036%{VENDOR}\\036%{SUMMARY}\\036%{LICENSE}\\036%{INSTALLTIME}\\036%{MODULARITYLABEL}\\n'"]
+[commands."rpm -qa --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}__%{INSTALLTIME}__%{MODULARITYLABEL}\\n'"]
 stdout="""
-tzdata 0:2021c-1.el8 noarch\u001ERed Hat, Inc.\u001ETimezone data\u001EGPLv3+\u001E1704067200\u001E(none)
-bash 0:4.4.20-1.el8_4 x86_64\u001ERed Hat, Inc.\u001EThe GNU Bourne Again shell\u001EGPLv3+\u001E1704067200\u001E(none)
-php-common 0:7.4.33-3.module+el8.10.0+23902+d3c8dd8f aarch64\u001ERed Hat, Inc.\u001ECommon files for PHP\u001EGPLv3+\u001E1704067200\u001Ephp:7.4:8100020260119075152:f7998665
-php-cli 0:7.4.33-3.module+el8.10.0+23902+d3c8dd8f aarch64\u001ERed Hat, Inc.\u001ECommand-line interface for PHP\u001EGPLv3+\u001E1704067200\u001Ephp:7.4:8100020260119075152:f7998665
+tzdata 0:2021c-1.el8 noarch__Red Hat, Inc.__Timezone data__GPLv3+__1704067200__(none)
+bash 0:4.4.20-1.el8_4 x86_64__Red Hat, Inc.__The GNU Bourne Again shell__GPLv3+__1704067200__(none)
+php-common 0:7.4.33-3.module+el8.10.0+23902+d3c8dd8f aarch64__Red Hat, Inc.__Common files for PHP__GPLv3+__1704067200__php:7.4:8100020260119075152:f7998665
+php-cli 0:7.4.33-3.module+el8.10.0+23902+d3c8dd8f aarch64__Red Hat, Inc.__Command-line interface for PHP__GPLv3+__1704067200__php:7.4:8100020260119075152:f7998665
 """

--- a/providers/os/resources/reboot/rhel.go
+++ b/providers/os/resources/reboot/rhel.go
@@ -30,7 +30,7 @@ func (s *RpmNewestKernel) RebootPending() (bool, error) {
 	}
 
 	// get installed kernel version
-	installedKernelCmd, err := s.conn.RunCommand(`rpm -q kernel --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}\036%{VENDOR}\036%{SUMMARY}\036%{LICENSE}\036%{INSTALLTIME}\n'`)
+	installedKernelCmd, err := s.conn.RunCommand("rpm -q kernel --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}__%{INSTALLTIME}\n'")
 	if err != nil {
 		return false, err
 	}

--- a/providers/os/resources/reboot/testdata/redhat_kernel_reboot.toml
+++ b/providers/os/resources/reboot/testdata/redhat_kernel_reboot.toml
@@ -1,8 +1,8 @@
-[commands."rpm -q kernel --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}\\036%{VENDOR}\\036%{SUMMARY}\\036%{LICENSE}\\036%{INSTALLTIME}\\n'"]
+[commands."rpm -q kernel --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}__%{INSTALLTIME}\n'"]
 stdout = """
-kernel 0:4.18.0-80.el8 x86_64\u001ERed Hat, Inc.\u001EThe Linux kernel\u001EGPLv2\u001E1704067200
-kernel 0:4.18.0-80.4.2.el8_0 x86_64\u001ERed Hat, Inc.\u001EThe Linux kernel\u001EGPLv2\u001E1704067200
-kernel 0:4.18.0-80.11.2.el8_0 x86_64\u001ERed Hat, Inc.\u001EThe Linux kernel\u001EGPLv2\u001E1704067200
+kernel 0:4.18.0-80.el8 x86_64__Red Hat, Inc.__The Linux kernel__GPLv2__1704067200
+kernel 0:4.18.0-80.4.2.el8_0 x86_64__Red Hat, Inc.__The Linux kernel__GPLv2__1704067200
+kernel 0:4.18.0-80.11.2.el8_0 x86_64__Red Hat, Inc.__The Linux kernel__GPLv2__1704067200
 """
 
 [commands."uname -r"]


### PR DESCRIPTION
## Summary

Reverts #7818 (commit 875418c). The RS-delimiter change broke RPM package parsing in real-world use; rolling back to the previous `__` delimiter while we work out a fix.

## Test plan

- [x] `go test ./providers/os/resources/packages/...` — pass
- [x] `go test ./providers/os/resources/reboot/...` — pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)