### PR TITLE
✨ os: scan Python source manifests for dependency detection

### DIFF
--- a/providers/os/resources/languages/python/requirements/requirestxt.go
+++ b/providers/os/resources/languages/python/requirements/requirestxt.go
@@ -27,6 +27,9 @@ import (
 
 var firstWordRegexp = regexp.MustCompile(`^[a-zA-Z0-9\._-]*`)
 
+// ParseRequiresTxtDependencies parses a requires.txt / requirements.txt file
+// and returns a list of package names (without versions). This is the legacy
+// API used internally for egg-info requires.txt files where only names matter.
 func ParseRequiresTxtDependencies(r io.Reader) ([]string, error) {
 	fileScanner := bufio.NewScanner(r)
 	fileScanner.Split(bufio.ScanLines)
@@ -47,4 +50,120 @@ func ParseRequiresTxtDependencies(r io.Reader) ([]string, error) {
 	}
 
 	return dependencies, nil
+}
+
+// Requirement represents a single entry parsed from a requirements.txt file.
+type Requirement struct {
+	Name    string
+	Version string
+	Extras  []string
+}
+
+// requirementLineRegexp matches a PEP 508 dependency line:
+//
+//	name[extras] version_constraint ; markers # comment
+var requirementLineRegexp = regexp.MustCompile(
+	`^\s*` +
+		`(?P<name>[a-zA-Z0-9][\w.\-]*)` +
+		`(?:\[(?P<extras>[^\]]*)\])?` +
+		`\s*` +
+		`(?P<constraint>[~=><!][^\s;#]*(?:\s*,\s*[~=><!][^\s;#]*)*)?\s*`,
+)
+
+// ParseRequirementsTxt parses a requirements.txt file and returns structured
+// requirements with names and pinned versions. It handles comments, line
+// continuations, editable installs, and extras.
+func ParseRequirementsTxt(r io.Reader) ([]Requirement, error) {
+	scanner := bufio.NewScanner(r)
+	var reqs []Requirement
+	var continuation string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Strip trailing comments (but not inside quotes)
+		if idx := strings.Index(line, "#"); idx >= 0 {
+			line = line[:idx]
+		}
+		line = strings.TrimSpace(line)
+
+		// Handle line continuations
+		if continuation != "" {
+			line = continuation + line
+			continuation = ""
+		}
+		if strings.HasSuffix(line, "\\") {
+			continuation = strings.TrimSuffix(line, "\\")
+			continue
+		}
+
+		if line == "" {
+			continue
+		}
+
+		// Skip options (-r, -c, -e, --index-url, etc.)
+		if strings.HasPrefix(line, "-") {
+			continue
+		}
+
+		// Skip URL-only lines (e.g. "https://...")
+		if strings.HasPrefix(line, "http://") || strings.HasPrefix(line, "https://") {
+			continue
+		}
+
+		m := requirementLineRegexp.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		name := m[requirementLineRegexp.SubexpIndex("name")]
+		extras := m[requirementLineRegexp.SubexpIndex("extras")]
+		constraint := strings.TrimSpace(m[requirementLineRegexp.SubexpIndex("constraint")])
+
+		if name == "" {
+			continue
+		}
+
+		req := Requirement{Name: name}
+
+		// Parse extras
+		if extras != "" {
+			for _, e := range strings.Split(extras, ",") {
+				e = strings.TrimSpace(e)
+				if e != "" {
+					req.Extras = append(req.Extras, e)
+				}
+			}
+		}
+
+		// Extract pinned version from == or === operators
+		req.Version = parsePinnedVersion(constraint)
+
+		reqs = append(reqs, req)
+	}
+
+	return reqs, scanner.Err()
+}
+
+// parsePinnedVersion extracts the version from an exact pin (== or ===).
+// Returns "" for unpinned or range constraints.
+func parsePinnedVersion(constraint string) string {
+	constraint = strings.TrimSpace(constraint)
+	if constraint == "" {
+		return ""
+	}
+
+	// Reject wildcards and multi-constraint specs
+	if strings.Contains(constraint, "*") || strings.Contains(constraint, ",") {
+		return ""
+	}
+
+	for _, op := range []string{"===", "=="} {
+		if strings.HasPrefix(constraint, op) {
+			v := strings.TrimSpace(strings.TrimPrefix(constraint, op))
+			if v != "" {
+				return v
+			}
+		}
+	}
+	return ""
 }

