### PR TITLE
os: add ai.applications resource for AI app, IDE and browser extension detection

### DIFF
--- a/providers/os/resources/ai_models.go
+++ b/providers/os/resources/ai_models.go
@@ -7,6 +7,7 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/v13/providers/os/resources/aiapp"
 	"go.mondoo.com/mql/v13/providers/os/resources/aimodel"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -89,4 +90,46 @@ func newAiModelResource(rt *plugin.Runtime, m aimodel.ModelInfo) (*mqlAiModel, e
 
 func (a *mqlAiModel) id() (string, error) {
 	return "ai.model/" + a.Source.Data + "/" + a.Name.Data, nil
+}
+
+func (a *mqlAi) applications() ([]any, error) {
+	home, err := targetHomeDir(a.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+
+	conn := a.MqlRuntime.Connection.(shared.Connection)
+	afs := connectionAfs(a.MqlRuntime)
+	osFamily := targetOSFamily(conn)
+
+	var all []any
+	for _, app := range aiapp.DetectAll(afs, home, osFamily) {
+		res, err := newAiApplicationResource(a.MqlRuntime, app)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, res)
+	}
+	return all, nil
+}
+
+func newAiApplicationResource(rt *plugin.Runtime, app aiapp.AppInfo) (*mqlAiApplication, error) {
+	res, err := NewResource(rt, "ai.application", map[string]*llx.RawData{
+		"__id":      llx.StringData("ai.application/" + app.Category + "/" + app.Name),
+		"name":      llx.StringData(app.Name),
+		"category":  llx.StringData(app.Category),
+		"version":   llx.StringData(app.Version),
+		"vendor":    llx.StringData(app.Vendor),
+		"path":      llx.StringData(app.Path),
+		"installed": llx.BoolData(app.Installed),
+		"updatedAt": llx.TimeData(app.UpdatedAt),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAiApplication), nil
+}
+
+func (a *mqlAiApplication) id() (string, error) {
+	return "ai.application/" + a.Category.Data + "/" + a.Name.Data, nil
 }

--- a/providers/os/resources/aiapp/detect.go
+++ b/providers/os/resources/aiapp/detect.go
@@ -1,0 +1,52 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package aiapp
+
+import (
+	"time"
+
+	"github.com/spf13/afero"
+)
+
+// AppInfo holds metadata for a discovered AI application.
+type AppInfo struct {
+	Name      string
+	Category  string // "desktop", "ide-extension", "browser-extension"
+	Version   string
+	Vendor    string
+	Path      string
+	Installed bool
+	UpdatedAt time.Time
+}
+
+// DetectContext carries shared state needed by every detector.
+type DetectContext struct {
+	Fs       *afero.Afero
+	Home     string
+	OSFamily string
+}
+
+// Detector discovers locally installed AI applications from a single source.
+type Detector interface {
+	Detect(ctx DetectContext) []AppInfo
+}
+
+// Detectors returns all registered application detectors.
+func Detectors() []Detector {
+	return []Detector{
+		&DesktopDetector{},
+		&VSCodeDetector{},
+		&ChromeDetector{},
+	}
+}
+
+// DetectAll runs every detector and returns the combined results.
+func DetectAll(afs *afero.Afero, home, osFamily string) []AppInfo {
+	ctx := DetectContext{Fs: afs, Home: home, OSFamily: osFamily}
+	var all []AppInfo
+	for _, d := range Detectors() {
+		all = append(all, d.Detect(ctx)...)
+	}
+	return all
+}

--- a/providers/os/resources/aiapp/detect_browser.go
+++ b/providers/os/resources/aiapp/detect_browser.go
@@ -1,0 +1,138 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package aiapp
+
+import (
+	"encoding/json"
+	"path/filepath"
+)
+
+// ChromeDetector discovers installed AI-related Chrome/Chromium extensions.
+type ChromeDetector struct{}
+
+type knownChromeExtension struct {
+	ExtID  string
+	Name   string
+	Vendor string
+}
+
+// Well-known Chrome extension IDs for AI tools.
+var aiChromeExtensions = []knownChromeExtension{
+	{ExtID: "agoklgmhkadcfnfmgfafjhpcibpciool", Name: "Claude", Vendor: "Anthropic"},
+	{ExtID: "gpaiobkfhnonpkbkdallhkhfalfmcpjm", Name: "Claude for Enterprise", Vendor: "Anthropic"},
+	{ExtID: "jjfacpkknndmilbakcaefalmfckoklcp", Name: "ChatGPT", Vendor: "OpenAI"},
+	{ExtID: "obnaaalnokmchdoagnhmjjpchkldadbde", Name: "Perplexity", Vendor: "Perplexity AI"},
+	{ExtID: "lnkdbjbjpnpjeciipoaflmpcddinpjjp", Name: "GitHub Copilot", Vendor: "GitHub"},
+	{ExtID: "dgjhfomjieaadpoljlnidmbgkdffpack", Name: "Gemini", Vendor: "Google"},
+	{ExtID: "pnjaknljhloefhkifoodeegdpnpljbnd", Name: "Codeium", Vendor: "Codeium"},
+	{ExtID: "iadjlbflapfkpbegnpkpnhhiidalihelm", Name: "Monica AI", Vendor: "Monica"},
+	{ExtID: "nfclhjlpoddfnbpkkabaoifjnnimjaog", Name: "Tabnine", Vendor: "Tabnine"},
+}
+
+type chromeManifest struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+func (d *ChromeDetector) Detect(ctx DetectContext) []AppInfo {
+	profileDirs := chromeProfileDirs(ctx)
+
+	idMap := make(map[string]knownChromeExtension, len(aiChromeExtensions))
+	for _, ext := range aiChromeExtensions {
+		idMap[ext.ExtID] = ext
+	}
+
+	seen := make(map[string]bool)
+	var results []AppInfo
+
+	for _, profileDir := range profileDirs {
+		extDir := filepath.Join(profileDir, "Extensions")
+		entries, err := ctx.Fs.ReadDir(extDir)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			ext, ok := idMap[entry.Name()]
+			if !ok {
+				continue
+			}
+			if seen[ext.ExtID] {
+				continue
+			}
+			seen[ext.ExtID] = true
+
+			ai := AppInfo{
+				Name:      ext.Name,
+				Category:  "browser-extension",
+				Vendor:    ext.Vendor,
+				Path:      filepath.Join(extDir, entry.Name()),
+				Installed: true,
+				UpdatedAt: entry.ModTime(),
+			}
+
+			versions, _ := ctx.Fs.ReadDir(filepath.Join(extDir, entry.Name()))
+			if len(versions) > 0 {
+				latest := versions[len(versions)-1]
+				mfPath := filepath.Join(extDir, entry.Name(), latest.Name(), "manifest.json")
+				if data, readErr := ctx.Fs.ReadFile(mfPath); readErr == nil {
+					var mf chromeManifest
+					if json.Unmarshal(data, &mf) == nil && mf.Version != "" {
+						ai.Version = mf.Version
+					}
+				}
+			}
+
+			results = append(results, ai)
+		}
+	}
+	return results
+}
+
+func chromeProfileDirs(ctx DetectContext) []string {
+	var dirs []string
+	switch ctx.OSFamily {
+	case "darwin", "unix":
+		base := filepath.Join(ctx.Home, "Library", "Application Support", "Google", "Chrome")
+		dirs = appendChromeProfiles(ctx, base, dirs)
+		// Chromium
+		base = filepath.Join(ctx.Home, "Library", "Application Support", "Chromium")
+		dirs = appendChromeProfiles(ctx, base, dirs)
+		// Brave
+		base = filepath.Join(ctx.Home, "Library", "Application Support", "BraveSoftware", "Brave-Browser")
+		dirs = appendChromeProfiles(ctx, base, dirs)
+		// Edge
+		base = filepath.Join(ctx.Home, "Library", "Application Support", "Microsoft Edge")
+		dirs = appendChromeProfiles(ctx, base, dirs)
+	case "linux":
+		base := filepath.Join(ctx.Home, ".config", "google-chrome")
+		dirs = appendChromeProfiles(ctx, base, dirs)
+		base = filepath.Join(ctx.Home, ".config", "chromium")
+		dirs = appendChromeProfiles(ctx, base, dirs)
+	case "windows":
+		base := filepath.Join(ctx.Home, "AppData", "Local", "Google", "Chrome", "User Data")
+		dirs = appendChromeProfiles(ctx, base, dirs)
+		base = filepath.Join(ctx.Home, "AppData", "Local", "Microsoft", "Edge", "User Data")
+		dirs = appendChromeProfiles(ctx, base, dirs)
+	}
+	return dirs
+}
+
+func appendChromeProfiles(ctx DetectContext, base string, dirs []string) []string {
+	if _, err := ctx.Fs.Stat(filepath.Join(base, "Default")); err == nil {
+		dirs = append(dirs, filepath.Join(base, "Default"))
+	}
+	entries, err := ctx.Fs.ReadDir(base)
+	if err != nil {
+		return dirs
+	}
+	for _, e := range entries {
+		if e.IsDir() && len(e.Name()) > 8 && e.Name()[:8] == "Profile " {
+			dirs = append(dirs, filepath.Join(base, e.Name()))
+		}
+	}
+	return dirs
+}

--- a/providers/os/resources/aiapp/detect_desktop.go
+++ b/providers/os/resources/aiapp/detect_desktop.go
@@ -1,0 +1,73 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package aiapp
+
+import (
+	"path/filepath"
+
+	"howett.net/plist"
+)
+
+// DesktopDetector discovers installed AI desktop applications.
+type DesktopDetector struct{}
+
+type knownApp struct {
+	Name   string
+	Dir    string // directory name under /Applications (macOS) or install path
+	Vendor string
+}
+
+var macApps = []knownApp{
+	{Name: "Claude Desktop", Dir: "Claude.app", Vendor: "Anthropic"},
+	{Name: "ChatGPT", Dir: "ChatGPT.app", Vendor: "OpenAI"},
+	{Name: "Cursor", Dir: "Cursor.app", Vendor: "Anysphere"},
+	{Name: "Windsurf", Dir: "Windsurf.app", Vendor: "Codeium"},
+	{Name: "Ollama", Dir: "Ollama.app", Vendor: "Ollama"},
+	{Name: "Jan", Dir: "Jan.app", Vendor: "Jan AI"},
+	{Name: "LM Studio", Dir: "LM Studio.app", Vendor: "LM Studio"},
+	{Name: "GPT4All", Dir: "GPT4All.app", Vendor: "Nomic"},
+	{Name: "oMLX", Dir: "oMLX.app", Vendor: "oMLX"},
+	{Name: "Msty", Dir: "Msty.app", Vendor: "Msty"},
+	{Name: "Perplexity", Dir: "Perplexity.app", Vendor: "Perplexity AI"},
+}
+
+type infoPlist struct {
+	BundleVersion string `plist:"CFBundleShortVersionString"`
+	BundleID      string `plist:"CFBundleIdentifier"`
+}
+
+func (d *DesktopDetector) Detect(ctx DetectContext) []AppInfo {
+	if ctx.OSFamily != "darwin" && ctx.OSFamily != "unix" {
+		return nil
+	}
+
+	var results []AppInfo
+	for _, app := range macApps {
+		appDir := filepath.Join("/Applications", app.Dir)
+		info, err := ctx.Fs.Stat(appDir)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+
+		ai := AppInfo{
+			Name:      app.Name,
+			Category:  "desktop",
+			Vendor:    app.Vendor,
+			Path:      appDir,
+			Installed: true,
+			UpdatedAt: info.ModTime(),
+		}
+
+		plistPath := filepath.Join(appDir, "Contents", "Info.plist")
+		if data, readErr := ctx.Fs.ReadFile(plistPath); readErr == nil {
+			var pl infoPlist
+			if _, parseErr := plist.Unmarshal(data, &pl); parseErr == nil {
+				ai.Version = pl.BundleVersion
+			}
+		}
+
+		results = append(results, ai)
+	}
+	return results
+}

--- a/providers/os/resources/aiapp/detect_test.go
+++ b/providers/os/resources/aiapp/detect_test.go
@@ -1,0 +1,220 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package aiapp
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"howett.net/plist"
+)
+
+func newTestAfs() (*afero.Afero, afero.Fs) {
+	fs := afero.NewMemMapFs()
+	return &afero.Afero{Fs: fs}, fs
+}
+
+func writeJSON(t *testing.T, fs afero.Fs, path string, v any) {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	require.NoError(t, afero.WriteFile(fs, path, data, 0644))
+}
+
+func detectWith(d Detector, afs *afero.Afero, home, osFamily string) []AppInfo {
+	return d.Detect(DetectContext{Fs: afs, Home: home, OSFamily: osFamily})
+}
+
+// --- Desktop ---
+
+func TestDetectDesktop_MacOS(t *testing.T) {
+	afs, fs := newTestAfs()
+	home := "/Users/testuser"
+
+	pl := infoPlist{BundleVersion: "1.8.0", BundleID: "com.anthropic.claudefordesktop"}
+	data, err := plist.Marshal(pl, plist.XMLFormat)
+	require.NoError(t, err)
+
+	require.NoError(t, fs.MkdirAll("/Applications/Claude.app/Contents", 0755))
+	require.NoError(t, afero.WriteFile(fs, "/Applications/Claude.app/Contents/Info.plist", data, 0644))
+
+	require.NoError(t, fs.MkdirAll("/Applications/Cursor.app/Contents", 0755))
+
+	results := detectWith(&DesktopDetector{}, afs, home, "darwin")
+	require.Len(t, results, 2)
+
+	byName := map[string]AppInfo{}
+	for _, r := range results {
+		byName[r.Name] = r
+	}
+
+	claude := byName["Claude Desktop"]
+	assert.Equal(t, "desktop", claude.Category)
+	assert.Equal(t, "Anthropic", claude.Vendor)
+	assert.Equal(t, "1.8.0", claude.Version)
+	assert.True(t, claude.Installed)
+
+	cursor := byName["Cursor"]
+	assert.Equal(t, "desktop", cursor.Category)
+	assert.Equal(t, "Anysphere", cursor.Vendor)
+	assert.Equal(t, "", cursor.Version)
+}
+
+func TestDetectDesktop_NotDarwin(t *testing.T) {
+	afs, _ := newTestAfs()
+	results := detectWith(&DesktopDetector{}, afs, "/home/testuser", "linux")
+	assert.Nil(t, results)
+}
+
+func TestDetectDesktop_NoAppsInstalled(t *testing.T) {
+	afs, _ := newTestAfs()
+	results := detectWith(&DesktopDetector{}, afs, "/Users/testuser", "darwin")
+	assert.Empty(t, results)
+}
+
+// --- VS Code ---
+
+func TestDetectVSCode_Extensions(t *testing.T) {
+	afs, fs := newTestAfs()
+	home := "/Users/testuser"
+	extDir := filepath.Join(home, ".vscode", "extensions")
+
+	pkg := vsCodePackageJSON{Version: "2.1.145"}
+	claudeDir := filepath.Join(extDir, "anthropic.claude-code-2.1.145-darwin-arm64")
+	require.NoError(t, fs.MkdirAll(claudeDir, 0755))
+	writeJSON(t, fs, filepath.Join(claudeDir, "package.json"), pkg)
+
+	copilotDir := filepath.Join(extDir, "github.copilot-1.250.0")
+	require.NoError(t, fs.MkdirAll(copilotDir, 0755))
+	writeJSON(t, fs, filepath.Join(copilotDir, "package.json"), vsCodePackageJSON{Version: "1.250.0"})
+
+	results := detectWith(&VSCodeDetector{}, afs, home, "darwin")
+	require.Len(t, results, 2)
+
+	byName := map[string]AppInfo{}
+	for _, r := range results {
+		byName[r.Name] = r
+	}
+
+	claude := byName["Claude Code"]
+	assert.Equal(t, "ide-extension", claude.Category)
+	assert.Equal(t, "Anthropic", claude.Vendor)
+	assert.Equal(t, "2.1.145", claude.Version)
+
+	copilot := byName["GitHub Copilot"]
+	assert.Equal(t, "ide-extension", copilot.Category)
+	assert.Equal(t, "GitHub", copilot.Vendor)
+	assert.Equal(t, "1.250.0", copilot.Version)
+}
+
+func TestDetectVSCode_Insiders(t *testing.T) {
+	afs, fs := newTestAfs()
+	home := "/Users/testuser"
+	extDir := filepath.Join(home, ".vscode-insiders", "extensions")
+
+	dir := filepath.Join(extDir, "continue.continue-1.0.0")
+	require.NoError(t, fs.MkdirAll(dir, 0755))
+	writeJSON(t, fs, filepath.Join(dir, "package.json"), vsCodePackageJSON{Version: "1.0.0"})
+
+	results := detectWith(&VSCodeDetector{}, afs, home, "darwin")
+	require.Len(t, results, 1)
+	assert.Equal(t, "Continue", results[0].Name)
+}
+
+func TestDetectVSCode_NoExtensions(t *testing.T) {
+	afs, _ := newTestAfs()
+	results := detectWith(&VSCodeDetector{}, afs, "/Users/testuser", "darwin")
+	assert.Empty(t, results)
+}
+
+func TestDetectVSCode_IgnoresNonAI(t *testing.T) {
+	afs, fs := newTestAfs()
+	home := "/Users/testuser"
+	extDir := filepath.Join(home, ".vscode", "extensions")
+
+	dir := filepath.Join(extDir, "esbenp.prettier-vscode-11.0.0")
+	require.NoError(t, fs.MkdirAll(dir, 0755))
+
+	results := detectWith(&VSCodeDetector{}, afs, home, "darwin")
+	assert.Empty(t, results)
+}
+
+// --- Chrome ---
+
+func TestDetectChrome_Extensions(t *testing.T) {
+	afs, fs := newTestAfs()
+	home := "/Users/testuser"
+
+	profileDir := filepath.Join(home, "Library", "Application Support", "Google", "Chrome", "Default")
+	require.NoError(t, fs.MkdirAll(profileDir, 0755))
+
+	// Claude extension
+	claudeExtID := "agoklgmhkadcfnfmgfafjhpcibpciool"
+	versionDir := filepath.Join(profileDir, "Extensions", claudeExtID, "1.0.0_0")
+	require.NoError(t, fs.MkdirAll(versionDir, 0755))
+	writeJSON(t, fs, filepath.Join(versionDir, "manifest.json"), chromeManifest{Name: "Claude", Version: "1.0.0"})
+
+	results := detectWith(&ChromeDetector{}, afs, home, "darwin")
+	require.Len(t, results, 1)
+
+	assert.Equal(t, "Claude", results[0].Name)
+	assert.Equal(t, "browser-extension", results[0].Category)
+	assert.Equal(t, "Anthropic", results[0].Vendor)
+	assert.Equal(t, "1.0.0", results[0].Version)
+}
+
+func TestDetectChrome_MultipleProfiles(t *testing.T) {
+	afs, fs := newTestAfs()
+	home := "/Users/testuser"
+	base := filepath.Join(home, "Library", "Application Support", "Google", "Chrome")
+
+	require.NoError(t, fs.MkdirAll(filepath.Join(base, "Default"), 0755))
+	require.NoError(t, fs.MkdirAll(filepath.Join(base, "Profile 1"), 0755))
+
+	chatgptID := "jjfacpkknndmilbakcaefalmfckoklcp"
+	vDir := filepath.Join(base, "Default", "Extensions", chatgptID, "1.0_0")
+	require.NoError(t, fs.MkdirAll(vDir, 0755))
+	writeJSON(t, fs, filepath.Join(vDir, "manifest.json"), chromeManifest{Name: "ChatGPT", Version: "1.0"})
+
+	vDir2 := filepath.Join(base, "Profile 1", "Extensions", chatgptID, "1.0_0")
+	require.NoError(t, fs.MkdirAll(vDir2, 0755))
+	writeJSON(t, fs, filepath.Join(vDir2, "manifest.json"), chromeManifest{Name: "ChatGPT", Version: "1.0"})
+
+	results := detectWith(&ChromeDetector{}, afs, home, "darwin")
+	require.Len(t, results, 1, "should deduplicate across profiles")
+}
+
+func TestDetectChrome_NoBrowser(t *testing.T) {
+	afs, _ := newTestAfs()
+	results := detectWith(&ChromeDetector{}, afs, "/Users/testuser", "darwin")
+	assert.Empty(t, results)
+}
+
+// --- DetectAll ---
+
+func TestDetectAll(t *testing.T) {
+	afs, fs := newTestAfs()
+	home := "/Users/testuser"
+
+	require.NoError(t, fs.MkdirAll("/Applications/Claude.app/Contents", 0755))
+
+	extDir := filepath.Join(home, ".vscode", "extensions")
+	dir := filepath.Join(extDir, "github.copilot-1.0.0")
+	require.NoError(t, fs.MkdirAll(dir, 0755))
+	writeJSON(t, fs, filepath.Join(dir, "package.json"), vsCodePackageJSON{Version: "1.0.0"})
+
+	results := DetectAll(afs, home, "darwin")
+	assert.GreaterOrEqual(t, len(results), 2)
+
+	categories := map[string]bool{}
+	for _, r := range results {
+		categories[r.Category] = true
+	}
+	assert.True(t, categories["desktop"])
+	assert.True(t, categories["ide-extension"])
+}

