### PR TITLE
🧹 azure: bump armmonitor to v0.12.0 and refactor diagnostic settings

### DIFF
--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/logic/armlogic v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v4 v4.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mongocluster/armmongocluster v1.1.0
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.12.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers v1.2.0

--- a/providers/azure/go.sum
+++ b/providers/azure/go.sum
@@ -146,8 +146,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachine
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v4 v4.0.0/go.mod h1:nivJvZio5SHpEASAk8LKIueqs7zEHU+iRLKWbx3Xi10=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mongocluster/armmongocluster v1.1.0 h1:Kt30VxZ4lRB/+7RgP9lur4/OweaB3V5JLBf3wQezWIU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mongocluster/armmongocluster v1.1.0/go.mod h1:07VKTvjY84x3qmE2pk3gwIhcDZ7RX7ZLntc59E+ZiRI=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0 h1:Ds0KRF8ggpEGg4Vo42oX1cIt/IfOhHWJBikksZbVxeg=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0/go.mod h1:jj6P8ybImR+5topJ+eH6fgcemSFBmU6/6bFF8KkwuDI=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.12.0 h1:qmeVFr8V9dDzhLZDDgdqyOEl+XLhhMpm7xrOajxqKuk=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.12.0/go.mod h1:x/aYmuTilxu4yQMFj2r3ZE3iiO2wxYFFmh6dRg2IWiQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.3.0 h1:L7G3dExHBgUxsO3qpTGhk/P2dgnYyW48yn7AO33Tbek=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.3.0/go.mod h1:Ms6gYEy0+A2knfKrwdatsggTXYA2+ICKug8w7STorFw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql v1.2.0 h1:dhywcZH9yPDIje9aTqwy6psZSPzI6CJLYEprDahIBSQ=

--- a/providers/azure/resources/monitor.go
+++ b/providers/azure/resources/monitor.go
@@ -416,6 +416,11 @@ func getDiagnosticSettings(id string, runtime *plugin.Runtime, conn *connection.
 		return nil, err
 	}
 