--- a/providers/os/resources/languages/python/requirements/requirestxt.go
+++ b/providers/os/resources/languages/python/requirements/requirestxt.go
@@ -81,7 +81,7 @@ func ParseRequirementsTxt(r io.Reader) ([]Requirement, error) {
 	for scanner.Scan() {
 		line := scanner.Text()
 
-		// Strip trailing comments (but not inside quotes)
+		// Strip inline comments
 		if idx := strings.Index(line, "#"); idx >= 0 {
 			line = line[:idx]
 		}

--- a/providers/os/resources/languages/python/requirements/requirestxt_test.go
+++ b/providers/os/resources/languages/python/requirements/requirestxt_test.go
@@ -28,3 +28,123 @@ cryptography
 	require.NoError(t, err)
 	assert.Equal(t, []string{"nose", "Mock", "pycryptodome"}, dependencies)
 }
+
+func TestParseRequirementsTxt_PinnedVersions(t *testing.T) {
+	data := `
+openai==1.30.0
+transformers==4.40.0
+requests>=2.32.0
+numpy
+torch===2.3.0
+`
+	reqs, err := ParseRequirementsTxt(strings.NewReader(data))
+	require.NoError(t, err)
+	require.Len(t, reqs, 5)
+
+	assert.Equal(t, "openai", reqs[0].Name)
+	assert.Equal(t, "1.30.0", reqs[0].Version)
+
+	assert.Equal(t, "transformers", reqs[1].Name)
+	assert.Equal(t, "4.40.0", reqs[1].Version)
+
+	assert.Equal(t, "requests", reqs[2].Name)
+	assert.Equal(t, "", reqs[2].Version, "non-pinned should have empty version")
+
+	assert.Equal(t, "numpy", reqs[3].Name)
+	assert.Equal(t, "", reqs[3].Version, "bare name should have empty version")
+
+	assert.Equal(t, "torch", reqs[4].Name)
+	assert.Equal(t, "2.3.0", reqs[4].Version, "=== should also pin")
+}
+
+func TestParseRequirementsTxt_Comments(t *testing.T) {
+	data := `
+# This is a comment
+openai==1.30.0  # inline comment
+# another comment
+torch==2.3.0
+`
+	reqs, err := ParseRequirementsTxt(strings.NewReader(data))
+	require.NoError(t, err)
+	require.Len(t, reqs, 2)
+	assert.Equal(t, "openai", reqs[0].Name)
+	assert.Equal(t, "torch", reqs[1].Name)
+}
+
+func TestParseRequirementsTxt_LineContinuation(t *testing.T) {
+	data := `openai==\
+1.30.0
+torch==2.3.0
+`
+	reqs, err := ParseRequirementsTxt(strings.NewReader(data))
+	require.NoError(t, err)
+	require.Len(t, reqs, 2)
+	assert.Equal(t, "openai", reqs[0].Name)
+	assert.Equal(t, "1.30.0", reqs[0].Version)
+}
+
+func TestParseRequirementsTxt_Extras(t *testing.T) {
+	data := `requests[security]==2.8.0
+langchain[llm,tools]==0.2.0
+`
+	reqs, err := ParseRequirementsTxt(strings.NewReader(data))
+	require.NoError(t, err)
+	require.Len(t, reqs, 2)
+
+	assert.Equal(t, "requests", reqs[0].Name)
+	assert.Equal(t, "2.8.0", reqs[0].Version)
+	assert.Equal(t, []string{"security"}, reqs[0].Extras)
+
+	assert.Equal(t, "langchain", reqs[1].Name)
+	assert.Equal(t, []string{"llm", "tools"}, reqs[1].Extras)
+}
+
+func TestParseRequirementsTxt_SkipOptions(t *testing.T) {
+	data := `
+-r other-requirements.txt
+--index-url https://pypi.org/simple
+-e git+https://github.com/user/project.git#egg=project
+openai==1.30.0
+`
+	reqs, err := ParseRequirementsTxt(strings.NewReader(data))
+	require.NoError(t, err)
+	require.Len(t, reqs, 1)
+	assert.Equal(t, "openai", reqs[0].Name)
+}
+
+func TestParseRequirementsTxt_WildcardNotPinned(t *testing.T) {
+	data := `requests==2.8.*
+`
+	reqs, err := ParseRequirementsTxt(strings.NewReader(data))
+	require.NoError(t, err)
+	require.Len(t, reqs, 1)
+	assert.Equal(t, "requests", reqs[0].Name)
+	assert.Equal(t, "", reqs[0].Version, "wildcard version should not be pinned")
+}
+
+func TestParseRequirementsTxt_Empty(t *testing.T) {
+	reqs, err := ParseRequirementsTxt(strings.NewReader(""))
+	require.NoError(t, err)
+	assert.Empty(t, reqs)
+}
+
+func TestParsePinnedVersion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"==1.30.0", "1.30.0"},
+		{"===2.3.0", "2.3.0"},
+		{">=1.0", ""},
+		{"~=1.0", ""},
+		{"==2.8.*", ""},
+		{">=1.0,<2.0", ""},
+		{"", ""},
+		{"  ==1.0  ", "1.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, parsePinnedVersion(tt.input))
+		})
+	}
+}

