### PR TITLE
🧹 oci: rename oci-loadbalancer-loadBalancer platform to oci-loadbalancer

### DIFF
--- a/providers/oci/config/config.go
+++ b/providers/oci/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "oci",
 	ID:              "go.mondoo.com/cnquery/v9/providers/oci",
-	Version:         "13.8.0",
+	Version:         "13.8.1",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/oci/resources/discovery.go
+++ b/providers/oci/resources/discovery.go
@@ -382,7 +382,7 @@ func getPlatformName(obj ociObject) string {
 		}
 	case "loadbalancer":
 		if obj.objectType == "loadBalancer" {
-			return "oci-loadbalancer-loadBalancer"
+			return "oci-loadbalancer"
 		}
 	case "redis":
 		if obj.objectType == "cluster" {
@@ -413,7 +413,7 @@ func getPlatformTitle(platform string) string {
 		return "OCI Object Storage Bucket"
 	case "oci-apigateway-deployment":
 		return "OCI API Gateway Deployment"
-	case "oci-loadbalancer-loadBalancer":
+	case "oci-loadbalancer":
 		return "OCI Load Balancer"
 	case "oci-redis-cluster":
 		return "OCI Redis Cluster"


### PR DESCRIPTION
## Summary
- Rename the OCI Load Balancer discovery platform from `oci-loadbalancer-loadBalancer` to `oci-loadbalancer`. The old name was mixed-case (every other OCI platform is all-lowercase) and had a redundant `-loadBalancer` suffix.
- Bump the OCI provider patch version to `13.8.1`.

The old name shipped in #7976 / `oci-13.8.0` and has not been referenced anywhere else in the repo.

## Test plan
- [ ] `make providers/build/oci && make providers/install/oci`
- [ ] `cnspec scan oci --discover load-balancer` returns assets with platform `oci-loadbalancer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)