### PR TITLE
✨ os: add kernel.module.onDisk and builtIn to detect present-but-not-loaded modules

### DIFF
--- a/providers/os/resources/kernel.go
+++ b/providers/os/resources/kernel.go
@@ -40,6 +40,16 @@ type mqlKernelInternal struct {
 	modprobeOnce  sync.Once
 	modprobeRules map[string]modprobeRule
 	modprobeErr   error
+
+	// module-index cache. modules.dep (loadable .ko files) and
+	// modules.builtin (features compiled into the kernel) for the running
+	// kernel are read once per query via loadModuleIndex, so every
+	// kernel.module.onDisk / .builtIn accessor shares a single read of
+	// those two index files.
+	moduleIndexOnce sync.Once
+	moduleOnDisk    map[string]bool
+	moduleBuiltIn   map[string]bool
+	moduleIndexErr  error
 }
 
 type KernelVersion struct {

--- a/providers/os/resources/kernel_internal_test.go
+++ b/providers/os/resources/kernel_internal_test.go
@@ -377,3 +377,162 @@ func TestSuseKernelMatchesRunning(t *testing.T) {
 		})
 	}
 }
+
+// TestModuleNameFromPath locks down the extraction of a bare module name
+// from the path entries found in modules.dep and modules.builtin. The tricky
+// parts are the compression suffixes that modern kernels apply to .ko files
+// (.xz / .zst / .gz) and the dash↔underscore normalization the kernel applies
+// to module names.
+func TestModuleNameFromPath(t *testing.T) {
+	cases := []struct {
+		in  string
+		out string
+	}{
+		{"kernel/net/netfilter/nf_conntrack.ko", "nf_conntrack"},
+		{"kernel/fs/cramfs/cramfs.ko.xz", "cramfs"},
+		{"kernel/fs/squashfs/squashfs.ko.zst", "squashfs"},
+		{"kernel/drivers/usb/storage/usb-storage.ko.gz", "usb_storage"},
+		// leading/trailing whitespace (modules.dep keeps the colon on the LHS,
+		// which the caller strips, but tabs around builtin entries appear too)
+		{"\tkernel/fs/ext4/ext4.ko\t", "ext4"},
+		{"snd-hda-intel.ko", "snd_hda_intel"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, tc.out, moduleNameFromPath(tc.in))
+		})
+	}
+}
+
+// TestNormalizeModuleName confirms dashes collapse to underscores so a lookup
+// by either spelling resolves the same module (the kernel treats them as
+// equivalent and lsmod always reports underscores).
+func TestNormalizeModuleName(t *testing.T) {
+	assert.Equal(t, "usb_storage", normalizeModuleName("usb-storage"))
+	assert.Equal(t, "usb_storage", normalizeModuleName("usb_storage"))
+	assert.Equal(t, "nf_conntrack", normalizeModuleName("nf_conntrack"))
+	assert.Equal(t, "", normalizeModuleName(""))
+}
+
+// TestParseModulesDep locks down the modules.dep parser behind
+// kernel.module.onDisk. Real Debian/Ubuntu indexes compress modules
+// (.ko.zst / .ko.xz), list each loadable module as the left-hand side of a
+// "module: deps" line, and may carry hundreds of dependency paths on the
+// right that must NOT be treated as separately installed modules unless they
+// appear as their own left-hand entry.
+func TestParseModulesDep(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		present []string // expected onDisk
+		absent  []string // expected NOT onDisk
+	}{
+		{
+			name:    "single module, no deps, trailing colon",
+			content: "kernel/fs/overlayfs/overlay.ko.zst:",
+			present: []string{"overlay"},
+		},
+		{
+			name: "module with deps records only the left-hand side",
+			content: "kernel/net/netfilter/nf_conntrack.ko: " +
+				"kernel/net/netfilter/nf_defrag_ipv4.ko kernel/lib/libcrc32c.ko",
+			present: []string{"nf_conntrack"},
+			// deps on the RHS are not independently installed unless they
+			// also appear as their own left-hand entry.
+			absent: []string{"nf_defrag_ipv4", "libcrc32c"},
+		},
+		{
+			name: "dep that also has its own line is present",
+			content: "kernel/net/netfilter/nf_conntrack.ko: kernel/lib/libcrc32c.ko\n" +
+				"kernel/lib/libcrc32c.ko:",
+			present: []string{"nf_conntrack", "libcrc32c"},
+		},
+		{
+			name: "all compression suffixes and dash normalization",
+			content: "kernel/fs/cramfs/cramfs.ko.xz:\n" +
+				"kernel/fs/squashfs/squashfs.ko.zst:\n" +
+				"kernel/drivers/usb/storage/usb-storage.ko.gz:\n" +
+				"kernel/sound/pci/hda/snd-hda-intel.ko:",
+			present: []string{"cramfs", "squashfs", "usb_storage", "snd_hda_intel"},
+		},
+		{
+			name:    "blank lines, whitespace-only lines, and a trailing newline are ignored",
+			content: "\n  \n\t\nkernel/fs/jffs2/jffs2.ko:\n\n",
+			present: []string{"jffs2"},
+		},
+		{
+			name:    "duplicate module across lines is idempotent",
+			content: "kernel/fs/hfs/hfs.ko:\nkernel/fs/hfs/hfs.ko: kernel/dep.ko",
+			present: []string{"hfs"},
+		},
+		{
+			name:    "empty content yields no modules",
+			content: "",
+			absent:  []string{"anything"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseModulesDep(tc.content)
+			for _, name := range tc.present {
+				assert.True(t, got[name], "expected %q to be on disk", name)
+			}
+			for _, name := range tc.absent {
+				assert.False(t, got[name], "expected %q NOT to be on disk", name)
+			}
+		})
+	}
+}
+
+// TestParseModulesBuiltin locks down the modules.builtin parser behind
+// kernel.module.builtIn. Each non-blank line is one module path; the file
+// uses the ".ko" suffix on modern kernels but historically listed bare paths
+// without an extension, and dash/underscore normalization applies the same
+// way as modules.dep.
+func TestParseModulesBuiltin(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		present []string
+		absent  []string
+	}{
+		{
+			name:    "modern .ko-suffixed entries",
+			content: "kernel/fs/ext4/ext4.ko\nkernel/net/ipv4/tcp_cubic.ko",
+			present: []string{"ext4", "tcp_cubic"},
+		},
+		{
+			name:    "legacy entries without a .ko extension",
+			content: "kernel/fs/ext4/ext4\nkernel/drivers/char/random",
+			present: []string{"ext4", "random"},
+		},
+		{
+			name:    "dash normalization",
+			content: "kernel/drivers/usb/storage/usb-storage.ko",
+			present: []string{"usb_storage"},
+		},
+		{
+			name:    "blank lines and trailing newline ignored",
+			content: "\nkernel/fs/ext4/ext4.ko\n  \n",
+			present: []string{"ext4"},
+		},
+		{
+			name:    "empty content yields no modules",
+			content: "",
+			absent:  []string{"ext4"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseModulesBuiltin(tc.content)
+			for _, name := range tc.present {
+				assert.True(t, got[name], "expected %q to be builtin", name)
+			}
+			for _, name := range tc.absent {
+				assert.False(t, got[name], "expected %q NOT to be builtin", name)
+			}
+		})
+	}
+}

