### PR TITLE
🎉 aws-13.28.0, gcp-13.18.0, azure-13.14.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.27.1",
+	Version:         "13.28.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "azure",
 	ID:      "go.mondoo.com/cnquery/v9/providers/azure",
-	Version: "13.13.0",
+	Version: "13.14.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(azureinstancesnapshot.SnapshotConnectionType),

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.17.0",
+	Version: "13.18.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
Minor version bump for the **aws**, **gcp**, and **azure** providers.

## Changelog

### aws — 13.27.1 → 13.28.0
- ✨ Discover SageMaker jobs, MSK, MQ, ECS task definitions, Route53, and ECR repos (#7982)
- ⚡ Cut API calls in init/N+1 hot paths (#7971)

### gcp — 13.17.0 → 13.18.0
- ⚡ Dedupe org IAM fetch and add missing pagination (#7968)

### azure — 13.13.0 → 13.14.0
- ✨ Discover function-apps, application-gateways, firewalls, and container-apps (#7981)
- ⚡ Reduce per-resource API calls across hot paths (#7972)

🤖 Generated with [Claude Code](https://claude.com/claude-code)