### PR TITLE
✨ helm: recurse into vendored subcharts

### DIFF
--- a/providers/helm/resources/helm.go
+++ b/providers/helm/resources/helm.go
@@ -29,7 +29,7 @@ func (r *mqlHelm) charts() ([]any, error) {
 
 	var mqlCharts []any
 	for _, lc := range charts {
-		mqlChart, err := newMqlHelmChart(r.MqlRuntime, lc.Chart, lc.Path)
+		mqlChart, err := newMqlHelmChart(r.MqlRuntime, lc.Chart, lc.Path, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -41,6 +41,8 @@ func (r *mqlHelm) charts() ([]any, error) {
 type mqlHelmChartInternal struct {
 	chartObj        *chart.Chart
 	chartPath       string
+	parentChart     *mqlHelmChart
+	idKey           string
 	renderedOnce    sync.Once
 	rendered        map[string]string
 	renderedErr     error
@@ -48,7 +50,12 @@ type mqlHelmChartInternal struct {
 	cachedResources []any
 }
 
-func newMqlHelmChart(runtime *plugin.Runtime, c *chart.Chart, chartPath string) (*mqlHelmChart, error) {
+// newMqlHelmChart materializes a *chart.Chart as a helm.chart resource.
+// parent is nil for a top-level chart and points at the vendoring chart
+// for a subchart reached through subcharts(). The cache key (__id) is
+// parent-qualified so that sibling subcharts sharing name+version under
+// different parents don't collapse onto one cached instance.
+func newMqlHelmChart(runtime *plugin.Runtime, c *chart.Chart, chartPath string, parent *mqlHelmChart) (*mqlHelmChart, error) {
 	// Guard against archives that load with a nil Metadata pointer.
 	// loader.LoadDir always populates Metadata for a valid chart, but
 	// loader.LoadFile (the .tgz path) can return a chart with nil
@@ -70,8 +77,18 @@ func newMqlHelmChart(runtime *plugin.Runtime, c *chart.Chart, chartPath string) 
 		chartKey += ":" + chartPath
 	}
 
+	// Parent-qualify the cache key for subcharts. Sibling subcharts can
+	// share name+version across different parents (and a vendored subchart
+	// carries no filesystem path of its own), so without the parent chain
+	// in the id distinct subcharts would collapse onto one cached instance.
+	idKey := "helm.chart:" + chartKey
+	if parent != nil {
+		idKey = parent.idKey + "/" + chartKey
+	}
+
 	args := map[string]*llx.RawData{
-		"__id":        llx.StringData("helm.chart:" + chartKey),
+		"__id":        llx.StringData(idKey),
+		"isSubchart":  llx.BoolData(parent != nil),
 		"name":        llx.StringData(meta.Name),
 		"version":     llx.StringData(meta.Version),
 		"apiVersion":  llx.StringData(meta.APIVersion),
@@ -102,10 +119,15 @@ func newMqlHelmChart(runtime *plugin.Runtime, c *chart.Chart, chartPath string) 
 	mqlChart := res.(*mqlHelmChart)
 	mqlChart.chartObj = c
 	mqlChart.chartPath = chartPath
+	mqlChart.parentChart = parent
+	mqlChart.idKey = idKey
 	return mqlChart, nil
 }
 
 func (c *mqlHelmChart) id() (string, error) {
+	if c.idKey != "" {
+		return c.idKey, nil
+	}
 	key := c.Name.Data + ":" + c.Version.Data
 	if c.chartPath != "" {
 		key += ":" + c.chartPath
@@ -142,6 +164,34 @@ func (c *mqlHelmChart) dependencies() ([]any, error) {
 		mqlDeps = append(mqlDeps, mqlDep)
 	}
 	return mqlDeps, nil
+}
+
+// subcharts wraps chart.Dependencies() — the subchart bodies actually
+// loaded from charts/ — as fully recursive helm.chart resources, reusing
+// newMqlHelmChart so every chart field works per-subchart. This is the
+// loaded subchart objects, distinct from dependencies() which reads the
+// declared dependency entries from Chart.yaml.
+func (c *mqlHelmChart) subcharts() ([]any, error) {
+	subs := c.chartObj.Dependencies()
+	mqlSubs := make([]any, 0, len(subs))
+	for _, sub := range subs {
+		// A vendored subchart has no filesystem path of its own; the
+		// parent-qualified id keeps siblings distinct.
+		mqlSub, err := newMqlHelmChart(c.MqlRuntime, sub, "", c)
+		if err != nil {
+			return nil, err
+		}
+		mqlSubs = append(mqlSubs, mqlSub)
+	}
+	return mqlSubs, nil
+}
+
+func (c *mqlHelmChart) parent() (*mqlHelmChart, error) {
+	if c.parentChart == nil {
+		c.Parent.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return c.parentChart, nil
 }
 
 func (c *mqlHelmChart) maintainers() ([]any, error) {

--- a/providers/helm/resources/helm.lr
+++ b/providers/helm/resources/helm.lr
@@ -70,6 +70,28 @@ helm.chart @defaults("name version") {
   resources() []helm.resource
   // Files in the chart
   files() []helm.file
+  // Vendored subcharts loaded from charts/
+  //
+  // Each entry is a fully recursive helm.chart for a dependency whose
+  // chart body is vendored under the chart's charts/ directory, so every
+  // chart field (templates, values, dependencies, maintainers, files,
+  // and subcharts again) works per-subchart. Helm's render engine already
+  // merges subchart templates into the parent chart's rendered output, so
+  // this is for introspecting the source tree — per-subchart values,
+  // metadata, and declared dependencies — not for obtaining additional
+  // rendered manifests beyond what the parent already renders.
+  subcharts() []helm.chart
+  // Whether this chart was reached as a vendored subchart of another chart
+  //
+  // True for charts materialized through subcharts(); false for top-level
+  // charts loaded directly from the connection path.
+  isSubchart bool
+  // Parent chart that vendors this chart as a subchart
+  //
+  // Null for top-level charts. For a vendored subchart, links back to the
+  // chart whose charts/ directory it was loaded from, enabling traversal
+  // back up the dependency tree.
+  parent() helm.chart
 }
 
 // Helm chart dependency

--- a/providers/helm/resources/helm.lr.go
+++ b/providers/helm/resources/helm.lr.go
@@ -192,6 +192,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"helm.chart.files": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHelmChart).GetFiles()).ToDataRes(types.Array(types.Resource("helm.file")))
 	},
+	"helm.chart.subcharts": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHelmChart).GetSubcharts()).ToDataRes(types.Array(types.Resource("helm.chart")))
+	},
+	"helm.chart.isSubchart": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHelmChart).GetIsSubchart()).ToDataRes(types.Bool)
+	},
+	"helm.chart.parent": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHelmChart).GetParent()).ToDataRes(types.Resource("helm.chart"))
+	},
 	"helm.dependency.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHelmDependency).GetName()).ToDataRes(types.String)
 	},
