### PR TITLE
🐛 os: strip control characters from windows package name/version for valid purl

### DIFF
--- a/providers/os/resources/packages/windows_packages.go
+++ b/providers/os/resources/packages/windows_packages.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
@@ -804,6 +805,21 @@ func normalizeMsSqlVersion(version string) string {
 	return m[1] + ".0." + m[3] + "." + m[4]
 }
 
+// sanitizePackageField removes control characters (e.g. \r, \n, \t) from a
+// package name or version and trims surrounding whitespace. Windows registry
+// DisplayName/DisplayVersion values occasionally contain trailing control
+// characters, which produce invalid purls such as
+// "pkg:windows/windows/Foo%0D%0A@1.2.3" and fail to parse as URLs.
+func sanitizePackageField(s string) string {
+	s = strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
+	return strings.TrimSpace(s)
+}
+
 // createPackage creates a new package with the given parameters
 func createPackage(name, version, format, arch, publisher, installLocation string, platform *inventory.Platform) *Package {
 	purlType := purl.TypeWindows
@@ -813,6 +829,11 @@ func createPackage(name, version, format, arch, publisher, installLocation strin
 
 	// replace non-breaking spaces with regular spaces
 	name = strings.ReplaceAll(name, "\u00a0", " ")
+	// Windows registry values can carry trailing control characters (e.g. \r\n).
+	// These break purl generation ("net/url: invalid control character in URL"),
+	// so strip control characters and surrounding whitespace from name and version.
+	name = sanitizePackageField(name)
+	version = sanitizePackageField(version)
 	pkg := &Package{
 		Name:    name,
 		Version: version,

--- a/providers/os/resources/packages/windows_packages_test.go
+++ b/providers/os/resources/packages/windows_packages_test.go
@@ -4,6 +4,7 @@
 package packages
 
 import (
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -874,6 +875,35 @@ func TestCreatePackage(t *testing.T) {
 
 		// Here we check that the name is replaced with a regular space
 		assert.Equal(t, "GDR 2042 für SQL Server 2017 (KB5014354) (64-bit)", pkg.Name)
+	})
+
+	t.Run("create package with control characters in name produces a valid purl", func(t *testing.T) {
+		// Regression test for https://github.com/mondoohq/mql/issues/7975
+		// Windows registry DisplayName values can carry trailing \r\n, which
+		// previously leaked into the purl and failed with
+		// "net/url: invalid control character in URL".
+		pkg := createPackage("Arcserve UDP Host-Based VM Backup VM-Integrationsdienst\r\n", "8.0.5628.430", "windows/app", "x86_64", "Arcserve", "", nil)
+		require.NotNil(t, pkg, "expected package to be created")
+
+		// The control characters must be stripped from the name...
+		assert.Equal(t, "Arcserve UDP Host-Based VM Backup VM-Integrationsdienst", pkg.Name)
+
+		// ...and the resulting purl must be free of control characters and parseable as a URL.
+		assert.NotContains(t, pkg.PUrl, "\r")
+		assert.NotContains(t, pkg.PUrl, "\n")
+		assert.NotContains(t, pkg.PUrl, "%0D")
+		assert.NotContains(t, pkg.PUrl, "%0A")
+		_, err := url.Parse(pkg.PUrl)
+		assert.NoError(t, err, "purl must parse as a URL")
+	})
+
+	t.Run("create package strips control characters from version", func(t *testing.T) {
+		pkg := createPackage("SomeApp", "1.2.3\r\n", "windows/app", "x86_64", "Vendor", "", nil)
+		require.NotNil(t, pkg, "expected package to be created")
+
+		assert.Equal(t, "1.2.3", pkg.Version)
+		assert.NotContains(t, pkg.PUrl, "%0D")
+		assert.NotContains(t, pkg.PUrl, "%0A")
 	})
 }
 


### PR DESCRIPTION
## What

Windows registry `DisplayName`/`DisplayVersion` values can carry trailing control characters (e.g. `\r\n`). These leaked into the generated purl, producing invalid values like:

```
pkg:windows/windows/Arcserve%20UDP%20Host-Based%20VM%20Backup%20VM-Integrationsdienst%0D%0A@8.0.5628.430
```

which failed downstream with `net/url: invalid control character in URL`, causing packages to be skipped ("skipping package with invalid purl").

## Fix

`createPackage` now strips control characters and trims surrounding whitespace from both the package `name` and `version` before building the purl (via a new `sanitizePackageField` helper). This runs alongside the existing non-breaking-space normalization.

## Test

Added regression tests to `TestCreatePackage`:
- `\r\n` in the name is stripped and the resulting purl contains no control characters (raw or `%0D%0A`-encoded) and parses as a URL.
- `\r\n` in the version is stripped.

Verified the new test fails on the pre-fix code (name retains `\r\n`, purl contains `%0D%0A`) and passes with the fix.

Fixes #7975

🤖 Generated with [Claude Code](https://claude.com/claude-code)