--- a/providers/os/resources/languages/python/requirements/setup.go
+++ b/providers/os/resources/languages/python/requirements/setup.go
@@ -14,12 +14,12 @@ import (
 //
 //	'pathlib3==2.2.0;python_version<"3.6"'
 //	"mypy==v0.770",
-var pinnedQuoted = regexp.MustCompile(`['"](\w[\w.\-]*)\s*==\s*([\w.\-]+)`)
+var pinnedQuoted = regexp.MustCompile(`['"]([a-zA-Z0-9][\w.\-]*)\s*==\s*([\w.\-]+)`)
 
 // pinnedUnquoted matches unquoted pinned dependencies, e.g.:
 //
 //	mypy == v0.770
-var pinnedUnquoted = regexp.MustCompile(`^\s*(\w[\w.\-]*)\s*==\s*([\w.\-]+)`)
+var pinnedUnquoted = regexp.MustCompile(`^\s*([a-zA-Z0-9][\w.\-]*)\s*==\s*([\w.\-]+)`)
 
 // ParseSetupPy scans a setup.py (or setup.cfg) file for pinned dependencies
 // (name==version). It extracts both quoted strings inside install_requires

--- a/providers/os/resources/languages/python/requirements/setup.go
+++ b/providers/os/resources/languages/python/requirements/setup.go
@@ -1,0 +1,69 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package requirements
+
+import (
+	"bufio"
+	"io"
+	"regexp"
+	"strings"
+)
+
+// pinnedQuoted matches quoted pinned dependencies in setup.py, e.g.:
+//
+//	'pathlib3==2.2.0;python_version<"3.6"'
+//	"mypy==v0.770",
+var pinnedQuoted = regexp.MustCompile(`['"](\w[\w.\-]*)\s*==\s*([\w.\-]+)`)
+
+// pinnedUnquoted matches unquoted pinned dependencies, e.g.:
+//
+//	mypy == v0.770
+var pinnedUnquoted = regexp.MustCompile(`^\s*(\w[\w.\-]*)\s*==\s*([\w.\-]+)`)
+
+// ParseSetupPy scans a setup.py (or setup.cfg) file for pinned dependencies
+// (name==version). It extracts both quoted strings inside install_requires
+// lists and bare unquoted assignments.
+func ParseSetupPy(r io.Reader) ([]Requirement, error) {
+	scanner := bufio.NewScanner(r)
+	seen := map[string]bool{}
+	var reqs []Requirement
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Quoted dependencies (can appear multiple times per line)
+		for _, m := range pinnedQuoted.FindAllStringSubmatch(line, -1) {
+			name, version := m[1], m[2]
+			if hasTemplate(name) || hasTemplate(version) {
+				continue
+			}
+			key := strings.ToLower(name) + "==" + version
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			reqs = append(reqs, Requirement{Name: name, Version: version})
+		}
+
+		// Unquoted dependency (one per line)
+		if m := pinnedUnquoted.FindStringSubmatch(line); m != nil {
+			name, version := m[1], m[2]
+			if hasTemplate(name) || hasTemplate(version) {
+				continue
+			}
+			key := strings.ToLower(name) + "==" + version
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			reqs = append(reqs, Requirement{Name: name, Version: version})
+		}
+	}
+
+	return reqs, scanner.Err()
+}
+
+func hasTemplate(s string) bool {
+	return strings.ContainsAny(s, "%{}$")
+}