--- a/providers/os/resources/aiapp/detect_vscode.go
+++ b/providers/os/resources/aiapp/detect_vscode.go
@@ -1,0 +1,93 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package aiapp
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+)
+
+// VSCodeDetector discovers installed AI-related VS Code extensions.
+type VSCodeDetector struct{}
+
+type knownExtension struct {
+	ID     string // publisher.name (lowercase)
+	Name   string
+	Vendor string
+}
+
+var aiVSCodeExtensions = []knownExtension{
+	{ID: "anthropic.claude-code", Name: "Claude Code", Vendor: "Anthropic"},
+	{ID: "github.copilot", Name: "GitHub Copilot", Vendor: "GitHub"},
+	{ID: "github.copilot-chat", Name: "GitHub Copilot Chat", Vendor: "GitHub"},
+	{ID: "continue.continue", Name: "Continue", Vendor: "Continue"},
+	{ID: "sourcegraph.cody-ai", Name: "Cody", Vendor: "Sourcegraph"},
+	{ID: "tabnine.tabnine-vscode", Name: "Tabnine", Vendor: "Tabnine"},
+	{ID: "codeium.codeium", Name: "Codeium", Vendor: "Codeium"},
+	{ID: "supermaven.supermaven", Name: "Supermaven", Vendor: "Supermaven"},
+	{ID: "amazonwebservices.aws-toolkit-vscode", Name: "AWS Toolkit (CodeWhisperer)", Vendor: "Amazon"},
+	{ID: "saoudrizwan.claude-dev", Name: "Cline", Vendor: "Cline"},
+	{ID: "rooveterinaryinc.roo-cline", Name: "Roo Code", Vendor: "Roo Veterinary"},
+	{ID: "codegpt.codegpt", Name: "CodeGPT", Vendor: "CodeGPT"},
+	{ID: "blackboxapp.blackbox", Name: "Blackbox AI", Vendor: "Blackbox"},
+	{ID: "googlecloudtools.cloudcode", Name: "Google Cloud Code (Gemini)", Vendor: "Google"},
+	{ID: "cursor.cursor", Name: "Cursor", Vendor: "Anysphere"},
+}
+
+type vsCodePackageJSON struct {
+	Version string `json:"version"`
+}
+
+func (d *VSCodeDetector) Detect(ctx DetectContext) []AppInfo {
+	extDirs := []string{
+		filepath.Join(ctx.Home, ".vscode", "extensions"),
+		filepath.Join(ctx.Home, ".vscode-insiders", "extensions"),
+	}
+
+	idMap := make(map[string]knownExtension, len(aiVSCodeExtensions))
+	for _, ext := range aiVSCodeExtensions {
+		idMap[ext.ID] = ext
+	}
+
+	var results []AppInfo
+	for _, extDir := range extDirs {
+		entries, err := ctx.Fs.ReadDir(extDir)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			dirName := strings.ToLower(entry.Name())
+			for id, ext := range idMap {
+				if !strings.HasPrefix(dirName, id+"-") {
+					continue
+				}
+
+				ai := AppInfo{
+					Name:      ext.Name,
+					Category:  "ide-extension",
+					Vendor:    ext.Vendor,
+					Path:      filepath.Join(extDir, entry.Name()),
+					Installed: true,
+					UpdatedAt: entry.ModTime(),
+				}
+
+				pkgPath := filepath.Join(extDir, entry.Name(), "package.json")
+				if data, readErr := ctx.Fs.ReadFile(pkgPath); readErr == nil {
+					var pkg vsCodePackageJSON
+					if json.Unmarshal(data, &pkg) == nil && pkg.Version != "" {
+						ai.Version = pkg.Version
+					}
+				}
+
+				results = append(results, ai)
+				break
+			}
+		}
+	}
+	return results
+}

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -6108,6 +6108,8 @@ zfs.dataset @defaults("name type usedBytes") {
 ai @maturity("preview") {
   // All locally cached AI models across all supported sources
   models() []ai.model
+  // All detected AI applications (desktop apps, IDE extensions, browser extensions)
+  applications() []ai.application
 }
 
 // AI Model
@@ -6155,6 +6157,29 @@ private ai.model @defaults("name source") @maturity("preview") {
   tags []string
   // Short description of the model
   description string
+}
+
+// AI Application
+//
+// A locally installed AI application such as a desktop app (Claude Desktop,
+// ChatGPT, Cursor), an IDE extension (GitHub Copilot, Claude Code), or a
+// browser extension (Claude, Perplexity). Use `ai.applications` to discover
+// all AI-related applications on the system.
+private ai.application @defaults("name category") @maturity("preview") {
+  // Application name (e.g., "Claude Desktop", "GitHub Copilot")
+  name string
+  // Category: desktop, ide-extension, browser-extension
+  category string
+  // Application version
+  version string
+  // Publisher or vendor
+  vendor string
+  // Filesystem path to the application
+  path string
+  // Whether the application is currently installed
+  installed bool
+  // Last update time
+  updatedAt time
 }
 
 // Claude Code (Anthropic CLI agent) instance

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -331,6 +331,7 @@ const (
 	ResourceZfsDataset                   string = "zfs.dataset"
 	ResourceAi                           string = "ai"
 	ResourceAiModel                      string = "ai.model"
+	ResourceAiApplication                string = "ai.application"
 	ResourceClaudeCode                   string = "claude.code"
 	ResourceClaudeCodePlugin             string = "claude.code.plugin"
 	ResourceClaudeCodeSkill              string = "claude.code.skill"
@@ -1661,6 +1662,10 @@ func init() {
 		"ai.model": {
 			// to override args, implement: initAiModel(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAiModel,
+		},
+		"ai.application": {
+			// to override args, implement: initAiApplication(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAiApplication,
 		},
 		"claude.code": {
 			Init:   initClaudeCode,
@@ -7354,6 +7359,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"ai.models": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAi).GetModels()).ToDataRes(types.Array(types.Resource("ai.model")))
 	},
+	"ai.applications": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAi).GetApplications()).ToDataRes(types.Array(types.Resource("ai.application")))
+	},
 	"ai.model.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAiModel).GetName()).ToDataRes(types.String)
 	},