@@ -374,6 +383,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"helm.chart.files": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHelmChart).Files, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"helm.chart.subcharts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHelmChart).Subcharts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"helm.chart.isSubchart": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHelmChart).IsSubchart, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"helm.chart.parent": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHelmChart).Parent, ok = plugin.RawToTValue[*mqlHelmChart](v.Value, v.Error)
 		return
 	},
 	"helm.dependency.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -621,6 +642,9 @@ type mqlHelmChart struct {
 	Values       plugin.TValue[any]
 	Resources    plugin.TValue[[]any]
 	Files        plugin.TValue[[]any]
+	Subcharts    plugin.TValue[[]any]
+	IsSubchart   plugin.TValue[bool]
+	Parent       plugin.TValue[*mqlHelmChart]
 }
 
 // createHelmChart creates a new instance of this resource
@@ -795,6 +819,42 @@ func (c *mqlHelmChart) GetFiles() *plugin.TValue[[]any] {
 		}
 
 		return c.files()
+	})
+}
+
+func (c *mqlHelmChart) GetSubcharts() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Subcharts, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("helm.chart", c.__id, "subcharts")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.subcharts()
+	})
+}
+
+func (c *mqlHelmChart) GetIsSubchart() *plugin.TValue[bool] {
+	return &c.IsSubchart
+}
+
+func (c *mqlHelmChart) GetParent() *plugin.TValue[*mqlHelmChart] {
+	return plugin.GetOrCompute[*mqlHelmChart](&c.Parent, func() (*mqlHelmChart, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("helm.chart", c.__id, "parent")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlHelmChart), nil
+			}
+		}
+
+		return c.parent()
 	})
 }
 

