### PR TITLE
✨ gcp: discover memorystore, artifact registry, memcache, vertexai jobs

### DIFF
--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -1039,6 +1039,16 @@ var gcpPermissionOverrides = map[string]map[string]string{
 		"GetInstance":         "memorystore.instances.get",
 		"GetBackupCollection": "memorystore.backupCollections.get",
 	},
+	"memcache": {
+		// CloudMemcacheClient.GetInstance → singular "instance" by default;
+		// the real IAM permission is the plural form.
+		"GetInstance": "memcache.instances.get",
+	},
+	"aiplatform": {
+		// JobClient.GetCustomJob → singular "customJob" by default; the real
+		// IAM permission is the plural form.
+		"GetCustomJob": "aiplatform.customJobs.get",
+	},
 	"pubsub": {
 		// SchemaClient.GetSchema → singular "schema" by default; real IAM
 		// permission is plural.

--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -1039,11 +1039,6 @@ var gcpPermissionOverrides = map[string]map[string]string{
 		"GetInstance":         "memorystore.instances.get",
 		"GetBackupCollection": "memorystore.backupCollections.get",
 	},
-	"aiplatform": {
-		// JobClient.GetCustomJob → singular "customJob" by default; the real
-		// IAM permission is the plural form.
-		"GetCustomJob": "aiplatform.customJobs.get",
-	},
 	"pubsub": {
 		// SchemaClient.GetSchema → singular "schema" by default; real IAM
 		// permission is plural.

--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -1039,6 +1039,11 @@ var gcpPermissionOverrides = map[string]map[string]string{
 		"GetInstance":         "memorystore.instances.get",
 		"GetBackupCollection": "memorystore.backupCollections.get",
 	},
+	"aiplatform": {
+		// JobClient.GetCustomJob → singular "customJob" by default; the real
+		// IAM permission is the plural form.
+		"GetCustomJob": "aiplatform.customJobs.get",
+	},
 	"pubsub": {
 		// SchemaClient.GetSchema → singular "schema" by default; real IAM
 		// permission is plural.

--- a/providers/gcp/connection/platform.go
+++ b/providers/gcp/connection/platform.go
@@ -126,6 +126,14 @@ func GetTitleForPlatformName(name string) string {
 		return "GCP Memorystore for Redis"
 	case "gcp-memorystore-rediscluster":
 		return "GCP Memorystore for Redis Cluster"
+	case "gcp-memorystore-instance":
+		return "GCP Memorystore Instance"
+	case "gcp-artifactregistry-repository":
+		return "GCP Artifact Registry Repository"
+	case "gcp-memcache-instance":
+		return "GCP Memorystore for Memcached Instance"
+	case "gcp-vertexai-job":
+		return "GCP Vertex AI Custom Job"
 	case "gcp-secretmanager-secret":
 		return "GCP Secret Manager Secret"
 	case "gcp-compute-instance":
@@ -223,8 +231,31 @@ func ResourceTechnologyUrl(service, project, region, objectType, name string) []
 			return []string{"gcp", project, "memorystore", region, "redis"}
 		case "rediscluster":
 			return []string{"gcp", project, "memorystore", region, "rediscluster"}
+		case "instance":
+			return []string{"gcp", project, "memorystore", region, "instance"}
 		default:
 			return []string{"gcp", project, "memorystore", region, "other"}
+		}
+	case "artifactregistry":
+		switch objectType {
+		case "repository":
+			return []string{"gcp", project, "artifactregistry", region, "repository"}
+		default:
+			return []string{"gcp", project, "artifactregistry", region, "other"}
+		}
+	case "memcache":
+		switch objectType {
+		case "instance":
+			return []string{"gcp", project, "memcache", region, "instance"}
+		default:
+			return []string{"gcp", project, "memcache", region, "other"}
+		}
+	case "vertexai":
+		switch objectType {
+		case "job":
+			return []string{"gcp", project, "vertexai", region, "job"}
+		default:
+			return []string{"gcp", project, "vertexai", region, "other"}
 		}
 	case "secretmanager":
 		switch objectType {

--- a/providers/gcp/resources/common.go
+++ b/providers/gcp/resources/common.go
@@ -126,6 +126,19 @@ func parseResourceName(fullPath string) string {
 	return segments[len(segments)-1]
 }
 
+// parseProjectFromPath extracts the project ID from a GCP resource path.
+// The path format is: projects/{project}/...
+// Returns "" if no project segment is found.
+func parseProjectFromPath(fullPath string) string {
+	segments := strings.Split(fullPath, "/")
+	for i, s := range segments {
+		if s == "projects" && i+1 < len(segments) {
+			return segments[i+1]
+		}
+	}
+	return ""
+}
+
 // parseLocationFromPath extracts the location/region from a GCP resource path.
 // The path format is: projects/{project}/locations/{location}/...
 // Returns "global" if no location segment is found.

--- a/providers/gcp/resources/discovery.go
+++ b/providers/gcp/resources/discovery.go
@@ -62,6 +62,10 @@ const (
 	DiscoverSpannerInstances        = "spanner-instances"
 	DiscoverFirestoreDatabases      = "firestore-databases"
 	DiscoverBigtableInstances       = "bigtable-instances"
+	DiscoverMemorystoreInstances    = "memorystore-instances"
+	DiscoverArtifactRegistryRepos   = "artifactregistry-repositories"
+	DiscoverMemcacheInstances       = "memcache-instances"
+	DiscoverVertexAIJobs            = "vertexai-jobs"
 )
 
 // All includes every discovery target: Auto covers all of them for GCP.
@@ -101,6 +105,10 @@ var Auto = []string{
 	DiscoverSpannerInstances,
 	DiscoverFirestoreDatabases,
 	DiscoverBigtableInstances,
+	DiscoverMemorystoreInstances,
+	DiscoverArtifactRegistryRepos,
+	DiscoverMemcacheInstances,
+	DiscoverVertexAIJobs,
 }
 
 var AllAPIResources = []string{
@@ -134,6 +142,10 @@ var AllAPIResources = []string{
 	DiscoverSpannerInstances,
 	DiscoverFirestoreDatabases,
 	DiscoverBigtableInstances,
+	DiscoverMemorystoreInstances,
+	DiscoverArtifactRegistryRepos,
+	DiscoverMemcacheInstances,
+	DiscoverVertexAIJobs,
 }
 
 // List of all CloudSQL types, this will be used during discovery
@@ -664,6 +676,143 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, 
 					TechnologyUrlSegments: connection.ResourceTechnologyUrl("memorystore", gcpProject.Id.Data, location, "rediscluster", clusterName),
 				},
 				Labels:      map[string]string{},
+				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+			})
+		}
+	}
+	if stringx.ContainsAnyOf(discoveryTargets, DiscoverMemorystoreInstances) {
+		memorystoreService := gcpProject.GetMemorystore()
+		if memorystoreService.Error != nil {
+			return nil, memorystoreService.Error
+		}
+		instances := memorystoreService.Data.GetInstances()
+		if instances.Error != nil {
+			return nil, instances.Error
+		}
+		for i := range instances.Data {
+			instance := instances.Data[i].(*mqlGcpProjectMemorystoreServiceInstance)
+			// Memorystore instance name is the full resource path:
+			// projects/{project}/locations/{location}/instances/{instance}
+			instanceName := parseResourceName(instance.Name.Data)
+			location := parseLocationFromPath(instance.Name.Data)
+
+			assetList = append(assetList, &inventory.Asset{
+				PlatformIds: []string{
+					connection.NewResourcePlatformID("memorystore", gcpProject.Id.Data, location, "instance", instanceName),
+				},
+				Name: instanceName,
+				Platform: &inventory.Platform{
+					Name:                  "gcp-memorystore-instance",
+					Title:                 connection.GetTitleForPlatformName("gcp-memorystore-instance"),
+					Runtime:               "gcp",
+					Kind:                  "gcp-object",
+					Family:                []string{"google"},
+					TechnologyUrlSegments: connection.ResourceTechnologyUrl("memorystore", gcpProject.Id.Data, location, "instance", instanceName),
+				},
+				Labels:      mapStrInterfaceToMapStrStr(instance.GetLabels().Data),
+				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+			})
+		}
+	}
+	if stringx.ContainsAnyOf(discoveryTargets, DiscoverArtifactRegistryRepos) {
+		artifactSvc := gcpProject.GetArtifactRegistry()
+		if artifactSvc.Error != nil {
+			return nil, artifactSvc.Error
+		}
+		repos := artifactSvc.Data.GetRepositories()
+		if repos.Error != nil {
+			return nil, repos.Error
+		}
+		for i := range repos.Data {
+			repo := repos.Data[i].(*mqlGcpProjectArtifactRegistryServiceRepository)
+			repoName := repo.Name.Data
+			location := repo.Location.Data
+			if location == "" {
+				location = "global"
+			}
+
+			assetList = append(assetList, &inventory.Asset{
+				PlatformIds: []string{
+					connection.NewResourcePlatformID("artifactregistry", gcpProject.Id.Data, location, "repository", repoName),
+				},
+				Name: repoName,
+				Platform: &inventory.Platform{
+					Name:                  "gcp-artifactregistry-repository",
+					Title:                 connection.GetTitleForPlatformName("gcp-artifactregistry-repository"),
+					Runtime:               "gcp",
+					Kind:                  "gcp-object",
+					Family:                []string{"google"},
+					TechnologyUrlSegments: connection.ResourceTechnologyUrl("artifactregistry", gcpProject.Id.Data, location, "repository", repoName),
+				},
+				Labels:      mapStrInterfaceToMapStrStr(repo.GetLabels().Data),
+				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+			})
+		}
+	}
+	if stringx.ContainsAnyOf(discoveryTargets, DiscoverMemcacheInstances) {
+		memcacheService := gcpProject.GetMemcache()
+		if memcacheService.Error != nil {
+			return nil, memcacheService.Error
+		}
+		instances := memcacheService.Data.GetInstances()
+		if instances.Error != nil {
+			return nil, instances.Error
+		}
+		for i := range instances.Data {
+			instance := instances.Data[i].(*mqlGcpProjectMemcacheServiceInstance)
+			// Memcache instance name is the full resource path:
+			// projects/{project}/locations/{location}/instances/{instance}
+			instanceName := parseResourceName(instance.Name.Data)
+			location := parseLocationFromPath(instance.Name.Data)
+
+			assetList = append(assetList, &inventory.Asset{
+				PlatformIds: []string{
+					connection.NewResourcePlatformID("memcache", gcpProject.Id.Data, location, "instance", instanceName),
+				},
+				Name: instanceName,
+				Platform: &inventory.Platform{
+					Name:                  "gcp-memcache-instance",
+					Title:                 connection.GetTitleForPlatformName("gcp-memcache-instance"),
+					Runtime:               "gcp",
+					Kind:                  "gcp-object",
+					Family:                []string{"google"},
+					TechnologyUrlSegments: connection.ResourceTechnologyUrl("memcache", gcpProject.Id.Data, location, "instance", instanceName),
+				},
+				Labels:      mapStrInterfaceToMapStrStr(instance.GetLabels().Data),
+				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
+			})
+		}
+	}
+	if stringx.ContainsAnyOf(discoveryTargets, DiscoverVertexAIJobs) {
+		vertexaiService := gcpProject.GetVertexai()
+		if vertexaiService.Error != nil {
+			return nil, vertexaiService.Error
+		}
+		jobs := vertexaiService.Data.GetCustomJobs()
+		if jobs.Error != nil {
+			return nil, jobs.Error
+		}
+		for i := range jobs.Data {
+			job := jobs.Data[i].(*mqlGcpProjectVertexaiServiceCustomJob)
+			// Custom job name is the full resource path:
+			// projects/{project}/locations/{location}/customJobs/{job}
+			jobName := parseResourceName(job.Name.Data)
+			location := parseLocationFromPath(job.Name.Data)
+
+			assetList = append(assetList, &inventory.Asset{
+				PlatformIds: []string{
+					connection.NewResourcePlatformID("vertexai", gcpProject.Id.Data, location, "job", jobName),
+				},
+				Name: jobName,
+				Platform: &inventory.Platform{
+					Name:                  "gcp-vertexai-job",
+					Title:                 connection.GetTitleForPlatformName("gcp-vertexai-job"),
+					Runtime:               "gcp",
+					Kind:                  "gcp-object",
+					Family:                []string{"google"},
+					TechnologyUrlSegments: connection.ResourceTechnologyUrl("vertexai", gcpProject.Id.Data, location, "job", jobName),
+				},
+				Labels:      mapStrInterfaceToMapStrStr(job.GetLabels().Data),
 				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))},
 			})
 		}

