### PR TITLE
✨ bicep: tokenize variable and output expressions into a queryable tree

### DIFF
--- a/providers/bicep/resources/bicep.lr
+++ b/providers/bicep/resources/bicep.lr
@@ -97,6 +97,14 @@ bicep.variable @defaults("name") {
   name string
   // Value expression (raw Bicep expression)
   expression string
+  // Parsed expression tree
+  //
+  // Structured, queryable view of the `expression` value. Use it to ask
+  // whether a value is a hardcoded literal, which Bicep function builds it
+  // (`functionCall`), which symbolic resources or parameters it references
+  // (`symbolicRef` / `propertyAccess`), and which parameters an
+  // interpolated name string embeds. See `bicep.expression`.
+  expressionTree() bicep.expression
   // Description from @description decorator
   description string
 }
@@ -181,8 +189,56 @@ bicep.output @defaults("name type") {
   type string
   // Value expression
   expression string
+  // Parsed expression tree
+  //
+  // Structured, queryable view of the `expression` value. Use it to spot
+  // outputs that return a hardcoded literal, that call a specific Bicep
+  // function (`functionCall`), or that reference a resource property or a
+  // `@secure` parameter (`symbolicRef` / `propertyAccess` / `interpolation`).
+  // See `bicep.expression`.
+  expressionTree() bicep.expression
   // Description from @description decorator
   description string
+}
+
+// Parsed Bicep expression
+//
+// Examine the structure of a single Bicep value expression broken into a
+// queryable tree. The `kind` field classifies the node — `literal`,
+// `functionCall`, `propertyAccess`, `symbolicRef`, `interpolation`,
+// `ternary`, `array`, or `unknown` — and `raw` always holds the original
+// source text. For a `functionCall`, `functionName` names the called
+// function (`resourceId`, `concat`, `reference`, …) and `args` lists its
+// parsed arguments. For a `propertyAccess` or `symbolicRef`, `target` is
+// the root identifier and `path` is the accessor chain (for example
+// `vnet.properties.subnets[0].id` yields target `vnet` and path
+// `["properties","subnets","0","id"]`). For an `interpolation`, `segments`
+// holds the alternating literal and embedded-expression parts of a
+// `'...${expr}...'` string. This is structure only — values are never
+// evaluated — so policies can ask questions like "is this location a
+// hardcoded literal?" or "does this name interpolate a parameter?" without
+// resolving the deployment.
+bicep.expression @defaults("kind raw") {
+  // Node kind
+  //
+  // One of literal, functionCall, propertyAccess, symbolicRef,
+  // interpolation, ternary, array, or unknown.
+  kind string
+  // Original source text of the expression
+  raw string
+  // Called function name for a functionCall node (empty otherwise)
+  functionName string
+  // Parsed arguments of a functionCall node
+  args() []bicep.expression
+  // Root identifier of a propertyAccess or symbolicRef node (empty otherwise)
+  target string
+  // Accessor chain of a propertyAccess node
+  //
+  // For example `vnet.properties.subnets[0].id` produces
+  // `["properties","subnets","0","id"]`. Empty for other kinds.
+  path []string
+  // Alternating literal and embedded-expression parts of an interpolation node
+  segments() []bicep.expression
 }
 
 // Compiled ARM template (from ARM JSON input)

--- a/providers/bicep/resources/bicep.lr.go
+++ b/providers/bicep/resources/bicep.lr.go
@@ -22,6 +22,7 @@ const (
 	ResourceBicepResource         string = "bicep.resource"
 	ResourceBicepModule           string = "bicep.module"
 	ResourceBicepOutput           string = "bicep.output"
+	ResourceBicepExpression       string = "bicep.expression"
 	ResourceBicepTemplate         string = "bicep.template"
 	ResourceBicepTemplateResource string = "bicep.template.resource"
 )
@@ -57,6 +58,10 @@ func init() {
 		"bicep.output": {
 			// to override args, implement: initBicepOutput(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createBicepOutput,
+		},
+		"bicep.expression": {
+			// to override args, implement: initBicepExpression(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createBicepExpression,
 		},
 		"bicep.template": {
 			// to override args, implement: initBicepTemplate(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -206,6 +211,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.variable.expression": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepVariable).GetExpression()).ToDataRes(types.String)
 	},
+	"bicep.variable.expressionTree": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepVariable).GetExpressionTree()).ToDataRes(types.Resource("bicep.expression"))
+	},
 	"bicep.variable.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepVariable).GetDescription()).ToDataRes(types.String)
 	},
@@ -281,8 +289,32 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.output.expression": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepOutput).GetExpression()).ToDataRes(types.String)
 	},
+	"bicep.output.expressionTree": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepOutput).GetExpressionTree()).ToDataRes(types.Resource("bicep.expression"))
+	},
 	"bicep.output.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepOutput).GetDescription()).ToDataRes(types.String)
+	},
+	"bicep.expression.kind": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepExpression).GetKind()).ToDataRes(types.String)
+	},
+	"bicep.expression.raw": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepExpression).GetRaw()).ToDataRes(types.String)
+	},
+	"bicep.expression.functionName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepExpression).GetFunctionName()).ToDataRes(types.String)
+	},
+	"bicep.expression.args": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepExpression).GetArgs()).ToDataRes(types.Array(types.Resource("bicep.expression")))
+	},
+	"bicep.expression.target": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepExpression).GetTarget()).ToDataRes(types.String)
+	},
+	"bicep.expression.path": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepExpression).GetPath()).ToDataRes(types.Array(types.String))
+	},
+	"bicep.expression.segments": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepExpression).GetSegments()).ToDataRes(types.Array(types.Resource("bicep.expression")))
 	},
 	"bicep.template.schema": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepTemplate).GetSchema()).ToDataRes(types.String)