--- a/providers/helm/resources/helm.lr.versions
+++ b/providers/helm/resources/helm.lr.versions
@@ -12,12 +12,15 @@ helm.chart.description 13.0.0
 helm.chart.files 13.0.0
 helm.chart.home 13.0.0
 helm.chart.icon 13.0.0
+helm.chart.isSubchart 13.0.10
 helm.chart.keywords 13.0.0
 helm.chart.kubeVersion 13.0.9
 helm.chart.maintainers 13.0.0
 helm.chart.name 13.0.0
+helm.chart.parent 13.0.10
 helm.chart.resources 13.0.0
 helm.chart.sources 13.0.0
+helm.chart.subcharts 13.0.10
 helm.chart.templates 13.0.0
 helm.chart.type 13.0.0
 helm.chart.values 13.0.0

--- a/providers/helm/resources/helm_test.go
+++ b/providers/helm/resources/helm_test.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
 )
 
 func TestNewMqlHelmChart_KubeVersionAndAnnotations(t *testing.T) {
@@ -23,7 +25,7 @@ func TestNewMqlHelmChart_KubeVersionAndAnnotations(t *testing.T) {
 			},
 		}}
 
-		mqlChart, err := newMqlHelmChart(newTestRuntime(), c, "")
+		mqlChart, err := newMqlHelmChart(newTestRuntime(), c, "", nil)
 		require.NoError(t, err)
 		assert.Equal(t, ">=1.27.0-0", mqlChart.KubeVersion.Data)
 		assert.Equal(t, map[string]any{
@@ -38,7 +40,7 @@ func TestNewMqlHelmChart_KubeVersionAndAnnotations(t *testing.T) {
 			Version: "1.2.3",
 		}}
 
-		mqlChart, err := newMqlHelmChart(newTestRuntime(), c, "")
+		mqlChart, err := newMqlHelmChart(newTestRuntime(), c, "", nil)
 		require.NoError(t, err)
 		assert.Equal(t, "", mqlChart.KubeVersion.Data)
 		// A chart without `annotations:` parses to nil; the resource layer
@@ -53,13 +55,13 @@ func TestNewMqlHelmChart_KubeVersionAndAnnotations(t *testing.T) {
 func TestNewMqlHelmChart_NilMetadataReturnsError(t *testing.T) {
 	t.Run("nil metadata", func(t *testing.T) {
 		c := &chart.Chart{Metadata: nil}
-		_, err := newMqlHelmChart(newTestRuntime(), c, "")
+		_, err := newMqlHelmChart(newTestRuntime(), c, "", nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "metadata")
 	})
 
 	t.Run("nil chart", func(t *testing.T) {
-		_, err := newMqlHelmChart(newTestRuntime(), nil, "")
+		_, err := newMqlHelmChart(newTestRuntime(), nil, "", nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "metadata")
 	})
@@ -78,7 +80,7 @@ func TestMaintainersDoNotDedupeOnDuplicateName(t *testing.T) {
 			{Name: "Alex", Email: "alex-secondary@example.com"},
 		},
 	}}
-	mqlChart, err := newMqlHelmChart(newTestRuntime(), c, "")
+	mqlChart, err := newMqlHelmChart(newTestRuntime(), c, "", nil)
 	require.NoError(t, err)
 
 	mqlChart.chartObj = c
@@ -95,6 +97,57 @@ func TestMaintainersDoNotDedupeOnDuplicateName(t *testing.T) {
 	assert.True(t, emails["alex-secondary@example.com"], "second Alex email kept")
 }
 
+// A chart with a vendored subchart under charts/ should surface that
+// subchart as a fully recursive helm.chart through subcharts(), with
+// isSubchart set on the child, parent() linking back to the top chart,
+// and nested fields (values/templates) resolving per-subchart.
+func TestSubchartRecursion(t *testing.T) {
+	c, err := loader.LoadDir("../testdata/with-subchart")
+	require.NoError(t, err)
+
+	mqlChart, err := newMqlHelmChart(newTestRuntime(), c, "../testdata/with-subchart", nil)
+	require.NoError(t, err)
+
+	// Top-level chart is not a subchart and has no parent.
+	assert.False(t, mqlChart.IsSubchart.Data, "top-level chart is not a subchart")
+	parent, err := mqlChart.parent()
+	require.NoError(t, err)
+	assert.Nil(t, parent, "top-level chart has no parent")
+	assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, mqlChart.Parent.State)
+
+	subs, err := mqlChart.subcharts()
+	require.NoError(t, err)
+	require.Len(t, subs, 1, "the vendored subchart should be returned")
+
+	sub := subs[0].(*mqlHelmChart)
+	assert.Equal(t, "mysubchart", sub.Name.Data)
+	assert.Equal(t, "0.2.0", sub.Version.Data)
+	assert.True(t, sub.IsSubchart.Data, "the subchart must be flagged isSubchart")
+
+	// parent() on the subchart links back to the top chart.
+	subParent, err := sub.parent()
+	require.NoError(t, err)
+	require.NotNil(t, subParent)
+	assert.Equal(t, "with-subchart", subParent.Name.Data)
+
+	// Parent-qualified __id keeps the subchart distinct from the parent.
+	assert.NotEqual(t, mqlChart.__id, sub.__id)
+	assert.Contains(t, sub.__id, mqlChart.__id, "subchart id is parent-qualified")
+
+	// Nested fields resolve per-subchart: the subchart's own values.yaml.
+	vals, err := sub.values()
+	require.NoError(t, err)
+	valsMap, ok := vals.(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, valsMap, "subImage", "subchart values.yaml should resolve")
+
+	// And the subchart's own template renders.
+	tmpls, err := sub.templates()
+	require.NoError(t, err)
+	require.Len(t, tmpls, 1)
+	assert.Equal(t, "templates/service.yaml", tmpls[0].(*mqlHelmTemplate).Name.Data)
+}
+
 // Two charts that share name + version (real for feature-branch forks
 // in a multi-chart directory) used to collide on the CreateResource
 // cache because the __id ignored their path. Including ChartFullPath
