### PR TITLE
os: detect Ollama model license from manifest layer

### DIFF
--- a/providers/os/resources/aimodel/detect_ollama.go
+++ b/providers/os/resources/aimodel/detect_ollama.go
@@ -185,6 +185,10 @@ func (d *OllamaDetector) Detect(ctx DetectContext) []ModelInfo {
 
 					extracted := readOllamaConfig(ctx.Fs, modelsDir, manifest.Config.Digest)
 
+					if extracted.License == "" {
+						extracted.License = readOllamaLicenseLayer(ctx.Fs, modelsDir, manifest.Layers)
+					}
+
 					version := tag.Name()
 
 					quant := extracted.Quantization
@@ -230,6 +234,83 @@ func (d *OllamaDetector) Detect(ctx DetectContext) []ModelInfo {
 		}
 	}
 	return results
+}
+
+const ollamaLicenseMediaType = "application/vnd.ollama.image.license"
+
+func readOllamaLicenseLayer(afs *afero.Afero, modelsDir string, layers []ollamaLayer) string {
+	for _, l := range layers {
+		if l.MediaType != ollamaLicenseMediaType || l.Digest == "" {
+			continue
+		}
+		blobName := strings.Replace(l.Digest, ":", "-", 1)
+		blobPath := filepath.Join(modelsDir, "blobs", blobName)
+		data, err := afs.ReadFile(blobPath)
+		if err != nil {
+			continue
+		}
+		if id := identifyLicense(string(data)); id != "" {
+			return id
+		}
+	}
+	return ""
+}
+
+// identifyLicense extracts a short SPDX-like identifier from license text.
+func identifyLicense(text string) string {
+	upper := strings.ToUpper(text)
+	switch {
+	case strings.Contains(upper, "APACHE LICENSE") && strings.Contains(upper, "VERSION 2.0"):
+		return "Apache-2.0"
+	case strings.Contains(upper, "MIT LICENSE"):
+		return "MIT"
+	case strings.Contains(upper, "BSD 2-CLAUSE"):
+		return "BSD-2-Clause"
+	case strings.Contains(upper, "BSD 3-CLAUSE"):
+		return "BSD-3-Clause"
+	case strings.Contains(upper, "GNU GENERAL PUBLIC LICENSE") && strings.Contains(upper, "VERSION 3"):
+		return "GPL-3.0"
+	case strings.Contains(upper, "GNU GENERAL PUBLIC LICENSE") && strings.Contains(upper, "VERSION 2"):
+		return "GPL-2.0"
+	case strings.Contains(upper, "LLAMA 3.1 COMMUNITY LICENSE"):
+		return "Llama-3.1"
+	case strings.Contains(upper, "LLAMA 3 COMMUNITY LICENSE"):
+		return "Llama-3"
+	case strings.Contains(upper, "LLAMA 2 COMMUNITY LICENSE"):
+		return "Llama-2"
+	case strings.Contains(upper, "GEMMA TERMS OF USE"):
+		return "Gemma"
+	case strings.Contains(upper, "DEEPSEEK"):
+		return "DeepSeek"
+	case strings.Contains(upper, "MICROSOFT RESEARCH LICENSE"):
+		return "MS-Research"
+	case strings.Contains(upper, "CREATIVECOMMONS.ORG") || strings.Contains(upper, "CREATIVE COMMONS"):
+		if strings.Contains(upper, "BY-NC-SA") {
+			return "CC-BY-NC-SA-4.0"
+		}
+		if strings.Contains(upper, "BY-NC-ND") {
+			return "CC-BY-NC-ND-4.0"
+		}
+		if strings.Contains(upper, "BY-NC") {
+			return "CC-BY-NC-4.0"
+		}
+		if strings.Contains(upper, "BY-SA") {
+			return "CC-BY-SA-4.0"
+		}
+		if strings.Contains(upper, "BY-ND") {
+			return "CC-BY-ND-4.0"
+		}
+		return "CC-BY-4.0"
+	}
+
+	first := strings.TrimSpace(text)
+	if i := strings.IndexByte(first, '\n'); i > 0 {
+		first = strings.TrimSpace(first[:i])
+	}
+	if len(first) > 0 && len(first) <= 80 {
+		return first
+	}
+	return ""
 }
 
 func readOllamaConfig(afs *afero.Afero, modelsDir string, digest string) ollamaExtracted {

--- a/providers/os/resources/aimodel/detect_ollama.go
+++ b/providers/os/resources/aimodel/detect_ollama.go
@@ -5,7 +5,9 @@ package aimodel
 
 import (
 	"encoding/json"
+	"io"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/afero"
@@ -238,14 +240,26 @@ func (d *OllamaDetector) Detect(ctx DetectContext) []ModelInfo {
 
 const ollamaLicenseMediaType = "application/vnd.ollama.image.license"
 
+// maxLicenseRead is the maximum bytes to read from a license blob.
+// License headers are identifiable within the first few KB.
+const maxLicenseRead = 8 * 1024
+
 func readOllamaLicenseLayer(afs *afero.Afero, modelsDir string, layers []ollamaLayer) string {
 	for _, l := range layers {
 		if l.MediaType != ollamaLicenseMediaType || l.Digest == "" {
 			continue
 		}
+		if l.Size > 1<<20 {
+			continue
+		}
 		blobName := strings.Replace(l.Digest, ":", "-", 1)
 		blobPath := filepath.Join(modelsDir, "blobs", blobName)
-		data, err := afs.ReadFile(blobPath)
+		f, err := afs.Open(blobPath)
+		if err != nil {
+			continue
+		}
+		data, err := io.ReadAll(io.LimitReader(f, maxLicenseRead))
+		f.Close()
 		if err != nil {
 			continue
 		}
@@ -256,9 +270,16 @@ func readOllamaLicenseLayer(afs *afero.Afero, modelsDir string, layers []ollamaL
 	return ""
 }
 
+var reCCVersion = regexp.MustCompile(`(?i)VERSION\s+(\d+\.\d+)`)
+
 // identifyLicense extracts a short SPDX-like identifier from license text.
 func identifyLicense(text string) string {
-	upper := strings.ToUpper(text)
+	prefix := text
+	if len(prefix) > 4096 {
+		prefix = prefix[:4096]
+	}
+	upper := strings.ToUpper(prefix)
+
 	switch {
 	case strings.Contains(upper, "APACHE LICENSE") && strings.Contains(upper, "VERSION 2.0"):
 		return "Apache-2.0"
@@ -285,22 +306,7 @@ func identifyLicense(text string) string {
 	case strings.Contains(upper, "MICROSOFT RESEARCH LICENSE"):
 		return "MS-Research"
 	case strings.Contains(upper, "CREATIVECOMMONS.ORG") || strings.Contains(upper, "CREATIVE COMMONS"):
-		if strings.Contains(upper, "BY-NC-SA") {
-			return "CC-BY-NC-SA-4.0"
-		}
-		if strings.Contains(upper, "BY-NC-ND") {
-			return "CC-BY-NC-ND-4.0"
-		}
-		if strings.Contains(upper, "BY-NC") {
-			return "CC-BY-NC-4.0"
-		}
-		if strings.Contains(upper, "BY-SA") {
-			return "CC-BY-SA-4.0"
-		}
-		if strings.Contains(upper, "BY-ND") {
-			return "CC-BY-ND-4.0"
-		}
-		return "CC-BY-4.0"
+		return identifyCCLicense(prefix)
 	}
 
 	first := strings.TrimSpace(text)
@@ -308,9 +314,32 @@ func identifyLicense(text string) string {
 		first = strings.TrimSpace(first[:i])
 	}
 	if len(first) > 0 && len(first) <= 80 {
-		return first
+		return "LicenseRef-" + first
 	}
 	return ""
+}
+
+func identifyCCLicense(text string) string {
+	upper := strings.ToUpper(text)
+	var variant string
+	switch {
+	case strings.Contains(upper, "BY-NC-SA"):
+		variant = "CC-BY-NC-SA"
+	case strings.Contains(upper, "BY-NC-ND"):
+		variant = "CC-BY-NC-ND"
+	case strings.Contains(upper, "BY-NC"):
+		variant = "CC-BY-NC"
+	case strings.Contains(upper, "BY-SA"):
+		variant = "CC-BY-SA"
+	case strings.Contains(upper, "BY-ND"):
+		variant = "CC-BY-ND"
+	default:
+		variant = "CC-BY"
+	}
+	if m := reCCVersion.FindStringSubmatch(text); len(m) > 1 {
+		return variant + "-" + m[1]
+	}
+	return variant
 }
 
 func readOllamaConfig(afs *afero.Afero, modelsDir string, digest string) ollamaExtracted {

--- a/providers/os/resources/aimodel/detect_test.go
+++ b/providers/os/resources/aimodel/detect_test.go
@@ -6,6 +6,7 @@ package aimodel
 import (
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -180,6 +181,130 @@ func TestDetectOllama_ExtractsNewFields(t *testing.T) {
 	assert.Equal(t, "llama", m.Architecture)
 	assert.Equal(t, "llama3", m.License)
 	assert.Equal(t, []string{"8b", "q4_0"}, m.Tags)
+}
+
+func TestDetectOllama_LicenseFromLayer(t *testing.T) {
+	afs, fs := newTestAfs()
+	home := "/home/testuser"
+
+	manifest := ollamaManifest{
+		Config: ollamaDescriptor{Digest: "sha256:cfg1"},
+		Layers: []ollamaLayer{
+			{MediaType: "application/vnd.ollama.image.model", Digest: "sha256:model1", Size: 1000},
+			{MediaType: "application/vnd.ollama.image.license", Digest: "sha256:lic1", Size: 500},
+		},
+	}
+	manifestPath := filepath.Join(home, ".ollama/models/manifests/registry.ollama.ai/library/llama3.1/latest")
+	writeJSON(t, fs, manifestPath, manifest)
+
+	configPath := filepath.Join(home, ".ollama/models/blobs/sha256-cfg1")
+	writeJSON(t, fs, configPath, map[string]any{"model_family": "llama"})
+
+	licenseText := "LLAMA 3.1 COMMUNITY LICENSE AGREEMENT\nLlama 3.1 Version Release Date: July 23, 2024\n..."
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(home, ".ollama/models/blobs/sha256-lic1"), []byte(licenseText), 0644))
+
+	results := detectWith(&OllamaDetector{}, afs, home)
+	require.Len(t, results, 1)
+	assert.Equal(t, "Llama-3.1", results[0].License)
+}
+
+func TestDetectOllama_LicenseApache(t *testing.T) {
+	afs, fs := newTestAfs()
+	home := "/home/testuser"
+
+	manifest := ollamaManifest{
+		Config: ollamaDescriptor{Digest: "sha256:cfg2"},
+		Layers: []ollamaLayer{
+			{MediaType: "application/vnd.ollama.image.model", Digest: "sha256:model2", Size: 1000},
+			{MediaType: "application/vnd.ollama.image.license", Digest: "sha256:lic2", Size: 500},
+		},
+	}
+	manifestPath := filepath.Join(home, ".ollama/models/manifests/registry.ollama.ai/library/gemma/latest")
+	writeJSON(t, fs, manifestPath, manifest)
+
+	configPath := filepath.Join(home, ".ollama/models/blobs/sha256-cfg2")
+	writeJSON(t, fs, configPath, map[string]any{"model_family": "gemma"})
+
+	licenseText := "\n                                 Apache License\n                           Version 2.0, January 2004\n"
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(home, ".ollama/models/blobs/sha256-lic2"), []byte(licenseText), 0644))
+
+	results := detectWith(&OllamaDetector{}, afs, home)
+	require.Len(t, results, 1)
+	assert.Equal(t, "Apache-2.0", results[0].License)
+}
+
+func TestDetectOllama_LicenseMIT(t *testing.T) {
+	afs, fs := newTestAfs()
+	home := "/home/testuser"
+
+	manifest := ollamaManifest{
+		Config: ollamaDescriptor{Digest: "sha256:cfg3"},
+		Layers: []ollamaLayer{
+			{MediaType: "application/vnd.ollama.image.model", Digest: "sha256:model3", Size: 1000},
+			{MediaType: "application/vnd.ollama.image.license", Digest: "sha256:lic3", Size: 200},
+		},
+	}
+	manifestPath := filepath.Join(home, ".ollama/models/manifests/registry.ollama.ai/library/deepseek-r1/7b")
+	writeJSON(t, fs, manifestPath, manifest)
+
+	configPath := filepath.Join(home, ".ollama/models/blobs/sha256-cfg3")
+	writeJSON(t, fs, configPath, map[string]any{"model_family": "deepseek2"})
+
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(home, ".ollama/models/blobs/sha256-lic3"), []byte("MIT License\n\nCopyright (c) 2024 DeepSeek"), 0644))
+
+	results := detectWith(&OllamaDetector{}, afs, home)
+	require.Len(t, results, 1)
+	assert.Equal(t, "MIT", results[0].License)
+}
+
+func TestDetectOllama_ConfigLicenseTakesPrecedence(t *testing.T) {
+	afs, fs := newTestAfs()
+	home := "/home/testuser"
+
+	manifest := ollamaManifest{
+		Config: ollamaDescriptor{Digest: "sha256:cfglic"},
+		Layers: []ollamaLayer{
+			{MediaType: "application/vnd.ollama.image.model", Digest: "sha256:model4", Size: 1000},
+			{MediaType: "application/vnd.ollama.image.license", Digest: "sha256:lic4", Size: 200},
+		},
+	}
+	manifestPath := filepath.Join(home, ".ollama/models/manifests/registry.ollama.ai/library/custom/latest")
+	writeJSON(t, fs, manifestPath, manifest)
+
+	configPath := filepath.Join(home, ".ollama/models/blobs/sha256-cfglic")
+	writeJSON(t, fs, configPath, map[string]any{"model_family": "custom", "license": "custom-license"})
+
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(home, ".ollama/models/blobs/sha256-lic4"), []byte("MIT License"), 0644))
+
+	results := detectWith(&OllamaDetector{}, afs, home)
+	require.Len(t, results, 1)
+	assert.Equal(t, "custom-license", results[0].License)
+}
+
+func TestIdentifyLicense(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{"Apache-2.0", "\n                                 Apache License\n                           Version 2.0, January 2004\n", "Apache-2.0"},
+		{"MIT", "MIT License\n\nCopyright (c) 2024", "MIT"},
+		{"Llama-3.1", "LLAMA 3.1 COMMUNITY LICENSE AGREEMENT\nLlama 3.1 Version Release Date: July 23, 2024", "Llama-3.1"},
+		{"Llama-3", "LLAMA 3 COMMUNITY LICENSE AGREEMENT\nMeta Llama 3 Version Release Date: April 18, 2024", "Llama-3"},
+		{"Llama-2", "LLAMA 2 COMMUNITY LICENSE AGREEMENT\n", "Llama-2"},
+		{"Gemma", "Gemma Terms of Use\nLast modified: February 21, 2024", "Gemma"},
+		{"DeepSeek", "DeepSeek License Agreement\nVersion 1.0", "DeepSeek"},
+		{"BSD-3-Clause", "BSD 3-Clause License\n\nCopyright", "BSD-3-Clause"},
+		{"CC-BY-NC-SA-4.0", "Creative Commons Attribution-NonCommercial-ShareAlike (CC BY-NC-SA 4.0)", "CC-BY-NC-SA-4.0"},
+		{"short-first-line", "Custom Model License v1\nSome details...", "Custom Model License v1"},
+		{"empty", "", ""},
+		{"long-no-match", strings.Repeat("x", 100) + "\n", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, identifyLicense(tt.text))
+		})
+	}
 }
 
 func TestDetectOllama_QuantizationFromTagFallback(t *testing.T) {

--- a/providers/os/resources/aimodel/detect_test.go
+++ b/providers/os/resources/aimodel/detect_test.go
@@ -295,8 +295,10 @@ func TestIdentifyLicense(t *testing.T) {
 		{"Gemma", "Gemma Terms of Use\nLast modified: February 21, 2024", "Gemma"},
 		{"DeepSeek", "DeepSeek License Agreement\nVersion 1.0", "DeepSeek"},
 		{"BSD-3-Clause", "BSD 3-Clause License\n\nCopyright", "BSD-3-Clause"},
-		{"CC-BY-NC-SA-4.0", "Creative Commons Attribution-NonCommercial-ShareAlike (CC BY-NC-SA 4.0)", "CC-BY-NC-SA-4.0"},
-		{"short-first-line", "Custom Model License v1\nSome details...", "Custom Model License v1"},
+		{"CC-BY-NC-SA-4.0", "Creative Commons Attribution-NonCommercial-ShareAlike\nVersion 4.0 (CC BY-NC-SA)", "CC-BY-NC-SA-4.0"},
+		{"CC-BY-NC-3.0", "Creative Commons Attribution-NonCommercial (CC BY-NC)\nVersion 3.0", "CC-BY-NC-3.0"},
+		{"CC-BY-no-version", "Creative Commons Attribution License\nSome text", "CC-BY"},
+		{"short-first-line", "Custom Model License v1\nSome details...", "LicenseRef-Custom Model License v1"},
 		{"empty", "", ""},
 		{"long-no-match", strings.Repeat("x", 100) + "\n", ""},
 	}


### PR DESCRIPTION
## Summary
- Read license text from the `application/vnd.ollama.image.license` manifest layer blob (the config blob doesn't contain a license field despite what the code assumed)
- Extract short SPDX-like identifiers from full license text (e.g. "Apache-2.0", "MIT", "Llama-3.1", "Gemma")
- Config blob `license` field still takes precedence when present (backwards compatible)

## Test plan
- [x] `TestDetectOllama_LicenseFromLayer` — Llama 3.1 license from layer blob
- [x] `TestDetectOllama_LicenseApache` — Apache 2.0 license detection
- [x] `TestDetectOllama_LicenseMIT` — MIT license detection  
- [x] `TestDetectOllama_ConfigLicenseTakesPrecedence` — config blob license wins
- [x] `TestIdentifyLicense` — table-driven test covering 12 license text patterns
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)