### PR TITLE
✨ kustomize: classify patch format and decompose JSON6902 operations

### DIFF
--- a/providers/kustomize/resources/kustomize.go
+++ b/providers/kustomize/resources/kustomize.go
@@ -167,12 +167,36 @@ func (k *mqlKustomizeKustomization) patches() ([]any, error) {
 		return nil, err
 	}
 	var mqlPatches []any
-	for i, p := range kust.Patches {
-		mqlP, err := newMqlKustomizePatch(k.MqlRuntime, kustPath, i, &p)
+	idx := 0
+	// Modern unified patches: classify each by inspecting its content shape.
+	for i := range kust.Patches {
+		p := kust.Patches[i]
+		mqlP, err := newMqlKustomizePatch(k.MqlRuntime, kustPath, idx, &p, hintNone)
 		if err != nil {
 			return nil, err
 		}
 		mqlPatches = append(mqlPatches, mqlP)
+		idx++
+	}
+	// Legacy patchesJson6902: format is unambiguous, force json6902.
+	for i := range kust.PatchesJson6902 {
+		p := kust.PatchesJson6902[i]
+		mqlP, err := newMqlKustomizePatch(k.MqlRuntime, kustPath, idx, &p, hintJSON6902)
+		if err != nil {
+			return nil, err
+		}
+		mqlPatches = append(mqlPatches, mqlP)
+		idx++
+	}
+	// Legacy patchesStrategicMerge: each entry is a file path, force strategicMerge.
+	for i := range kust.PatchesStrategicMerge {
+		p := kustomizeTypes.Patch{Path: string(kust.PatchesStrategicMerge[i])}
+		mqlP, err := newMqlKustomizePatch(k.MqlRuntime, kustPath, idx, &p, hintStrategicMerge)
+		if err != nil {
+			return nil, err
+		}
+		mqlPatches = append(mqlPatches, mqlP)
+		idx++
 	}
 	return mqlPatches, nil
 }