--- a/providers/os/resources/kernel_module_index.go
+++ b/providers/os/resources/kernel_module_index.go
@@ -1,0 +1,197 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"path"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/resources"
+)
+
+// normalizeModuleName canonicalizes a kernel module name for lookup. The
+// kernel treats '-' and '_' as interchangeable in module names (modprobe
+// normalizes between them), and lsmod / /proc/modules always report the
+// underscore form, so every key and lookup is keyed on underscores.
+func normalizeModuleName(name string) string {
+	return strings.ReplaceAll(name, "-", "_")
+}
+
+// moduleNameFromPath extracts the bare module name from a path entry in
+// modules.dep or modules.builtin. Entries look like
+// "kernel/net/netfilter/nf_conntrack.ko" (optionally with a .xz / .zst / .gz
+// compression suffix). Module names never contain a dot, so the name is the
+// basename up to its first dot.
+func moduleNameFromPath(p string) string {
+	base := path.Base(strings.TrimSpace(p))
+	if i := strings.IndexByte(base, '.'); i >= 0 {
+		base = base[:i]
+	}
+	return normalizeModuleName(base)
+}
+
+// parseModulesDep parses the contents of a /lib/modules/<version>/modules.dep
+// index and returns the set of module names that have a loadable .ko file on
+// disk. Each line has the form "kernel/.../foo.ko: dep1.ko dep2.ko ...": the
+// module is the path to the left of the colon, and the space-separated paths
+// to the right are that module's dependencies — already covered by their own
+// lines, so only the left-hand side is recorded. Blank or path-less lines are
+// skipped, and names are normalized so a later lookup by either the dash or
+// underscore spelling resolves.
+func parseModulesDep(content string) map[string]bool {
+	out := map[string]bool{}
+	for _, line := range strings.Split(content, "\n") {
+		lhs := line
+		if i := strings.IndexByte(line, ':'); i >= 0 {
+			lhs = line[:i]
+		}
+		if strings.TrimSpace(lhs) == "" {
+			continue
+		}
+		out[moduleNameFromPath(lhs)] = true
+	}
+	return out
+}
+
+// parseModulesBuiltin parses the contents of a
+// /lib/modules/<version>/modules.builtin index and returns the set of module
+// names compiled into the kernel. Each non-blank line is a single module path
+// (e.g. "kernel/fs/ext4/ext4.ko"); names are normalized the same way as
+// parseModulesDep.
+func parseModulesBuiltin(content string) map[string]bool {
+	out := map[string]bool{}
+	for _, line := range strings.Split(content, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		out[moduleNameFromPath(line)] = true
+	}
+	return out
+}
+
+// loadModuleIndex reads the running kernel's modules.dep and modules.builtin
+// once and records, per module name, whether a loadable .ko file is installed
+// on disk and whether the module is compiled into the kernel. Missing index
+// files are best-effort: a stripped-down image (or a non-Linux platform with
+// no /lib/modules tree) yields empty sets, so every module reports false
+// rather than erroring the query.
+func (k *mqlKernel) loadModuleIndex() (onDisk map[string]bool, builtIn map[string]bool, err error) {
+	k.moduleIndexOnce.Do(func() {
+		onDiskSet := map[string]bool{}
+		builtInSet := map[string]bool{}
+
+		version, verr := k.runningKernelVersion()
+		if verr != nil {
+			k.moduleIndexErr = verr
+			return
+		}
+		if version == "" {
+			k.moduleOnDisk = onDiskSet
+			k.moduleBuiltIn = builtInSet
+			return
+		}
+
+		base := "/lib/modules/" + version
+
+		dep, ok, derr := k.readKernelIndexFile(base + "/modules.dep")
+		if derr != nil {
+			k.moduleIndexErr = derr
+			return
+		}
+		if ok {
+			onDiskSet = parseModulesDep(dep)
+		}
+
+		bi, ok, berr := k.readKernelIndexFile(base + "/modules.builtin")
+		if berr != nil {
+			k.moduleIndexErr = berr
+			return
+		}
+		if ok {
+			builtInSet = parseModulesBuiltin(bi)
+		}
+
+		k.moduleOnDisk = onDiskSet
+		k.moduleBuiltIn = builtInSet
+	})
+
+	return k.moduleOnDisk, k.moduleBuiltIn, k.moduleIndexErr
+}
+
+// runningKernelVersion returns the uname -r string for the running kernel,
+// which is also the directory name under /lib/modules that holds that
+// kernel's module tree. It reads the already-resolved kernel.info dict.
+func (k *mqlKernel) runningKernelVersion() (string, error) {
+	info := k.GetInfo()
+	if info.Error != nil {
+		return "", info.Error
+	}
+	m, ok := info.Data.(map[string]any)
+	if !ok {
+		return "", nil
+	}
+	version, _ := m["version"].(string)
+	return version, nil
+}
+
+// readKernelIndexFile reads a /lib/modules index file via the file resource.
+// The bool reports whether the file exists; a missing file is not an error
+// (returns "", false, nil) so callers can treat absent indexes as empty.
+func (k *mqlKernel) readKernelIndexFile(filePath string) (string, bool, error) {
+	f, err := CreateResource(k.MqlRuntime, "file", map[string]*llx.RawData{
+		"path": llx.StringData(filePath),
+	})
+	if err != nil {
+		return "", false, err
+	}
+	mf := f.(*mqlFile)
+
+	exists := mf.GetExists()
+	if exists.Error != nil {
+		return "", false, exists.Error
+	}
+	if !exists.Data {
+		return "", false, nil
+	}
+
+	content := mf.GetContent()
+	if content.Error != nil {
+		if errors.Is(content.Error, resources.NotFoundError{}) {
+			return "", false, nil
+		}
+		return "", false, content.Error
+	}
+	return content.Data, true, nil
+}
+
+// moduleIndex resolves the parent kernel resource, triggers the one-shot
+// index read, and reports whether this module is present on disk and whether
+// it is built into the kernel.
+func (m *mqlKernelModule) moduleIndex() (onDisk bool, builtIn bool, err error) {
+	obj, err := CreateResource(m.MqlRuntime, "kernel", map[string]*llx.RawData{})
+	if err != nil {
+		return false, false, err
+	}
+	kernel := obj.(*mqlKernel)
+
+	onDiskSet, builtInSet, err := kernel.loadModuleIndex()
+	if err != nil {
+		return false, false, err
+	}
+
+	name := normalizeModuleName(m.Name.Data)
+	return onDiskSet[name], builtInSet[name], nil
+}
+
+func (m *mqlKernelModule) onDisk() (bool, error) {
+	onDisk, _, err := m.moduleIndex()
+	return onDisk, err
+}
+
+func (m *mqlKernelModule) builtIn() (bool, error) {
+	_, builtIn, err := m.moduleIndex()
+	return builtIn, err
+}

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -2441,7 +2441,10 @@ kernel @defaults("info") {
 // or iterate from `kernel.modules()` to audit the full loaded-module list.
 // Use `blacklisted`, `installBypass`, and `disabled` to express CIS-style
 // "module must not load" controls without falling back to raw modprobe.d
-// file parsing.
+// file parsing. Use `onDisk` to tell whether a loadable module file is
+// available for the running kernel even when it isn't currently loaded,
+// and `builtIn` to detect functionality compiled directly into the kernel
+// (which is always active and cannot be blacklisted or unloaded).
 kernel.module @defaults("name loaded") {
   init(name string)
 
@@ -2473,6 +2476,23 @@ kernel.module @defaults("name loaded") {
   // short-circuit rule. Use this as the canonical "module will not load
   // without explicit override" predicate.
   disabled() bool
+  // Whether a loadable module file is installed on disk for the running kernel
+  //
+  // True when a `.ko` (or compressed `.ko.xz` / `.ko.zst` / `.ko.gz`)
+  // file for this module exists under `/lib/modules/<version>/`, as
+  // listed in that kernel's `modules.dep` index. This reports presence
+  // independently of `loaded`, so it answers "the module is available to
+  // load but isn't loaded right now." Modules compiled into the kernel
+  // have no file on disk and report false here — see `builtIn`.
+  onDisk() bool
+  // Whether the module is compiled into the kernel image
+  //
+  // True when the functionality is built directly into the kernel
+  // (configured `=y`) rather than shipped as a loadable file, as listed
+  // in the running kernel's `modules.builtin` index. Built-in modules
+  // are always active: they never appear in `loaded`, have no file on
+  // disk (`onDisk` is false), and cannot be blacklisted or unloaded.
+  builtIn() bool
 }
 
 // Linux kernel boot command line

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -4316,6 +4316,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"kernel.module.disabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlKernelModule).GetDisabled()).ToDataRes(types.Bool)
 	},
+	"kernel.module.onDisk": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlKernelModule).GetOnDisk()).ToDataRes(types.Bool)
+	},
+	"kernel.module.builtIn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlKernelModule).GetBuiltIn()).ToDataRes(types.Bool)
+	},
 	"kernel.cmdline.raw": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlKernelCmdline).GetRaw()).ToDataRes(types.String)
 	},