@@ -443,6 +475,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlBicepVariable).Expression, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"bicep.variable.expressionTree": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepVariable).ExpressionTree, ok = plugin.RawToTValue[*mqlBicepExpression](v.Value, v.Error)
+		return
+	},
 	"bicep.variable.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepVariable).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -555,8 +591,44 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlBicepOutput).Expression, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"bicep.output.expressionTree": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepOutput).ExpressionTree, ok = plugin.RawToTValue[*mqlBicepExpression](v.Value, v.Error)
+		return
+	},
 	"bicep.output.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepOutput).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.expression.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepExpression).__id, ok = v.Value.(string)
+		return
+	},
+	"bicep.expression.kind": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepExpression).Kind, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.expression.raw": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepExpression).Raw, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.expression.functionName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepExpression).FunctionName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.expression.args": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepExpression).Args, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"bicep.expression.target": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepExpression).Target, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"bicep.expression.path": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepExpression).Path, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"bicep.expression.segments": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepExpression).Segments, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"bicep.template.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -964,9 +1036,10 @@ type mqlBicepVariable struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlBicepVariableInternal it will be used here
-	Name        plugin.TValue[string]
-	Expression  plugin.TValue[string]
-	Description plugin.TValue[string]
+	Name           plugin.TValue[string]
+	Expression     plugin.TValue[string]
+	ExpressionTree plugin.TValue[*mqlBicepExpression]
+	Description    plugin.TValue[string]
 }
 
 // createBicepVariable creates a new instance of this resource
@@ -1007,6 +1080,22 @@ func (c *mqlBicepVariable) GetName() *plugin.TValue[string] {
 
 func (c *mqlBicepVariable) GetExpression() *plugin.TValue[string] {
 	return &c.Expression
+}
+
+func (c *mqlBicepVariable) GetExpressionTree() *plugin.TValue[*mqlBicepExpression] {
+	return plugin.GetOrCompute[*mqlBicepExpression](&c.ExpressionTree, func() (*mqlBicepExpression, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.variable", c.__id, "expressionTree")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlBicepExpression), nil
+			}
+		}
+
+		return c.expressionTree()
+	})
 }
 
 func (c *mqlBicepVariable) GetDescription() *plugin.TValue[string] {
@@ -1201,10 +1290,11 @@ type mqlBicepOutput struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlBicepOutputInternal it will be used here
-	Name        plugin.TValue[string]
-	Type        plugin.TValue[string]
-	Expression  plugin.TValue[string]
-	Description plugin.TValue[string]
+	Name           plugin.TValue[string]
+	Type           plugin.TValue[string]
+	Expression     plugin.TValue[string]
+	ExpressionTree plugin.TValue[*mqlBicepExpression]
+	Description    plugin.TValue[string]
 }
 
 // createBicepOutput creates a new instance of this resource
@@ -1251,8 +1341,122 @@ func (c *mqlBicepOutput) GetExpression() *plugin.TValue[string] {
 	return &c.Expression
 }
 
+func (c *mqlBicepOutput) GetExpressionTree() *plugin.TValue[*mqlBicepExpression] {
+	return plugin.GetOrCompute[*mqlBicepExpression](&c.ExpressionTree, func() (*mqlBicepExpression, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.output", c.__id, "expressionTree")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlBicepExpression), nil
+			}
+		}
+
+		return c.expressionTree()
+	})
+}
+
 func (c *mqlBicepOutput) GetDescription() *plugin.TValue[string] {
 	return &c.Description
+}
+
+// mqlBicepExpression for the bicep.expression resource
+type mqlBicepExpression struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlBicepExpressionInternal
+	Kind         plugin.TValue[string]
+	Raw          plugin.TValue[string]
+	FunctionName plugin.TValue[string]
+	Args         plugin.TValue[[]any]
+	Target       plugin.TValue[string]
+	Path         plugin.TValue[[]any]
+	Segments     plugin.TValue[[]any]
+}
+
+// createBicepExpression creates a new instance of this resource
+func createBicepExpression(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlBicepExpression{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("bicep.expression", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlBicepExpression) MqlName() string {
+	return "bicep.expression"
+}
+
+func (c *mqlBicepExpression) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlBicepExpression) GetKind() *plugin.TValue[string] {
+	return &c.Kind
+}
+
+func (c *mqlBicepExpression) GetRaw() *plugin.TValue[string] {
+	return &c.Raw
+}
+
+func (c *mqlBicepExpression) GetFunctionName() *plugin.TValue[string] {
+	return &c.FunctionName
+}
+
+func (c *mqlBicepExpression) GetArgs() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Args, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.expression", c.__id, "args")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.args()
+	})
+}
+
+func (c *mqlBicepExpression) GetTarget() *plugin.TValue[string] {
+	return &c.Target
+}
+
+func (c *mqlBicepExpression) GetPath() *plugin.TValue[[]any] {
+	return &c.Path
+}
+
+func (c *mqlBicepExpression) GetSegments() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Segments, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.expression", c.__id, "segments")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.segments()
+	})
 }
 
 // mqlBicepTemplate for the bicep.template resource

--- a/providers/bicep/resources/bicep.lr.versions
+++ b/providers/bicep/resources/bicep.lr.versions
@@ -2,6 +2,14 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 bicep 13.0.0
+bicep.expression 13.1.2
+bicep.expression.args 13.1.2
+bicep.expression.functionName 13.1.2
+bicep.expression.kind 13.1.2
+bicep.expression.path 13.1.2
+bicep.expression.raw 13.1.2
+bicep.expression.segments 13.1.2
+bicep.expression.target 13.1.2
 bicep.file 13.0.0
 bicep.file.content 13.0.0
 bicep.file.modules 13.0.0
@@ -25,6 +33,7 @@ bicep.module.source 13.0.0
 bicep.output 13.0.0
 bicep.output.description 13.0.0
 bicep.output.expression 13.0.0
+bicep.output.expressionTree 13.1.2
 bicep.output.name 13.0.0
 bicep.output.type 13.0.0
 bicep.parameter 13.0.0