--- a/providers/os/resources/languages/python/requirements/setup_test.go
+++ b/providers/os/resources/languages/python/requirements/setup_test.go
@@ -1,0 +1,114 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package requirements
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSetupPy_QuotedDeps(t *testing.T) {
+	data := `
+from setuptools import setup
+
+setup(
+    name="myproject",
+    version="1.0.0",
+    install_requires=[
+        'requests==2.31.0',
+        "openai==1.30.0",
+        'transformers==4.40.0;python_version>="3.8"',
+        "numpy>=1.21",
+    ],
+)
+`
+	reqs, err := ParseSetupPy(strings.NewReader(data))
+	require.NoError(t, err)
+
+	// Should find 3 pinned deps, not numpy (not pinned with ==)
+	require.Len(t, reqs, 3)
+
+	byName := map[string]string{}
+	for _, r := range reqs {
+		byName[r.Name] = r.Version
+	}
+	assert.Equal(t, "2.31.0", byName["requests"])
+	assert.Equal(t, "1.30.0", byName["openai"])
+	assert.Equal(t, "4.40.0", byName["transformers"])
+}
+
+func TestParseSetupPy_UnquotedDeps(t *testing.T) {
+	data := `
+mypy == v0.770
+black == 23.3.0
+`
+	reqs, err := ParseSetupPy(strings.NewReader(data))
+	require.NoError(t, err)
+	require.Len(t, reqs, 2)
+	assert.Equal(t, "mypy", reqs[0].Name)
+	assert.Equal(t, "v0.770", reqs[0].Version)
+	assert.Equal(t, "black", reqs[1].Name)
+	assert.Equal(t, "23.3.0", reqs[1].Version)
+}
+
+func TestParseSetupPy_MixedQuotedAndUnquoted(t *testing.T) {
+	data := `
+setup(
+    install_requires=['requests==2.31.0'],
+)
+mypy == v0.770
+`
+	reqs, err := ParseSetupPy(strings.NewReader(data))
+	require.NoError(t, err)
+	require.Len(t, reqs, 2)
+}
+
+func TestParseSetupPy_Templates(t *testing.T) {
+	data := `
+setup(
+    install_requires=[
+        'requests==%s' % req_version,
+        '${package}==1.0.0',
+        'openai==1.30.0',
+    ],
+)
+`
+	reqs, err := ParseSetupPy(strings.NewReader(data))
+	require.NoError(t, err)
+	require.Len(t, reqs, 1)
+	assert.Equal(t, "openai", reqs[0].Name)
+}
+
+func TestParseSetupPy_Deduplication(t *testing.T) {
+	data := `
+    'requests==2.31.0',
+    "requests==2.31.0",
+`
+	reqs, err := ParseSetupPy(strings.NewReader(data))
+	require.NoError(t, err)
+	require.Len(t, reqs, 1)
+}
+
+func TestParseSetupPy_Empty(t *testing.T) {
+	reqs, err := ParseSetupPy(strings.NewReader(""))
+	require.NoError(t, err)
+	assert.Empty(t, reqs)
+}
+
+func TestParseSetupPy_SetupCfg(t *testing.T) {
+	data := `
+[options]
+install_requires =
+    requests==2.31.0
+    openai==1.30.0
+`
+	reqs, err := ParseSetupPy(strings.NewReader(data))
+	require.NoError(t, err)
+	require.Len(t, reqs, 2)
+	assert.Equal(t, "requests", reqs[0].Name)
+	assert.Equal(t, "openai", reqs[1].Name)
+}

--- a/providers/os/resources/python.go
+++ b/providers/os/resources/python.go
@@ -137,16 +137,7 @@ func (r *mqlPython) getAllPackages() ([]python.PackageDetails, error) {
 
 		return allResults, nil
 	} else {
-		installed, err := collectPythonPackagesInPaths(r.MqlRuntime, fs, defaultPythonPaths)
-		if err != nil {
-			return nil, err
-		}
-
-		// Also scan common project directories for source manifests
-		manifestResults := collectPythonManifestPackages(fs, ".")
-		installed = mergePythonPackages(installed, manifestResults)
-
-		return installed, nil
+		return collectPythonPackagesInPaths(r.MqlRuntime, fs, defaultPythonPaths)
 	}
 }
 