@@ -108,9 +161,9 @@ func TestChartIDIncludesPathToDeduplicate(t *testing.T) {
 	// real-world case for feature-branch forks in a multi-chart
 	// directory. The connection layer passes each chart's load path
 	// into newMqlHelmChart so the __id stays unique.
-	mqlA, err := newMqlHelmChart(runtime, a, "/repo/charts/a")
+	mqlA, err := newMqlHelmChart(runtime, a, "/repo/charts/a", nil)
 	require.NoError(t, err)
-	mqlB, err := newMqlHelmChart(runtime, b, "/repo/charts/b")
+	mqlB, err := newMqlHelmChart(runtime, b, "/repo/charts/b", nil)
 	require.NoError(t, err)
 
 	// CreateResource dedupes by __id; identical names would land both
@@ -123,7 +176,7 @@ func TestChartIDIncludesPathToDeduplicate(t *testing.T) {
 	// charts collide" but that matches prior behavior.
 	mqlNoPath, err := newMqlHelmChart(runtime, &chart.Chart{
 		Metadata: &chart.Metadata{Name: "lone", Version: "1.0.0"},
-	}, "")
+	}, "", nil)
 	require.NoError(t, err)
 	assert.NotEmpty(t, mqlNoPath.__id)
 }

--- a/providers/helm/testdata/with-subchart/Chart.yaml
+++ b/providers/helm/testdata/with-subchart/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: with-subchart
+version: 1.0.0
+appVersion: "1.0.0"
+description: A chart that vendors a subchart under charts/
+type: application
+dependencies:
+  - name: mysubchart
+    version: 0.2.0
+    repository: file://./charts/mysubchart