@@ -12645,6 +12651,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"kernel.module.disabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlKernelModule).Disabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"kernel.module.onDisk": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlKernelModule).OnDisk, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"kernel.module.builtIn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlKernelModule).BuiltIn, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"kernel.cmdline.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -30711,6 +30725,8 @@ type mqlKernelModule struct {
 	Blacklisted   plugin.TValue[bool]
 	InstallBypass plugin.TValue[bool]
 	Disabled      plugin.TValue[bool]
+	OnDisk        plugin.TValue[bool]
+	BuiltIn       plugin.TValue[bool]
 }
 
 // createKernelModule creates a new instance of this resource
@@ -30777,6 +30793,18 @@ func (c *mqlKernelModule) GetInstallBypass() *plugin.TValue[bool] {
 func (c *mqlKernelModule) GetDisabled() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.Disabled, func() (bool, error) {
 		return c.disabled()
+	})
+}
+
+func (c *mqlKernelModule) GetOnDisk() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.OnDisk, func() (bool, error) {
+		return c.onDisk()
+	})
+}
+
+func (c *mqlKernelModule) GetBuiltIn() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.BuiltIn, func() (bool, error) {
+		return c.builtIn()
 	})
 }
 

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -1146,10 +1146,12 @@ kernel.lockdown.enabled 13.16.10
 kernel.lockdown.mode 13.16.10
 kernel.module 9.0.0
 kernel.module.blacklisted 13.16.10