--- a/providers/kustomize/resources/kustomize.lr
+++ b/providers/kustomize/resources/kustomize.lr
@@ -69,6 +69,22 @@ kustomize.patch @defaults("path") {
   content string
   // Patch file path (empty if inline)
   path string
+  // Patch format
+  //
+  // Either "strategicMerge" or "json6902", determined from the patch
+  // declaration or by inspecting the patch content shape. A patch whose
+  // content is a sequence of operation objects (each carrying an `op` key)
+  // is classified as "json6902"; any mapping-shaped patch is
+  // "strategicMerge". Use this to distinguish a strategic-merge overlay
+  // from a JSON patch.
+  format string
+  // JSON patch operations
+  //
+  // Decomposed RFC6902 operations for a "json6902" patch — empty for a
+  // "strategicMerge" patch. Each entry exposes its `op`, `path`, and
+  // `value`, so an audit can detect a patch that removes a security
+  // control (for example an `op: remove` targeting a securityContext).
+  operations() []kustomize.patch.operation
   // Target group
   targetGroup string
   // Target version
@@ -83,6 +99,26 @@ kustomize.patch @defaults("path") {
   targetLabelSelector string
   // Target annotation selector
   targetAnnotationSelector string
+}
+
+// JSON patch operation from a JSON6902 Kustomize patch
+//
+// Examine a single RFC6902 operation decomposed from a "json6902" patch.
+// The `op` is one of add, remove, replace, move, copy, or test; `path` is
+// the RFC6901 JSON pointer the operation targets (for example
+// `/spec/template/spec/containers/0`); and `value` carries the operand for
+// add, replace, and test operations and is null otherwise. Use this to
+// detect operations that strip a security control from a base resource.
+kustomize.patch.operation @defaults("op path") {
+  // Operation: add, remove, replace, move, copy, or test
+  op string
+  // RFC6901 JSON pointer the operation targets
+  path string
+  // Operand value
+  //
+  // Present for add, replace, and test operations; null for remove, move,
+  // and copy.
+  value dict
 }
 
 // Kustomize ConfigMap or Secret generator

--- a/providers/kustomize/resources/kustomize.lr
+++ b/providers/kustomize/resources/kustomize.lr
@@ -109,7 +109,7 @@ kustomize.patch @defaults("path") {
 // `/spec/template/spec/containers/0`); and `value` carries the operand for
 // add, replace, and test operations and is null otherwise. Use this to
 // detect operations that strip a security control from a base resource.
-kustomize.patch.operation @defaults("op path") {
+private kustomize.patch.operation @defaults("op path") {
   // Operation: add, remove, replace, move, copy, or test
   op string
   // RFC6901 JSON pointer the operation targets

--- a/providers/kustomize/resources/kustomize.lr.go
+++ b/providers/kustomize/resources/kustomize.lr.go
@@ -18,6 +18,7 @@ const (
 	ResourceKustomize                  string = "kustomize"
 	ResourceKustomizeKustomization     string = "kustomize.kustomization"
 	ResourceKustomizePatch             string = "kustomize.patch"
+	ResourceKustomizePatchOperation    string = "kustomize.patch.operation"
 	ResourceKustomizeGenerator         string = "kustomize.generator"
 	ResourceKustomizeImage             string = "kustomize.image"
 	ResourceKustomizeResource          string = "kustomize.resource"
@@ -40,6 +41,10 @@ func init() {
 		"kustomize.patch": {
 			// to override args, implement: initKustomizePatch(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createKustomizePatch,
+		},
+		"kustomize.patch.operation": {
+			// to override args, implement: initKustomizePatchOperation(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createKustomizePatchOperation,
 		},
 		"kustomize.generator": {
 			// to override args, implement: initKustomizeGenerator(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -189,6 +194,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"kustomize.patch.path": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlKustomizePatch).GetPath()).ToDataRes(types.String)
 	},
+	"kustomize.patch.format": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlKustomizePatch).GetFormat()).ToDataRes(types.String)
+	},
+	"kustomize.patch.operations": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlKustomizePatch).GetOperations()).ToDataRes(types.Array(types.Resource("kustomize.patch.operation")))
+	},
 	"kustomize.patch.targetGroup": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlKustomizePatch).GetTargetGroup()).ToDataRes(types.String)
 	},
@@ -209,6 +220,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"kustomize.patch.targetAnnotationSelector": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlKustomizePatch).GetTargetAnnotationSelector()).ToDataRes(types.String)
+	},
+	"kustomize.patch.operation.op": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlKustomizePatchOperation).GetOp()).ToDataRes(types.String)
+	},
+	"kustomize.patch.operation.path": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlKustomizePatchOperation).GetPath()).ToDataRes(types.String)
+	},
+	"kustomize.patch.operation.value": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlKustomizePatchOperation).GetValue()).ToDataRes(types.Dict)
 	},
 	"kustomize.generator.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlKustomizeGenerator).GetName()).ToDataRes(types.String)
@@ -385,6 +405,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlKustomizePatch).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"kustomize.patch.format": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlKustomizePatch).Format, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"kustomize.patch.operations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlKustomizePatch).Operations, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"kustomize.patch.targetGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlKustomizePatch).TargetGroup, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -411,6 +439,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"kustomize.patch.targetAnnotationSelector": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlKustomizePatch).TargetAnnotationSelector, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"kustomize.patch.operation.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlKustomizePatchOperation).__id, ok = v.Value.(string)
+		return
+	},
+	"kustomize.patch.operation.op": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlKustomizePatchOperation).Op, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"kustomize.patch.operation.path": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlKustomizePatchOperation).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"kustomize.patch.operation.value": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlKustomizePatchOperation).Value, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"kustomize.generator.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -818,9 +862,11 @@ func (c *mqlKustomizeKustomization) GetReplacements() *plugin.TValue[[]any] {
 type mqlKustomizePatch struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlKustomizePatchInternal it will be used here