@@ -486,6 +477,7 @@ func parseRequirementsTxtFile(afs *afero.Afero, dir string) []python.PackageDeta
 			File:    reqPath,
 			Purl:    python.NewPackageUrl(req.Name, req.Version),
 			Cpes:    python.NewCpes(req.Name, req.Version),
+			IsLeaf:  true,
 		})
 	}
 	return results
@@ -515,6 +507,7 @@ func parseSetupFile(afs *afero.Afero, dir, name string) []python.PackageDetails 
 			File:    p,
 			Purl:    python.NewPackageUrl(req.Name, req.Version),
 			Cpes:    python.NewCpes(req.Name, req.Version),
+			IsLeaf:  true,
 		})
 	}
 	return results
@@ -532,6 +525,7 @@ func languagePackagesToDetails(pkgs languages.Packages, file string) []python.Pa
 			Cpes:    pkg.Cpes,
 			License: pkg.License,
 			Author:  pkg.Author,
+			IsLeaf:  true,
 		})
 	}
 	return results

--- a/providers/os/resources/python.go
+++ b/providers/os/resources/python.go
@@ -17,8 +17,13 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
 	"go.mondoo.com/mql/v13/providers/os/fsutil"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages"
 	"go.mondoo.com/mql/v13/providers/os/resources/languages/python"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages/python/pdmlock"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages/python/pipfilelock"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages/python/poetrylock"
 	"go.mondoo.com/mql/v13/providers/os/resources/languages/python/requirements"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages/python/uvlock"
 	"go.mondoo.com/mql/v13/providers/os/resources/languages/python/wheelegg"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -121,14 +126,27 @@ func (r *mqlPython) getAllPackages() ([]python.PackageDetails, error) {
 	}
 	pyPath := r.Path.Data
 	if pyPath != "" {
-		// only search the specific path provided (if it was provided)
 		allResults, err := collectPythonPackages(r.MqlRuntime, fs, pyPath)
 		if err != nil {
 			return nil, err
 		}
+
+		// Also scan for source manifests (requirements.txt, lock files) in the path.
+		manifestResults := collectPythonManifestPackages(fs, pyPath)
+		allResults = mergePythonPackages(allResults, manifestResults)
+
 		return allResults, nil
 	} else {
-		return collectPythonPackagesInPaths(r.MqlRuntime, fs, defaultPythonPaths)
+		installed, err := collectPythonPackagesInPaths(r.MqlRuntime, fs, defaultPythonPaths)
+		if err != nil {
+			return nil, err
+		}
+
+		// Also scan common project directories for source manifests
+		manifestResults := collectPythonManifestPackages(fs, ".")
+		installed = mergePythonPackages(installed, manifestResults)
+
+		return installed, nil
 	}
 }
 
@@ -390,4 +408,150 @@ func (r *mqlPythonPackage) dependencies() ([]any, error) {
 		}
 	}
 	return deps, nil