+kernel.module.builtIn 13.20.2
 kernel.module.disabled 13.16.10
 kernel.module.installBypass 13.16.10
 kernel.module.loaded 9.0.0
 kernel.module.name 9.0.0
+kernel.module.onDisk 13.20.2
 kernel.module.size 9.0.0
 kernel.modules 9.0.0
 kernel.parameters 9.0.0


### PR DESCRIPTION
## What

Adds two computed boolean fields to the `kernel.module` resource so you can tell whether a module is **present on the system but not loaded** — which `kernel.module` couldn't express before (it only reflected loaded modules from `lsmod` / `/proc/modules`).

- **`onDisk`** — a loadable `.ko` (incl. `.ko.xz` / `.ko.zst` / `.ko.gz`) exists for the running kernel, read from `/lib/modules/<ver>/modules.dep`. Reported independently of `loaded`.
- **`builtIn`** — the feature is compiled directly into the kernel (`=y`), read from `/lib/modules/<ver>/modules.builtin`. Built-in modules are always active: never in `lsmod`, no file on disk, and cannot be blacklisted or unloaded.

Together with the existing `loaded`, these give three clean, non-overlapping states for any module name:

| `onDisk` | `builtIn` | `loaded` | meaning |
|----------|-----------|----------|---------|
| true  | false | true/false | `.ko` on disk, may or may not be loaded |
| false | true  | false      | compiled into the kernel, always active |
| false | false | false      | not available to this kernel at all |