@@ -7398,6 +7406,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"ai.model.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAiModel).GetDescription()).ToDataRes(types.String)
+	},
+	"ai.application.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAiApplication).GetName()).ToDataRes(types.String)
+	},
+	"ai.application.category": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAiApplication).GetCategory()).ToDataRes(types.String)
+	},
+	"ai.application.version": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAiApplication).GetVersion()).ToDataRes(types.String)
+	},
+	"ai.application.vendor": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAiApplication).GetVendor()).ToDataRes(types.String)
+	},
+	"ai.application.path": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAiApplication).GetPath()).ToDataRes(types.String)
+	},
+	"ai.application.installed": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAiApplication).GetInstalled()).ToDataRes(types.Bool)
+	},
+	"ai.application.updatedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAiApplication).GetUpdatedAt()).ToDataRes(types.Time)
 	},
 	"claude.code.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlClaudeCode).GetConfigPath()).ToDataRes(types.String)
@@ -16772,6 +16801,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAi).Models, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"ai.applications": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAi).Applications, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"ai.model.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAiModel).__id, ok = v.Value.(string)
 		return
@@ -16834,6 +16867,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"ai.model.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAiModel).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"ai.application.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAiApplication).__id, ok = v.Value.(string)
+		return
+	},
+	"ai.application.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAiApplication).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"ai.application.category": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAiApplication).Category, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"ai.application.version": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAiApplication).Version, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"ai.application.vendor": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAiApplication).Vendor, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"ai.application.path": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAiApplication).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"ai.application.installed": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAiApplication).Installed, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"ai.application.updatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAiApplication).UpdatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"claude.code.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -45633,7 +45698,8 @@ type mqlAi struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAiInternal it will be used here
-	Models plugin.TValue[[]any]
+	Models       plugin.TValue[[]any]
+	Applications plugin.TValue[[]any]
 }
 
 // createAi creates a new instance of this resource
