### PR TITLE
⚡ azure: reduce per-resource API calls across hot paths

### DIFF
--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -52812,7 +52812,7 @@ func (c *mqlAzureSubscriptionKeyVaultServiceManagedHsm) GetPrivateEndpointConnec
 type mqlAzureSubscriptionKeyVaultServiceVault struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionKeyVaultServiceVaultInternal it will be used here
+	mqlAzureSubscriptionKeyVaultServiceVaultInternal
 	Id                           plugin.TValue[string]
 	VaultName                    plugin.TValue[string]
 	Type                         plugin.TValue[string]
@@ -57011,7 +57011,7 @@ func (c *mqlAzureSubscriptionCloudDefenderServiceDefenderForResourceManager) Get
 type mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionCloudDefenderServiceDefenderForContainersInternal it will be used here
+	mqlAzureSubscriptionCloudDefenderServiceDefenderForContainersInternal
 	SubscriptionId           plugin.TValue[string]
 	Enabled                  plugin.TValue[bool]
 	PricingTier              plugin.TValue[string]

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
-  "version": "13.12.1",
-  "generated_at": "2026-05-22T11:23:05-07:00",
+  "version": "13.13.0",
+  "generated_at": "2026-05-26T14:28:59+03:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",
@@ -394,7 +394,7 @@
     {
       "permission": "Microsoft.Cognitiveservices/raiTopics/read",
       "service": "Microsoft.Cognitiveservices",
-      "action": "Get",
+      "action": "NewListPager",
       "source_file": "cognitiveservices.go"
     },
     {
@@ -418,13 +418,13 @@
     {
       "permission": "Microsoft.Compute/diskEncryptionSets/read",
       "service": "Microsoft.Compute",
-      "action": "NewListPager",
+      "action": "Get",
       "source_file": "compute.go"
     },
     {
       "permission": "Microsoft.Compute/disks/read",
       "service": "Microsoft.Compute",
-      "action": "NewListPager",
+      "action": "Get",
       "source_file": "compute.go"
     },
     {
@@ -520,7 +520,7 @@
     {
       "permission": "Microsoft.ContainerRegistry/registries/scopeMaps/read",
       "service": "Microsoft.ContainerRegistry",
-      "action": "NewListPager",
+      "action": "Get",
       "source_file": "containerregistry.go"
     },
     {
@@ -550,7 +550,7 @@
     {
       "permission": "Microsoft.DBforMySQL/servers/configurations/read",
       "service": "Microsoft.DBforMySQL",
-      "action": "NewListByServerPager",
+      "action": "Get",
       "source_file": "mysql.go"
     },
     {
@@ -664,7 +664,7 @@
     {
       "permission": "Microsoft.DocumentDB/sQLResources/read",
       "service": "Microsoft.DocumentDB",
-      "action": "NewListSQLRoleDefinitionsPager",
+      "action": "NewListSQLRoleAssignmentsPager",
       "source_file": "cosmosdb.go"
     },
     {
@@ -784,7 +784,7 @@
     {
       "permission": "Microsoft.Network/applicationGateways/read",
       "service": "Microsoft.Network",
-      "action": "NewListAllPager",
+      "action": "Get",
       "source_file": "network.go"
     },
     {
@@ -820,7 +820,7 @@
     {
       "permission": "Microsoft.Network/connections/read",
       "service": "Microsoft.Network",
-      "action": "NewListPager",
+      "action": "Get",
       "source_file": "network.go"
     },
     {
@@ -892,7 +892,7 @@
     {
       "permission": "Microsoft.Network/natGateways/read",
       "service": "Microsoft.Network",
-      "action": "Get",
+      "action": "NewListAllPager",
       "source_file": "network.go"
     },
     {
@@ -952,13 +952,13 @@
     {
       "permission": "Microsoft.Network/privateEndpoints/read",
       "service": "Microsoft.Network",
-      "action": "NewListBySubscriptionPager",
+      "action": "Get",
       "source_file": "network.go"
     },
     {
       "permission": "Microsoft.Network/privateLinkServices/read",
       "service": "Microsoft.Network",
-      "action": "NewListPrivateEndpointConnectionsPager",
+      "action": "NewListBySubscriptionPager",
       "source_file": "network.go"
     },
     {
@@ -976,7 +976,7 @@
     {
       "permission": "Microsoft.Network/publicIPAddresses/read",
       "service": "Microsoft.Network",
-      "action": "Get",
+      "action": "NewListAllPager",
       "source_file": "network.go"
     },
     {
@@ -1480,7 +1480,7 @@
     {
       "permission": "Microsoft.Web/sites/read",
       "service": "Microsoft.Web",
-      "action": "NewListFunctionsPager",
+      "action": "NewListPager",
       "source_file": "functions.go"
     },
     {

--- a/providers/azure/resources/cloud_defender.go
+++ b/providers/azure/resources/cloud_defender.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"go.mondoo.com/mql/v13/llx"
@@ -132,36 +133,6 @@ func commonPricingArgs(props *security.PricingProperties, mqlResourceName, subId
 	return args
 }
 
-// getSimpleDictPricing fetches pricing data for a Defender component and returns it as a dict
-// with a single "enabled" boolean field. Used by the deprecated defenderForX() dict methods.
-func (a *mqlAzureSubscriptionCloudDefenderService) getSimpleDictPricing(azurePricingName string) (any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
-	subId := a.SubscriptionId.Data
-
-	clientFactory, err := armsecurity.NewClientFactory(subId, token, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	pricing, err := clientFactory.NewPricingsClient().Get(ctx, fmt.Sprintf("subscriptions/%s", subId), azurePricingName, &security.PricingsClientGetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	type simplePricing struct {
-		Enabled bool `json:"enabled"`
-	}
-
-	resp := simplePricing{}
-	if pricing.Properties != nil && pricing.Properties.PricingTier != nil {
-		resp.Enabled = *pricing.Properties.PricingTier == security.PricingTierStandard
-	}
-
-	return convert.JsonToDict(resp)
-}
-
 // getSimpleDefenderPricing fetches pricing data for a Defender component and creates a typed resource.
 func (a *mqlAzureSubscriptionCloudDefenderService) getSimpleDefenderPricing(azurePricingName, mqlResourceName string) (plugin.Resource, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
@@ -184,55 +155,14 @@ func (a *mqlAzureSubscriptionCloudDefenderService) getSimpleDefenderPricing(azur
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) defenderForServers() (any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
-	subId := a.SubscriptionId.Data
-	clientFactory, err := armsecurity.NewClientFactory(subId, token, nil)
-	if err != nil {
-		return nil, err
+	typed := a.GetForServers()
+	if typed.Error != nil {
+		return nil, typed.Error
 	}
-	vmPricing, err := clientFactory.NewPricingsClient().Get(ctx, fmt.Sprintf("subscriptions/%s", subId), "VirtualMachines", &security.PricingsClientGetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	armConn, err := getArmSecurityConnection(ctx, conn, subId)
-	if err != nil {
-		return nil, err
-	}
-	list, err := getPolicyAssignments(ctx, armConn)
-	if err != nil {
-		return nil, err
-	}
-	serverVASetings, err := getServerVulnAssessmentSettings(ctx, armConn)
-	if err != nil {
-		return nil, err
-	}
-
-	type defenderForServers struct {
-		Enabled                         bool   `json:"enabled"`
-		VulnerabilityManagementToolName string `json:"vulnerabilityManagementToolName"`
-	}
-
-	resp := defenderForServers{}
-	if vmPricing.Properties.PricingTier != nil {
-		resp.Enabled = *vmPricing.Properties.PricingTier == security.PricingTierStandard
-	}
-
-	for _, it := range list.PolicyAssignments {
-		if it.Properties.PolicyDefinitionID == vaQualysPolicyDefinitionId {
-			resp.Enabled = true
-			resp.VulnerabilityManagementToolName = "Microsoft Defender for Cloud integrated Qualys scanner"
-		}
-	}
-	for _, sett := range serverVASetings.Settings {
-		if sett.Properties.SelectedProvider == "MdeTvm" && sett.Name == "AzureServersSetting" {
-			resp.Enabled = true
-			resp.VulnerabilityManagementToolName = "Microsoft Defender vulnerability management"
-		}
-	}
-	return convert.JsonToDict(resp)
+	return map[string]any{
+		"enabled":                         typed.Data.GetEnabled().Data,
+		"vulnerabilityManagementToolName": typed.Data.GetVulnerabilityManagementToolName().Data,
+	}, nil
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) forServers() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers, error) {
@@ -290,8 +220,24 @@ func (a *mqlAzureSubscriptionCloudDefenderService) forServers() (*mqlAzureSubscr
 	return resource.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers), nil
 }
 
+// simpleDefenderDict serializes a typed Defender pricing resource's `enabled`
+// flag into the shape that the deprecated defenderForX() dict methods used to
+// return — `{"enabled": <bool>}`. Letting the dict methods delegate here keeps
+// them in sync with the typed equivalent and reuses the PricingsClient.Get
+// already issued by the typed resource.
+func simpleDefenderDict(enabled *plugin.TValue[bool]) (any, error) {
+	if enabled.Error != nil {
+		return nil, enabled.Error
+	}
+	return map[string]any{"enabled": enabled.Data}, nil
+}
+
 func (a *mqlAzureSubscriptionCloudDefenderService) defenderForAppServices() (any, error) {
-	return a.getSimpleDictPricing("AppServices")
+	typed := a.GetForAppServices()
+	if typed.Error != nil {
+		return nil, typed.Error
+	}
+	return simpleDefenderDict(typed.Data.GetEnabled())
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) forAppServices() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForAppServices, error) {
@@ -303,7 +249,11 @@ func (a *mqlAzureSubscriptionCloudDefenderService) forAppServices() (*mqlAzureSu
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) defenderForSqlServersOnMachines() (any, error) {
-	return a.getSimpleDictPricing("SqlServerVirtualMachines")
+	typed := a.GetForSqlServersOnMachines()
+	if typed.Error != nil {
+		return nil, typed.Error
+	}
+	return simpleDefenderDict(typed.Data.GetEnabled())
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) forSqlServersOnMachines() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines, error) {
@@ -315,7 +265,11 @@ func (a *mqlAzureSubscriptionCloudDefenderService) forSqlServersOnMachines() (*m
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) defenderForSqlDatabases() (any, error) {
-	return a.getSimpleDictPricing("SqlServers")
+	typed := a.GetForSqlDatabases()
+	if typed.Error != nil {
+		return nil, typed.Error
+	}
+	return simpleDefenderDict(typed.Data.GetEnabled())
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) forSqlDatabases() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlDatabases, error) {
@@ -327,7 +281,11 @@ func (a *mqlAzureSubscriptionCloudDefenderService) forSqlDatabases() (*mqlAzureS
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) defenderForOpenSourceDatabases() (any, error) {
-	return a.getSimpleDictPricing("OpenSourceRelationalDatabases")
+	typed := a.GetForOpenSourceDatabases()
+	if typed.Error != nil {
+		return nil, typed.Error
+	}
+	return simpleDefenderDict(typed.Data.GetEnabled())
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) forOpenSourceDatabases() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases, error) {
@@ -339,7 +297,11 @@ func (a *mqlAzureSubscriptionCloudDefenderService) forOpenSourceDatabases() (*mq
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) defenderForCosmosDb() (any, error) {
-	return a.getSimpleDictPricing("CosmosDbs")
+	typed := a.GetForCosmosDb()
+	if typed.Error != nil {
+		return nil, typed.Error
+	}
+	return simpleDefenderDict(typed.Data.GetEnabled())
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) forCosmosDb() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForCosmosDb, error) {
@@ -351,7 +313,11 @@ func (a *mqlAzureSubscriptionCloudDefenderService) forCosmosDb() (*mqlAzureSubsc
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) defenderForStorageAccounts() (any, error) {
-	return a.getSimpleDictPricing("StorageAccounts")
+	typed := a.GetForStorageAccounts()
+	if typed.Error != nil {
+		return nil, typed.Error
+	}
+	return simpleDefenderDict(typed.Data.GetEnabled())
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) forStorageAccounts() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts, error) {
@@ -363,7 +329,11 @@ func (a *mqlAzureSubscriptionCloudDefenderService) forStorageAccounts() (*mqlAzu
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) defenderForKeyVaults() (any, error) {
-	return a.getSimpleDictPricing("KeyVaults")
+	typed := a.GetForKeyVaults()
+	if typed.Error != nil {
+		return nil, typed.Error
+	}
+	return simpleDefenderDict(typed.Data.GetEnabled())
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) forKeyVaults() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults, error) {
@@ -375,7 +345,11 @@ func (a *mqlAzureSubscriptionCloudDefenderService) forKeyVaults() (*mqlAzureSubs
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) defenderForResourceManager() (any, error) {
-	return a.getSimpleDictPricing("Arm")
+	typed := a.GetForResourceManager()
+	if typed.Error != nil {
+		return nil, typed.Error
+	}
+	return simpleDefenderDict(typed.Data.GetEnabled())
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) forResourceManager() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForResourceManager, error) {
@@ -466,90 +440,32 @@ func (a *mqlAzureSubscriptionCloudDefenderService) monitoringAgentAutoProvision(
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) defenderForContainers() (any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	subId := a.SubscriptionId.Data
+	typed := a.GetForContainers()
+	if typed.Error != nil {
+		return nil, typed.Error
+	}
 
-	armConn, err := getArmSecurityConnection(ctx, conn, subId)
+	rawExts, err := typed.Data.fetchRawExtensions()
 	if err != nil {
 		return nil, err
 	}
-
-	pas, err := getPolicyAssignments(ctx, armConn)
-	if err != nil {
-		return nil, err
-	}
-
-	type extension struct {
-		Name      string `json:"name"`
-		IsEnabled bool   `json:"isEnabled"`
-	}
-
-	type defenderForContainers struct {
-		DefenderDaemonSet        bool        `json:"defenderDaemonSet"`
-		AzurePolicyForKubernetes bool        `json:"azurePolicyForKubernetes"`
-		Enabled                  bool        `json:"enabled"`
-		Extensions               []extension `json:"extensions"`
-	}
-
-	kubernetesDefender := false
-	arcDefender := false
-	kubernetesPolicyExt := false
-	arcPolicyExt := false
-	for _, it := range pas.PolicyAssignments {
-		if it.Properties.PolicyDefinitionID == arcClusterDefenderExtensionDefinitionId &&
-			it.Properties.Scope == fmt.Sprintf("/subscriptions/%s", subId) {
-			arcDefender = true
-		}
-		if it.Properties.PolicyDefinitionID == kubernetesClusterDefenderExtensionDefinitionId &&
-			it.Properties.Scope == fmt.Sprintf("/subscriptions/%s", subId) {
-			kubernetesDefender = true
-		}
-		if it.Properties.PolicyDefinitionID == arcClusterPolicyExtensionDefinitionId &&
-			it.Properties.Scope == fmt.Sprintf("/subscriptions/%s", subId) {
-			arcPolicyExt = true
-		}
-		if it.Properties.PolicyDefinitionID == kubernetesClusterPolicyExtensionDefinitionId &&
-			it.Properties.Scope == fmt.Sprintf("/subscriptions/%s", subId) {
-			kubernetesPolicyExt = true
-		}
-	}
-
-	// Check if Defender for Containers is enabled by querying the pricing tier
-	clientFactory, err := armsecurity.NewClientFactory(subId, armConn.token, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	containersPricing, err := clientFactory.NewPricingsClient().Get(ctx, fmt.Sprintf("subscriptions/%s", subId), "Containers", &security.PricingsClientGetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	enabled := false
-	if containersPricing.Properties.PricingTier != nil {
-		enabled = *containersPricing.Properties.PricingTier == security.PricingTierStandard
-	}
-	extensions := []extension{}
-	for _, ext := range containersPricing.Properties.Extensions {
+	exts := make([]map[string]any, 0, len(rawExts))
+	for _, ext := range rawExts {
 		if ext.IsEnabled == nil || ext.Name == nil {
 			continue
 		}
-		e := false
-		if *ext.IsEnabled == security.IsEnabledTrue {
-			e = true
-		}
-		extensions = append(extensions, extension{Name: *ext.Name, IsEnabled: e})
+		exts = append(exts, map[string]any{
+			"name":      *ext.Name,
+			"isEnabled": *ext.IsEnabled == security.IsEnabledTrue,
+		})
 	}
 
-	def := defenderForContainers{
-		DefenderDaemonSet:        arcDefender && kubernetesDefender,
-		AzurePolicyForKubernetes: arcPolicyExt && kubernetesPolicyExt,
-		Enabled:                  enabled,
-		Extensions:               extensions,
-	}
-
-	return convert.JsonToDict(def)
+	return map[string]any{
+		"defenderDaemonSet":        typed.Data.GetDefenderDaemonSet().Data,
+		"azurePolicyForKubernetes": typed.Data.GetAzurePolicyForKubernetes().Data,
+		"enabled":                  typed.Data.GetEnabled().Data,
+		"extensions":               exts,
+	}, nil
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) forContainers() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers, error) {
@@ -612,7 +528,47 @@ func (a *mqlAzureSubscriptionCloudDefenderService) forContainers() (*mqlAzureSub
 	if err != nil {
 		return nil, err
 	}
-	return resource.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers), nil
+	mqlContainers := resource.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers)
+	rawExtensions := containersPricing.Properties.Extensions
+	mqlContainers.rawExtensionsOnce.Do(func() {
+		mqlContainers.rawExtensions = rawExtensions
+	})
+	return mqlContainers, nil
+}
+
+type mqlAzureSubscriptionCloudDefenderServiceDefenderForContainersInternal struct {
+	rawExtensionsOnce sync.Once
+	rawExtensions     []*security.Extension
+	rawExtensionsErr  error
+}
+
+// fetchRawExtensions returns the raw extension list from the Containers
+// pricing endpoint. Cached with sync.Once so the typed extensions() accessor
+// and the deprecated defenderForContainers() dict share a single fetch (the
+// parent forContainers() primes the cache; standalone access falls back to
+// the API).
+func (a *mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers) fetchRawExtensions() ([]*security.Extension, error) {
+	a.rawExtensionsOnce.Do(func() {
+		conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+		subId := a.SubscriptionId.Data
+		clientFactory, err := armsecurity.NewClientFactory(subId, conn.Token(), nil)
+		if err != nil {
+			a.rawExtensionsErr = err
+			return
+		}
+		resp, err := clientFactory.NewPricingsClient().Get(context.Background(),
+			fmt.Sprintf("subscriptions/%s", subId), "Containers",
+			&security.PricingsClientGetOptions{})
+		if err != nil {
+			a.rawExtensionsErr = err
+			return
+		}
+		if resp.Properties == nil {
+			return
+		}
+		a.rawExtensions = resp.Properties.Extensions
+	})
+	return a.rawExtensions, a.rawExtensionsErr
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) settingsMCAS() (*mqlAzureSubscriptionCloudDefenderServiceSettings, error) {
@@ -917,31 +873,14 @@ func (a *mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers) id() (st
 	return a.__id, nil
 }
 
-// extensions lazily fetches extension data for Defender for Containers. This re-fetches the Containers
-// pricing data (already retrieved by defenderForContainers) so that extensions are only loaded when accessed.
 func (a *mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers) extensions() ([]any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
-	subId := a.SubscriptionId.Data
-
-	clientFactory, err := armsecurity.NewClientFactory(subId, token, nil)
+	exts, err := a.fetchRawExtensions()
 	if err != nil {
 		return nil, err
 	}
-
-	containersPricing, err := clientFactory.NewPricingsClient().Get(ctx, fmt.Sprintf("subscriptions/%s", subId), "Containers", &security.PricingsClientGetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	if containersPricing.Properties == nil {
-		return []any{}, nil
-	}
-
-	return buildExtensionResources(a.MqlRuntime, containersPricing.Properties.Extensions,
+	return buildExtensionResources(a.MqlRuntime, exts,
 		ResourceAzureSubscriptionCloudDefenderServiceDefenderForContainersExtension,
-		ResourceAzureSubscriptionCloudDefenderServiceDefenderForContainers+"/"+subId)
+		ResourceAzureSubscriptionCloudDefenderServiceDefenderForContainers+"/"+a.SubscriptionId.Data)
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderServiceDefenderForContainersExtension) id() (string, error) {

--- a/providers/azure/resources/cloud_defender.go
+++ b/providers/azure/resources/cloud_defender.go
@@ -529,7 +529,10 @@ func (a *mqlAzureSubscriptionCloudDefenderService) forContainers() (*mqlAzureSub
 		return nil, err
 	}
 	mqlContainers := resource.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers)
-	rawExtensions := containersPricing.Properties.Extensions
+	var rawExtensions []*security.Extension
+	if containersPricing.Properties != nil {
+		rawExtensions = containersPricing.Properties.Extensions
+	}
 	mqlContainers.rawExtensionsOnce.Do(func() {
 		mqlContainers.rawExtensions = rawExtensions
 	})

--- a/providers/azure/resources/cloud_defender_test.go
+++ b/providers/azure/resources/cloud_defender_test.go
@@ -4,12 +4,14 @@
 package resources
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	security "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/security/armsecurity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
 func TestCommonPricingArgs(t *testing.T) {
@@ -169,5 +171,28 @@ func TestArgsFromContactProperties(t *testing.T) {
 
 		args := argsFromContactProperties(props)
 		assert.Equal(t, false, args["isEnabled"].Value)
+	})
+}
+
+func TestSimpleDefenderDict(t *testing.T) {
+	t.Run("Enabled", func(t *testing.T) {
+		tv := &plugin.TValue[bool]{Data: true}
+		got, err := simpleDefenderDict(tv)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{"enabled": true}, got)
+	})
+
+	t.Run("Disabled", func(t *testing.T) {
+		tv := &plugin.TValue[bool]{Data: false}
+		got, err := simpleDefenderDict(tv)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{"enabled": false}, got)
+	})
+
+	t.Run("Propagates underlying error", func(t *testing.T) {
+		want := errors.New("boom")
+		tv := &plugin.TValue[bool]{Error: want}
+		_, err := simpleDefenderDict(tv)
+		assert.ErrorIs(t, err, want)
 	})
 }

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -94,165 +94,10 @@ func (a *mqlAzureSubscriptionComputeService) vms() ([]any, error) {
 			return nil, err
 		}
 		for _, vm := range vms.Value {
-			properties, err := convert.JsonToDict(vm.Properties)
-			if err != nil {
-				return nil, err
+			if vm == nil {
+				continue
 			}
-
-			var encryptionAtHost, secureBootEnabled, vtpmEnabled, proxyAgentEnabled, proxyAgentAddExtension *bool
-			var securityType, proxyAgentMode *string
-			if vm.Properties != nil && vm.Properties.SecurityProfile != nil {
-				sp := vm.Properties.SecurityProfile
-				encryptionAtHost = sp.EncryptionAtHost
-				securityType = (*string)(sp.SecurityType)
-				if sp.UefiSettings != nil {
-					secureBootEnabled = sp.UefiSettings.SecureBootEnabled
-					vtpmEnabled = sp.UefiSettings.VTpmEnabled
-				}
-				if sp.ProxyAgentSettings != nil {
-					proxyAgentEnabled = sp.ProxyAgentSettings.Enabled
-					proxyAgentAddExtension = sp.ProxyAgentSettings.AddProxyAgentExtension
-					proxyAgentMode = (*string)(sp.ProxyAgentSettings.Mode)
-				}
-			}
-
-			var fipsEncryptionEnabled *bool
-			var resiliencyProfileDict, scheduledEventsPolicyDict map[string]any
-			if vm.Properties != nil {
-				if vm.Properties.AdditionalCapabilities != nil {
-					fipsEncryptionEnabled = vm.Properties.AdditionalCapabilities.EnableFips1403Encryption
-				}
-				resiliencyProfileDict, err = convert.JsonToDict(vm.Properties.ResiliencyProfile)
-				if err != nil {
-					return nil, err
-				}
-				scheduledEventsPolicyDict, err = convert.JsonToDict(vm.Properties.ScheduledEventsPolicy)
-				if err != nil {
-					return nil, err
-				}
-			}
-			systemDataDict, err := convert.JsonToDict(vm.SystemData)
-			if err != nil {
-				return nil, err
-			}
-
-			var computerName, adminUsername, licenseType *string
-			var vmId, provisioningState *string
-			var timeCreated *time.Time
-			var disablePasswordAuth, provisionVMAgent, enableAutomaticUpdates *bool
-			var patchMode string
-			var sshPublicKeys []any
-			if vm.Properties != nil {
-				licenseType = vm.Properties.LicenseType
-				vmId = vm.Properties.VMID
-				provisioningState = vm.Properties.ProvisioningState
-				timeCreated = vm.Properties.TimeCreated
-				if osp := vm.Properties.OSProfile; osp != nil {
-					computerName = osp.ComputerName
-					adminUsername = osp.AdminUsername
-					if lc := osp.LinuxConfiguration; lc != nil {
-						disablePasswordAuth = lc.DisablePasswordAuthentication
-						provisionVMAgent = lc.ProvisionVMAgent
-						if lc.SSH != nil {
-							for _, k := range lc.SSH.PublicKeys {
-								if k == nil {
-									continue
-								}
-								entry := map[string]any{}
-								if k.Path != nil {
-									entry["path"] = *k.Path
-								}
-								if k.KeyData != nil {
-									entry["keyData"] = *k.KeyData
-								}
-								sshPublicKeys = append(sshPublicKeys, entry)
-							}
-						}
-						if lc.PatchSettings != nil && lc.PatchSettings.PatchMode != nil {
-							patchMode = string(*lc.PatchSettings.PatchMode)
-						}
-					}
-					if wc := osp.WindowsConfiguration; wc != nil {
-						provisionVMAgent = wc.ProvisionVMAgent
-						enableAutomaticUpdates = wc.EnableAutomaticUpdates
-						if wc.PatchSettings != nil && wc.PatchSettings.PatchMode != nil {
-							patchMode = string(*wc.PatchSettings.PatchMode)
-						}
-					}
-				}
-			}
-
-			var id *string
-			if vm.ID != nil {
-				normalized := strings.ToLower(*vm.ID)
-				id = &normalized
-			}
-
-			var bootDiagnosticsEnabled bool
-			var bootDiagnosticsStorageUri, userData string
-			if vm.Properties != nil {
-				if dp := vm.Properties.DiagnosticsProfile; dp != nil && dp.BootDiagnostics != nil {
-					if dp.BootDiagnostics.Enabled != nil {
-						bootDiagnosticsEnabled = *dp.BootDiagnostics.Enabled
-					}
-					if dp.BootDiagnostics.StorageURI != nil {
-						bootDiagnosticsStorageUri = *dp.BootDiagnostics.StorageURI
-					}
-				}
-				if vm.Properties.UserData != nil {
-					userData = *vm.Properties.UserData
-				}
-			}
-
-			vmIDStr := ""
-			if vm.ID != nil {
-				vmIDStr = *vm.ID
-			}
-			// vmImageReferenceToMql is nil-safe on vm.Properties — always returns a
-			// resource (fields default to empty strings when the VM has no storage
-			// profile / image reference).
-			mqlImageRef, err := vmImageReferenceToMql(a.MqlRuntime, vmIDStr, vm.Properties)
-			if err != nil {
-				return nil, err
-			}
-
-			mqlAzureVm, err := CreateResource(a.MqlRuntime, "azure.subscription.computeService.vm",
-				map[string]*llx.RawData{
-					"id":                            llx.StringDataPtr(id),
-					"name":                          llx.StringDataPtr(vm.Name),
-					"location":                      llx.StringDataPtr(vm.Location),
-					"zones":                         llx.ArrayData(convert.SliceStrPtrToInterface(vm.Zones), types.String),
-					"tags":                          llx.MapData(convert.PtrMapStrToInterface(vm.Tags), types.String),
-					"type":                          llx.StringDataPtr(vm.Type),
-					"properties":                    llx.DictData(properties),
-					"encryptionAtHost":              llx.BoolDataPtr(encryptionAtHost),
-					"securityType":                  llx.StringDataPtr(securityType),
-					"secureBootEnabled":             llx.BoolDataPtr(secureBootEnabled),
-					"vtpmEnabled":                   llx.BoolDataPtr(vtpmEnabled),
-					"proxyAgentEnabled":             llx.BoolDataPtr(proxyAgentEnabled),
-					"proxyAgentMode":                llx.StringDataPtr(proxyAgentMode),
-					"proxyAgentAddExtension":        llx.BoolDataPtr(proxyAgentAddExtension),
-					"fipsEncryptionEnabled":         llx.BoolDataPtr(fipsEncryptionEnabled),
-					"resiliencyProfile":             llx.DictData(resiliencyProfileDict),
-					"scheduledEventsPolicy":         llx.DictData(scheduledEventsPolicyDict),
-					"systemData":                    llx.DictData(systemDataDict),
-					"computerName":                  llx.StringDataPtr(computerName),
-					"adminUsername":                 llx.StringDataPtr(adminUsername),
-					"licenseType":                   llx.StringDataPtr(licenseType),
-					"managedBy":                     llx.StringDataPtr(vm.ManagedBy),
-					"vmId":                          llx.StringDataPtr(vmId),
-					"provisioningState":             llx.StringDataPtr(provisioningState),
-					"timeCreated":                   llx.TimeDataPtr(timeCreated),
-					"sshPublicKeys":                 llx.ArrayData(sshPublicKeys, types.Dict),
-					"disablePasswordAuthentication": llx.BoolDataPtr(disablePasswordAuth),
-					"provisionVMAgent":              llx.BoolDataPtr(provisionVMAgent),
-					"enableAutomaticUpdates":        llx.BoolDataPtr(enableAutomaticUpdates),
-					"patchMode":                     llx.StringData(patchMode),
-					"imageReference":                llx.ResourceData(mqlImageRef, mqlImageRef.MqlName()),
-					"bootDiagnosticsEnabled":        llx.BoolData(bootDiagnosticsEnabled),
-					"bootDiagnosticsStorageUri":     llx.StringData(bootDiagnosticsStorageUri),
-					"userData":                      llx.StringData(userData),
-				})
+			mqlAzureVm, err := vmToMql(a.MqlRuntime, *vm)
 			if err != nil {
 				return nil, err
 			}
@@ -261,6 +106,172 @@ func (a *mqlAzureSubscriptionComputeService) vms() ([]any, error) {
 	}
 
 	return res, nil
+}
+
+func vmToMql(runtime *plugin.Runtime, vm compute.VirtualMachine) (*mqlAzureSubscriptionComputeServiceVm, error) {
+	properties, err := convert.JsonToDict(vm.Properties)
+	if err != nil {
+		return nil, err
+	}
+
+	var encryptionAtHost, secureBootEnabled, vtpmEnabled, proxyAgentEnabled, proxyAgentAddExtension *bool
+	var securityType, proxyAgentMode *string
+	if vm.Properties != nil && vm.Properties.SecurityProfile != nil {
+		sp := vm.Properties.SecurityProfile
+		encryptionAtHost = sp.EncryptionAtHost
+		securityType = (*string)(sp.SecurityType)
+		if sp.UefiSettings != nil {
+			secureBootEnabled = sp.UefiSettings.SecureBootEnabled
+			vtpmEnabled = sp.UefiSettings.VTpmEnabled
+		}
+		if sp.ProxyAgentSettings != nil {
+			proxyAgentEnabled = sp.ProxyAgentSettings.Enabled
+			proxyAgentAddExtension = sp.ProxyAgentSettings.AddProxyAgentExtension
+			proxyAgentMode = (*string)(sp.ProxyAgentSettings.Mode)
+		}
+	}
+
+	var fipsEncryptionEnabled *bool
+	var resiliencyProfileDict, scheduledEventsPolicyDict map[string]any
+	if vm.Properties != nil {
+		if vm.Properties.AdditionalCapabilities != nil {
+			fipsEncryptionEnabled = vm.Properties.AdditionalCapabilities.EnableFips1403Encryption
+		}
+		resiliencyProfileDict, err = convert.JsonToDict(vm.Properties.ResiliencyProfile)
+		if err != nil {
+			return nil, err
+		}
+		scheduledEventsPolicyDict, err = convert.JsonToDict(vm.Properties.ScheduledEventsPolicy)
+		if err != nil {
+			return nil, err
+		}
+	}
+	systemDataDict, err := convert.JsonToDict(vm.SystemData)
+	if err != nil {
+		return nil, err
+	}
+
+	var computerName, adminUsername, licenseType *string
+	var vmId, provisioningState *string
+	var timeCreated *time.Time
+	var disablePasswordAuth, provisionVMAgent, enableAutomaticUpdates *bool
+	var patchMode string
+	var sshPublicKeys []any
+	if vm.Properties != nil {
+		licenseType = vm.Properties.LicenseType
+		vmId = vm.Properties.VMID
+		provisioningState = vm.Properties.ProvisioningState
+		timeCreated = vm.Properties.TimeCreated
+		if osp := vm.Properties.OSProfile; osp != nil {
+			computerName = osp.ComputerName
+			adminUsername = osp.AdminUsername
+			if lc := osp.LinuxConfiguration; lc != nil {
+				disablePasswordAuth = lc.DisablePasswordAuthentication
+				provisionVMAgent = lc.ProvisionVMAgent
+				if lc.SSH != nil {
+					for _, k := range lc.SSH.PublicKeys {
+						if k == nil {
+							continue
+						}
+						entry := map[string]any{}
+						if k.Path != nil {
+							entry["path"] = *k.Path
+						}
+						if k.KeyData != nil {
+							entry["keyData"] = *k.KeyData
+						}
+						sshPublicKeys = append(sshPublicKeys, entry)
+					}
+				}
+				if lc.PatchSettings != nil && lc.PatchSettings.PatchMode != nil {
+					patchMode = string(*lc.PatchSettings.PatchMode)
+				}
+			}
+			if wc := osp.WindowsConfiguration; wc != nil {
+				provisionVMAgent = wc.ProvisionVMAgent
+				enableAutomaticUpdates = wc.EnableAutomaticUpdates
+				if wc.PatchSettings != nil && wc.PatchSettings.PatchMode != nil {
+					patchMode = string(*wc.PatchSettings.PatchMode)
+				}
+			}
+		}
+	}
+
+	var id *string
+	if vm.ID != nil {
+		normalized := strings.ToLower(*vm.ID)
+		id = &normalized
+	}
+
+	var bootDiagnosticsEnabled bool
+	var bootDiagnosticsStorageUri, userData string
+	if vm.Properties != nil {
+		if dp := vm.Properties.DiagnosticsProfile; dp != nil && dp.BootDiagnostics != nil {
+			if dp.BootDiagnostics.Enabled != nil {
+				bootDiagnosticsEnabled = *dp.BootDiagnostics.Enabled
+			}
+			if dp.BootDiagnostics.StorageURI != nil {
+				bootDiagnosticsStorageUri = *dp.BootDiagnostics.StorageURI
+			}
+		}
+		if vm.Properties.UserData != nil {
+			userData = *vm.Properties.UserData
+		}
+	}
+
+	vmIDStr := ""
+	if vm.ID != nil {
+		vmIDStr = *vm.ID
+	}
+	// vmImageReferenceToMql is nil-safe on vm.Properties — always returns a
+	// resource (fields default to empty strings when the VM has no storage
+	// profile / image reference).
+	mqlImageRef, err := vmImageReferenceToMql(runtime, vmIDStr, vm.Properties)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := CreateResource(runtime, "azure.subscription.computeService.vm",
+		map[string]*llx.RawData{
+			"id":                            llx.StringDataPtr(id),
+			"name":                          llx.StringDataPtr(vm.Name),
+			"location":                      llx.StringDataPtr(vm.Location),
+			"zones":                         llx.ArrayData(convert.SliceStrPtrToInterface(vm.Zones), types.String),
+			"tags":                          llx.MapData(convert.PtrMapStrToInterface(vm.Tags), types.String),
+			"type":                          llx.StringDataPtr(vm.Type),
+			"properties":                    llx.DictData(properties),
+			"encryptionAtHost":              llx.BoolDataPtr(encryptionAtHost),
+			"securityType":                  llx.StringDataPtr(securityType),
+			"secureBootEnabled":             llx.BoolDataPtr(secureBootEnabled),
+			"vtpmEnabled":                   llx.BoolDataPtr(vtpmEnabled),
+			"proxyAgentEnabled":             llx.BoolDataPtr(proxyAgentEnabled),
+			"proxyAgentMode":                llx.StringDataPtr(proxyAgentMode),
+			"proxyAgentAddExtension":        llx.BoolDataPtr(proxyAgentAddExtension),
+			"fipsEncryptionEnabled":         llx.BoolDataPtr(fipsEncryptionEnabled),
+			"resiliencyProfile":             llx.DictData(resiliencyProfileDict),
+			"scheduledEventsPolicy":         llx.DictData(scheduledEventsPolicyDict),
+			"systemData":                    llx.DictData(systemDataDict),
+			"computerName":                  llx.StringDataPtr(computerName),
+			"adminUsername":                 llx.StringDataPtr(adminUsername),
+			"licenseType":                   llx.StringDataPtr(licenseType),
+			"managedBy":                     llx.StringDataPtr(vm.ManagedBy),
+			"vmId":                          llx.StringDataPtr(vmId),
+			"provisioningState":             llx.StringDataPtr(provisioningState),
+			"timeCreated":                   llx.TimeDataPtr(timeCreated),
+			"sshPublicKeys":                 llx.ArrayData(sshPublicKeys, types.Dict),
+			"disablePasswordAuthentication": llx.BoolDataPtr(disablePasswordAuth),
+			"provisionVMAgent":              llx.BoolDataPtr(provisionVMAgent),
+			"enableAutomaticUpdates":        llx.BoolDataPtr(enableAutomaticUpdates),
+			"patchMode":                     llx.StringData(patchMode),
+			"imageReference":                llx.ResourceData(mqlImageRef, mqlImageRef.MqlName()),
+			"bootDiagnosticsEnabled":        llx.BoolData(bootDiagnosticsEnabled),
+			"bootDiagnosticsStorageUri":     llx.StringData(bootDiagnosticsStorageUri),
+			"userData":                      llx.StringData(userData),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionComputeServiceVm), nil
 }
 
 func (a *mqlAzureSubscriptionComputeServiceVm) state() (string, error) {
@@ -945,26 +956,33 @@ func initAzureSubscriptionComputeServiceVm(runtime *plugin.Runtime, args map[str
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
 	}
-	res, err := NewResource(runtime, "azure.subscription.computeService", map[string]*llx.RawData{
-		"subscriptionId": llx.StringData(conn.SubId()),
+
+	id := args["id"].Value.(string)
+	resourceID, err := ParseResourceID(id)
+	if err != nil {
+		return nil, nil, err
+	}
+	vmName, err := resourceID.Component("virtualMachines")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	client, err := compute.NewVirtualMachinesClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
 	})
 	if err != nil {
 		return nil, nil, err
 	}
-	computeSvc := res.(*mqlAzureSubscriptionComputeService)
-	vms := computeSvc.GetVms()
-	if vms.Error != nil {
-		return nil, nil, vms.Error
-	}
-	id := args["id"].Value.(string)
-	for _, entry := range vms.Data {
-		vm := entry.(*mqlAzureSubscriptionComputeServiceVm)
-		if vm.Id.Data == id {
-			return args, vm, nil
-		}
+	resp, err := client.Get(context.Background(), resourceID.ResourceGroup, vmName, &compute.VirtualMachinesClientGetOptions{})
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return nil, nil, errors.New("azure compute instance does not exist")
+	mqlVm, err := vmToMql(runtime, resp.VirtualMachine)
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, mqlVm, nil
 }
 
 func (a *mqlAzureSubscriptionComputeServiceDiskEncryptionSet) id() (string, error) {
@@ -1004,52 +1022,7 @@ func (a *mqlAzureSubscriptionComputeService) diskEncryptionSets() ([]any, error)
 			if des == nil {
 				continue
 			}
-
-			identity, err := convert.JsonToDict(des.Identity)
-			if err != nil {
-				return nil, err
-			}
-
-			var encryptionType, provisioningState string
-			var activeKeyUrl, activeKeySourceVaultId string
-			var rotationToLatestKeyVersionEnabled *bool
-			var lastKeyRotationTimestamp *time.Time
-
-			if des.Properties != nil {
-				props := des.Properties
-				if props.EncryptionType != nil {
-					encryptionType = string(*props.EncryptionType)
-				}
-				if props.ActiveKey != nil {
-					if props.ActiveKey.KeyURL != nil {
-						activeKeyUrl = *props.ActiveKey.KeyURL
-					}
-					if props.ActiveKey.SourceVault != nil && props.ActiveKey.SourceVault.ID != nil {
-						activeKeySourceVaultId = *props.ActiveKey.SourceVault.ID
-					}
-				}
-				rotationToLatestKeyVersionEnabled = props.RotationToLatestKeyVersionEnabled
-				lastKeyRotationTimestamp = props.LastKeyRotationTimestamp
-				if props.ProvisioningState != nil {
-					provisioningState = *props.ProvisioningState
-				}
-			}
-
-			mqlDes, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionComputeServiceDiskEncryptionSet,
-				map[string]*llx.RawData{
-					"id":                                llx.StringDataPtr(des.ID),
-					"name":                              llx.StringDataPtr(des.Name),
-					"location":                          llx.StringDataPtr(des.Location),
-					"tags":                              llx.MapData(convert.PtrMapStrToInterface(des.Tags), types.String),
-					"type":                              llx.StringDataPtr(des.Type),
-					"identity":                          llx.DictData(identity),
-					"encryptionType":                    llx.StringData(encryptionType),
-					"activeKeyUrl":                      llx.StringData(activeKeyUrl),
-					"activeKeySourceVaultId":            llx.StringData(activeKeySourceVaultId),
-					"rotationToLatestKeyVersionEnabled": llx.BoolDataPtr(rotationToLatestKeyVersionEnabled),
-					"lastKeyRotationTimestamp":          llx.TimeDataPtr(lastKeyRotationTimestamp),
-					"provisioningState":                 llx.StringData(provisioningState),
-				})
+			mqlDes, err := diskEncryptionSetToMql(a.MqlRuntime, *des)
 			if err != nil {
 				return nil, err
 			}
@@ -1058,6 +1031,58 @@ func (a *mqlAzureSubscriptionComputeService) diskEncryptionSets() ([]any, error)
 	}
 
 	return res, nil
+}
+
+func diskEncryptionSetToMql(runtime *plugin.Runtime, des compute.DiskEncryptionSet) (*mqlAzureSubscriptionComputeServiceDiskEncryptionSet, error) {
+	identity, err := convert.JsonToDict(des.Identity)
+	if err != nil {
+		return nil, err
+	}
+
+	var encryptionType, provisioningState string
+	var activeKeyUrl, activeKeySourceVaultId string
+	var rotationToLatestKeyVersionEnabled *bool
+	var lastKeyRotationTimestamp *time.Time
+
+	if des.Properties != nil {
+		props := des.Properties
+		if props.EncryptionType != nil {
+			encryptionType = string(*props.EncryptionType)
+		}
+		if props.ActiveKey != nil {
+			if props.ActiveKey.KeyURL != nil {
+				activeKeyUrl = *props.ActiveKey.KeyURL
+			}
+			if props.ActiveKey.SourceVault != nil && props.ActiveKey.SourceVault.ID != nil {
+				activeKeySourceVaultId = *props.ActiveKey.SourceVault.ID
+			}
+		}
+		rotationToLatestKeyVersionEnabled = props.RotationToLatestKeyVersionEnabled
+		lastKeyRotationTimestamp = props.LastKeyRotationTimestamp
+		if props.ProvisioningState != nil {
+			provisioningState = *props.ProvisioningState
+		}
+	}
+
+	res, err := CreateResource(runtime, ResourceAzureSubscriptionComputeServiceDiskEncryptionSet,
+		map[string]*llx.RawData{
+			"id":                                llx.StringDataPtr(des.ID),
+			"name":                              llx.StringDataPtr(des.Name),
+			"location":                          llx.StringDataPtr(des.Location),
+			"tags":                              llx.MapData(convert.PtrMapStrToInterface(des.Tags), types.String),
+			"type":                              llx.StringDataPtr(des.Type),
+			"identity":                          llx.DictData(identity),
+			"encryptionType":                    llx.StringData(encryptionType),
+			"activeKeyUrl":                      llx.StringData(activeKeyUrl),
+			"activeKeySourceVaultId":            llx.StringData(activeKeySourceVaultId),
+			"rotationToLatestKeyVersionEnabled": llx.BoolDataPtr(rotationToLatestKeyVersionEnabled),
+			"lastKeyRotationTimestamp":          llx.TimeDataPtr(lastKeyRotationTimestamp),
+			"provisioningState":                 llx.StringData(provisioningState),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionComputeServiceDiskEncryptionSet), nil
 }
 
 type mqlAzureSubscriptionComputeServiceDiskAccessInternal struct {
@@ -1230,25 +1255,33 @@ func initAzureSubscriptionComputeServiceDisk(runtime *plugin.Runtime, args map[s
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
 	}
-	res, err := NewResource(runtime, "azure.subscription.computeService", map[string]*llx.RawData{
-		"subscriptionId": llx.StringData(conn.SubId()),
+
+	id := args["id"].Value.(string)
+	resourceID, err := ParseResourceID(id)
+	if err != nil {
+		return nil, nil, err
+	}
+	diskName, err := resourceID.Component("disks")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	client, err := compute.NewDisksClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
 	})
 	if err != nil {
 		return nil, nil, err
 	}
-	computeSvc := res.(*mqlAzureSubscriptionComputeService)
-	disks := computeSvc.GetDisks()
-	if disks.Error != nil {
-		return nil, nil, disks.Error
+	diskResp, err := client.Get(context.Background(), resourceID.ResourceGroup, diskName, &compute.DisksClientGetOptions{})
+	if err != nil {
+		return nil, nil, err
 	}
-	id := strings.ToLower(args["id"].Value.(string))
-	for _, entry := range disks.Data {
-		disk := entry.(*mqlAzureSubscriptionComputeServiceDisk)
-		if strings.ToLower(disk.Id.Data) == id {
-			return args, disk, nil
-		}
+
+	res, err := diskToMql(runtime, diskResp.Disk)
+	if err != nil {
+		return nil, nil, err
 	}
-	return nil, nil, errors.New("azure compute disk does not exist")
+	return args, res, nil
 }
 
 func initAzureSubscriptionComputeServiceDiskEncryptionSet(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -1262,25 +1295,33 @@ func initAzureSubscriptionComputeServiceDiskEncryptionSet(runtime *plugin.Runtim
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
 	}
-	res, err := NewResource(runtime, "azure.subscription.computeService", map[string]*llx.RawData{
-		"subscriptionId": llx.StringData(conn.SubId()),
+
+	id := args["id"].Value.(string)
+	resourceID, err := ParseResourceID(id)
+	if err != nil {
+		return nil, nil, err
+	}
+	desName, err := resourceID.Component("diskEncryptionSets")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	client, err := compute.NewDiskEncryptionSetsClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
 	})
 	if err != nil {
 		return nil, nil, err
 	}
-	computeSvc := res.(*mqlAzureSubscriptionComputeService)
-	sets := computeSvc.GetDiskEncryptionSets()
-	if sets.Error != nil {
-		return nil, nil, sets.Error
+	resp, err := client.Get(context.Background(), resourceID.ResourceGroup, desName, &compute.DiskEncryptionSetsClientGetOptions{})
+	if err != nil {
+		return nil, nil, err
 	}
-	id := strings.ToLower(args["id"].Value.(string))
-	for _, entry := range sets.Data {
-		des := entry.(*mqlAzureSubscriptionComputeServiceDiskEncryptionSet)
-		if strings.ToLower(des.Id.Data) == id {
-			return args, des, nil
-		}
+
+	mqlDes, err := diskEncryptionSetToMql(runtime, resp.DiskEncryptionSet)
+	if err != nil {
+		return nil, nil, err
 	}
-	return nil, nil, errors.New("azure disk encryption set does not exist")
+	return args, mqlDes, nil
 }
 
 type mqlAzureSubscriptionComputeServiceSnapshotInternal struct {

--- a/providers/azure/resources/keyvault.go
+++ b/providers/azure/resources/keyvault.go
@@ -78,6 +78,45 @@ func (a *mqlAzureSubscriptionKeyVaultServiceVault) id() (string, error) {
 	return a.Id.Data, nil
 }
 
+type mqlAzureSubscriptionKeyVaultServiceVaultInternal struct {
+	fetchVaultOnce sync.Once
+	fetchVaultResp *keyvault.VaultsClientGetResponse
+	fetchVaultErr  error
+}
+
+// fetchVault retrieves the full vault from ARM. Cached with sync.Once so that
+// properties, privateEndpointConnections, accessPolicies, and networkAcls
+// share a single VaultsClient.Get per vault.
+func (a *mqlAzureSubscriptionKeyVaultServiceVault) fetchVault() (*keyvault.VaultsClientGetResponse, error) {
+	a.fetchVaultOnce.Do(func() {
+		conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+		resourceID, err := ParseResourceID(a.Id.Data)
+		if err != nil {
+			a.fetchVaultErr = err
+			return
+		}
+		vaultName, err := resourceID.Component("vaults")
+		if err != nil {
+			a.fetchVaultErr = err
+			return
+		}
+		client, err := keyvault.NewVaultsClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
+			ClientOptions: conn.ClientOptions(),
+		})
+		if err != nil {
+			a.fetchVaultErr = err
+			return
+		}
+		vault, err := client.Get(context.Background(), resourceID.ResourceGroup, vaultName, &keyvault.VaultsClientGetOptions{})
+		if err != nil {
+			a.fetchVaultErr = err
+			return
+		}
+		a.fetchVaultResp = &vault
+	})
+	return a.fetchVaultResp, a.fetchVaultErr
+}
+
 func (a *mqlAzureSubscriptionKeyVaultServiceKey) id() (string, error) {
 	return a.Kid.Data, nil
 }
@@ -135,31 +174,10 @@ func (a *mqlAzureSubscriptionKeyVaultServiceVault) vaultUri() (string, error) {
 }
 
 func (a *mqlAzureSubscriptionKeyVaultServiceVault) properties() (any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
-	id := a.Id.Data
-
-	resourceID, err := ParseResourceID(id)
+	vault, err := a.fetchVault()
 	if err != nil {
 		return nil, err
 	}
-
-	vaultName, err := resourceID.Component("vaults")
-	if err != nil {
-		return nil, err
-	}
-	client, err := keyvault.NewVaultsClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, err
-	}
-	vault, err := client.Get(ctx, resourceID.ResourceGroup, vaultName, &keyvault.VaultsClientGetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
 	return convert.JsonToDict(vault.Properties)
 }
 
@@ -507,26 +525,7 @@ func (a *mqlAzureSubscriptionKeyVaultServiceVault) diagnosticSettings() ([]any, 
 }
 
 func (a *mqlAzureSubscriptionKeyVaultServiceVault) privateEndpointConnections() ([]any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
-	id := a.Id.Data
-
-	resourceID, err := ParseResourceID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	vaultName, err := resourceID.Component("vaults")
-	if err != nil {
-		return nil, err
-	}
-	client, err := keyvault.NewVaultsClient(resourceID.SubscriptionID, token, &arm.ClientOptions{ClientOptions: conn.ClientOptions()})
-	if err != nil {
-		return nil, err
-	}
-
-	vault, err := client.Get(ctx, resourceID.ResourceGroup, vaultName, &keyvault.VaultsClientGetOptions{})
+	vault, err := a.fetchVault()
 	if err != nil {
 		return nil, err
 	}
@@ -621,30 +620,11 @@ func (a *mqlAzureSubscriptionKeyVaultServiceVault) privateEndpointConnections() 
 }
 
 func (a *mqlAzureSubscriptionKeyVaultServiceVault) accessPolicies() ([]any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
+	vault, err := a.fetchVault()
+	if err != nil {
+		return nil, err
+	}
 	id := a.Id.Data
-
-	resourceID, err := ParseResourceID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	vaultName, err := resourceID.Component("vaults")
-	if err != nil {
-		return nil, err
-	}
-
-	client, err := keyvault.NewVaultsClient(resourceID.SubscriptionID, token, &arm.ClientOptions{ClientOptions: conn.ClientOptions()})
-	if err != nil {
-		return nil, err
-	}
-
-	vault, err := client.Get(ctx, resourceID.ResourceGroup, vaultName, &keyvault.VaultsClientGetOptions{})
-	if err != nil {
-		return nil, err
-	}
 
 	var res []any
 	if vault.Properties == nil || vault.Properties.AccessPolicies == nil {
@@ -705,30 +685,11 @@ func (a *mqlAzureSubscriptionKeyVaultServiceVault) accessPolicies() ([]any, erro
 }
 
 func (a *mqlAzureSubscriptionKeyVaultServiceVault) networkAcls() (*mqlAzureSubscriptionKeyVaultServiceVaultNetworkAcls, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
+	vault, err := a.fetchVault()
+	if err != nil {
+		return nil, err
+	}
 	id := a.Id.Data
-
-	resourceID, err := ParseResourceID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	vaultName, err := resourceID.Component("vaults")
-	if err != nil {
-		return nil, err
-	}
-
-	client, err := keyvault.NewVaultsClient(resourceID.SubscriptionID, token, &arm.ClientOptions{ClientOptions: conn.ClientOptions()})
-	if err != nil {
-		return nil, err
-	}
-
-	vault, err := client.Get(ctx, resourceID.ResourceGroup, vaultName, &keyvault.VaultsClientGetOptions{})
-	if err != nil {
-		return nil, err
-	}
 
 	var bypass, defaultAction string
 	var ipRules, vnetSubnetIds []any
@@ -1471,26 +1432,48 @@ func initAzureSubscriptionKeyVaultServiceVault(runtime *plugin.Runtime, args map
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
 	}
-	res, err := NewResource(runtime, "azure.subscription.keyVaultService", map[string]*llx.RawData{
-		"subscriptionId": llx.StringData(conn.SubId()),
+
+	id := args["id"].Value.(string)
+	resourceID, err := ParseResourceID(id)
+	if err != nil {
+		return nil, nil, err
+	}
+	vaultName, err := resourceID.Component("vaults")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	client, err := keyvault.NewVaultsClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
 	})
 	if err != nil {
 		return nil, nil, err
 	}
-	kv := res.(*mqlAzureSubscriptionKeyVaultService)
-	vaults := kv.GetVaults()
-	if vaults.Error != nil {
-		return nil, nil, vaults.Error
-	}
-	id := args["id"].Value.(string)
-	for _, entry := range vaults.Data {
-		vault := entry.(*mqlAzureSubscriptionKeyVaultServiceVault)
-		if vault.Id.Data == id {
-			return args, vault, nil
-		}
+	vault, err := client.Get(context.Background(), resourceID.ResourceGroup, vaultName, &keyvault.VaultsClientGetOptions{})
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return nil, nil, errors.New("azure key vault does not exist")
+	res, err := CreateResource(runtime, "azure.subscription.keyVaultService.vault",
+		map[string]*llx.RawData{
+			"id":        llx.StringData(id),
+			"vaultName": llx.StringDataPtr(vault.Name),
+			"type":      llx.StringDataPtr(vault.Type),
+			"location":  llx.StringDataPtr(vault.Location),
+			"tags":      llx.MapData(convert.PtrMapStrToInterface(vault.Tags), types.String),
+		})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Prime the fetchVault cache so subsequent property/networkAcls/etc.
+	// accesses reuse the response we already have in hand.
+	mqlVault := res.(*mqlAzureSubscriptionKeyVaultServiceVault)
+	mqlVault.fetchVaultOnce.Do(func() {
+		mqlVault.fetchVaultResp = &vault
+	})
+
+	return args, mqlVault, nil
 }
 
 func (a *mqlAzureSubscriptionKeyVaultServiceKeyRotationPolicyObject) id() (string, error) {

--- a/providers/azure/resources/sql.go
+++ b/providers/azure/resources/sql.go
@@ -26,6 +26,44 @@ type mqlAzureSubscriptionSqlServiceServerInternal struct {
 	encryptionProtectorOnce sync.Once
 	encryptionProtectorResp *sql.EncryptionProtectorsClientGetResponse
 	encryptionProtectorErr  error
+
+	connectionPolicyOnce sync.Once
+	connectionPolicyResp *sql.ServerConnectionPoliciesClientGetResponse
+	connectionPolicyErr  error
+}
+
+// fetchConnectionPolicy retrieves the server-scoped ConnectionPolicy. Cached
+// with sync.Once so the server's connectionPolicy() accessor and per-database
+// connectionPolicy() accessors share a single API call (the policy is keyed
+// on the server, not the database — see Azure docs).
+func (a *mqlAzureSubscriptionSqlServiceServer) fetchConnectionPolicy() (*sql.ServerConnectionPoliciesClientGetResponse, error) {
+	a.connectionPolicyOnce.Do(func() {
+		conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+		resourceID, err := ParseResourceID(a.Id.Data)
+		if err != nil {
+			a.connectionPolicyErr = err
+			return
+		}
+		server, err := resourceID.Component("servers")
+		if err != nil {
+			a.connectionPolicyErr = err
+			return
+		}
+		client, err := sql.NewServerConnectionPoliciesClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
+			ClientOptions: conn.ClientOptions(),
+		})
+		if err != nil {
+			a.connectionPolicyErr = err
+			return
+		}
+		resp, err := client.Get(context.Background(), resourceID.ResourceGroup, server, sql.ConnectionPolicyNameDefault, &sql.ServerConnectionPoliciesClientGetOptions{})
+		if err != nil {
+			a.connectionPolicyErr = err
+			return
+		}
+		a.connectionPolicyResp = &resp
+	})
+	return a.connectionPolicyResp, a.connectionPolicyErr
 }
 
 type mqlAzureSubscriptionSqlServiceServerFailoverGroupInternal struct {
@@ -393,31 +431,10 @@ func (a *mqlAzureSubscriptionSqlServiceServer) azureAdAdministrators() ([]any, e
 }
 
 func (a *mqlAzureSubscriptionSqlServiceServer) connectionPolicy() (any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
-	id := a.Id.Data
-	resourceID, err := ParseResourceID(id)
+	policy, err := a.fetchConnectionPolicy()
 	if err != nil {
 		return nil, err
 	}
-
-	server, err := resourceID.Component("servers")
-	if err != nil {
-		return nil, err
-	}
-
-	connectionClient, err := sql.NewServerConnectionPoliciesClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, err
-	}
-	policy, err := connectionClient.Get(ctx, resourceID.ResourceGroup, server, sql.ConnectionPolicyNameDefault, &sql.ServerConnectionPoliciesClientGetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
 	return convert.JsonToDict(policy)
 }
 
@@ -732,31 +749,27 @@ func (a *mqlAzureSubscriptionSqlServiceDatabase) threatDetectionPolicy() (any, e
 }
 
 func (a *mqlAzureSubscriptionSqlServiceDatabase) connectionPolicy() (any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
-	id := a.Id.Data
-	resourceID, err := ParseResourceID(id)
+	resourceID, err := ParseResourceID(a.Id.Data)
 	if err != nil {
 		return nil, err
 	}
+	serverName, err := resourceID.Component("servers")
+	if err != nil {
+		return nil, err
+	}
+	serverId := "/subscriptions/" + resourceID.SubscriptionID +
+		"/resourceGroups/" + resourceID.ResourceGroup +
+		"/providers/Microsoft.Sql/servers/" + serverName
 
-	server, err := resourceID.Component("servers")
+	serverRes, err := NewResource(a.MqlRuntime, "azure.subscription.sqlService.server",
+		map[string]*llx.RawData{"id": llx.StringData(serverId)})
 	if err != nil {
 		return nil, err
 	}
-
-	connectionClient, err := sql.NewServerConnectionPoliciesClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
+	policy, err := serverRes.(*mqlAzureSubscriptionSqlServiceServer).fetchConnectionPolicy()
 	if err != nil {
 		return nil, err
 	}
-	policy, err := connectionClient.Get(ctx, resourceID.ResourceGroup, server, sql.ConnectionPolicyNameDefault, &sql.ServerConnectionPoliciesClientGetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
 	return convert.JsonToDict(policy.ServerConnectionPolicy.Properties)
 }
 

--- a/providers/azure/resources/storage.go
+++ b/providers/azure/resources/storage.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -18,6 +19,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/azure/connection"
 	"go.mondoo.com/mql/v13/types"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -54,6 +56,43 @@ type mqlAzureSubscriptionStorageServiceAccountInternal struct {
 	cacheEncryptionKeyVaultURI string
 	cacheEncryptionKeyName     string
 	cacheEncryptionKeyVersion  string
+
+	fetchBlobSvcOnce sync.Once
+	fetchBlobSvcResp *storage.BlobServicesClientGetServicePropertiesResponse
+	fetchBlobSvcErr  error
+}
+
+// fetchBlobServiceProps retrieves BlobServicesClient.GetServiceProperties for
+// this storage account. Cached with sync.Once so blobProperties() and
+// dataProtection() share a single API call.
+func (a *mqlAzureSubscriptionStorageServiceAccount) fetchBlobServiceProps() (*storage.BlobServicesClientGetServicePropertiesResponse, error) {
+	a.fetchBlobSvcOnce.Do(func() {
+		conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+		resourceID, err := ParseResourceID(a.Id.Data)
+		if err != nil {
+			a.fetchBlobSvcErr = err
+			return
+		}
+		account, err := resourceID.Component("storageAccounts")
+		if err != nil {
+			a.fetchBlobSvcErr = err
+			return
+		}
+		client, err := storage.NewBlobServicesClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
+			ClientOptions: conn.ClientOptions(),
+		})
+		if err != nil {
+			a.fetchBlobSvcErr = err
+			return
+		}
+		resp, err := client.GetServiceProperties(context.Background(), resourceID.ResourceGroup, account, &storage.BlobServicesClientGetServicePropertiesOptions{})
+		if err != nil {
+			a.fetchBlobSvcErr = err
+			return
+		}
+		a.fetchBlobSvcResp = &resp
+	})
+	return a.fetchBlobSvcResp, a.fetchBlobSvcErr
 }
 
 func (a *mqlAzureSubscriptionStorageServiceAccount) id() (string, error) {
@@ -157,19 +196,41 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) containers() ([]any, error) 
 			}
 			return nil, err
 		}
-		for _, container := range page.Value {
-			// The list-by-account API returns hasImmutabilityPolicy/hasLegalHold flags but not the
-			// nested ImmutabilityPolicy/LegalHold detail. Fetch the container individually when
-			// either flag is set so the detail fields are populated.
+
+		// The list-by-account API returns hasImmutabilityPolicy/hasLegalHold
+		// flags but not the nested ImmutabilityPolicy/LegalHold detail.
+		// When either flag is set, fan out the per-container Get calls in
+		// parallel — accounts with many locked containers (common in
+		// regulated environments) would otherwise serialize one Get per
+		// container in the listing hot path.
+		detailedProps := make([]*storage.ContainerProperties, len(page.Value))
+		g, gctx := errgroup.WithContext(ctx)
+		g.SetLimit(10)
+		for i, container := range page.Value {
 			containerProps := container.Properties
 			needsDetail := containerProps != nil &&
 				((containerProps.HasImmutabilityPolicy != nil && *containerProps.HasImmutabilityPolicy) ||
 					(containerProps.HasLegalHold != nil && *containerProps.HasLegalHold))
-			if needsDetail && container.Name != nil {
-				detail, err := client.Get(ctx, resourceID.ResourceGroup, account, *container.Name, nil)
+			if !needsDetail || container.Name == nil {
+				continue
+			}
+			i, name := i, *container.Name
+			g.Go(func() error {
+				detail, err := client.Get(gctx, resourceID.ResourceGroup, account, name, nil)
 				if err == nil && detail.BlobContainer.ContainerProperties != nil {
-					containerProps = detail.BlobContainer.ContainerProperties
+					detailedProps[i] = detail.BlobContainer.ContainerProperties
 				}
+				return nil
+			})
+		}
+		if err := g.Wait(); err != nil {
+			return nil, err
+		}
+
+		for i, container := range page.Value {
+			containerProps := container.Properties
+			if detailedProps[i] != nil {
+				containerProps = detailedProps[i]
 			}
 
 			properties, err := convert.JsonToDict(containerProps)
@@ -326,28 +387,7 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) blobProperties() (*mqlAzureS
 		return nil, nil
 	}
 
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
-	id := a.Id.Data
-	resourceID, err := ParseResourceID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	account, err := resourceID.Component("storageAccounts")
-	if err != nil {
-		return nil, err
-	}
-
-	client, err := storage.NewBlobServicesClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	blobProps, err := client.GetServiceProperties(ctx, resourceID.ResourceGroup, account, &storage.BlobServicesClientGetServicePropertiesOptions{})
+	blobProps, err := a.fetchBlobServiceProps()
 	if err != nil {
 		if isFeatureNotSupportedForAccountError(err) {
 			a.BlobProperties.State = plugin.StateIsNull | plugin.StateIsSet
@@ -365,7 +405,7 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) blobProperties() (*mqlAzureS
 		return nil, err
 	}
 
-	return toMqlBlobServiceStorageProperties(a.MqlRuntime, props.ServiceProperties, blobProps.BlobServiceProperties, "blob", id)
+	return toMqlBlobServiceStorageProperties(a.MqlRuntime, props.ServiceProperties, blobProps.BlobServiceProperties, "blob", a.Id.Data)
 }
 
 func (a *mqlAzureSubscriptionStorageServiceAccount) dataProtection() (*mqlAzureSubscriptionStorageServiceAccountDataProtection, error) {
@@ -375,27 +415,7 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) dataProtection() (*mqlAzureS
 		return nil, nil
 	}
 
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
-	id := a.Id.Data
-	resourceID, err := ParseResourceID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	account, err := resourceID.Component("storageAccounts")
-	if err != nil {
-		return nil, err
-	}
-	client, err := storage.NewBlobServicesClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	properties, err := client.GetServiceProperties(ctx, resourceID.ResourceGroup, account, &storage.BlobServicesClientGetServicePropertiesOptions{})
+	properties, err := a.fetchBlobServiceProps()
 	if err != nil {
 		if isFeatureNotSupportedForAccountError(err) {
 			a.DataProtection.State = plugin.StateIsNull | plugin.StateIsSet
@@ -410,20 +430,16 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) dataProtection() (*mqlAzureS
 	var containerRetentionDays *int32
 	if properties.BlobServiceProperties.BlobServiceProperties.DeleteRetentionPolicy != nil {
 		blobSoftDeletionEnabled = convert.ToValue(properties.BlobServiceProperties.BlobServiceProperties.DeleteRetentionPolicy.Enabled)
-	}
-	if properties.BlobServiceProperties.BlobServiceProperties.DeleteRetentionPolicy != nil {
 		blobRetentionDays = properties.BlobServiceProperties.BlobServiceProperties.DeleteRetentionPolicy.Days
 	}
 	if properties.BlobServiceProperties.BlobServiceProperties.ContainerDeleteRetentionPolicy != nil {
 		containerSoftDeletionEnabled = convert.ToValue(properties.BlobServiceProperties.BlobServiceProperties.ContainerDeleteRetentionPolicy.Enabled)
-	}
-	if properties.BlobServiceProperties.BlobServiceProperties.ContainerDeleteRetentionPolicy != nil {
 		containerRetentionDays = properties.BlobServiceProperties.BlobServiceProperties.ContainerDeleteRetentionPolicy.Days
 	}
 
 	res, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionStorageServiceAccountDataProtection,
 		map[string]*llx.RawData{
-			"storageAccountId":             llx.StringData(id),
+			"storageAccountId":             llx.StringData(a.Id.Data),
 			"blobSoftDeletionEnabled":      llx.BoolData(blobSoftDeletionEnabled),
 			"blobRetentionDays":            llx.IntDataDefault(blobRetentionDays, 0),
 			"containerSoftDeletionEnabled": llx.BoolData(containerSoftDeletionEnabled),

--- a/providers/azure/resources/storage.go
+++ b/providers/azure/resources/storage.go
@@ -214,7 +214,7 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) containers() ([]any, error) 
 			if !needsDetail || container.Name == nil {
 				continue
 			}
-			i, name := i, *container.Name
+			name := *container.Name
 			g.Go(func() error {
 				detail, err := client.Get(gctx, resourceID.ResourceGroup, account, name, nil)
 				if err == nil && detail.BlobContainer.ContainerProperties != nil {


### PR DESCRIPTION
## Summary

Cuts duplicate ARM calls in Key Vault, Cloud Defender, Storage, SQL, and Compute by sharing fetched responses across field accessors and moving init lookups to direct `Get` instead of full-list scans. Follows up the audit in [memory/azure-perf-issues.md](../) (mirror of [PR #6830](https://github.com/mondoohq/mql/pull/6830)/[#6835](https://github.com/mondoohq/mql/pull/6835)'s AWS fixes).

## API call reduction

Per-asset call counts in policy scans (the numbers below assume a scan that touches every accessor on every asset; partial accessors scale proportionally):

| Resource | Before | After | Savings |
|---|---|---|---|
| Key Vault — `properties` + `privateEndpointConnections` + `accessPolicies` + `networkAcls` per vault | 4× `VaultsClient.Get` | 1× | **−3 per vault** |
| Key Vault — `vault(id)` by ID | full subscription `VaultsClient.NewListPager` | 1× direct `Get` (also primes the cache → 0 follow-up `Get`s for the 4 fields above) | **−(N−1) + −1 for fields** |
| Cloud Defender — 10 deprecated `defenderFor*` (dict) ↔ `for*` (typed) pairs | 2× `PricingsClient.Get` per pair (10 pairs × 2 = 20 hits if both accessors are queried) | 10× (deprecated delegates to typed) | **−1 per pair queried = up to −10 per subscription** |
| Cloud Defender — `defenderForServers` ↔ `forServers` | 2× `PricingsClient.Get`("VirtualMachines") + 2× `getPolicyAssignments` + 2× `getServerVulnAssessmentSettings` = 6 calls | 3× | **−3 per subscription** |
| Cloud Defender — `defenderForContainers` ↔ `forContainers` ↔ `forContainers.extensions` | 3× `PricingsClient.Get`("Containers") + 2× `getPolicyAssignments` | 1× + 1× | **−3 per subscription** |
| Storage — `blobProperties` + `dataProtection` per account | 2× `BlobServicesClient.GetServiceProperties` | 1× | **−1 per account** |
| Storage — `containers()` with N immutability- or legal-hold-locked containers | N synchronous `BlobContainersClient.Get` calls in the listing hot path | N parallel `Get` calls (errgroup, limit 10) — same count, **wall-clock ≈ N/10 instead of N** | **~10× faster** |
| SQL — `databases { connectionPolicy }` across D databases on one server | D× `ServerConnectionPoliciesClient.Get` (all identical, server-scoped) | 1× (per server) | **−(D−1) per server** |
| Compute — `vm(id)` / `disk(id)` / `diskEncryptionSet(id)` by ID | full subscription list of that type | 1× direct `Get` | **−(N−1) per init call** |

**Worst-case improved scenario:** a subscription with 50 vaults, 100 SQL databases on 5 servers, 200 storage accounts (10% locked containers per), and the full Defender posture pack will see roughly:
- Key Vault: 50 vaults × 3 saved = **150 fewer `VaultsClient.Get`**
- SQL: 5 servers × ~95 saved = **475 fewer `ServerConnectionPoliciesClient.Get`**
- Storage: 200 × 1 = **200 fewer `BlobServicesClient.GetServiceProperties`** + much faster container listing for the 20 accounts with locks
- Cloud Defender: **~15 fewer `PricingsClient.Get`** per scan
- Total: **~800+ fewer Azure ARM calls per full-scope scan**, plus wall-clock speedup on the storage container hot path.

## Changes

### H1 — Key Vault `fetchVault()`
`properties()`, `privateEndpointConnections()`, `accessPolicies()`, and `networkAcls()` each used to issue their own `VaultsClient.Get`. Now they share one fetch via a `sync.Once`-guarded helper on a new `mqlAzureSubscriptionKeyVaultServiceVaultInternal` struct.

### H2 — Cloud Defender dict → typed delegation
Deleted `getSimpleDictPricing` and the inline `defenderForServers`/`defenderForContainers` fetch logic. Each `defenderForX` dict accessor now reads from the corresponding `GetForX()` cached typed resource (and serializes to dict via a tiny `simpleDefenderDict` helper for the 10 simple pairs). `forContainers.extensions()` reads from an Internal cache primed by `forContainers()` itself, so the typed accessor doesn't re-fetch.

### H3 — Storage `fetchBlobServiceProps()`
Added `sync.Once` cache on the existing `mqlAzureSubscriptionStorageServiceAccountInternal`. `blobProperties()` and `dataProtection()` share one `GetServiceProperties` call.

### H4 — Storage parallel container detail fetch
The per-container `BlobContainersClient.Get` (issued only when `hasImmutabilityPolicy` or `hasLegalHold` is set) now runs through a bounded `errgroup` (limit 10), matching the pattern already used by `compute.go` `dataDisks`. Writes go to a pre-sized slice indexed by container position, so concurrent assignments to distinct indices are safe.

### M2 — SQL Database `connectionPolicy()` reuses parent server
`Server.connectionPolicy()` now uses a `sync.Once`-cached `ServerConnectionPoliciesClient.Get`. `Database.connectionPolicy()` resolves the parent `Server` resource via `NewResource` and reuses the cache — the policy is genuinely server-scoped (the previous code ignored the database name entirely).

### M5/M6 — Init functions use direct `Get`
- `initAzureSubscriptionComputeServiceVm` — direct `VirtualMachinesClient.Get`
- `initAzureSubscriptionComputeServiceDisk` — direct `DisksClient.Get`
- `initAzureSubscriptionComputeServiceDiskEncryptionSet` — direct `DiskEncryptionSetsClient.Get`
- `initAzureSubscriptionKeyVaultServiceVault` — direct `VaultsClient.Get` + primes `fetchVault` cache so the four field accessors above incur zero additional calls

Extracted `vmToMql` and `diskEncryptionSetToMql` helpers so the lister and the init share construction logic.

## Auto-generated files

- `azure.lr.go` — regenerated (`mqlr generate`, two-pass) to embed the new Internal structs.
- `azure.permissions.json` — regenerated by `make providers/build/azure`. Some `action` entries for resources I didn't touch flip in this diff because the extractor picks one representative call per permission and the order shifted slightly; the underlying permissions are unchanged (`206 permissions (unchanged)` per the build output).

## Test plan
- [x] `go test ./providers/azure/resources/...` — passes; new `TestSimpleDefenderDict` covers the pure delegation helper.
- [x] `go vet ./providers/azure/resources/...` — clean.
- [x] `make providers/build/azure` — builds the provider binary and idempotently regenerates `azure.permissions.json` (`unchanged` on second run).
- [ ] Interactive verification with a real Azure subscription against the modified accessors:
  - `azure.subscription.keyVaultService.vaults { properties accessPolicies networkAcls privateEndpointConnections }` — verify single ARM `Get` per vault in logs.
  - `azure.subscription.storageService.accounts { blobProperties dataProtection }` — verify single `GetServiceProperties` per account.
  - `azure.subscription.sqlService.servers { databases { connectionPolicy } }` — verify per-server call count, not per-database.
  - `azure.subscription.cloudDefenderService { defenderForServers forServers defenderForContainers forContainers }` — verify no duplicate pricing/policy-assignment calls.
  - `azure.subscription.computeService.vm(id: "...")` / disk / diskEncryptionSet — verify single ARM `Get`, no list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)