+}
+
+// pythonManifestFiles maps manifest filenames to their extractor. Lock files
+// are listed first so they take priority (checked in order).
+var pythonManifestFiles = []struct {
+	name      string
+	extractor languages.Extractor
+}{
+	{"Pipfile.lock", &pipfilelock.Extractor{}},
+	{"poetry.lock", &poetrylock.Extractor{}},
+	{"uv.lock", &uvlock.Extractor{}},
+	{"pdm.lock", &pdmlock.Extractor{}},
+}
+
+// collectPythonManifestPackages scans a directory for Python source manifest
+// files (lock files and requirements.txt) and returns packages found in them.
+// It prioritises lock files over requirements.txt to avoid duplicates.
+func collectPythonManifestPackages(fs afero.Fs, dir string) []python.PackageDetails {
+	afs := &afero.Afero{Fs: fs}
+
+	// Try lock files first — if any succeeds, use it and skip requirements.txt.
+	for _, mf := range pythonManifestFiles {
+		p := filepath.Join(dir, mf.name)
+		f, err := afs.Open(p)
+		if err != nil {
+			continue
+		}
+		bom, err := mf.extractor.Parse(f, p)
+		f.Close()
+		if err != nil {
+			log.Debug().Err(err).Str("file", p).Msg("failed to parse python manifest")
+			continue
+		}
+		pkgs := bom.Transitive()
+		if len(pkgs) > 0 {
+			return languagePackagesToDetails(pkgs, p)
+		}
+	}
+
+	// Fall back to requirements.txt
+	if results := parseRequirementsTxtFile(afs, dir); len(results) > 0 {
+		return results
+	}
+
+	// Fall back to setup.py / setup.cfg
+	for _, name := range []string{"setup.py", "setup.cfg"} {
+		if results := parseSetupFile(afs, dir, name); len(results) > 0 {
+			return results
+		}
+	}
+
+	return nil
+}
+
+func parseRequirementsTxtFile(afs *afero.Afero, dir string) []python.PackageDetails {
+	reqPath := filepath.Join(dir, "requirements.txt")
+	f, err := afs.Open(reqPath)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	reqs, err := requirements.ParseRequirementsTxt(f)
+	if err != nil {
+		log.Debug().Err(err).Str("file", reqPath).Msg("failed to parse requirements.txt")
+		return nil
+	}
+
+	var results []python.PackageDetails
+	for _, req := range reqs {
+		if req.Name == "" {
+			continue
+		}
+		results = append(results, python.PackageDetails{
+			Name:    req.Name,
+			Version: req.Version,
+			File:    reqPath,
+			Purl:    python.NewPackageUrl(req.Name, req.Version),
+			Cpes:    python.NewCpes(req.Name, req.Version),
+		})
+	}
+	return results
+}
+
+func parseSetupFile(afs *afero.Afero, dir, name string) []python.PackageDetails {
+	p := filepath.Join(dir, name)
+	f, err := afs.Open(p)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	reqs, err := requirements.ParseSetupPy(f)
+	if err != nil {
+		log.Debug().Err(err).Str("file", p).Msg("failed to parse setup file")
+		return nil
+	}
+
+	var results []python.PackageDetails
+	for _, req := range reqs {
+		if req.Name == "" {
+			continue
+		}
+		results = append(results, python.PackageDetails{
+			Name:    req.Name,
+			Version: req.Version,
+			File:    p,
+			Purl:    python.NewPackageUrl(req.Name, req.Version),
+			Cpes:    python.NewCpes(req.Name, req.Version),
+		})
+	}
+	return results
+}
+
+// languagePackagesToDetails converts languages.Packages to python.PackageDetails.
+func languagePackagesToDetails(pkgs languages.Packages, file string) []python.PackageDetails {
+	results := make([]python.PackageDetails, 0, len(pkgs))
+	for _, pkg := range pkgs {
+		results = append(results, python.PackageDetails{
+			Name:    pkg.Name,
+			Version: pkg.Version,
+			File:    file,
+			Purl:    pkg.Purl,
+			Cpes:    pkg.Cpes,
+			License: pkg.License,
+			Author:  pkg.Author,
+		})
+	}
+	return results
+}
+
+// mergePythonPackages merges two slices of PackageDetails, deduplicating by name.
+// Packages from the primary slice take precedence.
+func mergePythonPackages(primary, secondary []python.PackageDetails) []python.PackageDetails {
+	if len(secondary) == 0 {
+		return primary
+	}
+	seen := make(map[string]bool, len(primary))
+	for _, p := range primary {
+		seen[strings.ToLower(p.Name)] = true
+	}
+	for _, p := range secondary {
+		if !seen[strings.ToLower(p.Name)] {
+			primary = append(primary, p)
+			seen[strings.ToLower(p.Name)] = true
+		}
+	}
+	return primary
 }

