### PR TITLE
🎉 os-13.20.0

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.19.0",
+	Version: "13.20.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### os (13.20.0)
- ✨ os: add sudo resource for sudo binary metadata (#7985)
- ✨ os: add haproxy.config — parse haproxy.cfg with typed sections, binds & servers (#7915)
- ✨ os: scan Python source manifests for dependency detection (#7965)
- os: detect Ollama model license from manifest layer (#7969)
- ✨ os: add nfs resource for exports and client mounts (#7956)
- ✨ os: iptables-save parser + structured rule fields (dport, comment, …) (#7961)