+	mqlKustomizePatchInternal
 	Content                  plugin.TValue[string]
 	Path                     plugin.TValue[string]
+	Format                   plugin.TValue[string]
+	Operations               plugin.TValue[[]any]
 	TargetGroup              plugin.TValue[string]
 	TargetVersion            plugin.TValue[string]
 	TargetKind               plugin.TValue[string]
@@ -870,6 +916,26 @@ func (c *mqlKustomizePatch) GetPath() *plugin.TValue[string] {
 	return &c.Path
 }
 
+func (c *mqlKustomizePatch) GetFormat() *plugin.TValue[string] {
+	return &c.Format
+}
+
+func (c *mqlKustomizePatch) GetOperations() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Operations, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("kustomize.patch", c.__id, "operations")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.operations()
+	})
+}
+
 func (c *mqlKustomizePatch) GetTargetGroup() *plugin.TValue[string] {
 	return &c.TargetGroup
 }
@@ -896,6 +962,60 @@ func (c *mqlKustomizePatch) GetTargetLabelSelector() *plugin.TValue[string] {
 
 func (c *mqlKustomizePatch) GetTargetAnnotationSelector() *plugin.TValue[string] {
 	return &c.TargetAnnotationSelector
+}
+
+// mqlKustomizePatchOperation for the kustomize.patch.operation resource
+type mqlKustomizePatchOperation struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlKustomizePatchOperationInternal it will be used here
+	Op    plugin.TValue[string]
+	Path  plugin.TValue[string]
+	Value plugin.TValue[any]
+}
+
+// createKustomizePatchOperation creates a new instance of this resource
+func createKustomizePatchOperation(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlKustomizePatchOperation{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("kustomize.patch.operation", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlKustomizePatchOperation) MqlName() string {
+	return "kustomize.patch.operation"
+}
+
+func (c *mqlKustomizePatchOperation) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlKustomizePatchOperation) GetOp() *plugin.TValue[string] {
+	return &c.Op
+}
+
+func (c *mqlKustomizePatchOperation) GetPath() *plugin.TValue[string] {
+	return &c.Path
+}
+
+func (c *mqlKustomizePatchOperation) GetValue() *plugin.TValue[any] {
+	return &c.Value
 }
 
 // mqlKustomizeGenerator for the kustomize.generator resource

--- a/providers/kustomize/resources/kustomize.lr.versions
+++ b/providers/kustomize/resources/kustomize.lr.versions
@@ -35,6 +35,12 @@ kustomize.kustomization.secretGenerators 13.0.0
 kustomize.kustomizations 13.0.0
 kustomize.patch 13.0.0
 kustomize.patch.content 13.0.0
+kustomize.patch.format 13.0.10
+kustomize.patch.operation 13.0.10
+kustomize.patch.operation.op 13.0.10
+kustomize.patch.operation.path 13.0.10
+kustomize.patch.operation.value 13.0.10
+kustomize.patch.operations 13.0.10
 kustomize.patch.path 13.0.0
 kustomize.patch.targetAnnotationSelector 13.0.0
 kustomize.patch.targetGroup 13.0.0

--- a/providers/kustomize/resources/patch.go
+++ b/providers/kustomize/resources/patch.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -70,8 +71,13 @@ func newMqlKustomizePatch(runtime *plugin.Runtime, kustPath string, index int, p
 	if len(raw) == 0 && p.Path != "" {
 		// Best-effort read; a missing/unreadable file falls back to
 		// strategic-merge with no operations rather than failing the audit.
-		if data, err := os.ReadFile(filepath.Join(kustPath, p.Path)); err == nil {
-			raw = data
+		// Constrain the read to the kustomization directory so a malicious
+		// patch path (e.g. "../../etc/passwd") can't escape the scan root.
+		full := filepath.Join(kustPath, p.Path)
+		if rel, err := filepath.Rel(kustPath, full); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			if data, err := os.ReadFile(full); err == nil {
+				raw = data
+			}
 		}
 	}
 

--- a/providers/kustomize/resources/patch.go
+++ b/providers/kustomize/resources/patch.go
@@ -72,11 +72,19 @@ func newMqlKustomizePatch(runtime *plugin.Runtime, kustPath string, index int, p
 		// Best-effort read; a missing/unreadable file falls back to
 		// strategic-merge with no operations rather than failing the audit.
 		// Constrain the read to the kustomization directory so a malicious
-		// patch path (e.g. "../../etc/passwd") can't escape the scan root.
+		// patch path (e.g. "../../etc/passwd") — or a symlink inside the
+		// directory whose target is outside it — can't escape the scan root.
+		// Both the base and the candidate are symlink-resolved before the
+		// containment check so a symlinked scan root (e.g. /tmp on macOS,
+		// which resolves to /private/tmp) doesn't cause false rejections.
 		full := filepath.Join(kustPath, p.Path)
-		if rel, err := filepath.Rel(kustPath, full); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			if data, err := os.ReadFile(full); err == nil {
-				raw = data
+		base, baseErr := filepath.EvalSymlinks(kustPath)
+		resolved, resErr := filepath.EvalSymlinks(full)
+		if baseErr == nil && resErr == nil {
+			if rel, err := filepath.Rel(base, resolved); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				if data, err := os.ReadFile(resolved); err == nil {
+					raw = data
+				}
 			}
 		}
 	}

--- a/providers/kustomize/resources/patch.go
+++ b/providers/kustomize/resources/patch.go
@@ -4,14 +4,48 @@
 package resources
 
 import (
+	"os"
+	"path/filepath"
 	"strconv"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"gopkg.in/yaml.v3"
 	kustomizeTypes "sigs.k8s.io/kustomize/api/types"
 )
 
-func newMqlKustomizePatch(runtime *plugin.Runtime, kustPath string, index int, p *kustomizeTypes.Patch) (*mqlKustomizePatch, error) {
+const (
+	patchFormatStrategicMerge = "strategicMerge"
+	patchFormatJSON6902       = "json6902"
+)
+
+// formatHint forces a patch's classification when the source field is
+// unambiguous (the legacy patchesStrategicMerge / patchesJson6902 lists).
+// An empty hint means "inspect the content shape".
+type formatHint string
+
+const (
+	hintNone           formatHint = ""
+	hintStrategicMerge formatHint = patchFormatStrategicMerge
+	hintJSON6902       formatHint = patchFormatJSON6902
+)
+
+// jsonPatchOp is one decomposed RFC6902 operation.
+type jsonPatchOp struct {
+	op    string
+	path  string
+	value any
+	// hasValue distinguishes an explicit null value (add/replace/test) from
+	// an operation that carries no value at all (remove/move/copy).
+	hasValue bool
+}
+
+type mqlKustomizePatchInternal struct {
+	format string
+	ops    []jsonPatchOp
+}
+
+func newMqlKustomizePatch(runtime *plugin.Runtime, kustPath string, index int, p *kustomizeTypes.Patch, hint formatHint) (*mqlKustomizePatch, error) {
 	targetGroup := ""
 	targetVersion := ""
 	targetKind := ""
@@ -30,12 +64,26 @@ func newMqlKustomizePatch(runtime *plugin.Runtime, kustPath string, index int, p
 		targetAnnotationSelector = p.Target.AnnotationSelector
 	}
 
+	// Read the raw patch bytes: inline content wins, otherwise the file the
+	// patch points at (relative to the kustomization directory).
+	raw := []byte(p.Patch)
+	if len(raw) == 0 && p.Path != "" {
+		// Best-effort read; a missing/unreadable file falls back to
+		// strategic-merge with no operations rather than failing the audit.
+		if data, err := os.ReadFile(filepath.Join(kustPath, p.Path)); err == nil {
+			raw = data
+		}
+	}
+
+	format, ops := classifyPatch(raw, hint)
+
 	id := "kustomize.patch:" + kustPath + ":" + strconv.Itoa(index)
 
 	res, err := CreateResource(runtime, "kustomize.patch", map[string]*llx.RawData{
 		"__id":                     llx.StringData(id),
 		"content":                  llx.StringData(p.Patch),
 		"path":                     llx.StringData(p.Path),
+		"format":                   llx.StringData(format),
 		"targetGroup":              llx.StringData(targetGroup),
 		"targetVersion":            llx.StringData(targetVersion),
 		"targetKind":               llx.StringData(targetKind),
@@ -47,8 +95,104 @@ func newMqlKustomizePatch(runtime *plugin.Runtime, kustPath string, index int, p
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlKustomizePatch), nil
+	mqlP := res.(*mqlKustomizePatch)
+	mqlP.format = format
+	mqlP.ops = ops
+	return mqlP, nil
 }
 
-// Satisfy the plugin interface — all fields are static, no computed fields needed.
-var _ plugin.Resource = (*mqlKustomizePatch)(nil)
+// classifyPatch inspects raw patch bytes (YAML or JSON) and returns the
+// patch format plus, for JSON6902 patches, the decomposed operations. It
+// never panics on malformed input: anything it can't decode as a JSON6902
+// operation sequence is treated as a strategic-merge patch with no
+// operations. A non-empty hint forces the format.
+func classifyPatch(raw []byte, hint formatHint) (string, []jsonPatchOp) {
+	// A forced strategic-merge patch never carries operations.
+	if hint == hintStrategicMerge {
+		return patchFormatStrategicMerge, nil
+	}
+
+	ops, ok := decodeJSON6902(raw)
+	switch {
+	case hint == hintJSON6902:
+		// Forced JSON6902: decode what we can, even an empty list.
+		return patchFormatJSON6902, ops
+	case ok:
+		return patchFormatJSON6902, ops
+	default:
+		return patchFormatStrategicMerge, nil
+	}
+}
+
+// decodeJSON6902 attempts to decode raw bytes as a sequence of RFC6902
+// operations. It returns ok=true only when the content is a YAML/JSON
+// sequence whose elements are all mappings carrying an `op` key — the
+// shape that unambiguously identifies a JSON6902 patch.
+func decodeJSON6902(raw []byte) ([]jsonPatchOp, bool) {
+	if len(raw) == 0 {
+		return nil, false
+	}
+
+	var seq []map[string]any
+	if err := yaml.Unmarshal(raw, &seq); err != nil {
+		return nil, false
+	}
+	if len(seq) == 0 {
+		return nil, false
+	}
+
+	ops := make([]jsonPatchOp, 0, len(seq))
+	for _, elem := range seq {
+		if elem == nil {
+			return nil, false
+		}
+		opVal, hasOp := elem["op"]
+		if !hasOp {
+			return nil, false
+		}
+		opStr, _ := opVal.(string)
+
+		pathVal, _ := elem["path"].(string)
+		value, hasValue := elem["value"]
+
+		ops = append(ops, jsonPatchOp{
+			op:       opStr,
+			path:     pathVal,
+			value:    value,
+			hasValue: hasValue,
+		})
+	}
+	return ops, true
+}
+
+func (c *mqlKustomizePatch) operations() ([]any, error) {
+	if c.format != patchFormatJSON6902 || len(c.ops) == 0 {
+		return []any{}, nil
+	}
+
+	mqlOps := make([]any, 0, len(c.ops))
+	for i, op := range c.ops {
+		args := map[string]*llx.RawData{
+			"__id": llx.StringData(c.__id + "/op[" + strconv.Itoa(i) + "]"),
+			"op":   llx.StringData(op.op),
+			"path": llx.StringData(op.path),
+		}
+		if op.hasValue {
+			args["value"] = llx.DictData(op.value)
+		} else {
+			args["value"] = llx.NilData
+		}
+
+		res, err := CreateResource(c.MqlRuntime, "kustomize.patch.operation", args)
+		if err != nil {
+			return nil, err
+		}
+		mqlOps = append(mqlOps, res)
+	}
+	return mqlOps, nil
+}
+
+var (
+	_ plugin.Resource = (*mqlKustomizePatch)(nil)
+	_ plugin.Resource = (*mqlKustomizePatchOperation)(nil)
+)

--- a/providers/kustomize/resources/resource_test.go
+++ b/providers/kustomize/resources/resource_test.go
@@ -44,3 +44,92 @@ func TestCoerceStringMap_EmptyMap(t *testing.T) {
 	assert.NotNil(t, got)
 	assert.Len(t, got, 0)
 }
+
+func TestClassifyPatch_StrategicMerge(t *testing.T) {
+	// A mapping with apiVersion/kind is a strategic-merge patch.
+	raw := []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  replicas: 3
+`)
+	format, ops := classifyPatch(raw, hintNone)
+	assert.Equal(t, patchFormatStrategicMerge, format)
+	assert.Empty(t, ops, "strategic-merge patches carry no decomposed operations")
+}
+
+func TestClassifyPatch_JSON6902(t *testing.T) {
+	// A sequence whose elements each carry an `op` key is JSON6902.
+	raw := []byte(`- op: add
+  path: /spec/template/spec/containers/0/env
+  value:
+    - name: LOG_LEVEL
+      value: debug
+- op: remove
+  path: /spec/template/spec/containers/0/securityContext
+`)
+	format, ops := classifyPatch(raw, hintNone)
+	assert.Equal(t, patchFormatJSON6902, format)
+	assert.Len(t, ops, 2)
+
+	assert.Equal(t, "add", ops[0].op)
+	assert.Equal(t, "/spec/template/spec/containers/0/env", ops[0].path)
+	assert.True(t, ops[0].hasValue, "add carries a value")
+	assert.NotNil(t, ops[0].value)
+
+	assert.Equal(t, "remove", ops[1].op)
+	assert.Equal(t, "/spec/template/spec/containers/0/securityContext", ops[1].path)
+	assert.False(t, ops[1].hasValue, "remove carries no value")
+}
+
+func TestClassifyPatch_JSON6902InlineArray(t *testing.T) {
+	// JSON array syntax is equally valid and classifies the same way.
+	raw := []byte(`[{"op":"replace","path":"/spec/replicas","value":5}]`)
+	format, ops := classifyPatch(raw, hintNone)
+	assert.Equal(t, patchFormatJSON6902, format)
+	assert.Len(t, ops, 1)
+	assert.Equal(t, "replace", ops[0].op)
+	assert.Equal(t, "/spec/replicas", ops[0].path)
+	assert.True(t, ops[0].hasValue)
+	assert.EqualValues(t, 5, ops[0].value)
+}
+
+func TestClassifyPatch_SequenceWithoutOpIsStrategicMerge(t *testing.T) {
+	// A sequence whose elements lack `op` is not a JSON6902 patch.
+	raw := []byte(`- name: a
+  value: 1
+`)
+	format, ops := classifyPatch(raw, hintNone)
+	assert.Equal(t, patchFormatStrategicMerge, format)
+	assert.Empty(t, ops)
+}
+
+func TestClassifyPatch_Hints(t *testing.T) {
+	// A forced strategic-merge hint never decomposes operations even if the
+	// content looks like JSON6902.
+	json6902 := []byte(`- op: remove
+  path: /spec
+`)
+	format, ops := classifyPatch(json6902, hintStrategicMerge)
+	assert.Equal(t, patchFormatStrategicMerge, format)
+	assert.Empty(t, ops)
+
+	// A forced json6902 hint decodes whatever operations are present.
+	format, ops = classifyPatch(json6902, hintJSON6902)
+	assert.Equal(t, patchFormatJSON6902, format)
+	assert.Len(t, ops, 1)
+	assert.Equal(t, "remove", ops[0].op)
+}
+
+func TestClassifyPatch_MalformedIsStrategicMerge(t *testing.T) {
+	// Malformed YAML must never panic and falls back to strategic-merge.
+	format, ops := classifyPatch([]byte("this: : : not valid"), hintNone)
+	assert.Equal(t, patchFormatStrategicMerge, format)
+	assert.Empty(t, ops)
+
+	// Empty content is strategic-merge with no operations.
+	format, ops = classifyPatch(nil, hintNone)
+	assert.Equal(t, patchFormatStrategicMerge, format)
+	assert.Empty(t, ops)
+}

--- a/providers/kustomize/testdata/patches/deployment.yaml
+++ b/providers/kustomize/testdata/patches/deployment.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: app
+          image: nginx
+          securityContext:
+            runAsNonRoot: true

--- a/providers/kustomize/testdata/patches/kustomization.yaml
+++ b/providers/kustomize/testdata/patches/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+
+patches:
+  # Strategic-merge patch: a mapping with apiVersion/kind.
+  - target:
+      kind: Deployment
+      name: myapp
+    patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: myapp
+      spec:
+        replicas: 3
+  # JSON6902 patch: a sequence of op objects, including a remove that
+  # strips the container securityContext.
+  - target:
+      kind: Deployment
+      name: myapp
+    patch: |
+      - op: add
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: LOG_LEVEL
+            value: debug
+      - op: remove
+        path: /spec/template/spec/containers/0/securityContext


### PR DESCRIPTION
## What

Make Kustomize patches queryable by format and decompose JSON6902 patches into individual operations.

Adds to `kustomize.patch`:
- `format string` — `"strategicMerge"` or `"json6902"`.
- `operations() []kustomize.patch.operation` — decomposed RFC6902 ops, populated only for `json6902` patches (empty otherwise).

New sub-resource `kustomize.patch.operation` (`@defaults("op path")`):
- `op string` — add | remove | replace | move | copy | test
- `path string` — RFC6901 JSON pointer
- `value dict` — present for add/replace/test, null otherwise

Its `__id` is parent-qualified/synthetic (`<patchId>/op[<i>]`), so no public `id` field is declared (per the synthetic-id rule).

## Why (audit value)

Today `kustomize.patch.content` is an opaque raw string. A policy can't tell a strategic-merge patch from a JSON patch, nor detect a patch that **removes** a security control. With this change an auditor can write, e.g.:

```mql
kustomize.kustomizations.all(
  patches.where(format == "json6902").all(
    operations.none(op == "remove" && path.contains("securityContext"))
  )
)
```

## How

The classifier inspects the patch content shape (inline `content`, or the file at `path` relative to the kustomization dir):
- A YAML/JSON **sequence** whose elements are all maps carrying an `op` key → `json6902`; each element is decoded into op/path/value.
- Anything else (a mapping, typically with apiVersion/kind) → `strategicMerge`.

Legacy `patchesJson6902:` / `patchesStrategicMerge:` lists are now also surfaced and force their (unambiguous) format. Classification is defensive: malformed patches never panic — they fall back to `strategicMerge` with empty operations and don't error the audit.

## Tests / verification

- Unit tests for `classifyPatch`/`decodeJSON6902` covering strategic-merge, JSON6902 (sequence + inline-array), op-less sequence, forced hints, and malformed/empty input. `go test ./...` in the provider module passes.
- New testdata at `providers/kustomize/testdata/patches/` with both a strategic-merge patch and a JSON6902 patch (add + remove).
- Real query against the testdata:

```
kustomize.kustomizations: [ 0: { patches: [
  0: { format: "strategicMerge", operations: [] }
  1: { format: "json6902", operations: [
    0: { op: "add",    path: "/spec/template/spec/containers/0/env",            value: [...] }
    1: { op: "remove", path: "/spec/template/spec/containers/0/securityContext", value: null }
  ] }
] } ]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)