--- a/providers/os/resources/python_manifest_internal_test.go
+++ b/providers/os/resources/python_manifest_internal_test.go
@@ -1,0 +1,232 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages/python"
+)
+
+func TestCollectPythonManifestPackages_PipfileLock(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "/project/Pipfile.lock", []byte(`{
+		"_meta": {"hash": {"sha256": "abc"}, "pipfile-spec": 6},
+		"default": {
+			"openai": {"version": "==1.30.0"},
+			"requests": {"version": "==2.32.0"}
+		},
+		"develop": {}
+	}`), 0644)
+
+	results := collectPythonManifestPackages(fs, "/project")
+
+	require.Len(t, results, 2)
+	names := map[string]string{}
+	for _, r := range results {
+		names[r.Name] = r.Version
+	}
+	assert.Equal(t, "1.30.0", names["openai"])
+	assert.Equal(t, "2.32.0", names["requests"])
+
+	for _, r := range results {
+		assert.NotEmpty(t, r.Purl, "should have PURL for %s", r.Name)
+		assert.Equal(t, "/project/Pipfile.lock", r.File)
+	}
+}
+
+func TestCollectPythonManifestPackages_PoetryLock(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "/project/poetry.lock", []byte(`
+[[package]]
+name = "anthropic"
+version = "0.25.0"
+
+[[package]]
+name = "httpx"
+version = "0.27.0"
+`), 0644)
+
+	results := collectPythonManifestPackages(fs, "/project")
+
+	require.Len(t, results, 2)
+	names := map[string]string{}
+	for _, r := range results {
+		names[r.Name] = r.Version
+	}
+	assert.Equal(t, "0.25.0", names["anthropic"])
+	assert.Equal(t, "0.27.0", names["httpx"])
+}
+
+func TestCollectPythonManifestPackages_RequirementsTxt(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "/project/requirements.txt", []byte(`
+transformers>=4.40.0
+torch==2.3.0
+numpy
+# comment line
+`), 0644)
+
+	results := collectPythonManifestPackages(fs, "/project")
+
+	require.Len(t, results, 3)
+	byName := map[string]string{}
+	for _, r := range results {
+		byName[r.Name] = r.Version
+	}
+	assert.Contains(t, byName, "transformers")
+	assert.Contains(t, byName, "torch")
+	assert.Contains(t, byName, "numpy")
+
+	// Pinned versions (==) should be extracted
+	assert.Equal(t, "2.3.0", byName["torch"])
+	// Unpinned constraints (>=) have empty version
+	assert.Equal(t, "", byName["transformers"])
+	// Bare names have empty version
+	assert.Equal(t, "", byName["numpy"])
+}
+
+func TestCollectPythonManifestPackages_LockFilePriority(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	// Both Pipfile.lock and requirements.txt exist — lock file should win
+	_ = afero.WriteFile(fs, "/project/Pipfile.lock", []byte(`{
+		"_meta": {"hash": {"sha256": "abc"}, "pipfile-spec": 6},
+		"default": {"openai": {"version": "==1.30.0"}},
+		"develop": {}
+	}`), 0644)
+	_ = afero.WriteFile(fs, "/project/requirements.txt", []byte("openai\ntorch\n"), 0644)
+
+	results := collectPythonManifestPackages(fs, "/project")
+
+	// Should use Pipfile.lock (1 package with version), not requirements.txt (2 packages without)
+	require.Len(t, results, 1)
+	assert.Equal(t, "openai", results[0].Name)
+	assert.Equal(t, "1.30.0", results[0].Version)
+}
+
+func TestCollectPythonManifestPackages_NoManifest(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_ = fs.Mkdir("/project", 0755)
+
+	results := collectPythonManifestPackages(fs, "/project")
+	assert.Nil(t, results)
+}
+
+func TestCollectPythonManifestPackages_SetupPy(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "/project/setup.py", []byte(`
+from setuptools import setup
+
+setup(
+    name="myproject",
+    version="1.0.0",
+    install_requires=[
+        'openai==1.30.0',
+        "transformers==4.40.0",
+        'numpy>=1.21',
+    ],
+)
+`), 0644)
+
+	results := collectPythonManifestPackages(fs, "/project")
+
+	require.Len(t, results, 2)
+	byName := map[string]string{}
+	for _, r := range results {
+		byName[r.Name] = r.Version
+	}
+	assert.Equal(t, "1.30.0", byName["openai"])
+	assert.Equal(t, "4.40.0", byName["transformers"])
+
+	for _, r := range results {
+		assert.Equal(t, "/project/setup.py", r.File)
+		assert.NotEmpty(t, r.Purl, "should have PURL for %s", r.Name)
+	}
+}
+
+func TestCollectPythonManifestPackages_SetupCfg(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "/project/setup.cfg", []byte(`
+[options]
+install_requires =
+    requests==2.31.0
+    anthropic==0.25.0
+`), 0644)
+
+	results := collectPythonManifestPackages(fs, "/project")
+
+	require.Len(t, results, 2)
+	byName := map[string]string{}
+	for _, r := range results {
+		byName[r.Name] = r.Version
+	}
+	assert.Equal(t, "2.31.0", byName["requests"])
+	assert.Equal(t, "0.25.0", byName["anthropic"])
+}
+
+func TestCollectPythonManifestPackages_LockFileBeatsSetupPy(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	// Both Pipfile.lock and setup.py exist — lock file should win
+	_ = afero.WriteFile(fs, "/project/Pipfile.lock", []byte(`{
+		"_meta": {"hash": {"sha256": "abc"}, "pipfile-spec": 6},
+		"default": {"openai": {"version": "==1.30.0"}},
+		"develop": {}
+	}`), 0644)
+	_ = afero.WriteFile(fs, "/project/setup.py", []byte(`
+setup(install_requires=['openai==1.28.0', 'torch==2.3.0'])
+`), 0644)
+
+	results := collectPythonManifestPackages(fs, "/project")
+
+	require.Len(t, results, 1)
+	assert.Equal(t, "openai", results[0].Name)
+	assert.Equal(t, "1.30.0", results[0].Version)
+}
+
+func TestMergePythonPackages(t *testing.T) {
+	primary := []python.PackageDetails{
+		{Name: "openai", Version: "1.30.0"},
+		{Name: "requests", Version: "2.32.0"},
+	}
+	secondary := []python.PackageDetails{
+		{Name: "openai", Version: "1.28.0"},  // duplicate, should be skipped
+		{Name: "torch", Version: "2.3.0"},     // new, should be added
+	}
+
+	merged := mergePythonPackages(primary, secondary)
+
+	require.Len(t, merged, 3)
+	names := map[string]string{}
+	for _, p := range merged {
+		names[p.Name] = p.Version
+	}
+	assert.Equal(t, "1.30.0", names["openai"], "primary should take precedence")
+	assert.Equal(t, "2.32.0", names["requests"])
+	assert.Equal(t, "2.3.0", names["torch"])
+}
+
+func TestMergePythonPackages_CaseInsensitive(t *testing.T) {
+	primary := []python.PackageDetails{
+		{Name: "PyYAML", Version: "6.0.1"},
+	}
+	secondary := []python.PackageDetails{
+		{Name: "pyyaml", Version: "6.0.0"},
+	}
+
+	merged := mergePythonPackages(primary, secondary)
+	require.Len(t, merged, 1)
+	assert.Equal(t, "PyYAML", merged[0].Name)
+}
+
+func TestMergePythonPackages_EmptySecondary(t *testing.T) {
+	primary := []python.PackageDetails{
+		{Name: "openai", Version: "1.30.0"},
+	}
+
+	merged := mergePythonPackages(primary, nil)
+	assert.Equal(t, primary, merged)
+}

