### PR TITLE
✨ azure: add attack-path graphs to Defender assessments

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -6300,6 +6300,13 @@ private azure.subscription.cloudDefenderService.assessment @defaults("displayNam
   // References into the Defender attack-path graph; the same paths are
   // surfaced in the Microsoft Defender for Cloud portal.
   riskAttackPathReferences []string
+  // Attack-path graphs the finding contributes to
+  //
+  // Each entry is one attack path with shape `{id, nodes, edges}`: `nodes`
+  // are `{id, labels}` (the resources along the path) and `edges` are
+  // `{id, sourceId, targetId}` (the directed connections between nodes).
+  // Populated only when the subscription has a Defender CSPM plan enabled.
+  riskAttackPaths []dict
   // Whether the risk is contextual rather than static
   riskIsContextual bool
   // Origin of the assessment definition

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -9110,6 +9110,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.cloudDefenderService.assessment.riskAttackPathReferences": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderServiceAssessment).GetRiskAttackPathReferences()).ToDataRes(types.Array(types.String))
 	},
+	"azure.subscription.cloudDefenderService.assessment.riskAttackPaths": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderServiceAssessment).GetRiskAttackPaths()).ToDataRes(types.Array(types.Dict))
+	},
 	"azure.subscription.cloudDefenderService.assessment.riskIsContextual": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderServiceAssessment).GetRiskIsContextual()).ToDataRes(types.Bool)
 	},
@@ -24128,6 +24131,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.cloudDefenderService.assessment.riskAttackPathReferences": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCloudDefenderServiceAssessment).RiskAttackPathReferences, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.assessment.riskAttackPaths": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderServiceAssessment).RiskAttackPaths, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cloudDefenderService.assessment.riskIsContextual": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -55876,6 +55883,7 @@ type mqlAzureSubscriptionCloudDefenderServiceAssessment struct {
 	RiskLevel                plugin.TValue[string]
 	RiskFactors              plugin.TValue[[]any]
 	RiskAttackPathReferences plugin.TValue[[]any]
+	RiskAttackPaths          plugin.TValue[[]any]
 	RiskIsContextual         plugin.TValue[bool]
 	AssessmentType           plugin.TValue[string]
 	Categories               plugin.TValue[[]any]
@@ -55972,6 +55980,10 @@ func (c *mqlAzureSubscriptionCloudDefenderServiceAssessment) GetRiskFactors() *p
 
 func (c *mqlAzureSubscriptionCloudDefenderServiceAssessment) GetRiskAttackPathReferences() *plugin.TValue[[]any] {
 	return &c.RiskAttackPathReferences
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderServiceAssessment) GetRiskAttackPaths() *plugin.TValue[[]any] {
+	return &c.RiskAttackPaths
 }
 
 func (c *mqlAzureSubscriptionCloudDefenderServiceAssessment) GetRiskIsContextual() *plugin.TValue[bool] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -388,6 +388,7 @@ azure.subscription.cloudDefenderService.assessment.preview 13.14.1
 azure.subscription.cloudDefenderService.assessment.remediationDescription 13.14.1
 azure.subscription.cloudDefenderService.assessment.resourceId 13.11.3
 azure.subscription.cloudDefenderService.assessment.riskAttackPathReferences 13.14.1
+azure.subscription.cloudDefenderService.assessment.riskAttackPaths 13.14.1
 azure.subscription.cloudDefenderService.assessment.riskFactors 13.14.1
 azure.subscription.cloudDefenderService.assessment.riskIsContextual 13.14.1
 azure.subscription.cloudDefenderService.assessment.riskLevel 13.14.1

--- a/providers/azure/resources/cloud_defender.go
+++ b/providers/azure/resources/cloud_defender.go
@@ -1253,6 +1253,45 @@ func enumSliceToInterface[T ~string](in []*T) []any {
 	return out
 }
 
