### PR TITLE
🎉 os-13.19.0

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.18.0",
+	Version: "13.19.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
## Summary

Bumps the `os` provider from `13.18.0` to `13.19.0`.

## Test plan

- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)