### PR TITLE
✨ helm: parse and classify OCI/HTTP/file dependency sources

### DIFF
--- a/providers/helm/resources/helm.go
+++ b/providers/helm/resources/helm.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"errors"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/rs/zerolog/log"
@@ -253,11 +254,130 @@ func newMqlHelmDependency(runtime *plugin.Runtime, chartName string, dep *chart.
 		"tags":       llx.ArrayData(tags, types.String),
 		"enabled":    llx.BoolData(dep.Enabled),
 		"alias":      llx.StringData(dep.Alias),
+		"sourceType": llx.StringData(classifyHelmSource(dep.Repository, dep.Alias)),
 	})
 	if err != nil {
 		return nil, err
 	}
 	return res.(*mqlHelmDependency), nil
+}
+
+// classifyHelmSource categorizes a dependency's source from its
+// repository value (offline, no network). An empty repository with an
+// alias is a sibling-chart reference; an empty repository with neither
+// is unknown.
+func classifyHelmSource(repository, alias string) string {
+	repo := strings.TrimSpace(repository)
+	switch {
+	case repo == "":
+		if alias != "" {
+			return "alias"
+		}
+		return "unknown"
+	case strings.HasPrefix(repo, "oci://"):
+		return "oci"
+	case strings.HasPrefix(repo, "https://"):
+		return "https"
+	case strings.HasPrefix(repo, "http://"):
+		return "http"
+	case strings.HasPrefix(repo, "file://"), strings.HasPrefix(repo, "./"), strings.HasPrefix(repo, "../"), strings.HasPrefix(repo, "/"):
+		return "file"
+	default:
+		return "unknown"
+	}
+}
+
+func (d *mqlHelmDependency) registryRef() (*mqlHelmOciRef, error) {
+	if d.SourceType.Data != "oci" {
+		d.RegistryRef.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	parsed := parseOciRef(d.Repository.Data, d.Version.Data)
+
+	res, err := CreateResource(d.MqlRuntime, "helm.ociRef", map[string]*llx.RawData{
+		"__id":       llx.StringData("helm.dependency:" + d.Name.Data + "/ociRef"),
+		"reference":  llx.StringData(parsed.reference),
+		"registry":   llx.StringData(parsed.registry),
+		"repository": llx.StringData(parsed.repository),
+		"tag":        llx.StringData(parsed.tag),
+		"digest":     llx.StringData(parsed.digest),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlHelmOciRef), nil
+}
+
+type ociRef struct {
+	reference  string
+	registry   string
+	repository string
+	tag        string
+	digest     string
+}
+
+// parseOciRef decomposes an oci:// reference (and the dependency's
+// version constraint) into registry / repository / tag / digest. It is
+// defensive: an unparseable reference yields whatever parts could be
+// recovered with empty strings for the rest, and never panics.
+//
+//	oci://ghcr.io/acme/charts/redis        -> registry=ghcr.io repository=acme/charts/redis
+//	oci://ghcr.io/acme/redis:1.2.3         -> ... tag=1.2.3
+//	oci://ghcr.io/acme/redis@sha256:abc... -> ... digest=sha256:abc...
+//
+// The tag falls back to the dependency version when it's a concrete
+// version (no range operators); the digest falls back to the version
+// when the version itself pins a sha256 digest.
+func parseOciRef(repository, version string) ociRef {
+	ref := ociRef{reference: repository}
+
+	rest := strings.TrimPrefix(strings.TrimSpace(repository), "oci://")
+
+	// A digest pin (@sha256:...) takes precedence over a :tag suffix.
+	if at := strings.LastIndex(rest, "@"); at != -1 {
+		ref.digest = rest[at+1:]
+		rest = rest[:at]
+	}
+
+	// Split host from path. Everything before the first "/" is the
+	// registry host; the remainder is the repository path.
+	if slash := strings.Index(rest, "/"); slash != -1 {
+		ref.registry = rest[:slash]
+		repoPath := rest[slash+1:]
+
+		// A :tag suffix on the final path segment (only when no digest
+		// was found, and only if the colon isn't part of a host:port —
+		// which lives in the registry segment, already split off).
+		if ref.digest == "" {
+			if colon := strings.LastIndex(repoPath, ":"); colon != -1 {
+				ref.tag = repoPath[colon+1:]
+				repoPath = repoPath[:colon]
+			}
+		}
+		ref.repository = repoPath
+	} else {
+		// No path component — treat the whole thing as the registry.
+		ref.registry = rest
+	}
+
+	// Fall back to the version constraint for tag/digest when the
+	// reference itself didn't carry one.
+	v := strings.TrimSpace(version)
+	if ref.digest == "" && strings.HasPrefix(v, "sha256:") {
+		ref.digest = v
+	} else if ref.tag == "" && v != "" && isConcreteVersion(v) {
+		ref.tag = v
+	}
+
+	return ref
+}
+
+// isConcreteVersion reports whether a version string is a single
+// concrete version rather than a SemVer range/constraint. OCI tags are
+// concrete, so only a concrete version maps onto a tag.
+func isConcreteVersion(v string) bool {
+	return !strings.ContainsAny(v, "^~*><= |,x")
 }
 
 func newMqlHelmMaintainer(runtime *plugin.Runtime, chartName string, idx int, m *chart.Maintainer) (*mqlHelmMaintainer, error) {

--- a/providers/helm/resources/helm.lr
+++ b/providers/helm/resources/helm.lr
@@ -92,6 +92,48 @@ helm.dependency @defaults("name version") {
   enabled bool
   // Alias for the dependency
   alias string
+  // Classification of the dependency's source
+  //
+  // Derived from the `repository:` value (and `alias`/local path when the
+  // repository is empty). One of: "oci" for an OCI registry reference
+  // (`oci://...`, Helm 3.8+), "http" or "https" for a classic chart
+  // repository URL, "file" for a `file://` or local relative path, "alias"
+  // when the dependency references a sibling chart by alias with no
+  // repository, or "unknown" when the source can't be classified.
+  sourceType string
+  // OCI registry reference parsed from the repository
+  //
+  // Non-null only when sourceType is "oci"; null otherwise. Breaks the
+  // `oci://` reference into registry, repository, tag, and digest for
+  // offline supply-chain auditing without contacting the registry.
+  registryRef() helm.ociRef
+}
+
+// OCI registry reference for a Helm chart dependency
+//
+// Examine the parsed parts of an `oci://` dependency reference (Helm 3.8+):
+// the full reference, the registry host, the repository path, and the
+// pinned tag or digest. Parsing is offline — it classifies and decomposes
+// the reference string and the dependency's version constraint without ever
+// pulling from the registry.
+helm.ociRef @defaults("reference") {
+  // Full OCI reference (e.g., oci://ghcr.io/acme/charts/redis)
+  reference string
+  // Registry host (e.g., ghcr.io)
+  registry string
+  // Repository path within the registry (e.g., acme/charts/redis)
+  repository string
+  // Tag the reference resolves to
+  //
+  // Taken from the dependency's version constraint when it's a concrete
+  // version, or from a `:tag` suffix on the reference. Empty when the
+  // reference is pinned by digest or the version is a range constraint.
+  tag string
+  // Digest the reference is pinned to
+  //
+  // A `sha256:...` digest when the reference or version pins one (via an
+  // `@sha256:` suffix); empty otherwise.
+  digest string
 }
 
 // Helm chart maintainer

--- a/providers/helm/resources/helm.lr.go
+++ b/providers/helm/resources/helm.lr.go
@@ -18,6 +18,7 @@ const (
 	ResourceHelm           string = "helm"
 	ResourceHelmChart      string = "helm.chart"
 	ResourceHelmDependency string = "helm.dependency"
+	ResourceHelmOciRef     string = "helm.ociRef"
 	ResourceHelmMaintainer string = "helm.maintainer"
 	ResourceHelmTemplate   string = "helm.template"
 	ResourceHelmDirective  string = "helm.directive"
@@ -40,6 +41,10 @@ func init() {
 		"helm.dependency": {
 			// to override args, implement: initHelmDependency(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createHelmDependency,
+		},
+		"helm.ociRef": {
+			// to override args, implement: initHelmOciRef(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createHelmOciRef,
 		},
 		"helm.maintainer": {
 			// to override args, implement: initHelmMaintainer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -212,6 +217,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"helm.dependency.alias": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHelmDependency).GetAlias()).ToDataRes(types.String)
+	},
+	"helm.dependency.sourceType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHelmDependency).GetSourceType()).ToDataRes(types.String)
+	},
+	"helm.dependency.registryRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHelmDependency).GetRegistryRef()).ToDataRes(types.Resource("helm.ociRef"))
+	},
+	"helm.ociRef.reference": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHelmOciRef).GetReference()).ToDataRes(types.String)
+	},
+	"helm.ociRef.registry": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHelmOciRef).GetRegistry()).ToDataRes(types.String)
+	},
+	"helm.ociRef.repository": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHelmOciRef).GetRepository()).ToDataRes(types.String)
+	},
+	"helm.ociRef.tag": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHelmOciRef).GetTag()).ToDataRes(types.String)
+	},
+	"helm.ociRef.digest": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHelmOciRef).GetDigest()).ToDataRes(types.String)
 	},
 	"helm.maintainer.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHelmMaintainer).GetName()).ToDataRes(types.String)