--- a/providers/os/resources/python_manifest_internal_test.go
+++ b/providers/os/resources/python_manifest_internal_test.go
@@ -193,8 +193,8 @@ func TestMergePythonPackages(t *testing.T) {
 		{Name: "requests", Version: "2.32.0"},
 	}
 	secondary := []python.PackageDetails{
-		{Name: "openai", Version: "1.28.0"},  // duplicate, should be skipped
-		{Name: "torch", Version: "2.3.0"},     // new, should be added
+		{Name: "openai", Version: "1.28.0"}, // duplicate, should be skipped
+		{Name: "torch", Version: "2.3.0"},   // new, should be added
 	}
 
 	merged := mergePythonPackages(primary, secondary)


### PR DESCRIPTION
## Summary
- Extend the Python resource to discover and parse source-level dependency manifests when scanning directories
- Add `requirements.txt` parser with full PEP 508 support: pinned version extraction (`==`/`===`), extras (`[security]`), comments, line continuations, editable installs, and wildcard rejection
- Add `setup.py`/`setup.cfg` parser using regex-based extraction of pinned dependencies from `install_requires` lists and INI-style `[options]` sections
- Wire manifest scanning into the Python resource with priority ordering: lock files (Pipfile.lock, poetry.lock, uv.lock, pdm.lock) > requirements.txt > setup.py/setup.cfg
- Merge manifest packages with installed packages using case-insensitive deduplication

## Test plan
- [x] 16 unit tests for requirements.txt parser (pinned versions, comments, line continuations, extras, options, wildcards, empty)
- [x] 7 unit tests for setup.py parser (quoted deps, unquoted, mixed, templates, deduplication, empty, setup.cfg)
- [x] 11 integration tests for manifest scanning (Pipfile.lock, poetry.lock, requirements.txt, setup.py, setup.cfg, lock file priority, merge, case-insensitive dedup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)