### PR TITLE
⚡ gcp: dedupe org IAM fetch and add missing pagination

### DIFF
--- a/providers/gcp/resources/apikeys.go
+++ b/providers/gcp/resources/apikeys.go
@@ -48,13 +48,16 @@ func (g *mqlGcpProject) apiKeys() ([]any, error) {
 		return nil, err
 	}
 
-	keys, err := apiKeysSvc.Projects.Locations.Keys.List(fmt.Sprintf("projects/%s/locations/global", projectId)).Do()
-	if err != nil {
+	var apiKeyItems []*apikeys.V2Key
+	if err := apiKeysSvc.Projects.Locations.Keys.List(fmt.Sprintf("projects/%s/locations/global", projectId)).Pages(ctx, func(page *apikeys.V2ListKeysResponse) error {
+		apiKeyItems = append(apiKeyItems, page.Keys...)
+		return nil
+	}); err != nil {
 		return nil, err
 	}
 
-	mqlKeys := make([]any, 0, len(keys.Keys))
-	for _, k := range keys.Keys {
+	mqlKeys := make([]any, 0, len(apiKeyItems))
+	for _, k := range apiKeyItems {
 		var mqlRestrictions plugin.Resource
 		if k.Restrictions != nil {
 			var mqlAndroidRestr any

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -2336,242 +2336,244 @@ func (g *mqlGcpProjectComputeService) backendServices() ([]any, error) {
 		return nil, err
 	}
 
-	list, err := computeSvc.BackendServices.AggregatedList(projectId).Do()
-	if err != nil {
-		return nil, err
-	}
+	var res []any
+	req := computeSvc.BackendServices.AggregatedList(projectId)
+	if err := req.Pages(ctx, func(page *compute.BackendServiceAggregatedList) error {
+		for _, sb := range page.Items {
+			for _, b := range sb.BackendServices {
+				backendServiceId := strconv.FormatUint(b.Id, 10)
+				mqlBackends := make([]any, 0, len(b.Backends))
+				for _, backend := range b.Backends {
+					mqlBackend, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.backendService.backend", map[string]*llx.RawData{
+						"id":                        llx.StringData(fmt.Sprintf("gcp.project.computeService.backendService.backend/%s/%s", backendServiceId, backend.Group)),
+						"balancingMode":             llx.StringData(backend.BalancingMode),
+						"capacityScaler":            llx.FloatData(backend.CapacityScaler),
+						"description":               llx.StringData(backend.Description),
+						"failover":                  llx.BoolData(backend.Failover),
+						"groupUrl":                  llx.StringData(backend.Group),
+						"maxConnections":            llx.IntData(backend.MaxConnections),
+						"maxConnectionsPerEndpoint": llx.IntData(backend.MaxConnectionsPerEndpoint),
+						"maxConnectionsPerInstance": llx.IntData(backend.MaxConnectionsPerInstance),
+						"maxRate":                   llx.IntData(backend.MaxRate),
+						"maxRatePerEndpoint":        llx.FloatData(backend.MaxRatePerEndpoint),
+						"maxRatePerInstance":        llx.FloatData(backend.MaxRatePerInstance),
+						"maxUtilization":            llx.FloatData(backend.MaxUtilization),
+					})
+					if err != nil {
+						return err
+					}
+					mqlBackends = append(mqlBackends, mqlBackend)
+				}
 
-	res := make([]any, 0, len(list.Items))
-	for _, sb := range list.Items {
-		for _, b := range sb.BackendServices {
-			backendServiceId := strconv.FormatUint(b.Id, 10)
-			mqlBackends := make([]any, 0, len(b.Backends))
-			for _, backend := range b.Backends {
-				mqlBackend, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.backendService.backend", map[string]*llx.RawData{
-					"id":                        llx.StringData(fmt.Sprintf("gcp.project.computeService.backendService.backend/%s/%s", backendServiceId, backend.Group)),
-					"balancingMode":             llx.StringData(backend.BalancingMode),
-					"capacityScaler":            llx.FloatData(backend.CapacityScaler),
-					"description":               llx.StringData(backend.Description),
-					"failover":                  llx.BoolData(backend.Failover),
-					"groupUrl":                  llx.StringData(backend.Group),
-					"maxConnections":            llx.IntData(backend.MaxConnections),
-					"maxConnectionsPerEndpoint": llx.IntData(backend.MaxConnectionsPerEndpoint),
-					"maxConnectionsPerInstance": llx.IntData(backend.MaxConnectionsPerInstance),
-					"maxRate":                   llx.IntData(backend.MaxRate),
-					"maxRatePerEndpoint":        llx.FloatData(backend.MaxRatePerEndpoint),
-					"maxRatePerInstance":        llx.FloatData(backend.MaxRatePerInstance),
-					"maxUtilization":            llx.FloatData(backend.MaxUtilization),
+				var cdnPolicy plugin.Resource
+				if b.CdnPolicy != nil {
+					bypassCacheOnRequestHeaders := make([]any, 0, len(b.CdnPolicy.BypassCacheOnRequestHeaders))
+					for _, h := range b.CdnPolicy.BypassCacheOnRequestHeaders {
+						mqlH := map[string]any{"headerName": h.HeaderName}
+						bypassCacheOnRequestHeaders = append(bypassCacheOnRequestHeaders, mqlH)
+					}
+
+					var mqlCacheKeyPolicy any
+					if b.CdnPolicy.CacheKeyPolicy != nil {
+						mqlCacheKeyPolicy = map[string]any{
+							"includeHost":          b.CdnPolicy.CacheKeyPolicy.IncludeHost,
+							"includeHttpHeaders":   convert.SliceAnyToInterface(b.CdnPolicy.CacheKeyPolicy.IncludeHttpHeaders),
+							"includeNamedCookies":  convert.SliceAnyToInterface(b.CdnPolicy.CacheKeyPolicy.IncludeNamedCookies),
+							"includeProtocol":      b.CdnPolicy.CacheKeyPolicy.IncludeProtocol,
+							"includeQueryString":   b.CdnPolicy.CacheKeyPolicy.IncludeQueryString,
+							"queryStringBlacklist": convert.SliceAnyToInterface(b.CdnPolicy.CacheKeyPolicy.QueryStringBlacklist),
+							"queryStringWhitelist": convert.SliceAnyToInterface(b.CdnPolicy.CacheKeyPolicy.QueryStringWhitelist),
+						}
+					}
+
+					mqlNegativeCachingPolicy := make([]any, 0, len(b.CdnPolicy.NegativeCachingPolicy))
+					for _, p := range b.CdnPolicy.NegativeCachingPolicy {
+						mqlP := map[string]any{
+							"code": p.Code,
+							"ttl":  p.Ttl,
+						}
+						mqlNegativeCachingPolicy = append(mqlNegativeCachingPolicy, mqlP)
+					}
+
+					var err error
+					cdnPolicy, err = CreateResource(g.MqlRuntime, "gcp.project.computeService.backendService.cdnPolicy", map[string]*llx.RawData{
+						"id":                          llx.StringData(fmt.Sprintf("gcp.project.computeService.backendService.cdnPolicy/%s", backendServiceId)),
+						"bypassCacheOnRequestHeaders": llx.ArrayData(bypassCacheOnRequestHeaders, types.Dict),
+						"cacheKeyPolicy":              llx.DictData(mqlCacheKeyPolicy),
+						"cacheMode":                   llx.StringData(b.CdnPolicy.CacheMode),
+						"clientTtl":                   llx.IntData(b.CdnPolicy.ClientTtl),
+						"defaultTtl":                  llx.IntData(b.CdnPolicy.DefaultTtl),
+						"maxTtl":                      llx.IntData(b.CdnPolicy.MaxTtl),
+						"negativeCaching":             llx.BoolData(b.CdnPolicy.NegativeCaching),
+						"negativeCachingPolicy":       llx.ArrayData(mqlNegativeCachingPolicy, types.Dict),
+						"requestCoalescing":           llx.BoolData(b.CdnPolicy.RequestCoalescing),
+						"serveWhileStale":             llx.IntData(b.CdnPolicy.ServeWhileStale),
+						"signedUrlCacheMaxAgeSec":     llx.IntData(b.CdnPolicy.SignedUrlCacheMaxAgeSec),
+						"signedUrlKeyNames":           llx.ArrayData(convert.SliceAnyToInterface(b.CdnPolicy.SignedUrlKeyNames), types.String),
+					})
+					if err != nil {
+						return err
+					}
+				}
+
+				var mqlCircuitBreakers any
+				if b.CircuitBreakers != nil {
+					mqlCircuitBreakers = map[string]any{
+						"maxConnections":           b.CircuitBreakers.MaxConnections,
+						"maxPendingRequests":       b.CircuitBreakers.MaxPendingRequests,
+						"maxRequests":              b.CircuitBreakers.MaxRequests,
+						"maxRequestsPerConnection": b.CircuitBreakers.MaxRequestsPerConnection,
+						"maxRetries":               b.CircuitBreakers.MaxRetries,
+					}
+				}
+
+				var mqlConnectionDraining any
+				if b.ConnectionDraining != nil {
+					mqlConnectionDraining = map[string]any{
+						"drainingTimeoutSec": b.ConnectionDraining.DrainingTimeoutSec,
+					}
+				}
+
+				var mqlConnectionTrackingPolicy any
+				if b.ConnectionTrackingPolicy != nil {
+					mqlConnectionTrackingPolicy = map[string]any{
+						"connectionPersistenceOnUnhealthyBackends": b.ConnectionTrackingPolicy.ConnectionPersistenceOnUnhealthyBackends,
+						"enableStrongAffinity":                     b.ConnectionTrackingPolicy.EnableStrongAffinity,
+						"idleTimeoutSec":                           b.ConnectionTrackingPolicy.IdleTimeoutSec,
+						"trackingMode":                             b.ConnectionTrackingPolicy.TrackingMode,
+					}
+				}
+
+				var mqlConsistentHash any
+				if b.ConsistentHash != nil {
+					consistentHashMap := map[string]any{
+						"httpHeaderName":  b.ConsistentHash.HttpHeaderName,
+						"minimumRingSize": b.ConsistentHash.MinimumRingSize,
+					}
+					if b.ConsistentHash.HttpCookie != nil {
+						cookieMap := map[string]any{
+							"name": b.ConsistentHash.HttpCookie.Name,
+							"path": b.ConsistentHash.HttpCookie.Path,
+						}
+						if b.ConsistentHash.HttpCookie.Ttl != nil {
+							cookieMap["ttl"] = llx.TimeData(llx.DurationToTime(b.ConsistentHash.HttpCookie.Ttl.Seconds))
+						}
+						consistentHashMap["httpCookie"] = cookieMap
+					}
+					mqlConsistentHash = consistentHashMap
+				}
+
+				var mqlFailoverPolicy any
+				if b.FailoverPolicy != nil {
+					mqlFailoverPolicy = map[string]any{
+						"disableConnectionDrainOnFailover": b.FailoverPolicy.DisableConnectionDrainOnFailover,
+						"dropTrafficIfUnhealthy":           b.FailoverPolicy.DropTrafficIfUnhealthy,
+						"failoverRatio":                    b.FailoverPolicy.FailoverRatio,
+					}
+				}
+
+				var mqlIap any
+				if b.Iap != nil {
+					mqlIap = map[string]any{
+						"serviceEnabled":           b.Iap.Enabled,
+						"oauth2ClientId":           b.Iap.Oauth2ClientId,
+						"oauth2ClientSecret":       b.Iap.Oauth2ClientSecret,
+						"oauth2ClientSecretSha256": b.Iap.Oauth2ClientSecretSha256,
+					}
+				}
+
+				mqlLocalityLbPolicy := make([]any, 0, len(b.LocalityLbPolicies))
+				for _, p := range b.LocalityLbPolicies {
+					var mqlCustomPolicy any
+					if p.CustomPolicy != nil {
+						mqlCustomPolicy = map[string]any{
+							"data": p.CustomPolicy.Data,
+							"name": p.CustomPolicy.Name,
+						}
+					}
+
+					var mqlPolicy any
+					if p.Policy != nil {
+						mqlPolicy = map[string]any{
+							"name": p.Policy.Name,
+						}
+					}
+					mqlLocalityLbPolicy = append(mqlLocalityLbPolicy, map[string]any{
+						"customPolicy": mqlCustomPolicy,
+						"policy":       mqlPolicy,
+					})
+				}
+
+				var mqlLogConfig any
+				if b.LogConfig != nil {
+					mqlLogConfig = map[string]any{
+						"enable":     b.LogConfig.Enable,
+						"sampleRate": b.LogConfig.SampleRate,
+					}
+				}
+
+				var mqlSecuritySettings any
+				if b.SecuritySettings != nil {
+					mqlSecuritySettings = map[string]any{
+						"clientTlsPolicy": b.SecuritySettings.ClientTlsPolicy,
+						"subjectAltNames": convert.SliceAnyToInterface(b.SecuritySettings.SubjectAltNames),
+					}
+				}
+
+				var maxStreamDuration *time.Time
+				if b.MaxStreamDuration != nil {
+					v := llx.DurationToTime(b.MaxStreamDuration.Seconds)
+					maxStreamDuration = &v
+				}
+
+				mqlB, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.backendService", map[string]*llx.RawData{
+					"id":                       llx.StringData(backendServiceId),
+					"affinityCookieTtlSec":     llx.IntData(b.AffinityCookieTtlSec),
+					"backends":                 llx.ArrayData(mqlBackends, types.Resource("gcp.project.computeService.backendService.backend")),
+					"cdnPolicy":                llx.ResourceData(cdnPolicy, " gcp.project.computeService.backendService.cdnPolicy"),
+					"circuitBreakers":          llx.DictData(mqlCircuitBreakers),
+					"compressionMode":          llx.StringData(b.CompressionMode),
+					"connectionDraining":       llx.DictData(mqlConnectionDraining),
+					"connectionTrackingPolicy": llx.DictData(mqlConnectionTrackingPolicy),
+					"consistentHash":           llx.DictData(mqlConsistentHash),
+					"created":                  llx.TimeDataPtr(parseTime(b.CreationTimestamp)),
+					"customRequestHeaders":     llx.ArrayData(convert.SliceAnyToInterface(b.CustomRequestHeaders), types.String),
+					"customResponseHeaders":    llx.ArrayData(convert.SliceAnyToInterface(b.CustomResponseHeaders), types.String),
+					"description":              llx.StringData(b.Description),
+					"edgeSecurityPolicy":       llx.StringData(b.EdgeSecurityPolicy),
+					"enableCDN":                llx.BoolData(b.EnableCDN),
+					"failoverPolicy":           llx.DictData(mqlFailoverPolicy),
+					"healthChecks":             llx.ArrayData(convert.SliceAnyToInterface(b.HealthChecks), types.String),
+					"iap":                      llx.DictData(mqlIap),
+					"loadBalancingScheme":      llx.StringData(b.LoadBalancingScheme),
+					"localityLbPolicies":       llx.ArrayData(mqlLocalityLbPolicy, types.Dict),
+					"localityLbPolicy":         llx.StringData(b.LocalityLbPolicy),
+					"logConfig":                llx.DictData(mqlLogConfig),
+					"maxStreamDuration":        llx.TimeDataPtr(maxStreamDuration),
+					"name":                     llx.StringData(b.Name),
+					"networkUrl":               llx.StringData(b.Network),
+					"portName":                 llx.StringData(b.PortName),
+					"protocol":                 llx.StringData(b.Protocol),
+					"regionUrl":                llx.StringData(b.Region),
+					"securityPolicyUrl":        llx.StringData(b.SecurityPolicy),
+					"securitySettings":         llx.DictData(mqlSecuritySettings),
+					"serviceBindingUrls":       llx.ArrayData(convert.SliceAnyToInterface(b.ServiceBindings), types.String),
+					"sessionAffinity":          llx.StringData(b.SessionAffinity),
+					"timeoutSec":               llx.IntData(b.TimeoutSec),
+					"port":                     llx.IntData(b.Port),
+					"serviceLbPolicy":          llx.StringData(b.ServiceLbPolicy),
+					"ipAddressSelectionPolicy": llx.StringData(b.IpAddressSelectionPolicy),
+					"fingerprint":              llx.StringData(b.Fingerprint),
 				})
 				if err != nil {
-					return nil, err
+					return err
 				}
-				mqlBackends = append(mqlBackends, mqlBackend)
+				res = append(res, mqlB)
 			}
-
-			var cdnPolicy plugin.Resource
-			if b.CdnPolicy != nil {
-				bypassCacheOnRequestHeaders := make([]any, 0, len(b.CdnPolicy.BypassCacheOnRequestHeaders))
-				for _, h := range b.CdnPolicy.BypassCacheOnRequestHeaders {
-					mqlH := map[string]any{"headerName": h.HeaderName}
-					bypassCacheOnRequestHeaders = append(bypassCacheOnRequestHeaders, mqlH)
-				}
-
-				var mqlCacheKeyPolicy any
-				if b.CdnPolicy.CacheKeyPolicy != nil {
-					mqlCacheKeyPolicy = map[string]any{
-						"includeHost":          b.CdnPolicy.CacheKeyPolicy.IncludeHost,
-						"includeHttpHeaders":   convert.SliceAnyToInterface(b.CdnPolicy.CacheKeyPolicy.IncludeHttpHeaders),
-						"includeNamedCookies":  convert.SliceAnyToInterface(b.CdnPolicy.CacheKeyPolicy.IncludeNamedCookies),
-						"includeProtocol":      b.CdnPolicy.CacheKeyPolicy.IncludeProtocol,
-						"includeQueryString":   b.CdnPolicy.CacheKeyPolicy.IncludeQueryString,
-						"queryStringBlacklist": convert.SliceAnyToInterface(b.CdnPolicy.CacheKeyPolicy.QueryStringBlacklist),
-						"queryStringWhitelist": convert.SliceAnyToInterface(b.CdnPolicy.CacheKeyPolicy.QueryStringWhitelist),
-					}
-				}
-
-				mqlNegativeCachingPolicy := make([]any, 0, len(b.CdnPolicy.NegativeCachingPolicy))
-				for _, p := range b.CdnPolicy.NegativeCachingPolicy {
-					mqlP := map[string]any{
-						"code": p.Code,
-						"ttl":  p.Ttl,
-					}
-					mqlNegativeCachingPolicy = append(mqlNegativeCachingPolicy, mqlP)
-				}
-
-				cdnPolicy, err = CreateResource(g.MqlRuntime, "gcp.project.computeService.backendService.cdnPolicy", map[string]*llx.RawData{
-					"id":                          llx.StringData(fmt.Sprintf("gcp.project.computeService.backendService.cdnPolicy/%s", backendServiceId)),
-					"bypassCacheOnRequestHeaders": llx.ArrayData(bypassCacheOnRequestHeaders, types.Dict),
-					"cacheKeyPolicy":              llx.DictData(mqlCacheKeyPolicy),
-					"cacheMode":                   llx.StringData(b.CdnPolicy.CacheMode),
-					"clientTtl":                   llx.IntData(b.CdnPolicy.ClientTtl),
-					"defaultTtl":                  llx.IntData(b.CdnPolicy.DefaultTtl),
-					"maxTtl":                      llx.IntData(b.CdnPolicy.MaxTtl),
-					"negativeCaching":             llx.BoolData(b.CdnPolicy.NegativeCaching),
-					"negativeCachingPolicy":       llx.ArrayData(mqlNegativeCachingPolicy, types.Dict),
-					"requestCoalescing":           llx.BoolData(b.CdnPolicy.RequestCoalescing),
-					"serveWhileStale":             llx.IntData(b.CdnPolicy.ServeWhileStale),
-					"signedUrlCacheMaxAgeSec":     llx.IntData(b.CdnPolicy.SignedUrlCacheMaxAgeSec),
-					"signedUrlKeyNames":           llx.ArrayData(convert.SliceAnyToInterface(b.CdnPolicy.SignedUrlKeyNames), types.String),
-				})
-				if err != nil {
-					return nil, err
-				}
-			}
-
-			var mqlCircuitBreakers any
-			if b.CircuitBreakers != nil {
-				mqlCircuitBreakers = map[string]any{
-					"maxConnections":           b.CircuitBreakers.MaxConnections,
-					"maxPendingRequests":       b.CircuitBreakers.MaxPendingRequests,
-					"maxRequests":              b.CircuitBreakers.MaxRequests,
-					"maxRequestsPerConnection": b.CircuitBreakers.MaxRequestsPerConnection,
-					"maxRetries":               b.CircuitBreakers.MaxRetries,
-				}
-			}
-
-			var mqlConnectionDraining any
-			if b.ConnectionDraining != nil {
-				mqlConnectionDraining = map[string]any{
-					"drainingTimeoutSec": b.ConnectionDraining.DrainingTimeoutSec,
-				}
-			}
-
-			var mqlConnectionTrackingPolicy any
-			if b.ConnectionTrackingPolicy != nil {
-				mqlConnectionTrackingPolicy = map[string]any{
-					"connectionPersistenceOnUnhealthyBackends": b.ConnectionTrackingPolicy.ConnectionPersistenceOnUnhealthyBackends,
-					"enableStrongAffinity":                     b.ConnectionTrackingPolicy.EnableStrongAffinity,
-					"idleTimeoutSec":                           b.ConnectionTrackingPolicy.IdleTimeoutSec,
-					"trackingMode":                             b.ConnectionTrackingPolicy.TrackingMode,
-				}
-			}
-
-			var mqlConsistentHash any
-			if b.ConsistentHash != nil {
-				consistentHashMap := map[string]any{
-					"httpHeaderName":  b.ConsistentHash.HttpHeaderName,
-					"minimumRingSize": b.ConsistentHash.MinimumRingSize,
-				}
-				if b.ConsistentHash.HttpCookie != nil {
-					cookieMap := map[string]any{
-						"name": b.ConsistentHash.HttpCookie.Name,
-						"path": b.ConsistentHash.HttpCookie.Path,
-					}
-					if b.ConsistentHash.HttpCookie.Ttl != nil {
-						cookieMap["ttl"] = llx.TimeData(llx.DurationToTime(b.ConsistentHash.HttpCookie.Ttl.Seconds))
-					}
-					consistentHashMap["httpCookie"] = cookieMap
-				}
-				mqlConsistentHash = consistentHashMap
-			}
-
-			var mqlFailoverPolicy any
-			if b.FailoverPolicy != nil {
-				mqlFailoverPolicy = map[string]any{
-					"disableConnectionDrainOnFailover": b.FailoverPolicy.DisableConnectionDrainOnFailover,
-					"dropTrafficIfUnhealthy":           b.FailoverPolicy.DropTrafficIfUnhealthy,
-					"failoverRatio":                    b.FailoverPolicy.FailoverRatio,
-				}
-			}
-
-			var mqlIap any
-			if b.Iap != nil {
-				mqlIap = map[string]any{
-					"serviceEnabled":           b.Iap.Enabled,
-					"oauth2ClientId":           b.Iap.Oauth2ClientId,
-					"oauth2ClientSecret":       b.Iap.Oauth2ClientSecret,
-					"oauth2ClientSecretSha256": b.Iap.Oauth2ClientSecretSha256,
-				}
-			}
-
-			mqlLocalityLbPolicy := make([]any, 0, len(b.LocalityLbPolicies))
-			for _, p := range b.LocalityLbPolicies {
-				var mqlCustomPolicy any
-				if p.CustomPolicy != nil {
-					mqlCustomPolicy = map[string]any{
-						"data": p.CustomPolicy.Data,
-						"name": p.CustomPolicy.Name,
-					}
-				}
-
-				var mqlPolicy any
-				if p.Policy != nil {
-					mqlPolicy = map[string]any{
-						"name": p.Policy.Name,
-					}
-				}
-				mqlLocalityLbPolicy = append(mqlLocalityLbPolicy, map[string]any{
-					"customPolicy": mqlCustomPolicy,
-					"policy":       mqlPolicy,
-				})
-			}
-
-			var mqlLogConfig any
-			if b.LogConfig != nil {
-				mqlLogConfig = map[string]any{
-					"enable":     b.LogConfig.Enable,
-					"sampleRate": b.LogConfig.SampleRate,
-				}
-			}
-
-			var mqlSecuritySettings any
-			if b.SecuritySettings != nil {
-				mqlSecuritySettings = map[string]any{
-					"clientTlsPolicy": b.SecuritySettings.ClientTlsPolicy,
-					"subjectAltNames": convert.SliceAnyToInterface(b.SecuritySettings.SubjectAltNames),
-				}
-			}
-
-			var maxStreamDuration *time.Time
-			if b.MaxStreamDuration != nil {
-				v := llx.DurationToTime(b.MaxStreamDuration.Seconds)
-				maxStreamDuration = &v
-			}
-
-			mqlB, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.backendService", map[string]*llx.RawData{
-				"id":                       llx.StringData(backendServiceId),
-				"affinityCookieTtlSec":     llx.IntData(b.AffinityCookieTtlSec),
-				"backends":                 llx.ArrayData(mqlBackends, types.Resource("gcp.project.computeService.backendService.backend")),
-				"cdnPolicy":                llx.ResourceData(cdnPolicy, " gcp.project.computeService.backendService.cdnPolicy"),
-				"circuitBreakers":          llx.DictData(mqlCircuitBreakers),
-				"compressionMode":          llx.StringData(b.CompressionMode),
-				"connectionDraining":       llx.DictData(mqlConnectionDraining),
-				"connectionTrackingPolicy": llx.DictData(mqlConnectionTrackingPolicy),
-				"consistentHash":           llx.DictData(mqlConsistentHash),
-				"created":                  llx.TimeDataPtr(parseTime(b.CreationTimestamp)),
-				"customRequestHeaders":     llx.ArrayData(convert.SliceAnyToInterface(b.CustomRequestHeaders), types.String),
-				"customResponseHeaders":    llx.ArrayData(convert.SliceAnyToInterface(b.CustomResponseHeaders), types.String),
-				"description":              llx.StringData(b.Description),
-				"edgeSecurityPolicy":       llx.StringData(b.EdgeSecurityPolicy),
-				"enableCDN":                llx.BoolData(b.EnableCDN),
-				"failoverPolicy":           llx.DictData(mqlFailoverPolicy),
-				"healthChecks":             llx.ArrayData(convert.SliceAnyToInterface(b.HealthChecks), types.String),
-				"iap":                      llx.DictData(mqlIap),
-				"loadBalancingScheme":      llx.StringData(b.LoadBalancingScheme),
-				"localityLbPolicies":       llx.ArrayData(mqlLocalityLbPolicy, types.Dict),
-				"localityLbPolicy":         llx.StringData(b.LocalityLbPolicy),
-				"logConfig":                llx.DictData(mqlLogConfig),
-				"maxStreamDuration":        llx.TimeDataPtr(maxStreamDuration),
-				"name":                     llx.StringData(b.Name),
-				"networkUrl":               llx.StringData(b.Network),
-				"portName":                 llx.StringData(b.PortName),
-				"protocol":                 llx.StringData(b.Protocol),
-				"regionUrl":                llx.StringData(b.Region),
-				"securityPolicyUrl":        llx.StringData(b.SecurityPolicy),
-				"securitySettings":         llx.DictData(mqlSecuritySettings),
-				"serviceBindingUrls":       llx.ArrayData(convert.SliceAnyToInterface(b.ServiceBindings), types.String),
-				"sessionAffinity":          llx.StringData(b.SessionAffinity),
-				"timeoutSec":               llx.IntData(b.TimeoutSec),
-				"port":                     llx.IntData(b.Port),
-				"serviceLbPolicy":          llx.StringData(b.ServiceLbPolicy),
-				"ipAddressSelectionPolicy": llx.StringData(b.IpAddressSelectionPolicy),
-				"fingerprint":              llx.StringData(b.Fingerprint),
-			})
-			if err != nil {
-				return nil, err
-			}
-			res = append(res, mqlB)
 		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	return res, nil
 }
@@ -2626,37 +2628,39 @@ func (g *mqlGcpProjectComputeService) addresses() ([]any, error) {
 		return nil, err
 	}
 
-	list, err := computeSvc.Addresses.AggregatedList(projectId).Do()
-	if err != nil {
-		return nil, err
-	}
 	var mqlAddresses []any
-	for _, as := range list.Items {
-		for _, a := range as.Addresses {
-			mqlA, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.address", map[string]*llx.RawData{
-				"id":               llx.StringData(fmt.Sprintf("%d", a.Id)),
-				"address":          llx.StringData(a.Address),
-				"addressType":      llx.StringData(a.AddressType),
-				"created":          llx.TimeDataPtr(parseTime(a.CreationTimestamp)),
-				"description":      llx.StringData(a.Description),
-				"ipVersion":        llx.StringData(a.IpVersion),
-				"ipv6EndpointType": llx.StringData(a.Ipv6EndpointType),
-				"name":             llx.StringData(a.Name),
-				"labels":           llx.MapData(convert.MapToInterfaceMap(a.Labels), types.String),
-				"networkUrl":       llx.StringData(a.Network),
-				"networkTier":      llx.StringData(a.NetworkTier),
-				"prefixLength":     llx.IntData(a.PrefixLength),
-				"purpose":          llx.StringData(a.Purpose),
-				"regionUrl":        llx.StringData(a.Region),
-				"status":           llx.StringData(a.Status),
-				"subnetworkUrl":    llx.StringData(a.Subnetwork),
-				"resourceUrls":     llx.ArrayData(convert.SliceAnyToInterface(a.Users), types.String),
-			})
-			if err != nil {
-				return nil, err
+	req := computeSvc.Addresses.AggregatedList(projectId)
+	if err := req.Pages(ctx, func(page *compute.AddressAggregatedList) error {
+		for _, as := range page.Items {
+			for _, a := range as.Addresses {
+				mqlA, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.address", map[string]*llx.RawData{
+					"id":               llx.StringData(fmt.Sprintf("%d", a.Id)),
+					"address":          llx.StringData(a.Address),
+					"addressType":      llx.StringData(a.AddressType),
+					"created":          llx.TimeDataPtr(parseTime(a.CreationTimestamp)),
+					"description":      llx.StringData(a.Description),
+					"ipVersion":        llx.StringData(a.IpVersion),
+					"ipv6EndpointType": llx.StringData(a.Ipv6EndpointType),
+					"name":             llx.StringData(a.Name),
+					"labels":           llx.MapData(convert.MapToInterfaceMap(a.Labels), types.String),
+					"networkUrl":       llx.StringData(a.Network),
+					"networkTier":      llx.StringData(a.NetworkTier),
+					"prefixLength":     llx.IntData(a.PrefixLength),
+					"purpose":          llx.StringData(a.Purpose),
+					"regionUrl":        llx.StringData(a.Region),
+					"status":           llx.StringData(a.Status),
+					"subnetworkUrl":    llx.StringData(a.Subnetwork),
+					"resourceUrls":     llx.ArrayData(convert.SliceAnyToInterface(a.Users), types.String),
+				})
+				if err != nil {
+					return err
+				}
+				mqlAddresses = append(mqlAddresses, mqlA)
 			}
-			mqlAddresses = append(mqlAddresses, mqlA)
 		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	return mqlAddresses, nil
 }

--- a/providers/gcp/resources/discovery.go
+++ b/providers/gcp/resources/discovery.go
@@ -1408,24 +1408,27 @@ func (a *GcrImages) ListRepository(repository string, recursive bool) ([]*invent
 func (a *GcrImages) List() ([]*inventory.Asset, error) {
 	assets := []*inventory.Asset{}
 
-	resSrv, err := cloudresourcemanager.NewService(context.Background())
+	ctx := context.Background()
+	resSrv, err := cloudresourcemanager.NewService(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	projectsResp, err := resSrv.Projects.List().Do()
-	if err != nil {
+	var projectNames []string
+	if err := resSrv.Projects.List().Pages(ctx, func(page *cloudresourcemanager.ListProjectsResponse) error {
+		for _, p := range page.Projects {
+			projectNames = append(projectNames, p.Name)
+		}
+		return nil
+	}); err != nil {
 		return nil, err
 	}
 
 	var wg sync.WaitGroup
-
-	wg.Add(len(projectsResp.Projects))
+	wg.Add(len(projectNames))
 	mux := &sync.Mutex{}
-	for i := range projectsResp.Projects {
-
-		project := projectsResp.Projects[i].Name
-		go func() {
+	for _, project := range projectNames {
+		go func(project string) {
 			repoAssets, err := a.ListRepository("gcr.io/"+project, true)
 			if err == nil && repoAssets != nil {
 				mux.Lock()
@@ -1433,7 +1436,7 @@ func (a *GcrImages) List() ([]*inventory.Asset, error) {
 				mux.Unlock()
 			}
 			wg.Done()
-		}()
+		}(project)
 	}
 
 	wg.Wait()

--- a/providers/gcp/resources/essential_contacts.go
+++ b/providers/gcp/resources/essential_contacts.go
@@ -43,25 +43,25 @@ func (g *mqlGcpProject) essentialContacts() ([]any, error) {
 		return nil, err
 	}
 
-	contacts, err := contactSvc.Projects.Contacts.List("projects/" + projectId).Do()
-	if err != nil {
-		return nil, err
-	}
-
-	mqlContacts := make([]any, 0, len(contacts.Contacts))
-	for _, c := range contacts.Contacts {
-		mqlC, err := CreateResource(g.MqlRuntime, "gcp.essentialContact", map[string]*llx.RawData{
-			"resourcePath":           llx.StringData(c.Name),
-			"email":                  llx.StringData(c.Email),
-			"languageTag":            llx.StringData(c.LanguageTag),
-			"notificationCategories": llx.ArrayData(convert.SliceAnyToInterface(c.NotificationCategorySubscriptions), types.String),
-			"validated":              llx.TimeDataPtr(parseTime(c.ValidateTime)),
-			"validationState":        llx.StringData(c.ValidationState),
-		})
-		if err != nil {
-			return nil, err
+	var mqlContacts []any
+	if err := contactSvc.Projects.Contacts.List("projects/"+projectId).Pages(ctx, func(page *essentialcontacts.GoogleCloudEssentialcontactsV1ListContactsResponse) error {
+		for _, c := range page.Contacts {
+			mqlC, err := CreateResource(g.MqlRuntime, "gcp.essentialContact", map[string]*llx.RawData{
+				"resourcePath":           llx.StringData(c.Name),
+				"email":                  llx.StringData(c.Email),
+				"languageTag":            llx.StringData(c.LanguageTag),
+				"notificationCategories": llx.ArrayData(convert.SliceAnyToInterface(c.NotificationCategorySubscriptions), types.String),
+				"validated":              llx.TimeDataPtr(parseTime(c.ValidateTime)),
+				"validationState":        llx.StringData(c.ValidationState),
+			})
+			if err != nil {
+				return err
+			}
+			mqlContacts = append(mqlContacts, mqlC)
 		}
-		mqlContacts = append(mqlContacts, mqlC)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	return mqlContacts, nil
 }

--- a/providers/gcp/resources/folder.go
+++ b/providers/gcp/resources/folder.go
@@ -119,18 +119,18 @@ func (g *mqlGcpFolders) children() ([]any, error) {
 		return nil, err
 	}
 
-	folders, err := svc.Folders.List().Parent(parentId).Do()
-	if err != nil {
-		return nil, err
-	}
-
-	mqlFolders := make([]any, 0, len(folders.Folders))
-	for _, f := range folders.Folders {
-		mqlF, err := folderToMql(g.MqlRuntime, f)
-		if err != nil {
-			return nil, err
+	var mqlFolders []any
+	if err := svc.Folders.List().Parent(parentId).Pages(ctx, func(page *cloudresourcemanager.ListFoldersResponse) error {
+		for _, f := range page.Folders {
+			mqlF, err := folderToMql(g.MqlRuntime, f)
+			if err != nil {
+				return err
+			}
+			mqlFolders = append(mqlFolders, mqlF)
 		}
-		mqlFolders = append(mqlFolders, mqlF)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	return mqlFolders, nil
 }
@@ -154,12 +154,15 @@ func (g *mqlGcpFolders) list() ([]any, error) {
 		return nil, err
 	}
 
-	folders, err := svc.Folders.Search().Do()
-	if err != nil {
+	var allFolders []*cloudresourcemanager.Folder
+	if err := svc.Folders.Search().Pages(ctx, func(page *cloudresourcemanager.SearchFoldersResponse) error {
+		allFolders = append(allFolders, page.Folders...)
+		return nil
+	}); err != nil {
 		return nil, err
 	}
 
-	filteredFolders := getChildren(folders.Folders, parentId)
+	filteredFolders := getChildren(allFolders, parentId)
 	mqlFolders := make([]any, 0, len(filteredFolders))
 	for _, f := range filteredFolders {
 		mqlF, err := folderToMql(g.MqlRuntime, f)

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -33014,7 +33014,7 @@ func SetAllData(resource plugin.Resource, args map[string]*llx.RawData) error {
 type mqlGcpOrganization struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpOrganizationInternal it will be used here
+	mqlGcpOrganizationInternal
 	Id                           plugin.TValue[string]
 	CustomerId                   plugin.TValue[string]
 	Name                         plugin.TValue[string]

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
-  "version": "13.16.2",
-  "generated_at": "2026-05-23T17:10:11-07:00",
+  "version": "13.17.0",
+  "generated_at": "2026-05-26T14:28:59+03:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.customJobs.list",
@@ -1469,7 +1469,7 @@
     {
       "permission": "resourcemanager.folders.list",
       "service": "resourcemanager",
-      "action": "Folders.Search",
+      "action": "Folders.List",
       "source_file": "folder.go",
       "scope": "org"
     },

--- a/providers/gcp/resources/organization.go
+++ b/providers/gcp/resources/organization.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -22,6 +23,12 @@ import (
 	"google.golang.org/api/iam/v1"
 	"google.golang.org/api/option"
 )
+
+type mqlGcpOrganizationInternal struct {
+	iamPolicyOnce  sync.Once
+	iamPolicyCache *cloudresourcemanager.Policy
+	iamPolicyErr   error
+}
 
 func (g *mqlGcpOrganization) id() (string, error) {
 	return g.Id.Data, g.Id.Error
@@ -94,36 +101,49 @@ func (g *mqlGcpOrganization) state() (string, error) {
 	return "", errors.New("not implemented")
 }
 
+func (g *mqlGcpOrganization) fetchIamPolicy() (string, *cloudresourcemanager.Policy, error) {
+	g.iamPolicyOnce.Do(func() {
+		conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
+		client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope, iam.CloudPlatformScope, compute.CloudPlatformScope)
+		if err != nil {
+			g.iamPolicyErr = err
+			return
+		}
+
+		ctx := context.Background()
+		svc, err := cloudresourcemanager.NewService(ctx, option.WithHTTPClient(client))
+		if err != nil {
+			g.iamPolicyErr = err
+			return
+		}
+
+		orgId, err := conn.OrganizationID()
+		if err != nil {
+			g.iamPolicyErr = err
+			return
+		}
+
+		name := "organizations/" + orgId
+		g.iamPolicyCache, g.iamPolicyErr = svc.Organizations.GetIamPolicy(name, &cloudresourcemanager.GetIamPolicyRequest{}).Do()
+	})
+	if g.iamPolicyErr != nil {
+		return "", nil, g.iamPolicyErr
+	}
+	orgId, err := g.MqlRuntime.Connection.(*connection.GcpConnection).OrganizationID()
+	if err != nil {
+		return "", nil, err
+	}
+	return "organizations/" + orgId, g.iamPolicyCache, nil
+}
+
 func (g *mqlGcpOrganization) iamPolicy() ([]any, error) {
-	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
-
-	client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope, iam.CloudPlatformScope, compute.CloudPlatformScope)
+	name, policy, err := g.fetchIamPolicy()
 	if err != nil {
 		return nil, err
 	}
 
-	ctx := context.Background()
-	svc, err := cloudresourcemanager.NewService(ctx, option.WithHTTPClient(client))
-	if err != nil {
-		return nil, err
-	}
-
-	// determine org from project in transport
-	orgId, err := conn.OrganizationID()
-	if err != nil {
-		return nil, err
-	}
-
-	name := "organizations/" + orgId
-	orgpolicy, err := svc.Organizations.GetIamPolicy(name, &cloudresourcemanager.GetIamPolicyRequest{}).Do()
-	if err != nil {
-		return nil, err
-	}
-
-	res := []any{}
-	for i := range orgpolicy.Bindings {
-		b := orgpolicy.Bindings[i]
-
+	res := make([]any, 0, len(policy.Bindings))
+	for i, b := range policy.Bindings {
 		mqlServiceaccount, err := CreateResource(g.MqlRuntime, "gcp.resourcemanager.binding", map[string]*llx.RawData{
 			"id":      llx.StringData(name + "-" + strconv.Itoa(i)),
 			"role":    llx.StringData(b.Role),
@@ -180,26 +200,7 @@ func extractAuditConfigs(runtime *plugin.Runtime, parentId string, auditConfigs 
 }
 
 func (g *mqlGcpOrganization) auditConfig() ([]any, error) {
-	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
-
-	client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope, iam.CloudPlatformScope, compute.CloudPlatformScope)
-	if err != nil {
-		return nil, err
-	}
-
-	ctx := context.Background()
-	svc, err := cloudresourcemanager.NewService(ctx, option.WithHTTPClient(client))
-	if err != nil {
-		return nil, err
-	}
-
-	orgId, err := conn.OrganizationID()
-	if err != nil {
-		return nil, err
-	}
-
-	name := "organizations/" + orgId
-	policy, err := svc.Organizations.GetIamPolicy(name, &cloudresourcemanager.GetIamPolicyRequest{}).Do()
+	name, policy, err := g.fetchIamPolicy()
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/project.go
+++ b/providers/gcp/resources/project.go
@@ -328,18 +328,18 @@ func (g *mqlGcpProjects) children() ([]any, error) {
 		return nil, err
 	}
 
-	projects, err := svc.Projects.List().Parent(parentId).Do()
-	if err != nil {
-		return nil, err
-	}
-
-	mqlProjects := make([]any, 0, len(projects.Projects))
-	for _, p := range projects.Projects {
-		mqlP, err := projectToMql(g.MqlRuntime, p)
-		if err != nil {
-			return nil, err
+	var mqlProjects []any
+	if err := svc.Projects.List().Parent(parentId).Pages(ctx, func(page *cloudresourcemanager.ListProjectsResponse) error {
+		for _, p := range page.Projects {
+			mqlP, err := projectToMql(g.MqlRuntime, p)
+			if err != nil {
+				return err
+			}
+			mqlProjects = append(mqlProjects, mqlP)
 		}
-		mqlProjects = append(mqlProjects, mqlP)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	return mqlProjects, nil
 }
@@ -384,19 +384,20 @@ func (g *mqlGcpProjects) list() ([]any, error) {
 		return nil, err
 	}
 
-	projects, err := svc.Projects.Search().Do()
-	if err != nil {
-		return nil, err
-	}
-	mqlProjects := make([]any, 0, len(projects.Projects))
-	for _, p := range projects.Projects {
-		if _, ok := foldersMap[p.Parent]; ok {
-			mqlP, err := projectToMql(g.MqlRuntime, p)
-			if err != nil {
-				return nil, err
+	var mqlProjects []any
+	if err := svc.Projects.Search().Pages(ctx, func(page *cloudresourcemanager.SearchProjectsResponse) error {
+		for _, p := range page.Projects {
+			if _, ok := foldersMap[p.Parent]; ok {
+				mqlP, err := projectToMql(g.MqlRuntime, p)
+				if err != nil {
+					return err
+				}
+				mqlProjects = append(mqlProjects, mqlP)
 			}
-			mqlProjects = append(mqlProjects, mqlP)
 		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	return mqlProjects, nil
 }

--- a/providers/gcp/resources/storage.go
+++ b/providers/gcp/resources/storage.go
@@ -106,18 +106,18 @@ func (g *mqlGcpProjectStorageService) buckets() ([]any, error) {
 	}
 
 	projectID := conn.ResourceID()
-	buckets, err := storageSvc.Buckets.List(projectID).Do()
-	if err != nil {
-		return nil, err
-	}
-
-	res := make([]any, 0, len(buckets.Items))
-	for i := range buckets.Items {
-		mqlBucket, err := mqlBucketFromAPI(g.MqlRuntime, projectId, buckets.Items[i])
-		if err != nil {
-			return nil, err
+	var res []any
+	if err := storageSvc.Buckets.List(projectID).Pages(ctx, func(page *storage.Buckets) error {
+		for _, bucket := range page.Items {
+			mqlBucket, err := mqlBucketFromAPI(g.MqlRuntime, projectId, bucket)
+			if err != nil {
+				return err
+			}
+			res = append(res, mqlBucket)
 		}
-		res = append(res, mqlBucket)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	return res, nil
 }


### PR DESCRIPTION
## Summary

Fixes the high-severity items from a recent performance audit of the gcp provider. Two classes of problem:

1. **Duplicate API call**: `gcp.organization.iamPolicy()` and `gcp.organization.auditConfig()` each issued their own `Organizations.GetIamPolicy` call. They now share one call via a `sync.Once` `fetchIamPolicy()` helper — same pattern already used in [`folder.go`](../tree/main/providers/gcp/resources/folder.go) and [`project.go`](../tree/main/providers/gcp/resources/project.go).
2. **Missing pagination**: nine GCP List/Search/AggregatedList calls used `.Do()` instead of `.Pages()`, silently truncating at the SDK default page size. For some of these (BackendServices, Addresses, Folders/Projects) this is a **correctness** bug on large accounts, not just performance — items past the first page were never returned.

## What changed

| File | Call | Default page | Behavior change |
|---|---|---|---|
| `organization.go` | `Organizations.GetIamPolicy` | n/a | 2 calls → 1 call per org scan |
| `compute.go:2339` | `BackendServices.AggregatedList` | 500 | items past page 1 now returned |
| `compute.go:2629` | `Addresses.AggregatedList` | 500 | items past page 1 now returned |
| `folder.go:122` | `Folders.List` | 100 | folders past page 1 now returned |
| `folder.go:157` | `Folders.Search` | 100 | folders past page 1 now returned |
| `project.go:331` | `Projects.List` | 500 | projects past page 1 now returned |
| `project.go:387` | `Projects.Search` | 500 | projects past page 1 now returned |
| `discovery.go:1416` | `Projects.List` (GCR discovery) | 500 | projects past page 1 now scanned |
| `apikeys.go:51` | `Projects.Locations.Keys.List` | 300 | keys past page 1 now returned |
| `storage.go:109` | `Buckets.List` | 1000 | buckets past page 1 now returned |
| `essential_contacts.go:46` | `Projects.Contacts.List` | 50 | contacts past page 1 now returned |

## API usage impact

For accounts within the default page size, **no change** in API call count or behavior.

For accounts that exceed the default page size, the call count goes up to retrieve the previously-missing data, but the underlying scan was producing **incorrect output** before — it now returns the full set. Concretely:

- **Org IAM dedupe**: −1 `GetIamPolicy` call per org per asset scan that exercises both `iamPolicy` and `auditConfig` (e.g. most cnspec policies). Net ~50% reduction on org-level IAM traffic.
- **Folders/Projects search**: an org with 1,200 projects now issues ~3 paged calls instead of 1 truncated call, but returns all 1,200 instead of the first 500.
- **Compute AggregatedList**: a project with 800 backend services or addresses across regions now returns all of them (was ~62% missing).

The bigquery N+1 items (per-dataset/table/model/routine `Metadata()` calls) are deferred to a follow-up — they require an `.lr` schema migration to move fields from eager-init to computed methods.

## Test plan

- [x] `go build ./...` clean in `providers/gcp/`
- [x] `go test ./providers/gcp/resources/` passes
- [x] `make providers/build/gcp` regenerates `gcp.permissions.json` cleanly (one cosmetic action reclassification only)
- [ ] Smoke-test against a live GCP org: `cnspec shell gcp` → `gcp.organization { iamPolicy { role } auditConfig { service } }` (single combined API call confirmed via debug logs), large `gcp.projects.list`, and `gcp.project.computeService.backendServices`

🤖 Generated with [Claude Code](https://claude.com/claude-code)