### PR TITLE
✨ huggingface: add namespace flags and computed author/sha fields

### DIFF
--- a/providers/huggingface/config/config.go
+++ b/providers/huggingface/config/config.go
@@ -25,6 +25,17 @@ var Config = plugin.Provider{
 					Type: plugin.FlagType_String,
 					Desc: "Hugging Face API token (or set HF_TOKEN env var)",
 				},
+				{
+					Long: "namespace",
+					Type: plugin.FlagType_String,
+					Desc: "Target a specific user or organization namespace (e.g. openai)",
+				},
+				{
+					Long:    "namespace-type",
+					Type:    plugin.FlagType_String,
+					Default: "user",
+					Desc:    "Type of the namespace: user or org",
+				},
 			},
 		},
 	},

--- a/providers/huggingface/provider/provider.go
+++ b/providers/huggingface/provider/provider.go
@@ -50,7 +50,11 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	}
 
 	if nsType, ok := flags["namespace-type"]; ok {
-		conf.Options[connection.NamespaceType] = string(nsType.Value)
+		val := string(nsType.Value)
+		if val != connection.NamespaceTypeUser && val != connection.NamespaceTypeOrg {
+			return nil, fmt.Errorf("invalid --namespace-type %q: must be %q or %q", val, connection.NamespaceTypeUser, connection.NamespaceTypeOrg)
+		}
+		conf.Options[connection.NamespaceType] = val
 	}
 
 	discoverTargets := []string{}

--- a/providers/huggingface/provider/provider.go
+++ b/providers/huggingface/provider/provider.go
@@ -45,6 +45,14 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		conf.Options[connection.TokenOption] = string(token.Value)
 	}
 