### Why `builtIn` as its own field

A built-in isn't a *loadable module* in the strict sense — there's no `.ko` to load. Keeping it separate from `onDisk` (rather than folding both into one "present" flag) means a query can distinguish "no file, not built in → truly absent" from "no file, but built in → always active, can't be removed." It's also security-relevant: the existing `blacklisted` / `disabled` controls are meaningless for a built-in, so being able to detect that state matters for CIS-style "module must not load" audits.

```mql
kernel.module("overlay") { loaded onDisk builtIn }
kernel.modules.where(onDisk && !loaded) { name }   // available but not loaded
```

## How

- Both index files are read **once per query** and cached on the parent `kernel` resource via `sync.Once`, mirroring the existing modprobe-rule cache — iterating modules doesn't re-read.
- Module names are normalized between dash and underscore spellings, so `usb-storage` and `usb_storage` resolve to the same module (the kernel treats them as equivalent).
- The line-parsing logic is factored into pure functions (`parseModulesDep`, `parseModulesBuiltin`) so it's unit-testable, following the `parseModprobeConfig` precedent.
- Missing index files (stripped-down container images, non-Linux platforms) degrade to `false` with no error.
- Reads go through the `file` resource — no `os/exec`.

## Testing

- **Extensive unit tests** (`kernel_internal_test.go`): table-driven coverage of `parseModulesDep` (RHS-deps excluded, all compression suffixes, dash normalization, blank/whitespace lines, duplicates, empty), `parseModulesBuiltin` (modern `.ko` + legacy bare paths), `moduleNameFromPath`, and `normalizeModuleName`. Cases match the real Proxmox/Debian `modules.dep` format.
- **Live, end-to-end on a Debian 13 / Proxmox host** over SSH: confirmed version resolution + file reads + the graceful-absence path (a running kernel with no module tree → all `false`, no error), then planted a real-format index to prove the positive path — `nf_conntrack`→`onDisk`, `usb-storage`/`usb_storage`→`onDisk`, `ext4`→`builtIn`, bogus name→both `false` — and restored the host.
- `gofmt` clean; generated code regenerated (`os.lr.go`, `.lr.versions` entries at `13.20.2`); full `providers/os/resources` test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)