@@ -45686,6 +45752,22 @@ func (c *mqlAi) GetModels() *plugin.TValue[[]any] {
 		}
 
 		return c.models()
+	})
+}
+
+func (c *mqlAi) GetApplications() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Applications, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("ai", c.__id, "applications")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.applications()
 	})
 }
 
@@ -45806,6 +45888,85 @@ func (c *mqlAiModel) GetTags() *plugin.TValue[[]any] {
 
 func (c *mqlAiModel) GetDescription() *plugin.TValue[string] {
 	return &c.Description
+}
+
+// mqlAiApplication for the ai.application resource
+type mqlAiApplication struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAiApplicationInternal it will be used here
+	Name      plugin.TValue[string]
+	Category  plugin.TValue[string]
+	Version   plugin.TValue[string]
+	Vendor    plugin.TValue[string]
+	Path      plugin.TValue[string]
+	Installed plugin.TValue[bool]
+	UpdatedAt plugin.TValue[*time.Time]
+}
+
+// createAiApplication creates a new instance of this resource
+func createAiApplication(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAiApplication{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("ai.application", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAiApplication) MqlName() string {
+	return "ai.application"
+}
+
+func (c *mqlAiApplication) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAiApplication) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAiApplication) GetCategory() *plugin.TValue[string] {
+	return &c.Category
+}
+
+func (c *mqlAiApplication) GetVersion() *plugin.TValue[string] {
+	return &c.Version
+}
+
+func (c *mqlAiApplication) GetVendor() *plugin.TValue[string] {
+	return &c.Vendor
+}
+
+func (c *mqlAiApplication) GetPath() *plugin.TValue[string] {
+	return &c.Path
+}
+
+func (c *mqlAiApplication) GetInstalled() *plugin.TValue[bool] {
+	return &c.Installed
+}
+
+func (c *mqlAiApplication) GetUpdatedAt() *plugin.TValue[*time.Time] {
+	return &c.UpdatedAt
 }
 
 // mqlClaudeCode for the claude.code resource


