### PR TITLE
⚡ ci: parallelize core mql and provider tests in go-test job

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -125,13 +125,45 @@ jobs:
       - name: Test mql
         run: make test/go/plain-ci
 
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: success() || failure() # run this step even if previous step failed
+        with:
+          name: test-results
+          path: "*.xml"
+
+  go-test-providers:
+    runs-on:
+      group: Default
+    timeout-minutes: 120
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Import environment variables from file
+        run: cat ".github/env" >> $GITHUB_ENV
+
+      - name: Install Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ">=${{ env.golang-version }}"
+          check-latest: true
+          cache: false
+
+      - name: "Set up gcloud CLI"
+        uses: "google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db" # v3.0.1
+
+      - name: Set provider env
+        run: echo "PROVIDERS_PATH=${PWD}/.providers" >> $GITHUB_ENV
+      - name: Display Provider Path
+        run: echo $PROVIDERS_PATH
+
       - name: Test Providers
         run: make providers/test
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success() || failure() # run this step even if previous step failed
         with:
-          name: test-results
+          name: test-results-providers
           path: "*.xml"
 
   go-test-integration:
@@ -190,7 +222,7 @@ jobs:
 
   go-auto-approve:
     runs-on: ubuntu-latest
-    needs: [golangci-lint, golangci-lint-providers, go-test, go-test-integration, go-mod]
+    needs: [golangci-lint, golangci-lint-providers, go-test, go-test-providers, go-test-integration, go-mod]
     # For now, we only auto approve and merge provider release PRs created by mondoo-tools.
     # We use github.actor (the authenticated GitHub user who pushed) instead of
     # github.event.commits[0].author.username (the git commit author) because git commit

--- a/Makefile
+++ b/Makefile
@@ -403,7 +403,7 @@ test/go: mql/generate test/generate test/go/plain
 test/go/plain:
 	go test -cover $(shell go list ./... | grep -v '/providers/' | grep -v '/test/')
 
-test/go/plain-ci: prep/tools test/generate providers/build
+test/go/plain-ci: prep/tools test/generate
 	gotestsum --junitfile report.xml --format pkgname -- -cover $(shell go list ./... | grep -v '/vendor/' | grep -v '/providers/' | grep -v '/test/')
 
 test/integration:


### PR DESCRIPTION
## Summary
- Splits the `go-test` job in `pr-test-lint.yml` into two parallel jobs: `go-test` (core mql) and a new `go-test-providers` (`make providers/test`).
- Drops the `providers/build` Makefile dep from `test/go/plain-ci` — the core mql test list explicitly excludes `/providers/`, the test runtime calls `providers.Coordinator.DeactivateProviderDiscovery()`, and the only generated code core tests need (`core.lr.go`, `mockprovider.lr.go`) is checked in. Building all ~50 provider binaries was wasted work.
- Updates `go-auto-approve` to wait on the new job. The new job uploads its JUnit XML under `test-results-providers` so `test-report.yml`'s `artifacts/**/*.xml` glob picks both artifacts up without colliding.

Today's single job serializes provider-build (~10 min) + core tests (~10 min) + provider tests (~25 min). After the split, core ≈ 10 min and providers ≈ 25 min run in parallel — wall clock drops from ~45 min to ~25 min.

## Test plan
- [ ] CI green on this PR
- [ ] `test-report.yml` ingests JUnit XML from both `test-results` and `test-results-providers` artifacts
- [ ] `go-auto-approve` correctly waits on `go-test-providers` (verified by needs-list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)