@@ -70,4 +79,5 @@ bicep.template.variables 13.0.0
 bicep.variable 13.0.0
 bicep.variable.description 13.0.0
 bicep.variable.expression 13.0.0
+bicep.variable.expressionTree 13.1.2
 bicep.variable.name 13.0.0

--- a/providers/bicep/resources/expression.go
+++ b/providers/bicep/resources/expression.go
@@ -1,0 +1,524 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "strings"
+
+// exprKind classifies a parsed Bicep expression node.
+const (
+	exprKindLiteral        = "literal"
+	exprKindFunctionCall   = "functionCall"
+	exprKindPropertyAccess = "propertyAccess"
+	exprKindSymbolicRef    = "symbolicRef"
+	exprKindInterpolation  = "interpolation"
+	exprKindTernary        = "ternary"
+	exprKindArray          = "array"
+	exprKindUnknown        = "unknown"
+)
+
+// exprNode is the structured, queryable view of a single Bicep expression.
+// It is produced by parseExpression and never carries evaluated values —
+// it describes the *shape* of an expression (a function call, a symbolic
+// reference, an interpolated string, …), not its computed result.
+type exprNode struct {
+	kind string
+	// raw is the original source text of this node, always populated.
+	raw string
+
+	// functionName is set for functionCall nodes (e.g. "resourceId").
+	functionName string
+	// args holds the parsed arguments of a functionCall.
+	args []*exprNode
+
+	// target is the root identifier of a propertyAccess or symbolicRef
+	// (e.g. "vnet" in vnet.properties.subnets[0].id).
+	target string
+	// path is the accessor chain of a propertyAccess
+	// (e.g. ["properties","subnets","0","id"]).
+	path []string
+
+	// segments holds the alternating literal / embedded-expression parts
+	// of an interpolated string ('...${expr}...').
+	segments []*exprNode
+}
+
+// parseExpression turns a raw Bicep expression string into a structured
+// exprNode tree. It never panics and never returns an error — any input it
+// can't classify becomes an exprNode of kind "unknown" with raw preserved,
+// so audits always get a usable node. The grammar covered is intentionally
+// bounded (literals, identifiers, member/index chains, function calls,
+// ternaries, arrays, and interpolated-string segments); this is structure
+// only, never evaluation.
+func parseExpression(raw string) *exprNode {
+	trimmed := strings.TrimSpace(raw)
+	p := &exprParser{src: trimmed}
+	node := p.parseTernary()
+	// If the parser couldn't consume the whole input, the expression is
+	// outside the supported grammar — fall back to "unknown" but keep the
+	// original text intact.
+	if node == nil || !p.atEnd() {
+		return &exprNode{kind: exprKindUnknown, raw: trimmed}
+	}
+	// Always report the original (untrimmed-internal) text as raw.
+	node.raw = trimmed
+	return node
+}
+
+// exprParser is a tiny recursive-descent parser over the bounded Bicep
+// expression grammar. It walks the source by byte index and reuses the
+// package's string-aware scanState for skipping quoted literals when it
+// needs to find delimiters.
+type exprParser struct {
+	src string
+	pos int
+}
+
+func (p *exprParser) atEnd() bool {
+	p.skipSpace()
+	return p.pos >= len(p.src)
+}
+
+func (p *exprParser) skipSpace() {
+	for p.pos < len(p.src) {
+		c := p.src[p.pos]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			p.pos++
+			continue
+		}
+		break
+	}
+}
+
+func (p *exprParser) peek() byte {
+	if p.pos >= len(p.src) {
+		return 0
+	}
+	return p.src[p.pos]
+}
+
+// parseTernary parses `cond ? a : b`, falling through to the primary/postfix
+// grammar when no `?` is present at the current top level.
+func (p *exprParser) parseTernary() *exprNode {
+	start := p.pos
+	// A ternary is recognized by a `?` at the current top level. Scan for
+	// it first (string- and bracket-aware) so a condition that uses binary
+	// operators we don't model (`a == b`, `a && b`) still yields a ternary
+	// node — the condition simply parses as `unknown` with raw preserved,
+	// rather than collapsing the whole expression to unknown.
+	// The operand span runs from `start` up to the next top-level element
+	// terminator (`,`, `)`, `]`) or end of source — this keeps ternary
+	// detection scoped to a single array element or call argument.
+	operandEnd := p.findOperandEnd(start)
+	qPos := p.findTopLevelWithin('?', start, operandEnd)
+	if qPos < 0 {
+		return p.parsePostfix()
+	}
+	cPos := p.findTopLevelWithin(':', qPos+1, operandEnd)
+	if cPos < 0 {
+		return p.parsePostfix()
+	}
+
+	cond := parseSubExpression(p.src[start:qPos])
+	thenNode := parseSubExpression(p.src[qPos+1 : cPos])
+	elseNode := parseSubExpression(p.src[cPos+1 : operandEnd])
+	p.pos = operandEnd
+
+	return &exprNode{
+		kind: exprKindTernary,
+		raw:  strings.TrimSpace(p.src[start:operandEnd]),
+		args: []*exprNode{cond, thenNode, elseNode},
+	}
+}
+
+// findOperandEnd returns the byte index where the current operand ends — the
+// first top-level `,`, `)`, or `]`, or len(src) if none. This bounds ternary
+// detection to one element inside arrays and argument lists.
+func (p *exprParser) findOperandEnd(from int) int {
+	st := scanState{}
+	for i := from; i < len(p.src); {
+		if st.inStr == 0 && !st.inMulti && st.totalDepth() == 0 {
+			switch p.src[i] {
+			case ',', ')', ']':
+				return i
+			}
+		}
+		i = st.stepAt(p.src, i)
+	}
+	return len(p.src)
+}
+
+// findTopLevelWithin returns the index of the first `target` at depth zero,
+// outside any string, in [from, end). Returns -1 if not found. Reuses
+// scanState so quotes and nested brackets are respected.
+func (p *exprParser) findTopLevelWithin(target byte, from, end int) int {
+	st := scanState{}
+	for i := from; i < end; {
+		if st.inStr == 0 && !st.inMulti && st.totalDepth() == 0 && p.src[i] == target {
+			return i
+		}
+		i = st.stepAt(p.src, i)
+	}
+	return -1
+}
+
+// parseSubExpression parses a standalone sub-expression (a ternary branch or
+// condition). It never returns nil — anything outside the supported grammar
+// becomes an `unknown` node with raw preserved.
+func parseSubExpression(raw string) *exprNode {
+	return parseExpression(raw)
+}
+
+// parsePostfix parses a primary expression followed by any chain of member
+// (`.foo`), index (`[...]`), or call (`(...)`) accessors.
+func (p *exprParser) parsePostfix() *exprNode {
+	node := p.parsePrimary()
+	if node == nil {
+		return nil
+	}
+
+	for {
+		p.skipSpace()
+		c := p.peek()
+		switch {
+		case c == '.':
+			p.pos++
+			name := p.readIdentifier()
+			if name == "" {
+				return nil
+			}
+			node = appendAccess(node, name)
+		case c == '[':
+			idx, ok := p.readIndex()
+			if !ok {
+				return nil
+			}
+			node = appendAccess(node, idx)
+		case c == '(':
+			// A call applies only to a bare identifier (function name).
+			if node.kind != exprKindSymbolicRef {
+				return nil
+			}
+			args, ok := p.readArgs()
+			if !ok {
+				return nil
+			}
+			node = &exprNode{
+				kind:         exprKindFunctionCall,
+				functionName: node.target,
+				args:         args,
+			}
+		default:
+			return node
+		}
+	}
+}
+
+// appendAccess turns the base node into (or extends) a propertyAccess node
+// with the given accessor appended to its path. A bare symbolicRef or a
+// functionCall both become the `target`-less / `target`-bearing root of the
+// access chain as appropriate.
+func appendAccess(base *exprNode, accessor string) *exprNode {
+	if base.kind == exprKindSymbolicRef {
+		return &exprNode{
+			kind:   exprKindPropertyAccess,
+			target: base.target,
+			path:   []string{accessor},
+		}
+	}
+	if base.kind == exprKindPropertyAccess {
+		base.path = append(base.path, accessor)
+		return base
+	}
+	// Accessing into a functionCall, array, etc. — model it as a
+	// propertyAccess whose target is empty and that carries the base as
+	// its first arg so the chain stays queryable.
+	return &exprNode{
+		kind:   exprKindPropertyAccess,
+		target: "",
+		path:   []string{accessor},
+		args:   []*exprNode{base},
+	}
+}
+
+// parsePrimary parses a leaf: a string literal (possibly interpolated), a
+// number / bool / null literal, an array, a parenthesized sub-expression, or
+// a bare identifier (symbolic reference / function-name root).
+func (p *exprParser) parsePrimary() *exprNode {
+	p.skipSpace()
+	if p.pos >= len(p.src) {
+		return nil
+	}
+	c := p.peek()
+
+	switch {
+	case c == '\'':
+		return p.parseString()
+	case c == '"':
+		return p.parseDoubleString()
+	case c == '[':
+		return p.parseArray()
+	case c == '(':
+		return p.parseParen()
+	case c >= '0' && c <= '9', c == '-':
+		return p.parseNumber()
+	case isIdentStart(c):
+		ident := p.readIdentifier()
+		switch ident {
+		case "true", "false", "null":
+			return &exprNode{kind: exprKindLiteral, raw: ident}
+		case "":
+			return nil
+		}
+		return &exprNode{kind: exprKindSymbolicRef, raw: ident, target: ident}
+	}
+	return nil
+}
+
+// parseString parses a single-quoted Bicep string. If it contains `${...}`
+// interpolation it returns an interpolation node whose segments alternate
+// literal text and embedded expressions; otherwise a plain literal node.
+func (p *exprParser) parseString() *exprNode {
+	start := p.pos
+	// Triple-quoted multi-line string: treat as an opaque literal.
+	if strings.HasPrefix(p.src[p.pos:], "'''") {
+		end := strings.Index(p.src[p.pos+3:], "'''")
+		if end < 0 {
+			return nil
+		}
+		p.pos = p.pos + 3 + end + 3
+		return &exprNode{kind: exprKindLiteral, raw: p.src[start:p.pos]}
+	}
+
+	p.pos++ // consume opening quote
+	var segments []*exprNode
+	var lit strings.Builder
+	hasInterp := false
+
+	for p.pos < len(p.src) {
+		ch := p.src[p.pos]
+		if ch == '\\' && p.pos+1 < len(p.src) {
+			// Preserve the escape pair verbatim in the literal text.
+			lit.WriteByte(ch)
+			lit.WriteByte(p.src[p.pos+1])
+			p.pos += 2
+			continue
+		}
+		if ch == '$' && p.pos+1 < len(p.src) && p.src[p.pos+1] == '{' {
+			hasInterp = true
+			// Flush the literal collected so far as a segment.
+			segments = append(segments, &exprNode{kind: exprKindLiteral, raw: lit.String()})
+			lit.Reset()
+			inner, ok := p.readInterpolation()
+			if !ok {
+				return nil
+			}
+			segments = append(segments, parseExpression(inner))
+			continue
+		}
+		if ch == '\'' {
+			p.pos++ // consume closing quote
+			raw := p.src[start:p.pos]
+			if !hasInterp {
+				return &exprNode{kind: exprKindLiteral, raw: raw}
+			}
+			// Flush trailing literal segment.
+			segments = append(segments, &exprNode{kind: exprKindLiteral, raw: lit.String()})
+			return &exprNode{kind: exprKindInterpolation, raw: raw, segments: segments}
+		}
+		lit.WriteByte(ch)
+		p.pos++
+	}
+	// Unterminated string.
+	return nil
+}
+
+// parseDoubleString parses a double-quoted string as an opaque literal.
+// (Bicep proper uses single quotes; double quotes show up in compiled/ARM
+// fragments and are treated as plain literals here.)
+func (p *exprParser) parseDoubleString() *exprNode {
+	start := p.pos
+	p.pos++ // consume opening quote
+	for p.pos < len(p.src) {
+		ch := p.src[p.pos]
+		if ch == '\\' && p.pos+1 < len(p.src) {
+			p.pos += 2
+			continue
+		}
+		if ch == '"' {
+			p.pos++
+			return &exprNode{kind: exprKindLiteral, raw: p.src[start:p.pos]}
+		}
+		p.pos++
+	}
+	return nil
+}
+
+// readInterpolation consumes a `${ ... }` block (cursor sitting on `$`) and
+// returns the inner expression text. Brace and string nesting inside the
+// block is respected via scanState so a `}` inside a nested string doesn't
+// close it early.
+func (p *exprParser) readInterpolation() (string, bool) {
+	// Cursor is on '$', next is '{'.
+	p.pos += 2 // skip "${"
+	start := p.pos
+	st := scanState{brace: 1}
+	for p.pos < len(p.src) {
+		next := st.stepAt(p.src, p.pos)
+		if st.brace == 0 {
+			inner := p.src[start:p.pos]
+			p.pos = next
+			return inner, true
+		}
+		p.pos = next
+	}
+	return "", false
+}
+
+// parseNumber parses an integer literal (optionally negative).
+func (p *exprParser) parseNumber() *exprNode {
+	start := p.pos
+	if p.peek() == '-' {
+		p.pos++
+	}
+	digits := false
+	for p.pos < len(p.src) && p.src[p.pos] >= '0' && p.src[p.pos] <= '9' {
+		p.pos++
+		digits = true
+	}
+	if !digits {
+		return nil
+	}
+	return &exprNode{kind: exprKindLiteral, raw: p.src[start:p.pos]}
+}
+
+// parseArray parses `[ a, b, ... ]` into an array node whose args are the
+// parsed elements.
+func (p *exprParser) parseArray() *exprNode {
+	start := p.pos
+	p.pos++ // consume '['
+	var elems []*exprNode
+	for {
+		p.skipSpace()
+		if p.peek() == ']' {
+			p.pos++
+			return &exprNode{kind: exprKindArray, raw: p.src[start:p.pos], args: elems}
+		}
+		if p.pos >= len(p.src) {
+			return nil
+		}
+		elem := p.parseTernary()
+		if elem == nil {
+			return nil
+		}
+		elems = append(elems, elem)
+		p.skipSpace()
+		switch p.peek() {
+		case ',':
+			p.pos++
+		case ']':
+			p.pos++
+			return &exprNode{kind: exprKindArray, raw: p.src[start:p.pos], args: elems}
+		default:
+			return nil
+		}
+	}
+}
+
+// parseParen parses a parenthesized sub-expression and returns the inner
+// node directly (the parentheses are purely for grouping).
+func (p *exprParser) parseParen() *exprNode {
+	p.pos++ // consume '('
+	inner := p.parseTernary()
+	if inner == nil {
+		return nil
+	}
+	p.skipSpace()
+	if p.peek() != ')' {
+		return nil
+	}
+	p.pos++
+	return inner
+}
+
+// readArgs parses a `( arg1, arg2, ... )` argument list (cursor on `(`).
+func (p *exprParser) readArgs() ([]*exprNode, bool) {
+	p.pos++ // consume '('
+	var args []*exprNode
+	for {
+		p.skipSpace()
+		if p.peek() == ')' {
+			p.pos++
+			return args, true
+		}
+		if p.pos >= len(p.src) {
+			return nil, false
+		}
+		arg := p.parseTernary()
+		if arg == nil {
+			return nil, false
+		}
+		args = append(args, arg)
+		p.skipSpace()
+		switch p.peek() {
+		case ',':
+			p.pos++
+		case ')':
+			p.pos++
+			return args, true
+		default:
+			return nil, false
+		}
+	}
+}
+
+// readIndex parses a `[...]` index accessor (cursor on `[`) and returns the
+// accessor as a path segment: a quoted key becomes its unquoted contents, a
+// numeric index becomes its digits, everything else is the raw inner text.
+func (p *exprParser) readIndex() (string, bool) {
+	p.pos++ // consume '['
+	start := p.pos
+	st := scanState{bracket: 1}
+	for p.pos < len(p.src) {
+		next := st.stepAt(p.src, p.pos)
+		if st.bracket == 0 {
+			inner := strings.TrimSpace(p.src[start:p.pos])
+			p.pos = next
+			return normalizeIndex(inner), true
+		}
+		p.pos = next
+	}
+	return "", false
+}
+
+// normalizeIndex strips surrounding quotes from a string key so
+// foo['bar'] and foo.bar produce the same path segment "bar". Numeric and
+// expression indices are returned as-is.
+func normalizeIndex(s string) string {
+	if len(s) >= 2 {
+		if (s[0] == '\'' && s[len(s)-1] == '\'') || (s[0] == '"' && s[len(s)-1] == '"') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+
+func (p *exprParser) readIdentifier() string {
+	p.skipSpace()
+	start := p.pos
+	if p.pos < len(p.src) && isIdentStart(p.src[p.pos]) {
+		p.pos++
+		for p.pos < len(p.src) && isIdentPart(p.src[p.pos]) {
+			p.pos++
+		}
+	}
+	return p.src[start:p.pos]
+}
+
+func isIdentStart(c byte) bool {
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func isIdentPart(c byte) bool {
+	return isIdentStart(c) || (c >= '0' && c <= '9')
+}

--- a/providers/bicep/resources/expression.go
+++ b/providers/bicep/resources/expression.go
@@ -387,6 +387,9 @@ func (p *exprParser) parseNumber() *exprNode {
 		digits = true
 	}
 	if !digits {
+		// Rewind: a bare '-' (e.g. in an unsupported binary expression like
+		// `a - b`) is not a number, so leave the cursor where we found it.
+		p.pos = start
 		return nil
 	}
 	return &exprNode{kind: exprKindLiteral, raw: p.src[start:p.pos]}

--- a/providers/bicep/resources/expression_test.go
+++ b/providers/bicep/resources/expression_test.go
@@ -1,0 +1,238 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseExpressionLiteral(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{"single-quoted string", "'eastus'"},
+		{"integer", "42"},
+		{"negative integer", "-7"},
+		{"bool true", "true"},
+		{"bool false", "false"},
+		{"null", "null"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := parseExpression(tt.raw)
+			assert.Equal(t, exprKindLiteral, node.kind)
+			assert.Equal(t, tt.raw, node.raw)
+		})
+	}
+}
+
+func TestParseExpressionSymbolicRef(t *testing.T) {
+	node := parseExpression("myParam")
+	assert.Equal(t, exprKindSymbolicRef, node.kind)
+	assert.Equal(t, "myParam", node.target)
+	assert.Equal(t, "myParam", node.raw)
+	assert.Empty(t, node.path)
+}
+
+func TestParseExpressionFunctionCallSimple(t *testing.T) {
+	// resourceGroup().location -> propertyAccess whose base is a
+	// functionCall on resourceGroup.
+	node := parseExpression("resourceGroup().location")
+	require.Equal(t, exprKindPropertyAccess, node.kind)
+	assert.Equal(t, []string{"location"}, node.path)
+	assert.Equal(t, "resourceGroup().location", node.raw)
+
+	// The base function call is preserved as the first arg.
+	require.Len(t, node.args, 1)
+	base := node.args[0]
+	assert.Equal(t, exprKindFunctionCall, base.kind)
+	assert.Equal(t, "resourceGroup", base.functionName)
+	assert.Empty(t, base.args)
+}
+
+func TestParseExpressionFunctionCallNestedArgs(t *testing.T) {
+	node := parseExpression("concat('a', var, 'b')")
+	require.Equal(t, exprKindFunctionCall, node.kind)
+	assert.Equal(t, "concat", node.functionName)
+	require.Len(t, node.args, 3)
+
+	assert.Equal(t, exprKindLiteral, node.args[0].kind)
+	assert.Equal(t, "'a'", node.args[0].raw)
+
+	assert.Equal(t, exprKindSymbolicRef, node.args[1].kind)
+	assert.Equal(t, "var", node.args[1].target)
+
+	assert.Equal(t, exprKindLiteral, node.args[2].kind)
+	assert.Equal(t, "'b'", node.args[2].raw)
+}
+
+func TestParseExpressionFunctionCallDeepNesting(t *testing.T) {
+	node := parseExpression("resourceId('Microsoft.Network/virtualNetworks', concat(prefix, '-vnet'))")
+	require.Equal(t, exprKindFunctionCall, node.kind)
+	assert.Equal(t, "resourceId", node.functionName)
+	require.Len(t, node.args, 2)
+
+	assert.Equal(t, exprKindLiteral, node.args[0].kind)
+
+	inner := node.args[1]
+	require.Equal(t, exprKindFunctionCall, inner.kind)
+	assert.Equal(t, "concat", inner.functionName)
+	require.Len(t, inner.args, 2)
+	assert.Equal(t, exprKindSymbolicRef, inner.args[0].kind)
+	assert.Equal(t, "prefix", inner.args[0].target)
+	assert.Equal(t, exprKindLiteral, inner.args[1].kind)
+}
+
+func TestParseExpressionInterpolation(t *testing.T) {
+	node := parseExpression("'${prefix}-sa'")
+	require.Equal(t, exprKindInterpolation, node.kind)
+	assert.Equal(t, "'${prefix}-sa'", node.raw)
+
+	// segments: leading literal "", embedded expr `prefix`, trailing "-sa"
+	require.Len(t, node.segments, 3)
+	assert.Equal(t, exprKindLiteral, node.segments[0].kind)
+	assert.Equal(t, "", node.segments[0].raw)
+
+	assert.Equal(t, exprKindSymbolicRef, node.segments[1].kind)
+	assert.Equal(t, "prefix", node.segments[1].target)
+
+	assert.Equal(t, exprKindLiteral, node.segments[2].kind)
+	assert.Equal(t, "-sa", node.segments[2].raw)
+}
+
+func TestParseExpressionInterpolationNestedCall(t *testing.T) {
+	node := parseExpression("'sa-${toLower(resourceGroup().name)}'")
+	require.Equal(t, exprKindInterpolation, node.kind)
+	require.Len(t, node.segments, 3)
+
+	assert.Equal(t, exprKindLiteral, node.segments[0].kind)
+	assert.Equal(t, "sa-", node.segments[0].raw)
+
+	embedded := node.segments[1]
+	require.Equal(t, exprKindFunctionCall, embedded.kind)
+	assert.Equal(t, "toLower", embedded.functionName)
+	require.Len(t, embedded.args, 1)
+	assert.Equal(t, exprKindPropertyAccess, embedded.args[0].kind)
+
+	assert.Equal(t, exprKindLiteral, node.segments[2].kind)
+	assert.Equal(t, "", node.segments[2].raw)
+}
+
+func TestParseExpressionPropertyAccessChainWithIndex(t *testing.T) {
+	node := parseExpression("vnet.properties.subnets[0].id")
+	require.Equal(t, exprKindPropertyAccess, node.kind)
+	assert.Equal(t, "vnet", node.target)
+	assert.Equal(t, []string{"properties", "subnets", "0", "id"}, node.path)
+	assert.Equal(t, "vnet.properties.subnets[0].id", node.raw)
+}
+
+func TestParseExpressionPropertyAccessQuotedKey(t *testing.T) {
+	// foo['bar'] should normalize to the same segment as foo.bar.
+	node := parseExpression("storageAccounts['blobServices'].properties")
+	require.Equal(t, exprKindPropertyAccess, node.kind)
+	assert.Equal(t, "storageAccounts", node.target)
+	assert.Equal(t, []string{"blobServices", "properties"}, node.path)
+}
+
+func TestParseExpressionTernary(t *testing.T) {
+	node := parseExpression("useProd ? 'prod' : 'dev'")
+	require.Equal(t, exprKindTernary, node.kind)
+	require.Len(t, node.args, 3)
+
+	assert.Equal(t, exprKindSymbolicRef, node.args[0].kind)
+	assert.Equal(t, "useProd", node.args[0].target)
+
+	assert.Equal(t, exprKindLiteral, node.args[1].kind)
+	assert.Equal(t, "'prod'", node.args[1].raw)
+
+	assert.Equal(t, exprKindLiteral, node.args[2].kind)
+	assert.Equal(t, "'dev'", node.args[2].raw)
+}
+
+func TestParseExpressionTernaryWithComparisonCondition(t *testing.T) {
+	// The condition uses `==`, which is outside the modeled grammar, so it
+	// becomes an `unknown` node — but the overall expression is still a
+	// ternary with its branches parsed.
+	node := parseExpression("prefix == 'prod' ? 'Premium' : 'Standard'")
+	require.Equal(t, exprKindTernary, node.kind)
+	require.Len(t, node.args, 3)
+
+	assert.Equal(t, exprKindUnknown, node.args[0].kind)
+	assert.Equal(t, "prefix == 'prod'", node.args[0].raw)
+
+	assert.Equal(t, exprKindLiteral, node.args[1].kind)
+	assert.Equal(t, "'Premium'", node.args[1].raw)
+
+	assert.Equal(t, exprKindLiteral, node.args[2].kind)
+	assert.Equal(t, "'Standard'", node.args[2].raw)
+}
+
+func TestParseExpressionTernaryInsideArray(t *testing.T) {
+	// A ternary as an array element must not swallow the following element.
+	node := parseExpression("[useProd ? 'a' : 'b', other]")
+	require.Equal(t, exprKindArray, node.kind)
+	require.Len(t, node.args, 2)
+	assert.Equal(t, exprKindTernary, node.args[0].kind)
+	require.Len(t, node.args[0].args, 3)
+	assert.Equal(t, exprKindSymbolicRef, node.args[1].kind)
+	assert.Equal(t, "other", node.args[1].target)
+}
+
+func TestParseExpressionArray(t *testing.T) {
+	node := parseExpression("['a', 'b', myVar]")
+	require.Equal(t, exprKindArray, node.kind)
+	require.Len(t, node.args, 3)
+	assert.Equal(t, exprKindLiteral, node.args[0].kind)
+	assert.Equal(t, exprKindLiteral, node.args[1].kind)
+	assert.Equal(t, exprKindSymbolicRef, node.args[2].kind)
+	assert.Equal(t, "myVar", node.args[2].target)
+}
+
+func TestParseExpressionEmptyArray(t *testing.T) {
+	node := parseExpression("[]")
+	require.Equal(t, exprKindArray, node.kind)
+	assert.Empty(t, node.args)
+}
+
+func TestParseExpressionUnknown(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{"unbalanced parens", "concat('a', "},
+		{"trailing garbage", "foo.bar !! baz"},
+		{"unterminated string", "'no closing quote"},
+		{"bare operator", "a + b"},
+		{"empty", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := parseExpression(tt.raw)
+			assert.Equal(t, exprKindUnknown, node.kind, "input %q", tt.raw)
+			// raw is always preserved (trimmed).
+			assert.NotNil(t, node)
+		})
+	}
+}
+
+func TestParseExpressionInterpolationWithSecureParamRef(t *testing.T) {
+	// A realistic "does this name interpolate a parameter?" shape.
+	node := parseExpression("'${adminPassword}'")
+	require.Equal(t, exprKindInterpolation, node.kind)
+	require.Len(t, node.segments, 3)
+	assert.Equal(t, exprKindSymbolicRef, node.segments[1].kind)
+	assert.Equal(t, "adminPassword", node.segments[1].target)
+}
+
+func TestParseExpressionRawAlwaysPopulated(t *testing.T) {
+	// Whitespace around the expression is trimmed but raw is never empty
+	// for a non-empty input.
+	node := parseExpression("   resourceGroup().location   ")
+	assert.Equal(t, "resourceGroup().location", node.raw)
+	assert.Equal(t, exprKindPropertyAccess, node.kind)
+}