+// assessmentAttackPaths converts the Defender risk attack-path graph into a
+// slice of {id, nodes, edges} dicts. Each node is {id, labels} and each edge
+// is {id, sourceId, targetId}.
+func assessmentAttackPaths(paths []*armsecurity.AssessmentPropertiesBaseRiskPathsItem) []any {
+	out := make([]any, 0, len(paths))
+	for _, p := range paths {
+		if p == nil {
+			continue
+		}
+		nodes := make([]any, 0, len(p.Nodes))
+		for _, n := range p.Nodes {
+			if n == nil {
+				continue
+			}
+			nodes = append(nodes, map[string]any{
+				"id":     convert.ToValue(n.ID),
+				"labels": enumSliceToInterface(n.NodePropertiesLabel),
+			})
+		}
+		edges := make([]any, 0, len(p.Edges))
+		for _, e := range p.Edges {
+			if e == nil {
+				continue
+			}
+			edges = append(edges, map[string]any{
+				"id":       convert.ToValue(e.ID),
+				"sourceId": convert.ToValue(e.SourceID),
+				"targetId": convert.ToValue(e.TargetID),
+			})
+		}
+		out = append(out, map[string]any{
+			"id":    convert.ToValue(p.ID),
+			"nodes": nodes,
+			"edges": edges,
+		})
+	}
+	return out
+}
+
 // assessmentMetadataByName returns a map of assessment name to its catalog
 // metadata. Assessment list responses don't carry this metadata, so it is
 // joined in from the metadata catalog: built-in definitions come from the
@@ -1338,6 +1377,7 @@ func (a *mqlAzureSubscriptionCloudDefenderService) assessments() ([]any, error) 
 			var riskLevel string
 			var riskIsContextual bool
 			riskFactors := []any{}
+			riskAttackPathRefs := []any{}
 			riskAttackPaths := []any{}
 
 			if props := item.Properties; props != nil {
@@ -1364,7 +1404,8 @@ func (a *mqlAzureSubscriptionCloudDefenderService) assessments() ([]any, error) 
 					riskLevel = string(convert.ToValue(risk.Level))
 					riskIsContextual = convert.ToValue(risk.IsContextualRisk)
 					riskFactors = enumSliceToInterface(risk.RiskFactors)
-					riskAttackPaths = enumSliceToInterface(risk.AttackPathsReferences)
+					riskAttackPathRefs = enumSliceToInterface(risk.AttackPathsReferences)
+					riskAttackPaths = assessmentAttackPaths(risk.Paths)
 				}
 			}
 
@@ -1397,7 +1438,8 @@ func (a *mqlAzureSubscriptionCloudDefenderService) assessments() ([]any, error) 
 					"additionalData":           llx.DictData(additionalData),
 					"riskLevel":                llx.StringData(riskLevel),
 					"riskFactors":              llx.ArrayData(riskFactors, types.String),
-					"riskAttackPathReferences": llx.ArrayData(riskAttackPaths, types.String),
+					"riskAttackPathReferences": llx.ArrayData(riskAttackPathRefs, types.String),
+					"riskAttackPaths":          llx.ArrayData(riskAttackPaths, types.Dict),
 					"riskIsContextual":         llx.BoolData(riskIsContextual),
 					"assessmentType":           llx.StringData(meta.assessmentType),
 					"categories":               llx.ArrayData(meta.categories, types.String),


### PR DESCRIPTION
## What

Adds `riskAttackPaths []dict` to `azure.subscription.cloudDefenderService.assessment` — the Defender CSPM attack-path graph deferred from the initial risk-fields work (#7988).

Each entry is one attack path:
```
{ id, nodes: [{ id, labels }], edges: [{ id, sourceId, targetId }] }
```
- **nodes** — the resources along the path (`labels` describes each)
- **edges** — the directed connections between nodes

Example:
```mql
azure.subscription.cloudDefender.assessments.where(riskLevel == "Critical") {
  displayName
  riskAttackPaths { id nodes edges }
}
```

## Implementation

No new API calls — the graph already arrives in the assessment list response via `Risk.Paths`. A small `assessmentAttackPaths` helper converts the SDK structs to dicts, nil-safe at every level.

Modeled as `[]dict` rather than a sub-resource (per the sub-resource bar): an attack path has no stable standalone identifier (its `id` is unique only *within* the assessment → would need a synthetic composite key), and its nodes/edges aren't modeled resources. Populated only when the subscription has a Defender CSPM plan enabled; empty otherwise.

The previously misnamed `riskAttackPaths` variable (which held `AttackPathsReferences`) is renamed to `riskAttackPathRefs` to free the name for the graph.

## Verification

- `./mqlr generate` — clean (1 new field at `13.14.1`)
- `go build ./...` / `go vet ./...` — clean
- `go test ./resources/...` — pass
- `gofmt -l` — clean

⚠️ Not yet run against a live subscription — recommend smoke-testing `riskAttackPaths` on a Defender-CSPM-enabled subscription (to confirm graph population) and one without (graceful empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)