### PR TITLE
⚡ ms365: cut N+1 Graph calls on hot paths

### DIFF
--- a/providers/ms365/resources/applications.go
+++ b/providers/ms365/resources/applications.go
@@ -393,9 +393,12 @@ func (a *mqlMicrosoftApplication) owners() ([]any, error) {
 	}
 
 	ctx := context.Background()
+	// Select the same user fields used by initMicrosoftUser so accessing
+	// owner.displayName/mail/etc. is served from the owners response instead
+	// of triggering one Graph call per owner.
 	resp, err := graphClient.Applications().ByApplicationId(a.GetId().Data).Owners().Get(ctx, &applications.ItemOwnersRequestBuilderGetRequestConfiguration{
 		QueryParameters: &applications.ItemOwnersRequestBuilderGetQueryParameters{
-			Select: []string{"id"},
+			Select: userSelectFields,
 		},
 	})
 	if err != nil {
@@ -420,7 +423,21 @@ func (a *mqlMicrosoftApplication) owners() ([]any, error) {
 			continue
 		}
 
-		// otherwise we create a new user resource
+		// When the owner is a user, build the resource from the data
+		// already on the response — avoids a second Graph round-trip via
+		// initMicrosoftUser when callers read common user fields.
+		if user, ok := owner.(models.Userable); ok {
+			newUser, err := newMqlMicrosoftUser(a.MqlRuntime, user)
+			if err != nil {
+				return nil, err
+			}
+			mqlMicrsoftResource.indexUser(newUser)
+			res = append(res, newUser)
+			continue
+		}
+
+		// non-user owners (groups, service principals) fall back to the
+		// lazy reference so the framework can resolve them on demand.
 		newUserResource, err := a.MqlRuntime.NewResource(a.MqlRuntime, "microsoft.user", map[string]*llx.RawData{
 			"id": llx.StringDataPtr(ownerId),
 		})

--- a/providers/ms365/resources/conditional-access.go
+++ b/providers/ms365/resources/conditional-access.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"go.mondoo.com/mql/v13/llx"
@@ -27,19 +28,39 @@ func (a *mqlMicrosoftConditionalAccess) namedLocations() (*mqlMicrosoftCondition
 	return resource.(*mqlMicrosoftConditionalAccessNamedLocations), nil
 }
 
-func (a *mqlMicrosoftConditionalAccessNamedLocations) ipLocations() ([]any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)
-	graphClient, err := conn.GraphClient()
-	if err != nil {
-		return nil, err
-	}
+type mqlMicrosoftConditionalAccessNamedLocationsInternal struct {
+	// guards the named-locations Graph fetch so both ipLocations() and
+	// countryLocations() share a single API call.
+	namedLocationsOnce sync.Once
+	namedLocations     []models.NamedLocationable
+	namedLocationsErr  error
+}
 
-	ctx := context.Background()
-	resp, err := graphClient.Identity().ConditionalAccess().NamedLocations().Get(ctx, nil)
-	if err != nil {
-		return nil, transformError(err)
-	}
-	namedLocations, err := iterate[models.NamedLocationable](ctx, resp, graphClient.GetAdapter(), models.CreateNamedLocationCollectionResponseFromDiscriminatorValue)
+// loadNamedLocations fetches the tenant's named locations once and caches
+// the result. Both ipLocations() and countryLocations() filter from the
+// same backing slice instead of issuing duplicate Graph calls.
+func (a *mqlMicrosoftConditionalAccessNamedLocations) loadNamedLocations() ([]models.NamedLocationable, error) {
+	a.namedLocationsOnce.Do(func() {
+		conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)
+		graphClient, err := conn.GraphClient()
+		if err != nil {
+			a.namedLocationsErr = err
+			return
+		}
+
+		ctx := context.Background()
+		resp, err := graphClient.Identity().ConditionalAccess().NamedLocations().Get(ctx, nil)
+		if err != nil {
+			a.namedLocationsErr = transformError(err)
+			return
+		}
+		a.namedLocations, a.namedLocationsErr = iterate[models.NamedLocationable](ctx, resp, graphClient.GetAdapter(), models.CreateNamedLocationCollectionResponseFromDiscriminatorValue)
+	})
+	return a.namedLocations, a.namedLocationsErr
+}
+
+func (a *mqlMicrosoftConditionalAccessNamedLocations) ipLocations() ([]any, error) {
+	namedLocations, err := a.loadNamedLocations()
 	if err != nil {
 		return nil, err
 	}
@@ -85,18 +106,7 @@ func (m *mqlMicrosoftConditionalAccessCountryNamedLocation) id() (string, error)
 }
 
 func (a *mqlMicrosoftConditionalAccessNamedLocations) countryLocations() ([]any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)
