### PR TITLE
⚡ aws: cut API calls in init/N+1 hot paths

### DIFF
--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -511,25 +511,11 @@ func (a *mqlAwsEc2) getSecurityGroups(conn *connection.AwsConnection) []*jobpool
 						continue
 					}
 
-					args := map[string]*llx.RawData{
-						"arn":         llx.StringData(fmt.Sprintf(securityGroupArnPattern, region, conn.AccountId(), convert.ToValue(group.GroupId))),
-						"id":          llx.StringDataPtr(group.GroupId),
-						"name":        llx.StringDataPtr(group.GroupName),
-						"description": llx.StringDataPtr(group.Description),
-						"tags":        llx.MapData(toInterfaceMap(ec2TagsToMap(group.Tags)), types.String),
-						"region":      llx.StringData(region),
-					}
-
-					mqlEc2SecurityGroup, err := CreateResource(a.MqlRuntime, ResourceAwsEc2Securitygroup, args)
+					mqlSG, err := buildSecurityGroupResource(a.MqlRuntime, region, conn.AccountId(), group)
 					if err != nil {
 						return nil, err
 					}
-					res = append(res, mqlEc2SecurityGroup)
-					mqlEc2SecurityGroup.(*mqlAwsEc2Securitygroup).cacheIpPerms = group.IpPermissions
-					mqlEc2SecurityGroup.(*mqlAwsEc2Securitygroup).cacheIpPermsEgress = group.IpPermissionsEgress
-					mqlEc2SecurityGroup.(*mqlAwsEc2Securitygroup).groupId = *group.GroupId
-					mqlEc2SecurityGroup.(*mqlAwsEc2Securitygroup).region = region
-					mqlEc2SecurityGroup.(*mqlAwsEc2Securitygroup).cacheVpc = group.VpcId
+					res = append(res, mqlSG)
 				}
 			}
 			return jobpool.JobResult(res), nil
@@ -1494,24 +1480,39 @@ func initAwsEc2Networkinterface(runtime *plugin.Runtime, args map[string]*llx.Ra
 
 	conn := runtime.Connection.(*connection.AwsConnection)
 	if region == "" {
-		// Try all regions
+		// Region is required for a targeted DescribeNetworkInterfaces lookup, but
+		// it's not encoded in the ENI id itself. Fan out across regions in
+		// parallel and take the first hit instead of probing serially.
 		regions, err := conn.Regions()
 		if err != nil {
 			return nil, nil, err
 		}
+		type eniHit struct {
+			region string
+			eni    ec2types.NetworkInterface
+		}
+		hits := make(chan eniHit, len(regions))
+		var wg sync.WaitGroup
 		for _, r := range regions {
-			svc := conn.Ec2(r)
-			ctx := context.Background()
-			resp, err := svc.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
-				NetworkInterfaceIds: []string{eniId},
-			})
-			if err != nil {
-				continue
-			}
-			if len(resp.NetworkInterfaces) > 0 {
-				region = r
-				return buildNetworkInterfaceResource(runtime, region, resp.NetworkInterfaces[0])
-			}
+			wg.Add(1)
+			go func(r string) {
+				defer wg.Done()
+				svc := conn.Ec2(r)
+				resp, err := svc.DescribeNetworkInterfaces(context.Background(), &ec2.DescribeNetworkInterfacesInput{
+					NetworkInterfaceIds: []string{eniId},
+				})
+				if err != nil {
+					return
+				}
+				if len(resp.NetworkInterfaces) > 0 {
+					hits <- eniHit{region: r, eni: resp.NetworkInterfaces[0]}
+				}
+			}(r)
+		}
+		wg.Wait()
+		close(hits)
+		for hit := range hits {
+			return buildNetworkInterfaceResource(runtime, hit.region, hit.eni)
 		}
 		return nil, nil, errors.New("network interface not found")
 	}
@@ -1917,6 +1918,28 @@ func (a *mqlAwsEc2Securitygroup) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
+func buildSecurityGroupResource(runtime *plugin.Runtime, region, accountID string, group ec2types.SecurityGroup) (*mqlAwsEc2Securitygroup, error) {
+	args := map[string]*llx.RawData{
+		"arn":         llx.StringData(fmt.Sprintf(securityGroupArnPattern, region, accountID, convert.ToValue(group.GroupId))),
+		"id":          llx.StringDataPtr(group.GroupId),
+		"name":        llx.StringDataPtr(group.GroupName),
+		"description": llx.StringDataPtr(group.Description),
+		"tags":        llx.MapData(toInterfaceMap(ec2TagsToMap(group.Tags)), types.String),
+		"region":      llx.StringData(region),
+	}
+	mqlSG, err := CreateResource(runtime, ResourceAwsEc2Securitygroup, args)
+	if err != nil {
+		return nil, err
+	}
+	sg := mqlSG.(*mqlAwsEc2Securitygroup)
+	sg.cacheIpPerms = group.IpPermissions
+	sg.cacheIpPermsEgress = group.IpPermissionsEgress
+	sg.groupId = convert.ToValue(group.GroupId)
+	sg.region = region
+	sg.cacheVpc = group.VpcId
+	return sg, nil
+}
+
 func initAwsEc2Securitygroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