@@ -406,6 +432,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"helm.dependency.alias": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHelmDependency).Alias, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"helm.dependency.sourceType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHelmDependency).SourceType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"helm.dependency.registryRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHelmDependency).RegistryRef, ok = plugin.RawToTValue[*mqlHelmOciRef](v.Value, v.Error)
+		return
+	},
+	"helm.ociRef.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHelmOciRef).__id, ok = v.Value.(string)
+		return
+	},
+	"helm.ociRef.reference": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHelmOciRef).Reference, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"helm.ociRef.registry": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHelmOciRef).Registry, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"helm.ociRef.repository": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHelmOciRef).Repository, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"helm.ociRef.tag": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHelmOciRef).Tag, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"helm.ociRef.digest": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHelmOciRef).Digest, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"helm.maintainer.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -803,13 +861,15 @@ type mqlHelmDependency struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlHelmDependencyInternal it will be used here
-	Name       plugin.TValue[string]
-	Version    plugin.TValue[string]
-	Repository plugin.TValue[string]
-	Condition  plugin.TValue[string]
-	Tags       plugin.TValue[[]any]
-	Enabled    plugin.TValue[bool]
-	Alias      plugin.TValue[string]
+	Name        plugin.TValue[string]
+	Version     plugin.TValue[string]
+	Repository  plugin.TValue[string]
+	Condition   plugin.TValue[string]
+	Tags        plugin.TValue[[]any]
+	Enabled     plugin.TValue[bool]
+	Alias       plugin.TValue[string]
+	SourceType  plugin.TValue[string]
+	RegistryRef plugin.TValue[*mqlHelmOciRef]
 }
 
 // createHelmDependency creates a new instance of this resource