-	graphClient, err := conn.GraphClient()
-	if err != nil {
-		return nil, err
-	}
-
-	ctx := context.Background()
-	resp, err := graphClient.Identity().ConditionalAccess().NamedLocations().Get(ctx, nil)
-	if err != nil {
-		return nil, transformError(err)
-	}
-	namedLocations, err := iterate[models.NamedLocationable](ctx, resp, graphClient.GetAdapter(), models.CreateNamedLocationCollectionResponseFromDiscriminatorValue)
+	namedLocations, err := a.loadNamedLocations()
 	if err != nil {
 		return nil, err
 	}

--- a/providers/ms365/resources/devices.go
+++ b/providers/ms365/resources/devices.go
@@ -136,18 +136,6 @@ func initMicrosoftDevice(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 		return args, nil, nil
 	}
 
-	var filter *string
-	if okId {
-		idFilter := fmt.Sprintf("id eq '%s'", rawId.Value.(string))
-		filter = &idFilter
-	} else if okDisplayName {
-		displayNameFilter := fmt.Sprintf("displayName eq '%s'", rawDisplayName.Value.(string))
-		filter = &displayNameFilter
-	}
-	if filter == nil {
-		return nil, nil, errors.New("no filter found")
-	}
-
 	conn := runtime.Connection.(*connection.Ms365Connection)
 	graphClient, err := conn.GraphClient()
 	if err != nil {
@@ -155,9 +143,31 @@ func initMicrosoftDevice(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 	}
 
 	ctx := context.Background()
+
+	// Fast path: look up directly by id. Skips the redundant filter+get
+	// round-trip we'd otherwise pay for every microsoft.device(id: "...")
+	// reference.
+	if okId {
+		device, err := graphClient.Devices().ByDeviceId(rawId.Value.(string)).Get(ctx, &devices.DeviceItemRequestBuilderGetRequestConfiguration{
+			QueryParameters: &devices.DeviceItemRequestBuilderGetQueryParameters{
+				Select: deviceSelectFields,
+			},
+		})
+		if err != nil {
+			return nil, nil, transformError(err)
+		}
+		mqlMsApp, err := newMqlMicrosoftDevice(runtime, device)
+		if err != nil {
+			return nil, nil, err
+		}
+		return nil, mqlMsApp, nil
+	}
+
+	displayNameFilter := fmt.Sprintf("displayName eq '%s'", rawDisplayName.Value.(string))
 	resp, err := graphClient.Devices().Get(ctx, &devices.DevicesRequestBuilderGetRequestConfiguration{
 		QueryParameters: &devices.DevicesRequestBuilderGetQueryParameters{
-			Filter: filter,
+			Filter: &displayNameFilter,
+			Select: deviceSelectFields,
 		},
 	})
 	if err != nil {
@@ -169,17 +179,10 @@ func initMicrosoftDevice(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 		return nil, nil, errors.New("device not found")
 	}
 
-	deviceId := val[0].GetId()
-	if deviceId == nil {
-		return nil, nil, errors.New("device id not found")
-	}
-
-	// fetch devices by id
-	device, err := graphClient.Devices().ByDeviceId(*deviceId).Get(ctx, &devices.DeviceItemRequestBuilderGetRequestConfiguration{})
-	if err != nil {
-		return nil, nil, transformError(err)
-	}
-	mqlMsApp, err := newMqlMicrosoftDevice(runtime, device)
+	// Reuse the filter response directly — the requested Select carries
+	// every field newMqlMicrosoftDevice consumes, so a second Get by id
+	// would just return the same data.
+	mqlMsApp, err := newMqlMicrosoftDevice(runtime, val[0])
 	if err != nil {
 		return nil, nil, err
 	}

--- a/providers/ms365/resources/groups.go
+++ b/providers/ms365/resources/groups.go
@@ -35,8 +35,13 @@ func (a *mqlMicrosoftGroup) members() ([]any, error) {
 	}
 	top := int32(200)
 
+	// Pull the same fields the rest of the user resource consumes so
+	// accessing member.displayName/mail/userPrincipalName is served from
+	// this single response instead of triggering initMicrosoftUser per
+	// member.
 	queryParams := &groups.ItemMembersRequestBuilderGetQueryParameters{
-		Top: &top,
+		Top:    &top,
+		Select: userSelectFields,
 	}
 	ctx := context.Background()
 	resp, err := graphClient.Groups().
@@ -68,6 +73,18 @@ func (a *mqlMicrosoftGroup) members() ([]any, error) {
 		userResource, ok := mqlMicrosoftResource.userById(*memberId)
 		if ok {
 			res = append(res, userResource)
+			continue
+		}
+
+		// When the member is a user, build it from the data already on the
+		// response — avoids a second Graph round-trip via initMicrosoftUser.
+		if user, ok := member.(models.Userable); ok {
+			newUser, err := newMqlMicrosoftUser(a.MqlRuntime, user)
+			if err != nil {
+				return nil, err
+			}
+			mqlMicrosoftResource.indexUser(newUser)
+			res = append(res, newUser)
 			continue
 		}
 

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -10749,7 +10749,7 @@ func (c *mqlMicrosoftConditionalAccessAuthenticationMethodConfiguration) GetStat
 type mqlMicrosoftConditionalAccessNamedLocations struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlMicrosoftConditionalAccessNamedLocationsInternal it will be used here
+	mqlMicrosoftConditionalAccessNamedLocationsInternal
 	IpLocations      plugin.TValue[[]any]
 	CountryLocations plugin.TValue[[]any]
 }

--- a/providers/ms365/resources/users.go
+++ b/providers/ms365/resources/users.go
@@ -154,21 +154,6 @@ func initMicrosoftUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 		return args, nil, nil
 	}
 
-	var filter *string
-	if okId {
-		idFilter := fmt.Sprintf("id eq '%s'", rawId.Value.(string))
-		filter = &idFilter
-	} else if okPrincipalName {
-		principalNameFilter := fmt.Sprintf("userPrincipalName eq '%s'", rawPrincipalName.Value.(string))
-		filter = &principalNameFilter
-	} else if okDisplayName {
-		displayNameFilter := fmt.Sprintf("displayName eq '%s'", rawDisplayName.Value.(string))
-		filter = &displayNameFilter
-	}
-	if filter == nil {
-		return nil, nil, errors.New("no filter found")
-	}
-
 	conn := runtime.Connection.(*connection.Ms365Connection)
 	graphClient, err := conn.GraphClient()
 	if err != nil {
@@ -176,9 +161,37 @@ func initMicrosoftUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	}
 
 	ctx := context.Background()
+
+	// Fast path: look up directly by id. Skips the redundant filter+get
+	// round-trip we'd otherwise pay for every microsoft.user(id: "...")
+	// reference (most callers — owners, members, etc.).
+	if okId {
+		user, err := graphClient.Users().ByUserId(rawId.Value.(string)).Get(ctx, &users.UserItemRequestBuilderGetRequestConfiguration{
+			QueryParameters: &users.UserItemRequestBuilderGetQueryParameters{
+				Select: userSelectFields,
+			},
+		})
+		if err != nil {
+			return nil, nil, transformError(err)
+		}
+		mqlMsApp, err := newMqlMicrosoftUser(runtime, user)
+		if err != nil {
+			return nil, nil, err
+		}
+		return nil, mqlMsApp, nil
+	}
+
+	var filter string
+	if okPrincipalName {
+		filter = fmt.Sprintf("userPrincipalName eq '%s'", rawPrincipalName.Value.(string))
+	} else if okDisplayName {
+		filter = fmt.Sprintf("displayName eq '%s'", rawDisplayName.Value.(string))
+	}
+
 	resp, err := graphClient.Users().Get(ctx, &users.UsersRequestBuilderGetRequestConfiguration{
 		QueryParameters: &users.UsersRequestBuilderGetQueryParameters{
-			Filter: filter,
+			Filter: &filter,
+			Select: userSelectFields,
 		},
 	})
 	if err != nil {
@@ -190,17 +203,10 @@ func initMicrosoftUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 		return nil, nil, errors.New("user not found")
 	}
 
-	userId := val[0].GetId()
-	if userId == nil {
-		return nil, nil, errors.New("user id not found")
-	}
-
-	// fetch user by id
-	user, err := graphClient.Users().ByUserId(*userId).Get(ctx, &users.UserItemRequestBuilderGetRequestConfiguration{})
-	if err != nil {
-		return nil, nil, transformError(err)
-	}
-	mqlMsApp, err := newMqlMicrosoftUser(runtime, user)
+	// Reuse the filter response directly — it already carries every
+	// userSelectFields field, so a second Get by id would return the
+	// same data.
+	mqlMsApp, err := newMqlMicrosoftUser(runtime, val[0])
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Summary

Five focused changes that reduce Microsoft Graph API usage during common ms365 queries. No schema changes — pure refactors of the Graph call patterns.

## Changes

### 1. `conditional-access.go` — share the NamedLocations fetch (High)
`ipLocations()` and `countryLocations()` each issued an independent `Identity().ConditionalAccess().NamedLocations().Get()` and then filtered the result in memory. Added a `sync.Once`-guarded cache on `mqlMicrosoftConditionalAccessNamedLocationsInternal` so both accessors share one Graph call.

### 2. `users.go initMicrosoftUser` — drop redundant lookup (High)
The init function used to do `$filter=id eq '...'` then a second `ByUserId().Get()` to materialize the user. Both calls returned the same user.

- When `id` is the lookup key: skip the filter and call `ByUserId().Get(Select: userSelectFields)` directly.
- When `displayName` / `userPrincipalName` is the key: reuse the filter response (it already carries every `userSelectFields` field).

### 3. `devices.go initMicrosoftDevice` — same pattern (High)
Mirror of the users.go change for `microsoft.device(id: "...")` references.

### 4. `applications.go owners()` — preload user fields (High)
Previously the owners call set `$select=[id]`. Any access to `owner.displayName`, `owner.mail`, etc. fired `initMicrosoftUser` per owner (which itself was a 2-call dance until this PR).

Now requests `userSelectFields` and, when the directory object is a `models.Userable`, builds the `microsoft.user` resource directly from the owners response via `newMqlMicrosoftUser`. Group/SP owners fall back to the existing lazy reference.

### 5. `groups.go members()` — same as #4 (High)
Members previously came back as `microsoft.user` references with only `id`. With `Select: userSelectFields` and a direct `newMqlMicrosoftUser` build, accessing common fields no longer requires a follow-up call.

## Estimated API call reduction

Numbers below are *per query*. They compound when the same path runs against many tenants or in long-running scans.

| Query pattern | Before | After | Reduction |
| --- | --- | --- | --- |
| `microsoft.conditionalAccess.namedLocations { ipLocations countryLocations }` | 2 Graph calls | 1 Graph call | **50%** |
| `microsoft.user(id: "X").<any field>` | 2 calls | 1 call | **50%** |
| `microsoft.device(id: "X").<any field>` | 2 calls | 1 call | **50%** |
| `microsoft.application(...).owners { displayName }` with N owners | 1 + 2N calls | 1 call | **(1 + 2N) → 1** |
| `microsoft.group(...).members { displayName }` with N members | 1 + 2N calls | 1 call | **(1 + 2N) → 1** |

Fix #4 / #5 also compose with #2: previously each per-owner / per-member init was already a 2-call sequence, so the savings on those code paths are larger than they look in isolation.

For a typical compliance scan that walks groups and their members across a tenant with 500 groups and 50 members each, the members-side savings alone are ~25,000 → 500 Graph calls (~98% reduction).

## Test plan

- [x] `go build ./providers/ms365/...`
- [x] `go test ./providers/ms365/resources/...` — existing tests pass
- [x] `make providers/build/ms365` — provider binary builds cleanly
- [ ] (recommend) `cnspec shell ms365 ...` and exercise:
  - `microsoft.conditionalAccess.namedLocations { ipLocations countryLocations }`
  - `microsoft.user(id: "<id>").displayName`
  - `microsoft.device(id: "<id>").displayName`
  - `microsoft.applications { owners { displayName mail } }`
  - `microsoft.groups { members { displayName mail userPrincipalName } }`

### Why no new unit tests

The changes are entirely in how we shape Microsoft Graph requests and how we map responses to MQL resources. The existing test suite (`devicemanagement_assignments_test.go`, `ms365_sharepoint_test.go`, etc.) covers pure helper functions and doesn't mock the Graph client. Meaningful coverage for these changes is end-to-end against a real tenant, captured in the manual test plan above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)