+	if ns, ok := flags["namespace"]; ok {
+		conf.Options[connection.NamespaceOption] = string(ns.Value)
+	}
+
+	if nsType, ok := flags["namespace-type"]; ok {
+		conf.Options[connection.NamespaceType] = string(nsType.Value)
+	}
+
 	discoverTargets := []string{}
 	if x, ok := flags["discover"]; ok && len(x.Array) != 0 {
 		for i := range x.Array {

--- a/providers/huggingface/resources/huggingface.go
+++ b/providers/huggingface/resources/huggingface.go
@@ -156,7 +156,10 @@ func createModelResource(runtime *plugin.Runtime, m hfmodels.Model) (*mqlHugging
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlHuggingfaceModel), nil
+	model := res.(*mqlHuggingfaceModel)
+	model.listAuthor = m.Author
+	model.listSha = m.Sha
+	return model, nil
 }
 
 func (r *mqlHuggingface) datasets() ([]any, error) {
@@ -470,6 +473,8 @@ func initHuggingfaceModel(runtime *plugin.Runtime, args map[string]*llx.RawData)
 }
 
 type mqlHuggingfaceModelInternal struct {
+	listAuthor string
+	listSha    string
 	detail     *hfmodels.ModelDetail
 	detailOnce sync.Once
 	detailErr  error
@@ -488,6 +493,9 @@ func (r *mqlHuggingfaceModel) id() (string, error) {
 }
 
 func (r *mqlHuggingfaceModel) author() (string, error) {
+	if r.listAuthor != "" {
+		return r.listAuthor, nil
+	}
 	detail, err := r.fetchDetail()
 	if err != nil {
 		return "", err
@@ -502,6 +510,9 @@ func (r *mqlHuggingfaceModel) author() (string, error) {
 }
 
 func (r *mqlHuggingfaceModel) sha() (string, error) {
+	if r.listSha != "" {
+		return r.listSha, nil
+	}
 	detail, err := r.fetchDetail()
 	if err != nil {
 		return "", err

--- a/providers/huggingface/resources/huggingface.go
+++ b/providers/huggingface/resources/huggingface.go
@@ -143,14 +143,12 @@ func createModelResource(runtime *plugin.Runtime, m hfmodels.Model) (*mqlHugging
 		"__id":         llx.StringData("huggingface.model/" + m.ID),
 		"id":           llx.StringData(m.ID),
 		"modelId":      llx.StringData(m.ModelID),
-		"author":       llx.StringData(m.Author),
 		"private":      llx.BoolData(m.Private),
 		"pipelineTag":  llx.StringData(m.PipelineTag),
 		"libraryName":  llx.StringData(m.LibraryName),
 		"tags":         llx.ArrayData(stringsToInterface(m.Tags), types.String),
 		"downloads":    llx.IntData(int64(m.Downloads)),
 		"likes":        llx.IntData(int64(m.Likes)),
-		"sha":          llx.StringData(m.Sha),
 		"lastModified": llx.TimeDataPtr(lastMod),
 		"gated":        llx.BoolData(m.Gated.IsGated),
 		"disabled":     llx.BoolData(m.Disabled),
@@ -487,6 +485,28 @@ func (r *mqlHuggingfaceModel) fetchDetail() (*hfmodels.ModelDetail, error) {
 
 func (r *mqlHuggingfaceModel) id() (string, error) {
 	return "huggingface.model/" + r.Id.Data, nil
+}
+
+func (r *mqlHuggingfaceModel) author() (string, error) {
+	detail, err := r.fetchDetail()
+	if err != nil {
+		return "", err
+	}
+	if detail.Author != "" {
+		return detail.Author, nil
+	}
+	if parts := strings.SplitN(detail.ID, "/", 2); len(parts) == 2 {
+		return parts[0], nil
+	}
+	return "", nil
+}
+
+func (r *mqlHuggingfaceModel) sha() (string, error) {
+	detail, err := r.fetchDetail()
+	if err != nil {
+		return "", err
+	}
+	return detail.Sha, nil
 }
 
 func (r *mqlHuggingfaceModel) createdAt() (*time.Time, error) {

--- a/providers/huggingface/resources/huggingface.lr
+++ b/providers/huggingface/resources/huggingface.lr
@@ -100,7 +100,7 @@ huggingface.model @defaults("id author") {
   id string
   // Internal model identifier
   modelId string
-  author string
+  author() string
   private bool
   // ML pipeline tag
   //
@@ -115,7 +115,7 @@ huggingface.model @defaults("id author") {
   downloads int
   likes int
   // Git SHA of the current revision
-  sha string
+  sha() string
   createdAt() time
   lastModified time
   // Whether the model requires access approval

--- a/providers/huggingface/resources/huggingface.lr.go
+++ b/providers/huggingface/resources/huggingface.lr.go
@@ -1320,7 +1320,9 @@ func (c *mqlHuggingfaceModel) GetModelId() *plugin.TValue[string] {
 }
 
 func (c *mqlHuggingfaceModel) GetAuthor() *plugin.TValue[string] {
-	return &c.Author
+	return plugin.GetOrCompute[string](&c.Author, func() (string, error) {
+		return c.author()
+	})
 }
 
 func (c *mqlHuggingfaceModel) GetPrivate() *plugin.TValue[bool] {
@@ -1348,7 +1350,9 @@ func (c *mqlHuggingfaceModel) GetLikes() *plugin.TValue[int64] {
 }
 
 func (c *mqlHuggingfaceModel) GetSha() *plugin.TValue[string] {
-	return &c.Sha
+	return plugin.GetOrCompute[string](&c.Sha, func() (string, error) {
+		return c.sha()
+	})
 }
 
 func (c *mqlHuggingfaceModel) GetCreatedAt() *plugin.TValue[*time.Time] {


### PR DESCRIPTION
## Summary
- Add `--namespace` and `--namespace-type` CLI flags to target a specific user or organization namespace when scanning HuggingFace (e.g. `cnquery scan huggingface --namespace openai --namespace-type org`)
- Make `author` and `sha` computed fields on `huggingface.model` that fetch from the model detail API on demand, avoiding failures when the list API doesn't return these fields
- The `author` field falls back to extracting from the model ID (`org/model` format) when the detail API response is empty

## Test plan
- [ ] `cnquery scan huggingface --namespace <user>` targets only that user's models
- [ ] `cnquery scan huggingface --namespace <org> --namespace-type org` targets the organization
- [ ] `huggingface.models { author sha }` fetches computed fields correctly
- [ ] Existing `huggingface.models` queries continue to work without namespace flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)