@@ -870,6 +930,90 @@ func (c *mqlHelmDependency) GetEnabled() *plugin.TValue[bool] {
 
 func (c *mqlHelmDependency) GetAlias() *plugin.TValue[string] {
 	return &c.Alias
+}
+
+func (c *mqlHelmDependency) GetSourceType() *plugin.TValue[string] {
+	return &c.SourceType
+}
+
+func (c *mqlHelmDependency) GetRegistryRef() *plugin.TValue[*mqlHelmOciRef] {
+	return plugin.GetOrCompute[*mqlHelmOciRef](&c.RegistryRef, func() (*mqlHelmOciRef, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("helm.dependency", c.__id, "registryRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlHelmOciRef), nil
+			}
+		}
+
+		return c.registryRef()
+	})
+}
+
+// mqlHelmOciRef for the helm.ociRef resource
+type mqlHelmOciRef struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlHelmOciRefInternal it will be used here
+	Reference  plugin.TValue[string]
+	Registry   plugin.TValue[string]
+	Repository plugin.TValue[string]
+	Tag        plugin.TValue[string]
+	Digest     plugin.TValue[string]
+}
+
+// createHelmOciRef creates a new instance of this resource
+func createHelmOciRef(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlHelmOciRef{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("helm.ociRef", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlHelmOciRef) MqlName() string {
+	return "helm.ociRef"
+}
+
+func (c *mqlHelmOciRef) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlHelmOciRef) GetReference() *plugin.TValue[string] {
+	return &c.Reference
+}
+
+func (c *mqlHelmOciRef) GetRegistry() *plugin.TValue[string] {
+	return &c.Registry
+}
+
+func (c *mqlHelmOciRef) GetRepository() *plugin.TValue[string] {
+	return &c.Repository
+}
+
+func (c *mqlHelmOciRef) GetTag() *plugin.TValue[string] {
+	return &c.Tag
+}
+
+func (c *mqlHelmOciRef) GetDigest() *plugin.TValue[string] {
+	return &c.Digest
 }
 
 // mqlHelmMaintainer for the helm.maintainer resource

--- a/providers/helm/resources/helm.lr.versions
+++ b/providers/helm/resources/helm.lr.versions
@@ -28,7 +28,9 @@ helm.dependency.alias 13.0.0
 helm.dependency.condition 13.0.0
 helm.dependency.enabled 13.0.0
 helm.dependency.name 13.0.0
+helm.dependency.registryRef 13.0.10
 helm.dependency.repository 13.0.0
+helm.dependency.sourceType 13.0.10
 helm.dependency.tags 13.0.0
 helm.dependency.version 13.0.0
 helm.directive 13.0.0
@@ -42,6 +44,12 @@ helm.maintainer 13.0.0
 helm.maintainer.email 13.0.0
 helm.maintainer.name 13.0.0
 helm.maintainer.url 13.0.0
+helm.ociRef 13.0.10
+helm.ociRef.digest 13.0.10
+helm.ociRef.reference 13.0.10
+helm.ociRef.registry 13.0.10
+helm.ociRef.repository 13.0.10
+helm.ociRef.tag 13.0.10
 helm.resource 13.0.0
 helm.resource.annotations 13.0.0
 helm.resource.apiVersion 13.0.0

--- a/providers/helm/resources/ociref_test.go
+++ b/providers/helm/resources/ociref_test.go
@@ -1,0 +1,132 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"helm.sh/helm/v3/pkg/chart/loader"
+)
+
+func TestClassifyHelmSource(t *testing.T) {
+	cases := []struct {
+		repository string
+		alias      string
+		want       string
+	}{
+		{"oci://ghcr.io/acme/redis", "", "oci"},
+		{"https://charts.bitnami.com/bitnami", "", "https"},
+		{"http://charts.example.com", "", "http"},
+		{"file://./charts/localchart", "", "file"},
+		{"./charts/localchart", "", "file"},
+		{"../sibling", "", "file"},
+		{"/abs/path/chart", "", "file"},
+		{"", "common", "alias"},
+		{"", "", "unknown"},
+		{"weird-value", "", "unknown"},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, classifyHelmSource(c.repository, c.alias),
+			"repository=%q alias=%q", c.repository, c.alias)
+	}
+}
+
+func TestParseOciRef(t *testing.T) {
+	t.Run("registry and repository from path", func(t *testing.T) {
+		ref := parseOciRef("oci://ghcr.io/acme/charts/redis", "18.1.5")
+		assert.Equal(t, "oci://ghcr.io/acme/charts/redis", ref.reference)
+		assert.Equal(t, "ghcr.io", ref.registry)
+		assert.Equal(t, "acme/charts/redis", ref.repository)
+		// Concrete version maps onto the tag.
+		assert.Equal(t, "18.1.5", ref.tag)
+		assert.Equal(t, "", ref.digest)
+	})
+
+	t.Run("tag suffix on reference", func(t *testing.T) {
+		ref := parseOciRef("oci://ghcr.io/acme/redis:1.2.3", "")
+		assert.Equal(t, "ghcr.io", ref.registry)
+		assert.Equal(t, "acme/redis", ref.repository)
+		assert.Equal(t, "1.2.3", ref.tag)
+	})
+
+	t.Run("digest pin on reference", func(t *testing.T) {
+		ref := parseOciRef("oci://ghcr.io/acme/redis@sha256:abc123", "")
+		assert.Equal(t, "ghcr.io", ref.registry)
+		assert.Equal(t, "acme/redis", ref.repository)
+		assert.Equal(t, "sha256:abc123", ref.digest)
+		assert.Equal(t, "", ref.tag, "digest pin should not also set a tag")
+	})
+
+	t.Run("digest from version constraint", func(t *testing.T) {
+		ref := parseOciRef("oci://ghcr.io/acme/redis", "sha256:deadbeef")
+		assert.Equal(t, "sha256:deadbeef", ref.digest)
+		assert.Equal(t, "", ref.tag)
+	})
+
+	t.Run("range version is not a tag", func(t *testing.T) {
+		ref := parseOciRef("oci://ghcr.io/acme/redis", ">=18.0.0")
+		assert.Equal(t, "", ref.tag, "a SemVer range must not be treated as a concrete tag")
+	})
+
+	t.Run("host:port in registry", func(t *testing.T) {
+		ref := parseOciRef("oci://registry.local:5000/team/app", "2.0.0")
+		assert.Equal(t, "registry.local:5000", ref.registry)
+		assert.Equal(t, "team/app", ref.repository)
+		assert.Equal(t, "2.0.0", ref.tag)
+	})
+
+	t.Run("registry only, no path", func(t *testing.T) {
+		ref := parseOciRef("oci://ghcr.io", "")
+		assert.Equal(t, "ghcr.io", ref.registry)
+		assert.Equal(t, "", ref.repository)
+	})
+}
+
+// A chart with mixed dependency sources should classify each one and
+// only expose a parsed registryRef for the OCI dependency.
+func TestDependencySourceClassification(t *testing.T) {
+	c, err := loader.LoadDir("../testdata/oci-deps")
+	require.NoError(t, err)
+
+	mqlChart, err := newMqlHelmChart(newTestRuntime(), c, "../testdata/oci-deps")
+	require.NoError(t, err)
+
+	deps, err := mqlChart.dependencies()
+	require.NoError(t, err)
+	require.Len(t, deps, 3)
+
+	byName := map[string]*mqlHelmDependency{}
+	for _, d := range deps {
+		dep := d.(*mqlHelmDependency)
+		byName[dep.Name.Data] = dep
+	}
+
+	require.Contains(t, byName, "redis")
+	require.Contains(t, byName, "nginx")
+	require.Contains(t, byName, "localchart")
+
+	assert.Equal(t, "oci", byName["redis"].SourceType.Data)
+	assert.Equal(t, "https", byName["nginx"].SourceType.Data)
+	assert.Equal(t, "file", byName["localchart"].SourceType.Data)
+
+	// registryRef is non-null and parsed for the OCI dependency.
+	ociRef, err := byName["redis"].registryRef()
+	require.NoError(t, err)
+	require.NotNil(t, ociRef)
+	assert.Equal(t, "ghcr.io", ociRef.Registry.Data)
+	assert.Equal(t, "acme/charts/redis", ociRef.Repository.Data)
+	assert.Equal(t, "18.1.5", ociRef.Tag.Data)
+
+	// registryRef is null for the non-OCI dependencies.
+	for _, name := range []string{"nginx", "localchart"} {
+		ref, err := byName[name].registryRef()
+		require.NoError(t, err)
+		assert.Nil(t, ref, "%s should have no registryRef", name)
+		assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull,
+			byName[name].RegistryRef.State, "%s registryRef state", name)
+	}
+}