--- a/providers/gcp/resources/discovery.go
+++ b/providers/gcp/resources/discovery.go
@@ -700,7 +700,9 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, 
 				PlatformIds: []string{
 					connection.NewResourcePlatformID("memorystore", gcpProject.Id.Data, location, "instance", instanceName),
 				},
-				Name: instanceName,
+				// Short instance names are scoped per-location, so disambiguate
+				// the asset display name with the location.
+				Name: fmt.Sprintf("%s/%s", location, instanceName),
 				Platform: &inventory.Platform{
 					Name:                  "gcp-memorystore-instance",
 					Title:                 connection.GetTitleForPlatformName("gcp-memorystore-instance"),
@@ -735,7 +737,9 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, 
 				PlatformIds: []string{
 					connection.NewResourcePlatformID("artifactregistry", gcpProject.Id.Data, location, "repository", repoName),
 				},
-				Name: repoName,
+				// Repository names are scoped per-location, so disambiguate the
+				// asset display name with the location.
+				Name: fmt.Sprintf("%s/%s", location, repoName),
 				Platform: &inventory.Platform{
 					Name:                  "gcp-artifactregistry-repository",
 					Title:                 connection.GetTitleForPlatformName("gcp-artifactregistry-repository"),
@@ -769,7 +773,9 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, 
 				PlatformIds: []string{
 					connection.NewResourcePlatformID("memcache", gcpProject.Id.Data, location, "instance", instanceName),
 				},
-				Name: instanceName,
+				// Short instance names are scoped per-location, so disambiguate
+				// the asset display name with the location.
+				Name: fmt.Sprintf("%s/%s", location, instanceName),
 				Platform: &inventory.Platform{
 					Name:                  "gcp-memcache-instance",
 					Title:                 connection.GetTitleForPlatformName("gcp-memcache-instance"),
@@ -803,7 +809,9 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, 
 				PlatformIds: []string{
 					connection.NewResourcePlatformID("vertexai", gcpProject.Id.Data, location, "job", jobName),
 				},
-				Name: jobName,
+				// Custom job names are scoped per-region, so disambiguate the
+				// asset display name with the region.
+				Name: fmt.Sprintf("%s/%s", location, jobName),
 				Platform: &inventory.Platform{
 					Name:                  "gcp-vertexai-job",
 					Title:                 connection.GetTitleForPlatformName("gcp-vertexai-job"),

--- a/providers/gcp/resources/discovery_test.go
+++ b/providers/gcp/resources/discovery_test.go
@@ -46,6 +46,10 @@ func TestAllResolvedResources(t *testing.T) {
 		DiscoverSpannerInstances,
 		DiscoverFirestoreDatabases,
 		DiscoverBigtableInstances,
+		DiscoverMemorystoreInstances,
+		DiscoverArtifactRegistryRepos,
+		DiscoverMemcacheInstances,
+		DiscoverVertexAIJobs,
 	}
 	require.ElementsMatch(t, expected, All)
 }
@@ -85,6 +89,10 @@ func TestAutoResolvedResources(t *testing.T) {
 		DiscoverSpannerInstances,
 		DiscoverFirestoreDatabases,
 		DiscoverBigtableInstances,
+		DiscoverMemorystoreInstances,
+		DiscoverArtifactRegistryRepos,
+		DiscoverMemcacheInstances,
+		DiscoverVertexAIJobs,
 	}
 	require.ElementsMatch(t, expected, Auto)
 }

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -1706,7 +1706,7 @@ func init() {
 			Create: createGcpProjectVertexaiServiceTensorboard,
 		},
 		"gcp.project.vertexaiService.customJob": {
-			// to override args, implement: initGcpProjectVertexaiServiceCustomJob(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initGcpProjectVertexaiServiceCustomJob,
 			Create: createGcpProjectVertexaiServiceCustomJob,
 		},
 		"gcp.project.vertexaiService.index": {
@@ -1978,7 +1978,7 @@ func init() {
 			Create: createGcpProjectMemcacheService,
 		},
 		"gcp.project.memcacheService.instance": {
-			// to override args, implement: initGcpProjectMemcacheServiceInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initGcpProjectMemcacheServiceInstance,
 			Create: createGcpProjectMemcacheServiceInstance,
 		},
 		"gcp.project.memcacheService.instance.node": {

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,9 +1,10 @@
 {
   "provider": "gcp",
   "version": "13.17.0",
-  "generated_at": "2026-05-26T14:28:59+03:00",
+  "generated_at": "2026-05-26T10:17:51-07:00",
   "permissions": [
     "accessapproval.settings.get",
+    "aiplatform.customJobs.get",
     "aiplatform.customJobs.list",
     "aiplatform.datasets.list",
     "aiplatform.endpoints.list",
@@ -234,6 +235,12 @@
       "service": "accessapproval",
       "action": "GetAccessApprovalSettings",
       "source_file": "access_approval.go"
+    },
+    {
+      "permission": "aiplatform.customJobs.get",
+      "service": "aiplatform",
+      "action": "GetCustomJob",
+      "source_file": "vertexai.go"
     },
     {
       "permission": "aiplatform.customJobs.list",

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,10 +1,9 @@
 {
   "provider": "gcp",
   "version": "13.17.0",
-  "generated_at": "2026-05-26T10:17:51-07:00",
+  "generated_at": "2026-05-26T12:03:54-07:00",
   "permissions": [
     "accessapproval.settings.get",
-    "aiplatform.customJobs.get",
     "aiplatform.customJobs.list",
     "aiplatform.datasets.list",
     "aiplatform.endpoints.list",
@@ -235,12 +234,6 @@
       "service": "accessapproval",
       "action": "GetAccessApprovalSettings",
       "source_file": "access_approval.go"
-    },
-    {
-      "permission": "aiplatform.customJobs.get",
-      "service": "aiplatform",
-      "action": "GetCustomJob",
-      "source_file": "vertexai.go"
     },
     {
       "permission": "aiplatform.customJobs.list",

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,9 +1,10 @@
 {
   "provider": "gcp",
   "version": "13.17.0",
-  "generated_at": "2026-05-26T12:03:54-07:00",
+  "generated_at": "2026-05-26T12:04:42-07:00",
   "permissions": [
     "accessapproval.settings.get",
+    "aiplatform.customJobs.get",
     "aiplatform.customJobs.list",
     "aiplatform.datasets.list",
     "aiplatform.endpoints.list",
@@ -161,6 +162,7 @@
     "logging.exclusions.list",
     "logging.sinks.list",
     "logging.views.list",
+    "memcache.instances.get",
     "memcache.instances.list",
     "memorystore.backupCollections.get",
     "memorystore.backupCollections.list",
@@ -234,6 +236,12 @@
       "service": "accessapproval",
       "action": "GetAccessApprovalSettings",
       "source_file": "access_approval.go"
+    },
+    {
+      "permission": "aiplatform.customJobs.get",
+      "service": "aiplatform",
+      "action": "GetCustomJob",
+      "source_file": "vertexai.go"
     },
     {
       "permission": "aiplatform.customJobs.list",
@@ -1220,6 +1228,12 @@
       "source_file": "logging.go"
     },
     {
+      "permission": "memcache.instances.get",
+      "service": "memcache",
+      "action": "GetInstance",
+      "source_file": "memcache.go"
+    },
+    {
       "permission": "memcache.instances.list",
       "service": "memcache",
       "action": "ListInstances",
@@ -1469,7 +1483,7 @@
     {
       "permission": "resourcemanager.folders.list",
       "service": "resourcemanager",
-      "action": "Folders.List",
+      "action": "Folders.Search",
       "source_file": "folder.go",
       "scope": "org"
     },
@@ -1509,7 +1523,7 @@
     {
       "permission": "resourcemanager.projects.list",
       "service": "resourcemanager",
-      "action": "Projects.Search",
+      "action": "Projects.List",
       "source_file": "project.go",
       "scope": "org"
     },

--- a/providers/gcp/resources/memcache.go
+++ b/providers/gcp/resources/memcache.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	memcache "cloud.google.com/go/memcache/apiv1"
 	"cloud.google.com/go/memcache/apiv1/memcachepb"
@@ -59,6 +60,76 @@ func (g *mqlGcpProjectMemcacheServiceInstance) id() (string, error) {
 		return "", g.Name.Error
 	}
 	return fmt.Sprintf("gcp.project/%s/memcacheService/instance/%s", g.ProjectId.Data, g.Name.Data), nil
+}
+
+func initGcpProjectMemcacheServiceInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+
+	if len(args) == 0 {
+		args = make(map[string]*llx.RawData)
+		if ids := getAssetIdentifier(runtime); ids != nil {
+			args["name"] = llx.StringData(ids.name)
+			args["projectId"] = llx.StringData(ids.project)
+			args["location"] = llx.StringData(ids.region)
+		} else {
+			return nil, nil, errors.New("no asset identifier found")
+		}
+	}
+
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return args, nil, nil
+	}
+	name := nameRaw.Value.(string)
+
+	conn, ok := runtime.Connection.(*connection.GcpConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
+	}
+
+	// Accept either the full resource path or a short name + location.
+	projectId := conn.ResourceID()
+	location := ""
+	if !strings.HasPrefix(name, "projects/") {
+		locRaw := args["location"]
+		projRaw := args["projectId"]
+		if locRaw == nil || projRaw == nil {
+			return nil, nil, errors.New("memcache instance init: projectId and location required when name is not a full resource path")
+		}
+		projectId = projRaw.Value.(string)
+		location = locRaw.Value.(string)
+	} else {
+		projectId = parseProjectFromPath(name)
+		location = parseLocationFromPath(name)
+		name = parseResourceName(name)
+	}
+
+	obj, err := CreateResource(runtime, "gcp.project.memcacheService", map[string]*llx.RawData{
+		"projectId": llx.StringData(projectId),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	memcacheSvc := obj.(*mqlGcpProjectMemcacheService)
+	instances := memcacheSvc.GetInstances()
+	if instances.Error != nil {
+		return nil, nil, instances.Error
+	}
+
+	for _, i := range instances.Data {
+		instance := i.(*mqlGcpProjectMemcacheServiceInstance)
+		// Memcache instance names are full resource paths; compare short
+		// segments + location to the asset identifier.
+		if parseResourceName(instance.Name.Data) == name &&
+			(location == "" || parseLocationFromPath(instance.Name.Data) == location) {
+			delete(args, "location")
+			return args, instance, nil
+		}
+	}
+
+	return nil, nil, fmt.Errorf("memcache instance %q not found", name)
 }
 
 func (g *mqlGcpProjectMemcacheServiceInstanceNode) id() (string, error) {

--- a/providers/gcp/resources/memcache.go
+++ b/providers/gcp/resources/memcache.go
@@ -89,47 +89,44 @@ func initGcpProjectMemcacheServiceInstance(runtime *plugin.Runtime, args map[str
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
 
-	// Accept either the full resource path or a short name + location.
-	projectId := conn.ResourceID()
-	location := ""
-	if !strings.HasPrefix(name, "projects/") {
+	// Accept either the full resource path or a short name + location from
+	// the asset-identifier-driven discovery path.
+	var fullName, projectId string
+	if strings.HasPrefix(name, "projects/") {
+		fullName = name
+		projectId = parseProjectFromPath(name)
+	} else {
 		locRaw := args["location"]
 		projRaw := args["projectId"]
 		if locRaw == nil || projRaw == nil {
 			return nil, nil, errors.New("memcache instance init: projectId and location required when name is not a full resource path")
 		}
 		projectId = projRaw.Value.(string)
-		location = locRaw.Value.(string)
-	} else {
-		projectId = parseProjectFromPath(name)
-		location = parseLocationFromPath(name)
-		name = parseResourceName(name)
+		fullName = fmt.Sprintf("projects/%s/locations/%s/instances/%s", projectId, locRaw.Value.(string), name)
 	}
 
-	obj, err := CreateResource(runtime, "gcp.project.memcacheService", map[string]*llx.RawData{
-		"projectId": llx.StringData(projectId),
-	})
+	creds, err := conn.Credentials(memcache.DefaultAuthScopes()...)
 	if err != nil {
 		return nil, nil, err
 	}
-	memcacheSvc := obj.(*mqlGcpProjectMemcacheService)
-	instances := memcacheSvc.GetInstances()
-	if instances.Error != nil {
-		return nil, nil, instances.Error
+	ctx := context.Background()
+	client, err := memcache.NewCloudMemcacheClient(ctx, option.WithCredentials(creds))
+	if err != nil {
+		return nil, nil, err
+	}
+	defer client.Close()
+
+	inst, err := client.GetInstance(ctx, &memcachepb.GetInstanceRequest{Name: fullName})
+	if err != nil {
+		return nil, nil, err
 	}
 
-	for _, i := range instances.Data {
-		instance := i.(*mqlGcpProjectMemcacheServiceInstance)
-		// Memcache instance names are full resource paths; compare short
-		// segments + location to the asset identifier.
-		if parseResourceName(instance.Name.Data) == name &&
-			(location == "" || parseLocationFromPath(instance.Name.Data) == location) {
-			delete(args, "location")
-			return args, instance, nil
-		}
+	res, err := mqlMemcacheInstanceFromProto(runtime, projectId, inst)
+	if err != nil {
+		return nil, nil, err
 	}
-
-	return nil, nil, fmt.Errorf("memcache instance %q not found", name)
+	delete(args, "location")
+	return args, res, nil
 }
 
 func (g *mqlGcpProjectMemcacheServiceInstanceNode) id() (string, error) {
@@ -203,86 +200,92 @@ func (g *mqlGcpProjectMemcacheService) instances() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
-
-		var nodeCpu, nodeMem int64
-		if inst.NodeConfig != nil {
-			nodeCpu = int64(inst.NodeConfig.CpuCount)
-			nodeMem = int64(inst.NodeConfig.MemorySizeMb)
-		}
-
-		params, err := newMqlMemcacheParameters(g.MqlRuntime, projectId, inst.Name, inst.Parameters)
+		mqlInst, err := mqlMemcacheInstanceFromProto(g.MqlRuntime, projectId, inst)
 		if err != nil {
 			return nil, err
 		}
-
-		maintenancePolicy, err := protoToDict(inst.MaintenancePolicy)
-		if err != nil {
-			return nil, err
-		}
-		maintenanceSchedule, err := protoToDict(inst.MaintenanceSchedule)
-		if err != nil {
-			return nil, err
-		}
-
-		var createTime, updateTime *llx.RawData
-		if inst.CreateTime != nil {
-			createTime = llx.TimeData(inst.CreateTime.AsTime())
-		} else {
-			createTime = llx.NilData
-		}
-		if inst.UpdateTime != nil {
-			updateTime = llx.TimeData(inst.UpdateTime.AsTime())
-		} else {
-			updateTime = llx.NilData
-		}
-
-		instanceMessages := make([]any, 0, len(inst.InstanceMessages))
-		for _, msg := range inst.InstanceMessages {
-			if msg == nil {
-				continue
-			}
-			instanceMessages = append(instanceMessages, map[string]any{
-				"code":    msg.Code.String(),
-				"message": msg.Message,
-			})
-		}
-
-		nodes, err := buildMemcacheNodes(g.MqlRuntime, projectId, inst.Name, inst.MemcacheNodes)
-		if err != nil {
-			return nil, err
-		}
-
-		mqlInst, err := CreateResource(g.MqlRuntime, "gcp.project.memcacheService.instance", map[string]*llx.RawData{
-			"projectId":           llx.StringData(projectId),
-			"name":                llx.StringData(inst.Name),
-			"displayName":         llx.StringData(inst.DisplayName),
-			"labels":              llx.MapData(convert.MapToInterfaceMap(inst.Labels), types.String),
-			"zones":               llx.ArrayData(convert.SliceAnyToInterface(inst.Zones), types.String),
-			"nodeCount":           llx.IntData(int64(inst.NodeCount)),
-			"nodeCpuCount":        llx.IntData(nodeCpu),
-			"nodeMemorySizeMb":    llx.IntData(nodeMem),
-			"memcacheVersion":     llx.StringData(inst.MemcacheVersion.String()),
-			"memcacheFullVersion": llx.StringData(inst.MemcacheFullVersion),
-			"parameters":          llx.ResourceData(params, "gcp.project.memcacheService.instance.parameters"),
-			"state":               llx.StringData(inst.State.String()),
-			"discoveryEndpoint":   llx.StringData(inst.DiscoveryEndpoint),
-			"instanceMessages":    llx.ArrayData(instanceMessages, types.Dict),
-			"maintenancePolicy":   llx.DictData(maintenancePolicy),
-			"maintenanceSchedule": llx.DictData(maintenanceSchedule),
-			"createTime":          createTime,
-			"updateTime":          updateTime,
-			"nodes":               llx.ArrayData(nodes, types.Resource("gcp.project.memcacheService.instance.node")),
-		})
-		if err != nil {
-			return nil, err
-		}
-		mqlInstance := mqlInst.(*mqlGcpProjectMemcacheServiceInstance)
-		mqlInstance.cacheAuthorizedNetwork = inst.AuthorizedNetwork
-
-		res = append(res, mqlInstance)
+		res = append(res, mqlInst)
 	}
 
 	return res, nil
+}
+
+func mqlMemcacheInstanceFromProto(runtime *plugin.Runtime, projectId string, inst *memcachepb.Instance) (*mqlGcpProjectMemcacheServiceInstance, error) {
+	var nodeCpu, nodeMem int64
+	if inst.NodeConfig != nil {
+		nodeCpu = int64(inst.NodeConfig.CpuCount)
+		nodeMem = int64(inst.NodeConfig.MemorySizeMb)
+	}
+
+	params, err := newMqlMemcacheParameters(runtime, projectId, inst.Name, inst.Parameters)
+	if err != nil {
+		return nil, err
+	}
+
+	maintenancePolicy, err := protoToDict(inst.MaintenancePolicy)
+	if err != nil {
+		return nil, err
+	}
+	maintenanceSchedule, err := protoToDict(inst.MaintenanceSchedule)
+	if err != nil {
+		return nil, err
+	}
+
+	var createTime, updateTime *llx.RawData
+	if inst.CreateTime != nil {
+		createTime = llx.TimeData(inst.CreateTime.AsTime())
+	} else {
+		createTime = llx.NilData
+	}
+	if inst.UpdateTime != nil {
+		updateTime = llx.TimeData(inst.UpdateTime.AsTime())
+	} else {
+		updateTime = llx.NilData
+	}
+
+	instanceMessages := make([]any, 0, len(inst.InstanceMessages))
+	for _, msg := range inst.InstanceMessages {
+		if msg == nil {
+			continue
+		}
+		instanceMessages = append(instanceMessages, map[string]any{
+			"code":    msg.Code.String(),
+			"message": msg.Message,
+		})
+	}
+
+	nodes, err := buildMemcacheNodes(runtime, projectId, inst.Name, inst.MemcacheNodes)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := CreateResource(runtime, "gcp.project.memcacheService.instance", map[string]*llx.RawData{
+		"projectId":           llx.StringData(projectId),
+		"name":                llx.StringData(inst.Name),
+		"displayName":         llx.StringData(inst.DisplayName),
+		"labels":              llx.MapData(convert.MapToInterfaceMap(inst.Labels), types.String),
+		"zones":               llx.ArrayData(convert.SliceAnyToInterface(inst.Zones), types.String),
+		"nodeCount":           llx.IntData(int64(inst.NodeCount)),
+		"nodeCpuCount":        llx.IntData(nodeCpu),
+		"nodeMemorySizeMb":    llx.IntData(nodeMem),
+		"memcacheVersion":     llx.StringData(inst.MemcacheVersion.String()),
+		"memcacheFullVersion": llx.StringData(inst.MemcacheFullVersion),
+		"parameters":          llx.ResourceData(params, "gcp.project.memcacheService.instance.parameters"),
+		"state":               llx.StringData(inst.State.String()),
+		"discoveryEndpoint":   llx.StringData(inst.DiscoveryEndpoint),
+		"instanceMessages":    llx.ArrayData(instanceMessages, types.Dict),
+		"maintenancePolicy":   llx.DictData(maintenancePolicy),
+		"maintenanceSchedule": llx.DictData(maintenanceSchedule),
+		"createTime":          createTime,
+		"updateTime":          updateTime,
+		"nodes":               llx.ArrayData(nodes, types.Resource("gcp.project.memcacheService.instance.node")),
+	})
+	if err != nil {
+		return nil, err
+	}
+	mqlInstance := res.(*mqlGcpProjectMemcacheServiceInstance)
+	mqlInstance.cacheAuthorizedNetwork = inst.AuthorizedNetwork
+	return mqlInstance, nil
 }
 
 func newMqlMemcacheParameters(runtime *plugin.Runtime, projectId, instanceName string, p *memcachepb.MemcacheParameters) (*mqlGcpProjectMemcacheServiceInstanceParameters, error) {

--- a/providers/gcp/resources/memorystore.go
+++ b/providers/gcp/resources/memorystore.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	memorystore "cloud.google.com/go/memorystore/apiv1"
 	"cloud.google.com/go/memorystore/apiv1/memorystorepb"
@@ -270,9 +271,21 @@ func mqlMemorystoreInstanceFromProto(runtime *plugin.Runtime, projectId string, 
 }
 
 func initGcpProjectMemorystoreServiceInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	if len(args) > 1 {
+	if len(args) > 2 {
 		return args, nil, nil
 	}
+
+	if len(args) == 0 {
+		args = make(map[string]*llx.RawData)
+		if ids := getAssetIdentifier(runtime); ids != nil {
+			args["name"] = llx.StringData(ids.name)
+			args["projectId"] = llx.StringData(ids.project)
+			args["location"] = llx.StringData(ids.region)
+		} else {
+			return nil, nil, errors.New("no asset identifier found")
+		}
+	}
+
 	nameRaw := args["name"]
 	if nameRaw == nil {
 		return args, nil, nil
@@ -294,15 +307,30 @@ func initGcpProjectMemorystoreServiceInstance(runtime *plugin.Runtime, args map[
 	}
 	defer client.Close()
 
-	inst, err := client.GetInstance(ctx, &memorystorepb.GetInstanceRequest{Name: name})
+	// Accept either the full resource path or a short name + location from
+	// the asset identifier driven discovery path.
+	fullName := name
+	projectId := conn.ResourceID()
+	if !strings.HasPrefix(name, "projects/") {
+		locRaw := args["location"]
+		projRaw := args["projectId"]
+		if locRaw == nil || projRaw == nil {
+			return nil, nil, errors.New("memorystore instance init: projectId and location required when name is not a full resource path")
+		}
+		projectId = projRaw.Value.(string)
+		fullName = fmt.Sprintf("projects/%s/locations/%s/instances/%s", projectId, locRaw.Value.(string), name)
+	}
+
+	inst, err := client.GetInstance(ctx, &memorystorepb.GetInstanceRequest{Name: fullName})
 	if err != nil {
 		return nil, nil, err
 	}
 
-	res, err := mqlMemorystoreInstanceFromProto(runtime, conn.ResourceID(), inst)
+	res, err := mqlMemorystoreInstanceFromProto(runtime, projectId, inst)
 	if err != nil {
 		return nil, nil, err
 	}
+	delete(args, "location")
 	return args, res, nil
 }
 

--- a/providers/gcp/resources/memorystore.go
+++ b/providers/gcp/resources/memorystore.go
@@ -308,10 +308,12 @@ func initGcpProjectMemorystoreServiceInstance(runtime *plugin.Runtime, args map[
 	defer client.Close()
 
 	// Accept either the full resource path or a short name + location from
-	// the asset identifier driven discovery path.
-	fullName := name
-	projectId := conn.ResourceID()
-	if !strings.HasPrefix(name, "projects/") {
+	// the asset-identifier-driven discovery path.
+	var fullName, projectId string
+	if strings.HasPrefix(name, "projects/") {
+		fullName = name
+		projectId = parseProjectFromPath(name)
+	} else {
 		locRaw := args["location"]
 		projRaw := args["projectId"]
 		if locRaw == nil || projRaw == nil {

--- a/providers/gcp/resources/permissions_test.go
+++ b/providers/gcp/resources/permissions_test.go
@@ -18,6 +18,7 @@ import (
 // the live GCP IAM API using queryTestablePermissions.
 var validatedGCPPermissions = []string{
 	"accessapproval.settings.get",
+	"aiplatform.customJobs.get",
 	"aiplatform.customJobs.list",
 	"aiplatform.datasets.list",
 	"aiplatform.endpoints.list",
@@ -175,6 +176,7 @@ var validatedGCPPermissions = []string{
 	"logging.exclusions.list",
 	"logging.sinks.list",
 	"logging.views.list",
+	"memcache.instances.get",
 	"memcache.instances.list",
 	"memorystore.backupCollections.get",
 	"memorystore.backupCollections.list",

--- a/providers/gcp/resources/permissions_test.go
+++ b/providers/gcp/resources/permissions_test.go
@@ -18,6 +18,7 @@ import (
 // the live GCP IAM API using queryTestablePermissions.
 var validatedGCPPermissions = []string{
 	"accessapproval.settings.get",
+	"aiplatform.customJobs.get",
 	"aiplatform.customJobs.list",
 	"aiplatform.datasets.list",
 	"aiplatform.endpoints.list",

--- a/providers/gcp/resources/permissions_test.go
+++ b/providers/gcp/resources/permissions_test.go
@@ -18,7 +18,6 @@ import (
 // the live GCP IAM API using queryTestablePermissions.
 var validatedGCPPermissions = []string{
 	"accessapproval.settings.get",
-	"aiplatform.customJobs.get",
 	"aiplatform.customJobs.list",
 	"aiplatform.datasets.list",
 	"aiplatform.endpoints.list",

--- a/providers/gcp/resources/vertexai.go
+++ b/providers/gcp/resources/vertexai.go
@@ -717,43 +717,85 @@ func initGcpProjectVertexaiServiceCustomJob(runtime *plugin.Runtime, args map[st
 	}
 	name := nameRaw.Value.(string)
 
-	var projectId, location string
-	if strings.HasPrefix(name, "projects/") {
-		projectId = parseProjectFromPath(name)
-		location = parseLocationFromPath(name)
-		name = parseResourceName(name)
-	} else {
-		projRaw := args["projectId"]
-		locRaw := args["location"]
-		if projRaw == nil || locRaw == nil {
-			return nil, nil, errors.New("vertexai custom job init: projectId and location required when name is not a full resource path")
-		}
-		projectId = projRaw.Value.(string)
-		location = locRaw.Value.(string)
+	conn, ok := runtime.Connection.(*connection.GcpConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
 
-	obj, err := CreateResource(runtime, "gcp.project.vertexaiService", map[string]*llx.RawData{
-		"projectId": llx.StringData(projectId),
-	})
+	// Accept either the full resource path or a short name + location from
+	// the asset-identifier-driven discovery path.
+	var fullName, region string
+	if strings.HasPrefix(name, "projects/") {
+		fullName = name
+		region = parseLocationFromPath(name)
+	} else {
+		locRaw := args["location"]
+		projRaw := args["projectId"]
+		if locRaw == nil || projRaw == nil {
+			return nil, nil, errors.New("vertexai custom job init: projectId and location required when name is not a full resource path")
+		}
+		region = locRaw.Value.(string)
+		fullName = fmt.Sprintf("projects/%s/locations/%s/customJobs/%s", projRaw.Value.(string), region, name)
+	}
+
+	creds, err := conn.Credentials(aiplatform.DefaultAuthScopes()...)
 	if err != nil {
 		return nil, nil, err
 	}
-	vertexaiSvc := obj.(*mqlGcpProjectVertexaiService)
-	jobs := vertexaiSvc.GetCustomJobs()
-	if jobs.Error != nil {
-		return nil, nil, jobs.Error
+	ctx := context.Background()
+	client, err := aiplatform.NewJobClient(ctx,
+		option.WithCredentials(creds),
+		option.WithEndpoint(vertexaiEndpoint(region)),
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer client.Close()
+
+	job, err := client.GetCustomJob(ctx, &aiplatformpb.GetCustomJobRequest{Name: fullName})
+	if err != nil {
+		return nil, nil, err
 	}
 
-	for _, j := range jobs.Data {
-		job := j.(*mqlGcpProjectVertexaiServiceCustomJob)
-		if parseResourceName(job.Name.Data) == name &&
-			parseLocationFromPath(job.Name.Data) == location {
-			delete(args, "location")
-			return args, job, nil
-		}
+	res, err := mqlVertexAICustomJobFromProto(runtime, job)
+	if err != nil {
+		return nil, nil, err
+	}
+	delete(args, "location")
+	return args, res, nil
+}
+
+func mqlVertexAICustomJobFromProto(runtime *plugin.Runtime, job *aiplatformpb.CustomJob) (*mqlGcpProjectVertexaiServiceCustomJob, error) {
+	jobSpec, err := protoToDict(job.JobSpec)
+	if err != nil {
+		return nil, err
+	}
+	encryptionSpec, err := protoToDict(job.EncryptionSpec)
+	if err != nil {
+		return nil, err
+	}
+	errorDict, err := protoToDict(job.Error)
+	if err != nil {
+		return nil, err
 	}
 
-	return nil, nil, fmt.Errorf("vertexai custom job %q not found", name)
+	res, err := CreateResource(runtime, "gcp.project.vertexaiService.customJob", map[string]*llx.RawData{
+		"name":           llx.StringData(job.Name),
+		"displayName":    llx.StringData(job.DisplayName),
+		"state":          llx.StringData(job.State.String()),
+		"jobSpec":        llx.DictData(jobSpec),
+		"labels":         llx.MapData(convert.MapToInterfaceMap(job.Labels), types.String),
+		"encryptionSpec": llx.DictData(encryptionSpec),
+		"error":          llx.DictData(errorDict),
+		"created":        llx.TimeDataPtr(timestampAsTimePtr(job.CreateTime)),
+		"updated":        llx.TimeDataPtr(timestampAsTimePtr(job.UpdateTime)),
+		"startTime":      llx.TimeDataPtr(timestampAsTimePtr(job.StartTime)),
+		"endTime":        llx.TimeDataPtr(timestampAsTimePtr(job.EndTime)),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectVertexaiServiceCustomJob), nil
 }
 
 func (g *mqlGcpProjectVertexaiService) customJobs() ([]any, error) {
@@ -795,32 +837,7 @@ func (g *mqlGcpProjectVertexaiService) customJobs() ([]any, error) {
 				return nil, false, err
 			}
 
-			jobSpec, err := protoToDict(job.JobSpec)
-			if err != nil {
-				return nil, false, err
-			}
-			encryptionSpec, err := protoToDict(job.EncryptionSpec)
-			if err != nil {
-				return nil, false, err
-			}
-			errorDict, err := protoToDict(job.Error)
-			if err != nil {
-				return nil, false, err
-			}
-
-			mqlJob, err := CreateResource(g.MqlRuntime, "gcp.project.vertexaiService.customJob", map[string]*llx.RawData{
-				"name":           llx.StringData(job.Name),
-				"displayName":    llx.StringData(job.DisplayName),
-				"state":          llx.StringData(job.State.String()),
-				"jobSpec":        llx.DictData(jobSpec),
-				"labels":         llx.MapData(convert.MapToInterfaceMap(job.Labels), types.String),
-				"encryptionSpec": llx.DictData(encryptionSpec),
-				"error":          llx.DictData(errorDict),
-				"created":        llx.TimeDataPtr(timestampAsTimePtr(job.CreateTime)),
-				"updated":        llx.TimeDataPtr(timestampAsTimePtr(job.UpdateTime)),
-				"startTime":      llx.TimeDataPtr(timestampAsTimePtr(job.StartTime)),
-				"endTime":        llx.TimeDataPtr(timestampAsTimePtr(job.EndTime)),
-			})
+			mqlJob, err := mqlVertexAICustomJobFromProto(g.MqlRuntime, job)
 			if err != nil {
 				return nil, false, err
 			}

--- a/providers/gcp/resources/vertexai.go
+++ b/providers/gcp/resources/vertexai.go
@@ -717,19 +717,11 @@ func initGcpProjectVertexaiServiceCustomJob(runtime *plugin.Runtime, args map[st
 	}
 	name := nameRaw.Value.(string)
 
-	conn, ok := runtime.Connection.(*connection.GcpConnection)
-	if !ok {
-		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
-	}
-
-	// Build the full resource path. The asset identifier supplies a short
-	// name plus location; a direct user call may already pass the full path.
-	fullName := name
-	projectId := conn.ResourceID()
-	region := ""
+	var projectId, location string
 	if strings.HasPrefix(name, "projects/") {
 		projectId = parseProjectFromPath(name)
-		region = parseLocationFromPath(name)
+		location = parseLocationFromPath(name)
+		name = parseResourceName(name)
 	} else {
 		projRaw := args["projectId"]
 		locRaw := args["location"]
@@ -737,60 +729,31 @@ func initGcpProjectVertexaiServiceCustomJob(runtime *plugin.Runtime, args map[st
 			return nil, nil, errors.New("vertexai custom job init: projectId and location required when name is not a full resource path")
 		}
 		projectId = projRaw.Value.(string)
-		region = locRaw.Value.(string)
-		fullName = fmt.Sprintf("projects/%s/locations/%s/customJobs/%s", projectId, region, name)
+		location = locRaw.Value.(string)
 	}
 
-	creds, err := conn.Credentials(aiplatform.DefaultAuthScopes()...)
-	if err != nil {
-		return nil, nil, err
-	}
-	ctx := context.Background()
-	client, err := aiplatform.NewJobClient(ctx,
-		option.WithCredentials(creds),
-		option.WithEndpoint(vertexaiEndpoint(region)),
-	)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer client.Close()
-
-	job, err := client.GetCustomJob(ctx, &aiplatformpb.GetCustomJobRequest{Name: fullName})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	jobSpec, err := protoToDict(job.JobSpec)
-	if err != nil {
-		return nil, nil, err
-	}
-	encryptionSpec, err := protoToDict(job.EncryptionSpec)
-	if err != nil {
-		return nil, nil, err
-	}
-	errorDict, err := protoToDict(job.Error)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	res, err := CreateResource(runtime, "gcp.project.vertexaiService.customJob", map[string]*llx.RawData{
-		"name":           llx.StringData(job.Name),
-		"displayName":    llx.StringData(job.DisplayName),
-		"state":          llx.StringData(job.State.String()),
-		"jobSpec":        llx.DictData(jobSpec),
-		"labels":         llx.MapData(convert.MapToInterfaceMap(job.Labels), types.String),
-		"encryptionSpec": llx.DictData(encryptionSpec),
-		"error":          llx.DictData(errorDict),
-		"created":        llx.TimeDataPtr(timestampAsTimePtr(job.CreateTime)),
-		"updated":        llx.TimeDataPtr(timestampAsTimePtr(job.UpdateTime)),
-		"startTime":      llx.TimeDataPtr(timestampAsTimePtr(job.StartTime)),
-		"endTime":        llx.TimeDataPtr(timestampAsTimePtr(job.EndTime)),
+	obj, err := CreateResource(runtime, "gcp.project.vertexaiService", map[string]*llx.RawData{
+		"projectId": llx.StringData(projectId),
 	})
 	if err != nil {
 		return nil, nil, err
 	}
-	delete(args, "location")
-	return args, res, nil
+	vertexaiSvc := obj.(*mqlGcpProjectVertexaiService)
+	jobs := vertexaiSvc.GetCustomJobs()
+	if jobs.Error != nil {
+		return nil, nil, jobs.Error
+	}
+
+	for _, j := range jobs.Data {
+		job := j.(*mqlGcpProjectVertexaiServiceCustomJob)
+		if parseResourceName(job.Name.Data) == name &&
+			parseLocationFromPath(job.Name.Data) == location {
+			delete(args, "location")
+			return args, job, nil
+		}
+	}
+
+	return nil, nil, fmt.Errorf("vertexai custom job %q not found", name)
 }
 
 func (g *mqlGcpProjectVertexaiService) customJobs() ([]any, error) {

--- a/providers/gcp/resources/vertexai.go
+++ b/providers/gcp/resources/vertexai.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	aiplatform "cloud.google.com/go/aiplatform/apiv1"
@@ -692,6 +693,104 @@ func (g *mqlGcpProjectVertexaiService) tensorboards() ([]any, error) {
 
 func (g *mqlGcpProjectVertexaiServiceCustomJob) id() (string, error) {
 	return g.Name.Data, g.Name.Error
+}
+
+func initGcpProjectVertexaiServiceCustomJob(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+
+	if len(args) == 0 {
+		args = make(map[string]*llx.RawData)
+		if ids := getAssetIdentifier(runtime); ids != nil {
+			args["name"] = llx.StringData(ids.name)
+			args["projectId"] = llx.StringData(ids.project)
+			args["location"] = llx.StringData(ids.region)
+		} else {
+			return nil, nil, errors.New("no asset identifier found")
+		}
+	}
+
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return args, nil, nil
+	}
+	name := nameRaw.Value.(string)
+
+	conn, ok := runtime.Connection.(*connection.GcpConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
+	}
+
+	// Build the full resource path. The asset identifier supplies a short
+	// name plus location; a direct user call may already pass the full path.
+	fullName := name
+	projectId := conn.ResourceID()
+	region := ""
+	if strings.HasPrefix(name, "projects/") {
+		projectId = parseProjectFromPath(name)
+		region = parseLocationFromPath(name)
+	} else {
+		projRaw := args["projectId"]
+		locRaw := args["location"]
+		if projRaw == nil || locRaw == nil {
+			return nil, nil, errors.New("vertexai custom job init: projectId and location required when name is not a full resource path")
+		}
+		projectId = projRaw.Value.(string)
+		region = locRaw.Value.(string)
+		fullName = fmt.Sprintf("projects/%s/locations/%s/customJobs/%s", projectId, region, name)
+	}
+
+	creds, err := conn.Credentials(aiplatform.DefaultAuthScopes()...)
+	if err != nil {
+		return nil, nil, err
+	}
+	ctx := context.Background()
+	client, err := aiplatform.NewJobClient(ctx,
+		option.WithCredentials(creds),
+		option.WithEndpoint(vertexaiEndpoint(region)),
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer client.Close()
+
+	job, err := client.GetCustomJob(ctx, &aiplatformpb.GetCustomJobRequest{Name: fullName})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	jobSpec, err := protoToDict(job.JobSpec)
+	if err != nil {
+		return nil, nil, err
+	}
+	encryptionSpec, err := protoToDict(job.EncryptionSpec)
+	if err != nil {
+		return nil, nil, err
+	}
+	errorDict, err := protoToDict(job.Error)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	res, err := CreateResource(runtime, "gcp.project.vertexaiService.customJob", map[string]*llx.RawData{
+		"name":           llx.StringData(job.Name),
+		"displayName":    llx.StringData(job.DisplayName),
+		"state":          llx.StringData(job.State.String()),
+		"jobSpec":        llx.DictData(jobSpec),
+		"labels":         llx.MapData(convert.MapToInterfaceMap(job.Labels), types.String),
+		"encryptionSpec": llx.DictData(encryptionSpec),
+		"error":          llx.DictData(errorDict),
+		"created":        llx.TimeDataPtr(timestampAsTimePtr(job.CreateTime)),
+		"updated":        llx.TimeDataPtr(timestampAsTimePtr(job.UpdateTime)),
+		"startTime":      llx.TimeDataPtr(timestampAsTimePtr(job.StartTime)),
+		"endTime":        llx.TimeDataPtr(timestampAsTimePtr(job.EndTime)),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	delete(args, "location")
+	return args, res, nil
 }
 
 func (g *mqlGcpProjectVertexaiService) customJobs() ([]any, error) {


### PR DESCRIPTION
## Summary
- Add platform discovery for four GCP resource types so they can be scanned as their own assets:
  - `gcp-memorystore-instance` (Memorystore for Valkey/Redis v2)
  - `gcp-artifactregistry-repository`
  - `gcp-memcache-instance` (Memorystore for Memcached)
  - `gcp-vertexai-job` (Vertex AI custom training jobs)
- Each platform wires up a discovery toggle (`memorystore-instances`, `artifactregistry-repositories`, `memcache-instances`, `vertexai-jobs`), a `NewResourcePlatformID` + `ResourceTechnologyUrl` mapping, and a `getAssetIdentifier`-driven `init` so the corresponding singular MQL resource resolves directly against the discovered asset.
- Existing `gcp.project.memorystoreService.instance` init now also accepts the short-name + location + projectId asset-identifier shape (in addition to the previous full resource-path form).
- The Vertex AI custom job init uses a direct `GetCustomJob` call, which adds `aiplatform.customJobs.get` to the manifest. The permission extractor's singular/plural override map is updated so the IAM permission emits the correct plural form.

## Test plan
- [x] `cd providers/gcp && go build ./...`
- [x] `cd providers/gcp && go test ./... -count=1`
- [x] `make providers/build/gcp` (regenerates `gcp.lr.go` and `gcp.permissions.json`)
- [ ] Manual smoke (against a project with each resource type):
  - `cnspec scan gcp --discover memorystore-instances`
  - `cnspec scan gcp --discover artifactregistry-repositories`
  - `cnspec scan gcp --discover memcache-instances`
  - `cnspec scan gcp --discover vertexai-jobs`
  - For each, verify the singular MQL resource (`gcp.memorystore.instance`, `gcp.artifactregistry.repository`, `gcp.memcache.instance`, `gcp.vertexai.customJob`) resolves on the discovered asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)