--- a/providers/bicep/resources/mql_resources.go
+++ b/providers/bicep/resources/mql_resources.go
@@ -246,4 +246,5 @@ var (
 	_ plugin.Resource = (*mqlBicepResource)(nil)
 	_ plugin.Resource = (*mqlBicepModule)(nil)
 	_ plugin.Resource = (*mqlBicepOutput)(nil)
+	_ plugin.Resource = (*mqlBicepExpression)(nil)
 )

--- a/providers/bicep/resources/mql_resources.go
+++ b/providers/bicep/resources/mql_resources.go
@@ -4,6 +4,8 @@
 package resources
 
 import (
+	"strconv"
+
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
@@ -139,6 +141,76 @@ func createMqlModules(runtime *plugin.Runtime, filePath string, modules []parsed
 		mqlModules = append(mqlModules, res)
 	}
 	return mqlModules, nil
+}
+
+// mqlBicepExpressionInternal caches the parsed child nodes of an expression
+// so the lazy `args()` and `segments()` accessors can materialize their
+// child resources without re-parsing. The synthetic `__id` of each child is
+// derived from its parent's id (`<exprId>/arg[<i>]`, `<exprId>/seg[<i>]`).
+type mqlBicepExpressionInternal struct {
+	node *exprNode
+}
+
+// newMqlBicepExpression turns a parsed exprNode into a bicep.expression
+// resource. Scalar fields are set immediately; child nodes (args, segments)
+// are cached on the Internal struct and materialized lazily.
+func newMqlBicepExpression(runtime *plugin.Runtime, parentID string, node *exprNode) (*mqlBicepExpression, error) {
+	res, err := CreateResource(runtime, "bicep.expression", map[string]*llx.RawData{
+		"__id":         llx.StringData(parentID),
+		"kind":         llx.StringData(node.kind),
+		"raw":          llx.StringData(node.raw),
+		"functionName": llx.StringData(node.functionName),
+		"target":       llx.StringData(node.target),
+		"path":         llx.ArrayData(sliceToAny(node.path), types.String),
+	})
+	if err != nil {
+		return nil, err
+	}
+	mqlExpr := res.(*mqlBicepExpression)
+	mqlExpr.node = node
+	return mqlExpr, nil
+}
+
+func (e *mqlBicepExpression) args() ([]any, error) {
+	if e.node == nil {
+		return []any{}, nil
+	}
+	out := make([]any, 0, len(e.node.args))
+	for i, child := range e.node.args {
+		childID := e.__id + "/arg[" + strconv.Itoa(i) + "]"
+		mqlChild, err := newMqlBicepExpression(e.MqlRuntime, childID, child)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, mqlChild)
+	}
+	return out, nil
+}
+
+func (e *mqlBicepExpression) segments() ([]any, error) {
+	if e.node == nil {
+		return []any{}, nil
+	}
+	out := make([]any, 0, len(e.node.segments))
+	for i, child := range e.node.segments {
+		childID := e.__id + "/seg[" + strconv.Itoa(i) + "]"
+		mqlChild, err := newMqlBicepExpression(e.MqlRuntime, childID, child)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, mqlChild)
+	}
+	return out, nil
+}
+
+func (v *mqlBicepVariable) expressionTree() (*mqlBicepExpression, error) {
+	node := parseExpression(v.Expression.Data)
+	return newMqlBicepExpression(v.MqlRuntime, v.__id+"/expr", node)
+}
+
+func (o *mqlBicepOutput) expressionTree() (*mqlBicepExpression, error) {
+	node := parseExpression(o.Expression.Data)
+	return newMqlBicepExpression(o.MqlRuntime, o.__id+"/expr", node)
 }
 
 func createMqlOutputs(runtime *plugin.Runtime, filePath string, outputs []parsedOutput) ([]any, error) {

--- a/providers/bicep/resources/testdata/expressions.bicep
+++ b/providers/bicep/resources/testdata/expressions.bicep
@@ -1,0 +1,23 @@
+targetScope = 'resourceGroup'
+
+@description('Resource name prefix')
+param prefix string = 'app'
+
+@secure()
+param adminPassword string
+
+var location = resourceGroup().location
+var storageName = '${prefix}-sa'
+var tier = prefix == 'prod' ? 'Premium' : 'Standard'
+var tags = ['env', 'owner']
+var literalName = 'fixed-name'
+
+resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: storageName
+  location: location
+}
+
+output saId string = sa.id
+output region string = resourceGroup().location
+output adminEcho string = '${adminPassword}'
+output staticOut string = 'hello'