--- a/providers/helm/testdata/oci-deps/Chart.yaml
+++ b/providers/helm/testdata/oci-deps/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: oci-deps
+version: 1.0.0
+appVersion: "1.0.0"
+description: A chart with mixed dependency sources for source classification
+type: application
+dependencies:
+  - name: redis
+    version: 18.1.5
+    repository: oci://ghcr.io/acme/charts/redis
+  - name: nginx
+    version: ">=15.0.0"
+    repository: https://charts.bitnami.com/bitnami
+  - name: localchart
+    version: 0.1.0
+    repository: file://./charts/localchart

--- a/providers/helm/testdata/oci-deps/templates/configmap.yaml
+++ b/providers/helm/testdata/oci-deps/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-oci-deps
+data:
+  replicas: "{{ .Values.replicaCount }}"

--- a/providers/helm/testdata/oci-deps/values.yaml
+++ b/providers/helm/testdata/oci-deps/values.yaml
@@ -1,0 +1,1 @@
+replicaCount: 1


### PR DESCRIPTION
## What

Parse and classify Helm dependency sources offline — **no registry pulls** (Tier-1 parsing only) — with first-class support for OCI registry references (`oci://...`, supported by Helm 3.8+). The raw string is already exposed via `helm.dependency.repository`; this adds structured parsing on top.