--- a/providers/helm/testdata/with-subchart/charts/mysubchart/Chart.yaml
+++ b/providers/helm/testdata/with-subchart/charts/mysubchart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: mysubchart
+version: 0.2.0
+appVersion: "0.2.0"
+description: A vendored subchart
+type: application

--- a/providers/helm/testdata/with-subchart/charts/mysubchart/templates/service.yaml
+++ b/providers/helm/testdata/with-subchart/charts/mysubchart/templates/service.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-mysubchart
+spec:
+  ports:
+    - port: 6379

--- a/providers/helm/testdata/with-subchart/charts/mysubchart/values.yaml
+++ b/providers/helm/testdata/with-subchart/charts/mysubchart/values.yaml
@@ -1,0 +1,3 @@
+subImage:
+  repository: redis
+  tag: "7.2"

--- a/providers/helm/testdata/with-subchart/templates/configmap.yaml
+++ b/providers/helm/testdata/with-subchart/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-parent
+data:
+  replicas: "{{ .Values.replicaCount }}"

--- a/providers/helm/testdata/with-subchart/values.yaml
+++ b/providers/helm/testdata/with-subchart/values.yaml
@@ -1,0 +1,3 @@
+replicaCount: 2
+mysubchart:
+  enabled: true


### PR DESCRIPTION
## What

Expose vendored subcharts (Chart.yaml `dependencies:` whose chart bodies are loaded under `charts/`) as fully recursive `helm.chart` objects, so every existing chart field works per-subchart.

### Fields added to `helm.chart`
- `subcharts() []helm.chart` — wraps `chart.Dependencies()` (the actually-loaded subchart objects, distinct from the declared `dependencies()` list parsed from Chart.yaml), reusing the same `newMqlHelmChart` constructor so it recurses naturally. Templates, values, resources, dependencies, maintainers, files and `subcharts()` again all work on each subchart.
- `isSubchart bool` — true for charts reached as a vendored dependency, false for top-level charts.
- `parent() helm.chart` — the vendoring chart; null for top-level charts (sets `StateIsSet | StateIsNull` before returning nil per the singular-nil rule).

### `__id` stability
Sibling subcharts can share name+version across different parents (and a vendored subchart carries no filesystem path of its own), so the cache key is parent-qualified — `<parentId>/<name>:<version>` — extending the existing path-qualified scheme. Without this, distinct subcharts would collapse onto one cached instance.

### Note on rendering
Helm's render engine already merges subchart templates into the parent chart's rendered output, so `subcharts()` is for introspecting the **source tree** (per-subchart values, metadata, declared dependencies), not for obtaining additional rendered manifests. This is documented in the `.lr` description.

## Testing
- New `testdata/with-subchart` fixture: a parent chart vendoring `charts/mysubchart` (its own Chart.yaml, values.yaml, template).
- `TestSubchartRecursion` asserts the subchart is returned, `isSubchart` is true on it, `parent()` links back to the top chart, the `__id` is parent-qualified, and nested fields (subchart `values`/`templates`) resolve.
- `go test ./providers/helm/...` passes.
- Verified interactively: `mql run helm testdata/with-subchart -c "helm.charts { name isSubchart subcharts { name isSubchart parent { name } values } }"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)