### PR TITLE
🧹 permissions: make GCP/Azure manifest dedup deterministic

### DIFF
--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -103,12 +103,24 @@ func main() {
 	}
 	sort.Strings(orgPermissions)
 
-	// Sort details for stable output
+	// Sort details for stable output. Permission + source file are the dedup
+	// key; Action and Scope are included as tiebreakers so that when the same
+	// permission is derived from multiple call sites in one file (e.g. both
+	// Folders.Search and Folders.List map to resourcemanager.folders.list), the
+	// detail that survives deduplication is deterministic rather than dependent
+	// on the unstable sort order — otherwise unrelated `action` churn appears in
+	// the manifest every time entries are added.
 	sort.Slice(details, func(i, j int) bool {
 		if details[i].Permission != details[j].Permission {
 			return details[i].Permission < details[j].Permission
 		}
-		return details[i].SourceFile < details[j].SourceFile
+		if details[i].SourceFile != details[j].SourceFile {
+			return details[i].SourceFile < details[j].SourceFile
+		}
+		if details[i].Action != details[j].Action {
+			return details[i].Action < details[j].Action
+		}
+		return details[i].Scope < details[j].Scope
 	})
 
 	// Deduplicate details (same permission + source file)

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
   "version": "13.14.0",
-  "generated_at": "2026-05-26T16:21:16-07:00",
+  "generated_at": "2026-05-26T17:08:46-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",
@@ -419,7 +419,7 @@
     {
       "permission": "Microsoft.Compute/diskEncryptionSets/read",
       "service": "Microsoft.Compute",
-      "action": "NewListPager",
+      "action": "Get",
       "source_file": "compute.go"
     },
     {
@@ -485,7 +485,7 @@
     {
       "permission": "Microsoft.Compute/virtualMachines/read",
       "service": "Microsoft.Compute",
-      "action": "NewListAllPager",
+      "action": "Get",
       "source_file": "compute.go"
     },
     {
@@ -509,7 +509,7 @@
     {
       "permission": "Microsoft.ContainerRegistry/registries/credentialSets/read",
       "service": "Microsoft.ContainerRegistry",
-      "action": "NewListPager",
+      "action": "Get",
       "source_file": "containerregistry.go"
     },
     {
@@ -521,7 +521,7 @@
     {
       "permission": "Microsoft.ContainerRegistry/registries/scopeMaps/read",
       "service": "Microsoft.ContainerRegistry",
-      "action": "NewListPager",
+      "action": "Get",
       "source_file": "containerregistry.go"
     },
     {
@@ -551,7 +551,7 @@
     {
       "permission": "Microsoft.DBforMySQL/servers/configurations/read",
       "service": "Microsoft.DBforMySQL",
-      "action": "NewListByServerPager",
+      "action": "Get",
       "source_file": "mysql.go"
     },
     {
@@ -611,7 +611,7 @@
     {
       "permission": "Microsoft.DBforPostgreSQL/servers/read",
       "service": "Microsoft.DBforPostgreSQL",
-      "action": "NewListPager",
+      "action": "NewListBySubscriptionPager",
       "source_file": "postgresql.go"
     },
     {
@@ -665,13 +665,13 @@
     {
       "permission": "Microsoft.DocumentDB/sQLResources/read",
       "service": "Microsoft.DocumentDB",
-      "action": "NewListSQLRoleDefinitionsPager",
+      "action": "NewListSQLRoleAssignmentsPager",
       "source_file": "cosmosdb.go"
     },
     {
       "permission": "Microsoft.DocumentDB/sQLResources/read",
       "service": "Microsoft.DocumentDB",
-      "action": "NewListSQLDatabasesPager",
+      "action": "NewListSQLContainersPager",
       "source_file": "cosmosdb_extras.go"
     },
     {
@@ -731,7 +731,7 @@
     {
       "permission": "Microsoft.Insights/components/read",
       "service": "Microsoft.Insights",
-      "action": "NewListPager",
+      "action": "Get",
       "source_file": "monitor.go"
     },
     {
@@ -827,7 +827,7 @@
     {
       "permission": "Microsoft.Network/connections/read",
       "service": "Microsoft.Network",
-      "action": "NewListPager",
+      "action": "Get",
       "source_file": "network.go"
     },
     {
@@ -893,7 +893,7 @@
     {
       "permission": "Microsoft.Network/localNetworkGateways/read",
       "service": "Microsoft.Network",
-      "action": "NewListPager",
+      "action": "Get",
       "source_file": "network.go"
     },
     {
@@ -965,7 +965,7 @@
     {
       "permission": "Microsoft.Network/privateLinkServices/read",
       "service": "Microsoft.Network",
-      "action": "NewListPrivateEndpointConnectionsPager",
+      "action": "Get",
       "source_file": "network.go"
     },
     {
@@ -1001,13 +1001,13 @@
     {
       "permission": "Microsoft.Network/vPNSites/read",
       "service": "Microsoft.Network",
-      "action": "NewListPager",
+      "action": "Get",
       "source_file": "network_expansion.go"
     },
     {
       "permission": "Microsoft.Network/virtualHubs/read",
       "service": "Microsoft.Network",
-      "action": "NewListPager",
+      "action": "Get",
       "source_file": "network_expansion.go"
     },
     {
@@ -1019,7 +1019,7 @@
     {
       "permission": "Microsoft.Network/virtualNetworks/read",
       "service": "Microsoft.Network",
-      "action": "NewListAllPager",
+      "action": "Get",
       "source_file": "network.go"
     },
     {
@@ -1061,7 +1061,7 @@
     {
       "permission": "Microsoft.OperationalInsights/workspaces/read",
       "service": "Microsoft.OperationalInsights",
-      "action": "NewListNSPPager",
+      "action": "Get",
       "source_file": "loganalytics.go"
     },
     {
@@ -1109,7 +1109,7 @@
     {
       "permission": "Microsoft.RecoveryServices/vaults/read",
       "service": "Microsoft.RecoveryServices",
-      "action": "NewListBySubscriptionIDPager",
+      "action": "Get",
       "source_file": "recoveryservices.go"
     },
     {
@@ -1391,7 +1391,7 @@
     {
       "permission": "Microsoft.Storage/storageAccounts/blobServices/containers/read",
       "service": "Microsoft.Storage",
-      "action": "NewListPager",
+      "action": "Get",
       "source_file": "storage.go"
     },
     {
@@ -1493,7 +1493,7 @@
     {
       "permission": "Microsoft.Web/sites/read",
       "service": "Microsoft.Web",
-      "action": "NewListPager",
+      "action": "NewListFunctionsPager",
       "source_file": "web.go"
     },
     {

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
   "version": "13.18.0",
-  "generated_at": "2026-05-26T16:47:35-07:00",
+  "generated_at": "2026-05-26T17:08:46-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.customJobs.get",
@@ -1505,7 +1505,7 @@
     {
       "permission": "resourcemanager.folders.list",
       "service": "resourcemanager",
-      "action": "Folders.Search",
+      "action": "Folders.List",
       "source_file": "folder.go",
       "scope": "org"
     },


### PR DESCRIPTION
## Summary

The GCP/Azure permission extractor (`providers-sdk/v1/util/permissions`) sorts the detail list by `(permission, sourceFile)` and then deduplicates by that same key, keeping the first detail of each group. When a single permission is derived from **multiple call sites in the same file**, the surviving detail's `action` hint depended on Go's *unstable* `sort.Slice` order — so adding any unrelated entry could reshuffle which one wins, producing spurious `action` churn in the committed manifest on essentially every GCP/Azure PR.

Examples of colliding call sites:
- GCP `folder.go`: `Folders.Search` and `Folders.List` both → `resourcemanager.folders.list`
- Azure: many `NewList*Pager` calls collapse to one `*.read`/`*.action` permission

This was flagged in review on #7993 (the `Folders.Search` ↔ `Folders.List` flip).

## Fix

Add `Action` and `Scope` as final tiebreakers in the sort comparator so the deduplicated detail is deterministic (alphabetically-first `action`).

## Impact

- **No permission strings change** — the AWS/GCP/Azure permission *sets* are byte-for-byte identical (AWS manifest unchanged entirely).
- Only the regenerated `action` metadata hints stabilize: GCP 1 line (`Folders`), Azure ~19 lines (`NewList*Pager` → fixed value).
- `go vet` clean; `TestGCPPermissions` passes (validates permission strings, unaffected).

After this lands, GCP/Azure feature PRs will no longer carry unrelated `action` churn in their manifest diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)