### PR TITLE
✨ azure: discover function-apps, application-gateways, firewalls, container-apps

### DIFF
--- a/providers/azure/resources/appcontainers.go
+++ b/providers/azure/resources/appcontainers.go
@@ -117,6 +117,57 @@ func initAzureSubscriptionContainerAppService(runtime *plugin.Runtime, args map[
 	return args, nil, nil
 }
 
+// initAzureSubscriptionContainerAppServiceContainerApp resolves a single
+// container app by its ARM resource ID so platform-discovered assets can be
+// queried directly without re-listing every container app in the
+// subscription.
+func initAzureSubscriptionContainerAppServiceContainerApp(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+
+	if len(args) == 0 {
+		if ids := getAssetIdentifier(runtime); ids != nil {
+			args["id"] = llx.StringData(ids.id)
+		}
+	}
+
+	if args["id"] == nil {
+		return args, nil, nil
+	}
+
+	conn, ok := runtime.Connection.(*connection.AzureConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
+	}
+	id, ok := args["id"].Value.(string)
+	if !ok {
+		return nil, nil, errors.New("id must be a non-nil string value")
+	}
+	resourceID, err := ParseResourceID(id)
+	if err != nil {
+		return nil, nil, err
+	}
+	appName, err := resourceID.Component("containerApps")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	client, err := apps.NewContainerAppsClient(resourceID.SubscriptionID, conn.Token(), acaClientOptions(conn))
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := client.Get(context.Background(), resourceID.ResourceGroup, appName, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	mql, err := acaContainerAppToMQL(runtime, &resp.ContainerApp)
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, mql, nil
+}
+
 // resourceGroupAndName parses an ARM resource ID and returns the resource
 // group plus the leaf component for `leafKey` (e.g. "managedEnvironments",
 // "containerApps"). Returns empty strings when the ID is malformed or the

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -672,7 +672,7 @@ func init() {
 			Create: createAzureSubscriptionNetworkServiceWatcherConnectionMonitor,
 		},
 		"azure.subscription.networkService.applicationGateway": {
-			// to override args, implement: initAzureSubscriptionNetworkServiceApplicationGateway(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAzureSubscriptionNetworkServiceApplicationGateway,
 			Create: createAzureSubscriptionNetworkServiceApplicationGateway,
 		},
 		"azure.subscription.networkService.applicationGateway.listener": {
@@ -1584,7 +1584,7 @@ func init() {
 			Create: createAzureSubscriptionFunctionsService,
 		},
 		"azure.subscription.functionsService.functionApp": {
-			// to override args, implement: initAzureSubscriptionFunctionsServiceFunctionApp(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAzureSubscriptionFunctionsServiceFunctionApp,
 			Create: createAzureSubscriptionFunctionsServiceFunctionApp,
 		},
 		"azure.subscription.functionsService.functionApp.appSetting": {
@@ -1740,7 +1740,7 @@ func init() {
 			Create: createAzureSubscriptionContainerAppServiceManagedEnvironmentCertificate,
 		},
 		"azure.subscription.containerAppService.containerApp": {
-			// to override args, implement: initAzureSubscriptionContainerAppServiceContainerApp(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAzureSubscriptionContainerAppServiceContainerApp,
 			Create: createAzureSubscriptionContainerAppServiceContainerApp,
 		},
 		"azure.subscription.containerAppService.containerApp.container": {

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
   "version": "13.13.0",
-  "generated_at": "2026-05-26T14:28:59+03:00",
+  "generated_at": "2026-05-26T20:52:17+02:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",
@@ -232,7 +232,7 @@
     {
       "permission": "Microsoft.App/containerApps/read",
       "service": "Microsoft.App",
-      "action": "NewListBySubscriptionPager",
+      "action": "Get",
       "source_file": "appcontainers.go"
     },
     {
@@ -394,7 +394,7 @@
     {
       "permission": "Microsoft.Cognitiveservices/raiTopics/read",
       "service": "Microsoft.Cognitiveservices",
-      "action": "NewListPager",
+      "action": "Get",
       "source_file": "cognitiveservices.go"
     },
     {
@@ -418,7 +418,7 @@
     {
       "permission": "Microsoft.Compute/diskEncryptionSets/read",
       "service": "Microsoft.Compute",
-      "action": "Get",
+      "action": "NewListPager",
       "source_file": "compute.go"
     },
     {
@@ -484,7 +484,7 @@
     {
       "permission": "Microsoft.Compute/virtualMachines/read",
       "service": "Microsoft.Compute",
-      "action": "NewListAllPager",
+      "action": "Get",
       "source_file": "compute.go"
     },
     {
@@ -550,7 +550,7 @@
     {
       "permission": "Microsoft.DBforMySQL/servers/configurations/read",
       "service": "Microsoft.DBforMySQL",
-      "action": "Get",
+      "action": "NewListByServerPager",
       "source_file": "mysql.go"
     },
     {
@@ -664,13 +664,13 @@
     {
       "permission": "Microsoft.DocumentDB/sQLResources/read",
       "service": "Microsoft.DocumentDB",
-      "action": "NewListSQLRoleAssignmentsPager",
+      "action": "NewListSQLRoleDefinitionsPager",
       "source_file": "cosmosdb.go"
     },
     {
       "permission": "Microsoft.DocumentDB/sQLResources/read",
       "service": "Microsoft.DocumentDB",
-      "action": "NewListSQLContainersPager",
+      "action": "NewListSQLDatabasesPager",
       "source_file": "cosmosdb_extras.go"
     },
     {
@@ -796,7 +796,7 @@
     {
       "permission": "Microsoft.Network/azureFirewalls/read",
       "service": "Microsoft.Network",
-      "action": "Get",
+      "action": "NewListAllPager",
       "source_file": "network.go"
     },
     {
@@ -862,7 +862,7 @@
     {
       "permission": "Microsoft.Network/firewallPolicies/read",
       "service": "Microsoft.Network",
-      "action": "Get",
+      "action": "NewListAllPager",
       "source_file": "network.go"
     },
     {
@@ -886,7 +886,7 @@
     {
       "permission": "Microsoft.Network/localNetworkGateways/read",
       "service": "Microsoft.Network",
-      "action": "Get",
+      "action": "NewListPager",
       "source_file": "network.go"
     },
     {
@@ -952,13 +952,13 @@
     {
       "permission": "Microsoft.Network/privateEndpoints/read",
       "service": "Microsoft.Network",
-      "action": "Get",
+      "action": "NewListBySubscriptionPager",
       "source_file": "network.go"
     },
     {
       "permission": "Microsoft.Network/privateLinkServices/read",
       "service": "Microsoft.Network",
-      "action": "NewListBySubscriptionPager",
+      "action": "NewListPrivateEndpointConnectionsPager",
       "source_file": "network.go"
     },
     {
@@ -976,7 +976,7 @@
     {
       "permission": "Microsoft.Network/publicIPAddresses/read",
       "service": "Microsoft.Network",
-      "action": "NewListAllPager",
+      "action": "Get",
       "source_file": "network.go"
     },
     {
@@ -994,13 +994,13 @@
     {
       "permission": "Microsoft.Network/vPNSites/read",
       "service": "Microsoft.Network",
-      "action": "Get",
+      "action": "NewListPager",
       "source_file": "network_expansion.go"
     },
     {
       "permission": "Microsoft.Network/virtualHubs/read",
       "service": "Microsoft.Network",
-      "action": "Get",
+      "action": "NewListPager",
       "source_file": "network_expansion.go"
     },
     {
@@ -1030,7 +1030,7 @@
     {
       "permission": "Microsoft.Network/virtualWans/read",
       "service": "Microsoft.Network",
-      "action": "NewListPager",
+      "action": "Get",
       "source_file": "network_expansion.go"
     },
     {
@@ -1054,7 +1054,7 @@
     {
       "permission": "Microsoft.OperationalInsights/workspaces/read",
       "service": "Microsoft.OperationalInsights",
-      "action": "NewListNSPPager",
+      "action": "NewListPager",
       "source_file": "loganalytics.go"
     },
     {
@@ -1102,7 +1102,7 @@
     {
       "permission": "Microsoft.RecoveryServices/vaults/read",
       "service": "Microsoft.RecoveryServices",
-      "action": "Get",
+      "action": "NewListBySubscriptionIDPager",
       "source_file": "recoveryservices.go"
     },
     {
@@ -1480,7 +1480,7 @@
     {
       "permission": "Microsoft.Web/sites/read",
       "service": "Microsoft.Web",
-      "action": "NewListPager",
+      "action": "NewListFunctionsPager",
       "source_file": "functions.go"
     },
     {

--- a/providers/azure/resources/discovery.go
+++ b/providers/azure/resources/discovery.go
@@ -54,6 +54,10 @@ const (
 	DiscoveryRecoveryServicesVaults  = "recovery-services-vaults"
 	DiscoverySynapseWorkspaces       = "synapse-workspaces"
 	DiscoveryDataFactories           = "data-factories"
+	DiscoveryFunctionApps            = "function-apps"
+	DiscoveryApplicationGateways     = "application-gateways"
+	DiscoveryFirewalls               = "firewalls"
+	DiscoveryContainerApps           = "container-apps"
 )
 
 // Auto includes all API resources except storage containers (which require
@@ -95,39 +99,68 @@ var AllAPIResources = []string{
 	DiscoveryRecoveryServicesVaults,
 	DiscoverySynapseWorkspaces,
 	DiscoveryDataFactories,
+	DiscoveryFunctionApps,
+	DiscoveryApplicationGateways,
+	DiscoveryFirewalls,
+	DiscoveryContainerApps,
 }
 
 // genericDiscoverySpec maps an ARM resource type to the discovery metadata
 // needed to build an inventory asset. Resources listed here are discovered via
 // a single armresources.Client.NewListPager call per subscription instead of
 // individual service-specific API calls.
+//
+// When multiple specs share the same `armType` (e.g. function apps and web
+// apps both live under "Microsoft.Web/sites"), `matchKind` distinguishes
+// between them based on the resource's `kind` value returned by ARM.
 type genericDiscoverySpec struct {
-	armType                string // ARM resource type, e.g. "Microsoft.Sql/servers"
-	discoveryTarget        string // discovery constant, e.g. DiscoverySqlServers
-	service                string // service label for azureObject
-	objectType             string // objectType label for azureObject
-	includeObjectTypeInUrl bool   // passed to mqlObjectToAsset
+	armType                string                 // ARM resource type, e.g. "Microsoft.Sql/servers"
+	discoveryTarget        string                 // discovery constant, e.g. DiscoverySqlServers
+	service                string                 // service label for azureObject
+	objectType             string                 // objectType label for azureObject
+	includeObjectTypeInUrl bool                   // passed to mqlObjectToAsset
+	matchKind              func(kind string) bool // optional: only match resources whose kind matches
+}
+
+// isFunctionAppKind reports whether an ARM "Microsoft.Web/sites" resource is
+// a Function App. Function app kinds are "functionapp", "functionapp,linux",
+// "functionapp,linux,container", "functionapp,workflowapp", etc.
+func isFunctionAppKind(kind string) bool {
+	return strings.Contains(strings.ToLower(kind), "functionapp")
+}
+
+// isWebAppKind reports whether an ARM "Microsoft.Web/sites" resource is a
+// regular web/API app (i.e., not a function app). Web app kinds include
+// "app", "app,linux", "api", etc. Anything containing "functionapp" is
+// routed to function-app discovery instead.
+func isWebAppKind(kind string) bool {
+	return !isFunctionAppKind(kind)
 }
 
 var genericDiscoverySpecs = []genericDiscoverySpec{
-	{"Microsoft.Sql/servers", DiscoverySqlServers, "sql", "server", false},
-	{"Microsoft.DBforMySQL/servers", DiscoveryMySqlServers, "mysql", "server", false},
-	{"Microsoft.DBforMySQL/flexibleServers", DiscoveryMySqlFlexibleServers, "mysql", "flexible-server", false},
-	{"Microsoft.DBforPostgreSQL/servers", DiscoveryPostgresServers, "postgresql", "server", false},
-	{"Microsoft.DBforPostgreSQL/flexibleServers", DiscoveryPostgresFlexibleServers, "postgresql", "flexible-server", false},
-	{"Microsoft.ContainerService/managedClusters", DiscoveryAksClusters, "aks", "cluster", false},
-	{"Microsoft.Web/sites", DiscoveryAppServiceApps, "app-service", "app", false},
-	{"Microsoft.Cache/Redis", DiscoveryCacheRedis, "cache", "redis", false},
-	{"Microsoft.Batch/batchAccounts", DiscoveryBatchAccounts, "batch", "account", false},
-	{"Microsoft.Storage/storageAccounts", DiscoveryStorageAccounts, "storage", "account", true},
-	{"Microsoft.Network/networkSecurityGroups", DiscoverySecurityGroups, "network", "security-group", true},
-	{"Microsoft.KeyVault/vaults", DiscoveryKeyVaults, "keyvault", "vault", false},
-	{"Microsoft.DocumentDB/databaseAccounts", DiscoveryCosmosDb, "cosmosdb", "account", false},
-	{"Microsoft.Network/virtualNetworks", DiscoveryVirtualNetworks, "network", "virtual-network", true},
-	{"Microsoft.ContainerRegistry/registries", DiscoveryContainerRegistries, "containerregistry", "registry", false},
-	{"Microsoft.RecoveryServices/vaults", DiscoveryRecoveryServicesVaults, "recoveryservices", "vault", false},
-	{"Microsoft.Synapse/workspaces", DiscoverySynapseWorkspaces, "synapse", "workspace", false},
-	{"Microsoft.DataFactory/factories", DiscoveryDataFactories, "datafactory", "factory", false},
+	{armType: "Microsoft.Sql/servers", discoveryTarget: DiscoverySqlServers, service: "sql", objectType: "server"},
+	{armType: "Microsoft.DBforMySQL/servers", discoveryTarget: DiscoveryMySqlServers, service: "mysql", objectType: "server"},
+	{armType: "Microsoft.DBforMySQL/flexibleServers", discoveryTarget: DiscoveryMySqlFlexibleServers, service: "mysql", objectType: "flexible-server"},
+	{armType: "Microsoft.DBforPostgreSQL/servers", discoveryTarget: DiscoveryPostgresServers, service: "postgresql", objectType: "server"},
+	{armType: "Microsoft.DBforPostgreSQL/flexibleServers", discoveryTarget: DiscoveryPostgresFlexibleServers, service: "postgresql", objectType: "flexible-server"},
+	{armType: "Microsoft.ContainerService/managedClusters", discoveryTarget: DiscoveryAksClusters, service: "aks", objectType: "cluster"},
+	// Microsoft.Web/sites is shared by web apps and function apps; disambiguate by kind.
+	{armType: "Microsoft.Web/sites", discoveryTarget: DiscoveryAppServiceApps, service: "app-service", objectType: "app", matchKind: isWebAppKind},
+	{armType: "Microsoft.Web/sites", discoveryTarget: DiscoveryFunctionApps, service: "functions", objectType: "app", matchKind: isFunctionAppKind},
+	{armType: "Microsoft.Cache/Redis", discoveryTarget: DiscoveryCacheRedis, service: "cache", objectType: "redis"},
+	{armType: "Microsoft.Batch/batchAccounts", discoveryTarget: DiscoveryBatchAccounts, service: "batch", objectType: "account"},
+	{armType: "Microsoft.Storage/storageAccounts", discoveryTarget: DiscoveryStorageAccounts, service: "storage", objectType: "account", includeObjectTypeInUrl: true},
+	{armType: "Microsoft.Network/networkSecurityGroups", discoveryTarget: DiscoverySecurityGroups, service: "network", objectType: "security-group", includeObjectTypeInUrl: true},
+	{armType: "Microsoft.Network/applicationGateways", discoveryTarget: DiscoveryApplicationGateways, service: "network", objectType: "application-gateway", includeObjectTypeInUrl: true},
+	{armType: "Microsoft.Network/azureFirewalls", discoveryTarget: DiscoveryFirewalls, service: "network", objectType: "firewall", includeObjectTypeInUrl: true},
+	{armType: "Microsoft.KeyVault/vaults", discoveryTarget: DiscoveryKeyVaults, service: "keyvault", objectType: "vault"},
+	{armType: "Microsoft.DocumentDB/databaseAccounts", discoveryTarget: DiscoveryCosmosDb, service: "cosmosdb", objectType: "account"},
+	{armType: "Microsoft.Network/virtualNetworks", discoveryTarget: DiscoveryVirtualNetworks, service: "network", objectType: "virtual-network", includeObjectTypeInUrl: true},
+	{armType: "Microsoft.ContainerRegistry/registries", discoveryTarget: DiscoveryContainerRegistries, service: "containerregistry", objectType: "registry"},
+	{armType: "Microsoft.RecoveryServices/vaults", discoveryTarget: DiscoveryRecoveryServicesVaults, service: "recoveryservices", objectType: "vault"},
+	{armType: "Microsoft.Synapse/workspaces", discoveryTarget: DiscoverySynapseWorkspaces, service: "synapse", objectType: "workspace"},
+	{armType: "Microsoft.DataFactory/factories", discoveryTarget: DiscoveryDataFactories, service: "datafactory", objectType: "factory"},
+	{armType: "Microsoft.App/containerApps", discoveryTarget: DiscoveryContainerApps, service: "containerapps", objectType: "app"},
 }
 
 type azureObject struct {
@@ -376,17 +409,25 @@ func discoverGeneric(conn *connection.AzureConnection, subsWithConfigs []subWith
 		return nil, nil
 	}
 
-	// Build OR filter: "resourceType eq 'X' or resourceType eq 'Y' or ..."
-	clauses := make([]string, len(activeSpecs))
-	for i, s := range activeSpecs {
-		clauses[i] = fmt.Sprintf("resourceType eq '%s'", s.armType)
+	// Build OR filter on the de-duplicated set of ARM types (multiple specs may
+	// share an armType when disambiguated by `kind`).
+	seenTypes := make(map[string]struct{}, len(activeSpecs))
+	clauses := make([]string, 0, len(activeSpecs))
+	for _, s := range activeSpecs {
+		key := strings.ToLower(s.armType)
+		if _, ok := seenTypes[key]; ok {
+			continue
+		}
+		seenTypes[key] = struct{}{}
+		clauses = append(clauses, fmt.Sprintf("resourceType eq '%s'", s.armType))
 	}
 	filter := strings.Join(clauses, " or ")
 
-	// Build a lookup map: lowercase ARM type → spec
-	specByType := make(map[string]genericDiscoverySpec, len(activeSpecs))
+	// Group specs by lowercase ARM type to allow kind-based dispatch.
+	specsByType := make(map[string][]genericDiscoverySpec, len(activeSpecs))
 	for _, s := range activeSpecs {
-		specByType[strings.ToLower(s.armType)] = s
+		key := strings.ToLower(s.armType)
+		specsByType[key] = append(specsByType[key], s)
 	}
 
 	var assets []*inventory.Asset
@@ -409,7 +450,8 @@ func discoverGeneric(conn *connection.AzureConnection, subsWithConfigs []subWith
 			}
 			for _, resource := range page.Value {
 				resType := strings.ToLower(derefStr(resource.Type))
-				spec, ok := specByType[resType]
+				kind := derefStr(resource.Kind)
+				spec, ok := matchSpec(specsByType[resType], kind)
 				if !ok {
 					continue
 				}
@@ -432,6 +474,17 @@ func discoverGeneric(conn *connection.AzureConnection, subsWithConfigs []subWith
 		}
 	}
 	return assets, nil
+}
+
+// matchSpec picks the first spec from the candidates list whose matchKind
+// accepts the given resource kind. Specs without a matchKind match anything.
+func matchSpec(candidates []genericDiscoverySpec, kind string) (genericDiscoverySpec, bool) {
+	for _, s := range candidates {
+		if s.matchKind == nil || s.matchKind(kind) {
+			return s, true
+		}
+	}
+	return genericDiscoverySpec{}, false
 }
 
 func derefStr(s *string) string {
@@ -653,6 +706,20 @@ func getTitleFamily(azureObject azureObject) (azureObjectPlatformInfo, error) {
 		}
 		if azureObject.objectType == "virtual-network" {
 			return azureObjectPlatformInfo{title: "Azure Virtual Network", platform: "azure-virtual-network"}, nil
+		}
+		if azureObject.objectType == "application-gateway" {
+			return azureObjectPlatformInfo{title: "Azure Application Gateway", platform: "azure-application-gateway"}, nil
+		}
+		if azureObject.objectType == "firewall" {
+			return azureObjectPlatformInfo{title: "Azure Firewall", platform: "azure-firewall"}, nil
+		}
+	case "functions":
+		if azureObject.objectType == "app" {
+			return azureObjectPlatformInfo{title: "Azure Function App", platform: "azure-function-app"}, nil
+		}
+	case "containerapps":
+		if azureObject.objectType == "app" {
+			return azureObjectPlatformInfo{title: "Azure Container App", platform: "azure-container-app"}, nil
 		}
 	case "keyvault":
 		if azureObject.objectType == "vault" {

--- a/providers/azure/resources/discovery_test.go
+++ b/providers/azure/resources/discovery_test.go
@@ -35,6 +35,10 @@ func TestAllResolvedResources(t *testing.T) {
 		DiscoveryRecoveryServicesVaults,
 		DiscoverySynapseWorkspaces,
 		DiscoveryDataFactories,
+		DiscoveryFunctionApps,
+		DiscoveryApplicationGateways,
+		DiscoveryFirewalls,
+		DiscoveryContainerApps,
 		DiscoveryStorageContainers,
 	}
 	require.ElementsMatch(t, expected, All)
@@ -62,6 +66,10 @@ func TestAutoResolvedResources(t *testing.T) {
 		DiscoveryRecoveryServicesVaults,
 		DiscoverySynapseWorkspaces,
 		DiscoveryDataFactories,
+		DiscoveryFunctionApps,
+		DiscoveryApplicationGateways,
+		DiscoveryFirewalls,
+		DiscoveryContainerApps,
 	}
 	require.ElementsMatch(t, expected, Auto)
 }

--- a/providers/azure/resources/functions.go
+++ b/providers/azure/resources/functions.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -42,6 +43,64 @@ func (a *mqlAzureSubscriptionFunctionsServiceFunctionAppFunction) id() (string, 
 	return a.Id.Data, nil
 }
 
+// initAzureSubscriptionFunctionsServiceFunctionApp resolves a single function
+// app by its ARM resource ID so platform-discovered assets can be queried
+// directly without re-listing every Microsoft.Web/sites resource in the
+// subscription.
+func initAzureSubscriptionFunctionsServiceFunctionApp(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+
+	if len(args) == 0 {
+		if ids := getAssetIdentifier(runtime); ids != nil {
+			args["id"] = llx.StringData(ids.id)
+		}
+	}
+
+	if args["id"] == nil {
+		return args, nil, nil
+	}
+
+	conn, ok := runtime.Connection.(*connection.AzureConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
+	}
+	id, ok := args["id"].Value.(string)
+	if !ok {
+		return nil, nil, errors.New("id must be a non-nil string value")
+	}
+	resourceID, err := ParseResourceID(id)
+	if err != nil {
+		return nil, nil, err
+	}
+	siteName, err := resourceID.Component("sites")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	client, err := web.NewWebAppsClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := client.Get(context.Background(), resourceID.ResourceGroup, siteName, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	site := &resp.Site
+	if site.Kind == nil || !strings.Contains(strings.ToLower(*site.Kind), "functionapp") {
+		return nil, nil, fmt.Errorf("azure resource %q is not a function app", id)
+	}
+
+	mql, err := functionAppSiteToMql(runtime, site)
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, mql, nil
+}
+
 func (a *mqlAzureSubscriptionFunctionsService) functionApps() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	ctx := context.Background()
@@ -72,53 +131,7 @@ func (a *mqlAzureSubscriptionFunctionsService) functionApps() ([]any, error) {
 				continue
 			}
 
-			properties, err := convert.JsonToDict(site.Properties)
-			if err != nil {
-				return nil, err
-			}
-
-			var state, defaultHostName, clientCertMode, managedServiceIdentityId string
-			var keyVaultReferenceIdentity string
-			var httpsOnly, clientCertEnabled bool
-			if site.Properties != nil {
-				if site.Properties.State != nil {
-					state = *site.Properties.State
-				}
-				if site.Properties.DefaultHostName != nil {
-					defaultHostName = *site.Properties.DefaultHostName
-				}
-				if site.Properties.HTTPSOnly != nil {
-					httpsOnly = *site.Properties.HTTPSOnly
-				}
-				if site.Properties.ClientCertEnabled != nil {
-					clientCertEnabled = *site.Properties.ClientCertEnabled
-				}
-				if site.Properties.ClientCertMode != nil {
-					clientCertMode = string(*site.Properties.ClientCertMode)
-				}
-				if site.Properties.KeyVaultReferenceIdentity != nil {
-					keyVaultReferenceIdentity = *site.Properties.KeyVaultReferenceIdentity
-				}
-			}
-			if site.Identity != nil && site.Identity.PrincipalID != nil {
-				managedServiceIdentityId = *site.Identity.PrincipalID
-			}
-
-			mqlApp, err := CreateResource(a.MqlRuntime, "azure.subscription.functionsService.functionApp", map[string]*llx.RawData{
-				"id":                        llx.StringDataPtr(site.ID),
-				"name":                      llx.StringDataPtr(site.Name),
-				"location":                  llx.StringDataPtr(site.Location),
-				"tags":                      llx.MapData(convert.PtrMapStrToInterface(site.Tags), types.String),
-				"kind":                      llx.StringDataPtr(site.Kind),
-				"state":                     llx.StringData(state),
-				"defaultHostName":           llx.StringData(defaultHostName),
-				"httpsOnly":                 llx.BoolData(httpsOnly),
-				"clientCertEnabled":         llx.BoolData(clientCertEnabled),
-				"clientCertMode":            llx.StringData(clientCertMode),
-				"managedServiceIdentityId":  llx.StringData(managedServiceIdentityId),
-				"keyVaultReferenceIdentity": llx.StringData(keyVaultReferenceIdentity),
-				"properties":                llx.DictData(properties),
-			})
+			mqlApp, err := functionAppSiteToMql(a.MqlRuntime, site)
 			if err != nil {
 				return nil, err
 			}
@@ -127,6 +140,59 @@ func (a *mqlAzureSubscriptionFunctionsService) functionApps() ([]any, error) {
 	}
 
 	return res, nil
+}
+
+// functionAppSiteToMql converts a Web App ARM site (already known to be a
+// function app) into the matching MQL resource. Shared by the list path and
+// the init lookup so both produce identical fields.
+func functionAppSiteToMql(runtime *plugin.Runtime, site *web.Site) (plugin.Resource, error) {
+	properties, err := convert.JsonToDict(site.Properties)
+	if err != nil {
+		return nil, err
+	}
+
+	var state, defaultHostName, clientCertMode, managedServiceIdentityId string
+	var keyVaultReferenceIdentity string
+	var httpsOnly, clientCertEnabled bool
+	if site.Properties != nil {
+		if site.Properties.State != nil {
+			state = *site.Properties.State
+		}
+		if site.Properties.DefaultHostName != nil {
+			defaultHostName = *site.Properties.DefaultHostName
+		}
+		if site.Properties.HTTPSOnly != nil {
+			httpsOnly = *site.Properties.HTTPSOnly
+		}
+		if site.Properties.ClientCertEnabled != nil {
+			clientCertEnabled = *site.Properties.ClientCertEnabled
+		}
+		if site.Properties.ClientCertMode != nil {
+			clientCertMode = string(*site.Properties.ClientCertMode)
+		}
+		if site.Properties.KeyVaultReferenceIdentity != nil {
+			keyVaultReferenceIdentity = *site.Properties.KeyVaultReferenceIdentity
+		}
+	}
+	if site.Identity != nil && site.Identity.PrincipalID != nil {
+		managedServiceIdentityId = *site.Identity.PrincipalID
+	}
+
+	return CreateResource(runtime, "azure.subscription.functionsService.functionApp", map[string]*llx.RawData{
+		"id":                        llx.StringDataPtr(site.ID),
+		"name":                      llx.StringDataPtr(site.Name),
+		"location":                  llx.StringDataPtr(site.Location),
+		"tags":                      llx.MapData(convert.PtrMapStrToInterface(site.Tags), types.String),
+		"kind":                      llx.StringDataPtr(site.Kind),
+		"state":                     llx.StringData(state),
+		"defaultHostName":           llx.StringData(defaultHostName),
+		"httpsOnly":                 llx.BoolData(httpsOnly),
+		"clientCertEnabled":         llx.BoolData(clientCertEnabled),
+		"clientCertMode":            llx.StringData(clientCertMode),
+		"managedServiceIdentityId":  llx.StringData(managedServiceIdentityId),
+		"keyVaultReferenceIdentity": llx.StringData(keyVaultReferenceIdentity),
+		"properties":                llx.DictData(properties),
+	})
 }
 
 func (a *mqlAzureSubscriptionFunctionsServiceFunctionApp) functions() ([]any, error) {

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -4727,3 +4727,55 @@ func initAzureSubscriptionNetworkServiceLocalNetworkGateway(runtime *plugin.Runt
 	}
 	return args, mqlLng, nil
 }
+
+// initAzureSubscriptionNetworkServiceApplicationGateway resolves a single
+// application gateway by its ARM resource ID so platform-discovered assets
+// can be queried directly without re-listing every gateway in the
+// subscription.
+func initAzureSubscriptionNetworkServiceApplicationGateway(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+
+	if len(args) == 0 {
+		if ids := getAssetIdentifier(runtime); ids != nil {
+			args["id"] = llx.StringData(ids.id)
+		}
+	}
+
+	if args["id"] == nil {
+		return args, nil, nil
+	}
+
+	conn, ok := runtime.Connection.(*connection.AzureConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
+	}
+	id, ok := args["id"].Value.(string)
+	if !ok {
+		return nil, nil, errors.New("id must be a non-nil string value")
+	}
+	azureId, err := ParseResourceID(id)
+	if err != nil {
+		return nil, nil, err
+	}
+	name, err := azureId.Component("applicationGateways")
+	if err != nil {
+		return nil, nil, err
+	}
+	client, err := network.NewApplicationGatewaysClient(azureId.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := client.Get(context.Background(), azureId.ResourceGroup, name, &network.ApplicationGatewaysClientGetOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+	mql, err := azureAppGatewayToMql(runtime, resp.ApplicationGateway)
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, mql, nil
+}

--- a/providers/azure/resources/network_expansion.go
+++ b/providers/azure/resources/network_expansion.go
@@ -767,10 +767,16 @@ func (a *mqlAzureSubscriptionNetworkServiceVirtualHubVnetConnection) remoteVirtu
 	return res.(*mqlAzureSubscriptionNetworkServiceVirtualNetwork), nil
 }
 
-// init for firewall so virtualHub.azureFirewall() typed ref can resolve
+// init for firewall so virtualHub.azureFirewall() typed ref can resolve, and
+// so platform-discovered azure-firewall assets can be queried directly.
 func initAzureSubscriptionNetworkServiceFirewall(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 1 {
 		return args, nil, nil
+	}
+	if len(args) == 0 {
+		if ids := getAssetIdentifier(runtime); ids != nil {
+			args["id"] = llx.StringData(ids.id)
+		}
 	}
 	if args["id"] == nil {
 		return args, nil, nil
@@ -779,7 +785,10 @@ func initAzureSubscriptionNetworkServiceFirewall(runtime *plugin.Runtime, args m
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
 	}
-	id := args["id"].Value.(string)
+	id, ok := args["id"].Value.(string)
+	if !ok {
+		return nil, nil, errors.New("id must be a non-nil string value")
+	}
 	azureId, err := ParseResourceID(id)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
## Summary

- Adds platform discovery for four Azure resource types so they show up as first-class assets and can be scanned individually:
  - `azure-function-app` (`Microsoft.Web/sites` with `kind=functionapp*`)
  - `azure-application-gateway` (`Microsoft.Network/applicationGateways`)
  - `azure-firewall` (`Microsoft.Network/azureFirewalls`)
  - `azure-container-app` (`Microsoft.App/containerApps`)
- Function apps share `Microsoft.Web/sites` with web apps; `genericDiscoverySpec` gains an optional `matchKind` predicate so function apps route to the new platform while regular web apps continue to map to `azure-app-service-webapp`.
- Adds `init` functions for the four singular MQL resources so a discovered asset's id resolves directly via the corresponding ARM `Get`, instead of forcing a full subscription-wide list:
  - `azure.subscription.functionsService.functionApp`
  - `azure.subscription.networkService.applicationGateway`
  - `azure.subscription.networkService.firewall` (existing init, extended to honor the discovered asset's PlatformId)
  - `azure.subscription.containerAppService.containerApp`
- The existing function-app listing is refactored onto a shared `functionAppSiteToMql` helper so list and init produce identical resources.

## Test plan

- [x] `go test ./resources/...` in `providers/azure` (full provider tests pass)
- [x] `make providers/build/azure` clean
- [x] `mql discover azure --discover function-apps,application-gateways,firewalls,container-apps` runs cleanly against an empty subscription
- [ ] Verify discovery surfaces real assets and singular MQL queries work against them once an environment with these resources is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)