@@ -1933,27 +1956,63 @@ func initAwsEc2Securitygroup(runtime *plugin.Runtime, args map[string]*llx.RawDa
 		return nil, nil, errors.New("arn or id required to fetch aws security group")
 	}
 
-	// load all security groups
+	// Derive region + groupId for a single targeted DescribeSecurityGroups
+	// call instead of listing every SG in every region.
+	var region, groupId string
+	if args["arn"] != nil {
+		arnVal := args["arn"].Value.(string)
+		if parsed, err := arn.Parse(arnVal); err == nil {
+			region = parsed.Region
+			groupId = strings.TrimPrefix(parsed.Resource, "security-group/")
+		}
+	}
+	if args["id"] != nil && groupId == "" {
+		groupId = args["id"].Value.(string)
+	}
+	if args["region"] != nil {
+		if r, ok := args["region"].Value.(string); ok && r != "" {
+			region = r
+		}
+	}
+
+	if region != "" && groupId != "" {
+		conn := runtime.Connection.(*connection.AwsConnection)
+		svc := conn.Ec2(region)
+		resp, err := svc.DescribeSecurityGroups(context.Background(), &ec2.DescribeSecurityGroupsInput{
+			GroupIds: []string{groupId},
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(resp.SecurityGroups) > 0 {
+			sg, err := buildSecurityGroupResource(runtime, region, conn.AccountId(), resp.SecurityGroups[0])
+			if err != nil {
+				return nil, nil, err
+			}
+			return args, sg, nil
+		}
+		return nil, nil, errors.New("security group does not exist")
+	}
+
+	// Fallback: scan the cached list (e.g. when called with just an opaque id
+	// and no region hint).
 	obj, err := CreateResource(runtime, ResourceAwsEc2, map[string]*llx.RawData{})
 	if err != nil {
 		return nil, nil, err
 	}
 	awsEc2 := obj.(*mqlAwsEc2)
-
 	rawResources := awsEc2.GetSecurityGroups()
 	if rawResources.Error != nil {
-		return nil, nil, err
+		return nil, nil, rawResources.Error
 	}
 
 	var match func(secGroup *mqlAwsEc2Securitygroup) bool
-
 	if args["arn"] != nil {
 		arnVal := args["arn"].Value.(string)
 		match = func(secGroup *mqlAwsEc2Securitygroup) bool {
 			return secGroup.Arn.Data == arnVal
 		}
 	}
-
 	if args["id"] != nil {
 		idVal := args["id"].Value.(string)
 		match = func(secGroup *mqlAwsEc2Securitygroup) bool {
@@ -2164,32 +2223,10 @@ func (a *mqlAwsEc2) getVolumes(conn *connection.AwsConnection) []*jobpool.Job {
 						log.Debug().Interface("volume", vol.VolumeId).Msg("excluding volume due to filters")
 						continue
 					}
-					jsonAttachments, err := convert.JsonToDictSlice(vol.Attachments)
+					mqlVol, err := buildVolumeResource(a.MqlRuntime, region, conn.AccountId(), vol)
 					if err != nil {
 						return nil, err
 					}
-					mqlVol, err := CreateResource(a.MqlRuntime, ResourceAwsEc2Volume,
-						map[string]*llx.RawData{
-							"arn":                llx.StringData(fmt.Sprintf(volumeArnPattern, region, conn.AccountId(), convert.ToValue(vol.VolumeId))),
-							"attachments":        llx.ArrayData(jsonAttachments, types.Any),
-							"availabilityZone":   llx.StringDataPtr(vol.AvailabilityZone),
-							"createTime":         llx.TimeDataPtr(vol.CreateTime),
-							"encrypted":          llx.BoolDataPtr(vol.Encrypted),
-							"id":                 llx.StringDataPtr(vol.VolumeId),
-							"iops":               llx.IntDataDefault(vol.Iops, 0),
-							"multiAttachEnabled": llx.BoolDataPtr(vol.MultiAttachEnabled),
-							"region":             llx.StringData(region),
-							"size":               llx.IntDataDefault(vol.Size, 0),
-							"state":              llx.StringData(string(vol.State)),
-							"tags":               llx.MapData(toInterfaceMap(ec2TagsToMap(vol.Tags)), types.String),
-							"throughput":         llx.IntDataDefault(vol.Throughput, 0),
-							"volumeType":         llx.StringData(string(vol.VolumeType)),
-							"sseType":            llx.StringData(string(vol.SseType)),
-						})
-					if err != nil {
-						return nil, err
-					}
-					mqlVol.(*mqlAwsEc2Volume).cacheKmsKeyId = vol.KmsKeyId
 					res = append(res, mqlVol)
 				}
 			}
@@ -2214,36 +2251,77 @@ func initAwsEc2Volume(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 	if args["arn"] == nil {
 		return nil, nil, errors.New("arn required to fetch aws volume")
 	}
+	arnVal := args["arn"].Value.(string)
 
-	// load all security groups
+	parsed, err := arn.Parse(arnVal)
+	if err == nil && parsed.Region != "" && strings.HasPrefix(parsed.Resource, "volume/") {
+		volumeId := strings.TrimPrefix(parsed.Resource, "volume/")
+		conn := runtime.Connection.(*connection.AwsConnection)
+		svc := conn.Ec2(parsed.Region)
+		resp, err := svc.DescribeVolumes(context.Background(), &ec2.DescribeVolumesInput{
+			VolumeIds: []string{volumeId},
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(resp.Volumes) > 0 {
+			mqlVol, err := buildVolumeResource(runtime, parsed.Region, conn.AccountId(), resp.Volumes[0])
+			if err != nil {
+				return nil, nil, err
+			}
+			return args, mqlVol, nil
+		}
+		return nil, nil, errors.New("volume does not exist")
+	}
+
+	// Fallback: scan the cached list when the ARN is unparseable.
 	obj, err := CreateResource(runtime, ResourceAwsEc2, map[string]*llx.RawData{})
 	if err != nil {
 		return nil, nil, err
 	}
 	awsEc2 := obj.(*mqlAwsEc2)
-
 	rawResources := awsEc2.GetVolumes()
 	if rawResources.Error != nil {
 		return nil, nil, rawResources.Error
 	}
-
-	var match func(secGroup *mqlAwsEc2Volume) bool
-
-	if args["arn"] != nil {
-		arnVal := args["arn"].Value.(string)
-		match = func(vol *mqlAwsEc2Volume) bool {
-			return vol.Arn.Data == arnVal
-		}
-	}
-
 	for _, rawResource := range rawResources.Data {
 		volume := rawResource.(*mqlAwsEc2Volume)
-		if match(volume) {
+		if volume.Arn.Data == arnVal {
 			return args, volume, nil
 		}
 	}
-
 	return nil, nil, errors.New("volume does not exist")
+}
+
+func buildVolumeResource(runtime *plugin.Runtime, region, accountID string, vol ec2types.Volume) (*mqlAwsEc2Volume, error) {
+	jsonAttachments, err := convert.JsonToDictSlice(vol.Attachments)
+	if err != nil {
+		return nil, err
+	}
+	mqlVol, err := CreateResource(runtime, ResourceAwsEc2Volume,
+		map[string]*llx.RawData{
+			"arn":                llx.StringData(fmt.Sprintf(volumeArnPattern, region, accountID, convert.ToValue(vol.VolumeId))),
+			"attachments":        llx.ArrayData(jsonAttachments, types.Any),
+			"availabilityZone":   llx.StringDataPtr(vol.AvailabilityZone),
+			"createTime":         llx.TimeDataPtr(vol.CreateTime),
+			"encrypted":          llx.BoolDataPtr(vol.Encrypted),
+			"id":                 llx.StringDataPtr(vol.VolumeId),
+			"iops":               llx.IntDataDefault(vol.Iops, 0),
+			"multiAttachEnabled": llx.BoolDataPtr(vol.MultiAttachEnabled),
+			"region":             llx.StringData(region),
+			"size":               llx.IntDataDefault(vol.Size, 0),
+			"state":              llx.StringData(string(vol.State)),
+			"tags":               llx.MapData(toInterfaceMap(ec2TagsToMap(vol.Tags)), types.String),
+			"throughput":         llx.IntDataDefault(vol.Throughput, 0),
+			"volumeType":         llx.StringData(string(vol.VolumeType)),
+			"sseType":            llx.StringData(string(vol.SseType)),
+		})
+	if err != nil {
+		return nil, err
+	}
+	v := mqlVol.(*mqlAwsEc2Volume)
+	v.cacheKmsKeyId = vol.KmsKeyId
+	return v, nil
 }
 
 type mqlAwsEc2VolumeInternal struct {
@@ -2281,19 +2359,53 @@ func initAwsEc2Instance(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 	if args["arn"] == nil {
 		return nil, nil, errors.New("arn required to fetch ec2 instance")
 	}
+	arnVal := args["arn"].Value.(string)
 
+	// Parse the ARN to extract region + instance id and target a single
+	// DescribeInstances call. Fall back to the cross-region list path only
+	// when the ARN is malformed.
+	parsed, err := arn.Parse(arnVal)
+	if err == nil && parsed.Region != "" && strings.HasPrefix(parsed.Resource, "instance/") {
+		instanceId := strings.TrimPrefix(parsed.Resource, "instance/")
+		obj, err := CreateResource(runtime, ResourceAwsEc2, map[string]*llx.RawData{})
+		if err != nil {
+			return nil, nil, err
+		}
+		mqlEc2 := obj.(*mqlAwsEc2)
+
+		conn := runtime.Connection.(*connection.AwsConnection)
+		svc := conn.Ec2(parsed.Region)
+		resp, err := svc.DescribeInstances(context.Background(), &ec2.DescribeInstancesInput{
+			InstanceIds: []string{instanceId},
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, reservation := range resp.Reservations {
+			if len(reservation.Instances) == 0 {
+				continue
+			}
+			res, err := mqlEc2.gatherInstanceInfo(reservation.Instances[:1], parsed.Region)
+			if err != nil {
+				return nil, nil, err
+			}
+			if len(res) > 0 {
+				return args, res[0].(*mqlAwsEc2Instance), nil
+			}
+		}
+		return nil, nil, errors.New("ec2 instance does not exist")
+	}
+
+	// Fallback for unparseable ARNs: scan the cached list.
 	obj, err := CreateResource(runtime, ResourceAwsEc2, map[string]*llx.RawData{})
 	if err != nil {
 		return nil, nil, err
 	}
-	ec2 := obj.(*mqlAwsEc2)
-
-	rawResources := ec2.GetInstances()
+	mqlEc2 := obj.(*mqlAwsEc2)
+	rawResources := mqlEc2.GetInstances()
 	if rawResources.Error != nil {
-		return nil, nil, err
+		return nil, nil, rawResources.Error
 	}
-
-	arnVal := args["arn"].Value.(string)
 	for _, rawResource := range rawResources.Data {
 		instance := rawResource.(*mqlAwsEc2Instance)
 		if instance.Arn.Data == arnVal {
@@ -2301,6 +2413,30 @@ func initAwsEc2Instance(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		}
 	}
 	return nil, nil, errors.New("ec2 instance does not exist")
+}
+
+func buildSnapshotResource(runtime *plugin.Runtime, region, accountID string, snapshot ec2types.Snapshot) (*mqlAwsEc2Snapshot, error) {
+	mqlSnap, err := CreateResource(runtime, ResourceAwsEc2Snapshot,
+		map[string]*llx.RawData{
+			"arn":            llx.StringData(fmt.Sprintf(snapshotArnPattern, region, accountID, convert.ToValue(snapshot.SnapshotId))),
+			"completionTime": llx.TimeDataPtr(snapshot.CompletionTime),
+			"description":    llx.StringDataPtr(snapshot.Description),
+			"encrypted":      llx.BoolDataPtr(snapshot.Encrypted),
+			"id":             llx.StringDataPtr(snapshot.SnapshotId),
+			"region":         llx.StringData(region),
+			"startTime":      llx.TimeDataPtr(snapshot.StartTime),
+			"state":          llx.StringData(string(snapshot.State)),
+			"storageTier":    llx.StringData(string(snapshot.StorageTier)),
+			"tags":           llx.MapData(toInterfaceMap(ec2TagsToMap(snapshot.Tags)), types.String),
+			"volumeId":       llx.StringDataPtr(snapshot.VolumeId),
+			"volumeSize":     llx.IntDataDefault(snapshot.VolumeSize, 0),
+		})
+	if err != nil {
+		return nil, err
+	}
+	s := mqlSnap.(*mqlAwsEc2Snapshot)
+	s.cacheKmsKeyId = snapshot.KmsKeyId
+	return s, nil
 }
 
 func initAwsEc2Snapshot(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -2314,44 +2450,64 @@ func initAwsEc2Snapshot(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		}
 	}
 
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch aws snapshot")
+	if args["arn"] == nil && args["id"] == nil {
+		return nil, nil, errors.New("arn or id required to fetch aws snapshot")
 	}
 
-	// load all security groups
+	// Targeted path: arn carries the region and snapshot id.
+	if args["arn"] != nil {
+		arnVal := args["arn"].Value.(string)
+		if parsed, err := arn.Parse(arnVal); err == nil && parsed.Region != "" && strings.HasPrefix(parsed.Resource, "snapshot/") {
+			snapshotId := strings.TrimPrefix(parsed.Resource, "snapshot/")
+			conn := runtime.Connection.(*connection.AwsConnection)
+			svc := conn.Ec2(parsed.Region)
+			resp, err := svc.DescribeSnapshots(context.Background(), &ec2.DescribeSnapshotsInput{
+				SnapshotIds: []string{snapshotId},
+			})
+			if err != nil {
+				return nil, nil, err
+			}
+			if len(resp.Snapshots) > 0 {
+				mqlSnap, err := buildSnapshotResource(runtime, parsed.Region, conn.AccountId(), resp.Snapshots[0])
+				if err != nil {
+					return nil, nil, err
+				}
+				return args, mqlSnap, nil
+			}
+			return nil, nil, errors.New("snapshot does not exist")
+		}
+	}
+
+	// Fallback: scan the cached list when only an opaque id was supplied or
+	// the arn was unparseable.
 	obj, err := CreateResource(runtime, ResourceAwsEc2, map[string]*llx.RawData{})
 	if err != nil {
 		return nil, nil, err
 	}
 	awsEc2 := obj.(*mqlAwsEc2)
-
 	rawResources := awsEc2.GetSnapshots()
 	if rawResources.Error != nil {
-		return nil, nil, err
+		return nil, nil, rawResources.Error
 	}
 	var match func(snapshot *mqlAwsEc2Snapshot) bool
-
 	if args["arn"] != nil {
 		arnVal := args["arn"].Value.(string)
 		match = func(snapshot *mqlAwsEc2Snapshot) bool {
 			return snapshot.Arn.Data == arnVal
 		}
 	}
-
 	if args["id"] != nil {
 		idVal := args["id"].Value.(string)
 		match = func(snap *mqlAwsEc2Snapshot) bool {
 			return snap.Id.Data == idVal
 		}
 	}
-
 	for _, rawResource := range rawResources.Data {
 		snapshot := rawResource.(*mqlAwsEc2Snapshot)
 		if match(snapshot) {
 			return args, snapshot, nil
 		}
 	}
-
 	return nil, nil, errors.New("snapshot does not exist")
 }
 
@@ -2473,25 +2629,10 @@ func (a *mqlAwsEc2) getSnapshots(conn *connection.AwsConnection) []*jobpool.Job 
 						log.Debug().Interface("snapshot", snapshot.SnapshotId).Msg("excluding snapshot due to filters")
 						continue
 					}
-					mqlSnap, err := CreateResource(a.MqlRuntime, ResourceAwsEc2Snapshot,
-						map[string]*llx.RawData{
-							"arn":            llx.StringData(fmt.Sprintf(snapshotArnPattern, region, conn.AccountId(), convert.ToValue(snapshot.SnapshotId))),
-							"completionTime": llx.TimeDataPtr(snapshot.CompletionTime),
-							"description":    llx.StringDataPtr(snapshot.Description),
-							"encrypted":      llx.BoolDataPtr(snapshot.Encrypted),
-							"id":             llx.StringDataPtr(snapshot.SnapshotId),
-							"region":         llx.StringData(region),
-							"startTime":      llx.TimeDataPtr(snapshot.StartTime),
-							"state":          llx.StringData(string(snapshot.State)),
-							"storageTier":    llx.StringData(string(snapshot.StorageTier)),
-							"tags":           llx.MapData(toInterfaceMap(ec2TagsToMap(snapshot.Tags)), types.String),
-							"volumeId":       llx.StringDataPtr(snapshot.VolumeId),
-							"volumeSize":     llx.IntDataDefault(snapshot.VolumeSize, 0),
-						})
+					mqlSnap, err := buildSnapshotResource(a.MqlRuntime, region, conn.AccountId(), snapshot)
 					if err != nil {
 						return nil, err
 					}
-					mqlSnap.(*mqlAwsEc2Snapshot).cacheKmsKeyId = snapshot.KmsKeyId
 					res = append(res, mqlSnap)
 				}
 			}

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -1961,7 +1961,7 @@ func initAwsEc2Securitygroup(runtime *plugin.Runtime, args map[string]*llx.RawDa
 	var region, groupId string
 	if args["arn"] != nil {
 		arnVal := args["arn"].Value.(string)
-		if parsed, err := arn.Parse(arnVal); err == nil {
+		if parsed, err := arn.Parse(arnVal); err == nil && strings.HasPrefix(parsed.Resource, "security-group/") {
 			region = parsed.Region
 			groupId = strings.TrimPrefix(parsed.Resource, "security-group/")
 		}

--- a/providers/aws/resources/aws_guardduty.go
+++ b/providers/aws/resources/aws_guardduty.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/guardduty"
@@ -21,6 +22,12 @@ import (
 	"go.mondoo.com/mql/v13/providers/aws/connection"
 	mqlTypes "go.mondoo.com/mql/v13/types"
 )
+
+// guarddutyDetailConcurrency caps the per-detector fan-out of Describe/Get
+// calls for publishing destinations, IP sets, and threat-intel sets. There is
+// no batch API; fanning out shrinks the wall clock for detectors with many
+// children.
+const guarddutyDetailConcurrency = 10
 
 func (a *mqlAwsGuardduty) id() (string, error) {
 	return "aws.guardduty", nil
@@ -457,18 +464,34 @@ func (a *mqlAwsGuarddutyDetector) publishingDestinations() ([]any, error) {
 		return nil, err
 	}
 
+	details := make([]*guardduty.DescribePublishingDestinationOutput, len(resp.Destinations))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, guarddutyDetailConcurrency)
+	for i, dest := range resp.Destinations {
+		wg.Add(1)
+		go func(idx int, destId *string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			detail, err := svc.DescribePublishingDestination(ctx, &guardduty.DescribePublishingDestinationInput{
+				DetectorId:    &detectorId,
+				DestinationId: destId,
+			})
+			if err != nil {
+				log.Warn().Err(err).Str("destinationId", convert.ToValue(destId)).Msg("could not describe publishing destination")
+				return
+			}
+			details[idx] = detail
+		}(i, dest.DestinationId)
+	}
+	wg.Wait()
+
 	res := []any{}
-	for _, dest := range resp.Destinations {
-		// Fetch full details for each destination
-		detail, err := svc.DescribePublishingDestination(ctx, &guardduty.DescribePublishingDestinationInput{
-			DetectorId:    &detectorId,
-			DestinationId: dest.DestinationId,
-		})
-		if err != nil {
-			log.Warn().Err(err).Str("destinationId", convert.ToValue(dest.DestinationId)).Msg("could not describe publishing destination")
+	for i, dest := range resp.Destinations {
+		detail := details[i]
+		if detail == nil {
 			continue
 		}
-
 		mqlDest, err := CreateResource(a.MqlRuntime, "aws.guardduty.detector.publishingDestination",
 			map[string]*llx.RawData{
 				"__id":            llx.StringData(fmt.Sprintf("%s/publishingDestination/%s", detectorId, convert.ToValue(dest.DestinationId))),
@@ -554,16 +577,33 @@ func (a *mqlAwsGuarddutyDetector) ipSets() ([]any, error) {
 			}
 			return nil, err
 		}
-		for _, ipSetId := range resp.IpSetIds {
-			detail, err := svc.GetIPSet(ctx, &guardduty.GetIPSetInput{
-				DetectorId: &detectorId,
-				IpSetId:    &ipSetId,
-			})
-			if err != nil {
-				log.Warn().Err(err).Str("ipSetId", ipSetId).Msg("could not get IP set details")
+		details := make([]*guardduty.GetIPSetOutput, len(resp.IpSetIds))
+		var wg sync.WaitGroup
+		sem := make(chan struct{}, guarddutyDetailConcurrency)
+		for i, ipSetId := range resp.IpSetIds {
+			wg.Add(1)
+			go func(idx int, id string) {
+				defer wg.Done()
+				sem <- struct{}{}
+				defer func() { <-sem }()
+				detail, err := svc.GetIPSet(ctx, &guardduty.GetIPSetInput{
+					DetectorId: &detectorId,
+					IpSetId:    &id,
+				})
+				if err != nil {
+					log.Warn().Err(err).Str("ipSetId", id).Msg("could not get IP set details")
+					return
+				}
+				details[idx] = detail
+			}(i, ipSetId)
+		}
+		wg.Wait()
+
+		for i, ipSetId := range resp.IpSetIds {
+			detail := details[i]
+			if detail == nil {
 				continue
 			}
-
 			mqlIpSet, err := CreateResource(a.MqlRuntime, "aws.guardduty.detector.ipSet",
 				map[string]*llx.RawData{
 					"__id":     llx.StringData(fmt.Sprintf("%s/ipSet/%s", detectorId, ipSetId)),
@@ -602,16 +642,33 @@ func (a *mqlAwsGuarddutyDetector) threatIntelSets() ([]any, error) {
 			}
 			return nil, err
 		}
-		for _, tiSetId := range resp.ThreatIntelSetIds {
-			detail, err := svc.GetThreatIntelSet(ctx, &guardduty.GetThreatIntelSetInput{
-				DetectorId:       &detectorId,
-				ThreatIntelSetId: &tiSetId,
-			})
-			if err != nil {
-				log.Warn().Err(err).Str("threatIntelSetId", tiSetId).Msg("could not get threat intel set details")
+		details := make([]*guardduty.GetThreatIntelSetOutput, len(resp.ThreatIntelSetIds))
+		var wg sync.WaitGroup
+		sem := make(chan struct{}, guarddutyDetailConcurrency)
+		for i, tiSetId := range resp.ThreatIntelSetIds {
+			wg.Add(1)
+			go func(idx int, id string) {
+				defer wg.Done()
+				sem <- struct{}{}
+				defer func() { <-sem }()
+				detail, err := svc.GetThreatIntelSet(ctx, &guardduty.GetThreatIntelSetInput{
+					DetectorId:       &detectorId,
+					ThreatIntelSetId: &id,
+				})
+				if err != nil {
+					log.Warn().Err(err).Str("threatIntelSetId", id).Msg("could not get threat intel set details")
+					return
+				}
+				details[idx] = detail
+			}(i, tiSetId)
+		}
+		wg.Wait()
+
+		for i, tiSetId := range resp.ThreatIntelSetIds {
+			detail := details[i]
+			if detail == nil {
 				continue
 			}
-
 			mqlTiSet, err := CreateResource(a.MqlRuntime, "aws.guardduty.detector.threatIntelSet",
 				map[string]*llx.RawData{
 					"__id":     llx.StringData(fmt.Sprintf("%s/threatIntelSet/%s", detectorId, tiSetId)),

--- a/providers/aws/resources/aws_kinesis.go
+++ b/providers/aws/resources/aws_kinesis.go
@@ -24,6 +24,11 @@ import (
 	"go.mondoo.com/mql/v13/providers/aws/connection"
 )
 
+// firehoseDescribeConcurrency caps the per-region fan-out of
+// DescribeDeliveryStream calls. Firehose has no batch describe, so listing
+// streams costs 1 + N round-trips; fanning out shrinks the wall clock.
+const firehoseDescribeConcurrency = 10
+
 func (a *mqlAwsKinesis) id() (string, error) {
 	return "aws.kinesis", nil
 }
@@ -468,19 +473,39 @@ func (a *mqlAwsKinesis) getFirehoseDeliveryStreams(conn *connection.AwsConnectio
 					return nil, err
 				}
 
-				for _, streamName := range page.DeliveryStreamNames {
-					descResp, err := svc.DescribeDeliveryStream(ctx, &firehose.DescribeDeliveryStreamInput{
-						DeliveryStreamName: &streamName,
-					})
-					if err != nil {
-						log.Warn().Str("stream", streamName).Err(err).Msg("could not describe firehose delivery stream")
+				// Fan out the per-stream DescribeDeliveryStream calls. Firehose
+				// has no batch describe; up to firehoseDescribeConcurrency calls
+				// run at once to compress wall-clock latency for accounts with
+				// many streams.
+				descs := make([]*firehose_types.DeliveryStreamDescription, len(page.DeliveryStreamNames))
+				var wg sync.WaitGroup
+				sem := make(chan struct{}, firehoseDescribeConcurrency)
+				for i, streamName := range page.DeliveryStreamNames {
+					wg.Add(1)
+					go func(idx int, name string) {
+						defer wg.Done()
+						sem <- struct{}{}
+						defer func() { <-sem }()
+						descResp, err := svc.DescribeDeliveryStream(ctx, &firehose.DescribeDeliveryStreamInput{
+							DeliveryStreamName: &name,
+						})
+						if err != nil {
+							log.Warn().Str("stream", name).Err(err).Msg("could not describe firehose delivery stream")
+							return
+						}
+						if descResp.DeliveryStreamDescription == nil {
+							log.Warn().Str("stream", name).Msg("nil delivery stream description")
+							return
+						}
+						descs[idx] = descResp.DeliveryStreamDescription
+					}(i, streamName)
+				}
+				wg.Wait()
+				for _, desc := range descs {
+					if desc == nil {
 						continue
 					}
-					if descResp.DeliveryStreamDescription == nil {
-						log.Warn().Str("stream", streamName).Msg("nil delivery stream description")
-						continue
-					}
-					mqlStream, err := newMqlAwsKinesisFirehoseDeliveryStream(a.MqlRuntime, region, descResp.DeliveryStreamDescription)
+					mqlStream, err := newMqlAwsKinesisFirehoseDeliveryStream(a.MqlRuntime, region, desc)
 					if err != nil {
 						return nil, err
 					}

--- a/providers/aws/resources/aws_secretsmanager.go
+++ b/providers/aws/resources/aws_secretsmanager.go
@@ -149,7 +149,37 @@ func initAwsSecretsmanagerSecret(runtime *plugin.Runtime, args map[string]*llx.R
 	mqlSecretRes.cacheRegion = region
 	mqlSecretRes.cacheType = convert.ToValue(resp.Type)
 	mqlSecretRes.DeletedAt = plugin.TValue[*time.Time]{Data: resp.DeletedDate, State: plugin.StateIsSet}
+
+	// We already have the replication status from DescribeSecret; populate
+	// ReplicaRegions directly to avoid a redundant DescribeSecret call.
+	replicaRegions, err := buildSecretReplicaRegions(runtime, convert.ToValue(resp.ARN), resp.ReplicationStatus)
+	if err != nil {
+		return nil, nil, err
+	}
+	mqlSecretRes.ReplicaRegions = plugin.TValue[[]any]{Data: replicaRegions, State: plugin.StateIsSet}
+
 	return args, mqlSecretRes, nil
+}
+
+func buildSecretReplicaRegions(runtime *plugin.Runtime, arn string, replicas []secretstypes.ReplicationStatusType) ([]any, error) {
+	res := make([]any, 0, len(replicas))
+	for _, replica := range replicas {
+		mqlReplica, err := CreateResource(runtime, "aws.secretsmanager.secret.replicaRegion",
+			map[string]*llx.RawData{
+				"__id":             llx.StringData(arn + "/replica/" + convert.ToValue(replica.Region)),
+				"id":               llx.StringData(arn + "/replica/" + convert.ToValue(replica.Region)),
+				"region":           llx.StringDataPtr(replica.Region),
+				"status":           llx.StringData(string(replica.Status)),
+				"statusMessage":    llx.StringDataPtr(replica.StatusMessage),
+				"kmsKeyId":         llx.StringDataPtr(replica.KmsKeyId),
+				"lastAccessedDate": llx.TimeDataPtr(replica.LastAccessedDate),
+			})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlReplica)
+	}
+	return res, nil
 }
 
 func (a *mqlAwsSecretsmanagerSecret) kmsKey() (*mqlAwsKmsKey, error) {
@@ -304,24 +334,7 @@ func (a *mqlAwsSecretsmanagerSecret) replicaRegions() ([]any, error) {
 		return nil, err
 	}
 
-	res := []any{}
-	for _, replica := range resp.ReplicationStatus {
-		mqlReplica, err := CreateResource(a.MqlRuntime, "aws.secretsmanager.secret.replicaRegion",
-			map[string]*llx.RawData{
-				"__id":             llx.StringData(arn + "/replica/" + convert.ToValue(replica.Region)),
-				"id":               llx.StringData(arn + "/replica/" + convert.ToValue(replica.Region)),
-				"region":           llx.StringDataPtr(replica.Region),
-				"status":           llx.StringData(string(replica.Status)),
-				"statusMessage":    llx.StringDataPtr(replica.StatusMessage),
-				"kmsKeyId":         llx.StringDataPtr(replica.KmsKeyId),
-				"lastAccessedDate": llx.TimeDataPtr(replica.LastAccessedDate),
-			})
-		if err != nil {
-			return nil, err
-		}
-		res = append(res, mqlReplica)
-	}
-	return res, nil
+	return buildSecretReplicaRegions(a.MqlRuntime, arn, resp.ReplicationStatus)
 }
 
 type mqlAwsSecretsmanagerSecretInternal struct {


### PR DESCRIPTION
## Summary

Targeted perf fixes across the AWS provider following a deep audit:

- **EC2 init by ARN** (`aws.ec2.instance(arn:…)`, `securitygroup`, `volume`, `snapshot`): stop listing every resource in every region and Go-side filtering — parse the ARN, target the region, make one Describe call.
- **EC2 ENI init** (when region is unknown): probe regions in parallel instead of serially. ENI ids alone don't carry region, so the probe is unavoidable, but it doesn't have to be sequential.
- **GuardDuty `publishingDestinations` / `ipSets` / `threatIntelSets`**: per-item `DescribePublishingDestination` / `GetIPSet` / `GetThreatIntelSet` are now bounded-parallel instead of sequential. AWS exposes no batch API for these.
- **Kinesis Firehose `deliveryStreams`**: per-stream `DescribeDeliveryStream` calls now fan out within each region.
- **SecretsManager**: `init` already calls `DescribeSecret`; `replicaRegions()` was re-calling it for the same data. Cache the response and serve from it.

This is the first wave from a broader audit (see *Follow-ups* below).

## Estimated API call reduction

Real-world numbers depend on account shape; these are first-order estimates.

| Hot path | Before | After | Notes |
|---|---|---|---|
| `aws.ec2.instance(arn:…)` cold-cache | 1 `DescribeInstances` **per region** (e.g. 16) + Go-side filter | 1 `DescribeInstances` | -94% calls in a 16-region account; bigger savings for accounts with many instances per region (paginated) |
| `aws.ec2.securitygroup(arn:…)` | Same as above | 1 `DescribeSecurityGroups` | Same shape |
| `aws.ec2.volume(arn:…)` | Same as above | 1 `DescribeVolumes` | Same shape |
| `aws.ec2.snapshot(arn:…)` | Same as above + 1× `DescribeSnapshots(OwnerIds:[self])` per region | 1 `DescribeSnapshots` | Same shape |
| `aws.ec2.networkinterface(id:…)` (region unknown) | Up to N sequential `DescribeNetworkInterfaces` (average ~N/2) — ~5–10s wall | Same total call count, but parallel — ~1× call wall time | Same calls; wall-clock 5–10× faster |
| `aws.guardduty.detector.publishingDestinations` | 1 `List` + N sequential `Describe` | 1 `List` + N parallel `Describe` (pool=10) | Same calls; wall-clock ~N/10× faster |
| `aws.guardduty.detector.ipSets` / `.threatIntelSets` | 1 `List` + N sequential `Get` | 1 `List` + N parallel `Get` (pool=10) | Same shape |
| `aws.kinesis.firehoseDeliveryStreams` | 1 `List` + N sequential `Describe` per region | 1 `List` + N parallel `Describe` per region (pool=10) | Same shape |
| `aws.secretsmanager.secret(arn:…).replicaRegions` | 2 × `DescribeSecret` | 1 × `DescribeSecret` | -50% |

The **EC2 init** changes have the largest absolute reduction in call count — going from O(regions) (or worse, O(regions × pages)) to O(1) on cold-cache resolves. In a 16-region account with 200 instances (~10 pages), `aws.ec2.instance(arn:…)` previously cost up to **160 `DescribeInstances` calls**; it now costs **1**.

Existing **list paths** (e.g. `aws.ec2.instances`) are unchanged and pay no new cost — they go through the same factored builders.

## Behavior

- All targeted-API paths have a list-fallback if the ARN can't be parsed (preserving prior behavior for the corner cases).
- The ENI parallel probe collects the first successful hit and returns; it does not depend on ordering.
- Bounded parallelism uses a 10-slot semaphore (`firehoseDescribeConcurrency`, `guarddutyDetailConcurrency`) — consistent with existing parallel-fetch patterns in this provider (e.g. `batchFetchLambdaTags`, DocumentDB elastic clusters).

## Follow-ups (not in this PR)

Same audit also flagged, deferred to keep this PR reviewable:

- `initAws*` for **Lambda, RDS DBInstance/DBCluster, ECR image, SSM instance, ECS cluster/service/task, DocumentDB instance** — same mechanical pattern as the EC2 inits.
- **Pool inner-loop fixes** in `aws_iam_accessanalyzer.go` and `aws_guardduty.go` (region pool parallel, but per-region inner loops over analyzer/detector types still sequential). Architectural — wanted more careful interactive verification before touching.

## Test plan
- [ ] `make providers/build/aws && make providers/install/aws`
- [ ] `mql shell aws -c "aws.ec2.instance(arn:'arn:aws:ec2:us-east-1:…:instance/i-…').name"` — confirm targeted path returns a single instance
- [ ] `mql shell aws -c "aws.ec2.securitygroup(arn:'arn:aws:ec2:us-east-1:…:security-group/sg-…').description"`
- [ ] `mql shell aws -c "aws.ec2.volume(arn:'arn:aws:ec2:us-east-1:…:volume/vol-…').size"`
- [ ] `mql shell aws -c "aws.ec2.snapshot(arn:'arn:aws:ec2:us-east-1:…:snapshot/snap-…').state"`
- [ ] `mql shell aws -c "aws.ec2.networkinterface(id:'eni-…').macAddress"` — confirm parallel probe still resolves
- [ ] `mql shell aws -c "aws.guardduty.detectors.first.ipSets"` — confirm parallel fan-out works
- [ ] `mql shell aws -c "aws.kinesis.firehoseDeliveryStreams"` — confirm parallel fan-out works
- [ ] `mql shell aws -c "aws.secretsmanager.secret(arn:'…').replicaRegions"` — confirm single DescribeSecret + correct results
- [ ] `make test/go/plain` (run locally as part of pre-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)