### PR DESCRIPTION
## Summary
- New `ai.applications` MQL resource that detects installed AI applications across three categories:
  - **Desktop apps**: Claude Desktop, ChatGPT, Cursor, Windsurf, Ollama, Jan, LM Studio, GPT4All, oMLX, Msty, Perplexity (macOS `/Applications`)
  - **IDE extensions**: Claude Code, GitHub Copilot, Continue, Cody, Tabnine, Codeium, Supermaven, Cline, Roo Code, CodeGPT, Blackbox AI (VS Code + Insiders)
  - **Browser extensions**: Claude, ChatGPT, Perplexity, GitHub Copilot, Gemini, Codeium, Monica AI, Tabnine (Chrome, Chromium, Brave, Edge)
- Follows the same `Detector` pattern as `ai.models` with afero filesystem abstraction for remote scanning support
- Extracts version from Info.plist (macOS), package.json (VS Code), manifest.json (Chrome)
- Deduplicates Chrome extensions across multiple profiles

## Test plan
- [x] `TestDetectDesktop_MacOS` — detects Claude + Cursor with plist version extraction
- [x] `TestDetectDesktop_NotDarwin` — skips on non-macOS
- [x] `TestDetectVSCode_Extensions` — detects Claude Code + Copilot with version
- [x] `TestDetectVSCode_Insiders` — detects in .vscode-insiders directory
- [x] `TestDetectVSCode_IgnoresNonAI` — non-AI extensions filtered
- [x] `TestDetectChrome_Extensions` — detects by extension ID with manifest version
- [x] `TestDetectChrome_MultipleProfiles` — deduplication across profiles
- [x] `TestDetectAll` — combined detection across all categories
- [x] OS provider compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)