### PR DESCRIPTION
## What

Adds structured expression tokenization to the bicep provider. Today `bicep.variable.expression` and `bicep.output.expression` are raw strings (e.g. `resourceGroup().location`, `'${prefix}-sa'`, `vnet.properties.subnets[0].id`). This PR parses them into a structured, queryable tree.

### New resource

```
bicep.expression @defaults("kind raw") {
  kind string          // literal | functionCall | propertyAccess | symbolicRef | interpolation | ternary | array | unknown
  raw string           // original source text, always populated
  functionName string  // functionCall: e.g. "resourceId", "concat"
  args() []bicep.expression
  target string        // propertyAccess/symbolicRef root identifier
  path []string        // accessor chain, e.g. ["properties","subnets","0","id"]
  segments() []bicep.expression  // interpolation: alternating literal + embedded-expr parts
}
```

### New accessors (additive, raw fields untouched)

- `bicep.variable.expressionTree() bicep.expression`
- `bicep.output.expressionTree() bicep.expression`

## The tokenizer

A small recursive-descent parser (`providers/bicep/resources/expression.go`) over a **bounded, documented** Bicep expression grammar: string literals (incl. `'...${expr}...'` interpolation), int/bool/null, arrays, identifiers / symbolic references, member & index access chains (`foo.bar`, `foo['k']`, `foo[0]`), function calls with nested args, and ternaries. It reuses the existing string-aware `scanState` lexer for quote/escape/bracket handling.

**Structure only — no evaluation.** `concat(...)` results are never computed and params are never resolved (we don't have values). Anything outside the grammar becomes `kind: "unknown"` with `raw` preserved; the parser never panics and never errors the audit.

## Queries this unlocks

- "Is this location a hardcoded literal?" → `expressionTree.kind == "literal"`
- "Which Bicep function builds this value?" → `expressionTree.functionName`
- "Does this name interpolate a @secure parameter?" → `expressionTree.kind == "interpolation"` then inspect `segments` for a `symbolicRef`
- "Which symbolic resources does this reference?" → `expressionTree.target` / `path`

## Tests

Thorough table-driven unit tests for the tokenizer (`expression_test.go`) cover each kind: bare literals, `resourceGroup().location` (functionCall→propertyAccess), `concat('a', var, 'b')` (nested args), `'${prefix}-sa'` (interpolation segments), `vnet.properties.subnets[0].id` (propertyAccess chain with index), ternaries (incl. a comparison condition that itself parses as `unknown`), nested ternary inside an array, arrays, and malformed input → `unknown`. A `testdata/expressions.bicep` fixture backs end-to-end query verification. `go test ./resources/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)