### Fields added to `helm.dependency`
- `sourceType string` — classifies the `repository` value as one of `"oci" | "http" | "https" | "file" | "alias" | "unknown"`. An empty repository with an `alias` is a sibling-chart reference (`alias`); `file://` and local relative/absolute paths classify as `file`; anything unrecognized is `unknown`.
- `registryRef() helm.ociRef` — non-null only when `sourceType == "oci"`; otherwise sets `StateIsSet | StateIsNull` and returns nil (singular-nil rule).

### New resource `helm.ociRef`
Synthetic, internal `__id` (`<dependencyId>/ociRef`), no public `id` field:
- `reference` — the full `oci://` ref
- `registry` — host (incl. `host:port`)
- `repository` — repository path within the registry
- `tag` — from a `:tag` suffix or, failing that, the dependency's version when it's concrete
- `digest` — `sha256:...` from an `@sha256:` suffix on the ref or from a digest-pinned version

### Parsing notes
Parsing is defensive: strips the `oci://` scheme, splits host (including `host:port`) from the repository path, honors an `@sha256:` digest pin over a `:tag` suffix, and falls back to the dependency's version constraint for the tag (only when concrete — SemVer ranges are not treated as tags) or digest. An unparseable reference yields whatever parts can be recovered, never panicking.

## Testing
- New `testdata/oci-deps` fixture: a chart with an `oci://`, an `https://`, and a `file://` dependency.
- `TestClassifyHelmSource` and `TestParseOciRef` cover classification and reference decomposition (tag suffix, digest pin, digest-from-version, range-not-a-tag, `host:port`, registry-only).
- `TestDependencySourceClassification` asserts each dependency's `sourceType` and that `registryRef()` parses the OCI dep and is null for the others.
- `go test ./providers/helm/...` passes.
- Verified interactively: `mql run helm testdata/oci-deps -c "helm.charts { dependencies { name sourceType registryRef { registry repository tag digest } } }"`.

This pairs naturally with subchart recursion (#8004) for deeper supply-chain auditing of Helm charts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)