+	// id is an ARM resource URI (e.g. "/subscriptions/<id>" or a full resource ID
+	// returned by Azure). It is a multi-segment path, so it is joined raw rather than
+	// URL-escaped — escaping would turn the "/" separators into %2F. This matches the
+	// removed armmonitor DiagnosticSettingsClient, which substituted {resourceUri}
+	// without escaping for the same reason.
 	urlPath := azruntime.JoinPaths(client.Endpoint(), id, "/providers/Microsoft.Insights/diagnosticSettings")
 	req, err := azruntime.NewRequest(ctx, http.MethodGet, urlPath)
 	if err != nil {
@@ -447,6 +452,9 @@ func getDiagnosticSettings(id string, runtime *plugin.Runtime, conn *connection.
 			properties = map[string]any{}
 		}
 
+		// "storageAccountId" is the camelCase key defined by the diagnosticSettings
+		// API contract (it was the json tag on the SDK's DiagnosticSettings.StorageAccountID
+		// field). Azure returns response keys with stable casing, so a direct lookup is safe.
 		var storageAccountId *string
 		if v, ok := properties["storageAccountId"].(string); ok {
 			storageAccountId = &v

--- a/providers/azure/resources/monitor.go
+++ b/providers/azure/resources/monitor.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -14,6 +15,7 @@ import (
 	"go.mondoo.com/mql/v13/types"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	appinsights "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/applicationinsights/armapplicationinsights"
 	monitor "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
 )
@@ -394,41 +396,74 @@ func (a *mqlAzureSubscriptionMonitorServiceDiagnosticsetting) storageAccount() (
 	return getStorageAccount(storageAccId, a.MqlRuntime, a.MqlRuntime.Connection.(*connection.AzureConnection))
 }
 
+// diagnosticSettingsResource mirrors the fields of the
+// Microsoft.Insights/diagnosticSettings list response that we surface. armmonitor
+// dropped its typed DiagnosticSettings client in v0.12.0, so we call the REST API
+// directly through the ARM pipeline and decode the relevant fields here.
+type diagnosticSettingsResource struct {
+	ID         *string        `json:"id"`
+	Name       *string        `json:"name"`
+	Type       *string        `json:"type"`
+	Properties map[string]any `json:"properties"`
+}
+
 func getDiagnosticSettings(id string, runtime *plugin.Runtime, conn *connection.AzureConnection) ([]any, error) {
 	ctx := context.Background()
-	token := conn.Token()
-	client, err := monitor.NewDiagnosticSettingsClient(token, &arm.ClientOptions{
+	client, err := arm.NewClient("azure.subscription.monitorService.diagnosticSettings", "v1.0.0", conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})
 	if err != nil {
 		return nil, err
 	}
-	pager := client.NewListPager(id, &monitor.DiagnosticSettingsClientListOptions{})
+
+	urlPath := azruntime.JoinPaths(client.Endpoint(), id, "/providers/Microsoft.Insights/diagnosticSettings")
+	req, err := azruntime.NewRequest(ctx, http.MethodGet, urlPath)
+	if err != nil {
+		return nil, err
+	}
+	query := req.Raw().URL.Query()
+	query.Set("api-version", "2021-05-01-preview")
+	req.Raw().URL.RawQuery = query.Encode()
+
+	resp, err := client.Pipeline().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if !azruntime.HasStatusCode(resp, http.StatusOK) {
+		return nil, azruntime.NewResponseError(resp)
+	}
+
+	var result struct {
+		Value []diagnosticSettingsResource `json:"value"`
+	}
+	if err := azruntime.UnmarshalAsJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
 	res := []any{}
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
+	for _, entry := range result.Value {
+		properties := entry.Properties
+		if properties == nil {
+			properties = map[string]any{}
+		}
+
+		var storageAccountId *string
+		if v, ok := properties["storageAccountId"].(string); ok {
+			storageAccountId = &v
+		}
+
+		mqlAzure, err := CreateResource(runtime, "azure.subscription.monitorService.diagnosticsetting",
+			map[string]*llx.RawData{
+				"id":               llx.StringDataPtr(entry.ID),
+				"name":             llx.StringDataPtr(entry.Name),
+				"type":             llx.StringDataPtr(entry.Type),
+				"properties":       llx.DictData(properties),
+				"storageAccountId": llx.StringDataPtr(storageAccountId),
+			})
 		if err != nil {
 			return nil, err
 		}
-		for _, entry := range page.Value {
-			properties, err := convert.JsonToDict(entry.Properties)
-			if err != nil {
-				return nil, err
-			}
-
-			mqlAzure, err := CreateResource(runtime, "azure.subscription.monitorService.diagnosticsetting",
-				map[string]*llx.RawData{
-					"id":               llx.StringDataPtr(entry.ID),
-					"name":             llx.StringDataPtr(entry.Name),
-					"type":             llx.StringDataPtr(entry.Type),
-					"properties":       llx.DictData(properties),
-					"storageAccountId": llx.StringDataPtr(entry.Properties.StorageAccountID),
-				})
-			if err != nil {
-				return nil, err
-			}
-			res = append(res, mqlAzure)
-		}
+		res = append(res, mqlAzure)
 	}
 
 	return res, nil


### PR DESCRIPTION
## What

Bumps `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor` from **v0.11.0 → v0.12.0** in the Azure provider, and refactors the diagnostic-settings code so the upgrade is not a breaking change for our resources.

## Why

A routine Azure SDK dependency sweep found that `armmonitor` is the only dep with a stable upgrade available (everything else is already on its latest stable, or has a new major only as a beta/pseudo-version). However, v0.12.0 is a heavy breaking restructure: it **removes the typed `DiagnosticSettingsClient`** (`NewDiagnosticSettingsClient` / `NewListPager` / `DiagnosticSettingsClientListOptions`), which `resources/monitor.go` used to populate `azure.subscription.monitorService.diagnosticsetting`.

- The `ServiceDiagnosticSettingsClient` added in v0.12.0 is **not** a substitute — it targets the legacy `.../diagnosticSettings/service` API (api-version `2016-09-01`, single object, no list).
- There is **no split-out stable module** for the resource-level client (probed `armmonitordiagnosticsettings` and siblings → all 404; on `main` the resource-level client survives only in the frozen `profile/p20200901` stack profile).

## How

`getDiagnosticSettings` now calls the `Microsoft.Insights/diagnosticSettings` list API directly through the ARM pipeline (`arm.NewClient` → `Pipeline().Do`), decoding the response into a small local `diagnosticSettingsResource` struct.

Behavior is **identical** to the removed typed client:
- Same endpoint and same `api-version=2021-05-01-preview` (verified against the v0.11.0 generated client).
- `properties` dict and `storageAccountId` come out the same — the SDK struct's JSON tags matched the raw API keys, so unmarshaling into a `map[string]any` yields the same `dict`.

`ActivityLogAlertsClient` and `LogProfilesClient` are unchanged in v0.12.0 and were left untouched.

## Verification

- `go build ./...` ✅
- `go vet ./resources/...` ✅
- `go test ./resources/...` ✅
- `gofmt -l` clean

Not yet verified against a live Azure subscription — the diagnostic-settings path went from a typed client to a hand-rolled REST call, so an end-to-end check against a real `azure.subscription.monitorService.diagnosticSettings` query would be worthwhile before relying on it.

## Skipped

~29 modules whose next major exists only as beta/pseudo-version were intentionally left alone (apimanagement→v4, authorization→v3, cosmos→v4, eventhub→v2, sql→v2, armresources→v4, recoveryservices→v3, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)